### PR TITLE
Fix Docker build: use sqlite-vec prebuilt wheel

### DIFF
--- a/Dockerfile.agent
+++ b/Dockerfile.agent
@@ -1,9 +1,8 @@
 FROM python:3.12-slim
 
-# System tools useful for agent operations + build tools for native extensions
+# System tools useful for agent operations
 RUN apt-get update && apt-get install -y --no-install-recommends \
     curl wget git jq vim-tiny procps \
-    gcc python3-dev \
     && rm -rf /var/lib/apt/lists/*
 
 # Non-root user (created early so /data ownership is correct)
@@ -13,19 +12,15 @@ WORKDIR /app
 
 # Python dependencies — only what agents actually import
 # (litellm, pyyaml, click, docker are host-only — not needed here)
-# sqlite-vec is built from source to ensure correct architecture on all platforms
+# sqlite-vec has prebuilt wheels for all platforms (linux, macOS, Windows)
 COPY pyproject.toml .
 RUN pip install --no-cache-dir \
-    fastapi uvicorn httpx pydantic playwright \
-    && pip install --no-cache-dir --no-binary sqlite-vec sqlite-vec
+    fastapi uvicorn httpx pydantic playwright sqlite-vec
 
 # Install Chromium for browser automation — shared path so non-root agent can access it
 ENV PLAYWRIGHT_BROWSERS_PATH=/opt/pw-browsers
 RUN playwright install chromium --with-deps \
     && chmod -R o+rx /opt/pw-browsers
-
-# Remove build tools (no longer needed at runtime)
-RUN apt-get purge -y gcc python3-dev && apt-get autoremove -y
 
 # Application code
 COPY src/agent/ /app/src/agent/


### PR DESCRIPTION
## Summary
- Remove `--no-binary sqlite-vec` flag — sqlite-vec has no source distribution, only prebuilt wheels for all platforms
- Remove `gcc` and `python3-dev` build tools — no packages need source compilation anymore
- Fixes `ERROR: No matching distribution found for sqlite-vec` during `openlegion start`

## Test plan
- [x] All 407 tests pass
- [ ] `openlegion start` builds Docker image successfully on Linux