### PR TITLE
Add in-container subagent spawning for parallel work

### DIFF
--- a/src/agent/__main__.py
+++ b/src/agent/__main__.py
@@ -85,6 +85,9 @@ def main() -> None:
         context_manager=context_mgr,
     )
 
+    from src.agent.builtins.subagent_tool import register_parent_llm
+    register_parent_llm(agent_id, llm)
+
     agent_port = int(os.environ.get("AGENT_PORT", "8400"))
 
     @asynccontextmanager

--- a/src/agent/builtins/subagent_tool.py
+++ b/src/agent/builtins/subagent_tool.py
@@ -1,0 +1,269 @@
+"""In-container subagent spawning for parallel work.
+
+Subagents are lightweight AgentLoop instances that run in the same process.
+They share the parent's LLM client and mesh client (stateless httpx) but
+get their own memory store (in-memory SQLite) and workspace directory.
+
+Limits: max 3 concurrent per parent, max depth 2 (no grandchildren),
+default TTL 300s, default 10 max iterations.
+
+NOTE: Subagents should not use browser tools concurrently with the parent
+because browser state is stored in module-level globals.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import time
+from typing import TYPE_CHECKING
+
+from src.agent.skills import SkillRegistry, _skill_staging, skill
+from src.shared.utils import generate_id, setup_logging
+
+if TYPE_CHECKING:
+    from src.agent.llm import LLMClient
+
+logger = setup_logging("agent.subagent")
+
+# Module-level state
+_active_subagents: dict[str, dict[str, asyncio.Task]] = {}  # parent_id -> {subagent_id -> task}
+_depth_map: dict[str, int] = {}  # agent_id -> nesting depth
+_parent_llm_refs: dict[str, LLMClient] = {}  # agent_id -> LLM reference
+
+MAX_CONCURRENT = 3
+MAX_DEPTH = 2
+DEFAULT_TTL = 300
+DEFAULT_MAX_ITERATIONS = 10
+
+# Skills that subagents should NOT have (they could cause recursion or contention)
+_UNSAFE_SKILLS = frozenset({"create_skill", "reload_skills", "spawn_subagent"})
+
+
+def register_parent_llm(agent_id: str, llm: LLMClient) -> None:
+    """Register the parent's LLM client for subagent reuse. Called at agent startup."""
+    _parent_llm_refs[agent_id] = llm
+    _depth_map.setdefault(agent_id, 0)
+
+
+def _get_parent_llm(parent_id: str) -> LLMClient | None:
+    """Retrieve the LLM client for a parent agent."""
+    return _parent_llm_refs.get(parent_id)
+
+
+def _get_depth(agent_id: str) -> int:
+    return _depth_map.get(agent_id, 0)
+
+
+def _set_depth(agent_id: str, depth: int) -> None:
+    _depth_map[agent_id] = depth
+
+
+def _cleanup_depth(agent_id: str) -> None:
+    _depth_map.pop(agent_id, None)
+
+
+def _clone_skill_registry(workspace_manager=None) -> SkillRegistry:
+    """Create a cloned SkillRegistry from the current staging, removing unsafe skills.
+
+    The clone uses ``__new__`` to skip module re-execution, copies the current
+    skill dict, removes unsafe skills, and disables ``reload()``.
+    """
+    clone = SkillRegistry.__new__(SkillRegistry)
+    clone.skills_dir = ""
+    clone._mcp_client = None
+    # Copy current staging (which has all discovered skills)
+    clone.skills = {k: v for k, v in _skill_staging.items() if k not in _UNSAFE_SKILLS}
+    # Disable reload on clones
+    clone.reload = lambda: len(clone.skills)  # type: ignore[assignment]
+    return clone
+
+
+async def _run_subagent(
+    parent_id: str,
+    subagent_id: str,
+    task_text: str,
+    role: str,
+    ttl_seconds: int,
+    max_iterations: int,
+    mesh_client,
+) -> dict:
+    """Run a subagent loop and return the result."""
+    from src.agent.loop import AgentLoop
+    from src.agent.memory import MemoryStore
+    from src.agent.workspace import WorkspaceManager
+
+    llm = _get_parent_llm(parent_id)
+    if llm is None:
+        return {"error": "Parent LLM not found"}
+
+    # Each subagent gets isolated memory and workspace
+    memory = MemoryStore(db_path=":memory:")
+    ws_dir = f"/data/workspace/subagents/{subagent_id}"
+    workspace = WorkspaceManager(workspace_dir=ws_dir)
+    skills = _clone_skill_registry()
+
+    _set_depth(subagent_id, _get_depth(parent_id) + 1)
+
+    loop = AgentLoop(
+        agent_id=subagent_id,
+        role=role,
+        memory=memory,
+        skills=skills,
+        llm=llm,
+        mesh_client=mesh_client,
+        system_prompt=f"You are a subagent. Your task: {task_text}",
+        workspace=workspace,
+    )
+    loop.MAX_ITERATIONS = max_iterations
+
+    from src.shared.types import TaskAssignment
+    assignment = TaskAssignment(
+        task_id=subagent_id,
+        workflow_id=f"subagent_{parent_id}",
+        step_id=subagent_id,
+        task_type="subagent",
+        input_data={"task": task_text},
+    )
+
+    try:
+        result = await asyncio.wait_for(
+            loop.execute_task(assignment),
+            timeout=ttl_seconds,
+        )
+        result_data = {
+            "status": result.status,
+            "result": result.result,
+            "tokens_used": result.tokens_used,
+            "duration_ms": result.duration_ms,
+        }
+    except asyncio.TimeoutError:
+        result_data = {
+            "status": "timeout",
+            "result": f"Subagent timed out after {ttl_seconds}s",
+            "tokens_used": 0,
+            "iterations": 0,
+        }
+    except Exception as e:
+        result_data = {
+            "status": "error",
+            "result": str(e),
+            "tokens_used": 0,
+            "iterations": 0,
+        }
+    finally:
+        _cleanup_depth(subagent_id)
+        memory.close()
+
+    # Write result to blackboard
+    result_key = f"subagent_results/{parent_id}/{subagent_id}"
+    try:
+        await mesh_client.write_blackboard(result_key, result_data)
+    except Exception as e:
+        logger.warning("Failed to write subagent result to blackboard: %s", e)
+
+    return result_data
+
+
+@skill(
+    name="spawn_subagent",
+    description=(
+        "Spawn a lightweight subagent to handle a subtask in parallel. "
+        "The subagent runs in the same container with its own memory and workspace. "
+        "Results are written to the blackboard at subagent_results/<your_id>/<subagent_id>. "
+        "Use read_shared_state to check results. Max 3 concurrent, max depth 2. "
+        "NOTE: Subagents should not use browser tools (shared browser state)."
+    ),
+    parameters={
+        "task": {
+            "type": "string",
+            "description": "Task description for the subagent",
+        },
+        "role": {
+            "type": "string",
+            "description": "Role for the subagent (default 'assistant')",
+            "default": "assistant",
+        },
+        "ttl_seconds": {
+            "type": "integer",
+            "description": "Max time in seconds before timeout (default 300)",
+            "default": 300,
+        },
+    },
+)
+async def spawn_subagent(
+    task: str,
+    role: str = "assistant",
+    ttl_seconds: int = DEFAULT_TTL,
+    *,
+    mesh_client=None,
+) -> dict:
+    """Spawn a background subagent for parallel work."""
+    if mesh_client is None:
+        return {"error": "No mesh_client available"}
+
+    # Determine parent from mesh_client
+    parent_id = getattr(mesh_client, "agent_id", "unknown")
+
+    # Depth check
+    depth = _get_depth(parent_id)
+    if depth >= MAX_DEPTH:
+        return {"error": f"Max subagent depth ({MAX_DEPTH}) reached. Cannot spawn deeper."}
+
+    # Concurrent check
+    parent_tasks = _active_subagents.get(parent_id, {})
+    active_count = sum(1 for t in parent_tasks.values() if not t.done())
+    if active_count >= MAX_CONCURRENT:
+        return {"error": f"Max concurrent subagents ({MAX_CONCURRENT}) reached. Wait for one to finish."}
+
+    subagent_id = f"sub_{generate_id()}"
+    result_key = f"subagent_results/{parent_id}/{subagent_id}"
+
+    # Launch as background task
+    coro = _run_subagent(
+        parent_id=parent_id,
+        subagent_id=subagent_id,
+        task_text=task,
+        role=role,
+        ttl_seconds=ttl_seconds,
+        max_iterations=DEFAULT_MAX_ITERATIONS,
+        mesh_client=mesh_client,
+    )
+    async_task = asyncio.create_task(coro)
+
+    if parent_id not in _active_subagents:
+        _active_subagents[parent_id] = {}
+    _active_subagents[parent_id][subagent_id] = async_task
+
+    logger.info("Spawned subagent %s for parent %s: %s", subagent_id, parent_id, task[:80])
+    return {
+        "spawned": True,
+        "subagent_id": subagent_id,
+        "result_key": result_key,
+    }
+
+
+@skill(
+    name="list_subagents",
+    description="List active subagents spawned by this agent and their status.",
+    parameters={},
+)
+async def list_subagents(*, mesh_client=None) -> dict:
+    """List active subagents for the current agent."""
+    parent_id = getattr(mesh_client, "agent_id", "unknown") if mesh_client else "unknown"
+    parent_tasks = _active_subagents.get(parent_id, {})
+
+    subagents = []
+    for sid, task in parent_tasks.items():
+        subagents.append({
+            "subagent_id": sid,
+            "done": task.done(),
+            "result_key": f"subagent_results/{parent_id}/{sid}",
+        })
+
+    return {
+        "parent_id": parent_id,
+        "count": len(subagents),
+        "active": sum(1 for s in subagents if not s["done"]),
+        "subagents": subagents,
+    }

--- a/tests/test_subagent.py
+++ b/tests/test_subagent.py
@@ -1,0 +1,313 @@
+"""Tests for in-container subagent spawning."""
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from src.agent.builtins.subagent_tool import (
+    MAX_CONCURRENT,
+    MAX_DEPTH,
+    _active_subagents,
+    _clone_skill_registry,
+    _cleanup_depth,
+    _depth_map,
+    _get_depth,
+    _parent_llm_refs,
+    _set_depth,
+    list_subagents,
+    register_parent_llm,
+    spawn_subagent,
+)
+
+
+def _cleanup():
+    """Clean up module-level state between tests."""
+    _active_subagents.clear()
+    _depth_map.clear()
+    _parent_llm_refs.clear()
+
+
+class TestSpawnSubagentBasic:
+    @pytest.mark.asyncio
+    async def test_spawn_subagent_basic(self):
+        """Mock LLM (immediate final answer), verify spawned + blackboard write."""
+        _cleanup()
+
+        mock_llm = MagicMock()
+        mock_mesh = AsyncMock()
+        mock_mesh.agent_id = "parent-1"
+        mock_mesh.write_blackboard = AsyncMock(return_value={"version": 1})
+
+        register_parent_llm("parent-1", mock_llm)
+
+        # Mock execute_task to return immediately
+        from src.shared.types import TaskResult
+        mock_result = TaskResult(
+            task_id="test",
+            status="complete",
+            result={"answer": "42"},
+            tokens_used=100,
+            duration_ms=500,
+        )
+
+        with patch("src.agent.builtins.subagent_tool._run_subagent") as mock_run:
+            mock_run.return_value = {
+                "status": "complete",
+                "result": {"answer": "42"},
+                "tokens_used": 100,
+                "duration_ms": 500,
+            }
+            result = await spawn_subagent(
+                task="What is 6*7?", mesh_client=mock_mesh,
+            )
+
+        assert result["spawned"] is True
+        assert "subagent_id" in result
+        assert "result_key" in result
+        assert result["result_key"].startswith("subagent_results/parent-1/")
+
+        _cleanup()
+
+
+class TestSpawnSubagentDepthLimit:
+    @pytest.mark.asyncio
+    async def test_spawn_subagent_depth_limit(self):
+        """Set depth=2, verify error."""
+        _cleanup()
+
+        mock_mesh = AsyncMock()
+        mock_mesh.agent_id = "deep-agent"
+
+        _set_depth("deep-agent", MAX_DEPTH)
+
+        result = await spawn_subagent(
+            task="some task", mesh_client=mock_mesh,
+        )
+
+        assert "error" in result
+        assert "depth" in result["error"].lower()
+
+        _cleanup()
+
+
+class TestSpawnSubagentConcurrentLimit:
+    @pytest.mark.asyncio
+    async def test_spawn_subagent_concurrent_limit(self):
+        """Spawn 3, try 4th, verify error."""
+        _cleanup()
+
+        mock_llm = MagicMock()
+        mock_mesh = AsyncMock()
+        mock_mesh.agent_id = "busy-parent"
+        mock_mesh.write_blackboard = AsyncMock(return_value={"version": 1})
+
+        register_parent_llm("busy-parent", mock_llm)
+
+        # Create 3 "active" tasks that aren't done
+        _active_subagents["busy-parent"] = {}
+        for i in range(MAX_CONCURRENT):
+            mock_task = MagicMock()
+            mock_task.done.return_value = False
+            _active_subagents["busy-parent"][f"sub_{i}"] = mock_task
+
+        result = await spawn_subagent(
+            task="one more task", mesh_client=mock_mesh,
+        )
+
+        assert "error" in result
+        assert "concurrent" in result["error"].lower()
+
+        _cleanup()
+
+
+class TestSpawnSubagentTTLTimeout:
+    @pytest.mark.asyncio
+    async def test_spawn_subagent_ttl_timeout(self):
+        """TTL=1s, slow LLM, verify timeout result on blackboard."""
+        _cleanup()
+
+        mock_llm = MagicMock()
+        mock_mesh = AsyncMock()
+        mock_mesh.agent_id = "timeout-parent"
+        mock_mesh.write_blackboard = AsyncMock(return_value={"version": 1})
+
+        register_parent_llm("timeout-parent", mock_llm)
+
+        from src.agent.builtins.subagent_tool import _run_subagent
+
+        # Mock AgentLoop.execute_task to sleep forever
+        async def slow_execute(assignment):
+            await asyncio.sleep(100)
+
+        with patch("src.agent.loop.AgentLoop") as MockLoop:
+            mock_loop_inst = MagicMock()
+            mock_loop_inst.execute_task = slow_execute
+            MockLoop.return_value = mock_loop_inst
+
+            with patch("src.agent.memory.MemoryStore") as MockMem:
+                mock_mem = MagicMock()
+                mock_mem.close = MagicMock()
+                MockMem.return_value = mock_mem
+
+                with patch("src.agent.workspace.WorkspaceManager"):
+                    result = await _run_subagent(
+                        parent_id="timeout-parent",
+                        subagent_id="sub_slow",
+                        task_text="slow task",
+                        role="assistant",
+                        ttl_seconds=1,
+                        max_iterations=10,
+                        mesh_client=mock_mesh,
+                    )
+
+        assert result["status"] == "timeout"
+        assert "timed out" in result["result"].lower()
+        mock_mesh.write_blackboard.assert_called_once()
+
+        _cleanup()
+
+
+class TestCloneSkillRegistry:
+    def setup_method(self):
+        """Ensure skill staging is populated with builtins before each test."""
+        from src.agent.skills import SkillRegistry
+        # Creating a registry re-discovers builtins and populates _skill_staging
+        SkillRegistry(skills_dir="/nonexistent")
+
+    def test_clone_has_skills_minus_unsafe(self):
+        """Clone has same skills but without create_skill, reload_skills, spawn_subagent."""
+        _cleanup()
+
+        clone = _clone_skill_registry()
+
+        # Should have regular skills (builtins were discovered in setup)
+        assert len(clone.skills) > 0
+        assert "exec" in clone.skills
+
+        # Should NOT have unsafe skills
+        assert "create_skill" not in clone.skills
+        assert "reload_skills" not in clone.skills
+        assert "spawn_subagent" not in clone.skills
+
+    def test_clone_reload_is_noop(self):
+        """reload() on clone returns skill count without re-discovering."""
+        clone = _clone_skill_registry()
+        count = clone.reload()
+        assert isinstance(count, int)
+        assert count == len(clone.skills)
+
+
+class TestListSubagents:
+    @pytest.mark.asyncio
+    async def test_list_subagents(self):
+        """Verify count after spawning."""
+        _cleanup()
+
+        mock_mesh = AsyncMock()
+        mock_mesh.agent_id = "list-parent"
+
+        # No subagents yet
+        result = await list_subagents(mesh_client=mock_mesh)
+        assert result["count"] == 0
+
+        # Add some mock subagents
+        mock_done = MagicMock()
+        mock_done.done.return_value = True
+        mock_active = MagicMock()
+        mock_active.done.return_value = False
+
+        _active_subagents["list-parent"] = {
+            "sub_1": mock_done,
+            "sub_2": mock_active,
+        }
+
+        result = await list_subagents(mesh_client=mock_mesh)
+        assert result["count"] == 2
+        assert result["active"] == 1
+        assert len(result["subagents"]) == 2
+
+        _cleanup()
+
+
+class TestSubagentMemoryIsolation:
+    @pytest.mark.asyncio
+    async def test_subagent_memory_isolation(self):
+        """Subagent memory is separate from parent (uses :memory:)."""
+        _cleanup()
+
+        mock_llm = MagicMock()
+        mock_mesh = AsyncMock()
+        mock_mesh.agent_id = "iso-parent"
+        mock_mesh.write_blackboard = AsyncMock(return_value={"version": 1})
+
+        register_parent_llm("iso-parent", mock_llm)
+
+        # Track MemoryStore instantiations
+        memory_paths: list[str] = []
+
+        from src.agent.builtins.subagent_tool import _run_subagent
+
+        with patch("src.agent.memory.MemoryStore") as MockMem:
+            mock_mem = MagicMock()
+            mock_mem.close = MagicMock()
+            MockMem.return_value = mock_mem
+
+            def capture_path(db_path=":memory:", **kwargs):
+                memory_paths.append(db_path)
+                return mock_mem
+            MockMem.side_effect = capture_path
+
+            with patch("src.agent.loop.AgentLoop") as MockLoop:
+                from src.shared.types import TaskResult
+                mock_result = TaskResult(
+                    task_id="test", status="complete",
+                    result={"answer": "done"}, tokens_used=50, duration_ms=100,
+                )
+                mock_loop_inst = AsyncMock()
+                mock_loop_inst.execute_task = AsyncMock(return_value=mock_result)
+                mock_loop_inst.MAX_ITERATIONS = 20
+                MockLoop.return_value = mock_loop_inst
+
+                with patch("src.agent.workspace.WorkspaceManager"):
+                    await _run_subagent(
+                        parent_id="iso-parent",
+                        subagent_id="sub_iso",
+                        task_text="isolated task",
+                        role="assistant",
+                        ttl_seconds=30,
+                        max_iterations=10,
+                        mesh_client=mock_mesh,
+                    )
+
+        assert len(memory_paths) == 1
+        assert memory_paths[0] == ":memory:"
+
+        _cleanup()
+
+
+class TestDepthTracking:
+    def test_depth_tracking(self):
+        _cleanup()
+
+        _set_depth("agent-a", 0)
+        assert _get_depth("agent-a") == 0
+
+        _set_depth("agent-b", 1)
+        assert _get_depth("agent-b") == 1
+
+        _cleanup_depth("agent-a")
+        assert _get_depth("agent-a") == 0  # defaults to 0
+
+        _cleanup()
+
+    def test_register_parent_sets_depth_zero(self):
+        _cleanup()
+
+        mock_llm = MagicMock()
+        register_parent_llm("new-parent", mock_llm)
+
+        assert _get_depth("new-parent") == 0
+        assert _parent_llm_refs["new-parent"] is mock_llm
+
+        _cleanup()


### PR DESCRIPTION
## Summary
- New `spawn_subagent` tool creates lightweight AgentLoop instances in-process for parallel subtasks
- Each subagent gets isolated memory (`:memory:` SQLite) and workspace directory
- Shares parent's LLM client and mesh client (stateless httpx, safe for concurrent use)
- Results written to blackboard at `subagent_results/{parent_id}/{subagent_id}`
- `list_subagents` tool shows active subagent status
- Safety limits: max 3 concurrent, max depth 2 (no grandchildren), configurable TTL (default 300s)
- Unsafe skills removed from subagent registry (create_skill, reload_skills, spawn_subagent)
- Parent LLM registered at agent startup via `register_parent_llm()`

## Test plan
- [x] `test_spawn_subagent_basic` — Mock LLM, verify spawned + result key
- [x] `test_spawn_subagent_depth_limit` — Depth=2 returns error
- [x] `test_spawn_subagent_concurrent_limit` — 3 active, 4th returns error
- [x] `test_spawn_subagent_ttl_timeout` — TTL=1s, slow LLM, verify timeout on blackboard
- [x] `test_clone_skill_registry` — Clone has skills, reload is noop, unsafe skills removed
- [x] `test_list_subagents` — Verify count after spawning
- [x] `test_subagent_memory_isolation` — Uses :memory: not parent's db
- [x] `test_depth_tracking` / `test_register_parent_sets_depth_zero`
- [x] Full test suite passes (712 tests)