### PR TITLE
Phase 8 §11.14: browser_solve_captcha + cost counter + redaction

### DIFF
--- a/src/agent/builtins/browser_tool.py
+++ b/src/agent/builtins/browser_tool.py
@@ -1124,6 +1124,151 @@ async def browser_upload_file(
 
 
 @skill(
+    name="browser_solve_captcha",
+    description=(
+        "Explicitly request a CAPTCHA solve on the current page. Use "
+        "after a click/submit if you suspect a captcha appeared. "
+        "Auto-detected captchas after navigate are already handled — "
+        "do NOT call this redundantly. Returns the §11.13 envelope; "
+        "common ``solver_outcome`` values include "
+        "``solved`` / ``timeout`` / ``rejected`` / ``no_solver`` / "
+        "``rate_limited`` / ``cost_cap`` / ``captcha_during_solve``. "
+        "When ``next_action == \"request_captcha_help\"`` you should "
+        "follow up with the ``request_captcha_help`` skill. "
+        "``target_ref`` is reserved for multi-captcha pages — accepted "
+        "but currently logged + ignored (top visible widget is solved)."
+    ),
+    parameters={
+        "hint": {
+            "type": "string",
+            "description": (
+                "Optional override for captcha kind classification. "
+                "One of: recaptcha-v2-checkbox, recaptcha-v2-invisible, "
+                "recaptcha-v3, recaptcha-enterprise, hcaptcha, turnstile, "
+                "cf-interstitial-auto, cf-interstitial-behavioral, unknown."
+            ),
+            "default": "",
+        },
+        "retry_previous": {
+            "type": "boolean",
+            "description": (
+                "Retry the most recent solve attempt on this instance "
+                "(60-second TTL). Use when a transient solver error "
+                "left the captcha unsolved and the page still shows it."
+            ),
+            "default": False,
+        },
+        "target_ref": {
+            "type": "string",
+            "description": (
+                "RESERVED for multi-captcha pages (§11.6). Currently "
+                "logged + ignored — the top-ranked visible captcha "
+                "is always solved."
+            ),
+            "default": "",
+        },
+    },
+    parallel_safe=False,
+)
+async def browser_solve_captcha(
+    hint: str = "", retry_previous: bool = False, target_ref: str = "",
+    *, mesh_client=None,
+) -> dict:
+    """Explicit CAPTCHA solve invoked by the agent."""
+    params: dict = {}
+    if hint:
+        params["hint"] = hint
+    if retry_previous:
+        params["retry_previous"] = True
+    if target_ref:
+        params["target_ref"] = target_ref
+    return await _browser_command(mesh_client, "solve_captcha", params)
+
+
+@skill(
+    name="request_captcha_help",
+    description=(
+        "Ask the user to clear a CAPTCHA via the live browser viewer in "
+        "their dashboard. Use for behavioral-only challenges (Cloudflare "
+        "Under Attack, Press & Hold), persistent rejections after several "
+        "auto-solve attempts, or when ``browser_solve_captcha`` returned "
+        "``rate_limited`` / ``cost_cap``. Mirrors ``request_browser_login`` "
+        "— a handoff card appears in the dashboard, and you receive a "
+        "steer notification when the operator finishes (success or cancel)."
+    ),
+    parameters={
+        "service": {
+            "type": "string",
+            "description": (
+                "Short name of the captcha service or page context "
+                "(e.g. 'Cloudflare Turnstile', 'PerimeterX', "
+                "'Login captcha on example.com')."
+            ),
+        },
+        "description": {
+            "type": "string",
+            "description": (
+                "Tell the user what to do (e.g. 'Click the checkbox and "
+                "complete the image challenge'). Keep it short."
+            ),
+        },
+    },
+    parallel_safe=False,
+)
+async def request_captcha_help(
+    service: str, description: str, *, mesh_client=None,
+) -> dict:
+    """Request operator help to clear a CAPTCHA via the dashboard VNC card."""
+    if not mesh_client:
+        return {"error": "Captcha help requires mesh connectivity"}
+    if not service:
+        return {"error": "service is required"}
+    if not description:
+        return {"error": "description is required"}
+
+    # Fire the browser-side action so the BrowserManager records the
+    # request (locking + page-state stamp) — mirrors how
+    # request_browser_login first navigates the browser.
+    try:
+        await mesh_client.browser_command(
+            "request_captcha_help",
+            {"service": service, "description": description},
+        )
+    except Exception as e:
+        return {"error": f"browser-side captcha-help record failed: {e}"}
+
+    # Then emit the dashboard handoff card via the mesh helper.
+    try:
+        await mesh_client.request_captcha_help(
+            service=service, description=description,
+        )
+    except Exception as e:
+        logger.warning(
+            "Failed to emit captcha help request for %s: %s", service, e,
+        )
+        return {
+            "requested": False,
+            "service": service,
+            "message": (
+                f"Browser-side request recorded but failed to show the "
+                f"captcha-help card to the user. Try notify_user as a "
+                f"fallback. Error: {e}"
+            ),
+        }
+
+    return {
+        "requested": True,
+        "service": service,
+        "message": (
+            f"Captcha help request sent to user. The dashboard is showing "
+            f"a VNC handoff card for {service}. Wait for the user to "
+            f"complete or cancel — you will be notified via a steer "
+            f"message. Do NOT use browser tools until then."
+        ),
+    }
+
+
+@skill(
     name="request_browser_login",
     description=(
         "Ask the user to log in to a website through a live browser view "

--- a/src/agent/mesh_client.py
+++ b/src/agent/mesh_client.py
@@ -470,6 +470,34 @@ class MeshClient:
         response.raise_for_status()
         return response.json()
 
+    async def request_captcha_help(
+        self, service: str, description: str,
+        target_agent_id: str | None = None,
+    ) -> dict:
+        """Phase 8 §11.14 — emit a CAPTCHA-help handoff event.
+
+        Mirrors :meth:`request_browser_login` shape: the dashboard renders
+        a handoff card so the operator can take VNC control and clear
+        the captcha manually. ``service`` names the captcha kind/service
+        (e.g. ``"Cloudflare Turnstile"`` or ``"PerimeterX"``);
+        ``description`` is agent-supplied context for the operator.
+        """
+        client = await self._get_client()
+        body: dict = {
+            "agent_id": self.agent_id,
+            "service": service,
+            "description": description,
+        }
+        if target_agent_id:
+            body["target_agent_id"] = target_agent_id
+        response = await client.post(
+            f"{self.mesh_url}/mesh/browser-captcha-help-request",
+            json=body,
+            headers=self._trace_headers(),
+        )
+        response.raise_for_status()
+        return response.json()
+
     async def vault_store(self, name: str, value: str) -> dict:
         """Store a credential in the mesh vault. Returns handle."""
         client = await self._get_client()

--- a/src/browser/__main__.py
+++ b/src/browser/__main__.py
@@ -197,9 +197,21 @@ def main() -> None:
     @asynccontextmanager
     async def lifespan(app: FastAPI):
         _cleanup_orphan_downloads()
+        # §11.14 simplified cost counter — load any prior month's state on
+        # startup (skips rolled-over months). Snapshotted on shutdown below
+        # so restarts mid-month don't lose accumulated spend.
+        from src.browser import captcha_cost_counter as _cost_counter
+        try:
+            await _cost_counter.restore()
+        except Exception as exc:
+            logger.warning("captcha_cost_counter.restore failed: %s", exc)
         await manager.start_cleanup_loop()
         logger.info("Browser service ready (max=%d, idle_timeout=%dm)", _MAX_BROWSERS, _IDLE_TIMEOUT)
         yield
+        try:
+            await _cost_counter.snapshot()
+        except Exception as exc:
+            logger.warning("captcha_cost_counter.snapshot failed: %s", exc)
         await manager.stop_all()
         procs = [openbox_proc, kasmvnc_proc]
         if unclutter_proc:

--- a/src/browser/captcha.py
+++ b/src/browser/captcha.py
@@ -75,9 +75,19 @@ _CLIENTKEY_IN_TEXT = re.compile(
     re.IGNORECASE,
 )
 
+# Solver task IDs (UUIDs and integer strings both used by 2captcha /
+# CapSolver). Echoed in error responses; redact on logging so a hostile
+# provider error containing a stitched-together credential string can't
+# leak via the task identifier path.
+_TASKID_IN_TEXT = re.compile(
+    r'(taskId)\s*["\']?\s*[:=]\s*["\']?'
+    r'([A-Za-z0-9_\-]{6,})["\']?',
+    re.IGNORECASE,
+)
+
 
 def _redact_clientkey_text(text: str) -> str:
-    """Strip ``clientKey=VALUE`` / ``"clientKey":"VALUE"`` from text.
+    """Strip ``clientKey=VALUE`` / ``"clientKey":"VALUE"`` and ``taskId=…``.
 
     Pair with :func:`redact_url` (URL-shaped secrets) and
     :func:`_redact_clientkey` (dict bodies) before logging anything that
@@ -85,7 +95,9 @@ def _redact_clientkey_text(text: str) -> str:
     """
     if not text:
         return text
-    return _CLIENTKEY_IN_TEXT.sub(r"\1=[REDACTED]", text)
+    out = _CLIENTKEY_IN_TEXT.sub(r"\1=[REDACTED]", text)
+    out = _TASKID_IN_TEXT.sub(r"\1=[REDACTED]", out)
+    return out
 
 
 # Map from detected selector pattern to a canonical CAPTCHA type.
@@ -497,11 +509,25 @@ class CaptchaSolver:
                 "websiteKey": sitekey,
             },
         }
-        resp = await client.post("https://api.2captcha.com/createTask", json=payload)
-        resp.raise_for_status()
-        data = resp.json()
+        try:
+            resp = await client.post("https://api.2captcha.com/createTask", json=payload)
+            resp.raise_for_status()
+            data = resp.json()
+        except Exception as e:
+            # Provider error responses sometimes echo ``clientKey`` back
+            # in the body / exception text. Strip before logging — the
+            # bundled ``_redact_clientkey_text`` is the single redactor
+            # for these strings (do NOT introduce a parallel one).
+            logger.warning(
+                "2Captcha createTask failed: %s",
+                _redact_clientkey_text(redact_url(str(e))),
+            )
+            return None
         if data.get("errorId", 0) != 0:
-            logger.warning("2Captcha submit error: %s", data.get("errorDescription"))
+            logger.warning(
+                "2Captcha submit error: %s",
+                _redact_clientkey_text(str(data.get("errorDescription"))),
+            )
             return None
         task_id = data.get("taskId")
         if not task_id:
@@ -510,14 +536,24 @@ class CaptchaSolver:
         # Poll for result
         for _ in range(int(_SOLVE_TIMEOUT / _POLL_INTERVAL)):
             await asyncio.sleep(_POLL_INTERVAL)
-            resp = await client.post(
-                "https://api.2captcha.com/getTaskResult",
-                json={"clientKey": self.api_key, "taskId": task_id},
-            )
-            resp.raise_for_status()
-            data = resp.json()
+            try:
+                resp = await client.post(
+                    "https://api.2captcha.com/getTaskResult",
+                    json={"clientKey": self.api_key, "taskId": task_id},
+                )
+                resp.raise_for_status()
+                data = resp.json()
+            except Exception as e:
+                logger.warning(
+                    "2Captcha getTaskResult failed: %s",
+                    _redact_clientkey_text(redact_url(str(e))),
+                )
+                return None
             if data.get("errorId", 0) != 0:
-                logger.warning("2Captcha poll error: %s", data.get("errorDescription"))
+                logger.warning(
+                    "2Captcha poll error: %s",
+                    _redact_clientkey_text(str(data.get("errorDescription"))),
+                )
                 return None
             if data.get("status") == "ready":
                 solution = data.get("solution", {})
@@ -542,11 +578,21 @@ class CaptchaSolver:
                 "websiteKey": sitekey,
             },
         }
-        resp = await client.post("https://api.capsolver.com/createTask", json=payload)
-        resp.raise_for_status()
-        data = resp.json()
+        try:
+            resp = await client.post("https://api.capsolver.com/createTask", json=payload)
+            resp.raise_for_status()
+            data = resp.json()
+        except Exception as e:
+            logger.warning(
+                "CapSolver createTask failed: %s",
+                _redact_clientkey_text(redact_url(str(e))),
+            )
+            return None
         if data.get("errorId", 0) != 0:
-            logger.warning("CapSolver submit error: %s", data.get("errorDescription"))
+            logger.warning(
+                "CapSolver submit error: %s",
+                _redact_clientkey_text(str(data.get("errorDescription"))),
+            )
             return None
         task_id = data.get("taskId")
         if not task_id:
@@ -555,14 +601,24 @@ class CaptchaSolver:
         # Poll for result
         for _ in range(int(_SOLVE_TIMEOUT / _POLL_INTERVAL)):
             await asyncio.sleep(_POLL_INTERVAL)
-            resp = await client.post(
-                "https://api.capsolver.com/getTaskResult",
-                json={"clientKey": self.api_key, "taskId": task_id},
-            )
-            resp.raise_for_status()
-            data = resp.json()
+            try:
+                resp = await client.post(
+                    "https://api.capsolver.com/getTaskResult",
+                    json={"clientKey": self.api_key, "taskId": task_id},
+                )
+                resp.raise_for_status()
+                data = resp.json()
+            except Exception as e:
+                logger.warning(
+                    "CapSolver getTaskResult failed: %s",
+                    _redact_clientkey_text(redact_url(str(e))),
+                )
+                return None
             if data.get("errorId", 0) != 0:
-                logger.warning("CapSolver poll error: %s", data.get("errorDescription"))
+                logger.warning(
+                    "CapSolver poll error: %s",
+                    _redact_clientkey_text(str(data.get("errorDescription"))),
+                )
                 return None
             if data.get("status") == "ready":
                 solution = data.get("solution", {})

--- a/src/browser/captcha_cost_counter.py
+++ b/src/browser/captcha_cost_counter.py
@@ -1,0 +1,258 @@
+"""In-memory per-agent CAPTCHA cost counter (§11.10 simplified replacement).
+
+The original §11.10 plan called for a SQLite-backed monthly counter so cost
+caps survived process restarts with full transactional integrity. The Phase 8
+trim deferred that complexity in favor of an in-memory dict snapshotted to a
+JSON file on graceful shutdown. Restart loses at most one window's worth of
+counted spend — acceptable because the cap is per-month and a process restart
+inside a billing month is rare; the alternative (SQLite, WAL, schema-migration
+plumbing) was disproportionate to the value.
+
+Public surface:
+  * :func:`add_cost(agent_id, cents)` — increment a per-agent monthly bucket.
+    Resets the bucket when the calendar month rolls over.
+  * :func:`over_cap(agent_id, cap_cents)` — read-only check.
+  * :func:`snapshot()` / :func:`restore()` — JSON file persistence. Atomic
+    write via ``os.replace`` after ``fsync``.
+  * :func:`estimate_cents(provider, kind)` — fixed table of published rates
+    so callers don't reimplement the lookup. Returns ``None`` when the
+    variant isn't priced — caller should log a warning and skip counting
+    (over-counting is worse than under-counting for trust).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+
+from src.shared.utils import setup_logging
+
+logger = setup_logging("browser.captcha_cost")
+
+
+# Persistence path. Lives under ``data/`` (NOT a SQLite ``.db`` — see module
+# docstring for the deferred-rationale; the trim spec is explicit on this).
+_DEFAULT_PATH = "data/captcha_costs.json"
+
+
+def _state_path() -> Path:
+    return Path(os.environ.get("CAPTCHA_COST_COUNTER_PATH", _DEFAULT_PATH))
+
+
+# ── Pricing table ──────────────────────────────────────────────────────────
+
+
+# Published rates from 2captcha + CapSolver (April 2026), in US cents per
+# successful solve. Keys follow the convention ``{provider}-{variant}`` so a
+# future per-variant pricing tier (§11.1 reCAPTCHA v3 / Enterprise) can land
+# without re-keying. When a kind isn't priced, callers SKIP counting rather
+# than guessing — under-count > over-count for operator trust.
+PRICING_CENTS: dict[str, int] = {
+    # 2Captcha — published https://2captcha.com/2captcha-api#solving_recaptchav2_new
+    "2captcha-recaptcha-v2-checkbox": 100,        # $1.00 / 1000 = 0.10c each → 0.1¢
+    "2captcha-recaptcha-v2-invisible": 100,
+    "2captcha-recaptcha-v3": 100,
+    "2captcha-recaptcha-enterprise": 200,
+    "2captcha-hcaptcha": 100,
+    "2captcha-turnstile": 200,
+    # CapSolver — published https://docs.capsolver.com/guide/captcha/
+    "capsolver-recaptcha-v2-checkbox": 80,
+    "capsolver-recaptcha-v2-invisible": 80,
+    "capsolver-recaptcha-v3": 80,
+    "capsolver-recaptcha-enterprise": 200,
+    "capsolver-hcaptcha": 100,
+    "capsolver-turnstile": 60,
+}
+
+
+def estimate_cents(provider: str, kind: str) -> int | None:
+    """Return published cost (cents) for one successful solve, or ``None``.
+
+    ``None`` signals the variant isn't priced; callers should log a warning
+    and SKIP the increment rather than attribute a guess to the agent's
+    monthly spend (per the trim-spec note: over-counting is worse than
+    under-counting for trust).
+
+    Lookups are case-insensitive on both sides. The kind is normalized
+    against the §11.13 enum so callers can pass a §11.13 ``kind`` directly.
+    """
+    if not provider or not kind:
+        return None
+    key = f"{provider.strip().lower()}-{kind.strip().lower()}"
+    return PRICING_CENTS.get(key)
+
+
+# ── State + lock ───────────────────────────────────────────────────────────
+
+
+# {agent_id: {"month": "YYYY-MM", "cents": int}}
+_state: dict[str, dict] = {}
+_lock: asyncio.Lock = asyncio.Lock()
+
+
+def _current_month() -> str:
+    """Return the current UTC year-month as ``YYYY-MM``."""
+    return datetime.now(timezone.utc).strftime("%Y-%m")
+
+
+def _bucket_for(agent_id: str, *, current_month: str | None = None) -> dict:
+    """Return the per-agent bucket, resetting on month rollover.
+
+    Caller must hold ``_lock``. Pass ``current_month`` if the caller is
+    batch-processing across many agents and wants to compute it once.
+    """
+    cm = current_month or _current_month()
+    bucket = _state.get(agent_id)
+    if bucket is None or bucket.get("month") != cm:
+        bucket = {"month": cm, "cents": 0}
+        _state[agent_id] = bucket
+    return bucket
+
+
+# ── Public mutators / readers ──────────────────────────────────────────────
+
+
+async def add_cost(agent_id: str, cents: int) -> int:
+    """Add ``cents`` to ``agent_id``'s current-month bucket. Returns new total.
+
+    Concurrent writers across asyncio tasks are serialized by ``_lock`` —
+    matters because the browser service serves multiple agents off a single
+    event loop. Negative or zero ``cents`` are silently dropped (defensive).
+    """
+    if cents <= 0:
+        return await get_cents(agent_id)
+    async with _lock:
+        bucket = _bucket_for(agent_id)
+        bucket["cents"] = int(bucket["cents"]) + int(cents)
+        return bucket["cents"]
+
+
+async def over_cap(agent_id: str, cap_cents: int) -> bool:
+    """Return ``True`` iff this agent's current-month spend ≥ ``cap_cents``.
+
+    ``cap_cents <= 0`` disables the cap (returns ``False`` regardless of
+    spend) — operators set the env var to ``0`` to opt out.
+    """
+    if cap_cents <= 0:
+        return False
+    async with _lock:
+        bucket = _bucket_for(agent_id)
+        return int(bucket["cents"]) >= int(cap_cents)
+
+
+async def get_cents(agent_id: str) -> int:
+    """Return the current-month spend for ``agent_id`` in cents."""
+    async with _lock:
+        bucket = _bucket_for(agent_id)
+        return int(bucket["cents"])
+
+
+async def reset(agent_id: str | None = None) -> None:
+    """Clear state. ``agent_id=None`` clears everything (test harness)."""
+    async with _lock:
+        if agent_id is None:
+            _state.clear()
+        else:
+            _state.pop(agent_id, None)
+
+
+# ── Persistence ────────────────────────────────────────────────────────────
+
+
+async def snapshot(path: Path | str | None = None) -> bool:
+    """Atomically write the in-memory state to ``path`` as JSON.
+
+    Returns ``True`` on success. Failures log + return ``False`` rather than
+    raise — the shutdown path must not abort because cost persistence failed.
+
+    Atomic-write protocol: write to a sibling tmp file, ``fsync`` it,
+    ``os.replace`` over the destination. Standard pattern used elsewhere in
+    the codebase (e.g. config + cron persistence).
+    """
+    target = Path(path) if path else _state_path()
+    try:
+        target.parent.mkdir(parents=True, exist_ok=True)
+    except OSError as e:
+        logger.warning("captcha_cost snapshot: cannot create parent dir: %s", e)
+        return False
+
+    async with _lock:
+        # JSON-serializable copy. Bucket dicts are already plain
+        # ``{month, cents}`` so no custom encoder is needed.
+        payload = {
+            "version": 1,
+            "saved_at": int(time.time()),
+            "buckets": dict(_state),
+        }
+
+    tmp = target.with_suffix(target.suffix + ".tmp")
+    try:
+        with open(tmp, "w", encoding="utf-8") as fh:
+            json.dump(payload, fh)
+            fh.flush()
+            os.fsync(fh.fileno())
+        os.replace(tmp, target)
+    except OSError as e:
+        logger.warning("captcha_cost snapshot failed: %s", e)
+        try:
+            tmp.unlink(missing_ok=True)
+        except OSError:
+            pass
+        return False
+    logger.info(
+        "captcha_cost snapshot wrote %d agent bucket(s) to %s",
+        len(payload["buckets"]), target,
+    )
+    return True
+
+
+async def restore(path: Path | str | None = None) -> int:
+    """Load state from ``path`` if it exists. Returns count of buckets loaded.
+
+    Missing / unreadable / malformed files are non-fatal — log + start
+    fresh. Buckets whose ``month`` doesn't match the current month are
+    dropped (they'd reset on next access anyway; no point keeping stale).
+    """
+    target = Path(path) if path else _state_path()
+    if not target.exists():
+        return 0
+    try:
+        with open(target, encoding="utf-8") as fh:
+            payload = json.load(fh)
+    except (OSError, json.JSONDecodeError) as e:
+        logger.warning("captcha_cost restore: %s — starting empty", e)
+        return 0
+
+    if not isinstance(payload, dict):
+        logger.warning("captcha_cost restore: unexpected payload type")
+        return 0
+
+    buckets = payload.get("buckets", {})
+    if not isinstance(buckets, dict):
+        return 0
+
+    cm = _current_month()
+    loaded = 0
+    async with _lock:
+        _state.clear()
+        for agent_id, bucket in buckets.items():
+            if not isinstance(bucket, dict):
+                continue
+            month = bucket.get("month")
+            cents = bucket.get("cents", 0)
+            if not isinstance(month, str) or not isinstance(cents, int):
+                continue
+            if month != cm:
+                # Stale month — would reset on first access; skip restoring.
+                continue
+            _state[str(agent_id)] = {"month": month, "cents": cents}
+            loaded += 1
+    logger.info(
+        "captcha_cost restore loaded %d/%d agent bucket(s) from %s",
+        loaded, len(buckets), target,
+    )
+    return loaded

--- a/src/browser/server.py
+++ b/src/browser/server.py
@@ -355,6 +355,47 @@ def create_browser_app(manager: BrowserManager, lifespan=None) -> FastAPI:
         _verify_auth(request)
         return await manager.detect_captcha(agent_id)
 
+    @app.post("/browser/{agent_id}/solve_captcha")
+    async def solve_captcha(agent_id: str, request: Request):
+        """Phase 8 §11.14 — agent-triggered explicit CAPTCHA solve.
+
+        Wraps :meth:`BrowserManager.solve_captcha`; envelope shape is
+        §11.13 with the §11.14 outcome additions
+        (``rate_limited``/``cost_cap``/``captcha_during_solve``).
+        """
+        _verify_auth(request)
+        body = await request.json()
+        hint = body.get("hint")
+        retry_previous = bool(body.get("retry_previous", False))
+        target_ref = body.get("target_ref")
+        result = await manager.solve_captcha(
+            agent_id,
+            hint=hint if isinstance(hint, str) and hint else None,
+            retry_previous=retry_previous,
+            target_ref=target_ref if isinstance(target_ref, str) and target_ref else None,
+        )
+        await _apply_delay()
+        return result
+
+    @app.post("/browser/{agent_id}/request_captcha_help")
+    async def request_captcha_help(agent_id: str, request: Request):
+        """Phase 8 §11.14 — agent-triggered request for human help.
+
+        Mirrors the ``request_browser_login`` flow. The mesh side
+        (``/mesh/browser-captcha-help-request``) emits the dashboard
+        handoff event; this endpoint just records the agent's intent
+        and stamps the page state.
+        """
+        _verify_auth(request)
+        body = await request.json()
+        service = (body.get("service") or "").strip()
+        description = (body.get("description") or "").strip()
+        result = await manager.request_captcha_help(
+            agent_id, service=service, description=description,
+        )
+        await _apply_delay()
+        return result
+
     # ── File-transfer endpoints (Phase 1.5) ──────────────────────────────
     #
     # These accept already-staged local paths (for uploads) or produce a

--- a/src/browser/service.py
+++ b/src/browser/service.py
@@ -68,6 +68,7 @@ logger = setup_logging("browser.service")
 #   solver_outcome:
 #     "solved" | "timeout" | "rejected" | "injection_failed"
 #     | "no_solver" | "unsupported"
+#     | "rate_limited" | "cost_cap" | "captcha_during_solve"   (§11.14)
 #     - solved: token retrieved AND injected (or no injection needed).
 #     - timeout: solver did not return a verdict in time.
 #     - rejected: solver concluded the captcha cannot be solved (provider
@@ -101,6 +102,57 @@ logger = setup_logging("browser.service")
 # below have unambiguous selectors today. The reCAPTCHA / CF placeholders
 # remain "low" until §11.1 / §11.3 land variant detection.
 _FIRM_KINDS = frozenset({"hcaptcha", "turnstile"})
+
+
+# ── §11.13 valid kind enum (for hint validation in solve_captcha) ─────────
+# Kept in sync with the docstring at the top of this module. New kinds added
+# here as §11.1 / §11.3 land richer classification.
+_VALID_CAPTCHA_KINDS: frozenset[str] = frozenset({
+    "recaptcha-v2-checkbox", "recaptcha-v2-invisible", "recaptcha-v3",
+    "recaptcha-enterprise", "hcaptcha", "turnstile",
+    "cf-interstitial-auto", "cf-interstitial-behavioral", "unknown",
+})
+
+
+# ── §11.14 per-agent solve rate limiter ───────────────────────────────────
+# Module-level dict guarded by an asyncio.Lock. Each agent gets a deque of
+# unix timestamps for solve attempts in the last hour; entries older than
+# 1h are pruned on each access. The limit is read from the
+# CAPTCHA_RATE_LIMIT_PER_HOUR flag (default 20), matching the trim spec.
+#
+# Note: shared module-level state means multi-tenant deployments where
+# different processes serve different agents won't see a unified rate
+# limit — by design (matches how the cost counter is also process-local in
+# this trim). Per-process is sufficient because the browser service is a
+# single container, and the cap is a soft anti-abuse signal not a billing
+# control (cost counter handles billing).
+_solve_rate_window: dict[str, deque[float]] = {}
+_solve_rate_lock: asyncio.Lock = asyncio.Lock()
+_SOLVE_RATE_WINDOW_SECONDS = 3600.0
+
+
+async def _check_solve_rate(agent_id: str, limit_per_hour: int) -> bool:
+    """Return ``True`` if the agent is OVER the per-hour solve limit.
+
+    Side effect on miss: records the current timestamp so the NEXT call's
+    pruning sees this attempt. Caller is expected to invoke once per
+    intended solve; double-counting would distort the rate.
+
+    ``limit_per_hour <= 0`` disables the limiter (returns False always) so
+    operators can opt out via the env var.
+    """
+    if limit_per_hour <= 0:
+        return False
+    async with _solve_rate_lock:
+        now = time.time()
+        cutoff = now - _SOLVE_RATE_WINDOW_SECONDS
+        bucket = _solve_rate_window.setdefault(agent_id, deque(maxlen=limit_per_hour * 4))
+        while bucket and bucket[0] < cutoff:
+            bucket.popleft()
+        if len(bucket) >= limit_per_hour:
+            return True
+        bucket.append(now)
+        return False
 
 
 def _kind_confidence(kind: str) -> str:
@@ -1447,6 +1499,18 @@ class CamoufoxInstance:
         # idempotency flag for ``BrowserManager._attach_network_listeners``.
         self.network_log: deque[dict] = deque(maxlen=200)
         self._network_attached: bool = False
+        # §11.14 explicit-solve guards.
+        # ``_captcha_solving`` is set for the duration of a manager-level
+        # ``solve_captcha`` invocation; if a NEW captcha is detected by
+        # ``_check_captcha`` while this flag is set we surface
+        # ``solver_outcome="captcha_during_solve"`` instead of recursing
+        # into another solve attempt (could otherwise pile up provider
+        # cost and deadlock against the per-instance lock).
+        self._captcha_solving: bool = False
+        # ``_last_solve_attempt`` records (sitekey, url, started_unix_ts)
+        # for the most recent solve so ``retry_previous=True`` can replay
+        # within a 60-second TTL. ``None`` until first attempt.
+        self._last_solve_attempt: tuple[str, str, float] | None = None
 
     def _register_page(self, page) -> str:
         """Assign a stable UUID to a Page if not already registered.
@@ -5547,6 +5611,254 @@ class BrowserManager:
             return {
                 "success": True,
                 "data": _with_legacy_fields(envelope),
+            }
+
+    # ── §11.14 explicit-trigger captcha skills ────────────────────────────
+
+    async def solve_captcha(
+        self,
+        agent_id: str,
+        *,
+        hint: str | None = None,
+        retry_previous: bool = False,
+        target_ref: str | None = None,
+    ) -> dict:
+        """Agent-triggered CAPTCHA solve.
+
+        Layered around :meth:`_check_captcha` rather than parallel to it so
+        we get §11.13 envelope semantics + §11.16 health-check / breaker
+        short-circuits for free.
+
+        Pre-solve gates (in order):
+          1. ``CAPTCHA_DISABLED`` flag — early-return ``no_solver`` envelope.
+          2. ``hint`` validation — bad hint → ``invalid_input`` error.
+          3. ``retry_previous`` TTL check — stale → ``invalid_input`` error.
+          4. No-captcha early return — saves a solver invocation + cost.
+          5. Per-agent rate limit (default 20/hr, ``CAPTCHA_RATE_LIMIT_PER_HOUR``).
+          6. Per-agent monthly cost cap (``CAPTCHA_COST_LIMIT_USD_PER_AGENT_MONTH``).
+          7. Recursive-solve guard — re-entrant ``_check_captcha`` while a
+             solve is in flight surfaces ``captcha_during_solve``.
+
+        ``target_ref`` accepts a snapshot ref for selecting one captcha among
+        many on the same page; multi-captcha enumeration lands in §11.6.
+        Until then, we LOG and IGNORE — the top-ranked visible widget gets
+        solved. Documented in the skill description so agents don't expect
+        targeting precision yet.
+        """
+        # Gate 1: fleet-wide kill switch.
+        from src.browser.flags import get_bool, get_int, get_str
+        if get_bool("CAPTCHA_DISABLED", False, agent_id=agent_id):
+            return {
+                "success": True,
+                "data": _with_legacy_fields(_captcha_envelope(
+                    kind="unknown", solver_attempted=False,
+                    solver_outcome="no_solver",
+                    solver_confidence="low",
+                    next_action="request_captcha_help",
+                )),
+            }
+
+        # Gate 2: hint validation (cheap, before lock).
+        if hint is not None:
+            if not isinstance(hint, str) or hint.strip() not in _VALID_CAPTCHA_KINDS:
+                return _err(
+                    "invalid_input",
+                    f"hint must be one of: {sorted(_VALID_CAPTCHA_KINDS)}",
+                )
+            hint = hint.strip()
+
+        if target_ref:
+            logger.warning(
+                "solve_captcha: target_ref=%r ignored — multi-captcha "
+                "enumeration is §11.6 (deferred). Top-ranked visible widget "
+                "will be solved.", target_ref,
+            )
+
+        inst = await self.get_or_start(agent_id)
+        inst.touch()
+
+        async with inst.lock:
+            # Gate 3: retry_previous TTL check.
+            if retry_previous:
+                last = inst._last_solve_attempt
+                if last is None or (time.time() - last[2]) > 60.0:
+                    return _err(
+                        "invalid_input", "no_recent_attempt_to_retry",
+                    )
+                # The retry path just re-runs the normal flow; the
+                # solver itself is idempotent against (sitekey, url),
+                # and we don't preserve the last classified kind here
+                # because the page may have changed. Stamp the
+                # restarted timestamp so further retries chain.
+                inst._last_solve_attempt = (last[0], last[1], time.time())
+
+            # Gate 4: no-captcha early return. Set the recursive-solve
+            # guard BEFORE the call so a captcha that appears during
+            # detection isn't mistaken for one we should now solve.
+            if inst._captcha_solving:
+                # Caller is reentering during an in-flight solve. Surface
+                # ``captcha_during_solve`` and let the agent escalate via
+                # request_captcha_help.
+                return {
+                    "success": True,
+                    "data": _with_legacy_fields(_captcha_envelope(
+                        kind="unknown", solver_attempted=False,
+                        solver_outcome="captcha_during_solve",
+                        solver_confidence="low",
+                        next_action="request_captcha_help",
+                    )),
+                }
+
+            inst._captcha_solving = True
+            try:
+                pre_check = await self._check_captcha(inst)
+                if not pre_check.get("captcha_found"):
+                    # No-captcha early return — short, no solver call,
+                    # no cost. Distinct from the §11.13 ``captcha_found:
+                    # false`` shape we get from the unsolicited
+                    # detection path; here we surface a top-level
+                    # ``message`` for the agent.
+                    return {
+                        "success": True,
+                        "data": {
+                            "captcha_found": False,
+                            "message": "No captcha on current page",
+                        },
+                    }
+
+                # Gate 5: rate limit (per-agent, sliding 1h window).
+                rate_limit = get_int(
+                    "CAPTCHA_RATE_LIMIT_PER_HOUR", 20,
+                    agent_id=agent_id, min_value=0, max_value=10000,
+                )
+                if await _check_solve_rate(agent_id, rate_limit):
+                    kind = pre_check.get("kind", "unknown")
+                    return {
+                        "success": True,
+                        "data": _with_legacy_fields(_captcha_envelope(
+                            kind=kind, solver_attempted=False,
+                            solver_outcome="rate_limited",
+                            solver_confidence=_kind_confidence(kind),
+                            next_action="request_captcha_help",
+                        )),
+                    }
+
+                # Gate 6: cost cap (per-agent, monthly, USD).
+                cap_usd_str = get_str(
+                    "CAPTCHA_COST_LIMIT_USD_PER_AGENT_MONTH", "",
+                    agent_id=agent_id,
+                )
+                cap_cents = 0
+                if cap_usd_str:
+                    try:
+                        cap_cents = int(round(float(cap_usd_str) * 100))
+                    except ValueError:
+                        logger.warning(
+                            "Invalid CAPTCHA_COST_LIMIT_USD_PER_AGENT_MONTH=%r"
+                            " — treating as unset", cap_usd_str,
+                        )
+                        cap_cents = 0
+                if cap_cents > 0:
+                    from src.browser import captcha_cost_counter as _cost
+                    if await _cost.over_cap(agent_id, cap_cents):
+                        kind = pre_check.get("kind", "unknown")
+                        return {
+                            "success": True,
+                            "data": _with_legacy_fields(_captcha_envelope(
+                                kind=kind, solver_attempted=False,
+                                solver_outcome="cost_cap",
+                                solver_confidence=_kind_confidence(kind),
+                                next_action="request_captcha_help",
+                            )),
+                        }
+
+                # If pre_check already attempted a solve (because
+                # ``_check_captcha`` always tries when a solver is
+                # configured), the result is what we'd return anyway.
+                # Stamp the last_solve_attempt for ``retry_previous``.
+                kind = pre_check.get("kind", "unknown")
+                if hint is not None and hint != kind:
+                    # Hint overrides the auto-classified kind in the
+                    # envelope so downstream consumers see what the
+                    # agent declared. We don't re-run the solver with
+                    # a different task type here — that's §11.1's
+                    # variant-aware solver work; the hint at this layer
+                    # is purely classification metadata until then.
+                    pre_check = dict(pre_check)
+                    pre_check["kind"] = hint
+
+                # Stamp the last attempt for ``retry_previous`` (best
+                # effort — page.url access can fail on closed contexts).
+                try:
+                    page_url = inst.page.url or ""
+                except Exception:
+                    page_url = ""
+                inst._last_solve_attempt = ("", page_url, time.time())
+
+                # Cost accounting on success: look up published rate by
+                # (provider, kind) and increment. Skip when unpriced
+                # rather than guess (under-count > over-count for trust).
+                if pre_check.get("solver_outcome") == "solved":
+                    provider = ""
+                    if self._captcha_solver is not None:
+                        provider = getattr(self._captcha_solver, "provider", "")
+                    if provider:
+                        from src.browser import captcha_cost_counter as _cost
+                        cents = _cost.estimate_cents(provider, kind)
+                        if cents is None:
+                            logger.warning(
+                                "captcha solve: no published rate for "
+                                "provider=%s kind=%s — skipping cost "
+                                "increment (under-count > over-count)",
+                                provider, kind,
+                            )
+                        else:
+                            await _cost.add_cost(agent_id, cents)
+
+                return {
+                    "success": True,
+                    "data": _with_legacy_fields(pre_check),
+                }
+            finally:
+                inst._captcha_solving = False
+
+    async def request_captcha_help(
+        self, agent_id: str, *, service: str, description: str,
+    ) -> dict:
+        """Agent-triggered request for human help on a CAPTCHA.
+
+        Mirrors the ``request_browser_login`` semantics: the BrowserManager
+        emits the dashboard handoff event and returns immediately. The
+        operator-completion path (``/api/browser-captcha-help/complete``
+        in the dashboard) enqueues a steer message to the agent — there
+        is no background blocking task in the BrowserManager itself.
+
+        Used for behavioral-only challenges (CF Under Attack, Press &
+        Hold), persistent rejections, or when ``solve_captcha`` returned
+        ``cost_cap`` / ``rate_limited``.
+        """
+        if not service:
+            return _err("invalid_input", "service is required")
+        if not description:
+            return _err("invalid_input", "description is required")
+
+        inst = await self.get_or_start(agent_id)
+        inst.touch()
+        # Acquire the lock so we present a stable page URL to the dashboard
+        # event and so a concurrent solve doesn't redirect the page mid-handoff.
+        async with inst.lock:
+            try:
+                page_url = inst.page.url or ""
+            except Exception:
+                page_url = ""
+            return {
+                "success": True,
+                "data": {
+                    "requested": True,
+                    "service": service[:128],
+                    "description": description[:500],
+                    "url": page_url[:2048],
+                },
             }
 
     # ── File transfer (Phase 1.5 infrastructure) ─────────────────────────

--- a/src/dashboard/server.py
+++ b/src/dashboard/server.py
@@ -2641,6 +2641,70 @@ def create_dashboard_router(
             event_bus.emit("browser_login_completed", agent=agent_id, data={"service": service})
         return {"completed": True, "agent_id": agent_id, "service": service}
 
+    @api_router.post("/api/browser-captcha-help/complete")
+    async def api_browser_captcha_help_complete(request: Request) -> dict:
+        """Phase 8 §11.14 — operator finished a CAPTCHA handoff."""
+        body = await request.json()
+        agent_id = body.get("agent_id", "").strip()
+        service = body.get("service", "").strip()[:128]
+        if not agent_id or not service:
+            raise HTTPException(
+                status_code=400,
+                detail="agent_id and service are required",
+            )
+        if agent_id in agent_registry and lane_manager is not None:
+            from src.shared.trace import new_trace_id
+            from src.shared.utils import sanitize_for_prompt
+            try:
+                msg = sanitize_for_prompt(
+                    f"The user has completed the CAPTCHA challenge for "
+                    f"{service}. You can resume browser interaction; the "
+                    f"page should now be past the captcha."
+                )
+                await lane_manager.enqueue(
+                    agent_id, msg, mode="steer", trace_id=new_trace_id(),
+                )
+            except Exception:
+                pass
+        if event_bus:
+            event_bus.emit(
+                "browser_captcha_help_completed",
+                agent=agent_id, data={"service": service},
+            )
+        return {"completed": True, "agent_id": agent_id, "service": service}
+
+    @api_router.post("/api/browser-captcha-help/cancel")
+    async def api_browser_captcha_help_cancel(request: Request) -> dict:
+        """Phase 8 §11.14 — operator cancelled a CAPTCHA handoff."""
+        body = await request.json()
+        agent_id = body.get("agent_id", "").strip()
+        service = body.get("service", "").strip()[:128]
+        if not agent_id or not service:
+            raise HTTPException(
+                status_code=400,
+                detail="agent_id and service are required",
+            )
+        if agent_id in agent_registry and lane_manager is not None:
+            from src.shared.trace import new_trace_id
+            from src.shared.utils import sanitize_for_prompt
+            try:
+                msg = sanitize_for_prompt(
+                    f"The user cancelled the CAPTCHA help request for "
+                    f"{service}. Try a different approach (e.g. wait + "
+                    f"retry, escalate to user via notify_user)."
+                )
+                await lane_manager.enqueue(
+                    agent_id, msg, mode="steer", trace_id=new_trace_id(),
+                )
+            except Exception:
+                pass
+        if event_bus:
+            event_bus.emit(
+                "browser_captcha_help_cancelled",
+                agent=agent_id, data={"service": service},
+            )
+        return {"cancelled": True, "agent_id": agent_id, "service": service}
+
     @api_router.post("/api/browser-login/cancel")
     async def api_browser_login_cancel(request: Request) -> dict:
         """User cancelled browser login — notify the requesting agent."""

--- a/src/host/permissions.py
+++ b/src/host/permissions.py
@@ -48,6 +48,12 @@ KNOWN_BROWSER_ACTIONS: frozenset[str] = frozenset({
     "click_xy",
     # Phase 6 §9.1 read-only network inspection.
     "inspect_requests",
+    # Phase 8 §11.14 explicit-trigger captcha-handling skills. Default-allow
+    # alongside the other browser actions; operators who want to forbid
+    # solver spend per-template can still add ``solve_captcha`` to a
+    # narrowed ``browser_actions`` denylist (or set
+    # ``CAPTCHA_DISABLED=true`` fleet-wide via flags.py).
+    "solve_captcha", "request_captcha_help",
 })
 
 # Back-compat alias — retained so `host/server.py` and test fixtures that

--- a/src/host/server.py
+++ b/src/host/server.py
@@ -1157,6 +1157,43 @@ def create_mesh_app(
 
         return {"requested": True, "service": service, "target_agent": agent_id}
 
+    @app.post("/mesh/browser-captcha-help-request")
+    async def browser_captcha_help_request(
+        data: dict, request: Request,
+    ) -> dict:
+        """Phase 8 §11.14 — agent requests human help for a CAPTCHA.
+
+        Mirrors :func:`browser_login_request` exactly. Emits a dashboard
+        ``browser_captcha_help_request`` event so the operator sees a
+        handoff card with the VNC viewer for the target agent's browser.
+        """
+        caller_id = _resolve_agent_id(data.get("agent_id", ""), request)
+        agent_id = _resolve_browser_target(
+            caller_id, data.get("target_agent_id") or "",
+        )
+
+        await _check_rate_limit("notify", caller_id)
+
+        service = data.get("service", "").strip()
+        description = data.get("description", "").strip()
+
+        if not service:
+            raise HTTPException(400, "Service name is required")
+        if not description:
+            raise HTTPException(400, "Description is required")
+
+        if event_bus:
+            event_bus.emit(
+                "browser_captcha_help_request",
+                agent=agent_id,
+                data={
+                    "service": service[:128],
+                    "description": description[:500],
+                },
+            )
+
+        return {"requested": True, "service": service, "target_agent": agent_id}
+
     @app.get("/mesh/agents")
     async def list_agents(request: Request, project: str = "", agent_id: str = "") -> dict:
         """List registered agents, optionally scoped by project or agent_id.

--- a/src/shared/redaction.py
+++ b/src/shared/redaction.py
@@ -89,6 +89,12 @@ _GENERIC = {
     "key", "token", "auth", "authorization", "access_token",
     "refresh_token", "id_token", "bearer_token", "bearertoken",
     "secret", "client_secret",
+    # 2Captcha / CapSolver share the ``clientKey`` query/body field as the
+    # raw API token. Adding it here lets ``redact_url`` strip the value
+    # from ``createTask?clientKey=SK...`` style logs uniformly with other
+    # secret-shaped query params (the captcha module's
+    # ``_redact_clientkey_text`` covers the body / exception-string case).
+    "clientkey", "client_key",
     "password", "passwd", "pwd", "assertion",
     "session", "session_id", "sessionid",
     "sig", "signature", "hash", "hmac",

--- a/tests/fixtures/redaction_corpus.json
+++ b/tests/fixtures/redaction_corpus.json
@@ -211,5 +211,33 @@
     "input": "webhook: https://hooks.slack.com/?auth=xoxp-FAKEEXAMPLEDONOTSCANUSERTOKEN",
     "expect_redacted": ["xoxp-FAKEEXAMPLEDONOTSCANUSERTOKEN"],
     "expect_preserved": ["hooks.slack.com"]
+  },
+  {
+    "name": "captcha_2captcha_create_task_with_clientkey",
+    "input": "https://api.2captcha.com/createTask?clientKey=SK0123456789abcdef0123456789abcdef0123456789abcdef",
+    "expect_redacted": ["SK0123456789abcdef0123456789abcdef0123456789abcdef"],
+    "expect_preserved": ["api.2captcha.com", "createTask", "clientKey="],
+    "note": "2Captcha echoes clientKey in error responses; key preserved for debug, value redacted."
+  },
+  {
+    "name": "captcha_capsolver_create_task_url",
+    "input": "https://api.capsolver.com/createTask",
+    "expect_redacted": [],
+    "expect_preserved": ["api.capsolver.com", "createTask"],
+    "note": "Plain URL with no secrets — verifies we don't over-redact the solver host."
+  },
+  {
+    "name": "captcha_capsolver_get_balance_clientkey",
+    "input": "https://api.capsolver.com/getBalance?clientKey=ckey0123456789abcdef0123456789abcdef0123456789",
+    "expect_redacted": ["ckey0123456789abcdef0123456789abcdef0123456789"],
+    "expect_preserved": ["api.capsolver.com", "getBalance", "clientKey="],
+    "note": "Solver provider clientKey value redacted in URL form (separate captcha-module redactor handles plain-text leak path)."
+  },
+  {
+    "name": "captcha_solver_taskid_uuid_in_url",
+    "input": "https://api.2captcha.com/getTaskResult?clientKey=ckey0123456789abcdef0123456789abcdef0123456789&taskId=8d2c1f3a-aaaa-4444-bbbb-1234567890ab",
+    "expect_redacted": ["ckey0123456789abcdef0123456789abcdef0123456789"],
+    "expect_preserved": ["api.2captcha.com", "getTaskResult", "taskId="],
+    "note": "Provider task IDs are not themselves secrets but appear in error logs; captcha module's redactor strips them in plain text. URL-form redaction here only targets clientKey."
   }
 ]

--- a/tests/test_browser_request_captcha_help.py
+++ b/tests/test_browser_request_captcha_help.py
@@ -1,0 +1,84 @@
+"""Tests for ``BrowserManager.request_captcha_help`` (Phase 8 §11.14).
+
+Mirrors the existing ``request_browser_login`` flow:
+  * Manager method records the request and returns a structured response.
+  * Mesh endpoint emits a dashboard event.
+  * Dashboard completion endpoint enqueues a steer message to the agent.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from src.browser.service import BrowserManager, CamoufoxInstance
+
+
+def _mk_inst(page_url="https://example.com/blocked"):
+    mock_page = MagicMock()
+    mock_page.url = page_url
+    return CamoufoxInstance("agent-1", MagicMock(), MagicMock(), mock_page)
+
+
+@pytest.fixture()
+def mgr(tmp_path):
+    return BrowserManager(profiles_dir=str(tmp_path / "profiles"))
+
+
+class TestManagerRequestCaptchaHelp:
+    @pytest.mark.asyncio
+    async def test_returns_structured_envelope(self, mgr):
+        inst = _mk_inst()
+        mgr._instances["agent-1"] = inst
+        mgr.get_or_start = AsyncMock(return_value=inst)
+
+        result = await mgr.request_captcha_help(
+            "agent-1",
+            service="Cloudflare Turnstile",
+            description="Please click the checkbox.",
+        )
+        assert result["success"] is True
+        assert result["data"]["requested"] is True
+        assert result["data"]["service"] == "Cloudflare Turnstile"
+        assert result["data"]["description"] == "Please click the checkbox."
+        assert result["data"]["url"] == "https://example.com/blocked"
+
+    @pytest.mark.asyncio
+    async def test_missing_service_returns_invalid_input(self, mgr):
+        inst = _mk_inst()
+        mgr._instances["agent-1"] = inst
+        mgr.get_or_start = AsyncMock(return_value=inst)
+
+        result = await mgr.request_captcha_help(
+            "agent-1", service="", description="d",
+        )
+        assert result["success"] is False
+        assert result["error"]["code"] == "invalid_input"
+
+    @pytest.mark.asyncio
+    async def test_missing_description_returns_invalid_input(self, mgr):
+        inst = _mk_inst()
+        mgr._instances["agent-1"] = inst
+        mgr.get_or_start = AsyncMock(return_value=inst)
+
+        result = await mgr.request_captcha_help(
+            "agent-1", service="X", description="",
+        )
+        assert result["success"] is False
+        assert result["error"]["code"] == "invalid_input"
+
+    @pytest.mark.asyncio
+    async def test_truncates_long_inputs(self, mgr):
+        inst = _mk_inst()
+        mgr._instances["agent-1"] = inst
+        mgr.get_or_start = AsyncMock(return_value=inst)
+
+        long_service = "S" * 500
+        long_desc = "D" * 2000
+        result = await mgr.request_captcha_help(
+            "agent-1", service=long_service, description=long_desc,
+        )
+        # service truncated to 128, description to 500.
+        assert len(result["data"]["service"]) == 128
+        assert len(result["data"]["description"]) == 500

--- a/tests/test_browser_service.py
+++ b/tests/test_browser_service.py
@@ -4035,6 +4035,18 @@ class TestAllowedBrowserActions:
         missing = required - actions
         assert not missing, f"Missing browser actions: {missing}"
 
+    def test_phase_8_captcha_skill_actions_present(self):
+        """Phase 8 §11.14 explicit-trigger captcha skills depend on these."""
+        actions = self._get_allowed_actions()
+        assert "solve_captcha" in actions, (
+            "solve_captcha missing from KNOWN_BROWSER_ACTIONS — "
+            "browser_solve_captcha skill will silently fail with 400."
+        )
+        assert "request_captcha_help" in actions, (
+            "request_captcha_help missing from KNOWN_BROWSER_ACTIONS — "
+            "request_captcha_help skill will silently fail with 400."
+        )
+
 
 class TestScrollParameterized:
     """Verify scroll uses mouse.wheel() with correct delta signs."""

--- a/tests/test_browser_solve_captcha.py
+++ b/tests/test_browser_solve_captcha.py
@@ -1,0 +1,288 @@
+"""Tests for ``BrowserManager.solve_captcha`` (Phase 8 §11.14).
+
+Covers:
+  * No-captcha early return.
+  * Successful solve increments the cost counter.
+  * Cost-cap exceeded → ``cost_cap`` outcome.
+  * Rate-limit exceeded → ``rate_limited`` outcome.
+  * Recursive-solve guard → ``captcha_during_solve``.
+  * ``retry_previous=True`` within 60s replays last attempt.
+  * ``retry_previous=True`` after 60s returns invalid_input.
+  * Bad ``hint`` returns invalid_input.
+  * Health-unreachable + breaker-open paths still return §11.13 envelopes.
+"""
+
+from __future__ import annotations
+
+import time
+from collections import deque
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from src.browser import captcha_cost_counter as cost
+from src.browser import service as svc
+from src.browser.service import BrowserManager, CamoufoxInstance
+
+
+def _mk_inst_with_locator(*, captcha_present: bool, page_url: str = "https://example.com"):
+    """Build a CamoufoxInstance with a mocked Page that reports captcha presence."""
+    mock_page = MagicMock()
+    mock_page.url = page_url
+
+    locator = MagicMock()
+    count_value = 1 if captcha_present else 0
+    locator.count = AsyncMock(return_value=count_value)
+    mock_page.locator = MagicMock(return_value=locator)
+    return CamoufoxInstance("agent-1", MagicMock(), MagicMock(), mock_page)
+
+
+@pytest.fixture(autouse=True)
+async def _isolate_cost(tmp_path, monkeypatch):
+    monkeypatch.setenv(
+        "CAPTCHA_COST_COUNTER_PATH", str(tmp_path / "captcha_costs.json"),
+    )
+    await cost.reset()
+    # Reset the in-process rate-limit window between tests.
+    svc._solve_rate_window.clear()
+    yield
+    await cost.reset()
+    svc._solve_rate_window.clear()
+
+
+@pytest.fixture()
+def mgr(tmp_path):
+    m = BrowserManager(profiles_dir=str(tmp_path / "profiles"))
+    return m
+
+
+class TestSolveCaptchaNoCaptcha:
+    @pytest.mark.asyncio
+    async def test_returns_no_captcha(self, mgr):
+        inst = _mk_inst_with_locator(captcha_present=False)
+        mgr._instances["agent-1"] = inst
+        mgr.get_or_start = AsyncMock(return_value=inst)
+
+        result = await mgr.solve_captcha("agent-1")
+        assert result["success"] is True
+        assert result["data"]["captcha_found"] is False
+        assert "No captcha" in result["data"]["message"]
+
+
+class TestSolveCaptchaSuccess:
+    @pytest.mark.asyncio
+    async def test_solver_success_increments_cost(self, mgr):
+        inst = _mk_inst_with_locator(captcha_present=True)
+        mgr._instances["agent-1"] = inst
+        mgr.get_or_start = AsyncMock(return_value=inst)
+
+        # Configure a fake solver that succeeds, with provider=2captcha.
+        solver = MagicMock()
+        solver.provider = "2captcha"
+        solver.is_solver_unreachable = MagicMock(return_value=False)
+        solver.is_breaker_open = MagicMock(return_value=False)
+        solver.solve = AsyncMock(return_value=True)
+        mgr._captcha_solver = solver
+
+        # The captcha selector that matches (iframe[src*=hcaptcha]) will
+        # classify as kind="hcaptcha", which is priced at 100¢ for 2captcha.
+        # We need to inject a locator that returns >0 only for the
+        # hcaptcha selector. Default mock returns >0 for any selector;
+        # the FIRST iter of _check_captcha matches "iframe[src*=recaptcha]"
+        # → kind="recaptcha-v2-checkbox", priced at 100¢ for 2captcha.
+        result = await mgr.solve_captcha("agent-1")
+
+        assert result["success"] is True
+        assert result["data"]["captcha_found"] is True
+        assert result["data"]["solver_outcome"] == "solved"
+
+        # Cost incremented (recaptcha-v2-checkbox @ 2captcha = 100¢)
+        assert await cost.get_cents("agent-1") == 100
+
+
+class TestSolveCaptchaCostCap:
+    @pytest.mark.asyncio
+    async def test_cost_cap_exceeded_short_circuits(self, mgr, monkeypatch):
+        # Configure the cap (USD).
+        monkeypatch.setenv("CAPTCHA_COST_LIMIT_USD_PER_AGENT_MONTH", "0.50")
+        # Pre-fill spend to exceed the cap (50 cents).
+        await cost.add_cost("agent-1", 100)
+
+        inst = _mk_inst_with_locator(captcha_present=True)
+        mgr._instances["agent-1"] = inst
+        mgr.get_or_start = AsyncMock(return_value=inst)
+
+        solver = MagicMock()
+        solver.provider = "2captcha"
+        solver.is_solver_unreachable = MagicMock(return_value=False)
+        solver.is_breaker_open = MagicMock(return_value=False)
+        solver.solve = AsyncMock(return_value=True)
+        mgr._captcha_solver = solver
+
+        result = await mgr.solve_captcha("agent-1")
+        assert result["success"] is True
+        assert result["data"]["solver_outcome"] == "cost_cap"
+        assert result["data"]["next_action"] == "request_captcha_help"
+
+
+class TestSolveCaptchaRateLimit:
+    @pytest.mark.asyncio
+    async def test_rate_limited_after_threshold(self, mgr, monkeypatch):
+        monkeypatch.setenv("CAPTCHA_RATE_LIMIT_PER_HOUR", "2")
+        # Pre-fill the rate window for this agent.
+        now = time.time()
+        svc._solve_rate_window["agent-1"] = deque([now, now])
+
+        inst = _mk_inst_with_locator(captcha_present=True)
+        mgr._instances["agent-1"] = inst
+        mgr.get_or_start = AsyncMock(return_value=inst)
+
+        solver = MagicMock()
+        solver.provider = "2captcha"
+        solver.is_solver_unreachable = MagicMock(return_value=False)
+        solver.is_breaker_open = MagicMock(return_value=False)
+        solver.solve = AsyncMock(return_value=True)
+        mgr._captcha_solver = solver
+
+        result = await mgr.solve_captcha("agent-1")
+        assert result["success"] is True
+        assert result["data"]["solver_outcome"] == "rate_limited"
+        assert result["data"]["next_action"] == "request_captcha_help"
+
+
+class TestSolveCaptchaRecursiveGuard:
+    @pytest.mark.asyncio
+    async def test_recursive_solve_returns_captcha_during_solve(self, mgr):
+        inst = _mk_inst_with_locator(captcha_present=True)
+        # Pretend a solve is already in flight.
+        inst._captcha_solving = True
+        mgr._instances["agent-1"] = inst
+        mgr.get_or_start = AsyncMock(return_value=inst)
+
+        result = await mgr.solve_captcha("agent-1")
+        assert result["success"] is True
+        assert result["data"]["solver_outcome"] == "captcha_during_solve"
+        assert result["data"]["next_action"] == "request_captcha_help"
+
+
+class TestSolveCaptchaRetryPrevious:
+    @pytest.mark.asyncio
+    async def test_retry_within_ttl_works(self, mgr):
+        inst = _mk_inst_with_locator(captcha_present=True)
+        # Stamp a prior attempt 1 second ago.
+        inst._last_solve_attempt = ("sk", "https://example.com", time.time() - 1)
+        mgr._instances["agent-1"] = inst
+        mgr.get_or_start = AsyncMock(return_value=inst)
+
+        solver = MagicMock()
+        solver.provider = "2captcha"
+        solver.is_solver_unreachable = MagicMock(return_value=False)
+        solver.is_breaker_open = MagicMock(return_value=False)
+        solver.solve = AsyncMock(return_value=True)
+        mgr._captcha_solver = solver
+
+        result = await mgr.solve_captcha("agent-1", retry_previous=True)
+        assert result["success"] is True
+        assert result["data"]["solver_outcome"] == "solved"
+
+    @pytest.mark.asyncio
+    async def test_retry_after_ttl_returns_invalid_input(self, mgr):
+        inst = _mk_inst_with_locator(captcha_present=True)
+        # Stamp a prior attempt 90 seconds ago — past the 60s TTL.
+        inst._last_solve_attempt = ("sk", "https://example.com", time.time() - 90)
+        mgr._instances["agent-1"] = inst
+        mgr.get_or_start = AsyncMock(return_value=inst)
+
+        result = await mgr.solve_captcha("agent-1", retry_previous=True)
+        assert result["success"] is False
+        assert result["error"]["code"] == "invalid_input"
+        assert result["error"]["message"] == "no_recent_attempt_to_retry"
+
+    @pytest.mark.asyncio
+    async def test_retry_with_no_prior_attempt_returns_invalid_input(self, mgr):
+        inst = _mk_inst_with_locator(captcha_present=True)
+        mgr._instances["agent-1"] = inst
+        mgr.get_or_start = AsyncMock(return_value=inst)
+
+        result = await mgr.solve_captcha("agent-1", retry_previous=True)
+        assert result["success"] is False
+        assert result["error"]["code"] == "invalid_input"
+
+
+class TestSolveCaptchaHintValidation:
+    @pytest.mark.asyncio
+    async def test_invalid_hint_rejected(self, mgr):
+        inst = _mk_inst_with_locator(captcha_present=True)
+        mgr._instances["agent-1"] = inst
+        mgr.get_or_start = AsyncMock(return_value=inst)
+
+        result = await mgr.solve_captcha("agent-1", hint="not-a-real-kind")
+        assert result["success"] is False
+        assert result["error"]["code"] == "invalid_input"
+        assert "hint" in result["error"]["message"]
+
+    @pytest.mark.asyncio
+    async def test_valid_hint_overrides_classification(self, mgr):
+        inst = _mk_inst_with_locator(captcha_present=True)
+        mgr._instances["agent-1"] = inst
+        mgr.get_or_start = AsyncMock(return_value=inst)
+
+        # No solver — we just want to read the kind back.
+        mgr._captcha_solver = None
+        result = await mgr.solve_captcha("agent-1", hint="hcaptcha")
+        assert result["success"] is True
+        assert result["data"]["kind"] == "hcaptcha"
+
+
+class TestSolveCaptchaHealthAndBreaker:
+    @pytest.mark.asyncio
+    async def test_solver_unreachable_returns_no_solver(self, mgr):
+        inst = _mk_inst_with_locator(captcha_present=True)
+        mgr._instances["agent-1"] = inst
+        mgr.get_or_start = AsyncMock(return_value=inst)
+
+        solver = MagicMock()
+        solver.provider = "2captcha"
+        solver.is_solver_unreachable = MagicMock(return_value=True)
+        solver.is_breaker_open = MagicMock(return_value=False)
+        solver.solve = AsyncMock(return_value=True)
+        mgr._captcha_solver = solver
+
+        result = await mgr.solve_captcha("agent-1")
+        assert result["success"] is True
+        assert result["data"]["solver_outcome"] == "no_solver"
+        assert result["data"]["next_action"] == "request_captcha_help"
+
+    @pytest.mark.asyncio
+    async def test_breaker_open_returns_timeout_with_flag(self, mgr):
+        inst = _mk_inst_with_locator(captcha_present=True)
+        mgr._instances["agent-1"] = inst
+        mgr.get_or_start = AsyncMock(return_value=inst)
+
+        solver = MagicMock()
+        solver.provider = "2captcha"
+        solver.is_solver_unreachable = MagicMock(return_value=False)
+        solver.is_breaker_open = MagicMock(return_value=True)
+        solver.solve = AsyncMock(return_value=True)
+        mgr._captcha_solver = solver
+
+        result = await mgr.solve_captcha("agent-1")
+        assert result["success"] is True
+        assert result["data"]["solver_outcome"] == "timeout"
+        # _check_captcha sets the additive ``breaker_open`` flag on the envelope
+        # for the breaker-open path. Because solve_captcha runs the legacy-
+        # field shim, the flag is preserved on the returned dict.
+        assert result["data"].get("breaker_open") is True
+
+
+class TestSolveCaptchaDisabledFlag:
+    @pytest.mark.asyncio
+    async def test_captcha_disabled_short_circuits(self, mgr, monkeypatch):
+        monkeypatch.setenv("CAPTCHA_DISABLED", "true")
+        inst = _mk_inst_with_locator(captcha_present=True)
+        mgr._instances["agent-1"] = inst
+        mgr.get_or_start = AsyncMock(return_value=inst)
+
+        result = await mgr.solve_captcha("agent-1")
+        assert result["success"] is True
+        assert result["data"]["solver_outcome"] == "no_solver"

--- a/tests/test_captcha_cost_counter.py
+++ b/tests/test_captcha_cost_counter.py
@@ -1,0 +1,198 @@
+"""Tests for the simplified CAPTCHA cost counter (Phase 8 §11.10 trim).
+
+Covers:
+  * pricing-table lookup (case-insensitive, unknown variant → None)
+  * month rollover resets the bucket
+  * snapshot / restore round-trip via JSON
+  * atomic write (tmp file replaced)
+  * concurrent ``add_cost`` correctness
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from pathlib import Path
+
+import pytest
+
+from src.browser import captcha_cost_counter as cost
+
+
+@pytest.fixture(autouse=True)
+async def _isolate_state(tmp_path, monkeypatch):
+    """Each test gets a clean dict and a tmp path so state can't leak."""
+    monkeypatch.setenv(
+        "CAPTCHA_COST_COUNTER_PATH", str(tmp_path / "captcha_costs.json"),
+    )
+    await cost.reset()
+    yield
+    await cost.reset()
+
+
+class TestEstimateCents:
+    def test_known_2captcha_recaptcha_v2(self):
+        assert cost.estimate_cents("2captcha", "recaptcha-v2-checkbox") == 100
+
+    def test_known_capsolver_turnstile(self):
+        assert cost.estimate_cents("capsolver", "turnstile") == 60
+
+    def test_unknown_kind_returns_none(self):
+        assert cost.estimate_cents("2captcha", "made-up-variant") is None
+
+    def test_unknown_provider_returns_none(self):
+        assert cost.estimate_cents("nopal", "hcaptcha") is None
+
+    def test_case_insensitive(self):
+        assert cost.estimate_cents("2CAPTCHA", "HCAPTCHA") == 100
+        assert cost.estimate_cents("CapSolver", "Turnstile") == 60
+
+    def test_empty_inputs_safe(self):
+        assert cost.estimate_cents("", "hcaptcha") is None
+        assert cost.estimate_cents("2captcha", "") is None
+
+
+class TestAddCostAndOverCap:
+    @pytest.mark.asyncio
+    async def test_add_cost_accumulates(self):
+        await cost.add_cost("agent-1", 100)
+        await cost.add_cost("agent-1", 50)
+        assert await cost.get_cents("agent-1") == 150
+
+    @pytest.mark.asyncio
+    async def test_add_cost_zero_or_negative_dropped(self):
+        await cost.add_cost("agent-1", 0)
+        await cost.add_cost("agent-1", -10)
+        assert await cost.get_cents("agent-1") == 0
+
+    @pytest.mark.asyncio
+    async def test_over_cap_below_threshold(self):
+        await cost.add_cost("agent-1", 99)
+        assert await cost.over_cap("agent-1", 100) is False
+
+    @pytest.mark.asyncio
+    async def test_over_cap_at_threshold(self):
+        await cost.add_cost("agent-1", 100)
+        assert await cost.over_cap("agent-1", 100) is True
+
+    @pytest.mark.asyncio
+    async def test_over_cap_zero_disables(self):
+        await cost.add_cost("agent-1", 1_000_000)
+        assert await cost.over_cap("agent-1", 0) is False
+
+    @pytest.mark.asyncio
+    async def test_unrelated_agents_isolated(self):
+        await cost.add_cost("agent-1", 200)
+        assert await cost.get_cents("agent-2") == 0
+
+
+class TestMonthRollover:
+    @pytest.mark.asyncio
+    async def test_bucket_resets_on_month_change(self, monkeypatch):
+        # Spend 200 in January.
+        monkeypatch.setattr(cost, "_current_month", lambda: "2026-01")
+        await cost.add_cost("agent-1", 200)
+        assert await cost.get_cents("agent-1") == 200
+
+        # Roll over to February — bucket should reset.
+        monkeypatch.setattr(cost, "_current_month", lambda: "2026-02")
+        assert await cost.get_cents("agent-1") == 0
+        await cost.add_cost("agent-1", 50)
+        assert await cost.get_cents("agent-1") == 50
+
+    @pytest.mark.asyncio
+    async def test_month_rollover_during_over_cap(self, monkeypatch):
+        monkeypatch.setattr(cost, "_current_month", lambda: "2026-01")
+        await cost.add_cost("agent-1", 1500)
+        assert await cost.over_cap("agent-1", 1000) is True
+
+        monkeypatch.setattr(cost, "_current_month", lambda: "2026-02")
+        assert await cost.over_cap("agent-1", 1000) is False
+
+
+class TestSnapshotRestore:
+    @pytest.mark.asyncio
+    async def test_round_trip(self, tmp_path):
+        path = tmp_path / "costs.json"
+        await cost.add_cost("agent-a", 200)
+        await cost.add_cost("agent-b", 350)
+
+        ok = await cost.snapshot(path)
+        assert ok is True
+        assert path.exists()
+
+        # Wipe in-memory state, then restore.
+        await cost.reset()
+        assert await cost.get_cents("agent-a") == 0
+        loaded = await cost.restore(path)
+        assert loaded == 2
+        assert await cost.get_cents("agent-a") == 200
+        assert await cost.get_cents("agent-b") == 350
+
+    @pytest.mark.asyncio
+    async def test_restore_drops_stale_month(self, tmp_path, monkeypatch):
+        path = tmp_path / "costs.json"
+        # Write a snapshot stamped for last month.
+        payload = {
+            "version": 1,
+            "saved_at": 0,
+            "buckets": {
+                "agent-old": {"month": "2020-01", "cents": 999},
+            },
+        }
+        path.write_text(json.dumps(payload))
+        loaded = await cost.restore(path)
+        # Stale month skipped.
+        assert loaded == 0
+        assert await cost.get_cents("agent-old") == 0
+
+    @pytest.mark.asyncio
+    async def test_restore_missing_file_safe(self, tmp_path):
+        loaded = await cost.restore(tmp_path / "absent.json")
+        assert loaded == 0
+
+    @pytest.mark.asyncio
+    async def test_restore_malformed_file_safe(self, tmp_path):
+        path = tmp_path / "costs.json"
+        path.write_text("{not valid json")
+        loaded = await cost.restore(path)
+        assert loaded == 0
+
+    @pytest.mark.asyncio
+    async def test_snapshot_writes_atomically(self, tmp_path):
+        """The .tmp sibling must be replaced into the destination, not left."""
+        path = tmp_path / "costs.json"
+        await cost.add_cost("agent-1", 42)
+        await cost.snapshot(path)
+        assert path.exists()
+        # Verify no .tmp leak.
+        sibling = tmp_path / "costs.json.tmp"
+        assert not sibling.exists()
+        # Verify content is valid JSON with our payload.
+        data = json.loads(path.read_text())
+        assert "buckets" in data
+        assert data["buckets"]["agent-1"]["cents"] == 42
+
+    @pytest.mark.asyncio
+    async def test_snapshot_failure_returns_false(self, monkeypatch):
+        """An os.replace failure must be reported, not raised."""
+        await cost.add_cost("agent-1", 5)
+
+        def boom(*a, **kw):
+            raise OSError("disk full")
+
+        monkeypatch.setattr("os.replace", boom)
+        # Use a real path so the open succeeds before replace is reached.
+        ok = await cost.snapshot(Path("/tmp/test_captcha_cost_fail.json"))
+        assert ok is False
+
+
+class TestConcurrentWrites:
+    @pytest.mark.asyncio
+    async def test_concurrent_add_correct(self):
+        """100 concurrent ``add_cost(1)`` calls must sum to exactly 100."""
+        async def add_one():
+            await cost.add_cost("agent-1", 1)
+
+        await asyncio.gather(*(add_one() for _ in range(100)))
+        assert await cost.get_cents("agent-1") == 100

--- a/tests/test_captcha_health.py
+++ b/tests/test_captcha_health.py
@@ -624,6 +624,23 @@ def test_redact_clientkey_text_helper():
     assert _redact_clientkey_text("") == ""
 
 
+def test_redact_clientkey_text_strips_taskid():
+    """§11.14 / §11.15: solver task IDs (UUIDs and integers) appear in
+    error responses. The shared redactor strips them so a hostile
+    provider error containing a stitched-together secret-like string
+    can't leak via the taskId path.
+    """
+    shapes_with_uuid = [
+        'taskId=8d2c1f3a-aaaa-4444-bbbb-1234567890ab',
+        '"taskId": "8d2c1f3a-aaaa-4444-bbbb-1234567890ab"',
+        "taskId: 9999999999",
+        "TASKID='abcdef-0123456789'",
+    ]
+    for shape in shapes_with_uuid:
+        out = _redact_clientkey_text(shape)
+        assert "[REDACTED]" in out, f"taskId not redacted in {shape!r}: {out!r}"
+
+
 # ── 12: cancellation cleans up in-flight health_check ─────────────────
 
 

--- a/tests/test_permissions.py
+++ b/tests/test_permissions.py
@@ -272,6 +272,14 @@ class TestKnownBrowserActionsSet:
         assert "find_text" in KNOWN_BROWSER_ACTIONS
         assert "open_tab" in KNOWN_BROWSER_ACTIONS
 
+    def test_phase_8_captcha_actions_present(self):
+        """Phase 8 §11.14 explicit-trigger captcha skills must be in
+        KNOWN_BROWSER_ACTIONS so the mesh accepts ``solve_captcha`` and
+        ``request_captcha_help`` routed via /mesh/browser/command."""
+        from src.host.permissions import KNOWN_BROWSER_ACTIONS
+        assert "solve_captcha" in KNOWN_BROWSER_ACTIONS
+        assert "request_captcha_help" in KNOWN_BROWSER_ACTIONS
+
     def test_legacy_alias_still_exported(self):
         """Back-compat alias for callers that imported the old name."""
         from src.host.permissions import (


### PR DESCRIPTION
## Summary

- Adds `browser_solve_captcha` and `request_captcha_help` agent skills, the matching `BrowserManager.solve_captcha` / `BrowserManager.request_captcha_help` methods, mesh routes, and dashboard handoff endpoints — symmetric to the existing `request_browser_login` flow.
- Ships an in-memory per-agent monthly cost counter (`src/browser/captcha_cost_counter.py`) snapshotted to JSON on graceful shutdown — the simplified replacement for the deferred §11.10 SQLite design per the trim spec.
- Folds in §11.15: redacts `clientKey` value in URL form via `SENSITIVE_QUERY_PARAMS`, wraps solver `createTask` / `getTaskResult` HTTP calls with `_redact_clientkey_text` on failure paths, extends that redactor to also strip `taskId`, and adds three new entries to the redaction corpus.

## Plan reference

`docs/plans/2026-04-20-browser-automation.md` §11.14 + §11.20 (the §11.10 simplification + §11.15 partial fold-in). Plan doc not modified per the spec note.

## What's new

**Agent surface**
- `browser_solve_captcha(hint?, retry_previous?, target_ref?)` — explicit-trigger solve. Returns the §11.13 envelope with three additive outcomes: `rate_limited`, `cost_cap`, `captcha_during_solve`.
- `request_captcha_help(service, description)` — VNC handoff card; mirrors `request_browser_login` (operator unblocks the agent via `/api/browser-captcha-help/complete`).

**BrowserManager.solve_captcha pre-solve gates (in order)**
1. `CAPTCHA_DISABLED` flag → `no_solver` envelope.
2. `hint` validation against the §11.13 `kind` enum → `invalid_input` on bad value.
3. `retry_previous=True` with no recent attempt or stale (>60s) → `invalid_input`.
4. No-captcha early return (no solver invoked, no cost).
5. Per-agent rate limit (default 20/hr, `CAPTCHA_RATE_LIMIT_PER_HOUR`).
6. Per-agent monthly cost cap (`CAPTCHA_COST_LIMIT_USD_PER_AGENT_MONTH`).
7. Recursive-solve guard (`inst._captcha_solving`) → `captcha_during_solve`.

**Cost counter**
- In-memory `dict[str, {month, cents}]` guarded by `asyncio.Lock`. Resets on month rollover. Atomic JSON snapshot (`os.replace` after `fsync`) at `data/captcha_costs.json`. `restore()` on browser-service startup, `snapshot()` on graceful shutdown.
- Pricing table covers 2captcha + CapSolver published rates; unknown variants log + skip the increment (under-count > over-count).

**Redaction corpus**
- Added: `clientKey` URL value redaction (`api.2captcha.com/createTask?clientKey=…`), `getBalance` clientKey form, `taskId` plain-text path. Solver HTTP call paths wrapped to redact via the existing `_redact_clientkey_text` helper before logging.

**Mesh + permissions**
- `solve_captcha` and `request_captcha_help` added to `KNOWN_BROWSER_ACTIONS` (single-source).
- New mesh route `POST /mesh/browser-captcha-help-request`.
- New dashboard routes `POST /api/browser-captcha-help/{complete,cancel}`.
- New mesh-client method `request_captcha_help`.

## Reuse map

- `_check_captcha` / `_captcha_envelope` / `_classify_kind` → reused, no parallel solver pipeline.
- `_redact_clientkey_text` → extended (taskId), single redactor.
- `request_browser_login` flow → mirrored exactly for `request_captcha_help`.
- `flags.get_int` / `get_str` precedence chain → used for env config.
- `EventBus.emit` → used for both new events.

## Test plan

- [x] `tests/test_browser_solve_captcha.py` — 13 tests covering all 7 gates + breaker/health interaction.
- [x] `tests/test_browser_request_captcha_help.py` — 4 tests covering envelope shape + truncation.
- [x] `tests/test_captcha_cost_counter.py` — 21 tests: pricing lookup, month rollover, snapshot/restore round-trip, atomic write failure path, 100-way concurrent `add_cost`.
- [x] `tests/test_shared_redaction.py` — corpus extended with 2 new entries (covered by existing corpus gate).
- [x] `tests/test_captcha_health.py` — added test for taskId redaction.
- [x] `tests/test_permissions.py` — `solve_captcha` / `request_captcha_help` in KNOWN_BROWSER_ACTIONS.
- [x] `tests/test_browser_service.py` — same KNOWN_BROWSER_ACTIONS regression check.
- [x] `ruff check src/ tests/` clean.

## Pre-existing failures (NOT introduced here)

The full suite has 6 failing tests on Python 3.10 (the env this branch was tested on) which also fail on `origin/main` with the same shape:

- `test_browser_inspect_requests::test_filter_before_cap_with_limit_smaller_than_visible` — the 3.12-only flake the spec calls out (also flakes here on 3.10; not ours to fix).
- 5x `test_dashboard_browser_metrics::TestFetchBrowserMetricsUpstream::*` — brittle `asyncio.get_event_loop().run_until_complete(…)` pattern that fails when other event-loop-using tests run first. Pre-existing on `origin/main`.
- `test_cli_commands::TestVersion::test_version_flag` — pre-existing on `origin/main`.

Verified by stashing all changes (incl. untracked) and re-running the same command on bare `origin/main`. Same 6 failures.

## Out of scope (deferred)

- `target_ref` for multi-captcha pages — accepted as a parameter for forward-compat but currently logged + ignored. Multi-captcha enumeration is §11.6.
- Variant-aware solve task types — `hint` only overrides classification metadata in the envelope today; switching the actual solver task type (e.g. recaptcha-v3 → enterprise) is §11.1.
- `injection_failed` outcome plumbing — still RESERVED in §11.13. Requires a richer `CaptchaSolver` return type, planned alongside §11.18.