### PR TITLE
Use friendly error for streaming transport failures

### DIFF
--- a/src/host/transport.py
+++ b/src/host/transport.py
@@ -18,7 +18,7 @@ import re
 import httpx
 
 from src.shared.types import AGENT_ID_RE_PATTERN
-from src.shared.utils import setup_logging
+from src.shared.utils import friendly_streaming_error, setup_logging
 
 logger = setup_logging("host.transport")
 
@@ -188,7 +188,7 @@ class HttpTransport(Transport):
             yield {"type": "error", "message": f"HTTP {e.response.status_code}"}
         except (httpx.TimeoutException, httpx.ConnectError, httpx.RemoteProtocolError) as e:
             logger.warning("Stream connection failed for agent '%s' %s: %s", agent_id, path, e)
-            yield {"type": "error", "message": str(e)}
+            yield {"type": "error", "message": friendly_streaming_error(e)}
 
     def request_sync(
         self,


### PR DESCRIPTION
## Summary
- Raw httpx `RemoteProtocolError` message ("peer closed connection without sending complete message body (incomplete chunked read)") was leaking to the chat UI when the mesh→agent streaming connection dropped mid-response
- `friendly_streaming_error()` was already used by `credentials.py` and `dashboard/server.py` but missing from `transport.py`
- One-line fix: `str(e)` → `friendly_streaming_error(e)` in `HttpTransport.stream_request()`

## Test plan
- [x] 15 transport tests pass
- [ ] Manual: trigger a streaming disconnect — verify chat shows "Connection to the AI provider was interrupted" instead of raw protocol error