### PR TITLE
Auto-heartbeat, always-dispatch, cron editing, dashboard KISS redesign

### DIFF
--- a/src/agent/mesh_client.py
+++ b/src/agent/mesh_client.py
@@ -158,6 +158,17 @@ class MeshClient:
         response.raise_for_status()
         return response.json()
 
+    async def update_cron(self, job_id: str, **kwargs) -> dict:
+        """Update a cron job by ID."""
+        client = await self._get_client()
+        response = await client.put(
+            f"{self.mesh_url}/mesh/cron/{job_id}",
+            json=kwargs,
+            headers=self._trace_headers(),
+        )
+        response.raise_for_status()
+        return response.json()
+
     async def remove_cron(self, job_id: str) -> dict:
         """Remove a cron job by ID."""
         client = await self._get_client()

--- a/src/agent/workspace.py
+++ b/src/agent/workspace.py
@@ -52,11 +52,10 @@ _SCAFFOLD_FILES: dict[str, str] = {
     ),
     "HEARTBEAT.md": (
         "# Heartbeat Rules\n\n"
-        "Define what to check on each heartbeat. The agent reads this file\n"
-        "periodically and takes action when rules are triggered.\n\n"
-        "## Rules\n\n"
-        "- Check for pending tasks on the blackboard\n"
-        "- Review and summarize new information\n"
+        "You are woken periodically. On each heartbeat:\n"
+        "1. Check for pending tasks on the blackboard\n"
+        "2. Continue working toward your current goal\n"
+        "3. Send a brief status update to the user\n"
     ),
 }
 

--- a/src/dashboard/static/css/dashboard.css
+++ b/src/dashboard/static/css/dashboard.css
@@ -172,3 +172,15 @@ select:focus-visible,
 .heartbeat-indicator {
   animation: heartbeat-pulse 2s ease-in-out infinite;
 }
+
+/* Inline cron schedule editing */
+.cron-edit-input {
+  font-family: ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, monospace;
+  font-size: 0.75rem;
+}
+
+/* Queue depth badge on agent cards */
+.queue-badge {
+  font-size: 0.625rem;
+  letter-spacing: -0.01em;
+}

--- a/src/dashboard/templates/index.html
+++ b/src/dashboard/templates/index.html
@@ -68,7 +68,7 @@
               <span x-text="tab.label"></span>
               <!-- Unread event count badge -->
               <span
-                x-show="tab.id === 'events' && unreadEvents > 0 && activeTab !== 'events'"
+                x-show="tab.id === 'activity' && unreadEvents > 0 && activeTab !== 'activity'"
                 x-text="unreadEvents >= 100 ? '99+' : unreadEvents"
                 class="absolute -top-1 -right-1 bg-indigo-500 text-white text-[10px] font-bold rounded-full min-w-[16px] h-4 flex items-center justify-center px-1"
                 x-cloak
@@ -96,7 +96,7 @@
     <!-- Main content -->
     <main class="flex-1 overflow-auto p-4 lg:p-6">
 
-      <!-- Fleet Overview -->
+      <!-- Fleet Overview (merged: Fleet + Agents + Queues) -->
       <div x-show="activeTab === 'fleet'" x-cloak>
         <!-- Fleet summary bar -->
         <div class="flex items-center justify-between mb-4" x-show="agents.length > 0">
@@ -112,24 +112,30 @@
         <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-4">
           <template x-for="agent in agents" :key="agent.id">
             <div
-              @click="drillDown(agent.id)"
-              class="bg-gray-900 border border-gray-800 rounded-lg p-4 cursor-pointer hover:border-gray-600 transition-all hover:shadow-lg hover:shadow-black/20 group"
+              class="bg-gray-900 border border-gray-800 rounded-lg p-4 hover:border-gray-600 transition-all hover:shadow-lg hover:shadow-black/20 group"
               :class="agentStates[agent.id] === 'thinking' || agentStates[agent.id] === 'tool' ? 'pulse-border' : ''"
             >
               <div class="flex items-center justify-between mb-3">
-                <div class="flex items-center gap-2">
+                <div class="flex items-center gap-2 cursor-pointer" @click="drillDown(agent.id)">
                   <span class="font-semibold text-white group-hover:text-indigo-300 transition-colors" x-text="agent.id"></span>
                 </div>
-                <span
-                  class="text-[11px] px-2 py-0.5 rounded-full font-medium"
-                  :class="{
-                    'bg-green-900/40 text-green-400 border border-green-800/50': agent.health_status === 'healthy',
-                    'bg-yellow-900/40 text-yellow-400 border border-yellow-800/50': agent.health_status === 'unhealthy' || agent.health_status === 'restarting',
-                    'bg-red-900/40 text-red-400 border border-red-800/50': agent.health_status === 'failed',
-                    'bg-gray-800/60 text-gray-500 border border-gray-700/50': agent.health_status === 'unknown',
-                  }"
-                  x-text="agent.health_status"
-                ></span>
+                <div class="flex items-center gap-2">
+                  <!-- Queue depth badge -->
+                  <span x-show="queueStatus[agent.id] && queueStatus[agent.id].queued > 0"
+                    class="text-[10px] px-1.5 py-0.5 rounded-full bg-amber-900/30 text-amber-400 border border-amber-800/40 font-mono"
+                    x-text="queueStatus[agent.id]?.queued + ' queued'"
+                  ></span>
+                  <span
+                    class="text-[11px] px-2 py-0.5 rounded-full font-medium"
+                    :class="{
+                      'bg-green-900/40 text-green-400 border border-green-800/50': agent.health_status === 'healthy',
+                      'bg-yellow-900/40 text-yellow-400 border border-yellow-800/50': agent.health_status === 'unhealthy' || agent.health_status === 'restarting',
+                      'bg-red-900/40 text-red-400 border border-red-800/50': agent.health_status === 'failed',
+                      'bg-gray-800/60 text-gray-500 border border-gray-700/50': agent.health_status === 'unknown',
+                    }"
+                    x-text="agent.health_status"
+                  ></span>
+                </div>
               </div>
               <div class="space-y-2 text-xs">
                 <div class="flex justify-between items-center">
@@ -151,9 +157,75 @@
                   <span class="text-gray-500">Tokens</span>
                   <span class="text-gray-200 font-mono text-[11px]" x-text="agent.daily_tokens.toLocaleString()"></span>
                 </div>
+                <div class="flex justify-between items-center" x-show="agentConfigs[agent.id]">
+                  <span class="text-gray-500">Model</span>
+                  <span class="text-gray-300 font-mono text-[11px]" x-text="agentConfigs[agent.id]?.model || '-'"></span>
+                </div>
+                <div class="flex justify-between items-center" x-show="queueStatus[agent.id]">
+                  <span class="text-gray-500">Queue</span>
+                  <span class="font-mono text-[11px]"
+                    :class="queueStatus[agent.id]?.busy ? 'text-amber-400' : 'text-gray-600'"
+                    x-text="queueStatus[agent.id]?.busy ? 'busy (' + queueStatus[agent.id]?.queued + ' queued)' : 'idle'"
+                  ></span>
+                </div>
                 <div class="flex justify-between items-center" x-show="agent.restarts > 0">
                   <span class="text-gray-500">Restarts</span>
                   <span class="text-yellow-400 font-mono text-[11px]" x-text="agent.restarts"></span>
+                </div>
+              </div>
+              <!-- Agent actions -->
+              <div class="mt-3 pt-3 border-t border-gray-800/50 flex flex-wrap gap-1.5">
+                <button
+                  @click="openChat(agent.id)"
+                  class="text-[11px] px-2 py-1 rounded bg-indigo-900/30 hover:bg-indigo-800/40 text-indigo-300 hover:text-indigo-200 border border-indigo-800/30 transition-colors"
+                >Chat</button>
+                <button
+                  @click="steerAgent(agent.id)"
+                  class="text-[11px] px-2 py-1 rounded bg-gray-800 hover:bg-gray-700 text-gray-400 hover:text-white transition-colors"
+                >Steer</button>
+                <button
+                  @click="resetAgent(agent.id)"
+                  class="text-[11px] px-2 py-1 rounded bg-gray-800 hover:bg-gray-700 text-gray-400 hover:text-white transition-colors"
+                >Reset</button>
+                <button
+                  @click="openAgentConfig(agent.id)"
+                  x-show="editingAgent !== agent.id"
+                  class="text-[11px] px-2 py-1 rounded bg-gray-800 hover:bg-gray-700 text-gray-400 hover:text-white transition-colors"
+                >Edit</button>
+                <button
+                  @click="restartAgent(agent.id)"
+                  class="text-[11px] px-2 py-1 rounded bg-gray-800 hover:bg-red-900/50 text-gray-400 hover:text-red-400 transition-colors"
+                >Restart</button>
+              </div>
+              <!-- Inline edit mode -->
+              <div x-show="editingAgent === agent.id" class="mt-3 pt-3 border-t border-gray-800/50 space-y-2">
+                <div>
+                  <label class="text-[11px] text-gray-500">Model</label>
+                  <select x-model="editForm.model" class="dash-select w-full mt-0.5">
+                    <template x-for="m in availableModels" :key="m">
+                      <option :value="m" x-text="m"></option>
+                    </template>
+                  </select>
+                </div>
+                <div>
+                  <label class="text-[11px] text-gray-500">Browser</label>
+                  <select x-model="editForm.browser_backend" class="dash-select w-full mt-0.5">
+                    <template x-for="b in availableBrowsers" :key="b">
+                      <option :value="b" x-text="b"></option>
+                    </template>
+                  </select>
+                </div>
+                <div>
+                  <label class="text-[11px] text-gray-500">Role</label>
+                  <input type="text" x-model="editForm.role" class="dash-input w-full mt-0.5">
+                </div>
+                <div>
+                  <label class="text-[11px] text-gray-500">Budget ($/day)</label>
+                  <input type="number" step="0.5" min="0.1" x-model="editForm.budget_daily" class="dash-input w-full mt-0.5" placeholder="10.0">
+                </div>
+                <div class="flex gap-2 mt-2">
+                  <button @click="saveAgentConfig(agent.id)" class="text-xs px-3 py-1.5 rounded bg-indigo-600 hover:bg-indigo-500 text-white transition-colors">Save</button>
+                  <button @click="cancelEdit()" class="text-xs px-3 py-1.5 rounded bg-gray-800 hover:bg-gray-700 text-gray-400 transition-colors">Cancel</button>
                 </div>
               </div>
             </div>
@@ -171,10 +243,68 @@
           <div class="text-gray-600 text-lg mb-1">No agents registered</div>
           <div class="text-gray-700 text-sm">Start agents with <code class="bg-gray-800 px-1.5 py-0.5 rounded text-gray-400">openlegion start</code></div>
         </div>
+        <!-- Broadcast bar -->
+        <div x-show="agents.length > 1" class="mt-6 bg-gray-900 border border-gray-800 rounded-lg p-4" x-cloak>
+          <div class="text-xs text-gray-500 uppercase tracking-wider mb-2">Broadcast to all agents</div>
+          <div class="flex gap-2">
+            <input type="text" x-model="broadcastMessage" @keydown.enter="sendBroadcast()"
+              class="dash-input flex-1" placeholder="Message all agents...">
+            <button @click="sendBroadcast()" :disabled="broadcastLoading"
+              class="text-xs px-4 py-2 rounded bg-indigo-600 hover:bg-indigo-500 text-white disabled:opacity-50 transition-colors">
+              <span x-show="!broadcastLoading">Send</span>
+              <span x-show="broadcastLoading">Sending...</span>
+            </button>
+          </div>
+          <div x-show="broadcastResults" class="mt-3 space-y-2" x-cloak>
+            <template x-for="[aid, resp] in Object.entries(broadcastResults || {})" :key="aid">
+              <div class="text-xs bg-gray-800/50 rounded p-2">
+                <span class="text-indigo-400 font-medium" x-text="aid"></span>
+                <span class="text-gray-400 ml-2" x-text="resp.substring(0, 200)"></span>
+              </div>
+            </template>
+          </div>
+        </div>
       </div>
 
-      <!-- Events Feed -->
-      <div x-show="activeTab === 'events'" x-cloak>
+      <!-- Chat modal overlay -->
+      <div x-show="chatAgent" x-cloak class="fixed inset-0 z-50 flex items-center justify-center bg-black/60" @click.self="closeChat()">
+        <div class="bg-gray-900 border border-gray-700 rounded-xl shadow-2xl w-full max-w-2xl max-h-[80vh] flex flex-col">
+          <div class="flex items-center justify-between px-5 py-3 border-b border-gray-800">
+            <h3 class="text-sm font-medium text-white">Chat with <span class="text-indigo-400" x-text="chatAgent"></span></h3>
+            <button @click="closeChat()" class="text-gray-500 hover:text-white transition-colors text-lg">&times;</button>
+          </div>
+          <div class="flex-1 overflow-y-auto p-4 space-y-3 custom-scrollbar min-h-[200px]">
+            <template x-for="(msg, i) in chatHistory" :key="i">
+              <div :class="msg.role === 'user' ? 'text-right' : 'text-left'">
+                <div class="inline-block max-w-[80%] px-3 py-2 rounded-lg text-sm"
+                  :class="{
+                    'bg-indigo-600 text-white': msg.role === 'user',
+                    'bg-gray-800 text-gray-200': msg.role === 'agent',
+                    'bg-red-900/40 text-red-300': msg.role === 'error',
+                  }"
+                >
+                  <div class="whitespace-pre-wrap break-words" x-text="msg.content"></div>
+                </div>
+              </div>
+            </template>
+            <div x-show="chatLoading" class="text-center text-gray-600 text-sm">
+              <svg class="animate-spin h-4 w-4 inline mr-1" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24"><circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle><path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z"></path></svg>
+              Thinking...
+            </div>
+          </div>
+          <div class="px-4 py-3 border-t border-gray-800">
+            <div class="flex gap-2">
+              <input type="text" x-model="chatMessage" @keydown.enter="sendChat()"
+                class="dash-input flex-1" placeholder="Type a message..." :disabled="chatLoading">
+              <button @click="sendChat()" :disabled="chatLoading || !chatMessage.trim()"
+                class="text-xs px-4 py-2 rounded bg-indigo-600 hover:bg-indigo-500 text-white disabled:opacity-50 transition-colors">Send</button>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <!-- Activity Feed (formerly Events) -->
+      <div x-show="activeTab === 'activity'" x-cloak>
         <div class="flex items-center justify-between mb-3">
           <div class="flex gap-1.5 flex-wrap">
             <template x-for="etype in eventTypes" :key="etype">
@@ -210,91 +340,6 @@
             <div class="text-gray-700 text-sm">Events appear in real-time as agents work</div>
           </div>
         </div>
-      </div>
-
-      <!-- Agents Config Panel (V2) -->
-      <div x-show="activeTab === 'agents'" x-cloak>
-        <div class="flex items-center justify-between mb-4">
-          <h2 class="text-sm font-medium text-gray-400">Agent Configuration</h2>
-        </div>
-        <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
-          <template x-for="agent in agents" :key="'cfg_' + agent.id">
-            <div class="bg-gray-900 border border-gray-800 rounded-lg p-4">
-              <div class="flex items-center justify-between mb-3">
-                <span class="font-semibold text-white" x-text="agent.id"></span>
-                <div class="flex gap-2">
-                  <button
-                    @click="openAgentConfig(agent.id)"
-                    x-show="editingAgent !== agent.id"
-                    class="text-[11px] px-2 py-1 rounded bg-gray-800 hover:bg-gray-700 text-gray-400 hover:text-white transition-colors"
-                  >Edit</button>
-                  <button
-                    @click="restartAgent(agent.id)"
-                    class="text-[11px] px-2 py-1 rounded bg-gray-800 hover:bg-red-900/50 text-gray-400 hover:text-red-400 transition-colors"
-                  >Restart</button>
-                </div>
-              </div>
-              <!-- View mode -->
-              <div x-show="editingAgent !== agent.id" class="space-y-1.5 text-xs">
-                <div class="flex justify-between" x-show="agentConfigs[agent.id]">
-                  <span class="text-gray-500">Model</span>
-                  <span class="text-gray-300 font-mono" x-text="agentConfigs[agent.id]?.model || '-'"></span>
-                </div>
-                <div class="flex justify-between" x-show="agentConfigs[agent.id]">
-                  <span class="text-gray-500">Browser</span>
-                  <span class="text-gray-300" x-text="agentConfigs[agent.id]?.browser_backend || '-'"></span>
-                </div>
-                <div class="flex justify-between" x-show="agentConfigs[agent.id]">
-                  <span class="text-gray-500">Budget</span>
-                  <span class="text-gray-300 font-mono" x-text="agentConfigs[agent.id]?.budget?.daily_usd ? formatCost(agentConfigs[agent.id].budget.daily_usd) + '/day' : 'default'"></span>
-                </div>
-                <div x-show="agentConfigs[agent.id]?.role" class="mt-2">
-                  <span class="text-gray-500 text-[11px]">Role:</span>
-                  <span class="text-gray-400 text-[11px] ml-1" x-text="(agentConfigs[agent.id]?.role || '').substring(0, 80)"></span>
-                </div>
-                <div x-show="!agentConfigs[agent.id]" class="text-gray-600 text-center py-2">
-                  Click Edit to load config
-                </div>
-              </div>
-              <!-- Edit mode -->
-              <div x-show="editingAgent === agent.id" class="space-y-2">
-                <div>
-                  <label :for="'edit-model-' + agent.id" class="text-[11px] text-gray-500">Model</label>
-                  <select :id="'edit-model-' + agent.id" x-model="editForm.model" class="dash-select w-full mt-0.5">
-                    <template x-for="m in availableModels" :key="m">
-                      <option :value="m" x-text="m"></option>
-                    </template>
-                  </select>
-                </div>
-                <div>
-                  <label :for="'edit-browser-' + agent.id" class="text-[11px] text-gray-500">Browser</label>
-                  <select :id="'edit-browser-' + agent.id" x-model="editForm.browser_backend" class="dash-select w-full mt-0.5">
-                    <template x-for="b in availableBrowsers" :key="b">
-                      <option :value="b" x-text="b"></option>
-                    </template>
-                  </select>
-                </div>
-                <div>
-                  <label :for="'edit-role-' + agent.id" class="text-[11px] text-gray-500">Role</label>
-                  <input :id="'edit-role-' + agent.id" type="text" x-model="editForm.role" class="dash-input w-full mt-0.5">
-                </div>
-                <div>
-                  <label :for="'edit-prompt-' + agent.id" class="text-[11px] text-gray-500">System Prompt</label>
-                  <textarea :id="'edit-prompt-' + agent.id" x-model="editForm.system_prompt" class="dash-textarea w-full mt-0.5" rows="3"></textarea>
-                </div>
-                <div>
-                  <label :for="'edit-budget-' + agent.id" class="text-[11px] text-gray-500">Budget ($/day)</label>
-                  <input :id="'edit-budget-' + agent.id" type="number" step="0.5" min="0.1" x-model="editForm.budget_daily" class="dash-input w-full mt-0.5" placeholder="10.0">
-                </div>
-                <div class="flex gap-2 mt-3">
-                  <button @click="saveAgentConfig(agent.id)" class="text-xs px-3 py-1.5 rounded bg-indigo-600 hover:bg-indigo-500 text-white transition-colors">Save</button>
-                  <button @click="cancelEdit()" class="text-xs px-3 py-1.5 rounded bg-gray-800 hover:bg-gray-700 text-gray-400 transition-colors">Cancel</button>
-                </div>
-              </div>
-            </div>
-          </template>
-        </div>
-        <div x-show="agents.length === 0" class="text-center py-16 text-gray-600">No agents available</div>
       </div>
 
       <!-- Agent Detail -->
@@ -556,118 +601,10 @@
         </div>
       </div>
 
-      <!-- Traces -->
-      <div x-show="activeTab === 'traces'" x-cloak>
-        <div class="grid grid-cols-1 lg:grid-cols-2 gap-4">
-          <!-- Trace list -->
-          <div class="bg-gray-900 border border-gray-800 rounded-lg p-4">
-            <div class="flex items-center justify-between mb-3">
-              <div class="text-xs text-gray-500 uppercase tracking-wider">Recent Traces</div>
-              <span class="text-xs text-gray-700" x-text="traces.length + ' events'"></span>
-            </div>
-            <div class="space-y-0.5 max-h-[calc(100vh-14rem)] overflow-y-auto custom-scrollbar">
-              <template x-for="t in traces" :key="t.trace_id + t.timestamp">
-                <div
-                  @click="fetchTraceDetail(t.trace_id)"
-                  class="flex items-center gap-2 px-2.5 py-2 rounded-md cursor-pointer text-sm transition-all"
-                  :class="selectedTraceId === t.trace_id ? 'bg-gray-800 border border-gray-700' : 'hover:bg-gray-800/50'"
-                >
-                  <span class="font-mono text-blue-400/80 text-xs" x-text="t.trace_id.substring(0, 12)"></span>
-                  <span class="text-gray-500 text-xs" x-text="t.agent"></span>
-                  <span class="event-badge text-[10px]" :class="eventColor(t.event_type)" x-text="t.event_type"></span>
-                  <span class="text-gray-700 text-xs ml-auto font-mono" x-text="timeAgo(t.timestamp)"></span>
-                </div>
-              </template>
-              <!-- Loading -->
-              <div x-show="traces.length === 0 && tracesLoading" class="text-center py-8" x-cloak>
-                <div class="inline-flex items-center gap-2 text-gray-600 text-sm">
-                  <svg class="animate-spin h-4 w-4" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24"><circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle><path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z"></path></svg>
-                  Loading...
-                </div>
-              </div>
-              <!-- Empty state -->
-              <div x-show="traces.length === 0 && !tracesLoading" class="text-center py-8" x-cloak>
-                <div class="text-gray-600 text-sm">No traces recorded yet</div>
-              </div>
-            </div>
-          </div>
-          <!-- Trace detail -->
-          <div class="bg-gray-900 border border-gray-800 rounded-lg p-4">
-            <div class="text-xs text-gray-500 uppercase tracking-wider mb-3">
-              Trace <span class="font-mono text-blue-400 normal-case" x-text="selectedTraceId || ''"></span>
-            </div>
-            <template x-if="traceDetail && traceDetail.events">
-              <div class="space-y-0 max-h-[calc(100vh-14rem)] overflow-y-auto custom-scrollbar">
-                <template x-for="(evt, i) in traceDetail.events" :key="i">
-                  <div class="relative pl-6 border-l-2 border-gray-800 pb-3 last:pb-0">
-                    <div class="absolute left-[-5px] top-1.5 w-2 h-2 rounded-full" :class="eventBgColor(evt.event_type)"></div>
-                    <div class="flex items-center gap-2 text-sm">
-                      <span class="event-badge" :class="eventColor(evt.event_type)" x-text="evt.event_type"></span>
-                      <span class="text-gray-500 text-xs" x-text="evt.source"></span>
-                      <span x-show="evt.duration_ms > 0" class="text-gray-600 text-xs font-mono" x-text="evt.duration_ms + 'ms'"></span>
-                    </div>
-                    <div class="text-xs text-gray-500 mt-0.5" x-show="evt.agent" x-text="evt.agent"></div>
-                    <div class="text-xs text-gray-600 mt-0.5 font-mono" x-text="evt.detail" x-show="evt.detail"></div>
-                    <template x-if="evt.duration_ms > 0 && traceDetail.events.length > 1">
-                      <div class="waterfall-bar mt-1.5"
-                        :style="waterfall(evt, traceDetail.events)"
-                      ></div>
-                    </template>
-                  </div>
-                </template>
-              </div>
-            </template>
-            <div x-show="!traceDetail" class="text-center py-12 text-gray-700 text-sm">
-              Select a trace to inspect its event timeline
-            </div>
-          </div>
-        </div>
-      </div>
-
-      <!-- Queues (V2) -->
-      <div x-show="activeTab === 'queues'" x-cloak>
+      <!-- Automation (Cron with inline schedule editing) -->
+      <div x-show="activeTab === 'automation'" x-cloak>
         <div class="flex items-center justify-between mb-4">
-          <h2 class="text-sm font-medium text-gray-400">Task Queues</h2>
-          <button @click="fetchQueues()" class="text-xs px-2 py-1 rounded bg-gray-800 hover:bg-gray-700 text-gray-400 transition-colors">Refresh</button>
-        </div>
-        <div class="bg-gray-900 border border-gray-800 rounded-lg overflow-hidden">
-          <table class="w-full text-sm">
-            <thead>
-              <tr class="text-gray-500 text-left text-xs uppercase tracking-wider border-b border-gray-800">
-                <th class="py-3 px-4">Agent</th>
-                <th class="py-3 px-4">Queue Depth</th>
-                <th class="py-3 px-4">Pending</th>
-                <th class="py-3 px-4">Collected</th>
-                <th class="py-3 px-4">Status</th>
-              </tr>
-            </thead>
-            <tbody>
-              <template x-for="[agent, q] in Object.entries(queueStatus)" :key="agent">
-                <tr class="border-b border-gray-800/40 hover:bg-gray-800/30">
-                  <td class="py-2.5 px-4 font-medium text-white" x-text="agent"></td>
-                  <td class="py-2.5 px-4 font-mono text-gray-300" x-text="q.queued"></td>
-                  <td class="py-2.5 px-4 font-mono text-gray-300" x-text="q.pending"></td>
-                  <td class="py-2.5 px-4 font-mono text-gray-300" x-text="q.collected"></td>
-                  <td class="py-2.5 px-4">
-                    <span class="text-[11px] px-2 py-0.5 rounded-full font-medium"
-                      :class="q.busy ? 'bg-amber-900/30 text-amber-400 border border-amber-800/40' : 'bg-gray-800/50 text-gray-500 border border-gray-700/40'"
-                      x-text="q.busy ? 'busy' : 'idle'"
-                    ></span>
-                  </td>
-                </tr>
-              </template>
-            </tbody>
-          </table>
-          <div x-show="Object.keys(queueStatus).length === 0" class="text-center py-12 text-gray-600">
-            No active queues
-          </div>
-        </div>
-      </div>
-
-      <!-- Cron (V2) -->
-      <div x-show="activeTab === 'cron'" x-cloak>
-        <div class="flex items-center justify-between mb-4">
-          <h2 class="text-sm font-medium text-gray-400">Cron Jobs</h2>
+          <h2 class="text-sm font-medium text-gray-400">Automation</h2>
           <button @click="fetchCronJobs()" class="text-xs px-2 py-1 rounded bg-gray-800 hover:bg-gray-700 text-gray-400 transition-colors">Refresh</button>
         </div>
         <div class="bg-gray-900 border border-gray-800 rounded-lg overflow-hidden">
@@ -679,8 +616,8 @@
                   <th class="py-3 px-4">Agent</th>
                   <th class="py-3 px-4">Schedule</th>
                   <th class="py-3 px-4">Message</th>
-                  <th class="py-3 px-4">HB</th>
-                  <th class="py-3 px-4">Enabled</th>
+                  <th class="py-3 px-4">Type</th>
+                  <th class="py-3 px-4">Status</th>
                   <th class="py-3 px-4">Last Run</th>
                   <th class="py-3 px-4">Runs</th>
                   <th class="py-3 px-4">Errors</th>
@@ -692,18 +629,26 @@
                   <tr class="border-b border-gray-800/40 hover:bg-gray-800/30">
                     <td class="py-2.5 px-4 font-mono text-xs text-blue-400" x-text="job.id"></td>
                     <td class="py-2.5 px-4 text-white" x-text="job.agent"></td>
-                    <td class="py-2.5 px-4 font-mono text-gray-300 text-xs" x-text="job.schedule"></td>
+                    <td class="py-2.5 px-4">
+                      <span x-show="editingCronJob !== job.id" class="font-mono text-gray-300 text-xs cursor-pointer hover:text-indigo-300 transition-colors" @click="editCronJob(job)" x-text="job.schedule"></span>
+                      <div x-show="editingCronJob === job.id" class="flex gap-1 items-center">
+                        <input type="text" x-model="cronEditSchedule" @keyup.enter="saveCronEdit(job.id)" @keyup.escape="cancelCronEdit()" class="dash-input text-xs py-1 px-2 w-32">
+                        <button @click="saveCronEdit(job.id)" class="text-[10px] px-1.5 py-0.5 rounded bg-indigo-600 hover:bg-indigo-500 text-white transition-colors">Save</button>
+                        <button @click="cancelCronEdit()" class="text-[10px] px-1.5 py-0.5 rounded bg-gray-800 hover:bg-gray-700 text-gray-400 transition-colors">X</button>
+                      </div>
+                    </td>
                     <td class="py-2.5 px-4 text-gray-400 text-xs max-w-xs truncate" x-text="job.message"></td>
                     <td class="py-2.5 px-4">
-                      <span x-show="job.heartbeat" class="text-pink-400 heartbeat-indicator text-[11px]">HB</span>
+                      <span x-show="job.heartbeat" class="text-pink-400 heartbeat-indicator text-[11px]">heartbeat</span>
+                      <span x-show="!job.heartbeat" class="text-gray-600 text-[11px]">cron</span>
                     </td>
                     <td class="py-2.5 px-4">
                       <span class="text-[11px] px-2 py-0.5 rounded-full"
                         :class="job.enabled ? 'bg-green-900/30 text-green-400' : 'bg-gray-800/50 text-gray-500'"
-                        x-text="job.enabled ? 'on' : 'off'"
+                        x-text="job.enabled ? 'active' : 'paused'"
                       ></span>
                     </td>
-                    <td class="py-2.5 px-4 text-gray-600 text-xs font-mono" x-text="job.last_run || '-'"></td>
+                    <td class="py-2.5 px-4 text-gray-600 text-xs font-mono" x-text="job.last_run || 'never'"></td>
                     <td class="py-2.5 px-4 font-mono text-gray-300" x-text="job.run_count"></td>
                     <td class="py-2.5 px-4 font-mono" :class="job.error_count > 0 ? 'text-red-400' : 'text-gray-600'" x-text="job.error_count"></td>
                     <td class="py-2.5 px-4 flex gap-1">
@@ -725,14 +670,92 @@
             </table>
           </div>
           <div x-show="cronJobs.length === 0" class="text-center py-12 text-gray-600">
-            No cron jobs configured
+            No automation jobs configured
           </div>
         </div>
       </div>
 
-      <!-- Settings (V2) -->
-      <div x-show="activeTab === 'settings'" x-cloak>
-        <h2 class="text-sm font-medium text-gray-400 mb-4">Settings & Environment</h2>
+      <!-- System (merged: Traces + Settings) -->
+      <div x-show="activeTab === 'system'" x-cloak>
+        <!-- Traces section -->
+        <h3 class="text-sm font-medium text-gray-400 mb-3">Traces</h3>
+        <div class="grid grid-cols-1 lg:grid-cols-2 gap-4 mb-8">
+          <!-- Trace list -->
+          <div class="bg-gray-900 border border-gray-800 rounded-lg p-4">
+            <div class="flex items-center justify-between mb-3">
+              <div class="text-xs text-gray-500 uppercase tracking-wider">Recent Traces</div>
+              <button @click="fetchTraces()" class="text-xs px-2 py-1 rounded bg-gray-800 hover:bg-gray-700 text-gray-400 transition-colors">Refresh</button>
+            </div>
+            <div class="space-y-0.5 max-h-96 overflow-y-auto custom-scrollbar">
+              <template x-for="t in traces" :key="t.trace_id + t.timestamp">
+                <div
+                  @click="fetchTraceDetail(t.trace_id)"
+                  class="flex items-center gap-2 px-2.5 py-2 rounded-md cursor-pointer text-sm transition-all"
+                  :class="selectedTraceId === t.trace_id ? 'bg-gray-800 border border-gray-700' : 'hover:bg-gray-800/50'"
+                >
+                  <span class="font-mono text-blue-400/80 text-xs" x-text="t.trace_id.substring(0, 12)"></span>
+                  <span class="text-gray-500 text-xs" x-text="t.agent || '-'"></span>
+                  <span class="event-badge text-[10px]" :class="eventColor(t.event_type)" x-text="t.event_type"></span>
+                  <span x-show="t.status === 'error'" class="text-red-400 text-[10px]">ERR</span>
+                  <span x-show="t.duration_ms > 0" class="text-gray-700 text-[10px] font-mono" x-text="t.duration_ms + 'ms'"></span>
+                  <span class="text-gray-700 text-xs ml-auto font-mono" x-text="timeAgo(t.timestamp)"></span>
+                </div>
+              </template>
+              <div x-show="traces.length === 0 && tracesLoading" class="text-center py-8" x-cloak>
+                <div class="inline-flex items-center gap-2 text-gray-600 text-sm">
+                  <svg class="animate-spin h-4 w-4" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24"><circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle><path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z"></path></svg>
+                  Loading...
+                </div>
+              </div>
+              <div x-show="traces.length === 0 && !tracesLoading" class="text-center py-8" x-cloak>
+                <div class="text-gray-600 text-sm">No traces recorded yet</div>
+              </div>
+            </div>
+          </div>
+          <!-- Trace detail -->
+          <div class="bg-gray-900 border border-gray-800 rounded-lg p-4">
+            <div class="text-xs text-gray-500 uppercase tracking-wider mb-3">
+              Trace <span class="font-mono text-blue-400 normal-case" x-text="selectedTraceId || ''"></span>
+            </div>
+            <template x-if="traceDetail && traceDetail.events">
+              <div class="space-y-0 max-h-96 overflow-y-auto custom-scrollbar">
+                <template x-for="(evt, i) in traceDetail.events" :key="i">
+                  <div class="relative pl-6 border-l-2 pb-3 last:pb-0" :class="evt.status === 'error' ? 'border-red-900/50' : 'border-gray-800'">
+                    <div class="absolute left-[-5px] top-1.5 w-2 h-2 rounded-full" :class="evt.status === 'error' ? 'bg-red-500' : eventBgColor(evt.event_type)"></div>
+                    <div class="flex items-center gap-2 text-sm">
+                      <span class="event-badge" :class="eventColor(evt.event_type)" x-text="evt.event_type"></span>
+                      <span class="text-gray-500 text-xs" x-text="evt.source"></span>
+                      <span x-show="evt.agent" class="text-gray-600 text-xs" x-text="evt.agent"></span>
+                      <span x-show="evt.duration_ms > 0" class="text-gray-600 text-xs font-mono" x-text="evt.duration_ms + 'ms'"></span>
+                      <span x-show="evt.status === 'error'" class="text-red-400 text-xs font-medium">FAILED</span>
+                    </div>
+                    <div class="text-xs text-gray-400 mt-0.5 font-mono" x-text="evt.detail" x-show="evt.detail"></div>
+                    <div x-show="evt.error" class="text-xs text-red-400/80 mt-0.5 font-mono" x-text="evt.error"></div>
+                    <!-- Meta details (model, tokens, etc.) -->
+                    <template x-if="evt.meta && Object.keys(evt.meta).length > 0">
+                      <div class="mt-1 flex flex-wrap gap-x-3 gap-y-0.5">
+                        <template x-for="[k, v] in Object.entries(evt.meta)" :key="k">
+                          <span class="text-[10px] text-gray-600"><span class="text-gray-700" x-text="k"></span>=<span class="text-gray-500" x-text="typeof v === 'string' && v.length > 80 ? v.substring(0, 80) + '...' : v"></span></span>
+                        </template>
+                      </div>
+                    </template>
+                    <template x-if="evt.duration_ms > 0 && traceDetail.events.length > 1">
+                      <div class="waterfall-bar mt-1.5"
+                        :style="waterfall(evt, traceDetail.events)"
+                      ></div>
+                    </template>
+                  </div>
+                </template>
+              </div>
+            </template>
+            <div x-show="!traceDetail" class="text-center py-12 text-gray-700 text-sm">
+              Select a trace to inspect its event timeline
+            </div>
+          </div>
+        </div>
+
+        <!-- Settings section -->
+        <h3 class="text-sm font-medium text-gray-400 mb-3 mt-8">Settings</h3>
         <div x-show="!settingsData" class="text-center py-12 text-gray-600">Loading...</div>
         <template x-if="settingsData">
           <div class="grid grid-cols-1 lg:grid-cols-2 gap-4">
@@ -742,13 +765,21 @@
               <div class="text-sm text-gray-400 mb-2">
                 <span x-text="settingsData.credentials.count"></span> credential(s) configured
               </div>
-              <div class="space-y-1">
+              <div class="space-y-1 mb-3">
                 <template x-for="name in settingsData.credentials.names" :key="name">
                   <div class="flex items-center gap-2 text-xs">
                     <span class="w-2 h-2 rounded-full bg-green-500/50"></span>
                     <span class="text-gray-300 font-mono" x-text="name"></span>
                   </div>
                 </template>
+              </div>
+              <div class="border-t border-gray-800 pt-3">
+                <div class="text-xs text-gray-500 mb-2">Add credential</div>
+                <div class="flex gap-2">
+                  <input type="text" x-model="credService" class="dash-input flex-1" placeholder="Service (e.g. openai)">
+                  <input type="password" x-model="credKey" class="dash-input flex-1" placeholder="API key">
+                  <button @click="addCredential()" class="text-xs px-3 py-1.5 rounded bg-indigo-600 hover:bg-indigo-500 text-white transition-colors">Add</button>
+                </div>
               </div>
             </div>
             <!-- PubSub subscriptions -->

--- a/src/host/mesh.py
+++ b/src/host/mesh.py
@@ -309,6 +309,7 @@ class MessageRouter:
     ):
         self.permissions = permissions
         self.agent_registry: dict[str, str] = agent_registry
+        self.agent_roles: dict[str, str] = {}
         self.message_log: list[dict] = []
         self._capabilities_cache: dict[str, list[str]] = {}
         self._client: httpx.AsyncClient | None = None
@@ -377,9 +378,15 @@ class MessageRouter:
 
         return None
 
-    def register_agent(self, agent_id: str, url: str, capabilities: list[str] | None = None) -> None:
+    def register_agent(
+        self, agent_id: str, url: str,
+        capabilities: list[str] | None = None,
+        role: str = "",
+    ) -> None:
         """Register an agent and its capabilities."""
         self.agent_registry[agent_id] = url
+        if role:
+            self.agent_roles[agent_id] = role
         if capabilities:
             self._capabilities_cache[agent_id] = capabilities
         else:
@@ -389,3 +396,4 @@ class MessageRouter:
         """Remove an agent from the registry."""
         self.agent_registry.pop(agent_id, None)
         self._capabilities_cache.pop(agent_id, None)
+        self.agent_roles.pop(agent_id, None)

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -552,7 +552,12 @@ class TestDashboardQueues:
     def test_queues_empty(self):
         resp = self.client.get("/dashboard/api/queues")
         assert resp.status_code == 200
-        assert resp.json()["queues"] == {}
+        queues = resp.json()["queues"]
+        # All agents appear with idle status (even without active lanes)
+        assert "alpha" in queues
+        assert "beta" in queues
+        assert queues["alpha"]["busy"] is False
+        assert queues["alpha"]["queued"] == 0
 
     def test_queues_with_data(self):
         self.components["lane_manager"].get_status.return_value = {
@@ -569,7 +574,10 @@ class TestDashboardQueues:
         self.client = _make_client(self.components)
         resp = self.client.get("/dashboard/api/queues")
         assert resp.status_code == 200
-        assert resp.json()["queues"] == {}
+        queues = resp.json()["queues"]
+        # All agents still appear with idle defaults
+        assert "alpha" in queues
+        assert queues["alpha"]["busy"] is False
 
 
 # ── V2 Tests: Cron ──────────────────────────────────────────


### PR DESCRIPTION
## Summary

- **Auto-heartbeat**: Every agent automatically gets a heartbeat cron job on startup (`_reconcile_heartbeats()`), configurable via `heartbeat_schedule` in mesh.yaml
- **Always-dispatch**: Agents always wake on heartbeat — probes become informational context, not a gate
- **Cron editing**: `PUT /mesh/cron/{job_id}` endpoint + dashboard inline schedule editing
- **Dashboard 9→6 tabs**: Fleet+Agents+Queues → Fleet, Events → Activity, Cron → Automation, Traces+Settings → System
- **Bug fixes**: WebSocket event duplicates (sequence counter + subscribe-before-replay), queue visibility (merge registry with lane status)
- **Richer traces**: Added status/error/meta columns with backward-compatible ALTER TABLE migration
- **Fleet collaboration**: Agents auto-receive team roster in system prompt (solo agents opt out automatically)
- **Dashboard REPL parity**: Chat, broadcast, steer, reset, credential management — all available in dashboard
- **UI/UX polish**: Queue status on agent cards, clearer Automation wording, trace detail view with error highlighting

17 files changed, 907 insertions(+), 324 deletions(-). All 839 tests pass.

## Test plan

- [x] `pytest tests/ --ignore=tests/test_e2e*.py -x -q` — 839 passed
- [x] HTML template balanced (186 divs, 26 templates)
- [x] All 6 tab panels render correctly
- [ ] Manual: `openlegion start` — verify all agents get auto-heartbeat jobs in Automation tab
- [ ] Manual: verify chat/broadcast/steer/reset work from dashboard UI
- [ ] Manual: verify trace detail shows status, error, meta fields

🤖 Generated with [Claude Code](https://claude.com/claude-code)