### PR TITLE
fix(loop): re-register with mesh after skill reload for dashboard refresh

### DIFF
--- a/src/agent/loop.py
+++ b/src/agent/loop.py
@@ -802,16 +802,24 @@ class AgentLoop:
             success=False,
         )
 
-    def _maybe_reload_skills(self, result: Any) -> None:
+    async def _maybe_reload_skills(self, result: Any) -> None:
         """If a tool returned reload_requested, hot-reload the skill registry.
 
         Sets ``_skills_reloaded`` so callers can rebuild system prompts
-        with updated tool descriptions.
+        with updated tool descriptions.  Also re-registers with the mesh
+        so the dashboard receives an ``agent_state``/``registered`` event
+        and can refresh the capabilities panel immediately.
         """
         if isinstance(result, dict) and result.get("reload_requested"):
             count = self.skills.reload()
             self._skills_reloaded = True
             logger.info(f"Hot-reloaded skills: {count} available")
+            try:
+                await self.mesh_client.register(
+                    capabilities=self.skills.list_skills(),
+                )
+            except Exception as e:
+                logger.warning("Post-reload mesh re-registration failed: %s", e)
 
     @staticmethod
     def _collect_tool_names(messages: list[dict]) -> list[str]:
@@ -1505,7 +1513,7 @@ class AgentLoop:
                 )
             try:
                 await self._learn(tool_call.name, tool_call.arguments, result)
-                self._maybe_reload_skills(result)
+                await self._maybe_reload_skills(result)
             except Exception as learn_err:
                 logger.warning("Post-tool learning failed for %s: %s", tool_call.name, learn_err)
 

--- a/tests/test_chat.py
+++ b/tests/test_chat.py
@@ -33,6 +33,7 @@ def _make_loop(llm_responses: list[LLMResponse] | None = None) -> AgentLoop:
 
     mesh_client = MagicMock()
     mesh_client.send_system_message = AsyncMock(return_value={})
+    mesh_client.register = AsyncMock(return_value=None)
 
     return AgentLoop(
         agent_id="test_agent",

--- a/tests/test_chat_workspace.py
+++ b/tests/test_chat_workspace.py
@@ -49,6 +49,7 @@ def _make_loop_with_workspace(
 
     mesh_client = MagicMock()
     mesh_client.send_system_message = AsyncMock(return_value={})
+    mesh_client.register = AsyncMock(return_value=None)
 
     workspace = WorkspaceManager(workspace_dir=tmpdir)
     context_mgr = ContextManager(max_tokens=context_max_tokens, llm=llm, workspace=workspace)

--- a/tests/test_loop.py
+++ b/tests/test_loop.py
@@ -60,6 +60,7 @@ def _make_loop(llm_responses: list[LLMResponse] | None = None, *, real_memory: b
     mesh_client.send_system_message = AsyncMock(return_value={})
     mesh_client.read_blackboard = AsyncMock(return_value=None)
     mesh_client.list_agents = AsyncMock(return_value={})
+    mesh_client.register = AsyncMock(return_value=None)
 
     loop = AgentLoop(
         agent_id="test_agent",


### PR DESCRIPTION
## Summary

- After an agent hot-reloads skills via `reload_skills`, the dashboard didn't update the capabilities panel until a full page navigation. The root cause: `_maybe_reload_skills` in `loop.py` called `self.skills.reload()` but never re-registered with the mesh, so no `agent_state`/`registered` WebSocket event reached the dashboard.
- Made `_maybe_reload_skills` async and added a `mesh_client.register()` call after reload. The dashboard already handles `agent_state`/`registered` events (app.js:1103), so no dashboard changes were needed.
- Registration failure is caught and logged as a warning to avoid breaking the tool execution flow.

## Test plan

- [x] `tests/test_loop.py` — 137 tests pass (includes `test_skills_reload_rebuilds_system_prompt`)
- [x] `tests/test_chat.py` — 54 tests pass
- [x] `tests/test_builtins.py` — 91 tests pass
- [x] `tests/test_skills.py` — 93 tests pass (skill reload mechanics)
- [x] `tests/test_chat_workspace.py` — 19 tests pass
- [x] All 394 tests across the 5 files pass with no regressions