### PR TITLE
Fix install.sh: detect broken venv and handle root ownership

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -127,10 +127,16 @@ info "Git available"
 
 echo ""
 
-# If .venv exists but is broken (missing bin/python), recreate it
-if [ -d ".venv" ] && [ ! -x ".venv/bin/python" ]; then
+# If .venv exists but is broken (missing python or pip), recreate it
+if [ -d ".venv" ] && { [ ! -x ".venv/bin/python" ] || [ ! -x ".venv/bin/pip" ]; }; then
     warn "Existing .venv is broken — recreating..."
-    rm -rf .venv
+    rm -rf .venv 2>/dev/null || true
+    # If rm failed (e.g. root-owned .venv), try with sudo
+    if [ -d ".venv" ]; then
+        warn ".venv is owned by another user — need sudo to remove it"
+        sudo rm -rf .venv || fail "Cannot remove broken .venv. Delete it manually:
+      sudo rm -rf .venv"
+    fi
 fi
 
 if [ ! -d ".venv" ]; then


### PR DESCRIPTION
## Summary
- Check for both `bin/python` and `bin/pip` when detecting broken venvs (previously only checked python)
- Handle root-owned `.venv` that non-root user can't delete — falls back to `sudo rm -rf`
- Fixes the scenario: user runs `sudo ./install.sh`, creates root-owned broken venv, then runs `./install.sh` without sudo

## Test plan
- [x] `bash -n install.sh` syntax check passes
- [ ] Manual test on Debian 13 (Qubes AppVM) with pre-existing root-owned broken .venv

🤖 Generated with [Claude Code](https://claude.com/claude-code)