### PR TITLE
Make Docker containers default, sandbox opt-in via --sandbox

### DIFF
--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -193,29 +193,30 @@ class TestSandboxDetection:
 # ── select_backend ────────────────────────────────────────────
 
 class TestSelectBackend:
-    def test_force_docker(self):
+    def test_default_is_docker(self):
+        """Default (no flags) should always use DockerBackend."""
         with patch("src.host.runtime.DockerBackend") as MockDocker:
             mock_instance = MagicMock()
             MockDocker.return_value = mock_instance
-            result = select_backend(force_docker=True)
+            result = select_backend()
             assert result is mock_instance
 
-    def test_sandbox_when_available(self):
+    def test_sandbox_when_opted_in_and_available(self):
         with (
             patch("src.host.runtime.sandbox_available", return_value=True),
             patch("src.host.runtime.SandboxBackend") as MockSandbox,
         ):
             mock_instance = MagicMock()
             MockSandbox.return_value = mock_instance
-            result = select_backend()
+            result = select_backend(use_sandbox=True)
             assert result is mock_instance
 
-    def test_docker_fallback(self):
+    def test_sandbox_requested_but_unavailable_falls_back(self):
         with (
             patch("src.host.runtime.sandbox_available", return_value=False),
             patch("src.host.runtime.DockerBackend") as MockDocker,
         ):
             mock_instance = MagicMock()
             MockDocker.return_value = mock_instance
-            result = select_backend()
+            result = select_backend(use_sandbox=True)
             assert result is mock_instance


### PR DESCRIPTION
## Summary

Docker Sandbox requires Docker Desktop 4.58+ with microVM support (Apple Virtualization.framework on macOS, Hyper-V on Windows). It's **not available** on bare Docker Engine (most Linux installs via `apt install docker.io`) and is still experimental.

**Before:** OpenLegion auto-detected `docker sandbox version` and tried sandbox first. On systems where the CLI exists but the feature doesn't work, this caused a **120-second timeout** with no output — then fell back to standard containers anyway.

**After:**
- Standard Docker containers are the default — they work on every platform
- `openlegion start --sandbox` opts into microVM isolation for users who want it
- If sandbox is requested but unavailable, a clear message explains why and falls back immediately
- Removed the WARNING that made standard containers seem inadequate

## Test plan
- [x] All 407 tests pass
- [x] `test_default_is_docker` — default always picks DockerBackend
- [x] `test_sandbox_when_opted_in_and_available` — --sandbox flag works
- [x] `test_sandbox_requested_but_unavailable_falls_back` — graceful fallback