### PR TITLE
Treat empty streaming LLM responses as failure; widen test scope

### DIFF
--- a/src/host/credentials.py
+++ b/src/host/credentials.py
@@ -1362,6 +1362,16 @@ class CredentialVault:
 
             # Emit final done event
             tokens_used = input_tokens + output_tokens
+            # Treat zero-output responses as a failure so the model falls out of
+            # rotation instead of staying healthy.
+            if not collected_content and not collected_thinking and not collected_tool_calls:
+                logger.warning(
+                    "Anthropic OAuth streaming: model %s produced no content/thinking/tool_calls — marking failure",
+                    model,
+                )
+                self._health_tracker.record_failure(model, "EmptyResponse", 0)
+                yield f"data: {json.dumps({'error': f'Model {model} returned empty response'})}\n\n"
+                return
             self._health_tracker.record_success(model)
             done_data: dict = {
                 "type": "done",
@@ -2025,6 +2035,14 @@ class CredentialVault:
                         return
 
             tokens_used = input_tokens + output_tokens
+            if not collected_content and not collected_thinking and not collected_tool_calls:
+                logger.warning(
+                    "OpenAI Codex streaming: model %s produced no content/thinking/tool_calls — marking failure",
+                    model,
+                )
+                self._health_tracker.record_failure(model, "EmptyResponse", 0)
+                yield f"data: {json.dumps({'error': f'Model {model} returned empty response'})}\n\n"
+                return
             self._health_tracker.record_success(model)
 
             done_data: dict = {
@@ -2370,12 +2388,17 @@ class CredentialVault:
                     "Model %s returned only reasoning tokens — using as content",
                     used_model,
                 )
-            elif not collected_content and not collected_thinking:
+            elif not collected_content and not collected_thinking and not collected_tool_calls:
                 logger.warning(
-                    "Model %s produced no content and no reasoning tokens "
-                    "(tokens_used=%d)",
+                    "Model %s produced no content, reasoning tokens, or tool calls "
+                    "(tokens_used=%d) — marking failure",
                     used_model, tokens_used,
                 )
+                self._health_tracker.record_failure(
+                    used_model, "EmptyResponse", 0,
+                )
+                yield f"data: {json.dumps({'error': f'Model {used_model} returned empty response'})}\n\n"
+                return
 
             self._health_tracker.record_success(used_model)
             done_data: dict = {

--- a/tests/test_builtins.py
+++ b/tests/test_builtins.py
@@ -1970,6 +1970,40 @@ class TestStandaloneBlackboardGuards:
         mc.write_blackboard.assert_not_awaited()
 
     @pytest.mark.asyncio
+    async def test_save_artifact_blackboard_failure_is_graceful(self, tmp_path):
+        """If file write succeeds but blackboard registration fails, the file
+        is still saved and the result reports registered=False with the error."""
+        from src.agent.builtins.mesh_tool import save_artifact
+
+        workspace_manager = MagicMock()
+        workspace_manager.root = str(tmp_path)
+
+        mesh_client = MagicMock()
+        mesh_client.is_standalone = False
+        mesh_client.agent_id = "test-agent"
+        mesh_client.write_blackboard = AsyncMock(
+            side_effect=PermissionError("Agent cannot write to artifacts/*")
+        )
+
+        result = await save_artifact(
+            name="test.md",
+            content="test content",
+            description="a test artifact",
+            mesh_client=mesh_client,
+            workspace_manager=workspace_manager,
+        )
+
+        # File should be saved to disk
+        assert result["saved"] is True
+        assert (tmp_path / "artifacts" / "test.md").read_text() == "test content"
+        # Registration should be marked as failed
+        assert result["registered"] is False
+        assert (
+            "artifacts/*" in result["registration_error"]
+            or "Permission" in result["registration_error"]
+        )
+
+    @pytest.mark.asyncio
     async def test_read_blackboard_allowed_for_project_agent(self):
         """Project agents are NOT blocked by the standalone guard."""
         from src.agent.builtins.mesh_tool import read_blackboard

--- a/tests/test_templates.py
+++ b/tests/test_templates.py
@@ -640,8 +640,15 @@ def test_all_templates_save_artifact_has_permission():
 
         agents = tpl.get("agents", {}) or {}
         for agent_id, agent in agents.items():
-            instructions = agent.get("instructions", "") or ""
-            if "save_artifact" not in instructions:
+            # Scan all live prompt fields, not just instructions
+            prompt_fields = [
+                agent.get("instructions", ""),
+                agent.get("heartbeat", ""),
+                agent.get("initial_interface", ""),
+                agent.get("soul", ""),
+            ]
+            combined = "\n".join(str(f) for f in prompt_fields if f)
+            if "save_artifact" not in combined:
                 continue
 
             perms = agent.get("permissions", {}) or {}


### PR DESCRIPTION
## Summary

Three fixes from the final Codex review:

- **Streaming failover hardening (HIGH):** Three streaming LLM paths in `src/host/credentials.py` (Anthropic OAuth, OpenAI Codex, LiteLLM) were calling `record_success` after collecting zero content/thinking/tool_calls, leaving broken models healthy and in rotation. Now marks them as failures with an `EmptyResponse` reason so failover kicks in on the next request. Each path also yields a structured error event before returning, instead of emitting a `done` event with empty content.
- **Template test scope (MEDIUM):** `test_all_templates_save_artifact_has_permission` only scanned the `instructions` field for `save_artifact`. Widened to also scan `heartbeat`, `initial_interface`, and `soul` so future templates that call the tool from those prompt surfaces cannot bypass the permission check.
- **save_artifact graceful degradation test (LOW):** Added a regression test that mocks a `PermissionError` on `write_blackboard` and asserts the file is still written, `saved=True`, `registered=False`, and `registration_error` surfaces the underlying error.

## Test plan

- [x] `pytest tests/test_credentials.py tests/test_templates.py tests/test_builtins.py -v -k "save_artifact or failover or template or empty"` (67 passed)
- [x] Full suite excluding E2E: `pytest tests/ --ignore=tests/test_e2e.py --ignore=tests/test_e2e_chat.py --ignore=tests/test_e2e_memory.py --ignore=tests/test_e2e_triggering.py -x -q` (2997 passed, 28 skipped)