### PR TITLE
Update README and docs to reflect sessions 12-15

### DIFF
--- a/docs/agent-tools.md
+++ b/docs/agent-tools.md
@@ -28,7 +28,15 @@ All file operations are scoped to `/data` inside the container. Path traversal i
 
 ### Browser Automation
 
-Powered by Playwright with headless Chromium pre-installed in the agent container.
+Three-tier browser backend system controlled by `browser_backend` in `config/agents.yaml`:
+
+| Tier | Stack | Anti-Detection | Cost |
+|------|-------|---------------|------|
+| **basic** (default) | Playwright + Chromium | Low | Free |
+| **stealth** | Camoufox (Firefox-based anti-detect) | Medium | Free |
+| **advanced** | Bright Data Scraping Browser via CDP | High (residential proxies, CAPTCHA solving) | Paid |
+
+The backend is selected per-agent via the `BROWSER_BACKEND` environment variable. All tiers expose the same tool interface — downstream tools work identically regardless of backend.
 
 | Tool | Parameters | Description |
 |------|-----------|-------------|

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -77,7 +77,7 @@ Each agent runs in an isolated Docker container with its own FastAPI server.
 | `exec_tool.py` | Shell command execution |
 | `file_tool.py` | File read/write/list scoped to /data |
 | `http_tool.py` | HTTP requests |
-| `browser_tool.py` | Playwright headless Chromium |
+| `browser_tool.py` | 3-tier browser: Playwright Chromium, Camoufox stealth, Bright Data CDP |
 | `mesh_tool.py` | Blackboard, PubSub, fleet awareness, artifacts, cron, heartbeat, spawn |
 | `memory_tool.py` | Memory search, save, recall |
 | `vault_tool.py` | Credential-blind vault operations |
@@ -91,6 +91,8 @@ Each agent runs in an isolated Docker container with its own FastAPI server.
 | `base.py` | Abstract base with @mention routing, /commands, message chunking |
 | `telegram.py` | Telegram Bot API adapter |
 | `discord.py` | Discord Bot adapter |
+| `slack.py` | Slack adapter (Socket Mode via slack-bolt) |
+| `whatsapp.py` | WhatsApp Cloud API adapter |
 | `webhook.py` | Generic webhook-to-workflow adapter |
 
 ### Shared (`src/shared/`)

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -31,6 +31,7 @@ agents:
     budget:
       daily_usd: 5.00
       monthly_usd: 100.00
+    browser_backend: stealth
     mcp_servers:
       - name: filesystem
         command: mcp-server-filesystem
@@ -49,6 +50,7 @@ agents:
 | `resources.cpu_limit` | float | No | CPU quota, 0.5 = 50% (default: `0.5`) |
 | `budget.daily_usd` | float | No | Daily spend cap in USD |
 | `budget.monthly_usd` | float | No | Monthly spend cap in USD |
+| `browser_backend` | string | No | Browser tier: `basic` (default), `stealth` (Camoufox), or `advanced` (Bright Data CDP) |
 | `mcp_servers` | list | No | External MCP tool servers. See [MCP Integration](mcp.md) |
 
 ### Model Format
@@ -128,6 +130,10 @@ See [Channels](channels.md) for full setup instructions.
 | `channels.discord.enabled` | boolean | Enable Discord bot |
 | `channels.discord.default_agent` | string | Default agent for Discord users |
 | `channels.discord.allowed_guilds` | list[int] | Optional: restrict by Discord server ID |
+| `channels.slack.enabled` | boolean | Enable Slack bot (Socket Mode) |
+| `channels.slack.default_agent` | string | Default agent for Slack users |
+| `channels.whatsapp.enabled` | boolean | Enable WhatsApp bot (Cloud API) |
+| `channels.whatsapp.default_agent` | string | Default agent for WhatsApp users |
 
 ## `config/permissions.json`
 
@@ -186,6 +192,10 @@ OPENLEGION_CRED_GEMINI_API_KEY=...
 # Channel Bot Tokens (optional)
 OPENLEGION_CRED_TELEGRAM_BOT_TOKEN=123456:ABC-...
 OPENLEGION_CRED_DISCORD_BOT_TOKEN=MTIz...
+OPENLEGION_CRED_SLACK_BOT_TOKEN=xoxb-...
+OPENLEGION_CRED_SLACK_APP_TOKEN=xapp-...
+OPENLEGION_CRED_WHATSAPP_ACCESS_TOKEN=EAAx...
+OPENLEGION_CRED_WHATSAPP_PHONE_NUMBER_ID=1234...
 
 # External API Keys (optional)
 OPENLEGION_CRED_BRAVE_SEARCH_API_KEY=BSA...
@@ -226,6 +236,7 @@ Beyond credentials, these environment variables affect runtime behavior:
 | Variable | Default | Description |
 |----------|---------|-------------|
 | `OPENLEGION_LOG_FORMAT` | `json` | Log output format: `json` (structured) or `text` (human-readable) |
+| `BROWSER_BACKEND` | `basic` | Browser tier: `basic`, `stealth`, or `advanced` (set automatically in containers) |
 | `MCP_SERVERS` | -- | JSON string of MCP server configs (set automatically in containers) |
 | `MESH_AUTH_TOKEN` | -- | Agent auth token (set automatically in containers) |
 | `MESH_HOST` | -- | Mesh host URL (set automatically in containers) |

--- a/docs/development.md
+++ b/docs/development.md
@@ -287,6 +287,8 @@ openlegion/
 │   │   ├── base.py              # Abstract channel
 │   │   ├── telegram.py          # Telegram bot
 │   │   ├── discord.py           # Discord bot
+│   │   ├── slack.py             # Slack (Socket Mode)
+│   │   ├── whatsapp.py          # WhatsApp (Cloud API)
 │   │   └── webhook.py           # HTTP webhooks
 │   ├── shared/                  # Shared between host and agent
 │   │   ├── types.py             # Pydantic contracts
@@ -299,7 +301,7 @@ openlegion/
 │   ├── permissions.json
 │   ├── cron.json
 │   └── workflows/
-├── tests/                       # Test suite (~495 tests)
+├── tests/                       # Test suite (~638 tests)
 │   └── fixtures/                # Test fixtures (echo MCP server, etc.)
 ├── Dockerfile.agent             # Agent container image
 └── pyproject.toml               # Project metadata
@@ -330,7 +332,8 @@ openlegion/
 | `pydantic` | Type validation |
 | `sqlite-vec` | Vector search for memory |
 | `mcp` | Model Context Protocol client |
-| `playwright` | Browser automation (Chromium) |
+| `playwright` | Browser automation — basic tier (Chromium) |
+| `camoufox` | Anti-detect browser — stealth tier (Firefox) |
 
 ### Optional
 
@@ -338,7 +341,7 @@ openlegion/
 |-------|----------|---------|
 | `dev` | `pytest`, `pytest-asyncio`, `ruff` | Testing and linting |
 | `mcp` | `mcp>=1.0` | MCP tool support |
-| `channels` | `python-telegram-bot`, `discord.py` | Messaging channels |
+| `channels` | `python-telegram-bot`, `discord.py`, `slack-bolt` | Messaging channels |
 
 ## Common Mistakes
 

--- a/docs/memory.md
+++ b/docs/memory.md
@@ -41,9 +41,10 @@ Manages the LLM's context window to prevent overflow while preserving important 
 
 ### Token Tracking
 
-- Estimates token count for each message using word-based heuristics (~4 chars per token)
-- Tracks cumulative usage across the conversation
-- Three thresholds:
+- **Model-aware token estimation**: tiktoken for OpenAI models (accurate), 3.5 chars/token for Anthropic, 4 chars/token fallback for unknown providers
+- **Model-aware context windows**: auto-detects max context from model name (12 models supported), with explicit `max_tokens` override
+- **80% context warning**: injected into system prompt telling agents to wrap up or save important facts
+- Three compaction thresholds:
   - **60%** -- proactive flush (extract facts to MEMORY.md)
   - **70%** -- auto-compact (summarize + trim to last 4 messages)
   - **90%** -- emergency hard-prune (keep only first + last 4 messages)


### PR DESCRIPTION
## Summary
- Test count updated from 495 to 638 across all references
- Added Slack and WhatsApp channels to README, channels.md, architecture.md, configuration.md
- Added browser tiers (basic/stealth/advanced) to agent-tools.md, configuration.md, architecture.md
- Added `browser_backend` config field, `BROWSER_BACKEND` env var, camoufox + slack-bolt deps
- Fixed token estimation description in memory.md (tiktoken + model-aware, not "~4 chars/token")
- Updated test coverage table with accurate per-category counts

## Test plan
- [x] No code changes — documentation only
- [x] Full test suite passes (638/638)