### PR TITLE
Fix missing runtime deps in installer

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -178,7 +178,7 @@ echo -e "  ${YELLOW}First install takes 2-3 minutes (downloads ~70 packages).${N
 echo -e "  ${YELLOW}Subsequent installs are fast (cached).${NC}"
 echo ""
 
-"$VENV_BIN_DIR/pip" install -e ".[dev]" 2>&1 | while IFS= read -r line; do
+"$VENV_BIN_DIR/pip" install -e ".[dev,channels]" 2>&1 | while IFS= read -r line; do
     # Show download/install progress, skip noise
     case "$line" in
         *Collecting*|*Downloading*|*Installing*|*Building*|*Successfully*)
@@ -193,7 +193,7 @@ if [ ! -x "$VENV_BIN_DIR/openlegion" ] && [ ! -x "$VENV_BIN_DIR/openlegion.exe" 
     echo ""
     warn "Install may have failed. Retrying with full output..."
     echo ""
-    "$VENV_BIN_DIR/pip" install -e ".[dev]"
+    "$VENV_BIN_DIR/pip" install -e ".[dev,channels]"
 fi
 
 echo ""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ requires-python = ">=3.11"
 
 dependencies = [
     "fastapi>=0.115.0",
-    "uvicorn>=0.32.0",
+    "uvicorn[standard]>=0.32.0",
     "httpx>=0.28.0",
     "pydantic>=2.10.0",
     "litellm>=1.60.0",


### PR DESCRIPTION
## Summary
- Changed `uvicorn>=0.32.0` to `uvicorn[standard]>=0.32.0` in core dependencies — pulls in `websockets`, `uvloop`, and `httptools` needed for the EventBus WebSocket endpoint and dashboard live updates
- Changed `install.sh` to install `.[dev,channels]` instead of `.[dev]` — Telegram, Discord, and Slack libraries now install by default

## Test plan
- [x] 795 tests pass, no regressions
- [ ] Fresh VM: `./install.sh` → `openlegion setup` → `openlegion start` — no WebSocket warning, Telegram `/start` works

🤖 Generated with [Claude Code](https://claude.com/claude-code)