### PR TITLE
Hot-reload model/thinking from dashboard so UI matches runtime

### DIFF
--- a/src/dashboard/server.py
+++ b/src/dashboard/server.py
@@ -867,6 +867,30 @@ def create_dashboard_router(
             cfg_result["vnc_url"] = vnc_url
         return cfg_result
 
+    async def _hot_reload_runtime_config(agent_id: str, payload: dict) -> bool:
+        """Push model/thinking changes to a running agent's /config endpoint.
+
+        Returns True on success, False if the agent is unreachable or the
+        update returns an error. Callers use the return value to decide
+        whether restart_required should remain True.
+        """
+        if transport is None or agent_id not in agent_registry:
+            return False
+        try:
+            result = await transport.request(
+                agent_id, "POST", "/config", json=payload, timeout=10,
+            )
+        except Exception as e:
+            logger.warning("Hot-reload runtime config for '%s' failed: %s", agent_id, e)
+            return False
+        if isinstance(result, dict) and "error" in result:
+            logger.warning(
+                "Hot-reload runtime config for '%s' returned error: %s",
+                agent_id, result["error"],
+            )
+            return False
+        return True
+
     @api_router.put("/api/agents/{agent_id}/config")
     async def api_update_agent_config(agent_id: str, request: Request) -> dict:
         if agent_id not in agent_registry:
@@ -879,6 +903,7 @@ def create_dashboard_router(
 
         updated = []
         restart_required = False
+        runtime_payload: dict[str, str] = {}
 
         if "model" in body:
             new_model = body["model"]
@@ -888,7 +913,7 @@ def create_dashboard_router(
             if new_model != old_model:
                 _update_agent_field(agent_id, "model", new_model)
                 updated.append("model")
-                restart_required = True
+                runtime_payload["model"] = new_model
 
         if "role" in body:
             _update_agent_field(agent_id, "role", body["role"])
@@ -934,14 +959,18 @@ def create_dashboard_router(
 
         if "thinking" in body:
             thinking_val = body["thinking"]
-            if thinking_val not in ("off", "low", "medium", "high"):
+            from src.agent.llm import LLMClient
+            if thinking_val not in LLMClient.VALID_THINKING_LEVELS:
                 raise HTTPException(
                     status_code=400,
-                    detail="thinking must be one of: off, low, medium, high",
+                    detail=(
+                        "thinking must be one of: "
+                        f"{sorted(LLMClient.VALID_THINKING_LEVELS)}"
+                    ),
                 )
             _update_agent_field(agent_id, "thinking", thinking_val)
             updated.append("thinking")
-            restart_required = True
+            runtime_payload["thinking"] = thinking_val
 
         if "mcp_servers" in body:
             mcp_val = body["mcp_servers"]
@@ -956,6 +985,14 @@ def create_dashboard_router(
             _update_agent_field(agent_id, "mcp_servers", mcp_val if mcp_val else None)
             updated.append("mcp_servers")
             restart_required = True
+
+        # Hot-reload model/thinking into the running agent so dashboard
+        # display matches actual runtime state. If the push fails, fall back
+        # to restart_required so the UI can prompt the user.
+        if runtime_payload:
+            hot_reloaded = await _hot_reload_runtime_config(agent_id, runtime_payload)
+            if not hot_reloaded:
+                restart_required = True
 
         return {"updated": updated, "restart_required": restart_required}
 

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -819,6 +819,56 @@ class TestDashboardAgentConfig:
             )
             assert resp.status_code == 400
 
+    @patch("src.cli.config._update_agent_field")
+    @patch("src.cli.config._load_config")
+    def test_put_config_model_hot_reload_clears_restart_required(
+        self, mock_load, mock_update,
+    ):
+        """When hot-reload succeeds, restart_required is False."""
+        mock_load.return_value = {
+            "llm": {"default_model": "openai/gpt-4.1-mini"},
+            "agents": {"alpha": {"model": "openai/gpt-4.1-mini"}},
+        }
+        # Swap in a transport that returns a successful hot-reload result
+        self.components["transport"].request = AsyncMock(
+            return_value={"updated": {"model": "openai/gpt-4.1"}},
+        )
+        resp = self.client.put(
+            "/dashboard/api/agents/alpha/config",
+            json={"model": "openai/gpt-4.1"},
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert "model" in data["updated"]
+        assert data["restart_required"] is False
+        # Verify the hot-reload call was made to /config
+        call = self.components["transport"].request.await_args
+        assert call.args[0] == "alpha"
+        assert call.args[1] == "POST"
+        assert call.args[2] == "/config"
+        assert call.kwargs["json"] == {"model": "openai/gpt-4.1"}
+
+    @patch("src.cli.config._update_agent_field")
+    @patch("src.cli.config._load_config")
+    def test_put_config_model_hot_reload_failure_requires_restart(
+        self, mock_load, mock_update,
+    ):
+        """When the agent returns an error dict, restart_required falls back to True."""
+        mock_load.return_value = {
+            "llm": {"default_model": "openai/gpt-4.1-mini"},
+            "agents": {"alpha": {"model": "openai/gpt-4.1-mini"}},
+        }
+        self.components["transport"].request = AsyncMock(
+            return_value={"error": "Connection refused"},
+        )
+        resp = self.client.put(
+            "/dashboard/api/agents/alpha/config",
+            json={"model": "openai/gpt-4.1"},
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["restart_required"] is True
+
     def test_put_budget_quick(self):
         resp = self.client.put(
             "/dashboard/api/agents/alpha/budget",


### PR DESCRIPTION
## Summary

Follow-up to #727/#728. The operator path (`propose_edit` + `confirm_edit`) now hot-reloads model/thinking into the running agent, but the **dashboard path** (`PUT /api/agents/{id}/config`) still only wrote YAML and returned `restart_required: True`.

Result: users changing the model via the dashboard UI saw the new model displayed while the agent kept using the old one — same symptom the original bug described, just via a different entry point.

## Fix

- New `_hot_reload_runtime_config` helper in the dashboard router pushes model/thinking to the agent's `POST /config` endpoint
- On success: `restart_required` cleared
- On transport failure / agent error dict: falls back to `restart_required: True` so the UI still prompts for manual restart
- Thinking validation now uses `LLMClient.VALID_THINKING_LEVELS` (no more duplicated enum)

## Test plan
- [x] New test: hot-reload success → `restart_required: False`
- [x] New test: hot-reload failure (error dict) → `restart_required: True`
- [x] Existing tests still pass (MagicMock transport isn't awaitable → my `except` catches TypeError → falls back to `restart_required: True`)
- [x] 3165 tests pass (12 pre-existing flaky `test_credentials.py` order-dependent failures unchanged)