### PR TITLE
External Integration Workflow (incoming API & outgoing webhooks)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -54,7 +54,7 @@ Three trust zones: **User** (full trust), **Mesh** (trusted coordinator), **Agen
 | `file_tool.py` | File I/O with two-stage path traversal protection (`lstat()` for symlink safety) |
 | `http_tool.py` | HTTP requests with CRED handles, SSRF protection (DNS pinning, IP blocking incl. CGNAT, 6to4, Teredo), cross-origin auth header stripping |
 | `memory_tool.py` | Memory search with hierarchical fallback, memory save |
-| `mesh_tool.py` | Blackboard (with `sanitize_for_prompt()`), pub/sub, notify_user, list_agents, artifacts, cron, spawn |
+| `mesh_tool.py` | Blackboard (with `sanitize_for_prompt()`), pub/sub, notify_user, emit_event, list_agents, artifacts, cron, spawn |
 | `coordination_tool.py` | Structured multi-agent coordination protocol — hand_off, check_inbox, update_status. Higher-level wrappers over blackboard for inter-agent work handoffs. |
 | `vault_tool.py` | Credential generation without returning actual values |
 | `web_search_tool.py` | DuckDuckGo search (no API key needed) |
@@ -64,7 +64,7 @@ Three trust zones: **User** (full trust), **Mesh** (trusted coordinator), **Agen
 | `introspect_tool.py` | Runtime state query (permissions, budget, fleet, cron, health) |
 | `wallet_tool.py` | Wallet operations — get address, get balance, read contract, transfer, execute (Ethereum + Solana) |
 | **`src/host/`** | |
-| `server.py` | Mesh FastAPI app factory — 43 endpoints, all permission-checked. `_RATE_LIMITS` dict (13 entries). VNC reverse proxy with agent token rejection. Localhost validation for `x-mesh-internal`. |
+| `server.py` | Mesh FastAPI app factory — 44 endpoints, all permission-checked. Rate limits on state-mutating endpoints (`_RATE_LIMITS` dict at top of file). VNC reverse proxy with agent token rejection. Localhost validation for `x-mesh-internal`. |
 | `mesh.py` | Blackboard (SQLite WAL), PubSub, MessageRouter |
 | `runtime.py` | RuntimeBackend ABC → DockerBackend / SandboxBackend. Container security: non-root UID 1000, `cap_drop=[ALL]`, `no-new-privileges`, `read_only=True`, `tmpfs=/tmp` (100m, noexec, nosuid), `mem_limit=384m`, `cpu_quota=15000` (0.15 CPU), `pids_limit=256`. |
 | `transport.py` | Transport ABC → HttpTransport / SandboxTransport |
@@ -77,7 +77,8 @@ Three trust zones: **User** (full trust), **Mesh** (trusted coordinator), **Agen
 | `failover.py` | Model health tracking + failover chains |
 | `traces.py` | Request tracing + grouped summaries |
 | `transcript.py` | Provider-specific transcript sanitization |
-| `webhooks.py` | Named webhook endpoints (payloads sanitized, 1MB body size limit) |
+| `api_endpoints.py` | Named API endpoints that accept third-party POSTs and dispatch to agents (payloads sanitized, 1MB body size limit) |
+| `outbound_webhooks.py` | Outbound webhook delivery — POSTs signed event payloads to registered third-party URLs with retry |
 | `watchers.py` | File watcher with polling (messages sanitized) |
 | `wallet.py` | WalletService — Ethereum and Solana wallet operations |
 | `api_keys.py` | Named API key management — salted SHA-256 hashes stored in `config/api_keys.json`. Raw keys returned once at creation. |
@@ -97,7 +98,7 @@ Three trust zones: **User** (full trust), **Mesh** (trusted coordinator), **Agen
 | `slack.py` | Slack adapter (Socket Mode, sanitized streaming) |
 | `whatsapp.py` | WhatsApp Cloud API adapter (`X-Hub-Signature-256` verification, warns when signature verification disabled) |
 | **`src/dashboard/`** | |
-| `server.py` | Dashboard FastAPI router + 95 API endpoints + VNC URL injection. Alpine.js SPA with `autoescape=True`, CSP headers, CSRF via `X-Requested-With` requirement on state-changing endpoints. |
+| `server.py` | Dashboard FastAPI router + API endpoints + VNC URL injection + outbound webhook management endpoints. Alpine.js SPA with `autoescape=True`, CSP headers, CSRF via `X-Requested-With` requirement on state-changing endpoints. |
 | `events.py` | EventBus for real-time WebSocket streaming. `threading.Lock` on `emit()`. |
 | `auth.py` | Session cookie verification for dashboard access |
 | `static/` | JS (app.js, websocket.js), CSS, avatars (50 SVGs), favicons |
@@ -182,19 +183,20 @@ Provisioner manages engine instances via Docker/systemd on Hetzner VPS:
 - **Agents never hold API keys.** All LLM/API calls go through mesh credential vault.
 - **No `eval()`/`exec()` on untrusted input.** Skill self-authoring uses AST validation.
 - **Permission checks on all mesh endpoints.** Default deny.
-- **Rate limits on state-mutating mesh endpoints.** 13 rate-limited categories defined in `server.py:_RATE_LIMITS`.
+- **Rate limits on state-mutating mesh endpoints.** API proxy, vault, notify, emit_event, spawn, cron_create, wallet (read/transfer/execute), image_gen all rate-limited. Defined in `server.py:_RATE_LIMITS`.
 - **File path traversal protection.** Two-stage validation in `file_tool.py` (reject `..` before resolution, then walk with symlink resolution via `lstat()`). Workspace `_read_file()` uses `resolve` + `is_relative_to`.
 - **Container hardening.** Non-root (UID 1000), `no-new-privileges`, `cap_drop=[ALL]`, `read_only=True`, `tmpfs=/tmp` (100m, noexec, nosuid), 384MB memory, 0.15 CPU, `pids_limit=256`.
-- **All untrusted text sanitized** via `sanitize_for_prompt()` before reaching LLM context.
+- **All untrusted text sanitized** via `sanitize_for_prompt()` before reaching LLM context (72 call sites across 14 source files including inter-agent messages and daily logs).
 - **VNC proxy blocks agent Bearer tokens.** Dashboard auth required (`ol_session` cookie on HTTP and WebSocket).
 - **AST validation for skill self-authoring.** `_FORBIDDEN_IMPORTS` (23 modules), `_FORBIDDEN_CALLS` (16 functions incl. eval, exec, open), `_FORBIDDEN_ATTRS` (11 attributes incl. `__dict__`, `__subclasses__`).
-- **SSRF protection.** DNS pinning + IP blocking including `0.0.0.0` (unspecified), CGNAT (`100.64.0.0/10`), IPv4-mapped IPv6, 6to4 (`2002::/16`), Teredo (`2001::/32`). Max 5 redirects with re-validation at each hop.
+- **SSRF protection.** DNS pinning + IP blocking including `0.0.0.0` (unspecified), CGNAT (`100.64.0.0/10`), IPv4-mapped IPv6, 6to4 (`2002::/16`), Teredo (`2001::/32`). Max 5 redirects with re-validation at each hop. Also applied to outbound webhook delivery URLs.
+- **Outbound webhook signing.** HMAC-SHA256 signatures on all outbound webhook payloads (`X-OpenLegion-Signature` header).
 - **Credential isolation.** Two-tier vault (SYSTEM_*/CRED_*), opaque handles. Dashboard shows masked values (last 4 chars).
 - **Bounded execution.** 20 iterations for tasks, 30 tool rounds for chat, 200 total chat rounds, token budgets per task. Env-var bounds clamped with validation.
 - **Write-then-compact.** Before discarding context, important facts flush to MEMORY.md. Empty summary falls back to hard prune.
 - **CSRF protection.** Dashboard state-changing endpoints require `X-Requested-With` header.
 - **Workspace file caps.** `_FILE_CAPS` enforced on workspace writes (HTTP 413).
-- **Webhook body size limit.** 1MB with Content-Length pre-check.
+- **API endpoint body size limit.** 1MB with Content-Length pre-check.
 - **Wallet seed protection.** Seed reveal endpoint returns HTTP 410 (seed shown once at init). Init response has `Cache-Control: no-store`.
 - **Env file permissions.** `.agent.env` written with `chmod(0o600)`.
 
@@ -236,7 +238,7 @@ Provisioner manages engine instances via Docker/systemd on Hetzner VPS:
 6. **`src/shared/types.py` is the contract.** Every cross-component message is a Pydantic model here (335 lines, 24 models).
 7. **LLM tool-calling message roles must alternate.** `user → assistant(tool_calls) → tool(result) → assistant`. `_trim_context` merges summary into first user message to preserve this invariant.
 8. **busy_timeout variance.** Traces uses 5000ms while other SQLite connections use 30000ms.
-9. **Monolithic server files.** `dashboard/server.py` (~3045 lines, 95 endpoints) and `host/server.py` (~1566 lines, 43 endpoints) are single function-scoped definitions.
+9. **Monolithic server files.** `dashboard/server.py` (~3130 lines) and `host/server.py` (~1580 lines) are single function-scoped definitions.
 10. **`containers.py` backward-compat alias.** Only consumed by E2E tests.
 
 ## Git Workflow
@@ -267,7 +269,7 @@ pytest tests/test_loop.py -x -v
 - Mock LLM responses, not the loop. See `tests/test_loop.py:_make_loop()`.
 - `AsyncMock` for async methods, SQLite in-memory or `tmp_path` for DB paths.
 - E2E tests skip gracefully without Docker + API key.
-- 62 test files covering all modules.
+- 64 test files covering all modules.
 
 ### Test File Mapping
 
@@ -301,7 +303,8 @@ pytest tests/test_loop.py -x -v
 | `src/host/traces.py` | `tests/test_traces.py` |
 | `src/host/transcript.py` | `tests/test_transcript.py` |
 | `src/host/failover.py` | `tests/test_failover.py` |
-| `src/host/webhooks.py` | `tests/test_webhooks.py` |
+| `src/host/api_endpoints.py` | `tests/test_api_endpoints.py` |
+| `src/host/outbound_webhooks.py` | `tests/test_outbound_webhooks.py` |
 | `src/host/watchers.py` | `tests/test_watchers.py` |
 | `src/host/wallet.py` | `tests/test_wallet_endpoints.py` |
 | `src/host/api_keys.py` | `tests/test_api_keys.py` |

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -5,7 +5,7 @@ OpenLegion is a container-isolated multi-agent runtime. LLM-powered agents run i
 ## System Overview
 
 ```
-User (CLI REPL / Telegram / Discord / Slack / WhatsApp / Webhook)
+User (CLI REPL / Telegram / Discord / Slack / WhatsApp / API Endpoint)
   -> Mesh Host (FastAPI :8420) -- routes messages, enforces permissions, proxies APIs
     -> Agent Containers (FastAPI :8400 each) -- isolated execution with private memory
 ```
@@ -48,7 +48,8 @@ The mesh host runs on the user's machine as a single FastAPI process. It is the 
 | `cron.py` | Cron scheduler with heartbeat support |
 | `lanes.py` | Per-agent FIFO task queues |
 | `failover.py` | Model health tracking and failover chains |
-| `webhooks.py` | Named webhook endpoints |
+| `api_endpoints.py` | Named API endpoints for inbound HTTP dispatch |
+| `outbound_webhooks.py` | Outbound webhook delivery to external URLs |
 | `watchers.py` | File watcher with polling |
 | `containers.py` | Backward-compat alias (`ContainerManager = DockerBackend`) |
 | `traces.py` | Request tracing and diagnostics |

--- a/docs/channels.md
+++ b/docs/channels.md
@@ -273,26 +273,35 @@ After pairing, the bot sends a help summary with all available commands. Unautho
 - Per-user agent tracking by phone number
 - Webhook verification challenge handled automatically
 
-## Webhooks
+## API Endpoints (Inbound)
 
-HTTP webhooks for programmatic integration. Incoming payloads are dispatched to agents as tasks.
+Named HTTP endpoints for programmatic integration. Incoming payloads are dispatched to agents as tasks. Manage these from the **Integrations > API Endpoints** tab in the dashboard.
 
 ### Endpoints
 
 | Method | Path | Description |
 |--------|------|-------------|
-| `POST` | `/webhook/hook/<hook_id>` | Dispatch a JSON payload to the configured agent |
+| `POST` | `/api/inbound/<endpoint_id>` | Dispatch a JSON payload to the configured agent |
+| `POST` | `/webhook/hook/<endpoint_id>` | Deprecated compatibility route (same behavior) |
 
 ### Usage
 
 ```bash
-# Send a payload to a webhook
-curl -X POST http://localhost:8420/webhook/hook/<hook_id> \
+# Send a payload to an API endpoint
+curl -X POST http://localhost:8420/api/inbound/<endpoint_id> \
   -H "Content-Type: application/json" \
   -d '{"company": "Acme Corp", "source": "website"}'
+
+# With HMAC signature verification (if enabled on the endpoint)
+BODY='{"company": "Acme Corp", "source": "website"}'
+SIG=$(echo -n "$BODY" | openssl dgst -sha256 -hmac "$SECRET" | cut -d' ' -f2)
+curl -X POST http://localhost:8420/api/inbound/<endpoint_id> \
+  -H "Content-Type: application/json" \
+  -H "X-Signature: $SIG" \
+  -d "$BODY"
 ```
 
-Each webhook is configured with a target agent. When a payload arrives, it is dispatched to that agent as a task.
+Each endpoint is configured with a target agent. When a payload arrives, it is dispatched to that agent as a task.
 
 ## Writing a Custom Channel
 

--- a/docs/dashboard.md
+++ b/docs/dashboard.md
@@ -10,13 +10,13 @@ No additional setup is required -- the dashboard starts automatically with `open
 
 ## Navigation
 
-The dashboard uses a consolidated three-tab layout:
+The dashboard uses a three-tab layout:
 
 | Tab | What It Shows |
 |-----|--------------|
-| **Fleet** | Agent cards, agent detail views, configuration editing |
-| **Activity** | Traces, live events, blackboard, costs, and automation |
-| **System** | Credentials, pub/sub, model pricing |
+| **Agents** | Agent cards, agent detail views, configuration editing |
+| **Integrations** | API Endpoints, Webhooks (outbound), Access Keys, Credentials |
+| **System** | Activity, Costs, Automation, Channels, Wallet, Storage, Settings |
 
 A command palette (**Cmd+K** / **Ctrl+K**) provides quick access to agents, actions, and navigation. The search button in the nav bar also opens it.
 
@@ -241,10 +241,17 @@ All dashboard API endpoints are prefixed with `/dashboard/api/`.
 | `POST` | `/dashboard/api/broadcast` | Send message to all agents |
 | `POST` | `/dashboard/api/broadcast/stream` | SSE streaming broadcast to all agents |
 | `GET` | `/dashboard/api/messages` | Recent message log |
-| `GET` | `/dashboard/api/webhooks` | List configured webhooks |
-| `POST` | `/dashboard/api/webhooks` | Create a webhook endpoint |
-| `DELETE` | `/dashboard/api/webhooks/{name}` | Delete a webhook |
-| `POST` | `/dashboard/api/webhooks/{name}/test` | Send test payload to webhook |
+| `GET` | `/dashboard/api/endpoints` | List API endpoints (inbound) |
+| `POST` | `/dashboard/api/endpoints` | Create an API endpoint |
+| `DELETE` | `/dashboard/api/endpoints/{id}` | Delete an API endpoint |
+| `PATCH` | `/dashboard/api/endpoints/{id}` | Update an API endpoint |
+| `POST` | `/dashboard/api/endpoints/{id}/test` | Send test payload to API endpoint |
+| `GET` | `/dashboard/api/webhooks` | List outbound webhooks |
+| `POST` | `/dashboard/api/webhooks` | Create an outbound webhook |
+| `DELETE` | `/dashboard/api/webhooks/{id}` | Delete an outbound webhook |
+| `PATCH` | `/dashboard/api/webhooks/{id}` | Update an outbound webhook |
+| `POST` | `/dashboard/api/webhooks/{id}/test` | Send test event to outbound webhook |
+| `GET` | `/dashboard/api/webhooks/deliveries` | Recent outbound webhook delivery log |
 | `GET` | `/dashboard/api/logs` | Runtime logs (query: lines, level) |
 | `GET` | `/dashboard/api/channels` | List connected messaging channels |
 | `GET` | `/dashboard/api/agent-templates` | Available agent fleet templates |

--- a/docs/triggering.md
+++ b/docs/triggering.md
@@ -1,6 +1,6 @@
 # Triggering & Automation
 
-OpenLegion agents can be triggered automatically through cron schedules, heartbeat monitoring, webhooks, and pub/sub events.
+OpenLegion agents can be triggered automatically through cron schedules, heartbeat monitoring, API endpoints (inbound webhooks), outbound webhooks, and pub/sub events.
 
 ## Cron Jobs
 
@@ -190,17 +190,42 @@ Heartbeats skip the LLM dispatch entirely (zero cost) when all three conditions 
 
 This makes always-on heartbeats economically viable even at high frequencies.
 
-## Webhooks
+## API Endpoints (Inbound)
 
-External systems can dispatch messages to agents via named webhooks.
+External systems can dispatch messages to agents via named API endpoints.
 
 ```bash
-curl -X POST http://localhost:8420/webhook/hook/<hook_id> \
+curl -X POST http://localhost:8420/api/inbound/<endpoint_id> \
   -H "Content-Type: application/json" \
   -d '{"company": "Acme Corp", "source": "website"}'
 ```
 
-The webhook payload is included in the message dispatched to the configured agent.
+Optionally secure each endpoint with HMAC-SHA256 signature verification by enabling "Require HMAC signature" at creation time. When enabled, sign the raw request body with the endpoint secret and send as the `X-Signature` header.
+
+The payload is included in the message dispatched to the configured agent. A deprecated compatibility route at `/webhook/hook/<endpoint_id>` is also available.
+
+## Outbound Webhooks
+
+OpenLegion can push signed event payloads to external URLs when things happen. Configure outbound webhooks from the **Integrations > Webhooks** tab in the dashboard.
+
+### Event Types
+
+| Event | Fired When |
+|-------|-----------|
+| `notification` | Agent sends a user notification |
+| `task_complete` | Agent finishes a task |
+| `task_failed` | Agent task fails |
+| `agent_state` | Agent state changes (idle, working, error) |
+| `cron_complete` | Cron job execution completes |
+| `custom` | Agent emits a custom event |
+
+### Verification
+
+Each delivery includes an `X-OpenLegion-Signature` header containing an HMAC-SHA256 signature of the request body. Verify this against the webhook's signing secret to authenticate payloads.
+
+### Agent Filtering
+
+Webhooks can optionally filter by agent — only events from selected agents are delivered. An empty filter delivers events from all agents.
 
 ## Pub/Sub Events
 

--- a/src/agent/builtins/mesh_tool.py
+++ b/src/agent/builtins/mesh_tool.py
@@ -45,6 +45,34 @@ async def notify_user(message: str, *, mesh_client=None, workspace_manager=None)
 
 
 @skill(
+    name="emit_event",
+    description="Emit a custom event to outbound webhooks. Use this to notify external systems about specific occurrences.",
+    parameters={
+        "type": "object",
+        "properties": {
+            "event_name": {
+                "type": "string",
+                "description": "Name of the custom event (e.g. 'order_processed', 'report_ready')",
+            },
+            "data": {
+                "type": "object",
+                "description": "Event payload data to include in the webhook delivery",
+            },
+        },
+        "required": ["event_name"],
+    },
+)
+async def emit_event(event_name: str, data: dict | None = None, *, mesh_client=None) -> dict:
+    if mesh_client is None:
+        return {"error": "No mesh_client available"}
+    try:
+        await mesh_client.emit_event(event_name, data or {})
+        return {"emitted": True, "event_name": event_name}
+    except Exception as e:
+        return {"error": f"Failed to emit event: {e}"}
+
+
+@skill(
     name="list_agents",
     description=(
         "List agents in your project (or just yourself if standalone). Returns "

--- a/src/agent/builtins/mesh_tool.py
+++ b/src/agent/builtins/mesh_tool.py
@@ -46,7 +46,7 @@ async def notify_user(message: str, *, mesh_client=None, workspace_manager=None)
 
 @skill(
     name="emit_event",
-    description="Emit a custom event to outbound webhooks. Use this to notify external systems about specific occurrences.",
+    description="Emit a custom event to outbound webhooks. Notifies external systems.",
     parameters={
         "type": "object",
         "properties": {

--- a/src/agent/mesh_client.py
+++ b/src/agent/mesh_client.py
@@ -221,6 +221,16 @@ class MeshClient:
         )
         response.raise_for_status()
 
+    async def emit_event(self, event_name: str, data: dict) -> None:
+        """Emit a custom event to outbound webhooks."""
+        client = await self._get_client()
+        response = await client.post(
+            f"{self.mesh_url}/mesh/emit-event",
+            json={"agent_id": self.agent_id, "event_name": event_name, "data": data},
+            headers=self._trace_headers(),
+        )
+        response.raise_for_status()
+
     async def publish_event(self, topic: str, payload: dict | None = None) -> dict:
         """Publish an event to the mesh pub/sub."""
         scoped = self._scope_topic(topic)

--- a/src/cli/config.py
+++ b/src/cli/config.py
@@ -549,7 +549,7 @@ def _suppress_host_logs() -> None:
     """Set host-side loggers to WARNING for clean CLI output."""
     for name in [
         "host", "host.containers", "host.credentials",
-        "host.mesh", "host.costs", "host.permissions", "host.cron", "host.webhooks",
+        "host.mesh", "host.costs", "host.permissions", "host.cron", "host.api_endpoints",
         "host.health", "host.lanes", "host.runtime", "host.watchers",
         "channels", "channels.base", "channels.telegram", "channels.discord",
         "channels.slack", "channels.whatsapp",

--- a/src/cli/config.py
+++ b/src/cli/config.py
@@ -550,6 +550,7 @@ def _suppress_host_logs() -> None:
     for name in [
         "host", "host.containers", "host.credentials",
         "host.mesh", "host.costs", "host.permissions", "host.cron", "host.api_endpoints",
+        "host.outbound_webhooks",
         "host.health", "host.lanes", "host.runtime", "host.watchers",
         "channels", "channels.base", "channels.telegram", "channels.discord",
         "channels.slack", "channels.whatsapp",

--- a/src/cli/runtime.py
+++ b/src/cli/runtime.py
@@ -486,11 +486,11 @@ class RuntimeContext:
         import uvicorn
 
         from src.host.server import create_mesh_app
-        from src.host.webhooks import WebhookManager
+        from src.host.api_endpoints import ApiEndpointManager
 
         mesh_port = self.cfg["mesh"]["port"]
 
-        webhook_manager = WebhookManager(dispatch_fn=self.async_dispatch)
+        api_endpoint_manager = ApiEndpointManager(dispatch_fn=self.async_dispatch)
 
         # Wallet signing service (only if master seed is configured).
         # Wrapped in a single-item list so both mesh and dashboard closures
@@ -526,7 +526,7 @@ class RuntimeContext:
             wallet_service_ref=wallet_ref,
             api_key_manager=self._api_key_manager,
         )
-        app.include_router(webhook_manager.create_router())
+        app.include_router(api_endpoint_manager.create_router())
         self.health_monitor._cleanup_agent = app.cleanup_agent  # type: ignore[attr-defined]
 
         self._init_channel_manager()
@@ -549,7 +549,7 @@ class RuntimeContext:
             transport=self.transport,
             runtime=self.runtime,
             router=self.router,
-            webhook_manager=webhook_manager,
+            api_endpoint_manager=api_endpoint_manager,
             channel_manager=self.channel_manager,
             wallet_service_ref=wallet_ref,
             api_key_manager=self._api_key_manager,

--- a/src/cli/runtime.py
+++ b/src/cli/runtime.py
@@ -500,8 +500,8 @@ class RuntimeContext:
     def _start_mesh_server(self) -> None:
         import uvicorn
 
-        from src.host.server import create_mesh_app
         from src.host.api_endpoints import ApiEndpointManager
+        from src.host.server import create_mesh_app
 
         mesh_port = self.cfg["mesh"]["port"]
 

--- a/src/cli/runtime.py
+++ b/src/cli/runtime.py
@@ -120,6 +120,16 @@ class RuntimeContext:
         if self.blackboard:
             self.blackboard.close()
 
+        # Stop outbound webhook delivery worker
+        if hasattr(self, '_outbound_webhook_manager') and self._dispatch_loop:
+            try:
+                future = asyncio.run_coroutine_threadsafe(
+                    self._outbound_webhook_manager.stop(), self._dispatch_loop,
+                )
+                future.result(timeout=10)
+            except Exception as e:
+                logger.debug("Outbound webhook shutdown error: %s", e)
+
         # Close shared httpx clients on the dispatch loop — close all
         # concurrently so one slow close doesn't block the others.
         if self._dispatch_loop:
@@ -438,6 +448,8 @@ class RuntimeContext:
                     self.event_bus.emit("message_sent", agent=agent_name,
                         data={"message": message[:200], "response_length": len(response),
                               "source": "dispatch"})
+                    self.event_bus.emit("task_complete", agent=agent_name,
+                        data={"task": message[:200], "status": "complete"})
                 return response
             except Exception as e:
                 duration_ms = int((_time.time() - t0) * 1000)
@@ -447,6 +459,9 @@ class RuntimeContext:
                         event_type="chat_response", duration_ms=duration_ms,
                         status="error", error=str(e),
                     )
+                if self.event_bus:
+                    self.event_bus.emit("task_failed", agent=agent_name,
+                        data={"error": str(e)[:500], "status": "failed"})
                 return f"Error: {e}"
 
         async def _direct_steer(agent_name: str, message: str) -> dict:
@@ -510,6 +525,9 @@ class RuntimeContext:
         from src.host.api_keys import ApiKeyManager
         self._api_key_manager = ApiKeyManager()
 
+        from src.host.outbound_webhooks import OutboundWebhookManager
+        self._outbound_webhook_manager = OutboundWebhookManager()
+
         app = create_mesh_app(
             self.blackboard, self.pubsub, self.router, self.permissions,
             self.credential_vault, self.cron_scheduler, self.runtime,
@@ -553,10 +571,15 @@ class RuntimeContext:
             channel_manager=self.channel_manager,
             wallet_service_ref=wallet_ref,
             api_key_manager=self._api_key_manager,
+            outbound_webhook_manager=self._outbound_webhook_manager,
         )
         app.include_router(dashboard_router)
         app.include_router(create_spa_catchall_router())  # Must be last — SPA deep linking
         self._app = app
+
+        # Register outbound webhook manager as EventBus listener
+        if self.event_bus:
+            self.event_bus.add_listener(self._outbound_webhook_manager.enqueue)
 
         server_config = uvicorn.Config(app, host="0.0.0.0", port=mesh_port, log_level="warning")
         self._server = uvicorn.Server(server_config)
@@ -681,6 +704,12 @@ class RuntimeContext:
 
         health_thread = threading.Thread(target=run_health, daemon=True)
         health_thread.start()
+
+        # Start outbound webhook delivery worker
+        if hasattr(self, '_outbound_webhook_manager') and self._dispatch_loop:
+            self._dispatch_loop.call_soon_threadsafe(
+                self._outbound_webhook_manager.start,
+            )
 
     def _init_channel_manager(self) -> None:
         """Create the ChannelManager with callbacks (but don't start channels yet)."""

--- a/src/dashboard/events.py
+++ b/src/dashboard/events.py
@@ -11,6 +11,7 @@ import asyncio
 import json
 import threading
 from collections import deque
+from collections.abc import Callable
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any
 
@@ -52,6 +53,11 @@ class EventBus:
         self._loop: asyncio.AbstractEventLoop | None = None
         self._seq: int = 0  # monotonic sequence counter
         self._lock = threading.Lock()
+        self._listeners: list[Callable] = []
+
+    def add_listener(self, fn: Callable) -> None:
+        """Register a callback fn(event_type, agent, data) for all events."""
+        self._listeners.append(fn)
 
     def set_loop(self, loop: asyncio.AbstractEventLoop) -> None:
         """Bind to the mesh server's event loop. Idempotent."""
@@ -72,6 +78,12 @@ class EventBus:
             self._seq += 1
             evt_dict["_seq"] = self._seq
             self._buffer.append(evt_dict)
+
+        for listener in self._listeners:
+            try:
+                listener(event_type, agent, data or {})
+            except Exception:
+                logger.warning("Event listener failed", exc_info=True)
 
         if not self._clients:
             return

--- a/src/dashboard/server.py
+++ b/src/dashboard/server.py
@@ -143,7 +143,7 @@ def create_dashboard_router(
     transport: Any = None,
     runtime: Any = None,
     router: Any = None,
-    webhook_manager: Any = None,
+    api_endpoint_manager: Any = None,
     channel_manager: Any = None,
     wallet_service_ref: list | None = None,
     api_key_manager: Any = None,
@@ -2952,26 +2952,26 @@ def create_dashboard_router(
             return {"messages": []}
         return {"messages": router.message_log[-100:]}
 
-    # ── Webhooks ──────────────────────────────────────────────
+    # ── API Endpoints ──────────────────────────────────────────────
 
-    @api_router.get("/api/webhooks")
-    async def api_webhooks_list(request: Request) -> dict:
-        if webhook_manager is None:
-            return {"webhooks": []}
-        hooks = webhook_manager.list_hooks() if hasattr(webhook_manager, "list_hooks") else []
+    @api_router.get("/api/endpoints")
+    async def api_endpoints_list(request: Request) -> dict:
+        if api_endpoint_manager is None:
+            return {"endpoints": []}
+        hooks = api_endpoint_manager.list_endpoints() if hasattr(api_endpoint_manager, "list_endpoints") else []
         base = str(request.base_url).rstrip("/")
         result = []
         for h in hooks:
             entry = {k: v for k, v in h.items() if k != "secret"}
-            entry["url"] = f"{base}/webhook/hook/{h['id']}"
+            entry["url"] = f"{base}/api/inbound/{h['id']}"
             entry["has_secret"] = "secret" in h
             result.append(entry)
-        return {"webhooks": result}
+        return {"endpoints": result}
 
-    @api_router.post("/api/webhooks")
-    async def api_webhooks_create(request: Request) -> dict:
-        if webhook_manager is None:
-            raise HTTPException(status_code=503, detail="Webhook manager not available")
+    @api_router.post("/api/endpoints")
+    async def api_endpoints_create(request: Request) -> dict:
+        if api_endpoint_manager is None:
+            raise HTTPException(status_code=503, detail="API endpoint manager not available")
         body = await request.json()
         name = body.get("name", "")
         agent = body.get("agent", "")
@@ -2979,7 +2979,7 @@ def create_dashboard_router(
             raise HTTPException(status_code=400, detail="name and agent are required")
         require_signature = bool(body.get("secret"))
         instructions = body.get("instructions", "")
-        hook = webhook_manager.add_hook(
+        hook = api_endpoint_manager.add_endpoint(
             agent=agent,
             name=name,
             require_signature=require_signature,
@@ -2989,22 +2989,22 @@ def create_dashboard_router(
         # Return a copy so we don't mutate the stored dict; include
         # secret once so the user can copy it at creation time.
         result = dict(hook)
-        result["url"] = f"{base}/webhook/hook/{hook['id']}"
+        result["url"] = f"{base}/api/inbound/{hook['id']}"
         return {"created": True, "hook": result}
 
-    @api_router.delete("/api/webhooks/{hook_id}")
-    async def api_webhooks_delete(hook_id: str) -> dict:
-        if webhook_manager is None:
-            raise HTTPException(status_code=503, detail="Webhook manager not available")
-        removed = webhook_manager.remove_hook(hook_id)
+    @api_router.delete("/api/endpoints/{endpoint_id}")
+    async def api_endpoints_delete(endpoint_id: str) -> dict:
+        if api_endpoint_manager is None:
+            raise HTTPException(status_code=503, detail="API endpoint manager not available")
+        removed = api_endpoint_manager.remove_endpoint(endpoint_id)
         if not removed:
-            raise HTTPException(status_code=404, detail=f"Webhook '{hook_id}' not found")
-        return {"removed": True, "id": hook_id}
+            raise HTTPException(status_code=404, detail=f"Endpoint '{endpoint_id}' not found")
+        return {"removed": True, "id": endpoint_id}
 
-    @api_router.patch("/api/webhooks/{hook_id}")
-    async def api_webhooks_update(hook_id: str, request: Request) -> dict:
-        if webhook_manager is None:
-            raise HTTPException(status_code=503, detail="Webhook manager not available")
+    @api_router.patch("/api/endpoints/{endpoint_id}")
+    async def api_endpoints_update(endpoint_id: str, request: Request) -> dict:
+        if api_endpoint_manager is None:
+            raise HTTPException(status_code=503, detail="API endpoint manager not available")
         body = await request.json()
         fields: dict = {}
         for key in ("name", "agent", "instructions"):
@@ -3017,24 +3017,24 @@ def create_dashboard_router(
         if not fields:
             raise HTTPException(status_code=400, detail="No valid fields provided")
         try:
-            updated = webhook_manager.update_hook(hook_id, **fields)
+            updated = api_endpoint_manager.update_endpoint(endpoint_id, **fields)
         except ValueError as e:
             raise HTTPException(status_code=400, detail=str(e))
         if updated is None:
-            raise HTTPException(status_code=404, detail=f"Webhook '{hook_id}' not found")
+            raise HTTPException(status_code=404, detail=f"Endpoint '{endpoint_id}' not found")
         base = str(request.base_url).rstrip("/")
-        updated["url"] = f"{base}/webhook/hook/{updated['id']}"
+        updated["url"] = f"{base}/api/inbound/{updated['id']}"
         return {"updated": True, "hook": updated}
 
-    @api_router.post("/api/webhooks/{hook_id}/test")
-    async def api_webhooks_test(hook_id: str, request: Request) -> dict:
-        if webhook_manager is None:
-            raise HTTPException(status_code=503, detail="Webhook manager not available")
+    @api_router.post("/api/endpoints/{endpoint_id}/test")
+    async def api_endpoints_test(endpoint_id: str, request: Request) -> dict:
+        if api_endpoint_manager is None:
+            raise HTTPException(status_code=503, detail="API endpoint manager not available")
         body = await request.json()
-        result = await webhook_manager.test_hook(hook_id, payload=body)
+        result = await api_endpoint_manager.test_endpoint(endpoint_id, payload=body)
         if result is None:
-            raise HTTPException(status_code=404, detail=f"Webhook '{hook_id}' not found")
-        return {"tested": True, "id": hook_id, "result": result}
+            raise HTTPException(status_code=404, detail=f"Endpoint '{endpoint_id}' not found")
+        return {"tested": True, "id": endpoint_id, "result": result}
 
     # ── Channels ──────────────────────────────────────────────
 

--- a/src/dashboard/server.py
+++ b/src/dashboard/server.py
@@ -171,6 +171,7 @@ def create_dashboard_router(
     api_router = APIRouter(
         prefix="/dashboard",
         dependencies=[Depends(_verify_dashboard_auth), Depends(_csrf_check)],
+        include_in_schema=False,
     )
 
     jinja_env = Environment(
@@ -3462,7 +3463,7 @@ def create_spa_catchall_router() -> APIRouter:
         loader=FileSystemLoader(str(_TEMPLATES_DIR)),
         autoescape=True,
     )
-    catchall = APIRouter(dependencies=[Depends(_verify_dashboard_auth)])
+    catchall = APIRouter(dependencies=[Depends(_verify_dashboard_auth)], include_in_schema=False)
 
     @catchall.get("/{path:path}", response_class=HTMLResponse)
     async def spa_catchall(path: str) -> HTMLResponse:

--- a/src/dashboard/server.py
+++ b/src/dashboard/server.py
@@ -147,6 +147,7 @@ def create_dashboard_router(
     channel_manager: Any = None,
     wallet_service_ref: list | None = None,
     api_key_manager: Any = None,
+    outbound_webhook_manager: Any = None,
 ) -> APIRouter:
     """Create the dashboard FastAPI router."""
     # Plan limits — read once at startup; provisioner restarts engine after updating .env
@@ -948,11 +949,15 @@ def create_dashboard_router(
             if event_bus:
                 event_bus.emit("chat_done", agent=agent_id,
                     data={"response": response, "session": chat_session})
+                event_bus.emit("task_complete", agent=agent_id,
+                    data={"task": message[:200], "status": "complete"})
             return {"response": response}
         except Exception as e:
             if event_bus:
                 event_bus.emit("chat_done", agent=agent_id,
                     data={"response": "", "session": chat_session})
+                event_bus.emit("task_failed", agent=agent_id,
+                    data={"error": str(e)[:500], "status": "failed"})
             raise HTTPException(status_code=502, detail=str(e))
 
     @api_router.post("/api/agents/{agent_id}/chat/stream")
@@ -3035,6 +3040,84 @@ def create_dashboard_router(
         if result is None:
             raise HTTPException(status_code=404, detail=f"Endpoint '{endpoint_id}' not found")
         return {"tested": True, "id": endpoint_id, "result": result}
+
+    # ── Webhooks (Outbound) ──────────────────────────────────────────────
+
+    @api_router.get("/api/webhooks")
+    async def api_webhooks_list() -> dict:
+        if outbound_webhook_manager is None:
+            return {"webhooks": []}
+        subs = outbound_webhook_manager.list_subscriptions()
+        # Strip secrets from response
+        result = [{k: v for k, v in s.items() if k != "secret"} for s in subs]
+        for r in result:
+            r["has_secret"] = True  # all subscriptions have secrets
+        return {"webhooks": result}
+
+    @api_router.post("/api/webhooks")
+    async def api_webhooks_create(request: Request) -> dict:
+        if outbound_webhook_manager is None:
+            raise HTTPException(503, "Outbound webhooks not available")
+        body = await request.json()
+        name = body.get("name", "").strip()
+        url = body.get("url", "").strip()
+        events = body.get("events", [])
+        agent_filter = body.get("agent_filter", [])
+        if not name or not url:
+            raise HTTPException(400, "name and url are required")
+        if not events:
+            raise HTTPException(400, "At least one event type is required")
+        try:
+            sub = outbound_webhook_manager.add_subscription(name, url, events, agent_filter)
+        except ValueError as e:
+            raise HTTPException(400, str(e))
+        return {"created": True, "webhook": sub}  # includes secret on creation
+
+    @api_router.delete("/api/webhooks/{sub_id}")
+    async def api_webhooks_delete(sub_id: str) -> dict:
+        if outbound_webhook_manager is None:
+            raise HTTPException(503, "Outbound webhooks not available")
+        removed = outbound_webhook_manager.remove_subscription(sub_id)
+        if not removed:
+            raise HTTPException(404, f"Webhook '{sub_id}' not found")
+        return {"removed": True, "id": sub_id}
+
+    @api_router.patch("/api/webhooks/{sub_id}")
+    async def api_webhooks_update(sub_id: str, request: Request) -> dict:
+        if outbound_webhook_manager is None:
+            raise HTTPException(503, "Outbound webhooks not available")
+        body = await request.json()
+        fields = {}
+        for key in ("name", "url", "events", "agent_filter"):
+            if key in body:
+                fields[key] = body[key]
+        if "enabled" in body:
+            fields["enabled"] = bool(body["enabled"])
+        if not fields:
+            raise HTTPException(400, "No valid fields provided")
+        try:
+            updated = outbound_webhook_manager.update_subscription(sub_id, **fields)
+        except ValueError as e:
+            raise HTTPException(400, str(e))
+        if updated is None:
+            raise HTTPException(404, f"Webhook '{sub_id}' not found")
+        result = {k: v for k, v in updated.items() if k != "secret"}
+        return {"updated": True, "webhook": result}
+
+    @api_router.post("/api/webhooks/{sub_id}/test")
+    async def api_webhooks_test(sub_id: str) -> dict:
+        if outbound_webhook_manager is None:
+            raise HTTPException(503, "Outbound webhooks not available")
+        result = await outbound_webhook_manager.test_subscription(sub_id)
+        if result is None:
+            raise HTTPException(404, f"Webhook '{sub_id}' not found")
+        return {"tested": True, "id": sub_id, "result": result}
+
+    @api_router.get("/api/webhooks/deliveries")
+    async def api_webhooks_deliveries() -> dict:
+        if outbound_webhook_manager is None:
+            return {"deliveries": []}
+        return {"deliveries": outbound_webhook_manager.recent_deliveries()}
 
     # ── Channels ──────────────────────────────────────────────
 

--- a/src/dashboard/static/js/app.js
+++ b/src/dashboard/static/js/app.js
@@ -1,7 +1,7 @@
 /**
  * OpenLegion Dashboard — Alpine.js application.
  *
- * Two panels: Agents, System (Activity / Costs / Automation / Integrations / API Keys / Wallet / Storage / Settings).
+ * Three panels: Agents, Integrations (API Endpoints / Webhooks / Credentials), System (Activity / Costs / Automation / Channels / Wallet / Storage / Settings).
  * Real-time updates via WebSocket + periodic REST polling.
  */
 
@@ -47,6 +47,7 @@ function dashboard() {
     activeTab: 'fleet',
     tabs: [
       { id: 'fleet', label: 'Agents' },
+      { id: 'integrations', label: 'Integrations' },
       { id: 'system', label: 'System' },
     ],
     connected: false,
@@ -265,11 +266,19 @@ function dashboard() {
       { id: 'activity', label: 'Activity' },
       { id: 'costs', label: 'Costs' },
       { id: 'automation', label: 'Automation' },
-      { id: 'integrations', label: 'Integrations' },
-      { id: 'apikeys', label: 'API Keys' },
+      { id: 'channels', label: 'Channels' },
       { id: 'wallet', label: 'Wallet' },
       { id: 'storage', label: 'Storage' },
       { id: 'settings', label: 'Settings' },
+    ],
+
+    // Integrations tab — sub-navigation
+    integrationsTab: 'endpoints',
+    integrationsTabs: [
+      { id: 'endpoints', label: 'API Endpoints' },
+      { id: 'webhooks', label: 'Webhooks' },
+      { id: 'accesskeys', label: 'Access Keys' },
+      { id: 'apikeys', label: 'Credentials' },
     ],
 
     // Unified Project Hub (replaces separate PROJECT.md + Comms + Broadcast panels)
@@ -443,6 +452,9 @@ function dashboard() {
           ? `/agents/${this.detailAgent}`
           : `/agents/${this.detailAgent}/${tab}`;
       }
+      if (this.activeTab === 'integrations') {
+        return '/integrations/' + (this.integrationsTab || 'endpoints');
+      }
       if (this.activeTab === 'system') {
         if (this.systemTab === 'activity') {
           if (this.activityView === 'events') return '/system/activity/events';
@@ -459,6 +471,10 @@ function dashboard() {
         const tabLabel = (_IDENTITY_TABS.find(t => t.id === this.identityTab) || _IDENTITY_TABS[0]).label;
         return `${this.detailAgent} \u00b7 ${tabLabel} \u2014 OpenLegion`;
       }
+      if (this.activeTab === 'integrations') {
+        const st = this.integrationsTabs.find(t => t.id === this.integrationsTab);
+        return (st ? st.label : 'Integrations') + ' \u2014 OpenLegion';
+      }
       if (this.activeTab === 'system') {
         if (this.systemTab === 'activity') {
           if (this.activityView === 'events') return 'Live Feed \u2014 OpenLegion';
@@ -473,7 +489,7 @@ function dashboard() {
 
     _parsePath(path) {
       const clean = path.replace(/^\/+/, '').replace(/\/+$/, '');
-      const route = { tab: 'fleet', activityView: 'traces', systemTab: 'activity', agentId: null, identityTab: 'config' };
+      const route = { tab: 'fleet', activityView: 'traces', systemTab: 'activity', integrationsTab: 'endpoints', agentId: null, identityTab: 'config' };
       if (!clean) return route;
 
       const agentMatch = clean.match(/^agents\/([^/]+)(?:\/([^/]+))?$/);
@@ -487,13 +503,23 @@ function dashboard() {
       if (clean === 'activity/events') { route.tab = 'system'; route.systemTab = 'activity'; route.activityView = 'events'; }
       else if (clean === 'activity/logs') { route.tab = 'system'; route.systemTab = 'activity'; route.activityView = 'logs'; }
       else if (clean === 'activity') { route.tab = 'system'; route.systemTab = 'activity'; }
+      else if (clean.startsWith('integrations')) {
+        route.tab = 'integrations';
+        const sub = clean.split('/')[1];
+        if (sub && ['endpoints', 'webhooks', 'accesskeys', 'apikeys'].includes(sub)) {
+          route.integrationsTab = sub;
+        }
+      }
       else if (clean.startsWith('system')) {
         route.tab = 'system';
         const sub = clean.split('/')[1];
         // Backward compat for old URLs
-        const _tabAliases = { schedules: 'automation', connections: 'integrations', uploads: 'storage' };
+        const _tabAliases = { schedules: 'automation', connections: 'channels', uploads: 'storage' };
         const resolved = _tabAliases[sub] || sub;
-        if (resolved && ['activity', 'costs', 'automation', 'integrations', 'apikeys', 'wallet', 'storage', 'settings'].includes(resolved)) {
+        // Redirect old system/integrations and system/apikeys URLs to new integrations tab
+        if (resolved === 'integrations') { route.tab = 'integrations'; route.integrationsTab = 'endpoints'; }
+        else if (resolved === 'apikeys') { route.tab = 'integrations'; route.integrationsTab = 'apikeys'; }
+        else if (resolved && ['activity', 'costs', 'automation', 'channels', 'wallet', 'storage', 'settings'].includes(resolved)) {
           route.systemTab = resolved;
           if (resolved === 'activity') {
             const view = clean.split('/')[2];
@@ -536,20 +562,27 @@ function dashboard() {
           }
           if (this.activeTab !== route.tab) {
             // Sync sub-state before switchTab so it uses the correct values
+            if (route.tab === 'integrations') {
+              this.integrationsTab = route.integrationsTab;
+            }
             if (route.tab === 'system') {
               this.systemTab = route.systemTab;
               if (route.systemTab === 'activity') this.activityView = route.activityView;
             }
             this.switchTab(route.tab);
+          } else if (route.tab === 'integrations') {
+            if (this.integrationsTab !== route.integrationsTab) {
+              this.integrationsTab = route.integrationsTab;
+              if (route.integrationsTab === 'endpoints') { this.fetchEndpoints(); }
+              if (route.integrationsTab === 'webhooks') { this.fetchOutboundWebhooks(); }
+              if (route.integrationsTab === 'apikeys') { this.fetchSettings(); this.fetchApiKeys(); }
+            }
           } else if (route.tab === 'system') {
             if (this.systemTab !== route.systemTab) {
               if (this.systemTab === 'activity') this._stopActivityRefresh();
               this.systemTab = route.systemTab;
-              if (route.systemTab === 'integrations') {
-                this.fetchChannels(); this.fetchEndpoints(); this.fetchApiKeys(); this.fetchOutboundWebhooks();
-              }
-              if (route.systemTab === 'apikeys') {
-                this.fetchSettings();
+              if (route.systemTab === 'channels') {
+                this.fetchChannels();
               }
               if (route.systemTab === 'settings') {
                 this.fetchBrowserSettings();
@@ -1102,17 +1135,20 @@ function dashboard() {
         this.fetchProject();
         this.fetchProjects();
       }
+      if (tab === 'integrations') {
+        this.fetchEndpoints();
+        this.fetchOutboundWebhooks();
+        this.fetchApiKeys();
+        if (this.integrationsTab === 'apikeys') this.fetchSettings();
+      }
       if (tab === 'system') {
         this.fetchSettings();
         this.fetchCosts();
         this.fetchStorage();
         this.fetchCronJobs();
         this.fetchWorkflows();
-        if (this.systemTab === 'integrations') {
-          this.fetchEndpoints();
+        if (this.systemTab === 'channels') {
           this.fetchChannels();
-          this.fetchApiKeys();
-          this.fetchOutboundWebhooks();
         }
         if (this.systemTab === 'settings') {
           this.fetchBrowserSettings();
@@ -1134,14 +1170,22 @@ function dashboard() {
       if (this.systemTab === 'activity' && tabId !== 'activity') this._stopActivityRefresh();
       this.systemTab = tabId;
       this._pushUrl(false);
-      if (tabId === 'integrations') { this.fetchChannels(); this.fetchEndpoints(); this.fetchApiKeys(); this.fetchOutboundWebhooks(); }
-      if (tabId === 'apikeys') { this.fetchSettings(); }
+      if (tabId === 'channels') { this.fetchChannels(); }
       if (tabId === 'storage') { this.fetchUploads(); this.fetchStorage(); this.fetchDatabaseDetails(); }
       if (tabId === 'settings') { this.fetchBrowserSettings(); this.fetchSystemSettings(); }
       if (tabId === 'activity') {
         if (this.activityView === 'traces') { this.fetchTraces(); this._startActivityRefresh(); }
         else if (this.activityView === 'logs') { this.fetchSystemLogs(); }
       }
+    },
+
+    switchIntegrationsTab(tabId) {
+      this.integrationsTab = tabId;
+      this._pushUrl(false);
+      if (tabId === 'endpoints') { this.fetchEndpoints(); }
+      if (tabId === 'webhooks') { this.fetchOutboundWebhooks(); }
+      if (tabId === 'accesskeys') { this.fetchApiKeys(); }
+      if (tabId === 'apikeys') { this.fetchSettings(); this.fetchApiKeys(); }
     },
 
     // ── Markdown rendering for chat messages ─────────────
@@ -3951,7 +3995,8 @@ function dashboard() {
       // Match tabs with keywords
       const tabKeywords = {
         fleet: ['agents', 'fleet', 'cards', 'project'],
-        system: ['system', 'costs', 'cron', 'schedules', 'automation', 'credentials', 'api keys', 'connections', 'integrations', 'infrastructure', 'pricing', 'browsers', 'pubsub', 'blackboard', 'comms', 'communication', 'workflows', 'storage', 'uploads', 'disk'],
+        integrations: ['integrations', 'api', 'endpoints', 'webhooks', 'api keys', 'credentials'],
+        system: ['system', 'costs', 'cron', 'schedules', 'automation', 'channels', 'infrastructure', 'pricing', 'browsers', 'pubsub', 'blackboard', 'comms', 'communication', 'workflows', 'storage', 'uploads', 'disk'],
       };
       for (const [tabId, keywords] of Object.entries(tabKeywords)) {
         const tab = this.tabs.find(t => t.id === tabId);
@@ -4002,17 +4047,17 @@ function dashboard() {
       // Match credentials
       for (const name of this.settingsData?.credentials?.names || []) {
         if (name.toLowerCase().includes(q)) {
-          results.push({ type: 'action', label: name, desc: 'API Key', action: () => { this.systemTab = 'apikeys'; this.switchTab('system'); } });
+          results.push({ type: 'action', label: name, desc: 'Credential', action: () => { this.integrationsTab = 'apikeys'; this.switchTab('integrations'); } });
         }
       }
       // System quick actions
       const sysActions = [
         { label: 'Activity', desc: 'Traces, live feed, and logs', keywords: ['activity', 'traces', 'events', 'live'], action: () => { this.systemTab = 'activity'; this.switchTab('system'); } },
         { label: 'View Logs', desc: 'Open runtime logs', keywords: ['logs', 'runtime', 'debug'], action: () => { this.systemTab = 'activity'; this.switchTab('system'); this.setActivityView('logs'); } },
-        { label: 'Add API Key', desc: 'Add new API key or credential', keywords: ['key', 'api', 'credential', 'token'], action: () => { this.systemTab = 'apikeys'; this.switchTab('system'); this.showCredForm = true; } },
-        { label: 'Manage API Endpoints', desc: 'View and create API endpoints', keywords: ['api', 'endpoint', 'webhook', 'hook'], action: () => { this.systemTab = 'integrations'; this.switchTab('system'); this.fetchEndpoints(); } },
-        { label: 'Manage Webhooks', desc: 'View outbound webhook subscriptions', keywords: ['webhook', 'outbound', 'notify'], action: () => { this.systemTab = 'integrations'; this.switchTab('system'); this.fetchOutboundWebhooks(); } },
-        { label: 'Manage Channels', desc: 'Connect Telegram, Discord, Slack, WhatsApp', keywords: ['channel', 'telegram', 'discord', 'slack', 'whatsapp'], action: () => { this.systemTab = 'integrations'; this.switchTab('system'); this.fetchChannels(); } },
+        { label: 'Add Credential', desc: 'Add new LLM provider key or agent credential', keywords: ['key', 'api', 'credential', 'token'], action: () => { this.integrationsTab = 'apikeys'; this.switchTab('integrations'); this.showCredForm = true; } },
+        { label: 'Manage API Endpoints', desc: 'View and create API endpoints', keywords: ['api', 'endpoint', 'webhook', 'hook'], action: () => { this.integrationsTab = 'endpoints'; this.switchTab('integrations'); } },
+        { label: 'Manage Webhooks', desc: 'View outbound webhook subscriptions', keywords: ['webhook', 'outbound', 'notify'], action: () => { this.integrationsTab = 'webhooks'; this.switchTab('integrations'); } },
+        { label: 'Manage Channels', desc: 'Connect Telegram, Discord, Slack, WhatsApp', keywords: ['channel', 'telegram', 'discord', 'slack', 'whatsapp'], action: () => { this.systemTab = 'channels'; this.switchTab('system'); } },
         { label: 'Model Pricing', desc: 'Token costs by model', keywords: ['model', 'pricing', 'tokens'], action: () => { this.systemTab = 'costs'; this.switchTab('system'); } },
         { label: 'Browser Settings', desc: 'Browser speed and timing', keywords: ['browser', 'speed', 'settings', 'timing', 'stealth'], action: () => { this.systemTab = 'settings'; this.switchTab('system'); this.fetchBrowserSettings(); } },
         { label: 'Default Model', desc: 'Change the default LLM model', keywords: ['model', 'llm', 'default', 'openai', 'anthropic', 'ollama'], action: () => { this.systemTab = 'settings'; this.switchTab('system'); this.fetchSystemSettings(); } },

--- a/src/dashboard/static/js/app.js
+++ b/src/dashboard/static/js/app.js
@@ -367,6 +367,24 @@ function dashboard() {
     endpointSaving: false,
     endpointRevealedSecret: null,
     endpointRevealedSecretId: null,
+    // Outbound webhooks
+    outboundWebhooks: [],
+    outboundFormName: '',
+    outboundFormUrl: '',
+    outboundFormEvents: [],
+    outboundFormAgentFilter: [],
+    outboundEditName: '',
+    outboundEditUrl: '',
+    outboundEditEvents: [],
+    outboundEditAgentFilter: [],
+    outboundEditEnabled: true,
+    editingOutboundId: null,
+    outboundCreating: false,
+    outboundSaving: false,
+    outboundDeliveries: [],
+    showOutboundForm: false,
+    showDeliveries: false,
+
     apiKeys: [],
     apiKeysLegacy: false,
     apiKeyNewValue: null,
@@ -528,7 +546,7 @@ function dashboard() {
               if (this.systemTab === 'activity') this._stopActivityRefresh();
               this.systemTab = route.systemTab;
               if (route.systemTab === 'integrations') {
-                this.fetchChannels(); this.fetchEndpoints(); this.fetchApiKeys();
+                this.fetchChannels(); this.fetchEndpoints(); this.fetchApiKeys(); this.fetchOutboundWebhooks();
               }
               if (route.systemTab === 'apikeys') {
                 this.fetchSettings();
@@ -1094,6 +1112,7 @@ function dashboard() {
           this.fetchEndpoints();
           this.fetchChannels();
           this.fetchApiKeys();
+          this.fetchOutboundWebhooks();
         }
         if (this.systemTab === 'settings') {
           this.fetchBrowserSettings();
@@ -1115,7 +1134,7 @@ function dashboard() {
       if (this.systemTab === 'activity' && tabId !== 'activity') this._stopActivityRefresh();
       this.systemTab = tabId;
       this._pushUrl(false);
-      if (tabId === 'integrations') { this.fetchChannels(); this.fetchEndpoints(); this.fetchApiKeys(); }
+      if (tabId === 'integrations') { this.fetchChannels(); this.fetchEndpoints(); this.fetchApiKeys(); this.fetchOutboundWebhooks(); }
       if (tabId === 'apikeys') { this.fetchSettings(); }
       if (tabId === 'storage') { this.fetchUploads(); this.fetchStorage(); this.fetchDatabaseDetails(); }
       if (tabId === 'settings') { this.fetchBrowserSettings(); this.fetchSystemSettings(); }
@@ -3992,6 +4011,7 @@ function dashboard() {
         { label: 'View Logs', desc: 'Open runtime logs', keywords: ['logs', 'runtime', 'debug'], action: () => { this.systemTab = 'activity'; this.switchTab('system'); this.setActivityView('logs'); } },
         { label: 'Add API Key', desc: 'Add new API key or credential', keywords: ['key', 'api', 'credential', 'token'], action: () => { this.systemTab = 'apikeys'; this.switchTab('system'); this.showCredForm = true; } },
         { label: 'Manage API Endpoints', desc: 'View and create API endpoints', keywords: ['api', 'endpoint', 'webhook', 'hook'], action: () => { this.systemTab = 'integrations'; this.switchTab('system'); this.fetchEndpoints(); } },
+        { label: 'Manage Webhooks', desc: 'View outbound webhook subscriptions', keywords: ['webhook', 'outbound', 'notify'], action: () => { this.systemTab = 'integrations'; this.switchTab('system'); this.fetchOutboundWebhooks(); } },
         { label: 'Manage Channels', desc: 'Connect Telegram, Discord, Slack, WhatsApp', keywords: ['channel', 'telegram', 'discord', 'slack', 'whatsapp'], action: () => { this.systemTab = 'integrations'; this.switchTab('system'); this.fetchChannels(); } },
         { label: 'Model Pricing', desc: 'Token costs by model', keywords: ['model', 'pricing', 'tokens'], action: () => { this.systemTab = 'costs'; this.switchTab('system'); } },
         { label: 'Browser Settings', desc: 'Browser speed and timing', keywords: ['browser', 'speed', 'settings', 'timing', 'stealth'], action: () => { this.systemTab = 'settings'; this.switchTab('system'); this.fetchBrowserSettings(); } },
@@ -4628,6 +4648,94 @@ function dashboard() {
           }
         } catch (e) { this.showToast(`Error: ${e.message}`); }
       }, true);
+    },
+
+    // ── Outbound Webhooks ──────────────────────────────────
+
+    async fetchOutboundWebhooks() {
+      try {
+        const resp = await fetch(`${window.__config.apiBase}/webhooks`);
+        if (resp.ok) this.outboundWebhooks = (await resp.json()).webhooks || [];
+      } catch (e) { console.error('Failed to fetch webhooks', e); }
+    },
+
+    async createOutboundWebhook() {
+      if (this.outboundCreating) return;
+      const name = this.outboundFormName.trim();
+      const url = this.outboundFormUrl.trim();
+      const events = this.outboundFormEvents;
+      if (!name || !url || !events.length) { this.showToast('Name, URL, and at least one event required'); return; }
+      this.outboundCreating = true;
+      try {
+        const body = { name, url, events, agent_filter: this.outboundFormAgentFilter };
+        const resp = await fetch(`${window.__config.apiBase}/webhooks`, { method: 'POST', headers: { 'Content-Type': 'application/json', 'X-Requested-With': 'XMLHttpRequest' }, body: JSON.stringify(body) });
+        const data = await resp.json();
+        if (resp.ok) {
+          this.showToast('Webhook created');
+          this.outboundFormName = ''; this.outboundFormUrl = ''; this.outboundFormEvents = []; this.outboundFormAgentFilter = [];
+          this.showOutboundForm = false;
+          await this.fetchOutboundWebhooks();
+        } else { this.showToast(`Error: ${data.detail || 'Failed to create webhook'}`); }
+      } catch (e) { this.showToast('Failed to create webhook'); }
+      finally { this.outboundCreating = false; }
+    },
+
+    async deleteOutboundWebhook(subId, name) {
+      this.showConfirm('Delete Webhook', `Delete webhook "${name}"?`, async () => {
+        try {
+          const resp = await fetch(`${window.__config.apiBase}/webhooks/${encodeURIComponent(subId)}`, { method: 'DELETE', headers: { 'X-Requested-With': 'XMLHttpRequest' } });
+          if (resp.ok) { this.showToast('Webhook deleted'); await this.fetchOutboundWebhooks(); }
+        } catch (e) { this.showToast('Failed to delete webhook'); }
+      });
+    },
+
+    async testOutboundWebhook(subId) {
+      try {
+        const resp = await fetch(`${window.__config.apiBase}/webhooks/${encodeURIComponent(subId)}/test`, { method: 'POST', headers: { 'Content-Type': 'application/json', 'X-Requested-With': 'XMLHttpRequest' }, body: '{}' });
+        if (resp.ok) this.showToast('Test event sent');
+        else this.showToast('Test failed');
+      } catch (e) { this.showToast('Test failed'); }
+    },
+
+    async fetchDeliveries() {
+      try {
+        const resp = await fetch(`${window.__config.apiBase}/webhooks/deliveries`);
+        if (resp.ok) this.outboundDeliveries = (await resp.json()).deliveries || [];
+      } catch (e) { console.error('Failed to fetch deliveries', e); }
+    },
+
+    editOutboundWebhook(wh) {
+      this.editingOutboundId = wh.id;
+      this.outboundEditName = wh.name;
+      this.outboundEditUrl = wh.url;
+      this.outboundEditEvents = [...(wh.events || [])];
+      this.outboundEditAgentFilter = [...(wh.agent_filter || [])];
+      this.outboundEditEnabled = wh.enabled !== false;
+    },
+
+    cancelOutboundEdit() {
+      this.editingOutboundId = null;
+    },
+
+    async saveOutboundEdit() {
+      if (this.outboundSaving) return;
+      const id = this.editingOutboundId;
+      const body = {};
+      const wh = this.outboundWebhooks.find(w => w.id === id);
+      if (!wh) return;
+      if (this.outboundEditName.trim() !== wh.name) body.name = this.outboundEditName.trim();
+      if (this.outboundEditUrl.trim() !== wh.url) body.url = this.outboundEditUrl.trim();
+      if (JSON.stringify(this.outboundEditEvents) !== JSON.stringify(wh.events)) body.events = this.outboundEditEvents;
+      if (JSON.stringify(this.outboundEditAgentFilter) !== JSON.stringify(wh.agent_filter || [])) body.agent_filter = this.outboundEditAgentFilter;
+      if (this.outboundEditEnabled !== (wh.enabled !== false)) body.enabled = this.outboundEditEnabled;
+      if (!Object.keys(body).length) { this.editingOutboundId = null; return; }
+      this.outboundSaving = true;
+      try {
+        const resp = await fetch(`${window.__config.apiBase}/webhooks/${encodeURIComponent(id)}`, { method: 'PATCH', headers: { 'Content-Type': 'application/json', 'X-Requested-With': 'XMLHttpRequest' }, body: JSON.stringify(body) });
+        if (resp.ok) { this.showToast('Webhook updated'); this.editingOutboundId = null; await this.fetchOutboundWebhooks(); }
+        else { const data = await resp.json(); this.showToast(`Error: ${data.detail || 'Failed'}`); }
+      } catch (e) { this.showToast('Failed to update webhook'); }
+      finally { this.outboundSaving = false; }
     },
 
     // ── External API key ──────────────────────────────────

--- a/src/dashboard/static/js/app.js
+++ b/src/dashboard/static/js/app.js
@@ -277,7 +277,6 @@ function dashboard() {
     integrationsTabs: [
       { id: 'endpoints', label: 'API Endpoints' },
       { id: 'webhooks', label: 'Webhooks' },
-      { id: 'accesskeys', label: 'Access Keys' },
       { id: 'apikeys', label: 'Credentials' },
     ],
 
@@ -506,7 +505,7 @@ function dashboard() {
       else if (clean.startsWith('integrations')) {
         route.tab = 'integrations';
         const sub = clean.split('/')[1];
-        if (sub && ['endpoints', 'webhooks', 'accesskeys', 'apikeys'].includes(sub)) {
+        if (sub && ['endpoints', 'webhooks', 'apikeys'].includes(sub)) {
           route.integrationsTab = sub;
         }
       }
@@ -1182,9 +1181,8 @@ function dashboard() {
     switchIntegrationsTab(tabId) {
       this.integrationsTab = tabId;
       this._pushUrl(false);
-      if (tabId === 'endpoints') { this.fetchEndpoints(); }
+      if (tabId === 'endpoints') { this.fetchEndpoints(); this.fetchApiKeys(); }
       if (tabId === 'webhooks') { this.fetchOutboundWebhooks(); }
-      if (tabId === 'accesskeys') { this.fetchApiKeys(); }
       if (tabId === 'apikeys') { this.fetchSettings(); this.fetchApiKeys(); }
     },
 

--- a/src/dashboard/static/js/app.js
+++ b/src/dashboard/static/js/app.js
@@ -300,24 +300,24 @@ function dashboard() {
     channelTokens: {},
 
 
-    // Webhooks
-    webhooks: [],
-    showWebhookForm: false,
-    webhookFormName: '',
-    webhookFormAgent: '',
-    webhookFormInstructions: '',
-    webhookFormRequireSig: false,
-    editingWebhookId: null,
-    webhookEditName: '',
-    webhookEditAgent: '',
-    webhookEditInstructions: '',
-    webhookEditRequireSig: false,
+    // API Endpoints
+    apiEndpoints: [],
+    showEndpointForm: false,
+    endpointFormName: '',
+    endpointFormAgent: '',
+    endpointFormInstructions: '',
+    endpointFormRequireSig: false,
+    editingEndpointId: null,
+    endpointEditName: '',
+    endpointEditAgent: '',
+    endpointEditInstructions: '',
+    endpointEditRequireSig: false,
 
-    // Webhook inline edit
-    editingWebhookId: null,
-    webhookEditName: '',
-    webhookEditAgent: '',
-    webhookEditInstructions: '',
+    // Endpoint inline edit
+    editingEndpointId: null,
+    endpointEditName: '',
+    endpointEditAgent: '',
+    endpointEditInstructions: '',
 
     // Model health
     modelHealth: [],
@@ -362,11 +362,11 @@ function dashboard() {
     credSaving: false,
     onboardSaving: false,
     channelConnecting: false,
-    webhookCreating: false,
-    webhookTesting: {},
-    webhookSaving: false,
-    webhookRevealedSecret: null,
-    webhookRevealedSecretHookId: null,
+    endpointCreating: false,
+    endpointTesting: {},
+    endpointSaving: false,
+    endpointRevealedSecret: null,
+    endpointRevealedSecretId: null,
     apiKeys: [],
     apiKeysLegacy: false,
     apiKeyNewValue: null,
@@ -528,7 +528,7 @@ function dashboard() {
               if (this.systemTab === 'activity') this._stopActivityRefresh();
               this.systemTab = route.systemTab;
               if (route.systemTab === 'integrations') {
-                this.fetchChannels(); this.fetchWebhooks(); this.fetchApiKeys();
+                this.fetchChannels(); this.fetchEndpoints(); this.fetchApiKeys();
               }
               if (route.systemTab === 'apikeys') {
                 this.fetchSettings();
@@ -1091,7 +1091,7 @@ function dashboard() {
         this.fetchCronJobs();
         this.fetchWorkflows();
         if (this.systemTab === 'integrations') {
-          this.fetchWebhooks();
+          this.fetchEndpoints();
           this.fetchChannels();
           this.fetchApiKeys();
         }
@@ -1115,7 +1115,7 @@ function dashboard() {
       if (this.systemTab === 'activity' && tabId !== 'activity') this._stopActivityRefresh();
       this.systemTab = tabId;
       this._pushUrl(false);
-      if (tabId === 'integrations') { this.fetchChannels(); this.fetchWebhooks(); this.fetchApiKeys(); }
+      if (tabId === 'integrations') { this.fetchChannels(); this.fetchEndpoints(); this.fetchApiKeys(); }
       if (tabId === 'apikeys') { this.fetchSettings(); }
       if (tabId === 'storage') { this.fetchUploads(); this.fetchStorage(); this.fetchDatabaseDetails(); }
       if (tabId === 'settings') { this.fetchBrowserSettings(); this.fetchSystemSettings(); }
@@ -3991,7 +3991,7 @@ function dashboard() {
         { label: 'Activity', desc: 'Traces, live feed, and logs', keywords: ['activity', 'traces', 'events', 'live'], action: () => { this.systemTab = 'activity'; this.switchTab('system'); } },
         { label: 'View Logs', desc: 'Open runtime logs', keywords: ['logs', 'runtime', 'debug'], action: () => { this.systemTab = 'activity'; this.switchTab('system'); this.setActivityView('logs'); } },
         { label: 'Add API Key', desc: 'Add new API key or credential', keywords: ['key', 'api', 'credential', 'token'], action: () => { this.systemTab = 'apikeys'; this.switchTab('system'); this.showCredForm = true; } },
-        { label: 'Manage Webhooks', desc: 'View and create webhooks', keywords: ['webhook', 'hook', 'endpoint'], action: () => { this.systemTab = 'integrations'; this.switchTab('system'); this.fetchWebhooks(); } },
+        { label: 'Manage API Endpoints', desc: 'View and create API endpoints', keywords: ['api', 'endpoint', 'webhook', 'hook'], action: () => { this.systemTab = 'integrations'; this.switchTab('system'); this.fetchEndpoints(); } },
         { label: 'Manage Channels', desc: 'Connect Telegram, Discord, Slack, WhatsApp', keywords: ['channel', 'telegram', 'discord', 'slack', 'whatsapp'], action: () => { this.systemTab = 'integrations'; this.switchTab('system'); this.fetchChannels(); } },
         { label: 'Model Pricing', desc: 'Token costs by model', keywords: ['model', 'pricing', 'tokens'], action: () => { this.systemTab = 'costs'; this.switchTab('system'); } },
         { label: 'Browser Settings', desc: 'Browser speed and timing', keywords: ['browser', 'speed', 'settings', 'timing', 'stealth'], action: () => { this.systemTab = 'settings'; this.switchTab('system'); this.fetchBrowserSettings(); } },
@@ -4456,26 +4456,26 @@ function dashboard() {
       }, true);
     },
 
-    // ── Webhooks ──────────────────────────────────────────
+    // ── API Endpoints ──────────────────────────────────────────
 
-    async fetchWebhooks() {
+    async fetchEndpoints() {
       try {
-        const resp = await fetch(`${window.__config.apiBase}/webhooks`);
-        if (resp.ok) this.webhooks = (await resp.json()).webhooks || [];
-      } catch (e) { console.warn('fetchWebhooks failed:', e); }
+        const resp = await fetch(`${window.__config.apiBase}/endpoints`);
+        if (resp.ok) this.apiEndpoints = (await resp.json()).endpoints || [];
+      } catch (e) { console.warn('fetchEndpoints failed:', e); }
     },
 
-    async createWebhook() {
-      if (this.webhookCreating) return;
-      const name = this.webhookFormName.trim();
-      const agent = this.webhookFormAgent;
+    async createEndpoint() {
+      if (this.endpointCreating) return;
+      const name = this.endpointFormName.trim();
+      const agent = this.endpointFormAgent;
       if (!name || !agent) { this.showToast('Name and agent are required'); return; }
-      this.webhookCreating = true;
+      this.endpointCreating = true;
       try {
         const body = { name, agent };
-        if (this.webhookFormInstructions.trim()) body.instructions = this.webhookFormInstructions.trim();
-        if (this.webhookFormRequireSig) body.secret = true;
-        const resp = await fetch(`${window.__config.apiBase}/webhooks`, {
+        if (this.endpointFormInstructions.trim()) body.instructions = this.endpointFormInstructions.trim();
+        if (this.endpointFormRequireSig) body.secret = true;
+        const resp = await fetch(`${window.__config.apiBase}/endpoints`, {
           method: 'POST', headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify(body),
         });
@@ -4483,37 +4483,37 @@ function dashboard() {
           const data = await resp.json();
           const hook = data.hook || {};
           if (hook.secret) {
-            this.webhookRevealedSecret = hook.secret;
-            this.webhookRevealedSecretHookId = hook.id;
+            this.endpointRevealedSecret = hook.secret;
+            this.endpointRevealedSecretId = hook.id;
             if (navigator.clipboard) navigator.clipboard.writeText(hook.secret).catch(() => {});
-            this.showToast(`Webhook "${name}" created — copy the secret below`, 8000);
+            this.showToast(`Endpoint "${name}" created — copy the secret below`, 8000);
           } else if (hook.url && navigator.clipboard) {
             navigator.clipboard.writeText(hook.url).catch(() => {});
-            this.showToast(`Webhook "${name}" created — URL copied`);
+            this.showToast(`Endpoint "${name}" created — URL copied`);
           } else {
-            this.showToast(`Webhook "${name}" created`);
+            this.showToast(`Endpoint "${name}" created`);
           }
-          this.webhookFormName = '';
-          this.webhookFormAgent = '';
-          this.webhookFormInstructions = '';
-          this.webhookFormRequireSig = false;
-          this.showWebhookForm = false;
-          this.fetchWebhooks();
+          this.endpointFormName = '';
+          this.endpointFormAgent = '';
+          this.endpointFormInstructions = '';
+          this.endpointFormRequireSig = false;
+          this.showEndpointForm = false;
+          this.fetchEndpoints();
         } else {
           const err = await resp.json().catch(() => ({}));
-          this.showToast(`Error: ${err.detail || 'Failed to create webhook'}`);
+          this.showToast(`Error: ${err.detail || 'Failed to create endpoint'}`);
         }
       } catch (e) { this.showToast(`Error: ${e.message}`); }
-      finally { this.webhookCreating = false; }
+      finally { this.endpointCreating = false; }
     },
 
-    async deleteWebhook(hookId, name) {
-      this.showConfirm('Delete Webhook', `Delete webhook "${name}"?`, async () => {
+    async deleteEndpoint(hookId, name) {
+      this.showConfirm('Delete Endpoint', `Delete endpoint "${name}"?`, async () => {
         try {
-          const resp = await fetch(`${window.__config.apiBase}/webhooks/${encodeURIComponent(hookId)}`, { method: 'DELETE' });
+          const resp = await fetch(`${window.__config.apiBase}/endpoints/${encodeURIComponent(hookId)}`, { method: 'DELETE' });
           if (resp.ok) {
-            this.showToast(`Webhook "${name}" deleted`);
-            this.fetchWebhooks();
+            this.showToast(`Endpoint "${name}" deleted`);
+            this.fetchEndpoints();
           } else {
             const err = await resp.json().catch(() => ({}));
             this.showToast(`Error: ${err.detail || 'Delete failed'}`);
@@ -4522,62 +4522,62 @@ function dashboard() {
       }, true);
     },
 
-    async testWebhook(hookId) {
-      if (this.webhookTesting[hookId]) return;
-      this.webhookTesting = { ...this.webhookTesting, [hookId]: true };
+    async testEndpoint(hookId) {
+      if (this.endpointTesting[hookId]) return;
+      this.endpointTesting = { ...this.endpointTesting, [hookId]: true };
       try {
-        const resp = await fetch(`${window.__config.apiBase}/webhooks/${encodeURIComponent(hookId)}/test`, { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: '{}' });
+        const resp = await fetch(`${window.__config.apiBase}/endpoints/${encodeURIComponent(hookId)}/test`, { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: '{}' });
         if (resp.ok) {
-          this.showToast('Webhook test sent');
+          this.showToast('Endpoint test sent');
         } else {
           const err = await resp.json().catch(() => ({}));
           this.showToast(`Test failed: ${err.detail || 'Unknown error'}`);
         }
       } catch (e) { this.showToast(`Test failed: ${e.message}`); }
-      finally { this.webhookTesting = { ...this.webhookTesting, [hookId]: false }; }
+      finally { this.endpointTesting = { ...this.endpointTesting, [hookId]: false }; }
     },
 
-    editWebhook(wh) {
-      this.showWebhookForm = false;
-      this.editingWebhookId = wh.id;
-      this.webhookEditName = wh.name;
-      this.webhookEditAgent = wh.agent;
-      this.webhookEditInstructions = wh.instructions || '';
-      this.webhookEditRequireSig = !!wh.has_secret;
+    editEndpoint(wh) {
+      this.showEndpointForm = false;
+      this.editingEndpointId = wh.id;
+      this.endpointEditName = wh.name;
+      this.endpointEditAgent = wh.agent;
+      this.endpointEditInstructions = wh.instructions || '';
+      this.endpointEditRequireSig = !!wh.has_secret;
     },
 
-    cancelWebhookEdit() {
-      this.editingWebhookId = null;
-      this.webhookEditName = '';
-      this.webhookEditAgent = '';
-      this.webhookEditInstructions = '';
-      this.webhookEditRequireSig = false;
+    cancelEndpointEdit() {
+      this.editingEndpointId = null;
+      this.endpointEditName = '';
+      this.endpointEditAgent = '';
+      this.endpointEditInstructions = '';
+      this.endpointEditRequireSig = false;
     },
 
-    async saveWebhookEdit() {
-      if (this.webhookSaving) return;
-      const id = this.editingWebhookId;
+    async saveEndpointEdit() {
+      if (this.endpointSaving) return;
+      const id = this.editingEndpointId;
       if (!id) return;
-      const wh = this.webhooks.find(w => w.id === id);
+      const wh = this.apiEndpoints.find(w => w.id === id);
       if (!wh) return;
-      const name = this.webhookEditName.trim();
-      const agent = this.webhookEditAgent;
+      const name = this.endpointEditName.trim();
+      const agent = this.endpointEditAgent;
       if (!name || !agent) { this.showToast('Name and agent are required'); return; }
 
       const body = {};
       if (name !== wh.name) body.name = name;
       if (agent !== wh.agent) body.agent = agent;
-      const newInstr = this.webhookEditInstructions.trim();
+      const newInstr = this.endpointEditInstructions.trim();
       const oldInstr = (wh.instructions || '').trim();
       if (newInstr !== oldInstr) body.instructions = newInstr;
       const hadSecret = !!wh.has_secret;
-      if (this.webhookEditRequireSig !== hadSecret) body.require_signature = this.webhookEditRequireSig;
+      if (this.endpointEditRequireSig !== hadSecret) body.require_signature = this.endpointEditRequireSig;
 
       if (Object.keys(body).length === 0) { this.showToast('No changes to save'); return; }
 
-      this.webhookSaving = true;
+      this.endpointSaving = true;
       try {
-        const resp = await fetch(`${window.__config.apiBase}/webhooks/${encodeURIComponent(id)}`, {
+        const resp = await fetch(`${window.__config.apiBase}/endpoints/${encodeURIComponent(id)}`, {
           method: 'PATCH', headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify(body),
         });
@@ -4585,27 +4585,27 @@ function dashboard() {
           const data = await resp.json();
           const hook = data.hook || {};
           if (hook.secret) {
-            this.webhookRevealedSecret = hook.secret;
-            this.webhookRevealedSecretHookId = hook.id || this.editingWebhookId;
+            this.endpointRevealedSecret = hook.secret;
+            this.endpointRevealedSecretId = hook.id || this.editingEndpointId;
             if (navigator.clipboard) navigator.clipboard.writeText(hook.secret).catch(() => {});
-            this.showToast(`Webhook updated — copy the secret below`, 8000);
+            this.showToast(`Endpoint updated — copy the secret below`, 8000);
           } else {
-            this.showToast(`Webhook "${name}" updated`);
+            this.showToast(`Endpoint "${name}" updated`);
           }
-          this.cancelWebhookEdit();
-          this.fetchWebhooks();
+          this.cancelEndpointEdit();
+          this.fetchEndpoints();
         } else {
           const err = await resp.json().catch(() => ({}));
           this.showToast(`Error: ${err.detail || 'Update failed'}`);
         }
       } catch (e) { this.showToast(`Error: ${e.message}`); }
-      finally { this.webhookSaving = false; }
+      finally { this.endpointSaving = false; }
     },
 
-    regenerateWebhookSecret(hookId, name) {
+    regenerateEndpointSecret(hookId, name) {
       this.showConfirm('Regenerate Secret', `Regenerate HMAC secret for "${name}"? The old secret will stop working immediately.`, async () => {
         try {
-          const resp = await fetch(`${window.__config.apiBase}/webhooks/${encodeURIComponent(hookId)}`, {
+          const resp = await fetch(`${window.__config.apiBase}/endpoints/${encodeURIComponent(hookId)}`, {
             method: 'PATCH', headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify({ regenerate_secret: true }),
           });
@@ -4613,15 +4613,15 @@ function dashboard() {
             const data = await resp.json();
             const hook = data.hook || {};
             if (hook.secret) {
-              this.webhookRevealedSecret = hook.secret;
-              this.webhookRevealedSecretHookId = hook.id || hookId;
+              this.endpointRevealedSecret = hook.secret;
+              this.endpointRevealedSecretId = hook.id || hookId;
               if (navigator.clipboard) navigator.clipboard.writeText(hook.secret).catch(() => {});
               this.showToast('New secret shown below — copy it now', 8000);
             } else {
               this.showToast('Secret regenerated');
             }
-            this.cancelWebhookEdit();
-            this.fetchWebhooks();
+            this.cancelEndpointEdit();
+            this.fetchEndpoints();
           } else {
             const err = await resp.json().catch(() => ({}));
             this.showToast(`Error: ${err.detail || 'Regeneration failed'}`);

--- a/src/dashboard/templates/index.html
+++ b/src/dashboard/templates/index.html
@@ -2560,7 +2560,7 @@
         </div>
         </div><!-- /automation sub-tab -->
 
-        <!-- Integrations sub-tab (Channels + Webhooks) -->
+        <!-- Integrations sub-tab (Channels + API Endpoints) -->
         <div x-show="systemTab === 'integrations'">
 
         <!-- API Reference -->
@@ -2570,7 +2570,7 @@
             API Reference
           </summary>
           <div class="px-4 pb-4 space-y-3">
-            <div class="text-[11px] text-gray-500 mb-2">All endpoints below require an <code class="bg-gray-800 px-1 rounded">X-API-Key</code> header. Webhook triggers use <code class="bg-gray-800 px-1 rounded">X-Webhook-Signature</code> instead (HMAC-SHA256 of the raw body).</div>
+            <div class="text-[11px] text-gray-500 mb-2">All endpoints below require an <code class="bg-gray-800 px-1 rounded">X-API-Key</code> header. Inbound API endpoints use <code class="bg-gray-800 px-1 rounded">X-Signature</code> instead (HMAC-SHA256 of the raw body).</div>
             <div class="space-y-2">
               <div class="text-[10px] text-gray-600 uppercase tracking-wider font-medium">Credential Vault</div>
               <div class="grid grid-cols-1 sm:grid-cols-[auto_1fr_2fr] gap-x-3 gap-y-1 text-[11px]">
@@ -2587,9 +2587,9 @@
               </div>
             </div>
             <div class="space-y-2">
-              <div class="text-[10px] text-gray-600 uppercase tracking-wider font-medium">Webhooks</div>
+              <div class="text-[10px] text-gray-600 uppercase tracking-wider font-medium">API Endpoints</div>
               <div class="grid grid-cols-1 sm:grid-cols-[auto_1fr_2fr] gap-x-3 gap-y-1 text-[11px]">
-                <code class="text-green-400/70 font-mono">POST</code><code class="text-gray-400 font-mono">/webhook/hook/{hook_id}</code><span class="text-gray-500">Trigger an agent workflow. Requires <code class="bg-gray-800 px-0.5 rounded">X-Webhook-Signature</code> header (no API key needed)</span>
+                <code class="text-green-400/70 font-mono">POST</code><code class="text-gray-400 font-mono">/api/inbound/{endpoint_id}</code><span class="text-gray-500">Trigger an agent workflow. Requires <code class="bg-gray-800 px-0.5 rounded">X-Signature</code> header (no API key needed)</span>
               </div>
             </div>
           </div>
@@ -2712,16 +2712,16 @@
         </div>
         <div x-show="channels.length === 0" class="text-sm text-gray-500 py-4 mb-6">No channel data available</div>
 
-        <!-- Webhooks -->
-        <div class="text-xs text-gray-500 uppercase tracking-wider mb-3 flex items-center gap-1.5">Webhooks<span class="setting-hint" tabindex="0">?<span class="setting-hint-text">Named HTTP endpoints that accept POST requests and route them to agents. Enable "Require HMAC signature" to secure the webhook — your app signs the raw request body with HMAC-SHA256(body, secret) and sends it as the X-Webhook-Signature header. The secret is shown once at creation time; use Regenerate Secret if you missed it.</span></span></div>
+        <!-- API Endpoints -->
+        <div class="text-xs text-gray-500 uppercase tracking-wider mb-3 flex items-center gap-1.5">API Endpoints<span class="setting-hint" tabindex="0">?<span class="setting-hint-text">Named HTTP endpoints that accept POST requests and route them to agents. Enable "Require HMAC signature" to secure the endpoint — your app signs the raw request body with HMAC-SHA256(body, secret) and sends it as the X-Signature header. The secret is shown once at creation time; use Regenerate Secret if you missed it.</span></span></div>
         <div class="mb-6">
           <div class="bg-gray-900 border border-gray-800 rounded-lg p-4">
             <div class="mb-3 pb-3 border-b border-gray-800">
-              <div class="text-sm text-gray-200 font-medium mb-1">Incoming Webhooks</div>
+              <div class="text-sm text-gray-200 font-medium mb-1">API Endpoints</div>
               <div class="text-[12px] text-gray-500 leading-relaxed">Named HTTP endpoints that accept <code class="bg-gray-800 px-1 rounded text-gray-400">POST</code> requests and route payloads to agents. Optionally secure each endpoint with HMAC-SHA256 signature verification.</div>
             </div>
             <div class="space-y-2 mb-3">
-              <template x-for="wh in webhooks" :key="wh.id">
+              <template x-for="wh in apiEndpoints" :key="wh.id">
                 <div>
                   <div class="flex items-center gap-3 text-xs group py-2 px-2 -mx-2 rounded-md hover:bg-gray-800/40 transition-colors border-b border-gray-800/30 last:border-0">
                     <span class="w-2 h-2 rounded-full bg-green-400/70 shrink-0"></span>
@@ -2730,83 +2730,83 @@
                     <span class="text-gray-400 shrink-0" x-text="wh.agent"></span>
                     <span class="text-indigo-300/80 text-[10px] font-mono flex-1 truncate bg-indigo-950/30 px-2 py-0.5 rounded border border-indigo-900/50" x-text="wh.url || ''" :title="wh.url || ''"></span>
                     <button x-show="wh.url" @click.stop="copyToClipboard(wh.url)"
-                      class="opacity-0 group-hover:opacity-100 focus:opacity-100 text-[10px] px-1.5 py-0.5 rounded bg-gray-800 hover:bg-gray-700 text-gray-400 hover:text-gray-200 transition-all shrink-0" title="Copy URL" aria-label="Copy webhook URL">
+                      class="opacity-0 group-hover:opacity-100 focus:opacity-100 text-[10px] px-1.5 py-0.5 rounded bg-gray-800 hover:bg-gray-700 text-gray-400 hover:text-gray-200 transition-all shrink-0" title="Copy URL" aria-label="Copy endpoint URL">
                       <svg class="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="9" y="9" width="13" height="13" rx="2" ry="2"/><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/></svg>
                     </button>
-                    <button @click="editWebhook(wh)"
+                    <button @click="editEndpoint(wh)"
                       class="opacity-0 group-hover:opacity-100 focus:opacity-100 text-[10px] px-1.5 py-0.5 rounded bg-gray-800 hover:bg-gray-700 text-gray-400 hover:text-gray-200 transition-all shrink-0">Edit</button>
-                    <button @click="testWebhook(wh.id)" :disabled="webhookTesting[wh.id] === true"
-                      class="opacity-0 group-hover:opacity-100 focus:opacity-100 text-[10px] px-1.5 py-0.5 rounded bg-gray-800 hover:bg-indigo-900/40 text-gray-400 hover:text-indigo-300 transition-all disabled:opacity-50 shrink-0" x-text="webhookTesting[wh.id] === true ? '...' : 'Test'"></button>
-                    <button @click="deleteWebhook(wh.id, wh.name)"
+                    <button @click="testEndpoint(wh.id)" :disabled="endpointTesting[wh.id] === true"
+                      class="opacity-0 group-hover:opacity-100 focus:opacity-100 text-[10px] px-1.5 py-0.5 rounded bg-gray-800 hover:bg-indigo-900/40 text-gray-400 hover:text-indigo-300 transition-all disabled:opacity-50 shrink-0" x-text="endpointTesting[wh.id] === true ? '...' : 'Test'"></button>
+                    <button @click="deleteEndpoint(wh.id, wh.name)"
                       class="opacity-0 group-hover:opacity-100 focus:opacity-100 text-[10px] px-1.5 py-0.5 rounded bg-gray-800 hover:bg-red-900/30 text-gray-400 hover:text-red-400 transition-all shrink-0">Delete</button>
                   </div>
                   <!-- Inline edit form -->
-                  <div x-show="editingWebhookId === wh.id" x-transition class="bg-gray-800/30 border border-gray-800 rounded-lg p-3 mt-1 mb-2">
-                    <div class="text-xs text-gray-500 mb-2">Edit webhook</div>
+                  <div x-show="editingEndpointId === wh.id" x-transition class="bg-gray-800/30 border border-gray-800 rounded-lg p-3 mt-1 mb-2">
+                    <div class="text-xs text-gray-500 mb-2">Edit endpoint</div>
                     <div class="flex gap-2 mb-2">
-                      <input type="text" x-model="webhookEditName" :disabled="webhookSaving" class="dash-input text-xs flex-1" placeholder="Webhook name">
-                      <select x-model="webhookEditAgent" :disabled="webhookSaving" class="dash-select text-xs w-40">
+                      <input type="text" x-model="endpointEditName" :disabled="endpointSaving" class="dash-input text-xs flex-1" placeholder="Endpoint name">
+                      <select x-model="endpointEditAgent" :disabled="endpointSaving" class="dash-select text-xs w-40">
                         <option value="">Agent...</option>
                         <template x-for="a in agents" :key="a.id">
                           <option :value="a.id" x-text="a.id"></option>
                         </template>
                       </select>
                     </div>
-                    <textarea x-model="webhookEditInstructions" :disabled="webhookSaving" class="dash-input w-full text-xs mb-2" rows="2" placeholder="Instructions for the agent (optional)"></textarea>
+                    <textarea x-model="endpointEditInstructions" :disabled="endpointSaving" class="dash-input w-full text-xs mb-2" rows="2" placeholder="Instructions for the agent (optional)"></textarea>
                     <label class="flex items-center gap-2 text-xs text-gray-400 mb-3 cursor-pointer select-none">
-                      <input type="checkbox" x-model="webhookEditRequireSig" :disabled="webhookSaving" class="rounded border-gray-700 bg-gray-800 text-indigo-500 focus:ring-indigo-500/30">
+                      <input type="checkbox" x-model="endpointEditRequireSig" :disabled="endpointSaving" class="rounded border-gray-700 bg-gray-800 text-indigo-500 focus:ring-indigo-500/30">
                       Require HMAC signature
                     </label>
                     <div class="flex justify-between items-center">
                       <div class="flex gap-2">
-                        <button @click="cancelWebhookEdit()" :disabled="webhookSaving" class="text-xs px-3 py-1.5 rounded border border-gray-700 hover:border-gray-600 text-gray-400 hover:text-gray-300 transition-colors disabled:opacity-50">Cancel</button>
-                        <button x-show="wh.has_secret" @click="regenerateWebhookSecret(wh.id, wh.name)" :disabled="webhookSaving" class="text-xs px-3 py-1.5 rounded border border-yellow-900/50 hover:border-yellow-700/50 text-yellow-600 hover:text-yellow-500 transition-colors disabled:opacity-50">Regenerate Secret</button>
+                        <button @click="cancelEndpointEdit()" :disabled="endpointSaving" class="text-xs px-3 py-1.5 rounded border border-gray-700 hover:border-gray-600 text-gray-400 hover:text-gray-300 transition-colors disabled:opacity-50">Cancel</button>
+                        <button x-show="wh.has_secret" @click="regenerateEndpointSecret(wh.id, wh.name)" :disabled="endpointSaving" class="text-xs px-3 py-1.5 rounded border border-yellow-900/50 hover:border-yellow-700/50 text-yellow-600 hover:text-yellow-500 transition-colors disabled:opacity-50">Regenerate Secret</button>
                       </div>
-                      <button @click="saveWebhookEdit()" :disabled="webhookSaving" class="text-xs px-3 py-1.5 rounded bg-indigo-600 hover:bg-indigo-500 text-white transition-colors inline-flex items-center gap-1.5 disabled:opacity-50">
-                        <svg x-show="webhookSaving" x-cloak class="animate-spin h-3 w-3" fill="none" viewBox="0 0 24 24"><circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"/><path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z"/></svg>
-                        <span x-text="webhookSaving ? 'Saving...' : 'Save'"></span>
+                      <button @click="saveEndpointEdit()" :disabled="endpointSaving" class="text-xs px-3 py-1.5 rounded bg-indigo-600 hover:bg-indigo-500 text-white transition-colors inline-flex items-center gap-1.5 disabled:opacity-50">
+                        <svg x-show="endpointSaving" x-cloak class="animate-spin h-3 w-3" fill="none" viewBox="0 0 24 24"><circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"/><path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z"/></svg>
+                        <span x-text="endpointSaving ? 'Saving...' : 'Save'"></span>
                       </button>
                     </div>
                   </div>
                   <!-- One-time secret display -->
-                  <div x-show="webhookRevealedSecret && webhookRevealedSecretHookId === wh.id" x-transition class="mt-2 mb-2 p-3 bg-amber-950 border border-amber-700/60 rounded-lg">
+                  <div x-show="endpointRevealedSecret && endpointRevealedSecretId === wh.id" x-transition class="mt-2 mb-2 p-3 bg-amber-950 border border-amber-700/60 rounded-lg">
                     <div class="flex items-center gap-1.5 text-[11px] text-amber-300 font-semibold mb-2.5">
                       <svg class="w-3.5 h-3.5 shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M12 9v3.75m-9.303 3.376c-.866 1.5.217 3.374 1.948 3.374h14.71c1.73 0 2.813-1.874 1.948-3.374L13.949 3.378c-.866-1.5-3.032-1.5-3.898 0L2.697 16.126zM12 15.75h.007v.008H12v-.008z"/></svg>
                       HMAC Secret — copy this now, it won't be shown again
                     </div>
                     <div class="flex items-center gap-2">
-                      <code class="text-[12px] text-amber-100 bg-black/40 px-3 py-2 rounded font-mono flex-1 break-all select-all tracking-wide border border-amber-900/60" x-text="webhookRevealedSecret"></code>
-                      <button @click="copyToClipboard(webhookRevealedSecret)" class="text-[10px] px-3 py-1.5 rounded bg-amber-800/60 hover:bg-amber-700/60 text-amber-200 hover:text-white border border-amber-700/50 transition-colors shrink-0 font-medium">Copy</button>
-                      <button @click="webhookRevealedSecret = null; webhookRevealedSecretHookId = null" class="text-[10px] px-2.5 py-1.5 rounded bg-gray-800 hover:bg-gray-700 text-gray-400 hover:text-gray-200 transition-colors shrink-0">Dismiss</button>
+                      <code class="text-[12px] text-amber-100 bg-black/40 px-3 py-2 rounded font-mono flex-1 break-all select-all tracking-wide border border-amber-900/60" x-text="endpointRevealedSecret"></code>
+                      <button @click="copyToClipboard(endpointRevealedSecret)" class="text-[10px] px-3 py-1.5 rounded bg-amber-800/60 hover:bg-amber-700/60 text-amber-200 hover:text-white border border-amber-700/50 transition-colors shrink-0 font-medium">Copy</button>
+                      <button @click="endpointRevealedSecret = null; endpointRevealedSecretId = null" class="text-[10px] px-2.5 py-1.5 rounded bg-gray-800 hover:bg-gray-700 text-gray-400 hover:text-gray-200 transition-colors shrink-0">Dismiss</button>
                     </div>
                   </div>
                 </div>
               </template>
-              <div x-show="webhooks.length === 0" class="text-gray-600 text-sm py-2 text-center">No webhooks configured</div>
+              <div x-show="apiEndpoints.length === 0" class="text-gray-600 text-sm py-2 text-center">No API endpoints configured</div>
             </div>
             <div class="border-t border-gray-800 pt-3">
-              <button x-show="!showWebhookForm" @click="showWebhookForm = true; cancelWebhookEdit()" class="text-xs px-3 py-1.5 rounded border border-gray-700 hover:border-gray-600 text-gray-400 hover:text-gray-300 transition-colors">+ Add Webhook</button>
-              <div x-show="showWebhookForm" x-transition>
-                <div class="text-xs text-gray-500 mb-2">New webhook</div>
+              <button x-show="!showEndpointForm" @click="showEndpointForm = true; cancelEndpointEdit()" class="text-xs px-3 py-1.5 rounded border border-gray-700 hover:border-gray-600 text-gray-400 hover:text-gray-300 transition-colors">+ Add Endpoint</button>
+              <div x-show="showEndpointForm" x-transition>
+                <div class="text-xs text-gray-500 mb-2">New endpoint</div>
                 <div class="flex gap-2 mb-2">
-                  <input type="text" x-model="webhookFormName" :disabled="webhookCreating" class="dash-input text-xs flex-1" placeholder="Webhook name">
-                  <select x-model="webhookFormAgent" :disabled="webhookCreating" class="dash-select text-xs w-40">
+                  <input type="text" x-model="endpointFormName" :disabled="endpointCreating" class="dash-input text-xs flex-1" placeholder="Endpoint name">
+                  <select x-model="endpointFormAgent" :disabled="endpointCreating" class="dash-select text-xs w-40">
                     <option value="">Agent...</option>
                     <template x-for="a in agents" :key="a.id">
                       <option :value="a.id" x-text="a.id"></option>
                     </template>
                   </select>
                 </div>
-                <textarea x-model="webhookFormInstructions" :disabled="webhookCreating" class="dash-input w-full text-xs mb-2" rows="2" placeholder="Instructions for the agent (optional) — e.g. 'Extract the event type and update the CRM'"></textarea>
+                <textarea x-model="endpointFormInstructions" :disabled="endpointCreating" class="dash-input w-full text-xs mb-2" rows="2" placeholder="Instructions for the agent (optional) — e.g. 'Extract the event type and update the CRM'"></textarea>
                 <label class="flex items-center gap-2 text-xs text-gray-400 mb-3 cursor-pointer select-none">
-                  <input type="checkbox" x-model="webhookFormRequireSig" :disabled="webhookCreating" class="rounded border-gray-700 bg-gray-800 text-indigo-500 focus:ring-indigo-500/30">
+                  <input type="checkbox" x-model="endpointFormRequireSig" :disabled="endpointCreating" class="rounded border-gray-700 bg-gray-800 text-indigo-500 focus:ring-indigo-500/30">
                   Require HMAC signature
                 </label>
                 <div class="flex justify-between">
-                  <button @click="showWebhookForm = false; webhookFormName = ''; webhookFormAgent = ''; webhookFormInstructions = ''; webhookFormRequireSig = false" :disabled="webhookCreating" class="text-xs px-3 py-1.5 rounded border border-gray-700 hover:border-gray-600 text-gray-400 hover:text-gray-300 transition-colors disabled:opacity-50">Cancel</button>
-                  <button @click="createWebhook()" :disabled="webhookCreating" class="text-xs px-3 py-1.5 rounded bg-indigo-600 hover:bg-indigo-500 text-white transition-colors inline-flex items-center gap-1.5 disabled:opacity-50">
-                    <svg x-show="webhookCreating" x-cloak class="animate-spin h-3 w-3" fill="none" viewBox="0 0 24 24"><circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"/><path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z"/></svg>
-                    <span x-text="webhookCreating ? 'Creating...' : 'Create Webhook'"></span>
+                  <button @click="showEndpointForm = false; endpointFormName = ''; endpointFormAgent = ''; endpointFormInstructions = ''; endpointFormRequireSig = false" :disabled="endpointCreating" class="text-xs px-3 py-1.5 rounded border border-gray-700 hover:border-gray-600 text-gray-400 hover:text-gray-300 transition-colors disabled:opacity-50">Cancel</button>
+                  <button @click="createEndpoint()" :disabled="endpointCreating" class="text-xs px-3 py-1.5 rounded bg-indigo-600 hover:bg-indigo-500 text-white transition-colors inline-flex items-center gap-1.5 disabled:opacity-50">
+                    <svg x-show="endpointCreating" x-cloak class="animate-spin h-3 w-3" fill="none" viewBox="0 0 24 24"><circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"/><path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z"/></svg>
+                    <span x-text="endpointCreating ? 'Creating...' : 'Create Endpoint'"></span>
                   </button>
                 </div>
               </div>

--- a/src/dashboard/templates/index.html
+++ b/src/dashboard/templates/index.html
@@ -2226,44 +2226,17 @@
         <!-- ─── Endpoints sub-tab ─── -->
         <div x-show="integrationsTab === 'endpoints'">
 
-        <!-- API Reference -->
-        <details open class="mb-6 bg-gray-900/50 border border-gray-800 rounded-lg group">
-          <summary class="px-4 py-3 cursor-pointer text-xs text-gray-500 uppercase tracking-wider flex items-center gap-1.5 select-none">
-            <svg class="w-3 h-3 transition-transform group-open:rotate-90" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7"/></svg>
-            API Reference
-          </summary>
-          <div class="px-4 pb-4 space-y-3">
-            <div class="text-[11px] text-gray-500 mb-2">All endpoints below require an <code class="bg-gray-800 px-1 rounded">X-API-Key</code> header. Inbound API endpoints use <code class="bg-gray-800 px-1 rounded">X-Signature</code> instead (HMAC-SHA256 of the raw body).</div>
-            <div class="space-y-2">
-              <div class="text-[10px] text-gray-600 uppercase tracking-wider font-medium">Credential Vault</div>
-              <div class="grid grid-cols-1 sm:grid-cols-[auto_1fr_2fr] gap-x-3 gap-y-1 text-[11px]">
-                <code class="text-green-400/70 font-mono">POST</code><code class="text-gray-400 font-mono">/mesh/credentials</code><span class="text-gray-500">Store a secret. Body: <code class="bg-gray-800 px-0.5 rounded">{"name":"...","value":"..."}</code> &rarr; returns <code class="bg-gray-800 px-0.5 rounded">$CRED{name}</code> handle</span>
-                <code class="text-red-400/70 font-mono">DELETE</code><code class="text-gray-400 font-mono">/mesh/credentials/{name}</code><span class="text-gray-500">Remove a secret by name</span>
-                <code class="text-blue-400/70 font-mono">GET</code><code class="text-gray-400 font-mono">/mesh/credentials</code><span class="text-gray-500">List credential names (never values)</span>
-                <code class="text-blue-400/70 font-mono">GET</code><code class="text-gray-400 font-mono">/mesh/credentials/{name}/exists</code><span class="text-gray-500">Check if a credential exists</span>
-              </div>
-            </div>
-            <div class="space-y-2">
-              <div class="text-[10px] text-gray-600 uppercase tracking-wider font-medium">Agent Status</div>
-              <div class="grid grid-cols-1 sm:grid-cols-[auto_1fr_2fr] gap-x-3 gap-y-1 text-[11px]">
-                <code class="text-blue-400/70 font-mono">GET</code><code class="text-gray-400 font-mono">/mesh/agents/{id}/ext-status</code><span class="text-gray-500">Health, queue depth, and budget for an agent</span>
-              </div>
-            </div>
-            <div class="space-y-2">
-              <div class="text-[10px] text-gray-600 uppercase tracking-wider font-medium">API Endpoints</div>
-              <div class="grid grid-cols-1 sm:grid-cols-[auto_1fr_2fr] gap-x-3 gap-y-1 text-[11px]">
-                <code class="text-green-400/70 font-mono">POST</code><code class="text-gray-400 font-mono">/api/inbound/{endpoint_id}</code><span class="text-gray-500">Trigger an agent workflow. Requires <code class="bg-gray-800 px-0.5 rounded">X-Signature</code> header (no API key needed)</span>
-              </div>
-            </div>
-            <div class="space-y-2">
-              <div class="text-[10px] text-gray-600 uppercase tracking-wider font-medium">Outbound Webhook Payload</div>
-              <div class="text-[11px] text-gray-500 leading-relaxed">
-                Events POST to your URL with <code class="bg-gray-800 px-0.5 rounded">X-OpenLegion-Signature: sha256=HMAC</code> and <code class="bg-gray-800 px-0.5 rounded">X-OpenLegion-Event</code> headers.
-                Body: <code class="bg-gray-800 px-1 rounded text-gray-400">{"event", "agent", "data", "timestamp", "delivery_id"}</code>
-              </div>
-            </div>
+        <!-- API Reference link -->
+        <div class="mb-6 bg-gray-900/50 border border-gray-800 rounded-lg px-4 py-3 flex items-center justify-between">
+          <div>
+            <div class="text-xs text-gray-300 font-medium mb-0.5">API Reference</div>
+            <div class="text-[11px] text-gray-500">Interactive documentation with authentication and request testing.</div>
           </div>
-        </details>
+          <a href="/docs" target="_blank" rel="noopener" class="text-xs px-3 py-1.5 rounded bg-indigo-600 hover:bg-indigo-500 text-white transition-colors inline-flex items-center gap-1.5 shrink-0">
+            Open API Docs
+            <svg class="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M18 13v6a2 2 0 01-2 2H5a2 2 0 01-2-2V8a2 2 0 012-2h6"/><polyline points="15 3 21 3 21 9"/><line x1="10" y1="14" x2="21" y2="3"/></svg>
+          </a>
+        </div>
 
         <!-- API Endpoints -->
         <div class="text-xs text-gray-500 uppercase tracking-wider mb-3 flex items-center gap-1.5">API Endpoints<span class="setting-hint" tabindex="0">?<span class="setting-hint-text">Named HTTP endpoints that accept POST requests and route them to agents. Enable "Require HMAC signature" to secure the endpoint — your app signs the raw request body with HMAC-SHA256(body, secret) and sends it as the X-Signature header. The secret is shown once at creation time; use Regenerate Secret if you missed it.</span></span></div>
@@ -2360,6 +2333,65 @@
                   <button @click="createEndpoint()" :disabled="endpointCreating" class="text-xs px-3 py-1.5 rounded bg-indigo-600 hover:bg-indigo-500 text-white transition-colors inline-flex items-center gap-1.5 disabled:opacity-50">
                     <svg x-show="endpointCreating" x-cloak class="animate-spin h-3 w-3" fill="none" viewBox="0 0 24 24"><circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"/><path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z"/></svg>
                     <span x-text="endpointCreating ? 'Creating...' : 'Create Endpoint'"></span>
+                  </button>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <!-- Access Keys (inside endpoints sub-tab) -->
+        <div class="text-xs text-gray-500 uppercase tracking-wider mb-3 flex items-center gap-1.5 mt-6">Access Keys
+          <span class="setting-hint" tabindex="0">?<span class="setting-hint-text">API keys for authenticating server-to-server calls to the OpenLegion mesh. Send as X-API-Key header. Each key is hashed — the raw value is shown only once at creation.</span></span>
+        </div>
+        <div class="mb-6">
+          <div class="bg-gray-900 border border-gray-800 rounded-lg p-4">
+            <div class="text-[12px] text-gray-500 leading-relaxed mb-3">
+              Authenticate your backend for server-to-server API calls. Send as <code class="bg-gray-800 px-1 rounded text-gray-400">X-API-Key</code> header.
+              Create separate keys per environment or integration &mdash; each key is hashed and the raw value is shown only once at creation.
+            </div>
+            <div class="border-t border-gray-800 pt-3 mb-3"></div>
+            <!-- One-time new key display -->
+            <div x-show="apiKeyNewValue" x-transition class="mb-3 p-3 bg-emerald-950/40 border border-emerald-700/40 rounded-lg">
+              <div class="text-[11px] text-emerald-400 font-medium mb-2">New API Key &mdash; copy this now, it won't be shown again</div>
+              <div class="flex items-center gap-2">
+                <code class="text-[12px] text-emerald-200 bg-gray-950/80 px-3 py-2 rounded font-mono flex-1 break-all select-all tracking-wide" x-text="apiKeyNewValue"></code>
+                <button @click="copyToClipboard(apiKeyNewValue)" class="text-[10px] px-3 py-1.5 rounded bg-emerald-800/40 hover:bg-emerald-700/40 text-emerald-300 hover:text-emerald-200 border border-emerald-700/30 transition-colors shrink-0">Copy</button>
+                <button @click="apiKeyNewValue = null" class="text-[10px] px-2.5 py-1.5 rounded bg-gray-800 hover:bg-gray-700 text-gray-400 hover:text-gray-200 transition-colors shrink-0">Dismiss</button>
+              </div>
+            </div>
+            <!-- Legacy env var notice -->
+            <div x-show="apiKeysLegacy" x-cloak class="mb-3 px-3 py-2 bg-amber-950/30 border border-amber-800/25 rounded text-[11px] text-amber-400/90">
+              Legacy key detected from <code class="bg-gray-800/80 text-amber-300 px-1 rounded">OPENLEGION_API_KEY</code> env var. Create named keys below to replace it.
+            </div>
+            <!-- Key list -->
+            <div class="space-y-0.5 mb-3">
+              <template x-for="ak in apiKeys" :key="ak.id">
+                <div class="flex items-center gap-3 text-xs group py-2 px-2 rounded hover:bg-gray-800/30 transition-colors">
+                  <span class="w-2 h-2 rounded-full bg-emerald-500/60 shrink-0"></span>
+                  <span class="text-white font-medium" x-text="ak.name"></span>
+                  <span class="text-gray-500 font-mono text-[10px]" x-text="ak.id"></span>
+                  <span class="text-gray-500 text-[10px] flex-1 text-right" x-text="ak.last_used_at ? 'Used ' + ak.last_used_at.split('T')[0] : 'Never used'"></span>
+                  <span class="text-gray-600 text-[10px]" x-text="'Created ' + ak.created_at.split('T')[0]"></span>
+                  <button @click="revokeApiKey(ak.id, ak.name)"
+                    class="opacity-0 group-hover:opacity-100 focus:opacity-100 text-[10px] px-1.5 py-0.5 rounded bg-gray-800 hover:bg-red-900/30 text-gray-400 hover:text-red-400 transition-all">Revoke</button>
+                </div>
+              </template>
+              <div x-show="apiKeys.length === 0 && !apiKeysLegacy" class="text-gray-500 text-sm py-3 text-center">No API keys configured</div>
+            </div>
+            <!-- Create key form -->
+            <div class="border-t border-gray-800 pt-3">
+              <div x-show="!showApiKeyForm">
+                <button @click="showApiKeyForm = true; apiKeyNewName = ''" class="text-xs px-3 py-1.5 rounded border border-gray-700 hover:border-gray-600 text-gray-400 hover:text-gray-300 transition-colors">+ Create API Key</button>
+              </div>
+              <div x-show="showApiKeyForm" x-transition>
+                <div class="text-xs text-gray-500 mb-2">New API key</div>
+                <div class="flex gap-2">
+                  <input type="text" x-model="apiKeyNewName" :disabled="apiKeyCreating" class="dash-input text-xs flex-1" placeholder="Key name (e.g. company-production)" @keydown.enter="createApiKey()">
+                  <button @click="showApiKeyForm = false" :disabled="apiKeyCreating" class="text-xs px-3 py-1.5 rounded border border-gray-700 hover:border-gray-600 text-gray-400 hover:text-gray-300 transition-colors disabled:opacity-50">Cancel</button>
+                  <button @click="createApiKey()" :disabled="apiKeyCreating || !apiKeyNewName.trim()" class="text-xs px-3 py-1.5 rounded bg-indigo-600 hover:bg-indigo-500 text-white transition-colors inline-flex items-center gap-1.5 disabled:opacity-50">
+                    <svg x-show="apiKeyCreating" x-cloak class="animate-spin h-3 w-3" fill="none" viewBox="0 0 24 24"><circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"/><path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z"/></svg>
+                    <span x-text="apiKeyCreating ? 'Creating...' : 'Create'"></span>
                   </button>
                 </div>
               </div>
@@ -2515,76 +2547,6 @@
 
         </div><!-- /webhooks sub-tab -->
 
-        <!-- ─── Access Keys sub-tab ─── -->
-        <div x-show="integrationsTab === 'accesskeys'">
-        <div class="text-xs text-gray-500 uppercase tracking-wider mb-3 flex items-center gap-1.5">Access Keys
-          <span class="setting-hint" tabindex="0">?<span class="setting-hint-text">API keys for authenticating server-to-server calls to the OpenLegion mesh. Send as X-API-Key header. Each key is hashed — the raw value is shown only once at creation.</span></span>
-        </div>
-        <div class="mb-6">
-          <div class="bg-gray-900 border border-gray-800 rounded-lg p-4">
-            <div class="text-[12px] text-gray-500 leading-relaxed mb-3">
-              Authenticate your backend for server-to-server API calls. Send as <code class="bg-gray-800 px-1 rounded text-gray-400">X-API-Key</code> header.
-              Create separate keys per environment or integration &mdash; each key is hashed and the raw value is shown only once at creation.
-            </div>
-            <div class="grid grid-cols-1 sm:grid-cols-2 gap-x-4 gap-y-1 text-[11px] mb-4 chat-grid">
-              <div class="text-gray-500"><code class="text-gray-400 font-mono">POST</code> <code class="text-gray-400 font-mono">/mesh/credentials</code></div>
-              <div class="text-gray-600">Store a secret &rarr; returns <code class="bg-gray-800/60 px-0.5 rounded">$CRED{name}</code> handle</div>
-              <div class="text-gray-500"><code class="text-gray-400 font-mono">DELETE</code> <code class="text-gray-400 font-mono">/mesh/credentials/{name}</code></div>
-              <div class="text-gray-600">Remove a secret</div>
-              <div class="text-gray-500"><code class="text-gray-400 font-mono">GET</code> <code class="text-gray-400 font-mono">/mesh/credentials</code></div>
-              <div class="text-gray-600">List credential names (never values)</div>
-              <div class="text-gray-500"><code class="text-gray-400 font-mono">GET</code> <code class="text-gray-400 font-mono">/mesh/agents/{id}/ext-status</code></div>
-              <div class="text-gray-600">Agent health, queue depth, budget</div>
-            </div>
-            <div class="border-t border-gray-800 pt-3 mb-3"></div>
-            <!-- One-time new key display -->
-            <div x-show="apiKeyNewValue" x-transition class="mb-3 p-3 bg-emerald-950/40 border border-emerald-700/40 rounded-lg">
-              <div class="text-[11px] text-emerald-400 font-medium mb-2">New API Key &mdash; copy this now, it won't be shown again</div>
-              <div class="flex items-center gap-2">
-                <code class="text-[12px] text-emerald-200 bg-gray-950/80 px-3 py-2 rounded font-mono flex-1 break-all select-all tracking-wide" x-text="apiKeyNewValue"></code>
-                <button @click="copyToClipboard(apiKeyNewValue)" class="text-[10px] px-3 py-1.5 rounded bg-emerald-800/40 hover:bg-emerald-700/40 text-emerald-300 hover:text-emerald-200 border border-emerald-700/30 transition-colors shrink-0">Copy</button>
-                <button @click="apiKeyNewValue = null" class="text-[10px] px-2.5 py-1.5 rounded bg-gray-800 hover:bg-gray-700 text-gray-400 hover:text-gray-200 transition-colors shrink-0">Dismiss</button>
-              </div>
-            </div>
-            <!-- Legacy env var notice -->
-            <div x-show="apiKeysLegacy" x-cloak class="mb-3 px-3 py-2 bg-amber-950/30 border border-amber-800/25 rounded text-[11px] text-amber-400/90">
-              Legacy key detected from <code class="bg-gray-800/80 text-amber-300 px-1 rounded">OPENLEGION_API_KEY</code> env var. Create named keys below to replace it.
-            </div>
-            <!-- Key list -->
-            <div class="space-y-0.5 mb-3">
-              <template x-for="ak in apiKeys" :key="ak.id">
-                <div class="flex items-center gap-3 text-xs group py-2 px-2 rounded hover:bg-gray-800/30 transition-colors">
-                  <span class="w-2 h-2 rounded-full bg-emerald-500/60 shrink-0"></span>
-                  <span class="text-white font-medium" x-text="ak.name"></span>
-                  <span class="text-gray-500 font-mono text-[10px]" x-text="ak.id"></span>
-                  <span class="text-gray-500 text-[10px] flex-1 text-right" x-text="ak.last_used_at ? 'Used ' + ak.last_used_at.split('T')[0] : 'Never used'"></span>
-                  <span class="text-gray-600 text-[10px]" x-text="'Created ' + ak.created_at.split('T')[0]"></span>
-                  <button @click="revokeApiKey(ak.id, ak.name)"
-                    class="opacity-0 group-hover:opacity-100 focus:opacity-100 text-[10px] px-1.5 py-0.5 rounded bg-gray-800 hover:bg-red-900/30 text-gray-400 hover:text-red-400 transition-all">Revoke</button>
-                </div>
-              </template>
-              <div x-show="apiKeys.length === 0 && !apiKeysLegacy" class="text-gray-500 text-sm py-3 text-center">No API keys configured</div>
-            </div>
-            <!-- Create key form -->
-            <div class="border-t border-gray-800 pt-3">
-              <div x-show="!showApiKeyForm">
-                <button @click="showApiKeyForm = true; apiKeyNewName = ''" class="text-xs px-3 py-1.5 rounded border border-gray-700 hover:border-gray-600 text-gray-400 hover:text-gray-300 transition-colors">+ Create API Key</button>
-              </div>
-              <div x-show="showApiKeyForm" x-transition>
-                <div class="text-xs text-gray-500 mb-2">New API key</div>
-                <div class="flex gap-2">
-                  <input type="text" x-model="apiKeyNewName" :disabled="apiKeyCreating" class="dash-input text-xs flex-1" placeholder="Key name (e.g. company-production)" @keydown.enter="createApiKey()">
-                  <button @click="showApiKeyForm = false" :disabled="apiKeyCreating" class="text-xs px-3 py-1.5 rounded border border-gray-700 hover:border-gray-600 text-gray-400 hover:text-gray-300 transition-colors disabled:opacity-50">Cancel</button>
-                  <button @click="createApiKey()" :disabled="apiKeyCreating || !apiKeyNewName.trim()" class="text-xs px-3 py-1.5 rounded bg-indigo-600 hover:bg-indigo-500 text-white transition-colors inline-flex items-center gap-1.5 disabled:opacity-50">
-                    <svg x-show="apiKeyCreating" x-cloak class="animate-spin h-3 w-3" fill="none" viewBox="0 0 24 24"><circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"/><path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z"/></svg>
-                    <span x-text="apiKeyCreating ? 'Creating...' : 'Create'"></span>
-                  </button>
-                </div>
-              </div>
-            </div>
-          </div>
-        </div>
-        </div><!-- /accesskeys sub-tab -->
 
         <!-- ─── Credentials sub-tab (LLM provider keys + agent credentials) ─── -->
         <div x-show="integrationsTab === 'apikeys'" x-effect="if (integrationsTab === 'apikeys') fetchSettings()">

--- a/src/dashboard/templates/index.html
+++ b/src/dashboard/templates/index.html
@@ -188,6 +188,9 @@
               <template x-if="tab.id === 'fleet'">
                 <svg fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="3" width="7" height="7" rx="1"/><rect x="14" y="3" width="7" height="7" rx="1"/><rect x="3" y="14" width="7" height="7" rx="1"/><rect x="14" y="14" width="7" height="7" rx="1"/></svg>
               </template>
+              <template x-if="tab.id === 'integrations'">
+                <svg fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"/><path d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"/></svg>
+              </template>
               <template x-if="tab.id === 'system'">
                 <svg fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="4" y1="21" x2="4" y2="14"/><line x1="4" y1="10" x2="4" y2="3"/><line x1="12" y1="21" x2="12" y2="12"/><line x1="12" y1="8" x2="12" y2="3"/><line x1="20" y1="21" x2="20" y2="16"/><line x1="20" y1="12" x2="20" y2="3"/><line x1="1" y1="14" x2="7" y2="14"/><line x1="9" y1="8" x2="15" y2="8"/><line x1="17" y1="16" x2="23" y2="16"/></svg>
               </template>
@@ -2205,7 +2208,566 @@
         </template>
       </div>
 
-      <!-- System (Activity + Costs + Automation + Integrations + API Keys + Wallet + Storage + Settings) -->
+      <!-- ═══════════════════════════════════════════════════════════ -->
+      <!-- INTEGRATIONS TAB (API Endpoints + Webhooks + API Keys)    -->
+      <!-- ═══════════════════════════════════════════════════════════ -->
+      <div x-show="activeTab === 'integrations'" x-cloak>
+        <!-- Integrations sub-tab bar -->
+        <div class="flex flex-wrap gap-0.5 bg-gray-800/50 rounded-lg p-0.5 mb-4">
+          <template x-for="st in integrationsTabs" :key="st.id">
+            <button @click="switchIntegrationsTab(st.id)"
+              class="px-3 py-1.5 rounded-md text-sm font-medium transition-all relative whitespace-nowrap"
+              :class="integrationsTab === st.id ? 'bg-gray-700 text-white shadow-sm' : 'text-gray-400 hover:text-gray-200 hover:bg-gray-800/70'">
+              <span x-text="st.label"></span>
+            </button>
+          </template>
+        </div>
+
+        <!-- ─── Endpoints sub-tab ─── -->
+        <div x-show="integrationsTab === 'endpoints'">
+
+        <!-- API Reference -->
+        <details open class="mb-6 bg-gray-900/50 border border-gray-800 rounded-lg group">
+          <summary class="px-4 py-3 cursor-pointer text-xs text-gray-500 uppercase tracking-wider flex items-center gap-1.5 select-none">
+            <svg class="w-3 h-3 transition-transform group-open:rotate-90" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7"/></svg>
+            API Reference
+          </summary>
+          <div class="px-4 pb-4 space-y-3">
+            <div class="text-[11px] text-gray-500 mb-2">All endpoints below require an <code class="bg-gray-800 px-1 rounded">X-API-Key</code> header. Inbound API endpoints use <code class="bg-gray-800 px-1 rounded">X-Signature</code> instead (HMAC-SHA256 of the raw body).</div>
+            <div class="space-y-2">
+              <div class="text-[10px] text-gray-600 uppercase tracking-wider font-medium">Credential Vault</div>
+              <div class="grid grid-cols-1 sm:grid-cols-[auto_1fr_2fr] gap-x-3 gap-y-1 text-[11px]">
+                <code class="text-green-400/70 font-mono">POST</code><code class="text-gray-400 font-mono">/mesh/credentials</code><span class="text-gray-500">Store a secret. Body: <code class="bg-gray-800 px-0.5 rounded">{"name":"...","value":"..."}</code> &rarr; returns <code class="bg-gray-800 px-0.5 rounded">$CRED{name}</code> handle</span>
+                <code class="text-red-400/70 font-mono">DELETE</code><code class="text-gray-400 font-mono">/mesh/credentials/{name}</code><span class="text-gray-500">Remove a secret by name</span>
+                <code class="text-blue-400/70 font-mono">GET</code><code class="text-gray-400 font-mono">/mesh/credentials</code><span class="text-gray-500">List credential names (never values)</span>
+                <code class="text-blue-400/70 font-mono">GET</code><code class="text-gray-400 font-mono">/mesh/credentials/{name}/exists</code><span class="text-gray-500">Check if a credential exists</span>
+              </div>
+            </div>
+            <div class="space-y-2">
+              <div class="text-[10px] text-gray-600 uppercase tracking-wider font-medium">Agent Status</div>
+              <div class="grid grid-cols-1 sm:grid-cols-[auto_1fr_2fr] gap-x-3 gap-y-1 text-[11px]">
+                <code class="text-blue-400/70 font-mono">GET</code><code class="text-gray-400 font-mono">/mesh/agents/{id}/ext-status</code><span class="text-gray-500">Health, queue depth, and budget for an agent</span>
+              </div>
+            </div>
+            <div class="space-y-2">
+              <div class="text-[10px] text-gray-600 uppercase tracking-wider font-medium">API Endpoints</div>
+              <div class="grid grid-cols-1 sm:grid-cols-[auto_1fr_2fr] gap-x-3 gap-y-1 text-[11px]">
+                <code class="text-green-400/70 font-mono">POST</code><code class="text-gray-400 font-mono">/api/inbound/{endpoint_id}</code><span class="text-gray-500">Trigger an agent workflow. Requires <code class="bg-gray-800 px-0.5 rounded">X-Signature</code> header (no API key needed)</span>
+              </div>
+            </div>
+            <div class="space-y-2">
+              <div class="text-[10px] text-gray-600 uppercase tracking-wider font-medium">Outbound Webhook Payload</div>
+              <div class="text-[11px] text-gray-500 leading-relaxed">
+                Events POST to your URL with <code class="bg-gray-800 px-0.5 rounded">X-OpenLegion-Signature: sha256=HMAC</code> and <code class="bg-gray-800 px-0.5 rounded">X-OpenLegion-Event</code> headers.
+                Body: <code class="bg-gray-800 px-1 rounded text-gray-400">{"event", "agent", "data", "timestamp", "delivery_id"}</code>
+              </div>
+            </div>
+          </div>
+        </details>
+
+        <!-- API Endpoints -->
+        <div class="text-xs text-gray-500 uppercase tracking-wider mb-3 flex items-center gap-1.5">API Endpoints<span class="setting-hint" tabindex="0">?<span class="setting-hint-text">Named HTTP endpoints that accept POST requests and route them to agents. Enable "Require HMAC signature" to secure the endpoint — your app signs the raw request body with HMAC-SHA256(body, secret) and sends it as the X-Signature header. The secret is shown once at creation time; use Regenerate Secret if you missed it.</span></span></div>
+        <div class="mb-6">
+          <div class="bg-gray-900 border border-gray-800 rounded-lg p-4">
+            <div class="mb-3 pb-3 border-b border-gray-800">
+              <div class="text-sm text-gray-200 font-medium mb-1">API Endpoints</div>
+              <div class="text-[12px] text-gray-500 leading-relaxed">Named HTTP endpoints that accept <code class="bg-gray-800 px-1 rounded text-gray-400">POST</code> requests and route payloads to agents. Optionally secure each endpoint with HMAC-SHA256 signature verification.</div>
+            </div>
+            <div class="space-y-2 mb-3">
+              <template x-for="wh in apiEndpoints" :key="wh.id">
+                <div>
+                  <div class="flex items-center gap-3 text-xs group py-2 px-2 -mx-2 rounded-md hover:bg-gray-800/40 transition-colors border-b border-gray-800/30 last:border-0">
+                    <span class="w-2 h-2 rounded-full bg-green-400/70 shrink-0"></span>
+                    <span class="text-gray-200 font-mono font-medium shrink-0" x-text="wh.name"></span>
+                    <span class="text-gray-600 shrink-0">&rarr;</span>
+                    <span class="text-gray-400 shrink-0" x-text="wh.agent"></span>
+                    <span class="text-indigo-300/80 text-[10px] font-mono flex-1 truncate bg-indigo-950/30 px-2 py-0.5 rounded border border-indigo-900/50" x-text="wh.url || ''" :title="wh.url || ''"></span>
+                    <button x-show="wh.url" @click.stop="copyToClipboard(wh.url)"
+                      class="opacity-0 group-hover:opacity-100 focus:opacity-100 text-[10px] px-1.5 py-0.5 rounded bg-gray-800 hover:bg-gray-700 text-gray-400 hover:text-gray-200 transition-all shrink-0" title="Copy URL" aria-label="Copy endpoint URL">
+                      <svg class="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="9" y="9" width="13" height="13" rx="2" ry="2"/><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/></svg>
+                    </button>
+                    <button @click="editEndpoint(wh)"
+                      class="opacity-0 group-hover:opacity-100 focus:opacity-100 text-[10px] px-1.5 py-0.5 rounded bg-gray-800 hover:bg-gray-700 text-gray-400 hover:text-gray-200 transition-all shrink-0">Edit</button>
+                    <button @click="testEndpoint(wh.id)" :disabled="endpointTesting[wh.id] === true"
+                      class="opacity-0 group-hover:opacity-100 focus:opacity-100 text-[10px] px-1.5 py-0.5 rounded bg-gray-800 hover:bg-indigo-900/40 text-gray-400 hover:text-indigo-300 transition-all disabled:opacity-50 shrink-0" x-text="endpointTesting[wh.id] === true ? '...' : 'Test'"></button>
+                    <button @click="deleteEndpoint(wh.id, wh.name)"
+                      class="opacity-0 group-hover:opacity-100 focus:opacity-100 text-[10px] px-1.5 py-0.5 rounded bg-gray-800 hover:bg-red-900/30 text-gray-400 hover:text-red-400 transition-all shrink-0">Delete</button>
+                  </div>
+                  <!-- Inline edit form -->
+                  <div x-show="editingEndpointId === wh.id" x-transition class="bg-gray-800/30 border border-gray-800 rounded-lg p-3 mt-1 mb-2">
+                    <div class="text-xs text-gray-500 mb-2">Edit endpoint</div>
+                    <div class="flex gap-2 mb-2">
+                      <input type="text" x-model="endpointEditName" :disabled="endpointSaving" class="dash-input text-xs flex-1" placeholder="Endpoint name">
+                      <select x-model="endpointEditAgent" :disabled="endpointSaving" class="dash-select text-xs w-40">
+                        <option value="">Agent...</option>
+                        <template x-for="a in agents" :key="a.id">
+                          <option :value="a.id" x-text="a.id"></option>
+                        </template>
+                      </select>
+                    </div>
+                    <textarea x-model="endpointEditInstructions" :disabled="endpointSaving" class="dash-input w-full text-xs mb-2" rows="2" placeholder="Instructions for the agent (optional)"></textarea>
+                    <label class="flex items-center gap-2 text-xs text-gray-400 mb-3 cursor-pointer select-none">
+                      <input type="checkbox" x-model="endpointEditRequireSig" :disabled="endpointSaving" class="rounded border-gray-700 bg-gray-800 text-indigo-500 focus:ring-indigo-500/30">
+                      Require HMAC signature
+                    </label>
+                    <div class="flex justify-between items-center">
+                      <div class="flex gap-2">
+                        <button @click="cancelEndpointEdit()" :disabled="endpointSaving" class="text-xs px-3 py-1.5 rounded border border-gray-700 hover:border-gray-600 text-gray-400 hover:text-gray-300 transition-colors disabled:opacity-50">Cancel</button>
+                        <button x-show="wh.has_secret" @click="regenerateEndpointSecret(wh.id, wh.name)" :disabled="endpointSaving" class="text-xs px-3 py-1.5 rounded border border-yellow-900/50 hover:border-yellow-700/50 text-yellow-600 hover:text-yellow-500 transition-colors disabled:opacity-50">Regenerate Secret</button>
+                      </div>
+                      <button @click="saveEndpointEdit()" :disabled="endpointSaving" class="text-xs px-3 py-1.5 rounded bg-indigo-600 hover:bg-indigo-500 text-white transition-colors inline-flex items-center gap-1.5 disabled:opacity-50">
+                        <svg x-show="endpointSaving" x-cloak class="animate-spin h-3 w-3" fill="none" viewBox="0 0 24 24"><circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"/><path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z"/></svg>
+                        <span x-text="endpointSaving ? 'Saving...' : 'Save'"></span>
+                      </button>
+                    </div>
+                  </div>
+                  <!-- One-time secret display -->
+                  <div x-show="endpointRevealedSecret && endpointRevealedSecretId === wh.id" x-transition class="mt-2 mb-2 p-3 bg-amber-950 border border-amber-700/60 rounded-lg">
+                    <div class="flex items-center gap-1.5 text-[11px] text-amber-300 font-semibold mb-2.5">
+                      <svg class="w-3.5 h-3.5 shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M12 9v3.75m-9.303 3.376c-.866 1.5.217 3.374 1.948 3.374h14.71c1.73 0 2.813-1.874 1.948-3.374L13.949 3.378c-.866-1.5-3.032-1.5-3.898 0L2.697 16.126zM12 15.75h.007v.008H12v-.008z"/></svg>
+                      HMAC Secret — copy this now, it won't be shown again
+                    </div>
+                    <div class="flex items-center gap-2">
+                      <code class="text-[12px] text-amber-100 bg-black/40 px-3 py-2 rounded font-mono flex-1 break-all select-all tracking-wide border border-amber-900/60" x-text="endpointRevealedSecret"></code>
+                      <button @click="copyToClipboard(endpointRevealedSecret)" class="text-[10px] px-3 py-1.5 rounded bg-amber-800/60 hover:bg-amber-700/60 text-amber-200 hover:text-white border border-amber-700/50 transition-colors shrink-0 font-medium">Copy</button>
+                      <button @click="endpointRevealedSecret = null; endpointRevealedSecretId = null" class="text-[10px] px-2.5 py-1.5 rounded bg-gray-800 hover:bg-gray-700 text-gray-400 hover:text-gray-200 transition-colors shrink-0">Dismiss</button>
+                    </div>
+                  </div>
+                </div>
+              </template>
+              <div x-show="apiEndpoints.length === 0" class="text-gray-600 text-sm py-2 text-center">No API endpoints configured</div>
+            </div>
+            <div class="border-t border-gray-800 pt-3">
+              <button x-show="!showEndpointForm" @click="showEndpointForm = true; cancelEndpointEdit()" class="text-xs px-3 py-1.5 rounded border border-gray-700 hover:border-gray-600 text-gray-400 hover:text-gray-300 transition-colors">+ Add Endpoint</button>
+              <div x-show="showEndpointForm" x-transition>
+                <div class="text-xs text-gray-500 mb-2">New endpoint</div>
+                <div class="flex gap-2 mb-2">
+                  <input type="text" x-model="endpointFormName" :disabled="endpointCreating" class="dash-input text-xs flex-1" placeholder="Endpoint name">
+                  <select x-model="endpointFormAgent" :disabled="endpointCreating" class="dash-select text-xs w-40">
+                    <option value="">Agent...</option>
+                    <template x-for="a in agents" :key="a.id">
+                      <option :value="a.id" x-text="a.id"></option>
+                    </template>
+                  </select>
+                </div>
+                <textarea x-model="endpointFormInstructions" :disabled="endpointCreating" class="dash-input w-full text-xs mb-2" rows="2" placeholder="Instructions for the agent (optional) — e.g. 'Extract the event type and update the CRM'"></textarea>
+                <label class="flex items-center gap-2 text-xs text-gray-400 mb-3 cursor-pointer select-none">
+                  <input type="checkbox" x-model="endpointFormRequireSig" :disabled="endpointCreating" class="rounded border-gray-700 bg-gray-800 text-indigo-500 focus:ring-indigo-500/30">
+                  Require HMAC signature
+                </label>
+                <div class="flex justify-between">
+                  <button @click="showEndpointForm = false; endpointFormName = ''; endpointFormAgent = ''; endpointFormInstructions = ''; endpointFormRequireSig = false" :disabled="endpointCreating" class="text-xs px-3 py-1.5 rounded border border-gray-700 hover:border-gray-600 text-gray-400 hover:text-gray-300 transition-colors disabled:opacity-50">Cancel</button>
+                  <button @click="createEndpoint()" :disabled="endpointCreating" class="text-xs px-3 py-1.5 rounded bg-indigo-600 hover:bg-indigo-500 text-white transition-colors inline-flex items-center gap-1.5 disabled:opacity-50">
+                    <svg x-show="endpointCreating" x-cloak class="animate-spin h-3 w-3" fill="none" viewBox="0 0 24 24"><circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"/><path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z"/></svg>
+                    <span x-text="endpointCreating ? 'Creating...' : 'Create Endpoint'"></span>
+                  </button>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        </div><!-- /endpoints sub-tab -->
+
+        <!-- ─── Webhooks sub-tab ─── -->
+        <div x-show="integrationsTab === 'webhooks'">
+
+        <!-- Outbound Webhooks -->
+        <div class="text-xs text-gray-500 uppercase tracking-wider mb-3 flex items-center gap-1.5">Webhooks<span class="setting-hint" tabindex="0">?<span class="setting-hint-text">Send events to external URLs when things happen. OpenLegion POSTs signed JSON payloads with HMAC-SHA256 verification. Events: notification, task_complete, task_failed, agent_state, cron_complete, custom.</span></span></div>
+        <div class="mb-6">
+          <div class="bg-gray-900 border border-gray-800 rounded-lg p-4">
+            <div class="mb-4 pb-3 border-b border-gray-800">
+              <div class="text-sm text-gray-200 font-medium mb-1">Webhooks</div>
+              <div class="text-[12px] text-gray-500 leading-relaxed">Send events to external URLs. Each delivery includes an <code class="bg-gray-800 px-1 rounded text-gray-400">X-OpenLegion-Signature</code> HMAC-SHA256 header for verification.</div>
+            </div>
+            <div class="space-y-2 mb-3">
+              <template x-for="wh in outboundWebhooks" :key="wh.id">
+                <div>
+                  <div x-show="editingOutboundId !== wh.id" class="flex items-center gap-3 text-xs group py-2 px-2 -mx-2 rounded-md hover:bg-gray-800/40 transition-colors border-b border-gray-800/30 last:border-0">
+                    <span class="w-2 h-2 rounded-full shrink-0" :class="wh.enabled !== false ? 'bg-green-400/70' : 'bg-gray-600'"></span>
+                    <span class="text-gray-200 font-medium shrink-0" x-text="wh.name"></span>
+                    <span class="text-indigo-300/80 text-[10px] font-mono flex-1 truncate bg-indigo-950/30 px-2 py-0.5 rounded border border-indigo-900/50" x-text="wh.url" :title="wh.url"></span>
+                    <template x-for="ev in (wh.events || [])" :key="ev">
+                      <span class="text-[9px] px-1.5 py-0.5 rounded-full bg-cyan-900/40 text-cyan-400 border border-cyan-800/30" x-text="ev"></span>
+                    </template>
+                    <span x-show="wh.enabled === false" class="text-[9px] px-1.5 py-0.5 rounded-full bg-gray-800 text-gray-500">disabled</span>
+                    <button @click="editOutboundWebhook(wh)" class="opacity-0 group-hover:opacity-100 focus:opacity-100 text-[10px] px-1.5 py-0.5 rounded bg-gray-800 hover:bg-gray-700 text-gray-400 hover:text-gray-200 transition-all shrink-0">Edit</button>
+                    <button @click="testOutboundWebhook(wh.id)" class="opacity-0 group-hover:opacity-100 focus:opacity-100 text-[10px] px-1.5 py-0.5 rounded bg-gray-800 hover:bg-indigo-900/40 text-gray-400 hover:text-indigo-300 transition-all shrink-0">Test</button>
+                    <button @click="deleteOutboundWebhook(wh.id, wh.name)" class="opacity-0 group-hover:opacity-100 focus:opacity-100 text-[10px] px-1.5 py-0.5 rounded bg-gray-800 hover:bg-red-900/30 text-gray-400 hover:text-red-400 transition-all shrink-0">Delete</button>
+                  </div>
+                  <!-- Inline edit form -->
+                  <div x-show="editingOutboundId === wh.id" x-transition class="bg-gray-800/30 border border-gray-800 rounded-lg p-4 mt-1 mb-2">
+                    <div class="text-xs text-gray-400 font-medium mb-3">Edit webhook</div>
+                    <div class="flex gap-2 mb-4">
+                      <input type="text" x-model="outboundEditName" :disabled="outboundSaving" class="dash-input text-xs flex-1" placeholder="Webhook name">
+                      <input type="url" x-model="outboundEditUrl" :disabled="outboundSaving" class="dash-input text-xs flex-1" placeholder="https://example.com/hook">
+                    </div>
+                    <div class="text-[11px] text-gray-400 font-medium mb-2">Event types</div>
+                    <div class="flex flex-wrap gap-1.5 mb-4">
+                      <template x-for="et in ['notification','task_complete','task_failed','agent_state','cron_complete','custom']" :key="et">
+                        <label class="cursor-pointer select-none">
+                          <input type="checkbox" :value="et" x-model="outboundEditEvents" :disabled="outboundSaving" class="hidden peer">
+                          <span class="peer-checked:bg-indigo-600 peer-checked:text-white peer-checked:border-indigo-500 px-2.5 py-1 rounded-full text-[11px] border border-gray-700 text-gray-400 hover:border-gray-500 transition-all inline-block" x-text="et"></span>
+                        </label>
+                      </template>
+                    </div>
+                    <div class="text-[11px] text-gray-400 font-medium mb-2">Agent filter <span class="text-gray-600 font-normal">(empty = all agents)</span></div>
+                    <div class="flex flex-wrap gap-1.5 mb-4">
+                      <template x-for="a in agents" :key="a.id">
+                        <label class="cursor-pointer select-none">
+                          <input type="checkbox" :value="a.id" x-model="outboundEditAgentFilter" :disabled="outboundSaving" class="hidden peer">
+                          <span class="peer-checked:bg-slate-600 peer-checked:text-white peer-checked:border-slate-500 px-2.5 py-1 rounded-full text-[11px] border border-gray-700 text-gray-400 hover:border-gray-500 transition-all inline-block" x-text="a.id"></span>
+                        </label>
+                      </template>
+                    </div>
+                    <label class="flex items-center gap-2 text-xs text-gray-400 mb-4 cursor-pointer select-none">
+                      <input type="checkbox" x-model="outboundEditEnabled" :disabled="outboundSaving" class="rounded border-gray-700 bg-gray-800 text-indigo-500 focus:ring-indigo-500/30">
+                      Enabled
+                    </label>
+                    <div class="flex justify-end gap-2">
+                      <button @click="cancelOutboundEdit()" :disabled="outboundSaving" class="text-xs px-3 py-1.5 rounded border border-gray-700 hover:border-gray-600 text-gray-400 hover:text-gray-300 transition-colors disabled:opacity-50">Cancel</button>
+                      <button @click="saveOutboundEdit()" :disabled="outboundSaving" class="text-xs px-3 py-1.5 rounded bg-indigo-600 hover:bg-indigo-500 text-white transition-colors inline-flex items-center gap-1.5 disabled:opacity-50">
+                        <svg x-show="outboundSaving" x-cloak class="animate-spin h-3 w-3" fill="none" viewBox="0 0 24 24"><circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"/><path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z"/></svg>
+                        <span x-text="outboundSaving ? 'Saving...' : 'Save'"></span>
+                      </button>
+                    </div>
+                  </div>
+                </div>
+              </template>
+              <!-- Empty state -->
+              <div x-show="outboundWebhooks.length === 0" class="flex flex-col items-center py-6 text-center">
+                <svg class="w-8 h-8 text-gray-700 mb-2" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+                  <path d="M13.828 10.172a4 4 0 00-5.656 0l-4 4a4 4 0 105.656 5.656l1.102-1.101"/>
+                  <path d="M10.172 13.828a4 4 0 005.656 0l4-4a4 4 0 00-5.656-5.656l-1.102 1.101"/>
+                </svg>
+                <div class="text-gray-500 text-sm">No outbound webhooks configured</div>
+                <div class="text-gray-600 text-[11px] mt-1">Add a webhook to push events to your external services</div>
+              </div>
+            </div>
+            <div class="border-t border-gray-800 pt-3">
+              <div class="flex gap-2">
+                <button x-show="!showOutboundForm" @click="showOutboundForm = true; cancelOutboundEdit()" class="text-xs px-3 py-1.5 rounded border border-gray-700 hover:border-gray-600 text-gray-400 hover:text-gray-300 transition-colors">+ Add Webhook</button>
+                <button @click="showDeliveries = !showDeliveries; if (showDeliveries) fetchDeliveries()" class="text-xs px-3 py-1.5 rounded border border-gray-700 hover:border-gray-600 text-gray-400 hover:text-gray-300 transition-colors" x-text="showDeliveries ? 'Hide Deliveries' : 'Recent Deliveries'"></button>
+              </div>
+              <div x-show="showOutboundForm" x-transition class="mt-3">
+                <div class="text-xs text-gray-400 font-medium mb-3">New webhook</div>
+                <div class="flex gap-2 mb-4">
+                  <input type="text" x-model="outboundFormName" :disabled="outboundCreating" class="dash-input text-xs flex-1" placeholder="Webhook name">
+                  <input type="url" x-model="outboundFormUrl" :disabled="outboundCreating" class="dash-input text-xs flex-1" placeholder="https://example.com/hook">
+                </div>
+                <div class="text-[11px] text-gray-400 font-medium mb-2">Event types</div>
+                <div class="flex flex-wrap gap-1.5 mb-4">
+                  <template x-for="et in ['notification','task_complete','task_failed','agent_state','cron_complete','custom']" :key="et">
+                    <label class="cursor-pointer select-none">
+                      <input type="checkbox" :value="et" x-model="outboundFormEvents" :disabled="outboundCreating" class="hidden peer">
+                      <span class="peer-checked:bg-indigo-600 peer-checked:text-white peer-checked:border-indigo-500 px-2.5 py-1 rounded-full text-[11px] border border-gray-700 text-gray-400 hover:border-gray-500 transition-all inline-block" x-text="et"></span>
+                    </label>
+                  </template>
+                </div>
+                <div class="text-[11px] text-gray-400 font-medium mb-2">Agent filter <span class="text-gray-600 font-normal">(empty = all agents)</span></div>
+                <div class="flex flex-wrap gap-1.5 mb-4">
+                  <template x-for="a in agents" :key="a.id">
+                    <label class="cursor-pointer select-none">
+                      <input type="checkbox" :value="a.id" x-model="outboundFormAgentFilter" :disabled="outboundCreating" class="hidden peer">
+                      <span class="peer-checked:bg-slate-600 peer-checked:text-white peer-checked:border-slate-500 px-2.5 py-1 rounded-full text-[11px] border border-gray-700 text-gray-400 hover:border-gray-500 transition-all inline-block" x-text="a.id"></span>
+                    </label>
+                  </template>
+                </div>
+                <div class="flex justify-between">
+                  <button @click="showOutboundForm = false; outboundFormName = ''; outboundFormUrl = ''; outboundFormEvents = []; outboundFormAgentFilter = []" :disabled="outboundCreating" class="text-xs px-3 py-1.5 rounded border border-gray-700 hover:border-gray-600 text-gray-400 hover:text-gray-300 transition-colors disabled:opacity-50">Cancel</button>
+                  <button @click="createOutboundWebhook()" :disabled="outboundCreating" class="text-xs px-3 py-1.5 rounded bg-indigo-600 hover:bg-indigo-500 text-white transition-colors inline-flex items-center gap-1.5 disabled:opacity-50">
+                    <svg x-show="outboundCreating" x-cloak class="animate-spin h-3 w-3" fill="none" viewBox="0 0 24 24"><circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"/><path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z"/></svg>
+                    <span x-text="outboundCreating ? 'Creating...' : 'Create Webhook'"></span>
+                  </button>
+                </div>
+              </div>
+              <!-- Recent Deliveries -->
+              <div x-show="showDeliveries" x-transition class="mt-3">
+                <div class="text-xs text-gray-400 font-medium mb-2">Recent Deliveries</div>
+                <div class="max-h-60 overflow-y-auto">
+                  <!-- Header row -->
+                  <div class="grid grid-cols-[1.2rem_4.5rem_6rem_5rem_1fr_2.5rem_8rem] gap-2 text-[10px] text-gray-600 uppercase tracking-wider font-medium px-2 py-1.5 border-b border-gray-800 sticky top-0 bg-gray-900">
+                    <span>St</span>
+                    <span>Time</span>
+                    <span>Event</span>
+                    <span>Agent</span>
+                    <span>Webhook</span>
+                    <span>Code</span>
+                    <span>Error</span>
+                  </div>
+                  <template x-for="d in outboundDeliveries.slice().reverse()" :key="d.delivery_id">
+                    <div class="grid grid-cols-[1.2rem_4.5rem_6rem_5rem_1fr_2.5rem_8rem] gap-2 items-center text-[11px] py-1.5 px-2 rounded hover:bg-gray-800/30 border-b border-gray-800/20 last:border-0">
+                      <span class="shrink-0" :class="d.status === 'delivered' ? 'text-green-400' : 'text-red-400'" x-text="d.status === 'delivered' ? '&#10003;' : '&#10007;'"></span>
+                      <span class="text-gray-500 truncate" x-text="d.timestamp ? d.timestamp.split('T')[1]?.slice(0,8) : ''"></span>
+                      <span class="text-cyan-400/80 truncate" x-text="d.event"></span>
+                      <span class="text-gray-400 truncate" x-text="d.agent"></span>
+                      <span class="text-gray-600 truncate" x-text="d.subscription_id"></span>
+                      <span x-show="d.response_code" class="text-gray-500 text-[10px]" x-text="d.response_code"></span>
+                      <span x-show="d.error" class="text-red-400/70 text-[10px] truncate" :title="d.error" x-text="d.error"></span>
+                    </div>
+                  </template>
+                  <div x-show="outboundDeliveries.length === 0" class="text-gray-600 text-sm py-4 text-center">No recent deliveries</div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        </div><!-- /webhooks sub-tab -->
+
+        <!-- ─── Access Keys sub-tab ─── -->
+        <div x-show="integrationsTab === 'accesskeys'">
+        <div class="text-xs text-gray-500 uppercase tracking-wider mb-3 flex items-center gap-1.5">Access Keys
+          <span class="setting-hint" tabindex="0">?<span class="setting-hint-text">API keys for authenticating server-to-server calls to the OpenLegion mesh. Send as X-API-Key header. Each key is hashed — the raw value is shown only once at creation.</span></span>
+        </div>
+        <div class="mb-6">
+          <div class="bg-gray-900 border border-gray-800 rounded-lg p-4">
+            <div class="text-[12px] text-gray-500 leading-relaxed mb-3">
+              Authenticate your backend for server-to-server API calls. Send as <code class="bg-gray-800 px-1 rounded text-gray-400">X-API-Key</code> header.
+              Create separate keys per environment or integration &mdash; each key is hashed and the raw value is shown only once at creation.
+            </div>
+            <div class="grid grid-cols-1 sm:grid-cols-2 gap-x-4 gap-y-1 text-[11px] mb-4 chat-grid">
+              <div class="text-gray-500"><code class="text-gray-400 font-mono">POST</code> <code class="text-gray-400 font-mono">/mesh/credentials</code></div>
+              <div class="text-gray-600">Store a secret &rarr; returns <code class="bg-gray-800/60 px-0.5 rounded">$CRED{name}</code> handle</div>
+              <div class="text-gray-500"><code class="text-gray-400 font-mono">DELETE</code> <code class="text-gray-400 font-mono">/mesh/credentials/{name}</code></div>
+              <div class="text-gray-600">Remove a secret</div>
+              <div class="text-gray-500"><code class="text-gray-400 font-mono">GET</code> <code class="text-gray-400 font-mono">/mesh/credentials</code></div>
+              <div class="text-gray-600">List credential names (never values)</div>
+              <div class="text-gray-500"><code class="text-gray-400 font-mono">GET</code> <code class="text-gray-400 font-mono">/mesh/agents/{id}/ext-status</code></div>
+              <div class="text-gray-600">Agent health, queue depth, budget</div>
+            </div>
+            <div class="border-t border-gray-800 pt-3 mb-3"></div>
+            <!-- One-time new key display -->
+            <div x-show="apiKeyNewValue" x-transition class="mb-3 p-3 bg-emerald-950/40 border border-emerald-700/40 rounded-lg">
+              <div class="text-[11px] text-emerald-400 font-medium mb-2">New API Key &mdash; copy this now, it won't be shown again</div>
+              <div class="flex items-center gap-2">
+                <code class="text-[12px] text-emerald-200 bg-gray-950/80 px-3 py-2 rounded font-mono flex-1 break-all select-all tracking-wide" x-text="apiKeyNewValue"></code>
+                <button @click="copyToClipboard(apiKeyNewValue)" class="text-[10px] px-3 py-1.5 rounded bg-emerald-800/40 hover:bg-emerald-700/40 text-emerald-300 hover:text-emerald-200 border border-emerald-700/30 transition-colors shrink-0">Copy</button>
+                <button @click="apiKeyNewValue = null" class="text-[10px] px-2.5 py-1.5 rounded bg-gray-800 hover:bg-gray-700 text-gray-400 hover:text-gray-200 transition-colors shrink-0">Dismiss</button>
+              </div>
+            </div>
+            <!-- Legacy env var notice -->
+            <div x-show="apiKeysLegacy" x-cloak class="mb-3 px-3 py-2 bg-amber-950/30 border border-amber-800/25 rounded text-[11px] text-amber-400/90">
+              Legacy key detected from <code class="bg-gray-800/80 text-amber-300 px-1 rounded">OPENLEGION_API_KEY</code> env var. Create named keys below to replace it.
+            </div>
+            <!-- Key list -->
+            <div class="space-y-0.5 mb-3">
+              <template x-for="ak in apiKeys" :key="ak.id">
+                <div class="flex items-center gap-3 text-xs group py-2 px-2 rounded hover:bg-gray-800/30 transition-colors">
+                  <span class="w-2 h-2 rounded-full bg-emerald-500/60 shrink-0"></span>
+                  <span class="text-white font-medium" x-text="ak.name"></span>
+                  <span class="text-gray-500 font-mono text-[10px]" x-text="ak.id"></span>
+                  <span class="text-gray-500 text-[10px] flex-1 text-right" x-text="ak.last_used_at ? 'Used ' + ak.last_used_at.split('T')[0] : 'Never used'"></span>
+                  <span class="text-gray-600 text-[10px]" x-text="'Created ' + ak.created_at.split('T')[0]"></span>
+                  <button @click="revokeApiKey(ak.id, ak.name)"
+                    class="opacity-0 group-hover:opacity-100 focus:opacity-100 text-[10px] px-1.5 py-0.5 rounded bg-gray-800 hover:bg-red-900/30 text-gray-400 hover:text-red-400 transition-all">Revoke</button>
+                </div>
+              </template>
+              <div x-show="apiKeys.length === 0 && !apiKeysLegacy" class="text-gray-500 text-sm py-3 text-center">No API keys configured</div>
+            </div>
+            <!-- Create key form -->
+            <div class="border-t border-gray-800 pt-3">
+              <div x-show="!showApiKeyForm">
+                <button @click="showApiKeyForm = true; apiKeyNewName = ''" class="text-xs px-3 py-1.5 rounded border border-gray-700 hover:border-gray-600 text-gray-400 hover:text-gray-300 transition-colors">+ Create API Key</button>
+              </div>
+              <div x-show="showApiKeyForm" x-transition>
+                <div class="text-xs text-gray-500 mb-2">New API key</div>
+                <div class="flex gap-2">
+                  <input type="text" x-model="apiKeyNewName" :disabled="apiKeyCreating" class="dash-input text-xs flex-1" placeholder="Key name (e.g. company-production)" @keydown.enter="createApiKey()">
+                  <button @click="showApiKeyForm = false" :disabled="apiKeyCreating" class="text-xs px-3 py-1.5 rounded border border-gray-700 hover:border-gray-600 text-gray-400 hover:text-gray-300 transition-colors disabled:opacity-50">Cancel</button>
+                  <button @click="createApiKey()" :disabled="apiKeyCreating || !apiKeyNewName.trim()" class="text-xs px-3 py-1.5 rounded bg-indigo-600 hover:bg-indigo-500 text-white transition-colors inline-flex items-center gap-1.5 disabled:opacity-50">
+                    <svg x-show="apiKeyCreating" x-cloak class="animate-spin h-3 w-3" fill="none" viewBox="0 0 24 24"><circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"/><path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z"/></svg>
+                    <span x-text="apiKeyCreating ? 'Creating...' : 'Create'"></span>
+                  </button>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+        </div><!-- /accesskeys sub-tab -->
+
+        <!-- ─── Credentials sub-tab (LLM provider keys + agent credentials) ─── -->
+        <div x-show="integrationsTab === 'apikeys'" x-effect="if (integrationsTab === 'apikeys') fetchSettings()">
+        <div class="text-xs text-gray-500 uppercase tracking-wider mb-3 flex items-center gap-1.5">Credentials
+          <span class="setting-hint" tabindex="0">?<span class="setting-hint-text">LLM provider keys and agent credentials stored in the mesh vault. "System" keys (LLM providers like Anthropic, OpenAI) are used by the mesh for model routing and never exposed to agents. "Agent" keys are available to agents as opaque handles for HTTP requests.</span></span>
+        </div>
+        <div class="mb-6" x-show="settingsData">
+          <div class="bg-gray-900 border border-gray-800 rounded-lg p-4">
+            <div class="text-sm text-gray-400 mb-2">
+              <span x-text="settingsData?.credentials?.count || 0"></span> key(s) configured
+            </div>
+            <div class="space-y-1 mb-3">
+              <template x-for="name in settingsData?.credentials?.names || []" :key="name">
+                <div>
+                  <div class="flex items-center gap-2 text-xs group">
+                    <span class="w-2 h-2 rounded-full" :class="(settingsData.agent_credentials || []).includes(name) ? 'bg-green-500/50' : 'bg-amber-500/50'"></span>
+                    <span class="text-gray-300 font-mono flex-1 truncate" x-text="name"></span>
+                    <span class="text-[10px] px-1.5 py-0.5 rounded-full shrink-0" :class="(settingsData.agent_credentials || []).includes(name) ? 'bg-green-900/40 text-green-400' : 'bg-amber-900/40 text-amber-400'" x-text="(settingsData.agent_credentials || []).includes(name) ? 'agent' : 'system'"></span>
+                    <div class="flex items-center gap-0 shrink-0 w-[4.5rem] justify-end">
+                      <button x-show="!name.endsWith('_oauth')" @click="revealCredential(name)" class="opacity-0 group-hover:opacity-100 focus:opacity-100 text-gray-400 hover:text-gray-300 transition-opacity px-1" :title="revealedCredentials[name] ? 'Hide value' : 'Reveal value'">
+                        <svg x-show="!revealedCredentials[name]" class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z"/><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z"/></svg>
+                        <svg x-show="revealedCredentials[name]" x-cloak class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13.875 18.825A10.05 10.05 0 0112 19c-4.478 0-8.268-2.943-9.543-7a9.97 9.97 0 011.563-3.029m5.858.908a3 3 0 114.243 4.243M9.878 9.878l4.242 4.242M9.88 9.88l-3.29-3.29m7.532 7.532l3.29 3.29M3 3l3.59 3.59m0 0A9.953 9.953 0 0112 5c4.478 0 8.268 2.943 9.543 7a10.025 10.025 0 01-4.132 5.411m0 0L21 21"/></svg>
+                      </button>
+                      <button x-show="!name.endsWith('_oauth')" @click="editingCredential = editingCredential === name ? null : name; editCredKey = ''" :aria-expanded="editingCredential === name" class="opacity-0 group-hover:opacity-100 focus:opacity-100 text-gray-400 hover:text-indigo-300 transition-opacity text-[10px] px-1" title="Update key">Update</button>
+                      <button @click="deleteCredential(name)" class="opacity-0 group-hover:opacity-100 focus:opacity-100 text-red-400 hover:text-red-300 transition-opacity text-base leading-none px-1" title="Remove key" aria-label="Remove key">&times;</button>
+                    </div>
+                  </div>
+                  <!-- Revealed key value -->
+                  <div x-show="revealedCredentials[name]" x-cloak x-transition class="ml-4 mt-1 mb-1 flex items-center gap-2">
+                    <code class="text-[11px] text-green-400/80 bg-gray-800 px-2 py-1 rounded font-mono flex-1 break-all select-all" x-text="revealedCredentials[name]"></code>
+                    <button @click="copyToClipboard(revealedCredentials[name])" class="text-[10px] px-2 py-0.5 rounded bg-gray-800 hover:bg-gray-700 text-gray-400 shrink-0" title="Copy value">Copy</button>
+                  </div>
+                  <!-- Inline key update form -->
+                  <div x-show="editingCredential === name" x-cloak x-transition class="ml-4 mt-1 mb-1 flex items-center gap-2">
+                    <input type="password" x-model="editCredKey" class="dash-input text-xs flex-1" placeholder="New key value">
+                    <button @click="updateCredential(name)" :disabled="credentialSaving" class="text-[10px] px-2 py-1 rounded bg-indigo-600 hover:bg-indigo-500 text-white disabled:opacity-50 disabled:cursor-not-allowed" x-text="credentialSaving ? 'Saving...' : 'Save'"></button>
+                    <button @click="editingCredential = null; editCredKey = ''" class="text-[10px] px-2 py-1 rounded bg-gray-800 hover:bg-gray-700 text-gray-400">Cancel</button>
+                  </div>
+                </div>
+              </template>
+            </div>
+            <!-- Credential tier legend -->
+            <div class="flex flex-wrap gap-x-5 gap-y-1 mb-3 text-[10px] text-gray-500 leading-relaxed">
+              <span class="flex items-center gap-1.5"><span class="w-2 h-2 rounded-full bg-green-500/50 shrink-0"></span><strong class="text-gray-400">Agent key</strong> &mdash; agents can request by name, granted per-agent via Credential Access permissions. The vault returns an opaque handle; the raw value is never exposed.</span>
+              <span class="flex items-center gap-1.5"><span class="w-2 h-2 rounded-full bg-amber-500/50 shrink-0"></span><strong class="text-gray-400">System key</strong> &mdash; held exclusively by the mesh host. Agents cannot access it at all. LLM provider API keys (Anthropic, OpenAI, etc.) are always stored here.</span>
+            </div>
+            <div class="border-t border-gray-800 pt-3">
+              <button x-show="!showCredForm" @click="showCredForm = true" class="text-xs px-3 py-1.5 rounded border border-gray-700 hover:border-gray-600 text-gray-400 hover:text-gray-300 transition-colors">+ Add Key</button>
+              <div x-show="showCredForm" x-transition>
+                <div class="text-xs text-gray-500 mb-2">New API key</div>
+                <div class="flex gap-2 mb-2">
+                  <div class="relative" @click.outside="_credServiceDropdownOpen = false" @keydown.escape.stop="_credServiceDropdownOpen = false">
+                    <button type="button" :disabled="credSaving"
+                      @click="_credServiceDropdownOpen = !_credServiceDropdownOpen; if (_credServiceDropdownOpen) { _credServiceSearch = ''; $nextTick(() => $refs.credServiceSearchInput?.focus()); }"
+                      class="dash-input flex items-center justify-between gap-2 cursor-pointer text-left" style="min-width:10rem">
+                      <span class="truncate" :class="credService ? 'text-gray-200' : 'text-gray-400'"
+                        x-text="credService === '__custom__' ? 'Custom\u2026' : (credService ? (credServiceOptions.find(o => o.value === credService)?.label || credService) : 'Service\u2026')"></span>
+                      <svg class="w-3.5 h-3.5 text-gray-500 flex-shrink-0 transition-transform" :class="_credServiceDropdownOpen && 'rotate-180'" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M19 9l-7 7-7-7"/></svg>
+                    </button>
+                    <div x-show="_credServiceDropdownOpen" x-cloak x-transition:enter="transition ease-out duration-100" x-transition:enter-start="opacity-0 -translate-y-1" x-transition:enter-end="opacity-100 translate-y-0"
+                      class="absolute z-50 mt-1 min-w-full w-max bg-gray-800 border border-gray-700 rounded-lg shadow-xl" style="max-width:min(28rem, calc(100vw - 2rem))">
+                      <div class="p-2">
+                        <div class="flex items-center gap-2 bg-gray-900 border border-gray-600 rounded-md px-2.5 py-1.5 focus-within:border-indigo-500/60">
+                          <svg class="w-3.5 h-3.5 text-gray-500 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="2"><circle cx="11" cy="11" r="8"/><path stroke-linecap="round" d="m21 21-4.35-4.35"/></svg>
+                          <input x-ref="credServiceSearchInput" type="text" x-model="_credServiceSearch" placeholder="Search services…"
+                            @keydown.enter.prevent="(() => {
+                              const q = _credServiceSearch.toLowerCase().trim();
+                              const match = q ? credServiceOptions.find(o => o.label.toLowerCase().includes(q) || o.value.toLowerCase().includes(q)) : null;
+                              if (match) { credService = match.value; _credServiceDropdownOpen = false; credAuthType = 'api_key'; if (match.value === 'ollama') credBaseUrl = credBaseUrl || 'http://localhost:11434'; if (match.value !== '__custom__') { credCustomService = ''; credIsLlmProvider = false; credCustomModels = ''; credCustomLabel = ''; } }
+                            })()"
+                            class="w-full bg-transparent text-xs text-gray-200 placeholder-gray-500 outline-none focus:outline-none focus:ring-0" style="outline:none!important;box-shadow:none!important">
+                        </div>
+                      </div>
+                      <div class="border-t border-gray-700/60 overflow-y-auto custom-scrollbar" style="max-height:280px">
+                        <!-- Grouped options -->
+                        <template x-for="group in [...new Set(credServiceOptions.map(o => o.group))].filter(g => {
+                          const q = _credServiceSearch.toLowerCase().trim();
+                          if (!q) return true;
+                          return credServiceOptions.some(o => o.group === g && (o.label.toLowerCase().includes(q) || o.value.toLowerCase().includes(q)));
+                        })" :key="group">
+                          <div>
+                            <div class="px-3 pt-3 pb-1.5 mt-1 first:mt-0 border-t border-gray-700/50 first:border-t-0 text-[11px] font-medium text-gray-500 uppercase tracking-wider" x-text="group"></div>
+                            <template x-for="o in credServiceOptions.filter(o => {
+                              if (o.group !== group) return false;
+                              const q = _credServiceSearch.toLowerCase().trim();
+                              return !q || o.label.toLowerCase().includes(q) || o.value.toLowerCase().includes(q);
+                            })" :key="o.value">
+                              <button type="button"
+                                @click="credService = o.value; _credServiceDropdownOpen = false; credAuthType = 'api_key'; if (o.value === 'ollama') credBaseUrl = credBaseUrl || 'http://localhost:11434'; if (o.value !== '__custom__') { credCustomService = ''; credIsLlmProvider = false; credCustomModels = ''; credCustomLabel = ''; }"
+                                class="w-full text-left px-3 py-1.5 text-xs transition-colors flex items-center gap-2"
+                                :class="credService === o.value ? 'bg-indigo-600/20 text-indigo-300' : 'text-gray-300 hover:bg-gray-700/60'">
+                                <svg class="w-3 h-3 flex-shrink-0" :class="credService === o.value ? 'text-indigo-400' : 'text-transparent'" fill="currentColor" viewBox="0 0 20 20"><path fill-rule="evenodd" d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z" clip-rule="evenodd"/></svg>
+                                <span x-text="o.label" class="truncate"></span>
+                              </button>
+                            </template>
+                          </div>
+                        </template>
+                        <!-- Custom option (always visible at bottom) -->
+                        <div class="border-t border-gray-700/50">
+                          <button type="button"
+                            @click="credService = '__custom__'; _credServiceDropdownOpen = false; credAuthType = 'api_key';"
+                            class="w-full text-left px-3 py-1.5 text-xs transition-colors flex items-center gap-2"
+                            :class="credService === '__custom__' ? 'bg-indigo-600/20 text-indigo-300' : 'text-gray-300 hover:bg-gray-700/60'"
+                            x-show="!_credServiceSearch || 'custom'.includes(_credServiceSearch.toLowerCase().trim())">
+                            <svg class="w-3 h-3 flex-shrink-0" :class="credService === '__custom__' ? 'text-indigo-400' : 'text-transparent'" fill="currentColor" viewBox="0 0 20 20"><path fill-rule="evenodd" d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z" clip-rule="evenodd"/></svg>
+                            Custom&hellip;
+                          </button>
+                        </div>
+                        <!-- No results -->
+                        <div x-show="_credServiceSearch && !credServiceOptions.some(o => o.label.toLowerCase().includes(_credServiceSearch.toLowerCase().trim()) || o.value.toLowerCase().includes(_credServiceSearch.toLowerCase().trim())) && !'custom'.includes(_credServiceSearch.toLowerCase().trim())"
+                          class="px-3 py-3 text-xs text-gray-500 text-center">No services match your search.</div>
+                      </div>
+                    </div>
+                  </div>
+                  <template x-if="credService === 'anthropic' || credService === 'openai'">
+                    <select x-model="credAuthType" :disabled="credSaving" class="dash-select text-xs w-48">
+                      <option value="api_key">API Key (recommended)</option>
+                      <option value="oauth" x-text="credService === 'openai' ? 'ChatGPT OAuth (JSON)' : 'Subscription Token'"></option>
+                    </select>
+                  </template>
+                  <input x-show="credService === '__custom__'" type="text" x-model="credCustomService" :disabled="credSaving" class="dash-input text-xs w-40" placeholder="credential_name">
+                  <select x-show="credService === '__custom__'" x-model="credTier" :disabled="credSaving" class="dash-select text-xs w-28">
+                    <option value="agent">Agent tier</option>
+                    <option value="system">System tier</option>
+                  </select>
+                  <input x-show="credService !== 'ollama'" type="password" x-model="credKey" :disabled="credSaving" class="dash-input flex-1"
+                    :placeholder="credAuthType === 'oauth' ? (credService === 'openai' ? '{&quot;access_token&quot;:...,&quot;refresh_token&quot;:...}' : 'sk-ant-oat01-...') : 'API key or value'">
+                </div>
+                <template x-if="credService === '__custom__'">
+                  <div class="text-[10px] text-gray-500 leading-snug mb-2 p-2 rounded bg-gray-800/60 border border-gray-700/40">
+                    <strong class="text-gray-400">Agent tier</strong>: agents can request this credential by name. Access is controlled per-agent via the Credential Access permission pattern. The agent receives an opaque handle &mdash; the raw value is never returned.
+                    <span class="mx-1">&middot;</span>
+                    <strong class="text-gray-400">System tier</strong>: held only by the mesh host. No agent can read or reference it. Use this for infrastructure tokens or secrets that agents should never touch.
+                  </div>
+                </template>
+                <template x-if="credService === '__custom__' && credTier === 'system'">
+                  <div class="space-y-2 mb-2">
+                    <label class="inline-flex items-center gap-1.5 text-xs text-gray-400 cursor-pointer select-none">
+                      <input type="checkbox" x-model="credIsLlmProvider" class="rounded border-gray-700 bg-gray-800 text-indigo-500 focus:ring-indigo-500/30">
+                      This is an LLM provider
+                    </label>
+                    <template x-if="credIsLlmProvider">
+                      <div class="space-y-1.5">
+                        <input type="text" x-model="credCustomLabel" :disabled="credSaving" class="dash-input w-full text-xs" placeholder="Display name (e.g. My Provider)">
+                        <textarea x-model="credCustomModels" :disabled="credSaving" class="dash-input w-full text-xs" rows="2" placeholder="Model names, comma-separated (e.g. model-7b, model-70b)"></textarea>
+                        <div class="text-[10px] text-gray-500">Models will be available as <code class="bg-gray-800 px-0.5 rounded" x-text="(credCustomService || 'provider') + '/model-name'"></code> in the agent model selector. Must be OpenAI-compatible.</div>
+                      </div>
+                    </template>
+                  </div>
+                </template>
+                <template x-if="credAuthType === 'oauth' && credService === 'anthropic'">
+                  <div class="text-[10px] text-amber-400/80 leading-snug mb-2">
+                    Experimental — uses unofficial OAuth that may break without notice. Generate with: <code class="font-mono bg-gray-800 px-1 rounded">claude setup-token</code>
+                  </div>
+                </template>
+                <template x-if="credAuthType === 'oauth' && credService === 'openai'">
+                  <div class="text-[10px] text-amber-400/80 leading-snug mb-2">
+                    Paste the JSON blob from <code class="font-mono bg-gray-800 px-1 rounded">~/.codex/auth.json</code> containing <code class="font-mono bg-gray-800 px-1 rounded">access_token</code> and <code class="font-mono bg-gray-800 px-1 rounded">refresh_token</code>.
+                  </div>
+                </template>
+                <template x-if="credService === 'ollama'">
+                  <div>
+                    <input type="text" x-model="credBaseUrl" :disabled="credSaving" class="dash-input w-full mb-1" placeholder="http://localhost:11434">
+                    <div class="text-[10px] text-gray-500 mb-3">Ollama URL — no API key needed. Make sure Ollama is running.</div>
+                  </div>
+                </template>
+                <input x-show="credService !== 'ollama' && credAuthType !== 'oauth'" type="text" x-model="credBaseUrl" :disabled="credSaving" class="dash-input w-full mb-3" placeholder="Custom API base URL (optional)">
+                <div class="flex justify-between">
+                  <button @click="showCredForm = false; credService = ''; credKey = ''; credBaseUrl = ''; credCustomService = ''; credTier = 'agent'; credAuthType = 'api_key'; credIsLlmProvider = false; credCustomModels = ''; credCustomLabel = ''; _credServiceDropdownOpen = false; _credServiceSearch = ''" :disabled="credSaving" class="text-xs px-3 py-1.5 rounded border border-gray-700 hover:border-gray-600 text-gray-400 hover:text-gray-300 transition-colors disabled:opacity-50">Cancel</button>
+                  <button @click="addCredential()" :disabled="credSaving" class="text-xs px-3 py-1.5 rounded bg-indigo-600 hover:bg-indigo-500 text-white transition-colors inline-flex items-center gap-1.5 disabled:opacity-50">
+                    <svg x-show="credSaving" x-cloak class="animate-spin h-3 w-3" fill="none" viewBox="0 0 24 24"><circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"/><path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z"/></svg>
+                    <span x-text="credSaving ? 'Saving...' : 'Save'"></span>
+                  </button>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+        </div><!-- /apikeys sub-tab (integrations) -->
+
+      </div><!-- /integrations tab -->
+
+      <!-- System (Activity + Costs + Automation + Channels + Wallet + Storage + Settings) -->
       <div x-show="activeTab === 'system'" x-cloak>
         <!-- System sub-tab bar -->
         <div class="flex flex-wrap gap-0.5 bg-gray-800/50 rounded-lg p-0.5 mb-4">
@@ -2560,47 +3122,8 @@
         </div>
         </div><!-- /automation sub-tab -->
 
-        <!-- Integrations sub-tab (Channels + API Endpoints) -->
-        <div x-show="systemTab === 'integrations'">
-
-        <!-- API Reference -->
-        <details class="mb-6 bg-gray-900/50 border border-gray-800 rounded-lg group">
-          <summary class="px-4 py-3 cursor-pointer text-xs text-gray-500 uppercase tracking-wider flex items-center gap-1.5 select-none">
-            <svg class="w-3 h-3 transition-transform group-open:rotate-90" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7"/></svg>
-            API Reference
-          </summary>
-          <div class="px-4 pb-4 space-y-3">
-            <div class="text-[11px] text-gray-500 mb-2">All endpoints below require an <code class="bg-gray-800 px-1 rounded">X-API-Key</code> header. Inbound API endpoints use <code class="bg-gray-800 px-1 rounded">X-Signature</code> instead (HMAC-SHA256 of the raw body).</div>
-            <div class="space-y-2">
-              <div class="text-[10px] text-gray-600 uppercase tracking-wider font-medium">Credential Vault</div>
-              <div class="grid grid-cols-1 sm:grid-cols-[auto_1fr_2fr] gap-x-3 gap-y-1 text-[11px]">
-                <code class="text-green-400/70 font-mono">POST</code><code class="text-gray-400 font-mono">/mesh/credentials</code><span class="text-gray-500">Store a secret. Body: <code class="bg-gray-800 px-0.5 rounded">{"name":"...","value":"..."}</code> &rarr; returns <code class="bg-gray-800 px-0.5 rounded">$CRED{name}</code> handle</span>
-                <code class="text-red-400/70 font-mono">DELETE</code><code class="text-gray-400 font-mono">/mesh/credentials/{name}</code><span class="text-gray-500">Remove a secret by name</span>
-                <code class="text-blue-400/70 font-mono">GET</code><code class="text-gray-400 font-mono">/mesh/credentials</code><span class="text-gray-500">List credential names (never values)</span>
-                <code class="text-blue-400/70 font-mono">GET</code><code class="text-gray-400 font-mono">/mesh/credentials/{name}/exists</code><span class="text-gray-500">Check if a credential exists</span>
-              </div>
-            </div>
-            <div class="space-y-2">
-              <div class="text-[10px] text-gray-600 uppercase tracking-wider font-medium">Agent Status</div>
-              <div class="grid grid-cols-1 sm:grid-cols-[auto_1fr_2fr] gap-x-3 gap-y-1 text-[11px]">
-                <code class="text-blue-400/70 font-mono">GET</code><code class="text-gray-400 font-mono">/mesh/agents/{id}/ext-status</code><span class="text-gray-500">Health, queue depth, and budget for an agent</span>
-              </div>
-            </div>
-            <div class="space-y-2">
-              <div class="text-[10px] text-gray-600 uppercase tracking-wider font-medium">API Endpoints</div>
-              <div class="grid grid-cols-1 sm:grid-cols-[auto_1fr_2fr] gap-x-3 gap-y-1 text-[11px]">
-                <code class="text-green-400/70 font-mono">POST</code><code class="text-gray-400 font-mono">/api/inbound/{endpoint_id}</code><span class="text-gray-500">Trigger an agent workflow. Requires <code class="bg-gray-800 px-0.5 rounded">X-Signature</code> header (no API key needed)</span>
-              </div>
-            </div>
-            <div class="space-y-2">
-              <div class="text-[10px] text-gray-600 uppercase tracking-wider font-medium">Outbound Webhook Payload</div>
-              <div class="text-[11px] text-gray-500 leading-relaxed">
-                Events POST to your URL with <code class="bg-gray-800 px-0.5 rounded">X-OpenLegion-Signature: sha256=HMAC</code> and <code class="bg-gray-800 px-0.5 rounded">X-OpenLegion-Event</code> headers.
-                Body: <code class="bg-gray-800 px-1 rounded text-gray-400">{"event", "agent", "data", "timestamp", "delivery_id"}</code>
-              </div>
-            </div>
-          </div>
-        </details>
+        <!-- Channels sub-tab -->
+        <div x-show="systemTab === 'channels'">
 
         <!-- Channels -->
         <div class="text-xs text-gray-500 uppercase tracking-wider mb-3 flex items-center gap-1.5">Channels<span class="setting-hint" tabindex="0">?<span class="setting-hint-text">Messaging platform integrations. Connect Telegram, Discord, Slack, or WhatsApp so users can chat with agents from those platforms.</span></span></div>
@@ -2719,478 +3242,7 @@
         </div>
         <div x-show="channels.length === 0" class="text-sm text-gray-500 py-4 mb-6">No channel data available</div>
 
-        <!-- API Endpoints -->
-        <div class="text-xs text-gray-500 uppercase tracking-wider mb-3 flex items-center gap-1.5">API Endpoints<span class="setting-hint" tabindex="0">?<span class="setting-hint-text">Named HTTP endpoints that accept POST requests and route them to agents. Enable "Require HMAC signature" to secure the endpoint — your app signs the raw request body with HMAC-SHA256(body, secret) and sends it as the X-Signature header. The secret is shown once at creation time; use Regenerate Secret if you missed it.</span></span></div>
-        <div class="mb-6">
-          <div class="bg-gray-900 border border-gray-800 rounded-lg p-4">
-            <div class="mb-3 pb-3 border-b border-gray-800">
-              <div class="text-sm text-gray-200 font-medium mb-1">API Endpoints</div>
-              <div class="text-[12px] text-gray-500 leading-relaxed">Named HTTP endpoints that accept <code class="bg-gray-800 px-1 rounded text-gray-400">POST</code> requests and route payloads to agents. Optionally secure each endpoint with HMAC-SHA256 signature verification.</div>
-            </div>
-            <div class="space-y-2 mb-3">
-              <template x-for="wh in apiEndpoints" :key="wh.id">
-                <div>
-                  <div class="flex items-center gap-3 text-xs group py-2 px-2 -mx-2 rounded-md hover:bg-gray-800/40 transition-colors border-b border-gray-800/30 last:border-0">
-                    <span class="w-2 h-2 rounded-full bg-green-400/70 shrink-0"></span>
-                    <span class="text-gray-200 font-mono font-medium shrink-0" x-text="wh.name"></span>
-                    <span class="text-gray-600 shrink-0">&rarr;</span>
-                    <span class="text-gray-400 shrink-0" x-text="wh.agent"></span>
-                    <span class="text-indigo-300/80 text-[10px] font-mono flex-1 truncate bg-indigo-950/30 px-2 py-0.5 rounded border border-indigo-900/50" x-text="wh.url || ''" :title="wh.url || ''"></span>
-                    <button x-show="wh.url" @click.stop="copyToClipboard(wh.url)"
-                      class="opacity-0 group-hover:opacity-100 focus:opacity-100 text-[10px] px-1.5 py-0.5 rounded bg-gray-800 hover:bg-gray-700 text-gray-400 hover:text-gray-200 transition-all shrink-0" title="Copy URL" aria-label="Copy endpoint URL">
-                      <svg class="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="9" y="9" width="13" height="13" rx="2" ry="2"/><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/></svg>
-                    </button>
-                    <button @click="editEndpoint(wh)"
-                      class="opacity-0 group-hover:opacity-100 focus:opacity-100 text-[10px] px-1.5 py-0.5 rounded bg-gray-800 hover:bg-gray-700 text-gray-400 hover:text-gray-200 transition-all shrink-0">Edit</button>
-                    <button @click="testEndpoint(wh.id)" :disabled="endpointTesting[wh.id] === true"
-                      class="opacity-0 group-hover:opacity-100 focus:opacity-100 text-[10px] px-1.5 py-0.5 rounded bg-gray-800 hover:bg-indigo-900/40 text-gray-400 hover:text-indigo-300 transition-all disabled:opacity-50 shrink-0" x-text="endpointTesting[wh.id] === true ? '...' : 'Test'"></button>
-                    <button @click="deleteEndpoint(wh.id, wh.name)"
-                      class="opacity-0 group-hover:opacity-100 focus:opacity-100 text-[10px] px-1.5 py-0.5 rounded bg-gray-800 hover:bg-red-900/30 text-gray-400 hover:text-red-400 transition-all shrink-0">Delete</button>
-                  </div>
-                  <!-- Inline edit form -->
-                  <div x-show="editingEndpointId === wh.id" x-transition class="bg-gray-800/30 border border-gray-800 rounded-lg p-3 mt-1 mb-2">
-                    <div class="text-xs text-gray-500 mb-2">Edit endpoint</div>
-                    <div class="flex gap-2 mb-2">
-                      <input type="text" x-model="endpointEditName" :disabled="endpointSaving" class="dash-input text-xs flex-1" placeholder="Endpoint name">
-                      <select x-model="endpointEditAgent" :disabled="endpointSaving" class="dash-select text-xs w-40">
-                        <option value="">Agent...</option>
-                        <template x-for="a in agents" :key="a.id">
-                          <option :value="a.id" x-text="a.id"></option>
-                        </template>
-                      </select>
-                    </div>
-                    <textarea x-model="endpointEditInstructions" :disabled="endpointSaving" class="dash-input w-full text-xs mb-2" rows="2" placeholder="Instructions for the agent (optional)"></textarea>
-                    <label class="flex items-center gap-2 text-xs text-gray-400 mb-3 cursor-pointer select-none">
-                      <input type="checkbox" x-model="endpointEditRequireSig" :disabled="endpointSaving" class="rounded border-gray-700 bg-gray-800 text-indigo-500 focus:ring-indigo-500/30">
-                      Require HMAC signature
-                    </label>
-                    <div class="flex justify-between items-center">
-                      <div class="flex gap-2">
-                        <button @click="cancelEndpointEdit()" :disabled="endpointSaving" class="text-xs px-3 py-1.5 rounded border border-gray-700 hover:border-gray-600 text-gray-400 hover:text-gray-300 transition-colors disabled:opacity-50">Cancel</button>
-                        <button x-show="wh.has_secret" @click="regenerateEndpointSecret(wh.id, wh.name)" :disabled="endpointSaving" class="text-xs px-3 py-1.5 rounded border border-yellow-900/50 hover:border-yellow-700/50 text-yellow-600 hover:text-yellow-500 transition-colors disabled:opacity-50">Regenerate Secret</button>
-                      </div>
-                      <button @click="saveEndpointEdit()" :disabled="endpointSaving" class="text-xs px-3 py-1.5 rounded bg-indigo-600 hover:bg-indigo-500 text-white transition-colors inline-flex items-center gap-1.5 disabled:opacity-50">
-                        <svg x-show="endpointSaving" x-cloak class="animate-spin h-3 w-3" fill="none" viewBox="0 0 24 24"><circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"/><path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z"/></svg>
-                        <span x-text="endpointSaving ? 'Saving...' : 'Save'"></span>
-                      </button>
-                    </div>
-                  </div>
-                  <!-- One-time secret display -->
-                  <div x-show="endpointRevealedSecret && endpointRevealedSecretId === wh.id" x-transition class="mt-2 mb-2 p-3 bg-amber-950 border border-amber-700/60 rounded-lg">
-                    <div class="flex items-center gap-1.5 text-[11px] text-amber-300 font-semibold mb-2.5">
-                      <svg class="w-3.5 h-3.5 shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M12 9v3.75m-9.303 3.376c-.866 1.5.217 3.374 1.948 3.374h14.71c1.73 0 2.813-1.874 1.948-3.374L13.949 3.378c-.866-1.5-3.032-1.5-3.898 0L2.697 16.126zM12 15.75h.007v.008H12v-.008z"/></svg>
-                      HMAC Secret — copy this now, it won't be shown again
-                    </div>
-                    <div class="flex items-center gap-2">
-                      <code class="text-[12px] text-amber-100 bg-black/40 px-3 py-2 rounded font-mono flex-1 break-all select-all tracking-wide border border-amber-900/60" x-text="endpointRevealedSecret"></code>
-                      <button @click="copyToClipboard(endpointRevealedSecret)" class="text-[10px] px-3 py-1.5 rounded bg-amber-800/60 hover:bg-amber-700/60 text-amber-200 hover:text-white border border-amber-700/50 transition-colors shrink-0 font-medium">Copy</button>
-                      <button @click="endpointRevealedSecret = null; endpointRevealedSecretId = null" class="text-[10px] px-2.5 py-1.5 rounded bg-gray-800 hover:bg-gray-700 text-gray-400 hover:text-gray-200 transition-colors shrink-0">Dismiss</button>
-                    </div>
-                  </div>
-                </div>
-              </template>
-              <div x-show="apiEndpoints.length === 0" class="text-gray-600 text-sm py-2 text-center">No API endpoints configured</div>
-            </div>
-            <div class="border-t border-gray-800 pt-3">
-              <button x-show="!showEndpointForm" @click="showEndpointForm = true; cancelEndpointEdit()" class="text-xs px-3 py-1.5 rounded border border-gray-700 hover:border-gray-600 text-gray-400 hover:text-gray-300 transition-colors">+ Add Endpoint</button>
-              <div x-show="showEndpointForm" x-transition>
-                <div class="text-xs text-gray-500 mb-2">New endpoint</div>
-                <div class="flex gap-2 mb-2">
-                  <input type="text" x-model="endpointFormName" :disabled="endpointCreating" class="dash-input text-xs flex-1" placeholder="Endpoint name">
-                  <select x-model="endpointFormAgent" :disabled="endpointCreating" class="dash-select text-xs w-40">
-                    <option value="">Agent...</option>
-                    <template x-for="a in agents" :key="a.id">
-                      <option :value="a.id" x-text="a.id"></option>
-                    </template>
-                  </select>
-                </div>
-                <textarea x-model="endpointFormInstructions" :disabled="endpointCreating" class="dash-input w-full text-xs mb-2" rows="2" placeholder="Instructions for the agent (optional) — e.g. 'Extract the event type and update the CRM'"></textarea>
-                <label class="flex items-center gap-2 text-xs text-gray-400 mb-3 cursor-pointer select-none">
-                  <input type="checkbox" x-model="endpointFormRequireSig" :disabled="endpointCreating" class="rounded border-gray-700 bg-gray-800 text-indigo-500 focus:ring-indigo-500/30">
-                  Require HMAC signature
-                </label>
-                <div class="flex justify-between">
-                  <button @click="showEndpointForm = false; endpointFormName = ''; endpointFormAgent = ''; endpointFormInstructions = ''; endpointFormRequireSig = false" :disabled="endpointCreating" class="text-xs px-3 py-1.5 rounded border border-gray-700 hover:border-gray-600 text-gray-400 hover:text-gray-300 transition-colors disabled:opacity-50">Cancel</button>
-                  <button @click="createEndpoint()" :disabled="endpointCreating" class="text-xs px-3 py-1.5 rounded bg-indigo-600 hover:bg-indigo-500 text-white transition-colors inline-flex items-center gap-1.5 disabled:opacity-50">
-                    <svg x-show="endpointCreating" x-cloak class="animate-spin h-3 w-3" fill="none" viewBox="0 0 24 24"><circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"/><path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z"/></svg>
-                    <span x-text="endpointCreating ? 'Creating...' : 'Create Endpoint'"></span>
-                  </button>
-                </div>
-              </div>
-            </div>
-          </div>
-        </div>
-
-        <!-- Outbound Webhooks -->
-        <div class="text-xs text-gray-500 uppercase tracking-wider mb-3 flex items-center gap-1.5 mt-6">Webhooks<span class="setting-hint" tabindex="0">?<span class="setting-hint-text">Send events to external URLs when things happen. OpenLegion POSTs signed JSON payloads with HMAC-SHA256 verification. Events: notification, task_complete, task_failed, agent_state, cron_complete, custom.</span></span></div>
-        <div class="mb-6">
-          <div class="bg-gray-900 border border-gray-800 rounded-lg p-4">
-            <div class="mb-3 pb-3 border-b border-gray-800">
-              <div class="text-sm text-gray-200 font-medium mb-1">Webhooks</div>
-              <div class="text-[12px] text-gray-500 leading-relaxed">Send events to external URLs. Each delivery includes an <code class="bg-gray-800 px-1 rounded text-gray-400">X-OpenLegion-Signature</code> HMAC-SHA256 header for verification.</div>
-            </div>
-            <div class="space-y-2 mb-3">
-              <template x-for="wh in outboundWebhooks" :key="wh.id">
-                <div>
-                  <div x-show="editingOutboundId !== wh.id" class="flex items-center gap-3 text-xs group py-2 px-2 -mx-2 rounded-md hover:bg-gray-800/40 transition-colors border-b border-gray-800/30 last:border-0">
-                    <span class="w-2 h-2 rounded-full shrink-0" :class="wh.enabled !== false ? 'bg-green-400/70' : 'bg-gray-600'"></span>
-                    <span class="text-gray-200 font-medium shrink-0" x-text="wh.name"></span>
-                    <span class="text-indigo-300/80 text-[10px] font-mono flex-1 truncate bg-indigo-950/30 px-2 py-0.5 rounded border border-indigo-900/50" x-text="wh.url" :title="wh.url"></span>
-                    <template x-for="ev in (wh.events || [])" :key="ev">
-                      <span class="text-[9px] px-1.5 py-0.5 rounded-full bg-cyan-900/40 text-cyan-400 border border-cyan-800/30" x-text="ev"></span>
-                    </template>
-                    <span x-show="wh.enabled === false" class="text-[9px] px-1.5 py-0.5 rounded-full bg-gray-800 text-gray-500">disabled</span>
-                    <button @click="editOutboundWebhook(wh)" class="opacity-0 group-hover:opacity-100 focus:opacity-100 text-[10px] px-1.5 py-0.5 rounded bg-gray-800 hover:bg-gray-700 text-gray-400 hover:text-gray-200 transition-all shrink-0">Edit</button>
-                    <button @click="testOutboundWebhook(wh.id)" class="opacity-0 group-hover:opacity-100 focus:opacity-100 text-[10px] px-1.5 py-0.5 rounded bg-gray-800 hover:bg-indigo-900/40 text-gray-400 hover:text-indigo-300 transition-all shrink-0">Test</button>
-                    <button @click="deleteOutboundWebhook(wh.id, wh.name)" class="opacity-0 group-hover:opacity-100 focus:opacity-100 text-[10px] px-1.5 py-0.5 rounded bg-gray-800 hover:bg-red-900/30 text-gray-400 hover:text-red-400 transition-all shrink-0">Delete</button>
-                  </div>
-                  <!-- Inline edit form -->
-                  <div x-show="editingOutboundId === wh.id" x-transition class="bg-gray-800/30 border border-gray-800 rounded-lg p-3 mt-1 mb-2">
-                    <div class="text-xs text-gray-500 mb-2">Edit webhook</div>
-                    <div class="flex gap-2 mb-2">
-                      <input type="text" x-model="outboundEditName" :disabled="outboundSaving" class="dash-input text-xs flex-1" placeholder="Webhook name">
-                      <input type="url" x-model="outboundEditUrl" :disabled="outboundSaving" class="dash-input text-xs flex-1" placeholder="https://example.com/hook">
-                    </div>
-                    <div class="text-[10px] text-gray-500 mb-1">Event types:</div>
-                    <div class="flex flex-wrap gap-2 mb-2">
-                      <template x-for="et in ['notification','task_complete','task_failed','agent_state','cron_complete','custom']" :key="et">
-                        <label class="flex items-center gap-1 text-[11px] text-gray-400 cursor-pointer select-none">
-                          <input type="checkbox" :value="et" x-model="outboundEditEvents" :disabled="outboundSaving" class="rounded border-gray-700 bg-gray-800 text-indigo-500 focus:ring-indigo-500/30 w-3 h-3">
-                          <span x-text="et"></span>
-                        </label>
-                      </template>
-                    </div>
-                    <div class="text-[10px] text-gray-500 mb-1">Agent filter (empty = all agents):</div>
-                    <div class="flex flex-wrap gap-2 mb-2">
-                      <template x-for="a in agents" :key="a.id">
-                        <label class="flex items-center gap-1 text-[11px] text-gray-400 cursor-pointer select-none">
-                          <input type="checkbox" :value="a.id" x-model="outboundEditAgentFilter" :disabled="outboundSaving" class="rounded border-gray-700 bg-gray-800 text-indigo-500 focus:ring-indigo-500/30 w-3 h-3">
-                          <span x-text="a.id"></span>
-                        </label>
-                      </template>
-                    </div>
-                    <label class="flex items-center gap-2 text-xs text-gray-400 mb-3 cursor-pointer select-none">
-                      <input type="checkbox" x-model="outboundEditEnabled" :disabled="outboundSaving" class="rounded border-gray-700 bg-gray-800 text-indigo-500 focus:ring-indigo-500/30">
-                      Enabled
-                    </label>
-                    <div class="flex justify-end gap-2">
-                      <button @click="cancelOutboundEdit()" :disabled="outboundSaving" class="text-xs px-3 py-1.5 rounded border border-gray-700 hover:border-gray-600 text-gray-400 hover:text-gray-300 transition-colors disabled:opacity-50">Cancel</button>
-                      <button @click="saveOutboundEdit()" :disabled="outboundSaving" class="text-xs px-3 py-1.5 rounded bg-indigo-600 hover:bg-indigo-500 text-white transition-colors inline-flex items-center gap-1.5 disabled:opacity-50">
-                        <svg x-show="outboundSaving" x-cloak class="animate-spin h-3 w-3" fill="none" viewBox="0 0 24 24"><circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"/><path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z"/></svg>
-                        <span x-text="outboundSaving ? 'Saving...' : 'Save'"></span>
-                      </button>
-                    </div>
-                  </div>
-                </div>
-              </template>
-              <div x-show="outboundWebhooks.length === 0" class="text-gray-600 text-sm py-2 text-center">No outbound webhooks configured</div>
-            </div>
-            <div class="border-t border-gray-800 pt-3">
-              <div class="flex gap-2">
-                <button x-show="!showOutboundForm" @click="showOutboundForm = true; cancelOutboundEdit()" class="text-xs px-3 py-1.5 rounded border border-gray-700 hover:border-gray-600 text-gray-400 hover:text-gray-300 transition-colors">+ Add Webhook</button>
-                <button @click="showDeliveries = !showDeliveries; if (showDeliveries) fetchDeliveries()" class="text-xs px-3 py-1.5 rounded border border-gray-700 hover:border-gray-600 text-gray-400 hover:text-gray-300 transition-colors" x-text="showDeliveries ? 'Hide Deliveries' : 'Recent Deliveries'"></button>
-              </div>
-              <div x-show="showOutboundForm" x-transition class="mt-3">
-                <div class="text-xs text-gray-500 mb-2">New webhook</div>
-                <div class="flex gap-2 mb-2">
-                  <input type="text" x-model="outboundFormName" :disabled="outboundCreating" class="dash-input text-xs flex-1" placeholder="Webhook name">
-                  <input type="url" x-model="outboundFormUrl" :disabled="outboundCreating" class="dash-input text-xs flex-1" placeholder="https://example.com/hook">
-                </div>
-                <div class="text-[10px] text-gray-500 mb-1">Event types:</div>
-                <div class="flex flex-wrap gap-2 mb-2">
-                  <template x-for="et in ['notification','task_complete','task_failed','agent_state','cron_complete','custom']" :key="et">
-                    <label class="flex items-center gap-1 text-[11px] text-gray-400 cursor-pointer select-none">
-                      <input type="checkbox" :value="et" x-model="outboundFormEvents" :disabled="outboundCreating" class="rounded border-gray-700 bg-gray-800 text-indigo-500 focus:ring-indigo-500/30 w-3 h-3">
-                      <span x-text="et"></span>
-                    </label>
-                  </template>
-                </div>
-                <div class="text-[10px] text-gray-500 mb-1">Agent filter (empty = all agents):</div>
-                <div class="flex flex-wrap gap-2 mb-3">
-                  <template x-for="a in agents" :key="a.id">
-                    <label class="flex items-center gap-1 text-[11px] text-gray-400 cursor-pointer select-none">
-                      <input type="checkbox" :value="a.id" x-model="outboundFormAgentFilter" :disabled="outboundCreating" class="rounded border-gray-700 bg-gray-800 text-indigo-500 focus:ring-indigo-500/30 w-3 h-3">
-                      <span x-text="a.id"></span>
-                    </label>
-                  </template>
-                </div>
-                <div class="flex justify-between">
-                  <button @click="showOutboundForm = false; outboundFormName = ''; outboundFormUrl = ''; outboundFormEvents = []; outboundFormAgentFilter = []" :disabled="outboundCreating" class="text-xs px-3 py-1.5 rounded border border-gray-700 hover:border-gray-600 text-gray-400 hover:text-gray-300 transition-colors disabled:opacity-50">Cancel</button>
-                  <button @click="createOutboundWebhook()" :disabled="outboundCreating" class="text-xs px-3 py-1.5 rounded bg-indigo-600 hover:bg-indigo-500 text-white transition-colors inline-flex items-center gap-1.5 disabled:opacity-50">
-                    <svg x-show="outboundCreating" x-cloak class="animate-spin h-3 w-3" fill="none" viewBox="0 0 24 24"><circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"/><path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z"/></svg>
-                    <span x-text="outboundCreating ? 'Creating...' : 'Create Webhook'"></span>
-                  </button>
-                </div>
-              </div>
-              <!-- Recent Deliveries -->
-              <div x-show="showDeliveries" x-transition class="mt-3">
-                <div class="text-xs text-gray-500 mb-2">Recent Deliveries</div>
-                <div class="max-h-48 overflow-y-auto space-y-1">
-                  <template x-for="d in outboundDeliveries.slice().reverse()" :key="d.delivery_id">
-                    <div class="flex items-center gap-2 text-[11px] py-1 px-2 rounded hover:bg-gray-800/30">
-                      <span class="shrink-0" :class="d.status === 'delivered' ? 'text-green-400' : 'text-red-400'" x-text="d.status === 'delivered' ? '&#10003;' : '&#10007;'"></span>
-                      <span class="text-gray-500 shrink-0" x-text="d.timestamp ? d.timestamp.split('T')[1]?.slice(0,8) : ''"></span>
-                      <span class="text-cyan-400/80 shrink-0" x-text="d.event"></span>
-                      <span class="text-gray-400 shrink-0" x-text="d.agent"></span>
-                      <span class="text-gray-600 flex-1 truncate" x-text="d.subscription_id"></span>
-                      <span x-show="d.response_code" class="text-gray-500 text-[10px]" x-text="d.response_code"></span>
-                      <span x-show="d.error" class="text-red-400/70 text-[10px] truncate max-w-[200px]" :title="d.error" x-text="d.error"></span>
-                    </div>
-                  </template>
-                  <div x-show="outboundDeliveries.length === 0" class="text-gray-600 text-sm py-2 text-center">No recent deliveries</div>
-                </div>
-              </div>
-            </div>
-          </div>
-        </div>
-
-        <!-- API Keys -->
-        <div class="text-xs text-gray-500 uppercase tracking-wider mb-3 flex items-center gap-1.5 mt-6">API Keys</div>
-        <div class="mb-6">
-          <div class="bg-gray-900 border border-gray-800 rounded-lg p-4">
-            <div class="text-[12px] text-gray-500 leading-relaxed mb-3">
-              Authenticate your backend for server-to-server API calls. Send as <code class="bg-gray-800 px-1 rounded text-gray-400">X-API-Key</code> header.
-              Create separate keys per environment or integration — each key is hashed and the raw value is shown only once at creation.
-            </div>
-            <div class="grid grid-cols-1 sm:grid-cols-2 gap-x-4 gap-y-1 text-[11px] mb-4 chat-grid">
-              <div class="text-gray-500"><code class="text-gray-400 font-mono">POST</code> <code class="text-gray-400 font-mono">/mesh/credentials</code></div>
-              <div class="text-gray-600">Store a secret &rarr; returns <code class="bg-gray-800/60 px-0.5 rounded">$CRED{name}</code> handle</div>
-              <div class="text-gray-500"><code class="text-gray-400 font-mono">DELETE</code> <code class="text-gray-400 font-mono">/mesh/credentials/{name}</code></div>
-              <div class="text-gray-600">Remove a secret</div>
-              <div class="text-gray-500"><code class="text-gray-400 font-mono">GET</code> <code class="text-gray-400 font-mono">/mesh/credentials</code></div>
-              <div class="text-gray-600">List credential names (never values)</div>
-              <div class="text-gray-500"><code class="text-gray-400 font-mono">GET</code> <code class="text-gray-400 font-mono">/mesh/agents/{id}/ext-status</code></div>
-              <div class="text-gray-600">Agent health, queue depth, budget</div>
-            </div>
-            <div class="border-t border-gray-800 pt-3 mb-3"></div>
-            <!-- One-time new key display -->
-            <div x-show="apiKeyNewValue" x-transition class="mb-3 p-3 bg-emerald-950/40 border border-emerald-700/40 rounded-lg">
-              <div class="text-[11px] text-emerald-400 font-medium mb-2">New API Key — copy this now, it won't be shown again</div>
-              <div class="flex items-center gap-2">
-                <code class="text-[12px] text-emerald-200 bg-gray-950/80 px-3 py-2 rounded font-mono flex-1 break-all select-all tracking-wide" x-text="apiKeyNewValue"></code>
-                <button @click="copyToClipboard(apiKeyNewValue)" class="text-[10px] px-3 py-1.5 rounded bg-emerald-800/40 hover:bg-emerald-700/40 text-emerald-300 hover:text-emerald-200 border border-emerald-700/30 transition-colors shrink-0">Copy</button>
-                <button @click="apiKeyNewValue = null" class="text-[10px] px-2.5 py-1.5 rounded bg-gray-800 hover:bg-gray-700 text-gray-400 hover:text-gray-200 transition-colors shrink-0">Dismiss</button>
-              </div>
-            </div>
-            <!-- Legacy env var notice -->
-            <div x-show="apiKeysLegacy" x-cloak class="mb-3 px-3 py-2 bg-amber-950/30 border border-amber-800/25 rounded text-[11px] text-amber-400/90">
-              Legacy key detected from <code class="bg-gray-800/80 text-amber-300 px-1 rounded">OPENLEGION_API_KEY</code> env var. Create named keys below to replace it.
-            </div>
-            <!-- Key list -->
-            <div class="space-y-0.5 mb-3">
-              <template x-for="ak in apiKeys" :key="ak.id">
-                <div class="flex items-center gap-3 text-xs group py-2 px-2 rounded hover:bg-gray-800/30 transition-colors">
-                  <span class="w-2 h-2 rounded-full bg-emerald-500/60 shrink-0"></span>
-                  <span class="text-white font-medium" x-text="ak.name"></span>
-                  <span class="text-gray-500 font-mono text-[10px]" x-text="ak.id"></span>
-                  <span class="text-gray-500 text-[10px] flex-1 text-right" x-text="ak.last_used_at ? 'Used ' + ak.last_used_at.split('T')[0] : 'Never used'"></span>
-                  <span class="text-gray-600 text-[10px]" x-text="'Created ' + ak.created_at.split('T')[0]"></span>
-                  <button @click="revokeApiKey(ak.id, ak.name)"
-                    class="opacity-0 group-hover:opacity-100 focus:opacity-100 text-[10px] px-1.5 py-0.5 rounded bg-gray-800 hover:bg-red-900/30 text-gray-400 hover:text-red-400 transition-all">Revoke</button>
-                </div>
-              </template>
-              <div x-show="apiKeys.length === 0 && !apiKeysLegacy" class="text-gray-500 text-sm py-3 text-center">No API keys configured</div>
-            </div>
-            <!-- Create key form -->
-            <div class="border-t border-gray-800 pt-3">
-              <div x-show="!showApiKeyForm">
-                <button @click="showApiKeyForm = true; apiKeyNewName = ''" class="text-xs px-3 py-1.5 rounded border border-gray-700 hover:border-gray-600 text-gray-400 hover:text-gray-300 transition-colors">+ Create API Key</button>
-              </div>
-              <div x-show="showApiKeyForm" x-transition>
-                <div class="text-xs text-gray-500 mb-2">New API key</div>
-                <div class="flex gap-2">
-                  <input type="text" x-model="apiKeyNewName" :disabled="apiKeyCreating" class="dash-input text-xs flex-1" placeholder="Key name (e.g. company-production)" @keydown.enter="createApiKey()">
-                  <button @click="showApiKeyForm = false" :disabled="apiKeyCreating" class="text-xs px-3 py-1.5 rounded border border-gray-700 hover:border-gray-600 text-gray-400 hover:text-gray-300 transition-colors disabled:opacity-50">Cancel</button>
-                  <button @click="createApiKey()" :disabled="apiKeyCreating || !apiKeyNewName.trim()" class="text-xs px-3 py-1.5 rounded bg-indigo-600 hover:bg-indigo-500 text-white transition-colors inline-flex items-center gap-1.5 disabled:opacity-50">
-                    <svg x-show="apiKeyCreating" x-cloak class="animate-spin h-3 w-3" fill="none" viewBox="0 0 24 24"><circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"/><path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z"/></svg>
-                    <span x-text="apiKeyCreating ? 'Creating...' : 'Create'"></span>
-                  </button>
-                </div>
-              </div>
-            </div>
-          </div>
-        </div>
-
-        </div><!-- /integrations sub-tab -->
-
-        <!-- ═══ API KEYS SUB-TAB ═══ -->
-        <div x-show="systemTab === 'apikeys'" x-effect="if (systemTab === 'apikeys') fetchSettings()">
-        <div class="text-xs text-gray-500 uppercase tracking-wider mb-3 flex items-center gap-1.5">API Keys
-          <span class="setting-hint" tabindex="0">?<span class="setting-hint-text">Credentials stored in the mesh vault. "system" keys (OPENLEGION_SYSTEM_*) are used by the mesh for LLM routing and never exposed to agents. "agent" keys (OPENLEGION_CRED_*) are available to agents as opaque handles for HTTP requests.</span></span>
-        </div>
-        <div class="mb-6" x-show="settingsData">
-          <div class="bg-gray-900 border border-gray-800 rounded-lg p-4">
-            <div class="text-sm text-gray-400 mb-2">
-              <span x-text="settingsData?.credentials?.count || 0"></span> key(s) configured
-            </div>
-            <div class="space-y-1 mb-3">
-              <template x-for="name in settingsData?.credentials?.names || []" :key="name">
-                <div>
-                  <div class="flex items-center gap-2 text-xs group">
-                    <span class="w-2 h-2 rounded-full" :class="(settingsData.agent_credentials || []).includes(name) ? 'bg-green-500/50' : 'bg-amber-500/50'"></span>
-                    <span class="text-gray-300 font-mono flex-1 truncate" x-text="name"></span>
-                    <span class="text-[10px] px-1.5 py-0.5 rounded-full shrink-0" :class="(settingsData.agent_credentials || []).includes(name) ? 'bg-green-900/40 text-green-400' : 'bg-amber-900/40 text-amber-400'" x-text="(settingsData.agent_credentials || []).includes(name) ? 'agent' : 'system'"></span>
-                    <div class="flex items-center gap-0 shrink-0 w-[4.5rem] justify-end">
-                      <button x-show="!name.endsWith('_oauth')" @click="revealCredential(name)" class="opacity-0 group-hover:opacity-100 focus:opacity-100 text-gray-400 hover:text-gray-300 transition-opacity px-1" :title="revealedCredentials[name] ? 'Hide value' : 'Reveal value'">
-                        <svg x-show="!revealedCredentials[name]" class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z"/><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z"/></svg>
-                        <svg x-show="revealedCredentials[name]" x-cloak class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13.875 18.825A10.05 10.05 0 0112 19c-4.478 0-8.268-2.943-9.543-7a9.97 9.97 0 011.563-3.029m5.858.908a3 3 0 114.243 4.243M9.878 9.878l4.242 4.242M9.88 9.88l-3.29-3.29m7.532 7.532l3.29 3.29M3 3l3.59 3.59m0 0A9.953 9.953 0 0112 5c4.478 0 8.268 2.943 9.543 7a10.025 10.025 0 01-4.132 5.411m0 0L21 21"/></svg>
-                      </button>
-                      <button x-show="!name.endsWith('_oauth')" @click="editingCredential = editingCredential === name ? null : name; editCredKey = ''" :aria-expanded="editingCredential === name" class="opacity-0 group-hover:opacity-100 focus:opacity-100 text-gray-400 hover:text-indigo-300 transition-opacity text-[10px] px-1" title="Update key">Update</button>
-                      <button @click="deleteCredential(name)" class="opacity-0 group-hover:opacity-100 focus:opacity-100 text-red-400 hover:text-red-300 transition-opacity text-base leading-none px-1" title="Remove key" aria-label="Remove key">&times;</button>
-                    </div>
-                  </div>
-                  <!-- Revealed key value -->
-                  <div x-show="revealedCredentials[name]" x-cloak x-transition class="ml-4 mt-1 mb-1 flex items-center gap-2">
-                    <code class="text-[11px] text-green-400/80 bg-gray-800 px-2 py-1 rounded font-mono flex-1 break-all select-all" x-text="revealedCredentials[name]"></code>
-                    <button @click="copyToClipboard(revealedCredentials[name])" class="text-[10px] px-2 py-0.5 rounded bg-gray-800 hover:bg-gray-700 text-gray-400 shrink-0" title="Copy value">Copy</button>
-                  </div>
-                  <!-- Inline key update form -->
-                  <div x-show="editingCredential === name" x-cloak x-transition class="ml-4 mt-1 mb-1 flex items-center gap-2">
-                    <input type="password" x-model="editCredKey" class="dash-input text-xs flex-1" placeholder="New key value">
-                    <button @click="updateCredential(name)" :disabled="credentialSaving" class="text-[10px] px-2 py-1 rounded bg-indigo-600 hover:bg-indigo-500 text-white disabled:opacity-50 disabled:cursor-not-allowed" x-text="credentialSaving ? 'Saving...' : 'Save'"></button>
-                    <button @click="editingCredential = null; editCredKey = ''" class="text-[10px] px-2 py-1 rounded bg-gray-800 hover:bg-gray-700 text-gray-400">Cancel</button>
-                  </div>
-                </div>
-              </template>
-            </div>
-            <!-- Credential tier legend -->
-            <div class="flex flex-wrap gap-x-5 gap-y-1 mb-3 text-[10px] text-gray-500 leading-relaxed">
-              <span class="flex items-center gap-1.5"><span class="w-2 h-2 rounded-full bg-green-500/50 shrink-0"></span><strong class="text-gray-400">Agent key</strong> &mdash; agents can request by name, granted per-agent via Credential Access permissions. The vault returns an opaque handle; the raw value is never exposed.</span>
-              <span class="flex items-center gap-1.5"><span class="w-2 h-2 rounded-full bg-amber-500/50 shrink-0"></span><strong class="text-gray-400">System key</strong> &mdash; held exclusively by the mesh host. Agents cannot access it at all. LLM provider API keys (Anthropic, OpenAI, etc.) are always stored here.</span>
-            </div>
-            <div class="border-t border-gray-800 pt-3">
-              <button x-show="!showCredForm" @click="showCredForm = true" class="text-xs px-3 py-1.5 rounded border border-gray-700 hover:border-gray-600 text-gray-400 hover:text-gray-300 transition-colors">+ Add Key</button>
-              <div x-show="showCredForm" x-transition>
-                <div class="text-xs text-gray-500 mb-2">New API key</div>
-                <div class="flex gap-2 mb-2">
-                  <div class="relative" @click.outside="_credServiceDropdownOpen = false" @keydown.escape.stop="_credServiceDropdownOpen = false">
-                    <button type="button" :disabled="credSaving"
-                      @click="_credServiceDropdownOpen = !_credServiceDropdownOpen; if (_credServiceDropdownOpen) { _credServiceSearch = ''; $nextTick(() => $refs.credServiceSearchInput?.focus()); }"
-                      class="dash-input flex items-center justify-between gap-2 cursor-pointer text-left" style="min-width:10rem">
-                      <span class="truncate" :class="credService ? 'text-gray-200' : 'text-gray-400'"
-                        x-text="credService === '__custom__' ? 'Custom\u2026' : (credService ? (credServiceOptions.find(o => o.value === credService)?.label || credService) : 'Service\u2026')"></span>
-                      <svg class="w-3.5 h-3.5 text-gray-500 flex-shrink-0 transition-transform" :class="_credServiceDropdownOpen && 'rotate-180'" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M19 9l-7 7-7-7"/></svg>
-                    </button>
-                    <div x-show="_credServiceDropdownOpen" x-cloak x-transition:enter="transition ease-out duration-100" x-transition:enter-start="opacity-0 -translate-y-1" x-transition:enter-end="opacity-100 translate-y-0"
-                      class="absolute z-50 mt-1 min-w-full w-max bg-gray-800 border border-gray-700 rounded-lg shadow-xl" style="max-width:min(28rem, calc(100vw - 2rem))">
-                      <div class="p-2">
-                        <div class="flex items-center gap-2 bg-gray-900 border border-gray-600 rounded-md px-2.5 py-1.5 focus-within:border-indigo-500/60">
-                          <svg class="w-3.5 h-3.5 text-gray-500 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="2"><circle cx="11" cy="11" r="8"/><path stroke-linecap="round" d="m21 21-4.35-4.35"/></svg>
-                          <input x-ref="credServiceSearchInput" type="text" x-model="_credServiceSearch" placeholder="Search services…"
-                            @keydown.enter.prevent="(() => {
-                              const q = _credServiceSearch.toLowerCase().trim();
-                              const match = q ? credServiceOptions.find(o => o.label.toLowerCase().includes(q) || o.value.toLowerCase().includes(q)) : null;
-                              if (match) { credService = match.value; _credServiceDropdownOpen = false; credAuthType = 'api_key'; if (match.value === 'ollama') credBaseUrl = credBaseUrl || 'http://localhost:11434'; if (match.value !== '__custom__') { credCustomService = ''; credIsLlmProvider = false; credCustomModels = ''; credCustomLabel = ''; } }
-                            })()"
-                            class="w-full bg-transparent text-xs text-gray-200 placeholder-gray-500 outline-none focus:outline-none focus:ring-0" style="outline:none!important;box-shadow:none!important">
-                        </div>
-                      </div>
-                      <div class="border-t border-gray-700/60 overflow-y-auto custom-scrollbar" style="max-height:280px">
-                        <!-- Grouped options -->
-                        <template x-for="group in [...new Set(credServiceOptions.map(o => o.group))].filter(g => {
-                          const q = _credServiceSearch.toLowerCase().trim();
-                          if (!q) return true;
-                          return credServiceOptions.some(o => o.group === g && (o.label.toLowerCase().includes(q) || o.value.toLowerCase().includes(q)));
-                        })" :key="group">
-                          <div>
-                            <div class="px-3 pt-3 pb-1.5 mt-1 first:mt-0 border-t border-gray-700/50 first:border-t-0 text-[11px] font-medium text-gray-500 uppercase tracking-wider" x-text="group"></div>
-                            <template x-for="o in credServiceOptions.filter(o => {
-                              if (o.group !== group) return false;
-                              const q = _credServiceSearch.toLowerCase().trim();
-                              return !q || o.label.toLowerCase().includes(q) || o.value.toLowerCase().includes(q);
-                            })" :key="o.value">
-                              <button type="button"
-                                @click="credService = o.value; _credServiceDropdownOpen = false; credAuthType = 'api_key'; if (o.value === 'ollama') credBaseUrl = credBaseUrl || 'http://localhost:11434'; if (o.value !== '__custom__') { credCustomService = ''; credIsLlmProvider = false; credCustomModels = ''; credCustomLabel = ''; }"
-                                class="w-full text-left px-3 py-1.5 text-xs transition-colors flex items-center gap-2"
-                                :class="credService === o.value ? 'bg-indigo-600/20 text-indigo-300' : 'text-gray-300 hover:bg-gray-700/60'">
-                                <svg class="w-3 h-3 flex-shrink-0" :class="credService === o.value ? 'text-indigo-400' : 'text-transparent'" fill="currentColor" viewBox="0 0 20 20"><path fill-rule="evenodd" d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z" clip-rule="evenodd"/></svg>
-                                <span x-text="o.label" class="truncate"></span>
-                              </button>
-                            </template>
-                          </div>
-                        </template>
-                        <!-- Custom option (always visible at bottom) -->
-                        <div class="border-t border-gray-700/50">
-                          <button type="button"
-                            @click="credService = '__custom__'; _credServiceDropdownOpen = false; credAuthType = 'api_key';"
-                            class="w-full text-left px-3 py-1.5 text-xs transition-colors flex items-center gap-2"
-                            :class="credService === '__custom__' ? 'bg-indigo-600/20 text-indigo-300' : 'text-gray-300 hover:bg-gray-700/60'"
-                            x-show="!_credServiceSearch || 'custom'.includes(_credServiceSearch.toLowerCase().trim())">
-                            <svg class="w-3 h-3 flex-shrink-0" :class="credService === '__custom__' ? 'text-indigo-400' : 'text-transparent'" fill="currentColor" viewBox="0 0 20 20"><path fill-rule="evenodd" d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z" clip-rule="evenodd"/></svg>
-                            Custom&hellip;
-                          </button>
-                        </div>
-                        <!-- No results -->
-                        <div x-show="_credServiceSearch && !credServiceOptions.some(o => o.label.toLowerCase().includes(_credServiceSearch.toLowerCase().trim()) || o.value.toLowerCase().includes(_credServiceSearch.toLowerCase().trim())) && !'custom'.includes(_credServiceSearch.toLowerCase().trim())"
-                          class="px-3 py-3 text-xs text-gray-500 text-center">No services match your search.</div>
-                      </div>
-                    </div>
-                  </div>
-                  <template x-if="credService === 'anthropic' || credService === 'openai'">
-                    <select x-model="credAuthType" :disabled="credSaving" class="dash-select text-xs w-48">
-                      <option value="api_key">API Key (recommended)</option>
-                      <option value="oauth" x-text="credService === 'openai' ? 'ChatGPT OAuth (JSON)' : 'Subscription Token'"></option>
-                    </select>
-                  </template>
-                  <input x-show="credService === '__custom__'" type="text" x-model="credCustomService" :disabled="credSaving" class="dash-input text-xs w-40" placeholder="credential_name">
-                  <select x-show="credService === '__custom__'" x-model="credTier" :disabled="credSaving" class="dash-select text-xs w-28">
-                    <option value="agent">Agent tier</option>
-                    <option value="system">System tier</option>
-                  </select>
-                  <input x-show="credService !== 'ollama'" type="password" x-model="credKey" :disabled="credSaving" class="dash-input flex-1"
-                    :placeholder="credAuthType === 'oauth' ? (credService === 'openai' ? '{&quot;access_token&quot;:...,&quot;refresh_token&quot;:...}' : 'sk-ant-oat01-...') : 'API key or value'">
-                </div>
-                <template x-if="credService === '__custom__'">
-                  <div class="text-[10px] text-gray-500 leading-snug mb-2 p-2 rounded bg-gray-800/60 border border-gray-700/40">
-                    <strong class="text-gray-400">Agent tier</strong>: agents can request this credential by name. Access is controlled per-agent via the Credential Access permission pattern. The agent receives an opaque handle &mdash; the raw value is never returned.
-                    <span class="mx-1">&middot;</span>
-                    <strong class="text-gray-400">System tier</strong>: held only by the mesh host. No agent can read or reference it. Use this for infrastructure tokens or secrets that agents should never touch.
-                  </div>
-                </template>
-                <template x-if="credService === '__custom__' && credTier === 'system'">
-                  <div class="space-y-2 mb-2">
-                    <label class="inline-flex items-center gap-1.5 text-xs text-gray-400 cursor-pointer select-none">
-                      <input type="checkbox" x-model="credIsLlmProvider" class="rounded border-gray-700 bg-gray-800 text-indigo-500 focus:ring-indigo-500/30">
-                      This is an LLM provider
-                    </label>
-                    <template x-if="credIsLlmProvider">
-                      <div class="space-y-1.5">
-                        <input type="text" x-model="credCustomLabel" :disabled="credSaving" class="dash-input w-full text-xs" placeholder="Display name (e.g. My Provider)">
-                        <textarea x-model="credCustomModels" :disabled="credSaving" class="dash-input w-full text-xs" rows="2" placeholder="Model names, comma-separated (e.g. model-7b, model-70b)"></textarea>
-                        <div class="text-[10px] text-gray-500">Models will be available as <code class="bg-gray-800 px-0.5 rounded" x-text="(credCustomService || 'provider') + '/model-name'"></code> in the agent model selector. Must be OpenAI-compatible.</div>
-                      </div>
-                    </template>
-                  </div>
-                </template>
-                <template x-if="credAuthType === 'oauth' && credService === 'anthropic'">
-                  <div class="text-[10px] text-amber-400/80 leading-snug mb-2">
-                    Experimental — uses unofficial OAuth that may break without notice. Generate with: <code class="font-mono bg-gray-800 px-1 rounded">claude setup-token</code>
-                  </div>
-                </template>
-                <template x-if="credAuthType === 'oauth' && credService === 'openai'">
-                  <div class="text-[10px] text-amber-400/80 leading-snug mb-2">
-                    Paste the JSON blob from <code class="font-mono bg-gray-800 px-1 rounded">~/.codex/auth.json</code> containing <code class="font-mono bg-gray-800 px-1 rounded">access_token</code> and <code class="font-mono bg-gray-800 px-1 rounded">refresh_token</code>.
-                  </div>
-                </template>
-                <template x-if="credService === 'ollama'">
-                  <div>
-                    <input type="text" x-model="credBaseUrl" :disabled="credSaving" class="dash-input w-full mb-1" placeholder="http://localhost:11434">
-                    <div class="text-[10px] text-gray-500 mb-3">Ollama URL — no API key needed. Make sure Ollama is running.</div>
-                  </div>
-                </template>
-                <input x-show="credService !== 'ollama' && credAuthType !== 'oauth'" type="text" x-model="credBaseUrl" :disabled="credSaving" class="dash-input w-full mb-3" placeholder="Custom API base URL (optional)">
-                <div class="flex justify-between">
-                  <button @click="showCredForm = false; credService = ''; credKey = ''; credBaseUrl = ''; credCustomService = ''; credTier = 'agent'; credAuthType = 'api_key'; credIsLlmProvider = false; credCustomModels = ''; credCustomLabel = ''; _credServiceDropdownOpen = false; _credServiceSearch = ''" :disabled="credSaving" class="text-xs px-3 py-1.5 rounded border border-gray-700 hover:border-gray-600 text-gray-400 hover:text-gray-300 transition-colors disabled:opacity-50">Cancel</button>
-                  <button @click="addCredential()" :disabled="credSaving" class="text-xs px-3 py-1.5 rounded bg-indigo-600 hover:bg-indigo-500 text-white transition-colors inline-flex items-center gap-1.5 disabled:opacity-50">
-                    <svg x-show="credSaving" x-cloak class="animate-spin h-3 w-3" fill="none" viewBox="0 0 24 24"><circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"/><path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z"/></svg>
-                    <span x-text="credSaving ? 'Saving...' : 'Save'"></span>
-                  </button>
-                </div>
-              </div>
-            </div>
-          </div>
-        </div>
-        </div><!-- /apikeys sub-tab -->
+        </div><!-- /channels sub-tab -->
 
         <!-- ═══ WALLET SUB-TAB ═══ -->
         <div x-show="systemTab === 'wallet'" x-effect="if (systemTab === 'wallet') fetchWallet()">

--- a/src/dashboard/templates/index.html
+++ b/src/dashboard/templates/index.html
@@ -2592,6 +2592,13 @@
                 <code class="text-green-400/70 font-mono">POST</code><code class="text-gray-400 font-mono">/api/inbound/{endpoint_id}</code><span class="text-gray-500">Trigger an agent workflow. Requires <code class="bg-gray-800 px-0.5 rounded">X-Signature</code> header (no API key needed)</span>
               </div>
             </div>
+            <div class="space-y-2">
+              <div class="text-[10px] text-gray-600 uppercase tracking-wider font-medium">Outbound Webhook Payload</div>
+              <div class="text-[11px] text-gray-500 leading-relaxed">
+                Events POST to your URL with <code class="bg-gray-800 px-0.5 rounded">X-OpenLegion-Signature: sha256=HMAC</code> and <code class="bg-gray-800 px-0.5 rounded">X-OpenLegion-Event</code> headers.
+                Body: <code class="bg-gray-800 px-1 rounded text-gray-400">{"event", "agent", "data", "timestamp", "delivery_id"}</code>
+              </div>
+            </div>
           </div>
         </details>
 
@@ -2808,6 +2815,129 @@
                     <svg x-show="endpointCreating" x-cloak class="animate-spin h-3 w-3" fill="none" viewBox="0 0 24 24"><circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"/><path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z"/></svg>
                     <span x-text="endpointCreating ? 'Creating...' : 'Create Endpoint'"></span>
                   </button>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <!-- Outbound Webhooks -->
+        <div class="text-xs text-gray-500 uppercase tracking-wider mb-3 flex items-center gap-1.5 mt-6">Webhooks<span class="setting-hint" tabindex="0">?<span class="setting-hint-text">Send events to external URLs when things happen. OpenLegion POSTs signed JSON payloads with HMAC-SHA256 verification. Events: notification, task_complete, task_failed, agent_state, cron_complete, custom.</span></span></div>
+        <div class="mb-6">
+          <div class="bg-gray-900 border border-gray-800 rounded-lg p-4">
+            <div class="mb-3 pb-3 border-b border-gray-800">
+              <div class="text-sm text-gray-200 font-medium mb-1">Webhooks</div>
+              <div class="text-[12px] text-gray-500 leading-relaxed">Send events to external URLs. Each delivery includes an <code class="bg-gray-800 px-1 rounded text-gray-400">X-OpenLegion-Signature</code> HMAC-SHA256 header for verification.</div>
+            </div>
+            <div class="space-y-2 mb-3">
+              <template x-for="wh in outboundWebhooks" :key="wh.id">
+                <div>
+                  <div x-show="editingOutboundId !== wh.id" class="flex items-center gap-3 text-xs group py-2 px-2 -mx-2 rounded-md hover:bg-gray-800/40 transition-colors border-b border-gray-800/30 last:border-0">
+                    <span class="w-2 h-2 rounded-full shrink-0" :class="wh.enabled !== false ? 'bg-green-400/70' : 'bg-gray-600'"></span>
+                    <span class="text-gray-200 font-medium shrink-0" x-text="wh.name"></span>
+                    <span class="text-indigo-300/80 text-[10px] font-mono flex-1 truncate bg-indigo-950/30 px-2 py-0.5 rounded border border-indigo-900/50" x-text="wh.url" :title="wh.url"></span>
+                    <template x-for="ev in (wh.events || [])" :key="ev">
+                      <span class="text-[9px] px-1.5 py-0.5 rounded-full bg-cyan-900/40 text-cyan-400 border border-cyan-800/30" x-text="ev"></span>
+                    </template>
+                    <span x-show="wh.enabled === false" class="text-[9px] px-1.5 py-0.5 rounded-full bg-gray-800 text-gray-500">disabled</span>
+                    <button @click="editOutboundWebhook(wh)" class="opacity-0 group-hover:opacity-100 focus:opacity-100 text-[10px] px-1.5 py-0.5 rounded bg-gray-800 hover:bg-gray-700 text-gray-400 hover:text-gray-200 transition-all shrink-0">Edit</button>
+                    <button @click="testOutboundWebhook(wh.id)" class="opacity-0 group-hover:opacity-100 focus:opacity-100 text-[10px] px-1.5 py-0.5 rounded bg-gray-800 hover:bg-indigo-900/40 text-gray-400 hover:text-indigo-300 transition-all shrink-0">Test</button>
+                    <button @click="deleteOutboundWebhook(wh.id, wh.name)" class="opacity-0 group-hover:opacity-100 focus:opacity-100 text-[10px] px-1.5 py-0.5 rounded bg-gray-800 hover:bg-red-900/30 text-gray-400 hover:text-red-400 transition-all shrink-0">Delete</button>
+                  </div>
+                  <!-- Inline edit form -->
+                  <div x-show="editingOutboundId === wh.id" x-transition class="bg-gray-800/30 border border-gray-800 rounded-lg p-3 mt-1 mb-2">
+                    <div class="text-xs text-gray-500 mb-2">Edit webhook</div>
+                    <div class="flex gap-2 mb-2">
+                      <input type="text" x-model="outboundEditName" :disabled="outboundSaving" class="dash-input text-xs flex-1" placeholder="Webhook name">
+                      <input type="url" x-model="outboundEditUrl" :disabled="outboundSaving" class="dash-input text-xs flex-1" placeholder="https://example.com/hook">
+                    </div>
+                    <div class="text-[10px] text-gray-500 mb-1">Event types:</div>
+                    <div class="flex flex-wrap gap-2 mb-2">
+                      <template x-for="et in ['notification','task_complete','task_failed','agent_state','cron_complete','custom']" :key="et">
+                        <label class="flex items-center gap-1 text-[11px] text-gray-400 cursor-pointer select-none">
+                          <input type="checkbox" :value="et" x-model="outboundEditEvents" :disabled="outboundSaving" class="rounded border-gray-700 bg-gray-800 text-indigo-500 focus:ring-indigo-500/30 w-3 h-3">
+                          <span x-text="et"></span>
+                        </label>
+                      </template>
+                    </div>
+                    <div class="text-[10px] text-gray-500 mb-1">Agent filter (empty = all agents):</div>
+                    <div class="flex flex-wrap gap-2 mb-2">
+                      <template x-for="a in agents" :key="a.id">
+                        <label class="flex items-center gap-1 text-[11px] text-gray-400 cursor-pointer select-none">
+                          <input type="checkbox" :value="a.id" x-model="outboundEditAgentFilter" :disabled="outboundSaving" class="rounded border-gray-700 bg-gray-800 text-indigo-500 focus:ring-indigo-500/30 w-3 h-3">
+                          <span x-text="a.id"></span>
+                        </label>
+                      </template>
+                    </div>
+                    <label class="flex items-center gap-2 text-xs text-gray-400 mb-3 cursor-pointer select-none">
+                      <input type="checkbox" x-model="outboundEditEnabled" :disabled="outboundSaving" class="rounded border-gray-700 bg-gray-800 text-indigo-500 focus:ring-indigo-500/30">
+                      Enabled
+                    </label>
+                    <div class="flex justify-end gap-2">
+                      <button @click="cancelOutboundEdit()" :disabled="outboundSaving" class="text-xs px-3 py-1.5 rounded border border-gray-700 hover:border-gray-600 text-gray-400 hover:text-gray-300 transition-colors disabled:opacity-50">Cancel</button>
+                      <button @click="saveOutboundEdit()" :disabled="outboundSaving" class="text-xs px-3 py-1.5 rounded bg-indigo-600 hover:bg-indigo-500 text-white transition-colors inline-flex items-center gap-1.5 disabled:opacity-50">
+                        <svg x-show="outboundSaving" x-cloak class="animate-spin h-3 w-3" fill="none" viewBox="0 0 24 24"><circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"/><path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z"/></svg>
+                        <span x-text="outboundSaving ? 'Saving...' : 'Save'"></span>
+                      </button>
+                    </div>
+                  </div>
+                </div>
+              </template>
+              <div x-show="outboundWebhooks.length === 0" class="text-gray-600 text-sm py-2 text-center">No outbound webhooks configured</div>
+            </div>
+            <div class="border-t border-gray-800 pt-3">
+              <div class="flex gap-2">
+                <button x-show="!showOutboundForm" @click="showOutboundForm = true; cancelOutboundEdit()" class="text-xs px-3 py-1.5 rounded border border-gray-700 hover:border-gray-600 text-gray-400 hover:text-gray-300 transition-colors">+ Add Webhook</button>
+                <button @click="showDeliveries = !showDeliveries; if (showDeliveries) fetchDeliveries()" class="text-xs px-3 py-1.5 rounded border border-gray-700 hover:border-gray-600 text-gray-400 hover:text-gray-300 transition-colors" x-text="showDeliveries ? 'Hide Deliveries' : 'Recent Deliveries'"></button>
+              </div>
+              <div x-show="showOutboundForm" x-transition class="mt-3">
+                <div class="text-xs text-gray-500 mb-2">New webhook</div>
+                <div class="flex gap-2 mb-2">
+                  <input type="text" x-model="outboundFormName" :disabled="outboundCreating" class="dash-input text-xs flex-1" placeholder="Webhook name">
+                  <input type="url" x-model="outboundFormUrl" :disabled="outboundCreating" class="dash-input text-xs flex-1" placeholder="https://example.com/hook">
+                </div>
+                <div class="text-[10px] text-gray-500 mb-1">Event types:</div>
+                <div class="flex flex-wrap gap-2 mb-2">
+                  <template x-for="et in ['notification','task_complete','task_failed','agent_state','cron_complete','custom']" :key="et">
+                    <label class="flex items-center gap-1 text-[11px] text-gray-400 cursor-pointer select-none">
+                      <input type="checkbox" :value="et" x-model="outboundFormEvents" :disabled="outboundCreating" class="rounded border-gray-700 bg-gray-800 text-indigo-500 focus:ring-indigo-500/30 w-3 h-3">
+                      <span x-text="et"></span>
+                    </label>
+                  </template>
+                </div>
+                <div class="text-[10px] text-gray-500 mb-1">Agent filter (empty = all agents):</div>
+                <div class="flex flex-wrap gap-2 mb-3">
+                  <template x-for="a in agents" :key="a.id">
+                    <label class="flex items-center gap-1 text-[11px] text-gray-400 cursor-pointer select-none">
+                      <input type="checkbox" :value="a.id" x-model="outboundFormAgentFilter" :disabled="outboundCreating" class="rounded border-gray-700 bg-gray-800 text-indigo-500 focus:ring-indigo-500/30 w-3 h-3">
+                      <span x-text="a.id"></span>
+                    </label>
+                  </template>
+                </div>
+                <div class="flex justify-between">
+                  <button @click="showOutboundForm = false; outboundFormName = ''; outboundFormUrl = ''; outboundFormEvents = []; outboundFormAgentFilter = []" :disabled="outboundCreating" class="text-xs px-3 py-1.5 rounded border border-gray-700 hover:border-gray-600 text-gray-400 hover:text-gray-300 transition-colors disabled:opacity-50">Cancel</button>
+                  <button @click="createOutboundWebhook()" :disabled="outboundCreating" class="text-xs px-3 py-1.5 rounded bg-indigo-600 hover:bg-indigo-500 text-white transition-colors inline-flex items-center gap-1.5 disabled:opacity-50">
+                    <svg x-show="outboundCreating" x-cloak class="animate-spin h-3 w-3" fill="none" viewBox="0 0 24 24"><circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"/><path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z"/></svg>
+                    <span x-text="outboundCreating ? 'Creating...' : 'Create Webhook'"></span>
+                  </button>
+                </div>
+              </div>
+              <!-- Recent Deliveries -->
+              <div x-show="showDeliveries" x-transition class="mt-3">
+                <div class="text-xs text-gray-500 mb-2">Recent Deliveries</div>
+                <div class="max-h-48 overflow-y-auto space-y-1">
+                  <template x-for="d in outboundDeliveries.slice().reverse()" :key="d.delivery_id">
+                    <div class="flex items-center gap-2 text-[11px] py-1 px-2 rounded hover:bg-gray-800/30">
+                      <span class="shrink-0" :class="d.status === 'delivered' ? 'text-green-400' : 'text-red-400'" x-text="d.status === 'delivered' ? '&#10003;' : '&#10007;'"></span>
+                      <span class="text-gray-500 shrink-0" x-text="d.timestamp ? d.timestamp.split('T')[1]?.slice(0,8) : ''"></span>
+                      <span class="text-cyan-400/80 shrink-0" x-text="d.event"></span>
+                      <span class="text-gray-400 shrink-0" x-text="d.agent"></span>
+                      <span class="text-gray-600 flex-1 truncate" x-text="d.subscription_id"></span>
+                      <span x-show="d.response_code" class="text-gray-500 text-[10px]" x-text="d.response_code"></span>
+                      <span x-show="d.error" class="text-red-400/70 text-[10px] truncate max-w-[200px]" :title="d.error" x-text="d.error"></span>
+                    </div>
+                  </template>
+                  <div x-show="outboundDeliveries.length === 0" class="text-gray-600 text-sm py-2 text-center">No recent deliveries</div>
                 </div>
               </div>
             </div>

--- a/src/host/api_endpoints.py
+++ b/src/host/api_endpoints.py
@@ -1,9 +1,9 @@
-"""Named webhook endpoints that dispatch to agents.
+"""Named API endpoints that dispatch to agents.
 
-Each webhook gets a unique URL. External services POST payloads to it,
+Each endpoint gets a unique URL. External services POST payloads to it,
 and the mesh routes the content to the configured agent as a chat message.
 
-State persisted to config/webhooks.json.
+State persisted to config/api_endpoints.json.
 """
 
 from __future__ import annotations
@@ -17,27 +17,28 @@ from datetime import datetime, timezone
 from pathlib import Path
 
 from fastapi import APIRouter, HTTPException, Request
+from fastapi.responses import JSONResponse
 
 from src.shared.utils import generate_id, sanitize_for_prompt, setup_logging
 
-logger = setup_logging("host.webhooks")
+logger = setup_logging("host.api_endpoints")
 
 
 def _build_message(hook: dict, body_json: str, *, test: bool = False) -> str:
     """Build the dispatch message from hook config and payload."""
-    label = f"Webhook '{hook['name']}'" + (" (test)" if test else "") + " received:"
+    label = f"API endpoint '{hook['name']}'" + (" (test)" if test else "") + " received:"
     instructions = hook.get("instructions", "").strip()
     suffix = instructions if instructions else "Process this webhook payload."
     message = f"{label}\n```json\n{body_json[:3000]}\n```\n{suffix}"
     return sanitize_for_prompt(message)
 
 
-class WebhookManager:
-    """Manages named webhook endpoints that trigger agent actions."""
+class ApiEndpointManager:
+    """Manages named API endpoints that trigger agent actions."""
 
     def __init__(
         self,
-        config_path: str = "config/webhooks.json",
+        config_path: str = "config/api_endpoints.json",
         dispatch_fn: Callable | None = None,
     ):
         self.config_path = Path(config_path)
@@ -47,17 +48,26 @@ class WebhookManager:
 
     def _load(self) -> None:
         if not self.config_path.exists():
+            # Auto-migrate from old config path
+            old_path = self.config_path.parent / "webhooks.json"
+            if old_path.exists():
+                try:
+                    self.hooks = json.loads(old_path.read_text()).get("hooks", {})
+                    self._save()
+                    logger.info("Migrated config from %s to %s", old_path, self.config_path)
+                except Exception as e:
+                    logger.warning(f"Failed to migrate webhook config: {e}")
             return
         try:
             self.hooks = json.loads(self.config_path.read_text()).get("hooks", {})
         except Exception as e:
-            logger.warning(f"Failed to load webhook config: {e}")
+            logger.warning(f"Failed to load API endpoint config: {e}")
 
     def _save(self) -> None:
         self.config_path.parent.mkdir(parents=True, exist_ok=True)
         self.config_path.write_text(json.dumps({"hooks": self.hooks}, indent=2) + "\n")
 
-    def add_hook(
+    def add_endpoint(
         self,
         agent: str,
         name: str,
@@ -79,17 +89,17 @@ class WebhookManager:
             hook["instructions"] = instructions.strip()
         self.hooks[hook_id] = hook
         self._save()
-        logger.info(f"Added webhook {hook_id}: agent={agent} name={name}")
+        logger.info(f"Added API endpoint {hook_id}: agent={agent} name={name}")
         return hook
 
-    def remove_hook(self, hook_id: str) -> bool:
+    def remove_endpoint(self, hook_id: str) -> bool:
         if hook_id not in self.hooks:
             return False
         del self.hooks[hook_id]
         self._save()
         return True
 
-    def update_hook(
+    def update_endpoint(
         self,
         hook_id: str,
         *,
@@ -99,7 +109,7 @@ class WebhookManager:
         require_signature: bool | None = None,
         regenerate_secret: bool = False,
     ) -> dict | None:
-        """Update an existing webhook's configuration.
+        """Update an existing endpoint's configuration.
 
         Only provided fields are changed. Returns updated hook dict with
         secret included only when a new secret was generated, or None if
@@ -138,44 +148,44 @@ class WebhookManager:
             new_secret = True
 
         self._save()
-        logger.info("Updated webhook %s", hook_id)
+        logger.info("Updated API endpoint %s", hook_id)
 
         result = dict(hook)
         if not new_secret:
             result.pop("secret", None)
         return result
 
-    def list_hooks(self) -> list[dict]:
+    def list_endpoints(self) -> list[dict]:
         return [dict(h) for h in self.hooks.values()]
 
     def create_router(self) -> APIRouter:
-        """Create a FastAPI router for webhook endpoints."""
-        router = APIRouter(prefix="/webhook")
+        """Create a FastAPI router for API inbound endpoints."""
+        router = APIRouter()
         manager = self
 
-        _MAX_WEBHOOK_BODY = 1_048_576  # 1 MB
+        _MAX_BODY = 1_048_576  # 1 MB
 
-        @router.post("/hook/{hook_id}")
-        async def receive_webhook(hook_id: str, request: Request) -> dict:
-            hook = manager.hooks.get(hook_id)
+        async def _handle_inbound(endpoint_id: str, request: Request) -> dict:
+            hook = manager.hooks.get(endpoint_id)
             if not hook:
-                raise HTTPException(status_code=404, detail="Unknown webhook")
+                raise HTTPException(status_code=404, detail="Unknown endpoint")
 
             content_length = request.headers.get("content-length")
             if content_length:
                 try:
-                    if int(content_length) > _MAX_WEBHOOK_BODY:
+                    if int(content_length) > _MAX_BODY:
                         raise HTTPException(status_code=413, detail="Payload too large")
                 except ValueError:
                     pass  # Malformed header; body-length check below is authoritative
             raw_body = await request.body()
-            if len(raw_body) > _MAX_WEBHOOK_BODY:
+            if len(raw_body) > _MAX_BODY:
                 raise HTTPException(status_code=413, detail="Payload too large")
 
             # HMAC-SHA256 signature verification (when hook has a secret)
             hook_secret = hook.get("secret")
             if hook_secret:
-                sig_header = request.headers.get("x-webhook-signature", "")
+                # Accept x-signature first, fall back to x-webhook-signature
+                sig_header = request.headers.get("x-signature") or request.headers.get("x-webhook-signature", "")
                 expected = hmac.new(
                     hook_secret.encode(), raw_body, hashlib.sha256,
                 ).hexdigest()
@@ -185,7 +195,7 @@ class WebhookManager:
             try:
                 body = json.loads(raw_body)
             except (json.JSONDecodeError, UnicodeDecodeError) as e:
-                logger.debug("Webhook body is not valid JSON, using raw: %s", e)
+                logger.debug("API endpoint body is not valid JSON, using raw: %s", e)
                 body = {"raw": raw_body.decode(errors="replace")[:5000]}
 
             hook["call_count"] = hook.get("call_count", 0) + 1
@@ -198,10 +208,20 @@ class WebhookManager:
 
             return {"status": "processed", "hook": hook["name"]}
 
+        @router.post("/api/inbound/{endpoint_id}")
+        async def receive_inbound(endpoint_id: str, request: Request) -> dict:
+            return await _handle_inbound(endpoint_id, request)
+
+        @router.post("/webhook/hook/{endpoint_id}")
+        async def receive_webhook_compat(endpoint_id: str, request: Request) -> JSONResponse:
+            """Deprecated: use /api/inbound/{endpoint_id} instead."""
+            result = await _handle_inbound(endpoint_id, request)
+            return JSONResponse(content=result, headers={"Deprecation": "true"})
+
         return router
 
-    async def test_hook(self, hook_id: str, payload: dict) -> dict | None:
-        """Manually fire a webhook for testing."""
+    async def test_endpoint(self, hook_id: str, payload: dict) -> dict | None:
+        """Manually fire an endpoint for testing."""
         hook = self.hooks.get(hook_id)
         if not hook:
             return None

--- a/src/host/api_endpoints.py
+++ b/src/host/api_endpoints.py
@@ -160,7 +160,7 @@ class ApiEndpointManager:
 
     def create_router(self) -> APIRouter:
         """Create a FastAPI router for API inbound endpoints."""
-        router = APIRouter()
+        router = APIRouter(tags=["Inbound Dispatch"])
         manager = self
 
         _MAX_BODY = 1_048_576  # 1 MB
@@ -208,11 +208,17 @@ class ApiEndpointManager:
 
             return {"status": "processed", "hook": hook["name"]}
 
-        @router.post("/api/inbound/{endpoint_id}")
+        @router.post("/api/inbound/{endpoint_id}", summary="Dispatch payload to agent")
         async def receive_inbound(endpoint_id: str, request: Request) -> dict:
+            """POST a JSON payload to trigger the configured agent.
+
+            If the endpoint requires signature verification, include an
+            ``X-Signature`` header with the HMAC-SHA256 hex digest of the raw
+            request body signed with the endpoint secret.
+            """
             return await _handle_inbound(endpoint_id, request)
 
-        @router.post("/webhook/hook/{endpoint_id}")
+        @router.post("/webhook/hook/{endpoint_id}", deprecated=True, summary="Dispatch payload (deprecated)")
         async def receive_webhook_compat(endpoint_id: str, request: Request) -> JSONResponse:
             """Deprecated: use /api/inbound/{endpoint_id} instead."""
             result = await _handle_inbound(endpoint_id, request)

--- a/src/host/cron.py
+++ b/src/host/cron.py
@@ -510,6 +510,11 @@ class CronScheduler:
                     logger.info(f"Cron {job.id} executed for agent '{job.agent}'")
 
                 self._emit_cron_change("executed", job)
+                if self._event_bus:
+                    self._event_bus.emit(
+                        "cron_complete", agent=job.agent,
+                        data={"job_id": job.id, "job_name": job.message[:200]},
+                    )
                 return response
             except Exception as e:
                 job.error_count += 1

--- a/src/host/outbound_webhooks.py
+++ b/src/host/outbound_webhooks.py
@@ -1,0 +1,407 @@
+"""Outbound webhook delivery — POST events to registered third-party URLs.
+
+Users register subscriptions (URL + event types). When matching events
+occur, the manager queues delivery and POSTs signed payloads with retry.
+
+State persisted to config/outbound_webhooks.json.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import hmac
+import ipaddress
+import json
+import secrets
+import socket
+from collections import deque
+from datetime import datetime, timezone
+from pathlib import Path
+from urllib.parse import urlparse
+
+import httpx
+
+from src.shared.utils import generate_id, setup_logging
+
+logger = setup_logging("host.outbound_webhooks")
+
+VALID_EVENT_TYPES = frozenset({
+    "notification",    # anything through notify_user
+    "task_complete",   # agent task finished successfully
+    "task_failed",     # agent task errored/timed out
+    "agent_state",     # agent state changes
+    "cron_complete",   # scheduled cron job finished
+    "custom",          # agent-emitted custom events
+})
+
+_CGNAT_NETWORK = ipaddress.IPv4Network("100.64.0.0/10")
+
+_RETRY_DELAYS = (5, 30, 120)  # seconds between retry attempts
+_DELIVERY_TIMEOUT = 10  # seconds per attempt
+_RING_BUFFER_SIZE = 200
+
+
+def _is_blocked_ip(ip: ipaddress.IPv4Address | ipaddress.IPv6Address) -> bool:
+    """Return True if the IP is in a range that should be blocked for SSRF."""
+    if (ip.is_private or ip.is_loopback or ip.is_link_local
+            or ip.is_reserved or ip.is_unspecified or ip.is_multicast):
+        return True
+    if isinstance(ip, ipaddress.IPv4Address) and ip in _CGNAT_NETWORK:
+        return True
+    if isinstance(ip, ipaddress.IPv6Address) and ip.ipv4_mapped:
+        mapped = ip.ipv4_mapped
+        if (mapped.is_private or mapped.is_loopback or mapped.is_link_local
+                or mapped.is_reserved or mapped.is_unspecified or mapped.is_multicast):
+            return True
+        if mapped in _CGNAT_NETWORK:
+            return True
+    if isinstance(ip, ipaddress.IPv6Address) and ip.sixtofour:
+        embedded = ip.sixtofour
+        if (embedded.is_private or embedded.is_loopback or embedded.is_link_local
+                or embedded.is_reserved or embedded.is_unspecified or embedded.is_multicast):
+            return True
+        if embedded in _CGNAT_NETWORK:
+            return True
+    if isinstance(ip, ipaddress.IPv6Address) and ip.teredo:
+        _, teredo_client = ip.teredo
+        if (teredo_client.is_private or teredo_client.is_loopback or teredo_client.is_link_local
+                or teredo_client.is_reserved or teredo_client.is_unspecified or teredo_client.is_multicast):
+            return True
+        if teredo_client in _CGNAT_NETWORK:
+            return True
+    return False
+
+
+def _check_url_ssrf(url: str) -> str | None:
+    """Resolve URL hostname and check for SSRF. Returns error string or None."""
+    parsed = urlparse(url)
+    hostname = parsed.hostname
+    if not hostname:
+        return "Malformed URL"
+    # If hostname is an IP literal, validate directly
+    try:
+        ip = ipaddress.ip_address(hostname)
+        if _is_blocked_ip(ip):
+            return f"Blocked IP: {ip}"
+        return None
+    except ValueError:
+        pass
+    # DNS resolution
+    try:
+        infos = socket.getaddrinfo(hostname, None, socket.AF_UNSPEC, socket.SOCK_STREAM)
+    except socket.gaierror:
+        return f"DNS resolution failed for {hostname}"
+    for info in infos:
+        addr = info[4][0]
+        try:
+            ip = ipaddress.ip_address(addr)
+            if _is_blocked_ip(ip):
+                return f"Blocked IP: {ip} (resolved from {hostname})"
+        except ValueError:
+            continue
+    return None
+
+
+class OutboundWebhookManager:
+    """Manages outbound webhook subscriptions and event delivery."""
+
+    def __init__(self, config_path: str = "config/outbound_webhooks.json"):
+        self.config_path = Path(config_path)
+        self.subscriptions: dict[str, dict] = {}
+        self._queue: asyncio.Queue = asyncio.Queue()
+        self._client: httpx.AsyncClient | None = None
+        self._worker_task: asyncio.Task | None = None
+        self._stopping = False
+        self._deliveries: deque[dict] = deque(maxlen=_RING_BUFFER_SIZE)
+        self._load()
+
+    def _load(self) -> None:
+        if not self.config_path.exists():
+            return
+        try:
+            data = json.loads(self.config_path.read_text())
+            for sub in data.get("subscriptions", []):
+                self.subscriptions[sub["id"]] = sub
+        except Exception as e:
+            logger.warning("Failed to load outbound webhook config: %s", e)
+
+    def _save(self) -> None:
+        self.config_path.parent.mkdir(parents=True, exist_ok=True)
+        data = {"subscriptions": list(self.subscriptions.values())}
+        self.config_path.write_text(json.dumps(data, indent=2) + "\n")
+
+    def add_subscription(
+        self,
+        name: str,
+        url: str,
+        events: list[str],
+        agent_filter: list[str] | None = None,
+    ) -> dict:
+        """Register a new webhook subscription. Returns the subscription dict."""
+        if not name or not name.strip():
+            raise ValueError("name must not be empty")
+        if not url or not url.strip():
+            raise ValueError("url must not be empty")
+        parsed = urlparse(url.strip())
+        if parsed.scheme != "https":
+            raise ValueError("URL must use https")
+        invalid_events = set(events) - VALID_EVENT_TYPES
+        if invalid_events:
+            raise ValueError(f"Invalid event types: {', '.join(sorted(invalid_events))}")
+        if not events:
+            raise ValueError("At least one event type is required")
+
+        sub_id = generate_id("owh")[:16]
+        sub: dict = {
+            "id": sub_id,
+            "name": name.strip(),
+            "url": url.strip(),
+            "events": list(events),
+            "agent_filter": list(agent_filter or []),
+            "secret": secrets.token_hex(32),
+            "enabled": True,
+            "created_at": datetime.now(timezone.utc).isoformat(),
+            "delivery_count": 0,
+            "last_delivered_at": None,
+            "last_error": None,
+        }
+        self.subscriptions[sub_id] = sub
+        self._save()
+        logger.info("Added outbound webhook %s: name=%s url=%s", sub_id, name, url)
+        return sub
+
+    def remove_subscription(self, sub_id: str) -> bool:
+        if sub_id not in self.subscriptions:
+            return False
+        del self.subscriptions[sub_id]
+        self._save()
+        logger.info("Removed outbound webhook %s", sub_id)
+        return True
+
+    def update_subscription(
+        self,
+        sub_id: str,
+        *,
+        name: str | None = None,
+        url: str | None = None,
+        events: list[str] | None = None,
+        agent_filter: list[str] | None = None,
+        enabled: bool | None = None,
+    ) -> dict | None:
+        """Partial update with validation-before-mutation."""
+        sub = self.subscriptions.get(sub_id)
+        if sub is None:
+            return None
+
+        # Validate before mutating
+        if name is not None and not name.strip():
+            raise ValueError("name must not be empty")
+        if url is not None:
+            parsed = urlparse(url.strip())
+            if parsed.scheme != "https":
+                raise ValueError("URL must use https")
+        if events is not None:
+            invalid = set(events) - VALID_EVENT_TYPES
+            if invalid:
+                raise ValueError(f"Invalid event types: {', '.join(sorted(invalid))}")
+            if not events:
+                raise ValueError("At least one event type is required")
+
+        # Apply mutations
+        if name is not None:
+            sub["name"] = name.strip()
+        if url is not None:
+            sub["url"] = url.strip()
+        if events is not None:
+            sub["events"] = list(events)
+        if agent_filter is not None:
+            sub["agent_filter"] = list(agent_filter)
+        if enabled is not None:
+            sub["enabled"] = enabled
+
+        self._save()
+        logger.info("Updated outbound webhook %s", sub_id)
+        return dict(sub)
+
+    def list_subscriptions(self) -> list[dict]:
+        return [dict(s) for s in self.subscriptions.values()]
+
+    async def test_subscription(self, sub_id: str) -> dict | None:
+        """Immediately deliver a test event (bypasses queue)."""
+        sub = self.subscriptions.get(sub_id)
+        if sub is None:
+            return None
+
+        delivery_id = generate_id("dlv")[:20]
+        payload = {
+            "event": "test",
+            "agent": "system",
+            "data": {"test": True, "message": "Test delivery from OpenLegion"},
+            "timestamp": datetime.now(timezone.utc).isoformat(),
+            "delivery_id": delivery_id,
+        }
+        result = await self._deliver(sub, payload, delivery_id)
+        return result
+
+    def enqueue(self, event_type: str, agent: str, data: dict) -> None:
+        """Called by EventBus listener; filters and queues matching deliveries."""
+        for sub in self.subscriptions.values():
+            if not sub.get("enabled", True):
+                continue
+            if event_type not in sub.get("events", []):
+                continue
+            agent_filter = sub.get("agent_filter", [])
+            if agent_filter and agent not in agent_filter:
+                continue
+            delivery_id = generate_id("dlv")[:20]
+            item = {
+                "subscription": sub,
+                "payload": {
+                    "event": event_type,
+                    "agent": agent,
+                    "data": data,
+                    "timestamp": datetime.now(timezone.utc).isoformat(),
+                    "delivery_id": delivery_id,
+                },
+                "delivery_id": delivery_id,
+            }
+            self._queue.put_nowait(item)
+
+    def start(self) -> None:
+        """Create the background delivery worker task."""
+        self._stopping = False
+        self._worker_task = asyncio.ensure_future(self._delivery_worker())
+        logger.info("Outbound webhook delivery worker started")
+
+    async def stop(self) -> None:
+        """Signal worker to stop and wait for drain."""
+        self._stopping = True
+        # Put a sentinel to unblock the worker if it's waiting on get()
+        self._queue.put_nowait(None)
+        if self._worker_task is not None:
+            try:
+                await asyncio.wait_for(self._worker_task, timeout=30)
+            except (asyncio.TimeoutError, asyncio.CancelledError):
+                self._worker_task.cancel()
+        if self._client and not self._client.is_closed:
+            await self._client.aclose()
+            self._client = None
+
+    def recent_deliveries(self) -> list[dict]:
+        return list(self._deliveries)
+
+    async def _get_client(self) -> httpx.AsyncClient:
+        if self._client is None or self._client.is_closed:
+            self._client = httpx.AsyncClient(
+                limits=httpx.Limits(max_connections=20, max_keepalive_connections=10),
+            )
+        return self._client
+
+    async def _delivery_worker(self) -> None:
+        """Background worker that processes the delivery queue."""
+        while not self._stopping:
+            try:
+                item = await self._queue.get()
+            except asyncio.CancelledError:
+                break
+            if item is None:  # sentinel
+                break
+            sub = item["subscription"]
+            payload = item["payload"]
+            delivery_id = item["delivery_id"]
+            await self._deliver(sub, payload, delivery_id)
+
+    async def _deliver(
+        self, sub: dict, payload: dict, delivery_id: str,
+    ) -> dict:
+        """POST payload to subscription URL with retry."""
+        url = sub["url"]
+        secret = sub["secret"]
+
+        # SSRF check
+        ssrf_error = _check_url_ssrf(url)
+        if ssrf_error:
+            error_msg = f"SSRF blocked: {ssrf_error}"
+            logger.warning("Outbound webhook %s blocked: %s", sub["id"], error_msg)
+            record = {
+                "delivery_id": delivery_id,
+                "subscription_id": sub["id"],
+                "event": payload.get("event", ""),
+                "agent": payload.get("agent", ""),
+                "status": "failed",
+                "response_code": None,
+                "error": error_msg,
+                "timestamp": datetime.now(timezone.utc).isoformat(),
+            }
+            self._deliveries.append(record)
+            sub["last_error"] = error_msg
+            self._save()
+            return record
+
+        body_bytes = json.dumps(payload).encode()
+        signature = hmac.new(
+            secret.encode(), body_bytes, hashlib.sha256,
+        ).hexdigest()
+        headers = {
+            "Content-Type": "application/json",
+            "X-OpenLegion-Signature": f"sha256={signature}",
+            "X-OpenLegion-Event": payload.get("event", ""),
+            "User-Agent": "OpenLegion/1.0",
+        }
+
+        last_error = None
+        response_code = None
+        for attempt in range(len(_RETRY_DELAYS) + 1):
+            try:
+                client = await self._get_client()
+                resp = await client.post(
+                    url, content=body_bytes, headers=headers,
+                    timeout=_DELIVERY_TIMEOUT,
+                )
+                response_code = resp.status_code
+                if 200 <= resp.status_code < 300:
+                    # Success
+                    sub["delivery_count"] = sub.get("delivery_count", 0) + 1
+                    sub["last_delivered_at"] = datetime.now(timezone.utc).isoformat()
+                    sub["last_error"] = None
+                    self._save()
+                    record = {
+                        "delivery_id": delivery_id,
+                        "subscription_id": sub["id"],
+                        "event": payload.get("event", ""),
+                        "agent": payload.get("agent", ""),
+                        "status": "delivered",
+                        "response_code": response_code,
+                        "error": None,
+                        "timestamp": datetime.now(timezone.utc).isoformat(),
+                    }
+                    self._deliveries.append(record)
+                    return record
+                last_error = f"HTTP {resp.status_code}"
+            except Exception as e:
+                last_error = str(e)
+
+            # Retry with backoff if we haven't exhausted attempts
+            if attempt < len(_RETRY_DELAYS):
+                await asyncio.sleep(_RETRY_DELAYS[attempt])
+
+        # All retries exhausted
+        error_msg = f"Failed after {len(_RETRY_DELAYS) + 1} attempts: {last_error}"
+        sub["last_error"] = error_msg
+        self._save()
+        record = {
+            "delivery_id": delivery_id,
+            "subscription_id": sub["id"],
+            "event": payload.get("event", ""),
+            "agent": payload.get("agent", ""),
+            "status": "failed",
+            "response_code": response_code,
+            "error": error_msg,
+            "timestamp": datetime.now(timezone.utc).isoformat(),
+        }
+        self._deliveries.append(record)
+        logger.warning(
+            "Outbound webhook %s delivery failed: %s", sub["id"], error_msg,
+        )
+        return record

--- a/src/host/server.py
+++ b/src/host/server.py
@@ -20,8 +20,9 @@ from collections import defaultdict
 from collections.abc import Callable, Coroutine
 from typing import TYPE_CHECKING
 
-from fastapi import FastAPI, HTTPException, Request, WebSocket
+from fastapi import Depends, FastAPI, HTTPException, Request, WebSocket
 from fastapi.responses import StreamingResponse
+from fastapi.security import APIKeyHeader
 
 from src.host.credentials import is_system_credential
 from src.shared.types import (
@@ -96,7 +97,46 @@ def create_mesh_app(
     api_key_manager: ApiKeyManager | None = None,
 ) -> FastAPI:
     """Create the FastAPI application for the mesh host process."""
-    app = FastAPI(title="OpenLegion Mesh")
+    app = FastAPI(
+        title="OpenLegion API",
+        description=(
+            "External API for integrating with OpenLegion. "
+            "Authenticate with an API key sent as the `X-API-Key` header. "
+            "Create keys in the dashboard under Integrations > Access Keys."
+        ),
+        version="1.0.0",
+        docs_url="/docs",
+        redoc_url="/redoc",
+        openapi_tags=[
+            {
+                "name": "Credentials",
+                "description": (
+                    "Store and manage agent-tier credentials. Credentials are "
+                    "stored as opaque handles — agents reference them by name "
+                    "without seeing raw values."
+                ),
+            },
+            {
+                "name": "Agent Status",
+                "description": (
+                    "Query agent health, queue depth, and budget from external "
+                    "systems."
+                ),
+            },
+            {
+                "name": "Inbound Dispatch",
+                "description": (
+                    "Trigger agent workflows by POSTing JSON payloads to named "
+                    "API endpoints. Optionally secured with HMAC-SHA256 "
+                    "signature verification via the `X-Signature` header."
+                ),
+            },
+        ],
+    )
+    # OpenAPI security scheme — enables "Authorize" button in Swagger UI.
+    # auto_error=False so internal routes that share paths aren't blocked.
+    _api_key_header = APIKeyHeader(name="X-API-Key", auto_error=False)
+
     # Exposed for external callers (dashboard, health monitor) to clean up
     # agent state when agents are removed.
     app.cleanup_agent = lambda agent_id: None  # replaced below
@@ -255,7 +295,7 @@ def create_mesh_app(
 
     # === System Messaging (mesh → agent) ===
 
-    @app.post("/mesh/message")
+    @app.post("/mesh/message", include_in_schema=False)
     async def send_message(msg: AgentMessage, request: Request) -> dict:
         """Route a message to an agent via the mesh router."""
         msg.from_agent = _resolve_agent_id(msg.from_agent, request)
@@ -266,7 +306,7 @@ def create_mesh_app(
     # === Blackboard ===
     # NOTE: list route must be defined BEFORE the {key:path} route to avoid shadowing
 
-    @app.get("/mesh/blackboard/")
+    @app.get("/mesh/blackboard/", include_in_schema=False)
     async def list_blackboard(prefix: str, agent_id: str, request: Request) -> list[dict]:
         """List blackboard entries by prefix."""
         agent_id = _resolve_agent_id(agent_id, request)
@@ -276,7 +316,7 @@ def create_mesh_app(
         entries = blackboard.list_by_prefix(prefix)
         return [e.model_dump(mode="json") for e in entries]
 
-    @app.get("/mesh/blackboard/{key:path}")
+    @app.get("/mesh/blackboard/{key:path}", include_in_schema=False)
     async def read_blackboard(key: str, agent_id: str, request: Request) -> dict:
         """Read a blackboard entry. Agent must have read permission."""
         agent_id = _resolve_agent_id(agent_id, request)
@@ -288,7 +328,7 @@ def create_mesh_app(
             raise HTTPException(404, f"Key not found: {key}")
         return entry.model_dump(mode="json")
 
-    @app.put("/mesh/blackboard/{key:path}")
+    @app.put("/mesh/blackboard/{key:path}", include_in_schema=False)
     async def write_blackboard(
         key: str, agent_id: str, value: dict, request: Request,
         ttl: int | None = None,
@@ -322,7 +362,7 @@ def create_mesh_app(
             _notify_watchers_batch(watchers, notify_msg)
         return entry.model_dump(mode="json")
 
-    @app.delete("/mesh/blackboard/{key:path}")
+    @app.delete("/mesh/blackboard/{key:path}", include_in_schema=False)
     async def delete_blackboard_entry(key: str, agent_id: str, request: Request) -> dict:
         """Delete a blackboard entry. Agent must have write permission."""
         agent_id = _resolve_agent_id(agent_id, request)
@@ -339,7 +379,7 @@ def create_mesh_app(
             raise HTTPException(400, str(e))
         return {"deleted": True, "key": key}
 
-    @app.post("/mesh/blackboard/watch")
+    @app.post("/mesh/blackboard/watch", include_in_schema=False)
     async def watch_blackboard(data: BlackboardWatchRequest, request: Request) -> dict:
         """Register a glob pattern watch on blackboard keys."""
         agent_id = _resolve_agent_id(data.agent_id, request)
@@ -349,7 +389,7 @@ def create_mesh_app(
         blackboard.add_watch(agent_id, pattern)
         return {"watching": True, "pattern": pattern}
 
-    @app.post("/mesh/blackboard/claim")
+    @app.post("/mesh/blackboard/claim", include_in_schema=False)
     async def claim_blackboard(body: BlackboardClaimRequest, request: Request) -> dict:
         """Atomic compare-and-swap write. Returns 409 on version mismatch."""
         agent_id = _resolve_agent_id(body.agent_id, request)
@@ -387,7 +427,7 @@ def create_mesh_app(
 
     # === Pub/Sub ===
 
-    @app.post("/mesh/publish")
+    @app.post("/mesh/publish", include_in_schema=False)
     async def publish_event(event: MeshEvent, request: Request) -> dict:
         """Publish an event to a topic."""
         event.source = _resolve_agent_id(event.source, request)
@@ -433,7 +473,7 @@ def create_mesh_app(
                 ), return_exceptions=True)
         return {"subscribers_notified": len(subscribers)}
 
-    @app.post("/mesh/subscribe")
+    @app.post("/mesh/subscribe", include_in_schema=False)
     async def subscribe(topic: str, agent_id: str, request: Request) -> dict:
         """Subscribe an agent to an event topic."""
         agent_id = _resolve_agent_id(agent_id, request)
@@ -455,7 +495,7 @@ def create_mesh_app(
 
     # === API Proxy ===
 
-    @app.post("/mesh/api", response_model=APIProxyResponse)
+    @app.post("/mesh/api", response_model=APIProxyResponse, include_in_schema=False)
     async def proxy_api_call(request: Request, api_request: APIProxyRequest, agent_id: str) -> APIProxyResponse:
         """Proxy external API calls. Agent never sees credentials."""
         agent_id = _resolve_agent_id(agent_id, request)
@@ -537,7 +577,7 @@ def create_mesh_app(
             event_bus.emit("llm_call", agent=agent_id, data=event_data)
         return result
 
-    @app.post("/mesh/api/stream")
+    @app.post("/mesh/api/stream", include_in_schema=False)
     async def proxy_api_stream(request: Request, api_request: APIProxyRequest, agent_id: str) -> StreamingResponse:
         """Streaming API proxy. Returns SSE stream for LLM completions."""
         agent_id = _resolve_agent_id(agent_id, request)
@@ -571,7 +611,7 @@ def create_mesh_app(
 
     # === Model Health Diagnostic ===
 
-    @app.get("/mesh/model-health")
+    @app.get("/mesh/model-health", include_in_schema=False)
     async def model_health(request: Request) -> list[dict]:
         """Return model failover health status. Mesh-internal diagnostic."""
         _require_any_auth(request)
@@ -581,7 +621,7 @@ def create_mesh_app(
 
     # === Vault (credential management) ===
 
-    @app.post("/mesh/vault/store")
+    @app.post("/mesh/vault/store", include_in_schema=False)
     async def vault_store(data: dict, request: Request) -> dict:
         """Store a credential and return an opaque $CRED{name} handle."""
         agent_id = _resolve_agent_id(data.get("agent_id", ""), request)
@@ -605,7 +645,7 @@ def create_mesh_app(
         handle = credential_vault.add_credential(name, value)
         return {"stored": True, "handle": handle}
 
-    @app.get("/mesh/vault/list")
+    @app.get("/mesh/vault/list", include_in_schema=False)
     async def vault_list(agent_id: str, request: Request) -> dict:
         """List credential names the agent can access (never values)."""
         agent_id = _resolve_agent_id(agent_id, request)
@@ -618,7 +658,7 @@ def create_mesh_app(
         names = [n for n in all_names if permissions.can_access_credential(agent_id, n)]
         return {"credentials": names, "count": len(names)}
 
-    @app.get("/mesh/vault/status/{name}")
+    @app.get("/mesh/vault/status/{name}", include_in_schema=False)
     async def vault_status(name: str, agent_id: str, request: Request) -> dict:
         """Check if a credential exists by name."""
         agent_id = _resolve_agent_id(agent_id, request)
@@ -628,7 +668,7 @@ def create_mesh_app(
             raise HTTPException(503, "No credential vault configured")
         return {"name": name, "exists": credential_vault.has_credential(name)}
 
-    @app.post("/mesh/vault/resolve")
+    @app.post("/mesh/vault/resolve", include_in_schema=False)
     async def vault_resolve(data: dict, request: Request) -> dict:
         """Resolve a credential handle to its value. Internal use only (browser tool)."""
         agent_id = _resolve_agent_id(data.get("agent_id", ""), request)
@@ -657,7 +697,7 @@ def create_mesh_app(
 
     _ws_ref = wallet_service_ref or [None]
 
-    @app.get("/mesh/wallet/address")
+    @app.get("/mesh/wallet/address", include_in_schema=False)
     async def wallet_address(chain: str, agent_id: str, request: Request) -> dict:
         """Get agent's wallet address for a chain."""
         agent_id = _resolve_agent_id(agent_id, request)
@@ -674,7 +714,7 @@ def create_mesh_app(
         except ValueError as e:
             raise HTTPException(400, str(e))
 
-    @app.get("/mesh/wallet/balance")
+    @app.get("/mesh/wallet/balance", include_in_schema=False)
     async def wallet_balance(
         chain: str, agent_id: str, request: Request, token: str = "native",
     ) -> dict:
@@ -692,7 +732,7 @@ def create_mesh_app(
         except ValueError as e:
             raise HTTPException(400, str(e))
 
-    @app.post("/mesh/wallet/read")
+    @app.post("/mesh/wallet/read", include_in_schema=False)
     async def wallet_read(data: dict, request: Request) -> dict:
         """Read-only contract call / account read."""
         agent_id = _resolve_agent_id(data.get("agent_id", ""), request)
@@ -712,7 +752,7 @@ def create_mesh_app(
         except ValueError as e:
             raise HTTPException(400, str(e))
 
-    @app.post("/mesh/wallet/transfer")
+    @app.post("/mesh/wallet/transfer", include_in_schema=False)
     async def wallet_transfer_endpoint(data: dict, request: Request) -> dict:
         """Sign and broadcast a token transfer."""
         agent_id = _resolve_agent_id(data.get("agent_id", ""), request)
@@ -742,7 +782,7 @@ def create_mesh_app(
         except PermissionError as e:
             raise HTTPException(403, str(e))
 
-    @app.post("/mesh/wallet/execute")
+    @app.post("/mesh/wallet/execute", include_in_schema=False)
     async def wallet_execute_endpoint(data: dict, request: Request) -> dict:
         """Sign and broadcast a contract call or Solana transaction."""
         agent_id = _resolve_agent_id(data.get("agent_id", ""), request)
@@ -778,7 +818,7 @@ def create_mesh_app(
 
     # === Agent Registry ===
 
-    @app.post("/mesh/register")
+    @app.post("/mesh/register", include_in_schema=False)
     async def register_agent(data: dict, request: Request) -> dict:
         """Agent registers itself with the mesh on startup."""
         agent_id = _validate_agent_id(data.get("agent_id", ""))
@@ -820,7 +860,7 @@ def create_mesh_app(
     _NOTIFY_MAX_LEN = 2000
     _WS_FILE_NAMES = ("SOUL.md", "INSTRUCTIONS.md", "USER.md", "HEARTBEAT.md", "MEMORY.md")
 
-    @app.post("/mesh/notify")
+    @app.post("/mesh/notify", include_in_schema=False)
     async def notify_user(body: NotifyRequest, request: Request) -> dict:
         """Push a notification from an agent to the user across all channels."""
         body.agent_id = _resolve_agent_id(body.agent_id, request)
@@ -843,25 +883,7 @@ def create_mesh_app(
             raise HTTPException(500, f"Notification failed: {e}")
         return {"sent": True}
 
-    # === Custom Event Emission ===
-
-    _RATE_LIMITS["emit_event"] = (30, 60)
-
-    @app.post("/mesh/emit-event")
-    async def emit_event(request: Request) -> dict:
-        body = await request.json()
-        agent_id = _resolve_agent_id(body.get("agent_id", ""), request)
-        await _check_rate_limit("emit_event", agent_id)
-        event_name = (body.get("event_name") or "").strip()
-        if not event_name:
-            raise HTTPException(400, "event_name is required")
-        data = body.get("data", {})
-        if event_bus:
-            event_bus.emit("custom", agent=agent_id,
-                data={"event_name": event_name, "payload": data})
-        return {"emitted": True}
-
-    @app.get("/mesh/agents")
+    @app.get("/mesh/agents", include_in_schema=False)
     async def list_agents(request: Request, project: str = "", agent_id: str = "") -> dict:
         """List registered agents, optionally scoped by project or agent_id.
 
@@ -901,7 +923,7 @@ def create_mesh_app(
 
     # === Agent Introspection ===
 
-    @app.get("/mesh/introspect")
+    @app.get("/mesh/introspect", include_in_schema=False)
     async def introspect(section: str = "all", request: Request = ...):
         """Return runtime state for the requesting agent.
 
@@ -970,7 +992,7 @@ def create_mesh_app(
 
     # === Project Costs ===
 
-    @app.get("/mesh/costs/project/{project}")
+    @app.get("/mesh/costs/project/{project}", include_in_schema=False)
     async def get_project_costs(project: str, request: Request, period: str = "today") -> dict:
         """Return aggregated cost data for a project."""
         _require_any_auth(request)
@@ -982,7 +1004,7 @@ def create_mesh_app(
 
     # === Cron CRUD ===
 
-    @app.post("/mesh/cron")
+    @app.post("/mesh/cron", include_in_schema=False)
     async def create_cron_job(data: dict, request: Request) -> dict:
         """Create a cron job. Body: {agent_id, schedule, message, heartbeat?}."""
         if cron_scheduler is None:
@@ -1020,7 +1042,7 @@ def create_mesh_app(
             "heartbeat": job.heartbeat, "tool_name": job.tool_name,
         }
 
-    @app.get("/mesh/cron")
+    @app.get("/mesh/cron", include_in_schema=False)
     async def list_cron_jobs(request: Request, agent_id: str | None = None) -> list[dict]:
         """List cron jobs, optionally filtered by agent_id."""
         _require_any_auth(request)
@@ -1031,7 +1053,7 @@ def create_mesh_app(
             jobs = [j for j in jobs if j["agent"] == agent_id]
         return jobs
 
-    @app.put("/mesh/cron/{job_id}")
+    @app.put("/mesh/cron/{job_id}", include_in_schema=False)
     async def update_cron_job(job_id: str, request: Request) -> dict:
         """Update a cron job by ID. Body: fields to update (schedule, enabled, etc)."""
         agent_id = _resolve_agent_id("", request)
@@ -1055,7 +1077,7 @@ def create_mesh_app(
         from dataclasses import asdict
         return {"status": "updated", "job": asdict(job)}
 
-    @app.delete("/mesh/cron/{job_id}")
+    @app.delete("/mesh/cron/{job_id}", include_in_schema=False)
     async def delete_cron_job(job_id: str, request: Request) -> dict:
         """Remove a cron job by ID."""
         agent_id = _resolve_agent_id("", request)
@@ -1074,7 +1096,7 @@ def create_mesh_app(
 
     # === Dynamic Agent Spawning ===
 
-    @app.post("/mesh/spawn")
+    @app.post("/mesh/spawn", include_in_schema=False)
     async def spawn_agent(data: dict, request: Request) -> dict:
         """Spawn an ephemeral agent. Body: {role, system_prompt?, model?, ttl?}."""
         if container_manager is None:
@@ -1130,7 +1152,7 @@ def create_mesh_app(
 
     # === Agent History Access ===
 
-    @app.get("/mesh/agents/{agent_id}/history")
+    @app.get("/mesh/agents/{agent_id}/history", include_in_schema=False)
     async def get_agent_history(agent_id: str, request: Request, requesting_agent: str = "") -> dict:
         """Retrieve an agent's daily logs. Permission-checked."""
         if requesting_agent:
@@ -1162,7 +1184,7 @@ def create_mesh_app(
 
     # === Request Traces ===
 
-    @app.get("/mesh/traces")
+    @app.get("/mesh/traces", include_in_schema=False)
     async def list_traces(request: Request, limit: int = 50) -> list[dict]:
         """Return recent trace events."""
         _require_any_auth(request)
@@ -1170,7 +1192,7 @@ def create_mesh_app(
             return []
         return trace_store.list_recent(limit=limit)
 
-    @app.get("/mesh/traces/{trace_id}")
+    @app.get("/mesh/traces/{trace_id}", include_in_schema=False)
     async def get_trace(trace_id: str, request: Request) -> list[dict]:
         """Return all events for a specific trace."""
         _require_any_auth(request)
@@ -1201,7 +1223,7 @@ def create_mesh_app(
 
     _CRED_NAME_RE = re.compile(r"^[a-zA-Z0-9_.\-]{1,128}$")
 
-    @app.post("/mesh/credentials")
+    @app.post("/mesh/credentials", tags=["Credentials"], summary="Store a credential", dependencies=[Depends(_api_key_header)])
     async def ext_store_credential(request: Request) -> dict:
         """Store an agent-tier credential. Returns an opaque $CRED{name} handle.
 
@@ -1226,7 +1248,7 @@ def create_mesh_app(
         handle = credential_vault.add_credential(name, value)
         return {"stored": True, "handle": handle, "name": name}
 
-    @app.delete("/mesh/credentials/{name}")
+    @app.delete("/mesh/credentials/{name}", tags=["Credentials"], summary="Remove a credential", dependencies=[Depends(_api_key_header)])
     async def ext_remove_credential(name: str, request: Request) -> dict:
         """Remove an agent-tier credential by name."""
         kid = _require_api_key(request)
@@ -1240,7 +1262,7 @@ def create_mesh_app(
             raise HTTPException(404, f"Credential not found: {name}")
         return {"removed": True, "name": name}
 
-    @app.get("/mesh/credentials")
+    @app.get("/mesh/credentials", tags=["Credentials"], summary="List credentials", dependencies=[Depends(_api_key_header)])
     async def ext_list_credentials(request: Request) -> dict:
         """List agent-tier credential names (never values)."""
         kid = _require_api_key(request)
@@ -1250,7 +1272,7 @@ def create_mesh_app(
         names = credential_vault.list_agent_credential_names()
         return {"credentials": names, "count": len(names)}
 
-    @app.get("/mesh/credentials/{name}/exists")
+    @app.get("/mesh/credentials/{name}/exists", tags=["Credentials"], summary="Check credential exists", dependencies=[Depends(_api_key_header)])
     async def ext_credential_exists(name: str, request: Request) -> dict:
         """Check if a credential exists by name (never returns value)."""
         kid = _require_api_key(request)
@@ -1259,7 +1281,7 @@ def create_mesh_app(
             raise HTTPException(503, "Credential vault not configured")
         return {"name": name, "exists": credential_vault.has_credential(name)}
 
-    @app.get("/mesh/agents/{agent_id}/ext-status")
+    @app.get("/mesh/agents/{agent_id}/ext-status", tags=["Agent Status"], summary="Get agent status", dependencies=[Depends(_api_key_header)])
     async def ext_agent_status(agent_id: str, request: Request) -> dict:
         """Query agent status from an external system.
 
@@ -1299,7 +1321,7 @@ def create_mesh_app(
         "wait_for", "press_key", "go_back", "go_forward", "switch_tab",
     })
 
-    @app.post("/mesh/browser/command")
+    @app.post("/mesh/browser/command", include_in_schema=False)
     async def browser_command(request: Request) -> dict:
         """Proxy a browser command to the shared browser service.
 
@@ -1442,7 +1464,7 @@ def create_mesh_app(
                 if hmac.compare_digest(token, expected):
                     raise HTTPException(403, "Agent access denied")
 
-    @app.get("/vnc/{path:path}")
+    @app.get("/vnc/{path:path}", include_in_schema=False)
     async def vnc_http_proxy(path: str, request: Request):
         """Reverse-proxy HTTP requests to KasmVNC (static files)."""
         _reject_agent_tokens(request)

--- a/src/host/server.py
+++ b/src/host/server.py
@@ -843,6 +843,24 @@ def create_mesh_app(
             raise HTTPException(500, f"Notification failed: {e}")
         return {"sent": True}
 
+    # === Custom Event Emission ===
+
+    _RATE_LIMITS["emit_event"] = (30, 60)
+
+    @app.post("/mesh/emit-event")
+    async def emit_event(request: Request) -> dict:
+        body = await request.json()
+        agent_id = _resolve_agent_id(body.get("agent_id", ""), request)
+        await _check_rate_limit("emit_event", agent_id)
+        event_name = (body.get("event_name") or "").strip()
+        if not event_name:
+            raise HTTPException(400, "event_name is required")
+        data = body.get("data", {})
+        if event_bus:
+            event_bus.emit("custom", agent=agent_id,
+                data={"event_name": event_name, "payload": data})
+        return {"emitted": True}
+
     @app.get("/mesh/agents")
     async def list_agents(request: Request, project: str = "", agent_id: str = "") -> dict:
         """List registered agents, optionally scoped by project or agent_id.

--- a/src/host/server.py
+++ b/src/host/server.py
@@ -1223,7 +1223,10 @@ def create_mesh_app(
 
     _CRED_NAME_RE = re.compile(r"^[a-zA-Z0-9_.\-]{1,128}$")
 
-    @app.post("/mesh/credentials", tags=["Credentials"], summary="Store a credential", dependencies=[Depends(_api_key_header)])
+    @app.post(
+        "/mesh/credentials", tags=["Credentials"],
+        summary="Store a credential", dependencies=[Depends(_api_key_header)],
+    )
     async def ext_store_credential(request: Request) -> dict:
         """Store an agent-tier credential. Returns an opaque $CRED{name} handle.
 
@@ -1248,7 +1251,10 @@ def create_mesh_app(
         handle = credential_vault.add_credential(name, value)
         return {"stored": True, "handle": handle, "name": name}
 
-    @app.delete("/mesh/credentials/{name}", tags=["Credentials"], summary="Remove a credential", dependencies=[Depends(_api_key_header)])
+    @app.delete(
+        "/mesh/credentials/{name}", tags=["Credentials"],
+        summary="Remove a credential", dependencies=[Depends(_api_key_header)],
+    )
     async def ext_remove_credential(name: str, request: Request) -> dict:
         """Remove an agent-tier credential by name."""
         kid = _require_api_key(request)
@@ -1262,7 +1268,10 @@ def create_mesh_app(
             raise HTTPException(404, f"Credential not found: {name}")
         return {"removed": True, "name": name}
 
-    @app.get("/mesh/credentials", tags=["Credentials"], summary="List credentials", dependencies=[Depends(_api_key_header)])
+    @app.get(
+        "/mesh/credentials", tags=["Credentials"],
+        summary="List credentials", dependencies=[Depends(_api_key_header)],
+    )
     async def ext_list_credentials(request: Request) -> dict:
         """List agent-tier credential names (never values)."""
         kid = _require_api_key(request)
@@ -1272,7 +1281,10 @@ def create_mesh_app(
         names = credential_vault.list_agent_credential_names()
         return {"credentials": names, "count": len(names)}
 
-    @app.get("/mesh/credentials/{name}/exists", tags=["Credentials"], summary="Check credential exists", dependencies=[Depends(_api_key_header)])
+    @app.get(
+        "/mesh/credentials/{name}/exists", tags=["Credentials"],
+        summary="Check credential exists", dependencies=[Depends(_api_key_header)],
+    )
     async def ext_credential_exists(name: str, request: Request) -> dict:
         """Check if a credential exists by name (never returns value)."""
         kid = _require_api_key(request)
@@ -1281,7 +1293,10 @@ def create_mesh_app(
             raise HTTPException(503, "Credential vault not configured")
         return {"name": name, "exists": credential_vault.has_credential(name)}
 
-    @app.get("/mesh/agents/{agent_id}/ext-status", tags=["Agent Status"], summary="Get agent status", dependencies=[Depends(_api_key_header)])
+    @app.get(
+        "/mesh/agents/{agent_id}/ext-status", tags=["Agent Status"],
+        summary="Get agent status", dependencies=[Depends(_api_key_header)],
+    )
     async def ext_agent_status(agent_id: str, request: Request) -> dict:
         """Query agent status from an external system.
 

--- a/tests/test_api_endpoints.py
+++ b/tests/test_api_endpoints.py
@@ -1,4 +1,4 @@
-"""Tests for WebhookManager: add, remove, update, dispatch, persistence, instructions."""
+"""Tests for ApiEndpointManager: add, remove, update, dispatch, persistence, instructions."""
 
 from __future__ import annotations
 
@@ -12,14 +12,14 @@ import pytest
 from fastapi import APIRouter, HTTPException, Request
 from starlette.testclient import TestClient
 
-from src.host.webhooks import WebhookManager, _build_message
+from src.host.api_endpoints import ApiEndpointManager, _build_message
 
 
 class TestBuildMessage:
     def test_default_suffix(self):
         hook = {"name": "gh-push"}
         msg = _build_message(hook, '{"action": "push"}')
-        assert "Webhook 'gh-push' received:" in msg
+        assert "API endpoint 'gh-push' received:" in msg
         assert "Process this webhook payload." in msg
         assert '"action": "push"' in msg
 
@@ -44,166 +44,166 @@ class TestBuildMessage:
         assert "a" * 3001 not in msg
 
 
-class TestWebhookManager:
+class TestApiEndpointManager:
     def setup_method(self):
         self._tmpdir = tempfile.mkdtemp()
-        self.config_path = f"{self._tmpdir}/webhooks.json"
+        self.config_path = f"{self._tmpdir}/api_endpoints.json"
 
     def teardown_method(self):
         shutil.rmtree(self._tmpdir, ignore_errors=True)
 
-    def test_add_hook(self):
-        mgr = WebhookManager(config_path=self.config_path)
-        hook = mgr.add_hook(agent="researcher", name="github-push")
+    def test_add_endpoint(self):
+        mgr = ApiEndpointManager(config_path=self.config_path)
+        hook = mgr.add_endpoint(agent="researcher", name="github-push")
         assert hook["agent"] == "researcher"
         assert hook["name"] == "github-push"
         assert "id" in hook
         assert len(mgr.hooks) == 1
 
-    def test_add_hook_with_signature(self):
-        mgr = WebhookManager(config_path=self.config_path)
-        hook = mgr.add_hook(agent="test", name="signed", require_signature=True)
+    def test_add_endpoint_with_signature(self):
+        mgr = ApiEndpointManager(config_path=self.config_path)
+        hook = mgr.add_endpoint(agent="test", name="signed", require_signature=True)
         assert "secret" in hook
         assert len(hook["secret"]) == 64  # 32 bytes hex
 
-    def test_add_hook_with_instructions(self):
-        mgr = WebhookManager(config_path=self.config_path)
-        hook = mgr.add_hook(agent="test", name="instr", instructions="Do X then Y.")
+    def test_add_endpoint_with_instructions(self):
+        mgr = ApiEndpointManager(config_path=self.config_path)
+        hook = mgr.add_endpoint(agent="test", name="instr", instructions="Do X then Y.")
         assert hook["instructions"] == "Do X then Y."
 
-    def test_add_hook_blank_instructions_not_stored(self):
-        mgr = WebhookManager(config_path=self.config_path)
-        hook = mgr.add_hook(agent="test", name="blank", instructions="   ")
+    def test_add_endpoint_blank_instructions_not_stored(self):
+        mgr = ApiEndpointManager(config_path=self.config_path)
+        hook = mgr.add_endpoint(agent="test", name="blank", instructions="   ")
         assert "instructions" not in hook
 
     def test_persistence(self):
-        mgr = WebhookManager(config_path=self.config_path)
-        hook = mgr.add_hook(agent="test", name="test-hook")
+        mgr = ApiEndpointManager(config_path=self.config_path)
+        hook = mgr.add_endpoint(agent="test", name="test-hook")
 
-        mgr2 = WebhookManager(config_path=self.config_path)
+        mgr2 = ApiEndpointManager(config_path=self.config_path)
         assert hook["id"] in mgr2.hooks
 
-    def test_remove_hook(self):
-        mgr = WebhookManager(config_path=self.config_path)
-        hook = mgr.add_hook(agent="test", name="test-hook")
-        assert mgr.remove_hook(hook["id"])
+    def test_remove_endpoint(self):
+        mgr = ApiEndpointManager(config_path=self.config_path)
+        hook = mgr.add_endpoint(agent="test", name="test-hook")
+        assert mgr.remove_endpoint(hook["id"])
         assert len(mgr.hooks) == 0
 
     def test_remove_nonexistent(self):
-        mgr = WebhookManager(config_path=self.config_path)
-        assert not mgr.remove_hook("nonexistent")
+        mgr = ApiEndpointManager(config_path=self.config_path)
+        assert not mgr.remove_endpoint("nonexistent")
 
-    def test_list_hooks(self):
-        mgr = WebhookManager(config_path=self.config_path)
-        mgr.add_hook(agent="a", name="hook1")
-        mgr.add_hook(agent="b", name="hook2")
-        hooks = mgr.list_hooks()
+    def test_list_endpoints(self):
+        mgr = ApiEndpointManager(config_path=self.config_path)
+        mgr.add_endpoint(agent="a", name="hook1")
+        mgr.add_endpoint(agent="b", name="hook2")
+        hooks = mgr.list_endpoints()
         assert len(hooks) == 2
 
     @pytest.mark.asyncio
-    async def test_test_hook(self):
+    async def test_test_endpoint(self):
         dispatch = AsyncMock(return_value="processed")
-        mgr = WebhookManager(config_path=self.config_path, dispatch_fn=dispatch)
-        hook = mgr.add_hook(agent="test", name="test-hook")
+        mgr = ApiEndpointManager(config_path=self.config_path, dispatch_fn=dispatch)
+        hook = mgr.add_endpoint(agent="test", name="test-hook")
 
-        result = await mgr.test_hook(hook["id"], {"event": "push"})
+        result = await mgr.test_endpoint(hook["id"], {"event": "push"})
         assert result["status"] == "processed"
         dispatch.assert_called_once()
 
     @pytest.mark.asyncio
-    async def test_test_hook_with_instructions(self):
+    async def test_test_endpoint_with_instructions(self):
         dispatch = AsyncMock(return_value="done")
-        mgr = WebhookManager(config_path=self.config_path, dispatch_fn=dispatch)
-        hook = mgr.add_hook(agent="test", name="instr-hook", instructions="Summarize the event.")
+        mgr = ApiEndpointManager(config_path=self.config_path, dispatch_fn=dispatch)
+        hook = mgr.add_endpoint(agent="test", name="instr-hook", instructions="Summarize the event.")
 
-        await mgr.test_hook(hook["id"], {"event": "push"})
+        await mgr.test_endpoint(hook["id"], {"event": "push"})
         msg = dispatch.call_args[0][1]
         assert "Summarize the event." in msg
         assert "Process this webhook payload." not in msg
 
     @pytest.mark.asyncio
-    async def test_test_nonexistent_hook(self):
-        mgr = WebhookManager(config_path=self.config_path)
-        result = await mgr.test_hook("nonexistent", {})
+    async def test_test_nonexistent_endpoint(self):
+        mgr = ApiEndpointManager(config_path=self.config_path)
+        result = await mgr.test_endpoint("nonexistent", {})
         assert result is None
 
 
-class TestWebhookManagerUpdate:
-    """Tests for WebhookManager.update_hook()."""
+class TestApiEndpointManagerUpdate:
+    """Tests for ApiEndpointManager.update_endpoint()."""
 
     def setup_method(self):
         self._tmpdir = tempfile.mkdtemp()
-        self.config_path = f"{self._tmpdir}/webhooks.json"
+        self.config_path = f"{self._tmpdir}/api_endpoints.json"
 
     def teardown_method(self):
         shutil.rmtree(self._tmpdir, ignore_errors=True)
 
     def test_update_name(self):
-        mgr = WebhookManager(config_path=self.config_path)
-        hook = mgr.add_hook(agent="a", name="old-name")
-        result = mgr.update_hook(hook["id"], name="new-name")
+        mgr = ApiEndpointManager(config_path=self.config_path)
+        hook = mgr.add_endpoint(agent="a", name="old-name")
+        result = mgr.update_endpoint(hook["id"], name="new-name")
         assert result["name"] == "new-name"
         assert mgr.hooks[hook["id"]]["name"] == "new-name"
 
     def test_update_agent(self):
-        mgr = WebhookManager(config_path=self.config_path)
-        hook = mgr.add_hook(agent="old-agent", name="test")
-        result = mgr.update_hook(hook["id"], agent="new-agent")
+        mgr = ApiEndpointManager(config_path=self.config_path)
+        hook = mgr.add_endpoint(agent="old-agent", name="test")
+        result = mgr.update_endpoint(hook["id"], agent="new-agent")
         assert result["agent"] == "new-agent"
         assert mgr.hooks[hook["id"]]["agent"] == "new-agent"
 
     def test_set_instructions(self):
-        mgr = WebhookManager(config_path=self.config_path)
-        hook = mgr.add_hook(agent="a", name="test")
+        mgr = ApiEndpointManager(config_path=self.config_path)
+        hook = mgr.add_endpoint(agent="a", name="test")
         assert "instructions" not in mgr.hooks[hook["id"]]
-        result = mgr.update_hook(hook["id"], instructions="Do something.")
+        result = mgr.update_endpoint(hook["id"], instructions="Do something.")
         assert result["instructions"] == "Do something."
         assert mgr.hooks[hook["id"]]["instructions"] == "Do something."
 
     def test_clear_instructions(self):
-        mgr = WebhookManager(config_path=self.config_path)
-        hook = mgr.add_hook(agent="a", name="test", instructions="Keep this.")
+        mgr = ApiEndpointManager(config_path=self.config_path)
+        hook = mgr.add_endpoint(agent="a", name="test", instructions="Keep this.")
         assert mgr.hooks[hook["id"]]["instructions"] == "Keep this."
-        result = mgr.update_hook(hook["id"], instructions="")
+        result = mgr.update_endpoint(hook["id"], instructions="")
         assert "instructions" not in result
         assert "instructions" not in mgr.hooks[hook["id"]]
 
-    def test_nonexistent_hook(self):
-        mgr = WebhookManager(config_path=self.config_path)
-        assert mgr.update_hook("nonexistent", name="x") is None
+    def test_nonexistent_endpoint(self):
+        mgr = ApiEndpointManager(config_path=self.config_path)
+        assert mgr.update_endpoint("nonexistent", name="x") is None
 
     def test_persistence(self):
-        mgr = WebhookManager(config_path=self.config_path)
-        hook = mgr.add_hook(agent="a", name="original")
-        mgr.update_hook(hook["id"], name="updated")
+        mgr = ApiEndpointManager(config_path=self.config_path)
+        hook = mgr.add_endpoint(agent="a", name="original")
+        mgr.update_endpoint(hook["id"], name="updated")
 
-        mgr2 = WebhookManager(config_path=self.config_path)
+        mgr2 = ApiEndpointManager(config_path=self.config_path)
         assert mgr2.hooks[hook["id"]]["name"] == "updated"
 
     def test_return_is_copy(self):
         """Mutating the returned dict must not affect stored state."""
-        mgr = WebhookManager(config_path=self.config_path)
-        hook = mgr.add_hook(agent="a", name="test")
-        result = mgr.update_hook(hook["id"], name="updated")
+        mgr = ApiEndpointManager(config_path=self.config_path)
+        hook = mgr.add_endpoint(agent="a", name="test")
+        result = mgr.update_endpoint(hook["id"], name="updated")
         result["name"] = "tampered"
         assert mgr.hooks[hook["id"]]["name"] == "updated"
 
     def test_partial_update_preserves_other_fields(self):
-        mgr = WebhookManager(config_path=self.config_path)
-        hook = mgr.add_hook(agent="a", name="test", instructions="Keep me.")
-        mgr.update_hook(hook["id"], name="renamed")
+        mgr = ApiEndpointManager(config_path=self.config_path)
+        hook = mgr.add_endpoint(agent="a", name="test", instructions="Keep me.")
+        mgr.update_endpoint(hook["id"], name="renamed")
         stored = mgr.hooks[hook["id"]]
         assert stored["name"] == "renamed"
         assert stored["agent"] == "a"
         assert stored["instructions"] == "Keep me."
 
 
-class TestWebhookRouter:
-    """Test the FastAPI router created by WebhookManager."""
+class TestApiEndpointRouter:
+    """Test the FastAPI router created by ApiEndpointManager."""
 
     def setup_method(self):
         self._tmpdir = tempfile.mkdtemp()
-        self.config_path = f"{self._tmpdir}/webhooks.json"
+        self.config_path = f"{self._tmpdir}/api_endpoints.json"
 
     def teardown_method(self):
         shutil.rmtree(self._tmpdir, ignore_errors=True)
@@ -211,18 +211,18 @@ class TestWebhookRouter:
     def _make_app(self, dispatch_fn=None):
         from fastapi import FastAPI
 
-        mgr = WebhookManager(config_path=self.config_path, dispatch_fn=dispatch_fn)
+        mgr = ApiEndpointManager(config_path=self.config_path, dispatch_fn=dispatch_fn)
         app = FastAPI()
         app.include_router(mgr.create_router())
         return app, mgr
 
-    def test_receive_webhook_json(self):
+    def test_receive_inbound_json(self):
         dispatch = AsyncMock(return_value="ok")
         app, mgr = self._make_app(dispatch_fn=dispatch)
-        hook = mgr.add_hook(agent="a", name="test")
+        hook = mgr.add_endpoint(agent="a", name="test")
         client = TestClient(app)
 
-        resp = client.post(f"/webhook/hook/{hook['id']}", json={"foo": "bar"})
+        resp = client.post(f"/api/inbound/{hook['id']}", json={"foo": "bar"})
         assert resp.status_code == 200
         data = resp.json()
         assert data["status"] == "processed"
@@ -230,20 +230,32 @@ class TestWebhookRouter:
         msg = dispatch.call_args[0][1]
         assert '"foo": "bar"' in msg
 
-    def test_receive_webhook_unknown_id(self):
+    def test_receive_inbound_unknown_id(self):
         app, _ = self._make_app()
         client = TestClient(app)
-        resp = client.post("/webhook/hook/nonexistent", json={})
+        resp = client.post("/api/inbound/nonexistent", json={})
         assert resp.status_code == 404
 
-    def test_receive_webhook_non_json_body(self):
+    def test_deprecated_webhook_compat_route(self):
         dispatch = AsyncMock(return_value="ok")
         app, mgr = self._make_app(dispatch_fn=dispatch)
-        hook = mgr.add_hook(agent="a", name="raw")
+        hook = mgr.add_endpoint(agent="a", name="test")
+        client = TestClient(app)
+
+        resp = client.post(f"/webhook/hook/{hook['id']}", json={"foo": "bar"})
+        assert resp.status_code == 200
+        assert resp.headers.get("Deprecation") == "true"
+        data = resp.json()
+        assert data["status"] == "processed"
+
+    def test_receive_inbound_non_json_body(self):
+        dispatch = AsyncMock(return_value="ok")
+        app, mgr = self._make_app(dispatch_fn=dispatch)
+        hook = mgr.add_endpoint(agent="a", name="raw")
         client = TestClient(app)
 
         resp = client.post(
-            f"/webhook/hook/{hook['id']}",
+            f"/api/inbound/{hook['id']}",
             content=b"not json",
             headers={"Content-Type": "text/plain"},
         )
@@ -251,17 +263,33 @@ class TestWebhookRouter:
         msg = dispatch.call_args[0][1]
         assert "not json" in msg
 
-    def test_hmac_signature_valid(self):
+    def test_hmac_signature_valid_x_signature(self):
         dispatch = AsyncMock(return_value="ok")
         app, mgr = self._make_app(dispatch_fn=dispatch)
-        hook = mgr.add_hook(agent="a", name="signed", require_signature=True)
+        hook = mgr.add_endpoint(agent="a", name="signed", require_signature=True)
         secret = hook["secret"]
         client = TestClient(app)
 
         body = b'{"event": "push"}'
         sig = hmac.new(secret.encode(), body, hashlib.sha256).hexdigest()
         resp = client.post(
-            f"/webhook/hook/{hook['id']}",
+            f"/api/inbound/{hook['id']}",
+            content=body,
+            headers={"Content-Type": "application/json", "x-signature": sig},
+        )
+        assert resp.status_code == 200
+
+    def test_hmac_signature_valid_legacy_header(self):
+        dispatch = AsyncMock(return_value="ok")
+        app, mgr = self._make_app(dispatch_fn=dispatch)
+        hook = mgr.add_endpoint(agent="a", name="signed", require_signature=True)
+        secret = hook["secret"]
+        client = TestClient(app)
+
+        body = b'{"event": "push"}'
+        sig = hmac.new(secret.encode(), body, hashlib.sha256).hexdigest()
+        resp = client.post(
+            f"/api/inbound/{hook['id']}",
             content=body,
             headers={"Content-Type": "application/json", "x-webhook-signature": sig},
         )
@@ -269,43 +297,43 @@ class TestWebhookRouter:
 
     def test_hmac_signature_invalid(self):
         app, mgr = self._make_app()
-        hook = mgr.add_hook(agent="a", name="signed", require_signature=True)
+        hook = mgr.add_endpoint(agent="a", name="signed", require_signature=True)
         client = TestClient(app)
 
         resp = client.post(
-            f"/webhook/hook/{hook['id']}",
+            f"/api/inbound/{hook['id']}",
             json={"event": "push"},
-            headers={"x-webhook-signature": "bad"},
+            headers={"x-signature": "bad"},
         )
         assert resp.status_code == 401
 
     def test_call_count_increments(self):
         dispatch = AsyncMock(return_value="ok")
         app, mgr = self._make_app(dispatch_fn=dispatch)
-        hook = mgr.add_hook(agent="a", name="counter")
+        hook = mgr.add_endpoint(agent="a", name="counter")
         client = TestClient(app)
 
-        client.post(f"/webhook/hook/{hook['id']}", json={})
-        client.post(f"/webhook/hook/{hook['id']}", json={})
+        client.post(f"/api/inbound/{hook['id']}", json={})
+        client.post(f"/api/inbound/{hook['id']}", json={})
         assert mgr.hooks[hook["id"]]["call_count"] == 2
 
     def test_instructions_in_dispatched_message(self):
         dispatch = AsyncMock(return_value="ok")
         app, mgr = self._make_app(dispatch_fn=dispatch)
-        hook = mgr.add_hook(agent="a", name="instr", instructions="Log the event to Slack.")
+        hook = mgr.add_endpoint(agent="a", name="instr", instructions="Log the event to Slack.")
         client = TestClient(app)
 
-        client.post(f"/webhook/hook/{hook['id']}", json={"type": "deploy"})
+        client.post(f"/api/inbound/{hook['id']}", json={"type": "deploy"})
         msg = dispatch.call_args[0][1]
         assert "Log the event to Slack." in msg
         assert "Process this webhook payload." not in msg
 
     def test_no_dispatch_fn(self):
         app, mgr = self._make_app(dispatch_fn=None)
-        hook = mgr.add_hook(agent="a", name="no-dispatch")
+        hook = mgr.add_endpoint(agent="a", name="no-dispatch")
         client = TestClient(app)
 
-        resp = client.post(f"/webhook/hook/{hook['id']}", json={"x": 1})
+        resp = client.post(f"/api/inbound/{hook['id']}", json={"x": 1})
         assert resp.status_code == 200
         data = resp.json()
         assert "response" not in data  # response redacted for security (U14-4)
@@ -313,141 +341,141 @@ class TestWebhookRouter:
 
     def test_hmac_missing_header_when_required(self):
         app, mgr = self._make_app()
-        hook = mgr.add_hook(agent="a", name="signed", require_signature=True)
+        hook = mgr.add_endpoint(agent="a", name="signed", require_signature=True)
         client = TestClient(app)
 
-        # No x-webhook-signature header at all
-        resp = client.post(f"/webhook/hook/{hook['id']}", json={"event": "push"})
+        # No signature header at all
+        resp = client.post(f"/api/inbound/{hook['id']}", json={"event": "push"})
         assert resp.status_code == 401
 
-    def test_list_hooks_does_not_mutate_stored_data(self):
+    def test_list_endpoints_does_not_mutate_stored_data(self):
         """Callers mutating returned dicts must not pollute the manager's state."""
         app, mgr = self._make_app()
-        mgr.add_hook(agent="a", name="test")
-        hooks = mgr.list_hooks()
+        mgr.add_endpoint(agent="a", name="test")
+        hooks = mgr.list_endpoints()
         # Simulate what a caller might do
         for h in hooks:
-            h["url"] = "http://example.com/webhook/hook/" + h["id"]
+            h["url"] = "http://example.com/api/inbound/" + h["id"]
 
         # The stored hook should NOT have the url field
         stored = list(mgr.hooks.values())[0]
         assert "url" not in stored
 
 
-class TestUpdateHook:
+class TestUpdateEndpoint:
     def setup_method(self):
         self._tmpdir = tempfile.mkdtemp()
-        self.config_path = f"{self._tmpdir}/webhooks.json"
+        self.config_path = f"{self._tmpdir}/api_endpoints.json"
 
     def teardown_method(self):
         shutil.rmtree(self._tmpdir, ignore_errors=True)
 
     def test_update_name(self):
-        mgr = WebhookManager(config_path=self.config_path)
-        hook = mgr.add_hook(agent="test", name="old-name")
-        updated = mgr.update_hook(hook["id"], name="new-name")
+        mgr = ApiEndpointManager(config_path=self.config_path)
+        hook = mgr.add_endpoint(agent="test", name="old-name")
+        updated = mgr.update_endpoint(hook["id"], name="new-name")
         assert updated["name"] == "new-name"
         assert mgr.hooks[hook["id"]]["name"] == "new-name"
 
     def test_update_agent(self):
-        mgr = WebhookManager(config_path=self.config_path)
-        hook = mgr.add_hook(agent="old-agent", name="test")
-        updated = mgr.update_hook(hook["id"], agent="new-agent")
+        mgr = ApiEndpointManager(config_path=self.config_path)
+        hook = mgr.add_endpoint(agent="old-agent", name="test")
+        updated = mgr.update_endpoint(hook["id"], agent="new-agent")
         assert updated["agent"] == "new-agent"
 
     def test_update_instructions_set_change_clear(self):
-        mgr = WebhookManager(config_path=self.config_path)
-        hook = mgr.add_hook(agent="test", name="test")
+        mgr = ApiEndpointManager(config_path=self.config_path)
+        hook = mgr.add_endpoint(agent="test", name="test")
         # Set
-        updated = mgr.update_hook(hook["id"], instructions="Do X.")
+        updated = mgr.update_endpoint(hook["id"], instructions="Do X.")
         assert updated["instructions"] == "Do X."
         # Change
-        updated = mgr.update_hook(hook["id"], instructions="Do Y.")
+        updated = mgr.update_endpoint(hook["id"], instructions="Do Y.")
         assert updated["instructions"] == "Do Y."
         # Clear
-        updated = mgr.update_hook(hook["id"], instructions="")
+        updated = mgr.update_endpoint(hook["id"], instructions="")
         assert "instructions" not in updated
 
     def test_enable_signature(self):
-        mgr = WebhookManager(config_path=self.config_path)
-        hook = mgr.add_hook(agent="test", name="test")
+        mgr = ApiEndpointManager(config_path=self.config_path)
+        hook = mgr.add_endpoint(agent="test", name="test")
         assert "secret" not in hook
-        updated = mgr.update_hook(hook["id"], require_signature=True)
+        updated = mgr.update_endpoint(hook["id"], require_signature=True)
         assert "secret" in updated
         assert len(updated["secret"]) == 64
 
     def test_disable_signature(self):
-        mgr = WebhookManager(config_path=self.config_path)
-        hook = mgr.add_hook(agent="test", name="test", require_signature=True)
+        mgr = ApiEndpointManager(config_path=self.config_path)
+        hook = mgr.add_endpoint(agent="test", name="test", require_signature=True)
         assert "secret" in hook
-        updated = mgr.update_hook(hook["id"], require_signature=False)
+        updated = mgr.update_endpoint(hook["id"], require_signature=False)
         assert "secret" not in updated
         assert "secret" not in mgr.hooks[hook["id"]]
 
     def test_regenerate_secret(self):
-        mgr = WebhookManager(config_path=self.config_path)
-        hook = mgr.add_hook(agent="test", name="test", require_signature=True)
+        mgr = ApiEndpointManager(config_path=self.config_path)
+        hook = mgr.add_endpoint(agent="test", name="test", require_signature=True)
         old_secret = hook["secret"]
-        updated = mgr.update_hook(hook["id"], regenerate_secret=True)
+        updated = mgr.update_endpoint(hook["id"], regenerate_secret=True)
         assert "secret" in updated
         assert updated["secret"] != old_secret
 
     def test_regenerate_secret_ignored_when_unsigned(self):
-        mgr = WebhookManager(config_path=self.config_path)
-        hook = mgr.add_hook(agent="test", name="test")
-        updated = mgr.update_hook(hook["id"], regenerate_secret=True)
+        mgr = ApiEndpointManager(config_path=self.config_path)
+        hook = mgr.add_endpoint(agent="test", name="test")
+        updated = mgr.update_endpoint(hook["id"], regenerate_secret=True)
         assert "secret" not in updated
         assert "secret" not in mgr.hooks[hook["id"]]
 
     def test_update_preserves_call_count(self):
-        mgr = WebhookManager(config_path=self.config_path)
-        hook = mgr.add_hook(agent="test", name="test")
+        mgr = ApiEndpointManager(config_path=self.config_path)
+        hook = mgr.add_endpoint(agent="test", name="test")
         mgr.hooks[hook["id"]]["call_count"] = 42
-        updated = mgr.update_hook(hook["id"], name="renamed")
+        updated = mgr.update_endpoint(hook["id"], name="renamed")
         assert updated["call_count"] == 42
 
     def test_update_nonexistent(self):
-        mgr = WebhookManager(config_path=self.config_path)
-        assert mgr.update_hook("nonexistent", name="x") is None
+        mgr = ApiEndpointManager(config_path=self.config_path)
+        assert mgr.update_endpoint("nonexistent", name="x") is None
 
     def test_update_persists(self):
-        mgr = WebhookManager(config_path=self.config_path)
-        hook = mgr.add_hook(agent="test", name="test")
-        mgr.update_hook(hook["id"], name="persisted", agent="new-agent")
-        mgr2 = WebhookManager(config_path=self.config_path)
+        mgr = ApiEndpointManager(config_path=self.config_path)
+        hook = mgr.add_endpoint(agent="test", name="test")
+        mgr.update_endpoint(hook["id"], name="persisted", agent="new-agent")
+        mgr2 = ApiEndpointManager(config_path=self.config_path)
         assert mgr2.hooks[hook["id"]]["name"] == "persisted"
         assert mgr2.hooks[hook["id"]]["agent"] == "new-agent"
 
     def test_update_empty_name_rejected(self):
-        mgr = WebhookManager(config_path=self.config_path)
-        hook = mgr.add_hook(agent="test", name="test")
+        mgr = ApiEndpointManager(config_path=self.config_path)
+        hook = mgr.add_endpoint(agent="test", name="test")
         with pytest.raises(ValueError):
-            mgr.update_hook(hook["id"], name="")
+            mgr.update_endpoint(hook["id"], name="")
 
     def test_update_empty_agent_rejected(self):
-        mgr = WebhookManager(config_path=self.config_path)
-        hook = mgr.add_hook(agent="test", name="test")
+        mgr = ApiEndpointManager(config_path=self.config_path)
+        hook = mgr.add_endpoint(agent="test", name="test")
         with pytest.raises(ValueError):
-            mgr.update_hook(hook["id"], agent="")
+            mgr.update_endpoint(hook["id"], agent="")
 
     def test_validation_error_does_not_partially_mutate(self):
         """If agent validation fails, name should not be changed."""
-        mgr = WebhookManager(config_path=self.config_path)
-        hook = mgr.add_hook(agent="original-agent", name="original-name")
+        mgr = ApiEndpointManager(config_path=self.config_path)
+        hook = mgr.add_endpoint(agent="original-agent", name="original-name")
         with pytest.raises(ValueError):
-            mgr.update_hook(hook["id"], name="new-name", agent="")
+            mgr.update_endpoint(hook["id"], name="new-name", agent="")
         # Name must remain unchanged
         assert mgr.hooks[hook["id"]]["name"] == "original-name"
 
 
-class TestWebhookDashboardPatch:
-    """Test the PATCH /api/webhooks/{hook_id} endpoint via create_dashboard_router."""
+class TestEndpointDashboardPatch:
+    """Test the PATCH /api/endpoints/{endpoint_id} endpoint via create_dashboard_router."""
 
     def setup_method(self):
         import os
         import tempfile
         self._tmpdir = tempfile.mkdtemp()
-        self.config_path = os.path.join(self._tmpdir, "webhooks.json")
+        self.config_path = os.path.join(self._tmpdir, "api_endpoints.json")
 
     def teardown_method(self):
         shutil.rmtree(self._tmpdir, ignore_errors=True)
@@ -480,7 +508,7 @@ class TestWebhookDashboardPatch:
             runtime=runtime_mock, transport=transport_mock, router=router_mock,
         )
 
-        mgr = WebhookManager(config_path=self.config_path, dispatch_fn=dispatch_fn)
+        mgr = ApiEndpointManager(config_path=self.config_path, dispatch_fn=dispatch_fn)
         dashboard_router = create_dashboard_router(
             blackboard=bb,
             health_monitor=health_monitor,
@@ -489,7 +517,7 @@ class TestWebhookDashboardPatch:
             event_bus=event_bus,
             agent_registry={},
             mesh_port=8420,
-            webhook_manager=mgr,
+            api_endpoint_manager=mgr,
         )
         app = FastAPI()
         app.include_router(dashboard_router)
@@ -497,11 +525,11 @@ class TestWebhookDashboardPatch:
 
     def test_patch_via_dashboard_success(self):
         app, mgr = self._make_app()
-        hook = mgr.add_hook(agent="a", name="original")
+        hook = mgr.add_endpoint(agent="a", name="original")
         client = TestClient(app)
 
         resp = client.patch(
-            f"/dashboard/api/webhooks/{hook['id']}",
+            f"/dashboard/api/endpoints/{hook['id']}",
             json={"name": "updated", "instructions": "Do X."},
             headers={"X-Requested-With": "XMLHttpRequest"},
         )
@@ -517,7 +545,7 @@ class TestWebhookDashboardPatch:
         client = TestClient(app)
 
         resp = client.patch(
-            "/dashboard/api/webhooks/nonexistent",
+            "/dashboard/api/endpoints/nonexistent",
             json={"name": "x"},
             headers={"X-Requested-With": "XMLHttpRequest"},
         )
@@ -525,11 +553,11 @@ class TestWebhookDashboardPatch:
 
     def test_patch_via_dashboard_empty_body_rejected(self):
         app, mgr = self._make_app()
-        hook = mgr.add_hook(agent="a", name="test")
+        hook = mgr.add_endpoint(agent="a", name="test")
         client = TestClient(app)
 
         resp = client.patch(
-            f"/dashboard/api/webhooks/{hook['id']}",
+            f"/dashboard/api/endpoints/{hook['id']}",
             json={},
             headers={"X-Requested-With": "XMLHttpRequest"},
         )
@@ -537,11 +565,11 @@ class TestWebhookDashboardPatch:
 
     def test_patch_via_dashboard_empty_name_rejected(self):
         app, mgr = self._make_app()
-        hook = mgr.add_hook(agent="a", name="test")
+        hook = mgr.add_endpoint(agent="a", name="test")
         client = TestClient(app)
 
         resp = client.patch(
-            f"/dashboard/api/webhooks/{hook['id']}",
+            f"/dashboard/api/endpoints/{hook['id']}",
             json={"name": ""},
             headers={"X-Requested-With": "XMLHttpRequest"},
         )
@@ -549,12 +577,12 @@ class TestWebhookDashboardPatch:
 
     def test_patch_via_dashboard_enable_signature(self):
         app, mgr = self._make_app()
-        hook = mgr.add_hook(agent="a", name="test")
+        hook = mgr.add_endpoint(agent="a", name="test")
         assert "secret" not in hook
         client = TestClient(app)
 
         resp = client.patch(
-            f"/dashboard/api/webhooks/{hook['id']}",
+            f"/dashboard/api/endpoints/{hook['id']}",
             json={"require_signature": True},
             headers={"X-Requested-With": "XMLHttpRequest"},
         )
@@ -599,53 +627,53 @@ class TestWebhookDashboardPatch:
             event_bus=event_bus,
             agent_registry={},
             mesh_port=8420,
-            webhook_manager=None,
+            api_endpoint_manager=None,
         )
         app = FastAPI()
         app.include_router(dashboard_router)
         client = TestClient(app)
 
         resp = client.patch(
-            "/dashboard/api/webhooks/some-id",
+            "/dashboard/api/endpoints/some-id",
             json={"name": "x"},
             headers={"X-Requested-With": "XMLHttpRequest"},
         )
         assert resp.status_code == 503
 
 
-class TestWebhookUpdateRouter:
-    """Test the PATCH /api/webhooks/{hook_id} endpoint."""
+class TestEndpointUpdateRouter:
+    """Test the PATCH /api/endpoints/{endpoint_id} endpoint."""
 
     def setup_method(self):
         self._tmpdir = tempfile.mkdtemp()
-        self.config_path = f"{self._tmpdir}/webhooks.json"
+        self.config_path = f"{self._tmpdir}/api_endpoints.json"
 
     def teardown_method(self):
         shutil.rmtree(self._tmpdir, ignore_errors=True)
 
     def _make_app(self):
-        """Build a minimal FastAPI app with webhook update endpoints."""
+        """Build a minimal FastAPI app with endpoint update endpoints."""
         from fastapi import FastAPI
 
-        mgr = WebhookManager(config_path=self.config_path)
+        mgr = ApiEndpointManager(config_path=self.config_path)
 
         app = FastAPI()
         api = APIRouter()
 
-        @api.get("/api/webhooks")
-        async def api_webhooks_list(request: Request) -> dict:
-            hooks = mgr.list_hooks()
+        @api.get("/api/endpoints")
+        async def api_endpoints_list(request: Request) -> dict:
+            hooks = mgr.list_endpoints()
             base = str(request.base_url).rstrip("/")
             result = []
             for h in hooks:
                 entry = {k: v for k, v in h.items() if k != "secret"}
-                entry["url"] = f"{base}/webhook/hook/{h['id']}"
+                entry["url"] = f"{base}/api/inbound/{h['id']}"
                 entry["has_secret"] = "secret" in h
                 result.append(entry)
-            return {"webhooks": result}
+            return {"endpoints": result}
 
-        @api.patch("/api/webhooks/{hook_id}")
-        async def api_webhooks_update(hook_id: str, request: Request) -> dict:
+        @api.patch("/api/endpoints/{endpoint_id}")
+        async def api_endpoints_update(endpoint_id: str, request: Request) -> dict:
             body = await request.json()
             fields = {}
             for key in ("name", "agent", "instructions"):
@@ -658,25 +686,25 @@ class TestWebhookUpdateRouter:
             if not fields:
                 raise HTTPException(status_code=400, detail="No valid fields provided")
             try:
-                updated = mgr.update_hook(hook_id, **fields)
+                updated = mgr.update_endpoint(endpoint_id, **fields)
             except ValueError as e:
                 raise HTTPException(status_code=400, detail=str(e))
             if updated is None:
-                raise HTTPException(status_code=404, detail=f"Webhook '{hook_id}' not found")
+                raise HTTPException(status_code=404, detail=f"Endpoint '{endpoint_id}' not found")
             base = str(request.base_url).rstrip("/")
-            updated["url"] = f"{base}/webhook/hook/{updated['id']}"
+            updated["url"] = f"{base}/api/inbound/{updated['id']}"
             return {"updated": True, "hook": updated}
 
         app.include_router(api)
         return app, mgr
 
-    def test_patch_webhook_success(self):
+    def test_patch_endpoint_success(self):
         app, mgr = self._make_app()
-        hook = mgr.add_hook(agent="a", name="original")
+        hook = mgr.add_endpoint(agent="a", name="original")
         client = TestClient(app)
 
         resp = client.patch(
-            f"/api/webhooks/{hook['id']}",
+            f"/api/endpoints/{hook['id']}",
             json={"name": "renamed", "agent": "b"},
         )
         assert resp.status_code == 200
@@ -686,19 +714,19 @@ class TestWebhookUpdateRouter:
         assert data["hook"]["agent"] == "b"
         assert "url" in data["hook"]
 
-    def test_patch_webhook_not_found(self):
+    def test_patch_endpoint_not_found(self):
         app, _ = self._make_app()
         client = TestClient(app)
-        resp = client.patch("/api/webhooks/nonexistent", json={"name": "x"})
+        resp = client.patch("/api/endpoints/nonexistent", json={"name": "x"})
         assert resp.status_code == 404
 
-    def test_patch_webhook_new_secret_in_response(self):
+    def test_patch_endpoint_new_secret_in_response(self):
         app, mgr = self._make_app()
-        hook = mgr.add_hook(agent="a", name="test")
+        hook = mgr.add_endpoint(agent="a", name="test")
         client = TestClient(app)
 
         resp = client.patch(
-            f"/api/webhooks/{hook['id']}",
+            f"/api/endpoints/{hook['id']}",
             json={"require_signature": True},
         )
         assert resp.status_code == 200
@@ -706,36 +734,64 @@ class TestWebhookUpdateRouter:
         assert "secret" in data["hook"]
         assert len(data["hook"]["secret"]) == 64
 
-    def test_patch_webhook_no_secret_when_unchanged(self):
+    def test_patch_endpoint_no_secret_when_unchanged(self):
         app, mgr = self._make_app()
-        hook = mgr.add_hook(agent="a", name="test", require_signature=True)
+        hook = mgr.add_endpoint(agent="a", name="test", require_signature=True)
         client = TestClient(app)
 
         resp = client.patch(
-            f"/api/webhooks/{hook['id']}",
+            f"/api/endpoints/{hook['id']}",
             json={"name": "renamed"},
         )
         assert resp.status_code == 200
         data = resp.json()
         assert "secret" not in data["hook"]
 
-    def test_patch_webhook_empty_body(self):
+    def test_patch_endpoint_empty_body(self):
         app, mgr = self._make_app()
-        hook = mgr.add_hook(agent="a", name="test")
+        hook = mgr.add_endpoint(agent="a", name="test")
         client = TestClient(app)
-        resp = client.patch(f"/api/webhooks/{hook['id']}", json={})
+        resp = client.patch(f"/api/endpoints/{hook['id']}", json={})
         assert resp.status_code == 400
 
     def test_list_includes_has_secret(self):
         app, mgr = self._make_app()
-        mgr.add_hook(agent="a", name="unsigned")
-        mgr.add_hook(agent="b", name="signed", require_signature=True)
+        mgr.add_endpoint(agent="a", name="unsigned")
+        mgr.add_endpoint(agent="b", name="signed", require_signature=True)
         client = TestClient(app)
 
-        resp = client.get("/api/webhooks")
-        hooks = resp.json()["webhooks"]
+        resp = client.get("/api/endpoints")
+        hooks = resp.json()["endpoints"]
         unsigned = next(h for h in hooks if h["name"] == "unsigned")
         signed = next(h for h in hooks if h["name"] == "signed")
         assert unsigned["has_secret"] is False
         assert signed["has_secret"] is True
         assert "secret" not in signed  # value still stripped
+
+
+class TestConfigMigration:
+    """Test auto-migration from webhooks.json to api_endpoints.json."""
+
+    def setup_method(self):
+        self._tmpdir = tempfile.mkdtemp()
+
+    def teardown_method(self):
+        shutil.rmtree(self._tmpdir, ignore_errors=True)
+
+    def test_migrates_from_old_config(self):
+        import json
+        old_path = f"{self._tmpdir}/webhooks.json"
+        new_path = f"{self._tmpdir}/api_endpoints.json"
+
+        # Write old-format config
+        old_data = {"hooks": {"hook_abc123": {"id": "hook_abc123", "agent": "test", "name": "legacy"}}}
+        with open(old_path, "w") as f:
+            json.dump(old_data, f)
+
+        mgr = ApiEndpointManager(config_path=new_path)
+        assert "hook_abc123" in mgr.hooks
+        assert mgr.hooks["hook_abc123"]["name"] == "legacy"
+
+        # New config file should now exist
+        import os
+        assert os.path.exists(new_path)

--- a/tests/test_e2e_triggering.py
+++ b/tests/test_e2e_triggering.py
@@ -59,13 +59,13 @@ def e2e_trigger_stack(tmp_path_factory):
         if openai_key:
             os.environ["OPENLEGION_CRED_OPENAI_API_KEY"] = openai_key
 
+    from src.host.api_endpoints import ApiEndpointManager
     from src.host.containers import ContainerManager
     from src.host.costs import CostTracker
     from src.host.credentials import CredentialVault
     from src.host.mesh import Blackboard, MessageRouter, PubSub
     from src.host.permissions import PermissionMatrix
     from src.host.server import create_mesh_app
-    from src.host.api_endpoints import ApiEndpointManager
 
     tmp_dir = tmp_path_factory.mktemp("e2e_trigger")
     bb = Blackboard(db_path=str(tmp_dir / "blackboard.db"))

--- a/tests/test_e2e_triggering.py
+++ b/tests/test_e2e_triggering.py
@@ -65,7 +65,7 @@ def e2e_trigger_stack(tmp_path_factory):
     from src.host.mesh import Blackboard, MessageRouter, PubSub
     from src.host.permissions import PermissionMatrix
     from src.host.server import create_mesh_app
-    from src.host.webhooks import WebhookManager
+    from src.host.api_endpoints import ApiEndpointManager
 
     tmp_dir = tmp_path_factory.mktemp("e2e_trigger")
     bb = Blackboard(db_path=str(tmp_dir / "blackboard.db"))
@@ -88,13 +88,13 @@ def e2e_trigger_stack(tmp_path_factory):
             r = await client.post(f"{url}/chat", json={"message": message})
             return r.json().get("response", "(no response)")
 
-    webhook_manager = WebhookManager(
-        config_path=str(tmp_dir / "webhooks.json"),
+    api_endpoint_manager = ApiEndpointManager(
+        config_path=str(tmp_dir / "api_endpoints.json"),
         dispatch_fn=dispatch_fn,
     )
 
     app = create_mesh_app(bb, pubsub, router, perms, vault)
-    app.include_router(webhook_manager.create_router())
+    app.include_router(api_endpoint_manager.create_router())
 
     config = uvicorn.Config(app, host="0.0.0.0", port=MESH_PORT, log_level="warning")
     server = uvicorn.Server(config)
@@ -141,7 +141,7 @@ def e2e_trigger_stack(tmp_path_factory):
         "mesh_url": f"http://localhost:{MESH_PORT}",
         "agent_url": url,
         "cost_tracker": cost_tracker,
-        "webhook_manager": webhook_manager,
+        "api_endpoint_manager": api_endpoint_manager,
         "container_manager": cm,
         "dispatch_fn": dispatch_fn,
     }
@@ -192,11 +192,11 @@ def test_cron_dispatch_to_agent(e2e_trigger_stack):
 @skip_no_key
 def test_webhook_dispatch_to_agent(e2e_trigger_stack):
     """Webhook endpoint receives POST and dispatches to agent."""
-    mgr = e2e_trigger_stack["webhook_manager"]
-    hook = mgr.add_hook(agent="trigger_test", name="test-event")
+    mgr = e2e_trigger_stack["api_endpoint_manager"]
+    hook = mgr.add_endpoint(agent="trigger_test", name="test-event")
 
     r = httpx.post(
-        f"{e2e_trigger_stack['mesh_url']}/webhook/hook/{hook['id']}",
+        f"{e2e_trigger_stack['mesh_url']}/api/inbound/{hook['id']}",
         json={"event": "push", "repo": "openlegion"},
         timeout=120,
     )
@@ -230,7 +230,7 @@ def test_cost_tracked_after_chat(e2e_trigger_stack):
 def test_webhook_unknown_hook_returns_404(e2e_trigger_stack):
     """Unknown webhook ID returns 404."""
     r = httpx.post(
-        f"{e2e_trigger_stack['mesh_url']}/webhook/hook/nonexistent",
+        f"{e2e_trigger_stack['mesh_url']}/api/inbound/nonexistent",
         json={"event": "test"},
         timeout=10,
     )

--- a/tests/test_outbound_webhooks.py
+++ b/tests/test_outbound_webhooks.py
@@ -1,0 +1,492 @@
+"""Tests for OutboundWebhookManager: CRUD, delivery, HMAC, filtering, SSRF, retry."""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import hmac
+import json
+import shutil
+import tempfile
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from src.host.outbound_webhooks import (
+    VALID_EVENT_TYPES,
+    OutboundWebhookManager,
+    _check_url_ssrf,
+    _is_blocked_ip,
+)
+
+
+class TestSubscriptionCRUD:
+    def setup_method(self):
+        self._tmpdir = tempfile.mkdtemp()
+        self.config_path = f"{self._tmpdir}/outbound_webhooks.json"
+
+    def teardown_method(self):
+        shutil.rmtree(self._tmpdir, ignore_errors=True)
+
+    def test_add_subscription(self):
+        mgr = OutboundWebhookManager(config_path=self.config_path)
+        sub = mgr.add_subscription(
+            "My Webhook", "https://example.com/hook", ["notification"],
+        )
+        assert sub["name"] == "My Webhook"
+        assert sub["url"] == "https://example.com/hook"
+        assert sub["events"] == ["notification"]
+        assert sub["enabled"] is True
+        assert len(sub["secret"]) == 64  # hex of 32 bytes
+        assert sub["delivery_count"] == 0
+        assert sub["id"].startswith("owh_")
+
+    def test_add_subscription_with_agent_filter(self):
+        mgr = OutboundWebhookManager(config_path=self.config_path)
+        sub = mgr.add_subscription(
+            "Filtered", "https://example.com/hook",
+            ["task_complete"], agent_filter=["agent-1", "agent-2"],
+        )
+        assert sub["agent_filter"] == ["agent-1", "agent-2"]
+
+    def test_add_subscription_invalid_url(self):
+        mgr = OutboundWebhookManager(config_path=self.config_path)
+        with pytest.raises(ValueError, match="https"):
+            mgr.add_subscription("test", "http://example.com/hook", ["notification"])
+
+    def test_add_subscription_invalid_events(self):
+        mgr = OutboundWebhookManager(config_path=self.config_path)
+        with pytest.raises(ValueError, match="Invalid event types"):
+            mgr.add_subscription("test", "https://example.com", ["bogus_event"])
+
+    def test_add_subscription_empty_events(self):
+        mgr = OutboundWebhookManager(config_path=self.config_path)
+        with pytest.raises(ValueError, match="At least one event"):
+            mgr.add_subscription("test", "https://example.com", [])
+
+    def test_add_subscription_empty_name(self):
+        mgr = OutboundWebhookManager(config_path=self.config_path)
+        with pytest.raises(ValueError, match="name must not be empty"):
+            mgr.add_subscription("", "https://example.com", ["notification"])
+
+    def test_add_subscription_empty_url(self):
+        mgr = OutboundWebhookManager(config_path=self.config_path)
+        with pytest.raises(ValueError, match="url must not be empty"):
+            mgr.add_subscription("test", "", ["notification"])
+
+    def test_remove_subscription(self):
+        mgr = OutboundWebhookManager(config_path=self.config_path)
+        sub = mgr.add_subscription("test", "https://example.com", ["notification"])
+        assert mgr.remove_subscription(sub["id"]) is True
+        assert mgr.remove_subscription(sub["id"]) is False
+
+    def test_update_subscription(self):
+        mgr = OutboundWebhookManager(config_path=self.config_path)
+        sub = mgr.add_subscription("test", "https://example.com", ["notification"])
+        updated = mgr.update_subscription(
+            sub["id"], name="Updated Name", enabled=False,
+        )
+        assert updated["name"] == "Updated Name"
+        assert updated["enabled"] is False
+        assert updated["url"] == "https://example.com"  # unchanged
+
+    def test_update_subscription_validation(self):
+        mgr = OutboundWebhookManager(config_path=self.config_path)
+        sub = mgr.add_subscription("test", "https://example.com", ["notification"])
+        with pytest.raises(ValueError, match="https"):
+            mgr.update_subscription(sub["id"], url="http://insecure.com")
+        with pytest.raises(ValueError, match="Invalid event"):
+            mgr.update_subscription(sub["id"], events=["not_real"])
+        with pytest.raises(ValueError, match="name must not be empty"):
+            mgr.update_subscription(sub["id"], name="")
+
+    def test_update_nonexistent(self):
+        mgr = OutboundWebhookManager(config_path=self.config_path)
+        assert mgr.update_subscription("owh_nonexistent") is None
+
+    def test_list_subscriptions(self):
+        mgr = OutboundWebhookManager(config_path=self.config_path)
+        mgr.add_subscription("A", "https://a.com", ["notification"])
+        mgr.add_subscription("B", "https://b.com", ["task_complete"])
+        subs = mgr.list_subscriptions()
+        assert len(subs) == 2
+        names = {s["name"] for s in subs}
+        assert names == {"A", "B"}
+
+
+class TestConfigPersistence:
+    def setup_method(self):
+        self._tmpdir = tempfile.mkdtemp()
+        self.config_path = f"{self._tmpdir}/outbound_webhooks.json"
+
+    def teardown_method(self):
+        shutil.rmtree(self._tmpdir, ignore_errors=True)
+
+    def test_save_and_load(self):
+        mgr1 = OutboundWebhookManager(config_path=self.config_path)
+        sub = mgr1.add_subscription("persist", "https://example.com", ["notification"])
+
+        mgr2 = OutboundWebhookManager(config_path=self.config_path)
+        assert len(mgr2.subscriptions) == 1
+        loaded = list(mgr2.subscriptions.values())[0]
+        assert loaded["name"] == "persist"
+        assert loaded["secret"] == sub["secret"]
+
+    def test_load_missing_file(self):
+        mgr = OutboundWebhookManager(config_path=f"{self._tmpdir}/nonexistent.json")
+        assert len(mgr.subscriptions) == 0
+
+
+class TestHMACSignature:
+    def test_signature_matches(self):
+        """Verify the HMAC signature format matches expectations."""
+        import secrets
+        secret = secrets.token_hex(32)
+        payload = {"event": "test", "agent": "a1", "data": {}, "timestamp": "T", "delivery_id": "dlv_1"}
+        body_bytes = json.dumps(payload).encode()
+        expected = hmac.new(secret.encode(), body_bytes, hashlib.sha256).hexdigest()
+        # Verify the format is sha256=<hex>
+        header_value = f"sha256={expected}"
+        assert header_value.startswith("sha256=")
+        assert len(expected) == 64
+
+
+class TestEventFiltering:
+    def setup_method(self):
+        self._tmpdir = tempfile.mkdtemp()
+        self.config_path = f"{self._tmpdir}/outbound_webhooks.json"
+
+    def teardown_method(self):
+        shutil.rmtree(self._tmpdir, ignore_errors=True)
+
+    def test_enqueue_matching_event(self):
+        mgr = OutboundWebhookManager(config_path=self.config_path)
+        mgr.add_subscription("test", "https://example.com", ["notification"])
+        mgr.enqueue("notification", "agent-1", {"msg": "hello"})
+        assert mgr._queue.qsize() == 1
+
+    def test_enqueue_non_matching_event(self):
+        mgr = OutboundWebhookManager(config_path=self.config_path)
+        mgr.add_subscription("test", "https://example.com", ["notification"])
+        mgr.enqueue("task_complete", "agent-1", {"task": "done"})
+        assert mgr._queue.qsize() == 0
+
+    def test_enqueue_agent_filter(self):
+        mgr = OutboundWebhookManager(config_path=self.config_path)
+        mgr.add_subscription(
+            "filtered", "https://example.com", ["notification"],
+            agent_filter=["agent-1"],
+        )
+        mgr.enqueue("notification", "agent-1", {"msg": "yes"})
+        assert mgr._queue.qsize() == 1
+        mgr.enqueue("notification", "agent-2", {"msg": "no"})
+        assert mgr._queue.qsize() == 1  # agent-2 filtered out
+
+    def test_enqueue_disabled_subscription(self):
+        mgr = OutboundWebhookManager(config_path=self.config_path)
+        sub = mgr.add_subscription("test", "https://example.com", ["notification"])
+        mgr.update_subscription(sub["id"], enabled=False)
+        mgr.enqueue("notification", "agent-1", {"msg": "hello"})
+        assert mgr._queue.qsize() == 0
+
+    def test_enqueue_empty_agent_filter_matches_all(self):
+        mgr = OutboundWebhookManager(config_path=self.config_path)
+        mgr.add_subscription("test", "https://example.com", ["notification"])
+        mgr.enqueue("notification", "any-agent", {"msg": "hi"})
+        assert mgr._queue.qsize() == 1
+
+
+@pytest.mark.asyncio
+class TestDelivery:
+    async def test_successful_delivery(self, tmp_path):
+        config_path = str(tmp_path / "webhooks.json")
+        mgr = OutboundWebhookManager(config_path=config_path)
+        sub = mgr.add_subscription("test", "https://example.com/hook", ["notification"])
+
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+
+        with patch.object(mgr, "_get_client") as mock_get_client:
+            mock_client = AsyncMock()
+            mock_client.post.return_value = mock_response
+            mock_get_client.return_value = mock_client
+
+            payload = {
+                "event": "notification",
+                "agent": "agent-1",
+                "data": {"msg": "hello"},
+                "timestamp": "2026-01-01T00:00:00Z",
+                "delivery_id": "dlv_test123",
+            }
+            with patch("src.host.outbound_webhooks._check_url_ssrf", return_value=None):
+                result = await mgr._deliver(sub, payload, "dlv_test123")
+
+        assert result["status"] == "delivered"
+        assert result["response_code"] == 200
+        # Verify headers
+        call_kwargs = mock_client.post.call_args
+        headers = call_kwargs.kwargs.get("headers", {})
+        assert "X-OpenLegion-Signature" in headers
+        assert headers["X-OpenLegion-Signature"].startswith("sha256=")
+        assert headers["X-OpenLegion-Event"] == "notification"
+        assert headers["User-Agent"] == "OpenLegion/1.0"
+
+    async def test_delivery_correct_hmac(self, tmp_path):
+        """Verify delivered HMAC matches manual computation."""
+        config_path = str(tmp_path / "webhooks.json")
+        mgr = OutboundWebhookManager(config_path=config_path)
+        sub = mgr.add_subscription("test", "https://example.com/hook", ["notification"])
+        secret = sub["secret"]
+
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        captured_body = None
+        captured_headers = None
+
+        async def capture_post(url, content=None, headers=None, timeout=None):
+            nonlocal captured_body, captured_headers
+            captured_body = content
+            captured_headers = headers
+            return mock_response
+
+        with patch.object(mgr, "_get_client") as mock_get_client:
+            mock_client = AsyncMock()
+            mock_client.post = capture_post
+            mock_get_client.return_value = mock_client
+
+            payload = {"event": "test", "agent": "a1", "data": {}, "timestamp": "T", "delivery_id": "d1"}
+            with patch("src.host.outbound_webhooks._check_url_ssrf", return_value=None):
+                await mgr._deliver(sub, payload, "d1")
+
+        expected = hmac.new(secret.encode(), captured_body, hashlib.sha256).hexdigest()
+        assert captured_headers["X-OpenLegion-Signature"] == f"sha256={expected}"
+
+
+@pytest.mark.asyncio
+class TestRetry:
+    async def test_retry_on_failure(self, tmp_path):
+        """Verify retry attempts with exponential backoff."""
+        config_path = str(tmp_path / "webhooks.json")
+        mgr = OutboundWebhookManager(config_path=config_path)
+        sub = mgr.add_subscription("test", "https://example.com/hook", ["notification"])
+
+        mock_response = MagicMock()
+        mock_response.status_code = 500
+
+        with patch.object(mgr, "_get_client") as mock_get_client:
+            mock_client = AsyncMock()
+            mock_client.post.return_value = mock_response
+            mock_get_client.return_value = mock_client
+
+            payload = {"event": "test", "agent": "a1", "data": {}, "timestamp": "T", "delivery_id": "d1"}
+            # Patch sleep to avoid actual delays, and patch SSRF check
+            with patch("src.host.outbound_webhooks.asyncio.sleep", new_callable=AsyncMock) as mock_sleep:
+                with patch("src.host.outbound_webhooks._check_url_ssrf", return_value=None):
+                    result = await mgr._deliver(sub, payload, "d1")
+
+        assert result["status"] == "failed"
+        assert "Failed after 4 attempts" in result["error"]
+        # Should have retried 3 times (with 3 sleep calls)
+        assert mock_sleep.call_count == 3
+        assert mock_sleep.call_args_list[0].args[0] == 5
+        assert mock_sleep.call_args_list[1].args[0] == 30
+        assert mock_sleep.call_args_list[2].args[0] == 120
+
+    async def test_retry_succeeds_on_second_attempt(self, tmp_path):
+        config_path = str(tmp_path / "webhooks.json")
+        mgr = OutboundWebhookManager(config_path=config_path)
+        sub = mgr.add_subscription("test", "https://example.com/hook", ["notification"])
+
+        fail_response = MagicMock()
+        fail_response.status_code = 502
+        ok_response = MagicMock()
+        ok_response.status_code = 200
+
+        with patch.object(mgr, "_get_client") as mock_get_client:
+            mock_client = AsyncMock()
+            mock_client.post.side_effect = [fail_response, ok_response]
+            mock_get_client.return_value = mock_client
+
+            payload = {"event": "test", "agent": "a1", "data": {}, "timestamp": "T", "delivery_id": "d1"}
+            with patch("src.host.outbound_webhooks.asyncio.sleep", new_callable=AsyncMock):
+                with patch("src.host.outbound_webhooks._check_url_ssrf", return_value=None):
+                    result = await mgr._deliver(sub, payload, "d1")
+
+        assert result["status"] == "delivered"
+
+
+class TestSSRFBlocking:
+    def test_blocked_private_ip(self):
+        import ipaddress
+        assert _is_blocked_ip(ipaddress.ip_address("10.0.0.1")) is True
+        assert _is_blocked_ip(ipaddress.ip_address("192.168.1.1")) is True
+        assert _is_blocked_ip(ipaddress.ip_address("127.0.0.1")) is True
+        assert _is_blocked_ip(ipaddress.ip_address("0.0.0.0")) is True
+
+    def test_blocked_cgnat(self):
+        import ipaddress
+        assert _is_blocked_ip(ipaddress.ip_address("100.64.0.1")) is True
+        assert _is_blocked_ip(ipaddress.ip_address("100.127.255.254")) is True
+
+    def test_blocked_link_local(self):
+        import ipaddress
+        assert _is_blocked_ip(ipaddress.ip_address("169.254.1.1")) is True
+
+    def test_allowed_public_ip(self):
+        import ipaddress
+        assert _is_blocked_ip(ipaddress.ip_address("8.8.8.8")) is False
+        assert _is_blocked_ip(ipaddress.ip_address("93.184.216.34")) is False
+
+    def test_blocked_ipv4_mapped_ipv6(self):
+        import ipaddress
+        assert _is_blocked_ip(ipaddress.ip_address("::ffff:127.0.0.1")) is True
+
+    @pytest.mark.asyncio
+    async def test_ssrf_blocks_delivery(self, tmp_path):
+        config_path = str(tmp_path / "webhooks.json")
+        mgr = OutboundWebhookManager(config_path=config_path)
+        sub = mgr.add_subscription("test", "https://example.com/hook", ["notification"])
+
+        payload = {"event": "test", "agent": "a1", "data": {}, "timestamp": "T", "delivery_id": "d1"}
+        with patch("src.host.outbound_webhooks._check_url_ssrf", return_value="Blocked IP: 127.0.0.1"):
+            result = await mgr._deliver(sub, payload, "d1")
+
+        assert result["status"] == "failed"
+        assert "SSRF blocked" in result["error"]
+
+    def test_check_url_ssrf_private(self):
+        """check_url_ssrf should detect private IPs."""
+        with patch("socket.getaddrinfo") as mock_dns:
+            mock_dns.return_value = [(2, 1, 0, '', ('127.0.0.1', 0))]
+            result = _check_url_ssrf("https://internal.example.com/hook")
+            assert result is not None
+            assert "Blocked" in result
+
+    def test_check_url_ssrf_public(self):
+        """check_url_ssrf should allow public IPs."""
+        with patch("socket.getaddrinfo") as mock_dns:
+            mock_dns.return_value = [(2, 1, 0, '', ('93.184.216.34', 0))]
+            result = _check_url_ssrf("https://example.com/hook")
+            assert result is None
+
+
+class TestRingBuffer:
+    @pytest.mark.asyncio
+    async def test_recent_deliveries(self, tmp_path):
+        config_path = str(tmp_path / "webhooks.json")
+        mgr = OutboundWebhookManager(config_path=config_path)
+        sub = mgr.add_subscription("test", "https://example.com/hook", ["notification"])
+
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+
+        with patch.object(mgr, "_get_client") as mock_get_client:
+            mock_client = AsyncMock()
+            mock_client.post.return_value = mock_response
+            mock_get_client.return_value = mock_client
+
+            for i in range(3):
+                payload = {"event": "test", "agent": "a1", "data": {}, "timestamp": "T", "delivery_id": f"d{i}"}
+                with patch("src.host.outbound_webhooks._check_url_ssrf", return_value=None):
+                    await mgr._deliver(sub, payload, f"d{i}")
+
+        deliveries = mgr.recent_deliveries()
+        assert len(deliveries) == 3
+        assert all(d["status"] == "delivered" for d in deliveries)
+
+    @pytest.mark.asyncio
+    async def test_ring_buffer_maxlen(self, tmp_path):
+        config_path = str(tmp_path / "webhooks.json")
+        mgr = OutboundWebhookManager(config_path=config_path)
+        # Manually fill the deque beyond maxlen
+        for i in range(250):
+            mgr._deliveries.append({"delivery_id": f"d{i}"})
+        assert len(mgr.recent_deliveries()) == 200  # maxlen
+
+
+class TestEventBusIntegration:
+    def test_listener_integration(self, tmp_path):
+        """EventBus.add_listener + emit should call enqueue."""
+        from src.dashboard.events import EventBus
+
+        config_path = str(tmp_path / "webhooks.json")
+        mgr = OutboundWebhookManager(config_path=config_path)
+        mgr.add_subscription("test", "https://example.com/hook", ["notification"])
+
+        bus = EventBus()
+        bus.add_listener(mgr.enqueue)
+
+        bus.emit("notification", agent="agent-1", data={"msg": "hello"})
+        assert mgr._queue.qsize() == 1
+
+    def test_listener_non_matching_event(self, tmp_path):
+        from src.dashboard.events import EventBus
+
+        config_path = str(tmp_path / "webhooks.json")
+        mgr = OutboundWebhookManager(config_path=config_path)
+        mgr.add_subscription("test", "https://example.com/hook", ["notification"])
+
+        bus = EventBus()
+        bus.add_listener(mgr.enqueue)
+
+        bus.emit("llm_call", agent="agent-1", data={"model": "gpt-4"})
+        assert mgr._queue.qsize() == 0
+
+
+@pytest.mark.asyncio
+class TestDeliveryWorker:
+    async def test_worker_processes_queue(self, tmp_path):
+        config_path = str(tmp_path / "webhooks.json")
+        mgr = OutboundWebhookManager(config_path=config_path)
+        sub = mgr.add_subscription("test", "https://example.com/hook", ["notification"])
+
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+
+        with patch.object(mgr, "_get_client") as mock_get_client:
+            mock_client = AsyncMock()
+            mock_client.post.return_value = mock_response
+            mock_get_client.return_value = mock_client
+
+            with patch("src.host.outbound_webhooks._check_url_ssrf", return_value=None):
+                mgr.enqueue("notification", "agent-1", {"msg": "hi"})
+                mgr.start()
+                # Give worker time to process
+                await asyncio.sleep(0.1)
+                await mgr.stop()
+
+        assert len(mgr.recent_deliveries()) == 1
+        assert mgr.recent_deliveries()[0]["status"] == "delivered"
+
+
+@pytest.mark.asyncio
+class TestTestSubscription:
+    async def test_test_delivery(self, tmp_path):
+        config_path = str(tmp_path / "webhooks.json")
+        mgr = OutboundWebhookManager(config_path=config_path)
+        sub = mgr.add_subscription("test", "https://example.com/hook", ["notification"])
+
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+
+        with patch.object(mgr, "_get_client") as mock_get_client:
+            mock_client = AsyncMock()
+            mock_client.post.return_value = mock_response
+            mock_get_client.return_value = mock_client
+
+            with patch("src.host.outbound_webhooks._check_url_ssrf", return_value=None):
+                result = await mgr.test_subscription(sub["id"])
+
+        assert result["status"] == "delivered"
+
+    async def test_test_nonexistent(self, tmp_path):
+        config_path = str(tmp_path / "webhooks.json")
+        mgr = OutboundWebhookManager(config_path=config_path)
+        result = await mgr.test_subscription("owh_nonexistent")
+        assert result is None
+
+
+class TestValidEventTypes:
+    def test_all_event_types_defined(self):
+        expected = {"notification", "task_complete", "task_failed", "agent_state", "cron_complete", "custom"}
+        assert VALID_EVENT_TYPES == expected

--- a/tests/test_outbound_webhooks.py
+++ b/tests/test_outbound_webhooks.py
@@ -438,7 +438,7 @@ class TestDeliveryWorker:
     async def test_worker_processes_queue(self, tmp_path):
         config_path = str(tmp_path / "webhooks.json")
         mgr = OutboundWebhookManager(config_path=config_path)
-        sub = mgr.add_subscription("test", "https://example.com/hook", ["notification"])
+        mgr.add_subscription("test", "https://example.com/hook", ["notification"])
 
         mock_response = MagicMock()
         mock_response.status_code = 200


### PR DESCRIPTION
Renames the inbound webhook system to 'API Endpoints' to clarify that these are URLs third parties call to send data into OpenLegion, not outbound notifications.

Changes:
- WebhookManager -> ApiEndpointManager with renamed methods
- Route /webhook/hook/{id} -> /api/inbound/{endpoint_id}
- Dashboard API /api/webhooks -> /api/endpoints
- Config file webhooks.json -> api_endpoints.json with auto-migration
- Deprecated compat route at old /webhook/hook/ path (Deprecation header)
- Accept both x-signature and x-webhook-signature headers
- All dashboard UI labels and JS bindings updated
- All test files updated with new names and paths