### PR TITLE
Plumb initial_interface from templates to INTERFACE.md scaffold

### DIFF
--- a/src/agent/__main__.py
+++ b/src/agent/__main__.py
@@ -72,6 +72,7 @@ def main() -> None:
     initial_instructions = os.environ.get("INITIAL_INSTRUCTIONS", "")
     initial_soul = os.environ.get("INITIAL_SOUL", "")
     initial_heartbeat = os.environ.get("INITIAL_HEARTBEAT", "")
+    initial_interface = os.environ.get("INITIAL_INTERFACE", "")
 
     skills = SkillRegistry(skills_dir=skills_dir, mcp_client=mcp_client)
 
@@ -84,6 +85,7 @@ def main() -> None:
         initial_instructions=initial_instructions,
         initial_soul=initial_soul,
         initial_heartbeat=initial_heartbeat,
+        initial_interface=initial_interface,
     )
 
     # Copy host-mounted PROJECT.md into workspace (mounted at /app to avoid

--- a/src/agent/builtins/operator_tools.py
+++ b/src/agent/builtins/operator_tools.py
@@ -31,7 +31,7 @@ _OPERATOR_PERMISSION_CEILING = {
 
 _VALID_FIELDS = frozenset({
     "instructions", "soul", "model", "role", "heartbeat",
-    "thinking", "budget", "permissions",
+    "interface", "thinking", "budget", "permissions",
 })
 
 _OPERATOR_AGENT_ID = "operator"
@@ -43,7 +43,7 @@ _OPERATOR_AGENT_ID = "operator"
         "Propose a change to an agent's configuration. Returns a preview diff "
         "and change_id for confirmation. Always show the preview to the user "
         "and wait for their approval before calling confirm_edit.\n\n"
-        "Fields: instructions, soul, model, role, heartbeat, thinking, budget, permissions.\n"
+        "Fields: instructions, soul, model, role, heartbeat, interface, thinking, budget, permissions.\n"
         "Value format: string for text fields, object for budget/permissions.\n"
         "- budget: {\"daily_usd\": float, \"monthly_usd\": float}\n"
         "- permissions: {\"can_use_browser\": bool, ...}\n"
@@ -60,7 +60,7 @@ _OPERATOR_AGENT_ID = "operator"
             "description": "Config field to change",
             "enum": [
                 "instructions", "soul", "model", "role", "heartbeat",
-                "thinking", "budget", "permissions",
+                "interface", "thinking", "budget", "permissions",
             ],
         },
         "value": {

--- a/src/agent/workspace.py
+++ b/src/agent/workspace.py
@@ -121,11 +121,13 @@ class WorkspaceManager:
         initial_instructions: str = "",
         initial_soul: str = "",
         initial_heartbeat: str = "",
+        initial_interface: str = "",
     ):
         self.root = Path(workspace_dir)
         self._initial_instructions = initial_instructions
         self._initial_soul = initial_soul
         self._initial_heartbeat = initial_heartbeat
+        self._initial_interface = initial_interface
         self._ensure_scaffold()
 
         # Caches — invalidated by mtime changes or explicit writes
@@ -183,6 +185,13 @@ class WorkspaceManager:
                     content = (
                         "# Heartbeat Rules\n\n"
                         + self._initial_heartbeat.strip()
+                        + "\n"
+                    )
+                    path.write_text(content)
+                elif filename == "INTERFACE.md" and self._initial_interface:
+                    content = (
+                        "# Interface\n\n"
+                        + self._initial_interface.strip()
                         + "\n"
                     )
                     path.write_text(content)

--- a/src/cli/config.py
+++ b/src/cli/config.py
@@ -399,6 +399,7 @@ def _add_agent_to_config(
     initial_instructions: str = "",
     initial_soul: str = "",
     initial_heartbeat: str = "",
+    initial_interface: str = "",
     thinking: str = "",
     budget: dict | None = None,
     resources: dict | None = None,
@@ -422,6 +423,8 @@ def _add_agent_to_config(
         entry["initial_soul"] = initial_soul
     if initial_heartbeat:
         entry["initial_heartbeat"] = initial_heartbeat
+    if initial_interface:
+        entry["initial_interface"] = initial_interface
     if thinking:
         entry["thinking"] = thinking
     if budget:
@@ -897,6 +900,7 @@ def _apply_template(template_name: str, tpl: dict) -> list[str]:
         instructions = agent_def.get("instructions", "") or agent_def.get("system_prompt", "")
         soul = agent_def.get("soul", "")
         heartbeat = agent_def.get("heartbeat", "")
+        interface = agent_def.get("initial_interface", "") or agent_def.get("interface", "")
         thinking = agent_def.get("thinking", "")
         budget = agent_def.get("budget")
         agent_permissions = agent_def.get("permissions")
@@ -909,6 +913,7 @@ def _apply_template(template_name: str, tpl: dict) -> list[str]:
             initial_instructions=instructions,
             initial_soul=soul,
             initial_heartbeat=heartbeat,
+            initial_interface=interface,
             thinking=thinking,
             budget=budget,
             resources=resources,
@@ -976,6 +981,7 @@ def _create_agent_from_template(
     instructions = agent_def.get("instructions", "") or agent_def.get("system_prompt", "")
     soul = agent_def.get("soul", "")
     heartbeat = agent_def.get("heartbeat", "")
+    interface = agent_def.get("initial_interface", "") or agent_def.get("interface", "")
     thinking = agent_def.get("thinking", "")
     budget = agent_def.get("budget")
     resources = agent_def.get("resources")
@@ -988,6 +994,7 @@ def _create_agent_from_template(
         initial_instructions=instructions,
         initial_soul=soul,
         initial_heartbeat=heartbeat,
+        initial_interface=interface,
         thinking=thinking,
         budget=budget,
         resources=resources,

--- a/src/cli/runtime.py
+++ b/src/cli/runtime.py
@@ -366,6 +366,9 @@ class RuntimeContext:
             initial_heartbeat = agent_cfg.get("initial_heartbeat", "")
             if initial_heartbeat:
                 agent_env["INITIAL_HEARTBEAT"] = initial_heartbeat
+            initial_interface = agent_cfg.get("initial_interface", "")
+            if initial_interface:
+                agent_env["INITIAL_INTERFACE"] = initial_interface
             if agent_id == _OPERATOR_AGENT_ID:
                 agent_env["ALLOWED_TOOLS"] = ",".join(_OPERATOR_ALLOWED_TOOLS)
 
@@ -432,6 +435,7 @@ class RuntimeContext:
                 self.runtime.extra_env.pop("INITIAL_INSTRUCTIONS", None)
                 self.runtime.extra_env.pop("INITIAL_SOUL", None)
                 self.runtime.extra_env.pop("INITIAL_HEARTBEAT", None)
+                self.runtime.extra_env.pop("INITIAL_INTERFACE", None)
                 self.runtime.extra_env.pop("PROJECT_MD_PATH", None)
                 self.runtime.extra_env.pop("PROJECT_NAME", None)
                 self.runtime.extra_env.pop("HTTP_PROXY", None)

--- a/src/host/server.py
+++ b/src/host/server.py
@@ -1489,6 +1489,7 @@ def create_mesh_app(
                 ("INITIAL_INSTRUCTIONS", "initial_instructions"),
                 ("INITIAL_SOUL", "initial_soul"),
                 ("INITIAL_HEARTBEAT", "initial_heartbeat"),
+                ("INITIAL_INTERFACE", "initial_interface"),
             ):
                 val = acfg.get(cfg_key, "")
                 if val:
@@ -2236,10 +2237,15 @@ def create_mesh_app(
 
     # === Operator Config Endpoints ===
 
-    _VALID_CONFIG_FIELDS = {"instructions", "soul", "model", "role", "heartbeat", "thinking", "budget", "permissions"}
+    _VALID_CONFIG_FIELDS = {
+        "instructions", "soul", "model", "role", "heartbeat",
+        "interface", "thinking", "budget", "permissions",
+    }
     _CONFIG_FIELD_MAP = {
         "instructions": "initial_instructions", "soul": "initial_soul",
-        "heartbeat": "initial_heartbeat", "model": "model", "role": "role",
+        "heartbeat": "initial_heartbeat",
+        "interface": "initial_interface",
+        "model": "model", "role": "role",
         "thinking": "thinking", "budget": "budget",
     }
 
@@ -2358,6 +2364,7 @@ def create_mesh_app(
                 "instructions": "INSTRUCTIONS.md",
                 "soul": "SOUL.md",
                 "heartbeat": "HEARTBEAT.md",
+                "interface": "INTERFACE.md",
             }
             ws_file = workspace_map.get(field)
             if ws_file and isinstance(new_value, str):

--- a/tests/test_operator_tools.py
+++ b/tests/test_operator_tools.py
@@ -46,6 +46,26 @@ async def test_propose_edit_validates_field():
 
 
 @pytest.mark.asyncio
+async def test_propose_edit_accepts_interface_field():
+    """The 'interface' field should be valid and forwarded to the mesh."""
+    from src.agent.builtins.operator_tools import propose_edit
+
+    mc = MagicMock()
+    mc.propose_config_change = AsyncMock(
+        return_value={"change_id": "iface1", "preview_diff": "..."},
+    )
+    result = await propose_edit(
+        "writer", "interface", "Accepts research, produces notes.",
+        mesh_client=mc,
+    )
+    assert "error" not in result
+    assert result["change_id"] == "iface1"
+    mc.propose_config_change.assert_awaited_once_with(
+        "writer", "interface", "Accepts research, produces notes.",
+    )
+
+
+@pytest.mark.asyncio
 async def test_propose_edit_permission_ceiling_can_spawn():
     from src.agent.builtins.operator_tools import propose_edit
 

--- a/tests/test_templates.py
+++ b/tests/test_templates.py
@@ -84,6 +84,18 @@ class TestAddAgentToConfig(_TempConfigMixin):
             cfg = yaml.safe_load(f)
         assert cfg["agents"]["dave"]["initial_heartbeat"] == "Check alerts."
 
+    def test_initial_interface(self):
+        _add_agent_to_config(
+            "iris", "scout", "openai/gpt-4o",
+            initial_interface="Accepts research, produces notes.",
+        )
+        with open(self._agents_path) as f:
+            cfg = yaml.safe_load(f)
+        assert (
+            cfg["agents"]["iris"]["initial_interface"]
+            == "Accepts research, produces notes."
+        )
+
     def test_thinking(self):
         _add_agent_to_config("eve", "analyst", "openai/gpt-4o", thinking="medium")
         with open(self._agents_path) as f:
@@ -112,6 +124,7 @@ class TestAddAgentToConfig(_TempConfigMixin):
         assert "initial_soul" not in agent
         assert "initial_heartbeat" not in agent
         assert "initial_instructions" not in agent
+        assert "initial_interface" not in agent
         assert "thinking" not in agent
         assert "budget" not in agent
         assert "resources" not in agent
@@ -123,6 +136,7 @@ class TestAddAgentToConfig(_TempConfigMixin):
             initial_instructions="Do stuff.",
             initial_soul="Be nice.",
             initial_heartbeat="Check things.",
+            initial_interface="Accepts X, produces Y.",
             thinking="high",
             budget={"daily_usd": 10.0},
             resources={"memory_limit": "512m"},
@@ -133,6 +147,7 @@ class TestAddAgentToConfig(_TempConfigMixin):
         assert agent["initial_instructions"] == "Do stuff."
         assert agent["initial_soul"] == "Be nice."
         assert agent["initial_heartbeat"] == "Check things."
+        assert agent["initial_interface"] == "Accepts X, produces Y."
         assert agent["thinking"] == "high"
         assert agent["budget"]["daily_usd"] == 10.0
         assert agent["resources"]["memory_limit"] == "512m"
@@ -257,6 +272,7 @@ class TestApplyTemplate(_TempConfigMixin):
                     "instructions": "Find sources.",
                     "soul": "You are curious.",
                     "heartbeat": "Check news.",
+                    "initial_interface": "Accepts research requests, produces notes.",
                     "thinking": "medium",
                     "budget": {"daily_usd": 5.0, "monthly_usd": 100.0},
                 },
@@ -272,8 +288,43 @@ class TestApplyTemplate(_TempConfigMixin):
         assert scout["initial_instructions"] == "Find sources."
         assert scout["initial_soul"] == "You are curious."
         assert scout["initial_heartbeat"] == "Check news."
+        assert (
+            scout["initial_interface"]
+            == "Accepts research requests, produces notes."
+        )
         assert scout["thinking"] == "medium"
         assert scout["budget"]["daily_usd"] == 5.0
+
+    def test_initial_interface_persisted_from_real_template(self):
+        """At least one bundled template declares initial_interface; applying
+        it must persist the contract to agents.yaml so peers can discover it."""
+        from src.cli.config import _load_templates
+        templates = _load_templates()
+        candidate = None
+        for tpl_name, tpl in templates.items():
+            for agent_id, agent_def in tpl.get("agents", {}).items():
+                if agent_def.get("initial_interface"):
+                    candidate = (tpl_name, agent_id, agent_def["initial_interface"])
+                    break
+            if candidate:
+                break
+
+        assert candidate is not None, (
+            "Expected at least one bundled template to declare "
+            "initial_interface for the pipeline test"
+        )
+        tpl_name, agent_id, expected_interface = candidate
+        full_tpl = templates[tpl_name]
+
+        with self._mock_config():
+            created = _apply_template(tpl_name, full_tpl)
+
+        assert agent_id in created
+        with open(self._agents_path) as f:
+            cfg = yaml.safe_load(f)
+        assert (
+            cfg["agents"][agent_id]["initial_interface"] == expected_interface
+        )
 
     def test_resources_written_in_single_pass(self):
         """Resources are included in the same agents.yaml write, not a separate re-read."""

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -137,8 +137,52 @@ class TestWorkspaceScaffold:
         finally:
             shutil.rmtree(tmpdir, ignore_errors=True)
 
-    def test_all_three_seeded_together(self):
-        """All three initial_* params work simultaneously."""
+    def test_initial_interface_seeds_interface_md(self):
+        """When initial_interface is provided, INTERFACE.md is seeded with that content."""
+        tmpdir = tempfile.mkdtemp()
+        try:
+            interface_content = (
+                "## Accepts\n- research requests\n## Produces\n- notes.md"
+            )
+            WorkspaceManager(
+                workspace_dir=tmpdir, initial_interface=interface_content,
+            )
+            root = Path(tmpdir)
+            content = (root / "INTERFACE.md").read_text()
+            assert content.startswith("# Interface")
+            assert "Accepts" in content
+            assert "research requests" in content
+            assert "notes.md" in content
+        finally:
+            shutil.rmtree(tmpdir, ignore_errors=True)
+
+    def test_initial_interface_does_not_overwrite_existing(self):
+        """If INTERFACE.md already exists, initial_interface is ignored."""
+        tmpdir = tempfile.mkdtemp()
+        try:
+            root = Path(tmpdir)
+            root.mkdir(exist_ok=True)
+            (root / "INTERFACE.md").write_text("# Custom contract\nDo not touch.")
+            WorkspaceManager(
+                workspace_dir=tmpdir, initial_interface="New contract",
+            )
+            assert (root / "INTERFACE.md").read_text() == "# Custom contract\nDo not touch."
+        finally:
+            shutil.rmtree(tmpdir, ignore_errors=True)
+
+    def test_initial_interface_empty_uses_default(self):
+        """When initial_interface is empty, default scaffold content is used."""
+        tmpdir = tempfile.mkdtemp()
+        try:
+            WorkspaceManager(workspace_dir=tmpdir, initial_interface="")
+            root = Path(tmpdir)
+            content = (root / "INTERFACE.md").read_text()
+            assert content.strip() == "# Interface"  # minimal stub
+        finally:
+            shutil.rmtree(tmpdir, ignore_errors=True)
+
+    def test_all_four_seeded_together(self):
+        """All four initial_* params work simultaneously."""
         tmpdir = tempfile.mkdtemp()
         try:
             WorkspaceManager(
@@ -146,11 +190,15 @@ class TestWorkspaceScaffold:
                 initial_instructions="Do research.",
                 initial_soul="You are curious.",
                 initial_heartbeat="Monitor news.",
+                initial_interface="Accepts research, produces notes.",
             )
             root = Path(tmpdir)
             assert "Do research." in (root / "INSTRUCTIONS.md").read_text()
             assert "You are curious." in (root / "SOUL.md").read_text()
             assert "Monitor news." in (root / "HEARTBEAT.md").read_text()
+            assert "Accepts research, produces notes." in (
+                root / "INTERFACE.md"
+            ).read_text()
         finally:
             shutil.rmtree(tmpdir, ignore_errors=True)
 


### PR DESCRIPTION
## Summary
- Templates declare `initial_interface` for 27+ agents to define their coordination contracts (what they accept, produce, how to interact), but the field was silently discarded because the config and runtime pipeline only handled `initial_instructions`, `initial_soul`, and `initial_heartbeat`. Agents scaffolded a blank `# Interface\n` file, so `get_agent_profile()` returned empty contracts to peers and multi-agent coordination lost the declared contract surface exactly where templates depended on it.
- Adds `initial_interface` through the full pipeline: template YAML -> `_add_agent_to_config` -> `agents.yaml` -> `INITIAL_INTERFACE` env var (both CLI startup in `src/cli/runtime.py` and the dashboard-initiated start in `src/host/server.py`) -> `WorkspaceManager` -> `INTERFACE.md` seeded on first boot.
- Adds `interface` to the operator's `propose_edit` field allowlist, the mesh `_VALID_CONFIG_FIELDS` / `_CONFIG_FIELD_MAP`, and the live workspace push map so operator edits hot-reload INTERFACE.md on the running agent.

## Test plan
- [x] `pytest tests/test_workspace.py tests/test_templates.py tests/test_operator_tools.py tests/test_operator_config.py -q` (224 passed)
- [x] Full unit/integration suite: `pytest tests/ --ignore=tests/test_e2e.py --ignore=tests/test_e2e_chat.py --ignore=tests/test_e2e_memory.py --ignore=tests/test_e2e_triggering.py --deselect tests/test_cli_commands.py::TestVersion::test_version_flag -q` (3002 passed, pre-existing `--version` failure unrelated to this branch)
- [x] `ruff check src/ tests/` clean