### PR TITLE
Fix asyncio.get_event_loop() in test_dashboard_browser_metrics

### DIFF
--- a/tests/test_dashboard_browser_metrics.py
+++ b/tests/test_dashboard_browser_metrics.py
@@ -327,7 +327,14 @@ class TestFetchBrowserMetricsUpstream:
 
     def _run(self, coro):
         import asyncio
-        return asyncio.get_event_loop().run_until_complete(coro)
+        # Fresh loop per call — asyncio.get_event_loop() raises
+        # RuntimeError on Python 3.10+ when no loop is running, and
+        # asyncio.run() refuses to run inside an already-running loop.
+        loop = asyncio.new_event_loop()
+        try:
+            return loop.run_until_complete(coro)
+        finally:
+            loop.close()
 
     def test_network_failure_returns_envelope(self):
         from src.dashboard.server import _fetch_browser_metrics_upstream


### PR DESCRIPTION
## Summary

- Replaces `asyncio.get_event_loop().run_until_complete(coro)` with the `asyncio.new_event_loop()` + `run_until_complete` + `close` pattern already used elsewhere in the same file (line ~568).
- Fixes 5 latent failures in `TestFetchBrowserMetricsUpstream` on Python 3.11 and 3.12 — `get_event_loop()` raises `RuntimeError` on 3.10+ when called outside an async context with no running loop. Surfaces when test order changes.
- Originally introduced by #765.

## Test plan

- [x] `pytest tests/test_dashboard_browser_metrics.py::TestFetchBrowserMetricsUpstream -v` — all 5 named tests pass
- [x] `pytest tests/test_dashboard_browser_metrics.py -v` — full file (23 tests) passes
- [x] `ruff check tests/test_dashboard_browser_metrics.py` — clean