### PR TITLE
Add browser tiers: basic, stealth, and advanced (Roadmap 3.1)

### DIFF
--- a/Dockerfile.agent
+++ b/Dockerfile.agent
@@ -17,12 +17,16 @@ WORKDIR /app
 # sqlite-vec requires amd64 (ARM wheels have broken 32-bit .so files)
 COPY pyproject.toml .
 RUN pip install --no-cache-dir \
-    fastapi uvicorn httpx pydantic playwright sqlite-vec mcp
+    fastapi uvicorn httpx pydantic playwright sqlite-vec mcp camoufox
 
-# Install Chromium for browser automation — shared path so non-root agent can access it
+# Install browsers — must run as root before USER agent.
+# Playwright Chromium goes to /opt/pw-browsers; Camoufox fetches its Firefox binary.
+# Both need o+rx so the non-root agent user can execute them.
 ENV PLAYWRIGHT_BROWSERS_PATH=/opt/pw-browsers
 RUN playwright install chromium --with-deps \
-    && chmod -R o+rx /opt/pw-browsers
+    && chmod -R o+rx /opt/pw-browsers \
+    && python -m camoufox fetch \
+    && (chmod -R o+rx /root/.camoufox 2>/dev/null || true)
 
 # Application code
 COPY src/agent/ /app/src/agent/

--- a/src/agent/__main__.py
+++ b/src/agent/__main__.py
@@ -131,6 +131,8 @@ def main() -> None:
                     pass
         if mcp_client:
             await mcp_client.stop()
+        from src.agent.builtins.browser_tool import browser_cleanup
+        await browser_cleanup()
         await llm.close()
         memory.close()
         logger.info(f"Agent '{agent_id}' shut down")

--- a/src/agent/builtins/vault_tool.py
+++ b/src/agent/builtins/vault_tool.py
@@ -110,7 +110,7 @@ async def vault_capture_from_page(
     try:
         from src.agent.builtins.browser_tool import _get_page, _page_refs
 
-        page = await _get_page()
+        page = await _get_page(mesh_client=mesh_client)
         if ref:
             locator = _page_refs.get(ref)
             if not locator:

--- a/src/cli.py
+++ b/src/cli.py
@@ -981,6 +981,7 @@ def _start_interactive(config_path: str, use_sandbox: bool = False) -> None:
         skills_dir = os.path.abspath(agent_cfg.get("skills_dir", ""))
         agent_model = agent_cfg.get("model", default_model)
         agent_mcp_servers = agent_cfg.get("mcp_servers") or None
+        agent_browser_backend = agent_cfg.get("browser_backend", "")
         try:
             url = runtime.start_agent(
                 agent_id=agent_id,
@@ -989,6 +990,7 @@ def _start_interactive(config_path: str, use_sandbox: bool = False) -> None:
                 system_prompt=agent_cfg.get("system_prompt", ""),
                 model=agent_model,
                 mcp_servers=agent_mcp_servers,
+                browser_backend=agent_browser_backend,
             )
         except (subprocess.TimeoutExpired, RuntimeError) as exc:
             if isinstance(runtime, SandboxBackend):
@@ -1014,6 +1016,7 @@ def _start_interactive(config_path: str, use_sandbox: bool = False) -> None:
                     system_prompt=agent_cfg.get("system_prompt", ""),
                     model=agent_model,
                     mcp_servers=agent_mcp_servers,
+                    browser_backend=agent_browser_backend,
                 )
             else:
                 raise
@@ -1638,6 +1641,7 @@ def _multi_agent_repl(
                 agent_cfg_data = _load_config().get("agents", {}).get(new_name, {})
                 skills_dir = os.path.abspath(agent_cfg_data.get("skills_dir", ""))
                 add_mcp_servers = agent_cfg_data.get("mcp_servers") or None
+                add_browser_backend = agent_cfg_data.get("browser_backend", "")
                 import asyncio
                 url = container_manager.start_agent(
                     agent_id=new_name,
@@ -1646,6 +1650,7 @@ def _multi_agent_repl(
                     system_prompt=agent_cfg_data.get("system_prompt", ""),
                     model=agent_cfg_data.get("model", model),
                     mcp_servers=add_mcp_servers,
+                    browser_backend=add_browser_backend,
                 )
                 router.register_agent(new_name, url)
                 agent_urls[new_name] = url

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -112,6 +112,55 @@ class TestSandboxBackend:
         assert "MESH_AUTH_TOKEN=" in env_content
         assert "alpha" in backend.auth_tokens
 
+    def test_prepare_workspace_browser_backend(self, tmp_path):
+        """browser_backend config is passed as BROWSER_BACKEND env var."""
+        project_root = tmp_path / "project"
+        project_root.mkdir()
+
+        backend = SandboxBackend.__new__(SandboxBackend)
+        backend.project_root = project_root
+        backend.mesh_host_port = 8420
+        backend.agents = {}
+        backend.auth_tokens = {}
+        backend._workspace_root = tmp_path / ".openlegion" / "agents"
+        backend._workspace_root.mkdir(parents=True)
+
+        ws = backend._prepare_workspace(
+            agent_id="beta",
+            role="scraper",
+            skills_dir="",
+            system_prompt="You scrape",
+            model="openai/gpt-4o-mini",
+            browser_backend="stealth",
+        )
+
+        env_content = (ws / ".agent.env").read_text()
+        assert "BROWSER_BACKEND=stealth" in env_content
+
+    def test_prepare_workspace_no_browser_backend(self, tmp_path):
+        """Without browser_backend, BROWSER_BACKEND is not in env."""
+        project_root = tmp_path / "project"
+        project_root.mkdir()
+
+        backend = SandboxBackend.__new__(SandboxBackend)
+        backend.project_root = project_root
+        backend.mesh_host_port = 8420
+        backend.agents = {}
+        backend.auth_tokens = {}
+        backend._workspace_root = tmp_path / ".openlegion" / "agents"
+        backend._workspace_root.mkdir(parents=True)
+
+        ws = backend._prepare_workspace(
+            agent_id="gamma",
+            role="helper",
+            skills_dir="",
+            system_prompt="You help",
+            model="openai/gpt-4o-mini",
+        )
+
+        env_content = (ws / ".agent.env").read_text()
+        assert "BROWSER_BACKEND" not in env_content
+
     def test_stop_agent_removes_from_registry(self):
         backend = SandboxBackend.__new__(SandboxBackend)
         backend.agents = {


### PR DESCRIPTION
## Summary
- Three-tier browser backend system: **basic** (Playwright Chromium), **stealth** (Camoufox anti-detect Firefox), **advanced** (Bright Data Scraping Browser via CDP)
- Configured per-agent via `browser_backend` in agents.yaml, flows as `BROWSER_BACKEND` env var through runtime
- Proper resource lifecycle with `browser_cleanup()`, concurrency lock, and credential-blind vault integration for Bright Data

## Test plan
- [x] 6 new browser backend selection tests (dispatch, error handling, import errors)
- [x] 2 new runtime tests (env var propagation with/without browser_backend)
- [x] Full suite passes: 638/638 tests green