### PR TITLE
Fix WhatsApp channel issues from #714

### DIFF
--- a/src/agent/builtins/coordination_tool.py
+++ b/src/agent/builtins/coordination_tool.py
@@ -110,6 +110,11 @@ async def hand_off(
     summary = sanitize_for_prompt(summary)
     output_key = None
 
+    # Propagate origin so the target agent's lane can auto-notify the
+    # originating channel user when the handed-off task completes.
+    from src.shared.trace import current_origin as _current_origin
+    origin = _current_origin.get()
+
     # Write output data if provided
     if data and data.strip():
         try:
@@ -134,6 +139,8 @@ async def hand_off(
     }
     if output_key:
         task_record["output_key"] = output_key
+    if origin:
+        task_record["origin"] = origin
 
     task_key = f"tasks/{to}/{handoff_id}"
     try:
@@ -148,10 +155,12 @@ async def hand_off(
         return {"error": f"Failed to create task: {e}"}
 
     # Wake the target agent so it processes the task immediately
-    # instead of waiting for its next heartbeat.
+    # instead of waiting for its next heartbeat.  Pass origin so
+    # the mesh lane worker can auto-notify the originating user.
     try:
         await mesh_client.wake_agent(
             to, f"New task from {from_agent}: {summary[:200]}",
+            origin=origin,
         )
     except Exception as e:
         logger.debug("Wake for %s failed (task still queued): %s", to, e)

--- a/src/agent/loop.py
+++ b/src/agent/loop.py
@@ -1645,7 +1645,10 @@ class AgentLoop:
         except Exception as e:
             logger.warning("Failed to save chat checkpoint: %s", e)
 
-    async def chat(self, user_message: str, *, trace_id: str | None = None) -> dict:
+    async def chat(
+        self, user_message: str, *, trace_id: str | None = None,
+        origin: dict[str, str] | None = None,
+    ) -> dict:
         """Handle a single chat turn with persistent conversation history.
 
         On first message of a session, loads workspace context (INSTRUCTIONS.md,
@@ -1672,14 +1675,18 @@ class AgentLoop:
                 "tokens_used": 0,
             }
 
-        from src.shared.trace import current_trace_id
+        from src.shared.trace import current_origin, current_trace_id
         current_trace_id.set(trace_id)
-        async with self._chat_lock:
-            await self._maybe_restore_session()
-            try:
-                return await self._chat_inner(user_message)
-            finally:
-                await self._checkpoint_chat_session()
+        origin_token = current_origin.set(origin)
+        try:
+            async with self._chat_lock:
+                await self._maybe_restore_session()
+                try:
+                    return await self._chat_inner(user_message)
+                finally:
+                    await self._checkpoint_chat_session()
+        finally:
+            current_origin.reset(origin_token)
 
     # ── Chat helpers (shared by streaming and non-streaming) ────
 
@@ -2461,7 +2468,10 @@ class AgentLoop:
 
     # ── Streaming chat ────────────────────────────────────────
 
-    async def chat_stream(self, user_message: str, *, trace_id: str | None = None):
+    async def chat_stream(
+        self, user_message: str, *, trace_id: str | None = None,
+        origin: dict[str, str] | None = None,
+    ):
         """Streaming chat that yields SSE events as they happen.
 
         Events yielded (as dicts, caller serialises to SSE):
@@ -2488,15 +2498,19 @@ class AgentLoop:
             }
             return
 
-        from src.shared.trace import current_trace_id
+        from src.shared.trace import current_origin, current_trace_id
         current_trace_id.set(trace_id)
-        async with self._chat_lock:
-            await self._maybe_restore_session()
-            try:
-                async for event in self._chat_stream_inner(user_message):
-                    yield event
-            finally:
-                await self._checkpoint_chat_session()
+        origin_token = current_origin.set(origin)
+        try:
+            async with self._chat_lock:
+                await self._maybe_restore_session()
+                try:
+                    async for event in self._chat_stream_inner(user_message):
+                        yield event
+                finally:
+                    await self._checkpoint_chat_session()
+        finally:
+            current_origin.reset(origin_token)
 
     async def _chat_stream_inner(self, user_message: str):
         self.state = "working"

--- a/src/agent/mesh_client.py
+++ b/src/agent/mesh_client.py
@@ -232,13 +232,20 @@ class MeshClient:
         )
         response.raise_for_status()
 
-    async def wake_agent(self, target: str, message: str = "") -> dict:
+    async def wake_agent(
+        self, target: str, message: str = "",
+        origin: dict | None = None,
+    ) -> dict:
         """Wake a target agent so it processes work immediately."""
         client = await self._get_client()
+        headers = self._trace_headers()
+        if origin:
+            import json as _json
+            headers["X-Origin"] = _json.dumps(origin, separators=(",", ":"))
         response = await client.post(
             f"{self.mesh_url}/mesh/wake",
             params={"target": target, "message": message},
-            headers=self._trace_headers(),
+            headers=headers,
         )
         response.raise_for_status()
         return response.json()

--- a/src/agent/mesh_client.py
+++ b/src/agent/mesh_client.py
@@ -237,11 +237,11 @@ class MeshClient:
         origin: dict | None = None,
     ) -> dict:
         """Wake a target agent so it processes work immediately."""
+        from src.shared.trace import origin_header
+
         client = await self._get_client()
         headers = self._trace_headers()
-        if origin:
-            import json as _json
-            headers["X-Origin"] = _json.dumps(origin, separators=(",", ":"))
+        headers.update(origin_header(origin))
         response = await client.post(
             f"{self.mesh_url}/mesh/wake",
             params={"target": target, "message": message},

--- a/src/agent/server.py
+++ b/src/agent/server.py
@@ -193,9 +193,12 @@ def create_agent_app(loop: AgentLoop) -> FastAPI:
     @app.post("/chat", response_model=ChatResponse)
     async def chat(msg: ChatMessage, request: Request) -> ChatResponse:
         """Interactive chat with the agent. Supports tool use."""
+        from src.shared.trace import parse_origin_header
+        origin = parse_origin_header(request.headers.get("x-origin"))
         result = await loop.chat(
             sanitize_for_prompt(msg.message),
             trace_id=request.headers.get("x-trace-id"),
+            origin=origin,
         )
         return ChatResponse(**result)
 
@@ -208,10 +211,13 @@ def create_agent_app(loop: AgentLoop) -> FastAPI:
     @app.post("/chat/stream")
     async def chat_stream(msg: ChatMessage, request: Request) -> StreamingResponse:
         """Streaming chat. Returns SSE events for tool use and text deltas."""
+        from src.shared.trace import parse_origin_header
         _trace_id = request.headers.get("x-trace-id")
+        _origin = parse_origin_header(request.headers.get("x-origin"))
         async def event_generator():
             stream = loop.chat_stream(
                 sanitize_for_prompt(msg.message), trace_id=_trace_id,
+                origin=_origin,
             )
             stream_iter = stream.__aiter__()
             # Use asyncio.wait (not wait_for) so the pending __anext__

--- a/src/channels/base.py
+++ b/src/channels/base.py
@@ -98,7 +98,7 @@ class PairingManager:
     def allowed_list(self) -> list:
         return list(self._data.get("allowed", []))
 
-DispatchFn = Callable[[str, str], Coroutine[Any, Any, str]]
+DispatchFn = Callable[..., Coroutine[Any, Any, str]]
 StreamDispatchFn = Callable[[str, str], AsyncIterator[dict]]
 ListAgentsFn = Callable[[], dict]
 StatusFn = Callable[[str], dict | None]
@@ -190,7 +190,13 @@ class Channel(abc.ABC):
         self, agent: str, message: str,
         origin: dict[str, str] | None = None,
     ) -> str:
-        """Route a message to an agent and return the response."""
+        """Route a message to an agent and return the response.
+
+        ``dispatch_fn`` must accept ``origin`` as a keyword argument (defaulting
+        to None). Production dispatch_fns (``RuntimeContext.async_dispatch``)
+        already do; test stubs should use ``**kwargs`` or an explicit
+        ``origin=None`` kwarg.
+        """
         from src.shared.trace import current_trace_id, new_trace_id
 
         target = agent or self.default_agent
@@ -199,13 +205,6 @@ class Channel(abc.ABC):
         current_trace_id.set(new_trace_id())
         try:
             return await self.dispatch_fn(target, message, origin=origin)
-        except TypeError:
-            # Back-compat: dispatch_fn doesn't accept origin keyword
-            try:
-                return await self.dispatch_fn(target, message)
-            except Exception as e:
-                logger.error(f"Dispatch to '{target}' failed: {e}")
-                return f"Error: {e}"
         except Exception as e:
             logger.error(f"Dispatch to '{target}' failed: {e}")
             return f"Error: {e}"

--- a/src/channels/base.py
+++ b/src/channels/base.py
@@ -118,7 +118,12 @@ class Channel(abc.ABC):
     - /use, /agents, /status, /broadcast, /costs, /reset, /help commands
     - Agent name labels on every response
     - Async notification push for cron/heartbeat results
+
+    Subclasses should set ``CHANNEL_TYPE`` to the platform identifier string
+    (e.g. ``"whatsapp"``) used for origin-based response routing.
     """
+
+    CHANNEL_TYPE: str = ""
 
     def __init__(
         self,
@@ -158,6 +163,18 @@ class Channel(abc.ABC):
     async def send_notification(self, text: str) -> None:
         """Push a notification (e.g. cron result) to all registered users."""
 
+    async def send_to_user(self, user_id: str, text: str) -> None:
+        """Send a message to a specific user on this channel.
+
+        Subclasses should override to deliver via the platform's API.
+        Base implementation logs and drops — prevents crashes when a
+        channel that hasn't implemented it receives an auto-notify.
+        """
+        logger.warning(
+            "%s.send_to_user not implemented; dropping message to %s",
+            type(self).__name__, user_id,
+        )
+
     def _get_active_agent(self, user_id: str) -> str:
         return self._active_agent.get(user_id, self.default_agent)
 
@@ -169,7 +186,10 @@ class Channel(abc.ABC):
             return list(self.list_agents_fn().keys())
         return []
 
-    async def dispatch(self, agent: str, message: str) -> str:
+    async def dispatch(
+        self, agent: str, message: str,
+        origin: dict[str, str] | None = None,
+    ) -> str:
         """Route a message to an agent and return the response."""
         from src.shared.trace import current_trace_id, new_trace_id
 
@@ -178,7 +198,14 @@ class Channel(abc.ABC):
             return "No agent specified and no default agent configured."
         current_trace_id.set(new_trace_id())
         try:
-            return await self.dispatch_fn(target, message)
+            return await self.dispatch_fn(target, message, origin=origin)
+        except TypeError:
+            # Back-compat: dispatch_fn doesn't accept origin keyword
+            try:
+                return await self.dispatch_fn(target, message)
+            except Exception as e:
+                logger.error(f"Dispatch to '{target}' failed: {e}")
+                return f"Error: {e}"
         except Exception as e:
             logger.error(f"Dispatch to '{target}' failed: {e}")
             return f"Error: {e}"
@@ -213,8 +240,11 @@ class Channel(abc.ABC):
         if message.startswith("/"):
             return await self._handle_command(user_id, message, current, agents)
 
-        # Normal message: dispatch to agent
-        response = await self.dispatch(target, message)
+        # Normal message: build origin and dispatch to agent
+        origin: dict[str, str] | None = None
+        if self.CHANNEL_TYPE and user_id:
+            origin = {"channel": self.CHANNEL_TYPE, "user": str(user_id)}
+        response = await self.dispatch(target, message, origin=origin)
         if not response or not response.strip():
             return ""  # Suppress silent/empty responses
         return f"[{target}] {response}"

--- a/src/channels/discord.py
+++ b/src/channels/discord.py
@@ -31,6 +31,8 @@ MAX_DC_LEN = 1900
 class DiscordChannel(Channel):
     """Discord bot adapter for OpenLegion with pairing code security."""
 
+    CHANNEL_TYPE = "discord"
+
     def __init__(
         self,
         token: str,
@@ -529,3 +531,19 @@ class DiscordChannel(Channel):
                         await channel.send(c)
             except Exception as e:
                 logger.warning(f"Failed to notify channel {ch_id}: {e}")
+
+    async def send_to_user(self, user_id: str, text: str) -> None:
+        """Send a DM to a specific Discord user."""
+        if not self._client:
+            return
+        try:
+            uid = int(user_id)
+        except (TypeError, ValueError):
+            logger.warning("Discord send_to_user: invalid user_id %r", user_id)
+            return
+        try:
+            user = await self._client.fetch_user(uid)
+            for chunk in chunk_text(text, MAX_DC_LEN):
+                await user.send(chunk)
+        except Exception as e:
+            logger.warning("Discord send_to_user(%s) failed: %s", user_id, e)

--- a/src/channels/slack.py
+++ b/src/channels/slack.py
@@ -40,6 +40,8 @@ def _get_user_key(user_id: str, thread_ts: str | None) -> str:
 class SlackChannel(Channel):
     """Slack bot adapter for OpenLegion with Socket Mode and pairing code security."""
 
+    CHANNEL_TYPE = "slack"
+
     def __init__(
         self,
         bot_token: str,
@@ -147,6 +149,18 @@ class SlackChannel(Channel):
                     )
             except Exception as e:
                 logger.warning(f"Failed to notify channel {ch_id}: {e}")
+
+    async def send_to_user(self, user_id: str, text: str) -> None:
+        """Send a DM to a specific Slack user via their user ID."""
+        if not self._bolt_app:
+            return
+        try:
+            for part in chunk_text(text, MAX_SLACK_LEN):
+                await self._bolt_app.client.chat_postMessage(
+                    channel=user_id, text=part,
+                )
+        except Exception as e:
+            logger.warning("Slack send_to_user(%s) failed: %s", user_id, e)
 
     def _is_allowed(self, user_id: str) -> bool:
         return self._pairing.is_allowed(user_id)

--- a/src/channels/slack.py
+++ b/src/channels/slack.py
@@ -151,13 +151,24 @@ class SlackChannel(Channel):
                 logger.warning(f"Failed to notify channel {ch_id}: {e}")
 
     async def send_to_user(self, user_id: str, text: str) -> None:
-        """Send a DM to a specific Slack user via their user ID."""
+        """Send a message to a Slack user or thread.
+
+        ``user_id`` may be a raw user ID (``U123…``) or a composite
+        ``U123…:thread_ts`` key produced by ``_get_user_key`` for threaded
+        conversations.  Split the composite before calling the Slack API —
+        ``chat_postMessage`` expects a real channel/user ID as ``channel``
+        and routes to a thread via the separate ``thread_ts`` kwarg.
+        """
         if not self._bolt_app:
             return
+        channel_id, _, thread_ts = user_id.partition(":")
+        post_kwargs: dict[str, str] = {"channel": channel_id}
+        if thread_ts:
+            post_kwargs["thread_ts"] = thread_ts
         try:
             for part in chunk_text(text, MAX_SLACK_LEN):
                 await self._bolt_app.client.chat_postMessage(
-                    channel=user_id, text=part,
+                    text=part, **post_kwargs,
                 )
         except Exception as e:
             logger.warning("Slack send_to_user(%s) failed: %s", user_id, e)

--- a/src/channels/telegram.py
+++ b/src/channels/telegram.py
@@ -57,6 +57,8 @@ def _md_to_html(text: str) -> str:
 class TelegramChannel(Channel):
     """Telegram bot adapter for OpenLegion with pairing code security."""
 
+    CHANNEL_TYPE = "telegram"
+
     def __init__(
         self,
         token: str,
@@ -246,6 +248,27 @@ class TelegramChannel(Channel):
                     await self._app.bot.send_message(chat_id=chat_id, text=chunk)
             except Exception as e:
                 logger.warning(f"Failed to notify chat {chat_id}: {e}")
+
+    async def send_to_user(self, user_id: str, text: str) -> None:
+        """Send a message to a specific Telegram user.
+
+        Note: user_id is the numeric Telegram user ID. For private chats,
+        user_id == chat_id, so we can send directly.  For group chats the
+        user's chat_id and user_id differ; this path targets the DM channel.
+        """
+        if not self._app:
+            return
+        try:
+            chat_id = int(user_id)
+        except (TypeError, ValueError):
+            logger.warning("Telegram send_to_user: invalid user_id %r", user_id)
+            return
+        for chunk in chunk_text(text, MAX_TG_LEN):
+            try:
+                await self._app.bot.send_message(chat_id=chat_id, text=chunk)
+            except Exception as e:
+                logger.warning("Telegram send_to_user(%s) failed: %s", user_id, e)
+                return
 
     def _is_allowed(self, user_id: int) -> bool:
         if self._explicit_allowed is not None:

--- a/src/channels/whatsapp.py
+++ b/src/channels/whatsapp.py
@@ -38,6 +38,8 @@ _GRAPH_API_BASE = "https://graph.facebook.com/v21.0"
 class WhatsAppChannel(Channel):
     """WhatsApp Cloud API adapter for OpenLegion with webhook-based messaging."""
 
+    CHANNEL_TYPE = "whatsapp"
+
     def __init__(
         self,
         access_token: str,
@@ -91,19 +93,39 @@ class WhatsAppChannel(Channel):
             except Exception as e:
                 logger.warning(f"Failed to notify {phone}: {e}")
 
+    async def send_to_user(self, user_id: str, text: str) -> None:
+        """Send a message to a specific WhatsApp user (phone number)."""
+        if not self._http:
+            return
+        for part in chunk_text(text, MAX_WA_LEN):
+            await self._send_text(user_id, part)
+
     async def _send_text(self, to: str, text: str) -> None:
         """Send a text message via the WhatsApp Cloud API."""
         if not self._http:
             return
-        await self._http.post(
-            f"/{self.phone_number_id}/messages",
-            json={
-                "messaging_product": "whatsapp",
-                "to": to,
-                "type": "text",
-                "text": {"body": text},
-            },
-        )
+        try:
+            resp = await self._http.post(
+                f"/{self.phone_number_id}/messages",
+                json={
+                    "messaging_product": "whatsapp",
+                    "to": to,
+                    "type": "text",
+                    "text": {"body": text},
+                },
+            )
+        except httpx.HTTPError as e:
+            logger.warning("WhatsApp send to %s failed (network): %s", to, e)
+            return
+        if resp.status_code >= 400:
+            try:
+                body = resp.json()
+            except Exception:
+                body = resp.text
+            logger.warning(
+                "WhatsApp send to %s failed (HTTP %d): %s",
+                to, resp.status_code, body,
+            )
 
     def _is_allowed(self, phone: str) -> bool:
         return self._pairing.is_allowed(phone)

--- a/src/channels/whatsapp.py
+++ b/src/channels/whatsapp.py
@@ -22,6 +22,7 @@ import asyncio
 import hashlib
 import hmac
 import os
+import weakref
 
 import httpx
 from fastapi import APIRouter, HTTPException, Query, Request
@@ -52,10 +53,51 @@ class WhatsAppChannel(Channel):
         self.access_token = access_token
         self.phone_number_id = phone_number_id
         self.verify_token = verify_token
+        # ``_http`` exists for test injection and readiness checks:
+        #   - tests replace it with an AsyncMock and assert on ``_http.post``
+        #   - production code checks ``if not self._http`` as a "started" flag
+        # Real production sends go through ``_client_for_loop()`` which keeps
+        # one httpx.AsyncClient per event loop.  httpx pins its connection
+        # pool to the first loop that uses it, so reusing one client across
+        # loops (uvicorn webhook loop + dispatch loop for hand-off auto-notify)
+        # raises "Event loop is closed" on the second loop.
+        #
+        # Keyed by the loop object itself via WeakKeyDictionary so entries
+        # vanish automatically when a loop is garbage-collected — using id()
+        # is unsafe because CPython reuses loop memory addresses across
+        # successive ``asyncio.run()`` calls.
         self._http: httpx.AsyncClient | None = None
+        self._http_by_loop: weakref.WeakKeyDictionary[
+            asyncio.AbstractEventLoop, httpx.AsyncClient
+        ] = weakref.WeakKeyDictionary()
         self._phone_numbers: set[str] = set()
         self._denied_notified: set[str] = set()
         self._pairing = PairingManager("config/whatsapp_paired.json")
+
+    def _client_for_loop(self) -> httpx.AsyncClient | None:
+        """Return a per-loop httpx client, creating it lazily on first use.
+
+        Tests inject a mock via ``ch._http = AsyncMock()``; in that case we
+        return the mock directly so assertions like
+        ``ch._http.post.assert_called_once()`` keep working regardless of
+        which loop ``_send_text`` runs on.
+        """
+        # Test injection path: a unittest.mock client was assigned directly.
+        if self._http is not None and not isinstance(self._http, httpx.AsyncClient):
+            return self._http
+        try:
+            loop = asyncio.get_running_loop()
+        except RuntimeError:
+            return None
+        client = self._http_by_loop.get(loop)
+        if client is None:
+            client = httpx.AsyncClient(
+                base_url=_GRAPH_API_BASE,
+                headers={"Authorization": f"Bearer {self.access_token}"},
+                timeout=30,
+            )
+            self._http_by_loop[loop] = client
+        return client
 
     async def start(self) -> None:
         if os.environ.get("MESH_AUTH_TOKEN") and not os.environ.get("WHATSAPP_APP_SECRET"):
@@ -63,11 +105,22 @@ class WhatsAppChannel(Channel):
                 "WHATSAPP_APP_SECRET is required in production (MESH_AUTH_TOKEN is set). "
                 "Without it, webhook signature verification is disabled."
             )
-        self._http = httpx.AsyncClient(
-            base_url=_GRAPH_API_BASE,
-            headers={"Authorization": f"Bearer {self.access_token}"},
-            timeout=30,
-        )
+        # Warm the cache for the current loop and mirror the client onto
+        # ``_http`` so existing readiness checks (``if not self._http``)
+        # continue to work.  Cross-loop sends create their own client via
+        # ``_client_for_loop``.
+        try:
+            loop = asyncio.get_running_loop()
+            client = httpx.AsyncClient(
+                base_url=_GRAPH_API_BASE,
+                headers={"Authorization": f"Bearer {self.access_token}"},
+                timeout=30,
+            )
+            self._http_by_loop[loop] = client
+            self._http = client
+        except RuntimeError:
+            logger.warning("WhatsApp start() called outside an event loop")
+
         owner = self._pairing.owner
         if owner:
             logger.info(f"WhatsApp channel started (owner: {owner})")
@@ -77,9 +130,15 @@ class WhatsAppChannel(Channel):
             logger.info("WhatsApp channel started (no pairing code -- run setup again)")
 
     async def stop(self) -> None:
-        if self._http:
-            await self._http.aclose()
-            self._http = None
+        clients = list(self._http_by_loop.values())
+        self._http_by_loop.clear()
+        self._http = None
+        for client in clients:
+            try:
+                await client.aclose()
+            except Exception as e:
+                logger.debug("WhatsApp client aclose failed: %s", e)
+        if clients:
             logger.info("WhatsApp channel stopped")
 
     async def send_notification(self, text: str) -> None:
@@ -102,10 +161,11 @@ class WhatsAppChannel(Channel):
 
     async def _send_text(self, to: str, text: str) -> None:
         """Send a text message via the WhatsApp Cloud API."""
-        if not self._http:
+        client = self._client_for_loop()
+        if client is None:
             return
         try:
-            resp = await self._http.post(
+            resp = await client.post(
                 f"/{self.phone_number_id}/messages",
                 json={
                     "messaging_product": "whatsapp",

--- a/src/cli/channels.py
+++ b/src/cli/channels.py
@@ -144,8 +144,10 @@ class ChannelManager:
                 default_agent=wa_cfg.get("default_agent", first_agent),
                 **common,
             )
-            # CLI boot — no running loop; use asyncio.run here (start_channel
-        # awaits directly for the dashboard path, which runs inside uvicorn).
+            # CLI boot runs on the main thread with no event loop yet, so
+            # asyncio.run() is correct here.  The dashboard path
+            # (start_channel) is async and awaits ch.start() directly because
+            # it runs inside uvicorn's loop.
             asyncio.run(wa.start())
             webhook_routers.append(wa.create_router())
             self.active.append(wa)

--- a/src/cli/channels.py
+++ b/src/cli/channels.py
@@ -144,6 +144,8 @@ class ChannelManager:
                 default_agent=wa_cfg.get("default_agent", first_agent),
                 **common,
             )
+            # CLI boot — no running loop; use asyncio.run here (start_channel
+        # awaits directly for the dashboard path, which runs inside uvicorn).
             asyncio.run(wa.start())
             webhook_routers.append(wa.create_router())
             self.active.append(wa)
@@ -246,8 +248,14 @@ class ChannelManager:
             result.append(entry)
         return result
 
-    def start_channel(self, channel_type: str, tokens: dict) -> list:
-        """Start a single channel dynamically. Returns webhook routers (for WhatsApp)."""
+    async def start_channel(self, channel_type: str, tokens: dict) -> list:
+        """Start a single channel dynamically. Returns webhook routers (for WhatsApp).
+
+        Async so it can be awaited from the dashboard endpoint running inside uvicorn.
+        For Telegram/Discord/Slack, _start_async_channel spawns a daemon thread
+        (sync thread creation is fine from async context).  For WhatsApp, we await
+        ch.start() directly — it's short setup code, not a long-running loop.
+        """
         if channel_type not in self.CHANNEL_TYPES:
             raise ValueError(f"Unknown channel type: {channel_type}")
         if channel_type in self._channel_map:
@@ -309,7 +317,7 @@ class ChannelManager:
                 access_token=access_token, phone_number_id=phone_number_id,
                 verify_token=verify_token, default_agent=first_agent, **common,
             )
-            asyncio.run(ch.start())
+            await ch.start()
             webhook_routers.append(ch.create_router())
             self.active.append(ch)
             self._channel_map["whatsapp"] = ch

--- a/src/cli/runtime.py
+++ b/src/cli/runtime.py
@@ -464,10 +464,9 @@ class RuntimeContext:
 
         async def _direct_dispatch(
             agent_name: str, message: str, origin: dict | None = None,
+            **_kwargs,
         ) -> str:
-            import json as _json
-
-            from src.shared.trace import ORIGIN_HEADER, current_trace_id
+            from src.shared.trace import current_trace_id, origin_header
 
             tid = current_trace_id.get()
             if tid and self.trace_store:
@@ -481,10 +480,7 @@ class RuntimeContext:
             extra_headers: dict[str, str] = {}
             if tid:
                 extra_headers["x-trace-id"] = tid
-            if origin:
-                extra_headers[ORIGIN_HEADER] = _json.dumps(
-                    origin, separators=(",", ":"),
-                )
+            extra_headers.update(origin_header(origin))
             try:
                 result = await self.transport.request(
                     agent_name, "POST", "/chat", json={"message": message},
@@ -549,12 +545,24 @@ class RuntimeContext:
                 for ch in self._active_channels
             ), return_exceptions=True)
 
-    async def _handle_notify_origin(self, origin: dict, message: str) -> None:
+    async def _handle_notify_origin(
+        self, origin: dict, message: str, agent_name: str = "",
+    ) -> None:
         """Route a completed task result back to the originating channel+user.
 
         Called by the lane worker after a hand-off task completes with
         auto_notify=True.  Delivers the result to the specific user on the
         specific channel that originally dispatched the work.
+
+        Prefixes the message with ``[agent_name]`` for parity with the direct
+        dispatch path (``Channel.handle_message`` labels responses the same
+        way), so users can see which agent produced the reply.
+
+        Telegram/Discord/Slack adapters each run on their own event loop in a
+        daemon thread.  The lane worker calling this is on the dispatch loop,
+        so we hop onto the channel's own loop via ``run_coroutine_threadsafe``
+        to avoid cross-loop client reuse.  WhatsApp has no dedicated loop
+        (it's webhook-driven), so we call directly.
         """
         if not origin or not self.channel_manager:
             return
@@ -569,8 +577,18 @@ class RuntimeContext:
                 channel_type, user,
             )
             return
+
+        labelled = f"[{agent_name}] {message}" if agent_name else message
+
+        channel_loop = getattr(ch, "_channel_loop", None)
         try:
-            await ch.send_to_user(user, message)
+            if channel_loop is not None and channel_loop.is_running():
+                concurrent_fut = asyncio.run_coroutine_threadsafe(
+                    ch.send_to_user(user, labelled), channel_loop,
+                )
+                await asyncio.wrap_future(concurrent_fut)
+            else:
+                await ch.send_to_user(user, labelled)
         except Exception as e:
             logger.warning(
                 "send_to_user(%s, %s) failed: %s", channel_type, user, e,

--- a/src/cli/runtime.py
+++ b/src/cli/runtime.py
@@ -156,7 +156,10 @@ class RuntimeContext:
         click.echo(" done.")
 
     def dispatch(
-        self, agent: str, message: str, mode: str = "followup", trace_id: str | None = None,
+        self, agent: str, message: str, mode: str = "followup",
+        trace_id: str | None = None,
+        origin: dict[str, str] | None = None,
+        auto_notify: bool = False,
     ) -> str:
         """Thread-safe synchronous message dispatch.
 
@@ -164,17 +167,26 @@ class RuntimeContext:
         until the result is ready.  For async callers, use async_dispatch().
         """
         future = asyncio.run_coroutine_threadsafe(
-            self.lane_manager.enqueue(agent, message, mode=mode, trace_id=trace_id),
+            self.lane_manager.enqueue(
+                agent, message, mode=mode, trace_id=trace_id,
+                origin=origin, auto_notify=auto_notify,
+            ),
             self._dispatch_loop,
         )
         return future.result()
 
     async def async_dispatch(
-        self, agent: str, message: str, mode: str = "followup", trace_id: str | None = None,
+        self, agent: str, message: str, mode: str = "followup",
+        trace_id: str | None = None,
+        origin: dict[str, str] | None = None,
+        auto_notify: bool = False,
     ) -> str:
         """Async dispatch: schedules onto the dedicated dispatch loop."""
         future = asyncio.run_coroutine_threadsafe(
-            self.lane_manager.enqueue(agent, message, mode=mode, trace_id=trace_id),
+            self.lane_manager.enqueue(
+                agent, message, mode=mode, trace_id=trace_id,
+                origin=origin, auto_notify=auto_notify,
+            ),
             self._dispatch_loop,
         )
         try:
@@ -450,8 +462,12 @@ class RuntimeContext:
     def _setup_dispatch(self) -> None:
         from src.host.lanes import LaneManager
 
-        async def _direct_dispatch(agent_name: str, message: str) -> str:
-            from src.shared.trace import current_trace_id
+        async def _direct_dispatch(
+            agent_name: str, message: str, origin: dict | None = None,
+        ) -> str:
+            import json as _json
+
+            from src.shared.trace import ORIGIN_HEADER, current_trace_id
 
             tid = current_trace_id.get()
             if tid and self.trace_store:
@@ -462,9 +478,17 @@ class RuntimeContext:
                 )
             import time as _time
             t0 = _time.time()
+            extra_headers: dict[str, str] = {}
+            if tid:
+                extra_headers["x-trace-id"] = tid
+            if origin:
+                extra_headers[ORIGIN_HEADER] = _json.dumps(
+                    origin, separators=(",", ":"),
+                )
             try:
                 result = await self.transport.request(
                     agent_name, "POST", "/chat", json={"message": message},
+                    headers=extra_headers or None,
                 )
                 response = result.get("response", "(no response)")
                 duration_ms = int((_time.time() - t0) * 1000)
@@ -502,6 +526,7 @@ class RuntimeContext:
         self.lane_manager = LaneManager(
             dispatch_fn=_direct_dispatch, steer_fn=_direct_steer,
             trace_store=self.trace_store,
+            notify_fn=self._handle_notify_origin,
         )
 
         self._dispatch_loop = asyncio.new_event_loop()
@@ -523,6 +548,33 @@ class RuntimeContext:
                 ch.send_notification(notification)
                 for ch in self._active_channels
             ), return_exceptions=True)
+
+    async def _handle_notify_origin(self, origin: dict, message: str) -> None:
+        """Route a completed task result back to the originating channel+user.
+
+        Called by the lane worker after a hand-off task completes with
+        auto_notify=True.  Delivers the result to the specific user on the
+        specific channel that originally dispatched the work.
+        """
+        if not origin or not self.channel_manager:
+            return
+        channel_type = origin.get("channel")
+        user = origin.get("user")
+        if not channel_type or not user:
+            return
+        ch = self.channel_manager._channel_map.get(channel_type)
+        if ch is None:
+            logger.debug(
+                "Origin channel %s not connected — dropping notification to %s",
+                channel_type, user,
+            )
+            return
+        try:
+            await ch.send_to_user(user, message)
+        except Exception as e:
+            logger.warning(
+                "send_to_user(%s, %s) failed: %s", channel_type, user, e,
+            )
 
     def _start_mesh_server(self) -> None:
         import uvicorn

--- a/src/dashboard/server.py
+++ b/src/dashboard/server.py
@@ -3680,7 +3680,7 @@ def create_dashboard_router(
                     credential_vault.remove_credential(env_name)
 
         try:
-            routers = channel_manager.start_channel(channel_type, tokens)
+            routers = await channel_manager.start_channel(channel_type, tokens)
             if routers:
                 for ch_router in routers:
                     request.app.include_router(ch_router)
@@ -3985,7 +3985,7 @@ def create_spa_catchall_router() -> APIRouter:
 
     @catchall.get("/{path:path}", response_class=HTMLResponse)
     async def spa_catchall(path: str) -> HTMLResponse:
-        if path.startswith(("mesh/", "dashboard/", "ws/")):
+        if path.startswith(("mesh/", "dashboard/", "ws/", "channels/")):
             raise HTTPException(status_code=404, detail="Not found")
         from src.shared.models import KEYLESS_PROVIDERS, get_all_providers
         all_providers = get_all_providers()

--- a/src/host/lanes.py
+++ b/src/host/lanes.py
@@ -35,6 +35,8 @@ class QueuedTask:
     message: str
     mode: str = "followup"
     trace_id: str | None = None
+    origin: dict[str, str] | None = None
+    auto_notify: bool = False
     future: asyncio.Future = field(default_factory=asyncio.Future)
 
 
@@ -46,10 +48,12 @@ class LaneManager:
         dispatch_fn: Callable[..., Coroutine[Any, Any, str]],
         steer_fn: Callable[..., Coroutine[Any, Any, Any]] | None = None,
         trace_store: Any = None,
+        notify_fn: Callable[..., Coroutine[Any, Any, Any]] | None = None,
     ):
         self._dispatch_fn = dispatch_fn
         self._steer_fn = steer_fn
         self._trace_store = trace_store
+        self._notify_fn = notify_fn
         self._queues: dict[str, asyncio.Queue[QueuedTask]] = {}
         self._workers: dict[str, asyncio.Task] = {}
         self._pending: dict[str, list[QueuedTask]] = {}
@@ -69,7 +73,10 @@ class LaneManager:
             self._workers[agent] = asyncio.create_task(self._worker(agent))
 
     async def enqueue(
-        self, agent: str, message: str, *, mode: str = "followup", trace_id: str | None = None,
+        self, agent: str, message: str, *, mode: str = "followup",
+        trace_id: str | None = None,
+        origin: dict[str, str] | None = None,
+        auto_notify: bool = False,
     ) -> str:
         """Queue a message for an agent with the specified mode.
 
@@ -77,6 +84,10 @@ class LaneManager:
           followup — default FIFO, process after current task.
           steer    — inject into active conversation between tool rounds.
           collect  — batch when busy, dispatch combined when agent becomes free.
+
+        When ``origin`` and ``auto_notify=True`` are set, the lane worker will
+        forward the completed task result back to the originating channel+user
+        via the configured ``notify_fn``.
         """
         self._ensure_lane(agent)
 
@@ -85,10 +96,15 @@ class LaneManager:
         elif mode == "collect":
             return await self._handle_collect(agent, message)
         else:
-            return await self._handle_followup(agent, message, trace_id=trace_id)
+            return await self._handle_followup(
+                agent, message, trace_id=trace_id,
+                origin=origin, auto_notify=auto_notify,
+            )
 
     async def _handle_followup(
         self, agent: str, message: str, *, trace_id: str | None = None,
+        origin: dict[str, str] | None = None,
+        auto_notify: bool = False,
     ) -> str:
         """Standard FIFO enqueue."""
         task = QueuedTask(
@@ -97,6 +113,8 @@ class LaneManager:
             message=message,
             mode="followup",
             trace_id=trace_id,
+            origin=origin,
+            auto_notify=auto_notify,
         )
         self._pending[agent].append(task)
         await self._queues[agent].put(task)
@@ -216,8 +234,36 @@ class LaneManager:
                     meta={"mode": task.mode, "queue_depth": queue.qsize()},
                 )
             try:
-                result = await self._dispatch_fn(agent, task.message)
+                if task.origin is not None:
+                    result = await self._dispatch_fn(
+                        agent, task.message, origin=task.origin,
+                    )
+                else:
+                    result = await self._dispatch_fn(agent, task.message)
                 task.future.set_result(result)
+                # Auto-forward result to origin channel+user when requested
+                if (
+                    task.auto_notify
+                    and task.origin
+                    and self._notify_fn
+                    and isinstance(result, str)
+                    and result.strip()
+                    and result != SILENT_REPLY_TOKEN
+                ):
+                    fn = self._notify_fn
+                    origin_copy = dict(task.origin)
+                    task_result = result
+
+                    async def _forward():
+                        try:
+                            await fn(origin_copy, task_result)
+                        except Exception as fwd_e:
+                            logger.warning(
+                                "Lane auto-notify to origin %s failed: %s",
+                                origin_copy, fwd_e,
+                            )
+
+                    asyncio.create_task(_forward())
             except Exception as e:
                 if not task.future.done():
                     task.future.set_exception(e)

--- a/src/host/lanes.py
+++ b/src/host/lanes.py
@@ -26,6 +26,7 @@ logger = setup_logging("host.lanes")
 
 _STEER_WAKEUP_MAX = 10  # max wakeups per window
 _STEER_WAKEUP_WINDOW = 3600  # 1 hour window
+_NOTIFY_FORWARD_TIMEOUT = 30  # seconds — cap on auto-notify send
 
 
 @dataclass
@@ -241,7 +242,9 @@ class LaneManager:
                 else:
                     result = await self._dispatch_fn(agent, task.message)
                 task.future.set_result(result)
-                # Auto-forward result to origin channel+user when requested
+                # Auto-forward result to origin channel+user when requested.
+                # Runs as a background task with a timeout so a hung channel
+                # send does not leak a coroutine or stall the worker.
                 if (
                     task.auto_notify
                     and task.origin
@@ -252,11 +255,20 @@ class LaneManager:
                 ):
                     fn = self._notify_fn
                     origin_copy = dict(task.origin)
+                    task_agent = task.agent
                     task_result = result
 
                     async def _forward():
                         try:
-                            await fn(origin_copy, task_result)
+                            await asyncio.wait_for(
+                                fn(origin_copy, task_result, task_agent),
+                                timeout=_NOTIFY_FORWARD_TIMEOUT,
+                            )
+                        except asyncio.TimeoutError:
+                            logger.warning(
+                                "Lane auto-notify to origin %s timed out after %ds",
+                                origin_copy, _NOTIFY_FORWARD_TIMEOUT,
+                            )
                         except Exception as fwd_e:
                             logger.warning(
                                 "Lane auto-notify to origin %s failed: %s",

--- a/src/host/lanes.py
+++ b/src/host/lanes.py
@@ -62,6 +62,11 @@ class LaneManager:
         self._busy: dict[str, bool] = {}
         self._state_locks: dict[str, asyncio.Lock] = {}
         self._steer_wakeup_ts: dict[str, list[float]] = {}
+        # Strong references to in-flight auto-notify forward tasks.  The
+        # asyncio event loop only holds weak references, so a bare
+        # ``create_task(_forward())`` can be garbage-collected mid-flight
+        # per the Python docs warning.
+        self._forward_tasks: set[asyncio.Task] = set()
 
     def _ensure_lane(self, agent: str) -> None:
         """Lazily create queue, worker, and tracking structures for an agent."""
@@ -275,7 +280,9 @@ class LaneManager:
                                 origin_copy, fwd_e,
                             )
 
-                    asyncio.create_task(_forward())
+                    forward_task = asyncio.create_task(_forward())
+                    self._forward_tasks.add(forward_task)
+                    forward_task.add_done_callback(self._forward_tasks.discard)
             except Exception as e:
                 if not task.future.done():
                     task.future.set_exception(e)
@@ -322,7 +329,10 @@ class LaneManager:
         self._steer_wakeup_ts.pop(agent, None)
 
     async def stop(self) -> None:
-        """Cancel all worker tasks."""
+        """Cancel all worker tasks and any in-flight auto-notify forwards."""
         for task in self._workers.values():
             task.cancel()
         self._workers.clear()
+        for fwd in list(self._forward_tasks):
+            fwd.cancel()
+        self._forward_tasks.clear()

--- a/src/host/server.py
+++ b/src/host/server.py
@@ -382,10 +382,17 @@ def create_mesh_app(
             wake_msg = sanitize_for_prompt(message)
         else:
             wake_msg = f"You have a new task from {caller}. Call check_inbox() to see it."
+
+        from src.shared.trace import parse_origin_header
+        origin = parse_origin_header(request.headers.get("x-origin"))
+
         if lane_manager is not None and dispatch_loop is not None:
             try:
                 asyncio.run_coroutine_threadsafe(
-                    lane_manager.enqueue(target, wake_msg, mode="followup"),
+                    lane_manager.enqueue(
+                        target, wake_msg, mode="followup",
+                        origin=origin, auto_notify=origin is not None,
+                    ),
                     dispatch_loop,
                 )
             except Exception as e:

--- a/src/shared/trace.py
+++ b/src/shared/trace.py
@@ -4,6 +4,11 @@ Every user message, cron tick, and channel dispatch
 gets a unique trace ID (``tr_<hex12>``) that propagates through all hops
 via the ``X-Trace-Id`` HTTP header and a ``contextvars.ContextVar``.
 
+``current_origin`` travels alongside ``current_trace_id`` and propagates
+via the ``X-Origin`` HTTP header.  It carries ``{"channel": ..., "user": ...}``
+so lane workers can auto-forward task results back to the originating user
+on their messaging channel after a hand-off completes.
+
 Separate module (not utils.py) to keep tracing concerns isolated and
 avoid import cycles.
 """
@@ -11,12 +16,18 @@ avoid import cycles.
 from __future__ import annotations
 
 import contextvars
+import json
 import uuid
 
 TRACE_HEADER = "X-Trace-Id"
+ORIGIN_HEADER = "X-Origin"
 
 current_trace_id: contextvars.ContextVar[str | None] = contextvars.ContextVar(
     "current_trace_id", default=None,
+)
+
+current_origin: contextvars.ContextVar[dict[str, str] | None] = contextvars.ContextVar(
+    "current_origin", default=None,
 )
 
 
@@ -29,3 +40,35 @@ def trace_headers() -> dict[str, str]:
     """Return headers dict with ``X-Trace-Id`` if one is active."""
     tid = current_trace_id.get()
     return {TRACE_HEADER: tid} if tid else {}
+
+
+def origin_headers() -> dict[str, str]:
+    """Return an X-Origin header dict if origin is set on the current context."""
+    o = current_origin.get()
+    if not o:
+        return {}
+    return {ORIGIN_HEADER: json.dumps(o, separators=(",", ":"))}
+
+
+def parse_origin_header(raw: str | None) -> dict[str, str] | None:
+    """Parse an X-Origin header. Returns None on any error or invalid shape.
+
+    Only ``channel`` and ``user`` fields propagate — all other keys are dropped.
+    Both must be non-empty strings.
+    """
+    if not raw:
+        return None
+    try:
+        parsed = json.loads(raw)
+    except json.JSONDecodeError:
+        return None
+    if not isinstance(parsed, dict):
+        return None
+    ch = parsed.get("channel")
+    us = parsed.get("user")
+    if not isinstance(ch, str) or not isinstance(us, str):
+        return None
+    if not ch or not us:
+        return None
+    # Whitelist: only `channel` and `user` fields propagate.
+    return {"channel": ch, "user": us}

--- a/src/shared/trace.py
+++ b/src/shared/trace.py
@@ -42,12 +42,15 @@ def trace_headers() -> dict[str, str]:
     return {TRACE_HEADER: tid} if tid else {}
 
 
-def origin_headers() -> dict[str, str]:
-    """Return an X-Origin header dict if origin is set on the current context."""
-    o = current_origin.get()
-    if not o:
+def origin_header(origin: dict[str, str] | None) -> dict[str, str]:
+    """Serialize an origin dict to an ``X-Origin`` header dict.
+
+    Returns ``{}`` when origin is empty so it can be spread into a headers
+    dict unconditionally.
+    """
+    if not origin:
         return {}
-    return {ORIGIN_HEADER: json.dumps(o, separators=(",", ":"))}
+    return {ORIGIN_HEADER: json.dumps(origin, separators=(",", ":"))}
 
 
 def parse_origin_header(raw: str | None) -> dict[str, str] | None:

--- a/src/shared/trace.py
+++ b/src/shared/trace.py
@@ -53,13 +53,18 @@ def origin_header(origin: dict[str, str] | None) -> dict[str, str]:
     return {ORIGIN_HEADER: json.dumps(origin, separators=(",", ":"))}
 
 
+_MAX_ORIGIN_CHANNEL_LEN = 32
+_MAX_ORIGIN_USER_LEN = 128
+
+
 def parse_origin_header(raw: str | None) -> dict[str, str] | None:
     """Parse an X-Origin header. Returns None on any error or invalid shape.
 
     Only ``channel`` and ``user`` fields propagate — all other keys are dropped.
-    Both must be non-empty strings.
+    Both must be non-empty strings within reasonable length bounds so a
+    malicious or malformed header cannot inflate downstream payloads.
     """
-    if not raw:
+    if not raw or len(raw) > 512:
         return None
     try:
         parsed = json.loads(raw)
@@ -72,6 +77,8 @@ def parse_origin_header(raw: str | None) -> dict[str, str] | None:
     if not isinstance(ch, str) or not isinstance(us, str):
         return None
     if not ch or not us:
+        return None
+    if len(ch) > _MAX_ORIGIN_CHANNEL_LEN or len(us) > _MAX_ORIGIN_USER_LEN:
         return None
     # Whitelist: only `channel` and `user` fields propagate.
     return {"channel": ch, "user": us}

--- a/tests/test_agent_server.py
+++ b/tests/test_agent_server.py
@@ -531,3 +531,64 @@ class TestInvokeTool:
             resp = await client.post("/invoke", json={"tool": "broken_tool", "params": {}})
         assert resp.status_code == 200
         assert "error" in resp.json()
+
+
+# ── Fix 4f: X-Origin header propagation ────────────────────────
+
+class TestChatOriginHeader:
+    @pytest.mark.asyncio
+    async def test_chat_passes_origin_to_loop(self):
+        """POST /chat with X-Origin header calls loop.chat with parsed origin."""
+        import json
+
+        app, mock_loop = _make_app()
+        mock_loop.chat = AsyncMock(return_value={
+            "response": "hi", "tool_outputs": [], "tokens_used": 0,
+        })
+        mock_loop.current_task = None
+
+        origin = {"channel": "whatsapp", "user": "+1234"}
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+            resp = await client.post(
+                "/chat",
+                json={"message": "hello"},
+                headers={"x-origin": json.dumps(origin)},
+            )
+        assert resp.status_code == 200
+        mock_loop.chat.assert_awaited_once()
+        call_kwargs = mock_loop.chat.call_args.kwargs
+        assert call_kwargs.get("origin") == origin
+
+    @pytest.mark.asyncio
+    async def test_chat_no_origin_header_passes_none(self):
+        """POST /chat without X-Origin passes origin=None to loop.chat."""
+        app, mock_loop = _make_app()
+        mock_loop.chat = AsyncMock(return_value={
+            "response": "hi", "tool_outputs": [], "tokens_used": 0,
+        })
+        mock_loop.current_task = None
+
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+            resp = await client.post("/chat", json={"message": "hello"})
+        assert resp.status_code == 200
+        call_kwargs = mock_loop.chat.call_args.kwargs
+        assert call_kwargs.get("origin") is None
+
+    @pytest.mark.asyncio
+    async def test_chat_invalid_origin_header_passes_none(self):
+        """Malformed X-Origin silently becomes origin=None."""
+        app, mock_loop = _make_app()
+        mock_loop.chat = AsyncMock(return_value={
+            "response": "hi", "tool_outputs": [], "tokens_used": 0,
+        })
+        mock_loop.current_task = None
+
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+            resp = await client.post(
+                "/chat",
+                json={"message": "hello"},
+                headers={"x-origin": "not-valid-json"},
+            )
+        assert resp.status_code == 200
+        call_kwargs = mock_loop.chat.call_args.kwargs
+        assert call_kwargs.get("origin") is None

--- a/tests/test_channels.py
+++ b/tests/test_channels.py
@@ -46,7 +46,7 @@ class StubChannel(Channel):
 def _make_channel(agents: list[str] | None = None, **overrides):
     agents = agents or ["alpha", "beta"]
 
-    async def dispatch_fn(agent: str, message: str) -> str:
+    async def dispatch_fn(agent: str, message: str, **_kwargs) -> str:
         return f"reply from {agent}"
 
     def list_agents_fn():
@@ -206,7 +206,7 @@ class TestCommands:
 
         call_times = []
 
-        async def slow_dispatch(agent: str, message: str) -> str:
+        async def slow_dispatch(agent: str, message: str, **_kwargs) -> str:
             call_times.append(time.monotonic())
             await asyncio.sleep(0.1)
             return f"reply from {agent}"
@@ -279,7 +279,7 @@ class TestAddKeyCommand:
         """The /addkey command must be consumed at channel layer, never dispatched."""
         dispatch_called = []
 
-        async def dispatch_fn(agent: str, message: str) -> str:
+        async def dispatch_fn(agent: str, message: str, **_kwargs) -> str:
             dispatch_called.append(message)
             return "reply"
 
@@ -350,7 +350,7 @@ class TestSilentResponseSuppression:
     @pytest.mark.asyncio
     async def test_empty_response_suppressed(self):
         """When dispatch returns empty string, handle_message returns empty."""
-        async def silent_dispatch(agent: str, message: str) -> str:
+        async def silent_dispatch(agent: str, message: str, **_kwargs) -> str:
             return ""
 
         ch = _make_channel(dispatch_fn=silent_dispatch)
@@ -360,7 +360,7 @@ class TestSilentResponseSuppression:
     @pytest.mark.asyncio
     async def test_whitespace_only_response_suppressed(self):
         """Whitespace-only responses are suppressed."""
-        async def whitespace_dispatch(agent: str, message: str) -> str:
+        async def whitespace_dispatch(agent: str, message: str, **_kwargs) -> str:
             return "   \n  "
 
         ch = _make_channel(dispatch_fn=whitespace_dispatch)
@@ -370,7 +370,7 @@ class TestSilentResponseSuppression:
     @pytest.mark.asyncio
     async def test_none_response_suppressed(self):
         """None responses are suppressed."""
-        async def none_dispatch(agent: str, message: str) -> str:
+        async def none_dispatch(agent: str, message: str, **_kwargs) -> str:
             return None
 
         ch = _make_channel(dispatch_fn=none_dispatch)
@@ -562,7 +562,7 @@ class TestResetNotAvailable:
 
 def _make_tg_channel(tmp_path: Path | None = None, **overrides) -> TelegramChannel:
     """Create a TelegramChannel with stubbed callbacks for unit testing."""
-    async def dispatch_fn(agent: str, message: str) -> str:
+    async def dispatch_fn(agent: str, message: str, **_kwargs) -> str:
         return f"reply from {agent}"
 
     def list_agents_fn():

--- a/tests/test_channels.py
+++ b/tests/test_channels.py
@@ -812,3 +812,55 @@ class TestTelegramStop:
         with caplog.at_level(logging.INFO):
             await ch.stop()
         assert "stopped" not in caplog.text.lower()
+
+
+# ── Fix 4d/4e: CHANNEL_TYPE and origin propagation ──────────────
+
+class TestChannelTypeAndOriginPropagation:
+    @pytest.mark.asyncio
+    async def test_channel_type_included_in_origin(self):
+        """When CHANNEL_TYPE is set, dispatch receives origin with channel+user."""
+        received_origins = []
+
+        async def recording_dispatch(agent, message, **kwargs):
+            received_origins.append(kwargs.get("origin"))
+            return "ok"
+
+        class TypedChannel(StubChannel):
+            CHANNEL_TYPE = "testchannel"
+
+        ch = TypedChannel(
+            dispatch_fn=recording_dispatch,
+            default_agent="alpha",
+        )
+
+        await ch.handle_message("user42", "hello")
+        assert received_origins == [{"channel": "testchannel", "user": "user42"}]
+
+    @pytest.mark.asyncio
+    async def test_no_channel_type_origin_is_none(self):
+        """When CHANNEL_TYPE is empty, origin passed to dispatch is None."""
+        received_origins = []
+
+        async def recording_dispatch(agent, message, **kwargs):
+            received_origins.append(kwargs.get("origin"))
+            return "ok"
+
+        ch = _make_channel()  # StubChannel has empty CHANNEL_TYPE
+        ch.dispatch_fn = recording_dispatch
+
+        await ch.handle_message("user42", "hello")
+        assert received_origins == [None]
+
+    @pytest.mark.asyncio
+    async def test_send_to_user_base_logs_warning(self, caplog):
+        """Base Channel.send_to_user logs a warning instead of crashing."""
+        import logging
+
+        ch = _make_channel()
+
+        with caplog.at_level(logging.WARNING):
+            await ch.send_to_user("some_user", "hi")
+
+        assert any("send_to_user" in r.message for r in caplog.records)
+        assert any("not implemented" in r.message for r in caplog.records)

--- a/tests/test_coordination.py
+++ b/tests/test_coordination.py
@@ -534,3 +534,74 @@ class TestCompleteTask:
         # Should still succeed — output cleanup is best-effort
         assert result["completed"] is True
         assert mc.delete_blackboard.call_count == 2
+
+
+# ── Fix 4: origin propagation in hand_off ───────────────────────
+
+
+class TestHandOffOriginPropagation:
+    @pytest.mark.asyncio
+    async def test_hand_off_reads_and_propagates_current_origin(self):
+        """hand_off reads current_origin contextvar and passes it to wake_agent."""
+        from src.agent.builtins.coordination_tool import hand_off
+        from src.shared.trace import current_origin
+
+        mc = _make_mesh_client(agent_id="operator")
+        mc.list_agents.return_value = {"chef": {"role": "chef"}}
+
+        origin = {"channel": "whatsapp", "user": "+1234"}
+        token = current_origin.set(origin)
+        try:
+            result = await hand_off(
+                to="chef",
+                summary="make dinner",
+                mesh_client=mc,
+            )
+        finally:
+            current_origin.reset(token)
+
+        assert result["handed_off"] is True
+        # wake_agent should have been called with origin kwarg
+        mc.wake_agent.assert_awaited_once()
+        call_kwargs = mc.wake_agent.call_args
+        assert call_kwargs.kwargs.get("origin") == origin
+
+    @pytest.mark.asyncio
+    async def test_hand_off_stores_origin_in_task_record(self):
+        """Origin is stored in the task_record written to the blackboard."""
+        from src.agent.builtins.coordination_tool import hand_off
+        from src.shared.trace import current_origin
+
+        mc = _make_mesh_client(agent_id="operator")
+        mc.list_agents.return_value = {"chef": {"role": "chef"}}
+
+        origin = {"channel": "telegram", "user": "99"}
+        token = current_origin.set(origin)
+        try:
+            await hand_off(to="chef", summary="do work", mesh_client=mc)
+        finally:
+            current_origin.reset(token)
+
+        # The task_record write is the last write_blackboard call
+        last_call = mc.write_blackboard.call_args_list[-1]
+        task_record = last_call.args[1]
+        assert task_record.get("origin") == origin
+
+    @pytest.mark.asyncio
+    async def test_hand_off_no_origin_no_origin_in_task_record(self):
+        """When current_origin is None, task_record has no 'origin' key."""
+        from src.agent.builtins.coordination_tool import hand_off
+        from src.shared.trace import current_origin
+
+        mc = _make_mesh_client(agent_id="operator")
+        mc.list_agents.return_value = {"chef": {"role": "chef"}}
+
+        token = current_origin.set(None)
+        try:
+            await hand_off(to="chef", summary="do work", mesh_client=mc)
+        finally:
+            current_origin.reset(token)
+
+        last_call = mc.write_blackboard.call_args_list[-1]
+        task_record = last_call.args[1]
+        assert "origin" not in task_record

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -85,7 +85,7 @@ def _make_components(tmp_path: str, *, include_v2: bool = False) -> dict:
             {"type": t, "connected": False, "paired": False, "pairing_code": None}
             for t in ("telegram", "discord", "slack", "whatsapp")
         ]
-        channel_manager.start_channel.return_value = []
+        channel_manager.start_channel = AsyncMock(return_value=[])
 
         result.update({
             "lane_manager": lane_manager,
@@ -3960,3 +3960,32 @@ class TestDashboardDatabaseDetails:
         data = resp.json()
         assert data["purged"] is True
         assert data["deleted_records"] == 3
+
+
+# ── Fix 2: SPA catch-all excludes /channels/ ────────────────────
+
+class TestSpaCatchallChannelsExclusion:
+    def setup_method(self):
+        from fastapi import FastAPI
+
+        from src.dashboard.server import create_spa_catchall_router
+        self._tmpdir = tempfile.mkdtemp()
+        app = FastAPI()
+        router = create_spa_catchall_router()
+        app.include_router(router)
+        self.client = TestClient(app, raise_server_exceptions=False)
+
+    def teardown_method(self):
+        shutil.rmtree(self._tmpdir, ignore_errors=True)
+
+    def test_channels_path_returns_404(self):
+        resp = self.client.get("/channels/whatsapp/webhook")
+        assert resp.status_code == 404
+
+    def test_channels_subpath_returns_404(self):
+        resp = self.client.get("/channels/foo")
+        assert resp.status_code == 404
+
+    def test_mesh_path_still_returns_404(self):
+        resp = self.client.get("/mesh/agents")
+        assert resp.status_code == 404

--- a/tests/test_discord.py
+++ b/tests/test_discord.py
@@ -19,7 +19,7 @@ from src.channels.discord import MAX_DC_LEN, DiscordChannel
 
 def _make_discord_channel(tmp_path: Path | None = None, **overrides) -> DiscordChannel:
     """Create a DiscordChannel with stubbed callbacks for unit testing."""
-    async def dispatch_fn(agent: str, message: str) -> str:
+    async def dispatch_fn(agent: str, message: str, **_kwargs) -> str:
         return f"reply from {agent}"
 
     def list_agents_fn():
@@ -280,7 +280,7 @@ class TestHandleReplSlash:
         """Long responses are split into multiple followup messages."""
         long_reply = "x" * (MAX_DC_LEN + 500)
 
-        async def dispatch_fn(agent, msg):
+        async def dispatch_fn(agent, msg, **_kwargs):
             return long_reply
 
         ch = _make_discord_channel(dispatch_fn=dispatch_fn)

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -2074,3 +2074,141 @@ def test_agent_profile_permission_denied(mesh_components):
     # Try to read "research" profile from "qualify" — should be denied.
     resp = client.get("/mesh/agents/research/profile", params={"requesting_agent": "qualify"})
     assert resp.status_code == 403
+
+
+# ── Fix 4: /mesh/wake origin header propagation ───────────────────
+
+
+def _wake_test_app(tmp_path):
+    """Build a minimal mesh app wired with a real dispatch loop + mock lane.
+
+    Returns ``(client, captured_enqueue_kwargs)`` where captured_enqueue_kwargs
+    is a list the test can inspect after POSTing to /mesh/wake.
+    """
+    import asyncio
+    import threading
+
+    bb = Blackboard(db_path=str(tmp_path / "bb.db"))
+    pubsub = PubSub()
+    perms = PermissionMatrix.__new__(PermissionMatrix)
+    perms.permissions = {
+        "operator": AgentPermissions(
+            agent_id="operator", can_message=["*"],
+            blackboard_read=["*"], blackboard_write=["*"],
+            allowed_apis=[],
+        ),
+    }
+    router = MessageRouter(permissions=perms, agent_registry={})
+    router.register_agent("chef", "http://fake", role="chef")
+
+    captured: list[dict] = []
+
+    class _FakeLane:
+        async def enqueue(self, agent, message, **kwargs):
+            captured.append({"agent": agent, "message": message, **kwargs})
+            return ""
+
+    lane_manager = _FakeLane()
+
+    # Real loop running in a daemon thread so run_coroutine_threadsafe works.
+    loop = asyncio.new_event_loop()
+    ready = threading.Event()
+
+    def _run():
+        asyncio.set_event_loop(loop)
+        loop.call_soon(ready.set)
+        loop.run_forever()
+
+    t = threading.Thread(target=_run, daemon=True)
+    t.start()
+    ready.wait()
+
+    app = create_mesh_app(
+        bb, pubsub, router, perms,
+        lane_manager=lane_manager,
+        dispatch_loop=loop,
+    )
+    # Mesh endpoint resolves the caller agent from auth tokens; bypass that
+    # by pinning a request-scoped agent_id via _extract_verified_agent_id's
+    # fallback behaviour — no auth_tokens on the app means no verification,
+    # so the endpoint falls back to "mesh" as caller. That's fine for this test.
+    client = TestClient(app)
+    return client, captured, loop, bb
+
+
+def test_mesh_wake_propagates_origin_header(tmp_path):
+    """POST /mesh/wake with X-Origin passes parsed origin + auto_notify=True to enqueue."""
+    import json
+    import time
+
+    client, captured, loop, bb = _wake_test_app(tmp_path)
+    try:
+        resp = client.post(
+            "/mesh/wake",
+            params={"target": "chef", "message": "check inbox"},
+            headers={
+                "x-origin": json.dumps({"channel": "whatsapp", "user": "+1234"}),
+                "X-Agent-ID": "operator",
+            },
+        )
+        assert resp.status_code == 200
+        # Give the dispatch loop a moment to run the enqueue coroutine
+        deadline = time.monotonic() + 2.0
+        while not captured and time.monotonic() < deadline:
+            time.sleep(0.01)
+        assert captured, "lane_manager.enqueue was never called"
+        call = captured[0]
+        assert call["agent"] == "chef"
+        assert call["mode"] == "followup"
+        assert call["origin"] == {"channel": "whatsapp", "user": "+1234"}
+        assert call["auto_notify"] is True
+    finally:
+        loop.call_soon_threadsafe(loop.stop)
+        bb.close()
+
+
+def test_mesh_wake_no_origin_header_disables_auto_notify(tmp_path):
+    """POST /mesh/wake without X-Origin enqueues with origin=None, auto_notify=False."""
+    import time
+
+    client, captured, loop, bb = _wake_test_app(tmp_path)
+    try:
+        resp = client.post(
+            "/mesh/wake",
+            params={"target": "chef", "message": "check inbox"},
+            headers={"X-Agent-ID": "operator"},
+        )
+        assert resp.status_code == 200
+        deadline = time.monotonic() + 2.0
+        while not captured and time.monotonic() < deadline:
+            time.sleep(0.01)
+        assert captured
+        call = captured[0]
+        assert call["origin"] is None
+        assert call["auto_notify"] is False
+    finally:
+        loop.call_soon_threadsafe(loop.stop)
+        bb.close()
+
+
+def test_mesh_wake_invalid_origin_header_ignored(tmp_path):
+    """POST /mesh/wake with malformed X-Origin is treated as no origin."""
+    import time
+
+    client, captured, loop, bb = _wake_test_app(tmp_path)
+    try:
+        resp = client.post(
+            "/mesh/wake",
+            params={"target": "chef", "message": "check inbox"},
+            headers={"x-origin": "not-json", "X-Agent-ID": "operator"},
+        )
+        assert resp.status_code == 200
+        deadline = time.monotonic() + 2.0
+        while not captured and time.monotonic() < deadline:
+            time.sleep(0.01)
+        assert captured
+        assert captured[0]["origin"] is None
+        assert captured[0]["auto_notify"] is False
+    finally:
+        loop.call_soon_threadsafe(loop.stop)
+        bb.close()

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -2076,6 +2076,72 @@ def test_agent_profile_permission_denied(mesh_components):
     assert resp.status_code == 403
 
 
+# ── Fix 4: parse_origin_header input validation ─────────────────
+
+
+class TestParseOriginHeader:
+    def test_valid_header(self):
+        from src.shared.trace import parse_origin_header
+        assert parse_origin_header('{"channel":"whatsapp","user":"+1234"}') == {
+            "channel": "whatsapp", "user": "+1234",
+        }
+
+    def test_none_returns_none(self):
+        from src.shared.trace import parse_origin_header
+        assert parse_origin_header(None) is None
+        assert parse_origin_header("") is None
+
+    def test_invalid_json_returns_none(self):
+        from src.shared.trace import parse_origin_header
+        assert parse_origin_header("not-json") is None
+        assert parse_origin_header("{") is None
+
+    def test_non_dict_returns_none(self):
+        from src.shared.trace import parse_origin_header
+        assert parse_origin_header('"just a string"') is None
+        assert parse_origin_header("[1, 2, 3]") is None
+
+    def test_missing_fields_returns_none(self):
+        from src.shared.trace import parse_origin_header
+        assert parse_origin_header('{"channel":"whatsapp"}') is None
+        assert parse_origin_header('{"user":"+1"}') is None
+
+    def test_empty_fields_returns_none(self):
+        from src.shared.trace import parse_origin_header
+        assert parse_origin_header('{"channel":"","user":"+1"}') is None
+        assert parse_origin_header('{"channel":"whatsapp","user":""}') is None
+
+    def test_non_string_fields_returns_none(self):
+        from src.shared.trace import parse_origin_header
+        assert parse_origin_header('{"channel":1,"user":"+1"}') is None
+        assert parse_origin_header('{"channel":"whatsapp","user":123}') is None
+
+    def test_extra_fields_stripped(self):
+        from src.shared.trace import parse_origin_header
+        result = parse_origin_header(
+            '{"channel":"whatsapp","user":"+1","extra":"dropped","nested":{}}'
+        )
+        assert result == {"channel": "whatsapp", "user": "+1"}
+
+    def test_oversized_raw_header_returns_none(self):
+        from src.shared.trace import parse_origin_header
+        # Raw header >512 bytes is rejected before JSON parsing
+        big = '{"channel":"whatsapp","user":"' + ("x" * 600) + '"}'
+        assert parse_origin_header(big) is None
+
+    def test_oversized_user_field_returns_none(self):
+        from src.shared.trace import parse_origin_header
+        # Even if the raw blob fits under 512, a >128 char user is dropped
+        raw = '{"channel":"whatsapp","user":"' + ("x" * 200) + '"}'
+        # Raw is ~230 chars, under the 512 cap, so length-per-field check kicks in
+        assert parse_origin_header(raw) is None
+
+    def test_oversized_channel_field_returns_none(self):
+        from src.shared.trace import parse_origin_header
+        raw = '{"channel":"' + ("c" * 50) + '","user":"+1"}'
+        assert parse_origin_header(raw) is None
+
+
 # ── Fix 4: /mesh/wake origin header propagation ───────────────────
 
 
@@ -2212,3 +2278,111 @@ def test_mesh_wake_invalid_origin_header_ignored(tmp_path):
     finally:
         loop.call_soon_threadsafe(loop.stop)
         bb.close()
+
+
+# ── Fix 4: RuntimeContext._handle_notify_origin routing ───────────
+
+
+def _stub_runtime_with_channel(channel_type: str, channel_obj):
+    """Build a minimal RuntimeContext with a mocked channel_manager."""
+    from unittest.mock import MagicMock
+
+    from src.cli.runtime import RuntimeContext
+
+    rt = RuntimeContext.__new__(RuntimeContext)
+    rt.channel_manager = MagicMock()
+    rt.channel_manager._channel_map = {channel_type: channel_obj}
+    return rt
+
+
+class _FakeChannel:
+    def __init__(self, has_loop: bool = False):
+        from unittest.mock import AsyncMock
+
+        self.sent: list[tuple[str, str]] = []
+        self._channel_loop = None
+        if has_loop:
+            import asyncio as _aio
+            self._channel_loop = _aio.get_event_loop()
+
+        async def _send(user_id: str, text: str) -> None:
+            self.sent.append((user_id, text))
+
+        self.send_to_user = AsyncMock(side_effect=_send)
+
+
+class TestHandleNotifyOrigin:
+    @pytest.mark.asyncio
+    async def test_routes_to_channel_with_agent_label(self):
+        ch = _FakeChannel()
+        rt = _stub_runtime_with_channel("whatsapp", ch)
+        await rt._handle_notify_origin(
+            {"channel": "whatsapp", "user": "+1234"},
+            "dinner is ready",
+            "chef",
+        )
+        assert ch.sent == [("+1234", "[chef] dinner is ready")]
+
+    @pytest.mark.asyncio
+    async def test_no_agent_label_when_agent_name_empty(self):
+        ch = _FakeChannel()
+        rt = _stub_runtime_with_channel("whatsapp", ch)
+        await rt._handle_notify_origin(
+            {"channel": "whatsapp", "user": "+1234"},
+            "raw message",
+            "",
+        )
+        assert ch.sent == [("+1234", "raw message")]
+
+    @pytest.mark.asyncio
+    async def test_drops_when_channel_not_connected(self):
+        from unittest.mock import MagicMock
+
+        from src.cli.runtime import RuntimeContext
+        rt = RuntimeContext.__new__(RuntimeContext)
+        rt.channel_manager = MagicMock()
+        rt.channel_manager._channel_map = {}  # empty
+        # No exception raised, no call made
+        await rt._handle_notify_origin(
+            {"channel": "discord", "user": "99"},
+            "hi",
+            "chef",
+        )
+
+    @pytest.mark.asyncio
+    async def test_drops_when_channel_manager_missing(self):
+        from src.cli.runtime import RuntimeContext
+        rt = RuntimeContext.__new__(RuntimeContext)
+        rt.channel_manager = None
+        # Must be a no-op, not raise
+        await rt._handle_notify_origin(
+            {"channel": "whatsapp", "user": "+1"},
+            "hi",
+            "chef",
+        )
+
+    @pytest.mark.asyncio
+    async def test_drops_on_invalid_origin(self):
+        ch = _FakeChannel()
+        rt = _stub_runtime_with_channel("whatsapp", ch)
+        # Missing user
+        await rt._handle_notify_origin({"channel": "whatsapp"}, "hi", "chef")
+        # Missing channel
+        await rt._handle_notify_origin({"user": "+1"}, "hi", "chef")
+        # Empty dict
+        await rt._handle_notify_origin({}, "hi", "chef")
+        assert ch.sent == []
+
+    @pytest.mark.asyncio
+    async def test_send_failure_is_caught_not_raised(self):
+        from unittest.mock import AsyncMock
+
+        ch = _FakeChannel()
+        ch.send_to_user = AsyncMock(side_effect=RuntimeError("boom"))
+        rt = _stub_runtime_with_channel("whatsapp", ch)
+        # Must not raise — the warning is logged and swallowed
+        await rt._handle_notify_origin(
+            {"channel": "whatsapp", "user": "+1"},
+            "hi",
+            "chef",
+        )

--- a/tests/test_lanes.py
+++ b/tests/test_lanes.py
@@ -380,3 +380,91 @@ async def test_stop_cancels_workers():
 
     await lm.stop()
     assert len(lm._workers) == 0
+
+
+# ── Fix 4: origin / auto_notify / notify_fn ─────────────────────
+
+
+@pytest.mark.asyncio
+async def test_auto_notify_triggers_notify_fn():
+    """notify_fn called with origin+result when auto_notify=True and result is non-empty."""
+    dispatch = AsyncMock(return_value="task done!")
+    notify = AsyncMock()
+    lm = LaneManager(dispatch_fn=dispatch, notify_fn=notify)
+
+    origin = {"channel": "whatsapp", "user": "+1234"}
+    result = await lm.enqueue(
+        "agent1", "do work", origin=origin, auto_notify=True,
+    )
+
+    assert result == "task done!"
+    # Give the background task a chance to run
+    await asyncio.sleep(0.05)
+    notify.assert_awaited_once_with(origin, "task done!")
+
+
+@pytest.mark.asyncio
+async def test_auto_notify_false_does_not_trigger():
+    """notify_fn not called when auto_notify=False."""
+    dispatch = AsyncMock(return_value="done")
+    notify = AsyncMock()
+    lm = LaneManager(dispatch_fn=dispatch, notify_fn=notify)
+
+    origin = {"channel": "whatsapp", "user": "+1234"}
+    await lm.enqueue("agent1", "msg", origin=origin, auto_notify=False)
+    await asyncio.sleep(0.05)
+    notify.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_auto_notify_no_origin_does_not_trigger():
+    """notify_fn not called when origin=None even if auto_notify=True."""
+    dispatch = AsyncMock(return_value="done")
+    notify = AsyncMock()
+    lm = LaneManager(dispatch_fn=dispatch, notify_fn=notify)
+
+    await lm.enqueue("agent1", "msg", origin=None, auto_notify=True)
+    await asyncio.sleep(0.05)
+    notify.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_auto_notify_silent_reply_does_not_trigger():
+    """notify_fn not called when result is SILENT_REPLY_TOKEN."""
+    dispatch = AsyncMock(return_value=SILENT_REPLY_TOKEN)
+    notify = AsyncMock()
+    lm = LaneManager(dispatch_fn=dispatch, notify_fn=notify)
+
+    origin = {"channel": "whatsapp", "user": "+1234"}
+    await lm.enqueue("agent1", "msg", origin=origin, auto_notify=True)
+    await asyncio.sleep(0.05)
+    notify.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_auto_notify_empty_result_does_not_trigger():
+    """notify_fn not called when result is empty."""
+    dispatch = AsyncMock(return_value="   ")
+    notify = AsyncMock()
+    lm = LaneManager(dispatch_fn=dispatch, notify_fn=notify)
+
+    origin = {"channel": "whatsapp", "user": "+1234"}
+    await lm.enqueue("agent1", "msg", origin=origin, auto_notify=True)
+    await asyncio.sleep(0.05)
+    notify.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_origin_passed_to_dispatch_fn():
+    """When origin is set, dispatch_fn receives it as a kwarg."""
+    received_kwargs = {}
+
+    async def recording_dispatch(agent, message, **kwargs):
+        received_kwargs.update(kwargs)
+        return "ok"
+
+    lm = LaneManager(dispatch_fn=recording_dispatch)
+    origin = {"channel": "telegram", "user": "42"}
+    await lm.enqueue("agent1", "hello", origin=origin)
+
+    assert received_kwargs.get("origin") == origin

--- a/tests/test_lanes.py
+++ b/tests/test_lanes.py
@@ -387,7 +387,7 @@ async def test_stop_cancels_workers():
 
 @pytest.mark.asyncio
 async def test_auto_notify_triggers_notify_fn():
-    """notify_fn called with origin+result when auto_notify=True and result is non-empty."""
+    """notify_fn called with origin+result+agent when auto_notify=True and result is non-empty."""
     dispatch = AsyncMock(return_value="task done!")
     notify = AsyncMock()
     lm = LaneManager(dispatch_fn=dispatch, notify_fn=notify)
@@ -400,7 +400,7 @@ async def test_auto_notify_triggers_notify_fn():
     assert result == "task done!"
     # Give the background task a chance to run
     await asyncio.sleep(0.05)
-    notify.assert_awaited_once_with(origin, "task done!")
+    notify.assert_awaited_once_with(origin, "task done!", "agent1")
 
 
 @pytest.mark.asyncio

--- a/tests/test_slack.py
+++ b/tests/test_slack.py
@@ -306,3 +306,41 @@ class TestSendNotification:
         ch = _make_channel(paired={"owner": "U1", "allowed": []})
         ch._bolt_app = None
         await ch.send_notification("test")
+
+
+# ── Fix 4: send_to_user handles composite thread keys ─────────────
+
+class TestSendToUser:
+    def _mock_bolt(self, ch):
+        mock_client = MagicMock()
+        mock_client.chat_postMessage = AsyncMock()
+        ch._bolt_app = MagicMock()
+        ch._bolt_app.client = mock_client
+        return mock_client
+
+    @pytest.mark.asyncio
+    async def test_send_to_bare_user_id(self):
+        ch = _make_channel(paired={"owner": "U1", "allowed": []})
+        client = self._mock_bolt(ch)
+        await ch.send_to_user("U999", "hello")
+        client.chat_postMessage.assert_awaited_once_with(
+            channel="U999", text="hello",
+        )
+
+    @pytest.mark.asyncio
+    async def test_send_to_composite_thread_key(self):
+        """Composite ``user:thread_ts`` keys must split — channel is the bare
+        user ID, thread_ts is a separate kwarg.  Calling chat_postMessage with
+        ``channel="U999:1700000000.123"`` would otherwise fail silently."""
+        ch = _make_channel(paired={"owner": "U1", "allowed": []})
+        client = self._mock_bolt(ch)
+        await ch.send_to_user("U999:1700000000.123", "hello")
+        client.chat_postMessage.assert_awaited_once_with(
+            channel="U999", thread_ts="1700000000.123", text="hello",
+        )
+
+    @pytest.mark.asyncio
+    async def test_send_to_user_no_app_is_noop(self):
+        ch = _make_channel(paired={"owner": "U1", "allowed": []})
+        ch._bolt_app = None
+        await ch.send_to_user("U999", "hello")  # must not raise

--- a/tests/test_slack.py
+++ b/tests/test_slack.py
@@ -23,7 +23,7 @@ def _make_channel(
 ) -> SlackChannel:
     agents = agents or ["alpha", "beta"]
 
-    async def dispatch_fn(agent: str, message: str) -> str:
+    async def dispatch_fn(agent: str, message: str, **_kwargs) -> str:
         return f"reply from {agent}"
 
     def list_agents_fn():

--- a/tests/test_whatsapp.py
+++ b/tests/test_whatsapp.py
@@ -25,7 +25,7 @@ def _make_channel(
 ) -> WhatsAppChannel:
     agents = agents or ["alpha", "beta"]
 
-    async def dispatch_fn(agent: str, message: str) -> str:
+    async def dispatch_fn(agent: str, message: str, **_kwargs) -> str:
         return f"reply from {agent}"
 
     def list_agents_fn():

--- a/tests/test_whatsapp.py
+++ b/tests/test_whatsapp.py
@@ -7,7 +7,8 @@ Uses FastAPI TestClient for webhook endpoint tests.
 
 from __future__ import annotations
 
-from unittest.mock import AsyncMock
+import logging
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 from fastapi import FastAPI
@@ -58,6 +59,20 @@ def _make_app(channel: WhatsAppChannel) -> FastAPI:
     app = FastAPI()
     app.include_router(channel.create_router())
     return app
+
+
+def _mock_ok_response():
+    """Return a mock httpx response with status_code=200."""
+    resp = MagicMock()
+    resp.status_code = 200
+    return resp
+
+
+def _make_http_mock():
+    """Return a mock httpx.AsyncClient whose post() returns a 200 response."""
+    http = AsyncMock()
+    http.post = AsyncMock(return_value=_mock_ok_response())
+    return http
 
 
 def _webhook_payload(from_phone: str, text: str) -> dict:
@@ -127,8 +142,7 @@ class TestIncomingMessages:
     @pytest.mark.asyncio
     async def test_process_text_message(self):
         ch = _make_channel(paired={"owner": "+1234", "allowed": []})
-        ch._http = AsyncMock()
-        ch._http.post = AsyncMock()
+        ch._http = _make_http_mock()
 
         msg = {"from": "+1234", "type": "text", "text": {"body": "hello"}}
         await ch._process_message(msg)
@@ -142,8 +156,7 @@ class TestIncomingMessages:
     @pytest.mark.asyncio
     async def test_non_text_message_replies_to_allowed_user(self):
         ch = _make_channel(paired={"owner": "+1234", "allowed": []})
-        ch._http = AsyncMock()
-        ch._http.post = AsyncMock()
+        ch._http = _make_http_mock()
 
         msg = {"from": "+1234", "type": "image", "image": {"id": "img123"}}
         await ch._process_message(msg)
@@ -155,8 +168,7 @@ class TestIncomingMessages:
     @pytest.mark.asyncio
     async def test_non_text_message_skipped_for_unknown_user(self):
         ch = _make_channel(paired={"owner": "+1234", "allowed": []})
-        ch._http = AsyncMock()
-        ch._http.post = AsyncMock()
+        ch._http = _make_http_mock()
 
         msg = {"from": "+9999", "type": "image", "image": {"id": "img123"}}
         await ch._process_message(msg)
@@ -166,8 +178,7 @@ class TestIncomingMessages:
     @pytest.mark.asyncio
     async def test_empty_text_skipped(self):
         ch = _make_channel(paired={"owner": "+1234", "allowed": []})
-        ch._http = AsyncMock()
-        ch._http.post = AsyncMock()
+        ch._http = _make_http_mock()
 
         msg = {"from": "+1234", "type": "text", "text": {"body": "   "}}
         await ch._process_message(msg)
@@ -177,8 +188,7 @@ class TestIncomingMessages:
     @pytest.mark.asyncio
     async def test_missing_from_skipped(self):
         ch = _make_channel(paired={"owner": "+1234", "allowed": []})
-        ch._http = AsyncMock()
-        ch._http.post = AsyncMock()
+        ch._http = _make_http_mock()
 
         msg = {"type": "text", "text": {"body": "hello"}}
         await ch._process_message(msg)
@@ -218,8 +228,7 @@ class TestPairing:
         ch = _make_channel(
             paired={"owner": None, "allowed": [], "pairing_code": "abc123"},
         )
-        ch._http = AsyncMock()
-        ch._http.post = AsyncMock()
+        ch._http = _make_http_mock()
 
         msg = {"from": "+1234", "type": "text", "text": {"body": "!start abc123"}}
         await ch._process_message(msg)
@@ -230,8 +239,7 @@ class TestPairing:
         ch = _make_channel(
             paired={"owner": None, "allowed": [], "pairing_code": "abc123"},
         )
-        ch._http = AsyncMock()
-        ch._http.post = AsyncMock()
+        ch._http = _make_http_mock()
 
         msg = {"from": "+1234", "type": "text", "text": {"body": "!start wrong"}}
         await ch._process_message(msg)
@@ -240,8 +248,7 @@ class TestPairing:
     @pytest.mark.asyncio
     async def test_disallowed_user_rejected(self):
         ch = _make_channel(paired={"owner": "+0000", "allowed": []})
-        ch._http = AsyncMock()
-        ch._http.post = AsyncMock()
+        ch._http = _make_http_mock()
 
         msg = {"from": "+9999", "type": "text", "text": {"body": "!start code"}}
         await ch._process_message(msg)
@@ -251,8 +258,7 @@ class TestPairing:
     @pytest.mark.asyncio
     async def test_allowed_user_can_chat(self):
         ch = _make_channel(paired={"owner": "+0000", "allowed": ["+1111"]})
-        ch._http = AsyncMock()
-        ch._http.post = AsyncMock()
+        ch._http = _make_http_mock()
 
         msg = {"from": "+1111", "type": "text", "text": {"body": "hello"}}
         await ch._process_message(msg)
@@ -262,8 +268,7 @@ class TestPairing:
     @pytest.mark.asyncio
     async def test_owner_allow_command(self):
         ch = _make_channel(paired={"owner": "+0000", "allowed": []})
-        ch._http = AsyncMock()
-        ch._http.post = AsyncMock()
+        ch._http = _make_http_mock()
 
         msg = {"from": "+0000", "type": "text", "text": {"body": "!allow +1111"}}
         await ch._process_message(msg)
@@ -272,8 +277,7 @@ class TestPairing:
     @pytest.mark.asyncio
     async def test_owner_revoke_command(self):
         ch = _make_channel(paired={"owner": "+0000", "allowed": ["+1111"]})
-        ch._http = AsyncMock()
-        ch._http.post = AsyncMock()
+        ch._http = _make_http_mock()
 
         msg = {"from": "+0000", "type": "text", "text": {"body": "!revoke +1111"}}
         await ch._process_message(msg)
@@ -286,8 +290,7 @@ class TestSendText:
     @pytest.mark.asyncio
     async def test_send_text_calls_api(self):
         ch = _make_channel()
-        ch._http = AsyncMock()
-        ch._http.post = AsyncMock()
+        ch._http = _make_http_mock()
 
         await ch._send_text("+1234", "hello")
         ch._http.post.assert_called_once()
@@ -312,8 +315,7 @@ class TestSendNotification:
     async def test_notification_sends_to_all_phones(self):
         ch = _make_channel()
         ch._phone_numbers = {"+1111", "+2222"}
-        ch._http = AsyncMock()
-        ch._http.post = AsyncMock()
+        ch._http = _make_http_mock()
 
         await ch.send_notification("test notification")
         assert ch._http.post.call_count == 2
@@ -322,7 +324,7 @@ class TestSendNotification:
     async def test_notification_no_phones_is_noop(self):
         ch = _make_channel()
         ch._phone_numbers = set()
-        ch._http = AsyncMock()
+        ch._http = _make_http_mock()
         await ch.send_notification("test")
 
     @pytest.mark.asyncio
@@ -338,11 +340,119 @@ class TestCommandTranslation:
     @pytest.mark.asyncio
     async def test_exclamation_commands_translated(self):
         ch = _make_channel(paired={"owner": "+1234", "allowed": []})
-        ch._http = AsyncMock()
-        ch._http.post = AsyncMock()
+        ch._http = _make_http_mock()
 
         msg = {"from": "+1234", "type": "text", "text": {"body": "!agents"}}
         await ch._process_message(msg)
         body = ch._http.post.call_args[1]["json"]["text"]["body"]
         assert "alpha" in body
         assert "beta" in body
+
+
+# ── Fix 3: _send_text error logging ────────────────────────────────
+
+class TestSendTextErrorLogging:
+    @pytest.mark.asyncio
+    async def test_200_response_no_warning(self, caplog):
+        ch = _make_channel()
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        ch._http = AsyncMock()
+        ch._http.post = AsyncMock(return_value=mock_resp)
+
+        with caplog.at_level(logging.WARNING, logger="channels.whatsapp"):
+            await ch._send_text("+1234", "hello")
+
+        assert not caplog.records
+
+    @pytest.mark.asyncio
+    async def test_400_response_logs_warning_with_body(self, caplog):
+        ch = _make_channel()
+        mock_resp = MagicMock()
+        mock_resp.status_code = 400
+        mock_resp.json.return_value = {"error": {"message": "Invalid phone number"}}
+        ch._http = AsyncMock()
+        ch._http.post = AsyncMock(return_value=mock_resp)
+
+        with caplog.at_level(logging.WARNING, logger="channels.whatsapp"):
+            await ch._send_text("+1234", "hello")
+
+        assert any("HTTP 400" in r.message for r in caplog.records)
+        assert any("Invalid phone number" in r.message for r in caplog.records)
+
+    @pytest.mark.asyncio
+    async def test_network_error_logs_warning(self, caplog):
+        import httpx
+
+        ch = _make_channel()
+        ch._http = AsyncMock()
+        ch._http.post = AsyncMock(side_effect=httpx.ConnectError("refused"))
+
+        with caplog.at_level(logging.WARNING, logger="channels.whatsapp"):
+            await ch._send_text("+1234", "hello")  # should not raise
+
+        assert any("network" in r.message.lower() for r in caplog.records)
+
+
+# ── Fix 1: start_channel is async ──────────────────────────────────
+
+class TestStartChannelAsync:
+    @pytest.mark.asyncio
+    async def test_start_channel_whatsapp_can_be_awaited(self, tmp_path):
+        """start_channel must be awaitable (fixes asyncio.run crash in dashboard)."""
+        import os
+
+        from src.cli.channels import ChannelManager
+
+        async def dispatch_fn(agent, msg, **kwargs):
+            return "ok"
+
+        cfg = {"agents": {"alpha": {}}, "channels": {}}
+        manager = ChannelManager(cfg, dispatch_fn, {"alpha": {}})
+
+        # Mock WhatsAppChannel.start to avoid real HTTP setup
+        async def fake_start(self_inner):
+            pass
+
+        import src.channels.whatsapp as wa_mod
+        original_start = wa_mod.WhatsAppChannel.start
+
+        wa_mod.WhatsAppChannel.start = fake_start
+        # Patch MESH_AUTH_TOKEN to be absent so start() doesn't raise
+        old_env = os.environ.pop("MESH_AUTH_TOKEN", None)
+        try:
+            tokens = {
+                "access_token": "tok",
+                "phone_number_id": "phone123",
+                "verify_token": "vtoken",
+            }
+            # This must not raise "cannot be called from a running event loop"
+            routers = await manager.start_channel("whatsapp", tokens)
+            assert isinstance(routers, list)
+        finally:
+            wa_mod.WhatsAppChannel.start = original_start
+            if old_env is not None:
+                os.environ["MESH_AUTH_TOKEN"] = old_env
+
+
+# ── send_to_user ──────────────────────────────────────────────────
+
+class TestSendToUser:
+    @pytest.mark.asyncio
+    async def test_send_to_user_calls_send_text_for_each_chunk(self):
+        ch = _make_channel()
+        ch._http = AsyncMock()
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        ch._http.post = AsyncMock(return_value=mock_resp)
+
+        await ch.send_to_user("+1234", "hello world")
+        ch._http.post.assert_called_once()
+        payload = ch._http.post.call_args[1]["json"]
+        assert payload["to"] == "+1234"
+
+    @pytest.mark.asyncio
+    async def test_send_to_user_no_client_is_noop(self):
+        ch = _make_channel()
+        ch._http = None
+        await ch.send_to_user("+1234", "hello")  # should not raise


### PR DESCRIPTION
## Summary

Fixes all four bugs reported in #714 plus several review-pass hardenings.

1. **`asyncio.run()` crash in dynamic WhatsApp connect** — `ChannelManager.start_channel` is now `async def` and the WhatsApp branch `await`s `ch.start()` directly. CLI boot (`start_all`) stays sync.
2. **SPA catch-all shadowing `/channels/whatsapp/webhook`** — added `"channels/"` to the exclusion prefix tuple in `spa_catchall()`.
3. **Silent `_send_text` failures** — now logs WARNING with status + body on any non-2xx and a separate `httpx.HTTPError` branch for network failures.
4. **Hand-off replies never reached channel users** — threaded an `origin = {"channel", "user"}` through the whole dispatch chain via a `current_origin` contextvar + `X-Origin` HTTP header: channel → lane → agent `/chat` → `hand_off` → `wake_agent` → target's lane. When the target's task completes with `auto_notify=True`, the lane worker forwards the result to exactly that user via a new `Channel.send_to_user` method.

### Extras caught during review

- **WhatsApp cross-loop `httpx.AsyncClient`** — reproduced "Event loop is closed" with a minimal smoke test; replaced with a per-loop client cache using `weakref.WeakKeyDictionary` keyed on loop objects (id() is unsafe — CPython reuses loop addresses across successive `asyncio.run()` calls).
- **Cross-loop send dispatch** — Telegram/Discord/Slack each run on their own event loop, so `_handle_notify_origin` hops via `run_coroutine_threadsafe` onto `ch._channel_loop` when present.
- **Slack composite thread keys** — `_get_user_key` produces `"U123:thread_ts"` which `chat_postMessage(channel=...)` rejects; `send_to_user` now splits the composite into `channel` + `thread_ts` kwargs.
- **Strong reference to auto-notify forward tasks** — `asyncio.create_task` can be GC'd mid-flight per Python docs; stored in `LaneManager._forward_tasks` set with `add_done_callback(discard)`.
- **30s timeout on auto-notify** via `asyncio.wait_for`.
- **`parse_origin_header` length caps** — 512-byte raw header, 32-byte channel, 128-byte user.
- **Removed `Channel.dispatch` TypeError fallback** — masked real errors from `dispatch_fn` bodies; updated test stubs to accept `**_kwargs` instead.
- **`X-Trace-Id` header** now also propagates to the agent container (bonus fix — was only recorded in the host trace store before).

### Architecture notes

- Origin propagates through chained hand-offs (A → B → C) because each hop re-sets `current_origin` from the incoming `X-Origin` header.
- Direct dispatches from a channel use `auto_notify=False` (the channel is already awaiting the future), so the forward path never duplicates the direct-return path.
- If an agent ALSO calls `notify_user()` explicitly, the user may see two messages. Documented limitation; erring toward "user sees the answer".
- Task-mode (`execute_task`) intentionally does not propagate origin — tasks are autonomous (cron, heartbeat) and have no originating channel user.

## Test plan

- [x] `ruff check src/ tests/` — clean
- [x] Full non-e2e pytest (`pytest tests/ --ignore=tests/test_e2e*`) — **3139 passed**, 28 skipped, 1 pre-existing unrelated failure (`test_version_flag` — package not pip-installed in worktree, identical on main)
- [x] Cross-loop smoke test — confirmed `WeakKeyDictionary` auto-evicts the dead-loop entry after GC, new loops get fresh `AsyncClient` instances
- [x] 20 new unit tests across `test_whatsapp.py`, `test_slack.py`, `test_channels.py`, `test_lanes.py`, `test_coordination.py`, `test_agent_server.py`, `test_integration.py`, `test_dashboard.py` covering every new code path (origin header parse, `/mesh/wake` header propagation, `_handle_notify_origin` routing, Slack composite-key split, auto-notify guard conditions, WhatsApp error logging, dynamic `start_channel` async path, SPA catch-all 404)
- [ ] Real-world smoke: report author @svallejos offered to try it against his family self-hosted WhatsApp setup

Closes #714