### PR TITLE
Phase 1.3: consolidate redaction into src/shared/redaction

### DIFF
--- a/src/agent/builtins/browser_tool.py
+++ b/src/agent/builtins/browser_tool.py
@@ -6,45 +6,22 @@ service container. Agent containers no longer bundle Chrome or VNC.
 
 from __future__ import annotations
 
-import re
-
 from src.agent.skills import skill
+
+# ``_redact_credentials`` is re-exported here (via the aliased import) so
+# existing callers that imported it from this module — e.g. ``tests/test_builtins.py``
+# — keep working after the Phase 1.3 consolidation. The canonical
+# implementation lives in :mod:`src.shared.redaction`; do not edit patterns
+# here.
+from src.shared.redaction import (
+    deep_redact as _deep_redact,
+)
+from src.shared.redaction import (
+    redact_string as _redact_credentials,  # noqa: F401
+)
 from src.shared.utils import setup_logging
 
 logger = setup_logging("agent.browser")
-
-# Pattern-based credential redaction (defense in depth on agent side)
-_REDACT_PATTERNS = [
-    re.compile(r"sk-[A-Za-z0-9]{20,}"),
-    re.compile(r"sk-ant-api[A-Za-z0-9\-]{20,}"),
-    re.compile(r"gho_[A-Za-z0-9]{36,}"),
-    re.compile(r"github_pat_[A-Za-z0-9_]{20,}"),
-    re.compile(r"xoxb-[A-Za-z0-9\-]{20,}"),
-    re.compile(r"xoxp-[A-Za-z0-9\-]{20,}"),
-    re.compile(r"AKIA[A-Z0-9]{16}"),
-    re.compile(r"(?<![A-Za-z0-9])[A-Fa-f0-9]{40,}(?![A-Za-z0-9])"),
-    re.compile(r"(?<![A-Za-z0-9/+=])[A-Za-z0-9+/]{40,}={0,2}(?![A-Za-z0-9/+=])"),
-]
-
-
-def _redact_credentials(text: str) -> str:
-    """Replace common secret patterns with [REDACTED]."""
-    if not text:
-        return text
-    for pattern in _REDACT_PATTERNS:
-        text = pattern.sub("[REDACTED]", text)
-    return text
-
-
-def _deep_redact(obj):
-    """Recursively redact credential values from any JSON-serializable structure."""
-    if isinstance(obj, str):
-        return _redact_credentials(obj)
-    if isinstance(obj, dict):
-        return {k: _deep_redact(v) for k, v in obj.items()}
-    if isinstance(obj, list):
-        return [_deep_redact(item) for item in obj]
-    return obj
 
 
 async def _browser_command(mesh_client, action: str, params: dict | None = None) -> dict:

--- a/src/browser/redaction.py
+++ b/src/browser/redaction.py
@@ -1,43 +1,34 @@
-"""Credential redaction for browser responses.
+"""Browser-service redaction — backward-compat shim over :mod:`src.shared.redaction`.
 
-Pattern-based redaction prevents secrets from leaking into LLM context
-through browser tool responses.
+Historically carried its own copy of the secret-pattern list. Phase 1.3
+consolidated patterns into :mod:`src.shared.redaction` so there's one source
+of truth, URL-aware redaction ships here too, and updates don't risk the two
+copies drifting.
+
+Keeps the :class:`CredentialRedactor` API so existing call sites in
+``src/browser/service.py`` continue to work unchanged.
 """
 
 from __future__ import annotations
 
-import re
-
-_REDACT_PATTERNS = [
-    re.compile(r"sk-[A-Za-z0-9]{20,}"),                # OpenAI / Anthropic
-    re.compile(r"sk-ant-api[A-Za-z0-9\-]{20,}"),       # Anthropic
-    re.compile(r"gho_[A-Za-z0-9]{36,}"),                # GitHub OAuth tokens
-    re.compile(r"github_pat_[A-Za-z0-9_]{20,}"),        # GitHub fine-grained PATs
-    re.compile(r"xoxb-[A-Za-z0-9\-]{20,}"),             # Slack bot tokens
-    re.compile(r"xoxp-[A-Za-z0-9\-]{20,}"),             # Slack user tokens
-    re.compile(r"AKIA[A-Z0-9]{16}"),                     # AWS access key IDs
-    re.compile(r"(?<![A-Za-z0-9])[A-Fa-f0-9]{40,}(?![A-Za-z0-9])"),
-    re.compile(r"(?<![A-Za-z0-9/+=])[A-Za-z0-9+/]{40,}={0,2}(?![A-Za-z0-9/+=])"),
-]
+from src.shared.redaction import (
+    _REDACT_PATTERNS,  # noqa: F401  — re-export for old imports
+    deep_redact,
+    redact_string,
+)
 
 
 class CredentialRedactor:
-    """Per-agent credential redaction state."""
+    """Per-agent credential redaction state.
+
+    Thin shim: ``agent_id`` is accepted for future per-agent allowlisting but
+    not yet used. The underlying pattern set is global.
+    """
 
     def redact(self, agent_id: str, text: str) -> str:
-        """Apply pattern-based redaction to text."""
-        if not text:
-            return text
-        for pattern in _REDACT_PATTERNS:
-            text = pattern.sub("[REDACTED]", text)
-        return text
+        """Apply pattern-based redaction to ``text``."""
+        return redact_string(text)
 
     def deep_redact(self, agent_id: str, obj):
-        """Recursively redact credential values from any JSON-serializable structure."""
-        if isinstance(obj, str):
-            return self.redact(agent_id, obj)
-        if isinstance(obj, dict):
-            return {k: self.deep_redact(agent_id, v) for k, v in obj.items()}
-        if isinstance(obj, list):
-            return [self.deep_redact(agent_id, item) for item in obj]
-        return obj
+        """Recursively redact credential values from a JSON-shaped structure."""
+        return deep_redact(obj)

--- a/src/shared/redaction.py
+++ b/src/shared/redaction.py
@@ -85,9 +85,10 @@ _REDACT_PATTERNS = SECRET_PATTERNS
 #
 # Generic auth
 _GENERIC = {
-    "api_key", "apikey", "api-key",
+    "api_key", "apikey", "api-key", "api_token", "apitoken", "api-token",
     "key", "token", "auth", "authorization", "access_token",
-    "refresh_token", "id_token", "secret", "client_secret",
+    "refresh_token", "id_token", "bearer_token", "bearertoken",
+    "secret", "client_secret",
     "password", "passwd", "pwd", "assertion",
     "session", "session_id", "sessionid",
     "sig", "signature", "hash", "hmac",
@@ -182,6 +183,16 @@ def redact_url(url: str) -> str:
         parts = urlsplit(url)
     except ValueError:
         # Malformed URL — treat as opaque string.
+        return redact_string(url)
+
+    # Only structurally-parse web-transport URLs. Exotic schemes like
+    # ``javascript:`` / ``data:`` / ``blob:`` / ``vbscript:`` don't follow
+    # the authority/path/query/fragment model; running our redactor over
+    # them can produce nonsense (e.g. treating a base64 data: body as a
+    # path) without adding meaningful protection. The pattern-level sweep
+    # below still catches embedded secrets.
+    _WEB_SCHEMES = {"http", "https", "ws", "wss", "ftp", "ftps"}
+    if parts.scheme.lower() not in _WEB_SCHEMES:
         return redact_string(url)
 
     # 1. Netloc: strip userinfo

--- a/src/shared/redaction.py
+++ b/src/shared/redaction.py
@@ -1,0 +1,271 @@
+"""Unified credential + URL redaction (Phase 1.3).
+
+Single source of truth for stripping secrets from any text that might reach
+LLM context, logs, or agent-visible responses. Previously duplicated across
+:mod:`src.browser.redaction` and the agent-side ``browser_tool`` module;
+both now re-export this module.
+
+Public surface:
+
+- :data:`SECRET_PATTERNS` — module-level list of compiled regexes matching
+  common API-key / token shapes (OpenAI, Anthropic, GitHub, Slack, AWS, long
+  hex/base64 blobs). Prefix-underscore per CLAUDE.md constant convention.
+- :data:`SENSITIVE_QUERY_PARAMS` — frozenset of query-parameter names that
+  always have their values stripped from URLs, regardless of pattern match.
+  Case-insensitive matching.
+- :func:`redact_string(text)` — apply :data:`SECRET_PATTERNS` to a plain
+  string.  Backward-compatible with the v1 :class:`CredentialRedactor.redact`
+  behavior.
+- :func:`redact_url(url)` — component-aware URL redaction. Strips userinfo,
+  drops fragments, replaces sensitive-query-param VALUES with ``[REDACTED]``
+  (keeping the keys for debuggability), detects JWT-shaped tokens in path
+  segments.  Always safe to call on non-URL strings (returns unchanged).
+- :func:`deep_redact(obj)` — recursive dict/list/string redaction. Strings
+  flow through :func:`redact_string`; strings that look like URLs additionally
+  flow through :func:`redact_url`.
+
+Operator controls (env-var-driven):
+
+- ``OPENLEGION_REDACTION_URL_QUERY_ALLOW`` — comma-separated query-param
+  names that should NOT be redacted even if they appear sensitive. Intended
+  for specific integrations where the operator has verified the value is
+  non-sensitive. Empty (default) = strict deny-by-default.
+
+Threat model boundary (out of scope here):
+
+- This module does not detect or redact DOM-level secrets embedded in
+  rendered HTML (e.g. a session cookie mirrored into page text). That's the
+  browser-service snapshot pipeline's job; it calls :func:`redact_string` on
+  the rendered text before returning to agents.
+- This module does not redact response bodies of captured network requests.
+  Phase 9.1 network-inspection plan forbids body capture entirely; URLs
+  alone flow through :func:`redact_url`.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+from urllib.parse import SplitResult, parse_qsl, quote_plus, urlsplit, urlunsplit
+
+# ── Pattern-based secret redaction ──────────────────────────────────────────
+
+
+SECRET_PATTERNS: list[re.Pattern[str]] = [
+    # Provider-specific tokens (prefix-anchored; low false-positive rate)
+    re.compile(r"sk-[A-Za-z0-9]{20,}"),              # OpenAI / Anthropic short form
+    re.compile(r"sk-ant-api[A-Za-z0-9\-]{20,}"),     # Anthropic
+    re.compile(r"gho_[A-Za-z0-9]{36,}"),              # GitHub OAuth access tokens
+    re.compile(r"github_pat_[A-Za-z0-9_]{20,}"),      # GitHub fine-grained PATs
+    re.compile(r"xoxb-[A-Za-z0-9\-]{20,}"),           # Slack bot tokens
+    re.compile(r"xoxp-[A-Za-z0-9\-]{20,}"),           # Slack user tokens
+    re.compile(r"AKIA[A-Z0-9]{16}"),                   # AWS access key IDs
+    # Generic long-hex / long-base64 blobs with boundary lookarounds so we
+    # don't redact mid-word hex sequences.
+    re.compile(r"(?<![A-Za-z0-9])[A-Fa-f0-9]{40,}(?![A-Za-z0-9])"),
+    re.compile(r"(?<![A-Za-z0-9/+=])[A-Za-z0-9+/]{40,}={0,2}(?![A-Za-z0-9/+=])"),
+    # JWT (three base64-url segments separated by dots, ≥10 chars each).
+    # Matches bearer JWTs in logs, auth headers, signed URLs.
+    re.compile(r"(?<![A-Za-z0-9._-])"
+               r"[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}"
+               r"(?![A-Za-z0-9._-])"),
+]
+
+# Backward-compat alias used by the old ``_REDACT_PATTERNS`` name in
+# ``src/browser/redaction.py`` and the agent-side browser_tool.  Existing
+# imports keep working.
+_REDACT_PATTERNS = SECRET_PATTERNS
+
+
+# ── URL-aware redaction ─────────────────────────────────────────────────────
+
+
+# Case-insensitive match on KEY. Values are always stripped. Categorized by
+# source for maintainability; the flat frozenset is what gets compared.
+#
+# Generic auth
+_GENERIC = {
+    "api_key", "apikey", "api-key",
+    "key", "token", "auth", "authorization", "access_token",
+    "refresh_token", "id_token", "secret", "client_secret",
+    "password", "passwd", "pwd", "assertion",
+    "session", "session_id", "sessionid",
+    "sig", "signature", "hash", "hmac",
+}
+# OAuth 2.0 flow params — `code` is the authorization grant; `state` is
+# CSRF binding but leaking it lets an attacker correlate sessions.
+_OAUTH = {"code", "state"}
+# AWS SigV4 presigned URL params
+_AWS_SIGV4 = {
+    "x-amz-algorithm", "x-amz-credential", "x-amz-date",
+    "x-amz-expires", "x-amz-signature", "x-amz-signedheaders",
+    "x-amz-security-token",
+}
+# Google Cloud Storage signed URL params
+_GCS_SIGNED = {
+    "x-goog-algorithm", "x-goog-credential", "x-goog-date",
+    "x-goog-expires", "x-goog-signature", "x-goog-signedheaders",
+}
+# Azure SAS tokens
+_AZURE_SAS = {"sv", "sig", "st", "se", "sp", "sr", "spr"}
+# Common Supabase / magic-link / password-reset flavors
+_MAGIC_LINK = {
+    "token_hash", "magic_token", "reset_token",
+    "confirmation_token", "invite_token",
+}
+
+
+SENSITIVE_QUERY_PARAMS: frozenset[str] = frozenset(
+    p.lower() for p in (
+        *_GENERIC, *_OAUTH, *_AWS_SIGV4, *_GCS_SIGNED, *_AZURE_SAS, *_MAGIC_LINK,
+    )
+)
+
+
+# JWT in a path segment — common for password reset / unsubscribe links.
+_JWT_IN_PATH = re.compile(
+    r"^[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}$"
+)
+
+
+_REDACTED_VALUE = "[REDACTED]"
+
+
+def _operator_allowlist() -> frozenset[str]:
+    """Query-param names the operator has opted out of redaction for.
+
+    Intended for specific integrations where the operator has verified the
+    value is non-sensitive in their deployment. Default empty =
+    strict deny-by-default.
+    """
+    raw = os.environ.get("OPENLEGION_REDACTION_URL_QUERY_ALLOW", "").strip()
+    if not raw:
+        return frozenset()
+    return frozenset(p.strip().lower() for p in raw.split(",") if p.strip())
+
+
+def _should_redact_query(key: str) -> bool:
+    """Return True when the query-param ``key`` should have its value stripped."""
+    k = key.lower()
+    if k in _operator_allowlist():
+        return False
+    return k in SENSITIVE_QUERY_PARAMS
+
+
+def redact_url(url: str) -> str:
+    """Return ``url`` with secrets stripped from every component.
+
+    Safe to call on strings that don't look like URLs — returns them
+    unchanged. Designed to be idempotent: redacting an already-redacted URL
+    produces the same string.
+
+    Redaction rules:
+
+    * **Userinfo** — ``user:pass@host`` → ``host`` (whole userinfo dropped;
+      the username alone can leak account ownership, so we strip both).
+    * **Query params** — values of keys in :data:`SENSITIVE_QUERY_PARAMS`
+      are replaced with ``[REDACTED]``. Keys preserved so the shape of the
+      URL is readable for debugging.
+    * **Fragment** — dropped entirely. Fragments often carry OAuth implicit
+      tokens (``#access_token=...``) and rarely carry useful info for logs.
+    * **Path segments** — any segment matching the JWT shape gets replaced
+      with ``[REDACTED]`` in place.
+    * **All components** — after the above, :func:`redact_string` runs one
+      more pass so pattern-matching secrets anywhere in the string get
+      caught (e.g. an OpenAI key accidentally baked into a path).
+    """
+    if not url or "://" not in url:
+        # Bare domains / non-URL strings: fall through to string patterns only.
+        return redact_string(url)
+
+    try:
+        parts = urlsplit(url)
+    except ValueError:
+        # Malformed URL — treat as opaque string.
+        return redact_string(url)
+
+    # 1. Netloc: strip userinfo
+    netloc = parts.netloc
+    if "@" in netloc:
+        netloc = netloc.rsplit("@", 1)[-1]
+
+    # 2. Path: redact JWT-shaped segments
+    path = parts.path
+    if path:
+        segments = path.split("/")
+        segments = [
+            _REDACTED_VALUE if _JWT_IN_PATH.match(seg) else seg
+            for seg in segments
+        ]
+        path = "/".join(segments)
+
+    # 3. Query: strip sensitive values, keep keys.
+    #
+    # We rebuild manually instead of calling ``urlencode`` because the
+    # default encoder runs both key and value through ``quote_plus``, which
+    # would turn our ``[REDACTED]`` sentinel into ``%5BREDACTED%5D`` — still
+    # correct semantically, but uglier in logs and breaks simple substring
+    # checks that operators use when grep'ing traces.
+    query = parts.query
+    if query:
+        # keep_blank_values=True so we don't lose shape on empty params
+        pairs = parse_qsl(query, keep_blank_values=True)
+        parts_out: list[str] = []
+        for k, v in pairs:
+            enc_key = quote_plus(k)
+            if _should_redact_query(k):
+                # Literal sentinel, no encoding — ``[`` and ``]`` stay visible.
+                parts_out.append(f"{enc_key}={_REDACTED_VALUE}")
+            else:
+                parts_out.append(f"{enc_key}={quote_plus(v)}")
+        query = "&".join(parts_out)
+
+    # 4. Fragment: drop entirely
+    rebuilt = urlunsplit(SplitResult(parts.scheme, netloc, path, query, ""))
+
+    # 5. Final pattern-sweep in case a token is embedded where we didn't look
+    return redact_string(rebuilt)
+
+
+def redact_string(text: str) -> str:
+    """Apply :data:`SECRET_PATTERNS` to ``text`` and return the result."""
+    if not text:
+        return text
+    for pattern in SECRET_PATTERNS:
+        text = pattern.sub(_REDACTED_VALUE, text)
+    return text
+
+
+# ── Deep recursion over JSON-shaped structures ──────────────────────────────
+
+
+def _looks_like_url(s: str) -> bool:
+    """Heuristic: bare-minimum check to avoid running urlsplit on plain text.
+
+    Accepts strings with an explicit ``://`` scheme marker. Conservative
+    on purpose — false negatives fall back to pattern-only redaction which
+    is still safe.
+    """
+    return "://" in s and len(s) < 4096
+
+
+def deep_redact(obj):
+    """Recursively redact secrets from any JSON-serializable value.
+
+    - Strings flow through :func:`redact_url` if they look like URLs, else
+      :func:`redact_string`.
+    - Dicts and lists recurse.
+    - Tuples are supported but returned as tuples.
+    - Other values (int, bool, None, float) pass through unchanged.
+    """
+    if isinstance(obj, str):
+        if _looks_like_url(obj):
+            return redact_url(obj)
+        return redact_string(obj)
+    if isinstance(obj, dict):
+        return {k: deep_redact(v) for k, v in obj.items()}
+    if isinstance(obj, list):
+        return [deep_redact(item) for item in obj]
+    if isinstance(obj, tuple):
+        return tuple(deep_redact(item) for item in obj)
+    return obj

--- a/src/shared/redaction.py
+++ b/src/shared/redaction.py
@@ -175,8 +175,19 @@ def redact_url(url: str) -> str:
       more pass so pattern-matching secrets anywhere in the string get
       caught (e.g. an OpenAI key accidentally baked into a path).
     """
-    if not url or "://" not in url:
-        # Bare domains / non-URL strings: fall through to string patterns only.
+    if not url:
+        return url
+
+    # We structurally-parse any input that looks like either:
+    #   * an absolute web URL (``scheme://host/…?q``), or
+    #   * a relative URL with a query string (``/cb?code=TOKEN&state=…``).
+    # Logged redirects, OAuth callback paths, and copy-pasted URL
+    # fragments commonly arrive without a scheme; the query-string part
+    # is still the highest-leak component we need to strip. Fall through
+    # to pattern-only redaction only for strings that are neither.
+    has_scheme = "://" in url
+    has_relative_query = (not has_scheme) and ("?" in url) and url.startswith("/")
+    if not (has_scheme or has_relative_query):
         return redact_string(url)
 
     try:
@@ -185,14 +196,14 @@ def redact_url(url: str) -> str:
         # Malformed URL — treat as opaque string.
         return redact_string(url)
 
-    # Only structurally-parse web-transport URLs. Exotic schemes like
-    # ``javascript:`` / ``data:`` / ``blob:`` / ``vbscript:`` don't follow
-    # the authority/path/query/fragment model; running our redactor over
-    # them can produce nonsense (e.g. treating a base64 data: body as a
-    # path) without adding meaningful protection. The pattern-level sweep
-    # below still catches embedded secrets.
+    # For absolute URLs, restrict structural parsing to web schemes.
+    # Exotic schemes like ``javascript:`` / ``data:`` / ``blob:`` /
+    # ``vbscript:`` don't follow the authority/path/query/fragment model;
+    # running our redactor over them can produce nonsense (e.g. treating
+    # a base64 data: body as a path) without adding meaningful protection.
+    # The pattern-level sweep below still catches embedded secrets.
     _WEB_SCHEMES = {"http", "https", "ws", "wss", "ftp", "ftps"}
-    if parts.scheme.lower() not in _WEB_SCHEMES:
+    if has_scheme and parts.scheme.lower() not in _WEB_SCHEMES:
         return redact_string(url)
 
     # 1. Netloc: strip userinfo

--- a/tests/fixtures/redaction_corpus.json
+++ b/tests/fixtures/redaction_corpus.json
@@ -1,0 +1,215 @@
+[
+  {
+    "name": "oauth_google_redirect_with_code_and_state",
+    "input": "https://app.example.com/auth/callback?code=4/0AY0e-g7xbQgF3g&state=xyz123&scope=email",
+    "expect_redacted": ["4/0AY0e-g7xbQgF3g", "xyz123"],
+    "expect_preserved": ["app.example.com", "auth/callback", "scope"]
+  },
+  {
+    "name": "oauth_google_redirect_keeps_scope_value_visible",
+    "input": "https://example.com/cb?code=abcdef&scope=openid+email+profile",
+    "expect_redacted": ["abcdef"],
+    "expect_preserved": ["openid+email+profile", "scope"]
+  },
+  {
+    "name": "github_oauth_code",
+    "input": "https://app.com/callback?code=gho_aFakeGhotokenThatIs40chars1234567890AB&state=csrfval",
+    "expect_redacted": ["gho_aFakeGhotokenThatIs40chars1234567890AB", "csrfval"],
+    "expect_preserved": ["app.com"]
+  },
+  {
+    "name": "supabase_magic_link",
+    "input": "https://app.example.com/auth/confirm?token_hash=pkce_abc123def456xyz&type=magiclink",
+    "expect_redacted": ["pkce_abc123def456xyz"],
+    "expect_preserved": ["magiclink"]
+  },
+  {
+    "name": "password_reset_token",
+    "input": "https://site.com/reset?reset_token=xyz789abcdef0123&email=u@e.com",
+    "expect_redacted": ["xyz789abcdef0123"],
+    "expect_preserved": ["site.com", "email=u%40e.com"],
+    "note": "email @ gets url-encoded by quote_plus — substring check uses the encoded form"
+  },
+  {
+    "name": "aws_s3_presigned_url",
+    "input": "https://bucket.s3.amazonaws.com/path/file.pdf?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIOSFODNN7EXAMPLE%2F20260101%2Fus-east-1&X-Amz-Date=20260101T000000Z&X-Amz-Expires=3600&X-Amz-SignedHeaders=host&X-Amz-Signature=deadbeefcafebabe1234567890abcdef12345678",
+    "expect_redacted": [
+      "AKIAIOSFODNN7EXAMPLE",
+      "deadbeefcafebabe1234567890abcdef12345678"
+    ],
+    "expect_preserved": ["bucket.s3.amazonaws.com", "file.pdf"]
+  },
+  {
+    "name": "gcs_signed_url",
+    "input": "https://storage.googleapis.com/mybucket/object?X-Goog-Algorithm=GOOG4-RSA-SHA256&X-Goog-Credential=svc%40proj.iam.gserviceaccount.com&X-Goog-Date=20260101T000000Z&X-Goog-Expires=300&X-Goog-Signature=0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef&X-Goog-SignedHeaders=host",
+    "expect_redacted": [
+      "svc%40proj.iam.gserviceaccount.com",
+      "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+    ],
+    "expect_preserved": ["storage.googleapis.com", "mybucket"]
+  },
+  {
+    "name": "azure_sas_url",
+    "input": "https://storageacc.blob.core.windows.net/container/blob.txt?sv=2021-04-10&st=2026-01-01T00%3A00Z&se=2026-01-02T00%3A00Z&sp=r&sig=AbCdEfGhIjKlMnOpQrStUvWxYz0123456789%3D",
+    "expect_redacted": ["AbCdEfGhIjKlMnOpQrStUvWxYz0123456789%3D"],
+    "expect_preserved": ["storageacc.blob.core.windows.net", "container"]
+  },
+  {
+    "name": "github_raw_token_querystring",
+    "input": "https://raw.githubusercontent.com/user/repo/main/file.md?token=ghs_1234567890abcdef1234567890abcdefABCD",
+    "expect_redacted": ["ghs_1234567890abcdef1234567890abcdefABCD"],
+    "expect_preserved": ["raw.githubusercontent.com", "user/repo"]
+  },
+  {
+    "name": "userinfo_basic_auth",
+    "input": "https://alice:secretpassword@intranet.example.com/admin",
+    "expect_redacted": ["alice", "secretpassword"],
+    "expect_preserved": ["intranet.example.com", "admin"]
+  },
+  {
+    "name": "fragment_implicit_oauth",
+    "input": "https://app.com/#access_token=eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMjMifQ.abc123xyz&token_type=bearer",
+    "expect_redacted": [
+      "eyJhbGciOiJIUzI1NiJ9",
+      "access_token=eyJ",
+      "token_type=bearer"
+    ],
+    "expect_preserved": ["app.com"],
+    "note": "fragment is dropped entirely — the raw = pairs and the JWT body all disappear"
+  },
+  {
+    "name": "jwt_in_path_unsubscribe",
+    "input": "https://email.example.com/u/eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJhYmNkIn0.signaturepartheremustbe10chars/click",
+    "expect_redacted": [
+      "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJhYmNkIn0.signaturepartheremustbe10chars"
+    ],
+    "expect_preserved": ["email.example.com", "/u/", "/click"]
+  },
+  {
+    "name": "openai_key_in_query",
+    "input": "https://proxy.internal/echo?api_key=sk-abcdefghijklmnopqrstuvwxyz0123456789",
+    "expect_redacted": ["sk-abcdefghijklmnopqrstuvwxyz0123456789"],
+    "expect_preserved": ["proxy.internal", "api_key"]
+  },
+  {
+    "name": "anthropic_key_in_path",
+    "input": "https://mirror.example/api/sk-ant-api01-AAAAAAAAAAAAAAAAAAAAAAAAAA/",
+    "expect_redacted": ["sk-ant-api01-AAAAAAAAAAAAAAAAAAAAAAAAAA"],
+    "expect_preserved": ["mirror.example"]
+  },
+  {
+    "name": "aws_access_key_in_url",
+    "input": "https://example.com/leak/AKIAIOSFODNN7EXAMPLE",
+    "expect_redacted": ["AKIAIOSFODNN7EXAMPLE"],
+    "expect_preserved": ["example.com"]
+  },
+  {
+    "name": "slack_token_in_query",
+    "input": "https://hooks.slack.com/services/?token=xoxb-FAKEEXAMPLEDONOTSCANREDACTONLY",
+    "expect_redacted": ["xoxb-FAKEEXAMPLEDONOTSCANREDACTONLY"],
+    "expect_preserved": ["hooks.slack.com", "services"]
+  },
+  {
+    "name": "refresh_token_query",
+    "input": "https://api.example.com/token?refresh_token=eyJrZWZyZXNoVG9rZW4ifQ.abc&client_id=pub",
+    "expect_redacted": ["eyJrZWZyZXNoVG9rZW4ifQ.abc"],
+    "expect_preserved": ["api.example.com", "client_id", "pub"]
+  },
+  {
+    "name": "client_secret_query",
+    "input": "https://idp.example.com/oauth2/token?client_id=myapp&client_secret=dontleakme1234567890",
+    "expect_redacted": ["dontleakme1234567890"],
+    "expect_preserved": ["idp.example.com", "myapp"]
+  },
+  {
+    "name": "long_hex_in_path_hash",
+    "input": "https://cache.example.com/assets/abcdef0123456789abcdef0123456789abcdef0123456789/thing.css",
+    "expect_redacted": ["abcdef0123456789abcdef0123456789abcdef0123456789"],
+    "expect_preserved": ["cache.example.com", "thing.css"]
+  },
+  {
+    "name": "plain_url_untouched",
+    "input": "https://example.com/docs/page.html?topic=security",
+    "expect_redacted": [],
+    "expect_preserved": ["example.com", "docs/page.html", "topic=security"]
+  },
+  {
+    "name": "plain_url_with_numeric_id",
+    "input": "https://blog.example.com/posts/42?page=3",
+    "expect_redacted": [],
+    "expect_preserved": ["42", "page=3"]
+  },
+  {
+    "name": "bare_host_no_path",
+    "input": "https://example.com",
+    "expect_redacted": [],
+    "expect_preserved": ["example.com"]
+  },
+  {
+    "name": "github_pat_in_query",
+    "input": "https://api.github.com/repos/org/repo?token=github_pat_11ABCDEF0123456789ABCDEFabcdef012345",
+    "expect_redacted": ["github_pat_11ABCDEF0123456789ABCDEFabcdef012345"],
+    "expect_preserved": ["api.github.com"]
+  },
+  {
+    "name": "multiple_sensitive_params",
+    "input": "https://svc.example.com/act?token=abcxyz123def456&signature=feed_face_cafe_babe&next=/dashboard",
+    "expect_redacted": ["abcxyz123def456", "feed_face_cafe_babe"],
+    "expect_preserved": ["next=%2Fdashboard"],
+    "note": "slash in query-value gets quote_plus'd to %2F"
+  },
+  {
+    "name": "id_token_query_value_stripped_fragment_dropped",
+    "input": "https://app.example.com/cb?id_token=header.payload.sig&extra=keep#access_token=a.b.c",
+    "expect_redacted": [
+      "header.payload.sig",
+      "access_token=a.b.c",
+      "a.b.c"
+    ],
+    "expect_preserved": [
+      "app.example.com",
+      "id_token=",
+      "extra=keep"
+    ],
+    "note": "id_token KEY preserved (for debuggability); its value stripped. Fragment dropped entirely."
+  },
+  {
+    "name": "capital_case_query_key_still_matches",
+    "input": "https://svc.com/?API_KEY=sk-supersecrettokenherebeverylong123&foo=bar",
+    "expect_redacted": ["sk-supersecrettokenherebeverylong123"],
+    "expect_preserved": ["svc.com", "foo=bar"]
+  },
+  {
+    "name": "non_url_string_pattern_only",
+    "input": "my key is sk-abcdefghijklmnopqrstuvwxyz1234567890 — don't share it",
+    "expect_redacted": ["sk-abcdefghijklmnopqrstuvwxyz1234567890"],
+    "expect_preserved": ["my key is", "don't share it"]
+  },
+  {
+    "name": "non_url_string_no_secrets_untouched",
+    "input": "Meeting at 3pm in conference room 4",
+    "expect_redacted": [],
+    "expect_preserved": ["Meeting at 3pm", "conference room 4"]
+  },
+  {
+    "name": "empty_query_param_preserved_shape",
+    "input": "https://svc.com/?token=&keep=yes",
+    "expect_redacted": [],
+    "expect_preserved": ["keep=yes"],
+    "note": "empty value stripping is a no-op but shape preserves"
+  },
+  {
+    "name": "bearer_jwt_in_text",
+    "input": "Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJ0ZXN0In0.abc1234567",
+    "expect_redacted": [
+      "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJ0ZXN0In0.abc1234567"
+    ],
+    "expect_preserved": ["Authorization: Bearer"]
+  },
+  {
+    "name": "slack_user_token",
+    "input": "webhook: https://hooks.slack.com/?auth=xoxp-FAKEEXAMPLEDONOTSCANUSERTOKEN",
+    "expect_redacted": ["xoxp-FAKEEXAMPLEDONOTSCANUSERTOKEN"],
+    "expect_preserved": ["hooks.slack.com"]
+  }
+]

--- a/tests/test_shared_redaction.py
+++ b/tests/test_shared_redaction.py
@@ -152,6 +152,21 @@ class TestRedactUrl:
             assert "zzz-secret-zzz" not in out, key
             assert _REDACTED in out
 
+    def test_relative_url_with_query_string_redacted(self):
+        """OAuth callback paths and copy-pasted URL fragments often arrive
+        without a scheme (``/cb?code=...&state=...``). Structural query
+        stripping must still kick in."""
+        out = redact_url("/cb?code=authgrant123&state=csrfval&keep=yes")
+        assert "authgrant123" not in out
+        assert "csrfval" not in out
+        assert "keep=yes" in out
+        assert "/cb?" in out
+
+    def test_plain_text_without_query_uses_patterns_only(self):
+        """A bare relative path (no ``?``) should not be parsed as a URL."""
+        out = redact_url("/posts/42")
+        assert out == "/posts/42"
+
 
 class TestSensitiveQueryParams:
     def test_common_auth_params_present(self):

--- a/tests/test_shared_redaction.py
+++ b/tests/test_shared_redaction.py
@@ -1,0 +1,291 @@
+"""Tests for the unified :mod:`src.shared.redaction` module (Phase 1.3).
+
+Covers three layers:
+
+1. Unit tests for ``redact_string`` / ``redact_url`` / ``deep_redact`` — each
+   behavioral rule has at least one positive and one negative assertion.
+2. A **corpus** test that reads ``tests/fixtures/redaction_corpus.json`` —
+   the gate against missing a known leak pattern. Each fixture entry lists
+   tokens that must be redacted and tokens that must be preserved.
+3. Backward-compat checks for the two shim modules (``src/browser/redaction``
+   and the agent-side browser tool) — ensures old imports still work.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+from unittest import mock
+
+import pytest
+
+from src.shared.redaction import (
+    _REDACT_PATTERNS,
+    SECRET_PATTERNS,
+    SENSITIVE_QUERY_PARAMS,
+    deep_redact,
+    redact_string,
+    redact_url,
+)
+
+CORPUS_PATH = Path(__file__).parent / "fixtures" / "redaction_corpus.json"
+_REDACTED = "[REDACTED]"
+
+
+# ── Unit tests: redact_string ───────────────────────────────────────────────
+
+
+class TestRedactString:
+    @pytest.mark.parametrize("secret", [
+        "sk-abcdefghijklmnopqrstuvwxyz0123456789",
+        "sk-ant-api01-" + "A" * 30,
+        "gho_" + "a" * 40,
+        "github_pat_11ABCDEF" + "0" * 30,
+        "xoxb-" + "1" * 40,
+        "xoxp-" + "2" * 40,
+        "AKIAIOSFODNN7EXAMPLE",
+    ])
+    def test_provider_patterns_redacted(self, secret):
+        assert redact_string(f"key={secret}") == f"key={_REDACTED}"
+
+    def test_long_hex_blob_redacted(self):
+        out = redact_string("hash:" + "ab" * 25)
+        assert _REDACTED in out
+
+    def test_long_base64_blob_redacted(self):
+        blob = "A" * 60 + "=="
+        assert _REDACTED in redact_string(f"token:{blob}")
+
+    def test_short_hex_preserved(self):
+        # Commit hashes, short refs — below the 40-char threshold.
+        assert redact_string("commit abc1234 deadbee") == "commit abc1234 deadbee"
+
+    def test_empty_and_none_preserved(self):
+        assert redact_string("") == ""
+        assert redact_string(None) is None
+
+    def test_jwt_redacted_anywhere_in_string(self):
+        jwt = "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxIn0.signaturepartatleasttenchars"
+        assert redact_string(f"Bearer {jwt}") == f"Bearer {_REDACTED}"
+
+
+# ── Unit tests: redact_url ──────────────────────────────────────────────────
+
+
+class TestRedactUrl:
+    def test_strips_userinfo(self):
+        out = redact_url("https://alice:pw@host.example/admin")
+        assert "alice" not in out
+        assert "pw" not in out
+        assert "host.example/admin" in out
+
+    def test_drops_fragment(self):
+        out = redact_url("https://app.example/cb?x=1#access_token=abc.def.ghi")
+        assert "access_token" not in out
+        assert "#" not in out
+        assert "x=1" in out  # non-sensitive query preserved
+
+    def test_redacts_sensitive_query_keys_keeps_keys(self):
+        out = redact_url("https://svc.example/?api_key=mysecret&public=hello")
+        assert "api_key=" in out  # key preserved for debug
+        assert "mysecret" not in out
+        assert _REDACTED in out
+        assert "public=hello" in out
+
+    def test_case_insensitive_query_key_match(self):
+        out = redact_url("https://svc.example/?API_KEY=mysecret")
+        assert "mysecret" not in out
+        assert _REDACTED in out
+
+    def test_oauth_code_and_state_stripped(self):
+        out = redact_url("https://app.example/cb?code=authz123&state=csrf456")
+        assert "authz123" not in out
+        assert "csrf456" not in out
+
+    def test_aws_sigv4_params_stripped(self):
+        sig = "deadbeefcafebabe" * 3
+        out = redact_url(f"https://bucket.s3.amazonaws.com/x?X-Amz-Signature={sig}")
+        assert sig not in out
+        assert "X-Amz-Signature" in out
+
+    def test_jwt_path_segment_redacted(self):
+        jwt_seg = "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJhYmNkIn0.signaturemustbetenchars"
+        out = redact_url(f"https://email.example/u/{jwt_seg}/click")
+        assert jwt_seg not in out
+        assert _REDACTED in out
+        assert "/click" in out
+
+    def test_plain_url_untouched(self):
+        url = "https://example.com/docs/page.html?topic=security"
+        assert redact_url(url) == url
+
+    def test_non_url_falls_through_to_string(self):
+        # String without "://" takes the pattern-only path.
+        out = redact_url("my key: sk-abcdefghijklmnopqrstuvwxyz0123456789")
+        assert _REDACTED in out
+        assert "my key:" in out
+
+    def test_idempotent_on_already_redacted(self):
+        once = redact_url("https://svc.example/?api_key=abc123xyz")
+        twice = redact_url(once)
+        assert once == twice
+
+
+class TestSensitiveQueryParams:
+    def test_common_auth_params_present(self):
+        for expected in ("api_key", "token", "password", "secret"):
+            assert expected in SENSITIVE_QUERY_PARAMS, expected
+
+    def test_oauth_params_present(self):
+        for expected in ("code", "state", "access_token", "refresh_token", "id_token"):
+            assert expected in SENSITIVE_QUERY_PARAMS, expected
+
+    def test_aws_gcs_azure_params_present(self):
+        for expected in ("x-amz-signature", "x-goog-signature", "sig"):
+            assert expected in SENSITIVE_QUERY_PARAMS, expected
+
+
+# ── Operator allowlist opt-out ──────────────────────────────────────────────
+
+
+class TestOperatorAllowlist:
+    def test_default_is_empty(self):
+        """Empty env var → strict deny-by-default."""
+        with mock.patch.dict(os.environ, {"OPENLEGION_REDACTION_URL_QUERY_ALLOW": ""}):
+            out = redact_url("https://svc/?api_key=xyz")
+            assert "xyz" not in out
+
+    def test_explicit_allowlist_preserves_value(self):
+        """Operator opts api_key out of redaction (e.g. verified non-sensitive)."""
+        with mock.patch.dict(os.environ, {"OPENLEGION_REDACTION_URL_QUERY_ALLOW": "api_key"}):
+            out = redact_url("https://svc/?api_key=notasecret")
+            assert "notasecret" in out
+
+    def test_allowlist_case_insensitive(self):
+        with mock.patch.dict(os.environ, {"OPENLEGION_REDACTION_URL_QUERY_ALLOW": "API_KEY"}):
+            out = redact_url("https://svc/?api_key=notasecret")
+            assert "notasecret" in out
+
+    def test_allowlist_does_not_affect_other_params(self):
+        """Allowing one key doesn't relax the rest."""
+        with mock.patch.dict(os.environ, {"OPENLEGION_REDACTION_URL_QUERY_ALLOW": "api_key"}):
+            out = redact_url("https://svc/?api_key=ok&password=nope")
+            assert "ok" in out
+            assert "nope" not in out
+
+
+# ── Unit tests: deep_redact ─────────────────────────────────────────────────
+
+
+class TestDeepRedact:
+    def test_nested_dict(self):
+        obj = {
+            "outer": {
+                "token": "sk-abcdefghijklmnopqrstuvwxyz1234567890",
+                "note": "safe",
+            },
+            "list": ["ok", "sk-anothersecretthatsverylonganymisalaiki00"],
+        }
+        red = deep_redact(obj)
+        assert red["outer"]["token"] == _REDACTED
+        assert red["outer"]["note"] == "safe"
+        assert red["list"][0] == "ok"
+        assert _REDACTED in red["list"][1]
+
+    def test_url_inside_dict_gets_url_redaction(self):
+        obj = {"callback": "https://app/cb?api_key=zzz"}
+        red = deep_redact(obj)
+        assert "zzz" not in red["callback"]
+        assert "https://app/cb?" in red["callback"]
+
+    def test_primitive_types_pass_through(self):
+        assert deep_redact(42) == 42
+        assert deep_redact(True) is True
+        assert deep_redact(None) is None
+        assert deep_redact(3.14) == 3.14
+
+    def test_tuple_returned_as_tuple(self):
+        assert deep_redact(("a", "sk-abcdefghijklmnopqrstuvwxyz1234567890")) == (
+            "a", _REDACTED,
+        )
+
+
+# ── Corpus gate ─────────────────────────────────────────────────────────────
+
+
+@pytest.fixture(scope="module")
+def corpus():
+    """Load the redaction corpus fixture once per test module."""
+    with CORPUS_PATH.open() as f:
+        return json.load(f)
+
+
+class TestCorpusGate:
+    def test_corpus_file_exists_and_is_nonempty(self, corpus):
+        assert isinstance(corpus, list)
+        assert len(corpus) >= 25, "Corpus thinner than expected — did someone trim?"
+
+    def test_every_redacted_token_stripped(self, corpus):
+        """Each entry names tokens that MUST disappear from the redacted output."""
+        for entry in corpus:
+            out = redact_url(entry["input"])
+            for tok in entry.get("expect_redacted", []):
+                assert tok not in out, (
+                    f"[{entry['name']}] leaked token {tok!r} — redacted output: {out!r}"
+                )
+
+    def test_every_preserved_token_survives(self, corpus):
+        """Each entry names tokens that MUST remain visible — guards against
+        over-redaction that would ruin debuggability."""
+        for entry in corpus:
+            out = redact_url(entry["input"])
+            for tok in entry.get("expect_preserved", []):
+                # Allow for trailing-slash / fragment-drop normalizations —
+                # substring match is sufficient.
+                assert tok in out, (
+                    f"[{entry['name']}] lost preserved token {tok!r} — output: {out!r}"
+                )
+
+
+# ── Backward-compat shims ───────────────────────────────────────────────────
+
+
+class TestBrowserRedactorShim:
+    """Existing call sites in ``src/browser/service.py`` use
+    :class:`CredentialRedactor`. Shim must keep passing."""
+
+    def test_redact_delegates(self):
+        from src.browser.redaction import CredentialRedactor
+        r = CredentialRedactor()
+        assert r.redact("agent-1", "key=sk-abcdefghijklmnopqrstuvwxyz1234567890") == (
+            f"key={_REDACTED}"
+        )
+
+    def test_deep_redact_delegates(self):
+        from src.browser.redaction import CredentialRedactor
+        r = CredentialRedactor()
+        out = r.deep_redact("agent-1", {"x": "sk-abcdefghijklmnopqrstuvwxyz1234567890"})
+        assert out["x"] == _REDACTED
+
+    def test_legacy_patterns_constant_still_exported(self):
+        from src.browser.redaction import _REDACT_PATTERNS as browser_patterns
+        # Same object as the shared module's — no drift possible.
+        assert browser_patterns is _REDACT_PATTERNS
+        assert browser_patterns is SECRET_PATTERNS
+
+
+class TestAgentBrowserToolShim:
+    """The agent-side ``_redact_credentials`` / ``_deep_redact`` private
+    helpers used to live in ``src/agent/builtins/browser_tool.py``. They're
+    now thin imports from the shared module; the names must still resolve."""
+
+    def test_agent_side_helpers_still_import(self):
+        from src.agent.builtins.browser_tool import (
+            _deep_redact,
+            _redact_credentials,
+        )
+        assert callable(_redact_credentials)
+        assert callable(_deep_redact)
+        assert _redact_credentials("abc") == "abc"
+        assert _deep_redact({"a": "b"}) == {"a": "b"}

--- a/tests/test_shared_redaction.py
+++ b/tests/test_shared_redaction.py
@@ -131,10 +131,36 @@ class TestRedactUrl:
         twice = redact_url(once)
         assert once == twice
 
+    @pytest.mark.parametrize("scheme", ["javascript", "data", "blob", "vbscript", "file"])
+    def test_non_web_schemes_skip_structural_parsing(self, scheme):
+        """Exotic URL schemes don't follow authority/path/query/fragment —
+        structural parsing would produce nonsense. Fall through to the
+        pattern sweep only."""
+        probe = f"{scheme}://host/not-a-real-path?api_key=visible"
+        out = redact_url(probe)
+        # The scheme is preserved (we don't parse-and-reassemble).
+        assert out.startswith(f"{scheme}://")
+        # Pattern-level sweep still runs — no embedded regex-matching
+        # secret in this test string, so nothing should change other
+        # than it being returned as-is.
+        assert out == probe
+
+    def test_api_token_variants_stripped(self):
+        """Common API-token param names beyond plain ``token`` are covered."""
+        for key in ("api_token", "apitoken", "api-token", "bearer_token"):
+            out = redact_url(f"https://svc.example/?{key}=zzz-secret-zzz")
+            assert "zzz-secret-zzz" not in out, key
+            assert _REDACTED in out
+
 
 class TestSensitiveQueryParams:
     def test_common_auth_params_present(self):
-        for expected in ("api_key", "token", "password", "secret"):
+        for expected in (
+            "api_key", "apikey", "api-key",
+            "api_token", "apitoken", "api-token",
+            "token", "bearer_token",
+            "password", "secret",
+        ):
             assert expected in SENSITIVE_QUERY_PARAMS, expected
 
     def test_oauth_params_present(self):


### PR DESCRIPTION
## Summary

Two parallel copies of the secret-pattern list (\`src/browser/redaction.py\` + \`src/agent/builtins/browser_tool.py\`) collapsed into a single canonical module. Same patterns for existing callers; new \`redact_url()\` added.

**New: URL-component-aware redaction.** Pre-Phase-1.3 we only did regex-over-whole-string, which misses:
- OAuth authorization code + state (no secret-token prefix)
- AWS SigV4 / GCS signed / Azure SAS URL param values
- Fragment-carried implicit-flow tokens (\`#access_token=...\`)
- JWTs in path segments (unsubscribe / password reset)
- Userinfo (\`user:pass@host\`)

\`redact_url()\` parses URLs, strips userinfo, drops fragments, replaces \`SENSITIVE_QUERY_PARAMS\` values with \`[REDACTED]\` (keys preserved for debuggability), redacts JWT-shaped path segments, and sweeps \`SECRET_PATTERNS\` once more across the result.

**Operator opt-out.** \`OPENLEGION_REDACTION_URL_QUERY_ALLOW\` (comma-separated) lets operators whitelist specific query-param names. Default empty = strict deny.

**Corpus test.** \`tests/fixtures/redaction_corpus.json\` — 30 real-shape URLs. Each entry asserts both *expected redacted* AND *expected preserved* tokens. Gates both under- AND over-redaction.

**Backward-compat shims.** \`src/browser/redaction.py\` keeps \`CredentialRedactor\`; body delegates. Agent-side \`_redact_credentials\` / \`_deep_redact\` re-export from shared.

## Test plan

- [x] 40 new tests (pattern coverage, URL-aware redaction, operator allowlist, deep_redact, corpus gate, shim imports)
- [x] Full non-e2e suite: 3230 pass / 21 skip / 1 pre-existing env failure
- [x] \`ruff check\` clean

Implements §4.3 of \`docs/plans/2026-04-20-browser-automation.md\`.