### PR TITLE
Add modal bounding box filter, expose clear param, configurable click timeout

### DIFF
--- a/src/agent/builtins/browser_tool.py
+++ b/src/agent/builtins/browser_tool.py
@@ -265,28 +265,38 @@ async def browser_screenshot(full_page: bool = False, *, mesh_client=None) -> di
             "description": "Include element snapshot in the response (default false)",
             "default": False,
         },
+        "timeout_ms": {
+            "type": "integer",
+            "description": (
+                "Click timeout in milliseconds. Increase for heavy SPAs with "
+                "animations or link card previews (e.g. 20000 for X thread "
+                "'Post all'). Default 10000, max 30000."
+            ),
+        },
     },
     parallel_safe=False,
 )
 async def browser_click(
     selector: str = "", ref: str = "", force: bool = False,
-    snapshot_after: bool = False, *, mesh_client=None,
+    snapshot_after: bool = False, timeout_ms: int | None = None,
+    *, mesh_client=None,
 ) -> dict:
     """Click an element by ref or CSS selector."""
     if not selector and not ref:
         return {"error": "Provide either 'ref' (from browser_get_elements) or 'selector' (CSS)"}
-    return await _browser_command(
-        mesh_client, "click",
-        {"ref": ref, "selector": selector, "force": force,
-         "snapshot_after": snapshot_after},
-    )
+    cmd = {"ref": ref, "selector": selector, "force": force,
+           "snapshot_after": snapshot_after}
+    if timeout_ms is not None:
+        cmd["timeout_ms"] = timeout_ms
+    return await _browser_command(mesh_client, "click", cmd)
 
 
 @skill(
     name="browser_type",
     description=(
-        "Type text into a form field on the current page. Clears the field first, "
-        "then enters the new text. Preferred: use ref from browser_get_elements "
+        "Type text into a form field on the current page. Optionally clears the "
+        "field first (default); set clear=false to append. "
+        "Preferred: use ref from browser_get_elements "
         "(e.g. ref='e5'). Fallback: use a CSS selector. "
         "Set fast=true for search queries, URLs, and non-sensitive fields to "
         "type quickly. Set snapshot_after=true to include updated element refs."
@@ -309,6 +319,16 @@ async def browser_click(
             ),
             "default": "",
         },
+        "clear": {
+            "type": "boolean",
+            "description": (
+                "Clear the field before typing (default true). Set false to "
+                "append at the cursor position. Note: in rich-text editors "
+                "the cursor lands where the focus click hits, which may not "
+                "be at the end of existing text."
+            ),
+            "default": True,
+        },
         "fast": {
             "type": "boolean",
             "description": (
@@ -327,8 +347,8 @@ async def browser_click(
     parallel_safe=False,
 )
 async def browser_type(
-    text: str, selector: str = "", ref: str = "", fast: bool = False,
-    snapshot_after: bool = False, *, mesh_client=None,
+    text: str, selector: str = "", ref: str = "", clear: bool = True,
+    fast: bool = False, snapshot_after: bool = False, *, mesh_client=None,
 ) -> dict:
     """Type text into an element."""
     if not text:
@@ -338,7 +358,7 @@ async def browser_type(
 
     return await _browser_command(
         mesh_client, "type",
-        {"ref": ref, "selector": selector, "text": text, "clear": True,
+        {"ref": ref, "selector": selector, "text": text, "clear": clear,
          "fast": fast, "snapshot_after": snapshot_after},
     )
 

--- a/src/browser/server.py
+++ b/src/browser/server.py
@@ -101,6 +101,7 @@ def create_browser_app(manager: BrowserManager, lifespan=None) -> FastAPI:
             selector=body.get("selector"),
             force=body.get("force", False),
             snapshot_after=body.get("snapshot_after", False),
+            timeout_ms=body.get("timeout_ms"),
         )
         await _apply_delay()
         return result

--- a/src/browser/service.py
+++ b/src/browser/service.py
@@ -920,13 +920,11 @@ class BrowserManager:
             # so agents don't see/click elements behind the overlay
             # (e.g. X's sidebar "Post" button behind the compose modal).
             modal_els = await inst.page.query_selector_all(_MODAL_SELECTOR)
+            vp = inst.page.viewport_size
             visible_modals = []
             for el in modal_els:
-                try:
-                    if await el.is_visible():
-                        visible_modals.append(el)
-                except Exception:
-                    pass
+                if await self._is_visible_modal(el, vp):
+                    visible_modals.append(el)
 
             # Deduplicate nested modals: if modal A contains modal B,
             # snapshot(root=A) already includes B's elements.
@@ -978,11 +976,8 @@ class BrowserManager:
                     # like X/Twitter re-render the modal during the wait.
                     fresh_modals = []
                     for el in (await inst.page.query_selector_all(_MODAL_SELECTOR)):
-                        try:
-                            if await el.is_visible():
-                                fresh_modals.append(el)
-                        except Exception:
-                            pass
+                        if await self._is_visible_modal(el, vp):
+                            fresh_modals.append(el)
                     if fresh_modals:
                         visible_modals = fresh_modals
                     for el in visible_modals:
@@ -1026,6 +1021,28 @@ class BrowserManager:
             return {"success": True, "data": {"snapshot": snapshot_text, "refs": refs}}
         except Exception as e:
             return {"success": False, "error": str(e)}
+
+    @staticmethod
+    async def _is_visible_modal(el, vp_size: dict | None) -> bool:
+        """Check if a modal element is genuinely visible with real area.
+
+        Filters zero-area or off-screen modals (e.g. LinkedIn's background
+        messaging panels) that pass Playwright's ``is_visible()`` but are
+        not true dialog overlays.
+        """
+        try:
+            if not await el.is_visible():
+                return False
+            bb = await el.bounding_box()
+            if not bb or bb["width"] < 10 or bb["height"] < 10:
+                return False
+            if vp_size:
+                if (bb["x"] + bb["width"] <= 0 or bb["x"] >= vp_size["width"]
+                        or bb["y"] + bb["height"] <= 0 or bb["y"] >= vp_size["height"]):
+                    return False
+            return True
+        except Exception:
+            return False
 
     def _locator_from_ref(self, inst: CamoufoxInstance, ref: str):
         """Build a Playwright locator from a stored ref's role, name, and index.
@@ -1220,7 +1237,8 @@ class BrowserManager:
             await asyncio.sleep(x11_step_delay())
 
     async def _x11_ensure_in_viewport(
-        self, inst: CamoufoxInstance, locator,
+        self, inst: CamoufoxInstance, locator, *,
+        timeout: int = _CLICK_TIMEOUT_MS,
     ) -> None:
         """Scroll element into viewport using X11 wheel events.
 
@@ -1236,12 +1254,12 @@ class BrowserManager:
         scrollable inner containers, elements not yet in the DOM).
         """
         if not inst.x11_wid:
-            await locator.scroll_into_view_if_needed(timeout=_CLICK_TIMEOUT_MS)
+            await locator.scroll_into_view_if_needed(timeout=timeout)
             return
 
         vp = inst.page.viewport_size
         if not vp:
-            await locator.scroll_into_view_if_needed(timeout=_CLICK_TIMEOUT_MS)
+            await locator.scroll_into_view_if_needed(timeout=timeout)
             return
 
         vp_h = vp["height"]
@@ -1279,9 +1297,10 @@ class BrowserManager:
                 break  # Scroll didn't move element — inner container
 
         # Fallback for edge cases
-        await locator.scroll_into_view_if_needed(timeout=_CLICK_TIMEOUT_MS)
+        await locator.scroll_into_view_if_needed(timeout=timeout)
 
-    async def _x11_click(self, inst: CamoufoxInstance, locator) -> None:
+    async def _x11_click(self, inst: CamoufoxInstance, locator, *,
+                         timeout: int = _CLICK_TIMEOUT_MS) -> None:
         """Click via xdotool for isTrusted=true events.
 
         Bot-detection systems (ArkoseLabs on X/Twitter) hook addEventListener
@@ -1299,7 +1318,7 @@ class BrowserManager:
         4. mousedown + human dwell + mouseup (not instant click)
         """
         # 1. Scroll into view — prefer X11 wheel events over protocol scroll
-        await self._x11_ensure_in_viewport(inst, locator)
+        await self._x11_ensure_in_viewport(inst, locator, timeout=timeout)
         await asyncio.sleep(x11_settle_delay())
 
         # 2. Get element position — jitter within inner area, not dead center
@@ -1554,6 +1573,7 @@ class BrowserManager:
         self, agent_id: str, ref: str | None = None,
         selector: str | None = None, force: bool = False,
         snapshot_after: bool = False,
+        timeout_ms: int | None = None,
     ) -> dict:
         """Click element by ref or CSS selector.
 
@@ -1576,6 +1596,8 @@ class BrowserManager:
                         "success": False,
                         "error": "User has browser control — action paused until control is released.",
                     }
+                raw_timeout = _CLICK_TIMEOUT_MS if timeout_ms is None else timeout_ms
+                _timeout = max(1000, min(raw_timeout, 30000))
                 use_force = force
                 if ref and ref in inst.refs:
                     ref_info = inst.refs[ref]
@@ -1600,30 +1622,30 @@ class BrowserManager:
                     if locator:
                         if inst.x11_wid and self._is_x11_site(inst):
                             try:
-                                await self._x11_click(inst, locator)
+                                await self._x11_click(inst, locator, timeout=_timeout)
                             except Exception as e:
                                 logger.warning(
                                     "X11 click failed for '%s', falling back to CDP: %s",
                                     agent_id, e,
                                 )
-                                await self._human_click(inst.page, locator, force=use_force)
+                                await self._human_click(inst.page, locator, force=use_force, timeout=_timeout)
                         else:
-                            await self._human_click(inst.page, locator, force=use_force)
+                            await self._human_click(inst.page, locator, force=use_force, timeout=_timeout)
                     else:
                         return {"success": False, "error": f"Ref '{ref}' not found"}
                 elif selector:
                     if inst.x11_wid and self._is_x11_site(inst):
                         loc = inst.page.locator(selector).first
                         try:
-                            await self._x11_click(inst, loc)
+                            await self._x11_click(inst, loc, timeout=_timeout)
                         except Exception as e:
                             logger.warning(
                                 "X11 click failed for '%s' (selector), falling back to CDP: %s",
                                 agent_id, e,
                             )
-                            await self._human_click_selector(inst.page, selector, force=force)
+                            await self._human_click_selector(inst.page, selector, force=force, timeout=_timeout)
                     else:
-                        await self._human_click_selector(inst.page, selector, force=force)
+                        await self._human_click_selector(inst.page, selector, force=force, timeout=_timeout)
                 else:
                     return {"success": False, "error": "Must provide ref or selector"}
                 await asyncio.sleep(action_delay())
@@ -1642,17 +1664,15 @@ class BrowserManager:
                     if is_close:
                         await asyncio.sleep(0.3)
                         still_open = False
+                        vp = inst.page.viewport_size
                         try:
                             modal_els = await inst.page.query_selector_all(
                                 _MODAL_SELECTOR,
                             )
                             for el in modal_els:
-                                try:
-                                    if await el.is_visible():
-                                        still_open = True
-                                        break
-                                except Exception:
-                                    pass
+                                if await self._is_visible_modal(el, vp):
+                                    still_open = True
+                                    break
                         except Exception:
                             pass
                         if still_open:

--- a/tests/test_browser_service.py
+++ b/tests/test_browser_service.py
@@ -3381,7 +3381,11 @@ class TestDialogScoping:
         mock_page = AsyncMock()
         mock_modal_el = AsyncMock()
         mock_modal_el.is_visible = AsyncMock(return_value=True)
+        mock_modal_el.bounding_box = AsyncMock(return_value={
+            "x": 100, "y": 100, "width": 400, "height": 300,
+        })
         mock_page.query_selector_all = AsyncMock(return_value=[mock_modal_el])
+        mock_page.viewport_size = {"width": 1280, "height": 720}
 
         async def _snapshot(root=None):
             if root is not None:
@@ -3396,6 +3400,7 @@ class TestDialogScoping:
         """Create a mock page where DOM has no visible modal elements."""
         mock_page = AsyncMock()
         mock_page.query_selector_all = AsyncMock(return_value=[])
+        mock_page.viewport_size = {"width": 1280, "height": 720}
         mock_page.accessibility = MagicMock()
         mock_page.accessibility.snapshot = AsyncMock(return_value=full_tree)
         return mock_page
@@ -3685,7 +3690,11 @@ class TestDialogScoping:
         mock_page = AsyncMock()
         mock_modal_el = AsyncMock()
         mock_modal_el.is_visible = AsyncMock(return_value=True)
+        mock_modal_el.bounding_box = AsyncMock(return_value={
+            "x": 100, "y": 100, "width": 400, "height": 300,
+        })
         mock_page.query_selector_all = AsyncMock(return_value=[mock_modal_el])
+        mock_page.viewport_size = {"width": 1280, "height": 720}
 
         async def _snapshot(root=None):
             if root is not None:
@@ -3734,7 +3743,11 @@ class TestDialogScoping:
         mock_page = AsyncMock()
         mock_modal_el = AsyncMock()
         mock_modal_el.is_visible = AsyncMock(return_value=True)
+        mock_modal_el.bounding_box = AsyncMock(return_value={
+            "x": 100, "y": 100, "width": 400, "height": 300,
+        })
         mock_page.query_selector_all = AsyncMock(return_value=[mock_modal_el])
+        mock_page.viewport_size = {"width": 1280, "height": 720}
 
         async def _snapshot(root=None):
             if root is not None:
@@ -3867,8 +3880,12 @@ class TestDialogScoping:
         mock_page = AsyncMock()
         mock_modal_el = AsyncMock()
         mock_modal_el.is_visible = AsyncMock(return_value=True)
+        mock_modal_el.bounding_box = AsyncMock(return_value={
+            "x": 100, "y": 100, "width": 400, "height": 300,
+        })
         mock_modal_el.evaluate = AsyncMock(return_value=None)
         mock_page.query_selector_all = AsyncMock(return_value=[mock_modal_el])
+        mock_page.viewport_size = {"width": 1280, "height": 720}
 
         async def _snapshot(root=None):
             if root is not None:
@@ -3908,11 +3925,15 @@ class TestDialogScoping:
         mock_page = AsyncMock()
         mock_modal_el = AsyncMock()
         mock_modal_el.is_visible = AsyncMock(return_value=True)
+        mock_modal_el.bounding_box = AsyncMock(return_value={
+            "x": 100, "y": 100, "width": 400, "height": 300,
+        })
         # JS fallback for scoped snapshot also fails
         mock_modal_el.evaluate = AsyncMock(
             side_effect=RuntimeError("evaluate failed")
         )
         mock_page.query_selector_all = AsyncMock(return_value=[mock_modal_el])
+        mock_page.viewport_size = {"width": 1280, "height": 720}
 
         async def _snapshot(root=None):
             if root is not None:
@@ -3984,7 +4005,13 @@ class TestDialogScoping:
         mock_parent = AsyncMock()
         mock_child = AsyncMock()
         mock_parent.is_visible = AsyncMock(return_value=True)
+        mock_parent.bounding_box = AsyncMock(return_value={
+            "x": 100, "y": 100, "width": 400, "height": 300,
+        })
         mock_child.is_visible = AsyncMock(return_value=True)
+        mock_child.bounding_box = AsyncMock(return_value={
+            "x": 150, "y": 150, "width": 200, "height": 100,
+        })
         # parent.contains(child) = True, child.contains(parent) = False
         mock_parent.evaluate = AsyncMock(
             side_effect=lambda js, arg: arg is mock_child
@@ -3993,6 +4020,7 @@ class TestDialogScoping:
         mock_page.query_selector_all = AsyncMock(
             return_value=[mock_parent, mock_child]
         )
+        mock_page.viewport_size = {"width": 1280, "height": 720}
 
         child_subtree = {
             "role": "dialog", "name": "Confirm",
@@ -4144,9 +4172,13 @@ class TestJsA11yTreeFallback:
 
         mock_page = AsyncMock()
         mock_page.evaluate = AsyncMock(return_value=full_tree)
+        mock_page.viewport_size = {"width": 1280, "height": 720}
 
         mock_modal_el = AsyncMock()
         mock_modal_el.is_visible = AsyncMock(return_value=True)
+        mock_modal_el.bounding_box = AsyncMock(return_value={
+            "x": 100, "y": 100, "width": 400, "height": 300,
+        })
         mock_modal_el.evaluate = AsyncMock(return_value=dialog_tree)
         mock_page.query_selector_all = AsyncMock(return_value=[mock_modal_el])
 
@@ -5030,7 +5062,7 @@ class TestX11Input:
 
         result = await mgr.click("agent-1", ref="B1")
         assert result["success"]
-        mgr._x11_click.assert_called_once_with(inst, mock_locator)
+        mgr._x11_click.assert_called_once_with(inst, mock_locator, timeout=10000)
 
     @pytest.mark.asyncio
     async def test_type_text_clear_false_skips_x11_key(self):
@@ -5402,10 +5434,13 @@ class TestModalRetryRequery:
             ],
         }
 
+        _bb = {"x": 100, "y": 100, "width": 400, "height": 300}
         stale_el = AsyncMock()
         stale_el.is_visible = AsyncMock(return_value=True)
+        stale_el.bounding_box = AsyncMock(return_value=_bb)
         fresh_el = AsyncMock()
         fresh_el.is_visible = AsyncMock(return_value=True)
+        fresh_el.bounding_box = AsyncMock(return_value=_bb)
 
         query_call_count = [0]
 
@@ -5417,6 +5452,7 @@ class TestModalRetryRequery:
 
         mock_page = AsyncMock()
         mock_page.query_selector_all = mock_query_selector_all
+        mock_page.viewport_size = {"width": 1280, "height": 720}
 
         async def _snapshot(root=None):
             if root is stale_el:
@@ -5462,10 +5498,14 @@ class TestModalRetryRequery:
         # Modal is visible but a11y tree always returns None (scoping always fails)
         modal_el = AsyncMock()
         modal_el.is_visible = AsyncMock(return_value=True)
+        modal_el.bounding_box = AsyncMock(return_value={
+            "x": 100, "y": 100, "width": 400, "height": 300,
+        })
         modal_el.evaluate = AsyncMock(return_value=None)
 
         mock_page = AsyncMock()
         mock_page.query_selector_all = AsyncMock(return_value=[modal_el])
+        mock_page.viewport_size = {"width": 1280, "height": 720}
 
         async def _snapshot(root=None):
             if root is not None:


### PR DESCRIPTION
## Summary

Three browser improvements from agent feedback, reviewed by principal engineer + Codex:

- **Modal bounding box filter**: `_is_visible_modal()` checks `is_visible()` + `bounding_box()` for minimum 10x10 area and viewport overlap. Filters zero-area or off-screen elements (LinkedIn messaging panels) that pass `is_visible()`. Applied across all 3 modal check sites.

- **`clear=False` on browser_type**: Exposes the existing `clear` parameter to agents. Service layer already supported it — only the skill parameter was missing. Description warns about caret-placement unpredictability in rich-text editors.

- **Configurable click timeout**: `browser_click` accepts `timeout_ms` (default 10s, max 30s) for heavy SPAs with animations. Uses explicit `None` check (not `or`) to handle `timeout_ms=0` correctly. Threaded through server → click() → _x11_click/_human_click.

## Test plan
- [x] 475 tests pass (browser service + builtins)
- [ ] CI passes