### PR TITLE
Add CAPTCHA auto-solving via 2Captcha and CapSolver

### DIFF
--- a/src/agent/builtins/browser_tool.py
+++ b/src/agent/builtins/browser_tool.py
@@ -519,8 +519,9 @@ async def browser_switch_tab(tab_index: int = -1, *, mesh_client=None) -> dict:
     name="browser_detect_captcha",
     description=(
         "Detect CAPTCHAs (reCAPTCHA, hCaptcha, Cloudflare Turnstile) on the "
-        "current page. If found, the CAPTCHA must be solved manually via VNC. "
-        "Usually not needed — browser_navigate auto-detects CAPTCHAs."
+        "current page. When a CAPTCHA solver is configured, CAPTCHAs are "
+        "solved automatically after navigation. If auto-solving fails or no "
+        "solver is configured, the CAPTCHA must be solved manually via VNC."
     ),
     parameters={},
     parallel_safe=False,

--- a/src/browser/captcha.py
+++ b/src/browser/captcha.py
@@ -1,0 +1,348 @@
+"""CAPTCHA-solving service integration.
+
+Supports 2Captcha and CapSolver as solving providers.  Both are called via
+their public HTTP APIs using httpx — no additional dependencies required.
+
+When configured (via CAPTCHA_SOLVER_PROVIDER and CAPTCHA_SOLVER_KEY env vars),
+the browser service will automatically attempt to solve CAPTCHAs detected
+after navigation.  If solving fails or no solver is configured, the existing
+fallback (ask user via VNC) is preserved.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import re
+
+import httpx
+
+from src.shared.utils import setup_logging
+
+logger = setup_logging("browser.captcha")
+
+_SOLVE_TIMEOUT = 120  # max seconds to wait for a solution
+_POLL_INTERVAL = 5    # seconds between result polls
+_SUPPORTED_PROVIDERS = ("2captcha", "capsolver")
+
+# Map from detected selector pattern to a canonical CAPTCHA type.
+_CAPTCHA_TYPE_MAP: dict[str, str] = {
+    "recaptcha": "recaptcha",
+    "hcaptcha": "hcaptcha",
+    "challenges.cloudflare.com": "turnstile",
+    "cf-turnstile": "turnstile",
+    "captcha": "recaptcha",  # generic fallback — most common type
+}
+
+# 2Captcha task type mapping
+_2CAPTCHA_TASK_TYPES: dict[str, str] = {
+    "recaptcha": "NormalRecaptchaTaskProxyless",
+    "hcaptcha": "HCaptchaTaskProxyless",
+    "turnstile": "TurnstileTaskProxyless",
+}
+
+# CapSolver task type mapping
+_CAPSOLVER_TASK_TYPES: dict[str, str] = {
+    "recaptcha": "ReCaptchaV2TaskProxyLess",
+    "hcaptcha": "HCaptchaTaskProxyLess",
+    "turnstile": "AntiTurnstileTaskProxyLess",
+}
+
+
+def get_solver() -> CaptchaSolver | None:
+    """Create a CaptchaSolver from environment variables, or None if not configured."""
+    provider = os.environ.get("CAPTCHA_SOLVER_PROVIDER", "").strip().lower()
+    api_key = os.environ.get("CAPTCHA_SOLVER_KEY", "").strip()
+    if not provider or not api_key:
+        return None
+    if provider not in _SUPPORTED_PROVIDERS:
+        logger.warning(
+            "Unknown CAPTCHA_SOLVER_PROVIDER %r (expected one of %s), solver disabled",
+            provider,
+            ", ".join(_SUPPORTED_PROVIDERS),
+        )
+        return None
+    logger.info("CAPTCHA solver configured: provider=%s", provider)
+    return CaptchaSolver(provider, api_key)
+
+
+def _classify_captcha(selector: str) -> str:
+    """Map a CSS selector string to a canonical CAPTCHA type."""
+    sel_lower = selector.lower()
+    for pattern, captcha_type in _CAPTCHA_TYPE_MAP.items():
+        if pattern in sel_lower:
+            return captcha_type
+    return "recaptcha"  # safe default
+
+
+class CaptchaSolver:
+    """Async CAPTCHA solver using 2Captcha or CapSolver HTTP APIs."""
+
+    def __init__(self, provider: str, api_key: str):
+        self.provider = provider
+        self.api_key = api_key
+        self._client: httpx.AsyncClient | None = None
+
+    def _get_client(self) -> httpx.AsyncClient:
+        if self._client is None or self._client.is_closed:
+            self._client = httpx.AsyncClient(timeout=30)
+        return self._client
+
+    async def close(self) -> None:
+        if self._client and not self._client.is_closed:
+            await self._client.aclose()
+            self._client = None
+
+    async def solve(self, page, selector: str, page_url: str) -> bool:
+        """Attempt to solve a CAPTCHA on the page.
+
+        Args:
+            page: Playwright page object.
+            selector: The CSS selector that matched the CAPTCHA element.
+            page_url: The current page URL.
+
+        Returns:
+            True if the CAPTCHA was solved and token injected, False otherwise.
+        """
+        captcha_type = _classify_captcha(selector)
+        logger.info("Attempting to solve %s CAPTCHA on %s", captcha_type, page_url)
+
+        sitekey = await self._extract_sitekey(page, captcha_type)
+        if not sitekey:
+            logger.warning("Could not extract sitekey for %s CAPTCHA", captcha_type)
+            return False
+
+        try:
+            token = await asyncio.wait_for(
+                self._submit_and_poll(captcha_type, sitekey, page_url),
+                timeout=_SOLVE_TIMEOUT,
+            )
+        except asyncio.TimeoutError:
+            logger.warning("CAPTCHA solve timed out after %ds", _SOLVE_TIMEOUT)
+            return False
+        except Exception:
+            logger.exception("CAPTCHA solve failed")
+            return False
+
+        if not token:
+            return False
+
+        injected = await self._inject_token(page, captcha_type, token)
+        if injected:
+            logger.info("CAPTCHA solved and token injected successfully")
+        else:
+            logger.warning("CAPTCHA solved but token injection failed")
+        return injected
+
+    async def _extract_sitekey(self, page, captcha_type: str) -> str | None:
+        """Extract the sitekey from the page DOM."""
+        try:
+            # Try data-sitekey attribute first (works for reCAPTCHA, hCaptcha, Turnstile)
+            sitekey = await page.evaluate(
+                "() => document.querySelector('[data-sitekey]')?.getAttribute('data-sitekey')"
+            )
+            if sitekey:
+                return sitekey.strip()
+
+            # Fall back to parsing iframe src for sitekey parameter
+            if captcha_type == "recaptcha":
+                src = await page.evaluate(
+                    "() => document.querySelector('iframe[src*=\"recaptcha\"]')?.src"
+                )
+                if src:
+                    match = re.search(r'[?&]k=([^&]+)', src)
+                    if match:
+                        return match.group(1)
+
+            if captcha_type == "hcaptcha":
+                src = await page.evaluate(
+                    "() => document.querySelector('iframe[src*=\"hcaptcha\"]')?.src"
+                )
+                if src:
+                    match = re.search(r'[?&]sitekey=([^&]+)', src)
+                    if match:
+                        return match.group(1)
+
+            if captcha_type == "turnstile":
+                # Turnstile sometimes stores config in a script or div attribute
+                sitekey = await page.evaluate("""() => {
+                    const el = document.querySelector('[class*="cf-turnstile"]');
+                    return el?.getAttribute('data-sitekey') || null;
+                }""")
+                if sitekey:
+                    return sitekey.strip()
+
+        except Exception:
+            logger.debug("Error extracting sitekey", exc_info=True)
+        return None
+
+    async def _submit_and_poll(self, captcha_type: str, sitekey: str, page_url: str) -> str | None:
+        """Submit CAPTCHA to solving service and poll for result."""
+        if self.provider == "2captcha":
+            return await self._solve_2captcha(captcha_type, sitekey, page_url)
+        return await self._solve_capsolver(captcha_type, sitekey, page_url)
+
+    # ── 2Captcha ──────────────────────────────────────────────────────────────
+
+    async def _solve_2captcha(self, captcha_type: str, sitekey: str, page_url: str) -> str | None:
+        client = self._get_client()
+        task_type = _2CAPTCHA_TASK_TYPES.get(captcha_type)
+        if not task_type:
+            return None
+
+        # Submit task
+        payload = {
+            "clientKey": self.api_key,
+            "task": {
+                "type": task_type,
+                "websiteURL": page_url,
+                "websiteKey": sitekey,
+            },
+        }
+        resp = await client.post("https://api.2captcha.com/createTask", json=payload)
+        resp.raise_for_status()
+        data = resp.json()
+        if data.get("errorId", 0) != 0:
+            logger.warning("2Captcha submit error: %s", data.get("errorDescription"))
+            return None
+        task_id = data.get("taskId")
+        if not task_id:
+            return None
+
+        # Poll for result
+        for _ in range(int(_SOLVE_TIMEOUT / _POLL_INTERVAL)):
+            await asyncio.sleep(_POLL_INTERVAL)
+            resp = await client.post(
+                "https://api.2captcha.com/getTaskResult",
+                json={"clientKey": self.api_key, "taskId": task_id},
+            )
+            resp.raise_for_status()
+            data = resp.json()
+            if data.get("errorId", 0) != 0:
+                logger.warning("2Captcha poll error: %s", data.get("errorDescription"))
+                return None
+            if data.get("status") == "ready":
+                solution = data.get("solution", {})
+                return solution.get("gRecaptchaResponse") or solution.get("token")
+            # status == "processing" — keep polling
+        return None
+
+    # ── CapSolver ─────────────────────────────────────────────────────────────
+
+    async def _solve_capsolver(self, captcha_type: str, sitekey: str, page_url: str) -> str | None:
+        client = self._get_client()
+        task_type = _CAPSOLVER_TASK_TYPES.get(captcha_type)
+        if not task_type:
+            return None
+
+        # Submit task
+        payload = {
+            "clientKey": self.api_key,
+            "task": {
+                "type": task_type,
+                "websiteURL": page_url,
+                "websiteKey": sitekey,
+            },
+        }
+        resp = await client.post("https://api.capsolver.com/createTask", json=payload)
+        resp.raise_for_status()
+        data = resp.json()
+        if data.get("errorId", 0) != 0:
+            logger.warning("CapSolver submit error: %s", data.get("errorDescription"))
+            return None
+        task_id = data.get("taskId")
+        if not task_id:
+            return None
+
+        # Poll for result
+        for _ in range(int(_SOLVE_TIMEOUT / _POLL_INTERVAL)):
+            await asyncio.sleep(_POLL_INTERVAL)
+            resp = await client.post(
+                "https://api.capsolver.com/getTaskResult",
+                json={"clientKey": self.api_key, "taskId": task_id},
+            )
+            resp.raise_for_status()
+            data = resp.json()
+            if data.get("errorId", 0) != 0:
+                logger.warning("CapSolver poll error: %s", data.get("errorDescription"))
+                return None
+            if data.get("status") == "ready":
+                solution = data.get("solution", {})
+                return solution.get("gRecaptchaResponse") or solution.get("token")
+        return None
+
+    # ── Token injection ───────────────────────────────────────────────────────
+
+    async def _inject_token(self, page, captcha_type: str, token: str) -> bool:
+        """Inject the solved CAPTCHA token into the page."""
+        try:
+            if captcha_type == "recaptcha":
+                await page.evaluate("""(token) => {
+                    const textarea = document.getElementById('g-recaptcha-response');
+                    if (textarea) {
+                        textarea.style.display = '';
+                        textarea.value = token;
+                    }
+                    // Also try hidden textareas in iframes
+                    document.querySelectorAll('[name="g-recaptcha-response"]').forEach(el => {
+                        el.value = token;
+                    });
+                    // Trigger callback if available
+                    if (typeof ___grecaptcha_cfg !== 'undefined') {
+                        const clients = ___grecaptcha_cfg.clients;
+                        if (clients) {
+                            for (const cid in clients) {
+                                const client = clients[cid];
+                                // Walk the client object to find the callback
+                                const walk = (obj, depth) => {
+                                    if (depth > 5 || !obj) return;
+                                    for (const key in obj) {
+                                        if (typeof obj[key] === 'function' && key === 'callback') {
+                                            obj[key](token);
+                                            return;
+                                        }
+                                        if (typeof obj[key] === 'object') walk(obj[key], depth + 1);
+                                    }
+                                };
+                                walk(client, 0);
+                            }
+                        }
+                    }
+                }""", token)
+                return True
+
+            if captcha_type == "hcaptcha":
+                await page.evaluate("""(token) => {
+                    const textarea = document.querySelector('[name="h-captcha-response"]');
+                    if (textarea) textarea.value = token;
+                    document.querySelectorAll('[name="g-recaptcha-response"]').forEach(el => {
+                        el.value = token;
+                    });
+                    // Trigger hcaptcha callback
+                    if (typeof hcaptcha !== 'undefined' && hcaptcha.getRespKey) {
+                        try { hcaptcha.execute(); } catch(e) {}
+                    }
+                }""", token)
+                return True
+
+            if captcha_type == "turnstile":
+                await page.evaluate("""(token) => {
+                    // Find the Turnstile response input
+                    const input = document.querySelector('[name="cf-turnstile-response"]')
+                        || document.querySelector('input[name*="turnstile"]');
+                    if (input) input.value = token;
+                    // Trigger callback if available
+                    if (typeof turnstile !== 'undefined') {
+                        try {
+                            const widgetId = turnstile.getResponse ? null : Object.keys(turnstile._widgets || {})[0];
+                            if (widgetId && turnstile._widgets[widgetId]?.callback) {
+                                turnstile._widgets[widgetId].callback(token);
+                            }
+                        } catch(e) {}
+                    }
+                }""", token)
+                return True
+
+        except Exception:
+            logger.debug("Token injection error", exc_info=True)
+        return False

--- a/src/browser/service.py
+++ b/src/browser/service.py
@@ -18,6 +18,7 @@ import uuid
 from pathlib import Path
 from urllib.parse import urlparse
 
+from src.browser.captcha import get_solver
 from src.browser.redaction import CredentialRedactor
 from src.browser.stealth import build_launch_options
 from src.browser.timing import (
@@ -288,6 +289,7 @@ class BrowserManager:
         self.redactor = CredentialRedactor()
         self._proxy_configs: dict[str, dict | None] = {}
         self.boot_id: str = str(uuid.uuid4())
+        self._captcha_solver = get_solver()
 
     async def start_cleanup_loop(self):
         """Start background task that cleans up idle browsers."""
@@ -546,6 +548,8 @@ class BrowserManager:
         async with self._lock:
             for agent_id in list(self._instances.keys()):
                 await self._stop_instance(agent_id)
+        if self._captcha_solver:
+            await self._captcha_solver.close()
         if self._playwright:
             with contextlib.suppress(Exception):
                 await self._pw_context.__aexit__(None, None, None)
@@ -1807,11 +1811,10 @@ class BrowserManager:
                 return {"success": False, "error": str(e)}
 
     async def _check_captcha(self, inst: CamoufoxInstance) -> dict | None:
-        """Check for CAPTCHA elements on the current page.
+        """Check for CAPTCHA elements and attempt auto-solve if configured.
 
-        Returns a dict with captcha details if found, None otherwise.
-        Called automatically after navigation so agents are always
-        aware when a CAPTCHA is blocking progress.
+        Returns a dict with captcha details if found and unsolved, None if
+        no CAPTCHA or if it was solved automatically.
         """
         captcha_selectors = [
             'iframe[src*="recaptcha"]',
@@ -1825,6 +1828,16 @@ class BrowserManager:
         try:
             for sel in captcha_selectors:
                 if await inst.page.locator(sel).count() > 0:
+                    # Attempt auto-solve if a solver is configured
+                    if self._captcha_solver:
+                        logger.info("CAPTCHA detected (%s), attempting auto-solve", sel)
+                        solved = await self._captcha_solver.solve(
+                            inst.page, sel, inst.page.url,
+                        )
+                        if solved:
+                            return None  # solved — don't report to agent
+                        logger.warning("Auto-solve failed, falling back to manual")
+
                     return {
                         "type": sel,
                         "message": (

--- a/src/host/runtime.py
+++ b/src/host/runtime.py
@@ -394,6 +394,11 @@ class DockerBackend(RuntimeBackend):
             if os.environ.get(var):
                 environment[var] = os.environ[var]
 
+        for var in ("CAPTCHA_SOLVER_PROVIDER", "CAPTCHA_SOLVER_KEY"):
+            env_val = os.environ.get(f"OPENLEGION_{var}") or os.environ.get(var)
+            if env_val:
+                environment[var] = env_val
+
         with self._port_lock:
             api_port = self._next_port
             self._next_port += 1

--- a/tests/test_browser_service.py
+++ b/tests/test_browser_service.py
@@ -3,6 +3,7 @@
 import asyncio
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import httpx
 import pytest
 
 from src.browser.service import BrowserManager, CamoufoxInstance
@@ -2832,6 +2833,7 @@ class TestCaptchaDetection:
         from src.browser.service import BrowserManager
 
         mgr = BrowserManager.__new__(BrowserManager)
+        mgr._captcha_solver = None
         inst = MagicMock()
         inst.page = AsyncMock()
         inst.lock = asyncio.Lock()
@@ -2881,6 +2883,7 @@ class TestCaptchaDetection:
         from src.browser.service import BrowserManager
 
         mgr = BrowserManager.__new__(BrowserManager)
+        mgr._captcha_solver = None
         inst = MagicMock()
         inst.page = AsyncMock()
         inst.lock = asyncio.Lock()
@@ -5033,3 +5036,214 @@ class TestBrowserManagerProxyConfig:
         manager.set_proxy_config("agent-1", {"url": "http://host:8080"})
         manager.set_proxy_config("agent-1", None)
         assert manager.get_proxy_config("agent-1") is None
+
+
+# ── CAPTCHA solver tests ─────────────────────────────────────────────────────
+
+
+class TestGetSolver:
+    """Tests for captcha.get_solver() factory function."""
+
+    def test_get_solver_returns_none_when_not_configured(self):
+        """No env vars → None."""
+        with patch.dict("os.environ", {}, clear=True):
+            from src.browser.captcha import get_solver
+            assert get_solver() is None
+
+    def test_get_solver_returns_solver_when_configured(self):
+        """Valid provider + key → CaptchaSolver instance."""
+        with patch.dict("os.environ", {
+            "CAPTCHA_SOLVER_PROVIDER": "2captcha",
+            "CAPTCHA_SOLVER_KEY": "test-key-123",
+        }):
+            from src.browser.captcha import CaptchaSolver, get_solver
+            solver = get_solver()
+            assert isinstance(solver, CaptchaSolver)
+            assert solver.provider == "2captcha"
+            assert solver.api_key == "test-key-123"
+
+    def test_get_solver_rejects_unknown_provider(self):
+        """Unknown provider → None with warning."""
+        with patch.dict("os.environ", {
+            "CAPTCHA_SOLVER_PROVIDER": "badprovider",
+            "CAPTCHA_SOLVER_KEY": "key",
+        }):
+            from src.browser.captcha import get_solver
+            assert get_solver() is None
+
+
+class TestClassifyCaptcha:
+    """Tests for captcha._classify_captcha()."""
+
+    def test_classify_captcha(self):
+        from src.browser.captcha import _classify_captcha
+        assert _classify_captcha('iframe[src*="recaptcha"]') == "recaptcha"
+        assert _classify_captcha('iframe[src*="hcaptcha"]') == "hcaptcha"
+        assert _classify_captcha('iframe[src*="challenges.cloudflare.com"]') == "turnstile"
+        assert _classify_captcha('[class*="cf-turnstile"]') == "turnstile"
+        assert _classify_captcha('#captcha') == "recaptcha"  # generic fallback
+        assert _classify_captcha('[class*="captcha"]') == "recaptcha"
+        assert _classify_captcha("something-unknown") == "recaptcha"  # default
+
+
+class TestCaptchaSolverSolve:
+    """Tests for CaptchaSolver.solve() and provider flows."""
+
+    @pytest.mark.asyncio
+    async def test_solve_2captcha_success(self):
+        """Mock a successful 2Captcha create+poll flow."""
+        from src.browser.captcha import CaptchaSolver
+
+        solver = CaptchaSolver("2captcha", "test-key")
+
+        # Mock page
+        page = AsyncMock()
+        page.evaluate = AsyncMock(return_value="site-key-abc")
+        page.url = "https://example.com"
+
+        # Mock httpx responses
+        mock_client = AsyncMock(spec=httpx.AsyncClient)
+        mock_client.is_closed = False
+
+        create_resp = MagicMock()
+        create_resp.json.return_value = {"errorId": 0, "taskId": "task-123"}
+        create_resp.raise_for_status = MagicMock()
+
+        poll_resp = MagicMock()
+        poll_resp.json.return_value = {
+            "errorId": 0,
+            "status": "ready",
+            "solution": {"gRecaptchaResponse": "solved-token-xyz"},
+        }
+        poll_resp.raise_for_status = MagicMock()
+
+        mock_client.post = AsyncMock(side_effect=[create_resp, poll_resp])
+        solver._client = mock_client
+
+        result = await solver.solve(page, 'iframe[src*="recaptcha"]', "https://example.com")
+        assert result is True
+        # Verify token was injected
+        page.evaluate.assert_called()
+
+    @pytest.mark.asyncio
+    async def test_solve_capsolver_success(self):
+        """Mock a successful CapSolver create+poll flow."""
+        from src.browser.captcha import CaptchaSolver
+
+        solver = CaptchaSolver("capsolver", "cap-key")
+
+        page = AsyncMock()
+        page.evaluate = AsyncMock(return_value="site-key-abc")
+        page.url = "https://example.com"
+
+        mock_client = AsyncMock(spec=httpx.AsyncClient)
+        mock_client.is_closed = False
+
+        create_resp = MagicMock()
+        create_resp.json.return_value = {"errorId": 0, "taskId": "task-456"}
+        create_resp.raise_for_status = MagicMock()
+
+        poll_resp = MagicMock()
+        poll_resp.json.return_value = {
+            "errorId": 0,
+            "status": "ready",
+            "solution": {"token": "capsolver-token-xyz"},
+        }
+        poll_resp.raise_for_status = MagicMock()
+
+        mock_client.post = AsyncMock(side_effect=[create_resp, poll_resp])
+        solver._client = mock_client
+
+        result = await solver.solve(page, 'iframe[src*="hcaptcha"]', "https://example.com")
+        assert result is True
+
+    @pytest.mark.asyncio
+    async def test_solve_timeout(self):
+        """Verify timeout when solving takes too long."""
+        from src.browser.captcha import CaptchaSolver
+
+        solver = CaptchaSolver("2captcha", "test-key")
+
+        page = AsyncMock()
+        page.evaluate = AsyncMock(return_value="site-key-abc")
+        page.url = "https://example.com"
+
+        mock_client = AsyncMock(spec=httpx.AsyncClient)
+        mock_client.is_closed = False
+
+        create_resp = MagicMock()
+        create_resp.json.return_value = {"errorId": 0, "taskId": "task-789"}
+        create_resp.raise_for_status = MagicMock()
+
+        # Poll always returns processing — will eventually time out
+        poll_resp = MagicMock()
+        poll_resp.json.return_value = {"errorId": 0, "status": "processing"}
+        poll_resp.raise_for_status = MagicMock()
+
+        mock_client.post = AsyncMock(side_effect=[create_resp] + [poll_resp] * 100)
+        solver._client = mock_client
+
+        # Patch _SOLVE_TIMEOUT to make test fast
+        with patch("src.browser.captcha._SOLVE_TIMEOUT", 0.1), \
+             patch("src.browser.captcha._POLL_INTERVAL", 0.01):
+            result = await solver.solve(page, 'iframe[src*="recaptcha"]', "https://example.com")
+        assert result is False
+
+    @pytest.mark.asyncio
+    async def test_solve_no_sitekey_returns_false(self):
+        """Page with no sitekey → solve returns False."""
+        from src.browser.captcha import CaptchaSolver
+
+        solver = CaptchaSolver("2captcha", "test-key")
+
+        page = AsyncMock()
+        page.evaluate = AsyncMock(return_value=None)  # no sitekey found
+        page.url = "https://example.com"
+
+        result = await solver.solve(page, 'iframe[src*="recaptcha"]', "https://example.com")
+        assert result is False
+
+
+class TestCheckCaptchaAutoSolve:
+    """Tests for BrowserManager._check_captcha with auto-solve integration."""
+
+    @pytest.mark.asyncio
+    async def test_check_captcha_auto_solves(self):
+        """When solver succeeds, _check_captcha returns None (no CAPTCHA reported)."""
+        manager = BrowserManager(profiles_dir="/tmp/test_profiles_captcha1")
+
+        mock_solver = AsyncMock()
+        mock_solver.solve = AsyncMock(return_value=True)
+        manager._captcha_solver = mock_solver
+
+        # Mock instance with a page that has a CAPTCHA (no spec — CamoufoxInstance
+        # restricts .page access)
+        inst = MagicMock()
+        mock_locator = MagicMock()
+        mock_locator.count = AsyncMock(return_value=1)
+        inst.page.locator = MagicMock(return_value=mock_locator)
+        inst.page.url = "https://example.com"
+
+        result = await manager._check_captcha(inst)
+        assert result is None  # solved — not reported
+        mock_solver.solve.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_check_captcha_falls_back_on_failure(self):
+        """When solver fails, _check_captcha returns fallback dict."""
+        manager = BrowserManager(profiles_dir="/tmp/test_profiles_captcha2")
+
+        mock_solver = AsyncMock()
+        mock_solver.solve = AsyncMock(return_value=False)
+        manager._captcha_solver = mock_solver
+
+        inst = MagicMock()
+        mock_locator = MagicMock()
+        mock_locator.count = AsyncMock(return_value=1)
+        inst.page.locator = MagicMock(return_value=mock_locator)
+        inst.page.url = "https://example.com"
+
+        result = await manager._check_captcha(inst)
+        assert result is not None
+        assert "CAPTCHA detected" in result["message"]
+        mock_solver.solve.assert_called_once()


### PR DESCRIPTION
## Summary

- Adds automatic CAPTCHA solving when `CAPTCHA_SOLVER_PROVIDER` and `CAPTCHA_SOLVER_KEY` env vars are configured
- Supports **2Captcha** and **CapSolver** — the two most popular solving services (~$1-3 per 1000 solves)
- Handles **reCAPTCHA**, **hCaptcha**, and **Cloudflare Turnstile**
- Transparent to agents — CAPTCHAs are solved during navigation, agent never sees them
- Falls back to existing manual-solve-via-VNC behavior when solving fails or no solver is configured
- **No new dependencies** — uses httpx (already a project dep) for HTTP API calls

## How it works

1. Agent calls `browser_navigate` → page loads → `_check_captcha` detects a CAPTCHA
2. Solver extracts sitekey from the DOM (data-sitekey attribute or iframe src parsing)
3. Submits to 2Captcha/CapSolver API → polls for result (5s interval, 120s timeout)
4. Injects solution token back into the page via `page.evaluate()`
5. If successful, `_check_captcha` returns None — agent never sees the CAPTCHA
6. If failed, returns the existing fallback message ("ask user via VNC")

## Configuration

```bash
# In .env
OPENLEGION_CAPTCHA_SOLVER_PROVIDER=2captcha   # or "capsolver"
OPENLEGION_CAPTCHA_SOLVER_KEY=your_api_key
```

## Changes

| File | Change |
|---|---|
| `src/browser/captcha.py` | **New** — solver client with sitekey extraction, API submission/polling, token injection |
| `src/browser/service.py` | Wire solver into `_check_captcha` — auto-solve before falling back to manual |
| `src/host/runtime.py` | Forward solver env vars to browser container |
| `src/agent/builtins/browser_tool.py` | Update `browser_detect_captcha` description |
| `tests/test_browser_service.py` | 10 new tests covering solver flows, fallbacks, and integration |

## Test plan

- [x] All 271 tests pass (`pytest tests/ --ignore=tests/test_e2e*.py -x`)
- [x] Lint clean
- [ ] Manual test with 2Captcha account on a reCAPTCHA-protected site
- [ ] Manual test with CapSolver account on a Cloudflare Turnstile site

🤖 Generated with [Claude Code](https://claude.com/claude-code)