### PR TITLE
Add httpx to browser container dependencies

### DIFF
--- a/Dockerfile.browser
+++ b/Dockerfile.browser
@@ -40,7 +40,7 @@ WORKDIR /app
 COPY pyproject.toml .
 RUN pip install --no-cache-dir --root-user-action=ignore --upgrade pip \
     && pip install --no-cache-dir --root-user-action=ignore \
-    "camoufox[geoip]" fastapi uvicorn pydantic
+    "camoufox[geoip]" fastapi uvicorn pydantic httpx
 
 # Application code
 COPY src/browser/ /app/src/browser/


### PR DESCRIPTION
## Summary

- Adds `httpx` to `Dockerfile.browser` pip install line
- Fixes browser service crash (`ModuleNotFoundError: No module named 'httpx'`) introduced by #710 (CAPTCHA solver)

## Root cause

The CAPTCHA solver module (`src/browser/captcha.py`) imports `httpx` to call 2Captcha/CapSolver APIs, but `Dockerfile.browser` only installed `camoufox[geoip] fastapi uvicorn pydantic`. The main engine has httpx as a dependency, so tests passed, but the isolated browser container didn't have it.

## Test plan

- [x] `docker build -f Dockerfile.browser .` succeeds
- [x] Browser container starts without import errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)