### PR TITLE
Streamline install UX and remove unnecessary container deps

### DIFF
--- a/Dockerfile.agent
+++ b/Dockerfile.agent
@@ -11,11 +11,12 @@ RUN useradd --create-home --uid 1000 --shell /bin/bash agent
 
 WORKDIR /app
 
-# Python dependencies
+# Python dependencies — only what agents actually import
+# (litellm, pyyaml, click, docker are host-only — not needed here)
 # sqlite-vec is built from source to ensure correct architecture on all platforms
 COPY pyproject.toml .
 RUN pip install --no-cache-dir \
-    fastapi uvicorn httpx pydantic litellm pyyaml playwright \
+    fastapi uvicorn httpx pydantic playwright \
     && pip install --no-cache-dir --no-binary sqlite-vec sqlite-vec
 
 # Install Chromium for browser automation — shared path so non-root agent can access it

--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -23,6 +23,21 @@ make start           # openlegion start
 make test            # run the test suite
 ```
 
+## Fast Path (Windows)
+
+**Prerequisites:** [Docker Desktop](https://docker.com/products/docker-desktop) running, Python 3.12+, an LLM API key.
+
+```powershell
+git clone https://github.com/openlegion-ai/openlegion.git
+cd openlegion
+powershell -ExecutionPolicy Bypass -File install.ps1
+.venv\Scripts\Activate.ps1
+openlegion setup     # API key, project description, team template
+openlegion start     # launch agents and start chatting
+```
+
+> PowerShell blocks the script? Run: `Set-ExecutionPolicy -ExecutionPolicy RemoteSigned -Scope CurrentUser`
+
 ---
 
 ## Prerequisites
@@ -140,7 +155,7 @@ You need one key. Pick a provider:
 
 ## Install (Manual)
 
-If you prefer not to use `install.sh`:
+If you prefer not to use the install scripts:
 
 <details>
 <summary><strong>macOS / Linux</strong></summary>
@@ -170,6 +185,8 @@ pip install -e ".[dev]"
 
 </details>
 
+> First install downloads ~70 packages and takes 2-3 minutes. Subsequent installs use pip's cache and are much faster.
+
 Verify: `openlegion --help`
 
 ---
@@ -183,9 +200,10 @@ openlegion start     # launches agents and drops you into the chat REPL
 
 The setup wizard asks for:
 1. **LLM provider + API key** — pick one, paste your key
-2. **Project description** — one line about what your agents will do
+2. **Project description** — one line about what your agents will do (optional)
 3. **Team template** — starter (1 agent), sales (3), devteam (3), or content (3)
-4. **Docker image build** — automatic, takes 1-2 minutes on first run
+
+The Docker image builds automatically on your first `openlegion start` (~2 min).
 
 ---
 
@@ -220,11 +238,12 @@ Add bot tokens to `config/mesh.yaml`. On next start, a pairing code appears — 
 
 | Problem | Fix |
 |---|---|
-| `command not found: openlegion` | Activate the venv: `source .venv/bin/activate` |
+| `command not found: openlegion` | Activate the venv: `source .venv/bin/activate` (macOS/Linux) or `.venv\Scripts\Activate.ps1` (Windows) |
 | `Docker is not running` | Open Docker Desktop (macOS/Windows) or `sudo systemctl start docker` (Linux) |
 | `permission denied` on Docker | Linux: `sudo usermod -aG docker $USER` then log out/in |
-| `python3: command not found` | Install Python 3.12+ (see above) |
-| `pip install` permission error | Activate the venv first |
+| `python3: command not found` | Install Python 3.12+ (see above). On Windows, use `python` instead of `python3`. |
+| `pip install` is slow | First install downloads ~70 packages (2-3 min). This is normal. Subsequent installs are fast. |
+| `pip install` permission error | Activate the venv first — don't install globally. |
 | Docker build is slow | First build downloads base image + Chromium (~2 min). Rebuilds are fast. |
 | Agent not responding | `openlegion status` to check health. Verify API key has credits. |
-| PowerShell blocks venv | `Set-ExecutionPolicy -ExecutionPolicy RemoteSigned -Scope CurrentUser` |
+| PowerShell blocks scripts | `Set-ExecutionPolicy -ExecutionPolicy RemoteSigned -Scope CurrentUser` |

--- a/README.md
+++ b/README.md
@@ -53,6 +53,8 @@
 
 **Requirements:** Python 3.12+, Docker (running), an LLM API key ([Anthropic](https://console.anthropic.com/) / [Moonshot](https://platform.moonshot.cn/) / [OpenAI](https://platform.openai.com/api-keys))
 
+**macOS / Linux:**
+
 ```bash
 git clone https://github.com/openlegion-ai/openlegion.git && cd openlegion
 ./install.sh                     # checks deps, creates venv, installs everything
@@ -61,7 +63,20 @@ openlegion setup                 # API key, project description, team template
 openlegion start                 # launch agents and start chatting
 ```
 
-> **Need help?** See the **[full setup guide](QUICKSTART.md)** for platform-specific instructions, Windows support, and troubleshooting.
+**Windows (PowerShell):**
+
+```powershell
+git clone https://github.com/openlegion-ai/openlegion.git
+cd openlegion
+powershell -ExecutionPolicy Bypass -File install.ps1
+.venv\Scripts\Activate.ps1
+openlegion setup
+openlegion start
+```
+
+> First install downloads ~70 packages and takes 2-3 minutes. Subsequent installs are fast.
+>
+> **Need help?** See the **[full setup guide](QUICKSTART.md)** for platform-specific instructions and troubleshooting.
 
 ```bash
 # Add more agents later

--- a/install.ps1
+++ b/install.ps1
@@ -1,0 +1,109 @@
+# OpenLegion Installer for Windows (PowerShell)
+# Run: powershell -ExecutionPolicy Bypass -File install.ps1
+
+$ErrorActionPreference = "Stop"
+
+function Write-OK($msg)   { Write-Host "  ✓ $msg" -ForegroundColor Green }
+function Write-Warn($msg) { Write-Host "  ! $msg" -ForegroundColor Yellow }
+function Write-Fail($msg) { Write-Host "  ✗ $msg" -ForegroundColor Red; exit 1 }
+
+Write-Host ""
+Write-Host "  OpenLegion Installer"
+Write-Host "  ────────────────────"
+Write-Host ""
+
+# ── Check Python ──────────────────────────────────────────────
+
+$python = $null
+foreach ($cmd in @("python", "python3")) {
+    try {
+        $ver = & $cmd -c "import sys; print(f'{sys.version_info.major}.{sys.version_info.minor}')" 2>$null
+        $major = & $cmd -c "import sys; print(sys.version_info.major)" 2>$null
+        $minor = & $cmd -c "import sys; print(sys.version_info.minor)" 2>$null
+        if ([int]$major -ge 3 -and [int]$minor -ge 12) {
+            $python = $cmd
+            break
+        }
+    } catch { }
+}
+
+if (-not $python) {
+    Write-Fail "Python 3.12+ is required but not found.
+    Download from: https://python.org/downloads
+    IMPORTANT: Check 'Add python.exe to PATH' during install."
+}
+Write-OK "Python $ver ($python)"
+
+# ── Check pip ─────────────────────────────────────────────────
+
+try {
+    & $python -m pip --version 2>$null | Out-Null
+    Write-OK "pip available"
+} catch {
+    Write-Fail "pip is not installed.
+    Run: $python -m ensurepip --upgrade"
+}
+
+# ── Check Docker ──────────────────────────────────────────────
+
+if (-not (Get-Command docker -ErrorAction SilentlyContinue)) {
+    Write-Fail "Docker is not installed.
+    Download Docker Desktop: https://docker.com/products/docker-desktop"
+}
+
+try {
+    docker info 2>$null | Out-Null
+    Write-OK "Docker is running"
+} catch {
+    Write-Fail "Docker is installed but not running.
+    Open Docker Desktop and wait for 'Docker Desktop is running'."
+}
+
+# ── Check Git ─────────────────────────────────────────────────
+
+if (-not (Get-Command git -ErrorAction SilentlyContinue)) {
+    Write-Fail "Git is not installed.
+    Download from: https://git-scm.com"
+}
+Write-OK "Git available"
+
+# ── Create virtual environment ────────────────────────────────
+
+Write-Host ""
+if (-not (Test-Path ".venv")) {
+    Write-Host "  Creating virtual environment..."
+    & $python -m venv .venv
+    Write-OK "Virtual environment created"
+} else {
+    Write-OK "Virtual environment exists"
+}
+
+& .venv\Scripts\Activate.ps1
+
+# ── Install dependencies ──────────────────────────────────────
+
+Write-Host ""
+Write-Host "  Installing dependencies..." -NoNewline:$false
+Write-Host "  First install takes 2-3 minutes (downloads ~70 packages)." -ForegroundColor Yellow
+Write-Host "  Subsequent installs are fast (cached)." -ForegroundColor Yellow
+Write-Host ""
+
+pip install -e ".[dev]" 2>&1 | ForEach-Object {
+    if ($_ -match "Collecting|Downloading|Installing|Building|Successfully") {
+        Write-Host "  $_"
+    }
+}
+
+Write-Host ""
+Write-OK "OpenLegion installed"
+
+# ── Done ──────────────────────────────────────────────────────
+
+Write-Host ""
+Write-Host "  Ready!" -ForegroundColor Green -NoNewline
+Write-Host " Next steps:"
+Write-Host ""
+Write-Host "    .venv\Scripts\Activate.ps1   # activate the environment"
+Write-Host "    openlegion setup             # configure API key + agents"
+Write-Host "    openlegion start             # launch and start chatting"
+Write-Host ""

--- a/install.sh
+++ b/install.sh
@@ -6,11 +6,12 @@ set -e
 RED='\033[0;31m'
 GREEN='\033[0;32m'
 YELLOW='\033[1;33m'
+BOLD='\033[1m'
 NC='\033[0m'
 
-info()  { echo -e "${GREEN}✓${NC} $1"; }
-warn()  { echo -e "${YELLOW}!${NC} $1"; }
-fail()  { echo -e "${RED}✗${NC} $1"; exit 1; }
+info()  { echo -e "  ${GREEN}✓${NC} $1"; }
+warn()  { echo -e "  ${YELLOW}!${NC} $1"; }
+fail()  { echo -e "  ${RED}✗${NC} $1"; exit 1; }
 
 echo ""
 echo "  OpenLegion Installer"
@@ -42,6 +43,17 @@ if [ -z "$PYTHON" ]; then
 fi
 info "Python $version ($PYTHON)"
 
+# ── Check pip ─────────────────────────────────────────────────
+
+if ! "$PYTHON" -m pip --version &>/dev/null; then
+    fail "pip is not installed.
+    Install it:
+      macOS:   python3 -m ensurepip --upgrade
+      Ubuntu:  sudo apt install python3-pip
+      Other:   https://pip.pypa.io/en/stable/installation/"
+fi
+info "pip available"
+
 # ── Check Docker ──────────────────────────────────────────────
 
 if ! command -v docker &>/dev/null; then
@@ -70,19 +82,37 @@ if ! command -v git &>/dev/null; then
 fi
 info "Git available"
 
-# ── Create virtual environment and install ────────────────────
+# ── Create virtual environment ────────────────────────────────
 
+echo ""
 if [ ! -d ".venv" ]; then
-    echo ""
     echo "  Creating virtual environment..."
     "$PYTHON" -m venv .venv
+    info "Virtual environment created"
+else
+    info "Virtual environment exists"
 fi
 
 source .venv/bin/activate
 
-echo "  Installing dependencies (this may take a minute)..."
-pip install -q -e ".[dev]" 2>&1 | tail -1
+# ── Install dependencies ──────────────────────────────────────
 
+echo ""
+echo -e "  ${BOLD}Installing dependencies...${NC}"
+echo -e "  ${YELLOW}First install takes 2-3 minutes (downloads ~70 packages).${NC}"
+echo -e "  ${YELLOW}Subsequent installs are fast (cached).${NC}"
+echo ""
+
+pip install -e ".[dev]" 2>&1 | while IFS= read -r line; do
+    # Show download/install progress, skip noise
+    case "$line" in
+        *Collecting*|*Downloading*|*Installing*|*Building*|*Successfully*)
+            echo "  $line"
+            ;;
+    esac
+done
+
+echo ""
 info "OpenLegion installed"
 
 # ── Done ──────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- Remove `litellm` + `pyyaml` from Dockerfile.agent (agents never import them — saves ~130MB and 40+ transitive packages from container builds)
- Simplify setup wizard from 9 prompts to 5 (removed Telegram/Discord, collaboration, Docker build steps)
- Docker image builds lazily on first `openlegion start` instead of during setup
- Show real pip progress in install.sh instead of suppressing all output
- Add `install.ps1` for Windows with same checks and progress output
- Show Docker build step progress instead of silent capture
- Expand troubleshooting in QUICKSTART.md with Windows-specific fixes

## Test plan
- [x] All 407 tests pass
- [ ] Run `./install.sh` on fresh clone (macOS/Linux)
- [ ] Run `install.ps1` on Windows
- [ ] Run `openlegion setup` and verify 3-step flow
- [ ] Run `openlegion start` and verify Docker image builds automatically