### PR TITLE
Add Slack channel adapter with Socket Mode (Roadmap 2.3)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,7 @@ config/webhooks.json
 config/workflows/
 config/telegram_paired.json
 config/discord_paired.json
+config/slack_paired.json
 PROJECT.md
 SOUL.md
 ROADMAP.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,7 @@ mcp = [
 channels = [
     "python-telegram-bot>=21.0",
     "discord.py>=2.0",
+    "slack-bolt>=1.18",
 ]
 
 [project.scripts]

--- a/src/channels/slack.py
+++ b/src/channels/slack.py
@@ -1,0 +1,304 @@
+"""Slack channel adapter.
+
+Bridges Slack to the OpenLegion mesh with the same UX as the CLI REPL:
+  - Per-thread active agent tracking (composite key: user_id:thread_ts)
+  - @agent mentions for routing to specific agents
+  - /use, /agents, /status, /broadcast, /costs, /reset, /help commands
+  - Agent name labels on all responses: [agent_name] response
+  - Push notifications for cron/heartbeat results
+  - Pairing: owner must send !start <pairing_code> to claim the bot.
+    Code is generated during `openlegion setup`. Others need !allow.
+
+Requires: pip install slack-bolt>=1.18
+Config: SLACK_BOT_TOKEN + SLACK_APP_TOKEN in .env, channels.slack in mesh.yaml
+Uses Socket Mode (no public URL needed).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from pathlib import Path
+
+from src.channels.base import (
+    AddKeyFn,
+    Channel,
+    CostsFn,
+    DispatchFn,
+    ListAgentsFn,
+    ResetFn,
+    StatusFn,
+    StreamDispatchFn,
+    chunk_text,
+)
+from src.shared.utils import setup_logging
+
+logger = setup_logging("channels.slack")
+
+MAX_SLACK_LEN = 3000
+_PAIRING_FILE = Path("config/slack_paired.json")
+
+
+def _load_paired() -> dict:
+    """Load paired users from disk."""
+    if _PAIRING_FILE.exists():
+        try:
+            return json.loads(_PAIRING_FILE.read_text())
+        except Exception:
+            pass
+    return {"owner": None, "allowed": []}
+
+
+def _save_paired(data: dict) -> None:
+    _PAIRING_FILE.parent.mkdir(parents=True, exist_ok=True)
+    _PAIRING_FILE.write_text(json.dumps(data, indent=2) + "\n")
+
+
+def _get_user_key(user_id: str, thread_ts: str | None) -> str:
+    """Composite key for per-thread agent tracking."""
+    if thread_ts:
+        return f"{user_id}:{thread_ts}"
+    return user_id
+
+
+class SlackChannel(Channel):
+    """Slack bot adapter for OpenLegion with Socket Mode and pairing code security."""
+
+    def __init__(
+        self,
+        bot_token: str,
+        app_token: str,
+        dispatch_fn: DispatchFn,
+        default_agent: str = "",
+        list_agents_fn: ListAgentsFn | None = None,
+        status_fn: StatusFn | None = None,
+        costs_fn: CostsFn | None = None,
+        reset_fn: ResetFn | None = None,
+        stream_dispatch_fn: StreamDispatchFn | None = None,
+        addkey_fn: AddKeyFn | None = None,
+    ):
+        super().__init__(
+            dispatch_fn=dispatch_fn,
+            default_agent=default_agent,
+            list_agents_fn=list_agents_fn,
+            status_fn=status_fn,
+            costs_fn=costs_fn,
+            reset_fn=reset_fn,
+            stream_dispatch_fn=stream_dispatch_fn,
+            addkey_fn=addkey_fn,
+        )
+        self.bot_token = bot_token
+        self.app_token = app_token
+        self._bolt_app = None
+        self._handler = None
+        self._channel_ids: set[str] = set()
+        self._paired = _load_paired()
+
+    async def start(self) -> None:
+        try:
+            from slack_bolt.adapter.socket_mode.async_handler import (
+                AsyncSocketModeHandler,
+            )
+            from slack_bolt.async_app import AsyncApp
+        except ImportError:
+            logger.error(
+                "slack-bolt not installed. "
+                "Install with: pip install 'openlegion[channels]'"
+            )
+            return
+
+        self._bolt_app = AsyncApp(token=self.bot_token)
+        channel_ref = self
+
+        @self._bolt_app.event("message")
+        async def handle_message_event(event, say):
+            await channel_ref._on_message(event, say)
+
+        self._handler = AsyncSocketModeHandler(self._bolt_app, self.app_token)
+        await self._handler.start_async()
+
+        owner = self._paired.get("owner")
+        if owner:
+            logger.info(f"Slack channel started (owner: {owner})")
+        elif self._paired.get("pairing_code"):
+            logger.info("Slack channel started (awaiting pairing code)")
+        else:
+            logger.info("Slack channel started (no pairing code -- run setup again)")
+
+    async def stop(self) -> None:
+        if self._handler:
+            await self._handler.close_async()
+            logger.info("Slack channel stopped")
+
+    async def send_notification(self, text: str) -> None:
+        """Push a cron/heartbeat notification to all known channel IDs."""
+        if not self._bolt_app or not self._channel_ids:
+            return
+        for ch_id in self._channel_ids:
+            try:
+                for part in chunk_text(text, MAX_SLACK_LEN):
+                    await self._bolt_app.client.chat_postMessage(
+                        channel=ch_id, text=part,
+                    )
+            except Exception as e:
+                logger.warning(f"Failed to notify channel {ch_id}: {e}")
+
+    def _is_allowed(self, user_id: str) -> bool:
+        owner = self._paired.get("owner")
+        if owner is None:
+            return False
+        if user_id == owner:
+            return True
+        return user_id in self._paired.get("allowed", [])
+
+    def _is_owner(self, user_id: str) -> bool:
+        return user_id == self._paired.get("owner")
+
+    async def _on_message(self, event: dict, say) -> None:
+        """Handle incoming Slack message events."""
+        # Ignore bot messages and message subtypes (edits, joins, etc.)
+        if event.get("bot_id") or event.get("subtype"):
+            return
+
+        user_id = event.get("user", "")
+        text = (event.get("text") or "").strip()
+        channel_id = event.get("channel", "")
+        thread_ts = event.get("thread_ts")
+
+        if not text or not user_id:
+            return
+
+        # Pairing: !start <code>
+        if self._paired.get("owner") is None:
+            if text.lower().startswith("!start") or text.lower().startswith("/start"):
+                parts = text.split(None, 1)
+                code_arg = parts[1].strip() if len(parts) > 1 else ""
+                expected = self._paired.get("pairing_code", "")
+                if not expected or code_arg != expected:
+                    await say(
+                        text=(
+                            "Pairing required. Send:  `!start <pairing_code>`\n"
+                            "The code was shown during `openlegion setup`."
+                        ),
+                        thread_ts=thread_ts,
+                    )
+                    logger.warning(
+                        f"Rejected !start without valid pairing code from {user_id}"
+                    )
+                    return
+                self._paired["owner"] = user_id
+                self._paired.setdefault("allowed", [])
+                self._paired.pop("pairing_code", None)
+                _save_paired(self._paired)
+                logger.info(f"Paired owner via code: {user_id}")
+                self._channel_ids.add(channel_id)
+                await say(
+                    text=(
+                        f"Paired as owner. Your Slack ID: {user_id}\n"
+                        f"Only you can use this bot. Use `!allow <user_id>` to grant access."
+                    ),
+                    thread_ts=thread_ts,
+                )
+                return
+            else:
+                await say(
+                    text="This bot requires pairing. Send `!start <pairing_code>` to begin.",
+                    thread_ts=thread_ts,
+                )
+                return
+
+        if not self._is_allowed(user_id):
+            if text.lower().startswith("!start") or text.lower().startswith("/start"):
+                await say(
+                    text=(
+                        f"Access denied. This bot is paired to its owner.\n"
+                        f"Your Slack ID: {user_id}\n"
+                        f"Ask the owner to run `!allow {user_id}` to grant you access."
+                    ),
+                    thread_ts=thread_ts,
+                )
+            return
+
+        # Owner-only commands
+        if text.startswith("!allow ") or text.startswith("/allow "):
+            if not self._is_owner(user_id):
+                await say(text="Only the owner can use !allow.", thread_ts=thread_ts)
+                return
+            parts = text.split(None, 1)
+            if len(parts) < 2 or not parts[1].strip():
+                await say(text="Usage: !allow <slack_user_id>", thread_ts=thread_ts)
+                return
+            target_id = parts[1].strip()
+            allowed = self._paired.setdefault("allowed", [])
+            if target_id not in allowed:
+                allowed.append(target_id)
+                _save_paired(self._paired)
+            await say(text=f"User {target_id} is now allowed.", thread_ts=thread_ts)
+            logger.info(f"Owner allowed user {target_id}")
+            return
+
+        if text.startswith("!revoke ") or text.startswith("/revoke "):
+            if not self._is_owner(user_id):
+                await say(text="Only the owner can use !revoke.", thread_ts=thread_ts)
+                return
+            parts = text.split(None, 1)
+            if len(parts) < 2 or not parts[1].strip():
+                await say(text="Usage: !revoke <slack_user_id>", thread_ts=thread_ts)
+                return
+            target_id = parts[1].strip()
+            allowed = self._paired.get("allowed", [])
+            if target_id in allowed:
+                allowed.remove(target_id)
+                _save_paired(self._paired)
+                await say(text=f"User {target_id} access revoked.", thread_ts=thread_ts)
+            else:
+                await say(
+                    text=f"User {target_id} was not in the allowed list.",
+                    thread_ts=thread_ts,
+                )
+            return
+
+        if text.lower() in ("!paired", "/paired"):
+            if not self._is_owner(user_id):
+                await say(
+                    text="Only the owner can view pairing info.",
+                    thread_ts=thread_ts,
+                )
+                return
+            owner = self._paired.get("owner")
+            allowed = self._paired.get("allowed", [])
+            lines = [f"Owner: {owner}"]
+            if allowed:
+                lines.append(f"Allowed users: {', '.join(str(u) for u in allowed)}")
+            else:
+                lines.append("No additional users allowed.")
+            await say(text="\n".join(lines), thread_ts=thread_ts)
+            return
+
+        self._channel_ids.add(channel_id)
+
+        # Translate ! commands to / for base class handling
+        if text.startswith("!"):
+            text = "/" + text[1:]
+
+        user_key = _get_user_key(user_id, thread_ts)
+
+        asyncio.create_task(
+            self._dispatch_and_reply(say, user_key, text, thread_ts)
+        )
+
+    async def _dispatch_and_reply(
+        self, say, user_key: str, text: str, thread_ts: str | None,
+    ) -> None:
+        """Process a message in the background."""
+        try:
+            response = await self.handle_message(user_key, text)
+        except Exception as e:
+            logger.error(f"Dispatch failed for user {user_key}: {e}")
+            response = f"Error: {e}"
+        if response:
+            for part in chunk_text(response, MAX_SLACK_LEN):
+                try:
+                    await say(text=part, thread_ts=thread_ts)
+                except Exception as e:
+                    logger.warning(f"Failed to send response: {e}")

--- a/tests/test_slack.py
+++ b/tests/test_slack.py
@@ -1,0 +1,290 @@
+"""Tests for Slack channel adapter.
+
+Verifies Socket Mode integration, composite user key for per-thread
+agent tracking, pairing flow, command translation, and notifications.
+All tests mock slack_bolt -- no live API needed.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from src.channels.slack import SlackChannel, _get_user_key
+
+
+# ── helpers ──────────────────────────────────────────────────────
+
+def _make_channel(
+    paired: dict | None = None,
+    agents: list[str] | None = None,
+    **overrides,
+) -> SlackChannel:
+    agents = agents or ["alpha", "beta"]
+
+    async def dispatch_fn(agent: str, message: str) -> str:
+        return f"reply from {agent}"
+
+    def list_agents_fn():
+        return {a: {} for a in agents}
+
+    def status_fn(name: str):
+        return {"state": "running", "tasks_completed": 5}
+
+    def costs_fn():
+        return [{"agent": "alpha", "tokens": 100, "cost": 0.01}]
+
+    defaults = {
+        "bot_token": "xoxb-test",
+        "app_token": "xapp-test",
+        "dispatch_fn": dispatch_fn,
+        "default_agent": "alpha",
+        "list_agents_fn": list_agents_fn,
+        "status_fn": status_fn,
+        "costs_fn": costs_fn,
+    }
+    defaults.update(overrides)
+    ch = SlackChannel(**defaults)
+    if paired is not None:
+        ch._paired = paired
+    return ch
+
+
+def _make_say() -> AsyncMock:
+    return AsyncMock()
+
+
+# ── composite user key ──────────────────────────────────────────
+
+class TestCompositeUserKey:
+    def test_with_thread(self):
+        assert _get_user_key("U123", "1234.5678") == "U123:1234.5678"
+
+    def test_without_thread(self):
+        assert _get_user_key("U123", None) == "U123"
+
+    @pytest.mark.asyncio
+    async def test_independent_per_thread_agent_tracking(self):
+        """Different threads should maintain independent active agents."""
+        ch = _make_channel(paired={"owner": "U1", "allowed": []})
+        say = _make_say()
+
+        # Thread A: switch to beta
+        event_a = {"user": "U1", "text": "!use beta", "channel": "C1", "ts": "1.0", "thread_ts": "1.0"}
+        await ch._on_message(event_a, say)
+        await asyncio.sleep(0.05)  # let create_task complete
+        user_key_a = _get_user_key("U1", "1.0")
+        assert ch._get_active_agent(user_key_a) == "beta"
+
+        # Thread B: should still be on default (alpha)
+        user_key_b = _get_user_key("U1", "2.0")
+        assert ch._get_active_agent(user_key_b) == "alpha"
+
+
+# ── pairing flow ────────────────────────────────────────────────
+
+class TestPairing:
+    @pytest.mark.asyncio
+    async def test_pairing_with_correct_code(self):
+        ch = _make_channel(
+            paired={"owner": None, "allowed": [], "pairing_code": "abc123"},
+        )
+        say = _make_say()
+        event = {"user": "U1", "text": "!start abc123", "channel": "C1", "ts": "1.0"}
+        await ch._on_message(event, say)
+        assert ch._paired["owner"] == "U1"
+        say.assert_called()
+
+    @pytest.mark.asyncio
+    async def test_pairing_with_wrong_code(self):
+        ch = _make_channel(
+            paired={"owner": None, "allowed": [], "pairing_code": "abc123"},
+        )
+        say = _make_say()
+        event = {"user": "U1", "text": "!start wrongcode", "channel": "C1", "ts": "1.0"}
+        await ch._on_message(event, say)
+        assert ch._paired["owner"] is None
+        # Should inform about pairing requirement
+        say.assert_called()
+        msg = say.call_args[1]["text"]
+        assert "pairing" in msg.lower()
+
+    @pytest.mark.asyncio
+    async def test_unpaired_bot_rejects_regular_messages(self):
+        ch = _make_channel(
+            paired={"owner": None, "allowed": [], "pairing_code": "abc123"},
+        )
+        say = _make_say()
+        event = {"user": "U1", "text": "hello", "channel": "C1", "ts": "1.0"}
+        await ch._on_message(event, say)
+        assert ch._paired["owner"] is None
+        msg = say.call_args[1]["text"]
+        assert "pairing" in msg.lower()
+
+    @pytest.mark.asyncio
+    async def test_disallowed_user_rejected(self):
+        ch = _make_channel(paired={"owner": "U_OWNER", "allowed": []})
+        say = _make_say()
+        event = {"user": "U_OTHER", "text": "!start code", "channel": "C1", "ts": "1.0"}
+        await ch._on_message(event, say)
+        msg = say.call_args[1]["text"]
+        assert "denied" in msg.lower()
+
+    @pytest.mark.asyncio
+    async def test_disallowed_user_ignored_for_regular_messages(self):
+        ch = _make_channel(paired={"owner": "U_OWNER", "allowed": []})
+        say = _make_say()
+        event = {"user": "U_OTHER", "text": "hello", "channel": "C1", "ts": "1.0"}
+        await ch._on_message(event, say)
+        say.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_allowed_user_can_chat(self):
+        ch = _make_channel(paired={"owner": "U_OWNER", "allowed": ["U_FRIEND"]})
+        say = _make_say()
+        event = {"user": "U_FRIEND", "text": "hello", "channel": "C1", "ts": "1.0"}
+        await ch._on_message(event, say)
+        # Should dispatch (the response goes via create_task, but say is called)
+        await asyncio.sleep(0.05)
+        say.assert_called()
+
+    @pytest.mark.asyncio
+    async def test_owner_allow_command(self):
+        ch = _make_channel(paired={"owner": "U_OWNER", "allowed": []})
+        say = _make_say()
+        event = {"user": "U_OWNER", "text": "!allow U_FRIEND", "channel": "C1", "ts": "1.0"}
+        await ch._on_message(event, say)
+        assert "U_FRIEND" in ch._paired["allowed"]
+
+    @pytest.mark.asyncio
+    async def test_non_owner_allow_rejected(self):
+        ch = _make_channel(paired={"owner": "U_OWNER", "allowed": ["U_OTHER"]})
+        say = _make_say()
+        event = {"user": "U_OTHER", "text": "!allow U_SOMEONE", "channel": "C1", "ts": "1.0"}
+        await ch._on_message(event, say)
+        assert "U_SOMEONE" not in ch._paired.get("allowed", [])
+        msg = say.call_args[1]["text"]
+        assert "owner" in msg.lower()
+
+    @pytest.mark.asyncio
+    async def test_owner_revoke_command(self):
+        ch = _make_channel(paired={"owner": "U_OWNER", "allowed": ["U_FRIEND"]})
+        say = _make_say()
+        event = {"user": "U_OWNER", "text": "!revoke U_FRIEND", "channel": "C1", "ts": "1.0"}
+        await ch._on_message(event, say)
+        assert "U_FRIEND" not in ch._paired["allowed"]
+
+    @pytest.mark.asyncio
+    async def test_owner_paired_command(self):
+        ch = _make_channel(paired={"owner": "U_OWNER", "allowed": ["U_A"]})
+        say = _make_say()
+        event = {"user": "U_OWNER", "text": "!paired", "channel": "C1", "ts": "1.0"}
+        await ch._on_message(event, say)
+        msg = say.call_args[1]["text"]
+        assert "U_OWNER" in msg
+        assert "U_A" in msg
+
+
+# ── message routing ─────────────────────────────────────────────
+
+class TestMessageRouting:
+    @pytest.mark.asyncio
+    async def test_message_dispatches_to_handle_message(self):
+        """Regular messages should go through handle_message and get a response."""
+        ch = _make_channel(paired={"owner": "U1", "allowed": []})
+        say = _make_say()
+        event = {"user": "U1", "text": "hello world", "channel": "C1", "ts": "1.0"}
+        await ch._on_message(event, say)
+        await asyncio.sleep(0.05)
+        say.assert_called()
+        msg = say.call_args[1]["text"]
+        assert "[alpha]" in msg
+
+    @pytest.mark.asyncio
+    async def test_bot_messages_ignored(self):
+        ch = _make_channel(paired={"owner": "U1", "allowed": []})
+        say = _make_say()
+        event = {"user": "U1", "text": "hello", "channel": "C1", "ts": "1.0", "bot_id": "B123"}
+        await ch._on_message(event, say)
+        say.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_subtype_messages_ignored(self):
+        ch = _make_channel(paired={"owner": "U1", "allowed": []})
+        say = _make_say()
+        event = {"user": "U1", "text": "hello", "channel": "C1", "ts": "1.0", "subtype": "channel_join"}
+        await ch._on_message(event, say)
+        say.assert_not_called()
+
+
+# ── command translation ─────────────────────────────────────────
+
+class TestCommandTranslation:
+    @pytest.mark.asyncio
+    async def test_exclamation_translated_to_slash(self):
+        """! commands should be translated to / for base class handling."""
+        ch = _make_channel(paired={"owner": "U1", "allowed": []})
+        say = _make_say()
+        event = {"user": "U1", "text": "!agents", "channel": "C1", "ts": "1.0"}
+        await ch._on_message(event, say)
+        await asyncio.sleep(0.05)
+        say.assert_called()
+        msg = say.call_args[1]["text"]
+        assert "alpha" in msg
+        assert "beta" in msg
+
+
+# ── workspace filtering (thread_ts) ─────────────────────────────
+
+class TestThreadRouting:
+    @pytest.mark.asyncio
+    async def test_thread_ts_used_as_key(self):
+        ch = _make_channel(paired={"owner": "U1", "allowed": []})
+        say = _make_say()
+        # Message in a thread
+        event = {
+            "user": "U1", "text": "!use beta",
+            "channel": "C1", "ts": "2.0", "thread_ts": "1.0",
+        }
+        await ch._on_message(event, say)
+        await asyncio.sleep(0.05)
+
+        # thread_ts=1.0 should be the key
+        key = _get_user_key("U1", "1.0")
+        assert ch._get_active_agent(key) == "beta"
+
+        # A different thread keeps default
+        key2 = _get_user_key("U1", "3.0")
+        assert ch._get_active_agent(key2) == "alpha"
+
+
+# ── send_notification ────────────────────────────────────────────
+
+class TestSendNotification:
+    @pytest.mark.asyncio
+    async def test_notification_calls_chat_post_message(self):
+        ch = _make_channel(paired={"owner": "U1", "allowed": []})
+        ch._channel_ids = {"C1", "C2"}
+        mock_client = MagicMock()
+        mock_client.chat_postMessage = AsyncMock()
+        ch._bolt_app = MagicMock()
+        ch._bolt_app.client = mock_client
+
+        await ch.send_notification("test notification")
+        assert mock_client.chat_postMessage.call_count == 2
+
+    @pytest.mark.asyncio
+    async def test_notification_no_channels_is_noop(self):
+        ch = _make_channel(paired={"owner": "U1", "allowed": []})
+        ch._channel_ids = set()
+        ch._bolt_app = MagicMock()
+        await ch.send_notification("test")
+        # No calls should be made
+
+    @pytest.mark.asyncio
+    async def test_notification_no_app_is_noop(self):
+        ch = _make_channel(paired={"owner": "U1", "allowed": []})
+        ch._bolt_app = None
+        await ch.send_notification("test")


### PR DESCRIPTION
## Summary
- New `SlackChannel` adapter using `slack-bolt` AsyncApp + Socket Mode (no public URL needed)
- Thread-aware routing via composite user key (`user_id:thread_ts`) for independent per-thread agent tracking
- Pairing, access control (`!allow`/`!revoke`/`!paired`), and `!`-to-`/` command translation following existing Discord/Telegram patterns
- CLI integration: `openlegion channels add slack` prompts for both bot token and app-level token
- 21 unit tests covering composite keys, pairing flow, message routing, command translation, and notifications

## Test plan
- [x] All 21 new Slack tests pass
- [x] Full test suite (558 tests) passes with no regressions
- [ ] Manual: configure Slack app with Socket Mode, pair via `!start <code>`, verify multi-thread routing