### PR TITLE
Fix line-too-long lint error in test_browser_service

### DIFF
--- a/tests/test_browser_service.py
+++ b/tests/test_browser_service.py
@@ -22,7 +22,10 @@ class TestCredentialRedactor:
     def test_deep_redact_nested(self):
         from src.browser.redaction import CredentialRedactor
         r = CredentialRedactor()
-        obj = {"key": "has sk-abcdefghijklmnopqrstuvwxyz1234567890", "nested": [{"v": "also sk-abcdefghijklmnopqrstuvwxyz1234567890"}]}
+        obj = {
+            "key": "has sk-abcdefghijklmnopqrstuvwxyz1234567890",
+            "nested": [{"v": "also sk-abcdefghijklmnopqrstuvwxyz1234567890"}],
+        }
         result = r.deep_redact("a1", obj)
         assert "sk-abcdefgh" not in str(result)
         assert "[REDACTED]" in result["key"]


### PR DESCRIPTION
Line 25 was 135 chars (limit 120). Split into multi-line dict.