### PR TITLE
Phase 1.4: profile-schema migration framework

### DIFF
--- a/src/browser/profile_schema.py
+++ b/src/browser/profile_schema.py
@@ -90,6 +90,15 @@ _BACKUP_SUFFIX = ".bak"
 _TMP_SUFFIX = ".tmp"
 
 
+class ProfileMigrationBusy(Exception):
+    """Raised when a peer process holds the per-profile migration lock AND
+    there are pending migrations the target version needs.
+
+    Distinct from a generic failure so the caller can treat it as
+    transient (worth a short retry) rather than a hard error.
+    """
+
+
 # ── Public API ──────────────────────────────────────────────────────────────
 
 
@@ -127,12 +136,25 @@ def migrate_profile(profile_dir: Path | str) -> int:
     lock_path = profile / _LOCK_FILENAME
     with _try_lock(lock_path) as acquired:
         if not acquired:
+            # Another process holds the migration lock. If the on-disk
+            # version is ALREADY current, they're doing a pointless
+            # re-check — safe to proceed with the launch. If it's BELOW
+            # target, they're mid-migration and launching Camoufox now
+            # would race their writes into user_data_dir. Refuse loudly
+            # so the caller (``BrowserManager.get_or_start``) can either
+            # retry after a short wait or bubble up to the user.
             current = _read_marker(profile)
-            logger.info(
-                "Another process is migrating %s (version %d on disk); skipping",
-                profile, current,
+            if current >= PROFILE_SCHEMA_VERSION:
+                logger.info(
+                    "Profile %s already current (v%d); peer holds lock but "
+                    "no migration pending", profile, current,
+                )
+                return current
+            raise ProfileMigrationBusy(
+                f"Another process is migrating {profile} "
+                f"(on-disk v{current}, target v{PROFILE_SCHEMA_VERSION}) — "
+                f"cannot launch until they finish",
             )
-            return current
 
         current = _read_marker(profile)
         if current >= PROFILE_SCHEMA_VERSION:

--- a/src/browser/profile_schema.py
+++ b/src/browser/profile_schema.py
@@ -1,0 +1,319 @@
+"""Profile schema versioning + migration framework (Phase 1.4).
+
+Establishes a single source of truth for the state of a browser profile on
+disk so later phases (fonts in §6.2, uBlock Origin in §7.1, resolution
+randomization in §6.1) can evolve the profile format without leaving stale
+caches, mismatched prefs, or half-installed extensions behind.
+
+Design principles:
+
+* **Single marker file.** Each profile carries ``.ol_schema`` at its root
+  containing the integer version number. Missing marker = version 0
+  (pre-upgrade or fresh profile).
+* **Pre-launch migration.** Migrations run in
+  ``BrowserManager.get_or_start()`` **before** Camoufox / Playwright opens
+  the profile directory. Camoufox writes into the profile during launch,
+  so post-launch migrations would race its writes and cause corruption.
+* **Atomic per-profile lock.** ``fcntl.flock`` on a sidecar ``.ol_schema.lock``
+  file serializes concurrent migrations of the same profile. A second
+  process started during migration skips with an INFO log; it can retry
+  next startup.
+* **Crash-safe writes.** Marker writes are ``write-to-tmp`` + ``fsync`` +
+  ``os.replace``. A crash mid-migration leaves either the pre-swap ``.bak``
+  snapshot or the post-swap final state, never a half-written version.
+* **Orphan cleanup on boot.** Any ``*.tmp`` from a prior crash is deleted
+  at :func:`migrate_profile` entry so we never inherit partial writes.
+* **Cookies / localStorage / IndexedDB preserved.** Migrations only touch
+  build-time artifacts (font cache, startupCache, ephemeral prefs). Never
+  touch ``cookies.sqlite``, ``webappsstore.sqlite``, ``storage/default``
+  (IndexedDB), or ``bookmarks.sqlite``. Users' sessions and saved data
+  survive migrations.
+
+Usage:
+
+    from src.browser.profile_schema import migrate_profile
+
+    async def get_or_start(self, agent_id: str) -> CamoufoxInstance:
+        profile_dir = self.profiles_dir / agent_id
+        profile_dir.mkdir(parents=True, exist_ok=True)
+        migrate_profile(profile_dir)            # must run before Camoufox
+        browser = await AsyncNewBrowser(pw, user_data_dir=str(profile_dir), ...)
+
+Phase 1.4 ships the framework with version ``1`` as a no-op baseline. Later
+phases register migrations that advance the version and run their transforms.
+"""
+
+from __future__ import annotations
+
+import fcntl
+import os
+import shutil
+from collections.abc import Callable
+from pathlib import Path
+
+from src.shared.utils import setup_logging
+
+logger = setup_logging("browser.profile_schema")
+
+
+# ── Current schema version & migration registry ────────────────────────────
+
+
+# Bump this monotonically when adding a new migration. Never decrement.
+# Never reuse a number — migrations are applied by version key in order.
+PROFILE_SCHEMA_VERSION: int = 1
+
+
+# Callables registered here run in `migrate_profile()` when the on-disk
+# version is LESS than the key. Each callable takes the profile directory
+# Path and mutates it in place.
+#
+# Contract for a migration function:
+#   - Idempotent: running it twice on the same profile must be safe.
+#   - Never raise on expected-missing files (e.g. font cache may not exist
+#     on a freshly-created profile).
+#   - Never touch cookies.sqlite, webappsstore.sqlite, storage/default/,
+#     or bookmarks.sqlite. Preserve user sessions.
+#   - Raise on unrecoverable failure. The caller will restore from .bak.
+#
+# Phase 1.4 has no migrations yet — the framework is the deliverable.
+# Later phases append entries here.
+_MIGRATIONS: dict[int, Callable[[Path], None]] = {}
+
+
+# ── On-disk marker & lock file naming ──────────────────────────────────────
+
+
+_MARKER_FILENAME = ".ol_schema"
+_LOCK_FILENAME = ".ol_schema.lock"
+_BACKUP_SUFFIX = ".bak"
+_TMP_SUFFIX = ".tmp"
+
+
+# ── Public API ──────────────────────────────────────────────────────────────
+
+
+def migrate_profile(profile_dir: Path | str) -> int:
+    """Bring ``profile_dir`` to :data:`PROFILE_SCHEMA_VERSION`.
+
+    Returns the version the profile is at after the call. Idempotent —
+    calling on an already-current profile is a fast no-op.
+
+    Steps:
+
+    1. Clean up orphan ``*.tmp`` files (crash recovery).
+    2. Acquire non-blocking per-profile lock. If another process holds it,
+       log + return current-on-disk version (caller launches anyway; the
+       other process will finish).
+    3. Read the on-disk version. If ``>= PROFILE_SCHEMA_VERSION``, release
+       lock and return.
+    4. Snapshot the profile to ``profile_dir.bak`` (directory-level copy,
+       preserves cookies/storage/prefs).
+    5. Run each registered migration for versions
+       ``(current_version + 1)..PROFILE_SCHEMA_VERSION`` in order.
+    6. On success: write the new marker, remove the backup, release lock.
+    7. On any exception: restore from backup, re-raise. The lock is
+       released in the ``finally`` so a retry can proceed next startup.
+
+    Raises ``FileNotFoundError`` if ``profile_dir`` doesn't exist.
+    Raises any exception from a migration (after restoring backup).
+    """
+    profile = Path(profile_dir)
+    if not profile.exists():
+        raise FileNotFoundError(f"Profile dir does not exist: {profile}")
+
+    _clean_orphan_tmp(profile)
+
+    lock_path = profile / _LOCK_FILENAME
+    with _try_lock(lock_path) as acquired:
+        if not acquired:
+            current = _read_marker(profile)
+            logger.info(
+                "Another process is migrating %s (version %d on disk); skipping",
+                profile, current,
+            )
+            return current
+
+        current = _read_marker(profile)
+        if current >= PROFILE_SCHEMA_VERSION:
+            return current
+
+        pending = sorted(
+            v for v in _MIGRATIONS if current < v <= PROFILE_SCHEMA_VERSION
+        )
+
+        # Always advance the marker even when there are no transform
+        # functions between current and target (Phase 1.4 ships empty
+        # _MIGRATIONS but still needs to stamp profiles as version 1).
+        if not pending and current < PROFILE_SCHEMA_VERSION:
+            _write_marker_atomic(profile, PROFILE_SCHEMA_VERSION)
+            logger.info(
+                "Profile %s stamped from version %d to %d (no transforms needed)",
+                profile, current, PROFILE_SCHEMA_VERSION,
+            )
+            return PROFILE_SCHEMA_VERSION
+
+        backup = _snapshot_backup(profile)
+        try:
+            for version in pending:
+                logger.info(
+                    "Applying profile migration v%d → %s", version, profile,
+                )
+                _MIGRATIONS[version](profile)
+            _write_marker_atomic(profile, PROFILE_SCHEMA_VERSION)
+            logger.info(
+                "Profile %s migrated from v%d to v%d",
+                profile, current, PROFILE_SCHEMA_VERSION,
+            )
+        except Exception:
+            logger.exception(
+                "Migration failed for %s — restoring backup", profile,
+            )
+            _restore_backup(profile, backup)
+            raise
+        else:
+            # Remove the backup only after a successful write of the new
+            # marker. If we crashed between `_write_marker_atomic` and
+            # this line the backup would still be on disk; that's
+            # harmless — the next startup sees the current version and
+            # skips the migration path, and the orphan .bak is cleaned
+            # below.
+            _remove_tree(backup)
+
+        return PROFILE_SCHEMA_VERSION
+
+
+# ── Helpers ────────────────────────────────────────────────────────────────
+
+
+class _LockHandle:
+    """Context-manager wrapper around an fcntl.flock'd file.
+
+    ``__enter__`` returns ``True`` on exclusive acquisition, ``False`` if the
+    lock was already held by another process. Always releases on exit.
+    """
+
+    def __init__(self, path: Path):
+        self._path = path
+        self._fd: int | None = None
+        self._acquired: bool = False
+
+    def __enter__(self) -> bool:
+        self._fd = os.open(self._path, os.O_CREAT | os.O_RDWR, 0o600)
+        try:
+            fcntl.flock(self._fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+            self._acquired = True
+        except BlockingIOError:
+            self._acquired = False
+        return self._acquired
+
+    def __exit__(self, exc_type, exc, tb) -> None:
+        if self._fd is not None:
+            try:
+                if self._acquired:
+                    fcntl.flock(self._fd, fcntl.LOCK_UN)
+            finally:
+                os.close(self._fd)
+                self._fd = None
+
+
+def _try_lock(lock_path: Path) -> _LockHandle:
+    """Return a context manager that tries to acquire a non-blocking lock."""
+    return _LockHandle(lock_path)
+
+
+def _read_marker(profile: Path) -> int:
+    """Return the on-disk schema version, or 0 if missing / unreadable."""
+    marker = profile / _MARKER_FILENAME
+    if not marker.exists():
+        return 0
+    try:
+        raw = marker.read_text(encoding="utf-8").strip()
+        return int(raw)
+    except (OSError, ValueError):
+        logger.warning(
+            "Malformed %s at %s; treating as version 0",
+            _MARKER_FILENAME, marker,
+        )
+        return 0
+
+
+def _write_marker_atomic(profile: Path, version: int) -> None:
+    """Durably write the version marker.
+
+    Write-to-tmp + fsync + os.replace is atomic on POSIX: a reader either
+    sees the old marker or the new marker, never a half-written file.
+    """
+    marker = profile / _MARKER_FILENAME
+    tmp = profile / f"{_MARKER_FILENAME}{_TMP_SUFFIX}"
+
+    fd = os.open(tmp, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o644)
+    try:
+        os.write(fd, f"{version}\n".encode("utf-8"))
+        os.fsync(fd)
+    finally:
+        os.close(fd)
+    os.replace(tmp, marker)
+
+
+def _snapshot_backup(profile: Path) -> Path:
+    """Copy the profile to a sibling ``.bak`` dir. Returns backup path.
+
+    Removes any pre-existing backup first — a stale .bak from an
+    earlier-crashed migration is replaced by the current pre-migration
+    state, which is what we'd want to restore to.
+    """
+    backup = profile.with_name(profile.name + _BACKUP_SUFFIX)
+    if backup.exists():
+        _remove_tree(backup)
+    shutil.copytree(profile, backup, symlinks=True)
+    return backup
+
+
+def _restore_backup(profile: Path, backup: Path) -> None:
+    """Replace ``profile`` contents with ``backup``. Destroys the backup."""
+    if not backup.exists():
+        logger.error(
+            "Cannot restore: backup missing at %s (profile left as-is)", backup,
+        )
+        return
+    # Remove the (partially-migrated) profile contents, then move the
+    # backup into place. ``shutil.move`` across same-fs does a rename.
+    _remove_tree(profile)
+    shutil.move(str(backup), str(profile))
+
+
+def _clean_orphan_tmp(profile: Path) -> None:
+    """Delete any ``*.tmp`` files left by a prior crashed write.
+
+    Scoped to the profile root. We do NOT recurse — Firefox creates its
+    own ``.tmp`` files inside ``storage/`` etc. during normal operation,
+    and removing those would corrupt live state.
+    """
+    try:
+        for entry in profile.iterdir():
+            if entry.name.endswith(_TMP_SUFFIX) and entry.is_file():
+                try:
+                    entry.unlink()
+                    logger.info(
+                        "Removed orphan tmp file from prior migration: %s",
+                        entry,
+                    )
+                except OSError:
+                    logger.warning("Could not remove orphan tmp: %s", entry)
+    except OSError:
+        # Permissions or missing — don't block startup.
+        logger.debug("Could not scan %s for orphan tmp files", profile)
+
+
+def _remove_tree(path: Path) -> None:
+    """Best-effort recursive remove; logs on failure, doesn't raise."""
+    if not path.exists():
+        return
+    try:
+        if path.is_dir():
+            shutil.rmtree(path)
+        else:
+            path.unlink()
+    except OSError as e:
+        logger.warning("Could not remove %s: %s", path, e)

--- a/src/browser/service.py
+++ b/src/browser/service.py
@@ -493,8 +493,23 @@ class BrowserManager:
         # writes into the directory. Idempotent on already-current profiles;
         # on failure restores the pre-migration backup and re-raises so we
         # never launch against a half-migrated profile.
+        #
+        # Two error shapes propagate:
+        #   * ``ProfileMigrationBusy`` — a peer process holds the lock and
+        #     the on-disk version is below target. Retryable; agent can
+        #     call again in a few seconds.
+        #   * Any other exception — migration hit a real failure and the
+        #     backup has already been restored. Not safely retryable until
+        #     a human investigates.
+        from src.browser.profile_schema import ProfileMigrationBusy
         try:
             migrate_profile(Path(profile_dir))
+        except ProfileMigrationBusy:
+            logger.warning(
+                "Profile migration for '%s' busy (peer holds lock); "
+                "refusing to launch until they finish", agent_id,
+            )
+            raise
         except Exception:
             logger.exception(
                 "Profile migration failed for '%s' — aborting browser start",

--- a/src/browser/service.py
+++ b/src/browser/service.py
@@ -19,6 +19,7 @@ from pathlib import Path
 from urllib.parse import urlparse
 
 from src.browser.captcha import get_solver
+from src.browser.profile_schema import migrate_profile
 from src.browser.redaction import CredentialRedactor
 from src.browser.stealth import build_launch_options
 from src.browser.timing import (
@@ -486,6 +487,20 @@ class BrowserManager:
 
         profile_dir = str(self.profiles_dir / agent_id)
         Path(profile_dir).mkdir(parents=True, exist_ok=True)
+
+        # Bring the profile up to the current schema version BEFORE Camoufox
+        # opens it (§4.4). Post-launch migration would race Camoufox's own
+        # writes into the directory. Idempotent on already-current profiles;
+        # on failure restores the pre-migration backup and re-raises so we
+        # never launch against a half-migrated profile.
+        try:
+            migrate_profile(Path(profile_dir))
+        except Exception:
+            logger.exception(
+                "Profile migration failed for '%s' — aborting browser start",
+                agent_id,
+            )
+            raise
 
         proxy_config = self.get_proxy_config(agent_id)
         if proxy_config is not None:

--- a/tests/test_profile_schema.py
+++ b/tests/test_profile_schema.py
@@ -1,0 +1,328 @@
+"""Tests for the profile-schema migration framework (Phase 1.4).
+
+Exercises the six guarantees the :mod:`src.browser.profile_schema` module
+promises:
+
+1. First-time stamping (no marker) → profile ends up at current version.
+2. Already-current profile → no-op, cookies/state untouched.
+3. Empty migration registry between current and target → marker-only bump.
+4. Registered migration runs once in order, output preserved.
+5. Failing migration → backup restored, exception re-raised.
+6. Orphan ``*.tmp`` from a prior crash → cleaned at entry.
+
+Plus two concurrency / robustness tests:
+
+7. Concurrent migrate_profile calls — non-blocking fcntl.flock acts as
+   a mutual-exclusion gate; the late caller gets the on-disk version.
+8. Malformed ``.ol_schema`` → treated as version 0 (not a crash).
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from unittest import mock
+
+import pytest
+
+from src.browser import profile_schema
+from src.browser.profile_schema import (
+    _MARKER_FILENAME,
+    PROFILE_SCHEMA_VERSION,
+    migrate_profile,
+)
+
+# ── Fixtures ────────────────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def profile(tmp_path: Path) -> Path:
+    """Empty profile directory. Simulates a fresh agent."""
+    p = tmp_path / "profile-a"
+    p.mkdir()
+    return p
+
+
+@pytest.fixture
+def populated_profile(tmp_path: Path) -> Path:
+    """Profile dir with a representative set of files — stand-ins for
+    Firefox's cookies / storage / preferences — used to verify migrations
+    don't destroy user state."""
+    p = tmp_path / "profile-b"
+    p.mkdir()
+    (p / "cookies.sqlite").write_bytes(b"cookies-fake")
+    (p / "prefs.js").write_text('user_pref("browser.foo", true);\n')
+    storage = p / "storage" / "default"
+    storage.mkdir(parents=True)
+    (storage / "idb.sqlite").write_bytes(b"idb-fake")
+    return p
+
+
+@pytest.fixture(autouse=True)
+def _reset_migration_registry():
+    """Ensure tests don't leak registry entries across each other."""
+    before = dict(profile_schema._MIGRATIONS)
+    yield
+    profile_schema._MIGRATIONS.clear()
+    profile_schema._MIGRATIONS.update(before)
+
+
+# ── Core behavior ──────────────────────────────────────────────────────────
+
+
+class TestFirstTimeStamp:
+    def test_no_marker_creates_marker_at_current_version(self, profile):
+        result = migrate_profile(profile)
+        assert result == PROFILE_SCHEMA_VERSION
+        marker = profile / _MARKER_FILENAME
+        assert marker.exists()
+        assert int(marker.read_text().strip()) == PROFILE_SCHEMA_VERSION
+
+    def test_first_time_does_not_write_backup(self, profile):
+        migrate_profile(profile)
+        # Empty registry → marker-only bump, no snapshot/backup step.
+        backup = profile.with_name(profile.name + ".bak")
+        assert not backup.exists()
+
+
+class TestIdempotence:
+    def test_running_twice_is_noop(self, populated_profile):
+        migrate_profile(populated_profile)
+        first_marker = (populated_profile / _MARKER_FILENAME).read_text()
+        first_cookie = (populated_profile / "cookies.sqlite").read_bytes()
+
+        migrate_profile(populated_profile)
+        assert (populated_profile / _MARKER_FILENAME).read_text() == first_marker
+        assert (populated_profile / "cookies.sqlite").read_bytes() == first_cookie
+
+
+class TestMigrationRegistryExecution:
+    def test_registered_migration_runs_and_marker_advances(
+        self, populated_profile, monkeypatch,
+    ):
+        """A migration registered for the target version actually runs."""
+        ran = {"called": False}
+
+        def _mig_v1(p: Path) -> None:
+            ran["called"] = True
+            (p / "migration_artifact.txt").write_text("ran")
+
+        # Pretend the module is at version 1 and register our test migration.
+        monkeypatch.setattr(profile_schema, "PROFILE_SCHEMA_VERSION", 1)
+        profile_schema._MIGRATIONS[1] = _mig_v1
+
+        # Seed as version 0 (no marker) so _mig_v1 gets applied.
+        result = migrate_profile(populated_profile)
+        assert result == 1
+        assert ran["called"]
+        assert (populated_profile / "migration_artifact.txt").read_text() == "ran"
+        assert (populated_profile / _MARKER_FILENAME).read_text().strip() == "1"
+
+    def test_multiple_migrations_run_in_version_order(
+        self, profile, monkeypatch,
+    ):
+        order: list[int] = []
+
+        def _mig_v2(p: Path) -> None:
+            order.append(2)
+            (p / "v2").write_text("2")
+
+        def _mig_v3(p: Path) -> None:
+            order.append(3)
+            (p / "v3").write_text("3")
+
+        monkeypatch.setattr(profile_schema, "PROFILE_SCHEMA_VERSION", 3)
+        profile_schema._MIGRATIONS[3] = _mig_v3
+        profile_schema._MIGRATIONS[2] = _mig_v2
+
+        migrate_profile(profile)
+        assert order == [2, 3]
+        assert (profile / _MARKER_FILENAME).read_text().strip() == "3"
+
+
+class TestFailureRestoresBackup:
+    def test_migration_exception_restores_original_state(
+        self, populated_profile, monkeypatch,
+    ):
+        """When a migration raises, the profile state is restored from backup
+        and the exception propagates."""
+
+        def _broken(p: Path) -> None:
+            # Mutate the profile THEN raise — simulates partial work.
+            (p / "migration_artifact.txt").write_text("half-done")
+            (p / "cookies.sqlite").write_bytes(b"corrupted")
+            raise RuntimeError("boom")
+
+        monkeypatch.setattr(profile_schema, "PROFILE_SCHEMA_VERSION", 1)
+        profile_schema._MIGRATIONS[1] = _broken
+
+        with pytest.raises(RuntimeError, match="boom"):
+            migrate_profile(populated_profile)
+
+        # Cookies restored
+        assert (
+            populated_profile / "cookies.sqlite"
+        ).read_bytes() == b"cookies-fake"
+        # Partial artifact rolled back
+        assert not (populated_profile / "migration_artifact.txt").exists()
+        # Marker stays at pre-migration version (0)
+        assert not (populated_profile / _MARKER_FILENAME).exists()
+
+    def test_backup_removed_after_successful_migration(
+        self, profile, monkeypatch,
+    ):
+        def _mig(p: Path) -> None:
+            (p / "art").write_text("x")
+
+        monkeypatch.setattr(profile_schema, "PROFILE_SCHEMA_VERSION", 1)
+        profile_schema._MIGRATIONS[1] = _mig
+
+        migrate_profile(profile)
+        backup = profile.with_name(profile.name + ".bak")
+        assert not backup.exists()
+
+
+# ── Crash-recovery behaviors ────────────────────────────────────────────────
+
+
+class TestOrphanTmpCleanup:
+    def test_orphan_tmp_file_removed(self, profile):
+        orphan = profile / f"{_MARKER_FILENAME}.tmp"
+        orphan.write_text("99")
+        migrate_profile(profile)
+        assert not orphan.exists()
+
+    def test_orphan_tmp_cleanup_does_not_recurse(self, profile):
+        """Firefox writes .tmp files inside subdirs as normal operation —
+        we must not touch those."""
+        nested = profile / "storage" / "default"
+        nested.mkdir(parents=True)
+        live_tmp = nested / "live.tmp"
+        live_tmp.write_text("live firefox state")
+        migrate_profile(profile)
+        assert live_tmp.exists()
+        assert live_tmp.read_text() == "live firefox state"
+
+
+class TestMalformedMarker:
+    def test_non_integer_marker_treated_as_version_0(
+        self, populated_profile, monkeypatch,
+    ):
+        (populated_profile / _MARKER_FILENAME).write_text("not-a-number")
+
+        called = {"ran": False}
+
+        def _mig(p: Path) -> None:
+            called["ran"] = True
+
+        monkeypatch.setattr(profile_schema, "PROFILE_SCHEMA_VERSION", 1)
+        profile_schema._MIGRATIONS[1] = _mig
+
+        migrate_profile(populated_profile)
+        assert called["ran"]  # treated as pre-migration
+
+
+# ── Concurrency ────────────────────────────────────────────────────────────
+
+
+class TestConcurrencyLock:
+    def test_second_caller_skips_when_lock_held(
+        self, profile, monkeypatch,
+    ):
+        """While one process holds the flock, a concurrent migrate_profile
+        returns the on-disk version without re-running migrations."""
+        from src.browser.profile_schema import _LOCK_FILENAME
+
+        run_count = {"n": 0}
+
+        def _mig(p: Path) -> None:
+            run_count["n"] += 1
+
+        monkeypatch.setattr(profile_schema, "PROFILE_SCHEMA_VERSION", 1)
+        profile_schema._MIGRATIONS[1] = _mig
+
+        # Simulate another process holding the lock by opening the file
+        # and taking an exclusive flock outside of the function's try.
+        import fcntl
+        lock_path = profile / _LOCK_FILENAME
+        fd = os.open(lock_path, os.O_CREAT | os.O_RDWR, 0o600)
+        fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+        try:
+            result = migrate_profile(profile)
+            # Migration skipped; read-only path returns on-disk version (0).
+            assert run_count["n"] == 0
+            assert result == 0
+        finally:
+            fcntl.flock(fd, fcntl.LOCK_UN)
+            os.close(fd)
+
+
+# ── Integration w/ service.py ──────────────────────────────────────────────
+
+
+class TestServiceIntegration:
+    def test_service_imports_migrate_profile(self):
+        """Regression guard: service.py binds :func:`migrate_profile` at the
+        top of the module so it's called pre-launch in ``get_or_start``.
+
+        Kept as a lightweight symbol-presence check rather than a full
+        lifecycle test — Camoufox isn't available in the unit-test env
+        and mocking `AsyncNewBrowser` through a dynamic import is fragile.
+        """
+        import src.browser.service as svc
+        assert hasattr(svc, "migrate_profile")
+        # Must be the real function, not something shadowed mid-refactor.
+        assert svc.migrate_profile is migrate_profile
+
+    def test_service_calls_migrate_before_launch(self):
+        """Regression guard via source inspection: the call to
+        ``migrate_profile`` appears in service.py above the first
+        ``AsyncNewBrowser`` call inside the starter, so any future
+        refactor that reorders them fails this test."""
+        import inspect
+
+        import src.browser.service as svc
+
+        source = inspect.getsource(svc)
+        # Find positions of both anchors.
+        migrate_pos = source.find("migrate_profile(Path(profile_dir))")
+        launch_pos = source.find("await AsyncNewBrowser(")
+        assert migrate_pos != -1, "migrate_profile call disappeared"
+        assert launch_pos != -1, "AsyncNewBrowser call disappeared"
+        assert migrate_pos < launch_pos, (
+            "migrate_profile must be called before AsyncNewBrowser — "
+            "Camoufox writes into the profile directory during launch and "
+            "migrations must complete first."
+        )
+
+
+# ── Refuses missing profile ────────────────────────────────────────────────
+
+
+class TestMissingProfile:
+    def test_missing_dir_raises(self, tmp_path):
+        with pytest.raises(FileNotFoundError):
+            migrate_profile(tmp_path / "does-not-exist")
+
+
+# ── Marker atomicity ───────────────────────────────────────────────────────
+
+
+class TestMarkerAtomicWrite:
+    def test_write_uses_temp_and_replace(self, profile, monkeypatch):
+        """Regression guard: marker writes must go through .tmp + os.replace
+        so a crash never leaves a half-written marker."""
+        observed = {"used_tmp": False, "used_replace": False}
+        real_replace = os.replace
+
+        def spy_replace(src, dst):
+            if str(src).endswith(".tmp") and str(dst).endswith(_MARKER_FILENAME):
+                observed["used_replace"] = True
+            return real_replace(src, dst)
+
+        with mock.patch("src.browser.profile_schema.os.replace", spy_replace):
+            migrate_profile(profile)
+
+        # Under normal flow there's no persistent .tmp after the replace;
+        # the spy above already confirms the tmp→final replace happened.
+        assert observed["used_replace"]

--- a/tests/test_profile_schema.py
+++ b/tests/test_profile_schema.py
@@ -226,12 +226,21 @@ class TestMalformedMarker:
 
 
 class TestConcurrencyLock:
-    def test_second_caller_skips_when_lock_held(
+    def test_lock_held_with_pending_migration_raises_busy(
         self, profile, monkeypatch,
     ):
-        """While one process holds the flock, a concurrent migrate_profile
-        returns the on-disk version without re-running migrations."""
-        from src.browser.profile_schema import _LOCK_FILENAME
+        """A peer process mid-migration holds the flock AND the on-disk
+        version is below target. Continuing to launch Camoufox now would
+        race the peer's writes into user_data_dir. The caller must get a
+        distinct, retryable error — ProfileMigrationBusy — not a silent
+        skip (silent skip regresses the whole point of the pre-launch
+        migration hook)."""
+        import fcntl
+
+        from src.browser.profile_schema import (
+            _LOCK_FILENAME,
+            ProfileMigrationBusy,
+        )
 
         run_count = {"n": 0}
 
@@ -243,15 +252,38 @@ class TestConcurrencyLock:
 
         # Simulate another process holding the lock by opening the file
         # and taking an exclusive flock outside of the function's try.
+        lock_path = profile / _LOCK_FILENAME
+        fd = os.open(lock_path, os.O_CREAT | os.O_RDWR, 0o600)
+        fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+        try:
+            with pytest.raises(ProfileMigrationBusy):
+                migrate_profile(profile)
+            assert run_count["n"] == 0
+        finally:
+            fcntl.flock(fd, fcntl.LOCK_UN)
+            os.close(fd)
+
+    def test_lock_held_but_already_current_allows_launch(
+        self, profile, monkeypatch,
+    ):
+        """Conversely: if the on-disk version is ALREADY target, the peer
+        is doing a pointless re-check. Don't raise — no migration is
+        pending, safe to launch against the profile."""
         import fcntl
+
+        from src.browser.profile_schema import _LOCK_FILENAME
+
+        # Stamp the profile at version 1 first (no peer holding the lock).
+        monkeypatch.setattr(profile_schema, "PROFILE_SCHEMA_VERSION", 1)
+        migrate_profile(profile)
+
+        # Now simulate a peer holding the lock and call again.
         lock_path = profile / _LOCK_FILENAME
         fd = os.open(lock_path, os.O_CREAT | os.O_RDWR, 0o600)
         fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
         try:
             result = migrate_profile(profile)
-            # Migration skipped; read-only path returns on-disk version (0).
-            assert run_count["n"] == 0
-            assert result == 0
+            assert result == 1  # Already current; no raise, no work.
         finally:
             fcntl.flock(fd, fcntl.LOCK_UN)
             os.close(fd)


### PR DESCRIPTION
## Summary

Versioned migration framework for browser profiles so later phases (fonts §6.2, resolution §6.1, uBlock §7.1) can evolve the profile format without leaving stale caches, mismatched prefs, or half-installed extensions behind.

**Contract** (\`src/browser/profile_schema.py\`):
- \`PROFILE_SCHEMA_VERSION: int\`, monotonically increasing.
- \`.ol_schema\` marker file at profile root. Missing = version 0.
- \`_MIGRATIONS: dict[int, Callable]\` — each entry runs when on-disk version is below its key. Idempotent; must not touch cookies.sqlite / webappsstore / storage/default / bookmarks.
- \`migrate_profile(dir)\` — idempotent entry point:
  1. Clean orphan \`*.tmp\` (root only; doesn't recurse into Firefox's storage)
  2. Acquire non-blocking per-profile \`fcntl.flock\` (\`.ol_schema.lock\`)
  3. Compare on-disk vs target; noop when current
  4. Snapshot the profile to \`profile.bak/\`
  5. Run pending migrations in order
  6. Atomic marker write (\`.tmp + fsync + os.replace\`), then remove backup
  7. On any failure: restore backup, re-raise

**Service integration.** \`BrowserManager.get_or_start()\` calls \`migrate_profile()\` AFTER \`mkdir\` but BEFORE \`AsyncNewBrowser()\`. A regression test source-inspects \`service.py\` so future refactors can't silently reorder.

Phase 1.4 ships with \`PROFILE_SCHEMA_VERSION=1\` and empty \`_MIGRATIONS\` — framework only. Later phases append entries.

## Test plan

- [x] 15 new tests (first-time stamp, idempotence, registry execution order, failure restoration, orphan \`.tmp\` cleanup, Firefox-state non-recursion, malformed marker → v0, concurrent-migration lock, atomic write, missing-dir error, service integration source guards)
- [x] Full non-e2e suite: 3205 pass / 21 skip / 1 pre-existing env failure
- [x] \`ruff check\` clean

Implements §4.4 of \`docs/plans/2026-04-20-browser-automation.md\`.