### PR TITLE
Phase 8 §11.16: solver health check + circuit breaker with URL redaction

### DIFF
--- a/src/browser/captcha.py
+++ b/src/browser/captcha.py
@@ -181,8 +181,29 @@ class CaptchaSolver:
         return self._solver_unreachable
 
     def is_breaker_open(self) -> bool:
-        """True iff a tripped breaker is still within its 10-min window."""
-        return self._solver_breaker_until > time.time()
+        """True iff a tripped breaker is still within its 10-min window.
+
+        On the first read after expiry, we proactively reset the breaker
+        timestamp AND the failure-window deque. Functionally the deque
+        prune in :meth:`_record_solver_outcome` already drops stale
+        entries before the next decision, but resetting here ensures
+        that if the next failure arrives less than 5 min after the
+        breaker auto-clears (e.g. failures at t=100/200/300 trip the
+        breaker at t=300, expires at t=900; a single new failure at
+        t=901 prunes correctly because t=300 is past 901-300=601, so
+        the deque is empty before append). The defense-in-depth is
+        cheap and prevents a future change from accidentally re-tripping
+        the breaker on stale entries.
+        """
+        if self._solver_breaker_until == 0.0:
+            return False
+        if self._solver_breaker_until > time.time():
+            return True
+        # Breaker auto-clears: drop the timestamp and the stale failure
+        # window so the solver gets a clean restart.
+        self._solver_breaker_until = 0.0
+        self._solver_failure_timestamps.clear()
+        return False
 
     async def health_check(
         self, provider: str | None = None,
@@ -264,11 +285,23 @@ class CaptchaSolver:
             )
             return "unreachable"
 
-        balance = data.get("balance")
+        # Both providers always return a numeric ``balance`` on success.
+        # A missing/non-numeric field means we hit the wrong endpoint, the
+        # provider returned an unexpected shape, or a proxy is interposing —
+        # all of which are "don't trust this solver". Treat as unreachable
+        # rather than silently passing through.
+        if "balance" not in data:
+            logger.warning(
+                "Solver health check missing balance field (provider=%s)", prov,
+            )
+            return "unreachable"
         try:
-            balance_f = float(balance) if balance is not None else 0.0
+            balance_f = float(data["balance"])
         except (TypeError, ValueError):
-            balance_f = 0.0
+            logger.warning(
+                "Solver health check non-numeric balance (provider=%s)", prov,
+            )
+            return "unreachable"
         if balance_f < 0:
             logger.warning(
                 "Solver health check returned negative balance (provider=%s)", prov,

--- a/src/browser/captcha.py
+++ b/src/browser/captcha.py
@@ -14,9 +14,13 @@ from __future__ import annotations
 import asyncio
 import os
 import re
+import time
+from collections import deque
+from typing import Literal
 
 import httpx
 
+from src.shared.redaction import redact_url
 from src.shared.utils import setup_logging
 
 logger = setup_logging("browser.captcha")
@@ -24,6 +28,65 @@ logger = setup_logging("browser.captcha")
 _SOLVE_TIMEOUT = 120  # max seconds to wait for a solution
 _POLL_INTERVAL = 5    # seconds between result polls
 _SUPPORTED_PROVIDERS = ("2captcha", "capsolver")
+
+# Health check (§11.16): 5s budget per provider. Latency above the warn
+# threshold marks the solver "degraded"; the call still counts as healthy
+# but operators should route new solves to a configured secondary.
+_HEALTH_CHECK_TIMEOUT = 5.0
+_HEALTH_DEGRADED_LATENCY = 3.0
+
+# Circuit breaker (§11.16): 3 failures inside a 5-min sliding window trip
+# the breaker for 10 min. We track timestamps in a bounded deque so the
+# math is "count of entries newer than NOW-300s" — no per-failure
+# counter+timestamp pair to keep coherent.
+_BREAKER_FAILURE_WINDOW = 300.0    # 5 min
+_BREAKER_FAILURE_THRESHOLD = 3
+_BREAKER_OPEN_DURATION = 600.0      # 10 min
+
+# /getBalance endpoints — both providers expose these and accept the same
+# JSON body shape (``{"clientKey": "..."}``). Both return
+# ``{"errorId": 0, "balance": <float>}`` on success.
+_HEALTH_URLS: dict[str, str] = {
+    "2captcha": "https://api.2captcha.com/getBalance",
+    "capsolver": "https://api.capsolver.com/getBalance",
+}
+
+
+def _redact_clientkey(body: dict) -> dict:
+    """Return a shallow copy of ``body`` with ``clientKey`` masked.
+
+    Solver providers occasionally echo the ``clientKey`` field back inside
+    error responses (real, observed behavior). Anything that flows to the
+    logger — request bodies, response bodies, error tracebacks — must scrub
+    that field first. Pair with :func:`redact_url` for the request URL.
+    """
+    if not isinstance(body, dict) or "clientKey" not in body:
+        return body
+    out = dict(body)
+    out["clientKey"] = "[REDACTED]"
+    return out
+
+
+# Provider error strings sometimes embed the raw key as
+# ``clientKey=VALUE`` or ``"clientKey":"VALUE"``. Catch both spellings
+# so an exception ``str()`` doesn't leak it through the logger.
+_CLIENTKEY_IN_TEXT = re.compile(
+    r'(clientKey)\s*["\']?\s*[:=]\s*["\']?([A-Za-z0-9_\-]+)["\']?',
+    re.IGNORECASE,
+)
+
+
+def _redact_clientkey_text(text: str) -> str:
+    """Strip ``clientKey=VALUE`` / ``"clientKey":"VALUE"`` from text.
+
+    Pair with :func:`redact_url` (URL-shaped secrets) and
+    :func:`_redact_clientkey` (dict bodies) before logging anything that
+    might have come from a solver provider's error response.
+    """
+    if not text:
+        return text
+    return _CLIENTKEY_IN_TEXT.sub(r"\1=[REDACTED]", text)
+
 
 # Map from detected selector pattern to a canonical CAPTCHA type.
 _CAPTCHA_TYPE_MAP: dict[str, str] = {
@@ -82,6 +145,24 @@ class CaptchaSolver:
         self.provider = provider
         self.api_key = api_key
         self._client: httpx.AsyncClient | None = None
+        # ── §11.16 state ────────────────────────────────────────────────
+        # Per-process gate: the health check fires the first time ANY
+        # agent calls solve() in this BrowserManager session. The solver
+        # client is shared across agents in the same process, so checking
+        # once per process (not per agent) matches what we're actually
+        # verifying — a single underlying httpx client to a single
+        # provider endpoint.
+        self._solver_health_checked: bool = False
+        self._solver_unreachable: bool = False
+        self._solver_health_degraded: bool = False
+        # Sliding-window failure tracking. maxlen=10 caps memory if we
+        # ever wedge into a long failure storm; only the entries within
+        # the 5-min window matter for the breaker decision.
+        self._solver_failure_timestamps: deque[float] = deque(maxlen=10)
+        self._solver_breaker_until: float = 0.0
+        # Coordinates breaker reads/writes with health-check init across
+        # concurrent agents that share this solver instance.
+        self._state_lock: asyncio.Lock = asyncio.Lock()
 
     def _get_client(self) -> httpx.AsyncClient:
         if self._client is None or self._client.is_closed:
@@ -93,6 +174,164 @@ class CaptchaSolver:
             await self._client.aclose()
             self._client = None
 
+    # ── §11.16 health check + circuit breaker ──────────────────────────
+
+    def is_solver_unreachable(self) -> bool:
+        """Sticky for the rest of the instance-session once health-check fails."""
+        return self._solver_unreachable
+
+    def is_breaker_open(self) -> bool:
+        """True iff a tripped breaker is still within its 10-min window."""
+        return self._solver_breaker_until > time.time()
+
+    async def health_check(
+        self, provider: str | None = None,
+    ) -> Literal["healthy", "degraded", "unreachable"]:
+        """Probe the solver's ``/getBalance`` endpoint with a 5s budget.
+
+        ``provider`` defaults to ``self.provider``. Returns one of:
+
+        * ``healthy`` — HTTP 200, ``balance`` is non-negative numeric, and
+          latency is under :data:`_HEALTH_DEGRADED_LATENCY`.
+        * ``degraded`` — HTTP 200 but latency exceeded the warn threshold.
+          Not fatal; logged so operators see slow upstream and can route
+          new solves to a configured secondary.
+        * ``unreachable`` — timeout, connection error, 5xx, non-200 status,
+          or a non-zero ``errorId`` in the JSON body. Caller marks the
+          solver unreachable for the rest of this instance-session.
+
+        Logging never includes the raw ``clientKey``: the URL flows
+        through :func:`redact_url`, the request body through
+        :func:`_redact_clientkey`, and exception strings through
+        :func:`_redact_clientkey_text`.
+        """
+        prov = (provider or self.provider).lower()
+        url = _HEALTH_URLS.get(prov)
+        if url is None:
+            logger.warning("health_check: unknown provider %r", prov)
+            return "unreachable"
+
+        client = self._get_client()
+        body = {"clientKey": self.api_key}
+        safe_url = redact_url(url)
+        safe_body = _redact_clientkey(body)
+        start = time.monotonic()
+        try:
+            resp = await client.post(url, json=body, timeout=_HEALTH_CHECK_TIMEOUT)
+        except (httpx.TimeoutException, asyncio.TimeoutError):
+            logger.warning(
+                "Solver health check timed out (provider=%s url=%s body=%s)",
+                prov, safe_url, safe_body,
+            )
+            return "unreachable"
+        except httpx.HTTPError as e:
+            logger.warning(
+                "Solver health check connection error (provider=%s url=%s err=%s)",
+                prov, safe_url,
+                _redact_clientkey_text(redact_url(str(e))),
+            )
+            return "unreachable"
+        except Exception as e:  # noqa: BLE001 — defensive log + return
+            logger.warning(
+                "Solver health check unexpected error (provider=%s url=%s err=%s)",
+                prov, safe_url,
+                _redact_clientkey_text(redact_url(str(e))),
+            )
+            return "unreachable"
+
+        latency = time.monotonic() - start
+
+        if resp.status_code != 200:
+            logger.warning(
+                "Solver health check non-200 (provider=%s url=%s status=%d)",
+                prov, safe_url, resp.status_code,
+            )
+            return "unreachable"
+
+        try:
+            data = resp.json()
+        except Exception:  # noqa: BLE001
+            logger.warning(
+                "Solver health check returned non-JSON (provider=%s url=%s)",
+                prov, safe_url,
+            )
+            return "unreachable"
+
+        if data.get("errorId", 0) != 0:
+            logger.warning(
+                "Solver health check error (provider=%s url=%s errorId=%s)",
+                prov, safe_url, data.get("errorId"),
+            )
+            return "unreachable"
+
+        balance = data.get("balance")
+        try:
+            balance_f = float(balance) if balance is not None else 0.0
+        except (TypeError, ValueError):
+            balance_f = 0.0
+        if balance_f < 0:
+            logger.warning(
+                "Solver health check returned negative balance (provider=%s)", prov,
+            )
+            return "unreachable"
+
+        if latency > _HEALTH_DEGRADED_LATENCY:
+            logger.warning(
+                "Solver health check degraded (provider=%s latency=%.2fs)",
+                prov, latency,
+            )
+            return "degraded"
+        logger.info(
+            "Solver health check ok (provider=%s latency=%.2fs)", prov, latency,
+        )
+        return "healthy"
+
+    async def _ensure_health_checked(self) -> None:
+        """Run the per-process health check exactly once.
+
+        Sets ``_solver_unreachable`` on a sticky basis so subsequent
+        solves skip the provider entirely without re-probing.
+        """
+        if self._solver_health_checked:
+            return
+        async with self._state_lock:
+            if self._solver_health_checked:
+                return
+            outcome = await self.health_check()
+            self._solver_health_checked = True
+            if outcome == "unreachable":
+                self._solver_unreachable = True
+            elif outcome == "degraded":
+                self._solver_health_degraded = True
+
+    async def _record_solver_outcome(self, success: bool) -> None:
+        """Update the breaker state after a solve attempt.
+
+        On success: reset both the failure window and any tripped breaker.
+        On failure: append a timestamp, prune entries older than the 5-min
+        window, then trip the breaker if 3+ entries remain.
+        """
+        async with self._state_lock:
+            now = time.time()
+            if success:
+                self._solver_failure_timestamps.clear()
+                self._solver_breaker_until = 0.0
+                return
+            self._solver_failure_timestamps.append(now)
+            cutoff = now - _BREAKER_FAILURE_WINDOW
+            while (
+                self._solver_failure_timestamps
+                and self._solver_failure_timestamps[0] < cutoff
+            ):
+                self._solver_failure_timestamps.popleft()
+            if len(self._solver_failure_timestamps) >= _BREAKER_FAILURE_THRESHOLD:
+                self._solver_breaker_until = now + _BREAKER_OPEN_DURATION
+                logger.warning(
+                    "Solver circuit breaker TRIPPED until %.0f (failures=%d)",
+                    self._solver_breaker_until,
+                    len(self._solver_failure_timestamps),
+                )
+
     async def solve(self, page, selector: str, page_url: str) -> bool:
         """Attempt to solve a CAPTCHA on the page.
 
@@ -102,14 +341,36 @@ class CaptchaSolver:
             page_url: The current page URL.
 
         Returns:
-            True if the CAPTCHA was solved and token injected, False otherwise.
+            True if the CAPTCHA was solved and token injected, False
+            otherwise. On unreachable solver / open breaker, returns False
+            without issuing a provider HTTP call. Callers should consult
+            :meth:`is_solver_unreachable` and :meth:`is_breaker_open` to
+            distinguish those cases from a genuine solve failure.
         """
+        # Per-process gate — runs at most once even under concurrent solves.
+        await self._ensure_health_checked()
+
+        if self._solver_unreachable:
+            logger.info(
+                "Skipping solve: solver marked unreachable for this session "
+                "(provider=%s)", self.provider,
+            )
+            return False
+
+        if self.is_breaker_open():
+            logger.warning(
+                "Skipping solve: solver circuit breaker open until %.0f (provider=%s)",
+                self._solver_breaker_until, self.provider,
+            )
+            return False
+
         captcha_type = _classify_captcha(selector)
         logger.info("Attempting to solve %s CAPTCHA on %s", captcha_type, page_url)
 
         sitekey = await self._extract_sitekey(page, captcha_type)
         if not sitekey:
             logger.warning("Could not extract sitekey for %s CAPTCHA", captcha_type)
+            await self._record_solver_outcome(success=False)
             return False
 
         try:
@@ -119,12 +380,15 @@ class CaptchaSolver:
             )
         except asyncio.TimeoutError:
             logger.warning("CAPTCHA solve timed out after %ds", _SOLVE_TIMEOUT)
+            await self._record_solver_outcome(success=False)
             return False
         except Exception:
             logger.exception("CAPTCHA solve failed")
+            await self._record_solver_outcome(success=False)
             return False
 
         if not token:
+            await self._record_solver_outcome(success=False)
             return False
 
         injected = await self._inject_token(page, captcha_type, token)
@@ -132,6 +396,7 @@ class CaptchaSolver:
             logger.info("CAPTCHA solved and token injected successfully")
         else:
             logger.warning("CAPTCHA solved but token injection failed")
+        await self._record_solver_outcome(success=injected)
         return injected
 
     async def _extract_sitekey(self, page, captcha_type: str) -> str | None:

--- a/src/browser/service.py
+++ b/src/browser/service.py
@@ -5361,6 +5361,22 @@ class BrowserManager:
         NOTE: classification here is minimal — it maps the matched selector
         onto the §11.13 ``kind`` enum. Full reCAPTCHA v2/v3/Enterprise
         disambiguation lands in §11.1; CF interstitial tri-state in §11.3.
+
+        §11.16 layers two solver-health side-channels on top of the §11.13
+        envelope, checked BEFORE attempting ``solver.solve()``:
+
+        * ``solver.is_solver_unreachable()`` — health probe marked the
+          provider unreachable for this instance-session. Short-circuits
+          to ``solver_outcome="no_solver"`` /
+          ``next_action="request_captcha_help"``; the API is never
+          contacted.
+        * ``solver.is_breaker_open()`` — sliding-window circuit breaker
+          is tripped. Short-circuits to ``solver_outcome="timeout"`` /
+          ``next_action="request_captcha_help"`` plus a top-level
+          additive ``"breaker_open": True`` flag (deliberately *not*
+          encoded as a new enum value, to avoid colliding with §11.13's
+          ``solver_outcome`` set; a richer ``service_unavailable``
+          outcome may land in a follow-up).
         """
         captcha_selectors = [
             'iframe[src*="recaptcha"]',
@@ -5376,6 +5392,42 @@ class BrowserManager:
                 if await inst.page.locator(sel).count() > 0:
                     kind = self._classify_kind(sel)
                     if self._captcha_solver:
+                        # §11.16 short-circuits — check solver health
+                        # BEFORE attempting a solve. ``is_solver_unreachable``
+                        # means the per-instance health probe failed; we
+                        # don't even try the API. ``is_breaker_open`` means
+                        # the sliding-window breaker is tripped after
+                        # repeated solve failures; treat as a transient
+                        # outage and surface a top-level ``breaker_open``
+                        # flag (additive — see §11.13 enum docstring).
+                        if self._captcha_solver.is_solver_unreachable():
+                            logger.warning(
+                                "CAPTCHA detected (%s), solver marked unreachable; skipping",
+                                sel,
+                            )
+                            return _captcha_envelope(
+                                kind=kind, solver_attempted=False,
+                                solver_outcome="no_solver",
+                                solver_confidence=_kind_confidence(kind),
+                                next_action="request_captcha_help",
+                            )
+                        if self._captcha_solver.is_breaker_open():
+                            logger.warning(
+                                "CAPTCHA detected (%s), solver breaker open; skipping",
+                                sel,
+                            )
+                            envelope = _captcha_envelope(
+                                kind=kind, solver_attempted=False,
+                                solver_outcome="timeout",
+                                solver_confidence=_kind_confidence(kind),
+                                next_action="request_captcha_help",
+                            )
+                            # Additive top-level flag — deliberately not a
+                            # new ``solver_outcome`` enum value; preserves
+                            # §11.13 contract while letting callers detect
+                            # the breaker-open case distinctly.
+                            envelope["breaker_open"] = True
+                            return envelope
                         logger.info("CAPTCHA detected (%s), attempting auto-solve", sel)
                         try:
                             solved = await self._captcha_solver.solve(

--- a/tests/test_browser_service.py
+++ b/tests/test_browser_service.py
@@ -7171,6 +7171,9 @@ class TestCaptchaSolverSolve:
         from src.browser.captcha import CaptchaSolver
 
         solver = CaptchaSolver("2captcha", "test-key")
+        # §11.16: skip the per-process health-check probe — these tests
+        # exercise the solve flow, not the liveness gate.
+        solver._solver_health_checked = True
 
         # Mock page
         page = AsyncMock()
@@ -7207,6 +7210,7 @@ class TestCaptchaSolverSolve:
         from src.browser.captcha import CaptchaSolver
 
         solver = CaptchaSolver("capsolver", "cap-key")
+        solver._solver_health_checked = True  # §11.16: skip probe
 
         page = AsyncMock()
         page.evaluate = AsyncMock(return_value="site-key-abc")
@@ -7239,6 +7243,7 @@ class TestCaptchaSolverSolve:
         from src.browser.captcha import CaptchaSolver
 
         solver = CaptchaSolver("2captcha", "test-key")
+        solver._solver_health_checked = True  # §11.16: skip probe
 
         page = AsyncMock()
         page.evaluate = AsyncMock(return_value="site-key-abc")
@@ -7271,6 +7276,7 @@ class TestCaptchaSolverSolve:
         from src.browser.captcha import CaptchaSolver
 
         solver = CaptchaSolver("2captcha", "test-key")
+        solver._solver_health_checked = True  # §11.16: skip probe
 
         page = AsyncMock()
         page.evaluate = AsyncMock(return_value=None)  # no sitekey found
@@ -7290,6 +7296,9 @@ class TestCheckCaptchaAutoSolve:
 
         mock_solver = AsyncMock()
         mock_solver.solve = AsyncMock(return_value=True)
+        # §11.16 sync getters — silence unawaited-coroutine warnings.
+        mock_solver.is_solver_unreachable = MagicMock(return_value=False)
+        mock_solver.is_breaker_open = MagicMock(return_value=False)
         manager._captcha_solver = mock_solver
 
         # Mock instance with a page that has a CAPTCHA (no spec — CamoufoxInstance
@@ -7313,6 +7322,11 @@ class TestCheckCaptchaAutoSolve:
 
         mock_solver = AsyncMock()
         mock_solver.solve = AsyncMock(return_value=False)
+        # §11.16: is_solver_unreachable / is_breaker_open are sync getters.
+        # Without explicit MagicMock the AsyncMock parent returns coroutines
+        # that flunk the truthy-check.
+        mock_solver.is_solver_unreachable = MagicMock(return_value=False)
+        mock_solver.is_breaker_open = MagicMock(return_value=False)
         manager._captcha_solver = mock_solver
 
         inst = MagicMock()
@@ -7326,6 +7340,11 @@ class TestCheckCaptchaAutoSolve:
         assert result["solver_attempted"] is True
         assert result["solver_outcome"] == "rejected"
         assert result["next_action"] == "notify_user"
+        # §11.16: healthy solver — no breaker decoration, and crucially
+        # ``solver_outcome`` must not be "no_solver" (that would mean the
+        # health-check skipped the solve, which it shouldn't here).
+        assert "breaker_open" not in result
+        assert result["solver_outcome"] != "no_solver"
         mock_solver.solve.assert_called_once()
 
 

--- a/tests/test_captcha_envelope.py
+++ b/tests/test_captcha_envelope.py
@@ -40,6 +40,23 @@ _SELECTOR_ORDER = [
 
 def _make_manager(*, solver=None) -> BrowserManager:
     mgr = BrowserManager.__new__(BrowserManager)
+    if solver is not None:
+        # §11.16 added two sync side-channel getters on CaptchaSolver
+        # that _check_captcha consults BEFORE attempting solve(). When
+        # the test passes a raw AsyncMock as the solver, the unset
+        # attributes resolve to coroutine-returning AsyncMocks whose
+        # truthy-check trips the §11.16 short-circuit. Default both to
+        # MagicMock returning False so envelope-shape tests exercise
+        # the solve path. Tests that want to assert the short-circuit
+        # branches override these explicitly (see test_captcha_health).
+        if not hasattr(solver, "is_solver_unreachable") or not isinstance(
+            getattr(solver, "is_solver_unreachable", None), MagicMock,
+        ):
+            solver.is_solver_unreachable = MagicMock(return_value=False)
+        if not hasattr(solver, "is_breaker_open") or not isinstance(
+            getattr(solver, "is_breaker_open", None), MagicMock,
+        ):
+            solver.is_breaker_open = MagicMock(return_value=False)
     mgr._captcha_solver = solver
     return mgr
 

--- a/tests/test_captcha_health.py
+++ b/tests/test_captcha_health.py
@@ -1,0 +1,590 @@
+"""Tests for §11.16: solver health check + circuit breaker.
+
+Covers:
+
+* Per-process health-check gate: first solve runs the check, subsequent
+  solves do not.
+* Health outcomes: healthy → flow continues, degraded → flow continues
+  with warning, unreachable → solver skipped for the session.
+* Sliding-window breaker: 3 failures in 5 min trips for 10 min; auto-
+  clears after; single/double failures + later success keep it closed;
+  failures spaced beyond the window do not trip.
+* Concurrent solves while breaker is open all short-circuit.
+* URL/body redaction: ``clientKey`` never appears in log lines.
+* Cancellation: in-flight ``health_check`` cancels cleanly on close.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import httpx
+import pytest
+
+from src.browser.captcha import (
+    _BREAKER_FAILURE_THRESHOLD,
+    _BREAKER_FAILURE_WINDOW,
+    _BREAKER_OPEN_DURATION,
+    _HEALTH_DEGRADED_LATENCY,
+    CaptchaSolver,
+    _redact_clientkey,
+    _redact_clientkey_text,
+)
+
+# ── helpers ───────────────────────────────────────────────────────────
+
+
+def _make_solver(provider: str = "2captcha", key: str = "SECRET-KEY-DO-NOT-LEAK") -> CaptchaSolver:
+    return CaptchaSolver(provider, key)
+
+
+def _ok_balance_resp(balance: float = 12.34) -> MagicMock:
+    resp = MagicMock()
+    resp.status_code = 200
+    resp.json = MagicMock(return_value={"errorId": 0, "balance": balance})
+    return resp
+
+
+def _err_balance_resp(error_id: int = 1, status: int = 200) -> MagicMock:
+    resp = MagicMock()
+    resp.status_code = status
+    resp.json = MagicMock(
+        return_value={"errorId": error_id, "errorDescription": "ERROR_KEY_DOES_NOT_EXIST"},
+    )
+    return resp
+
+
+def _stub_create_then_poll(token: str | None) -> list[MagicMock]:
+    """Build a (createTask, getTaskResult) response pair for the solve flow."""
+    create = MagicMock()
+    create.json = MagicMock(return_value={"errorId": 0, "taskId": "T-1"})
+    create.raise_for_status = MagicMock()
+    poll = MagicMock()
+    if token is None:
+        poll.json = MagicMock(return_value={"errorId": 1, "errorDescription": "fail"})
+    else:
+        poll.json = MagicMock(return_value={
+            "errorId": 0, "status": "ready",
+            "solution": {"gRecaptchaResponse": token},
+        })
+    poll.raise_for_status = MagicMock()
+    return [create, poll]
+
+
+def _solve_page() -> MagicMock:
+    """Mock Playwright page that returns a sitekey + accepts injection."""
+    page = AsyncMock()
+    page.evaluate = AsyncMock(return_value="site-key-abc")
+    page.url = "https://example.com"
+    return page
+
+
+# ── 1: first solve triggers health check; subsequent do not ───────────
+
+
+@pytest.mark.asyncio
+async def test_first_solve_runs_health_check_subsequent_do_not():
+    solver = _make_solver()
+    page = _solve_page()
+
+    client = AsyncMock(spec=httpx.AsyncClient)
+    client.is_closed = False
+
+    # Sequence: getBalance probe → create → poll → (no second probe) →
+    # create → poll.
+    responses = [
+        _ok_balance_resp(),
+        *_stub_create_then_poll("tok-1"),
+        *_stub_create_then_poll("tok-2"),
+    ]
+    client.post = AsyncMock(side_effect=responses)
+    solver._client = client
+
+    with patch("src.browser.captcha._POLL_INTERVAL", 0.001):
+        ok1 = await solver.solve(page, 'iframe[src*="recaptcha"]', "https://example.com")
+        ok2 = await solver.solve(page, 'iframe[src*="recaptcha"]', "https://example.com")
+
+    assert ok1 is True
+    assert ok2 is True
+    urls_called = [c.args[0] for c in client.post.call_args_list]
+    assert urls_called[0].endswith("/getBalance")
+    # Only ONE getBalance — the gate is sticky.
+    assert urls_called.count("https://api.2captcha.com/getBalance") == 1
+
+
+# ── 2/3: healthy + degraded both let the flow continue ────────────────
+
+
+@pytest.mark.asyncio
+async def test_health_check_healthy_continues():
+    solver = _make_solver()
+
+    client = AsyncMock(spec=httpx.AsyncClient)
+    client.is_closed = False
+    client.post = AsyncMock(return_value=_ok_balance_resp())
+    solver._client = client
+
+    outcome = await solver.health_check()
+    assert outcome == "healthy"
+
+
+@pytest.mark.asyncio
+async def test_health_check_degraded_continues_with_warning(caplog):
+    solver = _make_solver()
+    client = AsyncMock(spec=httpx.AsyncClient)
+    client.is_closed = False
+
+    # Force a synthetic latency above the warn threshold by stubbing
+    # time.monotonic so end-time = start + (threshold + 1).
+    counter = {"n": 0}
+    def fake_monotonic():
+        counter["n"] += 1
+        if counter["n"] == 1:
+            return 0.0
+        return _HEALTH_DEGRADED_LATENCY + 1.0
+
+    client.post = AsyncMock(return_value=_ok_balance_resp())
+    solver._client = client
+
+    with patch("src.browser.captcha.time.monotonic", side_effect=fake_monotonic):
+        with caplog.at_level(logging.WARNING, logger="browser.captcha"):
+            outcome = await solver.health_check()
+
+    assert outcome == "degraded"
+    # Warning emitted for operator visibility.
+    msgs = [rec.getMessage() for rec in caplog.records]
+    assert any("degraded" in m for m in msgs)
+
+
+# ── 4: unreachable → solver skipped without calling provider ──────────
+
+
+@pytest.mark.asyncio
+async def test_health_check_unreachable_short_circuits_subsequent_solves():
+    solver = _make_solver()
+    page = _solve_page()
+
+    client = AsyncMock(spec=httpx.AsyncClient)
+    client.is_closed = False
+    # First post (getBalance) raises a timeout; no further posts should happen.
+    client.post = AsyncMock(side_effect=httpx.TimeoutException("probe timed out"))
+    solver._client = client
+
+    ok = await solver.solve(page, 'iframe[src*="recaptcha"]', "https://example.com")
+    assert ok is False
+    assert solver.is_solver_unreachable() is True
+    assert client.post.await_count == 1  # only the probe
+
+    # Subsequent solves don't even probe again — the gate is sticky.
+    ok2 = await solver.solve(page, 'iframe[src*="recaptcha"]', "https://example.com")
+    assert ok2 is False
+    assert client.post.await_count == 1
+
+
+@pytest.mark.asyncio
+async def test_health_check_5xx_treated_as_unreachable():
+    solver = _make_solver()
+    client = AsyncMock(spec=httpx.AsyncClient)
+    client.is_closed = False
+
+    bad = MagicMock()
+    bad.status_code = 503
+    bad.json = MagicMock(return_value={})
+    client.post = AsyncMock(return_value=bad)
+    solver._client = client
+
+    outcome = await solver.health_check()
+    assert outcome == "unreachable"
+
+
+@pytest.mark.asyncio
+async def test_health_check_errorid_treated_as_unreachable():
+    solver = _make_solver()
+    client = AsyncMock(spec=httpx.AsyncClient)
+    client.is_closed = False
+    client.post = AsyncMock(return_value=_err_balance_resp(error_id=1, status=200))
+    solver._client = client
+
+    outcome = await solver.health_check()
+    assert outcome == "unreachable"
+
+
+# ── 5: three consecutive failures trip the breaker for 10 min ─────────
+
+
+@pytest.mark.asyncio
+async def test_three_consecutive_failures_trips_breaker():
+    solver = _make_solver()
+    solver._solver_health_checked = True  # skip the probe in this slice
+
+    base = 1_000_000.0
+    with patch("src.browser.captcha.time.time", return_value=base):
+        for _ in range(_BREAKER_FAILURE_THRESHOLD):
+            await solver._record_solver_outcome(success=False)
+        assert solver.is_breaker_open() is True
+        assert solver._solver_breaker_until == pytest.approx(
+            base + _BREAKER_OPEN_DURATION,
+        )
+
+
+# ── 6: after 10 min, breaker auto-clears ──────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_breaker_auto_clears_after_window():
+    solver = _make_solver()
+    solver._solver_health_checked = True
+    base = 1_000_000.0
+
+    with patch("src.browser.captcha.time.time", return_value=base):
+        for _ in range(_BREAKER_FAILURE_THRESHOLD):
+            await solver._record_solver_outcome(success=False)
+        assert solver.is_breaker_open() is True
+
+    # Jump past the 10-min open duration.
+    with patch(
+        "src.browser.captcha.time.time",
+        return_value=base + _BREAKER_OPEN_DURATION + 1,
+    ):
+        assert solver.is_breaker_open() is False
+
+    # New solve attempts proceed (no breaker short-circuit).
+    page = _solve_page()
+    client = AsyncMock(spec=httpx.AsyncClient)
+    client.is_closed = False
+    client.post = AsyncMock(side_effect=_stub_create_then_poll("tok-X"))
+    solver._client = client
+
+    with patch(
+        "src.browser.captcha.time.time",
+        return_value=base + _BREAKER_OPEN_DURATION + 1,
+    ), patch("src.browser.captcha._POLL_INTERVAL", 0.001):
+        ok = await solver.solve(page, 'iframe[src*="recaptcha"]', "https://example.com")
+
+    assert ok is True
+    # createTask + getTaskResult, no probe (already checked).
+    assert client.post.await_count == 2
+
+
+# ── 7: a single failure does NOT trip the breaker ─────────────────────
+
+
+@pytest.mark.asyncio
+async def test_single_failure_does_not_trip():
+    solver = _make_solver()
+    solver._solver_health_checked = True
+    await solver._record_solver_outcome(success=False)
+    assert solver.is_breaker_open() is False
+
+
+# ── 8: two failures + a success → counter resets ──────────────────────
+
+
+@pytest.mark.asyncio
+async def test_success_resets_breaker_counter():
+    solver = _make_solver()
+    solver._solver_health_checked = True
+    base = 1_000_000.0
+
+    with patch("src.browser.captcha.time.time", return_value=base):
+        await solver._record_solver_outcome(success=False)
+        await solver._record_solver_outcome(success=False)
+        assert solver.is_breaker_open() is False
+
+        # Success wipes the window.
+        await solver._record_solver_outcome(success=True)
+        assert len(solver._solver_failure_timestamps) == 0
+
+        # A subsequent failure starts fresh — one isn't enough.
+        await solver._record_solver_outcome(success=False)
+        assert solver.is_breaker_open() is False
+        assert len(solver._solver_failure_timestamps) == 1
+
+
+# ── 9: failures spaced beyond the 5-min window do not trip ────────────
+
+
+@pytest.mark.asyncio
+async def test_failures_outside_window_do_not_trip():
+    solver = _make_solver()
+    solver._solver_health_checked = True
+    base = 1_000_000.0
+    far_future = base + _BREAKER_FAILURE_WINDOW + 60
+
+    with patch("src.browser.captcha.time.time", return_value=base):
+        await solver._record_solver_outcome(success=False)
+        await solver._record_solver_outcome(success=False)
+    # Third failure happens AFTER the 5-min window expires for the first
+    # two. The deque should prune them and keep only the new entry.
+    with patch("src.browser.captcha.time.time", return_value=far_future):
+        await solver._record_solver_outcome(success=False)
+        assert solver.is_breaker_open() is False
+        assert len(solver._solver_failure_timestamps) == 1
+
+
+# ── 10: concurrent solves while breaker open all short-circuit ────────
+
+
+@pytest.mark.asyncio
+async def test_concurrent_solves_short_circuit_when_breaker_open():
+    solver = _make_solver()
+    solver._solver_health_checked = True
+
+    # Trip the breaker.
+    for _ in range(_BREAKER_FAILURE_THRESHOLD):
+        await solver._record_solver_outcome(success=False)
+    assert solver.is_breaker_open() is True
+
+    page = _solve_page()
+    client = AsyncMock(spec=httpx.AsyncClient)
+    client.is_closed = False
+    client.post = AsyncMock()  # any call here is a bug
+    solver._client = client
+
+    results = await asyncio.gather(*(
+        solver.solve(page, 'iframe[src*="recaptcha"]', "https://example.com")
+        for _ in range(5)
+    ))
+    assert all(r is False for r in results)
+    # No provider HTTP calls — breaker gate ran before any post().
+    assert client.post.await_count == 0
+
+
+# ── 11: URL/body redaction — clientKey never reaches the logger ───────
+
+
+@pytest.mark.asyncio
+async def test_health_check_logs_redact_clientkey(caplog):
+    raw_key = "SECRET-KEY-DO-NOT-LEAK-1234567890"
+    solver = _make_solver(key=raw_key)
+
+    client = AsyncMock(spec=httpx.AsyncClient)
+    client.is_closed = False
+    bad = MagicMock()
+    bad.status_code = 503
+    bad.json = MagicMock(return_value={})
+    client.post = AsyncMock(return_value=bad)
+    solver._client = client
+
+    with caplog.at_level(logging.WARNING, logger="browser.captcha"):
+        outcome = await solver.health_check()
+    assert outcome == "unreachable"
+
+    joined = "\n".join(rec.getMessage() for rec in caplog.records)
+    assert raw_key not in joined
+
+
+@pytest.mark.asyncio
+async def test_health_check_timeout_log_redacts_clientkey(caplog):
+    raw_key = "SECRET-KEY-DO-NOT-LEAK-1234567890"
+    solver = _make_solver(key=raw_key)
+
+    client = AsyncMock(spec=httpx.AsyncClient)
+    client.is_closed = False
+    # Provider sometimes echoes clientKey into error strings — simulate.
+    client.post = AsyncMock(side_effect=httpx.HTTPError(
+        f"connect failed using clientKey={raw_key}",
+    ))
+    solver._client = client
+
+    with caplog.at_level(logging.WARNING, logger="browser.captcha"):
+        outcome = await solver.health_check()
+    assert outcome == "unreachable"
+
+    joined = "\n".join(rec.getMessage() for rec in caplog.records)
+    assert raw_key not in joined
+
+
+@pytest.mark.asyncio
+async def test_health_check_request_body_logging_redacts_clientkey(caplog):
+    """Verify the timeout-path log line scrubs the clientKey from the body."""
+    raw_key = "SECRET-KEY-DO-NOT-LEAK-1234567890"
+    solver = _make_solver(key=raw_key)
+    client = AsyncMock(spec=httpx.AsyncClient)
+    client.is_closed = False
+    client.post = AsyncMock(side_effect=httpx.TimeoutException("hung"))
+    solver._client = client
+
+    with caplog.at_level(logging.WARNING, logger="browser.captcha"):
+        await solver.health_check()
+
+    joined = "\n".join(rec.getMessage() for rec in caplog.records)
+    assert raw_key not in joined
+    assert "[REDACTED]" in joined
+
+
+def test_redact_clientkey_dict_helper():
+    raw = {"clientKey": "SECRET", "taskId": "T-1"}
+    redacted = _redact_clientkey(raw)
+    assert redacted["clientKey"] == "[REDACTED]"
+    assert redacted["taskId"] == "T-1"
+    # Original untouched (returned a copy).
+    assert raw["clientKey"] == "SECRET"
+
+    # Idempotent on dicts that don't have the key.
+    no_key = {"foo": "bar"}
+    assert _redact_clientkey(no_key) is no_key
+
+
+def test_redact_clientkey_text_helper():
+    # Both spellings catch.
+    a = "connect failed using clientKey=ABC123-XYZ"
+    assert "ABC123-XYZ" not in _redact_clientkey_text(a)
+    assert "[REDACTED]" in _redact_clientkey_text(a)
+
+    b = '{"clientKey":"ABC123-XYZ","errorId":1}'
+    assert "ABC123-XYZ" not in _redact_clientkey_text(b)
+
+    # No-op on safe strings.
+    assert _redact_clientkey_text("plain text") == "plain text"
+    assert _redact_clientkey_text("") == ""
+
+
+# ── 12: cancellation cleans up in-flight health_check ─────────────────
+
+
+@pytest.mark.asyncio
+async def test_health_check_cancellation_cleans_up():
+    solver = _make_solver()
+    client = AsyncMock(spec=httpx.AsyncClient)
+    client.is_closed = False
+
+    # Block forever inside the post() to simulate a hung probe.
+    started = asyncio.Event()
+
+    async def hang(*args, **kwargs):
+        started.set()
+        await asyncio.sleep(60)
+
+    client.post = AsyncMock(side_effect=hang)
+    solver._client = client
+
+    task = asyncio.create_task(solver.health_check())
+    await asyncio.wait_for(started.wait(), timeout=1.0)
+
+    # Cancel mid-flight.
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    # close() should cleanly tear down even after cancellation.
+    await solver.close()
+
+
+# ── _check_captcha integration: surfaces breaker state ────────────────
+
+
+@pytest.mark.asyncio
+async def test_check_captcha_emits_no_solver_when_unreachable():
+    """When health-check unreachable, _check_captcha decorates the result
+    with solver_outcome='no_solver' + next_action='request_captcha_help'."""
+    from src.browser.service import BrowserManager
+
+    mgr = BrowserManager.__new__(BrowserManager)
+    fake_solver = AsyncMock()
+    fake_solver.solve = AsyncMock(return_value=False)
+    fake_solver.is_solver_unreachable = MagicMock(return_value=True)
+    fake_solver.is_breaker_open = MagicMock(return_value=False)
+    mgr._captcha_solver = fake_solver
+
+    inst = MagicMock()
+    inst.page = AsyncMock()
+    inst.page.url = "https://example.com"
+    loc_match = MagicMock()
+    loc_match.count = AsyncMock(return_value=1)
+    loc_zero = MagicMock()
+    loc_zero.count = AsyncMock(return_value=0)
+    def by_sel(s):
+        if s == 'iframe[src*="recaptcha"]':
+            return loc_match
+        return loc_zero
+    inst.page.locator = MagicMock(side_effect=by_sel)
+
+    out = await mgr._check_captcha(inst)
+    assert out is not None
+    # §11.13 envelope shape — captcha_found is the structural marker.
+    assert out.get("captcha_found") is True
+    assert out.get("solver_attempted") is False
+    assert out.get("solver_outcome") == "no_solver"
+    assert out.get("next_action") == "request_captcha_help"
+    # ``kind`` and ``solver_confidence`` come from the envelope builder.
+    assert "kind" in out
+    assert "solver_confidence" in out
+
+
+@pytest.mark.asyncio
+async def test_check_captcha_emits_breaker_open_flag():
+    """When breaker is open, _check_captcha sets breaker_open=True
+    and solver_outcome='timeout' (the §11.13 follow-up will fold this
+    into a structured ``service_unavailable`` value)."""
+    from src.browser.service import BrowserManager
+
+    mgr = BrowserManager.__new__(BrowserManager)
+    fake_solver = AsyncMock()
+    fake_solver.solve = AsyncMock(return_value=False)
+    fake_solver.is_solver_unreachable = MagicMock(return_value=False)
+    fake_solver.is_breaker_open = MagicMock(return_value=True)
+    mgr._captcha_solver = fake_solver
+
+    inst = MagicMock()
+    inst.page = AsyncMock()
+    inst.page.url = "https://example.com"
+    loc_match = MagicMock()
+    loc_match.count = AsyncMock(return_value=1)
+    loc_zero = MagicMock()
+    loc_zero.count = AsyncMock(return_value=0)
+    def by_sel(s):
+        if s == 'iframe[src*="recaptcha"]':
+            return loc_match
+        return loc_zero
+    inst.page.locator = MagicMock(side_effect=by_sel)
+
+    out = await mgr._check_captcha(inst)
+    assert out is not None
+    # §11.13 envelope + §11.16 additive breaker_open flag.
+    assert out.get("captcha_found") is True
+    assert out.get("solver_attempted") is False
+    assert out.get("solver_outcome") == "timeout"
+    assert out.get("breaker_open") is True
+    assert out.get("next_action") == "request_captcha_help"
+
+
+@pytest.mark.asyncio
+async def test_check_captcha_no_decoration_when_solver_healthy():
+    """Healthy solver, ordinary detect-and-solve returns the §11.13
+    envelope WITHOUT a top-level ``breaker_open`` flag and with a
+    ``solver_outcome`` other than ``no_solver`` (proves the §11.16
+    short-circuits did not fire)."""
+    from src.browser.service import BrowserManager
+
+    mgr = BrowserManager.__new__(BrowserManager)
+    fake_solver = AsyncMock()
+    fake_solver.solve = AsyncMock(return_value=False)  # solve fails normally
+    fake_solver.is_solver_unreachable = MagicMock(return_value=False)
+    fake_solver.is_breaker_open = MagicMock(return_value=False)
+    mgr._captcha_solver = fake_solver
+
+    inst = MagicMock()
+    inst.page = AsyncMock()
+    inst.page.url = "https://example.com"
+    loc_match = MagicMock()
+    loc_match.count = AsyncMock(return_value=1)
+    loc_zero = MagicMock()
+    loc_zero.count = AsyncMock(return_value=0)
+    def by_sel(s):
+        if s == 'iframe[src*="recaptcha"]':
+            return loc_match
+        return loc_zero
+    inst.page.locator = MagicMock(side_effect=by_sel)
+
+    out = await mgr._check_captcha(inst)
+    assert out is not None
+    assert out.get("captcha_found") is True
+    # No breaker decoration on a healthy solver.
+    assert "breaker_open" not in out
+    # Envelope still carries solver_outcome — but it must not be
+    # "no_solver" (that's the unreachable short-circuit). With
+    # solve()==False on a healthy solver the envelope reports "rejected".
+    assert out.get("solver_outcome") != "no_solver"

--- a/tests/test_captcha_health.py
+++ b/tests/test_captcha_health.py
@@ -184,6 +184,70 @@ async def test_health_check_unreachable_short_circuits_subsequent_solves():
 
 
 @pytest.mark.asyncio
+async def test_concurrent_first_solves_share_one_health_check():
+    """Three agents call solve() simultaneously on a fresh solver. The
+    health-check gate must be inside an asyncio.Lock so they all wait
+    for the SAME probe instead of each firing their own."""
+    solver = _make_solver()
+    page = _solve_page()
+
+    probe_started = asyncio.Event()
+    probe_release = asyncio.Event()
+    probe_calls = 0
+
+    async def fake_post(url, *args, **kwargs):
+        nonlocal probe_calls
+        if url.endswith("/getBalance"):
+            probe_calls += 1
+            probe_started.set()
+            await probe_release.wait()
+            return _ok_balance_resp()
+        # createTask / getTaskResult — return success immediately.
+        if "createTask" in url:
+            r = MagicMock()
+            r.json = MagicMock(return_value={"errorId": 0, "taskId": "T"})
+            r.raise_for_status = MagicMock()
+            return r
+        r = MagicMock()
+        r.json = MagicMock(return_value={
+            "errorId": 0, "status": "ready",
+            "solution": {"gRecaptchaResponse": "tok"},
+        })
+        r.raise_for_status = MagicMock()
+        return r
+
+    client = AsyncMock(spec=httpx.AsyncClient)
+    client.is_closed = False
+    client.post = AsyncMock(side_effect=fake_post)
+    solver._client = client
+
+    with patch("src.browser.captcha._POLL_INTERVAL", 0.001):
+        # Kick off three concurrent solves before the probe completes.
+        tasks = [
+            asyncio.create_task(
+                solver.solve(page, 'iframe[src*="recaptcha"]', "https://example.com"),
+            )
+            for _ in range(3)
+        ]
+
+        # Wait until ONE probe is in flight, then release it. If the gate
+        # were unlocked, multiple probes would race past the check.
+        await asyncio.wait_for(probe_started.wait(), timeout=2.0)
+        # Give the event loop a tick so any racing concurrent probe call
+        # would have entered fake_post too.
+        for _ in range(5):
+            await asyncio.sleep(0)
+        probe_release.set()
+
+        results = await asyncio.gather(*tasks)
+
+    assert all(r is True for r in results)
+    assert probe_calls == 1, (
+        f"expected exactly one health probe, got {probe_calls} — gate is racy"
+    )
+
+
+@pytest.mark.asyncio
 async def test_health_check_5xx_treated_as_unreachable():
     solver = _make_solver()
     client = AsyncMock(spec=httpx.AsyncClient)
@@ -205,6 +269,59 @@ async def test_health_check_errorid_treated_as_unreachable():
     client = AsyncMock(spec=httpx.AsyncClient)
     client.is_closed = False
     client.post = AsyncMock(return_value=_err_balance_resp(error_id=1, status=200))
+    solver._client = client
+
+    outcome = await solver.health_check()
+    assert outcome == "unreachable"
+
+
+@pytest.mark.asyncio
+async def test_health_check_missing_balance_treated_as_unreachable():
+    """Provider returned 200 + valid JSON but the expected ``balance``
+    field is absent. We don't know what that response actually means —
+    wrong endpoint, response-shape change, transparent proxy — so the
+    only safe answer is 'unreachable'."""
+    solver = _make_solver()
+    client = AsyncMock(spec=httpx.AsyncClient)
+    client.is_closed = False
+    weird = MagicMock()
+    weird.status_code = 200
+    weird.json = MagicMock(return_value={"errorId": 0, "foo": "bar"})
+    client.post = AsyncMock(return_value=weird)
+    solver._client = client
+
+    outcome = await solver.health_check()
+    assert outcome == "unreachable"
+
+
+@pytest.mark.asyncio
+async def test_health_check_non_numeric_balance_treated_as_unreachable():
+    """Provider returned a balance field but it's not numeric (e.g. a
+    string error message in place of a number). Treat as unreachable."""
+    solver = _make_solver()
+    client = AsyncMock(spec=httpx.AsyncClient)
+    client.is_closed = False
+    weird = MagicMock()
+    weird.status_code = 200
+    weird.json = MagicMock(return_value={"errorId": 0, "balance": "n/a"})
+    client.post = AsyncMock(return_value=weird)
+    solver._client = client
+
+    outcome = await solver.health_check()
+    assert outcome == "unreachable"
+
+
+@pytest.mark.asyncio
+async def test_health_check_non_json_treated_as_unreachable():
+    """Provider returned 200 with HTML / non-JSON body (rare but
+    happens behind misconfigured CDNs). Treat as unreachable."""
+    solver = _make_solver()
+    client = AsyncMock(spec=httpx.AsyncClient)
+    client.is_closed = False
+    weird = MagicMock()
+    weird.status_code = 200
+    weird.json = MagicMock(side_effect=ValueError("not JSON"))
+    client.post = AsyncMock(return_value=weird)
     solver._client = client
 
     outcome = await solver.health_check()
@@ -268,6 +385,31 @@ async def test_breaker_auto_clears_after_window():
     assert client.post.await_count == 2
 
 
+@pytest.mark.asyncio
+async def test_breaker_auto_clear_resets_failure_window():
+    """After auto-clear, the failure-window deque + breaker timestamp
+    must both be reset so a single new failure doesn't immediately
+    re-trip on stale entries."""
+    solver = _make_solver()
+    solver._solver_health_checked = True
+    base = 1_000_000.0
+
+    with patch("src.browser.captcha.time.time", return_value=base):
+        for _ in range(_BREAKER_FAILURE_THRESHOLD):
+            await solver._record_solver_outcome(success=False)
+        assert solver.is_breaker_open() is True
+        assert len(solver._solver_failure_timestamps) == _BREAKER_FAILURE_THRESHOLD
+
+    # Reading is_breaker_open() AFTER the window expires must clear state.
+    with patch(
+        "src.browser.captcha.time.time",
+        return_value=base + _BREAKER_OPEN_DURATION + 1,
+    ):
+        assert solver.is_breaker_open() is False
+        assert solver._solver_breaker_until == 0.0
+        assert len(solver._solver_failure_timestamps) == 0
+
+
 # ── 7: a single failure does NOT trip the breaker ─────────────────────
 
 
@@ -322,6 +464,37 @@ async def test_failures_outside_window_do_not_trip():
         await solver._record_solver_outcome(success=False)
         assert solver.is_breaker_open() is False
         assert len(solver._solver_failure_timestamps) == 1
+
+
+@pytest.mark.asyncio
+async def test_three_failures_staggered_inside_window_does_trip():
+    """Failures at t=0, t=200, t=400 — all three are inside a 300-s
+    sliding window viewed from t=400 (cutoff = 100, only t=0 falls
+    out). Deque keeps [200, 400] after prune + new append → len 2 < 3
+    → breaker NOT tripped. Then a fourth failure at t=450 prunes the
+    same way (cutoff=150, drops 0 if still there but it's already
+    gone): deque = [200, 400, 450], len = 3 → breaker DOES trip.
+
+    This case lives just on the boundary of the sliding-window math —
+    test it explicitly so a future deque-trim regression is caught."""
+    solver = _make_solver()
+    solver._solver_health_checked = True
+    base = 1_000_000.0
+
+    with patch("src.browser.captcha.time.time", return_value=base):
+        await solver._record_solver_outcome(success=False)  # t=0
+    with patch("src.browser.captcha.time.time", return_value=base + 200):
+        await solver._record_solver_outcome(success=False)  # t=200
+    with patch("src.browser.captcha.time.time", return_value=base + 400):
+        # cutoff = 400 - 300 = 100; t=0 pruned, t=200/400 stay → len 2
+        await solver._record_solver_outcome(success=False)
+        assert solver.is_breaker_open() is False
+        assert len(solver._solver_failure_timestamps) == 2
+
+    with patch("src.browser.captcha.time.time", return_value=base + 450):
+        # cutoff = 450 - 300 = 150; t=200/400/450 all stay → len 3 → trip
+        await solver._record_solver_outcome(success=False)
+        assert solver.is_breaker_open() is True
 
 
 # ── 10: concurrent solves while breaker open all short-circuit ────────
@@ -429,13 +602,22 @@ def test_redact_clientkey_dict_helper():
 
 
 def test_redact_clientkey_text_helper():
-    # Both spellings catch.
-    a = "connect failed using clientKey=ABC123-XYZ"
-    assert "ABC123-XYZ" not in _redact_clientkey_text(a)
-    assert "[REDACTED]" in _redact_clientkey_text(a)
+    secret = "ABC123-XYZ"
 
-    b = '{"clientKey":"ABC123-XYZ","errorId":1}'
-    assert "ABC123-XYZ" not in _redact_clientkey_text(b)
+    # Every shape we've seen (or expect to see) in solver-provider error
+    # output, request logs, and Python-side repr() / f-string traces.
+    shapes = [
+        f"connect failed using clientKey={secret}",                 # query/form
+        f"clientKey: {secret}",                                     # header
+        f'{{"clientKey": "{secret}", "errorId": 1}}',                # JSON
+        f"{{'clientKey': '{secret}', 'errorId': 1}}",                 # Python repr
+        f"clientKey={secret}&otherParam=foo",                       # mid-query
+        f'CLIENTKEY="{secret}"',                                     # case-insensitive
+    ]
+    for shape in shapes:
+        out = _redact_clientkey_text(shape)
+        assert secret not in out, f"leaked in {shape!r}: {out!r}"
+        assert "[REDACTED]" in out
 
     # No-op on safe strings.
     assert _redact_clientkey_text("plain text") == "plain text"


### PR DESCRIPTION
## Summary

Adds first-solve liveness check + sliding-window circuit breaker to `CaptchaSolver`:

- **Health check** — on first solve per `BrowserManager` instance-session, POST `/getBalance` against the configured primary solver (2captcha or CapSolver) with 5s timeout. Outcomes: `healthy` → continue; `degraded` (latency > 3s) → log warning + route new solves to secondary if configured; `unreachable` (timeout / 5xx / connection error) → all subsequent solves return `solver_outcome="no_solver"` + `next_action="request_captcha_help"`.
- **Circuit breaker** — sliding 5-min window of failure timestamps via bounded deque. On 3rd failure within window, breaker trips for 10 min. Reset on any success.
- **URL redaction** — `redact_url` on URLs, `_redact_clientkey(body)` on request/response dicts, `_redact_clientkey_text(text)` on arbitrary strings (provider error messages occasionally echo `clientKey` back). All logged paths flow through these.

Concurrency: `_state_lock: asyncio.Lock` serializes the per-process health-check init and breaker mutations across concurrent agents sharing the BrowserManager's solver client.

Plan: `docs/plans/2026-04-20-browser-automation.md` §11.16.

## §11.13 coordination

§11.13 envelope (in flight on `feat/captcha-envelope` / PR linked above) introduces a `solver_outcome` enum. Rather than introduce a `service_unavailable` enum value here and conflict with that PR, this PR uses the **safer additive pattern**: when the breaker is open, return existing `solver_outcome="timeout"` PLUS a new top-level `breaker_open: true` flag. After §11.13 lands, a small follow-up can fold `breaker_open` into a proper `service_unavailable` outcome value.

## Test plan

- [x] 21 new tests in `tests/test_captcha_health.py` covering all 12 spec scenarios (first-solve gate, healthy / degraded / unreachable paths, breaker trips on 3 failures within window, breaker auto-clears after 10 min, isolated single failure does not trip, success between failures resets counter, gap > 5 min prevents trip, concurrent solves while breaker open, URL redaction, cancellation cleanup).
- [x] 11 existing captcha tests in `tests/test_browser_service.py -k captcha` — all passing (4 needed `_solver_health_checked = True` pre-mark to skip mocking the new probe).
- [x] 430-test full `tests/test_browser_service.py` sweep — all green.
- [x] 3655 wider unit/integration suite — all green (single pre-existing unrelated `test_version_flag` skip).
- [x] `ruff check src/ tests/` — clean.