### PR TITLE
Harden hot-reload: validate at propose, atomicity, error surfacing

### DIFF
--- a/src/agent/llm.py
+++ b/src/agent/llm.py
@@ -29,7 +29,7 @@ class LLMClient:
     """LLM interface that routes all calls through the mesh API proxy."""
 
     _THINKING_BUDGETS = {"low": 5_000, "medium": 10_000, "high": 25_000}
-    _VALID_THINKING_LEVELS = {"off", "low", "medium", "high"}
+    VALID_THINKING_LEVELS = {"off", "low", "medium", "high"}
 
     def __init__(
         self,
@@ -39,10 +39,10 @@ class LLMClient:
         embedding_model: str = "",
         thinking: str = "off",
     ):
-        if thinking and thinking not in self._VALID_THINKING_LEVELS:
+        if thinking and thinking not in self.VALID_THINKING_LEVELS:
             logger.warning(
                 "Invalid thinking level '%s', falling back to 'off'. "
-                "Valid: %s", thinking, ", ".join(sorted(self._VALID_THINKING_LEVELS)),
+                "Valid: %s", thinking, ", ".join(sorted(self.VALID_THINKING_LEVELS)),
             )
             thinking = "off"
         self.mesh_url = mesh_url

--- a/src/agent/server.py
+++ b/src/agent/server.py
@@ -427,18 +427,29 @@ def create_agent_app(loop: AgentLoop) -> FastAPI:
                 403,
                 "Runtime config updates require X-Mesh-Internal header.",
             )
+        if not loop.llm:
+            raise HTTPException(503, "LLM client not available")
         body = await request.json()
+        if not isinstance(body, dict):
+            raise HTTPException(400, "Body must be a JSON object")
+
+        # Validate all fields before applying any (atomicity).
+        from src.agent.llm import LLMClient
+        model = body.get("model") if "model" in body else None
+        thinking = body.get("thinking") if "thinking" in body else None
+        if "model" in body and (not isinstance(model, str) or not model):
+            raise HTTPException(400, "model must be a non-empty string")
+        if "thinking" in body and thinking not in LLMClient.VALID_THINKING_LEVELS:
+            raise HTTPException(
+                400,
+                f"thinking must be one of: {sorted(LLMClient.VALID_THINKING_LEVELS)}",
+            )
+
         updated: dict[str, str] = {}
         if "model" in body:
-            model = body["model"]
-            if not isinstance(model, str) or not model:
-                raise HTTPException(400, "model must be a non-empty string")
             loop.llm.default_model = model
             updated["model"] = model
         if "thinking" in body:
-            thinking = body["thinking"]
-            if thinking not in ("off", "low", "medium", "high"):
-                raise HTTPException(400, "thinking must be one of: off, low, medium, high")
             loop.llm.thinking = thinking
             updated["thinking"] = thinking
         return {"updated": updated}

--- a/src/host/server.py
+++ b/src/host/server.py
@@ -2336,6 +2336,21 @@ def create_mesh_app(
         if field not in _VALID_CONFIG_FIELDS:
             raise HTTPException(400, f"Invalid field: {field}. Must be one of: {_VALID_CONFIG_FIELDS}")
 
+        # Validate runtime-critical values before they can be persisted to
+        # YAML. The agent-side hot-reload endpoint also rejects these, but
+        # catching them here prevents a bad value from being stored as a
+        # pending change, confirmed, and surviving across restarts.
+        if field == "model":
+            if not isinstance(new_value, str) or not new_value:
+                raise HTTPException(400, "model must be a non-empty string")
+        elif field == "thinking":
+            from src.agent.llm import LLMClient
+            if new_value not in LLMClient.VALID_THINKING_LEVELS:
+                raise HTTPException(
+                    400,
+                    f"thinking must be one of: {sorted(LLMClient.VALID_THINKING_LEVELS)}",
+                )
+
         # Get current value
         from src.cli.config import _load_config
         agent_cfg = _load_config()
@@ -2444,10 +2459,20 @@ def create_mesh_app(
             and isinstance(new_value, str)
         ):
             try:
-                await transport.request(
+                result = await transport.request(
                     agent_id, "POST", "/config",
                     json={field: new_value}, timeout=10,
                 )
+                # transport.request returns {"error": ...} dicts for HTTP /
+                # timeout / connect failures rather than raising. Surface
+                # those so a silent agent-side failure isn't mistaken for
+                # success — the YAML write is durable, but runtime state
+                # only catches up on restart.
+                if isinstance(result, dict) and "error" in result:
+                    logger.warning(
+                        "Hot-reload %s for '%s' returned error: %s",
+                        field, agent_id, result["error"],
+                    )
             except Exception as e:
                 logger.warning(
                     "Failed to hot-reload %s for '%s': %s",
@@ -2527,7 +2552,9 @@ def create_mesh_app(
         change = _get_pending_change(change_id)
         if not change:
             raise HTTPException(404, "Change not found or expired")
-        # Consume only after validation — if apply fails, the change survives for retry
+        # Consume before apply to prevent double-apply on retry. If
+        # _apply_pending_change raises, the change is already gone — the
+        # caller must propose a new change rather than retry this one.
         _consume_pending_change(change_id)
 
         return await _apply_pending_change(change_id, change)

--- a/tests/test_agent_server.py
+++ b/tests/test_agent_server.py
@@ -346,6 +346,111 @@ class TestRuntimeConfig:
             )
             assert resp.status_code == 400
 
+    @pytest.mark.asyncio
+    async def test_update_model_and_thinking_together(self, tmp_workspace):
+        """POST /config updates both fields in a single request."""
+        app, loop = _make_app(tmp_workspace)
+        loop.llm = MagicMock()
+        loop.llm.default_model = "openai/gpt-4o-mini"
+        loop.llm.thinking = "off"
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+            resp = await client.post(
+                "/config",
+                json={"model": "openai/gpt-4o", "thinking": "medium"},
+                headers={"x-mesh-internal": "1"},
+            )
+            assert resp.status_code == 200
+            assert loop.llm.default_model == "openai/gpt-4o"
+            assert loop.llm.thinking == "medium"
+            assert resp.json()["updated"] == {
+                "model": "openai/gpt-4o", "thinking": "medium",
+            }
+
+    @pytest.mark.asyncio
+    async def test_update_config_atomic_on_invalid_thinking(self, tmp_workspace):
+        """Invalid thinking rejects the whole request; model not partially applied."""
+        app, loop = _make_app(tmp_workspace)
+        loop.llm = MagicMock()
+        loop.llm.default_model = "openai/gpt-4o-mini"
+        loop.llm.thinking = "off"
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+            resp = await client.post(
+                "/config",
+                json={"model": "openai/gpt-4o", "thinking": "bogus"},
+                headers={"x-mesh-internal": "1"},
+            )
+            assert resp.status_code == 400
+            # Neither field was applied
+            assert loop.llm.default_model == "openai/gpt-4o-mini"
+            assert loop.llm.thinking == "off"
+
+    @pytest.mark.asyncio
+    async def test_update_config_empty_body_is_noop(self, tmp_workspace):
+        """POST /config with empty body returns empty updated dict, doesn't error."""
+        app, loop = _make_app(tmp_workspace)
+        loop.llm = MagicMock()
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+            resp = await client.post(
+                "/config", json={}, headers={"x-mesh-internal": "1"},
+            )
+            assert resp.status_code == 200
+            assert resp.json() == {"updated": {}}
+
+    @pytest.mark.asyncio
+    async def test_update_config_ignores_unknown_fields(self, tmp_workspace):
+        """Unknown fields in body are silently ignored (not 400)."""
+        app, loop = _make_app(tmp_workspace)
+        loop.llm = MagicMock()
+        loop.llm.default_model = "openai/gpt-4o-mini"
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+            resp = await client.post(
+                "/config",
+                json={"foo": "bar", "model": "openai/gpt-4o"},
+                headers={"x-mesh-internal": "1"},
+            )
+            assert resp.status_code == 200
+            assert loop.llm.default_model == "openai/gpt-4o"
+            assert "foo" not in resp.json()["updated"]
+
+    @pytest.mark.asyncio
+    async def test_update_config_rejects_non_string_model(self, tmp_workspace):
+        """POST /config rejects non-string model value."""
+        app, loop = _make_app(tmp_workspace)
+        loop.llm = MagicMock()
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+            resp = await client.post(
+                "/config",
+                json={"model": 123},
+                headers={"x-mesh-internal": "1"},
+            )
+            assert resp.status_code == 400
+
+    @pytest.mark.asyncio
+    async def test_update_config_returns_503_without_llm(self, tmp_workspace):
+        """POST /config returns 503 if loop.llm is missing."""
+        app, loop = _make_app(tmp_workspace)
+        loop.llm = None
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+            resp = await client.post(
+                "/config",
+                json={"model": "openai/gpt-4o"},
+                headers={"x-mesh-internal": "1"},
+            )
+            assert resp.status_code == 503
+
+    @pytest.mark.asyncio
+    async def test_update_config_rejects_non_object_body(self, tmp_workspace):
+        """POST /config rejects a JSON array/string body."""
+        app, loop = _make_app(tmp_workspace)
+        loop.llm = MagicMock()
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+            resp = await client.post(
+                "/config",
+                json=["model", "openai/gpt-4o"],
+                headers={"x-mesh-internal": "1"},
+            )
+            assert resp.status_code == 400
+
 
 class TestWorkspaceLogs:
     @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Follow-up to #727 polish based on a principal-engineer review pass (with Codex second opinion).

- **Validate model/thinking at the mesh propose endpoint** before storing pending changes. Previously invalid values could be persisted to agents.yaml via `confirm_edit`, surviving across restarts even though the agent-side hot-reload rejected them (Codex blocker).
- **Promote `VALID_THINKING_LEVELS` to public** so cross-module callers don't depend on a private-looking attribute.
- **Atomic multi-field updates** in `POST /config` — validate all fields before applying any, so `{model: valid, thinking: bogus}` can't partially apply model then 400.
- **Surface transport error-dict returns** in the mesh-side hot-reload. Previously HTTP/timeout/connect failures from the agent were silently discarded because `transport.request()` returns `{error: ...}` rather than raising.
- **Guard `POST /config` against `loop.llm` being None** (503 instead of AttributeError → 500).
- **Reject non-object bodies explicitly** (400 instead of crashing).
- **Fix misleading comment** about pending-change retry — change is consumed before apply, so a failed apply is not retryable.

## Scope explicitly excluded

- **Dashboard path**: `PUT /api/agents/{id}/config` still returns `restart_required: true` for model/thinking. Could share the hot-reload push in a follow-up.
- **Token-budget race** (`loop.py:645` records usage against mutable `self.llm.default_model` post-await): latent pre-existing, tracked separately.
- **Mesh-side integration test for the propose endpoint**: requires auth-token scaffolding; validation logic mirrors already-tested agent-side rules.

## Test plan
- [x] 7 new agent-server tests covering: both fields together, atomicity on invalid thinking, empty body no-op, unknown fields ignored, non-string model rejection, missing llm → 503, non-object body → 400
- [x] 3163 tests pass (12 pre-existing flaky `test_credentials.py` order-dependent failures exist on main too)