### PR TITLE
Add request tracing (Roadmap 4.2)

### DIFF
--- a/src/agent/llm.py
+++ b/src/agent/llm.py
@@ -60,11 +60,14 @@ class LLMClient:
 
         request = APIProxyRequest(service="llm", action="chat", params=params, timeout=120)
 
+        from src.shared.trace import trace_headers
+
         client = await self._get_client()
         response = await client.post(
             f"{self.mesh_url}/mesh/api",
             json=request.model_dump(mode="json"),
             params={"agent_id": self.agent_id},
+            headers=trace_headers(),
         )
         response.raise_for_status()
         data = response.json()
@@ -99,11 +102,14 @@ class LLMClient:
             params={"model": model or "text-embedding-3-small", "text": text},
             timeout=30,
         )
+        from src.shared.trace import trace_headers
+
         client = await self._get_client()
         response = await client.post(
             f"{self.mesh_url}/mesh/api",
             json=request.model_dump(mode="json"),
             params={"agent_id": self.agent_id},
+            headers=trace_headers(),
         )
         response.raise_for_status()
         data = response.json()

--- a/src/channels/base.py
+++ b/src/channels/base.py
@@ -163,9 +163,12 @@ class Channel(abc.ABC):
 
     async def dispatch(self, agent: str, message: str) -> str:
         """Route a message to an agent and return the response."""
+        from src.shared.trace import current_trace_id, new_trace_id
+
         target = agent or self.default_agent
         if not target:
             return "No agent specified and no default agent configured."
+        current_trace_id.set(new_trace_id())
         try:
             return await self.dispatch_fn(target, message)
         except Exception as e:

--- a/src/host/orchestrator.py
+++ b/src/host/orchestrator.py
@@ -303,11 +303,14 @@ class Orchestrator:
             )
 
         try:
+            from src.shared.trace import TRACE_HEADER, new_trace_id
+            step_trace_id = new_trace_id()
             client = await self._get_client()
             response = await client.post(
                 f"{agent_url}/task",
                 json=assignment.model_dump(mode="json"),
                 timeout=step.timeout,
+                headers={TRACE_HEADER: step_trace_id},
             )
             resp_data = response.json()
 

--- a/src/host/traces.py
+++ b/src/host/traces.py
@@ -1,0 +1,113 @@
+"""TraceStore — SQLite ring buffer for request trace events.
+
+Stores trace events (dispatch, LLM call, transport hop, etc.) keyed by
+trace_id.  Capped at *max_events* rows — oldest events are evicted after
+each insert.
+
+Follows the same SQLite-WAL pattern as ``CostTracker`` and ``Blackboard``.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+import time
+from pathlib import Path
+
+from src.shared.utils import setup_logging
+
+logger = setup_logging("host.traces")
+
+
+class TraceStore:
+    """SQLite-backed ring buffer for request trace events."""
+
+    def __init__(self, db_path: str = "data/traces.db", max_events: int = 10_000):
+        self.max_events = max_events
+        Path(db_path).parent.mkdir(parents=True, exist_ok=True)
+        self._conn = sqlite3.connect(db_path, check_same_thread=False)
+        self._conn.execute("PRAGMA journal_mode=WAL")
+        self._conn.execute("PRAGMA busy_timeout=5000")
+        self._conn.execute("""
+            CREATE TABLE IF NOT EXISTS traces (
+                id         INTEGER PRIMARY KEY AUTOINCREMENT,
+                trace_id   TEXT NOT NULL,
+                timestamp  REAL NOT NULL,
+                source     TEXT NOT NULL,
+                agent      TEXT NOT NULL DEFAULT '',
+                event_type TEXT NOT NULL,
+                detail     TEXT NOT NULL DEFAULT '',
+                duration_ms INTEGER NOT NULL DEFAULT 0
+            )
+        """)
+        self._conn.execute(
+            "CREATE INDEX IF NOT EXISTS idx_traces_trace_id ON traces (trace_id)"
+        )
+        self._conn.commit()
+
+    def record(
+        self,
+        trace_id: str,
+        source: str,
+        agent: str,
+        event_type: str,
+        detail: str = "",
+        duration_ms: int = 0,
+    ) -> None:
+        """Insert a trace event and evict overflow."""
+        self._conn.execute(
+            "INSERT INTO traces (trace_id, timestamp, source, agent, event_type, detail, duration_ms) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?)",
+            (trace_id, time.time(), source, agent, event_type, detail, duration_ms),
+        )
+        # Ring-buffer eviction: keep newest N rows regardless of ID gaps
+        self._conn.execute(
+            "DELETE FROM traces WHERE id NOT IN ("
+            "  SELECT id FROM traces ORDER BY id DESC LIMIT ?"
+            ")",
+            (self.max_events,),
+        )
+        self._conn.commit()
+
+    def get_trace(self, trace_id: str) -> list[dict]:
+        """Return all events for a given trace_id, ordered by time."""
+        cur = self._conn.execute(
+            "SELECT trace_id, timestamp, source, agent, event_type, detail, duration_ms "
+            "FROM traces WHERE trace_id = ? ORDER BY id",
+            (trace_id,),
+        )
+        return [
+            {
+                "trace_id": row[0],
+                "timestamp": row[1],
+                "source": row[2],
+                "agent": row[3],
+                "event_type": row[4],
+                "detail": row[5],
+                "duration_ms": row[6],
+            }
+            for row in cur.fetchall()
+        ]
+
+    def list_recent(self, limit: int = 50) -> list[dict]:
+        """Return the most recent trace events (newest first)."""
+        cur = self._conn.execute(
+            "SELECT trace_id, timestamp, source, agent, event_type, detail, duration_ms "
+            "FROM traces ORDER BY id DESC LIMIT ?",
+            (limit,),
+        )
+        return [
+            {
+                "trace_id": row[0],
+                "timestamp": row[1],
+                "source": row[2],
+                "agent": row[3],
+                "event_type": row[4],
+                "detail": row[5],
+                "duration_ms": row[6],
+            }
+            for row in cur.fetchall()
+        ]
+
+    def close(self) -> None:
+        """Close the database connection."""
+        self._conn.close()

--- a/src/shared/trace.py
+++ b/src/shared/trace.py
@@ -1,0 +1,31 @@
+"""Request tracing: trace-ID generation, contextvar propagation, header helpers.
+
+Every user message, cron tick, channel dispatch, and orchestrator step
+gets a unique trace ID (``tr_<hex12>``) that propagates through all hops
+via the ``X-Trace-Id`` HTTP header and a ``contextvars.ContextVar``.
+
+Separate module (not utils.py) to keep tracing concerns isolated and
+avoid import cycles.
+"""
+
+from __future__ import annotations
+
+import contextvars
+import uuid
+
+TRACE_HEADER = "X-Trace-Id"
+
+current_trace_id: contextvars.ContextVar[str | None] = contextvars.ContextVar(
+    "current_trace_id", default=None,
+)
+
+
+def new_trace_id() -> str:
+    """Generate a fresh trace ID: ``tr_<12-hex-chars>``."""
+    return f"tr_{uuid.uuid4().hex[:12]}"
+
+
+def trace_headers() -> dict[str, str]:
+    """Return headers dict with ``X-Trace-Id`` if one is active."""
+    tid = current_trace_id.get()
+    return {TRACE_HEADER: tid} if tid else {}

--- a/tests/test_traces.py
+++ b/tests/test_traces.py
@@ -1,0 +1,248 @@
+"""Tests for request tracing: TraceStore, contextvar, lane propagation, transport headers."""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import shutil
+import tempfile
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from src.host.traces import TraceStore
+from src.shared.trace import TRACE_HEADER, current_trace_id, new_trace_id, trace_headers
+
+
+# ── TraceStore ───────────────────────────────────────────────
+
+class TestTraceStore:
+    def setup_method(self):
+        self._tmpdir = tempfile.mkdtemp()
+        self.db_path = os.path.join(self._tmpdir, "traces.db")
+        self.store = TraceStore(db_path=self.db_path, max_events=100)
+
+    def teardown_method(self):
+        self.store.close()
+        shutil.rmtree(self._tmpdir, ignore_errors=True)
+
+    def test_record_and_retrieve(self):
+        tid = "tr_abc123"
+        self.store.record(tid, source="repl", agent="alpha", event_type="chat", detail="hello")
+        self.store.record(tid, source="mesh.api_proxy", agent="alpha", event_type="llm_call", detail="llm/chat")
+        events = self.store.get_trace(tid)
+        assert len(events) == 2
+        assert events[0]["trace_id"] == tid
+        assert events[0]["source"] == "repl"
+        assert events[0]["event_type"] == "chat"
+        assert events[1]["event_type"] == "llm_call"
+
+    def test_list_recent(self):
+        self.store.record("tr_001", "repl", "a", "chat", "first")
+        self.store.record("tr_002", "repl", "b", "chat", "second")
+        recent = self.store.list_recent(limit=10)
+        assert len(recent) == 2
+        # Newest first
+        assert recent[0]["trace_id"] == "tr_002"
+        assert recent[1]["trace_id"] == "tr_001"
+
+    def test_list_recent_respects_limit(self):
+        for i in range(10):
+            self.store.record(f"tr_{i:03d}", "repl", "a", "chat")
+        recent = self.store.list_recent(limit=3)
+        assert len(recent) == 3
+
+    def test_ring_buffer_eviction(self):
+        """Insert more than max_events and verify oldest are evicted."""
+        small_store = TraceStore(
+            db_path=os.path.join(self._tmpdir, "small.db"), max_events=5,
+        )
+        try:
+            for i in range(10):
+                small_store.record(f"tr_{i:03d}", "repl", "a", "chat", f"msg-{i}")
+            recent = small_store.list_recent(limit=100)
+            assert len(recent) <= 5
+            # Newest should still be present
+            trace_ids = {e["trace_id"] for e in recent}
+            assert "tr_009" in trace_ids
+            # Oldest should be evicted
+            assert "tr_000" not in trace_ids
+        finally:
+            small_store.close()
+
+    def test_get_trace_empty(self):
+        events = self.store.get_trace("tr_nonexistent")
+        assert events == []
+
+    def test_duration_ms_field(self):
+        self.store.record("tr_dur", "mesh", "a", "llm_call", duration_ms=150)
+        events = self.store.get_trace("tr_dur")
+        assert events[0]["duration_ms"] == 150
+
+
+# ── Contextvar + helpers ─────────────────────────────────────
+
+class TestTraceContextvar:
+    def test_default_is_none(self):
+        tok = current_trace_id.set(None)
+        try:
+            assert current_trace_id.get() is None
+        finally:
+            current_trace_id.reset(tok)
+
+    def test_set_and_get(self):
+        tid = new_trace_id()
+        tok = current_trace_id.set(tid)
+        try:
+            assert current_trace_id.get() == tid
+        finally:
+            current_trace_id.reset(tok)
+
+    def test_new_trace_id_format(self):
+        tid = new_trace_id()
+        assert tid.startswith("tr_")
+        assert len(tid) == 15  # "tr_" + 12 hex chars
+
+    def test_new_trace_id_unique(self):
+        ids = {new_trace_id() for _ in range(100)}
+        assert len(ids) == 100
+
+    def test_trace_headers_empty_when_no_trace(self):
+        tok = current_trace_id.set(None)
+        try:
+            assert trace_headers() == {}
+        finally:
+            current_trace_id.reset(tok)
+
+    def test_trace_headers_returns_header(self):
+        tid = "tr_abc123def456"
+        tok = current_trace_id.set(tid)
+        try:
+            hdrs = trace_headers()
+            assert hdrs == {TRACE_HEADER: tid}
+        finally:
+            current_trace_id.reset(tok)
+
+
+# ── Lane propagates trace_id ────────────────────────────────
+
+class TestLanePropagatesTraceId:
+    @pytest.mark.asyncio
+    async def test_worker_sets_contextvar(self):
+        """Verify the lane worker sets current_trace_id before dispatch."""
+        from src.host.lanes import LaneManager
+
+        captured_trace_ids = []
+
+        async def mock_dispatch(agent: str, message: str) -> str:
+            captured_trace_ids.append(current_trace_id.get())
+            return "ok"
+
+        lm = LaneManager(dispatch_fn=mock_dispatch)
+        tid = "tr_lane_test_01"
+        result = await lm.enqueue("alpha", "hello", trace_id=tid)
+        assert result == "ok"
+        assert captured_trace_ids == [tid]
+        await lm.stop()
+
+    @pytest.mark.asyncio
+    async def test_worker_sets_none_when_no_trace(self):
+        """Without trace_id, contextvar should be set to None."""
+        from src.host.lanes import LaneManager
+
+        captured = []
+
+        async def mock_dispatch(agent: str, message: str) -> str:
+            captured.append(current_trace_id.get())
+            return "ok"
+
+        lm = LaneManager(dispatch_fn=mock_dispatch)
+        await lm.enqueue("alpha", "hello")
+        assert captured == [None]
+        await lm.stop()
+
+
+# ── Transport injects trace header ──────────────────────────
+
+class TestTransportInjectsTraceHeader:
+    @pytest.mark.asyncio
+    async def test_http_transport_sends_trace_header(self):
+        """HttpTransport.request should include X-Trace-Id from contextvar."""
+        from src.host.transport import HttpTransport
+
+        t = HttpTransport()
+        t.register("alpha", "http://localhost:8401")
+
+        mock_response = MagicMock()
+        mock_response.json.return_value = {"status": "ok"}
+        mock_response.raise_for_status = MagicMock()
+
+        mock_client = AsyncMock()
+        mock_client.request = AsyncMock(return_value=mock_response)
+        mock_client.is_closed = False
+
+        t._clients[id(asyncio.get_running_loop())] = mock_client
+
+        tid = "tr_transport_01"
+        tok = current_trace_id.set(tid)
+        try:
+            result = await t.request("alpha", "GET", "/status")
+            assert result == {"status": "ok"}
+            call_kwargs = mock_client.request.call_args
+            headers = call_kwargs.kwargs.get("headers", {})
+            assert headers.get(TRACE_HEADER) == tid
+        finally:
+            current_trace_id.reset(tok)
+
+    @pytest.mark.asyncio
+    async def test_http_transport_explicit_headers_override(self):
+        """Explicit headers should take priority over contextvar."""
+        from src.host.transport import HttpTransport
+
+        t = HttpTransport()
+        t.register("alpha", "http://localhost:8401")
+
+        mock_response = MagicMock()
+        mock_response.json.return_value = {"status": "ok"}
+        mock_response.raise_for_status = MagicMock()
+
+        mock_client = AsyncMock()
+        mock_client.request = AsyncMock(return_value=mock_response)
+        mock_client.is_closed = False
+
+        t._clients[id(asyncio.get_running_loop())] = mock_client
+
+        tok = current_trace_id.set("tr_should_not_use")
+        try:
+            await t.request(
+                "alpha", "GET", "/status",
+                headers={TRACE_HEADER: "tr_explicit"},
+            )
+            call_kwargs = mock_client.request.call_args
+            headers = call_kwargs.kwargs.get("headers", {})
+            assert headers.get(TRACE_HEADER) == "tr_explicit"
+        finally:
+            current_trace_id.reset(tok)
+
+    def test_http_transport_sync_sends_trace_header(self):
+        """request_sync should also include X-Trace-Id."""
+        from src.host.transport import HttpTransport
+
+        t = HttpTransport()
+        t.register("alpha", "http://localhost:8401")
+
+        mock_response = MagicMock()
+        mock_response.json.return_value = {"status": "ok"}
+        mock_response.raise_for_status = MagicMock()
+
+        tid = "tr_sync_test_01"
+        tok = current_trace_id.set(tid)
+        try:
+            with patch("httpx.request", return_value=mock_response) as mock_req:
+                result = t.request_sync("alpha", "GET", "/status")
+                assert result == {"status": "ok"}
+                call_kwargs = mock_req.call_args
+                headers = call_kwargs.kwargs.get("headers", {})
+                assert headers.get(TRACE_HEADER) == tid
+        finally:
+            current_trace_id.reset(tok)


### PR DESCRIPTION
## Summary

- Assign a trace ID (`tr_<hex12>`) at every entry point (REPL, channels, cron, orchestrator) and propagate it through all hops via `X-Trace-Id` header + `contextvars.ContextVar`
- Store trace events in a SQLite ring buffer (`TraceStore`, 10k events) for debugging and cost attribution
- Add `/debug [trace_id]` REPL command and `GET /mesh/traces` endpoints for trace inspection

## Changes

**New files:**
- `src/shared/trace.py` — contextvar, `new_trace_id()`, `trace_headers()`
- `src/host/traces.py` — `TraceStore` (SQLite WAL, ring buffer eviction)
- `tests/test_traces.py` — 17 tests

**Modified (11 files):**
- `src/host/transport.py` — `headers` param on ABC + both implementations, `_resolve_headers()` on base class
- `src/host/lanes.py` — `trace_id` on `QueuedTask`, contextvar set in worker
- `src/host/server.py` — record LLM proxy events with `duration_ms`, `/mesh/traces` endpoints
- `src/host/orchestrator.py` — generate trace_id per workflow step
- `src/cli/runtime.py` — create/wire/close `TraceStore`, `trace_id` on dispatch methods
- `src/cli/repl.py` — trace_id at send/broadcast/steer, `/debug` command
- `src/channels/base.py` — trace_id in dispatch path
- `src/agent/server.py` — extract `X-Trace-Id` from request headers
- `src/agent/loop.py` — `trace_id` param on `execute_task`/`chat`/`chat_stream`
- `src/agent/llm.py` — forward trace headers in LLM proxy calls
- `src/agent/mesh_client.py` — forward trace headers in all mesh calls

## Test plan

- [x] 17 new trace tests pass (`test_traces.py`)
- [x] Full test suite passes (738 tests, 0 failures)
- [ ] Manual smoke test: `openlegion start` → send message → `/debug` → `/debug tr_<id>`

🤖 Generated with [Claude Code](https://claude.com/claude-code)