### PR TITLE
Fix exc_info logging, deduplicate skill param normalization

### DIFF
--- a/src/agent/loop.py
+++ b/src/agent/loop.py
@@ -1498,8 +1498,7 @@ class AgentLoop:
             except Exception as e:
                 self.state = "idle"
                 duration_ms = int((time.time() - start) * 1000)
-                import traceback
-                logger.error("Heartbeat failed: %s\n%s", e, traceback.format_exc())
+                logger.error("Heartbeat failed: %s", e, exc_info=True)
                 if self.workspace:
                     self.workspace.append_activity(
                         trigger="heartbeat",
@@ -2714,8 +2713,7 @@ class AgentLoop:
         except asyncio.CancelledError:
             raise
         except Exception as e:
-            import traceback
-            logger.error("Streaming chat failed: %s\n%s", e, traceback.format_exc())
+            logger.error("Streaming chat failed: %s", e, exc_info=True)
             msg = f"Error: {e}"
             if self.workspace:
                 self.workspace.append_chat_message("assistant", msg)

--- a/src/agent/skills.py
+++ b/src/agent/skills.py
@@ -27,6 +27,25 @@ _skill_staging: dict[str, dict] = {}
 _skill_staging_lock = threading.Lock()
 
 
+def _normalize_params_dict(params: object) -> dict:
+    """Normalize skill parameters to the canonical dict shape.
+
+    Self-authored skills sometimes declare parameters as a list of
+    {name, type, description, ...} dicts instead of the canonical
+    {name: {type, description, ...}} dict. Normalize list form to dict
+    form; return empty dict for anything else unparseable.
+    """
+    if isinstance(params, dict):
+        return params
+    if isinstance(params, list):
+        return {
+            p["name"]: {k: v for k, v in p.items() if k != "name"}
+            for p in params
+            if isinstance(p, dict) and "name" in p
+        }
+    return {}
+
+
 def skill(
     name: str,
     description: str,
@@ -191,15 +210,7 @@ class SkillRegistry:
         # (e.g. "5" instead of 5 for an integer parameter).  Coerce to
         # the type declared in the skill's parameter schema so that tool
         # functions don't crash with TypeError.
-        param_schemas = info.get("parameters", {})
-        if isinstance(param_schemas, list):
-            param_schemas = {
-                p["name"]: {k: v for k, v in p.items() if k != "name"}
-                for p in param_schemas
-                if isinstance(p, dict) and "name" in p
-            }
-        if not isinstance(param_schemas, dict):
-            param_schemas = {}
+        param_schemas = _normalize_params_dict(info.get("parameters", {}))
         for key in list(call_args):
             schema = param_schemas.get(key)
             if not schema:
@@ -390,16 +401,7 @@ class SkillRegistry:
                     continue
             elif exclude and name in exclude:
                 continue
-            raw_params = info["parameters"]
-            # Normalise list-style params from self-authored skills
-            if isinstance(raw_params, list):
-                raw_params = {
-                    p["name"]: {k: v for k, v in p.items() if k != "name"}
-                    for p in raw_params
-                    if isinstance(p, dict) and "name" in p
-                }
-            if not isinstance(raw_params, dict):
-                raw_params = {}
+            raw_params = _normalize_params_dict(info["parameters"])
             # MCP tools have full JSON Schema; extract from "properties"
             if info.get("function") == "mcp":
                 props = raw_params.get("properties", {})
@@ -451,14 +453,7 @@ class SkillRegistry:
             # Built-in skills store a flat {param_name: {type, description, ...}} dict.
             # Self-authored skills may provide a list of {name, type, description}
             # dicts — normalise to the expected dict format.
-            if isinstance(params, list):
-                params = {
-                    p["name"]: {k: v for k, v in p.items() if k != "name"}
-                    for p in params
-                    if isinstance(p, dict) and "name" in p
-                }
-            if not isinstance(params, dict):
-                params = {}
+            params = _normalize_params_dict(params)
             properties = {}
             required = []
             for param_name, param_info in params.items():

--- a/src/shared/utils.py
+++ b/src/shared/utils.py
@@ -89,6 +89,8 @@ class StructuredFormatter(logging.Formatter):
             "module": record.name,
             "message": record.getMessage(),
         }
+        if record.exc_info:
+            log_entry["exception"] = self.formatException(record.exc_info)
         if hasattr(record, "extra_data"):
             log_entry.update(record.extra_data)
         return json.dumps(log_entry)
@@ -100,7 +102,10 @@ class TextFormatter(logging.Formatter):
     def format(self, record: logging.LogRecord) -> str:
         ts = datetime.now(UTC).strftime("%H:%M:%S")
         msg = record.getMessage()
-        return f"{ts} [{record.levelname:<5}] {record.name}: {msg}"
+        line = f"{ts} [{record.levelname:<5}] {record.name}: {msg}"
+        if record.exc_info:
+            line += "\n" + self.formatException(record.exc_info)
+        return line
 
 
 def setup_logging(name: str, level: str = "INFO") -> logging.Logger:

--- a/tests/test_skills.py
+++ b/tests/test_skills.py
@@ -7,7 +7,12 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
-from src.agent.skills import SkillRegistry, _skill_staging, skill
+from src.agent.skills import (
+    SkillRegistry,
+    _normalize_params_dict,
+    _skill_staging,
+    skill,
+)
 
 
 def setup_function():
@@ -859,3 +864,70 @@ async def test_execute_non_dict_arguments_treated_as_empty():
     for bad_args in [42, [1, 2], "hello", True, 0]:
         result = await registry.execute("safe_tool", bad_args)
         assert result == {"verbose": False}, f"Failed for arguments={bad_args!r}"
+
+
+# ── _normalize_params_dict ─────────────────────────────────────────────
+
+
+def test_normalize_params_dict_passes_through_dict():
+    params = {"x": {"type": "string"}}
+    assert _normalize_params_dict(params) == params
+
+
+def test_normalize_params_dict_converts_list():
+    params = [{"name": "x", "type": "string", "description": "an x"}]
+    result = _normalize_params_dict(params)
+    assert result == {"x": {"type": "string", "description": "an x"}}
+
+
+def test_normalize_params_dict_empty_for_invalid():
+    assert _normalize_params_dict("invalid") == {}
+    assert _normalize_params_dict(None) == {}
+    assert _normalize_params_dict(42) == {}
+
+
+def test_normalize_params_dict_skips_malformed_list_items():
+    params = [
+        {"name": "x", "type": "string"},
+        {"type": "string"},  # missing name
+        "not a dict",
+    ]
+    result = _normalize_params_dict(params)
+    assert result == {"x": {"type": "string"}}
+
+
+@pytest.mark.asyncio
+async def test_list_style_params_end_to_end():
+    """Skills with list-style params should work across all three entry points."""
+    @skill(
+        name="list_params_skill",
+        description="skill with list-style params",
+        parameters={"q": {"type": "string", "description": "query"}},
+    )
+    def list_fn(q: str) -> dict:
+        return {"q": q}
+
+    registry = SkillRegistry.__new__(SkillRegistry)
+    registry.skills = dict(_skill_staging)
+    # Simulate a self-authored skill that declared params as a list.
+    registry.skills["list_params_skill"]["parameters"] = [
+        {"name": "q", "type": "string", "description": "query"},
+    ]
+    registry._descriptions_cache = {}
+    registry._tool_defs_cache = {}
+    registry._mcp_client = None
+
+    # get_descriptions should not crash and should include the param.
+    descriptions = registry.get_descriptions()
+    assert "list_params_skill" in descriptions
+    assert "q: string" in descriptions
+
+    # get_tool_definitions should produce an OpenAI-style tool definition.
+    defs = registry.get_tool_definitions()
+    target = next(d for d in defs if d["function"]["name"] == "list_params_skill")
+    assert "q" in target["function"]["parameters"]["properties"]
+    assert target["function"]["parameters"]["properties"]["q"]["type"] == "string"
+
+    # execute should coerce and call the skill successfully.
+    result = await registry.execute("list_params_skill", {"q": 123})
+    assert result == {"q": "123"}


### PR DESCRIPTION
## Summary

Three issues found during review of PRs 694-697:

- **exc_info logging was broken in production.** `StructuredFormatter` and `TextFormatter` both ignored `record.exc_info`, so `logger.error(..., exc_info=True)` silently dropped tracebacks (JSON mode is the default). 12 call sites across 5 files were affected. Both formatters now include the formatted traceback when `exc_info` is present.
- **Revert PR 696 workaround.** PR 696 inlined `import traceback; logger.error("...", traceback.format_exc())` in `loop.py` to route around the broken formatter. With the formatter fixed, both call sites (heartbeat failure and streaming chat failure) return to the idiomatic `exc_info=True` form.
- **Deduplicate skill param normalization.** PR 695 added the same list-to-dict normalization in three places in `skills.py` (`execute`, `get_descriptions`, `get_tool_definitions`). Extracted to a `_normalize_params_dict` helper used by all three sites.

## Test plan

- [x] `pytest tests/test_skills.py -x -v` — new unit tests cover dict pass-through, list conversion, invalid input, malformed list items, and an end-to-end test that exercises all three entry points with a list-style parameter.
- [x] Full non-E2E suite: `pytest tests/ --ignore=tests/test_e2e.py --ignore=tests/test_e2e_chat.py --ignore=tests/test_e2e_memory.py --ignore=tests/test_e2e_triggering.py -x -q` — 2991 passed, 28 skipped.
- [x] `ruff check` clean on all modified files.