### PR TITLE
Deduplicate chat mode and extract PairingManager

### DIFF
--- a/tests/test_whatsapp.py
+++ b/tests/test_whatsapp.py
@@ -50,7 +50,7 @@ def _make_channel(
     defaults.update(overrides)
     ch = WhatsAppChannel(**defaults)
     if paired is not None:
-        ch._paired = paired
+        ch._pairing._data = paired
     return ch
 
 
@@ -211,7 +211,7 @@ class TestPairing:
 
         msg = {"from": "+1234", "type": "text", "text": {"body": "!start abc123"}}
         await ch._process_message(msg)
-        assert ch._paired["owner"] == "+1234"
+        assert ch._pairing.owner == "+1234"
 
     @pytest.mark.asyncio
     async def test_pairing_with_wrong_code(self):
@@ -223,7 +223,7 @@ class TestPairing:
 
         msg = {"from": "+1234", "type": "text", "text": {"body": "!start wrong"}}
         await ch._process_message(msg)
-        assert ch._paired["owner"] is None
+        assert ch._pairing.owner is None
 
     @pytest.mark.asyncio
     async def test_disallowed_user_rejected(self):
@@ -255,7 +255,7 @@ class TestPairing:
 
         msg = {"from": "+0000", "type": "text", "text": {"body": "!allow +1111"}}
         await ch._process_message(msg)
-        assert "+1111" in ch._paired["allowed"]
+        assert ch._pairing.is_allowed("+1111")
 
     @pytest.mark.asyncio
     async def test_owner_revoke_command(self):
@@ -265,7 +265,7 @@ class TestPairing:
 
         msg = {"from": "+0000", "type": "text", "text": {"body": "!revoke +1111"}}
         await ch._process_message(msg)
-        assert "+1111" not in ch._paired["allowed"]
+        assert not ch._pairing.is_allowed("+1111")
 
 
 # ── _send_text ──────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- **loop.py**: Extract 5 shared helpers from `_chat_inner` and `_chat_stream_inner`, eliminating ~160 lines of copy-paste duplication. Initialize `_chat_messages` in `__init__` instead of `hasattr` checks.
- **channels/base.py**: New `PairingManager` class with persistence, access checks, and mutation methods
- **4 channel adapters** (telegram, discord, slack, whatsapp): Remove duplicate `_load_paired`/`_save_paired` functions, use `PairingManager` instead
- **tests**: Update `test_slack.py` and `test_whatsapp.py` to use `PairingManager` API

Net: **-126 lines** across 8 files.

## Test plan
- [x] All 681 unit/integration tests pass
- [ ] Verify chat mode (streaming + non-streaming) produces identical behavior
- [ ] Verify all 4 channel adapters handle pairing, allow, revoke correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)