### PR TITLE
Silence missing workflows directory warning

### DIFF
--- a/src/host/orchestrator.py
+++ b/src/host/orchestrator.py
@@ -181,7 +181,7 @@ class Orchestrator:
         """Load all workflow YAML files."""
         wf_path = Path(workflows_dir)
         if not wf_path.exists():
-            logger.warning(f"Workflows directory not found: {workflows_dir}")
+            logger.debug(f"No workflows directory at %s — skipping", workflows_dir)
             return
         for yaml_file in wf_path.glob("*.yaml"):
             try:


### PR DESCRIPTION
## Summary
- Downgrade `Workflows directory not found: config/workflows` from WARNING to DEBUG
- No workflows is the normal default state — not worth a warning on every start