### PR TITLE
Add WhatsApp channel adapter with Cloud API webhooks (Roadmap 2.3)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,7 @@ config/workflows/
 config/telegram_paired.json
 config/discord_paired.json
 config/slack_paired.json
+config/whatsapp_paired.json
 PROJECT.md
 SOUL.md
 ROADMAP.md

--- a/src/channels/whatsapp.py
+++ b/src/channels/whatsapp.py
@@ -1,0 +1,324 @@
+"""WhatsApp channel adapter.
+
+Bridges WhatsApp Business API (Cloud API) to the OpenLegion mesh with the
+same UX as the CLI REPL:
+  - Per-user active agent tracking (phone number as user key)
+  - @agent mentions for routing to specific agents
+  - /use, /agents, /status, /broadcast, /costs, /reset, /help commands
+  - Agent name labels on all responses: [agent_name] response
+  - Push notifications for cron/heartbeat results
+  - Pairing: owner must send !start <pairing_code> to claim the bot.
+    Code is generated during `openlegion setup`. Others need !allow.
+
+Uses httpx (already a core dependency) to call the Cloud API.
+Webhook-based: mounts GET/POST endpoints on the mesh FastAPI app.
+Config: WHATSAPP_ACCESS_TOKEN, WHATSAPP_PHONE_NUMBER_ID in .env,
+        channels.whatsapp in mesh.yaml.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from pathlib import Path
+
+import httpx
+from fastapi import APIRouter, Query, Request
+
+from src.channels.base import (
+    AddKeyFn,
+    Channel,
+    CostsFn,
+    DispatchFn,
+    ListAgentsFn,
+    ResetFn,
+    StatusFn,
+    StreamDispatchFn,
+    chunk_text,
+)
+from src.shared.utils import setup_logging
+
+logger = setup_logging("channels.whatsapp")
+
+MAX_WA_LEN = 4096
+_PAIRING_FILE = Path("config/whatsapp_paired.json")
+_GRAPH_API_BASE = "https://graph.facebook.com/v21.0"
+
+
+def _load_paired() -> dict:
+    """Load paired users from disk."""
+    if _PAIRING_FILE.exists():
+        try:
+            return json.loads(_PAIRING_FILE.read_text())
+        except Exception:
+            pass
+    return {"owner": None, "allowed": []}
+
+
+def _save_paired(data: dict) -> None:
+    _PAIRING_FILE.parent.mkdir(parents=True, exist_ok=True)
+    _PAIRING_FILE.write_text(json.dumps(data, indent=2) + "\n")
+
+
+class WhatsAppChannel(Channel):
+    """WhatsApp Cloud API adapter for OpenLegion with webhook-based messaging."""
+
+    def __init__(
+        self,
+        access_token: str,
+        phone_number_id: str,
+        verify_token: str,
+        dispatch_fn: DispatchFn,
+        default_agent: str = "",
+        list_agents_fn: ListAgentsFn | None = None,
+        status_fn: StatusFn | None = None,
+        costs_fn: CostsFn | None = None,
+        reset_fn: ResetFn | None = None,
+        stream_dispatch_fn: StreamDispatchFn | None = None,
+        addkey_fn: AddKeyFn | None = None,
+    ):
+        super().__init__(
+            dispatch_fn=dispatch_fn,
+            default_agent=default_agent,
+            list_agents_fn=list_agents_fn,
+            status_fn=status_fn,
+            costs_fn=costs_fn,
+            reset_fn=reset_fn,
+            stream_dispatch_fn=stream_dispatch_fn,
+            addkey_fn=addkey_fn,
+        )
+        self.access_token = access_token
+        self.phone_number_id = phone_number_id
+        self.verify_token = verify_token
+        self._http: httpx.AsyncClient | None = None
+        self._phone_numbers: set[str] = set()
+        self._paired = _load_paired()
+
+    async def start(self) -> None:
+        self._http = httpx.AsyncClient(
+            base_url=_GRAPH_API_BASE,
+            headers={"Authorization": f"Bearer {self.access_token}"},
+            timeout=30,
+        )
+        owner = self._paired.get("owner")
+        if owner:
+            logger.info(f"WhatsApp channel started (owner: {owner})")
+        elif self._paired.get("pairing_code"):
+            logger.info("WhatsApp channel started (awaiting pairing code)")
+        else:
+            logger.info("WhatsApp channel started (no pairing code -- run setup again)")
+
+    async def stop(self) -> None:
+        if self._http:
+            await self._http.aclose()
+            self._http = None
+            logger.info("WhatsApp channel stopped")
+
+    async def send_notification(self, text: str) -> None:
+        """Push a cron/heartbeat notification to all known phone numbers."""
+        if not self._http or not self._phone_numbers:
+            return
+        for phone in self._phone_numbers:
+            try:
+                for part in chunk_text(text, MAX_WA_LEN):
+                    await self._send_text(phone, part)
+            except Exception as e:
+                logger.warning(f"Failed to notify {phone}: {e}")
+
+    async def _send_text(self, to: str, text: str) -> None:
+        """Send a text message via the WhatsApp Cloud API."""
+        if not self._http:
+            return
+        await self._http.post(
+            f"/{self.phone_number_id}/messages",
+            json={
+                "messaging_product": "whatsapp",
+                "to": to,
+                "type": "text",
+                "text": {"body": text},
+            },
+        )
+
+    def _is_allowed(self, phone: str) -> bool:
+        owner = self._paired.get("owner")
+        if owner is None:
+            return False
+        if phone == owner:
+            return True
+        return phone in self._paired.get("allowed", [])
+
+    def _is_owner(self, phone: str) -> bool:
+        return phone == self._paired.get("owner")
+
+    def create_router(self) -> APIRouter:
+        """Create a FastAPI router for WhatsApp webhook endpoints."""
+        router = APIRouter(prefix="/channels/whatsapp")
+        channel_ref = self
+
+        @router.get("/webhook")
+        async def verify_webhook(
+            hub_mode: str = Query(None, alias="hub.mode"),
+            hub_verify_token: str = Query(None, alias="hub.verify_token"),
+            hub_challenge: str = Query(None, alias="hub.challenge"),
+        ) -> int | str:
+            """Verification challenge from Meta."""
+            if hub_mode == "subscribe" and hub_verify_token == channel_ref.verify_token:
+                logger.info("WhatsApp webhook verified")
+                return int(hub_challenge) if hub_challenge else ""
+            logger.warning("WhatsApp webhook verification failed")
+            return "Verification failed"
+
+        @router.post("/webhook")
+        async def receive_webhook(request: Request) -> dict:
+            """Receive incoming WhatsApp messages."""
+            try:
+                body = await request.json()
+            except Exception:
+                return {"status": "ok"}
+
+            # Extract messages from the webhook payload
+            for entry in body.get("entry", []):
+                for change in entry.get("changes", []):
+                    value = change.get("value", {})
+                    for message in value.get("messages", []):
+                        asyncio.create_task(
+                            channel_ref._process_message(message)
+                        )
+
+            # Return 200 immediately (Cloud API retries if >5s)
+            return {"status": "ok"}
+
+        return router
+
+    async def _process_message(self, message: dict) -> None:
+        """Process a single incoming WhatsApp message."""
+        msg_type = message.get("type", "")
+        phone = message.get("from", "")
+
+        if not phone:
+            return
+
+        # Text-only initially -- log and skip media
+        if msg_type != "text":
+            logger.info(f"Skipping non-text message type '{msg_type}' from {phone}")
+            return
+
+        text = (message.get("text", {}).get("body") or "").strip()
+        if not text:
+            return
+
+        # Pairing: !start <code>
+        if self._paired.get("owner") is None:
+            if text.lower().startswith("!start") or text.lower().startswith("/start"):
+                parts = text.split(None, 1)
+                code_arg = parts[1].strip() if len(parts) > 1 else ""
+                expected = self._paired.get("pairing_code", "")
+                if not expected or code_arg != expected:
+                    await self._send_text(
+                        phone,
+                        "Pairing required. Send:  !start <pairing_code>\n"
+                        "The code was shown during `openlegion setup`.",
+                    )
+                    logger.warning(
+                        f"Rejected !start without valid pairing code from {phone}"
+                    )
+                    return
+                self._paired["owner"] = phone
+                self._paired.setdefault("allowed", [])
+                self._paired.pop("pairing_code", None)
+                _save_paired(self._paired)
+                logger.info(f"Paired owner via code: {phone}")
+                self._phone_numbers.add(phone)
+                await self._send_text(
+                    phone,
+                    f"Paired as owner. Your phone: {phone}\n"
+                    f"Only you can use this bot. Send !allow <phone> to grant access.",
+                )
+                return
+            else:
+                await self._send_text(
+                    phone,
+                    "This bot requires pairing. Send !start <pairing_code> to begin.",
+                )
+                return
+
+        if not self._is_allowed(phone):
+            if text.lower().startswith("!start") or text.lower().startswith("/start"):
+                await self._send_text(
+                    phone,
+                    f"Access denied. This bot is paired to its owner.\n"
+                    f"Your phone: {phone}\n"
+                    f"Ask the owner to send !allow {phone} to grant you access.",
+                )
+            return
+
+        # Owner-only commands
+        if text.startswith("!allow ") or text.startswith("/allow "):
+            if not self._is_owner(phone):
+                await self._send_text(phone, "Only the owner can use !allow.")
+                return
+            parts = text.split(None, 1)
+            if len(parts) < 2 or not parts[1].strip():
+                await self._send_text(phone, "Usage: !allow <phone_number>")
+                return
+            target = parts[1].strip()
+            allowed = self._paired.setdefault("allowed", [])
+            if target not in allowed:
+                allowed.append(target)
+                _save_paired(self._paired)
+            await self._send_text(phone, f"User {target} is now allowed.")
+            logger.info(f"Owner allowed user {target}")
+            return
+
+        if text.startswith("!revoke ") or text.startswith("/revoke "):
+            if not self._is_owner(phone):
+                await self._send_text(phone, "Only the owner can use !revoke.")
+                return
+            parts = text.split(None, 1)
+            if len(parts) < 2 or not parts[1].strip():
+                await self._send_text(phone, "Usage: !revoke <phone_number>")
+                return
+            target = parts[1].strip()
+            allowed = self._paired.get("allowed", [])
+            if target in allowed:
+                allowed.remove(target)
+                _save_paired(self._paired)
+                await self._send_text(phone, f"User {target} access revoked.")
+            else:
+                await self._send_text(
+                    phone, f"User {target} was not in the allowed list."
+                )
+            return
+
+        if text.lower() in ("!paired", "/paired"):
+            if not self._is_owner(phone):
+                await self._send_text(phone, "Only the owner can view pairing info.")
+                return
+            owner = self._paired.get("owner")
+            allowed = self._paired.get("allowed", [])
+            lines = [f"Owner: {owner}"]
+            if allowed:
+                lines.append(f"Allowed users: {', '.join(allowed)}")
+            else:
+                lines.append("No additional users allowed.")
+            await self._send_text(phone, "\n".join(lines))
+            return
+
+        self._phone_numbers.add(phone)
+
+        # Translate ! commands to / for base class handling
+        if text.startswith("!"):
+            text = "/" + text[1:]
+
+        try:
+            response = await self.handle_message(phone, text)
+        except Exception as e:
+            logger.error(f"Dispatch failed for {phone}: {e}")
+            response = f"Error: {e}"
+
+        if response:
+            for part in chunk_text(response, MAX_WA_LEN):
+                try:
+                    await self._send_text(phone, part)
+                except Exception as e:
+                    logger.warning(f"Failed to send response to {phone}: {e}")

--- a/tests/test_whatsapp.py
+++ b/tests/test_whatsapp.py
@@ -1,0 +1,336 @@
+"""Tests for WhatsApp channel adapter.
+
+Verifies webhook verification, incoming message processing, pairing flow,
+send_text with mocked httpx, and non-text message skipping.
+Uses FastAPI TestClient for webhook endpoint tests.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from src.channels.whatsapp import WhatsAppChannel
+
+
+# ── helpers ──────────────────────────────────────────────────────
+
+def _make_channel(
+    paired: dict | None = None,
+    agents: list[str] | None = None,
+    **overrides,
+) -> WhatsAppChannel:
+    agents = agents or ["alpha", "beta"]
+
+    async def dispatch_fn(agent: str, message: str) -> str:
+        return f"reply from {agent}"
+
+    def list_agents_fn():
+        return {a: {} for a in agents}
+
+    def status_fn(name: str):
+        return {"state": "running", "tasks_completed": 5}
+
+    def costs_fn():
+        return [{"agent": "alpha", "tokens": 100, "cost": 0.01}]
+
+    defaults = {
+        "access_token": "test-token",
+        "phone_number_id": "123456",
+        "verify_token": "my-verify-token",
+        "dispatch_fn": dispatch_fn,
+        "default_agent": "alpha",
+        "list_agents_fn": list_agents_fn,
+        "status_fn": status_fn,
+        "costs_fn": costs_fn,
+    }
+    defaults.update(overrides)
+    ch = WhatsAppChannel(**defaults)
+    if paired is not None:
+        ch._paired = paired
+    return ch
+
+
+def _make_app(channel: WhatsAppChannel) -> FastAPI:
+    """Create a test FastAPI app with the WhatsApp webhook router."""
+    app = FastAPI()
+    app.include_router(channel.create_router())
+    return app
+
+
+def _webhook_payload(from_phone: str, text: str) -> dict:
+    """Create a standard WhatsApp webhook payload for a text message."""
+    return {
+        "entry": [{
+            "changes": [{
+                "value": {
+                    "messages": [{
+                        "from": from_phone,
+                        "type": "text",
+                        "text": {"body": text},
+                    }],
+                },
+            }],
+        }],
+    }
+
+
+# ── webhook verification ────────────────────────────────────────
+
+class TestWebhookVerification:
+    def test_correct_token_returns_challenge(self):
+        ch = _make_channel()
+        app = _make_app(ch)
+        client = TestClient(app)
+        resp = client.get(
+            "/channels/whatsapp/webhook",
+            params={
+                "hub.mode": "subscribe",
+                "hub.verify_token": "my-verify-token",
+                "hub.challenge": "12345",
+            },
+        )
+        assert resp.status_code == 200
+        assert resp.json() == 12345
+
+    def test_wrong_token_fails(self):
+        ch = _make_channel()
+        app = _make_app(ch)
+        client = TestClient(app)
+        resp = client.get(
+            "/channels/whatsapp/webhook",
+            params={
+                "hub.mode": "subscribe",
+                "hub.verify_token": "wrong-token",
+                "hub.challenge": "12345",
+            },
+        )
+        assert resp.status_code == 200
+        assert resp.json() == "Verification failed"
+
+    def test_missing_mode_fails(self):
+        ch = _make_channel()
+        app = _make_app(ch)
+        client = TestClient(app)
+        resp = client.get(
+            "/channels/whatsapp/webhook",
+            params={"hub.verify_token": "my-verify-token", "hub.challenge": "12345"},
+        )
+        assert resp.json() == "Verification failed"
+
+
+# ── incoming message processing ──────────────────────────────────
+
+class TestIncomingMessages:
+    @pytest.mark.asyncio
+    async def test_process_text_message(self):
+        ch = _make_channel(paired={"owner": "+1234", "allowed": []})
+        ch._http = AsyncMock()
+        ch._http.post = AsyncMock()
+
+        msg = {"from": "+1234", "type": "text", "text": {"body": "hello"}}
+        await ch._process_message(msg)
+
+        ch._http.post.assert_called()
+        # Check the response includes the agent label
+        call_args = ch._http.post.call_args
+        body = call_args[1]["json"]["text"]["body"]
+        assert "[alpha]" in body
+
+    @pytest.mark.asyncio
+    async def test_non_text_message_skipped(self):
+        ch = _make_channel(paired={"owner": "+1234", "allowed": []})
+        ch._http = AsyncMock()
+        ch._http.post = AsyncMock()
+
+        msg = {"from": "+1234", "type": "image", "image": {"id": "img123"}}
+        await ch._process_message(msg)
+
+        ch._http.post.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_empty_text_skipped(self):
+        ch = _make_channel(paired={"owner": "+1234", "allowed": []})
+        ch._http = AsyncMock()
+        ch._http.post = AsyncMock()
+
+        msg = {"from": "+1234", "type": "text", "text": {"body": "   "}}
+        await ch._process_message(msg)
+
+        ch._http.post.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_missing_from_skipped(self):
+        ch = _make_channel(paired={"owner": "+1234", "allowed": []})
+        ch._http = AsyncMock()
+        ch._http.post = AsyncMock()
+
+        msg = {"type": "text", "text": {"body": "hello"}}
+        await ch._process_message(msg)
+
+        ch._http.post.assert_not_called()
+
+
+# ── webhook POST endpoint ───────────────────────────────────────
+
+class TestWebhookPost:
+    def test_webhook_post_returns_ok(self):
+        ch = _make_channel(paired={"owner": "+1234", "allowed": []})
+        app = _make_app(ch)
+        client = TestClient(app)
+        payload = _webhook_payload("+1234", "hello")
+        resp = client.post("/channels/whatsapp/webhook", json=payload)
+        assert resp.status_code == 200
+        assert resp.json()["status"] == "ok"
+
+    def test_webhook_post_empty_body_ok(self):
+        ch = _make_channel(paired={"owner": "+1234", "allowed": []})
+        app = _make_app(ch)
+        client = TestClient(app)
+        resp = client.post(
+            "/channels/whatsapp/webhook",
+            content=b"not json",
+            headers={"content-type": "application/json"},
+        )
+        assert resp.status_code == 200
+
+
+# ── pairing flow ────────────────────────────────────────────────
+
+class TestPairing:
+    @pytest.mark.asyncio
+    async def test_pairing_with_correct_code(self):
+        ch = _make_channel(
+            paired={"owner": None, "allowed": [], "pairing_code": "abc123"},
+        )
+        ch._http = AsyncMock()
+        ch._http.post = AsyncMock()
+
+        msg = {"from": "+1234", "type": "text", "text": {"body": "!start abc123"}}
+        await ch._process_message(msg)
+        assert ch._paired["owner"] == "+1234"
+
+    @pytest.mark.asyncio
+    async def test_pairing_with_wrong_code(self):
+        ch = _make_channel(
+            paired={"owner": None, "allowed": [], "pairing_code": "abc123"},
+        )
+        ch._http = AsyncMock()
+        ch._http.post = AsyncMock()
+
+        msg = {"from": "+1234", "type": "text", "text": {"body": "!start wrong"}}
+        await ch._process_message(msg)
+        assert ch._paired["owner"] is None
+
+    @pytest.mark.asyncio
+    async def test_disallowed_user_rejected(self):
+        ch = _make_channel(paired={"owner": "+0000", "allowed": []})
+        ch._http = AsyncMock()
+        ch._http.post = AsyncMock()
+
+        msg = {"from": "+9999", "type": "text", "text": {"body": "!start code"}}
+        await ch._process_message(msg)
+        body = ch._http.post.call_args[1]["json"]["text"]["body"]
+        assert "denied" in body.lower()
+
+    @pytest.mark.asyncio
+    async def test_allowed_user_can_chat(self):
+        ch = _make_channel(paired={"owner": "+0000", "allowed": ["+1111"]})
+        ch._http = AsyncMock()
+        ch._http.post = AsyncMock()
+
+        msg = {"from": "+1111", "type": "text", "text": {"body": "hello"}}
+        await ch._process_message(msg)
+        body = ch._http.post.call_args[1]["json"]["text"]["body"]
+        assert "[alpha]" in body
+
+    @pytest.mark.asyncio
+    async def test_owner_allow_command(self):
+        ch = _make_channel(paired={"owner": "+0000", "allowed": []})
+        ch._http = AsyncMock()
+        ch._http.post = AsyncMock()
+
+        msg = {"from": "+0000", "type": "text", "text": {"body": "!allow +1111"}}
+        await ch._process_message(msg)
+        assert "+1111" in ch._paired["allowed"]
+
+    @pytest.mark.asyncio
+    async def test_owner_revoke_command(self):
+        ch = _make_channel(paired={"owner": "+0000", "allowed": ["+1111"]})
+        ch._http = AsyncMock()
+        ch._http.post = AsyncMock()
+
+        msg = {"from": "+0000", "type": "text", "text": {"body": "!revoke +1111"}}
+        await ch._process_message(msg)
+        assert "+1111" not in ch._paired["allowed"]
+
+
+# ── _send_text ──────────────────────────────────────────────────
+
+class TestSendText:
+    @pytest.mark.asyncio
+    async def test_send_text_calls_api(self):
+        ch = _make_channel()
+        ch._http = AsyncMock()
+        ch._http.post = AsyncMock()
+
+        await ch._send_text("+1234", "hello")
+        ch._http.post.assert_called_once()
+        call_args = ch._http.post.call_args
+        assert call_args[0][0] == "/123456/messages"
+        payload = call_args[1]["json"]
+        assert payload["messaging_product"] == "whatsapp"
+        assert payload["to"] == "+1234"
+        assert payload["text"]["body"] == "hello"
+
+    @pytest.mark.asyncio
+    async def test_send_text_no_client_is_noop(self):
+        ch = _make_channel()
+        ch._http = None
+        await ch._send_text("+1234", "hello")  # should not raise
+
+
+# ── send_notification ────────────────────────────────────────────
+
+class TestSendNotification:
+    @pytest.mark.asyncio
+    async def test_notification_sends_to_all_phones(self):
+        ch = _make_channel()
+        ch._phone_numbers = {"+1111", "+2222"}
+        ch._http = AsyncMock()
+        ch._http.post = AsyncMock()
+
+        await ch.send_notification("test notification")
+        assert ch._http.post.call_count == 2
+
+    @pytest.mark.asyncio
+    async def test_notification_no_phones_is_noop(self):
+        ch = _make_channel()
+        ch._phone_numbers = set()
+        ch._http = AsyncMock()
+        await ch.send_notification("test")
+
+    @pytest.mark.asyncio
+    async def test_notification_no_client_is_noop(self):
+        ch = _make_channel()
+        ch._http = None
+        await ch.send_notification("test")
+
+
+# ── command translation ─────────────────────────────────────────
+
+class TestCommandTranslation:
+    @pytest.mark.asyncio
+    async def test_exclamation_commands_translated(self):
+        ch = _make_channel(paired={"owner": "+1234", "allowed": []})
+        ch._http = AsyncMock()
+        ch._http.post = AsyncMock()
+
+        msg = {"from": "+1234", "type": "text", "text": {"body": "!agents"}}
+        await ch._process_message(msg)
+        body = ch._http.post.call_args[1]["json"]["text"]["body"]
+        assert "alpha" in body
+        assert "beta" in body


### PR DESCRIPTION
## Summary
- New `WhatsAppChannel` adapter using httpx to call WhatsApp Cloud API (no new dependency)
- Webhook-based: mounts `GET`/`POST` endpoints on the mesh FastAPI app for Meta verification challenge and incoming message processing
- Text-only initially; media message types (image, voice, etc.) are logged and skipped
- Pairing, access control, and `!`-to-`/` command translation following existing channel patterns
- CLI integration: `openlegion channels add whatsapp` prompts for access token and phone number ID
- `_start_channels` now returns `(pairing_instructions, webhook_routers)` tuple for app mounting

**Depends on:** #23 (Slack channel)

## Test plan
- [x] All 21 new WhatsApp tests pass (webhook verification, message processing, pairing, send_text, non-text skip)
- [x] Full test suite (579 tests) passes with no regressions
- [ ] Manual: configure WhatsApp Business API, set up webhook URL, pair via `!start <code>`, verify text messaging