### PR TITLE
Render browser_captcha_help handoff card in dashboard SPA

### DIFF
--- a/src/dashboard/static/js/app.js
+++ b/src/dashboard/static/js/app.js
@@ -81,6 +81,7 @@ function dashboard() {
       'blackboard_write', 'health_change', 'notification', 'workspace_updated',
       'heartbeat_complete', 'cron_change', 'credit_exhausted', 'credential_request',
       'browser_login_request', 'browser_login_completed', 'browser_login_cancelled',
+      'browser_captcha_help_request', 'browser_captcha_help_completed', 'browser_captcha_help_cancelled',
     ],
 
     // Agent detail
@@ -1730,6 +1731,73 @@ function dashboard() {
           if (!hist) continue;
           for (const m of hist) {
             if (m.role === 'browser_login_request' && m.service === evt.data.service
+                && (chatId === agent || m._from_agent === agent)) {
+              m.cancelled = true;
+            }
+          }
+        }
+      }
+
+      // Surface browser CAPTCHA help requests as interactive VNC cards in chat.
+      // Mirrors the browser_login_request handler — Phase 8 §11.14.
+      if (evt.type === 'browser_captcha_help_request' && agent && evt.data && evt.data.service) {
+        const evtTs = this._normalizeEventTs(evt);
+        const captchaCard = {
+          role: 'browser_captcha_help_request',
+          content: evt.data.description || '',
+          service: evt.data.service || '',
+          url: evt.data.url || '',
+          completed: false,
+          cancelled: false,
+          ts: evtTs,
+        };
+        // Show in the requesting agent's chat
+        if (!this.chatHistories[agent]) this.chatHistories[agent] = [];
+        const isDup = this.chatHistories[agent].some(m =>
+          m.role === 'browser_captcha_help_request' && m.service === evt.data.service && Math.abs((m.ts || 0) - evtTs) < 5000
+        );
+        if (!isDup) {
+          this.chatHistories[agent].push(captchaCard);
+          if (this.activeChatId === agent) {
+            this.$nextTick(() => this._scrollChat(agent));
+          } else {
+            this.chatUnread = { ...this.chatUnread, [agent]: (this.chatUnread[agent] || 0) + 1 };
+          }
+        }
+        // Also surface in operator chat
+        if (agent !== 'operator') {
+          if (!this.chatHistories['operator']) this.chatHistories['operator'] = [];
+          const opDup = this.chatHistories['operator'].some(m =>
+            m.role === 'browser_captcha_help_request' && m._from_agent === agent && m.service === evt.data.service && Math.abs((m.ts || 0) - evtTs) < 5000
+          );
+          if (!opDup) {
+            this.chatHistories['operator'].push({ ...captchaCard, _from_agent: agent });
+            if (this.activeTab === 'chat') {
+              this.$nextTick(() => this._scrollChat('operator'));
+            }
+          }
+        }
+      }
+
+      // Sync browser CAPTCHA help card state across all copies (agent chat + operator chat).
+      if (evt.type === 'browser_captcha_help_completed' && agent && evt.data?.service) {
+        for (const chatId of [agent, 'operator']) {
+          const hist = this.chatHistories[chatId];
+          if (!hist) continue;
+          for (const m of hist) {
+            if (m.role === 'browser_captcha_help_request' && m.service === evt.data.service
+                && (chatId === agent || m._from_agent === agent)) {
+              m.completed = true;
+            }
+          }
+        }
+      }
+      if (evt.type === 'browser_captcha_help_cancelled' && agent && evt.data?.service) {
+        for (const chatId of [agent, 'operator']) {
+          const hist = this.chatHistories[chatId];
+          if (!hist) continue;
+          for (const m of hist) {
+            if (m.role === 'browser_captcha_help_request' && m.service === evt.data.service
                 && (chatId === agent || m._from_agent === agent)) {
               m.cancelled = true;
             }
@@ -4892,6 +4960,44 @@ function dashboard() {
       msg.cancelled = true;
       try {
         const resp = await fetch(window.__config.apiBase + '/browser-login/cancel', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json', 'X-Requested-With': 'XMLHttpRequest' },
+          body: JSON.stringify({ agent_id: agentId || '', service: msg.service }),
+        });
+        if (!resp.ok) {
+          msg.cancelled = prev.cancelled;
+          this.showToast('Failed to notify agent — please try again');
+        }
+      } catch (_) {
+        msg.cancelled = prev.cancelled;
+        this.showToast('Network error — please try again');
+      }
+    },
+
+    async _completeBrowserCaptchaHelp(msg, agentId) {
+      const prev = { completed: msg.completed, cancelled: msg.cancelled };
+      msg.completed = true;
+      try {
+        const resp = await fetch(window.__config.apiBase + '/browser-captcha-help/complete', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json', 'X-Requested-With': 'XMLHttpRequest' },
+          body: JSON.stringify({ agent_id: agentId || '', service: msg.service }),
+        });
+        if (!resp.ok) {
+          msg.completed = prev.completed;
+          this.showToast('Failed to notify agent — please try again');
+        }
+      } catch (_) {
+        msg.completed = prev.completed;
+        this.showToast('Network error — please try again');
+      }
+    },
+
+    async _cancelBrowserCaptchaHelp(msg, agentId) {
+      const prev = { completed: msg.completed, cancelled: msg.cancelled };
+      msg.cancelled = true;
+      try {
+        const resp = await fetch(window.__config.apiBase + '/browser-captcha-help/cancel', {
           method: 'POST',
           headers: { 'Content-Type': 'application/json', 'X-Requested-With': 'XMLHttpRequest' },
           body: JSON.stringify({ agent_id: agentId || '', service: msg.service }),

--- a/src/dashboard/templates/index.html
+++ b/src/dashboard/templates/index.html
@@ -484,6 +484,98 @@
                         </div>
                       </div>
                     </template>
+                    <!-- Browser CAPTCHA help request card (Phase 8 §11.14) -->
+                    <template x-if="msg.role === 'browser_captcha_help_request'">
+                      <div class="flex justify-start gap-2.5">
+                        <div class="shrink-0 mt-1">
+                          <img src="/dashboard/static/avatars/operator.png" alt="Operator" class="w-6 h-6 rounded-full">
+                        </div>
+                        <div class="min-w-0" :class="msg._browserExpanded ? 'max-w-[95%]' : 'max-w-[80%]'">
+                          <div class="px-4 py-3 rounded-2xl rounded-bl-md bg-gray-800 border border-amber-600/30"
+                            x-data="{ browserOpen: false, focusDone: false, focusing: false, vncLoaded: false }">
+                            <template x-if="!msg.completed && !msg.cancelled">
+                              <div>
+                                <div class="flex items-center gap-2 mb-2">
+                                  <svg class="w-4 h-4 text-amber-400 shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="2">
+                                    <path stroke-linecap="round" stroke-linejoin="round" d="M12 9v2m0 4h.01M5 19h14a2 2 0 001.84-2.75L13.74 4a2 2 0 00-3.48 0L3.16 16.25A2 2 0 005 19z"/>
+                                  </svg>
+                                  <span class="text-xs font-medium text-amber-300" x-text="'CAPTCHA help requested: ' + msg.service"></span>
+                                  <template x-if="browserOpen">
+                                    <button @click="msg._browserExpanded = !msg._browserExpanded"
+                                      class="ml-auto text-gray-500 hover:text-gray-300 transition-colors"
+                                      :title="msg._browserExpanded ? 'Shrink' : 'Expand'">
+                                      <svg x-show="!msg._browserExpanded" class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M4 8V4m0 0h4M4 4l5 5m11-1V4m0 0h-4m4 0l-5 5M4 16v4m0 0h4m-4 0l5-5m11 5v-4m0 4h-4m4 0l-5-5"/></svg>
+                                      <svg x-show="msg._browserExpanded" x-cloak class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M9 9L4 4m0 0v4m0-4h4m7 11l5 5m0 0v-4m0 4h-4M9 15l-5 5m0 0h4m-4 0v-4m11-7l5-5m0 0h-4m4 0v4"/></svg>
+                                    </button>
+                                  </template>
+                                </div>
+                                <p class="text-xs text-gray-300 mb-3" x-text="msg.content"></p>
+                                <!-- VNC viewer -->
+                                <template x-if="browserOpen">
+                                  <div class="mb-3">
+                                    <div class="relative rounded-lg overflow-hidden bg-gray-900 border border-gray-700" :style="msg._browserExpanded ? 'aspect-ratio: 16/9; max-width: 100%;' : 'aspect-ratio: 16/9; max-width: 480px;'">
+                                      <div class="absolute inset-0 flex flex-col items-center justify-center bg-gray-900 z-10 transition-opacity duration-500"
+                                        :class="vncLoaded ? 'opacity-0 pointer-events-none' : 'opacity-100'">
+                                        <svg class="animate-spin h-6 w-6 text-amber-400 mb-2" fill="none" viewBox="0 0 24 24">
+                                          <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"/>
+                                          <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z"/>
+                                        </svg>
+                                        <span class="text-xs text-gray-400">Connecting to browser...</span>
+                                      </div>
+                                      <iframe
+                                        :src="focusDone ? _getVncUrl() : ''"
+                                        class="w-full h-full border-0"
+                                        allow="clipboard-read; clipboard-write"
+                                        @load="if (focusDone) vncLoaded = true"
+                                      ></iframe>
+                                    </div>
+                                  </div>
+                                </template>
+                                <!-- Action buttons -->
+                                <div class="flex gap-2">
+                                  <template x-if="!browserOpen">
+                                    <button @click="if (!focusing && msg._from_agent) { if (!_getVncUrl()) { showToast('Browser service not available', 5000); return; } focusing = true; browserOpen = true; focusDone = false; vncLoaded = false; focusBrowser(msg._from_agent).then(ok => { if (ok) { focusDone = true; } else { browserOpen = false; } focusing = false; }); }"
+                                      class="flex-1 px-3 py-1.5 rounded-lg text-xs font-medium bg-amber-600 hover:bg-amber-500 text-white transition-colors flex items-center justify-center gap-1.5">
+                                      <svg class="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="2"><rect x="2" y="3" width="20" height="14" rx="2" ry="2"/><line x1="8" y1="21" x2="16" y2="21"/><line x1="12" y1="17" x2="12" y2="21"/></svg>
+                                      Open Browser
+                                    </button>
+                                  </template>
+                                  <template x-if="browserOpen">
+                                    <button @click="browserOpen = false; focusDone = false; vncLoaded = false; _completeBrowserCaptchaHelp(msg, msg._from_agent)"
+                                      class="flex-1 px-3 py-1.5 rounded-lg text-xs font-medium bg-emerald-600 hover:bg-emerald-500 text-white transition-colors">
+                                      &#10003; Mark complete
+                                    </button>
+                                  </template>
+                                  <button @click="browserOpen = false; focusDone = false; vncLoaded = false; _cancelBrowserCaptchaHelp(msg, msg._from_agent)"
+                                    class="px-3 py-1.5 rounded-lg text-xs font-medium transition-colors"
+                                    :class="browserOpen ? 'bg-gray-700 hover:bg-gray-600 text-gray-300' : 'bg-gray-700/50 hover:bg-gray-600 text-gray-400'">
+                                    Cancel
+                                  </button>
+                                </div>
+                              </div>
+                            </template>
+                            <!-- Completed state -->
+                            <template x-if="msg.completed">
+                              <div class="flex items-center gap-1.5 text-xs text-emerald-400">
+                                <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="2">
+                                  <path stroke-linecap="round" stroke-linejoin="round" d="M5 13l4 4L19 7"/>
+                                </svg>
+                                <span x-text="'CAPTCHA solved for ' + msg.service + '. The agent can resume.'"></span>
+                              </div>
+                            </template>
+                            <!-- Cancelled state -->
+                            <template x-if="msg.cancelled">
+                              <div class="flex items-center gap-1.5 text-xs text-gray-400">
+                                <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="2">
+                                  <path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12"/>
+                                </svg>
+                                <span x-text="'CAPTCHA help for ' + msg.service + ' was cancelled.'"></span>
+                              </div>
+                            </template>
+                          </div>
+                        </div>
+                      </div>
+                    </template>
                     <!-- Agent/error/notification response -->
                     <template x-if="msg.role === 'agent' || msg.role === 'error' || msg.role === 'notification'">
                       <div class="flex justify-start gap-2.5">
@@ -6016,8 +6108,97 @@
                   </div>
                 </div>
               </template>
+              <!-- Browser CAPTCHA help request card (Phase 8 §11.14) -->
+              <template x-if="msg.role === 'browser_captcha_help_request'">
+                <div class="flex justify-start">
+                  <div class="min-w-0" :class="msg._browserExpanded ? 'max-w-[95%]' : 'max-w-[80%]'">
+                    <div class="px-4 py-3 rounded-2xl rounded-bl-md bg-gray-800 border border-amber-600/30"
+                      x-data="{ browserOpen: false, focusDone: false, focusing: false, vncLoaded: false }">
+                      <template x-if="!msg.completed && !msg.cancelled">
+                        <div>
+                          <div class="flex items-center gap-2 mb-2">
+                            <svg class="w-4 h-4 text-amber-400 shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="2">
+                              <path stroke-linecap="round" stroke-linejoin="round" d="M12 9v2m0 4h.01M5 19h14a2 2 0 001.84-2.75L13.74 4a2 2 0 00-3.48 0L3.16 16.25A2 2 0 005 19z"/>
+                            </svg>
+                            <span class="text-xs font-medium text-amber-300" x-text="'CAPTCHA help requested: ' + msg.service"></span>
+                            <template x-if="browserOpen">
+                              <button @click="msg._browserExpanded = !msg._browserExpanded"
+                                class="ml-auto text-gray-500 hover:text-gray-300 transition-colors"
+                                :title="msg._browserExpanded ? 'Shrink' : 'Expand'">
+                                <svg x-show="!msg._browserExpanded" class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M4 8V4m0 0h4M4 4l5 5m11-1V4m0 0h-4m4 0l-5 5M4 16v4m0 0h4m-4 0l5-5m11 5v-4m0 4h-4m4 0l-5-5"/></svg>
+                                <svg x-show="msg._browserExpanded" x-cloak class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M9 9L4 4m0 0v4m0-4h4m7 11l5 5m0 0v-4m0 4h-4M9 15l-5 5m0 0h4m-4 0v-4m11-7l5-5m0 0h-4m4 0v4"/></svg>
+                              </button>
+                            </template>
+                          </div>
+                          <p class="text-xs text-gray-300 mb-3" x-text="msg.content"></p>
+                          <!-- VNC viewer -->
+                          <template x-if="browserOpen">
+                            <div class="mb-3">
+                              <div class="relative rounded-lg overflow-hidden bg-gray-900 border border-gray-700" :style="msg._browserExpanded ? 'aspect-ratio: 16/9; max-width: 100%;' : 'aspect-ratio: 16/9; max-width: 480px;'">
+                                <div class="absolute inset-0 flex flex-col items-center justify-center bg-gray-900 z-10 transition-opacity duration-500"
+                                  :class="vncLoaded ? 'opacity-0 pointer-events-none' : 'opacity-100'">
+                                  <svg class="animate-spin h-6 w-6 text-amber-400 mb-2" fill="none" viewBox="0 0 24 24">
+                                    <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"/>
+                                    <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z"/>
+                                  </svg>
+                                  <span class="text-xs text-gray-400">Connecting to browser...</span>
+                                </div>
+                                <iframe
+                                  :src="focusDone ? _getVncUrl() : ''"
+                                  class="w-full h-full border-0"
+                                  allow="clipboard-read; clipboard-write"
+                                  @load="if (focusDone) vncLoaded = true"
+                                ></iframe>
+                              </div>
+                            </div>
+                          </template>
+                          <!-- Action buttons -->
+                          <div class="flex gap-2">
+                            <template x-if="!browserOpen">
+                              <button @click="if (!focusing && (msg._from_agent || activeChatId)) { if (!_getVncUrl()) { showToast('Browser service not available', 5000); return; } focusing = true; browserOpen = true; focusDone = false; vncLoaded = false; focusBrowser(msg._from_agent || activeChatId).then(ok => { if (ok) { focusDone = true; } else { browserOpen = false; } focusing = false; }); }"
+                                class="flex-1 px-3 py-1.5 rounded-lg text-xs font-medium bg-amber-600 hover:bg-amber-500 text-white transition-colors flex items-center justify-center gap-1.5">
+                                <svg class="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="2"><rect x="2" y="3" width="20" height="14" rx="2" ry="2"/><line x1="8" y1="21" x2="16" y2="21"/><line x1="12" y1="17" x2="12" y2="21"/></svg>
+                                Open Browser
+                              </button>
+                            </template>
+                            <template x-if="browserOpen">
+                              <button @click="browserOpen = false; focusDone = false; vncLoaded = false; _completeBrowserCaptchaHelp(msg, msg._from_agent || activeChatId)"
+                                class="flex-1 px-3 py-1.5 rounded-lg text-xs font-medium bg-emerald-600 hover:bg-emerald-500 text-white transition-colors">
+                                &#10003; Mark complete
+                              </button>
+                            </template>
+                            <button @click="browserOpen = false; focusDone = false; vncLoaded = false; _cancelBrowserCaptchaHelp(msg, msg._from_agent || activeChatId)"
+                              class="px-3 py-1.5 rounded-lg text-xs font-medium transition-colors"
+                              :class="browserOpen ? 'bg-gray-700 hover:bg-gray-600 text-gray-300' : 'bg-gray-700/50 hover:bg-gray-600 text-gray-400'">
+                              Cancel
+                            </button>
+                          </div>
+                        </div>
+                      </template>
+                      <!-- Completed state -->
+                      <template x-if="msg.completed">
+                        <div class="flex items-center gap-1.5 text-xs text-emerald-400">
+                          <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="2">
+                            <path stroke-linecap="round" stroke-linejoin="round" d="M5 13l4 4L19 7"/>
+                          </svg>
+                          <span x-text="'CAPTCHA solved for ' + msg.service + '. The agent can resume.'"></span>
+                        </div>
+                      </template>
+                      <!-- Cancelled state -->
+                      <template x-if="msg.cancelled">
+                        <div class="flex items-center gap-1.5 text-xs text-gray-400">
+                          <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="2">
+                            <path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12"/>
+                          </svg>
+                          <span x-text="'CAPTCHA help for ' + msg.service + ' was cancelled.'"></span>
+                        </div>
+                      </template>
+                    </div>
+                  </div>
+                </div>
+              </template>
               <!-- Chat bubble -->
-              <template x-if="msg.role !== 'system' && msg.role !== 'credential_request' && msg.role !== 'credit_exhausted' && msg.role !== 'browser_login_request'">
+              <template x-if="msg.role !== 'system' && msg.role !== 'credential_request' && msg.role !== 'credit_exhausted' && msg.role !== 'browser_login_request' && msg.role !== 'browser_captcha_help_request'">
               <div :class="msg.role === 'user' ? 'flex justify-end' : 'flex justify-start'">
               <div class="max-w-[80%] px-3 py-2 rounded-2xl text-xs"
                 :class="{

--- a/src/shared/types.py
+++ b/src/shared/types.py
@@ -352,6 +352,11 @@ class DashboardEvent(BaseModel):
         "browser_login_request",
         "browser_login_completed",
         "browser_login_cancelled",
+        # Phase 8 §11.14 — operator CAPTCHA handoff. Without these literals
+        # DashboardEvent rejects the emit and the SPA card never renders.
+        "browser_captcha_help_request",
+        "browser_captcha_help_completed",
+        "browser_captcha_help_cancelled",
         # Phase 4 §4.6 / Phase 7 §10.1 — per-minute browser aggregates
         # forwarded from the browser service to the dashboard via
         # _poll_browser_metrics_once. Without these literals

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -2147,6 +2147,174 @@ class TestDashboardBrowserLoginDelegation:
         assert resp.status_code == 400
 
 
+# ── V2 Tests: Browser CAPTCHA Help Delegation (Phase 8 §11.14) ──
+
+
+class TestDashboardBrowserCaptchaHelpDelegation:
+    """The /api/browser-captcha-help/complete and /cancel endpoints mirror
+    the browser-login flow: route to the agent_id specified in the body,
+    emit dashboard events keyed by that agent so the SPA card-sync logic
+    flips both copies (operator + target chat) to resolved/cancelled.
+
+    Plan §11.14: Operator CAPTCHA handoff card. Wired into the SPA in
+    PR feat/dashboard-captcha-help-card. Server endpoints landed in #769.
+    """
+
+    def setup_method(self):
+        self._tmpdir = tempfile.mkdtemp()
+        self.components = _make_components(self._tmpdir, include_v2=True)
+        # Register the requesting agent so the lane-enqueue path is taken.
+        self.components["agent_registry"]["scraper-bot"] = "http://localhost:8403"
+        self.client = _make_client(self.components)
+
+    def teardown_method(self):
+        _teardown(self.components)
+        shutil.rmtree(self._tmpdir, ignore_errors=True)
+
+    def test_complete_routes_to_specified_target(self):
+        events: list[tuple] = []
+        original_emit = self.components["event_bus"].emit
+
+        def spy(event_type, **kwargs):
+            events.append((event_type, kwargs))
+            return original_emit(event_type, **kwargs)
+
+        self.components["event_bus"].emit = spy
+
+        resp = self.client.post(
+            "/dashboard/api/browser-captcha-help/complete",
+            json={"agent_id": "scraper-bot", "service": "Cloudflare Turnstile"},
+        )
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["completed"] is True
+        assert body["agent_id"] == "scraper-bot"
+        assert body["service"] == "Cloudflare Turnstile"
+
+        completed = [e for e in events if e[0] == "browser_captcha_help_completed"]
+        assert len(completed) == 1
+        assert completed[0][1]["agent"] == "scraper-bot"
+        assert completed[0][1]["data"]["service"] == "Cloudflare Turnstile"
+
+    def test_cancel_routes_to_specified_target(self):
+        events: list[tuple] = []
+        original_emit = self.components["event_bus"].emit
+
+        def spy(event_type, **kwargs):
+            events.append((event_type, kwargs))
+            return original_emit(event_type, **kwargs)
+
+        self.components["event_bus"].emit = spy
+
+        resp = self.client.post(
+            "/dashboard/api/browser-captcha-help/cancel",
+            json={"agent_id": "scraper-bot", "service": "hCaptcha"},
+        )
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["cancelled"] is True
+        assert body["agent_id"] == "scraper-bot"
+        assert body["service"] == "hCaptcha"
+
+        cancelled = [e for e in events if e[0] == "browser_captcha_help_cancelled"]
+        assert len(cancelled) == 1
+        assert cancelled[0][1]["agent"] == "scraper-bot"
+        assert cancelled[0][1]["data"]["service"] == "hCaptcha"
+
+    def test_complete_missing_agent_id_returns_400(self):
+        resp = self.client.post(
+            "/dashboard/api/browser-captcha-help/complete",
+            json={"service": "X"},
+        )
+        assert resp.status_code == 400
+
+    def test_cancel_missing_service_returns_400(self):
+        resp = self.client.post(
+            "/dashboard/api/browser-captcha-help/cancel",
+            json={"agent_id": "scraper-bot"},
+        )
+        assert resp.status_code == 400
+
+    def test_complete_without_csrf_header_returns_403(self):
+        """CSRF gate: state-changing POST without X-Requested-With must be rejected.
+
+        Reviewer flagged this gap explicitly — the api_router's
+        Depends(_csrf_check) must be exercised by the captcha endpoints.
+        """
+        # Bypass our CSRF-injecting test client by using a raw TestClient.
+        from fastapi.testclient import TestClient as RawClient
+        raw = RawClient(self.client.app)
+        resp = raw.post(
+            "/dashboard/api/browser-captcha-help/complete",
+            json={"agent_id": "scraper-bot", "service": "X"},
+        )
+        assert resp.status_code == 403
+
+    def test_cancel_without_csrf_header_returns_403(self):
+        from fastapi.testclient import TestClient as RawClient
+        raw = RawClient(self.client.app)
+        resp = raw.post(
+            "/dashboard/api/browser-captcha-help/cancel",
+            json={"agent_id": "scraper-bot", "service": "X"},
+        )
+        assert resp.status_code == 403
+
+
+# ── SPA static-asset coverage: the captcha card is wired in app.js ──
+
+
+class TestDashboardCaptchaHelpSpaWiring:
+    """Verify the SPA actually subscribes to and renders captcha events.
+
+    The server emits ``browser_captcha_help_request`` /
+    ``..._completed`` / ``..._cancelled`` over the WebSocket; the SPA
+    must list those types in ``eventTypes`` and have a handler that
+    builds a card with ``role: 'browser_captcha_help_request'``.
+
+    We assert against the served static assets so a regression
+    (someone deleting the wiring) trips a unit test.
+    """
+
+    def setup_method(self):
+        self._tmpdir = tempfile.mkdtemp()
+        self.components = _make_components(self._tmpdir)
+        self.client = _make_client(self.components)
+
+    def teardown_method(self):
+        _teardown(self.components)
+        shutil.rmtree(self._tmpdir, ignore_errors=True)
+
+    def test_app_js_subscribes_to_captcha_events(self):
+        resp = self.client.get("/dashboard/static/js/app.js")
+        assert resp.status_code == 200
+        body = resp.text
+        for evt in (
+            "browser_captcha_help_request",
+            "browser_captcha_help_completed",
+            "browser_captcha_help_cancelled",
+        ):
+            assert evt in body, f"app.js missing eventTypes entry: {evt}"
+
+    def test_app_js_has_captcha_card_handler(self):
+        resp = self.client.get("/dashboard/static/js/app.js")
+        body = resp.text
+        # Card-build site (handler creates a chat-message with this role).
+        assert "role: 'browser_captcha_help_request'" in body
+        # Endpoints the buttons POST to (CSRF-gated by _csrf_check).
+        assert "/browser-captcha-help/complete" in body
+        assert "/browser-captcha-help/cancel" in body
+
+    def test_index_html_renders_captcha_card_template(self):
+        resp = self.client.get("/dashboard/")
+        body = resp.text
+        # Alpine x-if rendering branch for the new role.
+        assert "msg.role === 'browser_captcha_help_request'" in body
+        # Card title text per scope.
+        assert "CAPTCHA help requested" in body
+        # Card must not block the chat-bubble fallback like login does.
+        assert "msg.role !== 'browser_captcha_help_request'" in body
+
+
 # ── V2 Tests: Messages ──────────────────────────────────────
 
 


### PR DESCRIPTION
## Summary

Server-side endpoints (#769) emit `browser_captcha_help_request`,
`browser_captcha_help_completed`, and `browser_captcha_help_cancelled`,
but the SPA (`src/dashboard/static/js/app.js`) never subscribed to them
and never rendered a card. Agents calling `request_captcha_help` were
invisible to operators today, so agents waited forever.

This PR wires the SPA to the existing endpoints — it does NOT change the
server-side contract. Plan §11.14.

The reviewer of #769 flagged a CSRF coverage gap (review item #6); this
PR adds explicit `X-Requested-With` rejection tests for both
`/api/browser-captcha-help/complete` and `/cancel`.

## Changes

- **`app.js`** — three new event types in `eventTypes`; a
  `browser_captcha_help_request` handler that mirrors
  `browser_login_request` exactly (chat card with `service` +
  `description`, 5-second dedupe on `(agent, service, ts)`, dual surface
  in agent thread + operator chat); completion / cancellation handlers
  that flip the matching card across both copies; two new
  `_completeBrowserCaptchaHelp` / `_cancelBrowserCaptchaHelp` POSTers
  with the CSRF header.
- **`index.html`** — two new card templates (one per chat surface)
  mirroring the login cards. Amber accent (vs violet for login) to
  distinguish CAPTCHA help from login help. Reuses `focusBrowser` +
  `_getVncUrl` + the same VNC iframe scaffolding. "Mark complete" /
  "Cancel" buttons. Card role added to the chat-bubble exclusion list
  so it doesn't render twice.
- **`shared/types.py`** — extend `DashboardEvent.type` Literal with the
  three captcha events. Without this, `EventBus.emit` raises
  `ValidationError` (caught in test setup as the reason the first
  delegation test failed before the fix) and the events never reach the
  WebSocket.

## Tests

`tests/test_dashboard.py`:
- `TestDashboardBrowserCaptchaHelpDelegation` — `complete` / `cancel`
  route to the specified target agent and emit events keyed by that
  agent (mirrors `TestDashboardBrowserLoginDelegation`).
- **CSRF rejection tests** for both endpoints — POST without
  `X-Requested-With` → 403. (Addresses review #6 from #769.)
- Missing-field 400 tests.
- `TestDashboardCaptchaHelpSpaWiring` — parses the served `app.js`
  and `index.html` to verify the eventTypes subscription, the
  card-build site, the endpoint URLs, and the Alpine `x-if` branch are
  all present. Catches regressions where someone removes the wiring.

## Test plan

- [x] `pytest tests/test_dashboard.py -v` — 235 passed (9 new).
- [x] `pytest tests/test_browser_request_captcha_help.py -v` — 4 passed
      (server-side, unaffected).
- [x] `pytest tests/test_dashboard.py tests/test_browser_request_captcha_help.py tests/test_browser_delegation.py tests/test_events.py tests/test_types.py tests/test_browser_canary.py tests/test_captcha_*.py -q` — 602 passed.
- [x] `ruff check src/ tests/` — clean.
- [ ] Manual QA: trigger `request_captcha_help` from an agent, verify
      operator sees the amber card with VNC viewer; "Mark complete"
      and "Cancel" both clear the card and steer the agent.