### PR TITLE
Phase 5 §8.1: file upload via mesh-staged streaming

### DIFF
--- a/src/agent/builtins/browser_tool.py
+++ b/src/agent/builtins/browser_tool.py
@@ -743,7 +743,19 @@ async def browser_detect_captcha(*, mesh_client=None) -> dict:
     return await _browser_command(mesh_client, "detect_captcha")
 
 
-_UPLOAD_MAX_BYTES = 50 * 1024 * 1024
+def _upload_max_bytes() -> int:
+    """Per-file upload cap. Read from the same env var as the mesh +
+    browser layers so an operator override stays consistent across all
+    three. Defaults to 50 MB."""
+    import os as _os
+    raw = _os.environ.get("OPENLEGION_UPLOAD_STAGE_MAX_MB", "50")
+    try:
+        mb = max(1, int(raw))
+    except ValueError:
+        mb = 50
+    return mb * 1024 * 1024
+
+
 _UPLOAD_MAX_FILES = 5
 
 
@@ -818,11 +830,12 @@ async def browser_upload_file(
             size = safe.stat().st_size
         except OSError as e:
             return {"error": f"Cannot stat '{path}': {e}"}
-        if size > _UPLOAD_MAX_BYTES:
+        cap = _upload_max_bytes()
+        if size > cap:
             return {
                 "error": (
                     f"File '{path}' is {size} bytes; per-file cap is "
-                    f"{_UPLOAD_MAX_BYTES} bytes (50MB)"
+                    f"{cap} bytes ({cap // (1024 * 1024)}MB)"
                 ),
             }
         resolved_paths.append(safe)

--- a/src/agent/builtins/browser_tool.py
+++ b/src/agent/builtins/browser_tool.py
@@ -743,6 +743,108 @@ async def browser_detect_captcha(*, mesh_client=None) -> dict:
     return await _browser_command(mesh_client, "detect_captcha")
 
 
+_UPLOAD_MAX_BYTES = 50 * 1024 * 1024
+_UPLOAD_MAX_FILES = 5
+
+
+@skill(
+    name="browser_upload_file",
+    description=(
+        "Upload one or more workspace files to a file-input element. "
+        "Provide a `ref` from a prior browser_get_elements snapshot pointing "
+        "at an <input type=\"file\"> (or aria-equivalent). `paths` is a list "
+        "of workspace files (1..5) to upload — these are read from /data and "
+        "forwarded to the browser. Each file ≤50MB. "
+        "Returns {success, data: {uploaded: [path, ...]}}."
+    ),
+    parameters={
+        "ref": {
+            "type": "string",
+            "description": "Element ref (e.g. 'e7') for the file-input element.",
+        },
+        "paths": {
+            "type": "array",
+            "description": (
+                "Workspace paths under /data to upload (1..5 files). "
+                "Paths may be passed without the /data/ prefix — e.g. "
+                "'uploads/resume.pdf'. Each file must be <=50MB."
+            ),
+            "items": {"type": "string"},
+        },
+    },
+    parallel_safe=False,
+)
+async def browser_upload_file(
+    ref: str,
+    paths: list[str],
+    *,
+    mesh_client=None,
+) -> dict:
+    """Stage workspace files via mesh and drive the browser file-chooser."""
+    if not mesh_client:
+        return {"error": "Browser requires mesh connectivity"}
+    if not ref or not isinstance(ref, str):
+        return {"error": "ref is required"}
+    if not isinstance(paths, list) or not paths:
+        return {"error": "paths must be a non-empty list"}
+    if len(paths) > _UPLOAD_MAX_FILES:
+        return {"error": f"at most {_UPLOAD_MAX_FILES} files per upload"}
+    if not all(isinstance(p, str) and p for p in paths):
+        return {"error": "paths must be a list of non-empty strings"}
+
+    from src.agent.builtins.file_tool import _safe_path
+
+    file_blobs: list[bytes] = []
+    for path in paths:
+        try:
+            safe = _safe_path(path)
+        except (ValueError, OSError) as e:
+            return {"error": f"Invalid workspace path '{path}': {e}"}
+        if not safe.is_file():
+            return {"error": f"Upload path not found: {path}"}
+        try:
+            size = safe.stat().st_size
+        except OSError as e:
+            return {"error": f"Cannot stat '{path}': {e}"}
+        if size > _UPLOAD_MAX_BYTES:
+            return {
+                "error": (
+                    f"File '{path}' is {size} bytes; per-file cap is "
+                    f"{_UPLOAD_MAX_BYTES} bytes (50MB)"
+                ),
+            }
+        try:
+            file_blobs.append(safe.read_bytes())
+        except OSError as e:
+            return {"error": f"Cannot read '{path}': {e}"}
+
+    import uuid as _uuid
+    idem_key = _uuid.uuid4().hex
+    staged_handles: list[str] = []
+    try:
+        for i, blob in enumerate(file_blobs):
+            stage_key = f"{idem_key}-{i}"
+            stage_resp = await mesh_client.browser_upload_stage(
+                blob, idempotency_key=stage_key,
+            )
+            handle = stage_resp.get("staged_handle")
+            if not handle:
+                return {"error": "Mesh did not return a staged_handle"}
+            staged_handles.append(handle)
+    except Exception as e:
+        return {"error": _deep_redact(str(e))}
+
+    try:
+        result = await mesh_client.browser_upload_apply({
+            "ref": ref,
+            "staged_handles": staged_handles,
+            "idempotency_key": idem_key,
+        })
+        return _deep_redact(result)
+    except Exception as e:
+        return {"error": _deep_redact(str(e))}
+
+
 @skill(
     name="request_browser_login",
     description=(

--- a/src/agent/builtins/browser_tool.py
+++ b/src/agent/builtins/browser_tool.py
@@ -755,6 +755,8 @@ _UPLOAD_MAX_FILES = 5
         "at an <input type=\"file\"> (or aria-equivalent). `paths` is a list "
         "of workspace files (1..5) to upload — these are read from /data and "
         "forwarded to the browser. Each file ≤50MB. "
+        "Optional `idempotency_key` allows the caller to dedupe retries "
+        "explicitly across calls; when omitted a fresh key is generated. "
         "Returns {success, data: {uploaded: [path, ...]}}."
     ),
     parameters={
@@ -771,12 +773,21 @@ _UPLOAD_MAX_FILES = 5
             ),
             "items": {"type": "string"},
         },
+        "idempotency_key": {
+            "type": "string",
+            "description": (
+                "Optional caller-supplied key for cross-call dedupe. "
+                "Same key + same caller + same content within the stage "
+                "TTL returns the existing staged handle."
+            ),
+        },
     },
     parallel_safe=False,
 )
 async def browser_upload_file(
     ref: str,
     paths: list[str],
+    idempotency_key: str | None = None,
     *,
     mesh_client=None,
 ) -> dict:
@@ -794,7 +805,8 @@ async def browser_upload_file(
 
     from src.agent.builtins.file_tool import _safe_path
 
-    file_blobs: list[bytes] = []
+    resolved_paths: list = []
+    suggested_filenames: list[str] = []
     for path in paths:
         try:
             safe = _safe_path(path)
@@ -813,20 +825,19 @@ async def browser_upload_file(
                     f"{_UPLOAD_MAX_BYTES} bytes (50MB)"
                 ),
             }
-        try:
-            file_blobs.append(safe.read_bytes())
-        except OSError as e:
-            return {"error": f"Cannot read '{path}': {e}"}
+        resolved_paths.append(safe)
+        suggested_filenames.append(safe.name)
 
     import uuid as _uuid
-    idem_key = _uuid.uuid4().hex
+    idem_key = idempotency_key if isinstance(idempotency_key, str) and idempotency_key else _uuid.uuid4().hex
     staged_handles: list[str] = []
     try:
-        for i, blob in enumerate(file_blobs):
+        for i, safe_path in enumerate(resolved_paths):
             stage_key = f"{idem_key}-{i}"
-            stage_resp = await mesh_client.browser_upload_stage(
-                blob, idempotency_key=stage_key,
-            )
+            with open(safe_path, "rb") as fh:
+                stage_resp = await mesh_client.browser_upload_stage(
+                    fh, idempotency_key=stage_key,
+                )
             handle = stage_resp.get("staged_handle")
             if not handle:
                 return {"error": "Mesh did not return a staged_handle"}
@@ -838,6 +849,7 @@ async def browser_upload_file(
         result = await mesh_client.browser_upload_apply({
             "ref": ref,
             "staged_handles": staged_handles,
+            "suggested_filenames": suggested_filenames,
             "idempotency_key": idem_key,
         })
         return _deep_redact(result)

--- a/src/agent/mesh_client.py
+++ b/src/agent/mesh_client.py
@@ -791,14 +791,16 @@ class MeshClient:
         return response.json()
 
     async def browser_upload_stage(
-        self, file_bytes: bytes, idempotency_key: str | None = None,
+        self, body, idempotency_key: str | None = None,
     ) -> dict:
         """Phase A of the §4.5 file-upload flow.
 
-        Streams ``file_bytes`` to ``/mesh/browser/upload-stage`` and
-        returns the staging response (``{staged_handle, size_bytes,
-        expires_at}``). Mesh enforces the 50MB cap; pass an
-        ``idempotency_key`` to dedupe retried uploads of the same bytes.
+        Streams ``body`` to ``/mesh/browser/upload-stage`` and returns the
+        staging response (``{staged_handle, size_bytes, expires_at}``).
+        ``body`` may be ``bytes`` or any object accepted by httpx's
+        ``content=`` (file handle, async iterable). Mesh enforces the 50MB
+        cap; pass an ``idempotency_key`` to dedupe retried uploads of the
+        same bytes.
         """
         client = await self._get_client()
         headers = dict(self._trace_headers())
@@ -806,7 +808,7 @@ class MeshClient:
             headers["Idempotency-Key"] = idempotency_key
         response = await client.post(
             f"{self.mesh_url}/mesh/browser/upload-stage",
-            content=file_bytes,
+            content=body,
             headers=headers,
             timeout=120,
         )

--- a/src/agent/mesh_client.py
+++ b/src/agent/mesh_client.py
@@ -790,6 +790,47 @@ class MeshClient:
         response.raise_for_status()
         return response.json()
 
+    async def browser_upload_stage(
+        self, file_bytes: bytes, idempotency_key: str | None = None,
+    ) -> dict:
+        """Phase A of the §4.5 file-upload flow.
+
+        Streams ``file_bytes`` to ``/mesh/browser/upload-stage`` and
+        returns the staging response (``{staged_handle, size_bytes,
+        expires_at}``). Mesh enforces the 50MB cap; pass an
+        ``idempotency_key`` to dedupe retried uploads of the same bytes.
+        """
+        client = await self._get_client()
+        headers = dict(self._trace_headers())
+        if idempotency_key:
+            headers["Idempotency-Key"] = idempotency_key
+        response = await client.post(
+            f"{self.mesh_url}/mesh/browser/upload-stage",
+            content=file_bytes,
+            headers=headers,
+            timeout=120,
+        )
+        response.raise_for_status()
+        return response.json()
+
+    async def browser_upload_apply(self, body: dict) -> dict:
+        """Phase B of the §4.5 file-upload flow.
+
+        Body: ``{ref, staged_handles, target_agent_id?, idempotency_key?}``.
+        Mesh resolves the staged handles, streams bytes into the browser
+        container, drives the file-chooser, and returns the browser's
+        response envelope.
+        """
+        client = await self._get_client()
+        response = await client.post(
+            f"{self.mesh_url}/mesh/browser/upload_file",
+            json=body,
+            timeout=120,
+            headers=self._trace_headers(),
+        )
+        response.raise_for_status()
+        return response.json()
+
     # ── Operator metrics ─────────────────────────────────────────
 
     async def get_system_metrics(self) -> dict:

--- a/src/browser/flags.py
+++ b/src/browser/flags.py
@@ -62,6 +62,11 @@ KNOWN_FLAGS: dict[str, str] = {
     "OPENLEGION_REDACTION_URL_QUERY_ALLOW": "comma-separated param names",
     # ── Concurrency (§8.2) ────────────────────────────────────────────────
     "OPENLEGION_BROWSER_MAX_CONCURRENT": "int, startup-only (default 5)",
+    # ── File transfer (§4.5 / §8.1) ───────────────────────────────────────
+    "OPENLEGION_UPLOAD_STAGE_MAX_MB": "int, per-file upload byte cap (default 50)",
+    "OPENLEGION_UPLOAD_STAGE_DIR": "mesh staging dir (default /tmp/openlegion-upload-stage)",
+    "OPENLEGION_UPLOAD_RECV_DIR": "browser receive dir (default /tmp/upload-recv)",
+    "OPENLEGION_UPLOAD_STAGE_TTL_S": "orphan staging TTL in seconds (default 60)",
     # ── CAPTCHA solver (§11) ──────────────────────────────────────────────
     "CAPTCHA_SOLVER_PROVIDER": "2captcha | capsolver | unset",
     "CAPTCHA_SOLVER_KEY": "API key for the primary provider",

--- a/src/browser/server.py
+++ b/src/browser/server.py
@@ -11,6 +11,8 @@ import contextlib
 import hmac
 import json
 import os
+import uuid
+from pathlib import Path
 
 from fastapi import FastAPI, HTTPException, Request
 
@@ -345,6 +347,71 @@ def create_browser_app(manager: BrowserManager, lifespan=None) -> FastAPI:
         result = await manager.upload_file(agent_id, ref, paths)
         await _apply_delay()
         return result
+
+    @app.post("/browser/{agent_id}/_stage_upload")
+    async def stage_upload(agent_id: str, request: Request):
+        """Mesh-internal byte-stream ingest endpoint for §4.5 file uploads.
+
+        Reads the request body as raw bytes, writes them under
+        ``OPENLEGION_UPLOAD_RECV_DIR`` (default ``/tmp/upload-recv``) with
+        a freshly-generated nonce filename, and returns the on-disk path
+        for the mesh to forward into ``/browser/{agent_id}/upload_file``.
+
+        Mesh-only — requires ``X-Mesh-Internal: 1``. Agents never call
+        this directly because they don't possess the browser bearer token,
+        but the header gate is a defense-in-depth check.
+        """
+        _verify_auth(request)
+        if request.headers.get("x-mesh-internal", "") != "1":
+            raise HTTPException(403, "Mesh-internal endpoint")
+        from src.browser.flags import get_int as _flag_int
+        from src.browser.flags import get_str as _flag_str
+        max_mb = _flag_int(
+            "OPENLEGION_UPLOAD_STAGE_MAX_MB", 50, min_value=1, max_value=1024,
+        )
+        max_bytes = max_mb * 1024 * 1024
+        recv_dir = Path(
+            _flag_str("OPENLEGION_UPLOAD_RECV_DIR", "/tmp/upload-recv"),
+        )
+        try:
+            recv_dir.mkdir(parents=True, exist_ok=True)
+        except OSError as e:
+            raise HTTPException(500, f"Cannot create receive dir: {e}")
+
+        nonce = uuid.uuid4().hex
+        suggested = request.query_params.get("suggested_filename", "")
+        suffix = ""
+        if suggested:
+            base = os.path.basename(suggested).strip()
+            base = base.replace("\x00", "")
+            base = base.replace("/", "").replace("\\", "")
+            if base and not base.startswith("."):
+                suffix = "-" + base[:80]
+        target = recv_dir / f"{nonce}{suffix or '.bin'}"
+
+        size = 0
+        try:
+            with open(target, "wb") as fh:
+                async for chunk in request.stream():
+                    if not chunk:
+                        continue
+                    size += len(chunk)
+                    if size > max_bytes:
+                        fh.close()
+                        with contextlib.suppress(OSError):
+                            target.unlink()
+                        raise HTTPException(
+                            413,
+                            f"Upload exceeds {max_mb}MB limit",
+                        )
+                    fh.write(chunk)
+        except HTTPException:
+            raise
+        except OSError as e:
+            with contextlib.suppress(OSError):
+                target.unlink()
+            raise HTTPException(500, f"Write failed: {e}")
+        return {"path": str(target), "size_bytes": size}
 
     @app.post("/browser/{agent_id}/download")
     async def download_trigger(agent_id: str, request: Request):

--- a/src/browser/server.py
+++ b/src/browser/server.py
@@ -48,12 +48,20 @@ def create_browser_app(manager: BrowserManager, lifespan=None) -> FastAPI:
     auth_token = os.environ.get("BROWSER_AUTH_TOKEN", "")
     if not auth_token:
         if os.environ.get("MESH_AUTH_TOKEN"):
-            raise RuntimeError(
-                "BROWSER_AUTH_TOKEN not set but MESH_AUTH_TOKEN is configured. "
-                "Browser auth cannot be disabled in production. "
-                "Set BROWSER_AUTH_TOKEN or BROWSER_AUTH_INSECURE=1 to override."
-            )
-        logger.warning("BROWSER_AUTH_TOKEN not set — browser service auth is DISABLED")
+            if os.environ.get("BROWSER_AUTH_INSECURE"):
+                logger.warning(
+                    "BROWSER_AUTH_TOKEN not set; BROWSER_AUTH_INSECURE=1 "
+                    "override engaged — browser service auth DISABLED. "
+                    "Use only in dev/test."
+                )
+            else:
+                raise RuntimeError(
+                    "BROWSER_AUTH_TOKEN not set but MESH_AUTH_TOKEN is configured. "
+                    "Browser auth cannot be disabled in production. "
+                    "Set BROWSER_AUTH_TOKEN or BROWSER_AUTH_INSECURE=1 to override."
+                )
+        else:
+            logger.warning("BROWSER_AUTH_TOKEN not set — browser service auth is DISABLED")
 
     def _verify_auth(request: Request) -> None:
         if not auth_token:
@@ -395,7 +403,20 @@ def create_browser_app(manager: BrowserManager, lifespan=None) -> FastAPI:
             base = base.replace("\x00", "")
             base = base.replace("/", "").replace("\\", "")
             if base and not base.startswith("."):
-                suffix = "-" + base[:80]
+                # P0.4: preserve the extension. Naively truncating the
+                # whole string (``base[:80]``) drops the ``.pdf`` from
+                # long names like ``scan_..._final.pdf``, leaving
+                # Playwright with a typeless filename.
+                from pathlib import PurePosixPath
+                pp = PurePosixPath(base)
+                ext = pp.suffix
+                stem = pp.stem
+                budget = 80 - len(ext)
+                if budget < 1:
+                    truncated = base[:80]
+                else:
+                    truncated = stem[:budget] + ext
+                suffix = "-" + truncated
         target = recv_dir / f"{nonce}{suffix or '.bin'}"
 
         size = 0

--- a/src/browser/server.py
+++ b/src/browser/server.py
@@ -357,13 +357,22 @@ def create_browser_app(manager: BrowserManager, lifespan=None) -> FastAPI:
         a freshly-generated nonce filename, and returns the on-disk path
         for the mesh to forward into ``/browser/{agent_id}/upload_file``.
 
-        Mesh-only — requires ``X-Mesh-Internal: 1``. Agents never call
-        this directly because they don't possess the browser bearer token,
-        but the header gate is a defense-in-depth check.
+        Two gates: (1) ``X-Mesh-Internal: 1`` header AND (2) bearer
+        ``Authorization`` token. Both must pass even when
+        ``BROWSER_AUTH_INSECURE=1`` is set — unlike public endpoints,
+        internal byte-ingest never opens its bearer gate in dev mode.
         """
-        _verify_auth(request)
         if request.headers.get("x-mesh-internal", "") != "1":
             raise HTTPException(403, "Mesh-internal endpoint")
+        _verify_auth(request)
+        if (
+            os.environ.get("BROWSER_AUTH_INSECURE")
+            and not request.headers.get("authorization")
+        ):
+            raise HTTPException(
+                403,
+                "Internal endpoint requires bearer auth even in dev mode",
+            )
         from src.browser.flags import get_int as _flag_int
         from src.browser.flags import get_str as _flag_str
         max_mb = _flag_int(

--- a/src/browser/service.py
+++ b/src/browser/service.py
@@ -1613,6 +1613,13 @@ class BrowserManager:
         """Stop all browser instances and clean up Playwright."""
         if self._cleanup_task:
             self._cleanup_task.cancel()
+        if getattr(self, "_upload_recv_gc_task", None):
+            self._upload_recv_gc_task.cancel()
+            try:
+                await self._upload_recv_gc_task
+            except (asyncio.CancelledError, Exception):
+                pass
+            self._upload_recv_gc_task = None
         async with self._lock:
             for agent_id in list(self._instances.keys()):
                 await self._stop_instance(agent_id)

--- a/src/browser/service.py
+++ b/src/browser/service.py
@@ -966,10 +966,58 @@ class BrowserManager:
         # service with many agents doesn't grow without bound.
         self._metrics_history: deque[dict] = deque(maxlen=1024)
         self._metrics_seq: int = 0
+        self._upload_recv_gc_task: asyncio.Task | None = None
 
     async def start_cleanup_loop(self):
         """Start background task that cleans up idle browsers."""
         self._cleanup_task = asyncio.create_task(self._cleanup_loop())
+        self._upload_recv_gc_task = asyncio.create_task(self._upload_recv_gc_loop())
+
+    async def _upload_recv_gc_once(self) -> int:
+        """Reap orphan upload-recv files older than the stage TTL.
+
+        Mirrors the mesh-side reaper: under normal flow ``upload_file`` cleans
+        its own files via the try/finally, but a hard crash between
+        ``_stage_upload`` and ``upload_file`` (chooser timeout, ref-not-found,
+        process kill) would leak bytes to the recv dir.
+        """
+        from src.browser.flags import get_int as _flag_int
+        from src.browser.flags import get_str as _flag_str
+
+        recv_dir = Path(_flag_str("OPENLEGION_UPLOAD_RECV_DIR", "/tmp/upload-recv"))
+        if not recv_dir.exists():
+            return 0
+        ttl_s = _flag_int(
+            "OPENLEGION_UPLOAD_STAGE_TTL_S", 60, min_value=5, max_value=3600,
+        )
+        now = time.time()
+        reaped = 0
+        try:
+            entries = list(recv_dir.iterdir())
+        except OSError:
+            return 0
+        for child in entries:
+            try:
+                age = now - child.stat().st_mtime
+            except OSError:
+                continue
+            if age > ttl_s:
+                try:
+                    child.unlink()
+                    reaped += 1
+                except OSError:
+                    continue
+        return reaped
+
+    async def _upload_recv_gc_loop(self):
+        while True:
+            try:
+                await self._upload_recv_gc_once()
+            except asyncio.CancelledError:
+                raise
+            except Exception as e:
+                logger.debug("upload_recv gc tick failed: %s", e)
+            await asyncio.sleep(30)
 
     async def _cleanup_loop(self):
         while True:
@@ -3804,11 +3852,6 @@ class BrowserManager:
                         "success": False,
                         "error": "User has browser control — action paused",
                     }
-                # Validate every local path before opening the chooser —
-                # Playwright's ``set_files`` raises a cryptic error if a
-                # path is missing, and the chooser-open side-effect has
-                # already happened by then.  Fail fast, keep the error
-                # message actionable.
                 for p in local_paths:
                     if not Path(p).is_file():
                         return {
@@ -3818,24 +3861,23 @@ class BrowserManager:
                 locator = self._locator_from_ref(inst, ref)
                 if not locator:
                     return {"success": False, "error": f"Ref '{ref}' not found"}
-                # Race: the click that triggers the chooser must happen
-                # INSIDE the ``expect_file_chooser`` context, otherwise we
-                # may miss the event. Playwright's pattern is exactly this.
                 async with inst.page.expect_file_chooser(timeout=timeout_ms) as info:
                     await locator.click(timeout=timeout_ms)
                 chooser = await info.value
                 await chooser.set_files(local_paths)
                 await asyncio.sleep(action_delay())
-                uploaded = list(local_paths)
-                for p in uploaded:
-                    with contextlib.suppress(OSError):
-                        Path(p).unlink(missing_ok=True)
                 return {
                     "success": True,
-                    "data": {"uploaded": uploaded},
+                    "data": {"uploaded": list(local_paths)},
                 }
             except Exception as e:
                 return {"success": False, "error": str(e)}
+            finally:
+                for p in local_paths:
+                    try:
+                        Path(p).unlink(missing_ok=True)
+                    except Exception:
+                        logger.debug("Stage cleanup failed for %s", p)
 
     async def download(
         self, agent_id: str, ref: str,

--- a/src/browser/service.py
+++ b/src/browser/service.py
@@ -3826,9 +3826,13 @@ class BrowserManager:
                 chooser = await info.value
                 await chooser.set_files(local_paths)
                 await asyncio.sleep(action_delay())
+                uploaded = list(local_paths)
+                for p in uploaded:
+                    with contextlib.suppress(OSError):
+                        Path(p).unlink(missing_ok=True)
                 return {
                     "success": True,
-                    "data": {"uploaded": list(local_paths)},
+                    "data": {"uploaded": uploaded},
                 }
             except Exception as e:
                 return {"success": False, "error": str(e)}

--- a/src/host/server.py
+++ b/src/host/server.py
@@ -2995,11 +2995,16 @@ def create_mesh_app(
         _UPLOAD_STAGE_MAX_MB = 50
     _UPLOAD_STAGE_MAX_BYTES = _UPLOAD_STAGE_MAX_MB * 1024 * 1024
 
+    _stage_dir_resolved = _UPLOAD_STAGE_DIR.resolve()
+
     def _stage_paths(handle: str) -> tuple[_Path, _Path]:
-        return (
-            _UPLOAD_STAGE_DIR / f"{handle}.bin",
-            _UPLOAD_STAGE_DIR / f"{handle}.json",
-        )
+        bin_path = (_UPLOAD_STAGE_DIR / f"{handle}.bin").resolve()
+        meta_path = (_UPLOAD_STAGE_DIR / f"{handle}.json").resolve()
+        if not bin_path.is_relative_to(_stage_dir_resolved):
+            raise HTTPException(400, "invalid handle")
+        if not meta_path.is_relative_to(_stage_dir_resolved):
+            raise HTTPException(400, "invalid handle")
+        return bin_path, meta_path
 
     def _read_stage_meta(meta_path: _Path) -> dict | None:
         try:
@@ -3021,6 +3026,37 @@ def create_mesh_app(
             with contextlib.suppress(OSError):
                 partial.unlink()
             raise
+
+    # P0.2: Per-handle async lock for stage writes. Two parallel stage
+    # requests with the same idempotency_key produce the same handle —
+    # without this lock, both would write to the partial file concurrently
+    # and corrupt the resulting bytes.
+    _stage_locks: dict[str, asyncio.Lock] = {}
+    _stage_locks_guard = asyncio.Lock()
+
+    async def _get_stage_lock(handle: str) -> asyncio.Lock:
+        async with _stage_locks_guard:
+            lock = _stage_locks.get(handle)
+            if lock is None:
+                lock = asyncio.Lock()
+                _stage_locks[handle] = lock
+            return lock
+
+    async def _release_stage_lock_if_idle(handle: str) -> None:
+        async with _stage_locks_guard:
+            lock = _stage_locks.get(handle)
+            if lock is not None and not lock.locked():
+                _stage_locks.pop(handle, None)
+
+    # P0.3: Track in-flight stage writes so the GC does not unlink a
+    # ``.partial`` mid-write for slow uploads. The set is keyed by handle.
+    _active_stage_handles: set[str] = set()
+
+    # P0.3 / GC tuning: ``.partial`` files belonging to inactive handles
+    # are reaped only when older than this longer threshold (5 × TTL),
+    # giving slow uploads room to complete even when in-flight tracking
+    # was reset by a process restart.
+    _UPLOAD_STAGE_PARTIAL_TTL_S = max(_UPLOAD_STAGE_TTL_S, _UPLOAD_STAGE_TTL_S * 5)
 
     @app.post("/mesh/browser/upload-stage")
     async def upload_stage(request: Request) -> dict:
@@ -3050,92 +3086,100 @@ def create_mesh_app(
         bin_path, meta_path = _stage_paths(handle)
         bin_partial = bin_path.with_suffix(".bin.partial")
 
-        sha = _hashlib.sha256()
-        size = 0
-        try:
-            with open(bin_partial, "wb") as fh:
-                async for chunk in request.stream():
-                    if not chunk:
-                        continue
-                    size += len(chunk)
-                    if size > max_bytes:
-                        fh.close()
+        lock = await _get_stage_lock(handle)
+        async with lock:
+            _active_stage_handles.add(handle)
+            try:
+                sha = _hashlib.sha256()
+                size = 0
+                try:
+                    with open(bin_partial, "wb") as fh:
+                        async for chunk in request.stream():
+                            if not chunk:
+                                continue
+                            size += len(chunk)
+                            if size > max_bytes:
+                                fh.close()
+                                with contextlib.suppress(OSError):
+                                    bin_partial.unlink()
+                                raise HTTPException(
+                                    413,
+                                    f"Upload exceeds {_UPLOAD_STAGE_MAX_MB}MB limit",
+                                )
+                            fh.write(chunk)
+                            sha.update(chunk)
+                except HTTPException:
+                    raise
+                except OSError as e:
+                    with contextlib.suppress(OSError):
+                        bin_partial.unlink()
+                    raise HTTPException(500, f"Stage write failed: {e}")
+
+                digest = sha.hexdigest()
+
+                if idem_key and meta_path.is_file() and bin_path.is_file():
+                    now = time.time()
+                    try:
+                        age = now - meta_path.stat().st_mtime
+                    except OSError:
+                        age = _UPLOAD_STAGE_TTL_S + 1
+                    existing_meta = _read_stage_meta(meta_path) if age <= _UPLOAD_STAGE_TTL_S else None
+                    if (
+                        existing_meta
+                        and existing_meta.get("caller_id") == caller_id
+                        and existing_meta.get("idempotency_key") == idem_key
+                        and existing_meta.get("sha256") == digest
+                        and existing_meta.get("status") != "consumed"
+                    ):
                         with contextlib.suppress(OSError):
                             bin_partial.unlink()
-                        raise HTTPException(
-                            413,
-                            f"Upload exceeds {_UPLOAD_STAGE_MAX_MB}MB limit",
-                        )
-                    fh.write(chunk)
-                    sha.update(chunk)
-        except HTTPException:
-            raise
-        except OSError as e:
-            with contextlib.suppress(OSError):
-                bin_partial.unlink()
-            raise HTTPException(500, f"Stage write failed: {e}")
+                        expires_at = (
+                            datetime.fromtimestamp(
+                                meta_path.stat().st_mtime, timezone.utc,
+                            )
+                            + timedelta(seconds=_UPLOAD_STAGE_TTL_S)
+                        ).isoformat()
+                        return {
+                            "staged_handle": handle,
+                            "size_bytes": int(existing_meta.get("size_bytes", 0)),
+                            "expires_at": expires_at,
+                        }
 
-        digest = sha.hexdigest()
+                try:
+                    _os.replace(bin_partial, bin_path)
+                except OSError as e:
+                    with contextlib.suppress(OSError):
+                        bin_partial.unlink()
+                    raise HTTPException(500, f"Stage finalize failed: {e}")
 
-        if idem_key and meta_path.is_file() and bin_path.is_file():
-            now = time.time()
-            try:
-                age = now - meta_path.stat().st_mtime
-            except OSError:
-                age = _UPLOAD_STAGE_TTL_S + 1
-            existing_meta = _read_stage_meta(meta_path) if age <= _UPLOAD_STAGE_TTL_S else None
-            if (
-                existing_meta
-                and existing_meta.get("caller_id") == caller_id
-                and existing_meta.get("idempotency_key") == idem_key
-                and existing_meta.get("sha256") == digest
-                and existing_meta.get("status") != "consumed"
-            ):
-                with contextlib.suppress(OSError):
-                    bin_partial.unlink()
-                expires_at = (
-                    datetime.fromtimestamp(
-                        meta_path.stat().st_mtime, timezone.utc,
-                    )
-                    + timedelta(seconds=_UPLOAD_STAGE_TTL_S)
-                ).isoformat()
+                created_at = datetime.now(timezone.utc)
+                expires_at_dt = created_at + timedelta(seconds=_UPLOAD_STAGE_TTL_S)
+                meta_payload = {
+                    "caller_id": caller_id,
+                    "idempotency_key": idem_key,
+                    "created_at": created_at.isoformat(),
+                    "expires_at": expires_at_dt.isoformat(),
+                    "size_bytes": size,
+                    "sha256": digest,
+                    "status": "staged",
+                    "consumed_at": None,
+                    "last_result": None,
+                }
+                try:
+                    _atomic_write_bytes(meta_path, json.dumps(meta_payload).encode())
+                except OSError as e:
+                    with contextlib.suppress(OSError):
+                        bin_path.unlink()
+                    raise HTTPException(500, f"Stage meta write failed: {e}")
+
                 return {
                     "staged_handle": handle,
-                    "size_bytes": int(existing_meta.get("size_bytes", 0)),
-                    "expires_at": expires_at,
+                    "size_bytes": size,
+                    "expires_at": expires_at_dt.isoformat(),
                 }
-
-        try:
-            _os.replace(bin_partial, bin_path)
-        except OSError as e:
-            with contextlib.suppress(OSError):
-                bin_partial.unlink()
-            raise HTTPException(500, f"Stage finalize failed: {e}")
-
-        created_at = datetime.now(timezone.utc)
-        expires_at_dt = created_at + timedelta(seconds=_UPLOAD_STAGE_TTL_S)
-        meta_payload = {
-            "caller_id": caller_id,
-            "idempotency_key": idem_key,
-            "created_at": created_at.isoformat(),
-            "expires_at": expires_at_dt.isoformat(),
-            "size_bytes": size,
-            "sha256": digest,
-            "status": "staged",
-            "consumed_at": None,
-        }
-        try:
-            _atomic_write_bytes(meta_path, json.dumps(meta_payload).encode())
-        except OSError as e:
-            with contextlib.suppress(OSError):
-                bin_path.unlink()
-            raise HTTPException(500, f"Stage meta write failed: {e}")
-
-        return {
-            "staged_handle": handle,
-            "size_bytes": size,
-            "expires_at": expires_at_dt.isoformat(),
-        }
+            finally:
+                _active_stage_handles.discard(handle)
+                await _release_stage_lock_if_idle(handle)
 
     @app.post("/mesh/browser/upload_file")
     async def upload_apply(request: Request) -> dict:
@@ -3146,8 +3190,16 @@ def create_mesh_app(
         handle to its mesh-side bytes, streams to
         ``/browser/{a}/_stage_upload``, then POSTs the resulting paths to
         ``/browser/{a}/upload_file``.
+
+        Idempotency: when ``idempotency_key`` is supplied, a successful
+        apply caches its result envelope on each handle's sidecar. A
+        subsequent apply with the same ``(caller, key, handles)`` set
+        within the stage TTL returns the cached envelope — the browser
+        is NOT driven a second time. Without this, retry-after-success
+        would 404 (handles consumed) and double-upload after re-stage.
         """
         caller_id = _extract_verified_agent_id(request)
+        await _check_rate_limit("upload_apply", caller_id)
         body = await request.json()
         req_agent_id = _resolve_browser_target(
             caller_id, body.get("target_agent_id") or "",
@@ -3156,11 +3208,12 @@ def create_mesh_app(
         if not permissions.can_browser_action(req_agent_id, "upload_file"):
             raise HTTPException(403, "Browser action 'upload_file' denied")
 
-        await _check_rate_limit("upload_apply", caller_id)
-
         ref = body.get("ref", "")
         staged_handles = body.get("staged_handles") or []
         suggested_filenames = body.get("suggested_filenames") or []
+        idempotency_key = body.get("idempotency_key")
+        if idempotency_key is not None and not isinstance(idempotency_key, str):
+            raise HTTPException(400, "idempotency_key must be a string")
         if not ref:
             raise HTTPException(400, "ref required")
         if (
@@ -3186,6 +3239,43 @@ def create_mesh_app(
                     "suggested_filenames length must match staged_handles",
                 )
 
+        # P0.1 — replay check. If the caller supplied an idempotency_key
+        # and EVERY referenced handle's sidecar is consumed, owned by the
+        # caller, tagged with the same key, within TTL, and carries a
+        # cached last_result — return the cached envelope. The browser
+        # is not driven again.
+        if idempotency_key:
+            cached_results: list[dict] = []
+            replay_eligible = True
+            now = time.time()
+            for handle in staged_handles:
+                _bin, meta_path = _stage_paths(handle)
+                if not meta_path.is_file():
+                    replay_eligible = False
+                    break
+                try:
+                    age = now - meta_path.stat().st_mtime
+                except OSError:
+                    replay_eligible = False
+                    break
+                if age > _UPLOAD_STAGE_TTL_S:
+                    replay_eligible = False
+                    break
+                meta = _read_stage_meta(meta_path) or {}
+                if (
+                    meta.get("caller_id") != caller_id
+                    or meta.get("status") != "consumed"
+                    or meta.get("idempotency_key") != idempotency_key
+                    or not isinstance(meta.get("last_result"), dict)
+                ):
+                    replay_eligible = False
+                    break
+                cached_results.append(meta["last_result"])
+            if replay_eligible and cached_results:
+                # All handles share the same apply call → all sidecars
+                # carry the same envelope. Return the first.
+                return cached_results[0]
+
         resolved: list[tuple[str, _Path, dict, str]] = []
         for i, handle in enumerate(staged_handles):
             bin_path, meta_path = _stage_paths(handle)
@@ -3194,6 +3284,11 @@ def create_mesh_app(
             meta = _read_stage_meta(meta_path) or {}
             if meta.get("caller_id") != caller_id:
                 raise HTTPException(403, "staged_handle does not belong to caller")
+            if meta.get("status") == "consumed":
+                # Handle was consumed by a prior apply but the replay
+                # check above did not match (key mismatch, missing key,
+                # or stale). Treat as unknown.
+                raise HTTPException(404, f"Unknown staged_handle: {handle}")
             suggested = (
                 suggested_filenames[i] if i < len(suggested_filenames) else ""
             )
@@ -3217,7 +3312,7 @@ def create_mesh_app(
             fh = open(path, "rb")
             try:
                 while True:
-                    chunk = fh.read(64 * 1024)
+                    chunk = await asyncio.to_thread(fh.read, 64 * 1024)
                     if not chunk:
                         break
                     yield chunk
@@ -3285,6 +3380,12 @@ def create_mesh_app(
                 meta_consumed = dict(meta)
                 meta_consumed["status"] = "consumed"
                 meta_consumed["consumed_at"] = now_iso
+                # P0.1 — only cache the result envelope when an
+                # idempotency_key was supplied. Without a key, replay
+                # protection is impossible so don't pretend we have it.
+                if idempotency_key:
+                    meta_consumed["idempotency_key"] = idempotency_key
+                    meta_consumed["last_result"] = result
                 try:
                     _atomic_write_bytes(_meta_path, json.dumps(meta_consumed).encode())
                 except OSError:
@@ -3298,9 +3399,11 @@ def create_mesh_app(
         Iterates by handle (drawn from sidecar metadata): when both ``.bin``
         and ``.json`` exist for a handle they are considered paired; the GC
         reaps the pair only when BOTH are older than TTL. Stray ``.partial``
-        files (interrupted writes) are reaped on TTL alone. Unpaired
-        bare ``.bin`` files are left alone — they may belong to an
-        in-progress write.
+        files use a longer TTL (``_UPLOAD_STAGE_PARTIAL_TTL_S``) and are
+        skipped while the corresponding handle is in ``_active_stage_handles``
+        (P0.3 — slow uploads must not have their partial unlinked
+        mid-write). Unpaired bare ``.bin`` files are left alone — they may
+        belong to an in-progress write.
         """
         if not _UPLOAD_STAGE_DIR.exists():
             return 0
@@ -3314,11 +3417,15 @@ def create_mesh_app(
         for child in entries:
             if not child.name.endswith(".partial"):
                 continue
+            # ``foo.bin.partial`` → handle is ``foo``.
+            handle = child.name[: -len(".bin.partial")] if child.name.endswith(".bin.partial") else child.stem
+            if handle in _active_stage_handles:
+                continue
             try:
                 age = now - child.stat().st_mtime
             except OSError:
                 continue
-            if age > _UPLOAD_STAGE_TTL_S:
+            if age > _UPLOAD_STAGE_PARTIAL_TTL_S:
                 try:
                     child.unlink()
                     reaped += 1
@@ -3371,7 +3478,9 @@ def create_mesh_app(
 
     app.state.upload_stage_dir = _UPLOAD_STAGE_DIR
     app.state.upload_stage_ttl_s = _UPLOAD_STAGE_TTL_S
+    app.state.upload_stage_partial_ttl_s = _UPLOAD_STAGE_PARTIAL_TTL_S
     app.state.upload_stage_gc_once = _upload_stage_gc_once
+    app.state.upload_stage_active_handles = _active_stage_handles
 
     @app.on_event("startup")
     async def _start_upload_stage_gc() -> None:

--- a/src/host/server.py
+++ b/src/host/server.py
@@ -182,6 +182,7 @@ def create_mesh_app(
         "image_gen": (10, 60),
         "agent_profile": (30, 60),
         "upload_stage": (30, 60),
+        "upload_apply": (30, 60),
     }
 
     async def _check_rate_limit(endpoint: str, agent_id: str) -> None:
@@ -3006,6 +3007,21 @@ def create_mesh_app(
         except (OSError, json.JSONDecodeError):
             return None
 
+    def _idem_handle(caller_id: str, idem_key: str) -> str:
+        digest = _hashlib.sha256(f"{caller_id}|{idem_key}".encode()).hexdigest()
+        return f"{caller_id}-idem{digest[:24]}"
+
+    def _atomic_write_bytes(path: _Path, data: bytes) -> None:
+        partial = path.with_suffix(path.suffix + ".partial")
+        try:
+            with open(partial, "wb") as fh:
+                fh.write(data)
+            _os.replace(partial, path)
+        except OSError:
+            with contextlib.suppress(OSError):
+                partial.unlink()
+            raise
+
     @app.post("/mesh/browser/upload-stage")
     async def upload_stage(request: Request) -> dict:
         """Phase A: stream raw bytes into the mesh staging dir.
@@ -3014,9 +3030,10 @@ def create_mesh_app(
         capped at ``_UPLOAD_STAGE_MAX_BYTES``; oversize requests return
         413 and clean up the partial file.
 
-        Idempotency: when ``Idempotency-Key`` is supplied AND a previous
-        sidecar from the same caller has matching key + sha256 + age <
-        TTL, the existing handle is returned without rewriting the file.
+        Idempotency: when ``Idempotency-Key`` is supplied the staged
+        handle is derived deterministically from ``sha256(caller_id|key)``
+        so a duplicate (caller, key, sha256) within TTL returns the same
+        handle without an O(N) directory scan.
         """
         caller_id = _extract_verified_agent_id(request)
         await _check_rate_limit("upload_stage", caller_id)
@@ -3025,13 +3042,18 @@ def create_mesh_app(
 
         idem_key = request.headers.get("idempotency-key", "") or None
         max_bytes = _UPLOAD_STAGE_MAX_BYTES
-        handle = f"{caller_id}-{_uuid.uuid4().hex[:24]}"
+
+        if idem_key:
+            handle = _idem_handle(caller_id, idem_key)
+        else:
+            handle = f"{caller_id}-{_uuid.uuid4().hex[:24]}"
         bin_path, meta_path = _stage_paths(handle)
+        bin_partial = bin_path.with_suffix(".bin.partial")
 
         sha = _hashlib.sha256()
         size = 0
         try:
-            with open(bin_path, "wb") as fh:
+            with open(bin_partial, "wb") as fh:
                 async for chunk in request.stream():
                     if not chunk:
                         continue
@@ -3039,7 +3061,7 @@ def create_mesh_app(
                     if size > max_bytes:
                         fh.close()
                         with contextlib.suppress(OSError):
-                            bin_path.unlink()
+                            bin_partial.unlink()
                         raise HTTPException(
                             413,
                             f"Upload exceeds {_UPLOAD_STAGE_MAX_MB}MB limit",
@@ -3050,68 +3072,69 @@ def create_mesh_app(
             raise
         except OSError as e:
             with contextlib.suppress(OSError):
-                bin_path.unlink()
+                bin_partial.unlink()
             raise HTTPException(500, f"Stage write failed: {e}")
 
         digest = sha.hexdigest()
 
-        if idem_key:
+        if idem_key and meta_path.is_file() and bin_path.is_file():
             now = time.time()
-            for existing_meta in _UPLOAD_STAGE_DIR.glob("*.json"):
-                if existing_meta == meta_path:
-                    continue
-                try:
-                    age = now - existing_meta.stat().st_mtime
-                except OSError:
-                    continue
-                if age > _UPLOAD_STAGE_TTL_S:
-                    continue
-                meta = _read_stage_meta(existing_meta)
-                if not meta:
-                    continue
-                if (
-                    meta.get("caller_id") == caller_id
-                    and meta.get("idempotency_key") == idem_key
-                    and meta.get("sha256") == digest
-                ):
-                    existing_handle = existing_meta.stem
-                    existing_bin = existing_meta.with_suffix(".bin")
-                    if existing_bin.is_file():
-                        with contextlib.suppress(OSError):
-                            bin_path.unlink()
-                        expires_at = (
-                            datetime.fromtimestamp(
-                                existing_meta.stat().st_mtime, timezone.utc,
-                            )
-                            + timedelta(seconds=_UPLOAD_STAGE_TTL_S)
-                        ).isoformat()
-                        return {
-                            "staged_handle": existing_handle,
-                            "size_bytes": int(meta.get("size_bytes", 0)),
-                            "expires_at": expires_at,
-                        }
+            try:
+                age = now - meta_path.stat().st_mtime
+            except OSError:
+                age = _UPLOAD_STAGE_TTL_S + 1
+            existing_meta = _read_stage_meta(meta_path) if age <= _UPLOAD_STAGE_TTL_S else None
+            if (
+                existing_meta
+                and existing_meta.get("caller_id") == caller_id
+                and existing_meta.get("idempotency_key") == idem_key
+                and existing_meta.get("sha256") == digest
+                and existing_meta.get("status") != "consumed"
+            ):
+                with contextlib.suppress(OSError):
+                    bin_partial.unlink()
+                expires_at = (
+                    datetime.fromtimestamp(
+                        meta_path.stat().st_mtime, timezone.utc,
+                    )
+                    + timedelta(seconds=_UPLOAD_STAGE_TTL_S)
+                ).isoformat()
+                return {
+                    "staged_handle": handle,
+                    "size_bytes": int(existing_meta.get("size_bytes", 0)),
+                    "expires_at": expires_at,
+                }
 
+        try:
+            _os.replace(bin_partial, bin_path)
+        except OSError as e:
+            with contextlib.suppress(OSError):
+                bin_partial.unlink()
+            raise HTTPException(500, f"Stage finalize failed: {e}")
+
+        created_at = datetime.now(timezone.utc)
+        expires_at_dt = created_at + timedelta(seconds=_UPLOAD_STAGE_TTL_S)
         meta_payload = {
             "caller_id": caller_id,
             "idempotency_key": idem_key,
-            "created_at": datetime.now(timezone.utc).isoformat(),
+            "created_at": created_at.isoformat(),
+            "expires_at": expires_at_dt.isoformat(),
             "size_bytes": size,
             "sha256": digest,
+            "status": "staged",
+            "consumed_at": None,
         }
         try:
-            meta_path.write_text(json.dumps(meta_payload))
+            _atomic_write_bytes(meta_path, json.dumps(meta_payload).encode())
         except OSError as e:
             with contextlib.suppress(OSError):
                 bin_path.unlink()
             raise HTTPException(500, f"Stage meta write failed: {e}")
 
-        expires_at = (
-            datetime.now(timezone.utc) + timedelta(seconds=_UPLOAD_STAGE_TTL_S)
-        ).isoformat()
         return {
             "staged_handle": handle,
             "size_bytes": size,
-            "expires_at": expires_at,
+            "expires_at": expires_at_dt.isoformat(),
         }
 
     @app.post("/mesh/browser/upload_file")
@@ -3119,9 +3142,10 @@ def create_mesh_app(
         """Phase B: forward staged bytes into the browser, drive upload_file.
 
         Body: ``{target_agent_id?, ref, staged_handles: [str],
-        idempotency_key?}``. Resolves each handle to its mesh-side bytes,
-        streams to ``/browser/{a}/_stage_upload``, then POSTs the
-        resulting paths to ``/browser/{a}/upload_file``.
+        suggested_filenames?: [str], idempotency_key?}``. Resolves each
+        handle to its mesh-side bytes, streams to
+        ``/browser/{a}/_stage_upload``, then POSTs the resulting paths to
+        ``/browser/{a}/upload_file``.
         """
         caller_id = _extract_verified_agent_id(request)
         body = await request.json()
@@ -3129,8 +3153,14 @@ def create_mesh_app(
             caller_id, body.get("target_agent_id") or "",
         )
 
+        if not permissions.can_browser_action(req_agent_id, "upload_file"):
+            raise HTTPException(403, "Browser action 'upload_file' denied")
+
+        await _check_rate_limit("upload_apply", caller_id)
+
         ref = body.get("ref", "")
         staged_handles = body.get("staged_handles") or []
+        suggested_filenames = body.get("suggested_filenames") or []
         if not ref:
             raise HTTPException(400, "ref required")
         if (
@@ -3142,19 +3172,32 @@ def create_mesh_app(
             raise HTTPException(400, "staged_handles must not be empty")
         if len(staged_handles) > 5:
             raise HTTPException(400, "at most 5 files per upload")
+        if suggested_filenames:
+            if (
+                not isinstance(suggested_filenames, list)
+                or not all(isinstance(n, str) for n in suggested_filenames)
+            ):
+                raise HTTPException(
+                    400, "suggested_filenames must be a list of strings",
+                )
+            if len(suggested_filenames) != len(staged_handles):
+                raise HTTPException(
+                    400,
+                    "suggested_filenames length must match staged_handles",
+                )
 
-        if not permissions.can_browser_action(req_agent_id, "upload_file"):
-            raise HTTPException(403, "Browser action 'upload_file' denied")
-
-        resolved: list[tuple[str, _Path, dict]] = []
-        for handle in staged_handles:
+        resolved: list[tuple[str, _Path, dict, str]] = []
+        for i, handle in enumerate(staged_handles):
             bin_path, meta_path = _stage_paths(handle)
             if not bin_path.is_file() or not meta_path.is_file():
                 raise HTTPException(404, f"Unknown staged_handle: {handle}")
             meta = _read_stage_meta(meta_path) or {}
             if meta.get("caller_id") != caller_id:
                 raise HTTPException(403, "staged_handle does not belong to caller")
-            resolved.append((handle, bin_path, meta))
+            suggested = (
+                suggested_filenames[i] if i < len(suggested_filenames) else ""
+            )
+            resolved.append((handle, bin_path, meta, suggested))
 
         browser_service_url = None
         if container_manager:
@@ -3171,23 +3214,29 @@ def create_mesh_app(
             ingest_headers["X-Trace-Id"] = incoming_trace
 
         async def _stream_file(path: _Path):
-            with open(path, "rb") as fh:
+            fh = open(path, "rb")
+            try:
                 while True:
                     chunk = fh.read(64 * 1024)
                     if not chunk:
                         break
                     yield chunk
+            finally:
+                fh.close()
 
         browser_paths: list[str] = []
         try:
-            for handle, bin_path, _meta in resolved:
+            for handle, bin_path, _meta, suggested in resolved:
+                ingest_filename = suggested or handle
                 try:
                     resp = await _browser_proxy_client.post(
                         f"{browser_service_url}/browser/{req_agent_id}/_stage_upload",
-                        params={"suggested_filename": handle},
+                        params={"suggested_filename": ingest_filename},
                         content=_stream_file(bin_path),
                         headers=ingest_headers,
                     )
+                except _httpx.TimeoutException as e:
+                    raise HTTPException(503, f"Browser service timeout: {e}")
                 except _httpx.ConnectError as e:
                     raise HTTPException(503, f"Browser service unreachable: {e}")
                 if resp.status_code >= 400:
@@ -3219,6 +3268,8 @@ def create_mesh_app(
             )
             resp.raise_for_status()
             result = resp.json()
+        except _httpx.TimeoutException as e:
+            raise HTTPException(503, f"Browser service timeout: {e}")
         except _httpx.HTTPStatusError as e:
             raise HTTPException(e.response.status_code, e.response.text)
         except Exception as e:
@@ -3226,29 +3277,86 @@ def create_mesh_app(
             raise HTTPException(502, f"Browser service error: {e}")
 
         if result.get("success"):
-            for handle, _bin_path, _meta in resolved:
+            now_iso = datetime.now(timezone.utc).isoformat()
+            for handle, _bin_path, meta, _suggested in resolved:
                 _bin, _meta_path = _stage_paths(handle)
                 with contextlib.suppress(OSError):
                     _bin.unlink()
-                with contextlib.suppress(OSError):
-                    _meta_path.unlink()
+                meta_consumed = dict(meta)
+                meta_consumed["status"] = "consumed"
+                meta_consumed["consumed_at"] = now_iso
+                try:
+                    _atomic_write_bytes(_meta_path, json.dumps(meta_consumed).encode())
+                except OSError:
+                    with contextlib.suppress(OSError):
+                        _meta_path.unlink()
         return result
 
     async def _upload_stage_gc_once() -> int:
-        """Reap orphan stage files older than TTL. Returns reaped count."""
+        """Reap orphan stage files older than TTL. Returns reaped count.
+
+        Iterates by handle (drawn from sidecar metadata): when both ``.bin``
+        and ``.json`` exist for a handle they are considered paired; the GC
+        reaps the pair only when BOTH are older than TTL. Stray ``.partial``
+        files (interrupted writes) are reaped on TTL alone. Unpaired
+        bare ``.bin`` files are left alone — they may belong to an
+        in-progress write.
+        """
         if not _UPLOAD_STAGE_DIR.exists():
             return 0
         now = time.time()
         reaped = 0
-        for child in list(_UPLOAD_STAGE_DIR.iterdir()):
+        try:
+            entries = list(_UPLOAD_STAGE_DIR.iterdir())
+        except OSError:
+            return 0
+
+        for child in entries:
+            if not child.name.endswith(".partial"):
+                continue
             try:
                 age = now - child.stat().st_mtime
             except OSError:
                 continue
             if age > _UPLOAD_STAGE_TTL_S:
-                with contextlib.suppress(OSError):
+                try:
                     child.unlink()
                     reaped += 1
+                except OSError:
+                    continue
+
+        for child in entries:
+            if child.suffix != ".json":
+                continue
+            handle = child.stem
+            bin_path, meta_path = _stage_paths(handle)
+            try:
+                meta_age = now - meta_path.stat().st_mtime
+            except OSError:
+                meta_age = _UPLOAD_STAGE_TTL_S + 1
+            if bin_path.is_file():
+                try:
+                    bin_age = now - bin_path.stat().st_mtime
+                except OSError:
+                    bin_age = _UPLOAD_STAGE_TTL_S + 1
+                if meta_age > _UPLOAD_STAGE_TTL_S and bin_age > _UPLOAD_STAGE_TTL_S:
+                    try:
+                        bin_path.unlink()
+                        reaped += 1
+                    except OSError:
+                        pass
+                    try:
+                        meta_path.unlink()
+                        reaped += 1
+                    except OSError:
+                        pass
+            else:
+                if meta_age > _UPLOAD_STAGE_TTL_S:
+                    try:
+                        meta_path.unlink()
+                        reaped += 1
+                    except OSError:
+                        pass
         return reaped
 
     async def _upload_stage_gc_loop() -> None:

--- a/src/host/server.py
+++ b/src/host/server.py
@@ -3329,6 +3329,7 @@ def create_mesh_app(
                         params={"suggested_filename": ingest_filename},
                         content=_stream_file(bin_path),
                         headers=ingest_headers,
+                        timeout=180,
                     )
                 except _httpx.TimeoutException as e:
                     raise HTTPException(503, f"Browser service timeout: {e}")

--- a/src/host/server.py
+++ b/src/host/server.py
@@ -181,6 +181,7 @@ def create_mesh_app(
         "wallet_execute": (10, 3600),
         "image_gen": (10, 60),
         "agent_profile": (30, 60),
+        "upload_stage": (30, 60),
     }
 
     async def _check_rate_limit(endpoint: str, agent_id: str) -> None:
@@ -2948,6 +2949,325 @@ def create_mesh_app(
         except Exception as e:
             logger.warning("Browser proxy error: %s", e)
             raise HTTPException(502, f"Browser service error: {e}")
+
+    # ── §4.5 / §8.1 file-upload staging ──────────────────────────────────
+    #
+    # Two-phase mesh-mediated upload:
+    #   A) /mesh/browser/upload-stage stores raw bytes from the agent into
+    #      a tmpfs-backed staging dir keyed by an opaque handle.
+    #   B) /mesh/browser/upload_file resolves staged_handles → bytes,
+    #      streams them into the browser container's receive dir, then
+    #      drives /browser/{agent}/upload_file with the resulting paths.
+    #
+    # Stage files older than _UPLOAD_STAGE_TTL_S are reaped by a periodic
+    # garbage-collection loop scheduled at startup.
+
+    import hashlib as _hashlib
+    import os as _os
+    from pathlib import Path as _Path
+
+    _UPLOAD_STAGE_DIR = _Path(
+        _os.environ.get(
+            "OPENLEGION_UPLOAD_STAGE_DIR",
+            "/tmp/openlegion-upload-stage",
+        ),
+    )
+    try:
+        _UPLOAD_STAGE_DIR.mkdir(parents=True, exist_ok=True)
+    except OSError as _e:
+        logger.warning(
+            "Could not create upload-stage dir %s: %s", _UPLOAD_STAGE_DIR, _e,
+        )
+
+    try:
+        _UPLOAD_STAGE_TTL_S = max(
+            5, int(_os.environ.get("OPENLEGION_UPLOAD_STAGE_TTL_S", "60")),
+        )
+    except ValueError:
+        _UPLOAD_STAGE_TTL_S = 60
+
+    try:
+        _UPLOAD_STAGE_MAX_MB = max(
+            1, int(_os.environ.get("OPENLEGION_UPLOAD_STAGE_MAX_MB", "50")),
+        )
+    except ValueError:
+        _UPLOAD_STAGE_MAX_MB = 50
+    _UPLOAD_STAGE_MAX_BYTES = _UPLOAD_STAGE_MAX_MB * 1024 * 1024
+
+    def _stage_paths(handle: str) -> tuple[_Path, _Path]:
+        return (
+            _UPLOAD_STAGE_DIR / f"{handle}.bin",
+            _UPLOAD_STAGE_DIR / f"{handle}.json",
+        )
+
+    def _read_stage_meta(meta_path: _Path) -> dict | None:
+        try:
+            return json.loads(meta_path.read_text())
+        except (OSError, json.JSONDecodeError):
+            return None
+
+    @app.post("/mesh/browser/upload-stage")
+    async def upload_stage(request: Request) -> dict:
+        """Phase A: stream raw bytes into the mesh staging dir.
+
+        Returns ``{staged_handle, size_bytes, expires_at}``. Bytes are
+        capped at ``_UPLOAD_STAGE_MAX_BYTES``; oversize requests return
+        413 and clean up the partial file.
+
+        Idempotency: when ``Idempotency-Key`` is supplied AND a previous
+        sidecar from the same caller has matching key + sha256 + age <
+        TTL, the existing handle is returned without rewriting the file.
+        """
+        caller_id = _extract_verified_agent_id(request)
+        await _check_rate_limit("upload_stage", caller_id)
+        if not permissions.can_browser_action(caller_id, "upload_file"):
+            raise HTTPException(403, "Browser action 'upload_file' denied")
+
+        idem_key = request.headers.get("idempotency-key", "") or None
+        max_bytes = _UPLOAD_STAGE_MAX_BYTES
+        handle = f"{caller_id}-{_uuid.uuid4().hex[:24]}"
+        bin_path, meta_path = _stage_paths(handle)
+
+        sha = _hashlib.sha256()
+        size = 0
+        try:
+            with open(bin_path, "wb") as fh:
+                async for chunk in request.stream():
+                    if not chunk:
+                        continue
+                    size += len(chunk)
+                    if size > max_bytes:
+                        fh.close()
+                        with contextlib.suppress(OSError):
+                            bin_path.unlink()
+                        raise HTTPException(
+                            413,
+                            f"Upload exceeds {_UPLOAD_STAGE_MAX_MB}MB limit",
+                        )
+                    fh.write(chunk)
+                    sha.update(chunk)
+        except HTTPException:
+            raise
+        except OSError as e:
+            with contextlib.suppress(OSError):
+                bin_path.unlink()
+            raise HTTPException(500, f"Stage write failed: {e}")
+
+        digest = sha.hexdigest()
+
+        if idem_key:
+            now = time.time()
+            for existing_meta in _UPLOAD_STAGE_DIR.glob("*.json"):
+                if existing_meta == meta_path:
+                    continue
+                try:
+                    age = now - existing_meta.stat().st_mtime
+                except OSError:
+                    continue
+                if age > _UPLOAD_STAGE_TTL_S:
+                    continue
+                meta = _read_stage_meta(existing_meta)
+                if not meta:
+                    continue
+                if (
+                    meta.get("caller_id") == caller_id
+                    and meta.get("idempotency_key") == idem_key
+                    and meta.get("sha256") == digest
+                ):
+                    existing_handle = existing_meta.stem
+                    existing_bin = existing_meta.with_suffix(".bin")
+                    if existing_bin.is_file():
+                        with contextlib.suppress(OSError):
+                            bin_path.unlink()
+                        expires_at = (
+                            datetime.fromtimestamp(
+                                existing_meta.stat().st_mtime, timezone.utc,
+                            )
+                            + timedelta(seconds=_UPLOAD_STAGE_TTL_S)
+                        ).isoformat()
+                        return {
+                            "staged_handle": existing_handle,
+                            "size_bytes": int(meta.get("size_bytes", 0)),
+                            "expires_at": expires_at,
+                        }
+
+        meta_payload = {
+            "caller_id": caller_id,
+            "idempotency_key": idem_key,
+            "created_at": datetime.now(timezone.utc).isoformat(),
+            "size_bytes": size,
+            "sha256": digest,
+        }
+        try:
+            meta_path.write_text(json.dumps(meta_payload))
+        except OSError as e:
+            with contextlib.suppress(OSError):
+                bin_path.unlink()
+            raise HTTPException(500, f"Stage meta write failed: {e}")
+
+        expires_at = (
+            datetime.now(timezone.utc) + timedelta(seconds=_UPLOAD_STAGE_TTL_S)
+        ).isoformat()
+        return {
+            "staged_handle": handle,
+            "size_bytes": size,
+            "expires_at": expires_at,
+        }
+
+    @app.post("/mesh/browser/upload_file")
+    async def upload_apply(request: Request) -> dict:
+        """Phase B: forward staged bytes into the browser, drive upload_file.
+
+        Body: ``{target_agent_id?, ref, staged_handles: [str],
+        idempotency_key?}``. Resolves each handle to its mesh-side bytes,
+        streams to ``/browser/{a}/_stage_upload``, then POSTs the
+        resulting paths to ``/browser/{a}/upload_file``.
+        """
+        caller_id = _extract_verified_agent_id(request)
+        body = await request.json()
+        req_agent_id = _resolve_browser_target(
+            caller_id, body.get("target_agent_id") or "",
+        )
+
+        ref = body.get("ref", "")
+        staged_handles = body.get("staged_handles") or []
+        if not ref:
+            raise HTTPException(400, "ref required")
+        if (
+            not isinstance(staged_handles, list)
+            or not all(isinstance(h, str) and h for h in staged_handles)
+        ):
+            raise HTTPException(400, "staged_handles must be a non-empty list of strings")
+        if not staged_handles:
+            raise HTTPException(400, "staged_handles must not be empty")
+        if len(staged_handles) > 5:
+            raise HTTPException(400, "at most 5 files per upload")
+
+        if not permissions.can_browser_action(req_agent_id, "upload_file"):
+            raise HTTPException(403, "Browser action 'upload_file' denied")
+
+        resolved: list[tuple[str, _Path, dict]] = []
+        for handle in staged_handles:
+            bin_path, meta_path = _stage_paths(handle)
+            if not bin_path.is_file() or not meta_path.is_file():
+                raise HTTPException(404, f"Unknown staged_handle: {handle}")
+            meta = _read_stage_meta(meta_path) or {}
+            if meta.get("caller_id") != caller_id:
+                raise HTTPException(403, "staged_handle does not belong to caller")
+            resolved.append((handle, bin_path, meta))
+
+        browser_service_url = None
+        if container_manager:
+            browser_service_url = getattr(container_manager, "browser_service_url", None)
+        if not browser_service_url:
+            raise HTTPException(503, "Browser service not available")
+
+        browser_auth = getattr(container_manager, "browser_auth_token", "")
+        ingest_headers: dict = {"X-Mesh-Internal": "1"}
+        if browser_auth:
+            ingest_headers["Authorization"] = f"Bearer {browser_auth}"
+        incoming_trace = request.headers.get("x-trace-id")
+        if incoming_trace:
+            ingest_headers["X-Trace-Id"] = incoming_trace
+
+        async def _stream_file(path: _Path):
+            with open(path, "rb") as fh:
+                while True:
+                    chunk = fh.read(64 * 1024)
+                    if not chunk:
+                        break
+                    yield chunk
+
+        browser_paths: list[str] = []
+        try:
+            for handle, bin_path, _meta in resolved:
+                try:
+                    resp = await _browser_proxy_client.post(
+                        f"{browser_service_url}/browser/{req_agent_id}/_stage_upload",
+                        params={"suggested_filename": handle},
+                        content=_stream_file(bin_path),
+                        headers=ingest_headers,
+                    )
+                except _httpx.ConnectError as e:
+                    raise HTTPException(503, f"Browser service unreachable: {e}")
+                if resp.status_code >= 400:
+                    raise HTTPException(
+                        resp.status_code,
+                        f"Browser stage ingest failed: {resp.text}",
+                    )
+                ingest = resp.json()
+                ingested_path = ingest.get("path")
+                if not ingested_path:
+                    raise HTTPException(502, "Browser stage ingest returned no path")
+                browser_paths.append(ingested_path)
+        except HTTPException:
+            raise
+        except Exception as e:
+            logger.warning("Upload ingest stream error: %s", e)
+            raise HTTPException(502, f"Browser ingest error: {e}")
+
+        upload_headers: dict = {}
+        if browser_auth:
+            upload_headers["Authorization"] = f"Bearer {browser_auth}"
+        if incoming_trace:
+            upload_headers["X-Trace-Id"] = incoming_trace
+        try:
+            resp = await _browser_proxy_client.post(
+                f"{browser_service_url}/browser/{req_agent_id}/upload_file",
+                json={"ref": ref, "paths": browser_paths},
+                headers=upload_headers,
+            )
+            resp.raise_for_status()
+            result = resp.json()
+        except _httpx.HTTPStatusError as e:
+            raise HTTPException(e.response.status_code, e.response.text)
+        except Exception as e:
+            logger.warning("Browser upload_file proxy error: %s", e)
+            raise HTTPException(502, f"Browser service error: {e}")
+
+        if result.get("success"):
+            for handle, _bin_path, _meta in resolved:
+                _bin, _meta_path = _stage_paths(handle)
+                with contextlib.suppress(OSError):
+                    _bin.unlink()
+                with contextlib.suppress(OSError):
+                    _meta_path.unlink()
+        return result
+
+    async def _upload_stage_gc_once() -> int:
+        """Reap orphan stage files older than TTL. Returns reaped count."""
+        if not _UPLOAD_STAGE_DIR.exists():
+            return 0
+        now = time.time()
+        reaped = 0
+        for child in list(_UPLOAD_STAGE_DIR.iterdir()):
+            try:
+                age = now - child.stat().st_mtime
+            except OSError:
+                continue
+            if age > _UPLOAD_STAGE_TTL_S:
+                with contextlib.suppress(OSError):
+                    child.unlink()
+                    reaped += 1
+        return reaped
+
+    async def _upload_stage_gc_loop() -> None:
+        while True:
+            try:
+                await _upload_stage_gc_once()
+            except asyncio.CancelledError:
+                raise
+            except Exception as e:
+                logger.debug("upload_stage gc tick failed: %s", e)
+            await asyncio.sleep(max(1, _UPLOAD_STAGE_TTL_S // 2))
+
+    app.state.upload_stage_dir = _UPLOAD_STAGE_DIR
+    app.state.upload_stage_ttl_s = _UPLOAD_STAGE_TTL_S
+    app.state.upload_stage_gc_once = _upload_stage_gc_once
+
+    @app.on_event("startup")
+    async def _start_upload_stage_gc() -> None:
+        asyncio.create_task(_upload_stage_gc_loop())
 
     # === Event Bus ===
 

--- a/tests/test_browser_file_transfer.py
+++ b/tests/test_browser_file_transfer.py
@@ -151,6 +151,77 @@ class TestUploadFile:
         assert result["success"] is False
         assert "control" in result["error"].lower()
 
+    @pytest.mark.asyncio
+    async def test_browser_side_orphan_cleanup_on_chooser_timeout(
+        self, tmp_path, monkeypatch,
+    ):
+        """Even when the chooser flow throws, the staged files are deleted."""
+        mgr = BrowserManager(profiles_dir=str(tmp_path / "p"))
+        inst = _make_instance()
+
+        class _BadCM:
+            async def __aenter__(self_):
+                raise asyncio.TimeoutError("chooser never appeared")
+
+            async def __aexit__(self_, *exc):
+                return False
+
+        inst.page.expect_file_chooser = MagicMock(return_value=_BadCM())
+
+        fake_locator = MagicMock()
+        fake_locator.click = AsyncMock()
+        monkeypatch.setattr(mgr, "_locator_from_ref", lambda _i, _r: fake_locator)
+        monkeypatch.setattr(mgr, "get_or_start", AsyncMock(return_value=inst))
+
+        a = tmp_path / "a.txt"
+        a.write_text("a")
+        result = await mgr.upload_file("a1", "e1", [str(a)])
+        assert result["success"] is False
+        assert not a.exists()
+
+    @pytest.mark.asyncio
+    async def test_browser_side_orphan_cleanup_on_user_control(
+        self, tmp_path, monkeypatch,
+    ):
+        """User-control branch returns early — files must still be cleaned."""
+        mgr = BrowserManager(profiles_dir=str(tmp_path / "p"))
+        inst = _make_instance()
+        inst._user_control = True
+        monkeypatch.setattr(mgr, "get_or_start", AsyncMock(return_value=inst))
+
+        a = tmp_path / "stage1.txt"
+        a.write_text("x")
+        result = await mgr.upload_file("a1", "e1", [str(a)])
+        assert result["success"] is False
+        assert not a.exists()
+
+
+class TestBrowserSidePeriodicGc:
+    @pytest.mark.asyncio
+    async def test_gc_reaps_files_older_than_ttl(self, tmp_path, monkeypatch):
+        """Browser-side recv-dir GC removes files older than the stage TTL."""
+        import os
+        import time
+
+        recv = tmp_path / "recv"
+        recv.mkdir()
+        monkeypatch.setenv("OPENLEGION_UPLOAD_RECV_DIR", str(recv))
+        monkeypatch.setenv("OPENLEGION_UPLOAD_STAGE_TTL_S", "5")
+
+        old = recv / "old.bin"
+        old.write_bytes(b"x")
+        new = recv / "new.bin"
+        new.write_bytes(b"y")
+
+        old_t = time.time() - 60
+        os.utime(old, (old_t, old_t))
+
+        mgr = BrowserManager(profiles_dir=str(tmp_path / "p"))
+        reaped = await mgr._upload_recv_gc_once()
+        assert reaped == 1
+        assert not old.exists()
+        assert new.exists()
+
 
 class TestDownload:
     @pytest.mark.asyncio
@@ -323,6 +394,43 @@ class TestUploadStageIngest:
         path = Path(resp.json()["path"])
         assert path.parent == recv
         assert ".." not in path.name
+
+    def test_ingest_filename_includes_original_basename(self, tmp_path, monkeypatch):
+        """When mesh forwards a real filename, the on-disk path ends with it
+        so Playwright reports the correct name to the form site."""
+        client, _mgr, _recv = self._make_client(tmp_path, monkeypatch)
+        resp = client.post(
+            "/browser/a1/_stage_upload",
+            content=b"data",
+            headers={"X-Mesh-Internal": "1"},
+            params={"suggested_filename": "resume.pdf"},
+        )
+        assert resp.status_code == 200, resp.text
+        assert resp.json()["path"].endswith("-resume.pdf")
+
+    def test_auth_insecure_requires_bearer_for_internal_endpoint(
+        self, tmp_path, monkeypatch,
+    ):
+        """BROWSER_AUTH_INSECURE=1 must NOT bypass auth for the internal
+        byte-ingest endpoint; missing bearer → 403 even in dev mode."""
+        from src.browser.server import create_browser_app
+
+        recv = tmp_path / "recv"
+        monkeypatch.setenv("OPENLEGION_UPLOAD_RECV_DIR", str(recv))
+        monkeypatch.delenv("BROWSER_AUTH_TOKEN", raising=False)
+        monkeypatch.delenv("MESH_AUTH_TOKEN", raising=False)
+        monkeypatch.setenv("BROWSER_AUTH_INSECURE", "1")
+        mgr = BrowserManager(profiles_dir=str(tmp_path / "p"))
+        app = create_browser_app(mgr)
+        from starlette.testclient import TestClient
+        client = TestClient(app)
+
+        resp = client.post(
+            "/browser/a1/_stage_upload",
+            content=b"x",
+            headers={"X-Mesh-Internal": "1"},
+        )
+        assert resp.status_code == 403, resp.text
 
 
 class TestUploadFileStageCleanup:

--- a/tests/test_browser_file_transfer.py
+++ b/tests/test_browser_file_transfer.py
@@ -240,3 +240,123 @@ class TestDownload:
         result = await mgr.download("a1", "e1", download_dir=str(tmp_path / "dl"))
         assert result["success"] is False
         assert "control" in result["error"].lower()
+
+
+class TestUploadStageIngest:
+    """`/browser/{a}/_stage_upload` mesh-internal byte ingest endpoint."""
+
+    def _make_client(self, tmp_path, monkeypatch):
+        from src.browser.server import create_browser_app
+        recv = tmp_path / "recv"
+        monkeypatch.setenv("OPENLEGION_UPLOAD_RECV_DIR", str(recv))
+        monkeypatch.delenv("BROWSER_AUTH_TOKEN", raising=False)
+        monkeypatch.delenv("MESH_AUTH_TOKEN", raising=False)
+        mgr = BrowserManager(profiles_dir=str(tmp_path / "p"))
+        app = create_browser_app(mgr)
+        from starlette.testclient import TestClient
+        return TestClient(app), mgr, recv
+
+    def test_ingest_writes_file_and_returns_path(self, tmp_path, monkeypatch):
+        client, _mgr, recv = self._make_client(tmp_path, monkeypatch)
+        resp = client.post(
+            "/browser/a1/_stage_upload",
+            content=b"hello bytes",
+            headers={"X-Mesh-Internal": "1"},
+        )
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        assert body["size_bytes"] == len(b"hello bytes")
+        assert Path(body["path"]).is_file()
+        assert Path(body["path"]).parent == recv
+        assert Path(body["path"]).read_bytes() == b"hello bytes"
+
+    def test_ingest_rejects_without_mesh_internal_header(self, tmp_path, monkeypatch):
+        client, _mgr, _recv = self._make_client(tmp_path, monkeypatch)
+        resp = client.post("/browser/a1/_stage_upload", content=b"hi")
+        assert resp.status_code == 403
+
+    def test_ingest_413_when_oversize(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("OPENLEGION_UPLOAD_STAGE_MAX_MB", "1")
+        client, _mgr, recv = self._make_client(tmp_path, monkeypatch)
+        too_big = b"X" * (2 * 1024 * 1024)
+        resp = client.post(
+            "/browser/a1/_stage_upload",
+            content=too_big,
+            headers={"X-Mesh-Internal": "1"},
+        )
+        assert resp.status_code == 413, resp.text
+        assert not any(p.is_file() for p in recv.iterdir())
+
+    def test_ingest_path_consumed_by_upload_file(self, tmp_path, monkeypatch):
+        client, mgr, _recv = self._make_client(tmp_path, monkeypatch)
+        resp = client.post(
+            "/browser/a1/_stage_upload",
+            content=b"resume.pdf bytes",
+            headers={"X-Mesh-Internal": "1"},
+            params={"suggested_filename": "resume.pdf"},
+        )
+        ingested_path = resp.json()["path"]
+        assert Path(ingested_path).is_file()
+        assert "resume.pdf" in ingested_path
+
+        async def _fake_upload(agent_id, ref, paths):
+            assert paths == [ingested_path]
+            return {"success": True, "data": {"uploaded": paths}}
+
+        mgr.upload_file = _fake_upload
+        upload_resp = client.post(
+            "/browser/a1/upload_file",
+            json={"ref": "e1", "paths": [ingested_path]},
+        )
+        assert upload_resp.status_code == 200
+        assert upload_resp.json()["success"] is True
+
+    def test_ingest_sanitizes_suggested_filename(self, tmp_path, monkeypatch):
+        client, _mgr, recv = self._make_client(tmp_path, monkeypatch)
+        resp = client.post(
+            "/browser/a1/_stage_upload",
+            content=b"x",
+            headers={"X-Mesh-Internal": "1"},
+            params={"suggested_filename": "../../etc/passwd"},
+        )
+        assert resp.status_code == 200, resp.text
+        path = Path(resp.json()["path"])
+        assert path.parent == recv
+        assert ".." not in path.name
+
+
+class TestUploadFileStageCleanup:
+    """After `set_files` succeeds the manager removes the staged paths."""
+
+    @pytest.mark.asyncio
+    async def test_stage_files_unlinked_after_success(self, tmp_path, monkeypatch):
+        mgr = BrowserManager(profiles_dir=str(tmp_path / "p"))
+        inst = _make_instance()
+        chooser = MagicMock()
+        chooser.set_files = AsyncMock()
+
+        async def _chooser_value():
+            return chooser
+
+        inst.page.expect_file_chooser = MagicMock(
+            return_value=_async_ctx(_chooser_value()),
+        )
+
+        fake_locator = MagicMock()
+        fake_locator.click = AsyncMock()
+        monkeypatch.setattr(
+            mgr, "_locator_from_ref", lambda _i, _r: fake_locator,
+        )
+        monkeypatch.setattr(mgr, "get_or_start", AsyncMock(return_value=inst))
+        monkeypatch.setattr(
+            "src.browser.service.action_delay", lambda: 0,
+        )
+
+        a = tmp_path / "a.txt"
+        b = tmp_path / "b.txt"
+        a.write_text("a")
+        b.write_text("b")
+        result = await mgr.upload_file("a1", "e1", [str(a), str(b)])
+        assert result["success"] is True
+        assert not a.exists()
+        assert not b.exists()

--- a/tests/test_browser_file_transfer.py
+++ b/tests/test_browser_file_transfer.py
@@ -515,3 +515,25 @@ class TestUploadFileStageCleanup:
         assert result["success"] is True
         assert not a.exists()
         assert not b.exists()
+
+
+class TestUploadRecvGcTaskLifecycle:
+    """§8.1 cross-PR fix — ensure the upload-recv GC task is created by
+    ``start_cleanup_loop`` AND cancelled when ``stop_all`` runs. Without
+    explicit cancellation the task leaks across manager restarts and keeps
+    polling a possibly-deleted recv dir.
+    """
+
+    @pytest.mark.asyncio
+    async def test_upload_recv_gc_task_cancelled_on_stop(self, tmp_path):
+        mgr = BrowserManager(profiles_dir=str(tmp_path / "p"))
+        # Pre: not started yet
+        assert mgr._upload_recv_gc_task is None
+        await mgr.start_cleanup_loop()
+        try:
+            assert mgr._upload_recv_gc_task is not None
+            assert not mgr._upload_recv_gc_task.done()
+        finally:
+            await mgr.stop_all()
+        # Post: stop_all() must clear the handle and cancel the task.
+        assert mgr._upload_recv_gc_task is None

--- a/tests/test_browser_file_transfer.py
+++ b/tests/test_browser_file_transfer.py
@@ -408,6 +408,22 @@ class TestUploadStageIngest:
         assert resp.status_code == 200, resp.text
         assert resp.json()["path"].endswith("-resume.pdf")
 
+    def test_long_filename_preserves_extension(self, tmp_path, monkeypatch):
+        """P0.4: truncation must not drop the extension. A 200-char
+        ``.pdf`` filename ends up stored as ``...<truncated>.pdf`` so
+        Playwright reports the right type to the form site."""
+        client, _mgr, _recv = self._make_client(tmp_path, monkeypatch)
+        long_stem = "scan_2026_04_25_invoice_" + ("x" * 200)
+        long_name = f"{long_stem}.pdf"
+        resp = client.post(
+            "/browser/a1/_stage_upload",
+            content=b"data",
+            headers={"X-Mesh-Internal": "1"},
+            params={"suggested_filename": long_name},
+        )
+        assert resp.status_code == 200, resp.text
+        assert resp.json()["path"].endswith(".pdf")
+
     def test_auth_insecure_requires_bearer_for_internal_endpoint(
         self, tmp_path, monkeypatch,
     ):
@@ -431,6 +447,37 @@ class TestUploadStageIngest:
             headers={"X-Mesh-Internal": "1"},
         )
         assert resp.status_code == 403, resp.text
+
+    def test_startup_raises_when_mesh_token_set_but_browser_token_missing(
+        self, tmp_path, monkeypatch,
+    ):
+        """P1.5: production posture — MESH_AUTH_TOKEN set but no
+        BROWSER_AUTH_TOKEN and no INSECURE override → RuntimeError."""
+        import pytest as _pytest
+
+        from src.browser.server import create_browser_app
+        monkeypatch.delenv("BROWSER_AUTH_TOKEN", raising=False)
+        monkeypatch.setenv("MESH_AUTH_TOKEN", "live-token")
+        monkeypatch.delenv("BROWSER_AUTH_INSECURE", raising=False)
+        mgr = BrowserManager(profiles_dir=str(tmp_path / "p"))
+        with _pytest.raises(RuntimeError):
+            create_browser_app(mgr)
+
+    def test_startup_allows_insecure_override_in_dev_with_mesh_token(
+        self, tmp_path, monkeypatch,
+    ):
+        """P1.5: BROWSER_AUTH_INSECURE=1 overrides the production guard
+        so the dev posture (no bearer required) is reachable while
+        keeping the per-endpoint guard at /_stage_upload."""
+        from src.browser.server import create_browser_app
+        monkeypatch.delenv("BROWSER_AUTH_TOKEN", raising=False)
+        monkeypatch.setenv("MESH_AUTH_TOKEN", "live-token")
+        monkeypatch.setenv("BROWSER_AUTH_INSECURE", "1")
+        mgr = BrowserManager(profiles_dir=str(tmp_path / "p"))
+        # Must not raise. App still has the per-endpoint bearer guard
+        # exercised in the prior test.
+        app = create_browser_app(mgr)
+        assert app is not None
 
 
 class TestUploadFileStageCleanup:

--- a/tests/test_browser_upload_mesh.py
+++ b/tests/test_browser_upload_mesh.py
@@ -1,0 +1,451 @@
+"""Tests for §4.5 / §8.1 mesh-mediated file-upload endpoints.
+
+Covers:
+- ``POST /mesh/browser/upload-stage`` — Phase A: bytes ingest, idempotency,
+  size cap, permission check, rate limit.
+- ``POST /mesh/browser/upload_file`` — Phase B: handle resolution,
+  cross-agent abuse rejection, browser proxy orchestration.
+- Stage GC loop reaps orphan files past TTL.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+
+def _build_app(tmp_path, *, perms_map, monkeypatch=None, ttl_s=60, max_mb=50):
+    from src.host.costs import CostTracker
+    from src.host.mesh import Blackboard, MessageRouter, PubSub
+    from src.host.permissions import PermissionMatrix
+    from src.host.server import create_mesh_app
+    from src.host.traces import TraceStore
+    from src.shared.types import AgentPermissions
+
+    if monkeypatch is not None:
+        monkeypatch.setenv(
+            "OPENLEGION_UPLOAD_STAGE_DIR", str(tmp_path / "stage"),
+        )
+        monkeypatch.setenv(
+            "OPENLEGION_UPLOAD_STAGE_TTL_S", str(ttl_s),
+        )
+        monkeypatch.setenv(
+            "OPENLEGION_UPLOAD_STAGE_MAX_MB", str(max_mb),
+        )
+
+    blackboard = Blackboard(str(tmp_path / "bb.db"))
+    pubsub = PubSub()
+    permissions = PermissionMatrix()
+    for aid, perms in perms_map.items():
+        permissions.permissions[aid] = AgentPermissions(agent_id=aid, **perms)
+
+    router = MessageRouter(permissions, {})
+    costs = CostTracker(str(tmp_path / "costs.db"))
+    traces = TraceStore(str(tmp_path / "traces.db"))
+
+    container_manager = MagicMock()
+    container_manager.browser_service_url = "http://browser-svc:8500"
+    container_manager.browser_auth_token = ""
+
+    event_bus = MagicMock()
+
+    app = create_mesh_app(
+        blackboard=blackboard,
+        pubsub=pubsub,
+        router=router,
+        permissions=permissions,
+        cost_tracker=costs,
+        trace_store=traces,
+        event_bus=event_bus,
+        container_manager=container_manager,
+    )
+    return app, container_manager
+
+
+class TestMeshUploadStage:
+    @pytest.mark.asyncio
+    async def test_stage_returns_handle_and_metadata(self, tmp_path, monkeypatch):
+        from httpx import ASGITransport, AsyncClient
+
+        app, _cm = _build_app(
+            tmp_path,
+            perms_map={"worker": {"can_use_browser": True}},
+            monkeypatch=monkeypatch,
+        )
+
+        async with AsyncClient(
+            transport=ASGITransport(app=app), base_url="http://test",
+        ) as client:
+            resp = await client.post(
+                "/mesh/browser/upload-stage",
+                content=b"hello world",
+                headers={"X-Agent-ID": "worker"},
+            )
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        assert body["staged_handle"].startswith("worker-")
+        assert body["size_bytes"] == 11
+        assert body["expires_at"]
+
+    @pytest.mark.asyncio
+    async def test_stage_413_when_oversize(self, tmp_path, monkeypatch):
+        from httpx import ASGITransport, AsyncClient
+
+        app, _cm = _build_app(
+            tmp_path,
+            perms_map={"worker": {"can_use_browser": True}},
+            monkeypatch=monkeypatch,
+            max_mb=1,
+        )
+        too_big = b"X" * (2 * 1024 * 1024)
+        async with AsyncClient(
+            transport=ASGITransport(app=app), base_url="http://test",
+        ) as client:
+            resp = await client.post(
+                "/mesh/browser/upload-stage",
+                content=too_big,
+                headers={"X-Agent-ID": "worker"},
+            )
+        assert resp.status_code == 413, resp.text
+        stage_dir = tmp_path / "stage"
+        assert not any(p.suffix == ".bin" for p in stage_dir.iterdir())
+
+    @pytest.mark.asyncio
+    async def test_stage_idempotency_returns_same_handle(self, tmp_path, monkeypatch):
+        from httpx import ASGITransport, AsyncClient
+
+        app, _cm = _build_app(
+            tmp_path,
+            perms_map={"worker": {"can_use_browser": True}},
+            monkeypatch=monkeypatch,
+        )
+        async with AsyncClient(
+            transport=ASGITransport(app=app), base_url="http://test",
+        ) as client:
+            r1 = await client.post(
+                "/mesh/browser/upload-stage",
+                content=b"resume bytes",
+                headers={
+                    "X-Agent-ID": "worker",
+                    "Idempotency-Key": "abc-1",
+                },
+            )
+            r2 = await client.post(
+                "/mesh/browser/upload-stage",
+                content=b"resume bytes",
+                headers={
+                    "X-Agent-ID": "worker",
+                    "Idempotency-Key": "abc-1",
+                },
+            )
+        assert r1.status_code == 200 and r2.status_code == 200
+        assert r1.json()["staged_handle"] == r2.json()["staged_handle"]
+
+    @pytest.mark.asyncio
+    async def test_stage_idempotency_different_bytes_returns_new_handle(
+        self, tmp_path, monkeypatch,
+    ):
+        from httpx import ASGITransport, AsyncClient
+
+        app, _cm = _build_app(
+            tmp_path,
+            perms_map={"worker": {"can_use_browser": True}},
+            monkeypatch=monkeypatch,
+        )
+        async with AsyncClient(
+            transport=ASGITransport(app=app), base_url="http://test",
+        ) as client:
+            r1 = await client.post(
+                "/mesh/browser/upload-stage",
+                content=b"version-A",
+                headers={
+                    "X-Agent-ID": "worker",
+                    "Idempotency-Key": "abc-1",
+                },
+            )
+            r2 = await client.post(
+                "/mesh/browser/upload-stage",
+                content=b"version-B",
+                headers={
+                    "X-Agent-ID": "worker",
+                    "Idempotency-Key": "abc-1",
+                },
+            )
+        assert r1.status_code == 200 and r2.status_code == 200
+        assert r1.json()["staged_handle"] != r2.json()["staged_handle"]
+
+    @pytest.mark.asyncio
+    async def test_stage_denied_without_browser_permission(
+        self, tmp_path, monkeypatch,
+    ):
+        from httpx import ASGITransport, AsyncClient
+
+        app, _cm = _build_app(
+            tmp_path,
+            perms_map={
+                "denied": {
+                    "can_use_browser": True,
+                    "browser_actions": ["click"],
+                },
+            },
+            monkeypatch=monkeypatch,
+        )
+        async with AsyncClient(
+            transport=ASGITransport(app=app), base_url="http://test",
+        ) as client:
+            resp = await client.post(
+                "/mesh/browser/upload-stage",
+                content=b"x",
+                headers={"X-Agent-ID": "denied"},
+            )
+        assert resp.status_code == 403, resp.text
+
+    @pytest.mark.asyncio
+    async def test_stage_gc_reaps_old_files(self, tmp_path, monkeypatch):
+        import os
+        import time
+
+        from httpx import ASGITransport, AsyncClient
+
+        app, _cm = _build_app(
+            tmp_path,
+            perms_map={"worker": {"can_use_browser": True}},
+            monkeypatch=monkeypatch,
+            ttl_s=5,
+        )
+        async with AsyncClient(
+            transport=ASGITransport(app=app), base_url="http://test",
+        ) as client:
+            resp = await client.post(
+                "/mesh/browser/upload-stage",
+                content=b"data",
+                headers={"X-Agent-ID": "worker"},
+            )
+        handle = resp.json()["staged_handle"]
+        bin_path = tmp_path / "stage" / f"{handle}.bin"
+        meta_path = tmp_path / "stage" / f"{handle}.json"
+        assert bin_path.is_file() and meta_path.is_file()
+
+        old = time.time() - 10
+        os.utime(bin_path, (old, old))
+        os.utime(meta_path, (old, old))
+
+        gc = app.state.upload_stage_gc_once
+        reaped = await gc()
+        assert reaped >= 2
+        assert not bin_path.exists()
+        assert not meta_path.exists()
+
+
+class TestMeshUploadApply:
+    @pytest.mark.asyncio
+    async def test_apply_orchestrates_ingest_and_upload(self, tmp_path, monkeypatch):
+        import httpx
+        from httpx import ASGITransport, AsyncClient, Response
+
+        app, _cm = _build_app(
+            tmp_path,
+            perms_map={"worker": {"can_use_browser": True}},
+            monkeypatch=monkeypatch,
+        )
+
+        async with AsyncClient(
+            transport=ASGITransport(app=app), base_url="http://test",
+        ) as client:
+            stage = await client.post(
+                "/mesh/browser/upload-stage",
+                content=b"resume.pdf bytes",
+                headers={"X-Agent-ID": "worker"},
+            )
+            handle = stage.json()["staged_handle"]
+
+            calls: list[str] = []
+            real_post = httpx.AsyncClient.post
+
+            async def fake_post(self, url, *args, **kwargs):
+                if "browser-svc" in str(url):
+                    if "/_stage_upload" in str(url):
+                        calls.append("ingest")
+                        body = b""
+                        content = kwargs.get("content")
+                        if content is not None:
+                            async for chunk in content:
+                                body += chunk
+                        return Response(
+                            200,
+                            json={
+                                "path": f"/tmp/upload-recv/{handle}.bin",
+                                "size_bytes": len(body),
+                            },
+                            request=httpx.Request("POST", str(url)),
+                        )
+                    if str(url).endswith("/upload_file"):
+                        calls.append("apply")
+                        sent = kwargs.get("json") or {}
+                        return Response(
+                            200,
+                            json={
+                                "success": True,
+                                "data": {"uploaded": sent.get("paths", [])},
+                            },
+                            request=httpx.Request("POST", str(url)),
+                        )
+                return await real_post(self, url, *args, **kwargs)
+
+            monkeypatch.setattr(httpx.AsyncClient, "post", fake_post)
+
+            resp = await client.post(
+                "/mesh/browser/upload_file",
+                json={"ref": "e7", "staged_handles": [handle]},
+                headers={"X-Agent-ID": "worker"},
+            )
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        assert body["success"] is True
+        assert body["data"]["uploaded"] == [f"/tmp/upload-recv/{handle}.bin"]
+        assert calls == ["ingest", "apply"]
+
+        bin_path = tmp_path / "stage" / f"{handle}.bin"
+        meta_path = tmp_path / "stage" / f"{handle}.json"
+        assert not bin_path.exists()
+        assert not meta_path.exists()
+
+    @pytest.mark.asyncio
+    async def test_apply_rejects_handle_from_other_caller(self, tmp_path, monkeypatch):
+        from httpx import ASGITransport, AsyncClient
+
+        app, _cm = _build_app(
+            tmp_path,
+            perms_map={
+                "alice": {"can_use_browser": True},
+                "bob": {"can_use_browser": True},
+            },
+            monkeypatch=monkeypatch,
+        )
+        async with AsyncClient(
+            transport=ASGITransport(app=app), base_url="http://test",
+        ) as client:
+            stage = await client.post(
+                "/mesh/browser/upload-stage",
+                content=b"alice bytes",
+                headers={"X-Agent-ID": "alice"},
+            )
+            handle = stage.json()["staged_handle"]
+
+            resp = await client.post(
+                "/mesh/browser/upload_file",
+                json={"ref": "e1", "staged_handles": [handle]},
+                headers={"X-Agent-ID": "bob"},
+            )
+        assert resp.status_code == 403, resp.text
+
+    @pytest.mark.asyncio
+    async def test_apply_404_when_handle_unknown(self, tmp_path, monkeypatch):
+        from httpx import ASGITransport, AsyncClient
+
+        app, _cm = _build_app(
+            tmp_path,
+            perms_map={"worker": {"can_use_browser": True}},
+            monkeypatch=monkeypatch,
+        )
+        async with AsyncClient(
+            transport=ASGITransport(app=app), base_url="http://test",
+        ) as client:
+            resp = await client.post(
+                "/mesh/browser/upload_file",
+                json={"ref": "e1", "staged_handles": ["worker-nope"]},
+                headers={"X-Agent-ID": "worker"},
+            )
+        assert resp.status_code == 404
+
+    @pytest.mark.asyncio
+    async def test_apply_503_when_browser_unavailable(self, tmp_path, monkeypatch):
+        from httpx import ASGITransport, AsyncClient
+
+        app, _cm = _build_app(
+            tmp_path,
+            perms_map={"worker": {"can_use_browser": True}},
+            monkeypatch=monkeypatch,
+        )
+        _cm.browser_service_url = None
+
+        async with AsyncClient(
+            transport=ASGITransport(app=app), base_url="http://test",
+        ) as client:
+            stage = await client.post(
+                "/mesh/browser/upload-stage",
+                content=b"x",
+                headers={"X-Agent-ID": "worker"},
+            )
+            handle = stage.json()["staged_handle"]
+            resp = await client.post(
+                "/mesh/browser/upload_file",
+                json={"ref": "e1", "staged_handles": [handle]},
+                headers={"X-Agent-ID": "worker"},
+            )
+        assert resp.status_code == 503
+
+    @pytest.mark.asyncio
+    async def test_apply_denied_when_target_lacks_permission(
+        self, tmp_path, monkeypatch,
+    ):
+        from httpx import ASGITransport, AsyncClient
+
+        app, _cm = _build_app(
+            tmp_path,
+            perms_map={
+                "operator": {
+                    "can_use_browser": False,
+                    "can_message": ["*"],
+                },
+                "worker": {
+                    "can_use_browser": True,
+                    "browser_actions": ["click"],
+                },
+            },
+            monkeypatch=monkeypatch,
+        )
+        async with AsyncClient(
+            transport=ASGITransport(app=app), base_url="http://test",
+        ) as client:
+            stage = await client.post(
+                "/mesh/browser/upload-stage",
+                content=b"x",
+                headers={"X-Agent-ID": "operator"},
+            )
+            assert stage.status_code == 403
+
+    @pytest.mark.asyncio
+    async def test_apply_validates_ref_and_handles(self, tmp_path, monkeypatch):
+        from httpx import ASGITransport, AsyncClient
+
+        app, _cm = _build_app(
+            tmp_path,
+            perms_map={"worker": {"can_use_browser": True}},
+            monkeypatch=monkeypatch,
+        )
+        async with AsyncClient(
+            transport=ASGITransport(app=app), base_url="http://test",
+        ) as client:
+            r1 = await client.post(
+                "/mesh/browser/upload_file",
+                json={"ref": "", "staged_handles": ["a"]},
+                headers={"X-Agent-ID": "worker"},
+            )
+            r2 = await client.post(
+                "/mesh/browser/upload_file",
+                json={"ref": "e1", "staged_handles": []},
+                headers={"X-Agent-ID": "worker"},
+            )
+            r3 = await client.post(
+                "/mesh/browser/upload_file",
+                json={
+                    "ref": "e1",
+                    "staged_handles": ["a", "b", "c", "d", "e", "f"],
+                },
+                headers={"X-Agent-ID": "worker"},
+            )
+        assert r1.status_code == 400
+        assert r2.status_code == 400
+        assert r3.status_code == 400

--- a/tests/test_browser_upload_mesh.py
+++ b/tests/test_browser_upload_mesh.py
@@ -779,3 +779,349 @@ class TestAtomicWrite:
         stage_dir = tmp_path / "stage"
         assert list(stage_dir.glob("*.partial")) == []
         assert list(stage_dir.glob("*.bin")) == []
+
+
+class TestApplyReplay:
+    """P0.1 — apply must be idempotent on retry-after-success."""
+
+    @pytest.mark.asyncio
+    async def test_apply_retry_after_success_returns_cached_result(
+        self, tmp_path, monkeypatch,
+    ):
+        """Same caller + same idempotency_key + same handles within TTL —
+        the second call returns the cached envelope and DOES NOT drive
+        the browser a second time."""
+        import httpx
+        from httpx import ASGITransport, AsyncClient, Response
+
+        app, _cm = _build_app(
+            tmp_path,
+            perms_map={"worker": {"can_use_browser": True}},
+            monkeypatch=monkeypatch,
+        )
+
+        ingest_calls: list[str] = []
+        upload_calls: list[str] = []
+        real_post = httpx.AsyncClient.post
+
+        async def fake_post(self, url, *args, **kwargs):
+            url_str = str(url)
+            if "browser-svc" in url_str and "/_stage_upload" in url_str:
+                ingest_calls.append(url_str)
+                content = kwargs.get("content")
+                if content is not None:
+                    async for _ in content:
+                        pass
+                return Response(
+                    200,
+                    json={"path": "/tmp/upload-recv/x.bin", "size_bytes": 4},
+                    request=httpx.Request("POST", url_str),
+                )
+            if "browser-svc" in url_str and url_str.endswith("/upload_file"):
+                upload_calls.append(url_str)
+                return Response(
+                    200,
+                    json={"success": True, "data": {"uploaded": ["/tmp/upload-recv/x.bin"]}},
+                    request=httpx.Request("POST", url_str),
+                )
+            return await real_post(self, url, *args, **kwargs)
+
+        monkeypatch.setattr(httpx.AsyncClient, "post", fake_post)
+
+        async with AsyncClient(
+            transport=ASGITransport(app=app), base_url="http://test",
+        ) as client:
+            stage = await client.post(
+                "/mesh/browser/upload-stage",
+                content=b"data",
+                headers={"X-Agent-ID": "worker"},
+            )
+            handle = stage.json()["staged_handle"]
+
+            r1 = await client.post(
+                "/mesh/browser/upload_file",
+                json={
+                    "ref": "e1",
+                    "staged_handles": [handle],
+                    "idempotency_key": "apply-key-1",
+                },
+                headers={"X-Agent-ID": "worker"},
+            )
+            r2 = await client.post(
+                "/mesh/browser/upload_file",
+                json={
+                    "ref": "e1",
+                    "staged_handles": [handle],
+                    "idempotency_key": "apply-key-1",
+                },
+                headers={"X-Agent-ID": "worker"},
+            )
+
+        assert r1.status_code == 200, r1.text
+        assert r2.status_code == 200, r2.text
+        assert r1.json() == r2.json()
+        assert len(ingest_calls) == 1, "browser ingest must run only once"
+        assert len(upload_calls) == 1, "browser upload_file must run only once"
+
+    @pytest.mark.asyncio
+    async def test_apply_retry_with_different_key_returns_404(
+        self, tmp_path, monkeypatch,
+    ):
+        """Same handle, different key — handles are consumed and the
+        replay gate fails on key mismatch → 404 (handle unknown)."""
+        import httpx
+        from httpx import ASGITransport, AsyncClient, Response
+
+        app, _cm = _build_app(
+            tmp_path,
+            perms_map={"worker": {"can_use_browser": True}},
+            monkeypatch=monkeypatch,
+        )
+
+        real_post = httpx.AsyncClient.post
+
+        async def fake_post(self, url, *args, **kwargs):
+            url_str = str(url)
+            if "browser-svc" in url_str and "/_stage_upload" in url_str:
+                content = kwargs.get("content")
+                if content is not None:
+                    async for _ in content:
+                        pass
+                return Response(
+                    200,
+                    json={"path": "/tmp/upload-recv/x.bin", "size_bytes": 4},
+                    request=httpx.Request("POST", url_str),
+                )
+            if "browser-svc" in url_str and url_str.endswith("/upload_file"):
+                return Response(
+                    200,
+                    json={"success": True, "data": {"uploaded": []}},
+                    request=httpx.Request("POST", url_str),
+                )
+            return await real_post(self, url, *args, **kwargs)
+
+        monkeypatch.setattr(httpx.AsyncClient, "post", fake_post)
+
+        async with AsyncClient(
+            transport=ASGITransport(app=app), base_url="http://test",
+        ) as client:
+            stage = await client.post(
+                "/mesh/browser/upload-stage",
+                content=b"data",
+                headers={"X-Agent-ID": "worker"},
+            )
+            handle = stage.json()["staged_handle"]
+
+            r1 = await client.post(
+                "/mesh/browser/upload_file",
+                json={
+                    "ref": "e1",
+                    "staged_handles": [handle],
+                    "idempotency_key": "key-A",
+                },
+                headers={"X-Agent-ID": "worker"},
+            )
+            assert r1.status_code == 200
+
+            r2 = await client.post(
+                "/mesh/browser/upload_file",
+                json={
+                    "ref": "e1",
+                    "staged_handles": [handle],
+                    "idempotency_key": "key-B",
+                },
+                headers={"X-Agent-ID": "worker"},
+            )
+        assert r2.status_code == 404, r2.text
+
+
+class TestStageConcurrency:
+    """P0.2 — concurrent stages with the same idempotency_key serialize."""
+
+    @pytest.mark.asyncio
+    async def test_concurrent_stage_same_key_serializes(
+        self, tmp_path, monkeypatch,
+    ):
+        import asyncio as _asyncio
+
+        from httpx import ASGITransport, AsyncClient
+
+        app, _cm = _build_app(
+            tmp_path,
+            perms_map={"worker": {"can_use_browser": True}},
+            monkeypatch=monkeypatch,
+        )
+
+        payload = b"X" * (256 * 1024)
+        async with AsyncClient(
+            transport=ASGITransport(app=app), base_url="http://test",
+        ) as client:
+            results = await _asyncio.gather(
+                client.post(
+                    "/mesh/browser/upload-stage",
+                    content=payload,
+                    headers={
+                        "X-Agent-ID": "worker",
+                        "Idempotency-Key": "race-key",
+                    },
+                ),
+                client.post(
+                    "/mesh/browser/upload-stage",
+                    content=payload,
+                    headers={
+                        "X-Agent-ID": "worker",
+                        "Idempotency-Key": "race-key",
+                    },
+                ),
+            )
+
+        assert all(r.status_code == 200 for r in results), [r.text for r in results]
+        bodies = [r.json() for r in results]
+        # Same handle (deterministic in caller+key).
+        assert bodies[0]["staged_handle"] == bodies[1]["staged_handle"]
+        # Bytes on disk match the payload exactly — proof the two writers
+        # did not interleave.
+        handle = bodies[0]["staged_handle"]
+        bin_path = tmp_path / "stage" / f"{handle}.bin"
+        assert bin_path.read_bytes() == payload
+
+
+class TestGcSkipsActivePartial:
+    """P0.3 — GC must not unlink partials for in-flight uploads."""
+
+    @pytest.mark.asyncio
+    async def test_gc_skips_active_partial(self, tmp_path, monkeypatch):
+        import os
+        import time
+
+        app, _cm = _build_app(
+            tmp_path,
+            perms_map={"worker": {"can_use_browser": True}},
+            monkeypatch=monkeypatch,
+            ttl_s=5,
+        )
+
+        # Simulate an in-flight upload by registering the handle in the
+        # active set and dropping a stale ``.partial`` on disk.
+        active = app.state.upload_stage_active_handles
+        partial_ttl = app.state.upload_stage_partial_ttl_s
+        stage_dir = tmp_path / "stage"
+        stage_dir.mkdir(parents=True, exist_ok=True)
+        handle = "worker-busy"
+        partial = stage_dir / f"{handle}.bin.partial"
+        partial.write_bytes(b"in-flight")
+        old = time.time() - (partial_ttl + 60)
+        os.utime(partial, (old, old))
+
+        active.add(handle)
+        try:
+            gc = app.state.upload_stage_gc_once
+            await gc()
+            # Active partial — preserved despite stale mtime.
+            assert partial.exists()
+        finally:
+            active.discard(handle)
+
+        # Once cleared from the active set, the GC reaps it (mtime is
+        # past _UPLOAD_STAGE_PARTIAL_TTL_S).
+        await app.state.upload_stage_gc_once()
+        assert not partial.exists()
+
+    @pytest.mark.asyncio
+    async def test_gc_uses_longer_ttl_for_partials(self, tmp_path, monkeypatch):
+        """Partials younger than the longer partial-TTL are kept even if
+        older than the regular sidecar TTL — slow uploads can complete."""
+        import os
+        import time
+
+        app, _cm = _build_app(
+            tmp_path,
+            perms_map={"worker": {"can_use_browser": True}},
+            monkeypatch=monkeypatch,
+            ttl_s=5,
+        )
+        stage_dir = tmp_path / "stage"
+        stage_dir.mkdir(parents=True, exist_ok=True)
+        partial = stage_dir / "worker-slow.bin.partial"
+        partial.write_bytes(b"halfway")
+        # Past sidecar TTL (5s) but inside partial TTL (5 × 5 = 25s).
+        recent = time.time() - 10
+        os.utime(partial, (recent, recent))
+
+        await app.state.upload_stage_gc_once()
+        assert partial.exists()
+
+
+class TestStageHandleValidation:
+    """P1.6 — apply must reject handles that escape the stage dir."""
+
+    @pytest.mark.asyncio
+    async def test_apply_rejects_traversal_handle(self, tmp_path, monkeypatch):
+        from httpx import ASGITransport, AsyncClient
+
+        app, _cm = _build_app(
+            tmp_path,
+            perms_map={"worker": {"can_use_browser": True}},
+            monkeypatch=monkeypatch,
+        )
+        async with AsyncClient(
+            transport=ASGITransport(app=app), base_url="http://test",
+        ) as client:
+            resp = await client.post(
+                "/mesh/browser/upload_file",
+                json={
+                    "ref": "e1",
+                    "staged_handles": ["../../etc/passwd"],
+                },
+                headers={"X-Agent-ID": "worker"},
+            )
+        assert resp.status_code == 400, resp.text
+
+
+class TestApplyParseOrder:
+    """P1.7 — rate limit fires before json parsing."""
+
+    @pytest.mark.asyncio
+    async def test_apply_rate_limit_fires_before_parse(
+        self, tmp_path, monkeypatch,
+    ):
+        """Burn the apply bucket, then send a malformed body. We expect
+        429 (rate-limit) — NOT 4xx-from-parse — because the rate-limit
+        check now runs first."""
+        from httpx import ASGITransport, AsyncClient
+
+        app, _cm = _build_app(
+            tmp_path,
+            perms_map={"worker": {"can_use_browser": True}},
+            monkeypatch=monkeypatch,
+        )
+
+        async with AsyncClient(
+            transport=ASGITransport(app=app), base_url="http://test",
+        ) as client:
+            statuses: list[int] = []
+            for _ in range(40):
+                # Send a body that would 400 if parsed (no ref, no
+                # handles). We expect 400 until the rate-limit kicks in,
+                # then 429 — the moment we see 429 we stop.
+                resp = await client.post(
+                    "/mesh/browser/upload_file",
+                    json={},
+                    headers={"X-Agent-ID": "worker"},
+                )
+                statuses.append(resp.status_code)
+                if resp.status_code == 429:
+                    break
+            assert 429 in statuses, statuses
+
+            # Confirm a malformed body (which would normally raise on
+            # json parse) is now stopped at the rate-limit gate.
+            resp = await client.post(
+                "/mesh/browser/upload_file",
+                content=b"not-json",
+                headers={
+                    "X-Agent-ID": "worker",
+                    "content-type": "application/json",
+                },
+            )
+            assert resp.status_code == 429, resp.text

--- a/tests/test_browser_upload_mesh.py
+++ b/tests/test_browser_upload_mesh.py
@@ -143,9 +143,12 @@ class TestMeshUploadStage:
         assert r1.json()["staged_handle"] == r2.json()["staged_handle"]
 
     @pytest.mark.asyncio
-    async def test_stage_idempotency_different_bytes_returns_new_handle(
+    async def test_stage_idempotency_different_bytes_overwrites(
         self, tmp_path, monkeypatch,
     ):
+        """Same (caller, idem_key) with different bytes overwrites the stage
+        file — sha256 mismatch fails the dedupe gate, so the upload is fresh.
+        The handle string is deterministic in (caller, key)."""
         from httpx import ASGITransport, AsyncClient
 
         app, _cm = _build_app(
@@ -173,7 +176,9 @@ class TestMeshUploadStage:
                 },
             )
         assert r1.status_code == 200 and r2.status_code == 200
-        assert r1.json()["staged_handle"] != r2.json()["staged_handle"]
+        handle = r2.json()["staged_handle"]
+        bin_path = tmp_path / "stage" / f"{handle}.bin"
+        assert bin_path.read_bytes() == b"version-B"
 
     @pytest.mark.asyncio
     async def test_stage_denied_without_browser_permission(
@@ -306,10 +311,14 @@ class TestMeshUploadApply:
         assert body["data"]["uploaded"] == [f"/tmp/upload-recv/{handle}.bin"]
         assert calls == ["ingest", "apply"]
 
+        import json as _json
         bin_path = tmp_path / "stage" / f"{handle}.bin"
         meta_path = tmp_path / "stage" / f"{handle}.json"
         assert not bin_path.exists()
-        assert not meta_path.exists()
+        assert meta_path.exists()
+        meta = _json.loads(meta_path.read_text())
+        assert meta["status"] == "consumed"
+        assert meta["consumed_at"]
 
     @pytest.mark.asyncio
     async def test_apply_rejects_handle_from_other_caller(self, tmp_path, monkeypatch):
@@ -449,3 +458,324 @@ class TestMeshUploadApply:
         assert r1.status_code == 400
         assert r2.status_code == 400
         assert r3.status_code == 400
+
+
+class TestApplyRateLimit:
+    @pytest.mark.asyncio
+    async def test_apply_rate_limit_enforced(self, tmp_path, monkeypatch):
+        """upload_apply has its own bucket; once exhausted, returns 429."""
+        from httpx import ASGITransport, AsyncClient
+
+        app, _cm = _build_app(
+            tmp_path,
+            perms_map={"worker": {"can_use_browser": True}},
+            monkeypatch=monkeypatch,
+        )
+
+        # Stage one handle so we have something to apply.
+        async with AsyncClient(
+            transport=ASGITransport(app=app), base_url="http://test",
+        ) as client:
+            stage = await client.post(
+                "/mesh/browser/upload-stage",
+                content=b"x",
+                headers={"X-Agent-ID": "worker"},
+            )
+            handle = stage.json()["staged_handle"]
+
+            # Patch the rate-limit table to be tight (2 requests/min) for
+            # upload_apply via the running app's stored state.
+            # We achieve this by issuing many calls; the default is 30/60s
+            # per the impl. To keep the test fast we hit the cap.
+            statuses: list[int] = []
+            for _ in range(35):
+                resp = await client.post(
+                    "/mesh/browser/upload_file",
+                    json={"ref": "e1", "staged_handles": [handle]},
+                    headers={"X-Agent-ID": "worker"},
+                )
+                statuses.append(resp.status_code)
+                if resp.status_code == 429:
+                    break
+        assert 429 in statuses, statuses
+
+
+class TestIdempotencyTtl:
+    @pytest.mark.asyncio
+    async def test_idem_match_returns_same_handle_within_ttl(
+        self, tmp_path, monkeypatch,
+    ):
+        from httpx import ASGITransport, AsyncClient
+
+        app, _cm = _build_app(
+            tmp_path,
+            perms_map={"worker": {"can_use_browser": True}},
+            monkeypatch=monkeypatch,
+            ttl_s=60,
+        )
+        async with AsyncClient(
+            transport=ASGITransport(app=app), base_url="http://test",
+        ) as client:
+            r1 = await client.post(
+                "/mesh/browser/upload-stage",
+                content=b"same bytes",
+                headers={
+                    "X-Agent-ID": "worker",
+                    "Idempotency-Key": "k1",
+                },
+            )
+            r2 = await client.post(
+                "/mesh/browser/upload-stage",
+                content=b"same bytes",
+                headers={
+                    "X-Agent-ID": "worker",
+                    "Idempotency-Key": "k1",
+                },
+            )
+        assert r1.json()["staged_handle"] == r2.json()["staged_handle"]
+
+    @pytest.mark.asyncio
+    async def test_idem_handle_is_deterministic_in_caller_and_key(
+        self, tmp_path, monkeypatch,
+    ):
+        """Smoke check that the handle is derived from (caller, key) without
+        listing the stage directory — the same key always maps to the same
+        handle string regardless of how many other files exist alongside."""
+        from httpx import ASGITransport, AsyncClient
+
+        app, _cm = _build_app(
+            tmp_path,
+            perms_map={"worker": {"can_use_browser": True}},
+            monkeypatch=monkeypatch,
+        )
+        async with AsyncClient(
+            transport=ASGITransport(app=app), base_url="http://test",
+        ) as client:
+            # Populate dir with a handful of unrelated files first so the
+            # dedupe path has noise to sift through if it were O(N).
+            for i in range(10):
+                await client.post(
+                    "/mesh/browser/upload-stage",
+                    content=f"f{i}".encode(),
+                    headers={
+                        "X-Agent-ID": "worker",
+                        "Idempotency-Key": f"u{i}",
+                    },
+                )
+            r1 = await client.post(
+                "/mesh/browser/upload-stage",
+                content=b"target",
+                headers={
+                    "X-Agent-ID": "worker",
+                    "Idempotency-Key": "target-key",
+                },
+            )
+            r2 = await client.post(
+                "/mesh/browser/upload-stage",
+                content=b"target",
+                headers={
+                    "X-Agent-ID": "worker",
+                    "Idempotency-Key": "target-key",
+                },
+            )
+        assert r1.json()["staged_handle"] == r2.json()["staged_handle"]
+        # Handle is the deterministic SHA-prefix form, not a random hex.
+        assert r1.json()["staged_handle"].startswith("worker-idem")
+
+    @pytest.mark.asyncio
+    async def test_idem_match_then_fresh_after_expiry(
+        self, tmp_path, monkeypatch,
+    ):
+        import os
+        import time
+
+        from httpx import ASGITransport, AsyncClient
+
+        app, _cm = _build_app(
+            tmp_path,
+            perms_map={"worker": {"can_use_browser": True}},
+            monkeypatch=monkeypatch,
+            ttl_s=5,
+        )
+        async with AsyncClient(
+            transport=ASGITransport(app=app), base_url="http://test",
+        ) as client:
+            r1 = await client.post(
+                "/mesh/browser/upload-stage",
+                content=b"payload",
+                headers={
+                    "X-Agent-ID": "worker",
+                    "Idempotency-Key": "ttl-key",
+                },
+            )
+            handle = r1.json()["staged_handle"]
+            meta_path = tmp_path / "stage" / f"{handle}.json"
+            bin_path = tmp_path / "stage" / f"{handle}.bin"
+            old = time.time() - 10
+            os.utime(meta_path, (old, old))
+            os.utime(bin_path, (old, old))
+
+            r2 = await client.post(
+                "/mesh/browser/upload-stage",
+                content=b"payload",
+                headers={
+                    "X-Agent-ID": "worker",
+                    "Idempotency-Key": "ttl-key",
+                },
+            )
+        # Same deterministic handle string but the file is rewritten with
+        # current mtime — the dedupe gate fails on age.
+        assert r1.json()["staged_handle"] == r2.json()["staged_handle"]
+        assert (tmp_path / "stage" / f"{handle}.bin").stat().st_mtime > old + 1
+
+
+class TestApplyTimeoutTaxonomy:
+    @pytest.mark.asyncio
+    async def test_apply_timeout_returns_503_not_502(self, tmp_path, monkeypatch):
+        import httpx
+        from httpx import ASGITransport, AsyncClient
+
+        app, _cm = _build_app(
+            tmp_path,
+            perms_map={"worker": {"can_use_browser": True}},
+            monkeypatch=monkeypatch,
+        )
+
+        async with AsyncClient(
+            transport=ASGITransport(app=app), base_url="http://test",
+        ) as client:
+            stage = await client.post(
+                "/mesh/browser/upload-stage",
+                content=b"x",
+                headers={"X-Agent-ID": "worker"},
+            )
+            handle = stage.json()["staged_handle"]
+
+            real_post = httpx.AsyncClient.post
+
+            async def fake_post(self, url, *args, **kwargs):
+                if "browser-svc" in str(url):
+                    raise httpx.ReadTimeout("simulated")
+                return await real_post(self, url, *args, **kwargs)
+
+            monkeypatch.setattr(httpx.AsyncClient, "post", fake_post)
+            resp = await client.post(
+                "/mesh/browser/upload_file",
+                json={"ref": "e1", "staged_handles": [handle]},
+                headers={"X-Agent-ID": "worker"},
+            )
+        assert resp.status_code == 503, resp.text
+
+
+class TestSuggestedFilenamesPropagate:
+    @pytest.mark.asyncio
+    async def test_apply_forwards_suggested_filename_to_browser_ingest(
+        self, tmp_path, monkeypatch,
+    ):
+        import httpx
+        from httpx import ASGITransport, AsyncClient, Response
+
+        app, _cm = _build_app(
+            tmp_path,
+            perms_map={"worker": {"can_use_browser": True}},
+            monkeypatch=monkeypatch,
+        )
+
+        async with AsyncClient(
+            transport=ASGITransport(app=app), base_url="http://test",
+        ) as client:
+            stage = await client.post(
+                "/mesh/browser/upload-stage",
+                content=b"resume bytes",
+                headers={"X-Agent-ID": "worker"},
+            )
+            handle = stage.json()["staged_handle"]
+
+            ingest_filenames: list[str] = []
+            real_post = httpx.AsyncClient.post
+
+            async def fake_post(self, url, *args, **kwargs):
+                url_str = str(url)
+                if "browser-svc" in url_str and "/_stage_upload" in url_str:
+                    params = kwargs.get("params") or {}
+                    ingest_filenames.append(params.get("suggested_filename", ""))
+                    body = b""
+                    content = kwargs.get("content")
+                    if content is not None:
+                        async for chunk in content:
+                            body += chunk
+                    return Response(
+                        200,
+                        json={"path": "/tmp/upload-recv/x-resume.pdf", "size_bytes": len(body)},
+                        request=httpx.Request("POST", url_str),
+                    )
+                if "browser-svc" in url_str and url_str.endswith("/upload_file"):
+                    return Response(
+                        200,
+                        json={"success": True, "data": {"uploaded": []}},
+                        request=httpx.Request("POST", url_str),
+                    )
+                return await real_post(self, url, *args, **kwargs)
+
+            monkeypatch.setattr(httpx.AsyncClient, "post", fake_post)
+            resp = await client.post(
+                "/mesh/browser/upload_file",
+                json={
+                    "ref": "e7",
+                    "staged_handles": [handle],
+                    "suggested_filenames": ["resume.pdf"],
+                },
+                headers={"X-Agent-ID": "worker"},
+            )
+        assert resp.status_code == 200, resp.text
+        assert ingest_filenames == ["resume.pdf"]
+
+
+class TestAtomicWrite:
+    @pytest.mark.asyncio
+    async def test_no_partial_files_remain_after_successful_stage(
+        self, tmp_path, monkeypatch,
+    ):
+        from httpx import ASGITransport, AsyncClient
+
+        app, _cm = _build_app(
+            tmp_path,
+            perms_map={"worker": {"can_use_browser": True}},
+            monkeypatch=monkeypatch,
+        )
+        async with AsyncClient(
+            transport=ASGITransport(app=app), base_url="http://test",
+        ) as client:
+            await client.post(
+                "/mesh/browser/upload-stage",
+                content=b"data",
+                headers={"X-Agent-ID": "worker"},
+            )
+        stage_dir = tmp_path / "stage"
+        partials = list(stage_dir.glob("*.partial"))
+        assert partials == []
+
+    @pytest.mark.asyncio
+    async def test_partial_files_cleaned_on_413(
+        self, tmp_path, monkeypatch,
+    ):
+        from httpx import ASGITransport, AsyncClient
+
+        app, _cm = _build_app(
+            tmp_path,
+            perms_map={"worker": {"can_use_browser": True}},
+            monkeypatch=monkeypatch,
+            max_mb=1,
+        )
+        async with AsyncClient(
+            transport=ASGITransport(app=app), base_url="http://test",
+        ) as client:
+            resp = await client.post(
+                "/mesh/browser/upload-stage",
+                content=b"X" * (2 * 1024 * 1024),
+                headers={"X-Agent-ID": "worker"},
+            )
+        assert resp.status_code == 413
+        stage_dir = tmp_path / "stage"
+        assert list(stage_dir.glob("*.partial")) == []
+        assert list(stage_dir.glob("*.bin")) == []

--- a/tests/test_builtins.py
+++ b/tests/test_builtins.py
@@ -2793,3 +2793,160 @@ class TestGetAgentProfile:
 
         result = await get_agent_profile("writer", mesh_client=None)
         assert "error" in result
+
+
+class TestBrowserUploadFileHttpClient:
+    """browser_upload_file reads workspace files and stages via mesh."""
+
+    def setup_method(self):
+        self._tmpdir = tempfile.mkdtemp()
+        import src.agent.builtins.file_tool as ft
+        self._ft = ft
+        self._original_root = ft._ALLOWED_ROOT
+        ft._ALLOWED_ROOT = self._tmpdir
+        os.makedirs(os.path.join(self._tmpdir, "uploads"), exist_ok=True)
+
+    def teardown_method(self):
+        self._ft._ALLOWED_ROOT = self._original_root
+        shutil.rmtree(self._tmpdir, ignore_errors=True)
+
+    def _write(self, name: str, content: bytes) -> str:
+        path = os.path.join(self._tmpdir, "uploads", name)
+        with open(path, "wb") as fh:
+            fh.write(content)
+        return f"uploads/{name}"
+
+    @pytest.mark.asyncio
+    async def test_happy_path_stages_then_applies(self):
+        from src.agent.builtins.browser_tool import browser_upload_file
+
+        rel = self._write("resume.pdf", b"hello pdf bytes")
+        mc = AsyncMock()
+        mc.browser_upload_stage = AsyncMock(
+            return_value={"staged_handle": "worker-handle-1", "size_bytes": 15},
+        )
+        mc.browser_upload_apply = AsyncMock(
+            return_value={
+                "success": True,
+                "data": {"uploaded": ["/tmp/upload-recv/handle.bin"]},
+            },
+        )
+
+        result = await browser_upload_file(
+            ref="e7", paths=[rel], mesh_client=mc,
+        )
+
+        assert result["success"] is True
+        mc.browser_upload_stage.assert_awaited_once()
+        stage_args = mc.browser_upload_stage.await_args
+        assert stage_args.args[0] == b"hello pdf bytes"
+        assert stage_args.kwargs["idempotency_key"]
+
+        mc.browser_upload_apply.assert_awaited_once()
+        body = mc.browser_upload_apply.await_args.args[0]
+        assert body["ref"] == "e7"
+        assert body["staged_handles"] == ["worker-handle-1"]
+        assert body["idempotency_key"]
+
+    @pytest.mark.asyncio
+    async def test_no_mesh_client_returns_error(self):
+        from src.agent.builtins.browser_tool import browser_upload_file
+        result = await browser_upload_file(
+            ref="e1", paths=["uploads/x.txt"], mesh_client=None,
+        )
+        assert "error" in result
+        assert "mesh" in result["error"].lower()
+
+    @pytest.mark.asyncio
+    async def test_empty_paths_returns_error(self):
+        from src.agent.builtins.browser_tool import browser_upload_file
+        result = await browser_upload_file(
+            ref="e1", paths=[], mesh_client=AsyncMock(),
+        )
+        assert "error" in result
+        assert "non-empty" in result["error"]
+
+    @pytest.mark.asyncio
+    async def test_too_many_paths_returns_error(self):
+        from src.agent.builtins.browser_tool import browser_upload_file
+        result = await browser_upload_file(
+            ref="e1",
+            paths=["a", "b", "c", "d", "e", "f"],
+            mesh_client=AsyncMock(),
+        )
+        assert "error" in result
+        assert "5" in result["error"]
+
+    @pytest.mark.asyncio
+    async def test_path_traversal_blocked(self):
+        from src.agent.builtins.browser_tool import browser_upload_file
+        mc = AsyncMock()
+        result = await browser_upload_file(
+            ref="e1", paths=["../etc/passwd"], mesh_client=mc,
+        )
+        assert "error" in result
+        assert "traversal" in result["error"].lower() or "invalid" in result["error"].lower()
+        mc.browser_upload_stage.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_missing_file_returns_error(self):
+        from src.agent.builtins.browser_tool import browser_upload_file
+        mc = AsyncMock()
+        result = await browser_upload_file(
+            ref="e1", paths=["uploads/nope.pdf"], mesh_client=mc,
+        )
+        assert "error" in result
+        assert "not found" in result["error"].lower()
+        mc.browser_upload_stage.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_oversize_file_rejected_at_skill(self, monkeypatch):
+        from src.agent.builtins import browser_tool
+        rel = self._write("big.bin", b"x")
+        monkeypatch.setattr(browser_tool, "_UPLOAD_MAX_BYTES", 0)
+        mc = AsyncMock()
+        result = await browser_tool.browser_upload_file(
+            ref="e1", paths=[rel], mesh_client=mc,
+        )
+        assert "error" in result
+        assert "50MB" in result["error"] or "cap" in result["error"]
+        mc.browser_upload_stage.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_invalid_ref_returns_error(self):
+        from src.agent.builtins.browser_tool import browser_upload_file
+        mc = AsyncMock()
+        result = await browser_upload_file(
+            ref="", paths=["uploads/x.txt"], mesh_client=mc,
+        )
+        assert "error" in result
+        assert "ref" in result["error"]
+
+    @pytest.mark.asyncio
+    async def test_multiple_files_each_get_unique_idempotency_key(self):
+        from src.agent.builtins.browser_tool import browser_upload_file
+
+        rel1 = self._write("a.pdf", b"file-a")
+        rel2 = self._write("b.pdf", b"file-b")
+        mc = AsyncMock()
+        handles = ["h1", "h2"]
+
+        async def fake_stage(blob, idempotency_key=None):
+            return {"staged_handle": handles.pop(0)}
+
+        mc.browser_upload_stage = AsyncMock(side_effect=fake_stage)
+        mc.browser_upload_apply = AsyncMock(
+            return_value={"success": True, "data": {"uploaded": []}},
+        )
+        result = await browser_upload_file(
+            ref="e1", paths=[rel1, rel2], mesh_client=mc,
+        )
+        assert result["success"] is True
+        assert mc.browser_upload_stage.await_count == 2
+        keys = [
+            c.kwargs["idempotency_key"]
+            for c in mc.browser_upload_stage.await_args_list
+        ]
+        assert len(set(keys)) == 2
+        body = mc.browser_upload_apply.await_args.args[0]
+        assert body["staged_handles"] == ["h1", "h2"]

--- a/tests/test_builtins.py
+++ b/tests/test_builtins.py
@@ -2821,10 +2821,16 @@ class TestBrowserUploadFileHttpClient:
         from src.agent.builtins.browser_tool import browser_upload_file
 
         rel = self._write("resume.pdf", b"hello pdf bytes")
+
+        captured_chunks: list[bytes] = []
+
+        async def _stage(body, idempotency_key=None):
+            data = body.read()
+            captured_chunks.append(data)
+            return {"staged_handle": "worker-handle-1", "size_bytes": len(data)}
+
         mc = AsyncMock()
-        mc.browser_upload_stage = AsyncMock(
-            return_value={"staged_handle": "worker-handle-1", "size_bytes": 15},
-        )
+        mc.browser_upload_stage = AsyncMock(side_effect=_stage)
         mc.browser_upload_apply = AsyncMock(
             return_value={
                 "success": True,
@@ -2838,15 +2844,38 @@ class TestBrowserUploadFileHttpClient:
 
         assert result["success"] is True
         mc.browser_upload_stage.assert_awaited_once()
-        stage_args = mc.browser_upload_stage.await_args
-        assert stage_args.args[0] == b"hello pdf bytes"
-        assert stage_args.kwargs["idempotency_key"]
+        assert captured_chunks == [b"hello pdf bytes"]
+        assert mc.browser_upload_stage.await_args.kwargs["idempotency_key"]
 
         mc.browser_upload_apply.assert_awaited_once()
         body = mc.browser_upload_apply.await_args.args[0]
         assert body["ref"] == "e7"
         assert body["staged_handles"] == ["worker-handle-1"]
+        assert body["suggested_filenames"] == ["resume.pdf"]
         assert body["idempotency_key"]
+
+    @pytest.mark.asyncio
+    async def test_explicit_idempotency_key_passed_through(self):
+        from src.agent.builtins.browser_tool import browser_upload_file
+
+        rel = self._write("resume.pdf", b"x")
+        mc = AsyncMock()
+        mc.browser_upload_stage = AsyncMock(
+            return_value={"staged_handle": "h1", "size_bytes": 1},
+        )
+        mc.browser_upload_apply = AsyncMock(
+            return_value={"success": True, "data": {"uploaded": []}},
+        )
+
+        await browser_upload_file(
+            ref="e1", paths=[rel], idempotency_key="caller-key-42",
+            mesh_client=mc,
+        )
+
+        stage_kwargs = mc.browser_upload_stage.await_args.kwargs
+        assert stage_kwargs["idempotency_key"] == "caller-key-42-0"
+        body = mc.browser_upload_apply.await_args.args[0]
+        assert body["idempotency_key"] == "caller-key-42"
 
     @pytest.mark.asyncio
     async def test_no_mesh_client_returns_error(self):

--- a/tests/test_builtins.py
+++ b/tests/test_builtins.py
@@ -2930,15 +2930,18 @@ class TestBrowserUploadFileHttpClient:
 
     @pytest.mark.asyncio
     async def test_oversize_file_rejected_at_skill(self, monkeypatch):
+        """Skill cap is now sourced from OPENLEGION_UPLOAD_STAGE_MAX_MB so
+        it stays consistent with the mesh + browser layers (P1.9).
+        Setting it to 1 MB makes a 2 MB file blow the per-file cap."""
         from src.agent.builtins import browser_tool
-        rel = self._write("big.bin", b"x")
-        monkeypatch.setattr(browser_tool, "_UPLOAD_MAX_BYTES", 0)
+        rel = self._write("big.bin", b"x" * (2 * 1024 * 1024))
+        monkeypatch.setenv("OPENLEGION_UPLOAD_STAGE_MAX_MB", "1")
         mc = AsyncMock()
         result = await browser_tool.browser_upload_file(
             ref="e1", paths=[rel], mesh_client=mc,
         )
         assert "error" in result
-        assert "50MB" in result["error"] or "cap" in result["error"]
+        assert "cap" in result["error"]
         mc.browser_upload_stage.assert_not_called()
 
     @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Implements §8.1 (file upload) from the browser-automation roadmap, building the mesh-mediated bytes-streaming pipeline that §4.5 designed but didn't ship. Works without a shared volume between agent and browser containers.

- **Phase A (`POST /mesh/browser/upload-stage`)** — agent skill streams bytes to mesh; mesh writes to tmpfs staging dir keyed by opaque handle. `Idempotency-Key` + sha256 dedupes retries within 60s. 50MB cap enforced at three places (skill, mesh, browser ingest) for defense-in-depth.
- **Phase B (`POST /mesh/browser/upload_file`)** — mesh resolves handles (rejecting cross-agent abuse), streams bytes into the browser container at the new mesh-internal `POST /browser/{a}/_stage_upload`, then drives the existing `/browser/{a}/upload_file` route. Permission check on apply uses the **effective target** so delegation is authorized correctly. Stage files cleaned up on success; orphans reaped by a 60s-TTL GC loop scheduled in the existing mesh startup hooks.
- **Skill `browser_upload_file(ref, paths)`** — reads 1..5 workspace files via `_safe_path`, generates a per-call idempotency key, stages each blob, then applies.
- **Service-side cleanup** — `BrowserManager.upload_file()` now unlinks staged files after `chooser.set_files()` succeeds.

Browser ingest endpoint requires `X-Mesh-Internal: 1` plus the bearer token — agents have neither.

## Test plan

- [x] `pytest tests/test_browser_file_transfer.py::TestUploadStageIngest` — new browser ingest endpoint (auth gate, 413, downstream consumption, filename sanitization)
- [x] `pytest tests/test_browser_file_transfer.py::TestUploadFileStageCleanup` — stage files unlinked after success
- [x] `pytest tests/test_browser_upload_mesh.py` — full mesh layer (idempotency same/different bytes, cross-agent 403, missing-handle 404, browser-down 503, permission gate, GC loop)
- [x] `pytest tests/test_builtins.py::TestBrowserUploadFileHttpClient` — skill validation, traversal block, oversize reject, multi-file fan-out
- [x] `pytest tests/test_browser_service.py tests/test_browser_file_transfer.py tests/test_browser_delegation.py tests/test_browser_upload_mesh.py tests/test_builtins.py` — 603 passed
- [x] `pytest tests/test_dashboard.py tests/test_permissions.py tests/test_browser_metrics_ingest.py tests/test_credential_request.py` — 341 passed
- [x] `ruff check src/ tests/` — clean