### PR TITLE
Phase 4.5/4.6: WebP screenshots + navigate body dedup

### DIFF
--- a/Dockerfile.browser
+++ b/Dockerfile.browser
@@ -66,10 +66,14 @@ RUN useradd --create-home --uid 1000 --shell /bin/bash browser
 WORKDIR /app
 
 # Python dependencies — upgrade pip first to avoid resolver bugs with stale base images
+# Pillow ships with bundled libwebp on manylinux wheels, so no apt-level WebP
+# library is required. The encode path in src/browser/service.py uses
+# Image.save(..., format="WEBP") which is Pillow's built-in encoder.
 COPY pyproject.toml .
 RUN pip install --no-cache-dir --root-user-action=ignore --upgrade pip \
     && pip install --no-cache-dir --root-user-action=ignore \
-    "camoufox[geoip]" fastapi uvicorn pydantic httpx
+    "camoufox[geoip]" fastapi uvicorn pydantic httpx \
+    "Pillow>=10.0"
 
 # Application code
 COPY src/browser/ /app/src/browser/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ dependencies = [
     "websockets>=13.0",
     "pypdf>=4.0",
     "python-multipart>=0.0.9",
+    "Pillow>=10.0",
 ]
 
 [project.optional-dependencies]

--- a/src/agent/builtins/browser_tool.py
+++ b/src/agent/builtins/browser_tool.py
@@ -175,8 +175,11 @@ async def browser_wait_for(
 @skill(
     name="browser_screenshot",
     description=(
-        "Take a screenshot of the current page. "
-        "Returns a visual PNG image you can see directly."
+        "Take a screenshot of the current page. Returns a visual image you "
+        "can see directly. Defaults: WebP at quality=75, full resolution. "
+        "Use format='png' for lossless capture (e.g. when comparing pixels "
+        "or feeding into an OCR pipeline). Use scale=0.75 to shrink the "
+        "image further for token-cheap reconnaissance shots."
     ),
     parameters={
         "full_page": {
@@ -184,37 +187,85 @@ async def browser_wait_for(
             "description": "Capture full scrollable page (default false)",
             "default": False,
         },
+        "format": {
+            "type": "string",
+            "description": (
+                "Image format: 'webp' (default, smaller, lossy) or 'png' "
+                "(lossless, larger). WebP is ~5–10× cheaper in tokens."
+            ),
+            "default": "webp",
+        },
+        "quality": {
+            "type": "integer",
+            "description": (
+                "WebP quality 1–100 (default 75). Ignored for PNG. Lower "
+                "values trade visual fidelity for smaller payloads."
+            ),
+            "default": 75,
+        },
+        "scale": {
+            "type": "number",
+            "description": (
+                "Resize factor 0.5–1.0 (default 1.0). 0.75 keeps the page "
+                "readable while cutting bytes ~45%."
+            ),
+            "default": 1.0,
+        },
     },
     parallel_safe=False,
     loop_exempt=True,
 )
-async def browser_screenshot(full_page: bool = False, *, mesh_client=None) -> dict:
+async def browser_screenshot(
+    full_page: bool = False,
+    format: str = "webp",
+    quality: int = 75,
+    scale: float = 1.0,
+    *,
+    mesh_client=None,
+) -> dict:
     """Take a screenshot via the browser service.
 
     Extracts image_base64 from the raw result *before* ``_deep_redact`` runs,
     because the broad credential-redaction patterns (40+ hex/base64 chars)
-    would corrupt any PNG payload.  The base64 data is returned under the
+    would corrupt any image payload. The base64 data is returned under the
     ``_image`` key so ``_run_tool`` can build a multimodal content block.
+
+    The browser service is the source of truth for the actual encoding
+    used — it may fall back to PNG when WebP encoding fails (e.g. Pillow
+    missing or a corrupt frame buffer). The returned ``_image.media_type``
+    reflects what was actually emitted, not what was requested.
     """
     if not mesh_client:
         return {"error": "Browser requires mesh connectivity"}
     try:
-        raw = await mesh_client.browser_command("screenshot", {"full_page": full_page})
+        raw = await mesh_client.browser_command(
+            "screenshot",
+            {
+                "full_page": full_page,
+                "format": format,
+                "quality": quality,
+                "scale": scale,
+            },
+        )
     except Exception as e:
         return {"error": _deep_redact(str(e))}
 
     # Pull out image data before redaction can corrupt it.
-    # Browser service returns {"success": ..., "data": {"image_base64": ..., ...}}
+    # Browser service returns {"success": ..., "data":
+    #   {"image_base64": ..., "format": "webp"|"png", "bytes": int}}
     image_data = None
+    actual_format = "png"
     if isinstance(raw, dict):
         data = raw.get("data")
         if isinstance(data, dict) and data.get("image_base64"):
             image_data = data.pop("image_base64")
+            actual_format = (data.get("format") or "png").lower()
 
     result = _deep_redact(raw)
 
     if image_data:
-        result["_image"] = {"data": image_data, "media_type": "image/png"}
+        media_type = "image/webp" if actual_format == "webp" else "image/png"
+        result["_image"] = {"data": image_data, "media_type": media_type}
         # Give the LLM a short text summary instead of the raw base64 blob
         result.setdefault("status", "screenshot captured")
 

--- a/src/browser/canary.py
+++ b/src/browser/canary.py
@@ -300,7 +300,13 @@ async def _run_single_scanner(
     # demote status. A page that navigated but can't screenshot is
     # still useful signal; operators read the status first.
     try:
-        shot = await manager.screenshot(CANARY_AGENT_ID, full_page=True)
+        # Force PNG: the canary report is read by humans for pixel-level
+        # comparisons across runs. WebP's lossy default would smear
+        # detection artefacts (color rings, font renderings) operators
+        # are watching for. Cost is fine — canary fires hourly.
+        shot = await manager.screenshot(
+            CANARY_AGENT_ID, full_page=True, format="png",
+        )
         if shot.get("success"):
             report_dir.mkdir(parents=True, exist_ok=True)
             path = report_dir / f"{int(ts)}-{name}.png"

--- a/src/browser/server.py
+++ b/src/browser/server.py
@@ -231,7 +231,13 @@ def create_browser_app(manager: BrowserManager, lifespan=None) -> FastAPI:
     async def screenshot(agent_id: str, request: Request):
         _verify_auth(request)
         body = await request.json()
-        return await manager.screenshot(agent_id, full_page=body.get("full_page", False))
+        return await manager.screenshot(
+            agent_id,
+            full_page=body.get("full_page", False),
+            format=body.get("format", "webp"),
+            quality=body.get("quality", 75),
+            scale=body.get("scale", 1.0),
+        )
 
     @app.post("/browser/{agent_id}/reset")
     async def reset(agent_id: str, request: Request):

--- a/src/browser/service.py
+++ b/src/browser/service.py
@@ -347,6 +347,71 @@ def _is_empty_payload(payload: dict) -> bool:
     ))
 
 
+def _encode_screenshot(
+    png_bytes: bytes,
+    fmt: str,
+    quality: int,
+    scale: float,
+    *,
+    agent_id: str = "",
+) -> tuple[bytes, str]:
+    """Encode a Playwright PNG to WebP / PNG with optional downscale.
+
+    Returns ``(encoded_bytes, actual_format)``. ``actual_format`` may be
+    ``"png"`` even when ``fmt="webp"`` was requested — Pillow may be
+    absent in the dev path or fail on a corrupt frame; PNG fallback
+    keeps the agent unblocked rather than returning an error.
+
+    The function is intentionally synchronous and pure — easy to unit
+    test and reason about. Pillow does its own threading internally;
+    callers should either be on a worker thread or accept that an
+    ~1080p WebP encode runs in ~10–20 ms.
+    """
+    # Fast path: caller asked for PNG and no scale change → pass through.
+    if fmt == "png" and abs(scale - 1.0) < 1e-3:
+        return png_bytes, "png"
+
+    try:
+        from io import BytesIO
+
+        from PIL import Image
+    except Exception:
+        # Pillow missing — log once per encode attempt at debug only;
+        # this is expected on the agent-side dev path where Pillow isn't
+        # bundled. Caller still gets a usable PNG.
+        logger.debug(
+            "Pillow not installed; falling back to PNG (agent=%s)", agent_id,
+        )
+        return png_bytes, "png"
+
+    try:
+        img = Image.open(BytesIO(png_bytes))
+        # Downscale via Lanczos when requested. Avoids the no-op resize
+        # cost when scale is effectively 1.0.
+        if abs(scale - 1.0) >= 1e-3 and scale > 0:
+            new_w = max(1, int(img.width * scale))
+            new_h = max(1, int(img.height * scale))
+            img = img.resize((new_w, new_h), Image.LANCZOS)
+
+        out = BytesIO()
+        if fmt == "webp":
+            # Convert to RGB first — WebP doesn't accept palette or
+            # certain RGBA modes from Pillow versions <10.4 cleanly.
+            if img.mode not in ("RGB", "RGBA"):
+                img = img.convert("RGB")
+            img.save(out, format="WEBP", quality=quality, method=4)
+            return out.getvalue(), "webp"
+        # PNG re-encode (only reached when scale != 1.0 above).
+        img.save(out, format="PNG", optimize=True)
+        return out.getvalue(), "png"
+    except Exception as e:
+        logger.warning(
+            "Screenshot %s encode failed (%s); falling back to original PNG",
+            fmt, e,
+        )
+        return png_bytes, "png"
+
+
 def _extract_text_from_a11y(tree: dict | None, max_chars: int = 5000) -> str:
     """Extract readable text from an accessibility snapshot tree.
 
@@ -1477,10 +1542,19 @@ class BrowserManager:
                 title = await inst.page.title()
                 current_url = inst.page.url
                 body_text = ""
+                # When snapshot_after=True the response already carries the
+                # full element tree — keep ``body`` as a short preview
+                # (1000 chars) so the agent has page-text context without
+                # paying full-text token cost twice. With snapshot_after
+                # off the agent depends on body for content, so retain
+                # the historical 5000-char cap.
+                body_cap = 1000 if snapshot_after else 5000
                 if not inst._js_snapshot_mode:
                     try:
                         _a11y = await inst.page.accessibility.snapshot()
-                        body_text = _extract_text_from_a11y(_a11y)
+                        body_text = _extract_text_from_a11y(
+                            _a11y, max_chars=body_cap,
+                        )
                     except AttributeError:
                         inst._js_snapshot_mode = True
                     except Exception:
@@ -2659,17 +2733,72 @@ class BrowserManager:
             except Exception as e:
                 return {"success": False, "error": str(e)}
 
-    async def screenshot(self, agent_id: str, full_page: bool = False) -> dict:
-        """Take screenshot, return base64 PNG."""
+    async def screenshot(
+        self,
+        agent_id: str,
+        full_page: bool = False,
+        format: str = "webp",
+        quality: int = 75,
+        scale: float = 1.0,
+    ) -> dict:
+        """Take a screenshot and return it as base64.
+
+        ``format`` controls the encoding:
+        - ``"webp"`` (default) — lossy WebP at ``quality`` (1–100). Roughly
+          5–10× smaller than PNG for the same visual content; the
+          difference compounds heavily across multi-step browsing tasks
+          where the agent may pull dozens of screenshots per task.
+        - ``"png"`` — original lossless PNG path (Playwright native).
+          Selected automatically if WebP encoding fails (e.g. Pillow
+          missing in dev env, corrupt frame buffer) so callers always
+          get a usable image.
+
+        ``scale`` (0.5–1.0) rescales the captured image post-encode-prep,
+        for further token savings when full-fidelity isn't needed. The
+        Playwright native scale option is intentionally NOT used —
+        Playwright applies it via ``deviceScaleFactor`` which mutates the
+        viewport's pixel ratio and can leak fingerprint signal. Pillow
+        downscale here is a pure post-process.
+        """
         inst = await self.get_or_start(agent_id)
         inst.touch()
+        # Validate inputs early — reject unknown formats with a clear
+        # error rather than silently falling through to PNG.
+        fmt = (format or "webp").lower()
+        if fmt not in ("webp", "png"):
+            return {"success": False, "error": f"Unsupported screenshot format: {format!r}"}
+        try:
+            quality = int(quality)
+        except (TypeError, ValueError):
+            quality = 75
+        quality = max(1, min(100, quality))
+        try:
+            scale_f = float(scale)
+        except (TypeError, ValueError):
+            scale_f = 1.0
+        scale_f = max(0.5, min(1.0, scale_f))
+
         async with inst.lock:
             try:
+                # Ask Playwright for PNG either way — WebP encoding happens
+                # post-capture so we can downscale and quality-tune in a
+                # single Pillow pass without touching the page renderer.
                 png_bytes = await inst.page.screenshot(full_page=full_page)
-                b64 = base64.b64encode(png_bytes).decode()
-                return {"success": True, "data": {"image_base64": b64, "format": "png"}}
             except Exception as e:
                 return {"success": False, "error": str(e)}
+
+        encoded, used_format = _encode_screenshot(
+            png_bytes, fmt, quality, scale_f, agent_id=agent_id,
+        )
+        b64 = base64.b64encode(encoded).decode()
+        return {
+            "success": True,
+            "data": {
+                "image_base64": b64,
+                "format": used_format,
+                "bytes": len(encoded),
+            },
+        }
 
     async def _type_with_variance(self, page, text: str) -> None:
         """Type text character-by-character with human-like inter-key delays.

--- a/src/browser/service.py
+++ b/src/browser/service.py
@@ -375,10 +375,13 @@ def _encode_screenshot(
         from io import BytesIO
 
         from PIL import Image
-    except Exception:
+    except ImportError:
         # Pillow missing — log once per encode attempt at debug only;
         # this is expected on the agent-side dev path where Pillow isn't
-        # bundled. Caller still gets a usable PNG.
+        # bundled. Caller still gets a usable PNG. Narrowed to
+        # ImportError specifically so non-import failures (e.g. partially
+        # broken install raising OSError at module init) surface as bugs
+        # rather than silently downgrading.
         logger.debug(
             "Pillow not installed; falling back to PNG (agent=%s)", agent_id,
         )

--- a/src/browser/service.py
+++ b/src/browser/service.py
@@ -2766,8 +2766,17 @@ class BrowserManager:
         inst = await self.get_or_start(agent_id)
         inst.touch()
         # Validate inputs early — reject unknown formats with a clear
-        # error rather than silently falling through to PNG.
-        fmt = (format or "webp").lower()
+        # error rather than silently falling through to PNG. Operator
+        # default comes from ``BROWSER_SCREENSHOT_FORMAT`` (per §2.1) so
+        # an operator can globally force PNG without changing the caller.
+        # ``.strip()`` guards against trailing whitespace from JSON UI
+        # defaults; ``.lower()`` normalizes case.
+        from src.browser.flags import get_str
+        if not format:
+            format = get_str(
+                "BROWSER_SCREENSHOT_FORMAT", "webp", agent_id=agent_id,
+            )
+        fmt = format.strip().lower()
         if fmt not in ("webp", "png"):
             return {"success": False, "error": f"Unsupported screenshot format: {format!r}"}
         try:
@@ -2790,7 +2799,12 @@ class BrowserManager:
             except Exception as e:
                 return {"success": False, "error": str(e)}
 
-        encoded, used_format = _encode_screenshot(
+        # Pillow encode is synchronous and ~10–20 ms on a 1080p frame —
+        # offload to a thread so we don't block the event loop. Pillow
+        # releases the GIL during its C-level encode steps, so this
+        # actually parallelizes across concurrent agent screenshots.
+        encoded, used_format = await asyncio.to_thread(
+            _encode_screenshot,
             png_bytes, fmt, quality, scale_f, agent_id=agent_id,
         )
         b64 = base64.b64encode(encoded).decode()

--- a/src/browser/service.py
+++ b/src/browser/service.py
@@ -1545,18 +1545,18 @@ class BrowserManager:
                 title = await inst.page.title()
                 current_url = inst.page.url
                 body_text = ""
-                # When snapshot_after=True the response already carries the
-                # full element tree — keep ``body`` as a short preview
-                # (1000 chars) so the agent has page-text context without
-                # paying full-text token cost twice. With snapshot_after
-                # off the agent depends on body for content, so retain
-                # the historical 5000-char cap.
-                body_cap = 1000 if snapshot_after else 5000
+                # Always extract body at the historical 5000-char cap so
+                # we have a usable fallback if the snapshot path fails
+                # below. We trim to a 1000-char preview only AFTER the
+                # snapshot succeeds — that's when the agent has the full
+                # element tree and doesn't need a long body. If the
+                # snapshot fails, we ship the full body so the agent
+                # isn't stranded with truncated text + empty snapshot.
                 if not inst._js_snapshot_mode:
                     try:
                         _a11y = await inst.page.accessibility.snapshot()
                         body_text = _extract_text_from_a11y(
-                            _a11y, max_chars=body_cap,
+                            _a11y, max_chars=5000,
                         )
                     except AttributeError:
                         inst._js_snapshot_mode = True
@@ -1567,16 +1567,34 @@ class BrowserManager:
                     "data": {
                         "url": self.redactor.redact(agent_id, current_url),
                         "title": self.redactor.redact(agent_id, title),
-                        "body": self.redactor.redact(agent_id, body_text),
+                        # Body filled in below once we know whether the
+                        # optional snapshot succeeded — see body cap
+                        # comment.
+                        "body": "",
                     },
                 }
                 # Auto-detect CAPTCHAs so the agent knows immediately
                 captcha = await self._check_captcha(inst)
                 if captcha:
                     result["captcha"] = captcha
+                snapshot_succeeded = False
                 if snapshot_after:
                     snap = await self._snapshot_impl(inst, agent_id)
-                    result["snapshot"] = snap.get("data", {})
+                    snap_data = snap.get("data") or {}
+                    result["snapshot"] = snap_data
+                    snapshot_succeeded = bool(snap.get("success") and snap_data)
+                # §7.6: shrink body to 1000-char preview ONLY when the
+                # snapshot actually carried back element refs. A failed
+                # snapshot would otherwise leave the agent with both a
+                # truncated body AND an empty/{} snapshot — strictly
+                # worse than the snapshot_after=False path. Restore the
+                # full body in that failure case.
+                final_body = (
+                    body_text[:1000] if snapshot_succeeded else body_text
+                )
+                result["data"]["body"] = self.redactor.redact(
+                    agent_id, final_body,
+                )
                 return result
             except Exception as e:
                 return {"success": False, "error": str(e)}

--- a/tests/test_browser_service.py
+++ b/tests/test_browser_service.py
@@ -999,6 +999,39 @@ class TestScreenshot:
         assert "Unsupported" in result["error"]
 
     @pytest.mark.asyncio
+    async def test_screenshot_format_none_uses_operator_default(self, monkeypatch):
+        """``format=None`` (JSON null) consults the operator flag,
+        defaulting to ``webp`` when unset."""
+        from src.browser.service import BrowserManager, CamoufoxInstance
+        # Force operator default to PNG via env override.
+        monkeypatch.setenv("BROWSER_SCREENSHOT_FORMAT", "png")
+        mgr = BrowserManager(profiles_dir="/tmp/test_profiles")
+        png = _make_png_bytes(400, 300)
+        mock_page = AsyncMock()
+        mock_page.screenshot = AsyncMock(return_value=png)
+        inst = CamoufoxInstance("a1", MagicMock(), MagicMock(), mock_page)
+        mgr._instances["a1"] = inst
+
+        result = await mgr.screenshot("a1", format=None)
+        assert result["success"] is True
+        assert result["data"]["format"] == "png"
+
+    @pytest.mark.asyncio
+    async def test_screenshot_format_whitespace_normalized(self):
+        """``format=' WEBP '`` strips + lowercases instead of rejecting."""
+        from src.browser.service import BrowserManager, CamoufoxInstance
+        mgr = BrowserManager(profiles_dir="/tmp/test_profiles")
+        png = _make_png_bytes(400, 300)
+        mock_page = AsyncMock()
+        mock_page.screenshot = AsyncMock(return_value=png)
+        inst = CamoufoxInstance("a1", MagicMock(), MagicMock(), mock_page)
+        mgr._instances["a1"] = inst
+
+        result = await mgr.screenshot("a1", format=" WEBP ")
+        assert result["success"] is True
+        assert result["data"]["format"] == "webp"
+
+    @pytest.mark.asyncio
     async def test_screenshot_quality_clamped(self):
         """Out-of-range quality clamps silently rather than raising."""
         from src.browser.service import BrowserManager, CamoufoxInstance

--- a/tests/test_browser_service.py
+++ b/tests/test_browser_service.py
@@ -879,23 +879,167 @@ class TestClick:
         assert inst.rolling_click_success_rate() == 0.0
 
 
+def _make_png_bytes(width: int = 64, height: int = 48) -> bytes:
+    """Render a real PNG via Pillow for screenshot encode tests."""
+    from io import BytesIO
+
+    from PIL import Image
+    img = Image.new("RGB", (width, height))
+    pixels = img.load()
+    for y in range(height):
+        for x in range(width):
+            pixels[x, y] = (x * 4 % 256, y * 4 % 256, (x + y) * 2 % 256)
+    out = BytesIO()
+    img.save(out, format="PNG")
+    return out.getvalue()
+
+
 class TestScreenshot:
     """Tests for BrowserManager.screenshot()."""
 
     @pytest.mark.asyncio
-    async def test_screenshot_success(self):
+    async def test_screenshot_corrupt_bytes_falls_back_to_png(self):
+        """Fake PNG bytes — Pillow can't decode them, so we fall back
+        to returning the original payload as PNG. Keeps the agent
+        unblocked rather than failing the call."""
         from src.browser.service import BrowserManager, CamoufoxInstance
         mgr = BrowserManager(profiles_dir="/tmp/test_profiles")
 
         mock_page = AsyncMock()
-        mock_page.screenshot = AsyncMock(return_value=b"\x89PNG\r\n\x1a\n" + b"\x00" * 100)
+        mock_page.screenshot = AsyncMock(
+            return_value=b"\x89PNG\r\n\x1a\n" + b"\x00" * 100,
+        )
         inst = CamoufoxInstance("a1", MagicMock(), MagicMock(), mock_page)
         mgr._instances["a1"] = inst
 
         result = await mgr.screenshot("a1")
         assert result["success"] is True
+        # Default format is webp; corrupt data triggers the PNG fallback.
         assert result["data"]["format"] == "png"
         assert len(result["data"]["image_base64"]) > 0
+
+    @pytest.mark.asyncio
+    async def test_screenshot_default_returns_webp(self):
+        """Default call yields a valid WebP payload."""
+        from src.browser.service import BrowserManager, CamoufoxInstance
+        mgr = BrowserManager(profiles_dir="/tmp/test_profiles")
+        # Larger fixture so WebP's container overhead is dominated by
+        # the encoded pixel data — small fixtures can encode larger as
+        # WebP than PNG because of header/chunk overhead.
+        png = _make_png_bytes(width=400, height=300)
+        mock_page = AsyncMock()
+        mock_page.screenshot = AsyncMock(return_value=png)
+        inst = CamoufoxInstance("a1", MagicMock(), MagicMock(), mock_page)
+        mgr._instances["a1"] = inst
+
+        result = await mgr.screenshot("a1")
+        assert result["success"] is True
+        assert result["data"]["format"] == "webp"
+        assert result["data"]["bytes"] > 0
+        # Decoded base64 should equal the byte-count we emitted.
+        import base64
+        decoded = base64.b64decode(result["data"]["image_base64"])
+        assert len(decoded) == result["data"]["bytes"]
+        # First 4 bytes of WebP file are 'RIFF'; bytes 8-11 are 'WEBP'.
+        assert decoded[:4] == b"RIFF"
+        assert decoded[8:12] == b"WEBP"
+
+    @pytest.mark.asyncio
+    async def test_screenshot_explicit_png_passthrough(self):
+        """Explicit ``format='png'`` with scale=1.0 returns the raw
+        Playwright bytes (no Pillow round-trip)."""
+        from src.browser.service import BrowserManager, CamoufoxInstance
+        mgr = BrowserManager(profiles_dir="/tmp/test_profiles")
+        png = _make_png_bytes()
+        mock_page = AsyncMock()
+        mock_page.screenshot = AsyncMock(return_value=png)
+        inst = CamoufoxInstance("a1", MagicMock(), MagicMock(), mock_page)
+        mgr._instances["a1"] = inst
+
+        result = await mgr.screenshot("a1", format="png", scale=1.0)
+        assert result["success"] is True
+        assert result["data"]["format"] == "png"
+        import base64
+        decoded = base64.b64decode(result["data"]["image_base64"])
+        # Pass-through: identical bytes.
+        assert decoded == png
+
+    @pytest.mark.asyncio
+    async def test_screenshot_scale_resizes(self):
+        """``scale=0.5`` cuts dimensions in half."""
+        from io import BytesIO
+
+        from PIL import Image
+        from src.browser.service import BrowserManager, CamoufoxInstance
+        mgr = BrowserManager(profiles_dir="/tmp/test_profiles")
+        png = _make_png_bytes(width=200, height=120)
+        mock_page = AsyncMock()
+        mock_page.screenshot = AsyncMock(return_value=png)
+        inst = CamoufoxInstance("a1", MagicMock(), MagicMock(), mock_page)
+        mgr._instances["a1"] = inst
+
+        result = await mgr.screenshot("a1", format="webp", scale=0.5)
+        assert result["success"] is True
+        import base64
+        decoded = base64.b64decode(result["data"]["image_base64"])
+        img = Image.open(BytesIO(decoded))
+        assert img.size == (100, 60)
+
+    @pytest.mark.asyncio
+    async def test_screenshot_unknown_format_rejected(self):
+        from src.browser.service import BrowserManager, CamoufoxInstance
+        mgr = BrowserManager(profiles_dir="/tmp/test_profiles")
+        mock_page = AsyncMock()
+        mock_page.screenshot = AsyncMock(return_value=b"")
+        inst = CamoufoxInstance("a1", MagicMock(), MagicMock(), mock_page)
+        mgr._instances["a1"] = inst
+
+        result = await mgr.screenshot("a1", format="jpeg")
+        assert result["success"] is False
+        assert "Unsupported" in result["error"]
+
+    @pytest.mark.asyncio
+    async def test_screenshot_quality_clamped(self):
+        """Out-of-range quality clamps silently rather than raising."""
+        from src.browser.service import BrowserManager, CamoufoxInstance
+        mgr = BrowserManager(profiles_dir="/tmp/test_profiles")
+        png = _make_png_bytes()
+        mock_page = AsyncMock()
+        mock_page.screenshot = AsyncMock(return_value=png)
+        inst = CamoufoxInstance("a1", MagicMock(), MagicMock(), mock_page)
+        mgr._instances["a1"] = inst
+
+        # quality=999 should clamp to 100 → encode succeeds.
+        result = await mgr.screenshot("a1", quality=999)
+        assert result["success"] is True
+        # quality=-1 should clamp to 1 → encode succeeds (tiny output).
+        result = await mgr.screenshot("a1", quality=-1)
+        assert result["success"] is True
+
+    @pytest.mark.asyncio
+    async def test_screenshot_pillow_missing_falls_back_to_png(self, monkeypatch):
+        """If Pillow can't be imported the helper returns the raw PNG."""
+        import builtins
+        from src.browser.service import BrowserManager, CamoufoxInstance
+        mgr = BrowserManager(profiles_dir="/tmp/test_profiles")
+        png = _make_png_bytes()
+        mock_page = AsyncMock()
+        mock_page.screenshot = AsyncMock(return_value=png)
+        inst = CamoufoxInstance("a1", MagicMock(), MagicMock(), mock_page)
+        mgr._instances["a1"] = inst
+
+        real_import = builtins.__import__
+
+        def _fake_import(name, *args, **kwargs):
+            if name == "PIL":
+                raise ImportError("forced for test")
+            return real_import(name, *args, **kwargs)
+
+        monkeypatch.setattr(builtins, "__import__", _fake_import)
+        result = await mgr.screenshot("a1", format="webp")
+        assert result["success"] is True
+        # Pillow missing → graceful PNG fallback.
+        assert result["data"]["format"] == "png"
 
 
 class TestEvaluate:
@@ -2127,6 +2271,80 @@ class TestSnapshotAfter:
 
         assert result["success"] is True
         assert "snapshot" not in result
+
+
+class TestNavigateBodyCap:
+    """§7.6 — body preview is shorter when snapshot_after=True since
+    the snapshot already carries the element tree."""
+
+    def _make_long_a11y(self, text_len: int) -> dict:
+        # Many short leaves — total joined length ≈ text_len. Avoids
+        # tripping the credential redactor (which targets long base64-
+        # like runs) and produces realistic word-spaced output that
+        # ``_extract_text_from_a11y`` joins with spaces.
+        word = "hello "
+        n_leaves = max(1, text_len // len(word))
+        return {
+            "role": "WebArea",
+            "name": "T",
+            "children": [
+                {"role": "text", "name": "hello"} for _ in range(n_leaves)
+            ],
+        }
+
+    @pytest.mark.asyncio
+    async def test_body_capped_at_1000_with_snapshot_after(self):
+        from src.browser.service import BrowserManager, CamoufoxInstance
+
+        mgr = BrowserManager(profiles_dir="/tmp/test_profiles")
+        mock_page = AsyncMock()
+        mock_page.goto = AsyncMock()
+        mock_page.title = AsyncMock(return_value="t")
+        mock_page.url = "https://example.com"
+        # accessibility.snapshot returns a tree with a 4000-char leaf
+        a11y_tree = self._make_long_a11y(4000)
+        mock_page.accessibility = AsyncMock()
+        mock_page.accessibility.snapshot = AsyncMock(return_value=a11y_tree)
+        # query_selector_all + evaluate are used by the snapshot path
+        mock_page.query_selector_all = AsyncMock(return_value=[])
+        mock_page.evaluate = AsyncMock(return_value={
+            "role": "WebArea", "name": "t", "children": [],
+        })
+        inst = CamoufoxInstance("a1", MagicMock(), MagicMock(), mock_page)
+        mgr._instances["a1"] = inst
+
+        result = await mgr.navigate(
+            "a1", "https://example.com", wait_ms=0, snapshot_after=True,
+        )
+        assert result["success"] is True
+        # body is the cap-1000 preview when snapshot_after is on.
+        assert len(result["data"]["body"]) <= 1000
+        # And the snapshot rides alongside.
+        assert "snapshot" in result
+
+    @pytest.mark.asyncio
+    async def test_body_capped_at_5000_without_snapshot_after(self):
+        from src.browser.service import BrowserManager, CamoufoxInstance
+
+        mgr = BrowserManager(profiles_dir="/tmp/test_profiles")
+        mock_page = AsyncMock()
+        mock_page.goto = AsyncMock()
+        mock_page.title = AsyncMock(return_value="t")
+        mock_page.url = "https://example.com"
+        # 8000-char-equivalent tree → joined output trims to the cap.
+        a11y_tree = self._make_long_a11y(8000)
+        mock_page.accessibility = AsyncMock()
+        mock_page.accessibility.snapshot = AsyncMock(return_value=a11y_tree)
+        inst = CamoufoxInstance("a1", MagicMock(), MagicMock(), mock_page)
+        mgr._instances["a1"] = inst
+
+        result = await mgr.navigate(
+            "a1", "https://example.com", wait_ms=0, snapshot_after=False,
+        )
+        assert result["success"] is True
+        # body is returned at the 5000-char cap when snapshot_after off.
+        body = result["data"]["body"]
+        assert 4000 <= len(body) <= 5000, len(body)
 
 
 class TestNavigateRetry:

--- a/tests/test_browser_service.py
+++ b/tests/test_browser_service.py
@@ -2379,6 +2379,39 @@ class TestNavigateBodyCap:
         body = result["data"]["body"]
         assert 4000 <= len(body) <= 5000, len(body)
 
+    @pytest.mark.asyncio
+    async def test_body_falls_back_to_5000_when_snapshot_fails(self):
+        """When snapshot_after=True but the snapshot itself fails or
+        returns nothing, the agent must NOT be left with a 1000-char
+        body AND an empty snapshot — strictly worse than the
+        snapshot_after=False path. The body falls back to the 5000-char
+        cap so the agent has usable page text."""
+        from src.browser.service import BrowserManager, CamoufoxInstance
+
+        mgr = BrowserManager(profiles_dir="/tmp/test_profiles")
+        mock_page = AsyncMock()
+        mock_page.goto = AsyncMock()
+        mock_page.title = AsyncMock(return_value="t")
+        mock_page.url = "https://example.com"
+        a11y_tree = self._make_long_a11y(8000)
+        mock_page.accessibility = AsyncMock()
+        mock_page.accessibility.snapshot = AsyncMock(return_value=a11y_tree)
+        inst = CamoufoxInstance("a1", MagicMock(), MagicMock(), mock_page)
+        mgr._instances["a1"] = inst
+
+        # Stub out _snapshot_impl to simulate failure.
+        async def _failing_snapshot(*_a, **_k):
+            return {"success": False, "error": "boom"}
+
+        with patch.object(mgr, "_snapshot_impl", _failing_snapshot):
+            result = await mgr.navigate(
+                "a1", "https://example.com", wait_ms=0, snapshot_after=True,
+            )
+        assert result["success"] is True
+        body = result["data"]["body"]
+        # Falls back to 5000-cap when snapshot was unsuccessful.
+        assert 4000 <= len(body) <= 5000, len(body)
+
 
 class TestNavigateRetry:
     """Tests for navigation timeout retry."""

--- a/tests/test_builtins.py
+++ b/tests/test_builtins.py
@@ -1691,10 +1691,14 @@ class TestBrowserScreenshotHttpClient:
 
         result = await browser_screenshot(mesh_client=mc)
 
-        mc.browser_command.assert_awaited_once_with("screenshot", {"full_page": False})
+        mc.browser_command.assert_awaited_once_with(
+            "screenshot",
+            {"full_page": False, "format": "webp", "quality": 75, "scale": 1.0},
+        )
         # image_base64 is extracted into _image, not left in data
         assert "image_base64" not in result.get("data", {})
         assert result["_image"]["data"] == "iVBORw0KGgo="
+        # Service returned format=png (legacy fallback) → media_type matches.
         assert result["_image"]["media_type"] == "image/png"
         assert result["status"] == "screenshot captured"
 
@@ -1710,8 +1714,41 @@ class TestBrowserScreenshotHttpClient:
 
         result = await browser_screenshot(full_page=True, mesh_client=mc)
 
-        mc.browser_command.assert_awaited_once_with("screenshot", {"full_page": True})
+        mc.browser_command.assert_awaited_once_with(
+            "screenshot",
+            {"full_page": True, "format": "webp", "quality": 75, "scale": 1.0},
+        )
         assert result["_image"]["data"] == "data"
+
+    @pytest.mark.asyncio
+    async def test_screenshot_webp_media_type(self):
+        """When the service returns format=webp, the agent-side block
+        carries media_type=image/webp so the LLM sees a WebP data URI."""
+        from src.agent.builtins.browser_tool import browser_screenshot
+
+        mc = AsyncMock()
+        mc.browser_command = AsyncMock(return_value={
+            "success": True,
+            "data": {"image_base64": "UklGRg==", "format": "webp", "bytes": 4},
+        })
+        result = await browser_screenshot(mesh_client=mc)
+        assert result["_image"]["media_type"] == "image/webp"
+
+    @pytest.mark.asyncio
+    async def test_screenshot_explicit_png(self):
+        """When the agent asks for PNG explicitly, the kwargs are forwarded."""
+        from src.agent.builtins.browser_tool import browser_screenshot
+
+        mc = AsyncMock()
+        mc.browser_command = AsyncMock(return_value={
+            "success": True,
+            "data": {"image_base64": "iVBORw0KGgo=", "format": "png"},
+        })
+        await browser_screenshot(format="png", quality=90, scale=0.75, mesh_client=mc)
+        mc.browser_command.assert_awaited_once_with(
+            "screenshot",
+            {"full_page": False, "format": "png", "quality": 90, "scale": 0.75},
+        )
 
     @pytest.mark.asyncio
     async def test_screenshot_no_image_in_response(self):


### PR DESCRIPTION
## Summary

§7.5 + §7.6 of the [browser-automation roadmap](docs/plans/2026-04-20-browser-automation.md) — token-efficiency wins on the browser tool surface.

- **§7.5 WebP screenshots.** ``browser_screenshot`` defaults to WebP (quality=75, scale=1.0) with new ``format``/``quality``/``scale`` params. Encodes via Pillow post-capture so the page renderer is untouched (no fingerprint signal). Pillow missing or encode failure → graceful PNG fallback so agents always get a usable image. Service-side response now includes a ``bytes`` field for dashboard observability.
- **§7.6 Navigate body dedup.** ``navigate(snapshot_after=true)`` caps the ``body`` preview at 1000 chars instead of 5000 because the snapshot already carries the element tree. Without ``snapshot_after`` the historical 5000-char cap stays.

## Risk and rollout

- WebP encoding has a CPU cost of ~10–20 ms per ~1080p image — invisible against the ~hundreds of ms a real screenshot already takes.
- Multimodal LLMs (Claude, GPT-4 vision) accept ``image/webp`` data URIs; ``media_type`` is set from the actual encoded format, not the requested one.
- Pillow added to ``pyproject.toml`` dependencies and to ``Dockerfile.browser`` pip install. WebP encoder is bundled in Pillow's manylinux wheel — no apt-level libwebp needed.
- ``format='png'`` with ``scale=1.0`` is a fast pass-through — zero Pillow round-trip.

## Test plan

- [x] WebP encode produces RIFF/WEBP-magic bytes and round-trips through Pillow.
- [x] Explicit ``format='png'`` + ``scale=1.0`` returns Playwright bytes verbatim.
- [x] ``scale=0.5`` halves dimensions.
- [x] Unknown format rejected with clear error.
- [x] Pillow missing → PNG fallback (monkeypatch of ``__import__``).
- [x] Body cap = 1000 with ``snapshot_after=true``; 5000 without.
- [x] Existing screenshot/navigate tests still pass (490/490 in test_browser_service + test_builtins).