### PR TITLE
Phase 8 §11.13: structured CAPTCHA detection envelope

### DIFF
--- a/src/agent/builtins/browser_tool.py
+++ b/src/agent/builtins/browser_tool.py
@@ -975,10 +975,18 @@ async def browser_inspect_requests(
 @skill(
     name="browser_detect_captcha",
     description=(
-        "Detect CAPTCHAs (reCAPTCHA, hCaptcha, Cloudflare Turnstile) on the "
-        "current page. When a CAPTCHA solver is configured, CAPTCHAs are "
-        "solved automatically after navigation. If auto-solving fails or no "
-        "solver is configured, the CAPTCHA must be solved manually via VNC."
+        "Detect CAPTCHAs (reCAPTCHA, hCaptcha, Cloudflare Turnstile, etc.) "
+        "on the current page. When a CAPTCHA solver is configured, "
+        "CAPTCHAs are solved automatically after navigation. Returns the "
+        "structured envelope: data.captcha_found is the primary signal; "
+        "when true, also inspect data.kind (e.g. 'recaptcha-v2-checkbox', "
+        "'turnstile', 'cf-interstitial-auto', 'unknown'), "
+        "data.solver_outcome ('solved', 'no_solver', 'timeout', "
+        "'rejected', ...), and data.next_action ('solved', 'wait', "
+        "'notify_user', 'request_captcha_help', ...). The legacy "
+        "data.type and data.message fields remain for back-compat but are "
+        "deprecated — prefer the structured fields. solver_outcome=='solved' "
+        "means no agent action is required; the captcha was already cleared."
     ),
     parameters={},
     parallel_safe=False,

--- a/src/browser/service.py
+++ b/src/browser/service.py
@@ -54,6 +54,78 @@ logger = setup_logging("browser.service")
 # enum would either need a json encoder shim or repr-leak risk. Strings
 # also keep the §11.1 / §11.3 / §11.16 / §11.18 follow-ups as pure data
 # changes — no type plumbing.
+#
+# Enum reference (kept here so future PRs editing the helpers see the full
+# vocabulary at a glance):
+#
+#   kind:
+#     "recaptcha-v2-checkbox" | "recaptcha-v2-invisible" | "recaptcha-v3"
+#     | "recaptcha-enterprise" | "hcaptcha" | "turnstile"
+#     | "cf-interstitial-auto" | "cf-interstitial-behavioral" | "unknown"
+#     §11.1 lands the four reCAPTCHA variants; §11.3 lands the CF tri-state.
+#     This PR ships the placeholder values only.
+#
+#   solver_outcome:
+#     "solved" | "timeout" | "rejected" | "injection_failed"
+#     | "no_solver" | "unsupported"
+#     - solved: token retrieved AND injected (or no injection needed).
+#     - timeout: solver did not return a verdict in time.
+#     - rejected: solver concluded the captcha cannot be solved (provider
+#       errorId, sitekey not extractable, polling exhausted, OR — until the
+#       solver API is enriched per Concern #10 below — a successful token
+#       fetch followed by a failed injection that we cannot distinguish at
+#       this layer).
+#     - injection_failed: token fetched but injection rejected.
+#       *RESERVED* — the current ``CaptchaSolver.solve()`` returns ``bool``,
+#       so this layer cannot disambiguate it from ``rejected``. Wired up
+#       once the solver returns a richer result (planned alongside §11.18).
+#     - no_solver: no provider configured (``CAPTCHA_SOLVER_PROVIDER`` empty).
+#     - unsupported: detected kind has no solver path. *RESERVED* until the
+#       kind→provider matrix lands.
+#
+#   solver_confidence:
+#     "high" | "medium" | "low" | "behavioral-only"
+#     Reflects confidence in the *report* (kind classification + outcome
+#     joint). Solved → "high"; timeout / exception / placeholder kinds →
+#     "low" or "medium". "behavioral-only" is *RESERVED* for §11.18 — used
+#     when no real captcha widget is shown and only the behavioral
+#     fingerprint is the signal.
+#
+#   next_action:
+#     "solved" | "wait" | "notify_user" | "request_captcha_help" | "ignored"
+#     - "ignored" is *RESERVED* — emitted in the future for low-importance
+#       captchas (analytics consent, ad-iframe captchas, etc.) that the
+#       agent can safely skip. No code path emits it today.
+
+# Selector-classification confidence: the two firmly-disambiguated kinds
+# below have unambiguous selectors today. The reCAPTCHA / CF placeholders
+# remain "low" until §11.1 / §11.3 land variant detection.
+_FIRM_KINDS = frozenset({"hcaptcha", "turnstile"})
+
+
+def _kind_confidence(kind: str) -> str:
+    """Default ``solver_confidence`` for a no-solver path, derived from how
+    confidently we classified the *kind*. Placeholder kinds (§11.1 / §11.3)
+    map to "low"; firmly-disambiguated kinds map to "high"; "unknown" → "low".
+    """
+    if kind in _FIRM_KINDS:
+        return "high"
+    return "low"
+
+
+def _is_httpx_timeout(exc: BaseException) -> bool:
+    """Detect httpx.TimeoutException without making httpx a hard import in
+    this module. ``httpx`` is already a transitive dep (used by the bundled
+    ``CaptchaSolver`` in src/browser/captcha.py); third-party solver
+    subclasses may also raise its exceptions. The local import keeps service
+    startup cheap when httpx hasn't been pulled in yet.
+    """
+    try:
+        import httpx  # noqa: PLC0415 — local-import is intentional
+    except Exception:
+        return False
+    return isinstance(exc, httpx.TimeoutException)
+
 
 def _captcha_envelope(
     *,
@@ -67,7 +139,9 @@ def _captcha_envelope(
     """Build the §11.13 ``data`` block for a found-captcha case.
 
     ``injection_failure_reason`` must be ``None`` unless
-    ``solver_outcome == "injection_failed"``.
+    ``solver_outcome == "injection_failed"``. The field is always present
+    (set to ``None`` rather than absent) so downstream consumers can rely
+    on a stable shape.
     """
     return {
         "captcha_found": True,
@@ -84,6 +158,10 @@ def _with_legacy_fields(envelope: dict) -> dict:
     """Soft-deprecated shim — populate the old ``type`` / ``message`` fields
     so agents whose rules still match against the freeform string keep
     working. New agents should read the structured fields directly.
+
+    Applied uniformly to BOTH the captcha-found and no-captcha cases — the
+    old shape was ``{captcha_found: false, message: "No CAPTCHA detected"}``
+    (no ``type`` field) so we only re-add ``message`` for that branch.
     """
     out = dict(envelope)
     if not out.get("captcha_found"):
@@ -5296,13 +5374,35 @@ class BrowserManager:
                                 inst.page, sel, inst.page.url,
                             )
                         except asyncio.TimeoutError:
+                            # Solver took too long — true "timeout" semantic.
                             return _captcha_envelope(
                                 kind=kind, solver_attempted=True,
                                 solver_outcome="timeout",
                                 solver_confidence="low",
                                 next_action="notify_user",
                             )
-                        except Exception:
+                        except Exception as exc:
+                            # Network / JSON-decode / programmer errors all
+                            # land here. A third-party CaptchaSolver subclass
+                            # could let httpx errors bubble up; the bundled
+                            # ``CaptchaSolver`` (src/browser/captcha.py)
+                            # swallows them and returns False instead. We
+                            # treat httpx timeouts as "timeout" and other
+                            # exceptions as "rejected" — closest fit in the
+                            # §11.13 enum (no "service_error" exists). A
+                            # richer SolverResult that distinguishes
+                            # transport vs verdict failure is planned
+                            # alongside §11.18.
+                            if _is_httpx_timeout(exc):
+                                logger.warning(
+                                    "Auto-solve timed out (httpx): %r", exc,
+                                )
+                                return _captcha_envelope(
+                                    kind=kind, solver_attempted=True,
+                                    solver_outcome="timeout",
+                                    solver_confidence="low",
+                                    next_action="notify_user",
+                                )
                             logger.exception("Auto-solve raised, falling back")
                             return _captcha_envelope(
                                 kind=kind, solver_attempted=True,
@@ -5317,6 +5417,15 @@ class BrowserManager:
                                 solver_confidence="high",
                                 next_action="solved",
                             )
+                        # solver.solve() returned False. Today this conflates
+                        # three failure modes: (a) provider verdict reject /
+                        # errorId>0, (b) sitekey not extractable, (c) token
+                        # fetched but injection failed. The §11.13 spec
+                        # reserves ``injection_failed`` for case (c), but
+                        # the solver surface returns plain bool — we cannot
+                        # distinguish without a richer return type. Map all
+                        # three to ``rejected`` for now and revisit once the
+                        # solver returns structured results.
                         logger.warning("Auto-solve failed, falling back to manual")
                         return _captcha_envelope(
                             kind=kind, solver_attempted=True,
@@ -5325,10 +5434,15 @@ class BrowserManager:
                             next_action="notify_user",
                         )
                     # No solver configured — surface to agent for manual VNC.
+                    # Confidence reflects how firmly we classified the kind:
+                    # firmly-disambiguated kinds (hcaptcha, turnstile) →
+                    # "high"; placeholders (recaptcha-v2-checkbox,
+                    # cf-interstitial-auto) and "unknown" → "low" until
+                    # §11.1 / §11.3 land variant detection.
                     return _captcha_envelope(
                         kind=kind, solver_attempted=False,
                         solver_outcome="no_solver",
-                        solver_confidence="high" if kind != "unknown" else "low",
+                        solver_confidence=_kind_confidence(kind),
                         next_action="notify_user",
                     )
         except Exception:

--- a/src/browser/service.py
+++ b/src/browser/service.py
@@ -47,6 +47,57 @@ from src.shared.utils import sanitize_for_prompt, setup_logging
 
 logger = setup_logging("browser.service")
 
+
+# ── §11.13 structured CAPTCHA detection envelope ──────────────────────────
+# Both helpers below produce literal-string enums (see plan §11.13). We do
+# NOT use Python ``enum.Enum``: the wire format is JSON strings, and a real
+# enum would either need a json encoder shim or repr-leak risk. Strings
+# also keep the §11.1 / §11.3 / §11.16 / §11.18 follow-ups as pure data
+# changes — no type plumbing.
+
+def _captcha_envelope(
+    *,
+    kind: str,
+    solver_attempted: bool,
+    solver_outcome: str,
+    solver_confidence: str,
+    next_action: str,
+    injection_failure_reason: str | None = None,
+) -> dict:
+    """Build the §11.13 ``data`` block for a found-captcha case.
+
+    ``injection_failure_reason`` must be ``None`` unless
+    ``solver_outcome == "injection_failed"``.
+    """
+    return {
+        "captcha_found": True,
+        "kind": kind,
+        "solver_attempted": solver_attempted,
+        "solver_outcome": solver_outcome,
+        "injection_failure_reason": injection_failure_reason,
+        "solver_confidence": solver_confidence,
+        "next_action": next_action,
+    }
+
+
+def _with_legacy_fields(envelope: dict) -> dict:
+    """Soft-deprecated shim — populate the old ``type`` / ``message`` fields
+    so agents whose rules still match against the freeform string keep
+    working. New agents should read the structured fields directly.
+    """
+    out = dict(envelope)
+    if not out.get("captcha_found"):
+        out.setdefault("message", "No CAPTCHA detected")
+        return out
+    kind = out.get("kind", "unknown")
+    next_action = out.get("next_action", "notify_user")
+    out["type"] = kind  # kept for back-compat; was a CSS selector before.
+    out["message"] = (
+        f"CAPTCHA detected of kind {kind}; next_action: {next_action}"
+    )
+    return out
+
+
 _ACTIONABLE_ROLES = frozenset({
     "button", "link", "textbox", "checkbox", "radio", "combobox",
     "searchbox", "slider", "spinbutton", "switch", "tab", "menuitem",
@@ -2521,10 +2572,16 @@ class BrowserManager:
                         "body": "",
                     },
                 }
-                # Auto-detect CAPTCHAs so the agent knows immediately
-                captcha = await self._check_captcha(inst)
-                if captcha:
-                    result["captcha"] = captcha
+                # Auto-detect CAPTCHAs so the agent knows immediately.
+                # _check_captcha now always returns the §11.13 envelope:
+                # only surface to the agent when something actually needs
+                # their attention (found AND not auto-solved).
+                envelope = await self._check_captcha(inst)
+                if (
+                    envelope.get("captcha_found")
+                    and envelope.get("solver_outcome") != "solved"
+                ):
+                    result["captcha"] = _with_legacy_fields(envelope)
                 snapshot_succeeded = False
                 if snapshot_after:
                     snap = await self._snapshot_impl(inst, agent_id)
@@ -5203,11 +5260,21 @@ class BrowserManager:
             except Exception as e:
                 return {"success": False, "error": str(e)}
 
-    async def _check_captcha(self, inst: CamoufoxInstance) -> dict | None:
+    async def _check_captcha(self, inst: CamoufoxInstance) -> dict:
         """Check for CAPTCHA elements and attempt auto-solve if configured.
 
-        Returns a dict with captcha details if found and unsolved, None if
-        no CAPTCHA or if it was solved automatically.
+        Returns the §11.13 structured envelope ``data`` block in all cases:
+          - ``{"captcha_found": false}`` when no captcha selector matched.
+          - ``{"captcha_found": true, "kind": ..., "solver_attempted": ...,
+                "solver_outcome": ..., "injection_failure_reason": ...,
+                "solver_confidence": ..., "next_action": ...}`` otherwise.
+
+        Callers should treat ``solver_outcome == "solved"`` as "no agent
+        action needed" — the captcha was detected but already cleared.
+
+        NOTE: classification here is minimal — it maps the matched selector
+        onto the §11.13 ``kind`` enum. Full reCAPTCHA v2/v3/Enterprise
+        disambiguation lands in §11.1; CF interstitial tri-state in §11.3.
         """
         captcha_selectors = [
             'iframe[src*="recaptcha"]',
@@ -5221,37 +5288,92 @@ class BrowserManager:
         try:
             for sel in captcha_selectors:
                 if await inst.page.locator(sel).count() > 0:
-                    # Attempt auto-solve if a solver is configured
+                    kind = self._classify_kind(sel)
                     if self._captcha_solver:
                         logger.info("CAPTCHA detected (%s), attempting auto-solve", sel)
-                        solved = await self._captcha_solver.solve(
-                            inst.page, sel, inst.page.url,
-                        )
+                        try:
+                            solved = await self._captcha_solver.solve(
+                                inst.page, sel, inst.page.url,
+                            )
+                        except asyncio.TimeoutError:
+                            return _captcha_envelope(
+                                kind=kind, solver_attempted=True,
+                                solver_outcome="timeout",
+                                solver_confidence="low",
+                                next_action="notify_user",
+                            )
+                        except Exception:
+                            logger.exception("Auto-solve raised, falling back")
+                            return _captcha_envelope(
+                                kind=kind, solver_attempted=True,
+                                solver_outcome="rejected",
+                                solver_confidence="low",
+                                next_action="notify_user",
+                            )
                         if solved:
-                            return None  # solved — don't report to agent
+                            return _captcha_envelope(
+                                kind=kind, solver_attempted=True,
+                                solver_outcome="solved",
+                                solver_confidence="high",
+                                next_action="solved",
+                            )
                         logger.warning("Auto-solve failed, falling back to manual")
-
-                    return {
-                        "type": sel,
-                        "message": (
-                            "CAPTCHA detected — you cannot bypass this. "
-                            "Use notify_user to ask the user for help, "
-                            "then wait before retrying."
-                        ),
-                    }
+                        return _captcha_envelope(
+                            kind=kind, solver_attempted=True,
+                            solver_outcome="rejected",
+                            solver_confidence="low",
+                            next_action="notify_user",
+                        )
+                    # No solver configured — surface to agent for manual VNC.
+                    return _captcha_envelope(
+                        kind=kind, solver_attempted=False,
+                        solver_outcome="no_solver",
+                        solver_confidence="high" if kind != "unknown" else "low",
+                        next_action="notify_user",
+                    )
         except Exception:
-            pass
-        return None
+            logger.debug("captcha detection raised", exc_info=True)
+        return {"captcha_found": False}
+
+    def _classify_kind(self, selector: str) -> str:
+        """Map the matched selector onto a §11.13 ``kind`` value.
+
+        Minimal classification — see §11.1 for the full reCAPTCHA variant
+        and §11.3 for the CF interstitial tri-state work that will refine
+        these placeholders.
+        """
+        if "recaptcha" in selector:
+            # v2-checkbox is the dominant case; v2-invisible/v3/Enterprise
+            # disambiguation lives in §11.1.
+            return "recaptcha-v2-checkbox"
+        if "hcaptcha" in selector:
+            return "hcaptcha"
+        if "challenges.cloudflare.com" in selector:
+            # Default to the auto-resolving JS challenge until §11.3 lands
+            # full tri-state (auto / behavioral / turnstile-embedded)
+            # detection.
+            return "cf-interstitial-auto"
+        if "cf-turnstile" in selector:
+            return "turnstile"
+        # Generic 'captcha' selectors and #captcha fall through to unknown.
+        return "unknown"
 
     async def detect_captcha(self, agent_id: str) -> dict:
-        """Detect CAPTCHAs on the current page."""
+        """Detect CAPTCHAs on the current page.
+
+        Returns the §11.13 envelope. The legacy ``type`` and ``message``
+        fields are populated for backward compatibility with rules that
+        condition on the old shape; new agents should read the structured
+        fields directly.
+        """
         inst = await self.get_or_start(agent_id)
         inst.touch()
         async with inst.lock:
-            captcha = await self._check_captcha(inst)
-            if captcha:
-                return {"success": True, "data": {"captcha_found": True, **captcha}}
-            return {"success": True, "data": {"captcha_found": False, "message": "No CAPTCHA detected"}}
+            envelope = await self._check_captcha(inst)
+            return {
+                "success": True,
+                "data": _with_legacy_fields(envelope),
+            }
 
     # ── File transfer (Phase 1.5 infrastructure) ─────────────────────────
 

--- a/src/browser/service.py
+++ b/src/browser/service.py
@@ -4786,7 +4786,12 @@ class BrowserManager:
 
                 # Post-click CAPTCHA re-detection — coordinate clicks
                 # frequently land on interstitial challenge widgets.
-                captcha = await self._check_captcha(inst)
+                # _check_captcha now always returns the §11.13 envelope
+                # (truthy even with no captcha), so we must explicitly
+                # check ``captcha_found`` AND skip auto-solved cases —
+                # only surface to the agent when something actually
+                # needs their attention.
+                envelope = await self._check_captcha(inst)
 
                 inst.m_click_success += 1
                 inst.click_window.append(True)
@@ -4802,8 +4807,11 @@ class BrowserManager:
                         },
                     },
                 }
-                if captcha:
-                    result["data"]["captcha"] = captcha
+                if (
+                    envelope.get("captcha_found")
+                    and envelope.get("solver_outcome") != "solved"
+                ):
+                    result["data"]["captcha"] = _with_legacy_fields(envelope)
                 return result
             except Exception as e:
                 inst.m_click_fail += 1
@@ -5995,10 +6003,17 @@ class BrowserManager:
                     # itself (rare — e.g. a JS challenge that injects on
                     # every navigation). Check before continuing so we
                     # don't keep pummeling a blocked page with snapshots.
-                    captcha = await self._check_captcha(inst)
-                    if captcha:
+                    # _check_captcha now always returns the §11.13 envelope
+                    # (truthy even with no captcha); only stop the loop
+                    # when a captcha was actually found AND not auto-solved.
+                    envelope = await self._check_captcha(inst)
+                    if (
+                        envelope.get("captcha_found")
+                        and envelope.get("solver_outcome") != "solved"
+                    ):
                         return self._fill_form_captcha_envelope(
-                            filled, normalized[i + 1:], captcha,
+                            filled, normalized[i + 1:],
+                            _with_legacy_fields(envelope),
                             submitted=submitted,
                         )
                     continue
@@ -6103,10 +6118,17 @@ class BrowserManager:
                 #    Captcha mid-flow takes priority over top-level
                 #    submit_after: we never auto-submit a half-completed
                 #    form behind a captcha.
-                captcha = await self._check_captcha(inst)
-                if captcha:
+                #    _check_captcha now always returns the §11.13 envelope
+                #    (truthy even with no captcha); only break out when a
+                #    captcha was actually found AND not auto-solved.
+                envelope = await self._check_captcha(inst)
+                if (
+                    envelope.get("captcha_found")
+                    and envelope.get("solver_outcome") != "solved"
+                ):
                     return self._fill_form_captcha_envelope(
-                        filled, normalized[i + 1:], captcha,
+                        filled, normalized[i + 1:],
+                        _with_legacy_fields(envelope),
                         submitted=submitted,
                     )
 

--- a/tests/test_browser_click_xy.py
+++ b/tests/test_browser_click_xy.py
@@ -88,10 +88,16 @@ class TestClickXyHappyPath:
             "masked_by": None, "mask_reason": "",
         })
         mgr = _make_mgr_with(inst)
-        mgr._check_captcha = AsyncMock(return_value=None)
+        # §11.13: ``_check_captcha`` now always returns the structured
+        # envelope; the no-captcha shape is ``{"captcha_found": False}``.
+        mgr._check_captcha = AsyncMock(return_value={"captcha_found": False})
 
-        await mgr.click_xy("a1", x=1, y=1)
+        result = await mgr.click_xy("a1", x=1, y=1)
         mgr._check_captcha.assert_awaited_once_with(inst)
+        # No-captcha envelope must NOT be surfaced as ``captcha`` on the
+        # success path — that field is reserved for "agent must act".
+        assert result["success"] is True
+        assert "captcha" not in result["data"]
 
     @pytest.mark.asyncio
     async def test_click_xy_success_increments_metrics(self):

--- a/tests/test_browser_fill_form.py
+++ b/tests/test_browser_fill_form.py
@@ -77,7 +77,8 @@ class TestFillFormHappyPath:
              patch.object(BrowserManager, "_locator_from_ref",
                           new_callable=AsyncMock, return_value=loc), \
              patch.object(BrowserManager, "_check_captcha",
-                          new_callable=AsyncMock, return_value=None), \
+                          new_callable=AsyncMock,
+                          return_value={"captcha_found": False}), \
              patch.object(BrowserManager, "_snapshot_impl", new=_fake_snapshot):
             result = await mgr.fill_form(
                 "agent1",
@@ -113,7 +114,8 @@ class TestFillFormHappyPath:
              patch.object(BrowserManager, "_locator_from_ref",
                           new_callable=AsyncMock, return_value=loc), \
              patch.object(BrowserManager, "_check_captcha",
-                          new_callable=AsyncMock, return_value=None), \
+                          new_callable=AsyncMock,
+                          return_value={"captcha_found": False}), \
              patch.object(BrowserManager, "_snapshot_impl", new=_fake_snapshot):
             result = await mgr.fill_form(
                 "agent1",
@@ -136,6 +138,7 @@ class TestFillFormCaptchaMidFlow:
 
     @pytest.mark.asyncio
     async def test_captcha_after_first_field_stops_loop(self):
+        from src.browser.service import _with_legacy_fields
         mgr = _make_manager()
         refs = {
             "e0": {"role": "textbox", "name": "Email", "index": 0, "disabled": False},
@@ -144,11 +147,20 @@ class TestFillFormCaptchaMidFlow:
         }
         inst = _make_instance(refs)
         loc = _make_locator()
-        captcha_blob = {"type": "iframe[src*=recaptcha]", "message": "CAPTCHA"}
+        # §11.13 envelope shape — ``_check_captcha`` always returns this.
+        captcha_envelope = {
+            "captcha_found": True,
+            "kind": "recaptcha-v2-checkbox",
+            "solver_attempted": False,
+            "solver_outcome": "no_solver",
+            "injection_failure_reason": None,
+            "solver_confidence": "low",
+            "next_action": "notify_user",
+        }
 
         # Captcha appears after the first fill; subsequent calls would also
         # report it, but the loop should bail before the second find_text.
-        check_captcha_mock = AsyncMock(return_value=captcha_blob)
+        check_captcha_mock = AsyncMock(return_value=captcha_envelope)
 
         with patch.object(BrowserManager, "get_or_start", return_value=inst), \
              patch.object(BrowserManager, "_locator_from_ref",
@@ -181,7 +193,11 @@ class TestFillFormCaptchaMidFlow:
         assert data["remaining"][1] == {
             "label": "Phone", "value": "555", "submit_after": False,
         }
-        assert data["captcha"] == captcha_blob
+        # Captcha echoed as the §11.13 envelope with legacy ``type`` /
+        # ``message`` fields appended for back-compat.
+        assert data["captcha"] == _with_legacy_fields(captcha_envelope)
+        assert data["captcha"]["captcha_found"] is True
+        assert data["captcha"]["kind"] == "recaptcha-v2-checkbox"
         assert data["submitted"] is False
         # Only one fill should have happened — the loop bailed.
         assert loc.fill.await_count == 1
@@ -203,11 +219,19 @@ class TestFillFormCaptchaMidFlow:
         }
         inst = _make_instance(refs)
         loc = _make_locator()
-        captcha_blob = {"type": "iframe[src*=recaptcha]", "message": "CAPTCHA"}
+        captcha_envelope = {
+            "captcha_found": True,
+            "kind": "recaptcha-v2-checkbox",
+            "solver_attempted": False,
+            "solver_outcome": "no_solver",
+            "injection_failure_reason": None,
+            "solver_confidence": "low",
+            "next_action": "notify_user",
+        }
 
         # No captcha after fill, captcha appears AFTER per-field Enter.
         # _check_captcha is called once per field (after fill+optional Enter).
-        check_captcha_mock = AsyncMock(return_value=captcha_blob)
+        check_captcha_mock = AsyncMock(return_value=captcha_envelope)
 
         with patch.object(BrowserManager, "get_or_start", return_value=inst), \
              patch.object(BrowserManager, "_locator_from_ref",
@@ -246,13 +270,22 @@ class TestFillFormCaptchaMidFlow:
         }
         inst = _make_instance(refs)
         loc = _make_locator()
-        captcha_blob = {"type": "iframe[src*=hcaptcha]", "message": "CAPTCHA"}
+        captcha_envelope = {
+            "captcha_found": True,
+            "kind": "hcaptcha",
+            "solver_attempted": False,
+            "solver_outcome": "no_solver",
+            "injection_failure_reason": None,
+            "solver_confidence": "high",
+            "next_action": "notify_user",
+        }
 
         with patch.object(BrowserManager, "get_or_start", return_value=inst), \
              patch.object(BrowserManager, "_locator_from_ref",
                           new_callable=AsyncMock, return_value=loc), \
              patch.object(BrowserManager, "_check_captcha",
-                          new_callable=AsyncMock, return_value=captcha_blob), \
+                          new_callable=AsyncMock,
+                          return_value=captcha_envelope), \
              patch.object(BrowserManager, "_snapshot_impl", new=_fake_snapshot):
             result = await mgr.fill_form(
                 "agent1",
@@ -294,7 +327,8 @@ class TestFillFormFieldFailures:
              patch.object(BrowserManager, "_locator_from_ref",
                           new_callable=AsyncMock, return_value=loc), \
              patch.object(BrowserManager, "_check_captcha",
-                          new_callable=AsyncMock, return_value=None), \
+                          new_callable=AsyncMock,
+                          return_value={"captcha_found": False}), \
              patch.object(BrowserManager, "_snapshot_impl", new=_fake_snapshot):
             result = await mgr.fill_form(
                 "agent1",
@@ -335,7 +369,8 @@ class TestFillFormFieldFailures:
         with patch.object(BrowserManager, "get_or_start", return_value=inst), \
              patch.object(BrowserManager, "_locator_from_ref", new=fake_locator), \
              patch.object(BrowserManager, "_check_captcha",
-                          new_callable=AsyncMock, return_value=None), \
+                          new_callable=AsyncMock,
+                          return_value={"captcha_found": False}), \
              patch.object(BrowserManager, "_snapshot_impl", new=_fake_snapshot):
             result = await mgr.fill_form(
                 "agent1",
@@ -375,7 +410,8 @@ class TestFillFormFieldFailures:
         with patch.object(BrowserManager, "get_or_start", return_value=inst), \
              patch.object(BrowserManager, "_locator_from_ref", new=fake_locator), \
              patch.object(BrowserManager, "_check_captcha",
-                          new_callable=AsyncMock, return_value=None), \
+                          new_callable=AsyncMock,
+                          return_value={"captcha_found": False}), \
              patch.object(BrowserManager, "_snapshot_impl", new=_fake_snapshot):
             result = await mgr.fill_form(
                 "agent1",
@@ -413,7 +449,8 @@ class TestFillFormFieldFailures:
         with patch.object(BrowserManager, "get_or_start", return_value=inst), \
              patch.object(BrowserManager, "_locator_from_ref", new=fake_locator), \
              patch.object(BrowserManager, "_check_captcha",
-                          new_callable=AsyncMock, return_value=None), \
+                          new_callable=AsyncMock,
+                          return_value={"captcha_found": False}), \
              patch.object(BrowserManager, "_snapshot_impl", new=_fake_snapshot):
             result = await mgr.fill_form(
                 "agent1",
@@ -547,7 +584,8 @@ class TestFillFormPerFieldSubmit:
              patch.object(BrowserManager, "_locator_from_ref",
                           new_callable=AsyncMock, return_value=loc), \
              patch.object(BrowserManager, "_check_captcha",
-                          new_callable=AsyncMock, return_value=None), \
+                          new_callable=AsyncMock,
+                          return_value={"captcha_found": False}), \
              patch.object(BrowserManager, "_snapshot_impl", new=_fake_snapshot):
             result = await mgr.fill_form(
                 "agent1",
@@ -581,10 +619,19 @@ class TestFillFormResume:
         }
         inst = _make_instance(refs)
         loc = _make_locator()
-        captcha_blob = {"type": "iframe[src*=recaptcha]", "message": "CAPTCHA"}
+        captcha_envelope = {
+            "captcha_found": True,
+            "kind": "recaptcha-v2-checkbox",
+            "solver_attempted": False,
+            "solver_outcome": "no_solver",
+            "injection_failure_reason": None,
+            "solver_confidence": "low",
+            "next_action": "notify_user",
+        }
+        no_captcha = {"captcha_found": False}
 
         # First call: captcha appears after Email fill.
-        check_seq = iter([captcha_blob, None, None])
+        check_seq = iter([captcha_envelope, no_captcha, no_captcha])
 
         async def fake_check(_self, _inst):
             return next(check_seq)
@@ -653,7 +700,8 @@ class TestFillFormConcurrency:
              patch.object(BrowserManager, "_locator_from_ref",
                           new_callable=AsyncMock, return_value=loc), \
              patch.object(BrowserManager, "_check_captcha",
-                          new_callable=AsyncMock, return_value=None), \
+                          new_callable=AsyncMock,
+                          return_value={"captcha_found": False}), \
              patch.object(BrowserManager, "_snapshot_impl", new=_fake_snapshot):
             r1, r2 = await asyncio.gather(
                 mgr.fill_form("agent1", [{"label": "Email", "value": "a"}]),
@@ -709,7 +757,8 @@ class TestFillFormErrorClassification:
              patch.object(BrowserManager, "_locator_from_ref",
                           new_callable=AsyncMock, return_value=loc), \
              patch.object(BrowserManager, "_check_captcha",
-                          new_callable=AsyncMock, return_value=None), \
+                          new_callable=AsyncMock,
+                          return_value={"captcha_found": False}), \
              patch.object(BrowserManager, "_snapshot_impl", new=_fake_snapshot):
             result = await mgr.fill_form(
                 "agent1",
@@ -735,7 +784,8 @@ class TestFillFormErrorClassification:
              patch.object(BrowserManager, "_locator_from_ref",
                           new_callable=AsyncMock, return_value=loc), \
              patch.object(BrowserManager, "_check_captcha",
-                          new_callable=AsyncMock, return_value=None), \
+                          new_callable=AsyncMock,
+                          return_value={"captcha_found": False}), \
              patch.object(BrowserManager, "_snapshot_impl", new=_fake_snapshot):
             result = await mgr.fill_form(
                 "agent1",
@@ -760,7 +810,8 @@ class TestFillFormErrorClassification:
              patch.object(BrowserManager, "_locator_from_ref",
                           new_callable=AsyncMock, return_value=loc), \
              patch.object(BrowserManager, "_check_captcha",
-                          new_callable=AsyncMock, return_value=None), \
+                          new_callable=AsyncMock,
+                          return_value={"captcha_found": False}), \
              patch.object(BrowserManager, "_snapshot_impl", new=_fake_snapshot):
             result = await mgr.fill_form(
                 "agent1",
@@ -794,7 +845,8 @@ class TestFillFormSubmitEdgeCases:
              patch.object(BrowserManager, "_locator_from_ref",
                           new_callable=AsyncMock, return_value=loc), \
              patch.object(BrowserManager, "_check_captcha",
-                          new_callable=AsyncMock, return_value=None), \
+                          new_callable=AsyncMock,
+                          return_value={"captcha_found": False}), \
              patch.object(BrowserManager, "_snapshot_impl", new=_fake_snapshot):
             result = await mgr.fill_form(
                 "agent1",
@@ -830,7 +882,8 @@ class TestFillFormSubmitEdgeCases:
              patch.object(BrowserManager, "_locator_from_ref",
                           new_callable=AsyncMock, return_value=loc), \
              patch.object(BrowserManager, "_check_captcha",
-                          new_callable=AsyncMock, return_value=None), \
+                          new_callable=AsyncMock,
+                          return_value={"captcha_found": False}), \
              patch.object(BrowserManager, "_snapshot_impl", new=_fake_snapshot):
             result = await mgr.fill_form(
                 "agent1",
@@ -867,7 +920,8 @@ class TestFillFormSubmitEdgeCases:
              patch.object(BrowserManager, "_locator_from_ref",
                           new_callable=AsyncMock, return_value=loc), \
              patch.object(BrowserManager, "_check_captcha",
-                          new_callable=AsyncMock, return_value=None), \
+                          new_callable=AsyncMock,
+                          return_value={"captcha_found": False}), \
              patch.object(BrowserManager, "_snapshot_impl", new=_fake_snapshot):
             result = await mgr.fill_form(
                 "agent1",
@@ -904,7 +958,8 @@ class TestFillFormValueAndLabelHandling:
              patch.object(BrowserManager, "_locator_from_ref",
                           new_callable=AsyncMock, return_value=loc), \
              patch.object(BrowserManager, "_check_captcha",
-                          new_callable=AsyncMock, return_value=None), \
+                          new_callable=AsyncMock,
+                          return_value={"captcha_found": False}), \
              patch.object(BrowserManager, "_snapshot_impl", new=_fake_snapshot):
             result = await mgr.fill_form(
                 "agent1",
@@ -943,7 +998,8 @@ class TestFillFormValueAndLabelHandling:
              patch.object(BrowserManager, "_locator_from_ref",
                           new_callable=AsyncMock, return_value=loc), \
              patch.object(BrowserManager, "_check_captcha",
-                          new_callable=AsyncMock, return_value=None), \
+                          new_callable=AsyncMock,
+                          return_value={"captcha_found": False}), \
              patch.object(BrowserManager, "_snapshot_impl", new=_fake_snapshot):
             result = await mgr.fill_form(
                 "agent1",

--- a/tests/test_browser_service.py
+++ b/tests/test_browser_service.py
@@ -4825,7 +4825,12 @@ class TestCaptchaDetection:
 
         assert result["success"] is True
         assert result["data"]["captcha_found"] is True
-        assert "challenges.cloudflare.com" in result["data"]["type"]
+        # New §11.13 envelope: the cloudflare iframe selector classifies
+        # to the cf-interstitial-auto placeholder kind. §11.3 will refine
+        # this into the proper tri-state.
+        assert result["data"]["kind"] == "cf-interstitial-auto"
+        # Legacy field still populated as the kind value for back-compat.
+        assert result["data"]["type"] == "cf-interstitial-auto"
 
     @pytest.mark.asyncio
     async def test_no_captcha(self):
@@ -7280,7 +7285,7 @@ class TestCheckCaptchaAutoSolve:
 
     @pytest.mark.asyncio
     async def test_check_captcha_auto_solves(self):
-        """When solver succeeds, _check_captcha returns None (no CAPTCHA reported)."""
+        """When solver succeeds, the §11.13 envelope reports solver_outcome='solved'."""
         manager = BrowserManager(profiles_dir="/tmp/test_profiles_captcha1")
 
         mock_solver = AsyncMock()
@@ -7296,12 +7301,14 @@ class TestCheckCaptchaAutoSolve:
         inst.page.url = "https://example.com"
 
         result = await manager._check_captcha(inst)
-        assert result is None  # solved — not reported
+        assert result["captcha_found"] is True
+        assert result["solver_outcome"] == "solved"
+        assert result["next_action"] == "solved"
         mock_solver.solve.assert_called_once()
 
     @pytest.mark.asyncio
     async def test_check_captcha_falls_back_on_failure(self):
-        """When solver fails, _check_captcha returns fallback dict."""
+        """When solver fails, _check_captcha reports solver_outcome='rejected'."""
         manager = BrowserManager(profiles_dir="/tmp/test_profiles_captcha2")
 
         mock_solver = AsyncMock()
@@ -7315,8 +7322,10 @@ class TestCheckCaptchaAutoSolve:
         inst.page.url = "https://example.com"
 
         result = await manager._check_captcha(inst)
-        assert result is not None
-        assert "CAPTCHA detected" in result["message"]
+        assert result["captcha_found"] is True
+        assert result["solver_attempted"] is True
+        assert result["solver_outcome"] == "rejected"
+        assert result["next_action"] == "notify_user"
         mock_solver.solve.assert_called_once()
 
 

--- a/tests/test_captcha_envelope.py
+++ b/tests/test_captcha_envelope.py
@@ -96,13 +96,16 @@ class TestRecaptchaNoSolver:
         mgr = _make_manager(solver=None)
         inst = _make_inst('iframe[src*="recaptcha"]')
         result = await mgr._check_captcha(inst)
+        # ``recaptcha-v2-checkbox`` is a §11.1 placeholder until reCAPTCHA
+        # variant disambiguation lands; we cannot vouch for the exact
+        # subtype yet, so confidence is "low".
         assert result == {
             "captcha_found": True,
             "kind": "recaptcha-v2-checkbox",
             "solver_attempted": False,
             "solver_outcome": "no_solver",
             "injection_failure_reason": None,
-            "solver_confidence": "high",
+            "solver_confidence": "low",
             "next_action": "notify_user",
         }
 
@@ -304,3 +307,265 @@ class TestJsonSerialization:
         assert result["captcha_found"] is True
         assert result["solver_outcome"] == "rejected"
         assert result["next_action"] == "notify_user"
+
+
+# ── 11. Httpx-specific exceptions map to 'timeout' not 'rejected' ────────
+
+
+class TestHttpxTimeoutMapping:
+    """Concern #1 (third-pass): a solver that lets an httpx.TimeoutException
+    bubble out should be reported as ``timeout``, not ``rejected``. The
+    bundled CaptchaSolver catches its own httpx errors and returns False,
+    but third-party subclasses may not — verify the dispatch is correct.
+    """
+
+    @pytest.mark.asyncio
+    async def test_httpx_timeout_exception_reports_timeout(self):
+        import httpx
+
+        solver = AsyncMock()
+        solver.solve = AsyncMock(
+            side_effect=httpx.ReadTimeout("upstream slow"),
+        )
+        mgr = _make_manager(solver=solver)
+        inst = _make_inst('iframe[src*="recaptcha"]')
+        result = await mgr._check_captcha(inst)
+        assert result["captcha_found"] is True
+        assert result["solver_attempted"] is True
+        assert result["solver_outcome"] == "timeout"
+        assert result["solver_confidence"] == "low"
+        assert result["next_action"] == "notify_user"
+
+    @pytest.mark.asyncio
+    async def test_httpx_connect_error_reports_rejected(self):
+        """Non-timeout httpx errors (connect refused, DNS fail) currently
+        map to 'rejected' — closest fit in the §11.13 enum, until a richer
+        SolverResult lands. Pin the behavior so a future change is
+        deliberate.
+        """
+        import httpx
+
+        solver = AsyncMock()
+        solver.solve = AsyncMock(
+            side_effect=httpx.ConnectError("refused"),
+        )
+        mgr = _make_manager(solver=solver)
+        inst = _make_inst('iframe[src*="hcaptcha"]')
+        result = await mgr._check_captcha(inst)
+        assert result["solver_outcome"] == "rejected"
+
+    @pytest.mark.asyncio
+    async def test_asyncio_timeout_still_reports_timeout(self):
+        """asyncio.TimeoutError takes the explicit branch — verify it
+        still works alongside the new httpx branch.
+        """
+        solver = AsyncMock()
+        solver.solve = AsyncMock(side_effect=asyncio.TimeoutError())
+        mgr = _make_manager(solver=solver)
+        inst = _make_inst('iframe[src*="hcaptcha"]')
+        result = await mgr._check_captcha(inst)
+        assert result["solver_outcome"] == "timeout"
+
+
+# ── 12. solver_confidence reflects kind-classification firmness ───────────
+
+
+class TestKindConfidence:
+    """Concern #2 (third-pass): no-solver + placeholder kind should not
+    return 'high' confidence. Only firmly-classified kinds (hcaptcha,
+    turnstile) earn 'high'; reCAPTCHA and CF interstitial placeholders
+    are 'low' until §11.1 / §11.3 land.
+    """
+
+    @pytest.mark.asyncio
+    async def test_hcaptcha_no_solver_high_confidence(self):
+        mgr = _make_manager(solver=None)
+        inst = _make_inst('iframe[src*="hcaptcha"]')
+        result = await mgr._check_captcha(inst)
+        assert result["solver_confidence"] == "high"
+
+    @pytest.mark.asyncio
+    async def test_turnstile_no_solver_high_confidence(self):
+        mgr = _make_manager(solver=None)
+        inst = _make_inst('[class*="cf-turnstile"]')
+        result = await mgr._check_captcha(inst)
+        assert result["solver_confidence"] == "high"
+
+    @pytest.mark.asyncio
+    async def test_recaptcha_placeholder_low_confidence(self):
+        mgr = _make_manager(solver=None)
+        inst = _make_inst('iframe[src*="recaptcha"]')
+        result = await mgr._check_captcha(inst)
+        # Placeholder kind — §11.1 will refine.
+        assert result["solver_confidence"] == "low"
+
+    @pytest.mark.asyncio
+    async def test_cf_interstitial_placeholder_low_confidence(self):
+        mgr = _make_manager(solver=None)
+        inst = _make_inst('iframe[src*="challenges.cloudflare.com"]')
+        result = await mgr._check_captcha(inst)
+        # Placeholder kind — §11.3 will refine.
+        assert result["solver_confidence"] == "low"
+
+
+# ── 13. Envelope shape is open for additive top-level fields ──────────────
+
+
+class TestEnvelopeOpenShape:
+    """Concern #8 (third-pass): §11.16 will add a top-level ``breaker_open``
+    flag alongside ``solver_outcome="timeout"``. Verify the envelope shape
+    is open — additional top-level keys survive the legacy-shim and JSON
+    round-trip.
+    """
+
+    @pytest.mark.asyncio
+    async def test_additive_top_level_field_survives_shim(self):
+        # Direct shim invocation — simulates §11.16 augmenting the envelope.
+        from src.browser.service import _captcha_envelope, _with_legacy_fields
+
+        env = _captcha_envelope(
+            kind="hcaptcha", solver_attempted=True,
+            solver_outcome="timeout", solver_confidence="low",
+            next_action="notify_user",
+        )
+        env["breaker_open"] = True  # §11.16 future field
+        out = _with_legacy_fields(env)
+        assert out["breaker_open"] is True
+        # Original structured fields preserved.
+        assert out["solver_outcome"] == "timeout"
+        # Legacy fields populated.
+        assert out["type"] == "hcaptcha"
+        assert "hcaptcha" in out["message"]
+        # JSON round-trip must preserve the additive field.
+        decoded = json.loads(json.dumps(out))
+        assert decoded["breaker_open"] is True
+
+
+# ── 14. injection_failure_reason is always present (None when N/A) ────────
+
+
+class TestInjectionFailureReasonShape:
+    """Concern #9 (third-pass): ``injection_failure_reason`` should be
+    consistently present (set to None) rather than absent when
+    solver_outcome != 'injection_failed'. Stable shape lets downstream
+    consumers do ``data['injection_failure_reason']`` without KeyError.
+    """
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "selector,solver_factory,expected_outcome",
+        [
+            ('iframe[src*="hcaptcha"]', lambda: None, "no_solver"),
+            (
+                'iframe[src*="hcaptcha"]',
+                lambda: AsyncMock(solve=AsyncMock(return_value=True)),
+                "solved",
+            ),
+            (
+                'iframe[src*="hcaptcha"]',
+                lambda: AsyncMock(solve=AsyncMock(return_value=False)),
+                "rejected",
+            ),
+            (
+                'iframe[src*="hcaptcha"]',
+                lambda: AsyncMock(
+                    solve=AsyncMock(side_effect=asyncio.TimeoutError()),
+                ),
+                "timeout",
+            ),
+        ],
+    )
+    async def test_injection_failure_reason_present_as_none(
+        self, selector, solver_factory, expected_outcome,
+    ):
+        mgr = _make_manager(solver=solver_factory())
+        inst = _make_inst(selector)
+        result = await mgr._check_captcha(inst)
+        assert result["solver_outcome"] == expected_outcome
+        # Field present in dict, set to None.
+        assert "injection_failure_reason" in result
+        assert result["injection_failure_reason"] is None
+
+
+# ── 15. Solver returning False on injection-fail is conflated to rejected ─
+
+
+class TestSolverFalseConflation:
+    """Concern #10 (third-pass): when the bundled CaptchaSolver returns
+    False for an injection failure (token fetched but ``_inject_token``
+    returned False), this layer cannot distinguish from a verdict reject.
+    Both currently report ``solver_outcome='rejected'``. Pin this so a
+    future PR that adds a richer SolverResult does so deliberately.
+    """
+
+    @pytest.mark.asyncio
+    async def test_solver_false_maps_to_rejected_today(self):
+        solver = AsyncMock()
+        solver.solve = AsyncMock(return_value=False)
+        mgr = _make_manager(solver=solver)
+        inst = _make_inst('iframe[src*="hcaptcha"]')
+        result = await mgr._check_captcha(inst)
+        assert result["captcha_found"] is True
+        assert result["solver_attempted"] is True
+        # ``injection_failed`` is reserved but unreachable today — the
+        # solver returns plain bool. Both injection-fail and verdict-fail
+        # surface as ``rejected``.
+        assert result["solver_outcome"] == "rejected"
+        assert result["injection_failure_reason"] is None
+
+
+# ── 16. Concurrency: same-instance calls are serialized via inst.lock ─────
+
+
+class TestConcurrency:
+    """Concern #11 (third-pass): ``detect_captcha`` acquires ``inst.lock``
+    before calling ``_check_captcha``. The post-navigate auto-detect path
+    runs inside the same lock acquired at the top of ``navigate()``. Two
+    parallel ``detect_captcha`` calls on the same agent should serialize.
+    """
+
+    @pytest.mark.asyncio
+    async def test_two_parallel_detect_captcha_serialize(self):
+        # Build a single instance that records lock acquisitions.
+        mgr = _make_manager()
+        acquisitions: list[int] = []
+        max_concurrent = [0]
+        active = [0]
+
+        inst = _make_inst('iframe[src*="hcaptcha"]')
+
+        # Replace lock with one that tracks contention.
+        real_lock = asyncio.Lock()
+
+        class TrackingLock:
+            async def __aenter__(self_inner):
+                await real_lock.acquire()
+                active[0] += 1
+                acquisitions.append(active[0])
+                max_concurrent[0] = max(max_concurrent[0], active[0])
+                # Hold briefly so a parallel acquirer would race here.
+                await asyncio.sleep(0.005)
+                return self_inner
+
+            async def __aexit__(self_inner, *exc):
+                active[0] -= 1
+                real_lock.release()
+                return False
+
+        inst.lock = TrackingLock()
+
+        with patch.object(BrowserManager, "get_or_start", return_value=inst):
+            results = await asyncio.gather(
+                mgr.detect_captcha("a1"),
+                mgr.detect_captcha("a1"),
+            )
+        # Both succeed.
+        assert all(r["success"] is True for r in results)
+        assert all(
+            r["data"]["captcha_found"] is True for r in results
+        )
+        # Crucial: at most one detect_captcha holds the lock at a time.
+        assert max_concurrent[0] == 1, (
+            f"detect_captcha did not serialize on inst.lock "
+            f"(max concurrent = {max_concurrent[0]})"
+        )

--- a/tests/test_captcha_envelope.py
+++ b/tests/test_captcha_envelope.py
@@ -1,0 +1,306 @@
+"""Tests for the §11.13 structured CAPTCHA detection envelope.
+
+Covers each path through `BrowserManager._check_captcha` and
+`BrowserManager.detect_captcha`, asserting that the response data block
+matches the schema described in the plan:
+
+  {captcha_found: false}                       # no captcha
+  {captcha_found: true, kind: <enum>,          # captcha found
+   solver_attempted: <bool>,
+   solver_outcome: <enum>,
+   injection_failure_reason: null | <enum>,
+   solver_confidence: <enum>,
+   next_action: <enum>}
+
+Plus the soft-deprecated legacy `type` and `message` fields.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from src.browser.service import BrowserManager
+
+# Selectors checked in order by `_check_captcha`. We use this to drive
+# the mock such that exactly one selector "matches" per scenario.
+_SELECTOR_ORDER = [
+    'iframe[src*="recaptcha"]',
+    'iframe[src*="hcaptcha"]',
+    'iframe[src*="challenges.cloudflare.com"]',
+    'iframe[src*="captcha"]',
+    '[class*="cf-turnstile"]',
+    '[class*="captcha"]',
+    "#captcha",
+]
+
+
+def _make_manager(*, solver=None) -> BrowserManager:
+    mgr = BrowserManager.__new__(BrowserManager)
+    mgr._captcha_solver = solver
+    return mgr
+
+
+def _make_inst(matching_selector: str | None, *, title: str = "") -> MagicMock:
+    """Build a mocked CamoufoxInstance whose `.page.locator(sel).count()`
+    returns 1 only for `matching_selector`. `None` means no captcha.
+    """
+    inst = MagicMock()
+    inst.page = MagicMock()
+    inst.page.url = "https://example.com"
+    inst.page.title = AsyncMock(return_value=title)
+
+    def locator(sel: str):
+        loc = MagicMock()
+        loc.count = AsyncMock(return_value=1 if sel == matching_selector else 0)
+        return loc
+
+    inst.page.locator = MagicMock(side_effect=locator)
+    inst.lock = asyncio.Lock()
+    inst.touch = MagicMock()
+    return inst
+
+
+# ── 1. No captcha ─────────────────────────────────────────────────────────
+
+
+class TestNoCaptcha:
+    @pytest.mark.asyncio
+    async def test_no_captcha_returns_minimal_envelope(self):
+        mgr = _make_manager()
+        inst = _make_inst(None)
+        result = await mgr._check_captcha(inst)
+        assert result == {"captcha_found": False}
+
+    @pytest.mark.asyncio
+    async def test_detect_captcha_no_captcha_path(self):
+        mgr = _make_manager()
+        inst = _make_inst(None)
+        with patch.object(BrowserManager, "get_or_start", return_value=inst):
+            result = await mgr.detect_captcha("a1")
+        assert result["success"] is True
+        assert result["data"]["captcha_found"] is False
+        # Legacy back-compat
+        assert result["data"]["message"] == "No CAPTCHA detected"
+
+
+# ── 2. reCAPTCHA detect, no solver ────────────────────────────────────────
+
+
+class TestRecaptchaNoSolver:
+    @pytest.mark.asyncio
+    async def test_recaptcha_no_solver(self):
+        mgr = _make_manager(solver=None)
+        inst = _make_inst('iframe[src*="recaptcha"]')
+        result = await mgr._check_captcha(inst)
+        assert result == {
+            "captcha_found": True,
+            "kind": "recaptcha-v2-checkbox",
+            "solver_attempted": False,
+            "solver_outcome": "no_solver",
+            "injection_failure_reason": None,
+            "solver_confidence": "high",
+            "next_action": "notify_user",
+        }
+
+
+# ── 3. reCAPTCHA detect, solver succeeds ──────────────────────────────────
+
+
+class TestRecaptchaSolverSuccess:
+    @pytest.mark.asyncio
+    async def test_recaptcha_solved(self):
+        solver = AsyncMock()
+        solver.solve = AsyncMock(return_value=True)
+        mgr = _make_manager(solver=solver)
+        inst = _make_inst('iframe[src*="recaptcha"]')
+        result = await mgr._check_captcha(inst)
+        assert result["captcha_found"] is True
+        assert result["kind"] == "recaptcha-v2-checkbox"
+        assert result["solver_attempted"] is True
+        assert result["solver_outcome"] == "solved"
+        assert result["solver_confidence"] == "high"
+        assert result["next_action"] == "solved"
+        assert result["injection_failure_reason"] is None
+        solver.solve.assert_awaited_once()
+
+
+# ── 4. reCAPTCHA detect, solver timeout ───────────────────────────────────
+
+
+class TestRecaptchaSolverTimeout:
+    @pytest.mark.asyncio
+    async def test_recaptcha_timeout(self):
+        solver = AsyncMock()
+        solver.solve = AsyncMock(side_effect=asyncio.TimeoutError())
+        mgr = _make_manager(solver=solver)
+        inst = _make_inst('iframe[src*="recaptcha"]')
+        result = await mgr._check_captcha(inst)
+        assert result["captcha_found"] is True
+        assert result["kind"] == "recaptcha-v2-checkbox"
+        assert result["solver_attempted"] is True
+        assert result["solver_outcome"] == "timeout"
+        assert result["next_action"] == "notify_user"
+        assert result["solver_confidence"] == "low"
+
+
+# ── 5. CF interstitial — placeholder for §11.3 ────────────────────────────
+
+
+class TestCfInterstitial:
+    @pytest.mark.asyncio
+    async def test_cf_interstitial_kind(self):
+        mgr = _make_manager()
+        # Title prefix matches "Just a moment" — current §11.13 placeholder
+        # still routes to cf-interstitial-auto. §11.3 will refine.
+        inst = _make_inst(
+            'iframe[src*="challenges.cloudflare.com"]',
+            title="Just a moment...",
+        )
+        result = await mgr._check_captcha(inst)
+        assert result["captcha_found"] is True
+        assert result["kind"] == "cf-interstitial-auto"
+        assert result["solver_outcome"] == "no_solver"
+        assert result["next_action"] == "notify_user"
+
+    @pytest.mark.asyncio
+    async def test_cf_interstitial_no_title_match(self):
+        mgr = _make_manager()
+        inst = _make_inst(
+            'iframe[src*="challenges.cloudflare.com"]',
+            title="Some unrelated page",
+        )
+        result = await mgr._check_captcha(inst)
+        # Until §11.3 lands tri-state, we still classify as the auto kind.
+        assert result["kind"] == "cf-interstitial-auto"
+
+
+# ── 6. Turnstile ──────────────────────────────────────────────────────────
+
+
+class TestTurnstile:
+    @pytest.mark.asyncio
+    async def test_turnstile_kind(self):
+        mgr = _make_manager()
+        inst = _make_inst('[class*="cf-turnstile"]')
+        result = await mgr._check_captcha(inst)
+        assert result["captcha_found"] is True
+        assert result["kind"] == "turnstile"
+        assert result["solver_outcome"] == "no_solver"
+
+
+# ── 7. hCaptcha ───────────────────────────────────────────────────────────
+
+
+class TestHCaptcha:
+    @pytest.mark.asyncio
+    async def test_hcaptcha_kind(self):
+        mgr = _make_manager()
+        inst = _make_inst('iframe[src*="hcaptcha"]')
+        result = await mgr._check_captcha(inst)
+        assert result["captcha_found"] is True
+        assert result["kind"] == "hcaptcha"
+
+
+# ── 8. Generic / unknown fallback ─────────────────────────────────────────
+
+
+class TestUnknownFallback:
+    @pytest.mark.asyncio
+    async def test_generic_iframe_captcha(self):
+        mgr = _make_manager()
+        inst = _make_inst('iframe[src*="captcha"]')
+        result = await mgr._check_captcha(inst)
+        assert result["captcha_found"] is True
+        assert result["kind"] == "unknown"
+        # Confidence drops to "low" for unknown when there is no solver,
+        # since we cannot vouch for the classification.
+        assert result["solver_confidence"] == "low"
+
+    @pytest.mark.asyncio
+    async def test_class_captcha(self):
+        mgr = _make_manager()
+        inst = _make_inst('[class*="captcha"]')
+        result = await mgr._check_captcha(inst)
+        assert result["kind"] == "unknown"
+
+    @pytest.mark.asyncio
+    async def test_id_captcha(self):
+        mgr = _make_manager()
+        inst = _make_inst("#captcha")
+        result = await mgr._check_captcha(inst)
+        assert result["kind"] == "unknown"
+
+
+# ── 9. Backward-compat: old `message` and `type` fields preserved ────────
+
+
+class TestLegacyFields:
+    @pytest.mark.asyncio
+    async def test_detect_captcha_carries_legacy_fields(self):
+        mgr = _make_manager()
+        inst = _make_inst('iframe[src*="hcaptcha"]')
+        with patch.object(BrowserManager, "get_or_start", return_value=inst):
+            result = await mgr.detect_captcha("a1")
+        data = result["data"]
+        # New shape
+        assert data["captcha_found"] is True
+        assert data["kind"] == "hcaptcha"
+        # Legacy shape (deprecated but present)
+        assert data["type"] == "hcaptcha"
+        assert "hcaptcha" in data["message"]
+        assert "next_action" in data["message"] or data["next_action"] in data["message"]
+
+    @pytest.mark.asyncio
+    async def test_detect_captcha_legacy_no_captcha_message(self):
+        mgr = _make_manager()
+        inst = _make_inst(None)
+        with patch.object(BrowserManager, "get_or_start", return_value=inst):
+            result = await mgr.detect_captcha("a1")
+        # Legacy callers still see the old "No CAPTCHA detected" string.
+        assert result["data"]["message"] == "No CAPTCHA detected"
+
+
+# ── 10. JSON serialization round-trip (no enum repr leakage) ─────────────
+
+
+class TestJsonSerialization:
+    @pytest.mark.asyncio
+    async def test_envelope_serializes_to_clean_json(self):
+        mgr = _make_manager()
+        inst = _make_inst('iframe[src*="recaptcha"]')
+        with patch.object(BrowserManager, "get_or_start", return_value=inst):
+            result = await mgr.detect_captcha("a1")
+        # Must round-trip through JSON without raising.
+        encoded = json.dumps(result)
+        decoded = json.loads(encoded)
+        assert decoded == result
+        # Every enum-style value should be a plain string, not a Python repr.
+        data = decoded["data"]
+        for field in (
+            "kind", "solver_outcome", "solver_confidence", "next_action",
+        ):
+            assert isinstance(data[field], str)
+            assert "<" not in data[field]
+            assert ":" not in data[field]
+        # Booleans not strings.
+        assert isinstance(data["captcha_found"], bool)
+        assert isinstance(data["solver_attempted"], bool)
+        # Optional null preserved (JSON null → Python None).
+        assert data["injection_failure_reason"] is None
+
+    @pytest.mark.asyncio
+    async def test_solver_exception_is_rejected_outcome(self):
+        """A solver raising arbitrary exception is reported as 'rejected'
+        rather than crashing detect_captcha or leaking the exception."""
+        solver = AsyncMock()
+        solver.solve = AsyncMock(side_effect=RuntimeError("boom"))
+        mgr = _make_manager(solver=solver)
+        inst = _make_inst('iframe[src*="hcaptcha"]')
+        result = await mgr._check_captcha(inst)
+        assert result["captcha_found"] is True
+        assert result["solver_outcome"] == "rejected"
+        assert result["next_action"] == "notify_user"


### PR DESCRIPTION
## Summary

Replaces the freeform `{"type": <selector>, "message": <string>}` from `_check_captcha` / `detect_captcha` with the §11.13 structured envelope:

```json
{"success": true, "data": {"captcha_found": true, "kind": "<enum>", "solver_attempted": <bool>,
                            "solver_outcome": "<enum>", "injection_failure_reason": null|"<enum>",
                            "solver_confidence": "<enum>", "next_action": "<enum>"}}
```

This is **foundational for Phase 8 Sub-release A** — §11.1, §11.2, §11.3, §11.16, §11.18 will populate fields on this envelope as they land.

- **Minimal classification** (selector → kind enum) — full v2-checkbox / v2-invisible / v3 / enterprise distinction is §11.1 work; this PR ships the envelope shape only with `cf-interstitial-auto`, `turnstile`, `hcaptcha`, `recaptcha-v2-checkbox`, `unknown` placeholders.
- **`_check_captcha` returns the envelope `data` block in all cases** (never `None`) — `detect_captcha` wraps with the §2.3 outer envelope. Post-navigate caller updated to gate on `captcha_found AND solver_outcome != "solved"`.
- **Backward compat shim** — `type` and `message` fields still present, populated by `_with_legacy_fields()`. Skill description tells agents to read the new fields and marks the legacy ones deprecated.

Plan: `docs/plans/2026-04-20-browser-automation.md` §11.13.

## Cross-PR coordination

Phase 6 §9.3 (#762) and §9.4 (#763) both call `_check_captcha` and treat truthy = "report to agent". After this PR and those merge to main, each needs a 1-line update to read `envelope.get("captcha_found") and envelope.get("solver_outcome") != "solved"`. Will follow up post-merge.

§11.16 (`feat/phase8-solver-health-circuit-breaker`) coordinates with this envelope using a SAFE additive pattern — adds `breaker_open: true` flag without modifying the §11.13 enum, so the two PRs merge without conflict.

## Test plan

- [x] 16 new tests in `tests/test_captcha_envelope.py` — each enum path (no-captcha, recaptcha+no-solver, +solved, +timeout, CF interstitial, turnstile, hcaptcha, generic unknown × 3, legacy field presence, JSON round-trip, solver-exception → rejected).
- [x] 11 existing captcha tests in `tests/test_browser_service.py` updated to assert the new envelope shape.
- [x] 664-test wider regression sweep across `test_captcha_envelope.py + test_browser_service.py + test_builtins.py` — all green.
- [x] `ruff check` — clean.