### PR TITLE
Fix request-pairing race in inspect_requests on Python 3.12

### DIFF
--- a/src/browser/service.py
+++ b/src/browser/service.py
@@ -6985,12 +6985,17 @@ class BrowserManager:
                 # response payload by ``inspect_requests``.
                 "_failure_tagged": False,
                 # Pair ``requestfailed`` back to the exact Playwright
-                # Request object when possible. URL+method is retained as
-                # fallback for tests / bindings that synthesize separate
-                # objects for the failure callback, but exact object identity
-                # avoids mis-tagging a newer identical request when only an
-                # older one fails.
-                "_request_key": id(req),
+                # Request object when possible. We hold a STRONG reference
+                # to the request object (not ``id(req)``) because Python
+                # explicitly recycles ``id()`` values for non-overlapping
+                # object lifetimes — on Python 3.12 the allocator is
+                # aggressive enough that a freshly-created mock in a unit
+                # test routinely lands at the same address as a previously
+                # GC'd request, causing ``id()``-based pairing to match the
+                # wrong entry. URL+method is retained as a fallback for
+                # bindings that synthesize a distinct object for the
+                # failure callback.
+                "_request_key": req,
             })
         except Exception as e:
             logger.debug("network listener record failed: %s", e)
@@ -7027,8 +7032,6 @@ class BrowserManager:
             err = getattr(failure, "errorText", "") if failure else ""
             if not isinstance(err, str):
                 err = str(err) if err else ""
-            request_key = id(req)
-
             blocked = False
             cancelled = False
             for marker in ("BLOCKED_BY_CLIENT", "CONTENT_BLOCKED", "BLOCKED_BY_POLICY"):
@@ -7046,10 +7049,13 @@ class BrowserManager:
             # Prefer the exact Request-object match. Playwright sends the
             # same Request object to ``request`` and ``requestfailed``; using
             # that identity prevents a failed older request from tagging a
-            # newer identical URL+method that is still in flight.
+            # newer identical URL+method that is still in flight. We compare
+            # by ``is`` (object identity) on the strong reference stashed at
+            # record time — NOT by ``id()``, which CPython recycles across
+            # non-overlapping lifetimes (the original bug).
             for entry in reversed(inst.network_log):
                 if (
-                    entry.get("_request_key") == request_key
+                    entry.get("_request_key") is req
                     and not entry.get("_failure_tagged")
                 ):
                     entry["blocked_by_adblock"] = blocked

--- a/tests/test_browser_inspect_requests.py
+++ b/tests/test_browser_inspect_requests.py
@@ -684,6 +684,40 @@ class TestParallelFailedRequestsPairing:
         )
         assert all(e["_failure_tagged"] for e in inst.network_log)
 
+    def test_pairing_does_not_use_recyclable_id(self):
+        """Regression: pairing must not key off ``id(req)``.
+
+        ``id(req)`` returns a memory address that CPython is free to
+        reuse for any later object once the original is GC'd. On
+        Python 3.12 the allocator recycles addresses aggressively
+        enough that a freshly-allocated failure-mock routinely lands
+        at the same address as a previously-recorded (and now GC'd)
+        request mock — making ``_request_key`` collisions cause the
+        failure to silently mis-tag an unrelated /ok/ entry.
+
+        This test inspects the implementation detail (``_request_key``)
+        rather than relying on probabilistic address collision. It
+        asserts the key is a real reference, not the integer ``id()``.
+        """
+        mgr, inst, _ctx, _page = _make_instance_with_listeners()
+        mgr._attach_network_listeners(inst)
+
+        req = _make_mock_request("https://example.com/r")
+        mgr._record_request(inst, req)
+        stored_key = inst.network_log[0]["_request_key"]
+
+        # The stashed key must BE the request, not its (recyclable) id.
+        # ``is`` rather than ``==`` because mocks compare deeply.
+        assert stored_key is req, (
+            f"_request_key must be the request object itself "
+            f"(strong reference), not a recyclable id(). Got: "
+            f"{type(stored_key).__name__}={stored_key!r}"
+        )
+        assert not isinstance(stored_key, int), (
+            "id()-style integer keys collide across non-overlapping "
+            "object lifetimes; pair-matching must use object identity."
+        )
+
     def test_third_failure_with_only_two_requests_is_dropped(self):
         """If a third ``requestfailed`` arrives but only two matching
         requests exist (both already tagged), the third update is


### PR DESCRIPTION
## Summary

- `_record_request` stashed `id(req)` as the pairing key for later `_record_request_failed` matching. CPython explicitly recycles `id()` values for non-overlapping object lifetimes — so on Python 3.12 (which has a more aggressive allocator than 3.11) a freshly-created failure mock routinely lands at the same address as a previously-GC'd request, causing the first loop in `_record_request_failed` to mis-tag an unrelated entry.
- Fix: store the request object as a strong reference and compare with `is`. Two-line behavioral change, kept inside the same `_request_key` field with no new abstraction.
- Added a deterministic regression test that asserts the pairing key is the request object itself, not an integer — so a refactor can't silently reintroduce the bug.

## Symptom

These tests failed intermittently on Python 3.12 (~15% locally) and consistently in CI; passed always on 3.11:

- `tests/test_browser_inspect_requests.py::TestFilterBeforeCapOrdering::test_filter_before_cap_with_limit_smaller_than_visible`
- `tests/test_browser_inspect_requests.py::TestIncludeBlockedFilter::test_excludes_blocked_by_default`

Failure assertion: `assert "/ok/" in 'https://tracker.example.com/blocked/199'` — a blocked URL leaked into the unblocked-only filter because its `_record_request_failed` event tagged the wrong entry (an `/ok/` entry whose mock had been GC'd and whose address was reused by the failure mock).

## Root cause

`src/browser/service.py:_record_request` stored `"_request_key": id(req)`. In `_record_request_failed`, the first loop compared `entry.get("_request_key") == id(failure_req)`. CPython's docs state: *"Two objects with non-overlapping lifetimes may have the same id() value."* The unit tests build short-lived mock requests via `_make_mock_request(...)` whose temporaries become eligible for GC immediately after each `_record_request*` call. On Python 3.12 the allocator reuses the memory slot for the next mock with high probability, producing `id()` collisions that mis-tag blocked-failure events onto unrelated entries — those entries get marked `blocked_by_adblock=True`, and the actual blocked URL stays untagged and leaks through the `include_blocked=False` filter.

Python 3.11 happens to keep the temp alive long enough (different bytecode/refcount timing) that the bug almost never triggers; 3.12 trips it readily.

## Fix

Change `_request_key` from `id(req)` (recyclable integer) to `req` itself (strong reference), and switch the comparator from `==` to `is` (object identity). The deque is bounded at `maxlen=200`, so retaining at most 200 small request descriptors is negligible. The fallback URL+method loop is unchanged.

## Test plan

- [x] Reproduced failure on Python 3.12.10 locally (~15% of runs against the buggy code).
- [x] After fix: 30/30 runs pass on Python 3.12.10.
- [x] Python 3.11 (baseline): 20/20 runs pass before and after.
- [x] `tests/test_browser_service.py`: 440 passed / 7 skipped on 3.11 — no regressions in adjacent code.
- [x] `ruff check src/browser/service.py tests/test_browser_inspect_requests.py` clean.
- [x] Added regression test `TestParallelFailedRequestsPairing::test_pairing_does_not_use_recyclable_id` — deterministically fails against old code, passes against new.
- [ ] CI passes on both 3.11 and 3.12 (the actual validation gate).