### PR TITLE
feat: add Exa AI-powered search tool

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -26,3 +26,5 @@ OPENLEGION_SYSTEM_OPENAI_API_KEY=sk-your-key-here
 # OPENLEGION_CRED_APOLLO_API_KEY=
 # OPENLEGION_CRED_HUNTER_API_KEY=
 # OPENLEGION_CRED_BRIGHTDATA_CDP_URL=wss://...
+# Powers the exa_search built-in tool (https://exa.ai). EXA_API_KEY is also accepted.
+# OPENLEGION_CRED_EXA_API_KEY=

--- a/docs/agent-tools.md
+++ b/docs/agent-tools.md
@@ -97,6 +97,7 @@ All agents share a single **browser service container** running Camoufox (a stea
 | Tool | Parameters | Description |
 |------|-----------|-------------|
 | `web_search` | `query`, `max_results` | Search via DuckDuckGo (no API key needed) |
+| `exa_search` | `query`, `max_results`, `search_type`, `content_mode`, `text_max_chars`, `category`, `include_domains`, `exclude_domains`, `include_text`, `exclude_text`, `start_published_date`, `end_published_date` | AI-powered search via Exa with highlights/text/summary, category and domain filters, date ranges. Requires `OPENLEGION_CRED_EXA_API_KEY` (or `EXA_API_KEY`) |
 
 ### Self-Extension
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -92,6 +92,7 @@ Each agent runs in an isolated Docker container with its own FastAPI server.
 | `subagent_tool.py` | In-container subagent spawning and management |
 | `wallet_tool.py` | Blockchain wallet operations (address, balance, transfer, contract calls) |
 | `web_search_tool.py` | DuckDuckGo web search (no API key) |
+| `exa_search_tool.py` | AI-powered web search via Exa (requires `OPENLEGION_CRED_EXA_API_KEY` or `EXA_API_KEY`) |
 | `image_gen_tool.py` | Image generation via Gemini or DALL-E 3, saves output as artifacts |
 | `coordination_tool.py` | Structured multi-agent coordination — `hand_off`, `check_inbox`, `update_status` |
 

--- a/src/agent/builtins/exa_search_tool.py
+++ b/src/agent/builtins/exa_search_tool.py
@@ -1,0 +1,415 @@
+"""Web search tool using Exa AI-powered search.
+
+Requires an Exa API key (``OPENLEGION_CRED_EXA_API_KEY`` preferred, with
+``EXA_API_KEY`` accepted as a fallback). Returns semantically ranked results
+with optional highlights, full text, or LLM-generated summary per result.
+Supports category filtering, domain/text filters, and date ranges.
+
+Docs: https://exa.ai/docs/reference/search
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from dataclasses import dataclass, field
+from typing import Any
+
+import httpx
+
+from src.agent.skills import skill
+from src.shared.utils import sanitize_for_prompt
+
+logger = logging.getLogger("agent.exa_search")
+
+_PROVIDER = "exa"
+_API_URL = "https://api.exa.ai/search"
+_INTEGRATION_NAME = "openlegion"
+
+_DEFAULT_MAX_RESULTS = 5
+_MAX_RESULTS = 25
+_DEFAULT_TEXT_CAP = 1000
+_SNIPPET_CAP = 500
+
+_DEFAULT_SEARCH_TYPE = "auto"
+_VALID_SEARCH_TYPES = frozenset({
+    "auto", "neural", "fast", "deep-lite", "deep", "deep-reasoning", "instant",
+})
+
+_DEFAULT_CONTENT_MODE = "highlights"
+_VALID_CONTENT_MODES = frozenset({"highlights", "text", "summary", "all"})
+
+_VALID_CATEGORIES = frozenset({
+    "company", "research paper", "news", "personal site",
+    "financial report", "people",
+})
+
+
+@dataclass(slots=True)
+class ExaResult:
+    """Typed view of a single Exa search result."""
+
+    title: str
+    url: str
+    snippet: str
+    published_date: str | None = None
+    author: str | None = None
+    score: float | None = None
+    highlights: list[str] = field(default_factory=list)
+    summary: str | None = None
+
+    def to_dict(self) -> dict:
+        out: dict[str, Any] = {
+            "title": self.title,
+            "url": self.url,
+            "snippet": self.snippet,
+        }
+        if self.published_date:
+            out["published_date"] = self.published_date
+        if self.author:
+            out["author"] = self.author
+        if self.score is not None:
+            out["score"] = self.score
+        if self.highlights:
+            out["highlights"] = self.highlights
+        if self.summary:
+            out["summary"] = self.summary
+        return out
+
+
+def _get_api_key() -> str:
+    """Resolve the Exa API key from agent-tier or standard env var."""
+    return (
+        os.environ.get("OPENLEGION_CRED_EXA_API_KEY")
+        or os.environ.get("EXA_API_KEY")
+        or ""
+    )
+
+
+def _normalize_max_results(value: Any) -> int:
+    try:
+        return max(1, min(int(value), _MAX_RESULTS))
+    except (TypeError, ValueError):
+        return _DEFAULT_MAX_RESULTS
+
+
+def _build_contents(content_mode: str, text_max_chars: int) -> dict:
+    """Build the ``contents`` payload. Content types are NOT mutually exclusive."""
+    text_cap = text_max_chars if text_max_chars and text_max_chars > 0 else _DEFAULT_TEXT_CAP
+    if content_mode == "text":
+        return {"text": {"maxCharacters": text_cap}}
+    if content_mode == "summary":
+        return {"summary": True}
+    if content_mode == "all":
+        return {
+            "highlights": True,
+            "text": {"maxCharacters": text_cap},
+            "summary": True,
+        }
+    return {"highlights": True}
+
+
+def _extract_snippet(item: dict) -> str:
+    """Cascade through available content fields for a readable snippet."""
+    highlights = item.get("highlights") or []
+    if highlights:
+        joined = " ".join(str(h) for h in highlights if h)
+        if joined:
+            return joined[:_SNIPPET_CAP]
+    summary = item.get("summary")
+    if summary:
+        return str(summary)[:_SNIPPET_CAP]
+    text = item.get("text")
+    if text:
+        return str(text)[:_SNIPPET_CAP]
+    return ""
+
+
+def _parse_result(item: dict) -> ExaResult:
+    highlights_raw = item.get("highlights") or []
+    highlights = [sanitize_for_prompt(str(h)) for h in highlights_raw if h]
+    summary_raw = item.get("summary")
+    summary = sanitize_for_prompt(str(summary_raw)) if summary_raw else None
+    score_raw = item.get("score")
+    try:
+        score = float(score_raw) if score_raw is not None else None
+    except (TypeError, ValueError):
+        score = None
+    return ExaResult(
+        title=sanitize_for_prompt(str(item.get("title") or "")),
+        url=sanitize_for_prompt(str(item.get("url") or "")),
+        snippet=sanitize_for_prompt(_extract_snippet(item)),
+        published_date=item.get("publishedDate") or None,
+        author=sanitize_for_prompt(str(item["author"])) if item.get("author") else None,
+        score=score,
+        highlights=highlights,
+        summary=summary,
+    )
+
+
+def _build_payload(
+    query: str,
+    max_results: int,
+    search_type: str,
+    contents: dict,
+    category: str,
+    include_domains: list[str] | None,
+    exclude_domains: list[str] | None,
+    include_text: list[str] | None,
+    exclude_text: list[str] | None,
+    start_published_date: str,
+    end_published_date: str,
+) -> dict:
+    payload: dict[str, Any] = {
+        "query": query,
+        "numResults": max_results,
+        "type": search_type,
+        "contents": contents,
+    }
+    if category:
+        payload["category"] = category
+    if include_domains:
+        payload["includeDomains"] = list(include_domains)
+    if exclude_domains:
+        payload["excludeDomains"] = list(exclude_domains)
+    if include_text:
+        payload["includeText"] = list(include_text)
+    if exclude_text:
+        payload["excludeText"] = list(exclude_text)
+    if start_published_date:
+        payload["startPublishedDate"] = start_published_date
+    if end_published_date:
+        payload["endPublishedDate"] = end_published_date
+    return payload
+
+
+def _base_response(
+    query: str,
+    requested_max: int,
+    max_results: int,
+    search_type: str,
+    content_mode: str,
+) -> dict:
+    return {
+        "query": query,
+        "results": [],
+        "count": 0,
+        "provider": _PROVIDER,
+        "search_type": search_type,
+        "content_mode": content_mode,
+        "max_results_requested": requested_max,
+        "max_results_used": max_results,
+    }
+
+
+@skill(
+    name="exa_search",
+    description=(
+        "Search the web using Exa AI-powered search. Returns semantically ranked "
+        "results with optional highlights, full text, or LLM-generated summary per "
+        "result. Supports category filtering (company, research paper, news, "
+        "personal site, financial report, people), domain/text filters, and "
+        "published-date ranges. Requires OPENLEGION_CRED_EXA_API_KEY or EXA_API_KEY."
+    ),
+    parameters={
+        "query": {
+            "type": "string",
+            "description": "Natural-language search query",
+        },
+        "max_results": {
+            "type": "integer",
+            "description": "Number of results to return (1-25, default 5)",
+            "default": _DEFAULT_MAX_RESULTS,
+        },
+        "search_type": {
+            "type": "string",
+            "description": (
+                "Search mode. 'auto' (default) lets Exa pick; 'neural' for semantic, "
+                "'fast' for low-latency, 'deep'/'deep-lite'/'deep-reasoning' for "
+                "thorough multi-step research, 'instant' for cached results."
+            ),
+            "enum": sorted(_VALID_SEARCH_TYPES),
+            "default": _DEFAULT_SEARCH_TYPE,
+        },
+        "content_mode": {
+            "type": "string",
+            "description": (
+                "What content to retrieve per result. 'highlights' (default) returns "
+                "LLM-selected snippets; 'text' returns page text; 'summary' returns "
+                "an LLM summary; 'all' returns all three."
+            ),
+            "enum": sorted(_VALID_CONTENT_MODES),
+            "default": _DEFAULT_CONTENT_MODE,
+        },
+        "text_max_chars": {
+            "type": "integer",
+            "description": "Max characters of page text to retrieve per result (default 1000).",
+            "default": _DEFAULT_TEXT_CAP,
+        },
+        "category": {
+            "type": "string",
+            "description": (
+                "Restrict to a category: company, research paper, news, personal site, "
+                "financial report, people. Empty string for no filter."
+            ),
+            "default": "",
+        },
+        "include_domains": {
+            "type": "array",
+            "description": "Only return results from these domains (e.g. ['arxiv.org']).",
+            "items": {"type": "string"},
+            "default": [],
+        },
+        "exclude_domains": {
+            "type": "array",
+            "description": "Exclude results from these domains.",
+            "items": {"type": "string"},
+            "default": [],
+        },
+        "include_text": {
+            "type": "array",
+            "description": "Only return results containing these phrases.",
+            "items": {"type": "string"},
+            "default": [],
+        },
+        "exclude_text": {
+            "type": "array",
+            "description": "Exclude results containing these phrases.",
+            "items": {"type": "string"},
+            "default": [],
+        },
+        "start_published_date": {
+            "type": "string",
+            "description": "Only results published on/after this date (ISO 8601, e.g. 2026-01-01).",
+            "default": "",
+        },
+        "end_published_date": {
+            "type": "string",
+            "description": "Only results published on/before this date (ISO 8601).",
+            "default": "",
+        },
+    },
+)
+async def exa_search(
+    query: str,
+    max_results: int = _DEFAULT_MAX_RESULTS,
+    search_type: str = _DEFAULT_SEARCH_TYPE,
+    content_mode: str = _DEFAULT_CONTENT_MODE,
+    text_max_chars: int = _DEFAULT_TEXT_CAP,
+    category: str = "",
+    include_domains: list[str] | None = None,
+    exclude_domains: list[str] | None = None,
+    include_text: list[str] | None = None,
+    exclude_text: list[str] | None = None,
+    start_published_date: str = "",
+    end_published_date: str = "",
+) -> dict:
+    """Search the web using Exa and return structured, sanitized results."""
+    requested_max = max_results
+    max_results = _normalize_max_results(max_results)
+
+    if search_type not in _VALID_SEARCH_TYPES:
+        search_type = _DEFAULT_SEARCH_TYPE
+    if content_mode not in _VALID_CONTENT_MODES:
+        content_mode = _DEFAULT_CONTENT_MODE
+    if category and category not in _VALID_CATEGORIES:
+        category = ""
+
+    base = _base_response(query, requested_max, max_results, search_type, content_mode)
+
+    api_key = _get_api_key()
+    if not api_key:
+        return {
+            **base,
+            "error": (
+                "Exa API key not configured. Set OPENLEGION_CRED_EXA_API_KEY "
+                "(agent tier) or EXA_API_KEY."
+            ),
+            "error_type": "missing_api_key",
+        }
+
+    contents = _build_contents(content_mode, text_max_chars)
+    payload = _build_payload(
+        query=query,
+        max_results=max_results,
+        search_type=search_type,
+        contents=contents,
+        category=category,
+        include_domains=include_domains,
+        exclude_domains=exclude_domains,
+        include_text=include_text,
+        exclude_text=exclude_text,
+        start_published_date=start_published_date,
+        end_published_date=end_published_date,
+    )
+
+    headers = {
+        "x-api-key": api_key,
+        "x-exa-integration": _INTEGRATION_NAME,
+        "Content-Type": "application/json",
+        "Accept": "application/json",
+    }
+
+    proxy_url = os.environ.get("HTTP_PROXY") or os.environ.get("HTTPS_PROXY")
+    client_kwargs: dict = {"follow_redirects": False, "timeout": 30}
+    if proxy_url:
+        client_kwargs["proxy"] = proxy_url
+
+    try:
+        async with httpx.AsyncClient(**client_kwargs) as client:
+            resp = await client.post(_API_URL, json=payload, headers=headers)
+            resp.raise_for_status()
+            data = resp.json()
+    except httpx.TimeoutException:
+        return {
+            **base,
+            "error": "Exa search timed out. Try again with a narrower query.",
+            "error_type": "timeout",
+        }
+    except httpx.HTTPStatusError as e:
+        status = e.response.status_code
+        error_type = "auth_error" if status in (401, 403) else "http_status"
+        hint = ""
+        if status in (401, 403):
+            hint = " Check that OPENLEGION_CRED_EXA_API_KEY is valid."
+        elif status == 429:
+            error_type = "rate_limit"
+            hint = " Exa rate limit reached."
+        return {
+            **base,
+            "error": f"Exa returned HTTP {status}.{hint}",
+            "error_type": error_type,
+            "status_code": status,
+        }
+    except httpx.HTTPError as e:
+        return {
+            **base,
+            "error": f"Exa request failed: {type(e).__name__}",
+            "error_type": "network",
+        }
+    except ValueError:
+        return {
+            **base,
+            "error": "Exa returned a non-JSON response.",
+            "error_type": "parse_error",
+        }
+    except Exception as e:
+        logger.exception("Unexpected error during Exa search")
+        return {
+            **base,
+            "error": str(e),
+            "error_type": "unexpected",
+        }
+
+    raw_results = data.get("results") if isinstance(data, dict) else None
+    if not isinstance(raw_results, list):
+        raw_results = []
+
+    parsed = [_parse_result(item) for item in raw_results if isinstance(item, dict)]
+    dict_results = [r.to_dict() for r in parsed]
+
+    return {
+        **base,
+        "results": dict_results,
+        "count": len(dict_results),
+    }

--- a/src/cli/formatting.py
+++ b/src/cli/formatting.py
@@ -33,7 +33,7 @@ def _format_tool_summary(name: str, inp: dict, out: dict) -> str:
         return f'{sel} \u2190 "{text}"'
     elif name == "browser_screenshot":
         return inp.get("filename", "screenshot.png")
-    elif name == "web_search":
+    elif name == "web_search" or name == "exa_search":
         query = inp.get("query", "")
         max_results = inp.get("max_results")
         if max_results is not None:
@@ -70,7 +70,7 @@ def _format_tool_result_hint(name: str, out: dict) -> str:
         return ""
     elif name == "browser_screenshot":
         return out.get("path", "")
-    elif name == "web_search":
+    elif name == "web_search" or name == "exa_search":
         results = out.get("results", [])
         if not results:
             return ""

--- a/tests/test_exa_search_tool.py
+++ b/tests/test_exa_search_tool.py
@@ -1,0 +1,413 @@
+"""Tests for exa_search built-in tool behavior."""
+
+from __future__ import annotations
+
+import json
+
+import httpx
+import pytest
+
+
+class _DummyResponse:
+    def __init__(self, payload: dict | str | None = None, status_code: int = 200,
+                 raise_on_json: bool = False):
+        if isinstance(payload, str):
+            self.text = payload
+            self._payload: dict | None = None
+        else:
+            self._payload = payload or {}
+            self.text = json.dumps(self._payload)
+        self.status_code = status_code
+        self._raise_on_json = raise_on_json
+
+    def json(self) -> dict:
+        if self._raise_on_json:
+            raise ValueError("not json")
+        return self._payload or {}
+
+    def raise_for_status(self) -> None:
+        if self.status_code >= 400:
+            request = httpx.Request("POST", "https://api.exa.ai/search")
+            response = httpx.Response(self.status_code, request=request)
+            raise httpx.HTTPStatusError("request failed", request=request, response=response)
+
+
+class _DummyClient:
+    def __init__(self, response: _DummyResponse | None = None, error: Exception | None = None):
+        self._response = response
+        self._error = error
+        self.last_url: str | None = None
+        self.last_json: dict | None = None
+        self.last_headers: dict | None = None
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+    async def post(self, url, *, json=None, headers=None, **_kwargs):
+        self.last_url = url
+        self.last_json = json
+        self.last_headers = headers
+        if self._error is not None:
+            raise self._error
+        return self._response
+
+
+def _patch_httpx(monkeypatch, module, response=None, error=None) -> _DummyClient:
+    """Install a _DummyClient in place of httpx.AsyncClient; return the instance."""
+    client = _DummyClient(response=response, error=error)
+    monkeypatch.setattr(module.httpx, "AsyncClient", lambda **_kwargs: client)
+    return client
+
+
+@pytest.fixture(autouse=True)
+def _clear_exa_env(monkeypatch):
+    monkeypatch.delenv("EXA_API_KEY", raising=False)
+    monkeypatch.delenv("OPENLEGION_CRED_EXA_API_KEY", raising=False)
+    monkeypatch.delenv("HTTP_PROXY", raising=False)
+    monkeypatch.delenv("HTTPS_PROXY", raising=False)
+    yield
+
+
+# ── Registration & disabled state ────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_exa_search_missing_api_key_returns_descriptive_error(monkeypatch):
+    from src.agent.builtins import exa_search_tool
+
+    # No client should be created — call shouldn't hit the network.
+    sentinel = {"called": False}
+
+    def _boom(**_kwargs):
+        sentinel["called"] = True
+        raise AssertionError("httpx client should not be constructed without an API key")
+
+    monkeypatch.setattr(exa_search_tool.httpx, "AsyncClient", _boom)
+
+    result = await exa_search_tool.exa_search("test query")
+
+    assert result["error_type"] == "missing_api_key"
+    assert "EXA_API_KEY" in result["error"]
+    assert result["provider"] == "exa"
+    assert result["count"] == 0
+    assert result["results"] == []
+    assert sentinel["called"] is False
+
+
+@pytest.mark.asyncio
+async def test_exa_search_prefers_openlegion_cred_env(monkeypatch):
+    from src.agent.builtins import exa_search_tool
+
+    monkeypatch.setenv("OPENLEGION_CRED_EXA_API_KEY", "cred-key")
+    monkeypatch.setenv("EXA_API_KEY", "fallback-key")
+    client = _patch_httpx(monkeypatch, exa_search_tool,
+                          response=_DummyResponse({"results": []}))
+
+    await exa_search_tool.exa_search("test")
+
+    assert client.last_headers["x-api-key"] == "cred-key"
+    assert client.last_headers["x-exa-integration"] == "openlegion"
+
+
+@pytest.mark.asyncio
+async def test_exa_search_falls_back_to_standard_env(monkeypatch):
+    from src.agent.builtins import exa_search_tool
+
+    monkeypatch.setenv("EXA_API_KEY", "fallback-key")
+    client = _patch_httpx(monkeypatch, exa_search_tool,
+                          response=_DummyResponse({"results": []}))
+
+    await exa_search_tool.exa_search("test")
+
+    assert client.last_headers["x-api-key"] == "fallback-key"
+
+
+# ── Response parsing & snippet fallbacks ─────────────────────
+
+
+@pytest.mark.asyncio
+async def test_exa_search_parses_highlights(monkeypatch):
+    from src.agent.builtins import exa_search_tool
+
+    monkeypatch.setenv("EXA_API_KEY", "k")
+    payload = {
+        "results": [
+            {
+                "id": "abc",
+                "url": "https://example.com/a",
+                "title": "Example A",
+                "publishedDate": "2026-03-01",
+                "author": "Alice",
+                "score": 0.87,
+                "highlights": ["first snippet", "second snippet"],
+                "highlightScores": [0.9, 0.8],
+            },
+        ],
+    }
+    _patch_httpx(monkeypatch, exa_search_tool, response=_DummyResponse(payload))
+
+    result = await exa_search_tool.exa_search("hello")
+
+    assert result["provider"] == "exa"
+    assert result["count"] == 1
+    r = result["results"][0]
+    assert r["url"] == "https://example.com/a"
+    assert r["title"] == "Example A"
+    assert r["published_date"] == "2026-03-01"
+    assert r["author"] == "Alice"
+    assert r["score"] == pytest.approx(0.87)
+    assert r["highlights"] == ["first snippet", "second snippet"]
+    assert "first snippet" in r["snippet"]
+    assert "second snippet" in r["snippet"]
+
+
+@pytest.mark.asyncio
+async def test_exa_search_snippet_falls_back_to_summary(monkeypatch):
+    """When highlights are missing, snippet should fall back to summary."""
+    from src.agent.builtins import exa_search_tool
+
+    monkeypatch.setenv("EXA_API_KEY", "k")
+    payload = {
+        "results": [
+            {
+                "url": "https://example.com/b",
+                "title": "Example B",
+                "summary": "This is an AI-generated summary of the page.",
+            },
+        ],
+    }
+    _patch_httpx(monkeypatch, exa_search_tool, response=_DummyResponse(payload))
+
+    result = await exa_search_tool.exa_search("hello", content_mode="summary")
+
+    r = result["results"][0]
+    assert "AI-generated summary" in r["snippet"]
+    assert r["summary"] == "This is an AI-generated summary of the page."
+    assert "highlights" not in r  # never set when empty
+
+
+@pytest.mark.asyncio
+async def test_exa_search_snippet_falls_back_to_text(monkeypatch):
+    """When highlights and summary are missing, snippet should fall back to text."""
+    from src.agent.builtins import exa_search_tool
+
+    monkeypatch.setenv("EXA_API_KEY", "k")
+    long_text = "Full page body. " * 100  # > 500 chars
+    payload = {
+        "results": [
+            {
+                "url": "https://example.com/c",
+                "title": "Example C",
+                "text": long_text,
+            },
+        ],
+    }
+    _patch_httpx(monkeypatch, exa_search_tool, response=_DummyResponse(payload))
+
+    result = await exa_search_tool.exa_search("hello", content_mode="text")
+
+    r = result["results"][0]
+    # Snippet is capped at 500 chars
+    assert r["snippet"].startswith("Full page body.")
+    assert len(r["snippet"]) <= 500
+    # Full text is NOT returned at top level (we only expose snippet + highlights/summary)
+
+
+@pytest.mark.asyncio
+async def test_exa_search_empty_results(monkeypatch):
+    from src.agent.builtins import exa_search_tool
+
+    monkeypatch.setenv("EXA_API_KEY", "k")
+    _patch_httpx(monkeypatch, exa_search_tool, response=_DummyResponse({"results": []}))
+
+    result = await exa_search_tool.exa_search("obscure query")
+
+    assert result["count"] == 0
+    assert result["results"] == []
+    assert "error" not in result
+
+
+@pytest.mark.asyncio
+async def test_exa_search_handles_missing_results_key(monkeypatch):
+    """API response without 'results' shouldn't crash — yields empty list."""
+    from src.agent.builtins import exa_search_tool
+
+    monkeypatch.setenv("EXA_API_KEY", "k")
+    _patch_httpx(monkeypatch, exa_search_tool, response=_DummyResponse({}))
+
+    result = await exa_search_tool.exa_search("q")
+
+    assert result["count"] == 0
+    assert result["results"] == []
+
+
+# ── Payload construction ─────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_exa_search_payload_includes_filters(monkeypatch):
+    from src.agent.builtins import exa_search_tool
+
+    monkeypatch.setenv("EXA_API_KEY", "k")
+    client = _patch_httpx(monkeypatch, exa_search_tool,
+                          response=_DummyResponse({"results": []}))
+
+    await exa_search_tool.exa_search(
+        "llm research",
+        max_results=3,
+        search_type="neural",
+        content_mode="all",
+        text_max_chars=500,
+        category="research paper",
+        include_domains=["arxiv.org"],
+        exclude_domains=["example.com"],
+        include_text=["transformer"],
+        exclude_text=["cat"],
+        start_published_date="2026-01-01",
+        end_published_date="2026-04-01",
+    )
+
+    body = client.last_json
+    assert body["query"] == "llm research"
+    assert body["numResults"] == 3
+    assert body["type"] == "neural"
+    assert body["category"] == "research paper"
+    assert body["includeDomains"] == ["arxiv.org"]
+    assert body["excludeDomains"] == ["example.com"]
+    assert body["includeText"] == ["transformer"]
+    assert body["excludeText"] == ["cat"]
+    assert body["startPublishedDate"] == "2026-01-01"
+    assert body["endPublishedDate"] == "2026-04-01"
+    # content_mode="all" enables highlights, text, and summary together
+    contents = body["contents"]
+    assert contents["highlights"] is True
+    assert contents["text"] == {"maxCharacters": 500}
+    assert contents["summary"] is True
+
+
+@pytest.mark.asyncio
+async def test_exa_search_clamps_max_results(monkeypatch):
+    from src.agent.builtins import exa_search_tool
+
+    monkeypatch.setenv("EXA_API_KEY", "k")
+    client = _patch_httpx(monkeypatch, exa_search_tool,
+                          response=_DummyResponse({"results": []}))
+
+    result = await exa_search_tool.exa_search("q", max_results=999)
+
+    assert result["max_results_requested"] == 999
+    assert result["max_results_used"] == 25
+    assert client.last_json["numResults"] == 25
+
+
+@pytest.mark.asyncio
+async def test_exa_search_rejects_invalid_enums(monkeypatch):
+    from src.agent.builtins import exa_search_tool
+
+    monkeypatch.setenv("EXA_API_KEY", "k")
+    client = _patch_httpx(monkeypatch, exa_search_tool,
+                          response=_DummyResponse({"results": []}))
+
+    result = await exa_search_tool.exa_search(
+        "q",
+        search_type="keyword",  # removed from API
+        content_mode="bogus",
+        category="invalid",
+    )
+
+    # search_type and content_mode should fall back to defaults
+    assert client.last_json["type"] == "auto"
+    assert client.last_json["contents"] == {"highlights": True}
+    assert "category" not in client.last_json
+    assert result["search_type"] == "auto"
+    assert result["content_mode"] == "highlights"
+
+
+# ── Error paths ──────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_exa_search_timeout(monkeypatch):
+    from src.agent.builtins import exa_search_tool
+
+    monkeypatch.setenv("EXA_API_KEY", "k")
+    _patch_httpx(monkeypatch, exa_search_tool,
+                 error=httpx.TimeoutException("timeout"))
+
+    result = await exa_search_tool.exa_search("q")
+
+    assert result["error_type"] == "timeout"
+    assert result["count"] == 0
+
+
+@pytest.mark.asyncio
+async def test_exa_search_auth_error(monkeypatch):
+    from src.agent.builtins import exa_search_tool
+
+    monkeypatch.setenv("EXA_API_KEY", "bad-key")
+    _patch_httpx(monkeypatch, exa_search_tool,
+                 response=_DummyResponse({}, status_code=401))
+
+    result = await exa_search_tool.exa_search("q")
+
+    assert result["error_type"] == "auth_error"
+    assert result["status_code"] == 401
+    assert "OPENLEGION_CRED_EXA_API_KEY" in result["error"]
+
+
+@pytest.mark.asyncio
+async def test_exa_search_rate_limit(monkeypatch):
+    from src.agent.builtins import exa_search_tool
+
+    monkeypatch.setenv("EXA_API_KEY", "k")
+    _patch_httpx(monkeypatch, exa_search_tool,
+                 response=_DummyResponse({}, status_code=429))
+
+    result = await exa_search_tool.exa_search("q")
+
+    assert result["error_type"] == "rate_limit"
+    assert result["status_code"] == 429
+
+
+@pytest.mark.asyncio
+async def test_exa_search_non_json_response(monkeypatch):
+    from src.agent.builtins import exa_search_tool
+
+    monkeypatch.setenv("EXA_API_KEY", "k")
+    _patch_httpx(monkeypatch, exa_search_tool,
+                 response=_DummyResponse("<html>oops</html>", raise_on_json=True))
+
+    result = await exa_search_tool.exa_search("q")
+
+    assert result["error_type"] == "parse_error"
+    assert result["count"] == 0
+
+
+# ── Sanitization ─────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_exa_search_strips_invisible_chars(monkeypatch):
+    """Results should be passed through sanitize_for_prompt."""
+    from src.agent.builtins import exa_search_tool
+
+    monkeypatch.setenv("EXA_API_KEY", "k")
+    # Zero-width joiner + bidi override in the title should be stripped.
+    dirty_title = "Normal​title‮ injected"
+    payload = {
+        "results": [
+            {"url": "https://example.com", "title": dirty_title,
+             "highlights": ["clean snippet"]},
+        ],
+    }
+    _patch_httpx(monkeypatch, exa_search_tool, response=_DummyResponse(payload))
+
+    result = await exa_search_tool.exa_search("q")
+
+    title = result["results"][0]["title"]
+    assert "​" not in title
+    assert "‮" not in title
+    assert "Normal" in title and "title" in title


### PR DESCRIPTION
## Summary

Adds `exa_search`, a second web-search built-in (alongside the existing DuckDuckGo scraper) powered by [Exa](https://exa.ai) AI-powered search.

- Semantically ranked results with optional LLM-generated highlights, page text, or summary per result
- Supports `auto` / `neural` / `fast` / `deep` / `deep-lite` / `deep-reasoning` / `instant` search modes
- Filters: category (company, research paper, news, personal site, financial report, people), include/exclude domains, include/exclude text, published-date ranges
- Requires `OPENLEGION_CRED_EXA_API_KEY` (agent-tier, preferred) or `EXA_API_KEY` as fallback
- Registers unconditionally; returns a `missing_api_key` error at call time when no key is configured

## Usage

```python
# From any agent skill:
results = await exa_search(
    query="fastest AI inference hardware 2026",
    max_results=5,
    search_type="neural",
    content_mode="highlights",
    category="news",
    start_published_date="2026-01-01",
)
```

Response shape matches the existing `web_search` tool: `{query, results: [{title, url, snippet, ...}], count, provider, ...}`.

## Design notes

- Follows the exact pattern of `web_search_tool.py`: `@skill`-decorated async function using raw `httpx.AsyncClient` (not the `exa-py` SDK). This keeps the tool aligned with how the repo already handles HTTP for search and avoids adding a new dependency since `httpx` is already pulled in.
- All user-visible strings pass through `sanitize_for_prompt` to strip invisible-character prompt-injection vectors (matching `web_search`).
- Results are parsed through a typed `ExaResult` dataclass rather than raw dicts.
- Snippet generation cascades highlights → summary → text so the tool degrades gracefully across content modes.
- Error surface uses the same shape and `error_type` taxonomy as `web_search`, adding `auth_error`, `rate_limit`, and `missing_api_key` for API-key-specific failures.

## Files changed

- `src/agent/builtins/exa_search_tool.py` — new built-in tool
- `tests/test_exa_search_tool.py` — 16 unit tests (parsing, fallbacks, disabled state, filters, error paths, sanitization)
- `src/cli/formatting.py` — extend the `web_search` CLI summary formatter to cover `exa_search`
- `.env.example` — document `OPENLEGION_CRED_EXA_API_KEY`
- `docs/agent-tools.md`, `docs/architecture.md` — document the new tool

## Test plan

- [x] `ruff check .` passes
- [x] `pytest tests/test_exa_search_tool.py` — 16/16 pass
- [x] `pytest tests/test_web_search_tool.py` — 3/3 pass (regression check on CLI formatter)
- [x] `pytest tests/test_builtins.py` — 181/181 pass
- [ ] End-to-end smoke test with a real `EXA_API_KEY` (requires reviewer's key; covered by unit tests with hardcoded fixtures)