### PR TITLE
Fix spawn health, channel /steer + /debug, dashboard V2 polish

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ OpenLegion was designed from day one assuming agents will be compromised.
 | **Cost controls** | None | Per-agent daily + monthly budget caps |
 | **Multi-agent routing** | LLM CEO agent | Deterministic YAML DAG workflows |
 | **LLM providers** | Broad | 100+ via LiteLLM with health-tracked failover |
-| **Test coverage** | Minimal | 717 tests including full Docker E2E |
+| **Test coverage** | Minimal | 745+ tests including full Docker E2E |
 | **Codebase size** | 430,000+ lines | ~14,000 lines — auditable in a day |
 
 ---
@@ -131,7 +131,7 @@ Chat with your agent fleet via **Telegram**, **Discord**, or CLI. Agents act aut
 via cron schedules, webhooks, heartbeat monitoring, and file watchers — without being
 prompted.
 
-**717 tests passing** across **~14,000 lines** of application code.
+**745+ tests passing** across **~14,000 lines** of application code.
 **Fully auditable in a day.**
 No LangChain. No Redis. No Kubernetes. No CEO agent. MIT License.
 
@@ -156,11 +156,13 @@ No LangChain. No Redis. No Kubernetes. No CEO agent. MIT License.
 
 7. **Multi-channel** — connect agents to Telegram, Discord, Slack, and WhatsApp. Also accessible via CLI and API.
 
-8. **Tracks and caps spend** — per-agent LLM cost tracking with daily and monthly budget enforcement.
+8. **Real-time dashboard** — web-based fleet observability at `/dashboard` with live event streaming, agent management, cost charts, trace timelines, and cron management.
 
-9. **Runs deterministic workflows** — YAML-defined DAG workflows chain agents in sequence with conditions, retries, and failure handlers.
+9. **Tracks and caps spend** — per-agent LLM cost tracking with daily and monthly budget enforcement.
 
-10. **Fails over across providers** — configurable model failover chains cascade across LLM providers with per-model health tracking and exponential cooldown.
+10. **Runs deterministic workflows** — YAML-defined DAG workflows chain agents in sequence with conditions, retries, and failure handlers.
+
+11. **Fails over across providers** — configurable model failover chains cascade across LLM providers with per-model health tracking and exponential cooldown.
 
 ---
 
@@ -795,7 +797,7 @@ pytest tests/
 | Memory Store | 34 | SQLite ops, vector search, categories, hierarchical search, tool outcomes |
 | Context Manager | 31 | Token estimation (tiktoken + model-aware), compaction, flushing |
 | Mesh | 31 | Blackboard, PubSub, MessageRouter, permissions |
-| Channels (base) | 30 | Abstract channel, commands, per-user routing, chunking |
+| Channels (base) | 37 | Abstract channel, commands, per-user routing, chunking, steer, debug |
 | Orchestrator | 25 | Workflows, conditions, retries, failures |
 | Integration | 25 | Multi-component mesh operations |
 | Cron | 25 | Cron expressions, intervals, dispatch, persistence |
@@ -823,8 +825,10 @@ pytest tests/
 | Memory Integration | 6 | Vector search, cross-task recall, salience |
 | Marketplace | 20 | Install, manifest parsing, validation, path traversal, remove |
 | Subagent | 11 | Spawn, depth/concurrent limits, TTL timeout, skill cloning, memory isolation |
+| Health Monitor | 4 | Ephemeral cleanup, TTL expiry, event emission |
+| Dashboard | 57 | Index, agents, blackboard, costs, traces, queues, cron, settings, config |
 | E2E | 17 | Container health, workflow, chat, memory, triggering |
-| **Total** | **734** | |
+| **Total** | **802** | |
 
 ---
 
@@ -849,7 +853,7 @@ pytest tests/
 
 Dev: pytest, pytest-asyncio, ruff.
 
-No LangChain. No Redis. No Kubernetes. No web UI.
+No LangChain. No Redis. No Kubernetes. Real-time web dashboard at `/dashboard`.
 
 ---
 
@@ -901,6 +905,11 @@ src/
 │   ├── slack.py                        # Slack adapter (Socket Mode)
 │   ├── whatsapp.py                     # WhatsApp Cloud API adapter
 │   └── webhook.py                      # Workflow trigger webhook adapter
+├── dashboard/
+│   ├── server.py                       # Dashboard FastAPI router + API
+│   ├── events.py                       # EventBus for real-time streaming
+│   ├── templates/index.html            # Dashboard UI (Alpine.js + Tailwind)
+│   └── static/                         # CSS + JS assets
 └── templates/
     ├── starter.yaml                    # Single-agent template
     ├── sales.yaml                      # Sales pipeline team

--- a/docs/README.md
+++ b/docs/README.md
@@ -14,6 +14,7 @@ Comprehensive documentation for the OpenLegion multi-agent runtime.
 | [Workflows](workflows.md) | DAG-based orchestration, step dependencies, conditions |
 | [Configuration](configuration.md) | All config files, environment variables, agent definitions |
 | [Channels](channels.md) | Telegram, Discord, and webhook channel setup |
+| [Dashboard](dashboard.md) | Real-time web dashboard for fleet observability and management |
 | [Triggering & Automation](triggering.md) | Cron, heartbeats, webhooks, file watchers |
 | [Development & Testing](development.md) | Testing guide, code patterns, adding new components |
 

--- a/docs/channels.md
+++ b/docs/channels.md
@@ -23,6 +23,8 @@ All channels support the same command set:
 | `/agents` | List all available agents |
 | `/status` | Show agent health and task counts |
 | `/broadcast <msg>` | Send a message to all agents |
+| `/steer <msg>` | Inject message into busy agent's context |
+| `/debug [trace_id]` | Show recent traces or trace detail |
 | `/costs` | Show today's LLM spend per agent |
 | `/addkey <service> <key>` | Add an API credential to the vault |
 | `/reset` | Clear conversation with active agent |
@@ -38,7 +40,7 @@ openlegion start -d       # Detached (background)
 openlegion chat <agent>   # Connect to running agent (detached mode)
 ```
 
-The CLI REPL supports the full command set above plus streaming responses with tool-use progress indicators.
+The CLI REPL supports the full command set above plus streaming responses with tool-use progress indicators. All channels now have full command parity with the CLI REPL (except `/add`, `/edit`, and `/remove` which require interactive prompts).
 
 ## Telegram
 
@@ -297,6 +299,8 @@ The channel receives these callbacks at construction:
 | `costs_fn` | `() -> list[dict]` | Today's spend per agent |
 | `reset_fn` | `(agent) -> bool` | Clear agent conversation |
 | `addkey_fn` | `(service, key) -> None` | Store credential in vault |
+| `steer_fn` | `(agent, msg) -> None` | Inject message into agent's context |
+| `debug_fn` | `(trace_id \| None) -> list[dict]` | Retrieve recent traces or trace detail |
 
 ## Source Files
 

--- a/docs/dashboard.md
+++ b/docs/dashboard.md
@@ -1,0 +1,121 @@
+# Dashboard
+
+Real-time web dashboard for fleet observability and management.
+
+## Overview
+
+The dashboard is served at `http://localhost:8420/dashboard` (or whatever port the mesh is configured on). It provides a live view of your agent fleet with nine panels for monitoring, configuration, and debugging.
+
+No additional setup is required -- the dashboard starts automatically with `openlegion start`.
+
+## Panels
+
+### Fleet
+
+Overview of all registered agents showing health status, activity state (idle/thinking/tool), daily cost, token usage, and restart count. Click any agent card to drill down into its detail view with cost breakdowns, budget bars, and recent events.
+
+### Events
+
+Real-time event feed streamed via WebSocket. Events include LLM calls, tool executions, messages sent/received, blackboard writes, cost updates, and health changes. Filter by event type using the chip toggles. Events are capped at 500 in the browser; older events are dropped.
+
+### Agents
+
+Agent configuration management. View and edit each agent's model, browser backend, role, system prompt, and daily budget. Changes that require a restart (model, browser) are flagged. Use the Restart button to apply changes. Agent configs are auto-loaded when switching to this tab.
+
+### Blackboard
+
+Browse, search, write, and delete shared state entries. Filter by key prefix (e.g., `tasks/`, `context/`, `signals/`). Click a value to expand/collapse. New entries are highlighted with a flash animation when written by agents in real-time. History namespace entries (`history/*`) cannot be deleted.
+
+### Costs
+
+Per-agent LLM spend with period selector (today/week/month). Bar chart shows cost and token usage side-by-side. Budget status bars show daily spend vs. configured limits. Cost data refreshes automatically when `cost_update` events arrive.
+
+### Traces
+
+Request trace timeline. The left panel lists recent trace events; clicking one shows its full event chain in the right panel with a waterfall timing visualization. Traces cover the full request path: dispatch, LLM calls, tool executions, blackboard writes, and pub/sub events.
+
+### Queues
+
+Live view of per-agent task queue depth, pending/collected counts, and busy/idle status. Auto-refreshes every 5 seconds while the tab is active.
+
+### Cron
+
+Manage scheduled jobs. View schedule, last run time, run count, error count, and heartbeat status. Actions: Run (trigger immediately), Pause, Resume. Auto-refreshes every 10 seconds while the tab is active.
+
+### Settings
+
+Environment overview showing configured credentials (names only, never values), pub/sub subscriptions, model pricing tables, and available browser backends.
+
+## Agent Management
+
+### Edit Agent Config
+
+1. Switch to the **Agents** tab
+2. Click **Edit** on an agent card
+3. Modify model, browser backend, role, system prompt, or daily budget
+4. Click **Save** -- a toast confirms which fields were updated
+5. If the change requires a restart (model or browser), click **Restart**
+
+### Restart Agent
+
+Click the **Restart** button on any agent card. A confirmation dialog prevents accidental restarts. The agent is stopped and restarted with its current configuration. The fleet panel updates automatically when the agent comes back online.
+
+### Update Budget
+
+From the agent detail view (click an agent in Fleet), budget bars show current daily and monthly usage. Budget can also be updated via the Agents tab edit form.
+
+## Blackboard Operations
+
+### Write Entry
+
+1. Click **+ New** to open the write form
+2. Enter a key (e.g., `context/my_data`) and JSON value
+3. Click **Save**
+
+### Delete Entry
+
+Click **Del** on any row. A confirmation dialog prevents accidental deletion. History namespace entries are protected and cannot be deleted.
+
+## Real-Time Updates
+
+The dashboard connects to the mesh via WebSocket at `/ws/events`. Events are streamed in real-time with optional agent and type filters. The connection indicator in the top-right shows live/disconnected status. On disconnect, the WebSocket client automatically reconnects with exponential backoff.
+
+## API Endpoints
+
+All dashboard API endpoints are prefixed with `/dashboard/api/`.
+
+| Method | Path | Description |
+|--------|------|-------------|
+| `GET` | `/dashboard/` | Serve dashboard HTML |
+| `GET` | `/dashboard/api/agents` | Fleet overview with health and costs |
+| `GET` | `/dashboard/api/agents/{id}` | Agent detail with spend and budget |
+| `GET` | `/dashboard/api/agents/{id}/config` | Agent configuration |
+| `PUT` | `/dashboard/api/agents/{id}/config` | Update agent configuration |
+| `POST` | `/dashboard/api/agents/{id}/restart` | Restart an agent |
+| `PUT` | `/dashboard/api/agents/{id}/budget` | Update agent budget |
+| `GET` | `/dashboard/api/blackboard` | List blackboard entries |
+| `PUT` | `/dashboard/api/blackboard/{key}` | Write blackboard entry |
+| `DELETE` | `/dashboard/api/blackboard/{key}` | Delete blackboard entry |
+| `GET` | `/dashboard/api/costs` | Cost data with optional period |
+| `GET` | `/dashboard/api/traces` | Recent trace events |
+| `GET` | `/dashboard/api/traces/{id}` | Trace detail |
+| `GET` | `/dashboard/api/queues` | Queue status per agent |
+| `GET` | `/dashboard/api/cron` | List cron jobs |
+| `POST` | `/dashboard/api/cron/{id}/run` | Trigger cron job |
+| `POST` | `/dashboard/api/cron/{id}/pause` | Pause cron job |
+| `POST` | `/dashboard/api/cron/{id}/resume` | Resume cron job |
+| `GET` | `/dashboard/api/settings` | Environment settings |
+| `GET` | `/dashboard/api/messages` | Recent message log |
+| `GET` | `/dashboard/api/workflows` | Workflow definitions |
+| `WS` | `/ws/events` | Real-time event stream |
+
+## Source Files
+
+| File | Role |
+|------|------|
+| `src/dashboard/server.py` | FastAPI router with all API endpoints |
+| `src/dashboard/templates/index.html` | Dashboard HTML (Alpine.js + Tailwind) |
+| `src/dashboard/static/js/app.js` | Dashboard application logic |
+| `src/dashboard/static/js/websocket.js` | WebSocket client with reconnect |
+| `src/dashboard/static/css/dashboard.css` | Custom styles |
+| `src/dashboard/events.py` | EventBus for real-time event distribution |

--- a/src/dashboard/static/css/dashboard.css
+++ b/src/dashboard/static/css/dashboard.css
@@ -80,8 +80,95 @@ main > div {
 /* Keyboard focus — visible ring on tab-navigation only */
 button:focus-visible,
 input:focus-visible,
+textarea:focus-visible,
+select:focus-visible,
 [role="button"]:focus-visible {
   outline: 2px solid rgba(99, 102, 241, 0.6);
   outline-offset: 2px;
   border-radius: 4px;
+}
+
+/* Form inputs for inline editing */
+.dash-input {
+  background: rgba(17, 17, 24, 0.8);
+  border: 1px solid rgba(42, 42, 58, 0.8);
+  border-radius: 0.375rem;
+  padding: 0.375rem 0.625rem;
+  font-size: 0.8125rem;
+  color: #e5e7eb;
+  transition: border-color 0.15s;
+}
+
+.dash-input:focus {
+  outline: none;
+  border-color: rgba(99, 102, 241, 0.5);
+  box-shadow: 0 0 0 2px rgba(99, 102, 241, 0.15);
+}
+
+.dash-select {
+  background: rgba(17, 17, 24, 0.8);
+  border: 1px solid rgba(42, 42, 58, 0.8);
+  border-radius: 0.375rem;
+  padding: 0.375rem 0.625rem;
+  font-size: 0.8125rem;
+  color: #e5e7eb;
+}
+
+.dash-textarea {
+  background: rgba(17, 17, 24, 0.8);
+  border: 1px solid rgba(42, 42, 58, 0.8);
+  border-radius: 0.375rem;
+  padding: 0.5rem 0.625rem;
+  font-size: 0.75rem;
+  font-family: ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, monospace;
+  color: #e5e7eb;
+  resize: vertical;
+  min-height: 3rem;
+}
+
+/* Queue status colors */
+.queue-busy { color: #f59e0b; }
+.queue-idle { color: #6b7280; }
+
+/* Toast notifications */
+@keyframes toast-in {
+  from { opacity: 0; transform: translateY(8px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+
+.toast {
+  animation: toast-in 0.2s ease-out;
+  background: rgba(17, 17, 24, 0.95);
+  border: 1px solid rgba(99, 102, 241, 0.3);
+  border-radius: 0.5rem;
+  padding: 0.625rem 1rem;
+  font-size: 0.8125rem;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.4);
+}
+
+/* Expandable JSON cell */
+.json-expand {
+  cursor: pointer;
+  transition: max-height 0.3s ease;
+  overflow: hidden;
+}
+
+.json-expand.collapsed {
+  max-height: 1.5rem;
+}
+
+.json-expand.expanded {
+  max-height: none;
+  white-space: pre-wrap;
+  word-break: break-all;
+}
+
+/* Heartbeat indicator */
+@keyframes heartbeat-pulse {
+  0%, 100% { opacity: 0.5; }
+  50% { opacity: 1; }
+}
+
+.heartbeat-indicator {
+  animation: heartbeat-pulse 2s ease-in-out infinite;
 }

--- a/src/dashboard/templates/index.html
+++ b/src/dashboard/templates/index.html
@@ -46,6 +46,9 @@
 
   <div x-data="dashboard()" x-init="init()" class="flex flex-col h-screen">
 
+    <!-- Toast notification -->
+    <div x-show="toastMessage" x-cloak class="fixed bottom-4 right-4 z-50 toast text-gray-200" x-text="toastMessage" x-transition></div>
+
     <!-- Navigation bar -->
     <nav class="bg-gray-900 border-b border-gray-800 px-4 py-2.5 flex items-center justify-between shrink-0">
       <div class="flex items-center gap-5">
@@ -209,6 +212,91 @@
         </div>
       </div>
 
+      <!-- Agents Config Panel (V2) -->
+      <div x-show="activeTab === 'agents'" x-cloak>
+        <div class="flex items-center justify-between mb-4">
+          <h2 class="text-sm font-medium text-gray-400">Agent Configuration</h2>
+        </div>
+        <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+          <template x-for="agent in agents" :key="'cfg_' + agent.id">
+            <div class="bg-gray-900 border border-gray-800 rounded-lg p-4">
+              <div class="flex items-center justify-between mb-3">
+                <span class="font-semibold text-white" x-text="agent.id"></span>
+                <div class="flex gap-2">
+                  <button
+                    @click="openAgentConfig(agent.id)"
+                    x-show="editingAgent !== agent.id"
+                    class="text-[11px] px-2 py-1 rounded bg-gray-800 hover:bg-gray-700 text-gray-400 hover:text-white transition-colors"
+                  >Edit</button>
+                  <button
+                    @click="restartAgent(agent.id)"
+                    class="text-[11px] px-2 py-1 rounded bg-gray-800 hover:bg-red-900/50 text-gray-400 hover:text-red-400 transition-colors"
+                  >Restart</button>
+                </div>
+              </div>
+              <!-- View mode -->
+              <div x-show="editingAgent !== agent.id" class="space-y-1.5 text-xs">
+                <div class="flex justify-between" x-show="agentConfigs[agent.id]">
+                  <span class="text-gray-500">Model</span>
+                  <span class="text-gray-300 font-mono" x-text="agentConfigs[agent.id]?.model || '-'"></span>
+                </div>
+                <div class="flex justify-between" x-show="agentConfigs[agent.id]">
+                  <span class="text-gray-500">Browser</span>
+                  <span class="text-gray-300" x-text="agentConfigs[agent.id]?.browser_backend || '-'"></span>
+                </div>
+                <div class="flex justify-between" x-show="agentConfigs[agent.id]">
+                  <span class="text-gray-500">Budget</span>
+                  <span class="text-gray-300 font-mono" x-text="agentConfigs[agent.id]?.budget?.daily_usd ? formatCost(agentConfigs[agent.id].budget.daily_usd) + '/day' : 'default'"></span>
+                </div>
+                <div x-show="agentConfigs[agent.id]?.role" class="mt-2">
+                  <span class="text-gray-500 text-[11px]">Role:</span>
+                  <span class="text-gray-400 text-[11px] ml-1" x-text="(agentConfigs[agent.id]?.role || '').substring(0, 80)"></span>
+                </div>
+                <div x-show="!agentConfigs[agent.id]" class="text-gray-600 text-center py-2">
+                  Click Edit to load config
+                </div>
+              </div>
+              <!-- Edit mode -->
+              <div x-show="editingAgent === agent.id" class="space-y-2">
+                <div>
+                  <label :for="'edit-model-' + agent.id" class="text-[11px] text-gray-500">Model</label>
+                  <select :id="'edit-model-' + agent.id" x-model="editForm.model" class="dash-select w-full mt-0.5">
+                    <template x-for="m in availableModels" :key="m">
+                      <option :value="m" x-text="m"></option>
+                    </template>
+                  </select>
+                </div>
+                <div>
+                  <label :for="'edit-browser-' + agent.id" class="text-[11px] text-gray-500">Browser</label>
+                  <select :id="'edit-browser-' + agent.id" x-model="editForm.browser_backend" class="dash-select w-full mt-0.5">
+                    <template x-for="b in availableBrowsers" :key="b">
+                      <option :value="b" x-text="b"></option>
+                    </template>
+                  </select>
+                </div>
+                <div>
+                  <label :for="'edit-role-' + agent.id" class="text-[11px] text-gray-500">Role</label>
+                  <input :id="'edit-role-' + agent.id" type="text" x-model="editForm.role" class="dash-input w-full mt-0.5">
+                </div>
+                <div>
+                  <label :for="'edit-prompt-' + agent.id" class="text-[11px] text-gray-500">System Prompt</label>
+                  <textarea :id="'edit-prompt-' + agent.id" x-model="editForm.system_prompt" class="dash-textarea w-full mt-0.5" rows="3"></textarea>
+                </div>
+                <div>
+                  <label :for="'edit-budget-' + agent.id" class="text-[11px] text-gray-500">Budget ($/day)</label>
+                  <input :id="'edit-budget-' + agent.id" type="number" step="0.5" min="0.1" x-model="editForm.budget_daily" class="dash-input w-full mt-0.5" placeholder="10.0">
+                </div>
+                <div class="flex gap-2 mt-3">
+                  <button @click="saveAgentConfig(agent.id)" class="text-xs px-3 py-1.5 rounded bg-indigo-600 hover:bg-indigo-500 text-white transition-colors">Save</button>
+                  <button @click="cancelEdit()" class="text-xs px-3 py-1.5 rounded bg-gray-800 hover:bg-gray-700 text-gray-400 transition-colors">Cancel</button>
+                </div>
+              </div>
+            </div>
+          </template>
+        </div>
+        <div x-show="agents.length === 0" class="text-center py-16 text-gray-600">No agents available</div>
+      </div>
+
       <!-- Agent Detail -->
       <div x-show="activeTab === 'agent-detail'" x-cloak>
         <button @click="switchTab('fleet')" class="text-sm text-gray-500 hover:text-gray-300 mb-4 flex items-center gap-1 transition-colors">
@@ -296,6 +384,21 @@
                 </div>
               </div>
             </div>
+            <!-- Per-model cost breakdown -->
+            <div class="bg-gray-900 border border-gray-800 rounded-lg p-4 mb-5" x-show="agentDetail.spend_today?.by_model && Object.keys(agentDetail.spend_today.by_model).length > 0">
+              <div class="text-xs text-gray-500 uppercase tracking-wider mb-3">Cost by Model (Today)</div>
+              <div class="space-y-1.5">
+                <template x-for="[model, data] in Object.entries(agentDetail.spend_today?.by_model || {})" :key="model">
+                  <div class="flex justify-between text-xs">
+                    <span class="text-gray-400 font-mono" x-text="model"></span>
+                    <div class="flex gap-4">
+                      <span class="text-gray-500" x-text="(data.total || 0).toLocaleString() + ' tok'"></span>
+                      <span class="text-gray-300 font-mono" x-text="formatCost(data.cost || 0)"></span>
+                    </div>
+                  </div>
+                </template>
+              </div>
+            </div>
             <!-- Recent events for this agent -->
             <div class="bg-gray-900 border border-gray-800 rounded-lg p-4">
               <div class="flex items-center justify-between mb-3">
@@ -328,6 +431,24 @@
             class="bg-gray-900 border border-gray-800 rounded-lg px-3 py-2 text-sm flex-1 focus:outline-none focus:border-gray-600 focus:ring-1 focus:ring-gray-600 placeholder-gray-700 transition-colors"
           >
           <button @click="fetchBlackboard()" class="bg-gray-800 hover:bg-gray-700 px-4 py-2 rounded-lg text-sm font-medium transition-colors">Search</button>
+          <button @click="bbWriteMode = !bbWriteMode" class="bg-gray-800 hover:bg-indigo-900/40 px-4 py-2 rounded-lg text-sm font-medium transition-colors" :class="bbWriteMode ? 'text-indigo-400 border border-indigo-500/40' : ''">+ New</button>
+        </div>
+        <!-- Write form -->
+        <div x-show="bbWriteMode" x-cloak class="bg-gray-900 border border-gray-800 rounded-lg p-4 mb-4">
+          <div class="grid grid-cols-1 md:grid-cols-2 gap-3">
+            <div>
+              <label for="bb-new-key" class="text-[11px] text-gray-500 mb-1 block">Key</label>
+              <input id="bb-new-key" type="text" x-model="bbNewKey" placeholder="context/my_key" class="dash-input w-full">
+            </div>
+            <div>
+              <label for="bb-new-value" class="text-[11px] text-gray-500 mb-1 block">Value (JSON)</label>
+              <textarea id="bb-new-value" x-model="bbNewValue" class="dash-textarea w-full" rows="2" placeholder='{"key": "value"}'></textarea>
+            </div>
+          </div>
+          <div class="mt-3 flex gap-2">
+            <button @click="writeBlackboard()" class="text-xs px-3 py-1.5 rounded bg-indigo-600 hover:bg-indigo-500 text-white transition-colors">Save</button>
+            <button @click="bbWriteMode = false" class="text-xs px-3 py-1.5 rounded bg-gray-800 hover:bg-gray-700 text-gray-400 transition-colors">Cancel</button>
+          </div>
         </div>
         <div class="bg-gray-900 border border-gray-800 rounded-lg overflow-hidden">
           <div class="overflow-x-auto">
@@ -339,6 +460,7 @@
                   <th class="py-3 px-4">Written By</th>
                   <th class="py-3 px-4">Updated</th>
                   <th class="py-3 px-4">Ver</th>
+                  <th class="py-3 px-4"></th>
                 </tr>
               </thead>
               <tbody>
@@ -347,11 +469,18 @@
                     :class="bbHighlights.has(entry.key) ? 'flash-yellow' : ''">
                     <td class="py-2.5 px-4 font-mono text-xs text-blue-400" x-text="entry.key"></td>
                     <td class="py-2.5 px-4 max-w-md">
-                      <span class="text-gray-300 text-xs font-mono truncate block" x-text="truncateJson(entry.value)"></span>
+                      <span class="text-gray-300 text-xs font-mono truncate block cursor-pointer" @click="$el.classList.toggle('truncate'); $el.classList.toggle('whitespace-pre-wrap')" x-text="truncateJson(entry.value)" :title="fullJson(entry.value)"></span>
                     </td>
                     <td class="py-2.5 px-4 text-gray-500" x-text="entry.written_by"></td>
                     <td class="py-2.5 px-4 text-gray-600 text-xs font-mono" x-text="entry.updated_at"></td>
                     <td class="py-2.5 px-4 text-gray-600 font-mono" x-text="entry.version"></td>
+                    <td class="py-2.5 px-4">
+                      <button
+                        @click="deleteBlackboard(entry.key)"
+                        :disabled="entry.key.startsWith('history/')"
+                        class="text-[10px] px-1.5 py-0.5 rounded text-gray-600 hover:text-red-400 hover:bg-red-900/20 transition-colors disabled:opacity-30 disabled:cursor-not-allowed"
+                      >Del</button>
+                    </td>
                   </tr>
                 </template>
               </tbody>
@@ -493,6 +622,178 @@
             </div>
           </div>
         </div>
+      </div>
+
+      <!-- Queues (V2) -->
+      <div x-show="activeTab === 'queues'" x-cloak>
+        <div class="flex items-center justify-between mb-4">
+          <h2 class="text-sm font-medium text-gray-400">Task Queues</h2>
+          <button @click="fetchQueues()" class="text-xs px-2 py-1 rounded bg-gray-800 hover:bg-gray-700 text-gray-400 transition-colors">Refresh</button>
+        </div>
+        <div class="bg-gray-900 border border-gray-800 rounded-lg overflow-hidden">
+          <table class="w-full text-sm">
+            <thead>
+              <tr class="text-gray-500 text-left text-xs uppercase tracking-wider border-b border-gray-800">
+                <th class="py-3 px-4">Agent</th>
+                <th class="py-3 px-4">Queue Depth</th>
+                <th class="py-3 px-4">Pending</th>
+                <th class="py-3 px-4">Collected</th>
+                <th class="py-3 px-4">Status</th>
+              </tr>
+            </thead>
+            <tbody>
+              <template x-for="[agent, q] in Object.entries(queueStatus)" :key="agent">
+                <tr class="border-b border-gray-800/40 hover:bg-gray-800/30">
+                  <td class="py-2.5 px-4 font-medium text-white" x-text="agent"></td>
+                  <td class="py-2.5 px-4 font-mono text-gray-300" x-text="q.queued"></td>
+                  <td class="py-2.5 px-4 font-mono text-gray-300" x-text="q.pending"></td>
+                  <td class="py-2.5 px-4 font-mono text-gray-300" x-text="q.collected"></td>
+                  <td class="py-2.5 px-4">
+                    <span class="text-[11px] px-2 py-0.5 rounded-full font-medium"
+                      :class="q.busy ? 'bg-amber-900/30 text-amber-400 border border-amber-800/40' : 'bg-gray-800/50 text-gray-500 border border-gray-700/40'"
+                      x-text="q.busy ? 'busy' : 'idle'"
+                    ></span>
+                  </td>
+                </tr>
+              </template>
+            </tbody>
+          </table>
+          <div x-show="Object.keys(queueStatus).length === 0" class="text-center py-12 text-gray-600">
+            No active queues
+          </div>
+        </div>
+      </div>
+
+      <!-- Cron (V2) -->
+      <div x-show="activeTab === 'cron'" x-cloak>
+        <div class="flex items-center justify-between mb-4">
+          <h2 class="text-sm font-medium text-gray-400">Cron Jobs</h2>
+          <button @click="fetchCronJobs()" class="text-xs px-2 py-1 rounded bg-gray-800 hover:bg-gray-700 text-gray-400 transition-colors">Refresh</button>
+        </div>
+        <div class="bg-gray-900 border border-gray-800 rounded-lg overflow-hidden">
+          <div class="overflow-x-auto">
+            <table class="w-full text-sm">
+              <thead>
+                <tr class="text-gray-500 text-left text-xs uppercase tracking-wider border-b border-gray-800">
+                  <th class="py-3 px-4">ID</th>
+                  <th class="py-3 px-4">Agent</th>
+                  <th class="py-3 px-4">Schedule</th>
+                  <th class="py-3 px-4">Message</th>
+                  <th class="py-3 px-4">HB</th>
+                  <th class="py-3 px-4">Enabled</th>
+                  <th class="py-3 px-4">Last Run</th>
+                  <th class="py-3 px-4">Runs</th>
+                  <th class="py-3 px-4">Errors</th>
+                  <th class="py-3 px-4">Actions</th>
+                </tr>
+              </thead>
+              <tbody>
+                <template x-for="job in cronJobs" :key="job.id">
+                  <tr class="border-b border-gray-800/40 hover:bg-gray-800/30">
+                    <td class="py-2.5 px-4 font-mono text-xs text-blue-400" x-text="job.id"></td>
+                    <td class="py-2.5 px-4 text-white" x-text="job.agent"></td>
+                    <td class="py-2.5 px-4 font-mono text-gray-300 text-xs" x-text="job.schedule"></td>
+                    <td class="py-2.5 px-4 text-gray-400 text-xs max-w-xs truncate" x-text="job.message"></td>
+                    <td class="py-2.5 px-4">
+                      <span x-show="job.heartbeat" class="text-pink-400 heartbeat-indicator text-[11px]">HB</span>
+                    </td>
+                    <td class="py-2.5 px-4">
+                      <span class="text-[11px] px-2 py-0.5 rounded-full"
+                        :class="job.enabled ? 'bg-green-900/30 text-green-400' : 'bg-gray-800/50 text-gray-500'"
+                        x-text="job.enabled ? 'on' : 'off'"
+                      ></span>
+                    </td>
+                    <td class="py-2.5 px-4 text-gray-600 text-xs font-mono" x-text="job.last_run || '-'"></td>
+                    <td class="py-2.5 px-4 font-mono text-gray-300" x-text="job.run_count"></td>
+                    <td class="py-2.5 px-4 font-mono" :class="job.error_count > 0 ? 'text-red-400' : 'text-gray-600'" x-text="job.error_count"></td>
+                    <td class="py-2.5 px-4 flex gap-1">
+                      <button @click="runCronJob(job.id)" class="text-[10px] px-1.5 py-0.5 rounded bg-gray-800 hover:bg-indigo-900/40 text-gray-400 hover:text-indigo-300 transition-colors">Run</button>
+                      <button
+                        x-show="job.enabled"
+                        @click="pauseCronJob(job.id)"
+                        class="text-[10px] px-1.5 py-0.5 rounded bg-gray-800 hover:bg-yellow-900/30 text-gray-400 hover:text-yellow-400 transition-colors"
+                      >Pause</button>
+                      <button
+                        x-show="!job.enabled"
+                        @click="resumeCronJob(job.id)"
+                        class="text-[10px] px-1.5 py-0.5 rounded bg-gray-800 hover:bg-green-900/30 text-gray-400 hover:text-green-400 transition-colors"
+                      >Resume</button>
+                    </td>
+                  </tr>
+                </template>
+              </tbody>
+            </table>
+          </div>
+          <div x-show="cronJobs.length === 0" class="text-center py-12 text-gray-600">
+            No cron jobs configured
+          </div>
+        </div>
+      </div>
+
+      <!-- Settings (V2) -->
+      <div x-show="activeTab === 'settings'" x-cloak>
+        <h2 class="text-sm font-medium text-gray-400 mb-4">Settings & Environment</h2>
+        <div x-show="!settingsData" class="text-center py-12 text-gray-600">Loading...</div>
+        <template x-if="settingsData">
+          <div class="grid grid-cols-1 lg:grid-cols-2 gap-4">
+            <!-- Credentials -->
+            <div class="bg-gray-900 border border-gray-800 rounded-lg p-4">
+              <div class="text-xs text-gray-500 uppercase tracking-wider mb-3">Credentials</div>
+              <div class="text-sm text-gray-400 mb-2">
+                <span x-text="settingsData.credentials.count"></span> credential(s) configured
+              </div>
+              <div class="space-y-1">
+                <template x-for="name in settingsData.credentials.names" :key="name">
+                  <div class="flex items-center gap-2 text-xs">
+                    <span class="w-2 h-2 rounded-full bg-green-500/50"></span>
+                    <span class="text-gray-300 font-mono" x-text="name"></span>
+                  </div>
+                </template>
+              </div>
+            </div>
+            <!-- PubSub subscriptions -->
+            <div class="bg-gray-900 border border-gray-800 rounded-lg p-4">
+              <div class="text-xs text-gray-500 uppercase tracking-wider mb-3">PubSub Subscriptions</div>
+              <div x-show="Object.keys(settingsData.pubsub_subscriptions || {}).length === 0" class="text-gray-600 text-sm">No subscriptions</div>
+              <div class="space-y-2">
+                <template x-for="[topic, agents] in Object.entries(settingsData.pubsub_subscriptions || {})" :key="topic">
+                  <div>
+                    <span class="text-xs text-cyan-400 font-mono" x-text="topic"></span>
+                    <span class="text-gray-600 text-xs mx-1">&rarr;</span>
+                    <span class="text-xs text-gray-400" x-text="agents.join(', ')"></span>
+                  </div>
+                </template>
+              </div>
+            </div>
+            <!-- Model pricing -->
+            <div class="bg-gray-900 border border-gray-800 rounded-lg p-4">
+              <div class="text-xs text-gray-500 uppercase tracking-wider mb-3">Model Pricing (per 1K tokens)</div>
+              <div class="space-y-1 max-h-60 overflow-y-auto custom-scrollbar">
+                <template x-for="[model, costs] in Object.entries(settingsData.model_costs || {})" :key="model">
+                  <div class="flex justify-between text-xs">
+                    <span class="text-gray-400 font-mono" x-text="model"></span>
+                    <div class="flex gap-3">
+                      <span class="text-gray-500">in: <span class="text-gray-300" x-text="'$' + costs.input_per_1k.toFixed(5)"></span></span>
+                      <span class="text-gray-500">out: <span class="text-gray-300" x-text="'$' + costs.output_per_1k.toFixed(5)"></span></span>
+                    </div>
+                  </div>
+                </template>
+              </div>
+            </div>
+            <!-- Browser backends -->
+            <div class="bg-gray-900 border border-gray-800 rounded-lg p-4">
+              <div class="text-xs text-gray-500 uppercase tracking-wider mb-3">Browser Backends</div>
+              <div class="space-y-2">
+                <template x-for="b in settingsData.browser_backends || []" :key="b.name">
+                  <div>
+                    <span class="text-sm text-white font-medium" x-text="b.label || b.name"></span>
+                    <div class="text-xs text-gray-500 mt-0.5" x-text="b.description || ''"></div>
+                  </div>
+                </template>
+              </div>
+            </div>
+          </div>
+        </template>
       </div>
 
     </main>

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -1,0 +1,93 @@
+"""Tests for the health monitor, including ephemeral agent cleanup."""
+
+from __future__ import annotations
+
+import time
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from src.host.health import AgentHealth, HealthMonitor
+
+
+def _make_monitor(agents_info: dict | None = None):
+    """Create a HealthMonitor with mocked dependencies."""
+    runtime = MagicMock()
+    runtime.agents = agents_info or {}
+    transport = MagicMock()
+    router = MagicMock()
+    event_bus = MagicMock()
+    monitor = HealthMonitor(
+        runtime=runtime, transport=transport, router=router, event_bus=event_bus,
+    )
+    return monitor
+
+
+class TestEphemeralCleanup:
+    @pytest.mark.asyncio
+    async def test_cleanup_ephemeral_expired(self):
+        """Agent past TTL is stopped and unregistered."""
+        monitor = _make_monitor({
+            "spawn-abc": {"ephemeral": True, "ttl": 60, "spawned_at": time.time() - 120},
+        })
+        monitor.agents["spawn-abc"] = AgentHealth(agent_id="spawn-abc")
+        await monitor._cleanup_ephemeral_agents()
+        monitor.runtime.stop_agent.assert_called_once_with("spawn-abc")
+        monitor.router.unregister_agent.assert_called_once_with("spawn-abc")
+        assert "spawn-abc" not in monitor.agents
+
+    @pytest.mark.asyncio
+    async def test_cleanup_ephemeral_not_expired(self):
+        """Agent within TTL is kept."""
+        monitor = _make_monitor({
+            "spawn-def": {"ephemeral": True, "ttl": 3600, "spawned_at": time.time()},
+        })
+        monitor.agents["spawn-def"] = AgentHealth(agent_id="spawn-def")
+        await monitor._cleanup_ephemeral_agents()
+        monitor.runtime.stop_agent.assert_not_called()
+        assert "spawn-def" in monitor.agents
+
+    @pytest.mark.asyncio
+    async def test_cleanup_non_ephemeral_untouched(self):
+        """Regular (non-ephemeral) agents are not affected by cleanup."""
+        monitor = _make_monitor({
+            "regular": {"role": "assistant"},
+        })
+        monitor.agents["regular"] = AgentHealth(agent_id="regular")
+        await monitor._cleanup_ephemeral_agents()
+        monitor.runtime.stop_agent.assert_not_called()
+        assert "regular" in monitor.agents
+
+    @pytest.mark.asyncio
+    async def test_cleanup_emits_event(self):
+        """Removing an expired ephemeral agent emits an agent_state event."""
+        monitor = _make_monitor({
+            "spawn-xyz": {"ephemeral": True, "ttl": 10, "spawned_at": time.time() - 100},
+        })
+        monitor.agents["spawn-xyz"] = AgentHealth(agent_id="spawn-xyz")
+        await monitor._cleanup_ephemeral_agents()
+        monitor._event_bus.emit.assert_called_once_with(
+            "agent_state", agent="spawn-xyz",
+            data={"state": "removed", "reason": "ttl_expired"},
+        )
+
+
+class TestHealthRecoveryEvent:
+    @pytest.mark.asyncio
+    async def test_recovery_emits_health_change(self):
+        """When an unhealthy agent becomes reachable, a health_change event fires."""
+        monitor = _make_monitor({"agent-a": {"role": "assistant"}})
+        monitor.register("agent-a")
+        # Simulate prior unhealthy state
+        monitor.agents["agent-a"].status = "unhealthy"
+        monitor.agents["agent-a"].consecutive_failures = 2
+        monitor.transport.is_reachable = AsyncMock(return_value=True)
+        await monitor._check_agent("agent-a")
+        assert monitor.agents["agent-a"].status == "healthy"
+        monitor._event_bus.emit.assert_called_once_with(
+            "health_change", agent="agent-a",
+            data={
+                "previous": "unhealthy", "current": "healthy",
+                "failures": 0, "restart_count": 0,
+            },
+        )


### PR DESCRIPTION
## Summary
- **Spawn agent fix**: Register spawned agents with health monitor + ephemeral TTL cleanup so they no longer show "unknown" badge
- **Channel REPL parity**: Add `/steer` and `/debug` commands to all messaging channels (Telegram, Discord, Slack, WhatsApp)
- **Dashboard V2 polish**: Confirmation dialogs for destructive actions, auto-refresh for queues/cron tabs, edit-on-click for agent configs, accessibility label associations, error feedback in catch blocks
- **Health recovery bug fix**: Recovery event never fired because status was set before the comparison — fixed with local variable
- **Docs**: New `docs/dashboard.md`, updated `channels.md` with `/steer` + `/debug`, updated README test counts and dashboard mention

## Test plan
- [x] 835 tests passing (5 new: 1 health recovery, 4 ephemeral cleanup, updated channel debug tests)
- [x] `tests/test_health.py` — ephemeral TTL cleanup + recovery event
- [x] `tests/test_channels.py` — /steer, /debug commands with edge cases
- [x] `tests/test_dashboard.py` — all 57 dashboard tests pass
- [x] Full suite: `pytest tests/ --ignore=tests/test_e2e*.py -x -q`

🤖 Generated with [Claude Code](https://claude.com/claude-code)