### PR TITLE
docs: align documentation with code (full audit)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,12 +38,12 @@ Three trust zones: **User** (full trust), **Mesh** (trusted coordinator), **Agen
 | `models.py` | Model cost/context window registry backed by LiteLLM, `estimate_cost()` |
 | **`src/agent/`** | |
 | `loop.py` | Agent execution loop (task + chat mode). `MAX_ITERATIONS=20`, `CHAT_MAX_TOOL_ROUNDS=30`, `CHAT_MAX_TOTAL_ROUNDS=200`, `_MAX_SESSION_CONTINUES=5`, `HEARTBEAT_MAX_ITERATIONS=10`. Env-var bounds clamped via `_clamp_env()`. |
-| `server.py` | Agent FastAPI server (27 endpoints). `_FILE_CAPS` enforced on workspace writes (HTTP 413). |
+| `server.py` | Agent FastAPI server (27 endpoints). `_FILE_CAPS` (7 entries) enforced on workspace writes (HTTP 413). `_WORKSPACE_ALLOWLIST` frozenset gates reads/writes. |
 | `llm.py` | LLM client — routes through mesh proxy, never holds keys |
 | `context.py` | Context window management (write-then-compact, `_SUMMARIZATION_INPUT_LIMIT=20_000`). Empty summary falls back to hard prune. |
 | `skills.py` | Skill registry and tool discovery |
 | `memory.py` | Per-agent SQLite + sqlite-vec + FTS5 memory store |
-| `workspace.py` | Persistent markdown workspace. Bootstrap files: PROJECT.md, SYSTEM.md, INSTRUCTIONS.md, SOUL.md, USER.md, MEMORY.md. Also manages HEARTBEAT.md (loaded separately), daily logs, learnings. |
+| `workspace.py` | Persistent markdown workspace. Bootstrap files: PROJECT.md, SYSTEM.md, INSTRUCTIONS.md, SOUL.md, USER.md, MEMORY.md, INTERFACE.md. Also manages HEARTBEAT.md (loaded separately), daily logs, learnings. |
 | `mesh_client.py` | Agent-side HTTP client for mesh communication |
 | `loop_detector.py` | Tool loop detection with escalating responses (warn/block/terminate) |
 | `mcp_client.py` | MCP tool server client and lifecycle |
@@ -63,8 +63,10 @@ Three trust zones: **User** (full trust), **Mesh** (trusted coordinator), **Agen
 | `subagent_tool.py` | In-process subagents (MAX_DEPTH=2, MAX_CONCURRENT=3, MAX_TTL=600s, DEFAULT_MAX_ITERATIONS=10) |
 | `introspect_tool.py` | Runtime state query (permissions, budget, fleet, cron, health) |
 | `wallet_tool.py` | Wallet operations — get address, get balance, read contract, transfer, execute (Ethereum + Solana) |
+| `fleet_tool.py` | Operator-only fleet management tools (`list_templates`, `apply_template`) |
+| `operator_tools.py` | Operator-only tools for fleet/project orchestration (`propose_edit`, `confirm_edit`, `save_observations`, `read_agent_history`, `create_agent`, `list_projects`, `get_project`, `create_project`, `add_agents_to_project`, `remove_agents_from_project`, `update_project_context`) |
 | **`src/host/`** | |
-| `server.py` | Mesh FastAPI app factory — 43 endpoints, all permission-checked. `_RATE_LIMITS` dict (13 entries). VNC reverse proxy with agent token rejection. Localhost validation for `x-mesh-internal`. |
+| `server.py` | Mesh FastAPI app factory — ~60 endpoints, all permission-checked. `_RATE_LIMITS` dict (16 entries: 14 static + `ext_credentials`/`ext_status` added at external-API init). VNC reverse proxy with agent token rejection. Localhost validation for `x-mesh-internal`. |
 | `mesh.py` | Blackboard (SQLite WAL), PubSub, MessageRouter |
 | `runtime.py` | RuntimeBackend ABC → DockerBackend / SandboxBackend. Container security: non-root UID 1000, `cap_drop=[ALL]`, `no-new-privileges`, `read_only=True`, `tmpfs=/tmp` (100m, noexec, nosuid), `mem_limit=384m`, `cpu_quota=15000` (0.15 CPU), `pids_limit=256`. |
 | `transport.py` | Transport ABC → HttpTransport / SandboxTransport |
@@ -97,7 +99,7 @@ Three trust zones: **User** (full trust), **Mesh** (trusted coordinator), **Agen
 | `slack.py` | Slack adapter (Socket Mode, sanitized streaming) |
 | `whatsapp.py` | WhatsApp Cloud API adapter (`X-Hub-Signature-256` verification, warns when signature verification disabled) |
 | **`src/dashboard/`** | |
-| `server.py` | Dashboard FastAPI router + 95 API endpoints + VNC URL injection. Alpine.js SPA with `autoescape=True`, CSP headers, CSRF via `X-Requested-With` requirement on state-changing endpoints. |
+| `server.py` | Dashboard FastAPI router + 106 API endpoints + VNC URL injection. Alpine.js SPA with `autoescape=True`, CSP headers, CSRF via `X-Requested-With` requirement on state-changing endpoints. |
 | `events.py` | EventBus for real-time WebSocket streaming. `threading.Lock` on `emit()`. |
 | `auth.py` | Session cookie verification for dashboard access |
 | `static/` | JS (app.js, websocket.js), CSS, avatars (50 SVGs), favicons |
@@ -109,7 +111,7 @@ Three trust zones: **User** (full trust), **Mesh** (trusted coordinator), **Agen
 | `repl.py` | REPLSession — interactive command dispatch |
 | `channels.py` | ChannelManager — messaging channel lifecycle |
 | `formatting.py` | Tool display, styled output, response rendering |
-| **`src/templates/`** | 11 YAML fleet templates: starter, content, deep-research, devteam, monitor, sales, competitive-intel, lead-enrichment, price-intelligence, review-ops, social-listening |
+| **`src/templates/`** | 13 YAML fleet templates: starter, content, deep-research, devteam, monitor, sales, competitive-intel, lead-enrichment, price-intelligence, review-ops, social-listening, research, opportunity-finder |
 | **Other** | |
 | `src/setup_wizard.py` | Interactive setup wizard with validation |
 | `src/marketplace.py` | Git-based skill marketplace (install/remove, git hooks disabled via `core.hooksPath=/dev/null`) |
@@ -123,7 +125,7 @@ The engine has NO direct dependencies on app/ or provisioner/. No imports, no ca
 ### Provisioner → Engine
 
 Provisioner manages engine instances via Docker/systemd on Hetzner VPS:
-- Deploys code via `git clone` in cloud-init, updates via `update.sh` (git pull + Docker rebuild)
+- Deploys code via `git clone` in cloud-init. An `update.sh` script is shipped alongside, but the live update path in `provisioner/app/services/ssh.py:run_update()` runs the equivalent commands inline over SSH (git pull + Docker rebuild + `systemctl restart openlegion`).
 - Writes `.env` with API keys and config via SSH (base64 encoded to prevent injection)
 - Health checks by SSH-ing to localhost and hitting `GET /mesh/agents` with `x-mesh-internal: 1`
 - Starts/stops via `systemctl restart openlegion`
@@ -155,7 +157,7 @@ Provisioner manages engine instances via Docker/systemd on Hetzner VPS:
 ### Error Handling
 - Domain-specific exceptions propagated with context
 - Overly broad catches avoided — transient vs permanent distinguished
-- `sanitize_for_prompt()` strips invisible Unicode across all input boundaries (~60 call sites across 16 source files)
+- `sanitize_for_prompt()` strips invisible Unicode across all input boundaries (88 call sites across 16 source files)
 - Security errors return generic messages (no leaking internals)
 
 ### Async Patterns
@@ -182,7 +184,7 @@ Provisioner manages engine instances via Docker/systemd on Hetzner VPS:
 - **Agents never hold API keys.** All LLM/API calls go through mesh credential vault.
 - **No `eval()`/`exec()` on untrusted input.** Skill self-authoring uses AST validation.
 - **Permission checks on all mesh endpoints.** Default deny.
-- **Rate limits on state-mutating mesh endpoints.** 13 rate-limited categories defined in `server.py:_RATE_LIMITS`.
+- **Rate limits on state-mutating mesh endpoints.** 16 rate-limited categories defined in `server.py:_RATE_LIMITS` (14 static + 2 added at external-API init).
 - **File path traversal protection.** Two-stage validation in `file_tool.py` (reject `..` before resolution, then walk with symlink resolution via `lstat()`). Workspace `_read_file()` uses `resolve` + `is_relative_to`.
 - **Agent container hardening.** Non-root (UID 1000), `no-new-privileges`, `cap_drop=[ALL]`, `read_only=True`, `tmpfs=/tmp` (100m, noexec, nosuid), 384MB memory, 0.15 CPU, `pids_limit=256`. Browser service container has a different posture (writable /home/browser for Firefox state) — see **Browser container network egress filter** below for its privilege model.
 - **All untrusted text sanitized** via `sanitize_for_prompt()` before reaching LLM context.
@@ -194,7 +196,7 @@ Provisioner manages engine instances via Docker/systemd on Hetzner VPS:
 - **Bounded execution.** 20 iterations for tasks, 30 tool rounds for chat, 200 total chat rounds, token budgets per task. Env-var bounds clamped with validation.
 - **Write-then-compact.** Before discarding context, important facts flush to MEMORY.md. Empty summary falls back to hard prune.
 - **CSRF protection.** Dashboard state-changing endpoints require `X-Requested-With` header.
-- **Workspace file caps.** `_FILE_CAPS` enforced on workspace writes (HTTP 413).
+- **Workspace file caps.** `_FILE_CAPS` enforced on workspace writes (HTTP 413). 7 entries: `SOUL.md: 4000`, `INSTRUCTIONS.md: 12000`, `AGENTS.md: 12000`, `USER.md: 4000`, `MEMORY.md: 16000`, `HEARTBEAT.md: None` (uncapped), `INTERFACE.md: 4000`.
 - **Webhook body size limit.** 1MB with Content-Length pre-check.
 - **Wallet seed protection.** Seed reveal endpoint returns HTTP 410 (seed shown once at init). Init response has `Cache-Control: no-store`.
 - **Env file permissions.** `.agent.env` written with `chmod(0o600)`.
@@ -237,7 +239,7 @@ Provisioner manages engine instances via Docker/systemd on Hetzner VPS:
 6. **`src/shared/types.py` is the contract.** Every cross-component message is a Pydantic model here (335 lines, 24 models).
 7. **LLM tool-calling message roles must alternate.** `user → assistant(tool_calls) → tool(result) → assistant`. `_trim_context` merges summary into first user message to preserve this invariant.
 8. **busy_timeout variance.** Traces uses 5000ms while other SQLite connections use 30000ms.
-9. **Monolithic server files.** `dashboard/server.py` (~3045 lines, 95 endpoints) and `host/server.py` (~1566 lines, 43 endpoints) are single function-scoped definitions.
+9. **Monolithic server files.** `dashboard/server.py` (~3045 lines, 106 endpoints) and `host/server.py` (~1566 lines, ~60 endpoints) are single function-scoped definitions.
 10. **`containers.py` backward-compat alias.** Only consumed by E2E tests.
 
 ## Git Workflow
@@ -360,4 +362,55 @@ pytest tests/test_loop.py -x -v
 
 ## Review State
 
-(Empty — ready for the next review cycle)
+### Documentation Alignment Audit — 2026-04-13 (✅ complete)
+
+**Worktree:** `docs/alignment-audit` (off `main`). **Scope:** `docs/*` + `README.md` + `QUICKSTART.md` (13 files, ~3900 lines).
+
+**Method.** Phase 1 spawned 5 parallel subagents to extract factual inventories from the codebase (commands, config/env, lifecycle, security, tools/integrations) → merged as Code Truth at `/tmp/engine-docs-audit/code-truth.md`. Phase 2 spawned 5 more subagents to cross-reference every claim in every doc file against Code Truth. Full discrepancy report at `/tmp/engine-docs-audit/discrepancy-report.md`; per-file findings at `/tmp/engine-docs-audit/phase2/`.
+
+**Totals.** 22 🔴 lies · 25 🟡 stale · 53 🟢 missing · 31 🔵 vague · 7 ❌ broken examples.
+
+**Highest-impact corrections (🔴):**
+- **"No external network" for agents is false** (README.md §Trust Zones line 222, docs/architecture.md line 20, docs/security.md line 30). Agents run on a standard Docker bridge with NAT egress; SSRF is enforced at the application layer (`src/host/runtime.py:165-174`).
+- **Blackboard tool names wrong** in README.md lines 396–398 and docs/agent-tools.md lines 62–64 (`read_shared_state`/`write_shared_state`/`list_shared_state` do not exist; actual names are `read_blackboard`/`write_blackboard`/`list_blackboard`).
+- **All six MCP `@anthropic/mcp-server-*` package names in docs/mcp.md:124–130 are wrong**; real scope is `@modelcontextprotocol/server-*`. Users installing them get package-not-found errors.
+- **`TaskAssignment` Pydantic example raises `ValidationError`** (docs/development.md:169–178) — missing required `workflow_id` and `step_id` fields.
+- **`allowed_credentials: ["*"]` is NOT the default for new agents** (docs/security.md:73); the Pydantic default is `[]` (deny all).
+- **`set_cron` parameters incomplete** — entire tool-mode (direct tool call without LLM) is invisible (docs/agent-tools.md:85 missing `tool_name`/`tool_params`).
+- **Fleet template table in README lines 656–666 has five wrong agent rosters** (`deep-research`, `competitive-intel`, `monitor`, `social-listening`, `lead-enrichment`) and two templates missing (`opportunity-finder`, `research`).
+- **Memory size caps wrong** — INSTRUCTIONS.md is 12K not 8K (docs/memory.md:81, docs/dashboard.md:102); bootstrap total is 48K not 40K (docs/memory.md:89); FTS5 uses unicode61 not trigram tokenizer (docs/memory.md:143); 90% "emergency hard-prune" threshold doesn't exist as a separate code path.
+- **QUICKSTART.md:278** says browser is Chromium; it's Camoufox (stealth Firefox). Build is two images (~1 + ~3 min), not a single "~2 min" build.
+- **`OPENLEGION_MAX_PROJECTS=0` disables projects, not "unlimited"** (docs/configuration.md:277). Unlimited is when the var is absent.
+- **Heartbeat "starts with scaffold prefix"** (docs/triggering.md:195) — actual check is exact equality `rules.strip() == "# Heartbeat Rules"` (`src/agent/server.py:449`).
+
+**Most serious gaps (🟢):**
+- `docs/channels.md` omits `WHATSAPP_APP_SECRET` (production requirement for X-Hub-Signature-256 webhook verification).
+- `docs/dashboard.md` has zero coverage of auth/CSRF/SSO flow (`ol_session` cookie, `X-Requested-With` requirement, VNC bearer-token rejection, hosted vs dev mode).
+- `coordination_tool.py` (4 tools), `operator_tools.py` (10 tools), and `fleet_tool.py` (2 tools) are entirely undocumented in `docs/agent-tools.md`.
+- `docs/configuration.md` missing: `OPENLEGION_SYSTEM_PROXY`, `HTTP_PROXY`/`HTTPS_PROXY`, `OPENLEGION_TOOL_TIMEOUT`, execution-limit env vars, `INTERFACE.md` bootstrap file, `config/settings.json`, `config/network.yaml`.
+- Tool-mode cron (direct tool invocation without LLM) entirely absent from `docs/triggering.md`.
+- `_UPDATABLE_FIELDS` for cron PUT is `{"schedule", "message", "enabled", "suppress_empty", "tool_name", "tool_params"}` — docs only mention schedule/message.
+- Webhook HMAC signature verification (`require_signature=True`, `X-Webhook-Signature` header) absent from `docs/security.md`.
+- `docs/development.md`: 7 test files missing from test-file map; `src/host/wallet.py`, `src/host/api_keys.py`, `src/shared/models.py`, `src/cli/proxy.py`, and several builtins missing from project tree; test count "2240" should be ~3121; dev dependency table missing `pytest-cov`, `pytest-xdist`, `websockets`, `pypdf`, `anthropic`, `python-multipart`.
+- `docs/dashboard.md` API endpoint table missing ~40+ real endpoints (wallet, network/proxy, external-api-keys, audit, storage, uploads, system-settings, etc.).
+
+**CLAUDE.md staleness found while extracting Code Truth (informational — technically outside scope):**
+- Tool modules listed: 14 → 16 exist (`fleet_tool.py`, `operator_tools.py` missing).
+- `_RATE_LIMITS`: "13 entries" → 16 (14 static + 2 runtime-added).
+- Fleet templates: "11" → 13 (`research.yaml`, `opportunity-finder.yaml` missing).
+- Mesh endpoints: "~43" → ~60.
+- `sanitize_for_prompt()` call sites: "~60" → 88.
+- `_FILE_CAPS` described as 2 entries → actually 7.
+
+**Phase 3 — fixes applied.** 6 parallel subagents edited 13 files: `README.md`, `QUICKSTART.md`, `CLAUDE.md`, and `docs/{agent-tools,architecture,channels,configuration,dashboard,development,mcp,memory,security,triggering}.md`. Priority order applied: 🔴 lies → 🟡 stale → ❌ broken → 🟢 missing → 🔵 vague. Scope expansions: (a) `CLAUDE.md` module table / counts / endpoint stats were refreshed alongside the main scope; (b) operator-only tools (`fleet_tool.py`, `operator_tools.py`) documented in a clearly-labeled section; (c) `skills/README.md` blackboard-tool-name fix applied as collateral cleanup when grep'd up during verification.
+
+**Verification.** Two final-pass subagents ran against the post-fix tree:
+1. Spot-check of all 14 highest-impact fixes against current doc text + source code — PASS on every check, zero regressions.
+2. Cross-repo sanity check against `app/` and `provisioner/` for SSO and deployment claims — all PASS except one minor `update.sh` mechanism note (engine docs said "updates via `update.sh`" but provisioner's `ssh.py:run_update()` actually runs the equivalent commands inline). Fixed in the §Cross-Repo Integration line above.
+
+**Artifacts (retained in `/tmp/engine-docs-audit/` for reference):**
+- `code-truth.md` + `phase1/01..05.md` — factual inventories from reading the code
+- `phase2/A..E.md` — per-file discrepancy reports
+- `discrepancy-report.md` — consolidated findings
+
+**Worktree state.** `docs/alignment-audit` branch off `main`, 13 tracked files modified + 1 collateral (`skills/README.md`). Ready for commit and PR.

--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -191,6 +191,8 @@ python -m venv .venv
 
 > PowerShell blocks the script? Run: `Set-ExecutionPolicy -ExecutionPolicy RemoteSigned -Scope CurrentUser`
 
+> After install, `openlegion` is available only inside the venv. Either activate it (`".venv\Scripts\Activate.ps1"`) before use, or run `openlegion` as `.venv\Scripts\openlegion.exe`. To make it available globally, add the `.venv\Scripts\` directory to your PATH.
+
 </details>
 
 > First install downloads ~70 packages and takes 2-3 minutes. Subsequent installs use pip's cache and are much faster.
@@ -210,7 +212,7 @@ On first run (no credentials configured), `openlegion start` offers three paths:
 2. **Open the dashboard** — configure everything via the web UI at `/dashboard`
 3. **Skip** — start the runtime and use `/addkey` later in the REPL
 
-The Docker image builds automatically on your first `openlegion start` (~2 min). Config files (`config/mesh.yaml`, `config/agents.yaml`, `config/permissions.json`) are created automatically during setup.
+Two Docker images build automatically on first run: the agent image (~1 min) and browser service image (Camoufox + KasmVNC, ~3 min). Config files (`config/mesh.yaml`, `config/agents.yaml`, `config/permissions.json`) are created automatically during setup.
 
 ---
 
@@ -221,7 +223,7 @@ The Docker image builds automatically on your first `openlegion start` (~2 min).
 /costs              # per-agent LLM spend
 /agents             # list running agents
 /broadcast Hello!   # message all agents
-/quit               # stop everything
+/quit               # exit REPL and stop runtime (foreground mode; use openlegion stop for background mode)
 ```
 
 ---
@@ -241,11 +243,13 @@ Use `/add` in the REPL to add more agents to a running system.
 Add channel tokens to `.env`:
 
 ```bash
-OPENLEGION_CRED_TELEGRAM_BOT_TOKEN=123456:ABC...
-OPENLEGION_CRED_DISCORD_BOT_TOKEN=MTIz...
+OPENLEGION_SYSTEM_TELEGRAM_BOT_TOKEN=123456:ABC...
+OPENLEGION_SYSTEM_DISCORD_BOT_TOKEN=MTIz...
 ```
 
-On next `openlegion start`, a pairing code appears — send it to your bot to link.
+The `OPENLEGION_SYSTEM_*` form is the recommended host-level tier. The `OPENLEGION_CRED_*` form and bare env vars (e.g., `TELEGRAM_BOT_TOKEN`, `DISCORD_BOT_TOKEN`) also work.
+
+On next `openlegion start`, a pairing code appears — send `/start <code>` to your Telegram bot (or DM `/start <code>` to your Discord bot) to link.
 
 ### Docker Sandbox (maximum security)
 
@@ -275,6 +279,6 @@ openlegion start --sandbox
 | `python3: command not found` | Install Python 3.10+ (see above). On Windows, use `python` instead of `python3`. |
 | `pip install` is slow | First install downloads ~70 packages (2-3 min). This is normal. Subsequent installs are fast. |
 | `pip install` permission error | Activate the venv first — don't install globally. |
-| Docker build is slow | First build downloads base image + Chromium (~2 min). Rebuilds are fast. |
+| Docker build is slow | First build downloads base image + Camoufox (stealth Firefox) (~3 min for browser image, ~1 min for agent image). Rebuilds are fast. |
 | Agent not responding | `openlegion status` to check health. Verify API key has credits. |
 | PowerShell blocks scripts | `Set-ExecutionPolicy -ExecutionPolicy RemoteSigned -Scope CurrentUser` |

--- a/README.md
+++ b/README.md
@@ -75,7 +75,13 @@ powershell -ExecutionPolicy Bypass -File install.ps1
 openlegion start
 ```
 
+> **Windows note:** Docker Desktop (not Docker Engine) is required on Windows. WSL2 must be enabled. See Docker's [WSL2 backend guide](https://docs.docker.com/desktop/wsl/) if containers fail to start.
+
 > First install downloads ~70 packages and takes 2-3 minutes. Subsequent installs are fast.
+>
+> **First run:** On the very first `openlegion start`, Docker builds the `openlegion-agent:latest` and `openlegion-browser:latest` images from the `Dockerfile.agent` and `Dockerfile.browser` in the repo root. This can take several minutes with no progress output — this is normal. Subsequent starts are fast.
+>
+> **Background mode:** `openlegion start -d` polls for startup for up to 90 seconds. If a Docker image build is needed on first run, this timeout may be exceeded — wait for the build to finish and re-run `openlegion start -d`.
 >
 > **Need help?** See the **[full setup guide](QUICKSTART.md)** for platform-specific instructions and troubleshooting.
 
@@ -164,7 +170,7 @@ No LangChain. No Redis. No Kubernetes. No CEO agent. BSL License.
 OpenLegion's architecture separates concerns across three trust zones:
 untrusted external input, sandboxed agent containers, and a trusted mesh host
 that holds credentials and coordinates the fleet. All inter-agent communication
-flows through the mesh — no agent has direct network access or peer-to-peer
+flows through the mesh. Agents do not contact each other directly — no direct peer-to-peer
 connections.
 
 ```
@@ -219,7 +225,7 @@ connections.
 | Level | Zone | Description |
 |-------|------|-------------|
 | 0 | Untrusted | External input (webhooks, user prompts). Sanitized before reaching agents. |
-| 1 | Sandboxed | Agent containers. Isolated filesystem, no external network, no credentials. |
+| 1 | Sandboxed | Agent containers. Isolated filesystem, no credentials. External network access gated through SSRF-protected mesh proxy — restricted Docker bridge with NAT egress; private/CGNAT/IPv4-mapped/6to4/Teredo ranges blocked by `http_tool.py`. |
 | 2 | Trusted | Mesh host. Holds credentials, manages containers, routes messages. |
 
 ---
@@ -256,8 +262,8 @@ and token usage is recorded after each response.
 
 Configurable failover chains cascade across LLM providers transparently.
 `ModelHealthTracker` applies exponential cooldown per model (transient errors:
-60s → 300s → 1500s, billing/auth errors: 1h). Streaming failover is supported — if a connection fails mid-stream,
-the next model in the chain picks up.
+60s → 300s → 1500s, billing/auth errors: 1h). Streaming failover is supported — if streaming fails mid-response (including empty/zero-length responses that indicate upstream provider failure),
+the next model in the chain retries the full request from the start.
 
 ### Permission Matrix
 
@@ -295,7 +301,7 @@ Agent containers are slim — no browser. Browsing is handled by a shared browse
 
 **Browser service container** (shared across all agents):
 - **Image**: `openlegion-browser:latest` (Camoufox stealth browser + KasmVNC)
-- **Resources**: 2–8GB RAM (scaled by fleet size), 1 CPU, 512MB shared memory
+- **Resources**: 2–8GB RAM (scaled by fleet size), 1–2 CPU (scaled by fleet size), 512MB–2GB shared memory (scaled by fleet size)
 - **Ports**: 8500 (browser API), 6080 (KasmVNC web client)
 - **Capacity**: 1–10 concurrent browser sessions (scaled by fleet size)
 
@@ -387,16 +393,22 @@ canonicalized parameters and results over a 15-call sliding window.
 | `browser_switch_tab` | List open tabs or switch to a specific tab |
 | `browser_reset` | Reset browser session (profile preserved) |
 | `browser_detect_captcha` | CAPTCHA detection (usually not needed — `browser_navigate` auto-detects) |
+| `request_browser_login` | Navigate browser to a URL and send a VNC login card to the user for manual credential entry |
+| `generate_image` | Generate an image via Gemini or DALL-E 3 and save as an artifact |
 | `memory_search` | Hybrid search across workspace files and structured DB |
 | `memory_save` | Save fact to workspace and structured memory DB |
 | `web_search` | Search the web via DuckDuckGo (no API key) |
 | `notify_user` | Send notification to user across all connected channels |
 | `list_agents` | Discover agents in your project (standalone agents see only themselves) |
-| `read_shared_state` | Read from the shared blackboard |
-| `write_shared_state` | Write to the shared blackboard |
-| `list_shared_state` | Browse blackboard entries by prefix |
+| `read_blackboard` | Read from the shared blackboard |
+| `write_blackboard` | Write to the shared blackboard |
+| `list_blackboard` | Browse blackboard entries by prefix |
 | `publish_event` | Publish event to mesh pub/sub |
 | `subscribe_event` | Subscribe to a pub/sub topic at runtime |
+| `hand_off` | Hand a work item to another agent via structured coordination protocol |
+| `check_inbox` | Check for pending work items handed off by other agents |
+| `update_status` | Update the status of an in-progress work item visible to coordinators |
+| `complete_task` | Mark a coordination work item as complete with a result |
 | `watch_blackboard` | Watch blackboard keys matching a glob pattern |
 | `claim_task` | Atomically claim a task from the shared blackboard |
 | `save_artifact` | Save deliverable file and register on blackboard |
@@ -411,6 +423,11 @@ canonicalized parameters and results over a 15-call sliding window.
 | `wait_for_subagent` | Wait for a subagent to complete and return its result |
 | `vault_generate_secret` | Generate and store a random secret (returns opaque handle) |
 | `vault_list` | List credential names (names only, never values) |
+| `wallet_get_address` | Get Ethereum/Solana wallet address for an agent |
+| `wallet_get_balance` | Get wallet balance (ETH or SOL) |
+| `wallet_read_contract` | Read data from an Ethereum smart contract |
+| `wallet_transfer` | Transfer ETH or SOL to an address |
+| `wallet_execute` | Execute an Ethereum smart contract function |
 | `get_system_status` | Query own runtime state: permissions, budget, fleet, cron, health |
 | `read_agent_history` | Read another agent's conversation logs |
 
@@ -467,7 +484,7 @@ Before the context manager discards messages, it:
 1. Asks the LLM to extract important facts from the conversation
 2. Stores facts in both `MEMORY.md` and the structured memory DB
 3. Summarizes the conversation
-4. Replaces message history with: summary + last 4 messages
+4. Replaces message history with: summary + last 3–4 messages (role-aware, preserving message alternation invariant)
 
 Nothing is permanently lost during compaction.
 
@@ -563,12 +580,12 @@ Defense-in-depth with six layers:
 
 | Layer | Mechanism | What It Prevents |
 |-------|-----------|-----------------|
-| Runtime isolation | **Docker Sandbox microVMs** when available; falls back to Docker containers | Agent escape, kernel exploits |
+| Runtime isolation | Docker containers (default); Docker Sandbox microVMs with `--sandbox` (Docker Desktop 4.58+ required) | Agent escape, kernel exploits |
 | Container hardening | Non-root user, no-new-privileges, memory/CPU limits | Privilege escalation, resource abuse |
 | Credential separation | Vault holds keys, agents call via proxy | Key leakage, unauthorized API use |
 | Permission enforcement | Per-agent ACLs for messaging, blackboard, pub/sub, APIs | Unauthorized data access |
 | Input validation | Path traversal prevention, SSRF blocking, safe condition eval (no `eval()`), token budgets, iteration limits, rate limiting | Injection, runaway loops, network abuse |
-| Unicode sanitization | Invisible character stripping at five choke points (user input, tool results, workspace, mesh tools, dashboard) | Prompt injection via hidden Unicode |
+| Unicode sanitization | Invisible character stripping at ~90 call sites across 16 source files, covering all external input boundaries | Prompt injection via hidden Unicode |
 
 ### Dual Runtime Backend
 
@@ -614,7 +631,7 @@ openlegion [--verbose/-v] [--quiet/-q] [--json]
 
 > Agent management, credentials, blackboard, cron, projects, and channels
 > are managed via **REPL commands** (below) inside a running session, or via the
-> **web dashboard** at `http://localhost:8420`.
+> **web dashboard** at `http://localhost:8420` (default port; change with `--port` flag or `mesh.port` in `config/mesh.yaml`).
 
 ### Interactive REPL Commands
 
@@ -637,14 +654,14 @@ openlegion [--verbose/-v] [--quiet/-q] [--json]
 /cron [list|del|pause|resume|run]    Manage cron jobs
 /project [list|use|info]              Manage multi-project namespaces
 /credential [add|list|remove]        Manage API credentials
-/debug [trace]                       Show recent request traces
+/traces [id]                         Show recent request traces
 /logs [--level LEVEL]                Show recent runtime logs
 /addkey <svc> [key]                  Add an API credential to the vault
 /removekey [name]                    Remove a credential from the vault
 /reset                               Clear conversation with active agent
 /quit                                Exit and stop runtime
 
-Aliases: /exit = /quit, /agents = /status, /traces = /debug
+Aliases: /exit = /quit, /agents = /status, /debug = /traces
 ```
 
 ### Team Templates
@@ -657,13 +674,15 @@ Templates are offered during first-run setup (via `openlegion start`):
 | `sales` | researcher, qualifier, outreach | Sales pipeline team |
 | `devteam` | pm, engineer, reviewer | Software development team |
 | `content` | researcher, writer, editor | Content creation team |
-| `deep-research` | researcher, analyst | Deep research and analysis team |
-| `monitor` | monitor | Autonomous monitoring agent |
-| `competitive-intel` | researcher, analyst, reporter | Market and competitor analysis |
-| `lead-enrichment` | enricher | Lead data enrichment |
-| `price-intelligence` | monitor, analyst | Price monitoring and analysis |
+| `deep-research` | scout, analyst, writer | Deep research and analysis team |
+| `monitor` | watcher, analyst | Autonomous monitoring agent |
+| `competitive-intel` | scout | Market and competitor analysis |
+| `lead-enrichment` | enricher, formatter | Lead data enrichment |
+| `price-intelligence` | crawler, analyst | Price monitoring and analysis |
 | `review-ops` | monitor, responder | Review and feedback management |
-| `social-listening` | listener | Social media monitoring |
+| `social-listening` | monitor, writer | Social media monitoring |
+| `opportunity-finder` | gap-scout, evaluator, modeler | Market opportunity discovery |
+| `research` | researcher | General-purpose research agent |
 
 ---
 
@@ -711,7 +730,7 @@ Created automatically by `openlegion start` (inline setup) or the `/add` REPL co
 agents:
   researcher:
     role: "research"
-    model: "openai/gpt-4.1-mini"
+    model: "openai/gpt-4o-mini"
     skills_dir: "./skills/researcher"
     initial_instructions: "You are a research specialist..."
     thinking: "medium"                   # off (default), low, medium, or high
@@ -782,6 +801,8 @@ the emerging standard for LLM tool interoperability. Any MCP-compatible tool ser
 can be plugged into an agent via config, with tools automatically discovered and
 exposed to the LLM alongside built-in skills.
 
+> **Note:** MCP support is an optional dependency. Install it with `pip install openlegion[mcp]` (or add `mcp` to your requirements). Without it, agents with `mcp_servers` configured will log an import error and skip MCP tool loading at startup.
+
 ### Configuration
 
 Add `mcp_servers` to any agent in `config/agents.yaml`:
@@ -790,7 +811,7 @@ Add `mcp_servers` to any agent in `config/agents.yaml`:
 agents:
   researcher:
     role: "research"
-    model: "openai/gpt-4.1-mini"
+    model: "openai/gpt-4o-mini"
     mcp_servers:
       - name: filesystem
         command: mcp-server-filesystem
@@ -857,7 +878,7 @@ pytest tests/
 | Mesh | 65 | Blackboard, PubSub, MessageRouter, permissions |
 | Channels (base) | 62 | Abstract channel, commands, per-user routing, chunking, steer, debug, addkey normalization, parallel broadcast |
 | Cron | 58 | Cron expressions, intervals, dispatch, persistence, enriched heartbeat, skip-LLM, concurrent mutations |
-| Templates | 54 | Template loading, agent creation, model interpolation, all 11 templates |
+| Templates | 54 | Template loading, agent creation, model interpolation, all 13 templates |
 | Runtime Backend | 54 | DockerBackend, SandboxBackend, extra_env, name sanitization, detection, VNC allocation |
 | Projects | 42 | Multi-project CRUD, config, agent membership, blackboard key scoping, cross-project permission isolation |
 | Context Manager | 41 | Token estimation (tiktoken + model-aware), compaction, flushing, flush reset |
@@ -960,7 +981,10 @@ src/
 │       ├── vault_tool.py               # Credential vault operations
 │       ├── skill_tool.py               # Runtime skill creation + hot-reload
 │       ├── introspect_tool.py          # Live runtime state queries
-│       └── subagent_tool.py            # Spawn in-process subagents
+│       ├── subagent_tool.py            # Spawn in-process subagents
+│       ├── coordination_tool.py        # Structured inter-agent coordination (hand_off, check_inbox, update_status, complete_task)
+│       ├── image_gen_tool.py           # Image generation via Gemini or DALL-E 3
+│       └── wallet_tool.py              # Wallet operations (Ethereum + Solana)
 ├── host/
 │   ├── server.py                       # Mesh FastAPI server
 │   ├── mesh.py                         # Blackboard, PubSub, MessageRouter
@@ -1011,7 +1035,9 @@ src/
     ├── lead-enrichment.yaml            # Lead data enrichment
     ├── price-intelligence.yaml         # Price monitoring and analysis
     ├── review-ops.yaml                 # Review and feedback management
-    └── social-listening.yaml           # Social media monitoring
+    ├── social-listening.yaml           # Social media monitoring
+    ├── opportunity-finder.yaml         # Market opportunity discovery
+    └── research.yaml                   # General-purpose researcher
 
 config/
 ├── mesh.yaml                           # Framework settings

--- a/docs/agent-tools.md
+++ b/docs/agent-tools.md
@@ -24,7 +24,7 @@ All file operations are scoped to `/data` inside the container. Path traversal i
 
 | Tool | Parameters | Description |
 |------|-----------|-------------|
-| `http_request` | `url`, `method`, `headers`, `body`, `timeout` | Make HTTP requests (GET/POST/PUT/DELETE/PATCH). Supports `$CRED{name}` handles in URL, headers, and body for credential-blind API calls. Resolved credentials are redacted from responses. Timeout default: 30s. SSRF protection blocks requests to private/internal addresses (loopback, link-local, reserved ranges) including redirect targets. |
+| `http_request` | `url`, `method` (default "GET"), `headers` (default {}), `body` (default "", string), `timeout` (default 30) | Make HTTP requests (GET/POST/PUT/DELETE/PATCH). Supports `$CRED{name}` handles in URL, headers, and body for credential-blind API calls. Resolved credentials are redacted from responses. SSRF protection blocks requests to private/internal addresses (loopback, link-local, reserved ranges) including redirect targets. **Note:** `body` must be a string — serialize JSON manually before passing it (e.g. `json.dumps(data)`). |
 
 ### Browser Automation
 
@@ -32,26 +32,29 @@ All agents share a single **browser service container** running Camoufox (a stea
 
 | Tool | Parameters | Description |
 |------|-----------|-------------|
-| `browser_navigate` | `url`, `wait_ms`, `wait_until` | Open URL, wait, extract page text. `wait_until`: `domcontentloaded` (default), `load`, `networkidle`, `commit`. |
+| `browser_navigate` | `url`, `wait_ms`, `wait_until`, `snapshot_after` (default false) | Open URL, wait, extract page text. `wait_until`: `domcontentloaded` (default), `load`, `networkidle`, `commit`. Set `snapshot_after=true` to return the accessibility tree immediately after navigation. |
 | `browser_get_elements` | -- | Accessibility tree snapshot with element refs (e1, e2, ...). Returns structured text, not a visual image. |
 | `browser_screenshot` | `full_page` | Take screenshot, return visual PNG image. |
-| `browser_click` | `ref` or `selector`, `force` | Click element by accessibility ref or CSS selector. `force` bypasses actionability checks. |
-| `browser_type` | `ref` or `selector`, `text` | Type into input field |
+| `browser_click` | `ref` or `selector`, `force`, `snapshot_after` (default false) | Click element by accessibility ref or CSS selector. `force` bypasses actionability checks. Set `snapshot_after=true` to return an accessibility tree snapshot after the click. |
+| `browser_type` | `ref` or `selector`, `text`, `fast` (default false), `snapshot_after` (default false) | Type into input field (clears field first). `fast=true` sets the value directly without keystrokes. `snapshot_after=true` returns an accessibility tree snapshot after typing. |
 | `browser_hover` | `ref` or `selector` | Hover over an element to trigger dropdowns/tooltips. |
-| `browser_scroll` | `direction`, `amount`, `ref` | Scroll page up/down or scroll element into view. Default direction: `down`, default amount: one viewport height. |
+| `browser_scroll` | `direction`, `amount` (default 0), `ref` | Scroll page up/down or scroll element into view. Default direction: `down`. `amount` is in pixels; `0` (default) is treated as one viewport height. |
 | `browser_wait_for` | `selector`, `state`, `timeout_ms` | Wait for a CSS selector to appear/disappear. `state`: `visible` (default), `attached`, `hidden`, `detached`. |
 | `browser_press_key` | `key` | Press a keyboard key or shortcut (e.g. `Escape`, `Enter`, `Control+a`). |
 | `browser_go_back` | -- | Navigate back in browser history. |
 | `browser_go_forward` | -- | Navigate forward in browser history. |
-| `browser_switch_tab` | `tab_index` | List open tabs or switch to a specific tab. Omit `tab_index` to list only. |
+| `browser_switch_tab` | `tab_index` (default -1) | List open tabs or switch to a specific tab. Default `-1` lists tabs without switching. |
 | `browser_reset` | -- | Reset browser session (profile preserved) |
 | `browser_detect_captcha` | -- | CAPTCHA detection (reCAPTCHA, hCaptcha, Cloudflare Turnstile). Usually not needed — `browser_navigate` auto-detects CAPTCHAs. |
+| `request_browser_login` | `url`, `service`, `description` | Navigate the browser to a login page and emit a VNC login card to the user, prompting them to log in manually. Useful when a service requires human authentication before automation can continue. |
+
+**Note:** All browser tools are `parallel_safe=False` — only one browser tool may execute at a time per agent. Subagents sharing the same parent agent should not attempt concurrent browser operations.
 
 ### Memory
 
 | Tool | Parameters | Description |
 |------|-----------|-------------|
-| `memory_search` | `query`, `category`, `max_results` | Hybrid search across workspace files and structured DB. Provide `category` to search only the fact database filtered to that category. |
+| `memory_search` | `query`, `category` (default ""), `max_results` (default 5) | Hybrid search across workspace files and the structured memory DB. Uses vector similarity (sqlite-vec) with FTS5 full-text fallback when the embedding model is unavailable. Provide `category` to restrict the search to the fact database filtered to that category. Returns `{results: [{key, value, category, confidence, access_count, source}], count}`. |
 | `memory_save` | `content` | Save a fact to workspace daily log and structured memory |
 
 ### Mesh / Fleet
@@ -59,30 +62,33 @@ All agents share a single **browser service container** running Camoufox (a stea
 | Tool | Parameters | Description |
 |------|-----------|-------------|
 | `list_agents` | -- | Discover agents in your project (standalone agents see only themselves) |
-| `read_shared_state` | `key` | Read from the project-scoped blackboard. Keys are auto-namespaced under `projects/{name}/` — agents use natural keys like `tasks/abc` |
-| `write_shared_state` | `key`, `value` | Write to the project-scoped blackboard |
-| `list_shared_state` | `prefix` | Browse project blackboard entries by prefix |
+| `read_blackboard` | `key` | Read from the project-scoped blackboard. Keys are auto-namespaced under `projects/{name}/` — agents use natural keys like `tasks/abc` |
+| `write_blackboard` | `key`, `value` | Write a JSON value to the project-scoped blackboard |
+| `list_blackboard` | `prefix` (default "") | Browse project blackboard entries by prefix. Returns key names, authors, timestamps, and 200-char value previews. |
 | `publish_event` | `topic`, `data` | Publish event to mesh pub/sub |
 | `subscribe_event` | `topic` | Subscribe to a pub/sub topic at runtime. Events arrive as steer messages between tool rounds. |
 | `watch_blackboard` | `pattern` | Watch blackboard keys matching a glob pattern. Notifications arrive when matching keys are written. |
 | `claim_task` | `key`, `claim_value` | Atomically claim a task from the blackboard (compare-and-swap). Prevents duplicate work. |
-| `save_artifact` | `name`, `content` | Save deliverable to workspace and register on project blackboard |
+| `save_artifact` | `name`, `content`, `description` (default "") | Save deliverable to workspace and register on project blackboard at `artifacts/{agent_id}/{name}` |
 | `notify_user` | `message` | Send a notification to the user across all connected channels (CLI, Telegram, Discord, Slack, etc.) |
 | `read_agent_history` | `agent_id` | Read another agent's conversation logs (permission-checked) |
+| `get_agent_profile` | `agent_id` | Read an agent's collaboration interface, inputs, outputs, and current status |
 
-**Project isolation:** Blackboard tools (`read_shared_state`, `write_shared_state`, `list_shared_state`, `save_artifact`) are only available to agents assigned to a project. Standalone agents cannot access the blackboard — calls return an error explaining they must be added to a project first.
+**Project isolation:** Blackboard tools (`read_blackboard`, `write_blackboard`, `list_blackboard`, `save_artifact`) are only available to agents assigned to a project. Standalone agents cannot access the blackboard — calls return an error explaining they must be added to a project first.
+
+**Project context:** Agents assigned to a project automatically receive a `PROJECT.md` file mounted read-only in their workspace. This file contains the project description and shared context, visible to the agent from its first turn without any tool call.
 
 ### Workspace
 
 | Tool | Parameters | Description |
 |------|-----------|-------------|
-| `update_workspace` | `filename`, `content` | Update a writable workspace file (SOUL.md, INSTRUCTIONS.md, USER.md, or HEARTBEAT.md) to persist learnings across sessions |
+| `update_workspace` | `filename`, `content` | Update a writable workspace file (`SOUL.md`, `INSTRUCTIONS.md`, `USER.md`, `HEARTBEAT.md`, or `INTERFACE.md`) to persist learnings across sessions |
 
 ### Scheduling & Automation
 
 | Tool | Parameters | Description |
 |------|-----------|-------------|
-| `set_cron` | `schedule`, `message`, `heartbeat` | Schedule a recurring job (cron expression or interval). Set `heartbeat=true` to update your autonomous wakeup schedule. |
+| `set_cron` | `schedule`, `tool_name` (default ""), `tool_params` (default "{}"), `message` (default ""), `heartbeat` (default false) | Schedule a recurring job (cron expression or interval). Three modes: **tool-mode** — set `tool_name` (and optionally `tool_params` as a JSON string) to invoke a tool directly on each tick without any LLM involved; **message-mode** — set `message` to dispatch the text to the LLM on each tick; **heartbeat-mode** — set `heartbeat=true` to update your autonomous wakeup schedule. `tool_name` and `message` are mutually exclusive. |
 | `list_cron` | -- | List scheduled jobs |
 | `remove_cron` | `job_id` | Remove a scheduled job |
 
@@ -118,8 +124,9 @@ Agents never see credential values. All operations return opaque `$CRED{name}` h
 
 | Tool | Parameters | Description |
 |------|-----------|-------------|
-| `vault_generate_secret` | `name`, `length`, `charset` | Generate a random secret and store it (returns handle only) |
+| `vault_generate_secret` | `name`, `length` (default 32), `charset` (default "urlsafe"; values: `urlsafe` / `hex` / `alphanumeric`) | Generate a random secret and store it (returns opaque `$CRED{name}` handle only — the actual value is never returned) |
 | `vault_list` | -- | List credential names the agent can access (names only, filtered by permissions) |
+| `request_credential` | `name`, `description`, `service` (default "") | Ask the user to supply a credential via the dashboard. The value is stored in the vault and the agent receives a `$CRED{name}` handle. Use this when a service requires a key the user must provide manually. |
 
 ### Wallet
 
@@ -137,7 +144,7 @@ Agents can interact with EVM and Solana blockchains through the wallet signing s
 
 | Tool | Parameters | Description |
 |------|-----------|-------------|
-| `get_system_status` | `section` | Query live runtime state: permissions, budget, fleet, cron, health, or all |
+| `get_system_status` | `section` (default "all"; values: `permissions` / `budget` / `fleet` / `cron` / `health` / `all`) | Query live runtime state |
 
 Agents receive system awareness through three layers:
 
@@ -147,11 +154,53 @@ Agents receive system awareness through three layers:
 
 The `section` parameter accepts: `permissions`, `budget`, `fleet`, `cron`, `health`, or `all` (default). Fleet data is filtered by `can_message` permissions — agents only see teammates they can interact with.
 
-### Agent History
+### Multi-Agent Coordination
+
+Higher-level tools from `coordination_tool.py` that implement a structured work-handoff protocol over the blackboard. Prefer these over raw blackboard writes for inter-agent task management.
+
+Protocol layout: `tasks/{agent_id}/{id}` for inboxes, `output/{agent_id}/{id}` for output data, `status/{agent_id}` for state. Handoff TTL is 24 hours.
 
 | Tool | Parameters | Description |
 |------|-----------|-------------|
-| `read_agent_history` | `agent_id` | Read another agent's conversation logs (permission-checked) |
+| `hand_off` | `to`, `summary`, `data` (default "", JSON string) | Send work to another agent. Validates the target agent ID, writes a task entry to the target's inbox, and wakes the target agent. |
+| `check_inbox` | -- | Read your own task inbox. Returns `{tasks: [{key, from, summary, status, output_key?, ts?}], count}`. Completed (`status == "done"`) tasks are omitted. |
+| `update_status` | `state` (enum: `idle` / `working` / `blocked` / `done`), `summary` (default "") | Broadcast your current state to the `status/{agent_id}` blackboard key so teammates can see what you're doing. |
+| `complete_task` | `task_key` | Mark a task done and remove it from the blackboard. Ownership check enforced — you can only complete tasks in your own inbox (`tasks/{own_id}/...`). |
+
+### Image Generation
+
+| Tool | Parameters | Description |
+|------|-----------|-------------|
+| `generate_image` | `prompt`, `size` (default "square"; values: `square` / `landscape` / `portrait`), `filename` (default ""), `provider` (default "", values: `gemini` / `openai`) | Generate an image from a text prompt. Routes through the mesh credential proxy — agents never hold API keys. Saves the PNG to `/data/workspace/artifacts/` and registers it on the project blackboard at `artifacts/{filename}` if in a project. Returns a multimodal `_image` block for inline display. Default provider is Gemini (falls back to OpenAI DALL-E 3 if `provider="openai"` is specified). |
+
+### Operator-Only Tools
+
+The following tools are only available to the **operator agent** (when `ALLOWED_TOOLS` is set in the agent's environment). They are not accessible to user-created agents.
+
+#### Fleet Templates (`fleet_tool.py`)
+
+| Tool | Parameters | Description |
+|------|-----------|-------------|
+| `list_templates` | -- | List available fleet templates |
+| `apply_template` | `template`, `model` (default "") | Apply a fleet template to deploy a predefined set of agents. Requires user-origin provenance check. |
+
+#### Fleet & Project Management (`operator_tools.py`)
+
+| Tool | Parameters | Description |
+|------|-----------|-------------|
+| `propose_edit` | `agent_id`, `field` (enum: `instructions` / `soul` / `model` / `role` / `heartbeat` / `thinking` / `budget` / `permissions`), `value` | Propose a config change for an agent. Returns a `change_id` that must be confirmed. |
+| `confirm_edit` | `change_id` | Apply a previously proposed edit. |
+| `save_observations` | `fleet_summary`, `agents_attention` (default []), `cost_trend`, `notes` (default "") | Persist fleet health observations for human review. |
+| `read_agent_history` | `agent_id`, `period` (default "today"; values: `today` / `yesterday` / `week`) | Read an agent's conversation history with period filtering (operator version). |
+| `create_agent` | `name`, `role`, `model` (default ""), `instructions`, `soul` (default "") | Create a new agent. |
+| `list_projects` | -- | List all projects. |
+| `get_project` | `project_name` | Get details for a project. |
+| `create_project` | `name`, `description`, `agent_ids` (default []) | Create a new project and optionally add agents. |
+| `add_agents_to_project` | `project_name`, `agent_ids` | Add one or more agents to a project. |
+| `remove_agents_from_project` | `project_name`, `agent_ids` | Remove one or more agents from a project. |
+| `update_project_context` | `project_name`, `context` | Update the shared context text (`PROJECT.md`) for a project. |
+
+**Permission ceiling:** The operator cannot grant `can_spawn=true` or `can_use_wallet=true` to agents. Budget limits: daily $0.01–$1000, monthly $0.10–$30000.
 
 ## MCP Tools
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -6,8 +6,9 @@ OpenLegion is a container-isolated multi-agent runtime. LLM-powered agents run i
 
 ```
 User (CLI REPL / Telegram / Discord / Slack / WhatsApp / Webhook)
-  -> Mesh Host (FastAPI :8420) -- routes messages, enforces permissions, proxies APIs
+  -> Mesh Host (FastAPI :8420) -- routes messages, enforces permissions, proxies APIs, VNC proxy
     -> Agent Containers (FastAPI :8400 each) -- isolated execution with private memory
+    -> Browser Service Container (FastAPI :8500 + KasmVNC :6080) -- shared Camoufox browser, per-agent VNC sessions
 ```
 
 ## Trust Zones
@@ -17,7 +18,7 @@ Three trust zones govern all inter-component communication:
 | Level | Zone | Description |
 |-------|------|-------------|
 | 0 | **Untrusted** | External input (webhooks, user prompts). Sanitized before reaching agents. |
-| 1 | **Sandboxed** | Agent containers. Isolated filesystem, no external network, no credentials. |
+| 1 | **Sandboxed** | Agent containers. Isolated filesystem, restricted network (bridge NAT; SSRF protection blocks private IPs), no LLM API keys (all provider calls proxy through the mesh). |
 | 2 | **Trusted** | Mesh host. Holds credentials, manages containers, routes messages. |
 
 Everything between zones is HTTP + JSON with Pydantic contracts defined in `src/shared/types.py`.
@@ -54,6 +55,7 @@ The mesh host runs on the user's machine as a single FastAPI process. It is the 
 | `traces.py` | Request tracing and diagnostics |
 | `transcript.py` | Provider-specific transcript sanitization |
 | `wallet.py` | Wallet signing service for EVM and Solana transactions |
+| `api_keys.py` | Named API key management — salted SHA-256 hashes stored in `config/api_keys.json`, `X-API-Key` header auth |
 
 ### Agent (`src/agent/`)
 
@@ -66,7 +68,7 @@ Each agent runs in an isolated Docker container with its own FastAPI server.
 | `skills.py` | Skill discovery and registry; `@skill` decorator system |
 | `mcp_client.py` | MCP server lifecycle management and tool routing |
 | `memory.py` | SQLite + sqlite-vec + FTS5 hierarchical memory store |
-| `workspace.py` | Persistent markdown workspace (INSTRUCTIONS.md, SOUL.md, USER.md, MEMORY.md, SYSTEM.md, HEARTBEAT.md, daily logs, learnings) |
+| `workspace.py` | Persistent markdown workspace (INSTRUCTIONS.md, SOUL.md, USER.md, MEMORY.md, SYSTEM.md, HEARTBEAT.md, INTERFACE.md, daily logs, learnings) |
 | `context.py` | Context window management with write-then-compact pattern |
 | `llm.py` | LLM client with streaming (`chat_stream()`) and non-streaming (`chat()`) — routes through mesh proxy |
 | `mesh_client.py` | HTTP client for agent-to-mesh communication |
@@ -90,6 +92,8 @@ Each agent runs in an isolated Docker container with its own FastAPI server.
 | `subagent_tool.py` | In-container subagent spawning and management |
 | `wallet_tool.py` | Blockchain wallet operations (address, balance, transfer, contract calls) |
 | `web_search_tool.py` | DuckDuckGo web search (no API key) |
+| `image_gen_tool.py` | Image generation via Gemini or DALL-E 3, saves output as artifacts |
+| `coordination_tool.py` | Structured multi-agent coordination — `hand_off`, `check_inbox`, `update_status` |
 
 ### Browser Service (`src/browser/`)
 
@@ -102,13 +106,13 @@ Each agent runs in an isolated Docker container with its own FastAPI server.
 
 ### Browser Container Resources
 
-Resources scale by plan to fit server constraints:
+Resources scale with the `OPENLEGION_MAX_AGENTS` environment variable:
 
-| Plan | Server | RAM | SHM | CPU | Max Browsers |
-|------|--------|-----|-----|-----|-------------|
-| Basic | cax11 4GB 2c | 2GB | 512MB | 1.0 core | 1 |
-| Growth | cax21 8GB 4c | 4GB | 1GB | 1.5 cores | 5 |
-| Pro | cax31 16GB 8c | 8GB | 2GB | 2.0 cores | 10 |
+| Tier | `OPENLEGION_MAX_AGENTS` | RAM | SHM | CPU | Max Browsers |
+|------|------------------------|-----|-----|-----|-------------|
+| Basic | ≤ 1 | 2GB | 512MB | 1.0 core | 1 |
+| Growth | 2–5 | 4GB | 1GB | 1.5 cores | `max_agents` |
+| Pro | > 5 | 8GB | 2GB | 2.0 cores | `min(max_agents, 10)` |
 
 SHM (shared memory) is critical for Firefox compositor IPC — too small causes VNC rendering freezes.
 
@@ -164,7 +168,7 @@ Agents can be organized into **projects** — isolated namespaces that scope bla
 
 ### Project Data
 
-Project configuration is stored in `config/projects/{name}/` with a `project.md` file for shared context and membership tracked in the project metadata.
+Project configuration is stored in `config/projects/{name}/`. Each project directory contains `metadata.yaml` (name, description, created_at, members list) and `project.md` (shared context mounted read-only into member containers).
 
 ## Data Flow
 

--- a/docs/channels.md
+++ b/docs/channels.md
@@ -63,6 +63,27 @@ openlegion chat <agent>   # Connect to running agent (detached mode)
 
 The CLI REPL supports all channel commands above plus the REPL-only commands listed in the table. It also provides token-level streaming responses with tool-use progress indicators and tab completion for agent names and subcommands.
 
+## Env Var Lookup
+
+All channel tokens are resolved via a three-tier lookup in this order:
+
+1. `OPENLEGION_SYSTEM_<NAME>` — host-level (recommended for operators; system-tier credentials are never exposed to agents)
+2. `OPENLEGION_CRED_<NAME>` — agent-accessible credential tier
+3. Bare env var (e.g. `TELEGRAM_BOT_TOKEN`, `DISCORD_BOT_TOKEN`) — convenience for quick local setup
+
+For production deployments, prefer the `OPENLEGION_SYSTEM_*` form so that token values never enter the agent credential vault.
+
+Examples for Telegram:
+```bash
+# Preferred (host-level):
+OPENLEGION_SYSTEM_TELEGRAM_BOT_TOKEN=123456:ABC-DEF...
+# Also accepted:
+OPENLEGION_CRED_TELEGRAM_BOT_TOKEN=123456:ABC-DEF...
+TELEGRAM_BOT_TOKEN=123456:ABC-DEF...
+```
+
+The same pattern applies to Discord (`DISCORD_BOT_TOKEN`), Slack (`SLACK_BOT_TOKEN`, `SLACK_APP_TOKEN`), and WhatsApp (`WHATSAPP_ACCESS_TOKEN`, `WHATSAPP_PHONE_NUMBER_ID`).
+
 ## Telegram
 
 ### Setup
@@ -116,7 +137,7 @@ Pairing state is stored in `config/telegram_paired.json`.
 
 ### Setup
 
-Set your bot token in `.env`:
+Set your bot token in `.env` (see [Env Var Lookup](#env-var-lookup) for all accepted forms):
 
 ```bash
 OPENLEGION_CRED_DISCORD_BOT_TOKEN=MTIz...
@@ -178,7 +199,7 @@ Pairing state is stored in `config/discord_paired.json`.
 
 ### Setup
 
-Set your tokens in `.env`:
+Set your tokens in `.env` (see [Env Var Lookup](#env-var-lookup) for all accepted forms):
 
 ```bash
 OPENLEGION_CRED_SLACK_BOT_TOKEN=xoxb-...
@@ -228,11 +249,17 @@ After pairing, the bot sends a help summary with all available commands. Unautho
 
 ### Setup
 
-Set your tokens in `.env`:
+Set your tokens in `.env`. All channel tokens support a three-tier lookup (see [Env Var Lookup](#env-var-lookup)):
 
 ```bash
 OPENLEGION_CRED_WHATSAPP_ACCESS_TOKEN=EAAx...
 OPENLEGION_CRED_WHATSAPP_PHONE_NUMBER_ID=1234...
+```
+
+In production you must also set the app secret for webhook signature verification (see [Security](#security) below):
+
+```bash
+WHATSAPP_APP_SECRET=<your-app-secret-from-meta-dashboard>
 ```
 
 Enable in `config/mesh.yaml`:
@@ -253,6 +280,30 @@ WhatsApp uses the **Cloud API** with webhook-based message delivery. In the [Met
 3. Configure the webhook URL: `https://your-server:8420/channels/whatsapp/webhook`
 4. Subscribe to `messages` webhook field
 
+### Security
+
+**Production deployments must set `WHATSAPP_APP_SECRET`.** Without it, `X-Hub-Signature-256` webhook signature verification is disabled — any HTTP client can inject arbitrary messages. When `MESH_AUTH_TOKEN` is set (i.e., production mode) and `WHATSAPP_APP_SECRET` is absent, startup raises a `RuntimeError`.
+
+Set the app secret to the value shown in the Meta dashboard under your WhatsApp app → App Settings → App Secret:
+
+```bash
+WHATSAPP_APP_SECRET=abc123...
+```
+
+The secret is read directly from the `WHATSAPP_APP_SECRET` environment variable (not via the `OPENLEGION_*` credential prefix).
+
+### Verify Token
+
+The webhook verification token is auto-generated as a random `secrets.token_hex(16)` value if none is configured. To use a deterministic, replay-safe token instead (recommended for reproducible deployments), set it explicitly:
+
+```bash
+OPENLEGION_SYSTEM_WHATSAPP_VERIFY_TOKEN=my-stable-verify-token
+# or
+OPENLEGION_CRED_WHATSAPP_VERIFY_TOKEN=my-stable-verify-token
+```
+
+The token configured here must match what you enter in the Meta Developer Portal webhook settings.
+
 ### Pairing
 
 WhatsApp uses the same pairing pattern:
@@ -268,7 +319,7 @@ After pairing, the bot sends a help summary with all available commands. Unautho
 
 ### Features
 
-- Text messages only (non-text messages get a reply explaining this to allowed users)
+- Text messages only. Non-text messages (images, audio, documents, etc.) receive a reply only when pairing is already complete **and** the sender is an allowed user. Before pairing is complete (no owner set yet), non-text messages are silently dropped.
 - Messages chunked at 4096 characters
 - Per-user agent tracking by phone number
 - Webhook verification challenge handled automatically

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -11,6 +11,8 @@ OpenLegion uses YAML and JSON files in the `config/` directory. Config files are
 | `config/permissions.json` | JSON | Per-agent ACL matrix |
 | `config/cron.json` | JSON | Scheduled job state (auto-managed) |
 | `config/projects/` | Directory | Per-project data (project.md, members) |
+| `config/settings.json` | JSON | Dashboard-managed runtime settings: browser speed/delay/timeout, execution limits (`max_iterations`, `chat_max_tool_rounds`, etc.), and default budgets. Written by the dashboard and injected as env vars into agent containers at startup. |
+| `config/network.yaml` | YAML | Network settings (`no_proxy` exclusion list for proxy mode). |
 | `.env` | dotenv | API keys and credentials |
 
 ## `config/agents.yaml`
@@ -44,7 +46,7 @@ agents:
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
 | `role` | string | Yes | Short description of the agent's purpose |
-| `model` | string | No | LLM model in `provider/model` format. Falls back to `llm.default_model` in mesh.yaml |
+| `model` | string | No | LLM model in `provider/model` format. Falls back to `llm.default_model` in mesh.yaml, then `openai/gpt-4o-mini` if neither is set. |
 | `skills_dir` | string | No | Path to custom skills directory |
 | `system_prompt` | string | No | Custom system prompt. Auto-generated if omitted. Also accepted as `instructions` |
 | `resources.memory_limit` | string | No | Reserved for future use. Currently hardcoded to `384m` by the runtime for security. |
@@ -55,6 +57,7 @@ agents:
 | `initial_instructions` | string | No | Seeds `INSTRUCTIONS.md` on first boot. Distinct from `system_prompt` — this sets the agent's operating instructions file |
 | `thinking` | string | No | Extended thinking/reasoning mode: `off` (default), `low`, `medium`, or `high`. Anthropic models use thinking budgets (5K/10K/25K tokens). OpenAI o-series models use `reasoning_effort`. Ignored for unsupported models |
 | `mcp_servers` | list | No | External MCP tool servers. See [MCP Integration](mcp.md) |
+| `initial_interface` | string | No | Seeds `INTERFACE.md` on first boot. Defines the agent's public collaboration contract — what inputs it accepts, what outputs it produces, and what topics it subscribes to. Readable by other agents via `get_agent_profile`. |
 
 ### Model Format
 
@@ -228,7 +231,7 @@ OPENLEGION_CRED_WHATSAPP_PHONE_NUMBER_ID=1234...
 
 All credentials are loaded by the credential vault (`src/host/credentials.py`). Agents never see values directly -- they make API calls through the mesh proxy, which injects credentials server-side.
 
-**Channel credential fallback:** Channel bot tokens (Telegram, Discord, Slack, WhatsApp) are resolved with a three-tier fallback chain: `OPENLEGION_SYSTEM_<NAME>` → `OPENLEGION_CRED_<NAME>` → legacy unprefixed `<NAME>` (e.g., `TELEGRAM_BOT_TOKEN`). The `OPENLEGION_CRED_` prefix is recommended for channel tokens.
+**Channel credential fallback:** Channel bot tokens (Telegram, Discord, Slack, WhatsApp) are resolved with a four-tier fallback chain: `mesh.yaml` channel config field (e.g. `channels.telegram.bot_token`) → `OPENLEGION_SYSTEM_<NAME>` → `OPENLEGION_CRED_<NAME>` → legacy unprefixed `<NAME>` (e.g., `TELEGRAM_BOT_TOKEN`). The `OPENLEGION_CRED_` prefix is recommended for channel tokens.
 
 **Important:** LLM provider keys **must** use the `OPENLEGION_SYSTEM_` prefix. The mesh proxy only looks for provider keys in the system tier. A provider key stored with `OPENLEGION_CRED_` will be treated as an agent-tier credential and will not be used for LLM calls.
 
@@ -274,8 +277,8 @@ Beyond credentials, these environment variables affect runtime behavior:
 | `PROJECT_NAME` | -- | Project this agent belongs to (set automatically for project members) |
 | `EMBEDDING_MODEL` | `text-embedding-3-small` | Embedding model for memory vector search (set automatically from `llm.embedding_model` in mesh.yaml). Set to `"none"` to disable vector search |
 | `OPENLEGION_MAX_AGENTS` | `0` | Plan limit: maximum agents to start. `0` means unlimited. If set to N > 0, only the first N agents are started. |
-| `OPENLEGION_MAX_PROJECTS` | `0` | Plan limit: maximum projects allowed. `0` means unlimited. |
-| `OPENLEGION_HOST_NETWORK` | `0` | Use Docker host networking for agent containers instead of bridge network. Set to `1` to enable. Not recommended — disables network isolation. |
+| `OPENLEGION_MAX_PROJECTS` | -- | Plan limit: maximum projects allowed. If unset, projects are unlimited. If set to `0`, projects are disabled entirely. If set to N > 0, only N projects are allowed. |
+| `OPENLEGION_HOST_NETWORK` | `0` | Use Docker host networking for agent containers instead of bridge network. Set to `1`, `true`, or `yes` (case-insensitive) to enable. Not recommended — disables network isolation. |
 | `OPENLEGION_SYSTEM_WALLET_MASTER_SEED` | -- | BIP-39 mnemonic (24 words) for HD wallet key derivation. Required to enable wallet features. Generate with `openlegion wallet init`. |
 | `BROWSER_OS` | `windows` | OS fingerprint for Camoufox browser: `windows`, `macos`, or `linux`. Windows is recommended (≈70% desktop market share; Linux is a datacenter signal). |
 | `BROWSER_LOCALE` | `en-US` | BCP-47 locale tag for browser fingerprint (e.g. `en-US`, `de-DE`). |
@@ -283,5 +286,11 @@ Beyond credentials, these environment variables affect runtime behavior:
 | `BROWSER_PROXY_URL` | -- | Proxy URL for browser traffic (HTTP/HTTPS only, e.g. `http://proxy:8080`). SOCKS5 is not supported. Residential proxies recommended. |
 | `BROWSER_PROXY_USER` | -- | Proxy authentication username. |
 | `BROWSER_PROXY_PASS` | -- | Proxy authentication password. |
+| `OPENLEGION_SYSTEM_PROXY` | -- | System-wide outbound HTTP proxy URL for all agent traffic. Managed via the dashboard proxy settings page. |
+| `HTTP_PROXY` / `HTTPS_PROXY` | -- | Per-agent proxy URLs. Auto-injected into agent containers by the runtime when a per-agent proxy is configured. Read by the agent-side `http_request` tool. |
+| `OPENLEGION_TOOL_TIMEOUT` | `300` | Per-tool execution timeout in seconds (hard ceiling). |
+| `OPENLEGION_MAX_ITERATIONS` | `20` | Maximum agent loop iterations per task (clamped 1–100). Overrides the default at the agent level. |
+| `OPENLEGION_CHAT_MAX_TOOL_ROUNDS` | `30` | Maximum tool rounds per chat turn (clamped 1–200). |
+| `OPENLEGION_CHAT_MAX_TOTAL_ROUNDS` | `200` | Maximum total chat rounds before session auto-continuation (clamped 1–1000). |
 
 The mesh port is configured in `config/mesh.yaml` (`mesh.port`), not via environment variable.

--- a/docs/dashboard.md
+++ b/docs/dashboard.md
@@ -6,7 +6,7 @@ Real-time web dashboard for fleet observability and management.
 
 The dashboard is served at `http://localhost:8420/dashboard` (or whatever port the mesh is configured on). It provides a live view of your agent fleet across three main tabs with a consolidated navigation bar, slide-over chat panels, and a keyboard command palette.
 
-No additional setup is required -- the dashboard starts automatically with `openlegion start`.
+No additional setup is required -- the dashboard starts automatically with `openlegion start`. In self-hosted and local dev mode, the dashboard is open to anyone who can reach port 8420. In hosted mode (subdomain deployments), SSO authentication is required; see [Authentication](#authentication) for details.
 
 ## Navigation
 
@@ -16,7 +16,7 @@ The dashboard uses a consolidated three-tab layout:
 |-----|--------------|
 | **Fleet** | Agent cards, agent detail views, configuration editing |
 | **Activity** | Traces, live events, blackboard, costs, and automation |
-| **System** | Credentials, pub/sub, model pricing |
+| **System** | Credentials, pub/sub, model pricing, network/proxy settings |
 
 A command palette (**Cmd+K** / **Ctrl+K**) provides quick access to agents, actions, and navigation. The search button in the nav bar also opens it.
 
@@ -51,7 +51,7 @@ When a project is selected, a PROJECT.md banner appears above the agent grid. Ed
 
 Overview of all registered agents showing health status, activity state (idle/thinking/tool), daily cost, token usage, and restart count. Click any agent card to drill down into its detail view with cost breakdowns, budget bars, workspace file editor, and recent events. Also includes agent configuration management -- view and edit each agent's model, role, system prompt, and daily budget. Changes that require a restart (model) are flagged.
 
-All agents show an embedded KasmVNC viewer in their detail view, providing a live view of the agent's browser session.
+When the shared browser service is running, an embedded KasmVNC viewer appears in each agent's detail view, providing a live view of the browser session. If the browser service has not started or is unavailable, the VNC viewer is not shown.
 
 ## Activity Tab
 
@@ -70,6 +70,8 @@ Sub-views toggled via a tab bar at the top of the panel:
 ## System Tab
 
 Environment overview showing configured credentials with tier labels (system or agent, names only, never values), pub/sub subscriptions, and model pricing tables. Add new credentials from a dropdown of LLM providers, known agent tools (Brave Search, Apollo, Hunter), or custom service names.
+
+The System tab also hosts a **Network** subsection for fleet-wide and per-agent proxy configuration (`GET/PUT /api/network/proxy`, `PUT /api/agents/{id}/proxy`). See [Proxy Configuration](#proxy-configuration) for details.
 
 ## Agent Management
 
@@ -99,7 +101,7 @@ The agent detail view features a tabbed **Agent Settings** panel for viewing and
 
 | Tab | Contents | Description |
 |-----|----------|-------------|
-| **Identity** | `SOUL.md` (4K cap), `INSTRUCTIONS.md` (8K cap) | Personality, tone, operating procedures, domain knowledge |
+| **Identity** | `SOUL.md` (4K cap), `INSTRUCTIONS.md` (12K cap) | Personality, tone, operating procedures, domain knowledge |
 | **Memory** | `MEMORY.md` (16K cap), `USER.md` (4K cap), `HEARTBEAT.md` (no cap) | Long-term facts, user preferences, autonomous heartbeat rules |
 | **Config** | Model, role, budget, credential access | Agent configuration (model changes trigger restart) |
 | **Logs** | Activity + Learnings (read-only) | Daily session logs and recorded errors/corrections |
@@ -200,13 +202,50 @@ Click **Del** on any entry row. History namespace entries are protected and cann
 
 The dashboard connects to the mesh via WebSocket at `/ws/events`. Events are streamed in real-time with optional agent and type filters. The connection indicator in the top-right shows live/disconnected status. On disconnect, the WebSocket client automatically reconnects with exponential backoff.
 
+## Authentication
+
+### Dev vs Hosted Mode
+
+The dashboard operates in two modes:
+
+- **Dev / self-hosted mode** — when `/opt/openlegion/.access_token` does not exist (the default for local installs), all requests are allowed. No cookie or SSO is required.
+- **Hosted mode** — when `/opt/openlegion/.subdomain` exists (subdomain deployments via the OpenLegion cloud), the `ol_session` cookie is required on every request. Access without a valid cookie is rejected with HTTP 401/403.
+
+### Session Cookie (`ol_session`)
+
+In hosted mode, the Caddy reverse proxy runs a `forward_auth` gate at `/__auth/callback`. The SSO flow is:
+
+1. The app generates an HMAC token: `HMAC-SHA256(access_token, "{subdomain}:{expiry}")` → `{expiry}.{signature}`
+2. The user is redirected to `https://{subdomain}.engine.openlegion.ai/__auth/callback?token=...`
+3. The auth gate verifies the HMAC, sets the `ol_session` cookie (one-time-use — replay attacks are blocked), and redirects to the dashboard
+4. Caddy `forward_auth` verifies the cookie on every subsequent request
+
+The cookie is valid for up to 24 hours (enforced by the engine, independent of the auth gate's issued expiry). The cookie key is derived from the access token on disk via HMAC-SHA256.
+
+### CSRF Protection
+
+All state-changing endpoints (POST, PUT, DELETE, PATCH) require the `X-Requested-With` header. Browsers block this custom header on cross-origin requests (CORS preflight), preventing CSRF attacks on cookie-authenticated sessions. GET, HEAD, and OPTIONS are exempt.
+
+```bash
+# Example: include X-Requested-With on state-changing dashboard API calls
+curl -X POST http://localhost:8420/dashboard/api/cron \
+  -H "X-Requested-With: XMLHttpRequest" \
+  -H "Content-Type: application/json" \
+  -d '{"agent_id": "researcher", "schedule": "every 1h", "message": "Check leads"}'
+```
+
+### VNC Proxy
+
+The VNC reverse proxy at `/vnc/` rejects agent Bearer tokens. Only `ol_session` cookie authentication (dashboard auth) is accepted for VNC access, preventing agents from directly reading the shared browser screen.
+
 ## API Endpoints
 
-All dashboard API endpoints are prefixed with `/dashboard/api/`.
+All dashboard API endpoints are prefixed with `/dashboard/api/`. The SPA root is served at `GET /dashboard/` (HTML, not an API endpoint). State-changing endpoints (POST/PUT/DELETE/PATCH) require the `X-Requested-With` header; see [Authentication](#authentication).
+
+**Agents**
 
 | Method | Path | Description |
 |--------|------|-------------|
-| `GET` | `/dashboard/` | Serve dashboard HTML |
 | `GET` | `/dashboard/api/agents` | Agent overview with health and costs |
 | `POST` | `/dashboard/api/agents` | Create a new agent |
 | `GET` | `/dashboard/api/agents/{id}` | Agent detail with spend and budget |
@@ -215,59 +254,192 @@ All dashboard API endpoints are prefixed with `/dashboard/api/`.
 | `PUT` | `/dashboard/api/agents/{id}/config` | Update agent configuration |
 | `GET` | `/dashboard/api/agents/{id}/status` | Agent status from container |
 | `GET` | `/dashboard/api/agents/{id}/capabilities` | Agent capabilities and tools |
-| `POST` | `/dashboard/api/agents/{id}/chat` | Non-streaming chat (request/response) |
-| `POST` | `/dashboard/api/agents/{id}/chat/stream` | SSE streaming chat (token-level) |
-| `POST` | `/dashboard/api/agents/{id}/steer` | Update agent system prompt live |
-| `POST` | `/dashboard/api/agents/{id}/reset` | Reset agent conversation history |
 | `POST` | `/dashboard/api/agents/{id}/restart` | Restart an agent |
 | `PUT` | `/dashboard/api/agents/{id}/budget` | Update agent budget |
 | `GET` | `/dashboard/api/agents/{id}/permissions` | Agent credential and API permissions |
 | `PUT` | `/dashboard/api/agents/{id}/permissions` | Update credential access patterns |
+| `GET` | `/dashboard/api/agents/{id}/activity` | Agent activity events |
+| `POST` | `/dashboard/api/restart-agents` | Restart all agent containers and the browser service |
+
+**Chat**
+
+| Method | Path | Description |
+|--------|------|-------------|
+| `POST` | `/dashboard/api/agents/{id}/chat` | Non-streaming chat (request/response) |
+| `POST` | `/dashboard/api/agents/{id}/chat/stream` | SSE streaming chat (token-level) |
+| `GET` | `/dashboard/api/agents/{id}/chat/history` | Retrieve conversation history for agent |
+| `POST` | `/dashboard/api/agents/{id}/steer` | Update agent system prompt live |
+| `POST` | `/dashboard/api/agents/{id}/reset` | Reset agent conversation history |
+| `POST` | `/dashboard/api/broadcast` | Send message to all agents |
+| `POST` | `/dashboard/api/broadcast/stream` | SSE streaming broadcast to all agents |
+
+**Workspace**
+
+| Method | Path | Description |
+|--------|------|-------------|
 | `GET` | `/dashboard/api/agents/{id}/workspace` | List agent workspace files (with cap, is_default) |
 | `GET` | `/dashboard/api/agents/{id}/workspace/{file}` | Read workspace file content |
 | `PUT` | `/dashboard/api/agents/{id}/workspace/{file}` | Write workspace file content |
 | `GET` | `/dashboard/api/agents/{id}/workspace-logs?days=N` | Read daily logs (read-only, default 3 days) |
 | `GET` | `/dashboard/api/agents/{id}/workspace-learnings` | Read errors and corrections (read-only) |
+
+**Artifacts & Uploads**
+
+| Method | Path | Description |
+|--------|------|-------------|
+| `GET` | `/dashboard/api/agents/{id}/artifacts` | List agent artifacts |
+| `GET` | `/dashboard/api/agents/{id}/artifacts/{name}` | Download an artifact |
+| `DELETE` | `/dashboard/api/agents/{id}/artifacts/{name}` | Delete an artifact |
+| `GET` | `/dashboard/api/agents/{id}/files` | List files in agent data volume |
+| `GET` | `/dashboard/api/agents/{id}/files/{path}` | Read a file from agent data volume |
+| `GET` | `/dashboard/api/uploads` | List uploads |
+| `POST` | `/dashboard/api/uploads/{name}` | Upload a file |
+| `GET` | `/dashboard/api/uploads/{name}/download` | Download an uploaded file |
+| `DELETE` | `/dashboard/api/uploads/{name}` | Delete an uploaded file |
+
+**Blackboard**
+
+| Method | Path | Description |
+|--------|------|-------------|
 | `GET` | `/dashboard/api/blackboard` | List blackboard entries |
 | `PUT` | `/dashboard/api/blackboard/{key}` | Write blackboard entry |
 | `DELETE` | `/dashboard/api/blackboard/{key}` | Delete blackboard entry |
+
+**Credentials**
+
+| Method | Path | Description |
+|--------|------|-------------|
 | `POST` | `/dashboard/api/credentials` | Add a credential to the vault |
 | `DELETE` | `/dashboard/api/credentials/{name}` | Remove a credential |
+| `POST` | `/dashboard/api/credentials/validate` | Validate a credential (check if set) |
+| `POST` | `/dashboard/api/credentials/agent` | Add an agent-tier credential |
+| `GET` | `/dashboard/api/credentials/{name}/value` | Retrieve masked credential value |
+| `POST` | `/dashboard/api/credentials/upload-env` | Bulk-import credentials from an .env file |
+
+**External API Keys**
+
+| Method | Path | Description |
+|--------|------|-------------|
+| `GET` | `/dashboard/api/external-api-keys` | List named external API keys |
+| `POST` | `/dashboard/api/external-api-keys` | Add an external API key |
+| `DELETE` | `/dashboard/api/external-api-keys/{key_id}` | Remove an external API key |
+
+**Costs & Budgets**
+
+| Method | Path | Description |
+|--------|------|-------------|
 | `GET` | `/dashboard/api/costs/{agent_id}` | Cost data for a specific agent |
 | `GET` | `/dashboard/api/costs` | Cost data with optional period |
+
+**Projects**
+
+| Method | Path | Description |
+|--------|------|-------------|
 | `GET` | `/dashboard/api/projects` | List all projects with members |
 | `POST` | `/dashboard/api/projects` | Create a new project |
 | `DELETE` | `/dashboard/api/projects/{name}` | Delete a project |
 | `POST` | `/dashboard/api/projects/{name}/members` | Add agent to project (auto-restarts agent) |
 | `DELETE` | `/dashboard/api/projects/{name}/members/{agent}` | Remove agent from project (auto-restarts agent) |
-| `GET` | `/dashboard/api/project?project={name}` | Read project's PROJECT.md (requires project param) |
-| `PUT` | `/dashboard/api/project?project={name}` | Update project's PROJECT.md (requires project param) |
-| `GET` | `/dashboard/api/traces` | Recent trace events |
-| `GET` | `/dashboard/api/traces/{id}` | Trace detail |
-| `GET` | `/dashboard/api/queues` | Queue status per agent |
+| `GET` | `/dashboard/api/project?project={name}` | Read project's PROJECT.md |
+| `PUT` | `/dashboard/api/project?project={name}` | Update project's PROJECT.md |
+
+**Automation (Cron)**
+
+| Method | Path | Description |
+|--------|------|-------------|
 | `GET` | `/dashboard/api/cron` | List cron jobs |
 | `POST` | `/dashboard/api/cron` | Create a cron job |
-| `POST` | `/dashboard/api/cron/{id}/run` | Trigger cron job |
-| `PUT` | `/dashboard/api/cron/{id}` | Update cron job schedule |
+| `POST` | `/dashboard/api/cron/{id}/run` | Trigger cron job immediately |
+| `PUT` | `/dashboard/api/cron/{id}` | Update cron job fields |
 | `POST` | `/dashboard/api/cron/{id}/pause` | Pause cron job |
 | `POST` | `/dashboard/api/cron/{id}/resume` | Resume cron job |
 | `DELETE` | `/dashboard/api/cron/{id}` | Delete cron job |
-| `GET` | `/dashboard/api/settings` | Environment settings |
-| `POST` | `/dashboard/api/credentials/validate` | Validate a credential (check if set) |
-| `GET` | `/dashboard/api/model-health` | Model health and failover status |
-| `POST` | `/dashboard/api/channels/{type}/connect` | Connect a messaging channel |
-| `POST` | `/dashboard/api/channels/{type}/disconnect` | Disconnect a messaging channel |
-| `POST` | `/dashboard/api/broadcast` | Send message to all agents |
-| `POST` | `/dashboard/api/broadcast/stream` | SSE streaming broadcast to all agents |
-| `GET` | `/dashboard/api/messages` | Recent message log |
+
+**Webhooks**
+
+| Method | Path | Description |
+|--------|------|-------------|
 | `GET` | `/dashboard/api/webhooks` | List configured webhooks |
 | `POST` | `/dashboard/api/webhooks` | Create a webhook endpoint |
-| `DELETE` | `/dashboard/api/webhooks/{name}` | Delete a webhook |
-| `POST` | `/dashboard/api/webhooks/{name}/test` | Send test payload to webhook |
-| `GET` | `/dashboard/api/logs` | Runtime logs (query: lines, level) |
+| `DELETE` | `/dashboard/api/webhooks/{hook_id}` | Delete a webhook |
+| `PATCH` | `/dashboard/api/webhooks/{hook_id}` | Update webhook configuration (name, agent, instructions, signature) |
+| `POST` | `/dashboard/api/webhooks/{hook_id}/test` | Send test payload to webhook |
+
+**Channels**
+
+| Method | Path | Description |
+|--------|------|-------------|
 | `GET` | `/dashboard/api/channels` | List connected messaging channels |
+| `POST` | `/dashboard/api/channels/{type}/connect` | Connect a messaging channel |
+| `POST` | `/dashboard/api/channels/{type}/disconnect` | Disconnect a messaging channel |
+| `GET` | `/dashboard/api/comms/activity` | Messaging channel activity log |
+| `GET` | `/dashboard/api/messages` | Recent message log |
+
+**Network / Proxy**
+
+| Method | Path | Description |
+|--------|------|-------------|
+| `GET` | `/dashboard/api/network/proxy` | Get fleet-wide proxy configuration |
+| `PUT` | `/dashboard/api/network/proxy` | Set fleet-wide proxy configuration |
+| `PUT` | `/dashboard/api/agents/{id}/proxy` | Set per-agent proxy override |
+
+**Wallet**
+
+| Method | Path | Description |
+|--------|------|-------------|
+| `POST` | `/dashboard/api/wallet/init` | Initialize wallet (generates seed; shown once) |
+| `GET` | `/dashboard/api/wallet/seed` | Retrieve wallet seed (HTTP 410 after first reveal) |
+| `GET` | `/dashboard/api/wallet/addresses` | List wallet addresses (Ethereum + Solana) |
+| `GET` | `/dashboard/api/wallet/rpc` | Get configured RPC endpoints |
+| `PUT` | `/dashboard/api/wallet/rpc` | Update RPC endpoints |
+| `POST` | `/dashboard/api/wallet/enable/{agent_id}` | Enable wallet access for an agent |
+
+**Storage**
+
+| Method | Path | Description |
+|--------|------|-------------|
+| `GET` | `/dashboard/api/storage` | Storage overview |
+| `GET` | `/dashboard/api/storage/databases` | List agent SQLite databases |
+| `POST` | `/dashboard/api/storage/databases/{db_id}/purge` | Purge a database |
+
+**Audit**
+
+| Method | Path | Description |
+|--------|------|-------------|
+| `GET` | `/dashboard/api/traces` | Recent trace events |
+| `GET` | `/dashboard/api/traces/{id}` | Trace detail |
+| `GET` | `/dashboard/api/audit` | Agent audit log |
+| `GET` | `/dashboard/api/operator-audit` | Operator-level audit log |
+| `GET` | `/dashboard/api/queues` | Queue status per agent |
+
+**System & Settings**
+
+| Method | Path | Description |
+|--------|------|-------------|
+| `GET` | `/dashboard/api/settings` | Environment settings (includes default_model) |
+| `GET` | `/dashboard/api/system-settings` | System-level settings |
+| `POST` | `/dashboard/api/system-settings` | Update system-level settings |
+| `GET` | `/dashboard/api/browser-settings` | Browser service settings |
+| `POST` | `/dashboard/api/browser-settings` | Update browser service settings |
+| `POST` | `/dashboard/api/default-model` | Set the default LLM model in mesh.yaml |
+| `GET` | `/dashboard/api/model-health` | Model health and failover status — per-model success/failure counts, cooldown status, and active model in the failover chain |
 | `GET` | `/dashboard/api/agent-templates` | Available agent fleet templates |
+| `GET` | `/dashboard/api/fleet/templates` | Fleet template list (alternate endpoint) |
+| `GET` | `/dashboard/api/logs` | Runtime logs (query: lines, level) |
+
+**Browser**
+
+| Method | Path | Description |
+|--------|------|-------------|
 | `POST` | `/dashboard/api/browser/{agent_id}/focus` | Focus browser window for agent |
+| `POST` | `/dashboard/api/browser/{agent_id}/reset` | Reset browser session for agent |
+| `POST` | `/dashboard/api/browser-login/complete` | Complete a browser login flow |
+| `POST` | `/dashboard/api/browser-login/cancel` | Cancel a browser login flow |
+
+**WebSocket**
+
+| Method | Path | Description |
+|--------|------|-------------|
 | `WS` | `/ws/events` | Real-time event stream |
 
 ## Accessibility

--- a/docs/development.md
+++ b/docs/development.md
@@ -94,6 +94,12 @@ pytest tests/ -x
 | `src/dashboard/events.py` | `tests/test_events.py` |
 | `src/agent/memory.py` (fallback) | `tests/test_embedding_fallback.py` |
 | Cross-component | `tests/test_integration.py` |
+| `src/agent/builtins/wallet_tool.py` | `tests/test_wallet.py`, `tests/test_wallet_tool.py` |
+| `src/host/wallet.py` | `tests/test_wallet_endpoints.py` |
+| `src/agent/builtins/image_gen_tool.py` | `tests/test_image_gen.py` |
+| `src/agent/builtins/coordination_tool.py` | `tests/test_coordination.py` |
+| `src/host/permissions.py` | `tests/test_permissions.py` |
+| `src/host/api_keys.py` | `tests/test_api_keys.py` |
 
 ### Testing Conventions
 
@@ -168,13 +174,23 @@ Cross-component messages use Pydantic models from `src/shared/types.py`. Interna
 ```python
 # In src/shared/types.py
 class TaskAssignment(BaseModel):
-    task_id: str
+    task_id: str                          # auto-generated if omitted
+    workflow_id: str                      # required
+    step_id: str                          # required
     task_type: str
-    input_data: dict
+    input_data: dict[str, Any]
+    context: dict[str, Any] = {}
     timeout: int = 120
+    max_retries: int = 0
+    token_budget: TokenBudget | None = None
 
 # Used at component boundaries — dispatching tasks to agents
-assignment = TaskAssignment(task_type="research", input_data={"company": "Acme Corp"})
+assignment = TaskAssignment(
+    workflow_id="wf_123",
+    step_id="step_1",
+    task_type="research",
+    input_data={"company": "Acme Corp"},
+)
 ```
 
 ### SQLite for All State
@@ -221,7 +237,7 @@ async def your_tool(param1: str, param2: int = 10, *, mesh_client=None) -> dict:
 2. Enforce permissions -- check `permissions.can_*()` before acting
 3. Use Pydantic models from `src/shared/types.py`
 4. Add a method to `src/agent/mesh_client.py` if agents need to call it
-5. Add tests in `tests/test_mesh.py`
+5. Add HTTP endpoint tests in `tests/test_dashboard.py` (which covers `create_mesh_app()` HTTP handlers). Reserve `tests/test_mesh.py` for blackboard/pubsub layer tests.
 
 ```python
 @app.post("/mesh/your_endpoint")
@@ -269,7 +285,12 @@ openlegion/
 │   │       ├── introspect_tool.py # Live runtime state queries
 │   │       ├── skill_tool.py    # Custom skill creation + reload
 │   │       ├── subagent_tool.py # In-process subagent spawning
-│   │       └── web_search_tool.py  # DuckDuckGo search
+│   │       ├── web_search_tool.py  # DuckDuckGo search
+│   │       ├── wallet_tool.py   # Blockchain wallet operations (address, balance, transfer)
+│   │       ├── image_gen_tool.py # Image generation via Gemini or DALL-E 3
+│   │       ├── coordination_tool.py # Structured multi-agent coordination (hand_off, check_inbox)
+│   │       ├── fleet_tool.py    # Fleet management (operator-agent only)
+│   │       └── operator_tools.py # Operator-privileged tools (operator-agent only)
 │   ├── host/                    # Runs on the host machine
 │   │   ├── server.py            # Mesh FastAPI app
 │   │   ├── mesh.py              # Blackboard, PubSub, routing
@@ -286,7 +307,9 @@ openlegion/
 │   │   ├── watchers.py          # File watchers
 │   │   ├── containers.py        # Backward-compat alias for DockerBackend
 │   │   ├── traces.py            # Request tracing and diagnostics
-│   │   └── transcript.py        # Provider-specific transcript sanitization
+│   │   ├── transcript.py        # Provider-specific transcript sanitization
+│   │   ├── wallet.py            # Ethereum + Solana wallet signing service
+│   │   └── api_keys.py          # Named API key management (salted SHA-256, config/api_keys.json)
 │   ├── channels/                # Messaging adapters
 │   │   ├── base.py              # Abstract channel
 │   │   ├── telegram.py          # Telegram bot
@@ -296,7 +319,8 @@ openlegion/
 │   ├── shared/                  # Shared between host and agent
 │   │   ├── types.py             # Pydantic contracts
 │   │   ├── utils.py             # Logging, ID generation
-│   │   └── trace.py             # Distributed trace context
+│   │   ├── trace.py             # Distributed trace context
+│   │   └── models.py            # Model cost/context window registry (LiteLLM-backed)
 │   ├── dashboard/               # Web dashboard
 │   │   ├── server.py            # FastAPI router + API endpoints
 │   │   ├── events.py            # EventBus for real-time streaming
@@ -311,13 +335,14 @@ openlegion/
 │       ├── runtime.py           # RuntimeContext lifecycle management
 │       ├── repl.py              # REPLSession interactive dispatch
 │       ├── channels.py          # ChannelManager messaging lifecycle
-│       └── formatting.py        # Tool display and styled output
+│       ├── formatting.py        # Tool display and styled output
+│       └── proxy.py             # Proxy env var builder (build_proxy_env_vars)
 ├── config/                      # Runtime configuration
 │   ├── agents.yaml
 │   ├── mesh.yaml
 │   ├── permissions.json
 │   └── cron.json
-├── tests/                       # Test suite (2240 tests)
+├── tests/                       # Test suite (~3100 tests)
 │   └── fixtures/                # Test fixtures (echo MCP server, etc.)
 ├── Dockerfile.agent             # Agent container image
 └── pyproject.toml               # Project metadata
@@ -338,6 +363,10 @@ openlegion/
 | `pyyaml` | Config parsing |
 | `python-dotenv` | `.env` file loading |
 | `sqlite-vec` | Vector search for memory |
+| `websockets` | Dashboard real-time streaming |
+| `pypdf` | PDF text extraction for attachments |
+| `anthropic` | Anthropic SDK (used by litellm) |
+| `python-multipart` | Multipart form data parsing |
 
 ### Agent-Side (installed in container via Dockerfile)
 
@@ -354,7 +383,7 @@ openlegion/
 
 | Group | Packages | Purpose |
 |-------|----------|---------|
-| `dev` | `pytest`, `pytest-asyncio`, `ruff` | Testing and linting |
+| `dev` | `pytest`, `pytest-asyncio`, `pytest-cov`, `pytest-xdist`, `ruff` | Testing, coverage, and linting |
 | `mcp` | `mcp>=1.0` | MCP tool support |
 | `channels` | `python-telegram-bot`, `discord.py`, `slack-bolt` | Messaging channels |
 

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -45,38 +45,43 @@ agents:
 
 ### Startup Sequence
 
-1. Host reads `mcp_servers` from agent config in `config/agents.yaml`
-2. Host serializes it as JSON into `MCP_SERVERS` environment variable
-3. Agent container starts, `__main__.py` reads `MCP_SERVERS`
-4. `MCPClient` is created and passed to `SkillRegistry`
-5. During lifespan startup, `MCPClient.start()` launches each server:
-   - Creates `StdioServerParameters` from config
+1. The runtime layer (`DockerBackend` in `src/host/runtime.py`) reads `mcp_servers` from agent config in `config/agents.yaml` and serializes it as JSON into the `MCP_SERVERS` environment variable passed to the agent container
+2. Agent container starts; `src/agent/__main__.py` reads `MCP_SERVERS`
+3. `MCPClient` is created and passed to `SkillRegistry`
+4. During lifespan startup, `MCPClient.start()` launches each server:
+   - Creates `StdioServerParameters` from config; any `env` dict in the server config is forwarded to the subprocess environment
    - Opens stdio transport via `AsyncExitStack`
    - Establishes `ClientSession` and calls `initialize()`
    - Calls `list_tools()` to discover available tools
-6. Tools are registered in `SkillRegistry` alongside built-in skills
-7. Agent registers with mesh, reporting MCP tools in its capabilities
+5. Tools are registered in `SkillRegistry` alongside built-in skills (name conflicts resolved by renaming at this point)
+6. Agent registers with mesh, reporting MCP tools in its capabilities
+
+If a server fails to start at step 4, its tools are not registered but the agent continues normally with built-in skills and any successfully started MCP servers.
 
 ### Tool Call Routing
 
-When the LLM calls an MCP tool:
+MCP tools are registered into `SkillRegistry` at startup alongside built-in skills. Name conflicts are resolved **at registration time** (not at call time) — if an MCP tool has the same name as a built-in or as another MCP tool, it is renamed to `mcp_{server_name}_{tool_name}` before insertion. This means by the time `execute()` runs, every tool has a unique name and there is no runtime priority check.
 
-1. `SkillRegistry.execute()` checks `MCPClient.has_tool(name)` first
-2. If it's an MCP tool, routes to `MCPClient.call_tool(name, arguments)`
-3. `MCPClient` looks up which server provides the tool
+When the LLM calls a tool:
+
+1. `SkillRegistry.execute()` looks up the name in the unified skill dict
+2. If the entry has `"function": "mcp"`, it routes to `MCPClient.call_tool(name, arguments)`
+3. `MCPClient` looks up which server provides the tool via its internal `_tool_to_server` map
 4. Sends the call via the MCP session to the correct subprocess
-5. Converts the MCP `CallToolResult` to a dict for the LLM
+5. Converts the MCP `CallToolResult` to a dict: text content blocks are concatenated under a `"result"` key; image and binary content blocks are silently dropped
+
+Each `call_tool()` call has a **60-second timeout**. If the server does not respond in time, the call returns an error dict.
+
+If an agent has `ALLOWED_TOOLS` configured (operator mode), MCP tool names must appear in that allowlist to be accessible — the restriction applies equally to built-ins and MCP tools.
 
 ### Name Conflict Resolution
 
-If an MCP tool has the same name as a built-in skill:
-- The MCP tool is renamed to `mcp_{server_name}_{tool_name}`
-- A warning is logged
-- The built-in skill keeps priority
+Conflicts are resolved at registration time, before execution:
 
-If two MCP servers provide tools with the same name:
-- The first server's tool keeps the original name
-- The second server's tool is prefixed with `mcp_{server_name}_{tool_name}`
+- If an MCP tool has the same name as a built-in skill, the MCP tool is renamed to `mcp_{server_name}_{tool_name}` and a warning is logged. The built-in always keeps its original name.
+- If two MCP servers provide tools with the same name, the first server's tool keeps the original name and the second server's tool is prefixed with `mcp_{server_name}_{tool_name}`.
+
+After registration every tool has a unique name, so there is no runtime priority resolution.
 
 ### Graceful Failure
 
@@ -113,7 +118,7 @@ On agent shutdown, `MCPClient.stop()` closes the `AsyncExitStack`, which termina
 **`SkillRegistry`** (`src/agent/skills.py`):
 - Accepts optional `mcp_client` parameter
 - `_register_mcp_tools()` -- Register MCP tools in the skill dict
-- `execute()` -- Routes MCP tools through MCPClient before checking builtins
+- `execute()` -- Dispatches tool calls by name from the unified skill dict; MCP tools are identified by the `"function": "mcp"` marker set at registration time
 - `get_tool_definitions()` -- MCP tools included with full JSON Schema
 
 ## Popular MCP Servers
@@ -122,18 +127,18 @@ Some well-known MCP servers that work with OpenLegion:
 
 | Server | Package | Tools |
 |--------|---------|-------|
-| Filesystem | `@anthropic/mcp-server-filesystem` | Read/write/search files |
-| SQLite | `@anthropic/mcp-server-sqlite` | Query SQLite databases |
-| PostgreSQL | `@anthropic/mcp-server-postgres` | Query PostgreSQL databases |
-| Brave Search | `@anthropic/mcp-server-brave-search` | Web search via Brave API |
-| GitHub | `@anthropic/mcp-server-github` | GitHub API operations |
+| Filesystem | `@modelcontextprotocol/server-filesystem` | Read/write/search files |
+| SQLite | `@modelcontextprotocol/server-sqlite` | Query SQLite databases |
+| PostgreSQL | `@modelcontextprotocol/server-postgres` | Query PostgreSQL databases |
+| Brave Search | `@modelcontextprotocol/server-brave-search` | Web search via Brave API |
+| GitHub | `@modelcontextprotocol/server-github` | GitHub API operations |
 | Playwright | `@playwright/mcp` | Browser automation (70+ tools) |
 
-**Note:** npm-based MCP servers require Node.js in the agent container. Python-based MCP servers work with the default container image.
+**Note:** npm-based MCP servers require Node.js in the agent container. Python-based MCP servers work with the default container image — the `mcp` Python SDK is pre-installed in `Dockerfile.agent`. If you use a custom agent image, ensure the `mcp` package is included; without it the `MCPClient` import fails silently (the error is logged and MCP is disabled for that agent).
 
 ## Writing a Custom MCP Server
 
-A minimal Python MCP server using the `mcp` SDK:
+A minimal Python MCP server using the `mcp` SDK (requires `mcp >= 1.0` for the `FastMCP` high-level API):
 
 ```python
 from mcp.server import FastMCP
@@ -170,8 +175,8 @@ openlegion status  # or docker logs openlegion_<agent_id>
 
 Common causes:
 - Command not found in container (missing dependency)
-- Port conflict (shouldn't happen with stdio transport)
 - Permission error (file not executable)
+- Missing environment variable the server requires (add it via the `env` config field)
 
 ### Tools not discovered
 

--- a/docs/memory.md
+++ b/docs/memory.md
@@ -44,11 +44,10 @@ Manages the LLM's context window to prevent overflow while preserving important 
 
 - **Model-aware token estimation**: tiktoken for OpenAI models (accurate), 3.5 chars/token for Anthropic, 4 chars/token fallback for unknown providers
 - **Model-aware context windows**: auto-detects max context from model name (12 models supported), with explicit `max_tokens` override
-- Four compaction thresholds:
+- Three compaction thresholds:
   - **60%** -- proactive flush (extract facts to MEMORY.md)
-  - **70%** -- auto-compact (summarize + trim to last 4 messages)
+  - **70%** -- auto-compact (summarize + trim to last 3–4 messages, preserving tool-call group boundaries). Hard-prune is used as a fallback within this path if the LLM is unavailable or summarization fails — it is not a separately triggered threshold.
   - **80%** -- warning injected into system prompt telling agents to wrap up or save important facts
-  - **90%** -- emergency hard-prune (keep first message group + last 4 message groups, where groups respect tool-call boundaries)
 
 ### Write-Then-Compact Pattern
 
@@ -57,7 +56,7 @@ Before discarding any conversation context:
 1. **Extract** -- Asks the LLM to identify important facts from the conversation
 2. **Store** -- Saves facts to both `MEMORY.md` and the structured memory DB
 3. **Summarize** -- Creates a concise summary of the conversation so far
-4. **Replace** -- Swaps full history with: summary + last 4 messages
+4. **Replace** -- Swaps full history with: summary + last 3 or 4 messages (4 normally; 3 + a bridge assistant message when the role invariant would be violated by consecutive user messages)
 
 Nothing is permanently lost during compaction.
 
@@ -78,15 +77,16 @@ Persistent markdown files stored on the agent's `/data/workspace` volume.
 
 | File | Purpose | Cap | When Loaded |
 |------|---------|-----|-------------|
-| `INSTRUCTIONS.md` | Operating procedures, workflow rules, domain knowledge | 8K chars | System prompt |
+| `INSTRUCTIONS.md` | Operating procedures, workflow rules, domain knowledge | 12K chars | System prompt |
 | `SOUL.md` | Agent personality and behavioral guidelines | 4K chars | System prompt |
 | `USER.md` | User preferences and working style | 4K chars | System prompt |
 | `MEMORY.md` | Curated long-term facts | 16K chars | System prompt |
 | `PROJECT.md` | Project-wide context (optional, mounted read-only from host) | -- | System prompt |
 | `SYSTEM.md` | System architecture guide + runtime snapshot (auto-generated, read-only) | 6K chars | System prompt |
 | `HEARTBEAT.md` | Autonomous monitoring rules | -- | Heartbeat dispatch (auto-loaded) |
+| `INTERFACE.md` | Public collaboration contract (inputs, outputs, subscriptions) | 4K chars | Not auto-loaded into system prompt — read by other agents via `get_agent_profile` |
 
-Total bootstrap injection into the system prompt is capped at 40K characters across all files.
+Total bootstrap injection into the system prompt is capped at 48K characters across all files.
 
 ### System File (`SYSTEM.md`)
 
@@ -122,10 +122,16 @@ Daily logs are auto-loaded into heartbeat messages (last 2 days, capped at 4000 
 
 The workspace supports keyword search across all markdown files using a built-in BM25 implementation:
 - Tokenization with stop-word removal
-- TF-IDF scoring
+- BM25 scoring (k1=1.5, b=0.75)
 - Returns ranked snippets with file paths
+- Files already injected into the system prompt (e.g. MEMORY.md, SOUL.md) are excluded from search results to avoid duplicate context
 
 ## Structured Memory (`src/agent/memory.py`)
+
+The per-agent SQLite database (`data/{agent_id}.db`) stores three types of data:
+- **Facts** with embeddings for semantic search (described below)
+- **Task checkpoints** — iteration state, message history, token usage, and budget state, used to resume interrupted tasks after a container restart
+- **Chat checkpoints** — conversation state for crash recovery across chat sessions
 
 SQLite database with three search capabilities:
 
@@ -137,8 +143,8 @@ SQLite database with three search capabilities:
 
 ### Full-Text Search (FTS5)
 
-- SQLite FTS5 index for keyword matching
-- Trigram tokenizer for partial matching
+- SQLite FTS5 index with the default `unicode61` tokenizer for keyword matching
+- Queries are sanitized to alphanumeric terms (special characters stripped, words 2+ chars, limit 20 terms)
 - Combined with vector search for hybrid retrieval
 
 ### Hierarchical Retrieval

--- a/docs/security.md
+++ b/docs/security.md
@@ -27,7 +27,7 @@ Agents run as non-root (UID 1000) with:
 - Read-only root filesystem (`read_only: True`)
 - Tmpfs at `/tmp` (100MB, noexec, nosuid)
 - No host filesystem access (only `/data` volume)
-- Internal bridge network (no external egress) — agents can only reach the mesh host
+- Regular Docker bridge network — agents have internet egress. External-network access is restricted at the application layer via SSRF protection in `src/agent/builtins/http_tool.py` (blocks private/CGNAT/IPv4-mapped/6to4/Teredo ranges, DNS pinning, max 5 redirects with revalidation at each hop, strips `Authorization` on cross-origin redirects).
 
 ```bash
 openlegion start  # Default container isolation
@@ -70,9 +70,9 @@ System credentials are identified by matching known provider names (`anthropic`,
 
 Per-agent access is controlled by `allowed_credentials` glob patterns in `config/permissions.json`:
 
-- `["*"]` -- access all agent-tier credentials (default for new agents)
+- `["*"]` -- grants access to all agent-tier credentials
 - `["brave_search_*", "myapp_*"]` -- access only matching names
-- `[]` -- no vault access
+- `[]` -- no vault access (Pydantic default — deny all unless explicitly configured)
 
 Even with `allowed_credentials: ["*"]`, system credentials are **always** blocked. Agents also cannot store or overwrite system credential names via `vault_store`.
 
@@ -130,14 +130,25 @@ Agent HTTP requests (`src/agent/builtins/http_tool.py`) are blocked from reachin
 - IPv4-mapped IPv6 addresses (e.g., `::ffff:127.0.0.1`) are also blocked
 - CGNAT range (100.64.0.0/10, RFC 6598) is also blocked
 - Prevents agents from using the HTTP tool to scan internal networks or access host services
-- SOCKS5 proxy URLs are rejected server-side with HTTP 400 — only HTTP/HTTPS proxies are supported
+
+**Proxy Configuration note:** SOCKS5 proxies are rejected when configuring system or per-agent proxies via the dashboard (HTTP 400 — only HTTP/HTTPS proxies are supported for proxy settings). The agent `http_request` tool itself uses whatever proxy is injected at container startup.
 
 ### Path Traversal Prevention
 
-Agent file tools (`src/agent/builtins/file_tool.py`) validate all paths are within `/data`:
-- Resolves symlinks before checking
-- Rejects `../` traversal attempts
-- All file operations are scoped to the container's `/data` volume
+Agent file tools (`src/agent/builtins/file_tool.py`) validate all paths through four stages:
+1. **Stage 0 — Absolute path rejection**: strips the `/data/` prefix from the candidate path; any remaining absolute path is rejected outright.
+2. **Stage 1 — Pre-resolution `..` check**: walks every path component and rejects any `..` segment *before* filesystem resolution — catches traversal attempts that rely on resolution order.
+3. **Stage 2 — Symlink-safe walk**: resolves each path component individually using `lstat()` to detect symlinks at every step, preventing symlink chains that point outside `/data`.
+4. **Stage 3 — Final `is_relative_to()` check**: confirms the fully resolved path is still under `/data`.
+All file operations are scoped to the container's `/data` volume.
+
+### Skill Self-Authoring
+
+Agents can write and register new tools (`skill_tool`). All submitted code is validated through AST analysis before execution:
+- Forbidden imports (23 modules including `os`, `subprocess`, `socket`, `importlib`, etc.)
+- Forbidden calls (16 functions including `eval`, `exec`, `open`, `compile`, etc.)
+- Forbidden attribute accesses (11 attributes including `__dict__`, `__subclasses__`, `__globals__`, etc.)
+- Skills are capped at 10,000 characters.
 
 ### Bounded Execution
 
@@ -152,14 +163,24 @@ Per-agent rate limits on mesh endpoints prevent abuse and resource exhaustion:
 
 | Endpoint | Limit | Window |
 |----------|-------|--------|
+| `api_proxy` | 30 requests | 60 seconds |
 | `vault_resolve` | 5 requests | 60 seconds |
+| `vault_store` | 10 requests | 3600 seconds |
 | `blackboard_read` | 200 requests | 60 seconds |
 | `blackboard_write` | 100 requests | 60 seconds |
 | `publish` | 200 requests | 60 seconds |
+| `notify` | 10 requests | 60 seconds |
 | `cron_create` | 10 requests | 3600 seconds |
+| `spawn` | 5 requests | 3600 seconds |
 | `wallet_read` | 120 requests | 60 seconds |
 | `wallet_transfer` | 10 requests | 3600 seconds |
 | `wallet_execute` | 10 requests | 3600 seconds |
+| `image_gen` | 10 requests | 60 seconds |
+| `agent_profile` | 30 requests | 60 seconds |
+| `ext_credentials` | 30 requests | 60 seconds |
+| `ext_status` | 60 requests | 60 seconds |
+
+All other endpoints default to 100 requests per 60 seconds.
 
 Exceeding a rate limit returns HTTP 429. Rate-limit buckets are automatically cleaned up when agents are deregistered.
 
@@ -167,7 +188,7 @@ Exceeding a rate limit returns HTTP 429. Rate-limit buckets are automatically cl
 
 Agents process untrusted text from user messages, web pages, HTTP responses, tool outputs, blackboard data, and MCP servers. Attackers can embed invisible instructions using tag characters (U+E0001-E007F), RTL overrides (U+202A-202E), zero-width spaces, variation selectors, and other invisible codepoints that LLM tokenizers decode while being invisible to humans.
 
-`sanitize_for_prompt()` in `src/shared/utils.py` strips these at multiple choke points (the primary three plus additional call sites in `workspace.py`, `mesh_tool.py`, and `dashboard/server.py`):
+`sanitize_for_prompt()` in `src/shared/utils.py` is called at 88+ sites across 16 source files. Key choke points:
 
 | Choke Point | File | What It Covers |
 |-------------|------|----------------|
@@ -188,6 +209,13 @@ Normal text in all scripts (Arabic, Hebrew, CJK, Devanagari, etc.), emoji with Z
 ### Adding New Paths to LLM Context
 
 If you add a new path where untrusted text reaches LLM context (new tool, new system prompt section, new message source), wrap it with `sanitize_for_prompt()`. See `tests/test_sanitize.py` for the full test suite.
+
+## Webhooks
+
+Named webhook endpoints support inbound HTTP payloads from external services. Security controls:
+
+- **Body size limit** — 1 MB (1,048,576 bytes). Enforced in two stages: a Content-Length pre-check rejects oversized requests immediately, followed by an authoritative check on the fully read body.
+- **Optional HMAC-SHA256 signature verification** — If a webhook is configured with a secret, every request must include an `X-Webhook-Signature` header. The signature is verified with `hmac.compare_digest` (constant-time comparison) against `HMAC-SHA256(secret, body)`. Requests with invalid or missing signatures are rejected with HTTP 401.
 
 ## System Introspection
 

--- a/docs/triggering.md
+++ b/docs/triggering.md
@@ -87,13 +87,15 @@ curl -X PUT -H "Authorization: Bearer $MESH_AUTH_TOKEN" \
   -d '{"schedule": "every 1h", "message": "Updated message"}'
 ```
 
+The updatable fields (`_UPDATABLE_FIELDS`) are: `schedule`, `message`, `enabled`, `suppress_empty`, `tool_name`, and `tool_params`. All other fields (e.g., `agent`, `heartbeat`) are immutable after creation. To enable or disable a job without deleting it, set `enabled: true` or `enabled: false`.
+
 **Via agent tools:**
 - `list_cron()` -- list all jobs for the agent
 - `remove_cron(job_id)` -- remove a job
 
 ### Empty Response Suppression
 
-By default, cron jobs suppress empty or trivial agent responses (e.g., "ok", "nothing to do"). This prevents notification spam when an agent has nothing to report. Disable with `suppress_empty: false`.
+By default, cron jobs suppress empty or trivial agent responses. The complete set of suppressed response strings is: `""` (empty), `"ok"`, `"heartbeat_ok"`, `"nothing to do"`, `"no updates"`. This prevents notification spam when an agent has nothing to report. Disable with `suppress_empty: false`.
 
 ## Heartbeats
 
@@ -130,7 +132,7 @@ Agent: I'll monitor the system every 30 minutes.
 → set_cron(schedule="every 30m", heartbeat=true)
 ```
 
-The probes (disk_usage, pending_signals, pending_tasks) run automatically -- you don't need to specify them. Define your escalation rules in `HEARTBEAT.md` instead.
+The three probes (`disk_usage`, `pending_signals`, `pending_tasks`) run automatically -- you don't need to specify them, and you cannot add custom probes. Define your escalation rules in `HEARTBEAT.md` instead.
 
 **Via mesh API** (add `heartbeat: true`):
 
@@ -181,7 +183,7 @@ When a heartbeat fires, the agent receives a single message with all the context
 | Section | Content | Source |
 |---------|---------|--------|
 | **Your Heartbeat Rules** | Custom HEARTBEAT.md content | Agent's `/heartbeat-context` endpoint |
-| **Your Recent Activity** | Last 2 days of daily logs (capped at 4000 chars) | Agent's `/heartbeat-context` endpoint |
+| **Your Recent Activity** | Last 2 days of daily logs (capped at 4000 chars) | Agent's `/heartbeat-context` endpoint (transport cap 8000 chars); 4000-char display cap applied by cron scheduler |
 | **Probe Alerts** | Triggered probe results with details | Deterministic probes |
 | **Pending Signals** | Actual blackboard signal content (up to 5 items) | Blackboard `signals/{agent}` |
 | **Pending Tasks** | Actual blackboard task content (up to 5 items) | Blackboard `tasks/{agent}` |
@@ -192,11 +194,36 @@ This replaces the previous pattern where agents had to waste tool calls reading 
 
 Heartbeats skip the LLM dispatch entirely (zero cost) when all three conditions are met:
 
-1. **HEARTBEAT.md is default** — empty or starts with the scaffold prefix
+1. **HEARTBEAT.md is default** — the file is empty (after stripping whitespace) or its content is **exactly** `# Heartbeat Rules` (exact equality, not prefix matching). A file containing `# Heartbeat Rules` followed by any additional content is considered customized and will be sent to the LLM.
 2. **No recent activity** — daily logs are empty
 3. **No probes triggered** — disk usage normal, no pending signals or tasks
 
 This makes always-on heartbeats economically viable even at high frequencies.
+
+## Tool-Mode Cron
+
+In addition to dispatching a message to an agent (message mode) or running a heartbeat (heartbeat mode), cron jobs can invoke a tool directly — **without any LLM call**. This is useful for fully deterministic periodic operations where no reasoning is needed.
+
+Set `tool_name` (and optionally `tool_params` as a JSON-encoded dict) when creating a job:
+
+**Via mesh API:**
+
+```bash
+curl -X POST http://localhost:8420/mesh/cron \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer $MESH_AUTH_TOKEN" \
+  -d '{
+    "agent_id": "researcher",
+    "schedule": "every 1h",
+    "message": "",
+    "tool_name": "web_search",
+    "tool_params": "{\"query\": \"openlegion news\"}"
+  }'
+```
+
+When `tool_name` is set, the cron scheduler calls the tool directly via the agent's invoke endpoint, bypassing the LLM entirely. The tool result is recorded in traces and, if non-empty and `suppress_empty` is not false, logged. The `message` field is ignored when `tool_name` is present.
+
+Both `tool_name` and `tool_params` are in the `_UPDATABLE_FIELDS` set and can be changed via `PUT /mesh/cron/<job_id>`.
 
 ## Webhooks
 
@@ -209,6 +236,29 @@ curl -X POST http://localhost:8420/webhook/hook/<hook_id> \
 ```
 
 The webhook payload is included in the message dispatched to the configured agent.
+
+### Webhook Signature Verification
+
+Webhooks can optionally require HMAC-SHA256 signature verification. When a webhook is created with `require_signature: true`, the server generates a random 32-byte hex secret and returns it once. Callers must include the signature in the `X-Webhook-Signature` header (not to be confused with WhatsApp's `X-Hub-Signature-256`):
+
+```bash
+# Create a webhook with signature verification
+curl -X POST http://localhost:8420/mesh/webhooks \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer $MESH_AUTH_TOKEN" \
+  -d '{"agent": "researcher", "name": "my-hook", "require_signature": true}'
+# Response includes "secret": "<hex>" -- save this, it is shown once
+
+# Send a signed payload
+BODY='{"company": "Acme"}'
+SIG=$(echo -n "$BODY" | openssl dgst -sha256 -hmac "$SECRET" | awk '{print $2}')
+curl -X POST http://localhost:8420/webhook/hook/<hook_id> \
+  -H "Content-Type: application/json" \
+  -H "X-Webhook-Signature: $SIG" \
+  -d "$BODY"
+```
+
+Unsigned requests to a signature-required webhook are rejected with HTTP 401.
 
 ## Pub/Sub Events
 
@@ -261,7 +311,7 @@ Poll directories for new or modified files matching glob patterns. Uses polling 
 
 ### Configuration
 
-File watchers are configured programmatically via the `FileWatcher.watch()` method. Each watcher specifies:
+File watchers are configured programmatically via the `FileWatcher.watch()` method. There is no dashboard UI, CLI command, or YAML config for file watchers -- they must be registered in code (e.g., from a custom channel integration or startup hook). Each watcher specifies:
 
 | Field | Type | Description |
 |-------|------|-------------|

--- a/skills/README.md
+++ b/skills/README.md
@@ -52,7 +52,7 @@ Every agent automatically has access to built-in tools defined in
 - `memory_search`, `memory_save` — Persistent memory
 - `web_search` — Web search via DuckDuckGo
 - `list_agents`, `spawn_fleet_agent`, `notify_user`, `publish_event`, `subscribe_event` — Fleet coordination
-- `read_shared_state`, `write_shared_state`, `list_shared_state`, `watch_blackboard`, `claim_task`, `save_artifact` — Shared blackboard
+- `read_blackboard`, `write_blackboard`, `list_blackboard`, `watch_blackboard`, `claim_task`, `save_artifact` — Shared blackboard
 - `update_workspace` — Persist learnings to workspace files
 - `spawn_subagent`, `list_subagents`, `wait_for_subagent` — In-process subagents
 - `set_cron`, `list_cron`, `remove_cron` — Scheduled jobs


### PR DESCRIPTION
## Summary

Three-phase audit of `README.md`, `QUICKSTART.md`, `CLAUDE.md`, and `docs/*.md` against the current codebase. Phase 1 extracted factual inventories straight from source; Phase 2 cross-referenced every doc claim; Phase 3 applied fixes. Corrected **22 lies**, **25 stale items**, **7 broken examples**, added **~53** undocumented features, and tightened **~31** vague descriptions. Every change was traced to file:line in source and spot-verified by a final pass.

## Highest-impact corrections

- **Trust zones no longer claim agents have "no external network".** Agents run on a standard Docker bridge with NAT egress; isolation is application-layer SSRF in `http_tool.py`, not network-layer (`README.md`, `docs/architecture.md`, `docs/security.md`).
- **Blackboard tool names.** The nonexistent `read_shared_state` / `write_shared_state` / `list_shared_state` names had propagated into the README and `docs/agent-tools.md`. Real names are `read_blackboard` / `write_blackboard` / `list_blackboard` (`src/agent/builtins/mesh_tool.py:123,155,197`).
- **MCP Popular Servers table** now uses the real npm scope `@modelcontextprotocol/server-*` (was `@anthropic/mcp-server-*`, which doesn't exist — users installing would get package-not-found).
- **`TaskAssignment` Pydantic example** in `docs/development.md` now instantiates cleanly (required `workflow_id` and `step_id` added).
- **`allowed_credentials` default is `[]`** (deny all), not `["*"]`.
- **`set_cron` parameter table** now includes `tool_name` and `tool_params`, exposing the tool-mode cron path (no LLM call).
- **Fleet template table in README** matches `src/templates/*.yaml`: five wrong agent rosters corrected, `opportunity-finder` and `research` added (13 templates, not 11).
- **Memory caps aligned with `workspace.py` / `server.py:_FILE_CAPS`:** INSTRUCTIONS.md 12K (not 8K), bootstrap total 48K (not 40K), FTS5 uses `unicode61` (not trigram), 90% hard-prune "threshold" removed (it's a fallback, not a separate trigger).
- **QUICKSTART** no longer says the browser is Chromium — it's Camoufox, and the build is two images (~1 min agent + ~3 min browser), not one.
- **Heartbeat skip** is documented as exact equality `rules.strip() == "# Heartbeat Rules"` (was "starts with scaffold prefix", which is wrong).
- **`OPENLEGION_MAX_PROJECTS=0`** now correctly says disabled, not unlimited.

## New or expanded documentation

- **`docs/dashboard.md`** — new Authentication section covering `ol_session`, `X-Requested-With` CSRF requirement, VNC agent-bearer rejection, SSO flow (`/__auth/callback`, HMAC token, one-time-use replay protection), dev vs hosted mode. API endpoint table expanded from ~60 to ~106 routes grouped by resource.
- **`docs/channels.md`** — `WHATSAPP_APP_SECRET` documented as a production requirement for X-Hub-Signature-256 webhook verification (previously absent, silently disabled verification). Three-tier credential lookup chain explained for all channels.
- **`docs/agent-tools.md`** — new **Multi-Agent Coordination** section (`hand_off` / `check_inbox` / `update_status` / `complete_task`), new **Image Generation** section (`generate_image`), new **Operator-Only Tools** section (`fleet_tool`, `operator_tools`); browser tools now show `snapshot_after` / `fast` params; `request_browser_login`, `get_agent_profile`, `request_credential` added.
- **`docs/triggering.md`** — tool-mode cron documented, `_UPDATABLE_FIELDS` list, webhook HMAC signature verification, full suppressed-response set.
- **`docs/configuration.md`** — added `OPENLEGION_SYSTEM_PROXY`, `HTTP_PROXY`/`HTTPS_PROXY`, `OPENLEGION_TOOL_TIMEOUT`, execution-limit env vars, `INTERFACE.md` workspace file, `config/settings.json`, `config/network.yaml`.
- **`docs/security.md`** — rate-limit table completed (8 → 16 entries), 10K skill size cap, webhook HMAC verification, four-stage path traversal protection documented.
- **`docs/development.md`** — 7 missing test files added to the test map (`test_wallet`, `test_wallet_tool`, `test_wallet_endpoints`, `test_image_gen`, `test_coordination`, `test_permissions`, `test_api_keys`); project tree gained `host/wallet.py`, `host/api_keys.py`, `shared/models.py`, `cli/proxy.py` and missing builtins; dev dependency table now lists `pytest-cov`, `pytest-xdist`, `websockets`, `pypdf`, `anthropic`, `python-multipart`; test count corrected (2240 → ~3100); "add tests in `test_mesh.py`" corrected to `test_dashboard.py` for HTTP-endpoint tests.

## CLAUDE.md

Refreshed alongside the user-facing docs: tool count 14→16, rate limits 13→16, templates 11→13, mesh endpoints ~43→~60, sanitize call sites 60→88, `_FILE_CAPS` described with all 7 entries. Cross-repo integration note for provisioner `update.sh` tightened to match the inline `run_update()` path in `ssh.py`.

## `skills/README.md`

Collateral fix for the same blackboard-name lie surfaced during verification grep.

## Verification

Two final-pass subagents ran against the post-fix tree:
1. **Spot-check of all 14 highest-impact fixes** against current doc text + source code — PASS on every check, zero regressions.
2. **Cross-repo sanity check** against `app/` and `provisioner/` for SSO and deployment claims — all PASS except one minor `update.sh` mechanism note already tightened in CLAUDE.md.

## Test plan

- [ ] CI lint + tests pass (docs-only change, no code paths touched).
- [ ] Skim `README.md` §Trust Zones, §Built-in Tools, §Fleet Templates for style consistency.
- [ ] Verify `docs/dashboard.md` Authentication section reflects your production deployment expectations.
- [ ] Confirm the `@modelcontextprotocol/server-*` package names in `docs/mcp.md` match the servers you actually intend to point users at.