### PR TITLE
Phase 8 §11.2: proxy-aware solver tasks with credential isolation

### DIFF
--- a/src/browser/captcha.py
+++ b/src/browser/captcha.py
@@ -16,6 +16,7 @@ import os
 import re
 import time
 from collections import deque
+from dataclasses import dataclass
 from typing import Literal
 
 import httpx
@@ -136,42 +137,337 @@ _CAPTCHA_TYPE_MAP: dict[str, str] = {
 # Drift here is silent (``ERROR_INVALID_TASK_TYPE``); re-verify against
 # provider docs when bumping variants.
 #
+# §11.2 — each variant entry is now ``{"proxyless": <task name>,
+# "proxy_aware": <task name> | None, "extra": {<flags>}}``. The task-body
+# builder picks ``proxy_aware`` when a dedicated solver proxy is configured
+# AND the compat table allows it; otherwise it falls back to ``proxyless``
+# and (when the fallback is *due to* a compat-table rejection) sets the
+# envelope's ``solver_confidence`` to ``"low"``. ``proxy_aware`` may be
+# ``None`` for variants where the provider does not document a
+# proxy-aware task type (e.g. 2captcha v3 has no documented proxy variant
+# as of April 2026 — only ``RecaptchaV3TaskProxyless``).
+#
 # 2Captcha
 _2CAPTCHA_TASK_TYPES: dict[str, dict[str, object]] = {
-    "recaptcha": {"type": "NormalRecaptchaTaskProxyless"},  # legacy alias
-    "hcaptcha": {"type": "HCaptchaTaskProxyless"},
-    "turnstile": {"type": "TurnstileTaskProxyless"},
-    # §11.1 reCAPTCHA variant matrix
-    "recaptcha-v2-checkbox": {"type": "RecaptchaV2TaskProxyless"},
-    "recaptcha-v2-invisible": {
-        "type": "RecaptchaV2TaskProxyless",
-        "isInvisible": True,
+    "recaptcha": {
+        "proxyless": "NormalRecaptchaTaskProxyless",  # legacy alias
+        "proxy_aware": None,
+        "extra": {},
     },
-    "recaptcha-v3": {"type": "RecaptchaV3TaskProxyless"},
-    "recaptcha-enterprise-v2": {"type": "RecaptchaV2EnterpriseTaskProxyless"},
+    "hcaptcha": {
+        "proxyless": "HCaptchaTaskProxyless",
+        "proxy_aware": "HCaptchaTask",
+        "extra": {},
+    },
+    "turnstile": {
+        "proxyless": "TurnstileTaskProxyless",
+        "proxy_aware": "TurnstileTask",
+        "extra": {},
+    },
+    # §11.1 reCAPTCHA variant matrix
+    "recaptcha-v2-checkbox": {
+        "proxyless": "RecaptchaV2TaskProxyless",
+        "proxy_aware": "RecaptchaV2Task",
+        "extra": {},
+    },
+    "recaptcha-v2-invisible": {
+        "proxyless": "RecaptchaV2TaskProxyless",
+        "proxy_aware": "RecaptchaV2Task",
+        "extra": {"isInvisible": True},
+    },
+    # 2captcha v3 has only ``RecaptchaV3TaskProxyless`` documented as of
+    # April 2026 — no proxy-aware variant is published. Solvers fall back
+    # to proxyless and surface ``solver_confidence="low"``.
+    "recaptcha-v3": {
+        "proxyless": "RecaptchaV3TaskProxyless",
+        "proxy_aware": None,
+        "extra": {},
+    },
+    "recaptcha-enterprise-v2": {
+        "proxyless": "RecaptchaV2EnterpriseTaskProxyless",
+        "proxy_aware": "RecaptchaV2EnterpriseTask",
+        "extra": {},
+    },
     # 2captcha uses the same v3 task with isEnterprise=true (no separate
-    # ``RecaptchaV3EnterpriseTaskProxyless`` type as of April 2026).
+    # ``RecaptchaV3EnterpriseTaskProxyless`` type as of April 2026); also
+    # no documented proxy-aware v3 variant.
     "recaptcha-enterprise-v3": {
-        "type": "RecaptchaV3TaskProxyless",
-        "isEnterprise": True,
+        "proxyless": "RecaptchaV3TaskProxyless",
+        "proxy_aware": None,
+        "extra": {"isEnterprise": True},
     },
 }
 
 # CapSolver
 _CAPSOLVER_TASK_TYPES: dict[str, dict[str, object]] = {
-    "recaptcha": {"type": "ReCaptchaV2TaskProxyLess"},  # legacy alias
-    "hcaptcha": {"type": "HCaptchaTaskProxyLess"},
-    "turnstile": {"type": "AntiTurnstileTaskProxyLess"},
-    # §11.1 reCAPTCHA variant matrix
-    "recaptcha-v2-checkbox": {"type": "ReCaptchaV2TaskProxyLess"},
-    "recaptcha-v2-invisible": {
-        "type": "ReCaptchaV2TaskProxyLess",
-        "isInvisible": True,
+    "recaptcha": {
+        "proxyless": "ReCaptchaV2TaskProxyLess",  # legacy alias
+        "proxy_aware": "ReCaptchaV2Task",
+        "extra": {},
     },
-    "recaptcha-v3": {"type": "ReCaptchaV3TaskProxyLess"},
-    "recaptcha-enterprise-v2": {"type": "ReCaptchaV2EnterpriseTaskProxyLess"},
-    "recaptcha-enterprise-v3": {"type": "ReCaptchaV3EnterpriseTaskProxyLess"},
+    "hcaptcha": {
+        "proxyless": "HCaptchaTaskProxyLess",
+        "proxy_aware": "HCaptchaTask",
+        "extra": {},
+    },
+    "turnstile": {
+        # CapSolver uses ``AntiTurnstileTask`` family for both proxyless
+        # and proxy-aware (drop the "ProxyLess" suffix for proxy-aware).
+        "proxyless": "AntiTurnstileTaskProxyLess",
+        "proxy_aware": "AntiTurnstileTask",
+        "extra": {},
+    },
+    # §11.1 reCAPTCHA variant matrix
+    "recaptcha-v2-checkbox": {
+        "proxyless": "ReCaptchaV2TaskProxyLess",
+        "proxy_aware": "ReCaptchaV2Task",
+        "extra": {},
+    },
+    "recaptcha-v2-invisible": {
+        "proxyless": "ReCaptchaV2TaskProxyLess",
+        "proxy_aware": "ReCaptchaV2Task",
+        "extra": {"isInvisible": True},
+    },
+    "recaptcha-v3": {
+        "proxyless": "ReCaptchaV3TaskProxyLess",
+        "proxy_aware": "ReCaptchaV3Task",
+        "extra": {},
+    },
+    "recaptcha-enterprise-v2": {
+        "proxyless": "ReCaptchaV2EnterpriseTaskProxyLess",
+        "proxy_aware": "ReCaptchaV2EnterpriseTask",
+        "extra": {},
+    },
+    "recaptcha-enterprise-v3": {
+        "proxyless": "ReCaptchaV3EnterpriseTaskProxyLess",
+        "proxy_aware": "ReCaptchaV3EnterpriseTask",
+        "extra": {},
+    },
 }
+
+
+# §11.2 — solver-proxy compatibility table.
+#
+# Hardcoded set of accepted ``proxyType`` values per (provider, variant).
+# Verified against 2captcha + CapSolver public docs in April 2026:
+#
+# * 2captcha — RecaptchaV2Task, HCaptchaTask, TurnstileTask all document
+#   ``http | socks4 | socks5`` (no ``https``). Source:
+#   https://2captcha.com/api-docs/recaptcha-v2 and the equivalent docs
+#   for hcaptcha + cloudflare-turnstile.
+# * CapSolver — all proxy-aware tasks document ``http | https | socks4 |
+#   socks5``. Source: https://docs.capsolver.com/en/guide/api-how-to-use-proxy/
+#   ("proxyType: socks5 | http | https | socks4").
+#
+# 2captcha FunCaptcha is documented to **reject SOCKS5** (FunCaptcha is
+# deferred to §11.5; this is a placeholder for when that lands):
+#   ``("2captcha", "funcaptcha"): {"http", "https", "socks4"}``
+# Add when the FunCaptcha variant is wired in §11.5.
+#
+# A variant whose ``proxy_aware`` is ``None`` (e.g. 2captcha v3) still
+# lives in the compat table for clarity, but the task-body builder
+# short-circuits to proxyless before consulting compat.
+_SOLVER_PROXY_COMPAT: dict[tuple[str, str], set[str]] = {
+    # 2captcha — uniformly {http, socks4, socks5} (NO https) on all
+    # documented proxy-aware task types.
+    ("2captcha", "recaptcha-v2-checkbox"):    {"http", "socks4", "socks5"},
+    ("2captcha", "recaptcha-v2-invisible"):   {"http", "socks4", "socks5"},
+    ("2captcha", "recaptcha-enterprise-v2"):  {"http", "socks4", "socks5"},
+    ("2captcha", "hcaptcha"):                 {"http", "socks4", "socks5"},
+    ("2captcha", "turnstile"):                {"http", "socks4", "socks5"},
+    # CapSolver — full set on all documented proxy-aware task types.
+    ("capsolver", "recaptcha-v2-checkbox"):   {"http", "https", "socks4", "socks5"},
+    ("capsolver", "recaptcha-v2-invisible"):  {"http", "https", "socks4", "socks5"},
+    ("capsolver", "recaptcha-v3"):            {"http", "https", "socks4", "socks5"},
+    ("capsolver", "recaptcha-enterprise-v2"): {"http", "https", "socks4", "socks5"},
+    ("capsolver", "recaptcha-enterprise-v3"): {"http", "https", "socks4", "socks5"},
+    ("capsolver", "hcaptcha"):                {"http", "https", "socks4", "socks5"},
+    ("capsolver", "turnstile"):               {"http", "https", "socks4", "socks5"},
+}
+
+
+_VALID_PROXY_TYPES = frozenset({"http", "https", "socks4", "socks5"})
+
+
+@dataclass(frozen=True)
+class SolverProxyConfig:
+    """Dedicated solver-side proxy.
+
+    **NOT** the agent's primary egress proxy. The agent's primary proxy
+    creds are NEVER forwarded to a solver provider — the threat model is
+    that handing your scraping proxy creds to a third-party solver is a
+    direct credential-leak vector. This struct is loaded from a
+    *separate* env-var family (``CAPTCHA_SOLVER_PROXY_*``) which an
+    operator opts into by setting all five fields.
+    """
+
+    proxy_type: str       # one of {"http", "https", "socks4", "socks5"}
+    address: str
+    port: int
+    login: str
+    password: str
+
+    def to_request_fields(self) -> dict[str, object]:
+        """Return the ``proxyType/Address/Port/Login/Password`` body fields.
+
+        Both 2captcha and CapSolver use this exact field naming in the
+        ``task`` block of ``createTask`` requests.
+        """
+        return {
+            "proxyType": self.proxy_type,
+            "proxyAddress": self.address,
+            "proxyPort": self.port,
+            "proxyLogin": self.login,
+            "proxyPassword": self.password,
+        }
+
+
+def _normalize_proxy_type(raw: str) -> str | None:
+    """Coerce ``socks5h://``/``socks5h``/``HTTP``/etc. to the canonical name.
+
+    Returns the canonical type (``"socks5"`` etc.) or ``None`` for an
+    unrecognized scheme. ``socks5h`` (DNS-via-SOCKS) collapses to
+    ``socks5`` because both providers list only ``socks5`` — the ``h``
+    variant is a client-side tunneling preference that doesn't change
+    what the provider expects.
+    """
+    if not raw:
+        return None
+    s = raw.strip().lower()
+    # Strip ``://`` if present (URL-style).
+    if "://" in s:
+        s = s.split("://", 1)[0]
+    # Collapse the ``socks5h`` (and theoretical ``socks4a``) variants to
+    # the base name documented by the providers.
+    if s == "socks5h":
+        s = "socks5"
+    if s == "socks4a":
+        s = "socks4"
+    return s if s in _VALID_PROXY_TYPES else None
+
+
+# Once-per-session warning gate (§11.16 cadence): the loader logs at most
+# one warning across the process lifetime when partial config is detected,
+# rather than spamming on every solver call.
+_proxy_config_warned: bool = False
+
+
+def _reset_proxy_config_warning() -> None:
+    """Test helper — clear the once-per-session warning flag."""
+    global _proxy_config_warned
+    _proxy_config_warned = False
+
+
+def get_solver_proxy_config(
+    *, agent_id: str | None = None,
+) -> SolverProxyConfig | None:
+    """Load the dedicated solver proxy from env via ``flags`` helpers.
+
+    Behavior:
+
+    * If ``CAPTCHA_SOLVER_PROXY_TYPE`` is unset → returns ``None``
+      (proxyless task types will be used; this is the default).
+    * If ``CAPTCHA_SOLVER_PROXY_TYPE`` is set, all five fields
+      (``TYPE``, ``ADDRESS``, ``PORT``, ``LOGIN``, ``PASSWORD``) are
+      required. Partial config logs a single warning at solver init and
+      returns ``None`` (falls back to proxyless).
+    * Bad scheme (anything other than http/https/socks4/socks5 after
+      normalization) logs a warning and returns ``None``.
+
+    Reads via ``flags.get_str``/``get_int`` so per-agent overrides and
+    operator settings.json take precedence over env vars (matches the
+    rest of the browser flag surface).
+    """
+    global _proxy_config_warned
+    # Local import — avoid circular: flags imports nothing from captcha.
+    from src.browser import flags as _flags
+
+    raw_type = _flags.get_str(
+        "CAPTCHA_SOLVER_PROXY_TYPE", "", agent_id=agent_id,
+    ).strip()
+    if not raw_type:
+        # Default off — proxyless task types are used.
+        return None
+
+    proxy_type = _normalize_proxy_type(raw_type)
+    if proxy_type is None:
+        if not _proxy_config_warned:
+            logger.warning(
+                "CAPTCHA_SOLVER_PROXY_TYPE=%r is not in {http, https, socks4, "
+                "socks5} (after socks5h→socks5 normalization); falling back "
+                "to proxyless solver tasks.",
+                raw_type,
+            )
+            _proxy_config_warned = True
+        return None
+
+    address = _flags.get_str(
+        "CAPTCHA_SOLVER_PROXY_ADDRESS", "", agent_id=agent_id,
+    ).strip()
+    # ``get_int`` returns the default when unset; use a sentinel default
+    # so we can distinguish "unset" from "explicitly 0".
+    raw_port_str = _flags.get_str(
+        "CAPTCHA_SOLVER_PROXY_PORT", "", agent_id=agent_id,
+    ).strip()
+    login = _flags.get_str(
+        "CAPTCHA_SOLVER_PROXY_LOGIN", "", agent_id=agent_id,
+    )
+    password = _flags.get_str(
+        "CAPTCHA_SOLVER_PROXY_PASSWORD", "", agent_id=agent_id,
+    )
+
+    # All 5 fields required when type is set.
+    missing: list[str] = []
+    if not address:
+        missing.append("CAPTCHA_SOLVER_PROXY_ADDRESS")
+    if not raw_port_str:
+        missing.append("CAPTCHA_SOLVER_PROXY_PORT")
+    if not login:
+        missing.append("CAPTCHA_SOLVER_PROXY_LOGIN")
+    if not password:
+        missing.append("CAPTCHA_SOLVER_PROXY_PASSWORD")
+
+    port = 0
+    if raw_port_str:
+        try:
+            port = int(raw_port_str)
+            if port <= 0 or port > 65535:
+                missing.append("CAPTCHA_SOLVER_PROXY_PORT(out-of-range)")
+        except ValueError:
+            missing.append("CAPTCHA_SOLVER_PROXY_PORT(non-integer)")
+
+    if missing:
+        if not _proxy_config_warned:
+            logger.warning(
+                "CAPTCHA_SOLVER_PROXY_TYPE is set but required fields are "
+                "missing/invalid: %s — falling back to proxyless solver "
+                "tasks. Set all 5 CAPTCHA_SOLVER_PROXY_* env vars to enable "
+                "the dedicated solver proxy.",
+                ", ".join(missing),
+            )
+            _proxy_config_warned = True
+        return None
+
+    return SolverProxyConfig(
+        proxy_type=proxy_type,
+        address=address,
+        port=port,
+        login=login,
+        password=password,
+    )
+
+
+def _solver_proxy_compatible(provider: str, captcha_type: str, proxy_type: str) -> bool:
+    """Return True iff ``(provider, captcha_type)`` documents ``proxy_type``.
+
+    Variants absent from the compat table are treated as not-compatible —
+    we'd rather fall back to proxyless than send a request shape the
+    provider hasn't documented.
+    """
+    allowed = _SOLVER_PROXY_COMPAT.get((provider.lower(), captcha_type))
+    if allowed is None:
+        return False
+    return proxy_type in allowed
 
 
 # Default ``pageAction`` when the classifier couldn't extract one. Most
@@ -610,6 +906,17 @@ class CaptchaSolver:
         # Coordinates breaker reads/writes with health-check init across
         # concurrent agents that share this solver instance.
         self._state_lock: asyncio.Lock = asyncio.Lock()
+        # ── §11.2 last-solve proxy metadata ─────────────────────────────
+        # ``solve()`` stamps these so the BrowserManager caller can pick
+        # them up without changing the public ``solve() -> bool`` return
+        # contract. ``last_used_proxy_aware`` reflects what was actually
+        # sent (proxy-aware task name + creds vs proxyless); the cost
+        # counter uses this to apply proxy-aware pricing. ``last_compat_rejected``
+        # is True when a proxy was configured but the (provider, variant,
+        # type) tuple rejected — caller downgrades ``solver_confidence``
+        # to "low".
+        self.last_used_proxy_aware: bool = False
+        self.last_compat_rejected: bool = False
 
     def _get_client(self) -> httpx.AsyncClient:
         if self._client is None or self._client.is_closed:
@@ -812,13 +1119,22 @@ class CaptchaSolver:
                     len(self._solver_failure_timestamps),
                 )
 
-    async def solve(self, page, selector: str, page_url: str) -> bool:
+    async def solve(
+        self,
+        page,
+        selector: str,
+        page_url: str,
+        *,
+        agent_id: str | None = None,
+    ) -> bool:
         """Attempt to solve a CAPTCHA on the page.
 
         Args:
             page: Playwright page object.
             selector: The CSS selector that matched the CAPTCHA element.
             page_url: The current page URL.
+            agent_id: Optional — for per-agent override of solver-proxy
+                config via :func:`flags.set_agent_override`.
 
         Returns:
             True if the CAPTCHA was solved and token injected, False
@@ -826,7 +1142,18 @@ class CaptchaSolver:
             without issuing a provider HTTP call. Callers should consult
             :meth:`is_solver_unreachable` and :meth:`is_breaker_open` to
             distinguish those cases from a genuine solve failure.
+
+        After every call (success or failure) the caller may inspect
+        :attr:`last_used_proxy_aware` and :attr:`last_compat_rejected`
+        to learn whether the dedicated solver proxy was applied (drives
+        cost-counter pricing tier and ``solver_confidence`` downgrades).
         """
+        # Reset the per-call metadata up front so a short-circuit return
+        # (unreachable / breaker) doesn't carry stale flags into the
+        # caller's envelope.
+        self.last_used_proxy_aware = False
+        self.last_compat_rejected = False
+
         # Per-process gate — runs at most once even under concurrent solves.
         await self._ensure_health_checked()
 
@@ -869,10 +1196,16 @@ class CaptchaSolver:
             await self._record_solver_outcome(success=False)
             return False
 
+        # §11.2 — load the dedicated solver-proxy config (NOT the agent's
+        # primary egress proxy; see ``get_solver_proxy_config`` docstring).
+        # Loader returns ``None`` when unset → proxyless task types.
+        proxy_config = get_solver_proxy_config(agent_id=agent_id)
+
         try:
-            token = await asyncio.wait_for(
+            token, used_proxy_aware, compat_rejected = await asyncio.wait_for(
                 self._submit_and_poll(
-                    captcha_type, sitekey, page_url, page_action=page_action,
+                    captcha_type, sitekey, page_url,
+                    page_action=page_action, proxy_config=proxy_config,
                 ),
                 timeout=_SOLVE_TIMEOUT,
             )
@@ -885,13 +1218,22 @@ class CaptchaSolver:
             await self._record_solver_outcome(success=False)
             return False
 
+        # Stamp metadata before returning so the caller can read the
+        # actual task type that was sent.
+        self.last_used_proxy_aware = used_proxy_aware
+        self.last_compat_rejected = compat_rejected
+
         if not token:
             await self._record_solver_outcome(success=False)
             return False
 
         injected = await self._inject_token(page, captcha_type, token)
         if injected:
-            logger.info("CAPTCHA solved and token injected successfully")
+            logger.info(
+                "CAPTCHA solved and token injected successfully "
+                "(proxy_aware=%s compat_rejected=%s)",
+                used_proxy_aware, compat_rejected,
+            )
         else:
             logger.warning("CAPTCHA solved but token injection failed")
         await self._record_solver_outcome(success=injected)
@@ -954,7 +1296,8 @@ class CaptchaSolver:
         page_url: str,
         *,
         page_action: str | None = None,
-    ) -> str | None:
+        proxy_config: SolverProxyConfig | None = None,
+    ) -> tuple[str | None, bool, bool]:
         """Submit CAPTCHA to solving service and poll for result.
 
         ``page_action`` is the v3 action string from the classifier; it's
@@ -962,13 +1305,19 @@ class CaptchaSolver:
         variants ignore it. ``min_score`` is read inside the per-provider
         helpers from :data:`CAPTCHA_RECAPTCHA_V3_MIN_SCORE` (operator
         config, not a page property).
+
+        Returns ``(token, used_proxy_aware, compat_rejected)`` so the
+        caller (``solve``) can mark the envelope's confidence and inform
+        the cost counter whether proxy-aware pricing applies.
         """
         if self.provider == "2captcha":
             return await self._solve_2captcha(
-                captcha_type, sitekey, page_url, page_action=page_action,
+                captcha_type, sitekey, page_url,
+                page_action=page_action, proxy_config=proxy_config,
             )
         return await self._solve_capsolver(
-            captcha_type, sitekey, page_url, page_action=page_action,
+            captcha_type, sitekey, page_url,
+            page_action=page_action, proxy_config=proxy_config,
         )
 
     # ── Task-body builder ─────────────────────────────────────────────────────
@@ -981,26 +1330,62 @@ class CaptchaSolver:
         page_url: str,
         *,
         page_action: str | None,
-    ) -> dict | None:
-        """Merge provider task-type fields with v3-specific extras.
+        proxy_config: SolverProxyConfig | None = None,
+        provider_name: str | None = None,
+    ) -> tuple[dict | None, bool, bool]:
+        """Merge provider task-type fields with v3 + proxy extras.
 
-        Returns ``None`` if ``captcha_type`` isn't in the provider table
-        (caller treats as "unsupported"). For v3 and v3-enterprise the
-        function reads the operator-configured ``CAPTCHA_RECAPTCHA_V3_MIN_SCORE``
-        flag (default 0.7) and applies the permissive ``"verify"`` fallback
-        when ``page_action`` is missing — see :data:`_DEFAULT_V3_ACTION`
-        for the rationale.
+        Returns ``(body, used_proxy_aware, compat_rejected)``:
+
+        * ``body`` is the JSON ``task`` dict, or ``None`` if
+          ``captcha_type`` isn't in the provider table (caller treats as
+          "unsupported").
+        * ``used_proxy_aware`` is ``True`` iff the body uses the
+          ``proxy_aware`` task name and includes the ``proxyType/...``
+          credential fields. ``False`` for the proxyless fallback.
+        * ``compat_rejected`` is ``True`` iff a proxy was configured but
+          the (provider, variant, type) tuple was rejected by
+          :data:`_SOLVER_PROXY_COMPAT`. Callers that get back
+          ``(body, False, True)`` should still send the proxyless body
+          AND set ``solver_confidence="low"`` on the envelope so the
+          operator sees that the dedicated proxy isn't being honored
+          for this variant.
+
+        For v3 and v3-enterprise the function reads the operator-configured
+        ``CAPTCHA_RECAPTCHA_V3_MIN_SCORE`` flag (default 0.7) and applies
+        the permissive ``"verify"`` fallback when ``page_action`` is
+        missing — see :data:`_DEFAULT_V3_ACTION` for the rationale.
+
+        SECURITY: ``proxy_config`` MUST be a :class:`SolverProxyConfig`
+        loaded via :func:`get_solver_proxy_config` from the dedicated
+        ``CAPTCHA_SOLVER_PROXY_*`` env-var family. The agent's primary
+        egress proxy (per-agent state in
+        ``BrowserManager._proxy_configs``) is NEVER threaded into this
+        path — see ``test_captcha_solver_proxy.py::test_primary_proxy_creds_never_leak``.
         """
         entry = provider_table.get(captcha_type)
         if not entry:
-            return None
+            return None, False, False
+        # Tolerate the legacy flat shape (``{"type": ..., "isInvisible": ...}``)
+        # in case third-party subclasses haven't migrated. The §11.2 shape
+        # is ``{"proxyless": ..., "proxy_aware": ..., "extra": {...}}``.
+        if "proxyless" in entry:
+            proxyless_name = entry.get("proxyless")
+            proxy_aware_name = entry.get("proxy_aware")
+            static_extras = dict(entry.get("extra") or {})
+        else:
+            proxyless_name = entry.get("type")
+            proxy_aware_name = None
+            static_extras = {k: v for k, v in entry.items() if k != "type"}
+
         body: dict[str, object] = {
             "websiteURL": page_url,
             "websiteKey": sitekey,
         }
-        # Merge static extras (``isInvisible``, ``isEnterprise``, ``type``).
-        for k, v in entry.items():
+        # Merge static extras (``isInvisible``, ``isEnterprise``).
+        for k, v in static_extras.items():
             body[k] = v
+
         # v3 extras — applied to both standard and enterprise v3 task entries.
         is_v3 = captcha_type in ("recaptcha-v3", "recaptcha-enterprise-v3")
         if is_v3:
@@ -1031,7 +1416,53 @@ class CaptchaSolver:
                 )
                 action = _DEFAULT_V3_ACTION
             body["pageAction"] = action
-        return body
+
+        # ── §11.2 proxy-aware selection ────────────────────────────────
+        used_proxy_aware = False
+        compat_rejected = False
+        provider = (provider_name or self.provider).lower()
+        if proxy_config is not None:
+            if proxy_aware_name is None:
+                # No documented proxy-aware task for this variant
+                # (e.g. 2captcha v3). Fall back to proxyless and treat
+                # as a soft compat rejection so the envelope reflects
+                # reduced confidence.
+                compat_rejected = True
+                logger.warning(
+                    "Solver proxy configured but provider=%s has no "
+                    "documented proxy-aware task for variant=%s — "
+                    "falling back to proxyless task type. "
+                    "solver_confidence will be downgraded.",
+                    provider, captcha_type,
+                )
+            elif _solver_proxy_compatible(
+                provider, captcha_type, proxy_config.proxy_type,
+            ):
+                used_proxy_aware = True
+                body["type"] = proxy_aware_name
+                # Inject credential fields into the task body.
+                body.update(proxy_config.to_request_fields())
+            else:
+                compat_rejected = True
+                logger.warning(
+                    "Solver proxy type=%s not in compat-table for "
+                    "provider=%s variant=%s — falling back to proxyless. "
+                    "solver_confidence will be downgraded. Configure a "
+                    "different proxy scheme (compat: %s) or accept "
+                    "proxyless for this variant.",
+                    proxy_config.proxy_type, provider, captcha_type,
+                    sorted(_SOLVER_PROXY_COMPAT.get(
+                        (provider, captcha_type), set(),
+                    )),
+                )
+
+        if not used_proxy_aware:
+            if not proxyless_name:
+                # Defensive — every entry should declare a proxyless name.
+                return None, False, compat_rejected
+            body["type"] = proxyless_name
+
+        return body, used_proxy_aware, compat_rejected
 
     # ── 2Captcha ──────────────────────────────────────────────────────────────
 
@@ -1042,14 +1473,16 @@ class CaptchaSolver:
         page_url: str,
         *,
         page_action: str | None = None,
-    ) -> str | None:
+        proxy_config: SolverProxyConfig | None = None,
+    ) -> tuple[str | None, bool, bool]:
         client = self._get_client()
-        task = self._build_task_body(
+        task, used_proxy_aware, compat_rejected = self._build_task_body(
             _2CAPTCHA_TASK_TYPES, captcha_type, sitekey, page_url,
-            page_action=page_action,
+            page_action=page_action, proxy_config=proxy_config,
+            provider_name="2captcha",
         )
         if not task:
-            return None
+            return None, used_proxy_aware, compat_rejected
 
         # Submit task
         payload = {
@@ -1069,16 +1502,16 @@ class CaptchaSolver:
                 "2Captcha createTask failed: %s",
                 _redact_clientkey_text(redact_url(str(e))),
             )
-            return None
+            return None, used_proxy_aware, compat_rejected
         if data.get("errorId", 0) != 0:
             logger.warning(
                 "2Captcha submit error: %s",
                 _redact_clientkey_text(str(data.get("errorDescription"))),
             )
-            return None
+            return None, used_proxy_aware, compat_rejected
         task_id = data.get("taskId")
         if not task_id:
-            return None
+            return None, used_proxy_aware, compat_rejected
 
         # Poll for result
         for _ in range(int(_SOLVE_TIMEOUT / _POLL_INTERVAL)):
@@ -1095,18 +1528,19 @@ class CaptchaSolver:
                     "2Captcha getTaskResult failed: %s",
                     _redact_clientkey_text(redact_url(str(e))),
                 )
-                return None
+                return None, used_proxy_aware, compat_rejected
             if data.get("errorId", 0) != 0:
                 logger.warning(
                     "2Captcha poll error: %s",
                     _redact_clientkey_text(str(data.get("errorDescription"))),
                 )
-                return None
+                return None, used_proxy_aware, compat_rejected
             if data.get("status") == "ready":
                 solution = data.get("solution", {})
-                return solution.get("gRecaptchaResponse") or solution.get("token")
+                token = solution.get("gRecaptchaResponse") or solution.get("token")
+                return token, used_proxy_aware, compat_rejected
             # status == "processing" — keep polling
-        return None
+        return None, used_proxy_aware, compat_rejected
 
     # ── CapSolver ─────────────────────────────────────────────────────────────
 
@@ -1117,14 +1551,16 @@ class CaptchaSolver:
         page_url: str,
         *,
         page_action: str | None = None,
-    ) -> str | None:
+        proxy_config: SolverProxyConfig | None = None,
+    ) -> tuple[str | None, bool, bool]:
         client = self._get_client()
-        task = self._build_task_body(
+        task, used_proxy_aware, compat_rejected = self._build_task_body(
             _CAPSOLVER_TASK_TYPES, captcha_type, sitekey, page_url,
-            page_action=page_action,
+            page_action=page_action, proxy_config=proxy_config,
+            provider_name="capsolver",
         )
         if not task:
-            return None
+            return None, used_proxy_aware, compat_rejected
 
         # Submit task
         payload = {
@@ -1140,16 +1576,16 @@ class CaptchaSolver:
                 "CapSolver createTask failed: %s",
                 _redact_clientkey_text(redact_url(str(e))),
             )
-            return None
+            return None, used_proxy_aware, compat_rejected
         if data.get("errorId", 0) != 0:
             logger.warning(
                 "CapSolver submit error: %s",
                 _redact_clientkey_text(str(data.get("errorDescription"))),
             )
-            return None
+            return None, used_proxy_aware, compat_rejected
         task_id = data.get("taskId")
         if not task_id:
-            return None
+            return None, used_proxy_aware, compat_rejected
 
         # Poll for result
         for _ in range(int(_SOLVE_TIMEOUT / _POLL_INTERVAL)):
@@ -1166,17 +1602,18 @@ class CaptchaSolver:
                     "CapSolver getTaskResult failed: %s",
                     _redact_clientkey_text(redact_url(str(e))),
                 )
-                return None
+                return None, used_proxy_aware, compat_rejected
             if data.get("errorId", 0) != 0:
                 logger.warning(
                     "CapSolver poll error: %s",
                     _redact_clientkey_text(str(data.get("errorDescription"))),
                 )
-                return None
+                return None, used_proxy_aware, compat_rejected
             if data.get("status") == "ready":
                 solution = data.get("solution", {})
-                return solution.get("gRecaptchaResponse") or solution.get("token")
-        return None
+                token = solution.get("gRecaptchaResponse") or solution.get("token")
+                return token, used_proxy_aware, compat_rejected
+        return None, used_proxy_aware, compat_rejected
 
     # ── Token injection ───────────────────────────────────────────────────────
 

--- a/src/browser/captcha_cost_counter.py
+++ b/src/browser/captcha_cost_counter.py
@@ -47,10 +47,18 @@ def _state_path() -> Path:
 
 
 # Published rates from 2captcha + CapSolver (April 2026), in US cents per
-# successful solve. Keys follow the convention ``{provider}-{variant}`` so a
-# future per-variant pricing tier (§11.1 reCAPTCHA v3 / Enterprise) can land
-# without re-keying. When a kind isn't priced, callers SKIP counting rather
-# than guessing — under-count > over-count for operator trust.
+# successful solve. Keys follow the convention ``{provider}-{variant}`` for
+# the proxyless tier; the proxy-aware tier uses a 3-tuple key
+# ``(provider, variant, proxy_aware=True)`` and lives in
+# :data:`PRICING_CENTS_PROXY_AWARE` below.
+#
+# Why two tables? Provider docs publish proxyless rates in a single line
+# but proxy-aware rates as "approximately 3× the base" in their pricing
+# pages. Keeping the dicts separate keeps the §11.1 string-key surface
+# untouched while letting §11.2's tuple-key path coexist.
+#
+# When a kind isn't priced, callers SKIP counting rather than guessing —
+# under-count > over-count for operator trust.
 PRICING_CENTS: dict[str, int] = {
     # 2Captcha — published https://2captcha.com/2captcha-api#solving_recaptchav2_new
     "2captcha-recaptcha-v2-checkbox": 100,        # $1.00 / 1000 = 0.10c each → 0.1¢
@@ -76,9 +84,45 @@ PRICING_CENTS: dict[str, int] = {
     "capsolver-turnstile": 60,
 }
 
+# §11.2 — proxy-aware pricing tier (~3× the proxyless rate as published
+# by both providers). Tuple key ``(provider, variant)``; ``proxy_aware``
+# flag at lookup time picks this table over :data:`PRICING_CENTS`.
+#
+# 2captcha v3 has no documented proxy-aware task type as of April 2026,
+# so its proxy-aware entries are intentionally absent — :func:`estimate_cents`
+# falls through to the proxyless price for those (the body builder
+# already falls back to proxyless when no proxy_aware task is documented,
+# so paying proxyless rate matches what the provider sees).
+PRICING_CENTS_PROXY_AWARE: dict[tuple[str, str], int] = {
+    # 2captcha — 3× the proxyless rate
+    ("2captcha", "recaptcha-v2-checkbox"):    300,
+    ("2captcha", "recaptcha-v2-invisible"):   300,
+    ("2captcha", "recaptcha-enterprise-v2"):  600,
+    ("2captcha", "hcaptcha"):                 300,
+    ("2captcha", "turnstile"):                600,
+    # CapSolver — 3× the proxyless rate
+    ("capsolver", "recaptcha-v2-checkbox"):   240,
+    ("capsolver", "recaptcha-v2-invisible"):  240,
+    ("capsolver", "recaptcha-v3"):            240,
+    ("capsolver", "recaptcha-enterprise-v2"): 600,
+    ("capsolver", "recaptcha-enterprise-v3"): 600,
+    ("capsolver", "hcaptcha"):                300,
+    ("capsolver", "turnstile"):               180,
+}
 
-def estimate_cents(provider: str, kind: str) -> int | None:
+
+def estimate_cents(
+    provider: str, kind: str, *, proxy_aware: bool = False,
+) -> int | None:
     """Return published cost (cents) for one successful solve, or ``None``.
+
+    ``proxy_aware=True`` consults :data:`PRICING_CENTS_PROXY_AWARE` first
+    (~3× the proxyless rate). When the proxy-aware table doesn't have a
+    row for the (provider, variant) tuple — e.g. 2captcha v3, where the
+    provider has no documented proxy-aware task type — we fall through to
+    the proxyless rate. That matches what the body builder did at the
+    request layer (proxyless task body), so the price billed equals the
+    request type sent.
 
     ``None`` signals the variant isn't priced; callers should log a warning
     and SKIP the increment rather than attribute a guess to the agent's
@@ -90,7 +134,15 @@ def estimate_cents(provider: str, kind: str) -> int | None:
     """
     if not provider or not kind:
         return None
-    key = f"{provider.strip().lower()}-{kind.strip().lower()}"
+    p = provider.strip().lower()
+    k = kind.strip().lower()
+    if proxy_aware:
+        cents = PRICING_CENTS_PROXY_AWARE.get((p, k))
+        if cents is not None:
+            return cents
+        # Fall through to the proxyless rate — the body builder degraded
+        # to proxyless for this variant, so the price tier matches.
+    key = f"{p}-{k}"
     return PRICING_CENTS.get(key)
 
 

--- a/src/browser/service.py
+++ b/src/browser/service.py
@@ -5695,6 +5695,7 @@ class BrowserManager:
                         try:
                             solved = await self._captcha_solver.solve(
                                 inst.page, sel, inst.page.url,
+                                agent_id=inst.agent_id,
                             )
                         except asyncio.TimeoutError:
                             # Solver took too long — true "timeout" semantic.
@@ -5734,10 +5735,30 @@ class BrowserManager:
                                 next_action="notify_user",
                             ))
                         if solved:
+                            # §11.2 — when the solver-proxy compat table
+                            # rejected the configured proxy for this
+                            # variant, we sent the proxyless task body
+                            # instead. The solve still succeeded, but the
+                            # operator's chosen IP profile didn't reach
+                            # the provider — signal "low" confidence so
+                            # downstream consumers can surface "the token
+                            # came from the provider's pool, not yours".
+                            # Strict ``is True`` so test mocks that
+                            # auto-spec attrs as MagicMocks (truthy) don't
+                            # accidentally trip the downgrade. The §11.3
+                            # ``_finalize`` helper still applies on top —
+                            # CF-Turnstile force-low override converges
+                            # naturally with the compat-rejected downgrade.
+                            confidence = "high"
+                            if getattr(
+                                self._captcha_solver,
+                                "last_compat_rejected", False,
+                            ) is True:
+                                confidence = "low"
                             return _finalize(_captcha_envelope(
                                 kind=kind, solver_attempted=True,
                                 solver_outcome="solved",
-                                solver_confidence="high",
+                                solver_confidence=confidence,
                                 next_action="solved",
                             ))
                         # solver.solve() returned False. Today this conflates
@@ -5999,21 +6020,35 @@ class BrowserManager:
                 inst._last_solve_attempt = ("", page_url, time.time())
 
                 # Cost accounting on success: look up published rate by
-                # (provider, kind) and increment. Skip when unpriced
-                # rather than guess (under-count > over-count for trust).
+                # (provider, kind, proxy_aware) and increment. Skip when
+                # unpriced rather than guess (under-count > over-count
+                # for trust). §11.2: ``proxy_aware`` is read from the
+                # solver's last-call metadata so we bill the tier that
+                # was actually sent (proxy-aware ~3× the proxyless rate).
                 if pre_check.get("solver_outcome") == "solved":
                     provider = ""
+                    proxy_aware_flag = False
                     if self._captcha_solver is not None:
                         provider = getattr(self._captcha_solver, "provider", "")
+                        # Strict ``is True`` so AsyncMock attrs (truthy
+                        # MagicMock instances) don't promote the price tier.
+                        proxy_aware_flag = getattr(
+                            self._captcha_solver,
+                            "last_used_proxy_aware",
+                            False,
+                        ) is True
                     if provider:
                         from src.browser import captcha_cost_counter as _cost
-                        cents = _cost.estimate_cents(provider, kind)
+                        cents = _cost.estimate_cents(
+                            provider, kind, proxy_aware=proxy_aware_flag,
+                        )
                         if cents is None:
                             logger.warning(
                                 "captcha solve: no published rate for "
-                                "provider=%s kind=%s — skipping cost "
-                                "increment (under-count > over-count)",
-                                provider, kind,
+                                "provider=%s kind=%s proxy_aware=%s — "
+                                "skipping cost increment "
+                                "(under-count > over-count)",
+                                provider, kind, proxy_aware_flag,
                             )
                         else:
                             await _cost.add_cost(agent_id, cents)

--- a/tests/test_captcha_recaptcha_classifier.py
+++ b/tests/test_captcha_recaptcha_classifier.py
@@ -351,52 +351,67 @@ class TestTaskTypeTables:
     ``RecaptchaV3EnterpriseTaskProxyless`` type).
     """
 
+    # §11.2 reshaped each entry to ``{"proxyless": ..., "proxy_aware": ...,
+    # "extra": {...}}`` so the body builder can pick a proxy-aware task name
+    # when a dedicated solver proxy is configured. The proxyless name (the
+    # one that goes to the provider when no proxy config is set) is what
+    # these tests assert.
+
     def test_2captcha_v2_checkbox(self):
         entry = _2CAPTCHA_TASK_TYPES["recaptcha-v2-checkbox"]
-        assert entry["type"] == "RecaptchaV2TaskProxyless"
-        assert "isInvisible" not in entry
-        assert "isEnterprise" not in entry
+        assert entry["proxyless"] == "RecaptchaV2TaskProxyless"
+        assert entry["proxy_aware"] == "RecaptchaV2Task"
+        assert entry["extra"] == {}
 
     def test_2captcha_v2_invisible(self):
         entry = _2CAPTCHA_TASK_TYPES["recaptcha-v2-invisible"]
-        assert entry["type"] == "RecaptchaV2TaskProxyless"
-        assert entry["isInvisible"] is True
+        assert entry["proxyless"] == "RecaptchaV2TaskProxyless"
+        assert entry["proxy_aware"] == "RecaptchaV2Task"
+        assert entry["extra"] == {"isInvisible": True}
 
     def test_2captcha_v3(self):
         entry = _2CAPTCHA_TASK_TYPES["recaptcha-v3"]
-        assert entry["type"] == "RecaptchaV3TaskProxyless"
+        assert entry["proxyless"] == "RecaptchaV3TaskProxyless"
+        # 2captcha has no documented proxy-aware v3 task as of April 2026.
+        assert entry["proxy_aware"] is None
 
     def test_2captcha_enterprise_v2(self):
         entry = _2CAPTCHA_TASK_TYPES["recaptcha-enterprise-v2"]
-        assert entry["type"] == "RecaptchaV2EnterpriseTaskProxyless"
+        assert entry["proxyless"] == "RecaptchaV2EnterpriseTaskProxyless"
+        assert entry["proxy_aware"] == "RecaptchaV2EnterpriseTask"
 
     def test_2captcha_enterprise_v3_uses_v3_with_flag(self):
         """2captcha drift: no standalone v3-Enterprise task; flag instead."""
         entry = _2CAPTCHA_TASK_TYPES["recaptcha-enterprise-v3"]
-        assert entry["type"] == "RecaptchaV3TaskProxyless"
-        assert entry["isEnterprise"] is True
+        assert entry["proxyless"] == "RecaptchaV3TaskProxyless"
+        assert entry["extra"] == {"isEnterprise": True}
 
     def test_capsolver_v2_checkbox(self):
         entry = _CAPSOLVER_TASK_TYPES["recaptcha-v2-checkbox"]
-        assert entry["type"] == "ReCaptchaV2TaskProxyLess"
-        assert "isInvisible" not in entry
+        assert entry["proxyless"] == "ReCaptchaV2TaskProxyLess"
+        assert entry["proxy_aware"] == "ReCaptchaV2Task"
+        assert entry["extra"] == {}
 
     def test_capsolver_v2_invisible(self):
         entry = _CAPSOLVER_TASK_TYPES["recaptcha-v2-invisible"]
-        assert entry["type"] == "ReCaptchaV2TaskProxyLess"
-        assert entry["isInvisible"] is True
+        assert entry["proxyless"] == "ReCaptchaV2TaskProxyLess"
+        assert entry["proxy_aware"] == "ReCaptchaV2Task"
+        assert entry["extra"] == {"isInvisible": True}
 
     def test_capsolver_v3(self):
         entry = _CAPSOLVER_TASK_TYPES["recaptcha-v3"]
-        assert entry["type"] == "ReCaptchaV3TaskProxyLess"
+        assert entry["proxyless"] == "ReCaptchaV3TaskProxyLess"
+        assert entry["proxy_aware"] == "ReCaptchaV3Task"
 
     def test_capsolver_enterprise_v2(self):
         entry = _CAPSOLVER_TASK_TYPES["recaptcha-enterprise-v2"]
-        assert entry["type"] == "ReCaptchaV2EnterpriseTaskProxyLess"
+        assert entry["proxyless"] == "ReCaptchaV2EnterpriseTaskProxyLess"
+        assert entry["proxy_aware"] == "ReCaptchaV2EnterpriseTask"
 
     def test_capsolver_enterprise_v3(self):
         entry = _CAPSOLVER_TASK_TYPES["recaptcha-enterprise-v3"]
-        assert entry["type"] == "ReCaptchaV3EnterpriseTaskProxyLess"
+        assert entry["proxyless"] == "ReCaptchaV3EnterpriseTaskProxyLess"
+        assert entry["proxy_aware"] == "ReCaptchaV3EnterpriseTask"
 
 
 # ── 9. Task-body merger ───────────────────────────────────────────────────
@@ -412,9 +427,15 @@ class TestTaskBodyMerger:
         # CaptchaSolver's __init__ does no I/O, so we can build directly.
         return CaptchaSolver(provider="2captcha", api_key="test")
 
+    # §11.2 changed ``_build_task_body`` to return
+    # ``(body, used_proxy_aware, compat_rejected)``. These tests cover the
+    # no-proxy-config path so the second/third tuple slots are always
+    # ``(False, False)``; the proxy-aware path is covered separately in
+    # ``tests/test_captcha_solver_proxy.py``.
+
     def test_v2_checkbox_body_has_no_v3_fields(self):
         s = self._solver()
-        body = s._build_task_body(
+        body, used_proxy_aware, compat_rejected = s._build_task_body(
             _2CAPTCHA_TASK_TYPES, "recaptcha-v2-checkbox",
             "SITEKEY", "https://example.com",
             page_action=None,
@@ -424,10 +445,12 @@ class TestTaskBodyMerger:
         assert body["websiteKey"] == "SITEKEY"
         assert "minScore" not in body
         assert "pageAction" not in body
+        assert used_proxy_aware is False
+        assert compat_rejected is False
 
     def test_v2_invisible_body_has_invisible_flag(self):
         s = self._solver()
-        body = s._build_task_body(
+        body, _, _ = s._build_task_body(
             _CAPSOLVER_TASK_TYPES, "recaptcha-v2-invisible",
             "SITEKEY", "https://example.com",
             page_action=None,
@@ -438,7 +461,7 @@ class TestTaskBodyMerger:
 
     def test_v3_body_has_min_score_and_action(self):
         s = self._solver()
-        body = s._build_task_body(
+        body, _, _ = s._build_task_body(
             _2CAPTCHA_TASK_TYPES, "recaptcha-v3",
             "SITEKEY", "https://example.com",
             page_action="checkout",
@@ -449,7 +472,7 @@ class TestTaskBodyMerger:
 
     def test_v3_body_action_falls_back_to_verify(self):
         s = self._solver()
-        body = s._build_task_body(
+        body, _, _ = s._build_task_body(
             _2CAPTCHA_TASK_TYPES, "recaptcha-v3",
             "SITEKEY", "https://example.com",
             page_action=None,
@@ -458,7 +481,7 @@ class TestTaskBodyMerger:
 
     def test_enterprise_v3_body_has_isEnterprise_and_v3_extras(self):
         s = self._solver()
-        body = s._build_task_body(
+        body, _, _ = s._build_task_body(
             _2CAPTCHA_TASK_TYPES, "recaptcha-enterprise-v3",
             "SITEKEY", "https://example.com",
             page_action="submit",
@@ -470,7 +493,7 @@ class TestTaskBodyMerger:
 
     def test_enterprise_v2_body_no_v3_fields(self):
         s = self._solver()
-        body = s._build_task_body(
+        body, _, _ = s._build_task_body(
             _2CAPTCHA_TASK_TYPES, "recaptcha-enterprise-v2",
             "SITEKEY", "https://example.com",
             page_action=None,
@@ -481,7 +504,7 @@ class TestTaskBodyMerger:
 
     def test_unknown_variant_returns_none(self):
         s = self._solver()
-        body = s._build_task_body(
+        body, _, _ = s._build_task_body(
             _2CAPTCHA_TASK_TYPES, "no-such-variant",
             "SITEKEY", "https://example.com",
             page_action=None,
@@ -494,7 +517,7 @@ class TestTaskBodyMerger:
         # flags loader caches; force re-read.
         from src.browser import flags as _flags
         _flags.reload_operator_settings()
-        body = s._build_task_body(
+        body, _, _ = s._build_task_body(
             _CAPSOLVER_TASK_TYPES, "recaptcha-v3",
             "SITEKEY", "https://example.com",
             page_action="x",
@@ -507,7 +530,7 @@ class TestTaskBodyMerger:
         monkeypatch.setenv("CAPTCHA_RECAPTCHA_V3_MIN_SCORE", "5.0")
         from src.browser import flags as _flags
         _flags.reload_operator_settings()
-        body = s._build_task_body(
+        body, _, _ = s._build_task_body(
             _2CAPTCHA_TASK_TYPES, "recaptcha-v3",
             "SITEKEY", "https://example.com",
             page_action="x",

--- a/tests/test_captcha_solver_proxy.py
+++ b/tests/test_captcha_solver_proxy.py
@@ -1,0 +1,733 @@
+"""Tests for §11.2 proxy-aware solver tasks with credential isolation.
+
+Covers:
+  * :func:`src.browser.captcha.get_solver_proxy_config` — env-var loader.
+  * :data:`src.browser.captcha._SOLVER_PROXY_COMPAT` — provider/variant
+    compatibility table.
+  * :meth:`CaptchaSolver._build_task_body` — proxy-aware vs proxyless
+    task-name selection and credential injection.
+  * :func:`src.browser.captcha_cost_counter.estimate_cents` —
+    ``proxy_aware`` flag pricing tier.
+  * **Credential-leak canary** — exercises a full solve with a mocked
+    httpx client and asserts the agent's primary egress proxy creds
+    NEVER appear in any outbound request to the solver provider.
+
+Threat model (the canary test enforces this):
+    The agent's primary egress proxy (per-agent state in
+    ``BrowserManager._proxy_configs``) is a residential / datacenter
+    IP we paid for to scrape from. Forwarding those credentials to a
+    third-party CAPTCHA solver would be a direct credential-leak vector
+    — the solver could exfiltrate, log, or rotate them. §11.2 requires
+    a SEPARATE ``CAPTCHA_SOLVER_PROXY_*`` env-var family for the solver-
+    side proxy; the agent's primary creds MUST never reach the solver.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import httpx
+import pytest
+
+from src.browser import captcha as cap
+from src.browser import captcha_cost_counter as cost
+from src.browser.captcha import (
+    _2CAPTCHA_TASK_TYPES,
+    _CAPSOLVER_TASK_TYPES,
+    _SOLVER_PROXY_COMPAT,
+    CaptchaSolver,
+    SolverProxyConfig,
+    _normalize_proxy_type,
+    _solver_proxy_compatible,
+    get_solver_proxy_config,
+)
+
+# ── Shared fixtures ───────────────────────────────────────────────────────
+
+
+@pytest.fixture(autouse=True)
+def _isolate_flag_state(monkeypatch):
+    """Reset the once-per-session warning gate + flag overrides per test."""
+    cap._reset_proxy_config_warning()
+    # Clear every CAPTCHA_SOLVER_PROXY_* var so a previous test or the
+    # ambient shell environment can't leak through.
+    for name in (
+        "CAPTCHA_SOLVER_PROXY_TYPE",
+        "CAPTCHA_SOLVER_PROXY_ADDRESS",
+        "CAPTCHA_SOLVER_PROXY_PORT",
+        "CAPTCHA_SOLVER_PROXY_LOGIN",
+        "CAPTCHA_SOLVER_PROXY_PASSWORD",
+    ):
+        monkeypatch.delenv(name, raising=False)
+    # flags.py caches operator settings — reload after the env mutation.
+    from src.browser import flags as _flags
+    _flags.reload_operator_settings()
+    yield
+    cap._reset_proxy_config_warning()
+
+
+def _set_full_proxy_env(monkeypatch, *, type_="http"):
+    monkeypatch.setenv("CAPTCHA_SOLVER_PROXY_TYPE", type_)
+    monkeypatch.setenv("CAPTCHA_SOLVER_PROXY_ADDRESS", "10.0.0.1")
+    monkeypatch.setenv("CAPTCHA_SOLVER_PROXY_PORT", "8080")
+    monkeypatch.setenv("CAPTCHA_SOLVER_PROXY_LOGIN", "solver-user")
+    monkeypatch.setenv("CAPTCHA_SOLVER_PROXY_PASSWORD", "solver-pass")
+    from src.browser import flags as _flags
+    _flags.reload_operator_settings()
+
+
+# ── 1. Loader: env-var → SolverProxyConfig ────────────────────────────────
+
+
+class TestLoader:
+    def test_unset_returns_none(self):
+        assert get_solver_proxy_config() is None
+
+    def test_full_config_returns_struct(self, monkeypatch):
+        _set_full_proxy_env(monkeypatch, type_="socks5")
+        cfg = get_solver_proxy_config()
+        assert cfg is not None
+        assert cfg.proxy_type == "socks5"
+        assert cfg.address == "10.0.0.1"
+        assert cfg.port == 8080
+        assert cfg.login == "solver-user"
+        assert cfg.password == "solver-pass"
+
+    def test_partial_config_returns_none_with_warning(self, monkeypatch, caplog):
+        # TYPE set but address missing.
+        monkeypatch.setenv("CAPTCHA_SOLVER_PROXY_TYPE", "http")
+        monkeypatch.setenv("CAPTCHA_SOLVER_PROXY_PORT", "8080")
+        monkeypatch.setenv("CAPTCHA_SOLVER_PROXY_LOGIN", "u")
+        monkeypatch.setenv("CAPTCHA_SOLVER_PROXY_PASSWORD", "p")
+        from src.browser import flags as _flags
+        _flags.reload_operator_settings()
+        with caplog.at_level("WARNING", logger="browser.captcha"):
+            cfg = get_solver_proxy_config()
+        assert cfg is None
+        # A single warning at the once-per-session cadence — the message
+        # MUST mention the missing field name so operators can fix it.
+        assert any("CAPTCHA_SOLVER_PROXY_ADDRESS" in r.message for r in caplog.records)
+
+    def test_warning_only_logged_once_per_session(self, monkeypatch, caplog):
+        monkeypatch.setenv("CAPTCHA_SOLVER_PROXY_TYPE", "http")
+        from src.browser import flags as _flags
+        _flags.reload_operator_settings()
+        with caplog.at_level("WARNING", logger="browser.captcha"):
+            assert get_solver_proxy_config() is None
+            assert get_solver_proxy_config() is None
+            assert get_solver_proxy_config() is None
+        warns = [
+            r for r in caplog.records
+            if "CAPTCHA_SOLVER_PROXY" in r.message
+        ]
+        # Exactly one per-process warning, not per call.
+        assert len(warns) == 1
+
+    def test_socks5h_normalizes_to_socks5(self, monkeypatch):
+        _set_full_proxy_env(monkeypatch, type_="socks5h://")
+        cfg = get_solver_proxy_config()
+        assert cfg is not None
+        assert cfg.proxy_type == "socks5"
+
+    def test_socks5h_bare_normalizes_to_socks5(self, monkeypatch):
+        _set_full_proxy_env(monkeypatch, type_="socks5h")
+        cfg = get_solver_proxy_config()
+        assert cfg is not None
+        assert cfg.proxy_type == "socks5"
+
+    def test_uppercase_normalizes(self, monkeypatch):
+        _set_full_proxy_env(monkeypatch, type_="HTTPS")
+        cfg = get_solver_proxy_config()
+        assert cfg is not None
+        assert cfg.proxy_type == "https"
+
+    def test_bad_scheme_returns_none(self, monkeypatch, caplog):
+        # ``ftp`` is obviously not a proxy scheme we accept.
+        _set_full_proxy_env(monkeypatch, type_="ftp")
+        with caplog.at_level("WARNING", logger="browser.captcha"):
+            cfg = get_solver_proxy_config()
+        assert cfg is None
+        assert any("not in" in r.message.lower() for r in caplog.records)
+
+    def test_url_style_with_creds_rejected(self, monkeypatch):
+        # The TYPE field is a scheme keyword, not a URL. Stripping ``://``
+        # is a kindness for ``socks5h://`` but ``http://user:pass@host``
+        # mid-stream would still leave ``http`` after the split, which is
+        # correct — we only validate the scheme bit.
+        _set_full_proxy_env(monkeypatch, type_="http://malicious")
+        cfg = get_solver_proxy_config()
+        assert cfg is not None
+        assert cfg.proxy_type == "http"
+
+    def test_invalid_port_returns_none(self, monkeypatch, caplog):
+        monkeypatch.setenv("CAPTCHA_SOLVER_PROXY_TYPE", "http")
+        monkeypatch.setenv("CAPTCHA_SOLVER_PROXY_ADDRESS", "10.0.0.1")
+        monkeypatch.setenv("CAPTCHA_SOLVER_PROXY_PORT", "not-a-number")
+        monkeypatch.setenv("CAPTCHA_SOLVER_PROXY_LOGIN", "u")
+        monkeypatch.setenv("CAPTCHA_SOLVER_PROXY_PASSWORD", "p")
+        from src.browser import flags as _flags
+        _flags.reload_operator_settings()
+        with caplog.at_level("WARNING", logger="browser.captcha"):
+            cfg = get_solver_proxy_config()
+        assert cfg is None
+
+    def test_out_of_range_port_returns_none(self, monkeypatch):
+        monkeypatch.setenv("CAPTCHA_SOLVER_PROXY_TYPE", "http")
+        monkeypatch.setenv("CAPTCHA_SOLVER_PROXY_ADDRESS", "10.0.0.1")
+        monkeypatch.setenv("CAPTCHA_SOLVER_PROXY_PORT", "70000")
+        monkeypatch.setenv("CAPTCHA_SOLVER_PROXY_LOGIN", "u")
+        monkeypatch.setenv("CAPTCHA_SOLVER_PROXY_PASSWORD", "p")
+        from src.browser import flags as _flags
+        _flags.reload_operator_settings()
+        cfg = get_solver_proxy_config()
+        assert cfg is None
+
+
+# ── 2. _normalize_proxy_type ──────────────────────────────────────────────
+
+
+class TestNormalizeProxyType:
+    @pytest.mark.parametrize("raw,expected", [
+        ("http", "http"),
+        ("https", "https"),
+        ("socks4", "socks4"),
+        ("socks5", "socks5"),
+        ("HTTP", "http"),
+        ("HTTPS", "https"),
+        ("socks5h", "socks5"),
+        ("socks5h://", "socks5"),
+        ("socks4a", "socks4"),
+        ("http://", "http"),
+        ("", None),
+        ("ftp", None),
+        ("gopher", None),
+        ("socks", None),  # bare "socks" not allowed
+    ])
+    def test_cases(self, raw, expected):
+        assert _normalize_proxy_type(raw) == expected
+
+
+# ── 3. Compatibility table ────────────────────────────────────────────────
+
+
+class TestCompatTable:
+    """Verify the hardcoded compat table matches provider docs (Apr 2026):
+
+    * 2captcha — RecaptchaV2Task / HCaptchaTask / TurnstileTask documented
+      proxy types: http, socks4, socks5 (no https). Source:
+      https://2captcha.com/api-docs/recaptcha-v2 (and equivalents).
+    * CapSolver — all proxy-aware tasks document http, https, socks4,
+      socks5. Source: https://docs.capsolver.com/en/guide/api-how-to-use-proxy/
+    """
+
+    def test_2captcha_v2_checkbox_no_https(self):
+        allowed = _SOLVER_PROXY_COMPAT[("2captcha", "recaptcha-v2-checkbox")]
+        assert "http" in allowed
+        assert "socks4" in allowed
+        assert "socks5" in allowed
+        assert "https" not in allowed
+
+    def test_2captcha_hcaptcha_no_https(self):
+        allowed = _SOLVER_PROXY_COMPAT[("2captcha", "hcaptcha")]
+        assert allowed == {"http", "socks4", "socks5"}
+
+    def test_2captcha_turnstile_no_https(self):
+        allowed = _SOLVER_PROXY_COMPAT[("2captcha", "turnstile")]
+        assert allowed == {"http", "socks4", "socks5"}
+
+    def test_capsolver_full_set(self):
+        allowed = _SOLVER_PROXY_COMPAT[("capsolver", "recaptcha-v2-checkbox")]
+        assert allowed == {"http", "https", "socks4", "socks5"}
+
+    def test_capsolver_v3_full_set(self):
+        allowed = _SOLVER_PROXY_COMPAT[("capsolver", "recaptcha-v3")]
+        assert allowed == {"http", "https", "socks4", "socks5"}
+
+    def test_2captcha_v3_absent(self):
+        """2captcha has no documented proxy-aware v3 task; the entry
+        should not exist (falls back to proxyless via task-table)."""
+        # The compat-table key is intentionally absent for variants where
+        # ``proxy_aware`` is None in the task-type table.
+        assert ("2captcha", "recaptcha-v3") not in _SOLVER_PROXY_COMPAT
+
+    def test_compatible_helper(self):
+        assert _solver_proxy_compatible(
+            "2captcha", "recaptcha-v2-checkbox", "http",
+        )
+        assert not _solver_proxy_compatible(
+            "2captcha", "recaptcha-v2-checkbox", "https",
+        )
+        assert _solver_proxy_compatible(
+            "capsolver", "hcaptcha", "https",
+        )
+
+    def test_compatible_helper_unknown_variant_false(self):
+        assert not _solver_proxy_compatible(
+            "2captcha", "made-up-variant", "http",
+        )
+
+
+# ── 4. Task-body builder: proxyless vs proxy-aware ────────────────────────
+
+
+class TestTaskBody:
+    def _solver(self, provider="2captcha"):
+        return CaptchaSolver(provider, api_key="test-key")
+
+    def test_proxyless_when_no_proxy_config(self):
+        s = self._solver()
+        body, used_proxy_aware, compat_rejected = s._build_task_body(
+            _2CAPTCHA_TASK_TYPES, "recaptcha-v2-checkbox",
+            "SITEKEY", "https://example.com",
+            page_action=None, proxy_config=None,
+        )
+        assert body is not None
+        assert body["type"] == "RecaptchaV2TaskProxyless"
+        assert "proxyType" not in body
+        assert "proxyAddress" not in body
+        assert used_proxy_aware is False
+        assert compat_rejected is False
+
+    def test_proxy_aware_when_compat_allows(self):
+        s = self._solver(provider="2captcha")
+        cfg = SolverProxyConfig(
+            proxy_type="socks5", address="10.0.0.1", port=8080,
+            login="u", password="p",
+        )
+        body, used_proxy_aware, compat_rejected = s._build_task_body(
+            _2CAPTCHA_TASK_TYPES, "recaptcha-v2-checkbox",
+            "SITEKEY", "https://example.com",
+            page_action=None, proxy_config=cfg,
+        )
+        assert body is not None
+        # Drop ``Proxyless`` suffix.
+        assert body["type"] == "RecaptchaV2Task"
+        assert body["proxyType"] == "socks5"
+        assert body["proxyAddress"] == "10.0.0.1"
+        assert body["proxyPort"] == 8080
+        assert body["proxyLogin"] == "u"
+        assert body["proxyPassword"] == "p"
+        assert used_proxy_aware is True
+        assert compat_rejected is False
+
+    def test_compat_rejected_falls_back_to_proxyless(self):
+        """2captcha + https is rejected by the compat table → proxyless +
+        compat_rejected=True."""
+        s = self._solver(provider="2captcha")
+        cfg = SolverProxyConfig(
+            proxy_type="https", address="10.0.0.1", port=8080,
+            login="u", password="p",
+        )
+        body, used_proxy_aware, compat_rejected = s._build_task_body(
+            _2CAPTCHA_TASK_TYPES, "recaptcha-v2-checkbox",
+            "SITEKEY", "https://example.com",
+            page_action=None, proxy_config=cfg,
+        )
+        assert body["type"] == "RecaptchaV2TaskProxyless"
+        # Critical: NO proxy fields in the body when compat rejects —
+        # we must NOT send https creds to a provider that rejects https.
+        assert "proxyType" not in body
+        assert "proxyAddress" not in body
+        assert "proxyPassword" not in body
+        assert used_proxy_aware is False
+        assert compat_rejected is True
+
+    def test_proxy_aware_no_documented_task_falls_back_to_proxyless(self):
+        """2captcha v3 has no proxy-aware task name → proxyless body
+        with compat_rejected=True so the envelope downgrades confidence."""
+        s = self._solver(provider="2captcha")
+        cfg = SolverProxyConfig(
+            proxy_type="http", address="10.0.0.1", port=8080,
+            login="u", password="p",
+        )
+        body, used_proxy_aware, compat_rejected = s._build_task_body(
+            _2CAPTCHA_TASK_TYPES, "recaptcha-v3",
+            "SITEKEY", "https://example.com",
+            page_action="checkout", proxy_config=cfg,
+        )
+        assert body["type"] == "RecaptchaV3TaskProxyless"
+        assert "proxyType" not in body
+        assert used_proxy_aware is False
+        assert compat_rejected is True
+
+    def test_capsolver_proxy_aware_with_https(self):
+        """CapSolver supports https — should use proxy-aware task name."""
+        s = self._solver(provider="capsolver")
+        cfg = SolverProxyConfig(
+            proxy_type="https", address="10.0.0.1", port=8080,
+            login="u", password="p",
+        )
+        body, used_proxy_aware, compat_rejected = s._build_task_body(
+            _CAPSOLVER_TASK_TYPES, "recaptcha-v3",
+            "SITEKEY", "https://example.com",
+            page_action="checkout", proxy_config=cfg,
+        )
+        assert body["type"] == "ReCaptchaV3Task"  # not ProxyLess
+        assert body["proxyType"] == "https"
+        assert used_proxy_aware is True
+        assert compat_rejected is False
+
+    def test_proxy_fields_dont_clobber_v3_extras(self):
+        """v3 fields (minScore, pageAction) must coexist with proxy creds."""
+        s = self._solver(provider="capsolver")
+        cfg = SolverProxyConfig(
+            proxy_type="http", address="10.0.0.1", port=8080,
+            login="u", password="p",
+        )
+        body, _, _ = s._build_task_body(
+            _CAPSOLVER_TASK_TYPES, "recaptcha-v3",
+            "SITEKEY", "https://example.com",
+            page_action="login", proxy_config=cfg,
+        )
+        assert body["pageAction"] == "login"
+        assert "minScore" in body
+        assert body["proxyType"] == "http"
+
+    def test_unknown_variant_returns_none(self):
+        s = self._solver()
+        body, used_proxy_aware, compat_rejected = s._build_task_body(
+            _2CAPTCHA_TASK_TYPES, "no-such-variant",
+            "SITEKEY", "https://example.com",
+            page_action=None, proxy_config=None,
+        )
+        assert body is None
+
+
+# ── 5. Cost counter respects proxy_aware flag ─────────────────────────────
+
+
+class TestCostCounterProxyAware:
+    def test_proxyless_baseline(self):
+        # 2captcha v2-checkbox proxyless rate: 100¢
+        assert cost.estimate_cents(
+            "2captcha", "recaptcha-v2-checkbox", proxy_aware=False,
+        ) == 100
+
+    def test_proxy_aware_three_x(self):
+        # 2captcha v2-checkbox proxy-aware: ~3× → 300¢
+        assert cost.estimate_cents(
+            "2captcha", "recaptcha-v2-checkbox", proxy_aware=True,
+        ) == 300
+
+    def test_capsolver_proxy_aware_three_x(self):
+        # CapSolver v2-checkbox proxyless 80¢ → proxy-aware 240¢
+        assert cost.estimate_cents(
+            "capsolver", "recaptcha-v2-checkbox", proxy_aware=True,
+        ) == 240
+
+    def test_proxy_aware_default_is_false(self):
+        # Default ``proxy_aware`` arg → proxyless tier (existing callers
+        # keep working).
+        assert cost.estimate_cents(
+            "capsolver", "turnstile",
+        ) == 60
+
+    def test_no_proxy_aware_entry_falls_back_to_proxyless(self):
+        # 2captcha v3 has no proxy-aware row (provider doesn't document
+        # the task) — caller billed proxyless rate to match the request
+        # body actually sent.
+        proxyless = cost.estimate_cents(
+            "2captcha", "recaptcha-v3", proxy_aware=False,
+        )
+        proxy_aware = cost.estimate_cents(
+            "2captcha", "recaptcha-v3", proxy_aware=True,
+        )
+        assert proxyless == proxy_aware == 100
+
+    def test_unknown_variant_still_returns_none(self):
+        assert cost.estimate_cents(
+            "2captcha", "unknown-variant", proxy_aware=True,
+        ) is None
+
+
+# ── 6. Credential-leak canary (CONTRACT TEST) ─────────────────────────────
+
+
+class TestCredentialLeakCanary:
+    """Contract test for §11.2 §security note.
+
+    If THIS test ever fails, the credential-leak vector is open: the
+    agent's primary egress proxy creds are reaching a third-party
+    CAPTCHA solver. Halt and investigate before merging anything that
+    breaks this test.
+    """
+
+    @pytest.mark.asyncio
+    async def test_primary_proxy_creds_never_leak(self, monkeypatch):
+        # ── Step 1: simulate an agent with a primary egress proxy that
+        # contains a unique canary string in the password. The code path
+        # under test (CaptchaSolver.solve → _solve_2captcha → httpx.post)
+        # MUST NEVER touch this primary proxy.
+        primary_proxy_creds = {
+            "proxyType": "http",
+            "proxyAddress": "primary-residential.example.com",
+            "proxyPort": 9999,
+            "proxyLogin": "primary-user-DO-NOT-LEAK",
+            "proxyPassword": "PRIMARY_LEAK_CANARY_xyz123",
+        }
+        # Stash on a stand-in BrowserManager-shaped object purely as a
+        # decoy; the solver code path doesn't read this — that's the
+        # contract we're enforcing.
+        decoy_manager = MagicMock()
+        decoy_manager._proxy_configs = {"agent-1": primary_proxy_creds}
+
+        # ── Step 2: configure the dedicated solver proxy with DIFFERENT
+        # creds (this is what the solver SHOULD send).
+        monkeypatch.setenv("CAPTCHA_SOLVER_PROXY_TYPE", "socks5")
+        monkeypatch.setenv("CAPTCHA_SOLVER_PROXY_ADDRESS", "solver-proxy.example.com")
+        monkeypatch.setenv("CAPTCHA_SOLVER_PROXY_PORT", "1080")
+        monkeypatch.setenv("CAPTCHA_SOLVER_PROXY_LOGIN", "solver-user")
+        monkeypatch.setenv("CAPTCHA_SOLVER_PROXY_PASSWORD", "DEDICATED_SOLVER_PASS")
+        from src.browser import flags as _flags
+        _flags.reload_operator_settings()
+
+        # ── Step 3: build a real solver and mock the httpx client.
+        # Capture every outbound POST the solver makes.
+        solver = CaptchaSolver("capsolver", "test-clientkey")
+        solver._solver_health_checked = True  # skip the §11.16 probe
+
+        captured_calls: list[dict] = []
+
+        async def _capturing_post(url, *args, **kwargs):
+            # Capture URL, JSON body, query string, headers — every
+            # surface where credentials could plausibly leak.
+            captured_calls.append({
+                "url": url,
+                "args": args,
+                "kwargs": kwargs,
+                "json": kwargs.get("json"),
+                "params": kwargs.get("params"),
+                "headers": kwargs.get("headers"),
+                "data": kwargs.get("data"),
+            })
+            # Return a successful create+poll flow.
+            resp = MagicMock()
+            resp.raise_for_status = MagicMock()
+            if "createTask" in url:
+                resp.json = MagicMock(return_value={
+                    "errorId": 0, "taskId": "task-canary-123",
+                })
+            else:
+                resp.json = MagicMock(return_value={
+                    "errorId": 0, "status": "ready",
+                    "solution": {"gRecaptchaResponse": "tok-xyz"},
+                })
+            return resp
+
+        mock_client = AsyncMock(spec=httpx.AsyncClient)
+        mock_client.is_closed = False
+        mock_client.post = AsyncMock(side_effect=_capturing_post)
+        solver._client = mock_client
+
+        # ── Step 4: drive the solve. Use a recaptcha-v2 selector so the
+        # body builder picks the (capsolver, recaptcha-v2-checkbox) entry,
+        # which is in the compat table — proxy-aware path is fully
+        # exercised.
+        # The solve() flow calls page.evaluate twice: once for the
+        # variant classifier (returns a dict) and again for the sitekey
+        # extractor (returns a string). Use side_effect so each call
+        # gets the right shape.
+        page = AsyncMock()
+        page.evaluate = AsyncMock(side_effect=[
+            # _classify_recaptcha probe → v2-checkbox
+            {
+                "enterprise": False, "v3": False,
+                "sitekeys": ["SITEKEY-canary"],
+                "actions_by_key": {},
+                "invisible_by_key": {"SITEKEY-canary": False},
+                "enterprise_script": False, "v3_render_param": None,
+            },
+            # any additional evaluate() (token injection JS) — return None
+            None, None, None, None, None,
+        ])
+        page.url = "https://example.com/login"
+
+        # Speed: collapse the poll interval so we don't actually wait.
+        monkeypatch.setattr(cap, "_POLL_INTERVAL", 0.001)
+        monkeypatch.setattr(cap, "_SOLVE_TIMEOUT", 5.0)
+
+        result = await solver.solve(
+            page, 'iframe[src*="recaptcha"]', "https://example.com/login",
+            agent_id="agent-1",
+        )
+        assert result is True, "solver should have succeeded under the mock"
+
+        # ── Step 5: ASSERT — the canary string must NOT appear anywhere
+        # in any outbound request.
+        assert len(captured_calls) >= 1, "solver issued no requests"
+
+        canary = "PRIMARY_LEAK_CANARY_xyz123"
+        primary_login = "primary-user-DO-NOT-LEAK"
+        primary_host = "primary-residential.example.com"
+
+        for call in captured_calls:
+            blob = repr(call)
+            assert canary not in blob, (
+                f"CREDENTIAL LEAK: primary proxy password "
+                f"'{canary}' found in outbound solver request: {call}"
+            )
+            assert primary_login not in blob, (
+                f"CREDENTIAL LEAK: primary proxy login "
+                f"'{primary_login}' found in outbound solver request: {call}"
+            )
+            assert primary_host not in blob, (
+                f"CREDENTIAL LEAK: primary proxy host "
+                f"'{primary_host}' found in outbound solver request: {call}"
+            )
+
+        # ── Step 6: positive assertion — the dedicated solver creds DO
+        # appear in the outbound body. Otherwise the test would pass
+        # trivially if no proxy fields were sent at all.
+        first_call = captured_calls[0]
+        body = first_call["json"]
+        assert body is not None
+        task = body.get("task", {})
+        assert task.get("proxyType") == "socks5"
+        assert task.get("proxyAddress") == "solver-proxy.example.com"
+        assert task.get("proxyPort") == 1080
+        assert task.get("proxyLogin") == "solver-user"
+        assert task.get("proxyPassword") == "DEDICATED_SOLVER_PASS"
+        # And the proxy-aware task name (sans ``ProxyLess``) was selected.
+        assert task.get("type") == "ReCaptchaV2Task"
+
+    @pytest.mark.asyncio
+    async def test_no_solver_proxy_means_proxyless_body(self, monkeypatch):
+        """When CAPTCHA_SOLVER_PROXY_* is unset, no proxy fields are
+        sent — and the agent's primary proxy creds are STILL not leaked.
+        """
+        # Pretend the agent has a primary proxy (the canary).
+        decoy_manager = MagicMock()
+        decoy_manager._proxy_configs = {"agent-1": {
+            "proxyPassword": "PRIMARY_LEAK_CANARY_unset_path",
+        }}
+
+        # No CAPTCHA_SOLVER_PROXY_* env vars → loader returns None.
+        solver = CaptchaSolver("2captcha", "test-clientkey")
+        solver._solver_health_checked = True
+
+        captured: list[dict] = []
+
+        async def _capturing_post(url, *args, **kwargs):
+            captured.append({"url": url, "json": kwargs.get("json")})
+            resp = MagicMock()
+            resp.raise_for_status = MagicMock()
+            if "createTask" in url:
+                resp.json = MagicMock(return_value={
+                    "errorId": 0, "taskId": "task-1",
+                })
+            else:
+                resp.json = MagicMock(return_value={
+                    "errorId": 0, "status": "ready",
+                    "solution": {"gRecaptchaResponse": "tok"},
+                })
+            return resp
+
+        mock_client = AsyncMock(spec=httpx.AsyncClient)
+        mock_client.is_closed = False
+        mock_client.post = AsyncMock(side_effect=_capturing_post)
+        solver._client = mock_client
+
+        # _classify_recaptcha needs a dict response; the sitekey
+        # extractor and token injection JS each call evaluate again.
+        page = AsyncMock()
+        page.evaluate = AsyncMock(side_effect=[
+            {
+                "enterprise": False, "v3": False,
+                "sitekeys": ["SITEKEY-x"],
+                "actions_by_key": {},
+                "invisible_by_key": {"SITEKEY-x": False},
+                "enterprise_script": False, "v3_render_param": None,
+            },
+            None, None, None, None, None,
+        ])
+        page.url = "https://example.com"
+
+        monkeypatch.setattr(cap, "_POLL_INTERVAL", 0.001)
+        monkeypatch.setattr(cap, "_SOLVE_TIMEOUT", 5.0)
+
+        await solver.solve(
+            page, 'iframe[src*="recaptcha"]', "https://example.com",
+            agent_id="agent-1",
+        )
+
+        # Canary must not leak even on the proxyless path.
+        for call in captured:
+            assert "PRIMARY_LEAK_CANARY_unset_path" not in repr(call)
+        # And proxy fields must be absent from the body.
+        body = captured[0]["json"]
+        task = body.get("task", {})
+        assert "proxyType" not in task
+        assert "proxyAddress" not in task
+        # Proxyless task name was selected.
+        assert task.get("type") == "RecaptchaV2TaskProxyless"
+
+    @pytest.mark.asyncio
+    async def test_compat_rejection_marks_envelope_low_confidence(self, monkeypatch):
+        """When a proxy is configured but the compat table rejects the
+        scheme for the variant, ``last_compat_rejected`` is True so the
+        envelope downgrades to ``solver_confidence='low'``.
+        """
+        # 2captcha + https is rejected by the compat table.
+        monkeypatch.setenv("CAPTCHA_SOLVER_PROXY_TYPE", "https")
+        monkeypatch.setenv("CAPTCHA_SOLVER_PROXY_ADDRESS", "10.0.0.1")
+        monkeypatch.setenv("CAPTCHA_SOLVER_PROXY_PORT", "8080")
+        monkeypatch.setenv("CAPTCHA_SOLVER_PROXY_LOGIN", "u")
+        monkeypatch.setenv("CAPTCHA_SOLVER_PROXY_PASSWORD", "p")
+        from src.browser import flags as _flags
+        _flags.reload_operator_settings()
+
+        solver = CaptchaSolver("2captcha", "test-clientkey")
+        solver._solver_health_checked = True
+
+        captured: list[dict] = []
+
+        async def _capturing_post(url, *args, **kwargs):
+            captured.append({"url": url, "json": kwargs.get("json")})
+            resp = MagicMock()
+            resp.raise_for_status = MagicMock()
+            if "createTask" in url:
+                resp.json = MagicMock(return_value={
+                    "errorId": 0, "taskId": "task-1",
+                })
+            else:
+                resp.json = MagicMock(return_value={
+                    "errorId": 0, "status": "ready",
+                    "solution": {"gRecaptchaResponse": "tok"},
+                })
+            return resp
+
+        mock_client = AsyncMock(spec=httpx.AsyncClient)
+        mock_client.is_closed = False
+        mock_client.post = AsyncMock(side_effect=_capturing_post)
+        solver._client = mock_client
+
+        # _classify_recaptcha needs a dict response; the sitekey
+        # extractor and token injection JS each call evaluate again.
+        page = AsyncMock()
+        page.evaluate = AsyncMock(side_effect=[
+            {
+                "enterprise": False, "v3": False,
+                "sitekeys": ["SITEKEY-x"],
+                "actions_by_key": {},
+                "invisible_by_key": {"SITEKEY-x": False},
+                "enterprise_script": False, "v3_render_param": None,
+            },
+            None, None, None, None, None,
+        ])
+        page.url = "https://example.com"
+
+        monkeypatch.setattr(cap, "_POLL_INTERVAL", 0.001)
+        monkeypatch.setattr(cap, "_SOLVE_TIMEOUT", 5.0)
+
+        result = await solver.solve(
+            page, 'iframe[src*="recaptcha"]', "https://example.com",
+            agent_id="agent-1",
+        )
+        assert result is True
+        assert solver.last_used_proxy_aware is False
+        assert solver.last_compat_rejected is True
+        # Body uses proxyless task name (no proxy creds sent).
+        body = captured[0]["json"]
+        task = body.get("task", {})
+        assert task.get("type") == "RecaptchaV2TaskProxyless"
+        assert "proxyType" not in task


### PR DESCRIPTION
## Summary

Adds opt-in support for routing CAPTCHA solver requests through a dedicated proxy via a new `CAPTCHA_SOLVER_PROXY_*` env-var family. **Off by default** — when unset, solvers continue to use proxyless task types exactly as before.

Builds on §11.1 (PR #771) — extends the `_2CAPTCHA_TASK_TYPES` / `_CAPSOLVER_TASK_TYPES` tables and the `_build_task_body` helper rather than introducing parallel structures.

Plan reference: `docs/plans/2026-04-20-browser-automation.md` §11.2.

## Threat model — why agent primary proxy creds are NEVER forwarded

The agent's primary egress proxy (per-agent state in `BrowserManager._proxy_configs`) is a residential / datacenter IP we paid for to scrape from. Forwarding those credentials to a third-party CAPTCHA solver would be a direct credential-leak vector — the solver could exfiltrate, log, or rotate them.

§11.2 enforces credential isolation by requiring a SEPARATE `CAPTCHA_SOLVER_PROXY_*` env-var family for solver-side proxies. The agent's primary creds are never threaded into the solver call path.

**Contract test:** `tests/test_captcha_solver_proxy.py::TestCredentialLeakCanary::test_primary_proxy_creds_never_leak`

This seeds a fake primary proxy with a unique canary string in the password, configures DIFFERENT creds on `CAPTCHA_SOLVER_PROXY_*`, drives a full solve with a mocked httpx client capturing every outbound request, then asserts the canary string appears **zero times** anywhere in those requests AND that the dedicated solver creds DO appear. If this test ever fails, halt and investigate — the credential-leak vector is open.

## Compat-table fallback behavior

`_SOLVER_PROXY_COMPAT` is a hardcoded `(provider, variant) → {accepted scheme}` table verified against current provider docs (April 2026):

* **2captcha** — uniformly `{http, socks4, socks5}` (NO `https`) on documented proxy-aware tasks. v3 / Enterprise-v3 have NO documented proxy-aware variants and are absent from the table; loaders fall back to proxyless. (Source: https://2captcha.com/api-docs/recaptcha-v2 and equivalents.)
* **CapSolver** — full `{http, https, socks4, socks5}` on every proxy-aware variant. (Source: https://docs.capsolver.com/en/guide/api-how-to-use-proxy/)

When the configured scheme is rejected for the variant, OR when the variant has no documented proxy-aware task at all, the body builder:
1. Falls back to the proxyless task name (drops `Task` → `TaskProxyless` / `TaskProxyLess`).
2. Sends NO `proxyType` / `proxyAddress` / `proxyLogin` / `proxyPassword` fields in the body.
3. Sets `last_compat_rejected=True` on the solver instance so `_check_captcha` downgrades the envelope's `solver_confidence` to `"low"` — operator sees the token came from the provider's IP pool, not theirs.

## Cost counter

`estimate_cents(provider, kind, *, proxy_aware=False)` — extended signature (existing call sites continue to use the proxyless tier by default). Proxy-aware rates are ~3× the proxyless rate per provider docs (e.g. 2captcha v2-checkbox: 100¢ → 300¢). When the proxy-aware tier has no entry (2captcha v3), we fall through to the proxyless rate so the price billed matches the request actually sent.

The `_check_captcha` cost-accounting branch reads `solver.last_used_proxy_aware` to pick the tier — no parallel cost path was introduced.

## Test plan

- [x] `pytest tests/test_captcha_solver_proxy.py -v` — 49 passing
- [x] `pytest tests/test_captcha_*.py tests/test_browser_solve_captcha.py tests/test_browser_service.py` — 659 passing, 7 skipped (pre-existing)
- [x] `pytest tests/ --ignore=tests/test_e2e*.py -x` — clean apart from two pre-existing flakes (`test_browser_inspect_requests` / `test_cli_commands::test_version_flag`) that are environmental and not touched by this PR
- [x] `ruff check src/ tests/` — clean

## Compat-table corrections / spec drift notes

* The §11.2 spec example listed `("2captcha", "recaptcha-v2-checkbox"): {"http", "https", "socks4", "socks5"}`. Provider docs (April 2026) explicitly list only `http | socks4 | socks5` for `RecaptchaV2Task` / `HCaptchaTask` / `TurnstileTask` — `https` is NOT a documented value. The compat table reflects the documented set; setting `CAPTCHA_SOLVER_PROXY_TYPE=https` with a 2captcha provider falls back to proxyless + `solver_confidence="low"`.
* 2captcha has no documented proxy-aware `RecaptchaV3Task` as of April 2026 — only `RecaptchaV3TaskProxyless`. The task-type table has `"proxy_aware": None` for `recaptcha-v3` and `recaptcha-enterprise-v3` on 2captcha; the compat table omits those entries; loaders fall back to proxyless and downgrade confidence.
* FunCaptcha is mentioned in the §11.2 SOCKS5-rejection note but is deferred to §11.5; commented in `_SOLVER_PROXY_COMPAT` for when that lands.

## Files

- `src/browser/captcha.py` — `SolverProxyConfig`, `get_solver_proxy_config`, `_SOLVER_PROXY_COMPAT`, restructured task tables, refactored `_build_task_body` to return `(body, used_proxy_aware, compat_rejected)`, threaded proxy_config through `_solve_2captcha` / `_solve_capsolver` / `solve`.
- `src/browser/captcha_cost_counter.py` — added `PRICING_CENTS_PROXY_AWARE` table and `proxy_aware` kwarg on `estimate_cents`.
- `src/browser/service.py` — `_check_captcha` reads `solver.last_compat_rejected` to downgrade confidence; cost-counter call site reads `solver.last_used_proxy_aware` for tier selection.
- `tests/test_captcha_solver_proxy.py` (new) — 49 tests covering loader, normalizer, compat table, task-body builder, cost counter, and the credential-leak canary.
- `tests/test_captcha_recaptcha_classifier.py` — updated existing §11.1 task-table tests for the new `{proxyless, proxy_aware, extra}` schema.