### PR TITLE
Add message queue modes: steer, collect, followup (Roadmap 2.4)

### DIFF
--- a/src/agent/server.py
+++ b/src/agent/server.py
@@ -18,7 +18,7 @@ import json as json_module
 from fastapi import FastAPI, HTTPException
 from fastapi.responses import StreamingResponse
 
-from src.shared.types import AgentMessage, AgentStatus, ChatMessage, ChatResponse, TaskAssignment, TaskResult
+from src.shared.types import AgentMessage, AgentStatus, ChatMessage, ChatResponse, SteerMessage, TaskAssignment, TaskResult
 from src.shared.utils import setup_logging
 
 if TYPE_CHECKING:
@@ -98,6 +98,12 @@ def create_agent_app(loop: AgentLoop) -> FastAPI:
         """Interactive chat with the agent. Supports tool use."""
         result = await loop.chat(msg.message)
         return ChatResponse(**result)
+
+    @app.post("/chat/steer")
+    async def chat_steer(msg: SteerMessage) -> dict:
+        """Inject a message into the active conversation. Does NOT acquire _chat_lock."""
+        injected = await loop.inject_steer(msg.message)
+        return {"injected": injected, "agent_state": loop.state}
 
     @app.post("/chat/stream")
     async def chat_stream(msg: ChatMessage) -> StreamingResponse:

--- a/src/host/lanes.py
+++ b/src/host/lanes.py
@@ -1,11 +1,14 @@
-"""Per-agent lane queues for serial task execution.
+"""Per-agent lane queues with message queue modes.
 
 Each agent gets its own FIFO queue. Tasks within a lane execute serially
 (one at a time per agent), but lanes run in parallel (different agents
 can work simultaneously).
 
-When the orchestrator or cron dispatches to a busy agent, the request
-is queued rather than rejected. The lane drains automatically.
+Three queue modes control how incoming messages interact with busy agents:
+
+- **followup** (default): FIFO — queue, process after current task.
+- **steer**: Inject into active conversation between tool rounds.
+- **collect**: Batch queued messages into a single dispatch when agent becomes free.
 """
 
 from __future__ import annotations
@@ -19,46 +22,143 @@ from src.shared.utils import generate_id, setup_logging
 
 logger = setup_logging("host.lanes")
 
+SILENT_REPLY_TOKEN = "__SILENT__"
+
 
 @dataclass
 class QueuedTask:
     id: str
     agent: str
     message: str
+    mode: str = "followup"
     future: asyncio.Future = field(default_factory=asyncio.Future)
 
 
 class LaneManager:
-    """Manages per-agent FIFO queues with serial execution."""
+    """Manages per-agent FIFO queues with serial execution and queue modes."""
 
-    def __init__(self, dispatch_fn: Callable[..., Coroutine[Any, Any, str]]):
+    def __init__(
+        self,
+        dispatch_fn: Callable[..., Coroutine[Any, Any, str]],
+        steer_fn: Callable[..., Coroutine[Any, Any, Any]] | None = None,
+    ):
         self._dispatch_fn = dispatch_fn
+        self._steer_fn = steer_fn
         self._queues: dict[str, asyncio.Queue[QueuedTask]] = {}
         self._workers: dict[str, asyncio.Task] = {}
         self._pending: dict[str, list[QueuedTask]] = {}
+        self._collect_buffers: dict[str, list[str]] = {}
+        self._busy: dict[str, bool] = {}
 
-    async def enqueue(self, agent: str, message: str) -> str:
-        """Queue a message for an agent. Returns the response when done."""
+    def _ensure_lane(self, agent: str) -> None:
+        """Lazily create queue, worker, and tracking structures for an agent."""
         if agent not in self._queues:
             self._queues[agent] = asyncio.Queue()
             self._pending[agent] = []
+            self._busy[agent] = False
+            self._collect_buffers[agent] = []
             self._workers[agent] = asyncio.create_task(self._worker(agent))
 
+    async def enqueue(self, agent: str, message: str, *, mode: str = "followup") -> str:
+        """Queue a message for an agent with the specified mode.
+
+        Modes:
+          followup — default FIFO, process after current task.
+          steer    — inject into active conversation between tool rounds.
+          collect  — batch when busy, dispatch combined when agent becomes free.
+        """
+        self._ensure_lane(agent)
+
+        if mode == "steer":
+            return await self._handle_steer(agent, message)
+        elif mode == "collect":
+            return await self._handle_collect(agent, message)
+        else:
+            return await self._handle_followup(agent, message)
+
+    async def _handle_followup(self, agent: str, message: str) -> str:
+        """Standard FIFO enqueue."""
         task = QueuedTask(
             id=generate_id("lane"),
             agent=agent,
             message=message,
+            mode="followup",
         )
         self._pending[agent].append(task)
         await self._queues[agent].put(task)
         logger.debug(f"Queued task {task.id} for agent '{agent}' (depth: {self._queues[agent].qsize()})")
         return await task.future
 
+    async def _handle_steer(self, agent: str, message: str) -> str:
+        """Inject a steer message into the agent's active conversation.
+
+        If a steer_fn is available, calls it directly (bypasses queue).
+        Falls back to followup if no steer_fn is configured.
+        """
+        if self._steer_fn is None:
+            logger.debug(f"No steer_fn configured, falling back to followup for '{agent}'")
+            return await self._handle_followup(agent, message)
+
+        try:
+            result = await self._steer_fn(agent, message)
+            injected = result.get("injected", False) if isinstance(result, dict) else False
+            if injected:
+                return f"Steered: message injected into {agent}'s active conversation"
+            else:
+                return f"Steered: message queued for {agent} (agent is idle, will see it next turn)"
+        except Exception as e:
+            logger.warning(f"Steer to '{agent}' failed, falling back to followup: {e}")
+            return await self._handle_followup(agent, message)
+
+    async def _handle_collect(self, agent: str, message: str) -> str:
+        """Batch messages when agent is busy, dispatch immediately when idle."""
+        if not self._busy.get(agent, False):
+            # Agent is idle — dispatch immediately
+            return await self._handle_followup(agent, message)
+
+        # Agent is busy — buffer the message
+        self._collect_buffers[agent].append(message)
+        logger.debug(
+            f"Collected message for '{agent}' "
+            f"(buffer size: {len(self._collect_buffers[agent])})"
+        )
+        return SILENT_REPLY_TOKEN
+
+    def _flush_collect_buffer(self, agent: str) -> None:
+        """Drain the collect buffer and enqueue a combined message as followup."""
+        buffer = self._collect_buffers.get(agent, [])
+        if not buffer:
+            return
+
+        messages = list(buffer)
+        buffer.clear()
+
+        if len(messages) == 1:
+            combined = messages[0]
+        else:
+            parts = [f"[Message {i + 1}]: {msg}" for i, msg in enumerate(messages)]
+            combined = "\n\n".join(parts)
+
+        task = QueuedTask(
+            id=generate_id("lane"),
+            agent=agent,
+            message=combined,
+            mode="followup",
+        )
+        # Suppress "Future exception was never retrieved" — no caller awaits this.
+        task.future.add_done_callback(lambda f: f.exception() if not f.cancelled() else None)
+        self._pending[agent].append(task)
+        self._queues[agent].put_nowait(task)
+        logger.debug(
+            f"Flushed {len(messages)} collected message(s) as task {task.id} for '{agent}'"
+        )
+
     async def _worker(self, agent: str) -> None:
         """Worker loop: drains the queue for a single agent serially."""
         queue = self._queues[agent]
         while True:
             task = await queue.get()
+            self._busy[agent] = True
             try:
                 result = await self._dispatch_fn(agent, task.message)
                 task.future.set_result(result)
@@ -67,17 +167,21 @@ class LaneManager:
                     task.future.set_exception(e)
                 logger.error(f"Lane task {task.id} for '{agent}' failed: {e}")
             finally:
+                self._busy[agent] = False
                 if agent in self._pending and task in self._pending[agent]:
                     self._pending[agent].remove(task)
                 queue.task_done()
+                self._flush_collect_buffer(agent)
 
     def get_status(self) -> dict[str, dict]:
-        """Return queue depth and pending task count per agent."""
+        """Return queue depth, pending task count, collected count, and busy flag per agent."""
         result = {}
         for agent, queue in self._queues.items():
             result[agent] = {
                 "queued": queue.qsize(),
                 "pending": len(self._pending.get(agent, [])),
+                "collected": len(self._collect_buffers.get(agent, [])),
+                "busy": self._busy.get(agent, False),
             }
         return result
 

--- a/src/shared/types.py
+++ b/src/shared/types.py
@@ -252,3 +252,9 @@ class ChatResponse(BaseModel):
     response: str
     tool_outputs: list[dict[str, Any]] = []
     tokens_used: int = 0
+
+
+class SteerMessage(BaseModel):
+    """Injected into an agent's active conversation mid-execution."""
+
+    message: str

--- a/tests/test_lanes.py
+++ b/tests/test_lanes.py
@@ -1,0 +1,244 @@
+"""Tests for per-agent lane queues and message queue modes.
+
+Covers:
+- Followup: basic dispatch, serial per agent, parallel across agents
+- Steer: calls steer_fn, falls back to followup, steer to idle agent
+- Collect: single idle dispatch, batching when busy, SILENT_REPLY_TOKEN
+- Status: includes collected count and busy flag
+- Stop: cancels workers cleanly
+"""
+
+import asyncio
+from unittest.mock import AsyncMock
+
+import pytest
+
+from src.host.lanes import SILENT_REPLY_TOKEN, LaneManager
+
+
+# ── Followup mode ────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_followup_basic_dispatch():
+    """Basic dispatch returns response."""
+    dispatch = AsyncMock(return_value="hello")
+    lm = LaneManager(dispatch_fn=dispatch)
+
+    result = await lm.enqueue("agent1", "hi")
+    assert result == "hello"
+    dispatch.assert_awaited_once_with("agent1", "hi")
+
+
+@pytest.mark.asyncio
+async def test_followup_serial_per_agent():
+    """Tasks for the same agent execute serially."""
+    call_order = []
+
+    async def slow_dispatch(agent: str, message: str) -> str:
+        call_order.append(message)
+        await asyncio.sleep(0.05)
+        return f"done:{message}"
+
+    lm = LaneManager(dispatch_fn=slow_dispatch)
+
+    r1, r2 = await asyncio.gather(
+        lm.enqueue("agent1", "first"),
+        lm.enqueue("agent1", "second"),
+    )
+    assert r1 == "done:first"
+    assert r2 == "done:second"
+    assert call_order == ["first", "second"]
+
+
+@pytest.mark.asyncio
+async def test_followup_parallel_across_agents():
+    """Different agents run in parallel."""
+    started = []
+
+    async def tracking_dispatch(agent: str, message: str) -> str:
+        started.append(agent)
+        await asyncio.sleep(0.05)
+        return f"done:{agent}"
+
+    lm = LaneManager(dispatch_fn=tracking_dispatch)
+
+    r1, r2 = await asyncio.gather(
+        lm.enqueue("agent1", "msg1"),
+        lm.enqueue("agent2", "msg2"),
+    )
+    assert r1 == "done:agent1"
+    assert r2 == "done:agent2"
+    # Both should have started before either finished
+    assert set(started) == {"agent1", "agent2"}
+
+
+# ── Steer mode ───────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_steer_calls_steer_fn():
+    """Steer mode calls steer_fn directly when available."""
+    dispatch = AsyncMock(return_value="normal")
+    steer = AsyncMock(return_value={"injected": True})
+    lm = LaneManager(dispatch_fn=dispatch, steer_fn=steer)
+
+    # Ensure lane exists
+    result = await lm.enqueue("agent1", "redirect now", mode="steer")
+    assert "injected" in result.lower() or "Steered" in result
+    steer.assert_awaited_once_with("agent1", "redirect now")
+    # dispatch_fn should NOT have been called
+    dispatch.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_steer_falls_back_without_steer_fn():
+    """Without steer_fn, steer falls back to followup."""
+    dispatch = AsyncMock(return_value="followup response")
+    lm = LaneManager(dispatch_fn=dispatch, steer_fn=None)
+
+    result = await lm.enqueue("agent1", "redirect now", mode="steer")
+    assert result == "followup response"
+    dispatch.assert_awaited_once_with("agent1", "redirect now")
+
+
+@pytest.mark.asyncio
+async def test_steer_to_idle_agent():
+    """Steer to idle agent returns queued message."""
+    steer = AsyncMock(return_value={"injected": False})
+    lm = LaneManager(dispatch_fn=AsyncMock(return_value="ok"), steer_fn=steer)
+
+    result = await lm.enqueue("agent1", "hey", mode="steer")
+    assert "idle" in result.lower() or "queued" in result.lower()
+
+
+# ── Collect mode ─────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_collect_single_idle_dispatches_normally():
+    """Collect when idle dispatches immediately like followup."""
+    dispatch = AsyncMock(return_value="immediate")
+    lm = LaneManager(dispatch_fn=dispatch)
+
+    result = await lm.enqueue("agent1", "msg", mode="collect")
+    assert result == "immediate"
+
+
+@pytest.mark.asyncio
+async def test_collect_batches_when_busy():
+    """Collect returns SILENT_REPLY_TOKEN for secondary callers when agent is busy."""
+    dispatch_event = asyncio.Event()
+    dispatch_done = asyncio.Event()
+
+    async def blocking_dispatch(agent: str, message: str) -> str:
+        dispatch_event.set()
+        await dispatch_done.wait()
+        return f"done:{message}"
+
+    lm = LaneManager(dispatch_fn=blocking_dispatch)
+
+    # Start a followup task to make agent busy
+    task1 = asyncio.create_task(lm.enqueue("agent1", "primary"))
+    await dispatch_event.wait()  # Wait until dispatch is running
+
+    # Now agent is busy — collect should return SILENT_REPLY_TOKEN
+    result = await lm.enqueue("agent1", "batched1", mode="collect")
+    assert result == SILENT_REPLY_TOKEN
+
+    result2 = await lm.enqueue("agent1", "batched2", mode="collect")
+    assert result2 == SILENT_REPLY_TOKEN
+
+    # Release the first task
+    dispatch_done.set()
+    primary_result = await task1
+    assert primary_result == "done:primary"
+
+    # The flushed collect buffer should have created a combined task
+    # Wait for the worker to process it
+    await asyncio.sleep(0.1)
+
+
+@pytest.mark.asyncio
+async def test_collect_combined_message_format():
+    """Collected messages are combined with [Message N] format."""
+    captured_messages = []
+    dispatch_event = asyncio.Event()
+    dispatch_done = asyncio.Event()
+
+    async def capturing_dispatch(agent: str, message: str) -> str:
+        captured_messages.append(message)
+        if not dispatch_event.is_set():
+            dispatch_event.set()
+            await dispatch_done.wait()
+        return "ok"
+
+    lm = LaneManager(dispatch_fn=capturing_dispatch)
+
+    # Start a task to make agent busy
+    task1 = asyncio.create_task(lm.enqueue("agent1", "primary"))
+    await dispatch_event.wait()
+
+    # Collect two messages
+    await lm.enqueue("agent1", "msg A", mode="collect")
+    await lm.enqueue("agent1", "msg B", mode="collect")
+
+    # Release primary task — flush will create combined message
+    dispatch_done.set()
+    await task1
+    await asyncio.sleep(0.1)
+
+    # The combined message should have been dispatched
+    assert len(captured_messages) >= 2
+    combined = captured_messages[1]
+    assert "[Message 1]: msg A" in combined
+    assert "[Message 2]: msg B" in combined
+
+
+# ── Status ───────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_status_includes_collected_and_busy():
+    """Status includes collected count and busy flag."""
+    dispatch_event = asyncio.Event()
+    dispatch_done = asyncio.Event()
+
+    async def blocking_dispatch(agent: str, message: str) -> str:
+        dispatch_event.set()
+        await dispatch_done.wait()
+        return "ok"
+
+    lm = LaneManager(dispatch_fn=blocking_dispatch)
+
+    task1 = asyncio.create_task(lm.enqueue("agent1", "work"))
+    await dispatch_event.wait()
+
+    status = lm.get_status()
+    assert "agent1" in status
+    assert status["agent1"]["busy"] is True
+    assert "collected" in status["agent1"]
+
+    # Collect a message while busy
+    await lm.enqueue("agent1", "extra", mode="collect")
+    status = lm.get_status()
+    assert status["agent1"]["collected"] == 1
+
+    dispatch_done.set()
+    await task1
+
+
+# ── Stop ─────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_stop_cancels_workers():
+    """Stop cancels all worker tasks."""
+    lm = LaneManager(dispatch_fn=AsyncMock(return_value="ok"))
+
+    # Create a lane so a worker exists
+    await lm.enqueue("agent1", "hi")
+    assert "agent1" in lm._workers
+
+    await lm.stop()
+    assert len(lm._workers) == 0


### PR DESCRIPTION
## Summary

- **Three queue modes** for `LaneManager`: `followup` (default FIFO), `steer` (inject into active conversation between tool rounds), and `collect` (batch when busy, flush combined on idle)
- **Agent-side steer injection** via `asyncio.Queue` that bypasses `_chat_lock` — two injection points in both `_chat_inner` and `_chat_stream_inner` (idle merge + mid-execution interjection)
- **`POST /chat/steer` endpoint** that returns immediately without blocking on the chat lock
- **CLI `/steer` command** for injecting messages into busy agents from the REPL

## Test plan

- [x] `tests/test_lanes.py` — 11 new tests covering all three modes, status fields, and stop
- [x] `tests/test_loop.py` — 5 new steer injection tests (state returns, idle merge, mid-tool injection, multiple steers)
- [x] `tests/test_chat.py` — 2 new endpoint tests (steer returns 200, steer doesn't block when lock held)
- [x] Full suite: 597/597 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)