### PR TITLE
Phase 4 §7.4 + §7.7: scoped + filtered snapshots

### DIFF
--- a/src/agent/builtins/browser_tool.py
+++ b/src/agent/builtins/browser_tool.py
@@ -116,14 +116,46 @@ async def browser_navigate(
         "page. Elements include structural context like (navigation), "
         "(dialog: Name) — when duplicates exist, prefer the one inside the "
         "relevant container. This returns structured text, NOT a visual "
-        "image — use browser_screenshot for that."
+        "image — use browser_screenshot for that.\n\n"
+        "Optional: pass filter='actionable'|'inputs'|'headings'|'landmarks' "
+        "to narrow the result (cheaper tokens on huge pages). Pass "
+        "from_ref='e3' to scope the snapshot to a specific element's "
+        "subtree — useful for drilling into a list, table, or form section."
     ),
-    parameters={},
+    parameters={
+        "filter": {
+            "type": "string",
+            "description": (
+                "Optional role filter. 'actionable' = clickable / typeable "
+                "elements only; 'inputs' = form inputs only; 'headings' = "
+                "section headings for orientation; 'landmarks' = top-level "
+                "regions (navigation/main/...). Omit for the default mix."
+            ),
+        },
+        "from_ref": {
+            "type": "string",
+            "description": (
+                "Optional ref id (e.g. 'e7') from a previous "
+                "browser_get_elements call. When set, the snapshot is "
+                "rooted at that element's subtree."
+            ),
+        },
+    },
     parallel_safe=False,
 )
-async def browser_get_elements(*, mesh_client=None) -> dict:
+async def browser_get_elements(
+    filter: str | None = None,
+    from_ref: str | None = None,
+    *,
+    mesh_client=None,
+) -> dict:
     """Return an accessibility tree snapshot with element refs."""
-    return await _browser_command(mesh_client, "snapshot")
+    payload: dict = {}
+    if filter is not None:
+        payload["filter"] = filter
+    if from_ref is not None:
+        payload["from_ref"] = from_ref
+    return await _browser_command(mesh_client, "snapshot", payload)
 
 
 @skill(

--- a/src/agent/builtins/browser_tool.py
+++ b/src/agent/builtins/browser_tool.py
@@ -137,7 +137,12 @@ async def browser_navigate(
             "description": (
                 "Optional ref id (e.g. 'e7') from a previous "
                 "browser_get_elements call. When set, the snapshot is "
-                "rooted at that element's subtree."
+                "rooted at that element's subtree. Note: refs returned "
+                "from a scoped snapshot resolve against the whole page, "
+                "not the subtree — if a modal or other overlay is open, "
+                "duplicate role+name elements behind it could match. "
+                "When in doubt, take a non-scoped browser_get_elements "
+                "before clicking refs from a scoped result."
             ),
         },
     },

--- a/src/browser/server.py
+++ b/src/browser/server.py
@@ -164,7 +164,15 @@ def create_browser_app(manager: BrowserManager, lifespan=None) -> FastAPI:
     @app.post("/browser/{agent_id}/snapshot")
     async def snapshot(agent_id: str, request: Request):
         _verify_auth(request)
-        return await manager.snapshot(agent_id)
+        try:
+            body = await request.json()
+        except Exception:
+            body = {}
+        return await manager.snapshot(
+            agent_id,
+            filter=(body or {}).get("filter"),
+            from_ref=(body or {}).get("from_ref"),
+        )
 
     @app.post("/browser/{agent_id}/click")
     async def click(agent_id: str, request: Request):

--- a/src/browser/service.py
+++ b/src/browser/service.py
@@ -84,10 +84,21 @@ def _resolve_filter_roles(filter_name: str | None) -> frozenset[str] | None:
     Unknown name ⇒ raises ``ValueError`` with a helpful list of valid
     options. Empty string is treated like ``None`` so callers passing
     JSON ``""`` from a UI default don't accidentally narrow the result.
+
+    Case-insensitive — LLMs frequently capitalize parameter values. A
+    naive case-sensitive lookup would have rejected ``"Actionable"`` /
+    ``"INPUTS"`` with ``invalid_input``; the agent then has to retry.
     """
-    if filter_name is None or filter_name == "":
+    if filter_name is None:
         return None
-    preset = _FILTER_PRESETS.get(filter_name)
+    if not isinstance(filter_name, str):
+        raise ValueError(
+            f"filter must be a string, got {type(filter_name).__name__}"
+        )
+    key = filter_name.strip().lower()
+    if key == "":
+        return None
+    preset = _FILTER_PRESETS.get(key)
     if preset is None:
         valid = ", ".join(sorted(_FILTER_PRESETS))
         raise ValueError(
@@ -272,11 +283,18 @@ _JS_A11Y_TREE = r"""(rootEl) => {
         'heading','img','dialog','alertdialog','alert',
         'listbox','tree','grid','toolbar','menu','status'
     ]);
-    const ROLES = new Set([...ACTIONABLE, ...CONTEXT]);
     const LANDMARK = new Set([
         'navigation','main','complementary','banner','contentinfo',
         'form','region','dialog','alertdialog'
     ]);
+    // §7.7 includes LANDMARK in the set so ``filter='landmarks'``
+    // works even when ``page.accessibility.snapshot()`` is unavailable
+    // and we fall back to this JS walker. Without LANDMARK in ROLES,
+    // landmark elements collapse to ``role: 'none'`` here and never
+    // reach the Python ``_walk`` even with the right ``allowed_roles``.
+    // Default snapshot output is unaffected: Python ``_walk`` still
+    // gates on ACTIONABLE+CONTEXT unless an explicit filter is passed.
+    const ROLES = new Set([...ACTIONABLE, ...CONTEXT, ...LANDMARK]);
     const IMPLICIT = {
         BUTTON:'button',TEXTAREA:'textbox',SELECT:'combobox',OPTION:'option',
         IMG:'img',H1:'heading',H2:'heading',H3:'heading',
@@ -1996,9 +2014,36 @@ class BrowserManager:
             # second-guess that intent, so skip straight to a single
             # ``_walk`` of the scoped tree.
             if scoped_root_handle is not None:
-                inst.dialog_active = False
-                inst.dialog_detected = False
+                # Snapshot the live modal state BEFORE walking — clearing
+                # ``dialog_active`` here would let subsequent
+                # ``_locator_from_ref`` resolutions of these scoped refs
+                # bypass modal scoping, allowing duplicate role+name
+                # elements behind the overlay to silently match. We keep
+                # the live state intact so the next non-scoped snapshot
+                # re-detects modals naturally; in the meantime, scoped
+                # refs taken inside a modal still resolve through the
+                # modal selector.
+                was_modal = bool(inst.dialog_active)
                 _walk(tree)
+                # If the agent took this scoped snapshot while a modal
+                # was open, patch ``scope_root`` on every emitted ref so
+                # ``_locator_from_ref`` keeps clicks bounded to the dialog
+                # subtree. Without this the scoped refs could resolve to
+                # identical-named elements behind the overlay.
+                if was_modal:
+                    for rid, handle in refs.items():
+                        if handle.scope_root is None:
+                            refs[rid] = RefHandle(
+                                page_id=handle.page_id,
+                                frame_id=handle.frame_id,
+                                shadow_path=handle.shadow_path,
+                                scope_root=_MODAL_SELECTOR,
+                                role=handle.role,
+                                name=handle.name,
+                                occurrence=handle.occurrence,
+                                disabled=handle.disabled,
+                                element_key=handle.element_key,
+                            )
                 inst.refs = refs
                 snapshot_text = (
                     "\n".join(lines) if lines else "(no interactive elements)"

--- a/src/browser/service.py
+++ b/src/browser/service.py
@@ -56,6 +56,46 @@ _CONTEXT_ROLES = frozenset({
     "listbox", "tree", "grid", "toolbar", "menu", "status",
 })
 
+# §7.7 semantic filters. Each value maps to a frozenset of roles that
+# admit nodes into the snapshot output. ``None`` (no filter passed) is
+# handled separately and falls back to the historical default of
+# ``_ACTIONABLE_ROLES ∪ _CONTEXT_ROLES``.
+_FILTER_INPUTS = frozenset({
+    "textbox", "searchbox", "checkbox", "radio", "combobox",
+    "slider", "spinbutton", "switch",
+})
+_FILTER_HEADINGS = frozenset({"heading"})
+_FILTER_LANDMARKS = frozenset({
+    "navigation", "main", "complementary", "banner", "contentinfo",
+    "form", "region", "dialog", "alertdialog",
+})
+_FILTER_PRESETS: dict[str, frozenset[str]] = {
+    "actionable": _ACTIONABLE_ROLES,
+    "inputs": _FILTER_INPUTS,
+    "headings": _FILTER_HEADINGS,
+    "landmarks": _FILTER_LANDMARKS,
+}
+
+
+def _resolve_filter_roles(filter_name: str | None) -> frozenset[str] | None:
+    """Map a ``filter`` parameter to the role frozenset to admit.
+
+    ``None`` ⇒ ``None`` (caller falls back to the historical default).
+    Unknown name ⇒ raises ``ValueError`` with a helpful list of valid
+    options. Empty string is treated like ``None`` so callers passing
+    JSON ``""`` from a UI default don't accidentally narrow the result.
+    """
+    if filter_name is None or filter_name == "":
+        return None
+    preset = _FILTER_PRESETS.get(filter_name)
+    if preset is None:
+        valid = ", ".join(sorted(_FILTER_PRESETS))
+        raise ValueError(
+            f"Unknown filter {filter_name!r}; valid options: {valid}"
+        )
+    return preset
+
+
 _MAX_SNAPSHOT_ELEMENTS = 200
 
 
@@ -1750,17 +1790,125 @@ class BrowserManager:
             logger.debug("JS a11y tree fallback failed: %s", e)
             return None
 
-    async def snapshot(self, agent_id: str) -> dict:
-        """Get accessibility tree with element refs."""
+    async def snapshot(
+        self,
+        agent_id: str,
+        filter: str | None = None,
+        from_ref: str | None = None,
+    ) -> dict:
+        """Get accessibility tree with element refs.
+
+        ``filter`` constrains which elements appear in the result (§7.7):
+
+        - ``None`` (default) — actionable + context roles (the historic
+          behavior, balanced for general-purpose agents).
+        - ``"actionable"`` — only roles the agent can act on
+          (button, link, textbox, ...). Skips heading/img/landmark.
+        - ``"inputs"`` — form-input roles only. Useful when the agent is
+          mid-form and doesn't need the navigation skeleton.
+        - ``"headings"`` — heading nodes only. ``browser_find_text`` for
+          structural orientation when the page is huge.
+        - ``"landmarks"`` — top-level region nodes only (navigation, main,
+          complementary, ...). Cheap orientation pass before drilling in.
+
+        ``from_ref`` (§7.4) restricts the snapshot to the subtree rooted
+        at an element captured in a previous call. Pass an ``e<N>`` ref
+        from ``inst.refs``; the returned tree shows only that element
+        and its descendants. Combine with ``filter`` to focus a busy
+        list on its inputs, etc.
+        """
         inst = await self.get_or_start(agent_id)
         inst.touch()
         async with inst.lock:
-            return await self._snapshot_impl(inst, agent_id)
+            return await self._snapshot_impl(
+                inst, agent_id, filter=filter, from_ref=from_ref,
+            )
 
-    async def _snapshot_impl(self, inst: CamoufoxInstance, agent_id: str) -> dict:
+    async def _snapshot_impl(
+        self,
+        inst: CamoufoxInstance,
+        agent_id: str,
+        filter: str | None = None,
+        from_ref: str | None = None,
+    ) -> dict:
         """Snapshot implementation.  Caller must hold ``inst.lock``."""
+        # Resolve the optional filter once so the inner _walk sees a
+        # frozenset rather than re-deriving on every node.
         try:
-            tree = await self._build_a11y_tree(inst)
+            allowed_roles = _resolve_filter_roles(filter)
+        except ValueError as e:
+            return {
+                "success": False,
+                "error": {
+                    "code": "invalid_input",
+                    "message": str(e),
+                    "retry_after_ms": None,
+                },
+            }
+        try:
+            # ── Optional scoped root via ``from_ref`` (§7.4) ────────────────
+            scoped_root_handle = None
+            if from_ref is not None:
+                if not from_ref:
+                    return {
+                        "success": False,
+                        "error": {
+                            "code": "invalid_input",
+                            "message": "from_ref must be a non-empty ref id",
+                            "retry_after_ms": None,
+                        },
+                    }
+                if from_ref not in inst.refs:
+                    return {
+                        "success": False,
+                        "error": {
+                            "code": "not_found",
+                            "message": f"ref {from_ref!r} not in current snapshot",
+                            "retry_after_ms": None,
+                        },
+                    }
+                # Resolve to a Playwright ElementHandle. ``_locator_from_ref``
+                # may raise RefStale on closed-tab refs — that's the same
+                # contract every other ref-using path follows; surface as
+                # ref_stale so the agent re-snapshots.
+                try:
+                    locator = self._locator_from_ref(inst, from_ref)
+                    if locator is None:
+                        return {
+                            "success": False,
+                            "error": {
+                                "code": "not_found",
+                                "message": f"ref {from_ref!r} could not be resolved",
+                                "retry_after_ms": None,
+                            },
+                        }
+                    scoped_root_handle = await locator.element_handle(timeout=2000)
+                except RefStale as e:
+                    return {
+                        "success": False,
+                        "error": {
+                            "code": "ref_stale",
+                            "message": str(e),
+                            "retry_after_ms": None,
+                        },
+                    }
+                if scoped_root_handle is None:
+                    # Locator resolved structurally but the element is no
+                    # longer in the DOM — common for dynamic SPAs that
+                    # tear down and re-render between snapshots.
+                    return {
+                        "success": False,
+                        "error": {
+                            "code": "ref_stale",
+                            "message": (
+                                f"ref {from_ref!r} no longer attached to the page; "
+                                "re-snapshot to get fresh refs"
+                            ),
+                            "retry_after_ms": None,
+                        },
+                    }
+
+            tree = await self._build_a11y_tree(inst, root=scoped_root_handle)
             if not tree:
                 return {"success": True, "data": {"snapshot": "(empty page)", "refs": {}}}
 
@@ -1790,7 +1938,13 @@ class BrowserManager:
                     return
                 role = node.get("role", "")
                 name = node.get("name", "")
-                if role in _ACTIONABLE_ROLES or role in _CONTEXT_ROLES:
+                # ``allowed_roles=None`` means "use the historical default"
+                # (actionable ∪ context). Any explicit filter shrinks that.
+                if allowed_roles is None:
+                    is_admitted = role in _ACTIONABLE_ROLES or role in _CONTEXT_ROLES
+                else:
+                    is_admitted = role in allowed_roles
+                if is_admitted:
                     if ref_counter[0] < _MAX_SNAPSHOT_ELEMENTS:
                         ref_id = f"e{ref_counter[0]}"
                         ref_counter[0] += 1
@@ -1836,6 +1990,28 @@ class BrowserManager:
                         )
                 for child in node.get("children", []):
                     _walk(child, depth + 1)
+
+            # When ``from_ref`` is set the caller is asking for a deep
+            # scope into a specific element; modal-detection would
+            # second-guess that intent, so skip straight to a single
+            # ``_walk`` of the scoped tree.
+            if scoped_root_handle is not None:
+                inst.dialog_active = False
+                inst.dialog_detected = False
+                _walk(tree)
+                inst.refs = refs
+                snapshot_text = (
+                    "\n".join(lines) if lines else "(no interactive elements)"
+                )
+                snapshot_text = self.redactor.redact(agent_id, snapshot_text)
+                inst.m_snapshot_bytes.append(len(snapshot_text))
+                response_refs = {
+                    rid: h.to_agent_dict() for rid, h in refs.items()
+                }
+                return {
+                    "success": True,
+                    "data": {"snapshot": snapshot_text, "refs": response_refs},
+                }
 
             # When a modal dialog is open, scope to only dialog elements
             # so agents don't see/click elements behind the overlay

--- a/src/browser/service.py
+++ b/src/browser/service.py
@@ -2045,9 +2045,26 @@ class BrowserManager:
                                 element_key=handle.element_key,
                             )
                 inst.refs = refs
-                snapshot_text = (
-                    "\n".join(lines) if lines else "(no interactive elements)"
+                # Cross-PR fix (#749 ↔ #750): the from_ref early-return
+                # must honor the same v2 dispatch as the main return
+                # path. Without this, scoped snapshots stay v1 even
+                # when ``BROWSER_SNAPSHOT_FORMAT=v2`` is set — agents
+                # parsing on the ``# snapshot-v2`` first-line marker
+                # would silently see mixed formats.
+                from src.browser.flags import get_str as _flag_get_str
+                _scoped_fmt = (
+                    _flag_get_str(
+                        "BROWSER_SNAPSHOT_FORMAT", "v1", agent_id=agent_id,
+                    )
+                    .strip()
+                    .lower()
                 )
+                if _scoped_fmt == "v2":
+                    snapshot_text = _format_snapshot_v2(lines, entries)
+                else:
+                    snapshot_text = (
+                        "\n".join(lines) if lines else "(no interactive elements)"
+                    )
                 snapshot_text = self.redactor.redact(agent_id, snapshot_text)
                 inst.m_snapshot_bytes.append(len(snapshot_text))
                 response_refs = {

--- a/src/browser/service.py
+++ b/src/browser/service.py
@@ -2167,7 +2167,20 @@ class BrowserManager:
             response_refs = {rid: h.to_agent_dict() for rid, h in refs.items()}
             return {"success": True, "data": {"snapshot": snapshot_text, "refs": response_refs}}
         except Exception as e:
-            return {"success": False, "error": str(e)}
+            # Match the §2.3 error envelope used by the new from_ref /
+            # filter paths above so agents see a uniform shape regardless
+            # of which branch raised. Preserves the message under
+            # ``error.message`` so existing log scrapers still see the
+            # underlying string.
+            logger.exception("Snapshot failed for %s", agent_id)
+            return {
+                "success": False,
+                "error": {
+                    "code": "service_unavailable",
+                    "message": str(e),
+                    "retry_after_ms": None,
+                },
+            }
 
     @staticmethod
     async def _is_visible_modal(el, vp_size: dict | None) -> bool:

--- a/tests/test_browser_service.py
+++ b/tests/test_browser_service.py
@@ -1726,6 +1726,28 @@ class TestSnapshotFilter:
         # Same set as the default-None case.
         assert "heading" in roles and "img" in roles
 
+    @pytest.mark.asyncio
+    async def test_filter_case_insensitive(self):
+        """LLMs frequently capitalize argument values. ``Actionable``,
+        ``INPUTS`` etc. must work like their lowercase counterparts."""
+        result = await self._snap_with_filter("Actionable")
+        assert result["success"] is True
+        roles = {r["role"] for r in result["data"]["refs"].values()}
+        assert roles == {"button", "textbox", "checkbox", "link"}
+
+        result = await self._snap_with_filter("INPUTS")
+        assert result["success"] is True
+        roles = {r["role"] for r in result["data"]["refs"].values()}
+        assert roles == {"textbox", "checkbox"}
+
+    @pytest.mark.asyncio
+    async def test_filter_whitespace_tolerated(self):
+        """Stray whitespace shouldn't trip the filter — strip+lower."""
+        result = await self._snap_with_filter("  inputs  ")
+        assert result["success"] is True
+        roles = {r["role"] for r in result["data"]["refs"].values()}
+        assert roles == {"textbox", "checkbox"}
+
 
 class TestSnapshotFromRef:
     """§7.4 — scoped snapshot rooted at a previously-seen element."""
@@ -1852,6 +1874,91 @@ class TestSnapshotFromRef:
         assert result["success"] is True
         roles = {r["role"] for r in result["data"]["refs"].values()}
         assert roles == {"textbox"}
+
+    @pytest.mark.asyncio
+    async def test_from_ref_inside_modal_preserves_scope_root(self):
+        """Regression for the silent-misclick bug: when ``from_ref`` is
+        used while a modal is open, the scoped refs MUST carry
+        ``scope_root=_MODAL_SELECTOR`` so subsequent ``_locator_from_ref``
+        calls stay bounded to the dialog. Pre-fix, scoped refs had
+        ``scope_root=None`` and ``inst.dialog_active`` was cleared,
+        letting clicks resolve to identical-named elements behind the
+        overlay."""
+        from src.browser.ref_handle import RefHandle
+        from src.browser.service import _MODAL_SELECTOR, BrowserManager, CamoufoxInstance
+        mgr = BrowserManager(profiles_dir="/tmp/test_profiles")
+
+        mock_page = AsyncMock()
+        mock_page.accessibility = MagicMock()
+        mock_page.accessibility.snapshot = AsyncMock(return_value={
+            "role": "form", "name": "Compose",
+            "children": [
+                {"role": "button", "name": "Post"},
+                {"role": "button", "name": "Cancel"},
+            ],
+        })
+        inst = CamoufoxInstance("a1", MagicMock(), MagicMock(), mock_page)
+        # Simulate live modal state at the time the agent calls snapshot.
+        inst.dialog_active = True
+        inst.dialog_detected = True
+        page_id = inst._page_id_for(inst.page)
+        inst.refs["e0"] = RefHandle.light_dom(
+            page_id=page_id, scope_root=_MODAL_SELECTOR,
+            role="form", name="Compose", occurrence=0, disabled=False,
+        )
+        mgr._instances["a1"] = inst
+
+        fake_locator = AsyncMock()
+        fake_locator.element_handle = AsyncMock(return_value=MagicMock())
+        with patch.object(
+            BrowserManager, "_locator_from_ref", return_value=fake_locator,
+        ):
+            result = await mgr.snapshot("a1", from_ref="e0")
+
+        assert result["success"] is True
+        # Every emitted ref should carry the modal scope_root so the
+        # next click stays bounded to the dialog subtree.
+        for handle in inst.refs.values():
+            assert handle.scope_root == _MODAL_SELECTOR, (
+                f"Ref {handle.role!r} {handle.name!r} leaked outside "
+                f"the modal scope: scope_root={handle.scope_root!r}"
+            )
+
+    @pytest.mark.asyncio
+    async def test_from_ref_outside_modal_no_scope_root(self):
+        """Inverse of the modal-preservation test: when no modal is
+        active during a from_ref snapshot, refs should NOT acquire a
+        modal scope_root (stays None)."""
+        from src.browser.ref_handle import RefHandle
+        from src.browser.service import BrowserManager, CamoufoxInstance
+        mgr = BrowserManager(profiles_dir="/tmp/test_profiles")
+
+        mock_page = AsyncMock()
+        mock_page.accessibility = MagicMock()
+        mock_page.accessibility.snapshot = AsyncMock(return_value={
+            "role": "form", "name": "Login",
+            "children": [{"role": "button", "name": "Submit"}],
+        })
+        inst = CamoufoxInstance("a1", MagicMock(), MagicMock(), mock_page)
+        # No modal active.
+        inst.dialog_active = False
+        page_id = inst._page_id_for(inst.page)
+        inst.refs["e0"] = RefHandle.light_dom(
+            page_id=page_id, scope_root=None,
+            role="form", name="Login", occurrence=0, disabled=False,
+        )
+        mgr._instances["a1"] = inst
+
+        fake_locator = AsyncMock()
+        fake_locator.element_handle = AsyncMock(return_value=MagicMock())
+        with patch.object(
+            BrowserManager, "_locator_from_ref", return_value=fake_locator,
+        ):
+            result = await mgr.snapshot("a1", from_ref="e0")
+
+        assert result["success"] is True
+        for handle in inst.refs.values():
+            assert handle.scope_root is None
 
 
 class TestTypeTextWithRef:

--- a/tests/test_browser_service.py
+++ b/tests/test_browser_service.py
@@ -1642,6 +1642,217 @@ class TestSnapshotFormatV2:
             f"phantom refs in v2 output: {rendered_refs - actual_refs}"
         )
 
+class TestSnapshotFilter:
+    """§7.7 — semantic filter narrows the snapshot to one role family."""
+
+    def _mixed_tree(self) -> dict:
+        return {
+            "role": "WebArea",
+            "name": "Mixed",
+            "children": [
+                {"role": "navigation", "name": "Top"},
+                {"role": "main", "name": "Main"},
+                {"role": "heading", "name": "Section A"},
+                {"role": "button", "name": "Click"},
+                {"role": "textbox", "name": "Email"},
+                {"role": "checkbox", "name": "Subscribe"},
+                {"role": "img", "name": "Logo"},
+                {"role": "link", "name": "Help"},
+            ],
+        }
+
+    async def _snap_with_filter(self, filter_value):
+        from src.browser.service import BrowserManager, CamoufoxInstance
+        mgr = BrowserManager(profiles_dir="/tmp/test_profiles")
+        mock_page = AsyncMock()
+        mock_page.accessibility = MagicMock()
+        mock_page.accessibility.snapshot = AsyncMock(
+            return_value=self._mixed_tree(),
+        )
+        inst = CamoufoxInstance("a1", MagicMock(), MagicMock(), mock_page)
+        mgr._instances["a1"] = inst
+        return await mgr.snapshot("a1", filter=filter_value)
+
+    @pytest.mark.asyncio
+    async def test_default_filter_includes_actionable_and_context(self):
+        result = await self._snap_with_filter(None)
+        assert result["success"] is True
+        roles = {r["role"] for r in result["data"]["refs"].values()}
+        # Actionable + context: button, textbox, checkbox, link, heading, img.
+        # Landmarks (navigation/main) are NOT in the default mix.
+        assert "button" in roles
+        assert "heading" in roles
+        assert "img" in roles
+        assert "navigation" not in roles
+        assert "main" not in roles
+
+    @pytest.mark.asyncio
+    async def test_actionable_filter_excludes_context(self):
+        result = await self._snap_with_filter("actionable")
+        roles = {r["role"] for r in result["data"]["refs"].values()}
+        assert roles == {"button", "textbox", "checkbox", "link"}
+
+    @pytest.mark.asyncio
+    async def test_inputs_filter_includes_inputs_only(self):
+        result = await self._snap_with_filter("inputs")
+        roles = {r["role"] for r in result["data"]["refs"].values()}
+        assert roles == {"textbox", "checkbox"}
+
+    @pytest.mark.asyncio
+    async def test_headings_filter(self):
+        result = await self._snap_with_filter("headings")
+        roles = {r["role"] for r in result["data"]["refs"].values()}
+        assert roles == {"heading"}
+
+    @pytest.mark.asyncio
+    async def test_landmarks_filter(self):
+        result = await self._snap_with_filter("landmarks")
+        roles = {r["role"] for r in result["data"]["refs"].values()}
+        assert roles == {"navigation", "main"}
+
+    @pytest.mark.asyncio
+    async def test_invalid_filter_returns_invalid_input(self):
+        result = await self._snap_with_filter("nope")
+        assert result["success"] is False
+        assert result["error"]["code"] == "invalid_input"
+        assert "nope" in result["error"]["message"]
+
+    @pytest.mark.asyncio
+    async def test_empty_string_treated_as_default(self):
+        """JSON UI defaults often pass ``""`` — must not narrow the result."""
+        result = await self._snap_with_filter("")
+        assert result["success"] is True
+        roles = {r["role"] for r in result["data"]["refs"].values()}
+        # Same set as the default-None case.
+        assert "heading" in roles and "img" in roles
+
+
+class TestSnapshotFromRef:
+    """§7.4 — scoped snapshot rooted at a previously-seen element."""
+
+    @pytest.mark.asyncio
+    async def test_from_ref_unknown_returns_not_found(self):
+        from src.browser.service import BrowserManager, CamoufoxInstance
+        mgr = BrowserManager(profiles_dir="/tmp/test_profiles")
+        mock_page = AsyncMock()
+        mock_page.accessibility = MagicMock()
+        mock_page.accessibility.snapshot = AsyncMock(return_value={
+            "role": "WebArea", "name": "", "children": [],
+        })
+        inst = CamoufoxInstance("a1", MagicMock(), MagicMock(), mock_page)
+        mgr._instances["a1"] = inst
+        result = await mgr.snapshot("a1", from_ref="e99")
+        assert result["success"] is False
+        assert result["error"]["code"] == "not_found"
+
+    @pytest.mark.asyncio
+    async def test_from_ref_empty_returns_invalid_input(self):
+        from src.browser.service import BrowserManager, CamoufoxInstance
+        mgr = BrowserManager(profiles_dir="/tmp/test_profiles")
+        inst = CamoufoxInstance("a1", MagicMock(), MagicMock(), AsyncMock())
+        mgr._instances["a1"] = inst
+        result = await mgr.snapshot("a1", from_ref="")
+        assert result["success"] is False
+        assert result["error"]["code"] == "invalid_input"
+
+    @pytest.mark.asyncio
+    async def test_from_ref_scopes_tree_to_subtree(self):
+        """When ``from_ref`` is set, ``_build_a11y_tree`` is called with the
+        resolved element handle as ``root``; the result is just that subtree."""
+        from src.browser.ref_handle import RefHandle
+        from src.browser.service import BrowserManager, CamoufoxInstance
+        mgr = BrowserManager(profiles_dir="/tmp/test_profiles")
+
+        # 1. Set up the inst and seed it with a single ref that
+        # ``_locator_from_ref`` can resolve. Using light_dom because shadow/
+        # frame fields aren't relevant to this test.
+        mock_page = AsyncMock()
+        mock_page.url = "https://example.com"
+        mock_page.accessibility = MagicMock()
+        # Default page-level a11y returns a small tree with a "form" role.
+        mock_page.accessibility.snapshot = AsyncMock(return_value={
+            "role": "form", "name": "Login",
+            "children": [
+                {"role": "textbox", "name": "Email"},
+                {"role": "textbox", "name": "Password"},
+            ],
+        })
+        inst = CamoufoxInstance("a1", MagicMock(), MagicMock(), mock_page)
+
+        page_id = inst._page_id_for(inst.page)
+        inst.refs["e0"] = RefHandle.light_dom(
+            page_id=page_id, scope_root=None,
+            role="form", name="Login", occurrence=0, disabled=False,
+        )
+
+        # 2. Stub ``_locator_from_ref`` so it returns a Locator-like object
+        # whose ``element_handle`` returns a stub ElementHandle. The
+        # ``_build_a11y_tree`` with ``root=<handle>`` path will be exercised.
+        scoped_handle = MagicMock()  # ElementHandle stand-in
+        # In this branch the page-level fallback uses ``root.evaluate``
+        # rather than ``page.accessibility.snapshot``. Stub that path.
+        scoped_tree = {
+            "role": "form", "name": "Login",
+            "children": [
+                {"role": "textbox", "name": "Email"},
+                {"role": "textbox", "name": "Password"},
+            ],
+        }
+        # Make Camoufox's accessibility.snapshot(root=...) succeed too —
+        # _build_a11y_tree tries the native API first.
+        mock_page.accessibility.snapshot = AsyncMock(return_value=scoped_tree)
+
+        fake_locator = AsyncMock()
+        fake_locator.element_handle = AsyncMock(return_value=scoped_handle)
+        mgr._instances["a1"] = inst
+
+        with patch.object(
+            BrowserManager, "_locator_from_ref", return_value=fake_locator,
+        ):
+            result = await mgr.snapshot("a1", from_ref="e0")
+
+        assert result["success"] is True
+        roles = {r["role"] for r in result["data"]["refs"].values()}
+        # The scoped subtree only contains the two textboxes.
+        assert roles == {"textbox"}
+
+    @pytest.mark.asyncio
+    async def test_from_ref_with_filter_combines(self):
+        """``from_ref`` + ``filter`` should narrow the scoped subtree
+        further."""
+        from src.browser.ref_handle import RefHandle
+        from src.browser.service import BrowserManager, CamoufoxInstance
+        mgr = BrowserManager(profiles_dir="/tmp/test_profiles")
+
+        mock_page = AsyncMock()
+        mock_page.accessibility = MagicMock()
+        # Scoped tree contains a heading + a button + a textbox.
+        mock_page.accessibility.snapshot = AsyncMock(return_value={
+            "role": "form", "name": "Login",
+            "children": [
+                {"role": "heading", "name": "Sign in"},
+                {"role": "button", "name": "Submit"},
+                {"role": "textbox", "name": "Email"},
+            ],
+        })
+        inst = CamoufoxInstance("a1", MagicMock(), MagicMock(), mock_page)
+        page_id = inst._page_id_for(inst.page)
+        inst.refs["e0"] = RefHandle.light_dom(
+            page_id=page_id, scope_root=None,
+            role="form", name="Login", occurrence=0, disabled=False,
+        )
+        mgr._instances["a1"] = inst
+
+        fake_locator = AsyncMock()
+        fake_locator.element_handle = AsyncMock(return_value=MagicMock())
+        with patch.object(
+            BrowserManager, "_locator_from_ref", return_value=fake_locator,
+        ):
+            result = await mgr.snapshot("a1", from_ref="e0", filter="inputs")
+        assert result["success"] is True
+        roles = {r["role"] for r in result["data"]["refs"].values()}
+        assert roles == {"textbox"}
+
 
 class TestTypeTextWithRef:
     """Tests for type_text using ref-based element resolution."""

--- a/tests/test_browser_service.py
+++ b/tests/test_browser_service.py
@@ -1960,6 +1960,43 @@ class TestSnapshotFromRef:
         for handle in inst.refs.values():
             assert handle.scope_root is None
 
+    @pytest.mark.asyncio
+    async def test_from_ref_dispatches_through_v2_when_flag_set(
+        self, monkeypatch,
+    ):
+        """Cross-PR (§7.4 ↔ §7.2): when BROWSER_SNAPSHOT_FORMAT=v2,
+        the from_ref early-return must use the v2 formatter so scoped
+        snapshots emit the ``# snapshot-v2`` marker just like the
+        main return path. Without this, agents parsing on the
+        first-line marker would see mixed formats."""
+        from src.browser.ref_handle import RefHandle
+        from src.browser.service import BrowserManager, CamoufoxInstance
+        monkeypatch.setenv("BROWSER_SNAPSHOT_FORMAT", "v2")
+        mgr = BrowserManager(profiles_dir="/tmp/test_profiles")
+        mock_page = AsyncMock()
+        mock_page.accessibility = MagicMock()
+        mock_page.accessibility.snapshot = AsyncMock(return_value={
+            "role": "form", "name": "Login",
+            "children": [{"role": "button", "name": "Submit"}],
+        })
+        inst = CamoufoxInstance("a1", MagicMock(), MagicMock(), mock_page)
+        page_id = inst._page_id_for(inst.page)
+        inst.refs["e0"] = RefHandle.light_dom(
+            page_id=page_id, scope_root=None,
+            role="form", name="Login", occurrence=0, disabled=False,
+        )
+        mgr._instances["a1"] = inst
+
+        fake_locator = AsyncMock()
+        fake_locator.element_handle = AsyncMock(return_value=MagicMock())
+        with patch.object(
+            BrowserManager, "_locator_from_ref", return_value=fake_locator,
+        ):
+            result = await mgr.snapshot("a1", from_ref="e0")
+        assert result["success"] is True
+        # v2 marker on first line — the scoped path now honors the flag.
+        assert result["data"]["snapshot"].startswith("# snapshot-v2\n")
+
 
 class TestTypeTextWithRef:
     """Tests for type_text using ref-based element resolution."""

--- a/tests/test_builtins.py
+++ b/tests/test_builtins.py
@@ -1113,8 +1113,47 @@ class TestBrowserSnapshotHttpClient:
 
         result = await browser_get_elements(mesh_client=mc)
 
+        # Default call sends an empty payload — service applies its
+        # historical default behavior.
         mc.browser_command.assert_awaited_once_with("snapshot", {})
         assert result["element_count"] == 3
+
+    @pytest.mark.asyncio
+    async def test_snapshot_filter_forwarded(self):
+        """``filter`` param is forwarded to the browser service."""
+        from src.agent.builtins.browser_tool import browser_get_elements
+
+        mc = AsyncMock()
+        mc.browser_command = AsyncMock(return_value={"data": {}})
+        await browser_get_elements(filter="actionable", mesh_client=mc)
+        mc.browser_command.assert_awaited_once_with(
+            "snapshot", {"filter": "actionable"},
+        )
+
+    @pytest.mark.asyncio
+    async def test_snapshot_from_ref_forwarded(self):
+        """``from_ref`` param scopes the snapshot to a subtree."""
+        from src.agent.builtins.browser_tool import browser_get_elements
+
+        mc = AsyncMock()
+        mc.browser_command = AsyncMock(return_value={"data": {}})
+        await browser_get_elements(from_ref="e3", mesh_client=mc)
+        mc.browser_command.assert_awaited_once_with(
+            "snapshot", {"from_ref": "e3"},
+        )
+
+    @pytest.mark.asyncio
+    async def test_snapshot_filter_and_from_ref_combine(self):
+        from src.agent.builtins.browser_tool import browser_get_elements
+
+        mc = AsyncMock()
+        mc.browser_command = AsyncMock(return_value={"data": {}})
+        await browser_get_elements(
+            filter="inputs", from_ref="e7", mesh_client=mc,
+        )
+        mc.browser_command.assert_awaited_once_with(
+            "snapshot", {"filter": "inputs", "from_ref": "e7"},
+        )
 
 
 class TestBrowserClickHttpClient:


### PR DESCRIPTION
## Summary

Two small token-saving knobs on ``browser_get_elements``:

- **§7.7 Semantic filter.** ``filter='actionable'|'inputs'|'headings'|'landmarks'`` constrains which roles appear. ``None`` or omitted preserves the historical actionable+context mix.
- **§7.4 Scoped snapshot.** ``from_ref='e7'`` roots the tree at an element captured in a previous snapshot, returning just that subtree. Skips modal-detection logic since the agent has explicitly chosen its scope.

Both can combine: ``from_ref='e3', filter='inputs'`` returns only the inputs inside the form at ref e3.

## Risk and rollout

- Both params are optional. Default behavior is byte-for-byte identical to the historical snapshot (verified by ``test_default_filter_includes_actionable_and_context`` and full 494-test browser_service+builtins suite).
- Errors follow the §2.3 envelope (``invalid_input``, ``not_found``, ``ref_stale``) so agent-side error handling matches the rest of the browser tool surface.
- ``from_ref`` resolves through the existing ``_locator_from_ref`` path — same modal/frame/shadow/page-id lookup as click/type, so identity guarantees carry over.

## Test plan

- [x] Default snapshot includes actionable + context (button, heading, img) but not landmarks.
- [x] ``filter='actionable'`` excludes context (no heading/img).
- [x] ``filter='inputs'`` returns only form-input roles.
- [x] ``filter='headings'`` returns only heading nodes.
- [x] ``filter='landmarks'`` returns only landmark regions (navigation, main, …).
- [x] Empty-string filter is treated as default (so JSON UI defaults don't accidentally narrow).
- [x] Unknown filter → ``error.code == 'invalid_input'`` with helpful message.
- [x] ``from_ref`` unknown → ``not_found``.
- [x] ``from_ref`` empty string → ``invalid_input``.
- [x] ``from_ref`` valid scopes the tree to a subtree.
- [x] ``from_ref`` + ``filter`` combine.
- [x] Agent skill forwards the params correctly to ``browser_command``.
- [x] 494/494 tests pass in test_browser_service + test_builtins (no regressions).