### PR TITLE
Fix agent connectivity on macOS and restore backend_label

### DIFF
--- a/src/cli.py
+++ b/src/cli.py
@@ -978,6 +978,7 @@ def _start_interactive(config_path: str, use_sandbox: bool = False) -> None:
         use_sandbox=use_sandbox,
     )
     is_sandbox = isinstance(runtime, SandboxBackend)
+    backend_label = runtime.backend_name()
 
     if is_sandbox:
         transport = SandboxTransport()

--- a/src/host/runtime.py
+++ b/src/host/runtime.py
@@ -553,9 +553,13 @@ def select_backend(
             "Docker Sandbox requested but not available. "
             "Requires Docker Desktop 4.58+. Falling back to containers."
         )
-    logger.info("Using Docker container isolation")
+    # Host networking only works reliably on Linux. On macOS/Windows,
+    # Docker Desktop runs in a VM so --network=host doesn't expose ports
+    # to the actual host. Use port mapping (bridge network) instead.
+    use_host_net = platform.system() == "Linux"
+    logger.info("Using Docker container isolation (host_network=%s)", use_host_net)
     return DockerBackend(
         mesh_host_port=mesh_host_port,
-        use_host_network=True,
+        use_host_network=use_host_net,
         project_root=project_root,
     )


### PR DESCRIPTION
## Summary

Two bugs fixed:

1. **macOS/Windows: agents unreachable** — `--network=host` doesn't work on Docker Desktop because containers run in a Linux VM. The "host" network is the VM's, not the actual host. This caused health check failures and "All connection attempts failed" errors when messaging agents. Now auto-detects platform: host networking on Linux, bridge + port mapping on macOS/Windows.

2. **NameError crash** — `backend_label` was referenced at startup but the variable assignment was accidentally removed in the sandbox opt-in refactor.

## Test plan
- [x] All 407 tests pass
- [ ] `openlegion start` on macOS — agents should be reachable
- [ ] `openlegion start` on Linux — still uses host networking