### PR TITLE
Add token estimation accuracy + context warnings (Roadmap 2.5)

### DIFF
--- a/src/agent/__main__.py
+++ b/src/agent/__main__.py
@@ -71,7 +71,7 @@ def main() -> None:
         except OSError:
             logger.debug("Could not copy PROJECT.md into workspace")
 
-    context_mgr = ContextManager(max_tokens=128_000, llm=llm, workspace=workspace, memory=memory)
+    context_mgr = ContextManager(llm=llm, workspace=workspace, memory=memory, model=llm_model)
 
     loop = AgentLoop(
         agent_id=agent_id,

--- a/src/channels/base.py
+++ b/src/channels/base.py
@@ -157,7 +157,12 @@ class Channel(abc.ABC):
                 if info:
                     state = info.get("state", "unknown")
                     tasks = info.get("tasks_completed", 0)
-                    lines.append(f"  {name}: {state} ({tasks} tasks)")
+                    ctx_max = info.get("context_max", 0)
+                    if ctx_max:
+                        ctx_pct = int(info.get("context_pct", 0) * 100)
+                        lines.append(f"  {name}: {state} ({tasks} tasks, ctx {ctx_pct}%)")
+                    else:
+                        lines.append(f"  {name}: {state} ({tasks} tasks)")
                 else:
                     lines.append(f"  {name}: unreachable")
             return "Agent status:\n" + "\n".join(lines)

--- a/src/cli.py
+++ b/src/cli.py
@@ -1721,6 +1721,22 @@ def _multi_agent_repl(
                         click.echo(f"Today's spend: ${total:.4f}\n")
                         for a in agents_spend:
                             click.echo(f"  {a['agent']:<16} {a['tokens']:>8,} tokens  ${a['cost']:.4f}")
+                    # Context window usage per agent
+                    click.echo("\nContext usage:")
+                    for name in agent_urls:
+                        try:
+                            data = transport.request_sync(name, "GET", "/status", timeout=3)
+                            ctx_tokens = data.get("context_tokens", 0)
+                            ctx_max = data.get("context_max", 0)
+                            ctx_pct = data.get("context_pct", 0.0)
+                            if ctx_max:
+                                pct_str = f"{int(ctx_pct * 100)}%"
+                                click.echo(f"  {name:<16} Context: {ctx_tokens:,}/{ctx_max:,} tokens ({pct_str})")
+                            else:
+                                click.echo(f"  {name:<16} Context: n/a")
+                        except Exception:
+                            click.echo(f"  {name:<16} Context: unreachable")
+
                     # Model health summary
                     model_health = credential_vault.get_model_health() if credential_vault else []
                     if model_health:

--- a/src/shared/types.py
+++ b/src/shared/types.py
@@ -89,6 +89,9 @@ class AgentStatus(BaseModel):
     uptime_seconds: float = 0
     tasks_completed: int = 0
     tasks_failed: int = 0
+    context_tokens: int = 0
+    context_max: int = 0
+    context_pct: float = 0.0
 
 
 # === Blackboard & Events ===


### PR DESCRIPTION
## Summary
- Replace rough 4-chars/token heuristic with model-aware estimation: tiktoken for OpenAI, 3.5 chars/token for Anthropic, 4 chars/token fallback
- Auto-detect context window size from model name (`MODEL_CONTEXT_WINDOWS` dict with 12 models); explicit `max_tokens` still overrides
- Inject "CONTEXT WARNING" into system prompts at 80% usage so agents proactively wrap up before auto-compaction
- Surface `context_tokens` / `context_max` / `context_pct` in `AgentStatus`, CLI `/costs`, and channel `/status`

## Test plan
- [x] `TestEstimateTokensAccuracy` — tiktoken for OpenAI, 3.5 ratio for Anthropic, 4 fallback, unknown OpenAI graceful fallback
- [x] `TestModelContextWindows` — auto-detect GPT-4o (128K), Claude (200K), unknown defaults 128K, explicit override
- [x] `TestContextWarning` — no warning below 80%, warning present at 80%+, warning contains token counts
- [x] `TestTokenCount` — returns positive int, works with model param
- [x] Context warning injection in chat system prompt and absence below threshold
- [x] `get_status` includes context fields (with and without context manager)
- [x] `/status` endpoint returns context fields via HTTP
- [x] Full suite: 616 passed, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)