### PR TITLE
Fix real-world dashboard issues

### DIFF
--- a/src/dashboard/events.py
+++ b/src/dashboard/events.py
@@ -126,7 +126,7 @@ class EventBus:
         result = []
         for e in self._buffer:
             if before_seq is not None and e.get("_seq", 0) > before_seq:
-                continue
+                break
             if agents_filter or types_filter:
                 if not sub.matches(e):
                     continue

--- a/src/dashboard/server.py
+++ b/src/dashboard/server.py
@@ -199,6 +199,16 @@ def create_dashboard_router(
         if health_monitor is not None:
             health_monitor.unregister(agent_id)
 
+        # Clean up PubSub subscriptions, cron jobs, and lane state
+        if pubsub is not None:
+            pubsub.unsubscribe_agent(agent_id)
+        if cron_scheduler is not None:
+            removed = cron_scheduler.remove_agent_jobs(agent_id)
+            if removed:
+                logger.info(f"Removed {removed} cron job(s) for agent {agent_id}")
+        if lane_manager is not None:
+            lane_manager.remove_lane(agent_id)
+
         # Remove from config and permissions (best-effort — don't fail if files are missing)
         try:
             import yaml

--- a/src/host/cron.py
+++ b/src/host/cron.py
@@ -149,6 +149,15 @@ class CronScheduler:
         self._save()
         return True
 
+    def remove_agent_jobs(self, agent_id: str) -> int:
+        """Remove ALL jobs for a given agent. Returns count of removed jobs."""
+        to_remove = [jid for jid, job in self.jobs.items() if job.agent == agent_id]
+        for jid in to_remove:
+            del self.jobs[jid]
+        if to_remove:
+            self._save()
+        return len(to_remove)
+
     def pause_job(self, job_id: str) -> bool:
         if job_id not in self.jobs:
             return False

--- a/src/host/lanes.py
+++ b/src/host/lanes.py
@@ -213,6 +213,16 @@ class LaneManager:
             }
         return result
 
+    def remove_lane(self, agent: str) -> None:
+        """Remove all lane state for an agent, cancelling its worker task."""
+        worker = self._workers.pop(agent, None)
+        if worker is not None:
+            worker.cancel()
+        self._queues.pop(agent, None)
+        self._pending.pop(agent, None)
+        self._collect_buffers.pop(agent, None)
+        self._busy.pop(agent, None)
+
     async def stop(self) -> None:
         """Cancel all worker tasks."""
         for task in self._workers.values():

--- a/src/host/mesh.py
+++ b/src/host/mesh.py
@@ -266,6 +266,16 @@ class PubSub:
                 )
                 self._db.commit()
 
+    def unsubscribe_agent(self, agent_id: str) -> None:
+        """Remove an agent from ALL topic subscriptions."""
+        for topic in list(self.subscriptions):
+            self.subscriptions[topic] = [a for a in self.subscriptions[topic] if a != agent_id]
+            if not self.subscriptions[topic]:
+                del self.subscriptions[topic]
+        if self._db is not None:
+            self._db.execute("DELETE FROM subscriptions WHERE agent_id = ?", (agent_id,))
+            self._db.commit()
+
     def get_subscribers(self, topic: str) -> list[str]:
         return self.subscriptions.get(topic, [])
 

--- a/tests/test_cron.py
+++ b/tests/test_cron.py
@@ -88,6 +88,30 @@ class TestCronScheduler:
         agents = {j["agent"] for j in jobs}
         assert agents == {"a", "b"}
 
+    def test_remove_agent_jobs(self):
+        sched = CronScheduler(config_path=self.config_path)
+        sched.add_job(agent="a", schedule="every 1h", message="m1")
+        sched.add_job(agent="a", schedule="every 2h", message="m2")
+        sched.add_job(agent="b", schedule="every 1h", message="m3")
+        assert sched.remove_agent_jobs("a") == 2
+        assert len(sched.jobs) == 1
+        assert list(sched.jobs.values())[0].agent == "b"
+
+    def test_remove_agent_jobs_none(self):
+        sched = CronScheduler(config_path=self.config_path)
+        sched.add_job(agent="a", schedule="every 1h", message="m1")
+        assert sched.remove_agent_jobs("nonexistent") == 0
+        assert len(sched.jobs) == 1
+
+    def test_remove_agent_jobs_persists(self):
+        sched = CronScheduler(config_path=self.config_path)
+        sched.add_job(agent="a", schedule="every 1h", message="m1")
+        sched.add_job(agent="b", schedule="every 1h", message="m2")
+        sched.remove_agent_jobs("a")
+        sched2 = CronScheduler(config_path=self.config_path)
+        assert len(sched2.jobs) == 1
+        assert list(sched2.jobs.values())[0].agent == "b"
+
 
 class TestCronIntervalDue:
     def setup_method(self):

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -62,8 +62,8 @@ def _make_components(tmp_path: str, *, include_v2: bool = False) -> dict:
         orchestrator.workflows = {}
         orchestrator.active_executions = {}
 
-        from src.host.mesh import PubSub
-        pubsub = PubSub()
+        pubsub = MagicMock()
+        pubsub.subscriptions = {}
 
         permissions_mock = MagicMock()
         credential_vault = MagicMock()
@@ -263,6 +263,10 @@ class TestDashboardAgentCRUD:
         assert "alpha" not in self.components["agent_registry"]
         # Verify health monitor cleanup
         assert "alpha" not in self.components["health_monitor"].agents
+        # Verify PubSub, cron, and lane cleanup
+        self.components["pubsub"].unsubscribe_agent.assert_called_once_with("alpha")
+        self.components["cron_scheduler"].remove_agent_jobs.assert_called_once_with("alpha")
+        self.components["lane_manager"].remove_lane.assert_called_once_with("alpha")
 
     def test_delete_agent_not_found(self):
         resp = self.client.delete("/dashboard/api/agents/nonexistent")

--- a/tests/test_lanes.py
+++ b/tests/test_lanes.py
@@ -232,6 +232,32 @@ async def test_status_includes_collected_and_busy():
 
 
 @pytest.mark.asyncio
+async def test_remove_lane():
+    """remove_lane cleans up all state for an agent."""
+    lm = LaneManager(dispatch_fn=AsyncMock(return_value="ok"))
+
+    await lm.enqueue("agent1", "hi")
+    await lm.enqueue("agent2", "hi")
+    assert "agent1" in lm._workers
+    assert "agent2" in lm._workers
+
+    lm.remove_lane("agent1")
+    assert "agent1" not in lm._workers
+    assert "agent1" not in lm._queues
+    assert "agent1" not in lm._pending
+    assert "agent1" not in lm._busy
+    # agent2 should be unaffected
+    assert "agent2" in lm._workers
+
+
+@pytest.mark.asyncio
+async def test_remove_lane_nonexistent():
+    """remove_lane on nonexistent agent doesn't raise."""
+    lm = LaneManager(dispatch_fn=AsyncMock(return_value="ok"))
+    lm.remove_lane("nonexistent")  # should not raise
+
+
+@pytest.mark.asyncio
 async def test_stop_cancels_workers():
     """Stop cancels all worker tasks."""
     lm = LaneManager(dispatch_fn=AsyncMock(return_value="ok"))

--- a/tests/test_mesh.py
+++ b/tests/test_mesh.py
@@ -184,6 +184,35 @@ def test_pubsub_no_db_backward_compat():
     ps.close()  # should not raise
 
 
+def test_pubsub_unsubscribe_agent():
+    """unsubscribe_agent removes agent from all topics."""
+    ps = PubSub()
+    ps.subscribe("topic1", "a1")
+    ps.subscribe("topic1", "a2")
+    ps.subscribe("topic2", "a1")
+    ps.subscribe("topic3", "a3")
+    ps.unsubscribe_agent("a1")
+    assert ps.get_subscribers("topic1") == ["a2"]
+    assert ps.get_subscribers("topic2") == []
+    assert ps.get_subscribers("topic3") == ["a3"]
+
+
+def test_pubsub_unsubscribe_agent_persistence(tmp_path):
+    """unsubscribe_agent is persisted to SQLite."""
+    db = str(tmp_path / "pubsub.db")
+    ps1 = PubSub(db_path=db)
+    ps1.subscribe("t1", "a1")
+    ps1.subscribe("t2", "a1")
+    ps1.subscribe("t1", "a2")
+    ps1.unsubscribe_agent("a1")
+    ps1.close()
+
+    ps2 = PubSub(db_path=db)
+    assert ps2.get_subscribers("t1") == ["a2"]
+    assert ps2.get_subscribers("t2") == []
+    ps2.close()
+
+
 # === Permission Tests ===
 
 


### PR DESCRIPTION
## Summary

Fixes 6 real-world issues discovered during dashboard usage:

- **NaN timestamps**: `timeAgo()` expected Unix epoch but received ISO 8601 strings from `DashboardEvent.model_dump(mode="json")` — all events showed "NaNd ago"
- **Duplicate events**: WebSocket reconnect replayed all buffered events without dedup — every event appeared twice
- **Event noise**: Failed API calls (missing embed keys) and empty streaming events emitted `llm_call` with no model/token data — activity feed flooded with "? · 0 tok"
- **Deleted agents persist**: PubSub subscriptions, cron/heartbeat jobs, and lane worker tasks survived agent deletion
- **CLI remove gaps**: Missing health_monitor.unregister and all PubSub/cron/lane cleanup
- **Cost inaccuracy**: Credential vault used hardcoded 70/30 token split instead of actual prompt/completion counts from LLM response

## Changes

| Area | Fix |
|------|-----|
| `app.js` | Parse ISO strings in `timeAgo()` and `waterfall()`; client-side event dedup by ID with Set eviction; graceful `eventSummary()` fallback for model-less events |
| `events.py` | `break` instead of `continue` in `recent_events()` (ordered buffer optimization) |
| `server.py` | Only emit `llm_call` on successful API calls; remove empty streaming event |
| `credentials.py` | Include `input_tokens`/`output_tokens` in response data; use actual values for cost tracking |
| `mesh.py` | Add `PubSub.unsubscribe_agent()` — removes agent from all topics + persists |
| `cron.py` | Add `CronScheduler.remove_agent_jobs()` — removes all jobs for agent + persists |
| `lanes.py` | Add `LaneManager.remove_lane()` — cancels worker, clears all state |
| `dashboard/server.py` | Wire PubSub/cron/lane cleanup into `api_remove_agent()` |
| `cli/repl.py` | Wire all cleanup into `_cmd_remove()` including health_monitor |

## Test plan

- [x] 854 tests pass (9 new: before_seq replay, unsubscribe_agent, remove_agent_jobs, remove_lane)
- [x] HTML balanced (200/200)
- [x] No `cost_update` references in src/
- [x] Cost and credential tests pass with actual token breakdown

🤖 Generated with [Claude Code](https://claude.com/claude-code)