### PR TITLE
Phase 4 §7.2: snapshot format v2 (landmarks as section headers)

### DIFF
--- a/src/browser/service.py
+++ b/src/browser/service.py
@@ -119,13 +119,38 @@ def _format_snapshot_v2(
         if landmark_key == _V2_NO_LANDMARK_KEY:
             out.append("# (no landmark)")
         else:
-            out.append(f"# {landmark_key}")
+            # Sanitize newlines in landmark keys: a malicious DOM
+            # node with ``aria-label="x\n# fake-section: pwn"`` would
+            # otherwise inject a phantom section header into the
+            # parsed output (operator scripts reading the v2 format
+            # split on '#' prefixes). Replace with single spaces so
+            # the structural marker stays one-line.
+            out.append(f"# {_v2_strip_newlines(landmark_key)}")
         for ref_id, role, name, attr_str, depth in group_entries:
             indent_depth = min(depth, _V2_MAX_INDENT_DEPTH)
             indent = "  " * indent_depth
-            out.append(f"{indent}- [{ref_id}] {role} \"{name}\"{attr_str}")
+            # Same sanitization on per-element name + attr_str so an
+            # accessible-name with embedded ``\n# fake`` can't escape
+            # to a fake section header.
+            safe_name = _v2_strip_newlines(name)
+            safe_attr = _v2_strip_newlines(attr_str)
+            out.append(f"{indent}- [{ref_id}] {role} \"{safe_name}\"{safe_attr}")
 
     return "\n".join(out)
+
+
+def _v2_strip_newlines(s: str) -> str:
+    """Collapse ``\\n``/``\\r`` to single spaces.
+
+    v2 promotes ``# ``-prefixed lines to structural meaning. A DOM
+    node with newlines in its accessible name or landmark would
+    otherwise inject phantom section headers into the parsed
+    snapshot. Cheap belt-and-braces over the JS-walker side which
+    only ``.trim()``s whitespace endpoints.
+    """
+    if not s:
+        return s
+    return s.replace("\r\n", " ").replace("\n", " ").replace("\r", " ")
 
 # Block schemes that could expose local files or browser internals.
 # about: covers about:logins (saved passwords), about:config, etc.

--- a/src/browser/service.py
+++ b/src/browser/service.py
@@ -58,6 +58,75 @@ _CONTEXT_ROLES = frozenset({
 
 _MAX_SNAPSHOT_ELEMENTS = 200
 
+
+# §7.2 v2 format — depth indent is capped so a 50-deep DOM doesn't
+# explode into 100-character indents. Anything past this depth shares
+# the cap-line indent (still distinguishable as "deep" but not bytewise
+# punishing).
+_V2_MAX_INDENT_DEPTH = 4
+_V2_NO_LANDMARK_KEY = ""
+
+
+def _format_snapshot_v2(
+    lines: list[str],
+    entries: list[tuple[str, str, str, str, str, int]],
+) -> str:
+    """Render the snapshot in §7.2 ``v2`` format.
+
+    Group entries by landmark and emit each group under a section
+    header (``# nav: Top``) instead of suffixing every element with
+    ``(navigation: Top)``. Indent depth is capped at
+    :data:`_V2_MAX_INDENT_DEPTH`.
+
+    Modal-mode preamble lines (those starting with ``**`` in the v1
+    output) are passed through verbatim ahead of the section blocks
+    so the agent still sees the modal context.
+
+    Args:
+        lines: the v1 line list — only used for ``**`` preamble lines.
+        entries: per-element tuples
+            ``(ref_id, role, name, attr_str, landmark, depth)``.
+
+    Returns the rendered string. Always begins with the
+    ``# snapshot-v2`` version marker so parsers can detect the format
+    without out-of-band signaling.
+    """
+    if not entries:
+        # Empty result. Still emit the marker so a parser using the
+        # first line for routing decisions doesn't trip. Also pass
+        # through any modal-banner preamble that v1 produced.
+        preamble = [ln for ln in lines if ln.startswith("**")]
+        if preamble:
+            return "# snapshot-v2\n" + "\n".join(preamble)
+        return "# snapshot-v2\n(no interactive elements)"
+
+    # Modal-banner preamble (lines starting ``**``) precedes the
+    # element output. Keeps the modal-scoped warning visible.
+    preamble = [ln for ln in lines if ln.startswith("**")]
+
+    # Preserve insertion order — the dict-by-design key order matches
+    # the order entries were emitted, which is doc order.
+    groups: dict[str, list[tuple[str, str, str, str, int]]] = {}
+    for ref_id, role, name, attr_str, landmark, depth in entries:
+        key = landmark or _V2_NO_LANDMARK_KEY
+        groups.setdefault(key, []).append(
+            (ref_id, role, name, attr_str, depth),
+        )
+
+    out: list[str] = ["# snapshot-v2"]
+    out.extend(preamble)
+    for landmark_key, group_entries in groups.items():
+        if landmark_key == _V2_NO_LANDMARK_KEY:
+            out.append("# (no landmark)")
+        else:
+            out.append(f"# {landmark_key}")
+        for ref_id, role, name, attr_str, depth in group_entries:
+            indent_depth = min(depth, _V2_MAX_INDENT_DEPTH)
+            indent = "  " * indent_depth
+            out.append(f"{indent}- [{ref_id}] {role} \"{name}\"{attr_str}")
+
+    return "\n".join(out)
+
 # Block schemes that could expose local files or browser internals.
 # about: covers about:logins (saved passwords), about:config, etc.
 # moz-extension: / chrome-extension: cover installed extensions.
@@ -1684,6 +1753,13 @@ class BrowserManager:
 
             _MAX_WALK_DEPTH = 50
 
+            # Collect entries for §7.2 v2 rendering AND build v1 lines in
+            # parallel. The entry list is a structured intermediate so we
+            # can pivot between formats post-walk without a second tree
+            # traversal. Each entry: (ref_id, role, name, attr_str,
+            # landmark, depth).
+            entries: list[tuple[str, str, str, str, str, int]] = []
+
             def _walk(node, depth=0):
                 if depth > _MAX_WALK_DEPTH:
                     return
@@ -1718,6 +1794,9 @@ class BrowserManager:
 
                         line = f"{'  ' * depth}- [{ref_id}] {role} \"{name}\"{attr_str}{ctx_str}"
                         lines.append(line)
+                        entries.append(
+                            (ref_id, role, name, attr_str, landmark, depth),
+                        )
                         # scope_root is finalized after the modal-scoping
                         # branch below. For now record the unscoped handle;
                         # we overwrite scope_root once we know the final
@@ -1852,7 +1931,21 @@ class BrowserManager:
                         )
 
             inst.refs = refs
-            snapshot_text = "\n".join(lines) if lines else "(no interactive elements)"
+            # §7.2 — choose between v1 (per-element landmark suffix) and
+            # v2 (landmark headers + capped indent). Flag default is v1
+            # for the canary period, flips to v2 once parse rate ≥99%.
+            from src.browser.flags import get_str
+            fmt = (
+                get_str("BROWSER_SNAPSHOT_FORMAT", "v1", agent_id=agent_id)
+                .strip()
+                .lower()
+            )
+            if fmt == "v2":
+                snapshot_text = _format_snapshot_v2(lines, entries)
+            else:
+                snapshot_text = (
+                    "\n".join(lines) if lines else "(no interactive elements)"
+                )
             snapshot_text = self.redactor.redact(agent_id, snapshot_text)
             # Record snapshot byte size for §4.6 metrics. Collected per call;
             # drained as p50/p95 on the next minute tick.

--- a/src/browser/service.py
+++ b/src/browser/service.py
@@ -1865,6 +1865,13 @@ class BrowserManager:
                     await asyncio.sleep(wait)
                     refs.clear()
                     lines.clear()
+                    # §7.2: ``entries`` is the parallel structure v2 renders
+                    # from. Forgetting to reset it here would leak entries
+                    # from the discarded scoping pass into the v2 output —
+                    # invisible in v1 (which renders ``lines`` only) but
+                    # produces phantom refs that don't match ``inst.refs``
+                    # under v2.
+                    entries.clear()
                     ref_counter[0] = 0
                     occurrence_counts.clear()
                     lines.append("** Modal dialog is open — only dialog elements are shown **")
@@ -1899,6 +1906,10 @@ class BrowserManager:
                     # scoped click that can't find the element will timeout
                     # rather than hit the wrong target.
                     lines.clear()
+                    # Same reset rationale as the retry branch above —
+                    # discard fallback's ``entries`` so v2 rendering
+                    # only sees the post-fallback _walk(tree) output.
+                    entries.clear()
                     lines.append(
                         "** A modal dialog is open but its elements could "
                         "not be isolated — elements with a (dialog: ...) "

--- a/tests/test_browser_service.py
+++ b/tests/test_browser_service.py
@@ -1534,6 +1534,51 @@ class TestSnapshotFormatV2:
         out = _format_snapshot_v2([], entries)
         assert '- [e0] checkbox "Subscribe" [checked=True]' in out
 
+    def test_v2_strips_newlines_from_landmark_and_name(self):
+        """An adversarial DOM with embedded newlines in the accessible
+        name (or landmark) must not inject a phantom section header.
+
+        Pre-fix, a button with ``aria-label="x\\n# fake-section: pwn"``
+        would land in v2 output as a literal newline followed by
+        ``# fake-section: pwn``, which a parser would interpret as a
+        new section. The fix collapses CR/LF to spaces before emit."""
+        from src.browser.service import _format_snapshot_v2
+        entries = [
+            (
+                "e0", "button",
+                "Real\n# fake-section: pwn",
+                " [disabled]",
+                "main: Body\n# evil",
+                1,
+            ),
+        ]
+        out = _format_snapshot_v2([], entries)
+        # No newline appears between ``Real`` and ``# fake``; landmark
+        # key is sanitized similarly.
+        assert "\n# fake-section: pwn" not in out
+        assert "\n# evil" not in out
+        # The actual emitted lines have a single section header and a
+        # single element line.
+        section_lines = [ln for ln in out.splitlines() if ln.startswith("# ")]
+        # First section line is the version marker; second is the
+        # sanitized landmark.
+        assert section_lines[0] == "# snapshot-v2"
+        assert section_lines[1] == "# main: Body # evil"
+
+    def test_v2_empty_with_preamble_only(self):
+        """Modal-scoping retry can produce zero entries but a non-empty
+        preamble (the ``** Modal dialog ... **`` banner). v2 must
+        emit the marker + the preamble cleanly."""
+        from src.browser.service import _format_snapshot_v2
+        out = _format_snapshot_v2(
+            ["** Modal dialog is open — only dialog elements are shown **"],
+            [],
+        )
+        assert out == (
+            "# snapshot-v2\n"
+            "** Modal dialog is open — only dialog elements are shown **"
+        )
+
     @pytest.mark.asyncio
     async def test_v2_modal_retry_does_not_leak_phantom_refs(self, v2_flag):
         """Regression: when modal scoping fails on first try, the discarded

--- a/tests/test_browser_service.py
+++ b/tests/test_browser_service.py
@@ -1393,6 +1393,148 @@ class TestSnapshot:
         assert len(result["data"]["refs"]) == _MAX_SNAPSHOT_ELEMENTS
 
 
+class TestSnapshotFormatV2:
+    """§7.2 — landmark section headers + capped indent."""
+
+    @pytest.fixture
+    def v2_flag(self, monkeypatch):
+        """Force BROWSER_SNAPSHOT_FORMAT=v2 for the duration of one test."""
+        monkeypatch.setenv("BROWSER_SNAPSHOT_FORMAT", "v2")
+
+    @pytest.mark.asyncio
+    async def test_v1_default_unchanged(self):
+        """Without the flag the snapshot is the historical v1 format —
+        no version marker, no section headers."""
+        from src.browser.service import BrowserManager, CamoufoxInstance
+        mgr = BrowserManager(profiles_dir="/tmp/test_profiles")
+        mock_page = AsyncMock()
+        mock_page.accessibility = MagicMock()
+        mock_page.accessibility.snapshot = AsyncMock(return_value={
+            "role": "WebArea", "name": "",
+            "children": [
+                {"role": "button", "name": "Submit",
+                 "landmark": "navigation: Top"},
+            ],
+        })
+        inst = CamoufoxInstance("a1", MagicMock(), MagicMock(), mock_page)
+        mgr._instances["a1"] = inst
+
+        result = await mgr.snapshot("a1")
+        snap = result["data"]["snapshot"]
+        assert "snapshot-v2" not in snap
+        assert "(navigation: Top)" in snap  # v1 suffix
+
+    @pytest.mark.asyncio
+    async def test_v2_emits_version_marker(self, v2_flag):
+        from src.browser.service import BrowserManager, CamoufoxInstance
+        mgr = BrowserManager(profiles_dir="/tmp/test_profiles")
+        mock_page = AsyncMock()
+        mock_page.accessibility = MagicMock()
+        mock_page.accessibility.snapshot = AsyncMock(return_value={
+            "role": "WebArea", "name": "",
+            "children": [{"role": "button", "name": "Click"}],
+        })
+        inst = CamoufoxInstance("a1", MagicMock(), MagicMock(), mock_page)
+        mgr._instances["a1"] = inst
+
+        result = await mgr.snapshot("a1")
+        snap = result["data"]["snapshot"]
+        assert snap.startswith("# snapshot-v2\n")
+
+    @pytest.mark.asyncio
+    async def test_v2_groups_by_landmark(self, v2_flag):
+        from src.browser.service import BrowserManager, CamoufoxInstance
+        mgr = BrowserManager(profiles_dir="/tmp/test_profiles")
+        mock_page = AsyncMock()
+        mock_page.accessibility = MagicMock()
+        mock_page.accessibility.snapshot = AsyncMock(return_value={
+            "role": "WebArea", "name": "",
+            "children": [
+                {"role": "navigation", "name": "Top",
+                 "children": [
+                     {"role": "link", "name": "Home",
+                      "landmark": "navigation: Top"},
+                 ]},
+                {"role": "main", "name": "Article",
+                 "children": [
+                     {"role": "heading", "name": "Title",
+                      "landmark": "main: Article"},
+                     {"role": "button", "name": "Comment",
+                      "landmark": "main: Article"},
+                 ]},
+            ],
+        })
+        inst = CamoufoxInstance("a1", MagicMock(), MagicMock(), mock_page)
+        mgr._instances["a1"] = inst
+
+        result = await mgr.snapshot("a1")
+        snap = result["data"]["snapshot"]
+        assert "# navigation: Top" in snap
+        assert "# main: Article" in snap
+        assert "(navigation: Top)" not in snap
+        assert "(main: Article)" not in snap
+        assert '] link "Home"' in snap
+        assert '] heading "Title"' in snap
+        assert '] button "Comment"' in snap
+
+    @pytest.mark.asyncio
+    async def test_v2_unlandmarked_section_emitted(self, v2_flag):
+        from src.browser.service import BrowserManager, CamoufoxInstance
+        mgr = BrowserManager(profiles_dir="/tmp/test_profiles")
+        mock_page = AsyncMock()
+        mock_page.accessibility = MagicMock()
+        mock_page.accessibility.snapshot = AsyncMock(return_value={
+            "role": "WebArea", "name": "",
+            "children": [
+                {"role": "button", "name": "Loose"},
+            ],
+        })
+        inst = CamoufoxInstance("a1", MagicMock(), MagicMock(), mock_page)
+        mgr._instances["a1"] = inst
+
+        result = await mgr.snapshot("a1")
+        snap = result["data"]["snapshot"]
+        assert "# (no landmark)" in snap
+        assert '] button "Loose"' in snap
+
+    def test_v2_caps_indent_depth(self):
+        """Direct test of the formatter — depth>4 collapses to 4 levels."""
+        from src.browser.service import _format_snapshot_v2
+        entries = [
+            ("e0", "button", "Deep", "", "main: Body", 7),
+            ("e1", "link", "Shallow", "", "main: Body", 1),
+        ]
+        out = _format_snapshot_v2([], entries)
+        assert '\n        - [e0] button "Deep"' in out
+        assert '\n  - [e1] link "Shallow"' in out
+
+    def test_v2_passes_through_modal_banner(self):
+        """``**`` preamble lines (modal warning) ride along ahead of the
+        section blocks."""
+        from src.browser.service import _format_snapshot_v2
+        lines = [
+            "** Modal dialog is open — only dialog elements are shown **",
+            "  - [e0] button \"Close\" (dialog: Compose)",
+        ]
+        entries = [("e0", "button", "Close", "", "dialog: Compose", 0)]
+        out = _format_snapshot_v2(lines, entries)
+        assert out.startswith("# snapshot-v2\n** Modal dialog is open")
+        assert "# dialog: Compose" in out
+
+    def test_v2_empty_entries_returns_marker_only(self):
+        from src.browser.service import _format_snapshot_v2
+        out = _format_snapshot_v2([], [])
+        assert out == "# snapshot-v2\n(no interactive elements)"
+
+    def test_v2_attr_string_preserved(self):
+        from src.browser.service import _format_snapshot_v2
+        entries = [
+            ("e0", "checkbox", "Subscribe", " [checked=True]", "form: Signup", 2),
+        ]
+        out = _format_snapshot_v2([], entries)
+        assert '- [e0] checkbox "Subscribe" [checked=True]' in out
+
+
 class TestTypeTextWithRef:
     """Tests for type_text using ref-based element resolution."""
 

--- a/tests/test_browser_service.py
+++ b/tests/test_browser_service.py
@@ -1534,6 +1534,69 @@ class TestSnapshotFormatV2:
         out = _format_snapshot_v2([], entries)
         assert '- [e0] checkbox "Subscribe" [checked=True]' in out
 
+    @pytest.mark.asyncio
+    async def test_v2_modal_retry_does_not_leak_phantom_refs(self, v2_flag):
+        """Regression: when modal scoping fails on first try, the discarded
+        ``_walk`` pass must not bleed entries into v2 output. Pre-fix,
+        ``lines.clear()`` reset v1 output but ``entries`` was never reset,
+        producing duplicated refs in v2 that didn't match ``inst.refs``.
+        """
+        from src.browser.service import BrowserManager, CamoufoxInstance
+
+        mgr = BrowserManager(profiles_dir="/tmp/test_profiles")
+        # Modal is detected (visible) but scoping returns a tree with
+        # only context (heading) — no actionable refs — on first pass.
+        # Second pass after the retry yields an actionable button.
+        first_pass_tree = {
+            "role": "WebArea", "name": "",
+            "children": [{"role": "heading", "name": "Loading...",
+                          "landmark": "dialog: Compose"}],
+        }
+        second_pass_tree = {
+            "role": "WebArea", "name": "",
+            "children": [{"role": "button", "name": "Post",
+                          "landmark": "dialog: Compose"}],
+        }
+
+        # Modal selector returns a single visible modal.
+        modal_el = AsyncMock()
+        modal_el.is_visible = AsyncMock(return_value=True)
+        modal_el.bounding_box = AsyncMock(
+            return_value={"x": 0, "y": 0, "width": 200, "height": 200},
+        )
+        modal_el.evaluate = AsyncMock(return_value=False)
+        mock_page = AsyncMock()
+        mock_page.viewport_size = {"width": 1920, "height": 1080}
+        mock_page.query_selector_all = AsyncMock(return_value=[modal_el])
+        mock_page.accessibility = MagicMock()
+        # First call (page-level snapshot) → first_pass.
+        # Calls with root=modal_el → first_pass on first attempt,
+        # second_pass after retry.
+        accessibility_calls = [
+            first_pass_tree,   # initial page-level snapshot for whole-tree fallback
+            first_pass_tree,   # first scoped snapshot inside modal
+            second_pass_tree,  # post-retry scoped snapshot
+        ]
+        mock_page.accessibility.snapshot = AsyncMock(
+            side_effect=accessibility_calls + [second_pass_tree] * 5,
+        )
+        inst = CamoufoxInstance("a1", MagicMock(), MagicMock(), mock_page)
+        mgr._instances["a1"] = inst
+
+        with patch("src.browser.service.asyncio.sleep"):
+            result = await mgr.snapshot("a1")
+
+        snap = result["data"]["snapshot"]
+        # Every ref id appearing in the rendered v2 snapshot must also
+        # exist in inst.refs (the resolution table). The pre-fix bug
+        # produced refs that were rendered but not present in inst.refs.
+        import re
+        rendered_refs = set(re.findall(r"\[e\d+\]", snap))
+        actual_refs = {f"[{rid}]" for rid in inst.refs}
+        assert rendered_refs.issubset(actual_refs), (
+            f"phantom refs in v2 output: {rendered_refs - actual_refs}"
+        )
+
 
 class TestTypeTextWithRef:
     """Tests for type_text using ref-based element resolution."""


### PR DESCRIPTION
## Summary

§7.2 of the [browser-automation roadmap](docs/plans/2026-04-20-browser-automation.md). Introduces a v2 snapshot rendering that groups elements by landmark and emits one section header per landmark instead of suffixing every element with ``(navigation: Top)``-style annotations. Indent depth caps at 4 so deep DOMs don't blow up element lines.

Gated behind ``BROWSER_SNAPSHOT_FORMAT=v2`` per §2.1. **Default stays v1** for the 48-hour canary period; flip to v2 after canary parse rate ≥99%. v1 output is byte-identical to today's behavior (regression-tested via ``test_v1_default_unchanged``).

## Format example

**v1 (today):**
```
- [e0] link "Home" (navigation: Top)
- [e1] heading "Title" (main: Article)
- [e2] button "Comment" (main: Article)
```

**v2:**
```
# snapshot-v2
# navigation: Top
- [e0] link "Home"
# main: Article
- [e1] heading "Title"
- [e2] button "Comment"
```

## Risk and rollout

- v2 is opt-in via env (``BROWSER_SNAPSHOT_FORMAT=v2``) or operator settings; no agent template changes required.
- Modal-banner preamble (``** Modal dialog ... **``) rides ahead of section blocks so modal-scoped behavior is still visible.
- Empty result still emits the ``# snapshot-v2`` marker so parsers can detect format from the first line.
- Roadmap calls out a prompt audit before flipping the default — agent-facing docs (``docs/agent-tools.md``, fleet-template bootstrap MDs) only reference ``browser_get_elements`` by name today, no in-template format examples to update. When v2 default ships we'll add a short note about the new layout.

## Test plan

- [x] v1 default unchanged (no marker, suffix-style annotation).
- [x] v2 emits ``# snapshot-v2`` first line.
- [x] v2 groups elements by landmark; suffix annotations gone.
- [x] Elements without a landmark land under ``# (no landmark)``.
- [x] Indent depth caps at 4 (depth=7 collapses to 8 spaces).
- [x] Modal banner ``**`` lines preserved ahead of section blocks.
- [x] Empty entries → ``# snapshot-v2\n(no interactive elements)``.
- [x] attr_string (``[checked=True]``, ``[dup:2]``) round-trips into v2 output.
- [x] 304/304 ``test_browser_service.py``, 184/184 ``test_builtins.py`` (no regressions).