### PR TITLE
Fix mesh agent creation: permissions reload + project context

### DIFF
--- a/src/host/server.py
+++ b/src/host/server.py
@@ -1387,6 +1387,7 @@ def create_mesh_app(
 
         # Apply template to create config entries
         created_names = _apply_template(template_name, tpl)
+        permissions.reload()
         if not created_names:
             return {
                 "template": template_name,
@@ -1546,6 +1547,7 @@ def create_mesh_app(
         )
         _update_agent_field(name, "avatar", random.randint(1, 50))
         _add_agent_permissions(name)
+        permissions.reload()
         skills_dir = PROJECT_ROOT / "skills" / name
         skills_dir.mkdir(parents=True, exist_ok=True)
 

--- a/src/host/server.py
+++ b/src/host/server.py
@@ -1433,6 +1433,15 @@ def create_mesh_app(
                 if val:
                     env_overrides[env_key] = val
 
+            # Inject project env vars so the agent gets its PROJECT.md
+            _proj = _agent_projects.get(agent_name)
+            if _proj:
+                from src.cli.config import PROJECTS_DIR
+                env_overrides["PROJECT_MD_PATH"] = str(
+                    PROJECTS_DIR / _proj / "project.md"
+                )
+                env_overrides["PROJECT_NAME"] = _proj
+
             try:
                 # Start container with per-agent env_overrides (not shared extra_env)
                 url = container_manager.start_agent(
@@ -1557,6 +1566,15 @@ def create_mesh_app(
             agent_env["INITIAL_INSTRUCTIONS"] = instructions
         if soul:
             agent_env["INITIAL_SOUL"] = soul
+
+        # Inject project env vars so the agent gets its PROJECT.md
+        _proj = _agent_projects.get(name)
+        if _proj:
+            from src.cli.config import PROJECTS_DIR
+            agent_env["PROJECT_MD_PATH"] = str(
+                PROJECTS_DIR / _proj / "project.md"
+            )
+            agent_env["PROJECT_NAME"] = _proj
 
         try:
             url = container_manager.start_agent(


### PR DESCRIPTION
## Summary
- **Reload permissions after agent creation**: `/mesh/fleet/apply` and `/mesh/agents/create` write permissions to disk but never called `permissions.reload()`, so newly created agents got 403 Forbidden on all mesh API calls (e.g. LLM proxy). The dashboard's create endpoint already did this correctly.
- **Pass PROJECT_MD_PATH to mesh-created agents**: Agents created via mesh endpoints (by the operator) never received `PROJECT_MD_PATH`/`PROJECT_NAME` env vars, so they launched without `PROJECT.md` even when assigned to a project. Now mirrors the CLI startup behavior.

## Test plan
- [ ] Verify `pytest tests/test_dashboard.py tests/test_permissions.py -x` passes
- [ ] Create agents via operator → confirm no 403 on LLM calls
- [ ] Create project, assign agents, then create new agent via operator → confirm PROJECT.md is mounted

🤖 Generated with [Claude Code](https://claude.com/claude-code)