### PR TITLE
Phase 5 §8.5+§8.6: third-pass fixes for find_text + open_tab

### DIFF
--- a/src/browser/service.py
+++ b/src/browser/service.py
@@ -108,6 +108,24 @@ def _resolve_filter_roles(filter_name: str | None) -> frozenset[str] | None:
     return preset
 
 
+def _err(
+    code: str, message: str, retry_after_ms: int | None = None,
+) -> dict:
+    """Build a Phase 5 §2.3 structured error envelope.
+
+    Per §2.3 the ``retry_after_ms`` field is always present
+    (``null`` when not applicable), so callers can rely on the shape.
+    """
+    return {
+        "success": False,
+        "error": {
+            "code": code,
+            "message": message,
+            "retry_after_ms": retry_after_ms,
+        },
+    }
+
+
 _MAX_SNAPSHOT_ELEMENTS = 200
 _MAX_WALK_DEPTH = 50
 
@@ -227,20 +245,6 @@ _BLOCKED_URL_SCHEMES = frozenset({
 })
 _ALLOWED_URL_SCHEMES = frozenset({"http", "https"})
 
-
-def _err(code: str, message: str) -> dict:
-    """Standard error envelope for browser actions (§2.3).
-
-    Returns a structured ``{"success": False, "error": {"code", "message"}}``
-    payload so callers (mesh + agent skills) can branch on ``code`` rather
-    than substring-matching ``message``. Existing call sites that emit
-    ``{"success": False, "error": "..."}`` (string error) remain valid for
-    backward compatibility — this helper is for new structured-error paths.
-    """
-    return {
-        "success": False,
-        "error": {"code": code, "message": message},
-    }
 
 
 _MAX_WAIT_MS = 10000  # 10 seconds max wait after navigation
@@ -5182,19 +5186,19 @@ class BrowserManager:
         match is scrolled into view (best-effort, non-fatal).
         """
         if not isinstance(query, str) or not (1 <= len(query) <= 500):
-            return {
-                "success": False,
-                "error": "query must be a non-empty string up to 500 chars",
-            }
+            return _err(
+                "invalid_input",
+                "query must be a non-empty string up to 500 chars",
+            )
         inst = await self.get_or_start(agent_id)
         inst.touch()
         async with inst.lock:
             try:
                 if inst._user_control:
-                    return {
-                        "success": False,
-                        "error": "User has browser control — action paused until control is released.",
-                    }
+                    return _err(
+                        "conflict",
+                        "User has browser control — action paused until control is released.",
+                    )
                 snap = await self._snapshot_impl(
                     inst, agent_id, _skip_baseline=True,
                 )
@@ -5264,7 +5268,8 @@ class BrowserManager:
                     },
                 }
             except Exception as e:
-                return {"success": False, "error": str(e)}
+                logger.debug("find_text failed for %s: %s", agent_id, e)
+                return _err("service_unavailable", "find_text failed")
 
     async def open_tab(
         self, agent_id: str, url: str, snapshot_after: bool = False,
@@ -5279,30 +5284,30 @@ class BrowserManager:
         try:
             parsed = urlparse(url)
         except Exception:
-            return {"success": False, "error": "Invalid URL"}
+            return _err("invalid_input", "Invalid URL")
         scheme = parsed.scheme.lower()
         if scheme not in _ALLOWED_URL_SCHEMES:
-            return {
-                "success": False,
-                "error": f"URL scheme '{parsed.scheme}' is not allowed",
-            }
+            return _err(
+                "invalid_input",
+                f"URL scheme '{parsed.scheme}' is not allowed",
+            )
 
         inst = await self.get_or_start(agent_id)
         inst.touch()
         async with inst.lock:
             if inst._user_control:
-                return {
-                    "success": False,
-                    "error": "User has browser control — action paused until control is released.",
-                }
+                return _err(
+                    "conflict",
+                    "User has browser control — action paused until control is released.",
+                )
             previous_page = inst.page
             try:
                 new_page = await inst.context.new_page()
             except Exception as e:
-                return {"success": False, "error": f"Failed to open tab: {e}"}
+                logger.debug("open_tab new_page failed for %s: %s", agent_id, e)
+                return _err("service_unavailable", "Failed to open new tab")
 
             try:
-                page_id = inst._register_page(new_page)
                 resolved_referer = ""
                 try:
                     previous_url = (
@@ -5327,18 +5332,24 @@ class BrowserManager:
                 try:
                     await new_page.goto(url, **goto_kwargs)
                 except Exception as e:
+                    logger.debug(
+                        "open_tab goto failed for %s url=%s: %s",
+                        agent_id, url, e,
+                    )
                     try:
                         await new_page.close()
                     except Exception:
                         pass
                     inst.page = previous_page
-                    return {"success": False, "error": str(e)}
+                    return _err("service_unavailable", "Failed to navigate to URL")
 
-                try:
-                    inst.recent_referers.append(resolved_referer)
-                    inst.had_real_navigate = True
-                except Exception as e:
-                    logger.debug("open_tab referer state update failed: %s", e)
+                # Register page only after goto succeeds — a failed goto
+                # closes the page, so registering before would leak an
+                # entry in inst.page_ids per failed open_tab call.
+                page_id = inst._register_page(new_page)
+
+                inst.recent_referers.append(resolved_referer)
+                inst.had_real_navigate = True
 
                 inst.page = new_page
                 inst.refs = {}  # Stale refs from previous tab's snapshot
@@ -5365,15 +5376,19 @@ class BrowserManager:
                 }
                 if snapshot_after:
                     snap = await self._snapshot_impl(inst, agent_id)
-                    data["snapshot"] = snap.get("data") or {}
+                    if snap.get("success"):
+                        data["snapshot"] = snap.get("data") or {}
+                    else:
+                        data["snapshot_error"] = snap.get("error")
                 return {"success": True, "data": data}
             except Exception as e:
+                logger.debug("open_tab failed for %s: %s", agent_id, e)
                 try:
                     await new_page.close()
                 except Exception:
                     pass
                 inst.page = previous_page
-                return {"success": False, "error": str(e)}
+                return _err("service_unavailable", "open_tab failed")
 
     async def press_key(self, agent_id: str, key: str) -> dict:
         """Press a keyboard key or combination (e.g. 'Enter', 'Escape', 'Control+a').

--- a/tests/test_browser_service.py
+++ b/tests/test_browser_service.py
@@ -7403,13 +7403,15 @@ class TestFindText:
         mgr = self._make_manager()
         result = await mgr.find_text("agent1", "x" * 501)
         assert result["success"] is False
-        assert "500" in result["error"]
+        assert result["error"]["code"] == "invalid_input"
+        assert "500" in result["error"]["message"]
 
     @pytest.mark.asyncio
     async def test_find_text_query_empty_rejected(self):
         mgr = self._make_manager()
         result = await mgr.find_text("agent1", "")
         assert result["success"] is False
+        assert result["error"]["code"] == "invalid_input"
 
     @pytest.mark.asyncio
     async def test_find_text_scroll_true_scrolls_first_match(self):
@@ -7475,7 +7477,8 @@ class TestFindText:
             result = await mgr.find_text("agent1", "submit")
 
         assert result["success"] is False
-        assert "User has browser control" in result["error"]
+        assert result["error"]["code"] == "conflict"
+        assert "User has browser control" in result["error"]["message"]
 
     @pytest.mark.asyncio
     async def test_find_text_multi_match_preserves_order(self):
@@ -7715,7 +7718,8 @@ class TestOpenTab:
         with patch.object(BrowserManager, "get_or_start", return_value=inst):
             result = await mgr.open_tab("agent1", "file:///etc/passwd")
         assert result["success"] is False
-        assert "not allowed" in result["error"]
+        assert result["error"]["code"] == "invalid_input"
+        assert "not allowed" in result["error"]["message"]
 
     @pytest.mark.asyncio
     async def test_open_tab_rejects_javascript_url(self):
@@ -7727,7 +7731,8 @@ class TestOpenTab:
         with patch.object(BrowserManager, "get_or_start", return_value=inst):
             result = await mgr.open_tab("agent1", "javascript:alert(1)")
         assert result["success"] is False
-        assert "not allowed" in result["error"]
+        assert result["error"]["code"] == "invalid_input"
+        assert "not allowed" in result["error"]["message"]
 
     @pytest.mark.asyncio
     async def test_open_tab_goto_failure_closes_new_page(self):
@@ -7746,7 +7751,9 @@ class TestOpenTab:
             result = await mgr.open_tab("agent1", "https://example.org/")
 
         assert result["success"] is False
-        assert "ERR_CONNECTION_REFUSED" in result["error"]
+        assert result["error"]["code"] == "service_unavailable"
+        assert result["error"]["message"] == "Failed to navigate to URL"
+        assert result["error"]["retry_after_ms"] is None
         new_page.close.assert_awaited_once()
         assert inst.page is page0
 
@@ -7762,7 +7769,8 @@ class TestOpenTab:
             result = await mgr.open_tab("agent1", "https://example.org/")
 
         assert result["success"] is False
-        assert "User has browser control" in result["error"]
+        assert result["error"]["code"] == "conflict"
+        assert "User has browser control" in result["error"]["message"]
 
     @pytest.mark.asyncio
     async def test_open_tab_snapshot_after_returns_snapshot(self):
@@ -7908,6 +7916,66 @@ class TestOpenTab:
         assert result["data"]["page_id"]
         assert inst.page is new_page
         assert inst.refs == {}
+
+    @pytest.mark.asyncio
+    async def test_open_tab_surfaces_snapshot_after_error_separately(self):
+        """When snapshot_after fails, the tab still opened so success stays True
+        but the snapshot error is surfaced under ``snapshot_error`` instead of
+        being silently dropped into an empty ``snapshot`` dict."""
+        from src.browser.service import BrowserManager
+
+        mgr = self._make_manager()
+        inst, page0 = self._make_instance()
+
+        new_page = AsyncMock()
+        new_page.goto = AsyncMock()
+        new_page.title = AsyncMock(return_value="X")
+        new_page.url = "https://example.org/"
+        new_page.bring_to_front = AsyncMock()
+        inst.context.new_page = AsyncMock(return_value=new_page)
+        inst.context.pages = [page0, new_page]
+
+        snap_err = {
+            "code": "service_unavailable",
+            "message": "snapshot timed out",
+            "retry_after_ms": None,
+        }
+
+        async def fake_snapshot(self_mgr, _inst, _agent_id, **_kw):
+            return {"success": False, "error": snap_err}
+
+        with patch.object(BrowserManager, "get_or_start", return_value=inst), \
+             patch.object(BrowserManager, "_snapshot_impl", new=fake_snapshot):
+            result = await mgr.open_tab(
+                "agent1", "https://example.org/", snapshot_after=True,
+            )
+
+        assert result["success"] is True
+        assert "snapshot" not in result["data"]
+        assert result["data"]["snapshot_error"] == snap_err
+
+    @pytest.mark.asyncio
+    async def test_open_tab_goto_failure_does_not_leak_page_id(self):
+        """A failed goto closes the new page; its id() must not remain
+        registered in inst.page_ids — otherwise repeated failures grow the
+        dict unboundedly with stale entries."""
+        from src.browser.service import BrowserManager
+
+        mgr = self._make_manager()
+        inst, page0 = self._make_instance()
+        baseline = dict(inst.page_ids)
+
+        new_page = AsyncMock()
+        new_page.goto = AsyncMock(side_effect=Exception("boom"))
+        new_page.close = AsyncMock()
+        inst.context.new_page = AsyncMock(return_value=new_page)
+        inst.context.pages = [page0, new_page]
+
+        with patch.object(BrowserManager, "get_or_start", return_value=inst):
+            result = await mgr.open_tab("agent1", "https://example.org/")
+
+        assert result["success"] is False
+        assert inst.page_ids == baseline
 
 
 class TestShadowDOM:


### PR DESCRIPTION
Follow-up to merged PR #753. Third-pass review found 0 P0s but 3 substantive P1s in `browser_find_text` + `browser_open_tab`. This PR addresses all three plus minor dead-code removal.

## Summary

- **`open_tab(snapshot_after=True)` no longer swallows snapshot failures.** Previously the code did `data["snapshot"] = snap.get("data") or {}` even on `_snapshot_impl` failure — agents saw `snapshot: {}` and assumed empty page. Now: the tab still opens successfully, but a snapshot failure surfaces under `data.snapshot_error` so the agent can distinguish "empty page" from "snapshot subsystem broke".
- **`page_ids` no longer leaks on `goto()` failure.** `_register_page` was called before `goto`. On goto failure the page is closed and the previous tab restored, but the `id(new_page)` entry in the plain `inst.page_ids` dict (not a weakref) stayed forever. Repeated goto failures (flaky network, dead URLs) grew the dict unboundedly with stale `id()` keys that could later collide with recycled CPython object ids. Fixed by registering only after `goto` succeeds.
- **Error envelopes now match plan §2.3.** Both functions previously mixed flat `{success: false, error: "<str>"}` returns (validation paths) with structured `{success: false, error: {code, message, retry_after_ms}}` returns (inherited from `_snapshot_impl`). Plan §2.3 mandates structured for all new skills. Every error return in `find_text` and `open_tab` is now structured, via a new module-level `_err` helper.

Bonus polish: removed dead `try`/`except` around `inst.recent_referers.append(...)` / `inst.had_real_navigate = True` — `deque.append` cannot raise and assignment to a known attribute won't either.

## Test plan

- [x] New: `test_open_tab_surfaces_snapshot_after_error_separately`
- [x] New: `test_open_tab_goto_failure_does_not_leak_page_id`
- [x] Existing find_text/open_tab tests updated to read structured envelope (`error["code"]`, `error["message"]`)
- [x] `pytest tests/test_browser_service.py::TestFindText tests/test_browser_service.py::TestOpenTab -x -v` — 25/25 pass
- [x] `pytest tests/test_browser_service.py tests/test_builtins.py tests/test_permissions.py -x` — 607/607 pass
- [x] `ruff check src/browser/service.py` — clean

## Out of scope

The agent-side wrappers in `src/agent/builtins/browser_tool.py` (and sibling browser skills) still return flat `{error: "..."}` envelopes. That's a separate plan-wide cleanup — this PR's scope is the §2.3 inconsistency *within* `find_text` and `open_tab`.