### PR TITLE
Phase 7: operator metrics dashboard panel + max_concurrent docs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -170,6 +170,7 @@ Provisioner manages engine instances via Docker/systemd on Hetzner VPS:
 - `OPENLEGION_CRED_<NAME>` env vars for agent-tier credentials
 - `OPENLEGION_MAX_AGENTS`, `OPENLEGION_MAX_PROJECTS` for plan limits
 - `OPENLEGION_LOG_FORMAT=json` for production
+- `OPENLEGION_BROWSER_MAX_CONCURRENT` (default `5`, legacy name `MAX_BROWSERS` still honored) — per-service cap on simultaneous Camoufox instances. **Startup-only**; restart the browser service to apply changes (see `src/browser/__main__.py:_resolve_max_browsers`). Runtime reconfig was deferred per plan §10.2 — bounding the acquire semaphore mid-flight is non-trivial.
 
 ### Logging
 - `logger = setup_logging("component.module")` — every module

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -286,6 +286,7 @@ Beyond credentials, these environment variables affect runtime behavior:
 | `BROWSER_PROXY_URL` | -- | Proxy URL for browser traffic (HTTP/HTTPS only, e.g. `http://proxy:8080`). SOCKS5 is not supported. Residential proxies recommended. |
 | `BROWSER_PROXY_USER` | -- | Proxy authentication username. |
 | `BROWSER_PROXY_PASS` | -- | Proxy authentication password. |
+| `OPENLEGION_BROWSER_MAX_CONCURRENT` | `5` | Per-service cap on simultaneous Camoufox browser instances (clamped to `[1, 64]`). **Startup-only** — runtime reconfig is unsupported (would need to bound the acquire semaphore mid-flight). Restart the browser service to change this. The legacy name `MAX_BROWSERS` is still honored as a fallback for older deployments. |
 | `OPENLEGION_SYSTEM_PROXY` | -- | System-wide outbound HTTP proxy URL for all agent traffic. Managed via the dashboard proxy settings page. |
 | `HTTP_PROXY` / `HTTPS_PROXY` | -- | Per-agent proxy URLs. Auto-injected into agent containers by the runtime when a per-agent proxy is configured. Read by the agent-side `http_request` tool. |
 | `OPENLEGION_TOOL_TIMEOUT` | `300` | Per-tool execution timeout in seconds (hard ceiling). |

--- a/src/browser/__main__.py
+++ b/src/browser/__main__.py
@@ -30,7 +30,39 @@ logger = setup_logging("browser.main")
 _DISPLAY = ":99"
 _VNC_PORT = int(os.environ.get("VNC_PORT", "6080"))
 _API_PORT = int(os.environ.get("API_PORT", "8500"))
-_MAX_BROWSERS = int(os.environ.get("MAX_BROWSERS", "5"))
+
+
+def _resolve_max_browsers() -> int:
+    """Return the per-service browser concurrency cap.
+
+    Startup-only — runtime reconfig is non-trivial (would need to bound an
+    asyncio.Semaphore mid-flight, drain over-budget instances, and unwind any
+    in-flight ``acquire`` waiters). Operators restart the browser service to
+    change this. Plan §10.2 keeps this as the explicit decision after the v3.6
+    review flagged the runtime path's complexity.
+
+    Precedence (highest → lowest):
+      1. ``OPENLEGION_BROWSER_MAX_CONCURRENT`` — canonical name, listed in
+         :data:`src.browser.flags.KNOWN_FLAGS`.
+      2. ``MAX_BROWSERS`` — legacy name kept for back-compat with existing
+         deployments / Docker compose files. Removable after one release.
+      3. Default of 5.
+    """
+    from src.browser.flags import get_int
+
+    # ``min_value=1`` rejects nonsense like ``MAX=0`` (would deadlock the
+    # acquire loop). ``max_value=64`` is a soft ceiling — a single VPS won't
+    # have RAM for that many Camoufox instances anyway.
+    legacy_default = int(os.environ.get("MAX_BROWSERS", "5"))
+    return get_int(
+        "OPENLEGION_BROWSER_MAX_CONCURRENT",
+        legacy_default,
+        min_value=1,
+        max_value=64,
+    )
+
+
+_MAX_BROWSERS = _resolve_max_browsers()
 _IDLE_TIMEOUT = int(os.environ.get("IDLE_TIMEOUT_MINUTES", "30"))
 
 

--- a/src/dashboard/server.py
+++ b/src/dashboard/server.py
@@ -46,6 +46,66 @@ _STATIC_DIR = _HERE / "static"
 _ENV_KEY_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
 
 
+async def _fetch_browser_metrics_upstream(
+    client: Any,
+    service_url: str,
+    auth_token: str,
+    since_seq: int,
+) -> dict:
+    """Call ``GET /browser/metrics?since=<seq>`` on the browser service.
+
+    Pulled out of :func:`create_dashboard_router`'s closure so tests can
+    patch it without reaching into a closure cell. Returns the §2.3 error
+    envelope on any failure (network, HTTP error, malformed JSON) and the
+    upstream payload (with ``success: True``) on success.
+    """
+    headers: dict[str, str] = {}
+    if auth_token:
+        headers["Authorization"] = f"Bearer {auth_token}"
+    try:
+        resp = await client.get(
+            f"{service_url}/browser/metrics",
+            params={"since": since_seq},
+            headers=headers,
+            timeout=10,
+        )
+    except Exception as e:
+        logger.debug("Browser metrics fetch failed: %s", e)
+        return {
+            "success": False,
+            "error": {
+                "code": "service_unavailable",
+                "message": "Browser service unreachable",
+                "retry_after_ms": 60_000,
+            },
+        }
+    if resp.status_code >= 400:
+        logger.debug(
+            "Browser metrics fetch returned HTTP %d", resp.status_code,
+        )
+        return {
+            "success": False,
+            "error": {
+                "code": "service_unavailable",
+                "message": f"Browser service returned HTTP {resp.status_code}",
+                "retry_after_ms": 60_000,
+            },
+        }
+    try:
+        data = resp.json()
+    except Exception as e:
+        logger.debug("Browser metrics JSON parse failed: %s", e)
+        return {
+            "success": False,
+            "error": {
+                "code": "service_unavailable",
+                "message": "Malformed response from browser service",
+                "retry_after_ms": None,
+            },
+        }
+    return {"success": True, "data": data}
+
+
 def _get_builtin_tool_names() -> frozenset[str]:
     """Return the names of all built-in agent tools by scanning the builtins package.
 
@@ -1021,6 +1081,76 @@ def create_dashboard_router(
                 "dropped": dropped,
                 "format": detected_fmt,
             },
+        }
+
+    @api_router.get("/api/agents/{agent_id}/browser/metrics")
+    async def api_agent_browser_metrics(
+        agent_id: str, since: int = 0,
+    ) -> dict:
+        """Return per-agent browser-metrics history (Phase 7 §10.1).
+
+        Surfaces the per-minute aggregates already collected by
+        :meth:`BrowserManager._emit_metrics` (§4.6) — click_success/fail,
+        snapshot p50/p95, nav timeouts, rolling click-success-rate. Read-only,
+        agent-scoped slice of ``/browser/metrics?since=<seq>``.
+
+        Pagination via ``since=<seq>``: client passes back the response's
+        ``current_seq`` on the next call so only new payloads are returned.
+        Buffer is bounded (1024 entries service-wide) so a long-idle dashboard
+        may miss intermediate payloads — that is by design (§2.7 forbids
+        per-call events; an hour of history per agent is more than the panel
+        renders anyway).
+
+        On error returns a §2.3 envelope: ``{success, error: {code, message,
+        retry_after_ms}}``. Per-call events are forbidden — this endpoint only
+        surfaces aggregates.
+        """
+        if agent_id not in agent_registry:
+            raise HTTPException(404, "Agent not found")
+        if (
+            not runtime
+            or not hasattr(runtime, "browser_service_url")
+            or not runtime.browser_service_url
+        ):
+            # Service unavailable rather than 404 — the agent exists, the
+            # browser service is just not configured / reachable. Use the
+            # error envelope so the panel can render a "service down" state.
+            return {
+                "success": False,
+                "error": {
+                    "code": "service_unavailable",
+                    "message": "Browser service not available",
+                    "retry_after_ms": None,
+                },
+            }
+        try:
+            since_seq = max(0, int(since))
+        except (TypeError, ValueError):
+            since_seq = 0
+
+        result = await _fetch_browser_metrics_upstream(
+            _dashboard_browser_client,
+            runtime.browser_service_url,
+            getattr(runtime, "browser_auth_token", ""),
+            since_seq,
+        )
+        if not result.get("success"):
+            return result
+        data = result["data"]
+
+        # Filter to this agent only — the upstream endpoint returns
+        # service-wide aggregates with one entry per (agent, minute, kind).
+        # ``current_seq`` is preserved as the high-water mark so pagination
+        # works even when no new payloads belong to this agent.
+        all_metrics = data.get("metrics") or []
+        agent_metrics = [
+            p for p in all_metrics if p.get("agent_id") == agent_id
+        ]
+        return {
+            "success": True,
+            "current_seq": int(data.get("current_seq", since_seq)),
+            "boot_id": data.get("boot_id") or "",
+            "metrics": agent_metrics,
         }
 
     @api_router.get("/api/agent-templates")

--- a/src/dashboard/static/js/app.js
+++ b/src/dashboard/static/js/app.js
@@ -193,6 +193,22 @@ function dashboard() {
     // emitted by BrowserManager._emit_metrics plus a receivedAt wall-clock
     // stamp the dashboard uses to flag stale rows.
     browserMetrics: {},
+    // Per-agent rolling history (Phase 7 §10.1). Keyed by agent_id; each
+    // value is an array of recent per-minute payloads (oldest → newest)
+    // capped by _BROWSER_METRICS_HISTORY_MAX. Seeded via
+    // GET /api/agents/{id}/browser/metrics on detail-panel open, then
+    // appended by the existing browser_metrics WS handler.
+    browserMetricsHistory: {},
+    // High-water seq per agent so subsequent fetches with ?since=N skip
+    // payloads we've already absorbed (panel re-open / hot reload).
+    _browserMetricsSeq: {},
+    // Boot id last seen per agent — when the browser service restarts the
+    // server-side seq counter resets, so we have to flush the local
+    // watermark to avoid missing the new payloads.
+    _browserMetricsBootId: {},
+    _browserMetricsLoading: {},
+    _browserMetricsError: {},
+    _BROWSER_METRICS_HISTORY_MAX: 60,  // ~1 hour at 60s emit cadence
 
     captchaSolverProvider: '',
     captchaSolverKeyMasked: '',
@@ -1450,6 +1466,10 @@ function dashboard() {
           ...this.browserMetrics,
           [evt.agent]: { ...evt.data, receivedAt: Date.now() },
         };
+        // Phase 7 §10.1 — also append to the per-agent rolling history so
+        // the detail panel can render trend sparklines without an extra
+        // fetch round-trip per tick.
+        this._appendBrowserMetricsHistory(evt.agent, evt.data);
       }
 
       // §6.3 navigator self-test result (one-shot per browser start).
@@ -5560,6 +5580,10 @@ function dashboard() {
       this.fetchIdentityFiles(agentId);
       this.fetchAgentConfig(agentId);
       this.fetchCronJobs();
+      // Phase 7 §10.1 — seed per-agent browser metrics history so the
+      // detail panel renders sparklines immediately on open. Subsequent
+      // updates flow through the existing browser_metrics WS handler.
+      this.fetchBrowserMetricsHistory(agentId);
       this.activeTab = 'fleet';
       if (!this._skipPush) this._pushUrl(false);
     },
@@ -5899,6 +5923,209 @@ function dashboard() {
       // Emit cadence is 60s, so a payload older than ~3 minutes means the
       // browser stopped or the poller broke.
       return receivedAt && Date.now() - receivedAt > 3 * 60 * 1000;
+    },
+
+    // ── Per-agent browser metrics panel (Phase 7 §10.1) ─────────────────
+    _appendBrowserMetricsHistory(agentId, payload) {
+      // §6.3 navigator-probe payloads also flow through `browser_metrics`
+      // when emitted as drain payloads, but the dashboard receives them as
+      // a separate `browser_nav_probe` event handled below — skip any
+      // probe-shaped payload here defensively so the trend bars only show
+      // per-minute drains.
+      if (!payload || payload.kind === 'nav_probe') return;
+      const existing = (this.browserMetricsHistory[agentId] || []).slice();
+      // Dedup by seq when present — WS replay (reconnect) plus the seed
+      // fetch both deliver the same payload; we want a single entry.
+      const seq = payload.seq;
+      if (seq != null && existing.some(p => p.seq === seq)) return;
+      existing.push({ ...payload, _receivedAt: Date.now() });
+      // Stable sort by seq (or ts as a fallback) to keep the rendered
+      // sparkline left-to-right ordered even if WS and HTTP fetch race.
+      existing.sort((a, b) => {
+        const sa = a.seq != null ? a.seq : (a.ts || 0);
+        const sb = b.seq != null ? b.seq : (b.ts || 0);
+        return sa - sb;
+      });
+      while (existing.length > this._BROWSER_METRICS_HISTORY_MAX) {
+        existing.shift();
+      }
+      this.browserMetricsHistory = {
+        ...this.browserMetricsHistory,
+        [agentId]: existing,
+      };
+      if (seq != null) {
+        this._browserMetricsSeq = {
+          ...this._browserMetricsSeq,
+          [agentId]: Math.max(this._browserMetricsSeq[agentId] || 0, seq),
+        };
+      }
+    },
+
+    async fetchBrowserMetricsHistory(agentId) {
+      // Seed the per-agent rolling history from the dashboard endpoint when
+      // the detail panel opens — WS events only deliver payloads received
+      // since this dashboard session started, so a freshly-loaded panel
+      // would otherwise show empty until the next 60s tick.
+      if (!agentId) return;
+      this._browserMetricsLoading = {
+        ...this._browserMetricsLoading,
+        [agentId]: true,
+      };
+      this._browserMetricsError = {
+        ...this._browserMetricsError,
+        [agentId]: '',
+      };
+      const since = this._browserMetricsSeq[agentId] || 0;
+      try {
+        const resp = await fetch(
+          `${window.__config.apiBase}/agents/${agentId}/browser/metrics?since=${since}`,
+        );
+        if (!resp.ok) {
+          this._browserMetricsError = {
+            ...this._browserMetricsError,
+            [agentId]: 'HTTP ' + resp.status,
+          };
+          return;
+        }
+        const data = await resp.json();
+        if (data.success === false) {
+          this._browserMetricsError = {
+            ...this._browserMetricsError,
+            [agentId]: (data.error && data.error.code) || 'unknown',
+          };
+          return;
+        }
+        // Boot-id change → server seq counter reset; flush local history
+        // so we don't render impossible gaps where seqs jumped backwards.
+        const prevBootId = this._browserMetricsBootId[agentId] || '';
+        if (data.boot_id && prevBootId && prevBootId !== data.boot_id) {
+          this.browserMetricsHistory = {
+            ...this.browserMetricsHistory,
+            [agentId]: [],
+          };
+          this._browserMetricsSeq = {
+            ...this._browserMetricsSeq,
+            [agentId]: 0,
+          };
+        }
+        this._browserMetricsBootId = {
+          ...this._browserMetricsBootId,
+          [agentId]: data.boot_id || '',
+        };
+        for (const p of data.metrics || []) {
+          this._appendBrowserMetricsHistory(agentId, p);
+        }
+        // Bump the high-water mark even when no payloads belonged to this
+        // agent so subsequent calls page forward.
+        const cs = data.current_seq || 0;
+        if (cs > (this._browserMetricsSeq[agentId] || 0)) {
+          this._browserMetricsSeq = {
+            ...this._browserMetricsSeq,
+            [agentId]: cs,
+          };
+        }
+      } catch (e) {
+        this._browserMetricsError = {
+          ...this._browserMetricsError,
+          [agentId]: 'network',
+        };
+      } finally {
+        this._browserMetricsLoading = {
+          ...this._browserMetricsLoading,
+          [agentId]: false,
+        };
+      }
+    },
+
+    browserHistoryFor(agentId) {
+      return this.browserMetricsHistory[agentId] || [];
+    },
+
+    browserHistoryClickRate(agentId) {
+      // Aggregate success rate over the rolling window — total successes /
+      // total clicks. Returns null when there's been no click traffic so
+      // the panel can render "—" instead of a misleading 0%.
+      const hist = this.browserHistoryFor(agentId);
+      let succ = 0;
+      let fail = 0;
+      for (const p of hist) {
+        succ += p.click_success || 0;
+        fail += p.click_fail || 0;
+      }
+      if (succ + fail === 0) return null;
+      return succ / (succ + fail);
+    },
+
+    browserHistorySnapshotCount(agentId) {
+      const hist = this.browserHistoryFor(agentId);
+      let total = 0;
+      for (const p of hist) total += p.snapshot_count || 0;
+      return total;
+    },
+
+    browserHistoryNavTimeouts(agentId) {
+      const hist = this.browserHistoryFor(agentId);
+      let total = 0;
+      for (const p of hist) total += p.nav_timeout || 0;
+      return total;
+    },
+
+    browserHistoryTrendArrow(agentId) {
+      // Compare the last data point's success rate to the second-to-last.
+      // Returns 'up' / 'down' / 'flat' / null. Fewer than two non-null
+      // points → null (no signal yet).
+      const hist = this.browserHistoryFor(agentId);
+      const ratios = [];
+      for (const p of hist) {
+        const denom = (p.click_success || 0) + (p.click_fail || 0);
+        if (denom > 0) {
+          ratios.push((p.click_success || 0) / denom);
+        }
+      }
+      if (ratios.length < 2) return null;
+      const last = ratios[ratios.length - 1];
+      const prev = ratios[ratios.length - 2];
+      const delta = last - prev;
+      if (Math.abs(delta) < 0.05) return 'flat';
+      return delta > 0 ? 'up' : 'down';
+    },
+
+    browserHistoryBars(agentId, field, max) {
+      // Build a list of {height, label, value} entries for the CSS sparkline.
+      // ``field`` is one of: 'snapshot_bytes_p50', 'snapshot_bytes_p95',
+      // 'snapshot_count', 'click_total' (computed). ``max`` clamps the
+      // upper bound for height normalization; null = autoscale.
+      const hist = this.browserHistoryFor(agentId);
+      if (hist.length === 0) return [];
+      const values = hist.map(p => {
+        if (field === 'click_total') {
+          return (p.click_success || 0) + (p.click_fail || 0);
+        }
+        return p[field] || 0;
+      });
+      const peak = max != null
+        ? max
+        : Math.max(1, ...values);
+      return values.map((v, i) => {
+        const heightPct = peak > 0 ? Math.min(100, (v / peak) * 100) : 0;
+        const p = hist[i];
+        return {
+          height: heightPct,
+          value: v,
+          ts: p.ts,
+          seq: p.seq,
+        };
+      });
+    },
+
+    browserHistoryActiveCount(agentId) {
+      // Active means we received a payload in the last 3 minutes (matches
+      // browserMetricsStale threshold) — instances that went idle drop to
+      // zero on the dashboard even though the BrowserManager may still
+      // hold a stopped CamoufoxInstance.
+      const last = this.browserMetrics[agentId];
+      if (!last) return 0;
+      return this.browserMetricsStale(last.receivedAt) ? 0 : 1;
     },
 
     eventDetail(evt) {

--- a/src/dashboard/static/js/app.js
+++ b/src/dashboard/static/js/app.js
@@ -1462,6 +1462,29 @@ function dashboard() {
       // from BrowserManager._emit_metrics — we just index it by agent_id
       // and stamp receipt time so stale rows can fade.
       if (evt.type === 'browser_metrics' && evt.agent && evt.data) {
+        // Phase 7 third-pass: if the mesh stamped a boot_id and it differs
+        // from the last one we saw, the browser service restarted — its
+        // seq counter reset to 0, so any history we accumulated is from
+        // a previous boot. Flush before appending so the dedup-by-seq
+        // path doesn't get fooled into mixing two counter generations.
+        const newBootId = evt.data.boot_id || '';
+        const prevBootId = this._browserMetricsBootId[evt.agent] || '';
+        if (newBootId && prevBootId && newBootId !== prevBootId) {
+          this.browserMetricsHistory = {
+            ...this.browserMetricsHistory,
+            [evt.agent]: [],
+          };
+          this._browserMetricsSeq = {
+            ...this._browserMetricsSeq,
+            [evt.agent]: 0,
+          };
+        }
+        if (newBootId) {
+          this._browserMetricsBootId = {
+            ...this._browserMetricsBootId,
+            [evt.agent]: newBootId,
+          };
+        }
         this.browserMetrics = {
           ...this.browserMetrics,
           [evt.agent]: { ...evt.data, receivedAt: Date.now() },
@@ -5975,7 +5998,21 @@ function dashboard() {
         ...this._browserMetricsError,
         [agentId]: '',
       };
-      const since = this._browserMetricsSeq[agentId] || 0;
+      // Phase 7 third-pass: always seed from seq=0 rather than the
+      // WS-derived high-water mark. The race we have to handle is:
+      // (1) WS subscribes at app boot and starts populating history
+      //     and `_browserMetricsSeq[agentId]` from live emits; then
+      // (2) operator opens the agent panel and calls this seeder.
+      // If we paginate from `_browserMetricsSeq[agentId]`, we'd ask
+      // upstream "give me payloads with seq > N" — and since N is
+      // the *latest* seq we already received via WS, we'd get an
+      // empty list, leaving the rolling-hour history that lived in
+      // the buffer BEFORE the panel opened invisible. The browser
+      // service ring buffer is bounded (1024 entries service-wide),
+      // so requesting from 0 is cheap; `_appendBrowserMetricsHistory`
+      // dedupes by seq so any overlap with WS-derived entries is a
+      // no-op.
+      const since = 0;
       try {
         const resp = await fetch(
           `${window.__config.apiBase}/agents/${agentId}/browser/metrics?since=${since}`,

--- a/src/dashboard/templates/index.html
+++ b/src/dashboard/templates/index.html
@@ -2859,6 +2859,131 @@
                 </div>
               </div>
             </div>
+            <!-- ═══ BROWSER METRICS PANEL (Phase 7 §10.1) ═══ -->
+            <!-- Per-agent rolling window of the per-minute aggregates from
+                 BrowserManager._emit_metrics. Read-only; gated on the agent
+                 having `can_use_browser`. Sparklines are pure CSS bars to
+                 stay aligned with the dashboard's no-charting-deps rule. -->
+            <template x-if="agentConfigs[selectedAgent]?.can_use_browser">
+              <div>
+                <div class="bg-gray-900 border border-gray-800 rounded-lg p-4">
+                  <div class="flex items-center justify-between mb-3">
+                    <div class="text-xs text-gray-500 uppercase tracking-wider flex items-center gap-1.5">
+                      Browser Health
+                      <span class="setting-hint" tabindex="0">?<span class="setting-hint-text">Per-minute aggregate of this agent's Camoufox browser activity. Click rate is success / total over the last hour; snapshot p50/p95 show the size distribution. Updates every ~60s — per-call events are intentionally not surfaced.</span></span>
+                    </div>
+                    <div class="flex items-center gap-2 text-[10px] text-gray-600">
+                      <span class="inline-flex items-center gap-1">
+                        <span class="w-1.5 h-1.5 rounded-full"
+                          :class="browserHistoryActiveCount(detailAgent) > 0 ? 'bg-green-400' : 'bg-gray-600'"></span>
+                        <span x-text="browserHistoryActiveCount(detailAgent) > 0 ? 'active' : 'idle'"></span>
+                      </span>
+                      <span>•</span>
+                      <span>updates every 60s</span>
+                    </div>
+                  </div>
+
+                  <!-- Error envelope (§2.3) -->
+                  <template x-if="_browserMetricsError[detailAgent]">
+                    <div class="text-[11px] text-amber-400 mb-3" x-text="'Could not fetch metrics: ' + _browserMetricsError[detailAgent]"></div>
+                  </template>
+
+                  <!-- Empty state -->
+                  <template x-if="browserHistoryFor(detailAgent).length === 0 && !_browserMetricsLoading[detailAgent]">
+                    <div class="text-[11px] text-gray-600 italic py-2">
+                      No browser activity yet. Metrics appear here ~60s after the agent first opens a page.
+                    </div>
+                  </template>
+
+                  <!-- Loading state on first fetch -->
+                  <template x-if="browserHistoryFor(detailAgent).length === 0 && _browserMetricsLoading[detailAgent]">
+                    <div class="text-[11px] text-gray-600 italic py-2">Loading browser metrics history…</div>
+                  </template>
+
+                  <template x-if="browserHistoryFor(detailAgent).length > 0">
+                    <div class="space-y-4">
+                      <!-- Headline stats -->
+                      <div class="grid grid-cols-2 sm:grid-cols-4 gap-2">
+                        <div class="bg-gray-800/50 rounded p-2.5">
+                          <div class="text-[10px] text-gray-500 uppercase tracking-wider mb-0.5">Click rate (1h)</div>
+                          <div class="flex items-baseline gap-1.5">
+                            <span class="text-lg font-bold font-mono"
+                              :class="clickRateColor(browserHistoryClickRate(detailAgent))"
+                              x-text="fmtClickRate(browserHistoryClickRate(detailAgent))"></span>
+                            <span class="text-xs"
+                              :class="{
+                                'text-green-400': browserHistoryTrendArrow(detailAgent) === 'up',
+                                'text-red-400': browserHistoryTrendArrow(detailAgent) === 'down',
+                                'text-gray-500': browserHistoryTrendArrow(detailAgent) === 'flat' || !browserHistoryTrendArrow(detailAgent)
+                              }"
+                              x-text="{up: '↑', down: '↓', flat: '→'}[browserHistoryTrendArrow(detailAgent)] || ''"></span>
+                          </div>
+                        </div>
+                        <div class="bg-gray-800/50 rounded p-2.5">
+                          <div class="text-[10px] text-gray-500 uppercase tracking-wider mb-0.5">Snapshots / hr</div>
+                          <div class="text-lg font-bold font-mono text-gray-200" x-text="browserHistorySnapshotCount(detailAgent)"></div>
+                        </div>
+                        <div class="bg-gray-800/50 rounded p-2.5">
+                          <div class="text-[10px] text-gray-500 uppercase tracking-wider mb-0.5">Snap p95 (last)</div>
+                          <div class="text-lg font-bold font-mono text-gray-200"
+                            x-text="fmtBytes(browserMetrics[detailAgent]?.snapshot_bytes_p95)"></div>
+                        </div>
+                        <div class="bg-gray-800/50 rounded p-2.5">
+                          <div class="text-[10px] text-gray-500 uppercase tracking-wider mb-0.5">Nav timeouts (1h)</div>
+                          <div class="text-lg font-bold font-mono"
+                            :class="browserHistoryNavTimeouts(detailAgent) > 0 ? 'text-amber-400' : 'text-gray-300'"
+                            x-text="browserHistoryNavTimeouts(detailAgent)"></div>
+                        </div>
+                      </div>
+
+                      <!-- Sparkline: clicks per minute -->
+                      <div>
+                        <div class="flex items-center justify-between mb-1.5">
+                          <span class="text-[10px] text-gray-500 uppercase tracking-wider">Clicks / minute</span>
+                          <span class="text-[10px] text-gray-600" x-text="browserHistoryFor(detailAgent).length + ' samples'"></span>
+                        </div>
+                        <div class="flex items-end gap-0.5 h-10 bg-gray-800/30 rounded px-1 py-1">
+                          <template x-for="(bar, idx) in browserHistoryBars(detailAgent, 'click_total', null)" :key="bar.seq != null ? bar.seq : ('i' + idx)">
+                            <div class="flex-1 min-w-0 bg-indigo-500/70 rounded-sm hover:bg-indigo-400 transition-colors"
+                              :style="'height: ' + Math.max(4, bar.height) + '%'"
+                              :title="bar.value + ' clicks'"></div>
+                          </template>
+                        </div>
+                      </div>
+
+                      <!-- Sparkline: snapshot p50 size -->
+                      <div>
+                        <div class="flex items-center justify-between mb-1.5">
+                          <span class="text-[10px] text-gray-500 uppercase tracking-wider">Snapshot p50 size</span>
+                        </div>
+                        <div class="flex items-end gap-0.5 h-10 bg-gray-800/30 rounded px-1 py-1">
+                          <template x-for="(bar, idx) in browserHistoryBars(detailAgent, 'snapshot_bytes_p50', null)" :key="bar.seq != null ? bar.seq : ('p50i' + idx)">
+                            <div class="flex-1 min-w-0 bg-cyan-500/60 rounded-sm hover:bg-cyan-400 transition-colors"
+                              :style="'height: ' + Math.max(4, bar.height) + '%'"
+                              :title="fmtBytes(bar.value)"></div>
+                          </template>
+                        </div>
+                      </div>
+
+                      <!-- Sparkline: snapshot p95 size -->
+                      <div>
+                        <div class="flex items-center justify-between mb-1.5">
+                          <span class="text-[10px] text-gray-500 uppercase tracking-wider">Snapshot p95 size</span>
+                        </div>
+                        <div class="flex items-end gap-0.5 h-10 bg-gray-800/30 rounded px-1 py-1">
+                          <template x-for="(bar, idx) in browserHistoryBars(detailAgent, 'snapshot_bytes_p95', null)" :key="bar.seq != null ? bar.seq : ('p95i' + idx)">
+                            <div class="flex-1 min-w-0 bg-amber-500/60 rounded-sm hover:bg-amber-400 transition-colors"
+                              :style="'height: ' + Math.max(4, bar.height) + '%'"
+                              :title="fmtBytes(bar.value)"></div>
+                          </template>
+                        </div>
+                      </div>
+                    </div>
+                  </template>
+                </div>
+              </div>
+            </template>
+
             <!-- ═══ AGENT AUTOMATIONS (cron jobs for this agent) ═══ -->
             <div>
               <div class="bg-gray-900 border border-gray-800 rounded-lg p-4">

--- a/src/host/server.py
+++ b/src/host/server.py
@@ -2816,7 +2816,18 @@ def create_mesh_app(
                 if payload.get("kind") == "nav_probe"
                 else "browser_metrics"
             )
-            event_bus.emit(event_type, agent=agent_id, data=payload)
+            # Stamp boot_id into the per-payload event data so the dashboard
+            # can detect a browser-service restart mid-session and flush its
+            # local history (otherwise post-restart seq=1..N would interleave
+            # with stale pre-restart entries — the dedup-by-seq path on the
+            # JS side wouldn't catch it because the seqs don't collide,
+            # they're just from a different counter generation). The mesh
+            # poller already resets its own watermark on boot_id change
+            # above; this propagates the same signal one hop further.
+            event_data = (
+                {**payload, "boot_id": boot_id} if boot_id else payload
+            )
+            event_bus.emit(event_type, agent=agent_id, data=event_data)
 
     async def _browser_metrics_loop() -> None:
         # First pass runs ~5s after boot to give the browser service time

--- a/src/shared/types.py
+++ b/src/shared/types.py
@@ -352,6 +352,12 @@ class DashboardEvent(BaseModel):
         "browser_login_request",
         "browser_login_completed",
         "browser_login_cancelled",
+        # Phase 4 §4.6 / Phase 7 §10.1 — per-minute browser aggregates
+        # forwarded from the browser service to the dashboard via
+        # _poll_browser_metrics_once. Without these literals
+        # DashboardEvent rejects the emit and the panel never renders.
+        "browser_metrics",
+        "browser_nav_probe",
     ]
     agent: str = ""
     timestamp: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))

--- a/tests/test_dashboard_browser_metrics.py
+++ b/tests/test_dashboard_browser_metrics.py
@@ -441,6 +441,156 @@ class TestBrowserMetricsEventBusContract:
         assert captured[0]["agent"] == "alpha"
         assert captured[0]["data"]["click_success"] == 1
 
+    def test_payload_shape_contract(self):
+        """Pin the WS event payload shape — the dashboard JS reads each of
+        these keys directly. A future refactor that drops or renames any
+        of them silently breaks the panel (Alpine renders ``undefined`` as
+        empty string, which looks like "no data" to the operator).
+
+        This is the single contract test gate the JS side relies on.
+        """
+        from src.dashboard.events import EventBus
+
+        # Canonical payload as produced by BrowserManager._emit_metrics.
+        # Every key here is read by app.js — see browserHistoryBars,
+        # browserHistoryClickRate, browserHistoryNavTimeouts, and the
+        # detail-panel template (Snap p95, etc.).
+        canonical = {
+            "agent_id": "alpha",
+            "seq": 7,
+            "ts": 1234567890.0,
+            "click_success": 5,
+            "click_fail": 1,
+            "snapshot_count": 4,
+            "snapshot_bytes_p50": 1024,
+            "snapshot_bytes_p95": 4096,
+            "nav_timeout": 0,
+            "click_success_rate_100": 0.83,
+            "click_window_size": 6,
+        }
+        # JS-side keys we cannot lose without breaking renders.
+        required_keys = {
+            "agent_id", "seq", "ts",
+            "click_success", "click_fail",
+            "snapshot_count", "snapshot_bytes_p50", "snapshot_bytes_p95",
+            "nav_timeout",
+            "click_success_rate_100", "click_window_size",
+        }
+        for k in required_keys:
+            assert k in canonical, f"required JS-side key missing: {k}"
+
+        # Round-trip through the EventBus to make sure none of the keys
+        # get dropped by Pydantic validation (DashboardEvent.data is
+        # ``dict[str, Any]`` so this is mostly a smoke check, but a future
+        # refactor that swaps to a typed model would surface here).
+        bus = EventBus()
+        bus.emit("browser_metrics", agent="alpha", data=canonical)
+        emitted = [e for e in bus.recent_events()
+                   if e["type"] == "browser_metrics"][0]
+        for k in required_keys:
+            assert k in emitted["data"]
+
+    @staticmethod
+    def _build_mesh_for_poll_test(tmp_path: str):
+        """Mirror tests/test_browser_metrics_ingest._build_mesh — minimal
+        mesh app with a fake container_manager pointing at a fake browser
+        service URL. Returns ``(app, event_bus)``.
+        """
+        from src.host.mesh import MessageRouter, PubSub
+        from src.host.permissions import PermissionMatrix
+        from src.host.server import create_mesh_app
+
+        blackboard = Blackboard(os.path.join(tmp_path, "bb.db"))
+        pubsub = PubSub()
+        permissions = PermissionMatrix()
+        router = MessageRouter(permissions, {})
+        costs = CostTracker(os.path.join(tmp_path, "costs.db"))
+        traces = TraceStore(os.path.join(tmp_path, "traces.db"))
+
+        cm = MagicMock()
+        cm.browser_service_url = "http://browser-svc:8500"
+        cm.browser_auth_token = ""
+
+        event_bus = MagicMock()
+        app = create_mesh_app(
+            blackboard=blackboard,
+            pubsub=pubsub,
+            router=router,
+            permissions=permissions,
+            cost_tracker=costs,
+            trace_store=traces,
+            event_bus=event_bus,
+            container_manager=cm,
+        )
+        return app, event_bus, blackboard, costs, traces
+
+    def test_poll_stamps_boot_id_into_emitted_payload(self):
+        """Phase 7 third-pass — mesh poller stamps ``boot_id`` into each
+        per-payload emit so the dashboard JS can detect a browser-service
+        restart mid-session. Without this, post-restart seq=1..N events
+        interleave with stale pre-restart entries on the operator's panel.
+
+        We reach into the startup handler's closure to call the poller
+        directly (same trick the existing ingest test uses to avoid the
+        5s sleep at the start of the poll loop).
+        """
+        import asyncio
+
+        import httpx
+
+        tmp = tempfile.mkdtemp()
+        try:
+            app, event_bus, bb, costs, traces = (
+                self._build_mesh_for_poll_test(tmp)
+            )
+
+            canned = {
+                "current_seq": 1,
+                "boot_id": "boot-XYZ",
+                "metrics": [{
+                    "seq": 1, "ts": 1.0, "agent_id": "alpha",
+                    "click_success": 1, "click_fail": 0, "nav_timeout": 0,
+                    "snapshot_count": 0, "snapshot_bytes_p50": 0,
+                    "snapshot_bytes_p95": 0, "click_window_size": 0,
+                    "click_success_rate_100": None,
+                }],
+            }
+
+            async def fake_get(self, url, *args, **kwargs):
+                req = httpx.Request("GET", url)
+                return httpx.Response(200, json=canned, request=req)
+
+            with mock.patch.object(httpx.AsyncClient, "get", fake_get):
+                poll_fn = app.state.poll_browser_metrics_once
+                # Fresh loop per call — asyncio.run() refuses to run
+                # inside an already-running loop, but TestClient hasn't
+                # opened one for this test path.
+                loop = asyncio.new_event_loop()
+                try:
+                    loop.run_until_complete(poll_fn())
+                finally:
+                    loop.close()
+
+            calls = [c for c in event_bus.emit.call_args_list
+                     if c.args and c.args[0] == "browser_metrics"]
+            assert len(calls) == 1
+            data = calls[0].kwargs["data"]
+            assert data.get("boot_id") == "boot-XYZ", (
+                "mesh poller must stamp boot_id into per-payload "
+                "browser_metrics emits so dashboard JS can detect a "
+                "browser service restart"
+            )
+            # Original payload fields must still be present alongside boot_id.
+            assert data.get("agent_id") == "alpha"
+            assert data.get("seq") == 1
+            assert data.get("click_success") == 1
+
+            bb.close()
+            costs.close()
+            traces.close()
+        finally:
+            shutil.rmtree(tmp, ignore_errors=True)
+
 
 # ── §10.2: max_concurrent env-var resolution ───────────────────────────────
 

--- a/tests/test_dashboard_browser_metrics.py
+++ b/tests/test_dashboard_browser_metrics.py
@@ -1,0 +1,500 @@
+"""Tests for the per-agent browser-metrics dashboard panel (Phase 7 §10.1).
+
+Covers the new ``GET /dashboard/api/agents/{id}/browser/metrics`` endpoint
+plus regression coverage for the existing WS event publication path
+(``_poll_browser_metrics_once`` already has its own integration test in
+``tests/test_browser_metrics_ingest.py`` — we only assert the wiring point
+here so we'd notice if the contract drifts).
+
+Also covers Phase 7 §10.2: the env-var read at
+``src/browser/__main__._resolve_max_browsers`` honors
+``OPENLEGION_BROWSER_MAX_CONCURRENT`` with the legacy ``MAX_BROWSERS``
+fallback and a default of 5.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import tempfile
+from unittest import mock
+from unittest.mock import AsyncMock, MagicMock
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from src.dashboard.events import EventBus
+from src.host.costs import CostTracker
+from src.host.health import HealthMonitor
+from src.host.mesh import Blackboard
+from src.host.traces import TraceStore
+
+# ── Test fixtures (mirror tests/test_dashboard.py patterns) ─────────────────
+
+
+def _make_components(tmp_path: str) -> dict:
+    bb = Blackboard(db_path=os.path.join(tmp_path, "bb.db"))
+    cost_tracker = CostTracker(db_path=os.path.join(tmp_path, "costs.db"))
+    trace_store = TraceStore(db_path=os.path.join(tmp_path, "traces.db"))
+    event_bus = EventBus()
+    agent_registry: dict[str, str] = {
+        "alpha": "http://localhost:8401",
+        "beta": "http://localhost:8402",
+    }
+    runtime_mock = MagicMock()
+    # The endpoint short-circuits to a `service_unavailable` envelope when
+    # this is unset; tests that exercise the upstream-fetch path patch it.
+    runtime_mock.browser_vnc_url = None
+    runtime_mock.browser_service_url = None
+    runtime_mock.browser_auth_token = ""
+    transport_mock = MagicMock()
+    router_mock = MagicMock()
+    health_monitor = HealthMonitor(
+        runtime=runtime_mock, transport=transport_mock, router=router_mock,
+    )
+    health_monitor.register("alpha")
+    health_monitor.register("beta")
+    return {
+        "blackboard": bb,
+        "health_monitor": health_monitor,
+        "cost_tracker": cost_tracker,
+        "trace_store": trace_store,
+        "event_bus": event_bus,
+        "agent_registry": agent_registry,
+        "runtime": runtime_mock,
+    }
+
+
+class _CSRFTestClient(TestClient):
+    """TestClient that auto-injects the X-Requested-With CSRF header."""
+
+    def request(self, method, url, **kwargs):
+        if method.upper() not in ("GET", "HEAD", "OPTIONS"):
+            headers = kwargs.get("headers") or {}
+            if "X-Requested-With" not in headers:
+                headers["X-Requested-With"] = "XMLHttpRequest"
+                kwargs["headers"] = headers
+        return super().request(method, url, **kwargs)
+
+
+def _make_client(components: dict) -> TestClient:
+    from src.dashboard.server import create_dashboard_router
+
+    router = create_dashboard_router(**components, mesh_port=8420)
+    app = FastAPI()
+    app.include_router(router)
+    return _CSRFTestClient(app)
+
+
+def _teardown(components: dict) -> None:
+    components["cost_tracker"].close()
+    components["trace_store"].close()
+    components["blackboard"].close()
+
+
+# ── Endpoint behaviour ─────────────────────────────────────────────────────
+
+
+class TestBrowserMetricsEndpoint:
+    """Phase 7 §10.1 — per-agent browser-metrics endpoint."""
+
+    def setup_method(self):
+        self._tmpdir = tempfile.mkdtemp()
+        self.components = _make_components(self._tmpdir)
+        self.client = _make_client(self.components)
+
+    def teardown_method(self):
+        _teardown(self.components)
+        shutil.rmtree(self._tmpdir, ignore_errors=True)
+
+    def test_unknown_agent_returns_404(self):
+        resp = self.client.get(
+            "/dashboard/api/agents/does-not-exist/browser/metrics",
+        )
+        assert resp.status_code == 404
+
+    def test_no_browser_service_returns_envelope(self):
+        # runtime.browser_service_url is None — the endpoint must not 500;
+        # it must return the §2.3 error envelope so the panel can degrade.
+        resp = self.client.get(
+            "/dashboard/api/agents/alpha/browser/metrics",
+        )
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["success"] is False
+        assert body["error"]["code"] == "service_unavailable"
+        assert "Browser service" in body["error"]["message"]
+
+    def test_returns_filtered_metrics(self):
+        """Endpoint returns only payloads for the requested agent."""
+        runtime = self.components["runtime"]
+        runtime.browser_service_url = "http://browser:8500"
+        runtime.browser_auth_token = "tok"
+
+        # Build a fake upstream response with two agents' metrics.
+        upstream = {
+            "current_seq": 7,
+            "boot_id": "boot-1",
+            "metrics": [
+                {"agent_id": "alpha", "seq": 5, "click_success": 3,
+                 "click_fail": 0, "snapshot_count": 2,
+                 "snapshot_bytes_p50": 1000, "snapshot_bytes_p95": 2000,
+                 "nav_timeout": 0, "click_success_rate_100": 1.0,
+                 "click_window_size": 3, "ts": 1000.0},
+                {"agent_id": "beta", "seq": 6, "click_success": 1,
+                 "click_fail": 0, "snapshot_count": 1,
+                 "snapshot_bytes_p50": 500, "snapshot_bytes_p95": 800,
+                 "nav_timeout": 0, "click_success_rate_100": 1.0,
+                 "click_window_size": 1, "ts": 1001.0},
+                {"agent_id": "alpha", "seq": 7, "click_success": 2,
+                 "click_fail": 1, "snapshot_count": 1,
+                 "snapshot_bytes_p50": 1100, "snapshot_bytes_p95": 1500,
+                 "nav_timeout": 0, "click_success_rate_100": 0.83,
+                 "click_window_size": 6, "ts": 1002.0},
+            ],
+        }
+
+        captured: dict = {}
+
+        async def _fake_fetch(client, service_url, auth_token, since_seq):
+            captured["service_url"] = service_url
+            captured["auth_token"] = auth_token
+            captured["since_seq"] = since_seq
+            return {"success": True, "data": upstream}
+
+        with mock.patch(
+            "src.dashboard.server._fetch_browser_metrics_upstream",
+            side_effect=_fake_fetch,
+        ):
+            resp = self.client.get(
+                "/dashboard/api/agents/alpha/browser/metrics",
+            )
+
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["success"] is True
+        assert body["current_seq"] == 7
+        assert body["boot_id"] == "boot-1"
+        # Only alpha's payloads — beta filtered out.
+        assert len(body["metrics"]) == 2
+        assert all(p["agent_id"] == "alpha" for p in body["metrics"])
+        seqs = [p["seq"] for p in body["metrics"]]
+        assert seqs == [5, 7]
+        # Confirm runtime values were forwarded.
+        assert captured["service_url"] == "http://browser:8500"
+        assert captured["auth_token"] == "tok"
+        assert captured["since_seq"] == 0
+
+    def test_pagination_via_since_param(self):
+        """``since=N`` is forwarded to the upstream helper unchanged."""
+        runtime = self.components["runtime"]
+        runtime.browser_service_url = "http://browser:8500"
+
+        captured: dict = {}
+
+        async def _fake_fetch(client, service_url, auth_token, since_seq):
+            captured["since_seq"] = since_seq
+            return {
+                "success": True,
+                "data": {
+                    "current_seq": 42, "boot_id": "b", "metrics": [],
+                },
+            }
+
+        with mock.patch(
+            "src.dashboard.server._fetch_browser_metrics_upstream",
+            side_effect=_fake_fetch,
+        ):
+            resp = self.client.get(
+                "/dashboard/api/agents/alpha/browser/metrics?since=12",
+            )
+
+        assert resp.status_code == 200
+        assert captured["since_seq"] == 12
+        assert resp.json()["current_seq"] == 42
+
+    def test_negative_since_clamped_to_zero(self):
+        runtime = self.components["runtime"]
+        runtime.browser_service_url = "http://browser:8500"
+
+        captured: dict = {}
+
+        async def _fake_fetch(client, service_url, auth_token, since_seq):
+            captured["since_seq"] = since_seq
+            return {
+                "success": True,
+                "data": {"current_seq": 0, "boot_id": "b", "metrics": []},
+            }
+
+        with mock.patch(
+            "src.dashboard.server._fetch_browser_metrics_upstream",
+            side_effect=_fake_fetch,
+        ):
+            resp = self.client.get(
+                "/dashboard/api/agents/alpha/browser/metrics?since=-99",
+            )
+        assert resp.status_code == 200
+        assert captured["since_seq"] == 0
+
+    def test_upstream_error_returns_envelope(self):
+        runtime = self.components["runtime"]
+        runtime.browser_service_url = "http://browser:8500"
+
+        async def _fake_fetch(*args, **kwargs):
+            return {
+                "success": False,
+                "error": {
+                    "code": "service_unavailable",
+                    "message": "Browser service unreachable",
+                    "retry_after_ms": 60_000,
+                },
+            }
+
+        with mock.patch(
+            "src.dashboard.server._fetch_browser_metrics_upstream",
+            side_effect=_fake_fetch,
+        ):
+            resp = self.client.get(
+                "/dashboard/api/agents/alpha/browser/metrics",
+            )
+
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["success"] is False
+        assert body["error"]["code"] == "service_unavailable"
+        assert body["error"]["retry_after_ms"] == 60_000
+
+    def test_no_metrics_for_agent_returns_empty_list(self):
+        """When the upstream payload has data for *other* agents only."""
+        runtime = self.components["runtime"]
+        runtime.browser_service_url = "http://browser:8500"
+
+        async def _fake_fetch(*args, **kwargs):
+            return {
+                "success": True,
+                "data": {
+                    "current_seq": 99,
+                    "boot_id": "b",
+                    "metrics": [
+                        {"agent_id": "beta", "seq": 50,
+                         "click_success": 1, "click_fail": 0},
+                    ],
+                },
+            }
+
+        with mock.patch(
+            "src.dashboard.server._fetch_browser_metrics_upstream",
+            side_effect=_fake_fetch,
+        ):
+            resp = self.client.get(
+                "/dashboard/api/agents/alpha/browser/metrics",
+            )
+
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["success"] is True
+        assert body["metrics"] == []
+        # current_seq still bumps so the client paginates forward.
+        assert body["current_seq"] == 99
+
+    def test_get_does_not_require_csrf_header(self):
+        """GET endpoints are safe methods; no CSRF requirement."""
+        # Bypass the auto-injecting test client by going through the bare
+        # FastAPI app — the dashboard router is GET-exempt for X-Requested-With.
+        from src.dashboard.server import create_dashboard_router
+
+        router = create_dashboard_router(
+            **self.components, mesh_port=8420,
+        )
+        app = FastAPI()
+        app.include_router(router)
+        plain = TestClient(app)
+        resp = plain.get("/dashboard/api/agents/alpha/browser/metrics")
+        # No CSRF rejection — service envelope (no browser configured).
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["success"] is False
+
+
+# ── Upstream helper coverage (network / HTTP / JSON errors) ────────────────
+
+
+class TestFetchBrowserMetricsUpstream:
+    """Direct coverage for ``_fetch_browser_metrics_upstream`` — the helper
+    the endpoint delegates to. Tested separately so the §2.3 envelope is
+    pinned at the boundary rather than re-asserted in every endpoint test.
+    """
+
+    def _run(self, coro):
+        import asyncio
+        return asyncio.get_event_loop().run_until_complete(coro)
+
+    def test_network_failure_returns_envelope(self):
+        from src.dashboard.server import _fetch_browser_metrics_upstream
+
+        client = MagicMock()
+        client.get = AsyncMock(side_effect=RuntimeError("connection refused"))
+        result = self._run(_fetch_browser_metrics_upstream(
+            client, "http://browser:8500", "tok", 0,
+        ))
+        assert result["success"] is False
+        assert result["error"]["code"] == "service_unavailable"
+        assert result["error"]["retry_after_ms"] == 60_000
+
+    def test_http_error_returns_envelope(self):
+        from src.dashboard.server import _fetch_browser_metrics_upstream
+
+        mock_resp = MagicMock()
+        mock_resp.status_code = 502
+        mock_resp.json = MagicMock(return_value={})
+        client = MagicMock()
+        client.get = AsyncMock(return_value=mock_resp)
+        result = self._run(_fetch_browser_metrics_upstream(
+            client, "http://browser:8500", "tok", 0,
+        ))
+        assert result["success"] is False
+        assert "502" in result["error"]["message"]
+
+    def test_bad_json_returns_envelope(self):
+        from src.dashboard.server import _fetch_browser_metrics_upstream
+
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.json = MagicMock(side_effect=ValueError("bad json"))
+        client = MagicMock()
+        client.get = AsyncMock(return_value=mock_resp)
+        result = self._run(_fetch_browser_metrics_upstream(
+            client, "http://browser:8500", "", 0,
+        ))
+        assert result["success"] is False
+        assert "Malformed" in result["error"]["message"]
+
+    def test_success_includes_data(self):
+        from src.dashboard.server import _fetch_browser_metrics_upstream
+
+        upstream = {"current_seq": 5, "boot_id": "b", "metrics": []}
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.json = MagicMock(return_value=upstream)
+        client = MagicMock()
+        client.get = AsyncMock(return_value=mock_resp)
+        result = self._run(_fetch_browser_metrics_upstream(
+            client, "http://browser:8500", "tok", 7,
+        ))
+        assert result["success"] is True
+        assert result["data"] == upstream
+        # Auth header forwarded.
+        called_kwargs = client.get.await_args.kwargs
+        assert called_kwargs["headers"]["Authorization"] == "Bearer tok"
+        assert called_kwargs["params"] == {"since": 7}
+
+    def test_no_auth_token_omits_header(self):
+        from src.dashboard.server import _fetch_browser_metrics_upstream
+
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.json = MagicMock(return_value={
+            "current_seq": 0, "boot_id": "", "metrics": [],
+        })
+        client = MagicMock()
+        client.get = AsyncMock(return_value=mock_resp)
+        self._run(_fetch_browser_metrics_upstream(
+            client, "http://browser:8500", "", 0,
+        ))
+        called_kwargs = client.get.await_args.kwargs
+        # Empty token → no Authorization header.
+        assert "Authorization" not in (called_kwargs.get("headers") or {})
+
+
+# ── WS event publication regression check ──────────────────────────────────
+
+
+class TestBrowserMetricsEventBusContract:
+    """Make sure the dashboard renderer's input contract stays intact.
+
+    The Alpine panel reads from ``browser_metrics`` events on the EventBus
+    via the existing ``/ws/events`` channel — the panel does NOT add a new
+    transport. This test pins that wiring so a future refactor that drops
+    the event-name doesn't silently break the dashboard.
+    """
+
+    def test_event_bus_emit_browser_metrics_routes_to_subscribers(self):
+        from src.dashboard.events import EventBus
+
+        bus = EventBus()
+        captured: list[dict] = []
+
+        # Fake subscription via direct buffer inspection — we don't need
+        # the WebSocket here, just to confirm the event-name plumbing.
+        bus.emit("browser_metrics", agent="alpha", data={
+            "agent_id": "alpha", "seq": 1, "click_success": 1,
+            "click_fail": 0, "snapshot_count": 1,
+            "snapshot_bytes_p50": 100, "snapshot_bytes_p95": 200,
+            "nav_timeout": 0, "click_success_rate_100": 1.0,
+            "click_window_size": 1,
+        })
+        captured = [
+            e for e in bus.recent_events()
+            if e["type"] == "browser_metrics"
+        ]
+        assert len(captured) == 1
+        assert captured[0]["agent"] == "alpha"
+        assert captured[0]["data"]["click_success"] == 1
+
+
+# ── §10.2: max_concurrent env-var resolution ───────────────────────────────
+
+
+class TestMaxConcurrentEnvVar:
+    """Phase 7 §10.2 — startup-only ``OPENLEGION_BROWSER_MAX_CONCURRENT``."""
+
+    def test_default_when_unset(self):
+        # Importing inside the test so each invocation gets a fresh read
+        # against the patched environment.
+        with mock.patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("OPENLEGION_BROWSER_MAX_CONCURRENT", None)
+            os.environ.pop("MAX_BROWSERS", None)
+            from src.browser.__main__ import _resolve_max_browsers
+            assert _resolve_max_browsers() == 5
+
+    def test_canonical_var_wins(self):
+        with mock.patch.dict(os.environ, {
+            "OPENLEGION_BROWSER_MAX_CONCURRENT": "12",
+            "MAX_BROWSERS": "3",
+        }):
+            from src.browser.__main__ import _resolve_max_browsers
+            assert _resolve_max_browsers() == 12
+
+    def test_legacy_var_used_when_canonical_unset(self):
+        with mock.patch.dict(os.environ, {"MAX_BROWSERS": "9"}, clear=False):
+            os.environ.pop("OPENLEGION_BROWSER_MAX_CONCURRENT", None)
+            from src.browser.__main__ import _resolve_max_browsers
+            assert _resolve_max_browsers() == 9
+
+    def test_clamped_to_min(self):
+        with mock.patch.dict(os.environ, {
+            "OPENLEGION_BROWSER_MAX_CONCURRENT": "0",
+        }):
+            from src.browser.__main__ import _resolve_max_browsers
+            assert _resolve_max_browsers() == 1  # clamped up
+
+    def test_clamped_to_max(self):
+        with mock.patch.dict(os.environ, {
+            "OPENLEGION_BROWSER_MAX_CONCURRENT": "9999",
+        }):
+            from src.browser.__main__ import _resolve_max_browsers
+            assert _resolve_max_browsers() == 64  # clamped down
+
+    def test_garbage_falls_back_to_default(self):
+        with mock.patch.dict(os.environ, {
+            "OPENLEGION_BROWSER_MAX_CONCURRENT": "not-a-number",
+        }):
+            os.environ.pop("MAX_BROWSERS", None)
+            from src.browser.__main__ import _resolve_max_browsers
+            # flags.get_int falls back to its default (legacy) which is 5
+            # when MAX_BROWSERS is also absent.
+            assert _resolve_max_browsers() == 5
+
+    def test_env_var_documented_in_known_flags(self):
+        from src.browser.flags import KNOWN_FLAGS
+        assert "OPENLEGION_BROWSER_MAX_CONCURRENT" in KNOWN_FLAGS


### PR DESCRIPTION
## Summary

**§10.1 Operator metrics dashboard panel** — surfaces per-agent browser-metrics counters (already collected per §4.6) on the dashboard's per-agent panel via a new dashboard endpoint that proxies the existing browser-service metrics, plus an Alpine partial with CSS-bar sparklines (no charting deps). New endpoint: `GET /dashboard/api/agents/{agent_id}/browser/metrics?since=<seq>` with auth + agent filter + pagination.

**§10.2 `OPENLEGION_BROWSER_MAX_CONCURRENT`** — wired through `src/browser/flags.py:get_int` with `[1, 64]` clamp at the existing `_resolve_max_browsers()` site, legacy `MAX_BROWSERS` retained as fallback. Documented as startup-only (operators restart browser service to change).

**Bug fix found while wiring** — `DashboardEvent.type` Literal in `src/shared/types.py` was missing `browser_metrics` and `browser_nav_probe`. Both event names were already being emitted by `host/server.py:2819`; Pydantic was silently rejecting them so the panel would never have received data. New contract test pins the event-type Literal so this can't regress.

Plan: `docs/plans/2026-04-20-browser-automation.md` §10.1, §10.2.

## Test plan

- [x] 21 new tests in `tests/test_dashboard_browser_metrics.py` — endpoint behavior, agent filter, pagination, since clamping, error envelope, no-CSRF on GET, upstream helper failure modes (network/HTTP/JSON), event-bus contract pin, `_resolve_max_browsers` precedence + clamping + garbage handling.
- [x] Wider regression sweep across `test_dashboard.py + test_browser_service.py + test_events.py + test_browser_metrics.py + test_browser_metrics_ingest.py + test_browser_flags.py + test_types.py + test_browser_canary.py + test_browser_nav_probe.py + test_browser_recorder.py + test_browser_trace_propagation.py + test_dashboard_workspace.py + test_dashboard_auth.py + test_integration.py + test_loop.py + test_chat.py` — all green.
- [x] `ruff check src/ tests/test_dashboard_browser_metrics.py` — clean.
- [x] Jinja template renders without errors; new panel section present.