### PR TITLE
Fix critical bugs found in codebase audit

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -64,7 +64,7 @@ Three trust zones: **User** (full trust), **Mesh** (trusted coordinator), **Agen
 
 7. **Fleet model, not hierarchy.** There is no CEO agent that routes or delegates. Users talk to agents directly. Agents coordinate through the blackboard (shared state) and YAML workflows (deterministic DAGs). Do not introduce agent-to-agent direct messaging patterns that bypass the mesh.
 
-8. **Bounded execution.** Agent loops have hard limits: 20 iterations for tasks (`AgentLoop.MAX_ITERATIONS`), 10 tool rounds for chat (`CHAT_MAX_TOOL_ROUNDS`). Token budgets are enforced per task. These prevent runaway agents. Do not remove these limits.
+8. **Bounded execution.** Agent loops have hard limits: 20 iterations for tasks (`AgentLoop.MAX_ITERATIONS`), 30 tool rounds for chat (`CHAT_MAX_TOOL_ROUNDS`). Token budgets are enforced per task. These prevent runaway agents. Do not remove these limits.
 
 9. **Write-then-compact.** Before discarding any conversation context, important facts are flushed to `MEMORY.md` via the workspace (`src/agent/context.py`). No information should be silently lost during context management.
 
@@ -170,7 +170,7 @@ pytest tests/test_loop.py -x -v
 - **Polling for task completion.** Prefer push-based patterns (agent posts result back to mesh) over polling loops. The current `_wait_for_task_result` in orchestrator.py is a known area for improvement.
 - **Breaking tool-call message grouping.** When trimming context, never separate an `assistant` message with `tool_calls` from its corresponding `tool` result messages. The `_trim_context` method handles this — respect the grouping pattern.
 - **Putting secrets in agent code.** Agents run in untrusted containers. API keys, tokens, credentials — all belong in the vault (`OPENLEGION_CRED_*` env vars loaded by `credentials.py`). New service integrations go through the vault proxy.
-- **Using global mutable state.** The `_skill_registry` global in `skills.py` is a known issue. Avoid adding new module-level mutable globals. Pass state through constructors.
+- **Using global mutable state.** The `_skill_staging` global in `skills.py` is a known issue. Avoid adding new module-level mutable globals. Pass state through constructors.
 - **Overly broad exception handling.** Don't `except Exception: pass`. Log the error. Distinguish transient errors (network timeouts, rate limits — retry with backoff) from permanent errors (invalid input, missing config — fail fast).
 - **Monolithic functions.** `cli.py:_start_interactive` is too large. When adding features, prefer composable components over growing existing functions. Extract classes with clear lifecycle (init, start, stop).
 

--- a/src/agent/builtins/mesh_tool.py
+++ b/src/agent/builtins/mesh_tool.py
@@ -189,7 +189,7 @@ async def save_artifact(
         return {"error": "No workspace_manager available"}
     try:
         from pathlib import Path
-        artifacts_dir = Path(workspace_manager.workspace_root) / "artifacts"
+        artifacts_dir = Path(workspace_manager.root) / "artifacts"
         artifacts_dir.mkdir(parents=True, exist_ok=True)
         filepath = artifacts_dir / name
         filepath.write_text(content)

--- a/src/agent/loop.py
+++ b/src/agent/loop.py
@@ -571,7 +571,7 @@ class AgentLoop:
                 total_tokens += llm_response.tokens_used
 
                 if not llm_response.tool_calls:
-                    content = llm_response.content
+                    content = llm_response.content or ""
                     # Suppress silent acknowledgments (heartbeat/cron filler)
                     if content and content.strip() == SILENT_REPLY_TOKEN:
                         content = ""
@@ -893,7 +893,7 @@ class AgentLoop:
                 total_tokens += llm_response.tokens_used
 
                 if not llm_response.tool_calls:
-                    content = llm_response.content
+                    content = llm_response.content or ""
                     if content and content.strip() == SILENT_REPLY_TOKEN:
                         content = ""
                     if content:

--- a/src/host/health.py
+++ b/src/host/health.py
@@ -120,11 +120,13 @@ class HealthMonitor:
             return
 
         logger.info(f"Restarting agent '{agent_id}'...")
+        info = self.runtime.agents.get(agent_id, {})
         try:
-            info = self.runtime.agents.get(agent_id, {})
-
             self.runtime.stop_agent(agent_id)
+        except Exception as e:
+            logger.warning(f"Error stopping agent '{agent_id}' during restart: {e}")
 
+        try:
             url = self.runtime.start_agent(
                 agent_id=agent_id,
                 role=info.get("role", ""),


### PR DESCRIPTION
## Summary
- **mesh_tool.py**: Fix `AttributeError` crash in `save_artifact` — `workspace_manager.workspace_root` → `.root`
- **loop.py**: Guard against `None` LLM content with `or ""` at two call sites (lines 574, 896)
- **skill_tool.py**: Harden AST validation — add `importlib`, `socket` to forbidden imports; detect `eval()`, `exec()`, `__import__()` calls
- **health.py**: Fix restart race — capture agent info before `stop_agent`, separate try/except for stop vs start so a stop failure doesn't skip the restart
- **CLAUDE.md**: Correct `CHAT_MAX_TOOL_ROUNDS` (10 → 30) and `_skill_registry` → `_skill_staging`

## Test plan
- [x] All 681 unit/integration tests pass
- [ ] Verify `save_artifact` no longer crashes when workspace is active
- [ ] Verify chat mode handles None LLM content gracefully
- [ ] Verify skill validation rejects `eval()` / `exec()` / `__import__()`

🤖 Generated with [Claude Code](https://claude.com/claude-code)