### PR TITLE
Add view-only VNC overlay with Take Control toggle

### DIFF
--- a/src/browser/server.py
+++ b/src/browser/server.py
@@ -198,6 +198,14 @@ def create_browser_app(manager: BrowserManager, lifespan=None) -> FastAPI:
         ok = await manager.focus(agent_id)
         return {"success": ok, "data": {"focused": ok}}
 
+    @app.post("/browser/{agent_id}/control")
+    async def browser_control(agent_id: str, request: Request):
+        """Toggle user browser control — pauses agent X11 input."""
+        _verify_auth(request)
+        body = await request.json()
+        enabled = bool(body.get("user_control", False))
+        return await manager.set_user_control(agent_id, enabled)
+
     @app.post("/browser/{agent_id}/scroll")
     async def scroll(agent_id: str, request: Request):
         _verify_auth(request)

--- a/src/browser/service.py
+++ b/src/browser/service.py
@@ -293,6 +293,7 @@ class CamoufoxInstance:
         self.lock = asyncio.Lock()  # serialize page operations per instance
         self.x11_wid: int | None = None  # X11 window ID for targeted focus
         self._js_snapshot_mode: bool = False  # True after page.accessibility permanently fails
+        self._user_control: bool = False  # True when user has VNC control
 
     def touch(self):
         self.last_activity = time.time()
@@ -694,6 +695,23 @@ class BrowserManager:
                 logger.debug("xdotool raise skipped for '%s': %s", agent_id, e)
             return True
 
+    async def set_user_control(self, agent_id: str, enabled: bool) -> dict:
+        """Toggle user browser control.
+
+        When enabled, pauses agent X11 input (mouse jitter, click, type,
+        scroll) so the user can interact via VNC without cursor fighting.
+        Browser read operations (snapshot, screenshot) remain available.
+        """
+        inst = self._instances.get(agent_id)
+        if not inst:
+            return {"success": False, "error": "No browser instance"}
+        inst._user_control = enabled
+        logger.info(
+            "User %s browser control for %s",
+            "took" if enabled else "released", agent_id,
+        )
+        return {"success": True, "user_control": enabled}
+
     # ── Browser operations ──────────────────────────────────
 
     async def navigate(
@@ -725,6 +743,11 @@ class BrowserManager:
         inst = await self.get_or_start(agent_id)
         inst.touch()
         async with inst.lock:
+            if inst._user_control:
+                return {
+                    "success": False,
+                    "error": "User has browser control — action paused until control is released.",
+                }
             # Single retry on timeout — transient network issues get a second chance.
             for attempt in range(2):
                 try:
@@ -1269,7 +1292,7 @@ class BrowserManager:
         """
         while True:
             await asyncio.sleep(random.uniform(2.0, 7.0))
-            if not inst.x11_wid or inst.lock.locked():
+            if not inst.x11_wid or inst.lock.locked() or inst._user_control:
                 continue
             try:
                 dx = random.randint(-3, 3)
@@ -1424,6 +1447,11 @@ class BrowserManager:
         inst.touch()
         async with inst.lock:
             try:
+                if inst._user_control:
+                    return {
+                        "success": False,
+                        "error": "User has browser control — action paused until control is released.",
+                    }
                 use_force = force
                 if ref and ref in inst.refs:
                     ref_info = inst.refs[ref]
@@ -1621,6 +1649,11 @@ class BrowserManager:
         inst.touch()
         async with inst.lock:
             try:
+                if inst._user_control:
+                    return {
+                        "success": False,
+                        "error": "User has browser control — action paused until control is released.",
+                    }
                 # Click to focus, then optionally select-all to clear.
                 # Never use fill() — it atomically sets the DOM value and bypasses
                 # the keyboard event chain, so React/Vue apps (e.g. X's tweet
@@ -1819,6 +1852,11 @@ class BrowserManager:
         inst.touch()
         async with inst.lock:
             try:
+                if inst._user_control:
+                    return {
+                        "success": False,
+                        "error": "User has browser control — action paused until control is released.",
+                    }
                 # Scroll element into view
                 if ref:
                     if ref not in inst.refs:
@@ -1974,6 +2012,11 @@ class BrowserManager:
         inst.touch()
         async with inst.lock:
             try:
+                if inst._user_control:
+                    return {
+                        "success": False,
+                        "error": "User has browser control — action paused until control is released.",
+                    }
                 if inst.x11_wid and self._is_x11_site(inst):
                     xkey = self._playwright_key_to_xdotool(key)
                     try:

--- a/src/dashboard/server.py
+++ b/src/dashboard/server.py
@@ -427,6 +427,28 @@ def create_dashboard_router(
         except Exception as e:
             return {"success": False, "error": str(e)}
 
+    @api_router.post("/api/browser/{agent_id}/control")
+    async def api_browser_control(agent_id: str, request: Request) -> dict:
+        """Toggle user browser control — pauses agent X11 input."""
+        if not runtime or not hasattr(runtime, 'browser_service_url') or not runtime.browser_service_url:
+            raise HTTPException(503, "Browser service not available")
+        body = await request.json()
+        try:
+            browser_auth = getattr(runtime, 'browser_auth_token', '')
+            headers: dict[str, str] = {}
+            if browser_auth:
+                headers["Authorization"] = f"Bearer {browser_auth}"
+            resp = await _dashboard_browser_client.post(
+                f"{runtime.browser_service_url}/browser/{agent_id}/control",
+                json=body,
+                headers=headers,
+                timeout=10,
+            )
+            resp.raise_for_status()
+            return resp.json()
+        except Exception as e:
+            return {"success": False, "error": str(e)}
+
     @api_router.post("/api/browser/{agent_id}/reset")
     async def api_browser_reset(agent_id: str) -> dict:
         """Reset an agent's browser session (close and relaunch with current config)."""

--- a/src/dashboard/static/js/app.js
+++ b/src/dashboard/static/js/app.js
@@ -89,6 +89,7 @@ function dashboard() {
     agentDetail: null,
     showBrowserViewer: false,
     _browserFocusDone: false,
+    _browserViewOnly: true,
     _browserPendingAgent: null,
 
     // Agent config
@@ -2887,6 +2888,7 @@ function dashboard() {
           this.showBrowserViewer = false;
           this._browserFocusDone = false;
           this._browserToggling = false;
+          this._browserViewOnly = true;
         }
         this.showToast(`Resetting browser for ${agentId}...`);
         try {
@@ -4760,9 +4762,7 @@ function dashboard() {
 
     async toggleBrowser() {
       if (this.showBrowserViewer) {
-        this.showBrowserViewer = false;
-        this._browserFocusDone = false;
-        this._browserToggling = false;
+        await this.closeBrowserViewer();
         return;
       }
       if (this._browserToggling) return;
@@ -4797,6 +4797,44 @@ function dashboard() {
         this._browserFocusDone = true;
       } finally {
         this._browserToggling = false;
+      }
+    },
+
+    async toggleBrowserControl() {
+      const taking = this._browserViewOnly;  // currently view-only → taking control
+      this._browserViewOnly = !taking;
+
+      const agentId = this.selectedAgent;
+      if (!agentId) return;
+      try {
+        await fetch(`${window.__config.apiBase}/browser/${agentId}/control`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json', 'X-Requested-With': 'XMLHttpRequest' },
+          body: JSON.stringify({ user_control: taking }),
+        });
+      } catch (e) {
+        console.warn('toggleBrowserControl failed:', e);
+      }
+    },
+
+    async closeBrowserViewer() {
+      const wasControlling = !this._browserViewOnly;
+      this.showBrowserViewer = false;
+      this._browserFocusDone = false;
+      this._browserToggling = false;
+      this._browserViewOnly = true;
+
+      // Release agent X11 pause if user had control
+      if (wasControlling && this.selectedAgent) {
+        try {
+          await fetch(`${window.__config.apiBase}/browser/${this.selectedAgent}/control`, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json', 'X-Requested-With': 'XMLHttpRequest' },
+            body: JSON.stringify({ user_control: false }),
+          });
+        } catch (e) {
+          console.warn('closeBrowserViewer release failed:', e);
+        }
       }
     },
 

--- a/src/dashboard/templates/index.html
+++ b/src/dashboard/templates/index.html
@@ -1789,17 +1789,30 @@
               <div class="flex items-center justify-between px-4 py-2 border-b border-gray-800">
                 <span class="text-xs text-gray-400 uppercase tracking-wider">Live Browser</span>
                 <div class="flex items-center gap-2">
+                  <button @click="toggleBrowserControl()"
+                    class="text-xs px-2 py-0.5 rounded transition-colors"
+                    :class="_browserViewOnly
+                      ? 'bg-gray-700 text-gray-400 hover:bg-gray-600 hover:text-gray-200'
+                      : 'bg-amber-600/20 text-amber-300 ring-1 ring-amber-500/40 hover:bg-amber-600/30'"
+                    x-text="_browserViewOnly ? 'Take Control' : 'Release Control'">
+                  </button>
                   <a :href="agentDetail?.vnc_url"
                     target="_blank" rel="noopener"
                     @click="focusBrowser(selectedAgent)"
                     class="text-xs text-gray-500 hover:text-gray-300 transition-colors"
                     title="Open in new tab">&#x2197; Pop out</a>
-                  <button @click="showBrowserViewer = false; _browserFocusDone = false; _browserToggling = false"
+                  <button @click="closeBrowserViewer()"
                     class="text-gray-500 hover:text-gray-300 transition-colors text-sm"
                     title="Close" aria-label="Close">&times;</button>
                 </div>
               </div>
               <div class="relative" style="max-width: 1280px; aspect-ratio: 16/9;">
+                <!-- View-only overlay — blocks user mouse/keyboard to prevent
+                     input collision with agent's xdotool events.  Removed when
+                     user explicitly takes control via the toggle button. -->
+                <div x-show="_browserViewOnly"
+                  class="absolute inset-0 z-20"
+                  style="cursor: default;"></div>
                 <!-- Loading overlay -->
                 <div x-ref="vncLoading"
                   class="absolute inset-0 flex flex-col items-center justify-center bg-gray-900 z-10 transition-opacity duration-500"
@@ -1813,6 +1826,7 @@
                 <iframe
                   :src="(showBrowserViewer && _browserFocusDone) ? agentDetail?.vnc_url : ''"
                   class="w-full h-full border-0"
+                  :tabindex="_browserViewOnly ? -1 : 0"
                   allow="clipboard-read; clipboard-write"
                   @load="_browserFocusDone && $refs.vncLoading && ($refs.vncLoading.style.opacity = '0')"
                 ></iframe>

--- a/tests/test_browser_service.py
+++ b/tests/test_browser_service.py
@@ -2468,6 +2468,9 @@ class TestAutoForceClick:
         inst.lock = asyncio.Lock()
         inst.touch = MagicMock()
         inst.x11_wid = None  # No X11 WID — use CDP click path
+        inst._user_control = False  # Not in user-control mode
+        inst.dialog_detected = False
+        inst.dialog_active = False
         return inst
 
     @pytest.mark.asyncio
@@ -2711,6 +2714,7 @@ class TestTypeTextSettleDelays:
         inst.refs = {"e1": {"role": "textbox", "name": "Tweet", "index": 0, "disabled": False}}
         inst.lock = asyncio.Lock()
         inst.touch = MagicMock()
+        inst._user_control = False
 
         sleep_calls: list[float] = []
 
@@ -2750,6 +2754,7 @@ class TestTypeTextSettleDelays:
         inst.refs = {"e1": {"role": "textbox", "name": "Tweet", "index": 0, "disabled": False}}
         inst.lock = asyncio.Lock()
         inst.touch = MagicMock()
+        inst._user_control = False
 
         sleep_calls: list[float] = []
 
@@ -2795,6 +2800,7 @@ class TestPressKey:
         inst.page.keyboard.press = AsyncMock()
         inst.lock = asyncio.Lock()
         inst.touch = MagicMock()
+        inst._user_control = False
 
         with patch.object(BrowserManager, "get_or_start", return_value=inst):
             with patch("src.browser.service.action_delay", return_value=0.01):
@@ -2816,6 +2822,7 @@ class TestPressKey:
         inst.page.keyboard.press = AsyncMock()
         inst.lock = asyncio.Lock()
         inst.touch = MagicMock()
+        inst._user_control = False
 
         with patch.object(BrowserManager, "get_or_start", return_value=inst):
             with patch("src.browser.service.action_delay", return_value=0.01):


### PR DESCRIPTION
## Summary

Prevents user mouse input from colliding with agent xdotool events when watching the browser via VNC. Two simultaneous input sources create impossible mouse telemetry (teleportation, contradictory velocity) that anti-bot systems detect.

- **VNC iframe blocked by transparent overlay** (`z-20` div) by default -- user can watch but cannot accidentally send input
- **"Take Control" button** removes overlay and pauses agent X11 input (jitter, clicks, typing, scrolling, navigation)
- **"Release Control"** re-enables overlay and resumes agent operations
- **Auto-releases** on viewer close
- Read-only operations (snapshot, screenshot) remain available during user control

### Files changed
- `src/dashboard/templates/index.html` -- overlay div + toggle button
- `src/dashboard/static/js/app.js` -- `toggleBrowserControl()`, `closeBrowserViewer()`, state management
- `src/browser/service.py` -- `_user_control` flag on CamoufoxInstance, `set_user_control()`, input method guards
- `src/browser/server.py` -- `POST /browser/{agent_id}/control` endpoint
- `src/dashboard/server.py` -- `POST /api/browser/{agent_id}/control` proxy endpoint
- `tests/test_browser_service.py` -- `_user_control` attribute on mock instances

## Test plan
- [x] 557 tests pass (browser service + dashboard)
- [ ] CI passes
- [ ] Manual: open browser viewer, verify cursor doesn't interact with VNC
- [ ] Manual: click "Take Control", verify mouse works in VNC and agent pauses
- [ ] Manual: click "Release Control" or close viewer, verify agent resumes