### PR TITLE
Phase 4 §7.1: bundle uBlock Origin in profile template

### DIFF
--- a/Dockerfile.browser
+++ b/Dockerfile.browser
@@ -71,6 +71,22 @@ RUN pip install --no-cache-dir --root-user-action=ignore --upgrade pip \
     && pip install --no-cache-dir --root-user-action=ignore \
     "camoufox[geoip]" fastapi uvicorn pydantic httpx
 
+# uBlock Origin XPI (Phase 4 §7.1) — bundled at build time so air-gapped
+# deployments don't need addons.mozilla.org reachability at runtime.
+# Stored read-only in /opt; the profile-schema v3 migration copies it
+# into each agent profile's extensions/ dir on first launch.
+#
+# Pin to the AMO-signed Firefox build so Camoufox's patched Firefox
+# loads it without warning. Updating this version → bump
+# PROFILE_SCHEMA_VERSION in src/browser/profile_schema.py to ensure
+# existing profiles re-install the new XPI.
+ARG UBLOCK_VERSION=1.62.0
+RUN mkdir -p /opt/openlegion/extensions \
+    && curl -fSL -o /opt/openlegion/extensions/uBlock0.xpi \
+       "https://github.com/gorhill/uBlock/releases/download/${UBLOCK_VERSION}/uBlock0_${UBLOCK_VERSION}.firefox.signed.xpi" \
+    && test -s /opt/openlegion/extensions/uBlock0.xpi \
+    && chmod 0644 /opt/openlegion/extensions/uBlock0.xpi
+
 # Application code
 COPY src/browser/ /app/src/browser/
 COPY src/shared/ /app/src/shared/

--- a/Dockerfile.browser
+++ b/Dockerfile.browser
@@ -65,27 +65,42 @@ RUN useradd --create-home --uid 1000 --shell /bin/bash browser
 
 WORKDIR /app
 
-# Python dependencies — upgrade pip first to avoid resolver bugs with stale base images
-COPY pyproject.toml .
-RUN pip install --no-cache-dir --root-user-action=ignore --upgrade pip \
-    && pip install --no-cache-dir --root-user-action=ignore \
-    "camoufox[geoip]" fastapi uvicorn pydantic httpx
-
 # uBlock Origin XPI (Phase 4 §7.1) — bundled at build time so air-gapped
 # deployments don't need addons.mozilla.org reachability at runtime.
 # Stored read-only in /opt; the profile-schema v3 migration copies it
 # into each agent profile's extensions/ dir on first launch.
 #
+# Placed BEFORE the pyproject.toml COPY layer so a Python-dependency
+# bump doesn't invalidate the 3MB XPI download cache. Bumping
+# UBLOCK_VERSION (or rebuilding without --cache-from) refreshes it.
+#
 # Pin to the AMO-signed Firefox build so Camoufox's patched Firefox
-# loads it without warning. Updating this version → bump
+# loads it without warning. Bumping this version → bump
 # PROFILE_SCHEMA_VERSION in src/browser/profile_schema.py to ensure
-# existing profiles re-install the new XPI.
+# existing profiles re-install the new XPI on next launch.
+#
+# The ``.firefox.signed.xpi`` naming covers all stable uBO 1.x releases
+# we'd reasonably ship. Pre-release / beta builds (1.70.1b1 etc.) ship
+# only ``.firefox.xpi`` (unsigned) — fall back to that name so a tester
+# can pin to a beta without hand-editing the URL. Camoufox's patched
+# Firefox accepts unsigned XPIs because xpinstall.signatures.required
+# is set to False in stealth prefs.
 ARG UBLOCK_VERSION=1.62.0
 RUN mkdir -p /opt/openlegion/extensions \
-    && curl -fSL -o /opt/openlegion/extensions/uBlock0.xpi \
-       "https://github.com/gorhill/uBlock/releases/download/${UBLOCK_VERSION}/uBlock0_${UBLOCK_VERSION}.firefox.signed.xpi" \
+    && ( \
+       curl -fSL -o /opt/openlegion/extensions/uBlock0.xpi \
+          "https://github.com/gorhill/uBlock/releases/download/${UBLOCK_VERSION}/uBlock0_${UBLOCK_VERSION}.firefox.signed.xpi" \
+       || curl -fSL -o /opt/openlegion/extensions/uBlock0.xpi \
+          "https://github.com/gorhill/uBlock/releases/download/${UBLOCK_VERSION}/uBlock0_${UBLOCK_VERSION}.firefox.xpi" \
+       ) \
     && test -s /opt/openlegion/extensions/uBlock0.xpi \
     && chmod 0644 /opt/openlegion/extensions/uBlock0.xpi
+
+# Python dependencies — upgrade pip first to avoid resolver bugs with stale base images
+COPY pyproject.toml .
+RUN pip install --no-cache-dir --root-user-action=ignore --upgrade pip \
+    && pip install --no-cache-dir --root-user-action=ignore \
+    "camoufox[geoip]" fastapi uvicorn pydantic httpx
 
 # Application code
 COPY src/browser/ /app/src/browser/

--- a/src/browser/flags.py
+++ b/src/browser/flags.py
@@ -48,8 +48,8 @@ KNOWN_FLAGS: dict[str, str] = {
     "BROWSER_SNAPSHOT_FORMAT": "v1 | v2 (default v2 after one release gate)",
     "BROWSER_SCREENSHOT_FORMAT": "webp (default) | png",
     "BROWSER_SCREENSHOT_QUALITY": "WebP quality 1-100 (default 75)",
-    # ── Ad-blocker / egress (§7.1, existing) ─────────────────────────────
-    "BROWSER_ENABLE_ADBLOCK": "true | false (default true after phase 7.1)",
+    # ── Ad-blocker / egress (§7.1) ─────────────────────────────
+    "BROWSER_ENABLE_ADBLOCK": "true | false (default true; gates uBO install)",
     # ── Resolution pool (§6.1) ────────────────────────────────────────────
     "BROWSER_RESOLUTION_POOL": "true | false (default true after phase 6.1)",
     # ── Canary (§5.4) ─────────────────────────────────────────────────────

--- a/src/browser/profile_schema.py
+++ b/src/browser/profile_schema.py
@@ -292,14 +292,40 @@ def sync_adblock_extension(profile_dir: Path | str) -> bool:
     profile = Path(profile_dir)
     if not profile.is_dir():
         return False
+    # Acquire the same per-profile flock that ``migrate_profile`` uses so
+    # two browser-service processes (e.g. agent restart racing the
+    # provisioner update path) can't both write to ``extensions/`` at
+    # once. Non-blocking — if the peer holds it, skip; the peer is
+    # doing the same work. Idempotency means the eventual XPI state is
+    # correct regardless of who wins.
+    lock_path = profile / _LOCK_FILENAME
     try:
-        # Re-use the migration helper — it's already idempotent and
-        # respects the source-missing / flag-disabled guards.
-        _v3_install_ublock(profile)
-    except Exception as e:
+        with _try_lock(lock_path) as acquired:
+            if not acquired:
+                logger.debug(
+                    "sync_adblock_extension: peer holds lock on %s; "
+                    "skipping (peer will install)", profile,
+                )
+                return (
+                    profile / "extensions" / f"{UBLOCK_ADDON_ID}.xpi"
+                ).is_file()
+            try:
+                # Re-use the migration helper — already idempotent and
+                # respects the source-missing / flag-disabled guards.
+                _v3_install_ublock(profile)
+            except Exception as e:
+                logger.warning(
+                    "Launch-time uBlock sync failed for %s: %s "
+                    "(browser will start without ad-blocking)",
+                    profile, e,
+                )
+                return False
+    except OSError as e:
+        # Lock-file creation failure (FS read-only, perms) — treat as
+        # best-effort and continue; the browser still launches.
         logger.warning(
-            "Launch-time uBlock sync failed for %s: %s "
-            "(browser will start without ad-blocking)", profile, e,
+            "sync_adblock_extension: lock acquire failed for %s: %s",
+            profile, e,
         )
         return False
     target = profile / "extensions" / f"{UBLOCK_ADDON_ID}.xpi"

--- a/src/browser/profile_schema.py
+++ b/src/browser/profile_schema.py
@@ -61,7 +61,42 @@ logger = setup_logging("browser.profile_schema")
 
 # Bump this monotonically when adding a new migration. Never decrement.
 # Never reuse a number — migrations are applied by version key in order.
-PROFILE_SCHEMA_VERSION: int = 2
+PROFILE_SCHEMA_VERSION: int = 3
+
+
+# uBlock Origin's Firefox addon ID. Used as the filename when copying
+# the bundled XPI into a profile's ``extensions/`` directory — Firefox
+# requires the file to be named ``{addon-id}.xpi`` for auto-discovery.
+UBLOCK_ADDON_ID: str = "uBlock0@raymondhill.net"
+
+
+def _ublock_source_path() -> Path:
+    """Source XPI inside the browser container (placed by Dockerfile.browser).
+
+    Override via ``OPENLEGION_UBLOCK_XPI`` for unit tests + dev environments
+    where the container artifact isn't available. When the source is
+    missing, the migration logs and stamps the schema anyway — the launch
+    still succeeds without the extension, which matters for fresh dev
+    installs whose Dockerfile.browser may not yet have shipped uBO.
+    """
+    return Path(
+        os.environ.get(
+            "OPENLEGION_UBLOCK_XPI",
+            "/opt/openlegion/extensions/uBlock0.xpi",
+        )
+    )
+
+
+def _adblock_enabled() -> bool:
+    """Operator escape hatch (§7.1 / §2.1 ``BROWSER_ENABLE_ADBLOCK``).
+
+    Defaults to ``true``. Setting ``BROWSER_ENABLE_ADBLOCK=false`` skips
+    the install entirely — already-installed profiles keep their
+    extension (cleanly uninstalling Firefox extensions in-place is
+    fragile; operators wanting a hard reset should ``openlegion reset``).
+    """
+    raw = os.environ.get("BROWSER_ENABLE_ADBLOCK", "true").strip().lower()
+    return raw not in ("false", "0", "no", "off", "")
 
 
 def _v2_clear_font_caches(profile: Path) -> None:
@@ -130,8 +165,84 @@ def _v2_clear_font_caches(profile: Path) -> None:
 #   - Never touch cookies.sqlite, webappsstore.sqlite, storage/default/,
 #     or bookmarks.sqlite. Preserve user sessions.
 #   - Raise on unrecoverable failure. The caller will restore from .bak.
+def _v3_install_ublock(profile: Path) -> None:
+    """Migration v3 (Phase 4 §7.1): install uBlock Origin into the profile.
+
+    Firefox auto-discovers extensions placed at
+    ``{profile}/extensions/{addon-id}.xpi`` on launch (combined with
+    ``extensions.autoDisableScopes=0`` and ``extensions.startupScanScopes``
+    set in stealth prefs). The XPI itself is bundled at build time by
+    ``Dockerfile.browser`` to ``/opt/openlegion/extensions/uBlock0.xpi``.
+
+    Behavior:
+
+    - **Source missing.** Log INFO and return. Happens on dev installs
+      whose browser image hasn't been rebuilt yet, or test environments
+      that don't ship the XPI. Migration framework still stamps the
+      profile to v3 — the next launch on a properly-built container
+      will fix it because :func:`sync_adblock_extension` runs every
+      launch (see ``src/browser/service.py``).
+    - **Adblock disabled.** Operator set ``BROWSER_ENABLE_ADBLOCK=false``;
+      skip without raising so existing profiles still upgrade their
+      schema marker (no-op-ifying the migration prevents a stuck
+      "stamped at v2 forever" state).
+    - **Default install.** Copy XPI to ``{profile}/extensions/``,
+      ``chmod 0644``. Firefox installs and enables on next launch.
+
+    Idempotent — copies are guarded by mtime/size comparison so
+    re-running the migration on an already-installed profile is cheap.
+
+    Raises ``OSError`` only on unrecoverable I/O failures (disk full,
+    permission denied on a directory we own). The migration framework's
+    backup-restore path triggers; the operator gets a stable profile
+    rolled back to v2.
+    """
+    source = _ublock_source_path()
+    if not source.is_file():
+        logger.info(
+            "uBlock Origin XPI not found at %s — skipping install for %s "
+            "(profile will be stamped to v3; launch-time sync will install "
+            "later when the source becomes available)",
+            source, profile,
+        )
+        return
+    if not _adblock_enabled():
+        logger.info(
+            "BROWSER_ENABLE_ADBLOCK=false — skipping uBlock Origin install "
+            "for %s (existing extension files left untouched)", profile,
+        )
+        return
+
+    extensions_dir = profile / "extensions"
+    extensions_dir.mkdir(parents=True, exist_ok=True)
+    target = extensions_dir / f"{UBLOCK_ADDON_ID}.xpi"
+
+    # Idempotent copy: skip when the destination already matches the
+    # source (same size + mtime within 1s). Re-applies the chmod regardless
+    # so a profile restored from a backup with stale perms gets fixed.
+    if target.is_file():
+        try:
+            src_stat = source.stat()
+            tgt_stat = target.stat()
+            if (
+                src_stat.st_size == tgt_stat.st_size
+                and abs(src_stat.st_mtime - tgt_stat.st_mtime) < 1.0
+            ):
+                target.chmod(0o644)
+                return
+        except OSError:
+            # Stat failure is non-fatal — fall through to a fresh copy.
+            pass
+
+    # ``copy2`` preserves mtime so the size+mtime guard above will hit on
+    # the next migration call (idempotency).
+    shutil.copy2(source, target)
+    target.chmod(0o644)
+
+
 _MIGRATIONS: dict[int, Callable[[Path], None]] = {
     2: _v2_clear_font_caches,
+    3: _v3_install_ublock,
 }
 
 
@@ -154,6 +265,45 @@ class ProfileMigrationBusy(Exception):
 
 
 # ── Public API ──────────────────────────────────────────────────────────────
+
+
+def sync_adblock_extension(profile_dir: Path | str) -> bool:
+    """Refresh the uBlock Origin install for ``profile_dir`` at launch.
+
+    Distinct from :func:`migrate_profile`: that runs once per schema bump.
+    This runs every launch so flipping ``BROWSER_ENABLE_ADBLOCK`` on a
+    long-lived profile, or rebuilding the browser image with a newer XPI
+    version, takes effect on the next browser start without needing a
+    schema bump.
+
+    Returns ``True`` if the profile now has the bundled uBlock XPI in
+    place, ``False`` otherwise (source missing, adblock disabled, or
+    copy failed). Never raises — extension install is best-effort and
+    must not block browser launch.
+
+    Note on uninstall: when the operator flips
+    ``BROWSER_ENABLE_ADBLOCK=false`` AND the profile previously had
+    uBlock, this function does *not* attempt removal. Cleanly removing
+    a Firefox extension after first install requires editing
+    ``extensions.json`` + the profile DB, which is fragile across
+    Firefox versions. Operators wanting a hard reset should
+    ``openlegion reset`` (full profile wipe).
+    """
+    profile = Path(profile_dir)
+    if not profile.is_dir():
+        return False
+    try:
+        # Re-use the migration helper — it's already idempotent and
+        # respects the source-missing / flag-disabled guards.
+        _v3_install_ublock(profile)
+    except Exception as e:
+        logger.warning(
+            "Launch-time uBlock sync failed for %s: %s "
+            "(browser will start without ad-blocking)", profile, e,
+        )
+        return False
+    target = profile / "extensions" / f"{UBLOCK_ADDON_ID}.xpi"
+    return target.is_file()
 
 
 def migrate_profile(profile_dir: Path | str) -> int:

--- a/src/browser/service.py
+++ b/src/browser/service.py
@@ -849,7 +849,10 @@ class BrowserManager:
         #   * Any other exception — migration hit a real failure and the
         #     backup has already been restored. Not safely retryable until
         #     a human investigates.
-        from src.browser.profile_schema import ProfileMigrationBusy
+        from src.browser.profile_schema import (
+            ProfileMigrationBusy,
+            sync_adblock_extension,
+        )
         try:
             migrate_profile(Path(profile_dir))
         except ProfileMigrationBusy:
@@ -864,6 +867,14 @@ class BrowserManager:
                 agent_id,
             )
             raise
+
+        # Phase 4 §7.1 — make sure the ad-blocker XPI matches the operator's
+        # current ``BROWSER_ENABLE_ADBLOCK`` setting. This is intentionally
+        # separate from the schema migration: the migration runs once per
+        # version bump, but flag toggles + image rebuilds with newer XPIs
+        # need to take effect on every launch. Best-effort — never blocks
+        # the browser from starting.
+        sync_adblock_extension(Path(profile_dir))
 
         proxy_config = self.get_proxy_config(agent_id)
         if proxy_config is not None:

--- a/src/browser/stealth.py
+++ b/src/browser/stealth.py
@@ -623,6 +623,28 @@ def _stealth_prefs() -> dict:
         "browser.newtabpage.activity-stream.asrouter.userprefs.cfr.features": False,
         "extensions.htmlaboutaddons.recommendations.enabled": False,
 
+        # ── Bundled extensions (Phase 4 §7.1) ─────────────────────────────────
+        # The profile-schema v3 migration drops uBlock Origin's signed XPI
+        # into ``{profile}/extensions/{addon-id}.xpi``. Firefox detects
+        # extensions there at launch but only enables them automatically
+        # when these prefs cooperate:
+        #   * ``autoDisableScopes=0`` — bit-mask of scopes whose extensions
+        #     start *disabled* on first install. 0 means none of the
+        #     auto-discovered scopes are disabled, so our profile-bundled
+        #     uBlock loads on first run.
+        #   * ``startupScanScopes=15`` — bit-mask of scopes scanned for
+        #     extension changes at every startup. 15 = all (1=app, 2=system,
+        #     4=user, 8=profile). Without this, Firefox only re-scans the
+        #     profile dir when the addon DB tracks a known XPI; a freshly-
+        #     dropped XPI from our migration would otherwise wait until the
+        #     next manifest change.
+        #   * ``xpinstall.signatures.required=False`` — Camoufox's patched
+        #     Firefox already loosens this, but setting it explicitly keeps
+        #     us robust against upstream Camoufox changes that re-tighten it.
+        "extensions.autoDisableScopes": 0,
+        "extensions.startupScanScopes": 15,
+        "xpinstall.signatures.required": False,
+
         # ── First-run / welcome / default-browser prompts ────────────────────
         # Belt-and-suspenders against the about:welcome tab, default-browser
         # nag, and profile-import wizard. Phase 3 profile schema v2 takes

--- a/tests/test_profile_schema.py
+++ b/tests/test_profile_schema.py
@@ -685,6 +685,63 @@ class TestSyncAdblockExtension:
         from src.browser.profile_schema import sync_adblock_extension
         assert sync_adblock_extension(tmp_path / "no-such") is False
 
+    def test_returns_existing_state_when_peer_holds_lock(
+        self, profile, fake_xpi,
+    ):
+        """When a peer browser-service process holds the per-profile
+        flock, sync_adblock_extension skips its install step and reports
+        whether the XPI is already present (peer is doing the same work,
+        idempotency means eventual state is correct)."""
+        import fcntl
+        import os
+
+        from src.browser.profile_schema import (
+            UBLOCK_ADDON_ID,
+            _LOCK_FILENAME,
+            sync_adblock_extension,
+        )
+        # Pre-install so the contended path can find the existing XPI.
+        (profile / "extensions").mkdir()
+        existing_xpi = profile / "extensions" / f"{UBLOCK_ADDON_ID}.xpi"
+        existing_xpi.write_bytes(b"existing")
+
+        lock_path = profile / _LOCK_FILENAME
+        fd = os.open(lock_path, os.O_CREAT | os.O_RDWR, 0o600)
+        fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+        try:
+            # Returns True because the existing XPI satisfies the
+            # presence check, but skips the install (verified by the
+            # XPI bytes being unchanged from the pre-existing state).
+            result = sync_adblock_extension(profile)
+            assert result is True
+            assert existing_xpi.read_bytes() == b"existing"
+        finally:
+            fcntl.flock(fd, fcntl.LOCK_UN)
+            os.close(fd)
+
+    def test_returns_false_when_peer_holds_lock_and_no_xpi(
+        self, profile, fake_xpi,
+    ):
+        """Same flock contention but no existing XPI in the profile —
+        the peer hasn't finished installing yet, so we report False."""
+        import fcntl
+        import os
+
+        from src.browser.profile_schema import (
+            _LOCK_FILENAME,
+            sync_adblock_extension,
+        )
+        lock_path = profile / _LOCK_FILENAME
+        fd = os.open(lock_path, os.O_CREAT | os.O_RDWR, 0o600)
+        fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+        try:
+            assert sync_adblock_extension(profile) is False
+            # No install happened — peer hasn't released the lock.
+            assert not (profile / "extensions").exists()
+        finally:
+            fcntl.flock(fd, fcntl.LOCK_UN)
+            os.close(fd)
+
 
 class TestStealthExtensionPrefs:
     """The migration drops the XPI on disk; Firefox needs cooperative

--- a/tests/test_profile_schema.py
+++ b/tests/test_profile_schema.py
@@ -524,6 +524,27 @@ class TestV3UblockInstall:
         _v3_install_ublock(profile)
         assert not (profile / "extensions").exists()
 
+    def test_full_migration_with_flag_disabled_still_stamps_v3(
+        self, profile, fake_xpi, monkeypatch,
+    ):
+        """Regression for the migration framework: even when the v3
+        callable is a no-op (flag disabled), the framework MUST stamp
+        the marker to v3 — otherwise every launch re-runs the migration
+        and the operator never sees forward progress."""
+        from src.browser.profile_schema import (
+            PROFILE_SCHEMA_VERSION,
+            _MARKER_FILENAME,
+            UBLOCK_ADDON_ID,
+        )
+        monkeypatch.setenv("BROWSER_ENABLE_ADBLOCK", "false")
+        result = migrate_profile(profile)
+        assert result == PROFILE_SCHEMA_VERSION == 3
+        assert (profile / _MARKER_FILENAME).read_text().strip() == "3"
+        # And no XPI was installed.
+        assert not (
+            profile / "extensions" / f"{UBLOCK_ADDON_ID}.xpi"
+        ).exists()
+
     def test_idempotent_skips_recopy_when_unchanged(
         self, profile, fake_xpi, monkeypatch,
     ):

--- a/tests/test_profile_schema.py
+++ b/tests/test_profile_schema.py
@@ -461,12 +461,13 @@ class TestV2FontCacheClear:
         _v2_clear_font_caches(profile)  # no caches to clear
         _v2_clear_font_caches(profile)  # and again — still fine
 
-    def test_end_to_end_migration_at_v2(self, profile):
-        """Fresh profile → migrate → marker is at v2, no crash on empty caches."""
+    def test_end_to_end_migration_clears_font_cache(self, profile):
+        """Fresh profile → migrate → font cache is wiped by v2 step,
+        regardless of which version the schema currently tops out at."""
         (profile / "startupCache").mkdir()
         (profile / "startupCache" / "x.bin").write_bytes(b"x")
         result = migrate_profile(profile)
-        assert result == 2
+        assert result == PROFILE_SCHEMA_VERSION
         assert not (profile / "startupCache").exists()
 
     def test_rerun_after_v2_is_noop(self, populated_profile):
@@ -479,3 +480,208 @@ class TestV2FontCacheClear:
         migrate_profile(populated_profile)
         # Cache survived the no-op re-migrate.
         assert (populated_profile / "startupCache" / "survives.bin").exists()
+
+
+class TestV3UblockInstall:
+    """§7.1 migration v3: drop the bundled uBlock Origin XPI into a
+    profile's ``extensions/`` directory so Firefox auto-installs it."""
+
+    @pytest.fixture
+    def fake_xpi(self, tmp_path: Path, monkeypatch) -> Path:
+        """Synthetic XPI on disk + ``OPENLEGION_UBLOCK_XPI`` env override
+        so the migration sees it instead of the container path."""
+        xpi = tmp_path / "uBlock0.xpi"
+        xpi.write_bytes(b"PK\x03\x04" + b"fake-zip" * 100)
+        monkeypatch.setenv("OPENLEGION_UBLOCK_XPI", str(xpi))
+        return xpi
+
+    def test_copies_xpi_into_extensions_dir(self, profile, fake_xpi):
+        from src.browser.profile_schema import (
+            UBLOCK_ADDON_ID,
+            _v3_install_ublock,
+        )
+        _v3_install_ublock(profile)
+        target = profile / "extensions" / f"{UBLOCK_ADDON_ID}.xpi"
+        assert target.exists()
+        assert target.read_bytes() == fake_xpi.read_bytes()
+        # Reasonable perms for Firefox to read.
+        mode = target.stat().st_mode & 0o777
+        assert mode == 0o644
+
+    def test_skipped_when_source_missing(self, profile, monkeypatch):
+        from src.browser.profile_schema import _v3_install_ublock
+        monkeypatch.setenv(
+            "OPENLEGION_UBLOCK_XPI", "/nonexistent/uBlock0.xpi",
+        )
+        _v3_install_ublock(profile)
+        assert not (profile / "extensions").exists()
+
+    def test_skipped_when_flag_disabled(
+        self, profile, fake_xpi, monkeypatch,
+    ):
+        from src.browser.profile_schema import _v3_install_ublock
+        monkeypatch.setenv("BROWSER_ENABLE_ADBLOCK", "false")
+        _v3_install_ublock(profile)
+        assert not (profile / "extensions").exists()
+
+    def test_idempotent_skips_recopy_when_unchanged(
+        self, profile, fake_xpi, monkeypatch,
+    ):
+        from src.browser.profile_schema import (
+            UBLOCK_ADDON_ID,
+            _v3_install_ublock,
+        )
+        _v3_install_ublock(profile)
+        target = profile / "extensions" / f"{UBLOCK_ADDON_ID}.xpi"
+        first_mtime = target.stat().st_mtime
+        # No changes → copy is skipped.
+        import shutil
+        copy_calls: list[tuple] = []
+        original_copy2 = shutil.copy2
+
+        def spy(src, dst, *a, **kw):
+            copy_calls.append((src, dst))
+            return original_copy2(src, dst, *a, **kw)
+
+        monkeypatch.setattr(shutil, "copy2", spy)
+        _v3_install_ublock(profile)
+        assert copy_calls == []
+        assert target.stat().st_mtime == first_mtime
+
+    def test_recopies_when_source_changes(
+        self, profile, fake_xpi, monkeypatch,
+    ):
+        import time
+
+        from src.browser.profile_schema import (
+            UBLOCK_ADDON_ID,
+            _v3_install_ublock,
+        )
+        _v3_install_ublock(profile)
+        target = profile / "extensions" / f"{UBLOCK_ADDON_ID}.xpi"
+        first_size = target.stat().st_size
+
+        # Update the source: bigger payload, fresher mtime.
+        time.sleep(1.1)  # bump mtime past the 1-second guard window
+        fake_xpi.write_bytes(b"PK\x03\x04" + b"new" * 1000)
+        _v3_install_ublock(profile)
+        assert target.stat().st_size != first_size
+        assert target.read_bytes() == fake_xpi.read_bytes()
+
+    def test_end_to_end_migration_at_v3(self, profile, fake_xpi):
+        from src.browser.profile_schema import UBLOCK_ADDON_ID
+        result = migrate_profile(profile)
+        assert result == 3
+        target = profile / "extensions" / f"{UBLOCK_ADDON_ID}.xpi"
+        assert target.exists()
+
+    def test_v3_runs_after_v2(self, profile, fake_xpi):
+        """v0 → v3 should run v2 then v3 in order."""
+        # Seed startupCache so v2 has work to do
+        (profile / "startupCache").mkdir()
+        (profile / "startupCache" / "x.bin").write_bytes(b"x")
+        migrate_profile(profile)
+        assert not (profile / "startupCache").exists()  # v2 ran
+        from src.browser.profile_schema import UBLOCK_ADDON_ID
+        assert (profile / "extensions" / f"{UBLOCK_ADDON_ID}.xpi").exists()  # v3 ran
+
+    def test_preserves_cookies_and_storage(
+        self, populated_profile, fake_xpi,
+    ):
+        """v3 must not touch the user's session — only adds the XPI."""
+        from src.browser.profile_schema import (
+            UBLOCK_ADDON_ID,
+            _v3_install_ublock,
+        )
+        _v3_install_ublock(populated_profile)
+        assert (
+            populated_profile / "cookies.sqlite"
+        ).read_bytes() == b"cookies-fake"
+        assert (populated_profile / "prefs.js").exists()
+        assert (
+            populated_profile / "storage" / "default" / "idb.sqlite"
+        ).exists()
+        assert (
+            populated_profile / "extensions" / f"{UBLOCK_ADDON_ID}.xpi"
+        ).exists()
+
+
+class TestSyncAdblockExtension:
+    """Launch-time sync helper — runs every browser start, distinct
+    from migration which runs once per schema bump."""
+
+    @pytest.fixture
+    def fake_xpi(self, tmp_path: Path, monkeypatch) -> Path:
+        xpi = tmp_path / "uBlock0.xpi"
+        xpi.write_bytes(b"PK\x03\x04" + b"sync-test" * 100)
+        monkeypatch.setenv("OPENLEGION_UBLOCK_XPI", str(xpi))
+        return xpi
+
+    def test_installs_when_flag_enabled_and_source_present(
+        self, profile, fake_xpi,
+    ):
+        from src.browser.profile_schema import (
+            UBLOCK_ADDON_ID,
+            sync_adblock_extension,
+        )
+        result = sync_adblock_extension(profile)
+        assert result is True
+        assert (
+            profile / "extensions" / f"{UBLOCK_ADDON_ID}.xpi"
+        ).exists()
+
+    def test_returns_false_when_flag_disabled(
+        self, profile, fake_xpi, monkeypatch,
+    ):
+        from src.browser.profile_schema import sync_adblock_extension
+        monkeypatch.setenv("BROWSER_ENABLE_ADBLOCK", "false")
+        assert sync_adblock_extension(profile) is False
+
+    def test_returns_false_when_source_missing(
+        self, profile, monkeypatch,
+    ):
+        from src.browser.profile_schema import sync_adblock_extension
+        monkeypatch.setenv(
+            "OPENLEGION_UBLOCK_XPI", "/nonexistent/uBlock0.xpi",
+        )
+        assert sync_adblock_extension(profile) is False
+
+    def test_never_raises_on_unexpected_failure(
+        self, profile, fake_xpi, monkeypatch,
+    ):
+        """Helper is best-effort — never block browser launch."""
+        from src.browser import profile_schema as ps
+        from src.browser.profile_schema import sync_adblock_extension
+
+        def boom(*_a, **_k):
+            raise OSError("simulated I/O explosion")
+
+        monkeypatch.setattr(ps, "_v3_install_ublock", boom)
+        # No exception escapes — caller (BrowserManager) keeps going.
+        assert sync_adblock_extension(profile) is False
+
+    def test_returns_false_for_missing_profile_dir(self, tmp_path):
+        from src.browser.profile_schema import sync_adblock_extension
+        assert sync_adblock_extension(tmp_path / "no-such") is False
+
+
+class TestStealthExtensionPrefs:
+    """The migration drops the XPI on disk; Firefox needs cooperative
+    prefs to actually load it. Regression-guard those prefs in
+    ``_stealth_prefs``."""
+
+    def test_auto_disable_scopes_zero(self):
+        from src.browser.stealth import _stealth_prefs
+        prefs = _stealth_prefs()
+        assert prefs["extensions.autoDisableScopes"] == 0
+
+    def test_startup_scan_scopes_all(self):
+        from src.browser.stealth import _stealth_prefs
+        prefs = _stealth_prefs()
+        # 15 = 1|2|4|8 = app|system|user|profile.
+        assert prefs["extensions.startupScanScopes"] == 15
+
+    def test_signature_required_off(self):
+        from src.browser.stealth import _stealth_prefs
+        prefs = _stealth_prefs()
+        assert prefs["xpinstall.signatures.required"] is False


### PR DESCRIPTION
## Summary

§7.1 of the [browser-automation roadmap](docs/plans/2026-04-20-browser-automation.md) — bundles uBlock Origin's signed XPI in the browser image and installs it into every agent profile via the profile-schema framework.

- **XPI bundled at build time.** ``Dockerfile.browser`` downloads ``uBlock0_${UBLOCK_VERSION}.firefox.signed.xpi`` from the official GitHub releases (pinned via ``UBLOCK_VERSION`` build arg, defaults to 1.62.0). Stored read-only at ``/opt/openlegion/extensions/uBlock0.xpi``.
- **Profile schema v3 migration** (``_v3_install_ublock``) drops the XPI into ``{profile}/extensions/{addon-id}.xpi`` where Firefox auto-discovers it on launch. Idempotent — size+mtime guard skips recopy on unchanged XPI; refreshes when the image rebuilds with a newer version.
- **Cooperating stealth prefs** in ``_stealth_prefs()``: ``extensions.autoDisableScopes=0``, ``extensions.startupScanScopes=15``, ``xpinstall.signatures.required=False``. Without these Firefox sees the file but installs disabled.
- **Operator escape hatch.** ``BROWSER_ENABLE_ADBLOCK=false`` skips install at migration time and at every-launch sync time. Default stays ``true`` per §2.1.
- **Launch-time sync helper** ``sync_adblock_extension()`` runs at every ``BrowserManager.get_or_start`` so flag toggles after a profile is at v3 (or image rebuilds with a newer XPI) take effect without another schema bump.

## Risk and rollout

- Default-true after this ships, per §2.1. uBlock Origin's defaults (EasyList + EasyPrivacy) are well-tested and won't break authentication flows or e-commerce checkouts. The roadmap's known-risk site (Forbes-class adblock walls) is covered by the operator kill switch — explicit per-host opt-out is deferred until we see real failures, since the spec is ambiguous between "operator config endpoint" and "per-page runtime disable" and the latter requires fragile uBO storage poking.
- Migration is wrapped in the existing backup-restore framework: a partial v3 failure restores the pre-migration profile.
- Source-XPI-missing path is graceful: dev installs whose ``Dockerfile.browser`` hasn't been rebuilt log INFO and continue, letting the next launch on a properly-built image fix the install via ``sync_adblock_extension``.

## Test plan

- [x] Migration copies XPI to ``{profile}/extensions/{addon-id}.xpi`` with mode 0644.
- [x] Source missing → migration logs and skips, profile still stamps v3.
- [x] ``BROWSER_ENABLE_ADBLOCK=false`` → install skipped.
- [x] Re-running migration on already-installed profile is a no-op (no recopy).
- [x] Source XPI changes (size + mtime) → migration recopies.
- [x] End-to-end ``v0 → v3`` runs v2 (font cache wipe) then v3 (XPI install) in order.
- [x] v3 preserves cookies, prefs, and IndexedDB (cookies.sqlite, prefs.js, storage/default).
- [x] ``sync_adblock_extension`` returns ``True`` when installed, ``False`` on flag-disabled / source-missing / failure.
- [x] Sync helper never raises (best-effort — must not block browser launch).
- [x] Stealth prefs include autoDisableScopes=0, startupScanScopes=15, signatures.required=False.
- [x] 41/41 in ``test_profile_schema.py``; 308/308 across ``test_browser_service.py`` + ``test_stealth.py`` (no regressions).