### PR TITLE
Add X11 scroll-into-view and typo injection for human-like behavior

### DIFF
--- a/src/browser/service.py
+++ b/src/browser/service.py
@@ -72,8 +72,8 @@ _WORD_BOUNDARY_CHARS = frozenset(" ,.:;!?\n\t")
 # Adjacent keys on QWERTY layout for natural typo injection.
 # Includes same-row neighbors and diagonal keys above/below.
 _TYPO_NEIGHBORS: dict[str, str] = {
-    'q': 'wa', 'w': 'qeas', 'e': 'wrds', 'r': 'etf', 't': 'ryg',
-    'y': 'tuh', 'u': 'yij', 'i': 'uok', 'o': 'ipl', 'p': 'o',
+    'q': 'wa', 'w': 'qeas', 'e': 'wrds', 'r': 'etdf', 't': 'ryfg',
+    'y': 'tugh', 'u': 'yihj', 'i': 'uojk', 'o': 'ipkl', 'p': 'ol',
     'a': 'qwsz', 's': 'weadxz', 'd': 'ersfxc', 'f': 'rtdgcv',
     'g': 'tyfhvb', 'h': 'yugjbn', 'j': 'uihknm', 'k': 'iojlm',
     'l': 'opk',
@@ -1252,7 +1252,7 @@ class BrowserManager:
             if new_box is None:
                 break
             new_center = new_box["y"] + new_box["height"] / 2
-            if abs(new_center - prev_center) < 10:
+            if abs(new_center - prev_center) < 2:
                 break  # Scroll didn't move element — inner container
 
         # Fallback for edge cases

--- a/src/browser/service.py
+++ b/src/browser/service.py
@@ -69,6 +69,17 @@ _VALID_WAIT_UNTIL = frozenset({"domcontentloaded", "load", "networkidle", "commi
 # After one of these, the next character gets a higher think-pause probability
 # to model the hesitation a human feels when starting the next word or sentence.
 _WORD_BOUNDARY_CHARS = frozenset(" ,.:;!?\n\t")
+# Adjacent keys on QWERTY layout for natural typo injection.
+# Includes same-row neighbors and diagonal keys above/below.
+_TYPO_NEIGHBORS: dict[str, str] = {
+    'q': 'wa', 'w': 'qeas', 'e': 'wrds', 'r': 'etf', 't': 'ryg',
+    'y': 'tuh', 'u': 'yij', 'i': 'uok', 'o': 'ipl', 'p': 'o',
+    'a': 'qwsz', 's': 'weadxz', 'd': 'ersfxc', 'f': 'rtdgcv',
+    'g': 'tyfhvb', 'h': 'yugjbn', 'j': 'uihknm', 'k': 'iojlm',
+    'l': 'opk',
+    'z': 'asx', 'x': 'zsdc', 'c': 'xdfv', 'v': 'cfgb',
+    'b': 'vghn', 'n': 'bhjm', 'm': 'njk',
+}
 # Roles where aria-disabled="true" should NOT block click attempts.
 # SPA frameworks (X/Twitter, Gmail) keep aria-disabled on buttons/links while
 # handling clicks via JS — the visual state and handler are the source of truth,
@@ -1185,6 +1196,64 @@ class BrowserManager:
             )
             await asyncio.sleep(x11_step_delay())
 
+    async def _x11_ensure_in_viewport(
+        self, inst: CamoufoxInstance, locator,
+    ) -> None:
+        """Scroll element into viewport using X11 wheel events.
+
+        Replaces ``locator.scroll_into_view_if_needed()`` for the X11
+        input path.  Protocol-level ``scrollIntoView`` produces scroll
+        events WITHOUT ``WheelEvent`` — a detectable automation signal.
+        X11 button 4/5 produces real ``WheelEvent`` with
+        ``deltaMode=DOM_DELTA_LINE``, matching physical hardware.
+
+        Scrolls in small increments (2–3 notches per batch), re-measures
+        the element position after each batch to prevent overshoot.
+        Falls back to protocol scroll for edge cases (elements inside
+        scrollable inner containers, elements not yet in the DOM).
+        """
+        vp = inst.page.viewport_size
+        if not vp:
+            await locator.scroll_into_view_if_needed(timeout=_CLICK_TIMEOUT_MS)
+            return
+
+        vp_h = vp["height"]
+        margin = 60
+
+        for _ in range(10):
+            box = await locator.bounding_box()
+            if box is None:
+                break  # Not in DOM — protocol scroll only option
+
+            center_y = box["y"] + box["height"] / 2
+            if margin <= center_y <= vp_h - margin:
+                return  # Element is visible
+
+            button = "4" if center_y < margin else "5"
+            prev_center = center_y
+
+            batch = random.randint(2, 3)
+            for _ in range(batch):
+                try:
+                    await self._x11_scroll_notch(inst, button)
+                except Exception:
+                    break
+                await asyncio.sleep(scroll_pause() * 0.4)
+
+            # Wait for smooth scrolling to settle
+            await asyncio.sleep(0.10)
+
+            # Check if element position actually changed
+            new_box = await locator.bounding_box()
+            if new_box is None:
+                break
+            new_center = new_box["y"] + new_box["height"] / 2
+            if abs(new_center - prev_center) < 10:
+                break  # Scroll didn't move element — inner container
+
+        # Fallback for edge cases
+        await locator.scroll_into_view_if_needed(timeout=_CLICK_TIMEOUT_MS)
+
     async def _x11_click(self, inst: CamoufoxInstance, locator) -> None:
         """Click via xdotool for isTrusted=true events.
 
@@ -1195,15 +1264,15 @@ class BrowserManager:
         which the browser marks isTrusted=true.
 
         Steps:
-        1. scroll_into_view_if_needed — ensures element is visible without
-           generating any mouse events (CDP hover produces isTrusted=false
-           mousemove events that create a detectable mixed-trust pattern)
+        1. _x11_ensure_in_viewport — scrolls element into viewport using
+           X11 wheel events (real WheelEvent with DOM_DELTA_LINE) instead
+           of protocol-level scrollIntoView (no WheelEvents, detectable)
         2. Get element bounding box (viewport coords)
         3. Bezier mouse trajectory via _x11_move_to
         4. mousedown + human dwell + mouseup (not instant click)
         """
-        # 1. Scroll into view — no mouse events, just DOM scroll
-        await locator.scroll_into_view_if_needed(timeout=_CLICK_TIMEOUT_MS)
+        # 1. Scroll into view — prefer X11 wheel events over protocol scroll
+        await self._x11_ensure_in_viewport(inst, locator)
         await asyncio.sleep(x11_settle_delay())
 
         # 2. Get element position — jitter within inner area, not dead center
@@ -1245,7 +1314,7 @@ class BrowserManager:
 
     async def _x11_hover(self, inst: CamoufoxInstance, locator) -> None:
         """Move mouse to element via xdotool for isTrusted=true mousemove events."""
-        await locator.scroll_into_view_if_needed(timeout=_CLICK_TIMEOUT_MS)
+        await self._x11_ensure_in_viewport(inst, locator)
         await asyncio.sleep(x11_settle_delay())
 
         box = await locator.bounding_box()
@@ -1290,15 +1359,19 @@ class BrowserManager:
             except Exception:
                 pass
 
-    async def _x11_type(self, inst: CamoufoxInstance, text: str) -> None:
+    async def _x11_type(self, inst: CamoufoxInstance, text: str,
+                        *, typos: bool = True) -> None:
         """Type text via xdotool for isTrusted=true key events.
 
         Same rationale as _x11_click — bot-detection checks isTrusted on
         keydown/keyup in tweet composer textareas.  xdotool key/type
         generates real X11 KeyPress/KeyRelease events.
 
-        Uses xdotool type with --clearmodifiers for the text, with a
-        per-character delay matching our human-like timing.
+        When *typos* is True (default), injects occasional typo +
+        backspace corrections to simulate natural human error patterns.
+        Zero-typo typing at consistent speed is one of the strongest
+        bot signals.  Typos are placed mid-word only (avoiding handles,
+        hashtags, URLs) and capped at a per-text budget.
         """
         wid = inst.x11_wid
         if not wid:
@@ -1307,14 +1380,62 @@ class BrowserManager:
         loop = asyncio.get_running_loop()
         wid_s = str(wid)
 
-        # Type character by character with human-like delays
+        # ── Typo budget ──────────────────────────────────────────
+        # Pre-select positions for typo injection.  Only mid-word
+        # alphabetic characters qualify (skips handles, hashtags,
+        # URLs).  Budget scales with text length.
+        typo_positions: set[int] = set()
+        if typos:
+            candidates = [
+                i for i, c in enumerate(text)
+                if c.isalpha() and c.lower() in _TYPO_NEIGHBORS
+                and i > 0 and text[i - 1].isalpha()
+            ]
+            alpha_count = len(candidates)
+            if alpha_count >= 15:
+                expected = max(1.0, alpha_count / 120)
+                budget = max(0, int(random.gauss(expected, expected * 0.5)))
+                budget = min(budget, 4)
+                if budget > 0 and len(candidates) >= budget:
+                    typo_positions = set(random.sample(candidates, budget))
+
+        # ── Character loop ───────────────────────────────────────
         prev_char = ""
-        for char in text:
+        for i, char in enumerate(text):
             # Word-boundary think pauses
             pause_prob = 0.08 if prev_char in _WORD_BOUNDARY_CHARS else 0.015
             if random.random() < pause_prob:
                 await asyncio.sleep(think_pause())
 
+            # Typo injection — wrong adjacent key → pause → backspace → correct
+            if i in typo_positions:
+                wrong = random.choice(_TYPO_NEIGHBORS[char.lower()])
+                if char.isupper():
+                    wrong = wrong.upper()
+                # Type wrong character
+                await loop.run_in_executor(
+                    None,
+                    lambda c=wrong: subprocess.run(
+                        ["xdotool", "type", "--clearmodifiers", "--window", wid_s,
+                         "--delay", "0", "--", c],
+                        capture_output=True, timeout=3,
+                    ),
+                )
+                await asyncio.sleep(keystroke_delay(wrong))
+                # Pause — noticing the error
+                await asyncio.sleep(random.uniform(0.15, 0.4))
+                # Backspace to correct
+                await loop.run_in_executor(
+                    None,
+                    lambda: subprocess.run(
+                        ["xdotool", "key", "--clearmodifiers", "--window", wid_s,
+                         "BackSpace"],
+                        capture_output=True, timeout=3,
+                    ),
+                )
+                await asyncio.sleep(random.uniform(0.03, 0.08))
+
+            # Type the correct character
             if char == "\n":
                 await loop.run_in_executor(
                     None,
@@ -1332,7 +1453,6 @@ class BrowserManager:
                     ),
                 )
             else:
-                # xdotool type handles special characters and Unicode
                 await loop.run_in_executor(
                     None,
                     lambda c=char: subprocess.run(
@@ -1682,7 +1802,7 @@ class BrowserManager:
                     await asyncio.sleep(0.05)
 
                 if _use_x11:
-                    await self._x11_type(inst, text)
+                    await self._x11_type(inst, text, typos=not fast)
                 elif fast:
                     await self._type_fast(inst.page, text)
                 else:

--- a/src/browser/service.py
+++ b/src/browser/service.py
@@ -1212,6 +1212,10 @@ class BrowserManager:
         Falls back to protocol scroll for edge cases (elements inside
         scrollable inner containers, elements not yet in the DOM).
         """
+        if not inst.x11_wid:
+            await locator.scroll_into_view_if_needed(timeout=_CLICK_TIMEOUT_MS)
+            return
+
         vp = inst.page.viewport_size
         if not vp:
             await locator.scroll_into_view_if_needed(timeout=_CLICK_TIMEOUT_MS)

--- a/tests/test_browser_service.py
+++ b/tests/test_browser_service.py
@@ -1604,6 +1604,180 @@ class TestX11Scroll:
         assert 100 <= delta <= 200  # remaining px, positive for down
 
 
+class TestX11EnsureInViewport:
+    """Tests for _x11_ensure_in_viewport element scroll behavior."""
+
+    @pytest.mark.asyncio
+    async def test_element_in_viewport_no_scroll(self):
+        """Element already visible — no scroll or fallback needed."""
+        from src.browser.service import BrowserManager, CamoufoxInstance
+        mgr = BrowserManager(profiles_dir="/tmp/test_profiles")
+
+        mock_page = AsyncMock()
+        mock_page.viewport_size = {"width": 1920, "height": 1080}
+        inst = CamoufoxInstance("a1", MagicMock(), MagicMock(), mock_page)
+        inst.x11_wid = 12345
+
+        mock_locator = AsyncMock()
+        mock_locator.bounding_box = AsyncMock(return_value={
+            "x": 100, "y": 400, "width": 200, "height": 40,
+        })
+        mock_locator.scroll_into_view_if_needed = AsyncMock()
+
+        with patch("src.browser.service.asyncio.sleep"):
+            await mgr._x11_ensure_in_viewport(inst, mock_locator)
+
+        # Element at y=400 is in viewport — no protocol scroll fallback
+        mock_locator.scroll_into_view_if_needed.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_element_below_viewport_scrolls_x11(self):
+        """Element below viewport — X11 scroll down until visible."""
+        from src.browser.service import BrowserManager, CamoufoxInstance
+        mgr = BrowserManager(profiles_dir="/tmp/test_profiles")
+
+        mock_page = AsyncMock()
+        mock_page.viewport_size = {"width": 1920, "height": 1080}
+        inst = CamoufoxInstance("a1", MagicMock(), MagicMock(), mock_page)
+        inst.x11_wid = 12345
+
+        # First call: element below viewport; second call: element now visible
+        mock_locator = AsyncMock()
+        mock_locator.bounding_box = AsyncMock(side_effect=[
+            {"x": 100, "y": 1200, "width": 200, "height": 40},  # below
+            {"x": 100, "y": 900, "width": 200, "height": 40},   # moved after scroll
+            {"x": 100, "y": 500, "width": 200, "height": 40},   # now visible
+        ])
+        mock_locator.scroll_into_view_if_needed = AsyncMock()
+
+        with patch("src.browser.service.asyncio.sleep"), \
+             patch("src.browser.service.subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=0)
+            await mgr._x11_ensure_in_viewport(inst, mock_locator)
+
+        # Should have called xdotool for scroll (button 5 = down)
+        scroll_calls = [c for c in mock_run.call_args_list
+                        if "click" in c[0][0] and "5" in c[0][0]]
+        assert len(scroll_calls) >= 1
+        # Protocol fallback should NOT have been called (X11 succeeded)
+        mock_locator.scroll_into_view_if_needed.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_no_x11_wid_uses_protocol_scroll(self):
+        """Without x11_wid, should use protocol scroll immediately."""
+        from src.browser.service import BrowserManager, CamoufoxInstance
+        mgr = BrowserManager(profiles_dir="/tmp/test_profiles")
+
+        mock_page = AsyncMock()
+        mock_page.viewport_size = {"width": 1920, "height": 1080}
+        inst = CamoufoxInstance("a1", MagicMock(), MagicMock(), mock_page)
+        inst.x11_wid = None  # No X11
+
+        mock_locator = AsyncMock()
+        mock_locator.scroll_into_view_if_needed = AsyncMock()
+
+        await mgr._x11_ensure_in_viewport(inst, mock_locator)
+
+        mock_locator.scroll_into_view_if_needed.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_inner_container_falls_back(self):
+        """When X11 scroll doesn't move element, fall back to protocol."""
+        from src.browser.service import BrowserManager, CamoufoxInstance
+        mgr = BrowserManager(profiles_dir="/tmp/test_profiles")
+
+        mock_page = AsyncMock()
+        mock_page.viewport_size = {"width": 1920, "height": 1080}
+        inst = CamoufoxInstance("a1", MagicMock(), MagicMock(), mock_page)
+        inst.x11_wid = 12345
+
+        # Element position never changes (inner container)
+        mock_locator = AsyncMock()
+        mock_locator.bounding_box = AsyncMock(return_value={
+            "x": 100, "y": 1200, "width": 200, "height": 40,
+        })
+        mock_locator.scroll_into_view_if_needed = AsyncMock()
+
+        with patch("src.browser.service.asyncio.sleep"), \
+             patch("src.browser.service.subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=0)
+            await mgr._x11_ensure_in_viewport(inst, mock_locator)
+
+        # Should have fallen back to protocol scroll
+        mock_locator.scroll_into_view_if_needed.assert_called_once()
+
+
+class TestTypoInjection:
+    """Tests for typo injection in _x11_type."""
+
+    @pytest.mark.asyncio
+    async def test_short_text_no_typos(self):
+        """Text shorter than 15 alpha chars should never get typos."""
+        from src.browser.service import BrowserManager, CamoufoxInstance
+        mgr = BrowserManager(profiles_dir="/tmp/test_profiles")
+
+        inst = CamoufoxInstance("a1", MagicMock(), MagicMock(), MagicMock())
+        inst.x11_wid = 12345
+
+        with patch("src.browser.service.asyncio.sleep"), \
+             patch("src.browser.service.subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=0)
+            await mgr._x11_type(inst, "Hello")
+
+        # No BackSpace should appear — text too short for typos
+        backspace_calls = [c for c in mock_run.call_args_list
+                           if "BackSpace" in str(c)]
+        assert len(backspace_calls) == 0
+
+    @pytest.mark.asyncio
+    async def test_typos_disabled_no_backspace(self):
+        """typos=False should produce zero typo corrections."""
+        from src.browser.service import BrowserManager, CamoufoxInstance
+        mgr = BrowserManager(profiles_dir="/tmp/test_profiles")
+
+        inst = CamoufoxInstance("a1", MagicMock(), MagicMock(), MagicMock())
+        inst.x11_wid = 12345
+
+        long_text = "The quick brown fox jumps over the lazy dog and keeps running"
+
+        with patch("src.browser.service.asyncio.sleep"), \
+             patch("src.browser.service.subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=0)
+            await mgr._x11_type(inst, long_text, typos=False)
+
+        backspace_calls = [c for c in mock_run.call_args_list
+                           if "BackSpace" in str(c)]
+        assert len(backspace_calls) == 0
+
+    @pytest.mark.asyncio
+    async def test_long_text_injects_typos(self):
+        """Long text with typos=True should inject BackSpace corrections.
+
+        Patches random.gauss to guarantee a budget of 2 typos.
+        """
+        from src.browser.service import BrowserManager, CamoufoxInstance
+        mgr = BrowserManager(profiles_dir="/tmp/test_profiles")
+
+        inst = CamoufoxInstance("a1", MagicMock(), MagicMock(), MagicMock())
+        inst.x11_wid = 12345
+
+        long_text = (
+            "The quick brown fox jumps over the lazy dog "
+            "and keeps running through the enchanted forest"
+        )
+
+        with patch("src.browser.service.asyncio.sleep"), \
+             patch("src.browser.service.subprocess.run") as mock_run, \
+             patch("src.browser.service.random.gauss", return_value=2.0), \
+             patch("src.browser.service.random.random", return_value=0.5):
+            mock_run.return_value = MagicMock(returncode=0)
+            await mgr._x11_type(inst, long_text, typos=True)
+
+        backspace_calls = [c for c in mock_run.call_args_list
+                           if "BackSpace" in str(c)]
+        assert len(backspace_calls) == 2, f"Expected 2 typo corrections, got {len(backspace_calls)}"
+
+
 class TestClickRandomDelay:
     """Verify click delay is not a fixed 0.3s."""
 

--- a/tests/test_browser_service.py
+++ b/tests/test_browser_service.py
@@ -1706,6 +1706,55 @@ class TestX11EnsureInViewport:
         # Should have fallen back to protocol scroll
         mock_locator.scroll_into_view_if_needed.assert_called_once()
 
+    @pytest.mark.asyncio
+    async def test_small_movement_continues_scrolling(self):
+        """Small but real movement (>= 2px) should NOT trigger stall detection."""
+        from src.browser.service import BrowserManager, CamoufoxInstance
+        mgr = BrowserManager(profiles_dir="/tmp/test_profiles")
+
+        mock_page = AsyncMock()
+        mock_page.viewport_size = {"width": 1920, "height": 1080}
+        inst = CamoufoxInstance("a1", MagicMock(), MagicMock(), mock_page)
+        inst.x11_wid = 12345
+
+        # Element moves 5px per batch (small but real progress), then enters viewport
+        call_count = [0]
+
+        async def moving_bbox():
+            call_count[0] += 1
+            y = max(500, 1200 - call_count[0] * 100)  # gradually enters viewport
+            return {"x": 100, "y": y, "width": 200, "height": 40}
+
+        mock_locator = AsyncMock()
+        mock_locator.bounding_box = AsyncMock(side_effect=moving_bbox)
+        mock_locator.scroll_into_view_if_needed = AsyncMock()
+
+        with patch("src.browser.service.asyncio.sleep"), \
+             patch("src.browser.service.subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=0)
+            await mgr._x11_ensure_in_viewport(inst, mock_locator)
+
+        # Should NOT have used protocol fallback — X11 scroll succeeded
+        mock_locator.scroll_into_view_if_needed.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_no_viewport_uses_protocol(self):
+        """When viewport_size is None, fall back to protocol scroll."""
+        from src.browser.service import BrowserManager, CamoufoxInstance
+        mgr = BrowserManager(profiles_dir="/tmp/test_profiles")
+
+        mock_page = AsyncMock()
+        mock_page.viewport_size = None
+        inst = CamoufoxInstance("a1", MagicMock(), MagicMock(), mock_page)
+        inst.x11_wid = 12345
+
+        mock_locator = AsyncMock()
+        mock_locator.scroll_into_view_if_needed = AsyncMock()
+
+        await mgr._x11_ensure_in_viewport(inst, mock_locator)
+
+        mock_locator.scroll_into_view_if_needed.assert_called_once()
+
 
 class TestTypoInjection:
     """Tests for typo injection in _x11_type."""

--- a/tests/test_browser_service.py
+++ b/tests/test_browser_service.py
@@ -4222,7 +4222,9 @@ class TestX11Input:
             return BrowserManager(profiles_dir="/tmp/test_profiles")
 
     def _make_instance(self, agent_id="agent-1", x11_wid=12345):
-        inst = CamoufoxInstance(agent_id, MagicMock(), MagicMock(), MagicMock())
+        mock_page = MagicMock()
+        mock_page.viewport_size = {"width": 1920, "height": 1080}
+        inst = CamoufoxInstance(agent_id, MagicMock(), MagicMock(), mock_page)
         inst.x11_wid = x11_wid
         return inst
 
@@ -4247,8 +4249,10 @@ class TestX11Input:
                 with patch("src.browser.service.random.randint", return_value=4):
                     await mgr._x11_click(inst, mock_locator)
 
-        mock_locator.scroll_into_view_if_needed.assert_called_once()
-        mock_locator.bounding_box.assert_called_once()
+        # Element at y=200 is in viewport (1080px) — no scroll needed
+        mock_locator.scroll_into_view_if_needed.assert_not_called()
+        # bounding_box called by _x11_ensure_in_viewport + _x11_click
+        assert mock_locator.bounding_box.await_count >= 1
         # At least: 1 getmouselocation + 3 mousemove + 1 mousedown + 1 mouseup = 6
         assert sub_run.call_count >= 6
         calls = sub_run.call_args_list
@@ -4451,7 +4455,7 @@ class TestX11Input:
         )
         assert result["success"]
         mgr._x11_click.assert_called_once()
-        mgr._x11_type.assert_called_once_with(inst, "Hello world")
+        mgr._x11_type.assert_called_once_with(inst, "Hello world", typos=True)
 
     @pytest.mark.asyncio
     async def test_type_text_uses_x11_on_all_sites(self):
@@ -4544,7 +4548,7 @@ class TestX11Input:
         result = await mgr.type_text("agent-1", ref="T1", text="Hello X")
         assert result["success"]
         mgr._x11_click.assert_called_once_with(inst, mock_locator)
-        mgr._x11_type.assert_called_once_with(inst, "Hello X")
+        mgr._x11_type.assert_called_once_with(inst, "Hello X", typos=True)
 
     @pytest.mark.asyncio
     async def test_type_text_ref_uses_x11_on_all_sites(self):


### PR DESCRIPTION
## Summary

Addresses two behavioral detection signals identified by agent self-analysis:

- **X11 scroll-into-view**: `_x11_click()` and `_x11_hover()` previously used Playwright's protocol-level `scrollIntoView` which produces scroll events WITHOUT WheelEvents — a detectable automation pattern. New `_x11_ensure_in_viewport()` method scrolls elements into view using X11 button 4/5 in small batches (2-3 notches), re-measures position after each batch to prevent overshoot, and detects inner-container edge cases (falls back to protocol scroll when X11 scroll doesn't move the element).

- **Typo injection**: `_x11_type()` now injects occasional adjacent-key typos with immediate backspace correction. Zero-typo typing at consistent speed is one of the strongest bot signals. Budget-based system (~1 typo per 120 alpha chars, max 4), only targets mid-word positions (skipping handles/hashtags/URLs), and is disabled for `fast=True` (operational text like search queries).

## Test plan
- [x] All 285 browser service tests pass
- [ ] CI passes (lint + full test suite)
- [ ] Manual verification: agent composes a post with visible typo corrections in VNC