### PR TITLE
Return 400 instead of 500 for invalid cron schedule

### DIFF
--- a/src/host/server.py
+++ b/src/host/server.py
@@ -188,9 +188,12 @@ def create_mesh_app(
         heartbeat = data.get("heartbeat", False)
         if not agent_id or not schedule:
             raise HTTPException(400, "agent_id and schedule are required")
-        job = cron_scheduler.add_job(
-            agent=agent_id, schedule=schedule, message=message, heartbeat=heartbeat,
-        )
+        try:
+            job = cron_scheduler.add_job(
+                agent=agent_id, schedule=schedule, message=message, heartbeat=heartbeat,
+            )
+        except ValueError as e:
+            raise HTTPException(400, str(e))
         return {"id": job.id, "agent": job.agent, "schedule": job.schedule, "heartbeat": job.heartbeat}
 
     @app.get("/mesh/cron")


### PR DESCRIPTION
## Summary
- Schedule validation raises `ValueError` but the `/mesh/cron` endpoint didn't catch it, causing a 500 Internal Server Error with a full stack trace
- Now catches `ValueError` and returns a clean 400 with the helpful message (e.g. "Use 'every 5s' for seconds")

## Test plan
- [x] All 407 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)