### PR TITLE
Fix security and correctness issues across Tier 3 features

### DIFF
--- a/src/agent/builtins/browser_tool.py
+++ b/src/agent/builtins/browser_tool.py
@@ -424,8 +424,9 @@ async def _draw_labels(image_path: str) -> dict[str, str]:
         text_bbox = draw.textbbox((0, 0), label_text, font=font) if font else (0, 0, 10, 12)
         tw = text_bbox[2] - text_bbox[0] + 6
         th = text_bbox[3] - text_bbox[1] + 4
-        draw.rectangle([x, y - th, x + tw, y], fill="red")
-        draw.text((x + 3, y - th + 2), label_text, fill="white", font=font)
+        label_y = max(0, y - th)
+        draw.rectangle([x, label_y, x + tw, label_y + th], fill="red")
+        draw.text((x + 3, label_y + 2), label_text, fill="white", font=font)
 
         labels[num] = f"{ref} at ({int(x)},{int(y)}) {int(w)}x{int(h)}"
 


### PR DESCRIPTION
## Summary

- **Marketplace path traversal fix**: Skill names from YAML manifests are now validated against `^[a-zA-Z0-9_-]+$` — rejects `../`, `/`, `\` to prevent directory escape. Same check added to `remove_skill`.
- **Marketplace PyYAML error**: Surfaces a helpful error log when `import yaml` fails instead of silently returning `None`.
- **Subagent result_data consistency**: Timeout and error paths now return `duration_ms: 0` instead of `iterations: 0` (which doesn't exist on `TaskResult`).
- **Subagent memory leak**: Done tasks are pruned from `_active_subagents` on each spawn to prevent unbounded growth.
- **Subagent dead code**: Removed unused `import json`, `import time`, and unused `workspace_manager` parameter.
- **Screenshot label positioning**: Clamped label Y coordinate to `max(0, y - th)` so labels don't draw off-screen.

## Test plan

- [x] 5 new tests added (3 marketplace, 2 subagent)
- [x] All 717 tests pass
- [x] Path traversal names rejected in both install and remove paths
- [x] Timeout results now have `duration_ms` key, not `iterations`
- [x] Done tasks pruned from active tracking dict on spawn

🤖 Generated with [Claude Code](https://claude.com/claude-code)