### PR TITLE
Fix cron seconds support, schedule validation, and read-only skills dir

### DIFF
--- a/src/agent/builtins/skill_tool.py
+++ b/src/agent/builtins/skill_tool.py
@@ -83,7 +83,8 @@ def create_skill(name: str, code: str, *, workspace_manager=None) -> dict:
     if error:
         return {"error": f"Validation failed: {error}"}
 
-    skills_dir = Path("/app/skills")
+    # Write to /data/custom_skills (writable) — /app/skills is read-only
+    skills_dir = Path("/data/custom_skills")
     skills_dir.mkdir(parents=True, exist_ok=True)
 
     filename = _sanitize_filename(name)
@@ -119,7 +120,7 @@ def reload_skills() -> dict:
     parameters={},
 )
 def list_custom_skills() -> dict:
-    skills_dir = Path("/app/skills")
+    skills_dir = Path("/data/custom_skills")
     if not skills_dir.exists():
         return {"skills": [], "count": 0}
     files = [f.name for f in skills_dir.glob("*.py") if not f.name.startswith("_")]

--- a/src/agent/skills.py
+++ b/src/agent/skills.py
@@ -42,11 +42,14 @@ class SkillRegistry:
     Supports hot-reload when agents create new skills at runtime.
     """
 
+    CUSTOM_SKILLS_DIR = "/data/custom_skills"
+
     def __init__(self, skills_dir: str):
         self.skills_dir = skills_dir
         self.skills: dict[str, dict] = {}
         self._discover_builtins()
         self._discover(skills_dir)
+        self._discover(self.CUSTOM_SKILLS_DIR)
         self.skills = dict(_skill_staging)
 
     def _discover_builtins(self) -> None:
@@ -82,6 +85,7 @@ class SkillRegistry:
         _skill_staging.clear()
         self._discover_builtins()
         self._discover(self.skills_dir)
+        self._discover(self.CUSTOM_SKILLS_DIR)
         self.skills = dict(_skill_staging)
         logger.info(f"Reloaded {len(self.skills)} skills")
         return len(self.skills)


### PR DESCRIPTION
## Summary
Three issues found during user testing:

- **`create_skill` Read-only file system**: Skills dir `/app/skills` is mounted `ro` in Docker. Custom skills now write to `/data/custom_skills` (writable data volume). `SkillRegistry` scans both directories on init and reload.
- **6-field cron silently ignored**: Agent used `*/5 * * * * *` (seconds-level cron) which the 5-field parser silently skipped. Added `_validate_schedule()` that rejects 6-field with a helpful error: *"Use 'every 5s' for seconds"*.
- **No seconds interval**: Added `s` to interval shorthand (`every 5s`, `every 30s`). Reduced `TICK_INTERVAL` from 15s to 5s for finer resolution.

## Test plan
- [x] All 407 tests pass
- [ ] Test `create_skill` — should write to `/data/custom_skills` without error
- [ ] Test `set_cron` with `every 5s` — should fire every 5 seconds
- [ ] Test `set_cron` with `*/5 * * * * *` — should return validation error

🤖 Generated with [Claude Code](https://claude.com/claude-code)