### PR TITLE
Phase 8 §11.18: site classification policy module

### DIFF
--- a/src/browser/captcha_policy.py
+++ b/src/browser/captcha_policy.py
@@ -1,0 +1,290 @@
+"""Site classification policy for captcha handling (Phase 8 §11.18).
+
+A pure-stdlib lookup module that maps a page URL to one of three captcha
+policy buckets. Consumed by the captcha detection / solver pipeline (§11.16,
+the §11.13-aware detect path) so a single source of truth governs whether a
+solver call is even attempted.
+
+Buckets
+-------
+
+* ``unsolvable`` — captcha is behavioral-only or fingerprint-locked. Never
+  charge the solver. Always escalate via ``request_captcha_help`` (§11.14).
+  Examples: HUMAN Security "Press & Hold", DataDome behavioral blocker,
+  Cloudflare Under-Attack-Mode after a wait.
+* ``low_success`` — captcha is technically solvable but token-IP /
+  fingerprint sensitive (Google signup, Twitter signup, LinkedIn auth).
+  Solver attempted ONCE at ``solver_confidence: "low"``; on first failure,
+  ``next_action`` upgrades to ``request_captcha_help`` rather than retry.
+* ``default`` — normal solver flow.
+
+Precedence (highest → lowest)
+-----------------------------
+
+1. ``OPENLEGION_CAPTCHA_FORCE_SOLVE_DOMAINS`` — operator forces normal flow
+   even on a hardcoded-unsolvable host.  Returns ``"default"``.
+2. ``OPENLEGION_CAPTCHA_SKIP_SOLVE_DOMAINS`` — operator forces escalation
+   even on a host we'd normally solve.  Returns ``"unsolvable"``.
+3. Hardcoded ``_UNSOLVABLE_DOMAINS`` set.  Returns ``"unsolvable"``.
+4. Hardcoded ``_LOW_SUCCESS_DOMAINS`` set.  Returns ``"low_success"``.
+5. Otherwise → ``"default"``.
+
+Domain-match semantics
+----------------------
+
+Hostname canonicalization: ``urllib.parse.urlsplit(url).hostname`` →
+lower-cased → leading ``www.`` stripped.
+
+* **Bare domain** entry (``example.com``) — matches ``example.com`` AND any
+  subdomain (``foo.example.com``, ``a.b.example.com``).  Most permissive;
+  matches the operator intent of "block this org".
+* **Leading-dot** entry (``.example.com``) — matches subdomains ONLY
+  (``foo.example.com``), NOT ``example.com`` itself.  Useful when an
+  operator wants to block a tenant's subdomains but allow the apex.
+
+The hardcoded site list uses the bare-domain convention.
+
+Operator override env vars are comma-separated.  Whitespace around entries
+is stripped.  Empty / unset env = no overrides.  Wildcard prefixes
+(``*.example.com``) are NOT supported by design — domain-suffix matching
+already covers the same intent without parser complexity.
+
+Caveat
+------
+
+The hardcoded list is intentionally short.  Real-world classification of
+behavioral-only captchas is an operations problem with quarterly drift
+(provider rebrands, selector changes — see §11.18).  Operators expand
+coverage via the env-var allow/block lists; reload requires service
+restart (out of scope here).
+
+URL redaction
+-------------
+
+Any log line emitted by this module that contains a URL flows through
+:func:`src.shared.redaction.redact_url` first.  In practice the module
+emits no per-call logs (this is a hot-path lookup); the logger only
+warns at module load if env-var parsing finds malformed entries.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Literal
+from urllib.parse import urlsplit
+
+from src.shared.utils import setup_logging
+
+logger = setup_logging("browser.captcha_policy")
+
+
+SitePolicy = Literal["unsolvable", "low_success", "default"]
+
+
+# ── Hardcoded site lists ───────────────────────────────────────────────────
+
+
+# Behavioral-only / fingerprint-locked. Solver call is wasted spend on these
+# hosts; route straight to operator escalation. Kept SHORT on purpose — the
+# real-world long tail lives in operator overrides (see module docstring).
+#
+# Why these specific entries:
+# - ``challenges.cloudflare.com`` — CF challenge platform host. Pages served
+#   here are interstitials, not target content; reaching one means the parent
+#   site is in Under-Attack mode and human action is required.
+# - ``humansecurity.com`` — HUMAN Security's own marketing / demo domain.
+#   Real protected sites embed HUMAN selectors (legacy ``data-v="px-button"``
+#   from the 2022 PerimeterX rebrand, modern ``[data-human-security]``);
+#   those selector hits live in §11.3 detection. The DOMAIN listed here only
+#   blocks demos / docs hosted by HUMAN themselves.
+# - ``captcha-delivery.com`` — DataDome's CDN. The ``/blocker`` iframe path
+#   indicates behavioral; the ``/solver`` path is solvable. Domain-level
+#   policy is conservative: any DataDome iframe is treated as unsolvable
+#   here, with the per-iframe path check living in §11.3.
+_UNSOLVABLE_DOMAINS: frozenset[str] = frozenset({
+    "challenges.cloudflare.com",
+    "humansecurity.com",
+    "captcha-delivery.com",
+})
+
+
+# Token-IP + fingerprint sensitive: solvable in principle, but solver tokens
+# minted from the provider's IP have ~50% success against the target's
+# server-side risk score. Policy: try once at low confidence, escalate on
+# failure (§11.18 + §11.13). Entries are full hostnames so adjacent
+# subdomains under the same registrable domain (``mail.google.com``,
+# ``drive.google.com``) keep the default policy — only signup / auth flows
+# are flagged.
+_LOW_SUCCESS_DOMAINS: frozenset[str] = frozenset({
+    "accounts.google.com",   # Google signup / login
+    "twitter.com",            # Twitter signup
+    "x.com",                  # X (Twitter rebrand) signup
+    "linkedin.com",           # LinkedIn auth
+    "signup.amazon.com",      # Amazon retail signup
+    "instagram.com",          # Instagram login / signup
+})
+
+
+# ── Env-var override parsing (module-load time) ────────────────────────────
+
+
+_FORCE_SOLVE_ENV = "OPENLEGION_CAPTCHA_FORCE_SOLVE_DOMAINS"
+_SKIP_SOLVE_ENV = "OPENLEGION_CAPTCHA_SKIP_SOLVE_DOMAINS"
+
+
+def _parse_domain_list(raw: str, env_name: str) -> frozenset[str]:
+    """Parse a comma-separated domain list from an env-var value.
+
+    Whitespace around entries is stripped; empty entries dropped. Each
+    surviving entry is lower-cased.  Leading-dot entries are preserved
+    verbatim (their subdomain-only semantics are honored at match time).
+
+    Malformed entries (containing whitespace inside the token, ``://``,
+    ``/``, or ``?``) are skipped with a startup warning.  We never crash
+    on bad operator config — that's a denial-of-service vector if the
+    module sits on a hot path.
+    """
+    out: set[str] = set()
+    for token in raw.split(","):
+        entry = token.strip().lower()
+        if not entry:
+            continue
+        # Reject things that are URLs or contain whitespace / path chars.
+        # Leading-dot is allowed (``.example.com``) — that's our own
+        # subdomain-only sigil, not a path char.
+        if (
+            "://" in entry
+            or "/" in entry
+            or "?" in entry
+            or " " in entry
+            or "\t" in entry
+        ):
+            logger.warning(
+                "Ignoring malformed %s entry %r (looks like a URL or path)",
+                env_name, token,
+            )
+            continue
+        out.add(entry)
+    return frozenset(out)
+
+
+_FORCE_SOLVE_DOMAINS: frozenset[str] = _parse_domain_list(
+    os.environ.get(_FORCE_SOLVE_ENV, ""), _FORCE_SOLVE_ENV,
+)
+
+_SKIP_SOLVE_DOMAINS: frozenset[str] = _parse_domain_list(
+    os.environ.get(_SKIP_SOLVE_ENV, ""), _SKIP_SOLVE_ENV,
+)
+
+
+# ── Hostname extraction + matching ─────────────────────────────────────────
+
+
+def _hostname(url: str) -> str | None:
+    """Return the canonicalized hostname of ``url``, or None on failure.
+
+    Canonicalization:
+    * lower-case
+    * strip leading ``www.``
+    * port is dropped (urlsplit.hostname does this for us)
+    * IPv6 literals returned without surrounding brackets
+
+    Returns None for empty input, malformed URLs, or URLs with no host.
+    Callers treat None as "no policy match" → falls through to default.
+    """
+    if not url or not isinstance(url, str):
+        return None
+    try:
+        parts = urlsplit(url)
+    except ValueError:
+        return None
+    host = parts.hostname
+    if not host:
+        return None
+    host = host.lower()
+    if host.startswith("www."):
+        host = host[4:]
+    return host
+
+
+def _matches(host: str, entry: str) -> bool:
+    """Return True iff ``host`` matches the policy ``entry``.
+
+    Semantics (see module docstring):
+    * Bare ``example.com`` → matches ``example.com`` AND any subdomain.
+    * Leading-dot ``.example.com`` → subdomains only.
+    """
+    if entry.startswith("."):
+        # Subdomain-only: must end with the entry, but the entry itself
+        # (without leading dot) is NOT a match.
+        return host.endswith(entry)
+    # Bare entry: exact host or any subdomain.
+    if host == entry:
+        return True
+    return host.endswith("." + entry)
+
+
+def _matches_any(host: str, entries: frozenset[str]) -> bool:
+    """Return True iff ``host`` matches any entry in ``entries``."""
+    for entry in entries:
+        if _matches(host, entry):
+            return True
+    return False
+
+
+# ── Public API ─────────────────────────────────────────────────────────────
+
+
+def is_force_solve(url: str) -> bool:
+    """True iff the operator has forced solver attempts for this URL's host.
+
+    Exposed separately from :func:`get_site_policy` so callers that want
+    to log "operator override applied" (with the URL run through
+    ``redact_url`` first) can do so without re-running the precedence
+    chain.
+    """
+    host = _hostname(url)
+    if host is None:
+        return False
+    return _matches_any(host, _FORCE_SOLVE_DOMAINS)
+
+
+def is_skip_solve(url: str) -> bool:
+    """True iff the operator has forced solver-skip for this URL's host."""
+    host = _hostname(url)
+    if host is None:
+        return False
+    return _matches_any(host, _SKIP_SOLVE_DOMAINS)
+
+
+def get_site_policy(url: str) -> SitePolicy:
+    """Classify ``url`` into a captcha-policy bucket.
+
+    Order of precedence:
+
+    1. ``OPENLEGION_CAPTCHA_FORCE_SOLVE_DOMAINS`` → ``"default"``
+    2. ``OPENLEGION_CAPTCHA_SKIP_SOLVE_DOMAINS`` → ``"unsolvable"``
+    3. Hardcoded :data:`_UNSOLVABLE_DOMAINS` → ``"unsolvable"``
+    4. Hardcoded :data:`_LOW_SUCCESS_DOMAINS` → ``"low_success"``
+    5. Otherwise → ``"default"``
+
+    Malformed / hostless URLs return ``"default"`` (fail-open).  The
+    solver pipeline downstream still has its own confidence gates and
+    cost caps — this module is a routing hint, not a security boundary.
+    """
+    host = _hostname(url)
+    if host is None:
+        return "default"
+
+    # Operator overrides win over hardcoded entries (in either direction).
+    if _matches_any(host, _FORCE_SOLVE_DOMAINS):
+        return "default"
+    if _matches_any(host, _SKIP_SOLVE_DOMAINS):
+        return "unsolvable"
+
+    if _matches_any(host, _UNSOLVABLE_DOMAINS):
+        return "unsolvable"
+    if _matches_any(host, _LOW_SUCCESS_DOMAINS):
+        return "low_success"
+
+    return "default"

--- a/src/browser/captcha_policy.py
+++ b/src/browser/captcha_policy.py
@@ -33,21 +33,47 @@ Domain-match semantics
 ----------------------
 
 Hostname canonicalization: ``urllib.parse.urlsplit(url).hostname`` →
-lower-cased → leading ``www.`` stripped.
+lower-cased → leading ``www.`` stripped.  ``urlsplit`` already drops the
+port and brackets around IPv6 literals.
+
+The same matching rule applies UNIFORMLY to hardcoded entries
+(:data:`_UNSOLVABLE_DOMAINS`, :data:`_LOW_SUCCESS_DOMAINS`) and operator
+override env-var entries — there is no asymmetry between the two sources:
 
 * **Bare domain** entry (``example.com``) — matches ``example.com`` AND any
   subdomain (``foo.example.com``, ``a.b.example.com``).  Most permissive;
-  matches the operator intent of "block this org".
+  matches the operator intent of "block this org".  This is what the
+  hardcoded list uses, e.g. ``twitter.com`` matches both ``twitter.com``
+  and ``mobile.twitter.com``; ``accounts.google.com`` matches both itself
+  and any sub-host like ``foo.accounts.google.com``.
 * **Leading-dot** entry (``.example.com``) — matches subdomains ONLY
   (``foo.example.com``), NOT ``example.com`` itself.  Useful when an
   operator wants to block a tenant's subdomains but allow the apex.
 
-The hardcoded site list uses the bare-domain convention.
+Examples — operator wants Google-wide override:
+
+* ``OPENLEGION_CAPTCHA_FORCE_SOLVE_DOMAINS=accounts.google.com`` — covers
+  ``accounts.google.com`` plus any sub-host.  Same matching rule as the
+  hardcoded entry; operator just opted to override it.
+* ``OPENLEGION_CAPTCHA_FORCE_SOLVE_DOMAINS=google.com`` — covers
+  ``google.com`` plus EVERY ``*.google.com`` (mail, drive, accounts, …).
+  This works because ``google.com`` is itself a valid bare-domain entry.
 
 Operator override env vars are comma-separated.  Whitespace around entries
-is stripped.  Empty / unset env = no overrides.  Wildcard prefixes
-(``*.example.com``) are NOT supported by design — domain-suffix matching
-already covers the same intent without parser complexity.
+is stripped; empty entries dropped.  Empty / unset / whitespace-only env =
+no overrides.  Each surviving entry is lower-cased.
+
+Wildcard prefix (``*.example.com``) handling: the leading ``*.`` is
+silently stripped and the remainder is treated as a bare-domain entry
+(equivalent to writing ``example.com``).  This produces the operator's
+intended subdomain-match without crashing on a syntax that's near-
+universal in DNS / firewall config.  A single literal ``*`` token is
+ignored as malformed.
+
+IDN / punycode hosts are matched in their **literal form** as returned
+by :func:`urllib.parse.urlsplit`.  An operator who lists
+``日本.example`` will not match a page that loads as
+``xn--wgv71a.example`` and vice versa.  When in doubt list both forms.
 
 Caveat
 ------
@@ -111,16 +137,33 @@ _UNSOLVABLE_DOMAINS: frozenset[str] = frozenset({
 # Token-IP + fingerprint sensitive: solvable in principle, but solver tokens
 # minted from the provider's IP have ~50% success against the target's
 # server-side risk score. Policy: try once at low confidence, escalate on
-# failure (§11.18 + §11.13). Entries are full hostnames so adjacent
-# subdomains under the same registrable domain (``mail.google.com``,
-# ``drive.google.com``) keep the default policy — only signup / auth flows
-# are flagged.
+# failure (§11.18 + §11.13).
+#
+# Granularity rationale:
+# - ``accounts.google.com`` (subdomain-scoped) — auth flows only; sibling
+#   hosts ``mail.google.com`` / ``drive.google.com`` / ``docs.google.com``
+#   keep default policy because their captcha posture is materially
+#   different (rare, content-blocking).  Note: bare-domain matching means
+#   this also covers any deeper subdomain of accounts.google.com.
+# - ``twitter.com`` / ``x.com`` (apex-scoped) — Twitter / X serve the same
+#   high-risk signup / login flow at any sub-host (``mobile.``,
+#   ``api.``, etc.); apex-scoped is the right granularity.
+# - ``linkedin.com`` (apex-scoped) — same reasoning as twitter; auth is
+#   org-wide.
+# - ``amazon.com`` (apex-scoped) — Amazon's auth portal lives at
+#   ``amazon.com/ap/register`` and ``amazon.com/ap/signin``; there is NO
+#   ``signup.amazon.com`` host (NXDOMAIN as of 2026-04).  Apex-scoping
+#   means general retail browsing also gets low_success classification,
+#   which matches Amazon's known site-wide bot-detection posture
+#   (PerimeterX / HUMAN integration).
+# - ``instagram.com`` (apex-scoped) — Meta's anti-bot covers the whole
+#   property uniformly.
 _LOW_SUCCESS_DOMAINS: frozenset[str] = frozenset({
     "accounts.google.com",   # Google signup / login
-    "twitter.com",            # Twitter signup
-    "x.com",                  # X (Twitter rebrand) signup
+    "twitter.com",            # Twitter signup / login (legacy domain)
+    "x.com",                  # X (Twitter rebrand) signup / login
     "linkedin.com",           # LinkedIn auth
-    "signup.amazon.com",      # Amazon retail signup
+    "amazon.com",             # Amazon /ap/register + /ap/signin (apex)
     "instagram.com",          # Instagram login / signup
 })
 
@@ -136,13 +179,24 @@ def _parse_domain_list(raw: str, env_name: str) -> frozenset[str]:
     """Parse a comma-separated domain list from an env-var value.
 
     Whitespace around entries is stripped; empty entries dropped. Each
-    surviving entry is lower-cased.  Leading-dot entries are preserved
-    verbatim (their subdomain-only semantics are honored at match time).
+    surviving entry is lower-cased.  Leading-dot entries (``.foo.com``)
+    are preserved verbatim — their subdomain-only semantics are honored
+    at match time.
+
+    Wildcard-prefix entries (``*.foo.com`` / ``*foo.com``) are normalized
+    to the bare-domain form (``foo.com``).  Bare-domain matching already
+    covers the apex + every subdomain, which is what the wildcard syntax
+    almost always means in operator-facing config (DNS, firewalls, CSP).
+    Accepting it here lets operators paste from those tools without
+    surprise.  A literal ``*`` alone is dropped as meaningless.
 
     Malformed entries (containing whitespace inside the token, ``://``,
     ``/``, or ``?``) are skipped with a startup warning.  We never crash
     on bad operator config — that's a denial-of-service vector if the
     module sits on a hot path.
+
+    Empty / whitespace-only env values produce an empty frozenset
+    (``" , , "`` → no entries, no warnings).
     """
     out: set[str] = set()
     for token in raw.split(","):
@@ -161,6 +215,22 @@ def _parse_domain_list(raw: str, env_name: str) -> frozenset[str]:
         ):
             logger.warning(
                 "Ignoring malformed %s entry %r (looks like a URL or path)",
+                env_name, token,
+            )
+            continue
+        # Normalize wildcard prefix: ``*.example.com`` → ``example.com``
+        # (bare-domain match already covers apex + subdomains).  We accept
+        # both ``*.`` (canonical DNS form) and a bare leading ``*`` for
+        # operator robustness; the post-strip remainder must be a real
+        # domain — a token that's just ``*`` or starts with ``*`` and
+        # leaves nothing after the strip is dropped as malformed.
+        if entry.startswith("*."):
+            entry = entry[2:]
+        elif entry.startswith("*"):
+            entry = entry[1:]
+        if not entry or entry == ".":
+            logger.warning(
+                "Ignoring malformed %s entry %r (empty after wildcard strip)",
                 env_name, token,
             )
             continue

--- a/src/browser/flags.py
+++ b/src/browser/flags.py
@@ -83,6 +83,10 @@ KNOWN_FLAGS: dict[str, str] = {
     "CAPTCHA_SOLVER_PROXY_LOGIN": "dedicated solver proxy user",
     "CAPTCHA_SOLVER_PROXY_PASSWORD": "dedicated solver proxy pass",
     "CAPTCHA_RECAPTCHA_V3_MIN_SCORE": "0.1-0.9 (default 0.7)",
+    "OPENLEGION_CAPTCHA_FORCE_SOLVE_DOMAINS":
+        "comma-separated; force normal solver flow on hardcoded-unsolvable hosts (§11.18)",
+    "OPENLEGION_CAPTCHA_SKIP_SOLVE_DOMAINS":
+        "comma-separated; force escalation-only on hosts we'd otherwise solve (§11.18)",
     # ── Observability ─────────────────────────────────────────────────────
     "BROWSER_RECORD_BEHAVIOR": "1 to enable behavior recorder (§5.3)",
 }

--- a/tests/test_captcha_policy.py
+++ b/tests/test_captcha_policy.py
@@ -1,0 +1,297 @@
+"""Tests for :mod:`src.browser.captcha_policy` (Phase 8 §11.18).
+
+Covers:
+* Hardcoded UNSOLVABLE / LOW_SUCCESS classification.
+* Operator env-var overrides (force-solve, skip-solve) and their precedence.
+* Domain-match semantics: bare-domain (eTLD+1 + subdomains) vs leading-dot
+  (subdomains only).
+* Hostname canonicalization edge cases: ``www.`` strip, port strip, IPv6,
+  malformed URLs, paths / queries, empty input.
+
+Env-var caches are parsed at module import time, so tests that exercise
+the override path use :func:`importlib.reload` inside a patched
+``os.environ`` context — same pattern used elsewhere in the suite for
+import-time-bound config.
+"""
+
+from __future__ import annotations
+
+import importlib
+import os
+from unittest import mock
+
+import pytest
+
+from src.browser import captcha_policy
+
+
+def _reload_with_env(env: dict[str, str]):
+    """Reload ``captcha_policy`` with the given env applied.
+
+    Returns the freshly-imported module so tests can call its functions
+    against the new env-var-derived caches.
+    """
+    with mock.patch.dict(os.environ, env, clear=False):
+        return importlib.reload(captcha_policy)
+
+
+@pytest.fixture(autouse=True)
+def _restore_module():
+    """Ensure each test sees the default (no-override) module state.
+
+    Some tests reload with custom env; this fixture reloads back to the
+    pristine ambient env after every test so subsequent tests don't see
+    leaked override caches.
+    """
+    yield
+    # Drop both override env vars before reloading so we don't pick up
+    # whatever ambient value was in the dev shell.
+    scrubbed = {
+        k: v for k, v in os.environ.items()
+        if k not in {
+            "OPENLEGION_CAPTCHA_FORCE_SOLVE_DOMAINS",
+            "OPENLEGION_CAPTCHA_SKIP_SOLVE_DOMAINS",
+        }
+    }
+    with mock.patch.dict(os.environ, scrubbed, clear=True):
+        importlib.reload(captcha_policy)
+
+
+# ── Hardcoded classification ───────────────────────────────────────────────
+
+
+class TestHardcodedClassification:
+    def test_unknown_domain_returns_default(self):
+        assert captcha_policy.get_site_policy("https://example.com/") == "default"
+
+    def test_accounts_google_is_low_success(self):
+        assert (
+            captcha_policy.get_site_policy("https://accounts.google.com/signup")
+            == "low_success"
+        )
+
+    def test_mail_google_is_default(self):
+        # `accounts.google.com` is the only Google entry; siblings under the
+        # same registrable domain stay on the normal solver path.
+        assert (
+            captcha_policy.get_site_policy("https://mail.google.com/")
+            == "default"
+        )
+
+    def test_twitter_is_low_success(self):
+        assert captcha_policy.get_site_policy("https://twitter.com/i/flow/signup") == "low_success"
+
+    def test_x_com_is_low_success(self):
+        assert captcha_policy.get_site_policy("https://x.com/i/flow/signup") == "low_success"
+
+    def test_linkedin_subdomain_is_low_success(self):
+        # `linkedin.com` is a bare entry → matches any subdomain.
+        assert (
+            captcha_policy.get_site_policy("https://www.linkedin.com/login")
+            == "low_success"
+        )
+
+    def test_instagram_login_is_low_success(self):
+        assert (
+            captcha_policy.get_site_policy("https://www.instagram.com/accounts/login/")
+            == "low_success"
+        )
+
+    def test_signup_amazon_subdomain_is_low_success(self):
+        assert (
+            captcha_policy.get_site_policy("https://us.signup.amazon.com/")
+            == "low_success"
+        )
+
+    def test_cloudflare_challenge_is_unsolvable(self):
+        assert (
+            captcha_policy.get_site_policy("https://challenges.cloudflare.com/cdn-cgi/challenge-platform/h/g")
+            == "unsolvable"
+        )
+
+    def test_humansecurity_is_unsolvable(self):
+        assert (
+            captcha_policy.get_site_policy("https://www.humansecurity.com/")
+            == "unsolvable"
+        )
+
+    def test_datadome_iframe_host_is_unsolvable(self):
+        assert (
+            captcha_policy.get_site_policy("https://geo.captcha-delivery.com/captcha/")
+            == "unsolvable"
+        )
+
+
+# ── Domain-match semantics ─────────────────────────────────────────────────
+
+
+class TestDomainMatching:
+    def test_bare_entry_matches_eTLD1_and_subdomains(self):
+        # `linkedin.com` (bare) matches both the apex and any subdomain.
+        assert captcha_policy._matches("linkedin.com", "linkedin.com")
+        assert captcha_policy._matches("foo.linkedin.com", "linkedin.com")
+        assert captcha_policy._matches("a.b.linkedin.com", "linkedin.com")
+
+    def test_bare_entry_does_not_match_unrelated_suffix(self):
+        # Naive `.endswith("linkedin.com")` would false-match
+        # `evil-linkedin.com`. Our matcher requires a `.` boundary.
+        assert not captcha_policy._matches("evil-linkedin.com", "linkedin.com")
+        assert not captcha_policy._matches("linkedin.com.attacker.io", "linkedin.com")
+
+    def test_leading_dot_entry_matches_subdomains_only(self):
+        assert captcha_policy._matches("foo.example.com", ".example.com")
+        # Apex itself is NOT a match for leading-dot entries.
+        assert not captcha_policy._matches("example.com", ".example.com")
+
+
+# ── Operator overrides ─────────────────────────────────────────────────────
+
+
+class TestOperatorOverrides:
+    def test_force_solve_overrides_low_success(self):
+        m = _reload_with_env({
+            "OPENLEGION_CAPTCHA_FORCE_SOLVE_DOMAINS": "accounts.google.com",
+            "OPENLEGION_CAPTCHA_SKIP_SOLVE_DOMAINS": "",
+        })
+        assert m.get_site_policy("https://accounts.google.com/signup") == "default"
+        assert m.is_force_solve("https://accounts.google.com/") is True
+
+    def test_force_solve_overrides_unsolvable(self):
+        m = _reload_with_env({
+            "OPENLEGION_CAPTCHA_FORCE_SOLVE_DOMAINS": "challenges.cloudflare.com",
+        })
+        assert m.get_site_policy("https://challenges.cloudflare.com/x") == "default"
+
+    def test_skip_solve_overrides_default(self):
+        m = _reload_with_env({
+            "OPENLEGION_CAPTCHA_SKIP_SOLVE_DOMAINS": "example.com",
+            "OPENLEGION_CAPTCHA_FORCE_SOLVE_DOMAINS": "",
+        })
+        assert m.get_site_policy("https://example.com/") == "unsolvable"
+        assert m.is_skip_solve("https://example.com/") is True
+
+    def test_force_solve_wins_over_skip_solve(self):
+        # If the operator lists the same host in both, force-solve takes
+        # precedence (matches the docstring's documented order).
+        m = _reload_with_env({
+            "OPENLEGION_CAPTCHA_FORCE_SOLVE_DOMAINS": "example.com",
+            "OPENLEGION_CAPTCHA_SKIP_SOLVE_DOMAINS": "example.com",
+        })
+        assert m.get_site_policy("https://example.com/") == "default"
+
+    def test_bare_env_entry_matches_subdomains(self):
+        m = _reload_with_env({
+            "OPENLEGION_CAPTCHA_SKIP_SOLVE_DOMAINS": "evilcorp.com",
+        })
+        assert m.get_site_policy("https://www.evilcorp.com/") == "unsolvable"
+        assert m.get_site_policy("https://api.evilcorp.com/") == "unsolvable"
+        assert m.get_site_policy("https://evilcorp.com/") == "unsolvable"
+
+    def test_leading_dot_env_entry_matches_subdomains_only(self):
+        m = _reload_with_env({
+            "OPENLEGION_CAPTCHA_SKIP_SOLVE_DOMAINS": ".tenant.example.com",
+        })
+        assert m.get_site_policy("https://a.tenant.example.com/") == "unsolvable"
+        # Apex `tenant.example.com` is not in the leading-dot scope.
+        assert m.get_site_policy("https://tenant.example.com/") == "default"
+
+    def test_empty_env_var_handled(self):
+        m = _reload_with_env({
+            "OPENLEGION_CAPTCHA_FORCE_SOLVE_DOMAINS": "",
+            "OPENLEGION_CAPTCHA_SKIP_SOLVE_DOMAINS": "   ",
+        })
+        # No entries parsed; hardcoded list still drives decisions.
+        assert m.get_site_policy("https://example.com/") == "default"
+        assert m.get_site_policy("https://accounts.google.com/") == "low_success"
+
+    def test_whitespace_and_blanks_stripped(self):
+        m = _reload_with_env({
+            "OPENLEGION_CAPTCHA_SKIP_SOLVE_DOMAINS": "  one.com ,, two.com  ,",
+        })
+        assert m.get_site_policy("https://one.com/") == "unsolvable"
+        assert m.get_site_policy("https://two.com/") == "unsolvable"
+
+    def test_malformed_env_entries_skipped(self):
+        # URL-shaped entries are dropped with a warning; well-formed
+        # entries on the same line still take effect.
+        m = _reload_with_env({
+            "OPENLEGION_CAPTCHA_SKIP_SOLVE_DOMAINS":
+                "https://bad.com/path,good.com,worse.com/x?q=1",
+        })
+        assert m.get_site_policy("https://good.com/") == "unsolvable"
+        assert m.get_site_policy("https://bad.com/") == "default"
+        assert m.get_site_policy("https://worse.com/") == "default"
+
+    def test_unset_env_means_no_overrides(self):
+        # Sanity: with no env, the override predicates are False for all hosts.
+        assert captcha_policy.is_force_solve("https://accounts.google.com/") is False
+        assert captcha_policy.is_skip_solve("https://accounts.google.com/") is False
+
+
+# ── URL canonicalization edge cases ────────────────────────────────────────
+
+
+class TestURLCanonicalization:
+    def test_path_and_query_ignored(self):
+        # Only host matters — query strings and paths must not trigger
+        # spurious matches via redaction or substring search.
+        assert (
+            captcha_policy.get_site_policy(
+                "https://accounts.google.com/signin/v2/identifier?service=mail"
+            )
+            == "low_success"
+        )
+
+    def test_port_stripped(self):
+        # urlsplit().hostname drops the port for us; verify the policy
+        # still classifies correctly when one is present.
+        assert (
+            captcha_policy.get_site_policy("https://accounts.google.com:8443/")
+            == "low_success"
+        )
+
+    def test_uppercase_host_normalized(self):
+        assert (
+            captcha_policy.get_site_policy("https://ACCOUNTS.GOOGLE.COM/")
+            == "low_success"
+        )
+
+    def test_www_prefix_stripped(self):
+        # `www.linkedin.com` matches the bare `linkedin.com` entry both via
+        # the www-strip AND the suffix match — either path produces
+        # low_success. Asserts no double-strip / mis-strip surprises.
+        assert (
+            captcha_policy.get_site_policy("https://www.linkedin.com/")
+            == "low_success"
+        )
+
+    def test_ipv6_host_handled_gracefully(self):
+        # IPv6 hostnames don't appear in our hardcoded list, and bracket
+        # parsing must not raise. Result: default.
+        assert captcha_policy.get_site_policy("https://[::1]/") == "default"
+        assert (
+            captcha_policy.get_site_policy("https://[2001:db8::1]:8443/path")
+            == "default"
+        )
+
+    def test_malformed_url_returns_default(self):
+        # Truly broken inputs → default (fail-open). The solver pipeline
+        # downstream has its own gates.
+        assert captcha_policy.get_site_policy("not a url at all") == "default"
+        assert captcha_policy.get_site_policy("") == "default"
+
+    def test_non_string_input_returns_default(self):
+        # Defensive: caller bug shouldn't crash a hot-path lookup.
+        assert captcha_policy.get_site_policy(None) == "default"  # type: ignore[arg-type]
+
+    def test_url_with_userinfo_uses_host(self):
+        # ``user:pass@host`` → host is what matters.
+        assert (
+            captcha_policy.get_site_policy("https://user:pass@accounts.google.com/")
+            == "low_success"
+        )
+
+    def test_no_scheme_url_returns_default(self):
+        # urlsplit on a bare hostname yields no `hostname` attribute →
+        # we treat it as unparseable and fall through to default.
+        assert captcha_policy.get_site_policy("accounts.google.com/x") == "default"

--- a/tests/test_captcha_policy.py
+++ b/tests/test_captcha_policy.py
@@ -97,10 +97,50 @@ class TestHardcodedClassification:
             == "low_success"
         )
 
-    def test_signup_amazon_subdomain_is_low_success(self):
+    def test_amazon_apex_is_low_success(self):
+        # Amazon's auth portal lives at amazon.com/ap/{register,signin}.
+        # There is no signup.amazon.com (NXDOMAIN); apex-scoping is the
+        # right granularity given Amazon's site-wide bot-detection posture.
         assert (
-            captcha_policy.get_site_policy("https://us.signup.amazon.com/")
+            captcha_policy.get_site_policy("https://www.amazon.com/ap/register")
             == "low_success"
+        )
+        assert (
+            captcha_policy.get_site_policy("https://amazon.com/")
+            == "low_success"
+        )
+
+    def test_accounts_google_subdomain_match(self):
+        # Hardcoded entries use the SAME bare-domain matching rule as
+        # operator overrides — they match the listed host AND any deeper
+        # subdomain.  Documenting this explicitly so future maintainers
+        # don't assume "host-exact" semantics for the hardcoded list.
+        assert (
+            captcha_policy.get_site_policy("https://foo.accounts.google.com/")
+            == "low_success"
+        )
+
+    def test_x_com_subdomain_match(self):
+        # ``x.com`` is a one-letter eTLD+1; verify single-character labels
+        # don't confuse the matcher.  ``mobile.x.com`` is intentionally
+        # classified low_success along with the apex (Twitter/X serve the
+        # same risky auth flow at any sub-host).
+        assert captcha_policy.get_site_policy("https://x.com/") == "low_success"
+        assert (
+            captcha_policy.get_site_policy("https://mobile.x.com/")
+            == "low_success"
+        )
+
+    def test_x_com_does_not_falsely_match_suffix_collisions(self):
+        # The dot-boundary check has to hold even for one-letter eTLD+1
+        # entries: ``evilx.com`` ends with ``x.com`` as a substring but
+        # not as a labeled suffix, so it must NOT match.  Same for the
+        # ``x.com.attacker.io`` shape (host that contains the entry but
+        # extends past it).
+        assert captcha_policy.get_site_policy("https://evilx.com/") == "default"
+        assert (
+            captcha_policy.get_site_policy("https://x.com.attacker.io/")
+            == "default"
         )
 
     def test_cloudflare_challenge_is_unsolvable(self):
@@ -227,6 +267,71 @@ class TestOperatorOverrides:
         assert captcha_policy.is_force_solve("https://accounts.google.com/") is False
         assert captcha_policy.is_skip_solve("https://accounts.google.com/") is False
 
+    def test_wildcard_prefix_normalized_to_bare_domain(self):
+        # ``*.example.com`` is the canonical DNS / firewall syntax for
+        # "every subdomain of example.com".  We strip the prefix and treat
+        # it as a bare-domain entry (which already covers apex + every
+        # subdomain via suffix match).  Critically, the entry must NOT be
+        # kept as the literal string ``*.example.com`` — that would never
+        # match any real page and would silently swallow operator intent.
+        m = _reload_with_env({
+            "OPENLEGION_CAPTCHA_SKIP_SOLVE_DOMAINS": "*.example.com",
+        })
+        assert "*.example.com" not in m._SKIP_SOLVE_DOMAINS
+        assert "example.com" in m._SKIP_SOLVE_DOMAINS
+        assert m.get_site_policy("https://a.example.com/") == "unsolvable"
+        assert m.get_site_policy("https://example.com/") == "unsolvable"
+
+    def test_bare_star_entry_dropped(self):
+        # A token that's just ``*`` (or ``*.``) leaves nothing after
+        # stripping — drop with a warning, don't crash, don't silently
+        # accept a frozenset entry of ``""`` that would match every host.
+        m = _reload_with_env({
+            "OPENLEGION_CAPTCHA_SKIP_SOLVE_DOMAINS": "*,*.,good.com",
+        })
+        assert "" not in m._SKIP_SOLVE_DOMAINS
+        assert "." not in m._SKIP_SOLVE_DOMAINS
+        assert "good.com" in m._SKIP_SOLVE_DOMAINS
+        # Sanity: an unrelated host should NOT match — proves ``""`` did
+        # not sneak into the frozenset (``host.endswith("")`` is True).
+        assert m.get_site_policy("https://unrelated.io/") == "default"
+
+    def test_whitespace_only_env_yields_no_entries(self):
+        # Pathological values like " , , " must parse to empty without
+        # warnings — operators commonly leave commented-out entries around.
+        m = _reload_with_env({
+            "OPENLEGION_CAPTCHA_FORCE_SOLVE_DOMAINS": " , , ",
+            "OPENLEGION_CAPTCHA_SKIP_SOLVE_DOMAINS": ",,,",
+        })
+        assert m._FORCE_SOLVE_DOMAINS == frozenset()
+        assert m._SKIP_SOLVE_DOMAINS == frozenset()
+
+    def test_force_and_skip_helpers_are_independent(self):
+        # is_force_solve / is_skip_solve return their raw membership;
+        # precedence is applied only inside get_site_policy.  When the
+        # operator lists the same host in both, both helpers say True
+        # and the policy resolves to "default" (force wins).
+        m = _reload_with_env({
+            "OPENLEGION_CAPTCHA_FORCE_SOLVE_DOMAINS": "dual.com",
+            "OPENLEGION_CAPTCHA_SKIP_SOLVE_DOMAINS": "dual.com",
+        })
+        assert m.is_force_solve("https://dual.com/") is True
+        assert m.is_skip_solve("https://dual.com/") is True
+        assert m.get_site_policy("https://dual.com/") == "default"
+
+    def test_env_override_matches_subdomains_like_hardcoded(self):
+        # Confirms the docstring's "no asymmetry" claim: an env entry
+        # ``google.com`` matches every google sub-host, exactly the same
+        # as if ``google.com`` were in the hardcoded list.
+        m = _reload_with_env({
+            "OPENLEGION_CAPTCHA_FORCE_SOLVE_DOMAINS": "google.com",
+        })
+        # accounts.google.com is a hardcoded LOW_SUCCESS entry; force-solve
+        # on the registrable domain neutralizes it.
+        assert m.get_site_policy("https://accounts.google.com/") == "default"
+        assert m.get_site_policy("https://mail.google.com/") == "default"
+        assert m.get_site_policy("https://google.com/") == "default"
+
 
 # ── URL canonicalization edge cases ────────────────────────────────────────
 
@@ -295,3 +400,26 @@ class TestURLCanonicalization:
         # urlsplit on a bare hostname yields no `hostname` attribute →
         # we treat it as unparseable and fall through to default.
         assert captcha_policy.get_site_policy("accounts.google.com/x") == "default"
+
+    def test_hostless_schemes_return_default(self):
+        # ``data:``, ``file:``, and ``about:`` have no host → default
+        # (fail-open).  Verifies _hostname() doesn't raise on these.
+        assert captcha_policy.get_site_policy("data:text/html,<p>hi</p>") == "default"
+        assert captcha_policy.get_site_policy("file:///etc/hosts") == "default"
+        assert captcha_policy.get_site_policy("about:blank") == "default"
+        # ``https://`` with no authority component also has no host.
+        assert captcha_policy.get_site_policy("https://") == "default"
+
+    def test_idn_punycode_match_literal_form(self):
+        # IDN matching is literal-form: the IDN unicode form and its
+        # punycode (``xn--``) equivalent are NOT auto-normalized to each
+        # other.  Operators who care about both forms must list both.
+        # This test pins the documented behavior so a future "helpfully"
+        # auto-IDNA-encoding change doesn't slip through unnoticed.
+        m = _reload_with_env({
+            "OPENLEGION_CAPTCHA_SKIP_SOLVE_DOMAINS": "xn--wgv71a.jp",
+        })
+        # Punycode form in URL → matches the punycode entry.
+        assert m.get_site_policy("https://xn--wgv71a.jp/") == "unsolvable"
+        # Unicode form in URL → does NOT match the punycode entry.
+        assert m.get_site_policy("https://日本.jp/") == "default"


### PR DESCRIPTION
## Summary

New self-contained `src/browser/captcha_policy.py` module that classifies a page URL into one of three categories used by the captcha solve pipeline:

- **`unsolvable`** — captcha is behavioral-only or fingerprint-locked. Never charge solver. Always escalate via `request_captcha_help`.
- **`low_success`** — captcha is technically solvable but token-IP / fingerprint sensitive (Google signup, Twitter/X signup, LinkedIn auth). Solver attempted ONCE at `solver_confidence: "low"`; on failure, escalate.
- **`default`** — normal solver flow.

Policy precedence: `OPENLEGION_CAPTCHA_FORCE_SOLVE_DOMAINS` env > `OPENLEGION_CAPTCHA_SKIP_SOLVE_DOMAINS` env > hardcoded UNSOLVABLE list > hardcoded LOW_SUCCESS list > `default`.

- **API**: `get_site_policy(url)`, `is_force_solve(url)`, `is_skip_solve(url)`.
- **Domain match**: bare domain matches eTLD+1 + all subdomains; leading-dot is subdomains-only. Documented with examples.
- **Hardcoded UNSOLVABLE list deliberately kept short** (3 entries) per §11.18 "start short, let operators expand" guidance — operational maintenance via env override.
- **Pure stdlib** (urllib.parse + frozensets + module-level cache); ~2.4ms import time.
- **No per-call logging** — module-level logger fires only at startup for env-parse warnings.

NOT consumed yet by `captcha.py` or `service.py` — wiring deferred to §11.16-consumer / future PRs per the spec.

Plan: `docs/plans/2026-04-20-browser-automation.md` §11.18.

## Test plan

- [x] 33 new tests in `tests/test_captcha_policy.py` across 4 classes — all spec items + extras (uppercase host, userinfo, no-scheme, IPv6, port, malformed URLs, force-vs-skip precedence).
- [x] `tests/test_browser_flags.py` — 30 passed (no regression from `KNOWN_FLAGS` doc-row addition).
- [x] `ruff check` — clean.