### PR TITLE
Fix channel subclasses rejecting steer_fn/debug_fn kwargs

### DIFF
--- a/src/channels/discord.py
+++ b/src/channels/discord.py
@@ -17,17 +17,7 @@ from __future__ import annotations
 
 import asyncio
 
-from src.channels.base import (
-    AddKeyFn,
-    Channel,
-    CostsFn,
-    DispatchFn,
-    ListAgentsFn,
-    PairingManager,
-    ResetFn,
-    StatusFn,
-    chunk_text,
-)
+from src.channels.base import Channel, PairingManager, chunk_text
 from src.shared.utils import setup_logging
 
 logger = setup_logging("channels.discord")
@@ -41,24 +31,11 @@ class DiscordChannel(Channel):
     def __init__(
         self,
         token: str,
-        dispatch_fn: DispatchFn,
         default_agent: str = "",
         allowed_guilds: list[int] | None = None,
-        list_agents_fn: ListAgentsFn | None = None,
-        status_fn: StatusFn | None = None,
-        costs_fn: CostsFn | None = None,
-        reset_fn: ResetFn | None = None,
-        addkey_fn: AddKeyFn | None = None,
+        **kwargs,
     ):
-        super().__init__(
-            dispatch_fn=dispatch_fn,
-            default_agent=default_agent,
-            list_agents_fn=list_agents_fn,
-            status_fn=status_fn,
-            costs_fn=costs_fn,
-            reset_fn=reset_fn,
-            addkey_fn=addkey_fn,
-        )
+        super().__init__(default_agent=default_agent, **kwargs)
         self.token = token
         self.allowed_guilds = set(allowed_guilds) if allowed_guilds else None
         self._client = None

--- a/src/channels/slack.py
+++ b/src/channels/slack.py
@@ -18,18 +18,7 @@ from __future__ import annotations
 
 import asyncio
 
-from src.channels.base import (
-    AddKeyFn,
-    Channel,
-    CostsFn,
-    DispatchFn,
-    ListAgentsFn,
-    PairingManager,
-    ResetFn,
-    StatusFn,
-    StreamDispatchFn,
-    chunk_text,
-)
+from src.channels.base import Channel, PairingManager, chunk_text
 from src.shared.utils import setup_logging
 
 logger = setup_logging("channels.slack")
@@ -51,25 +40,10 @@ class SlackChannel(Channel):
         self,
         bot_token: str,
         app_token: str,
-        dispatch_fn: DispatchFn,
         default_agent: str = "",
-        list_agents_fn: ListAgentsFn | None = None,
-        status_fn: StatusFn | None = None,
-        costs_fn: CostsFn | None = None,
-        reset_fn: ResetFn | None = None,
-        stream_dispatch_fn: StreamDispatchFn | None = None,
-        addkey_fn: AddKeyFn | None = None,
+        **kwargs,
     ):
-        super().__init__(
-            dispatch_fn=dispatch_fn,
-            default_agent=default_agent,
-            list_agents_fn=list_agents_fn,
-            status_fn=status_fn,
-            costs_fn=costs_fn,
-            reset_fn=reset_fn,
-            stream_dispatch_fn=stream_dispatch_fn,
-            addkey_fn=addkey_fn,
-        )
+        super().__init__(default_agent=default_agent, **kwargs)
         self.bot_token = bot_token
         self.app_token = app_token
         self._bolt_app = None

--- a/src/channels/telegram.py
+++ b/src/channels/telegram.py
@@ -17,18 +17,7 @@ from __future__ import annotations
 
 import asyncio
 
-from src.channels.base import (
-    AddKeyFn,
-    Channel,
-    CostsFn,
-    DispatchFn,
-    ListAgentsFn,
-    PairingManager,
-    ResetFn,
-    StatusFn,
-    StreamDispatchFn,
-    chunk_text,
-)
+from src.channels.base import Channel, PairingManager, chunk_text
 from src.shared.utils import setup_logging
 
 logger = setup_logging("channels.telegram")
@@ -68,26 +57,11 @@ class TelegramChannel(Channel):
     def __init__(
         self,
         token: str,
-        dispatch_fn: DispatchFn,
         default_agent: str = "",
         allowed_users: list[int] | None = None,
-        list_agents_fn: ListAgentsFn | None = None,
-        status_fn: StatusFn | None = None,
-        costs_fn: CostsFn | None = None,
-        reset_fn: ResetFn | None = None,
-        stream_dispatch_fn: StreamDispatchFn | None = None,
-        addkey_fn: AddKeyFn | None = None,
+        **kwargs,
     ):
-        super().__init__(
-            dispatch_fn=dispatch_fn,
-            default_agent=default_agent,
-            list_agents_fn=list_agents_fn,
-            status_fn=status_fn,
-            costs_fn=costs_fn,
-            reset_fn=reset_fn,
-            stream_dispatch_fn=stream_dispatch_fn,
-            addkey_fn=addkey_fn,
-        )
+        super().__init__(default_agent=default_agent, **kwargs)
         self.token = token
         self._explicit_allowed = set(allowed_users) if allowed_users else None
         self._app = None

--- a/src/channels/whatsapp.py
+++ b/src/channels/whatsapp.py
@@ -23,18 +23,7 @@ import asyncio
 import httpx
 from fastapi import APIRouter, Query, Request
 
-from src.channels.base import (
-    AddKeyFn,
-    Channel,
-    CostsFn,
-    DispatchFn,
-    ListAgentsFn,
-    PairingManager,
-    ResetFn,
-    StatusFn,
-    StreamDispatchFn,
-    chunk_text,
-)
+from src.channels.base import Channel, PairingManager, chunk_text
 from src.shared.utils import setup_logging
 
 logger = setup_logging("channels.whatsapp")
@@ -51,25 +40,10 @@ class WhatsAppChannel(Channel):
         access_token: str,
         phone_number_id: str,
         verify_token: str,
-        dispatch_fn: DispatchFn,
         default_agent: str = "",
-        list_agents_fn: ListAgentsFn | None = None,
-        status_fn: StatusFn | None = None,
-        costs_fn: CostsFn | None = None,
-        reset_fn: ResetFn | None = None,
-        stream_dispatch_fn: StreamDispatchFn | None = None,
-        addkey_fn: AddKeyFn | None = None,
+        **kwargs,
     ):
-        super().__init__(
-            dispatch_fn=dispatch_fn,
-            default_agent=default_agent,
-            list_agents_fn=list_agents_fn,
-            status_fn=status_fn,
-            costs_fn=costs_fn,
-            reset_fn=reset_fn,
-            stream_dispatch_fn=stream_dispatch_fn,
-            addkey_fn=addkey_fn,
-        )
+        super().__init__(default_agent=default_agent, **kwargs)
         self.access_token = access_token
         self.phone_number_id = phone_number_id
         self.verify_token = verify_token


### PR DESCRIPTION
## Summary
- Fixes `TypeError: TelegramChannel.__init__() got an unexpected keyword argument 'steer_fn'` crash on startup
- All 4 channel subclasses (Telegram, Discord, Slack, WhatsApp) explicitly listed each base class callback parameter — adding `steer_fn`/`debug_fn` to the base broke them all
- Switch to `**kwargs` passthrough so future base class callbacks flow through automatically
- Removes 113 lines of redundant parameter forwarding

## Test plan
- [x] 835 tests passing
- [x] `openlegion start` no longer crashes

🤖 Generated with [Claude Code](https://claude.com/claude-code)