### PR TITLE
Grant agents can_manage_vault permission

### DIFF
--- a/src/cli/config.py
+++ b/src/cli/config.py
@@ -301,6 +301,7 @@ def _add_agent_permissions(name: str) -> None:
         "blackboard_read": ["context/*", "tasks/*", "goals/*", "signals/*", "artifacts/*"],
         "blackboard_write": ["context/*", "goals/*", "signals/*", "artifacts/*"],
         "allowed_apis": ["llm"],
+        "can_manage_vault": True,
     }
     _save_permissions(perms)
 
@@ -317,6 +318,7 @@ def _set_collaborative_permissions() -> None:
             p["can_publish"] = list({*p.get("can_publish", []), "*"})
         if "*" not in p.get("can_subscribe", []):
             p["can_subscribe"] = list({*p.get("can_subscribe", []), "*"})
+        p["can_manage_vault"] = True
     _save_permissions(perms)
 
 


### PR DESCRIPTION
## Summary
- Vault tools (`vault_generate_secret`, `vault_list`, `vault_status`, `vault_capture_from_page`) all require `can_manage_vault` permission
- This field defaults to `False` on `AgentPermissions` and was never set in `_add_agent_permissions`
- All vault operations returned 403 Forbidden
- Now set `can_manage_vault: True` for all agents, and `_set_collaborative_permissions` patches existing configs at startup

## Test plan
- [ ] `openlegion start`, ask agent to generate a secret — should succeed
- [ ] `vault_list`, `vault_status` also work without 403
- [ ] All 717 unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)