### PR TITLE
Fix pub/sub publish 403 for collaborative agents

### DIFF
--- a/src/cli/config.py
+++ b/src/cli/config.py
@@ -296,7 +296,7 @@ def _add_agent_permissions(name: str) -> None:
 
     perms["permissions"][name] = {
         "can_message": can_message,
-        "can_publish": [f"{name}_complete"],
+        "can_publish": ["*"] if collab else [f"{name}_complete"],
         "can_subscribe": ["*"] if collab else [],
         "blackboard_read": ["context/*", "tasks/*", "goals/*", "signals/*", "artifacts/*"],
         "blackboard_write": ["context/*", "goals/*", "signals/*", "artifacts/*"],
@@ -306,13 +306,15 @@ def _add_agent_permissions(name: str) -> None:
 
 
 def _set_collaborative_permissions() -> None:
-    """Update all agent permissions to allow inter-agent messaging."""
+    """Update all agent permissions to allow inter-agent messaging and pub/sub."""
     perms = _load_permissions()
     for name, p in perms.get("permissions", {}).items():
         if name == "default":
             continue
         if "*" not in p.get("can_message", []):
             p["can_message"] = list({*p.get("can_message", []), "*"})
+        if "*" not in p.get("can_publish", []):
+            p["can_publish"] = list({*p.get("can_publish", []), "*"})
         if "*" not in p.get("can_subscribe", []):
             p["can_subscribe"] = list({*p.get("can_subscribe", []), "*"})
     _save_permissions(perms)

--- a/src/cli/runtime.py
+++ b/src/cli/runtime.py
@@ -168,6 +168,11 @@ class RuntimeContext:
         from src.host.orchestrator import Orchestrator
         from src.host.permissions import PermissionMatrix
 
+        # Ensure collaborative permissions are up to date before loading
+        if self.cfg.get("collaboration", False):
+            from src.cli.config import _set_collaborative_permissions
+            _set_collaborative_permissions()
+
         mesh_port = self.cfg["mesh"]["port"]
 
         self.blackboard = Blackboard()


### PR DESCRIPTION
## Summary
- Agents had `can_subscribe: ["*"]` but `can_publish: ["assistant_complete"]` — any custom topic publish failed with 403
- `_add_agent_permissions`: now grants `can_publish: ["*"]` when collaboration is enabled
- `_set_collaborative_permissions`: now also updates `can_publish` (was missing — only updated `can_message` and `can_subscribe`)
- `RuntimeContext._create_components`: applies collaborative permissions at startup so existing `permissions.json` files get patched without re-running setup

## Test plan
- [ ] `openlegion start`, then ask agent to publish an event to any topic — should succeed
- [ ] Existing blackboard/subscribe operations still work
- [ ] All 717 unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)