### PR TITLE
Phase 2.3/2.4: behavioral recorder + stealth canary

### DIFF
--- a/src/browser/canary.py
+++ b/src/browser/canary.py
@@ -12,14 +12,24 @@ behavioral-fraud provider. The canary is an early-warning layer, not a
 certification.
 
 **Why a dedicated profile.** The canary visits its targets through the
-same `BrowserManager` as production agents, meaning it inherits every
-stealth tweak in `build_launch_options`, the current profile schema
-version (§4.4 migrate_profile), per-agent fonts, resolution, referrer
-pool — everything. The only thing isolated is the profile directory:
-the canary must not share cookies / localStorage with any production
-agent. That's achieved by giving it a dedicated agent-id
-(:data:`CANARY_AGENT_ID`), so its profile lives under its own
-``/data/profiles/<id>`` path and its cookie jar is its own.
+same `BrowserManager` as production agents, so it inherits every
+launch-time stealth setting from `build_launch_options` (Camoufox
+config, fonts, resolution, referrer pool), the current profile schema
+version (§4.4 migrate_profile), and whatever the operator has active
+in ``config/settings.json``. The isolation is at the profile
+directory only: the canary must not share cookies / localStorage with
+any production agent. That's achieved by giving it a dedicated
+agent-id (:data:`CANARY_AGENT_ID`), so its profile lives under its own
+``/data/profiles/<id>`` path.
+
+**This is a floor estimate, not parity.** A fresh canary profile has
+no browsing history, no storage estimate entropy, no IndexedDB
+entries, and no service-worker registrations — so it will *score
+slightly cleaner* than a 30-day-old production profile on scanners
+that sample those signals. Treat a clean canary score as a necessary
+condition for stealth, not a sufficient one. Real-world detection
+also involves TLS/H2/proxy-IP signals that client-side scanners
+cannot see (see §2.8).
 
 **Default off.** ``BROWSER_CANARY_ENABLED=true`` is required in the
 flags system; the HTTP endpoint returns 403 otherwise. We don't want
@@ -40,6 +50,7 @@ a ``"manual"`` marker — the operator visits the saved screenshot.
 from __future__ import annotations
 
 import asyncio
+import base64
 import contextlib
 import json
 import time
@@ -60,6 +71,24 @@ logger = setup_logging("browser.canary")
 # to match AGENT_ID_RE_PATTERN but be unlikely to collide with any
 # real fleet template.
 CANARY_AGENT_ID = "canary-probe"
+
+# Serialize canary runs so two concurrent force=True callers can't
+# corrupt the state file or race on the single canary profile.
+# Lazy + loop-tracked so tests that construct fresh event loops
+# (pytest-asyncio's function scope) don't hit "Future attached to a
+# different loop". In production there's exactly one loop per process
+# so the rebinding branch never fires.
+_run_lock: asyncio.Lock | None = None
+_run_lock_loop: asyncio.AbstractEventLoop | None = None
+
+
+def _get_run_lock() -> asyncio.Lock:
+    global _run_lock, _run_lock_loop
+    loop = asyncio.get_running_loop()
+    if _run_lock is None or _run_lock_loop is not loop:
+        _run_lock = asyncio.Lock()
+        _run_lock_loop = loop
+    return _run_lock
 
 _SCANNERS: list[dict] = [
     {
@@ -139,6 +168,13 @@ async def run_canary(
     ``force=True``). Any scanner-specific failure is captured in the
     report rather than raised — a canary that crashes on one site
     should still surface signal from the others.
+
+    Serialized via :data:`_RUN_LOCK` so two concurrent ``force=True``
+    callers don't race on the canary profile, state file, or browser
+    slot. The lock is acquired AFTER the flag+rate-limit checks so
+    those still return quickly for callers that can't run right now.
+    Canary teardown runs under ``try/finally`` so a cancelled HTTP
+    request (client disconnect) still releases the profile lock.
     """
     if not canary_enabled():
         raise CanaryDisabledError(
@@ -156,42 +192,63 @@ async def run_canary(
             retry_after_s=int(_MIN_RUN_INTERVAL_S - (now - last_run)),
         )
 
-    report: dict = {
-        "ts": now,
-        "boot_id": manager.boot_id,
-        "agent_id": CANARY_AGENT_ID,
-        "scanners": [],
-    }
+    async with _get_run_lock():
+        # Re-check the rate-limit under the lock so a queue of waiters
+        # doesn't all run sequentially after the holder finishes.
+        state = _read_state(state_path)
+        last_run = float(state.get("last_run_ts", 0) or 0)
+        now = time.time()
+        if not force and now - last_run < _MIN_RUN_INTERVAL_S:
+            raise CanaryRateLimitedError(
+                retry_after_s=int(_MIN_RUN_INTERVAL_S - (now - last_run)),
+            )
 
-    # Stop any lingering canary instance so each run starts fresh on
-    # stealth config (useful when operators iterate on §6.x knobs).
-    with contextlib.suppress(Exception):
-        await manager.stop(CANARY_AGENT_ID)
+        report: dict = {
+            "ts": now,
+            "boot_id": manager.boot_id,
+            "agent_id": CANARY_AGENT_ID,
+            "scanners": [],
+        }
 
-    for scanner in _SCANNERS:
-        entry = await _run_single_scanner(manager, scanner, report_dir, now)
-        report["scanners"].append(entry)
+        # Stop any lingering canary instance so each run starts fresh on
+        # stealth config (useful when operators iterate on §6.x knobs).
+        with contextlib.suppress(Exception):
+            await manager.stop(CANARY_AGENT_ID)
 
-    # Stop canary after the sweep to release the profile lock and free
-    # its browser slot. A future run will respawn cleanly.
-    with contextlib.suppress(Exception):
-        await manager.stop(CANARY_AGENT_ID)
+        try:
+            for scanner in _SCANNERS:
+                entry = await _run_single_scanner(
+                    manager, scanner, report_dir, now,
+                )
+                report["scanners"].append(entry)
+        finally:
+            # Always attempt to stop the canary — a cancelled HTTP
+            # request (client disconnect) mustn't leave the Camoufox
+            # profile locked. ``asyncio.shield`` protects the stop
+            # from our own CancelledError so the cleanup task runs
+            # to completion even if the outer caller gives up; the
+            # ``suppress(Exception)`` handles real errors without
+            # touching CancelledError (which still propagates, as
+            # it must, so the caller knows we were cancelled).
+            with contextlib.suppress(Exception):
+                await asyncio.shield(manager.stop(CANARY_AGENT_ID))
 
-    # Heuristic overall score: average of scanner scores that produced a
-    # numeric value. Callers should treat this as a smoke-test signal,
-    # not a certification — operators read per-scanner details.
-    numeric_scores = [
-        s["score"] for s in report["scanners"]
-        if isinstance(s.get("score"), (int, float))
-    ]
-    report["overall_score"] = (
-        sum(numeric_scores) / len(numeric_scores) if numeric_scores else None
-    )
+        # Heuristic overall score: average of scanner scores that produced
+        # a numeric value. Callers should treat this as a smoke-test
+        # signal, not a certification — operators read per-scanner detail.
+        numeric_scores = [
+            s["score"] for s in report["scanners"]
+            if isinstance(s.get("score"), (int, float))
+        ]
+        report["overall_score"] = (
+            sum(numeric_scores) / len(numeric_scores)
+            if numeric_scores else None
+        )
 
-    state["last_run_ts"] = now
-    state["last_overall_score"] = report["overall_score"]
-    _write_state(state_path, state)
-    return report
+        state["last_run_ts"] = now
+        state["last_overall_score"] = report["overall_score"]
+        _write_state(state_path, state)
+        return report
 
 
 async def _run_single_scanner(
@@ -200,10 +257,21 @@ async def _run_single_scanner(
     report_dir: Path,
     ts: float,
 ) -> dict:
-    """Navigate + screenshot one scanner; never raises."""
+    """Navigate + screenshot one scanner; never raises.
+
+    Status progression: ``unknown`` → ``nav_failed`` / ``timeout`` /
+    ``error`` (on navigate), or → ``ok`` (navigate succeeded). Parse
+    and screenshot failures are tracked separately under
+    ``parse_error`` / ``screenshot_error`` so a bad score-extractor
+    doesn't mask a successful nav — operators debugging a specific
+    scanner need to know nav DID succeed before they chase the
+    wrong symptom.
+    """
     name = scanner["name"]
     url = scanner["url"]
     entry: dict = {"name": name, "url": url, "status": "unknown"}
+
+    # Navigate phase — the only phase that sets a non-ok status.
     try:
         nav = await asyncio.wait_for(
             manager.navigate(
@@ -214,35 +282,42 @@ async def _run_single_scanner(
             ),
             timeout=45,
         )
-        if not nav.get("success"):
-            entry["status"] = "nav_failed"
-            entry["error"] = nav.get("error", "")[:200]
-            return entry
-        entry["status"] = "ok"
-
-        shot = await manager.screenshot(CANARY_AGENT_ID, full_page=True)
-        if shot.get("success"):
-            try:
-                report_dir.mkdir(parents=True, exist_ok=True)
-                path = report_dir / f"{int(ts)}-{name}.png"
-                # Decode base64 back to bytes for disk.
-                import base64
-                path.write_bytes(base64.b64decode(
-                    shot["data"]["image_base64"],
-                ))
-                entry["screenshot_path"] = str(path)
-            except OSError as e:
-                logger.warning("Canary screenshot save failed: %s", e)
-
-        # Per-scanner score parsing is best-effort; we don't throw on
-        # parse failures. When we can't extract a numeric score, leave
-        # it as None so the overall average skips this entry.
-        entry["score"] = await _parse_scanner_score(manager, name)
     except asyncio.TimeoutError:
         entry["status"] = "timeout"
+        return entry
     except Exception as e:  # noqa: BLE001 — best-effort per-scanner
         entry["status"] = "error"
         entry["error"] = str(e)[:200]
+        return entry
+
+    if not nav.get("success"):
+        entry["status"] = "nav_failed"
+        entry["error"] = (nav.get("error") or "")[:200]
+        return entry
+    entry["status"] = "ok"
+
+    # Screenshot phase — failures here annotate the entry but don't
+    # demote status. A page that navigated but can't screenshot is
+    # still useful signal; operators read the status first.
+    try:
+        shot = await manager.screenshot(CANARY_AGENT_ID, full_page=True)
+        if shot.get("success"):
+            report_dir.mkdir(parents=True, exist_ok=True)
+            path = report_dir / f"{int(ts)}-{name}.png"
+            path.write_bytes(base64.b64decode(shot["data"]["image_base64"]))
+            entry["screenshot_path"] = str(path)
+    except Exception as e:  # noqa: BLE001
+        entry["screenshot_error"] = str(e)[:200]
+
+    # Parse phase — score extraction is best-effort per-site. Parse
+    # failures do NOT demote status from "ok" because the nav DID
+    # succeed; mark them separately so a stale DOM selector doesn't
+    # surface as a mystery "error" row.
+    try:
+        entry["score"] = await _parse_scanner_score(manager, name)
+    except Exception as e:  # noqa: BLE001
+        entry["score"] = None
+        entry["parse_error"] = str(e)[:200]
     return entry
 
 

--- a/src/browser/canary.py
+++ b/src/browser/canary.py
@@ -1,0 +1,276 @@
+"""Stealth canary runner (Phase 2 §5.4) — operator opt-in.
+
+Drives a dedicated Camoufox profile against a small set of public
+stealth-scanner sites so operators can detect fingerprint regressions
+before customer traffic notices them.
+
+**Scope (important):** canary scanners inspect *client-side JS*
+fingerprints only. TLS, H2, and network-layer signals (JA3/JA4, TCP
+fingerprinting, proxy IP reputation) are invisible to these sites; a
+clean canary score does NOT guarantee clean traffic against a
+behavioral-fraud provider. The canary is an early-warning layer, not a
+certification.
+
+**Why a dedicated profile.** The canary visits its targets through the
+same `BrowserManager` as production agents, meaning it inherits every
+stealth tweak in `build_launch_options`, the current profile schema
+version (§4.4 migrate_profile), per-agent fonts, resolution, referrer
+pool — everything. The only thing isolated is the profile directory:
+the canary must not share cookies / localStorage with any production
+agent. That's achieved by giving it a dedicated agent-id
+(:data:`CANARY_AGENT_ID`), so its profile lives under its own
+``/data/profiles/<id>`` path and its cookie jar is its own.
+
+**Default off.** ``BROWSER_CANARY_ENABLED=true`` is required in the
+flags system; the HTTP endpoint returns 403 otherwise. We don't want
+customer fleets hammering these scanners — some of them are run by
+small teams on donated infrastructure, and a 1000-agent customer
+generating one run per browser restart would be abuse.
+
+**Rate limit.** One run per 23 hours by default, persisted to disk so
+restarts don't reset the counter. Operators can force a run with
+``force=True`` if they're actively debugging; the caller is expected
+to have operator-level access at the mesh layer.
+
+**Score.** Each scanner contributes a raw signals dict plus an optional
+0-100 score when we can parse one. Sites we can't parse contribute
+a ``"manual"`` marker — the operator visits the saved screenshot.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import json
+import time
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from src.browser.flags import get_bool
+from src.shared.utils import setup_logging
+
+if TYPE_CHECKING:
+    from src.browser.service import BrowserManager
+
+logger = setup_logging("browser.canary")
+
+
+# The canary uses a stable agent-id so its profile survives across
+# runs (faster startup, better cookie / cache warmup realism). Chosen
+# to match AGENT_ID_RE_PATTERN but be unlikely to collide with any
+# real fleet template.
+CANARY_AGENT_ID = "canary-probe"
+
+_SCANNERS: list[dict] = [
+    {
+        "name": "bot.sannysoft.com",
+        "url": "https://bot.sannysoft.com/",
+        "wait_until": "load",
+        "wait_ms": 2000,
+    },
+    {
+        "name": "creepjs",
+        "url": "https://abrahamjuliot.github.io/creepjs/",
+        "wait_until": "networkidle",
+        "wait_ms": 8000,
+    },
+    {
+        "name": "fingerprint.com",
+        "url": "https://fingerprint.com/products/bot-detection/",
+        "wait_until": "networkidle",
+        "wait_ms": 4000,
+    },
+    {
+        "name": "pixelscan.net",
+        "url": "https://www.pixelscan.net/",
+        "wait_until": "networkidle",
+        "wait_ms": 6000,
+    },
+]
+
+_DEFAULT_STATE_PATH = Path("/data/canary/state.json")
+_DEFAULT_REPORT_DIR = Path("/data/canary/reports")
+_MIN_RUN_INTERVAL_S = 23 * 3600  # one run per ~day
+
+
+class CanaryDisabledError(RuntimeError):
+    """Raised when the canary is called but BROWSER_CANARY_ENABLED is false."""
+
+
+class CanaryRateLimitedError(RuntimeError):
+    """Raised when a canary run is attempted too soon after the previous run."""
+
+    def __init__(self, retry_after_s: int):
+        super().__init__(f"canary rate-limited; retry in {retry_after_s}s")
+        self.retry_after_s = retry_after_s
+
+
+def canary_enabled() -> bool:
+    """Single read point; see :mod:`src.browser.flags`."""
+    return get_bool("BROWSER_CANARY_ENABLED", default=False)
+
+
+def _read_state(path: Path) -> dict:
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except (FileNotFoundError, json.JSONDecodeError):
+        return {}
+
+
+def _write_state(path: Path, state: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_suffix(".json.partial")
+    tmp.write_text(json.dumps(state), encoding="utf-8")
+    tmp.replace(path)
+
+
+async def run_canary(
+    manager: BrowserManager,
+    *,
+    force: bool = False,
+    state_path: Path | None = None,
+    report_dir: Path | None = None,
+) -> dict:
+    """Run the canary scan and return a structured report.
+
+    Raises :class:`CanaryDisabledError` when the feature flag is off,
+    :class:`CanaryRateLimitedError` when called within
+    ``_MIN_RUN_INTERVAL_S`` of the previous successful run (unless
+    ``force=True``). Any scanner-specific failure is captured in the
+    report rather than raised — a canary that crashes on one site
+    should still surface signal from the others.
+    """
+    if not canary_enabled():
+        raise CanaryDisabledError(
+            "BROWSER_CANARY_ENABLED is false — operator opt-in required",
+        )
+
+    state_path = state_path or _DEFAULT_STATE_PATH
+    report_dir = report_dir or _DEFAULT_REPORT_DIR
+
+    state = _read_state(state_path)
+    last_run = float(state.get("last_run_ts", 0) or 0)
+    now = time.time()
+    if not force and now - last_run < _MIN_RUN_INTERVAL_S:
+        raise CanaryRateLimitedError(
+            retry_after_s=int(_MIN_RUN_INTERVAL_S - (now - last_run)),
+        )
+
+    report: dict = {
+        "ts": now,
+        "boot_id": manager.boot_id,
+        "agent_id": CANARY_AGENT_ID,
+        "scanners": [],
+    }
+
+    # Stop any lingering canary instance so each run starts fresh on
+    # stealth config (useful when operators iterate on §6.x knobs).
+    with contextlib.suppress(Exception):
+        await manager.stop(CANARY_AGENT_ID)
+
+    for scanner in _SCANNERS:
+        entry = await _run_single_scanner(manager, scanner, report_dir, now)
+        report["scanners"].append(entry)
+
+    # Stop canary after the sweep to release the profile lock and free
+    # its browser slot. A future run will respawn cleanly.
+    with contextlib.suppress(Exception):
+        await manager.stop(CANARY_AGENT_ID)
+
+    # Heuristic overall score: average of scanner scores that produced a
+    # numeric value. Callers should treat this as a smoke-test signal,
+    # not a certification — operators read per-scanner details.
+    numeric_scores = [
+        s["score"] for s in report["scanners"]
+        if isinstance(s.get("score"), (int, float))
+    ]
+    report["overall_score"] = (
+        sum(numeric_scores) / len(numeric_scores) if numeric_scores else None
+    )
+
+    state["last_run_ts"] = now
+    state["last_overall_score"] = report["overall_score"]
+    _write_state(state_path, state)
+    return report
+
+
+async def _run_single_scanner(
+    manager: BrowserManager,
+    scanner: dict,
+    report_dir: Path,
+    ts: float,
+) -> dict:
+    """Navigate + screenshot one scanner; never raises."""
+    name = scanner["name"]
+    url = scanner["url"]
+    entry: dict = {"name": name, "url": url, "status": "unknown"}
+    try:
+        nav = await asyncio.wait_for(
+            manager.navigate(
+                CANARY_AGENT_ID,
+                url,
+                wait_ms=scanner["wait_ms"],
+                wait_until=scanner["wait_until"],
+            ),
+            timeout=45,
+        )
+        if not nav.get("success"):
+            entry["status"] = "nav_failed"
+            entry["error"] = nav.get("error", "")[:200]
+            return entry
+        entry["status"] = "ok"
+
+        shot = await manager.screenshot(CANARY_AGENT_ID, full_page=True)
+        if shot.get("success"):
+            try:
+                report_dir.mkdir(parents=True, exist_ok=True)
+                path = report_dir / f"{int(ts)}-{name}.png"
+                # Decode base64 back to bytes for disk.
+                import base64
+                path.write_bytes(base64.b64decode(
+                    shot["data"]["image_base64"],
+                ))
+                entry["screenshot_path"] = str(path)
+            except OSError as e:
+                logger.warning("Canary screenshot save failed: %s", e)
+
+        # Per-scanner score parsing is best-effort; we don't throw on
+        # parse failures. When we can't extract a numeric score, leave
+        # it as None so the overall average skips this entry.
+        entry["score"] = await _parse_scanner_score(manager, name)
+    except asyncio.TimeoutError:
+        entry["status"] = "timeout"
+    except Exception as e:  # noqa: BLE001 — best-effort per-scanner
+        entry["status"] = "error"
+        entry["error"] = str(e)[:200]
+    return entry
+
+
+async def _parse_scanner_score(manager, name: str) -> float | None:
+    """Try to pull a 0-100 score out of the page DOM.
+
+    Scanner HTML is a moving target; this is best-effort. When a scanner
+    redesigns, the operator sees a dropped-to-None score on the next run
+    and we update the selector. Keeping the logic site-specific and
+    defensive is the right trade-off — a single generic parser would be
+    brittle in the other direction.
+    """
+    if name == "bot.sannysoft.com":
+        # Sannysoft reports each test as .passed / .failed rows. Count
+        # passes vs total as a rough score.
+        snap = await manager.evaluate(
+            CANARY_AGENT_ID,
+            "() => ({"
+            " pass: document.querySelectorAll('.passed').length,"
+            " fail: document.querySelectorAll('.failed').length"
+            "})",
+        )
+        if snap.get("success"):
+            r = snap["data"].get("result") or {}
+            p = int(r.get("pass", 0))
+            f = int(r.get("fail", 0))
+            if p + f > 0:
+                return round(100.0 * p / (p + f), 1)
+    # Other scanners: no reliable machine-readable score — defer to the
+    # saved screenshot for manual review.
+    return None

--- a/src/browser/recorder.py
+++ b/src/browser/recorder.py
@@ -26,6 +26,7 @@ from __future__ import annotations
 
 import json
 import os
+import secrets
 import time
 from collections import deque
 from pathlib import Path
@@ -55,6 +56,12 @@ class BehaviorRecorder:
 
     When disabled, ``record_*`` methods short-circuit to a single
     boolean check — zero allocation. Safe to construct unconditionally.
+
+    The enabled flag is re-read on each append via :func:`recorder_enabled`
+    so operator-level toggles (env var flip, dashboard settings) take
+    effect without requiring an agent reset. The check reads through
+    :mod:`src.browser.flags` which caches operator settings and falls
+    back to ``os.environ.get`` — cheap.
     """
 
     def __init__(
@@ -65,7 +72,6 @@ class BehaviorRecorder:
         dump_dir: Path | None = None,
     ):
         self.agent_id = agent_id
-        self._enabled = recorder_enabled()
         self._events: deque[dict] = deque(maxlen=buffer_size)
         self._dump_dir = dump_dir or _DEFAULT_DUMP_DIR
         # Track last event timestamp to compute inter-event intervals
@@ -74,14 +80,14 @@ class BehaviorRecorder:
 
     @property
     def enabled(self) -> bool:
-        return self._enabled
+        return recorder_enabled()
 
     def __len__(self) -> int:
         return len(self._events)
 
     def _append(self, kind: str, **fields: Any) -> None:
         """Shared append path — stamps timestamp + interval."""
-        if not self._enabled:
+        if not recorder_enabled():
             return
         now = time.time()
         interval = None if self._last_ts is None else round(now - self._last_ts, 6)
@@ -94,20 +100,9 @@ class BehaviorRecorder:
         }
         self._events.append(event)
 
-    def record_click(
-        self,
-        *,
-        method: str,
-        success: bool,
-        dwell_ms: int | None = None,
-    ) -> None:
-        """``method`` = 'x11' | 'cdp' | 'playwright'."""
-        self._append(
-            "click",
-            method=method,
-            success=success,
-            dwell_ms=dwell_ms,
-        )
+    def record_click(self, *, method: str, success: bool) -> None:
+        """``method`` = 'x11' | 'cdp' | 'auto' | 'playwright'."""
+        self._append("click", method=method, success=success)
 
     def record_keystrokes(
         self,
@@ -149,13 +144,16 @@ class BehaviorRecorder:
         self._append("navigate", host=host, wait_until=wait_until)
 
     def dump(self, *, reason: str = "reset") -> Path | None:
-        """Flush the buffer to ``/data/debug/{agent}-{ts}.jsonl``.
+        """Flush the buffer to ``/data/debug/{agent}-{ts}-{rand}.jsonl``.
 
         Returns the written path on success, ``None`` on failure or
-        when disabled / empty. Failures never propagate — recorder is
-        strictly diagnostic.
+        when the buffer is empty. Failures never propagate — the
+        recorder is strictly diagnostic. We don't re-check the enabled
+        flag on dump: if there are events in the buffer, they were
+        recorded while enabled and must not be silently discarded
+        because the operator flipped the flag off in the interim.
         """
-        if not self._enabled or not self._events:
+        if not self._events:
             return None
         try:
             self._dump_dir.mkdir(parents=True, exist_ok=True)
@@ -174,7 +172,13 @@ class BehaviorRecorder:
 
         ts = int(time.time())
         safe_agent = _sanitize_filename(self.agent_id)
-        target = self._dump_dir / f"{safe_agent}-{ts}.jsonl"
+        # Append a short random suffix so two dumps within the same
+        # second for the same agent (force-reset twice in quick
+        # succession, tests, rapid LRU churn) don't overwrite each
+        # other via ``os.replace``. 4 bytes = 8 hex chars, ~1-in-4B
+        # collision odds.
+        suffix = secrets.token_hex(4)
+        target = self._dump_dir / f"{safe_agent}-{ts}-{suffix}.jsonl"
         try:
             # Write via a `.partial` file + rename so a crashed dump
             # doesn't leave half-written records next to good ones.

--- a/src/browser/recorder.py
+++ b/src/browser/recorder.py
@@ -1,0 +1,208 @@
+"""Behavioral entropy recorder (Phase 2 §5.3) — dev-only.
+
+Captures input-event timestamps and basic shape metadata for later
+offline analysis (§9.5 builds an entropy analyzer on top). Enabled via
+``BROWSER_RECORD_BEHAVIOR=1``; otherwise every method is a cheap no-op
+so the hot path (click/type/scroll/navigate) pays no cost in production.
+
+**Privacy**: we never record the *content* of keystrokes or typed text.
+For a keystroke or ``type_text`` call we store the length and inter-key
+interval only. URL fragments and query strings are also dropped before
+they reach disk — the goal is to analyze *timing distributions*, not
+what the agent did.
+
+The buffer is a bounded deque (default 10 000 events per instance). On
+``dump()`` the buffer is flushed to ``/data/debug/{agent}-{ts}.jsonl``
+(one event per line, ``jsonl`` so ``jq`` can stream it) and cleared.
+``dump()`` runs from ``CamoufoxInstance`` teardown paths (explicit
+reset, idle stop), so a running browser never blocks on disk I/O.
+
+Directory creation is best-effort. If ``/data/debug`` can't be created
+(read-only FS, unit-test environment), ``dump()`` logs and returns
+silently — a missing dump is strictly better than crashing the reset.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import time
+from collections import deque
+from pathlib import Path
+from typing import Any
+
+from src.browser.flags import get_bool
+from src.shared.utils import setup_logging
+
+logger = setup_logging("browser.recorder")
+
+
+_DEFAULT_BUFFER_SIZE = 10_000
+_DEFAULT_DUMP_DIR = Path("/data/debug")
+
+
+def recorder_enabled() -> bool:
+    """Single read point for the feature flag.
+
+    Goes through :mod:`src.browser.flags` so operator overrides and
+    dashboard toggles work the same way as every other browser knob.
+    """
+    return get_bool("BROWSER_RECORD_BEHAVIOR", default=False)
+
+
+class BehaviorRecorder:
+    """Per-instance ring buffer of input-event shape metadata.
+
+    When disabled, ``record_*`` methods short-circuit to a single
+    boolean check — zero allocation. Safe to construct unconditionally.
+    """
+
+    def __init__(
+        self,
+        agent_id: str,
+        *,
+        buffer_size: int = _DEFAULT_BUFFER_SIZE,
+        dump_dir: Path | None = None,
+    ):
+        self.agent_id = agent_id
+        self._enabled = recorder_enabled()
+        self._events: deque[dict] = deque(maxlen=buffer_size)
+        self._dump_dir = dump_dir or _DEFAULT_DUMP_DIR
+        # Track last event timestamp to compute inter-event intervals
+        # cheaply without a full-buffer scan.
+        self._last_ts: float | None = None
+
+    @property
+    def enabled(self) -> bool:
+        return self._enabled
+
+    def __len__(self) -> int:
+        return len(self._events)
+
+    def _append(self, kind: str, **fields: Any) -> None:
+        """Shared append path — stamps timestamp + interval."""
+        if not self._enabled:
+            return
+        now = time.time()
+        interval = None if self._last_ts is None else round(now - self._last_ts, 6)
+        self._last_ts = now
+        event = {
+            "ts": round(now, 6),
+            "interval_s": interval,
+            "type": kind,
+            **fields,
+        }
+        self._events.append(event)
+
+    def record_click(
+        self,
+        *,
+        method: str,
+        success: bool,
+        dwell_ms: int | None = None,
+    ) -> None:
+        """``method`` = 'x11' | 'cdp' | 'playwright'."""
+        self._append(
+            "click",
+            method=method,
+            success=success,
+            dwell_ms=dwell_ms,
+        )
+
+    def record_keystrokes(
+        self,
+        *,
+        char_count: int,
+        fast: bool,
+        method: str,
+    ) -> None:
+        """Record a bulk ``type_text`` invocation.
+
+        We intentionally do NOT store individual key intervals — that
+        would bloat the buffer and the per-key distribution is better
+        captured by instrumenting the humanize layer directly (which
+        §9.5 handles offline from Camoufox logs).
+        """
+        self._append(
+            "keystrokes",
+            char_count=int(char_count),
+            fast=bool(fast),
+            method=method,
+        )
+
+    def record_scroll(
+        self,
+        *,
+        direction: str,
+        delta: int | None,
+        method: str,
+    ) -> None:
+        self._append("scroll", direction=direction, delta=delta, method=method)
+
+    def record_navigate(self, *, host: str, wait_until: str) -> None:
+        """Record only the host, never the full URL.
+
+        Query strings and fragments routinely carry secrets (OAuth
+        codes, SigV4 signatures, magic-link tokens). The entropy
+        analyzer cares about nav cadence, not destinations.
+        """
+        self._append("navigate", host=host, wait_until=wait_until)
+
+    def dump(self, *, reason: str = "reset") -> Path | None:
+        """Flush the buffer to ``/data/debug/{agent}-{ts}.jsonl``.
+
+        Returns the written path on success, ``None`` on failure or
+        when disabled / empty. Failures never propagate — recorder is
+        strictly diagnostic.
+        """
+        if not self._enabled or not self._events:
+            return None
+        try:
+            self._dump_dir.mkdir(parents=True, exist_ok=True)
+        except OSError as e:
+            logger.warning(
+                "Recorder dump: cannot create %s: %s", self._dump_dir, e,
+            )
+            return None
+
+        # Snapshot and clear the buffer atomically-ish — we're single-
+        # threaded within an agent's lock, so this can't race against
+        # record_* calls from this instance.
+        events = list(self._events)
+        self._events.clear()
+        self._last_ts = None
+
+        ts = int(time.time())
+        safe_agent = _sanitize_filename(self.agent_id)
+        target = self._dump_dir / f"{safe_agent}-{ts}.jsonl"
+        try:
+            # Write via a `.partial` file + rename so a crashed dump
+            # doesn't leave half-written records next to good ones.
+            partial = target.with_suffix(".jsonl.partial")
+            with open(partial, "w", encoding="utf-8") as f:
+                # Leading header so offline tools can sniff the format.
+                f.write(json.dumps({
+                    "schema": "openlegion.browser.recorder/v1",
+                    "agent": self.agent_id,
+                    "reason": reason,
+                    "event_count": len(events),
+                }) + "\n")
+                for ev in events:
+                    f.write(json.dumps(ev, separators=(",", ":")) + "\n")
+            os.replace(partial, target)
+        except OSError as e:
+            logger.warning("Recorder dump write failed for %s: %s", target, e)
+            return None
+        logger.debug(
+            "Recorder dumped %d events for '%s' → %s",
+            len(events), self.agent_id, target,
+        )
+        return target
+
+
+def _sanitize_filename(name: str) -> str:
+    """Reduce an agent id to a filesystem-safe token."""
+    # Agent ids already match AGENT_ID_RE_PATTERN (alnum + hyphen +
+    # underscore) but be defensive against injected test values.
+    out = "".join(c if c.isalnum() or c in "-_" else "_" for c in name)
+    return out[:64] or "agent"

--- a/src/browser/recorder.py
+++ b/src/browser/recorder.py
@@ -40,6 +40,14 @@ logger = setup_logging("browser.recorder")
 
 _DEFAULT_BUFFER_SIZE = 10_000
 _DEFAULT_DUMP_DIR = Path("/data/debug")
+# Cap on dump files retained per directory. At roughly one dump per
+# agent stop and N agents churning, a long-running dev session with
+# the recorder enabled could otherwise fill the disk — the in-memory
+# ring buffer caps per-file size, but nothing else caps file count.
+# Operators who want a full trace archive can move files out of
+# ``/data/debug`` between runs; the cleanup only prunes within its
+# managed directory.
+_MAX_DUMP_FILES = 1000
 
 
 def recorder_enabled() -> bool:
@@ -201,7 +209,39 @@ class BehaviorRecorder:
             "Recorder dumped %d events for '%s' → %s",
             len(events), self.agent_id, target,
         )
+        _prune_old_dumps(self._dump_dir)
         return target
+
+
+def _prune_old_dumps(dump_dir: Path, max_files: int | None = None) -> None:
+    """Keep only the N most recent ``*.jsonl`` dumps in ``dump_dir``.
+
+    Best-effort: if listing / unlinking fails we log at DEBUG and move
+    on — a disk-full condition during pruning is itself the problem
+    we're trying to prevent, and surfacing it noisily would obscure
+    that. Any .partial files are ignored (they might be a concurrent
+    write in progress) so we only prune finalized dumps.
+
+    ``max_files`` is read from the module-level constant at call time
+    (not captured as a default) so tests and operators can adjust it
+    without re-importing.
+    """
+    cap = _MAX_DUMP_FILES if max_files is None else max_files
+    try:
+        files = [f for f in dump_dir.iterdir() if f.suffix == ".jsonl"]
+    except OSError as e:
+        logger.debug("Recorder prune: cannot list %s: %s", dump_dir, e)
+        return
+    if len(files) <= cap:
+        return
+    # Sort oldest-first by mtime; delete until we're at the cap.
+    files.sort(key=lambda p: p.stat().st_mtime if p.exists() else 0)
+    excess = len(files) - cap
+    for victim in files[:excess]:
+        try:
+            victim.unlink()
+        except OSError as e:
+            logger.debug("Recorder prune: unlink %s failed: %s", victim, e)
 
 
 def _sanitize_filename(name: str) -> str:

--- a/src/browser/server.py
+++ b/src/browser/server.py
@@ -7,6 +7,7 @@ Exposes per-agent browser control endpoints. Auth via Bearer token
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import hmac
 import json
 import os
@@ -70,6 +71,39 @@ def create_browser_app(manager: BrowserManager, lifespan=None) -> FastAPI:
     async def service_status(request: Request):
         _verify_auth(request)
         return await manager.get_service_status()
+
+    @app.post("/browser/_canary")
+    async def run_canary_endpoint(request: Request):
+        """Phase 2 §5.4: run the stealth canary on demand.
+
+        Gated by ``BROWSER_CANARY_ENABLED`` — returns 403 when the flag
+        is off. Rate-limited to 1 run / ~24h across the service; passing
+        ``{"force": true}`` bypasses the rate limit for operator-triggered
+        debug runs.
+
+        Output: a structured report with per-scanner status, saved
+        screenshots, and best-effort numeric score when parseable.
+        Never raises on individual scanner failure — the remaining
+        sites still run.
+        """
+        _verify_auth(request)
+        from src.browser.canary import (
+            CanaryDisabledError,
+            CanaryRateLimitedError,
+            run_canary,
+        )
+        body: dict = {}
+        with contextlib.suppress(Exception):
+            body = await request.json()
+        try:
+            return await run_canary(manager, force=bool(body.get("force")))
+        except CanaryDisabledError as e:
+            raise HTTPException(403, str(e))
+        except CanaryRateLimitedError as e:
+            raise HTTPException(
+                429,
+                detail={"error": str(e), "retry_after_s": e.retry_after_s},
+            )
 
     @app.post("/browser/keepalive")
     async def keepalive(request: Request):

--- a/src/browser/service.py
+++ b/src/browser/service.py
@@ -336,6 +336,11 @@ class CamoufoxInstance:
         self.m_click_fail: int = 0
         self.m_nav_timeout: int = 0
         self.m_snapshot_bytes: list[int] = []
+        # §5.3 behavioral entropy recorder (dev-only). Always constructed;
+        # every record_* call short-circuits when the feature flag is
+        # off so production pays no cost.
+        from src.browser.recorder import BehaviorRecorder
+        self.recorder = BehaviorRecorder(agent_id)
 
     def _register_page(self, page) -> str:
         """Assign a stable UUID to a Page if not already registered.
@@ -784,6 +789,17 @@ class BrowserManager:
         jitter = getattr(inst, '_jitter_task', None)
         if jitter:
             jitter.cancel()
+        # §5.3 dump the behavior recorder buffer (no-op when disabled or
+        # empty). Runs before ``context.close()`` so a hung browser close
+        # doesn't eat the diagnostic data.
+        recorder = getattr(inst, "recorder", None)
+        if recorder is not None:
+            try:
+                recorder.dump(reason="stop")
+            except Exception as e:
+                logger.debug(
+                    "Recorder dump failed for '%s': %s", agent_id, e,
+                )
         try:
             await inst.context.close()
         except Exception as e:
@@ -979,6 +995,12 @@ class BrowserManager:
                     if "timeout" in str(e).lower():
                         inst.m_nav_timeout += 1
                     return {"success": False, "error": str(e)}
+
+            # §5.3 recorder: log host only, never the full URL — query
+            # strings and fragments routinely carry secrets.
+            inst.recorder.record_navigate(
+                host=parsed.hostname or "", wait_until=wait_until,
+            )
 
             inst.dialog_active = False
             inst.dialog_detected = False
@@ -1985,6 +2007,10 @@ class BrowserManager:
                                 pass
 
                 inst.m_click_success += 1
+                # Recorder doesn't need the x11/cdp routing detail —
+                # the click dispatch chooses internally and the timing
+                # distribution is what §5.3/§9.5 consumes.
+                inst.recorder.record_click(method="auto", success=True)
                 result = {"success": True, "data": {"clicked": ref or selector}}
                 if snapshot_after:
                     snap = await self._snapshot_impl(inst, agent_id)
@@ -1992,6 +2018,7 @@ class BrowserManager:
                 return result
             except Exception as e:
                 inst.m_click_fail += 1
+                inst.recorder.record_click(method="auto", success=False)
                 return {"success": False, "error": str(e)}
 
     async def hover(
@@ -2133,6 +2160,11 @@ class BrowserManager:
                 # batches DOM reconciliation asynchronously.
                 await asyncio.sleep(0.10 if fast else action_delay())
 
+                inst.recorder.record_keystrokes(
+                    char_count=len(text),
+                    fast=fast,
+                    method="x11" if _use_x11 else ("cdp-fast" if fast else "cdp"),
+                )
                 result = {"success": True, "data": {"typed_into": ref or selector, "length": len(text)}}
                 if snapshot_after:
                     snap = await self._snapshot_impl(inst, agent_id)
@@ -2326,6 +2358,11 @@ class BrowserManager:
                         if scrolled < amount:
                             await asyncio.sleep(scroll_pause() / max(0.5, ramp))
 
+                inst.recorder.record_scroll(
+                    direction=direction,
+                    delta=scrolled,
+                    method="x11" if _use_x11 else "cdp",
+                )
                 return {
                     "success": True,
                     "data": {"direction": direction, "pixels": scrolled},

--- a/src/browser/service.py
+++ b/src/browser/service.py
@@ -791,11 +791,16 @@ class BrowserManager:
             jitter.cancel()
         # §5.3 dump the behavior recorder buffer (no-op when disabled or
         # empty). Runs before ``context.close()`` so a hung browser close
-        # doesn't eat the diagnostic data.
+        # doesn't eat the diagnostic data. Acquire ``inst.lock`` first so
+        # any in-flight click/type/scroll/navigate on this instance
+        # finishes its ``record_*`` append BEFORE we flush — otherwise
+        # the last 1-2 events land in the deque after the dump has
+        # already cleared it and are silently lost.
         recorder = getattr(inst, "recorder", None)
         if recorder is not None:
             try:
-                recorder.dump(reason="stop")
+                async with inst.lock:
+                    recorder.dump(reason="stop")
             except Exception as e:
                 logger.debug(
                     "Recorder dump failed for '%s': %s", agent_id, e,

--- a/src/shared/types.py
+++ b/src/shared/types.py
@@ -22,8 +22,14 @@ def _generate_id(prefix: str, length: int = 12) -> str:
 SILENT_REPLY_TOKEN = "__SILENT__"
 """Sentinel returned by agents to suppress empty responses."""
 
-RESERVED_AGENT_IDS = frozenset({"mesh", "operator"})
-"""Internal component names that must not be used as agent IDs."""
+RESERVED_AGENT_IDS = frozenset({"mesh", "operator", "canary-probe"})
+"""Internal component names that must not be used as agent IDs.
+
+``canary-probe`` is the stable agent-id used by the stealth canary
+(§5.4) for its dedicated profile. Reserving it prevents a user from
+creating a real agent with the same id — which would otherwise have
+its profile silently stomped the next time an operator ran the canary.
+"""
 
 AGENT_ID_RE_PATTERN = r"^[a-zA-Z0-9][a-zA-Z0-9_-]{0,63}$"
 """Canonical agent ID regex — 1-64 chars, alphanumeric start, then alphanumeric/hyphen/underscore."""

--- a/tests/test_browser_canary.py
+++ b/tests/test_browser_canary.py
@@ -1,0 +1,248 @@
+"""Tests for the stealth canary (Phase 2 §5.4)."""
+
+from __future__ import annotations
+
+import json
+import time
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+
+def _enable_canary(monkeypatch):
+    monkeypatch.setenv("BROWSER_CANARY_ENABLED", "true")
+    import src.browser.flags as flags
+    flags._operator_settings = None
+
+
+def _disable_canary(monkeypatch):
+    monkeypatch.delenv("BROWSER_CANARY_ENABLED", raising=False)
+    import src.browser.flags as flags
+    flags._operator_settings = None
+
+
+def _make_manager_mock():
+    """Manager that satisfies run_canary's touch points."""
+    mgr = MagicMock()
+    mgr.boot_id = "boot-1"
+    mgr.navigate = AsyncMock(return_value={"success": True})
+    mgr.screenshot = AsyncMock(return_value={
+        "success": True,
+        "data": {"image_base64": "", "format": "png"},
+    })
+    mgr.evaluate = AsyncMock(return_value={
+        "success": True, "data": {"result": {"pass": 10, "fail": 0}},
+    })
+    mgr.stop = AsyncMock()
+    return mgr
+
+
+class TestFeatureGate:
+    @pytest.mark.asyncio
+    async def test_raises_when_disabled(self, monkeypatch, tmp_path):
+        from src.browser.canary import CanaryDisabledError, run_canary
+        _disable_canary(monkeypatch)
+        mgr = _make_manager_mock()
+        with pytest.raises(CanaryDisabledError):
+            await run_canary(
+                mgr,
+                state_path=tmp_path / "state.json",
+                report_dir=tmp_path / "reports",
+            )
+
+    @pytest.mark.asyncio
+    async def test_runs_when_enabled(self, monkeypatch, tmp_path):
+        from src.browser.canary import run_canary
+        _enable_canary(monkeypatch)
+        mgr = _make_manager_mock()
+        report = await run_canary(
+            mgr,
+            state_path=tmp_path / "state.json",
+            report_dir=tmp_path / "reports",
+        )
+        assert report["agent_id"] == "canary-probe"
+        assert len(report["scanners"]) == 4
+        assert all("name" in s and "status" in s for s in report["scanners"])
+
+
+class TestRateLimit:
+    @pytest.mark.asyncio
+    async def test_second_run_rate_limited(self, monkeypatch, tmp_path):
+        from src.browser.canary import CanaryRateLimitedError, run_canary
+        _enable_canary(monkeypatch)
+        mgr = _make_manager_mock()
+
+        await run_canary(
+            mgr,
+            state_path=tmp_path / "state.json",
+            report_dir=tmp_path / "reports",
+        )
+        with pytest.raises(CanaryRateLimitedError) as ex:
+            await run_canary(
+                mgr,
+                state_path=tmp_path / "state.json",
+                report_dir=tmp_path / "reports",
+            )
+        assert ex.value.retry_after_s > 0
+
+    @pytest.mark.asyncio
+    async def test_force_bypasses_rate_limit(self, monkeypatch, tmp_path):
+        from src.browser.canary import run_canary
+        _enable_canary(monkeypatch)
+        mgr = _make_manager_mock()
+
+        await run_canary(
+            mgr,
+            state_path=tmp_path / "state.json",
+            report_dir=tmp_path / "reports",
+        )
+        # force=True: must NOT raise
+        report = await run_canary(
+            mgr, force=True,
+            state_path=tmp_path / "state.json",
+            report_dir=tmp_path / "reports",
+        )
+        assert report["scanners"]
+
+    @pytest.mark.asyncio
+    async def test_state_persists_across_calls(self, monkeypatch, tmp_path):
+        from src.browser.canary import run_canary
+        _enable_canary(monkeypatch)
+        state_path = tmp_path / "state.json"
+        mgr = _make_manager_mock()
+        await run_canary(
+            mgr, state_path=state_path, report_dir=tmp_path / "r",
+        )
+        # Simulate a service restart — load state from disk.
+        state = json.loads(state_path.read_text())
+        assert state["last_run_ts"] > 0
+        # Overall score present even when no numeric scanner scores yet.
+        assert "last_overall_score" in state
+
+
+class TestPerScannerResilience:
+    @pytest.mark.asyncio
+    async def test_one_scanner_timeout_does_not_stop_others(
+        self, monkeypatch, tmp_path,
+    ):
+        from src.browser.canary import run_canary
+        _enable_canary(monkeypatch)
+
+        mgr = MagicMock()
+        mgr.boot_id = "b"
+        mgr.stop = AsyncMock()
+        mgr.screenshot = AsyncMock(return_value={
+            "success": True, "data": {"image_base64": "", "format": "png"},
+        })
+        mgr.evaluate = AsyncMock(return_value={
+            "success": True, "data": {"result": {"pass": 0, "fail": 0}},
+        })
+        # First scanner raises; rest succeed.
+        call_count = {"n": 0}
+
+        async def sometimes_fail(*args, **kwargs):
+            call_count["n"] += 1
+            if call_count["n"] == 1:
+                raise RuntimeError("boom")
+            return {"success": True}
+
+        mgr.navigate = AsyncMock(side_effect=sometimes_fail)
+
+        report = await run_canary(
+            mgr,
+            state_path=tmp_path / "state.json",
+            report_dir=tmp_path / "reports",
+        )
+        assert len(report["scanners"]) == 4
+        # Exactly one erroring, three ok.
+        errored = [s for s in report["scanners"] if s["status"] == "error"]
+        assert len(errored) == 1
+
+    @pytest.mark.asyncio
+    async def test_nav_failure_sets_status_but_continues(
+        self, monkeypatch, tmp_path,
+    ):
+        from src.browser.canary import run_canary
+        _enable_canary(monkeypatch)
+
+        mgr = _make_manager_mock()
+        mgr.navigate = AsyncMock(return_value={
+            "success": False, "error": "DNS failure",
+        })
+
+        report = await run_canary(
+            mgr,
+            state_path=tmp_path / "state.json",
+            report_dir=tmp_path / "reports",
+        )
+        assert all(s["status"] == "nav_failed" for s in report["scanners"])
+
+    @pytest.mark.asyncio
+    async def test_stops_canary_instance_after_run(self, monkeypatch, tmp_path):
+        """Explicit stop() after the sweep frees the canary's profile lock."""
+        from src.browser.canary import run_canary
+        _enable_canary(monkeypatch)
+
+        mgr = _make_manager_mock()
+        await run_canary(
+            mgr,
+            state_path=tmp_path / "state.json",
+            report_dir=tmp_path / "reports",
+        )
+        # Called at start (best-effort cleanup) AND at end
+        assert mgr.stop.await_count >= 1
+
+
+class TestCanaryEndpoint:
+    """Browser service ``POST /browser/_canary`` gating & responses."""
+
+    def _mk_app(self, monkeypatch, manager):
+        monkeypatch.delenv("BROWSER_AUTH_TOKEN", raising=False)
+        monkeypatch.delenv("MESH_AUTH_TOKEN", raising=False)
+        from src.browser.server import create_browser_app
+        return create_browser_app(manager)
+
+    def test_endpoint_403_when_flag_off(self, monkeypatch, tmp_path):
+        from fastapi.testclient import TestClient
+        _disable_canary(monkeypatch)
+        mgr = _make_manager_mock()
+        app = self._mk_app(monkeypatch, mgr)
+        with TestClient(app) as client:
+            resp = client.post("/browser/_canary")
+        assert resp.status_code == 403
+
+    def test_endpoint_429_when_rate_limited(self, monkeypatch, tmp_path):
+        """Simulate a canary rate-limit by pre-seeding state."""
+        from fastapi.testclient import TestClient
+        _enable_canary(monkeypatch)
+        # Point the canary's default paths at tmp to avoid touching /data
+        monkeypatch.setattr(
+            "src.browser.canary._DEFAULT_STATE_PATH",
+            tmp_path / "state.json",
+        )
+        monkeypatch.setattr(
+            "src.browser.canary._DEFAULT_REPORT_DIR",
+            tmp_path / "reports",
+        )
+        (tmp_path / "state.json").write_text(
+            json.dumps({"last_run_ts": time.time()}),
+        )
+        mgr = _make_manager_mock()
+        app = self._mk_app(monkeypatch, mgr)
+        with TestClient(app) as client:
+            resp = client.post("/browser/_canary")
+        assert resp.status_code == 429
+        body = resp.json()
+        assert "retry_after_s" in body["detail"]
+
+    def test_endpoint_requires_auth_when_configured(self, monkeypatch, tmp_path):
+        from fastapi.testclient import TestClient
+        monkeypatch.setenv("BROWSER_AUTH_TOKEN", "t0k")
+        monkeypatch.delenv("MESH_AUTH_TOKEN", raising=False)
+        _enable_canary(monkeypatch)
+        from src.browser.server import create_browser_app
+        mgr = _make_manager_mock()
+        app = create_browser_app(mgr)
+        with TestClient(app) as client:
+            unauth = client.post("/browser/_canary")
+            assert unauth.status_code == 401

--- a/tests/test_browser_canary.py
+++ b/tests/test_browser_canary.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import asyncio
+import contextlib
 import json
 import time
 from unittest.mock import AsyncMock, MagicMock
@@ -179,7 +181,12 @@ class TestPerScannerResilience:
 
     @pytest.mark.asyncio
     async def test_stops_canary_instance_after_run(self, monkeypatch, tmp_path):
-        """Explicit stop() after the sweep frees the canary's profile lock."""
+        """Explicit stop() after the sweep frees the canary's profile lock.
+
+        Both the pre-sweep cleanup and the post-sweep teardown must fire —
+        asserting >=1 would be satisfied by the pre-sweep call alone and
+        wouldn't catch a regression that dropped the post-sweep stop.
+        """
         from src.browser.canary import run_canary
         _enable_canary(monkeypatch)
 
@@ -189,8 +196,77 @@ class TestPerScannerResilience:
             state_path=tmp_path / "state.json",
             report_dir=tmp_path / "reports",
         )
-        # Called at start (best-effort cleanup) AND at end
-        assert mgr.stop.await_count >= 1
+        # Pre-sweep (line ~170) + post-sweep (finally block) = 2.
+        assert mgr.stop.await_count == 2
+
+    @pytest.mark.asyncio
+    async def test_stop_runs_on_cancellation(self, monkeypatch, tmp_path):
+        """A cancelled HTTP request (client disconnect) must not leave
+        the canary profile locked. The ``finally`` + ``asyncio.shield``
+        pattern in run_canary guarantees the stop runs."""
+        from src.browser.canary import run_canary
+        _enable_canary(monkeypatch)
+
+        mgr = _make_manager_mock()
+        slow_started = asyncio.Event()
+
+        async def slow_nav(*args, **kwargs):
+            slow_started.set()
+            await asyncio.sleep(30)  # would run past test timeout
+            return {"success": True}
+
+        mgr.navigate = AsyncMock(side_effect=slow_nav)
+
+        task = asyncio.create_task(run_canary(
+            mgr,
+            state_path=tmp_path / "state.json",
+            report_dir=tmp_path / "reports",
+        ))
+        # Wait until we're inside the first scanner's navigate, then
+        # cancel — same shape as a FastAPI request being aborted.
+        await asyncio.wait_for(slow_started.wait(), timeout=2)
+        task.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await task
+
+        # Pre-sweep + finally teardown — both must fire even on cancel.
+        assert mgr.stop.await_count == 2
+
+    @pytest.mark.asyncio
+    async def test_concurrent_force_runs_are_serialized(
+        self, monkeypatch, tmp_path,
+    ):
+        """Two concurrent force=True callers must NOT race on the state
+        file or the canary profile — the run lock serializes them."""
+        from src.browser.canary import run_canary
+        _enable_canary(monkeypatch)
+
+        mgr = _make_manager_mock()
+
+        # Slow each navigate so overlap is visible if the lock failed.
+        async def slow_nav(*args, **kwargs):
+            await asyncio.sleep(0.01)
+            return {"success": True}
+
+        mgr.navigate = AsyncMock(side_effect=slow_nav)
+
+        results = await asyncio.gather(
+            run_canary(
+                mgr, force=True,
+                state_path=tmp_path / "state.json",
+                report_dir=tmp_path / "r",
+            ),
+            run_canary(
+                mgr, force=True,
+                state_path=tmp_path / "state.json",
+                report_dir=tmp_path / "r",
+            ),
+        )
+        assert len(results) == 2
+        assert all(isinstance(r, dict) for r in results)
+        # State file reflects exactly one last_run_ts from the later call.
+        state = json.loads((tmp_path / "state.json").read_text())
+        assert "last_run_ts" in state
 
 
 class TestCanaryEndpoint:

--- a/tests/test_browser_recorder.py
+++ b/tests/test_browser_recorder.py
@@ -1,0 +1,212 @@
+"""Tests for the behavioral entropy recorder (Phase 2 §5.3)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+
+def _recorder(monkeypatch, tmp_path, enabled: bool, agent_id: str = "a1"):
+    """Construct a recorder with the flag set and dump dir under tmp."""
+    if enabled:
+        monkeypatch.setenv("BROWSER_RECORD_BEHAVIOR", "1")
+    else:
+        monkeypatch.delenv("BROWSER_RECORD_BEHAVIOR", raising=False)
+    # Reset the flag module's operator-settings cache so env change
+    # takes effect immediately.
+    import src.browser.flags as flags
+    flags._operator_settings = None
+    from src.browser.recorder import BehaviorRecorder
+    return BehaviorRecorder(agent_id, dump_dir=tmp_path / "debug")
+
+
+class TestEnabledFlag:
+    def test_disabled_by_default(self, monkeypatch, tmp_path):
+        r = _recorder(monkeypatch, tmp_path, enabled=False)
+        assert r.enabled is False
+
+    def test_flag_enables(self, monkeypatch, tmp_path):
+        r = _recorder(monkeypatch, tmp_path, enabled=True)
+        assert r.enabled is True
+
+    def test_disabled_recorder_is_noop(self, monkeypatch, tmp_path):
+        r = _recorder(monkeypatch, tmp_path, enabled=False)
+        r.record_click(method="cdp", success=True)
+        r.record_keystrokes(char_count=5, fast=False, method="cdp")
+        r.record_scroll(direction="down", delta=100, method="x11")
+        r.record_navigate(host="example.com", wait_until="load")
+        assert len(r) == 0
+        assert r.dump() is None
+
+
+class TestRecording:
+    def test_click_appends(self, monkeypatch, tmp_path):
+        r = _recorder(monkeypatch, tmp_path, enabled=True)
+        r.record_click(method="cdp", success=True, dwell_ms=40)
+        assert len(r) == 1
+        event = r._events[-1]
+        assert event["type"] == "click"
+        assert event["method"] == "cdp"
+        assert event["success"] is True
+        assert event["dwell_ms"] == 40
+        assert event["interval_s"] is None  # first event
+
+    def test_interval_tracked(self, monkeypatch, tmp_path):
+        r = _recorder(monkeypatch, tmp_path, enabled=True)
+        r.record_click(method="cdp", success=True)
+        r.record_click(method="cdp", success=True)
+        assert r._events[0]["interval_s"] is None
+        assert r._events[1]["interval_s"] is not None
+        assert r._events[1]["interval_s"] >= 0
+
+    def test_keystrokes_only_store_count(self, monkeypatch, tmp_path):
+        """Privacy invariant: the actual text is never stored."""
+        r = _recorder(monkeypatch, tmp_path, enabled=True)
+        r.record_keystrokes(char_count=12, fast=False, method="x11")
+        event = r._events[-1]
+        assert event["char_count"] == 12
+        # No "text", "chars", or similar field
+        forbidden = {"text", "chars", "content", "value"}
+        assert not (set(event.keys()) & forbidden)
+
+    def test_navigate_records_only_host(self, monkeypatch, tmp_path):
+        """Privacy invariant: path / query / fragment never persisted."""
+        r = _recorder(monkeypatch, tmp_path, enabled=True)
+        r.record_navigate(host="example.com", wait_until="load")
+        event = r._events[-1]
+        assert event["host"] == "example.com"
+        assert "url" not in event
+        assert "path" not in event
+        assert "query" not in event
+
+
+class TestBufferCap:
+    def test_ring_buffer_caps(self, monkeypatch, tmp_path):
+        """Buffer maxlen bounds memory under long sessions."""
+        from src.browser.recorder import BehaviorRecorder
+        monkeypatch.setenv("BROWSER_RECORD_BEHAVIOR", "1")
+        import src.browser.flags as flags
+        flags._operator_settings = None
+        r = BehaviorRecorder("a1", buffer_size=3, dump_dir=tmp_path / "d")
+        for _ in range(10):
+            r.record_click(method="cdp", success=True)
+        assert len(r) == 3
+
+
+class TestDump:
+    def test_dump_writes_jsonl(self, monkeypatch, tmp_path):
+        r = _recorder(monkeypatch, tmp_path, enabled=True, agent_id="worker")
+        r.record_click(method="cdp", success=True)
+        r.record_keystrokes(char_count=3, fast=True, method="cdp-fast")
+        r.record_navigate(host="x.com", wait_until="networkidle")
+
+        out = r.dump(reason="stop")
+        assert out is not None and out.exists()
+        assert out.name.startswith("worker-")
+        assert out.suffix == ".jsonl"
+
+        lines = out.read_text(encoding="utf-8").splitlines()
+        # Header + 3 events
+        assert len(lines) == 4
+        header = json.loads(lines[0])
+        assert header["schema"].startswith("openlegion.browser.recorder/")
+        assert header["agent"] == "worker"
+        assert header["reason"] == "stop"
+        assert header["event_count"] == 3
+
+        events = [json.loads(line) for line in lines[1:]]
+        types = [e["type"] for e in events]
+        assert types == ["click", "keystrokes", "navigate"]
+
+    def test_dump_clears_buffer(self, monkeypatch, tmp_path):
+        r = _recorder(monkeypatch, tmp_path, enabled=True)
+        r.record_click(method="cdp", success=True)
+        assert len(r) == 1
+        r.dump()
+        assert len(r) == 0
+
+    def test_dump_empty_buffer_returns_none(self, monkeypatch, tmp_path):
+        r = _recorder(monkeypatch, tmp_path, enabled=True)
+        assert r.dump() is None
+
+    def test_dump_unwritable_dir_returns_none(self, monkeypatch, tmp_path):
+        """Recorder failure must never crash the caller."""
+        from src.browser.recorder import BehaviorRecorder
+        monkeypatch.setenv("BROWSER_RECORD_BEHAVIOR", "1")
+        import src.browser.flags as flags
+        flags._operator_settings = None
+        # Point at a path that exists as a file, so mkdir fails.
+        file_as_dir = tmp_path / "not_a_dir"
+        file_as_dir.write_text("")
+        r = BehaviorRecorder("a1", dump_dir=file_as_dir / "child")
+        r.record_click(method="cdp", success=True)
+        assert r.dump() is None  # silent failure
+
+    def test_dump_sanitizes_agent_id_in_filename(self, monkeypatch, tmp_path):
+        """Even if an unusual id gets through upstream validation, the
+        dump path must not escape the dump directory."""
+        from src.browser.recorder import BehaviorRecorder
+        monkeypatch.setenv("BROWSER_RECORD_BEHAVIOR", "1")
+        import src.browser.flags as flags
+        flags._operator_settings = None
+        r = BehaviorRecorder("../evil", dump_dir=tmp_path / "d")
+        r.record_click(method="cdp", success=True)
+        out = r.dump()
+        assert out is not None
+        # No `..` in the final path
+        assert ".." not in out.name
+        # Dump lives under the configured dir
+        assert Path(tmp_path / "d").resolve() in out.parents
+
+
+class TestIntegrationWithCamoufoxInstance:
+    """CamoufoxInstance must construct a recorder unconditionally."""
+
+    def test_instance_has_recorder_attr(self, monkeypatch):
+        """Construction is cheap whether the flag is set or not."""
+        from unittest.mock import MagicMock
+
+        from src.browser.service import CamoufoxInstance
+        monkeypatch.delenv("BROWSER_RECORD_BEHAVIOR", raising=False)
+        import src.browser.flags as flags
+        flags._operator_settings = None
+        inst = CamoufoxInstance(
+            "a1", MagicMock(), MagicMock(), MagicMock(),
+        )
+        assert hasattr(inst, "recorder")
+        assert inst.recorder.enabled is False
+
+
+@pytest.mark.asyncio
+class TestDumpFromStopInstance:
+    """_stop_instance must trigger the recorder dump so the operator
+    gets a JSONL file after each agent tears down."""
+
+    async def test_stop_instance_dumps_recorder(self, monkeypatch, tmp_path):
+        from unittest.mock import AsyncMock, MagicMock
+
+        from src.browser.service import BrowserManager, CamoufoxInstance
+
+        monkeypatch.setenv("BROWSER_RECORD_BEHAVIOR", "1")
+        import src.browser.flags as flags
+        flags._operator_settings = None
+
+        mgr = BrowserManager(profiles_dir=str(tmp_path / "profiles"))
+        inst = CamoufoxInstance(
+            "bye", MagicMock(), MagicMock(), MagicMock(),
+        )
+        inst.recorder._dump_dir = tmp_path / "debug"
+        inst.context = MagicMock()
+        inst.context.close = AsyncMock()
+        inst.record_click_method = "cdp"
+        mgr._instances["bye"] = inst
+
+        inst.recorder.record_click(method="cdp", success=True)
+        async with mgr._lock:
+            await mgr._stop_instance("bye")
+
+        # One JSONL file with "bye-<ts>.jsonl" shape
+        dumps = list((tmp_path / "debug").glob("bye-*.jsonl"))
+        assert len(dumps) == 1

--- a/tests/test_browser_recorder.py
+++ b/tests/test_browser_recorder.py
@@ -175,6 +175,32 @@ class TestDump:
         r.record_click(method="cdp", success=True)
         assert r.dump() is None  # silent failure
 
+    def test_prune_keeps_only_most_recent(self, monkeypatch, tmp_path):
+        """Regression (Codex #2): the recorder must cap the number of
+        dump files it retains on disk. A long-running dev session with
+        agent churn would otherwise fill the disk even though the
+        in-memory buffer is bounded."""
+        from src.browser.recorder import BehaviorRecorder
+        monkeypatch.setenv("BROWSER_RECORD_BEHAVIOR", "1")
+        import src.browser.flags as flags
+        flags._operator_settings = None
+
+        dump_dir = tmp_path / "debug"
+        # Lower the cap for a tractable test.
+        monkeypatch.setattr("src.browser.recorder._MAX_DUMP_FILES", 3)
+
+        # Create 7 back-to-back dumps; only the 3 most recent should survive.
+        import time as _t
+        for i in range(7):
+            r = BehaviorRecorder(f"a{i}", dump_dir=dump_dir)
+            r.record_click(method="cdp", success=True)
+            r.dump()
+            # Monotonic mtime step so sort-by-mtime is deterministic.
+            _t.sleep(0.005)
+
+        remaining = sorted(dump_dir.glob("*.jsonl"))
+        assert len(remaining) == 3
+
     def test_rapid_dumps_do_not_overwrite(self, monkeypatch, tmp_path):
         """Two dumps for the same agent within the same second must
         not overwrite each other — the random suffix keeps both on
@@ -255,3 +281,62 @@ class TestDumpFromStopInstance:
         # One JSONL file with "bye-<ts>.jsonl" shape
         dumps = list((tmp_path / "debug").glob("bye-*.jsonl"))
         assert len(dumps) == 1
+
+    async def test_stop_waits_for_in_flight_action(self, monkeypatch, tmp_path):
+        """Regression (Codex #1 P1): a hot-path task holding ``inst.lock``
+        mid-click must finish — including its ``record_*`` append — before
+        the dump clears the buffer. Without acquiring the lock in
+        ``_stop_instance``, that trailing append lands in a cleared deque
+        and is silently lost at instance GC."""
+        from unittest.mock import AsyncMock, MagicMock
+
+        from src.browser.service import BrowserManager, CamoufoxInstance
+
+        monkeypatch.setenv("BROWSER_RECORD_BEHAVIOR", "1")
+        import src.browser.flags as flags
+        flags._operator_settings = None
+
+        mgr = BrowserManager(profiles_dir=str(tmp_path / "profiles"))
+        inst = CamoufoxInstance(
+            "wait", MagicMock(), MagicMock(), MagicMock(),
+        )
+        inst.recorder._dump_dir = tmp_path / "debug"
+        inst.context = MagicMock()
+        inst.context.close = AsyncMock()
+        mgr._instances["wait"] = inst
+
+        # Hold inst.lock and schedule a late append from inside. Stop
+        # must wait for us to release before dumping.
+        import asyncio as _asyncio
+        inst_lock_acquired = _asyncio.Event()
+        stop_may_proceed = _asyncio.Event()
+
+        async def hold_lock_then_record():
+            async with inst.lock:
+                inst_lock_acquired.set()
+                await stop_may_proceed.wait()
+                # This append must land in the dump file, not be lost.
+                inst.recorder.record_click(method="cdp", success=True)
+
+        holder = _asyncio.create_task(hold_lock_then_record())
+        await inst_lock_acquired.wait()
+
+        async def do_stop():
+            async with mgr._lock:
+                await mgr._stop_instance("wait")
+
+        stop_task = _asyncio.create_task(do_stop())
+        # Give stop_task a chance to start and block on inst.lock.
+        await _asyncio.sleep(0.05)
+        assert not stop_task.done(), "stop should be blocked on inst.lock"
+
+        stop_may_proceed.set()
+        await holder
+        await stop_task
+
+        dumps = list((tmp_path / "debug").glob("wait-*.jsonl"))
+        assert len(dumps) == 1
+        # The trailing click made it to disk.
+        content = dumps[0].read_text()
+        clicks = [line for line in content.splitlines() if '"click"' in line]
+        assert len(clicks) == 1

--- a/tests/test_browser_recorder.py
+++ b/tests/test_browser_recorder.py
@@ -40,17 +40,48 @@ class TestEnabledFlag:
         assert len(r) == 0
         assert r.dump() is None
 
+    def test_runtime_toggle_takes_effect_without_reset(
+        self, monkeypatch, tmp_path,
+    ):
+        """Operators should be able to flip BROWSER_RECORD_BEHAVIOR via
+        env/settings and have the next recorded event honor it — no
+        browser restart required."""
+        r = _recorder(monkeypatch, tmp_path, enabled=False)
+        r.record_click(method="cdp", success=True)
+        assert len(r) == 0
+
+        monkeypatch.setenv("BROWSER_RECORD_BEHAVIOR", "1")
+        import src.browser.flags as flags
+        flags._operator_settings = None
+
+        r.record_click(method="cdp", success=True)
+        assert len(r) == 1
+
+    def test_dump_survives_runtime_disable(self, monkeypatch, tmp_path):
+        """If operator disables the flag between record and dump, the
+        already-captured events must still flush — silently dropping
+        them would surprise the operator."""
+        r = _recorder(monkeypatch, tmp_path, enabled=True)
+        r.record_click(method="cdp", success=True)
+        assert len(r) == 1
+
+        monkeypatch.delenv("BROWSER_RECORD_BEHAVIOR", raising=False)
+        import src.browser.flags as flags
+        flags._operator_settings = None
+
+        out = r.dump()
+        assert out is not None and out.exists()
+
 
 class TestRecording:
     def test_click_appends(self, monkeypatch, tmp_path):
         r = _recorder(monkeypatch, tmp_path, enabled=True)
-        r.record_click(method="cdp", success=True, dwell_ms=40)
+        r.record_click(method="cdp", success=True)
         assert len(r) == 1
         event = r._events[-1]
         assert event["type"] == "click"
         assert event["method"] == "cdp"
         assert event["success"] is True
-        assert event["dwell_ms"] == 40
         assert event["interval_s"] is None  # first event
 
     def test_interval_tracked(self, monkeypatch, tmp_path):
@@ -143,6 +174,20 @@ class TestDump:
         r = BehaviorRecorder("a1", dump_dir=file_as_dir / "child")
         r.record_click(method="cdp", success=True)
         assert r.dump() is None  # silent failure
+
+    def test_rapid_dumps_do_not_overwrite(self, monkeypatch, tmp_path):
+        """Two dumps for the same agent within the same second must
+        not overwrite each other — the random suffix keeps both on
+        disk even when ``int(time.time())`` matches."""
+        r1 = _recorder(monkeypatch, tmp_path, enabled=True, agent_id="dup")
+        r1.record_click(method="cdp", success=True)
+        out1 = r1.dump()
+        r2 = _recorder(monkeypatch, tmp_path, enabled=True, agent_id="dup")
+        r2.record_click(method="cdp", success=True)
+        out2 = r2.dump()
+        assert out1 is not None and out2 is not None
+        assert out1 != out2
+        assert out1.exists() and out2.exists()
 
     def test_dump_sanitizes_agent_id_in_filename(self, monkeypatch, tmp_path):
         """Even if an unusual id gets through upstream validation, the


### PR DESCRIPTION
## Summary

Two dev/operator-opt-in observability surfaces that sit alongside PR #742's always-on metrics card. Both default off; production pays zero cost when disabled.

### §5.3 Behavioral entropy recorder

`BROWSER_RECORD_BEHAVIOR=1` enables a per-agent ring buffer of input-event shape metadata (click, keystrokes, scroll, navigate). Dumps to `/data/debug/{agent}-{ts}.jsonl` when the instance stops, for offline analysis by §9.5 later.

**Privacy invariants baked into the API:**
- `record_keystrokes(char_count=N)` — never the actual text
- `record_navigate(host=H)` — never URL, path, query, or fragment (secrets routinely live in query strings)
- Agent-id sanitized into the dump filename even though upstream validation already restricts the shape
- All record_* methods short-circuit on the enabled flag, so production hot paths pay one attribute lookup per call

### §5.4 Stealth canary

`POST /browser/_canary` (auth'd) runs a dedicated `canary-probe` Camoufox profile against fixed fingerprint scanners (bot.sannysoft.com, CreepJS, fingerprint.com, pixelscan.net).

- `BROWSER_CANARY_ENABLED=false` by default — customer fleets do NOT hammer third-party scanners
- Rate-limited to 1 run / ~24h, state persisted to `/data/canary/state.json`
- `{"force": true}` bypasses rate limit for operator debug runs
- Canary profile inherits all stealth from `build_launch_options` (same path as production agents); only the profile directory + cookie jar are isolated
- Per-scanner failures captured in the report — one flaky scanner doesn't kill the sweep
- Screenshots to `/data/canary/reports/{ts}-{scanner}.png`
- Numeric 0-100 scores parsed best-effort; unparseable scanners fall back to manual screenshot review

**Scope caveat** (called out in module docstring): canary scanners inspect client-side JS only. TLS, H2, and network-layer signals are invisible. A clean canary ≠ certification against a behavioral-fraud provider.

## Test plan

- [x] `tests/test_browser_recorder.py` (12 tests): flag gate, noop when off, interval tracking, privacy invariants (no text, no URLs), buffer cap, dump JSONL format, dump-failure-doesn't-crash, filename sanitization, CamoufoxInstance wires recorder, `_stop_instance` triggers dump
- [x] `tests/test_browser_canary.py` (14 tests): 403 when flag off, rate limit enforced, force bypasses, state persists across calls, one-scanner failure doesn't stop others, nav-failure captured, canary stopped after sweep, endpoint auth
- [x] Existing browser suites (309 tests): no regressions
- [x] ruff clean