### PR TITLE
Comprehensive CLI UX improvements

### DIFF
--- a/tests/test_cli_commands.py
+++ b/tests/test_cli_commands.py
@@ -1,4 +1,4 @@
-"""Tests for CLI commands: agent add/list/remove, setup helpers."""
+"""Tests for CLI commands: agent add/list/model/browser/remove, setup helpers."""
 
 import json
 import os
@@ -34,7 +34,7 @@ class TestAgentAdd:
             result = runner.invoke(
                 cli,
                 ["agent", "add", "mybot"],
-                input="Code review specialist\n\n",  # description + accept default model
+                input="Code review specialist\n\n\n",  # description + model + browser
             )
             assert result.exit_code == 0, result.output
             assert "mybot" in result.output
@@ -43,6 +43,7 @@ class TestAgentAdd:
             assert "mybot" in agents_cfg["agents"]
             assert agents_cfg["agents"]["mybot"]["role"] == "Code review specialist"
             assert "openai/" in agents_cfg["agents"]["mybot"]["model"]
+            assert agents_cfg["agents"]["mybot"].get("browser_backend", "basic") in ("basic", "")
 
             perms = json.loads(perms_file.read_text())
             assert "mybot" in perms["permissions"]
@@ -71,13 +72,45 @@ class TestAgentAdd:
             result = runner.invoke(
                 cli,
                 ["agent", "add", "mybot", "--model", "anthropic/claude-haiku-4-5-20251001"],
-                input="Code review specialist\n",  # only description needed
+                input="Code review specialist\n\n",  # description + browser
             )
             assert result.exit_code == 0, result.output
             assert "mybot" in result.output
 
             agents_cfg = yaml.safe_load(agents_file.read_text())
             assert agents_cfg["agents"]["mybot"]["model"] == "anthropic/claude-haiku-4-5-20251001"
+
+    def test_add_agent_with_browser_flag(self, tmp_path):
+        """--browser flag skips interactive browser selection."""
+        config_file = tmp_path / "mesh.yaml"
+        agents_file = tmp_path / "agents.yaml"
+        perms_file = tmp_path / "permissions.json"
+        project_root = tmp_path
+
+        config_file.write_text(yaml.dump({
+            "mesh": {"host": "0.0.0.0", "port": 8420},
+            "llm": {"default_model": "openai/gpt-4.1"},
+        }))
+        perms_file.write_text(json.dumps({"permissions": {}}))
+
+        with (
+            patch("src.cli.config.CONFIG_FILE", config_file),
+            patch("src.cli.config.AGENTS_FILE", agents_file),
+            patch("src.cli.config.PERMISSIONS_FILE", perms_file),
+            patch("src.cli.config.PROJECT_ROOT", project_root),
+        ):
+            runner = CliRunner()
+            result = runner.invoke(
+                cli,
+                ["agent", "add", "mybot", "--model", "openai/gpt-4.1", "--browser", "stealth"],
+                input="Web scraper agent\n",  # only description needed
+            )
+            assert result.exit_code == 0, result.output
+            assert "mybot" in result.output
+            assert "stealth" in result.output
+
+            agents_cfg = yaml.safe_load(agents_file.read_text())
+            assert agents_cfg["agents"]["mybot"]["browser_backend"] == "stealth"
 
     def test_add_duplicate_agent(self, tmp_path):
         config_file = tmp_path / "mesh.yaml"
@@ -125,7 +158,7 @@ class TestAgentModel:
                 ["agent", "model", "mybot", "anthropic/claude-sonnet-4-6"],
             )
             assert result.exit_code == 0, result.output
-            assert "changed" in result.output
+            assert "->" in result.output
 
             agents_cfg = yaml.safe_load(agents_file.read_text())
             assert agents_cfg["agents"]["mybot"]["model"] == "anthropic/claude-sonnet-4-6"
@@ -157,7 +190,7 @@ class TestAgentModel:
                 input="2\n",  # pick second model
             )
             assert result.exit_code == 0, result.output
-            assert "changed" in result.output
+            assert "->" in result.output
 
     def test_change_model_nonexistent_agent(self, tmp_path):
         config_file = tmp_path / "mesh.yaml"
@@ -196,6 +229,109 @@ class TestAgentModel:
             result = runner.invoke(
                 cli,
                 ["agent", "model", "mybot", "anthropic/claude-haiku-4-5-20251001"],
+            )
+            assert result.exit_code == 0
+            assert "already uses" in result.output
+
+
+class TestAgentBrowser:
+    def test_change_browser_direct(self, tmp_path):
+        """Direct backend argument updates agents.yaml."""
+        config_file = tmp_path / "mesh.yaml"
+        agents_file = tmp_path / "agents.yaml"
+
+        config_file.write_text(yaml.dump({
+            "mesh": {"host": "0.0.0.0", "port": 8420},
+        }))
+        agents_file.write_text(yaml.dump({
+            "agents": {"mybot": {
+                "role": "test",
+                "model": "openai/gpt-4.1",
+                "browser_backend": "basic",
+            }},
+        }))
+
+        with (
+            patch("src.cli.config.CONFIG_FILE", config_file),
+            patch("src.cli.config.AGENTS_FILE", agents_file),
+        ):
+            runner = CliRunner()
+            result = runner.invoke(
+                cli,
+                ["agent", "browser", "mybot", "stealth"],
+            )
+            assert result.exit_code == 0, result.output
+            assert "->" in result.output
+
+            agents_cfg = yaml.safe_load(agents_file.read_text())
+            assert agents_cfg["agents"]["mybot"]["browser_backend"] == "stealth"
+
+    def test_change_browser_interactive(self, tmp_path):
+        """Interactive browser picker updates agents.yaml."""
+        config_file = tmp_path / "mesh.yaml"
+        agents_file = tmp_path / "agents.yaml"
+
+        config_file.write_text(yaml.dump({
+            "mesh": {"host": "0.0.0.0", "port": 8420},
+        }))
+        agents_file.write_text(yaml.dump({
+            "agents": {"mybot": {
+                "role": "test",
+                "model": "openai/gpt-4.1",
+                "browser_backend": "basic",
+            }},
+        }))
+
+        with (
+            patch("src.cli.config.CONFIG_FILE", config_file),
+            patch("src.cli.config.AGENTS_FILE", agents_file),
+        ):
+            runner = CliRunner()
+            result = runner.invoke(
+                cli,
+                ["agent", "browser", "mybot"],
+                input="2\n",  # pick stealth
+            )
+            assert result.exit_code == 0, result.output
+            assert "->" in result.output
+
+    def test_change_browser_nonexistent_agent(self, tmp_path):
+        config_file = tmp_path / "mesh.yaml"
+        agents_file = tmp_path / "agents.yaml"
+        config_file.write_text(yaml.dump({"mesh": {}}))
+
+        with (
+            patch("src.cli.config.CONFIG_FILE", config_file),
+            patch("src.cli.config.AGENTS_FILE", agents_file),
+        ):
+            runner = CliRunner()
+            result = runner.invoke(cli, ["agent", "browser", "ghost", "stealth"])
+            assert "not found" in result.output
+
+    def test_change_browser_same_noop(self, tmp_path):
+        """Same browser should report no change."""
+        config_file = tmp_path / "mesh.yaml"
+        agents_file = tmp_path / "agents.yaml"
+
+        config_file.write_text(yaml.dump({
+            "mesh": {"host": "0.0.0.0", "port": 8420},
+        }))
+        agents_file.write_text(yaml.dump({
+            "agents": {"mybot": {
+                "role": "test",
+                "model": "openai/gpt-4.1",
+                "browser_backend": "basic",
+            }},
+        }))
+
+        with (
+            patch("src.cli.config.CONFIG_FILE", config_file),
+            patch("src.cli.config.AGENTS_FILE", agents_file),
+        ):
+            runner = CliRunner()
+            result = runner.invoke(
+                cli,
+                ["agent", "browser", "mybot", "basic"],
             )
             assert result.exit_code == 0
             assert "already uses" in result.output


### PR DESCRIPTION
## Summary
- **Fix terminal lag in detached mode**: Added `stdin=subprocess.DEVNULL` to `_start_detached()` — the root cause was the child process holding the terminal's stdin open
- **Add `agent browser` command**: Switch browser backends (basic/stealth/advanced) per agent, with interactive picker or direct argument
- **Add browser selection to `agent add`**: New `--browser` flag, interactive picker, and automatic Bright Data CDP URL prompt for advanced browser
- **Extract shared helpers**: `_pick_model_interactive()` and `_pick_browser_interactive()` in config.py — deduplicated across CLI commands and REPL
- **Improve REPL UX**: Better command descriptions, `/use` shows available agents on error, `/addkey` shows known service names, clearer help layout
- **723 tests passing** (18 CLI command tests, up from 9)

## Test plan
- [x] All 18 CLI command tests pass (add, add+model, add+browser, duplicate, model direct/interactive/nonexistent/noop, browser direct/interactive/nonexistent/noop, list, list empty, remove, remove nonexistent, chat no mesh, permissions default)
- [x] Full suite: 723 passed, 0 failures
- [ ] Manual: `openlegion start -d` no longer causes terminal lag
- [ ] Manual: `openlegion agent browser <name> stealth` updates config
- [ ] Manual: `openlegion agent add --browser advanced` prompts for Bright Data CDP URL

🤖 Generated with [Claude Code](https://claude.com/claude-code)