### PR TITLE
Phase 5 §8.3: shadow DOM walker + 2-stage resolver

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,3 +75,15 @@ select = ["E", "F", "W", "I"]
 [tool.pytest.ini_options]
 asyncio_mode = "auto"
 testpaths = ["tests"]
+markers = [
+    # Tests that drive a real browser via ``playwright.async_api``.
+    # Playwright is intentionally NOT in ``[dev]`` deps (browser
+    # binaries balloon the install). The shared browser container ships
+    # Camoufox which bundles a Playwright variant — production code is
+    # exercised end-to-end by ``tests/test_e2e_*``. For unit-test runs,
+    # ``_no_playwright()`` skipif lets these tests run only when the
+    # developer has installed playwright manually (``pip install
+    # playwright && playwright install firefox``). CI honours the same
+    # skipif and does NOT install playwright.
+    "browser: real-browser test requiring playwright (CI does not run)",
+]

--- a/src/browser/ref_handle.py
+++ b/src/browser/ref_handle.py
@@ -62,6 +62,12 @@ class ShadowHop:
     occurrence: int
     discriminator: str
 
+    def __post_init__(self) -> None:
+        if not self.selector:
+            raise ValueError("ShadowHop.selector must be non-empty")
+        if not self.discriminator:
+            raise ValueError("ShadowHop.discriminator must be non-empty")
+
 
 # ── Ref handle (the canonical identity of a snapshot ref) ───────────────────
 

--- a/src/browser/ref_handle.py
+++ b/src/browser/ref_handle.py
@@ -170,6 +170,40 @@ class RefHandle:
             element_key=element_key,
         )
 
+    @classmethod
+    def shadow(
+        cls,
+        *,
+        page_id: str,
+        scope_root: str | None,
+        shadow_path: tuple[ShadowHop, ...],
+        role: str,
+        name: str,
+        occurrence: int,
+        disabled: bool,
+        element_key: str = "",
+        frame_id: str | None = None,
+    ) -> "RefHandle":
+        """Build a handle that points inside one or more open shadow roots.
+
+        ``shadow_path`` must be non-empty; the outermost shadow host is
+        first. Empty ``shadow_path`` would be a light-DOM ref — use
+        :meth:`light_dom` instead so the call site reads correctly.
+        """
+        if not shadow_path:
+            raise ValueError("shadow_path must be non-empty for RefHandle.shadow")
+        return cls(
+            page_id=page_id,
+            frame_id=frame_id,
+            shadow_path=shadow_path,
+            scope_root=scope_root,
+            role=role,
+            name=name,
+            occurrence=occurrence,
+            disabled=disabled,
+            element_key=element_key,
+        )
+
 
 # ── Element-key computation ─────────────────────────────────────────────────
 

--- a/src/browser/service.py
+++ b/src/browser/service.py
@@ -109,6 +109,7 @@ def _resolve_filter_roles(filter_name: str | None) -> frozenset[str] | None:
 
 
 _MAX_SNAPSHOT_ELEMENTS = 200
+_MAX_WALK_DEPTH = 50
 
 
 # §7.2 v2 format — depth indent is capped so a 50-deep DOM doesn't
@@ -296,6 +297,7 @@ def _build_js_a11y_tree() -> str:
     """
     implicit_json = json.dumps(_IMPLICIT_ROLE_MAP)
     return r"""((rootEl) => {
+    const MAX_WALK_DEPTH = __MAX_WALK_DEPTH__;
     const ACTIONABLE = new Set([
         'button','link','textbox','checkbox','radio','combobox','searchbox',
         'slider','spinbutton','switch','tab','menuitem','menuitemcheckbox',
@@ -334,8 +336,20 @@ def _build_js_a11y_tree() -> str:
         if (t) return 'testid:' + t;
         const id = el.getAttribute('id');
         if (id && isStableId(id)) return 'id:' + id;
-        const cls = (el.getAttribute('class') || '').trim().split(/\s+/).slice(0, 3).join('.');
-        const fp = el.tagName + '|' + cls + '|' + (el.childElementCount || 0);
+        // Structural fingerprint excludes class/style/data-* —
+        // those flip on hover/focus/aria-state and would break the
+        // discriminator across snapshots. tagName + childElementCount
+        // + sorted attribute names (state-free subset) is stable.
+        const attrNames = [];
+        for (const a of el.attributes) {
+            const n = a.name;
+            if (n === 'class' || n === 'style') continue;
+            if (n.startsWith('data-')) continue;
+            attrNames.push(n);
+        }
+        attrNames.sort();
+        const fp = el.tagName + '|' + (el.childElementCount || 0)
+            + '|' + attrNames.join(',');
         return 'fp:' + fp;
     }
     function cssPath(host) {
@@ -346,13 +360,15 @@ def _build_js_a11y_tree() -> str:
         if (t) return tag + '[data-testid="' + t.replace(/"/g, '\\"') + '"]';
         return tag;
     }
-    function siblingOccurrence(host, parent, selector) {
-        if (!parent) return 0;
-        let i = 0;
-        const candidates = parent.querySelectorAll(selector);
-        for (const c of candidates) {
-            if (c === host) return i;
-            i++;
+    function siblingOccurrence(host, _parent, selector) {
+        // Document-wide indexing matches the stage-1 resolver scope
+        // (root = document → root.querySelectorAll(hop.selector)). A
+        // parent-scoped count would mismatch when bestStableId collides
+        // across multiple hosts under different parents. Tradeoff: an
+        // unrelated <my-tag> inserted elsewhere shifts the index.
+        const candidates = document.querySelectorAll(selector);
+        for (let i = 0; i < candidates.length; i++) {
+            if (candidates[i] === host) return i;
         }
         return 0;
     }
@@ -415,7 +431,7 @@ def _build_js_a11y_tree() -> str:
         return true;
     }
     function walk(el, d, parentLandmark, shadowPath) {
-        if (d > 50 || !el || el.nodeType !== 1) return null;
+        if (d > MAX_WALK_DEPTH || !el || el.nodeType !== 1) return null;
         const tag = el.tagName;
         if (tag === 'SCRIPT' || tag === 'STYLE' || tag === 'NOSCRIPT' || tag === 'TEMPLATE')
             return null;
@@ -474,7 +490,11 @@ def _build_js_a11y_tree() -> str:
     if (tree.role === 'none')
         return { role: 'WebArea', name: document.title || '', children: tree.children || [] };
     return { role: 'WebArea', name: document.title || '', children: [tree] };
-})""".replace("__IMPLICIT_ROLE_MAP__", implicit_json)
+})""".replace(
+        "__IMPLICIT_ROLE_MAP__", implicit_json,
+    ).replace(
+        "__MAX_WALK_DEPTH__", str(_MAX_WALK_DEPTH),
+    )
 
 
 # ── JS-based accessibility tree builder ──────────────────────────────────
@@ -522,8 +542,16 @@ _JS_SHADOW_RESOLVE_STAGE1 = r"""(args) => {
             if (t) return 'testid:' + t;
             const id = el.getAttribute('id');
             if (id && isStableId(id)) return 'id:' + id;
-            const cls = (el.getAttribute('class') || '').trim().split(/\s+/).slice(0, 3).join('.');
-            const fp = el.tagName + '|' + cls + '|' + (el.childElementCount || 0);
+            const attrNames = [];
+            for (const a of el.attributes) {
+                const n = a.name;
+                if (n === 'class' || n === 'style') continue;
+                if (n.startsWith('data-')) continue;
+                attrNames.push(n);
+            }
+            attrNames.sort();
+            const fp = el.tagName + '|' + (el.childElementCount || 0)
+                + '|' + attrNames.join(',');
             return 'fp:' + fp;
         }
         const got = bestStableId(host);
@@ -2215,8 +2243,8 @@ class BrowserManager:
                 # contract every other ref-using path follows; surface as
                 # ref_stale so the agent re-snapshots.
                 try:
-                    locator = await self._locator_from_ref(inst, from_ref)
-                    if locator is None:
+                    handle_or_loc = await self._locator_from_ref(inst, from_ref)
+                    if handle_or_loc is None:
                         return {
                             "success": False,
                             "error": {
@@ -2225,7 +2253,12 @@ class BrowserManager:
                                 "retry_after_ms": None,
                             },
                         }
-                    scoped_root_handle = await locator.element_handle(timeout=2000)
+                    if hasattr(handle_or_loc, "element_handle"):
+                        scoped_root_handle = await handle_or_loc.element_handle(
+                            timeout=2000,
+                        )
+                    else:
+                        scoped_root_handle = handle_or_loc
                 except RefStale as e:
                     return {
                         "success": False,
@@ -2267,8 +2300,6 @@ class BrowserManager:
             # disambiguate duplicate elements (e.g. X's two composer nodes).
             occurrence_counts: dict[tuple, int] = {}
 
-            _MAX_WALK_DEPTH = 50
-
             # Collect entries for §7.2 v2 rendering AND build v1 lines in
             # parallel. The entry list is a structured intermediate so we
             # can pivot between formats post-walk without a second tree
@@ -2295,7 +2326,22 @@ class BrowserManager:
                         ref_id = f"e{ref_counter[0]}"
                         ref_counter[0] += 1
 
-                        key = (role, name)
+                        # Materialize shadow_path NOW so the occurrence
+                        # key folds it: stage-2 picks candidates inside
+                        # one shadow root, so two same-named elements in
+                        # different roots must not share an occurrence
+                        # counter (would index past stage-2's candidates
+                        # array → spurious RefStale).
+                        raw_shadow = node.get("shadow_path") or ()
+                        shadow_hops: tuple[ShadowHop, ...] = tuple(
+                            ShadowHop(
+                                selector=str(hop.get("selector", "")),
+                                occurrence=int(hop.get("occurrence", 0)),
+                                discriminator=str(hop.get("discriminator", "")),
+                            )
+                            for hop in raw_shadow
+                        )
+                        key = (role, name, shadow_hops)
                         occ = occurrence_counts.get(key, 0)
                         occurrence_counts[key] = occ + 1
 
@@ -2346,19 +2392,11 @@ class BrowserManager:
                         #   reported as a remove+add pair instead of
                         #   "unchanged". Same fix: data-testid extraction.
                         from src.browser.ref_handle import compute_element_key
-                        raw_shadow = node.get("shadow_path") or ()
-                        shadow_hops: tuple[ShadowHop, ...] = tuple(
-                            ShadowHop(
-                                selector=str(hop.get("selector", "")),
-                                occurrence=int(hop.get("occurrence", 0)),
-                                discriminator=str(hop.get("discriminator", "")),
-                            )
-                            for hop in raw_shadow
-                        )
-                        # frame_id stays constant today (no iframe walker
-                        # until §8.4); ``shadow_path`` is now populated by
-                        # the §8.3 walker. ``compute_element_key`` folds
-                        # both so identical role+name+landmark in distinct
+                        # ``shadow_hops`` already materialized above so
+                        # the occurrence key could fold it. frame_id
+                        # stays constant today (no iframe walker until
+                        # §8.4). ``compute_element_key`` folds both so
+                        # identical role+name+landmark in distinct
                         # shadow roots produce different element_keys.
                         elem_key = compute_element_key(
                             role=role, name=name, landmark=landmark,

--- a/src/browser/service.py
+++ b/src/browser/service.py
@@ -4390,7 +4390,7 @@ class BrowserManager:
                     if len(matches) >= 50:
                         truncated = True
                         break
-                    locator = self._locator_from_ref(inst, ref_id)
+                    locator = await self._locator_from_ref(inst, ref_id)
                     in_viewport = False
                     if locator is not None:
                         try:

--- a/src/browser/service.py
+++ b/src/browser/service.py
@@ -425,6 +425,14 @@ def _build_js_a11y_tree() -> str:
         if (t) return tag + '[data-testid="' + t.replace(/"/g, '\\"') + '"]';
         return tag;
     }
+    // Walk-scoped cache for ``querySelectorAll`` results so a page with
+    // N shadow hosts at the same root no longer triggers O(N²) work
+    // (each emit ran a fresh ``scopeRoot.querySelectorAll(selector)``).
+    // Keyed by (scopeRoot, selector); both keys are alive only for the
+    // duration of one walker invocation. ``Map`` keyed on the live
+    // root reference is safe because the walker runs synchronously
+    // and the scopeRoot is held by caller frames during the walk.
+    const occurrenceCache = new Map();
     function siblingOccurrence(host, selector, scopeRoot) {
         // Per-hop scope mirrors the stage-1 resolver: first hop uses
         // ``document``, subsequent hops use the parent ``shadowRoot``
@@ -433,11 +441,18 @@ def _build_js_a11y_tree() -> str:
         // Walker passes ``document`` for the top-level call and the
         // parent shadowRoot when descending into a nested host.
         const root = scopeRoot || document;
-        const candidates = root.querySelectorAll(selector);
-        for (let i = 0; i < candidates.length; i++) {
-            if (candidates[i] === host) return i;
+        let scopeMap = occurrenceCache.get(root);
+        if (!scopeMap) {
+            scopeMap = new Map();
+            occurrenceCache.set(root, scopeMap);
         }
-        return 0;
+        let candidates = scopeMap.get(selector);
+        if (!candidates) {
+            candidates = Array.from(root.querySelectorAll(selector));
+            scopeMap.set(selector, candidates);
+        }
+        const idx = candidates.indexOf(host);
+        return idx === -1 ? 0 : idx;
     }
 __NAME_HELPERS__
     // Walker name/role wrappers — single source of truth shared with
@@ -563,7 +578,22 @@ _JS_RESOLVER_ERROR_KEY = "__OL_RESOLVER_ERROR__"
 _JS_SHADOW_RESOLVE_STAGE1 = r"""(args) => {
     const ERR_KEY = "__OL_RESOLVER_ERROR__";
     const path = JSON.parse(args.path);
-    let root = document;
+    // ``scope_root`` (optional): when the ref was captured during a
+    // modal-scoped snapshot, ``_locator_from_ref`` patches a modal
+    // selector onto the handle. Stage-1 must start its walk at the
+    // modal element instead of ``document`` so a same-selector shadow
+    // host living *outside* the dialog cannot match. Without this,
+    // shadow refs effectively bypass modal scoping, and clicks could
+    // land on a duplicate-named element behind the overlay.
+    let root;
+    if (args.scope_root) {
+        root = document.querySelector(args.scope_root);
+        if (!root) {
+            const e = {}; e[ERR_KEY] = "scope_root_missing"; return e;
+        }
+    } else {
+        root = document;
+    }
     for (const hop of path) {
         const candidates = root.querySelectorAll(hop.selector);
         const host = candidates[hop.occurrence];
@@ -647,19 +677,26 @@ def _build_js_shadow_resolve_stage2() -> str:
         submit:'button',reset:'button',button:'button'
     };
 __NAME_HELPERS__
+    // Normalize the snapshot-time name so the empty case is unambiguous:
+    // the walker buckets unnamed siblings as ``(role, "", path)``. Stage 2
+    // must match elements whose live accessible name is *also* empty when
+    // the ref carries an empty name — otherwise unnamed elements collapse
+    // with same-role *named* siblings (the previous ``if (!name) return
+    // true;`` admitted all same-role candidates, returning candidates[0]
+    // and landing the click on the wrong element).
+    const expected = (name || '').trim();
     let candidates;
     try {
         candidates = Array.from(root.querySelectorAll('*')).filter(el => {
             const r = implicitRoleFor(el);
             if (r !== role) return false;
-            if (!name) return true;
             // Match using the SAME accessible-name extraction the walker
             // ran when emitting the snapshot. Anything else (e.g. only
             // ``aria-label || textContent``) misses elements named via
             // ``placeholder``, ``alt``, ``aria-labelledby``, ``label[for=]``,
             // or ``title`` — producing spurious RefStale.
             const n = (accessibleName(el, role) || '').trim();
-            return n === name;
+            return n === expected;
         });
     } catch (_e) {
         // ``querySelectorAll`` on a detached ShadowRoot can throw. Treat
@@ -1007,7 +1044,11 @@ class CamoufoxInstance:
         self.dialog_detected: bool = False  # True when a modal was found (even if scoping failed)
         self.lock = asyncio.Lock()  # serialize page operations per instance
         self.x11_wid: int | None = None  # X11 window ID for targeted focus
-        self._js_snapshot_mode: bool = False  # True after page.accessibility permanently fails
+        # P0.3: vestigial — the snapshot tree builder always uses the JS
+        # walker now. Still consulted by ``navigate()`` for body-text
+        # extraction, where the native ``page.accessibility.snapshot()``
+        # is acceptable (no shadow descent needed for a text summary).
+        self._js_snapshot_mode: bool = False
         self._user_control: bool = False  # True when user has VNC control
         # Per-Page stable UUID maps. Page objects survive navigation within a
         # tab; UUIDs are stable for the life of the Page. Refs carry a
@@ -2163,49 +2204,33 @@ class BrowserManager:
                 return {"success": False, "error": str(e)}
 
     async def _build_a11y_tree(self, inst: CamoufoxInstance, root=None):
-        """Get accessibility tree, falling back to JS-based DOM walk.
+        """Get accessibility tree via the JS DOM walker.
 
-        Playwright's ``page.accessibility.snapshot()`` uses Firefox's native
-        ``nsIAccessibilityService`` — a browser-internal API with zero
-        JavaScript execution in the page context.  This makes it invisible
-        to anti-bot systems that hook DOM APIs via Proxy.
+        Phase 5 §8.3 collapsed the prior "native first / JS fallback"
+        dispatch into the JS walker as the sole path. Firefox's native
+        ``nsIAccessibilityService`` (exposed through Playwright's
+        ``page.accessibility.snapshot()``) is faster and more invisible
+        to anti-bot DOM proxies, but it does NOT pierce open shadow
+        boundaries — so a default Camoufox path silently lost shadow
+        content. Phase 5 (shadow + iframe support) made the JS walker
+        the canonical implementation, and the native path was retained
+        only as a perf optimisation; with shadow descent baked into the
+        JS walker, dual paths produced inconsistent snapshots depending
+        on which path won the race.
 
-        If the API is absent (``AttributeError``), permanently switches to
-        a JS-based tree builder per-instance.  Transient failures get one
-        retry before falling through to JS.
+        Always runs the JS walker now, regardless of the (now-vestigial)
+        ``inst._js_snapshot_mode`` flag. The flag remains in
+        :class:`CamoufoxInstance` for the navigate-mode body extraction
+        path that still consults ``page.accessibility.snapshot()`` for a
+        cheap text-only summary; that path is independent of the
+        snapshot tree builder.
         """
-        if not inst._js_snapshot_mode:
-            for attempt in range(2):
-                try:
-                    if root:
-                        return await inst.page.accessibility.snapshot(root=root)
-                    return await inst.page.accessibility.snapshot()
-                except AttributeError:
-                    logger.warning(
-                        "page.accessibility not available for %s — "
-                        "switching to JS-based accessibility tree",
-                        inst.agent_id,
-                    )
-                    inst._js_snapshot_mode = True
-                    break
-                except Exception:
-                    if attempt == 0:
-                        await asyncio.sleep(0.15)
-                        continue
-                    logger.warning(
-                        "page.accessibility.snapshot() failed after retry "
-                        "for %s — falling back to JS tree",
-                        inst.agent_id,
-                    )
-                    break
-
-        # JS fallback: walk DOM to build equivalent tree
         try:
             if root:
                 return await root.evaluate(_JS_A11Y_TREE)
             return await inst.page.evaluate(_JS_A11Y_TREE)
         except Exception as e:
-            logger.debug("JS a11y tree fallback failed: %s", e)
+            logger.debug("JS a11y tree builder failed: %s", e)
             return None
 
     async def snapshot(
@@ -2931,50 +2956,105 @@ class BrowserManager:
             }
             for hop in handle.shadow_path
         ]
+        # Defensive: shadow + iframe combination is not implemented yet
+        # (Phase 5 PR3). Threading a Frame through Stage 1 here would
+        # require cross-PR coordination; explicit error makes the seam
+        # loud so PR3's merge has to address it rather than letting a
+        # frame_id'd shadow ref silently resolve against the main frame.
+        if handle.frame_id is not None:
+            raise NotImplementedError(
+                "Shadow + iframe combination not yet supported",
+            )
+        # Pass scope_root through so Stage 1 starts its walk inside the
+        # modal subtree when a ref was captured under modal scoping.
+        # Without this, a same-selector shadow host living outside the
+        # dialog could resolve and the click would land on the wrong
+        # element entirely.
         stage1 = await page.evaluate_handle(
             _JS_SHADOW_RESOLVE_STAGE1,
-            {"path": json.dumps(path_payload)},
-        )
-        # Read the stage-1 error sentinel by exact key. Page-controlled
-        # ``error`` expandos cannot match because we look up
-        # ``__OL_RESOLVER_ERROR__`` specifically.
-        try:
-            err = await stage1.evaluate(
-                "(v) => (v && typeof v === 'object' && '__OL_RESOLVER_ERROR__' in v)"
-                " ? v.__OL_RESOLVER_ERROR__ : null",
-            )
-        except Exception:
-            err = None
-        if err == "stale_host_missing":
-            raise RefStale("shadow host missing", ref=ref)
-        if err == "stale_discriminator_mismatch":
-            raise RefStale("shadow host discriminator changed", ref=ref)
-        stage2 = await stage1.evaluate_handle(
-            _JS_SHADOW_RESOLVE_STAGE2,
             {
-                "role": handle.role,
-                "name": handle.name,
-                "occurrence": handle.occurrence,
+                "path": json.dumps(path_payload),
+                "scope_root": handle.scope_root,
             },
         )
-        # Distinguish a detached shadow root (transient TOCTOU between
-        # stage 1 and stage 2) from a genuine element-not-found. The
-        # detached case surfaces as the ``shadow_root_detached`` sentinel
-        # so the caller emits a transient ``ref_stale`` rather than a
-        # potentially-misleading ``not_found``.
+        # Stage 1 is a JSHandle that we OWN — Playwright does not GC
+        # JSHandles automatically (they pin the JS object on the page
+        # side). Wrap the entire stage-2 invocation in a try/finally so
+        # discriminator-mismatch / detach / RefStale paths don't leak
+        # the handle. Stage 2 is returned to the caller as an
+        # ElementHandle on success; ownership transfers there. On any
+        # failure path we dispose stage2 ourselves before raising so
+        # neither handle outlives this method.
+        stage2 = None
         try:
-            stage2_err = await stage2.evaluate(
-                "(v) => (v && typeof v === 'object' && '__OL_RESOLVER_ERROR__' in v)"
-                " ? v.__OL_RESOLVER_ERROR__ : null",
+            # Read the stage-1 error sentinel by exact key. Page-
+            # controlled ``error`` expandos cannot match because we look
+            # up ``__OL_RESOLVER_ERROR__`` specifically.
+            try:
+                err = await stage1.evaluate(
+                    "(v) => (v && typeof v === 'object' && '__OL_RESOLVER_ERROR__' in v)"
+                    " ? v.__OL_RESOLVER_ERROR__ : null",
+                )
+            except Exception:
+                err = None
+            if err == "stale_host_missing":
+                raise RefStale("shadow host missing", ref=ref)
+            if err == "stale_discriminator_mismatch":
+                raise RefStale("shadow host discriminator changed", ref=ref)
+            if err == "scope_root_missing":
+                # Modal closed between snapshot and resolve — same RefStale
+                # contract as a missing host. Agent re-snapshots.
+                raise RefStale("modal scope_root missing", ref=ref)
+            stage2 = await stage1.evaluate_handle(
+                _JS_SHADOW_RESOLVE_STAGE2,
+                {
+                    "role": handle.role,
+                    "name": handle.name,
+                    "occurrence": handle.occurrence,
+                },
             )
+            # Distinguish a detached shadow root (transient TOCTOU between
+            # stage 1 and stage 2) from a genuine element-not-found. The
+            # detached case surfaces as the ``shadow_root_detached``
+            # sentinel so the caller emits a transient ``ref_stale``
+            # rather than a potentially-misleading ``not_found``.
+            try:
+                stage2_err = await stage2.evaluate(
+                    "(v) => (v && typeof v === 'object' && '__OL_RESOLVER_ERROR__' in v)"
+                    " ? v.__OL_RESOLVER_ERROR__ : null",
+                )
+            except Exception:
+                stage2_err = None
+            if stage2_err == "shadow_root_detached":
+                raise RefStale("shadow root detached during resolve", ref=ref)
+            element = stage2.as_element()
+            if element is None:
+                raise RefStale(
+                    "shadow element not found at occurrence", ref=ref,
+                )
+            # Success — ownership of the underlying handle transfers to
+            # the caller via ``element``. Detach our local ``stage2``
+            # reference so the finally block below does not dispose the
+            # handle out from under the returned ElementHandle.
+            # (``as_element`` returns the same underlying handle, so
+            # disposing ``stage2`` would invalidate ``element`` too.)
+            stage2 = None
+            return element
         except Exception:
-            stage2_err = None
-        if stage2_err == "shadow_root_detached":
-            raise RefStale("shadow root detached during resolve", ref=ref)
-        element = stage2.as_element()
-        if element is None:
-            raise RefStale("shadow element not found at occurrence", ref=ref)
-        return element
+            # Any error path — dispose stage2 if we got that far. The
+            # outer finally takes care of stage1.
+            if stage2 is not None:
+                try:
+                    await stage2.dispose()
+                except Exception:
+                    pass
+                stage2 = None
+            raise
+        finally:
+            try:
+                await stage1.dispose()
+            except Exception:
+                pass
 
     async def _human_click(self, page, locator, *, force: bool = False,
                            timeout: int = _CLICK_TIMEOUT_MS) -> None:

--- a/src/browser/service.py
+++ b/src/browser/service.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import asyncio
 import base64
 import contextlib
+import json
 import mimetypes
 import os
 import random
@@ -25,7 +26,7 @@ from urllib.parse import urlparse
 from src.browser.captcha import get_solver
 from src.browser.profile_schema import migrate_profile
 from src.browser.redaction import CredentialRedactor
-from src.browser.ref_handle import RefHandle, RefStale
+from src.browser.ref_handle import RefHandle, RefStale, ShadowHop
 from src.browser.stealth import build_launch_options, pick_referer, validate_referer
 from src.browser.timing import (
     action_delay,
@@ -264,17 +265,37 @@ _MODAL_SELECTOR = (
 )
 
 
-# ── JS-based accessibility tree builder ──────────────────────────────────
-# Fallback when page.accessibility.snapshot() is unavailable (Camoufox
-# bundles a Playwright version that removed or never exposed the API).
-# Walks the DOM using standard APIs (getAttribute, getComputedStyle) and
-# returns the same {role, name, children, disabled, ...} tree structure
-# that the Python _walk() function expects.
-#
-# Called as:
-#   page.evaluate(_JS_A11Y_TREE)          — full page tree
-#   element_handle.evaluate(_JS_A11Y_TREE) — scoped to element
-_JS_A11Y_TREE = r"""(rootEl) => {
+# Implicit role map — single source of truth shared between the JS a11y
+# walker and the Python-side shadow-path resolver. Tag names are uppercase
+# (matches DOM ``Element.tagName``). Injected into the JS body via
+# ``json.dumps()`` so the JS literally sees this Python dict's contents.
+_IMPLICIT_ROLE_MAP: dict[str, str] = {
+    "BUTTON": "button", "TEXTAREA": "textbox", "SELECT": "combobox",
+    "OPTION": "option",
+    "IMG": "img", "H1": "heading", "H2": "heading", "H3": "heading",
+    "H4": "heading", "H5": "heading", "H6": "heading", "DIALOG": "dialog",
+    "NAV": "navigation", "MAIN": "main", "HEADER": "banner",
+    "FOOTER": "contentinfo",
+    "ASIDE": "complementary", "FORM": "form",
+}
+
+
+def _build_js_a11y_tree() -> str:
+    """Build the JS a11y walker source with the implicit role map injected.
+
+    The walker descends ``el.shadowRoot`` when ``shadowRoot.mode === 'open'``
+    (closed roots are unreachable per the spec). Each emitted node carries
+    a ``shadow_path`` array; on the page side this is empty for light-DOM
+    nodes and accumulates ``{selector, occurrence, discriminator}`` triples
+    as the walker crosses shadow boundaries.
+
+    Discriminator priority: ``data-testid`` > stable ``id`` (UUID-shaped
+    rejected) > structural fingerprint of host (tagName + className +
+    childElementCount). Always a string — ``ShadowHop.discriminator`` is
+    guaranteed non-empty by the JS side.
+    """
+    implicit_json = json.dumps(_IMPLICIT_ROLE_MAP)
+    return r"""((rootEl) => {
     const ACTIONABLE = new Set([
         'button','link','textbox','checkbox','radio','combobox','searchbox',
         'slider','spinbutton','switch','tab','menuitem','menuitemcheckbox',
@@ -288,21 +309,8 @@ _JS_A11Y_TREE = r"""(rootEl) => {
         'navigation','main','complementary','banner','contentinfo',
         'form','region','dialog','alertdialog'
     ]);
-    // §7.7 includes LANDMARK in the set so ``filter='landmarks'``
-    // works even when ``page.accessibility.snapshot()`` is unavailable
-    // and we fall back to this JS walker. Without LANDMARK in ROLES,
-    // landmark elements collapse to ``role: 'none'`` here and never
-    // reach the Python ``_walk`` even with the right ``allowed_roles``.
-    // Default snapshot output is unaffected: Python ``_walk`` still
-    // gates on ACTIONABLE+CONTEXT unless an explicit filter is passed.
     const ROLES = new Set([...ACTIONABLE, ...CONTEXT, ...LANDMARK]);
-    const IMPLICIT = {
-        BUTTON:'button',TEXTAREA:'textbox',SELECT:'combobox',OPTION:'option',
-        IMG:'img',H1:'heading',H2:'heading',H3:'heading',
-        H4:'heading',H5:'heading',H6:'heading',DIALOG:'dialog',
-        NAV:'navigation',MAIN:'main',HEADER:'banner',FOOTER:'contentinfo',
-        ASIDE:'complementary',FORM:'form'
-    };
+    const IMPLICIT = __IMPLICIT_ROLE_MAP__;
     const INPUT_ROLES = {
         text:'textbox',email:'textbox',url:'textbox',tel:'textbox',
         password:'textbox',search:'searchbox',
@@ -310,6 +318,44 @@ _JS_A11Y_TREE = r"""(rootEl) => {
         range:'slider',number:'spinbutton',
         submit:'button',reset:'button',button:'button'
     };
+    const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+    const REACT_ID_RE = /^(:r|r:|:R)[0-9a-zA-Z]+:?$/;
+    function isStableId(id) {
+        if (!id) return false;
+        if (UUID_RE.test(id)) return false;
+        if (REACT_ID_RE.test(id)) return false;
+        if (id.length >= 16 && /^[0-9a-f]+$/i.test(id)) return false;
+        return true;
+    }
+    function bestStableId(el) {
+        const t = el.getAttribute('data-testid')
+            || el.getAttribute('data-test')
+            || el.getAttribute('data-qa');
+        if (t) return 'testid:' + t;
+        const id = el.getAttribute('id');
+        if (id && isStableId(id)) return 'id:' + id;
+        const cls = (el.getAttribute('class') || '').trim().split(/\s+/).slice(0, 3).join('.');
+        const fp = el.tagName + '|' + cls + '|' + (el.childElementCount || 0);
+        return 'fp:' + fp;
+    }
+    function cssPath(host) {
+        const tag = host.tagName.toLowerCase();
+        const id = host.getAttribute('id');
+        if (id && isStableId(id)) return tag + '#' + CSS.escape(id);
+        const t = host.getAttribute('data-testid');
+        if (t) return tag + '[data-testid="' + t.replace(/"/g, '\\"') + '"]';
+        return tag;
+    }
+    function siblingOccurrence(host, parent, selector) {
+        if (!parent) return 0;
+        let i = 0;
+        const candidates = parent.querySelectorAll(selector);
+        for (const c of candidates) {
+            if (c === host) return i;
+            i++;
+        }
+        return 0;
+    }
     function getRole(el) {
         const r = el.getAttribute('role');
         if (r) return r.split(/\s+/)[0].toLowerCase();
@@ -323,8 +369,10 @@ _JS_A11Y_TREE = r"""(rootEl) => {
         if (n) return n.trim();
         const by = el.getAttribute('aria-labelledby');
         if (by) {
+            const root = el.getRootNode();
+            const lookup = (root && root.getElementById) ? root : document;
             const t = by.split(/\s+/).map(id => {
-                const ref = document.getElementById(id);
+                const ref = lookup.getElementById ? lookup.getElementById(id) : document.getElementById(id);
                 return ref ? ref.textContent.trim() : '';
             }).filter(Boolean).join(' ');
             if (t) return t;
@@ -332,7 +380,9 @@ _JS_A11Y_TREE = r"""(rootEl) => {
         if (el.tagName === 'IMG') return (el.alt || '').trim();
         if (['INPUT','TEXTAREA','SELECT'].includes(el.tagName)) {
             if (el.id) {
-                const lbl = document.querySelector('label[for="' + CSS.escape(el.id) + '"]');
+                const root = el.getRootNode();
+                const scope = (root && root.querySelector) ? root : document;
+                const lbl = scope.querySelector('label[for="' + CSS.escape(el.id) + '"]');
                 if (lbl) return lbl.textContent.trim().slice(0, 200);
             }
             const wrap = el.closest('label');
@@ -354,7 +404,7 @@ _JS_A11Y_TREE = r"""(rootEl) => {
         return (el.title || '').trim();
     }
     function isVisible(el) {
-        if (el.getAttribute('aria-hidden') === 'true') return false;
+        if (el.getAttribute && el.getAttribute('aria-hidden') === 'true') return false;
         const s = getComputedStyle(el);
         if (s.visibility === 'hidden' || s.visibility === 'collapse') return false;
         if (parseFloat(s.opacity) === 0) return false;
@@ -364,7 +414,7 @@ _JS_A11Y_TREE = r"""(rootEl) => {
         }
         return true;
     }
-    function walk(el, d, parentLandmark) {
+    function walk(el, d, parentLandmark, shadowPath) {
         if (d > 50 || !el || el.nodeType !== 1) return null;
         const tag = el.tagName;
         if (tag === 'SCRIPT' || tag === 'STYLE' || tag === 'NOSCRIPT' || tag === 'TEMPLATE')
@@ -378,8 +428,20 @@ _JS_A11Y_TREE = r"""(rootEl) => {
         }
         const children = [];
         for (const child of el.children) {
-            const r = walk(child, d + 1, childLandmark);
+            const r = walk(child, d + 1, childLandmark, shadowPath);
             if (r) children.push(r);
+        }
+        if (el.shadowRoot && el.shadowRoot.mode === 'open') {
+            const sel = cssPath(el);
+            const occ = siblingOccurrence(el, el.parentNode, sel);
+            const disc = bestStableId(el);
+            const nextPath = shadowPath.concat([{
+                selector: sel, occurrence: occ, discriminator: disc,
+            }]);
+            for (const child of el.shadowRoot.children) {
+                const r = walk(child, d + 1, childLandmark, nextPath);
+                if (r) children.push(r);
+            }
         }
         if (!role || !ROLES.has(role)) {
             if (!children.length) return null;
@@ -387,6 +449,7 @@ _JS_A11Y_TREE = r"""(rootEl) => {
             return { role: 'none', name: '', children };
         }
         const nd = { role, name: getName(el, role) };
+        if (shadowPath.length) nd.shadow_path = shadowPath;
         if (parentLandmark) nd.landmark = parentLandmark;
         if (el.disabled || el.getAttribute('aria-disabled') === 'true') nd.disabled = true;
         const chkRoles = ['checkbox','radio','switch','menuitemcheckbox','menuitemradio'];
@@ -405,13 +468,107 @@ _JS_A11Y_TREE = r"""(rootEl) => {
         return nd;
     }
     const start = rootEl || document.body || document.documentElement;
-    const tree = walk(start, 0, null);
+    const tree = walk(start, 0, null, []);
     if (rootEl) return tree || { role: 'none', name: '', children: [] };
     if (!tree) return { role: 'WebArea', name: document.title || '', children: [] };
     if (tree.role === 'none')
         return { role: 'WebArea', name: document.title || '', children: tree.children || [] };
     return { role: 'WebArea', name: document.title || '', children: [tree] };
+})""".replace("__IMPLICIT_ROLE_MAP__", implicit_json)
+
+
+# ── JS-based accessibility tree builder ──────────────────────────────────
+# Fallback when page.accessibility.snapshot() is unavailable (Camoufox
+# bundles a Playwright version that removed or never exposed the API).
+# Walks the DOM using standard APIs (getAttribute, getComputedStyle) and
+# returns the same {role, name, children, disabled, ...} tree structure
+# that the Python _walk() function expects.
+#
+# Descends ``el.shadowRoot`` when ``shadowRoot.mode === 'open'``; closed
+# shadow roots are unreachable by web spec and remain invisible. Emitted
+# nodes inside shadow DOM carry a ``shadow_path`` array of
+# ``{selector, occurrence, discriminator}`` hops that the Python side
+# folds into ``RefHandle.shadow_path`` for resolution.
+#
+# Called as:
+#   page.evaluate(_JS_A11Y_TREE)          — full page tree
+#   element_handle.evaluate(_JS_A11Y_TREE) — scoped to element
+_JS_A11Y_TREE = _build_js_a11y_tree()
+
+
+# Stage-1 (walk shadow_path → return inner shadowRoot) and Stage-2
+# (role+name match inside that shadowRoot → ElementHandle) for the
+# Playwright-correct two-stage shadow resolver. ``get_by_role`` does NOT
+# pierce shadow boundaries, so non-empty ``shadow_path`` falls through
+# this evaluate_handle pair instead of the locator API.
+_JS_SHADOW_RESOLVE_STAGE1 = r"""(args) => {
+    const path = JSON.parse(args.path);
+    let root = document;
+    for (const hop of path) {
+        const candidates = root.querySelectorAll(hop.selector);
+        const host = candidates[hop.occurrence];
+        if (!host || !host.shadowRoot) return {error: "stale_host_missing"};
+        function isStableId(id) {
+            if (!id) return false;
+            if (/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(id)) return false;
+            if (/^(:r|r:|:R)[0-9a-zA-Z]+:?$/.test(id)) return false;
+            if (id.length >= 16 && /^[0-9a-f]+$/i.test(id)) return false;
+            return true;
+        }
+        function bestStableId(el) {
+            const t = el.getAttribute('data-testid')
+                || el.getAttribute('data-test')
+                || el.getAttribute('data-qa');
+            if (t) return 'testid:' + t;
+            const id = el.getAttribute('id');
+            if (id && isStableId(id)) return 'id:' + id;
+            const cls = (el.getAttribute('class') || '').trim().split(/\s+/).slice(0, 3).join('.');
+            const fp = el.tagName + '|' + cls + '|' + (el.childElementCount || 0);
+            return 'fp:' + fp;
+        }
+        const got = bestStableId(host);
+        if (got !== hop.discriminator) return {error: "stale_discriminator_mismatch"};
+        root = host.shadowRoot;
+    }
+    return root;
 }"""
+
+
+def _build_js_shadow_resolve_stage2() -> str:
+    implicit_json = json.dumps(_IMPLICIT_ROLE_MAP)
+    return r"""((root, args) => {
+    if (!root || root.error) return null;
+    const role = args.role;
+    const name = args.name;
+    const occurrence = args.occurrence;
+    const IMPLICIT = __IMPLICIT_ROLE_MAP__;
+    const INPUT_ROLES = {
+        text:'textbox',email:'textbox',url:'textbox',tel:'textbox',
+        password:'textbox',search:'searchbox',
+        checkbox:'checkbox',radio:'radio',
+        range:'slider',number:'spinbutton',
+        submit:'button',reset:'button',button:'button'
+    };
+    function implicitRoleFor(el) {
+        const r = el.getAttribute('role');
+        if (r) return r.split(/\s+/)[0].toLowerCase();
+        if (el.tagName === 'A') return el.hasAttribute('href') ? 'link' : null;
+        if (el.tagName === 'INPUT') return INPUT_ROLES[(el.type||'text').toLowerCase()] || null;
+        if (el.getAttribute('contenteditable') === 'true') return 'textbox';
+        return IMPLICIT[el.tagName] || null;
+    }
+    const candidates = Array.from(root.querySelectorAll('*')).filter(el => {
+        const r = implicitRoleFor(el);
+        if (r !== role) return false;
+        if (!name) return true;
+        const n = (el.getAttribute('aria-label') || el.textContent || '').trim();
+        return n === name;
+    });
+    return candidates[occurrence] || null;
+})""".replace("__IMPLICIT_ROLE_MAP__", implicit_json)
+
+
+_JS_SHADOW_RESOLVE_STAGE2 = _build_js_shadow_resolve_stage2()
 
 
 def _short_ua(ua: str) -> str:
@@ -2058,7 +2215,7 @@ class BrowserManager:
                 # contract every other ref-using path follows; surface as
                 # ref_stale so the agent re-snapshots.
                 try:
-                    locator = self._locator_from_ref(inst, from_ref)
+                    locator = await self._locator_from_ref(inst, from_ref)
                     if locator is None:
                         return {
                             "success": False,
@@ -2189,33 +2346,51 @@ class BrowserManager:
                         #   reported as a remove+add pair instead of
                         #   "unchanged". Same fix: data-testid extraction.
                         from src.browser.ref_handle import compute_element_key
-                        # frame_id / shadow_path are folded in even though
-                        # they're constant defaults today (no iframe walker
-                        # until §8.4, no shadow walker until §8.3). Keeping
-                        # the kwargs explicit at this site means the §4.2
-                        # promise — "same role+name+landmark in different
-                        # frames / shadow roots get DIFFERENT keys" —
-                        # holds the moment the walkers start populating
-                        # those fields. No code change needed there.
+                        raw_shadow = node.get("shadow_path") or ()
+                        shadow_hops: tuple[ShadowHop, ...] = tuple(
+                            ShadowHop(
+                                selector=str(hop.get("selector", "")),
+                                occurrence=int(hop.get("occurrence", 0)),
+                                discriminator=str(hop.get("discriminator", "")),
+                            )
+                            for hop in raw_shadow
+                        )
+                        # frame_id stays constant today (no iframe walker
+                        # until §8.4); ``shadow_path`` is now populated by
+                        # the §8.3 walker. ``compute_element_key`` folds
+                        # both so identical role+name+landmark in distinct
+                        # shadow roots produce different element_keys.
                         elem_key = compute_element_key(
                             role=role, name=name, landmark=landmark,
                             sibling_index=occ,
                             frame_id=None,
-                            shadow_path=(),
+                            shadow_path=shadow_hops,
                         )
                         # scope_root is finalized after the modal-scoping
                         # branch below. For now record the unscoped handle;
                         # we overwrite scope_root once we know the final
                         # dialog_active state (see scope-root patching below).
-                        refs[ref_id] = RefHandle.light_dom(
-                            page_id=snapshot_page_id,
-                            scope_root=None,
-                            role=role,
-                            name=name,
-                            occurrence=occ,
-                            disabled=bool(node.get("disabled")),
-                            element_key=elem_key,
-                        )
+                        if shadow_hops:
+                            refs[ref_id] = RefHandle.shadow(
+                                page_id=snapshot_page_id,
+                                scope_root=None,
+                                shadow_path=shadow_hops,
+                                role=role,
+                                name=name,
+                                occurrence=occ,
+                                disabled=bool(node.get("disabled")),
+                                element_key=elem_key,
+                            )
+                        else:
+                            refs[ref_id] = RefHandle.light_dom(
+                                page_id=snapshot_page_id,
+                                scope_root=None,
+                                role=role,
+                                name=name,
+                                occurrence=occ,
+                                disabled=bool(node.get("disabled")),
+                                element_key=elem_key,
+                            )
                         # Diff-mode summary — keyed by element_key so the
                         # next snapshot can match across re-renders that
                         # change ref ids. A duplicate key inside one
@@ -2573,32 +2748,33 @@ class BrowserManager:
         except Exception:
             return False
 
-    def _locator_from_ref(self, inst: CamoufoxInstance, ref: str):
-        """Build a Playwright locator from a stored RefHandle.
+    async def _locator_from_ref(self, inst: CamoufoxInstance, ref: str):
+        """Build a Playwright locator (or ElementHandle) from a stored RefHandle.
 
         Resolution order (§4.2):
             1. ``page_id`` → Page object (raises :class:`RefStale` if the
                tab has closed).
-            2. ``frame_id`` → Frame (None = main frame).  Always None in
-               v1.2; populated by §8.4 iframe traversal.
+            2. ``frame_id`` → Frame (None = main frame).  Always None
+               until §8.4 iframe traversal.
             3. ``scope_root`` — modal selector bound during snapshot, so
                occurrence indices match.
-            4. ``shadow_path`` — walk through open shadow roots.  Empty in
-               v1.2; populated by §8.3 shadow DOM walker.
+            4. ``shadow_path`` — walk open shadow roots via the
+               §8.3 two-stage ``evaluate_handle`` pattern. Returns an
+               :class:`ElementHandle` rather than a ``Locator`` because
+               ``get_by_role`` does not pierce shadow boundaries.
             5. ``get_by_role(role, name=name, exact=True).nth(occurrence)``.
 
         Returns ``None`` when ``ref`` isn't in ``inst.refs`` (classic
         not-found).  Raises :class:`RefStale` when the ref points to a
-        closed tab — caller should report ``ref_stale`` to the agent so
-        it knows to re-snapshot rather than retry.
+        closed tab, a missing shadow host, or a discriminator mismatch —
+        callers should report ``ref_stale`` so the agent re-snapshots.
         """
         handle = inst.refs.get(ref)
         if handle is None:
             return None
-        # Resolve Page; may raise RefStale.
         page = inst._resolve_page_id(handle.page_id)
-        # v1.2: frame/shadow always empty — light DOM, main frame. Those
-        # branches activate in §8.3 / §8.4.
+        if handle.shadow_path:
+            return await self._resolve_shadow_element(page, handle, ref)
         base = page
         if handle.scope_root:
             base = page.locator(handle.scope_root)
@@ -2607,6 +2783,47 @@ class BrowserManager:
         else:
             locator = base.get_by_role(handle.role)
         return locator.nth(handle.occurrence)
+
+    async def _resolve_shadow_element(self, page, handle: RefHandle, ref: str):
+        """Two-stage resolver for refs whose ``shadow_path`` is non-empty.
+
+        Stage 1 walks the path to the inner ``shadowRoot``, verifying
+        each host's discriminator. Stage 2 picks the role+name match at
+        the requested occurrence inside that root. Either stage can
+        raise :class:`RefStale` when the DOM has shifted since snapshot.
+        """
+        path_payload = [
+            {
+                "selector": hop.selector,
+                "occurrence": hop.occurrence,
+                "discriminator": hop.discriminator,
+            }
+            for hop in handle.shadow_path
+        ]
+        stage1 = await page.evaluate_handle(
+            _JS_SHADOW_RESOLVE_STAGE1,
+            {"path": json.dumps(path_payload)},
+        )
+        try:
+            err = await stage1.evaluate("(v) => v && v.error ? v.error : null")
+        except Exception:
+            err = None
+        if err == "stale_host_missing":
+            raise RefStale("shadow host missing", ref=ref)
+        if err == "stale_discriminator_mismatch":
+            raise RefStale("shadow host discriminator changed", ref=ref)
+        stage2 = await stage1.evaluate_handle(
+            _JS_SHADOW_RESOLVE_STAGE2,
+            {
+                "role": handle.role,
+                "name": handle.name,
+                "occurrence": handle.occurrence,
+            },
+        )
+        element = stage2.as_element()
+        if element is None:
+            raise RefStale("shadow element not found at occurrence", ref=ref)
+        return element
 
     async def _human_click(self, page, locator, *, force: bool = False,
                            timeout: int = _CLICK_TIMEOUT_MS) -> None:
@@ -3162,7 +3379,7 @@ class BrowserManager:
                             "Auto-force click on disabled %s ref=%s for '%s'",
                             ref_info.role, ref, agent_id,
                         )
-                    locator = self._locator_from_ref(inst, ref)
+                    locator = await self._locator_from_ref(inst, ref)
                     if locator:
                         if inst.x11_wid and self._is_x11_site(inst):
                             try:
@@ -3298,7 +3515,7 @@ class BrowserManager:
         async with inst.lock:
             try:
                 if ref and ref in inst.refs:
-                    locator = self._locator_from_ref(inst, ref)
+                    locator = await self._locator_from_ref(inst, ref)
                     if not locator:
                         return {"success": False, "error": f"Ref '{ref}' not found"}
                     if inst.x11_wid and self._is_x11_site(inst):
@@ -3363,7 +3580,7 @@ class BrowserManager:
                 _use_x11 = bool(inst.x11_wid) and self._is_x11_site(inst)
 
                 if ref and ref in inst.refs:
-                    locator = self._locator_from_ref(inst, ref)
+                    locator = await self._locator_from_ref(inst, ref)
                     if not locator:
                         return {"success": False, "error": f"Ref '{ref}' not found"}
                     if _use_x11:
@@ -3632,7 +3849,7 @@ class BrowserManager:
                 if ref:
                     if ref not in inst.refs:
                         return {"success": False, "error": f"Ref '{ref}' not found in snapshot"}
-                    locator = self._locator_from_ref(inst, ref)
+                    locator = await self._locator_from_ref(inst, ref)
                     if locator:
                         await locator.scroll_into_view_if_needed(timeout=5000)
                         return {"success": True, "data": {"scrolled_to_ref": ref}}
@@ -3815,7 +4032,7 @@ class BrowserManager:
                             "success": False,
                             "error": f"Upload path not found: {p}",
                         }
-                locator = self._locator_from_ref(inst, ref)
+                locator = await self._locator_from_ref(inst, ref)
                 if not locator:
                     return {"success": False, "error": f"Ref '{ref}' not found"}
                 # Race: the click that triggers the chooser must happen
@@ -3860,7 +4077,7 @@ class BrowserManager:
                         "success": False,
                         "error": "User has browser control — action paused",
                     }
-                locator = self._locator_from_ref(inst, ref)
+                locator = await self._locator_from_ref(inst, ref)
                 if not locator:
                     return {"success": False, "error": f"Ref '{ref}' not found"}
 

--- a/src/browser/service.py
+++ b/src/browser/service.py
@@ -281,6 +281,71 @@ _IMPLICIT_ROLE_MAP: dict[str, str] = {
 }
 
 
+# Shared JS source for accessible-name extraction. Injected into BOTH the
+# walker (which produces ``name`` for emitted nodes) and the Stage-2
+# resolver (which matches candidates by name inside a shadowRoot). Single
+# source of truth — if these diverged, an element snapshotted with name
+# from e.g. ``placeholder`` would never re-resolve via Stage 2 and the
+# agent would see spurious ``ref_stale``. Defines two functions:
+#
+#   implicitRoleFor(el)              — implicit ARIA role mapping
+#   accessibleName(el, role)         — same priority chain as W3C ACCNAME:
+#       aria-label → aria-labelledby → label[for=] / wrapping <label>
+#       → alt (img) → placeholder/title (input/textarea/select)
+#       → textContent for name-from-content roles → title fallback
+#
+# IMPLICIT and INPUT_ROLES must already be in scope at the injection site.
+_JS_NAME_HELPERS = r"""
+    function implicitRoleFor(el) {
+        const r = el.getAttribute('role');
+        if (r) return r.split(/\s+/)[0].toLowerCase();
+        if (el.tagName === 'A') return el.hasAttribute('href') ? 'link' : null;
+        if (el.tagName === 'INPUT') return INPUT_ROLES[(el.type||'text').toLowerCase()] || null;
+        if (el.getAttribute('contenteditable') === 'true') return 'textbox';
+        return IMPLICIT[el.tagName] || null;
+    }
+    function accessibleName(el, role) {
+        let n = el.getAttribute('aria-label');
+        if (n) return n.trim();
+        const by = el.getAttribute('aria-labelledby');
+        if (by) {
+            const root = el.getRootNode();
+            const lookup = (root && root.getElementById) ? root : document;
+            const t = by.split(/\s+/).map(id => {
+                const ref = lookup.getElementById ? lookup.getElementById(id) : document.getElementById(id);
+                return ref ? ref.textContent.trim() : '';
+            }).filter(Boolean).join(' ');
+            if (t) return t;
+        }
+        if (el.tagName === 'IMG') return (el.alt || '').trim();
+        if (['INPUT','TEXTAREA','SELECT'].includes(el.tagName)) {
+            if (el.id) {
+                const root = el.getRootNode();
+                const scope = (root && root.querySelector) ? root : document;
+                const lbl = scope.querySelector('label[for="' + CSS.escape(el.id) + '"]');
+                if (lbl) return lbl.textContent.trim().slice(0, 200);
+            }
+            const wrap = el.closest('label');
+            if (wrap) {
+                const c = wrap.cloneNode(true);
+                c.querySelectorAll('input,textarea,select').forEach(i => i.remove());
+                const t = c.textContent.trim();
+                if (t) return t.slice(0, 200);
+            }
+            return (el.placeholder || el.title || '').trim();
+        }
+        if (['button','link','tab','menuitem','menuitemcheckbox','menuitemradio',
+            'switch','option','treeitem','heading','alert','alertdialog','dialog',
+            'listbox','toolbar','menu','status'
+        ].includes(role)) {
+            const t = el.textContent;
+            if (t) { const s = t.trim(); if (s) return s.slice(0, 200); }
+        }
+        return (el.title || '').trim();
+    }
+"""
+
+
 def _build_js_a11y_tree() -> str:
     """Build the JS a11y walker source with the implicit role map injected.
 
@@ -360,65 +425,25 @@ def _build_js_a11y_tree() -> str:
         if (t) return tag + '[data-testid="' + t.replace(/"/g, '\\"') + '"]';
         return tag;
     }
-    function siblingOccurrence(host, _parent, selector) {
-        // Document-wide indexing matches the stage-1 resolver scope
-        // (root = document → root.querySelectorAll(hop.selector)). A
-        // parent-scoped count would mismatch when bestStableId collides
-        // across multiple hosts under different parents. Tradeoff: an
-        // unrelated <my-tag> inserted elsewhere shifts the index.
-        const candidates = document.querySelectorAll(selector);
+    function siblingOccurrence(host, selector, scopeRoot) {
+        // Per-hop scope mirrors the stage-1 resolver: first hop uses
+        // ``document``, subsequent hops use the parent ``shadowRoot``
+        // (since stage-1 walks ``root = host.shadowRoot`` after each
+        // hop and queries ``root.querySelectorAll(hop.selector)``).
+        // Walker passes ``document`` for the top-level call and the
+        // parent shadowRoot when descending into a nested host.
+        const root = scopeRoot || document;
+        const candidates = root.querySelectorAll(selector);
         for (let i = 0; i < candidates.length; i++) {
             if (candidates[i] === host) return i;
         }
         return 0;
     }
-    function getRole(el) {
-        const r = el.getAttribute('role');
-        if (r) return r.split(/\s+/)[0].toLowerCase();
-        if (el.tagName === 'A') return el.hasAttribute('href') ? 'link' : null;
-        if (el.tagName === 'INPUT') return INPUT_ROLES[(el.type||'text').toLowerCase()] || null;
-        if (el.getAttribute('contenteditable') === 'true') return 'textbox';
-        return IMPLICIT[el.tagName] || null;
-    }
-    function getName(el, role) {
-        let n = el.getAttribute('aria-label');
-        if (n) return n.trim();
-        const by = el.getAttribute('aria-labelledby');
-        if (by) {
-            const root = el.getRootNode();
-            const lookup = (root && root.getElementById) ? root : document;
-            const t = by.split(/\s+/).map(id => {
-                const ref = lookup.getElementById ? lookup.getElementById(id) : document.getElementById(id);
-                return ref ? ref.textContent.trim() : '';
-            }).filter(Boolean).join(' ');
-            if (t) return t;
-        }
-        if (el.tagName === 'IMG') return (el.alt || '').trim();
-        if (['INPUT','TEXTAREA','SELECT'].includes(el.tagName)) {
-            if (el.id) {
-                const root = el.getRootNode();
-                const scope = (root && root.querySelector) ? root : document;
-                const lbl = scope.querySelector('label[for="' + CSS.escape(el.id) + '"]');
-                if (lbl) return lbl.textContent.trim().slice(0, 200);
-            }
-            const wrap = el.closest('label');
-            if (wrap) {
-                const c = wrap.cloneNode(true);
-                c.querySelectorAll('input,textarea,select').forEach(i => i.remove());
-                const t = c.textContent.trim();
-                if (t) return t.slice(0, 200);
-            }
-            return (el.placeholder || el.title || '').trim();
-        }
-        if (['button','link','tab','menuitem','menuitemcheckbox','menuitemradio',
-            'switch','option','treeitem','heading','alert','alertdialog','dialog',
-            'listbox','toolbar','menu','status'
-        ].includes(role)) {
-            const t = el.textContent;
-            if (t) { const s = t.trim(); if (s) return s.slice(0, 200); }
-        }
-        return (el.title || '').trim();
-    }
+__NAME_HELPERS__
+    // Walker name/role wrappers — single source of truth shared with
+    // the stage-2 resolver.
+    const getRole = implicitRoleFor;
+    const getName = accessibleName;
     function isVisible(el) {
         if (el.getAttribute && el.getAttribute('aria-hidden') === 'true') return false;
         const s = getComputedStyle(el);
@@ -430,7 +455,7 @@ def _build_js_a11y_tree() -> str:
         }
         return true;
     }
-    function walk(el, d, parentLandmark, shadowPath) {
+    function walk(el, d, parentLandmark, shadowPath, currentRoot) {
         if (d > MAX_WALK_DEPTH || !el || el.nodeType !== 1) return null;
         const tag = el.tagName;
         if (tag === 'SCRIPT' || tag === 'STYLE' || tag === 'NOSCRIPT' || tag === 'TEMPLATE')
@@ -444,18 +469,22 @@ def _build_js_a11y_tree() -> str:
         }
         const children = [];
         for (const child of el.children) {
-            const r = walk(child, d + 1, childLandmark, shadowPath);
+            const r = walk(child, d + 1, childLandmark, shadowPath, currentRoot);
             if (r) children.push(r);
         }
         if (el.shadowRoot && el.shadowRoot.mode === 'open') {
             const sel = cssPath(el);
-            const occ = siblingOccurrence(el, el.parentNode, sel);
+            // Scope occurrence to ``currentRoot`` (document for the
+            // first hop, parent shadowRoot for subsequent hops). Mirrors
+            // stage-1 resolver scope so nested hosts index identically
+            // on both sides.
+            const occ = siblingOccurrence(el, sel, currentRoot);
             const disc = bestStableId(el);
             const nextPath = shadowPath.concat([{
                 selector: sel, occurrence: occ, discriminator: disc,
             }]);
             for (const child of el.shadowRoot.children) {
-                const r = walk(child, d + 1, childLandmark, nextPath);
+                const r = walk(child, d + 1, childLandmark, nextPath, el.shadowRoot);
                 if (r) children.push(r);
             }
         }
@@ -484,13 +513,15 @@ def _build_js_a11y_tree() -> str:
         return nd;
     }
     const start = rootEl || document.body || document.documentElement;
-    const tree = walk(start, 0, null, []);
+    const tree = walk(start, 0, null, [], document);
     if (rootEl) return tree || { role: 'none', name: '', children: [] };
     if (!tree) return { role: 'WebArea', name: document.title || '', children: [] };
     if (tree.role === 'none')
         return { role: 'WebArea', name: document.title || '', children: tree.children || [] };
     return { role: 'WebArea', name: document.title || '', children: [tree] };
 })""".replace(
+        "__NAME_HELPERS__", _JS_NAME_HELPERS,
+    ).replace(
         "__IMPLICIT_ROLE_MAP__", implicit_json,
     ).replace(
         "__MAX_WALK_DEPTH__", str(_MAX_WALK_DEPTH),
@@ -521,13 +552,24 @@ _JS_A11Y_TREE = _build_js_a11y_tree()
 # Playwright-correct two-stage shadow resolver. ``get_by_role`` does NOT
 # pierce shadow boundaries, so non-empty ``shadow_path`` falls through
 # this evaluate_handle pair instead of the locator API.
+# Sentinel key for stage-1 errors. Uses a unique prefixed name rather than
+# bare ``error`` so a page that happens to set ``shadowRoot.error = 'foo'``
+# (or any expando the page might attach) cannot masquerade as a resolver
+# error. Stage-2 also rejects any rooted shadow root carrying this key as
+# an expando — defence-in-depth, since the property is on a ShadowRoot
+# object that the page does not normally write to.
+_JS_RESOLVER_ERROR_KEY = "__OL_RESOLVER_ERROR__"
+
 _JS_SHADOW_RESOLVE_STAGE1 = r"""(args) => {
+    const ERR_KEY = "__OL_RESOLVER_ERROR__";
     const path = JSON.parse(args.path);
     let root = document;
     for (const hop of path) {
         const candidates = root.querySelectorAll(hop.selector);
         const host = candidates[hop.occurrence];
-        if (!host || !host.shadowRoot) return {error: "stale_host_missing"};
+        if (!host || !host.shadowRoot) {
+            const e = {}; e[ERR_KEY] = "stale_host_missing"; return e;
+        }
         function isStableId(id) {
             if (!id) return false;
             if (/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(id)) return false;
@@ -555,7 +597,9 @@ _JS_SHADOW_RESOLVE_STAGE1 = r"""(args) => {
             return 'fp:' + fp;
         }
         const got = bestStableId(host);
-        if (got !== hop.discriminator) return {error: "stale_discriminator_mismatch"};
+        if (got !== hop.discriminator) {
+            const e = {}; e[ERR_KEY] = "stale_discriminator_mismatch"; return e;
+        }
         root = host.shadowRoot;
     }
     return root;
@@ -563,9 +607,34 @@ _JS_SHADOW_RESOLVE_STAGE1 = r"""(args) => {
 
 
 def _build_js_shadow_resolve_stage2() -> str:
+    """Stage-2 resolver: pick the role+name match at ``occurrence`` inside
+    the ShadowRoot stage-1 returned.
+
+    Uses the SAME ``accessibleName(el, role)`` helper as the walker
+    (injected via ``__NAME_HELPERS__``). If the two diverged, an element
+    snapshotted with name from e.g. ``placeholder=Search`` would never
+    match Stage 2 here and the agent would see spurious ``ref_stale``.
+    Defence-in-depth against page-controlled expandos: rejects any
+    ``root`` carrying the resolver-error sentinel even if the call site
+    forgot to pre-check it.
+    """
     implicit_json = json.dumps(_IMPLICIT_ROLE_MAP)
     return r"""((root, args) => {
-    if (!root || root.error) return null;
+    const ERR_KEY = "__OL_RESOLVER_ERROR__";
+    // TOCTOU sentinel distinct from null/undefined: caller maps this to
+    // RefStale (transient — shadow root detached between stage 1 and
+    // stage 2 evaluate_handle calls). A bare null result, by contrast,
+    // means stage 2 ran successfully but the element isn't at the
+    // requested occurrence inside an otherwise-live shadow root —
+    // that's a real "element vanished" condition.
+    if (!root) {
+        const e = {}; e[ERR_KEY] = "shadow_root_detached"; return e;
+    }
+    if (typeof root === 'object' && ERR_KEY in root) {
+        // Stage-1 already errored out; surface the same sentinel so the
+        // caller can distinguish from an element-not-found null.
+        return root;
+    }
     const role = args.role;
     const name = args.name;
     const occurrence = args.occurrence;
@@ -577,23 +646,32 @@ def _build_js_shadow_resolve_stage2() -> str:
         range:'slider',number:'spinbutton',
         submit:'button',reset:'button',button:'button'
     };
-    function implicitRoleFor(el) {
-        const r = el.getAttribute('role');
-        if (r) return r.split(/\s+/)[0].toLowerCase();
-        if (el.tagName === 'A') return el.hasAttribute('href') ? 'link' : null;
-        if (el.tagName === 'INPUT') return INPUT_ROLES[(el.type||'text').toLowerCase()] || null;
-        if (el.getAttribute('contenteditable') === 'true') return 'textbox';
-        return IMPLICIT[el.tagName] || null;
+__NAME_HELPERS__
+    let candidates;
+    try {
+        candidates = Array.from(root.querySelectorAll('*')).filter(el => {
+            const r = implicitRoleFor(el);
+            if (r !== role) return false;
+            if (!name) return true;
+            // Match using the SAME accessible-name extraction the walker
+            // ran when emitting the snapshot. Anything else (e.g. only
+            // ``aria-label || textContent``) misses elements named via
+            // ``placeholder``, ``alt``, ``aria-labelledby``, ``label[for=]``,
+            // or ``title`` — producing spurious RefStale.
+            const n = (accessibleName(el, role) || '').trim();
+            return n === name;
+        });
+    } catch (_e) {
+        // ``querySelectorAll`` on a detached ShadowRoot can throw. Treat
+        // as a transient detach rather than an element-not-found.
+        const e = {}; e[ERR_KEY] = "shadow_root_detached"; return e;
     }
-    const candidates = Array.from(root.querySelectorAll('*')).filter(el => {
-        const r = implicitRoleFor(el);
-        if (r !== role) return false;
-        if (!name) return true;
-        const n = (el.getAttribute('aria-label') || el.textContent || '').trim();
-        return n === name;
-    });
     return candidates[occurrence] || null;
-})""".replace("__IMPLICIT_ROLE_MAP__", implicit_json)
+})""".replace(
+        "__NAME_HELPERS__", _JS_NAME_HELPERS,
+    ).replace(
+        "__IMPLICIT_ROLE_MAP__", implicit_json,
+    )
 
 
 _JS_SHADOW_RESOLVE_STAGE2 = _build_js_shadow_resolve_stage2()
@@ -2829,6 +2907,21 @@ class BrowserManager:
         each host's discriminator. Stage 2 picks the role+name match at
         the requested occurrence inside that root. Either stage can
         raise :class:`RefStale` when the DOM has shifted since snapshot.
+
+        Error taxonomy:
+
+        * Stage-1 ``stale_host_missing``      → RefStale (host removed).
+        * Stage-1 ``stale_discriminator_mismatch`` → RefStale (host swapped).
+        * Stage-2 ``shadow_root_detached``    → RefStale (TOCTOU between
+          stage 1 succeeding and stage 2 running).
+        * Stage-2 returns null                → RefStale (element no
+          longer present at the requested occurrence inside an otherwise
+          live shadow root).
+
+        Errors are signaled via a unique ``__OL_RESOLVER_ERROR__`` key
+        rather than a plain ``error`` property so a page that happens to
+        attach an ``error`` expando to a ShadowRoot cannot masquerade as
+        a resolver failure.
         """
         path_payload = [
             {
@@ -2842,8 +2935,14 @@ class BrowserManager:
             _JS_SHADOW_RESOLVE_STAGE1,
             {"path": json.dumps(path_payload)},
         )
+        # Read the stage-1 error sentinel by exact key. Page-controlled
+        # ``error`` expandos cannot match because we look up
+        # ``__OL_RESOLVER_ERROR__`` specifically.
         try:
-            err = await stage1.evaluate("(v) => v && v.error ? v.error : null")
+            err = await stage1.evaluate(
+                "(v) => (v && typeof v === 'object' && '__OL_RESOLVER_ERROR__' in v)"
+                " ? v.__OL_RESOLVER_ERROR__ : null",
+            )
         except Exception:
             err = None
         if err == "stale_host_missing":
@@ -2858,6 +2957,20 @@ class BrowserManager:
                 "occurrence": handle.occurrence,
             },
         )
+        # Distinguish a detached shadow root (transient TOCTOU between
+        # stage 1 and stage 2) from a genuine element-not-found. The
+        # detached case surfaces as the ``shadow_root_detached`` sentinel
+        # so the caller emits a transient ``ref_stale`` rather than a
+        # potentially-misleading ``not_found``.
+        try:
+            stage2_err = await stage2.evaluate(
+                "(v) => (v && typeof v === 'object' && '__OL_RESOLVER_ERROR__' in v)"
+                " ? v.__OL_RESOLVER_ERROR__ : null",
+            )
+        except Exception:
+            stage2_err = None
+        if stage2_err == "shadow_root_detached":
+            raise RefStale("shadow root detached during resolve", ref=ref)
         element = stage2.as_element()
         if element is None:
             raise RefStale("shadow element not found at occurrence", ref=ref)

--- a/tests/test_browser_file_transfer.py
+++ b/tests/test_browser_file_transfer.py
@@ -81,7 +81,8 @@ class TestUploadFile:
         fake_locator = MagicMock()
         fake_locator.click = AsyncMock()
         monkeypatch.setattr(
-            mgr, "_locator_from_ref", lambda _inst, _ref: fake_locator,
+            mgr, "_locator_from_ref",
+            AsyncMock(return_value=fake_locator),
         )
         monkeypatch.setattr(mgr, "get_or_start", AsyncMock(return_value=inst))
         # Mock action_delay's sleep.
@@ -113,7 +114,8 @@ class TestUploadFile:
         fake_locator.click = AsyncMock()
         inst.page.expect_file_chooser = MagicMock()
         monkeypatch.setattr(
-            mgr, "_locator_from_ref", lambda _i, _r: fake_locator,
+            mgr, "_locator_from_ref",
+            AsyncMock(return_value=fake_locator),
         )
         monkeypatch.setattr(mgr, "get_or_start", AsyncMock(return_value=inst))
 
@@ -130,7 +132,9 @@ class TestUploadFile:
     async def test_ref_not_found_returns_error(self, tmp_path, monkeypatch):
         mgr = BrowserManager(profiles_dir=str(tmp_path / "p"))
         inst = _make_instance()
-        monkeypatch.setattr(mgr, "_locator_from_ref", lambda _i, _r: None)
+        monkeypatch.setattr(
+            mgr, "_locator_from_ref", AsyncMock(return_value=None),
+        )
         monkeypatch.setattr(mgr, "get_or_start", AsyncMock(return_value=inst))
         # Use a real path so the path-validation guard (added for upload
         # correctness) passes and we actually exercise the ref-not-found
@@ -181,7 +185,9 @@ class TestDownload:
         inst.page.expect_download = MagicMock(
             return_value=_async_ctx(_dl_value()),
         )
-        monkeypatch.setattr(mgr, "_locator_from_ref", lambda _i, _r: fake_locator)
+        monkeypatch.setattr(
+            mgr, "_locator_from_ref", AsyncMock(return_value=fake_locator),
+        )
         monkeypatch.setattr(mgr, "get_or_start", AsyncMock(return_value=inst))
 
         result = await mgr.download(
@@ -220,7 +226,9 @@ class TestDownload:
         inst.page.expect_download = MagicMock(
             return_value=_async_ctx(_dl_value()),
         )
-        monkeypatch.setattr(mgr, "_locator_from_ref", lambda _i, _r: fake_locator)
+        monkeypatch.setattr(
+            mgr, "_locator_from_ref", AsyncMock(return_value=fake_locator),
+        )
         monkeypatch.setattr(mgr, "get_or_start", AsyncMock(return_value=inst))
 
         result = await mgr.download(

--- a/tests/test_browser_service.py
+++ b/tests/test_browser_service.py
@@ -8024,9 +8024,14 @@ class TestShadowDOM:
         assert "if (d > MAX_WALK_DEPTH" in _JS_A11Y_TREE
 
     @pytest.mark.asyncio
+    @pytest.mark.browser
     @pytest.mark.skipif(
         _no_playwright(),
-        reason="playwright not installed in dev env; CI runs this",
+        reason=(
+            "playwright not in [dev] deps (browser binaries bloat install); "
+            "CI honours this skip — install manually via "
+            "'pip install playwright && playwright install firefox' to run"
+        ),
     )
     async def test_js_walker_open_shadow_root_real_browser(self):
         """Spin up a real browser, set HTML with an open shadow root,
@@ -8072,9 +8077,14 @@ class TestShadowDOM:
                 await browser.close()
 
     @pytest.mark.asyncio
+    @pytest.mark.browser
     @pytest.mark.skipif(
         _no_playwright(),
-        reason="playwright not installed in dev env; CI runs this",
+        reason=(
+            "playwright not in [dev] deps (browser binaries bloat install); "
+            "CI honours this skip — install manually via "
+            "'pip install playwright && playwright install firefox' to run"
+        ),
     )
     async def test_js_walker_closed_shadow_root_invisible_real_browser(self):
         """Real-browser test: closed shadow roots are unreachable per
@@ -8113,9 +8123,14 @@ class TestShadowDOM:
                 await browser.close()
 
     @pytest.mark.asyncio
+    @pytest.mark.browser
     @pytest.mark.skipif(
         _no_playwright(),
-        reason="playwright not installed in dev env; CI runs this",
+        reason=(
+            "playwright not in [dev] deps (browser binaries bloat install); "
+            "CI honours this skip — install manually via "
+            "'pip install playwright && playwright install firefox' to run"
+        ),
     )
     async def test_js_walker_depth_cap_real_browser(self):
         """Real-browser test: a 60-deep nested DOM must produce zero
@@ -8334,3 +8349,313 @@ class TestShadowDOM:
         result = await mgr.click("a1", ref="e0")
         assert result["success"] is True
         element_handle.click.assert_called()
+
+    # ── Codex-review fixes (Fix 1, 2, 4, 5) ─────────────────────────────────
+
+    def test_walker_and_stage2_share_name_extraction(self):
+        """Fix 1 — walker and stage-2 must use the *same* accessible-name
+        extraction. Both JS bodies must contain the shared
+        ``accessibleName`` helper string so a name emitted from
+        ``placeholder``/``alt``/``aria-labelledby``/``label[for=]``/etc.
+        in the walker is matchable in stage 2.
+        """
+        from src.browser.service import (
+            _JS_A11Y_TREE,
+            _JS_NAME_HELPERS,
+            _JS_SHADOW_RESOLVE_STAGE2,
+        )
+        # Sanity-check that the shared helper is well-formed.
+        assert "function accessibleName(el, role)" in _JS_NAME_HELPERS
+        assert "function implicitRoleFor(el)" in _JS_NAME_HELPERS
+        # Both JS bodies inline the shared helper. The placeholder
+        # ``__NAME_HELPERS__`` must NOT survive in either rendered body.
+        assert "__NAME_HELPERS__" not in _JS_A11Y_TREE
+        assert "__NAME_HELPERS__" not in _JS_SHADOW_RESOLVE_STAGE2
+        for js in (_JS_A11Y_TREE, _JS_SHADOW_RESOLVE_STAGE2):
+            assert "function accessibleName(el, role)" in js
+            assert "function implicitRoleFor(el)" in js
+        # Stage-2's matcher must use accessibleName(...) — not the old
+        # narrow ``aria-label || textContent`` fallback that missed
+        # placeholder/alt/labelledby.
+        assert "accessibleName(el, role)" in _JS_SHADOW_RESOLVE_STAGE2
+
+    @pytest.mark.asyncio
+    @pytest.mark.browser
+    @pytest.mark.skipif(
+        _no_playwright(),
+        reason=(
+            "playwright not in [dev] deps (browser binaries bloat install); "
+            "CI honours this skip — install manually via "
+            "'pip install playwright && playwright install firefox' to run"
+        ),
+    )
+    async def test_shadow_input_with_placeholder_resolves(self):
+        """Fix 1 (real browser) — an ``<input placeholder="Search">``
+        inside a shadow root snapshots with name "Search". Stage 2 must
+        match it via the shared ``accessibleName`` extraction; otherwise
+        the resolver returns null and the agent sees a spurious
+        ``ref_stale``.
+        """
+        from playwright.async_api import async_playwright
+
+        from src.browser.service import (
+            _JS_A11Y_TREE,
+            _JS_SHADOW_RESOLVE_STAGE1,
+            _JS_SHADOW_RESOLVE_STAGE2,
+        )
+        async with async_playwright() as p:
+            browser = await p.firefox.launch()
+            try:
+                page = await browser.new_page()
+                await page.set_content("""
+                    <html><body>
+                      <my-search id="srch"></my-search>
+                      <script>
+                        const host = document.getElementById('srch');
+                        host.setAttribute('data-testid', 'search-host');
+                        const root = host.attachShadow({mode: 'open'});
+                        const inp = document.createElement('input');
+                        inp.type = 'search';
+                        inp.placeholder = 'Search';
+                        root.appendChild(inp);
+                      </script>
+                    </body></html>
+                """)
+                tree = await page.evaluate(_JS_A11Y_TREE)
+
+                # Find the input emitted by the walker — its name must
+                # come from the placeholder.
+                def find_searchbox(node):
+                    if node.get("role") == "searchbox":
+                        return node
+                    for c in node.get("children", []) or []:
+                        r = find_searchbox(c)
+                        if r:
+                            return r
+                    return None
+                tb = find_searchbox(tree)
+                assert tb is not None, "shadow input not in walked tree"
+                assert tb.get("name") == "Search"
+                sp = tb.get("shadow_path")
+                assert sp, "shadow input missing shadow_path"
+
+                # Now drive the actual resolver. Stage-1 returns the
+                # shadowRoot; stage-2 must find the input *by its
+                # placeholder-derived name* — that's the regression.
+                import json as _json
+                stage1 = await page.evaluate_handle(
+                    _JS_SHADOW_RESOLVE_STAGE1,
+                    {"path": _json.dumps(sp)},
+                )
+                # Verify stage-1 didn't error out.
+                err = await stage1.evaluate(
+                    "(v) => (v && typeof v === 'object' && '__OL_RESOLVER_ERROR__' in v)"
+                    " ? v.__OL_RESOLVER_ERROR__ : null",
+                )
+                assert err is None, f"stage-1 unexpectedly errored: {err}"
+                stage2 = await stage1.evaluate_handle(
+                    _JS_SHADOW_RESOLVE_STAGE2,
+                    {"role": "searchbox", "name": "Search", "occurrence": 0},
+                )
+                element = stage2.as_element()
+                assert element is not None, (
+                    "stage-2 failed to match shadow input by placeholder name"
+                )
+                tag = await element.evaluate("(el) => el.tagName")
+                assert tag == "INPUT"
+            finally:
+                await browser.close()
+
+    @pytest.mark.asyncio
+    @pytest.mark.browser
+    @pytest.mark.skipif(
+        _no_playwright(),
+        reason=(
+            "playwright not in [dev] deps (browser binaries bloat install); "
+            "CI honours this skip — install manually via "
+            "'pip install playwright && playwright install firefox' to run"
+        ),
+    )
+    async def test_nested_shadow_hosts_indexed_per_root(self):
+        """Fix 2 (real browser) — two duplicate inner shadow hosts under
+        the *same* outer shadow root must each get an occurrence index
+        scoped to that outer root. Walker and stage-1 resolver must
+        agree on the scope (per-root for hops past the first), so both
+        hosts resolve back to a real button.
+
+        Without the fix the walker computes occurrence document-wide
+        while stage-1 walks ``parentShadowRoot.querySelectorAll(...)``
+        for nested hops — they disagree → stage-1 picks the wrong host
+        → discriminator mismatch → spurious RefStale.
+        """
+        from playwright.async_api import async_playwright
+
+        from src.browser.service import (
+            _JS_A11Y_TREE,
+            _JS_SHADOW_RESOLVE_STAGE1,
+            _JS_SHADOW_RESOLVE_STAGE2,
+        )
+        async with async_playwright() as p:
+            browser = await p.firefox.launch()
+            try:
+                page = await browser.new_page()
+                await page.set_content("""
+                    <html><body>
+                      <outer-host id="outer"></outer-host>
+                      <script>
+                        const outer = document.getElementById('outer');
+                        outer.setAttribute('data-testid', 'outer');
+                        const oroot = outer.attachShadow({mode: 'open'});
+                        // Two duplicate inner hosts inside the SAME outer
+                        // shadow root.
+                        for (let i = 0; i < 2; i++) {
+                          const inner = document.createElement('inner-host');
+                          inner.setAttribute('data-testid', 'inner-' + i);
+                          const iroot = inner.attachShadow({mode: 'open'});
+                          const btn = document.createElement('button');
+                          btn.textContent = 'Inner-' + i;
+                          iroot.appendChild(btn);
+                          oroot.appendChild(inner);
+                        }
+                      </script>
+                    </body></html>
+                """)
+                tree = await page.evaluate(_JS_A11Y_TREE)
+
+                # Collect both inner buttons with their shadow paths.
+                buttons = []
+                def collect(node):
+                    if node.get("role") == "button":
+                        buttons.append(node)
+                    for c in node.get("children", []) or []:
+                        collect(c)
+                collect(tree)
+                assert len(buttons) == 2, f"expected 2 inner buttons, got {len(buttons)}"
+                names = sorted(b.get("name") for b in buttons)
+                assert names == ["Inner-0", "Inner-1"]
+
+                # Each button has a 2-hop shadow path. The inner hop's
+                # ``occurrence`` must be 0 / 1 *within the outer root*,
+                # not document-scoped.
+                import json as _json
+                for btn in buttons:
+                    sp = btn.get("shadow_path")
+                    assert sp and len(sp) == 2, f"expected 2-hop path, got {sp}"
+                    # Resolve via the actual stage-1 + stage-2 pipeline.
+                    stage1 = await page.evaluate_handle(
+                        _JS_SHADOW_RESOLVE_STAGE1,
+                        {"path": _json.dumps(sp)},
+                    )
+                    err = await stage1.evaluate(
+                        "(v) => (v && typeof v === 'object' && '__OL_RESOLVER_ERROR__' in v)"
+                        " ? v.__OL_RESOLVER_ERROR__ : null",
+                    )
+                    assert err is None, (
+                        f"nested-host resolution errored for {btn['name']}: {err}"
+                    )
+                    stage2 = await stage1.evaluate_handle(
+                        _JS_SHADOW_RESOLVE_STAGE2,
+                        {
+                            "role": "button",
+                            "name": btn["name"],
+                            "occurrence": 0,
+                        },
+                    )
+                    element = stage2.as_element()
+                    assert element is not None, (
+                        f"stage-2 returned null for nested button {btn['name']}"
+                    )
+                    text = await element.evaluate("(el) => el.textContent")
+                    assert text == btn["name"]
+            finally:
+                await browser.close()
+
+    def test_stage1_uses_unique_resolver_error_sentinel(self):
+        """Fix 4 — stage 1 must signal errors via the unique
+        ``__OL_RESOLVER_ERROR__`` key, not bare ``error``. A page that
+        attaches an ``error`` expando to a ShadowRoot must NOT be able
+        to masquerade as a resolver error.
+        """
+        from src.browser.service import _JS_SHADOW_RESOLVE_STAGE1
+        # Sentinel key appears in the stage-1 body; bare ``error: "..."``
+        # must NOT be the only signal (i.e. ``return {error: "..."}`` is
+        # gone).
+        assert "__OL_RESOLVER_ERROR__" in _JS_SHADOW_RESOLVE_STAGE1
+        assert 'return {error: "stale_host_missing"}' not in _JS_SHADOW_RESOLVE_STAGE1
+        assert (
+            'return {error: "stale_discriminator_mismatch"}'
+            not in _JS_SHADOW_RESOLVE_STAGE1
+        )
+
+    @pytest.mark.asyncio
+    async def test_stale_host_uses_sentinel_key_not_bare_error(self):
+        """Fix 4 (Python side) — the resolver looks for the sentinel
+        ``__OL_RESOLVER_ERROR__`` value via the ``in`` operator on the
+        returned object, NOT a generic truthiness check on ``v.error``.
+        Mirrored here by mocking what ``stage1.evaluate(...)`` returns
+        with the new sentinel-key probe text and confirming the Python
+        path interprets the value correctly.
+        """
+        from src.browser.ref_handle import RefHandle, RefStale, ShadowHop
+        from src.browser.service import BrowserManager, CamoufoxInstance
+        mgr = BrowserManager(profiles_dir="/tmp/test_profiles")
+
+        mock_page = MagicMock()
+        stage1_handle = AsyncMock()
+        # The Python resolver evaluates a key-exact probe on the
+        # returned object. Whatever string it picks out *via that probe*
+        # is what we assert on. Mock returns the resolved sentinel value
+        # — the same shape the real probe produces.
+        stage1_handle.evaluate = AsyncMock(return_value="stale_host_missing")
+        mock_page.evaluate_handle = AsyncMock(return_value=stage1_handle)
+
+        inst = CamoufoxInstance("a1", MagicMock(), MagicMock(), mock_page)
+        page_id = inst._page_id_for(inst.page)
+        inst.refs["e0"] = RefHandle.shadow(
+            page_id=page_id, scope_root=None,
+            shadow_path=(ShadowHop("ghost-card", 0, "testid:gone"),),
+            role="button", name="Submit", occurrence=0, disabled=False,
+        )
+
+        with pytest.raises(RefStale):
+            await mgr._locator_from_ref(inst, "e0")
+
+        # The probe script must look up the sentinel key, NOT v.error.
+        eval_call = stage1_handle.evaluate.call_args
+        probe_src = eval_call[0][0]
+        assert "__OL_RESOLVER_ERROR__" in probe_src
+        assert "v.error" not in probe_src
+
+    @pytest.mark.asyncio
+    async def test_locator_from_ref_raises_ref_stale_on_detached_shadow_root(self):
+        """Fix 5 — when stage 1 succeeded but stage 2 sees a detached
+        shadow root (TOCTOU between the two evaluate_handle calls),
+        the resolver must raise ``RefStale("shadow root detached…")``,
+        not let it fall through to a plain element-not-found path.
+        """
+        from src.browser.ref_handle import RefHandle, RefStale, ShadowHop
+        from src.browser.service import BrowserManager, CamoufoxInstance
+        mgr = BrowserManager(profiles_dir="/tmp/test_profiles")
+
+        mock_page = MagicMock()
+        stage1_handle = AsyncMock()
+        stage1_handle.evaluate = AsyncMock(return_value=None)  # stage 1 OK
+        stage2_handle = AsyncMock()
+        # Stage-2 reports the detach sentinel via its evaluate probe.
+        stage2_handle.evaluate = AsyncMock(return_value="shadow_root_detached")
+        # ``as_element`` returns None because the JS object is the
+        # sentinel dict rather than an Element handle.
+        stage2_handle.as_element = MagicMock(return_value=None)
+        stage1_handle.evaluate_handle = AsyncMock(return_value=stage2_handle)
+        mock_page.evaluate_handle = AsyncMock(return_value=stage1_handle)
+
+        inst = CamoufoxInstance("a1", MagicMock(), MagicMock(), mock_page)
+        page_id = inst._page_id_for(inst.page)
+        inst.refs["e0"] = RefHandle.shadow(
+            page_id=page_id, scope_root=None,
+            shadow_path=(ShadowHop("my-card", 0, "testid:c"),),
+            role="button", name="Submit", occurrence=0, disabled=False,
+        )
+
+        with pytest.raises(RefStale, match="detached"):
+            await mgr._locator_from_ref(inst, "e0")

--- a/tests/test_browser_service.py
+++ b/tests/test_browser_service.py
@@ -7365,7 +7365,7 @@ class TestFindText:
             return {"success": True, "data": {}}
 
         with patch.object(BrowserManager, "get_or_start", return_value=inst), \
-             patch.object(BrowserManager, "_locator_from_ref", return_value=mock_locator), \
+             patch.object(BrowserManager, "_locator_from_ref", new_callable=AsyncMock, return_value=mock_locator), \
              patch.object(BrowserManager, "_snapshot_impl", new=fake_snapshot):
             result = await mgr.find_text("agent1", "submit")
 
@@ -7430,7 +7430,7 @@ class TestFindText:
             return {"success": True, "data": {}}
 
         with patch.object(BrowserManager, "get_or_start", return_value=inst), \
-             patch.object(BrowserManager, "_locator_from_ref", return_value=mock_locator), \
+             patch.object(BrowserManager, "_locator_from_ref", new_callable=AsyncMock, return_value=mock_locator), \
              patch.object(BrowserManager, "_snapshot_impl", new=fake_snapshot):
             result = await mgr.find_text("agent1", "save", scroll=True)
 
@@ -7456,7 +7456,7 @@ class TestFindText:
             return {"success": True, "data": {}}
 
         with patch.object(BrowserManager, "get_or_start", return_value=inst), \
-             patch.object(BrowserManager, "_locator_from_ref", return_value=mock_locator), \
+             patch.object(BrowserManager, "_locator_from_ref", new_callable=AsyncMock, return_value=mock_locator), \
              patch.object(BrowserManager, "_snapshot_impl", new=fake_snapshot):
             result = await mgr.find_text("agent1", "save", scroll=False)
 
@@ -7495,7 +7495,7 @@ class TestFindText:
             return {"success": True, "data": {}}
 
         with patch.object(BrowserManager, "get_or_start", return_value=inst), \
-             patch.object(BrowserManager, "_locator_from_ref", return_value=mock_locator), \
+             patch.object(BrowserManager, "_locator_from_ref", new_callable=AsyncMock, return_value=mock_locator), \
              patch.object(BrowserManager, "_snapshot_impl", new=fake_snapshot):
             result = await mgr.find_text("agent1", "save")
 
@@ -7520,7 +7520,7 @@ class TestFindText:
             return {"success": True, "data": {}}
 
         with patch.object(BrowserManager, "get_or_start", return_value=inst), \
-             patch.object(BrowserManager, "_locator_from_ref", return_value=mock_locator), \
+             patch.object(BrowserManager, "_locator_from_ref", new_callable=AsyncMock, return_value=mock_locator), \
              patch.object(BrowserManager, "_snapshot_impl", new=fake_snapshot):
             result = await mgr.find_text("agent1", "STRASSE")
 
@@ -7546,7 +7546,7 @@ class TestFindText:
             return {"success": True, "data": {}}
 
         with patch.object(BrowserManager, "get_or_start", return_value=inst), \
-             patch.object(BrowserManager, "_locator_from_ref", return_value=mock_locator), \
+             patch.object(BrowserManager, "_locator_from_ref", new_callable=AsyncMock, return_value=mock_locator), \
              patch.object(BrowserManager, "_snapshot_impl", new=fake_snapshot):
             result = await mgr.find_text("agent1", "save")
 
@@ -7573,7 +7573,7 @@ class TestFindText:
             return {"success": True, "data": {}}
 
         with patch.object(BrowserManager, "get_or_start", return_value=inst), \
-             patch.object(BrowserManager, "_locator_from_ref", return_value=mock_locator), \
+             patch.object(BrowserManager, "_locator_from_ref", new_callable=AsyncMock, return_value=mock_locator), \
              patch.object(BrowserManager, "_snapshot_impl", new=fake_snapshot):
             result = await mgr.find_text("agent1", "submit")
 
@@ -7601,6 +7601,7 @@ class TestFindText:
         mock_page.viewport_size = {"width": 1280, "height": 720}
         mock_page.accessibility = MagicMock()
         mock_page.accessibility.snapshot = AsyncMock(return_value=tree_v1)
+        mock_page.evaluate = AsyncMock(return_value=tree_v1)
         inst = CamoufoxInstance("agent1", MagicMock(), MagicMock(), mock_page)
         mgr._instances["agent1"] = inst
 
@@ -7618,12 +7619,13 @@ class TestFindText:
             ],
         }
         mock_page.accessibility.snapshot = AsyncMock(return_value=tree_v2)
+        mock_page.evaluate = AsyncMock(return_value=tree_v2)
 
         mock_locator = AsyncMock()
         mock_locator.is_visible = AsyncMock(return_value=False)
         mock_locator.bounding_box = AsyncMock(return_value=None)
         mock_locator.scroll_into_view_if_needed = AsyncMock()
-        with patch.object(BrowserManager, "_locator_from_ref", return_value=mock_locator):
+        with patch.object(BrowserManager, "_locator_from_ref", new_callable=AsyncMock, return_value=mock_locator):
             result = await mgr.find_text("agent1", "submit")
 
         assert result["success"] is True

--- a/tests/test_browser_service.py
+++ b/tests/test_browser_service.py
@@ -1270,6 +1270,7 @@ class TestSnapshot:
         mock_page = AsyncMock()
         mock_page.accessibility = MagicMock()
         mock_page.accessibility.snapshot = AsyncMock(return_value=None)
+        mock_page.evaluate = mock_page.accessibility.snapshot
         inst = CamoufoxInstance("a1", MagicMock(), MagicMock(), mock_page)
         mgr._instances["a1"] = inst
 
@@ -1295,6 +1296,7 @@ class TestSnapshot:
         }
         mock_page.accessibility = MagicMock()
         mock_page.accessibility.snapshot = AsyncMock(return_value=tree)
+        mock_page.evaluate = mock_page.accessibility.snapshot
         inst = CamoufoxInstance("a1", MagicMock(), MagicMock(), mock_page)
         mgr._instances["a1"] = inst
 
@@ -1331,6 +1333,7 @@ class TestSnapshot:
         }
         mock_page.accessibility = MagicMock()
         mock_page.accessibility.snapshot = AsyncMock(return_value=tree)
+        mock_page.evaluate = mock_page.accessibility.snapshot
         inst = CamoufoxInstance("a1", MagicMock(), MagicMock(), mock_page)
         mgr._instances["a1"] = inst
 
@@ -1361,6 +1364,7 @@ class TestSnapshot:
         }
         mock_page.accessibility = MagicMock()
         mock_page.accessibility.snapshot = AsyncMock(return_value=tree)
+        mock_page.evaluate = mock_page.accessibility.snapshot
         inst = CamoufoxInstance("a1", MagicMock(), MagicMock(), mock_page)
         mgr._instances["a1"] = inst
 
@@ -1395,6 +1399,7 @@ class TestSnapshot:
         tree = {"role": "WebArea", "name": "", "children": children}
         mock_page.accessibility = MagicMock()
         mock_page.accessibility.snapshot = AsyncMock(return_value=tree)
+        mock_page.evaluate = mock_page.accessibility.snapshot
         inst = CamoufoxInstance("a1", MagicMock(), MagicMock(), mock_page)
         mgr._instances["a1"] = inst
 
@@ -1426,6 +1431,7 @@ class TestSnapshotFormatV2:
                  "landmark": "navigation: Top"},
             ],
         })
+        mock_page.evaluate = mock_page.accessibility.snapshot
         inst = CamoufoxInstance("a1", MagicMock(), MagicMock(), mock_page)
         mgr._instances["a1"] = inst
 
@@ -1444,6 +1450,7 @@ class TestSnapshotFormatV2:
             "role": "WebArea", "name": "",
             "children": [{"role": "button", "name": "Click"}],
         })
+        mock_page.evaluate = mock_page.accessibility.snapshot
         inst = CamoufoxInstance("a1", MagicMock(), MagicMock(), mock_page)
         mgr._instances["a1"] = inst
 
@@ -1474,6 +1481,7 @@ class TestSnapshotFormatV2:
                  ]},
             ],
         })
+        mock_page.evaluate = mock_page.accessibility.snapshot
         inst = CamoufoxInstance("a1", MagicMock(), MagicMock(), mock_page)
         mgr._instances["a1"] = inst
 
@@ -1499,6 +1507,7 @@ class TestSnapshotFormatV2:
                 {"role": "button", "name": "Loose"},
             ],
         })
+        mock_page.evaluate = mock_page.accessibility.snapshot
         inst = CamoufoxInstance("a1", MagicMock(), MagicMock(), mock_page)
         mgr._instances["a1"] = inst
 
@@ -1635,6 +1644,7 @@ class TestSnapshotFormatV2:
         mock_page.accessibility.snapshot = AsyncMock(
             side_effect=accessibility_calls + [second_pass_tree] * 5,
         )
+        mock_page.evaluate = mock_page.accessibility.snapshot
         inst = CamoufoxInstance("a1", MagicMock(), MagicMock(), mock_page)
         mgr._instances["a1"] = inst
 
@@ -1679,6 +1689,7 @@ class TestSnapshotFilter:
         mock_page.accessibility.snapshot = AsyncMock(
             return_value=self._mixed_tree(),
         )
+        mock_page.evaluate = mock_page.accessibility.snapshot
         inst = CamoufoxInstance("a1", MagicMock(), MagicMock(), mock_page)
         mgr._instances["a1"] = inst
         return await mgr.snapshot("a1", filter=filter_value)
@@ -1771,6 +1782,7 @@ class TestSnapshotFromRef:
         mock_page.accessibility.snapshot = AsyncMock(return_value={
             "role": "WebArea", "name": "", "children": [],
         })
+        mock_page.evaluate = mock_page.accessibility.snapshot
         inst = CamoufoxInstance("a1", MagicMock(), MagicMock(), mock_page)
         mgr._instances["a1"] = inst
         result = await mgr.snapshot("a1", from_ref="e99")
@@ -1809,6 +1821,7 @@ class TestSnapshotFromRef:
                 {"role": "textbox", "name": "Password"},
             ],
         })
+        mock_page.evaluate = mock_page.accessibility.snapshot
         inst = CamoufoxInstance("a1", MagicMock(), MagicMock(), mock_page)
 
         page_id = inst._page_id_for(inst.page)
@@ -1820,9 +1833,9 @@ class TestSnapshotFromRef:
         # 2. Stub ``_locator_from_ref`` so it returns a Locator-like object
         # whose ``element_handle`` returns a stub ElementHandle. The
         # ``_build_a11y_tree`` with ``root=<handle>`` path will be exercised.
-        scoped_handle = MagicMock()  # ElementHandle stand-in
-        # In this branch the page-level fallback uses ``root.evaluate``
-        # rather than ``page.accessibility.snapshot``. Stub that path.
+        # Post-P0.3, ``_build_a11y_tree`` runs ``root.evaluate(_JS_A11Y_TREE)``
+        # for scoped trees (the native ``page.accessibility.snapshot(root=...)``
+        # path is gone) — so the stub ElementHandle must mock ``evaluate``.
         scoped_tree = {
             "role": "form", "name": "Login",
             "children": [
@@ -1830,9 +1843,8 @@ class TestSnapshotFromRef:
                 {"role": "textbox", "name": "Password"},
             ],
         }
-        # Make Camoufox's accessibility.snapshot(root=...) succeed too —
-        # _build_a11y_tree tries the native API first.
-        mock_page.accessibility.snapshot = AsyncMock(return_value=scoped_tree)
+        scoped_handle = AsyncMock()  # ElementHandle stand-in
+        scoped_handle.evaluate = AsyncMock(return_value=scoped_tree)
 
         fake_locator = AsyncMock()
         fake_locator.element_handle = AsyncMock(return_value=scoped_handle)
@@ -1857,17 +1869,19 @@ class TestSnapshotFromRef:
         from src.browser.service import BrowserManager, CamoufoxInstance
         mgr = BrowserManager(profiles_dir="/tmp/test_profiles")
 
-        mock_page = AsyncMock()
-        mock_page.accessibility = MagicMock()
-        # Scoped tree contains a heading + a button + a textbox.
-        mock_page.accessibility.snapshot = AsyncMock(return_value={
+        scoped_tree = {
             "role": "form", "name": "Login",
             "children": [
                 {"role": "heading", "name": "Sign in"},
                 {"role": "button", "name": "Submit"},
                 {"role": "textbox", "name": "Email"},
             ],
-        })
+        }
+        mock_page = AsyncMock()
+        mock_page.accessibility = MagicMock()
+        # Scoped tree contains a heading + a button + a textbox.
+        mock_page.accessibility.snapshot = AsyncMock(return_value=scoped_tree)
+        mock_page.evaluate = mock_page.accessibility.snapshot
         inst = CamoufoxInstance("a1", MagicMock(), MagicMock(), mock_page)
         page_id = inst._page_id_for(inst.page)
         inst.refs["e0"] = RefHandle.light_dom(
@@ -1876,8 +1890,12 @@ class TestSnapshotFromRef:
         )
         mgr._instances["a1"] = inst
 
+        # P0.3: scoped trees come from ``root.evaluate(_JS_A11Y_TREE)`` —
+        # mock that on the stub ElementHandle.
+        scoped_handle = AsyncMock()
+        scoped_handle.evaluate = AsyncMock(return_value=scoped_tree)
         fake_locator = AsyncMock()
-        fake_locator.element_handle = AsyncMock(return_value=MagicMock())
+        fake_locator.element_handle = AsyncMock(return_value=scoped_handle)
         with patch.object(
             BrowserManager, "_locator_from_ref",
             new_callable=AsyncMock, return_value=fake_locator,
@@ -1900,15 +1918,17 @@ class TestSnapshotFromRef:
         from src.browser.service import _MODAL_SELECTOR, BrowserManager, CamoufoxInstance
         mgr = BrowserManager(profiles_dir="/tmp/test_profiles")
 
-        mock_page = AsyncMock()
-        mock_page.accessibility = MagicMock()
-        mock_page.accessibility.snapshot = AsyncMock(return_value={
+        scoped_tree = {
             "role": "form", "name": "Compose",
             "children": [
                 {"role": "button", "name": "Post"},
                 {"role": "button", "name": "Cancel"},
             ],
-        })
+        }
+        mock_page = AsyncMock()
+        mock_page.accessibility = MagicMock()
+        mock_page.accessibility.snapshot = AsyncMock(return_value=scoped_tree)
+        mock_page.evaluate = mock_page.accessibility.snapshot
         inst = CamoufoxInstance("a1", MagicMock(), MagicMock(), mock_page)
         # Simulate live modal state at the time the agent calls snapshot.
         inst.dialog_active = True
@@ -1920,8 +1940,10 @@ class TestSnapshotFromRef:
         )
         mgr._instances["a1"] = inst
 
+        scoped_handle = AsyncMock()
+        scoped_handle.evaluate = AsyncMock(return_value=scoped_tree)
         fake_locator = AsyncMock()
-        fake_locator.element_handle = AsyncMock(return_value=MagicMock())
+        fake_locator.element_handle = AsyncMock(return_value=scoped_handle)
         with patch.object(
             BrowserManager, "_locator_from_ref",
             new_callable=AsyncMock, return_value=fake_locator,
@@ -1946,12 +1968,14 @@ class TestSnapshotFromRef:
         from src.browser.service import BrowserManager, CamoufoxInstance
         mgr = BrowserManager(profiles_dir="/tmp/test_profiles")
 
-        mock_page = AsyncMock()
-        mock_page.accessibility = MagicMock()
-        mock_page.accessibility.snapshot = AsyncMock(return_value={
+        scoped_tree = {
             "role": "form", "name": "Login",
             "children": [{"role": "button", "name": "Submit"}],
-        })
+        }
+        mock_page = AsyncMock()
+        mock_page.accessibility = MagicMock()
+        mock_page.accessibility.snapshot = AsyncMock(return_value=scoped_tree)
+        mock_page.evaluate = mock_page.accessibility.snapshot
         inst = CamoufoxInstance("a1", MagicMock(), MagicMock(), mock_page)
         # No modal active.
         inst.dialog_active = False
@@ -1962,8 +1986,10 @@ class TestSnapshotFromRef:
         )
         mgr._instances["a1"] = inst
 
+        scoped_handle = AsyncMock()
+        scoped_handle.evaluate = AsyncMock(return_value=scoped_tree)
         fake_locator = AsyncMock()
-        fake_locator.element_handle = AsyncMock(return_value=MagicMock())
+        fake_locator.element_handle = AsyncMock(return_value=scoped_handle)
         with patch.object(
             BrowserManager, "_locator_from_ref",
             new_callable=AsyncMock, return_value=fake_locator,
@@ -1987,12 +2013,14 @@ class TestSnapshotFromRef:
         from src.browser.service import BrowserManager, CamoufoxInstance
         monkeypatch.setenv("BROWSER_SNAPSHOT_FORMAT", "v2")
         mgr = BrowserManager(profiles_dir="/tmp/test_profiles")
-        mock_page = AsyncMock()
-        mock_page.accessibility = MagicMock()
-        mock_page.accessibility.snapshot = AsyncMock(return_value={
+        scoped_tree = {
             "role": "form", "name": "Login",
             "children": [{"role": "button", "name": "Submit"}],
-        })
+        }
+        mock_page = AsyncMock()
+        mock_page.accessibility = MagicMock()
+        mock_page.accessibility.snapshot = AsyncMock(return_value=scoped_tree)
+        mock_page.evaluate = mock_page.accessibility.snapshot
         inst = CamoufoxInstance("a1", MagicMock(), MagicMock(), mock_page)
         page_id = inst._page_id_for(inst.page)
         inst.refs["e0"] = RefHandle.light_dom(
@@ -2001,8 +2029,10 @@ class TestSnapshotFromRef:
         )
         mgr._instances["a1"] = inst
 
+        scoped_handle = AsyncMock()
+        scoped_handle.evaluate = AsyncMock(return_value=scoped_tree)
         fake_locator = AsyncMock()
-        fake_locator.element_handle = AsyncMock(return_value=MagicMock())
+        fake_locator.element_handle = AsyncMock(return_value=scoped_handle)
         with patch.object(
             BrowserManager, "_locator_from_ref",
             new_callable=AsyncMock, return_value=fake_locator,
@@ -2024,6 +2054,7 @@ class TestDiffSnapshot:
         mock_page.url = url
         mock_page.accessibility = MagicMock()
         mock_page.accessibility.snapshot = AsyncMock(return_value=tree)
+        mock_page.evaluate = mock_page.accessibility.snapshot
         inst = CamoufoxInstance("a1", MagicMock(), MagicMock(), mock_page)
         mgr._instances["a1"] = inst
         return mgr, inst, mock_page
@@ -2078,6 +2109,7 @@ class TestDiffSnapshot:
         mgr, inst, mock_page = await self._setup(tree_v1)
         await mgr.snapshot("a1")
         mock_page.accessibility.snapshot = AsyncMock(return_value=tree_v2)
+        mock_page.evaluate = mock_page.accessibility.snapshot
         result = await mgr.snapshot("a1", diff_from_last=True)
         data = result["data"]
         assert data["scope"] == "same"
@@ -2102,6 +2134,7 @@ class TestDiffSnapshot:
         mgr, inst, mock_page = await self._setup(tree_v1)
         await mgr.snapshot("a1")
         mock_page.accessibility.snapshot = AsyncMock(return_value=tree_v2)
+        mock_page.evaluate = mock_page.accessibility.snapshot
         result = await mgr.snapshot("a1", diff_from_last=True)
         data = result["data"]
         assert len(data["removed"]) == 1
@@ -2120,6 +2153,7 @@ class TestDiffSnapshot:
         mgr, _, mock_page = await self._setup(tree_v1)
         await mgr.snapshot("a1")
         mock_page.accessibility.snapshot = AsyncMock(return_value=tree_v2)
+        mock_page.evaluate = mock_page.accessibility.snapshot
         result = await mgr.snapshot("a1", diff_from_last=True)
         data = result["data"]
         assert len(data["changed"]) == 1
@@ -2185,6 +2219,7 @@ class TestDiffSnapshot:
             "role": "WebArea", "name": "",
             "children": [{"role": "button", "name": "A"}],
         })
+        page_a.evaluate = page_a.accessibility.snapshot
         inst = CamoufoxInstance("a1", MagicMock(), MagicMock(), page_a)
         mgr._instances["a1"] = inst
         await mgr.snapshot("a1")
@@ -2198,6 +2233,7 @@ class TestDiffSnapshot:
             "role": "WebArea", "name": "",
             "children": [{"role": "button", "name": "B"}],
         })
+        page_b.evaluate = page_b.accessibility.snapshot
         # Baseline tab B too.
         inst.page = page_b
         inst._register_page(page_b)
@@ -2225,6 +2261,7 @@ class TestDiffSnapshot:
             "role": "WebArea", "name": "",
             "children": [{"role": "button", "name": "A"}],
         })
+        page_a.evaluate = page_a.accessibility.snapshot
         inst = CamoufoxInstance("a1", MagicMock(), MagicMock(), page_a)
         mgr._instances["a1"] = inst
         # Baseline tab A.
@@ -2238,6 +2275,7 @@ class TestDiffSnapshot:
             "role": "WebArea", "name": "",
             "children": [{"role": "button", "name": "B"}],
         })
+        page_b.evaluate = page_b.accessibility.snapshot
         inst.page = page_b
         inst._register_page(page_b)
         result = await mgr.snapshot("a1", diff_from_last=True)
@@ -2261,6 +2299,7 @@ class TestDiffSnapshot:
         mgr, _, mock_page = await self._setup(tree_v1)
         await mgr.snapshot("a1")
         mock_page.accessibility.snapshot = AsyncMock(return_value=tree_v2)
+        mock_page.evaluate = mock_page.accessibility.snapshot
         result = await mgr.snapshot("a1", diff_from_last=True)
         data = result["data"]
         assert len(data["changed"]) == 1
@@ -2284,6 +2323,7 @@ class TestDiffSnapshot:
         mgr, _, mock_page = await self._setup(tree_v1)
         await mgr.snapshot("a1")
         mock_page.accessibility.snapshot = AsyncMock(return_value=tree_v2)
+        mock_page.evaluate = mock_page.accessibility.snapshot
         result = await mgr.snapshot("a1", diff_from_last=True)
         data = result["data"]
         assert len(data["changed"]) == 1
@@ -2317,6 +2357,7 @@ class TestDiffSnapshot:
         mgr, _, mock_page = await self._setup(tree_v1)
         await mgr.snapshot("a1")
         mock_page.accessibility.snapshot = AsyncMock(return_value=tree_v2)
+        mock_page.evaluate = mock_page.accessibility.snapshot
         result = await mgr.snapshot("a1", diff_from_last=True)
         data = result["data"]
         # Slot-0 survivor matches baseline slot-0 key → unchanged.
@@ -2349,6 +2390,7 @@ class TestDiffSnapshot:
         mgr, _, mock_page = await self._setup(tree_v1)
         await mgr.snapshot("a1")
         mock_page.accessibility.snapshot = AsyncMock(return_value=tree_v2)
+        mock_page.evaluate = mock_page.accessibility.snapshot
         result = await mgr.snapshot("a1", diff_from_last=True)
         data = result["data"]
         # Documented limitation: duplicate-named removal is invisible
@@ -2423,8 +2465,11 @@ class TestDiffSnapshot:
             page_id=page_id, scope_root=None, role="form", name="Login",
             occurrence=0, disabled=False,
         )
+        # P0.3: scoped tree comes from ``root.evaluate(_JS_A11Y_TREE)``.
+        scoped_handle = AsyncMock()
+        scoped_handle.evaluate = AsyncMock(return_value=tree)
         fake_locator = AsyncMock()
-        fake_locator.element_handle = AsyncMock(return_value=MagicMock())
+        fake_locator.element_handle = AsyncMock(return_value=scoped_handle)
         with patch.object(
             type(mgr), "_locator_from_ref",
             new_callable=AsyncMock, return_value=fake_locator,
@@ -3437,6 +3482,7 @@ class TestNavigateBodyCap:
         a11y_tree = self._make_long_a11y(8000)
         mock_page.accessibility = AsyncMock()
         mock_page.accessibility.snapshot = AsyncMock(return_value=a11y_tree)
+        mock_page.evaluate = mock_page.accessibility.snapshot
         inst = CamoufoxInstance("a1", MagicMock(), MagicMock(), mock_page)
         mgr._instances["a1"] = inst
 
@@ -3465,6 +3511,7 @@ class TestNavigateBodyCap:
         a11y_tree = self._make_long_a11y(8000)
         mock_page.accessibility = AsyncMock()
         mock_page.accessibility.snapshot = AsyncMock(return_value=a11y_tree)
+        mock_page.evaluate = mock_page.accessibility.snapshot
         inst = CamoufoxInstance("a1", MagicMock(), MagicMock(), mock_page)
         mgr._instances["a1"] = inst
 
@@ -3499,6 +3546,7 @@ class TestNavigateRetry:
         mock_page.accessibility.snapshot = AsyncMock(return_value={
             "role": "WebArea", "name": "OK", "children": [],
         })
+        mock_page.evaluate = mock_page.accessibility.snapshot
         inst = CamoufoxInstance("a1", MagicMock(), MagicMock(), mock_page)
         mgr._instances["a1"] = inst
 
@@ -3626,6 +3674,9 @@ class TestExtractTextFromA11y:
                 {"role": "text", "name": "World"},
             ],
         })
+        # Distinct evaluate mock — this test specifically asserts the
+        # navigate body-text path does NOT call ``page.evaluate``.
+        mock_page.evaluate = AsyncMock(return_value="should-not-be-used")
         inst = CamoufoxInstance("a1", MagicMock(), MagicMock(), mock_page)
         mgr._instances["a1"] = inst
 
@@ -4297,8 +4348,9 @@ class TestSnapshotDisabledField:
         mgr.redactor = CredentialRedactor()
         inst = MagicMock()
         inst.page = AsyncMock()
-        inst.page.accessibility = MagicMock()
-        inst.page.accessibility.snapshot = AsyncMock(return_value={
+        # P0.3: snapshot path runs the JS walker via page.evaluate(),
+        # never page.accessibility.snapshot() — tree is mocked there.
+        inst.page.evaluate = AsyncMock(return_value={
             "role": "WebArea",
             "children": [
                 {"role": "button", "name": "Post", "disabled": True},
@@ -4310,7 +4362,6 @@ class TestSnapshotDisabledField:
         inst.refs = {}
         inst.lock = asyncio.Lock()
         inst.touch = MagicMock()
-        inst._js_snapshot_mode = False
 
         with patch.object(BrowserManager, "get_or_start", return_value=inst):
             result = await mgr.snapshot("agent1")
@@ -4328,8 +4379,8 @@ class TestSnapshotDisabledField:
         mgr.redactor = CredentialRedactor()
         inst = MagicMock()
         inst.page = AsyncMock()
-        inst.page.accessibility = MagicMock()
-        inst.page.accessibility.snapshot = AsyncMock(return_value={
+        # P0.3: snapshot path runs the JS walker via page.evaluate().
+        inst.page.evaluate = AsyncMock(return_value={
             "role": "WebArea",
             "children": [
                 {"role": "button", "name": "Submit"},
@@ -4341,7 +4392,6 @@ class TestSnapshotDisabledField:
         inst.refs = {}
         inst.lock = asyncio.Lock()
         inst.touch = MagicMock()
-        inst._js_snapshot_mode = False
 
         with patch.object(BrowserManager, "get_or_start", return_value=inst):
             result = await mgr.snapshot("agent1")
@@ -4818,8 +4868,10 @@ class TestDialogScoping:
     def _mock_page_with_modal(full_tree, dialog_subtree):
         """Create a mock page where DOM has a visible modal element.
 
-        full_tree: returned by page.accessibility.snapshot() (no root)
-        dialog_subtree: returned by page.accessibility.snapshot(root=modal_el)
+        full_tree: returned by ``page.evaluate(_JS_A11Y_TREE)``
+        dialog_subtree: returned by ``modal_el.evaluate(_JS_A11Y_TREE)``
+        (Post-P0.3 the snapshot path always runs the JS walker; the
+        former native ``page.accessibility.snapshot`` dispatch is gone.)
         """
         mock_page = AsyncMock()
         mock_modal_el = AsyncMock()
@@ -4827,15 +4879,20 @@ class TestDialogScoping:
         mock_modal_el.bounding_box = AsyncMock(return_value={
             "x": 100, "y": 100, "width": 400, "height": 300,
         })
+        # P0.3: scoped trees come from ``modal_el.evaluate``.
+        mock_modal_el.evaluate = AsyncMock(return_value=dialog_subtree)
         mock_page.query_selector_all = AsyncMock(return_value=[mock_modal_el])
         mock_page.viewport_size = {"width": 1280, "height": 720}
 
-        async def _snapshot(root=None):
-            if root is not None:
-                return dialog_subtree
-            return full_tree
+        # The page-level walk goes through ``page.evaluate``.
+        mock_page.evaluate = AsyncMock(return_value=full_tree)
+        # Keep the native API mocked to prove it is NOT consulted.
         mock_page.accessibility = MagicMock()
-        mock_page.accessibility.snapshot = AsyncMock(side_effect=_snapshot)
+        mock_page.accessibility.snapshot = AsyncMock(
+            side_effect=AssertionError(
+                "native a11y path must not be invoked after P0.3"
+            )
+        )
         return mock_page
 
     @staticmethod
@@ -4844,8 +4901,15 @@ class TestDialogScoping:
         mock_page = AsyncMock()
         mock_page.query_selector_all = AsyncMock(return_value=[])
         mock_page.viewport_size = {"width": 1280, "height": 720}
+        # P0.3: the snapshot path always runs the JS walker via
+        # ``page.evaluate``.
+        mock_page.evaluate = AsyncMock(return_value=full_tree)
         mock_page.accessibility = MagicMock()
-        mock_page.accessibility.snapshot = AsyncMock(return_value=full_tree)
+        mock_page.accessibility.snapshot = AsyncMock(
+            side_effect=AssertionError(
+                "native a11y path must not be invoked after P0.3"
+            )
+        )
         return mock_page
 
     @pytest.mark.asyncio
@@ -4982,6 +5046,7 @@ class TestDialogScoping:
         }
         mock_page.query_selector_all = AsyncMock(return_value=[])
         mock_page.accessibility.snapshot = AsyncMock(return_value=tree_no_dialog)
+        mock_page.evaluate = mock_page.accessibility.snapshot
         await mgr.snapshot("a1")
         assert inst.dialog_active is False
         assert len(inst.refs) == 1
@@ -5095,6 +5160,7 @@ class TestDialogScoping:
         mock_page.query_selector_all = AsyncMock(return_value=[mock_hidden_el])
         mock_page.accessibility = MagicMock()
         mock_page.accessibility.snapshot = AsyncMock(return_value=tree)
+        mock_page.evaluate = mock_page.accessibility.snapshot
         inst = CamoufoxInstance("a1", MagicMock(), MagicMock(), mock_page)
         mgr._instances["a1"] = inst
 
@@ -5136,16 +5202,22 @@ class TestDialogScoping:
         mock_modal_el.bounding_box = AsyncMock(return_value={
             "x": 100, "y": 100, "width": 400, "height": 300,
         })
+        # P0.3: scoped trees come from ``modal_el.evaluate``, not
+        # ``page.accessibility.snapshot(root=...)``.
+        async def _modal_evaluate(*_args, **_kwargs):
+            call_count[0] += 1
+            return dialog_empty if call_count[0] <= 1 else dialog_full
+        mock_modal_el.evaluate = AsyncMock(side_effect=_modal_evaluate)
         mock_page.query_selector_all = AsyncMock(return_value=[mock_modal_el])
         mock_page.viewport_size = {"width": 1280, "height": 720}
 
-        async def _snapshot(root=None):
-            if root is not None:
-                call_count[0] += 1
-                return dialog_empty if call_count[0] <= 1 else dialog_full
-            return full_tree
+        mock_page.evaluate = AsyncMock(return_value=full_tree)
         mock_page.accessibility = MagicMock()
-        mock_page.accessibility.snapshot = AsyncMock(side_effect=_snapshot)
+        mock_page.accessibility.snapshot = AsyncMock(
+            side_effect=AssertionError(
+                "native a11y path must not be invoked after P0.3"
+            )
+        )
 
         inst = CamoufoxInstance("a1", MagicMock(), MagicMock(), mock_page)
         mgr._instances["a1"] = inst
@@ -5189,15 +5261,17 @@ class TestDialogScoping:
         mock_modal_el.bounding_box = AsyncMock(return_value={
             "x": 100, "y": 100, "width": 400, "height": 300,
         })
+        # P0.3: scoped trees come from ``modal_el.evaluate``.
+        mock_modal_el.evaluate = AsyncMock(return_value=dialog_subtree)
         mock_page.query_selector_all = AsyncMock(return_value=[mock_modal_el])
         mock_page.viewport_size = {"width": 1280, "height": 720}
-
-        async def _snapshot(root=None):
-            if root is not None:
-                return dialog_subtree
-            return full_tree
+        mock_page.evaluate = AsyncMock(return_value=full_tree)
         mock_page.accessibility = MagicMock()
-        mock_page.accessibility.snapshot = AsyncMock(side_effect=_snapshot)
+        mock_page.accessibility.snapshot = AsyncMock(
+            side_effect=AssertionError(
+                "native a11y path must not be invoked after P0.3"
+            )
+        )
 
         inst = CamoufoxInstance("a1", MagicMock(), MagicMock(), mock_page)
         mgr._instances["a1"] = inst
@@ -5319,7 +5393,8 @@ class TestDialogScoping:
                 ]},
             ],
         }
-        # Both Playwright and JS scoped snapshots return None
+        # P0.3: scoped tree always comes from ``modal_el.evaluate``.
+        # Mock it to return None to force the fall-back-to-full-tree path.
         mock_page = AsyncMock()
         mock_modal_el = AsyncMock()
         mock_modal_el.is_visible = AsyncMock(return_value=True)
@@ -5329,13 +5404,13 @@ class TestDialogScoping:
         mock_modal_el.evaluate = AsyncMock(return_value=None)
         mock_page.query_selector_all = AsyncMock(return_value=[mock_modal_el])
         mock_page.viewport_size = {"width": 1280, "height": 720}
-
-        async def _snapshot(root=None):
-            if root is not None:
-                return None  # Scoped snapshot fails
-            return full_tree
+        mock_page.evaluate = AsyncMock(return_value=full_tree)
         mock_page.accessibility = MagicMock()
-        mock_page.accessibility.snapshot = AsyncMock(side_effect=_snapshot)
+        mock_page.accessibility.snapshot = AsyncMock(
+            side_effect=AssertionError(
+                "native a11y path must not be invoked after P0.3"
+            )
+        )
 
         inst = CamoufoxInstance("a1", MagicMock(), MagicMock(), mock_page)
         mgr._instances["a1"] = inst
@@ -5371,19 +5446,20 @@ class TestDialogScoping:
         mock_modal_el.bounding_box = AsyncMock(return_value={
             "x": 100, "y": 100, "width": 400, "height": 300,
         })
-        # JS fallback for scoped snapshot also fails
+        # P0.3: scoped tree comes from ``modal_el.evaluate`` — make it
+        # raise to exercise the fall-back-to-full-tree path.
         mock_modal_el.evaluate = AsyncMock(
             side_effect=RuntimeError("evaluate failed")
         )
         mock_page.query_selector_all = AsyncMock(return_value=[mock_modal_el])
         mock_page.viewport_size = {"width": 1280, "height": 720}
-
-        async def _snapshot(root=None):
-            if root is not None:
-                raise RuntimeError("Not supported in Camoufox")
-            return full_tree
+        mock_page.evaluate = AsyncMock(return_value=full_tree)
         mock_page.accessibility = MagicMock()
-        mock_page.accessibility.snapshot = AsyncMock(side_effect=_snapshot)
+        mock_page.accessibility.snapshot = AsyncMock(
+            side_effect=AssertionError(
+                "native a11y path must not be invoked after P0.3"
+            )
+        )
 
         inst = CamoufoxInstance("a1", MagicMock(), MagicMock(), mock_page)
         mgr._instances["a1"] = inst
@@ -5455,29 +5531,38 @@ class TestDialogScoping:
         mock_child.bounding_box = AsyncMock(return_value={
             "x": 150, "y": 150, "width": 200, "height": 100,
         })
-        # parent.contains(child) = True, child.contains(parent) = False
-        mock_parent.evaluate = AsyncMock(
-            side_effect=lambda js, arg: arg is mock_child
-        )
-        mock_child.evaluate = AsyncMock(return_value=False)
-        mock_page.query_selector_all = AsyncMock(
-            return_value=[mock_parent, mock_child]
-        )
-        mock_page.viewport_size = {"width": 1280, "height": 720}
-
         child_subtree = {
             "role": "dialog", "name": "Confirm",
             "children": [{"role": "button", "name": "Yes"}],
         }
-
-        async def _snapshot(root=None):
-            if root is mock_parent:
-                return parent_subtree
-            if root is mock_child:
-                return child_subtree
-            return full_tree
+        # ``parent.evaluate`` is called for two distinct purposes:
+        #   1. Nested-modal containment check — JS string passed plus the
+        #      child handle as a positional arg. Returns True/False.
+        #   2. P0.3 a11y walk — JS string passed alone. Returns the
+        #      parent subtree.
+        # Disambiguate on the presence of the second positional arg.
+        async def _parent_evaluate(*args, **_kwargs):
+            if len(args) >= 2:
+                # contains(parent, child) check.
+                return args[1] is mock_child
+            return parent_subtree
+        async def _child_evaluate(*args, **_kwargs):
+            if len(args) >= 2:
+                return False  # child does not contain parent
+            return child_subtree
+        mock_parent.evaluate = AsyncMock(side_effect=_parent_evaluate)
+        mock_child.evaluate = AsyncMock(side_effect=_child_evaluate)
+        mock_page.query_selector_all = AsyncMock(
+            return_value=[mock_parent, mock_child]
+        )
+        mock_page.viewport_size = {"width": 1280, "height": 720}
+        mock_page.evaluate = AsyncMock(return_value=full_tree)
         mock_page.accessibility = MagicMock()
-        mock_page.accessibility.snapshot = AsyncMock(side_effect=_snapshot)
+        mock_page.accessibility.snapshot = AsyncMock(
+            side_effect=AssertionError(
+                "native a11y path must not be invoked after P0.3"
+            )
+        )
 
         inst = CamoufoxInstance("a1", MagicMock(), MagicMock(), mock_page)
         mgr._instances["a1"] = inst
@@ -5498,21 +5583,35 @@ class TestDialogScoping:
 
 
 class TestJsA11yTreeFallback:
-    """When page.accessibility is unavailable, snapshot uses JS-based DOM walk."""
+    """§8.3 (P0.3): the snapshot path always runs the JS walker via
+    ``page.evaluate(_JS_A11Y_TREE)``. The previous "native first / JS
+    fallback" dispatch was dropped because Firefox's native a11y API
+    does NOT pierce open shadow boundaries — the JS walker is the
+    canonical implementation now.
+
+    These tests pin the always-JS contract:
+        * snapshot uses ``page.evaluate``, never ``page.accessibility.snapshot``
+        * scoped snapshots use ``element.evaluate``
+        * ``None`` from the walker → "(empty page)" graceful return
+    """
 
     @pytest.mark.asyncio
-    async def test_fallback_on_attribute_error(self):
-        """AttributeError on page.accessibility.snapshot triggers JS fallback."""
+    async def test_snapshot_always_runs_js_walker(self):
+        """Default-construction snapshot drives ``page.evaluate``, NOT
+        ``page.accessibility.snapshot``. Pins the §8.3 P0.3 fix."""
         from src.browser.service import BrowserManager, CamoufoxInstance
         mgr = BrowserManager(profiles_dir="/tmp/test_profiles")
 
         mock_page = AsyncMock()
-        # Simulate Camoufox where accessibility.snapshot() raises AttributeError
+        # Sentinel: if anything routes through the native API the test
+        # blows up immediately rather than silently returning a default
+        # AsyncMock.
         mock_page.accessibility = MagicMock()
         mock_page.accessibility.snapshot = AsyncMock(
-            side_effect=AttributeError("'Page' object has no attribute 'accessibility'")
+            side_effect=AssertionError(
+                "native a11y path must not be invoked after P0.3"
+            )
         )
-        # JS fallback returns a tree via page.evaluate()
         js_tree = {
             "role": "WebArea", "name": "Test Page",
             "children": [
@@ -5525,7 +5624,6 @@ class TestJsA11yTreeFallback:
 
         inst = CamoufoxInstance("a1", MagicMock(), MagicMock(), mock_page)
         mgr._instances["a1"] = inst
-        assert inst._js_snapshot_mode is False
 
         result = await mgr.snapshot("a1")
         assert result["success"] is True
@@ -5533,64 +5631,56 @@ class TestJsA11yTreeFallback:
         assert len(refs) == 2
         assert refs["e0"]["name"] == "Submit"
         assert refs["e1"]["name"] == "Home"
-        assert inst._js_snapshot_mode is True
-
-    @pytest.mark.asyncio
-    async def test_transient_failure_retries_then_falls_back(self):
-        """Non-AttributeError failures retry once, then fall back to JS."""
-        from src.browser.service import BrowserManager, CamoufoxInstance
-        mgr = BrowserManager(profiles_dir="/tmp/test_profiles")
-
-        mock_page = AsyncMock()
-        mock_page.accessibility = MagicMock()
-        mock_page.accessibility.snapshot = AsyncMock(
-            side_effect=RuntimeError("accessibility service unavailable")
-        )
-        js_tree = {
-            "role": "WebArea", "name": "Fallback",
-            "children": [{"role": "button", "name": "OK"}],
-        }
-        mock_page.evaluate = AsyncMock(return_value=js_tree)
-        mock_page.query_selector_all = AsyncMock(return_value=[])
-
-        inst = CamoufoxInstance("a1", MagicMock(), MagicMock(), mock_page)
-        mgr._instances["a1"] = inst
-
-        with patch("src.browser.service.asyncio.sleep"):
-            result = await mgr.snapshot("a1")
-
-        assert result["success"] is True
-        # Should have retried accessibility.snapshot twice (attempt 0 + 1)
-        assert mock_page.accessibility.snapshot.await_count == 2
-        # JS fallback should have been used
+        # Native API never touched.
+        mock_page.accessibility.snapshot.assert_not_called()
+        # JS walker did all the work.
         mock_page.evaluate.assert_called()
-        # Transient failure should NOT permanently set _js_snapshot_mode
-        assert inst._js_snapshot_mode is False
 
     @pytest.mark.asyncio
-    async def test_js_mode_persists(self):
-        """Once JS mode is enabled, subsequent snapshots skip Playwright API."""
+    async def test_shadow_dom_visible_on_default_path(self):
+        """Default-path snapshot — i.e. *without* setting
+        ``inst._js_snapshot_mode = True`` — must still surface refs
+        carrying ``shadow_path``. This is the regression P0.3 closes:
+        the previous native-first dispatch lost shadow content silently
+        on the default Camoufox path because Firefox's native a11y API
+        does not pierce shadow boundaries.
+        """
+        from src.browser.ref_handle import RefHandle
         from src.browser.service import BrowserManager, CamoufoxInstance
         mgr = BrowserManager(profiles_dir="/tmp/test_profiles")
 
-        mock_page = AsyncMock()
-        js_tree = {
+        # Synthetic JS-walker output with a shadow-pathed button. The
+        # mock page only mocks ``page.evaluate`` — there is no
+        # ``_js_snapshot_mode = True`` setup. P0.3 means this path runs
+        # the JS walker unconditionally, so the shadow ref appears.
+        tree = {
             "role": "WebArea", "name": "",
-            "children": [{"role": "textbox", "name": "Search"}],
+            "children": [
+                {
+                    "role": "button", "name": "Submit",
+                    "shadow_path": [
+                        {"selector": "my-card", "occurrence": 0,
+                         "discriminator": "testid:c"},
+                    ],
+                },
+            ],
         }
-        mock_page.evaluate = AsyncMock(return_value=js_tree)
+        mock_page = AsyncMock()
+        mock_page.evaluate = AsyncMock(return_value=tree)
         mock_page.query_selector_all = AsyncMock(return_value=[])
 
         inst = CamoufoxInstance("a1", MagicMock(), MagicMock(), mock_page)
-        inst._js_snapshot_mode = True  # Already switched
+        # Critically — do NOT set inst._js_snapshot_mode = True. The
+        # whole point of P0.3 is that shadow content is reachable on
+        # the default-attribute path.
+        assert inst._js_snapshot_mode is False
         mgr._instances["a1"] = inst
 
         result = await mgr.snapshot("a1")
         assert result["success"] is True
-        assert len(result["data"]["refs"]) == 1
-        # Should NOT have tried page.accessibility at all
-        assert not hasattr(mock_page, 'accessibility') or \
-            not mock_page.accessibility.snapshot.called
+        handle: RefHandle = inst.refs["e0"]
+        assert len(handle.shadow_path) == 1
+        assert handle.shadow_path[0].selector == "my-card"
 
     @pytest.mark.asyncio
     async def test_js_fallback_scoped_to_dialog(self):
@@ -6885,9 +6975,12 @@ class TestModalRetryRequery:
         stale_el = AsyncMock()
         stale_el.is_visible = AsyncMock(return_value=True)
         stale_el.bounding_box = AsyncMock(return_value=_bb)
+        # P0.3: stale handle's evaluate returns None (initial scope fails).
+        stale_el.evaluate = AsyncMock(return_value=None)
         fresh_el = AsyncMock()
         fresh_el.is_visible = AsyncMock(return_value=True)
         fresh_el.bounding_box = AsyncMock(return_value=_bb)
+        fresh_el.evaluate = AsyncMock(return_value=dialog_tree)
 
         query_call_count = [0]
 
@@ -6900,15 +6993,13 @@ class TestModalRetryRequery:
         mock_page = AsyncMock()
         mock_page.query_selector_all = mock_query_selector_all
         mock_page.viewport_size = {"width": 1280, "height": 720}
-
-        async def _snapshot(root=None):
-            if root is stale_el:
-                return None  # stale handle fails silently
-            if root is fresh_el:
-                return dialog_tree
-            return full_tree
+        mock_page.evaluate = AsyncMock(return_value=full_tree)
         mock_page.accessibility = MagicMock()
-        mock_page.accessibility.snapshot = AsyncMock(side_effect=_snapshot)
+        mock_page.accessibility.snapshot = AsyncMock(
+            side_effect=AssertionError(
+                "native a11y path must not be invoked after P0.3"
+            )
+        )
 
         inst = CamoufoxInstance("a1", MagicMock(), MagicMock(), mock_page)
         mgr._instances["a1"] = inst
@@ -6948,18 +7039,19 @@ class TestModalRetryRequery:
         modal_el.bounding_box = AsyncMock(return_value={
             "x": 100, "y": 100, "width": 400, "height": 300,
         })
+        # P0.3: modal scoping always fails via ``modal_el.evaluate``.
         modal_el.evaluate = AsyncMock(return_value=None)
 
         mock_page = AsyncMock()
         mock_page.query_selector_all = AsyncMock(return_value=[modal_el])
         mock_page.viewport_size = {"width": 1280, "height": 720}
-
-        async def _snapshot(root=None):
-            if root is not None:
-                return None  # Modal scoping always fails
-            return full_tree
+        mock_page.evaluate = AsyncMock(return_value=full_tree)
         mock_page.accessibility = MagicMock()
-        mock_page.accessibility.snapshot = AsyncMock(side_effect=_snapshot)
+        mock_page.accessibility.snapshot = AsyncMock(
+            side_effect=AssertionError(
+                "native a11y path must not be invoked after P0.3"
+            )
+        )
 
         inst = CamoufoxInstance("a1", MagicMock(), MagicMock(), mock_page)
         mgr._instances["a1"] = inst
@@ -7882,6 +7974,7 @@ class TestShadowDOM:
         mock_page = AsyncMock()
         mock_page.accessibility = MagicMock()
         mock_page.accessibility.snapshot = AsyncMock(return_value=tree)
+        mock_page.evaluate = mock_page.accessibility.snapshot
         inst = CamoufoxInstance("a1", MagicMock(), MagicMock(), mock_page)
         mgr._instances["a1"] = inst
 
@@ -7915,6 +8008,7 @@ class TestShadowDOM:
         mock_page = AsyncMock()
         mock_page.accessibility = MagicMock()
         mock_page.accessibility.snapshot = AsyncMock(return_value=tree)
+        mock_page.evaluate = mock_page.accessibility.snapshot
         inst = CamoufoxInstance("a1", MagicMock(), MagicMock(), mock_page)
         mgr._instances["a1"] = inst
 
@@ -7945,6 +8039,7 @@ class TestShadowDOM:
         mock_page = AsyncMock()
         mock_page.accessibility = MagicMock()
         mock_page.accessibility.snapshot = AsyncMock(return_value=tree)
+        mock_page.evaluate = mock_page.accessibility.snapshot
         inst = CamoufoxInstance("a1", MagicMock(), MagicMock(), mock_page)
         mgr._instances["a1"] = inst
 
@@ -7973,6 +8068,7 @@ class TestShadowDOM:
         mock_page = AsyncMock()
         mock_page.accessibility = MagicMock()
         mock_page.accessibility.snapshot = AsyncMock(return_value=tree)
+        mock_page.evaluate = mock_page.accessibility.snapshot
         inst = CamoufoxInstance("a1", MagicMock(), MagicMock(), mock_page)
         mgr._instances["a1"] = inst
 
@@ -8002,6 +8098,7 @@ class TestShadowDOM:
         mock_page = AsyncMock()
         mock_page.accessibility = MagicMock()
         mock_page.accessibility.snapshot = AsyncMock(return_value=tree)
+        mock_page.evaluate = mock_page.accessibility.snapshot
         inst = CamoufoxInstance("a1", MagicMock(), MagicMock(), mock_page)
         mgr._instances["a1"] = inst
 
@@ -8659,3 +8756,377 @@ class TestShadowDOM:
 
         with pytest.raises(RefStale, match="detached"):
             await mgr._locator_from_ref(inst, "e0")
+
+    # ── Third-pass review fixes (P0.1, P0.2, P0.3, P1.4-P1.7) ────────────
+
+    def test_stage2_unnamed_match_is_strict(self):
+        """P0.1 — Stage 2's filter must require the live accessible name
+        to MATCH the snapshot-time name, even when that name is the
+        empty string. The walker buckets unnamed siblings as
+        ``(role, "", path)`` distinct from named siblings; if Stage 2
+        admitted all same-role candidates (the ``if (!name) return
+        true;`` bug) it would return ``candidates[0]`` — quite possibly
+        a *named* sibling — and the click would land on the wrong
+        element entirely.
+
+        Source-level pin: the Stage-2 body must NOT contain the
+        ``if (!name) return true;`` short-circuit, AND it must compare
+        the trimmed accessible-name string against the expected name on
+        every candidate.
+        """
+        from src.browser.service import _JS_SHADOW_RESOLVE_STAGE2
+        # The wrong-element-collapse short circuit is GONE.
+        assert "if (!name) return true" not in _JS_SHADOW_RESOLVE_STAGE2
+        # Every candidate is filtered by the strict name comparison.
+        # (Either ``=== expected`` against the normalized snapshot name
+        # or an explicit empty-vs-empty check, depending on how the
+        # implementation expresses it.)
+        assert "accessibleName(el, role)" in _JS_SHADOW_RESOLVE_STAGE2
+
+    @pytest.mark.asyncio
+    @pytest.mark.browser
+    @pytest.mark.skipif(
+        _no_playwright(),
+        reason=(
+            "playwright not in [dev] deps (browser binaries bloat install); "
+            "CI honours this skip — install manually via "
+            "'pip install playwright && playwright install firefox' to run"
+        ),
+    )
+    async def test_stage2_unnamed_button_among_named_siblings(self):
+        """P0.1 (real browser) — an unnamed shadow button sandwiched
+        between two named siblings must resolve to the unnamed one,
+        NOT to either named sibling. The walker emits each as a
+        separate (role, name, path) bucket; a permissive Stage 2 would
+        collapse them and click the wrong button.
+        """
+        from playwright.async_api import async_playwright
+
+        from src.browser.service import (
+            _JS_A11Y_TREE,
+            _JS_SHADOW_RESOLVE_STAGE1,
+            _JS_SHADOW_RESOLVE_STAGE2,
+        )
+        async with async_playwright() as p:
+            browser = await p.firefox.launch()
+            try:
+                page = await browser.new_page()
+                await page.set_content("""
+                    <html><body>
+                      <my-card id="card1"></my-card>
+                      <script>
+                        const host = document.getElementById('card1');
+                        host.setAttribute('data-testid', 'card');
+                        const root = host.attachShadow({mode: 'open'});
+                        const a = document.createElement('button');
+                        a.textContent = 'Submit';
+                        a.id = 'btn-submit';
+                        const b = document.createElement('button');
+                        b.setAttribute('aria-label', '');
+                        b.id = 'btn-unnamed';
+                        const c = document.createElement('button');
+                        c.textContent = 'Cancel';
+                        c.id = 'btn-cancel';
+                        root.appendChild(a);
+                        root.appendChild(b);
+                        root.appendChild(c);
+                      </script>
+                    </body></html>
+                """)
+                tree = await page.evaluate(_JS_A11Y_TREE)
+
+                # The walker emits three buttons with names "Submit", "",
+                # "Cancel". Pick the unnamed one.
+                buttons = []
+                def collect(node):
+                    if node.get("role") == "button":
+                        buttons.append(node)
+                    for c in node.get("children", []) or []:
+                        collect(c)
+                collect(tree)
+                assert len(buttons) == 3, f"got {len(buttons)} buttons"
+                names = sorted(b.get("name", "") for b in buttons)
+                assert names == ["", "Cancel", "Submit"]
+                unnamed = next(b for b in buttons if b.get("name", "") == "")
+
+                # Resolve via the actual two-stage pipeline.
+                import json as _json
+                stage1 = await page.evaluate_handle(
+                    _JS_SHADOW_RESOLVE_STAGE1,
+                    {"path": _json.dumps(unnamed["shadow_path"]),
+                     "scope_root": None},
+                )
+                stage2 = await stage1.evaluate_handle(
+                    _JS_SHADOW_RESOLVE_STAGE2,
+                    {"role": "button", "name": "", "occurrence": 0},
+                )
+                element = stage2.as_element()
+                assert element is not None, (
+                    "Stage 2 returned null for the unnamed shadow button"
+                )
+                # Must NOT be either named sibling.
+                resolved_id = await element.evaluate("(el) => el.id")
+                assert resolved_id == "btn-unnamed", (
+                    f"Stage 2 resolved to '{resolved_id}', not 'btn-unnamed' — "
+                    "unnamed match collapsed with named siblings"
+                )
+            finally:
+                await browser.close()
+
+    @pytest.mark.asyncio
+    async def test_stage1_passes_scope_root_when_modal_active(self):
+        """P0.2 — when a shadow ref carries ``scope_root`` (set by
+        modal-scoped snapshot), the Stage-1 evaluate_handle call must
+        thread that selector through so the JS walk starts inside the
+        modal subtree, not at ``document``.
+        """
+        from src.browser.ref_handle import RefHandle, ShadowHop
+        from src.browser.service import BrowserManager, CamoufoxInstance
+        mgr = BrowserManager(profiles_dir="/tmp/test_profiles")
+
+        mock_page = MagicMock()
+        stage1_handle = AsyncMock()
+        stage1_handle.evaluate = AsyncMock(return_value=None)
+        stage2_handle = AsyncMock()
+        stage2_handle.evaluate = AsyncMock(return_value=None)
+        stage2_element = MagicMock()
+        stage2_handle.as_element = MagicMock(return_value=stage2_element)
+        stage1_handle.evaluate_handle = AsyncMock(return_value=stage2_handle)
+        stage1_handle.dispose = AsyncMock()
+        mock_page.evaluate_handle = AsyncMock(return_value=stage1_handle)
+
+        inst = CamoufoxInstance("a1", MagicMock(), MagicMock(), mock_page)
+        page_id = inst._page_id_for(inst.page)
+        # Ref carries scope_root (set by the modal-scoping branch in
+        # _snapshot_impl) plus a shadow_path. P0.2 requires the
+        # Stage-1 call to receive that scope_root so the walk doesn't
+        # start at ``document`` and pick up duplicate hosts behind the
+        # overlay.
+        inst.refs["e0"] = RefHandle.shadow(
+            page_id=page_id,
+            scope_root='[role="dialog"]',
+            shadow_path=(ShadowHop("my-card", 0, "testid:c"),),
+            role="button", name="Submit", occurrence=0, disabled=False,
+        )
+
+        await mgr._locator_from_ref(inst, "e0")
+        # Stage-1 was called with the scope_root selector.
+        stage1_args = mock_page.evaluate_handle.call_args[0][1]
+        assert stage1_args.get("scope_root") == '[role="dialog"]'
+
+    def test_stage1_supports_scope_root_argument(self):
+        """P0.2 (source-level) — the Stage-1 JS body must accept an
+        optional ``scope_root`` argument and start its walk at
+        ``document.querySelector(scope_root)`` when one is supplied.
+        Without this, modal-scoped shadow refs effectively bypass
+        modal scoping at resolve time.
+        """
+        from src.browser.service import _JS_SHADOW_RESOLVE_STAGE1
+        # The argument is read off ``args`` and used for the root
+        # bootstrap.
+        assert "args.scope_root" in _JS_SHADOW_RESOLVE_STAGE1
+        # ``document.querySelector(...)`` is the bootstrap when
+        # scope_root is set.
+        assert "document.querySelector(args.scope_root)" in _JS_SHADOW_RESOLVE_STAGE1
+        # The missing-modal sentinel is emitted so the Python side can
+        # surface it as RefStale.
+        assert "scope_root_missing" in _JS_SHADOW_RESOLVE_STAGE1
+
+    @pytest.mark.asyncio
+    async def test_resolver_disposes_stage1_handle_on_success(self):
+        """P1.4 — Stage 1 is a JSHandle the resolver owns; on the happy
+        path it must be disposed before returning the ElementHandle.
+        Playwright does not GC JSHandles automatically.
+        """
+        from src.browser.ref_handle import RefHandle, ShadowHop
+        from src.browser.service import BrowserManager, CamoufoxInstance
+        mgr = BrowserManager(profiles_dir="/tmp/test_profiles")
+
+        mock_page = MagicMock()
+        stage1_handle = AsyncMock()
+        stage1_handle.evaluate = AsyncMock(return_value=None)
+        stage1_handle.dispose = AsyncMock()
+        stage2_handle = AsyncMock()
+        stage2_handle.evaluate = AsyncMock(return_value=None)
+        stage2_element = MagicMock()
+        stage2_handle.as_element = MagicMock(return_value=stage2_element)
+        stage1_handle.evaluate_handle = AsyncMock(return_value=stage2_handle)
+        mock_page.evaluate_handle = AsyncMock(return_value=stage1_handle)
+
+        inst = CamoufoxInstance("a1", MagicMock(), MagicMock(), mock_page)
+        page_id = inst._page_id_for(inst.page)
+        inst.refs["e0"] = RefHandle.shadow(
+            page_id=page_id, scope_root=None,
+            shadow_path=(ShadowHop("my-card", 0, "testid:c"),),
+            role="button", name="Submit", occurrence=0, disabled=False,
+        )
+
+        await mgr._locator_from_ref(inst, "e0")
+        stage1_handle.dispose.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_resolver_disposes_handles_on_ref_stale(self):
+        """P1.5 — RefStale paths must NOT leak the Stage 1 handle.
+        Discriminator mismatch raises before Stage 2 runs; Stage 1's
+        dispose still has to fire.
+        """
+        from src.browser.ref_handle import RefHandle, RefStale, ShadowHop
+        from src.browser.service import BrowserManager, CamoufoxInstance
+        mgr = BrowserManager(profiles_dir="/tmp/test_profiles")
+
+        mock_page = MagicMock()
+        stage1_handle = AsyncMock()
+        stage1_handle.evaluate = AsyncMock(
+            return_value="stale_discriminator_mismatch",
+        )
+        stage1_handle.dispose = AsyncMock()
+        mock_page.evaluate_handle = AsyncMock(return_value=stage1_handle)
+
+        inst = CamoufoxInstance("a1", MagicMock(), MagicMock(), mock_page)
+        page_id = inst._page_id_for(inst.page)
+        inst.refs["e0"] = RefHandle.shadow(
+            page_id=page_id, scope_root=None,
+            shadow_path=(ShadowHop("my-card", 0, "testid:swapped"),),
+            role="button", name="Submit", occurrence=0, disabled=False,
+        )
+
+        with pytest.raises(RefStale):
+            await mgr._locator_from_ref(inst, "e0")
+        stage1_handle.dispose.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_resolver_disposes_stage2_on_detached_root(self):
+        """P1.4/P1.5 — when Stage 2 reports ``shadow_root_detached``,
+        BOTH handles must be disposed before raising RefStale.
+        """
+        from src.browser.ref_handle import RefHandle, RefStale, ShadowHop
+        from src.browser.service import BrowserManager, CamoufoxInstance
+        mgr = BrowserManager(profiles_dir="/tmp/test_profiles")
+
+        mock_page = MagicMock()
+        stage1_handle = AsyncMock()
+        stage1_handle.evaluate = AsyncMock(return_value=None)
+        stage1_handle.dispose = AsyncMock()
+        stage2_handle = AsyncMock()
+        stage2_handle.evaluate = AsyncMock(return_value="shadow_root_detached")
+        stage2_handle.dispose = AsyncMock()
+        stage2_handle.as_element = MagicMock(return_value=None)
+        stage1_handle.evaluate_handle = AsyncMock(return_value=stage2_handle)
+        mock_page.evaluate_handle = AsyncMock(return_value=stage1_handle)
+
+        inst = CamoufoxInstance("a1", MagicMock(), MagicMock(), mock_page)
+        page_id = inst._page_id_for(inst.page)
+        inst.refs["e0"] = RefHandle.shadow(
+            page_id=page_id, scope_root=None,
+            shadow_path=(ShadowHop("my-card", 0, "testid:c"),),
+            role="button", name="Submit", occurrence=0, disabled=False,
+        )
+
+        with pytest.raises(RefStale, match="detached"):
+            await mgr._locator_from_ref(inst, "e0")
+        stage1_handle.dispose.assert_called_once()
+        stage2_handle.dispose.assert_called_once()
+
+    def test_walker_caches_querySelectorAll_per_root(self):
+        """P1.6 — the JS walker must cache ``scopeRoot.querySelectorAll``
+        results within a single walk so a page with N shadow hosts at
+        the same root no longer triggers O(N²) DOM queries. Source-
+        level pin so the cache isn't accidentally removed during a
+        future refactor.
+        """
+        from src.browser.service import _JS_A11Y_TREE
+        # The cache is constructed once per walk (top-level, before the
+        # walker function is defined).
+        assert "occurrenceCache" in _JS_A11Y_TREE
+        # Per-(scopeRoot, selector) memoisation is what avoids the
+        # quadratic behaviour.
+        assert "scopeMap.set(selector" in _JS_A11Y_TREE
+        # The lookup is by selector inside the per-root sub-map.
+        assert "scopeMap.get(selector)" in _JS_A11Y_TREE
+
+    @pytest.mark.asyncio
+    @pytest.mark.browser
+    @pytest.mark.skipif(
+        _no_playwright(),
+        reason=(
+            "playwright not in [dev] deps (browser binaries bloat install); "
+            "CI honours this skip — install manually via "
+            "'pip install playwright && playwright install firefox' to run"
+        ),
+    )
+    async def test_walker_slotted_content_not_double_emitted(self):
+        """P2 (real browser) — slotted content must appear EXACTLY once
+        in the walker output. The walker descends ``el.children`` for
+        light DOM and ``el.shadowRoot.children`` for shadow descendants.
+        A ``<slot>`` inside a shadow root projects light-DOM children of
+        the host into the rendered tree, but ``slot.children`` is the
+        slot's *fallback* content (empty here), so the projected span
+        is reachable only via ``host.children`` — no double-emit.
+        """
+        from playwright.async_api import async_playwright
+
+        from src.browser.service import _JS_A11Y_TREE
+        async with async_playwright() as p:
+            browser = await p.firefox.launch()
+            try:
+                page = await browser.new_page()
+                await page.set_content("""
+                    <html><body>
+                      <x-card id="card1">
+                        <span slot="title" role="button">Hi</span>
+                      </x-card>
+                      <script>
+                        const host = document.getElementById('card1');
+                        const root = host.attachShadow({mode: 'open'});
+                        const slot = document.createElement('slot');
+                        slot.setAttribute('name', 'title');
+                        root.appendChild(slot);
+                      </script>
+                    </body></html>
+                """)
+                tree = await page.evaluate(_JS_A11Y_TREE)
+                buttons = []
+                def collect(node):
+                    if node.get("role") == "button":
+                        buttons.append(node)
+                    for c in node.get("children", []) or []:
+                        collect(c)
+                collect(tree)
+                # Exactly ONE button — the slotted span emitted via the
+                # light-DOM children traversal of the host. No phantom
+                # second copy from the shadow walk.
+                assert len(buttons) == 1, (
+                    f"slotted span emitted {len(buttons)} times — "
+                    "walker double-emit regression"
+                )
+                assert buttons[0].get("name") == "Hi"
+            finally:
+                await browser.close()
+
+    @pytest.mark.asyncio
+    async def test_resolver_rejects_frame_id_until_pr3(self):
+        """P1.7 — until iframe support lands (PR3) the resolver must
+        refuse refs with a non-None frame_id rather than silently
+        resolving against the main frame. Explicit error makes the
+        cross-PR seam loud.
+        """
+        from src.browser.ref_handle import RefHandle, ShadowHop
+        from src.browser.service import BrowserManager, CamoufoxInstance
+        mgr = BrowserManager(profiles_dir="/tmp/test_profiles")
+
+        mock_page = MagicMock()
+        mock_page.evaluate_handle = AsyncMock()
+
+        inst = CamoufoxInstance("a1", MagicMock(), MagicMock(), mock_page)
+        page_id = inst._page_id_for(inst.page)
+        inst.refs["e0"] = RefHandle.shadow(
+            page_id=page_id, scope_root=None,
+            shadow_path=(ShadowHop("my-card", 0, "testid:c"),),
+            role="button", name="Submit", occurrence=0, disabled=False,
+            frame_id="f1-deadbeef",
+        )
+
+        with pytest.raises(NotImplementedError, match="iframe"):
+            await mgr._locator_from_ref(inst, "e0")
+        # Stage-1 was never invoked.
+        mock_page.evaluate_handle.assert_not_called()

--- a/tests/test_browser_service.py
+++ b/tests/test_browser_service.py
@@ -308,7 +308,7 @@ class TestBrowserManagerRefResolution:
         inst = CamoufoxInstance("a1", MagicMock(), MagicMock(), mock_page)
         inst.seed_refs_legacy({"e0": {"role": "button", "name": "Submit", "index": 0}})
 
-        locator = mgr._locator_from_ref(inst, "e0")
+        locator = await mgr._locator_from_ref(inst, "e0")
         mock_page.get_by_role.assert_called_once_with("button", name="Submit", exact=True)
         # .nth(0) is called to target the specific occurrence
         mock_page.get_by_role.return_value.nth.assert_called_once_with(0)
@@ -326,7 +326,7 @@ class TestBrowserManagerRefResolution:
         inst = CamoufoxInstance("a1", MagicMock(), MagicMock(), mock_page)
         inst.seed_refs_legacy({"e0": {"role": "textbox", "name": "", "index": 0}})
 
-        mgr._locator_from_ref(inst, "e0")
+        await mgr._locator_from_ref(inst, "e0")
         mock_page.get_by_role.assert_called_once_with("textbox")
         mock_locator.nth.assert_called_once_with(0)
 
@@ -347,7 +347,7 @@ class TestBrowserManagerRefResolution:
             "e1": {"role": "textbox", "name": "Post text", "index": 1},
         })
 
-        mgr._locator_from_ref(inst, "e1")
+        await mgr._locator_from_ref(inst, "e1")
         mock_locator.nth.assert_called_once_with(1)
 
     @pytest.mark.asyncio
@@ -358,7 +358,7 @@ class TestBrowserManagerRefResolution:
         inst = CamoufoxInstance("a1", MagicMock(), MagicMock(), MagicMock())
         inst.refs = {}
 
-        assert mgr._locator_from_ref(inst, "e99") is None
+        assert await mgr._locator_from_ref(inst, "e99") is None
 
 
 
@@ -1829,7 +1829,8 @@ class TestSnapshotFromRef:
         mgr._instances["a1"] = inst
 
         with patch.object(
-            BrowserManager, "_locator_from_ref", return_value=fake_locator,
+            BrowserManager, "_locator_from_ref",
+            new_callable=AsyncMock, return_value=fake_locator,
         ):
             result = await mgr.snapshot("a1", from_ref="e0")
 
@@ -1868,7 +1869,8 @@ class TestSnapshotFromRef:
         fake_locator = AsyncMock()
         fake_locator.element_handle = AsyncMock(return_value=MagicMock())
         with patch.object(
-            BrowserManager, "_locator_from_ref", return_value=fake_locator,
+            BrowserManager, "_locator_from_ref",
+            new_callable=AsyncMock, return_value=fake_locator,
         ):
             result = await mgr.snapshot("a1", from_ref="e0", filter="inputs")
         assert result["success"] is True
@@ -1911,7 +1913,8 @@ class TestSnapshotFromRef:
         fake_locator = AsyncMock()
         fake_locator.element_handle = AsyncMock(return_value=MagicMock())
         with patch.object(
-            BrowserManager, "_locator_from_ref", return_value=fake_locator,
+            BrowserManager, "_locator_from_ref",
+            new_callable=AsyncMock, return_value=fake_locator,
         ):
             result = await mgr.snapshot("a1", from_ref="e0")
 
@@ -1952,7 +1955,8 @@ class TestSnapshotFromRef:
         fake_locator = AsyncMock()
         fake_locator.element_handle = AsyncMock(return_value=MagicMock())
         with patch.object(
-            BrowserManager, "_locator_from_ref", return_value=fake_locator,
+            BrowserManager, "_locator_from_ref",
+            new_callable=AsyncMock, return_value=fake_locator,
         ):
             result = await mgr.snapshot("a1", from_ref="e0")
 
@@ -1990,7 +1994,8 @@ class TestSnapshotFromRef:
         fake_locator = AsyncMock()
         fake_locator.element_handle = AsyncMock(return_value=MagicMock())
         with patch.object(
-            BrowserManager, "_locator_from_ref", return_value=fake_locator,
+            BrowserManager, "_locator_from_ref",
+            new_callable=AsyncMock, return_value=fake_locator,
         ):
             result = await mgr.snapshot("a1", from_ref="e0")
         assert result["success"] is True
@@ -2411,7 +2416,8 @@ class TestDiffSnapshot:
         fake_locator = AsyncMock()
         fake_locator.element_handle = AsyncMock(return_value=MagicMock())
         with patch.object(
-            type(mgr), "_locator_from_ref", return_value=fake_locator,
+            type(mgr), "_locator_from_ref",
+            new_callable=AsyncMock, return_value=fake_locator,
         ):
             await mgr.snapshot("a1", from_ref="e0")
 
@@ -4112,7 +4118,7 @@ class TestAutoForceClick:
         mock_locator.click = AsyncMock()
 
         with patch.object(BrowserManager, "get_or_start", return_value=inst):
-            with patch.object(BrowserManager, "_locator_from_ref", return_value=mock_locator):
+            with patch.object(BrowserManager, "_locator_from_ref", new_callable=AsyncMock, return_value=mock_locator):
                 with patch("src.browser.service.action_delay", return_value=0.01):
                     with patch("src.browser.service.asyncio.sleep", new_callable=AsyncMock):
                         result = await mgr.click("agent1", ref="e1")
@@ -4135,7 +4141,7 @@ class TestAutoForceClick:
         mock_locator.click = AsyncMock()
 
         with patch.object(BrowserManager, "get_or_start", return_value=inst):
-            with patch.object(BrowserManager, "_locator_from_ref", return_value=mock_locator):
+            with patch.object(BrowserManager, "_locator_from_ref", new_callable=AsyncMock, return_value=mock_locator):
                 with patch("src.browser.service.action_delay", return_value=0.01):
                     with patch("src.browser.service.asyncio.sleep", new_callable=AsyncMock):
                         result = await mgr.click("agent1", ref="e2")
@@ -4162,7 +4168,7 @@ class TestAutoForceClick:
         mock_locator.click = AsyncMock()
 
         with patch.object(BrowserManager, "get_or_start", return_value=inst):
-            with patch.object(BrowserManager, "_locator_from_ref", return_value=mock_locator):
+            with patch.object(BrowserManager, "_locator_from_ref", new_callable=AsyncMock, return_value=mock_locator):
                 with patch("src.browser.service.action_delay", return_value=0.01):
                     with patch("src.browser.service.asyncio.sleep", new_callable=AsyncMock):
                         result = await mgr.click("agent1", ref="e3")
@@ -4188,7 +4194,7 @@ class TestAutoForceClick:
         mock_locator.click = AsyncMock()
 
         with patch.object(BrowserManager, "get_or_start", return_value=inst):
-            with patch.object(BrowserManager, "_locator_from_ref", return_value=mock_locator):
+            with patch.object(BrowserManager, "_locator_from_ref", new_callable=AsyncMock, return_value=mock_locator):
                 with patch("src.browser.service.action_delay", return_value=0.01):
                     with patch("src.browser.service.asyncio.sleep", new_callable=AsyncMock):
                         result = await mgr.click("agent1", ref="e4")
@@ -4214,7 +4220,7 @@ class TestAutoForceClick:
         mock_locator.click = AsyncMock()
 
         with patch.object(BrowserManager, "get_or_start", return_value=inst):
-            with patch.object(BrowserManager, "_locator_from_ref", return_value=mock_locator):
+            with patch.object(BrowserManager, "_locator_from_ref", new_callable=AsyncMock, return_value=mock_locator):
                 with patch("src.browser.service.action_delay", return_value=0.01):
                     with patch("src.browser.service.asyncio.sleep", new_callable=AsyncMock):
                         result = await mgr.click("agent1", ref="e5")
@@ -4236,7 +4242,7 @@ class TestAutoForceClick:
         mock_locator.click = AsyncMock()
 
         with patch.object(BrowserManager, "get_or_start", return_value=inst):
-            with patch.object(BrowserManager, "_locator_from_ref", return_value=mock_locator):
+            with patch.object(BrowserManager, "_locator_from_ref", new_callable=AsyncMock, return_value=mock_locator):
                 with patch("src.browser.service.action_delay", return_value=0.01):
                     with patch("src.browser.service.asyncio.sleep", new_callable=AsyncMock):
                         result = await mgr.click("agent1", ref="e6", force=True)
@@ -4258,7 +4264,7 @@ class TestAutoForceClick:
         mock_locator.click = AsyncMock()
 
         with patch.object(BrowserManager, "get_or_start", return_value=inst):
-            with patch.object(BrowserManager, "_locator_from_ref", return_value=mock_locator):
+            with patch.object(BrowserManager, "_locator_from_ref", new_callable=AsyncMock, return_value=mock_locator):
                 with patch("src.browser.service.action_delay", return_value=0.01):
                     with patch("src.browser.service.asyncio.sleep", new_callable=AsyncMock):
                         result = await mgr.click("agent1", ref="e7")
@@ -4366,7 +4372,7 @@ class TestTypeTextSettleDelays:
         mock_locator = AsyncMock()
 
         with patch.object(BrowserManager, "get_or_start", return_value=inst):
-            with patch.object(BrowserManager, "_locator_from_ref", return_value=mock_locator):
+            with patch.object(BrowserManager, "_locator_from_ref", new_callable=AsyncMock, return_value=mock_locator):
                 with patch.object(BrowserManager, "_x11_click", new_callable=AsyncMock):
                     with patch.object(BrowserManager, "_x11_type", new_callable=AsyncMock):
                         with patch.object(BrowserManager, "_x11_key", new_callable=AsyncMock):
@@ -4410,7 +4416,7 @@ class TestTypeTextSettleDelays:
         mock_locator = AsyncMock()
 
         with patch.object(BrowserManager, "get_or_start", return_value=inst):
-            with patch.object(BrowserManager, "_locator_from_ref", return_value=mock_locator):
+            with patch.object(BrowserManager, "_locator_from_ref", new_callable=AsyncMock, return_value=mock_locator):
                 with patch.object(BrowserManager, "_x11_click", new_callable=AsyncMock):
                     with patch.object(BrowserManager, "_x11_type", new_callable=AsyncMock):
                         with patch.object(BrowserManager, "_x11_key", new_callable=AsyncMock):
@@ -5029,7 +5035,7 @@ class TestDialogScoping:
         inst.dialog_active = True
         inst.seed_refs_legacy({"e0": {"role": "button", "name": "Post", "index": 0}})
 
-        locator = mgr._locator_from_ref(inst, "e0")
+        locator = await mgr._locator_from_ref(inst, "e0")
 
         # Should scope to dialog/modal elements
         call_args = mock_page.locator.call_args[0][0]
@@ -5054,7 +5060,7 @@ class TestDialogScoping:
         inst.dialog_active = False
         inst.seed_refs_legacy({"e0": {"role": "button", "name": "Post", "index": 0}})
 
-        mgr._locator_from_ref(inst, "e0")
+        await mgr._locator_from_ref(inst, "e0")
 
         mock_page.locator.assert_not_called()
         mock_page.get_by_role.assert_called_once_with("button", name="Post", exact=True)
@@ -6232,7 +6238,7 @@ class TestX11Input:
 
         mock_locator = AsyncMock()
         mgr.get_or_start = AsyncMock(return_value=inst)
-        mgr._locator_from_ref = MagicMock(return_value=mock_locator)
+        mgr._locator_from_ref = AsyncMock(return_value=mock_locator)
         mgr._x11_click = AsyncMock()
         mgr._x11_key = AsyncMock()
         mgr._x11_type = AsyncMock()
@@ -6256,7 +6262,7 @@ class TestX11Input:
 
         mock_locator = AsyncMock()
         mgr.get_or_start = AsyncMock(return_value=inst)
-        mgr._locator_from_ref = MagicMock(return_value=mock_locator)
+        mgr._locator_from_ref = AsyncMock(return_value=mock_locator)
         mgr._x11_click = AsyncMock()
         mgr._x11_type = AsyncMock()
         mgr._x11_key = AsyncMock()
@@ -6360,7 +6366,7 @@ class TestX11Input:
 
         mock_locator = AsyncMock()
         mgr.get_or_start = AsyncMock(return_value=inst)
-        mgr._locator_from_ref = MagicMock(return_value=mock_locator)
+        mgr._locator_from_ref = AsyncMock(return_value=mock_locator)
         mgr._x11_click = AsyncMock()
         mgr._x11_key = AsyncMock()
         mgr._x11_type = AsyncMock()
@@ -6383,7 +6389,7 @@ class TestX11Input:
 
         mock_locator = AsyncMock()
         mgr.get_or_start = AsyncMock(return_value=inst)
-        mgr._locator_from_ref = MagicMock(return_value=mock_locator)
+        mgr._locator_from_ref = AsyncMock(return_value=mock_locator)
         mgr._x11_click = AsyncMock()
         mgr._x11_key = AsyncMock()
         mgr._x11_type = AsyncMock()
@@ -6487,7 +6493,7 @@ class TestX11Input:
 
         mock_locator = AsyncMock()
         mgr.get_or_start = AsyncMock(return_value=inst)
-        mgr._locator_from_ref = MagicMock(return_value=mock_locator)
+        mgr._locator_from_ref = AsyncMock(return_value=mock_locator)
         mgr._x11_click = AsyncMock()
         mgr._snapshot_impl = AsyncMock(return_value={"data": {}})
 
@@ -6508,7 +6514,7 @@ class TestX11Input:
 
         mock_locator = AsyncMock()
         mgr.get_or_start = AsyncMock(return_value=inst)
-        mgr._locator_from_ref = MagicMock(return_value=mock_locator)
+        mgr._locator_from_ref = AsyncMock(return_value=mock_locator)
         mgr._x11_click = AsyncMock()
         mgr._x11_key = AsyncMock()
         mgr._x11_type = AsyncMock()
@@ -6532,7 +6538,7 @@ class TestX11Input:
 
         mock_locator = AsyncMock()
         mgr.get_or_start = AsyncMock(return_value=inst)
-        mgr._locator_from_ref = MagicMock(return_value=mock_locator)
+        mgr._locator_from_ref = AsyncMock(return_value=mock_locator)
         mgr._x11_click = AsyncMock(side_effect=RuntimeError("xdotool error"))
         mgr._human_click = AsyncMock()
         mgr._x11_key = AsyncMock()
@@ -6671,7 +6677,7 @@ class TestX11Input:
 
         mock_locator = AsyncMock()
         mgr.get_or_start = AsyncMock(return_value=inst)
-        mgr._locator_from_ref = MagicMock(return_value=mock_locator)
+        mgr._locator_from_ref = AsyncMock(return_value=mock_locator)
         mgr._x11_hover = AsyncMock()
 
         result = await mgr.hover("agent-1", ref="e0")
@@ -6691,7 +6697,7 @@ class TestX11Input:
         mock_locator = AsyncMock()
         mock_locator.hover = AsyncMock()
         mgr.get_or_start = AsyncMock(return_value=inst)
-        mgr._locator_from_ref = MagicMock(return_value=mock_locator)
+        mgr._locator_from_ref = AsyncMock(return_value=mock_locator)
         mgr._x11_hover = AsyncMock()
 
         result = await mgr.hover("agent-1", ref="e0")
@@ -6712,7 +6718,7 @@ class TestX11Input:
         mock_locator = AsyncMock()
         mock_locator.hover = AsyncMock()
         mgr.get_or_start = AsyncMock(return_value=inst)
-        mgr._locator_from_ref = MagicMock(return_value=mock_locator)
+        mgr._locator_from_ref = AsyncMock(return_value=mock_locator)
         mgr._x11_hover = AsyncMock(side_effect=RuntimeError("xdotool failed"))
 
         result = await mgr.hover("agent-1", ref="e0")
@@ -7795,3 +7801,384 @@ class TestOpenTab:
         assert result["data"]["page_id"]
         assert inst.page is new_page
         assert inst.refs == {}
+
+
+class TestShadowDOM:
+    """§8.3 — open shadow-root descent in the JS a11y walker plus the
+    two-stage Playwright resolver for shadow refs."""
+
+    @pytest.mark.asyncio
+    async def test_shadow_path_serialization_roundtrip(self):
+        from src.browser.ref_handle import ShadowHop
+        hop = ShadowHop(selector="my-card", occurrence=2, discriminator="testid:foo")
+        import dataclasses
+        d = dataclasses.asdict(hop)
+        roundtrip = ShadowHop(**d)
+        assert roundtrip == hop
+        assert roundtrip.selector == "my-card"
+        assert roundtrip.occurrence == 2
+        assert roundtrip.discriminator == "testid:foo"
+
+    @pytest.mark.asyncio
+    async def test_compute_element_key_folds_shadow_path(self):
+        from src.browser.ref_handle import ShadowHop, compute_element_key
+        light = compute_element_key(role="button", name="Submit")
+        in_shadow = compute_element_key(
+            role="button", name="Submit",
+            shadow_path=(ShadowHop("my-card", 0, "testid:a"),),
+        )
+        nested = compute_element_key(
+            role="button", name="Submit",
+            shadow_path=(
+                ShadowHop("my-card", 0, "testid:a"),
+                ShadowHop("inner-widget", 0, "testid:b"),
+            ),
+        )
+        assert light != in_shadow
+        assert in_shadow != nested
+        assert light != nested
+
+    @pytest.mark.asyncio
+    async def test_walker_emits_shadow_path_for_open_root(self):
+        from src.browser.ref_handle import RefHandle
+        from src.browser.service import BrowserManager, CamoufoxInstance
+        mgr = BrowserManager(profiles_dir="/tmp/test_profiles")
+
+        tree = {
+            "role": "WebArea", "name": "",
+            "children": [
+                {
+                    "role": "button", "name": "Submit",
+                    "shadow_path": [
+                        {
+                            "selector": "my-card",
+                            "occurrence": 0,
+                            "discriminator": "testid:card",
+                        },
+                    ],
+                },
+            ],
+        }
+        mock_page = AsyncMock()
+        mock_page.accessibility = MagicMock()
+        mock_page.accessibility.snapshot = AsyncMock(return_value=tree)
+        inst = CamoufoxInstance("a1", MagicMock(), MagicMock(), mock_page)
+        mgr._instances["a1"] = inst
+
+        result = await mgr.snapshot("a1")
+        assert result["success"] is True
+        assert "e0" in result["data"]["refs"]
+        handle: RefHandle = inst.refs["e0"]
+        assert len(handle.shadow_path) == 1
+        assert handle.shadow_path[0].selector == "my-card"
+        assert handle.shadow_path[0].occurrence == 0
+        assert handle.shadow_path[0].discriminator == "testid:card"
+
+    @pytest.mark.asyncio
+    async def test_walker_emits_nested_shadow_path(self):
+        from src.browser.service import BrowserManager, CamoufoxInstance
+        mgr = BrowserManager(profiles_dir="/tmp/test_profiles")
+        tree = {
+            "role": "WebArea", "name": "",
+            "children": [
+                {
+                    "role": "button", "name": "Inner",
+                    "shadow_path": [
+                        {"selector": "outer-host", "occurrence": 0,
+                         "discriminator": "testid:outer"},
+                        {"selector": "inner-host", "occurrence": 1,
+                         "discriminator": "id:inner-1"},
+                    ],
+                },
+            ],
+        }
+        mock_page = AsyncMock()
+        mock_page.accessibility = MagicMock()
+        mock_page.accessibility.snapshot = AsyncMock(return_value=tree)
+        inst = CamoufoxInstance("a1", MagicMock(), MagicMock(), mock_page)
+        mgr._instances["a1"] = inst
+
+        result = await mgr.snapshot("a1")
+        assert result["success"] is True
+        handle = inst.refs["e0"]
+        assert len(handle.shadow_path) == 2
+        assert handle.shadow_path[0].selector == "outer-host"
+        assert handle.shadow_path[0].discriminator == "testid:outer"
+        assert handle.shadow_path[1].selector == "inner-host"
+        assert handle.shadow_path[1].occurrence == 1
+        assert handle.shadow_path[1].discriminator == "id:inner-1"
+
+    @pytest.mark.asyncio
+    async def test_walker_light_dom_keeps_empty_shadow_path(self):
+        """Regression guard: pages without any shadow DOM must produce
+        light_dom-shaped handles (shadow_path=())."""
+        from src.browser.service import BrowserManager, CamoufoxInstance
+        mgr = BrowserManager(profiles_dir="/tmp/test_profiles")
+
+        tree = {
+            "role": "WebArea", "name": "",
+            "children": [
+                {"role": "button", "name": "Submit"},
+                {"role": "textbox", "name": "Email"},
+            ],
+        }
+        mock_page = AsyncMock()
+        mock_page.accessibility = MagicMock()
+        mock_page.accessibility.snapshot = AsyncMock(return_value=tree)
+        inst = CamoufoxInstance("a1", MagicMock(), MagicMock(), mock_page)
+        mgr._instances["a1"] = inst
+
+        result = await mgr.snapshot("a1")
+        assert result["success"] is True
+        for handle in inst.refs.values():
+            assert handle.shadow_path == ()
+            assert handle.frame_id is None
+
+    @pytest.mark.asyncio
+    async def test_closed_shadow_root_not_in_snapshot(self):
+        """Closed shadow roots are unreachable per the web spec — the
+        walker cannot pierce them. We assert that a tree without a
+        ``shadow_path`` annotation does NOT acquire one (i.e. nodes the
+        walker would have emitted for a closed root simply never appear)."""
+        from src.browser.service import BrowserManager, CamoufoxInstance
+        mgr = BrowserManager(profiles_dir="/tmp/test_profiles")
+
+        # Tree shape simulates a page where the shadow host is visible
+        # but its closed shadow contents are NOT walked: only the host
+        # element shows up, no inner ref.
+        tree = {
+            "role": "WebArea", "name": "",
+            "children": [
+                {"role": "button", "name": "Outside Shadow"},
+            ],
+        }
+        mock_page = AsyncMock()
+        mock_page.accessibility = MagicMock()
+        mock_page.accessibility.snapshot = AsyncMock(return_value=tree)
+        inst = CamoufoxInstance("a1", MagicMock(), MagicMock(), mock_page)
+        mgr._instances["a1"] = inst
+
+        result = await mgr.snapshot("a1")
+        assert result["success"] is True
+        for handle in inst.refs.values():
+            assert handle.shadow_path == ()
+
+    @pytest.mark.asyncio
+    async def test_max_walk_depth_caps_descent(self):
+        """``_MAX_WALK_DEPTH=50`` caps total walker depth — synthesizing
+        a 51-deep tree must produce zero refs past the cap."""
+        from src.browser.service import (
+            _MAX_SNAPSHOT_ELEMENTS,
+            BrowserManager,
+            CamoufoxInstance,
+        )
+        mgr = BrowserManager(profiles_dir="/tmp/test_profiles")
+
+        # Build 51 nested layers, the deepest carrying a button.
+        node = {"role": "button", "name": "Deep"}
+        for _ in range(51):
+            node = {"role": "generic", "name": "", "children": [node]}
+        tree = {"role": "WebArea", "name": "", "children": [node]}
+
+        mock_page = AsyncMock()
+        mock_page.accessibility = MagicMock()
+        mock_page.accessibility.snapshot = AsyncMock(return_value=tree)
+        inst = CamoufoxInstance("a1", MagicMock(), MagicMock(), mock_page)
+        mgr._instances["a1"] = inst
+
+        result = await mgr.snapshot("a1")
+        assert result["success"] is True
+        # Depth cap means the deepest button never gets walked.
+        # _MAX_SNAPSHOT_ELEMENTS is large; the cap is the limiter here.
+        assert _MAX_SNAPSHOT_ELEMENTS > 0  # sanity
+        # No refs emitted for the deeply nested button.
+        assert all(
+            h.name != "Deep" for h in inst.refs.values()
+        )
+
+    @pytest.mark.asyncio
+    async def test_locator_from_ref_uses_evaluate_handle_for_shadow(self):
+        """Non-empty ``shadow_path`` triggers the two-stage
+        ``evaluate_handle`` resolver instead of ``get_by_role.nth(...)``."""
+        from src.browser.ref_handle import RefHandle, ShadowHop
+        from src.browser.service import BrowserManager, CamoufoxInstance
+        mgr = BrowserManager(profiles_dir="/tmp/test_profiles")
+
+        mock_page = MagicMock()
+        # Stage-1 returns a JSHandle whose .evaluate returns no error
+        stage1_handle = AsyncMock()
+        stage1_handle.evaluate = AsyncMock(return_value=None)
+        stage2_handle = AsyncMock()
+        stage2_element = MagicMock()
+        stage2_handle.as_element = MagicMock(return_value=stage2_element)
+        stage1_handle.evaluate_handle = AsyncMock(return_value=stage2_handle)
+        mock_page.evaluate_handle = AsyncMock(return_value=stage1_handle)
+
+        inst = CamoufoxInstance("a1", MagicMock(), MagicMock(), mock_page)
+        page_id = inst._page_id_for(inst.page)
+        inst.refs["e0"] = RefHandle.shadow(
+            page_id=page_id, scope_root=None,
+            shadow_path=(ShadowHop("my-card", 0, "testid:foo"),),
+            role="button", name="Submit", occurrence=0, disabled=False,
+        )
+
+        result = await mgr._locator_from_ref(inst, "e0")
+        assert result is stage2_element
+        # get_by_role must NOT be called for shadow refs
+        mock_page.get_by_role.assert_not_called()
+        # Stage-1 evaluate_handle was called on the page with the path
+        mock_page.evaluate_handle.assert_called_once()
+        first_call_args = mock_page.evaluate_handle.call_args
+        path_arg = first_call_args[0][1]["path"]
+        import json as _json
+        decoded = _json.loads(path_arg)
+        assert decoded == [
+            {"selector": "my-card", "occurrence": 0, "discriminator": "testid:foo"},
+        ]
+        # Stage-2 evaluate_handle was called on the shadow root handle
+        # with role/name/occurrence
+        stage1_handle.evaluate_handle.assert_called_once()
+        stage2_call = stage1_handle.evaluate_handle.call_args
+        stage2_args = stage2_call[0][1]
+        assert stage2_args == {
+            "role": "button", "name": "Submit", "occurrence": 0,
+        }
+
+    @pytest.mark.asyncio
+    async def test_locator_from_ref_raises_ref_stale_on_missing_host(self):
+        from src.browser.ref_handle import RefHandle, RefStale, ShadowHop
+        from src.browser.service import BrowserManager, CamoufoxInstance
+        mgr = BrowserManager(profiles_dir="/tmp/test_profiles")
+
+        mock_page = MagicMock()
+        stage1_handle = AsyncMock()
+        stage1_handle.evaluate = AsyncMock(return_value="stale_host_missing")
+        mock_page.evaluate_handle = AsyncMock(return_value=stage1_handle)
+
+        inst = CamoufoxInstance("a1", MagicMock(), MagicMock(), mock_page)
+        page_id = inst._page_id_for(inst.page)
+        inst.refs["e0"] = RefHandle.shadow(
+            page_id=page_id, scope_root=None,
+            shadow_path=(ShadowHop("ghost-card", 0, "testid:gone"),),
+            role="button", name="Submit", occurrence=0, disabled=False,
+        )
+
+        with pytest.raises(RefStale):
+            await mgr._locator_from_ref(inst, "e0")
+
+    @pytest.mark.asyncio
+    async def test_locator_from_ref_raises_ref_stale_on_discriminator_mismatch(self):
+        from src.browser.ref_handle import RefHandle, RefStale, ShadowHop
+        from src.browser.service import BrowserManager, CamoufoxInstance
+        mgr = BrowserManager(profiles_dir="/tmp/test_profiles")
+
+        mock_page = MagicMock()
+        stage1_handle = AsyncMock()
+        stage1_handle.evaluate = AsyncMock(return_value="stale_discriminator_mismatch")
+        mock_page.evaluate_handle = AsyncMock(return_value=stage1_handle)
+
+        inst = CamoufoxInstance("a1", MagicMock(), MagicMock(), mock_page)
+        page_id = inst._page_id_for(inst.page)
+        inst.refs["e0"] = RefHandle.shadow(
+            page_id=page_id, scope_root=None,
+            shadow_path=(ShadowHop("my-card", 0, "testid:was-foo"),),
+            role="button", name="Submit", occurrence=0, disabled=False,
+        )
+
+        with pytest.raises(RefStale):
+            await mgr._locator_from_ref(inst, "e0")
+
+    @pytest.mark.asyncio
+    async def test_locator_from_ref_raises_ref_stale_when_element_not_found(self):
+        from src.browser.ref_handle import RefHandle, RefStale, ShadowHop
+        from src.browser.service import BrowserManager, CamoufoxInstance
+        mgr = BrowserManager(profiles_dir="/tmp/test_profiles")
+
+        mock_page = MagicMock()
+        stage1_handle = AsyncMock()
+        stage1_handle.evaluate = AsyncMock(return_value=None)
+        stage2_handle = AsyncMock()
+        stage2_handle.as_element = MagicMock(return_value=None)
+        stage1_handle.evaluate_handle = AsyncMock(return_value=stage2_handle)
+        mock_page.evaluate_handle = AsyncMock(return_value=stage1_handle)
+
+        inst = CamoufoxInstance("a1", MagicMock(), MagicMock(), mock_page)
+        page_id = inst._page_id_for(inst.page)
+        inst.refs["e0"] = RefHandle.shadow(
+            page_id=page_id, scope_root=None,
+            shadow_path=(ShadowHop("my-card", 0, "testid:foo"),),
+            role="button", name="Vanished", occurrence=99, disabled=False,
+        )
+
+        with pytest.raises(RefStale):
+            await mgr._locator_from_ref(inst, "e0")
+
+    @pytest.mark.asyncio
+    async def test_type_text_accepts_shadow_element_handle(self):
+        """``type_text`` must accept the ElementHandle returned by the
+        shadow resolver, not just a Locator. Both expose ``.click``,
+        ``.bounding_box`` and ``.scroll_into_view_if_needed``."""
+        from src.browser.ref_handle import RefHandle, ShadowHop
+        from src.browser.service import BrowserManager, CamoufoxInstance
+        mgr = BrowserManager(profiles_dir="/tmp/test_profiles")
+
+        mock_page = AsyncMock()
+        mock_page.keyboard = AsyncMock()
+        mock_page.keyboard.press = AsyncMock()
+        mock_page.evaluate = AsyncMock(return_value=True)
+
+        inst = CamoufoxInstance("a1", MagicMock(), MagicMock(), mock_page)
+        page_id = inst._page_id_for(inst.page)
+        inst.refs["e0"] = RefHandle.shadow(
+            page_id=page_id, scope_root=None,
+            shadow_path=(ShadowHop("my-input", 0, "testid:i"),),
+            role="textbox", name="Email", occurrence=0, disabled=False,
+        )
+        mgr._instances["a1"] = inst
+
+        # Stub _locator_from_ref to return an ElementHandle-like object
+        # whose interface matches what _human_click and the type code
+        # actually call: hover, click, scroll_into_view_if_needed,
+        # bounding_box.
+        element_handle = AsyncMock()
+        element_handle.hover = AsyncMock()
+        element_handle.click = AsyncMock()
+        element_handle.scroll_into_view_if_needed = AsyncMock()
+        element_handle.bounding_box = AsyncMock(
+            return_value={"x": 10, "y": 10, "width": 50, "height": 20},
+        )
+        mgr._locator_from_ref = AsyncMock(return_value=element_handle)
+
+        with patch("src.browser.service.random.random", return_value=1.0):
+            result = await mgr.type_text("a1", ref="e0", text="hi", clear=False)
+        assert result["success"] is True
+        # ElementHandle.click was driven by the focus path
+        element_handle.click.assert_called()
+        # Keyboard typing dispatched per character
+        press_calls = [c[0][0] for c in mock_page.keyboard.press.call_args_list]
+        assert "h" in press_calls and "i" in press_calls
+
+    @pytest.mark.asyncio
+    async def test_click_accepts_shadow_element_handle(self):
+        from src.browser.ref_handle import RefHandle, ShadowHop
+        from src.browser.service import BrowserManager, CamoufoxInstance
+        mgr = BrowserManager(profiles_dir="/tmp/test_profiles")
+
+        mock_page = AsyncMock()
+        inst = CamoufoxInstance("a1", MagicMock(), MagicMock(), mock_page)
+        page_id = inst._page_id_for(inst.page)
+        inst.refs["e0"] = RefHandle.shadow(
+            page_id=page_id, scope_root=None,
+            shadow_path=(ShadowHop("my-card", 0, "testid:c"),),
+            role="button", name="Submit", occurrence=0, disabled=False,
+        )
+        mgr._instances["a1"] = inst
+
+        element_handle = AsyncMock()
+        element_handle.hover = AsyncMock()
+        element_handle.click = AsyncMock()
+        mgr._locator_from_ref = AsyncMock(return_value=element_handle)
+
+        result = await mgr.click("a1", ref="e0")
+        assert result["success"] is True
+        element_handle.click.assert_called()

--- a/tests/test_browser_service.py
+++ b/tests/test_browser_service.py
@@ -10,6 +10,14 @@ from src.browser.ref_handle import from_legacy_dict as _h
 from src.browser.service import BrowserManager, CamoufoxInstance
 
 
+def _no_playwright() -> bool:
+    try:
+        import playwright.async_api  # noqa: F401
+        return False
+    except ImportError:
+        return True
+
+
 class TestCredentialRedactor:
     """Tests for browser.redaction.CredentialRedactor."""
 
@@ -970,6 +978,7 @@ class TestScreenshot:
         from io import BytesIO
 
         from PIL import Image
+
         from src.browser.service import BrowserManager, CamoufoxInstance
         mgr = BrowserManager(profiles_dir="/tmp/test_profiles")
         png = _make_png_bytes(width=200, height=120)
@@ -1053,6 +1062,7 @@ class TestScreenshot:
     async def test_screenshot_pillow_missing_falls_back_to_png(self, monkeypatch):
         """If Pillow can't be imported the helper returns the raw PNG."""
         import builtins
+
         from src.browser.service import BrowserManager, CamoufoxInstance
         mgr = BrowserManager(profiles_dir="/tmp/test_profiles")
         png = _make_png_bytes()
@@ -7819,6 +7829,16 @@ class TestShadowDOM:
         assert roundtrip.occurrence == 2
         assert roundtrip.discriminator == "testid:foo"
 
+    def test_shadow_hop_rejects_empty_selector(self):
+        from src.browser.ref_handle import ShadowHop
+        with pytest.raises(ValueError, match="selector"):
+            ShadowHop(selector="", occurrence=0, discriminator="testid:x")
+
+    def test_shadow_hop_rejects_empty_discriminator(self):
+        from src.browser.ref_handle import ShadowHop
+        with pytest.raises(ValueError, match="discriminator"):
+            ShadowHop(selector="my-card", occurrence=0, discriminator="")
+
     @pytest.mark.asyncio
     async def test_compute_element_key_folds_shadow_path(self):
         from src.browser.ref_handle import ShadowHop, compute_element_key
@@ -7935,17 +7955,15 @@ class TestShadowDOM:
             assert handle.frame_id is None
 
     @pytest.mark.asyncio
-    async def test_closed_shadow_root_not_in_snapshot(self):
-        """Closed shadow roots are unreachable per the web spec — the
-        walker cannot pierce them. We assert that a tree without a
-        ``shadow_path`` annotation does NOT acquire one (i.e. nodes the
-        walker would have emitted for a closed root simply never appear)."""
+    async def test_python_walk_does_not_invent_shadow_path(self):
+        """Python-side regression: the synthesized tree fed to the Python
+        ``_walk`` carries no ``shadow_path`` annotation, so emitted refs
+        must keep ``shadow_path == ()``. Does NOT exercise the JS walker
+        or actual closed shadow roots — see real-browser tests for that.
+        """
         from src.browser.service import BrowserManager, CamoufoxInstance
         mgr = BrowserManager(profiles_dir="/tmp/test_profiles")
 
-        # Tree shape simulates a page where the shadow host is visible
-        # but its closed shadow contents are NOT walked: only the host
-        # element shows up, no inner ref.
         tree = {
             "role": "WebArea", "name": "",
             "children": [
@@ -7964,9 +7982,10 @@ class TestShadowDOM:
             assert handle.shadow_path == ()
 
     @pytest.mark.asyncio
-    async def test_max_walk_depth_caps_descent(self):
-        """``_MAX_WALK_DEPTH=50`` caps total walker depth — synthesizing
-        a 51-deep tree must produce zero refs past the cap."""
+    async def test_python_walk_depth_cap_stops_descent(self):
+        """Python-side regression: ``_MAX_WALK_DEPTH`` aborts deep trees.
+        Does NOT exercise the JS walker's ``MAX_WALK_DEPTH`` constant —
+        see ``test_js_walker_depth_cap`` for the JS-side check."""
         from src.browser.service import (
             _MAX_SNAPSHOT_ELEMENTS,
             BrowserManager,
@@ -7988,13 +8007,146 @@ class TestShadowDOM:
 
         result = await mgr.snapshot("a1")
         assert result["success"] is True
-        # Depth cap means the deepest button never gets walked.
-        # _MAX_SNAPSHOT_ELEMENTS is large; the cap is the limiter here.
-        assert _MAX_SNAPSHOT_ELEMENTS > 0  # sanity
-        # No refs emitted for the deeply nested button.
-        assert all(
-            h.name != "Deep" for h in inst.refs.values()
-        )
+        assert _MAX_SNAPSHOT_ELEMENTS > 0
+        assert all(h.name != "Deep" for h in inst.refs.values())
+
+    def test_js_walker_max_walk_depth_constant_injected(self):
+        """The JS walker reads ``MAX_WALK_DEPTH`` from a Python-side
+        constant. A drift between the Python ``_MAX_WALK_DEPTH`` and the
+        JS template would silently let one path walk deeper than the
+        other; this test catches that by inspecting the rendered JS.
+        """
+        from src.browser.service import _JS_A11Y_TREE, _MAX_WALK_DEPTH
+        # The constant is materialized into the JS body — the literal
+        # number must appear and the placeholder must NOT remain.
+        assert "__MAX_WALK_DEPTH__" not in _JS_A11Y_TREE
+        assert f"const MAX_WALK_DEPTH = {_MAX_WALK_DEPTH};" in _JS_A11Y_TREE
+        assert "if (d > MAX_WALK_DEPTH" in _JS_A11Y_TREE
+
+    @pytest.mark.asyncio
+    @pytest.mark.skipif(
+        _no_playwright(),
+        reason="playwright not installed in dev env; CI runs this",
+    )
+    async def test_js_walker_open_shadow_root_real_browser(self):
+        """Spin up a real browser, set HTML with an open shadow root,
+        run the actual JS walker. The shadow ref must appear with
+        non-empty ``shadow_path``."""
+        from playwright.async_api import async_playwright
+
+        from src.browser.service import _JS_A11Y_TREE
+        async with async_playwright() as p:
+            browser = await p.firefox.launch()
+            try:
+                page = await browser.new_page()
+                await page.set_content("""
+                    <html><body>
+                      <my-card id="card1"></my-card>
+                      <script>
+                        const host = document.getElementById('card1');
+                        const root = host.attachShadow({mode: 'open'});
+                        const btn = document.createElement('button');
+                        btn.textContent = 'Submit';
+                        root.appendChild(btn);
+                      </script>
+                    </body></html>
+                """)
+                tree = await page.evaluate(_JS_A11Y_TREE)
+                # Walk the tree to find the button — must carry a
+                # non-empty shadow_path.
+                def find_button(node):
+                    if node.get("role") == "button":
+                        return node
+                    for c in node.get("children", []) or []:
+                        r = find_button(c)
+                        if r:
+                            return r
+                    return None
+                btn = find_button(tree)
+                assert btn is not None, "shadow button not found in walked tree"
+                sp = btn.get("shadow_path")
+                assert sp, "shadow button missing shadow_path"
+                assert sp[0]["selector"] in ("my-card", "my-card#card1")
+                assert sp[0]["discriminator"]
+            finally:
+                await browser.close()
+
+    @pytest.mark.asyncio
+    @pytest.mark.skipif(
+        _no_playwright(),
+        reason="playwright not installed in dev env; CI runs this",
+    )
+    async def test_js_walker_closed_shadow_root_invisible_real_browser(self):
+        """Real-browser test: closed shadow roots are unreachable per
+        spec, so descendants must not appear in the walker output."""
+        from playwright.async_api import async_playwright
+
+        from src.browser.service import _JS_A11Y_TREE
+        async with async_playwright() as p:
+            browser = await p.firefox.launch()
+            try:
+                page = await browser.new_page()
+                await page.set_content("""
+                    <html><body>
+                      <my-card id="card1"></my-card>
+                      <button>Outside</button>
+                      <script>
+                        const host = document.getElementById('card1');
+                        const root = host.attachShadow({mode: 'closed'});
+                        const btn = document.createElement('button');
+                        btn.textContent = 'Inside';
+                        root.appendChild(btn);
+                      </script>
+                    </body></html>
+                """)
+                tree = await page.evaluate(_JS_A11Y_TREE)
+                def collect_button_names(node, out):
+                    if node.get("role") == "button":
+                        out.append(node.get("name", ""))
+                    for c in node.get("children", []) or []:
+                        collect_button_names(c, out)
+                names = []
+                collect_button_names(tree, names)
+                assert "Outside" in names
+                assert "Inside" not in names
+            finally:
+                await browser.close()
+
+    @pytest.mark.asyncio
+    @pytest.mark.skipif(
+        _no_playwright(),
+        reason="playwright not installed in dev env; CI runs this",
+    )
+    async def test_js_walker_depth_cap_real_browser(self):
+        """Real-browser test: a 60-deep nested DOM must produce zero
+        emitted nodes past ``MAX_WALK_DEPTH=50``. Exercises the JS-side
+        depth gate, not the Python one."""
+        from playwright.async_api import async_playwright
+
+        from src.browser.service import _JS_A11Y_TREE, _MAX_WALK_DEPTH
+        async with async_playwright() as p:
+            browser = await p.firefox.launch()
+            try:
+                page = await browser.new_page()
+                # Generate 60 nested divs, deepest carries a button.
+                inner = '<button>Deep</button>'
+                for _ in range(60):
+                    inner = f'<div>{inner}</div>'
+                await page.set_content(f"<html><body>{inner}</body></html>")
+                tree = await page.evaluate(_JS_A11Y_TREE)
+                def find_button_depth(node, d=0):
+                    if node.get("role") == "button":
+                        return d
+                    for c in node.get("children", []) or []:
+                        r = find_button_depth(c, d + 1)
+                        if r is not None:
+                            return r
+                    return None
+                depth = find_button_depth(tree)
+                # Walker stopped before reaching the button at depth 60.
+                assert depth is None or depth <= _MAX_WALK_DEPTH
+            finally:
+                await browser.close()
 
     @pytest.mark.asyncio
     async def test_locator_from_ref_uses_evaluate_handle_for_shadow(self):


### PR DESCRIPTION
## Summary

- Walks open shadow roots in the JS a11y walker, accumulating a
  ``(selector, occurrence, discriminator)`` path through each boundary
  and folding it into ``RefHandle.shadow_path`` for emitted refs.
- Routes shadow refs through a two-stage Playwright ``evaluate_handle``
  resolver (``get_by_role`` does not pierce shadow). Stale hosts and
  discriminator mismatches surface as ``RefStale``.
- Hoists the implicit role map to a single Python constant
  (``_IMPLICIT_ROLE_MAP``) injected into both the walker and the
  stage-2 resolver via ``json.dumps`` — eliminates duplication.

## Test plan

- [x] ``pytest tests/test_browser_service.py::TestShadowDOM`` — 13 new tests, all green
- [x] ``pytest tests/test_browser_service.py`` — 364 tests, no regressions
- [x] ``pytest tests/test_browser_service.py::TestSnapshot ::TestBrowserManagerRefResolution ::TestSnapshotFromRef ::TestDiffSnapshot`` — 33 targeted tests, no regressions
- [x] ``pytest tests/`` (3472 non-E2E tests) — all pass
- [x] ``ruff check`` on changed source files — clean
- [x] Closed shadow roots remain unreachable (regression guard test)
- [x] Light-DOM-only pages produce ``shadow_path=()`` (regression guard test)

## Notes

- ``_locator_from_ref`` is now async. Existing test mocks were
  migrated from ``MagicMock`` to ``AsyncMock`` (``new_callable=AsyncMock``
  for ``patch.object``). Action methods (click, hover, type_text,
  scroll, upload_file, download) already use the
  ``Locator``/``ElementHandle`` shared interface
  (``.click``/``.hover``/``.bounding_box``/``.scroll_into_view_if_needed``).
- ``RefHandle.shadow`` factory added for symmetry with
  ``RefHandle.light_dom``.
- Discriminator priority: ``data-testid`` (most stable) > stable
  ``id`` (UUID/React-ID rejected) > structural fingerprint
  (``tagName|class|childCount``). Always a non-empty string.