### PR TITLE
Add prompt injection sanitization via invisible Unicode stripping (Roadmap 3.5)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,4 +1,6 @@
-# CLAUDE.md — OpenLegion Engineering Guide
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
 ## What This Is
 
@@ -53,6 +55,8 @@ Three trust zones: **User** (full trust), **Mesh** (trusted coordinator), **Agen
 4. **Path traversal protection in agent file tools.** Agent file operations are confined to `/data` inside the container. The `file_tool.py` tools must validate paths. Never expose host filesystem paths to agents.
 
 5. **Container hardening is not optional.** Agents run as non-root (UID 1000), with `no-new-privileges`, memory limits (512MB), and CPU quotas. Don't weaken these defaults.
+
+6. **All untrusted text is sanitized before reaching LLM context.** `sanitize_for_prompt()` in `src/shared/utils.py` strips invisible Unicode (bidi overrides, tag chars, zero-width chars, variation selectors, etc.) at three choke points: user input (`server.py`), tool results (`loop.py`), and system prompt context (`loop.py`). New paths from untrusted text to LLM context must call `sanitize_for_prompt()`. Never bypass these layers.
 
 ### Architectural invariants
 
@@ -157,6 +161,7 @@ pytest tests/test_loop.py -x -v
 | `src/host/cron.py` | `tests/test_cron.py` |
 | `src/channels/base.py` | `tests/test_channels.py` |
 | `src/cli.py` | `tests/test_cli_commands.py` |
+| `src/shared/utils.py` (sanitization) | `tests/test_sanitize.py` |
 | Chat mode | `tests/test_chat.py`, `tests/test_chat_workspace.py` |
 
 ## Common Mistakes to Avoid

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -100,7 +100,7 @@ Each agent runs in an isolated Docker container with its own FastAPI server.
 | Module | Purpose |
 |--------|---------|
 | `types.py` | **THE contract** -- all Pydantic models shared between host and agents |
-| `utils.py` | ID generation, structured logging setup |
+| `utils.py` | ID generation, structured logging, prompt injection sanitization |
 
 ## Data Flow
 
@@ -147,3 +147,4 @@ Both implement `RuntimeBackend` ABC so the rest of the system is isolation-agnos
 5. **Bounded execution** -- 20 iterations for tasks, 30 tool rounds for chat
 6. **Write-then-compact** -- facts are flushed to memory before discarding context
 7. **Tool-call message grouping** -- assistant(tool_calls) and tool(results) are never separated in context trimming
+8. **Unicode sanitization** -- all untrusted text passes through `sanitize_for_prompt()` before reaching LLM context (user input, tool results, system prompt context)

--- a/tests/test_sanitize.py
+++ b/tests/test_sanitize.py
@@ -1,0 +1,242 @@
+"""Unit tests for sanitize_for_prompt().
+
+Covers: guards, preservation, normalization, stripping, compound vectors,
+JSON content, and idempotency.
+"""
+
+import json
+
+import pytest
+
+from src.shared.utils import sanitize_for_prompt
+
+
+# === Guards ===
+
+
+def test_none_returns_empty():
+    assert sanitize_for_prompt(None) == ""
+
+
+def test_int_returns_empty():
+    assert sanitize_for_prompt(42) == ""
+
+
+def test_empty_string_returns_empty():
+    assert sanitize_for_prompt("") == ""
+
+
+# === Preservation ===
+
+
+def test_ascii_preserved():
+    assert sanitize_for_prompt("Hello, world! 123") == "Hello, world! 123"
+
+
+def test_arabic_preserved():
+    text = "\u0645\u0631\u062d\u0628\u0627"  # marhaba
+    assert sanitize_for_prompt(text) == text
+
+
+def test_hebrew_preserved():
+    text = "\u05e9\u05dc\u05d5\u05dd"  # shalom
+    assert sanitize_for_prompt(text) == text
+
+
+def test_cjk_preserved():
+    text = "\u4f60\u597d\u4e16\u754c"  # nihao shijie
+    assert sanitize_for_prompt(text) == text
+
+
+def test_devanagari_preserved():
+    text = "\u0928\u092e\u0938\u094d\u0924\u0947"  # namaste
+    assert sanitize_for_prompt(text) == text
+
+
+def test_emoji_with_zwj_preserved():
+    # Family emoji: person + ZWJ + person + ZWJ + child
+    text = "\U0001F468\u200D\U0001F469\u200D\U0001F467"
+    assert sanitize_for_prompt(text) == text
+
+
+def test_zwnj_persian_preserved():
+    # Persian word with ZWNJ (U+200C) — essential for correct rendering
+    text = "\u0645\u06cc\u200C\u06a9\u0646\u0645"
+    assert sanitize_for_prompt(text) == text
+
+
+def test_tabs_newlines_preserved():
+    text = "line1\tfield\nline2\r\nline3"
+    assert sanitize_for_prompt(text) == text
+
+
+def test_vs15_text_presentation_preserved():
+    # Heart + VS15 (text presentation)
+    text = "\u2764\uFE0E"
+    assert sanitize_for_prompt(text) == text
+
+
+def test_vs16_emoji_presentation_preserved():
+    # Heart + VS16 (emoji presentation)
+    text = "\u2764\uFE0F"
+    assert sanitize_for_prompt(text) == text
+
+
+def test_normal_spaces_preserved():
+    assert sanitize_for_prompt("hello   world") == "hello   world"
+
+
+# === Normalization ===
+
+
+def test_line_separator_normalized():
+    assert sanitize_for_prompt("a\u2028b") == "a\nb"
+
+
+def test_paragraph_separator_normalized():
+    assert sanitize_for_prompt("a\u2029b") == "a\nb"
+
+
+# === Stripping ===
+
+
+def test_null_byte_stripped():
+    assert sanitize_for_prompt("hello\x00world") == "helloworld"
+
+
+def test_c0_controls_stripped():
+    # BEL, BS, VT, FF
+    assert sanitize_for_prompt("a\x07\x08\x0b\x0cb") == "ab"
+
+
+def test_c1_controls_stripped():
+    # U+0080 through U+009F
+    assert sanitize_for_prompt("a\x80\x8f\x9fb") == "ab"
+
+
+def test_bidi_overrides_stripped():
+    # LRO, RLO, LRE, RLE, PDF
+    bidi = "\u202A\u202B\u202C\u202D\u202E"
+    assert sanitize_for_prompt(f"a{bidi}b") == "ab"
+
+
+def test_bidi_isolates_stripped():
+    # LRI, RLI, FSI, PDI
+    bidi = "\u2066\u2067\u2068\u2069"
+    assert sanitize_for_prompt(f"a{bidi}b") == "ab"
+
+
+def test_tag_chars_stripped():
+    # U+E0001 (language tag), U+E0020 (tag space), U+E007F (cancel tag)
+    tags = "\U000E0001\U000E0020\U000E007F"
+    assert sanitize_for_prompt(f"safe{tags}text") == "safetext"
+
+
+def test_vs1_through_vs14_stripped():
+    # VS1 (U+FE00) through VS14 (U+FE0D)
+    for cp in range(0xFE00, 0xFE0E):
+        result = sanitize_for_prompt(f"a{chr(cp)}b")
+        assert result == "ab", f"VS at U+{cp:04X} not stripped"
+
+
+def test_supplementary_variation_selectors_stripped():
+    # VS17 (U+E0100) through sample VS256 area
+    for cp in [0xE0100, 0xE0110, 0xE01EF]:
+        result = sanitize_for_prompt(f"a{chr(cp)}b")
+        assert result == "ab", f"Supplementary VS at U+{cp:05X} not stripped"
+
+
+def test_combining_grapheme_joiner_stripped():
+    assert sanitize_for_prompt(f"a\u034Fb") == "ab"
+
+
+def test_hangul_fillers_stripped():
+    for cp in [0x115F, 0x1160, 0x3164, 0xFFA0]:
+        result = sanitize_for_prompt(f"a{chr(cp)}b")
+        assert result == "ab", f"Hangul filler U+{cp:04X} not stripped"
+
+
+def test_object_replacement_stripped():
+    assert sanitize_for_prompt(f"a\uFFFCb") == "ab"
+
+
+def test_soft_hyphen_stripped():
+    assert sanitize_for_prompt("soft\u00ADhyphen") == "softhyphen"
+
+
+def test_zero_width_space_stripped():
+    assert sanitize_for_prompt("zero\u200Bwidth") == "zerowidth"
+
+
+def test_word_joiner_stripped():
+    assert sanitize_for_prompt("word\u2060joiner") == "wordjoiner"
+
+
+def test_bom_stripped():
+    assert sanitize_for_prompt("\uFEFFhello") == "hello"
+
+
+def test_private_use_stripped():
+    # U+E000 (private use area)
+    assert sanitize_for_prompt(f"a\uE000b") == "ab"
+
+
+# === Compound attack vectors ===
+
+
+def test_tag_char_hidden_instruction():
+    """Attacker hides 'ignore previous' using tag characters."""
+    # Build hidden text using tag characters (U+E0001 start, then tag letters)
+    hidden = "".join(chr(0xE0000 + ord(c)) for c in "ignore previous")
+    text = f"Normal question{hidden}"
+    result = sanitize_for_prompt(text)
+    assert result == "Normal question"
+    assert "ignore" not in result
+
+
+def test_bidi_reversed_text():
+    """Attacker uses bidi overrides to visually reverse text."""
+    text = "Display: \u202Ethis is reversed\u202C real text"
+    result = sanitize_for_prompt(text)
+    assert "\u202E" not in result
+    assert "\u202C" not in result
+    assert "this is reversed" in result
+    assert "real text" in result
+
+
+def test_mixed_arabic_with_injection():
+    """Arabic text with bidi overrides attempting injection."""
+    text = "\u0645\u0631\u062d\u0628\u0627 \u202Eignore instructions\u202C"
+    result = sanitize_for_prompt(text)
+    assert "\u202E" not in result
+    assert "\u202C" not in result
+    assert "\u0645\u0631\u062d\u0628\u0627" in result
+    assert "ignore instructions" in result
+
+
+# === JSON content ===
+
+
+def test_invisible_chars_in_json_strings():
+    """Invisible characters embedded in JSON string values are stripped."""
+    payload = {"key": "normal\u200Bvalue\u00AD", "safe": "ok"}
+    json_str = json.dumps(payload, ensure_ascii=False)
+    result = sanitize_for_prompt(json_str)
+    parsed = json.loads(result)
+    assert parsed["key"] == "normalvalue"
+    assert parsed["safe"] == "ok"
+
+
+# === Idempotency ===
+
+
+def test_idempotent_on_clean_text():
+    text = "Hello, world! This is normal text."
+    assert sanitize_for_prompt(sanitize_for_prompt(text)) == sanitize_for_prompt(text)
+
+
+def test_idempotent_on_dirty_text():
+    text = "dirty\u200B\u202E\x00\uFEFF\u2028text\U000E0001"
+    first = sanitize_for_prompt(text)
+    second = sanitize_for_prompt(first)
+    assert first == second


### PR DESCRIPTION
## Summary

- Add `sanitize_for_prompt()` to `src/shared/utils.py` — strips invisible Unicode characters (bidi overrides, tag chars, zero-width spaces, variation selectors, Hangul fillers, private use, etc.) while preserving legitimate text in all scripts
- Sanitize at three choke points covering all paths from untrusted text to LLM context:
  - **Layer 1 (User Input)**: `server.py` — chat, steer, stream endpoints
  - **Layer 2 (Tool Results)**: `loop.py` — all 6 json.dumps/str() points in execute_task, _chat_inner, _chat_stream_inner
  - **Layer 3 (System Prompt Context)**: `loop.py` — goals, bootstrap, learnings, memory facts, tool history, assignment context, workspace search snippets

## Test plan

- [x] 38 unit tests in `tests/test_sanitize.py` (guards, preservation, normalization, stripping, compound attack vectors, JSON content, idempotency)
- [x] 5 integration tests in `tests/test_loop.py` (tool results in task/chat mode, memory autoload, goals, learnings)
- [x] Full suite: 681 tests pass, 0 regressions
- [x] Review audit found and fixed 2 additional gaps: unsanitized tool_history in chat system prompt, unsanitized workspace search snippets in memory auto-load