### PR TITLE
Phase 3.5: referrer realism on navigate

### DIFF
--- a/src/agent/builtins/browser_tool.py
+++ b/src/agent/builtins/browser_tool.py
@@ -45,7 +45,11 @@ async def _browser_command(mesh_client, action: str, params: dict | None = None)
         "For heavy SPAs (X/Twitter, Gmail, etc.) use wait_until='networkidle' or "
         "wait_until='load' so the page fully renders before you read elements. "
         "Set snapshot_after=true to include element refs in the response (saves "
-        "a separate browser_get_elements call)."
+        "a separate browser_get_elements call). "
+        "Leave 'referer' unset for normal browsing — the service picks a "
+        "plausible referer (search engine, same-origin, etc.) based on the "
+        "destination so the page sees a realistic arrival pattern. Override "
+        "only when you're explicitly modeling a specific click-through."
     ),
     parameters={
         "url": {"type": "string", "description": "URL to navigate to"},
@@ -70,20 +74,35 @@ async def _browser_command(mesh_client, action: str, params: dict | None = None)
             "description": "Include element snapshot in the response (default false)",
             "default": False,
         },
+        "referer": {
+            "type": "string",
+            "description": (
+                "Optional referer URL to send with the navigation. "
+                "Default: leave unset and let the service pick. "
+                "Pass an empty string to explicitly send no referer "
+                "(equivalent to a typed URL or bookmark)."
+            ),
+        },
     },
     parallel_safe=False,
 )
 async def browser_navigate(
     url: str, wait_ms: int = 1000, wait_until: str = "domcontentloaded",
     snapshot_after: bool = False,
+    referer: str | None = None,
     *, mesh_client=None,
 ) -> dict:
     """Navigate to a URL via the browser service."""
-    return await _browser_command(
-        mesh_client, "navigate",
-        {"url": url, "wait_ms": wait_ms, "wait_until": wait_until,
-         "snapshot_after": snapshot_after},
-    )
+    params: dict = {
+        "url": url, "wait_ms": wait_ms, "wait_until": wait_until,
+        "snapshot_after": snapshot_after,
+    }
+    # Forward referer ONLY when the caller specified it — None means
+    # "let the service pick", which is signalled by the param's absence
+    # so the browser-service navigate picker fires.
+    if referer is not None:
+        params["referer"] = referer
+    return await _browser_command(mesh_client, "navigate", params)
 
 
 @skill(

--- a/src/browser/server.py
+++ b/src/browser/server.py
@@ -148,8 +148,16 @@ def create_browser_app(manager: BrowserManager, lifespan=None) -> FastAPI:
         wait_ms = body.get("wait_ms", 1000)
         wait_until = body.get("wait_until", "domcontentloaded")
         snapshot_after = body.get("snapshot_after", False)
-        result = await manager.navigate(agent_id, url, wait_ms, wait_until,
-                                        snapshot_after=snapshot_after)
+        # §6.5 referer: forward the param ONLY when the caller included
+        # it. ``"referer" not in body`` ⇒ leave the kwarg default (None)
+        # so the service-side picker runs. Explicit empty-string ⇒
+        # caller wants direct nav. Any other string ⇒ caller override.
+        nav_kwargs: dict = {"snapshot_after": snapshot_after}
+        if "referer" in body:
+            nav_kwargs["referer"] = body["referer"]
+        result = await manager.navigate(
+            agent_id, url, wait_ms, wait_until, **nav_kwargs,
+        )
         await _apply_delay()
         return result
 

--- a/src/browser/service.py
+++ b/src/browser/service.py
@@ -25,7 +25,7 @@ from src.browser.captcha import get_solver
 from src.browser.profile_schema import migrate_profile
 from src.browser.redaction import CredentialRedactor
 from src.browser.ref_handle import RefHandle, RefStale
-from src.browser.stealth import build_launch_options
+from src.browser.stealth import build_launch_options, pick_referer, validate_referer
 from src.browser.timing import (
     action_delay,
     click_dwell,
@@ -370,6 +370,14 @@ class CamoufoxInstance:
         # doesn't all show the same Google referer back-to-back. Resets
         # on browser restart, matching a real user-session boundary.
         self.recent_referers: deque[str] = deque(maxlen=5)
+        # §6.5 first-real-navigate gate. With ``persistent_context=True``
+        # the browser resumes whatever page was open last session — the
+        # picker would otherwise treat that stale URL as a "previous page"
+        # and fabricate a same-origin referer for the next nav, even though
+        # there's been no recent navigation in this session. The flag flips
+        # to True after the first navigate completes; subsequent navs may
+        # use ``inst.page.url`` as the previous-URL hint.
+        self.had_real_navigate: bool = False
 
     def _register_page(self, page) -> str:
         """Assign a stable UUID to a Page if not already registered.
@@ -1114,27 +1122,44 @@ class BrowserManager:
 
             # §6.5 referer realism. ``referer is None`` ⇒ picker decides;
             # explicit ``""`` ⇒ direct navigation (no referer); any other
-            # string ⇒ caller override (Playwright passes it through).
+            # string ⇒ caller override, validated before reaching
+            # Playwright (the agent skill is LLM-callable so a malformed
+            # value can land here from untrusted-by-default input).
             if referer is None:
-                from src.browser.stealth import pick_referer
-                previous_url = inst.page.url if inst.page else ""
+                # Only honour ``inst.page.url`` as the previous-URL hint
+                # AFTER the first navigate this session — otherwise a
+                # persistent profile resume would falsely indicate
+                # internal-link arrival on the very first nav.
+                previous_url = (
+                    inst.page.url if inst.page and inst.had_real_navigate
+                    else ""
+                )
                 resolved_referer = pick_referer(
                     url,
                     previous_url=previous_url,
                     recent_referers=tuple(inst.recent_referers),
                 )
             else:
-                resolved_referer = referer
-            # Maintain the rolling-5 history on the instance so subsequent
-            # navs avoid immediate repeats. We track even empty strings so
-            # the picker can see that we just used a "direct" pattern and
-            # not always pick direct again.
+                # Caller override — must validate. ValueError surfaces
+                # to the agent as a navigate error; better than silently
+                # forwarding ``javascript:alert(1)`` to Playwright.
+                try:
+                    resolved_referer = validate_referer(referer)
+                except ValueError as e:
+                    return {
+                        "success": False,
+                        "error": f"invalid referer: {e}",
+                    }
+
+            # Maintain the rolling-5 history on the instance. Both
+            # picker output and validated overrides are tracked so the
+            # picker can see "we just used a direct/social/search
+            # pattern" and rotate accordingly.
             inst.recent_referers.append(resolved_referer)
 
             # Playwright accepts ``referer`` for goto and sets both the
-            # network header and document.referrer consistently. Pass
-            # the empty string as no kwarg — Playwright treats unset as
-            # "no override" which is the right behaviour here.
+            # network header and document.referrer consistently. Empty
+            # string ⇒ omit the kwarg ⇒ Playwright sends no Referer.
             goto_kwargs: dict = {"wait_until": wait_until, "timeout": 30000}
             if resolved_referer:
                 goto_kwargs["referer"] = resolved_referer
@@ -1162,6 +1187,12 @@ class BrowserManager:
             inst.recorder.record_navigate(
                 host=parsed.hostname or "", wait_until=wait_until,
             )
+
+            # §6.5: future navs may now use ``inst.page.url`` as a
+            # previous-URL hint for the picker. The flag stays True for
+            # the lifetime of this CamoufoxInstance; a browser restart
+            # creates a new instance and resets it.
+            inst.had_real_navigate = True
 
             inst.dialog_active = False
             inst.dialog_detected = False

--- a/src/browser/service.py
+++ b/src/browser/service.py
@@ -365,6 +365,11 @@ class CamoufoxInstance:
         # off so production pays no cost.
         from src.browser.recorder import BehaviorRecorder
         self.recorder = BehaviorRecorder(agent_id)
+        # §6.5 rolling-5 history of recently-used referers. The picker
+        # uses this to avoid immediate repeats so a fleet at scale
+        # doesn't all show the same Google referer back-to-back. Resets
+        # on browser restart, matching a real user-session boundary.
+        self.recent_referers: deque[str] = deque(maxlen=5)
 
     def _register_page(self, page) -> str:
         """Assign a stable UUID to a Page if not already registered.
@@ -1066,6 +1071,7 @@ class BrowserManager:
         self, agent_id: str, url: str, wait_ms: int = 1000,
         wait_until: str = "domcontentloaded",
         snapshot_after: bool = False,
+        referer: str | None = None,
     ) -> dict:
         """Navigate to URL and return page text.
 
@@ -1074,6 +1080,15 @@ class BrowserManager:
           - "load": all resources loaded; good for most sites
           - "networkidle": no network requests for 500ms; best for heavy SPAs (X, etc.)
           - "commit": first byte received; fastest, rarely useful
+
+        referer (Phase 3 §6.5): override the Referer header / document.referrer
+        for this nav. ``None`` (default) lets the service pick a plausible
+        value from :func:`src.browser.stealth.pick_referer` based on the
+        target host and the agent's recent nav history. Pass an empty
+        string ``""`` to explicitly send NO referer (equivalent to a
+        bookmarked / typed-URL arrival). Pass a specific URL to override
+        the picker entirely — useful when the agent is following a known
+        link from a specific page.
         """
         # Validate URL scheme
         try:
@@ -1096,10 +1111,38 @@ class BrowserManager:
                     "success": False,
                     "error": "User has browser control — action paused until control is released.",
                 }
+
+            # §6.5 referer realism. ``referer is None`` ⇒ picker decides;
+            # explicit ``""`` ⇒ direct navigation (no referer); any other
+            # string ⇒ caller override (Playwright passes it through).
+            if referer is None:
+                from src.browser.stealth import pick_referer
+                previous_url = inst.page.url if inst.page else ""
+                resolved_referer = pick_referer(
+                    url,
+                    previous_url=previous_url,
+                    recent_referers=tuple(inst.recent_referers),
+                )
+            else:
+                resolved_referer = referer
+            # Maintain the rolling-5 history on the instance so subsequent
+            # navs avoid immediate repeats. We track even empty strings so
+            # the picker can see that we just used a "direct" pattern and
+            # not always pick direct again.
+            inst.recent_referers.append(resolved_referer)
+
+            # Playwright accepts ``referer`` for goto and sets both the
+            # network header and document.referrer consistently. Pass
+            # the empty string as no kwarg — Playwright treats unset as
+            # "no override" which is the right behaviour here.
+            goto_kwargs: dict = {"wait_until": wait_until, "timeout": 30000}
+            if resolved_referer:
+                goto_kwargs["referer"] = resolved_referer
+
             # Single retry on timeout — transient network issues get a second chance.
             for attempt in range(2):
                 try:
-                    await inst.page.goto(url, wait_until=wait_until, timeout=30000)
+                    await inst.page.goto(url, **goto_kwargs)
                     break
                 except Exception as e:
                     if attempt == 0 and "timeout" in str(e).lower():

--- a/src/browser/stealth.py
+++ b/src/browser/stealth.py
@@ -152,12 +152,13 @@ def validate_referer(referer: str) -> str:
 
     Allowed shapes:
       * ``""`` — explicit no-referer, equivalent to a typed-URL arrival
+      * Whitespace-only strings — normalized to ``""``
       * ``http://...`` or ``https://...`` with a hostname
 
-    Rejected:
-      * Whitespace-only strings (would emit a malformed Referer header)
+    Rejected (raises ``ValueError``):
       * Pseudo-schemes (``javascript:``, ``data:``, ``file:``, ``about:``)
       * URLs without a hostname (``http:///path``)
+      * Non-string types
 
     The agent skill is LLM-callable, so a malformed value can reach
     here from untrusted-by-default agent output. Playwright doesn't

--- a/src/browser/stealth.py
+++ b/src/browser/stealth.py
@@ -81,8 +81,13 @@ _SEARCH_REFERERS: tuple[str, ...] = (
 _SOCIAL_REFERERS: dict[str, tuple[str, ...]] = {
     # Pool of >1 entry per destination so the rolling-5 history can
     # rotate without creating an obvious "every 6th visit is t.co"
-    # pattern. The same-origin shapes are plausible "user clicked a
-    # tweet from another tweet" arrivals.
+    # pattern. Path-bearing entries (``twitter.com/home``) are
+    # intentional — they mimic "user clicked a tweet from another
+    # tweet/explore tab" arrivals. Real Referer headers carry the
+    # full path of the source page, so a path-bearing referer is the
+    # closer-to-real shape; the bare-origin entries (``t.co/``) cover
+    # the click-tracking shim case. Picker emits these unchanged via
+    # ``rng.choice`` — no path-stripping needed.
     "twitter.com": (
         "https://t.co/",
         "https://twitter.com/home",
@@ -224,8 +229,19 @@ def pick_referer(
             prev = urlparse(previous_url)
             if (prev.hostname and prev.scheme
                     and prev.hostname.lower() == host):
-                # Real-user-shape: landed via internal link from "/"
-                return f"{prev.scheme}://{prev.hostname}/"
+                # Real-user-shape: landed via internal link from "/".
+                # Rebuild the origin from ``hostname`` + ``port`` rather
+                # than using ``netloc`` directly: ``netloc`` includes
+                # userinfo (``user:pass@host``), and emitting that as
+                # a Referer would both leak credentials AND look like
+                # a bot. Including the non-default port is intentional
+                # — browsers treat ``host:8443`` and ``host`` as
+                # different origins, so a mismatch on emit is itself
+                # a fingerprint bug.
+                authority = prev.hostname.lower()
+                if prev.port is not None:
+                    authority = f"{authority}:{prev.port}"
+                return f"{prev.scheme}://{authority}/"
         except Exception:
             pass
 

--- a/src/browser/stealth.py
+++ b/src/browser/stealth.py
@@ -79,30 +79,102 @@ _SEARCH_REFERERS: tuple[str, ...] = (
 # own click-tracking shim; every real Twitter outbound link travels
 # through it.
 _SOCIAL_REFERERS: dict[str, tuple[str, ...]] = {
-    "twitter.com": ("https://t.co/",),
-    "x.com": ("https://t.co/",),
+    # Pool of >1 entry per destination so the rolling-5 history can
+    # rotate without creating an obvious "every 6th visit is t.co"
+    # pattern. The same-origin shapes are plausible "user clicked a
+    # tweet from another tweet" arrivals.
+    "twitter.com": (
+        "https://t.co/",
+        "https://twitter.com/home",
+        "https://twitter.com/explore",
+    ),
+    "x.com": (
+        "https://t.co/",
+        "https://x.com/home",
+        "https://x.com/explore",
+    ),
 }
 
 # Hosts where real users typically arrive via direct navigation (typed
 # URL, bookmark, app deep-link). A search-engine referer would itself
 # be suspicious here — nobody Googles "gmail.com" to check their email.
+#
+# Includes OAuth identity providers: an OAuth flow lands on
+# ``accounts.google.com`` mid-redirect carrying the consumer-app's
+# Referer; a fabricated Google referer there breaks detection at
+# the IDP layer. Better to send no referer (matches the bookmark /
+# typed-URL shape) than a fabricated one.
 _DIRECT_NAV_HOSTS: frozenset[str] = frozenset({
+    # Webmail / messaging
     "mail.google.com",
     "gmail.com",
-    "github.com",
-    "app.slack.com",
     "outlook.office.com",
-    "calendar.google.com",
-    "drive.google.com",
+    "outlook.live.com",
+    # Source / collab
+    "github.com",
+    "gist.github.com",
     "linear.app",
     "notion.so",
     "www.notion.so",
+    # Real-time chat
+    "app.slack.com",
+    # Google productivity
+    "calendar.google.com",
+    "drive.google.com",
+    "docs.google.com",
+    "sheets.google.com",
+    # OAuth identity providers — preserve the consumer-app referer or
+    # send empty; never fabricate. (GitHub OAuth uses ``github.com``,
+    # already covered above.)
+    "accounts.google.com",
+    "login.microsoftonline.com",
+    "login.live.com",
+    "appleid.apple.com",
+    "id.atlassian.com",
 })
 
 # Probability of using a social referer when one is registered for the
 # target host. Real users mix social inbound with direct/search arrivals;
 # always-social would itself be a pattern break.
 _SOCIAL_REFERER_PROB: float = 0.30
+
+
+def validate_referer(referer: str) -> str:
+    """Sanitize a caller-supplied ``referer`` string.
+
+    Returns the cleaned value (empty string ⇒ "no referer"). Raises
+    ``ValueError`` on a value that isn't safe to forward to Playwright.
+
+    Allowed shapes:
+      * ``""`` — explicit no-referer, equivalent to a typed-URL arrival
+      * ``http://...`` or ``https://...`` with a hostname
+
+    Rejected:
+      * Whitespace-only strings (would emit a malformed Referer header)
+      * Pseudo-schemes (``javascript:``, ``data:``, ``file:``, ``about:``)
+      * URLs without a hostname (``http:///path``)
+
+    The agent skill is LLM-callable, so a malformed value can reach
+    here from untrusted-by-default agent output. Playwright doesn't
+    validate ``Page.goto(referer=...)`` strictly enough for our threat
+    model — defense in depth.
+    """
+    if not isinstance(referer, str):
+        raise ValueError(f"referer must be str, got {type(referer).__name__}")
+    cleaned = referer.strip()
+    if not cleaned:
+        return ""
+    try:
+        parsed = urlparse(cleaned)
+    except Exception as e:
+        raise ValueError(f"referer is not a parseable URL: {e}") from e
+    if parsed.scheme.lower() not in ("http", "https"):
+        raise ValueError(
+            f"referer must be http:// or https://, got scheme {parsed.scheme!r}",
+        )
+    if not parsed.hostname:
+        raise ValueError("referer URL has no hostname")
+    return cleaned
 
 
 def pick_referer(

--- a/src/browser/stealth.py
+++ b/src/browser/stealth.py
@@ -28,10 +28,157 @@ consistent and realistic:
 from __future__ import annotations
 
 import os
+import random
+from urllib.parse import urlparse
 
 from src.shared.utils import setup_logging
 
 logger = setup_logging("browser.stealth")
+
+
+# ── §6.5 Referrer realism on navigate ─────────────────────────────────────────
+
+
+# Why a referer pool at all: real users overwhelmingly arrive at a page with
+# a non-empty ``document.referrer`` and a ``Referer`` request header. An
+# agent that issues every navigate with no referer at all is, statistically,
+# the easiest fingerprint to flag at scale — a single property that holds
+# across every page load.
+#
+# The pool models the common arrival shapes:
+#
+#   * **same-origin** — landed via internal link from same host; populated
+#                       at runtime per-nav by the picker when the previous
+#                       URL's host matches; not a static pool entry
+#   * **direct**   — empty referer; typed URL, bookmark, or in-app deep
+#                    link; the right shape for first-party logged-in
+#                    surfaces (Gmail, GitHub dashboards) where a
+#                    search-engine referer would itself be suspicious
+#   * **social**   — Twitter/Facebook click-through; targeted at host-
+#                    specific destinations where a social referer is
+#                    plausible (don't fabricate ``t.co`` for arbitrary
+#                    sites — would itself be a tell)
+#   * **search**   — "user found us via Google/Bing/DDG"; safe default
+#                    for any site that tolerates organic-search arrivals
+#
+# Per the plan: picked per-nav with small randomness, stored per-agent
+# rolling-5 to avoid immediate repeats. The rolling history lives on
+# ``CamoufoxInstance`` so it survives across navigate calls but resets on
+# browser restart (matches a real session boundary).
+
+# Search-engine referrers — by far the most common organic-arrival shape.
+# Google dominates global desktop traffic; Bing + DDG are the next plausible
+# non-Google shapes that wouldn't themselves look like a spoof.
+_SEARCH_REFERERS: tuple[str, ...] = (
+    "https://www.google.com/",
+    "https://www.bing.com/",
+    "https://duckduckgo.com/",
+)
+
+# Social referers, keyed by destination hostname. ``t.co`` is Twitter's
+# own click-tracking shim; every real Twitter outbound link travels
+# through it.
+_SOCIAL_REFERERS: dict[str, tuple[str, ...]] = {
+    "twitter.com": ("https://t.co/",),
+    "x.com": ("https://t.co/",),
+}
+
+# Hosts where real users typically arrive via direct navigation (typed
+# URL, bookmark, app deep-link). A search-engine referer would itself
+# be suspicious here — nobody Googles "gmail.com" to check their email.
+_DIRECT_NAV_HOSTS: frozenset[str] = frozenset({
+    "mail.google.com",
+    "gmail.com",
+    "github.com",
+    "app.slack.com",
+    "outlook.office.com",
+    "calendar.google.com",
+    "drive.google.com",
+    "linear.app",
+    "notion.so",
+    "www.notion.so",
+})
+
+# Probability of using a social referer when one is registered for the
+# target host. Real users mix social inbound with direct/search arrivals;
+# always-social would itself be a pattern break.
+_SOCIAL_REFERER_PROB: float = 0.30
+
+
+def pick_referer(
+    target_url: str,
+    *,
+    previous_url: str = "",
+    recent_referers: tuple[str, ...] = (),
+    rng: random.Random | None = None,
+) -> str:
+    """Pick a plausible referer for navigating to ``target_url``.
+
+    Returns an empty string for the "direct navigation" case. Caller passes
+    the result straight to ``Page.goto(referer=...)`` which sets BOTH the
+    network ``Referer`` header and the JS-visible ``document.referrer`` —
+    keeping them consistent (a mismatch would itself be a detection signal).
+
+    Decision order:
+
+    1. If ``previous_url`` is a real page on the target host, return its
+       origin as a same-origin referer. Real users follow internal links;
+       same-origin referer is the commonest case once you're inside a site.
+    2. If the target host is in :data:`_DIRECT_NAV_HOSTS`, return empty.
+       These are surfaces where a search-engine referer would itself be
+       suspicious.
+    3. If the target host has a registered social pool, do a weighted
+       coin-flip (:data:`_SOCIAL_REFERER_PROB`) between social and search.
+    4. Default: pick a search-engine referer.
+
+    ``recent_referers`` is the per-agent rolling history (most-recent
+    last). The picker avoids returning a value already in that list,
+    falling back to a different slot in the same category. This breaks
+    the obvious "every nav has the same Google referer" pattern at
+    fleet scale.
+    """
+    rng = rng or random
+    try:
+        parsed = urlparse(target_url)
+    except Exception:
+        return ""
+    host = (parsed.hostname or "").lower()
+    if not host:
+        return ""
+
+    # 1. Same-origin: previous nav was on the same host
+    if previous_url:
+        try:
+            prev = urlparse(previous_url)
+            if (prev.hostname and prev.scheme
+                    and prev.hostname.lower() == host):
+                # Real-user-shape: landed via internal link from "/"
+                return f"{prev.scheme}://{prev.hostname}/"
+        except Exception:
+            pass
+
+    # 2. Direct-nav surface
+    if host in _DIRECT_NAV_HOSTS:
+        return ""
+
+    # 3. Social — only when destination has one registered AND only some
+    # of the time so we don't make every X visit look like it came
+    # from t.co.
+    social = _SOCIAL_REFERERS.get(host)
+    if social and rng.random() < _SOCIAL_REFERER_PROB:
+        unseen = [r for r in social if r not in recent_referers]
+        if unseen:
+            return rng.choice(unseen)
+
+    # 4. Default — search referer, avoid immediate repeats from history
+    candidates = [r for r in _SEARCH_REFERERS if r not in recent_referers]
+    if not candidates:
+        # Rolling history covered every option — fall back to the full
+        # set rather than return empty (which would itself be a
+        # notable pattern break).
+        candidates = list(_SEARCH_REFERERS)
+    return rng.choice(candidates)
+
 
 # ── Launch options ─────────────────────────────────────────────────────────────
 

--- a/tests/test_browser_service.py
+++ b/tests/test_browser_service.py
@@ -2352,9 +2352,13 @@ class TestNavigateWaitUntil:
         mgr._instances["a1"] = inst
 
         await mgr.navigate("a1", "https://x.com", wait_ms=0)
-        mock_page.goto.assert_awaited_once_with(
-            "https://x.com", wait_until="domcontentloaded", timeout=30000
-        )
+        # Assert the wait_until and timeout kwargs specifically — Phase 3
+        # §6.5 may also pass a ``referer=`` kwarg picked from the pool;
+        # we don't pin it here to keep this test about wait_until alone.
+        call = mock_page.goto.await_args
+        assert call.args == ("https://x.com",)
+        assert call.kwargs["wait_until"] == "domcontentloaded"
+        assert call.kwargs["timeout"] == 30000
 
     @pytest.mark.asyncio
     async def test_navigate_networkidle_passed_through(self):
@@ -2369,11 +2373,14 @@ class TestNavigateWaitUntil:
         inst = CamoufoxInstance("a1", MagicMock(), MagicMock(), mock_page)
         mgr._instances["a1"] = inst
 
-        result = await mgr.navigate("a1", "https://x.com", wait_ms=0, wait_until="networkidle")
-        assert result["success"] is True
-        mock_page.goto.assert_awaited_once_with(
-            "https://x.com", wait_until="networkidle", timeout=30000
+        result = await mgr.navigate(
+            "a1", "https://x.com", wait_ms=0, wait_until="networkidle",
         )
+        assert result["success"] is True
+        call = mock_page.goto.await_args
+        assert call.args == ("https://x.com",)
+        assert call.kwargs["wait_until"] == "networkidle"
+        assert call.kwargs["timeout"] == 30000
 
     @pytest.mark.asyncio
     async def test_navigate_invalid_wait_until_rejected(self):

--- a/tests/test_builtins.py
+++ b/tests/test_builtins.py
@@ -1050,6 +1050,49 @@ class TestBrowserNavigateHttpClient:
         assert "error" in result
         assert "mesh" in result["error"].lower()
 
+    @pytest.mark.asyncio
+    async def test_navigate_omits_referer_when_unset(self):
+        """§6.5: ``referer is None`` (default) ⇒ param NOT in the
+        forwarded body. The browser-service-side picker decides."""
+        from src.agent.builtins.browser_tool import browser_navigate
+
+        mc = AsyncMock()
+        mc.browser_command = AsyncMock(return_value={"url": "..."})
+
+        await browser_navigate(url="https://example.com", mesh_client=mc)
+        params = mc.browser_command.await_args.args[1]
+        assert "referer" not in params
+
+    @pytest.mark.asyncio
+    async def test_navigate_forwards_explicit_referer(self):
+        from src.agent.builtins.browser_tool import browser_navigate
+
+        mc = AsyncMock()
+        mc.browser_command = AsyncMock(return_value={"url": "..."})
+
+        await browser_navigate(
+            url="https://example.com",
+            referer="https://news.ycombinator.com/",
+            mesh_client=mc,
+        )
+        params = mc.browser_command.await_args.args[1]
+        assert params["referer"] == "https://news.ycombinator.com/"
+
+    @pytest.mark.asyncio
+    async def test_navigate_forwards_empty_referer_explicitly(self):
+        """``referer=""`` is a deliberate "no referer" — must reach the
+        service layer (which uses it to bypass the picker)."""
+        from src.agent.builtins.browser_tool import browser_navigate
+
+        mc = AsyncMock()
+        mc.browser_command = AsyncMock(return_value={"url": "..."})
+
+        await browser_navigate(
+            url="https://example.com", referer="", mesh_client=mc,
+        )
+        params = mc.browser_command.await_args.args[1]
+        assert params["referer"] == ""
+
 
 class TestBrowserSnapshotHttpClient:
     """browser_get_elements sends snapshot command through mesh_client."""

--- a/tests/test_navigate_referer.py
+++ b/tests/test_navigate_referer.py
@@ -1,0 +1,140 @@
+"""Phase 3 §6.5 — navigate plumbs the picked referer to Playwright."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+
+def _make_inst(monkeypatch, current_url=""):
+    """Minimal CamoufoxInstance with mocked page.goto."""
+    monkeypatch.delenv("BROWSER_RECORD_BEHAVIOR", raising=False)
+    import src.browser.flags as flags
+    flags._operator_settings = None
+    from src.browser.service import CamoufoxInstance
+
+    page = MagicMock()
+    page.goto = AsyncMock()
+    page.url = current_url
+    page.title = AsyncMock(return_value="title")
+    page.accessibility = MagicMock()
+    page.accessibility.snapshot = AsyncMock(return_value={})
+    inst = CamoufoxInstance("a1", MagicMock(), MagicMock(), page)
+    return inst
+
+
+class TestPickerInvokedByDefault:
+    @pytest.mark.asyncio
+    async def test_picker_runs_when_referer_unset(self, monkeypatch, tmp_path):
+        """``referer=None`` ⇒ service picks one. Verify a search referer
+        ends up on the goto call for an unknown destination."""
+        from src.browser.service import BrowserManager
+
+        mgr = BrowserManager(profiles_dir=str(tmp_path / "profiles"))
+        inst = _make_inst(monkeypatch)
+        mgr._instances["a1"] = inst
+
+        await mgr.navigate("a1", "https://www.example.com/page")
+
+        kwargs = inst.page.goto.call_args.kwargs
+        assert "referer" in kwargs
+        # Unknown host → search-engine referer
+        assert kwargs["referer"] in (
+            "https://www.google.com/",
+            "https://www.bing.com/",
+            "https://duckduckgo.com/",
+        )
+
+    @pytest.mark.asyncio
+    async def test_direct_nav_host_omits_referer_kwarg(
+        self, monkeypatch, tmp_path,
+    ):
+        """For Gmail-class hosts the picker returns empty; the navigate
+        path should NOT pass ``referer=`` to ``goto`` (Playwright's
+        unset default is the right behaviour)."""
+        from src.browser.service import BrowserManager
+
+        mgr = BrowserManager(profiles_dir=str(tmp_path / "profiles"))
+        inst = _make_inst(monkeypatch)
+        mgr._instances["a1"] = inst
+
+        await mgr.navigate("a1", "https://mail.google.com/")
+
+        kwargs = inst.page.goto.call_args.kwargs
+        assert "referer" not in kwargs
+
+
+class TestExplicitReferer:
+    @pytest.mark.asyncio
+    async def test_caller_override_passes_through(self, monkeypatch, tmp_path):
+        from src.browser.service import BrowserManager
+
+        mgr = BrowserManager(profiles_dir=str(tmp_path / "profiles"))
+        inst = _make_inst(monkeypatch)
+        mgr._instances["a1"] = inst
+
+        await mgr.navigate(
+            "a1", "https://example.com/",
+            referer="https://news.ycombinator.com/",
+        )
+
+        kwargs = inst.page.goto.call_args.kwargs
+        assert kwargs["referer"] == "https://news.ycombinator.com/"
+
+    @pytest.mark.asyncio
+    async def test_explicit_empty_string_means_no_referer(
+        self, monkeypatch, tmp_path,
+    ):
+        """``referer=""`` is a deliberate "no referer" — picker must
+        NOT run and the kwarg must be absent on goto."""
+        from src.browser.service import BrowserManager
+
+        mgr = BrowserManager(profiles_dir=str(tmp_path / "profiles"))
+        inst = _make_inst(monkeypatch)
+        mgr._instances["a1"] = inst
+
+        await mgr.navigate("a1", "https://example.com/", referer="")
+
+        kwargs = inst.page.goto.call_args.kwargs
+        assert "referer" not in kwargs
+
+
+class TestRollingHistory:
+    @pytest.mark.asyncio
+    async def test_each_nav_appends_to_recent(self, monkeypatch, tmp_path):
+        from src.browser.service import BrowserManager
+
+        mgr = BrowserManager(profiles_dir=str(tmp_path / "profiles"))
+        inst = _make_inst(monkeypatch)
+        mgr._instances["a1"] = inst
+
+        for _ in range(3):
+            await mgr.navigate("a1", "https://example.com/")
+        assert len(inst.recent_referers) == 3
+
+    @pytest.mark.asyncio
+    async def test_recent_referers_capped_at_5(self, monkeypatch, tmp_path):
+        from src.browser.service import BrowserManager
+
+        mgr = BrowserManager(profiles_dir=str(tmp_path / "profiles"))
+        inst = _make_inst(monkeypatch)
+        mgr._instances["a1"] = inst
+
+        for _ in range(12):
+            await mgr.navigate("a1", "https://example.com/")
+        assert len(inst.recent_referers) == 5
+
+    @pytest.mark.asyncio
+    async def test_same_origin_picked_when_previous_url_matches(
+        self, monkeypatch, tmp_path,
+    ):
+        from src.browser.service import BrowserManager
+
+        mgr = BrowserManager(profiles_dir=str(tmp_path / "profiles"))
+        inst = _make_inst(monkeypatch, current_url="https://example.com/dash")
+        mgr._instances["a1"] = inst
+
+        await mgr.navigate("a1", "https://example.com/orders")
+        kwargs = inst.page.goto.call_args.kwargs
+        assert kwargs["referer"] == "https://example.com/"

--- a/tests/test_navigate_referer.py
+++ b/tests/test_navigate_referer.py
@@ -133,8 +133,95 @@ class TestRollingHistory:
 
         mgr = BrowserManager(profiles_dir=str(tmp_path / "profiles"))
         inst = _make_inst(monkeypatch, current_url="https://example.com/dash")
+        # Mark this as a session that's already had at least one real
+        # navigate — without this flag, ``inst.page.url`` is ignored
+        # to avoid leaking stale persistent-profile state.
+        inst.had_real_navigate = True
         mgr._instances["a1"] = inst
 
         await mgr.navigate("a1", "https://example.com/orders")
         kwargs = inst.page.goto.call_args.kwargs
         assert kwargs["referer"] == "https://example.com/"
+
+
+class TestPersistentProfileGate:
+    """Phase 3 §6.5 review fix — first navigate after restart must NOT
+    treat the persistent-profile resumed URL as a "previous page"."""
+
+    @pytest.mark.asyncio
+    async def test_first_nav_ignores_resumed_page_url(
+        self, monkeypatch, tmp_path,
+    ):
+        from src.browser.service import BrowserManager
+
+        mgr = BrowserManager(profiles_dir=str(tmp_path / "profiles"))
+        # Profile resumed to twitter.com from a prior session
+        inst = _make_inst(monkeypatch, current_url="https://twitter.com/home")
+        assert inst.had_real_navigate is False
+        mgr._instances["a1"] = inst
+
+        # Navigating to a different site should NOT see twitter.com as
+        # the previous URL (would falsify "internal-link arrival" claim).
+        await mgr.navigate("a1", "https://example.com/")
+        kwargs = inst.page.goto.call_args.kwargs
+        # No same-origin referer (would be "https://twitter.com/" if
+        # the gate failed). Picker should fall through to search/etc.
+        assert kwargs.get("referer") != "https://twitter.com/"
+
+    @pytest.mark.asyncio
+    async def test_subsequent_nav_uses_previous_url(
+        self, monkeypatch, tmp_path,
+    ):
+        from src.browser.service import BrowserManager
+
+        mgr = BrowserManager(profiles_dir=str(tmp_path / "profiles"))
+        inst = _make_inst(monkeypatch, current_url="")
+        mgr._instances["a1"] = inst
+
+        # First nav — picker runs but no previous URL hint.
+        await mgr.navigate("a1", "https://example.com/page1")
+        assert inst.had_real_navigate is True
+
+        # Mock the page url to mirror real Playwright behaviour.
+        inst.page.url = "https://example.com/page1"
+        await mgr.navigate("a1", "https://example.com/page2")
+        # Same-origin referer now applies.
+        kwargs = inst.page.goto.call_args_list[-1].kwargs
+        assert kwargs["referer"] == "https://example.com/"
+
+
+class TestExplicitRefererValidation:
+    @pytest.mark.asyncio
+    async def test_javascript_referer_rejected(self, monkeypatch, tmp_path):
+        from src.browser.service import BrowserManager
+
+        mgr = BrowserManager(profiles_dir=str(tmp_path / "profiles"))
+        inst = _make_inst(monkeypatch)
+        mgr._instances["a1"] = inst
+
+        result = await mgr.navigate(
+            "a1", "https://example.com/", referer="javascript:alert(1)",
+        )
+        assert result["success"] is False
+        assert "invalid referer" in result["error"]
+        # And nothing reached Playwright
+        inst.page.goto.assert_not_called()
+        # And nothing was appended to recent_referers
+        assert len(inst.recent_referers) == 0
+
+    @pytest.mark.asyncio
+    async def test_whitespace_referer_normalized_to_empty(
+        self, monkeypatch, tmp_path,
+    ):
+        from src.browser.service import BrowserManager
+
+        mgr = BrowserManager(profiles_dir=str(tmp_path / "profiles"))
+        inst = _make_inst(monkeypatch)
+        mgr._instances["a1"] = inst
+
+        await mgr.navigate("a1", "https://example.com/", referer="   ")
+        # Validator strips → empty → goto called WITHOUT referer kwarg
+        kwargs = inst.page.goto.call_args.kwargs
+        assert "referer" not in kwargs
+        # Recent_referers got the cleaned (empty) value
+        assert list(inst.recent_referers) == [""]

--- a/tests/test_referer_picker.py
+++ b/tests/test_referer_picker.py
@@ -1,0 +1,154 @@
+"""Phase 3 §6.5 — referrer realism on navigate."""
+
+from __future__ import annotations
+
+import random
+
+
+class TestSameOrigin:
+    def test_previous_same_host_yields_same_origin_referer(self):
+        from src.browser.stealth import pick_referer
+
+        ref = pick_referer(
+            "https://www.example.com/products",
+            previous_url="https://www.example.com/category",
+        )
+        assert ref == "https://www.example.com/"
+
+    def test_previous_different_host_does_not_match(self):
+        from src.browser.stealth import pick_referer
+
+        ref = pick_referer(
+            "https://www.example.com/products",
+            previous_url="https://other.com/page",
+            rng=random.Random(0),
+        )
+        # Falls through to search default (deterministic via seeded rng).
+        assert ref in (
+            "https://www.google.com/",
+            "https://www.bing.com/",
+            "https://duckduckgo.com/",
+        )
+
+    def test_previous_url_with_no_scheme_is_ignored(self):
+        from src.browser.stealth import pick_referer
+
+        # Malformed previous URL must not crash and must fall through
+        # to a normal pick instead of yielding "://example.com/".
+        ref = pick_referer(
+            "https://www.example.com/page",
+            previous_url="example.com",
+            rng=random.Random(0),
+        )
+        assert ref.startswith("https://")
+        assert "example.com" not in ref
+
+
+class TestDirectNavHosts:
+    def test_gmail_returns_empty_referer(self):
+        """Gmail / GitHub etc. — search referers would themselves be
+        suspicious (nobody Googles 'gmail.com' to check email)."""
+        from src.browser.stealth import pick_referer
+
+        for host in ("https://mail.google.com/inbox",
+                     "https://github.com/myorg/myrepo",
+                     "https://app.slack.com/client/T123"):
+            assert pick_referer(host) == ""
+
+    def test_direct_nav_overrides_social(self):
+        """Even if a host is in BOTH _DIRECT_NAV_HOSTS and _SOCIAL_REFERERS
+        (it isn't today, but defensive): direct should win."""
+        from src.browser.stealth import _DIRECT_NAV_HOSTS, pick_referer
+
+        assert "github.com" in _DIRECT_NAV_HOSTS
+        assert pick_referer("https://github.com/whatever") == ""
+
+
+class TestSocialPool:
+    def test_twitter_picks_tco_some_of_the_time(self):
+        """t.co is plausible but not universal; ~30% of nav should
+        produce it. We don't assert a specific frequency, just that
+        across 100 picks both shapes appear."""
+        from src.browser.stealth import pick_referer
+
+        rng = random.Random(42)
+        picks = [
+            pick_referer("https://twitter.com/foo", rng=rng)
+            for _ in range(100)
+        ]
+        assert "https://t.co/" in picks
+        # Search referers fill the gap when the social coin-flip says no
+        assert any(p.startswith("https://www.google.com") for p in picks)
+
+    def test_x_com_uses_twitter_pool(self):
+        from src.browser.stealth import pick_referer
+
+        rng = random.Random(0)
+        picks = [
+            pick_referer("https://x.com/alice", rng=rng) for _ in range(50)
+        ]
+        # Both shapes present
+        assert "https://t.co/" in picks
+
+
+class TestSearchDefault:
+    def test_unknown_host_yields_search_referer(self):
+        from src.browser.stealth import pick_referer
+
+        rng = random.Random(7)
+        ref = pick_referer("https://www.someshop.com/", rng=rng)
+        assert ref in (
+            "https://www.google.com/",
+            "https://www.bing.com/",
+            "https://duckduckgo.com/",
+        )
+
+
+class TestRollingHistoryAvoidance:
+    def test_avoids_recently_used_referer(self):
+        """The picker should not return a referer already in the rolling
+        history when alternatives are available."""
+        from src.browser.stealth import pick_referer
+
+        # All three search referers in history → pool exhausted → fall
+        # back rather than return empty (which would itself be a tell).
+        recent = (
+            "https://www.google.com/",
+            "https://www.bing.com/",
+            "https://duckduckgo.com/",
+        )
+        ref = pick_referer(
+            "https://example.com/", recent_referers=recent,
+            rng=random.Random(0),
+        )
+        assert ref in recent  # exhaustion fallback
+
+    def test_partial_history_yields_unseen_referer(self):
+        from src.browser.stealth import pick_referer
+
+        recent = ("https://www.google.com/",)
+        rng = random.Random(0)
+        # Across many picks with google in recent, all picks should be
+        # something else (Bing or DDG).
+        picks = {
+            pick_referer("https://shop.example/", recent_referers=recent,
+                         rng=rng)
+            for _ in range(20)
+        }
+        assert "https://www.google.com/" not in picks
+        assert picks <= {
+            "https://www.bing.com/", "https://duckduckgo.com/",
+        }
+
+
+class TestEdgeCases:
+    def test_invalid_url_returns_empty(self):
+        from src.browser.stealth import pick_referer
+
+        assert pick_referer("") == ""
+        assert pick_referer("not-a-url") == ""
+
+    def test_url_without_host_returns_empty(self):
+        from src.browser.stealth import pick_referer
+
+        assert pick_referer("file:///etc/passwd") == ""

--- a/tests/test_referer_picker.py
+++ b/tests/test_referer_picker.py
@@ -152,3 +152,125 @@ class TestEdgeCases:
         from src.browser.stealth import pick_referer
 
         assert pick_referer("file:///etc/passwd") == ""
+
+    def test_userinfo_in_target_url_does_not_leak(self):
+        """``https://evil@google.com/`` should not produce a same-origin
+        leak even if previous URL also has userinfo. The picker uses
+        ``parsed.hostname`` which strips userinfo, so this is correct
+        by-construction — regression test pins the contract."""
+        from src.browser.stealth import pick_referer
+
+        # No previous → fall through to search (deterministic via rng)
+        ref = pick_referer(
+            "https://evil@google.com/", rng=__import__("random").Random(0),
+        )
+        assert ref.startswith("https://")
+        # Should not be a fabricated same-origin pointing at evil
+        assert "evil@" not in ref
+
+
+class TestValidateReferer:
+    """Phase 3 §6.5 — validation of caller-supplied referer values."""
+
+    def test_empty_string_passes(self):
+        from src.browser.stealth import validate_referer
+
+        assert validate_referer("") == ""
+        assert validate_referer("   ") == ""  # whitespace → empty
+
+    def test_http_and_https_pass(self):
+        from src.browser.stealth import validate_referer
+
+        assert validate_referer("https://example.com/") == "https://example.com/"
+        assert validate_referer("http://example.com/") == "http://example.com/"
+
+    def test_strips_surrounding_whitespace(self):
+        from src.browser.stealth import validate_referer
+
+        assert validate_referer("  https://example.com/  ") == "https://example.com/"
+
+    def test_javascript_scheme_rejected(self):
+        """Most important rejection — Playwright doesn't validate this
+        strictly enough for our threat model."""
+        import pytest
+
+        from src.browser.stealth import validate_referer
+
+        with pytest.raises(ValueError, match="http"):
+            validate_referer("javascript:alert(1)")
+
+    def test_data_scheme_rejected(self):
+        import pytest
+
+        from src.browser.stealth import validate_referer
+
+        with pytest.raises(ValueError, match="http"):
+            validate_referer("data:text/html,<h1>x</h1>")
+
+    def test_file_scheme_rejected(self):
+        import pytest
+
+        from src.browser.stealth import validate_referer
+
+        with pytest.raises(ValueError, match="http"):
+            validate_referer("file:///etc/passwd")
+
+    def test_about_scheme_rejected(self):
+        import pytest
+
+        from src.browser.stealth import validate_referer
+
+        with pytest.raises(ValueError, match="http"):
+            validate_referer("about:blank")
+
+    def test_url_without_hostname_rejected(self):
+        import pytest
+
+        from src.browser.stealth import validate_referer
+
+        with pytest.raises(ValueError, match="hostname"):
+            validate_referer("https:///path-only")
+
+    def test_non_string_rejected(self):
+        import pytest
+
+        from src.browser.stealth import validate_referer
+
+        with pytest.raises(ValueError, match="str"):
+            validate_referer(42)  # type: ignore
+
+
+class TestOAuthDirectNav:
+    """Phase 3 §6.5 review fix — OAuth identity providers must NOT
+    receive a fabricated search referer mid-flow."""
+
+    def test_oauth_idps_in_direct_nav(self):
+        from src.browser.stealth import _DIRECT_NAV_HOSTS
+
+        for host in (
+            "accounts.google.com",
+            "login.microsoftonline.com",
+            "appleid.apple.com",
+            "id.atlassian.com",
+        ):
+            assert host in _DIRECT_NAV_HOSTS, (
+                f"{host} missing from direct-nav set; OAuth bounce would "
+                f"get fabricated search referer"
+            )
+
+    def test_oauth_idp_navigation_returns_empty_referer(self):
+        from src.browser.stealth import pick_referer
+
+        assert pick_referer("https://accounts.google.com/signin") == ""
+
+
+class TestExpandedSocialPool:
+    """Phase 3 §6.5 review fix — Twitter/X social pool is no longer
+    size 1, so rolling-history exhaustion doesn't force a clockwork
+    pattern."""
+
+    def test_x_social_pool_has_multiple_shapes(self):
+        from src.browser.stealth import _SOCIAL_REFERERS
+
+        assert len(_SOCIAL_REFERERS["x.com"]) >= 2
+        assert len(_SOCIAL_REFERERS["twitter.com"]) >= 2

--- a/tests/test_referer_picker.py
+++ b/tests/test_referer_picker.py
@@ -15,6 +15,32 @@ class TestSameOrigin:
         )
         assert ref == "https://www.example.com/"
 
+    def test_same_origin_preserves_non_default_port(self):
+        """Codex review: dropping the port produces a wrong-origin
+        referer. Browsers treat ``host:8443`` and ``host`` as
+        different origins; a mismatch on emit is itself a tell."""
+        from src.browser.stealth import pick_referer
+
+        ref = pick_referer(
+            "https://example.com:8443/api",
+            previous_url="https://example.com:8443/dashboard",
+        )
+        assert ref == "https://example.com:8443/"
+
+    def test_same_origin_strips_userinfo_from_referer(self):
+        """Defensive: ``netloc`` includes userinfo so naive use would
+        emit ``https://user:pass@host/`` as a Referer, leaking
+        credentials. The picker must rebuild from hostname+port."""
+        from src.browser.stealth import pick_referer
+
+        ref = pick_referer(
+            "https://example.com/page",
+            previous_url="https://user:pass@example.com/dash",
+        )
+        assert "user:pass@" not in ref
+        assert "@" not in ref
+        assert ref == "https://example.com/"
+
     def test_previous_different_host_does_not_match(self):
         from src.browser.stealth import pick_referer
 


### PR DESCRIPTION
## Summary

Real users overwhelmingly arrive at a page with a non-empty ``document.referrer`` and a ``Referer`` header. An agent that emits every navigate with empty referer is statistically the easiest fingerprint to flag at fleet scale — a single property that holds across every page load.

This PR adds a per-nav picker that selects a plausible referer based on the destination, plus an opt-in agent-facing parameter for explicit override.

## Picker decision order (`src.browser.stealth.pick_referer`)

1. **Same-origin** — previous page on the target host → its origin (real users follow internal links)
2. **Direct nav** — hosts where a search referer would itself be suspicious (Gmail, GitHub, Slack, Notion, etc.) → empty (typed URL / bookmark / deep link shape)
3. **Social** — destinations with a registered shim (Twitter / X → ``t.co``) → pool, ~30% probability so we don't make every X visit look like t.co inbound
4. **Search default** — uniform pick from Google / Bing / DuckDuckGo

Rolling history of size 5 lives on `CamoufoxInstance.recent_referers`. Picker avoids returning a value already in history; falls back to the full pool only when every option is in history (rather than returning empty, which would itself be a notable break).

## Plumbing

- `BrowserManager.navigate` gained optional `referer` kwarg: `None` (default) → picker runs; `""` → explicit direct nav; any other string → caller override
- Picked value passes straight to `Page.goto(referer=...)` so the network header and `document.referrer` stay consistent
- `POST /browser/{agent}/navigate` forwards the param only when the body includes it (so picker fires by default for old clients)
- `browser_navigate` agent skill exposes optional `referer` param with docstring guiding agents to leave unset

## Test plan

- [x] `tests/test_referer_picker.py` — same-origin / direct-nav / social ~30% / search default / rolling-history avoidance / edge cases
- [x] `tests/test_navigate_referer.py` — picker invoked by default, `goto(referer=)` populated, `""` bypasses picker, caller override, deque maxlen=5, same-origin path
- [x] `tests/test_builtins.py` — agent skill omits referer from forwarded body when unset, forwards explicit (including `""`)
- [x] Pre-existing wait_until tests updated — the kwarg set on `goto` now also includes `referer` when picker fires
- [x] Full browser + stealth + recorder + canary suites — no regressions
- [x] ruff clean

## Blast radius

- **Default behaviour change**: every navigate now sends a referer (picked) instead of none. This is the whole point of the PR. Sites that previously saw "no referer" from agents will now see Google/Bing/etc. — overwhelmingly closer to real-user-shape, but a behaviour change worth flagging for anyone with referer-based analytics
- **Agent-skill API addition**: optional kwarg, no regression for existing prompts
- **Endpoint shape**: `POST /browser/{agent}/navigate` accepts an optional `referer` body field; absent ⇒ picker runs (matches old behaviour for callers who never knew about it)
- **`Page.goto` call**: kwargs structure changed — old tests asserting strict equality on the goto args needed updating (done in this PR)