### PR TITLE
Add labeled screenshots to browser_screenshot tool

### DIFF
--- a/Dockerfile.agent
+++ b/Dockerfile.agent
@@ -17,7 +17,7 @@ WORKDIR /app
 # sqlite-vec requires amd64 (ARM wheels have broken 32-bit .so files)
 COPY pyproject.toml .
 RUN pip install --no-cache-dir \
-    fastapi uvicorn httpx pydantic playwright sqlite-vec mcp camoufox
+    fastapi uvicorn httpx pydantic playwright sqlite-vec mcp camoufox Pillow
 
 # Install browsers — must run as root before USER agent.
 # Playwright Chromium goes to /opt/pw-browsers; Camoufox fetches its Firefox binary.


### PR DESCRIPTION
## Summary
- `browser_screenshot` now accepts `labeled=True` to overlay numbered red labels on interactive elements
- Auto-calls `browser_snapshot` if page refs are empty when labeling is requested
- Draws red bounding boxes + white number labels using Pillow (PIL)
- Gracefully degrades when Pillow is not installed (returns empty labels)
- Added `Pillow` to `Dockerfile.agent` pip dependencies

## Test plan
- [x] `test_labeled_false_unchanged` — No labels key when labeled=False
- [x] `test_labeled_auto_snapshots` — Auto-calls snapshot when _page_refs empty
- [x] `test_labeled_draws_labels` — Mock locators with bounding boxes, verify label_count > 0
- [x] `test_labeled_skips_offscreen` — bbox=None elements excluded from label map
- [x] `test_labeled_pillow_import_error` — Graceful fallback returns empty labels
- [x] Full test suite passes (686 tests)