### PR TITLE
Hot-reload model and thinking changes without container restart

### DIFF
--- a/src/agent/server.py
+++ b/src/agent/server.py
@@ -413,6 +413,36 @@ def create_agent_app(loop: AgentLoop) -> FastAPI:
         path.write_text(content)
         return {"updated": True, "size": path.stat().st_size}
 
+    @app.post("/config")
+    async def update_runtime_config(request: Request) -> dict:
+        """Hot-reload runtime config (model, thinking) without container restart.
+
+        Mesh pushes here after the operator confirms a model/thinking edit
+        so the next LLM call uses the new setting. Fields read from env vars
+        at startup (LLM_MODEL, THINKING) don't get picked up by YAML edits
+        on their own — this endpoint closes that gap.
+        """
+        if not request.headers.get("x-mesh-internal"):
+            raise HTTPException(
+                403,
+                "Runtime config updates require X-Mesh-Internal header.",
+            )
+        body = await request.json()
+        updated: dict[str, str] = {}
+        if "model" in body:
+            model = body["model"]
+            if not isinstance(model, str) or not model:
+                raise HTTPException(400, "model must be a non-empty string")
+            loop.llm.default_model = model
+            updated["model"] = model
+        if "thinking" in body:
+            thinking = body["thinking"]
+            if thinking not in ("off", "low", "medium", "high"):
+                raise HTTPException(400, "thinking must be one of: off, low, medium, high")
+            loop.llm.thinking = thinking
+            updated["thinking"] = thinking
+        return {"updated": updated}
+
     @app.get("/workspace-logs")
     async def workspace_logs(days: int = 3) -> dict:
         """Return daily logs for the dashboard (read-only)."""

--- a/src/host/server.py
+++ b/src/host/server.py
@@ -2435,6 +2435,25 @@ def create_mesh_app(
                 except Exception:
                     pass  # Agent might not be running
 
+        # Hot-reload: runtime config (model, thinking) — env-var fields that
+        # won't get picked up by the YAML write alone.
+        if (
+            transport
+            and agent_id in router.agent_registry
+            and field in ("model", "thinking")
+            and isinstance(new_value, str)
+        ):
+            try:
+                await transport.request(
+                    agent_id, "POST", "/config",
+                    json={field: new_value}, timeout=10,
+                )
+            except Exception as e:
+                logger.warning(
+                    "Failed to hot-reload %s for '%s': %s",
+                    field, agent_id, e,
+                )
+
         # Heartbeat schedule sync: if the value looks like a cron schedule
         # (5-field expression or "every Xm/h/d"), update the cron job too.
         # This handles the common case where the operator edits heartbeat

--- a/tests/test_agent_server.py
+++ b/tests/test_agent_server.py
@@ -278,6 +278,75 @@ class TestProjectEndpoint:
             assert resp.status_code == 400
 
 
+class TestRuntimeConfig:
+    @pytest.mark.asyncio
+    async def test_update_model_hot_reloads_llm(self, tmp_workspace):
+        """POST /config updates llm.default_model immediately."""
+        app, loop = _make_app(tmp_workspace)
+        loop.llm = MagicMock()
+        loop.llm.default_model = "openai/gpt-4o-mini"
+        loop.llm.thinking = "off"
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+            resp = await client.post(
+                "/config",
+                json={"model": "openai/gpt-4o"},
+                headers={"x-mesh-internal": "1"},
+            )
+            assert resp.status_code == 200
+            assert resp.json() == {"updated": {"model": "openai/gpt-4o"}}
+            assert loop.llm.default_model == "openai/gpt-4o"
+
+    @pytest.mark.asyncio
+    async def test_update_thinking_hot_reloads_llm(self, tmp_workspace):
+        """POST /config updates llm.thinking immediately."""
+        app, loop = _make_app(tmp_workspace)
+        loop.llm = MagicMock()
+        loop.llm.default_model = "openai/gpt-4o-mini"
+        loop.llm.thinking = "off"
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+            resp = await client.post(
+                "/config",
+                json={"thinking": "high"},
+                headers={"x-mesh-internal": "1"},
+            )
+            assert resp.status_code == 200
+            assert loop.llm.thinking == "high"
+
+    @pytest.mark.asyncio
+    async def test_update_config_requires_mesh_header(self, tmp_workspace):
+        """POST /config rejects requests without X-Mesh-Internal header."""
+        app, _ = _make_app(tmp_workspace)
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+            resp = await client.post("/config", json={"model": "openai/gpt-4o"})
+            assert resp.status_code == 403
+
+    @pytest.mark.asyncio
+    async def test_update_config_rejects_invalid_thinking(self, tmp_workspace):
+        """POST /config rejects invalid thinking values."""
+        app, loop = _make_app(tmp_workspace)
+        loop.llm = MagicMock()
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+            resp = await client.post(
+                "/config",
+                json={"thinking": "extreme"},
+                headers={"x-mesh-internal": "1"},
+            )
+            assert resp.status_code == 400
+
+    @pytest.mark.asyncio
+    async def test_update_config_rejects_empty_model(self, tmp_workspace):
+        """POST /config rejects empty model string."""
+        app, loop = _make_app(tmp_workspace)
+        loop.llm = MagicMock()
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+            resp = await client.post(
+                "/config",
+                json={"model": ""},
+                headers={"x-mesh-internal": "1"},
+            )
+            assert resp.status_code == 400
+
+
 class TestWorkspaceLogs:
     @pytest.mark.asyncio
     async def test_workspace_logs_returns_content(self, tmp_workspace):


### PR DESCRIPTION
## Summary

- **The bug**: Operator `propose_edit(agent_id, "model", "openai/...")` writes to agents.yaml but the running container keeps using the old `LLM_MODEL` env var from startup. Agents continue hitting the old provider (e.g. Anthropic) and getting rate-limited until manual restart.
- **The fix**: Add `POST /config` endpoint on the agent that updates `llm.default_model` and `llm.thinking` in place. Mesh pushes to this endpoint after applying the config change, alongside the existing workspace hot-reloads for instructions/soul/heartbeat.
- **Result**: Next LLM call picks up the new setting. No container restart, no loss of in-memory state (active chats, task progress).

## Fields covered
`model` and `thinking` — the two `_VALID_FIELDS` that map to env vars read only at agent startup.

## Out of scope
Dashboard path (`PUT /api/agents/{id}/config`) still returns `restart_required: true` for model/thinking. Could be migrated to use the same hot-reload in a follow-up for consistency.

## Test plan
- [x] 5 new tests in `TestRuntimeConfig` covering: model update, thinking update, missing mesh header, invalid thinking value, empty model
- [x] All 3156 relevant tests pass (12 test_credentials.py failures are pre-existing flaky order-dependent failures on main — verified independently)