### PR TITLE
Add openlegion channels command for Telegram/Discord setup

### DIFF
--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -230,7 +230,13 @@ openlegion stop                 # shut down
 
 ### Telegram / Discord (optional)
 
-Add bot tokens to `config/mesh.yaml`. On next start, a pairing code appears — send it to your bot to link.
+```bash
+openlegion channels add telegram   # prompts for bot token
+openlegion channels add discord    # prompts for bot token
+openlegion channels list           # check what's connected
+```
+
+On next `openlegion start`, a pairing code appears — send it to your bot to link.
 
 ---
 


### PR DESCRIPTION
## Summary
- Add `openlegion channels add telegram` / `openlegion channels add discord` commands
- Add `openlegion channels list` to show configured channels
- Add `openlegion channels remove` to disconnect a channel
- Interactive mode when no channel type specified (prompts with numbered list)
- Setup wizard now points to the command instead of "edit .env"
- QUICKSTART.md updated with channel commands

## User experience
```
$ openlegion channels add telegram

  Telegram Setup
  Get one from @BotFather on Telegram: https://t.me/BotFather

  Telegram bot token: ****

  Telegram connected. A pairing code will appear on next `openlegion start`.
```

## Test plan
- [x] All 407 tests pass
- [x] `openlegion channels --help` shows add/list/remove
- [ ] `openlegion channels add telegram` prompts and saves token