### PR TITLE
Phase 2.1/2.2: live browser metrics + dashboard card

### DIFF
--- a/src/browser/server.py
+++ b/src/browser/server.py
@@ -71,6 +71,22 @@ def create_browser_app(manager: BrowserManager, lifespan=None) -> FastAPI:
         _verify_auth(request)
         return await manager.get_service_status()
 
+    @app.get("/browser/metrics")
+    async def service_metrics(request: Request, since: int = 0):
+        """Return per-agent metric payloads buffered since ``since``.
+
+        Polled by the mesh host every ~60s to forward aggregate browser
+        metrics into the dashboard EventBus (§5.1/§5.2). The mesh tracks
+        the high-water ``current_seq`` across calls and only replays new
+        payloads; ``boot_id`` lets it detect a service restart and reset.
+        """
+        _verify_auth(request)
+        try:
+            since_seq = max(0, int(since))
+        except (TypeError, ValueError):
+            since_seq = 0
+        return manager.get_recent_metrics(since_seq=since_seq)
+
     @app.post("/browser/keepalive")
     async def keepalive(request: Request):
         """Touch all running browser instances to reset their idle timers.

--- a/src/browser/service.py
+++ b/src/browser/service.py
@@ -260,6 +260,23 @@ _JS_A11Y_TREE = r"""(rootEl) => {
 }"""
 
 
+def _is_empty_payload(payload: dict) -> bool:
+    """True when a drain produced neither activity nor rolling state.
+
+    Used by :meth:`BrowserManager._emit_metrics` to filter out idle-
+    agent payloads so the history buffer doesn't flood with no-ops.
+    A payload with any click/snapshot/nav count, OR any rolling-window
+    data, is kept.
+    """
+    return not any((
+        payload.get("click_success"),
+        payload.get("click_fail"),
+        payload.get("nav_timeout"),
+        payload.get("snapshot_count"),
+        payload.get("click_window_size"),
+    ))
+
+
 def _extract_text_from_a11y(tree: dict | None, max_chars: int = 5000) -> str:
     """Extract readable text from an accessibility snapshot tree.
 
@@ -527,6 +544,10 @@ class BrowserManager:
         the optional ``metrics_sink`` callback (for tests / in-process
         wiring). Counters always reset, whether or not a sink is attached,
         so a long-idle service doesn't grow memory.
+
+        Per-instance drain failures are caught — a single agent with a
+        corrupt counter must not abort the emit loop and starve the other
+        agents' data.
         """
         if not self._instances:
             return
@@ -534,7 +555,20 @@ class BrowserManager:
         # Take a consistent view of the instance list; drain_metrics()
         # is cheap and doesn't require the page lock, so we don't serialize.
         for inst in list(self._instances.values()):
-            payload = inst.drain_metrics()
+            try:
+                payload = inst.drain_metrics()
+            except Exception as e:
+                logger.warning(
+                    "drain_metrics failed for '%s': %s", inst.agent_id, e,
+                )
+                continue
+            # Skip payloads with zero activity AND an empty rolling window —
+            # idle agents should not flood the history buffer (meshes that
+            # were briefly offline will otherwise replay dozens of no-op
+            # entries on reconnect, evicting live signal from the dashboard
+            # ring buffer).
+            if _is_empty_payload(payload):
+                continue
             self._metrics_seq += 1
             payload["seq"] = self._metrics_seq
             payload["ts"] = now
@@ -827,15 +861,18 @@ class BrowserManager:
         # still-live instances; post-pop is the final accounting chance.
         # Always write to the history buffer (even without a sink) so the
         # mesh poller sees the last minute of activity for a freshly-stopped
-        # agent on its next tick.
+        # agent on its next tick. Empty payloads are skipped — no point
+        # flooding the history with no-ops for agents that never did
+        # anything.
         try:
             payload = inst.drain_metrics()
-            self._metrics_seq += 1
-            payload["seq"] = self._metrics_seq
-            payload["ts"] = time.time()
-            self._metrics_history.append(payload)
-            if self._metrics_sink is not None:
-                self._metrics_sink(payload)
+            if not _is_empty_payload(payload):
+                self._metrics_seq += 1
+                payload["seq"] = self._metrics_seq
+                payload["ts"] = time.time()
+                self._metrics_history.append(payload)
+                if self._metrics_sink is not None:
+                    self._metrics_sink(payload)
         except Exception as e:
             logger.warning(
                 "Final metrics drain failed for '%s': %s", agent_id, e,

--- a/src/browser/service.py
+++ b/src/browser/service.py
@@ -17,6 +17,7 @@ import subprocess
 import time
 import uuid
 import weakref
+from collections import deque
 from pathlib import Path
 from urllib.parse import urlparse
 
@@ -327,15 +328,21 @@ class CamoufoxInstance:
         # Register the initial page so refs captured on it resolve correctly.
         self._register_page(page)
 
-        # Per-agent metrics (§4.6). Reset to zero after each emit cycle so
-        # dashboards see per-minute values, not monotonic counters. Snapshot
-        # byte sizes accumulate as a list (p50/p95 computed at emit time)
-        # rather than a rolling histogram — size samples are small (~200 per
-        # minute per agent at most) and simpler wins.
+        # Per-agent metrics (§4.6). Per-minute counters reset at each emit
+        # cycle so dashboards see rate-of-change, not monotonic totals.
+        # Snapshot byte sizes accumulate as a list (p50/p95 at emit time);
+        # size samples are small (~200/min/agent at most) and simpler wins.
         self.m_click_success: int = 0
         self.m_click_fail: int = 0
         self.m_nav_timeout: int = 0
         self.m_snapshot_bytes: list[int] = []
+        # §5.2 rolling click-success-rate: deque of booleans for the last
+        # 100 click outcomes. Unlike the per-minute counters above, this
+        # window is NOT reset on drain — it's a user-facing live gauge
+        # exposed via /browser/{agent}/status and in the per-minute metric
+        # payload, giving operators an "is the browser currently healthy"
+        # signal that doesn't flap on low-traffic minutes.
+        self.click_window: deque[bool] = deque(maxlen=100)
 
     def _register_page(self, page) -> str:
         """Assign a stable UUID to a Page if not already registered.
@@ -396,11 +403,26 @@ class CamoufoxInstance:
     def touch(self):
         self.last_activity = time.time()
 
-    def drain_metrics(self) -> dict:
-        """Snapshot counters and reset to zero.
+    def rolling_click_success_rate(self) -> float | None:
+        """Fraction of the last 100 clicks that succeeded, or ``None``.
 
-        Called by :meth:`BrowserManager._emit_metrics` every minute. Returns
-        an aggregate dict; the live instance fields reset to zero.
+        Returns ``None`` when no clicks have been recorded yet — callers
+        should render this as "—" rather than "0%", which would misleadingly
+        imply catastrophic failure on a freshly-booted agent.
+        """
+        if not self.click_window:
+            return None
+        successes = sum(1 for ok in self.click_window if ok)
+        return successes / len(self.click_window)
+
+    def drain_metrics(self) -> dict:
+        """Snapshot counters and reset the per-minute ones to zero.
+
+        Called by :meth:`BrowserManager._emit_metrics` every minute. The
+        rolling 100-click window is NOT reset — it continues to track the
+        most recent 100 clicks across emit cycles. Emits the rolling rate
+        alongside per-minute counters so the dashboard can show both
+        "activity in the last minute" and "health over recent work."
         """
         snaps = self.m_snapshot_bytes
         snap_count = len(snaps)
@@ -420,8 +442,10 @@ class CamoufoxInstance:
             "snapshot_count": snap_count,
             "snapshot_bytes_p50": p50,
             "snapshot_bytes_p95": p95,
+            "click_window_size": len(self.click_window),
+            "click_success_rate_100": self.rolling_click_success_rate(),
         }
-        # Reset for next interval.
+        # Reset the per-minute counters; the rolling window persists.
         self.m_click_success = 0
         self.m_click_fail = 0
         self.m_nav_timeout = 0
@@ -468,6 +492,13 @@ class BrowserManager:
         self.boot_id: str = str(uuid.uuid4())
         self._captcha_solver = get_solver()
         self._metrics_sink = metrics_sink
+        # Per-agent rolling buffer of recent emit payloads (§5.1/§5.2) used by
+        # the mesh's periodic poll to forward metrics to the dashboard
+        # EventBus. Kept as a monotonic sequence so repeated polls can
+        # request only what they haven't seen. Bounded so a long-lived
+        # service with many agents doesn't grow without bound.
+        self._metrics_history: deque[dict] = deque(maxlen=1024)
+        self._metrics_seq: int = 0
 
     async def start_cleanup_loop(self):
         """Start background task that cleans up idle browsers."""
@@ -488,19 +519,26 @@ class BrowserManager:
                 logger.warning("Metrics emit error: %s", e)
 
     async def _emit_metrics(self):
-        """Drain per-agent counters and hand them to the metrics sink.
+        """Drain per-agent counters and fan them out.
 
         Runs on the same 60s tick as idle cleanup (per §2.7: per-call
-        events are forbidden; aggregates only). When no sink is wired
-        (tests, or production pre-dashboard-integration), counters still
-        reset so memory doesn't grow unboundedly.
+        events are forbidden; aggregates only). Writes each payload to the
+        in-memory history buffer so the mesh can poll it, then forwards to
+        the optional ``metrics_sink`` callback (for tests / in-process
+        wiring). Counters always reset, whether or not a sink is attached,
+        so a long-idle service doesn't grow memory.
         """
         if not self._instances:
             return
+        now = time.time()
         # Take a consistent view of the instance list; drain_metrics()
         # is cheap and doesn't require the page lock, so we don't serialize.
         for inst in list(self._instances.values()):
             payload = inst.drain_metrics()
+            self._metrics_seq += 1
+            payload["seq"] = self._metrics_seq
+            payload["ts"] = now
+            self._metrics_history.append(payload)
             if self._metrics_sink is None:
                 continue
             try:
@@ -509,6 +547,22 @@ class BrowserManager:
                 logger.warning(
                     "Metrics sink raised for '%s': %s", inst.agent_id, e,
                 )
+
+    def get_recent_metrics(self, since_seq: int = 0) -> dict:
+        """Return buffered metric payloads with ``seq > since_seq``.
+
+        Shape: ``{"current_seq": N, "metrics": [...]}``. The poller passes
+        back ``current_seq`` as ``since_seq`` on the next call to get only
+        new payloads. On service restart the seq counter resets to 0 — the
+        poller detects this via the ``boot_id`` on ``/browser/status`` and
+        resets its high-water mark.
+        """
+        metrics = [p for p in self._metrics_history if p.get("seq", 0) > since_seq]
+        return {
+            "current_seq": self._metrics_seq,
+            "boot_id": self.boot_id,
+            "metrics": metrics,
+        }
 
     async def _cleanup_idle(self):
         now = time.time()
@@ -771,14 +825,21 @@ class BrowserManager:
         # minute-tick are silently lost when idle cleanup or explicit
         # stop fires. The periodic _emit_metrics hook only sees
         # still-live instances; post-pop is the final accounting chance.
-        if self._metrics_sink is not None:
-            try:
-                payload = inst.drain_metrics()
+        # Always write to the history buffer (even without a sink) so the
+        # mesh poller sees the last minute of activity for a freshly-stopped
+        # agent on its next tick.
+        try:
+            payload = inst.drain_metrics()
+            self._metrics_seq += 1
+            payload["seq"] = self._metrics_seq
+            payload["ts"] = time.time()
+            self._metrics_history.append(payload)
+            if self._metrics_sink is not None:
                 self._metrics_sink(payload)
-            except Exception as e:
-                logger.warning(
-                    "Final metrics drain failed for '%s': %s", agent_id, e,
-                )
+        except Exception as e:
+            logger.warning(
+                "Final metrics drain failed for '%s': %s", agent_id, e,
+            )
         if self._user_focused_agent == agent_id:
             self._user_focused_agent = None
         jitter = getattr(inst, '_jitter_task', None)
@@ -821,7 +882,13 @@ class BrowserManager:
         return self._proxy_configs.get(agent_id)
 
     async def get_status(self, agent_id: str) -> dict:
-        """Get status for a specific agent's browser."""
+        """Get status for a specific agent's browser.
+
+        Includes the rolling 100-click success rate (§5.2) as a live gauge —
+        distinct from the per-minute counters, which only flow via EventBus.
+        Operators polling /status see the current health signal without
+        waiting for the next emit tick.
+        """
         async with self._lock:
             inst = self._instances.get(agent_id)
             if not inst:
@@ -830,6 +897,8 @@ class BrowserManager:
                 "running": True,
                 "idle_seconds": int(time.time() - inst.last_activity),
                 "url": inst.page.url if inst.page else "",
+                "click_window_size": len(inst.click_window),
+                "click_success_rate_100": inst.rolling_click_success_rate(),
             }
 
     async def get_service_status(self) -> dict:
@@ -1985,6 +2054,7 @@ class BrowserManager:
                                 pass
 
                 inst.m_click_success += 1
+                inst.click_window.append(True)
                 result = {"success": True, "data": {"clicked": ref or selector}}
                 if snapshot_after:
                     snap = await self._snapshot_impl(inst, agent_id)
@@ -1992,6 +2062,7 @@ class BrowserManager:
                 return result
             except Exception as e:
                 inst.m_click_fail += 1
+                inst.click_window.append(False)
                 return {"success": False, "error": str(e)}
 
     async def hover(

--- a/src/browser/service.py
+++ b/src/browser/service.py
@@ -261,19 +261,19 @@ _JS_A11Y_TREE = r"""(rootEl) => {
 
 
 def _is_empty_payload(payload: dict) -> bool:
-    """True when a drain produced neither activity nor rolling state.
+    """True when a drain produced no activity *in this interval*.
 
     Used by :meth:`BrowserManager._emit_metrics` to filter out idle-
     agent payloads so the history buffer doesn't flood with no-ops.
-    A payload with any click/snapshot/nav count, OR any rolling-window
-    data, is kept.
+    Only per-minute counters count here — the rolling click window
+    persists across drains and would permanently bypass the filter if
+    included (any agent that ever clicked would be "non-idle" forever).
     """
     return not any((
         payload.get("click_success"),
         payload.get("click_fail"),
         payload.get("nav_timeout"),
         payload.get("snapshot_count"),
-        payload.get("click_window_size"),
     ))
 
 
@@ -552,8 +552,15 @@ class BrowserManager:
         if not self._instances:
             return
         now = time.time()
-        # Take a consistent view of the instance list; drain_metrics()
-        # is cheap and doesn't require the page lock, so we don't serialize.
+        # Take a consistent view of the instance list; ``drain_metrics()``
+        # is a fully synchronous read-then-reset so no ``await`` boundary
+        # opens between the counter read and its zeroing. Under asyncio's
+        # single-threaded event loop, an in-flight hot-path task that
+        # holds ``inst.lock`` cannot run between those two statements —
+        # its coroutine is suspended elsewhere. This is WHY we don't
+        # need ``inst.lock`` here. If ``drain_metrics`` ever grows an
+        # ``await``, that invariant breaks and this must take the lock
+        # or swap counter objects atomically.
         for inst in list(self._instances.values()):
             try:
                 payload = inst.drain_metrics()

--- a/src/dashboard/static/js/app.js
+++ b/src/dashboard/static/js/app.js
@@ -533,7 +533,7 @@ function dashboard() {
         // Backward compat for old URLs
         const _tabAliases = { schedules: 'automation', connections: 'integrations', uploads: 'storage' };
         const resolved = _tabAliases[sub] || sub;
-        if (resolved && ['activity', 'costs', 'automation', 'integrations', 'apikeys', 'wallet', 'network', 'storage', 'operator', 'settings'].includes(resolved)) {
+        if (resolved && ['activity', 'costs', 'automation', 'integrations', 'apikeys', 'wallet', 'network', 'storage', 'operator', 'browser', 'settings'].includes(resolved)) {
           route.systemTab = resolved;
           if (resolved === 'activity') {
             const view = clean.split('/')[2];

--- a/src/dashboard/static/js/app.js
+++ b/src/dashboard/static/js/app.js
@@ -5787,8 +5787,21 @@ function dashboard() {
     },
 
     // ── Browser metrics card helpers (Phase 2 §5.1/§5.2) ───────────────
+    _BROWSER_METRICS_EVICT_MS: 30 * 60 * 1000,  // 30 minutes
+
     browserMetricsList() {
-      return Object.entries(this.browserMetrics)
+      // Evict agents that haven't reported in 30+ minutes so stopped /
+      // renamed / deleted agents eventually fall off the card. Without
+      // this, ghost rows accumulate forever.
+      const cutoff = Date.now() - this._BROWSER_METRICS_EVICT_MS;
+      const fresh = {};
+      for (const [agent, m] of Object.entries(this.browserMetrics)) {
+        if ((m.receivedAt || 0) >= cutoff) fresh[agent] = m;
+      }
+      if (Object.keys(fresh).length !== Object.keys(this.browserMetrics).length) {
+        this.browserMetrics = fresh;
+      }
+      return Object.entries(fresh)
         .map(([agent, m]) => ({ agent, ...m }))
         .sort((a, b) => a.agent.localeCompare(b.agent));
     },

--- a/src/dashboard/static/js/app.js
+++ b/src/dashboard/static/js/app.js
@@ -188,6 +188,12 @@ function dashboard() {
     _browserSettingsDebounce: null,
     _browserDelayDebounce: null,
 
+    // Live per-agent browser metrics (Phase 2 §5.1/§5.2) — keyed by agent_id.
+    // Populated from `browser_metrics` WS events; each entry is the payload
+    // emitted by BrowserManager._emit_metrics plus a receivedAt wall-clock
+    // stamp the dashboard uses to flag stale rows.
+    browserMetrics: {},
+
     captchaSolverProvider: '',
     captchaSolverKeyMasked: '',
     captchaSolverSaving: false,
@@ -1434,6 +1440,16 @@ function dashboard() {
       // Clear credit exhausted state on successful LLM call
       if (evt.type === 'llm_call' && this.creditExhausted) {
         this.creditExhausted = false;
+      }
+
+      // Per-agent browser metrics (Phase 2 §5.1/§5.2). Payload shape comes
+      // from BrowserManager._emit_metrics — we just index it by agent_id
+      // and stamp receipt time so stale rows can fade.
+      if (evt.type === 'browser_metrics' && evt.agent && evt.data) {
+        this.browserMetrics = {
+          ...this.browserMetrics,
+          [evt.agent]: { ...evt.data, receivedAt: Date.now() },
+        };
       }
 
       // Highlight blackboard writes + update comms badge
@@ -5707,6 +5723,7 @@ function dashboard() {
         lane_complete: 'text-yellow-300',
         cron_trigger: 'text-pink-400',
         llm_stream: 'text-purple-300',
+        browser_metrics: 'text-sky-400',
       };
       return map[type] || 'text-gray-400';
     },
@@ -5737,6 +5754,7 @@ function dashboard() {
         lane_complete: 'bg-yellow-300',
         cron_trigger: 'bg-pink-400',
         llm_stream: 'bg-purple-300',
+        browser_metrics: 'bg-sky-400',
       };
       return map[type] || 'bg-gray-400';
     },
@@ -5766,6 +5784,41 @@ function dashboard() {
         minute: '2-digit',
         second: '2-digit',
       });
+    },
+
+    // ── Browser metrics card helpers (Phase 2 §5.1/§5.2) ───────────────
+    browserMetricsList() {
+      return Object.entries(this.browserMetrics)
+        .map(([agent, m]) => ({ agent, ...m }))
+        .sort((a, b) => a.agent.localeCompare(b.agent));
+    },
+    fmtClickRate(rate) {
+      if (rate == null) return '—';
+      return (rate * 100).toFixed(0) + '%';
+    },
+    clickRateColor(rate) {
+      if (rate == null) return 'text-gray-500';
+      if (rate >= 0.9) return 'text-green-400';
+      if (rate >= 0.7) return 'text-yellow-400';
+      return 'text-red-400';
+    },
+    fmtBytes(n) {
+      if (n == null || !Number.isFinite(n)) return '—';
+      if (n < 1024) return n + 'B';
+      if (n < 1024 * 1024) return (n / 1024).toFixed(1) + 'KB';
+      return (n / (1024 * 1024)).toFixed(1) + 'MB';
+    },
+    browserMetricsAge(receivedAt) {
+      if (!receivedAt) return '';
+      const secs = Math.max(0, Math.round((Date.now() - receivedAt) / 1000));
+      if (secs < 60) return secs + 's ago';
+      const mins = Math.round(secs / 60);
+      return mins + 'm ago';
+    },
+    browserMetricsStale(receivedAt) {
+      // Emit cadence is 60s, so a payload older than ~3 minutes means the
+      // browser stopped or the poller broke.
+      return receivedAt && Date.now() - receivedAt > 3 * 60 * 1000;
     },
 
     eventDetail(evt) {

--- a/src/dashboard/templates/index.html
+++ b/src/dashboard/templates/index.html
@@ -4705,6 +4705,62 @@
         <!-- ═══ BROWSER SUB-TAB ═══ -->
         <div x-show="systemTab === 'browser'" class="space-y-4">
 
+          <!-- ── Live Browser Metrics (Phase 2 §5.1/§5.2) ── -->
+          <div class="bg-gray-900 border border-gray-800 rounded-lg p-5">
+            <div class="flex items-center justify-between mb-1">
+              <div class="flex items-center gap-2">
+                <svg class="w-4 h-4 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 3v18h18M7 17V9m4 8V5m4 12v-6m4 6v-9"/></svg>
+                <h3 class="text-sm font-medium text-gray-200">Live Browser Health</h3>
+              </div>
+              <span class="text-[10px] text-gray-600">updates every 60s</span>
+            </div>
+            <p class="text-[10px] text-gray-500 mb-4 leading-relaxed">
+              Per-agent browser behaviour from the shared Camoufox service. Click success rate is rolling over the last 100 clicks; snapshot size and timeout counts cover the most recent minute. A falling click rate or climbing timeouts is usually the first sign of a stealth regression on a target site.
+            </p>
+            <template x-if="browserMetricsList().length === 0">
+              <div class="text-xs text-gray-600 italic py-2">
+                No browser activity yet. Metrics appear here once an agent opens a page.
+              </div>
+            </template>
+            <template x-if="browserMetricsList().length > 0">
+              <div class="overflow-x-auto">
+                <table class="w-full text-xs">
+                  <thead>
+                    <tr class="text-[10px] uppercase tracking-wide text-gray-500 border-b border-gray-800">
+                      <th class="text-left font-medium pb-2 pr-4">Agent</th>
+                      <th class="text-right font-medium pb-2 pr-4">Click rate (100)</th>
+                      <th class="text-right font-medium pb-2 pr-4">Clicks / min</th>
+                      <th class="text-right font-medium pb-2 pr-4">Snap p50</th>
+                      <th class="text-right font-medium pb-2 pr-4">Snap p95</th>
+                      <th class="text-right font-medium pb-2 pr-4">Nav timeouts</th>
+                      <th class="text-right font-medium pb-2">Last update</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    <template x-for="m in browserMetricsList()" :key="m.agent">
+                      <tr class="border-b border-gray-800/40"
+                        :class="browserMetricsStale(m.receivedAt) ? 'opacity-50' : ''">
+                        <td class="py-2 pr-4 text-gray-200 font-mono truncate max-w-[12rem]" x-text="m.agent"></td>
+                        <td class="py-2 pr-4 text-right font-mono"
+                          :class="clickRateColor(m.click_success_rate_100)"
+                          x-text="fmtClickRate(m.click_success_rate_100)"></td>
+                        <td class="py-2 pr-4 text-right font-mono text-gray-300">
+                          <span x-text="(m.click_success || 0) + '/' + ((m.click_success || 0) + (m.click_fail || 0))"></span>
+                        </td>
+                        <td class="py-2 pr-4 text-right font-mono text-gray-300" x-text="fmtBytes(m.snapshot_bytes_p50)"></td>
+                        <td class="py-2 pr-4 text-right font-mono text-gray-300" x-text="fmtBytes(m.snapshot_bytes_p95)"></td>
+                        <td class="py-2 pr-4 text-right font-mono"
+                          :class="(m.nav_timeout || 0) > 0 ? 'text-amber-400' : 'text-gray-500'"
+                          x-text="m.nav_timeout || 0"></td>
+                        <td class="py-2 text-right text-gray-500" x-text="browserMetricsAge(m.receivedAt)"></td>
+                      </tr>
+                    </template>
+                  </tbody>
+                </table>
+              </div>
+            </template>
+          </div>
+
           <!-- ── Interaction Speed ── -->
           <div class="bg-gray-900 border border-gray-800 rounded-lg p-5">
             <div class="flex items-center gap-2 mb-4">

--- a/src/host/server.py
+++ b/src/host/server.py
@@ -2680,6 +2680,70 @@ def create_mesh_app(
         """Schedule initial browser proxy push as a background task (non-blocking)."""
         asyncio.create_task(_deferred_push_browser_proxies())
 
+    # § Browser metrics poll loop. The browser service container can't push
+    # to the mesh's in-process EventBus, so the mesh pulls. Runs on a 60s
+    # cadence — matching BrowserManager._emit_metrics — and fans each new
+    # per-agent aggregate out as a ``browser_metrics`` event. High-water
+    # seq per boot_id; boot_id change resets the watermark.
+    _browser_metrics_seq: dict[str, int] = {}  # keyed by boot_id
+
+    async def _poll_browser_metrics_once() -> None:
+        if not container_manager or event_bus is None:
+            return
+        svc_url = getattr(container_manager, "browser_service_url", None)
+        svc_token = getattr(container_manager, "browser_auth_token", "")
+        if not svc_url:
+            return
+        headers: dict = {"X-Mesh-Internal": "1"}
+        if svc_token:
+            headers["Authorization"] = f"Bearer {svc_token}"
+        try:
+            resp = await _browser_proxy_client.get(
+                f"{svc_url}/browser/metrics",
+                params={"since": _browser_metrics_seq.get("_last_seen", 0)},
+                headers=headers,
+                timeout=10,
+            )
+            if resp.status_code >= 400:
+                return
+            data = resp.json()
+        except Exception as e:
+            logger.debug("Browser metrics poll failed: %s", e)
+            return
+        boot_id = data.get("boot_id") or ""
+        # Reset the watermark when the browser service restarts, otherwise
+        # we'd starve forever waiting for seqs that never arrive.
+        if _browser_metrics_seq.get("_boot_id") != boot_id:
+            _browser_metrics_seq["_boot_id"] = boot_id
+            _browser_metrics_seq["_last_seen"] = 0
+        for payload in data.get("metrics", []) or []:
+            seq = int(payload.get("seq", 0))
+            if seq <= _browser_metrics_seq.get("_last_seen", 0):
+                continue
+            _browser_metrics_seq["_last_seen"] = seq
+            agent_id = payload.get("agent_id", "")
+            event_bus.emit("browser_metrics", agent=agent_id, data=payload)
+
+    async def _browser_metrics_loop() -> None:
+        # First pass runs ~5s after boot to give the browser service time
+        # to register, then every 60s. Tolerates transient failures — the
+        # metric channel is best-effort observability, not correctness.
+        await asyncio.sleep(5)
+        while True:
+            try:
+                await _poll_browser_metrics_once()
+            except asyncio.CancelledError:
+                raise
+            except Exception as e:
+                logger.debug("Browser metrics poll loop tick failed: %s", e)
+            await asyncio.sleep(60)
+
+    @app.on_event("startup")
+    async def _start_browser_metrics_poll() -> None:
+        # No-op if the mesh is running without a browser service configured
+        # (early-returned inside _poll_browser_metrics_once).
+        asyncio.create_task(_browser_metrics_loop())
+
     # Mesh-side input validation: reject typo'd action names with a clean 400
     # before proxying to the browser service. Permissions are enforced separately
     # via PermissionMatrix.can_browser_action (default-allow for all known

--- a/src/host/server.py
+++ b/src/host/server.py
@@ -2711,16 +2711,34 @@ def create_mesh_app(
             logger.debug("Browser metrics poll failed: %s", e)
             return
         boot_id = data.get("boot_id") or ""
+        is_first_seen = _browser_metrics_seq.get("_boot_id") != boot_id
         # Reset the watermark when the browser service restarts, otherwise
         # we'd starve forever waiting for seqs that never arrive.
-        if _browser_metrics_seq.get("_boot_id") != boot_id:
+        if is_first_seen:
             _browser_metrics_seq["_boot_id"] = boot_id
             _browser_metrics_seq["_last_seen"] = 0
-        for payload in data.get("metrics", []) or []:
+
+        payloads = [
+            p for p in (data.get("metrics") or [])
+            if int(p.get("seq", 0)) > _browser_metrics_seq.get("_last_seen", 0)
+        ]
+        # On first-seen (fresh mesh or browser restart), only surface the
+        # latest payload per agent. A long-running browser service can
+        # return hours of history; flooding the dashboard's 500-event
+        # ring buffer with stale entries would evict live events and
+        # show agents with data that no longer reflects current health.
+        if is_first_seen and payloads:
+            latest_by_agent: dict[str, dict] = {}
+            for p in payloads:
+                latest_by_agent[p.get("agent_id", "")] = p
+            payloads = sorted(
+                latest_by_agent.values(), key=lambda p: int(p.get("seq", 0)),
+            )
+
+        for payload in payloads:
             seq = int(payload.get("seq", 0))
-            if seq <= _browser_metrics_seq.get("_last_seen", 0):
-                continue
-            _browser_metrics_seq["_last_seen"] = seq
+            if seq > _browser_metrics_seq.get("_last_seen", 0):
+                _browser_metrics_seq["_last_seen"] = seq
             agent_id = payload.get("agent_id", "")
             event_bus.emit("browser_metrics", agent=agent_id, data=payload)
 

--- a/src/host/server.py
+++ b/src/host/server.py
@@ -2751,12 +2751,35 @@ def create_mesh_app(
         _poll_state["last_success_ts"] = time.time()
 
         boot_id = data.get("boot_id") or ""
-        is_first_seen = _poll_state["boot_id"] != boot_id
+        previous_boot_id = _poll_state["boot_id"]
+        since_used = _poll_state["last_seen_seq"]
+        is_first_seen = previous_boot_id != boot_id
         # Reset the watermark when the browser service restarts, otherwise
         # we'd starve forever waiting for seqs that never arrive.
         if is_first_seen:
             _poll_state["boot_id"] = boot_id
             _poll_state["last_seen_seq"] = 0
+            # If we queried with a non-zero ``since`` (stale high-water
+            # from the pre-restart browser) and the browser's ``seq > since``
+            # filter dropped everything, we have to re-poll with ``since=0``
+            # before those payloads scroll off the browser's history deque.
+            # Skip the re-poll when: (a) since was already 0 — nothing got
+            # filtered; or (b) the response already contains payloads — the
+            # filter wasn't the problem. Both cases would double-emit.
+            if since_used > 0 and previous_boot_id and not data.get("metrics"):
+                try:
+                    resp = await _browser_proxy_client.get(
+                        f"{svc_url}/browser/metrics",
+                        params={"since": 0},
+                        headers=headers,
+                        timeout=10,
+                    )
+                    if resp.status_code < 400:
+                        data = resp.json()
+                except Exception as e:
+                    logger.debug("Post-restart re-poll failed: %s", e)
+                    # Keep the original response rather than aborting;
+                    # next tick will recover.
 
         payloads = [
             p for p in (data.get("metrics") or [])

--- a/src/host/server.py
+++ b/src/host/server.py
@@ -2684,8 +2684,17 @@ def create_mesh_app(
     # to the mesh's in-process EventBus, so the mesh pulls. Runs on a 60s
     # cadence — matching BrowserManager._emit_metrics — and fans each new
     # per-agent aggregate out as a ``browser_metrics`` event. High-water
-    # seq per boot_id; boot_id change resets the watermark.
-    _browser_metrics_seq: dict[str, int] = {}  # keyed by boot_id
+    # seq per boot_id; boot_id change resets the watermark. Poll failures
+    # are logged at DEBUG normally; after ``_POLL_WARN_THRESHOLD`` consecutive
+    # failures we escalate to WARNING so operators can diagnose persistent
+    # issues (auth rotation, browser down, network partition).
+    _poll_state: dict = {
+        "boot_id": "",
+        "last_seen_seq": 0,
+        "consecutive_failures": 0,
+        "last_success_ts": 0.0,
+    }
+    _POLL_WARN_THRESHOLD = 5  # ~5 minutes of failures before warning
 
     async def _poll_browser_metrics_once() -> None:
         if not container_manager or event_bus is None:
@@ -2694,33 +2703,64 @@ def create_mesh_app(
         svc_token = getattr(container_manager, "browser_auth_token", "")
         if not svc_url:
             return
-        headers: dict = {"X-Mesh-Internal": "1"}
+        headers: dict = {}
         if svc_token:
             headers["Authorization"] = f"Bearer {svc_token}"
+
+        def _record_failure(reason: str) -> None:
+            _poll_state["consecutive_failures"] += 1
+            n = _poll_state["consecutive_failures"]
+            # Quiet when it's the first couple of misses (normal during
+            # boot / brief outages); loud once it looks like a real problem,
+            # then back off so we don't flood logs indefinitely.
+            if n in (_POLL_WARN_THRESHOLD, _POLL_WARN_THRESHOLD * 4,
+                     _POLL_WARN_THRESHOLD * 16):
+                logger.warning(
+                    "Browser metrics poll has failed %d consecutive times "
+                    "(%s)", n, reason,
+                )
+            else:
+                logger.debug("Browser metrics poll failed: %s", reason)
+
         try:
             resp = await _browser_proxy_client.get(
                 f"{svc_url}/browser/metrics",
-                params={"since": _browser_metrics_seq.get("_last_seen", 0)},
+                params={"since": _poll_state["last_seen_seq"]},
                 headers=headers,
                 timeout=10,
             )
-            if resp.status_code >= 400:
-                return
+        except Exception as e:
+            _record_failure(f"request error: {e}")
+            return
+        if resp.status_code >= 400:
+            _record_failure(f"HTTP {resp.status_code}")
+            return
+        try:
             data = resp.json()
         except Exception as e:
-            logger.debug("Browser metrics poll failed: %s", e)
+            _record_failure(f"bad JSON: {e}")
             return
+
+        # Success — reset failure counter and log recovery if we were noisy.
+        if _poll_state["consecutive_failures"] >= _POLL_WARN_THRESHOLD:
+            logger.info(
+                "Browser metrics poll recovered after %d failures",
+                _poll_state["consecutive_failures"],
+            )
+        _poll_state["consecutive_failures"] = 0
+        _poll_state["last_success_ts"] = time.time()
+
         boot_id = data.get("boot_id") or ""
-        is_first_seen = _browser_metrics_seq.get("_boot_id") != boot_id
+        is_first_seen = _poll_state["boot_id"] != boot_id
         # Reset the watermark when the browser service restarts, otherwise
         # we'd starve forever waiting for seqs that never arrive.
         if is_first_seen:
-            _browser_metrics_seq["_boot_id"] = boot_id
-            _browser_metrics_seq["_last_seen"] = 0
+            _poll_state["boot_id"] = boot_id
+            _poll_state["last_seen_seq"] = 0
 
         payloads = [
             p for p in (data.get("metrics") or [])
-            if int(p.get("seq", 0)) > _browser_metrics_seq.get("_last_seen", 0)
+            if int(p.get("seq", 0)) > _poll_state["last_seen_seq"]
         ]
         # On first-seen (fresh mesh or browser restart), only surface the
         # latest payload per agent. A long-running browser service can
@@ -2737,8 +2777,8 @@ def create_mesh_app(
 
         for payload in payloads:
             seq = int(payload.get("seq", 0))
-            if seq > _browser_metrics_seq.get("_last_seen", 0):
-                _browser_metrics_seq["_last_seen"] = seq
+            if seq > _poll_state["last_seen_seq"]:
+                _poll_state["last_seen_seq"] = seq
             agent_id = payload.get("agent_id", "")
             event_bus.emit("browser_metrics", agent=agent_id, data=payload)
 
@@ -2755,6 +2795,11 @@ def create_mesh_app(
             except Exception as e:
                 logger.debug("Browser metrics poll loop tick failed: %s", e)
             await asyncio.sleep(60)
+
+    # Expose the poll primitives on app.state so tests (and future admin
+    # endpoints) can reach them without walking closure cells.
+    app.state.poll_browser_metrics_once = _poll_browser_metrics_once
+    app.state.browser_metrics_poll_state = _poll_state
 
     @app.on_event("startup")
     async def _start_browser_metrics_poll() -> None:

--- a/tests/test_browser_metrics.py
+++ b/tests/test_browser_metrics.py
@@ -188,6 +188,10 @@ class TestEmitMetrics:
             "bad": _new_instance("bad"),
             "good": _new_instance("good"),
         }
+        # Both need activity to avoid the _is_empty_payload skip —
+        # zero-counter payloads are intentionally filtered out.
+        mgr._instances["bad"].m_click_success = 1
+        mgr._instances["good"].m_click_success = 1
         await mgr._emit_metrics()
         assert "good" in delivered
 
@@ -300,11 +304,14 @@ class TestMetricsHistoryBuffer:
         """The poller passes back current_seq as ``since`` — we must
         return only payloads strictly newer than that."""
         mgr = BrowserManager(profiles_dir=str(tmp_path / "profiles"))
-        mgr._instances = {"a1": _new_instance("a1")}
+        inst = _new_instance("a1")
+        mgr._instances = {"a1": inst}
 
-        await mgr._emit_metrics()  # seq=1
-        await mgr._emit_metrics()  # seq=2
-        await mgr._emit_metrics()  # seq=3
+        # Each drain needs activity — otherwise ``_is_empty_payload``
+        # (correctly) skips the emit to keep idle history tidy.
+        for _ in range(3):
+            inst.m_click_success = 1
+            await mgr._emit_metrics()
 
         snap = mgr.get_recent_metrics(since_seq=2)
         assert snap["current_seq"] == 3
@@ -313,11 +320,24 @@ class TestMetricsHistoryBuffer:
     @pytest.mark.asyncio
     async def test_since_beyond_current_returns_empty(self, tmp_path):
         mgr = BrowserManager(profiles_dir=str(tmp_path / "profiles"))
-        mgr._instances = {"a1": _new_instance("a1")}
+        inst = _new_instance("a1")
+        mgr._instances = {"a1": inst}
+        inst.m_click_success = 1
         await mgr._emit_metrics()
         snap = mgr.get_recent_metrics(since_seq=999)
         assert snap["metrics"] == []
         assert snap["current_seq"] == 1
+
+    @pytest.mark.asyncio
+    async def test_idle_agent_skipped_from_history(self, tmp_path):
+        """Regression: agents with zero activity on a tick must not
+        consume seqs or pollute the history buffer."""
+        mgr = BrowserManager(profiles_dir=str(tmp_path / "profiles"))
+        mgr._instances = {"idle": _new_instance("idle")}
+        await mgr._emit_metrics()
+        snap = mgr.get_recent_metrics(since_seq=0)
+        assert snap["current_seq"] == 0
+        assert snap["metrics"] == []
 
     @pytest.mark.asyncio
     async def test_history_records_final_stop_drain(self, tmp_path):
@@ -378,9 +398,13 @@ class TestBrowserMetricsEndpoint:
         from fastapi.testclient import TestClient
 
         mgr = BrowserManager(profiles_dir=str(tmp_path / "profiles"))
-        mgr._instances = {"a1": _new_instance("a1")}
-        await mgr._emit_metrics()
-        await mgr._emit_metrics()
+        inst = _new_instance("a1")
+        mgr._instances = {"a1": inst}
+        # Activity on each tick so both payloads survive the
+        # empty-payload filter.
+        for _ in range(2):
+            inst.m_click_success = 1
+            await mgr._emit_metrics()
 
         app = self._mk_app(monkeypatch, mgr)
         with TestClient(app) as client:

--- a/tests/test_browser_metrics.py
+++ b/tests/test_browser_metrics.py
@@ -340,6 +340,28 @@ class TestMetricsHistoryBuffer:
         assert snap["metrics"] == []
 
     @pytest.mark.asyncio
+    async def test_post_click_idle_interval_still_filtered(self, tmp_path):
+        """Regression (Codex #1 P1): the rolling click window persists
+        across drains, so if ``_is_empty_payload`` treated a non-empty
+        window as "activity" the filter would be permanently bypassed
+        for any agent that ever clicked. This test would silently
+        pass even with the bug if the agent had an active minute; we
+        specifically exercise an idle minute *after* activity.
+        """
+        mgr = BrowserManager(profiles_dir=str(tmp_path / "profiles"))
+        inst = _new_instance("chatty")
+        mgr._instances = {"chatty": inst}
+        # Minute 1: has a click.
+        inst.m_click_success = 1
+        inst.click_window.append(True)
+        await mgr._emit_metrics()
+        assert mgr.get_recent_metrics(since_seq=0)["current_seq"] == 1
+        # Minute 2: no new clicks, but window is still non-empty from M1.
+        await mgr._emit_metrics()
+        # Seq must NOT advance — the idle minute is correctly filtered.
+        assert mgr.get_recent_metrics(since_seq=0)["current_seq"] == 1
+
+    @pytest.mark.asyncio
     async def test_history_records_final_stop_drain(self, tmp_path):
         """An agent stopping must still surface its last minute of data
         to the next poll, even without a metrics_sink wired in-process."""

--- a/tests/test_browser_metrics.py
+++ b/tests/test_browser_metrics.py
@@ -30,6 +30,58 @@ class TestCounterInitialState:
         assert inst.m_click_fail == 0
         assert inst.m_nav_timeout == 0
         assert inst.m_snapshot_bytes == []
+        assert len(inst.click_window) == 0
+        # Empty window must read as "unknown", not 0% — would falsely
+        # suggest catastrophic failure on a freshly-booted agent.
+        assert inst.rolling_click_success_rate() is None
+
+
+class TestRollingClickWindow:
+    def test_counts_success_rate(self):
+        inst = _new_instance()
+        for _ in range(8):
+            inst.click_window.append(True)
+        for _ in range(2):
+            inst.click_window.append(False)
+        assert inst.rolling_click_success_rate() == 0.8
+        assert len(inst.click_window) == 10
+
+    def test_window_capped_at_100(self):
+        inst = _new_instance()
+        for i in range(150):
+            inst.click_window.append(True)
+        assert len(inst.click_window) == 100
+        assert inst.rolling_click_success_rate() == 1.0
+
+    def test_window_evicts_old_entries(self):
+        """Older failures age out past the 100-sample window."""
+        inst = _new_instance()
+        # 50 failures, then 100 successes — the failures fall off the
+        # head once the deque reaches its maxlen.
+        for _ in range(50):
+            inst.click_window.append(False)
+        for _ in range(100):
+            inst.click_window.append(True)
+        assert len(inst.click_window) == 100
+        assert inst.rolling_click_success_rate() == 1.0
+
+    def test_window_survives_drain(self):
+        """Rolling window persists across per-minute emits — it's a
+        longer-horizon health signal than the per-minute counters."""
+        inst = _new_instance()
+        for _ in range(10):
+            inst.click_window.append(True)
+        payload = inst.drain_metrics()
+        assert payload["click_window_size"] == 10
+        assert payload["click_success_rate_100"] == 1.0
+        # Window survives the drain; per-minute counters reset.
+        assert len(inst.click_window) == 10
+
+    def test_drain_reports_none_when_empty(self):
+        inst = _new_instance()
+        payload = inst.drain_metrics()
+        assert payload["click_window_size"] == 0
+        assert payload["click_success_rate_100"] is None
 
 
 class TestDrainMetrics:
@@ -218,3 +270,156 @@ class TestCleanupLoopIntegration:
             await mgr._cleanup_loop()
         assert len(sink_calls) == 1
         assert sink_calls[0]["click_success"] == 1
+
+
+class TestMetricsHistoryBuffer:
+    """§5.1/§5.2: the mesh polls /browser/metrics?since=<seq> to forward
+    aggregate payloads into the EventBus. This test class covers the
+    browser-side buffer + cursor semantics the poller relies on.
+    """
+
+    @pytest.mark.asyncio
+    async def test_emit_writes_to_history(self, tmp_path):
+        mgr = BrowserManager(profiles_dir=str(tmp_path / "profiles"))
+        mgr._instances = {"a1": _new_instance("a1")}
+        mgr._instances["a1"].m_click_success = 3
+
+        await mgr._emit_metrics()
+
+        snap = mgr.get_recent_metrics(since_seq=0)
+        assert snap["current_seq"] == 1
+        assert snap["boot_id"] == mgr.boot_id
+        assert len(snap["metrics"]) == 1
+        assert snap["metrics"][0]["agent_id"] == "a1"
+        assert snap["metrics"][0]["click_success"] == 3
+        assert snap["metrics"][0]["seq"] == 1
+        assert "ts" in snap["metrics"][0]
+
+    @pytest.mark.asyncio
+    async def test_since_filter_returns_only_new(self, tmp_path):
+        """The poller passes back current_seq as ``since`` — we must
+        return only payloads strictly newer than that."""
+        mgr = BrowserManager(profiles_dir=str(tmp_path / "profiles"))
+        mgr._instances = {"a1": _new_instance("a1")}
+
+        await mgr._emit_metrics()  # seq=1
+        await mgr._emit_metrics()  # seq=2
+        await mgr._emit_metrics()  # seq=3
+
+        snap = mgr.get_recent_metrics(since_seq=2)
+        assert snap["current_seq"] == 3
+        assert [m["seq"] for m in snap["metrics"]] == [3]
+
+    @pytest.mark.asyncio
+    async def test_since_beyond_current_returns_empty(self, tmp_path):
+        mgr = BrowserManager(profiles_dir=str(tmp_path / "profiles"))
+        mgr._instances = {"a1": _new_instance("a1")}
+        await mgr._emit_metrics()
+        snap = mgr.get_recent_metrics(since_seq=999)
+        assert snap["metrics"] == []
+        assert snap["current_seq"] == 1
+
+    @pytest.mark.asyncio
+    async def test_history_records_final_stop_drain(self, tmp_path):
+        """An agent stopping must still surface its last minute of data
+        to the next poll, even without a metrics_sink wired in-process."""
+        mgr = BrowserManager(profiles_dir=str(tmp_path / "profiles"))
+        inst = _new_instance("goodbye")
+        inst.context = MagicMock()
+        inst.context.close = AsyncMock()
+        mgr._instances["goodbye"] = inst
+        inst.m_click_success = 9
+        async with mgr._lock:
+            await mgr._stop_instance("goodbye")
+
+        snap = mgr.get_recent_metrics(since_seq=0)
+        assert len(snap["metrics"]) == 1
+        assert snap["metrics"][0]["agent_id"] == "goodbye"
+        assert snap["metrics"][0]["click_success"] == 9
+
+
+class TestBrowserMetricsEndpoint:
+    """``GET /browser/metrics?since=<seq>`` is the mesh's polling target.
+
+    These tests construct ``BrowserManager`` inside an async context so the
+    ``asyncio.Lock()`` in its ``__init__`` binds cleanly on Python 3.9 — on
+    3.10+ this is a no-op but it also avoids test-order leakage when
+    ``asyncio.run`` closes the default event loop between test cases.
+    """
+
+    def _mk_app(self, monkeypatch, manager):
+        monkeypatch.delenv("BROWSER_AUTH_TOKEN", raising=False)
+        monkeypatch.delenv("MESH_AUTH_TOKEN", raising=False)
+        from src.browser.server import create_browser_app
+        return create_browser_app(manager)
+
+    @pytest.mark.asyncio
+    async def test_endpoint_returns_buffered_metrics(self, tmp_path, monkeypatch):
+        from fastapi.testclient import TestClient
+
+        mgr = BrowserManager(profiles_dir=str(tmp_path / "profiles"))
+        mgr._instances = {"a1": _new_instance("a1")}
+        mgr._instances["a1"].m_click_success = 2
+        await mgr._emit_metrics()
+
+        app = self._mk_app(monkeypatch, mgr)
+        with TestClient(app) as client:
+            resp = client.get("/browser/metrics?since=0")
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["current_seq"] == 1
+        assert body["boot_id"] == mgr.boot_id
+        assert len(body["metrics"]) == 1
+        assert body["metrics"][0]["agent_id"] == "a1"
+        assert body["metrics"][0]["click_success"] == 2
+
+    @pytest.mark.asyncio
+    async def test_endpoint_respects_since_filter(self, tmp_path, monkeypatch):
+        from fastapi.testclient import TestClient
+
+        mgr = BrowserManager(profiles_dir=str(tmp_path / "profiles"))
+        mgr._instances = {"a1": _new_instance("a1")}
+        await mgr._emit_metrics()
+        await mgr._emit_metrics()
+
+        app = self._mk_app(monkeypatch, mgr)
+        with TestClient(app) as client:
+            resp = client.get("/browser/metrics?since=1")
+        assert resp.status_code == 200
+        body = resp.json()
+        assert [m["seq"] for m in body["metrics"]] == [2]
+
+    @pytest.mark.asyncio
+    async def test_endpoint_handles_invalid_since(self, tmp_path, monkeypatch):
+        """A non-integer ``since`` must not crash the server; FastAPI
+        returns 422 at the validation layer."""
+        from fastapi.testclient import TestClient
+
+        mgr = BrowserManager(profiles_dir=str(tmp_path / "profiles"))
+        app = self._mk_app(monkeypatch, mgr)
+        with TestClient(app) as client:
+            resp = client.get("/browser/metrics?since=abc")
+        assert resp.status_code == 422
+
+    @pytest.mark.asyncio
+    async def test_endpoint_requires_auth_when_configured(
+        self, tmp_path, monkeypatch,
+    ):
+        """With BROWSER_AUTH_TOKEN set, metrics require a Bearer token —
+        same posture as every other /browser/* endpoint."""
+        from fastapi.testclient import TestClient
+
+        monkeypatch.setenv("BROWSER_AUTH_TOKEN", "secret-t0k")
+        monkeypatch.delenv("MESH_AUTH_TOKEN", raising=False)
+        from src.browser.server import create_browser_app
+
+        mgr = BrowserManager(profiles_dir=str(tmp_path / "profiles"))
+        app = create_browser_app(mgr)
+        with TestClient(app) as client:
+            unauth = client.get("/browser/metrics")
+            assert unauth.status_code == 401
+            authed = client.get(
+                "/browser/metrics",
+                headers={"Authorization": "Bearer secret-t0k"},
+            )
+            assert authed.status_code == 200

--- a/tests/test_browser_metrics_ingest.py
+++ b/tests/test_browser_metrics_ingest.py
@@ -187,6 +187,66 @@ class TestMetricsPoll:
         assert len(metric_emits) == 1  # only the first tick carried a new seq
 
     @pytest.mark.asyncio
+    async def test_browser_restart_no_data_loss_on_first_poll(
+        self, tmp_path, monkeypatch,
+    ):
+        """Regression (Codex #2 P1): after a browser restart the mesh's
+        cached high-water `since` is stale — post-restart seqs start at
+        1, which fails the browser's `seq > since` filter. The mesh
+        must re-poll with `since=0` the moment it detects the new
+        boot_id, before those payloads scroll off the browser's history.
+        """
+        import httpx
+
+        responses = [
+            # First poll: stale since=100 ; browser restarted and seqs
+            # now go 1..3 but the filter drops them all.
+            {"current_seq": 3, "boot_id": "boot-B", "metrics": []},
+            # Second request (the immediate re-poll triggered by boot_id
+            # change) with since=0 returns the post-restart data.
+            {
+                "current_seq": 3, "boot_id": "boot-B", "metrics": [
+                    {"seq": 1, "ts": 1.0, "agent_id": "a1",
+                     "click_success": 5, "click_fail": 0, "nav_timeout": 0,
+                     "snapshot_count": 0, "snapshot_bytes_p50": 0,
+                     "snapshot_bytes_p95": 0, "click_window_size": 0,
+                     "click_success_rate_100": None},
+                ],
+            },
+        ]
+        call_count = {"n": 0}
+
+        async def fake_get(self, url, *args, **kwargs):
+            idx = min(call_count["n"], len(responses) - 1)
+            call_count["n"] += 1
+            req = httpx.Request("GET", url)
+            return httpx.Response(200, json=responses[idx], request=req)
+
+        monkeypatch.setattr(httpx.AsyncClient, "get", fake_get)
+
+        app, event_bus, _cm = _build_mesh(tmp_path)
+        # Seed the mesh with a stale high-water so the first poll
+        # hits the filter-drops-everything case.
+        app.state.browser_metrics_poll_state["boot_id"] = "boot-A"
+        app.state.browser_metrics_poll_state["last_seen_seq"] = 100
+
+        poll = _extract_poll_fn(app)
+        await poll()
+
+        # The post-restart payload must have reached the EventBus.
+        metric_emits = [c for c in event_bus.emit.call_args_list
+                        if c.args and c.args[0] == "browser_metrics"]
+        assert len(metric_emits) == 1, (
+            "expected 1 browser_metrics event after restart recovery; "
+            "got " + repr(metric_emits)
+        )
+        payload = metric_emits[0].kwargs["data"]
+        assert payload["seq"] == 1
+        assert payload["click_success"] == 5
+        # And the HTTP client was actually called twice (original + re-poll).
+        assert call_count["n"] == 2
+
+    @pytest.mark.asyncio
     async def test_poll_resets_watermark_on_boot_id_change(
         self, tmp_path, monkeypatch,
     ):

--- a/tests/test_browser_metrics_ingest.py
+++ b/tests/test_browser_metrics_ingest.py
@@ -264,6 +264,68 @@ class TestMetricsPoll:
         assert len(metric_emits) == 0
 
     @pytest.mark.asyncio
+    async def test_first_seen_collapses_to_latest_per_agent(
+        self, tmp_path, monkeypatch,
+    ):
+        """On boot-id-first-seen (fresh mesh OR browser restart), the
+        browser's history buffer may contain hours of stale payloads per
+        agent. Replaying all of them would flood the dashboard's 500-event
+        ring buffer and evict live signals. Only the latest seq per agent
+        should emit.
+        """
+        import httpx
+
+        # Browser has 3 entries for a1, 2 entries for a2 — all from the
+        # same boot. Only the highest-seq payload per agent should reach
+        # the EventBus on the first poll.
+        canned = {
+            "current_seq": 5,
+            "boot_id": "boot-new",
+            "metrics": [
+                {"seq": 1, "ts": 1.0, "agent_id": "a1", "click_success": 1,
+                 "click_fail": 0, "nav_timeout": 0, "snapshot_count": 0,
+                 "snapshot_bytes_p50": 0, "snapshot_bytes_p95": 0,
+                 "click_window_size": 0, "click_success_rate_100": None},
+                {"seq": 2, "ts": 2.0, "agent_id": "a2", "click_success": 2,
+                 "click_fail": 0, "nav_timeout": 0, "snapshot_count": 0,
+                 "snapshot_bytes_p50": 0, "snapshot_bytes_p95": 0,
+                 "click_window_size": 0, "click_success_rate_100": None},
+                {"seq": 3, "ts": 3.0, "agent_id": "a1", "click_success": 3,
+                 "click_fail": 0, "nav_timeout": 0, "snapshot_count": 0,
+                 "snapshot_bytes_p50": 0, "snapshot_bytes_p95": 0,
+                 "click_window_size": 0, "click_success_rate_100": None},
+                {"seq": 4, "ts": 4.0, "agent_id": "a2", "click_success": 4,
+                 "click_fail": 0, "nav_timeout": 0, "snapshot_count": 0,
+                 "snapshot_bytes_p50": 0, "snapshot_bytes_p95": 0,
+                 "click_window_size": 0, "click_success_rate_100": None},
+                {"seq": 5, "ts": 5.0, "agent_id": "a1", "click_success": 5,
+                 "click_fail": 0, "nav_timeout": 0, "snapshot_count": 0,
+                 "snapshot_bytes_p50": 0, "snapshot_bytes_p95": 0,
+                 "click_window_size": 0, "click_success_rate_100": None},
+            ],
+        }
+
+        async def fake_get(self, url, *args, **kwargs):
+            req = httpx.Request("GET", url)
+            return httpx.Response(200, json=canned, request=req)
+
+        monkeypatch.setattr(httpx.AsyncClient, "get", fake_get)
+
+        app, event_bus, _cm = _build_mesh(tmp_path)
+        poll = _extract_poll_fn(app)
+        await poll()
+
+        metric_emits = [c for c in event_bus.emit.call_args_list
+                        if c.args and c.args[0] == "browser_metrics"]
+        # Exactly 2 events (latest per agent), not 5.
+        assert len(metric_emits) == 2
+        agents_emitted = {}
+        for c in metric_emits:
+            data = c.kwargs.get("data") or {}
+            agents_emitted[c.kwargs.get("agent")] = data["seq"]
+        assert agents_emitted == {"a1": 5, "a2": 4}
+
+    @pytest.mark.asyncio
     async def test_poll_noop_without_browser_service(self, tmp_path, monkeypatch):
         """If container_manager has no browser_service_url, the poll is
         a silent no-op — mesh configurations without a browser shouldn't

--- a/tests/test_browser_metrics_ingest.py
+++ b/tests/test_browser_metrics_ingest.py
@@ -326,6 +326,79 @@ class TestMetricsPoll:
         assert agents_emitted == {"a1": 5, "a2": 4}
 
     @pytest.mark.asyncio
+    async def test_persistent_failures_escalate_to_warning(
+        self, tmp_path, monkeypatch, caplog,
+    ):
+        """Silent debug-level failures hide real outages. After the
+        threshold (5 ticks), the mesh must log at WARNING so operators
+        can diagnose 'why no metrics'."""
+        import logging
+
+        import httpx
+
+        async def always_fails(self, url, *args, **kwargs):
+            raise httpx.ConnectError("simulated down")
+
+        monkeypatch.setattr(httpx.AsyncClient, "get", always_fails)
+
+        app, _event_bus, _cm = _build_mesh(tmp_path)
+        poll = _extract_poll_fn(app)
+
+        caplog.set_level(logging.WARNING)
+        # Hit the threshold (5 consecutive) — fifth call must warn.
+        for _ in range(5):
+            await poll()
+
+        warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
+        assert any("consecutive" in r.getMessage() for r in warnings), (
+            "expected consecutive-failure warning; got: "
+            + repr([r.getMessage() for r in warnings])
+        )
+
+    @pytest.mark.asyncio
+    async def test_recovery_logs_info(self, tmp_path, monkeypatch, caplog):
+        """After a noisy failure streak, a success must log at INFO so
+        operators see the all-clear."""
+        import logging
+
+        import httpx
+
+        call_count = {"n": 0}
+
+        async def fail_then_succeed(self, url, *args, **kwargs):
+            call_count["n"] += 1
+            if call_count["n"] <= 5:
+                raise httpx.ConnectError("down")
+            req = httpx.Request("GET", url)
+            return httpx.Response(200, json={
+                "current_seq": 0, "boot_id": "b", "metrics": [],
+            }, request=req)
+
+        monkeypatch.setattr(httpx.AsyncClient, "get", fail_then_succeed)
+
+        app, _event_bus, _cm = _build_mesh(tmp_path)
+        poll = _extract_poll_fn(app)
+
+        caplog.set_level(logging.INFO)
+        for _ in range(6):
+            await poll()
+
+        info = [r for r in caplog.records if r.levelno == logging.INFO]
+        assert any("recovered" in r.getMessage() for r in info)
+
+    @pytest.mark.asyncio
+    async def test_poll_state_accessible_via_app_state(self, tmp_path):
+        """The poll primitive + state are exposed on ``app.state`` so
+        tests and future admin endpoints can reach them without walking
+        closure cells."""
+        app, _event_bus, _cm = _build_mesh(tmp_path)
+        assert callable(getattr(app.state, "poll_browser_metrics_once", None))
+        state = getattr(app.state, "browser_metrics_poll_state", None)
+        assert isinstance(state, dict)
+        assert "consecutive_failures" in state
+        assert "last_seen_seq" in state
+
+    @pytest.mark.asyncio
     async def test_poll_noop_without_browser_service(self, tmp_path, monkeypatch):
         """If container_manager has no browser_service_url, the poll is
         a silent no-op — mesh configurations without a browser shouldn't
@@ -348,30 +421,16 @@ class TestMetricsPoll:
 
 
 def _extract_poll_fn(app):
-    """Locate ``_poll_browser_metrics_once`` in the app's closures.
+    """Return ``_poll_browser_metrics_once`` from the mesh app.
 
-    ``create_mesh_app`` registers a startup handler named
-    ``_start_browser_metrics_poll`` that schedules
-    ``_browser_metrics_loop`` — which itself closes over
-    ``_poll_browser_metrics_once``. We walk one level of closure to
-    return the poll function directly so tests can invoke it without
-    spinning up the 60s sleep loop.
+    The poll primitive is exposed on ``app.state`` precisely so tests
+    (and future admin endpoints) can reach it without walking closure
+    cells. Raises AssertionError if missing — a noisy failure here
+    means production wiring broke.
     """
-    for handler in app.router.on_startup:
-        if handler.__name__ != "_start_browser_metrics_poll":
-            continue
-        # handler closes over _browser_metrics_loop
-        for cell in (handler.__closure__ or ()):
-            val = cell.cell_contents
-            if callable(val) and getattr(val, "__name__", "") == "_browser_metrics_loop":
-                loop_fn = val
-                break
-        else:
-            continue
-        # loop_fn closes over _poll_browser_metrics_once
-        for cell in (loop_fn.__closure__ or ()):
-            val = cell.cell_contents
-            name = getattr(val, "__name__", "")
-            if callable(val) and name == "_poll_browser_metrics_once":
-                return val
-    return None
+    fn = getattr(app.state, "poll_browser_metrics_once", None)
+    assert fn is not None, (
+        "app.state.poll_browser_metrics_once missing — did create_mesh_app "
+        "stop publishing the poll primitive?"
+    )
+    return fn

--- a/tests/test_browser_metrics_ingest.py
+++ b/tests/test_browser_metrics_ingest.py
@@ -1,0 +1,315 @@
+"""Tests for the mesh-side browser-metrics poll loop (Phase 2 §5.1/§5.2).
+
+The browser service container exposes ``GET /browser/metrics?since=<seq>``.
+The mesh host polls it every 60s and fans each new per-agent payload out
+as a ``browser_metrics`` event on the dashboard EventBus.
+
+These tests exercise ``_poll_browser_metrics_once`` in isolation: the
+cadence loop itself is just ``asyncio.sleep`` + retries and not worth
+testing separately.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+
+def _build_mesh(tmp_path):
+    """Minimal mesh app with a fake container_manager pointing at a
+    fake browser service URL. Returns ``(app, event_bus, container_manager)``.
+
+    We build the app via ``create_mesh_app`` so the poller inside its
+    closure is wired normally. The tests then patch the module-level
+    ``httpx.AsyncClient.get`` to return canned metric payloads.
+    """
+    from src.host.costs import CostTracker
+    from src.host.mesh import Blackboard, MessageRouter, PubSub
+    from src.host.permissions import PermissionMatrix
+    from src.host.server import create_mesh_app
+    from src.host.traces import TraceStore
+
+    blackboard = Blackboard(str(tmp_path / "bb.db"))
+    pubsub = PubSub()
+    permissions = PermissionMatrix()
+    router = MessageRouter(permissions, {})
+    costs = CostTracker(str(tmp_path / "costs.db"))
+    traces = TraceStore(str(tmp_path / "traces.db"))
+
+    cm = MagicMock()
+    cm.browser_service_url = "http://browser-svc:8500"
+    cm.browser_auth_token = "t0k"
+
+    event_bus = MagicMock()
+
+    app = create_mesh_app(
+        blackboard=blackboard,
+        pubsub=pubsub,
+        router=router,
+        permissions=permissions,
+        cost_tracker=costs,
+        trace_store=traces,
+        event_bus=event_bus,
+        container_manager=cm,
+    )
+    return app, event_bus, cm
+
+
+class TestMetricsPoll:
+    @pytest.mark.asyncio
+    async def test_poll_emits_browser_metrics_events(self, tmp_path, monkeypatch):
+        """A fresh poll fetches from /browser/metrics and emits one
+        browser_metrics event per payload agent to the EventBus."""
+        import httpx
+
+        # Canned response from the fake browser service.
+        canned = {
+            "current_seq": 2,
+            "boot_id": "boot-1",
+            "metrics": [
+                {
+                    "seq": 1,
+                    "ts": 1000.0,
+                    "agent_id": "a1",
+                    "click_success": 5,
+                    "click_fail": 0,
+                    "nav_timeout": 0,
+                    "snapshot_count": 3,
+                    "snapshot_bytes_p50": 400,
+                    "snapshot_bytes_p95": 900,
+                    "click_window_size": 10,
+                    "click_success_rate_100": 1.0,
+                },
+                {
+                    "seq": 2,
+                    "ts": 1001.0,
+                    "agent_id": "a2",
+                    "click_success": 1,
+                    "click_fail": 4,
+                    "nav_timeout": 2,
+                    "snapshot_count": 1,
+                    "snapshot_bytes_p50": 200,
+                    "snapshot_bytes_p95": 200,
+                    "click_window_size": 20,
+                    "click_success_rate_100": 0.5,
+                },
+            ],
+        }
+
+        async def fake_get(self, url, *args, **kwargs):
+            req = httpx.Request("GET", url)
+            return httpx.Response(200, json=canned, request=req)
+
+        monkeypatch.setattr(httpx.AsyncClient, "get", fake_get)
+
+        # Build app and manually invoke the poll. We avoid relying on
+        # FastAPI startup events firing: instead, find the captured
+        # closure via the app's routes' lifespan hook by calling the
+        # registered startup function directly.
+        app, event_bus, _cm = _build_mesh(tmp_path)
+
+        # FastAPI stores startup handlers on app.router.on_startup.
+        handlers = list(app.router.on_startup)
+        assert handlers, "expected at least one startup handler"
+
+        # Poll function is closed over by _browser_metrics_loop which is
+        # scheduled by one of those handlers. Rather than scheduling the
+        # loop (which sleeps 5s), we reach into the closure directly.
+        loop_handler = None
+        for h in handlers:
+            # The handler that schedules the metrics loop is named
+            # ``_start_browser_metrics_poll`` in the source.
+            if h.__name__ == "_start_browser_metrics_poll":
+                loop_handler = h
+                break
+        assert loop_handler is not None, "missing _start_browser_metrics_poll"
+
+        # Walk the closure to find _poll_browser_metrics_once (via the
+        # loop function closure). The loop function is created inside
+        # create_mesh_app, so we grab it from the start handler's
+        # co_freevars binding.
+        poll_fn = _extract_poll_fn(app)
+        assert poll_fn is not None
+
+        await poll_fn()
+
+        # Both agents should have emitted a browser_metrics event.
+        calls = [c for c in event_bus.emit.call_args_list
+                 if c.args and c.args[0] == "browser_metrics"]
+        assert len(calls) == 2
+        agents = [c.kwargs.get("agent") or (c.args[1] if len(c.args) > 1 else "")
+                  for c in calls]
+        assert set(agents) == {"a1", "a2"}
+        # Payload round-trip
+        for c in calls:
+            data = c.kwargs.get("data") or (c.args[2] if len(c.args) > 2 else {})
+            assert "click_success_rate_100" in data
+
+    @pytest.mark.asyncio
+    async def test_poll_skips_already_seen_seqs(self, tmp_path, monkeypatch):
+        """Second poll with same seqs emits nothing (idempotent)."""
+        import httpx
+
+        canned = {
+            "current_seq": 1,
+            "boot_id": "b1",
+            "metrics": [{
+                "seq": 1, "ts": 1.0, "agent_id": "a1",
+                "click_success": 1, "click_fail": 0, "nav_timeout": 0,
+                "snapshot_count": 0, "snapshot_bytes_p50": 0,
+                "snapshot_bytes_p95": 0, "click_window_size": 0,
+                "click_success_rate_100": None,
+            }],
+        }
+
+        # On the second call the browser would return {metrics: []} with
+        # the same current_seq since nothing new happened.
+        call_count = {"n": 0}
+        responses = [canned, {"current_seq": 1, "boot_id": "b1", "metrics": []}]
+
+        async def fake_get(self, url, *args, **kwargs):
+            idx = min(call_count["n"], len(responses) - 1)
+            call_count["n"] += 1
+            req = httpx.Request("GET", url)
+            return httpx.Response(200, json=responses[idx], request=req)
+
+        monkeypatch.setattr(httpx.AsyncClient, "get", fake_get)
+
+        app, event_bus, _cm = _build_mesh(tmp_path)
+        poll = _extract_poll_fn(app)
+
+        await poll()
+        await poll()
+
+        metric_emits = [c for c in event_bus.emit.call_args_list
+                        if c.args and c.args[0] == "browser_metrics"]
+        assert len(metric_emits) == 1  # only the first tick carried a new seq
+
+    @pytest.mark.asyncio
+    async def test_poll_resets_watermark_on_boot_id_change(
+        self, tmp_path, monkeypatch,
+    ):
+        """Browser service restart → boot_id changes → seq counter resets
+        to 0 inside the browser. The poller must detect this and re-emit
+        post-restart seqs (which would otherwise be <= high-water)."""
+        import httpx
+
+        responses = [
+            {
+                "current_seq": 5,
+                "boot_id": "boot-A",
+                "metrics": [{
+                    "seq": 5, "ts": 1.0, "agent_id": "a1",
+                    "click_success": 1, "click_fail": 0, "nav_timeout": 0,
+                    "snapshot_count": 0, "snapshot_bytes_p50": 0,
+                    "snapshot_bytes_p95": 0, "click_window_size": 0,
+                    "click_success_rate_100": None,
+                }],
+            },
+            # Service restarted — boot_id changed, seq reset
+            {
+                "current_seq": 1,
+                "boot_id": "boot-B",
+                "metrics": [{
+                    "seq": 1, "ts": 2.0, "agent_id": "a1",
+                    "click_success": 2, "click_fail": 0, "nav_timeout": 0,
+                    "snapshot_count": 0, "snapshot_bytes_p50": 0,
+                    "snapshot_bytes_p95": 0, "click_window_size": 0,
+                    "click_success_rate_100": None,
+                }],
+            },
+        ]
+        call_count = {"n": 0}
+
+        async def fake_get(self, url, *args, **kwargs):
+            idx = min(call_count["n"], len(responses) - 1)
+            call_count["n"] += 1
+            req = httpx.Request("GET", url)
+            return httpx.Response(200, json=responses[idx], request=req)
+
+        monkeypatch.setattr(httpx.AsyncClient, "get", fake_get)
+
+        app, event_bus, _cm = _build_mesh(tmp_path)
+        poll = _extract_poll_fn(app)
+
+        await poll()
+        await poll()
+
+        metric_emits = [c for c in event_bus.emit.call_args_list
+                        if c.args and c.args[0] == "browser_metrics"]
+        # Both post-boot-A seq=5 and post-boot-B seq=1 should have been
+        # surfaced — restart must not swallow metrics.
+        assert len(metric_emits) == 2
+
+    @pytest.mark.asyncio
+    async def test_poll_tolerates_browser_service_error(
+        self, tmp_path, monkeypatch,
+    ):
+        """A 5xx or transport error must not crash the poll loop — metrics
+        are best-effort observability, not correctness."""
+        import httpx
+
+        async def fake_get(self, url, *args, **kwargs):
+            raise httpx.ConnectError("simulated down")
+
+        monkeypatch.setattr(httpx.AsyncClient, "get", fake_get)
+
+        app, event_bus, _cm = _build_mesh(tmp_path)
+        poll = _extract_poll_fn(app)
+
+        await poll()  # must not raise
+        metric_emits = [c for c in event_bus.emit.call_args_list
+                        if c.args and c.args[0] == "browser_metrics"]
+        assert len(metric_emits) == 0
+
+    @pytest.mark.asyncio
+    async def test_poll_noop_without_browser_service(self, tmp_path, monkeypatch):
+        """If container_manager has no browser_service_url, the poll is
+        a silent no-op — mesh configurations without a browser shouldn't
+        log spurious errors."""
+        import httpx
+
+        def boom(*_a, **_k):
+            raise AssertionError("HTTP client should not be called")
+
+        monkeypatch.setattr(httpx.AsyncClient, "get", boom)
+
+        app, event_bus, cm = _build_mesh(tmp_path)
+        cm.browser_service_url = None
+        poll = _extract_poll_fn(app)
+        await poll()
+        assert event_bus.emit.call_count == 0
+
+
+# ── Helpers ─────────────────────────────────────────────────────────
+
+
+def _extract_poll_fn(app):
+    """Locate ``_poll_browser_metrics_once`` in the app's closures.
+
+    ``create_mesh_app`` registers a startup handler named
+    ``_start_browser_metrics_poll`` that schedules
+    ``_browser_metrics_loop`` — which itself closes over
+    ``_poll_browser_metrics_once``. We walk one level of closure to
+    return the poll function directly so tests can invoke it without
+    spinning up the 60s sleep loop.
+    """
+    for handler in app.router.on_startup:
+        if handler.__name__ != "_start_browser_metrics_poll":
+            continue
+        # handler closes over _browser_metrics_loop
+        for cell in (handler.__closure__ or ()):
+            val = cell.cell_contents
+            if callable(val) and getattr(val, "__name__", "") == "_browser_metrics_loop":
+                loop_fn = val
+                break
+        else:
+            continue
+        # loop_fn closes over _poll_browser_metrics_once
+        for cell in (loop_fn.__closure__ or ()):
+            val = cell.cell_contents
+            name = getattr(val, "__name__", "")
+            if callable(val) and name == "_poll_browser_metrics_once":
+                return val
+    return None

--- a/tests/test_browser_service.py
+++ b/tests/test_browser_service.py
@@ -813,6 +813,43 @@ class TestClick:
         result = await mgr.click("a1", ref="e99")
         assert result["success"] is False
 
+    @pytest.mark.asyncio
+    async def test_successful_click_updates_rolling_window(self):
+        """Phase 2 §5.2: every successful click must append ``True`` to
+        ``click_window`` so the dashboard's live success-rate widget
+        reflects the latest 100 outcomes.
+        """
+        from src.browser.service import BrowserManager, CamoufoxInstance
+        mgr = BrowserManager(profiles_dir="/tmp/test_profiles")
+
+        mock_page = AsyncMock()
+        mock_page.click = AsyncMock()
+        inst = CamoufoxInstance("a1", MagicMock(), MagicMock(), mock_page)
+        mgr._instances["a1"] = inst
+
+        await mgr.click("a1", selector="#ok")
+        assert list(inst.click_window) == [True]
+        assert inst.m_click_success == 1
+        assert inst.rolling_click_success_rate() == 1.0
+
+    @pytest.mark.asyncio
+    async def test_failed_click_updates_rolling_window(self):
+        """A click raising an exception must also append to the window
+        (as ``False``) — otherwise failure modes disappear from health."""
+        from src.browser.service import BrowserManager, CamoufoxInstance
+        mgr = BrowserManager(profiles_dir="/tmp/test_profiles")
+
+        mock_page = AsyncMock()
+        mock_page.click = AsyncMock(side_effect=RuntimeError("boom"))
+        inst = CamoufoxInstance("a1", MagicMock(), MagicMock(), mock_page)
+        mgr._instances["a1"] = inst
+
+        result = await mgr.click("a1", selector="#ok")
+        assert result["success"] is False
+        assert list(inst.click_window) == [False]
+        assert inst.m_click_fail == 1
+        assert inst.rolling_click_success_rate() == 0.0
+
 
 class TestScreenshot:
     """Tests for BrowserManager.screenshot()."""


### PR DESCRIPTION
## Summary

Phase 2 observability — §5.1 snapshot p50/p95 + §5.2 rolling click success rate, wired end-to-end to a live dashboard card on the Browser settings sub-tab.

- **Rolling 100-click success rate** on `CamoufoxInstance`. Every click appends to a fixed-size deque; rate is computed on demand. Empty window reads as "unknown" (renders `—`) instead of `0%` so freshly-booted agents aren't flagged as catastrophic.
- **Snapshot p50/p95 + nav-timeout aggregates** per minute. Already existed from Phase 1.6 — this PR fans them out to the dashboard via an in-memory metrics history + mesh poll loop.
- **Dashboard card** on the existing Browser settings tab. Shows agent, click rate (color-coded green/yellow/red), clicks this minute, snapshot p50/p95 bytes, nav timeouts, last update age. Rows fade when data goes stale (>3 min).

## Architecture

Browser service can't push to the mesh's in-process `EventBus`, so the mesh pulls:

```
BrowserManager.drain → _metrics_history (keyed by monotonic seq, maxlen=1024)
  → GET /browser/metrics?since=<seq>    (new, authed)
  → mesh _poll_browser_metrics_once every 60s
  → event_bus.emit("browser_metrics", agent, data)
  → dashboard WS → browserMetrics reactive dict
  → Alpine.js card
```

High-water seq per-boot_id; a browser service restart resets the watermark so no metrics get swallowed. `_stop_instance` writes the final drain into the history buffer even without a sink attached, so short-lived agents still surface their last minute.

## Test plan

- [x] `tests/test_browser_metrics.py` — rolling window math, 100-sample cap, eviction of old entries, persistence across drain, history-buffer `since` filter, endpoint auth, endpoint 422 on invalid `since`
- [x] `tests/test_browser_metrics_ingest.py` (new) — poll emits one `browser_metrics` event per agent payload, idempotency on repeated polls (same seqs ignored), `boot_id` change resets watermark, transport error doesn't crash loop, no-op when browser service absent
- [x] `tests/test_browser_service.py` — click handlers append True/False to rolling window on both success and exception paths
- [x] Full browser + dashboard suites (710 tests) — no regressions
- [x] ruff clean on all modified Python files
- [x] Jinja parse clean; JS syntax clean (`node --check`)