### PR TITLE
Fix 403 on dynamically added agents

### DIFF
--- a/src/cli/repl.py
+++ b/src/cli/repl.py
@@ -128,6 +128,8 @@ class REPLSession:
         )
         model = _get_default_model()
         _create_agent(new_name, new_desc, model)
+        # Reload permissions so the mesh grants the new agent API access
+        self.ctx.permissions.reload()
         agent_cfg_data = _load_config().get("agents", {}).get(new_name, {})
         skills_dir = os.path.abspath(agent_cfg_data.get("skills_dir", ""))
         add_mcp_servers = agent_cfg_data.get("mcp_servers") or None

--- a/src/host/permissions.py
+++ b/src/host/permissions.py
@@ -22,7 +22,12 @@ class PermissionMatrix:
 
     def __init__(self, config_path: str = "config/permissions.json"):
         self.permissions: dict[str, AgentPermissions] = {}
+        self._config_path = config_path
         self._load(config_path)
+
+    def reload(self) -> None:
+        """Reload permissions from disk (e.g. after adding an agent at runtime)."""
+        self._load(self._config_path)
 
     def _load(self, config_path: str) -> None:
         path = Path(config_path)


### PR DESCRIPTION
## Summary
- When `/add` creates a new agent at runtime, `_create_agent()` writes permissions to `config/permissions.json` on disk, but the in-memory `PermissionMatrix` used by the mesh server was never updated
- The new agent's LLM API calls were denied with 403 Forbidden
- Adds `PermissionMatrix.reload()` method and calls it from `_cmd_add` after agent creation

## Test plan
- [ ] `openlegion start`, then `/add tester`, then send a message to `@tester` — should respond instead of 403
- [ ] Existing agents still work normally after adding a new one
- [ ] All 717 unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)