### PR TITLE
Redesign CLI and REPL UX: unified agent edit, grouped help

### DIFF
--- a/src/cli/__init__.py
+++ b/src/cli/__init__.py
@@ -19,14 +19,18 @@ from src.cli.config import (  # noqa: F401
     _check_docker_image,
     _check_docker_running,
     _create_agent,
+    _default_description,
+    _edit_agent_interactive,
     _get_default_model,
     _load_config,
     _load_permissions,
     _load_templates,
+    _prompt_brightdata_key,
     _save_permissions,
     _set_collaborative_permissions,
     _set_env_key,
     _setup_agent_wizard,
+    _update_agent_field,
 )
 from src.cli.formatting import _format_tool_result_hint, _format_tool_summary  # noqa: F401
 from src.cli.main import cli  # noqa: F401

--- a/tests/test_setup_wizard.py
+++ b/tests/test_setup_wizard.py
@@ -64,7 +64,7 @@ class TestSetupFull:
         """Full setup with piped input creates all config files."""
         project = _make_project(tmp_path)
 
-        # Input: provider=1 (anthropic), model=1, API key, project desc, agent name, description
+        # Input: provider=1 (anthropic), model=1, API key, project desc, agent name, description, browser
         piped_input = (
             "1\n"           # provider: Anthropic
             "1\n"           # model: first option
@@ -73,6 +73,7 @@ class TestSetupFull:
             "none\n"        # template: none (custom)
             "myagent\n"     # agent name
             "Test agent\n"  # agent description
+            "\n"            # browser: default (basic)
         )
 
         with _patch_all(project):
@@ -158,7 +159,7 @@ class TestSetupFull:
         """Invalid key on first attempt triggers retry, valid on second."""
         project = _make_project(tmp_path)
 
-        # Input: provider=1, model=1, bad key, good key, skip project, agent
+        # Input: provider=1, model=1, bad key, good key, skip project, agent, browser
         piped_input = (
             "1\n"                # provider
             "1\n"                # model
@@ -168,6 +169,7 @@ class TestSetupFull:
             "none\n"             # no template
             "bot\n"              # agent name
             "Test bot\n"         # agent description
+            "\n"                 # browser: default (basic)
         )
 
         call_count = {"n": 0}


### PR DESCRIPTION
## Summary
- Replace `agent model` + `agent browser` with unified `agent edit` command exposing 5 properties (model, browser, description, system prompt, budget) via flags or interactive picker
- Group REPL `/help` into Chat / Agents / System categories for discoverability
- Add `/edit` and `/remove` commands to the REPL with full lifecycle cleanup
- Add browser selection to the setup wizard
- Extract shared `_edit_agent_interactive` into `config.py` to eliminate duplication between CLI and REPL

## Test plan
- [x] All 721 tests pass (`pytest tests/ --ignore=tests/test_e2e*.py -x`)
- [x] `TestAgentEdit` covers flag mode, interactive mode, nonexistent agent, and no-change noop
- [x] Setup wizard tests updated for new browser prompt
- [x] `agent list` test verifies new Browser column
- [ ] Manual: `openlegion agent edit` — interactive picker flow
- [ ] Manual: `openlegion setup` — browser prompt during agent creation
- [ ] Manual: REPL `/help`, `/edit`, `/remove`

🤖 Generated with [Claude Code](https://claude.com/claude-code)