### PR TITLE
Fix spurious 'connection interrupted' error after SSE chat completes

### DIFF
--- a/src/dashboard/server.py
+++ b/src/dashboard/server.py
@@ -1353,6 +1353,7 @@ def create_dashboard_router(
                                           if k != "type"} | {"session": chat_session})
                             if etype == "done":
                                 final_response = event.get("response", "")
+                                break
             except Exception as e:
                 yield f"data: {json.dumps({'type': 'error', 'message': friendly_streaming_error(e)})}\n\n"
             # Notify other sessions that the response is complete
@@ -1448,6 +1449,8 @@ def create_dashboard_router(
                     if isinstance(event, dict):
                         tagged = {**event, "agent": aid}
                         await queue.put(tagged)
+                        if event.get("type") == "done":
+                            break
                         if event_bus:
                             etype = event.get("type", "")
                             if etype in ("tool_start", "tool_result"):


### PR DESCRIPTION
## Summary
- Break out of SSE stream loop after receiving `"type": "done"` event in both `api_chat_stream` and `api_broadcast_stream` endpoints
- The agent's `chat_stream()` always yields `done` as its terminal event — continuing to iterate after that hits a `RemoteProtocolError` when the agent container closes, producing a false error to the client

## Test plan
- Send a chat message to any agent via the dashboard — should no longer show "Connection to the AI provider was interrupted. Retrying may help." after the response completes
- Broadcast a message to multiple agents — same fix applied