### PR TITLE
Fix stop crash and add interactive fallbacks to all commands

### DIFF
--- a/tests/test_cli_commands.py
+++ b/tests/test_cli_commands.py
@@ -196,6 +196,9 @@ class TestAgentModel:
         config_file = tmp_path / "mesh.yaml"
         agents_file = tmp_path / "agents.yaml"
         config_file.write_text(yaml.dump({"mesh": {}}))
+        agents_file.write_text(yaml.dump({
+            "agents": {"other": {"role": "test", "model": "openai/gpt-4.1"}},
+        }))
 
         with (
             patch("src.cli.config.CONFIG_FILE", config_file),
@@ -299,6 +302,9 @@ class TestAgentBrowser:
         config_file = tmp_path / "mesh.yaml"
         agents_file = tmp_path / "agents.yaml"
         config_file.write_text(yaml.dump({"mesh": {}}))
+        agents_file.write_text(yaml.dump({
+            "agents": {"other": {"role": "test", "model": "openai/gpt-4.1"}},
+        }))
 
         with (
             patch("src.cli.config.CONFIG_FILE", config_file),
@@ -413,6 +419,9 @@ class TestAgentRemove:
         config_file = tmp_path / "mesh.yaml"
         agents_file = tmp_path / "agents.yaml"
         config_file.write_text(yaml.dump({"mesh": {}}))
+        agents_file.write_text(yaml.dump({
+            "agents": {"other": {"role": "test"}},
+        }))
 
         with (
             patch("src.cli.config.CONFIG_FILE", config_file),


### PR DESCRIPTION
## Summary
- **Fix `stop` crash (404 NotFound)**: When `stop` sends SIGTERM to the host process, `ctx.shutdown()` already stops and removes all containers. By the time `stop` tried the Docker API, the containers were gone. Now waits for host process to exit (up to 10s), and wraps container.stop() in NotFound handler for any stragglers.
- **Interactive fallbacks for all commands**: Every command now works without arguments by prompting interactively:
  - `openlegion chat` — lists running agents, lets you pick one
  - `openlegion agent` — shows numbered action menu (list/add/model/browser/remove)
  - `openlegion agent model` — picks agent interactively, then model
  - `openlegion agent browser` — picks agent interactively, then browser
  - `openlegion agent remove` — picks agent interactively
- **Shared `_resolve_agent_name()` helper**: Deduplicates the "find agent or prompt" pattern across model/browser/remove commands

## Test plan
- [x] 723 tests passing, 18 CLI tests passing
- [ ] Manual: `openlegion stop` after `start -d` — no crash
- [ ] Manual: `openlegion chat` with no args — agent picker works
- [ ] Manual: `openlegion agent` with no subcommand — action menu works
- [ ] Manual: `openlegion agent model` with no args — picks agent then model

🤖 Generated with [Claude Code](https://claude.com/claude-code)