### PR TITLE
Fix operator import error by moving playbooks to shared module

### DIFF
--- a/src/agent/loop.py
+++ b/src/agent/loop.py
@@ -314,7 +314,7 @@ class AgentLoop:
         if not self._is_operator:
             return []
 
-        from src.cli.operator_playbooks import PLAYBOOK_STICKY_TURNS, extract_triggered_playbooks
+        from src.shared.operator_playbooks import PLAYBOOK_STICKY_TURNS, extract_triggered_playbooks
 
         # Scan only messages added since last check.
         # After context compaction, the message list may shrink — clamp the
@@ -344,7 +344,7 @@ class AgentLoop:
         """Increment turn counter for all active playbooks. Call once per user turn."""
         if not self._is_operator:
             return
-        from src.cli.operator_playbooks import PLAYBOOK_STICKY_TURNS
+        from src.shared.operator_playbooks import PLAYBOOK_STICKY_TURNS
 
         expired = [pb for pb, turns in self._operator_playbook_state.items() if turns > PLAYBOOK_STICKY_TURNS]
         for pb in expired:
@@ -2405,7 +2405,7 @@ class AgentLoop:
         if self._is_operator:
             active_playbooks = self._update_operator_playbooks()
             if active_playbooks:
-                from src.cli.operator_playbooks import get_playbook_content
+                from src.shared.operator_playbooks import get_playbook_content
 
                 playbook_text = get_playbook_content(active_playbooks)
                 if playbook_text:

--- a/src/cli/config.py
+++ b/src/cli/config.py
@@ -14,7 +14,7 @@ from pathlib import Path
 import click
 import yaml
 
-from src.cli.operator_playbooks import _OPERATOR_CORE
+from src.shared.operator_playbooks import _OPERATOR_CORE
 from src.shared.types import RESERVED_AGENT_IDS
 from src.shared.utils import truncate
 

--- a/src/shared/operator_playbooks.py
+++ b/src/shared/operator_playbooks.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 
 from src.shared.utils import setup_logging
 
-logger = setup_logging("cli.operator_playbooks")
+logger = setup_logging("shared.operator_playbooks")
 
 # ── Core instructions (always loaded) ─────────────────────────
 

--- a/tests/test_operator_config.py
+++ b/tests/test_operator_config.py
@@ -236,7 +236,7 @@ class TestOperatorConstants:
 
     def test_instructions_not_empty(self):
         from src.cli.config import _OPERATOR_HEARTBEAT, _OPERATOR_SOUL
-        from src.cli.operator_playbooks import _OPERATOR_CORE
+        from src.shared.operator_playbooks import _OPERATOR_CORE
         assert len(_OPERATOR_CORE) > 100
         assert len(_OPERATOR_SOUL) > 50
         assert len(_OPERATOR_HEARTBEAT) > 100
@@ -266,7 +266,7 @@ class TestOperatorConstants:
         assert "notify_user" in _OPERATOR_HEARTBEAT
 
     def test_core_has_key_sections(self):
-        from src.cli.operator_playbooks import _OPERATOR_CORE
+        from src.shared.operator_playbooks import _OPERATOR_CORE
         assert "Routing Work" in _OPERATOR_CORE
         assert "Plan Limits" in _OPERATOR_CORE
         assert "Assessment" in _OPERATOR_CORE
@@ -274,7 +274,7 @@ class TestOperatorConstants:
         assert "playbook_v2" in _OPERATOR_CORE
 
     def test_playbooks_have_key_tools(self):
-        from src.cli.operator_playbooks import (
+        from src.shared.operator_playbooks import (
             _PLAYBOOK_CREDENTIALS,
             _PLAYBOOK_EDIT,
             _PLAYBOOK_MONITOR,
@@ -287,7 +287,7 @@ class TestOperatorConstants:
         assert "vault_list" in _PLAYBOOK_CREDENTIALS
 
     def test_core_has_plan_tiers(self):
-        from src.cli.operator_playbooks import _OPERATOR_CORE
+        from src.shared.operator_playbooks import _OPERATOR_CORE
         assert "Basic" in _OPERATOR_CORE
         assert "Growth" in _OPERATOR_CORE
         assert "Pro" in _OPERATOR_CORE

--- a/tests/test_operator_playbooks.py
+++ b/tests/test_operator_playbooks.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import pytest  # noqa: F401
 
-from src.cli.operator_playbooks import (
+from src.shared.operator_playbooks import (
     _OPERATOR_CORE,
     _PLAYBOOK_CREDENTIALS,
     _PLAYBOOK_EDIT,


### PR DESCRIPTION
## Summary
The operator agent was failing with "No module named 'src.cli'" because
src/agent/loop.py imports from src.cli.operator_playbooks, but the agent
Docker container only ships src/agent/ and src/shared/ — not src/cli/.

Moves operator_playbooks.py to src/shared/ where both the host CLI and
the agent container can import it.

## Test plan
- [x] Run `pytest tests/test_operator_playbooks.py tests/test_operator_config.py -v` (36 passed)