### PR TITLE
Add Browser sub-tab with CAPTCHA solver configuration

### DIFF
--- a/src/dashboard/server.py
+++ b/src/dashboard/server.py
@@ -2967,6 +2967,57 @@ def create_dashboard_router(
             "delay": settings.get("browser_delay", 0.0),
         }
 
+    # ── CAPTCHA solver settings ───────────────────────────────
+
+    @api_router.get("/api/captcha-solver")
+    async def api_get_captcha_solver() -> dict:
+        """Return CAPTCHA solver configuration (key is masked)."""
+        settings = _load_settings()
+        provider = settings.get("captcha_solver_provider", "")
+        key = settings.get("captcha_solver_key", "")
+        return {
+            "provider": provider,
+            "key_masked": f"...{key[-4:]}" if len(key) >= 4 else "",
+        }
+
+    @api_router.post("/api/captcha-solver")
+    async def api_set_captcha_solver(request: Request) -> dict:
+        """Save CAPTCHA solver provider and API key."""
+        await _csrf_check(request)
+        body = await request.json()
+        provider = body.get("provider", "").strip().lower()
+        key = body.get("key", "").strip()
+
+        if provider and provider not in ("2captcha", "capsolver"):
+            raise HTTPException(400, "provider must be '2captcha' or 'capsolver'")
+
+        with _settings_lock:
+            settings = _load_settings()
+            settings["captcha_solver_provider"] = provider
+            if key:
+                settings["captcha_solver_key"] = key
+            elif not provider:
+                settings.pop("captcha_solver_key", None)
+            _save_settings(settings)
+
+        settings = _load_settings()
+        stored_key = settings.get("captcha_solver_key", "")
+        return {
+            "provider": settings.get("captcha_solver_provider", ""),
+            "key_masked": f"...{stored_key[-4:]}" if len(stored_key) >= 4 else "",
+        }
+
+    @api_router.delete("/api/captcha-solver")
+    async def api_delete_captcha_solver(request: Request) -> dict:
+        """Remove CAPTCHA solver configuration."""
+        await _csrf_check(request)
+        with _settings_lock:
+            settings = _load_settings()
+            settings.pop("captcha_solver_provider", None)
+            settings.pop("captcha_solver_key", None)
+            _save_settings(settings)
+        return {"removed": True}
+
     # ── System settings (consolidated) ────────────────────────
 
     _SYSTEM_SETTINGS_VALIDATORS: dict[str, tuple[type, float, float]] = {
@@ -3104,6 +3155,13 @@ def create_dashboard_router(
                 }.items():
                     if cfg_key in sys_settings:
                         runtime.extra_env[env_key] = str(sys_settings[cfg_key])
+                # Push CAPTCHA solver config to env for browser service
+                _solver_provider = sys_settings.get("captcha_solver_provider", "")
+                _solver_key = sys_settings.get("captcha_solver_key", "")
+                if _solver_provider:
+                    os.environ["OPENLEGION_CAPTCHA_SOLVER_PROVIDER"] = _solver_provider
+                if _solver_key:
+                    os.environ["OPENLEGION_CAPTCHA_SOLVER_KEY"] = _solver_key
             except (ValueError, OSError):
                 pass
 

--- a/src/dashboard/static/js/app.js
+++ b/src/dashboard/static/js/app.js
@@ -187,6 +187,10 @@ function dashboard() {
     _browserSettingsDebounce: null,
     _browserDelayDebounce: null,
 
+    captchaSolverProvider: '',
+    captchaSolverKeyMasked: '',
+    captchaSolverSaving: false,
+
     // System settings
     systemSettings: null,
     systemSettingsLoading: false,
@@ -288,6 +292,7 @@ function dashboard() {
       { id: 'network', label: 'Network' },
       { id: 'storage', label: 'Storage' },
       { id: 'operator', label: 'Operator' },
+      { id: 'browser', label: 'Browser' },
       { id: 'settings', label: 'Settings' },
     ],
 
@@ -1227,6 +1232,11 @@ function dashboard() {
           this.fetchBrowserSettings();
           this.fetchSystemSettings();
         }
+        if (this.systemTab === 'browser') {
+          this.fetchBrowserSettings();
+          this.fetchSystemSettings();
+          this.fetchCaptchaSolver();
+        }
         if (this.systemTab === 'activity') {
           if (this.activityView === 'traces') {
             this.fetchTraces();
@@ -1248,6 +1258,7 @@ function dashboard() {
       if (tabId === 'storage') { this.fetchUploads(); this.fetchStorage(); this.fetchDatabaseDetails(); }
       if (tabId === 'network') { this.loadNetworkProxy(); }
       if (tabId === 'settings') { this.fetchBrowserSettings(); this.fetchSystemSettings(); }
+      if (tabId === 'browser') { this.fetchBrowserSettings(); this.fetchSystemSettings(); this.fetchCaptchaSolver(); }
       if (tabId === 'operator') {
         this.fetchAuditLog();
       }
@@ -3516,6 +3527,63 @@ function dashboard() {
       if (d <= 4.0) return 'Moderate';
       if (d <= 7.0) return 'Heavy';
       return 'Maximum';
+    },
+
+    async fetchCaptchaSolver() {
+      try {
+        const resp = await fetch(`${window.__config.apiBase}/captcha-solver`);
+        if (resp.ok) {
+          const data = await resp.json();
+          this.captchaSolverProvider = data.provider || '';
+          this.captchaSolverKeyMasked = data.key_masked || '';
+        }
+      } catch (e) { console.warn('fetchCaptchaSolver failed:', e); }
+    },
+
+    async saveCaptchaSolver() {
+      this.captchaSolverSaving = true;
+      try {
+        const body = { provider: this.captchaSolverProvider };
+        const keyInput = document.getElementById('captcha-solver-key');
+        if (keyInput && keyInput.value) {
+          body.key = keyInput.value;
+        }
+        const resp = await fetch(`${window.__config.apiBase}/captcha-solver`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json', 'X-Requested-With': 'XMLHttpRequest' },
+          body: JSON.stringify(body),
+        });
+        if (resp.ok) {
+          const data = await resp.json();
+          this.captchaSolverProvider = data.provider || '';
+          this.captchaSolverKeyMasked = data.key_masked || '';
+          if (keyInput) keyInput.value = '';
+          this._showToast('CAPTCHA solver settings saved');
+        } else {
+          const err = await resp.json().catch(() => ({}));
+          this._showToast(err.detail || 'Failed to save', 'error');
+        }
+      } catch (e) {
+        console.warn('saveCaptchaSolver failed:', e);
+        this._showToast('Failed to save CAPTCHA solver settings', 'error');
+      }
+      this.captchaSolverSaving = false;
+    },
+
+    async removeCaptchaSolver() {
+      this.captchaSolverSaving = true;
+      try {
+        const resp = await fetch(`${window.__config.apiBase}/captcha-solver`, {
+          method: 'DELETE',
+          headers: { 'X-Requested-With': 'XMLHttpRequest' },
+        });
+        if (resp.ok) {
+          this.captchaSolverProvider = '';
+          this.captchaSolverKeyMasked = '';
+          this._showToast('CAPTCHA solver removed');
+        }
+      } catch (e) { console.warn('removeCaptchaSolver failed:', e); }
+      this.captchaSolverSaving = false;
     },
 
     // ── Network / Proxy ────────────────────────────────

--- a/src/dashboard/templates/index.html
+++ b/src/dashboard/templates/index.html
@@ -4688,6 +4688,217 @@
           </div>
         </div><!-- /operator sub-tab -->
 
+        <!-- ═══ BROWSER SUB-TAB ═══ -->
+        <div x-show="systemTab === 'browser'" class="space-y-4">
+
+          <!-- ── Interaction Speed ── -->
+          <div class="bg-gray-900 border border-gray-800 rounded-lg p-5">
+            <div class="flex items-center gap-2 mb-4">
+              <svg class="w-4 h-4 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 10V3L4 14h7v7l9-11h-7z"/></svg>
+              <h3 class="text-sm font-medium text-gray-200">Interaction Speed</h3>
+            </div>
+            <div class="space-y-3">
+              <div class="flex items-center justify-between">
+                <div>
+                  <div class="text-xs text-gray-400">Speed Multiplier</div>
+                  <div class="text-[10px] text-gray-600 mt-0.5">Controls typing, clicking, and scrolling delays</div>
+                </div>
+                <div class="flex items-center gap-2">
+                  <span class="text-xs font-medium px-2 py-0.5 rounded-full"
+                    :class="{
+                      'bg-indigo-500/10 text-indigo-400': browserSpeed >= 1.8,
+                      'bg-gray-700 text-gray-300': browserSpeed >= 0.8 && browserSpeed < 1.8,
+                      'bg-yellow-500/10 text-yellow-400': browserSpeed < 0.8
+                    }"
+                    x-text="browserSpeedLabel"></span>
+                  <span class="text-xs text-gray-500 font-mono w-10 text-right" x-text="browserSpeed.toFixed(2) + 'x'"></span>
+                </div>
+              </div>
+              <div class="flex items-center gap-3">
+                <span class="text-[10px] text-gray-600 w-10">Slow</span>
+                <input type="range" min="0.25" max="4.0" step="0.05"
+                  :value="browserSpeed"
+                  @input="saveBrowserSpeed($event.target.value)"
+                  class="flex-1 h-1.5 bg-gray-700 rounded-full appearance-none cursor-pointer
+                    [&::-webkit-slider-thumb]:appearance-none [&::-webkit-slider-thumb]:w-3.5 [&::-webkit-slider-thumb]:h-3.5
+                    [&::-webkit-slider-thumb]:rounded-full [&::-webkit-slider-thumb]:bg-indigo-500 [&::-webkit-slider-thumb]:cursor-pointer
+                    [&::-webkit-slider-thumb]:hover:bg-indigo-400 [&::-webkit-slider-thumb]:transition-colors
+                    [&::-moz-range-thumb]:w-3.5 [&::-moz-range-thumb]:h-3.5 [&::-moz-range-thumb]:rounded-full
+                    [&::-moz-range-thumb]:bg-indigo-500 [&::-moz-range-thumb]:border-0 [&::-moz-range-thumb]:cursor-pointer">
+                <span class="text-[10px] text-gray-600 w-6 text-right">Fast</span>
+              </div>
+              <div class="flex gap-2 pt-1">
+                <template x-for="preset in [
+                  { value: 0.25, label: 'Stealth' },
+                  { value: 0.5, label: 'Careful' },
+                  { value: 1.0, label: 'Normal' },
+                  { value: 2.0, label: 'Fast' },
+                  { value: 4.0, label: 'Lightning' }
+                ]" :key="preset.value">
+                  <button @click="saveBrowserSpeed(preset.value)"
+                    class="px-2 py-1 text-[10px] rounded transition-all"
+                    :class="Math.abs(browserSpeed - preset.value) < 0.05
+                      ? 'bg-indigo-500/20 text-indigo-300 ring-1 ring-indigo-500/30'
+                      : 'bg-gray-800 text-gray-500 hover:text-gray-300 hover:bg-gray-700'"
+                    x-text="preset.label"></button>
+                </template>
+              </div>
+              <p class="text-[10px] text-gray-600 leading-relaxed pt-1">
+                Higher values make the browser faster. Lower values add more natural variance
+                to typing rhythm, click delays, and scroll pauses for better stealth on sites with bot detection.
+              </p>
+            </div>
+          </div>
+
+          <!-- ── Inter-Action Delay ── -->
+          <div class="bg-gray-900 border border-gray-800 rounded-lg p-5">
+            <div class="flex items-center gap-2 mb-4">
+              <svg class="w-4 h-4 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z"/></svg>
+              <h3 class="text-sm font-medium text-gray-200">Inter-Action Delay</h3>
+            </div>
+            <div class="space-y-3">
+              <div class="flex items-center justify-between">
+                <div>
+                  <div class="text-xs text-gray-400">Delay Between Actions</div>
+                  <div class="text-[10px] text-gray-600 mt-0.5">Pause between browser actions to simulate human think time</div>
+                </div>
+                <div class="flex items-center gap-2">
+                  <span class="text-xs font-medium px-2 py-0.5 rounded-full"
+                    :class="{
+                      'bg-green-500/10 text-green-400': browserDelay <= 0,
+                      'bg-yellow-500/10 text-yellow-400': browserDelay > 0 && browserDelay <= 4,
+                      'bg-orange-500/10 text-orange-400': browserDelay > 4
+                    }"
+                    x-text="browserDelayLabel"></span>
+                  <span class="text-xs text-gray-500 font-mono w-10 text-right" x-text="browserDelay.toFixed(1) + 's'"></span>
+                </div>
+              </div>
+              <div class="flex items-center gap-3">
+                <span class="text-[10px] text-gray-600 w-10">Off</span>
+                <input type="range" min="0" max="10" step="0.5"
+                  :value="browserDelay"
+                  @input="saveBrowserDelay($event.target.value)"
+                  class="flex-1 h-1.5 bg-gray-700 rounded-full appearance-none cursor-pointer
+                    [&::-webkit-slider-thumb]:appearance-none [&::-webkit-slider-thumb]:w-3.5 [&::-webkit-slider-thumb]:h-3.5
+                    [&::-webkit-slider-thumb]:rounded-full [&::-webkit-slider-thumb]:bg-indigo-500 [&::-webkit-slider-thumb]:cursor-pointer
+                    [&::-webkit-slider-thumb]:hover:bg-indigo-400 [&::-webkit-slider-thumb]:transition-colors
+                    [&::-moz-range-thumb]:w-3.5 [&::-moz-range-thumb]:h-3.5 [&::-moz-range-thumb]:rounded-full
+                    [&::-moz-range-thumb]:bg-indigo-500 [&::-moz-range-thumb]:border-0 [&::-moz-range-thumb]:cursor-pointer">
+                <span class="text-[10px] text-gray-600 w-6 text-right">10s</span>
+              </div>
+              <div class="flex gap-2 pt-1">
+                <template x-for="preset in [
+                  { value: 0, label: 'Off' },
+                  { value: 1.5, label: 'Light' },
+                  { value: 3, label: 'Moderate' },
+                  { value: 6, label: 'Heavy' },
+                  { value: 10, label: 'Maximum' }
+                ]" :key="preset.value">
+                  <button @click="saveBrowserDelay(preset.value)"
+                    class="px-2 py-1 text-[10px] rounded transition-all"
+                    :class="Math.abs(browserDelay - preset.value) < 0.3
+                      ? 'bg-indigo-500/20 text-indigo-300 ring-1 ring-indigo-500/30'
+                      : 'bg-gray-800 text-gray-500 hover:text-gray-300 hover:bg-gray-700'"
+                    x-text="preset.label"></button>
+                </template>
+              </div>
+              <p class="text-[10px] text-gray-600 leading-relaxed pt-1">
+                Adds a randomized pause after each browser action (click, type, navigate, etc.)
+                to simulate human reading and decision time. Higher values are stealthier on
+                bot-protected sites like X/Twitter. 0 = disabled.
+              </p>
+            </div>
+          </div>
+
+          <!-- ── Idle Timeout ── -->
+          <div class="bg-gray-900 border border-gray-800 rounded-lg p-5" x-show="systemSettings">
+            <div class="flex items-center gap-2 mb-4">
+              <svg class="w-4 h-4 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M20 12H4"/></svg>
+              <h3 class="text-sm font-medium text-gray-200">Idle Timeout</h3>
+            </div>
+            <div class="max-w-xs">
+              <div class="flex items-center gap-1 mb-1">
+                <label class="text-xs text-gray-400">Timeout (minutes)</label>
+                <span class="setting-hint" tabindex="0">?<span class="setting-hint-text">How long the browser container stays alive after the last agent interaction. Lower values save resources; higher values avoid cold-start delays. Default: 30 min.</span></span>
+                <span class="text-[10px] text-amber-500/70">restart required</span>
+              </div>
+              <input type="number" step="1" min="5" max="120"
+                class="dash-input w-full"
+                :value="systemSettings?.browser_idle_timeout"
+                @change="saveSystemSetting('browser_idle_timeout', $event.target.value)">
+            </div>
+          </div>
+
+          <!-- ── CAPTCHA Solver ── -->
+          <div class="bg-gray-900 border border-gray-800 rounded-lg p-5">
+            <div class="flex items-center gap-2 mb-4">
+              <svg class="w-4 h-4 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4m5.618-4.016A11.955 11.955 0 0112 2.944a11.955 11.955 0 01-8.618 3.04A12.02 12.02 0 003 9c0 5.591 3.824 10.29 9 11.622 5.176-1.332 9-6.03 9-11.622 0-1.042-.133-2.052-.382-3.016z"/></svg>
+              <h3 class="text-sm font-medium text-gray-200">CAPTCHA Solver</h3>
+            </div>
+            <p class="text-[10px] text-gray-500 mb-4 leading-relaxed">
+              When configured, CAPTCHAs (reCAPTCHA, hCaptcha, Cloudflare Turnstile) are solved automatically
+              during browser navigation. Requires a paid account with a solving service (~$1-3 per 1000 solves).
+            </p>
+
+            <div class="space-y-3">
+              <div>
+                <label class="text-xs text-gray-400 mb-1 block">Provider</label>
+                <select x-model="captchaSolverProvider"
+                  class="dash-input w-full max-w-xs">
+                  <option value="">None (disabled)</option>
+                  <option value="2captcha">2Captcha</option>
+                  <option value="capsolver">CapSolver</option>
+                </select>
+              </div>
+
+              <div x-show="captchaSolverProvider">
+                <label class="text-xs text-gray-400 mb-1 block">API Key</label>
+                <div class="flex items-center gap-2 max-w-md">
+                  <input type="password" id="captcha-solver-key"
+                    :placeholder="captchaSolverKeyMasked ? ('Configured: ' + captchaSolverKeyMasked) : 'Enter your API key'"
+                    class="dash-input flex-1"
+                    autocomplete="off">
+                  <button @click="saveCaptchaSolver()" :disabled="captchaSolverSaving"
+                    class="px-3 py-1.5 text-xs rounded bg-indigo-600 hover:bg-indigo-500 text-white disabled:opacity-50 transition-colors whitespace-nowrap">
+                    <span x-show="!captchaSolverSaving">Save</span>
+                    <span x-show="captchaSolverSaving">Saving...</span>
+                  </button>
+                </div>
+                <p class="text-[10px] text-gray-600 mt-1">
+                  <template x-if="captchaSolverProvider === '2captcha'">
+                    <span>Get your API key from <span class="text-gray-400">2captcha.com</span> dashboard</span>
+                  </template>
+                  <template x-if="captchaSolverProvider === 'capsolver'">
+                    <span>Get your API key from <span class="text-gray-400">capsolver.com</span> dashboard</span>
+                  </template>
+                </p>
+              </div>
+
+              <div x-show="!captchaSolverProvider && captchaSolverKeyMasked" class="pt-1">
+                <p class="text-[10px] text-amber-400/70 mb-2">Solver was previously configured. Select a provider to update, or remove below.</p>
+              </div>
+
+              <div x-show="captchaSolverKeyMasked" class="pt-2 border-t border-gray-800">
+                <div class="flex items-center justify-between">
+                  <div class="text-xs text-gray-500">
+                    Status: <span class="text-green-400">Configured</span>
+                    <span class="text-gray-600 ml-1" x-text="'(' + captchaSolverKeyMasked + ')'"></span>
+                  </div>
+                  <button @click="if(confirm('Remove CAPTCHA solver configuration?')) removeCaptchaSolver()"
+                    :disabled="captchaSolverSaving"
+                    class="px-2 py-1 text-[10px] rounded bg-red-500/10 text-red-400 hover:bg-red-500/20 transition-colors disabled:opacity-50">
+                    Remove
+                  </button>
+                </div>
+              </div>
+            </div>
+            <p class="text-[10px] text-gray-600 leading-relaxed mt-4">
+              Requires a restart to take effect. The API key is stored securely and passed to the browser container as an environment variable.
+            </p>
+          </div>
+
+        </div><!-- /browser sub-tab -->
+
         <!-- ═══ SETTINGS SUB-TAB ═══ -->
         <div x-show="systemTab === 'settings'" class="space-y-4">
 
@@ -4840,147 +5051,7 @@
             </div>
           </div>
 
-          <!-- ── 4. Browser ── -->
-          <div class="bg-gray-900 border border-gray-800 rounded-lg p-5">
-            <div class="flex items-center gap-2 mb-4">
-              <svg class="w-4 h-4 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 12a9 9 0 01-9 9m9-9a9 9 0 00-9-9m9 9H3m9 9a9 9 0 01-9-9m9 9c1.657 0 3-4.03 3-9s-1.343-9-3-9m0 18c-1.657 0-3-4.03-3-9s1.343-9 3-9m-9 9a9 9 0 019-9"/></svg>
-              <h3 class="text-sm font-medium text-gray-200">Browser</h3>
-            </div>
-
-            <!-- Speed control (existing) -->
-            <div class="space-y-3">
-              <div class="flex items-center justify-between">
-                <div>
-                  <div class="text-xs text-gray-400">Interaction Speed</div>
-                  <div class="text-[10px] text-gray-600 mt-0.5">Controls typing, clicking, and scrolling delays</div>
-                </div>
-                <div class="flex items-center gap-2">
-                  <span class="text-xs font-medium px-2 py-0.5 rounded-full"
-                    :class="{
-                      'bg-indigo-500/10 text-indigo-400': browserSpeed >= 1.8,
-                      'bg-gray-700 text-gray-300': browserSpeed >= 0.8 && browserSpeed < 1.8,
-                      'bg-yellow-500/10 text-yellow-400': browserSpeed < 0.8
-                    }"
-                    x-text="browserSpeedLabel"></span>
-                  <span class="text-xs text-gray-500 font-mono w-10 text-right" x-text="browserSpeed.toFixed(2) + 'x'"></span>
-                </div>
-              </div>
-
-              <div class="flex items-center gap-3">
-                <span class="text-[10px] text-gray-600 w-10">Slow</span>
-                <input type="range" min="0.25" max="4.0" step="0.05"
-                  :value="browserSpeed"
-                  @input="saveBrowserSpeed($event.target.value)"
-                  class="flex-1 h-1.5 bg-gray-700 rounded-full appearance-none cursor-pointer
-                    [&::-webkit-slider-thumb]:appearance-none [&::-webkit-slider-thumb]:w-3.5 [&::-webkit-slider-thumb]:h-3.5
-                    [&::-webkit-slider-thumb]:rounded-full [&::-webkit-slider-thumb]:bg-indigo-500 [&::-webkit-slider-thumb]:cursor-pointer
-                    [&::-webkit-slider-thumb]:hover:bg-indigo-400 [&::-webkit-slider-thumb]:transition-colors
-                    [&::-moz-range-thumb]:w-3.5 [&::-moz-range-thumb]:h-3.5 [&::-moz-range-thumb]:rounded-full
-                    [&::-moz-range-thumb]:bg-indigo-500 [&::-moz-range-thumb]:border-0 [&::-moz-range-thumb]:cursor-pointer">
-                <span class="text-[10px] text-gray-600 w-6 text-right">Fast</span>
-              </div>
-
-              <!-- Preset buttons -->
-              <div class="flex gap-2 pt-1">
-                <template x-for="preset in [
-                  { value: 0.25, label: 'Stealth' },
-                  { value: 0.5, label: 'Careful' },
-                  { value: 1.0, label: 'Normal' },
-                  { value: 2.0, label: 'Fast' },
-                  { value: 4.0, label: 'Lightning' }
-                ]" :key="preset.value">
-                  <button @click="saveBrowserSpeed(preset.value)"
-                    class="px-2 py-1 text-[10px] rounded transition-all"
-                    :class="Math.abs(browserSpeed - preset.value) < 0.05
-                      ? 'bg-indigo-500/20 text-indigo-300 ring-1 ring-indigo-500/30'
-                      : 'bg-gray-800 text-gray-500 hover:text-gray-300 hover:bg-gray-700'"
-                    x-text="preset.label"></button>
-                </template>
-              </div>
-
-              <p class="text-[10px] text-gray-600 leading-relaxed pt-1">
-                Higher values make the browser faster. Lower values add more natural variance
-                to typing rhythm, click delays, and scroll pauses for better stealth on sites with bot detection.
-              </p>
-            </div>
-
-            <!-- Inter-action delay control -->
-            <div class="mt-4 pt-4 border-t border-gray-800">
-              <div class="space-y-3">
-                <div class="flex items-center justify-between">
-                  <div>
-                    <div class="text-xs text-gray-400">Inter-Action Delay</div>
-                    <div class="text-[10px] text-gray-600 mt-0.5">Pause between browser actions to simulate human think time</div>
-                  </div>
-                  <div class="flex items-center gap-2">
-                    <span class="text-xs font-medium px-2 py-0.5 rounded-full"
-                      :class="{
-                        'bg-green-500/10 text-green-400': browserDelay <= 0,
-                        'bg-yellow-500/10 text-yellow-400': browserDelay > 0 && browserDelay <= 4,
-                        'bg-orange-500/10 text-orange-400': browserDelay > 4
-                      }"
-                      x-text="browserDelayLabel"></span>
-                    <span class="text-xs text-gray-500 font-mono w-10 text-right" x-text="browserDelay.toFixed(1) + 's'"></span>
-                  </div>
-                </div>
-
-                <div class="flex items-center gap-3">
-                  <span class="text-[10px] text-gray-600 w-10">Off</span>
-                  <input type="range" min="0" max="10" step="0.5"
-                    :value="browserDelay"
-                    @input="saveBrowserDelay($event.target.value)"
-                    class="flex-1 h-1.5 bg-gray-700 rounded-full appearance-none cursor-pointer
-                      [&::-webkit-slider-thumb]:appearance-none [&::-webkit-slider-thumb]:w-3.5 [&::-webkit-slider-thumb]:h-3.5
-                      [&::-webkit-slider-thumb]:rounded-full [&::-webkit-slider-thumb]:bg-indigo-500 [&::-webkit-slider-thumb]:cursor-pointer
-                      [&::-webkit-slider-thumb]:hover:bg-indigo-400 [&::-webkit-slider-thumb]:transition-colors
-                      [&::-moz-range-thumb]:w-3.5 [&::-moz-range-thumb]:h-3.5 [&::-moz-range-thumb]:rounded-full
-                      [&::-moz-range-thumb]:bg-indigo-500 [&::-moz-range-thumb]:border-0 [&::-moz-range-thumb]:cursor-pointer">
-                  <span class="text-[10px] text-gray-600 w-6 text-right">10s</span>
-                </div>
-
-                <!-- Preset buttons -->
-                <div class="flex gap-2 pt-1">
-                  <template x-for="preset in [
-                    { value: 0, label: 'Off' },
-                    { value: 1.5, label: 'Light' },
-                    { value: 3, label: 'Moderate' },
-                    { value: 6, label: 'Heavy' },
-                    { value: 10, label: 'Maximum' }
-                  ]" :key="preset.value">
-                    <button @click="saveBrowserDelay(preset.value)"
-                      class="px-2 py-1 text-[10px] rounded transition-all"
-                      :class="Math.abs(browserDelay - preset.value) < 0.3
-                        ? 'bg-indigo-500/20 text-indigo-300 ring-1 ring-indigo-500/30'
-                        : 'bg-gray-800 text-gray-500 hover:text-gray-300 hover:bg-gray-700'"
-                      x-text="preset.label"></button>
-                  </template>
-                </div>
-
-                <p class="text-[10px] text-gray-600 leading-relaxed pt-1">
-                  Adds a randomized pause after each browser action (click, type, navigate, etc.)
-                  to simulate human reading and decision time. Higher values are stealthier on
-                  bot-protected sites like X/Twitter. 0 = disabled.
-                </p>
-              </div>
-            </div>
-
-            <!-- Idle timeout -->
-            <div class="mt-4 pt-4 border-t border-gray-800" x-show="systemSettings">
-              <div class="max-w-xs">
-                <div class="flex items-center gap-1 mb-1">
-                  <label class="text-xs text-gray-400">Idle Timeout (minutes)</label>
-                  <span class="setting-hint" tabindex="0">?<span class="setting-hint-text">How long the browser container stays alive after the last agent interaction. Lower values save resources; higher values avoid cold-start delays. Default: 30 min.</span></span>
-                  <span class="text-[10px] text-amber-500/70">restart required</span>
-                </div>
-                <input type="number" step="1" min="5" max="120"
-                  class="dash-input w-full"
-                  :value="systemSettings?.browser_idle_timeout"
-                  @change="saveSystemSetting('browser_idle_timeout', $event.target.value)">
-              </div>
-            </div>
-          </div>
-
-          <!-- ── 5. Health & Recovery ── -->
+          <!-- ── 4. Health & Recovery ── -->
           <div class="bg-gray-900 border border-gray-800 rounded-lg p-5">
             <div class="flex items-center gap-2 mb-4">
               <svg class="w-4 h-4 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4.318 6.318a4.5 4.5 0 000 6.364L12 20.364l7.682-7.682a4.5 4.5 0 00-6.364-6.364L12 7.636l-1.318-1.318a4.5 4.5 0 00-6.364 0z"/></svg>


### PR DESCRIPTION
## Summary

- Breaks browser settings (speed, delay, idle timeout) out of the Settings tab into a dedicated **Browser** sub-tab
- Adds **CAPTCHA solver configuration UI** for 2Captcha and CapSolver providers
- API key is stored in `config/settings.json` and displayed masked (last 4 chars only)
- Solver env vars are propagated to the browser container on restart

## Browser tab sections

| Section | Description |
|---|---|
| Interaction Speed | Slider + presets (Stealth through Lightning) — moved from Settings |
| Inter-Action Delay | Slider + presets (Off through Maximum) — moved from Settings |
| Idle Timeout | Minutes input with restart-required notice — moved from Settings |
| CAPTCHA Solver | **New** — provider dropdown (2Captcha/CapSolver), API key input, status display, remove button |

## New API endpoints

| Method | Path | Description |
|---|---|---|
| GET | `/api/captcha-solver` | Returns provider + masked key |
| POST | `/api/captcha-solver` | Saves provider and/or key (CSRF-protected) |
| DELETE | `/api/captcha-solver` | Removes solver configuration (CSRF-protected) |

## Depends on

- #707 (CAPTCHA auto-solving backend) — this PR adds the UI configuration for it

## Test plan

- [x] All 295 dashboard tests pass
- [ ] Verify Browser tab renders with speed/delay/timeout controls
- [ ] Verify CAPTCHA solver provider dropdown and key input
- [ ] Verify save/remove flow with masked key display

🤖 Generated with [Claude Code](https://claude.com/claude-code)