### PR TITLE
Phase 8 §11.3: Cloudflare interstitial tri-state + behavioral-only

### DIFF
--- a/src/browser/captcha.py
+++ b/src/browser/captcha.py
@@ -422,6 +422,169 @@ async def _classify_recaptcha(page) -> dict:
     return result
 
 
+# ── §11.3 Cloudflare interstitial tri-state classifier ────────────────────
+#
+# CF interstitial is not one thing. We distinguish three states so that
+# ``_check_captcha`` can route each appropriately:
+#
+#   "auto"       — CF auto-resolving JS challenge ("Checking your
+#                  browser...") with NO Turnstile widget. Wait+recheck.
+#   "behavioral" — Under Attack Mode (error 1020) or persistent challenge
+#                  with no solvable widget. Skip solver, escalate.
+#   "turnstile"  — CF interstitial with embedded Turnstile widget. Solve
+#                  via existing Turnstile path but with low confidence
+#                  (token may not unblock the session).
+#   "none"       — Doesn't match any CF interstitial pattern (caller falls
+#                  through to standalone Turnstile / other handling).
+#
+# The classifier reads ``page.title`` and runs a single lightweight JS
+# probe; both calls are wrapped in try/except so a closed page or evaluate
+# failure simply collapses the result to "none" rather than raising.
+
+_CF_STATE_PROBE_JS = r"""
+() => {
+  const out = {
+    has_challenge_running: false,
+    has_turnstile: false,
+    has_cf_error_1020: false,
+    has_challenge_error_text: false,
+  };
+  try {
+    if (document.querySelector('#challenge-running')) {
+      out.has_challenge_running = true;
+    }
+    // Accept both ``.cf-turnstile`` (new) and ``[class*="cf-turnstile"]``
+    // partial-match for safety against version drift. ``data-sitekey`` is
+    // not strictly required here — its absence is interpreted by the
+    // Python side which prefers the auto-resolving path when no widget
+    // is renderable.
+    const ts = document.querySelector('.cf-turnstile, [class*="cf-turnstile"]');
+    if (ts) out.has_turnstile = true;
+    const errEl = document.querySelector('#cf-error-details');
+    if (errEl) {
+      const txt = (errEl.textContent || '').toLowerCase();
+      // CF error code 1020 = "Access denied" / Under Attack Mode block.
+      if (txt.indexOf('1020') !== -1) out.has_cf_error_1020 = true;
+    }
+    if (document.querySelector('#challenge-error-text')) {
+      out.has_challenge_error_text = true;
+    }
+  } catch (e) { /* defensive — never throw to the page */ }
+  return out;
+}
+"""
+
+
+async def _classify_cf_state(page) -> str:
+    """Classify a CF interstitial into one of four states.
+
+    Returns one of ``"auto"`` / ``"behavioral"`` / ``"turnstile"`` /
+    ``"none"``. Never raises — any page-side failure (closed page, JS
+    sandbox error, page navigated mid-call) collapses to ``"none"``.
+
+    Detection precedence (highest to lowest):
+
+    1. ``has_cf_error_1020`` OR ``has_challenge_error_text`` →
+       ``"behavioral"``. These are the Under Attack / persistent-challenge
+       markers; the agent is being soft-blocked and a solver call won't
+       help.
+    2. ``has_turnstile`` AND title starts with "Just a moment" →
+       ``"turnstile"``. Solve via existing flow but caller marks
+       confidence low (~50% success; tokens are session-cookie bound).
+    3. ``has_challenge_running`` AND title starts with "Just a moment"
+       AND NOT ``has_turnstile`` → ``"auto"``. The classic "Checking your
+       browser..." auto-resolving JS challenge — wait then re-check.
+    4. Anything else → ``"none"``.
+    """
+    try:
+        title = await page.title()
+    except Exception:
+        title = ""
+    try:
+        probe = await page.evaluate(_CF_STATE_PROBE_JS)
+    except Exception:
+        logger.debug("_classify_cf_state: page.evaluate failed", exc_info=True)
+        return "none"
+    if not isinstance(probe, dict):
+        return "none"
+
+    title_str = title if isinstance(title, str) else ""
+    title_match = title_str.startswith("Just a moment")
+
+    if probe.get("has_cf_error_1020") or probe.get("has_challenge_error_text"):
+        return "behavioral"
+    if probe.get("has_turnstile") and title_match:
+        return "turnstile"
+    if probe.get("has_challenge_running") and title_match:
+        return "auto"
+    return "none"
+
+
+# ── §11.3 Behavioral-only challenge classifier ────────────────────────────
+#
+# Non-CF challenges that present no solvable widget — the only correct
+# response is to escalate to ``request_captcha_help``. We detect via DOM
+# query rather than touching ``page.title`` so the classifier works on
+# challenge overlays that don't change the document title.
+
+_BEHAVIORAL_PROBE_JS = r"""
+() => {
+  const out = { px: false, datadome: false };
+  try {
+    // PerimeterX / HUMAN Security "Press & Hold". Both legacy
+    // (``#px-captcha``, ``button[data-v="px-button"]``) and the modern
+    // HUMAN-rebrand selectors per §11.18 (``[data-human-security]``,
+    // ``[class*="human-challenge"]``).
+    if (
+      document.querySelector('#px-captcha') ||
+      document.querySelector('button[data-v="px-button"]') ||
+      document.querySelector('[data-human-security]') ||
+      document.querySelector('[class*="human-challenge"]')
+    ) {
+      out.px = true;
+    }
+    // DataDome behavioral blocker — only the ``/blocker`` path. The
+    // generic ``captcha-delivery.com`` host is also used by the solvable
+    // slider (deferred §11.5); we MUST NOT flag that as behavioral.
+    const ddIframes = document.querySelectorAll(
+      'iframe[src*="captcha-delivery.com/blocker"]'
+    );
+    if (ddIframes.length > 0) out.datadome = true;
+  } catch (e) { /* defensive */ }
+  return out;
+}
+"""
+
+
+async def _classify_behavioral(page) -> str | None:
+    """Detect non-CF behavioral-only challenges that should bypass the solver.
+
+    Returns the §11.13 ``kind`` enum string for the matched challenge, or
+    ``None`` if no behavioral challenge is present. Never raises.
+
+    Detection order (highest precedence first):
+      1. PerimeterX / HUMAN Security "Press & Hold" → ``"px-press-hold"``.
+      2. DataDome behavioral blocker (``/blocker`` path only) →
+         ``"datadome-behavioral"``.
+
+    The DataDome solvable-slider path (``captcha-delivery.com`` without
+    ``/blocker``) is intentionally NOT detected here — it routes through
+    §11.5 (deferred) once that solver lands.
+    """
+    try:
+        probe = await page.evaluate(_BEHAVIORAL_PROBE_JS)
+    except Exception:
+        logger.debug("_classify_behavioral: page.evaluate failed", exc_info=True)
+        return None
+    if not isinstance(probe, dict):
+        return None
+    if probe.get("px"):
+        return "px-press-hold"
+    if probe.get("datadome"):
+        return "datadome-behavioral"
+    return None
+
+
 class CaptchaSolver:
     """Async CAPTCHA solver using 2Captcha or CapSolver HTTP APIs."""
 

--- a/src/browser/service.py
+++ b/src/browser/service.py
@@ -24,7 +24,12 @@ from collections import deque
 from pathlib import Path
 from urllib.parse import urlparse
 
-from src.browser.captcha import _classify_recaptcha, get_solver
+from src.browser.captcha import (
+    _classify_behavioral,
+    _classify_cf_state,
+    _classify_recaptcha,
+    get_solver,
+)
 from src.browser.profile_schema import migrate_profile
 from src.browser.redaction import CredentialRedactor
 from src.browser.ref_handle import RefHandle, RefStale, ShadowHop
@@ -61,13 +66,15 @@ logger = setup_logging("browser.service")
 #   kind:
 #     "recaptcha-v2-checkbox" | "recaptcha-v2-invisible" | "recaptcha-v3"
 #     | "recaptcha-enterprise" | "hcaptcha" | "turnstile"
-#     | "cf-interstitial-auto" | "cf-interstitial-behavioral" | "unknown"
-#     §11.1 lands the four reCAPTCHA variants; §11.3 lands the CF tri-state.
-#     This PR ships the placeholder values only.
+#     | "cf-interstitial-auto" | "cf-interstitial-behavioral"
+#     | "cf-interstitial-turnstile" | "px-press-hold"
+#     | "datadome-behavioral" | "unknown"
+#     §11.1 lands the four reCAPTCHA variants; §11.3 lands the CF tri-state
+#     plus the behavioral-only kinds (px-press-hold / datadome-behavioral).
 #
 #   solver_outcome:
 #     "solved" | "timeout" | "rejected" | "injection_failed"
-#     | "no_solver" | "unsupported"
+#     | "no_solver" | "unsupported" | "skipped_behavioral"
 #     | "rate_limited" | "cost_cap" | "captcha_during_solve"   (§11.14)
 #     - solved: token retrieved AND injected (or no injection needed).
 #     - timeout: solver did not return a verdict in time.
@@ -83,6 +90,11 @@ logger = setup_logging("browser.service")
 #     - no_solver: no provider configured (``CAPTCHA_SOLVER_PROVIDER`` empty).
 #     - unsupported: detected kind has no solver path. *RESERVED* until the
 #       kind→provider matrix lands.
+#     - skipped_behavioral: detected kind is behavioral-only (CF Under
+#       Attack, PerimeterX Press & Hold, DataDome behavioral blocker) —
+#       solver can't help; the agent should call ``request_captcha_help``.
+#       Emitted by §11.3 detection BEFORE solver health/breaker gates so
+#       behavioral-only flows don't consume health-check or breaker quota.
 #
 #   solver_confidence:
 #     "high" | "medium" | "low" | "behavioral-only"
@@ -127,8 +139,21 @@ _VALID_CAPTCHA_KINDS: frozenset[str] = frozenset({
     "recaptcha-enterprise",  # legacy alias for back-compat
     "recaptcha-enterprise-v2", "recaptcha-enterprise-v3",
     "hcaptcha", "turnstile",
-    "cf-interstitial-auto", "cf-interstitial-behavioral", "unknown",
+    # §11.3 — CF interstitial tri-state + behavioral-only kinds.
+    "cf-interstitial-auto", "cf-interstitial-behavioral",
+    "cf-interstitial-turnstile",
+    "px-press-hold", "datadome-behavioral",
+    "unknown",
 })
+
+
+# §11.3 — wait duration for CF auto-resolving JS challenge ("Just a moment").
+# Spec calls for 5–10s; we pick 8s (midpoint) as a reasonable default:
+# legitimate fingerprints typically clear in <5s, while 10s+ would stall
+# agent loops on dead pages. One wait+recheck cycle per ``_check_captcha``
+# call (no retry loop) — if the page hasn't navigated by then we fall
+# through to behavioral classification.
+_CF_AUTO_WAIT_SECONDS = 8.0
 
 
 # ── §11.14 per-agent solve rate limiter ───────────────────────────────────
@@ -5439,9 +5464,29 @@ class BrowserManager:
         Callers should treat ``solver_outcome == "solved"`` as "no agent
         action needed" — the captcha was detected but already cleared.
 
-        NOTE: classification here is minimal — it maps the matched selector
-        onto the §11.13 ``kind`` enum. Full reCAPTCHA v2/v3/Enterprise
-        disambiguation lands in §11.1; CF interstitial tri-state in §11.3.
+        Classification dispatches the matched selector through three
+        live-page classifiers in order:
+
+        1. §11.1 reCAPTCHA variant classifier (``_classify_recaptcha``) —
+           upgrades the coarse ``recaptcha-v2-checkbox`` placeholder to
+           ``recaptcha-v{2-invisible,3,enterprise-v2,enterprise-v3}``.
+        2. §11.3 behavioral-only classifier (``_classify_behavioral``) —
+           detects PerimeterX Press & Hold and DataDome ``/blocker``
+           pages. Runs **before** the §11.16 solver health/breaker gates
+           so behavioral-only flows don't consume health-check or
+           breaker quota; the solver genuinely cannot help with these.
+        3. §11.3 Cloudflare tri-state classifier (``_classify_cf_state``):
+           - ``auto``: wait :data:`_CF_AUTO_WAIT_SECONDS` once and
+             re-check the selector list. If page navigated away, return
+             ``solver_outcome="solved"``; otherwise treat as behavioral.
+           - ``behavioral``: emit ``cf-interstitial-behavioral`` with
+             ``skipped_behavioral`` outcome.
+           - ``turnstile``: route through the existing Turnstile solver
+             path with kind upgraded to ``cf-interstitial-turnstile``
+             and ``solver_confidence`` forced to ``"low"`` regardless
+             of the solver verdict (CF binds Turnstile tokens to session
+             cookies; the solve may not unblock the session).
+           - ``none``: fall through to the existing flow unchanged.
 
         §11.16 layers two solver-health side-channels on top of the §11.13
         envelope, checked BEFORE attempting ``solver.solve()``:
@@ -5493,6 +5538,122 @@ class BrowserManager:
                                 "_classify_recaptcha raised; falling back to "
                                 "coarse kind=%s", kind, exc_info=True,
                             )
+
+                    # §11.3 — behavioral-only classifier runs BEFORE the
+                    # solver health/breaker gates so behavioral-only flows
+                    # (PerimeterX Press & Hold, DataDome blocker) don't
+                    # consume health-check or breaker quota. The solver
+                    # genuinely cannot help with these challenges; the
+                    # only correct response is to escalate via
+                    # ``request_captcha_help`` (§11.14).
+                    behavioral_kind = await _classify_behavioral(inst.page)
+                    if behavioral_kind:
+                        logger.info(
+                            "Behavioral-only challenge detected (%s); "
+                            "skipping solver, escalating to request_captcha_help",
+                            behavioral_kind,
+                        )
+                        return _captcha_envelope(
+                            kind=behavioral_kind,
+                            solver_attempted=False,
+                            solver_outcome="skipped_behavioral",
+                            solver_confidence="behavioral-only",
+                            next_action="request_captcha_help",
+                        )
+
+                    # §11.3 — Cloudflare interstitial tri-state classifier.
+                    # ``auto`` waits once and re-checks; ``behavioral``
+                    # short-circuits to the behavioral envelope; ``turnstile``
+                    # falls through to the existing solver path with a
+                    # forced-``low`` confidence override; ``none`` keeps
+                    # the existing legacy fallback (for CF iframes that
+                    # don't expose any of the discriminating anchors).
+                    cf_force_low_confidence = False
+                    cf_state = await _classify_cf_state(inst.page)
+                    if cf_state == "behavioral":
+                        logger.info(
+                            "CF interstitial classified as behavioral "
+                            "(under-attack / persistent challenge); "
+                            "skipping solver",
+                        )
+                        return _captcha_envelope(
+                            kind="cf-interstitial-behavioral",
+                            solver_attempted=False,
+                            solver_outcome="skipped_behavioral",
+                            solver_confidence="behavioral-only",
+                            next_action="request_captcha_help",
+                        )
+                    if cf_state == "auto":
+                        logger.info(
+                            "CF auto-resolving challenge detected; "
+                            "waiting %.1fs for it to clear",
+                            _CF_AUTO_WAIT_SECONDS,
+                        )
+                        await asyncio.sleep(_CF_AUTO_WAIT_SECONDS)
+                        # Re-run the selector match — if the page has
+                        # navigated away from the challenge, no captcha
+                        # selector matches. If still on the challenge,
+                        # treat as behavioral (one wait+recheck cycle
+                        # only — never loop).
+                        still_present = False
+                        for recheck_sel in captcha_selectors:
+                            try:
+                                if (
+                                    await inst.page.locator(recheck_sel).count()
+                                    > 0
+                                ):
+                                    still_present = True
+                                    break
+                            except Exception:
+                                # Page closed / navigated mid-recheck —
+                                # treat as cleared.
+                                logger.debug(
+                                    "CF auto recheck locator raised; "
+                                    "treating as cleared",
+                                    exc_info=True,
+                                )
+                                break
+                        if not still_present:
+                            return _captcha_envelope(
+                                kind="cf-interstitial-auto",
+                                solver_attempted=False,
+                                solver_outcome="solved",
+                                solver_confidence="medium",
+                                next_action="solved",
+                            )
+                        logger.info(
+                            "CF auto-resolving challenge still present "
+                            "after wait; treating as behavioral",
+                        )
+                        return _captcha_envelope(
+                            kind="cf-interstitial-behavioral",
+                            solver_attempted=False,
+                            solver_outcome="skipped_behavioral",
+                            solver_confidence="behavioral-only",
+                            next_action="request_captcha_help",
+                        )
+                    if cf_state == "turnstile":
+                        # CF-bound Turnstile: existing Turnstile solver
+                        # path runs, but the resulting confidence is
+                        # forced to "low" because CF binds the token to
+                        # session cookies and the solve may not unblock
+                        # the session even when the verdict is good.
+                        kind = "cf-interstitial-turnstile"
+                        cf_force_low_confidence = True
+                    # cf_state == "none" — fall through to existing
+                    # standalone-Turnstile / generic flow unchanged.
+
+                    # Local helper applies the §11.3 CF-Turnstile
+                    # confidence override (see ``cf_force_low_confidence``)
+                    # to every return path through the solver block. Token
+                    # validity is unrelated to the per-call solve verdict
+                    # for CF-bound Turnstile, so the override fires
+                    # regardless of ``solver_outcome``.
+                    def _finalize(envelope: dict) -> dict:
+                        if cf_force_low_confidence:
+                            envelope["solver_confidence"] = "low"
+                        return envelope
+
                     if self._captcha_solver:
                         # §11.16 short-circuits — check solver health
                         # BEFORE attempting a solve. ``is_solver_unreachable``
@@ -5507,12 +5668,12 @@ class BrowserManager:
                                 "CAPTCHA detected (%s), solver marked unreachable; skipping",
                                 sel,
                             )
-                            return _captcha_envelope(
+                            return _finalize(_captcha_envelope(
                                 kind=kind, solver_attempted=False,
                                 solver_outcome="no_solver",
                                 solver_confidence=_kind_confidence(kind),
                                 next_action="request_captcha_help",
-                            )
+                            ))
                         if self._captcha_solver.is_breaker_open():
                             logger.warning(
                                 "CAPTCHA detected (%s), solver breaker open; skipping",
@@ -5529,7 +5690,7 @@ class BrowserManager:
                             # §11.13 contract while letting callers detect
                             # the breaker-open case distinctly.
                             envelope["breaker_open"] = True
-                            return envelope
+                            return _finalize(envelope)
                         logger.info("CAPTCHA detected (%s), attempting auto-solve", sel)
                         try:
                             solved = await self._captcha_solver.solve(
@@ -5537,12 +5698,12 @@ class BrowserManager:
                             )
                         except asyncio.TimeoutError:
                             # Solver took too long — true "timeout" semantic.
-                            return _captcha_envelope(
+                            return _finalize(_captcha_envelope(
                                 kind=kind, solver_attempted=True,
                                 solver_outcome="timeout",
                                 solver_confidence="low",
                                 next_action="notify_user",
-                            )
+                            ))
                         except Exception as exc:
                             # Network / JSON-decode / programmer errors all
                             # land here. A third-party CaptchaSolver subclass
@@ -5559,26 +5720,26 @@ class BrowserManager:
                                 logger.warning(
                                     "Auto-solve timed out (httpx): %r", exc,
                                 )
-                                return _captcha_envelope(
+                                return _finalize(_captcha_envelope(
                                     kind=kind, solver_attempted=True,
                                     solver_outcome="timeout",
                                     solver_confidence="low",
                                     next_action="notify_user",
-                                )
+                                ))
                             logger.exception("Auto-solve raised, falling back")
-                            return _captcha_envelope(
+                            return _finalize(_captcha_envelope(
                                 kind=kind, solver_attempted=True,
                                 solver_outcome="rejected",
                                 solver_confidence="low",
                                 next_action="notify_user",
-                            )
+                            ))
                         if solved:
-                            return _captcha_envelope(
+                            return _finalize(_captcha_envelope(
                                 kind=kind, solver_attempted=True,
                                 solver_outcome="solved",
                                 solver_confidence="high",
                                 next_action="solved",
-                            )
+                            ))
                         # solver.solve() returned False. Today this conflates
                         # three failure modes: (a) provider verdict reject /
                         # errorId>0, (b) sitekey not extractable, (c) token
@@ -5589,45 +5750,49 @@ class BrowserManager:
                         # three to ``rejected`` for now and revisit once the
                         # solver returns structured results.
                         logger.warning("Auto-solve failed, falling back to manual")
-                        return _captcha_envelope(
+                        return _finalize(_captcha_envelope(
                             kind=kind, solver_attempted=True,
                             solver_outcome="rejected",
                             solver_confidence="low",
                             next_action="notify_user",
-                        )
+                        ))
                     # No solver configured — surface to agent for manual VNC.
                     # Confidence reflects how firmly we classified the kind:
                     # firmly-disambiguated kinds (hcaptcha, turnstile) →
                     # "high"; placeholders (recaptcha-v2-checkbox,
                     # cf-interstitial-auto) and "unknown" → "low" until
                     # §11.1 / §11.3 land variant detection.
-                    return _captcha_envelope(
+                    return _finalize(_captcha_envelope(
                         kind=kind, solver_attempted=False,
                         solver_outcome="no_solver",
                         solver_confidence=_kind_confidence(kind),
                         next_action="notify_user",
-                    )
+                    ))
         except Exception:
             logger.debug("captcha detection raised", exc_info=True)
         return {"captcha_found": False}
 
     def _classify_kind(self, selector: str) -> str:
-        """Map the matched selector onto a §11.13 ``kind`` value.
+        """Map the matched selector onto the coarse §11.13 ``kind`` value.
 
-        Minimal classification — see §11.1 for the full reCAPTCHA variant
-        and §11.3 for the CF interstitial tri-state work that will refine
-        these placeholders.
+        First-pass classification only — the live-page classifiers in
+        ``_check_captcha`` (§11.1 ``_classify_recaptcha``, §11.3
+        ``_classify_cf_state`` / ``_classify_behavioral``) refine these
+        placeholders against the actual page state.
         """
         if "recaptcha" in selector:
-            # v2-checkbox is the dominant case; v2-invisible/v3/Enterprise
-            # disambiguation lives in §11.1.
+            # v2-checkbox is the safe default; the §11.1 classifier
+            # upgrades to v2-invisible / v3 / Enterprise variants when
+            # the live page exposes the disambiguating signals.
             return "recaptcha-v2-checkbox"
         if "hcaptcha" in selector:
             return "hcaptcha"
         if "challenges.cloudflare.com" in selector:
-            # Default to the auto-resolving JS challenge until §11.3 lands
-            # full tri-state (auto / behavioral / turnstile-embedded)
-            # detection.
+            # Coarse CF default. The §11.3 classifier in ``_check_captcha``
+            # routes to ``cf-interstitial-{auto,behavioral,turnstile}``
+            # based on live-page anchors (challenge frame, error 1020,
+            # embedded Turnstile widget). When the JS probe finds none
+            # of those, this placeholder stays.
             return "cf-interstitial-auto"
         if "cf-turnstile" in selector:
             return "turnstile"

--- a/tests/test_browser_service.py
+++ b/tests/test_browser_service.py
@@ -5022,6 +5022,125 @@ class TestCheckCaptchaUsesVariantClassifier:
         assert result["kind"] == "recaptcha-v2-checkbox"
 
 
+# ── §11.3 CF tri-state + Turnstile selector regression tests ──────────────
+
+
+class TestCheckCaptchaCfTristateSelectorRegression:
+    """Verify post-§11.3 ``_check_captcha`` keeps the existing CF / Turnstile
+    selector contracts. These tests drive ``page.evaluate`` per-JS-string
+    so the §11.3 classifiers (``_classify_behavioral``, ``_classify_cf_state``)
+    receive realistic shapes, not a single shared return value.
+    """
+
+    @staticmethod
+    def _make_inst(matching_selector: str, *, cf_probe=None, behavioral_probe=None,
+                   recaptcha_probe=None, title: str = "") -> MagicMock:
+        from src.browser.captcha import (
+            _BEHAVIORAL_PROBE_JS,
+            _CF_STATE_PROBE_JS,
+            _CLASSIFY_RECAPTCHA_JS,
+        )
+        inst = MagicMock()
+        inst.page = MagicMock()
+        inst.page.url = "https://example.com"
+        inst.page.title = AsyncMock(return_value=title)
+
+        def locator(sel: str):
+            loc = MagicMock()
+            loc.count = AsyncMock(
+                return_value=1 if sel == matching_selector else 0,
+            )
+            return loc
+
+        inst.page.locator = MagicMock(side_effect=locator)
+
+        async def evaluate(js, *args, **kwargs):
+            if js == _BEHAVIORAL_PROBE_JS:
+                return behavioral_probe if behavioral_probe is not None else {
+                    "px": False, "datadome": False,
+                }
+            if js == _CF_STATE_PROBE_JS:
+                return cf_probe if cf_probe is not None else {
+                    "has_challenge_running": False,
+                    "has_turnstile": False,
+                    "has_cf_error_1020": False,
+                    "has_challenge_error_text": False,
+                }
+            if js == _CLASSIFY_RECAPTCHA_JS:
+                return recaptcha_probe if recaptcha_probe is not None else {
+                    "enterprise": False, "v3": False, "sitekeys": [],
+                    "actions_by_key": {}, "invisible_by_key": {},
+                    "enterprise_script": False, "v3_render_param": None,
+                }
+            return None
+
+        inst.page.evaluate = evaluate
+        inst.lock = asyncio.Lock()
+        inst.touch = MagicMock()
+        return inst
+
+    @pytest.mark.asyncio
+    async def test_standalone_turnstile_kind_unchanged(self):
+        """``[class*="cf-turnstile"]`` selector with no CF challenge frame
+        keeps ``kind="turnstile"`` and ``solver_confidence="high"`` (firm
+        kind, no solver).
+        """
+        from src.browser.service import BrowserManager
+        mgr = BrowserManager.__new__(BrowserManager)
+        mgr._captcha_solver = None
+        # CF probe returns "none" (no challenge_running / no turnstile flag /
+        # no error markers) — falls through to existing flow.
+        inst = self._make_inst('[class*="cf-turnstile"]', title="Login")
+        result = await mgr._check_captcha(inst)
+        assert result["kind"] == "turnstile"
+        assert result["solver_confidence"] == "high"
+        assert result["solver_outcome"] == "no_solver"
+
+    @pytest.mark.asyncio
+    async def test_cf_iframe_with_no_anchors_falls_through_to_auto_placeholder(self):
+        """CF iframe selector match with the JS probe finding no
+        discriminating anchors → existing ``cf-interstitial-auto``
+        placeholder kind, ``solver_confidence="low"`` (placeholder).
+        """
+        from src.browser.service import BrowserManager
+        mgr = BrowserManager.__new__(BrowserManager)
+        mgr._captcha_solver = None
+        inst = self._make_inst(
+            'iframe[src*="challenges.cloudflare.com"]',
+            title="Just a moment...",
+        )
+        result = await mgr._check_captcha(inst)
+        assert result["kind"] == "cf-interstitial-auto"
+        assert result["solver_confidence"] == "low"
+
+    @pytest.mark.asyncio
+    async def test_cf_iframe_with_turnstile_widget_routes_to_cf_turnstile_kind(self):
+        """When the CF iframe selector matches AND the JS probe reports
+        a Turnstile widget AND the title is "Just a moment...", the §11.3
+        classifier returns ``"turnstile"`` and the envelope kind becomes
+        ``cf-interstitial-turnstile`` with forced-low confidence.
+        """
+        from src.browser.service import BrowserManager
+        mgr = BrowserManager.__new__(BrowserManager)
+        mgr._captcha_solver = None
+        inst = self._make_inst(
+            'iframe[src*="challenges.cloudflare.com"]',
+            cf_probe={
+                "has_challenge_running": False,
+                "has_turnstile": True,
+                "has_cf_error_1020": False,
+                "has_challenge_error_text": False,
+            },
+            title="Just a moment...",
+        )
+        result = await mgr._check_captcha(inst)
+        assert result["kind"] == "cf-interstitial-turnstile"
+        # No solver configured → no_solver outcome with low confidence
+        # (override applies regardless).
+        assert result["solver_outcome"] == "no_solver"
+        assert result["solver_confidence"] == "low"
+
+
 # ── Dialog scoping tests ──────────────────────────────────────────────────
 
 

--- a/tests/test_captcha_cf_tristate.py
+++ b/tests/test_captcha_cf_tristate.py
@@ -1,0 +1,564 @@
+"""Tests for §11.3 Cloudflare interstitial tri-state + behavioral-only.
+
+Covers the integration of ``_classify_cf_state`` and ``_classify_behavioral``
+inside :meth:`BrowserManager._check_captcha`:
+
+* CF auto-resolving JS challenge: wait + recheck. If page navigates →
+  ``solver_outcome="solved"``, ``solver_confidence="medium"``. If still on
+  challenge → behavioral envelope.
+* CF Under Attack mode (1020) → behavioral envelope, solver never invoked.
+* CF interstitial with embedded Turnstile widget → existing solver path,
+  but ``solver_confidence`` overridden to ``"low"`` regardless of verdict.
+* PerimeterX legacy / modern selectors → ``"px-press-hold"`` envelope.
+* DataDome ``/blocker`` path → ``"datadome-behavioral"`` envelope.
+* Behavioral classification runs **before** the solver health/breaker
+  gates (so CF Under Attack doesn't consume health-check or breaker quota).
+* Wait-and-recheck happens at most once per ``_check_captcha`` call.
+
+The ``_classify_*`` helpers each issue a single ``page.evaluate`` JS probe;
+tests stub ``page.evaluate`` to return whatever shape we need to drive
+each branch and ``asyncio.sleep`` to a no-op so the 8-second wait doesn't
+slow the suite.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from src.browser.captcha import (
+    _BEHAVIORAL_PROBE_JS,
+    _CF_STATE_PROBE_JS,
+    _CLASSIFY_RECAPTCHA_JS,
+)
+from src.browser.service import _CF_AUTO_WAIT_SECONDS, BrowserManager
+
+
+def _make_manager(*, solver=None) -> BrowserManager:
+    """Build a bare ``BrowserManager`` shell with optional solver mock.
+
+    The §11.16 solver-health side-channels (``is_solver_unreachable`` /
+    ``is_breaker_open``) are defaulted to ``False`` so the §11.3
+    short-circuits are exercised separately from the §11.16 ones.
+    """
+    mgr = BrowserManager.__new__(BrowserManager)
+    if solver is not None:
+        if not isinstance(getattr(solver, "is_solver_unreachable", None), MagicMock):
+            solver.is_solver_unreachable = MagicMock(return_value=False)
+        if not isinstance(getattr(solver, "is_breaker_open", None), MagicMock):
+            solver.is_breaker_open = MagicMock(return_value=False)
+    mgr._captcha_solver = solver
+    return mgr
+
+
+def _make_inst(
+    *,
+    matching_selector: str | None,
+    behavioral_probe=None,
+    cf_probe=None,
+    recaptcha_probe=None,
+    title: str = "",
+    rechecked_selectors_present: bool | None = None,
+) -> MagicMock:
+    """Build a mocked CamoufoxInstance for §11.3 tests.
+
+    ``page.evaluate`` is dispatched on the JS string passed in:
+      * ``_BEHAVIORAL_PROBE_JS`` → ``behavioral_probe``
+      * ``_CF_STATE_PROBE_JS``   → ``cf_probe``
+      * ``_CLASSIFY_RECAPTCHA_JS`` → ``recaptcha_probe`` (rare; included
+        for completeness — recaptcha selectors aren't covered here)
+
+    ``rechecked_selectors_present`` controls what ``locator(sel).count()``
+    returns on the second pass through ``captcha_selectors`` (i.e. after
+    the wait+recheck). When ``None``, the locator returns the same
+    ``matching_selector`` count both times. When set, the second pass
+    returns ``rechecked_selectors_present`` for every selector — used to
+    simulate "page navigated away" vs "still on challenge" after wait.
+    """
+    inst = MagicMock()
+    inst.page = MagicMock()
+    inst.page.url = "https://example.com"
+    inst.page.title = AsyncMock(return_value=title)
+
+    # Track recheck pass: first call to locator(sel).count() per selector
+    # is the "initial match"; subsequent calls are the "recheck pass".
+    locator_call_counts: dict[str, int] = {}
+
+    def locator(sel: str):
+        loc = MagicMock()
+
+        async def _count():
+            n = locator_call_counts.get(sel, 0)
+            locator_call_counts[sel] = n + 1
+            if n == 0:
+                # Initial match — only the matching selector returns 1.
+                return 1 if sel == matching_selector else 0
+            # Recheck pass — driven by ``rechecked_selectors_present``.
+            if rechecked_selectors_present is None:
+                return 1 if sel == matching_selector else 0
+            return 1 if rechecked_selectors_present else 0
+
+        loc.count = _count
+        return loc
+
+    inst.page.locator = MagicMock(side_effect=locator)
+
+    # Dispatch ``page.evaluate`` based on which JS body is passed.
+    async def evaluate(js, *args, **kwargs):
+        if js == _BEHAVIORAL_PROBE_JS:
+            return behavioral_probe if behavioral_probe is not None else {
+                "px": False,
+                "datadome": False,
+            }
+        if js == _CF_STATE_PROBE_JS:
+            return cf_probe if cf_probe is not None else {
+                "has_challenge_running": False,
+                "has_turnstile": False,
+                "has_cf_error_1020": False,
+                "has_challenge_error_text": False,
+            }
+        if js == _CLASSIFY_RECAPTCHA_JS:
+            return recaptcha_probe if recaptcha_probe is not None else {
+                "enterprise": False, "v3": False, "sitekeys": [],
+                "actions_by_key": {}, "invisible_by_key": {},
+                "enterprise_script": False, "v3_render_param": None,
+            }
+        return None
+
+    inst.page.evaluate = evaluate
+    inst.lock = asyncio.Lock()
+    inst.touch = MagicMock()
+    return inst
+
+
+# ── 1. CF auto-resolving challenge — page clears within wait ─────────────
+
+
+class TestCfAutoResolves:
+    @pytest.mark.asyncio
+    async def test_cf_auto_clears_after_wait(self):
+        """Auto-resolving CF challenge that clears within the 8s wait.
+
+        ``rechecked_selectors_present=False`` simulates the page navigating
+        away from the challenge during the wait. Envelope must report
+        ``solver_outcome="solved"`` / ``solver_confidence="medium"``.
+        """
+        mgr = _make_manager()
+        inst = _make_inst(
+            matching_selector='iframe[src*="challenges.cloudflare.com"]',
+            cf_probe={
+                "has_challenge_running": True,
+                "has_turnstile": False,
+                "has_cf_error_1020": False,
+                "has_challenge_error_text": False,
+            },
+            title="Just a moment...",
+            rechecked_selectors_present=False,
+        )
+        with patch("src.browser.service.asyncio.sleep", new=AsyncMock()) as sleep_mock:
+            result = await mgr._check_captcha(inst)
+        assert result["captcha_found"] is True
+        assert result["kind"] == "cf-interstitial-auto"
+        assert result["solver_attempted"] is False
+        assert result["solver_outcome"] == "solved"
+        assert result["next_action"] == "solved"
+        assert result["solver_confidence"] == "medium"
+        # Exactly one wait+recheck cycle.
+        sleep_mock.assert_awaited_once_with(_CF_AUTO_WAIT_SECONDS)
+
+
+# ── 2. CF auto-resolving — still present after wait → behavioral ─────────
+
+
+class TestCfAutoStuck:
+    @pytest.mark.asyncio
+    async def test_cf_auto_still_present_falls_through_to_behavioral(self):
+        """Auto-resolving CF challenge that doesn't clear within the wait
+        falls through to the behavioral envelope. Solver must NOT be invoked.
+        """
+        solver = AsyncMock()
+        solver.solve = AsyncMock(return_value=True)
+        mgr = _make_manager(solver=solver)
+        inst = _make_inst(
+            matching_selector='iframe[src*="challenges.cloudflare.com"]',
+            cf_probe={
+                "has_challenge_running": True,
+                "has_turnstile": False,
+                "has_cf_error_1020": False,
+                "has_challenge_error_text": False,
+            },
+            title="Just a moment...",
+            rechecked_selectors_present=True,
+        )
+        with patch("src.browser.service.asyncio.sleep", new=AsyncMock()):
+            result = await mgr._check_captcha(inst)
+        assert result["captcha_found"] is True
+        assert result["kind"] == "cf-interstitial-behavioral"
+        assert result["solver_attempted"] is False
+        assert result["solver_outcome"] == "skipped_behavioral"
+        assert result["next_action"] == "request_captcha_help"
+        assert result["solver_confidence"] == "behavioral-only"
+        # Solver MUST NOT have been invoked.
+        solver.solve.assert_not_awaited()
+
+
+# ── 3. CF Under Attack (error 1020) → behavioral ─────────────────────────
+
+
+class TestCfUnderAttack:
+    @pytest.mark.asyncio
+    async def test_cf_error_1020_is_behavioral(self):
+        """Under Attack Mode shows ``cf-error-details`` containing 1020.
+        Solver call would be useless — expect behavioral envelope.
+        """
+        solver = AsyncMock()
+        solver.solve = AsyncMock(return_value=True)
+        mgr = _make_manager(solver=solver)
+        inst = _make_inst(
+            matching_selector='iframe[src*="challenges.cloudflare.com"]',
+            cf_probe={
+                "has_challenge_running": False,
+                "has_turnstile": False,
+                "has_cf_error_1020": True,
+                "has_challenge_error_text": False,
+            },
+            title="Attention Required! | Cloudflare",
+        )
+        with patch("src.browser.service.asyncio.sleep", new=AsyncMock()) as sleep_mock:
+            result = await mgr._check_captcha(inst)
+        assert result["kind"] == "cf-interstitial-behavioral"
+        assert result["solver_outcome"] == "skipped_behavioral"
+        assert result["next_action"] == "request_captcha_help"
+        assert result["solver_confidence"] == "behavioral-only"
+        solver.solve.assert_not_awaited()
+        # No wait/recheck for the under-attack path.
+        sleep_mock.assert_not_awaited()
+
+
+# ── 4. CF interstitial with Turnstile widget → solver path, low conf ─────
+
+
+class TestCfTurnstileEmbedded:
+    @pytest.mark.asyncio
+    async def test_cf_turnstile_embedded_solves_with_low_confidence(self):
+        """CF interstitial with a Turnstile widget — solver IS invoked.
+        Envelope kind is the new ``cf-interstitial-turnstile`` and
+        ``solver_confidence`` is forced to ``"low"`` regardless of verdict.
+        """
+        solver = AsyncMock()
+        solver.solve = AsyncMock(return_value=True)
+        mgr = _make_manager(solver=solver)
+        inst = _make_inst(
+            matching_selector='iframe[src*="challenges.cloudflare.com"]',
+            cf_probe={
+                "has_challenge_running": False,
+                "has_turnstile": True,
+                "has_cf_error_1020": False,
+                "has_challenge_error_text": False,
+            },
+            title="Just a moment...",
+        )
+        result = await mgr._check_captcha(inst)
+        assert result["kind"] == "cf-interstitial-turnstile"
+        assert result["solver_attempted"] is True
+        assert result["solver_outcome"] == "solved"
+        # Override applies even on success.
+        assert result["solver_confidence"] == "low"
+        assert result["next_action"] == "solved"
+        solver.solve.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_cf_turnstile_embedded_low_confidence_on_solver_failure(self):
+        """Same override applies when solver returns False (rejected)."""
+        solver = AsyncMock()
+        solver.solve = AsyncMock(return_value=False)
+        mgr = _make_manager(solver=solver)
+        inst = _make_inst(
+            matching_selector='iframe[src*="challenges.cloudflare.com"]',
+            cf_probe={
+                "has_challenge_running": False,
+                "has_turnstile": True,
+                "has_cf_error_1020": False,
+                "has_challenge_error_text": False,
+            },
+            title="Just a moment...",
+        )
+        result = await mgr._check_captcha(inst)
+        assert result["kind"] == "cf-interstitial-turnstile"
+        assert result["solver_outcome"] == "rejected"
+        # Override fires regardless of solver verdict.
+        assert result["solver_confidence"] == "low"
+
+
+# ── 5. Standalone Turnstile (no "Just a moment") preserves existing flow ──
+
+
+class TestStandaloneTurnstile:
+    @pytest.mark.asyncio
+    async def test_standalone_turnstile_unchanged(self):
+        """Standalone Turnstile widget (no CF challenge frame, no
+        "Just a moment" title) goes through the existing flow with
+        ``kind="turnstile"`` and §11.16 firm-kind confidence rules.
+        """
+        mgr = _make_manager(solver=None)
+        inst = _make_inst(
+            matching_selector='[class*="cf-turnstile"]',
+            cf_probe={
+                "has_challenge_running": False,
+                "has_turnstile": True,
+                "has_cf_error_1020": False,
+                "has_challenge_error_text": False,
+            },
+            # No title → CF state classifier returns "none" because
+            # ``title.startswith("Just a moment")`` is False.
+            title="Login Page",
+        )
+        result = await mgr._check_captcha(inst)
+        assert result["kind"] == "turnstile"
+        # Firm kind without solver → "high".
+        assert result["solver_confidence"] == "high"
+        assert result["solver_outcome"] == "no_solver"
+
+
+# ── 6. PerimeterX behavioral selectors ────────────────────────────────────
+
+
+class TestPerimeterXBehavioral:
+    @pytest.mark.asyncio
+    async def test_px_legacy_selector_is_behavioral(self):
+        """PerimeterX ``#px-captcha`` legacy selector → ``px-press-hold``."""
+        solver = AsyncMock()
+        solver.solve = AsyncMock(return_value=True)
+        mgr = _make_manager(solver=solver)
+        inst = _make_inst(
+            matching_selector='[class*="captcha"]',
+            behavioral_probe={"px": True, "datadome": False},
+        )
+        result = await mgr._check_captcha(inst)
+        assert result["kind"] == "px-press-hold"
+        assert result["solver_attempted"] is False
+        assert result["solver_outcome"] == "skipped_behavioral"
+        assert result["solver_confidence"] == "behavioral-only"
+        assert result["next_action"] == "request_captcha_help"
+        solver.solve.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_px_modern_human_selector_is_behavioral(self):
+        """HUMAN-rebrand selector ``[data-human-security]`` → ``px-press-hold``.
+
+        Same outcome envelope as legacy — they're the same challenge
+        family, just different DOM markers.
+        """
+        solver = AsyncMock()
+        solver.solve = AsyncMock(return_value=True)
+        mgr = _make_manager(solver=solver)
+        inst = _make_inst(
+            matching_selector='[class*="captcha"]',
+            behavioral_probe={"px": True, "datadome": False},
+        )
+        result = await mgr._check_captcha(inst)
+        assert result["kind"] == "px-press-hold"
+        solver.solve.assert_not_awaited()
+
+
+# ── 7. DataDome behavioral vs solvable slider ─────────────────────────────
+
+
+class TestDataDome:
+    @pytest.mark.asyncio
+    async def test_datadome_blocker_is_behavioral(self):
+        """``/blocker`` path on captcha-delivery.com → behavioral envelope."""
+        solver = AsyncMock()
+        solver.solve = AsyncMock(return_value=True)
+        mgr = _make_manager(solver=solver)
+        inst = _make_inst(
+            matching_selector='iframe[src*="captcha"]',
+            behavioral_probe={"px": False, "datadome": True},
+        )
+        result = await mgr._check_captcha(inst)
+        assert result["kind"] == "datadome-behavioral"
+        assert result["solver_outcome"] == "skipped_behavioral"
+        assert result["solver_confidence"] == "behavioral-only"
+        assert result["next_action"] == "request_captcha_help"
+        solver.solve.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_datadome_non_blocker_path_falls_through(self):
+        """Generic ``captcha-delivery.com`` (no ``/blocker``) MUST NOT
+        trip the behavioral classifier — that's the solvable slider
+        which routes through §11.5 once it lands. Envelope falls through
+        to the existing flow. The matched selector (``[class*="captcha"]``)
+        classifies to ``unknown`` in ``_classify_kind``.
+        """
+        mgr = _make_manager(solver=None)
+        inst = _make_inst(
+            matching_selector='[class*="captcha"]',
+            behavioral_probe={"px": False, "datadome": False},
+        )
+        result = await mgr._check_captcha(inst)
+        # Behavioral classifier returned None → existing flow kicks in.
+        assert result["kind"] == "unknown"
+        assert result["solver_outcome"] == "no_solver"
+        # No behavioral-only here.
+        assert result["solver_confidence"] == "low"
+
+
+# ── 8. Wait-and-recheck only happens once per call ────────────────────────
+
+
+class TestSingleRecheckPerCall:
+    @pytest.mark.asyncio
+    async def test_wait_called_at_most_once(self):
+        """Even when the page is still on the challenge after the wait,
+        we MUST NOT loop. The single wait+recheck cycle is the spec.
+        """
+        mgr = _make_manager()
+        inst = _make_inst(
+            matching_selector='iframe[src*="challenges.cloudflare.com"]',
+            cf_probe={
+                "has_challenge_running": True,
+                "has_turnstile": False,
+                "has_cf_error_1020": False,
+                "has_challenge_error_text": False,
+            },
+            title="Just a moment...",
+            rechecked_selectors_present=True,
+        )
+        with patch("src.browser.service.asyncio.sleep", new=AsyncMock()) as sleep_mock:
+            await mgr._check_captcha(inst)
+        # Exactly one wait at the configured duration. No retries.
+        assert sleep_mock.await_count == 1
+        sleep_mock.assert_awaited_with(_CF_AUTO_WAIT_SECONDS)
+
+
+# ── 9. Behavioral classifier runs BEFORE solver gates (§11.16 regression) ─
+
+
+class TestBehavioralBeforeSolverGate:
+    """When solver health is DOWN (unreachable / breaker open), a
+    behavioral-only page MUST still produce a behavioral envelope —
+    NOT ``solver_outcome="no_solver"`` or ``"timeout"``. The classifier
+    is invoked before the §11.16 short-circuits so behavioral-only
+    flows don't burn health-check / breaker quota.
+    """
+
+    @pytest.mark.asyncio
+    async def test_behavioral_with_unreachable_solver(self):
+        solver = AsyncMock()
+        solver.is_solver_unreachable = MagicMock(return_value=True)
+        solver.is_breaker_open = MagicMock(return_value=False)
+        solver.solve = AsyncMock(return_value=True)
+        mgr = _make_manager(solver=solver)
+        inst = _make_inst(
+            matching_selector='[class*="captcha"]',
+            behavioral_probe={"px": True, "datadome": False},
+        )
+        result = await mgr._check_captcha(inst)
+        # Behavioral wins over §11.16 short-circuit.
+        assert result["kind"] == "px-press-hold"
+        assert result["solver_outcome"] == "skipped_behavioral"
+        assert result["solver_confidence"] == "behavioral-only"
+        # Solver health was never consulted because behavioral runs first.
+        solver.is_solver_unreachable.assert_not_called()
+        solver.solve.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_behavioral_with_breaker_open(self):
+        solver = AsyncMock()
+        solver.is_solver_unreachable = MagicMock(return_value=False)
+        solver.is_breaker_open = MagicMock(return_value=True)
+        solver.solve = AsyncMock(return_value=True)
+        mgr = _make_manager(solver=solver)
+        inst = _make_inst(
+            matching_selector='iframe[src*="captcha"]',
+            behavioral_probe={"px": False, "datadome": True},
+        )
+        result = await mgr._check_captcha(inst)
+        assert result["kind"] == "datadome-behavioral"
+        assert result["solver_outcome"] == "skipped_behavioral"
+        assert result["solver_confidence"] == "behavioral-only"
+        solver.is_breaker_open.assert_not_called()
+        solver.solve.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_cf_under_attack_with_unreachable_solver(self):
+        """CF Under Attack also runs through ``_classify_cf_state``,
+        which is invoked before §11.16 short-circuits. The envelope
+        is the CF behavioral kind, not ``no_solver``.
+        """
+        solver = AsyncMock()
+        solver.is_solver_unreachable = MagicMock(return_value=True)
+        solver.is_breaker_open = MagicMock(return_value=False)
+        solver.solve = AsyncMock(return_value=True)
+        mgr = _make_manager(solver=solver)
+        inst = _make_inst(
+            matching_selector='iframe[src*="challenges.cloudflare.com"]',
+            cf_probe={
+                "has_challenge_running": False,
+                "has_turnstile": False,
+                "has_cf_error_1020": True,
+                "has_challenge_error_text": False,
+            },
+        )
+        result = await mgr._check_captcha(inst)
+        assert result["kind"] == "cf-interstitial-behavioral"
+        assert result["solver_outcome"] == "skipped_behavioral"
+        # §11.16 health check bypassed.
+        solver.is_solver_unreachable.assert_not_called()
+        solver.solve.assert_not_awaited()
+
+
+# ── 10. CF challenge-error-text → behavioral (alternate marker) ───────────
+
+
+class TestCfChallengeErrorText:
+    @pytest.mark.asyncio
+    async def test_challenge_error_text_is_behavioral(self):
+        """``#challenge-error-text`` on the page is the persistent-challenge
+        marker (no widget, just an error block). Maps to behavioral.
+        """
+        mgr = _make_manager()
+        inst = _make_inst(
+            matching_selector='iframe[src*="challenges.cloudflare.com"]',
+            cf_probe={
+                "has_challenge_running": False,
+                "has_turnstile": False,
+                "has_cf_error_1020": False,
+                "has_challenge_error_text": True,
+            },
+        )
+        result = await mgr._check_captcha(inst)
+        assert result["kind"] == "cf-interstitial-behavioral"
+        assert result["solver_outcome"] == "skipped_behavioral"
+        assert result["next_action"] == "request_captcha_help"
+
+
+# ── 11. CF state="none" preserves existing flow (no behavioral, no solve) ─
+
+
+class TestCfStateNone:
+    @pytest.mark.asyncio
+    async def test_cf_state_none_with_cloudflare_iframe(self):
+        """CF iframe selector matches but the JS probe finds none of the
+        discriminating anchors (no challenge-running, no turnstile, no
+        error). Falls through to the existing ``cf-interstitial-auto``
+        placeholder kind.
+        """
+        mgr = _make_manager(solver=None)
+        inst = _make_inst(
+            matching_selector='iframe[src*="challenges.cloudflare.com"]',
+            cf_probe={
+                "has_challenge_running": False,
+                "has_turnstile": False,
+                "has_cf_error_1020": False,
+                "has_challenge_error_text": False,
+            },
+            title="Just a moment...",
+        )
+        result = await mgr._check_captcha(inst)
+        assert result["kind"] == "cf-interstitial-auto"
+        assert result["solver_outcome"] == "no_solver"
+        # Placeholder kind → "low" confidence per ``_kind_confidence``.
+        assert result["solver_confidence"] == "low"


### PR DESCRIPTION
## Summary

Cloudflare's interstitial isn't one thing — it's three different challenge states, each requiring a different response. This PR adds live-page classification to disambiguate them, plus a behavioral-only classifier for PerimeterX and DataDome blocker pages where the solver genuinely can't help.

### The three CF states

| State | Detection signal | Response |
|---|---|---|
| `auto` | `#challenge-running` + "Just a moment" title, no Turnstile widget | Wait `_CF_AUTO_WAIT_SECONDS` (8s) once, recheck selectors. Page navigated → `solver_outcome="solved"` / `solver_confidence="medium"`. Still on challenge → falls through to behavioral. |
| `behavioral` | `cf-error-details` containing `1020` (Under Attack), or `#challenge-error-text` (persistent challenge) | `kind="cf-interstitial-behavioral"`, `solver_outcome="skipped_behavioral"`, `next_action="request_captcha_help"`. Solver never invoked. |
| `turnstile` | Embedded `.cf-turnstile` widget under "Just a moment" title | Continue into existing Turnstile solver path with `kind="cf-interstitial-turnstile"` and `solver_confidence` forced to `"low"` regardless of verdict. CF binds the token to session cookies; success in the solver doesn't guarantee the session unblocks. |
| `none` | None of the above | Fall through to existing flow unchanged (covers CF iframes with no discriminating anchors). |

### Behavioral-only selectors

`_classify_behavioral` runs **before** `_classify_cf_state` and **before** the §11.16 solver health/breaker gates so behavioral-only pages don't burn health-check or breaker quota. Detected:

- PerimeterX legacy: `#px-captcha`, `button[data-v="px-button"]`
- HUMAN Security rebrand (§11.18): `[data-human-security]`, `[class*="human-challenge"]`
- DataDome behavioral: `iframe[src*="captcha-delivery.com/blocker"]` only — the generic `captcha-delivery.com` host without `/blocker` is the solvable slider (§11.5, deferred) and intentionally NOT flagged here.

All behavioral matches emit `solver_outcome="skipped_behavioral"` / `solver_confidence="behavioral-only"` / `next_action="request_captcha_help"`, integrating with the §11.14 `request_captcha_help` skill.

### Wait-and-recheck guarantee

Exactly one `asyncio.sleep(_CF_AUTO_WAIT_SECONDS)` per `_check_captcha` call — never loops. If the page is still on the challenge after the wait, the envelope falls through to behavioral rather than retrying. Tests assert `sleep.await_count == 1` for the stuck path and `assert_awaited_once_with(_CF_AUTO_WAIT_SECONDS)` for the cleared path.

### Reuse

- Reuses `_captcha_envelope`, `_classify_kind`, `_kind_confidence` — no forked envelope builders.
- Reuses the existing Turnstile solver path for `cf-interstitial-turnstile`; only the envelope confidence override is new (handled via a local `_finalize` helper).
- Wait uses `asyncio.sleep` directly; no new timing helper.

Plan reference: `docs/plans/2026-04-20-browser-automation.md` §11.3.

## Test plan

- [x] `pytest tests/test_captcha_cf_tristate.py -x -v` — 16 tests, all green
- [x] `pytest tests/test_browser_service.py -k captcha tests/test_captcha_envelope.py tests/test_captcha_recaptcha_classifier.py tests/test_captcha_health.py tests/test_captcha_policy.py tests/test_browser_request_captcha_help.py tests/test_browser_solve_captcha.py tests/test_captcha_cost_counter.py -x` — 633 captcha-adjacent tests, all green (zero regressions on §11.1, §11.13, §11.14, §11.16)
- [x] `pytest tests/ --ignore=tests/test_e2e.py --ignore=tests/test_e2e_chat.py --ignore=tests/test_e2e_memory.py --ignore=tests/test_e2e_triggering.py` — 4126 passed, 1 pre-existing unrelated failure (`test_version_flag` requires installed `openlegion` package; reproduces on `main`)
- [x] `ruff check src/ tests/` — clean
- [x] Asserted that `is_solver_unreachable()` and `is_breaker_open()` are NOT invoked on behavioral paths (regression test for the "behavioral runs before solver gate" rule)
- [x] Asserted `cf_force_low_confidence` override fires regardless of solver verdict (success and failure cases both pinned)

## Notes

- CF Under Attack detection signals: settled on `has_cf_error_1020` (substring `1020` in `#cf-error-details` text content) OR `has_challenge_error_text` (presence of `#challenge-error-text`). Both are stable across CF versions seen in the wild; `1020` is the documented "Access denied" code for Under Attack Mode blocks. Spec said "1020 / repeat-challenge after wait" — the latter is implemented as the auto-classifier falling through to behavioral when the recheck still finds a captcha selector, rather than as a separate JS probe.
- The cloudflare iframe selector with NO discriminating anchors (no `#challenge-running`, no Turnstile, no error markers) keeps the existing `cf-interstitial-auto` placeholder kind and `solver_confidence="low"` per `_kind_confidence`. Existing `test_turnstile_detected` continues to pass without modification because the test's `inst.page = AsyncMock()` produces a probe that doesn't expose any of the new anchors → state="none" → existing path.