### PR TITLE
fix: Anthropic OAuth temperature restriction + defensive schema normalization

### DIFF
--- a/src/host/credentials.py
+++ b/src/host/credentials.py
@@ -1023,6 +1023,37 @@ class CredentialVault:
         ):
             extra["reasoning_effort"] = "none"
 
+        # Anthropic's tool input_schema validator rejects array-valued
+        # ``type`` fields. Normalize tool schemas before handing them to
+        # LiteLLM on the non-OAuth Anthropic path. The OAuth fast path
+        # (``_build_anthropic_body``) applies the same normalization at
+        # its own seam.
+        if self._resolve_provider(model) == "anthropic" and extra.get("tools"):
+            normalized_tools: list = []
+            for tool in extra["tools"]:
+                if not isinstance(tool, dict):
+                    normalized_tools.append(tool)
+                    continue
+                func = tool.get("function")
+                if isinstance(func, dict) and "parameters" in func:
+                    new_func = {
+                        **func,
+                        "parameters": self._normalize_tool_schema_for_anthropic(
+                            func["parameters"]
+                        ),
+                    }
+                    normalized_tools.append({**tool, "function": new_func})
+                elif "input_schema" in tool:
+                    normalized_tools.append({
+                        **tool,
+                        "input_schema": self._normalize_tool_schema_for_anthropic(
+                            tool["input_schema"]
+                        ),
+                    })
+                else:
+                    normalized_tools.append(tool)
+            extra["tools"] = normalized_tools
+
         return sanitized, extra
 
     # ── OAuth direct-call helpers ────────────────────────────
@@ -1030,6 +1061,46 @@ class CredentialVault:
     # _oauth_headers has been removed — the Anthropic SDK handles auth
     # headers natively. For non-SDK callers (e.g. setup_wizard validation),
     # construct headers inline.
+
+    @staticmethod
+    def _normalize_tool_schema_for_anthropic(schema: object) -> object:
+        """Normalize tool JSON Schema fragments for Anthropic requests.
+
+        Anthropic's tool ``input_schema`` validator rejects array-valued ``type``
+        fields (e.g. ``"type": ["string", "object"]``) even though they are valid
+        JSON Schema. Convert them to the equivalent ``anyOf`` form, which Anthropic
+        does accept. Preserves ``null`` member types — Anthropic supports
+        nullability via ``anyOf`` with a ``null`` branch.
+
+        Keep this narrow and semantics-preserving. The concrete repo offender is
+        array-valued ``type`` in tool parameter schemas; do not broaden this into
+        a generic schema compiler without evidence of additional rejected forms.
+        """
+        if isinstance(schema, list):
+            return [
+                CredentialVault._normalize_tool_schema_for_anthropic(item)
+                for item in schema
+            ]
+        if not isinstance(schema, dict):
+            return schema
+
+        normalized = {
+            key: CredentialVault._normalize_tool_schema_for_anthropic(value)
+            for key, value in schema.items()
+        }
+
+        schema_type = normalized.get("type")
+        if isinstance(schema_type, list):
+            types = [t for t in schema_type if isinstance(t, str)]
+            if not types:
+                normalized.pop("type", None)
+            elif len(types) == 1:
+                normalized["type"] = types[0]
+            elif not any(k in normalized for k in ("anyOf", "oneOf", "allOf")):
+                normalized.pop("type", None)
+                normalized["anyOf"] = [{"type": t} for t in types]
+
+        return normalized
 
     @staticmethod
     def _build_anthropic_body(params: dict) -> dict:
@@ -1136,7 +1207,16 @@ class CredentialVault:
                     anthropic_tools.append({
                         "name": func["name"],
                         "description": func.get("description", ""),
-                        "input_schema": func.get("parameters", {"type": "object"}),
+                        "input_schema": CredentialVault._normalize_tool_schema_for_anthropic(
+                            func.get("parameters", {"type": "object"})
+                        ),
+                    })
+                elif isinstance(t, dict) and "input_schema" in t:
+                    anthropic_tools.append({
+                        **t,
+                        "input_schema": CredentialVault._normalize_tool_schema_for_anthropic(
+                            t["input_schema"]
+                        ),
                     })
                 else:
                     anthropic_tools.append(t)

--- a/src/host/credentials.py
+++ b/src/host/credentials.py
@@ -1092,6 +1092,13 @@ class CredentialVault:
         schema_type = normalized.get("type")
         if isinstance(schema_type, list):
             types = [t for t in schema_type if isinstance(t, str)]
+            # Intentionally lossy for malformed input: if a multi-type
+            # list contains no usable string types (empty list, or only
+            # non-strings like [None, True]), drop the ``type`` entirely.
+            # The alternative — leaving an invalid array — would be
+            # rejected by Anthropic with an unhelpful error. Silent
+            # widening lets the request proceed with type-agnostic
+            # validation, which is the least-bad outcome for bad input.
             if not types:
                 normalized.pop("type", None)
             elif len(types) == 1:
@@ -1208,23 +1215,37 @@ class CredentialVault:
         if tools:
             anthropic_tools = []
             for t in tools:
-                if "function" in t:
-                    func = t["function"]
+                if not isinstance(t, dict):
+                    # Unknown entry — pass through; Anthropic SDK will reject
+                    # with a clear error rather than us crashing here.
+                    anthropic_tools.append(t)
+                    continue
+                func = t.get("function")
+                if isinstance(func, dict) and "parameters" in func:
+                    # Well-formed OpenAI shape.
                     anthropic_tools.append({
-                        "name": func["name"],
+                        "name": func.get("name", ""),
                         "description": func.get("description", ""),
                         "input_schema": CredentialVault._normalize_tool_schema_for_anthropic(
-                            func.get("parameters", {"type": "object"})
+                            func["parameters"]
                         ),
                     })
-                elif isinstance(t, dict) and "input_schema" in t:
-                    anthropic_tools.append({
-                        **t,
-                        "input_schema": CredentialVault._normalize_tool_schema_for_anthropic(
-                            t["input_schema"]
-                        ),
-                    })
+                elif "input_schema" in t:
+                    # Already in Anthropic shape, OR an OpenAI-shaped tool that
+                    # has function without parameters but carries input_schema
+                    # as a fallback. Strip any OpenAI wrapper keys and normalize
+                    # the schema in place. Mirrors the LiteLLM seam fallback.
+                    out = {
+                        k: v for k, v in t.items()
+                        if k not in ("function", "type")
+                    }
+                    out["input_schema"] = CredentialVault._normalize_tool_schema_for_anthropic(
+                        t["input_schema"]
+                    )
+                    anthropic_tools.append(out)
                 else:
+                    # Neither well-formed OpenAI nor Anthropic — pass through.
+                    # We don't guess; the Anthropic SDK will reject cleanly.
                     anthropic_tools.append(t)
             body["tools"] = anthropic_tools
 

--- a/src/host/credentials.py
+++ b/src/host/credentials.py
@@ -1096,7 +1096,13 @@ class CredentialVault:
                 normalized.pop("type", None)
             elif len(types) == 1:
                 normalized["type"] = types[0]
-            elif not any(k in normalized for k in ("anyOf", "oneOf", "allOf")):
+            elif any(k in normalized for k in ("anyOf", "oneOf", "allOf")):
+                # Multi-type alongside an existing union construct: drop the
+                # array ``type`` to keep the schema valid for Anthropic. The
+                # existing union stands. Slight semantic loosening — the
+                # alternative (sending an invalid schema) is worse.
+                normalized.pop("type", None)
+            else:
                 normalized.pop("type", None)
                 normalized["anyOf"] = [{"type": t} for t in types]
 

--- a/src/host/credentials.py
+++ b/src/host/credentials.py
@@ -1319,6 +1319,14 @@ class CredentialVault:
            blocks with the Claude Code identity as the mandatory first block.
         2. Add an override so the model follows the agent's actual instructions
            instead of defaulting to Claude Code behavior.
+        3. Drop ``temperature`` and ``top_p`` when they are not exactly 1.0.
+           Anthropic's Claude Code OAuth policy rejects any non-default
+           sampling value with a generic "Invalid request data" error. The
+           engine's default ``temperature=0.7`` (``src/agent/llm.py``) triggers
+           this on every request. Silently drop non-default values so the
+           request succeeds — the model falls back to Anthropic's default
+           sampling (temperature=1.0, top_p=1.0), which is the only
+           combination OAuth accepts.
         """
         identity = CredentialVault._CLAUDE_CODE_IDENTITY
         system_blocks: list[dict] = [{"type": "text", "text": identity}]
@@ -1331,6 +1339,22 @@ class CredentialVault:
             elif isinstance(existing, list):
                 system_blocks.extend(existing)
         body["system"] = system_blocks
+
+        # Claude Code OAuth restriction: drop non-default sampling params.
+        temp = body.get("temperature")
+        if temp is not None and temp != 1.0:
+            logger.debug(
+                "Anthropic OAuth: dropping temperature=%s (only 1.0 permitted)",
+                temp,
+            )
+            body.pop("temperature", None)
+        top_p = body.get("top_p")
+        if top_p is not None and top_p != 1.0:
+            logger.debug(
+                "Anthropic OAuth: dropping top_p=%s (only 1.0 permitted)",
+                top_p,
+            )
+            body.pop("top_p", None)
 
     async def _oauth_chat(
         self, request: APIProxyRequest, api_key: str, model: str,

--- a/tests/test_credentials.py
+++ b/tests/test_credentials.py
@@ -1889,6 +1889,66 @@ class TestOAuthTokenHandling:
         body = CredentialVault._build_anthropic_body(params)
         assert body["top_p"] == 0.9
 
+    def test_patch_oauth_body_drops_non_default_temperature(self):
+        """Anthropic Claude Code OAuth rejects any temperature != 1.0.
+
+        Regression: the engine's default temperature=0.7 triggered
+        "Invalid request data" on every OAuth request, breaking the
+        operator agent's heartbeat cycle on VPS deployments.
+        """
+        body = {
+            "model": "claude-opus-4-6",
+            "messages": [{"role": "user", "content": "hi"}],
+            "system": "test",
+            "temperature": 0.7,
+        }
+        CredentialVault._patch_anthropic_oauth_body(body)
+        assert "temperature" not in body
+
+    def test_patch_oauth_body_keeps_default_temperature(self):
+        """temperature=1.0 is accepted by Anthropic OAuth and must not be dropped."""
+        body = {
+            "model": "claude-opus-4-6",
+            "messages": [{"role": "user", "content": "hi"}],
+            "system": "test",
+            "temperature": 1.0,
+        }
+        CredentialVault._patch_anthropic_oauth_body(body)
+        assert body["temperature"] == 1.0
+
+    def test_patch_oauth_body_drops_non_default_top_p(self):
+        """Anthropic Claude Code OAuth rejects any top_p != 1.0."""
+        body = {
+            "model": "claude-opus-4-6",
+            "messages": [{"role": "user", "content": "hi"}],
+            "system": "test",
+            "top_p": 0.9,
+        }
+        CredentialVault._patch_anthropic_oauth_body(body)
+        assert "top_p" not in body
+
+    def test_patch_oauth_body_keeps_default_top_p(self):
+        """top_p=1.0 is accepted by Anthropic OAuth and must not be dropped."""
+        body = {
+            "model": "claude-opus-4-6",
+            "messages": [{"role": "user", "content": "hi"}],
+            "system": "test",
+            "top_p": 1.0,
+        }
+        CredentialVault._patch_anthropic_oauth_body(body)
+        assert body["top_p"] == 1.0
+
+    def test_patch_oauth_body_absent_sampling_params_unchanged(self):
+        """When temperature/top_p are absent, body stays absent (don't inject defaults)."""
+        body = {
+            "model": "claude-opus-4-6",
+            "messages": [{"role": "user", "content": "hi"}],
+            "system": "test",
+        }
+        CredentialVault._patch_anthropic_oauth_body(body)
+        assert "temperature" not in body
+        assert "top_p" not in body
+
     def test_build_anthropic_body_tool_choice_none_removes_tools(self):
         """tool_choice='none' removes tools from body entirely."""
         params = {

--- a/tests/test_credentials.py
+++ b/tests/test_credentials.py
@@ -1691,6 +1691,55 @@ class TestOAuthTokenHandling:
             },
         }
 
+    def test_normalize_tool_schema_for_anthropic_drops_type_when_anyof_exists(self):
+        """Multi-type alongside existing anyOf drops the array type.
+
+        Sending both ``type: [...]`` and ``anyOf`` to Anthropic produces
+        an invalid request. The existing ``anyOf`` stands; the multi-type
+        is removed. Semantic loosening is preferable to rejection.
+        """
+        schema = {
+            "type": ["string", "object"],
+            "anyOf": [{"const": "yes"}, {"const": "no"}],
+        }
+        result = CredentialVault._normalize_tool_schema_for_anthropic(schema)
+        assert "type" not in result
+        assert result["anyOf"] == [{"const": "yes"}, {"const": "no"}]
+
+    def test_normalize_tool_schema_for_anthropic_drops_type_when_oneof_exists(self):
+        """Same rule for `oneOf` — drop the array type, keep the union."""
+        schema = {
+            "type": ["string", "number"],
+            "oneOf": [{"const": 1}, {"const": "one"}],
+        }
+        result = CredentialVault._normalize_tool_schema_for_anthropic(schema)
+        assert "type" not in result
+        assert result["oneOf"] == [{"const": 1}, {"const": "one"}]
+
+    def test_normalize_tool_schema_for_anthropic_drops_type_when_allof_exists(self):
+        """Same rule for `allOf` — drop the array type, keep the union."""
+        schema = {
+            "type": ["string", "object"],
+            "allOf": [{"description": "x"}],
+        }
+        result = CredentialVault._normalize_tool_schema_for_anthropic(schema)
+        assert "type" not in result
+        assert result["allOf"] == [{"description": "x"}]
+
+    def test_normalize_tool_schema_for_anthropic_recurses_into_anyof_branches(self):
+        """Nested multi-type schemas inside anyOf branches are normalized."""
+        schema = {
+            "anyOf": [
+                {"type": ["string", "number"]},
+                {"type": "object"},
+            ],
+        }
+        result = CredentialVault._normalize_tool_schema_for_anthropic(schema)
+        # First branch: multi-type was converted to anyOf (no anyOf sibling there)
+        assert result["anyOf"][0] == {"anyOf": [{"type": "string"}, {"type": "number"}]}
+        # Second branch unchanged
+        assert result["anyOf"][1] == {"type": "object"}
+
     def test_parse_anthropic_response_text(self):
         """Parses a simple text response."""
         data = {
@@ -2421,7 +2470,6 @@ async def test_oauth_chat_stream_normalizes_tool_schema_before_sdk_call(monkeypa
     fake_anthropic.APIStatusError = _FakeAPIStatusError
     monkeypatch.setitem(sys.modules, "anthropic", fake_anthropic)
 
-    monkeypatch.setenv("OPENLEGION_SYSTEM_ANTHROPIC_API_KEY", "sk-ant-oat01-" + "x" * 80)
     v = CredentialVault()
 
     req = APIProxyRequest(

--- a/tests/test_credentials.py
+++ b/tests/test_credentials.py
@@ -1655,6 +1655,69 @@ class TestOAuthTokenHandling:
         assert "type" not in value_schema
         assert value_schema["anyOf"] == [{"type": "string"}, {"type": "object"}]
 
+    def test_build_anthropic_body_does_not_crash_on_none_function(self):
+        """Malformed ``{"function": None}`` must not crash the OAuth seam.
+
+        Previously the code tested ``if "function" in t`` then dereferenced
+        ``func["name"]`` — crashing with TypeError when function was None.
+        The LiteLLM seam handled this correctly; the OAuth seam had diverged.
+        """
+        params = {
+            "model": "anthropic/claude-sonnet-4-6",
+            "messages": [{"role": "user", "content": "test"}],
+            "tools": [
+                {"type": "function", "function": None},
+                {"function": None},
+            ],
+        }
+        # Must not raise.
+        body = CredentialVault._build_anthropic_body(params)
+        # Both malformed tools passed through unchanged; Anthropic SDK will
+        # reject them at request time, but our body builder doesn't crash.
+        assert len(body["tools"]) == 2
+
+    def test_build_anthropic_body_mixed_shape_falls_back_to_input_schema(self):
+        """Tool with ``function`` but no ``parameters`` falls back to ``input_schema``.
+
+        The LiteLLM seam already has this behavior; the OAuth seam
+        previously substituted ``{"type": "object"}`` and dropped the
+        input_schema on the floor. Both seams must agree.
+        """
+        params = {
+            "model": "anthropic/claude-sonnet-4-6",
+            "messages": [{"role": "user", "content": "test"}],
+            "tools": [{
+                "function": {"name": "edge_case"},  # no parameters
+                "name": "edge_case",
+                "input_schema": {
+                    "type": "object",
+                    "properties": {
+                        "value": {"type": ["string", "object"]},
+                    },
+                },
+            }],
+        }
+        body = CredentialVault._build_anthropic_body(params)
+        tool = body["tools"][0]
+        assert tool["name"] == "edge_case"
+        # input_schema was used and normalized
+        value_schema = tool["input_schema"]["properties"]["value"]
+        assert value_schema["anyOf"] == [{"type": "string"}, {"type": "object"}]
+        # Stripped OpenAI wrapper keys
+        assert "function" not in tool
+        assert "type" not in tool  # the OpenAI "type": "function" wrapper
+
+    def test_build_anthropic_body_non_dict_tool_passes_through(self):
+        """Non-dict tool entries pass through without crashing."""
+        params = {
+            "model": "anthropic/claude-sonnet-4-6",
+            "messages": [{"role": "user", "content": "test"}],
+            "tools": ["not_a_dict", 42, None],
+        }
+        # Must not raise.
+        body = CredentialVault._build_anthropic_body(params)
+        assert body["tools"] == ["not_a_dict", 42, None]
+
     def test_normalize_tool_schema_for_anthropic_collapses_singleton_type_array(self):
         """Single-element type arrays collapse to a bare string."""
         result = CredentialVault._normalize_tool_schema_for_anthropic(

--- a/tests/test_credentials.py
+++ b/tests/test_credentials.py
@@ -1602,6 +1602,95 @@ class TestOAuthTokenHandling:
         assert tool["description"] == "Search the web"
         assert "input_schema" in tool
 
+    def test_build_anthropic_body_normalizes_multi_type_schema(self):
+        """Multi-type `type` arrays in nested properties become `anyOf`.
+
+        Regression test for the Anthropic OAuth "Invalid request data"
+        failure caused by ``propose_edit`` declaring
+        ``"value": {"type": ["string", "object"]}``. Anthropic rejects
+        array-valued JSON Schema ``type`` in tool ``input_schema``.
+        """
+        params = {
+            "model": "anthropic/claude-sonnet-4-6",
+            "messages": [{"role": "user", "content": "test"}],
+            "tools": [{
+                "type": "function",
+                "function": {
+                    "name": "propose_edit",
+                    "description": "Propose an edit",
+                    "parameters": {
+                        "type": "object",
+                        "properties": {
+                            "value": {"type": ["string", "object"]},
+                        },
+                    },
+                },
+            }],
+        }
+        body = CredentialVault._build_anthropic_body(params)
+        value_schema = body["tools"][0]["input_schema"]["properties"]["value"]
+        assert "type" not in value_schema
+        assert value_schema["anyOf"] == [{"type": "string"}, {"type": "object"}]
+
+    def test_build_anthropic_body_normalizes_unwrapped_input_schema(self):
+        """Tools already in Anthropic shape still get schemas normalized."""
+        params = {
+            "model": "anthropic/claude-sonnet-4-6",
+            "messages": [{"role": "user", "content": "test"}],
+            "tools": [{
+                "name": "propose_edit",
+                "description": "Propose an edit",
+                "input_schema": {
+                    "type": "object",
+                    "properties": {
+                        "value": {"type": ["string", "object"]},
+                    },
+                },
+            }],
+        }
+        body = CredentialVault._build_anthropic_body(params)
+        tool = body["tools"][0]
+        assert tool["name"] == "propose_edit"
+        value_schema = tool["input_schema"]["properties"]["value"]
+        assert "type" not in value_schema
+        assert value_schema["anyOf"] == [{"type": "string"}, {"type": "object"}]
+
+    def test_normalize_tool_schema_for_anthropic_collapses_singleton_type_array(self):
+        """Single-element type arrays collapse to a bare string."""
+        result = CredentialVault._normalize_tool_schema_for_anthropic(
+            {"type": ["string"]}
+        )
+        assert result == {"type": "string"}
+
+    def test_normalize_tool_schema_for_anthropic_preserves_null_union(self):
+        """`null` is preserved in anyOf unions — do NOT strip it."""
+        result = CredentialVault._normalize_tool_schema_for_anthropic(
+            {"type": ["string", "null"]}
+        )
+        assert result == {
+            "anyOf": [{"type": "string"}, {"type": "null"}],
+        }
+
+    def test_normalize_tool_schema_for_anthropic_passthrough_single_type(self):
+        """Schemas without multi-type `type` are returned unchanged."""
+        original = {"type": "string", "description": "x"}
+        result = CredentialVault._normalize_tool_schema_for_anthropic(original)
+        assert result == {"type": "string", "description": "x"}
+
+    def test_normalize_tool_schema_for_anthropic_recurses_into_items(self):
+        """Nested items schemas are normalized recursively."""
+        original = {
+            "type": "array",
+            "items": {"type": ["string", "number"]},
+        }
+        result = CredentialVault._normalize_tool_schema_for_anthropic(original)
+        assert result == {
+            "type": "array",
+            "items": {
+                "anyOf": [{"type": "string"}, {"type": "number"}],
+            },
+        }
+
     def test_parse_anthropic_response_text(self):
         """Parses a simple text response."""
         data = {
@@ -2262,6 +2351,123 @@ async def test_oauth_stream_skips_preflight_even_when_over_budget(monkeypatch):
     assert any("done" in e for e in events)
     assert not any("Budget exceeded" in e for e in events)
     cost_tracker.preflight_check.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_oauth_chat_stream_normalizes_tool_schema_before_sdk_call(monkeypatch):
+    """End-to-end: multi-type tool schemas reach the SDK as `anyOf`.
+
+    Regression test for the Anthropic OAuth failure where
+    ``propose_edit``'s ``{"type": ["string", "object"]}`` value schema
+    tripped Anthropic's tool ``input_schema`` validator, yielding
+    "Invalid request data". The fix must normalize at the
+    ``_build_anthropic_body`` seam before the SDK sees the tool list.
+    """
+    import json as _json
+    import sys
+    import types as _types
+
+    captured: dict = {}
+
+    class _FakeAuthenticationError(Exception):
+        pass
+
+    class _FakeAPIStatusError(Exception):
+        pass
+
+    class _FakeMessageDelta:
+        type = "message_delta"
+        usage = _types.SimpleNamespace(output_tokens=5)
+
+    class _FakeStart:
+        type = "message_start"
+        message = _types.SimpleNamespace(
+            usage=_types.SimpleNamespace(input_tokens=10),
+        )
+
+    class _FakeTextDelta:
+        type = "content_block_delta"
+        delta = _types.SimpleNamespace(type="text_delta", text="Hello!")
+
+    class _FakeStream:
+        def __init__(self, events):
+            self._events = events
+
+        def __aiter__(self):
+            async def gen():
+                for evt in self._events:
+                    yield evt
+            return gen()
+
+    class _FakeMessages:
+        async def create(self, **kwargs):
+            captured.update(kwargs)
+            return _FakeStream([
+                _FakeStart(),
+                _FakeTextDelta(),
+                _FakeMessageDelta(),
+            ])
+
+    class _FakeAnthropicClient:
+        def __init__(self, *args, **kwargs):
+            self.messages = _FakeMessages()
+
+        async def close(self):
+            captured["_closed"] = True
+
+    fake_anthropic = _types.ModuleType("anthropic")
+    fake_anthropic.AsyncAnthropic = _FakeAnthropicClient
+    fake_anthropic.AuthenticationError = _FakeAuthenticationError
+    fake_anthropic.APIStatusError = _FakeAPIStatusError
+    monkeypatch.setitem(sys.modules, "anthropic", fake_anthropic)
+
+    monkeypatch.setenv("OPENLEGION_SYSTEM_ANTHROPIC_API_KEY", "sk-ant-oat01-" + "x" * 80)
+    v = CredentialVault()
+
+    req = APIProxyRequest(
+        service="llm", action="chat",
+        params={
+            "model": "anthropic/claude-sonnet-4-6",
+            "messages": [{"role": "user", "content": "propose an edit"}],
+            "max_tokens": 256,
+            "tools": [{
+                "type": "function",
+                "function": {
+                    "name": "propose_edit",
+                    "description": "Propose an edit",
+                    "parameters": {
+                        "type": "object",
+                        "properties": {
+                            "value": {"type": ["string", "object"]},
+                        },
+                    },
+                },
+            }],
+        },
+    )
+
+    events = []
+    async for event in v._oauth_chat_stream(
+        req, "sk-ant-oat01-" + "x" * 80, "anthropic/claude-sonnet-4-6",
+    ):
+        events.append(event)
+
+    # Close was called in the finally block.
+    assert captured.get("_closed") is True
+
+    # Tool schema was normalized: multi-type `value` → anyOf.
+    assert "tools" in captured
+    value_schema = captured["tools"][0]["input_schema"]["properties"]["value"]
+    assert "type" not in value_schema
+    assert value_schema["anyOf"] == [{"type": "string"}, {"type": "object"}]
+
+    # A done event was yielded after consuming the stream.
+    assert any("done" in e for e in events)
+    # Sanity: the done event parses as JSON with the expected type.
+    done_events = [e for e in events if '"type": "done"' in e]
+    assert done_events, "expected at least one done event"
+    payload = _json.loads(done_events[0].removeprefix("data: ").strip())
+    assert payload["type"] == "done"
 
 
 @pytest.mark.asyncio

--- a/tests/test_llm_param_allowlist.py
+++ b/tests/test_llm_param_allowlist.py
@@ -142,9 +142,26 @@ class TestPrepareParamsAllowlist:
         msgs, extra = cred_manager._prepare_llm_params(req, "openai/o3-mini")
         assert extra["reasoning_effort"] == "medium"
 
-    def test_tools_and_tool_choice_pass_through(self, cred_manager):
-        """tools and tool_choice should pass through."""
-        tools = [{"type": "function", "function": {"name": "test", "parameters": {}}}]
+    def test_anthropic_tools_are_normalized(self, cred_manager):
+        """Anthropic tools with array-valued `type` are normalized to anyOf.
+
+        Anthropic's tool input_schema validator rejects JSON Schema
+        `type: [..]` unions (e.g. propose_edit's ``value`` property). The
+        LiteLLM-path defense in ``_prepare_llm_params`` must normalize them
+        before handing tools off to LiteLLM for Anthropic providers.
+        """
+        tools = [{
+            "type": "function",
+            "function": {
+                "name": "propose_edit",
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "value": {"type": ["string", "object"]},
+                    },
+                },
+            },
+        }]
         req = self._make_request({
             "model": "anthropic/claude-3-sonnet",
             "messages": [{"role": "user", "content": "hi"}],
@@ -152,6 +169,34 @@ class TestPrepareParamsAllowlist:
             "tool_choice": "auto",
         })
         msgs, extra = cred_manager._prepare_llm_params(req, "anthropic/claude-3-sonnet")
+        value_schema = (
+            extra["tools"][0]["function"]["parameters"]["properties"]["value"]
+        )
+        assert "type" not in value_schema
+        assert value_schema["anyOf"] == [{"type": "string"}, {"type": "object"}]
+        assert extra["tool_choice"] == "auto"
+
+    def test_non_anthropic_tools_still_pass_through(self, cred_manager):
+        """OpenAI-provider tools must pass through unchanged."""
+        tools = [{
+            "type": "function",
+            "function": {
+                "name": "propose_edit",
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "value": {"type": ["string", "object"]},
+                    },
+                },
+            },
+        }]
+        req = self._make_request({
+            "model": "openai/gpt-4o",
+            "messages": [{"role": "user", "content": "hi"}],
+            "tools": tools,
+            "tool_choice": "auto",
+        })
+        msgs, extra = cred_manager._prepare_llm_params(req, "openai/gpt-4o")
         assert extra["tools"] == tools
         assert extra["tool_choice"] == "auto"
 

--- a/tests/test_llm_param_allowlist.py
+++ b/tests/test_llm_param_allowlist.py
@@ -200,6 +200,49 @@ class TestPrepareParamsAllowlist:
         assert extra["tools"] == tools
         assert extra["tool_choice"] == "auto"
 
+    def test_anthropic_input_schema_tools_are_normalized(self, cred_manager):
+        """Anthropic-shape tools (with ``input_schema``) get normalized too.
+
+        Some callers (e.g. MCP, custom tool builders) emit Anthropic shape
+        directly rather than the OpenAI ``function`` wrapper. The LiteLLM-path
+        defense must normalize both shapes.
+        """
+        tools = [{
+            "name": "propose_edit",
+            "input_schema": {
+                "type": "object",
+                "properties": {
+                    "value": {"type": ["string", "object"]},
+                },
+            },
+        }]
+        req = self._make_request({
+            "model": "anthropic/claude-3-sonnet",
+            "messages": [{"role": "user", "content": "hi"}],
+            "tools": tools,
+        })
+        msgs, extra = cred_manager._prepare_llm_params(req, "anthropic/claude-3-sonnet")
+        value_schema = (
+            extra["tools"][0]["input_schema"]["properties"]["value"]
+        )
+        assert "type" not in value_schema
+        assert value_schema["anyOf"] == [{"type": "string"}, {"type": "object"}]
+
+    def test_anthropic_unknown_shape_tools_pass_through(self, cred_manager):
+        """Tools that match neither shape pass through without crashing.
+
+        Defensive: a malformed or future tool shape should not cause the
+        normalization block to raise. It just passes through unchanged.
+        """
+        tools = [{"unknown_key": "value"}]
+        req = self._make_request({
+            "model": "anthropic/claude-3-sonnet",
+            "messages": [{"role": "user", "content": "hi"}],
+            "tools": tools,
+        })
+        msgs, extra = cred_manager._prepare_llm_params(req, "anthropic/claude-3-sonnet")
+        assert extra["tools"] == tools
+
     def test_multiple_dangerous_params_all_blocked(self, cred_manager):
         """Multiple dangerous params should all be blocked simultaneously."""
         req = self._make_request({


### PR DESCRIPTION
## Summary

Two Anthropic OAuth reliability fixes in one PR:

### 1. Drop non-default temperature/top_p for Anthropic OAuth (ROOT CAUSE)

The user's VPS operator agent was failing every 15 minutes with "Anthropic OAuth error: Invalid request data". Root cause: **Anthropic's Claude Code OAuth tokens only accept `temperature=1.0` and `top_p=1.0` (or omitted)**. Any other value is silently rejected with a generic error. The engine's default `temperature=0.7` triggered this on every call.

Bisected live against a real OAuth token:
- `temp=0.7` → FAIL "Invalid request data"
- `temp=1.0` → OK
- `no temp` → OK
- `top_p=0.9` → FAIL "Invalid request data"
- `top_p=1.0` → OK

Fix: `_patch_anthropic_oauth_body` now drops non-default sampling params before sending to the Anthropic SDK. Agents lose per-call temperature control under OAuth, which is unavoidable — the alternative is every request failing.

### 2. Normalize multi-type JSON Schema for Anthropic OAuth tool validation (DEFENSIVE)

A separate latent bug: `propose_edit`'s `value` parameter declares `"type": ["string", "object"]`. This is valid JSON Schema, but would be rejected by Anthropic's tool `input_schema` validator if the OAuth path ever started enforcing it.

Fix: new `_normalize_tool_schema_for_anthropic` helper recursively converts multi-type arrays to `anyOf` form. Wired into both Anthropic seams:
- `_build_anthropic_body` (OAuth path)
- `_prepare_llm_params` (LiteLLM path, Anthropic-only)

Also hardened `_build_anthropic_body` against malformed tool inputs (`{"function": None}`, mixed-shape tools, non-dict entries) to mirror the LiteLLM seam's defensive logic.

## Test plan
- [x] 5 unit tests for `_patch_anthropic_oauth_body` OAuth param handling
- [x] 10 unit tests for `_normalize_tool_schema_for_anthropic` (multi-type → anyOf, singleton collapse, null preservation, recursion into items/anyOf/properties, multi-type + existing union)
- [x] 3 robustness tests for malformed tool inputs (`{"function": None}`, mixed-shape, non-dict)
- [x] 2 `_prepare_llm_params` tests (Anthropic normalization + OpenAI passthrough)
- [x] End-to-end OAuth stream test with mocked `anthropic.AsyncAnthropic` verifying normalized schemas reach the SDK
- [x] Full non-e2e suite: 3051 passed (pre-existing worktree env failure unrelated)
- [x] Ruff clean
- [x] Fix #1 verified live against the failing VPS — reproduced the exact error and confirmed removing temperature resolves it
