### PR TITLE
Live-apply REPL edits and silence health check log noise

### DIFF
--- a/src/host/health.py
+++ b/src/host/health.py
@@ -94,12 +94,13 @@ class HealthMonitor:
 
         health.consecutive_failures += 1
         health.status = "unhealthy"
-        logger.warning(
+        logger.debug(
             f"Agent '{agent_id}' health check failed "
             f"({health.consecutive_failures}/{self.MAX_FAILURES})"
         )
 
         if health.consecutive_failures >= self.MAX_FAILURES:
+            logger.warning(f"Agent '{agent_id}' unreachable, restarting...")
             await self._try_restart(agent_id)
 
     async def _try_restart(self, agent_id: str) -> None:


### PR DESCRIPTION
## Summary
- REPL `/edit` now auto-restarts the agent container so changes (model, browser, description, system prompt) take effect immediately — no manual restart
- Budget edits update the mesh cost tracker directly without container restart
- Fix budget field format: was writing `daily_budget` (ignored by runtime) instead of `budget: {daily_usd: ...}`
- Redirect host-side loggers to `.openlegion.log` during interactive REPL so JSON log lines don't interleave with chat output
- Health monitor intermediate failures (1/3, 2/3) demoted to DEBUG; only warns when actually restarting

## Test plan
- [x] All 721 tests pass
- [ ] Manual: `/edit` in REPL — change model, verify agent restarts and new model is active
- [ ] Manual: `/edit` budget — verify no restart, cost tracker updated
- [ ] Manual: `/broadcast` — verify no health check warnings in terminal
- [ ] Manual: Check `.openlegion.log` contains redirected host logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)