### PR TITLE
Add dashboard reset button and agent request_reset tool

### DIFF
--- a/src/agent/builtins/reset_tool.py
+++ b/src/agent/builtins/reset_tool.py
@@ -1,0 +1,58 @@
+"""Reset request tool for agents.
+
+Allows an agent to request a full system reset from the user.
+The actual reset is performed through the dashboard after user
+confirmation — the agent cannot reset the system directly.
+"""
+
+from __future__ import annotations
+
+from src.agent.skills import skill
+from src.shared.utils import setup_logging
+
+logger = setup_logging("agent.reset_tool")
+
+
+@skill(
+    name="request_reset",
+    description=(
+        "Request a full system reset from the user. This sends a notification "
+        "to the dashboard where the user can confirm or dismiss the request. "
+        "A reset wipes all agent configs, projects, skills, memory, and runtime "
+        "data. Use this only when the system is in a fundamentally broken state "
+        "that cannot be fixed otherwise."
+    ),
+    parameters={
+        "reason": {
+            "type": "string",
+            "description": "Explain why a system reset is needed",
+        },
+    },
+)
+async def request_reset(
+    reason: str,
+    *,
+    mesh_client=None,
+    **_kw,
+) -> dict:
+    """Request a system reset from the user via the dashboard."""
+    if not mesh_client:
+        return {"error": "Reset tool requires mesh connectivity"}
+
+    if not reason or not reason.strip():
+        return {"error": "reason is required — explain why a reset is needed"}
+
+    try:
+        await mesh_client.request_reset_from_user(reason=reason.strip())
+    except Exception as e:
+        logger.warning("Failed to send reset request: %s", e)
+        return {"error": f"Failed to send reset request: {e}"}
+
+    return {
+        "requested": True,
+        "message": (
+            "Reset request sent to the user. They will see a confirmation "
+            "prompt in the dashboard. The system will only reset if the user "
+            "explicitly confirms."
+        ),
+    }

--- a/src/agent/mesh_client.py
+++ b/src/agent/mesh_client.py
@@ -442,6 +442,17 @@ class MeshClient:
         response.raise_for_status()
         return response.json()
 
+    async def request_reset_from_user(self, reason: str) -> dict:
+        """Emit a system reset request event to the dashboard."""
+        client = await self._get_client()
+        response = await client.post(
+            f"{self.mesh_url}/mesh/reset-request",
+            json={"agent_id": self.agent_id, "reason": reason},
+            headers=self._trace_headers(),
+        )
+        response.raise_for_status()
+        return response.json()
+
     async def request_browser_login(
         self, url: str, service: str, description: str,
         target_agent_id: str | None = None,

--- a/src/dashboard/server.py
+++ b/src/dashboard/server.py
@@ -3237,6 +3237,78 @@ def create_dashboard_router(
 
         return {"restarted": results}
 
+    # ── System reset ─────────────────────────────────────────────
+
+    @api_router.post("/api/system/reset")
+    async def api_system_reset() -> dict:
+        """Wipe all state: config, data, agent skills, Docker volumes.
+
+        Mirrors the CLI ``openlegion reset`` command.  Stops all agents
+        first, then removes config/, data/, non-underscore skill dirs,
+        and Docker volumes named ``openlegion_*``.
+        """
+        import asyncio as _asyncio
+        from src.host.runtime import DockerBackend
+
+        root = Path.cwd()
+
+        # 1. Stop all agents
+        if runtime is not None and isinstance(runtime, DockerBackend):
+            loop = _asyncio.get_running_loop()
+            for agent_id in list(agent_registry.keys()):
+                try:
+                    await loop.run_in_executor(None, runtime.stop_agent, agent_id)
+                except Exception as e:
+                    logger.warning("Failed to stop agent '%s': %s", agent_id, e)
+            # Stop browser service
+            try:
+                await loop.run_in_executor(None, runtime.stop_browser_service)
+            except Exception as e:
+                logger.debug("Browser stop: %s", e)
+
+        removed = []
+
+        # 2. Remove config/
+        config_dir = root / "config"
+        if config_dir.is_dir():
+            shutil.rmtree(config_dir)
+            removed.append("config/")
+
+        # 3. Remove data/
+        data_dir = root / "data"
+        if data_dir.is_dir():
+            shutil.rmtree(data_dir)
+            removed.append("data/")
+
+        # 4. Remove agent skills (keep _marketplace, _* prefixed dirs, and files)
+        skills_dir = root / "skills"
+        if skills_dir.is_dir():
+            for entry in skills_dir.iterdir():
+                if entry.name.startswith("_") or entry.is_file():
+                    continue
+                shutil.rmtree(entry)
+            removed.append("skills/")
+
+        # 5. Remove Docker volumes
+        volumes_removed = 0
+        try:
+            import docker as _docker
+            dclient = _docker.from_env()
+            volumes = dclient.volumes.list(filters={"name": "openlegion_"})
+            for vol in volumes:
+                vol.remove(force=True)
+                volumes_removed += 1
+        except Exception:
+            pass
+
+        if volumes_removed:
+            removed.append(f"{volumes_removed} Docker volume(s)")
+
+        # Clear in-memory registries
+        agent_registry.clear()
+
+        return {"status": "reset_complete", "removed": removed}
+
     # ── Storage ────────────────────────────────────────────────
 
     _STORAGE_SKIP_DIRS = {"src", ".git", ".venv", "venv", "node_modules", ".claude"}

--- a/src/dashboard/static/js/app.js
+++ b/src/dashboard/static/js/app.js
@@ -81,6 +81,7 @@ function dashboard() {
       'blackboard_write', 'health_change', 'notification', 'workspace_updated',
       'heartbeat_complete', 'cron_change', 'credit_exhausted', 'credential_request',
       'browser_login_request', 'browser_login_completed', 'browser_login_cancelled',
+      'reset_request',
     ],
 
     // Agent detail
@@ -1536,6 +1537,45 @@ function dashboard() {
           );
           if (!opDup) {
             this.chatHistories['operator'].push({ ...credCard, _from_agent: agent });
+            if (this.activeTab === 'chat') {
+              this.$nextTick(() => this._scrollChat('operator'));
+            }
+          }
+        }
+      }
+
+      // Surface reset requests as confirmation cards in chat.
+      if (evt.type === 'reset_request' && agent && evt.data && evt.data.reason) {
+        const evtTs = this._normalizeEventTs(evt);
+        const resetCard = {
+          role: 'reset_request',
+          content: evt.data.reason || '',
+          agent_id: evt.data.agent_id || agent,
+          dismissed: false,
+          resetDone: false,
+          ts: evtTs,
+        };
+        // Show in the requesting agent's chat
+        if (!this.chatHistories[agent]) this.chatHistories[agent] = [];
+        const isDup = this.chatHistories[agent].some(m =>
+          m.role === 'reset_request' && Math.abs((m.ts || 0) - evtTs) < 5000
+        );
+        if (!isDup) {
+          this.chatHistories[agent].push(resetCard);
+          if (this.activeChatId === agent) {
+            this.$nextTick(() => this._scrollChat(agent));
+          } else {
+            this.chatUnread = { ...this.chatUnread, [agent]: (this.chatUnread[agent] || 0) + 1 };
+          }
+        }
+        // Also surface in operator chat
+        if (agent !== 'operator') {
+          if (!this.chatHistories['operator']) this.chatHistories['operator'] = [];
+          const opDup = this.chatHistories['operator'].some(m =>
+            m.role === 'reset_request' && Math.abs((m.ts || 0) - evtTs) < 5000
+          );
+          if (!opDup) {
+            this.chatHistories['operator'].push({ ...resetCard, _from_agent: agent });
             if (this.activeTab === 'chat') {
               this.$nextTick(() => this._scrollChat('operator'));
             }
@@ -3811,6 +3851,28 @@ function dashboard() {
           }
         } catch (e) { this.showToast(`Error: ${e.message}`); }
         this._restartingAll = false;
+      }, true);
+    },
+
+    resetSystem() {
+      this.showConfirm('Reset System', 'This will stop all agents and permanently delete all configs, projects, skills, memory, and runtime data. Your .env file will be preserved. This cannot be undone.', async () => {
+        this.showToast('Resetting system...');
+        try {
+          const resp = await fetch(`${window.__config.apiBase}/system/reset`, {
+            method: 'POST',
+            headers: { 'X-Requested-With': 'XMLHttpRequest' },
+          });
+          if (resp.ok) {
+            this.showToast('System reset complete. Reload the page to start fresh.');
+            // Clear local state
+            this.agents = [];
+            this.chatHistories = {};
+            this.events = [];
+          } else {
+            const err = await resp.json().catch(() => ({}));
+            this.showToast(`Error: ${err.detail || 'Reset failed'}`);
+          }
+        } catch (e) { this.showToast(`Error: ${e.message}`); }
       }, true);
     },
 

--- a/src/dashboard/templates/index.html
+++ b/src/dashboard/templates/index.html
@@ -389,6 +389,46 @@
                         </div>
                       </div>
                     </template>
+                    <!-- Reset request card -->
+                    <template x-if="msg.role === 'reset_request'">
+                      <div class="flex justify-start gap-2.5">
+                        <div class="shrink-0 mt-1">
+                          <img src="/dashboard/static/avatars/operator.png" alt="Operator" class="w-6 h-6 rounded-full">
+                        </div>
+                        <div class="max-w-[80%] min-w-0">
+                          <div class="px-4 py-3 rounded-2xl rounded-bl-md bg-gray-800 border border-red-600/30">
+                            <div class="flex items-center gap-2 mb-2">
+                              <svg class="w-4 h-4 text-red-400 shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="2">
+                                <path stroke-linecap="round" stroke-linejoin="round" d="M12 9v3.75m-9.303 3.376c-.866 1.5.217 3.374 1.948 3.374h14.71c1.73 0 2.813-1.874 1.948-3.374L13.949 3.378c-.866-1.5-3.032-1.5-3.898 0L2.697 16.126ZM12 15.75h.007v.008H12v-.008Z"/>
+                              </svg>
+                              <span class="text-xs font-medium text-red-300" x-text="'Reset requested by ' + (msg._from_agent || msg.agent_id || 'agent')"></span>
+                            </div>
+                            <p class="text-xs text-gray-300 mb-3" x-text="msg.content"></p>
+                            <template x-if="!msg.dismissed && !msg.resetDone">
+                              <div class="flex gap-2">
+                                <button @click="resetSystem()" x-data="{ resetting: false }"
+                                  class="px-3 py-1.5 rounded-lg text-xs font-medium bg-red-600/20 text-red-400 hover:bg-red-600/30 border border-red-600/30 transition-colors">
+                                  Reset System
+                                </button>
+                                <button @click="msg.dismissed = true"
+                                  class="px-3 py-1.5 rounded-lg text-xs font-medium bg-gray-700 hover:bg-gray-600 text-gray-300 transition-colors">
+                                  Dismiss
+                                </button>
+                              </div>
+                            </template>
+                            <div x-show="msg.dismissed && !msg.resetDone" class="text-xs text-gray-500">
+                              Reset request dismissed.
+                            </div>
+                            <div x-show="msg.resetDone" class="flex items-center gap-1.5 text-xs text-emerald-400">
+                              <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="2">
+                                <path stroke-linecap="round" stroke-linejoin="round" d="M5 13l4 4L19 7"/>
+                              </svg>
+                              <span>System has been reset.</span>
+                            </div>
+                          </div>
+                        </div>
+                      </div>
+                    </template>
                     <!-- Browser login request card -->
                     <template x-if="msg.role === 'browser_login_request'">
                       <div class="flex justify-start gap-2.5">
@@ -5115,6 +5155,22 @@
             </button>
           </div>
 
+          <!-- ── Danger Zone ── -->
+          <div class="bg-gray-900 border border-red-900/50 rounded-lg p-5 mt-6">
+            <h3 class="text-sm font-medium text-red-400 mb-1">Danger Zone</h3>
+            <p class="text-[10px] text-gray-500 mb-4">Irreversible actions that affect the entire system.</p>
+            <div class="flex items-center justify-between">
+              <div>
+                <p class="text-xs text-gray-300 font-medium">Reset System</p>
+                <p class="text-[10px] text-gray-500 mt-0.5">Stop all agents and permanently delete all configs, projects, skills, memory, and data. Your .env file is preserved.</p>
+              </div>
+              <button @click="resetSystem()"
+                class="px-4 py-2 text-xs font-medium rounded-lg transition-colors bg-red-600/20 text-red-400 hover:bg-red-600/30 border border-red-600/30">
+                Reset System
+              </button>
+            </div>
+          </div>
+
         </div><!-- /settings sub-tab -->
 
       </div>
@@ -5604,6 +5660,43 @@
                   </div>
                 </div>
               </template>
+              <!-- Reset request card -->
+              <template x-if="msg.role === 'reset_request'">
+                <div class="flex justify-start">
+                  <div class="max-w-[80%] min-w-0">
+                    <div class="px-4 py-3 rounded-2xl rounded-bl-md bg-gray-800 border border-red-600/30">
+                      <div class="flex items-center gap-2 mb-2">
+                        <svg class="w-4 h-4 text-red-400 shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="2">
+                          <path stroke-linecap="round" stroke-linejoin="round" d="M12 9v3.75m-9.303 3.376c-.866 1.5.217 3.374 1.948 3.374h14.71c1.73 0 2.813-1.874 1.948-3.374L13.949 3.378c-.866-1.5-3.032-1.5-3.898 0L2.697 16.126ZM12 15.75h.007v.008H12v-.008Z"/>
+                        </svg>
+                        <span class="text-xs font-medium text-red-300" x-text="'Reset requested by ' + (msg._from_agent || msg.agent_id || 'agent')"></span>
+                      </div>
+                      <p class="text-xs text-gray-300 mb-3" x-text="msg.content"></p>
+                      <template x-if="!msg.dismissed && !msg.resetDone">
+                        <div class="flex gap-2">
+                          <button @click="resetSystem()"
+                            class="px-3 py-1.5 rounded-lg text-xs font-medium bg-red-600/20 text-red-400 hover:bg-red-600/30 border border-red-600/30 transition-colors">
+                            Reset System
+                          </button>
+                          <button @click="msg.dismissed = true"
+                            class="px-3 py-1.5 rounded-lg text-xs font-medium bg-gray-700 hover:bg-gray-600 text-gray-300 transition-colors">
+                            Dismiss
+                          </button>
+                        </div>
+                      </template>
+                      <div x-show="msg.dismissed && !msg.resetDone" class="text-xs text-gray-500">
+                        Reset request dismissed.
+                      </div>
+                      <div x-show="msg.resetDone" class="flex items-center gap-1.5 text-xs text-emerald-400">
+                        <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="2">
+                          <path stroke-linecap="round" stroke-linejoin="round" d="M5 13l4 4L19 7"/>
+                        </svg>
+                        <span>System has been reset.</span>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </template>
               <!-- Browser login request card -->
               <template x-if="msg.role === 'browser_login_request'">
                 <div class="flex justify-start">
@@ -5697,7 +5790,7 @@
                 </div>
               </template>
               <!-- Chat bubble -->
-              <template x-if="msg.role !== 'system' && msg.role !== 'credential_request' && msg.role !== 'credit_exhausted' && msg.role !== 'browser_login_request'">
+              <template x-if="msg.role !== 'system' && msg.role !== 'credential_request' && msg.role !== 'credit_exhausted' && msg.role !== 'browser_login_request' && msg.role !== 'reset_request'">
               <div :class="msg.role === 'user' ? 'flex justify-end' : 'flex justify-start'">
               <div class="max-w-[80%] px-3 py-2 rounded-2xl text-xs"
                 :class="{

--- a/src/host/server.py
+++ b/src/host/server.py
@@ -1109,6 +1109,30 @@ def create_mesh_app(
 
         return {"requested": True, "name": name}
 
+    @app.post("/mesh/reset-request")
+    async def reset_request(data: dict, request: Request) -> dict:
+        """Agent requests a full system reset from the user via dashboard UI.
+
+        Emits a ``reset_request`` event so the dashboard renders a
+        confirmation card.  The actual reset is triggered by the user
+        through the dashboard, not by the agent directly.
+        """
+        agent_id = _resolve_agent_id(data.get("agent_id", ""), request)
+        await _check_rate_limit("notify", agent_id)
+
+        reason = (data.get("reason") or "").strip()
+        if not reason:
+            raise HTTPException(400, "Reason is required")
+
+        if event_bus:
+            event_bus.emit(
+                "reset_request",
+                agent=agent_id,
+                data={"reason": reason[:500], "agent_id": agent_id},
+            )
+
+        return {"requested": True}
+
     @app.post("/mesh/browser-login-request")
     async def browser_login_request(data: dict, request: Request) -> dict:
         """Agent requests user login via browser VNC viewer in chat.


### PR DESCRIPTION
## Summary
- Adds a **Danger Zone** section to dashboard System > Settings with a "Reset System" button
- Adds `request_reset` agent tool that surfaces an interactive confirmation card in chat (same pattern as `request_credential`)
- Adds `POST /api/system/reset` dashboard endpoint and `POST /mesh/reset-request` mesh endpoint

## Details
The reset button on the settings page uses `showConfirm` for user confirmation before wiping config/, data/, agent skills, and Docker volumes (preserving .env).

Agents can call `request_reset(reason="...")` to request a reset from the user. This emits a `reset_request` event that renders as a red warning card in chat with "Reset System" and "Dismiss" buttons. The agent cannot execute the reset directly — only the user can confirm.

## Files changed
- `src/dashboard/templates/index.html` — danger zone card + chat card templates (both chat views)
- `src/dashboard/server.py` — `POST /api/system/reset` endpoint
- `src/dashboard/static/js/app.js` — `resetSystem()`, event handling, state
- `src/host/server.py` — `POST /mesh/reset-request` mesh endpoint
- `src/agent/mesh_client.py` — `request_reset_from_user()` method
- `src/agent/builtins/reset_tool.py` — new `request_reset` skill

## Test plan
- [x] Open dashboard > System > Settings, verify Danger Zone section appears at bottom
- [x] Click Reset System, verify confirmation modal appears with destructive styling
- [x] Cancel the confirmation, verify nothing happens
- [x] Verify the `request_reset` tool is available in agent tool list
- [x] Test agent calling `request_reset` — verify chat card appears with reason text
- [x] Click Dismiss on chat card — verify it shows dismissed state
- [x] Click Reset System on chat card — verify confirmation modal, then reset executes
- [x] Run existing test suite to verify no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)