### PR TITLE
Fix LLM failover, SSRF, artifact permissions, and schema validation

### DIFF
--- a/src/agent/builtins/mesh_tool.py
+++ b/src/agent/builtins/mesh_tool.py
@@ -399,6 +399,9 @@ async def save_artifact(
 ) -> dict:
     if workspace_manager is None:
         return {"error": "No workspace_manager available"}
+
+    # Stage 1: write the file to disk. If this fails the work is lost, so
+    # return an error.
     try:
         artifacts_dir = Path(workspace_manager.root) / "artifacts"
         artifacts_dir.mkdir(parents=True, exist_ok=True)
@@ -407,11 +410,19 @@ async def save_artifact(
             return {"error": f"Invalid artifact name: {name}"}
         filepath.parent.mkdir(parents=True, exist_ok=True)
         filepath.write_text(content)
+    except Exception as e:
+        return {"error": f"Failed to save artifact '{name}': {e}"}
 
-        # Register on blackboard (skip for standalone agents — no project blackboard)
-        if mesh_client and not mesh_client.is_standalone:
-            agent_id = mesh_client.agent_id
-            key = f"artifacts/{agent_id}/{name}"
+    # Stage 2: register on the blackboard so teammates can discover it.
+    # This is best-effort — if it fails (permissions, transient network),
+    # the file is still on disk so we report success with a warning rather
+    # than losing the work.
+    registered = True
+    registration_error: str | None = None
+    if mesh_client and not mesh_client.is_standalone:
+        agent_id = mesh_client.agent_id
+        key = f"artifacts/{agent_id}/{name}"
+        try:
             meta = {
                 "path": str(filepath),
                 "size": len(content),
@@ -420,10 +431,19 @@ async def save_artifact(
             if description:
                 meta["description"] = description
             await mesh_client.write_blackboard(key, meta)
+        except Exception as e:
+            logger.warning(
+                "save_artifact: file written but blackboard registration failed for %s: %s",
+                key, e,
+            )
+            registered = False
+            registration_error = str(e)
 
-        return {"saved": True, "path": str(filepath), "name": name}
-    except Exception as e:
-        return {"error": f"Failed to save artifact '{name}': {e}"}
+    result: dict = {"saved": True, "path": str(filepath), "name": name}
+    if not registered:
+        result["registered"] = False
+        result["registration_error"] = registration_error
+    return result
 
 
 @skill(

--- a/src/agent/builtins/web_search_tool.py
+++ b/src/agent/builtins/web_search_tool.py
@@ -102,7 +102,10 @@ async def web_search(query: str, max_results: int = 5) -> dict:
     proxy_url = os.environ.get("HTTP_PROXY") or os.environ.get("HTTPS_PROXY")
 
     try:
-        client_kwargs: dict = {"follow_redirects": True, "timeout": 15}
+        # follow_redirects=False: the DDG HTML endpoint doesn't redirect
+        # legitimately, and enabling redirects creates SSRF risk without
+        # the hop validation that http_tool has.
+        client_kwargs: dict = {"follow_redirects": False, "timeout": 15}
         if proxy_url:
             client_kwargs["proxy"] = proxy_url
         async with httpx.AsyncClient(**client_kwargs) as client:

--- a/src/agent/skills.py
+++ b/src/agent/skills.py
@@ -38,11 +38,18 @@ def _normalize_params_dict(params: object) -> dict:
     if isinstance(params, dict):
         return params
     if isinstance(params, list):
-        return {
-            p["name"]: {k: v for k, v in p.items() if k != "name"}
-            for p in params
-            if isinstance(p, dict) and "name" in p
-        }
+        result: dict = {}
+        for p in params:
+            if not isinstance(p, dict) or "name" not in p:
+                continue
+            name = p["name"]
+            if name in result:
+                logger.warning(
+                    "Skill params contain duplicate name %r — keeping first", name,
+                )
+                continue
+            result[name] = {k: v for k, v in p.items() if k != "name"}
+        return result
     return {}
 
 
@@ -471,7 +478,14 @@ class SkillRegistry:
                 if "items" in param_info:
                     prop["items"] = param_info["items"]
                 properties[param_name] = prop
-                if "default" not in param_info:
+                # Honor explicit required metadata as well as the default-based
+                # inference — list-form self-authored skills may carry
+                # `required: true` on individual params.
+                is_required = (
+                    param_info.get("required") is True
+                    or "default" not in param_info
+                )
+                if is_required:
                     required.append(param_name)
 
             tools.append({

--- a/src/agent/workspace.py
+++ b/src/agent/workspace.py
@@ -208,7 +208,7 @@ class WorkspaceManager:
                 parts.append(f"## Session Log: {date.isoformat()}\n\n{content.strip()}")
         return "\n\n".join(parts) if parts else ""
 
-    _BOOTSTRAP_FILES = ("PROJECT.md", "SYSTEM.md", "INSTRUCTIONS.md", "SOUL.md", "USER.md", "MEMORY.md")
+    _BOOTSTRAP_FILES = ("PROJECT.md", "project.md", "SYSTEM.md", "INSTRUCTIONS.md", "SOUL.md", "USER.md", "MEMORY.md")
 
     @staticmethod
     def _get_mtime(path: Path) -> float:

--- a/src/host/credentials.py
+++ b/src/host/credentials.py
@@ -2088,20 +2088,18 @@ class CredentialVault:
                 }
                 if api_key:
                     llm_kwargs["api_key"] = api_key
-                return await litellm.acompletion(**llm_kwargs)
+                result = await litellm.acompletion(**llm_kwargs)
+                # Empty choices = failed generation — raise so failover can
+                # try the next model instead of marking this one healthy.
+                if not getattr(result, "choices", None):
+                    raise RuntimeError(
+                        f"LLM returned empty response (no choices) for model {model}"
+                    )
+                return result
 
             response, used_model = await self._call_llm_with_failover(
                 requested_model, _chat,
             )
-            if not response.choices:
-                logger.error(
-                    "LLM returned empty choices for model %s — raw response: %s",
-                    used_model, response,
-                )
-                return APIProxyResponse(
-                    success=False,
-                    error=f"LLM returned empty response (no choices) for model {used_model}",
-                )
             msg = response.choices[0].message
             usage = response.usage
             content, thinking_content = _extract_content(msg.content)

--- a/src/templates/opportunity-finder.yaml
+++ b/src/templates/opportunity-finder.yaml
@@ -139,7 +139,7 @@ agents:
       If nothing requires action, respond HEARTBEAT_OK immediately.
 
     permissions:
-      blackboard_read: ["gaps/*", "evaluations/*", "models/*", "requests/*", "tasks/*", "output/*", "status/*"]
+      blackboard_read: ["artifacts/*", "gaps/*", "evaluations/*", "models/*", "requests/*", "tasks/*", "output/*", "status/*"]
       blackboard_write: ["gaps/raw/*", "tasks/*", "output/*", "status/*"]
       can_publish: ["gaps_ready", "new_gap_found"]
       can_subscribe: ["research_requested", "evaluation_complete"]
@@ -289,7 +289,7 @@ agents:
       If nothing requires action, respond HEARTBEAT_OK immediately.
 
     permissions:
-      blackboard_read: ["gaps/*", "evaluations/*", "models/*", "requests/*", "tasks/*", "output/*", "status/*"]
+      blackboard_read: ["artifacts/*", "gaps/*", "evaluations/*", "models/*", "requests/*", "tasks/*", "output/*", "status/*"]
       blackboard_write: ["evaluations/*", "tasks/*", "output/*", "status/*"]
       can_publish: ["evaluation_complete", "more_evidence_needed"]
       can_subscribe: ["gaps_ready", "new_gap_found"]
@@ -498,8 +498,8 @@ agents:
       If nothing requires action, respond HEARTBEAT_OK immediately.
 
     permissions:
-      blackboard_read: ["gaps/*", "evaluations/*", "models/*", "requests/*", "tasks/*", "output/*", "status/*"]
-      blackboard_write: ["models/*", "tasks/*", "output/*", "status/*"]
+      blackboard_read: ["artifacts/*", "gaps/*", "evaluations/*", "models/*", "requests/*", "tasks/*", "output/*", "status/*"]
+      blackboard_write: ["artifacts/*", "models/*", "tasks/*", "output/*", "status/*"]
       can_publish: ["model_complete"]
       can_subscribe: ["evaluation_complete"]
     resources:

--- a/tests/test_credentials.py
+++ b/tests/test_credentials.py
@@ -274,6 +274,52 @@ async def test_handle_llm_all_models_exhausted(monkeypatch):
     assert "down" in result.error
 
 
+async def test_handle_llm_empty_choices_triggers_failover(monkeypatch):
+    """HTTP 200 with empty choices must raise so failover kicks in —
+    otherwise the broken model gets marked healthy and keeps serving
+    empty responses.
+    """
+    monkeypatch.setenv("OPENLEGION_SYSTEM_GEMINI_API_KEY", "sk-gem")
+    monkeypatch.setenv("OPENLEGION_SYSTEM_OPENAI_API_KEY", "sk-oai")
+    v = CredentialVault(
+        failover_config={"gemini/gemini-2.5-pro": ["openai/gpt-4o-mini"]},
+    )
+
+    call_count = 0
+
+    async def mock_acompletion(model, messages, api_key, **kwargs):
+        nonlocal call_count
+        call_count += 1
+        if model.startswith("gemini/"):
+            # Simulate the broken response: HTTP 200, no choices.
+            resp = MagicMock()
+            resp.choices = []
+            return resp
+        # Fallback succeeds.
+        resp = MagicMock()
+        resp.choices = [MagicMock()]
+        resp.choices[0].message.content = "recovered"
+        resp.choices[0].message.tool_calls = None
+        resp.usage = MagicMock()
+        resp.usage.total_tokens = 7
+        return resp
+
+    with patch("litellm.acompletion", side_effect=mock_acompletion):
+        req = APIProxyRequest(
+            service="llm", action="chat",
+            params={
+                "model": "gemini/gemini-2.5-pro",
+                "messages": [{"role": "user", "content": "hi"}],
+            },
+        )
+        result = await v.execute_api_call(req)
+
+    assert result.success, f"Expected failover to succeed, got: {result.error}"
+    assert result.data["content"] == "recovered"
+    assert result.data["model"] == "openai/gpt-4o-mini"
+    assert call_count == 2
+
+
 async def test_stream_failover(monkeypatch):
     """Streaming: first model fails on connection, second streams OK."""
     monkeypatch.setenv("OPENLEGION_SYSTEM_ANTHROPIC_API_KEY", "sk-ant")

--- a/tests/test_skills.py
+++ b/tests/test_skills.py
@@ -931,3 +931,50 @@ async def test_list_style_params_end_to_end():
     # execute should coerce and call the skill successfully.
     result = await registry.execute("list_params_skill", {"q": 123})
     assert result == {"q": "123"}
+
+
+def test_normalize_params_dict_warns_on_duplicate_names(caplog):
+    params = [
+        {"name": "x", "type": "string", "description": "first"},
+        {"name": "x", "type": "integer", "description": "second"},
+    ]
+    with caplog.at_level("WARNING", logger="agent.skills"):
+        result = _normalize_params_dict(params)
+    # First wins, second discarded.
+    assert result == {"x": {"type": "string", "description": "first"}}
+    assert any("duplicate" in rec.message for rec in caplog.records)
+
+
+@pytest.mark.asyncio
+async def test_list_style_params_explicit_required_honored():
+    """List-form params with explicit required:true should mark the param required."""
+    @skill(
+        name="explicit_required_skill",
+        description="skill with explicit required param",
+        parameters={"q": {"type": "string"}},
+    )
+    def explicit_fn(q: str = "default") -> dict:
+        return {"q": q}
+
+    registry = SkillRegistry.__new__(SkillRegistry)
+    registry.skills = dict(_skill_staging)
+    # List form with an explicit `required: true` flag on a param that also
+    # carries a `default` (which would normally mark it optional).
+    registry.skills["explicit_required_skill"]["parameters"] = [
+        {
+            "name": "q",
+            "type": "string",
+            "description": "query",
+            "required": True,
+            "default": "x",
+        },
+    ]
+    registry._descriptions_cache = {}
+    registry._tool_defs_cache = {}
+    registry._mcp_client = None
+
+    defs = registry.get_tool_definitions()
+    target = next(
+        d for d in defs if d["function"]["name"] == "explicit_required_skill"
+    )
+    assert "q" in target["function"]["parameters"]["required"]

--- a/tests/test_templates.py
+++ b/tests/test_templates.py
@@ -595,3 +595,29 @@ class TestCreateAgentFromTemplate(_TempConfigMixin):
             cfg = yaml.safe_load(f)
         budget = cfg["agents"]["my_eng"].get("budget", {})
         assert budget.get("daily_usd") == 10.0
+
+
+def test_opportunity_finder_artifact_permissions():
+    """Modeler writes artifacts via save_artifact; researcher and evaluator
+    need to discover them. All three must grant artifacts/* on the blackboard
+    (read) and the modeler additionally on write.
+    """
+    template_path = (
+        Path(__file__).resolve().parent.parent
+        / "src" / "templates" / "opportunity-finder.yaml"
+    )
+    data = yaml.safe_load(template_path.read_text())
+    agents = data["agents"]
+
+    for agent_id in ("gap-scout", "evaluator", "modeler"):
+        perms = agents[agent_id]["permissions"]
+        reads = perms.get("blackboard_read", [])
+        assert "artifacts/*" in reads, (
+            f"{agent_id} must be able to read artifacts/* on the blackboard"
+        )
+
+    # Modeler is the one calling save_artifact.
+    modeler_writes = agents["modeler"]["permissions"].get("blackboard_write", [])
+    assert "artifacts/*" in modeler_writes, (
+        "modeler must have artifacts/* in blackboard_write to register saved artifacts"
+    )


### PR DESCRIPTION
Fixes 6 issues found during review of PRs 694-697:

1. Empty LLM choices now trigger failover (was silently marked healthy)
2. Opportunity-finder template grants artifacts/* permission to agents
   that use save_artifact (modeler/researcher/evaluator)
3. save_artifact degrades gracefully if blackboard registration fails
4. web_search disables follow_redirects to prevent SSRF via malicious
   redirects (DDG HTML endpoint doesn't legitimately redirect anyway)
5. Bootstrap cache now tracks both PROJECT.md and project.md so edits
   to the lowercase fallback invalidate the cache
6. Skill params honor explicit required field; duplicate list entries
   warn instead of silently overwriting

## Test plan
- [x] tests/test_skills.py (new duplicate-name and explicit-required tests)
- [x] tests/test_templates.py (new opportunity-finder permissions test)
- [x] tests/test_credentials.py (new empty-choices failover test)
- [x] tests/test_web_search_tool.py
- [x] tests/test_workspace.py
- [x] Full suite minus E2E: 2994 passed, 28 skipped (1 pre-existing version-flag failure deselected — unrelated to these changes, happens because openlegion isn't pip-installed in worktree)