### PR TITLE
Add real-time web dashboard (roadmap 4.4)

### DIFF
--- a/src/dashboard/server.py
+++ b/src/dashboard/server.py
@@ -1,0 +1,170 @@
+"""Dashboard API router: fleet overview, costs, blackboard, traces.
+
+Serves the SPA template and static files, plus JSON API endpoints
+consumed by the Alpine.js frontend.  All data comes from live Python
+objects — no HTTP round-trips through mesh endpoints.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from fastapi import APIRouter, HTTPException
+from fastapi.responses import FileResponse, HTMLResponse
+from jinja2 import Environment, FileSystemLoader
+
+from src.shared.utils import setup_logging
+
+if TYPE_CHECKING:
+    from src.dashboard.events import EventBus
+    from src.host.costs import CostTracker
+    from src.host.health import HealthMonitor
+    from src.host.mesh import Blackboard
+    from src.host.traces import TraceStore
+
+logger = setup_logging("dashboard.server")
+
+_HERE = Path(__file__).resolve().parent
+_TEMPLATES_DIR = _HERE / "templates"
+_STATIC_DIR = _HERE / "static"
+
+
+def create_dashboard_router(
+    blackboard: Blackboard,
+    health_monitor: HealthMonitor | None,
+    cost_tracker: CostTracker,
+    trace_store: TraceStore | None,
+    event_bus: EventBus | None,
+    agent_registry: dict[str, str],
+    mesh_port: int = 8420,
+) -> APIRouter:
+    """Create the dashboard FastAPI router."""
+    router = APIRouter(prefix="/dashboard")
+
+    jinja_env = Environment(
+        loader=FileSystemLoader(str(_TEMPLATES_DIR)),
+        autoescape=True,
+    )
+
+    # ── SPA entry point ──────────────────────────────────────
+
+    @router.get("/", response_class=HTMLResponse)
+    async def dashboard_index() -> HTMLResponse:
+        template = jinja_env.get_template("index.html")
+        html = template.render(
+            ws_path="/ws/events",
+            api_base="/dashboard/api",
+        )
+        return HTMLResponse(html)
+
+    # ── Fleet overview ───────────────────────────────────────
+
+    @router.get("/api/agents")
+    async def api_agents() -> dict:
+        health_list = health_monitor.get_status() if health_monitor else []
+        health_map = {h["agent"]: h for h in health_list}
+        cost_list = cost_tracker.get_all_agents_spend("today")
+        cost_map = {c["agent"]: c for c in cost_list}
+
+        agents = []
+        for agent_id, url in agent_registry.items():
+            h = health_map.get(agent_id, {})
+            c = cost_map.get(agent_id, {})
+            agents.append({
+                "id": agent_id,
+                "url": url,
+                "health_status": h.get("status", "unknown"),
+                "failures": h.get("failures", 0),
+                "restarts": h.get("restarts", 0),
+                "last_check": h.get("last_check", 0),
+                "last_healthy": h.get("last_healthy", 0),
+                "daily_cost": c.get("cost", 0),
+                "daily_tokens": c.get("tokens", 0),
+            })
+        return {"agents": agents}
+
+    # ── Agent detail ─────────────────────────────────────────
+
+    @router.get("/api/agents/{agent_id}")
+    async def api_agent_detail(agent_id: str) -> dict:
+        if agent_id not in agent_registry:
+            raise HTTPException(status_code=404, detail="Agent not found")
+
+        url = agent_registry[agent_id]
+        health_list = health_monitor.get_status() if health_monitor else []
+        health = next((h for h in health_list if h["agent"] == agent_id), {})
+        spend_today = cost_tracker.get_spend(agent_id, "today")
+        spend_week = cost_tracker.get_spend(agent_id, "week")
+        budget = cost_tracker.check_budget(agent_id)
+
+        return {
+            "id": agent_id,
+            "url": url,
+            "health": health or {"status": "unknown"},
+            "spend_today": spend_today,
+            "spend_week": spend_week,
+            "budget": budget,
+        }
+
+    # ── Cost dashboard ───────────────────────────────────────
+
+    _VALID_PERIODS = {"today", "week", "month"}
+
+    @router.get("/api/costs")
+    async def api_costs(period: str = "today") -> dict:
+        if period not in _VALID_PERIODS:
+            period = "today"
+        agents_spend = cost_tracker.get_all_agents_spend(period)
+        budgets = {}
+        for item in agents_spend:
+            budgets[item["agent"]] = cost_tracker.check_budget(item["agent"])
+        return {"period": period, "agents": agents_spend, "budgets": budgets}
+
+    # ── Blackboard viewer ────────────────────────────────────
+
+    @router.get("/api/blackboard")
+    async def api_blackboard(prefix: str = "") -> dict:
+        entries = blackboard.list_by_prefix(prefix)
+        return {
+            "prefix": prefix,
+            "entries": [e.model_dump(mode="json") for e in entries],
+        }
+
+    # ── Trace inspector ──────────────────────────────────────
+
+    @router.get("/api/traces")
+    async def api_traces(limit: int = 50) -> dict:
+        if trace_store is None:
+            return {"traces": []}
+        limit = max(1, min(limit, 500))
+        return {"traces": trace_store.list_recent(limit)}
+
+    @router.get("/api/traces/{trace_id}")
+    async def api_trace_detail(trace_id: str) -> dict:
+        if trace_store is None:
+            raise HTTPException(status_code=404, detail="Trace store not configured")
+        events = trace_store.get_trace(trace_id)
+        if not events:
+            raise HTTPException(status_code=404, detail="Trace not found")
+        return {"trace_id": trace_id, "events": events}
+
+    # ── Static files ─────────────────────────────────────────
+
+    _MEDIA_TYPES = {
+        ".css": "text/css",
+        ".js": "application/javascript",
+        ".png": "image/png",
+        ".svg": "image/svg+xml",
+        ".ico": "image/x-icon",
+    }
+
+    @router.get("/static/{file_path:path}")
+    async def static_file(file_path: str) -> FileResponse:
+        full = (_STATIC_DIR / file_path).resolve()
+        if not str(full).startswith(str(_STATIC_DIR)) or not full.is_file():
+            raise HTTPException(status_code=404, detail="Not found")
+        suffix = full.suffix.lower()
+        return FileResponse(str(full), media_type=_MEDIA_TYPES.get(suffix))
+
+    return router

--- a/src/dashboard/static/css/dashboard.css
+++ b/src/dashboard/static/css/dashboard.css
@@ -1,0 +1,87 @@
+/* OpenLegion Dashboard — custom styles beyond Tailwind */
+
+/* Hide panels until Alpine.js initializes */
+[x-cloak] {
+  display: none !important;
+}
+
+/* Pulse animation for active agent cards */
+@keyframes pulse-border {
+  0%, 100% { border-color: rgba(99, 102, 241, 0.2); }
+  50% { border-color: rgba(99, 102, 241, 0.6); }
+}
+
+.pulse-border {
+  animation: pulse-border 2s ease-in-out infinite;
+}
+
+/* Event type badge — monospace pill */
+.event-badge {
+  font-family: ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, monospace;
+  font-size: 0.65rem;
+  letter-spacing: -0.02em;
+  white-space: nowrap;
+}
+
+/* Flash highlight for recent blackboard writes */
+@keyframes flash-yellow {
+  0% { background-color: rgba(234, 179, 8, 0.15); }
+  100% { background-color: transparent; }
+}
+
+.flash-yellow {
+  animation: flash-yellow 5s ease-out forwards;
+}
+
+/* Waterfall bar for trace inspector */
+.waterfall-bar {
+  position: relative;
+  height: 5px;
+  border-radius: 3px;
+  background: rgba(99, 102, 241, 0.4);
+  min-width: 4px;
+  transition: width 0.3s ease;
+}
+
+/* Dark scrollbar — WebKit */
+.custom-scrollbar::-webkit-scrollbar {
+  width: 5px;
+}
+
+.custom-scrollbar::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+.custom-scrollbar::-webkit-scrollbar-thumb {
+  background: rgba(55, 55, 75, 0.6);
+  border-radius: 3px;
+}
+
+.custom-scrollbar::-webkit-scrollbar-thumb:hover {
+  background: rgba(75, 75, 100, 0.8);
+}
+
+/* Dark scrollbar — Firefox */
+.custom-scrollbar {
+  scrollbar-width: thin;
+  scrollbar-color: rgba(55, 55, 75, 0.6) transparent;
+}
+
+/* Smooth transitions for panel switching */
+main > div {
+  animation: fade-in 0.15s ease-out;
+}
+
+@keyframes fade-in {
+  from { opacity: 0; transform: translateY(4px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+
+/* Keyboard focus — visible ring on tab-navigation only */
+button:focus-visible,
+input:focus-visible,
+[role="button"]:focus-visible {
+  outline: 2px solid rgba(99, 102, 241, 0.6);
+  outline-offset: 2px;
+  border-radius: 4px;
+}

--- a/src/dashboard/static/js/app.js
+++ b/src/dashboard/static/js/app.js
@@ -1,0 +1,429 @@
+/**
+ * OpenLegion Dashboard — Alpine.js application.
+ *
+ * Six panels: Fleet, Events, Agent Detail, Blackboard, Costs, Traces.
+ * Real-time updates via WebSocket + periodic REST polling.
+ */
+function dashboard() {
+  return {
+    // Navigation
+    activeTab: 'fleet',
+    tabs: [
+      { id: 'fleet', label: 'Fleet' },
+      { id: 'events', label: 'Events' },
+      { id: 'blackboard', label: 'Blackboard' },
+      { id: 'costs', label: 'Costs' },
+      { id: 'traces', label: 'Traces' },
+    ],
+    connected: false,
+    loading: true,
+    lastRefresh: 0,
+    unreadEvents: 0,
+    _lastSeenEventCount: 0,
+
+    // Fleet
+    agents: [],
+    agentStates: {},
+    _stateTimers: {},
+
+    // Events
+    events: [],
+    eventFilters: new Set(),
+    eventTypes: [
+      'agent_state', 'message_sent', 'message_received',
+      'tool_start', 'tool_result', 'llm_call',
+      'blackboard_write', 'cost_update', 'health_change',
+    ],
+
+    // Agent detail
+    selectedAgent: null,
+    agentDetail: null,
+    agentEvents: [],
+
+    // Blackboard
+    bbEntries: [],
+    bbPrefix: '',
+    bbHighlights: new Set(),
+    bbLoading: false,
+
+    // Costs
+    costData: {},
+    costPeriod: 'today',
+    costChart: null,
+    _costDebounce: null,
+
+    // Traces
+    traces: [],
+    selectedTraceId: null,
+    traceDetail: null,
+    tracesLoading: false,
+
+    // WebSocket
+    _ws: null,
+    _refreshInterval: null,
+    _fleetDebounce: null,
+
+    // ── Computed ───────────────────────────────────────────
+
+    get filteredEvents() {
+      if (this.eventFilters.size === 0) return this.events;
+      return this.events.filter(e => this.eventFilters.has(e.type));
+    },
+
+    get fleetTotalCost() {
+      return this.agents.reduce((sum, a) => sum + (a.daily_cost || 0), 0);
+    },
+
+    get fleetTotalTokens() {
+      return this.agents.reduce((sum, a) => sum + (a.daily_tokens || 0), 0);
+    },
+
+    get costTotal() {
+      return (this.costData.agents || []).reduce((sum, a) => sum + (a.cost || 0), 0);
+    },
+
+    // ── Lifecycle ─────────────────────────────────────────
+
+    init() {
+      const cfg = window.__config || {};
+      this._ws = new DashboardWebSocket(cfg.wsUrl, {
+        onEvent: (evt) => this.onWsEvent(evt),
+        onConnect: () => { this.connected = true; },
+        onDisconnect: () => { this.connected = false; },
+      });
+      this._ws.connect();
+
+      this.fetchAgents();
+      this._refreshInterval = setInterval(() => this.fetchAgents(), 15000);
+    },
+
+    destroy() {
+      if (this._ws) this._ws.disconnect();
+      if (this._refreshInterval) clearInterval(this._refreshInterval);
+      if (this._costDebounce) clearTimeout(this._costDebounce);
+      if (this._fleetDebounce) clearTimeout(this._fleetDebounce);
+      if (this.costChart) this.costChart.destroy();
+      Object.values(this._stateTimers).forEach(clearTimeout);
+    },
+
+    // ── Tab switching ─────────────────────────────────────
+
+    switchTab(tab) {
+      this.activeTab = tab;
+      if (tab === 'events') {
+        this.unreadEvents = 0;
+        this._lastSeenEventCount = this.events.length;
+      }
+      if (tab === 'blackboard') this.fetchBlackboard();
+      if (tab === 'costs') this.fetchCosts();
+      if (tab === 'traces') this.fetchTraces();
+    },
+
+    // ── WebSocket event handler ───────────────────────────
+
+    onWsEvent(evt) {
+      // Append to event feed (newest first, cap at 500)
+      this.events.unshift(evt);
+      if (this.events.length > 500) this.events.splice(500);
+
+      // Track unread events when not on Events tab
+      if (this.activeTab !== 'events') {
+        this.unreadEvents++;
+      }
+
+      // Update agent activity state
+      const agent = evt.agent;
+      if (agent) {
+        this._updateAgentState(agent, evt.type);
+
+        // Feed agent-detail events
+        if (this.selectedAgent === agent) {
+          this.agentEvents.unshift(evt);
+          if (this.agentEvents.length > 100) this.agentEvents.splice(100);
+        }
+      }
+
+      // Live-update fleet on cost/health changes (debounced)
+      if (evt.type === 'cost_update' || evt.type === 'health_change') {
+        this._debouncedFleetRefresh();
+      }
+
+      // Highlight blackboard writes
+      if (evt.type === 'blackboard_write' && evt.data && evt.data.key) {
+        this.bbHighlights.add(evt.data.key);
+        setTimeout(() => this.bbHighlights.delete(evt.data.key), 5000);
+        if (this.activeTab === 'blackboard') this.fetchBlackboard();
+      }
+
+      // Debounced cost panel refresh on cost updates
+      if (evt.type === 'cost_update' && this.activeTab === 'costs') {
+        if (this._costDebounce) clearTimeout(this._costDebounce);
+        this._costDebounce = setTimeout(() => this.fetchCosts(), 2000);
+      }
+    },
+
+    _updateAgentState(agent, eventType) {
+      const stateMap = {
+        llm_call: 'thinking',
+        tool_start: 'tool',
+        tool_result: 'thinking',
+        message_sent: 'thinking',
+        message_received: 'thinking',
+      };
+
+      const newState = stateMap[eventType];
+      if (newState) {
+        this.agentStates[agent] = newState;
+
+        // Reset to idle after 30s of no events
+        if (this._stateTimers[agent]) clearTimeout(this._stateTimers[agent]);
+        this._stateTimers[agent] = setTimeout(() => {
+          this.agentStates[agent] = 'idle';
+        }, 30000);
+      }
+    },
+
+    _debouncedFleetRefresh() {
+      if (this._fleetDebounce) clearTimeout(this._fleetDebounce);
+      this._fleetDebounce = setTimeout(() => this.fetchAgents(), 3000);
+    },
+
+    toggleEventFilter(type) {
+      if (this.eventFilters.has(type)) {
+        this.eventFilters.delete(type);
+      } else {
+        this.eventFilters.add(type);
+      }
+    },
+
+    // ── REST fetchers ─────────────────────────────────────
+
+    async fetchAgents() {
+      try {
+        const resp = await fetch(`${window.__config.apiBase}/agents`);
+        if (resp.ok) {
+          this.agents = (await resp.json()).agents;
+          this.lastRefresh = Date.now() / 1000;
+        }
+      } catch (_) {}
+      this.loading = false;
+    },
+
+    async fetchAgentDetail(agentId) {
+      this.agentDetail = null;
+      try {
+        const resp = await fetch(`${window.__config.apiBase}/agents/${agentId}`);
+        if (resp.ok) this.agentDetail = await resp.json();
+      } catch (_) {}
+    },
+
+    async fetchBlackboard() {
+      this.bbLoading = true;
+      try {
+        const resp = await fetch(`${window.__config.apiBase}/blackboard?prefix=${encodeURIComponent(this.bbPrefix)}`);
+        if (resp.ok) this.bbEntries = (await resp.json()).entries;
+      } catch (_) {}
+      this.bbLoading = false;
+    },
+
+    async fetchCosts() {
+      try {
+        const resp = await fetch(`${window.__config.apiBase}/costs?period=${this.costPeriod}`);
+        if (resp.ok) {
+          this.costData = await resp.json();
+          this.$nextTick(() => this.renderCostChart());
+        }
+      } catch (_) {}
+    },
+
+    async fetchTraces() {
+      this.tracesLoading = true;
+      try {
+        const resp = await fetch(`${window.__config.apiBase}/traces?limit=50`);
+        if (resp.ok) this.traces = (await resp.json()).traces;
+      } catch (_) {}
+      this.tracesLoading = false;
+    },
+
+    async fetchTraceDetail(traceId) {
+      this.selectedTraceId = traceId;
+      this.traceDetail = null;
+      try {
+        const resp = await fetch(`${window.__config.apiBase}/traces/${traceId}`);
+        if (resp.ok) this.traceDetail = await resp.json();
+      } catch (_) {}
+    },
+
+    // ── Agent drill-down ──────────────────────────────────
+
+    drillDown(agentId) {
+      this.selectedAgent = agentId;
+      this.agentEvents = this.events.filter(e => e.agent === agentId).slice(0, 100);
+      this.fetchAgentDetail(agentId);
+      this.activeTab = 'agent-detail';
+    },
+
+    // ── Chart.js rendering ────────────────────────────────
+
+    renderCostChart() {
+      const canvas = document.getElementById('costChart');
+      if (!canvas) return;
+      if (this.costChart) this.costChart.destroy();
+
+      const agents = (this.costData.agents || []);
+      if (agents.length === 0) {
+        this.costChart = null;
+        return;
+      }
+
+      const labels = agents.map(a => a.agent);
+      const costs = agents.map(a => a.cost);
+      const tokens = agents.map(a => a.tokens);
+
+      this.costChart = new Chart(canvas, {
+        type: 'bar',
+        data: {
+          labels,
+          datasets: [
+            {
+              label: 'Cost (USD)',
+              data: costs,
+              backgroundColor: 'rgba(99, 102, 241, 0.4)',
+              borderColor: 'rgb(99, 102, 241)',
+              borderWidth: 1,
+              borderRadius: 4,
+              yAxisID: 'y',
+            },
+            {
+              label: 'Tokens',
+              data: tokens,
+              backgroundColor: 'rgba(168, 85, 247, 0.25)',
+              borderColor: 'rgb(168, 85, 247)',
+              borderWidth: 1,
+              borderRadius: 4,
+              yAxisID: 'y1',
+            },
+          ],
+        },
+        options: {
+          responsive: true,
+          maintainAspectRatio: false,
+          interaction: { mode: 'index', intersect: false },
+          plugins: {
+            legend: {
+              labels: { color: '#6b7280', usePointStyle: true, pointStyleWidth: 8, font: { size: 11 } },
+            },
+          },
+          scales: {
+            x: {
+              ticks: { color: '#4b5563', font: { size: 11 } },
+              grid: { color: 'rgba(31, 41, 55, 0.5)' },
+            },
+            y: {
+              position: 'left',
+              title: { display: true, text: 'Cost (USD)', color: '#6b7280', font: { size: 11 } },
+              ticks: { color: '#4b5563', font: { size: 10 } },
+              grid: { color: 'rgba(31, 41, 55, 0.5)' },
+            },
+            y1: {
+              position: 'right',
+              title: { display: true, text: 'Tokens', color: '#6b7280', font: { size: 11 } },
+              ticks: { color: '#4b5563', font: { size: 10 } },
+              grid: { drawOnChartArea: false },
+            },
+          },
+        },
+      });
+    },
+
+    // ── Formatting helpers ────────────────────────────────
+
+    eventColor(type) {
+      const map = {
+        agent_state: 'text-blue-400',
+        message_sent: 'text-green-400',
+        message_received: 'text-green-400',
+        tool_start: 'text-amber-400',
+        tool_result: 'text-amber-400',
+        llm_call: 'text-purple-400',
+        blackboard_write: 'text-cyan-400',
+        cost_update: 'text-rose-400',
+        health_change: 'text-red-400',
+      };
+      return map[type] || 'text-gray-400';
+    },
+
+    eventBgColor(type) {
+      const map = {
+        agent_state: 'bg-blue-400',
+        message_sent: 'bg-green-400',
+        message_received: 'bg-green-400',
+        tool_start: 'bg-amber-400',
+        tool_result: 'bg-amber-400',
+        llm_call: 'bg-purple-400',
+        blackboard_write: 'bg-cyan-400',
+        cost_update: 'bg-rose-400',
+        health_change: 'bg-red-400',
+        chat: 'bg-green-400',
+      };
+      return map[type] || 'bg-gray-400';
+    },
+
+    eventSummary(evt) {
+      const d = evt.data || {};
+      switch (evt.type) {
+        case 'llm_call':
+          return `model=${d.model || '?'} tokens=${d.total_tokens || '?'}`;
+        case 'tool_start':
+          return `${d.tool || d.name || '?'}(${(d.preview || '').substring(0, 60)})`;
+        case 'tool_result':
+          return `${d.tool || d.name || '?'} \u2192 ${(d.preview || d.result || '').substring(0, 60)}`;
+        case 'message_sent':
+        case 'message_received':
+          return (d.message || '').substring(0, 80);
+        case 'cost_update':
+          return `$${(d.cost_usd || 0).toFixed(4)} (${d.model || '?'})`;
+        case 'health_change':
+          return `${d.previous || '?'} \u2192 ${d.current || '?'}`;
+        case 'blackboard_write':
+          return d.key || '';
+        default:
+          return JSON.stringify(d).substring(0, 80);
+      }
+    },
+
+    timeAgo(ts) {
+      if (!ts) return '';
+      const now = Date.now() / 1000;
+      const diff = now - ts;
+      if (diff < 0) return 'just now';
+      if (diff < 5) return 'just now';
+      if (diff < 60) return Math.floor(diff) + 's ago';
+      if (diff < 3600) return Math.floor(diff / 60) + 'm ago';
+      if (diff < 86400) return Math.floor(diff / 3600) + 'h ago';
+      return Math.floor(diff / 86400) + 'd ago';
+    },
+
+    formatCost(usd) {
+      if (usd === 0 || usd == null) return '$0.00';
+      if (usd < 0.01) return '$' + usd.toFixed(4);
+      return '$' + usd.toFixed(2);
+    },
+
+    truncateJson(value) {
+      const s = JSON.stringify(value);
+      if (s.length <= 120) return s;
+      return s.substring(0, 117) + '\u2026';
+    },
+
+    waterfall(evt, allEvents) {
+      if (!allEvents || allEvents.length < 2) return '';
+      const minTs = allEvents[0].timestamp;
+      const maxTs = allEvents[allEvents.length - 1].timestamp;
+      const span = maxTs - minTs || 1;
+      const left = ((evt.timestamp - minTs) / span) * 100;
+      const width = Math.max(2, (evt.duration_ms / 1000 / span) * 100);
+      return `left:${left.toFixed(1)}%;width:${Math.min(width, 100 - left).toFixed(1)}%`;
+    },
+  };
+}

--- a/src/dashboard/static/js/websocket.js
+++ b/src/dashboard/static/js/websocket.js
@@ -1,0 +1,70 @@
+/**
+ * DashboardWebSocket — auto-reconnecting WebSocket client.
+ *
+ * Exponential backoff: 1s, 2s, 4s ... up to 30s max.
+ * Resets backoff on successful connection.
+ */
+class DashboardWebSocket {
+  constructor(url, { onEvent, onConnect, onDisconnect }) {
+    this.url = url;
+    this._onEvent = onEvent;
+    this._onConnect = onConnect;
+    this._onDisconnect = onDisconnect;
+    this._ws = null;
+    this._backoff = 1000;
+    this._maxBackoff = 30000;
+    this._intentionalClose = false;
+    this._timer = null;
+  }
+
+  connect() {
+    this._intentionalClose = false;
+    try {
+      this._ws = new WebSocket(this.url);
+    } catch (e) {
+      this._scheduleReconnect();
+      return;
+    }
+
+    this._ws.onopen = () => {
+      this._backoff = 1000;
+      if (this._onConnect) this._onConnect();
+    };
+
+    this._ws.onmessage = (e) => {
+      try {
+        const data = JSON.parse(e.data);
+        if (this._onEvent) this._onEvent(data);
+      } catch (_) {}
+    };
+
+    this._ws.onclose = () => {
+      if (this._onDisconnect) this._onDisconnect();
+      if (!this._intentionalClose) this._scheduleReconnect();
+    };
+
+    this._ws.onerror = () => {
+      // onclose will fire after onerror
+    };
+  }
+
+  disconnect() {
+    this._intentionalClose = true;
+    if (this._timer) {
+      clearTimeout(this._timer);
+      this._timer = null;
+    }
+    if (this._ws) {
+      this._ws.close();
+      this._ws = null;
+    }
+  }
+
+  _scheduleReconnect() {
+    this._timer = setTimeout(() => {
+      this._timer = null;
+      this.connect();
+    }, this._backoff);
+    this._backoff = Math.min(this._backoff * 2, this._maxBackoff);
+  }
+}

--- a/src/dashboard/templates/index.html
+++ b/src/dashboard/templates/index.html
@@ -1,0 +1,506 @@
+<!DOCTYPE html>
+<html lang="en" class="dark">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>OpenLegion Dashboard</title>
+
+  <!-- Tailwind CSS -->
+  <script src="https://cdn.tailwindcss.com"></script>
+  <script>
+    tailwind.config = {
+      darkMode: 'class',
+      theme: {
+        extend: {
+          colors: {
+            gray: {
+              950: '#0a0a0f',
+              900: '#111118',
+              850: '#16161f',
+              800: '#1e1e2a',
+              700: '#2a2a3a',
+              600: '#3a3a4f',
+            }
+          },
+          fontFamily: {
+            mono: ['ui-monospace', 'SFMono-Regular', '"SF Mono"', 'Menlo', 'Consolas', 'monospace'],
+          }
+        }
+      }
+    }
+  </script>
+
+  <!-- Chart.js -->
+  <script src="https://cdn.jsdelivr.net/npm/chart.js@4"></script>
+
+  <!-- Custom CSS -->
+  <link rel="stylesheet" href="/dashboard/static/css/dashboard.css">
+</head>
+<body class="bg-gray-950 text-gray-100 min-h-screen">
+  <script>
+    window.__config = {
+      wsUrl: (location.protocol === 'https:' ? 'wss://' : 'ws://') + location.host + "{{ ws_path }}",
+      apiBase: "{{ api_base }}"
+    };
+  </script>
+
+  <div x-data="dashboard()" x-init="init()" class="flex flex-col h-screen">
+
+    <!-- Navigation bar -->
+    <nav class="bg-gray-900 border-b border-gray-800 px-4 py-2.5 flex items-center justify-between shrink-0">
+      <div class="flex items-center gap-5">
+        <div class="flex items-center gap-2">
+          <div class="w-2 h-2 rounded-full bg-indigo-500"></div>
+          <span class="text-base font-bold text-white tracking-tight">OpenLegion</span>
+        </div>
+        <div class="flex gap-0.5 bg-gray-800/50 rounded-lg p-0.5">
+          <template x-for="tab in tabs" :key="tab.id">
+            <button
+              @click="switchTab(tab.id)"
+              :class="activeTab === tab.id
+                ? 'bg-gray-700 text-white shadow-sm'
+                : 'text-gray-400 hover:text-gray-200 hover:bg-gray-800/70'"
+              class="px-3 py-1.5 rounded-md text-sm font-medium transition-all relative"
+            >
+              <span x-text="tab.label"></span>
+              <!-- Unread event count badge -->
+              <span
+                x-show="tab.id === 'events' && unreadEvents > 0 && activeTab !== 'events'"
+                x-text="unreadEvents >= 100 ? '99+' : unreadEvents"
+                class="absolute -top-1 -right-1 bg-indigo-500 text-white text-[10px] font-bold rounded-full min-w-[16px] h-4 flex items-center justify-center px-1"
+                x-cloak
+              ></span>
+            </button>
+          </template>
+        </div>
+      </div>
+      <div class="flex items-center gap-4">
+        <!-- Fleet total cost -->
+        <div class="text-xs text-gray-400 hidden sm:block" x-show="fleetTotalCost > 0">
+          Fleet today: <span class="text-gray-200 font-medium" x-text="formatCost(fleetTotalCost)"></span>
+        </div>
+        <!-- Connection indicator -->
+        <div class="flex items-center gap-1.5 text-xs">
+          <span class="relative flex h-2 w-2">
+            <span :class="connected ? 'bg-green-400' : 'bg-red-400'" class="animate-ping absolute inline-flex h-full w-full rounded-full opacity-75" x-show="connected"></span>
+            <span :class="connected ? 'bg-green-400' : 'bg-red-400'" class="relative inline-flex rounded-full h-2 w-2"></span>
+          </span>
+          <span :class="connected ? 'text-green-400' : 'text-red-400'" x-text="connected ? 'Live' : 'Disconnected'"></span>
+        </div>
+      </div>
+    </nav>
+
+    <!-- Main content -->
+    <main class="flex-1 overflow-auto p-4 lg:p-6">
+
+      <!-- Fleet Overview -->
+      <div x-show="activeTab === 'fleet'" x-cloak>
+        <!-- Fleet summary bar -->
+        <div class="flex items-center justify-between mb-4" x-show="agents.length > 0">
+          <h2 class="text-sm font-medium text-gray-400">
+            <span x-text="agents.length"></span> agent<span x-show="agents.length !== 1">s</span>
+            <span class="text-gray-600 mx-1">&middot;</span>
+            <span x-text="formatCost(fleetTotalCost)"></span> today
+            <span class="text-gray-600 mx-1">&middot;</span>
+            <span x-text="fleetTotalTokens.toLocaleString()"></span> tokens
+          </h2>
+          <div class="text-xs text-gray-600" x-text="'Updated ' + timeAgo(lastRefresh)"></div>
+        </div>
+        <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-4">
+          <template x-for="agent in agents" :key="agent.id">
+            <div
+              @click="drillDown(agent.id)"
+              class="bg-gray-900 border border-gray-800 rounded-lg p-4 cursor-pointer hover:border-gray-600 transition-all hover:shadow-lg hover:shadow-black/20 group"
+              :class="agentStates[agent.id] === 'thinking' || agentStates[agent.id] === 'tool' ? 'pulse-border' : ''"
+            >
+              <div class="flex items-center justify-between mb-3">
+                <div class="flex items-center gap-2">
+                  <span class="font-semibold text-white group-hover:text-indigo-300 transition-colors" x-text="agent.id"></span>
+                </div>
+                <span
+                  class="text-[11px] px-2 py-0.5 rounded-full font-medium"
+                  :class="{
+                    'bg-green-900/40 text-green-400 border border-green-800/50': agent.health_status === 'healthy',
+                    'bg-yellow-900/40 text-yellow-400 border border-yellow-800/50': agent.health_status === 'unhealthy' || agent.health_status === 'restarting',
+                    'bg-red-900/40 text-red-400 border border-red-800/50': agent.health_status === 'failed',
+                    'bg-gray-800/60 text-gray-500 border border-gray-700/50': agent.health_status === 'unknown',
+                  }"
+                  x-text="agent.health_status"
+                ></span>
+              </div>
+              <div class="space-y-2 text-xs">
+                <div class="flex justify-between items-center">
+                  <span class="text-gray-500">Activity</span>
+                  <span class="event-badge font-medium"
+                    :class="{
+                      'text-purple-400': agentStates[agent.id] === 'thinking',
+                      'text-amber-400': agentStates[agent.id] === 'tool',
+                      'text-gray-600': agentStates[agent.id] === 'idle' || !agentStates[agent.id],
+                    }"
+                    x-text="agentStates[agent.id] || 'idle'"
+                  ></span>
+                </div>
+                <div class="flex justify-between items-center">
+                  <span class="text-gray-500">Cost today</span>
+                  <span class="text-gray-200 font-mono text-[11px]" x-text="formatCost(agent.daily_cost)"></span>
+                </div>
+                <div class="flex justify-between items-center">
+                  <span class="text-gray-500">Tokens</span>
+                  <span class="text-gray-200 font-mono text-[11px]" x-text="agent.daily_tokens.toLocaleString()"></span>
+                </div>
+                <div class="flex justify-between items-center" x-show="agent.restarts > 0">
+                  <span class="text-gray-500">Restarts</span>
+                  <span class="text-yellow-400 font-mono text-[11px]" x-text="agent.restarts"></span>
+                </div>
+              </div>
+            </div>
+          </template>
+        </div>
+        <!-- Loading state -->
+        <div x-show="agents.length === 0 && loading" class="text-center py-16" x-cloak>
+          <div class="inline-flex items-center gap-2 text-gray-500">
+            <svg class="animate-spin h-4 w-4" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24"><circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle><path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z"></path></svg>
+            Loading fleet...
+          </div>
+        </div>
+        <!-- Empty state -->
+        <div x-show="agents.length === 0 && !loading" class="text-center py-16" x-cloak>
+          <div class="text-gray-600 text-lg mb-1">No agents registered</div>
+          <div class="text-gray-700 text-sm">Start agents with <code class="bg-gray-800 px-1.5 py-0.5 rounded text-gray-400">openlegion start</code></div>
+        </div>
+      </div>
+
+      <!-- Events Feed -->
+      <div x-show="activeTab === 'events'" x-cloak>
+        <div class="flex items-center justify-between mb-3">
+          <div class="flex gap-1.5 flex-wrap">
+            <template x-for="etype in eventTypes" :key="etype">
+              <button
+                @click="toggleEventFilter(etype)"
+                class="text-[11px] px-2 py-1 rounded-md border transition-all"
+                :class="eventFilters.has(etype)
+                  ? 'border-indigo-500/60 bg-indigo-900/20 text-indigo-300'
+                  : 'border-gray-800 text-gray-600 hover:text-gray-400 hover:border-gray-700'"
+                x-text="etype"
+              ></button>
+            </template>
+            <button
+              x-show="eventFilters.size > 0"
+              @click="eventFilters.clear()"
+              class="text-[11px] px-2 py-1 rounded-md text-gray-600 hover:text-gray-400"
+            >Clear</button>
+          </div>
+          <span class="text-xs text-gray-600" x-text="filteredEvents.length + ' events'"></span>
+        </div>
+        <div class="space-y-1 max-h-[calc(100vh-10rem)] overflow-y-auto custom-scrollbar">
+          <template x-for="(evt, i) in filteredEvents" :key="i">
+            <div class="bg-gray-900/70 border border-gray-800/60 rounded-md px-3 py-2 flex items-start gap-3 text-sm hover:bg-gray-900 transition-colors">
+              <span class="event-badge shrink-0 mt-0.5" :class="eventColor(evt.type)" x-text="evt.type"></span>
+              <span class="text-gray-500 shrink-0 w-20 truncate" x-text="evt.agent || '-'"></span>
+              <span class="text-gray-300 truncate flex-1" x-text="eventSummary(evt)"></span>
+              <span class="text-gray-700 text-xs shrink-0 font-mono" x-text="timeAgo(evt.timestamp)"></span>
+            </div>
+          </template>
+          <!-- Empty state -->
+          <div x-show="filteredEvents.length === 0" class="text-center py-16">
+            <div class="text-gray-600 text-lg mb-1">No events yet</div>
+            <div class="text-gray-700 text-sm">Events appear in real-time as agents work</div>
+          </div>
+        </div>
+      </div>
+
+      <!-- Agent Detail -->
+      <div x-show="activeTab === 'agent-detail'" x-cloak>
+        <button @click="switchTab('fleet')" class="text-sm text-gray-500 hover:text-gray-300 mb-4 flex items-center gap-1 transition-colors">
+          <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 19l-7-7 7-7"/></svg>
+          Back to fleet
+        </button>
+        <!-- Loading -->
+        <div x-show="!agentDetail && selectedAgent" class="text-center py-12" x-cloak>
+          <div class="inline-flex items-center gap-2 text-gray-500">
+            <svg class="animate-spin h-4 w-4" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24"><circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle><path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z"></path></svg>
+            Loading...
+          </div>
+        </div>
+        <template x-if="agentDetail">
+          <div>
+            <div class="flex items-center gap-3 mb-5">
+              <h2 class="text-xl font-bold" x-text="agentDetail.id"></h2>
+              <span
+                class="text-[11px] px-2 py-0.5 rounded-full font-medium"
+                :class="{
+                  'bg-green-900/40 text-green-400 border border-green-800/50': agentDetail.health?.status === 'healthy',
+                  'bg-yellow-900/40 text-yellow-400 border border-yellow-800/50': agentDetail.health?.status === 'unhealthy',
+                  'bg-red-900/40 text-red-400 border border-red-800/50': agentDetail.health?.status === 'failed',
+                  'bg-gray-800/60 text-gray-500 border border-gray-700/50': !agentDetail.health?.status || agentDetail.health?.status === 'unknown',
+                }"
+                x-text="agentDetail.health?.status || 'unknown'"
+              ></span>
+              <span class="text-xs text-gray-600 font-mono" x-text="agentDetail.url"></span>
+            </div>
+            <div class="grid grid-cols-1 md:grid-cols-3 gap-4 mb-5">
+              <!-- Spend today card -->
+              <div class="bg-gray-900 border border-gray-800 rounded-lg p-4">
+                <div class="text-xs text-gray-500 uppercase tracking-wider mb-2">Spend Today</div>
+                <div class="text-2xl font-bold font-mono" x-text="formatCost(agentDetail.spend_today?.total_cost || 0)"></div>
+                <div class="text-xs text-gray-500 mt-1" x-text="(agentDetail.spend_today?.total_tokens || 0).toLocaleString() + ' tokens'"></div>
+              </div>
+              <!-- Spend this week card -->
+              <div class="bg-gray-900 border border-gray-800 rounded-lg p-4">
+                <div class="text-xs text-gray-500 uppercase tracking-wider mb-2">Spend This Week</div>
+                <div class="text-2xl font-bold font-mono" x-text="formatCost(agentDetail.spend_week?.total_cost || 0)"></div>
+                <div class="text-xs text-gray-500 mt-1" x-text="(agentDetail.spend_week?.total_tokens || 0).toLocaleString() + ' tokens'"></div>
+              </div>
+              <!-- Health card -->
+              <div class="bg-gray-900 border border-gray-800 rounded-lg p-4">
+                <div class="text-xs text-gray-500 uppercase tracking-wider mb-2">Health</div>
+                <div class="space-y-1.5 text-sm">
+                  <div class="flex justify-between">
+                    <span class="text-gray-500">Failures</span>
+                    <span class="font-mono" x-text="agentDetail.health?.failures || 0"></span>
+                  </div>
+                  <div class="flex justify-between">
+                    <span class="text-gray-500">Restarts</span>
+                    <span class="font-mono" x-text="agentDetail.health?.restarts || 0"></span>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <!-- Budget bar -->
+            <div class="bg-gray-900 border border-gray-800 rounded-lg p-4 mb-5">
+              <div class="text-xs text-gray-500 uppercase tracking-wider mb-3">Budget</div>
+              <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+                <div>
+                  <div class="flex justify-between text-sm mb-1.5">
+                    <span class="text-gray-400">Daily</span>
+                    <span class="font-mono text-xs" x-text="formatCost(agentDetail.budget?.daily_used || 0) + ' / ' + formatCost(agentDetail.budget?.daily_limit || 0)"></span>
+                  </div>
+                  <div class="w-full bg-gray-800 rounded-full h-1.5">
+                    <div class="h-1.5 rounded-full transition-all duration-500"
+                      :class="(agentDetail.budget?.daily_used || 0) / (agentDetail.budget?.daily_limit || 1) > 0.8 ? 'bg-red-500' : 'bg-indigo-500'"
+                      :style="'width:' + Math.min(100, ((agentDetail.budget?.daily_used || 0) / (agentDetail.budget?.daily_limit || 1)) * 100) + '%'"
+                    ></div>
+                  </div>
+                </div>
+                <div>
+                  <div class="flex justify-between text-sm mb-1.5">
+                    <span class="text-gray-400">Monthly</span>
+                    <span class="font-mono text-xs" x-text="formatCost(agentDetail.budget?.monthly_used || 0) + ' / ' + formatCost(agentDetail.budget?.monthly_limit || 0)"></span>
+                  </div>
+                  <div class="w-full bg-gray-800 rounded-full h-1.5">
+                    <div class="h-1.5 rounded-full transition-all duration-500"
+                      :class="(agentDetail.budget?.monthly_used || 0) / (agentDetail.budget?.monthly_limit || 1) > 0.8 ? 'bg-red-500' : 'bg-indigo-500'"
+                      :style="'width:' + Math.min(100, ((agentDetail.budget?.monthly_used || 0) / (agentDetail.budget?.monthly_limit || 1)) * 100) + '%'"
+                    ></div>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <!-- Recent events for this agent -->
+            <div class="bg-gray-900 border border-gray-800 rounded-lg p-4">
+              <div class="flex items-center justify-between mb-3">
+                <div class="text-xs text-gray-500 uppercase tracking-wider">Recent Events</div>
+                <span class="text-xs text-gray-700" x-text="agentEvents.length + ' events'"></span>
+              </div>
+              <div class="space-y-1 max-h-72 overflow-y-auto custom-scrollbar">
+                <template x-for="(evt, i) in agentEvents" :key="i">
+                  <div class="flex items-center gap-2 text-sm py-1.5 border-b border-gray-800/30 last:border-0">
+                    <span class="event-badge" :class="eventColor(evt.type)" x-text="evt.type"></span>
+                    <span class="text-gray-300 truncate flex-1" x-text="eventSummary(evt)"></span>
+                    <span class="text-gray-700 text-xs ml-auto shrink-0 font-mono" x-text="timeAgo(evt.timestamp)"></span>
+                  </div>
+                </template>
+                <div x-show="agentEvents.length === 0" class="text-gray-600 text-sm py-4 text-center">No recent events for this agent</div>
+              </div>
+            </div>
+          </div>
+        </template>
+      </div>
+
+      <!-- Blackboard -->
+      <div x-show="activeTab === 'blackboard'" x-cloak>
+        <div class="mb-4 flex gap-2">
+          <input
+            type="text"
+            x-model="bbPrefix"
+            @keyup.enter="fetchBlackboard()"
+            placeholder="Filter by prefix (e.g. tasks/, context/, signals/)"
+            class="bg-gray-900 border border-gray-800 rounded-lg px-3 py-2 text-sm flex-1 focus:outline-none focus:border-gray-600 focus:ring-1 focus:ring-gray-600 placeholder-gray-700 transition-colors"
+          >
+          <button @click="fetchBlackboard()" class="bg-gray-800 hover:bg-gray-700 px-4 py-2 rounded-lg text-sm font-medium transition-colors">Search</button>
+        </div>
+        <div class="bg-gray-900 border border-gray-800 rounded-lg overflow-hidden">
+          <div class="overflow-x-auto">
+            <table class="w-full text-sm">
+              <thead>
+                <tr class="text-gray-500 text-left text-xs uppercase tracking-wider border-b border-gray-800">
+                  <th class="py-3 px-4">Key</th>
+                  <th class="py-3 px-4">Value</th>
+                  <th class="py-3 px-4">Written By</th>
+                  <th class="py-3 px-4">Updated</th>
+                  <th class="py-3 px-4">Ver</th>
+                </tr>
+              </thead>
+              <tbody>
+                <template x-for="entry in bbEntries" :key="entry.key">
+                  <tr class="border-b border-gray-800/40 hover:bg-gray-800/30 transition-colors"
+                    :class="bbHighlights.has(entry.key) ? 'flash-yellow' : ''">
+                    <td class="py-2.5 px-4 font-mono text-xs text-blue-400" x-text="entry.key"></td>
+                    <td class="py-2.5 px-4 max-w-md">
+                      <span class="text-gray-300 text-xs font-mono truncate block" x-text="truncateJson(entry.value)"></span>
+                    </td>
+                    <td class="py-2.5 px-4 text-gray-500" x-text="entry.written_by"></td>
+                    <td class="py-2.5 px-4 text-gray-600 text-xs font-mono" x-text="entry.updated_at"></td>
+                    <td class="py-2.5 px-4 text-gray-600 font-mono" x-text="entry.version"></td>
+                  </tr>
+                </template>
+              </tbody>
+            </table>
+          </div>
+          <!-- Loading -->
+          <div x-show="bbEntries.length === 0 && bbLoading" class="text-center py-12" x-cloak>
+            <div class="inline-flex items-center gap-2 text-gray-600">
+              <svg class="animate-spin h-4 w-4" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24"><circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle><path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z"></path></svg>
+              Loading...
+            </div>
+          </div>
+          <!-- Empty state -->
+          <div x-show="bbEntries.length === 0 && !bbLoading" class="text-center py-12" x-cloak>
+            <div class="text-gray-600 mb-1">No entries found</div>
+            <div class="text-gray-700 text-xs">Try a broader prefix or leave empty for all entries</div>
+          </div>
+        </div>
+      </div>
+
+      <!-- Costs -->
+      <div x-show="activeTab === 'costs'" x-cloak>
+        <div class="flex items-center justify-between mb-4">
+          <div class="flex gap-0.5 bg-gray-800/50 rounded-lg p-0.5">
+            <template x-for="p in ['today', 'week', 'month']" :key="p">
+              <button
+                @click="costPeriod = p; fetchCosts()"
+                class="px-3 py-1.5 rounded-md text-sm font-medium transition-all"
+                :class="costPeriod === p ? 'bg-gray-700 text-white shadow-sm' : 'text-gray-500 hover:text-gray-300'"
+                x-text="p.charAt(0).toUpperCase() + p.slice(1)"
+              ></button>
+            </template>
+          </div>
+          <div class="text-sm text-gray-400" x-show="costData.agents && costData.agents.length > 0">
+            Total: <span class="text-white font-mono font-medium" x-text="formatCost(costTotal)"></span>
+          </div>
+        </div>
+        <div class="grid grid-cols-1 lg:grid-cols-2 gap-4">
+          <div class="bg-gray-900 border border-gray-800 rounded-lg p-4">
+            <div class="h-72" x-show="costData.agents && costData.agents.length > 0">
+              <canvas id="costChart"></canvas>
+            </div>
+            <div x-show="!costData.agents || costData.agents.length === 0" class="flex items-center justify-center h-72 text-gray-600">
+              No cost data for this period
+            </div>
+          </div>
+          <div class="bg-gray-900 border border-gray-800 rounded-lg p-4">
+            <div class="text-xs text-gray-500 uppercase tracking-wider mb-4">Budget Status</div>
+            <div class="space-y-4">
+              <template x-for="item in costData.agents || []" :key="item.agent">
+                <div>
+                  <div class="flex justify-between text-sm mb-1">
+                    <span class="text-white font-medium" x-text="item.agent"></span>
+                    <div class="flex items-center gap-3">
+                      <span class="text-gray-500 text-xs font-mono" x-text="item.tokens.toLocaleString() + ' tok'"></span>
+                      <span class="text-gray-300 font-mono text-xs" x-text="formatCost(item.cost)"></span>
+                    </div>
+                  </div>
+                  <div x-show="costData.budgets && costData.budgets[item.agent]">
+                    <div class="w-full bg-gray-800 rounded-full h-1.5">
+                      <div class="h-1.5 rounded-full transition-all duration-500"
+                        :class="item.cost / (costData.budgets?.[item.agent]?.daily_limit || 1) > 0.8 ? 'bg-red-500' : 'bg-indigo-500'"
+                        :style="'width:' + Math.min(100, (item.cost / (costData.budgets?.[item.agent]?.daily_limit || 1)) * 100) + '%'"
+                      ></div>
+                    </div>
+                    <div class="text-[10px] text-gray-700 mt-1 font-mono" x-text="formatCost(item.cost) + ' / ' + formatCost(costData.budgets?.[item.agent]?.daily_limit || 0) + ' daily'"></div>
+                  </div>
+                </div>
+              </template>
+              <div x-show="!costData.agents || costData.agents.length === 0" class="text-gray-600 text-sm py-4 text-center">Budgets appear once agents incur costs</div>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <!-- Traces -->
+      <div x-show="activeTab === 'traces'" x-cloak>
+        <div class="grid grid-cols-1 lg:grid-cols-2 gap-4">
+          <!-- Trace list -->
+          <div class="bg-gray-900 border border-gray-800 rounded-lg p-4">
+            <div class="flex items-center justify-between mb-3">
+              <div class="text-xs text-gray-500 uppercase tracking-wider">Recent Traces</div>
+              <span class="text-xs text-gray-700" x-text="traces.length + ' events'"></span>
+            </div>
+            <div class="space-y-0.5 max-h-[calc(100vh-14rem)] overflow-y-auto custom-scrollbar">
+              <template x-for="t in traces" :key="t.trace_id + t.timestamp">
+                <div
+                  @click="fetchTraceDetail(t.trace_id)"
+                  class="flex items-center gap-2 px-2.5 py-2 rounded-md cursor-pointer text-sm transition-all"
+                  :class="selectedTraceId === t.trace_id ? 'bg-gray-800 border border-gray-700' : 'hover:bg-gray-800/50'"
+                >
+                  <span class="font-mono text-blue-400/80 text-xs" x-text="t.trace_id.substring(0, 12)"></span>
+                  <span class="text-gray-500 text-xs" x-text="t.agent"></span>
+                  <span class="event-badge text-[10px]" :class="eventColor(t.event_type)" x-text="t.event_type"></span>
+                  <span class="text-gray-700 text-xs ml-auto font-mono" x-text="timeAgo(t.timestamp)"></span>
+                </div>
+              </template>
+              <!-- Loading -->
+              <div x-show="traces.length === 0 && tracesLoading" class="text-center py-8" x-cloak>
+                <div class="inline-flex items-center gap-2 text-gray-600 text-sm">
+                  <svg class="animate-spin h-4 w-4" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24"><circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle><path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z"></path></svg>
+                  Loading...
+                </div>
+              </div>
+              <!-- Empty state -->
+              <div x-show="traces.length === 0 && !tracesLoading" class="text-center py-8" x-cloak>
+                <div class="text-gray-600 text-sm">No traces recorded yet</div>
+              </div>
+            </div>
+          </div>
+          <!-- Trace detail -->
+          <div class="bg-gray-900 border border-gray-800 rounded-lg p-4">
+            <div class="text-xs text-gray-500 uppercase tracking-wider mb-3">
+              Trace <span class="font-mono text-blue-400 normal-case" x-text="selectedTraceId || ''"></span>
+            </div>
+            <template x-if="traceDetail && traceDetail.events">
+              <div class="space-y-0 max-h-[calc(100vh-14rem)] overflow-y-auto custom-scrollbar">
+                <template x-for="(evt, i) in traceDetail.events" :key="i">
+                  <div class="relative pl-6 border-l-2 border-gray-800 pb-3 last:pb-0">
+                    <div class="absolute left-[-5px] top-1.5 w-2 h-2 rounded-full" :class="eventBgColor(evt.event_type)"></div>
+                    <div class="flex items-center gap-2 text-sm">
+                      <span class="event-badge" :class="eventColor(evt.event_type)" x-text="evt.event_type"></span>
+                      <span class="text-gray-500 text-xs" x-text="evt.source"></span>
+                      <span x-show="evt.duration_ms > 0" class="text-gray-600 text-xs font-mono" x-text="evt.duration_ms + 'ms'"></span>
+                    </div>
+                    <div class="text-xs text-gray-500 mt-0.5" x-show="evt.agent" x-text="evt.agent"></div>
+                    <div class="text-xs text-gray-600 mt-0.5 font-mono" x-text="evt.detail" x-show="evt.detail"></div>
+                    <template x-if="evt.duration_ms > 0 && traceDetail.events.length > 1">
+                      <div class="waterfall-bar mt-1.5"
+                        :style="waterfall(evt, traceDetail.events)"
+                      ></div>
+                    </template>
+                  </div>
+                </template>
+              </div>
+            </template>
+            <div x-show="!traceDetail" class="text-center py-12 text-gray-700 text-sm">
+              Select a trace to inspect its event timeline
+            </div>
+          </div>
+        </div>
+      </div>
+
+    </main>
+  </div>
+
+  <!-- Alpine.js (deferred) -->
+  <script defer src="https://cdn.jsdelivr.net/npm/alpinejs@3.14.8/dist/cdn.min.js"></script>
+  <script src="/dashboard/static/js/websocket.js"></script>
+  <script src="/dashboard/static/js/app.js"></script>
+</body>
+</html>

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -1,0 +1,369 @@
+"""Tests for the dashboard API router."""
+
+from __future__ import annotations
+
+import os
+import shutil
+import tempfile
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from src.dashboard.events import EventBus
+from src.host.costs import CostTracker
+from src.host.health import HealthMonitor
+from src.host.mesh import Blackboard
+from src.host.traces import TraceStore
+
+
+def _make_components(tmp_path: str) -> dict:
+    """Create all dashboard dependencies with tmp-dir databases."""
+    bb = Blackboard(db_path=os.path.join(tmp_path, "bb.db"))
+    cost_tracker = CostTracker(db_path=os.path.join(tmp_path, "costs.db"))
+    trace_store = TraceStore(db_path=os.path.join(tmp_path, "traces.db"))
+    event_bus = EventBus()
+    agent_registry: dict[str, str] = {
+        "alpha": "http://localhost:8401",
+        "beta": "http://localhost:8402",
+    }
+
+    # Minimal health monitor with mocked runtime/transport/router
+    from unittest.mock import MagicMock
+
+    runtime_mock = MagicMock()
+    transport_mock = MagicMock()
+    router_mock = MagicMock()
+    health_monitor = HealthMonitor(
+        runtime=runtime_mock, transport=transport_mock, router=router_mock,
+    )
+    health_monitor.register("alpha")
+    health_monitor.register("beta")
+    health_monitor.agents["alpha"].status = "healthy"
+    health_monitor.agents["beta"].status = "unknown"
+
+    return {
+        "blackboard": bb,
+        "health_monitor": health_monitor,
+        "cost_tracker": cost_tracker,
+        "trace_store": trace_store,
+        "event_bus": event_bus,
+        "agent_registry": agent_registry,
+    }
+
+
+def _make_client(components: dict) -> TestClient:
+    """Build a TestClient with the dashboard router mounted."""
+    from src.dashboard.server import create_dashboard_router
+
+    router = create_dashboard_router(**components, mesh_port=8420)
+    app = FastAPI()
+    app.include_router(router)
+    return TestClient(app)
+
+
+class TestDashboardIndex:
+    def setup_method(self):
+        self._tmpdir = tempfile.mkdtemp()
+        self.components = _make_components(self._tmpdir)
+        self.client = _make_client(self.components)
+
+    def teardown_method(self):
+        self.components["cost_tracker"].close()
+        self.components["trace_store"].close()
+        self.components["blackboard"].close()
+        shutil.rmtree(self._tmpdir, ignore_errors=True)
+
+    def test_dashboard_index_serves_html(self):
+        resp = self.client.get("/dashboard/")
+        assert resp.status_code == 200
+        assert "text/html" in resp.headers["content-type"]
+        assert "window.__config" in resp.text
+        # WebSocket URL is derived from window.location at runtime;
+        # the template injects only the path.
+        assert "/ws/events" in resp.text
+        assert "/dashboard/api" in resp.text
+
+    def test_static_css_served(self):
+        resp = self.client.get("/dashboard/static/css/dashboard.css")
+        assert resp.status_code == 200
+        assert "pulse-border" in resp.text
+
+    def test_static_js_served(self):
+        resp = self.client.get("/dashboard/static/js/app.js")
+        assert resp.status_code == 200
+        assert "dashboard" in resp.text
+
+    def test_static_websocket_js_served(self):
+        resp = self.client.get("/dashboard/static/js/websocket.js")
+        assert resp.status_code == 200
+        assert "DashboardWebSocket" in resp.text
+
+    def test_static_nonexistent_returns_404(self):
+        resp = self.client.get("/dashboard/static/js/nonexistent.js")
+        assert resp.status_code == 404
+
+    def test_static_path_traversal_blocked(self):
+        resp = self.client.get("/dashboard/static/../../server.py")
+        assert resp.status_code == 404
+
+
+class TestDashboardAgentsAPI:
+    def setup_method(self):
+        self._tmpdir = tempfile.mkdtemp()
+        self.components = _make_components(self._tmpdir)
+        self.client = _make_client(self.components)
+
+    def teardown_method(self):
+        self.components["cost_tracker"].close()
+        self.components["trace_store"].close()
+        self.components["blackboard"].close()
+        shutil.rmtree(self._tmpdir, ignore_errors=True)
+
+    def test_api_agents_returns_fleet(self):
+        resp = self.client.get("/dashboard/api/agents")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert "agents" in data
+        assert len(data["agents"]) == 2
+        ids = {a["id"] for a in data["agents"]}
+        assert ids == {"alpha", "beta"}
+
+    def test_api_agents_includes_all_fields(self):
+        resp = self.client.get("/dashboard/api/agents")
+        data = resp.json()
+        agent = data["agents"][0]
+        expected_fields = {
+            "id", "url", "health_status", "failures", "restarts",
+            "last_check", "last_healthy", "daily_cost", "daily_tokens",
+        }
+        assert expected_fields.issubset(agent.keys())
+
+    def test_api_agents_includes_health(self):
+        resp = self.client.get("/dashboard/api/agents")
+        data = resp.json()
+        alpha = next(a for a in data["agents"] if a["id"] == "alpha")
+        assert alpha["health_status"] == "healthy"
+        beta = next(a for a in data["agents"] if a["id"] == "beta")
+        assert beta["health_status"] == "unknown"
+
+    def test_api_agents_includes_costs(self):
+        self.components["cost_tracker"].track("alpha", "openai/gpt-4o-mini", 500, 100)
+        resp = self.client.get("/dashboard/api/agents")
+        data = resp.json()
+        alpha = next(a for a in data["agents"] if a["id"] == "alpha")
+        assert alpha["daily_cost"] > 0
+        assert alpha["daily_tokens"] > 0
+
+    def test_api_agents_empty_registry(self):
+        self.components["agent_registry"].clear()
+        resp = self.client.get("/dashboard/api/agents")
+        data = resp.json()
+        assert data["agents"] == []
+
+
+class TestDashboardAgentDetail:
+    def setup_method(self):
+        self._tmpdir = tempfile.mkdtemp()
+        self.components = _make_components(self._tmpdir)
+        self.client = _make_client(self.components)
+
+    def teardown_method(self):
+        self.components["cost_tracker"].close()
+        self.components["trace_store"].close()
+        self.components["blackboard"].close()
+        shutil.rmtree(self._tmpdir, ignore_errors=True)
+
+    def test_api_agent_detail_found(self):
+        resp = self.client.get("/dashboard/api/agents/alpha")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["id"] == "alpha"
+        assert data["url"] == "http://localhost:8401"
+        assert "health" in data
+        assert "spend_today" in data
+        assert "spend_week" in data
+        assert "budget" in data
+
+    def test_api_agent_detail_health_data(self):
+        resp = self.client.get("/dashboard/api/agents/alpha")
+        data = resp.json()
+        assert data["health"]["status"] == "healthy"
+        assert "failures" in data["health"]
+        assert "restarts" in data["health"]
+
+    def test_api_agent_detail_budget_data(self):
+        self.components["cost_tracker"].set_budget("alpha", daily_usd=5.0, monthly_usd=100.0)
+        resp = self.client.get("/dashboard/api/agents/alpha")
+        data = resp.json()
+        assert data["budget"]["daily_limit"] == 5.0
+        assert data["budget"]["monthly_limit"] == 100.0
+        assert data["budget"]["allowed"] is True
+
+    def test_api_agent_detail_not_found(self):
+        resp = self.client.get("/dashboard/api/agents/nonexistent")
+        assert resp.status_code == 404
+
+
+class TestDashboardCosts:
+    def setup_method(self):
+        self._tmpdir = tempfile.mkdtemp()
+        self.components = _make_components(self._tmpdir)
+        self.client = _make_client(self.components)
+
+    def teardown_method(self):
+        self.components["cost_tracker"].close()
+        self.components["trace_store"].close()
+        self.components["blackboard"].close()
+        shutil.rmtree(self._tmpdir, ignore_errors=True)
+
+    def test_api_costs_today(self):
+        self.components["cost_tracker"].track("alpha", "openai/gpt-4o-mini", 1000, 200)
+        resp = self.client.get("/dashboard/api/costs?period=today")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["period"] == "today"
+        assert len(data["agents"]) >= 1
+        assert data["agents"][0]["agent"] == "alpha"
+        assert data["agents"][0]["cost"] > 0
+        assert data["agents"][0]["tokens"] > 0
+
+    def test_api_costs_week(self):
+        self.components["cost_tracker"].track("beta", "openai/gpt-4o", 500, 100)
+        resp = self.client.get("/dashboard/api/costs?period=week")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["period"] == "week"
+        assert len(data["agents"]) >= 1
+
+    def test_api_costs_with_budgets(self):
+        self.components["cost_tracker"].set_budget("alpha", daily_usd=5.0, monthly_usd=100.0)
+        self.components["cost_tracker"].track("alpha", "openai/gpt-4o-mini", 1000, 200)
+        resp = self.client.get("/dashboard/api/costs?period=today")
+        data = resp.json()
+        assert "budgets" in data
+        assert "alpha" in data["budgets"]
+        assert data["budgets"]["alpha"]["daily_limit"] == 5.0
+        assert data["budgets"]["alpha"]["allowed"] is True
+
+    def test_api_costs_invalid_period_defaults_to_today(self):
+        """Invalid period parameter silently defaults to 'today'."""
+        self.components["cost_tracker"].track("alpha", "openai/gpt-4o-mini", 500, 100)
+        resp = self.client.get("/dashboard/api/costs?period=invalid")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["period"] == "today"
+
+    def test_api_costs_empty(self):
+        resp = self.client.get("/dashboard/api/costs?period=today")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["agents"] == []
+
+
+class TestDashboardBlackboard:
+    def setup_method(self):
+        self._tmpdir = tempfile.mkdtemp()
+        self.components = _make_components(self._tmpdir)
+        self.client = _make_client(self.components)
+
+    def teardown_method(self):
+        self.components["cost_tracker"].close()
+        self.components["trace_store"].close()
+        self.components["blackboard"].close()
+        shutil.rmtree(self._tmpdir, ignore_errors=True)
+
+    def test_api_blackboard_with_entries(self):
+        self.components["blackboard"].write("test/key1", {"val": 1}, written_by="alpha")
+        self.components["blackboard"].write("test/key2", {"val": 2}, written_by="beta")
+        resp = self.client.get("/dashboard/api/blackboard?prefix=test/")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["prefix"] == "test/"
+        assert len(data["entries"]) == 2
+
+    def test_api_blackboard_entry_fields(self):
+        self.components["blackboard"].write("test/key1", {"val": 42}, written_by="alpha")
+        resp = self.client.get("/dashboard/api/blackboard?prefix=test/")
+        data = resp.json()
+        entry = data["entries"][0]
+        assert entry["key"] == "test/key1"
+        assert entry["value"] == {"val": 42}
+        assert entry["written_by"] == "alpha"
+        assert "updated_at" in entry
+        assert entry["version"] == 1
+
+    def test_api_blackboard_empty(self):
+        resp = self.client.get("/dashboard/api/blackboard?prefix=nothing/")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["entries"] == []
+
+    def test_api_blackboard_all_entries(self):
+        """Empty prefix returns all entries."""
+        self.components["blackboard"].write("a/1", {"v": 1}, written_by="alpha")
+        self.components["blackboard"].write("b/2", {"v": 2}, written_by="beta")
+        resp = self.client.get("/dashboard/api/blackboard?prefix=")
+        data = resp.json()
+        assert len(data["entries"]) == 2
+
+
+class TestDashboardTraces:
+    def setup_method(self):
+        self._tmpdir = tempfile.mkdtemp()
+        self.components = _make_components(self._tmpdir)
+        self.client = _make_client(self.components)
+
+    def teardown_method(self):
+        self.components["cost_tracker"].close()
+        self.components["trace_store"].close()
+        self.components["blackboard"].close()
+        shutil.rmtree(self._tmpdir, ignore_errors=True)
+
+    def test_api_traces_list(self):
+        ts = self.components["trace_store"]
+        ts.record(trace_id="tr_abc", source="dispatch", agent="alpha", event_type="chat", detail="hello")
+        ts.record(trace_id="tr_abc", source="llm", agent="alpha", event_type="llm_call", duration_ms=150)
+        resp = self.client.get("/dashboard/api/traces?limit=50")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert len(data["traces"]) == 2
+
+    def test_api_traces_limit_respected(self):
+        ts = self.components["trace_store"]
+        for i in range(10):
+            ts.record(trace_id=f"tr_{i}", source="test", agent="alpha", event_type="chat")
+        resp = self.client.get("/dashboard/api/traces?limit=3")
+        data = resp.json()
+        assert len(data["traces"]) == 3
+
+    def test_api_traces_limit_clamped(self):
+        """Negative limit gets clamped to 1."""
+        ts = self.components["trace_store"]
+        ts.record(trace_id="tr_x", source="test", agent="alpha", event_type="chat")
+        resp = self.client.get("/dashboard/api/traces?limit=-5")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert len(data["traces"]) >= 1
+
+    def test_api_traces_detail(self):
+        ts = self.components["trace_store"]
+        ts.record(trace_id="tr_abc", source="dispatch", agent="alpha", event_type="chat", detail="hello")
+        ts.record(trace_id="tr_abc", source="llm", agent="alpha", event_type="llm_call", duration_ms=150)
+        resp = self.client.get("/dashboard/api/traces/tr_abc")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["trace_id"] == "tr_abc"
+        assert len(data["events"]) == 2
+        # Verify event fields
+        evt = data["events"][0]
+        assert "trace_id" in evt
+        assert "timestamp" in evt
+        assert "source" in evt
+        assert "agent" in evt
+        assert "event_type" in evt
+        assert "detail" in evt
+        assert "duration_ms" in evt
+
+    def test_api_traces_not_found(self):
+        resp = self.client.get("/dashboard/api/traces/nonexistent")
+        assert resp.status_code == 404


### PR DESCRIPTION
## Summary
- Adds a real-time web dashboard served at `/dashboard` from the existing mesh server
- Six panels: Fleet overview, Events feed (live WebSocket), Agent detail drill-down, Blackboard viewer, Cost dashboard (Chart.js), Trace inspector with waterfall timeline
- Alpine.js + Tailwind CSS + Chart.js via CDN — zero new Python dependencies, no build step
- WebSocket URL derived from `window.location` for remote access; HealthMonitor lifecycle moved earlier so dashboard router can reference it at construction time

## Test plan
- [x] 29 dashboard-specific tests pass (index HTML, static files, path traversal, all 6 API endpoints with edge cases)
- [x] Full suite: 795 tests pass, no regressions
- [ ] Manual smoke test: `openlegion start` → open `http://localhost:8420/dashboard`
  - Fleet tab shows agent cards with health/cost/activity
  - Events tab shows real-time events via WebSocket
  - Blackboard tab lists entries with prefix filter
  - Costs tab renders Chart.js bar chart + budget bars
  - Traces tab shows waterfall timeline on click

🤖 Generated with [Claude Code](https://claude.com/claude-code)