### PR TITLE
Phase 1.1: per-browser-action permission contract (default-allow)

### DIFF
--- a/src/host/permissions.py
+++ b/src/host/permissions.py
@@ -18,6 +18,28 @@ from src.shared.utils import setup_logging
 logger = setup_logging("host.permissions")
 
 
+# Known browser action names. Used ONLY for mesh-side input validation —
+# catches typo'd action names with a clean 400 before reaching the browser
+# service. Does NOT gate permissions (every known action is granted to any
+# agent with `can_use_browser=true` unless an explicit `browser_actions`
+# list narrows the set; see `can_browser_action`).
+#
+# As new actions are added in later phases they SHOULD be added here so the
+# mesh recognizes them. Agents gain access to them automatically; operators
+# who want to restrict specific actions do so per-template via
+# `AgentPermissions.browser_actions`.
+KNOWN_BROWSER_ACTIONS: frozenset[str] = frozenset({
+    "navigate", "snapshot", "click", "type", "hover",
+    "screenshot", "reset", "focus", "status", "detect_captcha", "scroll",
+    "wait_for", "press_key", "go_back", "go_forward", "switch_tab",
+})
+
+# Back-compat alias — retained so `host/server.py` and test fixtures that
+# imported `LEGACY_BROWSER_ACTIONS` keep working. Prefer `KNOWN_BROWSER_ACTIONS`
+# in new code.
+LEGACY_BROWSER_ACTIONS = KNOWN_BROWSER_ACTIONS
+
+
 class PermissionMatrix:
     """Enforces agent-level permissions for mesh operations."""
 
@@ -60,6 +82,7 @@ class PermissionMatrix:
                 allowed_apis=default.allowed_apis,
                 allowed_credentials=default.allowed_credentials,
                 can_use_browser=default.can_use_browser,
+                browser_actions=default.browser_actions,
                 can_spawn=default.can_spawn,
                 can_manage_cron=default.can_manage_cron,
                 can_use_wallet=default.can_use_wallet,
@@ -112,6 +135,40 @@ class PermissionMatrix:
             return True
         perms = self.get_permissions(agent_id)
         return perms.can_use_browser
+
+    def can_browser_action(self, agent_id: str, action: str) -> bool:
+        """Check if agent has permission for a specific browser action.
+
+        Default-allow UX: any agent with ``can_use_browser=true`` gets ALL
+        known browser actions unless their template explicitly narrows the
+        set via ``browser_actions``. Operators who want restriction use
+        an explicit list.
+
+        ``browser_actions`` semantics:
+           - ``None`` (default) → **all** current and future actions.
+             Equivalent to ``["*"]``; kept as the default because "turn
+             browser on, agent can browse" is the common expectation.
+           - ``["*"]`` → all actions (explicit form).
+           - Specific list → only those actions (opt-out restriction).
+           - ``[]`` → no actions (equivalent to ``can_use_browser=False``).
+
+        ``action`` must be a known action string. Input validation against
+        :data:`KNOWN_BROWSER_ACTIONS` (catching typos) happens at the mesh
+        gate; this method assumes the caller has validated and does not
+        re-check, allowing it to also pass for future actions not yet in
+        ``KNOWN_BROWSER_ACTIONS`` at the moment a specific grant is evaluated.
+        """
+        if self._is_trusted(agent_id):
+            return True
+        perms = self.get_permissions(agent_id)
+        if not perms.can_use_browser:
+            return False
+        allowed = perms.browser_actions
+        if allowed is None:
+            return True  # default-allow: all known actions
+        if "*" in allowed:
+            return True
+        return action in allowed
 
     def can_spawn(self, agent_id: str) -> bool:
         """Check if agent is allowed to spawn ephemeral agents."""

--- a/src/host/permissions.py
+++ b/src/host/permissions.py
@@ -29,9 +29,17 @@ logger = setup_logging("host.permissions")
 # who want to restrict specific actions do so per-template via
 # `AgentPermissions.browser_actions`.
 KNOWN_BROWSER_ACTIONS: frozenset[str] = frozenset({
+    # Legacy 16 — present pre-Phase 1 refactor.
     "navigate", "snapshot", "click", "type", "hover",
     "screenshot", "reset", "focus", "status", "detect_captcha", "scroll",
     "wait_for", "press_key", "go_back", "go_forward", "switch_tab",
+    # Phase 1.5 file-transfer actions. Reserved here so the mesh input
+    # validation accepts the action names even before Phase 1.5's
+    # endpoints land in `src/browser/server.py`. If a caller invokes
+    # these before 1.5 is deployed, the browser service returns a clean
+    # 404 on the unknown URL instead of the mesh rejecting the action
+    # name as unknown — avoids a cross-PR merge-order dependency.
+    "upload_file", "download",
 })
 
 # Back-compat alias — retained so `host/server.py` and test fixtures that

--- a/src/host/server.py
+++ b/src/host/server.py
@@ -2680,11 +2680,14 @@ def create_mesh_app(
         """Schedule initial browser proxy push as a background task (non-blocking)."""
         asyncio.create_task(_deferred_push_browser_proxies())
 
-    _ALLOWED_BROWSER_ACTIONS = frozenset({
-        "navigate", "snapshot", "click", "type", "hover",
-        "screenshot", "reset", "focus", "status", "detect_captcha", "scroll",
-        "wait_for", "press_key", "go_back", "go_forward", "switch_tab",
-    })
+    # Mesh-side input validation: reject typo'd action names with a clean 400
+    # before proxying to the browser service. Permissions are enforced separately
+    # via PermissionMatrix.can_browser_action (default-allow for all known
+    # actions when `browser_actions` is unset in the template).
+    #
+    # New actions must be added to src/host/permissions.KNOWN_BROWSER_ACTIONS
+    # so the mesh stops rejecting them.
+    from src.host.permissions import KNOWN_BROWSER_ACTIONS as _ALLOWED_BROWSER_ACTIONS
 
     @app.post("/mesh/browser/command")
     async def browser_command(request: Request) -> dict:
@@ -2707,21 +2710,26 @@ def create_mesh_app(
             caller_id, body.get("target_agent_id") or "",
         )
 
-        # Self-browser path also has to satisfy can_use_browser.
-        # _resolve_browser_target already enforced this on the delegation
-        # path; here we close the gap when no target_agent_id was sent
-        # (or when target == caller).
-        if req_agent_id == caller_id and not permissions.can_use_browser(caller_id):
-            raise HTTPException(403, "Browser access denied")
-
         action = body.get("action", "")
         params = body.get("params", {})
 
         if not action:
             raise HTTPException(400, "action is required")
 
+        # Reject unknown actions with 400 before any permission check — we
+        # want a distinct error for "action doesn't exist" vs "not authorized."
         if action not in _ALLOWED_BROWSER_ACTIONS:
             raise HTTPException(400, f"Unknown browser action: {action}")
+
+        # Per-action gate applies to the EFFECTIVE target (`req_agent_id`),
+        # not the caller. The action runs against the target's browser
+        # profile, so the target's `browser_actions` list is the authoritative
+        # policy. This closes a delegation bypass where an operator with
+        # `browser_actions=["*"]` could otherwise exercise actions the target
+        # was never granted. `_resolve_browser_target` already confirmed the
+        # caller has delegation rights (can_message + target has browser).
+        if not permissions.can_browser_action(req_agent_id, action):
+            raise HTTPException(403, f"Browser action '{action}' denied")
 
         # SSRF protection: early-reject for literal private-IP navigations so
         # agents get a clean 400 rather than a cryptic browser error. The

--- a/src/shared/types.py
+++ b/src/shared/types.py
@@ -147,6 +147,13 @@ class AgentPermissions(BaseModel):
     allowed_apis: list[str] = []
     allowed_credentials: list[str] = []
     can_use_browser: bool = False
+    browser_actions: list[str] | None = None  # None = all known actions
+                                               # (default-allow UX).
+                                               # ["*"] = all (explicit form).
+                                               # Specific list = only those
+                                               # (opt-out restriction).
+                                               # [] = no actions (equivalent
+                                               # to can_use_browser=False).
     can_spawn: bool = False
     can_manage_cron: bool = False
     can_use_wallet: bool = False

--- a/tests/test_browser_delegation.py
+++ b/tests/test_browser_delegation.py
@@ -377,7 +377,11 @@ class TestBrowserCommandEndpoint:
                 headers={"X-Agent-ID": "operator"},
             )
         assert resp.status_code == 403
-        assert "Browser access denied" in resp.text
+        # Per Phase 1.1 (per-action permission contract), denial message
+        # names the specific action rather than the generic "browser access"
+        # phrase — agents and operators get actionable feedback.
+        assert "denied" in resp.text.lower()
+        assert "snapshot" in resp.text
 
     @pytest.mark.asyncio
     async def test_delegation_happy_path(self, tmp_path, monkeypatch):
@@ -525,6 +529,55 @@ class TestBrowserCommandEndpoint:
         assert "/browser/worker/snapshot" in proxy_url_seen["url"]
 
     @pytest.mark.asyncio
+    async def test_delegation_respects_target_per_action_policy(self, tmp_path):
+        """Per-action gate applies to the EFFECTIVE TARGET, not the caller.
+
+        Regression guard: an operator with ``browser_actions=['*']`` could
+        otherwise delegate any action to a worker whose own policy restricts
+        what actions are allowed against its profile. The gate must enforce
+        the target's policy before ever proxying to the browser service.
+
+        We deliberately do NOT monkey-patch httpx here: the 403 must fire
+        inside the mesh before any proxy attempt. (Monkey-patching
+        httpx.AsyncClient.send would also short-circuit the TEST client's
+        ASGITransport path, hiding the real behavior.)
+        """
+        from httpx import ASGITransport, AsyncClient
+
+        app, _event_bus, _cm = _build_app(
+            tmp_path,
+            perms_map={
+                "operator": {
+                    "can_use_browser": True,
+                    "browser_actions": ["*"],
+                    "can_message": ["*"],
+                },
+                "worker": {
+                    "can_use_browser": True,
+                    # Worker's profile allows navigation only — no snapshot.
+                    "browser_actions": ["navigate"],
+                },
+            },
+        )
+
+        async with AsyncClient(
+            transport=ASGITransport(app=app), base_url="http://test",
+        ) as client:
+            # Operator delegating snapshot to worker — worker's policy denies it.
+            resp = await client.post(
+                "/mesh/browser/command",
+                json={
+                    "action": "snapshot",
+                    "params": {},
+                    "target_agent_id": "worker",
+                },
+                headers={"X-Agent-ID": "operator"},
+            )
+
+        assert resp.status_code == 403
+        assert "snapshot" in resp.text
+
+    @pytest.mark.asyncio
     async def test_target_equals_caller_self_denied_without_browser(self, tmp_path):
         """target_agent_id == caller_id with caller lacking browser → 403."""
         from httpx import ASGITransport, AsyncClient
@@ -549,7 +602,9 @@ class TestBrowserCommandEndpoint:
                 headers={"X-Agent-ID": "operator"},
             )
         assert resp.status_code == 403
-        assert "Browser access denied" in resp.text
+        # Per-action denial message (Phase 1.1 contract).
+        assert "denied" in resp.text.lower()
+        assert "snapshot" in resp.text
 
     @pytest.mark.asyncio
     async def test_unknown_target_blocked(self, tmp_path):

--- a/tests/test_browser_service.py
+++ b/tests/test_browser_service.py
@@ -2512,34 +2512,19 @@ class TestHover:
 
 
 class TestAllowedBrowserActions:
-    """Regression tests for the mesh-proxy allowed-action allowlist.
+    """Regression tests for the mesh-proxy known-action set.
 
-    Any browser action added to browser_tool.py must also be in the
-    _ALLOWED_BROWSER_ACTIONS set in host/server.py, otherwise the skill silently
-    fails with a 400 from the proxy.
+    Any browser action added to browser_tool.py must also be in
+    KNOWN_BROWSER_ACTIONS in src/host/permissions.py (single source of truth;
+    host/server.py imports as _ALLOWED_BROWSER_ACTIONS for input validation)
+    — otherwise the skill silently fails with a 400 "unknown action" from
+    the proxy.
     """
 
     def _get_allowed_actions(self) -> frozenset[str]:
-        """Extract _ALLOWED_BROWSER_ACTIONS from host/server.py without running the server."""
-        import ast
-        from pathlib import Path
-        source = (Path(__file__).parent.parent / "src/host/server.py").read_text()
-        tree = ast.parse(source)
-        for node in ast.walk(tree):
-            if (
-                isinstance(node, ast.Assign)
-                and isinstance(node.targets[0], ast.Name)
-                and node.targets[0].id == "_ALLOWED_BROWSER_ACTIONS"
-                and isinstance(node.value, ast.Call)
-            ):
-                # frozenset({...}) call — extract string elements
-                set_literal = node.value.args[0]
-                if isinstance(set_literal, ast.Set):
-                    return frozenset(
-                        elt.value for elt in set_literal.elts
-                        if isinstance(elt, ast.Constant)
-                    )
-        return frozenset()
+        """Load the canonical known-action set from host.permissions."""
+        from src.host.permissions import KNOWN_BROWSER_ACTIONS
+        return KNOWN_BROWSER_ACTIONS
 
     def test_wait_for_in_allowed_actions(self):
         """wait_for must be allowed — browser_wait_for skill depends on it."""

--- a/tests/test_permissions.py
+++ b/tests/test_permissions.py
@@ -119,3 +119,181 @@ class TestDefaultTemplatePropagation:
         assert perms.wallet_spend_limit_daily_usd == 0.0
         assert perms.wallet_rate_limit_per_hour == 0
         assert perms.wallet_allowed_contracts == []
+
+
+# ── Per-browser-action permissions (Phase 1.1) ─────────────────────────────
+
+
+@pytest.fixture()
+def browser_matrix(tmp_path):
+    """PermissionMatrix with a range of browser_actions configurations."""
+    cfg = {
+        "permissions": {
+            "default": {
+                "can_use_browser": False,
+            },
+            # Legacy-style agent: `browser_actions` unset → None → legacy set
+            "legacy-agent": {
+                "can_use_browser": True,
+            },
+            # Explicit wildcard: every known + future action allowed
+            "wildcard-agent": {
+                "can_use_browser": True,
+                "browser_actions": ["*"],
+            },
+            # Specific allowlist only
+            "readonly-agent": {
+                "can_use_browser": True,
+                "browser_actions": ["navigate", "snapshot", "screenshot"],
+            },
+            # Explicit empty list: equivalent to can_use_browser=False
+            "empty-list-agent": {
+                "can_use_browser": True,
+                "browser_actions": [],
+            },
+            # can_use_browser=False but browser_actions populated — must deny
+            "no-browser-agent": {
+                "can_use_browser": False,
+                "browser_actions": ["*"],
+            },
+            # Agent with a future action opt-in (simulating post-upgrade grant)
+            "uploader-agent": {
+                "can_use_browser": True,
+                "browser_actions": [
+                    "navigate", "click", "type", "upload_file",
+                ],
+            },
+        },
+    }
+    path = tmp_path / "permissions.json"
+    path.write_text(json.dumps(cfg))
+    return PermissionMatrix(config_path=str(path))
+
+
+class TestCanBrowserAction:
+    def test_default_grants_all_known_actions(self, browser_matrix):
+        """browser_actions=None (default) → all known actions allowed."""
+        for action in ("navigate", "click", "type", "screenshot", "scroll",
+                       "focus", "status", "detect_captcha", "upload_file",
+                       "download", "fill_form", "solve_captcha"):
+            assert browser_matrix.can_browser_action("legacy-agent", action) is True, action
+
+    def test_default_also_allows_future_actions(self, browser_matrix):
+        """The default None is an unbounded allow — future actions pass too.
+
+        The mesh validates unknown action names as 400 input errors before
+        calling can_browser_action; this method is permission-only.
+        """
+        for action in ("upload_file", "download", "brand_new_future_action"):
+            assert browser_matrix.can_browser_action("legacy-agent", action) is True, action
+
+    def test_wildcard_equivalent_to_default(self, browser_matrix):
+        """Explicit ['*'] is equivalent to None for permission purposes."""
+        for action in ("navigate", "upload_file", "brand_new_action"):
+            assert browser_matrix.can_browser_action("wildcard-agent", action) is True
+
+    def test_specific_list_is_opt_out_restriction(self, browser_matrix):
+        """Operators can narrow to a specific list — opt-out default-allow."""
+        assert browser_matrix.can_browser_action("readonly-agent", "navigate") is True
+        assert browser_matrix.can_browser_action("readonly-agent", "snapshot") is True
+        assert browser_matrix.can_browser_action("readonly-agent", "click") is False
+        assert browser_matrix.can_browser_action("readonly-agent", "upload_file") is False
+
+    def test_empty_list_denies_all(self, browser_matrix):
+        for action in ("navigate", "click", "upload_file"):
+            assert browser_matrix.can_browser_action("empty-list-agent", action) is False
+
+    def test_can_use_browser_false_overrides(self, browser_matrix):
+        """Even with browser_actions=['*'], can_use_browser=False must deny."""
+        for action in ("navigate", "click", "upload_file"):
+            assert browser_matrix.can_browser_action("no-browser-agent", action) is False
+
+    def test_curated_list_honored_even_for_legacy_actions(self, browser_matrix):
+        """Explicit curation is respected — listed actions only, nothing else."""
+        assert browser_matrix.can_browser_action("uploader-agent", "upload_file") is True
+        assert browser_matrix.can_browser_action("uploader-agent", "navigate") is True
+        # Not granted explicitly → denied (curated = strict opt-out default)
+        assert browser_matrix.can_browser_action("uploader-agent", "download") is False
+        # Even legacy action is denied when caller specified a curated list
+        assert browser_matrix.can_browser_action("uploader-agent", "screenshot") is False
+
+    def test_trusted_always_allowed(self, browser_matrix):
+        """The 'mesh' internal identity bypasses all checks."""
+        for action in ("navigate", "upload_file", "brand_new_action"):
+            assert browser_matrix.can_browser_action("mesh", action) is True
+
+    def test_unknown_agent_falls_through_to_default(self, browser_matrix):
+        """Default here is can_use_browser=False → deny."""
+        assert browser_matrix.can_browser_action("ghost-agent", "navigate") is False
+
+    def test_can_use_browser_unchanged_for_legacy_callers(self, browser_matrix):
+        """The old binary check still works for callers that haven't migrated."""
+        assert browser_matrix.can_use_browser("legacy-agent") is True
+        assert browser_matrix.can_use_browser("no-browser-agent") is False
+        assert browser_matrix.can_use_browser("empty-list-agent") is True  # flag itself is True
+
+
+class TestKnownBrowserActionsSet:
+    """KNOWN_BROWSER_ACTIONS is the mesh-side input validation set.
+    Catches typo'd action names with a clean 400 before reaching the
+    browser service. Does NOT gate permissions.
+
+    Regression-proof against accidental REMOVAL — every action the mesh
+    is expected to recognize must appear here.
+    """
+
+    def test_exact_16_actions(self):
+        from src.host.permissions import KNOWN_BROWSER_ACTIONS
+        assert len(KNOWN_BROWSER_ACTIONS) == 16
+        assert KNOWN_BROWSER_ACTIONS == frozenset({
+            "navigate", "snapshot", "click", "type", "hover",
+            "screenshot", "reset", "focus", "status", "detect_captcha",
+            "scroll", "wait_for", "press_key", "go_back", "go_forward",
+            "switch_tab",
+        })
+
+    def test_legacy_alias_still_exported(self):
+        """Back-compat alias for callers that imported the old name."""
+        from src.host.permissions import (
+            KNOWN_BROWSER_ACTIONS,
+            LEGACY_BROWSER_ACTIONS,
+        )
+        assert LEGACY_BROWSER_ACTIONS is KNOWN_BROWSER_ACTIONS
+
+
+class TestDefaultFallbackPropagatesBrowserActions:
+    """The 'default' template's browser_actions must flow into fallback perms
+    for unknown agents; otherwise per-action grants on 'default' silently lose."""
+
+    def test_default_browser_actions_curation_propagates(self, tmp_path):
+        """When 'default' template curates a specific list, unknown agents
+        inherit that curation — the restriction flows through the fallback."""
+        cfg = {
+            "permissions": {
+                "default": {
+                    "can_use_browser": True,
+                    "browser_actions": ["navigate", "snapshot"],
+                },
+            },
+        }
+        path = tmp_path / "permissions.json"
+        path.write_text(json.dumps(cfg))
+        matrix = PermissionMatrix(config_path=str(path))
+        # Unknown agent falls through to default
+        assert matrix.can_browser_action("unknown", "navigate") is True
+        assert matrix.can_browser_action("unknown", "click") is False
+
+    def test_default_unspecified_inherits_default_allow(self, tmp_path):
+        """When 'default' template has can_use_browser=True but no
+        browser_actions key, the full default-allow semantic propagates:
+        unknown agents get ALL known actions."""
+        cfg = {
+            "permissions": {
+                "default": {"can_use_browser": True},
+            },
+        }
+        path = tmp_path / "permissions.json"
+        path.write_text(json.dumps(cfg))
+        matrix = PermissionMatrix(config_path=str(path))
+        for action in ("navigate", "upload_file", "download", "solve_captcha"):
+            assert matrix.can_browser_action("unknown", action) is True, action

--- a/tests/test_permissions.py
+++ b/tests/test_permissions.py
@@ -242,15 +242,27 @@ class TestKnownBrowserActionsSet:
     is expected to recognize must appear here.
     """
 
-    def test_exact_16_actions(self):
+    def test_legacy_actions_present(self):
         from src.host.permissions import KNOWN_BROWSER_ACTIONS
-        assert len(KNOWN_BROWSER_ACTIONS) == 16
-        assert KNOWN_BROWSER_ACTIONS == frozenset({
+        legacy = frozenset({
             "navigate", "snapshot", "click", "type", "hover",
             "screenshot", "reset", "focus", "status", "detect_captcha",
             "scroll", "wait_for", "press_key", "go_back", "go_forward",
             "switch_tab",
         })
+        assert legacy.issubset(KNOWN_BROWSER_ACTIONS), (
+            "Legacy actions disappeared from KNOWN_BROWSER_ACTIONS — this "
+            "would silently break every pre-upgrade agent."
+        )
+
+    def test_phase_1_5_file_transfer_actions_reserved(self):
+        """upload_file + download must be recognized by the mesh input
+        validator even before Phase 1.5 endpoints exist, so the PRs can
+        merge in any order without cross-branch action-name coordination.
+        """
+        from src.host.permissions import KNOWN_BROWSER_ACTIONS
+        assert "upload_file" in KNOWN_BROWSER_ACTIONS
+        assert "download" in KNOWN_BROWSER_ACTIONS
 
     def test_legacy_alias_still_exported(self):
         """Back-compat alias for callers that imported the old name."""


### PR DESCRIPTION
## Summary

Replaces the binary `can_use_browser: bool` with a per-action permission contract that lets operators restrict specific browser actions per template. Default is all-on for UX simplicity; operators opt *out* via explicit list.

- `AgentPermissions.browser_actions: list[str] | None = None` — `None` = all known actions, `[...]` = only those, `[]` = none, `["*"]` = explicit wildcard.
- `PermissionMatrix.can_browser_action(agent_id, action)` enforces it (short-circuits on trusted + `can_use_browser=false`).
- `KNOWN_BROWSER_ACTIONS` frozenset in `src/host/permissions.py` is single source of truth for mesh-side action-name validation; `host/server.py` imports it. `LEGACY_BROWSER_ACTIONS` kept as back-compat alias.
- **Security fix in delegation path:** the mesh gate at `/mesh/browser/command` now enforces per-action permission on the **effective target** (not just caller on self path). Closed a bypass where wildcard-operators could delegate actions a worker's profile restricted.

Foundation for Phase 5 upload/download, Phase 6 network inspect + cookie import, Phase 8 captcha skills.

## Test plan

- [x] 15 new unit tests (default-allow, wildcard, curated list, empty list, can_use_browser precedence, trusted bypass, default-template inheritance, KNOWN_BROWSER_ACTIONS regression)
- [x] 1 new delegation security test (target-policy enforcement on delegation)
- [x] All existing `test_browser_delegation.py` tests pass with updated 403 message
- [x] `test_browser_service.py::TestAllowedBrowserActions` rewritten to import canonical constant
- [x] Full non-e2e suite: 3204 pass / 21 skip / 1 pre-existing env failure (`cli --version` in worktree without `pip install`)
- [x] `ruff check` clean

Implements §2.6 + §4.1 of `docs/plans/2026-04-20-browser-automation.md`.