### PR TITLE
Add blind credential vault, mesh auth, SOUL.md, silent reply, and global CLI

### DIFF
--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -7,12 +7,13 @@
 ```bash
 git clone https://github.com/openlegion-ai/openlegion.git && cd openlegion
 ./install.sh         # checks dependencies, creates venv, installs everything
-source .venv/bin/activate
 openlegion setup     # API key, project description, team template
 openlegion start     # launch agents and start chatting
 ```
 
-That's it. If `install.sh` passes, you're good. If it fails, it tells you exactly what's missing.
+That's it. The installer makes `openlegion` available globally — no need to activate a virtual environment. If `install.sh` passes, you're good. If it fails, it tells you exactly what's missing.
+
+> **Note:** If `openlegion: command not found` after install, your `~/.local/bin` may not be on PATH. The installer will print the exact command to fix this.
 
 You can also use `make`:
 
@@ -31,12 +32,12 @@ make test            # run the test suite
 git clone https://github.com/openlegion-ai/openlegion.git
 cd openlegion
 powershell -ExecutionPolicy Bypass -File install.ps1
-.venv\Scripts\Activate.ps1
 openlegion setup     # API key, project description, team template
 openlegion start     # launch agents and start chatting
 ```
 
 > PowerShell blocks the script? Run: `Set-ExecutionPolicy -ExecutionPolicy RemoteSigned -Scope CurrentUser`
+> After install, restart your terminal if `openlegion` isn't recognized.
 
 ---
 
@@ -164,8 +165,19 @@ If you prefer not to use the install scripts:
 git clone https://github.com/openlegion-ai/openlegion.git
 cd openlegion
 python3 -m venv .venv
-source .venv/bin/activate
-pip3 install -e ".[dev]"
+.venv/bin/pip install -e ".[dev]"
+
+# Make openlegion available globally (no venv activation needed):
+mkdir -p ~/.local/bin
+ln -sf "$(pwd)/.venv/bin/openlegion" ~/.local/bin/openlegion
+```
+
+If `~/.local/bin` isn't on your PATH, add it:
+```bash
+# bash
+echo 'export PATH="$HOME/.local/bin:$PATH"' >> ~/.bashrc && source ~/.bashrc
+# zsh
+echo 'export PATH="$HOME/.local/bin:$PATH"' >> ~/.zshrc && source ~/.zshrc
 ```
 
 </details>
@@ -177,8 +189,7 @@ pip3 install -e ".[dev]"
 git clone https://github.com/openlegion-ai/openlegion.git
 cd openlegion
 python -m venv .venv
-.venv\Scripts\Activate.ps1
-pip install -e ".[dev]"
+.venv\Scripts\pip install -e ".[dev]"
 ```
 
 > PowerShell blocks the script? Run: `Set-ExecutionPolicy -ExecutionPolicy RemoteSigned -Scope CurrentUser`
@@ -260,7 +271,7 @@ openlegion start --sandbox
 
 | Problem | Fix |
 |---|---|
-| `command not found: openlegion` | Activate the venv: `source .venv/bin/activate` (macOS/Linux) or `.venv\Scripts\Activate.ps1` (Windows) |
+| `command not found: openlegion` | Re-run `./install.sh` or add `~/.local/bin` to PATH: `export PATH="$HOME/.local/bin:$PATH"`. On Windows, restart your terminal after install. |
 | `Docker is not running` | Open Docker Desktop (macOS/Windows) or `sudo systemctl start docker` (Linux) |
 | `permission denied` on Docker | Linux: `sudo usermod -aG docker $USER` then log out/in |
 | `python3: command not found` | Install Python 3.10+ (see above). On Windows, use `python` instead of `python3`. |

--- a/README.md
+++ b/README.md
@@ -57,8 +57,7 @@
 
 ```bash
 git clone https://github.com/openlegion-ai/openlegion.git && cd openlegion
-./install.sh                     # checks deps, creates venv, installs everything
-source .venv/bin/activate
+./install.sh                     # checks deps, creates venv, makes CLI global
 openlegion setup                 # API key, project description, team template
 openlegion start                 # launch agents and start chatting
 ```
@@ -69,7 +68,6 @@ openlegion start                 # launch agents and start chatting
 git clone https://github.com/openlegion-ai/openlegion.git
 cd openlegion
 powershell -ExecutionPolicy Bypass -File install.ps1
-.venv\Scripts\Activate.ps1
 openlegion setup
 openlegion start
 ```

--- a/src/agent/builtins/vault_tool.py
+++ b/src/agent/builtins/vault_tool.py
@@ -1,0 +1,165 @@
+"""Credential-blind vault tools for agents.
+
+Agents can generate, capture, list, and check credentials without ever
+seeing the actual secret values. Values are stored in the mesh vault and
+referenced via opaque ``$CRED{name}`` handles.
+"""
+
+from __future__ import annotations
+
+import re
+import secrets
+import string
+
+from src.agent.skills import skill
+from src.shared.utils import setup_logging
+
+logger = setup_logging("agent.vault")
+
+_CHARSETS = {
+    "urlsafe": None,  # uses secrets.token_urlsafe
+    "hex": string.hexdigits[:16],
+    "alphanumeric": string.ascii_letters + string.digits,
+}
+
+
+@skill(
+    name="vault_generate_secret",
+    description=(
+        "Generate a cryptographically random secret and store it in the vault. "
+        "Returns an opaque $CRED{name} handle — the actual value is NEVER returned. "
+        "Use this to create API keys, passwords, or tokens for service accounts."
+    ),
+    parameters={
+        "name": {"type": "string", "description": "Credential name (e.g. 'myservice_api_key')"},
+        "length": {
+            "type": "integer",
+            "description": "Length of the secret (default 32)",
+            "default": 32,
+        },
+        "charset": {
+            "type": "string",
+            "description": "Character set: 'urlsafe' (default), 'hex', or 'alphanumeric'",
+            "default": "urlsafe",
+        },
+    },
+)
+async def vault_generate_secret(
+    name: str,
+    length: int = 32,
+    charset: str = "urlsafe",
+    *,
+    mesh_client=None,
+) -> dict:
+    """Generate a random secret, store it, return only the handle."""
+    if not mesh_client:
+        return {"error": "Vault tools require mesh connectivity"}
+    if not name:
+        return {"error": "name is required"}
+
+    if charset == "urlsafe":
+        value = secrets.token_urlsafe(length)[:length]
+    elif charset in _CHARSETS and _CHARSETS[charset]:
+        value = "".join(secrets.choice(_CHARSETS[charset]) for _ in range(length))
+    else:
+        return {"error": f"Unknown charset: {charset}. Use: urlsafe, hex, alphanumeric"}
+
+    try:
+        result = await mesh_client.vault_store(name, value)
+        return {"stored": True, "handle": result.get("handle", f"$CRED{{{name}}}")}
+    except Exception as e:
+        return {"error": f"Failed to store credential: {e}"}
+
+
+@skill(
+    name="vault_capture_from_page",
+    description=(
+        "Read text from a browser element and store it as a credential in the vault. "
+        "Returns an opaque $CRED{name} handle — the captured value is NEVER returned. "
+        "Use after signing up for a service to capture displayed API keys."
+    ),
+    parameters={
+        "name": {"type": "string", "description": "Credential name to store under"},
+        "selector": {
+            "type": "string",
+            "description": "CSS selector of the element containing the secret (optional if ref given)",
+            "default": "",
+        },
+        "ref": {
+            "type": "string",
+            "description": "Element ref from browser_snapshot (e.g. 'e3')",
+            "default": "",
+        },
+    },
+)
+async def vault_capture_from_page(
+    name: str,
+    selector: str = "",
+    ref: str = "",
+    *,
+    mesh_client=None,
+) -> dict:
+    """Capture text from a browser element and store as credential."""
+    if not mesh_client:
+        return {"error": "Vault tools require mesh connectivity"}
+    if not name:
+        return {"error": "name is required"}
+    if not selector and not ref:
+        return {"error": "Provide either 'ref' (from browser_snapshot) or 'selector' (CSS)"}
+
+    try:
+        from src.agent.builtins.browser_tool import _get_page, _page_refs
+
+        page = await _get_page()
+        if ref:
+            locator = _page_refs.get(ref)
+            if not locator:
+                return {"error": f"Unknown ref '{ref}'. Call browser_snapshot first."}
+            value = await locator.inner_text(timeout=10000)
+        else:
+            value = await page.inner_text(selector, timeout=10000)
+
+        value = value.strip()
+        if not value:
+            return {"error": "Element is empty — no text to capture"}
+
+        result = await mesh_client.vault_store(name, value)
+        return {"captured": True, "handle": result.get("handle", f"$CRED{{{name}}}")}
+    except Exception as e:
+        return {"error": f"Failed to capture credential: {e}"}
+
+
+@skill(
+    name="vault_list",
+    description="List all credential names stored in the vault (names only, never values).",
+    parameters={},
+)
+async def vault_list(*, mesh_client=None) -> dict:
+    """List credential names from the vault."""
+    if not mesh_client:
+        return {"error": "Vault tools require mesh connectivity"}
+    try:
+        names = await mesh_client.vault_list()
+        return {"credentials": names, "count": len(names)}
+    except Exception as e:
+        return {"error": f"Failed to list credentials: {e}"}
+
+
+@skill(
+    name="vault_status",
+    description="Check if a credential exists in the vault by name.",
+    parameters={
+        "name": {"type": "string", "description": "Credential name to check"},
+    },
+)
+async def vault_status(name: str, *, mesh_client=None) -> dict:
+    """Check if a credential exists."""
+    if not mesh_client:
+        return {"error": "Vault tools require mesh connectivity"}
+    if not name:
+        return {"error": "name is required"}
+    try:
+        result = await mesh_client.vault_status(name)
+        return {"name": name, "exists": result.get("exists", False)}
+    except Exception as e:
+        return {"error": f"Failed to check credential: {e}"}

--- a/src/agent/llm.py
+++ b/src/agent/llm.py
@@ -7,6 +7,7 @@ The mesh tracks token usage and enforces budgets.
 from __future__ import annotations
 
 import json
+import os
 
 import httpx
 
@@ -24,10 +25,14 @@ class LLMClient:
         self.agent_id = agent_id
         self.default_model = default_model
         self._client: httpx.AsyncClient | None = None
+        self._auth_token: str = os.environ.get("MESH_AUTH_TOKEN", "")
 
     async def _get_client(self) -> httpx.AsyncClient:
         if self._client is None or self._client.is_closed:
-            self._client = httpx.AsyncClient(timeout=120)
+            headers: dict[str, str] = {}
+            if self._auth_token:
+                headers["Authorization"] = f"Bearer {self._auth_token}"
+            self._client = httpx.AsyncClient(timeout=120, headers=headers)
         return self._client
 
     async def close(self) -> None:

--- a/src/channels/discord.py
+++ b/src/channels/discord.py
@@ -20,6 +20,7 @@ import json
 from pathlib import Path
 
 from src.channels.base import (
+    AddKeyFn,
     Channel,
     CostsFn,
     DispatchFn,
@@ -63,6 +64,7 @@ class DiscordChannel(Channel):
         status_fn: StatusFn | None = None,
         costs_fn: CostsFn | None = None,
         reset_fn: ResetFn | None = None,
+        addkey_fn: AddKeyFn | None = None,
     ):
         super().__init__(
             dispatch_fn=dispatch_fn,
@@ -71,6 +73,7 @@ class DiscordChannel(Channel):
             status_fn=status_fn,
             costs_fn=costs_fn,
             reset_fn=reset_fn,
+            addkey_fn=addkey_fn,
         )
         self.token = token
         self.allowed_guilds = set(allowed_guilds) if allowed_guilds else None

--- a/src/channels/telegram.py
+++ b/src/channels/telegram.py
@@ -20,6 +20,7 @@ import json
 from pathlib import Path
 
 from src.channels.base import (
+    AddKeyFn,
     Channel,
     CostsFn,
     DispatchFn,
@@ -92,6 +93,7 @@ class TelegramChannel(Channel):
         costs_fn: CostsFn | None = None,
         reset_fn: ResetFn | None = None,
         stream_dispatch_fn: StreamDispatchFn | None = None,
+        addkey_fn: AddKeyFn | None = None,
     ):
         super().__init__(
             dispatch_fn=dispatch_fn,
@@ -101,6 +103,7 @@ class TelegramChannel(Channel):
             costs_fn=costs_fn,
             reset_fn=reset_fn,
             stream_dispatch_fn=stream_dispatch_fn,
+            addkey_fn=addkey_fn,
         )
         self.token = token
         self._explicit_allowed = set(allowed_users) if allowed_users else None
@@ -130,7 +133,7 @@ class TelegramChannel(Channel):
         self._app.add_handler(CommandHandler("paired", self._cmd_paired))
         # Route OpenLegion REPL commands (/status, /agents, /costs, etc.)
         # through the base Channel.handle_message() handler.
-        _repl_cmds = ("use", "agents", "status", "broadcast", "costs", "reset", "help")
+        _repl_cmds = ("use", "agents", "status", "broadcast", "costs", "reset", "addkey", "help")
         for cmd in _repl_cmds:
             self._app.add_handler(CommandHandler(cmd, self._on_repl_command))
         self._app.add_handler(

--- a/src/host/permissions.py
+++ b/src/host/permissions.py
@@ -48,6 +48,7 @@ class PermissionMatrix:
                 blackboard_read=default.blackboard_read,
                 blackboard_write=default.blackboard_write,
                 allowed_apis=default.allowed_apis,
+                can_manage_vault=default.can_manage_vault,
             )
         return AgentPermissions(agent_id=agent_id)
 
@@ -86,3 +87,9 @@ class PermissionMatrix:
             return True
         perms = self.get_permissions(agent_id)
         return service in perms.allowed_apis
+
+    def can_manage_vault(self, agent_id: str) -> bool:
+        if agent_id in ("mesh", "orchestrator"):
+            return True
+        perms = self.get_permissions(agent_id)
+        return perms.can_manage_vault

--- a/src/shared/types.py
+++ b/src/shared/types.py
@@ -161,6 +161,7 @@ class AgentPermissions(BaseModel):
     blackboard_read: list[str] = []
     blackboard_write: list[str] = []
     allowed_apis: list[str] = []
+    can_manage_vault: bool = False
 
 
 # === Memory (inside agent container) ===

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -87,6 +87,7 @@ class TestSandboxBackend:
         backend.project_root = project_root
         backend.mesh_host_port = 8420
         backend.agents = {}
+        backend.auth_tokens = {}
         backend._workspace_root = tmp_path / ".openlegion" / "agents"
         backend._workspace_root.mkdir(parents=True)
 
@@ -108,6 +109,8 @@ class TestSandboxBackend:
         assert "AGENT_ID=alpha" in env_content
         assert "AGENT_ROLE=test" in env_content
         assert "LLM_MODEL=openai/gpt-4o-mini" in env_content
+        assert "MESH_AUTH_TOKEN=" in env_content
+        assert "alpha" in backend.auth_tokens
 
     def test_stop_agent_removes_from_registry(self):
         backend = SandboxBackend.__new__(SandboxBackend)

--- a/tests/test_vault.py
+++ b/tests/test_vault.py
@@ -1,0 +1,217 @@
+"""Tests for vault tools (credential-blind agent tools)."""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+
+class TestVaultGenerateSecret:
+    @pytest.mark.asyncio
+    async def test_no_value_in_return(self):
+        """The actual secret value must NEVER appear in the return dict."""
+        from src.agent.builtins.vault_tool import vault_generate_secret
+
+        mock_client = AsyncMock()
+        mock_client.vault_store.return_value = {"stored": True, "handle": "$CRED{test_key}"}
+
+        result = await vault_generate_secret(
+            name="test_key", length=32, charset="urlsafe", mesh_client=mock_client,
+        )
+        assert result["stored"] is True
+        assert result["handle"] == "$CRED{test_key}"
+        assert "value" not in result
+
+        # Verify vault_store was called with a non-empty value
+        call_args = mock_client.vault_store.call_args
+        assert len(call_args[0][1]) > 0  # value is non-empty
+
+    @pytest.mark.asyncio
+    async def test_charsets_hex(self):
+        from src.agent.builtins.vault_tool import vault_generate_secret
+
+        mock_client = AsyncMock()
+        mock_client.vault_store.return_value = {"stored": True, "handle": "$CRED{hex_key}"}
+
+        result = await vault_generate_secret(
+            name="hex_key", length=16, charset="hex", mesh_client=mock_client,
+        )
+        assert result["stored"] is True
+
+        # Verify hex charset used
+        stored_value = mock_client.vault_store.call_args[0][1]
+        assert all(c in "0123456789abcdef" for c in stored_value)
+        assert len(stored_value) == 16
+
+    @pytest.mark.asyncio
+    async def test_charsets_alphanumeric(self):
+        from src.agent.builtins.vault_tool import vault_generate_secret
+
+        mock_client = AsyncMock()
+        mock_client.vault_store.return_value = {"stored": True, "handle": "$CRED{alnum_key}"}
+
+        result = await vault_generate_secret(
+            name="alnum_key", length=24, charset="alphanumeric", mesh_client=mock_client,
+        )
+        assert result["stored"] is True
+
+        stored_value = mock_client.vault_store.call_args[0][1]
+        assert stored_value.isalnum()
+        assert len(stored_value) == 24
+
+    @pytest.mark.asyncio
+    async def test_charsets_urlsafe(self):
+        from src.agent.builtins.vault_tool import vault_generate_secret
+
+        mock_client = AsyncMock()
+        mock_client.vault_store.return_value = {"stored": True, "handle": "$CRED{url_key}"}
+
+        result = await vault_generate_secret(
+            name="url_key", length=32, charset="urlsafe", mesh_client=mock_client,
+        )
+        assert result["stored"] is True
+        assert "value" not in result
+
+    @pytest.mark.asyncio
+    async def test_unknown_charset_returns_error(self):
+        from src.agent.builtins.vault_tool import vault_generate_secret
+
+        mock_client = AsyncMock()
+        result = await vault_generate_secret(
+            name="key", charset="bogus", mesh_client=mock_client,
+        )
+        assert "error" in result
+        assert "Unknown charset" in result["error"]
+
+    @pytest.mark.asyncio
+    async def test_no_mesh_client_returns_error(self):
+        from src.agent.builtins.vault_tool import vault_generate_secret
+
+        result = await vault_generate_secret(name="key", mesh_client=None)
+        assert "error" in result
+
+    @pytest.mark.asyncio
+    async def test_empty_name_returns_error(self):
+        from src.agent.builtins.vault_tool import vault_generate_secret
+
+        mock_client = AsyncMock()
+        result = await vault_generate_secret(name="", mesh_client=mock_client)
+        assert "error" in result
+
+
+class TestVaultCaptureFromPage:
+    @pytest.mark.asyncio
+    async def test_no_value_in_return(self):
+        """Captured value must NEVER appear in the return dict."""
+        from src.agent.builtins.vault_tool import vault_capture_from_page
+
+        mock_client = AsyncMock()
+        mock_client.vault_store.return_value = {"stored": True, "handle": "$CRED{api_key}"}
+
+        mock_page = AsyncMock()
+        mock_page.inner_text = AsyncMock(return_value="sk-secret-12345")
+
+        with patch("src.agent.builtins.browser_tool._get_page", return_value=mock_page):
+            result = await vault_capture_from_page(
+                name="api_key", selector="#key-display", mesh_client=mock_client,
+            )
+
+        assert result["captured"] is True
+        assert result["handle"] == "$CRED{api_key}"
+        assert "value" not in result
+        assert "sk-secret" not in str(result)
+
+    @pytest.mark.asyncio
+    async def test_capture_with_ref(self):
+        import src.agent.builtins.browser_tool as bt
+        from src.agent.builtins.vault_tool import vault_capture_from_page
+
+        mock_client = AsyncMock()
+        mock_client.vault_store.return_value = {"stored": True, "handle": "$CRED{token}"}
+
+        mock_locator = AsyncMock()
+        mock_locator.inner_text.return_value = "secret-token-value"
+        bt._page_refs["e5"] = mock_locator
+
+        mock_page = AsyncMock()
+
+        with patch("src.agent.builtins.browser_tool._get_page", return_value=mock_page):
+            result = await vault_capture_from_page(
+                name="token", ref="e5", mesh_client=mock_client,
+            )
+
+        assert result["captured"] is True
+        assert "value" not in result
+
+    @pytest.mark.asyncio
+    async def test_capture_empty_element(self):
+        from src.agent.builtins.vault_tool import vault_capture_from_page
+
+        mock_client = AsyncMock()
+        mock_page = AsyncMock()
+        mock_page.inner_text = AsyncMock(return_value="   ")
+
+        with patch("src.agent.builtins.browser_tool._get_page", return_value=mock_page):
+            result = await vault_capture_from_page(
+                name="empty", selector="#key", mesh_client=mock_client,
+            )
+
+        assert "error" in result
+        assert "empty" in result["error"].lower()
+
+    @pytest.mark.asyncio
+    async def test_no_selector_or_ref_returns_error(self):
+        from src.agent.builtins.vault_tool import vault_capture_from_page
+
+        mock_client = AsyncMock()
+        result = await vault_capture_from_page(name="key", mesh_client=mock_client)
+        assert "error" in result
+
+
+class TestVaultListTool:
+    @pytest.mark.asyncio
+    async def test_vault_list_returns_names(self):
+        from src.agent.builtins.vault_tool import vault_list
+
+        mock_client = AsyncMock()
+        mock_client.vault_list.return_value = ["brave_search", "anthropic_api_key"]
+
+        result = await vault_list(mesh_client=mock_client)
+        assert result["credentials"] == ["brave_search", "anthropic_api_key"]
+        assert result["count"] == 2
+
+    @pytest.mark.asyncio
+    async def test_vault_list_no_mesh_client(self):
+        from src.agent.builtins.vault_tool import vault_list
+
+        result = await vault_list(mesh_client=None)
+        assert "error" in result
+
+
+class TestVaultStatusTool:
+    @pytest.mark.asyncio
+    async def test_vault_status_exists(self):
+        from src.agent.builtins.vault_tool import vault_status
+
+        mock_client = AsyncMock()
+        mock_client.vault_status.return_value = {"name": "my_key", "exists": True}
+
+        result = await vault_status(name="my_key", mesh_client=mock_client)
+        assert result["name"] == "my_key"
+        assert result["exists"] is True
+
+    @pytest.mark.asyncio
+    async def test_vault_status_not_exists(self):
+        from src.agent.builtins.vault_tool import vault_status
+
+        mock_client = AsyncMock()
+        mock_client.vault_status.return_value = {"name": "nope", "exists": False}
+
+        result = await vault_status(name="nope", mesh_client=mock_client)
+        assert result["exists"] is False
+
+    @pytest.mark.asyncio
+    async def test_vault_status_no_mesh_client(self):
+        from src.agent.builtins.vault_tool import vault_status
+
+        result = await vault_status(name="key", mesh_client=None)
+        assert "error" in result


### PR DESCRIPTION
## Summary

- **Mesh auth tokens**: Per-agent `secrets.token_urlsafe(32)` generated at container startup, verified via `hmac.compare_digest` on all 14 agent-facing endpoints. LLMClient and MeshClient both include `Authorization: Bearer` headers.
- **Blind credential vault**: 4 mesh endpoints + 4 agent tools (`vault_generate_secret`, `vault_capture_from_page`, `vault_list`, `vault_status`). Credential values never enter the LLM context window. `$CRED{name}` opaque handles resolve at the browser layer.
- **Vault security hardening**: `_redact_credentials()` on all browser output paths (navigate, snapshot, evaluate). Rate limiting on `/mesh/vault/resolve` (5/agent/60s). Audit logging.
- **SOUL.md persona injection**: Fallback chain — agent workspace SOUL.md → project `/app/SOUL.md` → default scaffold. Injected into chat system prompt.
- **Silent reply token**: `__SILENT__` detected in all 4 chat code paths (normal, max-rounds, stream normal, stream max-rounds). Channels suppress empty responses.
- **`/addkey` command**: Works in CLI REPL, Telegram, and Discord. Consumed at channel layer, never dispatched to agent.
- **Global CLI access**: `install.sh` creates `~/.local/bin/openlegion` symlink and auto-adds PATH to shell rc file. `install.ps1` creates `.cmd` wrapper and adds to user PATH. No more `source .venv/bin/activate` in quickstart.

## Fixes

- `LLMClient` was missing auth header → 401 on all agent LLM calls
- Telegram `/addkey` silently dropped (missing from `_repl_cmds` registration)
- `TelegramChannel` and `DiscordChannel` crashed on `addkey_fn` kwarg

## Test plan

- [x] 473 unit/integration tests passing
- [ ] `openlegion start` — agents respond without 401 errors
- [ ] `/addkey test_svc test_key` works in CLI and Telegram
- [ ] `install.sh` creates working symlink; `openlegion --help` works from any directory
- [ ] Verify SOUL.md persona loads into agent chat responses

🤖 Generated with [Claude Code](https://claude.com/claude-code)