### PR TITLE
Phase 5 §8.5+§8.6: browser_find_text + browser_open_tab

### DIFF
--- a/src/agent/builtins/browser_tool.py
+++ b/src/agent/builtins/browser_tool.py
@@ -638,6 +638,91 @@ async def browser_switch_tab(tab_index: int = -1, *, mesh_client=None) -> dict:
 
 
 @skill(
+    name="browser_find_text",
+    description=(
+        "Find elements on the current page whose accessible name contains "
+        "the query string. Matching is Unicode-aware case-insensitive via "
+        "str.casefold() — 'EMAIL' matches 'email', 'STRASSE' matches "
+        "'straße'. Returns up to 50 matches in snapshot order, each with "
+        "a ref usable by browser_click / browser_type plus an in_viewport "
+        "flag. When scroll=true (default) and at least one match exists, "
+        "the first match is scrolled into view. Use this to locate a "
+        "specific button or link by its visible label without scanning "
+        "the whole element list yourself."
+    ),
+    parameters={
+        "query": {
+            "type": "string",
+            "description": (
+                "Substring to search for (1–500 chars). Case-insensitive."
+            ),
+        },
+        "scroll": {
+            "type": "boolean",
+            "description": (
+                "If true (default), scroll the first match into view. "
+                "Set false to inspect matches without affecting scroll "
+                "position."
+            ),
+            "default": True,
+        },
+    },
+    parallel_safe=False,
+)
+async def browser_find_text(
+    query: str, scroll: bool = True, *, mesh_client=None,
+) -> dict:
+    """Find elements whose accessible name contains the query."""
+    if not query:
+        return {"error": "The 'query' parameter is required"}
+    return await _browser_command(
+        mesh_client, "find_text", {"query": query, "scroll": scroll},
+    )
+
+
+@skill(
+    name="browser_open_tab",
+    description=(
+        "Open a URL in a new browser tab. The new tab becomes the active "
+        "page — subsequent browser_get_elements / browser_click / etc. "
+        "operate on it. Cookies and storage are shared with existing "
+        "tabs. Use browser_switch_tab to return to the previous tab. "
+        "Set snapshot_after=true to include the element snapshot in the "
+        "response (saves a separate browser_get_elements call)."
+    ),
+    parameters={
+        "url": {
+            "type": "string",
+            "description": (
+                "URL to open in a new tab. Must be http:// or https://."
+            ),
+        },
+        "snapshot_after": {
+            "type": "boolean",
+            "description": (
+                "Include element snapshot in the response (default false)."
+            ),
+            "default": False,
+        },
+    },
+    parallel_safe=False,
+)
+async def browser_open_tab(
+    url: str, snapshot_after: bool = False, *, mesh_client=None,
+) -> dict:
+    """Open a URL in a new tab and make it the active page."""
+    if not url:
+        return {"error": "The 'url' parameter is required"}
+    scheme = url.split(":", 1)[0].lower() if ":" in url else ""
+    if scheme not in ("http", "https"):
+        return {"error": "URL must start with http:// or https://"}
+    return await _browser_command(
+        mesh_client, "open_tab",
+        {"url": url, "snapshot_after": snapshot_after},
+    )
+
+
+@skill(
     name="browser_detect_captcha",
     description=(
         "Detect CAPTCHAs (reCAPTCHA, hCaptcha, Cloudflare Turnstile) on the "

--- a/src/agent/builtins/browser_tool.py
+++ b/src/agent/builtins/browser_tool.py
@@ -6,6 +6,8 @@ service container. Agent containers no longer bundle Chrome or VNC.
 
 from __future__ import annotations
 
+from urllib.parse import urlparse
+
 from src.agent.skills import skill
 
 # ``_redact_credentials`` is re-exported here (via the aliased import) so
@@ -713,7 +715,10 @@ async def browser_open_tab(
     """Open a URL in a new tab and make it the active page."""
     if not url:
         return {"error": "The 'url' parameter is required"}
-    scheme = url.split(":", 1)[0].lower() if ":" in url else ""
+    try:
+        scheme = urlparse(url).scheme.lower()
+    except Exception:
+        scheme = ""
     if scheme not in ("http", "https"):
         return {"error": "URL must start with http:// or https://"}
     return await _browser_command(

--- a/src/browser/server.py
+++ b/src/browser/server.py
@@ -401,6 +401,32 @@ def create_browser_app(manager: BrowserManager, lifespan=None) -> FastAPI:
         await _apply_delay()
         return result
 
+    @app.post("/browser/{agent_id}/find_text")
+    async def find_text(agent_id: str, request: Request):
+        _verify_auth(request)
+        body = await request.json()
+        query = body.get("query", "")
+        if not query:
+            raise HTTPException(400, "query required")
+        scroll = bool(body.get("scroll", True))
+        result = await manager.find_text(agent_id, query, scroll=scroll)
+        await _apply_delay()
+        return result
+
+    @app.post("/browser/{agent_id}/open_tab")
+    async def open_tab(agent_id: str, request: Request):
+        _verify_auth(request)
+        body = await request.json()
+        url = body.get("url", "")
+        if not url:
+            raise HTTPException(400, "url required")
+        snapshot_after = bool(body.get("snapshot_after", False))
+        result = await manager.open_tab(
+            agent_id, url, snapshot_after=snapshot_after,
+        )
+        await _apply_delay()
+        return result
+
     # ── Settings ───────────────────────────────────────────────────────────
 
     @app.get("/browser/settings")

--- a/src/browser/service.py
+++ b/src/browser/service.py
@@ -41,7 +41,7 @@ from src.browser.timing import (
     x11_step_delay,
 )
 from src.shared.types import AGENT_ID_RE_PATTERN
-from src.shared.utils import setup_logging
+from src.shared.utils import sanitize_for_prompt, setup_logging
 
 logger = setup_logging("browser.service")
 
@@ -3892,6 +3892,184 @@ class BrowserManager:
                     },
                 }
             except Exception as e:
+                return {"success": False, "error": str(e)}
+
+    async def find_text(
+        self, agent_id: str, query: str, scroll: bool = True,
+    ) -> dict:
+        """Find elements whose accessible name contains ``query`` (case-folded).
+
+        Performs a fresh snapshot to populate ``inst.refs``, then scans every
+        ref's accessible name with :meth:`str.casefold` for Unicode-aware
+        case-insensitive substring matching. Returns up to 50 matches in
+        snapshot order. When ``scroll`` is True and matches exist, the first
+        match is scrolled into view (best-effort, non-fatal).
+        """
+        if not isinstance(query, str) or not (1 <= len(query) <= 500):
+            return {
+                "success": False,
+                "error": "query must be a non-empty string up to 500 chars",
+            }
+        inst = await self.get_or_start(agent_id)
+        inst.touch()
+        async with inst.lock:
+            try:
+                if inst._user_control:
+                    return {
+                        "success": False,
+                        "error": "User has browser control — action paused until control is released.",
+                    }
+                snap = await self._snapshot_impl(inst, agent_id)
+                if not snap.get("success"):
+                    return snap
+
+                needle = query.casefold()
+                viewport = inst.page.viewport_size or {}
+                vw = int(viewport.get("width") or 0)
+                vh = int(viewport.get("height") or 0)
+
+                matches: list[dict] = []
+                truncated = False
+                first_locator = None
+                for ref_id, handle in inst.refs.items():
+                    name = handle.name or ""
+                    if not name or needle not in name.casefold():
+                        continue
+                    if len(matches) >= 50:
+                        truncated = True
+                        break
+                    locator = self._locator_from_ref(inst, ref_id)
+                    in_viewport = False
+                    if locator is not None:
+                        try:
+                            visible = await locator.is_visible()
+                        except Exception:
+                            visible = False
+                        if visible and vw > 0 and vh > 0:
+                            try:
+                                box = await locator.bounding_box()
+                            except Exception:
+                                box = None
+                            if box:
+                                bx = float(box.get("x", 0))
+                                by = float(box.get("y", 0))
+                                bw = float(box.get("width", 0))
+                                bh = float(box.get("height", 0))
+                                in_viewport = (
+                                    bx + bw > 0 and by + bh > 0
+                                    and bx < vw and by < vh
+                                )
+                    redacted_name = self.redactor.redact(agent_id, name)
+                    matches.append({
+                        "ref": ref_id,
+                        "text": sanitize_for_prompt(redacted_name),
+                        "in_viewport": bool(in_viewport),
+                    })
+                    if first_locator is None and locator is not None:
+                        first_locator = locator
+
+                if scroll and first_locator is not None:
+                    try:
+                        await first_locator.scroll_into_view_if_needed(timeout=3000)
+                    except Exception as e:
+                        logger.debug(
+                            "scroll_into_view_if_needed failed for %s: %s",
+                            agent_id, e,
+                        )
+
+                return {
+                    "success": True,
+                    "data": {
+                        "matches": matches,
+                        "total": len(matches),
+                        "truncated": truncated,
+                    },
+                }
+            except Exception as e:
+                return {"success": False, "error": str(e)}
+
+    async def open_tab(
+        self, agent_id: str, url: str, snapshot_after: bool = False,
+    ) -> dict:
+        """Open ``url`` in a new tab and make it the active page.
+
+        Cookies and storage are shared with existing tabs (same browser
+        context). The new page is registered in ``inst.page_ids`` so refs
+        captured against it resolve correctly. On goto failure the new
+        page is closed and the previous active tab is restored.
+        """
+        try:
+            parsed = urlparse(url)
+        except Exception:
+            return {"success": False, "error": "Invalid URL"}
+        scheme = parsed.scheme.lower()
+        if scheme not in ("http", "https"):
+            return {
+                "success": False,
+                "error": f"URL scheme '{parsed.scheme}' is not allowed",
+            }
+
+        inst = await self.get_or_start(agent_id)
+        inst.touch()
+        async with inst.lock:
+            if inst._user_control:
+                return {
+                    "success": False,
+                    "error": "User has browser control — action paused until control is released.",
+                }
+            previous_page = inst.page
+            try:
+                new_page = await inst.context.new_page()
+            except Exception as e:
+                return {"success": False, "error": f"Failed to open tab: {e}"}
+
+            try:
+                page_id = inst._register_page(new_page)
+                try:
+                    await new_page.goto(
+                        url, wait_until="domcontentloaded", timeout=30000,
+                    )
+                except Exception as e:
+                    try:
+                        await new_page.close()
+                    except Exception:
+                        pass
+                    inst.page = previous_page
+                    return {"success": False, "error": str(e)}
+
+                inst.page = new_page
+                inst.dialog_active = False
+                inst.dialog_detected = False
+                try:
+                    await new_page.bring_to_front()
+                except Exception:
+                    pass
+
+                title = ""
+                try:
+                    title = await new_page.title()
+                except Exception:
+                    pass
+                tabs = list(inst.context.pages)
+                tab_index = tabs.index(new_page) if new_page in tabs else len(tabs) - 1
+                current_url = new_page.url
+
+                data = {
+                    "page_id": page_id,
+                    "tab_index": tab_index,
+                    "url": self.redactor.redact(agent_id, current_url),
+                    "title": self.redactor.redact(agent_id, title),
+                }
+                if snapshot_after:
+                    snap = await self._snapshot_impl(inst, agent_id)
+                    data["snapshot"] = snap.get("data") or {}
+                return {"success": True, "data": data}
+            except Exception as e:
+                try:
+                    await new_page.close()
+                except Exception:
+                    pass
+                inst.page = previous_page
                 return {"success": False, "error": str(e)}
 
     async def press_key(self, agent_id: str, key: str) -> dict:

--- a/src/browser/service.py
+++ b/src/browser/service.py
@@ -210,6 +210,7 @@ _BLOCKED_URL_SCHEMES = frozenset({
     "file", "javascript", "data", "blob",
     "about", "moz-extension", "chrome-extension", "chrome",
 })
+_ALLOWED_URL_SCHEMES = frozenset({"http", "https"})
 _MAX_WAIT_MS = 10000  # 10 seconds max wait after navigation
 _MAX_SCROLL_PX = 10000  # 10000 pixels max per scroll call
 _CLICK_TIMEOUT_MS = 10000  # 10 seconds — SPAs like X need time for animations/overlays
@@ -2014,6 +2015,7 @@ class BrowserManager:
         filter: str | None = None,
         from_ref: str | None = None,
         diff_from_last: bool = False,
+        _skip_baseline: bool = False,
     ) -> dict:
         """Snapshot implementation.  Caller must hold ``inst.lock``."""
         # Resolve the optional filter once so the inner _walk sees a
@@ -2494,7 +2496,7 @@ class BrowserManager:
             # snapshots, not anchors. ``last_active_page_id`` still
             # advances so tab-change detection stays accurate.
             _is_scoped_call = (filter is not None) or (from_ref is not None)
-            if not _is_scoped_call:
+            if not _is_scoped_call and not _skip_baseline:
                 inst.last_snapshot[snapshot_page_id] = {
                     "refs_by_key": dict(ref_summary),
                     "url": current_url,
@@ -3919,7 +3921,9 @@ class BrowserManager:
                         "success": False,
                         "error": "User has browser control — action paused until control is released.",
                     }
-                snap = await self._snapshot_impl(inst, agent_id)
+                snap = await self._snapshot_impl(
+                    inst, agent_id, _skip_baseline=True,
+                )
                 if not snap.get("success"):
                     return snap
 
@@ -4003,7 +4007,7 @@ class BrowserManager:
         except Exception:
             return {"success": False, "error": "Invalid URL"}
         scheme = parsed.scheme.lower()
-        if scheme not in ("http", "https"):
+        if scheme not in _ALLOWED_URL_SCHEMES:
             return {
                 "success": False,
                 "error": f"URL scheme '{parsed.scheme}' is not allowed",
@@ -4025,10 +4029,29 @@ class BrowserManager:
 
             try:
                 page_id = inst._register_page(new_page)
+                resolved_referer = ""
                 try:
-                    await new_page.goto(
-                        url, wait_until="domcontentloaded", timeout=30000,
+                    previous_url = (
+                        previous_page.url
+                        if previous_page is not None and inst.had_real_navigate
+                        else ""
                     )
+                    resolved_referer = pick_referer(
+                        url,
+                        previous_url=previous_url,
+                        recent_referers=tuple(inst.recent_referers),
+                    )
+                except Exception as e:
+                    logger.debug("open_tab referer pick failed: %s", e)
+                    resolved_referer = ""
+
+                goto_kwargs: dict = {
+                    "wait_until": "domcontentloaded", "timeout": 30000,
+                }
+                if resolved_referer:
+                    goto_kwargs["referer"] = resolved_referer
+                try:
+                    await new_page.goto(url, **goto_kwargs)
                 except Exception as e:
                     try:
                         await new_page.close()
@@ -4036,6 +4059,12 @@ class BrowserManager:
                         pass
                     inst.page = previous_page
                     return {"success": False, "error": str(e)}
+
+                try:
+                    inst.recent_referers.append(resolved_referer)
+                    inst.had_real_navigate = True
+                except Exception as e:
+                    logger.debug("open_tab referer state update failed: %s", e)
 
                 inst.page = new_page
                 inst.dialog_active = False
@@ -4050,8 +4079,7 @@ class BrowserManager:
                     title = await new_page.title()
                 except Exception:
                     pass
-                tabs = list(inst.context.pages)
-                tab_index = tabs.index(new_page) if new_page in tabs else len(tabs) - 1
+                tab_index = len(inst.context.pages) - 1
                 current_url = new_page.url
 
                 data = {

--- a/src/browser/service.py
+++ b/src/browser/service.py
@@ -3966,7 +3966,7 @@ class BrowserManager:
                     redacted_name = self.redactor.redact(agent_id, name)
                     matches.append({
                         "ref": ref_id,
-                        "text": sanitize_for_prompt(redacted_name),
+                        "text": sanitize_for_prompt(redacted_name)[:200],
                         "in_viewport": bool(in_viewport),
                     })
                     if first_locator is None and locator is not None:
@@ -4067,6 +4067,7 @@ class BrowserManager:
                     logger.debug("open_tab referer state update failed: %s", e)
 
                 inst.page = new_page
+                inst.refs = {}  # Stale refs from previous tab's snapshot
                 inst.dialog_active = False
                 inst.dialog_detected = False
                 try:

--- a/src/host/permissions.py
+++ b/src/host/permissions.py
@@ -40,6 +40,8 @@ KNOWN_BROWSER_ACTIONS: frozenset[str] = frozenset({
     # 404 on the unknown URL instead of the mesh rejecting the action
     # name as unknown — avoids a cross-PR merge-order dependency.
     "upload_file", "download",
+    # Phase 5 §8.5 / §8.6 default-allow read-only / nav-equivalent actions.
+    "find_text", "open_tab",
 })
 
 # Back-compat alias — retained so `host/server.py` and test fixtures that

--- a/src/host/server.py
+++ b/src/host/server.py
@@ -2899,7 +2899,7 @@ def create_mesh_app(
         # docker/browser-entrypoint.sh — that layer covers DNS rebinding,
         # HTTP redirects, subresource loads (img/script/iframe), XHR/fetch,
         # and WebSockets, none of which can be gated at the Playwright API.
-        if action == "navigate":
+        if action in ("navigate", "open_tab"):
             nav_url = params.get("url", "")
             if nav_url:
                 from src.agent.builtins.http_tool import _resolve_and_pin

--- a/tests/test_browser_delegation.py
+++ b/tests/test_browser_delegation.py
@@ -975,3 +975,45 @@ class TestBrowserLoginRequestEndpoint:
                 )
                 assert resp.status_code == 400, (bad, resp.text)
                 assert "must be a string" in resp.text
+
+
+class TestBrowserCommandSSRF:
+    """Mesh-side early-reject for navigate / open_tab pointing at private IPs."""
+
+    @pytest.mark.asyncio
+    async def test_navigate_private_ip_rejected(self, tmp_path):
+        from httpx import ASGITransport, AsyncClient
+
+        app, _event_bus, _cm = _build_app(
+            tmp_path,
+            perms_map={"worker": {"can_use_browser": True}},
+        )
+
+        async with AsyncClient(
+            transport=ASGITransport(app=app), base_url="http://test",
+        ) as client:
+            resp = await client.post(
+                "/mesh/browser/command",
+                json={"action": "navigate", "params": {"url": "http://127.0.0.1/"}},
+                headers={"X-Agent-ID": "worker"},
+            )
+        assert resp.status_code == 400, resp.text
+
+    @pytest.mark.asyncio
+    async def test_open_tab_private_ip_rejected(self, tmp_path):
+        from httpx import ASGITransport, AsyncClient
+
+        app, _event_bus, _cm = _build_app(
+            tmp_path,
+            perms_map={"worker": {"can_use_browser": True}},
+        )
+
+        async with AsyncClient(
+            transport=ASGITransport(app=app), base_url="http://test",
+        ) as client:
+            resp = await client.post(
+                "/mesh/browser/command",
+                json={"action": "open_tab", "params": {"url": "http://127.0.0.1/"}},
+                headers={"X-Agent-ID": "worker"},
+            )
+        assert resp.status_code == 400, resp.text

--- a/tests/test_browser_service.py
+++ b/tests/test_browser_service.py
@@ -7395,6 +7395,88 @@ class TestFindText:
         match_refs = [m["ref"] for m in result["data"]["matches"]]
         assert match_refs == ["e0", "e2"]
 
+    @pytest.mark.asyncio
+    async def test_find_text_unicode_casefold(self):
+        mgr = self._make_manager()
+        refs = {
+            "e0": {"role": "link", "name": "Straße", "index": 0, "disabled": False},
+        }
+        inst, BrowserManager = self._make_instance(refs)
+
+        mock_locator = AsyncMock()
+        mock_locator.is_visible = AsyncMock(return_value=False)
+        mock_locator.bounding_box = AsyncMock(return_value=None)
+        mock_locator.scroll_into_view_if_needed = AsyncMock()
+
+        async def fake_snapshot(self_mgr, _inst, _agent_id, **_kw):
+            return {"success": True, "data": {}}
+
+        with patch.object(BrowserManager, "get_or_start", return_value=inst), \
+             patch.object(BrowserManager, "_locator_from_ref", return_value=mock_locator), \
+             patch.object(BrowserManager, "_snapshot_impl", new=fake_snapshot):
+            result = await mgr.find_text("agent1", "STRASSE")
+
+        assert result["success"] is True
+        match_refs = [m["ref"] for m in result["data"]["matches"]]
+        assert match_refs == ["e0"]
+
+    @pytest.mark.asyncio
+    async def test_find_text_caps_at_50_matches(self):
+        mgr = self._make_manager()
+        refs = {
+            f"e{i}": {"role": "button", "name": "Save item", "index": i, "disabled": False}
+            for i in range(60)
+        }
+        inst, BrowserManager = self._make_instance(refs)
+
+        mock_locator = AsyncMock()
+        mock_locator.is_visible = AsyncMock(return_value=False)
+        mock_locator.bounding_box = AsyncMock(return_value=None)
+        mock_locator.scroll_into_view_if_needed = AsyncMock()
+
+        async def fake_snapshot(self_mgr, _inst, _agent_id, **_kw):
+            return {"success": True, "data": {}}
+
+        with patch.object(BrowserManager, "get_or_start", return_value=inst), \
+             patch.object(BrowserManager, "_locator_from_ref", return_value=mock_locator), \
+             patch.object(BrowserManager, "_snapshot_impl", new=fake_snapshot):
+            result = await mgr.find_text("agent1", "save")
+
+        assert result["success"] is True
+        assert len(result["data"]["matches"]) == 50
+        assert result["data"]["truncated"] is True
+
+    @pytest.mark.asyncio
+    async def test_find_text_does_not_clobber_diff_baseline(self):
+        from src.browser.service import BrowserManager
+
+        mgr = self._make_manager()
+        refs = {
+            "e0": {"role": "button", "name": "Submit", "index": 0, "disabled": False},
+        }
+        inst, _BM = self._make_instance(refs)
+
+        captured: dict = {}
+
+        async def fake_snapshot(
+            self_mgr, _inst, _agent_id, *, _skip_baseline=False, **_kw,
+        ):
+            captured["skip"] = _skip_baseline
+            return {"success": True, "data": {}}
+
+        mock_locator = AsyncMock()
+        mock_locator.is_visible = AsyncMock(return_value=False)
+        mock_locator.bounding_box = AsyncMock(return_value=None)
+        mock_locator.scroll_into_view_if_needed = AsyncMock()
+
+        with patch.object(BrowserManager, "get_or_start", return_value=inst), \
+             patch.object(BrowserManager, "_locator_from_ref", return_value=mock_locator), \
+             patch.object(BrowserManager, "_snapshot_impl", new=fake_snapshot):
+            result = await mgr.find_text("agent1", "submit")
+
+        assert result["success"] is True
+        assert captured.get("skip") is True
+
 
 # ── browser_open_tab tests ─────────────────────────────────────────────────
 

--- a/tests/test_browser_service.py
+++ b/tests/test_browser_service.py
@@ -7447,27 +7447,22 @@ class TestFindText:
         assert result["data"]["truncated"] is True
 
     @pytest.mark.asyncio
-    async def test_find_text_does_not_clobber_diff_baseline(self):
-        from src.browser.service import BrowserManager
-
+    async def test_find_text_caps_text_at_200_chars(self):
         mgr = self._make_manager()
+        # Use a phrase the credential redactor won't flag as a secret.
+        long_name = "Submit application " * 50  # 950 chars
         refs = {
-            "e0": {"role": "button", "name": "Submit", "index": 0, "disabled": False},
+            "e0": {"role": "button", "name": long_name, "index": 0, "disabled": False},
         }
-        inst, _BM = self._make_instance(refs)
-
-        captured: dict = {}
-
-        async def fake_snapshot(
-            self_mgr, _inst, _agent_id, *, _skip_baseline=False, **_kw,
-        ):
-            captured["skip"] = _skip_baseline
-            return {"success": True, "data": {}}
+        inst, BrowserManager = self._make_instance(refs)
 
         mock_locator = AsyncMock()
         mock_locator.is_visible = AsyncMock(return_value=False)
         mock_locator.bounding_box = AsyncMock(return_value=None)
         mock_locator.scroll_into_view_if_needed = AsyncMock()
+
+        async def fake_snapshot(self_mgr, _inst, _agent_id, **_kw):
+            return {"success": True, "data": {}}
 
         with patch.object(BrowserManager, "get_or_start", return_value=inst), \
              patch.object(BrowserManager, "_locator_from_ref", return_value=mock_locator), \
@@ -7475,7 +7470,57 @@ class TestFindText:
             result = await mgr.find_text("agent1", "submit")
 
         assert result["success"] is True
-        assert captured.get("skip") is True
+        matches = result["data"]["matches"]
+        assert len(matches) == 1
+        assert len(matches[0]["text"]) == 200
+        assert matches[0]["text"] == long_name[:200]
+
+    @pytest.mark.asyncio
+    async def test_find_text_does_not_clobber_diff_baseline(self):
+        """Calling find_text after a baselined snapshot must not overwrite the
+        per-page diff baseline — the next ``diff_from_last`` call should
+        compare against the pre-find_text state, not the find_text-time state.
+        """
+        from src.browser.service import BrowserManager, CamoufoxInstance
+
+        mgr = BrowserManager(profiles_dir="/tmp/test_profiles")
+        tree_v1 = {
+            "role": "WebArea", "name": "",
+            "children": [{"role": "button", "name": "Submit"}],
+        }
+        mock_page = AsyncMock()
+        mock_page.url = "https://example.com"
+        mock_page.viewport_size = {"width": 1280, "height": 720}
+        mock_page.accessibility = MagicMock()
+        mock_page.accessibility.snapshot = AsyncMock(return_value=tree_v1)
+        inst = CamoufoxInstance("agent1", MagicMock(), MagicMock(), mock_page)
+        mgr._instances["agent1"] = inst
+
+        # Establish baseline via a real snapshot.
+        await mgr.snapshot("agent1")
+        page_id = inst.last_active_page_id
+        baseline_before = dict(inst.last_snapshot[page_id])
+
+        # Page state changes (a Cancel button appears) before find_text runs.
+        tree_v2 = {
+            "role": "WebArea", "name": "",
+            "children": [
+                {"role": "button", "name": "Submit"},
+                {"role": "button", "name": "Cancel"},
+            ],
+        }
+        mock_page.accessibility.snapshot = AsyncMock(return_value=tree_v2)
+
+        mock_locator = AsyncMock()
+        mock_locator.is_visible = AsyncMock(return_value=False)
+        mock_locator.bounding_box = AsyncMock(return_value=None)
+        mock_locator.scroll_into_view_if_needed = AsyncMock()
+        with patch.object(BrowserManager, "_locator_from_ref", return_value=mock_locator):
+            result = await mgr.find_text("agent1", "submit")
+
+        assert result["success"] is True
+        # Baseline must be unchanged — find_text passes _skip_baseline=True.
+        assert inst.last_snapshot[page_id] == baseline_before
 
 
 # ── browser_open_tab tests ─────────────────────────────────────────────────
@@ -7668,3 +7713,85 @@ class TestOpenTab:
         assert r2["success"] is True
         assert r1["data"]["page_id"] != r2["data"]["page_id"]
         assert r2["data"]["tab_index"] == 2
+
+    @pytest.mark.asyncio
+    async def test_open_tab_clears_prior_tab_refs(self):
+        from src.browser.service import BrowserManager
+
+        mgr = self._make_manager()
+        inst, _page0 = self._make_instance()
+        # Pre-populate refs as if a prior snapshot ran on the original tab.
+        inst.seed_refs_legacy({
+            "e0": {"role": "button", "name": "OldTabButton", "index": 0},
+        })
+        assert "e0" in inst.refs
+
+        new_page = AsyncMock()
+        new_page.goto = AsyncMock()
+        new_page.title = AsyncMock(return_value="New")
+        new_page.url = "https://example.org/"
+        new_page.bring_to_front = AsyncMock()
+        inst.context.new_page = AsyncMock(return_value=new_page)
+        inst.context.pages = [inst.page, new_page]
+
+        with patch.object(BrowserManager, "get_or_start", return_value=inst):
+            result = await mgr.open_tab("agent1", "https://example.org/")
+
+        assert result["success"] is True
+        assert inst.refs == {}
+
+    @pytest.mark.asyncio
+    async def test_click_after_open_tab_uses_fresh_refs(self):
+        from src.browser.service import BrowserManager
+
+        mgr = self._make_manager()
+        inst, _page0 = self._make_instance()
+        inst.seed_refs_legacy({
+            "e0": {"role": "button", "name": "OldTabButton", "index": 0},
+        })
+
+        new_page = AsyncMock()
+        new_page.goto = AsyncMock()
+        new_page.title = AsyncMock(return_value="New")
+        new_page.url = "https://example.org/"
+        new_page.bring_to_front = AsyncMock()
+        inst.context.new_page = AsyncMock(return_value=new_page)
+        inst.context.pages = [inst.page, new_page]
+
+        with patch.object(BrowserManager, "get_or_start", return_value=inst):
+            open_result = await mgr.open_tab("agent1", "https://example.org/")
+            assert open_result["success"] is True
+            click_result = await mgr.click("agent1", ref="e0")
+
+        # Old ref must not resolve — open_tab cleared inst.refs, so the click
+        # rejects the request rather than acting on a stale handle from the
+        # previous tab.
+        assert click_result["success"] is False
+        assert "e0" not in inst.refs
+
+    @pytest.mark.asyncio
+    async def test_open_tab_as_first_action(self):
+        """Opening a tab as the very first action (no prior snapshot/refs) succeeds
+        and the new page becomes active."""
+        from src.browser.service import BrowserManager
+
+        mgr = self._make_manager()
+        inst, page0 = self._make_instance()
+        # Fresh instance: refs empty, no prior snapshot.
+        assert inst.refs == {}
+
+        new_page = AsyncMock()
+        new_page.goto = AsyncMock()
+        new_page.title = AsyncMock(return_value="First")
+        new_page.url = "https://example.org/first"
+        new_page.bring_to_front = AsyncMock()
+        inst.context.new_page = AsyncMock(return_value=new_page)
+        inst.context.pages = [page0, new_page]
+
+        with patch.object(BrowserManager, "get_or_start", return_value=inst):
+            result = await mgr.open_tab("agent1", "https://example.org/first")
+
+        assert result["success"] is True
+        assert result["data"]["page_id"]
+        assert inst.page is new_page
+        assert inst.refs == {}

--- a/tests/test_browser_service.py
+++ b/tests/test_browser_service.py
@@ -7210,3 +7210,379 @@ class TestCheckCaptchaAutoSolve:
         assert result is not None
         assert "CAPTCHA detected" in result["message"]
         mock_solver.solve.assert_called_once()
+
+
+# ── browser_find_text tests ────────────────────────────────────────────────
+
+
+class TestFindText:
+    """Tests for BrowserManager.find_text() (Phase 5 §8.5)."""
+
+    def _make_manager(self):
+        from src.browser.redaction import CredentialRedactor
+        from src.browser.service import BrowserManager
+        mgr = BrowserManager.__new__(BrowserManager)
+        mgr.redactor = CredentialRedactor()
+        return mgr
+
+    def _make_instance(self, refs_dict: dict):
+        from src.browser.service import BrowserManager
+        inst = MagicMock()
+        inst.refs = {k: _h(v) for k, v in refs_dict.items()}
+        inst.page = AsyncMock()
+        inst.page.viewport_size = {"width": 1280, "height": 720}
+        inst.lock = asyncio.Lock()
+        inst.touch = MagicMock()
+        inst._user_control = False
+        return inst, BrowserManager
+
+    @pytest.mark.asyncio
+    async def test_find_text_matches_by_name_case_insensitive(self):
+        mgr = self._make_manager()
+        refs = {
+            "e0": {"role": "button", "name": "Submit", "index": 0, "disabled": False},
+            "e1": {"role": "button", "name": "Cancel", "index": 0, "disabled": False},
+            "e2": {"role": "link", "name": "View profile", "index": 0, "disabled": False},
+        }
+        inst, BrowserManager = self._make_instance(refs)
+
+        mock_locator = AsyncMock()
+        mock_locator.is_visible = AsyncMock(return_value=True)
+        mock_locator.bounding_box = AsyncMock(
+            return_value={"x": 10, "y": 10, "width": 50, "height": 20},
+        )
+        mock_locator.scroll_into_view_if_needed = AsyncMock()
+
+        async def fake_snapshot(self_mgr, _inst, _agent_id, **_kw):
+            return {"success": True, "data": {}}
+
+        with patch.object(BrowserManager, "get_or_start", return_value=inst), \
+             patch.object(BrowserManager, "_locator_from_ref", return_value=mock_locator), \
+             patch.object(BrowserManager, "_snapshot_impl", new=fake_snapshot):
+            result = await mgr.find_text("agent1", "submit")
+
+        assert result["success"] is True
+        matches = result["data"]["matches"]
+        assert len(matches) == 1
+        assert matches[0]["ref"] == "e0"
+        assert matches[0]["text"] == "Submit"
+        assert matches[0]["in_viewport"] is True
+        assert result["data"]["truncated"] is False
+
+    @pytest.mark.asyncio
+    async def test_find_text_no_matches(self):
+        mgr = self._make_manager()
+        refs = {
+            "e0": {"role": "button", "name": "Submit", "index": 0, "disabled": False},
+        }
+        inst, BrowserManager = self._make_instance(refs)
+
+        async def fake_snapshot(self_mgr, _inst, _agent_id, **_kw):
+            return {"success": True, "data": {}}
+
+        with patch.object(BrowserManager, "get_or_start", return_value=inst), \
+             patch.object(BrowserManager, "_snapshot_impl", new=fake_snapshot):
+            result = await mgr.find_text("agent1", "no-such-thing")
+
+        assert result["success"] is True
+        assert result["data"]["matches"] == []
+        assert result["data"]["total"] == 0
+        assert result["data"]["truncated"] is False
+
+    @pytest.mark.asyncio
+    async def test_find_text_query_too_long_rejected(self):
+        mgr = self._make_manager()
+        result = await mgr.find_text("agent1", "x" * 501)
+        assert result["success"] is False
+        assert "500" in result["error"]
+
+    @pytest.mark.asyncio
+    async def test_find_text_query_empty_rejected(self):
+        mgr = self._make_manager()
+        result = await mgr.find_text("agent1", "")
+        assert result["success"] is False
+
+    @pytest.mark.asyncio
+    async def test_find_text_scroll_true_scrolls_first_match(self):
+        mgr = self._make_manager()
+        refs = {
+            "e0": {"role": "button", "name": "Save", "index": 0, "disabled": False},
+            "e1": {"role": "button", "name": "Save", "index": 1, "disabled": False},
+        }
+        inst, BrowserManager = self._make_instance(refs)
+
+        mock_locator = AsyncMock()
+        mock_locator.is_visible = AsyncMock(return_value=True)
+        mock_locator.bounding_box = AsyncMock(
+            return_value={"x": 0, "y": 0, "width": 50, "height": 20},
+        )
+        mock_locator.scroll_into_view_if_needed = AsyncMock()
+
+        async def fake_snapshot(self_mgr, _inst, _agent_id, **_kw):
+            return {"success": True, "data": {}}
+
+        with patch.object(BrowserManager, "get_or_start", return_value=inst), \
+             patch.object(BrowserManager, "_locator_from_ref", return_value=mock_locator), \
+             patch.object(BrowserManager, "_snapshot_impl", new=fake_snapshot):
+            result = await mgr.find_text("agent1", "save", scroll=True)
+
+        assert result["success"] is True
+        mock_locator.scroll_into_view_if_needed.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_find_text_scroll_false_does_not_scroll(self):
+        mgr = self._make_manager()
+        refs = {
+            "e0": {"role": "button", "name": "Save", "index": 0, "disabled": False},
+        }
+        inst, BrowserManager = self._make_instance(refs)
+
+        mock_locator = AsyncMock()
+        mock_locator.is_visible = AsyncMock(return_value=True)
+        mock_locator.bounding_box = AsyncMock(
+            return_value={"x": 0, "y": 0, "width": 50, "height": 20},
+        )
+        mock_locator.scroll_into_view_if_needed = AsyncMock()
+
+        async def fake_snapshot(self_mgr, _inst, _agent_id, **_kw):
+            return {"success": True, "data": {}}
+
+        with patch.object(BrowserManager, "get_or_start", return_value=inst), \
+             patch.object(BrowserManager, "_locator_from_ref", return_value=mock_locator), \
+             patch.object(BrowserManager, "_snapshot_impl", new=fake_snapshot):
+            result = await mgr.find_text("agent1", "save", scroll=False)
+
+        assert result["success"] is True
+        mock_locator.scroll_into_view_if_needed.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_find_text_user_control_returns_error(self):
+        mgr = self._make_manager()
+        refs = {"e0": {"role": "button", "name": "Submit", "index": 0, "disabled": False}}
+        inst, BrowserManager = self._make_instance(refs)
+        inst._user_control = True
+
+        with patch.object(BrowserManager, "get_or_start", return_value=inst):
+            result = await mgr.find_text("agent1", "submit")
+
+        assert result["success"] is False
+        assert "User has browser control" in result["error"]
+
+    @pytest.mark.asyncio
+    async def test_find_text_multi_match_preserves_order(self):
+        mgr = self._make_manager()
+        refs = {
+            "e0": {"role": "button", "name": "Save draft", "index": 0, "disabled": False},
+            "e1": {"role": "button", "name": "Cancel", "index": 0, "disabled": False},
+            "e2": {"role": "link", "name": "Save and exit", "index": 0, "disabled": False},
+        }
+        inst, BrowserManager = self._make_instance(refs)
+
+        mock_locator = AsyncMock()
+        mock_locator.is_visible = AsyncMock(return_value=False)
+        mock_locator.bounding_box = AsyncMock(return_value=None)
+        mock_locator.scroll_into_view_if_needed = AsyncMock()
+
+        async def fake_snapshot(self_mgr, _inst, _agent_id, **_kw):
+            return {"success": True, "data": {}}
+
+        with patch.object(BrowserManager, "get_or_start", return_value=inst), \
+             patch.object(BrowserManager, "_locator_from_ref", return_value=mock_locator), \
+             patch.object(BrowserManager, "_snapshot_impl", new=fake_snapshot):
+            result = await mgr.find_text("agent1", "save")
+
+        assert result["success"] is True
+        match_refs = [m["ref"] for m in result["data"]["matches"]]
+        assert match_refs == ["e0", "e2"]
+
+
+# ── browser_open_tab tests ─────────────────────────────────────────────────
+
+
+class TestOpenTab:
+    """Tests for BrowserManager.open_tab() (Phase 5 §8.6)."""
+
+    def _make_manager(self):
+        from src.browser.redaction import CredentialRedactor
+        from src.browser.service import BrowserManager
+        mgr = BrowserManager.__new__(BrowserManager)
+        mgr.redactor = CredentialRedactor()
+        return mgr
+
+    def _make_instance(self, *, existing_pages=None):
+        from src.browser.service import CamoufoxInstance
+        page0 = AsyncMock()
+        page0.url = "https://example.com"
+        inst = CamoufoxInstance("agent1", MagicMock(), MagicMock(), page0)
+        inst.context = MagicMock()
+        existing = list(existing_pages) if existing_pages else [page0]
+        inst.context.pages = existing
+        return inst, page0
+
+    @pytest.mark.asyncio
+    async def test_open_tab_success_returns_page_id_and_index(self):
+        from src.browser.service import BrowserManager
+
+        mgr = self._make_manager()
+        inst, _page0 = self._make_instance()
+
+        new_page = AsyncMock()
+        new_page.goto = AsyncMock()
+        new_page.title = AsyncMock(return_value="New Tab Title")
+        new_page.url = "https://example.org/landing"
+        new_page.bring_to_front = AsyncMock()
+        inst.context.new_page = AsyncMock(return_value=new_page)
+        inst.context.pages = [inst.page, new_page]
+
+        with patch.object(BrowserManager, "get_or_start", return_value=inst):
+            result = await mgr.open_tab("agent1", "https://example.org/landing")
+
+        assert result["success"] is True
+        assert result["data"]["page_id"]
+        assert result["data"]["tab_index"] == 1
+        assert result["data"]["url"] == "https://example.org/landing"
+        assert result["data"]["title"] == "New Tab Title"
+        assert inst.page is new_page
+        new_page.goto.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_open_tab_becomes_active(self):
+        from src.browser.service import BrowserManager
+
+        mgr = self._make_manager()
+        inst, page0 = self._make_instance()
+
+        new_page = AsyncMock()
+        new_page.goto = AsyncMock()
+        new_page.title = AsyncMock(return_value="X")
+        new_page.url = "https://example.org/"
+        new_page.bring_to_front = AsyncMock()
+        inst.context.new_page = AsyncMock(return_value=new_page)
+        inst.context.pages = [page0, new_page]
+
+        with patch.object(BrowserManager, "get_or_start", return_value=inst):
+            await mgr.open_tab("agent1", "https://example.org/")
+
+        assert inst.page is new_page
+
+    @pytest.mark.asyncio
+    async def test_open_tab_rejects_file_url(self):
+        from src.browser.service import BrowserManager
+
+        mgr = self._make_manager()
+        inst, _page0 = self._make_instance()
+
+        with patch.object(BrowserManager, "get_or_start", return_value=inst):
+            result = await mgr.open_tab("agent1", "file:///etc/passwd")
+        assert result["success"] is False
+        assert "not allowed" in result["error"]
+
+    @pytest.mark.asyncio
+    async def test_open_tab_rejects_javascript_url(self):
+        from src.browser.service import BrowserManager
+
+        mgr = self._make_manager()
+        inst, _page0 = self._make_instance()
+
+        with patch.object(BrowserManager, "get_or_start", return_value=inst):
+            result = await mgr.open_tab("agent1", "javascript:alert(1)")
+        assert result["success"] is False
+        assert "not allowed" in result["error"]
+
+    @pytest.mark.asyncio
+    async def test_open_tab_goto_failure_closes_new_page(self):
+        from src.browser.service import BrowserManager
+
+        mgr = self._make_manager()
+        inst, page0 = self._make_instance()
+
+        new_page = AsyncMock()
+        new_page.goto = AsyncMock(side_effect=Exception("net::ERR_CONNECTION_REFUSED"))
+        new_page.close = AsyncMock()
+        inst.context.new_page = AsyncMock(return_value=new_page)
+        inst.context.pages = [page0, new_page]
+
+        with patch.object(BrowserManager, "get_or_start", return_value=inst):
+            result = await mgr.open_tab("agent1", "https://example.org/")
+
+        assert result["success"] is False
+        assert "ERR_CONNECTION_REFUSED" in result["error"]
+        new_page.close.assert_awaited_once()
+        assert inst.page is page0
+
+    @pytest.mark.asyncio
+    async def test_open_tab_user_control_returns_error(self):
+        from src.browser.service import BrowserManager
+
+        mgr = self._make_manager()
+        inst, _page0 = self._make_instance()
+        inst._user_control = True
+
+        with patch.object(BrowserManager, "get_or_start", return_value=inst):
+            result = await mgr.open_tab("agent1", "https://example.org/")
+
+        assert result["success"] is False
+        assert "User has browser control" in result["error"]
+
+    @pytest.mark.asyncio
+    async def test_open_tab_snapshot_after_returns_snapshot(self):
+        from src.browser.service import BrowserManager
+
+        mgr = self._make_manager()
+        inst, page0 = self._make_instance()
+
+        new_page = AsyncMock()
+        new_page.goto = AsyncMock()
+        new_page.title = AsyncMock(return_value="X")
+        new_page.url = "https://example.org/"
+        new_page.bring_to_front = AsyncMock()
+        inst.context.new_page = AsyncMock(return_value=new_page)
+        inst.context.pages = [page0, new_page]
+
+        async def fake_snapshot(self_mgr, _inst, _agent_id, **_kw):
+            return {"success": True, "data": {"element_count": 7}}
+
+        with patch.object(BrowserManager, "get_or_start", return_value=inst), \
+             patch.object(BrowserManager, "_snapshot_impl", new=fake_snapshot):
+            result = await mgr.open_tab(
+                "agent1", "https://example.org/", snapshot_after=True,
+            )
+
+        assert result["success"] is True
+        assert result["data"]["snapshot"] == {"element_count": 7}
+
+    @pytest.mark.asyncio
+    async def test_open_tab_two_consecutive_distinct_page_ids(self):
+        from src.browser.service import BrowserManager
+
+        mgr = self._make_manager()
+        inst, page0 = self._make_instance()
+
+        new_page1 = AsyncMock()
+        new_page1.goto = AsyncMock()
+        new_page1.title = AsyncMock(return_value="A")
+        new_page1.url = "https://example.org/a"
+        new_page1.bring_to_front = AsyncMock()
+
+        new_page2 = AsyncMock()
+        new_page2.goto = AsyncMock()
+        new_page2.title = AsyncMock(return_value="B")
+        new_page2.url = "https://example.org/b"
+        new_page2.bring_to_front = AsyncMock()
+
+        pages_iter = iter([new_page1, new_page2])
+        async def fake_new_page():
+            p = next(pages_iter)
+            inst.context.pages = inst.context.pages + [p]
+            return p
+
+        inst.context.new_page = fake_new_page
+
+        with patch.object(BrowserManager, "get_or_start", return_value=inst):
+            r1 = await mgr.open_tab("agent1", "https://example.org/a")
+            r2 = await mgr.open_tab("agent1", "https://example.org/b")
+
+        assert r1["success"] is True
+        assert r2["success"] is True
+        assert r1["data"]["page_id"] != r2["data"]["page_id"]
+        assert r2["data"]["tab_index"] == 2

--- a/tests/test_builtins.py
+++ b/tests/test_builtins.py
@@ -2393,6 +2393,117 @@ class TestBrowserDetectCaptchaHttpClient:
         assert "error" in result
 
 
+class TestBrowserFindTextHttpClient:
+    """browser_find_text sends find_text command through mesh_client."""
+
+    @pytest.mark.asyncio
+    async def test_find_text_calls_browser_command(self):
+        from src.agent.builtins.browser_tool import browser_find_text
+
+        mc = AsyncMock()
+        mc.browser_command = AsyncMock(return_value={
+            "success": True,
+            "data": {"matches": [], "total": 0, "truncated": False},
+        })
+
+        result = await browser_find_text(query="submit", mesh_client=mc)
+
+        mc.browser_command.assert_awaited_once_with(
+            "find_text", {"query": "submit", "scroll": True},
+        )
+        assert result["success"] is True
+
+    @pytest.mark.asyncio
+    async def test_find_text_passes_scroll_false(self):
+        from src.agent.builtins.browser_tool import browser_find_text
+
+        mc = AsyncMock()
+        mc.browser_command = AsyncMock(return_value={"success": True, "data": {}})
+
+        await browser_find_text(query="hi", scroll=False, mesh_client=mc)
+        mc.browser_command.assert_awaited_once_with(
+            "find_text", {"query": "hi", "scroll": False},
+        )
+
+    @pytest.mark.asyncio
+    async def test_find_text_empty_query_rejected(self):
+        from src.agent.builtins.browser_tool import browser_find_text
+
+        result = await browser_find_text(query="", mesh_client=AsyncMock())
+        assert "error" in result
+
+    @pytest.mark.asyncio
+    async def test_find_text_no_mesh_client(self):
+        from src.agent.builtins.browser_tool import browser_find_text
+
+        result = await browser_find_text(query="ok", mesh_client=None)
+        assert "error" in result
+
+
+class TestBrowserOpenTabHttpClient:
+    """browser_open_tab sends open_tab command through mesh_client."""
+
+    @pytest.mark.asyncio
+    async def test_open_tab_calls_browser_command(self):
+        from src.agent.builtins.browser_tool import browser_open_tab
+
+        mc = AsyncMock()
+        mc.browser_command = AsyncMock(return_value={
+            "success": True,
+            "data": {
+                "page_id": "p2-abc",
+                "tab_index": 1,
+                "url": "https://example.com/",
+                "title": "Example",
+            },
+        })
+
+        result = await browser_open_tab(url="https://example.com/", mesh_client=mc)
+
+        mc.browser_command.assert_awaited_once_with(
+            "open_tab",
+            {"url": "https://example.com/", "snapshot_after": False},
+        )
+        assert result["data"]["tab_index"] == 1
+
+    @pytest.mark.asyncio
+    async def test_open_tab_with_snapshot_after(self):
+        from src.agent.builtins.browser_tool import browser_open_tab
+
+        mc = AsyncMock()
+        mc.browser_command = AsyncMock(return_value={"success": True, "data": {}})
+
+        await browser_open_tab(
+            url="https://example.com/", snapshot_after=True, mesh_client=mc,
+        )
+        mc.browser_command.assert_awaited_once_with(
+            "open_tab",
+            {"url": "https://example.com/", "snapshot_after": True},
+        )
+
+    @pytest.mark.asyncio
+    async def test_open_tab_rejects_non_http_scheme(self):
+        from src.agent.builtins.browser_tool import browser_open_tab
+
+        for bad in ("file:///etc/passwd", "javascript:alert(1)", "data:text/html,x"):
+            result = await browser_open_tab(url=bad, mesh_client=AsyncMock())
+            assert "error" in result, bad
+
+    @pytest.mark.asyncio
+    async def test_open_tab_empty_url_rejected(self):
+        from src.agent.builtins.browser_tool import browser_open_tab
+
+        result = await browser_open_tab(url="", mesh_client=AsyncMock())
+        assert "error" in result
+
+    @pytest.mark.asyncio
+    async def test_open_tab_no_mesh_client(self):
+        from src.agent.builtins.browser_tool import browser_open_tab
+
+        result = await browser_open_tab(url="https://example.com/", mesh_client=None)
+        assert "error" in result
+
+
 class TestBrowserScrollHttpClient:
     """browser_scroll sends scroll command through mesh_client."""
 

--- a/tests/test_permissions.py
+++ b/tests/test_permissions.py
@@ -175,7 +175,8 @@ class TestCanBrowserAction:
         """browser_actions=None (default) → all known actions allowed."""
         for action in ("navigate", "click", "type", "screenshot", "scroll",
                        "focus", "status", "detect_captcha", "upload_file",
-                       "download", "fill_form", "solve_captcha"):
+                       "download", "find_text", "open_tab",
+                       "fill_form", "solve_captcha"):
             assert browser_matrix.can_browser_action("legacy-agent", action) is True, action
 
     def test_default_also_allows_future_actions(self, browser_matrix):
@@ -263,6 +264,13 @@ class TestKnownBrowserActionsSet:
         from src.host.permissions import KNOWN_BROWSER_ACTIONS
         assert "upload_file" in KNOWN_BROWSER_ACTIONS
         assert "download" in KNOWN_BROWSER_ACTIONS
+
+    def test_phase_5_find_text_and_open_tab_present(self):
+        """Phase 5 §8.5 / §8.6 default-allow actions registered with the
+        mesh input validator."""
+        from src.host.permissions import KNOWN_BROWSER_ACTIONS
+        assert "find_text" in KNOWN_BROWSER_ACTIONS
+        assert "open_tab" in KNOWN_BROWSER_ACTIONS
 
     def test_legacy_alias_still_exported(self):
         """Back-compat alias for callers that imported the old name."""


### PR DESCRIPTION
## Summary

Adds two default-allow browser actions per the Phase 5 roadmap (`docs/plans/2026-04-20-browser-automation.md`):

- **§8.5 `browser_find_text(query, scroll=true)`** — Unicode-aware case-insensitive search via `str.casefold()` over the live snapshot's accessible names. Returns up to 50 matches in snapshot order with `ref`, sanitized `text`, and `in_viewport` flag. Optionally scrolls the first match into view.
- **§8.6 `browser_open_tab(url, snapshot_after=false)`** — opens `url` in a new tab in the same browser context (cookies/storage shared) and makes it the active page. On goto failure the new page is closed and the previous active tab is restored.

Both actions are default-allow (read-only / nav-equivalent per §2.6) and added to `KNOWN_BROWSER_ACTIONS`. The mesh-side SSRF early-reject that already protects `navigate` is broadened to also cover `open_tab`; the browser container's iptables egress filter remains the authoritative SSRF control.

Match strings reaching the LLM are passed through `sanitize_for_prompt()` to neutralize zero-width / bidi-override smuggling.

## Test plan

- [x] `pytest tests/test_browser_service.py::TestFindText tests/test_browser_service.py::TestOpenTab tests/test_permissions.py::TestKnownBrowserActionsSet tests/test_permissions.py::TestCanBrowserAction tests/test_builtins.py::TestBrowserFindTextHttpClient tests/test_builtins.py::TestBrowserOpenTabHttpClient tests/test_browser_delegation.py::TestBrowserCommandSSRF -v` — 41/41 pass
- [x] `pytest tests/test_browser_service.py tests/test_permissions.py tests/test_builtins.py tests/test_browser_delegation.py` — 628/628 pass
- [x] `ruff check` clean on all touched source files
- [ ] CI green