### PR TITLE
Phase 5 §8.4: iframe traversal in walker + frame param on click/type/snapshot

### DIFF
--- a/src/agent/builtins/browser_tool.py
+++ b/src/agent/builtins/browser_tool.py
@@ -162,6 +162,27 @@ async def browser_navigate(
             ),
             "default": False,
         },
+        "frame": {
+            "type": "string",
+            "description": (
+                "Optional frame selector. Matched as a URL substring "
+                "against frame URLs, or as a frame_id token returned by "
+                "a prior snapshot. When set, the snapshot walks only "
+                "that frame instead of main-frame plus iframes."
+            ),
+        },
+        "include_frames": {
+            "type": "boolean",
+            "description": (
+                "When True (default) the snapshot descends into "
+                "same-origin iframes, emitting refs from inner frames "
+                "with their own frame_id. Set False to walk only the "
+                "main frame (or, with frame= set, only that frame) "
+                "without recursing — useful when iframe contents are "
+                "noise for the current task."
+            ),
+            "default": True,
+        },
     },
     parallel_safe=False,
 )
@@ -169,6 +190,8 @@ async def browser_get_elements(
     filter: str | None = None,
     from_ref: str | None = None,
     diff_from_last: bool = False,
+    frame: str | None = None,
+    include_frames: bool = True,
     *,
     mesh_client=None,
 ) -> dict:
@@ -180,6 +203,10 @@ async def browser_get_elements(
         payload["from_ref"] = from_ref
     if diff_from_last:
         payload["diff_from_last"] = True
+    if frame is not None:
+        payload["frame"] = frame
+    if not include_frames:
+        payload["include_frames"] = False
     return await _browser_command(mesh_client, "snapshot", payload)
 
 
@@ -377,12 +404,23 @@ async def browser_screenshot(
                 "'Post all'). Default 10000, max 30000."
             ),
         },
+        "frame": {
+            "type": "string",
+            "description": (
+                "Optional frame selector for selector-based clicks. "
+                "Matched as a URL substring against frame URLs, or as a "
+                "frame_id token from a prior snapshot. Refs from a "
+                "snapshot already carry their frame, so this argument is "
+                "redundant when ref is set and conflicts return an error."
+            ),
+        },
     },
     parallel_safe=False,
 )
 async def browser_click(
     selector: str = "", ref: str = "", force: bool = False,
     snapshot_after: bool = False, timeout_ms: int | None = None,
+    frame: str | None = None,
     *, mesh_client=None,
 ) -> dict:
     """Click an element by ref or CSS selector."""
@@ -392,6 +430,8 @@ async def browser_click(
            "snapshot_after": snapshot_after}
     if timeout_ms is not None:
         cmd["timeout_ms"] = timeout_ms
+    if frame is not None:
+        cmd["frame"] = frame
     return await _browser_command(mesh_client, "click", cmd)
 
 
@@ -447,12 +487,23 @@ async def browser_click(
             "description": "Include element snapshot in the response (default false)",
             "default": False,
         },
+        "frame": {
+            "type": "string",
+            "description": (
+                "Optional frame selector for selector-based typing. "
+                "Matched as a URL substring against frame URLs, or as a "
+                "frame_id token from a prior snapshot. Refs from a "
+                "snapshot already carry their frame, so this argument is "
+                "redundant when ref is set and conflicts return an error."
+            ),
+        },
     },
     parallel_safe=False,
 )
 async def browser_type(
     text: str, selector: str = "", ref: str = "", clear: bool = True,
-    fast: bool = False, snapshot_after: bool = False, *, mesh_client=None,
+    fast: bool = False, snapshot_after: bool = False,
+    frame: str | None = None, *, mesh_client=None,
 ) -> dict:
     """Type text into an element."""
     if not text:
@@ -460,11 +511,11 @@ async def browser_type(
     if not selector and not ref:
         return {"error": "Provide either 'ref' (from browser_get_elements) or 'selector' (CSS)"}
 
-    return await _browser_command(
-        mesh_client, "type",
-        {"ref": ref, "selector": selector, "text": text, "clear": clear,
-         "fast": fast, "snapshot_after": snapshot_after},
-    )
+    cmd = {"ref": ref, "selector": selector, "text": text, "clear": clear,
+           "fast": fast, "snapshot_after": snapshot_after}
+    if frame is not None:
+        cmd["frame"] = frame
+    return await _browser_command(mesh_client, "type", cmd)
 
 
 @skill(

--- a/src/browser/ref_handle.py
+++ b/src/browser/ref_handle.py
@@ -136,13 +136,23 @@ class RefHandle:
 
         Stable public surface — do not add fields here without updating
         ``browser_get_elements`` callers and the agent-tools documentation.
+
+        ``frame_id`` is exposed only when the ref came from inside an
+        iframe (main-frame refs keep the historical 4-key shape). The
+        ``browser_click`` / ``browser_type`` ``frame=`` parameter is
+        documented as accepting either a URL substring or a frame_id
+        token returned by snapshot, so the token MUST appear here for
+        duplicate or anonymous iframes that cannot be addressed by URL.
         """
-        return {
+        d: dict = {
             "role": self.role,
             "name": self.name,
             "index": self.occurrence,
             "disabled": self.disabled,
         }
+        if self.frame_id is not None:
+            d["frame_id"] = self.frame_id
+        return d
 
     # ── Factory helpers ─────────────────────────────────────────────────────
 

--- a/src/browser/server.py
+++ b/src/browser/server.py
@@ -168,11 +168,14 @@ def create_browser_app(manager: BrowserManager, lifespan=None) -> FastAPI:
             body = await request.json()
         except Exception:
             body = {}
+        body = body or {}
         return await manager.snapshot(
             agent_id,
-            filter=(body or {}).get("filter"),
-            from_ref=(body or {}).get("from_ref"),
-            diff_from_last=bool((body or {}).get("diff_from_last", False)),
+            filter=body.get("filter"),
+            from_ref=body.get("from_ref"),
+            diff_from_last=bool(body.get("diff_from_last", False)),
+            frame=body.get("frame"),
+            include_frames=bool(body.get("include_frames", True)),
         )
 
     @app.post("/browser/{agent_id}/click")
@@ -186,6 +189,7 @@ def create_browser_app(manager: BrowserManager, lifespan=None) -> FastAPI:
             force=body.get("force", False),
             snapshot_after=body.get("snapshot_after", False),
             timeout_ms=body.get("timeout_ms"),
+            frame=body.get("frame"),
         )
         await _apply_delay()
         return result
@@ -228,6 +232,7 @@ def create_browser_app(manager: BrowserManager, lifespan=None) -> FastAPI:
             clear=body.get("clear", True),
             fast=body.get("fast", False),
             snapshot_after=body.get("snapshot_after", False),
+            frame=body.get("frame"),
         )
         await _apply_delay()
         return result

--- a/src/browser/service.py
+++ b/src/browser/service.py
@@ -111,6 +111,13 @@ def _resolve_filter_roles(filter_name: str | None) -> frozenset[str] | None:
 _MAX_SNAPSHOT_ELEMENTS = 200
 _MAX_WALK_DEPTH = 50
 
+_MAX_FRAME_NESTING = 3
+
+# Token shape for frame_id values produced by `_register_frame`. Used
+# in `_resolve_frame_arg` to distinguish a detached/unknown frame_id
+# token (raise ref_stale) from a URL-substring miss (return None).
+_FRAME_ID_RE = re.compile(r"^f-[0-9a-f]{8}$")
+
 
 # §7.2 v2 format — depth indent is capped so a 50-deep DOM doesn't
 # explode into 100-character indents. Anything past this depth shares
@@ -187,7 +194,13 @@ def _format_snapshot_v2(
             # to a fake section header.
             safe_name = _v2_strip_newlines(name)
             safe_attr = _v2_strip_newlines(attr_str)
-            out.append(f"{indent}- [{ref_id}] {role} \"{safe_name}\"{safe_attr}")
+            # Iframe stubs (ref_id == "") are content nodes, not
+            # clickable handles — render without the ``[ref_id]``
+            # prefix so the v2 surface matches v1 (``- iframe "name"``).
+            if ref_id == "":
+                out.append(f"{indent}- {role} \"{safe_name}\"{safe_attr}")
+            else:
+                out.append(f"{indent}- [{ref_id}] {role} \"{safe_name}\"{safe_attr}")
 
     return "\n".join(out)
 
@@ -213,6 +226,23 @@ _BLOCKED_URL_SCHEMES = frozenset({
     "about", "moz-extension", "chrome-extension", "chrome",
 })
 _ALLOWED_URL_SCHEMES = frozenset({"http", "https"})
+
+
+def _err(code: str, message: str) -> dict:
+    """Standard error envelope for browser actions (§2.3).
+
+    Returns a structured ``{"success": False, "error": {"code", "message"}}``
+    payload so callers (mesh + agent skills) can branch on ``code`` rather
+    than substring-matching ``message``. Existing call sites that emit
+    ``{"success": False, "error": "..."}`` (string error) remain valid for
+    backward compatibility — this helper is for new structured-error paths.
+    """
+    return {
+        "success": False,
+        "error": {"code": code, "message": message},
+    }
+
+
 _MAX_WAIT_MS = 10000  # 10 seconds max wait after navigation
 _MAX_SCROLL_PX = 10000  # 10000 pixels max per scroll call
 _CLICK_TIMEOUT_MS = 10000  # 10 seconds — SPAs like X need time for animations/overlays
@@ -470,12 +500,59 @@ __NAME_HELPERS__
         }
         return true;
     }
+    function isCrossOriginFrame(el) {
+        try {
+            if (el.contentDocument === null) return true;
+        } catch (e) {
+            return true;
+        }
+        try {
+            const src = el.getAttribute('src') || '';
+            if (!src || src === 'about:blank') return false;
+            const u = new URL(src, window.location.href);
+            return u.origin !== window.location.origin;
+        } catch (e) {
+            return true;
+        }
+    }
     function walk(el, d, parentLandmark, shadowPath, currentRoot) {
         if (d > MAX_WALK_DEPTH || !el || el.nodeType !== 1) return null;
         const tag = el.tagName;
         if (tag === 'SCRIPT' || tag === 'STYLE' || tag === 'NOSCRIPT' || tag === 'TEMPLATE')
             return null;
         if (!isVisible(el)) return null;
+        if (tag === 'IFRAME' || tag === 'FRAME') {
+            const src = el.getAttribute('src') || '';
+            const title = (el.getAttribute('title') || '').trim();
+            const opaque = isCrossOriginFrame(el);
+            // srcdoc / anonymous iframes (no src, or src=about:blank)
+            // get an empty ``frame_url``; the Python descent uses
+            // ``iframe_index`` (sibling position among same-document
+            // iframes) as the descent key for those, and as a tie-
+            // breaker when two iframes legitimately share a URL.
+            let iframeIndex = -1;
+            try {
+                const allFrames = el.ownerDocument.querySelectorAll(
+                    'iframe, frame'
+                );
+                for (let i = 0; i < allFrames.length; i++) {
+                    if (allFrames[i] === el) { iframeIndex = i; break; }
+                }
+            } catch (e) {
+                // ownerDocument can be null in pathological cases — fall
+                // through with -1 so the Python side treats this as
+                // "no index hint available".
+            }
+            const stub = {
+                role: 'iframe',
+                name: opaque ? 'cross-origin' : (title || src).slice(0, 200),
+                frame_url: src,
+                opaque: opaque,
+                iframe_index: iframeIndex,
+            };
+            if (parentLandmark) stub.landmark = parentLandmark;
+            return stub;
+        }
         const role = getRole(el);
         let childLandmark = parentLandmark;
         if (role && LANDMARK.has(role)) {
@@ -1062,6 +1139,16 @@ class CamoufoxInstance:
         self.page_ids_inv: weakref.WeakValueDictionary = (
             weakref.WeakValueDictionary()
         )
+        # Per-Frame stable UUID maps. Frames navigate / detach as the page
+        # changes; WeakKey here so detached Frames drop out of the forward
+        # map automatically, and WeakValue on the reverse map so closed
+        # frames drop from resolution.
+        self.frame_ids: weakref.WeakKeyDictionary = (
+            weakref.WeakKeyDictionary()
+        )
+        self.frame_ids_inv: weakref.WeakValueDictionary = (
+            weakref.WeakValueDictionary()
+        )
         # Register the initial page so refs captured on it resolve correctly.
         self._register_page(page)
 
@@ -1146,6 +1233,21 @@ class CamoufoxInstance:
         if page is None:
             raise RefStale("tab closed or unknown page_id", ref=None)
         return page
+
+    def _register_frame(self, frame) -> str:
+        existing = self.frame_ids.get(frame)
+        if existing is not None:
+            return existing
+        new_id = f"f-{uuid.uuid4().hex[:8]}"
+        self.frame_ids[frame] = new_id
+        self.frame_ids_inv[new_id] = frame
+        return new_id
+
+    def _resolve_frame_id(self, frame_id: str):
+        frame = self.frame_ids_inv.get(frame_id)
+        if frame is None:
+            raise RefStale("frame_detached", ref=None)
+        return frame
 
     def seed_refs_legacy(self, legacy: "dict[str, dict]") -> None:
         """Test helper: build ``RefHandle`` entries from v1-shape dicts.
@@ -2239,6 +2341,8 @@ class BrowserManager:
         filter: str | None = None,
         from_ref: str | None = None,
         diff_from_last: bool = False,
+        frame: str | None = None,
+        include_frames: bool = True,
     ) -> dict:
         """Get accessibility tree with element refs.
 
@@ -2294,6 +2398,8 @@ class BrowserManager:
                 filter=filter,
                 from_ref=from_ref,
                 diff_from_last=diff_from_last,
+                frame=frame,
+                include_frames=include_frames,
             )
 
     async def _snapshot_impl(
@@ -2304,6 +2410,8 @@ class BrowserManager:
         from_ref: str | None = None,
         diff_from_last: bool = False,
         _skip_baseline: bool = False,
+        frame: str | None = None,
+        include_frames: bool = True,
     ) -> dict:
         """Snapshot implementation.  Caller must hold ``inst.lock``."""
         # Resolve the optional filter once so the inner _walk sees a
@@ -2320,6 +2428,42 @@ class BrowserManager:
                 },
             }
         try:
+            if frame is not None and from_ref is not None:
+                return {
+                    "success": False,
+                    "error": {
+                        "code": "invalid_input",
+                        "message": (
+                            "frame and from_ref are mutually exclusive"
+                        ),
+                        "retry_after_ms": None,
+                    },
+                }
+            target_frame = None
+            if frame is not None:
+                try:
+                    target_frame = self._resolve_frame_arg(inst, frame)
+                except RefStale as rs:
+                    return {
+                        "success": False,
+                        "error": {
+                            "code": "ref_stale",
+                            "message": str(rs),
+                            "retry_after_ms": None,
+                        },
+                    }
+                if target_frame is None:
+                    return {
+                        "success": False,
+                        "error": {
+                            "code": "not_found",
+                            "message": (
+                                f"frame {frame!r} did not match any frame "
+                                "url-substring or frame_id"
+                            ),
+                            "retry_after_ms": None,
+                        },
+                    }
             # ── Optional scoped root via ``from_ref`` (§7.4) ────────────────
             scoped_root_handle = None
             if from_ref is not None:
@@ -2387,7 +2531,19 @@ class BrowserManager:
                         },
                     }
 
-            tree = await self._build_a11y_tree(inst, root=scoped_root_handle)
+            if target_frame is not None and scoped_root_handle is None:
+                try:
+                    tree = await target_frame.evaluate(_JS_A11Y_TREE)
+                except Exception as exc:
+                    logger.debug(
+                        "Frame snapshot evaluate failed for %s: %s",
+                        agent_id, exc,
+                    )
+                    tree = None
+            else:
+                tree = await self._build_a11y_tree(
+                    inst, root=scoped_root_handle,
+                )
             if not tree:
                 return {"success": True, "data": {"snapshot": "(empty page)", "refs": {}}}
 
@@ -2398,6 +2554,11 @@ class BrowserManager:
             # refs still carry their original page_id so resolution targets
             # the right tab (or raises RefStale if the tab is closed).
             snapshot_page_id = inst._page_id_for(inst.page)
+            target_frame_id = (
+                inst._register_frame(target_frame)
+                if target_frame is not None
+                else None
+            )
             ref_counter = [0]
             # Counts occurrences of each (role, name) pair so we can
             # disambiguate duplicate elements (e.g. X's two composer nodes).
@@ -2413,11 +2574,69 @@ class BrowserManager:
             # element_key so changed-state detection can compare values.
             ref_summary: dict[str, dict] = {}
 
-            def _walk(node, depth=0):
+            pending_frames: list[tuple] = []
+
+            def _walk(node, depth=0, current_frame_id=None, frame_nesting=0):
                 if depth > _MAX_WALK_DEPTH:
                     return
                 role = node.get("role", "")
                 name = node.get("name", "")
+                if role == "iframe":
+                    # Stub name is title || src — long URLs in srcs are
+                    # common; cap so a single iframe doesn't blow up the
+                    # snapshot byte count.
+                    if name:
+                        name = name[:200]
+                    frame_url = node.get("frame_url", "")
+                    is_opaque = bool(node.get("opaque"))
+                    iframe_index = node.get("iframe_index", -1)
+                    landmark = node.get("landmark", "")
+                    ctx_str = f" ({landmark})" if landmark else ""
+                    suffix = " [cross-origin]" if is_opaque else ""
+                    # ``frame_nesting`` here is the iframe-level of the
+                    # CURRENT walking frame (0 = main). The stub being
+                    # emitted is one level deeper, so descent would only
+                    # succeed if ``frame_nesting + 1 <= _MAX_FRAME_NESTING``.
+                    # When that fails we still emit the stub (so the agent
+                    # sees the iframe exists) but tag it ``[depth-capped]``
+                    # so the agent doesn't waste a turn fishing for refs
+                    # that will never appear.
+                    is_depth_capped = (
+                        not is_opaque
+                        and include_frames
+                        and frame_nesting + 1 > _MAX_FRAME_NESTING
+                    )
+                    cap_suffix = " [depth-capped]" if is_depth_capped else ""
+                    line = (
+                        f"{'  ' * depth}- iframe \"{name}\""
+                        f"{suffix}{cap_suffix}{ctx_str}"
+                    )
+                    lines.append(line)
+                    # §7.2 v2 also needs to see iframe stubs — they were
+                    # previously lines-only, which made them invisible
+                    # under the v2 renderer. Emit a synthetic entry with
+                    # an empty ref_id; ``_format_snapshot_v2`` renders
+                    # iframe entries without the ``[ref_id]`` prefix to
+                    # match the v1 wire shape (iframe stubs are not
+                    # clickable handles).
+                    # Preserve leading-space convention for v2 attr_str:
+                    # ``suffix``/``cap_suffix`` already start with a space
+                    # (e.g. ``" [cross-origin]"``), so concatenation gives
+                    # ``" [cross-origin] [depth-capped]"`` when both apply.
+                    iframe_attr = f"{suffix}{cap_suffix}"
+                    entries.append(
+                        ("", "iframe", name, iframe_attr, landmark, depth),
+                    )
+                    # Descend into same-origin iframes regardless of
+                    # ``frame_url`` truthiness — srcdoc / about:blank
+                    # iframes legitimately emit ``frame_url=""`` and
+                    # must still be traversed via ``iframe_index``.
+                    if not is_opaque and include_frames:
+                        idx = iframe_index if isinstance(iframe_index, int) else -1
+                        pending_frames.append(
+                            (frame_url, depth, current_frame_id, idx),
+                        )
+                    return
                 # ``allowed_roles=None`` means "use the historical default"
                 # (actionable ∪ context). Any explicit filter shrinks that.
                 if allowed_roles is None:
@@ -2504,7 +2723,7 @@ class BrowserManager:
                         elem_key = compute_element_key(
                             role=role, name=name, landmark=landmark,
                             sibling_index=occ,
-                            frame_id=None,
+                            frame_id=current_frame_id,
                             shadow_path=shadow_hops,
                         )
                         # scope_root is finalized after the modal-scoping
@@ -2516,6 +2735,19 @@ class BrowserManager:
                                 page_id=snapshot_page_id,
                                 scope_root=None,
                                 shadow_path=shadow_hops,
+                                role=role,
+                                name=name,
+                                occurrence=occ,
+                                disabled=bool(node.get("disabled")),
+                                element_key=elem_key,
+                                frame_id=current_frame_id,
+                            )
+                        elif current_frame_id is not None:
+                            refs[ref_id] = RefHandle(
+                                page_id=snapshot_page_id,
+                                frame_id=current_frame_id,
+                                shadow_path=(),
+                                scope_root=None,
                                 role=role,
                                 name=name,
                                 occurrence=occ,
@@ -2557,7 +2789,174 @@ class BrowserManager:
                             "checked": node.get("checked"),
                         }
                 for child in node.get("children", []):
-                    _walk(child, depth + 1)
+                    _walk(child, depth + 1, current_frame_id, frame_nesting)
+
+            async def _descend_frames(parent_frame, parent_frame_id,
+                                      frame_nesting):
+                # ``_MAX_FRAME_NESTING`` counts iframe levels beyond the
+                # main frame. With cap=3: main(0) + L1 + L2 + L3 are
+                # admitted; an L4 stub triggers this guard. The plan
+                # §8.4 phrasing "Nesting cap: 3 levels" refers to these
+                # iframe-only levels — main is treated as the host
+                # surface and not counted.
+                if frame_nesting >= _MAX_FRAME_NESTING:
+                    capped = [
+                        e for e in pending_frames if e[2] == parent_frame_id
+                    ]
+                    if capped:
+                        # The corresponding stub lines were emitted by
+                        # ``_walk`` already with a ``[depth-capped]`` tag
+                        # so the agent can see them. Log the count so an
+                        # operator chasing "where did the deep iframe go?"
+                        # has a single grep target.
+                        try:
+                            parent_url = parent_frame.url
+                        except Exception:
+                            parent_url = "<unknown>"
+                        logger.debug(
+                            "iframe depth cap reached at %s; %d nested "
+                            "frame(s) not descended",
+                            parent_url, len(capped),
+                        )
+                    pending_frames[:] = [
+                        e for e in pending_frames
+                        if e[2] != parent_frame_id
+                    ]
+                    return
+                drained = [
+                    e for e in pending_frames if e[2] == parent_frame_id
+                ]
+                pending_frames[:] = [
+                    e for e in pending_frames if e[2] != parent_frame_id
+                ]
+                # Track per-parent-frame consumed children so two stubs
+                # that share a URL (e.g. duplicate ad iframes from one
+                # provider, or two srcdoc iframes that emit empty
+                # ``frame_url``) descend into DISTINCT child frames
+                # instead of both matching the first hit. Keyed by
+                # ``id(frame)`` because Playwright Frame objects aren't
+                # hashable in all binding versions.
+                consumed_child_ids: set[int] = set()
+                try:
+                    children_frames = list(parent_frame.child_frames)
+                except Exception:
+                    children_frames = []
+                # Filter to frames whose underlying iframe element is still
+                # attached. Playwright may briefly retain ``Frame`` objects
+                # whose ``<iframe>`` was just removed (GC lag); the JS
+                # walker counts only LIVE iframes via
+                # ``ownerDocument.querySelectorAll``, so its
+                # ``iframe_index`` is positional over live frames only. If
+                # we let detached frames stay in ``children_frames``, the
+                # index-based fallback below would target the wrong slot.
+                live_children: list = []
+                for cf in children_frames:
+                    try:
+                        if hasattr(cf, "is_detached") and cf.is_detached():
+                            continue
+                    except Exception:
+                        # ``is_detached()`` itself may raise on torn-down
+                        # bindings — fall through and trust the URL match
+                        # tiers below to handle it.
+                        pass
+                    live_children.append(cf)
+                for stub_url, stub_depth, _stub_parent_id, stub_index in drained:
+                    target_child = None
+                    # Phase 1: prefer exact URL match against an unconsumed
+                    # child. Falls through to substring + iframe_index
+                    # tiers so stubs whose ``frame_url`` was a partial
+                    # match (or empty for srcdoc) still resolve.
+                    if stub_url:
+                        for cf in live_children:
+                            if id(cf) in consumed_child_ids:
+                                continue
+                            try:
+                                cf_url = cf.url or ""
+                            except Exception:
+                                cf_url = ""
+                            if cf_url == stub_url:
+                                target_child = cf
+                                break
+                        if target_child is None:
+                            for cf in live_children:
+                                if id(cf) in consumed_child_ids:
+                                    continue
+                                try:
+                                    cf_url = cf.url or ""
+                                except Exception:
+                                    cf_url = ""
+                                if stub_url in cf_url:
+                                    target_child = cf
+                                    break
+                        if target_child is None:
+                            # Walker emitted ``frame_url=src`` from the
+                            # iframe ATTRIBUTE; by the time descent runs,
+                            # an in-page navigation may have changed
+                            # ``frame.url``. Falls through to the index
+                            # tier below — log so debugging walks aren't
+                            # blind to this race.
+                            try:
+                                live_urls = [c.url for c in live_children]
+                            except Exception:
+                                live_urls = []
+                            logger.debug(
+                                "Frame URL changed during snapshot for "
+                                "%s: stub_url=%r, live child urls=%r",
+                                agent_id, stub_url, live_urls,
+                            )
+                    if target_child is None:
+                        # Empty frame_url (srcdoc / about:blank-style
+                        # anonymous iframe) or no URL match: fall back
+                        # to the JS-emitted sibling index. The walker
+                        # tags every iframe stub with its position
+                        # among the parent document's iframes so two
+                        # same-URL or empty-URL siblings are still
+                        # individually addressable. Index is positional
+                        # over LIVE iframes (matching the walker's
+                        # ``ownerDocument.querySelectorAll`` count), so
+                        # we index into ``live_children`` not
+                        # ``children_frames``.
+                        if (
+                            stub_index is not None
+                            and 0 <= stub_index < len(live_children)
+                            and id(live_children[stub_index])
+                            not in consumed_child_ids
+                        ):
+                            target_child = live_children[stub_index]
+                    if target_child is None and len(live_children) == 1 and not consumed_child_ids:
+                        # Last-resort single-child fallback preserves
+                        # behavior on pages where the JS walker emitted
+                        # neither URL nor index (e.g. legacy stubs from
+                        # tests written before iframe_index existed).
+                        target_child = live_children[0]
+                    if target_child is None:
+                        continue
+                    consumed_child_ids.add(id(target_child))
+                    child_frame_id = inst._register_frame(target_child)
+                    try:
+                        # Cross-origin classification (``isCrossOriginFrame``
+                        # in ``_JS_A11Y_TREE``) runs within each frame's
+                        # OWN context, so a grandchild iframe's ``opaque``
+                        # bit reflects ITS origin vs its parent's, not vs
+                        # the main frame's. Spec-correct (Firefox SOP),
+                        # but means a grandchild whose origin matches main
+                        # may still be classified opaque if its parent is
+                        # on a different origin.
+                        sub_tree = await target_child.evaluate(_JS_A11Y_TREE)
+                    except Exception as exc:
+                        logger.debug(
+                            "Frame walk failed for %s: %s", agent_id, exc,
+                        )
+                        continue
+                    if not sub_tree:
+                        continue
+                    _walk(
+                        sub_tree, stub_depth + 1, child_frame_id,
+                        frame_nesting + 1,
+                    )
+                    await _descend_frames(
+                        target_child, child_frame_id, frame_nesting + 1,
+                    )
 
             # When ``from_ref`` is set the caller is asking for a deep
             # scope into a specific element; modal-detection would
@@ -2574,7 +2973,8 @@ class BrowserManager:
                 # refs taken inside a modal still resolve through the
                 # modal selector.
                 was_modal = bool(inst.dialog_active)
-                _walk(tree)
+                _walk(tree, 0, target_frame_id)
+                pending_frames.clear()
                 # If the agent took this scoped snapshot while a modal
                 # was open, patch ``scope_root`` on every emitted ref so
                 # ``_locator_from_ref`` keeps clicks bounded to the dialog
@@ -2662,7 +3062,10 @@ class BrowserManager:
                 for el in visible_modals:
                     subtree = await self._build_a11y_tree(inst, root=el)
                     if subtree:
-                        _walk(subtree)
+                        _walk(subtree, 0, target_frame_id)
+                # Modals are typically light-DOM in the main frame; iframe
+                # descent skipped for scoping fidelity.
+                pending_frames.clear()
                 actionable_refs = [
                     r for r in refs.values() if r.role in _ACTIONABLE_ROLES
                 ]
@@ -2706,9 +3109,12 @@ class BrowserManager:
                         try:
                             subtree = await self._build_a11y_tree(inst, root=el)
                             if subtree:
-                                _walk(subtree)
+                                _walk(subtree, 0, target_frame_id)
                         except Exception:
                             pass
+                    # Modals are typically light-DOM in the main frame;
+                    # iframe descent skipped for scoping fidelity.
+                    pending_frames.clear()
                     actionable_refs = [
                         r for r in refs.values() if r.role in _ACTIONABLE_ROLES
                     ]
@@ -2738,11 +3144,41 @@ class BrowserManager:
                         "or similar landmark annotation are in the modal; "
                         "others are behind the overlay **"
                     )
-                    _walk(tree)
+                    _walk(tree, 0, target_frame_id)
+                    if include_frames:
+                        if target_frame is None:
+                            await _descend_frames(
+                                inst.page.main_frame, None, 0,
+                            )
+                        else:
+                            # frame=X with nested same-origin frames inside
+                            # X: descend so refs from inner frames carry
+                            # their own frame_id. Nesting cap is relative
+                            # to the target — start at depth 0.
+                            await _descend_frames(
+                                target_frame, target_frame_id, 0,
+                            )
+                    else:
+                        pending_frames.clear()
             else:
                 inst.dialog_active = False
                 inst.dialog_detected = False
-                _walk(tree)
+                _walk(tree, 0, target_frame_id)
+                if include_frames:
+                    if target_frame is None:
+                        await _descend_frames(
+                            inst.page.main_frame, None, 0,
+                        )
+                    else:
+                        # frame=X with nested same-origin frames inside X:
+                        # descend so refs from inner frames carry their
+                        # own frame_id. Nesting cap is relative to the
+                        # target — start at depth 0.
+                        await _descend_frames(
+                            target_frame, target_frame_id, 0,
+                        )
+                else:
+                    pending_frames.clear()
 
             # Patch scope_root on refs captured during modal scoping so
             # `_locator_from_ref` queries are bounded to the dialog subtree.
@@ -2915,10 +3351,17 @@ class BrowserManager:
             return None
         page = inst._resolve_page_id(handle.page_id)
         if handle.shadow_path:
+            # NOTE: shadow + iframe combination raises NotImplementedError
+            # inside ``_resolve_shadow_element``; callers (click/type/etc)
+            # catch it and surface a ``not_supported`` envelope.
             return await self._resolve_shadow_element(page, handle, ref)
-        base = page
+        if handle.frame_id is not None:
+            frame = inst._resolve_frame_id(handle.frame_id)
+            base = frame
+        else:
+            base = page
         if handle.scope_root:
-            base = page.locator(handle.scope_root)
+            base = base.locator(handle.scope_root)
         if handle.name:
             locator = base.get_by_role(handle.role, name=handle.name, exact=True)
         else:
@@ -3055,6 +3498,41 @@ class BrowserManager:
                 await stage1.dispose()
             except Exception:
                 pass
+
+    def _resolve_frame_arg(self, inst: CamoufoxInstance, frame_arg: str):
+        if not isinstance(frame_arg, str) or not frame_arg.strip():
+            return None
+        token = frame_arg.strip()
+        direct = inst.frame_ids_inv.get(token)
+        if direct is not None:
+            return direct
+        # Frame-id-shaped tokens that miss the inverse map signal a
+        # detached frame, not a URL substring miss. Surfacing as
+        # RefStale lets callers re-snapshot rather than chase a
+        # non-existent URL substring.
+        if _FRAME_ID_RE.match(token):
+            raise RefStale("frame_detached", ref=None)
+        page = inst.page
+        exact = None
+        substring = None
+        # When two frames share the same URL exactly, the FIRST matching
+        # one wins (page.frames iteration order). Callers needing to
+        # disambiguate duplicate-URL siblings should use the frame_id
+        # token from ``RefHandle.to_agent_dict()`` instead of a URL
+        # substring.
+        for f in page.frames:
+            if f is page.main_frame:
+                continue
+            try:
+                url = f.url or ""
+            except Exception:
+                continue
+            if url == token:
+                exact = f
+                break
+            if substring is None and token in url:
+                substring = f
+        return exact if exact is not None else substring
 
     async def _human_click(self, page, locator, *, force: bool = False,
                            timeout: int = _CLICK_TIMEOUT_MS) -> None:
@@ -3566,6 +4044,7 @@ class BrowserManager:
         selector: str | None = None, force: bool = False,
         snapshot_after: bool = False,
         timeout_ms: int | None = None,
+        frame: str | None = None,
     ) -> dict:
         """Click element by ref or CSS selector.
 
@@ -3591,8 +4070,48 @@ class BrowserManager:
                 raw_timeout = _CLICK_TIMEOUT_MS if timeout_ms is None else timeout_ms
                 _timeout = max(1000, min(raw_timeout, 30000))
                 use_force = force
+                resolved_frame = None
+                if frame is not None:
+                    try:
+                        resolved_frame = self._resolve_frame_arg(inst, frame)
+                    except RefStale as rs:
+                        return {
+                            "success": False,
+                            "error": {
+                                "code": "ref_stale",
+                                "message": str(rs),
+                            },
+                        }
+                    if resolved_frame is None:
+                        return {
+                            "success": False,
+                            "error": (
+                                f"frame {frame!r} did not match any frame "
+                                "url-substring or frame_id"
+                            ),
+                        }
                 if ref and ref in inst.refs:
                     ref_info = inst.refs[ref]
+                    if frame is not None:
+                        resolved_frame_id = (
+                            inst._register_frame(resolved_frame)
+                            if resolved_frame is not None else None
+                        )
+                        # Caller asserted a specific frame; ref must agree.
+                        # Fires on main-frame refs (frame_id=None) too — a
+                        # frame= arg with a main-frame ref is a bug, not a
+                        # silently-ignored hint.
+                        if ref_info.frame_id != resolved_frame_id:
+                            return {
+                                "success": False,
+                                "error": {
+                                    "code": "invalid_input",
+                                    "message": (
+                                        "frame argument conflicts with "
+                                        "ref's frame"
+                                    ),
+                                },
+                            }
                     # Auto-force for disabled button/link roles — aria-disabled
                     # on SPA buttons doesn't mean the JS click handler won't fire.
                     # BUT: when a modal was detected and scoping failed
@@ -3610,7 +4129,16 @@ class BrowserManager:
                             "Auto-force click on disabled %s ref=%s for '%s'",
                             ref_info.role, ref, agent_id,
                         )
-                    locator = await self._locator_from_ref(inst, ref)
+                    try:
+                        locator = await self._locator_from_ref(inst, ref)
+                    except RefStale as rs:
+                        return {
+                            "success": False,
+                            "error": {
+                                "code": "ref_stale",
+                                "message": str(rs),
+                            },
+                        }
                     if locator:
                         if inst.x11_wid and self._is_x11_site(inst):
                             try:
@@ -3626,7 +4154,20 @@ class BrowserManager:
                     else:
                         return {"success": False, "error": f"Ref '{ref}' not found"}
                 elif selector:
-                    if inst.x11_wid and self._is_x11_site(inst):
+                    if resolved_frame is not None:
+                        # X11 click path requires page-level coordinates;
+                        # iframe-scoped selectors resolve through
+                        # Playwright's frame locator only. Anti-bot benefit
+                        # of the X11 path is lost for iframe clicks —
+                        # accepted tradeoff.
+                        loc = resolved_frame.locator(selector).first
+                        try:
+                            await self._human_click(
+                                inst.page, loc, force=force, timeout=_timeout,
+                            )
+                        except Exception as e:
+                            return {"success": False, "error": str(e)}
+                    elif inst.x11_wid and self._is_x11_site(inst):
                         loc = inst.page.locator(selector).first
                         try:
                             await self._x11_click(inst, loc, timeout=_timeout)
@@ -3725,6 +4266,20 @@ class BrowserManager:
                     snap = await self._snapshot_impl(inst, agent_id)
                     result["snapshot"] = snap.get("data", {})
                 return result
+            except NotImplementedError as e:
+                # Defensive: when PR2 (shadow DOM) merges, refs carrying
+                # both ``shadow_path`` and ``frame_id`` will hit the
+                # ``Shadow + iframe combination not yet supported`` guard
+                # in ``_resolve_shadow_element``. Wrap as a structured
+                # ``not_supported`` envelope so the agent sees a typed
+                # error rather than a 500 from the generic catch-all.
+                inst.m_click_fail += 1
+                inst.click_window.append(False)
+                inst.recorder.record_click(method="auto", success=False)
+                return _err(
+                    "not_supported",
+                    str(e) or "Action not supported on this ref type",
+                )
             except Exception as e:
                 inst.m_click_fail += 1
                 inst.click_window.append(False)
@@ -3777,12 +4332,20 @@ class BrowserManager:
                     return {"success": False, "error": "Must provide ref or selector"}
                 await asyncio.sleep(action_delay())
                 return {"success": True, "data": {"hovered": ref or selector}}
+            except NotImplementedError as e:
+                # See click() for rationale — pre-emptive catch for PR2's
+                # shadow+iframe combination guard.
+                return _err(
+                    "not_supported",
+                    str(e) or "Action not supported on this ref type",
+                )
             except Exception as e:
                 return {"success": False, "error": str(e)}
 
     async def type_text(self, agent_id: str, ref: str | None = None, selector: str | None = None,
                         text: str = "", clear: bool = True,
-                        fast: bool = False, snapshot_after: bool = False) -> dict:
+                        fast: bool = False, snapshot_after: bool = False,
+                        frame: str | None = None) -> dict:
         """Type text into element.
 
         fast=True uses minimal inter-key delays (8 ms) — still fires real
@@ -3810,8 +4373,59 @@ class BrowserManager:
                 # CDP+X11 sequences create a detectable signal.
                 _use_x11 = bool(inst.x11_wid) and self._is_x11_site(inst)
 
+                resolved_frame = None
+                if frame is not None:
+                    try:
+                        resolved_frame = self._resolve_frame_arg(inst, frame)
+                    except RefStale as rs:
+                        return {
+                            "success": False,
+                            "error": {
+                                "code": "ref_stale",
+                                "message": str(rs),
+                            },
+                        }
+                    if resolved_frame is None:
+                        return {
+                            "success": False,
+                            "error": (
+                                f"frame {frame!r} did not match any frame "
+                                "url-substring or frame_id"
+                            ),
+                        }
+
                 if ref and ref in inst.refs:
-                    locator = await self._locator_from_ref(inst, ref)
+                    if frame is not None:
+                        ref_info = inst.refs[ref]
+                        resolved_frame_id = (
+                            inst._register_frame(resolved_frame)
+                            if resolved_frame is not None else None
+                        )
+                        # Caller asserted a specific frame; ref must agree.
+                        # Fires on main-frame refs (frame_id=None) too — a
+                        # frame= arg with a main-frame ref is a bug, not a
+                        # silently-ignored hint.
+                        if ref_info.frame_id != resolved_frame_id:
+                            return {
+                                "success": False,
+                                "error": {
+                                    "code": "invalid_input",
+                                    "message": (
+                                        "frame argument conflicts with "
+                                        "ref's frame"
+                                    ),
+                                },
+                            }
+                    try:
+                        locator = await self._locator_from_ref(inst, ref)
+                    except RefStale as rs:
+                        return {
+                            "success": False,
+                            "error": {
+                                "code": "ref_stale",
+                                "message": str(rs),
+                            },
+                        }
                     if not locator:
                         return {"success": False, "error": f"Ref '{ref}' not found"}
                     if _use_x11:
@@ -3826,7 +4440,18 @@ class BrowserManager:
                     else:
                         await self._human_click(inst.page, locator)
                 elif selector:
-                    if _use_x11:
+                    if resolved_frame is not None:
+                        # X11 click path requires page-level coordinates;
+                        # iframe-scoped selectors resolve through
+                        # Playwright's frame locator only. Anti-bot benefit
+                        # of the X11 path is lost for iframe focus-clicks —
+                        # accepted tradeoff.
+                        loc = resolved_frame.locator(selector).first
+                        try:
+                            await self._human_click(inst.page, loc)
+                        except Exception as e:
+                            return {"success": False, "error": str(e)}
+                    elif _use_x11:
                         loc = inst.page.locator(selector).first
                         try:
                             await self._x11_click(inst, loc)
@@ -3880,6 +4505,13 @@ class BrowserManager:
                     snap = await self._snapshot_impl(inst, agent_id)
                     result["snapshot"] = snap.get("data", {})
                 return result
+            except NotImplementedError as e:
+                # See click() for rationale — pre-emptive catch for PR2's
+                # shadow+iframe combination guard.
+                return _err(
+                    "not_supported",
+                    str(e) or "Action not supported on this ref type",
+                )
             except Exception as e:
                 return {"success": False, "error": str(e)}
 
@@ -4146,6 +4778,15 @@ class BrowserManager:
                     "success": True,
                     "data": {"direction": direction, "pixels": scrolled},
                 }
+            except NotImplementedError as e:
+                # See click() for rationale — pre-emptive catch for PR2's
+                # shadow+iframe combination guard. ``scroll(ref=...)``
+                # routes through ``_locator_from_ref`` which is the path
+                # that will raise once shadow_path resolution lands.
+                return _err(
+                    "not_supported",
+                    str(e) or "Action not supported on this ref type",
+                )
             except Exception as e:
                 return {"success": False, "error": str(e)}
 

--- a/tests/test_browser_service.py
+++ b/tests/test_browser_service.py
@@ -3452,6 +3452,7 @@ class TestNavigateBodyCap:
         a11y_tree = self._make_long_a11y(4000)
         mock_page.accessibility = AsyncMock()
         mock_page.accessibility.snapshot = AsyncMock(return_value=a11y_tree)
+        mock_page.evaluate = mock_page.accessibility.snapshot
         # query_selector_all + evaluate are used by the snapshot path
         mock_page.query_selector_all = AsyncMock(return_value=[])
         mock_page.evaluate = AsyncMock(return_value={
@@ -7601,6 +7602,7 @@ class TestFindText:
         mock_page.viewport_size = {"width": 1280, "height": 720}
         mock_page.accessibility = MagicMock()
         mock_page.accessibility.snapshot = AsyncMock(return_value=tree_v1)
+        mock_page.evaluate = mock_page.accessibility.snapshot
         mock_page.evaluate = AsyncMock(return_value=tree_v1)
         inst = CamoufoxInstance("agent1", MagicMock(), MagicMock(), mock_page)
         mgr._instances["agent1"] = inst
@@ -7619,6 +7621,7 @@ class TestFindText:
             ],
         }
         mock_page.accessibility.snapshot = AsyncMock(return_value=tree_v2)
+        mock_page.evaluate = mock_page.accessibility.snapshot
         mock_page.evaluate = AsyncMock(return_value=tree_v2)
 
         mock_locator = AsyncMock()
@@ -9132,3 +9135,1267 @@ class TestShadowDOM:
             await mgr._locator_from_ref(inst, "e0")
         # Stage-1 was never invoked.
         mock_page.evaluate_handle.assert_not_called()
+
+
+def _make_frame(url, tree, *, detached: bool = False):
+    f = MagicMock()
+    f.url = url
+    f.evaluate = AsyncMock(return_value=tree)
+    f.child_frames = []
+    f.locator = MagicMock()
+    f.is_detached = MagicMock(return_value=detached)
+    return f
+
+
+def _attach_main_frame(mock_page, child_frames):
+    main_frame = MagicMock()
+    main_frame.child_frames = child_frames
+    mock_page.main_frame = main_frame
+    return main_frame
+
+
+class TestIframeTraversal:
+    """Tests for §8.4 iframe traversal in walker + click/type/snapshot."""
+
+    @pytest.mark.asyncio
+    async def test_same_origin_iframe_emits_refs_with_frame_id(self):
+        from src.browser.service import BrowserManager, CamoufoxInstance
+        mgr = BrowserManager(profiles_dir="/tmp/test_profiles")
+
+        mock_page = AsyncMock()
+        mock_page.url = "https://example.com/"
+        mock_page.viewport_size = {"width": 1024, "height": 768}
+        mock_page.query_selector_all = AsyncMock(return_value=[])
+        main_tree = {
+            "role": "WebArea",
+            "name": "outer",
+            "children": [
+                {"role": "button", "name": "Outer"},
+                {
+                    "role": "iframe",
+                    "name": "inner",
+                    "frame_url": "https://example.com/iframe.html",
+                    "opaque": False,
+                },
+            ],
+        }
+        mock_page.accessibility = MagicMock()
+        mock_page.accessibility.snapshot = AsyncMock(return_value=main_tree)
+        mock_page.evaluate = mock_page.accessibility.snapshot
+
+        inner_tree = {
+            "role": "WebArea",
+            "name": "inner",
+            "children": [
+                {"role": "button", "name": "InnerSubmit"},
+            ],
+        }
+        child = _make_frame("https://example.com/iframe.html", inner_tree)
+        _attach_main_frame(mock_page, [child])
+
+        inst = CamoufoxInstance("a1", MagicMock(), MagicMock(), mock_page)
+        mgr._instances["a1"] = inst
+
+        result = await mgr.snapshot("a1")
+        assert result["success"] is True
+        refs = result["data"]["refs"]
+        assert refs["e0"]["role"] == "button"
+        assert refs["e0"]["name"] == "Outer"
+        assert inst.refs["e0"].frame_id is None
+        assert refs["e1"]["role"] == "button"
+        assert refs["e1"]["name"] == "InnerSubmit"
+        assert inst.refs["e1"].frame_id is not None
+        assert inst.refs["e1"].frame_id in inst.frame_ids_inv
+        assert "iframe" in result["data"]["snapshot"]
+
+    @pytest.mark.asyncio
+    async def test_two_iframes_get_different_frame_ids(self):
+        from src.browser.service import BrowserManager, CamoufoxInstance
+        mgr = BrowserManager(profiles_dir="/tmp/test_profiles")
+
+        mock_page = AsyncMock()
+        mock_page.url = "https://example.com/"
+        mock_page.viewport_size = {"width": 1024, "height": 768}
+        mock_page.query_selector_all = AsyncMock(return_value=[])
+        main_tree = {
+            "role": "WebArea",
+            "name": "outer",
+            "children": [
+                {
+                    "role": "iframe",
+                    "name": "a",
+                    "frame_url": "https://example.com/a.html",
+                    "opaque": False,
+                },
+                {
+                    "role": "iframe",
+                    "name": "b",
+                    "frame_url": "https://example.com/b.html",
+                    "opaque": False,
+                },
+            ],
+        }
+        mock_page.accessibility = MagicMock()
+        mock_page.accessibility.snapshot = AsyncMock(return_value=main_tree)
+        mock_page.evaluate = mock_page.accessibility.snapshot
+
+        tree_a = {
+            "role": "WebArea", "name": "a",
+            "children": [{"role": "button", "name": "AAA"}],
+        }
+        tree_b = {
+            "role": "WebArea", "name": "b",
+            "children": [{"role": "button", "name": "BBB"}],
+        }
+        child_a = _make_frame("https://example.com/a.html", tree_a)
+        child_b = _make_frame("https://example.com/b.html", tree_b)
+        _attach_main_frame(mock_page, [child_a, child_b])
+
+        inst = CamoufoxInstance("a1", MagicMock(), MagicMock(), mock_page)
+        mgr._instances["a1"] = inst
+
+        result = await mgr.snapshot("a1")
+        assert result["success"] is True
+        a_ref = next(
+            (rid for rid, h in inst.refs.items() if h.name == "AAA"), None,
+        )
+        b_ref = next(
+            (rid for rid, h in inst.refs.items() if h.name == "BBB"), None,
+        )
+        assert a_ref is not None
+        assert b_ref is not None
+        a_fid = inst.refs[a_ref].frame_id
+        b_fid = inst.refs[b_ref].frame_id
+        assert a_fid is not None and b_fid is not None
+        assert a_fid != b_fid
+
+    @pytest.mark.asyncio
+    async def test_cross_origin_iframe_emits_opaque_stub_no_descent(self):
+        from src.browser.service import BrowserManager, CamoufoxInstance
+        mgr = BrowserManager(profiles_dir="/tmp/test_profiles")
+
+        mock_page = AsyncMock()
+        mock_page.url = "https://example.com/"
+        mock_page.viewport_size = {"width": 1024, "height": 768}
+        mock_page.query_selector_all = AsyncMock(return_value=[])
+        main_tree = {
+            "role": "WebArea",
+            "name": "outer",
+            "children": [
+                {
+                    "role": "iframe",
+                    "name": "cross-origin",
+                    "frame_url": "https://other.example/widget.html",
+                    "opaque": True,
+                },
+            ],
+        }
+        mock_page.accessibility = MagicMock()
+        mock_page.accessibility.snapshot = AsyncMock(return_value=main_tree)
+        mock_page.evaluate = mock_page.accessibility.snapshot
+
+        # If descent were attempted on this Frame, evaluate would be called.
+        forbidden = _make_frame(
+            "https://other.example/widget.html", {"role": "WebArea"},
+        )
+        _attach_main_frame(mock_page, [forbidden])
+
+        inst = CamoufoxInstance("a1", MagicMock(), MagicMock(), mock_page)
+        mgr._instances["a1"] = inst
+
+        result = await mgr.snapshot("a1")
+        assert result["success"] is True
+        snap = result["data"]["snapshot"]
+        assert "iframe" in snap
+        assert "cross-origin" in snap
+        forbidden.evaluate.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_click_via_ref_inside_iframe_uses_frame_locator(self):
+        from src.browser.ref_handle import RefHandle
+        from src.browser.service import BrowserManager, CamoufoxInstance
+        mgr = BrowserManager(profiles_dir="/tmp/test_profiles")
+
+        mock_page = AsyncMock()
+        mock_page.url = "https://example.com/"
+        inst = CamoufoxInstance("a1", MagicMock(), MagicMock(), mock_page)
+        mgr._instances["a1"] = inst
+        page_id = inst._page_id_for(mock_page)
+
+        frame = MagicMock()
+        frame_locator = MagicMock()
+        frame_locator.nth = MagicMock(return_value=frame_locator)
+        frame_locator.hover = AsyncMock()
+        frame_locator.click = AsyncMock()
+        frame.get_by_role = MagicMock(return_value=frame_locator)
+        frame_id = inst._register_frame(frame)
+
+        inst.refs = {
+            "e0": RefHandle(
+                page_id=page_id, frame_id=frame_id, shadow_path=(),
+                scope_root=None, role="button", name="Inner", occurrence=0,
+                disabled=False, element_key="",
+            ),
+        }
+
+        result = await mgr.click("a1", ref="e0")
+        assert result["success"] is True
+        frame.get_by_role.assert_called_once_with(
+            "button", name="Inner", exact=True,
+        )
+        frame_locator.click.assert_called()
+
+    @pytest.mark.asyncio
+    async def test_type_via_ref_inside_iframe_uses_frame_locator(self):
+        from src.browser.ref_handle import RefHandle
+        from src.browser.service import BrowserManager, CamoufoxInstance
+        mgr = BrowserManager(profiles_dir="/tmp/test_profiles")
+
+        mock_page = AsyncMock()
+        mock_page.url = "https://example.com/"
+        mock_page.keyboard = AsyncMock()
+        mock_page.keyboard.press = AsyncMock()
+        inst = CamoufoxInstance("a1", MagicMock(), MagicMock(), mock_page)
+        mgr._instances["a1"] = inst
+        page_id = inst._page_id_for(mock_page)
+
+        frame = MagicMock()
+        frame_locator = MagicMock()
+        frame_locator.nth = MagicMock(return_value=frame_locator)
+        frame_locator.hover = AsyncMock()
+        frame_locator.click = AsyncMock()
+        frame.get_by_role = MagicMock(return_value=frame_locator)
+        frame_id = inst._register_frame(frame)
+
+        inst.refs = {
+            "e0": RefHandle(
+                page_id=page_id, frame_id=frame_id, shadow_path=(),
+                scope_root=None, role="textbox", name="Email", occurrence=0,
+                disabled=False, element_key="",
+            ),
+        }
+
+        result = await mgr.type_text("a1", ref="e0", text="hi", clear=False)
+        assert result["success"] is True
+        frame.get_by_role.assert_called_once_with(
+            "textbox", name="Email", exact=True,
+        )
+
+    @pytest.mark.asyncio
+    async def test_two_level_nested_iframes(self):
+        from src.browser.service import BrowserManager, CamoufoxInstance
+        mgr = BrowserManager(profiles_dir="/tmp/test_profiles")
+
+        mock_page = AsyncMock()
+        mock_page.url = "https://example.com/"
+        mock_page.viewport_size = {"width": 1024, "height": 768}
+        mock_page.query_selector_all = AsyncMock(return_value=[])
+        main_tree = {
+            "role": "WebArea", "name": "",
+            "children": [
+                {
+                    "role": "iframe", "name": "outer",
+                    "frame_url": "https://example.com/outer.html",
+                    "opaque": False,
+                },
+            ],
+        }
+        mock_page.accessibility = MagicMock()
+        mock_page.accessibility.snapshot = AsyncMock(return_value=main_tree)
+        mock_page.evaluate = mock_page.accessibility.snapshot
+
+        outer_tree = {
+            "role": "WebArea", "name": "outer",
+            "children": [
+                {
+                    "role": "iframe", "name": "inner",
+                    "frame_url": "https://example.com/inner.html",
+                    "opaque": False,
+                },
+            ],
+        }
+        inner_tree = {
+            "role": "WebArea", "name": "inner",
+            "children": [{"role": "button", "name": "DEEP"}],
+        }
+        outer_frame = _make_frame("https://example.com/outer.html", outer_tree)
+        inner_frame = _make_frame("https://example.com/inner.html", inner_tree)
+        outer_frame.child_frames = [inner_frame]
+        _attach_main_frame(mock_page, [outer_frame])
+
+        inst = CamoufoxInstance("a1", MagicMock(), MagicMock(), mock_page)
+        mgr._instances["a1"] = inst
+
+        result = await mgr.snapshot("a1")
+        assert result["success"] is True
+        deep_ref = next(
+            (rid for rid, h in inst.refs.items() if h.name == "DEEP"), None,
+        )
+        assert deep_ref is not None
+        deep_handle = inst.refs[deep_ref]
+        assert deep_handle.frame_id is not None
+        assert deep_handle.frame_id in inst.frame_ids_inv
+        assert inst.frame_ids_inv[deep_handle.frame_id] is inner_frame
+
+    @pytest.mark.asyncio
+    async def test_four_deep_nesting_stops_at_limit(self):
+        from src.browser.service import BrowserManager, CamoufoxInstance
+        mgr = BrowserManager(profiles_dir="/tmp/test_profiles")
+
+        mock_page = AsyncMock()
+        mock_page.url = "https://example.com/"
+        mock_page.viewport_size = {"width": 1024, "height": 768}
+        mock_page.query_selector_all = AsyncMock(return_value=[])
+        main_tree = {
+            "role": "WebArea", "name": "",
+            "children": [
+                {
+                    "role": "iframe", "name": "lvl1",
+                    "frame_url": "https://example.com/1.html",
+                    "opaque": False,
+                },
+            ],
+        }
+        mock_page.accessibility = MagicMock()
+        mock_page.accessibility.snapshot = AsyncMock(return_value=main_tree)
+        mock_page.evaluate = mock_page.accessibility.snapshot
+
+        def _level(level):
+            children = []
+            if level < 4:
+                children = [{
+                    "role": "iframe", "name": f"lvl{level + 1}",
+                    "frame_url": f"https://example.com/{level + 1}.html",
+                    "opaque": False,
+                }]
+            children.append({"role": "button", "name": f"BTN{level}"})
+            return {"role": "WebArea", "name": f"lvl{level}", "children": children}
+
+        f1 = _make_frame("https://example.com/1.html", _level(1))
+        f2 = _make_frame("https://example.com/2.html", _level(2))
+        f3 = _make_frame("https://example.com/3.html", _level(3))
+        f4 = _make_frame("https://example.com/4.html", _level(4))
+        f1.child_frames = [f2]
+        f2.child_frames = [f3]
+        f3.child_frames = [f4]
+        _attach_main_frame(mock_page, [f1])
+
+        inst = CamoufoxInstance("a1", MagicMock(), MagicMock(), mock_page)
+        mgr._instances["a1"] = inst
+
+        result = await mgr.snapshot("a1")
+        assert result["success"] is True
+        names = {h.name for h in inst.refs.values()}
+        assert "BTN1" in names
+        assert "BTN2" in names
+        assert "BTN3" in names
+        assert "BTN4" not in names
+        f4.evaluate.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_snapshot_frame_arg_walks_only_target(self):
+        from src.browser.service import BrowserManager, CamoufoxInstance
+        mgr = BrowserManager(profiles_dir="/tmp/test_profiles")
+
+        mock_page = AsyncMock()
+        mock_page.url = "https://example.com/"
+        mock_page.viewport_size = {"width": 1024, "height": 768}
+        mock_page.query_selector_all = AsyncMock(return_value=[])
+
+        main_tree = {
+            "role": "WebArea", "name": "main",
+            "children": [
+                {"role": "button", "name": "MainOnly"},
+                {
+                    "role": "iframe", "name": "i",
+                    "frame_url": "https://example.com/iframe.html",
+                    "opaque": False,
+                },
+            ],
+        }
+        mock_page.accessibility = MagicMock()
+        mock_page.accessibility.snapshot = AsyncMock(return_value=main_tree)
+        mock_page.evaluate = mock_page.accessibility.snapshot
+
+        target_tree = {
+            "role": "WebArea", "name": "i",
+            "children": [{"role": "button", "name": "FromIframe"}],
+        }
+        target = _make_frame("https://example.com/iframe.html", target_tree)
+        mock_page.frames = [MagicMock(url="https://example.com/"), target]
+        _attach_main_frame(mock_page, [target])
+        # The page.main_frame should NOT be the target so iteration order
+        # reflects "skip main_frame" path in _resolve_frame_arg.
+        mock_page.frames[0].url = "https://example.com/"
+
+        inst = CamoufoxInstance("a1", MagicMock(), MagicMock(), mock_page)
+        mgr._instances["a1"] = inst
+
+        result = await mgr.snapshot("a1", frame="example.com/iframe")
+        assert result["success"] is True
+        names = {h.name for h in inst.refs.values()}
+        assert names == {"FromIframe"}
+
+    @pytest.mark.asyncio
+    async def test_click_with_frame_arg_conflicting_ref_returns_error(self):
+        from src.browser.ref_handle import RefHandle
+        from src.browser.service import BrowserManager, CamoufoxInstance
+        mgr = BrowserManager(profiles_dir="/tmp/test_profiles")
+
+        mock_page = AsyncMock()
+        mock_page.url = "https://example.com/"
+        inst = CamoufoxInstance("a1", MagicMock(), MagicMock(), mock_page)
+        mgr._instances["a1"] = inst
+        page_id = inst._page_id_for(mock_page)
+
+        # Ref carries one frame_id; caller passes frame= for a different
+        # iframe — these conflict.
+        other_frame = MagicMock()
+        other_frame.url = "https://example.com/other.html"
+        other_id = inst._register_frame(other_frame)
+        inst.refs = {
+            "e0": RefHandle(
+                page_id=page_id, frame_id=other_id, shadow_path=(),
+                scope_root=None, role="button", name="X", occurrence=0,
+                disabled=False, element_key="",
+            ),
+        }
+        target = MagicMock()
+        target.url = "https://example.com/iframe.html"
+        inst._register_frame(target)
+        mock_page.frames = [MagicMock(url="https://example.com/"), target]
+        mock_page.main_frame = mock_page.frames[0]
+
+        result = await mgr.click(
+            "a1", ref="e0", frame="example.com/iframe",
+        )
+        assert result["success"] is False
+        err = result["error"]
+        assert isinstance(err, dict)
+        assert err.get("code") == "invalid_input"
+        assert "frame" in err.get("message", "").lower()
+        assert "conflict" in err.get("message", "").lower()
+
+    @pytest.mark.asyncio
+    async def test_main_frame_ref_with_frame_arg_returns_error(self):
+        """Ref from main frame (frame_id=None) + frame= arg must error.
+
+        Pre-fix the conflict guard skipped the check when ref.frame_id
+        was None, silently ignoring the caller's frame= assertion.
+        """
+        from src.browser.ref_handle import RefHandle
+        from src.browser.service import BrowserManager, CamoufoxInstance
+        mgr = BrowserManager(profiles_dir="/tmp/test_profiles")
+
+        mock_page = AsyncMock()
+        mock_page.url = "https://example.com/"
+        inst = CamoufoxInstance("a1", MagicMock(), MagicMock(), mock_page)
+        mgr._instances["a1"] = inst
+        page_id = inst._page_id_for(mock_page)
+
+        # Main-frame ref — frame_id=None.
+        inst.refs = {
+            "e0": RefHandle.light_dom(
+                page_id=page_id, scope_root=None, role="button",
+                name="Main", occurrence=0, disabled=False,
+            ),
+        }
+        target = MagicMock()
+        target.url = "https://example.com/iframe.html"
+        inst._register_frame(target)
+        mock_page.frames = [MagicMock(url="https://example.com/"), target]
+        mock_page.main_frame = mock_page.frames[0]
+
+        result = await mgr.click(
+            "a1", ref="e0", frame="example.com/iframe",
+        )
+        assert result["success"] is False
+        err = result["error"]
+        assert isinstance(err, dict)
+        assert err.get("code") == "invalid_input"
+        assert "frame" in err.get("message", "").lower()
+
+    @pytest.mark.asyncio
+    async def test_type_main_frame_ref_with_frame_arg_returns_error(self):
+        """Same as click() but for type_text()."""
+        from src.browser.ref_handle import RefHandle
+        from src.browser.service import BrowserManager, CamoufoxInstance
+        mgr = BrowserManager(profiles_dir="/tmp/test_profiles")
+
+        mock_page = AsyncMock()
+        mock_page.url = "https://example.com/"
+        inst = CamoufoxInstance("a1", MagicMock(), MagicMock(), mock_page)
+        mgr._instances["a1"] = inst
+        page_id = inst._page_id_for(mock_page)
+
+        inst.refs = {
+            "e0": RefHandle.light_dom(
+                page_id=page_id, scope_root=None, role="textbox",
+                name="Email", occurrence=0, disabled=False,
+            ),
+        }
+        target = MagicMock()
+        target.url = "https://example.com/iframe.html"
+        inst._register_frame(target)
+        mock_page.frames = [MagicMock(url="https://example.com/"), target]
+        mock_page.main_frame = mock_page.frames[0]
+
+        result = await mgr.type_text(
+            "a1", text="hi", ref="e0", frame="example.com/iframe",
+        )
+        assert result["success"] is False
+        err = result["error"]
+        assert isinstance(err, dict)
+        assert err.get("code") == "invalid_input"
+
+    @pytest.mark.asyncio
+    async def test_click_returns_ref_stale_when_frame_detached(self):
+        from src.browser.ref_handle import RefHandle
+        from src.browser.service import BrowserManager, CamoufoxInstance
+        mgr = BrowserManager(profiles_dir="/tmp/test_profiles")
+
+        mock_page = AsyncMock()
+        mock_page.url = "https://example.com/"
+        inst = CamoufoxInstance("a1", MagicMock(), MagicMock(), mock_page)
+        mgr._instances["a1"] = inst
+        page_id = inst._page_id_for(mock_page)
+
+        inst.refs = {
+            "e0": RefHandle(
+                page_id=page_id, frame_id="f-detached", shadow_path=(),
+                scope_root=None, role="button", name="Gone", occurrence=0,
+                disabled=False, element_key="",
+            ),
+        }
+        result = await mgr.click("a1", ref="e0")
+        assert result["success"] is False
+        err = result["error"]
+        assert isinstance(err, dict)
+        assert err.get("code") == "ref_stale"
+
+    @pytest.mark.asyncio
+    async def test_light_dom_only_page_unaffected(self):
+        from src.browser.service import BrowserManager, CamoufoxInstance
+        mgr = BrowserManager(profiles_dir="/tmp/test_profiles")
+
+        mock_page = AsyncMock()
+        mock_page.url = "https://example.com/"
+        mock_page.viewport_size = {"width": 1024, "height": 768}
+        mock_page.query_selector_all = AsyncMock(return_value=[])
+        main_tree = {
+            "role": "WebArea", "name": "Test",
+            "children": [
+                {"role": "button", "name": "Submit"},
+                {"role": "textbox", "name": "Email"},
+            ],
+        }
+        mock_page.accessibility = MagicMock()
+        mock_page.accessibility.snapshot = AsyncMock(return_value=main_tree)
+        mock_page.evaluate = mock_page.accessibility.snapshot
+        _attach_main_frame(mock_page, [])
+
+        inst = CamoufoxInstance("a1", MagicMock(), MagicMock(), mock_page)
+        mgr._instances["a1"] = inst
+
+        result = await mgr.snapshot("a1")
+        assert result["success"] is True
+        for handle in inst.refs.values():
+            assert handle.frame_id is None
+        assert "iframe" not in result["data"]["snapshot"]
+
+    @pytest.mark.asyncio
+    async def test_frame_and_from_ref_mutually_exclusive(self):
+        """Passing both frame= and from_ref= must error rather than
+        silently ignoring frame=."""
+        from src.browser.ref_handle import RefHandle
+        from src.browser.service import BrowserManager, CamoufoxInstance
+        mgr = BrowserManager(profiles_dir="/tmp/test_profiles")
+
+        mock_page = AsyncMock()
+        mock_page.url = "https://example.com/"
+        mock_page.viewport_size = {"width": 1024, "height": 768}
+        mock_page.query_selector_all = AsyncMock(return_value=[])
+        _attach_main_frame(mock_page, [])
+        inst = CamoufoxInstance("a1", MagicMock(), MagicMock(), mock_page)
+        mgr._instances["a1"] = inst
+        page_id = inst._page_id_for(mock_page)
+        inst.refs = {
+            "e0": RefHandle.light_dom(
+                page_id=page_id, scope_root=None, role="button",
+                name="X", occurrence=0, disabled=False,
+            ),
+        }
+
+        result = await mgr.snapshot(
+            "a1", frame="example.com/iframe", from_ref="e0",
+        )
+        assert result["success"] is False
+        err = result["error"]
+        assert isinstance(err, dict)
+        assert err.get("code") == "invalid_input"
+        assert "mutually exclusive" in err.get("message", "").lower()
+
+    @pytest.mark.asyncio
+    async def test_snapshot_frame_arg_recurses_into_nested_frames(self):
+        """snapshot(frame=outer) descends into same-origin frames inside
+        the targeted frame so nested refs carry their own frame_id."""
+        from src.browser.service import BrowserManager, CamoufoxInstance
+        mgr = BrowserManager(profiles_dir="/tmp/test_profiles")
+
+        mock_page = AsyncMock()
+        mock_page.url = "https://example.com/"
+        mock_page.viewport_size = {"width": 1024, "height": 768}
+        mock_page.query_selector_all = AsyncMock(return_value=[])
+
+        # Main page is irrelevant when frame= targets outer.
+        main_tree = {
+            "role": "WebArea", "name": "main",
+            "children": [{"role": "button", "name": "MainOnly"}],
+        }
+        mock_page.accessibility = MagicMock()
+        mock_page.accessibility.snapshot = AsyncMock(return_value=main_tree)
+        mock_page.evaluate = mock_page.accessibility.snapshot
+
+        # Outer frame has a child iframe stub pointing at inner.
+        outer_tree = {
+            "role": "WebArea", "name": "outer",
+            "children": [
+                {"role": "button", "name": "OUTER_BTN"},
+                {
+                    "role": "iframe", "name": "inner",
+                    "frame_url": "https://example.com/inner.html",
+                    "opaque": False,
+                },
+            ],
+        }
+        inner_tree = {
+            "role": "WebArea", "name": "inner",
+            "children": [{"role": "button", "name": "DEEP_NESTED"}],
+        }
+        outer_frame = _make_frame(
+            "https://example.com/outer.html", outer_tree,
+        )
+        inner_frame = _make_frame(
+            "https://example.com/inner.html", inner_tree,
+        )
+        outer_frame.child_frames = [inner_frame]
+        # page.frames lists every frame; main_frame plus outer plus inner.
+        mock_page.frames = [
+            MagicMock(url="https://example.com/"),
+            outer_frame,
+            inner_frame,
+        ]
+        _attach_main_frame(mock_page, [outer_frame])
+
+        inst = CamoufoxInstance("a1", MagicMock(), MagicMock(), mock_page)
+        mgr._instances["a1"] = inst
+
+        result = await mgr.snapshot("a1", frame="example.com/outer")
+        assert result["success"] is True
+        names = {h.name for h in inst.refs.values()}
+        # MainOnly is from the main frame and must NOT appear.
+        assert "MainOnly" not in names
+        assert "OUTER_BTN" in names
+        # P0.3 — inner frame's content must appear with its own frame_id.
+        assert "DEEP_NESTED" in names
+        deep_handle = next(
+            h for h in inst.refs.values() if h.name == "DEEP_NESTED"
+        )
+        outer_handle = next(
+            h for h in inst.refs.values() if h.name == "OUTER_BTN"
+        )
+        # Both have frame_ids; they must differ.
+        assert deep_handle.frame_id is not None
+        assert outer_handle.frame_id is not None
+        assert deep_handle.frame_id != outer_handle.frame_id
+        assert inst.frame_ids_inv[deep_handle.frame_id] is inner_frame
+        assert inst.frame_ids_inv[outer_handle.frame_id] is outer_frame
+
+    @pytest.mark.asyncio
+    async def test_resolve_frame_arg_token_not_in_inv_raises_ref_stale(self):
+        """A frame-id-shaped token (f-XXXXXXXX) that isn't in
+        frame_ids_inv signals a detached frame, not a URL miss — surface
+        as ref_stale so the agent re-snapshots."""
+        from src.browser.service import BrowserManager, CamoufoxInstance
+        mgr = BrowserManager(profiles_dir="/tmp/test_profiles")
+
+        mock_page = AsyncMock()
+        mock_page.url = "https://example.com/"
+        mock_page.viewport_size = {"width": 1024, "height": 768}
+        mock_page.query_selector_all = AsyncMock(return_value=[])
+        mock_page.accessibility = MagicMock()
+        mock_page.accessibility.snapshot = AsyncMock(return_value={
+            "role": "WebArea", "name": "", "children": [],
+        })
+        mock_page.frames = [MagicMock(url="https://example.com/")]
+        _attach_main_frame(mock_page, [])
+        inst = CamoufoxInstance("a1", MagicMock(), MagicMock(), mock_page)
+        mgr._instances["a1"] = inst
+
+        # Detached frame_id shape: f- + 8 hex.
+        result = await mgr.snapshot("a1", frame="f-deadbeef")
+        assert result["success"] is False
+        err = result["error"]
+        assert isinstance(err, dict)
+        assert err.get("code") == "ref_stale"
+
+    @pytest.mark.asyncio
+    async def test_resolve_frame_arg_prefers_exact_url_match(self):
+        """When two frames match by substring, exact URL equality wins."""
+        from src.browser.service import BrowserManager, CamoufoxInstance
+        mgr = BrowserManager(profiles_dir="/tmp/test_profiles")
+
+        mock_page = AsyncMock()
+        mock_page.url = "https://example.com/"
+        # Two frames: one whose URL is the substring exactly, one longer.
+        wanted = MagicMock()
+        wanted.url = "https://example.com/feed"
+        longer = MagicMock()
+        longer.url = "https://example.com/feed/details"
+        mock_page.frames = [
+            MagicMock(url="https://example.com/"),
+            longer,
+            wanted,
+        ]
+        mock_page.main_frame = mock_page.frames[0]
+
+        inst = CamoufoxInstance("a1", MagicMock(), MagicMock(), mock_page)
+
+        resolved = mgr._resolve_frame_arg(inst, "https://example.com/feed")
+        # Both frames contain the substring; exact match must win.
+        assert resolved is wanted
+
+    @pytest.mark.asyncio
+    async def test_iframe_stub_name_truncated_to_200(self):
+        """Long title/src on an iframe stub gets capped to 200 chars."""
+        from src.browser.service import BrowserManager, CamoufoxInstance
+        mgr = BrowserManager(profiles_dir="/tmp/test_profiles")
+
+        mock_page = AsyncMock()
+        mock_page.url = "https://example.com/"
+        mock_page.viewport_size = {"width": 1024, "height": 768}
+        mock_page.query_selector_all = AsyncMock(return_value=[])
+
+        # Pick a character pattern that the credential redactor leaves
+        # alone: spaces split it into short tokens, none of which match
+        # the long-hex / long-base64 patterns in src/shared/redaction.py.
+        # opaque=False so the stub name is title||src (the long string),
+        # not the constant "cross-origin" sentinel.
+        long_word = "iframe-title "
+        very_long = (long_word * 50)[:500]  # 500 chars, broken by spaces
+        assert len(very_long) == 500
+        main_tree = {
+            "role": "WebArea", "name": "main",
+            "children": [
+                {
+                    "role": "iframe", "name": very_long,
+                    "frame_url": "https://example.com/inner.html",
+                    "opaque": False,
+                },
+            ],
+        }
+        mock_page.accessibility = MagicMock()
+        mock_page.accessibility.snapshot = AsyncMock(return_value=main_tree)
+        mock_page.evaluate = mock_page.accessibility.snapshot
+        # No matching child frame — descent is skipped, the stub line is
+        # all we get to inspect.
+        _attach_main_frame(mock_page, [])
+
+        inst = CamoufoxInstance("a1", MagicMock(), MagicMock(), mock_page)
+        mgr._instances["a1"] = inst
+
+        result = await mgr.snapshot("a1")
+        assert result["success"] is True
+        snap = result["data"]["snapshot"]
+        # Truncated stub must not contain the full 500-char run.
+        assert very_long not in snap
+        # The truncated 200-char prefix must appear.
+        assert very_long[:200] in snap
+        # And no character past the cap should be present in a single run.
+        assert very_long[:201] not in snap
+
+    # ── Codex-review fixes (P1) ────────────────────────────────────────
+
+    @pytest.mark.asyncio
+    async def test_snapshot_emits_frame_id_in_ref_dict_when_in_iframe(self):
+        """Fix 1 — refs from inside an iframe must surface ``frame_id``
+        in the agent-facing dict so duplicate / anonymous frames are
+        addressable via the documented ``frame=`` token. Main-frame
+        refs keep the historical 4-key shape."""
+        from src.browser.service import BrowserManager, CamoufoxInstance
+        mgr = BrowserManager(profiles_dir="/tmp/test_profiles")
+
+        mock_page = AsyncMock()
+        mock_page.url = "https://example.com/"
+        mock_page.viewport_size = {"width": 1024, "height": 768}
+        mock_page.query_selector_all = AsyncMock(return_value=[])
+        main_tree = {
+            "role": "WebArea", "name": "outer",
+            "children": [
+                {"role": "button", "name": "MainBtn"},
+                {
+                    "role": "iframe", "name": "inner",
+                    "frame_url": "https://example.com/iframe.html",
+                    "opaque": False,
+                },
+            ],
+        }
+        mock_page.accessibility = MagicMock()
+        mock_page.accessibility.snapshot = AsyncMock(return_value=main_tree)
+        mock_page.evaluate = mock_page.accessibility.snapshot
+        inner_tree = {
+            "role": "WebArea", "name": "inner",
+            "children": [{"role": "button", "name": "InnerBtn"}],
+        }
+        child = _make_frame("https://example.com/iframe.html", inner_tree)
+        _attach_main_frame(mock_page, [child])
+
+        inst = CamoufoxInstance("a1", MagicMock(), MagicMock(), mock_page)
+        mgr._instances["a1"] = inst
+
+        result = await mgr.snapshot("a1")
+        assert result["success"] is True
+        refs = result["data"]["refs"]
+        # Main-frame ref: 4-key shape, no frame_id field.
+        main_rid = next(rid for rid, r in refs.items() if r["name"] == "MainBtn")
+        assert "frame_id" not in refs[main_rid]
+        # Inner-frame ref: frame_id present and matches inst.frame_ids_inv.
+        inner_rid = next(rid for rid, r in refs.items() if r["name"] == "InnerBtn")
+        assert "frame_id" in refs[inner_rid]
+        token = refs[inner_rid]["frame_id"]
+        assert token in inst.frame_ids_inv
+        assert inst.frame_ids_inv[token] is child
+
+    @pytest.mark.asyncio
+    async def test_two_same_url_iframes_descend_into_distinct_children(self):
+        """Fix 2 — when two iframe stubs share a URL (e.g. two ad
+        frames from one provider), descent must consume each child
+        frame at most once so contents from BOTH frames appear with
+        distinct frame_ids — not the first child's content twice.
+        """
+        from src.browser.service import BrowserManager, CamoufoxInstance
+        mgr = BrowserManager(profiles_dir="/tmp/test_profiles")
+
+        mock_page = AsyncMock()
+        mock_page.url = "https://example.com/"
+        mock_page.viewport_size = {"width": 1024, "height": 768}
+        mock_page.query_selector_all = AsyncMock(return_value=[])
+        main_tree = {
+            "role": "WebArea", "name": "outer",
+            "children": [
+                {
+                    "role": "iframe", "name": "ad1",
+                    "frame_url": "https://ads.example/widget.html",
+                    "opaque": False,
+                    "iframe_index": 0,
+                },
+                {
+                    "role": "iframe", "name": "ad2",
+                    "frame_url": "https://ads.example/widget.html",
+                    "opaque": False,
+                    "iframe_index": 1,
+                },
+            ],
+        }
+        mock_page.accessibility = MagicMock()
+        mock_page.accessibility.snapshot = AsyncMock(return_value=main_tree)
+        mock_page.evaluate = mock_page.accessibility.snapshot
+        # Two distinct child Frame objects with the SAME url; each
+        # exposes its own button so we can prove both were walked.
+        tree_a = {
+            "role": "WebArea", "name": "ad-a",
+            "children": [{"role": "button", "name": "AD_A"}],
+        }
+        tree_b = {
+            "role": "WebArea", "name": "ad-b",
+            "children": [{"role": "button", "name": "AD_B"}],
+        }
+        child_a = _make_frame("https://ads.example/widget.html", tree_a)
+        child_b = _make_frame("https://ads.example/widget.html", tree_b)
+        _attach_main_frame(mock_page, [child_a, child_b])
+
+        inst = CamoufoxInstance("a1", MagicMock(), MagicMock(), mock_page)
+        mgr._instances["a1"] = inst
+
+        result = await mgr.snapshot("a1")
+        assert result["success"] is True
+        names = {h.name for h in inst.refs.values()}
+        # Both buttons must surface — pre-fix only AD_A appeared twice.
+        assert "AD_A" in names
+        assert "AD_B" in names
+        # Each frame got its own frame_id token.
+        a_handle = next(h for h in inst.refs.values() if h.name == "AD_A")
+        b_handle = next(h for h in inst.refs.values() if h.name == "AD_B")
+        assert a_handle.frame_id is not None
+        assert b_handle.frame_id is not None
+        assert a_handle.frame_id != b_handle.frame_id
+        # And the tokens map back to the distinct child Frames.
+        assert inst.frame_ids_inv[a_handle.frame_id] is child_a
+        assert inst.frame_ids_inv[b_handle.frame_id] is child_b
+
+    @pytest.mark.asyncio
+    async def test_srcdoc_iframe_traversed_via_iframe_index(self):
+        """Fix 3 — srcdoc / about:blank iframes emit ``frame_url=""``;
+        descent uses ``iframe_index`` (sibling position) so their
+        contents still surface in the snapshot."""
+        from src.browser.service import BrowserManager, CamoufoxInstance
+        mgr = BrowserManager(profiles_dir="/tmp/test_profiles")
+
+        mock_page = AsyncMock()
+        mock_page.url = "https://example.com/"
+        mock_page.viewport_size = {"width": 1024, "height": 768}
+        mock_page.query_selector_all = AsyncMock(return_value=[])
+        # Stub has empty frame_url (srcdoc) — descent must NOT skip it.
+        main_tree = {
+            "role": "WebArea", "name": "outer",
+            "children": [
+                {
+                    "role": "iframe", "name": "(srcdoc)",
+                    "frame_url": "",
+                    "opaque": False,
+                    "iframe_index": 0,
+                },
+            ],
+        }
+        mock_page.accessibility = MagicMock()
+        mock_page.accessibility.snapshot = AsyncMock(return_value=main_tree)
+        mock_page.evaluate = mock_page.accessibility.snapshot
+        srcdoc_tree = {
+            "role": "WebArea", "name": "srcdoc-content",
+            "children": [{"role": "button", "name": "SRCDOC_BTN"}],
+        }
+        # Real srcdoc iframes have url == "about:srcdoc".
+        child = _make_frame("about:srcdoc", srcdoc_tree)
+        _attach_main_frame(mock_page, [child])
+
+        inst = CamoufoxInstance("a1", MagicMock(), MagicMock(), mock_page)
+        mgr._instances["a1"] = inst
+
+        result = await mgr.snapshot("a1")
+        assert result["success"] is True
+        names = {h.name for h in inst.refs.values()}
+        # The srcdoc button surfaced — pre-fix descent was gated on a
+        # truthy ``frame_url`` and skipped this iframe entirely.
+        assert "SRCDOC_BTN" in names
+        srcdoc_handle = next(
+            h for h in inst.refs.values() if h.name == "SRCDOC_BTN"
+        )
+        assert srcdoc_handle.frame_id is not None
+        assert inst.frame_ids_inv[srcdoc_handle.frame_id] is child
+
+    @pytest.mark.asyncio
+    async def test_v2_snapshot_includes_iframe_stub(self, monkeypatch):
+        """Fix 4 — under ``BROWSER_SNAPSHOT_FORMAT=v2`` the iframe
+        stub must appear in the rendered snapshot. Pre-fix iframe
+        stubs were appended only to the v1 ``lines`` list and v2
+        rendered solely from ``entries``, so iframes vanished."""
+        monkeypatch.setenv("BROWSER_SNAPSHOT_FORMAT", "v2")
+        from src.browser.service import BrowserManager, CamoufoxInstance
+        mgr = BrowserManager(profiles_dir="/tmp/test_profiles")
+
+        mock_page = AsyncMock()
+        mock_page.url = "https://example.com/"
+        mock_page.viewport_size = {"width": 1024, "height": 768}
+        mock_page.query_selector_all = AsyncMock(return_value=[])
+        main_tree = {
+            "role": "WebArea", "name": "outer",
+            "children": [
+                {"role": "button", "name": "OuterBtn"},
+                {
+                    "role": "iframe", "name": "embedded",
+                    "frame_url": "https://example.com/inner.html",
+                    "opaque": False,
+                    "iframe_index": 0,
+                },
+            ],
+        }
+        mock_page.accessibility = MagicMock()
+        mock_page.accessibility.snapshot = AsyncMock(return_value=main_tree)
+        mock_page.evaluate = mock_page.accessibility.snapshot
+        inner_tree = {
+            "role": "WebArea", "name": "inner",
+            "children": [{"role": "button", "name": "InnerBtn"}],
+        }
+        child = _make_frame("https://example.com/inner.html", inner_tree)
+        _attach_main_frame(mock_page, [child])
+
+        inst = CamoufoxInstance("a1", MagicMock(), MagicMock(), mock_page)
+        mgr._instances["a1"] = inst
+
+        result = await mgr.snapshot("a1")
+        assert result["success"] is True
+        snap = result["data"]["snapshot"]
+        assert snap.startswith("# snapshot-v2")
+        # Iframe stub line is present in v2 output (rendered without a
+        # ``[ref_id]`` prefix because iframes are not clickable handles).
+        assert 'iframe "embedded"' in snap
+        # And the inner frame's button still has its own [eN] handle.
+        assert "InnerBtn" in snap
+
+    @pytest.mark.asyncio
+    async def test_depth_capped_iframe_stub_marked_in_snapshot(self):
+        """P1.1 — when a 4-deep iframe nest is encountered the L4 stub
+        is emitted (so the agent SEES the iframe exists) but tagged
+        ``[depth-capped]`` so the agent doesn't waste a turn fishing
+        for refs that will never appear.
+        """
+        from src.browser.service import BrowserManager, CamoufoxInstance
+        mgr = BrowserManager(profiles_dir="/tmp/test_profiles")
+
+        mock_page = AsyncMock()
+        mock_page.url = "https://example.com/"
+        mock_page.viewport_size = {"width": 1024, "height": 768}
+        mock_page.query_selector_all = AsyncMock(return_value=[])
+        main_tree = {
+            "role": "WebArea", "name": "",
+            "children": [
+                {
+                    "role": "iframe", "name": "lvl1",
+                    "frame_url": "https://example.com/1.html",
+                    "opaque": False,
+                },
+            ],
+        }
+        mock_page.accessibility = MagicMock()
+        mock_page.accessibility.snapshot = AsyncMock(return_value=main_tree)
+        mock_page.evaluate = mock_page.accessibility.snapshot
+
+        def _level(level):
+            children = []
+            if level < 4:
+                children = [{
+                    "role": "iframe", "name": f"lvl{level + 1}",
+                    "frame_url": f"https://example.com/{level + 1}.html",
+                    "opaque": False,
+                }]
+            children.append({"role": "button", "name": f"BTN{level}"})
+            return {"role": "WebArea", "name": f"lvl{level}", "children": children}
+
+        f1 = _make_frame("https://example.com/1.html", _level(1))
+        f2 = _make_frame("https://example.com/2.html", _level(2))
+        f3 = _make_frame("https://example.com/3.html", _level(3))
+        f4 = _make_frame("https://example.com/4.html", _level(4))
+        f1.child_frames = [f2]
+        f2.child_frames = [f3]
+        f3.child_frames = [f4]
+        _attach_main_frame(mock_page, [f1])
+
+        inst = CamoufoxInstance("a1", MagicMock(), MagicMock(), mock_page)
+        mgr._instances["a1"] = inst
+
+        result = await mgr.snapshot("a1")
+        assert result["success"] is True
+        snap = result["data"]["snapshot"]
+        # L1/L2/L3 stubs are NOT capped — descent proceeds.
+        for n in ("lvl1", "lvl2", "lvl3"):
+            line = next(
+                ln for ln in snap.split("\n")
+                if f'iframe "{n}"' in ln
+            )
+            assert "[depth-capped]" not in line, (
+                f"{n} stub should not be depth-capped: {line!r}"
+            )
+        # L4 stub IS capped — descent into it would exceed the nesting
+        # cap so the walker tags the stub.
+        l4_line = next(
+            ln for ln in snap.split("\n") if 'iframe "lvl4"' in ln
+        )
+        assert "[depth-capped]" in l4_line, (
+            f"lvl4 stub should be tagged depth-capped: {l4_line!r}"
+        )
+        # Sanity: the L4 frame was NOT descended into (no BTN4 ref).
+        names = {h.name for h in inst.refs.values()}
+        assert "BTN4" not in names
+
+    @pytest.mark.asyncio
+    async def test_descend_skips_detached_frames_when_index_matching(self):
+        """P1.2 — Playwright may briefly retain detached ``Frame``
+        objects in ``parent.child_frames``; the JS walker counts only
+        live iframes via ``ownerDocument.querySelectorAll``, so its
+        ``iframe_index`` is positional over LIVE frames only. Descent
+        must skip detached entries before applying the index fallback.
+        """
+        from src.browser.service import BrowserManager, CamoufoxInstance
+        mgr = BrowserManager(profiles_dir="/tmp/test_profiles")
+
+        mock_page = AsyncMock()
+        mock_page.url = "https://example.com/"
+        mock_page.viewport_size = {"width": 1024, "height": 768}
+        mock_page.query_selector_all = AsyncMock(return_value=[])
+        # Two srcdoc iframes (empty frame_url forces index-based matching).
+        # Walker emits index=0 and index=1 — the live iframe count.
+        main_tree = {
+            "role": "WebArea", "name": "outer",
+            "children": [
+                {
+                    "role": "iframe", "name": "(srcdoc-0)",
+                    "frame_url": "", "opaque": False, "iframe_index": 0,
+                },
+                {
+                    "role": "iframe", "name": "(srcdoc-1)",
+                    "frame_url": "", "opaque": False, "iframe_index": 1,
+                },
+            ],
+        }
+        mock_page.accessibility = MagicMock()
+        mock_page.accessibility.snapshot = AsyncMock(return_value=main_tree)
+        mock_page.evaluate = mock_page.accessibility.snapshot
+        # Build child_frames with a detached entry sandwiched in slot 0.
+        # Without filtering, index=0 would target the detached frame and
+        # the LIVE frames would shift to slots 1 and 2.
+        detached = _make_frame("about:blank-stale", None, detached=True)
+        live_a = _make_frame("about:srcdoc", {
+            "role": "WebArea", "name": "a",
+            "children": [{"role": "button", "name": "LIVE_A"}],
+        })
+        live_b = _make_frame("about:srcdoc", {
+            "role": "WebArea", "name": "b",
+            "children": [{"role": "button", "name": "LIVE_B"}],
+        })
+        _attach_main_frame(mock_page, [detached, live_a, live_b])
+
+        inst = CamoufoxInstance("a1", MagicMock(), MagicMock(), mock_page)
+        mgr._instances["a1"] = inst
+
+        result = await mgr.snapshot("a1")
+        assert result["success"] is True
+        names = {h.name for h in inst.refs.values()}
+        # Both LIVE iframes' contents must surface — pre-fix index=0
+        # would have targeted the detached frame and missed LIVE_A.
+        assert "LIVE_A" in names
+        assert "LIVE_B" in names
+        # And the detached frame's evaluate was never invoked.
+        detached.evaluate.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_click_returns_not_supported_on_shadow_in_iframe(self):
+        """Defensive: when PR2 (shadow DOM) merges, refs carrying both
+        ``shadow_path`` AND ``frame_id`` will raise ``NotImplementedError``
+        from ``_resolve_shadow_element`` (the explicit "Shadow + iframe
+        combination not yet supported" guard). The click()/type/hover/
+        scroll outer try-blocks must wrap that as a structured
+        ``not_supported`` envelope rather than letting it surface as a
+        500 from the generic ``except Exception`` catch-all.
+        """
+        from src.browser.ref_handle import RefHandle
+        from src.browser.service import BrowserManager, CamoufoxInstance
+        mgr = BrowserManager(profiles_dir="/tmp/test_profiles")
+
+        mock_page = AsyncMock()
+        mock_page.url = "https://example.com/"
+        inst = CamoufoxInstance("a1", MagicMock(), MagicMock(), mock_page)
+        mgr._instances["a1"] = inst
+        page_id = inst._page_id_for(mock_page)
+
+        # Register a fake frame so the ref's frame_id resolves cleanly —
+        # the NotImplementedError is the *only* failure surface this
+        # test cares about, so everything else has to look healthy.
+        frame = MagicMock()
+        frame_id = inst._register_frame(frame)
+
+        # Ref carries both shadow_path AND frame_id — exactly the
+        # combination PR2's guard rejects.
+        inst.refs = {
+            "e0": RefHandle(
+                page_id=page_id, frame_id=frame_id,
+                shadow_path=("div#root",), scope_root=None,
+                role="button", name="Submit", occurrence=0,
+                disabled=False, element_key="",
+            ),
+        }
+
+        # Stub the resolution path to simulate PR2's guard.
+        with patch.object(
+            BrowserManager, "_locator_from_ref",
+            side_effect=NotImplementedError(
+                "Shadow + iframe combination not yet supported",
+            ),
+        ):
+            result = await mgr.click("a1", ref="e0")
+
+        assert result["success"] is False, result
+        assert isinstance(result["error"], dict)
+        assert result["error"]["code"] == "not_supported"
+        assert "Shadow + iframe" in result["error"]["message"]
+        # Click failure stats still get bumped — the action attempted
+        # and failed even if the failure mode is structured.
+        assert inst.m_click_fail == 1
+
+
+class TestSelectorFrameClickAndType:
+    """P2.1 — happy-path coverage for ``selector + frame=`` on click()
+    and type_text(). Existing tests cover the conflict-with-ref case
+    only; these tests pin the selector path so a regression that drops
+    iframe-scoped selector dispatch surfaces immediately.
+    """
+
+    @pytest.mark.asyncio
+    async def test_click_with_selector_and_frame_arg(self):
+        from src.browser.service import BrowserManager, CamoufoxInstance
+        mgr = BrowserManager(profiles_dir="/tmp/test_profiles")
+
+        mock_page = AsyncMock()
+        mock_page.url = "https://example.com/"
+        inst = CamoufoxInstance("a1", MagicMock(), MagicMock(), mock_page)
+        mgr._instances["a1"] = inst
+
+        # Frame whose URL substring the agent passes via frame=.
+        frame_locator = MagicMock()
+        frame_locator.hover = AsyncMock()
+        frame_locator.click = AsyncMock()
+        target_frame = MagicMock()
+        target_frame.url = "https://example.com/widget.html"
+        target_locator = MagicMock()
+        target_locator.first = frame_locator
+        target_frame.locator = MagicMock(return_value=target_locator)
+        inst._register_frame(target_frame)
+        mock_page.frames = [
+            MagicMock(url="https://example.com/"),
+            target_frame,
+        ]
+        mock_page.main_frame = mock_page.frames[0]
+
+        result = await mgr.click(
+            "a1", selector="button.submit", frame="example.com/widget",
+        )
+        assert result["success"] is True
+        # Selector resolved through the frame's locator, not page's.
+        target_frame.locator.assert_called_once_with("button.submit")
+        frame_locator.click.assert_called()
+
+    @pytest.mark.asyncio
+    async def test_type_with_selector_and_frame_arg(self):
+        from src.browser.service import BrowserManager, CamoufoxInstance
+        mgr = BrowserManager(profiles_dir="/tmp/test_profiles")
+
+        mock_page = AsyncMock()
+        mock_page.url = "https://example.com/"
+        mock_page.keyboard = AsyncMock()
+        mock_page.keyboard.press = AsyncMock()
+        mock_page.keyboard.type = AsyncMock()
+        inst = CamoufoxInstance("a1", MagicMock(), MagicMock(), mock_page)
+        mgr._instances["a1"] = inst
+
+        frame_locator = MagicMock()
+        frame_locator.hover = AsyncMock()
+        frame_locator.click = AsyncMock()
+        target_frame = MagicMock()
+        target_frame.url = "https://example.com/widget.html"
+        target_locator = MagicMock()
+        target_locator.first = frame_locator
+        target_frame.locator = MagicMock(return_value=target_locator)
+        inst._register_frame(target_frame)
+        mock_page.frames = [
+            MagicMock(url="https://example.com/"),
+            target_frame,
+        ]
+        mock_page.main_frame = mock_page.frames[0]
+
+        result = await mgr.type_text(
+            "a1", selector="input.email", text="hi",
+            frame="example.com/widget", clear=False,
+        )
+        assert result["success"] is True
+        target_frame.locator.assert_called_once_with("input.email")
+        # Focus click went through the frame-scoped locator.
+        frame_locator.click.assert_called()

--- a/tests/test_builtins.py
+++ b/tests/test_builtins.py
@@ -1167,6 +1167,39 @@ class TestBrowserSnapshotHttpClient:
             "snapshot", {"diff_from_last": True},
         )
 
+    @pytest.mark.asyncio
+    async def test_frame_param_forwarded(self):
+        from src.agent.builtins.browser_tool import browser_get_elements
+
+        mc = AsyncMock()
+        mc.browser_command = AsyncMock(return_value={"data": {}})
+        await browser_get_elements(
+            frame="example.com/iframe", mesh_client=mc,
+        )
+        mc.browser_command.assert_awaited_once_with(
+            "snapshot", {"frame": "example.com/iframe"},
+        )
+
+    @pytest.mark.asyncio
+    async def test_browser_get_elements_skill_include_frames_param(self):
+        """include_frames=False is forwarded; default True is omitted from
+        payload (server defaults to True)."""
+        from src.agent.builtins.browser_tool import browser_get_elements
+
+        # Default — payload should NOT carry include_frames.
+        mc = AsyncMock()
+        mc.browser_command = AsyncMock(return_value={"data": {}})
+        await browser_get_elements(mesh_client=mc)
+        mc.browser_command.assert_awaited_once_with("snapshot", {})
+
+        # Explicit False — payload carries include_frames=False.
+        mc2 = AsyncMock()
+        mc2.browser_command = AsyncMock(return_value={"data": {}})
+        await browser_get_elements(include_frames=False, mesh_client=mc2)
+        mc2.browser_command.assert_awaited_once_with(
+            "snapshot", {"include_frames": False},
+        )
+
 
 class TestBrowserClickHttpClient:
     """browser_click sends click command through mesh_client."""
@@ -1205,6 +1238,19 @@ class TestBrowserClickHttpClient:
         assert "error" in result
         assert "Provide either" in result["error"]
 
+    @pytest.mark.asyncio
+    async def test_click_frame_param_forwarded(self):
+        from src.agent.builtins.browser_tool import browser_click
+
+        mc = AsyncMock()
+        mc.browser_command = AsyncMock(return_value={"clicked": "#btn"})
+        await browser_click(
+            selector="#btn", frame="iframe.html", mesh_client=mc,
+        )
+        sent = mc.browser_command.await_args.args[1]
+        assert sent.get("frame") == "iframe.html"
+        assert sent.get("selector") == "#btn"
+
 
 class TestBrowserTypeHttpClient:
     """browser_type sends type command through mesh_client (plain text)."""
@@ -1239,6 +1285,20 @@ class TestBrowserTypeHttpClient:
         result = await browser_type(text="hello", mesh_client=AsyncMock())
         assert "error" in result
         assert "Provide either" in result["error"]
+
+    @pytest.mark.asyncio
+    async def test_type_frame_param_forwarded(self):
+        from src.agent.builtins.browser_tool import browser_type
+
+        mc = AsyncMock()
+        mc.browser_command = AsyncMock(return_value={"success": True})
+        await browser_type(
+            text="hello", selector="input", frame="iframe.html",
+            mesh_client=mc,
+        )
+        sent = mc.browser_command.await_args.args[1]
+        assert sent.get("frame") == "iframe.html"
+        assert sent.get("text") == "hello"
 
 
 class TestCredentialRedaction:


### PR DESCRIPTION
## Summary

- Walker descends into same-origin iframes (cap: 3 levels of nesting), assigning a stable per-Frame UUID to each Frame via `CamoufoxInstance.frame_ids` (WeakKey) / `frame_ids_inv` (WeakValue) so detached frames drop out automatically.
- Refs collected inside an iframe carry their `frame_id`; `_locator_from_ref` resolves through `Frame.get_by_role(...)` instead of `Page.get_by_role(...)`.
- Cross-origin iframes are opaque: the JS walker emits a stub line with URL + `cross-origin` label and skips descent. Python descent loop also refuses to walk opaque stubs.
- `snapshot()` gains `frame` (URL substring or frame_id token) and `include_frames` (default true) params; click/type gain `frame`. Frame argument that conflicts with a ref's `frame_id` returns an error envelope. `RefStale` from a detached frame surfaces as `ref_stale`.
- Light-DOM single-frame snapshots produce identical output (regression-guarded).

## Test plan

- [x] `pytest tests/test_browser_service.py::TestIframeTraversal -x -v` (11 new tests, all pass)
- [x] `pytest tests/test_browser_service.py -x` (362 tests pass — 351 existing + 11 new)
- [x] `pytest tests/test_builtins.py::TestBrowserSnapshotHttpClient tests/test_builtins.py::TestBrowserClickHttpClient tests/test_builtins.py::TestBrowserTypeHttpClient -x` (14 tests pass — 11 existing + 3 new)
- [x] Broad regression sweep: `pytest tests/test_browser_service.py tests/test_builtins.py tests/test_dashboard.py -x` (840 pass)