### PR TITLE
Eliminate CDP detection vectors from browser automation

### DIFF
--- a/src/browser/service.py
+++ b/src/browser/service.py
@@ -744,11 +744,13 @@ class BrowserManager:
             try:
                 title = await inst.page.title()
                 current_url = inst.page.url
-                try:
-                    _a11y = await inst.page.accessibility.snapshot()
-                    body_text = _extract_text_from_a11y(_a11y)
-                except Exception:
-                    body_text = ""
+                body_text = ""
+                if not inst._js_snapshot_mode:
+                    try:
+                        _a11y = await inst.page.accessibility.snapshot()
+                        body_text = _extract_text_from_a11y(_a11y)
+                    except Exception:
+                        pass
                 result = {
                     "success": True,
                     "data": {

--- a/src/browser/service.py
+++ b/src/browser/service.py
@@ -244,6 +244,40 @@ _JS_A11Y_TREE = r"""(rootEl) => {
 }"""
 
 
+def _extract_text_from_a11y(tree: dict | None, max_chars: int = 5000) -> str:
+    """Extract readable text from an accessibility snapshot tree.
+
+    Walks leaf nodes to avoid duplicating text that parent containers
+    aggregate from their children.  Used by ``navigate()`` as a
+    stealth-safe alternative to ``page.evaluate("document.body.innerText")``
+    — the a11y API reads from Firefox's internal accessibility service
+    with zero JavaScript execution in the page context.
+    """
+    if not tree:
+        return ""
+    parts: list[str] = []
+    total = 0
+
+    def _collect(node: dict) -> bool:
+        nonlocal total
+        if total >= max_chars:
+            return False
+        children = node.get("children")
+        if children:
+            for child in children:
+                if not _collect(child):
+                    return False
+        else:
+            name = (node.get("name") or "").strip()
+            if name:
+                parts.append(name)
+                total += len(name) + 1
+        return total < max_chars
+
+    _collect(tree)
+    return " ".join(parts)[:max_chars]
+
+
 class CamoufoxInstance:
     """Wrapper around a single Camoufox browser for one agent."""
 
@@ -258,6 +292,7 @@ class CamoufoxInstance:
         self.dialog_detected: bool = False  # True when a modal was found (even if scoping failed)
         self.lock = asyncio.Lock()  # serialize page operations per instance
         self.x11_wid: int | None = None  # X11 window ID for targeted focus
+        self._js_snapshot_mode: bool = False  # True after page.accessibility permanently fails
 
     def touch(self):
         self.last_activity = time.time()
@@ -284,7 +319,6 @@ class BrowserManager:
         self._lock = asyncio.Lock()
         self._cleanup_task: asyncio.Task | None = None
         self._playwright = None
-        self._js_snapshot_mode: bool = False  # True after page.accessibility fails
         self._user_focused_agent: str | None = None  # set by explicit focus() call
         self.redactor = CredentialRedactor()
         self._proxy_configs: dict[str, dict | None] = {}
@@ -710,7 +744,11 @@ class BrowserManager:
             try:
                 title = await inst.page.title()
                 current_url = inst.page.url
-                body_text = await inst.page.evaluate("() => document.body?.innerText?.slice(0, 5000) || ''")
+                try:
+                    _a11y = await inst.page.accessibility.snapshot()
+                    body_text = _extract_text_from_a11y(_a11y)
+                except Exception:
+                    body_text = ""
                 result = {
                     "success": True,
                     "data": {
@@ -733,26 +771,39 @@ class BrowserManager:
     async def _build_a11y_tree(self, inst: CamoufoxInstance, root=None):
         """Get accessibility tree, falling back to JS-based DOM walk.
 
-        Playwright's ``page.accessibility.snapshot()`` may not exist in
-        Camoufox (modified Firefox bundles its own Playwright build).
-        On first ``AttributeError``, switches permanently to a JS-based
-        tree builder that uses standard DOM APIs (``getAttribute``,
-        ``getComputedStyle``) to produce the same ``{role, name, children}``
-        tree structure the rest of the snapshot pipeline expects.
+        Playwright's ``page.accessibility.snapshot()`` uses Firefox's native
+        ``nsIAccessibilityService`` — a browser-internal API with zero
+        JavaScript execution in the page context.  This makes it invisible
+        to anti-bot systems that hook DOM APIs via Proxy.
+
+        If the API is absent (``AttributeError``), permanently switches to
+        a JS-based tree builder per-instance.  Transient failures get one
+        retry before falling through to JS.
         """
-        if not getattr(self, "_js_snapshot_mode", False):
-            try:
-                if root:
-                    return await inst.page.accessibility.snapshot(root=root)
-                return await inst.page.accessibility.snapshot()
-            except AttributeError:
-                logger.warning(
-                    "page.accessibility not available — "
-                    "switching to JS-based accessibility tree"
-                )
-                self._js_snapshot_mode = True
-            except Exception:
-                pass  # Other snapshot failures — fall through to JS
+        if not inst._js_snapshot_mode:
+            for attempt in range(2):
+                try:
+                    if root:
+                        return await inst.page.accessibility.snapshot(root=root)
+                    return await inst.page.accessibility.snapshot()
+                except AttributeError:
+                    logger.warning(
+                        "page.accessibility not available for %s — "
+                        "switching to JS-based accessibility tree",
+                        inst.agent_id,
+                    )
+                    inst._js_snapshot_mode = True
+                    break
+                except Exception:
+                    if attempt == 0:
+                        await asyncio.sleep(0.15)
+                        continue
+                    logger.warning(
+                        "page.accessibility.snapshot() failed after retry "
+                        "for %s — falling back to JS tree",
+                        inst.agent_id,
+                    )
+                    break
 
         # JS fallback: walk DOM to build equivalent tree
         try:
@@ -1305,6 +1356,29 @@ class BrowserManager:
         if result.returncode != 0:
             raise RuntimeError(f"xdotool key {key!r} failed (rc={result.returncode})")
 
+    async def _x11_scroll_notch(self, inst: CamoufoxInstance, button: str) -> None:
+        """Send a single scroll notch via xdotool button 4 (up) or 5 (down).
+
+        X11 button 4/5 events are processed by Firefox identically to
+        physical mouse wheel input, producing ``WheelEvent`` with
+        ``deltaMode=DOM_DELTA_LINE`` — matching real hardware.  Playwright's
+        ``page.mouse.wheel()`` instead uses ``nsIDOMWindowUtils.sendWheelEvent``
+        with ``deltaMode=DOM_DELTA_PIXEL``, which is a detectable fingerprint.
+        """
+        wid = inst.x11_wid
+        if not wid:
+            raise RuntimeError("No X11 window ID — cannot use xdotool scroll")
+        loop = asyncio.get_running_loop()
+        result = await loop.run_in_executor(
+            None,
+            lambda: subprocess.run(
+                ["xdotool", "click", "--clearmodifiers", "--window", str(wid), button],
+                capture_output=True, timeout=3,
+            ),
+        )
+        if result.returncode != 0:
+            raise RuntimeError(f"xdotool scroll button {button} failed (rc={result.returncode})")
+
     @staticmethod
     def _playwright_key_to_xdotool(key: str) -> str:
         """Convert a Playwright key name to xdotool key name."""
@@ -1758,27 +1832,49 @@ class BrowserManager:
                 amount = min(amount, _MAX_SCROLL_PX)
 
                 sign = -1 if direction == "up" else 1
-                scrolled = 0
-                while scrolled < amount:
-                    remaining = amount - scrolled
-                    # Momentum ramp using actual scroll progress — smaller
-                    # steps at start/end, full in middle.  Tracks real
-                    # position rather than estimated step count so the ramp
-                    # adapts to variable-size increments.
-                    progress = scrolled / amount
-                    ramp = scroll_ramp(progress)
-                    step = max(40, int(scroll_increment() * ramp))
-                    step = min(step, remaining)
-                    delta = step * sign
-                    # Use mouse.wheel() to dispatch real WheelEvent
-                    # (isTrusted=true). JS window.scrollBy() only fires
-                    # scroll events without wheel events — antibot systems
-                    # check for the presence of wheel events in the stream.
-                    await inst.page.mouse.wheel(0, delta)
-                    scrolled += step
-                    if scrolled < amount:
-                        # Pause varies with momentum — shorter during fast cruise
-                        await asyncio.sleep(scroll_pause() / max(0.5, ramp))
+                _use_x11 = bool(inst.x11_wid) and self._is_x11_site(inst)
+
+                if _use_x11:
+                    # X11 scroll: each button 4/5 click ≈ 3 lines ≈ 53 px.
+                    # Produces real WheelEvent with deltaMode=DOM_DELTA_LINE,
+                    # matching physical mouse hardware.
+                    _PX_PER_NOTCH = 53
+                    button = "4" if direction == "up" else "5"
+                    total_notches = max(1, round(amount / _PX_PER_NOTCH))
+                    scrolled = 0
+                    for i in range(total_notches):
+                        progress = i / max(1, total_notches)
+                        ramp = scroll_ramp(progress)
+                        try:
+                            await self._x11_scroll_notch(inst, button)
+                        except Exception as e:
+                            logger.warning(
+                                "X11 scroll failed for '%s', falling back to CDP: %s",
+                                agent_id, e,
+                            )
+                            # Fall back to CDP for remaining scroll
+                            remaining_px = (total_notches - i) * _PX_PER_NOTCH
+                            await inst.page.mouse.wheel(0, remaining_px * sign)
+                            scrolled += remaining_px
+                            break
+                        scrolled += _PX_PER_NOTCH
+                        if i < total_notches - 1:
+                            await asyncio.sleep(scroll_pause() / max(0.5, ramp))
+                    scrolled = min(scrolled, amount)
+                else:
+                    # CDP fallback when X11 unavailable
+                    scrolled = 0
+                    while scrolled < amount:
+                        remaining = amount - scrolled
+                        progress = scrolled / amount if amount > 0 else 1.0
+                        ramp = scroll_ramp(progress)
+                        step = max(40, int(scroll_increment() * ramp))
+                        step = min(step, remaining)
+                        delta = step * sign
+                        await inst.page.mouse.wheel(0, delta)
+                        scrolled += step
+                        if scrolled < amount:
+                            await asyncio.sleep(scroll_pause() / max(0.5, ramp))
 
                 return {
                     "success": True,

--- a/src/browser/service.py
+++ b/src/browser/service.py
@@ -260,8 +260,8 @@ def _extract_text_from_a11y(tree: dict | None, max_chars: int = 5000) -> str:
 
     def _collect(node: dict) -> bool:
         nonlocal total
-        if total >= max_chars:
-            return False
+        if not isinstance(node, dict) or total >= max_chars:
+            return total < max_chars
         children = node.get("children")
         if children:
             for child in children:
@@ -749,6 +749,8 @@ class BrowserManager:
                     try:
                         _a11y = await inst.page.accessibility.snapshot()
                         body_text = _extract_text_from_a11y(_a11y)
+                    except AttributeError:
+                        inst._js_snapshot_mode = True
                     except Exception:
                         pass
                 result = {
@@ -1854,8 +1856,8 @@ class BrowserManager:
                                 "X11 scroll failed for '%s', falling back to CDP: %s",
                                 agent_id, e,
                             )
-                            # Fall back to CDP for remaining scroll
-                            remaining_px = (total_notches - i) * _PX_PER_NOTCH
+                            # Fall back to CDP for actual remaining distance
+                            remaining_px = max(0, amount - scrolled)
                             await inst.page.mouse.wheel(0, remaining_px * sign)
                             scrolled += remaining_px
                             break

--- a/tests/test_browser_service.py
+++ b/tests/test_browser_service.py
@@ -1789,6 +1789,128 @@ class TestNavigateRetry:
         assert mock_page.goto.await_count == 1
 
 
+class TestExtractTextFromA11y:
+    """Tests for _extract_text_from_a11y helper used by navigate()."""
+
+    def test_none_returns_empty(self):
+        from src.browser.service import _extract_text_from_a11y
+        assert _extract_text_from_a11y(None) == ""
+
+    def test_empty_dict_returns_empty(self):
+        from src.browser.service import _extract_text_from_a11y
+        assert _extract_text_from_a11y({}) == ""
+
+    def test_leaf_node_extracts_name(self):
+        from src.browser.service import _extract_text_from_a11y
+        tree = {"role": "text", "name": "Hello world"}
+        assert _extract_text_from_a11y(tree) == "Hello world"
+
+    def test_nested_children_collects_leaves(self):
+        from src.browser.service import _extract_text_from_a11y
+        tree = {
+            "role": "WebArea", "name": "Page Title",
+            "children": [
+                {"role": "heading", "name": "Welcome", "children": [
+                    {"role": "text", "name": "Welcome"},
+                ]},
+                {"role": "paragraph", "name": "Some text", "children": [
+                    {"role": "text", "name": "Some text"},
+                ]},
+                {"role": "button", "name": "Click me"},
+            ],
+        }
+        result = _extract_text_from_a11y(tree)
+        assert "Welcome" in result
+        assert "Some text" in result
+        assert "Click me" in result
+
+    def test_no_duplicate_from_parent_and_child(self):
+        from src.browser.service import _extract_text_from_a11y
+        tree = {
+            "role": "WebArea", "name": "Page",
+            "children": [
+                {"role": "heading", "name": "Title", "children": [
+                    {"role": "text", "name": "Title"},
+                ]},
+            ],
+        }
+        result = _extract_text_from_a11y(tree)
+        # Should contain "Title" once, not twice
+        assert result.count("Title") == 1
+
+    def test_truncation_at_max_chars(self):
+        from src.browser.service import _extract_text_from_a11y
+        tree = {
+            "role": "WebArea", "name": "",
+            "children": [{"role": "text", "name": "x" * 100}
+                         for _ in range(100)],
+        }
+        result = _extract_text_from_a11y(tree, max_chars=500)
+        assert len(result) <= 500
+
+    def test_empty_name_nodes_skipped(self):
+        from src.browser.service import _extract_text_from_a11y
+        tree = {
+            "role": "WebArea", "name": "",
+            "children": [
+                {"role": "generic", "name": ""},
+                {"role": "button", "name": "OK"},
+            ],
+        }
+        assert _extract_text_from_a11y(tree) == "OK"
+
+    @pytest.mark.asyncio
+    async def test_navigate_body_text_from_a11y(self):
+        """navigate() should extract body text via a11y snapshot, not page.evaluate."""
+        from src.browser.service import BrowserManager, CamoufoxInstance
+
+        mgr = BrowserManager(profiles_dir="/tmp/test_profiles")
+        mock_page = AsyncMock()
+        mock_page.goto = AsyncMock()
+        mock_page.title = AsyncMock(return_value="Example")
+        mock_page.url = "https://example.com"
+        mock_page.accessibility.snapshot = AsyncMock(return_value={
+            "role": "WebArea", "name": "Example",
+            "children": [
+                {"role": "heading", "name": "Hello"},
+                {"role": "text", "name": "World"},
+            ],
+        })
+        inst = CamoufoxInstance("a1", MagicMock(), MagicMock(), mock_page)
+        mgr._instances["a1"] = inst
+
+        with patch("src.browser.service.asyncio.sleep"):
+            result = await mgr.navigate("a1", "https://example.com", wait_ms=0)
+
+        assert result["success"] is True
+        assert "Hello" in result["data"]["body"]
+        assert "World" in result["data"]["body"]
+        # page.evaluate should NOT have been called for body text
+        mock_page.evaluate.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_navigate_skips_a11y_in_js_mode(self):
+        """When _js_snapshot_mode is True, navigate skips a11y call."""
+        from src.browser.service import BrowserManager, CamoufoxInstance
+
+        mgr = BrowserManager(profiles_dir="/tmp/test_profiles")
+        mock_page = AsyncMock()
+        mock_page.goto = AsyncMock()
+        mock_page.title = AsyncMock(return_value="Example")
+        mock_page.url = "https://example.com"
+        inst = CamoufoxInstance("a1", MagicMock(), MagicMock(), mock_page)
+        inst._js_snapshot_mode = True
+        mgr._instances["a1"] = inst
+
+        with patch("src.browser.service.asyncio.sleep"):
+            result = await mgr.navigate("a1", "https://example.com", wait_ms=0)
+
+        assert result["success"] is True
+        assert result["data"]["body"] == ""
+        # a11y snapshot should NOT have been called
+        mock_page.accessibility.snapshot.assert_not_called()
+
+
 class TestLandmarkAnnotations:
     """Tests for structural landmark context in snapshot output."""
 

--- a/tests/test_browser_service.py
+++ b/tests/test_browser_service.py
@@ -1518,6 +1518,92 @@ class TestScroll:
         assert "page closed" in result["error"]
 
 
+class TestX11Scroll:
+    """Tests for X11-based scroll via xdotool button 4/5."""
+
+    @pytest.mark.asyncio
+    async def test_x11_scroll_uses_xdotool(self):
+        """When x11_wid is set, scroll uses xdotool button 5 for down."""
+        from src.browser.service import BrowserManager, CamoufoxInstance
+        mgr = BrowserManager(profiles_dir="/tmp/test_profiles")
+
+        mock_page = AsyncMock()
+        mock_page.viewport_size = {"width": 1280, "height": 720}
+        inst = CamoufoxInstance("a1", MagicMock(), MagicMock(), mock_page)
+        inst.x11_wid = 12345
+        mgr._instances["a1"] = inst
+
+        with patch("src.browser.service.asyncio.sleep"), \
+             patch("src.browser.service.subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=0)
+            result = await mgr.scroll("a1", direction="down", amount=200)
+
+        assert result["success"] is True
+        # Should have called xdotool, not mouse.wheel
+        assert mock_run.call_count >= 1
+        # All calls should use button 5 (scroll down)
+        for call in mock_run.call_args_list:
+            args = call[0][0]
+            if "click" in args:
+                assert "5" in args
+
+    @pytest.mark.asyncio
+    async def test_x11_scroll_up_uses_button_4(self):
+        """Scroll up uses xdotool button 4."""
+        from src.browser.service import BrowserManager, CamoufoxInstance
+        mgr = BrowserManager(profiles_dir="/tmp/test_profiles")
+
+        mock_page = AsyncMock()
+        mock_page.viewport_size = {"width": 1280, "height": 720}
+        inst = CamoufoxInstance("a1", MagicMock(), MagicMock(), mock_page)
+        inst.x11_wid = 12345
+        mgr._instances["a1"] = inst
+
+        with patch("src.browser.service.asyncio.sleep"), \
+             patch("src.browser.service.subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=0)
+            result = await mgr.scroll("a1", direction="up", amount=100)
+
+        assert result["success"] is True
+        for call in mock_run.call_args_list:
+            args = call[0][0]
+            if "click" in args:
+                assert "4" in args
+
+    @pytest.mark.asyncio
+    async def test_x11_scroll_fallback_on_failure(self):
+        """When xdotool fails mid-scroll, remaining distance uses CDP."""
+        from src.browser.service import BrowserManager, CamoufoxInstance
+        mgr = BrowserManager(profiles_dir="/tmp/test_profiles")
+
+        mock_page = AsyncMock()
+        mock_page.viewport_size = {"width": 1280, "height": 720}
+        mock_page.mouse.wheel = AsyncMock()
+        inst = CamoufoxInstance("a1", MagicMock(), MagicMock(), mock_page)
+        inst.x11_wid = 12345
+        mgr._instances["a1"] = inst
+
+        call_count = 0
+
+        def fail_on_second(*args, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            result = MagicMock(returncode=0 if call_count == 1 else 1)
+            return result
+
+        with patch("src.browser.service.asyncio.sleep"), \
+             patch("src.browser.service.subprocess.run", side_effect=fail_on_second):
+            result = await mgr.scroll("a1", direction="down", amount=200)
+
+        assert result["success"] is True
+        # CDP fallback should have been called for remaining distance
+        mock_page.mouse.wheel.assert_called_once()
+        _, kwargs = mock_page.mouse.wheel.call_args
+        # Remaining should be amount - scrolled (200 - 53 = 147)
+        delta = mock_page.mouse.wheel.call_args[0][1]
+        assert 100 <= delta <= 200  # remaining px, positive for down
+
+
 class TestClickRandomDelay:
     """Verify click delay is not a fixed 0.3s."""
 
@@ -1855,6 +1941,20 @@ class TestExtractTextFromA11y:
             "children": [
                 {"role": "generic", "name": ""},
                 {"role": "button", "name": "OK"},
+            ],
+        }
+        assert _extract_text_from_a11y(tree) == "OK"
+
+    def test_malformed_children_handled(self):
+        """Non-dict children should be skipped without crashing."""
+        from src.browser.service import _extract_text_from_a11y
+        tree = {
+            "role": "WebArea", "name": "",
+            "children": [
+                None,
+                "stray string",
+                {"role": "button", "name": "OK"},
+                42,
             ],
         }
         assert _extract_text_from_a11y(tree) == "OK"
@@ -3733,6 +3833,38 @@ class TestJsA11yTreeFallback:
         assert refs["e0"]["name"] == "Submit"
         assert refs["e1"]["name"] == "Home"
         assert inst._js_snapshot_mode is True
+
+    @pytest.mark.asyncio
+    async def test_transient_failure_retries_then_falls_back(self):
+        """Non-AttributeError failures retry once, then fall back to JS."""
+        from src.browser.service import BrowserManager, CamoufoxInstance
+        mgr = BrowserManager(profiles_dir="/tmp/test_profiles")
+
+        mock_page = AsyncMock()
+        mock_page.accessibility = MagicMock()
+        mock_page.accessibility.snapshot = AsyncMock(
+            side_effect=RuntimeError("accessibility service unavailable")
+        )
+        js_tree = {
+            "role": "WebArea", "name": "Fallback",
+            "children": [{"role": "button", "name": "OK"}],
+        }
+        mock_page.evaluate = AsyncMock(return_value=js_tree)
+        mock_page.query_selector_all = AsyncMock(return_value=[])
+
+        inst = CamoufoxInstance("a1", MagicMock(), MagicMock(), mock_page)
+        mgr._instances["a1"] = inst
+
+        with patch("src.browser.service.asyncio.sleep"):
+            result = await mgr.snapshot("a1")
+
+        assert result["success"] is True
+        # Should have retried accessibility.snapshot twice (attempt 0 + 1)
+        assert mock_page.accessibility.snapshot.await_count == 2
+        # JS fallback should have been used
+        mock_page.evaluate.assert_called()
+        # Transient failure should NOT permanently set _js_snapshot_mode
+        assert inst._js_snapshot_mode is False
 
     @pytest.mark.asyncio
     async def test_js_mode_persists(self):

--- a/tests/test_browser_service.py
+++ b/tests/test_browser_service.py
@@ -1708,7 +1708,6 @@ class TestSnapshotAfter:
         from src.browser.service import BrowserManager, CamoufoxInstance
 
         mgr = BrowserManager(profiles_dir="/tmp/test_profiles")
-        mgr._js_snapshot_mode = True
 
         mock_page = AsyncMock()
         mock_page.click = AsyncMock()
@@ -1718,6 +1717,7 @@ class TestSnapshotAfter:
             "children": [{"role": "button", "name": "OK", "refId": "e0"}],
         })
         inst = CamoufoxInstance("a1", MagicMock(), MagicMock(), mock_page)
+        inst._js_snapshot_mode = True
         mgr._instances["a1"] = inst
 
         with patch("src.browser.service.asyncio.sleep"):
@@ -1760,7 +1760,9 @@ class TestNavigateRetry:
         )
         mock_page.title = AsyncMock(return_value="OK")
         mock_page.url = "https://example.com"
-        mock_page.evaluate = AsyncMock(return_value="body text")
+        mock_page.accessibility.snapshot = AsyncMock(return_value={
+            "role": "WebArea", "name": "OK", "children": [],
+        })
         inst = CamoufoxInstance("a1", MagicMock(), MagicMock(), mock_page)
         mgr._instances["a1"] = inst
 
@@ -1795,7 +1797,6 @@ class TestLandmarkAnnotations:
         from src.browser.service import BrowserManager, CamoufoxInstance
 
         mgr = BrowserManager(profiles_dir="/tmp/test_profiles")
-        mgr._js_snapshot_mode = True
 
         tree = {
             "role": "WebArea", "name": "Test Page",
@@ -1808,6 +1809,7 @@ class TestLandmarkAnnotations:
         mock_page.query_selector_all = AsyncMock(return_value=[])
         mock_page.evaluate = AsyncMock(return_value=tree)
         inst = CamoufoxInstance("a1", MagicMock(), MagicMock(), mock_page)
+        inst._js_snapshot_mode = True
         mgr._instances["a1"] = inst
 
         result = await mgr.snapshot("a1")
@@ -1823,7 +1825,6 @@ class TestLandmarkAnnotations:
         from src.browser.service import BrowserManager, CamoufoxInstance
 
         mgr = BrowserManager(profiles_dir="/tmp/test_profiles")
-        mgr._js_snapshot_mode = True
 
         tree = {
             "role": "WebArea", "name": "Test",
@@ -1833,6 +1834,7 @@ class TestLandmarkAnnotations:
         mock_page.query_selector_all = AsyncMock(return_value=[])
         mock_page.evaluate = AsyncMock(return_value=tree)
         inst = CamoufoxInstance("a1", MagicMock(), MagicMock(), mock_page)
+        inst._js_snapshot_mode = True
         mgr._instances["a1"] = inst
 
         result = await mgr.snapshot("a1")
@@ -2429,6 +2431,7 @@ class TestSnapshotDisabledField:
         inst.refs = {}
         inst.lock = asyncio.Lock()
         inst.touch = MagicMock()
+        inst._js_snapshot_mode = False
 
         with patch.object(BrowserManager, "get_or_start", return_value=inst):
             result = await mgr.snapshot("agent1")
@@ -2459,6 +2462,7 @@ class TestSnapshotDisabledField:
         inst.refs = {}
         inst.lock = asyncio.Lock()
         inst.touch = MagicMock()
+        inst._js_snapshot_mode = False
 
         with patch.object(BrowserManager, "get_or_start", return_value=inst):
             result = await mgr.snapshot("agent1")
@@ -3598,7 +3602,7 @@ class TestJsA11yTreeFallback:
 
         inst = CamoufoxInstance("a1", MagicMock(), MagicMock(), mock_page)
         mgr._instances["a1"] = inst
-        assert mgr._js_snapshot_mode is False
+        assert inst._js_snapshot_mode is False
 
         result = await mgr.snapshot("a1")
         assert result["success"] is True
@@ -3606,14 +3610,13 @@ class TestJsA11yTreeFallback:
         assert len(refs) == 2
         assert refs["e0"]["name"] == "Submit"
         assert refs["e1"]["name"] == "Home"
-        assert mgr._js_snapshot_mode is True
+        assert inst._js_snapshot_mode is True
 
     @pytest.mark.asyncio
     async def test_js_mode_persists(self):
         """Once JS mode is enabled, subsequent snapshots skip Playwright API."""
         from src.browser.service import BrowserManager, CamoufoxInstance
         mgr = BrowserManager(profiles_dir="/tmp/test_profiles")
-        mgr._js_snapshot_mode = True  # Already switched
 
         mock_page = AsyncMock()
         js_tree = {
@@ -3624,6 +3627,7 @@ class TestJsA11yTreeFallback:
         mock_page.query_selector_all = AsyncMock(return_value=[])
 
         inst = CamoufoxInstance("a1", MagicMock(), MagicMock(), mock_page)
+        inst._js_snapshot_mode = True  # Already switched
         mgr._instances["a1"] = inst
 
         result = await mgr.snapshot("a1")
@@ -3638,7 +3642,6 @@ class TestJsA11yTreeFallback:
         """In JS mode, scoped snapshots use element.evaluate()."""
         from src.browser.service import BrowserManager, CamoufoxInstance
         mgr = BrowserManager(profiles_dir="/tmp/test_profiles")
-        mgr._js_snapshot_mode = True
 
         full_tree = {
             "role": "WebArea", "name": "",
@@ -3664,6 +3667,7 @@ class TestJsA11yTreeFallback:
         mock_page.query_selector_all = AsyncMock(return_value=[mock_modal_el])
 
         inst = CamoufoxInstance("a1", MagicMock(), MagicMock(), mock_page)
+        inst._js_snapshot_mode = True
         mgr._instances["a1"] = inst
 
         result = await mgr.snapshot("a1")
@@ -3684,12 +3688,12 @@ class TestJsA11yTreeFallback:
         """When JS fallback returns None, snapshot returns empty page."""
         from src.browser.service import BrowserManager, CamoufoxInstance
         mgr = BrowserManager(profiles_dir="/tmp/test_profiles")
-        mgr._js_snapshot_mode = True
 
         mock_page = AsyncMock()
         mock_page.evaluate = AsyncMock(return_value=None)
 
         inst = CamoufoxInstance("a1", MagicMock(), MagicMock(), mock_page)
+        inst._js_snapshot_mode = True
         mgr._instances["a1"] = inst
 
         result = await mgr.snapshot("a1")
@@ -3702,7 +3706,6 @@ class TestJsA11yTreeFallback:
         """Nodes with role='none' (non-role containers) are walked for children."""
         from src.browser.service import BrowserManager, CamoufoxInstance
         mgr = BrowserManager(profiles_dir="/tmp/test_profiles")
-        mgr._js_snapshot_mode = True
 
         # JS tree has 'none' role wrapper (non-role div containing buttons)
         js_tree = {
@@ -3720,6 +3723,7 @@ class TestJsA11yTreeFallback:
         mock_page.query_selector_all = AsyncMock(return_value=[])
 
         inst = CamoufoxInstance("a1", MagicMock(), MagicMock(), mock_page)
+        inst._js_snapshot_mode = True
         mgr._instances["a1"] = inst
 
         result = await mgr.snapshot("a1")


### PR DESCRIPTION
## Summary

Closes the gap between manual VNC usage (undetected) and automated agent usage (detected by anti-bot systems like ArkoseLabs, DataDome, Kasada, Cloudflare).

Three fixes targeting the remaining CDP/Playwright calls that don't occur during manual VNC use:

- **Replace `page.evaluate("document.body.innerText")` with `page.accessibility.snapshot()` text extraction** — eliminates JavaScript injection into the page context on every navigation. The a11y API reads from Firefox's internal `nsIAccessibilityService` with zero JS execution.

- **Replace `page.mouse.wheel()` with xdotool button 4/5 (X11 input)** — the last remaining CDP input method. Playwright's wheel() dispatches via `nsIDOMWindowUtils.sendWheelEvent` with `deltaMode=DOM_DELTA_PIXEL` and coordinates from Playwright's internal mouse state (desynced from the X11 cursor). X11 button 4/5 produces real hardware-equivalent WheelEvents with `deltaMode=DOM_DELTA_LINE`.

- **Harden `_build_a11y_tree()` fallback** — retry `page.accessibility.snapshot()` on transient failure before falling through to the JS DOM walker (a ~130-line script that walks every element calling `getAttribute`, `getComputedStyle`, `textContent`). Log WARNING when JS fallback fires. Track the fallback flag per-instance instead of globally on BrowserManager.

## Test plan
- [x] All 271 browser service tests pass
- [ ] CI passes (lint + full test suite)
- [ ] Manual verification: agent posts on a platform that was previously detecting automation