### PR TITLE
Fix credential request card alignment, placeholder, and agent notification

### DIFF
--- a/src/dashboard/server.py
+++ b/src/dashboard/server.py
@@ -1815,7 +1815,8 @@ def create_dashboard_router(
             try:
                 await lane_manager.enqueue(
                     agent_id,
-                    f"The user just saved credential '{service}' to the vault. You can now use $CRED{{{service}}} in your requests.",
+                    f"The user just saved credential '{service}' to the vault. "
+                    f"You can now use $CRED{{{service}}} in your requests.",
                     mode="steer",
                     trace_id=new_trace_id(),
                 )

--- a/src/dashboard/server.py
+++ b/src/dashboard/server.py
@@ -1808,6 +1808,21 @@ def create_dashboard_router(
                 detail=f"Cannot store system credential via chat card: {service}",
             )
         credential_vault.add_credential(service, key)
+        # Notify the requesting agent that the credential is now available.
+        agent_id = body.get("agent_id", "").strip()
+        if agent_id and lane_manager is not None and agent_id in agent_registry:
+            from src.shared.trace import new_trace_id
+            try:
+                await lane_manager.enqueue(
+                    agent_id,
+                    f"The user just saved credential '{service}' to the vault. You can now use $CRED{{{service}}} in your requests.",
+                    mode="steer",
+                    trace_id=new_trace_id(),
+                )
+            except Exception:
+                pass  # Best effort — credential is already stored
+        if event_bus:
+            event_bus.emit("credential_stored", data={"name": service})
         return {"stored": True, "service": service, "tier": "agent"}
 
     @api_router.post("/api/credentials/upload-env")

--- a/src/dashboard/templates/index.html
+++ b/src/dashboard/templates/index.html
@@ -353,6 +353,9 @@
                     <!-- Credential request card -->
                     <template x-if="msg.role === 'credential_request'">
                       <div class="flex justify-start gap-2.5">
+                        <div class="shrink-0 mt-1">
+                          <img src="/dashboard/static/avatars/operator.png" alt="Operator" class="w-6 h-6 rounded-full">
+                        </div>
                         <div class="max-w-[80%] min-w-0">
                           <div class="px-4 py-3 rounded-2xl rounded-bl-md bg-gray-800 border border-indigo-600/30">
                             <div class="flex items-center gap-2 mb-2">
@@ -366,9 +369,9 @@
                             <div x-show="!msg.saved" x-data="{ credValue: '', saving: false, saveError: '' }">
                               <input type="password" x-model="credValue"
                                 class="w-full px-3 py-1.5 rounded-lg bg-gray-900 border border-gray-700 text-xs text-white placeholder-gray-500 focus:border-indigo-500 focus:outline-none mb-2"
-                                :placeholder="'Enter ' + (msg.service || msg.name)">
+                                :placeholder="'Paste your ' + msg.name.replace(/[_.\-]/g, ' ').replace(/^\w/, c => c.toUpperCase())">
                               <div x-show="saveError" class="text-[10px] text-red-400 mb-1.5" x-text="saveError"></div>
-                              <button @click="if (credValue.trim()) { saving = true; saveError = ''; fetch(window.__config.apiBase + '/credentials/agent', { method: 'POST', headers: {'Content-Type':'application/json', 'X-Requested-With':'XMLHttpRequest'}, body: JSON.stringify({service: msg.name, key: credValue.trim()}) }).then(r => { if (r.ok) { msg.saved = true; credValue = ''; } else { saveError = 'Failed to save. Please try again.'; } saving = false; }).catch(() => { saveError = 'Network error. Please try again.'; saving = false; }); }"
+                              <button @click="if (credValue.trim()) { saving = true; saveError = ''; fetch(window.__config.apiBase + '/credentials/agent', { method: 'POST', headers: {'Content-Type':'application/json', 'X-Requested-With':'XMLHttpRequest'}, body: JSON.stringify({service: msg.name, key: credValue.trim(), agent_id: msg._from_agent || ''}) }).then(r => { if (r.ok) { msg.saved = true; credValue = ''; } else { saveError = 'Failed to save. Please try again.'; } saving = false; }).catch(() => { saveError = 'Network error. Please try again.'; saving = false; }); }"
                                 :disabled="!credValue.trim() || saving"
                                 class="w-full px-3 py-1.5 rounded-lg text-xs font-medium transition-colors"
                                 :class="credValue.trim() && !saving ? 'bg-indigo-600 hover:bg-indigo-500 text-white' : 'bg-gray-700 text-gray-500 cursor-not-allowed'">
@@ -5415,9 +5418,9 @@
                       <div x-show="!msg.saved" x-data="{ credValue: '', saving: false, saveError: '' }">
                         <input type="password" x-model="credValue"
                           class="w-full px-3 py-1.5 rounded-lg bg-gray-900 border border-gray-700 text-xs text-white placeholder-gray-500 focus:border-indigo-500 focus:outline-none mb-2"
-                          :placeholder="'Enter ' + (msg.service || msg.name)">
+                          :placeholder="'Paste your ' + msg.name.replace(/[_.\-]/g, ' ').replace(/^\w/, c => c.toUpperCase())">
                         <div x-show="saveError" class="text-[10px] text-red-400 mb-1.5" x-text="saveError"></div>
-                        <button @click="if (credValue.trim()) { saving = true; saveError = ''; fetch(window.__config.apiBase + '/credentials/agent', { method: 'POST', headers: {'Content-Type':'application/json', 'X-Requested-With':'XMLHttpRequest'}, body: JSON.stringify({service: msg.name, key: credValue.trim()}) }).then(r => { if (r.ok) { msg.saved = true; credValue = ''; } else { saveError = 'Failed to save. Please try again.'; } saving = false; }).catch(() => { saveError = 'Network error. Please try again.'; saving = false; }); }"
+                        <button @click="if (credValue.trim()) { saving = true; saveError = ''; fetch(window.__config.apiBase + '/credentials/agent', { method: 'POST', headers: {'Content-Type':'application/json', 'X-Requested-With':'XMLHttpRequest'}, body: JSON.stringify({service: msg.name, key: credValue.trim(), agent_id: activeChatId || ''}) }).then(r => { if (r.ok) { msg.saved = true; credValue = ''; } else { saveError = 'Failed to save. Please try again.'; } saving = false; }).catch(() => { saveError = 'Network error. Please try again.'; saving = false; }); }"
                           :disabled="!credValue.trim() || saving"
                           class="w-full px-3 py-1.5 rounded-lg text-xs font-medium transition-colors"
                           :class="credValue.trim() && !saving ? 'bg-indigo-600 hover:bg-indigo-500 text-white' : 'bg-gray-700 text-gray-500 cursor-not-allowed'">

--- a/tests/test_operator_playbooks.py
+++ b/tests/test_operator_playbooks.py
@@ -1,16 +1,14 @@
 """Tests for operator playbook detection, state tracking, and content assembly."""
 from __future__ import annotations
 
-import pytest
-
 from src.cli.operator_playbooks import (
-    PLAYBOOK_STICKY_TURNS,
     _OPERATOR_CORE,
     _PLAYBOOK_CREDENTIALS,
     _PLAYBOOK_EDIT,
     _PLAYBOOK_MONITOR,
     _PLAYBOOK_TEAM_BUILD,
     _TOOL_PLAYBOOK_MAP,
+    PLAYBOOK_STICKY_TURNS,
     extract_triggered_playbooks,
     get_playbook_content,
 )


### PR DESCRIPTION
## Summary
- **Alignment**: Added operator avatar to the credential request card on the operator chat page so it aligns with agent/error/notification messages
- **Placeholder text**: Changed vague `"Enter TikTok"` placeholders to descriptive `"Paste your Tiktok api key"` by formatting the credential name (replaces underscores/hyphens/dots with spaces)
- **Agent notification**: After user saves a credential, the requesting agent now receives a steer message with the `$CRED{name}` handle so it can proceed immediately instead of polling

## Test plan
- [x] `test_dashboard.py` — 248 tests pass
- [x] `test_vault.py` — 27 tests pass
- [ ] Manual: trigger `request_credential` from an agent, verify card alignment matches other messages on operator chat
- [ ] Manual: verify placeholder reads e.g. "Paste your Tiktok api key" not "Enter TikTok"
- [ ] Manual: verify agent receives steer message after credential is saved