### PR TITLE
Lower Python requirement from 3.12+ to 3.10+

### DIFF
--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -2,7 +2,7 @@
 
 ## Fast Path (macOS / Linux)
 
-**Prerequisites:** [Docker Desktop](https://docker.com/products/docker-desktop) running, Python 3.12+, an LLM API key.
+**Prerequisites:** [Docker Desktop](https://docker.com/products/docker-desktop) running, Python 3.10+, an LLM API key.
 
 ```bash
 git clone https://github.com/openlegion-ai/openlegion.git && cd openlegion
@@ -25,7 +25,7 @@ make test            # run the test suite
 
 ## Fast Path (Windows)
 
-**Prerequisites:** [Docker Desktop](https://docker.com/products/docker-desktop) running, Python 3.12+, an LLM API key.
+**Prerequisites:** [Docker Desktop](https://docker.com/products/docker-desktop) running, Python 3.10+, an LLM API key.
 
 ```powershell
 git clone https://github.com/openlegion-ai/openlegion.git
@@ -44,14 +44,14 @@ openlegion start     # launch agents and start chatting
 
 You need three things installed before running OpenLegion:
 
-### 1. Python 3.12+
+### 1. Python 3.10+
 
 <details>
 <summary><strong>macOS</strong></summary>
 
 ```bash
-brew install python@3.12
-python3 --version   # verify: 3.12 or higher
+brew install python@3
+python3 --version   # verify: 3.10 or higher
 ```
 
 Or download from [python.org/downloads](https://www.python.org/downloads/).
@@ -70,17 +70,17 @@ sudo dnf install python3 python3-pip git
 ```
 
 ```bash
-python3 --version   # verify: 3.12 or higher
+python3 --version   # verify: 3.10 or higher
 ```
 
-> Distro ships 3.11 or older? Use [pyenv](https://github.com/pyenv/pyenv) to get 3.12+.
+> Distro ships 3.9 or older? Use [pyenv](https://github.com/pyenv/pyenv) to get 3.10+.
 
 </details>
 
 <details>
 <summary><strong>Windows</strong></summary>
 
-1. Download Python 3.12+ from [python.org/downloads](https://www.python.org/downloads/)
+1. Download Python 3.10+ from [python.org/downloads](https://www.python.org/downloads/)
 2. Run installer — **check "Add python.exe to PATH"**
 3. Verify in PowerShell: `python --version`
 
@@ -241,7 +241,7 @@ Add bot tokens to `config/mesh.yaml`. On next start, a pairing code appears — 
 | `command not found: openlegion` | Activate the venv: `source .venv/bin/activate` (macOS/Linux) or `.venv\Scripts\Activate.ps1` (Windows) |
 | `Docker is not running` | Open Docker Desktop (macOS/Windows) or `sudo systemctl start docker` (Linux) |
 | `permission denied` on Docker | Linux: `sudo usermod -aG docker $USER` then log out/in |
-| `python3: command not found` | Install Python 3.12+ (see above). On Windows, use `python` instead of `python3`. |
+| `python3: command not found` | Install Python 3.10+ (see above). On Windows, use `python` instead of `python3`. |
 | `pip install` is slow | First install downloads ~70 packages (2-3 min). This is normal. Subsequent installs are fast. |
 | `pip install` permission error | Activate the venv first — don't install globally. |
 | Docker build is slow | First build downloads base image + Chromium (~2 min). Rebuilds are fast. |

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 > Chat via Telegram or Discord. Built-in cost controls. 100+ LLM providers.
 
 [![MIT License](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
-[![Python 3.12+](https://img.shields.io/badge/python-3.12+-blue.svg)](https://python.org)
+[![Python 3.10+](https://img.shields.io/badge/python-3.10+-blue.svg)](https://python.org)
 [![Tests](https://img.shields.io/badge/tests-424%20passing-brightgreen.svg)]()
 [![LiteLLM](https://img.shields.io/badge/LLM-100%2B%20providers-orange.svg)](https://litellm.ai)
 [![Docker](https://img.shields.io/badge/isolation-Docker%20%2B%20microVM-blue.svg)]()
@@ -51,7 +51,7 @@
 
 ## Quick Start
 
-**Requirements:** Python 3.12+, Docker (running), an LLM API key ([Anthropic](https://console.anthropic.com/) / [Moonshot](https://platform.moonshot.cn/) / [OpenAI](https://platform.openai.com/api-keys))
+**Requirements:** Python 3.10+, Docker (running), an LLM API key ([Anthropic](https://console.anthropic.com/) / [Moonshot](https://platform.moonshot.cn/) / [OpenAI](https://platform.openai.com/api-keys))
 
 **macOS / Linux:**
 

--- a/install.ps1
+++ b/install.ps1
@@ -20,7 +20,7 @@ foreach ($cmd in @("python", "python3")) {
         $ver = & $cmd -c "import sys; print(f'{sys.version_info.major}.{sys.version_info.minor}')" 2>$null
         $major = & $cmd -c "import sys; print(sys.version_info.major)" 2>$null
         $minor = & $cmd -c "import sys; print(sys.version_info.minor)" 2>$null
-        if ([int]$major -ge 3 -and [int]$minor -ge 12) {
+        if ([int]$major -ge 3 -and [int]$minor -ge 10) {
             $python = $cmd
             break
         }
@@ -28,7 +28,7 @@ foreach ($cmd in @("python", "python3")) {
 }
 
 if (-not $python) {
-    Write-Fail "Python 3.12+ is required but not found.
+    Write-Fail "Python 3.10+ is required but not found.
     Download from: https://python.org/downloads
     IMPORTANT: Check 'Add python.exe to PATH' during install."
 }

--- a/install.sh
+++ b/install.sh
@@ -26,7 +26,7 @@ for cmd in python3 python; do
         version=$("$cmd" -c "import sys; print(f'{sys.version_info.major}.{sys.version_info.minor}')" 2>/dev/null)
         major=$("$cmd" -c "import sys; print(sys.version_info.major)" 2>/dev/null)
         minor=$("$cmd" -c "import sys; print(sys.version_info.minor)" 2>/dev/null)
-        if [ "$major" -ge 3 ] && [ "$minor" -ge 12 ]; then
+        if [ "$major" -ge 3 ] && [ "$minor" -ge 10 ]; then
             PYTHON="$cmd"
             break
         fi
@@ -34,9 +34,9 @@ for cmd in python3 python; do
 done
 
 if [ -z "$PYTHON" ]; then
-    fail "Python 3.12+ is required but not found.
+    fail "Python 3.10+ is required but not found.
     Install it:
-      macOS:   brew install python@3.12
+      macOS:   brew install python@3
       Ubuntu:  sudo apt install python3
       Windows: https://python.org/downloads
       Other:   https://github.com/pyenv/pyenv"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 name = "openlegion"
 version = "0.1.0"
 description = "A lean, container-isolated, memory-aware multi-agent runtime"
-requires-python = ">=3.12"
+requires-python = ">=3.10"
 
 dependencies = [
     "fastapi>=0.115.0",
@@ -40,7 +40,7 @@ openlegion = "src.cli:cli"
 where = ["."]
 
 [tool.ruff]
-target-version = "py312"
+target-version = "py310"
 line-length = 120
 
 [tool.ruff.lint]


### PR DESCRIPTION
## Summary
- Lower `requires-python` from `>=3.12` to `>=3.10`
- Codebase only uses 3.10 features (`X | Y` unions, `match/case`)
- No 3.11 or 3.12 features are used anywhere
- Updated all references in pyproject.toml, install.sh, install.ps1, QUICKSTART.md, README.md
- Ruff target lowered to `py310`

Most Linux distros ship Python 3.10 or 3.11 by default — this removes a major install barrier.

## Test plan
- [x] All 407 tests pass
- [x] No remaining 3.12 references in install scripts or docs