### PR TITLE
Add CAPTCHA auto-solving with dashboard configuration

### DIFF
--- a/src/agent/builtins/browser_tool.py
+++ b/src/agent/builtins/browser_tool.py
@@ -519,8 +519,9 @@ async def browser_switch_tab(tab_index: int = -1, *, mesh_client=None) -> dict:
     name="browser_detect_captcha",
     description=(
         "Detect CAPTCHAs (reCAPTCHA, hCaptcha, Cloudflare Turnstile) on the "
-        "current page. If found, the CAPTCHA must be solved manually via VNC. "
-        "Usually not needed — browser_navigate auto-detects CAPTCHAs."
+        "current page. When a CAPTCHA solver is configured, CAPTCHAs are "
+        "solved automatically after navigation. If auto-solving fails or no "
+        "solver is configured, the CAPTCHA must be solved manually via VNC."
     ),
     parameters={},
     parallel_safe=False,

--- a/src/browser/captcha.py
+++ b/src/browser/captcha.py
@@ -1,0 +1,348 @@
+"""CAPTCHA-solving service integration.
+
+Supports 2Captcha and CapSolver as solving providers.  Both are called via
+their public HTTP APIs using httpx — no additional dependencies required.
+
+When configured (via CAPTCHA_SOLVER_PROVIDER and CAPTCHA_SOLVER_KEY env vars),
+the browser service will automatically attempt to solve CAPTCHAs detected
+after navigation.  If solving fails or no solver is configured, the existing
+fallback (ask user via VNC) is preserved.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import re
+
+import httpx
+
+from src.shared.utils import setup_logging
+
+logger = setup_logging("browser.captcha")
+
+_SOLVE_TIMEOUT = 120  # max seconds to wait for a solution
+_POLL_INTERVAL = 5    # seconds between result polls
+_SUPPORTED_PROVIDERS = ("2captcha", "capsolver")
+
+# Map from detected selector pattern to a canonical CAPTCHA type.
+_CAPTCHA_TYPE_MAP: dict[str, str] = {
+    "recaptcha": "recaptcha",
+    "hcaptcha": "hcaptcha",
+    "challenges.cloudflare.com": "turnstile",
+    "cf-turnstile": "turnstile",
+    "captcha": "recaptcha",  # generic fallback — most common type
+}
+
+# 2Captcha task type mapping
+_2CAPTCHA_TASK_TYPES: dict[str, str] = {
+    "recaptcha": "NormalRecaptchaTaskProxyless",
+    "hcaptcha": "HCaptchaTaskProxyless",
+    "turnstile": "TurnstileTaskProxyless",
+}
+
+# CapSolver task type mapping
+_CAPSOLVER_TASK_TYPES: dict[str, str] = {
+    "recaptcha": "ReCaptchaV2TaskProxyLess",
+    "hcaptcha": "HCaptchaTaskProxyLess",
+    "turnstile": "AntiTurnstileTaskProxyLess",
+}
+
+
+def get_solver() -> CaptchaSolver | None:
+    """Create a CaptchaSolver from environment variables, or None if not configured."""
+    provider = os.environ.get("CAPTCHA_SOLVER_PROVIDER", "").strip().lower()
+    api_key = os.environ.get("CAPTCHA_SOLVER_KEY", "").strip()
+    if not provider or not api_key:
+        return None
+    if provider not in _SUPPORTED_PROVIDERS:
+        logger.warning(
+            "Unknown CAPTCHA_SOLVER_PROVIDER %r (expected one of %s), solver disabled",
+            provider,
+            ", ".join(_SUPPORTED_PROVIDERS),
+        )
+        return None
+    logger.info("CAPTCHA solver configured: provider=%s", provider)
+    return CaptchaSolver(provider, api_key)
+
+
+def _classify_captcha(selector: str) -> str:
+    """Map a CSS selector string to a canonical CAPTCHA type."""
+    sel_lower = selector.lower()
+    for pattern, captcha_type in _CAPTCHA_TYPE_MAP.items():
+        if pattern in sel_lower:
+            return captcha_type
+    return "recaptcha"  # safe default
+
+
+class CaptchaSolver:
+    """Async CAPTCHA solver using 2Captcha or CapSolver HTTP APIs."""
+
+    def __init__(self, provider: str, api_key: str):
+        self.provider = provider
+        self.api_key = api_key
+        self._client: httpx.AsyncClient | None = None
+
+    def _get_client(self) -> httpx.AsyncClient:
+        if self._client is None or self._client.is_closed:
+            self._client = httpx.AsyncClient(timeout=30)
+        return self._client
+
+    async def close(self) -> None:
+        if self._client and not self._client.is_closed:
+            await self._client.aclose()
+            self._client = None
+
+    async def solve(self, page, selector: str, page_url: str) -> bool:
+        """Attempt to solve a CAPTCHA on the page.
+
+        Args:
+            page: Playwright page object.
+            selector: The CSS selector that matched the CAPTCHA element.
+            page_url: The current page URL.
+
+        Returns:
+            True if the CAPTCHA was solved and token injected, False otherwise.
+        """
+        captcha_type = _classify_captcha(selector)
+        logger.info("Attempting to solve %s CAPTCHA on %s", captcha_type, page_url)
+
+        sitekey = await self._extract_sitekey(page, captcha_type)
+        if not sitekey:
+            logger.warning("Could not extract sitekey for %s CAPTCHA", captcha_type)
+            return False
+
+        try:
+            token = await asyncio.wait_for(
+                self._submit_and_poll(captcha_type, sitekey, page_url),
+                timeout=_SOLVE_TIMEOUT,
+            )
+        except asyncio.TimeoutError:
+            logger.warning("CAPTCHA solve timed out after %ds", _SOLVE_TIMEOUT)
+            return False
+        except Exception:
+            logger.exception("CAPTCHA solve failed")
+            return False
+
+        if not token:
+            return False
+
+        injected = await self._inject_token(page, captcha_type, token)
+        if injected:
+            logger.info("CAPTCHA solved and token injected successfully")
+        else:
+            logger.warning("CAPTCHA solved but token injection failed")
+        return injected
+
+    async def _extract_sitekey(self, page, captcha_type: str) -> str | None:
+        """Extract the sitekey from the page DOM."""
+        try:
+            # Try data-sitekey attribute first (works for reCAPTCHA, hCaptcha, Turnstile)
+            sitekey = await page.evaluate(
+                "() => document.querySelector('[data-sitekey]')?.getAttribute('data-sitekey')"
+            )
+            if sitekey:
+                return sitekey.strip()
+
+            # Fall back to parsing iframe src for sitekey parameter
+            if captcha_type == "recaptcha":
+                src = await page.evaluate(
+                    "() => document.querySelector('iframe[src*=\"recaptcha\"]')?.src"
+                )
+                if src:
+                    match = re.search(r'[?&]k=([^&]+)', src)
+                    if match:
+                        return match.group(1)
+
+            if captcha_type == "hcaptcha":
+                src = await page.evaluate(
+                    "() => document.querySelector('iframe[src*=\"hcaptcha\"]')?.src"
+                )
+                if src:
+                    match = re.search(r'[?&]sitekey=([^&]+)', src)
+                    if match:
+                        return match.group(1)
+
+            if captcha_type == "turnstile":
+                # Turnstile sometimes stores config in a script or div attribute
+                sitekey = await page.evaluate("""() => {
+                    const el = document.querySelector('[class*="cf-turnstile"]');
+                    return el?.getAttribute('data-sitekey') || null;
+                }""")
+                if sitekey:
+                    return sitekey.strip()
+
+        except Exception:
+            logger.debug("Error extracting sitekey", exc_info=True)
+        return None
+
+    async def _submit_and_poll(self, captcha_type: str, sitekey: str, page_url: str) -> str | None:
+        """Submit CAPTCHA to solving service and poll for result."""
+        if self.provider == "2captcha":
+            return await self._solve_2captcha(captcha_type, sitekey, page_url)
+        return await self._solve_capsolver(captcha_type, sitekey, page_url)
+
+    # ── 2Captcha ──────────────────────────────────────────────────────────────
+
+    async def _solve_2captcha(self, captcha_type: str, sitekey: str, page_url: str) -> str | None:
+        client = self._get_client()
+        task_type = _2CAPTCHA_TASK_TYPES.get(captcha_type)
+        if not task_type:
+            return None
+
+        # Submit task
+        payload = {
+            "clientKey": self.api_key,
+            "task": {
+                "type": task_type,
+                "websiteURL": page_url,
+                "websiteKey": sitekey,
+            },
+        }
+        resp = await client.post("https://api.2captcha.com/createTask", json=payload)
+        resp.raise_for_status()
+        data = resp.json()
+        if data.get("errorId", 0) != 0:
+            logger.warning("2Captcha submit error: %s", data.get("errorDescription"))
+            return None
+        task_id = data.get("taskId")
+        if not task_id:
+            return None
+
+        # Poll for result
+        for _ in range(int(_SOLVE_TIMEOUT / _POLL_INTERVAL)):
+            await asyncio.sleep(_POLL_INTERVAL)
+            resp = await client.post(
+                "https://api.2captcha.com/getTaskResult",
+                json={"clientKey": self.api_key, "taskId": task_id},
+            )
+            resp.raise_for_status()
+            data = resp.json()
+            if data.get("errorId", 0) != 0:
+                logger.warning("2Captcha poll error: %s", data.get("errorDescription"))
+                return None
+            if data.get("status") == "ready":
+                solution = data.get("solution", {})
+                return solution.get("gRecaptchaResponse") or solution.get("token")
+            # status == "processing" — keep polling
+        return None
+
+    # ── CapSolver ─────────────────────────────────────────────────────────────
+
+    async def _solve_capsolver(self, captcha_type: str, sitekey: str, page_url: str) -> str | None:
+        client = self._get_client()
+        task_type = _CAPSOLVER_TASK_TYPES.get(captcha_type)
+        if not task_type:
+            return None
+
+        # Submit task
+        payload = {
+            "clientKey": self.api_key,
+            "task": {
+                "type": task_type,
+                "websiteURL": page_url,
+                "websiteKey": sitekey,
+            },
+        }
+        resp = await client.post("https://api.capsolver.com/createTask", json=payload)
+        resp.raise_for_status()
+        data = resp.json()
+        if data.get("errorId", 0) != 0:
+            logger.warning("CapSolver submit error: %s", data.get("errorDescription"))
+            return None
+        task_id = data.get("taskId")
+        if not task_id:
+            return None
+
+        # Poll for result
+        for _ in range(int(_SOLVE_TIMEOUT / _POLL_INTERVAL)):
+            await asyncio.sleep(_POLL_INTERVAL)
+            resp = await client.post(
+                "https://api.capsolver.com/getTaskResult",
+                json={"clientKey": self.api_key, "taskId": task_id},
+            )
+            resp.raise_for_status()
+            data = resp.json()
+            if data.get("errorId", 0) != 0:
+                logger.warning("CapSolver poll error: %s", data.get("errorDescription"))
+                return None
+            if data.get("status") == "ready":
+                solution = data.get("solution", {})
+                return solution.get("gRecaptchaResponse") or solution.get("token")
+        return None
+
+    # ── Token injection ───────────────────────────────────────────────────────
+
+    async def _inject_token(self, page, captcha_type: str, token: str) -> bool:
+        """Inject the solved CAPTCHA token into the page."""
+        try:
+            if captcha_type == "recaptcha":
+                await page.evaluate("""(token) => {
+                    const textarea = document.getElementById('g-recaptcha-response');
+                    if (textarea) {
+                        textarea.style.display = '';
+                        textarea.value = token;
+                    }
+                    // Also try hidden textareas in iframes
+                    document.querySelectorAll('[name="g-recaptcha-response"]').forEach(el => {
+                        el.value = token;
+                    });
+                    // Trigger callback if available
+                    if (typeof ___grecaptcha_cfg !== 'undefined') {
+                        const clients = ___grecaptcha_cfg.clients;
+                        if (clients) {
+                            for (const cid in clients) {
+                                const client = clients[cid];
+                                // Walk the client object to find the callback
+                                const walk = (obj, depth) => {
+                                    if (depth > 5 || !obj) return;
+                                    for (const key in obj) {
+                                        if (typeof obj[key] === 'function' && key === 'callback') {
+                                            obj[key](token);
+                                            return;
+                                        }
+                                        if (typeof obj[key] === 'object') walk(obj[key], depth + 1);
+                                    }
+                                };
+                                walk(client, 0);
+                            }
+                        }
+                    }
+                }""", token)
+                return True
+
+            if captcha_type == "hcaptcha":
+                await page.evaluate("""(token) => {
+                    const textarea = document.querySelector('[name="h-captcha-response"]');
+                    if (textarea) textarea.value = token;
+                    document.querySelectorAll('[name="g-recaptcha-response"]').forEach(el => {
+                        el.value = token;
+                    });
+                    // Trigger hcaptcha callback
+                    if (typeof hcaptcha !== 'undefined' && hcaptcha.getRespKey) {
+                        try { hcaptcha.execute(); } catch(e) {}
+                    }
+                }""", token)
+                return True
+
+            if captcha_type == "turnstile":
+                await page.evaluate("""(token) => {
+                    // Find the Turnstile response input
+                    const input = document.querySelector('[name="cf-turnstile-response"]')
+                        || document.querySelector('input[name*="turnstile"]');
+                    if (input) input.value = token;
+                    // Trigger callback if available
+                    if (typeof turnstile !== 'undefined') {
+                        try {
+                            const widgetId = turnstile.getResponse ? null : Object.keys(turnstile._widgets || {})[0];
+                            if (widgetId && turnstile._widgets[widgetId]?.callback) {
+                                turnstile._widgets[widgetId].callback(token);
+                            }
+                        } catch(e) {}
+                    }
+                }""", token)
+                return True
+
+        except Exception:
+            logger.debug("Token injection error", exc_info=True)
+        return False

--- a/src/browser/service.py
+++ b/src/browser/service.py
@@ -18,6 +18,7 @@ import uuid
 from pathlib import Path
 from urllib.parse import urlparse
 
+from src.browser.captcha import get_solver
 from src.browser.redaction import CredentialRedactor
 from src.browser.stealth import build_launch_options
 from src.browser.timing import (
@@ -288,6 +289,7 @@ class BrowserManager:
         self.redactor = CredentialRedactor()
         self._proxy_configs: dict[str, dict | None] = {}
         self.boot_id: str = str(uuid.uuid4())
+        self._captcha_solver = get_solver()
 
     async def start_cleanup_loop(self):
         """Start background task that cleans up idle browsers."""
@@ -546,6 +548,8 @@ class BrowserManager:
         async with self._lock:
             for agent_id in list(self._instances.keys()):
                 await self._stop_instance(agent_id)
+        if self._captcha_solver:
+            await self._captcha_solver.close()
         if self._playwright:
             with contextlib.suppress(Exception):
                 await self._pw_context.__aexit__(None, None, None)
@@ -1807,11 +1811,10 @@ class BrowserManager:
                 return {"success": False, "error": str(e)}
 
     async def _check_captcha(self, inst: CamoufoxInstance) -> dict | None:
-        """Check for CAPTCHA elements on the current page.
+        """Check for CAPTCHA elements and attempt auto-solve if configured.
 
-        Returns a dict with captcha details if found, None otherwise.
-        Called automatically after navigation so agents are always
-        aware when a CAPTCHA is blocking progress.
+        Returns a dict with captcha details if found and unsolved, None if
+        no CAPTCHA or if it was solved automatically.
         """
         captcha_selectors = [
             'iframe[src*="recaptcha"]',
@@ -1825,6 +1828,16 @@ class BrowserManager:
         try:
             for sel in captcha_selectors:
                 if await inst.page.locator(sel).count() > 0:
+                    # Attempt auto-solve if a solver is configured
+                    if self._captcha_solver:
+                        logger.info("CAPTCHA detected (%s), attempting auto-solve", sel)
+                        solved = await self._captcha_solver.solve(
+                            inst.page, sel, inst.page.url,
+                        )
+                        if solved:
+                            return None  # solved — don't report to agent
+                        logger.warning("Auto-solve failed, falling back to manual")
+
                     return {
                         "type": sel,
                         "message": (

--- a/src/dashboard/server.py
+++ b/src/dashboard/server.py
@@ -2967,6 +2967,57 @@ def create_dashboard_router(
             "delay": settings.get("browser_delay", 0.0),
         }
 
+    # ── CAPTCHA solver settings ───────────────────────────────
+
+    @api_router.get("/api/captcha-solver")
+    async def api_get_captcha_solver() -> dict:
+        """Return CAPTCHA solver configuration (key is masked)."""
+        settings = _load_settings()
+        provider = settings.get("captcha_solver_provider", "")
+        key = settings.get("captcha_solver_key", "")
+        return {
+            "provider": provider,
+            "key_masked": f"...{key[-4:]}" if len(key) >= 4 else "",
+        }
+
+    @api_router.post("/api/captcha-solver")
+    async def api_set_captcha_solver(request: Request) -> dict:
+        """Save CAPTCHA solver provider and API key."""
+        await _csrf_check(request)
+        body = await request.json()
+        provider = body.get("provider", "").strip().lower()
+        key = body.get("key", "").strip()
+
+        if provider and provider not in ("2captcha", "capsolver"):
+            raise HTTPException(400, "provider must be '2captcha' or 'capsolver'")
+
+        with _settings_lock:
+            settings = _load_settings()
+            settings["captcha_solver_provider"] = provider
+            if key:
+                settings["captcha_solver_key"] = key
+            elif not provider:
+                settings.pop("captcha_solver_key", None)
+            _save_settings(settings)
+
+        settings = _load_settings()
+        stored_key = settings.get("captcha_solver_key", "")
+        return {
+            "provider": settings.get("captcha_solver_provider", ""),
+            "key_masked": f"...{stored_key[-4:]}" if len(stored_key) >= 4 else "",
+        }
+
+    @api_router.delete("/api/captcha-solver")
+    async def api_delete_captcha_solver(request: Request) -> dict:
+        """Remove CAPTCHA solver configuration."""
+        await _csrf_check(request)
+        with _settings_lock:
+            settings = _load_settings()
+            settings.pop("captcha_solver_provider", None)
+            settings.pop("captcha_solver_key", None)
+            _save_settings(settings)
+        return {"removed": True}
+
     # ── System settings (consolidated) ────────────────────────
 
     _SYSTEM_SETTINGS_VALIDATORS: dict[str, tuple[type, float, float]] = {
@@ -3104,6 +3155,13 @@ def create_dashboard_router(
                 }.items():
                     if cfg_key in sys_settings:
                         runtime.extra_env[env_key] = str(sys_settings[cfg_key])
+                # Push CAPTCHA solver config to env for browser service
+                _solver_provider = sys_settings.get("captcha_solver_provider", "")
+                _solver_key = sys_settings.get("captcha_solver_key", "")
+                if _solver_provider:
+                    os.environ["OPENLEGION_CAPTCHA_SOLVER_PROVIDER"] = _solver_provider
+                if _solver_key:
+                    os.environ["OPENLEGION_CAPTCHA_SOLVER_KEY"] = _solver_key
             except (ValueError, OSError):
                 pass
 

--- a/src/dashboard/static/js/app.js
+++ b/src/dashboard/static/js/app.js
@@ -187,6 +187,10 @@ function dashboard() {
     _browserSettingsDebounce: null,
     _browserDelayDebounce: null,
 
+    captchaSolverProvider: '',
+    captchaSolverKeyMasked: '',
+    captchaSolverSaving: false,
+
     // System settings
     systemSettings: null,
     systemSettingsLoading: false,
@@ -288,6 +292,7 @@ function dashboard() {
       { id: 'network', label: 'Network' },
       { id: 'storage', label: 'Storage' },
       { id: 'operator', label: 'Operator' },
+      { id: 'browser', label: 'Browser' },
       { id: 'settings', label: 'Settings' },
     ],
 
@@ -1227,6 +1232,11 @@ function dashboard() {
           this.fetchBrowserSettings();
           this.fetchSystemSettings();
         }
+        if (this.systemTab === 'browser') {
+          this.fetchBrowserSettings();
+          this.fetchSystemSettings();
+          this.fetchCaptchaSolver();
+        }
         if (this.systemTab === 'activity') {
           if (this.activityView === 'traces') {
             this.fetchTraces();
@@ -1248,6 +1258,7 @@ function dashboard() {
       if (tabId === 'storage') { this.fetchUploads(); this.fetchStorage(); this.fetchDatabaseDetails(); }
       if (tabId === 'network') { this.loadNetworkProxy(); }
       if (tabId === 'settings') { this.fetchBrowserSettings(); this.fetchSystemSettings(); }
+      if (tabId === 'browser') { this.fetchBrowserSettings(); this.fetchSystemSettings(); this.fetchCaptchaSolver(); }
       if (tabId === 'operator') {
         this.fetchAuditLog();
       }
@@ -3516,6 +3527,63 @@ function dashboard() {
       if (d <= 4.0) return 'Moderate';
       if (d <= 7.0) return 'Heavy';
       return 'Maximum';
+    },
+
+    async fetchCaptchaSolver() {
+      try {
+        const resp = await fetch(`${window.__config.apiBase}/captcha-solver`);
+        if (resp.ok) {
+          const data = await resp.json();
+          this.captchaSolverProvider = data.provider || '';
+          this.captchaSolverKeyMasked = data.key_masked || '';
+        }
+      } catch (e) { console.warn('fetchCaptchaSolver failed:', e); }
+    },
+
+    async saveCaptchaSolver() {
+      this.captchaSolverSaving = true;
+      try {
+        const body = { provider: this.captchaSolverProvider };
+        const keyInput = document.getElementById('captcha-solver-key');
+        if (keyInput && keyInput.value) {
+          body.key = keyInput.value;
+        }
+        const resp = await fetch(`${window.__config.apiBase}/captcha-solver`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json', 'X-Requested-With': 'XMLHttpRequest' },
+          body: JSON.stringify(body),
+        });
+        if (resp.ok) {
+          const data = await resp.json();
+          this.captchaSolverProvider = data.provider || '';
+          this.captchaSolverKeyMasked = data.key_masked || '';
+          if (keyInput) keyInput.value = '';
+          this._showToast('CAPTCHA solver settings saved');
+        } else {
+          const err = await resp.json().catch(() => ({}));
+          this._showToast(err.detail || 'Failed to save', 'error');
+        }
+      } catch (e) {
+        console.warn('saveCaptchaSolver failed:', e);
+        this._showToast('Failed to save CAPTCHA solver settings', 'error');
+      }
+      this.captchaSolverSaving = false;
+    },
+
+    async removeCaptchaSolver() {
+      this.captchaSolverSaving = true;
+      try {
+        const resp = await fetch(`${window.__config.apiBase}/captcha-solver`, {
+          method: 'DELETE',
+          headers: { 'X-Requested-With': 'XMLHttpRequest' },
+        });
+        if (resp.ok) {
+          this.captchaSolverProvider = '';
+          this.captchaSolverKeyMasked = '';
+          this._showToast('CAPTCHA solver removed');
+        }
+      } catch (e) { console.warn('removeCaptchaSolver failed:', e); }
+      this.captchaSolverSaving = false;
     },
 
     // ── Network / Proxy ────────────────────────────────

--- a/src/dashboard/templates/index.html
+++ b/src/dashboard/templates/index.html
@@ -4688,6 +4688,217 @@
           </div>
         </div><!-- /operator sub-tab -->
 
+        <!-- ═══ BROWSER SUB-TAB ═══ -->
+        <div x-show="systemTab === 'browser'" class="space-y-4">
+
+          <!-- ── Interaction Speed ── -->
+          <div class="bg-gray-900 border border-gray-800 rounded-lg p-5">
+            <div class="flex items-center gap-2 mb-4">
+              <svg class="w-4 h-4 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 10V3L4 14h7v7l9-11h-7z"/></svg>
+              <h3 class="text-sm font-medium text-gray-200">Interaction Speed</h3>
+            </div>
+            <div class="space-y-3">
+              <div class="flex items-center justify-between">
+                <div>
+                  <div class="text-xs text-gray-400">Speed Multiplier</div>
+                  <div class="text-[10px] text-gray-600 mt-0.5">Controls typing, clicking, and scrolling delays</div>
+                </div>
+                <div class="flex items-center gap-2">
+                  <span class="text-xs font-medium px-2 py-0.5 rounded-full"
+                    :class="{
+                      'bg-indigo-500/10 text-indigo-400': browserSpeed >= 1.8,
+                      'bg-gray-700 text-gray-300': browserSpeed >= 0.8 && browserSpeed < 1.8,
+                      'bg-yellow-500/10 text-yellow-400': browserSpeed < 0.8
+                    }"
+                    x-text="browserSpeedLabel"></span>
+                  <span class="text-xs text-gray-500 font-mono w-10 text-right" x-text="browserSpeed.toFixed(2) + 'x'"></span>
+                </div>
+              </div>
+              <div class="flex items-center gap-3">
+                <span class="text-[10px] text-gray-600 w-10">Slow</span>
+                <input type="range" min="0.25" max="4.0" step="0.05"
+                  :value="browserSpeed"
+                  @input="saveBrowserSpeed($event.target.value)"
+                  class="flex-1 h-1.5 bg-gray-700 rounded-full appearance-none cursor-pointer
+                    [&::-webkit-slider-thumb]:appearance-none [&::-webkit-slider-thumb]:w-3.5 [&::-webkit-slider-thumb]:h-3.5
+                    [&::-webkit-slider-thumb]:rounded-full [&::-webkit-slider-thumb]:bg-indigo-500 [&::-webkit-slider-thumb]:cursor-pointer
+                    [&::-webkit-slider-thumb]:hover:bg-indigo-400 [&::-webkit-slider-thumb]:transition-colors
+                    [&::-moz-range-thumb]:w-3.5 [&::-moz-range-thumb]:h-3.5 [&::-moz-range-thumb]:rounded-full
+                    [&::-moz-range-thumb]:bg-indigo-500 [&::-moz-range-thumb]:border-0 [&::-moz-range-thumb]:cursor-pointer">
+                <span class="text-[10px] text-gray-600 w-6 text-right">Fast</span>
+              </div>
+              <div class="flex gap-2 pt-1">
+                <template x-for="preset in [
+                  { value: 0.25, label: 'Stealth' },
+                  { value: 0.5, label: 'Careful' },
+                  { value: 1.0, label: 'Normal' },
+                  { value: 2.0, label: 'Fast' },
+                  { value: 4.0, label: 'Lightning' }
+                ]" :key="preset.value">
+                  <button @click="saveBrowserSpeed(preset.value)"
+                    class="px-2 py-1 text-[10px] rounded transition-all"
+                    :class="Math.abs(browserSpeed - preset.value) < 0.05
+                      ? 'bg-indigo-500/20 text-indigo-300 ring-1 ring-indigo-500/30'
+                      : 'bg-gray-800 text-gray-500 hover:text-gray-300 hover:bg-gray-700'"
+                    x-text="preset.label"></button>
+                </template>
+              </div>
+              <p class="text-[10px] text-gray-600 leading-relaxed pt-1">
+                Higher values make the browser faster. Lower values add more natural variance
+                to typing rhythm, click delays, and scroll pauses for better stealth on sites with bot detection.
+              </p>
+            </div>
+          </div>
+
+          <!-- ── Inter-Action Delay ── -->
+          <div class="bg-gray-900 border border-gray-800 rounded-lg p-5">
+            <div class="flex items-center gap-2 mb-4">
+              <svg class="w-4 h-4 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z"/></svg>
+              <h3 class="text-sm font-medium text-gray-200">Inter-Action Delay</h3>
+            </div>
+            <div class="space-y-3">
+              <div class="flex items-center justify-between">
+                <div>
+                  <div class="text-xs text-gray-400">Delay Between Actions</div>
+                  <div class="text-[10px] text-gray-600 mt-0.5">Pause between browser actions to simulate human think time</div>
+                </div>
+                <div class="flex items-center gap-2">
+                  <span class="text-xs font-medium px-2 py-0.5 rounded-full"
+                    :class="{
+                      'bg-green-500/10 text-green-400': browserDelay <= 0,
+                      'bg-yellow-500/10 text-yellow-400': browserDelay > 0 && browserDelay <= 4,
+                      'bg-orange-500/10 text-orange-400': browserDelay > 4
+                    }"
+                    x-text="browserDelayLabel"></span>
+                  <span class="text-xs text-gray-500 font-mono w-10 text-right" x-text="browserDelay.toFixed(1) + 's'"></span>
+                </div>
+              </div>
+              <div class="flex items-center gap-3">
+                <span class="text-[10px] text-gray-600 w-10">Off</span>
+                <input type="range" min="0" max="10" step="0.5"
+                  :value="browserDelay"
+                  @input="saveBrowserDelay($event.target.value)"
+                  class="flex-1 h-1.5 bg-gray-700 rounded-full appearance-none cursor-pointer
+                    [&::-webkit-slider-thumb]:appearance-none [&::-webkit-slider-thumb]:w-3.5 [&::-webkit-slider-thumb]:h-3.5
+                    [&::-webkit-slider-thumb]:rounded-full [&::-webkit-slider-thumb]:bg-indigo-500 [&::-webkit-slider-thumb]:cursor-pointer
+                    [&::-webkit-slider-thumb]:hover:bg-indigo-400 [&::-webkit-slider-thumb]:transition-colors
+                    [&::-moz-range-thumb]:w-3.5 [&::-moz-range-thumb]:h-3.5 [&::-moz-range-thumb]:rounded-full
+                    [&::-moz-range-thumb]:bg-indigo-500 [&::-moz-range-thumb]:border-0 [&::-moz-range-thumb]:cursor-pointer">
+                <span class="text-[10px] text-gray-600 w-6 text-right">10s</span>
+              </div>
+              <div class="flex gap-2 pt-1">
+                <template x-for="preset in [
+                  { value: 0, label: 'Off' },
+                  { value: 1.5, label: 'Light' },
+                  { value: 3, label: 'Moderate' },
+                  { value: 6, label: 'Heavy' },
+                  { value: 10, label: 'Maximum' }
+                ]" :key="preset.value">
+                  <button @click="saveBrowserDelay(preset.value)"
+                    class="px-2 py-1 text-[10px] rounded transition-all"
+                    :class="Math.abs(browserDelay - preset.value) < 0.3
+                      ? 'bg-indigo-500/20 text-indigo-300 ring-1 ring-indigo-500/30'
+                      : 'bg-gray-800 text-gray-500 hover:text-gray-300 hover:bg-gray-700'"
+                    x-text="preset.label"></button>
+                </template>
+              </div>
+              <p class="text-[10px] text-gray-600 leading-relaxed pt-1">
+                Adds a randomized pause after each browser action (click, type, navigate, etc.)
+                to simulate human reading and decision time. Higher values are stealthier on
+                bot-protected sites like X/Twitter. 0 = disabled.
+              </p>
+            </div>
+          </div>
+
+          <!-- ── Idle Timeout ── -->
+          <div class="bg-gray-900 border border-gray-800 rounded-lg p-5" x-show="systemSettings">
+            <div class="flex items-center gap-2 mb-4">
+              <svg class="w-4 h-4 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M20 12H4"/></svg>
+              <h3 class="text-sm font-medium text-gray-200">Idle Timeout</h3>
+            </div>
+            <div class="max-w-xs">
+              <div class="flex items-center gap-1 mb-1">
+                <label class="text-xs text-gray-400">Timeout (minutes)</label>
+                <span class="setting-hint" tabindex="0">?<span class="setting-hint-text">How long the browser container stays alive after the last agent interaction. Lower values save resources; higher values avoid cold-start delays. Default: 30 min.</span></span>
+                <span class="text-[10px] text-amber-500/70">restart required</span>
+              </div>
+              <input type="number" step="1" min="5" max="120"
+                class="dash-input w-full"
+                :value="systemSettings?.browser_idle_timeout"
+                @change="saveSystemSetting('browser_idle_timeout', $event.target.value)">
+            </div>
+          </div>
+
+          <!-- ── CAPTCHA Solver ── -->
+          <div class="bg-gray-900 border border-gray-800 rounded-lg p-5">
+            <div class="flex items-center gap-2 mb-4">
+              <svg class="w-4 h-4 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4m5.618-4.016A11.955 11.955 0 0112 2.944a11.955 11.955 0 01-8.618 3.04A12.02 12.02 0 003 9c0 5.591 3.824 10.29 9 11.622 5.176-1.332 9-6.03 9-11.622 0-1.042-.133-2.052-.382-3.016z"/></svg>
+              <h3 class="text-sm font-medium text-gray-200">CAPTCHA Solver</h3>
+            </div>
+            <p class="text-[10px] text-gray-500 mb-4 leading-relaxed">
+              When configured, CAPTCHAs (reCAPTCHA, hCaptcha, Cloudflare Turnstile) are solved automatically
+              during browser navigation. Requires a paid account with a solving service (~$1-3 per 1000 solves).
+            </p>
+
+            <div class="space-y-3">
+              <div>
+                <label class="text-xs text-gray-400 mb-1 block">Provider</label>
+                <select x-model="captchaSolverProvider"
+                  class="dash-input w-full max-w-xs">
+                  <option value="">None (disabled)</option>
+                  <option value="2captcha">2Captcha</option>
+                  <option value="capsolver">CapSolver</option>
+                </select>
+              </div>
+
+              <div x-show="captchaSolverProvider">
+                <label class="text-xs text-gray-400 mb-1 block">API Key</label>
+                <div class="flex items-center gap-2 max-w-md">
+                  <input type="password" id="captcha-solver-key"
+                    :placeholder="captchaSolverKeyMasked ? ('Configured: ' + captchaSolverKeyMasked) : 'Enter your API key'"
+                    class="dash-input flex-1"
+                    autocomplete="off">
+                  <button @click="saveCaptchaSolver()" :disabled="captchaSolverSaving"
+                    class="px-3 py-1.5 text-xs rounded bg-indigo-600 hover:bg-indigo-500 text-white disabled:opacity-50 transition-colors whitespace-nowrap">
+                    <span x-show="!captchaSolverSaving">Save</span>
+                    <span x-show="captchaSolverSaving">Saving...</span>
+                  </button>
+                </div>
+                <p class="text-[10px] text-gray-600 mt-1">
+                  <template x-if="captchaSolverProvider === '2captcha'">
+                    <span>Get your API key from <span class="text-gray-400">2captcha.com</span> dashboard</span>
+                  </template>
+                  <template x-if="captchaSolverProvider === 'capsolver'">
+                    <span>Get your API key from <span class="text-gray-400">capsolver.com</span> dashboard</span>
+                  </template>
+                </p>
+              </div>
+
+              <div x-show="!captchaSolverProvider && captchaSolverKeyMasked" class="pt-1">
+                <p class="text-[10px] text-amber-400/70 mb-2">Solver was previously configured. Select a provider to update, or remove below.</p>
+              </div>
+
+              <div x-show="captchaSolverKeyMasked" class="pt-2 border-t border-gray-800">
+                <div class="flex items-center justify-between">
+                  <div class="text-xs text-gray-500">
+                    Status: <span class="text-green-400">Configured</span>
+                    <span class="text-gray-600 ml-1" x-text="'(' + captchaSolverKeyMasked + ')'"></span>
+                  </div>
+                  <button @click="if(confirm('Remove CAPTCHA solver configuration?')) removeCaptchaSolver()"
+                    :disabled="captchaSolverSaving"
+                    class="px-2 py-1 text-[10px] rounded bg-red-500/10 text-red-400 hover:bg-red-500/20 transition-colors disabled:opacity-50">
+                    Remove
+                  </button>
+                </div>
+              </div>
+            </div>
+            <p class="text-[10px] text-gray-600 leading-relaxed mt-4">
+              Requires a restart to take effect. The API key is stored securely and passed to the browser container as an environment variable.
+            </p>
+          </div>
+
+        </div><!-- /browser sub-tab -->
+
         <!-- ═══ SETTINGS SUB-TAB ═══ -->
         <div x-show="systemTab === 'settings'" class="space-y-4">
 
@@ -4840,147 +5051,7 @@
             </div>
           </div>
 
-          <!-- ── 4. Browser ── -->
-          <div class="bg-gray-900 border border-gray-800 rounded-lg p-5">
-            <div class="flex items-center gap-2 mb-4">
-              <svg class="w-4 h-4 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 12a9 9 0 01-9 9m9-9a9 9 0 00-9-9m9 9H3m9 9a9 9 0 01-9-9m9 9c1.657 0 3-4.03 3-9s-1.343-9-3-9m0 18c-1.657 0-3-4.03-3-9s1.343-9 3-9m-9 9a9 9 0 019-9"/></svg>
-              <h3 class="text-sm font-medium text-gray-200">Browser</h3>
-            </div>
-
-            <!-- Speed control (existing) -->
-            <div class="space-y-3">
-              <div class="flex items-center justify-between">
-                <div>
-                  <div class="text-xs text-gray-400">Interaction Speed</div>
-                  <div class="text-[10px] text-gray-600 mt-0.5">Controls typing, clicking, and scrolling delays</div>
-                </div>
-                <div class="flex items-center gap-2">
-                  <span class="text-xs font-medium px-2 py-0.5 rounded-full"
-                    :class="{
-                      'bg-indigo-500/10 text-indigo-400': browserSpeed >= 1.8,
-                      'bg-gray-700 text-gray-300': browserSpeed >= 0.8 && browserSpeed < 1.8,
-                      'bg-yellow-500/10 text-yellow-400': browserSpeed < 0.8
-                    }"
-                    x-text="browserSpeedLabel"></span>
-                  <span class="text-xs text-gray-500 font-mono w-10 text-right" x-text="browserSpeed.toFixed(2) + 'x'"></span>
-                </div>
-              </div>
-
-              <div class="flex items-center gap-3">
-                <span class="text-[10px] text-gray-600 w-10">Slow</span>
-                <input type="range" min="0.25" max="4.0" step="0.05"
-                  :value="browserSpeed"
-                  @input="saveBrowserSpeed($event.target.value)"
-                  class="flex-1 h-1.5 bg-gray-700 rounded-full appearance-none cursor-pointer
-                    [&::-webkit-slider-thumb]:appearance-none [&::-webkit-slider-thumb]:w-3.5 [&::-webkit-slider-thumb]:h-3.5
-                    [&::-webkit-slider-thumb]:rounded-full [&::-webkit-slider-thumb]:bg-indigo-500 [&::-webkit-slider-thumb]:cursor-pointer
-                    [&::-webkit-slider-thumb]:hover:bg-indigo-400 [&::-webkit-slider-thumb]:transition-colors
-                    [&::-moz-range-thumb]:w-3.5 [&::-moz-range-thumb]:h-3.5 [&::-moz-range-thumb]:rounded-full
-                    [&::-moz-range-thumb]:bg-indigo-500 [&::-moz-range-thumb]:border-0 [&::-moz-range-thumb]:cursor-pointer">
-                <span class="text-[10px] text-gray-600 w-6 text-right">Fast</span>
-              </div>
-
-              <!-- Preset buttons -->
-              <div class="flex gap-2 pt-1">
-                <template x-for="preset in [
-                  { value: 0.25, label: 'Stealth' },
-                  { value: 0.5, label: 'Careful' },
-                  { value: 1.0, label: 'Normal' },
-                  { value: 2.0, label: 'Fast' },
-                  { value: 4.0, label: 'Lightning' }
-                ]" :key="preset.value">
-                  <button @click="saveBrowserSpeed(preset.value)"
-                    class="px-2 py-1 text-[10px] rounded transition-all"
-                    :class="Math.abs(browserSpeed - preset.value) < 0.05
-                      ? 'bg-indigo-500/20 text-indigo-300 ring-1 ring-indigo-500/30'
-                      : 'bg-gray-800 text-gray-500 hover:text-gray-300 hover:bg-gray-700'"
-                    x-text="preset.label"></button>
-                </template>
-              </div>
-
-              <p class="text-[10px] text-gray-600 leading-relaxed pt-1">
-                Higher values make the browser faster. Lower values add more natural variance
-                to typing rhythm, click delays, and scroll pauses for better stealth on sites with bot detection.
-              </p>
-            </div>
-
-            <!-- Inter-action delay control -->
-            <div class="mt-4 pt-4 border-t border-gray-800">
-              <div class="space-y-3">
-                <div class="flex items-center justify-between">
-                  <div>
-                    <div class="text-xs text-gray-400">Inter-Action Delay</div>
-                    <div class="text-[10px] text-gray-600 mt-0.5">Pause between browser actions to simulate human think time</div>
-                  </div>
-                  <div class="flex items-center gap-2">
-                    <span class="text-xs font-medium px-2 py-0.5 rounded-full"
-                      :class="{
-                        'bg-green-500/10 text-green-400': browserDelay <= 0,
-                        'bg-yellow-500/10 text-yellow-400': browserDelay > 0 && browserDelay <= 4,
-                        'bg-orange-500/10 text-orange-400': browserDelay > 4
-                      }"
-                      x-text="browserDelayLabel"></span>
-                    <span class="text-xs text-gray-500 font-mono w-10 text-right" x-text="browserDelay.toFixed(1) + 's'"></span>
-                  </div>
-                </div>
-
-                <div class="flex items-center gap-3">
-                  <span class="text-[10px] text-gray-600 w-10">Off</span>
-                  <input type="range" min="0" max="10" step="0.5"
-                    :value="browserDelay"
-                    @input="saveBrowserDelay($event.target.value)"
-                    class="flex-1 h-1.5 bg-gray-700 rounded-full appearance-none cursor-pointer
-                      [&::-webkit-slider-thumb]:appearance-none [&::-webkit-slider-thumb]:w-3.5 [&::-webkit-slider-thumb]:h-3.5
-                      [&::-webkit-slider-thumb]:rounded-full [&::-webkit-slider-thumb]:bg-indigo-500 [&::-webkit-slider-thumb]:cursor-pointer
-                      [&::-webkit-slider-thumb]:hover:bg-indigo-400 [&::-webkit-slider-thumb]:transition-colors
-                      [&::-moz-range-thumb]:w-3.5 [&::-moz-range-thumb]:h-3.5 [&::-moz-range-thumb]:rounded-full
-                      [&::-moz-range-thumb]:bg-indigo-500 [&::-moz-range-thumb]:border-0 [&::-moz-range-thumb]:cursor-pointer">
-                  <span class="text-[10px] text-gray-600 w-6 text-right">10s</span>
-                </div>
-
-                <!-- Preset buttons -->
-                <div class="flex gap-2 pt-1">
-                  <template x-for="preset in [
-                    { value: 0, label: 'Off' },
-                    { value: 1.5, label: 'Light' },
-                    { value: 3, label: 'Moderate' },
-                    { value: 6, label: 'Heavy' },
-                    { value: 10, label: 'Maximum' }
-                  ]" :key="preset.value">
-                    <button @click="saveBrowserDelay(preset.value)"
-                      class="px-2 py-1 text-[10px] rounded transition-all"
-                      :class="Math.abs(browserDelay - preset.value) < 0.3
-                        ? 'bg-indigo-500/20 text-indigo-300 ring-1 ring-indigo-500/30'
-                        : 'bg-gray-800 text-gray-500 hover:text-gray-300 hover:bg-gray-700'"
-                      x-text="preset.label"></button>
-                  </template>
-                </div>
-
-                <p class="text-[10px] text-gray-600 leading-relaxed pt-1">
-                  Adds a randomized pause after each browser action (click, type, navigate, etc.)
-                  to simulate human reading and decision time. Higher values are stealthier on
-                  bot-protected sites like X/Twitter. 0 = disabled.
-                </p>
-              </div>
-            </div>
-
-            <!-- Idle timeout -->
-            <div class="mt-4 pt-4 border-t border-gray-800" x-show="systemSettings">
-              <div class="max-w-xs">
-                <div class="flex items-center gap-1 mb-1">
-                  <label class="text-xs text-gray-400">Idle Timeout (minutes)</label>
-                  <span class="setting-hint" tabindex="0">?<span class="setting-hint-text">How long the browser container stays alive after the last agent interaction. Lower values save resources; higher values avoid cold-start delays. Default: 30 min.</span></span>
-                  <span class="text-[10px] text-amber-500/70">restart required</span>
-                </div>
-                <input type="number" step="1" min="5" max="120"
-                  class="dash-input w-full"
-                  :value="systemSettings?.browser_idle_timeout"
-                  @change="saveSystemSetting('browser_idle_timeout', $event.target.value)">
-              </div>
-            </div>
-          </div>
-
-          <!-- ── 5. Health & Recovery ── -->
+          <!-- ── 4. Health & Recovery ── -->
           <div class="bg-gray-900 border border-gray-800 rounded-lg p-5">
             <div class="flex items-center gap-2 mb-4">
               <svg class="w-4 h-4 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4.318 6.318a4.5 4.5 0 000 6.364L12 20.364l7.682-7.682a4.5 4.5 0 00-6.364-6.364L12 7.636l-1.318-1.318a4.5 4.5 0 00-6.364 0z"/></svg>

--- a/src/host/runtime.py
+++ b/src/host/runtime.py
@@ -479,6 +479,11 @@ class DockerBackend(RuntimeBackend):
             except Exception as e:
                 logger.warning("Could not parse BROWSER_PROXY_URL for validation: %s", e)
 
+        for var in ("CAPTCHA_SOLVER_PROVIDER", "CAPTCHA_SOLVER_KEY"):
+            env_val = os.environ.get(f"OPENLEGION_{var}") or os.environ.get(var)
+            if env_val:
+                environment[var] = env_val
+
         with self._port_lock:
             api_port = self._next_port
             self._next_port += 1

--- a/tests/test_browser_service.py
+++ b/tests/test_browser_service.py
@@ -3,6 +3,7 @@
 import asyncio
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import httpx
 import pytest
 
 from src.browser.service import BrowserManager, CamoufoxInstance
@@ -2832,6 +2833,7 @@ class TestCaptchaDetection:
         from src.browser.service import BrowserManager
 
         mgr = BrowserManager.__new__(BrowserManager)
+        mgr._captcha_solver = None
         inst = MagicMock()
         inst.page = AsyncMock()
         inst.lock = asyncio.Lock()
@@ -2881,6 +2883,7 @@ class TestCaptchaDetection:
         from src.browser.service import BrowserManager
 
         mgr = BrowserManager.__new__(BrowserManager)
+        mgr._captcha_solver = None
         inst = MagicMock()
         inst.page = AsyncMock()
         inst.lock = asyncio.Lock()
@@ -5033,3 +5036,214 @@ class TestBrowserManagerProxyConfig:
         manager.set_proxy_config("agent-1", {"url": "http://host:8080"})
         manager.set_proxy_config("agent-1", None)
         assert manager.get_proxy_config("agent-1") is None
+
+
+# ── CAPTCHA solver tests ─────────────────────────────────────────────────────
+
+
+class TestGetSolver:
+    """Tests for captcha.get_solver() factory function."""
+
+    def test_get_solver_returns_none_when_not_configured(self):
+        """No env vars → None."""
+        with patch.dict("os.environ", {}, clear=True):
+            from src.browser.captcha import get_solver
+            assert get_solver() is None
+
+    def test_get_solver_returns_solver_when_configured(self):
+        """Valid provider + key → CaptchaSolver instance."""
+        with patch.dict("os.environ", {
+            "CAPTCHA_SOLVER_PROVIDER": "2captcha",
+            "CAPTCHA_SOLVER_KEY": "test-key-123",
+        }):
+            from src.browser.captcha import CaptchaSolver, get_solver
+            solver = get_solver()
+            assert isinstance(solver, CaptchaSolver)
+            assert solver.provider == "2captcha"
+            assert solver.api_key == "test-key-123"
+
+    def test_get_solver_rejects_unknown_provider(self):
+        """Unknown provider → None with warning."""
+        with patch.dict("os.environ", {
+            "CAPTCHA_SOLVER_PROVIDER": "badprovider",
+            "CAPTCHA_SOLVER_KEY": "key",
+        }):
+            from src.browser.captcha import get_solver
+            assert get_solver() is None
+
+
+class TestClassifyCaptcha:
+    """Tests for captcha._classify_captcha()."""
+
+    def test_classify_captcha(self):
+        from src.browser.captcha import _classify_captcha
+        assert _classify_captcha('iframe[src*="recaptcha"]') == "recaptcha"
+        assert _classify_captcha('iframe[src*="hcaptcha"]') == "hcaptcha"
+        assert _classify_captcha('iframe[src*="challenges.cloudflare.com"]') == "turnstile"
+        assert _classify_captcha('[class*="cf-turnstile"]') == "turnstile"
+        assert _classify_captcha('#captcha') == "recaptcha"  # generic fallback
+        assert _classify_captcha('[class*="captcha"]') == "recaptcha"
+        assert _classify_captcha("something-unknown") == "recaptcha"  # default
+
+
+class TestCaptchaSolverSolve:
+    """Tests for CaptchaSolver.solve() and provider flows."""
+
+    @pytest.mark.asyncio
+    async def test_solve_2captcha_success(self):
+        """Mock a successful 2Captcha create+poll flow."""
+        from src.browser.captcha import CaptchaSolver
+
+        solver = CaptchaSolver("2captcha", "test-key")
+
+        # Mock page
+        page = AsyncMock()
+        page.evaluate = AsyncMock(return_value="site-key-abc")
+        page.url = "https://example.com"
+
+        # Mock httpx responses
+        mock_client = AsyncMock(spec=httpx.AsyncClient)
+        mock_client.is_closed = False
+
+        create_resp = MagicMock()
+        create_resp.json.return_value = {"errorId": 0, "taskId": "task-123"}
+        create_resp.raise_for_status = MagicMock()
+
+        poll_resp = MagicMock()
+        poll_resp.json.return_value = {
+            "errorId": 0,
+            "status": "ready",
+            "solution": {"gRecaptchaResponse": "solved-token-xyz"},
+        }
+        poll_resp.raise_for_status = MagicMock()
+
+        mock_client.post = AsyncMock(side_effect=[create_resp, poll_resp])
+        solver._client = mock_client
+
+        result = await solver.solve(page, 'iframe[src*="recaptcha"]', "https://example.com")
+        assert result is True
+        # Verify token was injected
+        page.evaluate.assert_called()
+
+    @pytest.mark.asyncio
+    async def test_solve_capsolver_success(self):
+        """Mock a successful CapSolver create+poll flow."""
+        from src.browser.captcha import CaptchaSolver
+
+        solver = CaptchaSolver("capsolver", "cap-key")
+
+        page = AsyncMock()
+        page.evaluate = AsyncMock(return_value="site-key-abc")
+        page.url = "https://example.com"
+
+        mock_client = AsyncMock(spec=httpx.AsyncClient)
+        mock_client.is_closed = False
+
+        create_resp = MagicMock()
+        create_resp.json.return_value = {"errorId": 0, "taskId": "task-456"}
+        create_resp.raise_for_status = MagicMock()
+
+        poll_resp = MagicMock()
+        poll_resp.json.return_value = {
+            "errorId": 0,
+            "status": "ready",
+            "solution": {"token": "capsolver-token-xyz"},
+        }
+        poll_resp.raise_for_status = MagicMock()
+
+        mock_client.post = AsyncMock(side_effect=[create_resp, poll_resp])
+        solver._client = mock_client
+
+        result = await solver.solve(page, 'iframe[src*="hcaptcha"]', "https://example.com")
+        assert result is True
+
+    @pytest.mark.asyncio
+    async def test_solve_timeout(self):
+        """Verify timeout when solving takes too long."""
+        from src.browser.captcha import CaptchaSolver
+
+        solver = CaptchaSolver("2captcha", "test-key")
+
+        page = AsyncMock()
+        page.evaluate = AsyncMock(return_value="site-key-abc")
+        page.url = "https://example.com"
+
+        mock_client = AsyncMock(spec=httpx.AsyncClient)
+        mock_client.is_closed = False
+
+        create_resp = MagicMock()
+        create_resp.json.return_value = {"errorId": 0, "taskId": "task-789"}
+        create_resp.raise_for_status = MagicMock()
+
+        # Poll always returns processing — will eventually time out
+        poll_resp = MagicMock()
+        poll_resp.json.return_value = {"errorId": 0, "status": "processing"}
+        poll_resp.raise_for_status = MagicMock()
+
+        mock_client.post = AsyncMock(side_effect=[create_resp] + [poll_resp] * 100)
+        solver._client = mock_client
+
+        # Patch _SOLVE_TIMEOUT to make test fast
+        with patch("src.browser.captcha._SOLVE_TIMEOUT", 0.1), \
+             patch("src.browser.captcha._POLL_INTERVAL", 0.01):
+            result = await solver.solve(page, 'iframe[src*="recaptcha"]', "https://example.com")
+        assert result is False
+
+    @pytest.mark.asyncio
+    async def test_solve_no_sitekey_returns_false(self):
+        """Page with no sitekey → solve returns False."""
+        from src.browser.captcha import CaptchaSolver
+
+        solver = CaptchaSolver("2captcha", "test-key")
+
+        page = AsyncMock()
+        page.evaluate = AsyncMock(return_value=None)  # no sitekey found
+        page.url = "https://example.com"
+
+        result = await solver.solve(page, 'iframe[src*="recaptcha"]', "https://example.com")
+        assert result is False
+
+
+class TestCheckCaptchaAutoSolve:
+    """Tests for BrowserManager._check_captcha with auto-solve integration."""
+
+    @pytest.mark.asyncio
+    async def test_check_captcha_auto_solves(self):
+        """When solver succeeds, _check_captcha returns None (no CAPTCHA reported)."""
+        manager = BrowserManager(profiles_dir="/tmp/test_profiles_captcha1")
+
+        mock_solver = AsyncMock()
+        mock_solver.solve = AsyncMock(return_value=True)
+        manager._captcha_solver = mock_solver
+
+        # Mock instance with a page that has a CAPTCHA (no spec — CamoufoxInstance
+        # restricts .page access)
+        inst = MagicMock()
+        mock_locator = MagicMock()
+        mock_locator.count = AsyncMock(return_value=1)
+        inst.page.locator = MagicMock(return_value=mock_locator)
+        inst.page.url = "https://example.com"
+
+        result = await manager._check_captcha(inst)
+        assert result is None  # solved — not reported
+        mock_solver.solve.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_check_captcha_falls_back_on_failure(self):
+        """When solver fails, _check_captcha returns fallback dict."""
+        manager = BrowserManager(profiles_dir="/tmp/test_profiles_captcha2")
+
+        mock_solver = AsyncMock()
+        mock_solver.solve = AsyncMock(return_value=False)
+        manager._captcha_solver = mock_solver
+
+        inst = MagicMock()
+        mock_locator = MagicMock()
+        mock_locator.count = AsyncMock(return_value=1)
+        inst.page.locator = MagicMock(return_value=mock_locator)
+        inst.page.url = "https://example.com"
+
+        result = await manager._check_captcha(inst)
+        assert result is not None
+        assert "CAPTCHA detected" in result["message"]
+        mock_solver.solve.assert_called_once()


### PR DESCRIPTION
## Summary

- Adds automatic CAPTCHA solving (reCAPTCHA, hCaptcha, Cloudflare Turnstile) via **2Captcha** or **CapSolver**
- Breaks browser settings out of Settings into a dedicated **Browser** sub-tab in the dashboard
- Adds CAPTCHA solver configuration UI (provider dropdown + API key input) to the new Browser tab
- No new dependencies — uses httpx for solver API calls

## How it works

1. Agent navigates to a page -> CAPTCHA detected after load
2. Solver extracts sitekey from DOM -> submits to 2Captcha/CapSolver API -> polls for result -> injects token
3. If solved, agent never sees the CAPTCHA. If failed, falls back to "ask user via VNC"

## Configuration

Go to **System > Browser > CAPTCHA Solver**, select a provider, paste your API key, save, and restart.

## Changes

| File | Change |
|---|---|
| `src/browser/captcha.py` | **New** — solver client: sitekey extraction, API submission/polling, token injection |
| `src/browser/service.py` | Wire solver into `_check_captcha` for transparent auto-solving |
| `src/host/runtime.py` | Forward solver env vars to browser container |
| `src/agent/builtins/browser_tool.py` | Update `browser_detect_captcha` skill description |
| `src/dashboard/server.py` | Add GET/POST/DELETE `/api/captcha-solver` endpoints + restart propagation |
| `src/dashboard/static/js/app.js` | Add Browser tab, CAPTCHA solver state & methods |
| `src/dashboard/templates/index.html` | New Browser sub-tab with speed, delay, timeout, and CAPTCHA solver UI |
| `tests/test_browser_service.py` | 10 new tests for solver flows and integration |

## Test plan

- [x] All 271 unit tests pass
- [x] All 295 dashboard tests pass
- [ ] Manual: verify Browser tab renders with all controls
- [ ] Manual: test save/remove flow with 2Captcha API key

🤖 Generated with [Claude Code](https://claude.com/claude-code)