### PR TITLE
Replace silent except:pass with logging in cli.py

### DIFF
--- a/src/channels/base.py
+++ b/src/channels/base.py
@@ -38,7 +38,7 @@ class PairingManager:
         if self._path.exists():
             try:
                 return json.loads(self._path.read_text())
-            except Exception:
+            except (json.JSONDecodeError, OSError):
                 pass
         return {"owner": None, "allowed": []}
 


### PR DESCRIPTION
## Summary
- **cli.py**: Add module-level `logger` and replace 6 bare `except Exception: pass` blocks with `logger.debug(...)` so failures during shutdown, cron notification, and status checks are traceable when debug logging is enabled
- **cli.py + base.py**: Narrow two JSON-reading `except Exception` clauses to `except (json.JSONDecodeError, OSError)` — only catch expected file/parse errors

## Test plan
- [x] All 681 unit/integration tests pass
- [ ] Verify CLI output is still clean (debug logs suppressed by default)

🤖 Generated with [Claude Code](https://claude.com/claude-code)