### PR TITLE
Force amd64 Docker image to fix sqlite-vec crash on Apple Silicon

### DIFF
--- a/Dockerfile.agent
+++ b/Dockerfile.agent
@@ -1,4 +1,6 @@
-FROM python:3.12-slim
+# Force amd64: sqlite-vec and Chromium have broken ARM wheels/binaries.
+# Docker Desktop uses Rosetta 2 on Apple Silicon — fast and reliable.
+FROM --platform=linux/amd64 python:3.12-slim
 
 # System tools useful for agent operations
 RUN apt-get update && apt-get install -y --no-install-recommends \
@@ -12,7 +14,7 @@ WORKDIR /app
 
 # Python dependencies — only what agents actually import
 # (litellm, pyyaml, click, docker are host-only — not needed here)
-# sqlite-vec has prebuilt wheels for all platforms (linux, macOS, Windows)
+# sqlite-vec requires amd64 (ARM wheels have broken 32-bit .so files)
 COPY pyproject.toml .
 RUN pip install --no-cache-dir \
     fastapi uvicorn httpx pydantic playwright sqlite-vec

--- a/src/cli.py
+++ b/src/cli.py
@@ -221,7 +221,12 @@ def _build_docker_image() -> None:
     click.echo("Building Docker image...")
     click.echo("  First build downloads base image + Chromium (~2 min). Rebuilds are fast.\n")
     proc = subprocess.Popen(
-        ["docker", "build", "-t", "openlegion-agent:latest", "-f", "Dockerfile.agent", "."],
+        [
+            "docker", "build",
+            "--platform", "linux/amd64",
+            "-t", "openlegion-agent:latest",
+            "-f", "Dockerfile.agent", ".",
+        ],
         cwd=str(PROJECT_ROOT),
         stdout=subprocess.PIPE,
         stderr=subprocess.STDOUT,
@@ -237,7 +242,7 @@ def _build_docker_image() -> None:
     proc.wait()
     if proc.returncode != 0:
         click.echo("Docker build failed. Run manually for full output:", err=True)
-        click.echo("  docker build -t openlegion-agent:latest -f Dockerfile.agent .", err=True)
+        click.echo("  docker build --platform linux/amd64 -t openlegion-agent:latest -f Dockerfile.agent .", err=True)
         sys.exit(1)
     click.echo("\n  Docker image built successfully.")
 


### PR DESCRIPTION
## Summary
- sqlite-vec's ARM Linux wheel ships a 32-bit `.so` (`ELFCLASS32`) that crashes on Apple Silicon's 64-bit ARM containers
- Force `linux/amd64` platform in both the Dockerfile (`FROM --platform`) and the CLI build command
- Docker Desktop uses Rosetta 2 on Apple Silicon — fast and reliable

## Root cause
On Apple Silicon Macs, Docker Desktop pulls ARM64 Linux images. sqlite-vec's ARM wheel contains a 32-bit ELF binary (`vec0.so`) which fails to load, crashing the agent container on startup.

## Test plan
- [x] All 407 tests pass
- [ ] Test on Apple Silicon Mac: `git pull && openlegion start` — image rebuilds as amd64, agents start

🤖 Generated with [Claude Code](https://claude.com/claude-code)