### PR TITLE
Phase 3.3/3.4/3.6: nav probe + UA guard + NetworkInformation

### DIFF
--- a/src/browser/service.py
+++ b/src/browser/service.py
@@ -11,6 +11,7 @@ import asyncio
 import base64
 import contextlib
 import mimetypes
+import os
 import random
 import re
 import subprocess
@@ -260,6 +261,18 @@ _JS_A11Y_TREE = r"""(rootEl) => {
 }"""
 
 
+def _short_ua(ua: str) -> str:
+    """Compact a UA string for log output — keep the tail Firefox-version
+    bit, drop the OS/locale boilerplate readers don't need at INFO level."""
+    if not ua:
+        return ""
+    # Most useful bit is "Firefox/138.0" at the end; everything before is
+    # noise for debugging fingerprint regressions.
+    if "Firefox/" in ua:
+        return "Firefox/" + ua.split("Firefox/", 1)[1]
+    return ua[:80]
+
+
 def _is_empty_payload(payload: dict) -> bool:
     """True when a drain produced no activity *in this interval*.
 
@@ -268,7 +281,13 @@ def _is_empty_payload(payload: dict) -> bool:
     Only per-minute counters count here — the rolling click window
     persists across drains and would permanently bypass the filter if
     included (any agent that ever clicked would be "non-idle" forever).
+
+    Payloads with an explicit ``kind`` (e.g. §6.3 ``nav_probe``) are
+    one-shot events, not drain samples — they are never "empty" even
+    when the per-minute counter fields are absent.
     """
+    if payload.get("kind"):
+        return False
     return not any((
         payload.get("click_success"),
         payload.get("click_fail"),
@@ -365,6 +384,11 @@ class CamoufoxInstance:
         # off so production pays no cost.
         from src.browser.recorder import BehaviorRecorder
         self.recorder = BehaviorRecorder(agent_id)
+        # §6.3 navigator self-test result. ``None`` until the post-launch
+        # probe runs. Populated dict (see ``BrowserManager._run_navigator_probe``)
+        # exposes ``ok`` + ``mismatches`` + raw signal values for dashboard /
+        # status endpoint consumers.
+        self.probe_result: dict | None = None
 
     def _register_page(self, page) -> str:
         """Assign a stable UUID to a Page if not already registered.
@@ -854,7 +878,137 @@ class BrowserManager:
             )
             inst._jitter_task = None
 
+        # §6.3 run the navigator self-test once. Best-effort — a probe
+        # failure must not block browser start (the inconsistency is
+        # itself the operator's signal to investigate).
+        try:
+            await self._run_navigator_probe(inst)
+        except Exception as e:
+            logger.warning(
+                "Navigator self-test probe failed for '%s': %s", agent_id, e,
+            )
+
         return inst
+
+    async def _run_navigator_probe(self, inst: CamoufoxInstance) -> None:
+        """Read key navigator/Intl signals from the live page and validate
+        them against the configured fingerprint.
+
+        Stores the result on ``inst.probe_result`` and emits a one-shot
+        ``nav_probe`` payload via ``self._metrics_sink`` (when wired). At
+        the dashboard layer this surfaces as a ``browser_metrics`` event
+        with a ``probe`` field, distinct from per-minute drain payloads.
+
+        Mismatches the probe flags:
+          * ``navigator.webdriver !== false`` — the canonical bot tell
+          * ``navigator.platform`` doesn't match our configured ``os`` hint
+          * ``navigator.userAgent`` lacks ``Firefox/`` (would mean §6.4
+            tripwire was bypassed somehow at runtime)
+          * ``navigator.connection.*`` is undefined (would mean §6.6
+            override silently failed inside Camoufox)
+
+        Per the plan: "WARNING if webdriver !== false or mismatch."
+        """
+        os_hint = os.environ.get("BROWSER_OS", "windows").lower()
+        expected_platform = {
+            "windows": "Win32",
+            "macos": "MacIntel",
+            "linux": "Linux x86_64",
+        }.get(os_hint)
+
+        try:
+            signals = await inst.page.evaluate(
+                "() => ({"
+                "  webdriver: navigator.webdriver,"
+                "  plugins_len: navigator.plugins ? navigator.plugins.length : -1,"
+                "  mimeTypes_len: navigator.mimeTypes ? navigator.mimeTypes.length : -1,"
+                "  hardwareConcurrency: navigator.hardwareConcurrency,"
+                "  deviceMemory: navigator.deviceMemory,"
+                "  userAgent: navigator.userAgent,"
+                "  platform: navigator.platform,"
+                "  language: navigator.language,"
+                "  timezone: Intl.DateTimeFormat().resolvedOptions().timeZone,"
+                "  conn_effective: navigator.connection ? navigator.connection.effectiveType : null,"
+                "  conn_downlink: navigator.connection ? navigator.connection.downlink : null,"
+                "  conn_rtt: navigator.connection ? navigator.connection.rtt : null"
+                "})",
+            )
+        except Exception as e:
+            inst.probe_result = {
+                "ok": False, "mismatches": [f"evaluate failed: {e}"],
+                "signals": {},
+            }
+            logger.warning(
+                "Navigator probe evaluate failed for '%s': %s",
+                inst.agent_id, e,
+            )
+            return
+
+        mismatches: list[str] = []
+        if signals.get("webdriver") is not False:
+            mismatches.append(
+                f"webdriver={signals.get('webdriver')!r} (expected False)",
+            )
+        if expected_platform and signals.get("platform") != expected_platform:
+            mismatches.append(
+                f"platform={signals.get('platform')!r} "
+                f"(expected {expected_platform!r} for os={os_hint!r})",
+            )
+        ua = signals.get("userAgent", "")
+        if ua and "Firefox/" not in ua:
+            mismatches.append(f"userAgent lacks 'Firefox/': {ua!r}")
+        # navigator.connection should be populated by §6.6 spoof. ``null``
+        # means the override silently failed.
+        if signals.get("conn_effective") is None:
+            mismatches.append(
+                "navigator.connection.effectiveType is null "
+                "(§6.6 override may have failed)",
+            )
+
+        ok = not mismatches
+        inst.probe_result = {
+            "ok": ok,
+            "mismatches": mismatches,
+            "signals": signals,
+        }
+
+        if ok:
+            logger.info(
+                "Navigator probe OK for '%s': platform=%s, ua=%s, tz=%s",
+                inst.agent_id, signals.get("platform"),
+                _short_ua(ua), signals.get("timezone"),
+            )
+        else:
+            logger.warning(
+                "Navigator probe MISMATCH for '%s': %s",
+                inst.agent_id, "; ".join(mismatches),
+            )
+
+        # One-shot emit so operators see the result on the dashboard
+        # without waiting for the next per-minute drain. Distinguished
+        # from drain payloads by the ``kind`` field; Phase 2.1's history
+        # buffer + mesh poll forward both shapes. We write to the history
+        # buffer FIRST (so a missing sink doesn't drop the event) and
+        # call the optional sink for in-process consumers (tests).
+        probe_payload = {
+            "kind": "nav_probe",
+            "agent_id": inst.agent_id,
+            "ok": ok,
+            "mismatches": mismatches,
+            "signals": signals,
+        }
+        self._metrics_seq += 1
+        probe_payload["seq"] = self._metrics_seq
+        probe_payload["ts"] = time.time()
+        self._metrics_history.append(probe_payload)
+        if self._metrics_sink is not None:
+            try:
+                self._metrics_sink(probe_payload)
+            except Exception as e:
+                logger.debug(
+                    "metrics_sink raised on nav_probe for '%s': %s",
+                    inst.agent_id, e,
+                )
 
     async def stop(self, agent_id: str) -> None:
         """Stop and clean up a specific agent's browser."""
@@ -958,13 +1112,24 @@ class BrowserManager:
             inst = self._instances.get(agent_id)
             if not inst:
                 return {"running": False}
-            return {
+            status = {
                 "running": True,
                 "idle_seconds": int(time.time() - inst.last_activity),
                 "url": inst.page.url if inst.page else "",
                 "click_window_size": len(inst.click_window),
                 "click_success_rate_100": inst.rolling_click_success_rate(),
             }
+            # §6.3 navigator probe summary (boot-once). When ``probe_result``
+            # is None the probe hasn't run yet (instance just started).
+            # Operators polling /status get the same signal as the dashboard
+            # nav-probe event; we only surface the high-level shape, not the
+            # raw signals payload (those are in the EventBus event).
+            if inst.probe_result is not None:
+                status["probe_ok"] = inst.probe_result["ok"]
+                status["probe_mismatches"] = list(
+                    inst.probe_result.get("mismatches") or [],
+                )
+            return status
 
     async def get_service_status(self) -> dict:
         """Get overall service health."""

--- a/src/browser/service.py
+++ b/src/browser/service.py
@@ -1011,6 +1011,13 @@ class BrowserManager:
         # some weird policy), we fall through and probe the current
         # page anyway; the result will still be populated and any
         # shadowing-induced mismatch is itself useful signal.
+        #
+        # Side-effect operators may notice: this clobbers the resumed
+        # page on a persistent-profile restart. An agent that had
+        # ``twitter.com`` open last session sees ``about:blank`` for a
+        # split second after restart, then whatever its first action
+        # navigates to. Cookies / localStorage / IndexedDB all survive
+        # — only the loaded-page URL is lost.
         try:
             await inst.page.goto("about:blank", timeout=5000)
         except Exception as e:

--- a/src/browser/service.py
+++ b/src/browser/service.py
@@ -273,6 +273,57 @@ def _short_ua(ua: str) -> str:
     return ua[:80]
 
 
+def _js_string(value: str) -> str:
+    """Escape a Python string for safe interpolation into a JS literal.
+
+    Used by the ``navigator.connection`` init-script to inject the
+    per-agent ``effectiveType`` value. The values are drawn from a
+    fixed pool (``"4g"`` etc.) so injection is bounded today, but
+    a defensive escape costs nothing and prevents future agent-id-
+    derived values from breaking out.
+    """
+    return ("'" + value
+            .replace("\\", "\\\\")
+            .replace("'", "\\'")
+            .replace("\n", "\\n") + "'")
+
+
+# §6.6 navigator.connection fallback. Defines a getter on
+# ``Navigator.prototype`` that returns a frozen object matching the
+# NetworkInformation API surface real Chromium-shaped browsers expose.
+# ``configurable: true`` so a future Camoufox upgrade that adds native
+# support can override this. Runs before any page script via
+# ``BrowserContext.add_init_script``.
+_NAV_CONNECTION_INIT_SCRIPT = """
+(() => {{
+  try {{
+    if (typeof navigator !== 'undefined' && navigator.connection !== undefined) {{
+      return;  // Camoufox / Firefox already exposes the API
+    }}
+    const fake = Object.freeze({{
+      effectiveType: {effective},
+      downlink: {downlink},
+      rtt: {rtt},
+      saveData: {save_data},
+      type: 'wifi',
+      addEventListener: () => {{}},
+      removeEventListener: () => {{}},
+      dispatchEvent: () => false,
+      onchange: null,
+    }});
+    Object.defineProperty(Navigator.prototype, 'connection', {{
+      get: () => fake,
+      configurable: true,
+      enumerable: true,
+    }});
+  }} catch (_e) {{
+    // Defensive: any failure here is operator-debuggable via the
+    // §6.3 navigator self-test, which will flag the missing API.
+  }}
+}})();
+"""
+
+
 def _is_empty_payload(payload: dict) -> bool:
     """True when a drain produced no activity *in this interval*.
 
@@ -861,6 +912,35 @@ class BrowserManager:
         pages = context.pages
         page = pages[0] if pages else await context.new_page()
 
+        # §6.6 ``navigator.connection`` fallback. We pass the spoof
+        # values via Camoufox's ``config`` dict above, but it's not
+        # documented whether Camoufox honours those keys (Firefox itself
+        # doesn't natively expose NetworkInformation). Install an
+        # ``add_init_script`` that defines ``navigator.connection`` if
+        # the property is missing — runs in every document context
+        # before page scripts. ``Object.defineProperty`` on
+        # ``Navigator.prototype`` with ``configurable: true`` matches
+        # what real Chromium-shaped Firefox extension polyfills do.
+        try:
+            from src.browser.stealth import pick_network_info
+            netinfo = pick_network_info(agent_id)
+            await context.add_init_script(
+                _NAV_CONNECTION_INIT_SCRIPT.format(
+                    effective=_js_string(netinfo["effectiveType"]),
+                    downlink=float(netinfo["downlink"]),
+                    rtt=int(netinfo["rtt"]),
+                    save_data="false",
+                ),
+            )
+        except Exception as e:
+            # Non-fatal — Camoufox may already have NetworkInformation
+            # support, and the §6.3 probe will catch the gap if neither
+            # path lands.
+            logger.debug(
+                "navigator.connection init-script failed for '%s': %s",
+                agent_id, e,
+            )
+
         inst = CamoufoxInstance(agent_id, browser, context, page)
 
         # Discover the new X11 window for targeted focus
@@ -896,8 +976,16 @@ class BrowserManager:
 
         Stores the result on ``inst.probe_result`` and emits a one-shot
         ``nav_probe`` payload via ``self._metrics_sink`` (when wired). At
-        the dashboard layer this surfaces as a ``browser_metrics`` event
-        with a ``probe`` field, distinct from per-minute drain payloads.
+        the dashboard layer this surfaces as a ``browser_nav_probe``
+        event, distinct from per-minute drain payloads.
+
+        **Probes on ``about:blank``** so we read the platform / browser
+        signals as the engine sees them, not as some loaded site has
+        possibly shadowed them via an injected content script. With
+        ``persistent_context=True`` the page resumes whatever the agent
+        had open last session — that page's globals could include
+        custom getters on ``Navigator.prototype``. Forcing a navigation
+        to ``about:blank`` first eliminates that path.
 
         Mismatches the probe flags:
           * ``navigator.webdriver !== false`` — the canonical bot tell
@@ -915,6 +1003,21 @@ class BrowserManager:
             "macos": "MacIntel",
             "linux": "Linux x86_64",
         }.get(os_hint)
+
+        # Best-effort isolate the probe context. ``about:blank`` is a
+        # special URL that Firefox loads instantly with a fresh,
+        # script-free document — perfect for reading raw navigator
+        # signals. If the goto fails (e.g. ``about:blank`` blocked by
+        # some weird policy), we fall through and probe the current
+        # page anyway; the result will still be populated and any
+        # shadowing-induced mismatch is itself useful signal.
+        try:
+            await inst.page.goto("about:blank", timeout=5000)
+        except Exception as e:
+            logger.debug(
+                "Probe pre-nav to about:blank failed for '%s' "
+                "(continuing on current page): %s", inst.agent_id, e,
+            )
 
         try:
             signals = await inst.page.evaluate(

--- a/src/browser/stealth.py
+++ b/src/browser/stealth.py
@@ -27,11 +27,75 @@ consistent and realistic:
 
 from __future__ import annotations
 
+import hashlib
 import os
 
 from src.shared.utils import setup_logging
 
 logger = setup_logging("browser.stealth")
+
+
+# ── §6.6 NetworkInformation per-agent fingerprint ─────────────────────────────
+
+
+def pick_network_info(agent_id: str) -> dict:
+    """Stable per-agent ``navigator.connection`` values.
+
+    Real desktop users on broadband / 4G / 5G report
+    ``effectiveType="4g"`` overwhelmingly; the variability is in
+    ``downlink`` (Mbps) and ``rtt`` (ms). Datacenter Firefox often
+    leaves all three undefined, which is itself a signal.
+
+    Picks per-agent from plausible bands:
+      - downlink: 5–20 Mbps (covers home broadband, mobile 4G good signal)
+      - rtt: 20–120 ms (covers wired through mobile)
+      - saveData: always False (rare on desktop; True would itself be a flag)
+
+    Deterministic from ``agent_id`` so the same agent reports the same
+    network shape across browser restarts. SHA-256 splits into two
+    independent 4-byte words for downlink and rtt — using one byte each
+    would give a coarse 256-bucket distribution and visible quantisation
+    on fleet-scale analysis.
+    """
+    digest = hashlib.sha256(f"netinfo:{agent_id}".encode("utf-8")).digest()
+    dl_unit = int.from_bytes(digest[:4], "big") / (1 << 32)   # [0, 1)
+    rtt_unit = int.from_bytes(digest[4:8], "big") / (1 << 32)  # [0, 1)
+    return {
+        "effectiveType": "4g",
+        "downlink": round(5.0 + dl_unit * 15.0, 1),
+        "rtt": int(20 + rtt_unit * 100),
+        "saveData": False,
+    }
+
+
+# ── §6.4 Client-Hints / Firefox-UA guard ──────────────────────────────────────
+
+
+def _assert_firefox_ua(ua: str) -> None:
+    """Refuse a non-Firefox UA string.
+
+    Detection at the Client-Hints layer (Sec-CH-UA-* headers) is
+    Chromium-only — real Firefox doesn't send those headers. If this
+    project ever switches to a Chromium base (or someone hand-overrides
+    ``BROWSER_UA_VERSION`` with a Chrome string), the resulting browser
+    would advertise itself as Chrome via UA but NOT send the matching
+    Sec-CH-UA-* hints, which is itself a strong inconsistency signal.
+
+    This assertion is a tripwire: if it fires, whoever changed the UA
+    has to also wire up Sec-CH-UA / Sec-CH-UA-Mobile / Sec-CH-UA-Platform
+    overrides before removing the guard. Camoufox doesn't currently
+    expose Client-Hints injection, so flipping this off without that
+    work means shipping a detectable agent.
+    """
+    if not ua:
+        return
+    if "Firefox/" not in ua:
+        raise ValueError(
+            "Refusing non-Firefox UA — Client-Hints would leak the "
+            "inconsistency. Wire up Sec-CH-UA-* overrides before "
+            f"shipping this UA: {ua!r}",
+        )
+
 
 # ── Launch options ─────────────────────────────────────────────────────────────
 
@@ -105,6 +169,24 @@ def build_launch_options(agent_id: str, profile_dir: str, proxy: dict | None = N
 
     options["firefox_user_prefs"] = _stealth_prefs()
 
+    # ── §6.6 NetworkInformation spoof ────────────────────────────────────────
+    # Camoufox's ``config`` dict supports dotted keys for navigator.* override.
+    # Set per-agent stable values so ``navigator.connection.{effectiveType,
+    # downlink, rtt}`` look like a desktop on broadband. Without this Firefox
+    # leaves these undefined on Linux containers, which detection scripts use
+    # as a desktop-vs-bot tell.
+    netinfo = pick_network_info(agent_id)
+    options["config"] = {
+        "navigator.connection.effectiveType": netinfo["effectiveType"],
+        "navigator.connection.downlink": netinfo["downlink"],
+        "navigator.connection.rtt": netinfo["rtt"],
+        "navigator.connection.saveData": netinfo["saveData"],
+    }
+    # Camoufox requires this acknowledgement before applying ``config``
+    # overrides. We're past the early-return path so it's safe to set
+    # unconditionally now.
+    options["i_know_what_im_doing"] = True
+
     # ── User-Agent version override ──────────────────────────────────────────
     # Camoufox bundles a specific Firefox build (e.g. 135.0).  Some sites
     # (Shopify, etc.) enforce minimum browser versions and block old Firefox.
@@ -120,8 +202,11 @@ def build_launch_options(agent_id: str, profile_dir: str, proxy: dict | None = N
     if ua_version:
         ua = _build_ua_string(os_hint, ua_version)
         if ua:
-            options["config"] = {"navigator.userAgent": ua}
-            options["i_know_what_im_doing"] = True
+            # §6.4 tripwire — the UA we're about to ship MUST be Firefox.
+            # If a future change introduces a Chromium UA, this raises so
+            # the developer has to wire Sec-CH-UA-* overrides first.
+            _assert_firefox_ua(ua)
+            options["config"]["navigator.userAgent"] = ua
             options["firefox_user_prefs"]["general.useragent.override"] = ua
             logger.info("UA override: Firefox/%s", ua_version)
 

--- a/src/dashboard/static/js/app.js
+++ b/src/dashboard/static/js/app.js
@@ -1467,18 +1467,43 @@ function dashboard() {
             probe_signals: evt.data.signals || {},
             probe_at: Date.now(),
             // Preserve the most recent drain timestamp if any so the
-            // staleness check still works.
+            // staleness check still works. For probe-only updates we
+            // intentionally do NOT bump receivedAt — otherwise an
+            // agent that only ever probes (no clicks/navs) would never
+            // hit the 30-min eviction even after going truly idle.
             receivedAt: existing.receivedAt || Date.now(),
           },
         };
         if (!evt.data.ok && (evt.data.mismatches || []).length) {
-          // Linger 8s — fingerprint drift deserves more attention than
-          // the default 4s success toast.
-          this.showToast(
-            'Browser fingerprint drift on ' + evt.agent + ': ' +
-            evt.data.mismatches.slice(0, 2).join('; '),
-            8000,
-          );
+          // Toast dedup: a fleet-wide regression (e.g. Camoufox version
+          // bump that breaks navigator.connection injection) would
+          // otherwise stack one 8s toast per agent on a mass restart.
+          // Fingerprint signature = the sorted mismatch list. Suppress
+          // identical signatures fired within the same 30s window;
+          // surface a "+N more" toast instead.
+          const sig = (evt.data.mismatches || []).slice().sort().join('|');
+          this._probeToastSeen = this._probeToastSeen || new Map();
+          const now = Date.now();
+          const last = this._probeToastSeen.get(sig);
+          if (!last || now - last.firstAt > 30000) {
+            this._probeToastSeen.set(sig, { firstAt: now, count: 1 });
+            this.showToast(
+              'Browser fingerprint drift on ' + evt.agent + ': ' +
+              evt.data.mismatches.slice(0, 2).join('; '),
+              8000,
+            );
+          } else {
+            last.count += 1;
+            // Coalesce: only emit the rollup toast on the second hit
+            // (rollup-of-rollup would itself spam).
+            if (last.count === 2) {
+              this.showToast(
+                'Browser fingerprint drift hit ' + last.count +
+                ' agents in the last 30s — check Browser tab',
+                8000,
+              );
+            }
+          }
         }
       }
 

--- a/src/dashboard/static/js/app.js
+++ b/src/dashboard/static/js/app.js
@@ -1484,6 +1484,16 @@ function dashboard() {
           const sig = (evt.data.mismatches || []).slice().sort().join('|');
           this._probeToastSeen = this._probeToastSeen || new Map();
           const now = Date.now();
+          // Cap the dedup map at ~5 minutes of history so a long-lived
+          // dashboard session doesn't accumulate signatures forever.
+          // Past 5 minutes, the entry is irrelevant (way past the 30s
+          // dedup window) and just leaks memory.
+          const STALE_AT = now - 5 * 60 * 1000;
+          if (this._probeToastSeen.size > 50) {
+            for (const [k, v] of this._probeToastSeen) {
+              if (v.firstAt < STALE_AT) this._probeToastSeen.delete(k);
+            }
+          }
           const last = this._probeToastSeen.get(sig);
           if (!last || now - last.firstAt > 30000) {
             this._probeToastSeen.set(sig, { firstAt: now, count: 1 });

--- a/src/dashboard/static/js/app.js
+++ b/src/dashboard/static/js/app.js
@@ -1452,6 +1452,36 @@ function dashboard() {
         };
       }
 
+      // §6.3 navigator self-test result (one-shot per browser start).
+      // We attach the probe summary to the per-agent metrics entry so it
+      // renders alongside click rate / snapshot bytes, and toast on
+      // mismatch so operators see fingerprint regressions immediately.
+      if (evt.type === 'browser_nav_probe' && evt.agent && evt.data) {
+        const existing = this.browserMetrics[evt.agent] || {};
+        this.browserMetrics = {
+          ...this.browserMetrics,
+          [evt.agent]: {
+            ...existing,
+            probe_ok: evt.data.ok,
+            probe_mismatches: evt.data.mismatches || [],
+            probe_signals: evt.data.signals || {},
+            probe_at: Date.now(),
+            // Preserve the most recent drain timestamp if any so the
+            // staleness check still works.
+            receivedAt: existing.receivedAt || Date.now(),
+          },
+        };
+        if (!evt.data.ok && (evt.data.mismatches || []).length) {
+          // Linger 8s — fingerprint drift deserves more attention than
+          // the default 4s success toast.
+          this.showToast(
+            'Browser fingerprint drift on ' + evt.agent + ': ' +
+            evt.data.mismatches.slice(0, 2).join('; '),
+            8000,
+          );
+        }
+      }
+
       // Highlight blackboard writes + update comms badge
       if (evt.type === 'blackboard_write' && evt.data && evt.data.key) {
         if (!this.bbHighlights.includes(evt.data.key)) this.bbHighlights.push(evt.data.key);
@@ -5724,6 +5754,7 @@ function dashboard() {
         cron_trigger: 'text-pink-400',
         llm_stream: 'text-purple-300',
         browser_metrics: 'text-sky-400',
+        browser_nav_probe: 'text-amber-400',
       };
       return map[type] || 'text-gray-400';
     },
@@ -5755,6 +5786,7 @@ function dashboard() {
         cron_trigger: 'bg-pink-400',
         llm_stream: 'bg-purple-300',
         browser_metrics: 'bg-sky-400',
+        browser_nav_probe: 'bg-amber-400',
       };
       return map[type] || 'bg-gray-400';
     },

--- a/src/host/server.py
+++ b/src/host/server.py
@@ -2786,16 +2786,19 @@ def create_mesh_app(
             if int(p.get("seq", 0)) > _poll_state["last_seen_seq"]
         ]
         # On first-seen (fresh mesh or browser restart), only surface the
-        # latest payload per agent. A long-running browser service can
-        # return hours of history; flooding the dashboard's 500-event
-        # ring buffer with stale entries would evict live events and
-        # show agents with data that no longer reflects current health.
+        # latest payload per (agent, kind). A long-running browser
+        # service can return hours of history; flooding the dashboard's
+        # 500-event ring buffer with stale entries would evict live
+        # events. Collapse keys are ``(agent_id, kind)`` so a drain
+        # payload and a §6.3 nav_probe for the same agent are both
+        # preserved (each kind has at most one entry per agent).
         if is_first_seen and payloads:
-            latest_by_agent: dict[str, dict] = {}
+            latest_by_key: dict[tuple[str, str], dict] = {}
             for p in payloads:
-                latest_by_agent[p.get("agent_id", "")] = p
+                key = (p.get("agent_id", ""), p.get("kind", ""))
+                latest_by_key[key] = p
             payloads = sorted(
-                latest_by_agent.values(), key=lambda p: int(p.get("seq", 0)),
+                latest_by_key.values(), key=lambda p: int(p.get("seq", 0)),
             )
 
         for payload in payloads:
@@ -2803,7 +2806,15 @@ def create_mesh_app(
             if seq > _poll_state["last_seen_seq"]:
                 _poll_state["last_seen_seq"] = seq
             agent_id = payload.get("agent_id", "")
-            event_bus.emit("browser_metrics", agent=agent_id, data=payload)
+            # §6.3 nav_probe events get their own type so the dashboard can
+            # render them distinctly (warning toast on mismatch, etc.) and
+            # they don't overwrite the per-minute drain in browserMetrics[].
+            event_type = (
+                "browser_nav_probe"
+                if payload.get("kind") == "nav_probe"
+                else "browser_metrics"
+            )
+            event_bus.emit(event_type, agent=agent_id, data=payload)
 
     async def _browser_metrics_loop() -> None:
         # First pass runs ~5s after boot to give the browser service time

--- a/tests/test_browser_metrics_ingest.py
+++ b/tests/test_browser_metrics_ingest.py
@@ -476,6 +476,57 @@ class TestMetricsPoll:
         await poll()
         assert event_bus.emit.call_count == 0
 
+    @pytest.mark.asyncio
+    async def test_nav_probe_payload_routes_to_distinct_event(
+        self, tmp_path, monkeypatch,
+    ):
+        """§6.3 nav_probe payloads must emit as ``browser_nav_probe`` (not
+        ``browser_metrics``) so the dashboard can render them distinctly
+        and they don't overwrite the per-minute drain payload in
+        browserMetrics[]."""
+        import httpx
+
+        canned = {
+            "current_seq": 2,
+            "boot_id": "b1",
+            "metrics": [
+                {
+                    "seq": 1, "ts": 1.0, "agent_id": "a1",
+                    "click_success": 1, "click_fail": 0, "nav_timeout": 0,
+                    "snapshot_count": 0, "snapshot_bytes_p50": 0,
+                    "snapshot_bytes_p95": 0, "click_window_size": 0,
+                    "click_success_rate_100": None,
+                },
+                {
+                    "seq": 2, "ts": 2.0, "agent_id": "a1",
+                    "kind": "nav_probe", "ok": True, "mismatches": [],
+                    "signals": {"webdriver": False},
+                },
+            ],
+        }
+
+        async def fake_get(self, url, *args, **kwargs):
+            req = httpx.Request("GET", url)
+            return httpx.Response(200, json=canned, request=req)
+
+        monkeypatch.setattr(httpx.AsyncClient, "get", fake_get)
+
+        app, event_bus, _cm = _build_mesh(tmp_path)
+        poll = _extract_poll_fn(app)
+        await poll()
+
+        # Two emit() calls, with distinct event types.
+        types = [c.args[0] for c in event_bus.emit.call_args_list]
+        assert "browser_metrics" in types
+        assert "browser_nav_probe" in types
+        # The nav_probe call carries the kind field intact.
+        probe_call = next(
+            c for c in event_bus.emit.call_args_list
+            if c.args[0] == "browser_nav_probe"
+        )
+        assert probe_call.kwargs["data"]["kind"] == "nav_probe"
+        assert probe_call.kwargs["agent"] == "a1"
+
 
 # ── Helpers ─────────────────────────────────────────────────────────
 

--- a/tests/test_browser_nav_probe.py
+++ b/tests/test_browser_nav_probe.py
@@ -1,0 +1,191 @@
+"""Phase 3 §6.3 — navigator self-test probe."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+
+def _make_inst(monkeypatch=None):
+    """CamoufoxInstance with an async-mocked ``page.evaluate``."""
+    if monkeypatch is not None:
+        monkeypatch.delenv("BROWSER_RECORD_BEHAVIOR", raising=False)
+        import src.browser.flags as flags
+        flags._operator_settings = None
+
+    from src.browser.service import CamoufoxInstance
+
+    page = MagicMock()
+    page.evaluate = AsyncMock()
+    inst = CamoufoxInstance("a1", MagicMock(), MagicMock(), page)
+    return inst
+
+
+def _ok_signals(os_hint="windows", **overrides):
+    """A clean signals dict that should produce ok=True."""
+    base = {
+        "webdriver": False,
+        "plugins_len": 4,
+        "mimeTypes_len": 2,
+        "hardwareConcurrency": 8,
+        "deviceMemory": None,
+        "userAgent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:138.0) "
+                     "Gecko/20100101 Firefox/138.0",
+        "platform": {"windows": "Win32", "macos": "MacIntel",
+                     "linux": "Linux x86_64"}[os_hint],
+        "language": "en-US",
+        "timezone": "America/Los_Angeles",
+        "conn_effective": "4g",
+        "conn_downlink": 12.4,
+        "conn_rtt": 55,
+    }
+    base.update(overrides)
+    return base
+
+
+class TestProbeOK:
+    @pytest.mark.asyncio
+    async def test_clean_browser_passes(self, monkeypatch, tmp_path):
+        from src.browser.service import BrowserManager
+
+        mgr = BrowserManager(profiles_dir=str(tmp_path / "profiles"))
+        inst = _make_inst(monkeypatch)
+        inst.page.evaluate.return_value = _ok_signals()
+
+        await mgr._run_navigator_probe(inst)
+
+        assert inst.probe_result is not None
+        assert inst.probe_result["ok"] is True
+        assert inst.probe_result["mismatches"] == []
+
+
+class TestProbeMismatches:
+    @pytest.mark.asyncio
+    async def test_webdriver_true_flags_mismatch(self, monkeypatch, tmp_path):
+        from src.browser.service import BrowserManager
+
+        mgr = BrowserManager(profiles_dir=str(tmp_path / "profiles"))
+        inst = _make_inst(monkeypatch)
+        inst.page.evaluate.return_value = _ok_signals(webdriver=True)
+
+        await mgr._run_navigator_probe(inst)
+        assert inst.probe_result["ok"] is False
+        assert any("webdriver" in m for m in inst.probe_result["mismatches"])
+
+    @pytest.mark.asyncio
+    async def test_platform_mismatch_flagged(self, monkeypatch, tmp_path):
+        """os_hint=windows but platform=Linux x86_64 — fingerprint inconsistency."""
+        from src.browser.service import BrowserManager
+
+        mgr = BrowserManager(profiles_dir=str(tmp_path / "profiles"))
+        inst = _make_inst(monkeypatch)
+        monkeypatch.setenv("BROWSER_OS", "windows")
+        inst.page.evaluate.return_value = _ok_signals(platform="Linux x86_64")
+
+        await mgr._run_navigator_probe(inst)
+        assert inst.probe_result["ok"] is False
+        assert any("platform" in m for m in inst.probe_result["mismatches"])
+
+    @pytest.mark.asyncio
+    async def test_non_firefox_ua_flagged(self, monkeypatch, tmp_path):
+        from src.browser.service import BrowserManager
+
+        mgr = BrowserManager(profiles_dir=str(tmp_path / "profiles"))
+        inst = _make_inst(monkeypatch)
+        inst.page.evaluate.return_value = _ok_signals(
+            userAgent="Mozilla/5.0 (X11; Linux x86_64) Chrome/120.0.0.0",
+        )
+
+        await mgr._run_navigator_probe(inst)
+        assert inst.probe_result["ok"] is False
+        assert any("Firefox" in m for m in inst.probe_result["mismatches"])
+
+    @pytest.mark.asyncio
+    async def test_missing_navigator_connection_flagged(
+        self, monkeypatch, tmp_path,
+    ):
+        """§6.6 spoof not landing → conn_effective null → mismatch."""
+        from src.browser.service import BrowserManager
+
+        mgr = BrowserManager(profiles_dir=str(tmp_path / "profiles"))
+        inst = _make_inst(monkeypatch)
+        inst.page.evaluate.return_value = _ok_signals(conn_effective=None)
+
+        await mgr._run_navigator_probe(inst)
+        assert inst.probe_result["ok"] is False
+        assert any("connection" in m for m in inst.probe_result["mismatches"])
+
+
+class TestProbeResilience:
+    @pytest.mark.asyncio
+    async def test_evaluate_failure_records_result(self, monkeypatch, tmp_path):
+        """A page.evaluate raising must not crash _start_browser. The
+        failure is recorded as a probe result with ok=False so operators
+        still see the diagnostic signal."""
+        from src.browser.service import BrowserManager
+
+        mgr = BrowserManager(profiles_dir=str(tmp_path / "profiles"))
+        inst = _make_inst(monkeypatch)
+        inst.page.evaluate.side_effect = RuntimeError("page closed")
+
+        await mgr._run_navigator_probe(inst)
+        assert inst.probe_result is not None
+        assert inst.probe_result["ok"] is False
+        assert "evaluate failed" in inst.probe_result["mismatches"][0]
+
+
+class TestProbeEmission:
+    @pytest.mark.asyncio
+    async def test_probe_payload_lands_in_history(self, monkeypatch, tmp_path):
+        """Mesh poll consumes _metrics_history; nav_probe events must be
+        written there even when no in-process sink is wired."""
+        from src.browser.service import BrowserManager
+
+        mgr = BrowserManager(profiles_dir=str(tmp_path / "profiles"))
+        inst = _make_inst(monkeypatch)
+        inst.page.evaluate.return_value = _ok_signals()
+
+        await mgr._run_navigator_probe(inst)
+
+        snap = mgr.get_recent_metrics(since_seq=0)
+        kinds = [p.get("kind") for p in snap["metrics"]]
+        assert "nav_probe" in kinds
+
+    @pytest.mark.asyncio
+    async def test_probe_payload_calls_sink(self, monkeypatch, tmp_path):
+        from src.browser.service import BrowserManager
+
+        seen: list[dict] = []
+        mgr = BrowserManager(
+            profiles_dir=str(tmp_path / "profiles"),
+            metrics_sink=seen.append,
+        )
+        inst = _make_inst(monkeypatch)
+        inst.page.evaluate.return_value = _ok_signals(webdriver=True)
+
+        await mgr._run_navigator_probe(inst)
+
+        probe = next(p for p in seen if p.get("kind") == "nav_probe")
+        assert probe["agent_id"] == inst.agent_id
+        assert probe["ok"] is False
+        assert any("webdriver" in m for m in probe["mismatches"])
+
+    @pytest.mark.asyncio
+    async def test_status_endpoint_includes_probe_summary(
+        self, monkeypatch, tmp_path,
+    ):
+        """``/browser/{agent}/status`` must surface probe ok + mismatches
+        so operators can spot-check without subscribing to events."""
+        from src.browser.service import BrowserManager
+
+        mgr = BrowserManager(profiles_dir=str(tmp_path / "profiles"))
+        inst = _make_inst(monkeypatch)
+        mgr._instances["a1"] = inst
+        inst.page.evaluate.return_value = _ok_signals()
+        inst.page.url = "https://example.com/"
+        await mgr._run_navigator_probe(inst)
+
+        st = await mgr.get_status("a1")
+        assert st["probe_ok"] is True
+        assert st["probe_mismatches"] == []

--- a/tests/test_browser_nav_probe.py
+++ b/tests/test_browser_nav_probe.py
@@ -8,7 +8,12 @@ import pytest
 
 
 def _make_inst(monkeypatch=None):
-    """CamoufoxInstance with an async-mocked ``page.evaluate``."""
+    """CamoufoxInstance with async-mocked ``page.evaluate`` AND ``page.goto``.
+
+    The probe pre-navigates to ``about:blank`` to isolate the read from
+    any page-script shadowing on a resumed persistent profile (P0 fix
+    from review). Tests must therefore mock ``goto`` too.
+    """
     if monkeypatch is not None:
         monkeypatch.delenv("BROWSER_RECORD_BEHAVIOR", raising=False)
         import src.browser.flags as flags
@@ -18,6 +23,7 @@ def _make_inst(monkeypatch=None):
 
     page = MagicMock()
     page.evaluate = AsyncMock()
+    page.goto = AsyncMock()
     inst = CamoufoxInstance("a1", MagicMock(), MagicMock(), page)
     return inst
 
@@ -115,6 +121,48 @@ class TestProbeMismatches:
         await mgr._run_navigator_probe(inst)
         assert inst.probe_result["ok"] is False
         assert any("connection" in m for m in inst.probe_result["mismatches"])
+
+
+class TestProbeIsolation:
+    @pytest.mark.asyncio
+    async def test_probe_navigates_to_about_blank_first(
+        self, monkeypatch, tmp_path,
+    ):
+        """Persistent profiles resume to whatever page was open last
+        session. That page's globals could shadow ``Navigator.prototype``
+        properties. The probe must navigate to ``about:blank`` first to
+        guarantee it reads engine signals, not page-injected ones."""
+        from src.browser.service import BrowserManager
+
+        mgr = BrowserManager(profiles_dir=str(tmp_path / "profiles"))
+        inst = _make_inst(monkeypatch)
+        inst.page.evaluate.return_value = _ok_signals()
+
+        await mgr._run_navigator_probe(inst)
+
+        inst.page.goto.assert_awaited_once()
+        call = inst.page.goto.await_args
+        assert call.args == ("about:blank",)
+
+    @pytest.mark.asyncio
+    async def test_probe_continues_when_about_blank_fails(
+        self, monkeypatch, tmp_path,
+    ):
+        """If ``about:blank`` itself fails to load (weird edge case),
+        probe should still attempt to read signals from whatever the
+        current page is — better partial signal than no signal."""
+        from src.browser.service import BrowserManager
+
+        mgr = BrowserManager(profiles_dir=str(tmp_path / "profiles"))
+        inst = _make_inst(monkeypatch)
+        inst.page.goto.side_effect = RuntimeError("blank blocked")
+        inst.page.evaluate.return_value = _ok_signals()
+
+        await mgr._run_navigator_probe(inst)
+
+        # Despite goto failure, evaluate ran and produced a result.
+        assert inst.probe_result is not None
+        assert inst.probe_result["ok"] is True
 
 
 class TestProbeResilience:

--- a/tests/test_browser_service.py
+++ b/tests/test_browser_service.py
@@ -553,22 +553,29 @@ class TestUAOverride:
     """Tests for BROWSER_UA_VERSION user-agent override."""
 
     def test_no_override_by_default(self):
-        """Without BROWSER_UA_VERSION, no config or UA pref should be set."""
+        """Without BROWSER_UA_VERSION, no UA-specific keys should be set.
+
+        Phase 3 §6.6 introduced unconditional ``navigator.connection.*``
+        keys plus ``i_know_what_im_doing`` so the assertions for those
+        no longer hold here — but ``navigator.userAgent`` and the
+        Firefox pref-level override must still be absent on the no-UA-
+        version path. That's the actual contract this test is guarding.
+        """
         from src.browser.stealth import build_launch_options
         with patch.dict("os.environ", {}, clear=True):
             opts = build_launch_options("agent1", "/tmp/profile")
-        assert "config" not in opts
-        assert "i_know_what_im_doing" not in opts
+        assert "navigator.userAgent" not in (opts.get("config") or {})
         assert "general.useragent.override" not in opts["firefox_user_prefs"]
 
     def test_override_sets_camoufox_config(self):
-        """BROWSER_UA_VERSION should set Camoufox's config dict (primary mechanism)."""
+        """BROWSER_UA_VERSION should set Camoufox's UA config (primary mechanism)."""
         from src.browser.stealth import build_launch_options
         with patch.dict("os.environ", {"BROWSER_UA_VERSION": "138.0"}, clear=True):
             opts = build_launch_options("agent1", "/tmp/profile")
-        assert opts["config"] == {
-            "navigator.userAgent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:138.0) Gecko/20100101 Firefox/138.0",
-        }
+        assert opts["config"]["navigator.userAgent"] == (
+            "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:138.0) "
+            "Gecko/20100101 Firefox/138.0"
+        )
         assert opts["i_know_what_im_doing"] is True
 
     def test_override_sets_firefox_pref_fallback(self):
@@ -615,11 +622,13 @@ class TestUAOverride:
         assert "Firefox/138.0.1" in opts["config"]["navigator.userAgent"]
 
     def test_override_rejects_non_numeric(self):
-        """Non-numeric version should be ignored with a warning."""
+        """Non-numeric version should be ignored — UA-specific keys absent."""
         from src.browser.stealth import build_launch_options
         with patch.dict("os.environ", {"BROWSER_UA_VERSION": "abc"}, clear=True):
             opts = build_launch_options("agent1", "/tmp/profile")
-        assert "config" not in opts
+        # The §6.6 navigator.connection.* keys are still set; only the
+        # UA override path must not have run.
+        assert "navigator.userAgent" not in (opts.get("config") or {})
         assert "general.useragent.override" not in opts["firefox_user_prefs"]
 
     def test_override_rejects_single_number(self):
@@ -627,7 +636,7 @@ class TestUAOverride:
         from src.browser.stealth import build_launch_options
         with patch.dict("os.environ", {"BROWSER_UA_VERSION": "138"}, clear=True):
             opts = build_launch_options("agent1", "/tmp/profile")
-        assert "config" not in opts
+        assert "navigator.userAgent" not in (opts.get("config") or {})
 
     def test_override_rejects_empty_parts(self):
         """Malformed versions like '138.' or '.0' should be rejected."""
@@ -635,7 +644,9 @@ class TestUAOverride:
         for bad in ("138.", ".0", ".", ".."):
             with patch.dict("os.environ", {"BROWSER_UA_VERSION": bad}, clear=True):
                 opts = build_launch_options("agent1", "/tmp/profile")
-            assert "config" not in opts, f"Expected rejection for {bad!r}"
+            assert "navigator.userAgent" not in (opts.get("config") or {}), (
+                f"Expected rejection for {bad!r}"
+            )
 
     def test_override_strips_whitespace(self):
         """Leading/trailing whitespace should be stripped."""
@@ -648,7 +659,9 @@ class TestUAOverride:
         from src.browser.stealth import build_launch_options
         with patch.dict("os.environ", {"BROWSER_UA_VERSION": ""}, clear=True):
             opts = build_launch_options("agent1", "/tmp/profile")
-        assert "config" not in opts
+        # config exists for §6.6 NetworkInformation; the UA-specific
+        # key inside it is what must not be set.
+        assert "navigator.userAgent" not in (opts.get("config") or {})
 
     def test_build_ua_string_directly(self):
         """Unit test the helper function."""

--- a/tests/test_stealth_runtime.py
+++ b/tests/test_stealth_runtime.py
@@ -1,0 +1,111 @@
+"""Phase 3 §6.4 / §6.6 — UA guard + NetworkInformation per-agent fingerprint."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+# ── §6.4 Firefox UA tripwire ──────────────────────────────────────────────────
+
+
+class TestFirefoxUAGuard:
+    def test_firefox_ua_passes(self):
+        from src.browser.stealth import _assert_firefox_ua
+
+        _assert_firefox_ua("Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:138.0) "
+                           "Gecko/20100101 Firefox/138.0")  # no raise
+
+    def test_chromium_ua_raises(self):
+        """Sec-CH-UA-* would leak inconsistency; refuse the UA early."""
+        from src.browser.stealth import _assert_firefox_ua
+
+        with pytest.raises(ValueError, match="Sec-CH-UA"):
+            _assert_firefox_ua(
+                "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 "
+                "(KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36",
+            )
+
+    def test_empty_ua_is_no_op(self):
+        """We never want to fail-fast on a missing UA — it's a normal
+        path (no override requested)."""
+        from src.browser.stealth import _assert_firefox_ua
+
+        _assert_firefox_ua("")  # no raise
+        _assert_firefox_ua(None)  # type: ignore — also no raise
+
+    def test_build_launch_options_with_chromium_uaversion_would_not_raise(
+        self, monkeypatch,
+    ):
+        """``BROWSER_UA_VERSION`` only takes a version string; the OS
+        template wraps it as Firefox. There's no in-band way for an
+        operator to inject a Chromium UA via the env var. This test
+        documents that fact — the guard fires only if a future code
+        change introduces a non-Firefox template path."""
+        from src.browser.stealth import build_launch_options
+
+        monkeypatch.setenv("BROWSER_UA_VERSION", "138.0")
+        opts = build_launch_options("agent-1", "/tmp/profile")
+        ua = opts["config"].get("navigator.userAgent")
+        assert ua and "Firefox/138.0" in ua
+
+
+# ── §6.6 NetworkInformation per-agent stable values ──────────────────────────
+
+
+class TestNetworkInformation:
+    def test_pick_network_info_is_deterministic(self):
+        from src.browser.stealth import pick_network_info
+
+        a = pick_network_info("agent-stable")
+        b = pick_network_info("agent-stable")
+        assert a == b
+
+    def test_pick_network_info_different_agents_differ(self):
+        from src.browser.stealth import pick_network_info
+
+        picks = {
+            tuple(sorted(pick_network_info(f"a{i}").items()))
+            for i in range(50)
+        }
+        # Across 50 agents we expect a healthy spread of (downlink, rtt)
+        # combinations — not a single universal value.
+        assert len(picks) >= 30
+
+    def test_pick_network_info_in_band(self):
+        """Stay within plausible desktop broadband ranges."""
+        from src.browser.stealth import pick_network_info
+
+        for i in range(200):
+            ni = pick_network_info(f"agent-{i}")
+            assert ni["effectiveType"] == "4g"
+            assert 5.0 <= ni["downlink"] <= 20.0
+            assert 20 <= ni["rtt"] <= 120
+            assert ni["saveData"] is False
+
+    def test_build_launch_options_writes_navigator_connection(self, monkeypatch):
+        from src.browser.stealth import build_launch_options, pick_network_info
+
+        with patch.dict("os.environ", {}, clear=True):
+            opts = build_launch_options("agent-x", "/tmp/profile")
+        cfg = opts.get("config") or {}
+        expected = pick_network_info("agent-x")
+        assert cfg["navigator.connection.effectiveType"] == expected["effectiveType"]
+        assert cfg["navigator.connection.downlink"] == expected["downlink"]
+        assert cfg["navigator.connection.rtt"] == expected["rtt"]
+        assert cfg["navigator.connection.saveData"] is False
+        assert opts["i_know_what_im_doing"] is True
+
+    def test_ua_override_does_not_clobber_netinfo(self, monkeypatch):
+        """Setting BROWSER_UA_VERSION used to overwrite the whole config
+        dict — must not regress now that we share the dict with §6.6
+        keys."""
+        from src.browser.stealth import build_launch_options, pick_network_info
+
+        monkeypatch.setenv("BROWSER_UA_VERSION", "138.0")
+        opts = build_launch_options("agent-y", "/tmp/profile")
+        cfg = opts["config"]
+        expected = pick_network_info("agent-y")
+        # Both kinds of override coexist
+        assert cfg["navigator.userAgent"].endswith("Firefox/138.0")
+        assert cfg["navigator.connection.downlink"] == expected["downlink"]


### PR DESCRIPTION
## Summary

Three runtime stealth signals that work together to detect / prevent fingerprint regressions at the JS layer.

### §6.3 — Navigator self-test probe
- One-shot ``page.evaluate`` runs immediately after Camoufox starts (best-effort; failure doesn't block startup)
- Reads ``navigator.{webdriver, plugins, mimeTypes, hardwareConcurrency, deviceMemory, userAgent, platform, language, connection.*}`` + Intl timezone
- Flags four mismatch classes: webdriver≠false / platform≠os_hint / UA lacks Firefox / navigator.connection null
- Result on ``inst.probe_result``, surfaced via ``/browser/{agent}/status``
- Emits one-shot ``browser_nav_probe`` event via existing Phase 2.1 history+poll pipeline (NOT ``browser_metrics`` — distinct routing so the dashboard ``browserMetrics[]`` index isn't overwritten by drain payloads)
- Dashboard shows fingerprint-drift toast (8s linger) on mismatch

### §6.4 — Firefox UA tripwire
- ``_assert_firefox_ua()`` raises if a non-Firefox UA hits the launch-options path
- Why: Sec-CH-UA-* headers are Chromium-only; a UA→headers inconsistency is itself a detection signal. Future Chromium-base switch must wire Client-Hints overrides before removing this guard

### §6.6 — NetworkInformation per-agent fingerprint
- Per-agent stable values (effectiveType=4g, downlink 5–20 Mbps, rtt 20–120 ms, saveData=false)
- HMAC-derived from agent_id; doesn't flap across restarts
- Injected via Camoufox ``config`` dict alongside the existing UA override path

### Mesh poll refinement
First-seen collapse key changed from ``agent_id`` to ``(agent_id, kind)`` so a fresh mesh can replay both the latest drain AND the latest probe for each agent without one stomping the other.

## Test plan
- [x] ``tests/test_stealth_runtime.py`` — UA guard pass/fail/empty, NetInfo determinism, in-band ranges, UA-override coexistence with §6.6 keys
- [x] ``tests/test_browser_nav_probe.py`` — probe ok/mismatch matrix (webdriver/platform/UA/connection), evaluate-failure resilience, history+sink emission, status-endpoint surfacing
- [x] ``tests/test_browser_metrics_ingest.py`` — mesh poll routes ``nav_probe`` to ``browser_nav_probe`` event type
- [x] Existing ``TestUAOverride`` updated — ``"config" in opts`` is now always true for §6.6; tests assert UA-specific sub-key absence instead
- [x] Full browser+dashboard suite (743 tests) — no regressions
- [x] ruff clean, JS syntax check clean

## Blast radius
- ``GET /browser/{agent}/status`` gains optional ``probe_ok``/``probe_mismatches`` fields. Existing consumers (mesh boot-id check, runtime readiness) only read pre-existing keys
- New event type ``browser_nav_probe`` on the WebSocket. Dashboard renders it; other consumers get one extra event type they can ignore
- Camoufox ``config`` dict + ``i_know_what_im_doing=True`` now set unconditionally (was only set on UA override). If Camoufox version is too old to honour ``navigator.connection.*`` keys, those silently no-op — and the §6.3 probe catches that as a mismatch
- Probe runs once per browser-start. ``page.evaluate`` is ~10ms; not on a hot path