### PR TITLE
Phase 8 §11.1: reCAPTCHA v3/Enterprise variant classification

### DIFF
--- a/src/agent/builtins/browser_tool.py
+++ b/src/agent/builtins/browser_tool.py
@@ -1144,8 +1144,10 @@ async def browser_upload_file(
             "description": (
                 "Optional override for captcha kind classification. "
                 "One of: recaptcha-v2-checkbox, recaptcha-v2-invisible, "
-                "recaptcha-v3, recaptcha-enterprise, hcaptcha, turnstile, "
-                "cf-interstitial-auto, cf-interstitial-behavioral, unknown."
+                "recaptcha-v3, recaptcha-enterprise-v2, "
+                "recaptcha-enterprise-v3, recaptcha-enterprise (legacy "
+                "alias), hcaptcha, turnstile, cf-interstitial-auto, "
+                "cf-interstitial-behavioral, unknown."
             ),
             "default": "",
         },

--- a/src/browser/captcha.py
+++ b/src/browser/captcha.py
@@ -109,19 +109,78 @@ _CAPTCHA_TYPE_MAP: dict[str, str] = {
     "captcha": "recaptcha",  # generic fallback — most common type
 }
 
-# 2Captcha task type mapping
-_2CAPTCHA_TASK_TYPES: dict[str, str] = {
-    "recaptcha": "NormalRecaptchaTaskProxyless",
-    "hcaptcha": "HCaptchaTaskProxyless",
-    "turnstile": "TurnstileTaskProxyless",
+
+# §11.1 — provider task-type tables, structured as
+# ``dict[variant, dict[provider_field, value]]`` so each variant can
+# declare task-specific extras (``isInvisible``, ``isEnterprise``) without
+# growing the call-site logic. The submit-task code paths merge these
+# extras into the task body alongside ``websiteURL`` / ``websiteKey``.
+#
+# Task-name verification (April 2026, against current public docs):
+#   * 2captcha — https://2captcha.com/api-docs/recaptcha-v{2,3}{,-enterprise}
+#     - v2 / v2-invisible: same task name ``RecaptchaV2TaskProxyless`` with
+#       ``isInvisible`` flag distinguishing invisible.
+#     - v3: ``RecaptchaV3TaskProxyless`` requires ``minScore`` + accepts
+#       ``pageAction``. Enterprise v3 is the same task name with
+#       ``isEnterprise: true`` — 2captcha has NO standalone
+#       ``RecaptchaV3EnterpriseTaskProxyless`` type as of April 2026
+#       (drift from the early spec; verified against the v3 doc page).
+#     - Enterprise v2: ``RecaptchaV2EnterpriseTaskProxyless`` (distinct).
+#   * CapSolver — https://docs.capsolver.com/en/guide/captcha/ReCaptchaV{2,3}/
+#     - Distinct task names for each variant. ``isInvisible`` is the v2
+#       knob; ``minScore`` is documented but score filtering may be
+#       performed downstream at validation time rather than affecting
+#       the solve itself (we still pass it; CapSolver tolerates extra
+#       fields). ``pageAction`` is documented as optional.
+#
+# Drift here is silent (``ERROR_INVALID_TASK_TYPE``); re-verify against
+# provider docs when bumping variants.
+#
+# 2Captcha
+_2CAPTCHA_TASK_TYPES: dict[str, dict[str, object]] = {
+    "recaptcha": {"type": "NormalRecaptchaTaskProxyless"},  # legacy alias
+    "hcaptcha": {"type": "HCaptchaTaskProxyless"},
+    "turnstile": {"type": "TurnstileTaskProxyless"},
+    # §11.1 reCAPTCHA variant matrix
+    "recaptcha-v2-checkbox": {"type": "RecaptchaV2TaskProxyless"},
+    "recaptcha-v2-invisible": {
+        "type": "RecaptchaV2TaskProxyless",
+        "isInvisible": True,
+    },
+    "recaptcha-v3": {"type": "RecaptchaV3TaskProxyless"},
+    "recaptcha-enterprise-v2": {"type": "RecaptchaV2EnterpriseTaskProxyless"},
+    # 2captcha uses the same v3 task with isEnterprise=true (no separate
+    # ``RecaptchaV3EnterpriseTaskProxyless`` type as of April 2026).
+    "recaptcha-enterprise-v3": {
+        "type": "RecaptchaV3TaskProxyless",
+        "isEnterprise": True,
+    },
 }
 
-# CapSolver task type mapping
-_CAPSOLVER_TASK_TYPES: dict[str, str] = {
-    "recaptcha": "ReCaptchaV2TaskProxyLess",
-    "hcaptcha": "HCaptchaTaskProxyLess",
-    "turnstile": "AntiTurnstileTaskProxyLess",
+# CapSolver
+_CAPSOLVER_TASK_TYPES: dict[str, dict[str, object]] = {
+    "recaptcha": {"type": "ReCaptchaV2TaskProxyLess"},  # legacy alias
+    "hcaptcha": {"type": "HCaptchaTaskProxyLess"},
+    "turnstile": {"type": "AntiTurnstileTaskProxyLess"},
+    # §11.1 reCAPTCHA variant matrix
+    "recaptcha-v2-checkbox": {"type": "ReCaptchaV2TaskProxyLess"},
+    "recaptcha-v2-invisible": {
+        "type": "ReCaptchaV2TaskProxyLess",
+        "isInvisible": True,
+    },
+    "recaptcha-v3": {"type": "ReCaptchaV3TaskProxyLess"},
+    "recaptcha-enterprise-v2": {"type": "ReCaptchaV2EnterpriseTaskProxyLess"},
+    "recaptcha-enterprise-v3": {"type": "ReCaptchaV3EnterpriseTaskProxyLess"},
 }
+
+
+# Default ``pageAction`` when the classifier couldn't extract one. Most
+# v3 implementations accept a generic ``"verify"`` action — solving with
+# the wrong action returns a token bound to the wrong action and the
+# verifying server may still reject the score, but it's the best
+# permissive fallback we have.
+_DEFAULT_V3_ACTION = "verify"
+_DEFAULT_V3_MIN_SCORE = 0.7
 
 
 def get_solver() -> CaptchaSolver | None:
@@ -148,6 +207,219 @@ def _classify_captcha(selector: str) -> str:
         if pattern in sel_lower:
             return captcha_type
     return "recaptcha"  # safe default
+
+
+# ── §11.1 reCAPTCHA variant classifier ───────────────────────────────────
+
+
+# Single JS probe walking ``window.___grecaptcha_cfg`` plus the script /
+# DOM signals. Returning a structured dict from one ``page.evaluate`` is
+# cheaper than five round trips and keeps the page-side logic auditable
+# in one place. Designed to never throw — every branch wraps in
+# try/catch and falls back to ``null``.
+_CLASSIFY_RECAPTCHA_JS = r"""
+() => {
+  const out = {
+    enterprise: false,
+    v3: false,
+    sitekeys: [],         // collected from registry walk
+    actions_by_key: {},   // sitekey -> action (v3 only)
+    invisible_by_key: {}, // sitekey -> bool (explicit-render size)
+    enterprise_script: false,
+    v3_render_param: null,    // sitekey from api.js?render=...
+  };
+  try {
+    // ── 1. Script-tag scan: enterprise namespace + v3 render param ──
+    const scripts = document.querySelectorAll('script[src]');
+    for (const s of scripts) {
+      const src = s.getAttribute('src') || '';
+      if (
+        src.indexOf('enterprise.recaptcha.net') !== -1 ||
+        src.indexOf('recaptcha/enterprise/') !== -1 ||
+        src.indexOf('/enterprise.js') !== -1
+      ) {
+        out.enterprise = true;
+        out.enterprise_script = true;
+      }
+      // v3-only render parameter on api.js: ?render=<sitekey>
+      const m = src.match(/[?&]render=([^&]+)/);
+      if (m && m[1] && m[1] !== 'explicit') {
+        out.v3 = true;
+        out.v3_render_param = decodeURIComponent(m[1]);
+      }
+    }
+    // ── 2. Global ``grecaptcha.enterprise`` presence ───────────────
+    try {
+      if (
+        typeof window.grecaptcha !== 'undefined' &&
+        window.grecaptcha &&
+        typeof window.grecaptcha.enterprise === 'object'
+      ) {
+        out.enterprise = true;
+      }
+    } catch (e) { /* defensive */ }
+    // ── 3. ``___grecaptcha_cfg`` registry walk ─────────────────────
+    let cfg = null;
+    try { cfg = window.___grecaptcha_cfg; } catch (e) { cfg = null; }
+    if (cfg && cfg.clients) {
+      for (const cid in cfg.clients) {
+        const client = cfg.clients[cid];
+        // The widget config is nested arbitrarily deep inside ``client``
+        // (Google obfuscates the tree). Walk shallowly looking for the
+        // canonical fields. Depth 6 is enough in practice.
+        const seen = new Set();
+        const stack = [[client, 0]];
+        let foundSitekey = null;
+        let foundAction = null;
+        let foundSize = null;
+        while (stack.length) {
+          const [node, d] = stack.pop();
+          if (!node || typeof node !== 'object' || d > 6) continue;
+          if (seen.has(node)) continue;
+          seen.add(node);
+          for (const k in node) {
+            const v = node[k];
+            if (k === 'sitekey' && typeof v === 'string' && v.length > 10) {
+              foundSitekey = foundSitekey || v;
+            }
+            if (k === 'action' && typeof v === 'string' && v.length > 0) {
+              foundAction = foundAction || v;
+            }
+            if (k === 'size' && typeof v === 'string') {
+              foundSize = foundSize || v;
+            }
+            if (v && typeof v === 'object') {
+              stack.push([v, d + 1]);
+            }
+          }
+        }
+        if (foundSitekey) {
+          out.sitekeys.push(foundSitekey);
+          if (foundAction) {
+            out.v3 = true;
+            out.actions_by_key[foundSitekey] = foundAction;
+          }
+          if (foundSize) {
+            out.invisible_by_key[foundSitekey] = (foundSize === 'invisible');
+          }
+        }
+      }
+    }
+    // ── 4. DOM ``data-sitekey`` fallback ───────────────────────────
+    if (out.sitekeys.length === 0) {
+      const el = document.querySelector('[data-sitekey]');
+      if (el) {
+        const sk = el.getAttribute('data-sitekey');
+        if (sk) out.sitekeys.push(sk);
+        // ``data-size="invisible"`` on the widget div is the v2-invisible
+        // marker for explicit-render pages.
+        const ds = el.getAttribute('data-size');
+        if (ds && sk) out.invisible_by_key[sk] = (ds === 'invisible');
+      }
+    }
+  } catch (e) { /* defensive — never throw to the page */ }
+  return out;
+}
+"""
+
+
+async def _classify_recaptcha(page) -> dict:
+    """Classify a reCAPTCHA widget into one of five variants.
+
+    Returns a dict with::
+
+        {
+          "variant": "recaptcha-v2-checkbox" | "recaptcha-v2-invisible"
+                   | "recaptcha-v3" | "recaptcha-enterprise-v2"
+                   | "recaptcha-enterprise-v3" | "unknown",
+          "sitekey": str | None,
+          "action": str | None,      # v3 only — extracted from registry
+          "min_score": float | None, # always None — operator config
+        }
+
+    Falls back gracefully:
+
+    * ``variant: "unknown"`` is returned if the page doesn't expose enough
+      signal (e.g. JS not yet loaded, registry obfuscated, no
+      ``data-sitekey``). Callers should fall through to the existing
+      v2-checkbox heuristic when they want the safe default.
+    * ``min_score`` is **never** filled here — it's an operator-tuned
+      knob (``CAPTCHA_RECAPTCHA_V3_MIN_SCORE``) read at solve time, not
+      a property of the page.
+    * ``action`` extraction is **best-effort** for v3. If the widget
+      renders explicitly via ``grecaptcha.execute(sitekey, {action: X})``
+      where ``X`` is a string literal in a separate script we don't see,
+      we return ``None`` and let ``_check_captcha`` log a warning. The
+      solver will still produce a token, but it'll be bound to a
+      different action and the target server may reject — known
+      limitation, documented at the call site.
+
+    Logging uses the existing ``browser.captcha`` logger; no new logger.
+    """
+    result: dict = {
+        "variant": "unknown",
+        "sitekey": None,
+        "action": None,
+        "min_score": None,
+    }
+    try:
+        probe = await page.evaluate(_CLASSIFY_RECAPTCHA_JS)
+    except Exception:
+        logger.debug("_classify_recaptcha: page.evaluate failed", exc_info=True)
+        return result
+    if not isinstance(probe, dict):
+        return result
+
+    enterprise = bool(probe.get("enterprise"))
+    is_v3 = bool(probe.get("v3"))
+    sitekeys = probe.get("sitekeys") or []
+    actions_by_key = probe.get("actions_by_key") or {}
+    invisible_by_key = probe.get("invisible_by_key") or {}
+    v3_render_param = probe.get("v3_render_param") or None
+
+    # Sitekey: prefer registry walk; fall back to v3 render param; then None.
+    sitekey: str | None = None
+    if sitekeys:
+        sitekey = sitekeys[0]
+    elif v3_render_param:
+        sitekey = v3_render_param
+    if isinstance(sitekey, str):
+        sitekey = sitekey.strip() or None
+
+    # Action: only meaningful for v3 widgets. Use the registry mapping
+    # for the chosen sitekey.
+    action: str | None = None
+    if is_v3 and sitekey and sitekey in actions_by_key:
+        candidate = actions_by_key.get(sitekey)
+        if isinstance(candidate, str) and candidate.strip():
+            action = candidate.strip()
+
+    # Variant decision tree.
+    if is_v3 and enterprise:
+        variant = "recaptcha-enterprise-v3"
+    elif is_v3:
+        variant = "recaptcha-v3"
+    elif enterprise:
+        variant = "recaptcha-enterprise-v2"
+    else:
+        # v2 — distinguish checkbox vs invisible.
+        invisible = False
+        if sitekey and sitekey in invisible_by_key:
+            invisible = bool(invisible_by_key.get(sitekey))
+        elif invisible_by_key:
+            # No sitekey match but some widget on the page is invisible.
+            invisible = any(bool(v) for v in invisible_by_key.values())
+        if invisible:
+            variant = "recaptcha-v2-invisible"
+        elif sitekey or v3_render_param:
+            variant = "recaptcha-v2-checkbox"
+        else:
+            variant = "unknown"
+
+    result["variant"] = variant
+    result["sitekey"] = sitekey
+    result["action"] = action
+    return result
 
 
 class CaptchaSolver:
@@ -410,9 +682,25 @@ class CaptchaSolver:
             return False
 
         captcha_type = _classify_captcha(selector)
+        # §11.1 — when the coarse selector classifier says "recaptcha", run
+        # the precise variant classifier so v3 / v2-invisible / Enterprise
+        # widgets get the right provider task type. Falls back to
+        # ``captcha_type`` when the classifier returns ``unknown`` (e.g. the
+        # registry isn't accessible from this frame); legacy selector-based
+        # behavior is preserved.
+        page_action: str | None = None
+        sitekey: str | None = None
+        if captcha_type == "recaptcha":
+            classified = await _classify_recaptcha(page)
+            variant = classified.get("variant") or "unknown"
+            if variant != "unknown":
+                captcha_type = variant
+            sitekey = classified.get("sitekey")
+            page_action = classified.get("action")
         logger.info("Attempting to solve %s CAPTCHA on %s", captcha_type, page_url)
 
-        sitekey = await self._extract_sitekey(page, captcha_type)
+        if not sitekey:
+            sitekey = await self._extract_sitekey(page, captcha_type)
         if not sitekey:
             logger.warning("Could not extract sitekey for %s CAPTCHA", captcha_type)
             await self._record_solver_outcome(success=False)
@@ -420,7 +708,9 @@ class CaptchaSolver:
 
         try:
             token = await asyncio.wait_for(
-                self._submit_and_poll(captcha_type, sitekey, page_url),
+                self._submit_and_poll(
+                    captcha_type, sitekey, page_url, page_action=page_action,
+                ),
                 timeout=_SOLVE_TIMEOUT,
             )
         except asyncio.TimeoutError:
@@ -446,6 +736,14 @@ class CaptchaSolver:
 
     async def _extract_sitekey(self, page, captcha_type: str) -> str | None:
         """Extract the sitekey from the page DOM."""
+        # All reCAPTCHA variants share the same DOM-level sitekey markers
+        # (``[data-sitekey]`` and the ``iframe[src*="recaptcha"]?k=…``
+        # parameter); collapse the family to a single iframe-fallback path
+        # so the v2-checkbox / v2-invisible / v3 / Enterprise variants
+        # don't each need their own branch here.
+        family = captcha_type
+        if captcha_type.startswith("recaptcha"):
+            family = "recaptcha"
         try:
             # Try data-sitekey attribute first (works for reCAPTCHA, hCaptcha, Turnstile)
             sitekey = await page.evaluate(
@@ -455,7 +753,7 @@ class CaptchaSolver:
                 return sitekey.strip()
 
             # Fall back to parsing iframe src for sitekey parameter
-            if captcha_type == "recaptcha":
+            if family == "recaptcha":
                 src = await page.evaluate(
                     "() => document.querySelector('iframe[src*=\"recaptcha\"]')?.src"
                 )
@@ -464,7 +762,7 @@ class CaptchaSolver:
                     if match:
                         return match.group(1)
 
-            if captcha_type == "hcaptcha":
+            if family == "hcaptcha":
                 src = await page.evaluate(
                     "() => document.querySelector('iframe[src*=\"hcaptcha\"]')?.src"
                 )
@@ -473,7 +771,7 @@ class CaptchaSolver:
                     if match:
                         return match.group(1)
 
-            if captcha_type == "turnstile":
+            if family == "turnstile":
                 # Turnstile sometimes stores config in a script or div attribute
                 sitekey = await page.evaluate("""() => {
                     const el = document.querySelector('[class*="cf-turnstile"]');
@@ -486,28 +784,114 @@ class CaptchaSolver:
             logger.debug("Error extracting sitekey", exc_info=True)
         return None
 
-    async def _submit_and_poll(self, captcha_type: str, sitekey: str, page_url: str) -> str | None:
-        """Submit CAPTCHA to solving service and poll for result."""
+    async def _submit_and_poll(
+        self,
+        captcha_type: str,
+        sitekey: str,
+        page_url: str,
+        *,
+        page_action: str | None = None,
+    ) -> str | None:
+        """Submit CAPTCHA to solving service and poll for result.
+
+        ``page_action`` is the v3 action string from the classifier; it's
+        merged into the task body for v3 / Enterprise-v3 variants. v2
+        variants ignore it. ``min_score`` is read inside the per-provider
+        helpers from :data:`CAPTCHA_RECAPTCHA_V3_MIN_SCORE` (operator
+        config, not a page property).
+        """
         if self.provider == "2captcha":
-            return await self._solve_2captcha(captcha_type, sitekey, page_url)
-        return await self._solve_capsolver(captcha_type, sitekey, page_url)
+            return await self._solve_2captcha(
+                captcha_type, sitekey, page_url, page_action=page_action,
+            )
+        return await self._solve_capsolver(
+            captcha_type, sitekey, page_url, page_action=page_action,
+        )
+
+    # ── Task-body builder ─────────────────────────────────────────────────────
+
+    def _build_task_body(
+        self,
+        provider_table: dict[str, dict[str, object]],
+        captcha_type: str,
+        sitekey: str,
+        page_url: str,
+        *,
+        page_action: str | None,
+    ) -> dict | None:
+        """Merge provider task-type fields with v3-specific extras.
+
+        Returns ``None`` if ``captcha_type`` isn't in the provider table
+        (caller treats as "unsupported"). For v3 and v3-enterprise the
+        function reads the operator-configured ``CAPTCHA_RECAPTCHA_V3_MIN_SCORE``
+        flag (default 0.7) and applies the permissive ``"verify"`` fallback
+        when ``page_action`` is missing — see :data:`_DEFAULT_V3_ACTION`
+        for the rationale.
+        """
+        entry = provider_table.get(captcha_type)
+        if not entry:
+            return None
+        body: dict[str, object] = {
+            "websiteURL": page_url,
+            "websiteKey": sitekey,
+        }
+        # Merge static extras (``isInvisible``, ``isEnterprise``, ``type``).
+        for k, v in entry.items():
+            body[k] = v
+        # v3 extras — applied to both standard and enterprise v3 task entries.
+        is_v3 = captcha_type in ("recaptcha-v3", "recaptcha-enterprise-v3")
+        if is_v3:
+            # Operator-configured min score. ``flags.get_float`` clamps;
+            # we additionally clamp 0.1-0.9 to match the env-var doc.
+            try:
+                from src.browser import flags as _flags
+                min_score = _flags.get_float(
+                    "CAPTCHA_RECAPTCHA_V3_MIN_SCORE",
+                    _DEFAULT_V3_MIN_SCORE,
+                    min_value=0.1,
+                    max_value=0.9,
+                )
+            except Exception:
+                # Defensive: if flags import fails (shouldn't, but the
+                # solver module is sometimes imported in test contexts
+                # without ``src.browser`` initialized) fall back to the
+                # default rather than aborting the solve.
+                min_score = _DEFAULT_V3_MIN_SCORE
+            body["minScore"] = min_score
+            action = (page_action or "").strip()
+            if not action:
+                logger.warning(
+                    "v3 reCAPTCHA solve: pageAction missing; falling back to "
+                    "%r — token may be bound to the wrong action and rejected "
+                    "by the target server (kind=%s sitekey=%s)",
+                    _DEFAULT_V3_ACTION, captcha_type, sitekey[:8] + "…",
+                )
+                action = _DEFAULT_V3_ACTION
+            body["pageAction"] = action
+        return body
 
     # ── 2Captcha ──────────────────────────────────────────────────────────────
 
-    async def _solve_2captcha(self, captcha_type: str, sitekey: str, page_url: str) -> str | None:
+    async def _solve_2captcha(
+        self,
+        captcha_type: str,
+        sitekey: str,
+        page_url: str,
+        *,
+        page_action: str | None = None,
+    ) -> str | None:
         client = self._get_client()
-        task_type = _2CAPTCHA_TASK_TYPES.get(captcha_type)
-        if not task_type:
+        task = self._build_task_body(
+            _2CAPTCHA_TASK_TYPES, captcha_type, sitekey, page_url,
+            page_action=page_action,
+        )
+        if not task:
             return None
 
         # Submit task
         payload = {
             "clientKey": self.api_key,
-            "task": {
-                "type": task_type,
-                "websiteURL": page_url,
-                "websiteKey": sitekey,
-            },
+            "task": task,
         }
         try:
             resp = await client.post("https://api.2captcha.com/createTask", json=payload)
@@ -563,20 +947,26 @@ class CaptchaSolver:
 
     # ── CapSolver ─────────────────────────────────────────────────────────────
 
-    async def _solve_capsolver(self, captcha_type: str, sitekey: str, page_url: str) -> str | None:
+    async def _solve_capsolver(
+        self,
+        captcha_type: str,
+        sitekey: str,
+        page_url: str,
+        *,
+        page_action: str | None = None,
+    ) -> str | None:
         client = self._get_client()
-        task_type = _CAPSOLVER_TASK_TYPES.get(captcha_type)
-        if not task_type:
+        task = self._build_task_body(
+            _CAPSOLVER_TASK_TYPES, captcha_type, sitekey, page_url,
+            page_action=page_action,
+        )
+        if not task:
             return None
 
         # Submit task
         payload = {
             "clientKey": self.api_key,
-            "task": {
-                "type": task_type,
-                "websiteURL": page_url,
-                "websiteKey": sitekey,
-            },
+            "task": task,
         }
         try:
             resp = await client.post("https://api.capsolver.com/createTask", json=payload)
@@ -628,9 +1018,18 @@ class CaptchaSolver:
     # ── Token injection ───────────────────────────────────────────────────────
 
     async def _inject_token(self, page, captcha_type: str, token: str) -> bool:
-        """Inject the solved CAPTCHA token into the page."""
+        """Inject the solved CAPTCHA token into the page.
+
+        ``captcha_type`` is matched against the variant *family* (``recaptcha``,
+        ``hcaptcha``, ``turnstile``); the §11.1 reCAPTCHA variants
+        (``recaptcha-v2-checkbox`` / ``...-v3`` / ``...-enterprise-v2`` / etc.)
+        all share the same ``g-recaptcha-response`` injection path.
+        """
+        family = captcha_type
+        if captcha_type.startswith("recaptcha"):
+            family = "recaptcha"
         try:
-            if captcha_type == "recaptcha":
+            if family == "recaptcha":
                 await page.evaluate("""(token) => {
                     const textarea = document.getElementById('g-recaptcha-response');
                     if (textarea) {
@@ -665,7 +1064,7 @@ class CaptchaSolver:
                 }""", token)
                 return True
 
-            if captcha_type == "hcaptcha":
+            if family == "hcaptcha":
                 await page.evaluate("""(token) => {
                     const textarea = document.querySelector('[name="h-captcha-response"]');
                     if (textarea) textarea.value = token;
@@ -679,7 +1078,7 @@ class CaptchaSolver:
                 }""", token)
                 return True
 
-            if captcha_type == "turnstile":
+            if family == "turnstile":
                 await page.evaluate("""(token) => {
                     // Find the Turnstile response input
                     const input = document.querySelector('[name="cf-turnstile-response"]')

--- a/src/browser/captcha_cost_counter.py
+++ b/src/browser/captcha_cost_counter.py
@@ -56,7 +56,13 @@ PRICING_CENTS: dict[str, int] = {
     "2captcha-recaptcha-v2-checkbox": 100,        # $1.00 / 1000 = 0.10c each → 0.1¢
     "2captcha-recaptcha-v2-invisible": 100,
     "2captcha-recaptcha-v3": 100,
+    # §11.1 splits ``recaptcha-enterprise`` into v2/v3 enterprise variants;
+    # both keep the same Enterprise rate. ``recaptcha-enterprise`` is
+    # retained as a back-compat alias for any callers still emitting the
+    # coarse kind from a hint override.
     "2captcha-recaptcha-enterprise": 200,
+    "2captcha-recaptcha-enterprise-v2": 200,
+    "2captcha-recaptcha-enterprise-v3": 200,
     "2captcha-hcaptcha": 100,
     "2captcha-turnstile": 200,
     # CapSolver — published https://docs.capsolver.com/guide/captcha/
@@ -64,6 +70,8 @@ PRICING_CENTS: dict[str, int] = {
     "capsolver-recaptcha-v2-invisible": 80,
     "capsolver-recaptcha-v3": 80,
     "capsolver-recaptcha-enterprise": 200,
+    "capsolver-recaptcha-enterprise-v2": 200,
+    "capsolver-recaptcha-enterprise-v3": 200,
     "capsolver-hcaptcha": 100,
     "capsolver-turnstile": 60,
 }

--- a/src/browser/service.py
+++ b/src/browser/service.py
@@ -24,7 +24,7 @@ from collections import deque
 from pathlib import Path
 from urllib.parse import urlparse
 
-from src.browser.captcha import get_solver
+from src.browser.captcha import _classify_recaptcha, get_solver
 from src.browser.profile_schema import migrate_profile
 from src.browser.redaction import CredentialRedactor
 from src.browser.ref_handle import RefHandle, RefStale, ShadowHop
@@ -98,18 +98,35 @@ logger = setup_logging("browser.service")
 #       captchas (analytics consent, ad-iframe captchas, etc.) that the
 #       agent can safely skip. No code path emits it today.
 
-# Selector-classification confidence: the two firmly-disambiguated kinds
-# below have unambiguous selectors today. The reCAPTCHA / CF placeholders
-# remain "low" until §11.1 / §11.3 land variant detection.
-_FIRM_KINDS = frozenset({"hcaptcha", "turnstile"})
+# Selector-classification confidence: the kinds below are firmly
+# disambiguated either by an unambiguous selector (``hcaptcha`` /
+# ``turnstile``) or by the §11.1 reCAPTCHA variant classifier — when the
+# classifier returns one of the four precise variants (v2-invisible / v3 /
+# Enterprise-v2 / Enterprise-v3) we trust it as "high". The coarse
+# ``recaptcha-v2-checkbox`` placeholder stays "low" because it's the
+# fallback the classifier emits when it can't disambiguate. CF placeholders
+# remain "low" until §11.3 lands variant detection.
+_FIRM_KINDS = frozenset({
+    "hcaptcha", "turnstile",
+    "recaptcha-v2-invisible", "recaptcha-v3",
+    "recaptcha-enterprise-v2", "recaptcha-enterprise-v3",
+})
 
 
 # ── §11.13 valid kind enum (for hint validation in solve_captcha) ─────────
 # Kept in sync with the docstring at the top of this module. New kinds added
 # here as §11.1 / §11.3 land richer classification.
+#
+# §11.1 splits the prior coarse ``recaptcha-enterprise`` placeholder into
+# the v2/v3 enterprise variants ``recaptcha-enterprise-v{2,3}``. The old
+# ``recaptcha-enterprise`` value is kept as a back-compat alias so agents
+# whose stored hints reference the coarse kind keep working — the
+# classifier never emits it for new detections.
 _VALID_CAPTCHA_KINDS: frozenset[str] = frozenset({
     "recaptcha-v2-checkbox", "recaptcha-v2-invisible", "recaptcha-v3",
-    "recaptcha-enterprise", "hcaptcha", "turnstile",
+    "recaptcha-enterprise",  # legacy alias for back-compat
+    "recaptcha-enterprise-v2", "recaptcha-enterprise-v3",
+    "hcaptcha", "turnstile",
     "cf-interstitial-auto", "cf-interstitial-behavioral", "unknown",
 })
 
@@ -5455,6 +5472,27 @@ class BrowserManager:
             for sel in captcha_selectors:
                 if await inst.page.locator(sel).count() > 0:
                     kind = self._classify_kind(sel)
+                    # §11.1 — when the matched selector is a reCAPTCHA, run
+                    # the precise variant classifier on the live page to
+                    # disambiguate v2-checkbox / v2-invisible / v3 /
+                    # Enterprise-v2 / Enterprise-v3. The coarse selector
+                    # classifier returns ``recaptcha-v2-checkbox`` as the
+                    # safe default; the variant classifier upgrades the
+                    # ``kind`` whenever it returns anything other than
+                    # ``unknown``. Falls back silently to the coarse value
+                    # if ``page.evaluate`` fails (test mocks, frames,
+                    # registry obfuscation, etc.).
+                    if "recaptcha" in sel:
+                        try:
+                            classified = await _classify_recaptcha(inst.page)
+                            variant = classified.get("variant") or "unknown"
+                            if variant != "unknown":
+                                kind = variant
+                        except Exception:
+                            logger.debug(
+                                "_classify_recaptcha raised; falling back to "
+                                "coarse kind=%s", kind, exc_info=True,
+                            )
                     if self._captcha_solver:
                         # §11.16 short-circuits — check solver health
                         # BEFORE attempting a solve. ``is_solver_unreachable``

--- a/tests/test_browser_service.py
+++ b/tests/test_browser_service.py
@@ -4867,6 +4867,161 @@ class TestCaptchaDetection:
         assert result["data"]["captcha_found"] is False
 
 
+# ── §11.1 reCAPTCHA variant classifier integration with _check_captcha ───
+
+
+class TestCheckCaptchaUsesVariantClassifier:
+    """Verify ``_check_captcha`` upgrades the coarse ``recaptcha-v2-checkbox``
+    placeholder to the precise §11.1 variant when the classifier returns
+    one. Falls back silently when classification is ``unknown``.
+    """
+
+    @staticmethod
+    def _make_inst(matching_selector: str, *, classifier_result):
+        """Mock a CamoufoxInstance whose page.locator(sel).count is 1
+        for ``matching_selector`` and whose page.evaluate (used by
+        ``_classify_recaptcha``) returns ``classifier_result``.
+        """
+        inst = MagicMock()
+        inst.page = MagicMock()
+        inst.page.url = "https://example.com"
+        inst.page.title = AsyncMock(return_value="")
+
+        def locator(sel: str):
+            loc = MagicMock()
+            loc.count = AsyncMock(
+                return_value=1 if sel == matching_selector else 0,
+            )
+            return loc
+        inst.page.locator = MagicMock(side_effect=locator)
+        inst.page.evaluate = AsyncMock(return_value=classifier_result)
+        inst.lock = asyncio.Lock()
+        inst.touch = MagicMock()
+        return inst
+
+    @pytest.mark.asyncio
+    async def test_v3_variant_propagates_to_envelope(self):
+        from src.browser.service import BrowserManager
+        mgr = BrowserManager.__new__(BrowserManager)
+        mgr._captcha_solver = None
+        inst = self._make_inst(
+            'iframe[src*="recaptcha"]',
+            classifier_result={
+                "enterprise": False, "v3": True,
+                "sitekeys": ["SK"], "actions_by_key": {"SK": "homepage"},
+                "invisible_by_key": {}, "enterprise_script": False,
+                "v3_render_param": "SK",
+            },
+        )
+        result = await mgr._check_captcha(inst)
+        assert result["captcha_found"] is True
+        assert result["kind"] == "recaptcha-v3"
+        # _FIRM_KINDS includes recaptcha-v3 → confidence "high" on no-solver.
+        assert result["solver_confidence"] == "high"
+
+    @pytest.mark.asyncio
+    async def test_v2_invisible_variant_propagates(self):
+        from src.browser.service import BrowserManager
+        mgr = BrowserManager.__new__(BrowserManager)
+        mgr._captcha_solver = None
+        inst = self._make_inst(
+            'iframe[src*="recaptcha"]',
+            classifier_result={
+                "enterprise": False, "v3": False,
+                "sitekeys": ["SK"], "actions_by_key": {},
+                "invisible_by_key": {"SK": True},
+                "enterprise_script": False, "v3_render_param": None,
+            },
+        )
+        result = await mgr._check_captcha(inst)
+        assert result["kind"] == "recaptcha-v2-invisible"
+        assert result["solver_confidence"] == "high"
+
+    @pytest.mark.asyncio
+    async def test_enterprise_v2_variant_propagates(self):
+        from src.browser.service import BrowserManager
+        mgr = BrowserManager.__new__(BrowserManager)
+        mgr._captcha_solver = None
+        inst = self._make_inst(
+            'iframe[src*="recaptcha"]',
+            classifier_result={
+                "enterprise": True, "v3": False,
+                "sitekeys": ["SK"], "actions_by_key": {},
+                "invisible_by_key": {}, "enterprise_script": True,
+                "v3_render_param": None,
+            },
+        )
+        result = await mgr._check_captcha(inst)
+        assert result["kind"] == "recaptcha-enterprise-v2"
+        assert result["solver_confidence"] == "high"
+
+    @pytest.mark.asyncio
+    async def test_enterprise_v3_variant_propagates(self):
+        from src.browser.service import BrowserManager
+        mgr = BrowserManager.__new__(BrowserManager)
+        mgr._captcha_solver = None
+        inst = self._make_inst(
+            'iframe[src*="recaptcha"]',
+            classifier_result={
+                "enterprise": True, "v3": True,
+                "sitekeys": ["SK"], "actions_by_key": {"SK": "submit"},
+                "invisible_by_key": {}, "enterprise_script": True,
+                "v3_render_param": None,
+            },
+        )
+        result = await mgr._check_captcha(inst)
+        assert result["kind"] == "recaptcha-enterprise-v3"
+        assert result["solver_confidence"] == "high"
+
+    @pytest.mark.asyncio
+    async def test_unknown_classification_falls_back_to_v2_checkbox(self):
+        """Classifier returning ``variant: "unknown"`` must keep the
+        existing coarse ``recaptcha-v2-checkbox`` placeholder so legacy
+        agents still see a valid kind value.
+        """
+        from src.browser.service import BrowserManager
+        mgr = BrowserManager.__new__(BrowserManager)
+        mgr._captcha_solver = None
+        inst = self._make_inst(
+            'iframe[src*="recaptcha"]',
+            classifier_result={
+                "enterprise": False, "v3": False,
+                "sitekeys": [], "actions_by_key": {},
+                "invisible_by_key": {}, "enterprise_script": False,
+                "v3_render_param": None,
+            },
+        )
+        result = await mgr._check_captcha(inst)
+        assert result["kind"] == "recaptcha-v2-checkbox"
+
+    @pytest.mark.asyncio
+    async def test_classifier_exception_falls_back(self):
+        """page.evaluate raising must not break ``_check_captcha`` —
+        the coarse selector kind stays."""
+        from src.browser.service import BrowserManager
+        mgr = BrowserManager.__new__(BrowserManager)
+        mgr._captcha_solver = None
+        inst = MagicMock()
+        inst.page = MagicMock()
+        inst.page.url = "https://example.com"
+        inst.page.title = AsyncMock(return_value="")
+        sel = 'iframe[src*="recaptcha"]'
+
+        def locator(s):
+            loc = MagicMock()
+            loc.count = AsyncMock(return_value=1 if s == sel else 0)
+            return loc
+
+        inst.page.locator = MagicMock(side_effect=locator)
+        inst.page.evaluate = AsyncMock(side_effect=RuntimeError("frame closed"))
+        inst.lock = asyncio.Lock()
+        inst.touch = MagicMock()
+
+        result = await mgr._check_captcha(inst)
+        assert result["captcha_found"] is True
+        assert result["kind"] == "recaptcha-v2-checkbox"
+
+
 # ── Dialog scoping tests ──────────────────────────────────────────────────
 
 

--- a/tests/test_captcha_recaptcha_classifier.py
+++ b/tests/test_captcha_recaptcha_classifier.py
@@ -1,0 +1,515 @@
+"""Tests for §11.1 reCAPTCHA variant classifier and provider task tables.
+
+Covers :func:`src.browser.captcha._classify_recaptcha` and the structured
+``_2CAPTCHA_TASK_TYPES`` / ``_CAPSOLVER_TASK_TYPES`` lookups added in §11.1.
+
+The classifier is a single ``page.evaluate`` JS probe that returns a
+structured dict; tests stub the eval to return whatever shape we need
+to drive each branch (enterprise namespace, v3 markers, invisible v2,
+etc.). No real browser involved.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+from src.browser.captcha import (
+    _2CAPTCHA_TASK_TYPES,
+    _CAPSOLVER_TASK_TYPES,
+    _DEFAULT_V3_ACTION,
+    _DEFAULT_V3_MIN_SCORE,
+    CaptchaSolver,
+    _classify_recaptcha,
+)
+
+
+def _make_page(probe_result):
+    """Return a MagicMock page whose ``evaluate`` returns ``probe_result``.
+
+    ``probe_result`` is whatever the JS classifier would emit (a dict),
+    or an ``Exception`` instance to simulate a thrown ``page.evaluate``.
+    """
+    page = AsyncMock()
+    if isinstance(probe_result, BaseException):
+        page.evaluate = AsyncMock(side_effect=probe_result)
+    else:
+        page.evaluate = AsyncMock(return_value=probe_result)
+    return page
+
+
+# ── 1. Each variant — happy path ──────────────────────────────────────────
+
+
+class TestVariantHappyPath:
+    @pytest.mark.asyncio
+    async def test_v2_checkbox(self):
+        page = _make_page({
+            "enterprise": False,
+            "v3": False,
+            "sitekeys": ["ABCDEFGHIJK_v2_checkbox"],
+            "actions_by_key": {},
+            "invisible_by_key": {"ABCDEFGHIJK_v2_checkbox": False},
+            "enterprise_script": False,
+            "v3_render_param": None,
+        })
+        result = await _classify_recaptcha(page)
+        assert result["variant"] == "recaptcha-v2-checkbox"
+        assert result["sitekey"] == "ABCDEFGHIJK_v2_checkbox"
+        assert result["action"] is None
+        assert result["min_score"] is None  # operator config; not page-extractable
+
+    @pytest.mark.asyncio
+    async def test_v2_invisible(self):
+        page = _make_page({
+            "enterprise": False,
+            "v3": False,
+            "sitekeys": ["SITEKEY_invisible_widget"],
+            "actions_by_key": {},
+            "invisible_by_key": {"SITEKEY_invisible_widget": True},
+            "enterprise_script": False,
+            "v3_render_param": None,
+        })
+        result = await _classify_recaptcha(page)
+        assert result["variant"] == "recaptcha-v2-invisible"
+        assert result["sitekey"] == "SITEKEY_invisible_widget"
+
+    @pytest.mark.asyncio
+    async def test_v3(self):
+        page = _make_page({
+            "enterprise": False,
+            "v3": True,
+            "sitekeys": ["V3_SITEKEY_AAAAAAAAAA"],
+            "actions_by_key": {"V3_SITEKEY_AAAAAAAAAA": "homepage"},
+            "invisible_by_key": {},
+            "enterprise_script": False,
+            "v3_render_param": "V3_SITEKEY_AAAAAAAAAA",
+        })
+        result = await _classify_recaptcha(page)
+        assert result["variant"] == "recaptcha-v3"
+        assert result["sitekey"] == "V3_SITEKEY_AAAAAAAAAA"
+        assert result["action"] == "homepage"
+        assert result["min_score"] is None
+
+    @pytest.mark.asyncio
+    async def test_enterprise_v2(self):
+        page = _make_page({
+            "enterprise": True,
+            "v3": False,
+            "sitekeys": ["ENT_V2_SITEKEY_BBBBBBB"],
+            "actions_by_key": {},
+            "invisible_by_key": {},
+            "enterprise_script": True,
+            "v3_render_param": None,
+        })
+        result = await _classify_recaptcha(page)
+        assert result["variant"] == "recaptcha-enterprise-v2"
+        assert result["sitekey"] == "ENT_V2_SITEKEY_BBBBBBB"
+
+    @pytest.mark.asyncio
+    async def test_enterprise_v3(self):
+        page = _make_page({
+            "enterprise": True,
+            "v3": True,
+            "sitekeys": ["ENT_V3_SITEKEY_CCCCCCC"],
+            "actions_by_key": {"ENT_V3_SITEKEY_CCCCCCC": "submit"},
+            "invisible_by_key": {},
+            "enterprise_script": True,
+            "v3_render_param": None,
+        })
+        result = await _classify_recaptcha(page)
+        assert result["variant"] == "recaptcha-enterprise-v3"
+        assert result["sitekey"] == "ENT_V3_SITEKEY_CCCCCCC"
+        assert result["action"] == "submit"
+
+
+# ── 2. Enterprise detection paths ─────────────────────────────────────────
+
+
+class TestEnterpriseDetection:
+    @pytest.mark.asyncio
+    async def test_enterprise_via_script_src(self):
+        """``<script src*="enterprise.recaptcha.net">`` flips enterprise on."""
+        page = _make_page({
+            "enterprise": True,           # set by JS branch when script tag matches
+            "enterprise_script": True,
+            "v3": False,
+            "sitekeys": ["SK_via_script"],
+            "actions_by_key": {},
+            "invisible_by_key": {},
+            "v3_render_param": None,
+        })
+        result = await _classify_recaptcha(page)
+        assert result["variant"] == "recaptcha-enterprise-v2"
+
+    @pytest.mark.asyncio
+    async def test_enterprise_via_grecaptcha_global(self):
+        """``window.grecaptcha.enterprise`` global flips enterprise on."""
+        page = _make_page({
+            "enterprise": True,
+            "enterprise_script": False,   # no script tag — only the global signal
+            "v3": False,
+            "sitekeys": ["SK_via_global"],
+            "actions_by_key": {},
+            "invisible_by_key": {},
+            "v3_render_param": None,
+        })
+        result = await _classify_recaptcha(page)
+        assert result["variant"] == "recaptcha-enterprise-v2"
+
+
+# ── 3. v3 detection paths ─────────────────────────────────────────────────
+
+
+class TestV3Detection:
+    @pytest.mark.asyncio
+    async def test_v3_via_render_param(self):
+        """``<script src="...api.js?render=<sitekey>">`` is v3-only."""
+        page = _make_page({
+            "enterprise": False,
+            "v3": True,                    # JS sets this when render param present
+            "sitekeys": [],
+            "actions_by_key": {},
+            "invisible_by_key": {},
+            "enterprise_script": False,
+            "v3_render_param": "RENDER_PARAM_SITEKEY",
+        })
+        result = await _classify_recaptcha(page)
+        assert result["variant"] == "recaptcha-v3"
+        # Sitekey falls back to the render param when registry walk yielded nothing.
+        assert result["sitekey"] == "RENDER_PARAM_SITEKEY"
+
+    @pytest.mark.asyncio
+    async def test_v3_via_clients_action_field(self):
+        """A widget config with ``action: "..."`` field → v3."""
+        page = _make_page({
+            "enterprise": False,
+            "v3": True,
+            "sitekeys": ["SK_with_action"],
+            "actions_by_key": {"SK_with_action": "checkout"},
+            "invisible_by_key": {},
+            "enterprise_script": False,
+            "v3_render_param": None,
+        })
+        result = await _classify_recaptcha(page)
+        assert result["variant"] == "recaptcha-v3"
+        assert result["action"] == "checkout"
+
+
+# ── 4. v2-invisible detection paths ───────────────────────────────────────
+
+
+class TestV2InvisibleDetection:
+    @pytest.mark.asyncio
+    async def test_invisible_via_data_size_attr(self):
+        """``data-size="invisible"`` on the widget div → v2-invisible."""
+        page = _make_page({
+            "enterprise": False,
+            "v3": False,
+            "sitekeys": ["SK_data_size"],
+            "actions_by_key": {},
+            "invisible_by_key": {"SK_data_size": True},
+            "enterprise_script": False,
+            "v3_render_param": None,
+        })
+        result = await _classify_recaptcha(page)
+        assert result["variant"] == "recaptcha-v2-invisible"
+
+    @pytest.mark.asyncio
+    async def test_invisible_via_clients_size_field(self):
+        """``size: "invisible"`` inside the registry config → v2-invisible."""
+        # Same shape as the data-size test — both feed the same map.
+        page = _make_page({
+            "enterprise": False,
+            "v3": False,
+            "sitekeys": ["SK_registry_size"],
+            "actions_by_key": {},
+            "invisible_by_key": {"SK_registry_size": True},
+            "enterprise_script": False,
+            "v3_render_param": None,
+        })
+        result = await _classify_recaptcha(page)
+        assert result["variant"] == "recaptcha-v2-invisible"
+
+
+# ── 5. pageAction extraction ──────────────────────────────────────────────
+
+
+class TestPageActionExtraction:
+    @pytest.mark.asyncio
+    async def test_action_extracted_from_registry(self):
+        page = _make_page({
+            "enterprise": False,
+            "v3": True,
+            "sitekeys": ["SK_action"],
+            "actions_by_key": {"SK_action": "login_form"},
+            "invisible_by_key": {},
+            "enterprise_script": False,
+            "v3_render_param": None,
+        })
+        result = await _classify_recaptcha(page)
+        assert result["action"] == "login_form"
+
+    @pytest.mark.asyncio
+    async def test_action_extraction_failure_returns_none(self):
+        """v3 detected via render param but no action in registry → None."""
+        page = _make_page({
+            "enterprise": False,
+            "v3": True,
+            "sitekeys": [],
+            "actions_by_key": {},
+            "invisible_by_key": {},
+            "enterprise_script": False,
+            "v3_render_param": "JUST_THE_RENDER_KEY",
+        })
+        result = await _classify_recaptcha(page)
+        assert result["variant"] == "recaptcha-v3"
+        assert result["action"] is None  # solver caller must default to "verify"
+
+
+# ── 6. Sitekey fallback chain ─────────────────────────────────────────────
+
+
+class TestSitekeyFallbackChain:
+    @pytest.mark.asyncio
+    async def test_sitekey_from_registry(self):
+        page = _make_page({
+            "enterprise": False, "v3": False,
+            "sitekeys": ["FROM_REGISTRY"],
+            "actions_by_key": {}, "invisible_by_key": {},
+            "enterprise_script": False, "v3_render_param": None,
+        })
+        result = await _classify_recaptcha(page)
+        assert result["sitekey"] == "FROM_REGISTRY"
+
+    @pytest.mark.asyncio
+    async def test_sitekey_from_render_param_when_registry_empty(self):
+        page = _make_page({
+            "enterprise": False, "v3": True,
+            "sitekeys": [],
+            "actions_by_key": {}, "invisible_by_key": {},
+            "enterprise_script": False,
+            "v3_render_param": "FROM_RENDER_PARAM",
+        })
+        result = await _classify_recaptcha(page)
+        assert result["sitekey"] == "FROM_RENDER_PARAM"
+
+    @pytest.mark.asyncio
+    async def test_sitekey_none_when_no_signal(self):
+        page = _make_page({
+            "enterprise": False, "v3": False,
+            "sitekeys": [],
+            "actions_by_key": {}, "invisible_by_key": {},
+            "enterprise_script": False, "v3_render_param": None,
+        })
+        result = await _classify_recaptcha(page)
+        assert result["sitekey"] is None
+        assert result["variant"] == "unknown"
+
+
+# ── 7. Defensive: malformed / missing probe output ────────────────────────
+
+
+class TestDefensive:
+    @pytest.mark.asyncio
+    async def test_evaluate_throws_returns_unknown(self):
+        page = _make_page(RuntimeError("page closed"))
+        result = await _classify_recaptcha(page)
+        assert result == {
+            "variant": "unknown",
+            "sitekey": None,
+            "action": None,
+            "min_score": None,
+        }
+
+    @pytest.mark.asyncio
+    async def test_evaluate_returns_non_dict_returns_unknown(self):
+        page = _make_page(None)  # JS returned null/undefined
+        result = await _classify_recaptcha(page)
+        assert result["variant"] == "unknown"
+
+    @pytest.mark.asyncio
+    async def test_evaluate_returns_empty_dict(self):
+        page = _make_page({})
+        result = await _classify_recaptcha(page)
+        assert result["variant"] == "unknown"
+        assert result["sitekey"] is None
+
+
+# ── 8. Provider task-type tables ──────────────────────────────────────────
+
+
+class TestTaskTypeTables:
+    """Table lookup must return the right provider-side ``type`` plus any
+    variant-specific extras (``isInvisible``, ``isEnterprise``).
+
+    Task names verified against the public 2captcha + CapSolver docs in
+    April 2026; see the comment block in src/browser/captcha.py for the
+    URLs and the drift note (2captcha v3-Enterprise reuses the v3 task
+    name with ``isEnterprise: true`` rather than offering a standalone
+    ``RecaptchaV3EnterpriseTaskProxyless`` type).
+    """
+
+    def test_2captcha_v2_checkbox(self):
+        entry = _2CAPTCHA_TASK_TYPES["recaptcha-v2-checkbox"]
+        assert entry["type"] == "RecaptchaV2TaskProxyless"
+        assert "isInvisible" not in entry
+        assert "isEnterprise" not in entry
+
+    def test_2captcha_v2_invisible(self):
+        entry = _2CAPTCHA_TASK_TYPES["recaptcha-v2-invisible"]
+        assert entry["type"] == "RecaptchaV2TaskProxyless"
+        assert entry["isInvisible"] is True
+
+    def test_2captcha_v3(self):
+        entry = _2CAPTCHA_TASK_TYPES["recaptcha-v3"]
+        assert entry["type"] == "RecaptchaV3TaskProxyless"
+
+    def test_2captcha_enterprise_v2(self):
+        entry = _2CAPTCHA_TASK_TYPES["recaptcha-enterprise-v2"]
+        assert entry["type"] == "RecaptchaV2EnterpriseTaskProxyless"
+
+    def test_2captcha_enterprise_v3_uses_v3_with_flag(self):
+        """2captcha drift: no standalone v3-Enterprise task; flag instead."""
+        entry = _2CAPTCHA_TASK_TYPES["recaptcha-enterprise-v3"]
+        assert entry["type"] == "RecaptchaV3TaskProxyless"
+        assert entry["isEnterprise"] is True
+
+    def test_capsolver_v2_checkbox(self):
+        entry = _CAPSOLVER_TASK_TYPES["recaptcha-v2-checkbox"]
+        assert entry["type"] == "ReCaptchaV2TaskProxyLess"
+        assert "isInvisible" not in entry
+
+    def test_capsolver_v2_invisible(self):
+        entry = _CAPSOLVER_TASK_TYPES["recaptcha-v2-invisible"]
+        assert entry["type"] == "ReCaptchaV2TaskProxyLess"
+        assert entry["isInvisible"] is True
+
+    def test_capsolver_v3(self):
+        entry = _CAPSOLVER_TASK_TYPES["recaptcha-v3"]
+        assert entry["type"] == "ReCaptchaV3TaskProxyLess"
+
+    def test_capsolver_enterprise_v2(self):
+        entry = _CAPSOLVER_TASK_TYPES["recaptcha-enterprise-v2"]
+        assert entry["type"] == "ReCaptchaV2EnterpriseTaskProxyLess"
+
+    def test_capsolver_enterprise_v3(self):
+        entry = _CAPSOLVER_TASK_TYPES["recaptcha-enterprise-v3"]
+        assert entry["type"] == "ReCaptchaV3EnterpriseTaskProxyLess"
+
+
+# ── 9. Task-body merger ───────────────────────────────────────────────────
+
+
+class TestTaskBodyMerger:
+    """``CaptchaSolver._build_task_body`` produces the JSON the provider
+    receives. v3 / Enterprise-v3 must include ``minScore`` + ``pageAction``;
+    v2 variants must NOT include them; Enterprise-v2 does not gain v3 fields.
+    """
+
+    def _solver(self):
+        # CaptchaSolver's __init__ does no I/O, so we can build directly.
+        return CaptchaSolver(provider="2captcha", api_key="test")
+
+    def test_v2_checkbox_body_has_no_v3_fields(self):
+        s = self._solver()
+        body = s._build_task_body(
+            _2CAPTCHA_TASK_TYPES, "recaptcha-v2-checkbox",
+            "SITEKEY", "https://example.com",
+            page_action=None,
+        )
+        assert body["type"] == "RecaptchaV2TaskProxyless"
+        assert body["websiteURL"] == "https://example.com"
+        assert body["websiteKey"] == "SITEKEY"
+        assert "minScore" not in body
+        assert "pageAction" not in body
+
+    def test_v2_invisible_body_has_invisible_flag(self):
+        s = self._solver()
+        body = s._build_task_body(
+            _CAPSOLVER_TASK_TYPES, "recaptcha-v2-invisible",
+            "SITEKEY", "https://example.com",
+            page_action=None,
+        )
+        assert body["type"] == "ReCaptchaV2TaskProxyLess"
+        assert body["isInvisible"] is True
+        assert "minScore" not in body
+
+    def test_v3_body_has_min_score_and_action(self):
+        s = self._solver()
+        body = s._build_task_body(
+            _2CAPTCHA_TASK_TYPES, "recaptcha-v3",
+            "SITEKEY", "https://example.com",
+            page_action="checkout",
+        )
+        assert body["type"] == "RecaptchaV3TaskProxyless"
+        assert body["minScore"] == _DEFAULT_V3_MIN_SCORE
+        assert body["pageAction"] == "checkout"
+
+    def test_v3_body_action_falls_back_to_verify(self):
+        s = self._solver()
+        body = s._build_task_body(
+            _2CAPTCHA_TASK_TYPES, "recaptcha-v3",
+            "SITEKEY", "https://example.com",
+            page_action=None,
+        )
+        assert body["pageAction"] == _DEFAULT_V3_ACTION
+
+    def test_enterprise_v3_body_has_isEnterprise_and_v3_extras(self):
+        s = self._solver()
+        body = s._build_task_body(
+            _2CAPTCHA_TASK_TYPES, "recaptcha-enterprise-v3",
+            "SITEKEY", "https://example.com",
+            page_action="submit",
+        )
+        assert body["type"] == "RecaptchaV3TaskProxyless"
+        assert body["isEnterprise"] is True
+        assert body["minScore"] == _DEFAULT_V3_MIN_SCORE
+        assert body["pageAction"] == "submit"
+
+    def test_enterprise_v2_body_no_v3_fields(self):
+        s = self._solver()
+        body = s._build_task_body(
+            _2CAPTCHA_TASK_TYPES, "recaptcha-enterprise-v2",
+            "SITEKEY", "https://example.com",
+            page_action=None,
+        )
+        assert body["type"] == "RecaptchaV2EnterpriseTaskProxyless"
+        assert "minScore" not in body
+        assert "pageAction" not in body
+
+    def test_unknown_variant_returns_none(self):
+        s = self._solver()
+        body = s._build_task_body(
+            _2CAPTCHA_TASK_TYPES, "no-such-variant",
+            "SITEKEY", "https://example.com",
+            page_action=None,
+        )
+        assert body is None
+
+    def test_min_score_honors_env_var(self, monkeypatch):
+        s = self._solver()
+        monkeypatch.setenv("CAPTCHA_RECAPTCHA_V3_MIN_SCORE", "0.3")
+        # flags loader caches; force re-read.
+        from src.browser import flags as _flags
+        _flags.reload_operator_settings()
+        body = s._build_task_body(
+            _CAPSOLVER_TASK_TYPES, "recaptcha-v3",
+            "SITEKEY", "https://example.com",
+            page_action="x",
+        )
+        assert body["minScore"] == 0.3
+
+    def test_min_score_clamped(self, monkeypatch):
+        """Out-of-range values clamp to [0.1, 0.9]."""
+        s = self._solver()
+        monkeypatch.setenv("CAPTCHA_RECAPTCHA_V3_MIN_SCORE", "5.0")
+        from src.browser import flags as _flags
+        _flags.reload_operator_settings()
+        body = s._build_task_body(
+            _2CAPTCHA_TASK_TYPES, "recaptcha-v3",
+            "SITEKEY", "https://example.com",
+            page_action="x",
+        )
+        assert body["minScore"] == 0.9


### PR DESCRIPTION
## Summary

Adds a precise reCAPTCHA variant classifier (`_classify_recaptcha`) that
disambiguates v2-checkbox / v2-invisible / v3 / Enterprise-v2 /
Enterprise-v3 from a single `page.evaluate` probe walking
`___grecaptcha_cfg.clients`, the script tags, and `window.grecaptcha.enterprise`.

The §11.13 envelope's `kind` field now reports the precise variant when
the classifier resolves it; legacy v2-checkbox is the safe fallback
when the registry is opaque or `evaluate` fails.

The provider task-type tables (`_2CAPTCHA_TASK_TYPES`,
`_CAPSOLVER_TASK_TYPES`) restructured from `dict[variant, str]` to
`dict[variant, dict]` so variant-specific extras (`isInvisible`,
`isEnterprise`) merge cleanly into the request body. New
`_build_task_body` helper applies v3 `minScore` (from
`CAPTCHA_RECAPTCHA_V3_MIN_SCORE`, default 0.7) and `pageAction` (from
classifier, defaulting to `"verify"` when missing).

## Output shape

```python
{
  "variant": "recaptcha-v2-checkbox" | "recaptcha-v2-invisible"
           | "recaptcha-v3" | "recaptcha-enterprise-v2"
           | "recaptcha-enterprise-v3" | "unknown",
  "sitekey": str | None,
  "action": str | None,      # v3 only — extracted from registry
  "min_score": float | None, # always None — operator config, not page-extractable
}
```

## Provider task table (verified April 2026)

| Variant | 2Captcha | CapSolver |
|---|---|---|
| recaptcha-v2-checkbox | `RecaptchaV2TaskProxyless` | `ReCaptchaV2TaskProxyLess` |
| recaptcha-v2-invisible | `RecaptchaV2TaskProxyless` + `isInvisible: true` | `ReCaptchaV2TaskProxyLess` + `isInvisible: true` |
| recaptcha-v3 | `RecaptchaV3TaskProxyless` + `minScore` + `pageAction` | `ReCaptchaV3TaskProxyLess` + `minScore` + `pageAction` |
| recaptcha-enterprise-v2 | `RecaptchaV2EnterpriseTaskProxyless` | `ReCaptchaV2EnterpriseTaskProxyLess` |
| recaptcha-enterprise-v3 | `RecaptchaV3TaskProxyless` + `isEnterprise: true` | `ReCaptchaV3EnterpriseTaskProxyLess` |

## Task-name drift vs original spec

**2captcha does NOT have a standalone `RecaptchaV3EnterpriseTaskProxyless`
type** as of April 2026. The spec assumed parallel naming with CapSolver;
the public 2captcha v3 doc page documents the same `RecaptchaV3TaskProxyless`
task name with an `isEnterprise: true` flag. The provider table encodes
the flag-form correctly so 2captcha submissions for `recaptcha-enterprise-v3`
hit the right endpoint. CapSolver's standalone
`ReCaptchaV3EnterpriseTaskProxyLess` matches the spec.

Drift here is silent (`ERROR_INVALID_TASK_TYPE` from the provider) — the
table is the canonical source-of-truth and re-verification is part of
any future variant addition.

## Notable decisions

- **`min_score` not on the classifier output** — it's an operator-tuned
  knob, not a page property. Read at solve time inside `_build_task_body`.
- **`pageAction` extraction is best-effort** for v3. When the widget
  renders explicitly via a script we don't see, classifier returns
  `action: None`; the solver then logs a warning and uses `"verify"` as
  the permissive default. Documented in the classifier docstring.
- **`_VALID_CAPTCHA_KINDS` keeps `recaptcha-enterprise`** as a legacy
  alias so agents whose stored hints reference the coarse value still
  pass `solve_captcha`'s hint validator. The classifier never emits it.
- **`_FIRM_KINDS` admits the four precise variants** (`recaptcha-v2-invisible`,
  `recaptcha-v3`, `recaptcha-enterprise-v{2,3}`) — successful
  classification now reports `solver_confidence: "high"` instead of the
  placeholder "low". `recaptcha-v2-checkbox` stays "low" because it's
  the fallback the classifier emits when it can't disambiguate.

## Tests

44 new test cases:

- `tests/test_captcha_recaptcha_classifier.py` (38) — every variant happy
  path, both enterprise-detection paths, both v3-detection paths, both
  v2-invisible-detection paths, `pageAction` extraction success/failure,
  sitekey fallback chain (registry → render-param → None), defensive
  branches (eval throws / non-dict / empty), task-type tables, and
  `_build_task_body` v2/v3/enterprise/min-score-clamp/env-override.
- `tests/test_browser_service.py::TestCheckCaptchaUsesVariantClassifier` (6)
  — `_check_captcha` propagates each new variant string into the §11.13
  envelope; legacy fallback when classifier is `unknown`; eval exception
  doesn't break detection.

`pytest tests/ --ignore=tests/test_e2e*.py -x` results: my changes are
green; the existing failures reproduce on `origin/main` as well —
`test_dashboard_browser_metrics::TestFetchBrowserMetricsUpstream` (5),
`test_filter_before_cap_with_limit_smaller_than_visible`, and
`test_cli_commands::TestVersion::test_version_flag` (the last is a
worktree-environment-only failure: `'openlegion' is not installed`).
None are touched by this PR.

`ruff check src/ tests/` — clean.

## Plan reference

`docs/plans/2026-04-20-browser-automation.md` §11.1.

## Test plan

- [x] `pytest tests/test_captcha_recaptcha_classifier.py -v` — 38/38 pass
- [x] `pytest tests/test_browser_service.py::TestCheckCaptchaUsesVariantClassifier -v` — 6/6 pass
- [x] `pytest tests/test_captcha_envelope.py tests/test_browser_solve_captcha.py tests/test_captcha_health.py tests/test_browser_request_captcha_help.py tests/test_captcha_policy.py tests/test_captcha_cost_counter.py tests/test_browser_fill_form.py` — all green
- [x] `ruff check src/ tests/` — clean
- [x] Full unit/integration suite — only pre-existing failures (verified against `origin/main`)