### PR TITLE
Phase 6 §9.2: operator cookie/session import

### DIFF
--- a/src/agent/builtins/browser_tool.py
+++ b/src/agent/builtins/browser_tool.py
@@ -779,6 +779,50 @@ async def browser_open_tab(
 
 
 @skill(
+    name="browser_inspect_requests",
+    description=(
+        "List recent network requests from the current browser context "
+        "(URLs only, redacted; no bodies/headers). Useful for verifying "
+        "which third-party endpoints a page hit, debugging when a page "
+        "seems broken because adblock dropped requests, or confirming a "
+        "form POST went through. Returns up to 50 most-recent entries by "
+        "default. Set include_blocked=true to include adblock-suppressed "
+        "entries (verbose; usually you don't want this)."
+    ),
+    parameters={
+        "include_blocked": {
+            "type": "boolean",
+            "description": (
+                "Include requests blocked by the in-browser ad-blocker. "
+                "Default false — adblock-suppressed trackers are usually "
+                "noise. Set true when debugging missing analytics or "
+                "third-party widgets."
+            ),
+            "default": False,
+        },
+        "limit": {
+            "type": "integer",
+            "description": (
+                "Max number of newest-first entries to return. Default 50, "
+                "max 200 (the underlying buffer size). Values above 200 "
+                "are coerced to 200."
+            ),
+            "default": 50,
+        },
+    },
+    parallel_safe=False,
+)
+async def browser_inspect_requests(
+    include_blocked: bool = False, limit: int = 50, *, mesh_client=None,
+) -> dict:
+    """List recent network requests for the current browser context."""
+    return await _browser_command(
+        mesh_client, "inspect_requests",
+        {"include_blocked": bool(include_blocked), "limit": int(limit)},
+    )
+
+
+@skill(
     name="browser_detect_captcha",
     description=(
         "Detect CAPTCHAs (reCAPTCHA, hCaptcha, Cloudflare Turnstile) on the "

--- a/src/agent/builtins/browser_tool.py
+++ b/src/agent/builtins/browser_tool.py
@@ -787,7 +787,20 @@ async def browser_open_tab(
         "seems broken because adblock dropped requests, or confirming a "
         "form POST went through. Returns up to 50 most-recent entries by "
         "default. Set include_blocked=true to include adblock-suppressed "
-        "entries (verbose; usually you don't want this)."
+        "entries (verbose; usually you don't want this).\n\n"
+        "Buffer holds the most recent 200 requests per agent; older "
+        "entries are evicted automatically. URLs are redacted at "
+        "store-time (userinfo stripped, JWT-shaped path segments masked, "
+        "sensitive query values like token/api_key replaced with "
+        "[REDACTED]).\n\n"
+        "Each entry has: url (str, redacted), method (str), "
+        "resource_type (str, one of: document, stylesheet, image, media, "
+        "font, script, texttrack, xhr, fetch, eventsource, websocket, "
+        "manifest, other), ts (str, ISO-8601 UTC like "
+        "'2026-04-26T12:34:56Z'), status (int|null — currently always "
+        "null; reserved for future response-status capture), "
+        "blocked_by_adblock (bool), user_cancelled (bool), "
+        "failed_network (bool)."
     ),
     parameters={
         "include_blocked": {

--- a/src/browser/server.py
+++ b/src/browser/server.py
@@ -604,6 +604,23 @@ def create_browser_app(manager: BrowserManager, lifespan=None) -> FastAPI:
         await _apply_delay()
         return result
 
+    @app.post("/browser/{agent_id}/import_cookies")
+    async def import_cookies(agent_id: str, request: Request):
+        """Phase 6 §9.2 — operator-only cookie/session import.
+
+        NOT in ``KNOWN_BROWSER_ACTIONS`` — agents cannot reach this via
+        the ``/mesh/browser/command`` proxy. The dashboard endpoint calls
+        this route directly with the browser-service bearer token.
+        Validation and shape coercion happen upstream in the dashboard.
+        """
+        _verify_auth(request)
+        body = await request.json()
+        cookies = body.get("cookies")
+        if not isinstance(cookies, list):
+            raise HTTPException(400, "cookies must be a list")
+        result = await manager.import_cookies(agent_id, cookies)
+        return result
+
     # ── Settings ───────────────────────────────────────────────────────────
 
     @app.get("/browser/settings")

--- a/src/browser/server.py
+++ b/src/browser/server.py
@@ -604,6 +604,22 @@ def create_browser_app(manager: BrowserManager, lifespan=None) -> FastAPI:
         await _apply_delay()
         return result
 
+    @app.post("/browser/{agent_id}/inspect_requests")
+    async def inspect_requests(agent_id: str, request: Request):
+        """Phase 6 §9.1 — list recent (redacted) network requests for an agent."""
+        _verify_auth(request)
+        body = await request.json()
+        include_blocked = bool(body.get("include_blocked", False))
+        try:
+            limit = int(body.get("limit", 50))
+        except (TypeError, ValueError):
+            limit = 50
+        result = await manager.inspect_requests(
+            agent_id, include_blocked=include_blocked, limit=limit,
+        )
+        await _apply_delay()
+        return result
+
     # ── Settings ───────────────────────────────────────────────────────────
 
     @app.get("/browser/settings")

--- a/src/browser/service.py
+++ b/src/browser/service.py
@@ -108,6 +108,20 @@ def _resolve_filter_roles(filter_name: str | None) -> frozenset[str] | None:
     return preset
 
 
+def _iso8601_utc(ts_unix: float) -> str:
+    """Format a unix timestamp as ISO-8601 UTC with seconds precision.
+
+    Returns ``""`` when ``ts_unix`` is falsy (0 / None) so callers don't
+    have to special-case the absence of a timestamp.
+    """
+    if not ts_unix:
+        return ""
+    from datetime import datetime, timezone
+    return datetime.fromtimestamp(float(ts_unix), tz=timezone.utc).isoformat(
+        timespec="seconds",
+    ).replace("+00:00", "Z")
+
+
 def _err(
     code: str, message: str, retry_after_ms: int | None = None,
 ) -> dict:
@@ -1205,6 +1219,15 @@ class CamoufoxInstance:
         # exposes ``ok`` + ``mismatches`` + raw signal values for dashboard /
         # status endpoint consumers.
         self.probe_result: dict | None = None
+        # §9.1 network-inspection log. Bounded deque of recent
+        # ``request`` / ``requestfailed`` events, populated by listeners
+        # attached at the BrowserContext level so new tabs (in-page
+        # ``window.open()`` or ``browser_open_tab``) are covered too. URLs
+        # are redacted via ``shared.redaction.redact_url`` at store-time;
+        # the deque NEVER holds raw URLs. ``_network_attached`` is the
+        # idempotency flag for ``BrowserManager._attach_network_listeners``.
+        self.network_log: deque[dict] = deque(maxlen=200)
+        self._network_attached: bool = False
 
     def _register_page(self, page) -> str:
         """Assign a stable UUID to a Page if not already registered.
@@ -1837,6 +1860,13 @@ class BrowserManager:
             )
 
         inst = CamoufoxInstance(agent_id, browser, context, page)
+
+        # §9.1 wire request listeners at the BrowserContext level so new
+        # tabs (in-page ``window.open()`` or ``browser_open_tab``) inherit
+        # them automatically. Idempotent — also re-runs after browser RESET
+        # because RESET drops the whole instance and the next get_or_start
+        # creates a fresh one with ``_network_attached=False``.
+        self._attach_network_listeners(inst)
 
         # Discover the new X11 window for targeted focus
         wid = await self._discover_new_wid(wids_before)
@@ -5390,6 +5420,180 @@ class BrowserManager:
                 inst.page = previous_page
                 return _err("service_unavailable", "open_tab failed")
 
+    # ── §9.1 Network inspection ─────────────────────────────────
+
+    def _attach_network_listeners(self, inst: CamoufoxInstance) -> None:
+        """Wire BrowserContext-level ``request`` / ``requestfailed`` listeners.
+
+        Idempotent — second and subsequent calls return immediately. Listeners
+        are attached on the *context* so tabs opened later (via ``window.open()``
+        or :meth:`open_tab`) inherit them automatically. The current page is
+        also wired explicitly in case the context-level ``page`` event has
+        already fired for it before listeners landed.
+        """
+        if inst._network_attached:
+            return
+        try:
+            inst.context.on(
+                "page",
+                lambda p: p.on("request", lambda req: self._record_request(inst, req)),
+            )
+            if inst.page is not None:
+                inst.page.on("request", lambda req: self._record_request(inst, req))
+            inst.context.on(
+                "requestfailed",
+                lambda req: self._record_request_failed(inst, req),
+            )
+        except Exception as e:
+            # Listener wiring is best-effort: a Camoufox build that doesn't
+            # surface these events shouldn't take the browser down. The
+            # `inspect_requests` reader returns an empty list cleanly.
+            logger.debug(
+                "Network listener wiring failed for '%s': %s",
+                inst.agent_id, e,
+            )
+            return
+        inst._network_attached = True
+
+    def _record_request(self, inst: CamoufoxInstance, req) -> None:
+        """Record an outbound request. Listener; never raises."""
+        try:
+            from src.shared.redaction import redact_url
+            url = redact_url(getattr(req, "url", "") or "")
+            method = getattr(req, "method", "") or ""
+            resource_type = getattr(req, "resource_type", "") or ""
+            inst.network_log.append({
+                "url": url,
+                "method": method,
+                "resource_type": resource_type,
+                "ts": time.time(),
+                "status": None,
+                "blocked_by_adblock": False,
+                "user_cancelled": False,
+                "failed_network": False,
+            })
+        except Exception as e:
+            logger.debug("network listener record failed: %s", e)
+
+    def _record_request_failed(self, inst: CamoufoxInstance, req) -> None:
+        """Mark the matching log entry as blocked / cancelled / failed.
+
+        Updates by URL+method match if found, else discards the failure
+        update. ``requestfailed`` fires asynchronously and may overlap with
+        the request having already scrolled out of the maxlen=200 window.
+        Creating a phantom entry would mislead operators about traffic that
+        actually happened.
+        """
+        try:
+            from src.shared.redaction import redact_url
+            url = redact_url(getattr(req, "url", "") or "")
+            method = getattr(req, "method", "") or ""
+            failure = getattr(req, "failure", None)
+            # Playwright surfaces ``failure`` as a property; some bindings
+            # may expose it as a callable. Handle both.
+            if callable(failure):
+                try:
+                    failure = failure()
+                except Exception:
+                    failure = None
+            err = getattr(failure, "errorText", "") if failure else ""
+            if not isinstance(err, str):
+                err = str(err) if err else ""
+
+            blocked = False
+            cancelled = False
+            for marker in ("BLOCKED_BY_CLIENT", "CONTENT_BLOCKED", "BLOCKED_BY_POLICY"):
+                if marker in err:
+                    blocked = True
+                    break
+            # Why classify BINDING_ABORTED separately from blocked: user-
+            # cancelled is a real outcome (page nav interrupted, user hit
+            # stop), not adblock — agents debugging form submits should see
+            # these distinctly.
+            if not blocked and "BINDING_ABORTED" in err:
+                cancelled = True
+            failed_net = not (blocked or cancelled)
+
+            # Update the most recent matching entry. Reverse iteration so a
+            # rapid-fire request to the same URL+method picks up the freshest.
+            for entry in reversed(inst.network_log):
+                if entry["url"] == url and entry["method"] == method:
+                    entry["blocked_by_adblock"] = blocked
+                    entry["user_cancelled"] = cancelled
+                    entry["failed_network"] = failed_net
+                    return
+            # No match → discard. Do NOT append; would create a phantom entry.
+        except Exception as e:
+            logger.debug("network listener fail-record failed: %s", e)
+
+    async def inspect_requests(
+        self,
+        agent_id: str,
+        *,
+        include_blocked: bool = False,
+        limit: int = 50,
+    ) -> dict:
+        """Return a snapshot of recent network requests for ``agent_id``.
+
+        URLs in the deque are already redacted at store-time. The returned
+        ``requests`` list is sorted newest-first and capped at ``limit``
+        (which is itself capped at the deque maxlen of 200). When
+        ``include_blocked`` is False, entries flagged ``blocked_by_adblock``
+        are filtered out so agents aren't confused by adblock-suppressed
+        third-party trackers; the count of dropped entries is returned as
+        ``dropped_blocked``.
+        """
+        try:
+            limit = int(limit)
+        except (TypeError, ValueError):
+            limit = 50
+        if limit < 1:
+            limit = 1
+        if limit > 200:
+            limit = 200
+
+        inst = await self.get_or_start(agent_id)
+        inst.touch()
+        async with inst.lock:
+            if inst._user_control:
+                return _err(
+                    "conflict",
+                    "User has browser control — action paused until control is released.",
+                )
+            # Snapshot under the lock so we don't race a concurrent listener
+            # append. The deque itself is thread-safe for single op-pends but
+            # multi-step iteration + filter benefits from the lock.
+            entries = list(inst.network_log)
+            total = len(entries)
+            dropped = 0
+            visible: list[dict] = []
+            # Iterate newest-first.
+            for entry in reversed(entries):
+                if entry.get("blocked_by_adblock") and not include_blocked:
+                    dropped += 1
+                    continue
+                if len(visible) >= limit:
+                    continue
+                ts_unix = entry.get("ts") or 0
+                visible.append({
+                    "url": entry.get("url", ""),
+                    "method": entry.get("method", ""),
+                    "resource_type": entry.get("resource_type", ""),
+                    "ts": _iso8601_utc(ts_unix),
+                    "status": entry.get("status"),
+                    "blocked_by_adblock": bool(entry.get("blocked_by_adblock")),
+                    "user_cancelled": bool(entry.get("user_cancelled")),
+                    "failed_network": bool(entry.get("failed_network")),
+                })
+            return {
+                "success": True,
+                "data": {
+                    "requests": visible,
+                    "total": total,
+                    "dropped_blocked": dropped,
+                },
+            }
+
     async def press_key(self, agent_id: str, key: str) -> dict:
         """Press a keyboard key or combination (e.g. 'Enter', 'Escape', 'Control+a').
 
@@ -5516,3 +5720,4 @@ class BrowserManager:
                 }
             except Exception as e:
                 return {"success": False, "error": str(e)}
+

--- a/src/browser/service.py
+++ b/src/browser/service.py
@@ -5483,6 +5483,13 @@ class BrowserManager:
                 # rather than overwriting the same one. Stripped from the
                 # response payload by ``inspect_requests``.
                 "_failure_tagged": False,
+                # Pair ``requestfailed`` back to the exact Playwright
+                # Request object when possible. URL+method is retained as
+                # fallback for tests / bindings that synthesize separate
+                # objects for the failure callback, but exact object identity
+                # avoids mis-tagging a newer identical request when only an
+                # older one fails.
+                "_request_key": id(req),
             })
         except Exception as e:
             logger.debug("network listener record failed: %s", e)
@@ -5519,6 +5526,7 @@ class BrowserManager:
             err = getattr(failure, "errorText", "") if failure else ""
             if not isinstance(err, str):
                 err = str(err) if err else ""
+            request_key = id(req)
 
             blocked = False
             cancelled = False
@@ -5534,10 +5542,25 @@ class BrowserManager:
                 cancelled = True
             failed_net = not (blocked or cancelled)
 
-            # Update the newest matching entry that hasn't already been
-            # tagged. Reverse iteration so a rapid-fire request to the same
-            # URL+method picks up the freshest available slot. Skipping
-            # tagged entries makes parallel identical failures pair 1:1.
+            # Prefer the exact Request-object match. Playwright sends the
+            # same Request object to ``request`` and ``requestfailed``; using
+            # that identity prevents a failed older request from tagging a
+            # newer identical URL+method that is still in flight.
+            for entry in reversed(inst.network_log):
+                if (
+                    entry.get("_request_key") == request_key
+                    and not entry.get("_failure_tagged")
+                ):
+                    entry["blocked_by_adblock"] = blocked
+                    entry["user_cancelled"] = cancelled
+                    entry["failed_network"] = failed_net
+                    entry["_failure_tagged"] = True
+                    return
+
+            # Fallback for tests / alternate bindings that surface distinct
+            # request objects for failure events: update the newest matching
+            # entry that hasn't already been tagged. Reverse iteration keeps
+            # rapid-fire identical failures paired 1:1 via ``_failure_tagged``.
             for entry in reversed(inst.network_log):
                 if (
                     entry["url"] == url
@@ -5748,4 +5771,3 @@ class BrowserManager:
                 }
             except Exception as e:
                 return {"success": False, "error": str(e)}
-

--- a/src/browser/service.py
+++ b/src/browser/service.py
@@ -5516,3 +5516,51 @@ class BrowserManager:
                 }
             except Exception as e:
                 return {"success": False, "error": str(e)}
+
+    async def import_cookies(
+        self, agent_id: str, cookies: list[dict],
+    ) -> dict:
+        """Phase 6 §9.2: import operator-supplied cookies into the agent's
+        browser context.
+
+        Invoked by the operator-only dashboard endpoint — agents NEVER
+        call this. Validation, format detection (Playwright vs Netscape),
+        and shape coercion happen upstream in the dashboard helper
+        :func:`_validate_cookies` so this method receives a pre-validated
+        list of Playwright-shaped cookie dicts.
+
+        At-rest leak warning: Firefox stores cookies plaintext in
+        ``cookies.sqlite`` inside the agent profile dir — operators
+        handling high-value sessions must use encrypted volumes or
+        ephemeral profiles (see plan §13 risk register).
+        """
+        if not isinstance(cookies, list):
+            return _err("invalid_input", "cookies must be a list")
+        try:
+            inst = await self.get_or_start(agent_id)
+        except Exception as e:
+            logger.warning(
+                "import_cookies: failed to start browser for '%s': %s",
+                agent_id, e,
+            )
+            return _err("service_unavailable", "Browser unavailable")
+        inst.touch()
+        async with inst.lock:
+            try:
+                # Empty list is a valid no-op (count=0).
+                if cookies:
+                    await inst.context.add_cookies(cookies)
+                return {
+                    "success": True,
+                    "data": {"imported": len(cookies)},
+                }
+            except Exception as e:
+                # Playwright raises various TypeError / ValueError shapes
+                # when a cookie field is malformed. Sanitize so we never
+                # echo a cookie value back in the response. The upstream
+                # validator already rejects malformed entries; this is
+                # defense-in-depth against future Playwright shape changes.
+                msg = str(e)
+                if "value" in msg.lower():
+                    msg = "Playwright rejected cookie shape"
+                return _err("invalid_input", msg)

--- a/src/browser/service.py
+++ b/src/browser/service.py
@@ -5426,20 +5426,26 @@ class BrowserManager:
         """Wire BrowserContext-level ``request`` / ``requestfailed`` listeners.
 
         Idempotent — second and subsequent calls return immediately. Listeners
-        are attached on the *context* so tabs opened later (via ``window.open()``
-        or :meth:`open_tab`) inherit them automatically. The current page is
-        also wired explicitly in case the context-level ``page`` event has
-        already fired for it before listeners landed.
+        are attached on the *context*. Per Playwright docs the context-level
+        ``request`` event is "emitted when a request is issued from any pages
+        created through this context", so this single hook covers:
+
+        * the initial page (``inst.page``) without a separate per-page hookup,
+        * any pre-existing pages already in ``inst.context.pages`` (e.g. a
+          Camoufox profile that restored prior tabs at launch — rare, but
+          per-page wiring used to silently miss these),
+        * tabs opened later via in-page ``window.open()`` or
+          :meth:`open_tab`.
+
+        ``requestfailed`` is similarly context-scoped.
         """
         if inst._network_attached:
             return
         try:
             inst.context.on(
-                "page",
-                lambda p: p.on("request", lambda req: self._record_request(inst, req)),
+                "request",
+                lambda req: self._record_request(inst, req),
             )
-            if inst.page is not None:
-                inst.page.on("request", lambda req: self._record_request(inst, req))
             inst.context.on(
                 "requestfailed",
                 lambda req: self._record_request_failed(inst, req),
@@ -5471,6 +5477,12 @@ class BrowserManager:
                 "blocked_by_adblock": False,
                 "user_cancelled": False,
                 "failed_network": False,
+                # Internal pairing sentinel — set True the first time a
+                # ``requestfailed`` matches this entry so concurrent
+                # identical-URL failures pair to DIFFERENT log entries
+                # rather than overwriting the same one. Stripped from the
+                # response payload by ``inspect_requests``.
+                "_failure_tagged": False,
             })
         except Exception as e:
             logger.debug("network listener record failed: %s", e)
@@ -5483,6 +5495,14 @@ class BrowserManager:
         the request having already scrolled out of the maxlen=200 window.
         Creating a phantom entry would mislead operators about traffic that
         actually happened.
+
+        When two identical-URL requests fire in parallel and both fail
+        (e.g. two ``<img>`` loads of the same blocked tracker), each
+        ``requestfailed`` event tags a *different* log entry — we walk
+        newest-first and skip entries whose ``_failure_tagged`` is already
+        True. Without this, the second ``requestfailed`` would overwrite
+        the same entry and the first request would silently appear as
+        "successful" in the log.
         """
         try:
             from src.shared.redaction import redact_url
@@ -5514,15 +5534,23 @@ class BrowserManager:
                 cancelled = True
             failed_net = not (blocked or cancelled)
 
-            # Update the most recent matching entry. Reverse iteration so a
-            # rapid-fire request to the same URL+method picks up the freshest.
+            # Update the newest matching entry that hasn't already been
+            # tagged. Reverse iteration so a rapid-fire request to the same
+            # URL+method picks up the freshest available slot. Skipping
+            # tagged entries makes parallel identical failures pair 1:1.
             for entry in reversed(inst.network_log):
-                if entry["url"] == url and entry["method"] == method:
+                if (
+                    entry["url"] == url
+                    and entry["method"] == method
+                    and not entry.get("_failure_tagged")
+                ):
                     entry["blocked_by_adblock"] = blocked
                     entry["user_cancelled"] = cancelled
                     entry["failed_network"] = failed_net
+                    entry["_failure_tagged"] = True
                     return
-            # No match → discard. Do NOT append; would create a phantom entry.
+            # No untagged match → discard. Do NOT append; would create a
+            # phantom entry.
         except Exception as e:
             logger.debug("network listener fail-record failed: %s", e)
 

--- a/src/browser/service.py
+++ b/src/browser/service.py
@@ -5529,6 +5529,12 @@ class BrowserManager:
         :func:`_validate_cookies` so this method receives a pre-validated
         list of Playwright-shaped cookie dicts.
 
+        Merge semantics: this calls Playwright's ``add_cookies`` which
+        MERGES with the existing context — a (name, domain, path) tuple
+        collision overwrites the prior cookie; non-colliding entries are
+        appended. There is no "wipe and replace" — operators wanting a
+        clean slate should reset the agent profile first.
+
         At-rest leak warning: Firefox stores cookies plaintext in
         ``cookies.sqlite`` inside the agent profile dir — operators
         handling high-value sessions must use encrypted volumes or
@@ -5555,12 +5561,19 @@ class BrowserManager:
                     "data": {"imported": len(cookies)},
                 }
             except Exception as e:
-                # Playwright raises various TypeError / ValueError shapes
-                # when a cookie field is malformed. Sanitize so we never
-                # echo a cookie value back in the response. The upstream
-                # validator already rejects malformed entries; this is
-                # defense-in-depth against future Playwright shape changes.
-                msg = str(e)
-                if "value" in msg.lower():
-                    msg = "Playwright rejected cookie shape"
-                return _err("invalid_input", msg)
+                # Defense-in-depth: never echo a Playwright error back to
+                # the operator — earlier review noted that a substring
+                # heuristic ("value" in msg) was fragile, e.g. a future
+                # Playwright change that renamed the offending field
+                # (or used the cookie ``name``) could leak the secret.
+                # The upstream ``_validate_cookies`` already rejects
+                # malformed entries, so any error here is unexpected.
+                # Log raw error server-side ONLY; return a generic shape.
+                logger.warning(
+                    "import_cookies: Playwright add_cookies failed for "
+                    "'%s': %s", agent_id, e,
+                )
+                return _err(
+                    "invalid_input",
+                    "cookie import failed (see service logs)",
+                )

--- a/src/dashboard/server.py
+++ b/src/dashboard/server.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import contextlib
 import hashlib
+import ipaddress
 import json
 import os
 import re
@@ -17,6 +18,7 @@ import sqlite3
 import threading
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
+from urllib.parse import urlparse
 
 from fastapi import APIRouter, Depends, File, HTTPException, Request, UploadFile
 from fastapi.responses import FileResponse, HTMLResponse
@@ -153,26 +155,29 @@ _COOKIE_LIST_MAX_LEN = 1000                     # max cookies per import
 
 _VALID_SAMESITE = {"Lax": "Lax", "Strict": "Strict", "None": "None"}
 
-# Match a literal IPv4 (4-tuple) or IPv6 (bracketed). Cookie domains
-# matching these are dropped — Firefox stores them but the SSRF egress
-# filter inside the browser container would reject the requests anyway.
-_IPV4_DOMAIN_RE = re.compile(r"^\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}$")
-_IPV6_DOMAIN_RE = re.compile(r"^\[[0-9A-Fa-f:]+\]$")
-
-
 def _is_ip_literal_domain(domain: str) -> bool:
     """True when ``domain`` is a literal IPv4 or IPv6 address."""
     if not domain:
         return False
-    bare = domain.lstrip(".")
-    if _IPV4_DOMAIN_RE.match(bare):
-        # Defense: confirm each octet is in 0..255.
-        try:
-            octets = [int(o) for o in bare.split(".")]
-            return all(0 <= o <= 255 for o in octets)
-        except ValueError:
-            return False
-    return bool(_IPV6_DOMAIN_RE.match(bare))
+    bare = domain.strip().lstrip(".")
+    if bare.startswith("[") and bare.endswith("]"):
+        bare = bare[1:-1]
+    try:
+        ipaddress.ip_address(bare)
+    except ValueError:
+        return False
+    return True
+
+
+def _cookie_url_host(url: str) -> str | None:
+    """Return host for an http(s) cookie URL, or None when invalid."""
+    try:
+        parsed = urlparse(url)
+    except Exception:
+        return None
+    if parsed.scheme.lower() not in ("http", "https") or not parsed.hostname:
+        return None
+    return parsed.hostname
 
 
 def _parse_netscape(
@@ -288,11 +293,25 @@ def _validate_cookies(
         name = raw.get("name", "")
         value = raw.get("value", "")
         domain = raw.get("domain", "")
+        url = raw.get("url")
         path = raw.get("path", "/") or "/"
         if not isinstance(name, str) or not name:
             _drop("empty_name")
             continue
-        if not isinstance(domain, str) or not domain:
+        if domain is None:
+            domain = ""
+        if not isinstance(domain, str):
+            _drop("empty_domain")
+            continue
+        if url is None:
+            url = ""
+        if not isinstance(url, str):
+            _drop("invalid_url")
+            continue
+        if domain and url:
+            _drop("domain_url_conflict")
+            continue
+        if not domain and not url:
             _drop("empty_domain")
             continue
         if not isinstance(value, str):
@@ -301,16 +320,39 @@ def _validate_cookies(
         if len(value.encode("utf-8")) > _COOKIE_VALUE_MAX_BYTES:
             _drop("value_too_large")
             continue
-        if _is_ip_literal_domain(domain):
+        url_host: str | None = None
+        if url:
+            url_host = _cookie_url_host(url)
+            if url_host is None:
+                _drop("invalid_url")
+                continue
+            if _is_ip_literal_domain(url_host):
+                _drop("ip_domain_unsupported")
+                continue
+        if domain and _is_ip_literal_domain(domain):
             _drop("ip_domain_unsupported")
             continue
         # RFC 6265bis: __Host- prefix forbids an explicit domain.
         if name.startswith("__Host-") and domain:
             _drop("host_prefix_with_domain")
             continue
-        normalized: dict = {
-            "name": name, "value": value, "domain": domain, "path": path,
-        }
+        secure_raw = raw.get("secure")
+        secure = bool(secure_raw) if secure_raw is not None else False
+        if name.startswith("__Host-"):
+            if path != "/":
+                _drop("host_prefix_invalid_path")
+                continue
+            if not secure:
+                _drop("host_prefix_without_secure")
+                continue
+        normalized: dict = {"name": name, "value": value}
+        if url:
+            normalized["url"] = url
+            if path:
+                normalized["path"] = path
+        else:
+            normalized["domain"] = domain
+            normalized["path"] = path
         # SameSite normalize (case-insensitive) — drop entry on unknown.
         ss_raw = raw.get("sameSite")
         if ss_raw is not None:
@@ -332,8 +374,8 @@ def _validate_cookies(
         # httpOnly / secure — coerce to bool only when explicitly present.
         if "httpOnly" in raw:
             normalized["httpOnly"] = bool(raw["httpOnly"])
-        if "secure" in raw:
-            normalized["secure"] = bool(raw["secure"])
+        if secure_raw is not None:
+            normalized["secure"] = secure
         accepted.append(normalized)
 
     dropped = [

--- a/src/dashboard/server.py
+++ b/src/dashboard/server.py
@@ -175,7 +175,9 @@ def _is_ip_literal_domain(domain: str) -> bool:
     return bool(_IPV6_DOMAIN_RE.match(bare))
 
 
-def _parse_netscape(text: str) -> list[dict]:
+def _parse_netscape(
+    text: str, *, malformed: list[str] | None = None,
+) -> list[dict]:
     """Parse Netscape ``cookies.txt`` format → Playwright-shaped dicts.
 
     Netscape format: ``domain\tincludeSubdomains\tpath\tsecure\texpires\tname\tvalue``
@@ -183,8 +185,11 @@ def _parse_netscape(text: str) -> list[dict]:
     ``#HttpOnly_<domain>`` prefix which marks the cookie as HttpOnly.
 
     Malformed lines (wrong field count, non-numeric ``expires``) are
-    silently skipped — the upstream validator records the drop count. This
-    parser never raises.
+    silently skipped. When ``malformed`` is supplied, a sentinel string
+    describing the reason is appended for each skipped line so the caller
+    can surface a ``malformed_line`` drop count to the operator. This
+    parser never raises and never echoes the bad line content (which may
+    contain a cookie value).
     """
     result: list[dict] = []
     if not isinstance(text, str):
@@ -203,12 +208,16 @@ def _parse_netscape(text: str) -> list[dict]:
         # value may itself contain tabs in some exporters, so don't split unbounded.
         parts = line.split("\t")
         if len(parts) < 7:
+            if malformed is not None:
+                malformed.append("field_count")
             continue
         domain, _include_sub, path, secure, expires, name, *value_parts = parts
         value = "\t".join(value_parts) if value_parts else ""
         try:
             expires_int = int(float(expires))
         except (ValueError, TypeError):
+            if malformed is not None:
+                malformed.append("expires")
             continue
         result.append({
             "name": name,
@@ -249,6 +258,11 @@ def _validate_cookies(
         elif isinstance(payload, str) and "\t" in payload:
             detected = "netscape"
 
+    drop_counts: dict[str, int] = {}
+
+    def _drop(reason: str) -> None:
+        drop_counts[reason] = drop_counts.get(reason, 0) + 1
+
     if detected == "playwright":
         if not isinstance(payload, list):
             return [], [], None
@@ -256,15 +270,16 @@ def _validate_cookies(
     elif detected == "netscape":
         if not isinstance(payload, str):
             return [], [], None
-        items = _parse_netscape(payload)
+        # Capture per-line malformed reasons so the operator sees a count
+        # of dropped Netscape lines instead of a silent zero result.
+        malformed_lines: list[str] = []
+        items = _parse_netscape(payload, malformed=malformed_lines)
+        for _ in malformed_lines:
+            _drop("malformed_line")
     else:
         return [], [], None
 
     accepted: list[dict] = []
-    drop_counts: dict[str, int] = {}
-
-    def _drop(reason: str) -> None:
-        drop_counts[reason] = drop_counts.get(reason, 0) + 1
 
     for raw in items:
         if not isinstance(raw, dict):
@@ -741,6 +756,12 @@ def create_dashboard_router(
         agent_id: str, request: Request,
     ) -> dict:
         """Phase 6 §9.2 — operator-only cookie/session import.
+
+        Merge semantics: Playwright's ``BrowserContext.add_cookies``
+        MERGES with existing cookies. A (name, domain, path) collision
+        OVERWRITES the existing cookie; non-colliding cookies are
+        appended. There is no "wipe and replace" — to start clean,
+        reset the agent profile first.
 
         At-rest leak warning (see plan §13 risk register row "Imported
         cookies at rest in profile (plaintext)"): Firefox stores cookies

--- a/src/dashboard/server.py
+++ b/src/dashboard/server.py
@@ -34,6 +34,9 @@ if TYPE_CHECKING:
     from src.host.traces import TraceStore
 
 logger = setup_logging("dashboard.server")
+# Phase 6 §9.2: dedicated logger for cookie-import audit. Records domain
+# + cookie name only — NEVER the value (see _validate_cookies docstring).
+_cookie_audit_logger = setup_logging("dashboard.cookie_import")
 
 _HERE = Path(__file__).resolve().parent
 _TEMPLATES_DIR = _HERE / "templates"
@@ -125,6 +128,204 @@ def _wallet_chain_label(chain_id: str, cfg: dict) -> str:
     if "devnet" in chain_id or "sepolia" in chain_id:
         return f"{name} ({eco} Testnet)"
     return f"{name} ({eco} · {symbol})"
+
+
+# ── Phase 6 §9.2 — operator cookie/session import helpers ─────────────────
+# Pure functions split out for unit-testability. The dashboard endpoint
+# validates and shape-coerces operator-supplied cookie payloads here, then
+# hands a normalized Playwright-shaped list to the browser service.
+#
+# SECURITY INVARIANTS:
+#   • Cookie VALUES never appear in audit logs, error messages, or any
+#     return shape that crosses a process boundary. Only domain + name
+#     are logged.
+#   • Validation rejects cookies whose ``value`` is larger than 4 KiB
+#     (per cookie) and whole payloads larger than 256 KiB.
+#   • RFC 6265bis violations (`__Host-` with explicit domain) are
+#     dropped server-side; importing them is silently rejected by Firefox
+#     anyway and confuses operators.
+#   • IP-literal domains are dropped — Firefox stores them but our SSRF
+#     egress filter would block the requests, so importing is a footgun.
+
+_COOKIE_VALUE_MAX_BYTES = 4 * 1024              # per-cookie value cap
+_COOKIE_PAYLOAD_MAX_BYTES = 256 * 1024          # whole-payload cap (DoS guard)
+_COOKIE_LIST_MAX_LEN = 1000                     # max cookies per import
+
+_VALID_SAMESITE = {"Lax": "Lax", "Strict": "Strict", "None": "None"}
+
+# Match a literal IPv4 (4-tuple) or IPv6 (bracketed). Cookie domains
+# matching these are dropped — Firefox stores them but the SSRF egress
+# filter inside the browser container would reject the requests anyway.
+_IPV4_DOMAIN_RE = re.compile(r"^\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}$")
+_IPV6_DOMAIN_RE = re.compile(r"^\[[0-9A-Fa-f:]+\]$")
+
+
+def _is_ip_literal_domain(domain: str) -> bool:
+    """True when ``domain`` is a literal IPv4 or IPv6 address."""
+    if not domain:
+        return False
+    bare = domain.lstrip(".")
+    if _IPV4_DOMAIN_RE.match(bare):
+        # Defense: confirm each octet is in 0..255.
+        try:
+            octets = [int(o) for o in bare.split(".")]
+            return all(0 <= o <= 255 for o in octets)
+        except ValueError:
+            return False
+    return bool(_IPV6_DOMAIN_RE.match(bare))
+
+
+def _parse_netscape(text: str) -> list[dict]:
+    """Parse Netscape ``cookies.txt`` format → Playwright-shaped dicts.
+
+    Netscape format: ``domain\tincludeSubdomains\tpath\tsecure\texpires\tname\tvalue``
+    Lines starting with ``#`` are comments and skipped, EXCEPT the special
+    ``#HttpOnly_<domain>`` prefix which marks the cookie as HttpOnly.
+
+    Malformed lines (wrong field count, non-numeric ``expires``) are
+    silently skipped — the upstream validator records the drop count. This
+    parser never raises.
+    """
+    result: list[dict] = []
+    if not isinstance(text, str):
+        return result
+    for raw_line in text.splitlines():
+        line = raw_line.rstrip("\r\n")
+        if not line.strip():
+            continue
+        http_only = False
+        if line.startswith("#HttpOnly_"):
+            http_only = True
+            line = line[len("#HttpOnly_"):]
+        elif line.startswith("#"):
+            continue
+        # Fields: domain, includeSubdomains, path, secure, expires, name, value
+        # value may itself contain tabs in some exporters, so don't split unbounded.
+        parts = line.split("\t")
+        if len(parts) < 7:
+            continue
+        domain, _include_sub, path, secure, expires, name, *value_parts = parts
+        value = "\t".join(value_parts) if value_parts else ""
+        try:
+            expires_int = int(float(expires))
+        except (ValueError, TypeError):
+            continue
+        result.append({
+            "name": name,
+            "value": value,
+            "domain": domain,
+            "path": path or "/",
+            "secure": secure.strip().upper() == "TRUE",
+            "httpOnly": http_only,
+            "expires": expires_int,
+        })
+    return result
+
+
+def _validate_cookies(
+    payload: Any, *, fmt: str | None = None,
+) -> tuple[list[dict], list[dict], str | None]:
+    """Validate + normalize an operator cookie payload.
+
+    Returns ``(accepted, dropped, detected_format_or_None)``:
+      • ``accepted`` — list of Playwright-shaped cookie dicts ready to
+        push into ``BrowserContext.add_cookies``.
+      • ``dropped`` — list of ``{reason, count}`` aggregated by reason.
+      • ``detected_format_or_None`` — ``"playwright"`` | ``"netscape"`` | None.
+        ``None`` signals an unrecognized shape — callers should return a
+        400 ``invalid_input`` envelope.
+
+    Pure function: no I/O, no mutation of inputs. Suitable for unit tests
+    without HTTP plumbing.
+    """
+    detected: str | None = fmt
+    items: list[dict] = []
+
+    if detected is None:
+        if isinstance(payload, list) and (
+            not payload or isinstance(payload[0], dict)
+        ):
+            detected = "playwright"
+        elif isinstance(payload, str) and "\t" in payload:
+            detected = "netscape"
+
+    if detected == "playwright":
+        if not isinstance(payload, list):
+            return [], [], None
+        items = list(payload)
+    elif detected == "netscape":
+        if not isinstance(payload, str):
+            return [], [], None
+        items = _parse_netscape(payload)
+    else:
+        return [], [], None
+
+    accepted: list[dict] = []
+    drop_counts: dict[str, int] = {}
+
+    def _drop(reason: str) -> None:
+        drop_counts[reason] = drop_counts.get(reason, 0) + 1
+
+    for raw in items:
+        if not isinstance(raw, dict):
+            _drop("not_a_dict")
+            continue
+        name = raw.get("name", "")
+        value = raw.get("value", "")
+        domain = raw.get("domain", "")
+        path = raw.get("path", "/") or "/"
+        if not isinstance(name, str) or not name:
+            _drop("empty_name")
+            continue
+        if not isinstance(domain, str) or not domain:
+            _drop("empty_domain")
+            continue
+        if not isinstance(value, str):
+            _drop("invalid_value_type")
+            continue
+        if len(value.encode("utf-8")) > _COOKIE_VALUE_MAX_BYTES:
+            _drop("value_too_large")
+            continue
+        if _is_ip_literal_domain(domain):
+            _drop("ip_domain_unsupported")
+            continue
+        # RFC 6265bis: __Host- prefix forbids an explicit domain.
+        if name.startswith("__Host-") and domain:
+            _drop("host_prefix_with_domain")
+            continue
+        normalized: dict = {
+            "name": name, "value": value, "domain": domain, "path": path,
+        }
+        # SameSite normalize (case-insensitive) — drop entry on unknown.
+        ss_raw = raw.get("sameSite")
+        if ss_raw is not None:
+            if not isinstance(ss_raw, str):
+                _drop("invalid_samesite")
+                continue
+            ss_norm = _VALID_SAMESITE.get(ss_raw.strip().capitalize())
+            if ss_norm is None:
+                _drop("invalid_samesite")
+                continue
+            normalized["sameSite"] = ss_norm
+        # expires: must be numeric (int or float). Strings rejected.
+        if "expires" in raw and raw["expires"] is not None:
+            exp = raw["expires"]
+            if isinstance(exp, bool) or not isinstance(exp, (int, float)):
+                _drop("invalid_expires")
+                continue
+            normalized["expires"] = int(exp)
+        # httpOnly / secure — coerce to bool only when explicitly present.
+        if "httpOnly" in raw:
+            normalized["httpOnly"] = bool(raw["httpOnly"])
+        if "secure" in raw:
+            normalized["secure"] = bool(raw["secure"])
+        accepted.append(normalized)
+
+    dropped = [
+        {"reason": reason, "count": count}
+        for reason, count in sorted(drop_counts.items())
+    ]
+    return accepted, dropped, detected
 
 
 def create_dashboard_router(
@@ -471,6 +672,293 @@ def create_dashboard_router(
         except Exception as e:
             logger.warning("Browser reset failed for '%s': %s", agent_id, e)
             raise HTTPException(500, "Browser reset failed")
+
+    # ── Phase 6 §9.2 — operator cookie/session import ────────────────────
+    # In-memory rate limiter keyed by (operator_session_user, agent_id).
+    # 60-min sliding window; capacity 10. Limiter state lives on this
+    # router instance — restarting the engine resets the window which is
+    # the desired behavior (operators rarely depend on the precise number
+    # surviving a process boundary).
+    _COOKIE_IMPORT_LIMIT = 10
+    _COOKIE_IMPORT_WINDOW_S = 60 * 60
+    _cookie_import_buckets: dict[tuple[str, str], list[float]] = {}
+    _cookie_import_lock = threading.Lock()
+
+    def _cookie_import_check_rate_limit(
+        operator: str, agent_id: str,
+    ) -> tuple[bool, int]:
+        """Sliding-window rate limit. Returns (allowed, retry_after_ms).
+
+        ``retry_after_ms`` is 0 when ``allowed`` is True; otherwise it is
+        the time until the oldest event in the window expires.
+        """
+        import time as _time
+        now = _time.time()
+        cutoff = now - _COOKIE_IMPORT_WINDOW_S
+        key = (operator, agent_id)
+        with _cookie_import_lock:
+            bucket = _cookie_import_buckets.setdefault(key, [])
+            # Drop entries outside the window in-place.
+            bucket[:] = [t for t in bucket if t > cutoff]
+            if len(bucket) >= _COOKIE_IMPORT_LIMIT:
+                oldest = bucket[0]
+                retry_after_ms = max(
+                    1, int((oldest + _COOKIE_IMPORT_WINDOW_S - now) * 1000),
+                )
+                return False, retry_after_ms
+            bucket.append(now)
+            return True, 0
+
+    def _cookie_envelope_err(
+        code: str, message: str, retry_after_ms: int | None = None,
+    ) -> dict:
+        """Build a §2.3 error envelope for cookie-import responses."""
+        return {
+            "success": False,
+            "error": {
+                "code": code,
+                "message": message,
+                "retry_after_ms": retry_after_ms,
+            },
+        }
+
+    def _operator_session_id(request: Request) -> str:
+        """Derive a stable per-session identifier for rate-limiting + audit.
+
+        The ``ol_session`` cookie is an HMAC of an expiry; there is no
+        per-user identity (the engine has a single operator). We hash the
+        cookie value so the audit log records a stable identifier without
+        echoing the cookie itself. Empty cookie (dev mode) → "operator".
+        """
+        raw = request.cookies.get("ol_session", "")
+        if not raw:
+            return "operator"
+        digest = hashlib.sha256(raw.encode()).hexdigest()[:12]
+        return f"operator:{digest}"
+
+    @api_router.post("/api/agents/{agent_id}/browser/import_cookies")
+    async def api_browser_import_cookies(
+        agent_id: str, request: Request,
+    ) -> dict:
+        """Phase 6 §9.2 — operator-only cookie/session import.
+
+        At-rest leak warning (see plan §13 risk register row "Imported
+        cookies at rest in profile (plaintext)"): Firefox stores cookies
+        in ``cookies.sqlite`` UNENCRYPTED inside the agent profile. This
+        endpoint does NOT silently mitigate that — operators handling
+        high-value sessions are expected to use encrypted volumes or
+        ephemeral profiles. Audit log records domain + cookie name ONLY.
+        """
+        # Choice (per plan §9.2): we hit the browser service directly via
+        # `runtime.browser_service_url` rather than going through
+        # /mesh/browser/command. Rationale: this is operator-only — adding
+        # it to KNOWN_BROWSER_ACTIONS would expose it to agents.
+        from src.browser import flags as _flags
+
+        operator = _operator_session_id(request)
+
+        if agent_id not in agent_registry:
+            raise HTTPException(404, "Agent not found")
+
+        # Kill-switch ─ honor BROWSER_COOKIE_IMPORT_DISABLED.
+        if _flags.get_bool("BROWSER_COOKIE_IMPORT_DISABLED", False):
+            raise HTTPException(
+                403,
+                detail=_cookie_envelope_err(
+                    "forbidden",
+                    "Cookie import disabled by operator policy",
+                ),
+            )
+
+        # Rate-limit pre-check (10/hr per (operator, agent_id)).
+        allowed, retry_ms = _cookie_import_check_rate_limit(operator, agent_id)
+        if not allowed:
+            raise HTTPException(
+                429,
+                detail=_cookie_envelope_err(
+                    "conflict",
+                    "rate limit exceeded",
+                    retry_after_ms=retry_ms,
+                ),
+            )
+
+        # Read raw body once. Enforce 256 KiB DoS guard before JSON parse
+        # so we don't allocate a fat string for an attacker payload.
+        raw = await request.body()
+        if len(raw) > _COOKIE_PAYLOAD_MAX_BYTES:
+            raise HTTPException(
+                413,
+                detail=_cookie_envelope_err(
+                    "size_limit",
+                    f"payload exceeds {_COOKIE_PAYLOAD_MAX_BYTES} bytes",
+                ),
+            )
+
+        try:
+            body = json.loads(raw.decode("utf-8")) if raw else {}
+        except (UnicodeDecodeError, json.JSONDecodeError):
+            raise HTTPException(
+                400,
+                detail=_cookie_envelope_err(
+                    "invalid_input", "request body is not valid JSON",
+                ),
+            )
+
+        if not isinstance(body, dict):
+            raise HTTPException(
+                400,
+                detail=_cookie_envelope_err(
+                    "invalid_input",
+                    "request body must be a JSON object",
+                ),
+            )
+
+        # Format detection: explicit ``format`` field overrides auto-detect.
+        # Payload may live under ``cookies`` (playwright list or netscape
+        # text) — also accept the bare list/string for back-compat with
+        # the simpler curl-style input.
+        explicit_fmt = body.get("format")
+        if explicit_fmt is not None and explicit_fmt not in ("playwright", "netscape"):
+            raise HTTPException(
+                400,
+                detail=_cookie_envelope_err(
+                    "invalid_input",
+                    "format must be 'playwright' or 'netscape'",
+                ),
+            )
+
+        payload = body.get("cookies", body)
+        if isinstance(payload, dict) and "cookies" not in payload:
+            # Caller passed the entire body as the cookies field by accident.
+            raise HTTPException(
+                400,
+                detail=_cookie_envelope_err(
+                    "invalid_input", "missing 'cookies' field",
+                ),
+            )
+
+        accepted, dropped, detected_fmt = _validate_cookies(
+            payload, fmt=explicit_fmt,
+        )
+        if detected_fmt is None:
+            raise HTTPException(
+                400,
+                detail=_cookie_envelope_err(
+                    "invalid_input",
+                    "unable to detect cookie format — supply 'format' or use "
+                    "Playwright JSON list / Netscape TSV string",
+                ),
+            )
+
+        # List-length cap applied AFTER parsing (Netscape format may have
+        # supplied >1000 lines).
+        if len(accepted) + sum(d["count"] for d in dropped) > _COOKIE_LIST_MAX_LEN:
+            raise HTTPException(
+                413,
+                detail=_cookie_envelope_err(
+                    "size_limit",
+                    f"more than {_COOKIE_LIST_MAX_LEN} cookies in payload",
+                ),
+            )
+
+        # Audit log — domain + name only. NEVER cookie values.
+        # _COOKIE_AUDIT_VALUE_EXCLUSION_GUARANTEE: the keys passed to
+        # the logger here are an explicit allowlist; cookie ``value`` is
+        # NOT included by construction. A unit test (test_audit_log_no_value)
+        # asserts this property holds against a corpus including JWT,
+        # Bearer, and SigV4-shaped values.
+        domains = sorted({c["domain"] for c in accepted if c.get("domain")})
+        names = sorted({c["name"] for c in accepted if c.get("name")})
+        _cookie_audit_logger.info(
+            "cookie_import operator=%s agent_id=%s count=%d domains=%s "
+            "names=%s format=%s dropped=%s",
+            operator, agent_id, len(accepted),
+            json.dumps(domains), json.dumps(names),
+            detected_fmt, json.dumps(dropped),
+        )
+        if blackboard is not None:
+            try:
+                blackboard.log_audit(
+                    action="cookie_import",
+                    target=agent_id,
+                    actor=operator,
+                    field=detected_fmt,
+                    after_value=json.dumps({
+                        "count": len(accepted),
+                        "domains": domains,
+                        "names": names,
+                        "dropped": dropped,
+                    }),
+                )
+            except Exception as e:
+                logger.warning("Failed to write cookie_import audit row: %s", e)
+
+        # Push to browser service.
+        if not runtime or not getattr(runtime, "browser_service_url", ""):
+            raise HTTPException(
+                503,
+                detail=_cookie_envelope_err(
+                    "service_unavailable", "Browser service not available",
+                ),
+            )
+        try:
+            browser_auth = getattr(runtime, "browser_auth_token", "")
+            headers: dict[str, str] = {}
+            if browser_auth:
+                headers["Authorization"] = f"Bearer {browser_auth}"
+            resp = await _dashboard_browser_client.post(
+                f"{runtime.browser_service_url}/browser/{agent_id}/import_cookies",
+                json={"cookies": accepted},
+                headers=headers,
+                timeout=30,
+            )
+        except Exception as e:
+            logger.warning("Cookie import push to browser service failed: %s", e)
+            raise HTTPException(
+                503,
+                detail=_cookie_envelope_err(
+                    "service_unavailable",
+                    "Browser service unreachable",
+                ),
+            )
+        if resp.status_code >= 500:
+            raise HTTPException(
+                503,
+                detail=_cookie_envelope_err(
+                    "service_unavailable",
+                    f"Browser service returned {resp.status_code}",
+                ),
+            )
+        try:
+            svc_payload = resp.json()
+        except Exception:
+            raise HTTPException(
+                503,
+                detail=_cookie_envelope_err(
+                    "service_unavailable",
+                    "Browser service returned non-JSON response",
+                ),
+            )
+        # Browser service may have its own dropped/imported counts; merge.
+        if not svc_payload.get("success"):
+            err = svc_payload.get("error") or {}
+            return {
+                "success": False,
+                "error": {
+                    "code": err.get("code", "service_unavailable"),
+                    "message": err.get("message", "import failed"),
+                    "retry_after_ms": err.get("retry_after_ms"),
+                },
+            }
+        svc_data = svc_payload.get("data") or {}
+        return {
+            "success": True,
+            "data": {
+                "imported": svc_data.get("imported", len(accepted)),
+                "dropped": dropped,
+                "format": detected_fmt,
+            },
+        }
 
     @api_router.get("/api/agent-templates")
     async def api_agent_templates() -> list:

--- a/src/dashboard/templates/index.html
+++ b/src/dashboard/templates/index.html
@@ -1832,6 +1832,125 @@
                 ></iframe>
               </div>
             </div>
+            <!-- Phase 6 §9.2 — Operator cookie/session import.
+                 Operator-only. State lives in `x-data` ONLY (never
+                 localStorage) — cookie text is high-trust and persisting
+                 it would cross a security boundary. CSRF header is
+                 injected automatically by the global fetch wrapper. -->
+            <div x-show="agentDetail?.vnc_url && selectedAgent !== 'operator'" x-cloak
+              x-data="{
+                ciOpen: false,
+                ciMode: 'playwright',
+                ciPlaywrightText: '',
+                ciNetscapeText: '',
+                ciSubmitting: false,
+                ciResult: null,
+                ciError: null,
+                async ciSubmit() {
+                  this.ciSubmitting = true;
+                  this.ciResult = null;
+                  this.ciError = null;
+                  try {
+                    let payload;
+                    if (this.ciMode === 'playwright') {
+                      try {
+                        payload = { format: 'playwright', cookies: JSON.parse(this.ciPlaywrightText) };
+                      } catch (e) {
+                        this.ciError = 'Playwright cookies must be valid JSON: ' + e.message;
+                        return;
+                      }
+                    } else {
+                      payload = { format: 'netscape', cookies: this.ciNetscapeText };
+                    }
+                    const resp = await fetch(
+                      `${window.__config.apiBase}/agents/${selectedAgent}/browser/import_cookies`,
+                      {
+                        method: 'POST',
+                        headers: { 'Content-Type': 'application/json' },
+                        body: JSON.stringify(payload),
+                      }
+                    );
+                    const data = await resp.json().catch(() => ({}));
+                    if (!resp.ok || !data.success) {
+                      const e = (data && data.detail && data.detail.error) || (data && data.error) || {};
+                      this.ciError = e.message || `Import failed (HTTP ${resp.status})`;
+                      if (e.retry_after_ms) {
+                        this.ciError += ` — retry in ${Math.ceil(e.retry_after_ms / 1000)}s`;
+                      }
+                      return;
+                    }
+                    this.ciResult = data.data;
+                    // Clear inputs on success so secrets don't linger in DOM.
+                    this.ciPlaywrightText = '';
+                    this.ciNetscapeText = '';
+                  } finally {
+                    this.ciSubmitting = false;
+                  }
+                }
+              }"
+              class="bg-gray-900 border border-gray-800 rounded-lg mb-5 overflow-hidden">
+              <div class="flex items-center justify-between px-4 py-2 border-b border-gray-800 cursor-pointer"
+                @click="ciOpen = !ciOpen">
+                <div class="flex items-center gap-2">
+                  <span class="text-xs text-gray-400 uppercase tracking-wider">Cookie / Session Import</span>
+                  <span class="text-[10px] text-amber-400/80 bg-amber-900/20 border border-amber-800/30 rounded px-1.5 py-0.5">operator-only</span>
+                </div>
+                <span class="text-xs text-gray-500" x-text="ciOpen ? '−' : '+'"></span>
+              </div>
+              <div x-show="ciOpen" x-cloak class="p-4 space-y-3">
+                <div class="text-[11px] text-amber-300/80 bg-amber-900/10 border border-amber-900/30 rounded px-2 py-1.5">
+                  Imported cookies are stored UNENCRYPTED in the agent's Firefox
+                  profile (<code>cookies.sqlite</code>). For high-value sessions,
+                  use an encrypted volume or treat the profile as ephemeral.
+                </div>
+                <div class="flex items-center gap-3">
+                  <label class="flex items-center gap-1.5 text-xs text-gray-300 cursor-pointer">
+                    <input type="radio" name="ci-mode" value="playwright"
+                      x-model="ciMode" class="accent-indigo-500"/>
+                    Playwright JSON
+                  </label>
+                  <label class="flex items-center gap-1.5 text-xs text-gray-300 cursor-pointer">
+                    <input type="radio" name="ci-mode" value="netscape"
+                      x-model="ciMode" class="accent-indigo-500"/>
+                    Netscape (cookies.txt)
+                  </label>
+                </div>
+                <textarea x-show="ciMode === 'playwright'"
+                  x-model="ciPlaywrightText"
+                  placeholder='[{"name": "sid", "value": "...", "domain": ".example.com", "path": "/", "expires": 1735689600, "httpOnly": true, "secure": true, "sameSite": "Lax"}]'
+                  spellcheck="false" autocomplete="off"
+                  class="w-full h-32 text-xs font-mono bg-gray-950 border border-gray-800 rounded p-2 text-gray-200 focus:border-indigo-500 focus:outline-none"></textarea>
+                <textarea x-show="ciMode === 'netscape'" x-cloak
+                  x-model="ciNetscapeText"
+                  placeholder="# Netscape HTTP Cookie File&#10;.example.com&#9;TRUE&#9;/&#9;TRUE&#9;1735689600&#9;sid&#9;..."
+                  spellcheck="false" autocomplete="off"
+                  class="w-full h-32 text-xs font-mono bg-gray-950 border border-gray-800 rounded p-2 text-gray-200 focus:border-indigo-500 focus:outline-none"></textarea>
+                <div class="flex items-center justify-between">
+                  <button @click="ciSubmit()"
+                    :disabled="ciSubmitting || (ciMode === 'playwright' ? !ciPlaywrightText.trim() : !ciNetscapeText.trim())"
+                    class="px-3 py-1.5 text-xs rounded bg-indigo-600 hover:bg-indigo-500 text-white disabled:opacity-40 disabled:cursor-not-allowed transition-colors">
+                    <span x-show="!ciSubmitting">Import</span>
+                    <span x-show="ciSubmitting" x-cloak>Importing...</span>
+                  </button>
+                  <span class="text-[10px] text-gray-600">Rate limit: 10/hr per agent</span>
+                </div>
+                <div x-show="ciError" x-cloak
+                  class="text-xs text-red-300 bg-red-900/20 border border-red-800/30 rounded px-2 py-1.5"
+                  x-text="ciError"></div>
+                <div x-show="ciResult" x-cloak
+                  class="text-xs text-emerald-300 bg-emerald-900/20 border border-emerald-800/30 rounded px-2 py-1.5">
+                  <span>Imported </span><span x-text="ciResult?.imported || 0"></span><span> cookie(s) (format: </span><span x-text="ciResult?.format || ''"></span><span>)</span>
+                  <template x-if="ciResult?.dropped && ciResult.dropped.length">
+                    <div class="mt-1 text-amber-300/80">
+                      Dropped:
+                      <template x-for="d in ciResult.dropped" :key="d.reason">
+                        <span class="inline-block mr-2"><span x-text="d.reason"></span> (<span x-text="d.count"></span>)</span>
+                      </template>
+                    </div>
+                  </template>
+                </div>
+              </div>
+            </div>
             <!-- 2-column detail layout -->
             <div class="grid grid-cols-1 md:grid-cols-5 gap-5 mb-5 chat-grid">
               <!-- Left column: Identity panel -->

--- a/src/dashboard/templates/index.html
+++ b/src/dashboard/templates/index.html
@@ -1903,6 +1903,12 @@
                   profile (<code>cookies.sqlite</code>). For high-value sessions,
                   use an encrypted volume or treat the profile as ephemeral.
                 </div>
+                <div class="text-[11px] text-gray-400/90 bg-gray-800/40 border border-gray-700/40 rounded px-2 py-1.5">
+                  Imports MERGE with existing cookies — a collision on
+                  (name + domain + path) overwrites the prior cookie; everything
+                  else is appended. Reset the agent profile first if you need a
+                  clean slate.
+                </div>
                 <div class="flex items-center gap-3">
                   <label class="flex items-center gap-1.5 text-xs text-gray-300 cursor-pointer">
                     <input type="radio" name="ci-mode" value="playwright"

--- a/src/host/permissions.py
+++ b/src/host/permissions.py
@@ -42,6 +42,8 @@ KNOWN_BROWSER_ACTIONS: frozenset[str] = frozenset({
     "upload_file", "download",
     # Phase 5 §8.5 / §8.6 default-allow read-only / nav-equivalent actions.
     "find_text", "open_tab",
+    # Phase 6 §9.1 read-only network inspection.
+    "inspect_requests",
 })
 
 # Back-compat alias — retained so `host/server.py` and test fixtures that

--- a/src/host/server.py
+++ b/src/host/server.py
@@ -2910,6 +2910,24 @@ def create_mesh_app(
                 except ValueError as e:
                     raise HTTPException(400, str(e))
 
+        # Phase 6 §9.1 operator kill-switch for the network-inspection
+        # surface. Mirrors the BROWSER_DOWNLOADS_DISABLED pattern so
+        # operators can disable read-only request logging fleet-wide
+        # without removing the action from `browser_actions` per agent.
+        if action == "inspect_requests":
+            from src.browser.flags import get_bool
+            if get_bool(
+                "BROWSER_NETWORK_INSPECT_DISABLED", False, agent_id=req_agent_id,
+            ):
+                raise HTTPException(403, detail={
+                    "success": False,
+                    "error": {
+                        "code": "forbidden",
+                        "message": "Network inspection disabled by operator",
+                        "retry_after_ms": None,
+                    },
+                })
+
         # Check for browser service restart — re-push proxy config for ALL agents
         try:
             restarted = await _check_browser_boot_id_changed()

--- a/tests/test_browser_inspect_requests.py
+++ b/tests/test_browser_inspect_requests.py
@@ -63,14 +63,18 @@ def _make_instance_with_listeners():
     """Return a CamoufoxInstance with mocked context/page wired by listeners.
 
     The mocks capture handlers passed to ``.on(...)`` so the test can fire
-    them synchronously.
+    them synchronously. Listeners are attached at the *context* level
+    (``request`` + ``requestfailed``), so per-page ``request`` events from
+    any page in the context are covered by the single context handler. The
+    ``page_handlers`` dict is retained for backward-compat with tests that
+    expect the four-tuple shape, but is unused for new wiring.
     """
     from src.browser.service import BrowserManager, CamoufoxInstance
 
     mgr = BrowserManager.__new__(BrowserManager)
 
-    # Track context listeners in a dict so we can fire ``page`` / ``requestfailed``.
-    context_handlers: dict[str, list] = {"page": [], "requestfailed": []}
+    # Track context listeners in a dict so we can fire them synchronously.
+    context_handlers: dict[str, list] = {"request": [], "requestfailed": []}
 
     def _ctx_on(event: str, handler):
         context_handlers.setdefault(event, []).append(handler)
@@ -78,7 +82,9 @@ def _make_instance_with_listeners():
     context = MagicMock()
     context.on = MagicMock(side_effect=_ctx_on)
 
-    # Page mock: same trick — ``request`` handlers stored, callable via _fire.
+    # Page mock retained for tests that may still poke at it. Per-page
+    # ``request`` listeners are no longer attached by the implementation —
+    # see ``_attach_network_listeners`` which uses context-scope events.
     page_handlers: dict[str, list] = {}
 
     def _page_on(event: str, handler):
@@ -491,23 +497,28 @@ class TestResetClearsAndReattaches:
 
         mgr._attach_network_listeners(fresh)
         assert fresh._network_attached is True
-        # context-level listeners wired for ``page`` and ``requestfailed``.
+        # Context-level listeners wired for ``request`` and ``requestfailed`` —
+        # the single context-scope ``request`` event covers every page
+        # in the context (existing pages and new tabs alike), so per-page
+        # listener wiring is no longer needed.
         events = [call.args[0] for call in fresh_ctx.on.call_args_list]
-        assert "page" in events
+        assert "request" in events
         assert "requestfailed" in events
 
 
 # ───────────────────────────────────────────────────────────────────────
-# 10. Context-level listener wires per-request handler on new pages
+# 10. Context-level ``request`` listener covers every page in the context
 # ───────────────────────────────────────────────────────────────────────
 
 
 class TestContextLevelPageListener:
-    def test_new_page_inherits_request_handler(self):
-        """Simulate context.emit('page', new_page) firing the registered handler.
-
-        The handler we registered should attach a per-page ``request``
-        listener; firing that listener should record into ``network_log``.
+    def test_context_level_request_listener_records_for_any_page(self):
+        """Per Playwright, ``BrowserContext.on('request', ...)`` fires for
+        requests issued by ANY page in the context — both pre-existing
+        pages (e.g. profile-restored tabs) and pages opened later via
+        in-page ``window.open()`` or :meth:`open_tab`. We rely on this
+        single hook instead of per-page wiring + a ``page`` event hookup,
+        which used to silently miss pre-existing pages.
         """
         from src.browser.service import BrowserManager, CamoufoxInstance
 
@@ -527,27 +538,24 @@ class TestContextLevelPageListener:
         inst = CamoufoxInstance("agent1", MagicMock(), context, existing_page)
         mgr._attach_network_listeners(inst)
 
-        # Now fire a context-level "page" event with a brand-new Mock Page.
-        new_page = MagicMock()
-        new_page_handlers: dict[str, list] = {}
+        # Only context-level listeners should be wired — no per-page
+        # ``request`` hooks. The page mock should have received zero
+        # ``.on('request', ...)`` calls.
+        page_on_events = [c.args[0] for c in existing_page.on.call_args_list]
+        assert "request" not in page_on_events, (
+            "Per-page request listener was wired; "
+            f"context-level should be sufficient. Saw: {page_on_events}"
+        )
 
-        def _new_page_on(event: str, handler):
-            new_page_handlers.setdefault(event, []).append(handler)
+        # Context handlers must include both ``request`` and ``requestfailed``.
+        assert "request" in ctx_handlers
+        assert "requestfailed" in ctx_handlers
+        assert len(ctx_handlers["request"]) == 1
 
-        new_page.on = MagicMock(side_effect=_new_page_on)
-
-        # The registered context handler should attach a request handler
-        # to the new page when invoked.
-        for h in ctx_handlers["page"]:
-            h(new_page)
-
-        # The new_page now has a "request" listener registered.
-        assert "request" in new_page_handlers
-        assert len(new_page_handlers["request"]) == 1
-
-        # Firing that listener with a Mock request should record into log.
+        # Fire the context-level request handler — it should record into
+        # the network log regardless of which page emitted the request.
         req = _make_mock_request("https://newtab.example.com/asset.js")
-        new_page_handlers["request"][0](req)
+        ctx_handlers["request"][0](req)
 
         assert len(inst.network_log) == 1
         assert "/asset.js" in inst.network_log[0]["url"]
@@ -606,3 +614,215 @@ class TestSkillRegistration:
             registry_desc = fn.description  # type: ignore[attr-defined]
         haystack = " ".join([meta_text, registry_desc, decorated.__doc__ or ""])
         assert "network requests" in haystack.lower() or "adblock" in haystack.lower()
+
+
+# ───────────────────────────────────────────────────────────────────────
+# 13. Parallel identical failed requests pair to DIFFERENT entries
+# ───────────────────────────────────────────────────────────────────────
+
+
+class TestParallelFailedRequestsPairing:
+    """Two parallel ``<img>`` loads of the same blocked tracker URL each
+    record their own ``request`` and then each fire ``requestfailed``.
+
+    Naive pairing (walk newest-first, update the first match) would tag
+    the SAME entry twice and leave the older one unflagged — making one
+    of the two failures silently appear "successful" in the log. The
+    ``_failure_tagged`` sentinel + skip-already-tagged logic ensures each
+    failure pairs with a distinct request entry.
+    """
+
+    def test_two_parallel_identical_failures_tag_distinct_entries(self):
+        mgr, inst, _ctx, _page = _make_instance_with_listeners()
+        mgr._attach_network_listeners(inst)
+
+        url = "https://tracker.example.com/pixel.gif"
+        # Two parallel image loads → two ``request`` entries.
+        mgr._record_request(inst, _make_mock_request(url))
+        mgr._record_request(inst, _make_mock_request(url))
+        assert len(inst.network_log) == 2
+        assert all(not e["blocked_by_adblock"] for e in inst.network_log)
+        assert all(not e["_failure_tagged"] for e in inst.network_log)
+
+        # Both fail with adblock. Each ``requestfailed`` should pair with
+        # a different log entry.
+        mgr._record_request_failed(
+            inst,
+            _make_mock_request(url, failure_error="ERR_BLOCKED_BY_CLIENT"),
+        )
+        mgr._record_request_failed(
+            inst,
+            _make_mock_request(url, failure_error="ERR_BLOCKED_BY_CLIENT"),
+        )
+
+        # BOTH entries should now be flagged blocked. Without the
+        # ``_failure_tagged`` skip, the second pairing would have
+        # overwritten the first entry instead of finding the older one.
+        assert all(e["blocked_by_adblock"] for e in inst.network_log), (
+            "Expected both parallel failures to tag distinct entries; "
+            f"network_log={list(inst.network_log)}"
+        )
+        assert all(e["_failure_tagged"] for e in inst.network_log)
+
+    def test_third_failure_with_only_two_requests_is_dropped(self):
+        """If a third ``requestfailed`` arrives but only two matching
+        requests exist (both already tagged), the third update is
+        discarded — no phantom entry, no overwrite.
+        """
+        mgr, inst, _ctx, _page = _make_instance_with_listeners()
+        mgr._attach_network_listeners(inst)
+
+        url = "https://tracker.example.com/pixel.gif"
+        mgr._record_request(inst, _make_mock_request(url))
+        mgr._record_request(inst, _make_mock_request(url))
+        mgr._record_request_failed(
+            inst,
+            _make_mock_request(url, failure_error="ERR_BLOCKED_BY_CLIENT"),
+        )
+        mgr._record_request_failed(
+            inst,
+            _make_mock_request(url, failure_error="ERR_BLOCKED_BY_CLIENT"),
+        )
+        # A third failure for the same URL — both entries already tagged.
+        mgr._record_request_failed(
+            inst,
+            _make_mock_request(url, failure_error="ERR_BLOCKED_BY_CLIENT"),
+        )
+
+        # Length unchanged, both flags still True.
+        assert len(inst.network_log) == 2
+        assert all(e["blocked_by_adblock"] for e in inst.network_log)
+
+
+# ───────────────────────────────────────────────────────────────────────
+# 14. ``include_blocked=False`` filter happens BEFORE the ``limit`` cap
+# ───────────────────────────────────────────────────────────────────────
+
+
+class TestFilterBeforeCapOrdering:
+    """With a buffer dominated by blocked entries, filter-after-cap would
+    return near-empty results when the agent calls ``include_blocked=False,
+    limit=N`` — the cap would slice off the few non-blocked entries before
+    the filter ran. The implementation iterates newest-first, drops blocked
+    entries (incrementing ``dropped_blocked``), and only counts non-blocked
+    entries toward ``limit``.
+    """
+
+    @pytest.mark.asyncio
+    async def test_180_blocked_of_200_returns_visible_non_blocked(self):
+        mgr, inst, _ctx, _page = _make_instance_with_listeners()
+        mgr._attach_network_listeners(inst)
+        mgr.get_or_start = AsyncMock(return_value=inst)
+
+        # 20 visible (non-blocked) + 180 blocked, interleaved so the
+        # newest 50 by timestamp would be a mix dominated by blocked.
+        # Blocked URLs go through ``_record_request`` then are flagged
+        # via ``_record_request_failed``.
+        ok_count = 0
+        blocked_count = 0
+        for i in range(200):
+            if i % 10 == 0:
+                # 1 in 10 is non-blocked.
+                mgr._record_request(
+                    inst,
+                    _make_mock_request(f"https://example.com/ok/{i}"),
+                )
+                ok_count += 1
+            else:
+                url = f"https://tracker.example.com/blocked/{i}"
+                mgr._record_request(inst, _make_mock_request(url))
+                mgr._record_request_failed(
+                    inst,
+                    _make_mock_request(
+                        url, failure_error="ERR_BLOCKED_BY_CLIENT",
+                    ),
+                )
+                blocked_count += 1
+
+        assert ok_count == 20
+        assert blocked_count == 180
+        assert len(inst.network_log) == 200
+
+        # Ask for 50 with include_blocked=False. Filter-before-cap means
+        # we should see all 20 visible entries (limit isn't reached).
+        result = await mgr.inspect_requests(
+            "agent1", include_blocked=False, limit=50,
+        )
+        assert result["success"] is True
+        data = result["data"]
+        assert data["total"] == 200
+        assert data["dropped_blocked"] == 180
+        assert len(data["requests"]) == 20, (
+            "filter-before-cap: 20 non-blocked entries should all appear "
+            f"under limit=50; got {len(data['requests'])}"
+        )
+        # Every returned entry is non-blocked.
+        assert all(
+            not r["blocked_by_adblock"] for r in data["requests"]
+        )
+
+    @pytest.mark.asyncio
+    async def test_filter_before_cap_with_limit_smaller_than_visible(self):
+        """When non-blocked count exceeds ``limit``, cap kicks in correctly
+        AFTER the filter — newest-first selection.
+        """
+        mgr, inst, _ctx, _page = _make_instance_with_listeners()
+        mgr._attach_network_listeners(inst)
+        mgr.get_or_start = AsyncMock(return_value=inst)
+
+        # 100 non-blocked, 100 blocked, all interleaved.
+        for i in range(200):
+            if i % 2 == 0:
+                mgr._record_request(
+                    inst,
+                    _make_mock_request(f"https://example.com/ok/{i}"),
+                )
+            else:
+                url = f"https://tracker.example.com/blocked/{i}"
+                mgr._record_request(inst, _make_mock_request(url))
+                mgr._record_request_failed(
+                    inst,
+                    _make_mock_request(
+                        url, failure_error="ERR_BLOCKED_BY_CLIENT",
+                    ),
+                )
+
+        result = await mgr.inspect_requests(
+            "agent1", include_blocked=False, limit=10,
+        )
+        data = result["data"]
+        assert data["total"] == 200
+        assert data["dropped_blocked"] == 100
+        assert len(data["requests"]) == 10
+        assert all(not r["blocked_by_adblock"] for r in data["requests"])
+        # Newest-first — entry urls should reference the higher-numbered
+        # /ok/ paths.
+        assert "/ok/" in data["requests"][0]["url"]
+
+
+# ───────────────────────────────────────────────────────────────────────
+# 15. Internal ``_failure_tagged`` sentinel never leaks into responses
+# ───────────────────────────────────────────────────────────────────────
+
+
+class TestSentinelNeverLeaks:
+    @pytest.mark.asyncio
+    async def test_failure_tagged_field_stripped_from_response(self):
+        mgr, inst, _ctx, _page = _make_instance_with_listeners()
+        mgr._attach_network_listeners(inst)
+        mgr.get_or_start = AsyncMock(return_value=inst)
+
+        url = "https://tracker.example.com/pixel.gif"
+        mgr._record_request(inst, _make_mock_request(url))
+        mgr._record_request_failed(
+            inst,
+            _make_mock_request(url, failure_error="ERR_BLOCKED_BY_CLIENT"),
+        )
+
+        result = await mgr.inspect_requests(
+            "agent1", include_blocked=True, limit=10,
+        )
+        for entry in result["data"]["requests"]:
+            assert "_failure_tagged" not in entry, (
+                f"internal sentinel leaked into response: {entry}"
+            )

--- a/tests/test_browser_inspect_requests.py
+++ b/tests/test_browser_inspect_requests.py
@@ -215,6 +215,26 @@ class TestRequestFailedClassifier:
 
         assert inst.network_log[-1]["blocked_by_adblock"] is True
 
+    def test_exact_request_identity_wins_for_identical_url(self):
+        """If two same-URL requests are in flight and only the older one
+        fails, the failure must tag that exact request, not the newest
+        URL+method match.
+        """
+        mgr, inst, _ctx, _page = _make_instance_with_listeners()
+        mgr._attach_network_listeners(inst)
+
+        url = "https://tracker.example.com/pixel.gif"
+        older = _make_mock_request(url)
+        newer = _make_mock_request(url)
+        mgr._record_request(inst, older)
+        mgr._record_request(inst, newer)
+
+        older.failure = _FakeFailure("ERR_BLOCKED_BY_CLIENT")
+        mgr._record_request_failed(inst, older)
+
+        assert inst.network_log[0]["blocked_by_adblock"] is True
+        assert inst.network_log[1]["blocked_by_adblock"] is False
+
 
 # ───────────────────────────────────────────────────────────────────────
 # 4. include_blocked / dropped_blocked
@@ -825,4 +845,7 @@ class TestSentinelNeverLeaks:
         for entry in result["data"]["requests"]:
             assert "_failure_tagged" not in entry, (
                 f"internal sentinel leaked into response: {entry}"
+            )
+            assert "_request_key" not in entry, (
+                f"internal request key leaked into response: {entry}"
             )

--- a/tests/test_browser_inspect_requests.py
+++ b/tests/test_browser_inspect_requests.py
@@ -1,0 +1,608 @@
+"""Tests for Phase 6 §9.1 ``inspect_requests`` browser action.
+
+Covers:
+  * URL redaction at store-time (userinfo, JWT-shaped path, sensitive query).
+  * ``deque`` maxlen enforcement (200) — older entries drop.
+  * ``requestfailed`` classifier — adblock vs user-cancelled vs failed.
+  * ``include_blocked`` filter + ``dropped_blocked`` counter.
+  * ``limit`` cap at 200.
+  * User-control conflict envelope.
+  * ``BROWSER_NETWORK_INSPECT_DISABLED`` operator kill-switch (mesh route).
+  * ISO-8601 UTC ``ts``.
+  * RESET clears ``network_log`` and re-attaches listeners.
+  * Context-level ``page`` listener attaches per-request handler to new tabs.
+"""
+
+from __future__ import annotations
+
+import re
+from collections import deque
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+# ───────────────────────────────────────────────────────────────────────
+# Helpers
+# ───────────────────────────────────────────────────────────────────────
+
+
+class _FakeFailure:
+    """Non-callable failure shape — matches Playwright's ``Request.failure``
+    which is a property holding an object with ``errorText``. We deliberately
+    avoid ``MagicMock`` here because MagicMocks are always callable, which
+    would force the implementation's callable-fallback path on every test
+    rather than exercising the property path.
+    """
+
+    def __init__(self, error_text: str):
+        self.errorText = error_text
+
+
+class _FakeRequest:
+    """Non-callable request shape with the four attributes listeners read."""
+
+    def __init__(self, url, method, resource_type, failure):
+        self.url = url
+        self.method = method
+        self.resource_type = resource_type
+        self.failure = failure
+
+
+def _make_mock_request(
+    url: str,
+    method: str = "GET",
+    resource_type: str = "document",
+    failure_error: str | None = None,
+):
+    """Build a Playwright-Request-shaped fake for listener tests."""
+    failure = _FakeFailure(failure_error) if failure_error is not None else None
+    return _FakeRequest(url, method, resource_type, failure)
+
+
+def _make_instance_with_listeners():
+    """Return a CamoufoxInstance with mocked context/page wired by listeners.
+
+    The mocks capture handlers passed to ``.on(...)`` so the test can fire
+    them synchronously.
+    """
+    from src.browser.service import BrowserManager, CamoufoxInstance
+
+    mgr = BrowserManager.__new__(BrowserManager)
+
+    # Track context listeners in a dict so we can fire ``page`` / ``requestfailed``.
+    context_handlers: dict[str, list] = {"page": [], "requestfailed": []}
+
+    def _ctx_on(event: str, handler):
+        context_handlers.setdefault(event, []).append(handler)
+
+    context = MagicMock()
+    context.on = MagicMock(side_effect=_ctx_on)
+
+    # Page mock: same trick — ``request`` handlers stored, callable via _fire.
+    page_handlers: dict[str, list] = {}
+
+    def _page_on(event: str, handler):
+        page_handlers.setdefault(event, []).append(handler)
+
+    page = MagicMock()
+    page.on = MagicMock(side_effect=_page_on)
+
+    inst = CamoufoxInstance("agent1", MagicMock(), context, page)
+    return mgr, inst, context_handlers, page_handlers
+
+
+# ───────────────────────────────────────────────────────────────────────
+# 1. URL redaction at store time
+# ───────────────────────────────────────────────────────────────────────
+
+
+class TestStoreTimeRedaction:
+    def test_userinfo_jwt_and_sensitive_query_redacted(self):
+        mgr, inst, _ctx, _page = _make_instance_with_listeners()
+        mgr._attach_network_listeners(inst)
+
+        # userinfo + JWT in path + sensitive query (``token``)
+        jwt = "abcdefghij.klmnopqrst.uvwxyz1234"
+        url = (
+            "https://user:secret@example.com/auth/"
+            f"{jwt}/cb?token=SUPER_SECRET&keep=1"
+        )
+        req = _make_mock_request(url)
+        mgr._record_request(inst, req)
+
+        assert len(inst.network_log) == 1
+        stored = inst.network_log[0]["url"]
+        # Userinfo gone
+        assert "user:secret" not in stored
+        assert "secret@" not in stored
+        # JWT segment redacted
+        assert jwt not in stored
+        # Sensitive query value redacted; key preserved
+        assert "SUPER_SECRET" not in stored
+        assert "token=%5BREDACTED%5D" in stored or "token=[REDACTED]" in stored
+        # Non-sensitive query preserved
+        assert "keep=1" in stored
+
+
+# ───────────────────────────────────────────────────────────────────────
+# 2. deque maxlen enforcement
+# ───────────────────────────────────────────────────────────────────────
+
+
+class TestDequeMaxlen:
+    def test_only_newest_200_kept(self):
+        mgr, inst, _ctx, _page = _make_instance_with_listeners()
+        mgr._attach_network_listeners(inst)
+
+        for i in range(250):
+            mgr._record_request(
+                inst,
+                _make_mock_request(f"https://example.com/r/{i}"),
+            )
+
+        assert len(inst.network_log) == 200
+        # Oldest 50 dropped — first remaining entry should be /r/50.
+        assert "/r/50" in inst.network_log[0]["url"]
+        assert "/r/249" in inst.network_log[-1]["url"]
+
+
+# ───────────────────────────────────────────────────────────────────────
+# 3. requestfailed classifier
+# ───────────────────────────────────────────────────────────────────────
+
+
+class TestRequestFailedClassifier:
+    @pytest.mark.parametrize("marker, flag", [
+        ("NS_ERROR_CONTENT_BLOCKED", "blocked_by_adblock"),
+        ("ERR_BLOCKED_BY_CLIENT", "blocked_by_adblock"),
+        ("NS_ERROR_BLOCKED_BY_POLICY", "blocked_by_adblock"),
+        ("NS_BINDING_ABORTED", "user_cancelled"),
+        ("NS_ERROR_NET_TIMEOUT", "failed_network"),
+    ])
+    def test_marker_routes_to_correct_flag(self, marker, flag):
+        mgr, inst, _ctx, _page = _make_instance_with_listeners()
+        mgr._attach_network_listeners(inst)
+
+        url = "https://tracker.example.com/pixel.gif"
+        mgr._record_request(inst, _make_mock_request(url))
+        assert inst.network_log[-1][flag] is False  # Initial state
+
+        failed_req = _make_mock_request(url, failure_error=marker)
+        mgr._record_request_failed(inst, failed_req)
+
+        entry = inst.network_log[-1]
+        assert entry[flag] is True
+        # Mutually exclusive — only the matching flag flips.
+        for other in ("blocked_by_adblock", "user_cancelled", "failed_network"):
+            if other != flag:
+                assert entry[other] is False, (
+                    f"marker={marker!r} also flipped {other}"
+                )
+
+    def test_failed_with_no_matching_entry_does_not_create_phantom(self):
+        """requestfailed for a URL that scrolled out of the window is dropped."""
+        mgr, inst, _ctx, _page = _make_instance_with_listeners()
+        mgr._attach_network_listeners(inst)
+
+        # No matching request recorded — the failure update should be ignored.
+        failed_req = _make_mock_request(
+            "https://gone.example.com/never-recorded",
+            failure_error="NS_ERROR_CONTENT_BLOCKED",
+        )
+        mgr._record_request_failed(inst, failed_req)
+        assert len(inst.network_log) == 0
+
+    def test_callable_failure_attribute_handled(self):
+        """Some Playwright bindings expose ``failure`` as a callable."""
+        mgr, inst, _ctx, _page = _make_instance_with_listeners()
+        mgr._attach_network_listeners(inst)
+
+        url = "https://tracker.example.com/x"
+        mgr._record_request(inst, _make_mock_request(url))
+
+        # Build a request whose ``failure`` is a callable returning the
+        # error-bearing object. Use a plain class (not MagicMock) so the
+        # rest of the request shape stays property-like.
+        failure_obj = _FakeFailure("NS_ERROR_CONTENT_BLOCKED")
+        failed_req = _FakeRequest(url, "GET", "document", failure=lambda: failure_obj)
+        mgr._record_request_failed(inst, failed_req)
+
+        assert inst.network_log[-1]["blocked_by_adblock"] is True
+
+
+# ───────────────────────────────────────────────────────────────────────
+# 4. include_blocked / dropped_blocked
+# ───────────────────────────────────────────────────────────────────────
+
+
+class TestIncludeBlockedFilter:
+    @pytest.mark.asyncio
+    async def test_excludes_blocked_by_default(self):
+        mgr, inst, _ctx, _page = _make_instance_with_listeners()
+        mgr._attach_network_listeners(inst)
+        mgr.get_or_start = AsyncMock(return_value=inst)
+
+        # 3 normal + 2 blocked
+        for i in range(3):
+            mgr._record_request(
+                inst,
+                _make_mock_request(f"https://example.com/ok/{i}"),
+            )
+        for i in range(2):
+            url = f"https://tracker.example.com/blocked/{i}"
+            mgr._record_request(inst, _make_mock_request(url))
+            mgr._record_request_failed(
+                inst,
+                _make_mock_request(url, failure_error="ERR_BLOCKED_BY_CLIENT"),
+            )
+
+        result = await mgr.inspect_requests("agent1", include_blocked=False)
+        assert result["success"] is True
+        data = result["data"]
+        assert data["total"] == 5
+        assert data["dropped_blocked"] == 2
+        assert len(data["requests"]) == 3
+        assert all("blocked" not in r["url"] for r in data["requests"])
+
+    @pytest.mark.asyncio
+    async def test_include_blocked_keeps_them(self):
+        mgr, inst, _ctx, _page = _make_instance_with_listeners()
+        mgr._attach_network_listeners(inst)
+        mgr.get_or_start = AsyncMock(return_value=inst)
+
+        for i in range(2):
+            url = f"https://tracker.example.com/blocked/{i}"
+            mgr._record_request(inst, _make_mock_request(url))
+            mgr._record_request_failed(
+                inst,
+                _make_mock_request(url, failure_error="ERR_BLOCKED_BY_CLIENT"),
+            )
+        mgr._record_request(
+            inst,
+            _make_mock_request("https://example.com/ok"),
+        )
+
+        result = await mgr.inspect_requests("agent1", include_blocked=True)
+        assert result["success"] is True
+        data = result["data"]
+        assert data["total"] == 3
+        assert data["dropped_blocked"] == 0
+        assert len(data["requests"]) == 3
+        blocked_returned = [
+            r for r in data["requests"] if r["blocked_by_adblock"]
+        ]
+        assert len(blocked_returned) == 2
+
+
+# ───────────────────────────────────────────────────────────────────────
+# 5. limit cap at 200
+# ───────────────────────────────────────────────────────────────────────
+
+
+class TestLimitCap:
+    @pytest.mark.asyncio
+    async def test_limit_above_200_coerced_to_200(self):
+        mgr, inst, _ctx, _page = _make_instance_with_listeners()
+        mgr._attach_network_listeners(inst)
+        mgr.get_or_start = AsyncMock(return_value=inst)
+
+        for i in range(250):
+            mgr._record_request(
+                inst,
+                _make_mock_request(f"https://example.com/r/{i}"),
+            )
+
+        result = await mgr.inspect_requests("agent1", limit=500)
+        assert result["success"] is True
+        # Underlying deque is also capped at 200.
+        assert len(result["data"]["requests"]) == 200
+
+    @pytest.mark.asyncio
+    async def test_default_limit_50_returns_50(self):
+        mgr, inst, _ctx, _page = _make_instance_with_listeners()
+        mgr._attach_network_listeners(inst)
+        mgr.get_or_start = AsyncMock(return_value=inst)
+
+        for i in range(120):
+            mgr._record_request(
+                inst,
+                _make_mock_request(f"https://example.com/r/{i}"),
+            )
+
+        result = await mgr.inspect_requests("agent1")
+        assert len(result["data"]["requests"]) == 50
+
+    @pytest.mark.asyncio
+    async def test_results_are_newest_first(self):
+        mgr, inst, _ctx, _page = _make_instance_with_listeners()
+        mgr._attach_network_listeners(inst)
+        mgr.get_or_start = AsyncMock(return_value=inst)
+
+        for i in range(5):
+            mgr._record_request(
+                inst,
+                _make_mock_request(f"https://example.com/r/{i}"),
+            )
+
+        result = await mgr.inspect_requests("agent1", limit=5)
+        urls = [r["url"] for r in result["data"]["requests"]]
+        assert "/r/4" in urls[0]
+        assert "/r/0" in urls[-1]
+
+
+# ───────────────────────────────────────────────────────────────────────
+# 6. user_control returns conflict envelope
+# ───────────────────────────────────────────────────────────────────────
+
+
+class TestUserControlConflict:
+    @pytest.mark.asyncio
+    async def test_user_control_returns_conflict_envelope(self):
+        mgr, inst, _ctx, _page = _make_instance_with_listeners()
+        inst._user_control = True
+        mgr.get_or_start = AsyncMock(return_value=inst)
+
+        result = await mgr.inspect_requests("agent1")
+
+        assert result["success"] is False
+        assert result["error"]["code"] == "conflict"
+        assert "retry_after_ms" in result["error"]
+        assert result["error"]["retry_after_ms"] is None
+
+
+# ───────────────────────────────────────────────────────────────────────
+# 7. Mesh kill-switch — BROWSER_NETWORK_INSPECT_DISABLED returns 403
+# ───────────────────────────────────────────────────────────────────────
+
+
+class TestMeshKillSwitch:
+    @pytest.mark.asyncio
+    async def test_kill_switch_returns_forbidden(self, tmp_path, monkeypatch):
+        from httpx import ASGITransport, AsyncClient
+
+        from src.browser import flags as bflags
+        from src.host.costs import CostTracker
+        from src.host.mesh import Blackboard, MessageRouter, PubSub
+        from src.host.permissions import PermissionMatrix
+        from src.host.server import create_mesh_app
+        from src.host.traces import TraceStore
+        from src.shared.types import AgentPermissions
+
+        monkeypatch.setenv("BROWSER_NETWORK_INSPECT_DISABLED", "1")
+        # Reset cached operator settings so the env override wins.
+        bflags.reload_operator_settings()
+
+        permissions = PermissionMatrix()
+        permissions.permissions["worker"] = AgentPermissions(
+            agent_id="worker", can_use_browser=True,
+        )
+        router = MessageRouter(permissions, {"worker": "http://worker:8400"})
+        bb = Blackboard(str(tmp_path / "bb.db"))
+        pubsub = PubSub()
+        costs = CostTracker(str(tmp_path / "costs.db"))
+        traces = TraceStore(str(tmp_path / "traces.db"))
+        cm = MagicMock()
+        cm.browser_service_url = "http://browser-svc:8500"
+        cm.browser_auth_token = ""
+
+        app = create_mesh_app(
+            blackboard=bb,
+            pubsub=pubsub,
+            router=router,
+            permissions=permissions,
+            cost_tracker=costs,
+            trace_store=traces,
+            event_bus=MagicMock(),
+            container_manager=cm,
+        )
+
+        async with AsyncClient(
+            transport=ASGITransport(app=app), base_url="http://test",
+        ) as client:
+            resp = await client.post(
+                "/mesh/browser/command",
+                json={
+                    "agent_id": "worker",
+                    "action": "inspect_requests",
+                    "params": {"include_blocked": False, "limit": 10},
+                },
+                headers={"X-Agent-ID": "worker"},
+            )
+
+        assert resp.status_code == 403, (resp.status_code, resp.text)
+        body = resp.json()
+        # FastAPI wraps ``detail=`` payload under ``detail``.
+        detail = body.get("detail", body)
+        assert detail.get("success") is False
+        assert detail["error"]["code"] == "forbidden"
+        assert "retry_after_ms" in detail["error"]
+
+
+# ───────────────────────────────────────────────────────────────────────
+# 8. ts is ISO-8601 UTC string
+# ───────────────────────────────────────────────────────────────────────
+
+
+class TestTimestampShape:
+    @pytest.mark.asyncio
+    async def test_ts_is_iso8601_utc(self):
+        mgr, inst, _ctx, _page = _make_instance_with_listeners()
+        mgr._attach_network_listeners(inst)
+        mgr.get_or_start = AsyncMock(return_value=inst)
+
+        mgr._record_request(
+            inst, _make_mock_request("https://example.com/x"),
+        )
+        result = await mgr.inspect_requests("agent1")
+
+        ts = result["data"]["requests"][0]["ts"]
+        # Shape: 2024-01-01T00:00:00Z
+        assert isinstance(ts, str)
+        assert ts.endswith("Z"), ts
+        assert re.match(r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$", ts), ts
+
+
+# ───────────────────────────────────────────────────────────────────────
+# 9. RESET clears network_log + re-attaches listeners on next start
+# ───────────────────────────────────────────────────────────────────────
+
+
+class TestResetClearsAndReattaches:
+    @pytest.mark.asyncio
+    async def test_reset_drops_old_instance_and_new_one_starts_fresh(self):
+        from src.browser.service import BrowserManager, CamoufoxInstance
+
+        # Build a manager with one stale instance carrying a populated log.
+        mgr = BrowserManager(profiles_dir="/tmp/_test_inspect_reset")
+        old_ctx = AsyncMock()
+        old_page = MagicMock()
+        # Old context.on was wired during __init__ by _attach_network_listeners;
+        # we simulate that state by manually flipping the flag + populating log.
+        old = CamoufoxInstance("agent1", MagicMock(), old_ctx, old_page)
+        old._network_attached = True
+        old.network_log.append({
+            "url": "https://example.com/stale",
+            "method": "GET",
+            "resource_type": "document",
+            "ts": 1.0,
+            "status": None,
+            "blocked_by_adblock": False,
+            "user_cancelled": False,
+            "failed_network": False,
+        })
+        mgr._instances["agent1"] = old
+
+        # RESET drops the old instance — confirmed by absence in _instances.
+        await mgr.reset("agent1")
+        assert "agent1" not in mgr._instances
+
+        # The next CamoufoxInstance constructed for the same agent is a
+        # fresh object. We verify the contract: a new instance starts with
+        # empty network_log + _network_attached=False, so the next
+        # _attach_network_listeners call wires fresh listeners.
+        fresh_page = MagicMock()
+        fresh_ctx = MagicMock()
+        fresh_ctx.on = MagicMock()
+        fresh_page.on = MagicMock()
+        fresh = CamoufoxInstance("agent1", MagicMock(), fresh_ctx, fresh_page)
+        assert fresh.network_log == deque(maxlen=200)
+        assert len(fresh.network_log) == 0
+        assert fresh._network_attached is False
+
+        mgr._attach_network_listeners(fresh)
+        assert fresh._network_attached is True
+        # context-level listeners wired for ``page`` and ``requestfailed``.
+        events = [call.args[0] for call in fresh_ctx.on.call_args_list]
+        assert "page" in events
+        assert "requestfailed" in events
+
+
+# ───────────────────────────────────────────────────────────────────────
+# 10. Context-level listener wires per-request handler on new pages
+# ───────────────────────────────────────────────────────────────────────
+
+
+class TestContextLevelPageListener:
+    def test_new_page_inherits_request_handler(self):
+        """Simulate context.emit('page', new_page) firing the registered handler.
+
+        The handler we registered should attach a per-page ``request``
+        listener; firing that listener should record into ``network_log``.
+        """
+        from src.browser.service import BrowserManager, CamoufoxInstance
+
+        mgr = BrowserManager.__new__(BrowserManager)
+
+        ctx_handlers: dict[str, list] = {}
+
+        def _ctx_on(event: str, handler):
+            ctx_handlers.setdefault(event, []).append(handler)
+
+        context = MagicMock()
+        context.on = MagicMock(side_effect=_ctx_on)
+
+        existing_page = MagicMock()
+        existing_page.on = MagicMock()
+
+        inst = CamoufoxInstance("agent1", MagicMock(), context, existing_page)
+        mgr._attach_network_listeners(inst)
+
+        # Now fire a context-level "page" event with a brand-new Mock Page.
+        new_page = MagicMock()
+        new_page_handlers: dict[str, list] = {}
+
+        def _new_page_on(event: str, handler):
+            new_page_handlers.setdefault(event, []).append(handler)
+
+        new_page.on = MagicMock(side_effect=_new_page_on)
+
+        # The registered context handler should attach a request handler
+        # to the new page when invoked.
+        for h in ctx_handlers["page"]:
+            h(new_page)
+
+        # The new_page now has a "request" listener registered.
+        assert "request" in new_page_handlers
+        assert len(new_page_handlers["request"]) == 1
+
+        # Firing that listener with a Mock request should record into log.
+        req = _make_mock_request("https://newtab.example.com/asset.js")
+        new_page_handlers["request"][0](req)
+
+        assert len(inst.network_log) == 1
+        assert "/asset.js" in inst.network_log[0]["url"]
+
+
+# ───────────────────────────────────────────────────────────────────────
+# 11. Idempotency of _attach_network_listeners
+# ───────────────────────────────────────────────────────────────────────
+
+
+class TestAttachIdempotent:
+    def test_double_attach_does_not_double_register(self):
+        from src.browser.service import BrowserManager, CamoufoxInstance
+
+        mgr = BrowserManager.__new__(BrowserManager)
+        ctx = MagicMock()
+        ctx.on = MagicMock()
+        page = MagicMock()
+        page.on = MagicMock()
+        inst = CamoufoxInstance("agent1", MagicMock(), ctx, page)
+
+        mgr._attach_network_listeners(inst)
+        first_count = ctx.on.call_count
+        mgr._attach_network_listeners(inst)  # second call: must no-op
+        assert ctx.on.call_count == first_count
+        assert inst._network_attached is True
+
+
+# ───────────────────────────────────────────────────────────────────────
+# 12. Skill registration sanity check
+# ───────────────────────────────────────────────────────────────────────
+
+
+class TestSkillRegistration:
+    def test_skill_present_with_correct_name_and_params(self):
+        from src.agent.builtins import browser_tool
+
+        fn = getattr(browser_tool, "browser_inspect_requests", None)
+        assert fn is not None
+
+        meta = getattr(fn, "skill_meta", None) or getattr(fn, "_skill", None)
+        # Registry-agnostic — just confirm callable + has the expected name
+        # somewhere on its metadata. The skill registry itself is tested
+        # separately in tests/test_skills.py.
+        assert callable(fn)
+        # The skill decorator stores metadata; we just confirm description
+        # mentions adblock so future refactors can't silently lose intent.
+        # Falls back to inspecting the docstring if no metadata attr.
+        meta_text = (
+            getattr(meta, "description", "") if meta else ""
+        ) or (fn.__doc__ or "")
+        # description bound to the decorator-generated callable
+        decorated = getattr(fn, "__wrapped__", fn)
+        registry_desc = ""
+        if hasattr(fn, "description"):
+            registry_desc = fn.description  # type: ignore[attr-defined]
+        haystack = " ".join([meta_text, registry_desc, decorated.__doc__ or ""])
+        assert "network requests" in haystack.lower() or "adblock" in haystack.lower()

--- a/tests/test_dashboard_cookie_import.py
+++ b/tests/test_dashboard_cookie_import.py
@@ -1,0 +1,729 @@
+"""Tests for Phase 6 §9.2: operator cookie/session import.
+
+Coverage:
+1.  Audit log NEVER contains cookie values, JWTs, Bearer tokens, or
+    SigV4-shaped strings (the most important security property).
+2.  Playwright + Netscape happy paths.
+3.  CSRF rejection (missing X-Requested-With).
+4.  Auth rejection (missing ol_session in hosted mode).
+5.  Rate-limit overflow → 429 with retry_after_ms.
+6.  Kill-switch (BROWSER_COOKIE_IMPORT_DISABLED=1).
+7.  Per-cookie 4 KiB value cap and 256 KiB total payload cap and
+    1000-cookie list-length cap.
+8.  Drop reasons: __Host-with-domain, IP-literal domain, invalid SameSite.
+9.  Invalid JSON / unknown shape → 400.
+10. Idempotency-ish: two overlapping imports succeed.
+11. Browser-service down → 503.
+12. Parser unit tests for ``_parse_netscape``.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import shutil
+import tempfile
+from unittest.mock import MagicMock
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from src.dashboard.events import EventBus
+from src.dashboard.server import (
+    _is_ip_literal_domain,
+    _parse_netscape,
+    _validate_cookies,
+    create_dashboard_router,
+)
+from src.host.costs import CostTracker
+from src.host.health import HealthMonitor
+from src.host.mesh import Blackboard
+from src.host.traces import TraceStore
+
+# A short corpus of value shapes the audit log MUST NEVER echo. Each
+# string is also wrapped into a Playwright cookie payload below.
+_SECRET_VALUES = [
+    "raw-secretvalue-12345",
+    "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJ0ZXN0In0.abc123",  # JWT-shape
+    "Bearer abc123def456ghi789jkl012mno345pqr678stu901vwx234",          # Bearer
+    "AKIAIOSFODNN7EXAMPLEAWS4-HMAC-SHA256-Credential-AKIAIOSFODNN7EXAMPLE-1234567890abcdef",  # SigV4-ish
+]
+
+
+class _CSRFTestClient(TestClient):
+    """Auto-injects X-Requested-With on state-changing methods."""
+
+    def request(self, method, url, **kwargs):
+        if method.upper() not in ("GET", "HEAD", "OPTIONS"):
+            headers = kwargs.get("headers") or {}
+            if "X-Requested-With" not in headers:
+                headers["X-Requested-With"] = "XMLHttpRequest"
+                kwargs["headers"] = headers
+        return super().request(method, url, **kwargs)
+
+
+def _make_components(tmp_path: str) -> dict:
+    """Minimal components for the dashboard router, with a runtime mock
+    pointing at a non-existent browser_service_url so the test can
+    intercept httpx calls via the shared client."""
+    bb = Blackboard(db_path=os.path.join(tmp_path, "bb.db"))
+    cost_tracker = CostTracker(db_path=os.path.join(tmp_path, "costs.db"))
+    trace_store = TraceStore(db_path=os.path.join(tmp_path, "traces.db"))
+    event_bus = EventBus()
+    agent_registry: dict[str, str] = {
+        "alpha": "http://localhost:8401",
+    }
+
+    runtime_mock = MagicMock()
+    runtime_mock.browser_service_url = "http://browser-svc:8500"
+    runtime_mock.browser_auth_token = "test-token"
+    runtime_mock.browser_vnc_url = None
+
+    transport_mock = MagicMock()
+    router_mock = MagicMock()
+    health_monitor = HealthMonitor(
+        runtime=runtime_mock, transport=transport_mock, router=router_mock,
+    )
+    health_monitor.register("alpha")
+    health_monitor.agents["alpha"].status = "healthy"
+
+    return {
+        "blackboard": bb,
+        "health_monitor": health_monitor,
+        "cost_tracker": cost_tracker,
+        "trace_store": trace_store,
+        "event_bus": event_bus,
+        "agent_registry": agent_registry,
+        "runtime": runtime_mock,
+    }
+
+
+def _make_client(components: dict) -> TestClient:
+    router = create_dashboard_router(**components, mesh_port=8420)
+    app = FastAPI()
+    app.include_router(router)
+    return _CSRFTestClient(app)
+
+
+def _teardown(components: dict) -> None:
+    components["cost_tracker"].close()
+    components["trace_store"].close()
+    components["blackboard"].close()
+
+
+def _stub_browser_service(monkeypatch, *, success: bool = True,
+                          imported_count: int | None = None,
+                          status_code: int = 200,
+                          raise_exc: Exception | None = None) -> dict:
+    """Patch the dashboard's shared httpx client so we can intercept
+    posts to the browser service. Returns a dict where ``calls`` collects
+    every (url, body) tuple."""
+    tracker: dict = {"calls": []}
+
+    async def _fake_post(url, *args, **kwargs):
+        tracker["calls"].append({"url": url, "json": kwargs.get("json")})
+        if raise_exc is not None:
+            raise raise_exc
+        body = kwargs.get("json") or {}
+        cookies = body.get("cookies") or []
+        count = imported_count if imported_count is not None else len(cookies)
+
+        class _Resp:
+            def __init__(self, code, payload):
+                self.status_code = code
+                self._payload = payload
+
+            def json(self):
+                return self._payload
+
+            def raise_for_status(self):
+                if self.status_code >= 400:
+                    raise RuntimeError(f"HTTP {self.status_code}")
+
+        if success:
+            payload = {"success": True, "data": {"imported": count}}
+        else:
+            payload = {
+                "success": False,
+                "error": {
+                    "code": "invalid_input",
+                    "message": "fake failure",
+                    "retry_after_ms": None,
+                },
+            }
+        return _Resp(status_code, payload)
+
+    # Patch by mutating the module-level client used inside the router.
+    # The client is created fresh per `create_dashboard_router` call —
+    # we monkeypatch httpx.AsyncClient.post via the instance the router
+    # captured. Easiest path: stash a reference into the router state.
+    import src.dashboard.server as _srv
+
+    real_async_client = _srv._httpx.AsyncClient if hasattr(_srv, "_httpx") else None
+    if real_async_client is None:
+        # The httpx import is local to create_dashboard_router. Patch
+        # the real httpx module instead so all clients route through.
+        import httpx as _httpx_mod
+
+        async def _proxy_post(self, url, *args, **kwargs):
+            return await _fake_post(url, *args, **kwargs)
+
+        monkeypatch.setattr(_httpx_mod.AsyncClient, "post", _proxy_post)
+    return tracker
+
+
+# ────────────────────────────────────────────────────────────────────────
+# Pure-function tests (no HTTP)
+# ────────────────────────────────────────────────────────────────────────
+
+
+class TestParseNetscape:
+    def test_basic_line(self):
+        text = ".example.com\tTRUE\t/\tTRUE\t1735689600\tsid\tabcdef\n"
+        result = _parse_netscape(text)
+        assert len(result) == 1
+        assert result[0]["name"] == "sid"
+        assert result[0]["value"] == "abcdef"
+        assert result[0]["domain"] == ".example.com"
+        assert result[0]["secure"] is True
+        assert result[0]["httpOnly"] is False
+        assert result[0]["expires"] == 1735689600
+        assert result[0]["path"] == "/"
+
+    def test_comment_lines_skipped(self):
+        text = (
+            "# this is a comment\n"
+            "# another comment\n"
+            ".example.com\tTRUE\t/\tFALSE\t100\tname\tvalue\n"
+        )
+        result = _parse_netscape(text)
+        assert len(result) == 1
+        assert result[0]["secure"] is False
+
+    def test_httponly_prefix(self):
+        text = "#HttpOnly_.example.com\tTRUE\t/\tTRUE\t100\tsid\tabc\n"
+        result = _parse_netscape(text)
+        assert len(result) == 1
+        assert result[0]["domain"] == ".example.com"
+        assert result[0]["httpOnly"] is True
+
+    def test_missing_fields_dropped(self):
+        text = "# header\n.example.com\tTRUE\t/\tTRUE\n"  # too few fields
+        assert _parse_netscape(text) == []
+
+    def test_unicode_domain_accepted(self):
+        text = ".пример.com\tTRUE\t/\tTRUE\t100\tsid\txyz\n"
+        result = _parse_netscape(text)
+        assert len(result) == 1
+        assert result[0]["domain"] == ".пример.com"
+
+    def test_non_numeric_expires_dropped(self):
+        text = ".example.com\tTRUE\t/\tTRUE\tnot-a-number\tsid\txyz\n"
+        assert _parse_netscape(text) == []
+
+    def test_blank_lines_skipped(self):
+        text = "\n\n\n.example.com\tTRUE\t/\tTRUE\t100\tsid\tabc\n\n"
+        assert len(_parse_netscape(text)) == 1
+
+
+class TestValidateCookies:
+    def test_playwright_happy_path(self):
+        accepted, dropped, fmt = _validate_cookies(
+            [{"name": "sid", "value": "abc", "domain": ".example.com"}],
+        )
+        assert fmt == "playwright"
+        assert len(accepted) == 1
+        assert dropped == []
+
+    def test_drops_value_too_large(self):
+        accepted, dropped, fmt = _validate_cookies(
+            [{"name": "sid", "value": "x" * 5000, "domain": ".example.com"}],
+        )
+        assert accepted == []
+        assert dropped == [{"reason": "value_too_large", "count": 1}]
+
+    def test_drops_host_prefix_with_domain(self):
+        accepted, dropped, _ = _validate_cookies(
+            [{"name": "__Host-sess", "value": "abc", "domain": ".example.com"}],
+        )
+        assert accepted == []
+        assert dropped == [{"reason": "host_prefix_with_domain", "count": 1}]
+
+    def test_allows_host_prefix_without_domain(self):
+        # __Host- without domain (empty domain) is rejected by empty_domain rule.
+        # The valid form has domain absent entirely; we just verify host_prefix
+        # only fires when domain is set.
+        accepted, dropped, _ = _validate_cookies(
+            [{"name": "__Host-sess", "value": "abc", "domain": ""}],
+        )
+        # empty_domain triggers first; not host_prefix
+        assert "host_prefix_with_domain" not in [d["reason"] for d in dropped]
+
+    def test_drops_ip_literal_domain(self):
+        for domain in ["127.0.0.1", "[::1]", "192.168.1.1"]:
+            accepted, dropped, _ = _validate_cookies(
+                [{"name": "sid", "value": "x", "domain": domain}],
+            )
+            assert accepted == []
+            assert dropped == [{"reason": "ip_domain_unsupported", "count": 1}]
+
+    def test_drops_invalid_samesite(self):
+        accepted, dropped, _ = _validate_cookies(
+            [{"name": "sid", "value": "x", "domain": ".example.com",
+              "sameSite": "BadValue"}],
+        )
+        assert accepted == []
+        assert dropped == [{"reason": "invalid_samesite", "count": 1}]
+
+    def test_normalizes_samesite_case_insensitive(self):
+        accepted, _, _ = _validate_cookies(
+            [{"name": "sid", "value": "x", "domain": ".example.com",
+              "sameSite": "lax"}],
+        )
+        assert accepted[0]["sameSite"] == "Lax"
+
+    def test_rejects_string_expires(self):
+        accepted, dropped, _ = _validate_cookies(
+            [{"name": "sid", "value": "x", "domain": ".example.com",
+              "expires": "not-a-number"}],
+        )
+        assert accepted == []
+        assert dropped == [{"reason": "invalid_expires", "count": 1}]
+
+    def test_unknown_format_returns_none(self):
+        # An int payload doesn't match either format.
+        _, _, fmt = _validate_cookies(42)
+        assert fmt is None
+
+
+class TestIsIpLiteralDomain:
+    def test_ipv4(self):
+        assert _is_ip_literal_domain("127.0.0.1")
+        assert _is_ip_literal_domain("8.8.8.8")
+        assert _is_ip_literal_domain(".10.0.0.1")  # leading dot stripped
+
+    def test_ipv6_bracketed(self):
+        assert _is_ip_literal_domain("[::1]")
+        assert _is_ip_literal_domain("[2001:db8::1]")
+
+    def test_normal_domain(self):
+        assert not _is_ip_literal_domain(".example.com")
+        assert not _is_ip_literal_domain("not.an.ip")
+
+    def test_octet_out_of_range_rejected(self):
+        # 999 is not a valid octet — must NOT be classified as IP.
+        assert not _is_ip_literal_domain("999.999.999.999")
+
+
+# ────────────────────────────────────────────────────────────────────────
+# HTTP-level tests (full router)
+# ────────────────────────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def setup(monkeypatch):
+    """Build a fresh dashboard router + browser-service stub per test."""
+    tmpdir = tempfile.mkdtemp()
+    components = _make_components(tmpdir)
+    tracker = _stub_browser_service(monkeypatch)
+    client = _make_client(components)
+    yield {
+        "client": client,
+        "components": components,
+        "tracker": tracker,
+        "tmpdir": tmpdir,
+    }
+    _teardown(components)
+    shutil.rmtree(tmpdir, ignore_errors=True)
+
+
+# Reset the cookie-import rate-limit dict between tests by tearing
+# down and rebuilding the router fresh in each test (the fixture does this).
+
+
+class TestAuditLogValueRedaction:
+    """The most critical property: audit log MUST NEVER contain cookie values."""
+
+    def test_audit_log_no_value(self, setup, caplog):
+        """Captured log text contains domain + name but NEVER value."""
+        client = setup["client"]
+        # Build a payload where each cookie's VALUE is one of the secret shapes.
+        cookies = [
+            {"name": f"sid_{i}", "value": secret,
+             "domain": f".example{i}.com"}
+            for i, secret in enumerate(_SECRET_VALUES)
+        ]
+        with caplog.at_level(logging.INFO, logger="dashboard.cookie_import"):
+            resp = client.post(
+                "/dashboard/api/agents/alpha/browser/import_cookies",
+                json={"format": "playwright", "cookies": cookies},
+            )
+        assert resp.status_code == 200, resp.text
+        # Concatenate every captured record.
+        log_text = "\n".join(r.getMessage() for r in caplog.records)
+        # Domains AND names should appear (proves audit hit and we have
+        # the right log messages).
+        for c in cookies:
+            assert c["domain"] in log_text
+            assert c["name"] in log_text
+        # NONE of the cookie values should appear in any form.
+        for secret in _SECRET_VALUES:
+            assert secret not in log_text, (
+                f"Cookie value leaked into audit log: {secret!r}"
+            )
+        # Also assert structural negatives — common patterns within values.
+        assert "raw-secretvalue" not in log_text
+        assert "eyJhbGciOiJIUzI1NiIs" not in log_text
+        assert "Bearer abc123" not in log_text
+
+    def test_audit_log_no_value_in_netscape_path(self, setup, caplog):
+        """Same property when the input format is Netscape TSV."""
+        client = setup["client"]
+        # Build a Netscape blob whose VALUE column carries each secret.
+        ns = "\n".join(
+            f".example{i}.com\tTRUE\t/\tTRUE\t1735689600\tsid_{i}\t{secret}"
+            for i, secret in enumerate(_SECRET_VALUES)
+        )
+        with caplog.at_level(logging.INFO, logger="dashboard.cookie_import"):
+            resp = client.post(
+                "/dashboard/api/agents/alpha/browser/import_cookies",
+                json={"format": "netscape", "cookies": ns},
+            )
+        assert resp.status_code == 200, resp.text
+        log_text = "\n".join(r.getMessage() for r in caplog.records)
+        for secret in _SECRET_VALUES:
+            assert secret not in log_text
+
+
+class TestHappyPaths:
+    def test_playwright_format_pushes_to_browser_service(self, setup):
+        client = setup["client"]
+        tracker = setup["tracker"]
+        cookies = [
+            {"name": "sid", "value": "abc",
+             "domain": ".example.com", "path": "/",
+             "expires": 1735689600,
+             "httpOnly": True, "secure": True, "sameSite": "Lax"},
+        ]
+        resp = client.post(
+            "/dashboard/api/agents/alpha/browser/import_cookies",
+            json={"format": "playwright", "cookies": cookies},
+        )
+        assert resp.status_code == 200, resp.text
+        data = resp.json()
+        assert data["success"] is True
+        assert data["data"]["imported"] == 1
+        assert data["data"]["format"] == "playwright"
+        # Browser service was actually called.
+        assert any(
+            c["url"].endswith("/browser/alpha/import_cookies")
+            for c in tracker["calls"]
+        )
+        # The list pushed contains the normalized shape (sameSite still "Lax").
+        pushed = next(
+            c for c in tracker["calls"]
+            if c["url"].endswith("/browser/alpha/import_cookies")
+        )
+        assert pushed["json"]["cookies"][0]["sameSite"] == "Lax"
+
+    def test_netscape_format_with_httponly_prefix(self, setup):
+        client = setup["client"]
+        tracker = setup["tracker"]
+        ns = (
+            "# Netscape\n"
+            "#HttpOnly_.example.com\tTRUE\t/\tTRUE\t1735689600\tsid\tabc\n"
+        )
+        resp = client.post(
+            "/dashboard/api/agents/alpha/browser/import_cookies",
+            json={"format": "netscape", "cookies": ns},
+        )
+        assert resp.status_code == 200, resp.text
+        data = resp.json()
+        assert data["success"] is True
+        assert data["data"]["imported"] == 1
+        # Verify the pushed cookie has httpOnly=True.
+        pushed = next(
+            c for c in tracker["calls"]
+            if c["url"].endswith("/browser/alpha/import_cookies")
+        )
+        cookie = pushed["json"]["cookies"][0]
+        assert cookie["httpOnly"] is True
+        assert cookie["domain"] == ".example.com"
+
+
+class TestCSRFAndAuth:
+    def test_csrf_rejection_no_x_requested_with(self, setup):
+        client = TestClient(_make_client(setup["components"]).app)
+        # Bare TestClient — no X-Requested-With injection.
+        resp = client.post(
+            "/dashboard/api/agents/alpha/browser/import_cookies",
+            json={"format": "playwright", "cookies": []},
+        )
+        assert resp.status_code == 403
+        assert "X-Requested-With" in resp.text
+
+    def test_auth_rejection_in_hosted_mode(self, setup, monkeypatch, tmp_path):
+        """When access token file is present, missing ol_session → 401."""
+        from src.dashboard import auth
+        # Create a fake access token + hosted indicator so verify_session_cookie
+        # enters hosted-mode behavior.
+        token_path = tmp_path / "access_token"
+        token_path.write_text("test-access-token")
+        hosted_indicator = tmp_path / ".subdomain"
+        hosted_indicator.write_text("test")
+        monkeypatch.setattr(auth, "_ACCESS_TOKEN_PATH", str(token_path))
+        monkeypatch.setattr(auth, "_HOSTED_INDICATOR", str(hosted_indicator))
+        auth.reset_cache()
+        # Reset _is_hosted cache.
+        monkeypatch.setattr(auth, "_is_hosted", None)
+        client = setup["client"]
+        resp = client.post(
+            "/dashboard/api/agents/alpha/browser/import_cookies",
+            json={"format": "playwright", "cookies": []},
+        )
+        assert resp.status_code == 401
+        # Cleanup auth cache so other tests in this session aren't affected.
+        auth.reset_cache()
+
+
+class TestRateLimit:
+    def test_eleventh_call_within_window_returns_429(self, setup):
+        client = setup["client"]
+        # Send 10 requests — all should succeed.
+        for i in range(10):
+            resp = client.post(
+                "/dashboard/api/agents/alpha/browser/import_cookies",
+                json={"format": "playwright",
+                      "cookies": [{"name": f"sid{i}", "value": "x",
+                                   "domain": ".example.com"}]},
+            )
+            assert resp.status_code == 200, f"call {i}: {resp.text}"
+        # 11th must be rate-limited.
+        resp = client.post(
+            "/dashboard/api/agents/alpha/browser/import_cookies",
+            json={"format": "playwright",
+                  "cookies": [{"name": "sidX", "value": "x",
+                               "domain": ".example.com"}]},
+        )
+        assert resp.status_code == 429
+        body = resp.json()
+        # FastAPI nests the structured body under "detail" when raising HTTPException.
+        err = body.get("detail", {}).get("error") or body.get("error") or {}
+        assert err.get("code") == "conflict"
+        assert err.get("retry_after_ms") and err["retry_after_ms"] > 0
+
+
+class TestKillSwitch:
+    def test_disabled_flag_returns_403(self, setup, monkeypatch):
+        from src.browser import flags as _flags
+        monkeypatch.setenv("BROWSER_COOKIE_IMPORT_DISABLED", "1")
+        # Reload settings cache so the flag picks up.
+        _flags.reload_operator_settings()
+        client = setup["client"]
+        resp = client.post(
+            "/dashboard/api/agents/alpha/browser/import_cookies",
+            json={"format": "playwright", "cookies": []},
+        )
+        assert resp.status_code == 403
+        body = resp.json()
+        err = body.get("detail", {}).get("error") or {}
+        assert err.get("code") == "forbidden"
+
+
+class TestSizeCaps:
+    def test_per_cookie_value_too_large(self, setup):
+        client = setup["client"]
+        # 5 KiB > 4 KiB cap; cookie should be DROPPED (not import-fail).
+        resp = client.post(
+            "/dashboard/api/agents/alpha/browser/import_cookies",
+            json={"format": "playwright",
+                  "cookies": [{"name": "sid", "value": "x" * 5000,
+                               "domain": ".example.com"}]},
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["success"] is True
+        assert data["data"]["imported"] == 0
+        reasons = [d["reason"] for d in data["data"]["dropped"]]
+        assert "value_too_large" in reasons
+
+    def test_total_payload_too_large(self, setup):
+        client = setup["client"]
+        # 257 KiB raw bytes — must be 413 BEFORE we even parse JSON.
+        big = "x" * (257 * 1024)
+        resp = client.post(
+            "/dashboard/api/agents/alpha/browser/import_cookies",
+            content=big,
+            headers={"Content-Type": "application/json"},
+        )
+        assert resp.status_code == 413
+        body = resp.json()
+        err = body.get("detail", {}).get("error") or {}
+        assert err.get("code") == "size_limit"
+
+    def test_list_length_cap_exceeded(self, setup):
+        """1001 cookies → 413 envelope."""
+        client = setup["client"]
+        # Use minimal payload per cookie to stay under 256 KiB total.
+        cookies = [
+            {"name": f"s{i}", "value": "v", "domain": ".example.com"}
+            for i in range(1001)
+        ]
+        resp = client.post(
+            "/dashboard/api/agents/alpha/browser/import_cookies",
+            json={"format": "playwright", "cookies": cookies},
+        )
+        assert resp.status_code == 413
+        body = resp.json()
+        err = body.get("detail", {}).get("error") or {}
+        assert err.get("code") == "size_limit"
+
+
+class TestDropReasons:
+    def test_host_prefix_with_domain_dropped(self, setup):
+        client = setup["client"]
+        resp = client.post(
+            "/dashboard/api/agents/alpha/browser/import_cookies",
+            json={"format": "playwright",
+                  "cookies": [{"name": "__Host-sess", "value": "x",
+                               "domain": ".example.com"}]},
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["data"]["imported"] == 0
+        reasons = [d["reason"] for d in data["data"]["dropped"]]
+        assert "host_prefix_with_domain" in reasons
+
+    def test_ip_literal_dropped(self, setup):
+        client = setup["client"]
+        resp = client.post(
+            "/dashboard/api/agents/alpha/browser/import_cookies",
+            json={"format": "playwright",
+                  "cookies": [{"name": "sid", "value": "x",
+                               "domain": "127.0.0.1"}]},
+        )
+        data = resp.json()
+        reasons = [d["reason"] for d in data["data"]["dropped"]]
+        assert "ip_domain_unsupported" in reasons
+
+    def test_invalid_samesite_dropped(self, setup):
+        client = setup["client"]
+        resp = client.post(
+            "/dashboard/api/agents/alpha/browser/import_cookies",
+            json={"format": "playwright",
+                  "cookies": [{"name": "sid", "value": "x",
+                               "domain": ".example.com",
+                               "sameSite": "RandomGarbage"}]},
+        )
+        data = resp.json()
+        reasons = [d["reason"] for d in data["data"]["dropped"]]
+        assert "invalid_samesite" in reasons
+
+
+class TestInvalidInput:
+    def test_invalid_json_returns_400(self, setup):
+        client = setup["client"]
+        resp = client.post(
+            "/dashboard/api/agents/alpha/browser/import_cookies",
+            content="this is not json",
+            headers={"Content-Type": "application/json"},
+        )
+        assert resp.status_code == 400
+        body = resp.json()
+        err = body.get("detail", {}).get("error") or {}
+        assert err.get("code") == "invalid_input"
+
+    def test_unknown_shape_returns_400(self, setup):
+        client = setup["client"]
+        # Payload is neither a list (playwright) nor a TSV string (netscape).
+        resp = client.post(
+            "/dashboard/api/agents/alpha/browser/import_cookies",
+            json={"cookies": 42},
+        )
+        assert resp.status_code == 400
+        body = resp.json()
+        err = body.get("detail", {}).get("error") or {}
+        assert err.get("code") == "invalid_input"
+
+    def test_unknown_format_explicit(self, setup):
+        client = setup["client"]
+        resp = client.post(
+            "/dashboard/api/agents/alpha/browser/import_cookies",
+            json={"format": "curl-cookie-jar", "cookies": []},
+        )
+        assert resp.status_code == 400
+
+
+class TestIdempotencyLike:
+    def test_two_overlapping_imports_succeed(self, setup):
+        client = setup["client"]
+        cookies1 = [{"name": "sid", "value": "v1", "domain": ".example.com"}]
+        cookies2 = [
+            {"name": "sid", "value": "v2", "domain": ".example.com"},
+            {"name": "tok", "value": "v3", "domain": ".example.com"},
+        ]
+        r1 = client.post(
+            "/dashboard/api/agents/alpha/browser/import_cookies",
+            json={"format": "playwright", "cookies": cookies1},
+        )
+        r2 = client.post(
+            "/dashboard/api/agents/alpha/browser/import_cookies",
+            json={"format": "playwright", "cookies": cookies2},
+        )
+        assert r1.status_code == 200
+        assert r2.status_code == 200
+        assert r1.json()["data"]["imported"] == 1
+        assert r2.json()["data"]["imported"] == 2
+
+
+class TestBrowserServiceDown:
+    def test_browser_service_raises_returns_503(self, monkeypatch):
+        tmpdir = tempfile.mkdtemp()
+        try:
+            components = _make_components(tmpdir)
+            # Make any httpx post raise.
+            _stub_browser_service(monkeypatch, raise_exc=RuntimeError("svc down"))
+            client = _make_client(components)
+            resp = client.post(
+                "/dashboard/api/agents/alpha/browser/import_cookies",
+                json={"format": "playwright",
+                      "cookies": [{"name": "sid", "value": "x",
+                                   "domain": ".example.com"}]},
+                headers={"X-Requested-With": "XMLHttpRequest"},
+            )
+            assert resp.status_code == 503
+            body = resp.json()
+            err = body.get("detail", {}).get("error") or {}
+            assert err.get("code") == "service_unavailable"
+        finally:
+            _teardown(components)
+            shutil.rmtree(tmpdir, ignore_errors=True)
+
+    def test_browser_service_returns_500_returns_503(self, monkeypatch):
+        tmpdir = tempfile.mkdtemp()
+        try:
+            components = _make_components(tmpdir)
+            _stub_browser_service(monkeypatch, status_code=502)
+            client = _make_client(components)
+            resp = client.post(
+                "/dashboard/api/agents/alpha/browser/import_cookies",
+                json={"format": "playwright",
+                      "cookies": [{"name": "sid", "value": "x",
+                                   "domain": ".example.com"}]},
+                headers={"X-Requested-With": "XMLHttpRequest"},
+            )
+            assert resp.status_code == 503
+        finally:
+            _teardown(components)
+            shutil.rmtree(tmpdir, ignore_errors=True)
+
+
+class TestUnknownAgent:
+    def test_404_when_agent_not_in_registry(self, setup):
+        client = setup["client"]
+        resp = client.post(
+            "/dashboard/api/agents/nonexistent/browser/import_cookies",
+            json={"format": "playwright", "cookies": []},
+        )
+        assert resp.status_code == 404

--- a/tests/test_dashboard_cookie_import.py
+++ b/tests/test_dashboard_cookie_import.py
@@ -272,23 +272,85 @@ class TestValidateCookies:
         assert accepted == []
         assert dropped == [{"reason": "host_prefix_with_domain", "count": 1}]
 
-    def test_allows_host_prefix_without_domain(self):
-        # __Host- without domain (empty domain) is rejected by empty_domain rule.
-        # The valid form has domain absent entirely; we just verify host_prefix
-        # only fires when domain is set.
+    def test_allows_host_prefix_url_cookie_without_domain(self):
         accepted, dropped, _ = _validate_cookies(
-            [{"name": "__Host-sess", "value": "abc", "domain": ""}],
+            [{
+                "name": "__Host-sess",
+                "value": "abc",
+                "url": "https://example.com/",
+                "path": "/",
+                "secure": True,
+            }],
         )
-        # empty_domain triggers first; not host_prefix
-        assert "host_prefix_with_domain" not in [d["reason"] for d in dropped]
+        assert dropped == []
+        assert accepted == [{
+            "name": "__Host-sess",
+            "value": "abc",
+            "url": "https://example.com/",
+            "path": "/",
+            "secure": True,
+        }]
+
+    def test_drops_host_prefix_url_cookie_without_secure(self):
+        accepted, dropped, _ = _validate_cookies(
+            [{
+                "name": "__Host-sess",
+                "value": "abc",
+                "url": "https://example.com/",
+                "path": "/",
+                "secure": False,
+            }],
+        )
+        assert accepted == []
+        assert dropped == [{"reason": "host_prefix_without_secure", "count": 1}]
+
+    def test_drops_host_prefix_url_cookie_wrong_path(self):
+        accepted, dropped, _ = _validate_cookies(
+            [{
+                "name": "__Host-sess",
+                "value": "abc",
+                "url": "https://example.com/app",
+                "path": "/app",
+                "secure": True,
+            }],
+        )
+        assert accepted == []
+        assert dropped == [{"reason": "host_prefix_invalid_path", "count": 1}]
+
+    def test_playwright_url_cookie_supported(self):
+        accepted, dropped, fmt = _validate_cookies(
+            [{"name": "sid", "value": "abc", "url": "https://example.com/"}],
+        )
+        assert fmt == "playwright"
+        assert dropped == []
+        assert accepted[0]["url"] == "https://example.com/"
+
+    def test_domain_and_url_conflict_dropped(self):
+        accepted, dropped, _ = _validate_cookies(
+            [{
+                "name": "sid",
+                "value": "abc",
+                "domain": ".example.com",
+                "url": "https://example.com/",
+            }],
+        )
+        assert accepted == []
+        assert dropped == [{"reason": "domain_url_conflict", "count": 1}]
 
     def test_drops_ip_literal_domain(self):
-        for domain in ["127.0.0.1", "[::1]", "192.168.1.1"]:
+        for domain in ["127.0.0.1", "[::1]", "2001:db8::1", "192.168.1.1"]:
             accepted, dropped, _ = _validate_cookies(
                 [{"name": "sid", "value": "x", "domain": domain}],
             )
             assert accepted == []
             assert dropped == [{"reason": "ip_domain_unsupported", "count": 1}]
+
+    def test_drops_ip_literal_url_host(self):
+        accepted, dropped, _ = _validate_cookies(
+            [{"name": "sid", "value": "x", "url": "https://127.0.0.1/"}],
+        )
+        assert accepted == []
+        assert dropped == [{"reason": "ip_domain_unsupported", "count": 1}]
 
     def test_drops_invalid_samesite(self):
         accepted, dropped, _ = _validate_cookies(
@@ -356,6 +418,10 @@ class TestIsIpLiteralDomain:
     def test_ipv6_bracketed(self):
         assert _is_ip_literal_domain("[::1]")
         assert _is_ip_literal_domain("[2001:db8::1]")
+
+    def test_ipv6_unbracketed(self):
+        assert _is_ip_literal_domain("::1")
+        assert _is_ip_literal_domain("2001:db8::1")
 
     def test_normal_domain(self):
         assert not _is_ip_literal_domain(".example.com")

--- a/tests/test_dashboard_cookie_import.py
+++ b/tests/test_dashboard_cookie_import.py
@@ -212,6 +212,28 @@ class TestParseNetscape:
         text = "# header\n.example.com\tTRUE\t/\tTRUE\n"  # too few fields
         assert _parse_netscape(text) == []
 
+    def test_malformed_lines_reported_via_optional_sink(self):
+        """Bad lines (wrong field count, non-numeric expires) accumulate
+        in the optional ``malformed`` list so callers can surface a
+        ``malformed_line`` drop count to the operator."""
+        text = (
+            ".example.com\tTRUE\t/\tTRUE\t100\tname\tval\n"  # ok
+            ".example.com\tTRUE\t/\tTRUE\n"                   # too few fields
+            ".example.com\tTRUE\t/\tTRUE\tnope\tn\tv\n"      # bad expires
+            "single-column-junk\n"                            # too few fields
+        )
+        sink: list[str] = []
+        result = _parse_netscape(text, malformed=sink)
+        assert len(result) == 1
+        # 3 malformed lines captured (2 field_count + 1 expires).
+        assert len(sink) == 3
+        # Sink contains category strings only — never the raw bad line
+        # (which could include cookie values).
+        assert all(reason in {"field_count", "expires"} for reason in sink)
+        for reason in sink:
+            assert "single-column-junk" not in reason
+            assert "nope" not in reason
+
     def test_unicode_domain_accepted(self):
         text = ".пример.com\tTRUE\t/\tTRUE\t100\tsid\txyz\n"
         result = _parse_netscape(text)
@@ -295,6 +317,34 @@ class TestValidateCookies:
         # An int payload doesn't match either format.
         _, _, fmt = _validate_cookies(42)
         assert fmt is None
+
+    def test_secure_prefix_passes_through(self):
+        """``__Secure-`` cookies have no special validation here —
+        Playwright/Firefox enforces the ``secure=true`` rule at SET time,
+        not at import. Importing a ``__Secure-foo`` with a domain is
+        therefore expected to be ACCEPTED by ``_validate_cookies``."""
+        accepted, dropped, fmt = _validate_cookies(
+            [{"name": "__Secure-sess", "value": "x",
+              "domain": ".example.com", "secure": True}],
+        )
+        assert fmt == "playwright"
+        assert len(accepted) == 1
+        assert dropped == []
+
+    def test_netscape_malformed_lines_surface_as_drop_count(self):
+        """When the input is Netscape and contains malformed lines, the
+        ``dropped`` aggregate must include a ``malformed_line`` entry —
+        operators previously got a silent zero-import result."""
+        ns = (
+            ".example.com\tTRUE\t/\tTRUE\t100\tsid\tabc\n"   # ok
+            ".example.com\tTRUE\t/\tTRUE\n"                   # too few fields
+            ".example.com\tTRUE\t/\tTRUE\tNaN\tn\tv\n"       # bad expires
+        )
+        accepted, dropped, fmt = _validate_cookies(ns, fmt="netscape")
+        assert fmt == "netscape"
+        assert len(accepted) == 1
+        reasons = {d["reason"]: d["count"] for d in dropped}
+        assert reasons.get("malformed_line") == 2
 
 
 class TestIsIpLiteralDomain:
@@ -727,3 +777,59 @@ class TestUnknownAgent:
             json={"format": "playwright", "cookies": []},
         )
         assert resp.status_code == 404
+
+
+class TestBrowserServiceErrorRedaction:
+    """Phase 6 §9.2 third-pass review: the browser service must NEVER
+    echo a Playwright-supplied error string back to the dashboard. Even
+    if a future Playwright update changes the error shape (so the prior
+    substring heuristic for ``value`` would miss it), the response must
+    use a generic message.
+    """
+
+    def test_browser_service_import_returns_generic_message(self):
+        """Direct unit test of ``BrowserManager.import_cookies``: when
+        the underlying ``add_cookies`` raises an exception whose message
+        embeds a cookie value, the response message MUST be the static
+        ``cookie import failed`` string."""
+        import asyncio
+        from unittest.mock import AsyncMock, MagicMock
+
+        from src.browser.service import BrowserManager
+
+        mgr = BrowserManager.__new__(BrowserManager)
+
+        # Stub get_or_start to return a fake instance whose context
+        # raises a Playwright-shaped error — exactly what we don't want
+        # leaked back to the operator.
+        ctx_mock = MagicMock()
+        leaky_msg = "cookie name=session domain=evil.com VALUE=sk_live_DEADBEEF rejected"
+        ctx_mock.add_cookies = AsyncMock(side_effect=RuntimeError(leaky_msg))
+
+        inst_mock = MagicMock()
+        inst_mock.context = ctx_mock
+        inst_mock.touch = MagicMock()
+
+        class _AsyncCM:
+            async def __aenter__(self):
+                return None
+
+            async def __aexit__(self, *a):
+                return False
+
+        inst_mock.lock = _AsyncCM()
+        mgr.get_or_start = AsyncMock(return_value=inst_mock)
+
+        result = asyncio.run(
+            mgr.import_cookies("alpha", [{"name": "x", "value": "y",
+                                          "domain": ".e.com", "path": "/"}]),
+        )
+        assert result["success"] is False
+        msg = result["error"]["message"]
+        # Generic string regardless of Playwright error shape.
+        assert "cookie import failed" in msg.lower()
+        # MUST NOT include the secret or any Playwright-supplied detail.
+        assert "sk_live" not in msg
+        assert "DEADBEEF" not in msg
+        assert "session" not in msg.lower() or msg.lower().count("session") == 0
+        assert leaky_msg not in msg


### PR DESCRIPTION
## Summary

Operator-only dashboard endpoint (NOT an agent action) to import Playwright OR Netscape cookie JSON into a target agent's browser profile.

- `POST /api/agents/{agent_id}/browser/import_cookies` on the dashboard router. Auth via existing `ol_session` cookie. CSRF via `X-Requested-With`.
- Auto-detects Playwright list-of-dicts vs Netscape TSV.
- **Audit log records domain + cookie name only — NEVER values.** Verified by tests that assert raw secrets, JWT-shapes, Bearer tokens, and SigV4-shapes never appear in captured log records.
- Rate-limited 10/hr per `(operator_session_id, agent_id)` sliding window. 11th call → 429 with `retry_after_ms`.
- Validation matrix: per-cookie value ≤ 4 KiB, total payload ≤ 256 KiB, list ≤ 1000 entries, `__Host-` prefix with `domain` rejected, IP-literal domains rejected, invalid SameSite rejected.
- Operator kill-switch: `BROWSER_COOKIE_IMPORT_DISABLED=1` → 403.
- Frontend Alpine partial — state in `x-data` only, never `localStorage`. Inline at-rest leak warning per §13 risk register row (Firefox `cookies.sqlite` plaintext).
- `import_cookies` is intentionally NOT in `KNOWN_BROWSER_ACTIONS` — agents cannot invoke it via the agent-facing mesh; the bearer-auth on the browser service is the security boundary, and the dashboard endpoint is the only legitimate caller.

Plan: `docs/plans/2026-04-20-browser-automation.md` §9.2. Security-review-gated per §12.4.

## Test plan

- [x] 41 new tests in `tests/test_dashboard_cookie_import.py` (audit values-NEVER on both formats, CSRF, auth, rate limit, kill-switch, all validation reasons, idempotency, browser-service-down).
- [x] 725-test wider regression sweep — 0 failures.
- [x] `ruff check` — clean.
- [x] Independent principal-engineer review pass — LGTM, no fixes.