### PR TITLE
Fix template artifact permissions and remove noisy PROJECT.md warning

### DIFF
--- a/src/agent/workspace.py
+++ b/src/agent/workspace.py
@@ -261,12 +261,9 @@ class WorkspaceManager:
         project = self._read_file("PROJECT.md") or self._read_file("project.md")
         if project and project.strip():
             parts.append(_maybe_add_header("PROJECT.md", project.strip()))
-        else:
-            ws_files = sorted(p.name for p in self.root.iterdir()) if self.root.exists() else []
-            logger.warning(
-                "PROJECT.md not found in workspace %s — files present: %s",
-                self.root, ws_files,
-            )
+        # Note: missing PROJECT.md is normal for standalone agents (not in a
+        # project). No warning — the dashboard pushes PROJECT.md only for agents
+        # assigned to a project.
 
         # SYSTEM.md — generated architecture guide (static preamble + snapshot)
         system = self._read_file("SYSTEM.md")

--- a/src/templates/content.yaml
+++ b/src/templates/content.yaml
@@ -46,7 +46,7 @@ agents:
       searches fall short, you try different angles. You organize findings
       clearly so the writer can work efficiently.
     permissions:
-      blackboard_read: ["sources/*", "drafts/*", "requests/*", "tasks/*", "output/*", "status/*"]
+      blackboard_read: ["sources/*", "drafts/*", "requests/*", "tasks/*", "output/*", "status/*", "artifacts/*"]
       blackboard_write: ["sources/*", "tasks/*", "output/*", "status/*"]
       can_publish: ["research_complete"]
       can_subscribe: ["content_requested"]
@@ -110,8 +110,8 @@ agents:
       You use concrete examples and avoid filler. Your writing is clear,
       scannable, and backed by the research brief.
     permissions:
-      blackboard_read: ["sources/*", "drafts/*", "feedback/*", "tasks/*", "output/*", "status/*"]
-      blackboard_write: ["drafts/*", "tasks/*", "output/*", "status/*"]
+      blackboard_read: ["sources/*", "drafts/*", "feedback/*", "tasks/*", "output/*", "status/*", "artifacts/*"]
+      blackboard_write: ["drafts/*", "tasks/*", "output/*", "status/*", "artifacts/*"]
       can_publish: ["draft_ready"]
       can_subscribe: ["research_complete", "revision_requested"]
     resources:
@@ -172,7 +172,7 @@ agents:
       rewrites, not vague critiques. You catch factual errors, weak arguments,
       and unclear phrasing. You approve strong work quickly.
     permissions:
-      blackboard_read: ["sources/*", "drafts/*", "feedback/*", "tasks/*", "output/*", "status/*"]
+      blackboard_read: ["sources/*", "drafts/*", "feedback/*", "tasks/*", "output/*", "status/*", "artifacts/*"]
       blackboard_write: ["feedback/*", "tasks/*", "output/*", "status/*"]
       can_publish: ["edit_complete", "revision_requested"]
       can_subscribe: ["draft_ready"]

--- a/src/templates/deep-research.yaml
+++ b/src/templates/deep-research.yaml
@@ -57,7 +57,7 @@ agents:
       evidence. You always cite your sources. When a search comes up empty, you try
       different terms before giving up.
     permissions:
-      blackboard_read: ["sources/*", "requests/*", "analysis/*", "tasks/*", "output/*", "status/*"]
+      blackboard_read: ["sources/*", "requests/*", "analysis/*", "tasks/*", "output/*", "status/*", "artifacts/*"]
       blackboard_write: ["sources/*", "tasks/*", "output/*", "status/*"]
       can_publish: ["sources_ready"]
       can_subscribe: ["research_requested", "more_sources_needed"]
@@ -120,7 +120,7 @@ agents:
       uncertainty — you never overstate confidence. You find the signal
       in the noise. You always read the sources before forming conclusions.
     permissions:
-      blackboard_read: ["sources/*", "analysis/*", "requests/*", "tasks/*", "output/*", "status/*"]
+      blackboard_read: ["sources/*", "analysis/*", "requests/*", "tasks/*", "output/*", "status/*", "artifacts/*"]
       blackboard_write: ["analysis/*", "tasks/*", "output/*", "status/*"]
       can_publish: ["analysis_ready", "more_sources_needed"]
       can_subscribe: ["sources_ready"]
@@ -181,8 +181,8 @@ agents:
       You make complex topics accessible without dumbing them down.
       You are concise — you respect the reader's time.
     permissions:
-      blackboard_read: ["sources/*", "analysis/*", "reports/*", "tasks/*", "output/*", "status/*"]
-      blackboard_write: ["reports/*", "tasks/*", "output/*", "status/*"]
+      blackboard_read: ["sources/*", "analysis/*", "reports/*", "tasks/*", "output/*", "status/*", "artifacts/*"]
+      blackboard_write: ["reports/*", "tasks/*", "output/*", "status/*", "artifacts/*"]
       can_publish: ["report_ready"]
       can_subscribe: ["analysis_ready"]
     resources:

--- a/src/templates/lead-enrichment.yaml
+++ b/src/templates/lead-enrichment.yaml
@@ -165,7 +165,7 @@ agents:
       - Call update_status() with your current state
 
     permissions:
-      blackboard_read: ["leads/*", "tasks/*", "output/*", "status/*"]
+      blackboard_read: ["leads/*", "tasks/*", "output/*", "status/*", "artifacts/*"]
       blackboard_write: ["leads/*", "tasks/*", "output/*", "status/*"]
       can_publish: ["lead_enriched", "batch_complete"]
       can_subscribe: ["enrich_requested"]
@@ -263,8 +263,8 @@ agents:
       - Call update_status() with your current state
 
     permissions:
-      blackboard_read: ["leads/*", "tasks/*", "output/*", "status/*"]
-      blackboard_write: ["leads/exports/*", "tasks/*", "output/*", "status/*"]
+      blackboard_read: ["leads/*", "tasks/*", "output/*", "status/*", "artifacts/*"]
+      blackboard_write: ["leads/exports/*", "tasks/*", "output/*", "status/*", "artifacts/*"]
       can_publish: ["export_ready"]
       can_subscribe: ["lead_enriched", "batch_complete"]
     resources:

--- a/src/templates/price-intelligence.yaml
+++ b/src/templates/price-intelligence.yaml
@@ -162,7 +162,7 @@ agents:
         extract: current Buy Box price and availability
 
     permissions:
-      blackboard_read: ["prices/*", "tasks/*", "output/*", "status/*"]
+      blackboard_read: ["prices/*", "tasks/*", "output/*", "status/*", "artifacts/*"]
       blackboard_write: ["prices/*", "tasks/*", "output/*", "status/*"]
       can_publish: ["price_change", "extraction_failed"]
       can_subscribe: ["check_requested"]
@@ -286,8 +286,8 @@ agents:
       - Call update_status() with your current state
 
     permissions:
-      blackboard_read: ["prices/*", "tasks/*", "output/*", "status/*"]
-      blackboard_write: ["prices/*/analysis", "tasks/*", "output/*", "status/*"]
+      blackboard_read: ["prices/*", "tasks/*", "output/*", "status/*", "artifacts/*"]
+      blackboard_write: ["prices/*/analysis", "tasks/*", "output/*", "status/*", "artifacts/*"]
       can_publish: ["price_report_ready"]
       can_subscribe: ["price_change"]
     resources:

--- a/src/templates/research.yaml
+++ b/src/templates/research.yaml
@@ -92,8 +92,8 @@ agents:
       discrepancy. You respect the user's time by leading with what matters
       most.
     permissions:
-      blackboard_read: ["research/*", "sources/*", "tasks/*", "output/*", "status/*"]
-      blackboard_write: ["research/*", "sources/*", "tasks/*", "output/*", "status/*"]
+      blackboard_read: ["research/*", "sources/*", "tasks/*", "output/*", "status/*", "artifacts/*"]
+      blackboard_write: ["research/*", "sources/*", "tasks/*", "output/*", "status/*", "artifacts/*"]
       can_publish: ["research_complete"]
       can_subscribe: ["research_requested"]
     resources:

--- a/src/templates/review-ops.yaml
+++ b/src/templates/review-ops.yaml
@@ -147,7 +147,7 @@ agents:
         product_slug: your-product
 
     permissions:
-      blackboard_read: ["reviews/*", "tasks/*", "output/*", "status/*"]
+      blackboard_read: ["reviews/*", "tasks/*", "output/*", "status/*", "artifacts/*"]
       blackboard_write: ["reviews/*", "tasks/*", "output/*", "status/*"]
       can_publish: ["new_review", "negative_review"]
       can_subscribe: []
@@ -331,8 +331,8 @@ agents:
       - Call update_status() with your current state
 
     permissions:
-      blackboard_read: ["reviews/*", "tasks/*", "output/*", "status/*"]
-      blackboard_write: ["reviews/*/draft", "tasks/*", "output/*", "status/*"]
+      blackboard_read: ["reviews/*", "tasks/*", "output/*", "status/*", "artifacts/*"]
+      blackboard_write: ["reviews/*/draft", "tasks/*", "output/*", "status/*", "artifacts/*"]
       can_publish: ["response_drafted"]
       can_subscribe: ["negative_review"]
     resources:

--- a/src/templates/sales.yaml
+++ b/src/templates/sales.yaml
@@ -53,7 +53,7 @@ agents:
       You focus on information that helps qualify and personalize outreach:
       company size, tech decisions, recent changes, and named contacts.
     permissions:
-      blackboard_read: ["leads/*", "tasks/*", "output/*", "status/*"]
+      blackboard_read: ["leads/*", "tasks/*", "output/*", "status/*", "artifacts/*"]
       blackboard_write: ["leads/*/research", "tasks/*", "output/*", "status/*"]
       can_publish: ["research_complete"]
       can_subscribe: ["lead_added"]
@@ -117,7 +117,7 @@ agents:
       You explain your reasoning clearly. You flag missing information
       rather than guessing. A disqualified lead saves everyone time.
     permissions:
-      blackboard_read: ["leads/*", "tasks/*", "output/*", "status/*"]
+      blackboard_read: ["leads/*", "tasks/*", "output/*", "status/*", "artifacts/*"]
       blackboard_write: ["leads/*/qualification", "tasks/*", "output/*", "status/*"]
       can_publish: ["qualified", "disqualified"]
       can_subscribe: ["research_complete"]
@@ -182,8 +182,8 @@ agents:
       details from the research — never generic claims. You are concise,
       respectful of the recipient's time, and focused on value.
     permissions:
-      blackboard_read: ["leads/*", "tasks/*", "output/*", "status/*"]
-      blackboard_write: ["leads/*/outreach", "tasks/*", "output/*", "status/*"]
+      blackboard_read: ["leads/*", "tasks/*", "output/*", "status/*", "artifacts/*"]
+      blackboard_write: ["leads/*/outreach", "tasks/*", "output/*", "status/*", "artifacts/*"]
       can_publish: ["outreach_ready"]
       can_subscribe: ["qualified"]
     resources:

--- a/src/templates/social-listening.yaml
+++ b/src/templates/social-listening.yaml
@@ -144,7 +144,7 @@ agents:
       Rotate through these during each heartbeat cycle.
 
     permissions:
-      blackboard_read: ["signals/*", "drafts/*", "tasks/*", "output/*", "status/*"]
+      blackboard_read: ["signals/*", "drafts/*", "tasks/*", "output/*", "status/*", "artifacts/*"]
       blackboard_write: ["signals/*", "tasks/*", "output/*", "status/*"]
       can_publish: ["signal_found"]
       can_subscribe: ["draft_complete"]
@@ -290,8 +290,8 @@ agents:
       - Call update_status() with your current state
 
     permissions:
-      blackboard_read: ["signals/*", "drafts/*", "tasks/*", "output/*", "status/*"]
-      blackboard_write: ["drafts/*", "tasks/*", "output/*", "status/*"]
+      blackboard_read: ["signals/*", "drafts/*", "tasks/*", "output/*", "status/*", "artifacts/*"]
+      blackboard_write: ["drafts/*", "tasks/*", "output/*", "status/*", "artifacts/*"]
       can_publish: ["draft_complete"]
       can_subscribe: ["signal_found"]
     resources:

--- a/tests/test_templates.py
+++ b/tests/test_templates.py
@@ -621,3 +621,39 @@ def test_opportunity_finder_artifact_permissions():
     assert "artifacts/*" in modeler_writes, (
         "modeler must have artifacts/* in blackboard_write to register saved artifacts"
     )
+
+
+def test_all_templates_save_artifact_has_permission():
+    """Any agent using save_artifact must have artifacts/* in blackboard_write.
+
+    Regression guard for the template permission bug found in PR review.
+    save_artifact writes a file and registers metadata at artifacts/{agent}/{name}
+    on the blackboard. Without artifacts/* in blackboard_write, the registration
+    fails silently and the artifact is invisible to blackboard-based discovery.
+    """
+    template_dir = Path(__file__).resolve().parent.parent / "src" / "templates"
+    issues: list[str] = []
+
+    for yaml_file in sorted(template_dir.glob("*.yaml")):
+        with open(yaml_file) as f:
+            tpl = yaml.safe_load(f)
+
+        agents = tpl.get("agents", {}) or {}
+        for agent_id, agent in agents.items():
+            instructions = agent.get("instructions", "") or ""
+            if "save_artifact" not in instructions:
+                continue
+
+            perms = agent.get("permissions", {}) or {}
+            writes = perms.get("blackboard_write", []) or []
+
+            # Check for "*" wildcard or explicit "artifacts/*"
+            has_perm = any(w == "artifacts/*" or w == "*" for w in writes)
+
+            if not has_perm:
+                issues.append(
+                    f"{yaml_file.name}:{agent_id} uses save_artifact but "
+                    f"blackboard_write={writes} lacks artifacts/*"
+                )
+
+    assert not issues, "\n".join(issues)


### PR DESCRIPTION
## Summary

- **Fix 8 fleet templates** that had agents using `save_artifact()` without `artifacts/*` in `blackboard_write`. `save_artifact` writes the file successfully but blackboard registration was failing silently (per-file artifact discovery still works via the agent HTTP endpoint, but inter-agent blackboard discovery was broken). Also added `artifacts/*` to `blackboard_read` for all agents in these templates so they can discover each other's artifacts.
- **Remove noisy warning** in `workspace.py` that fired on every bootstrap load for every standalone/unassigned agent whenever `PROJECT.md` was missing. Missing `PROJECT.md` is normal — the dashboard pushes it only for agents assigned to a project.
- **Add regression test** in `test_templates.py` that scans all templates and fails if any `save_artifact`-using agent lacks `artifacts/*` in `blackboard_write`.

## Templates fixed
- content.yaml
- deep-research.yaml
- lead-enrichment.yaml
- price-intelligence.yaml
- research.yaml
- review-ops.yaml
- sales.yaml
- social-listening.yaml

## Test plan
- [x] `pytest tests/test_templates.py tests/test_workspace.py -v` (146 passed)
- [x] Full suite: `pytest tests/ --ignore=tests/test_e2e.py --ignore=tests/test_e2e_chat.py --ignore=tests/test_e2e_memory.py --ignore=tests/test_e2e_triggering.py -x -q` (2996 passed, 28 skipped)