### PR TITLE
Phase 6 §9.4: browser_fill_form with CAPTCHA-aware partial-success

### DIFF
--- a/src/agent/builtins/browser_tool.py
+++ b/src/agent/builtins/browser_tool.py
@@ -744,10 +744,15 @@ async def browser_find_text(
         "CAPTCHA, then call browser_fill_form again with the remaining "
         "fields. Set submit_after=true (top-level OR per-field) to press "
         "Enter after typing. Each field requires a 'label' (visible text "
-        "near the input) and 'value' (string to fill). Use this when you "
-        "have a clear list of name/email/password fields; for adaptive "
-        "flows where labels reveal themselves only after each click, use "
-        "browser_get_elements + browser_type field-by-field instead."
+        "near the input) and 'value' (string to fill). The response "
+        "always includes 'submitted': true if Enter was pressed (final "
+        "or per-field), false otherwise. If submitted=true alongside "
+        "captcha_required=true, the form may have ALREADY been submitted "
+        "with partial data — re-snapshot before blindly resuming. Use "
+        "this when you have a clear list of name/email/password fields; "
+        "for adaptive flows where labels reveal themselves only after "
+        "each click, use browser_get_elements + browser_type "
+        "field-by-field instead."
     ),
     parameters={
         "fields": {

--- a/src/agent/builtins/browser_tool.py
+++ b/src/agent/builtins/browser_tool.py
@@ -436,6 +436,49 @@ async def browser_click(
 
 
 @skill(
+    name="browser_click_xy",
+    description=(
+        "Click at viewport-relative pixel coordinates (x, y). Useful for "
+        "canvas, custom-rendered widgets, or non-accessible interactives "
+        "where browser_get_elements does not surface a ref. Performs a "
+        "document.elementFromPoint pre-check — if an overlay or "
+        "pointer-events:none ancestor would intercept the click, the call "
+        "returns invalid_input with the actual hit element's tag/role/name "
+        "so you can re-target. Coordinates are bounded by the current "
+        "viewport (typically 0 <= x < 1280 and 0 <= y < 800; verify via "
+        "browser_status if unsure). Prefer browser_click(ref) when "
+        "possible — coordinate clicks are brittle across resolution changes."
+    ),
+    parameters={
+        "x": {
+            "type": "number",
+            "description": (
+                "Viewport-relative x coordinate in pixels. Origin is the "
+                "top-left of the rendered page area; must satisfy "
+                "0 <= x < viewport.width."
+            ),
+        },
+        "y": {
+            "type": "number",
+            "description": (
+                "Viewport-relative y coordinate in pixels. Origin is the "
+                "top-left of the rendered page area; must satisfy "
+                "0 <= y < viewport.height."
+            ),
+        },
+    },
+    parallel_safe=False,
+)
+async def browser_click_xy(
+    x: float, y: float, *, mesh_client=None,
+) -> dict:
+    """Click at viewport-relative pixel coordinates."""
+    return await _browser_command(
+        mesh_client, "click_xy", {"x": x, "y": y},
+    )
+
+
+@skill(
     name="browser_type",
     description=(
         "Type text into a form field on the current page. Optionally clears the "

--- a/src/agent/builtins/browser_tool.py
+++ b/src/agent/builtins/browser_tool.py
@@ -438,31 +438,44 @@ async def browser_click(
 @skill(
     name="browser_click_xy",
     description=(
-        "Click at viewport-relative pixel coordinates (x, y). Useful for "
-        "canvas, custom-rendered widgets, or non-accessible interactives "
-        "where browser_get_elements does not surface a ref. Performs a "
-        "document.elementFromPoint pre-check — if an overlay or "
-        "pointer-events:none ancestor would intercept the click, the call "
-        "returns invalid_input with the actual hit element's tag/role/name "
-        "so you can re-target. Coordinates are bounded by the current "
-        "viewport (typically 0 <= x < 1280 and 0 <= y < 800; verify via "
-        "browser_status if unsure). Prefer browser_click(ref) when "
-        "possible — coordinate clicks are brittle across resolution changes."
+        "Click at viewport-relative CSS pixel coordinates (x, y). Useful "
+        "for canvas, custom-rendered widgets, or non-accessible "
+        "interactives where browser_get_elements does not surface a ref. "
+        "Performs a document.elementFromPoint pre-check — if an overlay "
+        "or pointer-events:none ancestor would intercept the click, the "
+        "call returns invalid_input with the actual hit element's "
+        "tag/role/name so you can re-target. "
+        "Coordinates are CSS pixels (NOT device pixels — devicePixelRatio "
+        "is ignored), viewport-relative, and bounded by the current "
+        "viewport (call browser_status for exact width/height — fleet "
+        "resolutions vary, e.g. 1920x1080, 1366x768, 1536x864). "
+        "Coordinates are NOT document-absolute: after a scroll, resize, "
+        "or any DOM-relayout interaction, the same (x, y) hits a "
+        "different element — recompute coords from a fresh snapshot. "
+        "Limitations: (a) cross-origin iframes — elementFromPoint "
+        "returns the <iframe> element, not its inner document, so "
+        "actual_element will be uninformative; (b) shadow DOM — "
+        "elementFromPoint returns the shadow host, not the inner shadow "
+        "element; (c) the post-click CAPTCHA check is best-effort and "
+        "may race the challenge render — call browser_detect_captcha "
+        "after a short delay if the click likely triggered a challenge. "
+        "Prefer browser_click(ref) when possible — coordinate clicks "
+        "are brittle across resolution changes."
     ),
     parameters={
         "x": {
             "type": "number",
             "description": (
-                "Viewport-relative x coordinate in pixels. Origin is the "
-                "top-left of the rendered page area; must satisfy "
+                "Viewport-relative x coordinate in CSS pixels. Origin is "
+                "the top-left of the rendered page area; must satisfy "
                 "0 <= x < viewport.width."
             ),
         },
         "y": {
             "type": "number",
             "description": (
-                "Viewport-relative y coordinate in pixels. Origin is the "
-                "top-left of the rendered page area; must satisfy "
+                "Viewport-relative y coordinate in CSS pixels. Origin is "
+                "the top-left of the rendered page area; must satisfy "
                 "0 <= y < viewport.height."
             ),
         },
@@ -472,7 +485,7 @@ async def browser_click(
 async def browser_click_xy(
     x: float, y: float, *, mesh_client=None,
 ) -> dict:
-    """Click at viewport-relative pixel coordinates."""
+    """Click at viewport-relative CSS pixel coordinates."""
     return await _browser_command(
         mesh_client, "click_xy", {"x": x, "y": y},
     )

--- a/src/agent/builtins/browser_tool.py
+++ b/src/agent/builtins/browser_tool.py
@@ -779,6 +779,50 @@ async def browser_open_tab(
 
 
 @skill(
+    name="browser_inspect_requests",
+    description=(
+        "List recent network requests from the current browser context "
+        "(URLs only, redacted; no bodies/headers). Useful for verifying "
+        "which third-party endpoints a page hit, debugging when a page "
+        "seems broken because adblock dropped requests, or confirming a "
+        "form POST went through. Returns up to 50 most-recent entries by "
+        "default. Set include_blocked=true to include adblock-suppressed "
+        "entries (verbose; usually you don't want this)."
+    ),
+    parameters={
+        "include_blocked": {
+            "type": "boolean",
+            "description": (
+                "Include requests blocked by the in-browser ad-blocker. "
+                "Default false — adblock-suppressed trackers are usually "
+                "noise. Set true when debugging missing analytics or "
+                "third-party widgets."
+            ),
+            "default": False,
+        },
+        "limit": {
+            "type": "integer",
+            "description": (
+                "Max number of newest-first entries to return. Default 50, "
+                "max 200 (the underlying buffer size). Values above 200 "
+                "are coerced to 200."
+            ),
+            "default": 50,
+        },
+    },
+    parallel_safe=False,
+)
+async def browser_inspect_requests(
+    include_blocked: bool = False, limit: int = 50, *, mesh_client=None,
+) -> dict:
+    """List recent network requests for the current browser context."""
+    return await _browser_command(
+        mesh_client, "inspect_requests",
+        {"include_blocked": bool(include_blocked), "limit": int(limit)},
+    )
+
+
+@skill(
     name="browser_detect_captcha",
     description=(
         "Detect CAPTCHAs (reCAPTCHA, hCaptcha, Cloudflare Turnstile) on the "

--- a/src/agent/builtins/browser_tool.py
+++ b/src/agent/builtins/browser_tool.py
@@ -734,6 +734,82 @@ async def browser_find_text(
 
 
 @skill(
+    name="browser_fill_form",
+    description=(
+        "Fill multiple form fields by their visible labels in one call. "
+        "For each field, locates the input by label text (find_text under "
+        "the hood), then fills the value (clears existing content first). "
+        "On CAPTCHA detection mid-flow, returns partial_success with the "
+        "fields that were filled and the fields that remain — solve the "
+        "CAPTCHA, then call browser_fill_form again with the remaining "
+        "fields. Set submit_after=true (top-level OR per-field) to press "
+        "Enter after typing. Each field requires a 'label' (visible text "
+        "near the input) and 'value' (string to fill). Use this when you "
+        "have a clear list of name/email/password fields; for adaptive "
+        "flows where labels reveal themselves only after each click, use "
+        "browser_get_elements + browser_type field-by-field instead."
+    ),
+    parameters={
+        "fields": {
+            "type": "array",
+            "description": (
+                "Ordered list of fields to fill. Each entry: "
+                "{label: <visible label text>, value: <string to fill>, "
+                "submit_after?: <press Enter after this field, default "
+                "false>}. 1–50 entries; label 1–500 chars; value up to "
+                "10000 chars."
+            ),
+            "items": {
+                "type": "object",
+                "properties": {
+                    "label": {
+                        "type": "string",
+                        "description": (
+                            "Visible label text for the input "
+                            "(case-insensitive substring match)."
+                        ),
+                    },
+                    "value": {
+                        "type": "string",
+                        "description": "Value to fill into the input.",
+                    },
+                    "submit_after": {
+                        "type": "boolean",
+                        "description": (
+                            "Press Enter on this field after filling. "
+                            "Default false."
+                        ),
+                        "default": False,
+                    },
+                },
+                "required": ["label", "value"],
+            },
+        },
+        "submit_after": {
+            "type": "boolean",
+            "description": (
+                "Press Enter on the LAST filled field after the loop "
+                "completes (skipped if a CAPTCHA stopped the flow). "
+                "Default false."
+            ),
+            "default": False,
+        },
+    },
+    parallel_safe=False,
+)
+async def browser_fill_form(
+    fields: list, submit_after: bool = False, *, mesh_client=None,
+) -> dict:
+    """Fill a sequence of form fields by visible label."""
+    if not isinstance(fields, list):
+        return {"error": "The 'fields' parameter must be an array"}
+    return await _browser_command(
+        mesh_client, "fill_form",
+        {"fields": fields, "submit_after": submit_after},
+    )
+
+
+@skill(
     name="browser_open_tab",
     description=(
         "Open a URL in a new browser tab. The new tab becomes the active "

--- a/src/agent/builtins/browser_tool.py
+++ b/src/agent/builtins/browser_tool.py
@@ -787,7 +787,20 @@ async def browser_open_tab(
         "seems broken because adblock dropped requests, or confirming a "
         "form POST went through. Returns up to 50 most-recent entries by "
         "default. Set include_blocked=true to include adblock-suppressed "
-        "entries (verbose; usually you don't want this)."
+        "entries (verbose; usually you don't want this).\n\n"
+        "Buffer holds the most recent 200 requests per agent; older "
+        "entries are evicted automatically. URLs are redacted at "
+        "store-time (userinfo stripped, JWT-shaped path segments masked, "
+        "sensitive query values like token/api_key replaced with "
+        "[REDACTED]).\n\n"
+        "Each entry has: url (str, redacted), method (str), "
+        "resource_type (str, one of: document, stylesheet, image, media, "
+        "font, script, texttrack, xhr, fetch, eventsource, websocket, "
+        "manifest, other), ts (str, ISO-8601 UTC like "
+        "'2026-04-26T12:34:56Z'), status (int|null — currently always "
+        "null; reserved for future response-status capture), "
+        "blocked_by_adblock (bool), user_cancelled (bool), "
+        "failed_network (bool)."
     ),
     parameters={
         "include_blocked": {

--- a/src/browser/server.py
+++ b/src/browser/server.py
@@ -604,6 +604,23 @@ def create_browser_app(manager: BrowserManager, lifespan=None) -> FastAPI:
         await _apply_delay()
         return result
 
+    @app.post("/browser/{agent_id}/import_cookies")
+    async def import_cookies(agent_id: str, request: Request):
+        """Phase 6 §9.2 — operator-only cookie/session import.
+
+        NOT in ``KNOWN_BROWSER_ACTIONS`` — agents cannot reach this via
+        the ``/mesh/browser/command`` proxy. The dashboard endpoint calls
+        this route directly with the browser-service bearer token.
+        Validation and shape coercion happen upstream in the dashboard.
+        """
+        _verify_auth(request)
+        body = await request.json()
+        cookies = body.get("cookies")
+        if not isinstance(cookies, list):
+            raise HTTPException(400, "cookies must be a list")
+        result = await manager.import_cookies(agent_id, cookies)
+        return result
+
     # ── Settings ───────────────────────────────────────────────────────────
 
     @app.get("/browser/settings")

--- a/src/browser/server.py
+++ b/src/browser/server.py
@@ -206,6 +206,29 @@ def create_browser_app(manager: BrowserManager, lifespan=None) -> FastAPI:
         await _apply_delay()
         return result
 
+    @app.post("/browser/{agent_id}/click_xy")
+    async def click_xy(agent_id: str, request: Request):
+        """Phase 6 §9.3: click at viewport-relative pixel coordinates.
+
+        Manager-side performs a ``document.elementFromPoint`` pre-check
+        and returns a §2.3 envelope on overlay/visibility/pointer-events
+        masking; this route only validates the JSON shape.
+        """
+        _verify_auth(request)
+        body = await request.json()
+        x = body.get("x")
+        y = body.get("y")
+        # Reject bool first — Python's ``True == 1`` would otherwise pass
+        # the (int, float) check; same gate as the manager method, but a
+        # 400 here saves a round-trip through ``get_or_start``.
+        if isinstance(x, bool) or isinstance(y, bool):
+            raise HTTPException(400, "x and y must be numbers, not booleans")
+        if not isinstance(x, (int, float)) or not isinstance(y, (int, float)):
+            raise HTTPException(400, "x and y must be numbers")
+        result = await manager.click_xy(agent_id, x=float(x), y=float(y))
+        await _apply_delay()
+        return result
+
     @app.post("/browser/{agent_id}/wait_for")
     async def wait_for(agent_id: str, request: Request):
         _verify_auth(request)

--- a/src/browser/server.py
+++ b/src/browser/server.py
@@ -604,6 +604,22 @@ def create_browser_app(manager: BrowserManager, lifespan=None) -> FastAPI:
         await _apply_delay()
         return result
 
+    @app.post("/browser/{agent_id}/inspect_requests")
+    async def inspect_requests(agent_id: str, request: Request):
+        """Phase 6 §9.1 — list recent (redacted) network requests for an agent."""
+        _verify_auth(request)
+        body = await request.json()
+        include_blocked = bool(body.get("include_blocked", False))
+        try:
+            limit = int(body.get("limit", 50))
+        except (TypeError, ValueError):
+            limit = 50
+        result = await manager.inspect_requests(
+            agent_id, include_blocked=include_blocked, limit=limit,
+        )
+        await _apply_delay()
+        return result
+
     # ── Settings ───────────────────────────────────────────────────────────
 
     @app.get("/browser/settings")

--- a/src/browser/server.py
+++ b/src/browser/server.py
@@ -590,6 +590,24 @@ def create_browser_app(manager: BrowserManager, lifespan=None) -> FastAPI:
         await _apply_delay()
         return result
 
+    @app.post("/browser/{agent_id}/fill_form")
+    async def fill_form(agent_id: str, request: Request):
+        """Phase 6 §9.4 — fill a sequence of form fields by visible label.
+
+        Manager-side handles validation (returns ``invalid_input`` envelope
+        rather than raising HTTP 400) so the agent gets the structured
+        error taxonomy. We pass the body straight through.
+        """
+        _verify_auth(request)
+        body = await request.json()
+        fields = body.get("fields") or []
+        submit_after = bool(body.get("submit_after", False))
+        result = await manager.fill_form(
+            agent_id, fields, submit_after=submit_after,
+        )
+        await _apply_delay()
+        return result
+
     @app.post("/browser/{agent_id}/open_tab")
     async def open_tab(agent_id: str, request: Request):
         _verify_auth(request)

--- a/src/browser/service.py
+++ b/src/browser/service.py
@@ -4598,6 +4598,9 @@ class BrowserManager:
                             ),
                             "retry_after_ms": None,
                             "data": {
+                                "actual_element": actual,
+                                # Back-compat for the first branch revision;
+                                # callers should prefer ``actual_element``.
                                 "actual": actual,
                                 "masked_by": masked_by,
                                 "mask_reason": hit.get("mask_reason", ""),

--- a/src/browser/service.py
+++ b/src/browser/service.py
@@ -108,6 +108,20 @@ def _resolve_filter_roles(filter_name: str | None) -> frozenset[str] | None:
     return preset
 
 
+def _iso8601_utc(ts_unix: float) -> str:
+    """Format a unix timestamp as ISO-8601 UTC with seconds precision.
+
+    Returns ``""`` when ``ts_unix`` is falsy (0 / None) so callers don't
+    have to special-case the absence of a timestamp.
+    """
+    if not ts_unix:
+        return ""
+    from datetime import datetime, timezone
+    return datetime.fromtimestamp(float(ts_unix), tz=timezone.utc).isoformat(
+        timespec="seconds",
+    ).replace("+00:00", "Z")
+
+
 def _err(
     code: str, message: str, retry_after_ms: int | None = None,
 ) -> dict:
@@ -1205,6 +1219,15 @@ class CamoufoxInstance:
         # exposes ``ok`` + ``mismatches`` + raw signal values for dashboard /
         # status endpoint consumers.
         self.probe_result: dict | None = None
+        # §9.1 network-inspection log. Bounded deque of recent
+        # ``request`` / ``requestfailed`` events, populated by listeners
+        # attached at the BrowserContext level so new tabs (in-page
+        # ``window.open()`` or ``browser_open_tab``) are covered too. URLs
+        # are redacted via ``shared.redaction.redact_url`` at store-time;
+        # the deque NEVER holds raw URLs. ``_network_attached`` is the
+        # idempotency flag for ``BrowserManager._attach_network_listeners``.
+        self.network_log: deque[dict] = deque(maxlen=200)
+        self._network_attached: bool = False
 
     def _register_page(self, page) -> str:
         """Assign a stable UUID to a Page if not already registered.
@@ -1837,6 +1860,13 @@ class BrowserManager:
             )
 
         inst = CamoufoxInstance(agent_id, browser, context, page)
+
+        # §9.1 wire request listeners at the BrowserContext level so new
+        # tabs (in-page ``window.open()`` or ``browser_open_tab``) inherit
+        # them automatically. Idempotent — also re-runs after browser RESET
+        # because RESET drops the whole instance and the next get_or_start
+        # creates a fresh one with ``_network_attached=False``.
+        self._attach_network_listeners(inst)
 
         # Discover the new X11 window for targeted focus
         wid = await self._discover_new_wid(wids_before)
@@ -5390,6 +5420,180 @@ class BrowserManager:
                 inst.page = previous_page
                 return _err("service_unavailable", "open_tab failed")
 
+    # ── §9.1 Network inspection ─────────────────────────────────
+
+    def _attach_network_listeners(self, inst: CamoufoxInstance) -> None:
+        """Wire BrowserContext-level ``request`` / ``requestfailed`` listeners.
+
+        Idempotent — second and subsequent calls return immediately. Listeners
+        are attached on the *context* so tabs opened later (via ``window.open()``
+        or :meth:`open_tab`) inherit them automatically. The current page is
+        also wired explicitly in case the context-level ``page`` event has
+        already fired for it before listeners landed.
+        """
+        if inst._network_attached:
+            return
+        try:
+            inst.context.on(
+                "page",
+                lambda p: p.on("request", lambda req: self._record_request(inst, req)),
+            )
+            if inst.page is not None:
+                inst.page.on("request", lambda req: self._record_request(inst, req))
+            inst.context.on(
+                "requestfailed",
+                lambda req: self._record_request_failed(inst, req),
+            )
+        except Exception as e:
+            # Listener wiring is best-effort: a Camoufox build that doesn't
+            # surface these events shouldn't take the browser down. The
+            # `inspect_requests` reader returns an empty list cleanly.
+            logger.debug(
+                "Network listener wiring failed for '%s': %s",
+                inst.agent_id, e,
+            )
+            return
+        inst._network_attached = True
+
+    def _record_request(self, inst: CamoufoxInstance, req) -> None:
+        """Record an outbound request. Listener; never raises."""
+        try:
+            from src.shared.redaction import redact_url
+            url = redact_url(getattr(req, "url", "") or "")
+            method = getattr(req, "method", "") or ""
+            resource_type = getattr(req, "resource_type", "") or ""
+            inst.network_log.append({
+                "url": url,
+                "method": method,
+                "resource_type": resource_type,
+                "ts": time.time(),
+                "status": None,
+                "blocked_by_adblock": False,
+                "user_cancelled": False,
+                "failed_network": False,
+            })
+        except Exception as e:
+            logger.debug("network listener record failed: %s", e)
+
+    def _record_request_failed(self, inst: CamoufoxInstance, req) -> None:
+        """Mark the matching log entry as blocked / cancelled / failed.
+
+        Updates by URL+method match if found, else discards the failure
+        update. ``requestfailed`` fires asynchronously and may overlap with
+        the request having already scrolled out of the maxlen=200 window.
+        Creating a phantom entry would mislead operators about traffic that
+        actually happened.
+        """
+        try:
+            from src.shared.redaction import redact_url
+            url = redact_url(getattr(req, "url", "") or "")
+            method = getattr(req, "method", "") or ""
+            failure = getattr(req, "failure", None)
+            # Playwright surfaces ``failure`` as a property; some bindings
+            # may expose it as a callable. Handle both.
+            if callable(failure):
+                try:
+                    failure = failure()
+                except Exception:
+                    failure = None
+            err = getattr(failure, "errorText", "") if failure else ""
+            if not isinstance(err, str):
+                err = str(err) if err else ""
+
+            blocked = False
+            cancelled = False
+            for marker in ("BLOCKED_BY_CLIENT", "CONTENT_BLOCKED", "BLOCKED_BY_POLICY"):
+                if marker in err:
+                    blocked = True
+                    break
+            # Why classify BINDING_ABORTED separately from blocked: user-
+            # cancelled is a real outcome (page nav interrupted, user hit
+            # stop), not adblock — agents debugging form submits should see
+            # these distinctly.
+            if not blocked and "BINDING_ABORTED" in err:
+                cancelled = True
+            failed_net = not (blocked or cancelled)
+
+            # Update the most recent matching entry. Reverse iteration so a
+            # rapid-fire request to the same URL+method picks up the freshest.
+            for entry in reversed(inst.network_log):
+                if entry["url"] == url and entry["method"] == method:
+                    entry["blocked_by_adblock"] = blocked
+                    entry["user_cancelled"] = cancelled
+                    entry["failed_network"] = failed_net
+                    return
+            # No match → discard. Do NOT append; would create a phantom entry.
+        except Exception as e:
+            logger.debug("network listener fail-record failed: %s", e)
+
+    async def inspect_requests(
+        self,
+        agent_id: str,
+        *,
+        include_blocked: bool = False,
+        limit: int = 50,
+    ) -> dict:
+        """Return a snapshot of recent network requests for ``agent_id``.
+
+        URLs in the deque are already redacted at store-time. The returned
+        ``requests`` list is sorted newest-first and capped at ``limit``
+        (which is itself capped at the deque maxlen of 200). When
+        ``include_blocked`` is False, entries flagged ``blocked_by_adblock``
+        are filtered out so agents aren't confused by adblock-suppressed
+        third-party trackers; the count of dropped entries is returned as
+        ``dropped_blocked``.
+        """
+        try:
+            limit = int(limit)
+        except (TypeError, ValueError):
+            limit = 50
+        if limit < 1:
+            limit = 1
+        if limit > 200:
+            limit = 200
+
+        inst = await self.get_or_start(agent_id)
+        inst.touch()
+        async with inst.lock:
+            if inst._user_control:
+                return _err(
+                    "conflict",
+                    "User has browser control — action paused until control is released.",
+                )
+            # Snapshot under the lock so we don't race a concurrent listener
+            # append. The deque itself is thread-safe for single op-pends but
+            # multi-step iteration + filter benefits from the lock.
+            entries = list(inst.network_log)
+            total = len(entries)
+            dropped = 0
+            visible: list[dict] = []
+            # Iterate newest-first.
+            for entry in reversed(entries):
+                if entry.get("blocked_by_adblock") and not include_blocked:
+                    dropped += 1
+                    continue
+                if len(visible) >= limit:
+                    continue
+                ts_unix = entry.get("ts") or 0
+                visible.append({
+                    "url": entry.get("url", ""),
+                    "method": entry.get("method", ""),
+                    "resource_type": entry.get("resource_type", ""),
+                    "ts": _iso8601_utc(ts_unix),
+                    "status": entry.get("status"),
+                    "blocked_by_adblock": bool(entry.get("blocked_by_adblock")),
+                    "user_cancelled": bool(entry.get("user_cancelled")),
+                    "failed_network": bool(entry.get("failed_network")),
+                })
+            return {
+                "success": True,
+                "data": {
+                    "requests": visible,
+                    "total": total,
+                    "dropped_blocked": dropped,
+                },
+            }
+
     async def press_key(self, agent_id: str, key: str) -> dict:
         """Press a keyboard key or combination (e.g. 'Enter', 'Escape', 'Control+a').
 
@@ -5516,3 +5720,4 @@ class BrowserManager:
                 }
             except Exception as e:
                 return {"success": False, "error": str(e)}
+

--- a/src/browser/service.py
+++ b/src/browser/service.py
@@ -5483,6 +5483,13 @@ class BrowserManager:
                 # rather than overwriting the same one. Stripped from the
                 # response payload by ``inspect_requests``.
                 "_failure_tagged": False,
+                # Pair ``requestfailed`` back to the exact Playwright
+                # Request object when possible. URL+method is retained as
+                # fallback for tests / bindings that synthesize separate
+                # objects for the failure callback, but exact object identity
+                # avoids mis-tagging a newer identical request when only an
+                # older one fails.
+                "_request_key": id(req),
             })
         except Exception as e:
             logger.debug("network listener record failed: %s", e)
@@ -5519,6 +5526,7 @@ class BrowserManager:
             err = getattr(failure, "errorText", "") if failure else ""
             if not isinstance(err, str):
                 err = str(err) if err else ""
+            request_key = id(req)
 
             blocked = False
             cancelled = False
@@ -5534,10 +5542,25 @@ class BrowserManager:
                 cancelled = True
             failed_net = not (blocked or cancelled)
 
-            # Update the newest matching entry that hasn't already been
-            # tagged. Reverse iteration so a rapid-fire request to the same
-            # URL+method picks up the freshest available slot. Skipping
-            # tagged entries makes parallel identical failures pair 1:1.
+            # Prefer the exact Request-object match. Playwright sends the
+            # same Request object to ``request`` and ``requestfailed``; using
+            # that identity prevents a failed older request from tagging a
+            # newer identical URL+method that is still in flight.
+            for entry in reversed(inst.network_log):
+                if (
+                    entry.get("_request_key") == request_key
+                    and not entry.get("_failure_tagged")
+                ):
+                    entry["blocked_by_adblock"] = blocked
+                    entry["user_cancelled"] = cancelled
+                    entry["failed_network"] = failed_net
+                    entry["_failure_tagged"] = True
+                    return
+
+            # Fallback for tests / alternate bindings that surface distinct
+            # request objects for failure events: update the newest matching
+            # entry that hasn't already been tagged. Reverse iteration keeps
+            # rapid-fire identical failures paired 1:1 via ``_failure_tagged``.
             for entry in reversed(inst.network_log):
                 if (
                     entry["url"] == url
@@ -5748,4 +5771,3 @@ class BrowserManager:
                 }
             except Exception as e:
                 return {"success": False, "error": str(e)}
-

--- a/src/browser/service.py
+++ b/src/browser/service.py
@@ -5297,6 +5297,7 @@ class BrowserManager:
     _FILL_FORM_MAX_VALUE_CHARS = 10000
     _FILL_FORM_MAX_LABEL_CHARS = 500
     _FILL_FORM_MAX_FIELDS = 50
+    _FILL_FORM_PREFERRED_ROLES = frozenset({"textbox", "searchbox", "spinbutton"})
 
     @staticmethod
     def _classify_fill_error(exc: Exception) -> str:
@@ -5498,10 +5499,32 @@ class BrowserManager:
                         )
                     continue
 
-                # Pick the first in-viewport match; fall back to first match.
-                pick = next(
-                    (m for m in matches if m.get("in_viewport")),
-                    matches[0],
+                # Prefer fillable controls when the visible label text and
+                # the input's accessible name both match. Snapshot order can
+                # put a <label> before its <input>; picking that label first
+                # would yield a needless not_fillable failure even though the
+                # correct textbox is present in the same match set.
+                def _preferred_match(m: dict) -> bool:
+                    ref_id = m.get("ref")
+                    handle = inst.refs.get(ref_id)
+                    role = (getattr(handle, "role", "") or "").lower()
+                    disabled = bool(getattr(handle, "disabled", False))
+                    return (
+                        role in self._FILL_FORM_PREFERRED_ROLES
+                        and not disabled
+                    )
+
+                pick = (
+                    next(
+                        (
+                            m for m in matches
+                            if m.get("in_viewport") and _preferred_match(m)
+                        ),
+                        None,
+                    )
+                    or next((m for m in matches if _preferred_match(m)), None)
+                    or next((m for m in matches if m.get("in_viewport")), None)
+                    or matches[0]
                 )
                 ref = pick.get("ref")
 
@@ -5583,13 +5606,14 @@ class BrowserManager:
                         submitted=submitted,
                     )
 
-            # 3) Final submit — only if no captcha interrupted us. Top-level
-            #    submit_after presses Enter on the LAST filled field's
-            #    locator. If no field was successfully filled (all
-            #    not_found / type_failed) we have no anchor to press Enter
-            #    on, so submitted stays whatever it was (False unless a
-            #    per-field submit fired earlier in the same call).
-            if submit_after and last_locator is not None:
+            all_filled = all(f.get("status") == "filled" for f in filled)
+            # 3) Final submit — only if no captcha interrupted us AND every
+            #    requested field was filled. Top-level submit_after is the
+            #    "submit the completed form" affordance; submitting after a
+            #    not_found/type_failed field would send partial data without
+            #    the caller explicitly opting into that via per-field
+            #    submit_after.
+            if submit_after and last_locator is not None and all_filled:
                 try:
                     await last_locator.press("Enter")
                     submitted = True
@@ -5599,9 +5623,7 @@ class BrowserManager:
                         agent_id, e,
                     )
 
-            partial = any(
-                f.get("status") != "filled" for f in filled
-            )
+            partial = not all_filled
             return {
                 "success": True,
                 "data": {

--- a/src/browser/service.py
+++ b/src/browser/service.py
@@ -11,6 +11,7 @@ import asyncio
 import base64
 import contextlib
 import json
+import math
 import mimetypes
 import os
 import random
@@ -641,6 +642,95 @@ __NAME_HELPERS__
 #   page.evaluate(_JS_A11Y_TREE)          — full page tree
 #   element_handle.evaluate(_JS_A11Y_TREE) — scoped to element
 _JS_A11Y_TREE = _build_js_a11y_tree()
+
+
+# Phase 6 §9.3: viewport-relative click pre-check.
+# Returns null when document.elementFromPoint(x, y) yields no element
+# (off-page or transparent root). Otherwise returns a JSON-friendly dict
+# with the hit element's tag/role/accessible-name plus a mask trace.
+#
+# Why we walk inside-out and stop at the first ``pointer-events: auto``
+# ancestor: per the CSS spec, ``pointer-events`` does NOT inherit; an
+# inner ``pointer-events: auto`` re-enables hit-testing for that subtree
+# even when an outer ancestor is ``pointer-events: none``. Naïve
+# "scan all ancestors for pointer-events: none" would falsely flag the
+# common pattern of a ``pointer-events: none`` overlay container with
+# ``pointer-events: auto`` on its interactive children. visibility/
+# display/opacity hide the subtree outright, so any ancestor matching
+# those is reported as the masking element regardless of pointer-events.
+_JS_ELEMENT_FROM_POINT = r"""([x, y]) => {
+    const el = document.elementFromPoint(x, y);
+    if (!el) return null;
+    const elementSelector = (node) => {
+        if (!node || node.nodeType !== 1) return null;
+        const tag = node.tagName ? node.tagName.toLowerCase() : "";
+        if (node.id) return tag + "#" + node.id;
+        const cls = (node.className && typeof node.className === "string")
+            ? node.className.trim().split(/\s+/).filter(Boolean).slice(0, 2).join(".")
+            : "";
+        return cls ? tag + "." + cls : tag;
+    };
+    const accName = (node) => {
+        try {
+            const aria = node.getAttribute && node.getAttribute("aria-label");
+            if (aria) return aria;
+            const title = node.getAttribute && node.getAttribute("title");
+            if (title) return title;
+            const txt = node.innerText || node.textContent || "";
+            return txt.slice(0, 80);
+        } catch (e) { return ""; }
+    };
+    let masked_by = null;
+    let mask_reason = "";
+    let pointer_events_decided = false;
+    let cur = el;
+    while (cur && cur !== document.body && cur !== document.documentElement) {
+        let cs;
+        try { cs = window.getComputedStyle(cur); } catch (e) { cs = null; }
+        if (cs) {
+            // display:none and visibility:hidden mask the subtree
+            // regardless of pointer-events. Check these unconditionally.
+            if (cs.display === "none") {
+                masked_by = elementSelector(cur);
+                mask_reason = "display";
+                break;
+            }
+            if (cs.visibility === "hidden") {
+                masked_by = elementSelector(cur);
+                mask_reason = "visibility";
+                break;
+            }
+            // opacity:0 — fully transparent, treat as masked.
+            if (cs.opacity === "0") {
+                masked_by = elementSelector(cur);
+                mask_reason = "opacity";
+                break;
+            }
+            // pointer-events: walk inside-out. The closest ancestor to
+            // the hit element with ``pointer-events: auto`` re-enables
+            // hit-testing for everything below it; stop checking
+            // pointer-events at that boundary. A ``none`` ancestor seen
+            // before any ``auto`` boundary masks the click.
+            if (!pointer_events_decided && cs.pointerEvents) {
+                if (cs.pointerEvents === "auto") {
+                    pointer_events_decided = true;
+                } else if (cs.pointerEvents === "none") {
+                    masked_by = elementSelector(cur);
+                    mask_reason = "pointer-events";
+                    break;
+                }
+            }
+        }
+        cur = cur.parentElement;
+    }
+    return {
+        tag: el.tagName ? el.tagName.toLowerCase() : "",
+        role: (el.getAttribute && el.getAttribute("role")) || null,
+        name: accName(el),
+        masked_by: masked_by,
+        mask_reason: mask_reason,
+    };
+}"""
 
 
 # Stage-1 (walk shadow_path → return inner shadowRoot) and Stage-2
@@ -4407,6 +4497,139 @@ class BrowserManager:
                 inst.click_window.append(False)
                 inst.recorder.record_click(method="auto", success=False)
                 return {"success": False, "error": str(e)}
+
+    async def click_xy(
+        self, agent_id: str, x: float, y: float,
+    ) -> dict:
+        """Phase 6 §9.3: click at viewport-relative pixel coordinates.
+
+        ``(x, y)`` are viewport-relative pixels — origin is the top-left
+        of the rendered page area (NOT the screen, NOT including window
+        chrome). The method first calls ``document.elementFromPoint(x, y)``
+        and walks up the ancestor chain to detect overlay/visibility/
+        pointer-events masking; on a clean hit the click is dispatched via
+        ``page.mouse.click(x, y)``.
+
+        Returns a §2.3 success or error envelope. The mask walk respects
+        the CSS cascade for ``pointer-events``: an inner ancestor with
+        ``pointer-events: auto`` overrides an outer ``pointer-events: none``,
+        so we cannot naively flag any ancestor with ``none`` as masked —
+        we walk inside-out and stop the pointer-events check at the first
+        ``auto`` boundary.
+        """
+        # Reject bool first — Python's ``True == 1`` would otherwise pass
+        # the (int, float) check; a Boolean coordinate is a caller bug.
+        if isinstance(x, bool) or isinstance(y, bool):
+            return _err(
+                "invalid_input",
+                "x and y must be numbers, not booleans",
+            )
+        if not isinstance(x, (int, float)) or not isinstance(y, (int, float)):
+            return _err(
+                "invalid_input",
+                "x and y must be numbers",
+            )
+        # Coerce ints to floats so downstream math is uniform.
+        x = float(x)
+        y = float(y)
+        if math.isnan(x) or math.isnan(y) or math.isinf(x) or math.isinf(y):
+            return _err(
+                "invalid_input",
+                "x and y must be finite numbers",
+            )
+
+        inst = await self.get_or_start(agent_id)
+        inst.touch()
+        async with inst.lock:
+            try:
+                if inst._user_control:
+                    return _err(
+                        "conflict",
+                        "User has browser control — action paused until "
+                        "control is released.",
+                    )
+                vp = inst.page.viewport_size or {}
+                vw = vp.get("width") if isinstance(vp, dict) else None
+                vh = vp.get("height") if isinstance(vp, dict) else None
+                if not (isinstance(vw, (int, float)) and isinstance(vh, (int, float))):
+                    return _err(
+                        "service_unavailable",
+                        "viewport size unavailable",
+                    )
+                if x < 0 or y < 0 or x >= vw or y >= vh:
+                    return _err(
+                        "invalid_input",
+                        f"coordinate (x, y) out of viewport bounds "
+                        f"({int(vw)} x {int(vh)})",
+                    )
+
+                hit = await inst.page.evaluate(_JS_ELEMENT_FROM_POINT, [x, y])
+                if hit is None:
+                    return _err(
+                        "no_element_at_point",
+                        f"no element at ({x}, {y})",
+                    )
+                masked_by = hit.get("masked_by") if isinstance(hit, dict) else None
+                if masked_by:
+                    actual = {
+                        "tag": hit.get("tag", ""),
+                        "role": hit.get("role"),
+                        "name": hit.get("name", ""),
+                    }
+                    return {
+                        "success": False,
+                        "error": {
+                            "code": "invalid_input",
+                            "message": (
+                                f"click at ({x}, {y}) would be intercepted "
+                                f"by an ancestor element"
+                            ),
+                            "retry_after_ms": None,
+                            "data": {
+                                "actual": actual,
+                                "masked_by": masked_by,
+                                "mask_reason": hit.get("mask_reason", ""),
+                            },
+                        },
+                    }
+
+                # Clean hit — dispatch the click.
+                await inst.page.mouse.click(x, y)
+                await asyncio.sleep(action_delay())
+
+                # DOM may have changed; drop the diff baseline for the
+                # active page so the next snapshot is a full re-walk
+                # rather than a stale-against-new diff.
+                active_pid = inst.last_active_page_id
+                if active_pid is not None:
+                    inst.last_snapshot.pop(active_pid, None)
+
+                # Post-click CAPTCHA re-detection — coordinate clicks
+                # frequently land on interstitial challenge widgets.
+                captcha = await self._check_captcha(inst)
+
+                inst.m_click_success += 1
+                inst.click_window.append(True)
+                inst.recorder.record_click(method="xy", success=True)
+                result = {
+                    "success": True,
+                    "data": {
+                        "clicked_at": {"x": x, "y": y},
+                        "actual_element": {
+                            "tag": hit.get("tag", ""),
+                            "role": hit.get("role"),
+                            "name": hit.get("name", ""),
+                        },
+                    },
+                }
+                if captcha:
+                    result["data"]["captcha"] = captcha
+                return result
+            except Exception as e:
+                inst.m_click_fail += 1
+                inst.click_window.append(False)
+                inst.recorder.record_click(method="xy", success=False)
+                return _err("service_unavailable", str(e))
 
     async def hover(
         self, agent_id: str, ref: str | None = None,

--- a/src/browser/service.py
+++ b/src/browser/service.py
@@ -5193,83 +5193,381 @@ class BrowserManager:
         inst = await self.get_or_start(agent_id)
         inst.touch()
         async with inst.lock:
-            try:
-                if inst._user_control:
-                    return _err(
-                        "conflict",
-                        "User has browser control — action paused until control is released.",
-                    )
-                snap = await self._snapshot_impl(
-                    inst, agent_id, _skip_baseline=True,
+            if inst._user_control:
+                return _err(
+                    "conflict",
+                    "User has browser control — action paused until control is released.",
                 )
-                if not snap.get("success"):
-                    return snap
+            return await self._find_text_impl(
+                inst, agent_id, query, scroll=scroll,
+            )
 
-                needle = query.casefold()
-                viewport = inst.page.viewport_size or {}
-                vw = int(viewport.get("width") or 0)
-                vh = int(viewport.get("height") or 0)
+    async def _find_text_impl(
+        self, inst: "CamoufoxInstance", agent_id: str, query: str,
+        *, scroll: bool = True,
+    ) -> dict:
+        """Lock-free body of :meth:`find_text`.
 
-                matches: list[dict] = []
-                truncated = False
-                first_locator = None
-                for ref_id, handle in inst.refs.items():
-                    name = handle.name or ""
-                    if not name or needle not in name.casefold():
-                        continue
-                    if len(matches) >= 50:
-                        truncated = True
-                        break
-                    locator = await self._locator_from_ref(inst, ref_id)
-                    in_viewport = False
-                    if locator is not None:
-                        try:
-                            visible = await locator.is_visible()
-                        except Exception:
-                            visible = False
-                        if visible and vw > 0 and vh > 0:
-                            try:
-                                box = await locator.bounding_box()
-                            except Exception:
-                                box = None
-                            if box:
-                                bx = float(box.get("x", 0))
-                                by = float(box.get("y", 0))
-                                bw = float(box.get("width", 0))
-                                bh = float(box.get("height", 0))
-                                in_viewport = (
-                                    bx + bw > 0 and by + bh > 0
-                                    and bx < vw and by < vh
-                                )
-                    redacted_name = self.redactor.redact(agent_id, name)
-                    matches.append({
-                        "ref": ref_id,
-                        "text": sanitize_for_prompt(redacted_name)[:200],
-                        "in_viewport": bool(in_viewport),
-                    })
-                    if first_locator is None and locator is not None:
-                        first_locator = locator
+        Caller must hold ``inst.lock`` and have already cleared the
+        ``inst._user_control`` gate. Extracted so compound primitives
+        (e.g. §9.4 ``fill_form``) can reuse the matching pipeline
+        without dropping and re-acquiring the per-instance lock —
+        ``asyncio.Lock`` is not reentrant, so calling :meth:`find_text`
+        directly from inside a held-lock section would deadlock.
+        """
+        try:
+            snap = await self._snapshot_impl(
+                inst, agent_id, _skip_baseline=True,
+            )
+            if not snap.get("success"):
+                return snap
 
-                if scroll and first_locator is not None:
+            needle = query.casefold()
+            viewport = inst.page.viewport_size or {}
+            vw = int(viewport.get("width") or 0)
+            vh = int(viewport.get("height") or 0)
+
+            matches: list[dict] = []
+            truncated = False
+            first_locator = None
+            for ref_id, handle in inst.refs.items():
+                name = handle.name or ""
+                if not name or needle not in name.casefold():
+                    continue
+                if len(matches) >= 50:
+                    truncated = True
+                    break
+                locator = await self._locator_from_ref(inst, ref_id)
+                in_viewport = False
+                if locator is not None:
                     try:
-                        await first_locator.scroll_into_view_if_needed(timeout=3000)
+                        visible = await locator.is_visible()
+                    except Exception:
+                        visible = False
+                    if visible and vw > 0 and vh > 0:
+                        try:
+                            box = await locator.bounding_box()
+                        except Exception:
+                            box = None
+                        if box:
+                            bx = float(box.get("x", 0))
+                            by = float(box.get("y", 0))
+                            bw = float(box.get("width", 0))
+                            bh = float(box.get("height", 0))
+                            in_viewport = (
+                                bx + bw > 0 and by + bh > 0
+                                and bx < vw and by < vh
+                            )
+                redacted_name = self.redactor.redact(agent_id, name)
+                matches.append({
+                    "ref": ref_id,
+                    "text": sanitize_for_prompt(redacted_name)[:200],
+                    "in_viewport": bool(in_viewport),
+                })
+                if first_locator is None and locator is not None:
+                    first_locator = locator
+
+            if scroll and first_locator is not None:
+                try:
+                    await first_locator.scroll_into_view_if_needed(timeout=3000)
+                except Exception as e:
+                    logger.debug(
+                        "scroll_into_view_if_needed failed for %s: %s",
+                        agent_id, e,
+                    )
+
+            return {
+                "success": True,
+                "data": {
+                    "matches": matches,
+                    "total": len(matches),
+                    "truncated": truncated,
+                },
+            }
+        except Exception as e:
+            logger.debug("find_text failed for %s: %s", agent_id, e)
+            return _err("service_unavailable", "find_text failed")
+
+    # ── §9.4 fill_form ───────────────────────────────────────────────────
+
+    # Per-field max value length. Long enough that legitimate form values
+    # (textarea bodies, etc.) fit; short enough that an unbounded
+    # prompt-injected value is rejected with a clean ``invalid_input``
+    # before reaching Playwright's ``fill`` (which has no documented cap).
+    _FILL_FORM_MAX_VALUE_CHARS = 10000
+    _FILL_FORM_MAX_LABEL_CHARS = 500
+    _FILL_FORM_MAX_FIELDS = 50
+
+    async def fill_form(
+        self, agent_id: str, fields: list[dict],
+        *, submit_after: bool = False,
+    ) -> dict:
+        """Sequence of find-text + fill across multiple form fields (§9.4).
+
+        For each field, locates the input by visible label (reusing
+        :meth:`_find_text_impl`), resolves the ref to a locator
+        (:meth:`_locator_from_ref`), and calls Playwright's ``fill``.
+
+        We use ``fill`` rather than the per-keystroke ``type_text``
+        because (a) ``fill`` clears existing content first, making
+        idempotent retries safe (no double-prefix on resume after
+        CAPTCHA); (b) per-key humanization across many fields is
+        excessive when the agent has explicitly chosen the compound
+        path. Agents needing per-key entropy on a sensitive field
+        (rare; mostly password fields with bot detection) should fall
+        back to ``browser_type`` field-by-field.
+
+        On CAPTCHA detection mid-flow (after any successful fill) the
+        loop stops, the remaining un-attempted fields are echoed back
+        verbatim in ``remaining`` so the agent can resume after
+        solving, and we do NOT submit even if ``submit_after=True``.
+        See §9.4 for the partial-success protocol.
+        """
+        if not isinstance(fields, list) or not fields:
+            return _err(
+                "invalid_input",
+                "fields must be a non-empty list of {label, value} entries",
+            )
+        if len(fields) > self._FILL_FORM_MAX_FIELDS:
+            return _err(
+                "invalid_input",
+                f"fields list exceeds max length {self._FILL_FORM_MAX_FIELDS}",
+            )
+
+        # Validate each field upfront so we don't half-fill the form before
+        # discovering an invalid entry deep in the list.
+        normalized: list[dict] = []
+        for idx, raw in enumerate(fields):
+            if not isinstance(raw, dict):
+                return _err(
+                    "invalid_input",
+                    f"fields[{idx}] must be an object",
+                )
+            label = raw.get("label")
+            value = raw.get("value")
+            if not isinstance(label, str) or not (
+                1 <= len(label) <= self._FILL_FORM_MAX_LABEL_CHARS
+            ):
+                return _err(
+                    "invalid_input",
+                    f"fields[{idx}].label must be a string 1–"
+                    f"{self._FILL_FORM_MAX_LABEL_CHARS} chars",
+                )
+            if (
+                not isinstance(value, str)
+                or len(value) > self._FILL_FORM_MAX_VALUE_CHARS
+            ):
+                return _err(
+                    "invalid_input",
+                    f"fields[{idx}].value must be a string up to "
+                    f"{self._FILL_FORM_MAX_VALUE_CHARS} chars",
+                )
+            # NUL bytes confuse Playwright's keyboard pipeline; reject early
+            # rather than letting fill() raise a less-clear error mid-flow.
+            if "\x00" in value:
+                return _err(
+                    "invalid_input",
+                    f"fields[{idx}].value contains null byte",
+                )
+            field_submit = raw.get("submit_after", False)
+            normalized.append({
+                "label": label,
+                "value": value,
+                "submit_after": bool(field_submit),
+            })
+
+        inst = await self.get_or_start(agent_id)
+        inst.touch()
+
+        # One lock for the entire form fill — per §2.4, ``inst.lock`` already
+        # serializes per-instance page ops; acquiring it once gives us a
+        # consistent view of the page across the find→fill→captcha-check
+        # cycle for every field. Per-field lock acquisition would let
+        # another action interleave between find_text and fill, breaking
+        # the ref freshness guarantee.
+        async with inst.lock:
+            if inst._user_control:
+                return _err(
+                    "conflict",
+                    "User has browser control — action paused until control is released.",
+                )
+
+            filled: list[dict] = []
+            last_locator = None
+            for i, field in enumerate(normalized):
+                label = field["label"]
+                value = field["value"]
+                field_submit = field["submit_after"]
+
+                # 1) Locate the field via find_text. scroll=True so the
+                #    matched input is brought into view before the fill;
+                #    avoids "element not in viewport" failures on long
+                #    forms.
+                find_res = await self._find_text_impl(
+                    inst, agent_id, label, scroll=True,
+                )
+                if not find_res.get("success"):
+                    # Snapshot/find_text failure is service-side; surface
+                    # as type_failed so the loop continues — the agent
+                    # can re-snapshot and retry.
+                    err = find_res.get("error") or {}
+                    raw_reason = (
+                        str(err.get("message")) if isinstance(err, dict)
+                        else str(err)
+                    ) or "find_text failed"
+                    filled.append({
+                        "label": label,
+                        "status": "type_failed",
+                        "reason": self.redactor.redact(agent_id, raw_reason),
+                    })
+                    continue
+
+                matches = (find_res.get("data") or {}).get("matches") or []
+                if not matches:
+                    filled.append({"label": label, "status": "not_found"})
+                    # CAPTCHA may have appeared as a result of the snapshot
+                    # itself (rare — e.g. a JS challenge that injects on
+                    # every navigation). Check before continuing so we
+                    # don't keep pummeling a blocked page with snapshots.
+                    captcha = await self._check_captcha(inst)
+                    if captcha:
+                        return self._fill_form_captcha_envelope(
+                            filled, normalized[i + 1:], captcha,
+                        )
+                    continue
+
+                # Pick the first in-viewport match; fall back to first match.
+                pick = next(
+                    (m for m in matches if m.get("in_viewport")),
+                    matches[0],
+                )
+                ref = pick.get("ref")
+
+                try:
+                    locator = await self._locator_from_ref(inst, ref)
+                except RefStale as rs:
+                    filled.append({
+                        "label": label,
+                        "ref": ref,
+                        "status": "type_failed",
+                        "reason": self.redactor.redact(agent_id, str(rs)),
+                    })
+                    continue
+                if locator is None:
+                    filled.append({
+                        "label": label,
+                        "ref": ref,
+                        "status": "type_failed",
+                        "reason": "ref not found",
+                    })
+                    continue
+
+                try:
+                    await locator.fill(value)
+                except Exception as e:
+                    # Element no longer attached / disabled / hidden — record
+                    # and continue. Don't bail the whole form: subsequent
+                    # fields may still be reachable.
+                    filled.append({
+                        "label": label,
+                        "ref": ref,
+                        "status": "type_failed",
+                        "reason": self.redactor.redact(agent_id, str(e)),
+                    })
+                    continue
+
+                filled.append({
+                    "label": label,
+                    "ref": ref,
+                    "status": "filled",
+                })
+                last_locator = locator
+
+                # Per-field submit_after fires after a successful fill but
+                # BEFORE the captcha check, because submitting can be what
+                # triggers the captcha.
+                if field_submit:
+                    try:
+                        await locator.press("Enter")
                     except Exception as e:
                         logger.debug(
-                            "scroll_into_view_if_needed failed for %s: %s",
-                            agent_id, e,
+                            "fill_form per-field submit failed for %s "
+                            "label=%r: %s", agent_id, label, e,
                         )
 
-                return {
-                    "success": True,
-                    "data": {
-                        "matches": matches,
-                        "total": len(matches),
-                        "truncated": truncated,
-                    },
-                }
-            except Exception as e:
-                logger.debug("find_text failed for %s: %s", agent_id, e)
-                return _err("service_unavailable", "find_text failed")
+                # 2) After each successful fill (or per-field submit), check
+                #    for a captcha. If found, stop the loop and return
+                #    partial_success — the agent must solve before resuming.
+                #    Captcha mid-flow takes priority over top-level
+                #    submit_after: we never auto-submit a half-completed
+                #    form behind a captcha.
+                captcha = await self._check_captcha(inst)
+                if captcha:
+                    return self._fill_form_captcha_envelope(
+                        filled, normalized[i + 1:], captcha,
+                    )
+
+            # 3) Final submit — only if no captcha interrupted us. Top-level
+            #    submit_after presses Enter on the LAST filled field's
+            #    locator. If no field was successfully filled (all
+            #    not_found / type_failed) we have no anchor to press Enter
+            #    on, so submitted stays False.
+            submitted = False
+            if submit_after and last_locator is not None:
+                try:
+                    await last_locator.press("Enter")
+                    submitted = True
+                except Exception as e:
+                    logger.debug(
+                        "fill_form final submit failed for %s: %s",
+                        agent_id, e,
+                    )
+
+            partial = any(
+                f.get("status") != "filled" for f in filled
+            )
+            return {
+                "success": True,
+                "data": {
+                    "partial_success": partial,
+                    "captcha_required": False,
+                    "filled": filled,
+                    "remaining": [],
+                    "submitted": submitted,
+                },
+            }
+
+    @staticmethod
+    def _fill_form_captcha_envelope(
+        filled: list[dict], remaining_fields: list[dict], captcha: dict,
+    ) -> dict:
+        """Compose the §9.4 partial-success envelope on captcha mid-flow.
+
+        ``remaining`` echoes ``label`` + ``value`` + per-field
+        ``submit_after`` verbatim — the agent supplied these and needs
+        them unchanged to resume after solving. The redactor runs on
+        ``error.message`` strings but NOT on ``remaining[].value``: the
+        agent already has the value (it sent it to us); echoing it back
+        is not a leak, and stripping it would break resume.
+        """
+        return {
+            "success": True,
+            "data": {
+                "partial_success": True,
+                "captcha_required": True,
+                "filled": filled,
+                "remaining": [
+                    {
+                        "label": f["label"],
+                        "value": f["value"],
+                        "submit_after": f.get("submit_after", False),
+                    }
+                    for f in remaining_fields
+                ],
+                "captcha": captcha,
+                "submitted": False,
+            },
+        }
 
     async def open_tab(
         self, agent_id: str, url: str, snapshot_after: bool = False,

--- a/src/browser/service.py
+++ b/src/browser/service.py
@@ -5394,6 +5394,14 @@ class BrowserManager:
 
             filled: list[dict] = []
             last_locator = None
+            # Track whether ANY Enter press has succeeded — per-field
+            # submit_after immediately before the captcha check is the
+            # most common trigger for a mid-flow captcha (submission is
+            # often what gates the challenge). When that happens, the
+            # form may have ALREADY been submitted with partial data, so
+            # the captcha-envelope must report ``submitted=True`` rather
+            # than the agent thinking it can safely resume by re-typing.
+            submitted = False
             for i, field in enumerate(normalized):
                 label = field["label"]
                 value = field["value"]
@@ -5433,6 +5441,7 @@ class BrowserManager:
                     if captcha:
                         return self._fill_form_captcha_envelope(
                             filled, normalized[i + 1:], captcha,
+                            submitted=submitted,
                         )
                     continue
 
@@ -5485,10 +5494,16 @@ class BrowserManager:
 
                 # Per-field submit_after fires after a successful fill but
                 # BEFORE the captcha check, because submitting can be what
-                # triggers the captcha.
+                # triggers the captcha. If the press succeeds we mark
+                # ``submitted=True`` so a follow-up captcha envelope tells
+                # the agent the form was already submitted (possibly with
+                # partial data) — the agent must NOT just resume typing
+                # the remaining fields without first re-checking page
+                # state.
                 if field_submit:
                     try:
                         await locator.press("Enter")
+                        submitted = True
                     except Exception as e:
                         logger.debug(
                             "fill_form per-field submit failed for %s "
@@ -5505,14 +5520,15 @@ class BrowserManager:
                 if captcha:
                     return self._fill_form_captcha_envelope(
                         filled, normalized[i + 1:], captcha,
+                        submitted=submitted,
                     )
 
             # 3) Final submit — only if no captcha interrupted us. Top-level
             #    submit_after presses Enter on the LAST filled field's
             #    locator. If no field was successfully filled (all
             #    not_found / type_failed) we have no anchor to press Enter
-            #    on, so submitted stays False.
-            submitted = False
+            #    on, so submitted stays whatever it was (False unless a
+            #    per-field submit fired earlier in the same call).
             if submit_after and last_locator is not None:
                 try:
                     await last_locator.press("Enter")
@@ -5540,6 +5556,7 @@ class BrowserManager:
     @staticmethod
     def _fill_form_captcha_envelope(
         filled: list[dict], remaining_fields: list[dict], captcha: dict,
+        *, submitted: bool = False,
     ) -> dict:
         """Compose the §9.4 partial-success envelope on captcha mid-flow.
 
@@ -5549,6 +5566,12 @@ class BrowserManager:
         ``error.message`` strings but NOT on ``remaining[].value``: the
         agent already has the value (it sent it to us); echoing it back
         is not a leak, and stripping it would break resume.
+
+        ``submitted`` is True when a per-field ``submit_after=True``
+        Enter-press succeeded earlier in this call (and was likely the
+        trigger for the captcha). The agent uses this to decide whether
+        to plain-resume (re-type ``remaining``) or re-snapshot first to
+        check whether the partial-data submit went through.
         """
         return {
             "success": True,
@@ -5565,7 +5588,7 @@ class BrowserManager:
                     for f in remaining_fields
                 ],
                 "captcha": captcha,
-                "submitted": False,
+                "submitted": submitted,
             },
         }
 

--- a/src/browser/service.py
+++ b/src/browser/service.py
@@ -5516,3 +5516,51 @@ class BrowserManager:
                 }
             except Exception as e:
                 return {"success": False, "error": str(e)}
+
+    async def import_cookies(
+        self, agent_id: str, cookies: list[dict],
+    ) -> dict:
+        """Phase 6 §9.2: import operator-supplied cookies into the agent's
+        browser context.
+
+        Invoked by the operator-only dashboard endpoint — agents NEVER
+        call this. Validation, format detection (Playwright vs Netscape),
+        and shape coercion happen upstream in the dashboard helper
+        :func:`_validate_cookies` so this method receives a pre-validated
+        list of Playwright-shaped cookie dicts.
+
+        At-rest leak warning: Firefox stores cookies plaintext in
+        ``cookies.sqlite`` inside the agent profile dir — operators
+        handling high-value sessions must use encrypted volumes or
+        ephemeral profiles (see plan §13 risk register).
+        """
+        if not isinstance(cookies, list):
+            return _err("invalid_input", "cookies must be a list")
+        try:
+            inst = await self.get_or_start(agent_id)
+        except Exception as e:
+            logger.warning(
+                "import_cookies: failed to start browser for '%s': %s",
+                agent_id, e,
+            )
+            return _err("service_unavailable", "Browser unavailable")
+        inst.touch()
+        async with inst.lock:
+            try:
+                # Empty list is a valid no-op (count=0).
+                if cookies:
+                    await inst.context.add_cookies(cookies)
+                return {
+                    "success": True,
+                    "data": {"imported": len(cookies)},
+                }
+            except Exception as e:
+                # Playwright raises various TypeError / ValueError shapes
+                # when a cookie field is malformed. Sanitize so we never
+                # echo a cookie value back in the response. The upstream
+                # validator already rejects malformed entries; this is
+                # defense-in-depth against future Playwright shape changes.
+                msg = str(e)
+                if "value" in msg.lower():
+                    msg = "Playwright rejected cookie shape"
+                return _err("invalid_input", msg)

--- a/src/browser/service.py
+++ b/src/browser/service.py
@@ -5426,20 +5426,26 @@ class BrowserManager:
         """Wire BrowserContext-level ``request`` / ``requestfailed`` listeners.
 
         Idempotent — second and subsequent calls return immediately. Listeners
-        are attached on the *context* so tabs opened later (via ``window.open()``
-        or :meth:`open_tab`) inherit them automatically. The current page is
-        also wired explicitly in case the context-level ``page`` event has
-        already fired for it before listeners landed.
+        are attached on the *context*. Per Playwright docs the context-level
+        ``request`` event is "emitted when a request is issued from any pages
+        created through this context", so this single hook covers:
+
+        * the initial page (``inst.page``) without a separate per-page hookup,
+        * any pre-existing pages already in ``inst.context.pages`` (e.g. a
+          Camoufox profile that restored prior tabs at launch — rare, but
+          per-page wiring used to silently miss these),
+        * tabs opened later via in-page ``window.open()`` or
+          :meth:`open_tab`.
+
+        ``requestfailed`` is similarly context-scoped.
         """
         if inst._network_attached:
             return
         try:
             inst.context.on(
-                "page",
-                lambda p: p.on("request", lambda req: self._record_request(inst, req)),
+                "request",
+                lambda req: self._record_request(inst, req),
             )
-            if inst.page is not None:
-                inst.page.on("request", lambda req: self._record_request(inst, req))
             inst.context.on(
                 "requestfailed",
                 lambda req: self._record_request_failed(inst, req),
@@ -5471,6 +5477,12 @@ class BrowserManager:
                 "blocked_by_adblock": False,
                 "user_cancelled": False,
                 "failed_network": False,
+                # Internal pairing sentinel — set True the first time a
+                # ``requestfailed`` matches this entry so concurrent
+                # identical-URL failures pair to DIFFERENT log entries
+                # rather than overwriting the same one. Stripped from the
+                # response payload by ``inspect_requests``.
+                "_failure_tagged": False,
             })
         except Exception as e:
             logger.debug("network listener record failed: %s", e)
@@ -5483,6 +5495,14 @@ class BrowserManager:
         the request having already scrolled out of the maxlen=200 window.
         Creating a phantom entry would mislead operators about traffic that
         actually happened.
+
+        When two identical-URL requests fire in parallel and both fail
+        (e.g. two ``<img>`` loads of the same blocked tracker), each
+        ``requestfailed`` event tags a *different* log entry — we walk
+        newest-first and skip entries whose ``_failure_tagged`` is already
+        True. Without this, the second ``requestfailed`` would overwrite
+        the same entry and the first request would silently appear as
+        "successful" in the log.
         """
         try:
             from src.shared.redaction import redact_url
@@ -5514,15 +5534,23 @@ class BrowserManager:
                 cancelled = True
             failed_net = not (blocked or cancelled)
 
-            # Update the most recent matching entry. Reverse iteration so a
-            # rapid-fire request to the same URL+method picks up the freshest.
+            # Update the newest matching entry that hasn't already been
+            # tagged. Reverse iteration so a rapid-fire request to the same
+            # URL+method picks up the freshest available slot. Skipping
+            # tagged entries makes parallel identical failures pair 1:1.
             for entry in reversed(inst.network_log):
-                if entry["url"] == url and entry["method"] == method:
+                if (
+                    entry["url"] == url
+                    and entry["method"] == method
+                    and not entry.get("_failure_tagged")
+                ):
                     entry["blocked_by_adblock"] = blocked
                     entry["user_cancelled"] = cancelled
                     entry["failed_network"] = failed_net
+                    entry["_failure_tagged"] = True
                     return
-            # No match → discard. Do NOT append; would create a phantom entry.
+            # No untagged match → discard. Do NOT append; would create a
+            # phantom entry.
         except Exception as e:
             logger.debug("network listener fail-record failed: %s", e)
 

--- a/src/browser/service.py
+++ b/src/browser/service.py
@@ -5298,6 +5298,46 @@ class BrowserManager:
     _FILL_FORM_MAX_LABEL_CHARS = 500
     _FILL_FORM_MAX_FIELDS = 50
 
+    @staticmethod
+    def _classify_fill_error(exc: Exception) -> str:
+        """Map a Playwright ``locator.fill`` exception → structured reason.
+
+        Third-pass review §9.4 concern 1: ``find_text`` can return refs
+        for non-input elements (a ``<label>``, ``<span>`` containing the
+        label text, etc.). Calling ``fill()`` on those raises a Playwright
+        error like ``"Element is not an <input>, <textarea> or
+        [contenteditable]"``. Without classification the agent sees a
+        generic ``type_failed`` and can't plan a recovery — with a
+        ``not_fillable`` code it knows to fall back to
+        ``browser_get_elements`` to find the underlying input near the
+        label.
+
+        Returns one of: ``not_fillable``, ``timeout``, ``detached``,
+        ``hidden``, ``disabled``, ``other``.
+        """
+        msg = str(exc).lower()
+        # Order matters: TimeoutError is a subclass check; the string
+        # heuristics below cover both Playwright's ``Error`` class and
+        # plain Python exceptions.
+        if isinstance(exc, TimeoutError) or "timeout" in msg:
+            return "timeout"
+        if (
+            "is not an <input>" in msg
+            or "is not an <textarea>" in msg
+            or "not an editable" in msg
+            or "not editable" in msg
+            or "not fillable" in msg
+            or "[contenteditable]" in msg
+        ):
+            return "not_fillable"
+        if "detached" in msg or "not attached" in msg:
+            return "detached"
+        if "not visible" in msg or "hidden" in msg:
+            return "hidden"
+        if "disabled" in msg or "readonly" in msg or "read-only" in msg:
+            return "disabled"
+        return "other"
+
     async def fill_form(
         self, agent_id: str, fields: list[dict],
         *, submit_after: bool = False,
@@ -5414,6 +5454,19 @@ class BrowserManager:
                 find_res = await self._find_text_impl(
                     inst, agent_id, label, scroll=True,
                 )
+                # Output-side label hygiene: defensively redact the label
+                # echoed back in ``filled[]``. Mirrors :meth:`_find_text_impl`
+                # line ~5261, which redacts the matched ``text`` it returns.
+                # If an agent passes a label like ``"Token: abc123"`` the
+                # response should not echo the secret in plaintext into the
+                # transcript — same defense as the URL redaction in §9.1.
+                # (``remaining[]`` deliberately keeps labels & values
+                # verbatim — see :meth:`_fill_form_captcha_envelope` — so
+                # the agent can resume after solving without losing data.)
+                safe_label = sanitize_for_prompt(
+                    self.redactor.redact(agent_id, label)
+                )
+
                 if not find_res.get("success"):
                     # Snapshot/find_text failure is service-side; surface
                     # as type_failed so the loop continues — the agent
@@ -5424,7 +5477,7 @@ class BrowserManager:
                         else str(err)
                     ) or "find_text failed"
                     filled.append({
-                        "label": label,
+                        "label": safe_label,
                         "status": "type_failed",
                         "reason": self.redactor.redact(agent_id, raw_reason),
                     })
@@ -5432,7 +5485,7 @@ class BrowserManager:
 
                 matches = (find_res.get("data") or {}).get("matches") or []
                 if not matches:
-                    filled.append({"label": label, "status": "not_found"})
+                    filled.append({"label": safe_label, "status": "not_found"})
                     # CAPTCHA may have appeared as a result of the snapshot
                     # itself (rare — e.g. a JS challenge that injects on
                     # every navigation). Check before continuing so we
@@ -5456,7 +5509,7 @@ class BrowserManager:
                     locator = await self._locator_from_ref(inst, ref)
                 except RefStale as rs:
                     filled.append({
-                        "label": label,
+                        "label": safe_label,
                         "ref": ref,
                         "status": "type_failed",
                         "reason": self.redactor.redact(agent_id, str(rs)),
@@ -5464,7 +5517,7 @@ class BrowserManager:
                     continue
                 if locator is None:
                     filled.append({
-                        "label": label,
+                        "label": safe_label,
                         "ref": ref,
                         "status": "type_failed",
                         "reason": "ref not found",
@@ -5474,19 +5527,26 @@ class BrowserManager:
                 try:
                     await locator.fill(value)
                 except Exception as e:
-                    # Element no longer attached / disabled / hidden — record
-                    # and continue. Don't bail the whole form: subsequent
-                    # fields may still be reachable.
+                    # Element no longer attached / disabled / hidden /
+                    # not-fillable (label-element returned by find_text).
+                    # Don't bail the whole form: subsequent fields may still
+                    # be reachable. ``reason`` is a structured code (see
+                    # :meth:`_classify_fill_error`) so the agent can plan a
+                    # specific recovery — e.g. re-snapshot on ``detached``,
+                    # fall back to ``browser_get_elements`` on
+                    # ``not_fillable``.
+                    reason_code = self._classify_fill_error(e)
                     filled.append({
-                        "label": label,
+                        "label": safe_label,
                         "ref": ref,
                         "status": "type_failed",
-                        "reason": self.redactor.redact(agent_id, str(e)),
+                        "reason": reason_code,
+                        "detail": self.redactor.redact(agent_id, str(e))[:200],
                     })
                     continue
 
                 filled.append({
-                    "label": label,
+                    "label": safe_label,
                     "ref": ref,
                     "status": "filled",
                 })

--- a/src/browser/service.py
+++ b/src/browser/service.py
@@ -5529,6 +5529,12 @@ class BrowserManager:
         :func:`_validate_cookies` so this method receives a pre-validated
         list of Playwright-shaped cookie dicts.
 
+        Merge semantics: this calls Playwright's ``add_cookies`` which
+        MERGES with the existing context — a (name, domain, path) tuple
+        collision overwrites the prior cookie; non-colliding entries are
+        appended. There is no "wipe and replace" — operators wanting a
+        clean slate should reset the agent profile first.
+
         At-rest leak warning: Firefox stores cookies plaintext in
         ``cookies.sqlite`` inside the agent profile dir — operators
         handling high-value sessions must use encrypted volumes or
@@ -5555,12 +5561,19 @@ class BrowserManager:
                     "data": {"imported": len(cookies)},
                 }
             except Exception as e:
-                # Playwright raises various TypeError / ValueError shapes
-                # when a cookie field is malformed. Sanitize so we never
-                # echo a cookie value back in the response. The upstream
-                # validator already rejects malformed entries; this is
-                # defense-in-depth against future Playwright shape changes.
-                msg = str(e)
-                if "value" in msg.lower():
-                    msg = "Playwright rejected cookie shape"
-                return _err("invalid_input", msg)
+                # Defense-in-depth: never echo a Playwright error back to
+                # the operator — earlier review noted that a substring
+                # heuristic ("value" in msg) was fragile, e.g. a future
+                # Playwright change that renamed the offending field
+                # (or used the cookie ``name``) could leak the secret.
+                # The upstream ``_validate_cookies`` already rejects
+                # malformed entries, so any error here is unexpected.
+                # Log raw error server-side ONLY; return a generic shape.
+                logger.warning(
+                    "import_cookies: Playwright add_cookies failed for "
+                    "'%s': %s", agent_id, e,
+                )
+                return _err(
+                    "invalid_input",
+                    "cookie import failed (see service logs)",
+                )

--- a/src/browser/service.py
+++ b/src/browser/service.py
@@ -4548,18 +4548,30 @@ class BrowserManager:
                         "User has browser control — action paused until "
                         "control is released.",
                     )
+                # ``viewport_size`` is normally populated for Camoufox
+                # (fingerprint-driven, see ``stealth.pick_resolution``).
+                # Defensive: in some Playwright configurations (no explicit
+                # context viewport, e.g. tests with a default-page context)
+                # ``viewport_size`` returns ``None``. Negative coords are
+                # always invalid; for the upper bound, when viewport size
+                # is unknown skip the bounds check and let Playwright's
+                # ``mouse.click`` reject out-of-window coordinates with
+                # its own error (caught below as ``service_unavailable``).
+                if x < 0 or y < 0:
+                    return _err(
+                        "invalid_input",
+                        f"coordinate ({x}, {y}) out of viewport bounds "
+                        f"(coordinates must be non-negative)",
+                    )
                 vp = inst.page.viewport_size or {}
                 vw = vp.get("width") if isinstance(vp, dict) else None
                 vh = vp.get("height") if isinstance(vp, dict) else None
-                if not (isinstance(vw, (int, float)) and isinstance(vh, (int, float))):
-                    return _err(
-                        "service_unavailable",
-                        "viewport size unavailable",
-                    )
-                if x < 0 or y < 0 or x >= vw or y >= vh:
+                if (isinstance(vw, (int, float))
+                        and isinstance(vh, (int, float))
+                        and (x >= vw or y >= vh)):
                     return _err(
                         "invalid_input",
-                        f"coordinate (x, y) out of viewport bounds "
+                        f"coordinate ({x}, {y}) out of viewport bounds "
                         f"({int(vw)} x {int(vh)})",
                     )
 

--- a/src/dashboard/server.py
+++ b/src/dashboard/server.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import contextlib
 import hashlib
+import ipaddress
 import json
 import os
 import re
@@ -17,6 +18,7 @@ import sqlite3
 import threading
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
+from urllib.parse import urlparse
 
 from fastapi import APIRouter, Depends, File, HTTPException, Request, UploadFile
 from fastapi.responses import FileResponse, HTMLResponse
@@ -153,26 +155,29 @@ _COOKIE_LIST_MAX_LEN = 1000                     # max cookies per import
 
 _VALID_SAMESITE = {"Lax": "Lax", "Strict": "Strict", "None": "None"}
 
-# Match a literal IPv4 (4-tuple) or IPv6 (bracketed). Cookie domains
-# matching these are dropped — Firefox stores them but the SSRF egress
-# filter inside the browser container would reject the requests anyway.
-_IPV4_DOMAIN_RE = re.compile(r"^\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}$")
-_IPV6_DOMAIN_RE = re.compile(r"^\[[0-9A-Fa-f:]+\]$")
-
-
 def _is_ip_literal_domain(domain: str) -> bool:
     """True when ``domain`` is a literal IPv4 or IPv6 address."""
     if not domain:
         return False
-    bare = domain.lstrip(".")
-    if _IPV4_DOMAIN_RE.match(bare):
-        # Defense: confirm each octet is in 0..255.
-        try:
-            octets = [int(o) for o in bare.split(".")]
-            return all(0 <= o <= 255 for o in octets)
-        except ValueError:
-            return False
-    return bool(_IPV6_DOMAIN_RE.match(bare))
+    bare = domain.strip().lstrip(".")
+    if bare.startswith("[") and bare.endswith("]"):
+        bare = bare[1:-1]
+    try:
+        ipaddress.ip_address(bare)
+    except ValueError:
+        return False
+    return True
+
+
+def _cookie_url_host(url: str) -> str | None:
+    """Return host for an http(s) cookie URL, or None when invalid."""
+    try:
+        parsed = urlparse(url)
+    except Exception:
+        return None
+    if parsed.scheme.lower() not in ("http", "https") or not parsed.hostname:
+        return None
+    return parsed.hostname
 
 
 def _parse_netscape(
@@ -288,11 +293,25 @@ def _validate_cookies(
         name = raw.get("name", "")
         value = raw.get("value", "")
         domain = raw.get("domain", "")
+        url = raw.get("url")
         path = raw.get("path", "/") or "/"
         if not isinstance(name, str) or not name:
             _drop("empty_name")
             continue
-        if not isinstance(domain, str) or not domain:
+        if domain is None:
+            domain = ""
+        if not isinstance(domain, str):
+            _drop("empty_domain")
+            continue
+        if url is None:
+            url = ""
+        if not isinstance(url, str):
+            _drop("invalid_url")
+            continue
+        if domain and url:
+            _drop("domain_url_conflict")
+            continue
+        if not domain and not url:
             _drop("empty_domain")
             continue
         if not isinstance(value, str):
@@ -301,16 +320,39 @@ def _validate_cookies(
         if len(value.encode("utf-8")) > _COOKIE_VALUE_MAX_BYTES:
             _drop("value_too_large")
             continue
-        if _is_ip_literal_domain(domain):
+        url_host: str | None = None
+        if url:
+            url_host = _cookie_url_host(url)
+            if url_host is None:
+                _drop("invalid_url")
+                continue
+            if _is_ip_literal_domain(url_host):
+                _drop("ip_domain_unsupported")
+                continue
+        if domain and _is_ip_literal_domain(domain):
             _drop("ip_domain_unsupported")
             continue
         # RFC 6265bis: __Host- prefix forbids an explicit domain.
         if name.startswith("__Host-") and domain:
             _drop("host_prefix_with_domain")
             continue
-        normalized: dict = {
-            "name": name, "value": value, "domain": domain, "path": path,
-        }
+        secure_raw = raw.get("secure")
+        secure = bool(secure_raw) if secure_raw is not None else False
+        if name.startswith("__Host-"):
+            if path != "/":
+                _drop("host_prefix_invalid_path")
+                continue
+            if not secure:
+                _drop("host_prefix_without_secure")
+                continue
+        normalized: dict = {"name": name, "value": value}
+        if url:
+            normalized["url"] = url
+            if path:
+                normalized["path"] = path
+        else:
+            normalized["domain"] = domain
+            normalized["path"] = path
         # SameSite normalize (case-insensitive) — drop entry on unknown.
         ss_raw = raw.get("sameSite")
         if ss_raw is not None:
@@ -332,8 +374,8 @@ def _validate_cookies(
         # httpOnly / secure — coerce to bool only when explicitly present.
         if "httpOnly" in raw:
             normalized["httpOnly"] = bool(raw["httpOnly"])
-        if "secure" in raw:
-            normalized["secure"] = bool(raw["secure"])
+        if secure_raw is not None:
+            normalized["secure"] = secure
         accepted.append(normalized)
 
     dropped = [

--- a/src/dashboard/server.py
+++ b/src/dashboard/server.py
@@ -175,7 +175,9 @@ def _is_ip_literal_domain(domain: str) -> bool:
     return bool(_IPV6_DOMAIN_RE.match(bare))
 
 
-def _parse_netscape(text: str) -> list[dict]:
+def _parse_netscape(
+    text: str, *, malformed: list[str] | None = None,
+) -> list[dict]:
     """Parse Netscape ``cookies.txt`` format → Playwright-shaped dicts.
 
     Netscape format: ``domain\tincludeSubdomains\tpath\tsecure\texpires\tname\tvalue``
@@ -183,8 +185,11 @@ def _parse_netscape(text: str) -> list[dict]:
     ``#HttpOnly_<domain>`` prefix which marks the cookie as HttpOnly.
 
     Malformed lines (wrong field count, non-numeric ``expires``) are
-    silently skipped — the upstream validator records the drop count. This
-    parser never raises.
+    silently skipped. When ``malformed`` is supplied, a sentinel string
+    describing the reason is appended for each skipped line so the caller
+    can surface a ``malformed_line`` drop count to the operator. This
+    parser never raises and never echoes the bad line content (which may
+    contain a cookie value).
     """
     result: list[dict] = []
     if not isinstance(text, str):
@@ -203,12 +208,16 @@ def _parse_netscape(text: str) -> list[dict]:
         # value may itself contain tabs in some exporters, so don't split unbounded.
         parts = line.split("\t")
         if len(parts) < 7:
+            if malformed is not None:
+                malformed.append("field_count")
             continue
         domain, _include_sub, path, secure, expires, name, *value_parts = parts
         value = "\t".join(value_parts) if value_parts else ""
         try:
             expires_int = int(float(expires))
         except (ValueError, TypeError):
+            if malformed is not None:
+                malformed.append("expires")
             continue
         result.append({
             "name": name,
@@ -249,6 +258,11 @@ def _validate_cookies(
         elif isinstance(payload, str) and "\t" in payload:
             detected = "netscape"
 
+    drop_counts: dict[str, int] = {}
+
+    def _drop(reason: str) -> None:
+        drop_counts[reason] = drop_counts.get(reason, 0) + 1
+
     if detected == "playwright":
         if not isinstance(payload, list):
             return [], [], None
@@ -256,15 +270,16 @@ def _validate_cookies(
     elif detected == "netscape":
         if not isinstance(payload, str):
             return [], [], None
-        items = _parse_netscape(payload)
+        # Capture per-line malformed reasons so the operator sees a count
+        # of dropped Netscape lines instead of a silent zero result.
+        malformed_lines: list[str] = []
+        items = _parse_netscape(payload, malformed=malformed_lines)
+        for _ in malformed_lines:
+            _drop("malformed_line")
     else:
         return [], [], None
 
     accepted: list[dict] = []
-    drop_counts: dict[str, int] = {}
-
-    def _drop(reason: str) -> None:
-        drop_counts[reason] = drop_counts.get(reason, 0) + 1
 
     for raw in items:
         if not isinstance(raw, dict):
@@ -741,6 +756,12 @@ def create_dashboard_router(
         agent_id: str, request: Request,
     ) -> dict:
         """Phase 6 §9.2 — operator-only cookie/session import.
+
+        Merge semantics: Playwright's ``BrowserContext.add_cookies``
+        MERGES with existing cookies. A (name, domain, path) collision
+        OVERWRITES the existing cookie; non-colliding cookies are
+        appended. There is no "wipe and replace" — to start clean,
+        reset the agent profile first.
 
         At-rest leak warning (see plan §13 risk register row "Imported
         cookies at rest in profile (plaintext)"): Firefox stores cookies

--- a/src/dashboard/server.py
+++ b/src/dashboard/server.py
@@ -34,6 +34,9 @@ if TYPE_CHECKING:
     from src.host.traces import TraceStore
 
 logger = setup_logging("dashboard.server")
+# Phase 6 §9.2: dedicated logger for cookie-import audit. Records domain
+# + cookie name only — NEVER the value (see _validate_cookies docstring).
+_cookie_audit_logger = setup_logging("dashboard.cookie_import")
 
 _HERE = Path(__file__).resolve().parent
 _TEMPLATES_DIR = _HERE / "templates"
@@ -125,6 +128,204 @@ def _wallet_chain_label(chain_id: str, cfg: dict) -> str:
     if "devnet" in chain_id or "sepolia" in chain_id:
         return f"{name} ({eco} Testnet)"
     return f"{name} ({eco} · {symbol})"
+
+
+# ── Phase 6 §9.2 — operator cookie/session import helpers ─────────────────
+# Pure functions split out for unit-testability. The dashboard endpoint
+# validates and shape-coerces operator-supplied cookie payloads here, then
+# hands a normalized Playwright-shaped list to the browser service.
+#
+# SECURITY INVARIANTS:
+#   • Cookie VALUES never appear in audit logs, error messages, or any
+#     return shape that crosses a process boundary. Only domain + name
+#     are logged.
+#   • Validation rejects cookies whose ``value`` is larger than 4 KiB
+#     (per cookie) and whole payloads larger than 256 KiB.
+#   • RFC 6265bis violations (`__Host-` with explicit domain) are
+#     dropped server-side; importing them is silently rejected by Firefox
+#     anyway and confuses operators.
+#   • IP-literal domains are dropped — Firefox stores them but our SSRF
+#     egress filter would block the requests, so importing is a footgun.
+
+_COOKIE_VALUE_MAX_BYTES = 4 * 1024              # per-cookie value cap
+_COOKIE_PAYLOAD_MAX_BYTES = 256 * 1024          # whole-payload cap (DoS guard)
+_COOKIE_LIST_MAX_LEN = 1000                     # max cookies per import
+
+_VALID_SAMESITE = {"Lax": "Lax", "Strict": "Strict", "None": "None"}
+
+# Match a literal IPv4 (4-tuple) or IPv6 (bracketed). Cookie domains
+# matching these are dropped — Firefox stores them but the SSRF egress
+# filter inside the browser container would reject the requests anyway.
+_IPV4_DOMAIN_RE = re.compile(r"^\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}$")
+_IPV6_DOMAIN_RE = re.compile(r"^\[[0-9A-Fa-f:]+\]$")
+
+
+def _is_ip_literal_domain(domain: str) -> bool:
+    """True when ``domain`` is a literal IPv4 or IPv6 address."""
+    if not domain:
+        return False
+    bare = domain.lstrip(".")
+    if _IPV4_DOMAIN_RE.match(bare):
+        # Defense: confirm each octet is in 0..255.
+        try:
+            octets = [int(o) for o in bare.split(".")]
+            return all(0 <= o <= 255 for o in octets)
+        except ValueError:
+            return False
+    return bool(_IPV6_DOMAIN_RE.match(bare))
+
+
+def _parse_netscape(text: str) -> list[dict]:
+    """Parse Netscape ``cookies.txt`` format → Playwright-shaped dicts.
+
+    Netscape format: ``domain\tincludeSubdomains\tpath\tsecure\texpires\tname\tvalue``
+    Lines starting with ``#`` are comments and skipped, EXCEPT the special
+    ``#HttpOnly_<domain>`` prefix which marks the cookie as HttpOnly.
+
+    Malformed lines (wrong field count, non-numeric ``expires``) are
+    silently skipped — the upstream validator records the drop count. This
+    parser never raises.
+    """
+    result: list[dict] = []
+    if not isinstance(text, str):
+        return result
+    for raw_line in text.splitlines():
+        line = raw_line.rstrip("\r\n")
+        if not line.strip():
+            continue
+        http_only = False
+        if line.startswith("#HttpOnly_"):
+            http_only = True
+            line = line[len("#HttpOnly_"):]
+        elif line.startswith("#"):
+            continue
+        # Fields: domain, includeSubdomains, path, secure, expires, name, value
+        # value may itself contain tabs in some exporters, so don't split unbounded.
+        parts = line.split("\t")
+        if len(parts) < 7:
+            continue
+        domain, _include_sub, path, secure, expires, name, *value_parts = parts
+        value = "\t".join(value_parts) if value_parts else ""
+        try:
+            expires_int = int(float(expires))
+        except (ValueError, TypeError):
+            continue
+        result.append({
+            "name": name,
+            "value": value,
+            "domain": domain,
+            "path": path or "/",
+            "secure": secure.strip().upper() == "TRUE",
+            "httpOnly": http_only,
+            "expires": expires_int,
+        })
+    return result
+
+
+def _validate_cookies(
+    payload: Any, *, fmt: str | None = None,
+) -> tuple[list[dict], list[dict], str | None]:
+    """Validate + normalize an operator cookie payload.
+
+    Returns ``(accepted, dropped, detected_format_or_None)``:
+      • ``accepted`` — list of Playwright-shaped cookie dicts ready to
+        push into ``BrowserContext.add_cookies``.
+      • ``dropped`` — list of ``{reason, count}`` aggregated by reason.
+      • ``detected_format_or_None`` — ``"playwright"`` | ``"netscape"`` | None.
+        ``None`` signals an unrecognized shape — callers should return a
+        400 ``invalid_input`` envelope.
+
+    Pure function: no I/O, no mutation of inputs. Suitable for unit tests
+    without HTTP plumbing.
+    """
+    detected: str | None = fmt
+    items: list[dict] = []
+
+    if detected is None:
+        if isinstance(payload, list) and (
+            not payload or isinstance(payload[0], dict)
+        ):
+            detected = "playwright"
+        elif isinstance(payload, str) and "\t" in payload:
+            detected = "netscape"
+
+    if detected == "playwright":
+        if not isinstance(payload, list):
+            return [], [], None
+        items = list(payload)
+    elif detected == "netscape":
+        if not isinstance(payload, str):
+            return [], [], None
+        items = _parse_netscape(payload)
+    else:
+        return [], [], None
+
+    accepted: list[dict] = []
+    drop_counts: dict[str, int] = {}
+
+    def _drop(reason: str) -> None:
+        drop_counts[reason] = drop_counts.get(reason, 0) + 1
+
+    for raw in items:
+        if not isinstance(raw, dict):
+            _drop("not_a_dict")
+            continue
+        name = raw.get("name", "")
+        value = raw.get("value", "")
+        domain = raw.get("domain", "")
+        path = raw.get("path", "/") or "/"
+        if not isinstance(name, str) or not name:
+            _drop("empty_name")
+            continue
+        if not isinstance(domain, str) or not domain:
+            _drop("empty_domain")
+            continue
+        if not isinstance(value, str):
+            _drop("invalid_value_type")
+            continue
+        if len(value.encode("utf-8")) > _COOKIE_VALUE_MAX_BYTES:
+            _drop("value_too_large")
+            continue
+        if _is_ip_literal_domain(domain):
+            _drop("ip_domain_unsupported")
+            continue
+        # RFC 6265bis: __Host- prefix forbids an explicit domain.
+        if name.startswith("__Host-") and domain:
+            _drop("host_prefix_with_domain")
+            continue
+        normalized: dict = {
+            "name": name, "value": value, "domain": domain, "path": path,
+        }
+        # SameSite normalize (case-insensitive) — drop entry on unknown.
+        ss_raw = raw.get("sameSite")
+        if ss_raw is not None:
+            if not isinstance(ss_raw, str):
+                _drop("invalid_samesite")
+                continue
+            ss_norm = _VALID_SAMESITE.get(ss_raw.strip().capitalize())
+            if ss_norm is None:
+                _drop("invalid_samesite")
+                continue
+            normalized["sameSite"] = ss_norm
+        # expires: must be numeric (int or float). Strings rejected.
+        if "expires" in raw and raw["expires"] is not None:
+            exp = raw["expires"]
+            if isinstance(exp, bool) or not isinstance(exp, (int, float)):
+                _drop("invalid_expires")
+                continue
+            normalized["expires"] = int(exp)
+        # httpOnly / secure — coerce to bool only when explicitly present.
+        if "httpOnly" in raw:
+            normalized["httpOnly"] = bool(raw["httpOnly"])
+        if "secure" in raw:
+            normalized["secure"] = bool(raw["secure"])
+        accepted.append(normalized)
+
+    dropped = [
+        {"reason": reason, "count": count}
+        for reason, count in sorted(drop_counts.items())
+    ]
+    return accepted, dropped, detected
 
 
 def create_dashboard_router(
@@ -471,6 +672,293 @@ def create_dashboard_router(
         except Exception as e:
             logger.warning("Browser reset failed for '%s': %s", agent_id, e)
             raise HTTPException(500, "Browser reset failed")
+
+    # ── Phase 6 §9.2 — operator cookie/session import ────────────────────
+    # In-memory rate limiter keyed by (operator_session_user, agent_id).
+    # 60-min sliding window; capacity 10. Limiter state lives on this
+    # router instance — restarting the engine resets the window which is
+    # the desired behavior (operators rarely depend on the precise number
+    # surviving a process boundary).
+    _COOKIE_IMPORT_LIMIT = 10
+    _COOKIE_IMPORT_WINDOW_S = 60 * 60
+    _cookie_import_buckets: dict[tuple[str, str], list[float]] = {}
+    _cookie_import_lock = threading.Lock()
+
+    def _cookie_import_check_rate_limit(
+        operator: str, agent_id: str,
+    ) -> tuple[bool, int]:
+        """Sliding-window rate limit. Returns (allowed, retry_after_ms).
+
+        ``retry_after_ms`` is 0 when ``allowed`` is True; otherwise it is
+        the time until the oldest event in the window expires.
+        """
+        import time as _time
+        now = _time.time()
+        cutoff = now - _COOKIE_IMPORT_WINDOW_S
+        key = (operator, agent_id)
+        with _cookie_import_lock:
+            bucket = _cookie_import_buckets.setdefault(key, [])
+            # Drop entries outside the window in-place.
+            bucket[:] = [t for t in bucket if t > cutoff]
+            if len(bucket) >= _COOKIE_IMPORT_LIMIT:
+                oldest = bucket[0]
+                retry_after_ms = max(
+                    1, int((oldest + _COOKIE_IMPORT_WINDOW_S - now) * 1000),
+                )
+                return False, retry_after_ms
+            bucket.append(now)
+            return True, 0
+
+    def _cookie_envelope_err(
+        code: str, message: str, retry_after_ms: int | None = None,
+    ) -> dict:
+        """Build a §2.3 error envelope for cookie-import responses."""
+        return {
+            "success": False,
+            "error": {
+                "code": code,
+                "message": message,
+                "retry_after_ms": retry_after_ms,
+            },
+        }
+
+    def _operator_session_id(request: Request) -> str:
+        """Derive a stable per-session identifier for rate-limiting + audit.
+
+        The ``ol_session`` cookie is an HMAC of an expiry; there is no
+        per-user identity (the engine has a single operator). We hash the
+        cookie value so the audit log records a stable identifier without
+        echoing the cookie itself. Empty cookie (dev mode) → "operator".
+        """
+        raw = request.cookies.get("ol_session", "")
+        if not raw:
+            return "operator"
+        digest = hashlib.sha256(raw.encode()).hexdigest()[:12]
+        return f"operator:{digest}"
+
+    @api_router.post("/api/agents/{agent_id}/browser/import_cookies")
+    async def api_browser_import_cookies(
+        agent_id: str, request: Request,
+    ) -> dict:
+        """Phase 6 §9.2 — operator-only cookie/session import.
+
+        At-rest leak warning (see plan §13 risk register row "Imported
+        cookies at rest in profile (plaintext)"): Firefox stores cookies
+        in ``cookies.sqlite`` UNENCRYPTED inside the agent profile. This
+        endpoint does NOT silently mitigate that — operators handling
+        high-value sessions are expected to use encrypted volumes or
+        ephemeral profiles. Audit log records domain + cookie name ONLY.
+        """
+        # Choice (per plan §9.2): we hit the browser service directly via
+        # `runtime.browser_service_url` rather than going through
+        # /mesh/browser/command. Rationale: this is operator-only — adding
+        # it to KNOWN_BROWSER_ACTIONS would expose it to agents.
+        from src.browser import flags as _flags
+
+        operator = _operator_session_id(request)
+
+        if agent_id not in agent_registry:
+            raise HTTPException(404, "Agent not found")
+
+        # Kill-switch ─ honor BROWSER_COOKIE_IMPORT_DISABLED.
+        if _flags.get_bool("BROWSER_COOKIE_IMPORT_DISABLED", False):
+            raise HTTPException(
+                403,
+                detail=_cookie_envelope_err(
+                    "forbidden",
+                    "Cookie import disabled by operator policy",
+                ),
+            )
+
+        # Rate-limit pre-check (10/hr per (operator, agent_id)).
+        allowed, retry_ms = _cookie_import_check_rate_limit(operator, agent_id)
+        if not allowed:
+            raise HTTPException(
+                429,
+                detail=_cookie_envelope_err(
+                    "conflict",
+                    "rate limit exceeded",
+                    retry_after_ms=retry_ms,
+                ),
+            )
+
+        # Read raw body once. Enforce 256 KiB DoS guard before JSON parse
+        # so we don't allocate a fat string for an attacker payload.
+        raw = await request.body()
+        if len(raw) > _COOKIE_PAYLOAD_MAX_BYTES:
+            raise HTTPException(
+                413,
+                detail=_cookie_envelope_err(
+                    "size_limit",
+                    f"payload exceeds {_COOKIE_PAYLOAD_MAX_BYTES} bytes",
+                ),
+            )
+
+        try:
+            body = json.loads(raw.decode("utf-8")) if raw else {}
+        except (UnicodeDecodeError, json.JSONDecodeError):
+            raise HTTPException(
+                400,
+                detail=_cookie_envelope_err(
+                    "invalid_input", "request body is not valid JSON",
+                ),
+            )
+
+        if not isinstance(body, dict):
+            raise HTTPException(
+                400,
+                detail=_cookie_envelope_err(
+                    "invalid_input",
+                    "request body must be a JSON object",
+                ),
+            )
+
+        # Format detection: explicit ``format`` field overrides auto-detect.
+        # Payload may live under ``cookies`` (playwright list or netscape
+        # text) — also accept the bare list/string for back-compat with
+        # the simpler curl-style input.
+        explicit_fmt = body.get("format")
+        if explicit_fmt is not None and explicit_fmt not in ("playwright", "netscape"):
+            raise HTTPException(
+                400,
+                detail=_cookie_envelope_err(
+                    "invalid_input",
+                    "format must be 'playwright' or 'netscape'",
+                ),
+            )
+
+        payload = body.get("cookies", body)
+        if isinstance(payload, dict) and "cookies" not in payload:
+            # Caller passed the entire body as the cookies field by accident.
+            raise HTTPException(
+                400,
+                detail=_cookie_envelope_err(
+                    "invalid_input", "missing 'cookies' field",
+                ),
+            )
+
+        accepted, dropped, detected_fmt = _validate_cookies(
+            payload, fmt=explicit_fmt,
+        )
+        if detected_fmt is None:
+            raise HTTPException(
+                400,
+                detail=_cookie_envelope_err(
+                    "invalid_input",
+                    "unable to detect cookie format — supply 'format' or use "
+                    "Playwright JSON list / Netscape TSV string",
+                ),
+            )
+
+        # List-length cap applied AFTER parsing (Netscape format may have
+        # supplied >1000 lines).
+        if len(accepted) + sum(d["count"] for d in dropped) > _COOKIE_LIST_MAX_LEN:
+            raise HTTPException(
+                413,
+                detail=_cookie_envelope_err(
+                    "size_limit",
+                    f"more than {_COOKIE_LIST_MAX_LEN} cookies in payload",
+                ),
+            )
+
+        # Audit log — domain + name only. NEVER cookie values.
+        # _COOKIE_AUDIT_VALUE_EXCLUSION_GUARANTEE: the keys passed to
+        # the logger here are an explicit allowlist; cookie ``value`` is
+        # NOT included by construction. A unit test (test_audit_log_no_value)
+        # asserts this property holds against a corpus including JWT,
+        # Bearer, and SigV4-shaped values.
+        domains = sorted({c["domain"] for c in accepted if c.get("domain")})
+        names = sorted({c["name"] for c in accepted if c.get("name")})
+        _cookie_audit_logger.info(
+            "cookie_import operator=%s agent_id=%s count=%d domains=%s "
+            "names=%s format=%s dropped=%s",
+            operator, agent_id, len(accepted),
+            json.dumps(domains), json.dumps(names),
+            detected_fmt, json.dumps(dropped),
+        )
+        if blackboard is not None:
+            try:
+                blackboard.log_audit(
+                    action="cookie_import",
+                    target=agent_id,
+                    actor=operator,
+                    field=detected_fmt,
+                    after_value=json.dumps({
+                        "count": len(accepted),
+                        "domains": domains,
+                        "names": names,
+                        "dropped": dropped,
+                    }),
+                )
+            except Exception as e:
+                logger.warning("Failed to write cookie_import audit row: %s", e)
+
+        # Push to browser service.
+        if not runtime or not getattr(runtime, "browser_service_url", ""):
+            raise HTTPException(
+                503,
+                detail=_cookie_envelope_err(
+                    "service_unavailable", "Browser service not available",
+                ),
+            )
+        try:
+            browser_auth = getattr(runtime, "browser_auth_token", "")
+            headers: dict[str, str] = {}
+            if browser_auth:
+                headers["Authorization"] = f"Bearer {browser_auth}"
+            resp = await _dashboard_browser_client.post(
+                f"{runtime.browser_service_url}/browser/{agent_id}/import_cookies",
+                json={"cookies": accepted},
+                headers=headers,
+                timeout=30,
+            )
+        except Exception as e:
+            logger.warning("Cookie import push to browser service failed: %s", e)
+            raise HTTPException(
+                503,
+                detail=_cookie_envelope_err(
+                    "service_unavailable",
+                    "Browser service unreachable",
+                ),
+            )
+        if resp.status_code >= 500:
+            raise HTTPException(
+                503,
+                detail=_cookie_envelope_err(
+                    "service_unavailable",
+                    f"Browser service returned {resp.status_code}",
+                ),
+            )
+        try:
+            svc_payload = resp.json()
+        except Exception:
+            raise HTTPException(
+                503,
+                detail=_cookie_envelope_err(
+                    "service_unavailable",
+                    "Browser service returned non-JSON response",
+                ),
+            )
+        # Browser service may have its own dropped/imported counts; merge.
+        if not svc_payload.get("success"):
+            err = svc_payload.get("error") or {}
+            return {
+                "success": False,
+                "error": {
+                    "code": err.get("code", "service_unavailable"),
+                    "message": err.get("message", "import failed"),
+                    "retry_after_ms": err.get("retry_after_ms"),
+                },
+            }
+        svc_data = svc_payload.get("data") or {}
+        return {
+            "success": True,
+            "data": {
+                "imported": svc_data.get("imported", len(accepted)),
+                "dropped": dropped,
+                "format": detected_fmt,
+            },
+        }
 
     @api_router.get("/api/agent-templates")
     async def api_agent_templates() -> list:

--- a/src/dashboard/templates/index.html
+++ b/src/dashboard/templates/index.html
@@ -1832,6 +1832,125 @@
                 ></iframe>
               </div>
             </div>
+            <!-- Phase 6 §9.2 — Operator cookie/session import.
+                 Operator-only. State lives in `x-data` ONLY (never
+                 localStorage) — cookie text is high-trust and persisting
+                 it would cross a security boundary. CSRF header is
+                 injected automatically by the global fetch wrapper. -->
+            <div x-show="agentDetail?.vnc_url && selectedAgent !== 'operator'" x-cloak
+              x-data="{
+                ciOpen: false,
+                ciMode: 'playwright',
+                ciPlaywrightText: '',
+                ciNetscapeText: '',
+                ciSubmitting: false,
+                ciResult: null,
+                ciError: null,
+                async ciSubmit() {
+                  this.ciSubmitting = true;
+                  this.ciResult = null;
+                  this.ciError = null;
+                  try {
+                    let payload;
+                    if (this.ciMode === 'playwright') {
+                      try {
+                        payload = { format: 'playwright', cookies: JSON.parse(this.ciPlaywrightText) };
+                      } catch (e) {
+                        this.ciError = 'Playwright cookies must be valid JSON: ' + e.message;
+                        return;
+                      }
+                    } else {
+                      payload = { format: 'netscape', cookies: this.ciNetscapeText };
+                    }
+                    const resp = await fetch(
+                      `${window.__config.apiBase}/agents/${selectedAgent}/browser/import_cookies`,
+                      {
+                        method: 'POST',
+                        headers: { 'Content-Type': 'application/json' },
+                        body: JSON.stringify(payload),
+                      }
+                    );
+                    const data = await resp.json().catch(() => ({}));
+                    if (!resp.ok || !data.success) {
+                      const e = (data && data.detail && data.detail.error) || (data && data.error) || {};
+                      this.ciError = e.message || `Import failed (HTTP ${resp.status})`;
+                      if (e.retry_after_ms) {
+                        this.ciError += ` — retry in ${Math.ceil(e.retry_after_ms / 1000)}s`;
+                      }
+                      return;
+                    }
+                    this.ciResult = data.data;
+                    // Clear inputs on success so secrets don't linger in DOM.
+                    this.ciPlaywrightText = '';
+                    this.ciNetscapeText = '';
+                  } finally {
+                    this.ciSubmitting = false;
+                  }
+                }
+              }"
+              class="bg-gray-900 border border-gray-800 rounded-lg mb-5 overflow-hidden">
+              <div class="flex items-center justify-between px-4 py-2 border-b border-gray-800 cursor-pointer"
+                @click="ciOpen = !ciOpen">
+                <div class="flex items-center gap-2">
+                  <span class="text-xs text-gray-400 uppercase tracking-wider">Cookie / Session Import</span>
+                  <span class="text-[10px] text-amber-400/80 bg-amber-900/20 border border-amber-800/30 rounded px-1.5 py-0.5">operator-only</span>
+                </div>
+                <span class="text-xs text-gray-500" x-text="ciOpen ? '−' : '+'"></span>
+              </div>
+              <div x-show="ciOpen" x-cloak class="p-4 space-y-3">
+                <div class="text-[11px] text-amber-300/80 bg-amber-900/10 border border-amber-900/30 rounded px-2 py-1.5">
+                  Imported cookies are stored UNENCRYPTED in the agent's Firefox
+                  profile (<code>cookies.sqlite</code>). For high-value sessions,
+                  use an encrypted volume or treat the profile as ephemeral.
+                </div>
+                <div class="flex items-center gap-3">
+                  <label class="flex items-center gap-1.5 text-xs text-gray-300 cursor-pointer">
+                    <input type="radio" name="ci-mode" value="playwright"
+                      x-model="ciMode" class="accent-indigo-500"/>
+                    Playwright JSON
+                  </label>
+                  <label class="flex items-center gap-1.5 text-xs text-gray-300 cursor-pointer">
+                    <input type="radio" name="ci-mode" value="netscape"
+                      x-model="ciMode" class="accent-indigo-500"/>
+                    Netscape (cookies.txt)
+                  </label>
+                </div>
+                <textarea x-show="ciMode === 'playwright'"
+                  x-model="ciPlaywrightText"
+                  placeholder='[{"name": "sid", "value": "...", "domain": ".example.com", "path": "/", "expires": 1735689600, "httpOnly": true, "secure": true, "sameSite": "Lax"}]'
+                  spellcheck="false" autocomplete="off"
+                  class="w-full h-32 text-xs font-mono bg-gray-950 border border-gray-800 rounded p-2 text-gray-200 focus:border-indigo-500 focus:outline-none"></textarea>
+                <textarea x-show="ciMode === 'netscape'" x-cloak
+                  x-model="ciNetscapeText"
+                  placeholder="# Netscape HTTP Cookie File&#10;.example.com&#9;TRUE&#9;/&#9;TRUE&#9;1735689600&#9;sid&#9;..."
+                  spellcheck="false" autocomplete="off"
+                  class="w-full h-32 text-xs font-mono bg-gray-950 border border-gray-800 rounded p-2 text-gray-200 focus:border-indigo-500 focus:outline-none"></textarea>
+                <div class="flex items-center justify-between">
+                  <button @click="ciSubmit()"
+                    :disabled="ciSubmitting || (ciMode === 'playwright' ? !ciPlaywrightText.trim() : !ciNetscapeText.trim())"
+                    class="px-3 py-1.5 text-xs rounded bg-indigo-600 hover:bg-indigo-500 text-white disabled:opacity-40 disabled:cursor-not-allowed transition-colors">
+                    <span x-show="!ciSubmitting">Import</span>
+                    <span x-show="ciSubmitting" x-cloak>Importing...</span>
+                  </button>
+                  <span class="text-[10px] text-gray-600">Rate limit: 10/hr per agent</span>
+                </div>
+                <div x-show="ciError" x-cloak
+                  class="text-xs text-red-300 bg-red-900/20 border border-red-800/30 rounded px-2 py-1.5"
+                  x-text="ciError"></div>
+                <div x-show="ciResult" x-cloak
+                  class="text-xs text-emerald-300 bg-emerald-900/20 border border-emerald-800/30 rounded px-2 py-1.5">
+                  <span>Imported </span><span x-text="ciResult?.imported || 0"></span><span> cookie(s) (format: </span><span x-text="ciResult?.format || ''"></span><span>)</span>
+                  <template x-if="ciResult?.dropped && ciResult.dropped.length">
+                    <div class="mt-1 text-amber-300/80">
+                      Dropped:
+                      <template x-for="d in ciResult.dropped" :key="d.reason">
+                        <span class="inline-block mr-2"><span x-text="d.reason"></span> (<span x-text="d.count"></span>)</span>
+                      </template>
+                    </div>
+                  </template>
+                </div>
+              </div>
+            </div>
             <!-- 2-column detail layout -->
             <div class="grid grid-cols-1 md:grid-cols-5 gap-5 mb-5 chat-grid">
               <!-- Left column: Identity panel -->

--- a/src/dashboard/templates/index.html
+++ b/src/dashboard/templates/index.html
@@ -1903,6 +1903,12 @@
                   profile (<code>cookies.sqlite</code>). For high-value sessions,
                   use an encrypted volume or treat the profile as ephemeral.
                 </div>
+                <div class="text-[11px] text-gray-400/90 bg-gray-800/40 border border-gray-700/40 rounded px-2 py-1.5">
+                  Imports MERGE with existing cookies — a collision on
+                  (name + domain + path) overwrites the prior cookie; everything
+                  else is appended. Reset the agent profile first if you need a
+                  clean slate.
+                </div>
                 <div class="flex items-center gap-3">
                   <label class="flex items-center gap-1.5 text-xs text-gray-300 cursor-pointer">
                     <input type="radio" name="ci-mode" value="playwright"

--- a/src/host/permissions.py
+++ b/src/host/permissions.py
@@ -42,6 +42,8 @@ KNOWN_BROWSER_ACTIONS: frozenset[str] = frozenset({
     "upload_file", "download",
     # Phase 5 §8.5 / §8.6 default-allow read-only / nav-equivalent actions.
     "find_text", "open_tab",
+    # Phase 6 §9.4 compound find-text+type with CAPTCHA-mid-flow partial success
+    "fill_form",
 })
 
 # Back-compat alias — retained so `host/server.py` and test fixtures that

--- a/src/host/permissions.py
+++ b/src/host/permissions.py
@@ -42,6 +42,8 @@ KNOWN_BROWSER_ACTIONS: frozenset[str] = frozenset({
     "upload_file", "download",
     # Phase 5 §8.5 / §8.6 default-allow read-only / nav-equivalent actions.
     "find_text", "open_tab",
+    # Phase 6 §9.3 coordinate-based click with overlay pre-check.
+    "click_xy",
 })
 
 # Back-compat alias — retained so `host/server.py` and test fixtures that

--- a/src/host/permissions.py
+++ b/src/host/permissions.py
@@ -42,6 +42,8 @@ KNOWN_BROWSER_ACTIONS: frozenset[str] = frozenset({
     "upload_file", "download",
     # Phase 5 §8.5 / §8.6 default-allow read-only / nav-equivalent actions.
     "find_text", "open_tab",
+    # Phase 6 §9.1 read-only network inspection.
+    "inspect_requests",
 })
 
 # Back-compat alias — retained so `host/server.py` and test fixtures that

--- a/src/host/server.py
+++ b/src/host/server.py
@@ -2910,6 +2910,24 @@ def create_mesh_app(
                 except ValueError as e:
                     raise HTTPException(400, str(e))
 
+        # Phase 6 §9.1 operator kill-switch for the network-inspection
+        # surface. Mirrors the BROWSER_DOWNLOADS_DISABLED pattern so
+        # operators can disable read-only request logging fleet-wide
+        # without removing the action from `browser_actions` per agent.
+        if action == "inspect_requests":
+            from src.browser.flags import get_bool
+            if get_bool(
+                "BROWSER_NETWORK_INSPECT_DISABLED", False, agent_id=req_agent_id,
+            ):
+                raise HTTPException(403, detail={
+                    "success": False,
+                    "error": {
+                        "code": "forbidden",
+                        "message": "Network inspection disabled by operator",
+                        "retry_after_ms": None,
+                    },
+                })
+
         # Check for browser service restart — re-push proxy config for ALL agents
         try:
             restarted = await _check_browser_boot_id_changed()

--- a/tests/test_browser_click_xy.py
+++ b/tests/test_browser_click_xy.py
@@ -112,7 +112,12 @@ class TestClickXyBoundsValidation:
 
     @pytest.mark.asyncio
     async def test_negative_x_returns_invalid_input(self):
-        """Spec test #2 — x=-1 → invalid_input."""
+        """Spec test #2 — x=-1 → invalid_input.
+
+        Negative coords are rejected before viewport_size is even read,
+        so the message doesn't carry viewport dimensions — it's a
+        coordinate-domain bug, not a viewport-mismatch.
+        """
         inst = _make_inst()
         inst.page.evaluate = AsyncMock()
         mgr = _make_mgr_with(inst)
@@ -121,11 +126,22 @@ class TestClickXyBoundsValidation:
         assert result["success"] is False
         assert result["error"]["code"] == "invalid_input"
         assert "out of viewport bounds" in result["error"]["message"]
-        assert "1280" in result["error"]["message"]
-        assert "800" in result["error"]["message"]
+        assert "non-negative" in result["error"]["message"]
         # Must not have evaluated or clicked.
         inst.page.evaluate.assert_not_awaited()
         inst.page.mouse.click.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_x_at_or_above_width_carries_viewport_dims(self):
+        """Upper-bound rejection includes the viewport dims so the agent
+        can re-target. Negative-coord rejection (above) skips them."""
+        inst = _make_inst()
+        mgr = _make_mgr_with(inst)
+        result = await mgr.click_xy("a1", x=2000, y=10)
+        assert result["success"] is False
+        assert result["error"]["code"] == "invalid_input"
+        assert "1280" in result["error"]["message"]
+        assert "800" in result["error"]["message"]
 
     @pytest.mark.asyncio
     async def test_x_at_or_above_width_returns_invalid_input(self):
@@ -165,6 +181,41 @@ class TestClickXyBoundsValidation:
 
         result = await mgr.click_xy("a1", x=0, y=0)
         assert result["success"] is True
+
+    @pytest.mark.asyncio
+    async def test_viewport_size_none_skips_upper_bound_check(self):
+        """``page.viewport_size`` is ``None`` in some Playwright configs.
+        The manager must not return ``service_unavailable`` — it should
+        skip the upper bound check and let Playwright reject out-of-window
+        coords with its own error if needed. Negative coords are still
+        rejected unconditionally."""
+        inst = _make_inst(viewport=None)
+        # Override _make_inst's default to actually set viewport_size=None
+        inst.page.viewport_size = None
+        inst.page.evaluate = AsyncMock(return_value={
+            "tag": "div", "role": None, "name": "ok",
+            "masked_by": None, "mask_reason": "",
+        })
+        mgr = _make_mgr_with(inst)
+
+        # Positive coords with no viewport metadata: click proceeds.
+        result = await mgr.click_xy("a1", x=100, y=200)
+        assert result["success"] is True
+        inst.page.mouse.click.assert_awaited_once_with(100.0, 200.0)
+
+    @pytest.mark.asyncio
+    async def test_viewport_size_none_still_rejects_negative(self):
+        """Even when viewport_size is unknown, negative coords are
+        always invalid — clamp before reading viewport_size at all."""
+        inst = _make_inst()
+        inst.page.viewport_size = None
+        inst.page.evaluate = AsyncMock()
+        mgr = _make_mgr_with(inst)
+
+        result = await mgr.click_xy("a1", x=-1, y=10)
+        assert result["success"] is False
+        assert result["error"]["code"] == "invalid_input"
+        inst.page.evaluate.assert_not_awaited()
 
 
 class TestClickXyTypeValidation:
@@ -507,3 +558,24 @@ class TestClickXyAgentSkill:
         assert meta["_parallel_safe"] is False
         assert "x" in meta["parameters"]
         assert "y" in meta["parameters"]
+
+    def test_skill_description_documents_review_caveats(self):
+        """Third-pass review locked these caveats into the description so
+        agents are warned about the non-obvious failure modes:
+          - CSS pixels (not device pixels — DPR irrelevant)
+          - viewport-relative (not document-absolute; invalid across scrolls)
+          - cross-origin iframe / shadow DOM limitations
+          - post-click CAPTCHA detection is best-effort
+        """
+        import src.agent.builtins.browser_tool  # noqa: F401
+        from src.agent.skills import _skill_staging
+
+        desc = _skill_staging["browser_click_xy"]["description"].lower()
+        assert "css pixel" in desc, "DPR clarification missing"
+        assert "scroll" in desc, "scroll-position warning missing"
+        assert "iframe" in desc, "cross-origin iframe limitation missing"
+        assert "shadow" in desc, "shadow DOM limitation missing"
+        assert "captcha" in desc, "post-click captcha caveat missing"
+        # Specific viewport literals that lie about the fleet pool must
+        # not be present — fleet uses 1920x1080, 1366x768, etc.
+        assert "1280" not in desc, "stale viewport literal in description"

--- a/tests/test_browser_click_xy.py
+++ b/tests/test_browser_click_xy.py
@@ -1,0 +1,509 @@
+"""Tests for Phase 6 §9.3 ``click_xy`` — coordinate-based click with
+``document.elementFromPoint`` overlay pre-check.
+
+Style follows ``tests/test_browser_service.py``: Playwright is mocked
+end-to-end, so the real engine never runs. The element-from-point JS
+also stays in the manager — we mock ``inst.page.evaluate`` to return
+canned dicts and verify the manager's classification + dispatch path.
+"""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+
+def _make_inst(
+    *, viewport: dict | None = None, user_control: bool = False,
+):
+    """Build a CamoufoxInstance with the bits ``click_xy`` reads."""
+    from src.browser.service import CamoufoxInstance
+    mock_page = MagicMock()
+    mock_page.viewport_size = (
+        {"width": 1280, "height": 800} if viewport is None else viewport
+    )
+    # mouse.click is awaited; AsyncMock for the mouse facade.
+    mock_page.mouse = MagicMock()
+    mock_page.mouse.click = AsyncMock()
+    # locator() is used by _check_captcha — return zero matches by default.
+    mock_locator = MagicMock()
+    mock_locator.count = AsyncMock(return_value=0)
+    mock_page.locator.return_value = mock_locator
+    inst = CamoufoxInstance("a1", MagicMock(), MagicMock(), mock_page)
+    inst._user_control = user_control
+    return inst
+
+
+def _make_mgr_with(inst):
+    from src.browser.service import BrowserManager
+    mgr = BrowserManager(profiles_dir="/tmp/test_profiles")
+    mgr._instances[inst.agent_id] = inst
+    return mgr
+
+
+class TestClickXyHappyPath:
+    """A clean hit on an unmasked element should dispatch the click."""
+
+    @pytest.mark.asyncio
+    async def test_click_xy_success_returns_actual_element(self):
+        inst = _make_inst()
+        inst.page.evaluate = AsyncMock(return_value={
+            "tag": "button",
+            "role": "button",
+            "name": "Save",
+            "masked_by": None,
+            "mask_reason": "",
+        })
+        mgr = _make_mgr_with(inst)
+
+        result = await mgr.click_xy("a1", x=100, y=200)
+        assert result["success"] is True
+        assert result["data"]["clicked_at"] == {"x": 100.0, "y": 200.0}
+        actual = result["data"]["actual_element"]
+        assert actual["tag"] == "button"
+        assert actual["role"] == "button"
+        assert actual["name"] == "Save"
+
+    @pytest.mark.asyncio
+    async def test_click_xy_dispatches_mouse_click_exactly_once(self):
+        """Spec test #10 — mouse.click invoked once with the supplied coords."""
+        inst = _make_inst()
+        inst.page.evaluate = AsyncMock(return_value={
+            "tag": "div", "role": None, "name": "x",
+            "masked_by": None, "mask_reason": "",
+        })
+        mgr = _make_mgr_with(inst)
+
+        await mgr.click_xy("a1", x=42, y=43)
+        inst.page.mouse.click.assert_awaited_once_with(42.0, 43.0)
+
+    @pytest.mark.asyncio
+    async def test_click_xy_calls_check_captcha_post_click(self):
+        """Spec test #11 — post-click CAPTCHA re-detection runs."""
+        inst = _make_inst()
+        inst.page.evaluate = AsyncMock(return_value={
+            "tag": "a", "role": None, "name": "Link",
+            "masked_by": None, "mask_reason": "",
+        })
+        mgr = _make_mgr_with(inst)
+        mgr._check_captcha = AsyncMock(return_value=None)
+
+        await mgr.click_xy("a1", x=1, y=1)
+        mgr._check_captcha.assert_awaited_once_with(inst)
+
+    @pytest.mark.asyncio
+    async def test_click_xy_success_increments_metrics(self):
+        inst = _make_inst()
+        inst.page.evaluate = AsyncMock(return_value={
+            "tag": "button", "role": "button", "name": "ok",
+            "masked_by": None, "mask_reason": "",
+        })
+        mgr = _make_mgr_with(inst)
+
+        await mgr.click_xy("a1", x=10, y=10)
+        assert inst.m_click_success == 1
+        assert list(inst.click_window) == [True]
+
+
+class TestClickXyBoundsValidation:
+    """§2.3 ``invalid_input`` envelope on out-of-range coordinates."""
+
+    @pytest.mark.asyncio
+    async def test_negative_x_returns_invalid_input(self):
+        """Spec test #2 — x=-1 → invalid_input."""
+        inst = _make_inst()
+        inst.page.evaluate = AsyncMock()
+        mgr = _make_mgr_with(inst)
+
+        result = await mgr.click_xy("a1", x=-1, y=10)
+        assert result["success"] is False
+        assert result["error"]["code"] == "invalid_input"
+        assert "out of viewport bounds" in result["error"]["message"]
+        assert "1280" in result["error"]["message"]
+        assert "800" in result["error"]["message"]
+        # Must not have evaluated or clicked.
+        inst.page.evaluate.assert_not_awaited()
+        inst.page.mouse.click.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_x_at_or_above_width_returns_invalid_input(self):
+        """Spec test #2 — x=10000 → invalid_input."""
+        inst = _make_inst()
+        mgr = _make_mgr_with(inst)
+        result = await mgr.click_xy("a1", x=10000, y=10)
+        assert result["success"] is False
+        assert result["error"]["code"] == "invalid_input"
+
+    @pytest.mark.asyncio
+    async def test_x_equal_to_width_is_rejected(self):
+        """``x == width`` is out of bounds (0-indexed)."""
+        inst = _make_inst()
+        mgr = _make_mgr_with(inst)
+        result = await mgr.click_xy("a1", x=1280, y=400)
+        assert result["success"] is False
+        assert result["error"]["code"] == "invalid_input"
+
+    @pytest.mark.asyncio
+    async def test_negative_y_returns_invalid_input(self):
+        inst = _make_inst()
+        mgr = _make_mgr_with(inst)
+        result = await mgr.click_xy("a1", x=10, y=-5)
+        assert result["success"] is False
+        assert result["error"]["code"] == "invalid_input"
+
+    @pytest.mark.asyncio
+    async def test_zero_zero_is_in_bounds(self):
+        """(0, 0) is valid — top-left pixel of the viewport."""
+        inst = _make_inst()
+        inst.page.evaluate = AsyncMock(return_value={
+            "tag": "html", "role": None, "name": "",
+            "masked_by": None, "mask_reason": "",
+        })
+        mgr = _make_mgr_with(inst)
+
+        result = await mgr.click_xy("a1", x=0, y=0)
+        assert result["success"] is True
+
+
+class TestClickXyTypeValidation:
+    """Reject NaN/inf/bool — these are caller bugs."""
+
+    @pytest.mark.asyncio
+    async def test_nan_x_returns_invalid_input(self):
+        """Spec test #3 — NaN/inf → invalid_input."""
+        inst = _make_inst()
+        mgr = _make_mgr_with(inst)
+        result = await mgr.click_xy("a1", x=float("nan"), y=10)
+        assert result["success"] is False
+        assert result["error"]["code"] == "invalid_input"
+        assert "finite" in result["error"]["message"]
+
+    @pytest.mark.asyncio
+    async def test_inf_y_returns_invalid_input(self):
+        inst = _make_inst()
+        mgr = _make_mgr_with(inst)
+        result = await mgr.click_xy("a1", x=10, y=float("inf"))
+        assert result["success"] is False
+        assert result["error"]["code"] == "invalid_input"
+
+    @pytest.mark.asyncio
+    async def test_bool_x_rejected(self):
+        """Python ``True == 1`` would pass the (int, float) check —
+        booleans are rejected explicitly so a typo doesn't silently click."""
+        inst = _make_inst()
+        mgr = _make_mgr_with(inst)
+        result = await mgr.click_xy("a1", x=True, y=10)
+        assert result["success"] is False
+        assert result["error"]["code"] == "invalid_input"
+        assert "bool" in result["error"]["message"].lower()
+
+    @pytest.mark.asyncio
+    async def test_string_x_rejected(self):
+        inst = _make_inst()
+        mgr = _make_mgr_with(inst)
+        result = await mgr.click_xy("a1", x="100", y=10)
+        assert result["success"] is False
+        assert result["error"]["code"] == "invalid_input"
+
+
+class TestClickXyElementFromPoint:
+    """Pre-check classification: null hit, masking detection."""
+
+    @pytest.mark.asyncio
+    async def test_no_element_at_point(self):
+        """Spec test #4 — ``elementFromPoint`` returns null."""
+        inst = _make_inst()
+        inst.page.evaluate = AsyncMock(return_value=None)
+        mgr = _make_mgr_with(inst)
+
+        result = await mgr.click_xy("a1", x=10, y=10)
+        assert result["success"] is False
+        assert result["error"]["code"] == "no_element_at_point"
+        inst.page.mouse.click.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_masked_by_pointer_events(self):
+        """Spec test #5 — ancestor ``pointer-events: none`` → invalid_input
+        with ``masked_by`` set."""
+        inst = _make_inst()
+        inst.page.evaluate = AsyncMock(return_value={
+            "tag": "button",
+            "role": "button",
+            "name": "Hidden",
+            "masked_by": "div.overlay",
+            "mask_reason": "pointer-events",
+        })
+        mgr = _make_mgr_with(inst)
+
+        result = await mgr.click_xy("a1", x=10, y=10)
+        assert result["success"] is False
+        assert result["error"]["code"] == "invalid_input"
+        data = result["error"]["data"]
+        assert data["masked_by"] == "div.overlay"
+        assert data["mask_reason"] == "pointer-events"
+        assert data["actual"]["tag"] == "button"
+        assert data["actual"]["role"] == "button"
+        assert data["actual"]["name"] == "Hidden"
+        # No click should be dispatched on a masked hit.
+        inst.page.mouse.click.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_masked_by_visibility_hidden(self):
+        """Spec test #6 — ancestor ``visibility: hidden`` → mask_reason=visibility."""
+        inst = _make_inst()
+        inst.page.evaluate = AsyncMock(return_value={
+            "tag": "span", "role": None, "name": "x",
+            "masked_by": "div.hidden",
+            "mask_reason": "visibility",
+        })
+        mgr = _make_mgr_with(inst)
+
+        result = await mgr.click_xy("a1", x=10, y=10)
+        assert result["success"] is False
+        assert result["error"]["code"] == "invalid_input"
+        assert result["error"]["data"]["mask_reason"] == "visibility"
+
+    @pytest.mark.asyncio
+    async def test_masked_by_display_none(self):
+        """Spec test #7 — ancestor ``display: none`` → mask_reason=display."""
+        inst = _make_inst()
+        inst.page.evaluate = AsyncMock(return_value={
+            "tag": "a", "role": None, "name": "y",
+            "masked_by": "section#hide",
+            "mask_reason": "display",
+        })
+        mgr = _make_mgr_with(inst)
+
+        result = await mgr.click_xy("a1", x=10, y=10)
+        assert result["success"] is False
+        assert result["error"]["code"] == "invalid_input"
+        assert result["error"]["data"]["mask_reason"] == "display"
+
+    @pytest.mark.asyncio
+    async def test_inner_pointer_events_auto_overrides_outer_none(self):
+        """Spec test #8 — inner ``pointer-events: auto`` cascades over outer
+        ``pointer-events: none``; the click MUST proceed.
+
+        The element-from-point walker is in JS; we represent the "auto
+        boundary detected before any none ancestor" outcome with
+        ``masked_by=null`` (the unmasked hit shape). The click then
+        dispatches normally.
+        """
+        inst = _make_inst()
+        inst.page.evaluate = AsyncMock(return_value={
+            "tag": "button",
+            "role": "button",
+            "name": "Reachable",
+            "masked_by": None,
+            "mask_reason": "",
+        })
+        mgr = _make_mgr_with(inst)
+
+        result = await mgr.click_xy("a1", x=50, y=60)
+        assert result["success"] is True
+        inst.page.mouse.click.assert_awaited_once_with(50.0, 60.0)
+
+
+class TestClickXyConcurrency:
+    """User control + lock invariants."""
+
+    @pytest.mark.asyncio
+    async def test_user_control_returns_conflict(self):
+        """Spec test #9 — ``inst._user_control = True`` → conflict envelope."""
+        inst = _make_inst(user_control=True)
+        inst.page.evaluate = AsyncMock()
+        mgr = _make_mgr_with(inst)
+
+        result = await mgr.click_xy("a1", x=10, y=10)
+        assert result["success"] is False
+        assert result["error"]["code"] == "conflict"
+        # Pre-check JS and the click must not have run.
+        inst.page.evaluate.assert_not_awaited()
+        inst.page.mouse.click.assert_not_awaited()
+
+
+class TestClickXyJsHelper:
+    """The element-from-point JS string is a key integration surface —
+    we don't run it (no real browser) but we verify it is the helper that
+    the manager evaluates and that it carries the cascade comment so a
+    future maintainer doesn't naively rewrite the walk."""
+
+    def test_js_helper_referenced_by_click_xy(self):
+        """``click_xy`` must pass the helper to ``page.evaluate``."""
+        from src.browser import service as svc
+        assert hasattr(svc, "_JS_ELEMENT_FROM_POINT")
+        assert "elementFromPoint" in svc._JS_ELEMENT_FROM_POINT
+        # Pointer-events cascade comment must remain — explicit test that
+        # the inside-out walk is documented.
+        assert "pointer_events_decided" in svc._JS_ELEMENT_FROM_POINT
+        assert "auto" in svc._JS_ELEMENT_FROM_POINT
+        assert "none" in svc._JS_ELEMENT_FROM_POINT
+
+
+class TestClickXyServerRoute:
+    """``POST /browser/{agent_id}/click_xy`` route validation."""
+
+    def test_route_accepts_numeric_xy(self):
+        from starlette.testclient import TestClient
+
+        from src.browser.server import create_browser_app
+        from src.browser.service import BrowserManager
+
+        mgr = BrowserManager(profiles_dir="/tmp/test_profiles")
+
+        async def _fake_click_xy(agent_id, x, y):
+            return {
+                "success": True,
+                "data": {"clicked_at": {"x": x, "y": y},
+                         "actual_element": {"tag": "div", "role": None, "name": ""}},
+            }
+        mgr.click_xy = _fake_click_xy
+        app = create_browser_app(mgr)
+
+        client = TestClient(app)
+        resp = client.post(
+            "/browser/test_agent/click_xy",
+            json={"x": 100, "y": 200},
+        )
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["success"] is True
+        assert body["data"]["clicked_at"] == {"x": 100, "y": 200}
+
+    def test_route_rejects_missing_coords(self):
+        from starlette.testclient import TestClient
+
+        from src.browser.server import create_browser_app
+        from src.browser.service import BrowserManager
+
+        mgr = BrowserManager(profiles_dir="/tmp/test_profiles")
+        app = create_browser_app(mgr)
+
+        client = TestClient(app)
+        resp = client.post("/browser/test_agent/click_xy", json={})
+        # Missing keys are rejected via the type guard (None → not number).
+        assert resp.status_code == 400
+
+    def test_route_rejects_string_coords(self):
+        from starlette.testclient import TestClient
+
+        from src.browser.server import create_browser_app
+        from src.browser.service import BrowserManager
+
+        mgr = BrowserManager(profiles_dir="/tmp/test_profiles")
+        app = create_browser_app(mgr)
+
+        client = TestClient(app)
+        resp = client.post(
+            "/browser/test_agent/click_xy",
+            json={"x": "10", "y": "20"},
+        )
+        assert resp.status_code == 400
+
+    def test_route_rejects_bool_coords(self):
+        from starlette.testclient import TestClient
+
+        from src.browser.server import create_browser_app
+        from src.browser.service import BrowserManager
+
+        mgr = BrowserManager(profiles_dir="/tmp/test_profiles")
+        app = create_browser_app(mgr)
+
+        client = TestClient(app)
+        resp = client.post(
+            "/browser/test_agent/click_xy",
+            json={"x": True, "y": 10},
+        )
+        assert resp.status_code == 400
+
+
+class TestClickXyMeshAction:
+    """The action name must be in ``KNOWN_BROWSER_ACTIONS`` so the mesh
+    accepts it (input validation), AND ``can_browser_action`` must
+    default-allow it for any agent with ``can_use_browser=true``."""
+
+    def test_click_xy_in_known_browser_actions(self):
+        """Spec test #12 — KNOWN_BROWSER_ACTIONS contains click_xy."""
+        from src.host.permissions import KNOWN_BROWSER_ACTIONS
+        assert "click_xy" in KNOWN_BROWSER_ACTIONS
+
+    def test_default_allow_grants_click_xy(self, tmp_path):
+        """Spec test #13 — agent with ``browser_actions=None`` is granted."""
+        from src.host.permissions import PermissionMatrix
+
+        cfg = {
+            "permissions": {
+                "default-grant": {"can_use_browser": True},
+            },
+        }
+        path = tmp_path / "permissions.json"
+        path.write_text(json.dumps(cfg))
+        matrix = PermissionMatrix(config_path=str(path))
+        assert matrix.can_browser_action("default-grant", "click_xy") is True
+
+    def test_restricted_actions_denies_click_xy(self, tmp_path):
+        """Spec test #13 — ``browser_actions=['navigate']`` denies click_xy."""
+        from src.host.permissions import PermissionMatrix
+
+        cfg = {
+            "permissions": {
+                "restricted": {
+                    "can_use_browser": True,
+                    "browser_actions": ["navigate"],
+                },
+            },
+        }
+        path = tmp_path / "permissions.json"
+        path.write_text(json.dumps(cfg))
+        matrix = PermissionMatrix(config_path=str(path))
+        assert matrix.can_browser_action("restricted", "click_xy") is False
+
+    def test_can_use_browser_false_denies_click_xy(self, tmp_path):
+        from src.host.permissions import PermissionMatrix
+
+        cfg = {
+            "permissions": {
+                "no-browser": {"can_use_browser": False},
+            },
+        }
+        path = tmp_path / "permissions.json"
+        path.write_text(json.dumps(cfg))
+        matrix = PermissionMatrix(config_path=str(path))
+        assert matrix.can_browser_action("no-browser", "click_xy") is False
+
+
+class TestClickXyAgentSkill:
+    """Agent-side skill registration + invocation."""
+
+    @pytest.mark.asyncio
+    async def test_browser_click_xy_skill_calls_mesh_with_click_xy_action(self):
+        from src.agent.builtins import browser_tool
+
+        mesh = MagicMock()
+        mesh.browser_command = AsyncMock(return_value={"success": True, "data": {}})
+
+        result = await browser_tool.browser_click_xy(
+            x=12, y=34, mesh_client=mesh,
+        )
+        mesh.browser_command.assert_awaited_once_with(
+            "click_xy", {"x": 12, "y": 34},
+        )
+        # Skills wrap responses in deep_redact — the success envelope round-trips.
+        assert result["success"] is True
+
+    def test_browser_click_xy_registered_as_skill(self):
+        """Skill metadata must surface to the staging registry so the LLM
+        sees it. Importing ``browser_tool`` triggers the @skill decorator
+        which populates ``_skill_staging``."""
+        import src.agent.builtins.browser_tool  # noqa: F401
+        from src.agent.skills import _skill_staging
+
+        assert "browser_click_xy" in _skill_staging
+        meta = _skill_staging["browser_click_xy"]
+        # Match plan §9.3 contract — parallel_safe=False because clicks
+        # mutate shared browser state.
+        assert meta["_parallel_safe"] is False
+        assert "x" in meta["parameters"]
+        assert "y" in meta["parameters"]

--- a/tests/test_browser_click_xy.py
+++ b/tests/test_browser_click_xy.py
@@ -294,6 +294,11 @@ class TestClickXyElementFromPoint:
         data = result["error"]["data"]
         assert data["masked_by"] == "div.overlay"
         assert data["mask_reason"] == "pointer-events"
+        assert data["actual_element"]["tag"] == "button"
+        assert data["actual_element"]["role"] == "button"
+        assert data["actual_element"]["name"] == "Hidden"
+        # Back-compat alias retained for callers from the first branch
+        # revision; the documented contract is actual_element.
         assert data["actual"]["tag"] == "button"
         assert data["actual"]["role"] == "button"
         assert data["actual"]["name"] == "Hidden"

--- a/tests/test_browser_fill_form.py
+++ b/tests/test_browser_fill_form.py
@@ -315,6 +315,40 @@ class TestFillFormFieldFailures:
         assert loc.fill.await_count == 1
 
     @pytest.mark.asyncio
+    async def test_prefers_textbox_over_matching_label_text(self):
+        """When both a label element and its textbox match, fill textbox."""
+        mgr = _make_manager()
+        refs = {
+            # DOM/snapshot order often sees the visible <label> first.
+            "e0": {"role": "text", "name": "Email", "index": 0, "disabled": False},
+            "e1": {"role": "textbox", "name": "Email", "index": 0, "disabled": False},
+        }
+        inst = _make_instance(refs)
+        label_loc = _make_locator(raise_on_fill=RuntimeError("not fillable"))
+        input_loc = _make_locator()
+
+        async def fake_locator(self_mgr, _inst, ref_id):
+            if ref_id == "e0":
+                return label_loc
+            return input_loc
+
+        with patch.object(BrowserManager, "get_or_start", return_value=inst), \
+             patch.object(BrowserManager, "_locator_from_ref", new=fake_locator), \
+             patch.object(BrowserManager, "_check_captcha",
+                          new_callable=AsyncMock, return_value=None), \
+             patch.object(BrowserManager, "_snapshot_impl", new=_fake_snapshot):
+            result = await mgr.fill_form(
+                "agent1",
+                [{"label": "Email", "value": "a@b.co"}],
+            )
+
+        assert result["success"] is True
+        assert result["data"]["filled"][0]["status"] == "filled"
+        assert result["data"]["filled"][0]["ref"] == "e1"
+        label_loc.fill.assert_not_awaited()
+        input_loc.fill.assert_awaited_once_with("a@b.co")
+
+    @pytest.mark.asyncio
     async def test_locator_from_ref_returns_none_marks_type_failed(self):
         """find_text yields a match, but locator resolution returns None.
 
@@ -778,6 +812,42 @@ class TestFillFormSubmitEdgeCases:
         assert loc.press.await_count == 0
 
     @pytest.mark.asyncio
+    async def test_top_level_submit_with_partial_fill_no_press(self):
+        """Top-level submit_after should not submit an incomplete form.
+
+        A caller asking for final submit expects the whole requested field
+        set to be present. If one field is missing, return partial_success
+        and leave submission to an explicit follow-up decision.
+        """
+        mgr = _make_manager()
+        refs = {
+            "e0": {"role": "textbox", "name": "Email", "index": 0, "disabled": False},
+        }
+        inst = _make_instance(refs)
+        loc = _make_locator()
+
+        with patch.object(BrowserManager, "get_or_start", return_value=inst), \
+             patch.object(BrowserManager, "_locator_from_ref",
+                          new_callable=AsyncMock, return_value=loc), \
+             patch.object(BrowserManager, "_check_captcha",
+                          new_callable=AsyncMock, return_value=None), \
+             patch.object(BrowserManager, "_snapshot_impl", new=_fake_snapshot):
+            result = await mgr.fill_form(
+                "agent1",
+                [
+                    {"label": "Email", "value": "a@b.co"},
+                    {"label": "Password", "value": "pw"},
+                ],
+                submit_after=True,
+            )
+
+        data = result["data"]
+        assert [f["status"] for f in data["filled"]] == ["filled", "not_found"]
+        assert data["partial_success"] is True
+        assert data["submitted"] is False
+        assert loc.press.await_count == 0
+
+    @pytest.mark.asyncio
     async def test_per_field_submit_on_not_found_field_no_press(self):
         """Concern 10: per-field ``submit_after`` on not_found → no Enter.
 
@@ -934,5 +1004,3 @@ class TestFillFormServerRoute:
         assert args[0] == "a1"
         assert args[1] == [{"label": "Email", "value": "a@b.co"}]
         assert kwargs == {"submit_after": False}
-
-

--- a/tests/test_browser_fill_form.py
+++ b/tests/test_browser_fill_form.py
@@ -187,6 +187,56 @@ class TestFillFormCaptchaMidFlow:
         assert loc.fill.await_count == 1
 
     @pytest.mark.asyncio
+    async def test_per_field_submit_then_captcha_reports_submitted_true(self):
+        """Per-field Enter triggers the CAPTCHA → ``submitted=True``.
+
+        The plan §9.4 reviewer flagged this: pressing Enter often IS
+        what triggers the CAPTCHA, and if the press succeeded the form
+        may already have been submitted with partial data. The captcha
+        envelope must report ``submitted: true`` so the agent doesn't
+        blindly re-type the remaining fields against a navigated page.
+        """
+        mgr = _make_manager()
+        refs = {
+            "e0": {"role": "textbox", "name": "Email", "index": 0, "disabled": False},
+            "e1": {"role": "textbox", "name": "Password", "index": 0, "disabled": False},
+        }
+        inst = _make_instance(refs)
+        loc = _make_locator()
+        captcha_blob = {"type": "iframe[src*=recaptcha]", "message": "CAPTCHA"}
+
+        # No captcha after fill, captcha appears AFTER per-field Enter.
+        # _check_captcha is called once per field (after fill+optional Enter).
+        check_captcha_mock = AsyncMock(return_value=captcha_blob)
+
+        with patch.object(BrowserManager, "get_or_start", return_value=inst), \
+             patch.object(BrowserManager, "_locator_from_ref",
+                          new_callable=AsyncMock, return_value=loc), \
+             patch.object(BrowserManager, "_check_captcha",
+                          new=check_captcha_mock), \
+             patch.object(BrowserManager, "_snapshot_impl", new=_fake_snapshot):
+            result = await mgr.fill_form(
+                "agent1",
+                [
+                    {"label": "Email", "value": "a@b.co", "submit_after": True},
+                    {"label": "Password", "value": "pw"},
+                ],
+            )
+
+        assert result["success"] is True
+        data = result["data"]
+        assert data["captcha_required"] is True
+        # Critical: the per-field Enter pressed → submitted=True so the
+        # agent knows the form was already submitted with partial data.
+        assert data["submitted"] is True
+        # Enter was pressed exactly once (the per-field one).
+        assert loc.press.await_count == 1
+        loc.press.assert_awaited_with("Enter")
+        # Remaining still echoes Password un-attempted.
+        assert len(data["remaining"]) == 1
+        assert data["remaining"][0]["label"] == "Password"
+
+    @pytest.mark.asyncio
     async def test_captcha_before_any_fill_yields_empty_filled(self):
         """find_text returns no matches; captcha then detected → no fills."""
         mgr = _make_manager()

--- a/tests/test_browser_fill_form.py
+++ b/tests/test_browser_fill_form.py
@@ -1,0 +1,589 @@
+"""Tests for BrowserManager.fill_form (Phase 6 §9.4).
+
+Compound find-text + fill across a sequence of form fields with
+CAPTCHA-mid-flow partial-success protocol.
+
+Style mirrors :class:`tests.test_browser_service.TestFindText` —
+mocks ``_locator_from_ref``, ``_check_captcha``, ``_snapshot_impl``
+on the manager, and seeds ``inst.refs`` directly.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from src.browser.ref_handle import from_legacy_dict as _h
+from src.browser.service import BrowserManager
+
+
+def _make_manager() -> BrowserManager:
+    """Build a BrowserManager without invoking __init__ side effects."""
+    from src.browser.redaction import CredentialRedactor
+    mgr = BrowserManager.__new__(BrowserManager)
+    mgr.redactor = CredentialRedactor()
+    return mgr
+
+
+def _make_instance(refs_dict: dict | None = None) -> MagicMock:
+    """Build a mock CamoufoxInstance with the given ref-id → ref-dict map."""
+    inst = MagicMock()
+    inst.refs = {k: _h(v) for k, v in (refs_dict or {}).items()}
+    inst.page = AsyncMock()
+    inst.page.viewport_size = {"width": 1280, "height": 720}
+    inst.lock = asyncio.Lock()
+    inst.touch = MagicMock()
+    inst._user_control = False
+    return inst
+
+
+def _make_locator(*, raise_on_fill: Exception | None = None) -> AsyncMock:
+    """Locator stub: visible, in-viewport, fill/press succeed unless overridden."""
+    loc = AsyncMock()
+    loc.is_visible = AsyncMock(return_value=True)
+    loc.bounding_box = AsyncMock(
+        return_value={"x": 10, "y": 10, "width": 50, "height": 20},
+    )
+    loc.scroll_into_view_if_needed = AsyncMock()
+    if raise_on_fill is not None:
+        loc.fill = AsyncMock(side_effect=raise_on_fill)
+    else:
+        loc.fill = AsyncMock(return_value=None)
+    loc.press = AsyncMock(return_value=None)
+    return loc
+
+
+async def _fake_snapshot(self_mgr, _inst, _agent_id, **_kw):
+    return {"success": True, "data": {}}
+
+
+class TestFillFormHappyPath:
+    """End-to-end happy path: every field found and filled."""
+
+    @pytest.mark.asyncio
+    async def test_three_fields_all_filled(self):
+        mgr = _make_manager()
+        refs = {
+            "e0": {"role": "textbox", "name": "Email", "index": 0, "disabled": False},
+            "e1": {"role": "textbox", "name": "Password", "index": 0, "disabled": False},
+            "e2": {"role": "textbox", "name": "Phone", "index": 0, "disabled": False},
+        }
+        inst = _make_instance(refs)
+        loc = _make_locator()
+
+        with patch.object(BrowserManager, "get_or_start", return_value=inst), \
+             patch.object(BrowserManager, "_locator_from_ref",
+                          new_callable=AsyncMock, return_value=loc), \
+             patch.object(BrowserManager, "_check_captcha",
+                          new_callable=AsyncMock, return_value=None), \
+             patch.object(BrowserManager, "_snapshot_impl", new=_fake_snapshot):
+            result = await mgr.fill_form(
+                "agent1",
+                [
+                    {"label": "Email", "value": "alice@example.com"},
+                    {"label": "Password", "value": "hunter2"},
+                    {"label": "Phone", "value": "555-1212"},
+                ],
+            )
+
+        assert result["success"] is True
+        data = result["data"]
+        assert data["partial_success"] is False
+        assert data["captcha_required"] is False
+        assert len(data["filled"]) == 3
+        assert all(f["status"] == "filled" for f in data["filled"])
+        assert data["remaining"] == []
+        assert data["submitted"] is False
+        assert loc.fill.await_count == 3
+        assert loc.press.await_count == 0
+
+    @pytest.mark.asyncio
+    async def test_top_level_submit_after_presses_enter_on_last_field(self):
+        mgr = _make_manager()
+        refs = {
+            "e0": {"role": "textbox", "name": "Email", "index": 0, "disabled": False},
+            "e1": {"role": "textbox", "name": "Password", "index": 0, "disabled": False},
+        }
+        inst = _make_instance(refs)
+        loc = _make_locator()
+
+        with patch.object(BrowserManager, "get_or_start", return_value=inst), \
+             patch.object(BrowserManager, "_locator_from_ref",
+                          new_callable=AsyncMock, return_value=loc), \
+             patch.object(BrowserManager, "_check_captcha",
+                          new_callable=AsyncMock, return_value=None), \
+             patch.object(BrowserManager, "_snapshot_impl", new=_fake_snapshot):
+            result = await mgr.fill_form(
+                "agent1",
+                [
+                    {"label": "Email", "value": "a@b.co"},
+                    {"label": "Password", "value": "pw"},
+                ],
+                submit_after=True,
+            )
+
+        assert result["success"] is True
+        assert result["data"]["submitted"] is True
+        # Enter pressed exactly once at end.
+        assert loc.press.await_count == 1
+        loc.press.assert_awaited_with("Enter")
+
+
+class TestFillFormCaptchaMidFlow:
+    """CAPTCHA detection mid-flow → partial_success envelope."""
+
+    @pytest.mark.asyncio
+    async def test_captcha_after_first_field_stops_loop(self):
+        mgr = _make_manager()
+        refs = {
+            "e0": {"role": "textbox", "name": "Email", "index": 0, "disabled": False},
+            "e1": {"role": "textbox", "name": "Password", "index": 0, "disabled": False},
+            "e2": {"role": "textbox", "name": "Phone", "index": 0, "disabled": False},
+        }
+        inst = _make_instance(refs)
+        loc = _make_locator()
+        captcha_blob = {"type": "iframe[src*=recaptcha]", "message": "CAPTCHA"}
+
+        # Captcha appears after the first fill; subsequent calls would also
+        # report it, but the loop should bail before the second find_text.
+        check_captcha_mock = AsyncMock(return_value=captcha_blob)
+
+        with patch.object(BrowserManager, "get_or_start", return_value=inst), \
+             patch.object(BrowserManager, "_locator_from_ref",
+                          new_callable=AsyncMock, return_value=loc), \
+             patch.object(BrowserManager, "_check_captcha",
+                          new=check_captcha_mock), \
+             patch.object(BrowserManager, "_snapshot_impl", new=_fake_snapshot):
+            result = await mgr.fill_form(
+                "agent1",
+                [
+                    {"label": "Email", "value": "a@b.co"},
+                    {"label": "Password", "value": "pw"},
+                    {"label": "Phone", "value": "555"},
+                ],
+                submit_after=True,  # Must NOT be honored on captcha exit.
+            )
+
+        assert result["success"] is True
+        data = result["data"]
+        assert data["partial_success"] is True
+        assert data["captcha_required"] is True
+        assert len(data["filled"]) == 1
+        assert data["filled"][0]["status"] == "filled"
+        assert data["filled"][0]["label"] == "Email"
+        # Both un-attempted fields echoed back verbatim with full value.
+        assert len(data["remaining"]) == 2
+        assert data["remaining"][0] == {
+            "label": "Password", "value": "pw", "submit_after": False,
+        }
+        assert data["remaining"][1] == {
+            "label": "Phone", "value": "555", "submit_after": False,
+        }
+        assert data["captcha"] == captcha_blob
+        assert data["submitted"] is False
+        # Only one fill should have happened — the loop bailed.
+        assert loc.fill.await_count == 1
+
+    @pytest.mark.asyncio
+    async def test_captcha_before_any_fill_yields_empty_filled(self):
+        """find_text returns no matches; captcha then detected → no fills."""
+        mgr = _make_manager()
+        # No matching refs — find_text returns empty matches for "Email".
+        refs = {
+            "e0": {"role": "button", "name": "Cancel", "index": 0, "disabled": False},
+        }
+        inst = _make_instance(refs)
+        loc = _make_locator()
+        captcha_blob = {"type": "iframe[src*=hcaptcha]", "message": "CAPTCHA"}
+
+        with patch.object(BrowserManager, "get_or_start", return_value=inst), \
+             patch.object(BrowserManager, "_locator_from_ref",
+                          new_callable=AsyncMock, return_value=loc), \
+             patch.object(BrowserManager, "_check_captcha",
+                          new_callable=AsyncMock, return_value=captcha_blob), \
+             patch.object(BrowserManager, "_snapshot_impl", new=_fake_snapshot):
+            result = await mgr.fill_form(
+                "agent1",
+                [
+                    {"label": "Email", "value": "a@b.co"},
+                    {"label": "Password", "value": "pw"},
+                ],
+            )
+
+        assert result["success"] is True
+        data = result["data"]
+        assert data["partial_success"] is True
+        assert data["captcha_required"] is True
+        # Email got attempted (and recorded as not_found) BEFORE captcha
+        # check; Password was never touched.
+        assert len(data["filled"]) == 1
+        assert data["filled"][0]["status"] == "not_found"
+        assert data["filled"][0]["label"] == "Email"
+        assert data["remaining"] == [
+            {"label": "Password", "value": "pw", "submit_after": False},
+        ]
+        assert loc.fill.await_count == 0
+
+
+class TestFillFormFieldFailures:
+    """Per-field failure modes — loop continues, doesn't abort."""
+
+    @pytest.mark.asyncio
+    async def test_field_not_found_continues_loop(self):
+        """Field 1 has no matching label; field 2 fills successfully."""
+        mgr = _make_manager()
+        refs = {
+            "e0": {"role": "textbox", "name": "Phone", "index": 0, "disabled": False},
+        }
+        inst = _make_instance(refs)
+        loc = _make_locator()
+
+        with patch.object(BrowserManager, "get_or_start", return_value=inst), \
+             patch.object(BrowserManager, "_locator_from_ref",
+                          new_callable=AsyncMock, return_value=loc), \
+             patch.object(BrowserManager, "_check_captcha",
+                          new_callable=AsyncMock, return_value=None), \
+             patch.object(BrowserManager, "_snapshot_impl", new=_fake_snapshot):
+            result = await mgr.fill_form(
+                "agent1",
+                [
+                    {"label": "Email", "value": "a@b.co"},
+                    {"label": "Phone", "value": "555"},
+                ],
+            )
+
+        assert result["success"] is True
+        data = result["data"]
+        # partial_success because of the not_found, but no captcha.
+        assert data["partial_success"] is True
+        assert data["captcha_required"] is False
+        statuses = [f["status"] for f in data["filled"]]
+        assert statuses == ["not_found", "filled"]
+        assert data["remaining"] == []
+        assert loc.fill.await_count == 1
+
+    @pytest.mark.asyncio
+    async def test_locator_from_ref_returns_none_marks_type_failed(self):
+        """find_text yields a match, but locator resolution returns None.
+
+        ``_locator_from_ref`` is called twice for the email field — once by
+        ``_find_text_impl`` (visibility check) and again by ``fill_form``
+        (to drive the fill). Returning ``None`` for "e0" on every call
+        models a fully-stale ref. find_text gracefully tolerates None
+        (in_viewport falls to False), and the fill_form path then sees
+        the None and reports type_failed.
+        """
+        mgr = _make_manager()
+        refs = {
+            "e0": {"role": "textbox", "name": "Email", "index": 0, "disabled": False},
+            "e1": {"role": "textbox", "name": "Phone", "index": 0, "disabled": False},
+        }
+        inst = _make_instance(refs)
+        good_loc = _make_locator()
+
+        async def fake_locator(self_mgr, _inst, ref_id):
+            if ref_id == "e0":
+                return None
+            return good_loc
+
+        with patch.object(BrowserManager, "get_or_start", return_value=inst), \
+             patch.object(BrowserManager, "_locator_from_ref", new=fake_locator), \
+             patch.object(BrowserManager, "_check_captcha",
+                          new_callable=AsyncMock, return_value=None), \
+             patch.object(BrowserManager, "_snapshot_impl", new=_fake_snapshot):
+            result = await mgr.fill_form(
+                "agent1",
+                [
+                    {"label": "Email", "value": "a@b.co"},
+                    {"label": "Phone", "value": "555"},
+                ],
+            )
+
+        assert result["success"] is True
+        data = result["data"]
+        assert data["filled"][0]["status"] == "type_failed"
+        assert data["filled"][0]["reason"] == "ref not found"
+        assert data["filled"][1]["status"] == "filled"
+
+    @pytest.mark.asyncio
+    async def test_fill_raises_timeout_marks_type_failed_and_continues(self):
+        mgr = _make_manager()
+        refs = {
+            "e0": {"role": "textbox", "name": "Email", "index": 0, "disabled": False},
+            "e1": {"role": "textbox", "name": "Phone", "index": 0, "disabled": False},
+        }
+        inst = _make_instance(refs)
+        good_loc = _make_locator()
+        bad_loc = _make_locator(raise_on_fill=TimeoutError("element detached"))
+
+        # _locator_from_ref is called by both find_text (for in-viewport
+        # check) and the fill_form body itself, so route by ref-id rather
+        # than call order.
+        loc_map = {"e0": bad_loc, "e1": good_loc}
+
+        async def fake_locator(self_mgr, _inst, ref_id):
+            return loc_map[ref_id]
+
+        with patch.object(BrowserManager, "get_or_start", return_value=inst), \
+             patch.object(BrowserManager, "_locator_from_ref", new=fake_locator), \
+             patch.object(BrowserManager, "_check_captcha",
+                          new_callable=AsyncMock, return_value=None), \
+             patch.object(BrowserManager, "_snapshot_impl", new=_fake_snapshot):
+            result = await mgr.fill_form(
+                "agent1",
+                [
+                    {"label": "Email", "value": "a@b.co"},
+                    {"label": "Phone", "value": "555"},
+                ],
+            )
+
+        assert result["success"] is True
+        data = result["data"]
+        assert data["filled"][0]["status"] == "type_failed"
+        assert "detached" in data["filled"][0]["reason"]
+        assert data["filled"][1]["status"] == "filled"
+
+
+class TestFillFormValidation:
+    """Input validation — rejected with invalid_input before any browser work."""
+
+    @pytest.mark.asyncio
+    async def test_empty_fields_rejected(self):
+        mgr = _make_manager()
+        with patch.object(BrowserManager, "get_or_start") as get_start:
+            result = await mgr.fill_form("agent1", [])
+        assert result["success"] is False
+        assert result["error"]["code"] == "invalid_input"
+        # Should never reach get_or_start.
+        get_start.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_too_many_fields_rejected(self):
+        mgr = _make_manager()
+        fields = [
+            {"label": f"Field{i}", "value": "v"} for i in range(51)
+        ]
+        result = await mgr.fill_form("agent1", fields)
+        assert result["success"] is False
+        assert result["error"]["code"] == "invalid_input"
+        assert "50" in result["error"]["message"]
+
+    @pytest.mark.asyncio
+    async def test_value_with_null_byte_rejected(self):
+        mgr = _make_manager()
+        result = await mgr.fill_form(
+            "agent1",
+            [{"label": "Email", "value": "a\x00b"}],
+        )
+        assert result["success"] is False
+        assert result["error"]["code"] == "invalid_input"
+        assert "null byte" in result["error"]["message"]
+
+    @pytest.mark.asyncio
+    async def test_value_too_long_rejected(self):
+        mgr = _make_manager()
+        result = await mgr.fill_form(
+            "agent1",
+            [{"label": "Email", "value": "x" * 10001}],
+        )
+        assert result["success"] is False
+        assert result["error"]["code"] == "invalid_input"
+        assert "10000" in result["error"]["message"]
+
+    @pytest.mark.asyncio
+    async def test_label_empty_rejected(self):
+        mgr = _make_manager()
+        result = await mgr.fill_form(
+            "agent1",
+            [{"label": "", "value": "v"}],
+        )
+        assert result["success"] is False
+        assert result["error"]["code"] == "invalid_input"
+
+    @pytest.mark.asyncio
+    async def test_label_too_long_rejected(self):
+        mgr = _make_manager()
+        result = await mgr.fill_form(
+            "agent1",
+            [{"label": "x" * 501, "value": "v"}],
+        )
+        assert result["success"] is False
+        assert result["error"]["code"] == "invalid_input"
+
+    @pytest.mark.asyncio
+    async def test_non_dict_field_rejected(self):
+        mgr = _make_manager()
+        result = await mgr.fill_form("agent1", ["not a dict"])
+        assert result["success"] is False
+        assert result["error"]["code"] == "invalid_input"
+
+
+class TestFillFormUserControl:
+    """User VNC control pauses agent input — return conflict."""
+
+    @pytest.mark.asyncio
+    async def test_user_control_returns_conflict(self):
+        mgr = _make_manager()
+        inst = _make_instance({})
+        inst._user_control = True
+
+        with patch.object(BrowserManager, "get_or_start", return_value=inst):
+            result = await mgr.fill_form(
+                "agent1",
+                [{"label": "Email", "value": "a@b.co"}],
+            )
+
+        assert result["success"] is False
+        assert result["error"]["code"] == "conflict"
+
+
+class TestFillFormPerFieldSubmit:
+    """Per-field submit_after presses Enter without aborting the loop."""
+
+    @pytest.mark.asyncio
+    async def test_per_field_submit_does_not_stop_loop(self):
+        """Field 2 of 3 has submit_after=True; field 3 still gets filled."""
+        mgr = _make_manager()
+        refs = {
+            "e0": {"role": "textbox", "name": "Email", "index": 0, "disabled": False},
+            "e1": {"role": "textbox", "name": "Password", "index": 0, "disabled": False},
+            "e2": {"role": "textbox", "name": "Phone", "index": 0, "disabled": False},
+        }
+        inst = _make_instance(refs)
+        loc = _make_locator()
+
+        with patch.object(BrowserManager, "get_or_start", return_value=inst), \
+             patch.object(BrowserManager, "_locator_from_ref",
+                          new_callable=AsyncMock, return_value=loc), \
+             patch.object(BrowserManager, "_check_captcha",
+                          new_callable=AsyncMock, return_value=None), \
+             patch.object(BrowserManager, "_snapshot_impl", new=_fake_snapshot):
+            result = await mgr.fill_form(
+                "agent1",
+                [
+                    {"label": "Email", "value": "a@b.co"},
+                    {"label": "Password", "value": "pw", "submit_after": True},
+                    {"label": "Phone", "value": "555"},
+                ],
+            )
+
+        assert result["success"] is True
+        data = result["data"]
+        assert all(f["status"] == "filled" for f in data["filled"])
+        assert len(data["filled"]) == 3
+        assert loc.fill.await_count == 3
+        # Per-field submit on field 2 → one Enter press during the loop.
+        # Top-level submit_after was False so no extra Enter at end.
+        assert loc.press.await_count == 1
+        loc.press.assert_awaited_with("Enter")
+
+
+class TestFillFormResume:
+    """Two-call resume: captcha → solver → resume with `remaining`."""
+
+    @pytest.mark.asyncio
+    async def test_resume_after_captcha_completes_form(self):
+        mgr = _make_manager()
+        refs = {
+            "e0": {"role": "textbox", "name": "Email", "index": 0, "disabled": False},
+            "e1": {"role": "textbox", "name": "Password", "index": 0, "disabled": False},
+        }
+        inst = _make_instance(refs)
+        loc = _make_locator()
+        captcha_blob = {"type": "iframe[src*=recaptcha]", "message": "CAPTCHA"}
+
+        # First call: captcha appears after Email fill.
+        check_seq = iter([captcha_blob, None, None])
+
+        async def fake_check(_self, _inst):
+            return next(check_seq)
+
+        with patch.object(BrowserManager, "get_or_start", return_value=inst), \
+             patch.object(BrowserManager, "_locator_from_ref",
+                          new_callable=AsyncMock, return_value=loc), \
+             patch.object(BrowserManager, "_check_captcha", new=fake_check), \
+             patch.object(BrowserManager, "_snapshot_impl", new=_fake_snapshot):
+            first = await mgr.fill_form(
+                "agent1",
+                [
+                    {"label": "Email", "value": "a@b.co"},
+                    {"label": "Password", "value": "pw"},
+                ],
+            )
+            assert first["data"]["captcha_required"] is True
+            remaining = first["data"]["remaining"]
+            assert len(remaining) == 1
+
+            # Resume — pass `remaining` straight back. This mirrors what the
+            # agent would do after solving the CAPTCHA.
+            second = await mgr.fill_form("agent1", remaining)
+
+        assert second["success"] is True
+        assert second["data"]["captcha_required"] is False
+        assert second["data"]["partial_success"] is False
+        assert len(second["data"]["filled"]) == 1
+        assert second["data"]["filled"][0]["status"] == "filled"
+        assert second["data"]["filled"][0]["label"] == "Password"
+        # First call: 1 fill (Email). Second call: 1 fill (Password). Total 2.
+        assert loc.fill.await_count == 2
+
+
+class TestFillFormConcurrency:
+    """Lock serialization — concurrent fill_form calls don't interleave."""
+
+    @pytest.mark.asyncio
+    async def test_concurrent_calls_serialize_via_lock(self):
+        """Two parallel fill_form calls execute strictly one after another.
+
+        Verifies the §2.4 lock invariant: ``inst.lock`` is the single
+        serialization point. Whichever call grabs the lock first
+        completes before the other proceeds — no interleaving of
+        find_text and fill across the two flows.
+        """
+        mgr = _make_manager()
+        refs = {
+            "e0": {"role": "textbox", "name": "Email", "index": 0, "disabled": False},
+        }
+        inst = _make_instance(refs)
+        loc = _make_locator()
+
+        # Track entry/exit ordering of fill() calls. If the lock works,
+        # we should see [enter, exit, enter, exit] not interleaved.
+        events: list[str] = []
+
+        async def slow_fill(_value):
+            events.append("enter")
+            await asyncio.sleep(0.05)
+            events.append("exit")
+
+        loc.fill = AsyncMock(side_effect=slow_fill)
+
+        with patch.object(BrowserManager, "get_or_start", return_value=inst), \
+             patch.object(BrowserManager, "_locator_from_ref",
+                          new_callable=AsyncMock, return_value=loc), \
+             patch.object(BrowserManager, "_check_captcha",
+                          new_callable=AsyncMock, return_value=None), \
+             patch.object(BrowserManager, "_snapshot_impl", new=_fake_snapshot):
+            r1, r2 = await asyncio.gather(
+                mgr.fill_form("agent1", [{"label": "Email", "value": "a"}]),
+                mgr.fill_form("agent1", [{"label": "Email", "value": "b"}]),
+            )
+
+        assert r1["success"] is True
+        assert r2["success"] is True
+        # Strict ordering — never enter/enter back-to-back.
+        assert events == ["enter", "exit", "enter", "exit"]
+
+
+class TestFillFormActionRegistered:
+    """Action name must appear in the mesh-side known-action set."""
+
+    def test_fill_form_in_known_browser_actions(self):
+        from src.host.permissions import KNOWN_BROWSER_ACTIONS
+        assert "fill_form" in KNOWN_BROWSER_ACTIONS, (
+            "fill_form missing from KNOWN_BROWSER_ACTIONS in "
+            "host/permissions.py — browser_fill_form skill will silently "
+            "fail with a 400 from the mesh proxy."
+        )

--- a/tests/test_browser_fill_form.py
+++ b/tests/test_browser_fill_form.py
@@ -392,7 +392,12 @@ class TestFillFormFieldFailures:
         assert result["success"] is True
         data = result["data"]
         assert data["filled"][0]["status"] == "type_failed"
-        assert "detached" in data["filled"][0]["reason"]
+        # Structured reason code (third-pass review §9.4 concern 1) — the
+        # exception type is ``TimeoutError`` so the classifier returns
+        # ``"timeout"``. The original message ("element detached") is
+        # preserved in ``detail`` so an operator can debug.
+        assert data["filled"][0]["reason"] == "timeout"
+        assert "detached" in data["filled"][0]["detail"]
         assert data["filled"][1]["status"] == "filled"
 
 
@@ -637,3 +642,297 @@ class TestFillFormActionRegistered:
             "host/permissions.py — browser_fill_form skill will silently "
             "fail with a 400 from the mesh proxy."
         )
+
+
+# ── Third-pass review additions (§9.4 concerns 1, 6, 8, 10, 13, 15) ─────
+
+
+class TestFillFormErrorClassification:
+    """Concern 1 — Playwright fill errors classified into structured codes."""
+
+    @pytest.mark.asyncio
+    async def test_classify_not_fillable(self):
+        """Find_text returned a <label> ref → fill() raises 'not an <input>'.
+
+        Without classification the agent sees a generic ``type_failed`` and
+        can't recover. With ``reason: "not_fillable"`` it knows to fall
+        back to ``browser_get_elements`` to find the underlying input.
+        """
+        mgr = _make_manager()
+        refs = {
+            "e0": {"role": "text", "name": "Email", "index": 0, "disabled": False},
+        }
+        inst = _make_instance(refs)
+        # Playwright's actual message; classifier is case-insensitive.
+        loc = _make_locator(
+            raise_on_fill=Exception(
+                "Element is not an <input>, <textarea> or "
+                "[contenteditable] element"
+            ),
+        )
+
+        with patch.object(BrowserManager, "get_or_start", return_value=inst), \
+             patch.object(BrowserManager, "_locator_from_ref",
+                          new_callable=AsyncMock, return_value=loc), \
+             patch.object(BrowserManager, "_check_captcha",
+                          new_callable=AsyncMock, return_value=None), \
+             patch.object(BrowserManager, "_snapshot_impl", new=_fake_snapshot):
+            result = await mgr.fill_form(
+                "agent1",
+                [{"label": "Email", "value": "a@b.co"}],
+            )
+
+        f0 = result["data"]["filled"][0]
+        assert f0["status"] == "type_failed"
+        assert f0["reason"] == "not_fillable"
+
+    @pytest.mark.asyncio
+    async def test_classify_disabled(self):
+        mgr = _make_manager()
+        refs = {
+            "e0": {"role": "textbox", "name": "Email", "index": 0, "disabled": False},
+        }
+        inst = _make_instance(refs)
+        loc = _make_locator(
+            raise_on_fill=Exception("element is disabled"),
+        )
+
+        with patch.object(BrowserManager, "get_or_start", return_value=inst), \
+             patch.object(BrowserManager, "_locator_from_ref",
+                          new_callable=AsyncMock, return_value=loc), \
+             patch.object(BrowserManager, "_check_captcha",
+                          new_callable=AsyncMock, return_value=None), \
+             patch.object(BrowserManager, "_snapshot_impl", new=_fake_snapshot):
+            result = await mgr.fill_form(
+                "agent1",
+                [{"label": "Email", "value": "a@b.co"}],
+            )
+
+        assert result["data"]["filled"][0]["reason"] == "disabled"
+
+    @pytest.mark.asyncio
+    async def test_classify_other_falls_through(self):
+        """Unknown error message → reason='other' (no crash)."""
+        mgr = _make_manager()
+        refs = {
+            "e0": {"role": "textbox", "name": "Email", "index": 0, "disabled": False},
+        }
+        inst = _make_instance(refs)
+        loc = _make_locator(
+            raise_on_fill=Exception("some weird Playwright internal error"),
+        )
+
+        with patch.object(BrowserManager, "get_or_start", return_value=inst), \
+             patch.object(BrowserManager, "_locator_from_ref",
+                          new_callable=AsyncMock, return_value=loc), \
+             patch.object(BrowserManager, "_check_captcha",
+                          new_callable=AsyncMock, return_value=None), \
+             patch.object(BrowserManager, "_snapshot_impl", new=_fake_snapshot):
+            result = await mgr.fill_form(
+                "agent1",
+                [{"label": "Email", "value": "a@b.co"}],
+            )
+
+        assert result["data"]["filled"][0]["reason"] == "other"
+        # Detail preserves the underlying message for operator debugging.
+        assert "weird" in result["data"]["filled"][0]["detail"]
+
+
+class TestFillFormSubmitEdgeCases:
+    """Concerns 8 & 10 — submit_after only fires when there's an anchor."""
+
+    @pytest.mark.asyncio
+    async def test_top_level_submit_with_all_failed_fields_no_press(self):
+        """Concern 8: ``submit_after=True`` but no field filled → no Enter.
+
+        ``last_locator`` stays ``None``, so the final-submit branch must
+        be skipped. ``submitted`` must remain ``False``.
+        """
+        mgr = _make_manager()
+        # No matching ref for either label → both fields go ``not_found``.
+        refs = {
+            "e0": {"role": "button", "name": "Cancel", "index": 0, "disabled": False},
+        }
+        inst = _make_instance(refs)
+        loc = _make_locator()
+
+        with patch.object(BrowserManager, "get_or_start", return_value=inst), \
+             patch.object(BrowserManager, "_locator_from_ref",
+                          new_callable=AsyncMock, return_value=loc), \
+             patch.object(BrowserManager, "_check_captcha",
+                          new_callable=AsyncMock, return_value=None), \
+             patch.object(BrowserManager, "_snapshot_impl", new=_fake_snapshot):
+            result = await mgr.fill_form(
+                "agent1",
+                [
+                    {"label": "Email", "value": "a@b.co"},
+                    {"label": "Phone", "value": "555"},
+                ],
+                submit_after=True,
+            )
+
+        data = result["data"]
+        assert all(f["status"] == "not_found" for f in data["filled"])
+        # Critical: no anchor → no Enter pressed → submitted stays False.
+        assert data["submitted"] is False
+        assert loc.press.await_count == 0
+
+    @pytest.mark.asyncio
+    async def test_per_field_submit_on_not_found_field_no_press(self):
+        """Concern 10: per-field ``submit_after`` on not_found → no Enter.
+
+        The submit-on-field branch lives below the successful-fill path.
+        A ``not_found`` field must ``continue`` straight to the next
+        iteration without pressing Enter on a phantom locator.
+        """
+        mgr = _make_manager()
+        refs = {
+            # Matches "Phone" but NOT "Email"
+            "e0": {"role": "textbox", "name": "Phone", "index": 0, "disabled": False},
+        }
+        inst = _make_instance(refs)
+        loc = _make_locator()
+
+        with patch.object(BrowserManager, "get_or_start", return_value=inst), \
+             patch.object(BrowserManager, "_locator_from_ref",
+                          new_callable=AsyncMock, return_value=loc), \
+             patch.object(BrowserManager, "_check_captcha",
+                          new_callable=AsyncMock, return_value=None), \
+             patch.object(BrowserManager, "_snapshot_impl", new=_fake_snapshot):
+            result = await mgr.fill_form(
+                "agent1",
+                [
+                    # submit_after=True on a field that won't be found —
+                    # must NOT press Enter on anything.
+                    {"label": "Email", "value": "a@b.co", "submit_after": True},
+                    {"label": "Phone", "value": "555"},
+                ],
+            )
+
+        data = result["data"]
+        statuses = [f["status"] for f in data["filled"]]
+        assert statuses == ["not_found", "filled"]
+        # Only Phone was filled; no Enter presses anywhere.
+        assert loc.press.await_count == 0
+        assert data["submitted"] is False
+
+
+class TestFillFormValueAndLabelHandling:
+    """Concerns 6 (empty string) & 13 (label redaction in response)."""
+
+    @pytest.mark.asyncio
+    async def test_empty_string_value_clears_input(self):
+        """Concern 6: ``value=""`` is valid — fill('') clears the input."""
+        mgr = _make_manager()
+        refs = {
+            "e0": {"role": "textbox", "name": "Email", "index": 0, "disabled": False},
+        }
+        inst = _make_instance(refs)
+        loc = _make_locator()
+
+        with patch.object(BrowserManager, "get_or_start", return_value=inst), \
+             patch.object(BrowserManager, "_locator_from_ref",
+                          new_callable=AsyncMock, return_value=loc), \
+             patch.object(BrowserManager, "_check_captcha",
+                          new_callable=AsyncMock, return_value=None), \
+             patch.object(BrowserManager, "_snapshot_impl", new=_fake_snapshot):
+            result = await mgr.fill_form(
+                "agent1",
+                [{"label": "Email", "value": ""}],
+            )
+
+        assert result["success"] is True
+        assert result["data"]["filled"][0]["status"] == "filled"
+        loc.fill.assert_awaited_with("")
+
+    @pytest.mark.asyncio
+    async def test_label_with_secret_redacted_in_filled_response(self):
+        """Concern 13: ``filled[].label`` redacted on the way out.
+
+        If the agent passes a label like ``"sk-abc123def456..."`` (e.g. a
+        prompt-injected label that contains a secret pattern), the
+        echoed-back ``filled[].label`` must run through the same
+        redactor that scrubs URLs, snapshot text, and find_text matches.
+        ``remaining[].label`` deliberately keeps verbatim values for
+        resume — that path is covered by the captcha-mid-flow tests.
+        """
+        mgr = _make_manager()
+        # Use a label that ALSO matches a ref (so find_text → fill path
+        # exercises the safe_label substitution).
+        secret_label = "sk-1234567890abcdefghijklmnopqrstuv"
+        refs = {
+            "e0": {
+                "role": "textbox", "name": secret_label,
+                "index": 0, "disabled": False,
+            },
+        }
+        inst = _make_instance(refs)
+        loc = _make_locator()
+
+        with patch.object(BrowserManager, "get_or_start", return_value=inst), \
+             patch.object(BrowserManager, "_locator_from_ref",
+                          new_callable=AsyncMock, return_value=loc), \
+             patch.object(BrowserManager, "_check_captcha",
+                          new_callable=AsyncMock, return_value=None), \
+             patch.object(BrowserManager, "_snapshot_impl", new=_fake_snapshot):
+            result = await mgr.fill_form(
+                "agent1",
+                [{"label": secret_label, "value": "x"}],
+            )
+
+        echoed = result["data"]["filled"][0]["label"]
+        # Some fragment of the secret (the ``sk-`` prefix + suffix) should
+        # be redacted; we don't pin exact format because the redaction
+        # patterns may evolve. The contract is "literal echo blocked".
+        assert echoed != secret_label, (
+            "filled[].label echoed user-supplied secret verbatim — "
+            "expected redactor to mask it"
+        )
+
+
+class TestFillFormServerRoute:
+    """Concern 15 — happy-path POST /browser/{agent_id}/fill_form route test."""
+
+    def test_route_happy_path_returns_envelope(self, monkeypatch):
+        """Verify the FastAPI route shape: 200 + the manager envelope."""
+        from fastapi.testclient import TestClient
+
+        from src.browser.server import create_browser_app
+
+        monkeypatch.delenv("BROWSER_AUTH_TOKEN", raising=False)
+        monkeypatch.delenv("MESH_AUTH_TOKEN", raising=False)
+
+        mgr = MagicMock()
+        mgr.fill_form = AsyncMock(return_value={
+            "success": True,
+            "data": {
+                "partial_success": False,
+                "captcha_required": False,
+                "filled": [{"label": "Email", "ref": "e0", "status": "filled"}],
+                "remaining": [],
+                "submitted": False,
+            },
+        })
+
+        app = create_browser_app(mgr)
+        with TestClient(app) as client:
+            resp = client.post(
+                "/browser/a1/fill_form",
+                json={
+                    "fields": [{"label": "Email", "value": "a@b.co"}],
+                    "submit_after": False,
+                },
+            )
+
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["success"] is True
+        assert body["data"]["filled"][0]["status"] == "filled"
+        # Manager called with the body's fields verbatim plus the keyword arg.
+        mgr.fill_form.assert_awaited_once()
+        args, kwargs = mgr.fill_form.await_args
+        assert args[0] == "a1"
+        assert args[1] == [{"label": "Email", "value": "a@b.co"}]
+        assert kwargs == {"submit_after": False}
+
+

--- a/tests/test_browser_inspect_requests.py
+++ b/tests/test_browser_inspect_requests.py
@@ -63,14 +63,18 @@ def _make_instance_with_listeners():
     """Return a CamoufoxInstance with mocked context/page wired by listeners.
 
     The mocks capture handlers passed to ``.on(...)`` so the test can fire
-    them synchronously.
+    them synchronously. Listeners are attached at the *context* level
+    (``request`` + ``requestfailed``), so per-page ``request`` events from
+    any page in the context are covered by the single context handler. The
+    ``page_handlers`` dict is retained for backward-compat with tests that
+    expect the four-tuple shape, but is unused for new wiring.
     """
     from src.browser.service import BrowserManager, CamoufoxInstance
 
     mgr = BrowserManager.__new__(BrowserManager)
 
-    # Track context listeners in a dict so we can fire ``page`` / ``requestfailed``.
-    context_handlers: dict[str, list] = {"page": [], "requestfailed": []}
+    # Track context listeners in a dict so we can fire them synchronously.
+    context_handlers: dict[str, list] = {"request": [], "requestfailed": []}
 
     def _ctx_on(event: str, handler):
         context_handlers.setdefault(event, []).append(handler)
@@ -78,7 +82,9 @@ def _make_instance_with_listeners():
     context = MagicMock()
     context.on = MagicMock(side_effect=_ctx_on)
 
-    # Page mock: same trick — ``request`` handlers stored, callable via _fire.
+    # Page mock retained for tests that may still poke at it. Per-page
+    # ``request`` listeners are no longer attached by the implementation —
+    # see ``_attach_network_listeners`` which uses context-scope events.
     page_handlers: dict[str, list] = {}
 
     def _page_on(event: str, handler):
@@ -491,23 +497,28 @@ class TestResetClearsAndReattaches:
 
         mgr._attach_network_listeners(fresh)
         assert fresh._network_attached is True
-        # context-level listeners wired for ``page`` and ``requestfailed``.
+        # Context-level listeners wired for ``request`` and ``requestfailed`` —
+        # the single context-scope ``request`` event covers every page
+        # in the context (existing pages and new tabs alike), so per-page
+        # listener wiring is no longer needed.
         events = [call.args[0] for call in fresh_ctx.on.call_args_list]
-        assert "page" in events
+        assert "request" in events
         assert "requestfailed" in events
 
 
 # ───────────────────────────────────────────────────────────────────────
-# 10. Context-level listener wires per-request handler on new pages
+# 10. Context-level ``request`` listener covers every page in the context
 # ───────────────────────────────────────────────────────────────────────
 
 
 class TestContextLevelPageListener:
-    def test_new_page_inherits_request_handler(self):
-        """Simulate context.emit('page', new_page) firing the registered handler.
-
-        The handler we registered should attach a per-page ``request``
-        listener; firing that listener should record into ``network_log``.
+    def test_context_level_request_listener_records_for_any_page(self):
+        """Per Playwright, ``BrowserContext.on('request', ...)`` fires for
+        requests issued by ANY page in the context — both pre-existing
+        pages (e.g. profile-restored tabs) and pages opened later via
+        in-page ``window.open()`` or :meth:`open_tab`. We rely on this
+        single hook instead of per-page wiring + a ``page`` event hookup,
+        which used to silently miss pre-existing pages.
         """
         from src.browser.service import BrowserManager, CamoufoxInstance
 
@@ -527,27 +538,24 @@ class TestContextLevelPageListener:
         inst = CamoufoxInstance("agent1", MagicMock(), context, existing_page)
         mgr._attach_network_listeners(inst)
 
-        # Now fire a context-level "page" event with a brand-new Mock Page.
-        new_page = MagicMock()
-        new_page_handlers: dict[str, list] = {}
+        # Only context-level listeners should be wired — no per-page
+        # ``request`` hooks. The page mock should have received zero
+        # ``.on('request', ...)`` calls.
+        page_on_events = [c.args[0] for c in existing_page.on.call_args_list]
+        assert "request" not in page_on_events, (
+            "Per-page request listener was wired; "
+            f"context-level should be sufficient. Saw: {page_on_events}"
+        )
 
-        def _new_page_on(event: str, handler):
-            new_page_handlers.setdefault(event, []).append(handler)
+        # Context handlers must include both ``request`` and ``requestfailed``.
+        assert "request" in ctx_handlers
+        assert "requestfailed" in ctx_handlers
+        assert len(ctx_handlers["request"]) == 1
 
-        new_page.on = MagicMock(side_effect=_new_page_on)
-
-        # The registered context handler should attach a request handler
-        # to the new page when invoked.
-        for h in ctx_handlers["page"]:
-            h(new_page)
-
-        # The new_page now has a "request" listener registered.
-        assert "request" in new_page_handlers
-        assert len(new_page_handlers["request"]) == 1
-
-        # Firing that listener with a Mock request should record into log.
+        # Fire the context-level request handler — it should record into
+        # the network log regardless of which page emitted the request.
         req = _make_mock_request("https://newtab.example.com/asset.js")
-        new_page_handlers["request"][0](req)
+        ctx_handlers["request"][0](req)
 
         assert len(inst.network_log) == 1
         assert "/asset.js" in inst.network_log[0]["url"]
@@ -606,3 +614,215 @@ class TestSkillRegistration:
             registry_desc = fn.description  # type: ignore[attr-defined]
         haystack = " ".join([meta_text, registry_desc, decorated.__doc__ or ""])
         assert "network requests" in haystack.lower() or "adblock" in haystack.lower()
+
+
+# ───────────────────────────────────────────────────────────────────────
+# 13. Parallel identical failed requests pair to DIFFERENT entries
+# ───────────────────────────────────────────────────────────────────────
+
+
+class TestParallelFailedRequestsPairing:
+    """Two parallel ``<img>`` loads of the same blocked tracker URL each
+    record their own ``request`` and then each fire ``requestfailed``.
+
+    Naive pairing (walk newest-first, update the first match) would tag
+    the SAME entry twice and leave the older one unflagged — making one
+    of the two failures silently appear "successful" in the log. The
+    ``_failure_tagged`` sentinel + skip-already-tagged logic ensures each
+    failure pairs with a distinct request entry.
+    """
+
+    def test_two_parallel_identical_failures_tag_distinct_entries(self):
+        mgr, inst, _ctx, _page = _make_instance_with_listeners()
+        mgr._attach_network_listeners(inst)
+
+        url = "https://tracker.example.com/pixel.gif"
+        # Two parallel image loads → two ``request`` entries.
+        mgr._record_request(inst, _make_mock_request(url))
+        mgr._record_request(inst, _make_mock_request(url))
+        assert len(inst.network_log) == 2
+        assert all(not e["blocked_by_adblock"] for e in inst.network_log)
+        assert all(not e["_failure_tagged"] for e in inst.network_log)
+
+        # Both fail with adblock. Each ``requestfailed`` should pair with
+        # a different log entry.
+        mgr._record_request_failed(
+            inst,
+            _make_mock_request(url, failure_error="ERR_BLOCKED_BY_CLIENT"),
+        )
+        mgr._record_request_failed(
+            inst,
+            _make_mock_request(url, failure_error="ERR_BLOCKED_BY_CLIENT"),
+        )
+
+        # BOTH entries should now be flagged blocked. Without the
+        # ``_failure_tagged`` skip, the second pairing would have
+        # overwritten the first entry instead of finding the older one.
+        assert all(e["blocked_by_adblock"] for e in inst.network_log), (
+            "Expected both parallel failures to tag distinct entries; "
+            f"network_log={list(inst.network_log)}"
+        )
+        assert all(e["_failure_tagged"] for e in inst.network_log)
+
+    def test_third_failure_with_only_two_requests_is_dropped(self):
+        """If a third ``requestfailed`` arrives but only two matching
+        requests exist (both already tagged), the third update is
+        discarded — no phantom entry, no overwrite.
+        """
+        mgr, inst, _ctx, _page = _make_instance_with_listeners()
+        mgr._attach_network_listeners(inst)
+
+        url = "https://tracker.example.com/pixel.gif"
+        mgr._record_request(inst, _make_mock_request(url))
+        mgr._record_request(inst, _make_mock_request(url))
+        mgr._record_request_failed(
+            inst,
+            _make_mock_request(url, failure_error="ERR_BLOCKED_BY_CLIENT"),
+        )
+        mgr._record_request_failed(
+            inst,
+            _make_mock_request(url, failure_error="ERR_BLOCKED_BY_CLIENT"),
+        )
+        # A third failure for the same URL — both entries already tagged.
+        mgr._record_request_failed(
+            inst,
+            _make_mock_request(url, failure_error="ERR_BLOCKED_BY_CLIENT"),
+        )
+
+        # Length unchanged, both flags still True.
+        assert len(inst.network_log) == 2
+        assert all(e["blocked_by_adblock"] for e in inst.network_log)
+
+
+# ───────────────────────────────────────────────────────────────────────
+# 14. ``include_blocked=False`` filter happens BEFORE the ``limit`` cap
+# ───────────────────────────────────────────────────────────────────────
+
+
+class TestFilterBeforeCapOrdering:
+    """With a buffer dominated by blocked entries, filter-after-cap would
+    return near-empty results when the agent calls ``include_blocked=False,
+    limit=N`` — the cap would slice off the few non-blocked entries before
+    the filter ran. The implementation iterates newest-first, drops blocked
+    entries (incrementing ``dropped_blocked``), and only counts non-blocked
+    entries toward ``limit``.
+    """
+
+    @pytest.mark.asyncio
+    async def test_180_blocked_of_200_returns_visible_non_blocked(self):
+        mgr, inst, _ctx, _page = _make_instance_with_listeners()
+        mgr._attach_network_listeners(inst)
+        mgr.get_or_start = AsyncMock(return_value=inst)
+
+        # 20 visible (non-blocked) + 180 blocked, interleaved so the
+        # newest 50 by timestamp would be a mix dominated by blocked.
+        # Blocked URLs go through ``_record_request`` then are flagged
+        # via ``_record_request_failed``.
+        ok_count = 0
+        blocked_count = 0
+        for i in range(200):
+            if i % 10 == 0:
+                # 1 in 10 is non-blocked.
+                mgr._record_request(
+                    inst,
+                    _make_mock_request(f"https://example.com/ok/{i}"),
+                )
+                ok_count += 1
+            else:
+                url = f"https://tracker.example.com/blocked/{i}"
+                mgr._record_request(inst, _make_mock_request(url))
+                mgr._record_request_failed(
+                    inst,
+                    _make_mock_request(
+                        url, failure_error="ERR_BLOCKED_BY_CLIENT",
+                    ),
+                )
+                blocked_count += 1
+
+        assert ok_count == 20
+        assert blocked_count == 180
+        assert len(inst.network_log) == 200
+
+        # Ask for 50 with include_blocked=False. Filter-before-cap means
+        # we should see all 20 visible entries (limit isn't reached).
+        result = await mgr.inspect_requests(
+            "agent1", include_blocked=False, limit=50,
+        )
+        assert result["success"] is True
+        data = result["data"]
+        assert data["total"] == 200
+        assert data["dropped_blocked"] == 180
+        assert len(data["requests"]) == 20, (
+            "filter-before-cap: 20 non-blocked entries should all appear "
+            f"under limit=50; got {len(data['requests'])}"
+        )
+        # Every returned entry is non-blocked.
+        assert all(
+            not r["blocked_by_adblock"] for r in data["requests"]
+        )
+
+    @pytest.mark.asyncio
+    async def test_filter_before_cap_with_limit_smaller_than_visible(self):
+        """When non-blocked count exceeds ``limit``, cap kicks in correctly
+        AFTER the filter — newest-first selection.
+        """
+        mgr, inst, _ctx, _page = _make_instance_with_listeners()
+        mgr._attach_network_listeners(inst)
+        mgr.get_or_start = AsyncMock(return_value=inst)
+
+        # 100 non-blocked, 100 blocked, all interleaved.
+        for i in range(200):
+            if i % 2 == 0:
+                mgr._record_request(
+                    inst,
+                    _make_mock_request(f"https://example.com/ok/{i}"),
+                )
+            else:
+                url = f"https://tracker.example.com/blocked/{i}"
+                mgr._record_request(inst, _make_mock_request(url))
+                mgr._record_request_failed(
+                    inst,
+                    _make_mock_request(
+                        url, failure_error="ERR_BLOCKED_BY_CLIENT",
+                    ),
+                )
+
+        result = await mgr.inspect_requests(
+            "agent1", include_blocked=False, limit=10,
+        )
+        data = result["data"]
+        assert data["total"] == 200
+        assert data["dropped_blocked"] == 100
+        assert len(data["requests"]) == 10
+        assert all(not r["blocked_by_adblock"] for r in data["requests"])
+        # Newest-first — entry urls should reference the higher-numbered
+        # /ok/ paths.
+        assert "/ok/" in data["requests"][0]["url"]
+
+
+# ───────────────────────────────────────────────────────────────────────
+# 15. Internal ``_failure_tagged`` sentinel never leaks into responses
+# ───────────────────────────────────────────────────────────────────────
+
+
+class TestSentinelNeverLeaks:
+    @pytest.mark.asyncio
+    async def test_failure_tagged_field_stripped_from_response(self):
+        mgr, inst, _ctx, _page = _make_instance_with_listeners()
+        mgr._attach_network_listeners(inst)
+        mgr.get_or_start = AsyncMock(return_value=inst)
+
+        url = "https://tracker.example.com/pixel.gif"
+        mgr._record_request(inst, _make_mock_request(url))
+        mgr._record_request_failed(
+            inst,
+            _make_mock_request(url, failure_error="ERR_BLOCKED_BY_CLIENT"),
+        )
+
+        result = await mgr.inspect_requests(
+            "agent1", include_blocked=True, limit=10,
+        )
+        for entry in result["data"]["requests"]:
+            assert "_failure_tagged" not in entry, (
+                f"internal sentinel leaked into response: {entry}"
+            )

--- a/tests/test_browser_inspect_requests.py
+++ b/tests/test_browser_inspect_requests.py
@@ -215,6 +215,26 @@ class TestRequestFailedClassifier:
 
         assert inst.network_log[-1]["blocked_by_adblock"] is True
 
+    def test_exact_request_identity_wins_for_identical_url(self):
+        """If two same-URL requests are in flight and only the older one
+        fails, the failure must tag that exact request, not the newest
+        URL+method match.
+        """
+        mgr, inst, _ctx, _page = _make_instance_with_listeners()
+        mgr._attach_network_listeners(inst)
+
+        url = "https://tracker.example.com/pixel.gif"
+        older = _make_mock_request(url)
+        newer = _make_mock_request(url)
+        mgr._record_request(inst, older)
+        mgr._record_request(inst, newer)
+
+        older.failure = _FakeFailure("ERR_BLOCKED_BY_CLIENT")
+        mgr._record_request_failed(inst, older)
+
+        assert inst.network_log[0]["blocked_by_adblock"] is True
+        assert inst.network_log[1]["blocked_by_adblock"] is False
+
 
 # ───────────────────────────────────────────────────────────────────────
 # 4. include_blocked / dropped_blocked
@@ -825,4 +845,7 @@ class TestSentinelNeverLeaks:
         for entry in result["data"]["requests"]:
             assert "_failure_tagged" not in entry, (
                 f"internal sentinel leaked into response: {entry}"
+            )
+            assert "_request_key" not in entry, (
+                f"internal request key leaked into response: {entry}"
             )

--- a/tests/test_browser_inspect_requests.py
+++ b/tests/test_browser_inspect_requests.py
@@ -1,0 +1,608 @@
+"""Tests for Phase 6 §9.1 ``inspect_requests`` browser action.
+
+Covers:
+  * URL redaction at store-time (userinfo, JWT-shaped path, sensitive query).
+  * ``deque`` maxlen enforcement (200) — older entries drop.
+  * ``requestfailed`` classifier — adblock vs user-cancelled vs failed.
+  * ``include_blocked`` filter + ``dropped_blocked`` counter.
+  * ``limit`` cap at 200.
+  * User-control conflict envelope.
+  * ``BROWSER_NETWORK_INSPECT_DISABLED`` operator kill-switch (mesh route).
+  * ISO-8601 UTC ``ts``.
+  * RESET clears ``network_log`` and re-attaches listeners.
+  * Context-level ``page`` listener attaches per-request handler to new tabs.
+"""
+
+from __future__ import annotations
+
+import re
+from collections import deque
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+# ───────────────────────────────────────────────────────────────────────
+# Helpers
+# ───────────────────────────────────────────────────────────────────────
+
+
+class _FakeFailure:
+    """Non-callable failure shape — matches Playwright's ``Request.failure``
+    which is a property holding an object with ``errorText``. We deliberately
+    avoid ``MagicMock`` here because MagicMocks are always callable, which
+    would force the implementation's callable-fallback path on every test
+    rather than exercising the property path.
+    """
+
+    def __init__(self, error_text: str):
+        self.errorText = error_text
+
+
+class _FakeRequest:
+    """Non-callable request shape with the four attributes listeners read."""
+
+    def __init__(self, url, method, resource_type, failure):
+        self.url = url
+        self.method = method
+        self.resource_type = resource_type
+        self.failure = failure
+
+
+def _make_mock_request(
+    url: str,
+    method: str = "GET",
+    resource_type: str = "document",
+    failure_error: str | None = None,
+):
+    """Build a Playwright-Request-shaped fake for listener tests."""
+    failure = _FakeFailure(failure_error) if failure_error is not None else None
+    return _FakeRequest(url, method, resource_type, failure)
+
+
+def _make_instance_with_listeners():
+    """Return a CamoufoxInstance with mocked context/page wired by listeners.
+
+    The mocks capture handlers passed to ``.on(...)`` so the test can fire
+    them synchronously.
+    """
+    from src.browser.service import BrowserManager, CamoufoxInstance
+
+    mgr = BrowserManager.__new__(BrowserManager)
+
+    # Track context listeners in a dict so we can fire ``page`` / ``requestfailed``.
+    context_handlers: dict[str, list] = {"page": [], "requestfailed": []}
+
+    def _ctx_on(event: str, handler):
+        context_handlers.setdefault(event, []).append(handler)
+
+    context = MagicMock()
+    context.on = MagicMock(side_effect=_ctx_on)
+
+    # Page mock: same trick — ``request`` handlers stored, callable via _fire.
+    page_handlers: dict[str, list] = {}
+
+    def _page_on(event: str, handler):
+        page_handlers.setdefault(event, []).append(handler)
+
+    page = MagicMock()
+    page.on = MagicMock(side_effect=_page_on)
+
+    inst = CamoufoxInstance("agent1", MagicMock(), context, page)
+    return mgr, inst, context_handlers, page_handlers
+
+
+# ───────────────────────────────────────────────────────────────────────
+# 1. URL redaction at store time
+# ───────────────────────────────────────────────────────────────────────
+
+
+class TestStoreTimeRedaction:
+    def test_userinfo_jwt_and_sensitive_query_redacted(self):
+        mgr, inst, _ctx, _page = _make_instance_with_listeners()
+        mgr._attach_network_listeners(inst)
+
+        # userinfo + JWT in path + sensitive query (``token``)
+        jwt = "abcdefghij.klmnopqrst.uvwxyz1234"
+        url = (
+            "https://user:secret@example.com/auth/"
+            f"{jwt}/cb?token=SUPER_SECRET&keep=1"
+        )
+        req = _make_mock_request(url)
+        mgr._record_request(inst, req)
+
+        assert len(inst.network_log) == 1
+        stored = inst.network_log[0]["url"]
+        # Userinfo gone
+        assert "user:secret" not in stored
+        assert "secret@" not in stored
+        # JWT segment redacted
+        assert jwt not in stored
+        # Sensitive query value redacted; key preserved
+        assert "SUPER_SECRET" not in stored
+        assert "token=%5BREDACTED%5D" in stored or "token=[REDACTED]" in stored
+        # Non-sensitive query preserved
+        assert "keep=1" in stored
+
+
+# ───────────────────────────────────────────────────────────────────────
+# 2. deque maxlen enforcement
+# ───────────────────────────────────────────────────────────────────────
+
+
+class TestDequeMaxlen:
+    def test_only_newest_200_kept(self):
+        mgr, inst, _ctx, _page = _make_instance_with_listeners()
+        mgr._attach_network_listeners(inst)
+
+        for i in range(250):
+            mgr._record_request(
+                inst,
+                _make_mock_request(f"https://example.com/r/{i}"),
+            )
+
+        assert len(inst.network_log) == 200
+        # Oldest 50 dropped — first remaining entry should be /r/50.
+        assert "/r/50" in inst.network_log[0]["url"]
+        assert "/r/249" in inst.network_log[-1]["url"]
+
+
+# ───────────────────────────────────────────────────────────────────────
+# 3. requestfailed classifier
+# ───────────────────────────────────────────────────────────────────────
+
+
+class TestRequestFailedClassifier:
+    @pytest.mark.parametrize("marker, flag", [
+        ("NS_ERROR_CONTENT_BLOCKED", "blocked_by_adblock"),
+        ("ERR_BLOCKED_BY_CLIENT", "blocked_by_adblock"),
+        ("NS_ERROR_BLOCKED_BY_POLICY", "blocked_by_adblock"),
+        ("NS_BINDING_ABORTED", "user_cancelled"),
+        ("NS_ERROR_NET_TIMEOUT", "failed_network"),
+    ])
+    def test_marker_routes_to_correct_flag(self, marker, flag):
+        mgr, inst, _ctx, _page = _make_instance_with_listeners()
+        mgr._attach_network_listeners(inst)
+
+        url = "https://tracker.example.com/pixel.gif"
+        mgr._record_request(inst, _make_mock_request(url))
+        assert inst.network_log[-1][flag] is False  # Initial state
+
+        failed_req = _make_mock_request(url, failure_error=marker)
+        mgr._record_request_failed(inst, failed_req)
+
+        entry = inst.network_log[-1]
+        assert entry[flag] is True
+        # Mutually exclusive — only the matching flag flips.
+        for other in ("blocked_by_adblock", "user_cancelled", "failed_network"):
+            if other != flag:
+                assert entry[other] is False, (
+                    f"marker={marker!r} also flipped {other}"
+                )
+
+    def test_failed_with_no_matching_entry_does_not_create_phantom(self):
+        """requestfailed for a URL that scrolled out of the window is dropped."""
+        mgr, inst, _ctx, _page = _make_instance_with_listeners()
+        mgr._attach_network_listeners(inst)
+
+        # No matching request recorded — the failure update should be ignored.
+        failed_req = _make_mock_request(
+            "https://gone.example.com/never-recorded",
+            failure_error="NS_ERROR_CONTENT_BLOCKED",
+        )
+        mgr._record_request_failed(inst, failed_req)
+        assert len(inst.network_log) == 0
+
+    def test_callable_failure_attribute_handled(self):
+        """Some Playwright bindings expose ``failure`` as a callable."""
+        mgr, inst, _ctx, _page = _make_instance_with_listeners()
+        mgr._attach_network_listeners(inst)
+
+        url = "https://tracker.example.com/x"
+        mgr._record_request(inst, _make_mock_request(url))
+
+        # Build a request whose ``failure`` is a callable returning the
+        # error-bearing object. Use a plain class (not MagicMock) so the
+        # rest of the request shape stays property-like.
+        failure_obj = _FakeFailure("NS_ERROR_CONTENT_BLOCKED")
+        failed_req = _FakeRequest(url, "GET", "document", failure=lambda: failure_obj)
+        mgr._record_request_failed(inst, failed_req)
+
+        assert inst.network_log[-1]["blocked_by_adblock"] is True
+
+
+# ───────────────────────────────────────────────────────────────────────
+# 4. include_blocked / dropped_blocked
+# ───────────────────────────────────────────────────────────────────────
+
+
+class TestIncludeBlockedFilter:
+    @pytest.mark.asyncio
+    async def test_excludes_blocked_by_default(self):
+        mgr, inst, _ctx, _page = _make_instance_with_listeners()
+        mgr._attach_network_listeners(inst)
+        mgr.get_or_start = AsyncMock(return_value=inst)
+
+        # 3 normal + 2 blocked
+        for i in range(3):
+            mgr._record_request(
+                inst,
+                _make_mock_request(f"https://example.com/ok/{i}"),
+            )
+        for i in range(2):
+            url = f"https://tracker.example.com/blocked/{i}"
+            mgr._record_request(inst, _make_mock_request(url))
+            mgr._record_request_failed(
+                inst,
+                _make_mock_request(url, failure_error="ERR_BLOCKED_BY_CLIENT"),
+            )
+
+        result = await mgr.inspect_requests("agent1", include_blocked=False)
+        assert result["success"] is True
+        data = result["data"]
+        assert data["total"] == 5
+        assert data["dropped_blocked"] == 2
+        assert len(data["requests"]) == 3
+        assert all("blocked" not in r["url"] for r in data["requests"])
+
+    @pytest.mark.asyncio
+    async def test_include_blocked_keeps_them(self):
+        mgr, inst, _ctx, _page = _make_instance_with_listeners()
+        mgr._attach_network_listeners(inst)
+        mgr.get_or_start = AsyncMock(return_value=inst)
+
+        for i in range(2):
+            url = f"https://tracker.example.com/blocked/{i}"
+            mgr._record_request(inst, _make_mock_request(url))
+            mgr._record_request_failed(
+                inst,
+                _make_mock_request(url, failure_error="ERR_BLOCKED_BY_CLIENT"),
+            )
+        mgr._record_request(
+            inst,
+            _make_mock_request("https://example.com/ok"),
+        )
+
+        result = await mgr.inspect_requests("agent1", include_blocked=True)
+        assert result["success"] is True
+        data = result["data"]
+        assert data["total"] == 3
+        assert data["dropped_blocked"] == 0
+        assert len(data["requests"]) == 3
+        blocked_returned = [
+            r for r in data["requests"] if r["blocked_by_adblock"]
+        ]
+        assert len(blocked_returned) == 2
+
+
+# ───────────────────────────────────────────────────────────────────────
+# 5. limit cap at 200
+# ───────────────────────────────────────────────────────────────────────
+
+
+class TestLimitCap:
+    @pytest.mark.asyncio
+    async def test_limit_above_200_coerced_to_200(self):
+        mgr, inst, _ctx, _page = _make_instance_with_listeners()
+        mgr._attach_network_listeners(inst)
+        mgr.get_or_start = AsyncMock(return_value=inst)
+
+        for i in range(250):
+            mgr._record_request(
+                inst,
+                _make_mock_request(f"https://example.com/r/{i}"),
+            )
+
+        result = await mgr.inspect_requests("agent1", limit=500)
+        assert result["success"] is True
+        # Underlying deque is also capped at 200.
+        assert len(result["data"]["requests"]) == 200
+
+    @pytest.mark.asyncio
+    async def test_default_limit_50_returns_50(self):
+        mgr, inst, _ctx, _page = _make_instance_with_listeners()
+        mgr._attach_network_listeners(inst)
+        mgr.get_or_start = AsyncMock(return_value=inst)
+
+        for i in range(120):
+            mgr._record_request(
+                inst,
+                _make_mock_request(f"https://example.com/r/{i}"),
+            )
+
+        result = await mgr.inspect_requests("agent1")
+        assert len(result["data"]["requests"]) == 50
+
+    @pytest.mark.asyncio
+    async def test_results_are_newest_first(self):
+        mgr, inst, _ctx, _page = _make_instance_with_listeners()
+        mgr._attach_network_listeners(inst)
+        mgr.get_or_start = AsyncMock(return_value=inst)
+
+        for i in range(5):
+            mgr._record_request(
+                inst,
+                _make_mock_request(f"https://example.com/r/{i}"),
+            )
+
+        result = await mgr.inspect_requests("agent1", limit=5)
+        urls = [r["url"] for r in result["data"]["requests"]]
+        assert "/r/4" in urls[0]
+        assert "/r/0" in urls[-1]
+
+
+# ───────────────────────────────────────────────────────────────────────
+# 6. user_control returns conflict envelope
+# ───────────────────────────────────────────────────────────────────────
+
+
+class TestUserControlConflict:
+    @pytest.mark.asyncio
+    async def test_user_control_returns_conflict_envelope(self):
+        mgr, inst, _ctx, _page = _make_instance_with_listeners()
+        inst._user_control = True
+        mgr.get_or_start = AsyncMock(return_value=inst)
+
+        result = await mgr.inspect_requests("agent1")
+
+        assert result["success"] is False
+        assert result["error"]["code"] == "conflict"
+        assert "retry_after_ms" in result["error"]
+        assert result["error"]["retry_after_ms"] is None
+
+
+# ───────────────────────────────────────────────────────────────────────
+# 7. Mesh kill-switch — BROWSER_NETWORK_INSPECT_DISABLED returns 403
+# ───────────────────────────────────────────────────────────────────────
+
+
+class TestMeshKillSwitch:
+    @pytest.mark.asyncio
+    async def test_kill_switch_returns_forbidden(self, tmp_path, monkeypatch):
+        from httpx import ASGITransport, AsyncClient
+
+        from src.browser import flags as bflags
+        from src.host.costs import CostTracker
+        from src.host.mesh import Blackboard, MessageRouter, PubSub
+        from src.host.permissions import PermissionMatrix
+        from src.host.server import create_mesh_app
+        from src.host.traces import TraceStore
+        from src.shared.types import AgentPermissions
+
+        monkeypatch.setenv("BROWSER_NETWORK_INSPECT_DISABLED", "1")
+        # Reset cached operator settings so the env override wins.
+        bflags.reload_operator_settings()
+
+        permissions = PermissionMatrix()
+        permissions.permissions["worker"] = AgentPermissions(
+            agent_id="worker", can_use_browser=True,
+        )
+        router = MessageRouter(permissions, {"worker": "http://worker:8400"})
+        bb = Blackboard(str(tmp_path / "bb.db"))
+        pubsub = PubSub()
+        costs = CostTracker(str(tmp_path / "costs.db"))
+        traces = TraceStore(str(tmp_path / "traces.db"))
+        cm = MagicMock()
+        cm.browser_service_url = "http://browser-svc:8500"
+        cm.browser_auth_token = ""
+
+        app = create_mesh_app(
+            blackboard=bb,
+            pubsub=pubsub,
+            router=router,
+            permissions=permissions,
+            cost_tracker=costs,
+            trace_store=traces,
+            event_bus=MagicMock(),
+            container_manager=cm,
+        )
+
+        async with AsyncClient(
+            transport=ASGITransport(app=app), base_url="http://test",
+        ) as client:
+            resp = await client.post(
+                "/mesh/browser/command",
+                json={
+                    "agent_id": "worker",
+                    "action": "inspect_requests",
+                    "params": {"include_blocked": False, "limit": 10},
+                },
+                headers={"X-Agent-ID": "worker"},
+            )
+
+        assert resp.status_code == 403, (resp.status_code, resp.text)
+        body = resp.json()
+        # FastAPI wraps ``detail=`` payload under ``detail``.
+        detail = body.get("detail", body)
+        assert detail.get("success") is False
+        assert detail["error"]["code"] == "forbidden"
+        assert "retry_after_ms" in detail["error"]
+
+
+# ───────────────────────────────────────────────────────────────────────
+# 8. ts is ISO-8601 UTC string
+# ───────────────────────────────────────────────────────────────────────
+
+
+class TestTimestampShape:
+    @pytest.mark.asyncio
+    async def test_ts_is_iso8601_utc(self):
+        mgr, inst, _ctx, _page = _make_instance_with_listeners()
+        mgr._attach_network_listeners(inst)
+        mgr.get_or_start = AsyncMock(return_value=inst)
+
+        mgr._record_request(
+            inst, _make_mock_request("https://example.com/x"),
+        )
+        result = await mgr.inspect_requests("agent1")
+
+        ts = result["data"]["requests"][0]["ts"]
+        # Shape: 2024-01-01T00:00:00Z
+        assert isinstance(ts, str)
+        assert ts.endswith("Z"), ts
+        assert re.match(r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$", ts), ts
+
+
+# ───────────────────────────────────────────────────────────────────────
+# 9. RESET clears network_log + re-attaches listeners on next start
+# ───────────────────────────────────────────────────────────────────────
+
+
+class TestResetClearsAndReattaches:
+    @pytest.mark.asyncio
+    async def test_reset_drops_old_instance_and_new_one_starts_fresh(self):
+        from src.browser.service import BrowserManager, CamoufoxInstance
+
+        # Build a manager with one stale instance carrying a populated log.
+        mgr = BrowserManager(profiles_dir="/tmp/_test_inspect_reset")
+        old_ctx = AsyncMock()
+        old_page = MagicMock()
+        # Old context.on was wired during __init__ by _attach_network_listeners;
+        # we simulate that state by manually flipping the flag + populating log.
+        old = CamoufoxInstance("agent1", MagicMock(), old_ctx, old_page)
+        old._network_attached = True
+        old.network_log.append({
+            "url": "https://example.com/stale",
+            "method": "GET",
+            "resource_type": "document",
+            "ts": 1.0,
+            "status": None,
+            "blocked_by_adblock": False,
+            "user_cancelled": False,
+            "failed_network": False,
+        })
+        mgr._instances["agent1"] = old
+
+        # RESET drops the old instance — confirmed by absence in _instances.
+        await mgr.reset("agent1")
+        assert "agent1" not in mgr._instances
+
+        # The next CamoufoxInstance constructed for the same agent is a
+        # fresh object. We verify the contract: a new instance starts with
+        # empty network_log + _network_attached=False, so the next
+        # _attach_network_listeners call wires fresh listeners.
+        fresh_page = MagicMock()
+        fresh_ctx = MagicMock()
+        fresh_ctx.on = MagicMock()
+        fresh_page.on = MagicMock()
+        fresh = CamoufoxInstance("agent1", MagicMock(), fresh_ctx, fresh_page)
+        assert fresh.network_log == deque(maxlen=200)
+        assert len(fresh.network_log) == 0
+        assert fresh._network_attached is False
+
+        mgr._attach_network_listeners(fresh)
+        assert fresh._network_attached is True
+        # context-level listeners wired for ``page`` and ``requestfailed``.
+        events = [call.args[0] for call in fresh_ctx.on.call_args_list]
+        assert "page" in events
+        assert "requestfailed" in events
+
+
+# ───────────────────────────────────────────────────────────────────────
+# 10. Context-level listener wires per-request handler on new pages
+# ───────────────────────────────────────────────────────────────────────
+
+
+class TestContextLevelPageListener:
+    def test_new_page_inherits_request_handler(self):
+        """Simulate context.emit('page', new_page) firing the registered handler.
+
+        The handler we registered should attach a per-page ``request``
+        listener; firing that listener should record into ``network_log``.
+        """
+        from src.browser.service import BrowserManager, CamoufoxInstance
+
+        mgr = BrowserManager.__new__(BrowserManager)
+
+        ctx_handlers: dict[str, list] = {}
+
+        def _ctx_on(event: str, handler):
+            ctx_handlers.setdefault(event, []).append(handler)
+
+        context = MagicMock()
+        context.on = MagicMock(side_effect=_ctx_on)
+
+        existing_page = MagicMock()
+        existing_page.on = MagicMock()
+
+        inst = CamoufoxInstance("agent1", MagicMock(), context, existing_page)
+        mgr._attach_network_listeners(inst)
+
+        # Now fire a context-level "page" event with a brand-new Mock Page.
+        new_page = MagicMock()
+        new_page_handlers: dict[str, list] = {}
+
+        def _new_page_on(event: str, handler):
+            new_page_handlers.setdefault(event, []).append(handler)
+
+        new_page.on = MagicMock(side_effect=_new_page_on)
+
+        # The registered context handler should attach a request handler
+        # to the new page when invoked.
+        for h in ctx_handlers["page"]:
+            h(new_page)
+
+        # The new_page now has a "request" listener registered.
+        assert "request" in new_page_handlers
+        assert len(new_page_handlers["request"]) == 1
+
+        # Firing that listener with a Mock request should record into log.
+        req = _make_mock_request("https://newtab.example.com/asset.js")
+        new_page_handlers["request"][0](req)
+
+        assert len(inst.network_log) == 1
+        assert "/asset.js" in inst.network_log[0]["url"]
+
+
+# ───────────────────────────────────────────────────────────────────────
+# 11. Idempotency of _attach_network_listeners
+# ───────────────────────────────────────────────────────────────────────
+
+
+class TestAttachIdempotent:
+    def test_double_attach_does_not_double_register(self):
+        from src.browser.service import BrowserManager, CamoufoxInstance
+
+        mgr = BrowserManager.__new__(BrowserManager)
+        ctx = MagicMock()
+        ctx.on = MagicMock()
+        page = MagicMock()
+        page.on = MagicMock()
+        inst = CamoufoxInstance("agent1", MagicMock(), ctx, page)
+
+        mgr._attach_network_listeners(inst)
+        first_count = ctx.on.call_count
+        mgr._attach_network_listeners(inst)  # second call: must no-op
+        assert ctx.on.call_count == first_count
+        assert inst._network_attached is True
+
+
+# ───────────────────────────────────────────────────────────────────────
+# 12. Skill registration sanity check
+# ───────────────────────────────────────────────────────────────────────
+
+
+class TestSkillRegistration:
+    def test_skill_present_with_correct_name_and_params(self):
+        from src.agent.builtins import browser_tool
+
+        fn = getattr(browser_tool, "browser_inspect_requests", None)
+        assert fn is not None
+
+        meta = getattr(fn, "skill_meta", None) or getattr(fn, "_skill", None)
+        # Registry-agnostic — just confirm callable + has the expected name
+        # somewhere on its metadata. The skill registry itself is tested
+        # separately in tests/test_skills.py.
+        assert callable(fn)
+        # The skill decorator stores metadata; we just confirm description
+        # mentions adblock so future refactors can't silently lose intent.
+        # Falls back to inspecting the docstring if no metadata attr.
+        meta_text = (
+            getattr(meta, "description", "") if meta else ""
+        ) or (fn.__doc__ or "")
+        # description bound to the decorator-generated callable
+        decorated = getattr(fn, "__wrapped__", fn)
+        registry_desc = ""
+        if hasattr(fn, "description"):
+            registry_desc = fn.description  # type: ignore[attr-defined]
+        haystack = " ".join([meta_text, registry_desc, decorated.__doc__ or ""])
+        assert "network requests" in haystack.lower() or "adblock" in haystack.lower()

--- a/tests/test_dashboard_cookie_import.py
+++ b/tests/test_dashboard_cookie_import.py
@@ -1,0 +1,729 @@
+"""Tests for Phase 6 §9.2: operator cookie/session import.
+
+Coverage:
+1.  Audit log NEVER contains cookie values, JWTs, Bearer tokens, or
+    SigV4-shaped strings (the most important security property).
+2.  Playwright + Netscape happy paths.
+3.  CSRF rejection (missing X-Requested-With).
+4.  Auth rejection (missing ol_session in hosted mode).
+5.  Rate-limit overflow → 429 with retry_after_ms.
+6.  Kill-switch (BROWSER_COOKIE_IMPORT_DISABLED=1).
+7.  Per-cookie 4 KiB value cap and 256 KiB total payload cap and
+    1000-cookie list-length cap.
+8.  Drop reasons: __Host-with-domain, IP-literal domain, invalid SameSite.
+9.  Invalid JSON / unknown shape → 400.
+10. Idempotency-ish: two overlapping imports succeed.
+11. Browser-service down → 503.
+12. Parser unit tests for ``_parse_netscape``.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import shutil
+import tempfile
+from unittest.mock import MagicMock
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from src.dashboard.events import EventBus
+from src.dashboard.server import (
+    _is_ip_literal_domain,
+    _parse_netscape,
+    _validate_cookies,
+    create_dashboard_router,
+)
+from src.host.costs import CostTracker
+from src.host.health import HealthMonitor
+from src.host.mesh import Blackboard
+from src.host.traces import TraceStore
+
+# A short corpus of value shapes the audit log MUST NEVER echo. Each
+# string is also wrapped into a Playwright cookie payload below.
+_SECRET_VALUES = [
+    "raw-secretvalue-12345",
+    "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJ0ZXN0In0.abc123",  # JWT-shape
+    "Bearer abc123def456ghi789jkl012mno345pqr678stu901vwx234",          # Bearer
+    "AKIAIOSFODNN7EXAMPLEAWS4-HMAC-SHA256-Credential-AKIAIOSFODNN7EXAMPLE-1234567890abcdef",  # SigV4-ish
+]
+
+
+class _CSRFTestClient(TestClient):
+    """Auto-injects X-Requested-With on state-changing methods."""
+
+    def request(self, method, url, **kwargs):
+        if method.upper() not in ("GET", "HEAD", "OPTIONS"):
+            headers = kwargs.get("headers") or {}
+            if "X-Requested-With" not in headers:
+                headers["X-Requested-With"] = "XMLHttpRequest"
+                kwargs["headers"] = headers
+        return super().request(method, url, **kwargs)
+
+
+def _make_components(tmp_path: str) -> dict:
+    """Minimal components for the dashboard router, with a runtime mock
+    pointing at a non-existent browser_service_url so the test can
+    intercept httpx calls via the shared client."""
+    bb = Blackboard(db_path=os.path.join(tmp_path, "bb.db"))
+    cost_tracker = CostTracker(db_path=os.path.join(tmp_path, "costs.db"))
+    trace_store = TraceStore(db_path=os.path.join(tmp_path, "traces.db"))
+    event_bus = EventBus()
+    agent_registry: dict[str, str] = {
+        "alpha": "http://localhost:8401",
+    }
+
+    runtime_mock = MagicMock()
+    runtime_mock.browser_service_url = "http://browser-svc:8500"
+    runtime_mock.browser_auth_token = "test-token"
+    runtime_mock.browser_vnc_url = None
+
+    transport_mock = MagicMock()
+    router_mock = MagicMock()
+    health_monitor = HealthMonitor(
+        runtime=runtime_mock, transport=transport_mock, router=router_mock,
+    )
+    health_monitor.register("alpha")
+    health_monitor.agents["alpha"].status = "healthy"
+
+    return {
+        "blackboard": bb,
+        "health_monitor": health_monitor,
+        "cost_tracker": cost_tracker,
+        "trace_store": trace_store,
+        "event_bus": event_bus,
+        "agent_registry": agent_registry,
+        "runtime": runtime_mock,
+    }
+
+
+def _make_client(components: dict) -> TestClient:
+    router = create_dashboard_router(**components, mesh_port=8420)
+    app = FastAPI()
+    app.include_router(router)
+    return _CSRFTestClient(app)
+
+
+def _teardown(components: dict) -> None:
+    components["cost_tracker"].close()
+    components["trace_store"].close()
+    components["blackboard"].close()
+
+
+def _stub_browser_service(monkeypatch, *, success: bool = True,
+                          imported_count: int | None = None,
+                          status_code: int = 200,
+                          raise_exc: Exception | None = None) -> dict:
+    """Patch the dashboard's shared httpx client so we can intercept
+    posts to the browser service. Returns a dict where ``calls`` collects
+    every (url, body) tuple."""
+    tracker: dict = {"calls": []}
+
+    async def _fake_post(url, *args, **kwargs):
+        tracker["calls"].append({"url": url, "json": kwargs.get("json")})
+        if raise_exc is not None:
+            raise raise_exc
+        body = kwargs.get("json") or {}
+        cookies = body.get("cookies") or []
+        count = imported_count if imported_count is not None else len(cookies)
+
+        class _Resp:
+            def __init__(self, code, payload):
+                self.status_code = code
+                self._payload = payload
+
+            def json(self):
+                return self._payload
+
+            def raise_for_status(self):
+                if self.status_code >= 400:
+                    raise RuntimeError(f"HTTP {self.status_code}")
+
+        if success:
+            payload = {"success": True, "data": {"imported": count}}
+        else:
+            payload = {
+                "success": False,
+                "error": {
+                    "code": "invalid_input",
+                    "message": "fake failure",
+                    "retry_after_ms": None,
+                },
+            }
+        return _Resp(status_code, payload)
+
+    # Patch by mutating the module-level client used inside the router.
+    # The client is created fresh per `create_dashboard_router` call —
+    # we monkeypatch httpx.AsyncClient.post via the instance the router
+    # captured. Easiest path: stash a reference into the router state.
+    import src.dashboard.server as _srv
+
+    real_async_client = _srv._httpx.AsyncClient if hasattr(_srv, "_httpx") else None
+    if real_async_client is None:
+        # The httpx import is local to create_dashboard_router. Patch
+        # the real httpx module instead so all clients route through.
+        import httpx as _httpx_mod
+
+        async def _proxy_post(self, url, *args, **kwargs):
+            return await _fake_post(url, *args, **kwargs)
+
+        monkeypatch.setattr(_httpx_mod.AsyncClient, "post", _proxy_post)
+    return tracker
+
+
+# ────────────────────────────────────────────────────────────────────────
+# Pure-function tests (no HTTP)
+# ────────────────────────────────────────────────────────────────────────
+
+
+class TestParseNetscape:
+    def test_basic_line(self):
+        text = ".example.com\tTRUE\t/\tTRUE\t1735689600\tsid\tabcdef\n"
+        result = _parse_netscape(text)
+        assert len(result) == 1
+        assert result[0]["name"] == "sid"
+        assert result[0]["value"] == "abcdef"
+        assert result[0]["domain"] == ".example.com"
+        assert result[0]["secure"] is True
+        assert result[0]["httpOnly"] is False
+        assert result[0]["expires"] == 1735689600
+        assert result[0]["path"] == "/"
+
+    def test_comment_lines_skipped(self):
+        text = (
+            "# this is a comment\n"
+            "# another comment\n"
+            ".example.com\tTRUE\t/\tFALSE\t100\tname\tvalue\n"
+        )
+        result = _parse_netscape(text)
+        assert len(result) == 1
+        assert result[0]["secure"] is False
+
+    def test_httponly_prefix(self):
+        text = "#HttpOnly_.example.com\tTRUE\t/\tTRUE\t100\tsid\tabc\n"
+        result = _parse_netscape(text)
+        assert len(result) == 1
+        assert result[0]["domain"] == ".example.com"
+        assert result[0]["httpOnly"] is True
+
+    def test_missing_fields_dropped(self):
+        text = "# header\n.example.com\tTRUE\t/\tTRUE\n"  # too few fields
+        assert _parse_netscape(text) == []
+
+    def test_unicode_domain_accepted(self):
+        text = ".пример.com\tTRUE\t/\tTRUE\t100\tsid\txyz\n"
+        result = _parse_netscape(text)
+        assert len(result) == 1
+        assert result[0]["domain"] == ".пример.com"
+
+    def test_non_numeric_expires_dropped(self):
+        text = ".example.com\tTRUE\t/\tTRUE\tnot-a-number\tsid\txyz\n"
+        assert _parse_netscape(text) == []
+
+    def test_blank_lines_skipped(self):
+        text = "\n\n\n.example.com\tTRUE\t/\tTRUE\t100\tsid\tabc\n\n"
+        assert len(_parse_netscape(text)) == 1
+
+
+class TestValidateCookies:
+    def test_playwright_happy_path(self):
+        accepted, dropped, fmt = _validate_cookies(
+            [{"name": "sid", "value": "abc", "domain": ".example.com"}],
+        )
+        assert fmt == "playwright"
+        assert len(accepted) == 1
+        assert dropped == []
+
+    def test_drops_value_too_large(self):
+        accepted, dropped, fmt = _validate_cookies(
+            [{"name": "sid", "value": "x" * 5000, "domain": ".example.com"}],
+        )
+        assert accepted == []
+        assert dropped == [{"reason": "value_too_large", "count": 1}]
+
+    def test_drops_host_prefix_with_domain(self):
+        accepted, dropped, _ = _validate_cookies(
+            [{"name": "__Host-sess", "value": "abc", "domain": ".example.com"}],
+        )
+        assert accepted == []
+        assert dropped == [{"reason": "host_prefix_with_domain", "count": 1}]
+
+    def test_allows_host_prefix_without_domain(self):
+        # __Host- without domain (empty domain) is rejected by empty_domain rule.
+        # The valid form has domain absent entirely; we just verify host_prefix
+        # only fires when domain is set.
+        accepted, dropped, _ = _validate_cookies(
+            [{"name": "__Host-sess", "value": "abc", "domain": ""}],
+        )
+        # empty_domain triggers first; not host_prefix
+        assert "host_prefix_with_domain" not in [d["reason"] for d in dropped]
+
+    def test_drops_ip_literal_domain(self):
+        for domain in ["127.0.0.1", "[::1]", "192.168.1.1"]:
+            accepted, dropped, _ = _validate_cookies(
+                [{"name": "sid", "value": "x", "domain": domain}],
+            )
+            assert accepted == []
+            assert dropped == [{"reason": "ip_domain_unsupported", "count": 1}]
+
+    def test_drops_invalid_samesite(self):
+        accepted, dropped, _ = _validate_cookies(
+            [{"name": "sid", "value": "x", "domain": ".example.com",
+              "sameSite": "BadValue"}],
+        )
+        assert accepted == []
+        assert dropped == [{"reason": "invalid_samesite", "count": 1}]
+
+    def test_normalizes_samesite_case_insensitive(self):
+        accepted, _, _ = _validate_cookies(
+            [{"name": "sid", "value": "x", "domain": ".example.com",
+              "sameSite": "lax"}],
+        )
+        assert accepted[0]["sameSite"] == "Lax"
+
+    def test_rejects_string_expires(self):
+        accepted, dropped, _ = _validate_cookies(
+            [{"name": "sid", "value": "x", "domain": ".example.com",
+              "expires": "not-a-number"}],
+        )
+        assert accepted == []
+        assert dropped == [{"reason": "invalid_expires", "count": 1}]
+
+    def test_unknown_format_returns_none(self):
+        # An int payload doesn't match either format.
+        _, _, fmt = _validate_cookies(42)
+        assert fmt is None
+
+
+class TestIsIpLiteralDomain:
+    def test_ipv4(self):
+        assert _is_ip_literal_domain("127.0.0.1")
+        assert _is_ip_literal_domain("8.8.8.8")
+        assert _is_ip_literal_domain(".10.0.0.1")  # leading dot stripped
+
+    def test_ipv6_bracketed(self):
+        assert _is_ip_literal_domain("[::1]")
+        assert _is_ip_literal_domain("[2001:db8::1]")
+
+    def test_normal_domain(self):
+        assert not _is_ip_literal_domain(".example.com")
+        assert not _is_ip_literal_domain("not.an.ip")
+
+    def test_octet_out_of_range_rejected(self):
+        # 999 is not a valid octet — must NOT be classified as IP.
+        assert not _is_ip_literal_domain("999.999.999.999")
+
+
+# ────────────────────────────────────────────────────────────────────────
+# HTTP-level tests (full router)
+# ────────────────────────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def setup(monkeypatch):
+    """Build a fresh dashboard router + browser-service stub per test."""
+    tmpdir = tempfile.mkdtemp()
+    components = _make_components(tmpdir)
+    tracker = _stub_browser_service(monkeypatch)
+    client = _make_client(components)
+    yield {
+        "client": client,
+        "components": components,
+        "tracker": tracker,
+        "tmpdir": tmpdir,
+    }
+    _teardown(components)
+    shutil.rmtree(tmpdir, ignore_errors=True)
+
+
+# Reset the cookie-import rate-limit dict between tests by tearing
+# down and rebuilding the router fresh in each test (the fixture does this).
+
+
+class TestAuditLogValueRedaction:
+    """The most critical property: audit log MUST NEVER contain cookie values."""
+
+    def test_audit_log_no_value(self, setup, caplog):
+        """Captured log text contains domain + name but NEVER value."""
+        client = setup["client"]
+        # Build a payload where each cookie's VALUE is one of the secret shapes.
+        cookies = [
+            {"name": f"sid_{i}", "value": secret,
+             "domain": f".example{i}.com"}
+            for i, secret in enumerate(_SECRET_VALUES)
+        ]
+        with caplog.at_level(logging.INFO, logger="dashboard.cookie_import"):
+            resp = client.post(
+                "/dashboard/api/agents/alpha/browser/import_cookies",
+                json={"format": "playwright", "cookies": cookies},
+            )
+        assert resp.status_code == 200, resp.text
+        # Concatenate every captured record.
+        log_text = "\n".join(r.getMessage() for r in caplog.records)
+        # Domains AND names should appear (proves audit hit and we have
+        # the right log messages).
+        for c in cookies:
+            assert c["domain"] in log_text
+            assert c["name"] in log_text
+        # NONE of the cookie values should appear in any form.
+        for secret in _SECRET_VALUES:
+            assert secret not in log_text, (
+                f"Cookie value leaked into audit log: {secret!r}"
+            )
+        # Also assert structural negatives — common patterns within values.
+        assert "raw-secretvalue" not in log_text
+        assert "eyJhbGciOiJIUzI1NiIs" not in log_text
+        assert "Bearer abc123" not in log_text
+
+    def test_audit_log_no_value_in_netscape_path(self, setup, caplog):
+        """Same property when the input format is Netscape TSV."""
+        client = setup["client"]
+        # Build a Netscape blob whose VALUE column carries each secret.
+        ns = "\n".join(
+            f".example{i}.com\tTRUE\t/\tTRUE\t1735689600\tsid_{i}\t{secret}"
+            for i, secret in enumerate(_SECRET_VALUES)
+        )
+        with caplog.at_level(logging.INFO, logger="dashboard.cookie_import"):
+            resp = client.post(
+                "/dashboard/api/agents/alpha/browser/import_cookies",
+                json={"format": "netscape", "cookies": ns},
+            )
+        assert resp.status_code == 200, resp.text
+        log_text = "\n".join(r.getMessage() for r in caplog.records)
+        for secret in _SECRET_VALUES:
+            assert secret not in log_text
+
+
+class TestHappyPaths:
+    def test_playwright_format_pushes_to_browser_service(self, setup):
+        client = setup["client"]
+        tracker = setup["tracker"]
+        cookies = [
+            {"name": "sid", "value": "abc",
+             "domain": ".example.com", "path": "/",
+             "expires": 1735689600,
+             "httpOnly": True, "secure": True, "sameSite": "Lax"},
+        ]
+        resp = client.post(
+            "/dashboard/api/agents/alpha/browser/import_cookies",
+            json={"format": "playwright", "cookies": cookies},
+        )
+        assert resp.status_code == 200, resp.text
+        data = resp.json()
+        assert data["success"] is True
+        assert data["data"]["imported"] == 1
+        assert data["data"]["format"] == "playwright"
+        # Browser service was actually called.
+        assert any(
+            c["url"].endswith("/browser/alpha/import_cookies")
+            for c in tracker["calls"]
+        )
+        # The list pushed contains the normalized shape (sameSite still "Lax").
+        pushed = next(
+            c for c in tracker["calls"]
+            if c["url"].endswith("/browser/alpha/import_cookies")
+        )
+        assert pushed["json"]["cookies"][0]["sameSite"] == "Lax"
+
+    def test_netscape_format_with_httponly_prefix(self, setup):
+        client = setup["client"]
+        tracker = setup["tracker"]
+        ns = (
+            "# Netscape\n"
+            "#HttpOnly_.example.com\tTRUE\t/\tTRUE\t1735689600\tsid\tabc\n"
+        )
+        resp = client.post(
+            "/dashboard/api/agents/alpha/browser/import_cookies",
+            json={"format": "netscape", "cookies": ns},
+        )
+        assert resp.status_code == 200, resp.text
+        data = resp.json()
+        assert data["success"] is True
+        assert data["data"]["imported"] == 1
+        # Verify the pushed cookie has httpOnly=True.
+        pushed = next(
+            c for c in tracker["calls"]
+            if c["url"].endswith("/browser/alpha/import_cookies")
+        )
+        cookie = pushed["json"]["cookies"][0]
+        assert cookie["httpOnly"] is True
+        assert cookie["domain"] == ".example.com"
+
+
+class TestCSRFAndAuth:
+    def test_csrf_rejection_no_x_requested_with(self, setup):
+        client = TestClient(_make_client(setup["components"]).app)
+        # Bare TestClient — no X-Requested-With injection.
+        resp = client.post(
+            "/dashboard/api/agents/alpha/browser/import_cookies",
+            json={"format": "playwright", "cookies": []},
+        )
+        assert resp.status_code == 403
+        assert "X-Requested-With" in resp.text
+
+    def test_auth_rejection_in_hosted_mode(self, setup, monkeypatch, tmp_path):
+        """When access token file is present, missing ol_session → 401."""
+        from src.dashboard import auth
+        # Create a fake access token + hosted indicator so verify_session_cookie
+        # enters hosted-mode behavior.
+        token_path = tmp_path / "access_token"
+        token_path.write_text("test-access-token")
+        hosted_indicator = tmp_path / ".subdomain"
+        hosted_indicator.write_text("test")
+        monkeypatch.setattr(auth, "_ACCESS_TOKEN_PATH", str(token_path))
+        monkeypatch.setattr(auth, "_HOSTED_INDICATOR", str(hosted_indicator))
+        auth.reset_cache()
+        # Reset _is_hosted cache.
+        monkeypatch.setattr(auth, "_is_hosted", None)
+        client = setup["client"]
+        resp = client.post(
+            "/dashboard/api/agents/alpha/browser/import_cookies",
+            json={"format": "playwright", "cookies": []},
+        )
+        assert resp.status_code == 401
+        # Cleanup auth cache so other tests in this session aren't affected.
+        auth.reset_cache()
+
+
+class TestRateLimit:
+    def test_eleventh_call_within_window_returns_429(self, setup):
+        client = setup["client"]
+        # Send 10 requests — all should succeed.
+        for i in range(10):
+            resp = client.post(
+                "/dashboard/api/agents/alpha/browser/import_cookies",
+                json={"format": "playwright",
+                      "cookies": [{"name": f"sid{i}", "value": "x",
+                                   "domain": ".example.com"}]},
+            )
+            assert resp.status_code == 200, f"call {i}: {resp.text}"
+        # 11th must be rate-limited.
+        resp = client.post(
+            "/dashboard/api/agents/alpha/browser/import_cookies",
+            json={"format": "playwright",
+                  "cookies": [{"name": "sidX", "value": "x",
+                               "domain": ".example.com"}]},
+        )
+        assert resp.status_code == 429
+        body = resp.json()
+        # FastAPI nests the structured body under "detail" when raising HTTPException.
+        err = body.get("detail", {}).get("error") or body.get("error") or {}
+        assert err.get("code") == "conflict"
+        assert err.get("retry_after_ms") and err["retry_after_ms"] > 0
+
+
+class TestKillSwitch:
+    def test_disabled_flag_returns_403(self, setup, monkeypatch):
+        from src.browser import flags as _flags
+        monkeypatch.setenv("BROWSER_COOKIE_IMPORT_DISABLED", "1")
+        # Reload settings cache so the flag picks up.
+        _flags.reload_operator_settings()
+        client = setup["client"]
+        resp = client.post(
+            "/dashboard/api/agents/alpha/browser/import_cookies",
+            json={"format": "playwright", "cookies": []},
+        )
+        assert resp.status_code == 403
+        body = resp.json()
+        err = body.get("detail", {}).get("error") or {}
+        assert err.get("code") == "forbidden"
+
+
+class TestSizeCaps:
+    def test_per_cookie_value_too_large(self, setup):
+        client = setup["client"]
+        # 5 KiB > 4 KiB cap; cookie should be DROPPED (not import-fail).
+        resp = client.post(
+            "/dashboard/api/agents/alpha/browser/import_cookies",
+            json={"format": "playwright",
+                  "cookies": [{"name": "sid", "value": "x" * 5000,
+                               "domain": ".example.com"}]},
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["success"] is True
+        assert data["data"]["imported"] == 0
+        reasons = [d["reason"] for d in data["data"]["dropped"]]
+        assert "value_too_large" in reasons
+
+    def test_total_payload_too_large(self, setup):
+        client = setup["client"]
+        # 257 KiB raw bytes — must be 413 BEFORE we even parse JSON.
+        big = "x" * (257 * 1024)
+        resp = client.post(
+            "/dashboard/api/agents/alpha/browser/import_cookies",
+            content=big,
+            headers={"Content-Type": "application/json"},
+        )
+        assert resp.status_code == 413
+        body = resp.json()
+        err = body.get("detail", {}).get("error") or {}
+        assert err.get("code") == "size_limit"
+
+    def test_list_length_cap_exceeded(self, setup):
+        """1001 cookies → 413 envelope."""
+        client = setup["client"]
+        # Use minimal payload per cookie to stay under 256 KiB total.
+        cookies = [
+            {"name": f"s{i}", "value": "v", "domain": ".example.com"}
+            for i in range(1001)
+        ]
+        resp = client.post(
+            "/dashboard/api/agents/alpha/browser/import_cookies",
+            json={"format": "playwright", "cookies": cookies},
+        )
+        assert resp.status_code == 413
+        body = resp.json()
+        err = body.get("detail", {}).get("error") or {}
+        assert err.get("code") == "size_limit"
+
+
+class TestDropReasons:
+    def test_host_prefix_with_domain_dropped(self, setup):
+        client = setup["client"]
+        resp = client.post(
+            "/dashboard/api/agents/alpha/browser/import_cookies",
+            json={"format": "playwright",
+                  "cookies": [{"name": "__Host-sess", "value": "x",
+                               "domain": ".example.com"}]},
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["data"]["imported"] == 0
+        reasons = [d["reason"] for d in data["data"]["dropped"]]
+        assert "host_prefix_with_domain" in reasons
+
+    def test_ip_literal_dropped(self, setup):
+        client = setup["client"]
+        resp = client.post(
+            "/dashboard/api/agents/alpha/browser/import_cookies",
+            json={"format": "playwright",
+                  "cookies": [{"name": "sid", "value": "x",
+                               "domain": "127.0.0.1"}]},
+        )
+        data = resp.json()
+        reasons = [d["reason"] for d in data["data"]["dropped"]]
+        assert "ip_domain_unsupported" in reasons
+
+    def test_invalid_samesite_dropped(self, setup):
+        client = setup["client"]
+        resp = client.post(
+            "/dashboard/api/agents/alpha/browser/import_cookies",
+            json={"format": "playwright",
+                  "cookies": [{"name": "sid", "value": "x",
+                               "domain": ".example.com",
+                               "sameSite": "RandomGarbage"}]},
+        )
+        data = resp.json()
+        reasons = [d["reason"] for d in data["data"]["dropped"]]
+        assert "invalid_samesite" in reasons
+
+
+class TestInvalidInput:
+    def test_invalid_json_returns_400(self, setup):
+        client = setup["client"]
+        resp = client.post(
+            "/dashboard/api/agents/alpha/browser/import_cookies",
+            content="this is not json",
+            headers={"Content-Type": "application/json"},
+        )
+        assert resp.status_code == 400
+        body = resp.json()
+        err = body.get("detail", {}).get("error") or {}
+        assert err.get("code") == "invalid_input"
+
+    def test_unknown_shape_returns_400(self, setup):
+        client = setup["client"]
+        # Payload is neither a list (playwright) nor a TSV string (netscape).
+        resp = client.post(
+            "/dashboard/api/agents/alpha/browser/import_cookies",
+            json={"cookies": 42},
+        )
+        assert resp.status_code == 400
+        body = resp.json()
+        err = body.get("detail", {}).get("error") or {}
+        assert err.get("code") == "invalid_input"
+
+    def test_unknown_format_explicit(self, setup):
+        client = setup["client"]
+        resp = client.post(
+            "/dashboard/api/agents/alpha/browser/import_cookies",
+            json={"format": "curl-cookie-jar", "cookies": []},
+        )
+        assert resp.status_code == 400
+
+
+class TestIdempotencyLike:
+    def test_two_overlapping_imports_succeed(self, setup):
+        client = setup["client"]
+        cookies1 = [{"name": "sid", "value": "v1", "domain": ".example.com"}]
+        cookies2 = [
+            {"name": "sid", "value": "v2", "domain": ".example.com"},
+            {"name": "tok", "value": "v3", "domain": ".example.com"},
+        ]
+        r1 = client.post(
+            "/dashboard/api/agents/alpha/browser/import_cookies",
+            json={"format": "playwright", "cookies": cookies1},
+        )
+        r2 = client.post(
+            "/dashboard/api/agents/alpha/browser/import_cookies",
+            json={"format": "playwright", "cookies": cookies2},
+        )
+        assert r1.status_code == 200
+        assert r2.status_code == 200
+        assert r1.json()["data"]["imported"] == 1
+        assert r2.json()["data"]["imported"] == 2
+
+
+class TestBrowserServiceDown:
+    def test_browser_service_raises_returns_503(self, monkeypatch):
+        tmpdir = tempfile.mkdtemp()
+        try:
+            components = _make_components(tmpdir)
+            # Make any httpx post raise.
+            _stub_browser_service(monkeypatch, raise_exc=RuntimeError("svc down"))
+            client = _make_client(components)
+            resp = client.post(
+                "/dashboard/api/agents/alpha/browser/import_cookies",
+                json={"format": "playwright",
+                      "cookies": [{"name": "sid", "value": "x",
+                                   "domain": ".example.com"}]},
+                headers={"X-Requested-With": "XMLHttpRequest"},
+            )
+            assert resp.status_code == 503
+            body = resp.json()
+            err = body.get("detail", {}).get("error") or {}
+            assert err.get("code") == "service_unavailable"
+        finally:
+            _teardown(components)
+            shutil.rmtree(tmpdir, ignore_errors=True)
+
+    def test_browser_service_returns_500_returns_503(self, monkeypatch):
+        tmpdir = tempfile.mkdtemp()
+        try:
+            components = _make_components(tmpdir)
+            _stub_browser_service(monkeypatch, status_code=502)
+            client = _make_client(components)
+            resp = client.post(
+                "/dashboard/api/agents/alpha/browser/import_cookies",
+                json={"format": "playwright",
+                      "cookies": [{"name": "sid", "value": "x",
+                                   "domain": ".example.com"}]},
+                headers={"X-Requested-With": "XMLHttpRequest"},
+            )
+            assert resp.status_code == 503
+        finally:
+            _teardown(components)
+            shutil.rmtree(tmpdir, ignore_errors=True)
+
+
+class TestUnknownAgent:
+    def test_404_when_agent_not_in_registry(self, setup):
+        client = setup["client"]
+        resp = client.post(
+            "/dashboard/api/agents/nonexistent/browser/import_cookies",
+            json={"format": "playwright", "cookies": []},
+        )
+        assert resp.status_code == 404

--- a/tests/test_dashboard_cookie_import.py
+++ b/tests/test_dashboard_cookie_import.py
@@ -272,23 +272,85 @@ class TestValidateCookies:
         assert accepted == []
         assert dropped == [{"reason": "host_prefix_with_domain", "count": 1}]
 
-    def test_allows_host_prefix_without_domain(self):
-        # __Host- without domain (empty domain) is rejected by empty_domain rule.
-        # The valid form has domain absent entirely; we just verify host_prefix
-        # only fires when domain is set.
+    def test_allows_host_prefix_url_cookie_without_domain(self):
         accepted, dropped, _ = _validate_cookies(
-            [{"name": "__Host-sess", "value": "abc", "domain": ""}],
+            [{
+                "name": "__Host-sess",
+                "value": "abc",
+                "url": "https://example.com/",
+                "path": "/",
+                "secure": True,
+            }],
         )
-        # empty_domain triggers first; not host_prefix
-        assert "host_prefix_with_domain" not in [d["reason"] for d in dropped]
+        assert dropped == []
+        assert accepted == [{
+            "name": "__Host-sess",
+            "value": "abc",
+            "url": "https://example.com/",
+            "path": "/",
+            "secure": True,
+        }]
+
+    def test_drops_host_prefix_url_cookie_without_secure(self):
+        accepted, dropped, _ = _validate_cookies(
+            [{
+                "name": "__Host-sess",
+                "value": "abc",
+                "url": "https://example.com/",
+                "path": "/",
+                "secure": False,
+            }],
+        )
+        assert accepted == []
+        assert dropped == [{"reason": "host_prefix_without_secure", "count": 1}]
+
+    def test_drops_host_prefix_url_cookie_wrong_path(self):
+        accepted, dropped, _ = _validate_cookies(
+            [{
+                "name": "__Host-sess",
+                "value": "abc",
+                "url": "https://example.com/app",
+                "path": "/app",
+                "secure": True,
+            }],
+        )
+        assert accepted == []
+        assert dropped == [{"reason": "host_prefix_invalid_path", "count": 1}]
+
+    def test_playwright_url_cookie_supported(self):
+        accepted, dropped, fmt = _validate_cookies(
+            [{"name": "sid", "value": "abc", "url": "https://example.com/"}],
+        )
+        assert fmt == "playwright"
+        assert dropped == []
+        assert accepted[0]["url"] == "https://example.com/"
+
+    def test_domain_and_url_conflict_dropped(self):
+        accepted, dropped, _ = _validate_cookies(
+            [{
+                "name": "sid",
+                "value": "abc",
+                "domain": ".example.com",
+                "url": "https://example.com/",
+            }],
+        )
+        assert accepted == []
+        assert dropped == [{"reason": "domain_url_conflict", "count": 1}]
 
     def test_drops_ip_literal_domain(self):
-        for domain in ["127.0.0.1", "[::1]", "192.168.1.1"]:
+        for domain in ["127.0.0.1", "[::1]", "2001:db8::1", "192.168.1.1"]:
             accepted, dropped, _ = _validate_cookies(
                 [{"name": "sid", "value": "x", "domain": domain}],
             )
             assert accepted == []
             assert dropped == [{"reason": "ip_domain_unsupported", "count": 1}]
+
+    def test_drops_ip_literal_url_host(self):
+        accepted, dropped, _ = _validate_cookies(
+            [{"name": "sid", "value": "x", "url": "https://127.0.0.1/"}],
+        )
+        assert accepted == []
+        assert dropped == [{"reason": "ip_domain_unsupported", "count": 1}]
 
     def test_drops_invalid_samesite(self):
         accepted, dropped, _ = _validate_cookies(
@@ -356,6 +418,10 @@ class TestIsIpLiteralDomain:
     def test_ipv6_bracketed(self):
         assert _is_ip_literal_domain("[::1]")
         assert _is_ip_literal_domain("[2001:db8::1]")
+
+    def test_ipv6_unbracketed(self):
+        assert _is_ip_literal_domain("::1")
+        assert _is_ip_literal_domain("2001:db8::1")
 
     def test_normal_domain(self):
         assert not _is_ip_literal_domain(".example.com")

--- a/tests/test_dashboard_cookie_import.py
+++ b/tests/test_dashboard_cookie_import.py
@@ -212,6 +212,28 @@ class TestParseNetscape:
         text = "# header\n.example.com\tTRUE\t/\tTRUE\n"  # too few fields
         assert _parse_netscape(text) == []
 
+    def test_malformed_lines_reported_via_optional_sink(self):
+        """Bad lines (wrong field count, non-numeric expires) accumulate
+        in the optional ``malformed`` list so callers can surface a
+        ``malformed_line`` drop count to the operator."""
+        text = (
+            ".example.com\tTRUE\t/\tTRUE\t100\tname\tval\n"  # ok
+            ".example.com\tTRUE\t/\tTRUE\n"                   # too few fields
+            ".example.com\tTRUE\t/\tTRUE\tnope\tn\tv\n"      # bad expires
+            "single-column-junk\n"                            # too few fields
+        )
+        sink: list[str] = []
+        result = _parse_netscape(text, malformed=sink)
+        assert len(result) == 1
+        # 3 malformed lines captured (2 field_count + 1 expires).
+        assert len(sink) == 3
+        # Sink contains category strings only — never the raw bad line
+        # (which could include cookie values).
+        assert all(reason in {"field_count", "expires"} for reason in sink)
+        for reason in sink:
+            assert "single-column-junk" not in reason
+            assert "nope" not in reason
+
     def test_unicode_domain_accepted(self):
         text = ".пример.com\tTRUE\t/\tTRUE\t100\tsid\txyz\n"
         result = _parse_netscape(text)
@@ -295,6 +317,34 @@ class TestValidateCookies:
         # An int payload doesn't match either format.
         _, _, fmt = _validate_cookies(42)
         assert fmt is None
+
+    def test_secure_prefix_passes_through(self):
+        """``__Secure-`` cookies have no special validation here —
+        Playwright/Firefox enforces the ``secure=true`` rule at SET time,
+        not at import. Importing a ``__Secure-foo`` with a domain is
+        therefore expected to be ACCEPTED by ``_validate_cookies``."""
+        accepted, dropped, fmt = _validate_cookies(
+            [{"name": "__Secure-sess", "value": "x",
+              "domain": ".example.com", "secure": True}],
+        )
+        assert fmt == "playwright"
+        assert len(accepted) == 1
+        assert dropped == []
+
+    def test_netscape_malformed_lines_surface_as_drop_count(self):
+        """When the input is Netscape and contains malformed lines, the
+        ``dropped`` aggregate must include a ``malformed_line`` entry —
+        operators previously got a silent zero-import result."""
+        ns = (
+            ".example.com\tTRUE\t/\tTRUE\t100\tsid\tabc\n"   # ok
+            ".example.com\tTRUE\t/\tTRUE\n"                   # too few fields
+            ".example.com\tTRUE\t/\tTRUE\tNaN\tn\tv\n"       # bad expires
+        )
+        accepted, dropped, fmt = _validate_cookies(ns, fmt="netscape")
+        assert fmt == "netscape"
+        assert len(accepted) == 1
+        reasons = {d["reason"]: d["count"] for d in dropped}
+        assert reasons.get("malformed_line") == 2
 
 
 class TestIsIpLiteralDomain:
@@ -727,3 +777,59 @@ class TestUnknownAgent:
             json={"format": "playwright", "cookies": []},
         )
         assert resp.status_code == 404
+
+
+class TestBrowserServiceErrorRedaction:
+    """Phase 6 §9.2 third-pass review: the browser service must NEVER
+    echo a Playwright-supplied error string back to the dashboard. Even
+    if a future Playwright update changes the error shape (so the prior
+    substring heuristic for ``value`` would miss it), the response must
+    use a generic message.
+    """
+
+    def test_browser_service_import_returns_generic_message(self):
+        """Direct unit test of ``BrowserManager.import_cookies``: when
+        the underlying ``add_cookies`` raises an exception whose message
+        embeds a cookie value, the response message MUST be the static
+        ``cookie import failed`` string."""
+        import asyncio
+        from unittest.mock import AsyncMock, MagicMock
+
+        from src.browser.service import BrowserManager
+
+        mgr = BrowserManager.__new__(BrowserManager)
+
+        # Stub get_or_start to return a fake instance whose context
+        # raises a Playwright-shaped error — exactly what we don't want
+        # leaked back to the operator.
+        ctx_mock = MagicMock()
+        leaky_msg = "cookie name=session domain=evil.com VALUE=sk_live_DEADBEEF rejected"
+        ctx_mock.add_cookies = AsyncMock(side_effect=RuntimeError(leaky_msg))
+
+        inst_mock = MagicMock()
+        inst_mock.context = ctx_mock
+        inst_mock.touch = MagicMock()
+
+        class _AsyncCM:
+            async def __aenter__(self):
+                return None
+
+            async def __aexit__(self, *a):
+                return False
+
+        inst_mock.lock = _AsyncCM()
+        mgr.get_or_start = AsyncMock(return_value=inst_mock)
+
+        result = asyncio.run(
+            mgr.import_cookies("alpha", [{"name": "x", "value": "y",
+                                          "domain": ".e.com", "path": "/"}]),
+        )
+        assert result["success"] is False
+        msg = result["error"]["message"]
+        # Generic string regardless of Playwright error shape.
+        assert "cookie import failed" in msg.lower()
+        # MUST NOT include the secret or any Playwright-supplied detail.
+        assert "sk_live" not in msg
+        assert "DEADBEEF" not in msg
+        assert "session" not in msg.lower() or msg.lower().count("session") == 0
+        assert leaky_msg not in msg


### PR DESCRIPTION
## Summary

Adds `browser_fill_form(fields, submit_after?)` — compound find-text + atomic-fill across a list of `{label, value}` instructions, with CAPTCHA-mid-flow `partial_success` resume protocol.

- Each field locates by visible label via `_find_text_impl` (extracted lock-free from `find_text` so `fill_form` reuses the matching pipeline without re-entering `inst.lock`), then `locator.fill(value)` (atomic, clears first; resume after CAPTCHA stays idempotent).
- After EACH successful fill, `_check_captcha` runs. Positive detection → return `{partial_success: true, captcha_required: true, filled: [...], remaining: [...untouched...]}`. Agent solves CAPTCHA, calls `browser_fill_form` again with `remaining`.
- Per-field `submit_after=True` fires Enter BEFORE the captcha check (submission is often what gates the challenge). When the press triggered the CAPTCHA, the envelope reports `submitted=true` so the agent knows to re-snapshot before resuming rather than blindly re-typing partial form state.
- Single `inst.lock` acquisition for the entire form — no interleaving between find_text and fill.
- Validation: 1–50 fields, label 1–500 chars, value 0–10000 chars, no `\x00` in values.
- §2.3 envelope on every error path.
- Action `fill_form` added to `KNOWN_BROWSER_ACTIONS`.

Plan: `docs/plans/2026-04-20-browser-automation.md` §9.4.

## Test plan

- [x] 20 tests in `tests/test_browser_fill_form.py` covering all spec cases plus the per-field-submit-then-captcha P0 case (caught by review pass; fix `395eea2`).
- [x] 482-test regression sweep including existing `find_text` tests against the `_find_text_impl` extraction — 0 failures.
- [x] `ruff check` — clean.
- [x] Independent principal-engineer review pass — LGTM after applying the P0 fix.

## Reviewer notes

The original PR reported 19 tests; review caught a P0 where per-field `submit_after` could fire Enter, trigger CAPTCHA, and the response hardcoded `submitted=false`. Without the fix the agent would resume by re-typing `remaining`, risking double-submission. Test count is now 20 with the new `test_per_field_submit_then_captcha_reports_submitted_true` coverage.