### PR TITLE
Auto-recover chat after streaming connection drops

### DIFF
--- a/src/dashboard/static/js/app.js
+++ b/src/dashboard/static/js/app.js
@@ -4380,6 +4380,7 @@ function dashboard() {
               entry.content = errContent;
               entry.role = isCreditErr ? 'credit_exhausted' : 'error';
               if (isCreditErr) entry._creditExhausted = true;
+              else entry._recoverable = true;
               entry.streaming = false;
               entry.phase = 'error';
               this._pushChatTimelinePhase(entry, 'error');
@@ -4412,6 +4413,7 @@ function dashboard() {
               ? 'Response timed out — please try again.'
               : 'Connection interrupted — please try again.';
             entry.role = 'error';
+            entry._recoverable = true;
             entry.streaming = false;
             entry.phase = 'error';
             this._pushChatTimelinePhase(entry, 'error');
@@ -4428,6 +4430,26 @@ function dashboard() {
         this.$nextTick(() => this._scrollChat(agentId));
         this._saveChatToSession();
         this.fetchQueues();
+        // Auto-recover from stream interruptions: the agent may still be
+        // processing via non-streaming fallback or may have already finished.
+        const _lastMsg = (this.chatHistories[agentId] || []).slice(-1)[0];
+        if (_lastMsg && _lastMsg._recoverable) {
+          setTimeout(async () => {
+            if (!this.openChats.includes(agentId)) return;
+            try {
+              const qr = await fetch(`${window.__config.apiBase}/queues`);
+              if (qr.ok) this.queueStatus = (await qr.json()).queues;
+            } catch (_) { /* ignore */ }
+            if (this.queueStatus?.[agentId]?.busy) {
+              this._chatWasStreaming = this._chatWasStreaming || {};
+              this._chatWasStreaming[agentId] = true;
+              this._recoverDeadStreams();
+            } else {
+              delete this._chatFetchedAt[agentId];
+              this._loadChatHistory(agentId);
+            }
+          }, 4000);
+        }
       }
     },
 


### PR DESCRIPTION
## Summary
- When the SSE stream to the agent container breaks mid-response, the agent often recovers via non-streaming fallback — but the dashboard showed a permanent error without checking
- After a recoverable streaming error, the dashboard now waits 4s then checks if the agent is still busy (enters recovery polling) or idle (loads chat history to pick up the completed response)
- Only triggers for stream interruptions and transport errors — not HTTP failures before streaming or credit exhaustion

## Changes
- Mark server-sent stream errors and network interruptions as `_recoverable` on the chat entry
- In the streaming handler's `finally` block, trigger delayed auto-recovery for recoverable errors
- Recovery checks agent queue status: if busy, delegates to existing `_recoverDeadStreams` polling; if idle, loads chat history directly

## Test plan
- [x] 347 dashboard/transport tests pass
- [ ] Manual: kill agent container mid-stream — verify response appears after recovery
- [ ] Manual: trigger LLM provider timeout — verify auto-recovery picks up fallback response
- [ ] Manual: close chat before recovery fires — verify no stale recovery attempt
- [ ] Manual: credit exhaustion error — verify no recovery attempt