### PR TITLE
Polish operator model awareness: single config load, dedup audit call

### DIFF
--- a/src/dashboard/server.py
+++ b/src/dashboard/server.py
@@ -992,26 +992,36 @@ def create_dashboard_router(
 
         # Phase 2: apply writes now that every field validated.
         updated: list[str] = []
-        for field, value in pending_writes:
-            old = agent_cfg.get(field, "")
-            _update_agent_field(agent_id, field, value)
-            updated.append(field)
-            # Audit so the operator and audit consumers can see
-            # dashboard-initiated edits; the mesh propose/confirm path
-            # already audits via _apply_pending_change.
+        def _audit(field: str, old_value: object, new_value: object) -> None:
+            """Log a dashboard-initiated edit. Never raises — a broken audit
+            sink must not block the caller's config change, but silent
+            failure is worth a warning so it doesn't rot unnoticed."""
             try:
                 blackboard.log_audit(
                     action="edit_agent",
                     target=agent_id,
                     field=field,
-                    before_value=json.dumps(old) if not isinstance(old, str) else old,
-                    after_value=json.dumps(value) if not isinstance(value, str) else value,
+                    before_value=(
+                        old_value if isinstance(old_value, str)
+                        else json.dumps(old_value)
+                    ),
+                    after_value=(
+                        new_value if isinstance(new_value, str)
+                        else json.dumps(new_value)
+                    ),
                     actor="dashboard",
                     provenance="user",
                 )
             except Exception as e:
-                logger.debug("Audit log failed for %s/%s: %s", agent_id, field, e)
+                logger.warning("Audit log failed for %s/%s: %s", agent_id, field, e)
+
+        for field, value in pending_writes:
+            old = agent_cfg.get(field, "")
+            _update_agent_field(agent_id, field, value)
+            updated.append(field)
+            _audit(field, old, value)
         if budget_apply is not None:
+            old_budget = agent_cfg.get("budget", "")
             _update_agent_field(agent_id, "budget", budget_apply)
             cost_tracker.set_budget(
                 agent_id,
@@ -1019,17 +1029,7 @@ def create_dashboard_router(
                 monthly_usd=budget_apply["monthly_usd"],
             )
             updated.append("budget")
-            try:
-                blackboard.log_audit(
-                    action="edit_agent",
-                    target=agent_id,
-                    field="budget",
-                    after_value=json.dumps(budget_apply),
-                    actor="dashboard",
-                    provenance="user",
-                )
-            except Exception as e:
-                logger.debug("Audit log failed for %s/budget: %s", agent_id, e)
+            _audit("budget", old_budget, budget_apply)
 
         # Phase 3: hot-reload runtime state. mcp_servers needs a container
         # restart regardless of hot-reload result.

--- a/src/host/server.py
+++ b/src/host/server.py
@@ -1238,15 +1238,17 @@ def create_mesh_app(
             # Operator also needs per-agent model so dashboard-initiated
             # model changes don't leave its mental state stale. Load the
             # YAML once; other agents don't see models (noise for peers).
+            include_models = agent_id == "operator"
             agent_models: dict[str, str] = {}
-            if agent_id == "operator":
+            if include_models:
                 from src.cli.config import _load_config
-                _fleet_cfg = _load_config().get("agents", {})
-                _default_model = _load_config().get("llm", {}).get(
-                    "default_model", "",
+                _cfg = _load_config()
+                _agents_cfg = _cfg.get("agents", {})
+                _default_model = _cfg.get("llm", {}).get(
+                    "default_model", "openai/gpt-4o-mini",
                 )
                 agent_models = {
-                    aid: _fleet_cfg.get(aid, {}).get("model", _default_model)
+                    aid: _agents_cfg.get(aid, {}).get("model", _default_model)
                     for aid in router.agent_registry
                 }
 
@@ -1254,8 +1256,8 @@ def create_mesh_app(
                 entry: dict = {
                     "id": aid, "role": router.agent_roles.get(aid, ""),
                 }
-                if aid in agent_models:
-                    entry["model"] = agent_models[aid]
+                if include_models:
+                    entry["model"] = agent_models.get(aid, "")
                 return entry
 
             if agent_id == "operator":

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -1050,10 +1050,63 @@ class TestDashboardAgentConfig:
         assert any(
             e["action"] == "edit_agent"
             and e["field"] == "model"
+            and e["before_value"] == "openai/gpt-4.1-mini"
             and e["after_value"] == "openai/gpt-4.1"
             and e["actor"] == "dashboard"
             for e in entries
         )
+
+    @patch("src.cli.config._update_agent_field")
+    @patch("src.cli.config._load_config")
+    def test_put_config_audit_failure_does_not_block_request(
+        self, mock_load, mock_update,
+    ):
+        """A broken audit sink must not fail the config change."""
+        mock_load.return_value = {
+            "llm": {"default_model": "openai/gpt-4.1-mini"},
+            "agents": {"alpha": {"model": "openai/gpt-4.1-mini"}},
+        }
+        self.components["transport"].request = AsyncMock(
+            return_value={"updated": {"model": "openai/gpt-4.1"}},
+        )
+        # Make audit logging raise unconditionally
+        self.components["blackboard"].log_audit = MagicMock(
+            side_effect=RuntimeError("audit db locked"),
+        )
+        resp = self.client.put(
+            "/dashboard/api/agents/alpha/config",
+            json={"model": "openai/gpt-4.1"},
+        )
+        assert resp.status_code == 200
+        assert "model" in resp.json()["updated"]
+
+    @patch("src.cli.config._update_agent_field")
+    @patch("src.cli.config._load_config")
+    def test_put_config_budget_audit_captures_before_value(
+        self, mock_load, mock_update,
+    ):
+        """Budget audit entries include the prior budget, not just the new one."""
+        mock_load.return_value = {
+            "llm": {"default_model": "openai/gpt-4.1-mini"},
+            "agents": {
+                "alpha": {
+                    "model": "openai/gpt-4.1-mini",
+                    "budget": {"daily_usd": 5.0, "monthly_usd": 100.0},
+                },
+            },
+        }
+        resp = self.client.put(
+            "/dashboard/api/agents/alpha/config",
+            json={"budget": {"daily_usd": 7.5, "monthly_usd": 150.0}},
+        )
+        assert resp.status_code == 200
+        entries = self.components["blackboard"].get_audit_log(agent_id="alpha")["entries"]
+        budget_entry = next(
+            e for e in entries
+            if e["field"] == "budget" and e["actor"] == "dashboard"
+        )
+        assert "5.0" in budget_entry["before_value"]
+        assert "7.5" in budget_entry["after_value"]
 
     def test_put_budget_quick(self):
         resp = self.client.put(

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -852,6 +852,36 @@ def test_introspect_operator_fleet_includes_models(tmp_path):
     bb.close()
 
 
+def test_introspect_operator_fleet_model_falls_back_to_runtime_default(tmp_path):
+    """When YAML has no llm.default_model, fleet entries show the agent
+    runtime default (matches src/agent/__main__.py), not empty string."""
+    from unittest.mock import patch
+
+    bb = Blackboard(db_path=str(tmp_path / "bb.db"))
+    pubsub = PubSub()
+    perms = PermissionMatrix.__new__(PermissionMatrix)
+    perms.permissions = {}
+    router = MessageRouter(permissions=perms, agent_registry={})
+    router.register_agent("writer", "http://localhost:8401")
+
+    app = create_mesh_app(bb, pubsub, router, perms)
+    client = TestClient(app)
+
+    # Config has agents but no llm.default_model set
+    fake_cfg = {"agents": {"writer": {}}}
+    with patch("src.cli.config._load_config", return_value=fake_cfg):
+        response = client.get(
+            "/mesh/introspect",
+            params={"section": "fleet"},
+            headers={"X-Agent-ID": "operator"},
+        )
+    assert response.status_code == 200
+    fleet = {a["id"]: a for a in response.json()["fleet"]}
+    assert fleet["writer"]["model"] == "openai/gpt-4o-mini"
+
+    bb.close()
+
+
 def test_introspect_non_operator_fleet_omits_model(tmp_path):
     """Non-operator agents don't see peer models — keeps their context lean."""
     from unittest.mock import patch


### PR DESCRIPTION
## Summary

Follow-up to #732 after a principal-engineer + Codex review pass.

## Fixes

- **Load agents.yaml once per introspect call** instead of twice (was calling \`_load_config()\` for both the agents map and \`llm.default_model\`).
- **Default-model fallback now matches the agent runtime default** (\`openai/gpt-4o-mini\` per \`src/agent/__main__.py:49\`) instead of empty string. Prevents showing \`model: \"\"\` in the operator's fleet context if a deployment somehow lacks \`llm.default_model\`.
- **Dashboard audit logging deduplicated** into a local \`_audit()\` helper so field writes and budget updates share the same stringification rules. Budget audit now captures \`before_value\` (previously only \`after_value\`).
- **Audit failure logs bumped from debug to warning** — a missing audit trail is a real observability gap, not noise to hide.
- **\`include_models\` boolean** replaces the double-branching on \`agent_id == \"operator\"\`.

## Tests added

1. Fleet entries fall back to \`openai/gpt-4o-mini\` when \`llm.default_model\` is absent
2. Audit sink raising does not block \`PUT /config\`
3. Budget audit entries carry \`before_value\`, not just \`after_value\`

## Tracked but out of scope

- Inconsistent no-op-write handling across fields (only \`model\` has an equality check today)
- Persistence atomicity across multi-field updates (each \`_update_agent_field\` rewrites the whole YAML, no batching)

Both are pre-existing behaviors that predate this series; worth separate PRs if they cause real pain.

## Test plan
- [x] 3179 tests pass (12 pre-existing flakes unchanged)
- [x] All 3 new polish tests green