### PR TITLE
Fix: captcha accounting + solver-state isolation + adjacent

### DIFF
--- a/src/browser/captcha.py
+++ b/src/browser/captcha.py
@@ -27,6 +27,71 @@ from src.shared.utils import setup_logging
 
 logger = setup_logging("browser.captcha")
 
+
+# ── §11.2/§11.13 structured solver result ─────────────────────────────────
+#
+# Replaces the old ``solve() -> bool`` + per-instance scratch-pad attrs
+# (``last_used_proxy_aware`` / ``last_compat_rejected``) which raced across
+# concurrent agents sharing a single CaptchaSolver instance.
+#
+# The dataclass is frozen so callers cannot accidentally mutate it after
+# they've stamped it onto an envelope; concurrent solves on different
+# agents now each own their own SolveResult and the cross-agent clobber
+# is structurally impossible.
+@dataclass(frozen=True)
+class SolveResult:
+    """Per-call solver result.
+
+    Attributes:
+        token: Provider-issued solution token, or ``None`` when the solver
+            never retrieved one (sitekey extraction failed, provider
+            returned ``errorId>0``, the breaker / health gate fired, etc.).
+        injection_succeeded: Only meaningful when ``token`` is not ``None``.
+            ``False`` indicates the provider was paid but the token failed
+            to land in the page DOM — accounting MUST still increment
+            because the provider already charged. Caller surfaces
+            ``solver_outcome="injection_failed"`` in this case.
+        used_proxy_aware: ``True`` iff the body sent to the provider used
+            the proxy-aware task family + carried the dedicated solver-proxy
+            credential fields. Drives cost-counter pricing tier (~3× the
+            proxyless rate) and replaces the old per-instance
+            ``last_used_proxy_aware`` scratch attr.
+        compat_rejected: ``True`` iff a solver proxy was configured but the
+            (provider, variant, type) tuple was rejected by the compat
+            table — the body fell back to proxyless. Drives the
+            ``solver_confidence="low"`` envelope downgrade. Replaces the
+            old per-instance ``last_compat_rejected`` scratch attr.
+        skipped: When non-``None``, the metering layer short-circuited
+            BEFORE the solver HTTP call. One of:
+              * ``"rate_limited"`` — per-agent solve-rate gate fired.
+              * ``"cost_cap"`` — per-agent monthly cost-cap reached.
+            ``None`` for a real solver attempt (success or failure).
+
+    Field-population guarantee for ``_metered_solve`` consumers:
+      * ``skipped="rate_limited"`` → ``token=None, injection_succeeded=False,
+        used_proxy_aware=False, compat_rejected=False``.
+      * ``skipped="cost_cap"`` → same.
+      * ``skipped=None``: every other field reflects the actual solver
+        attempt; ``token is None`` indicates a failed solve.
+    """
+
+    token: str | None
+    injection_succeeded: bool
+    used_proxy_aware: bool
+    compat_rejected: bool
+    skipped: str | None = None
+
+    def __bool__(self) -> bool:
+        """Truthiness == "agent-visible success" (token retrieved AND injected).
+
+        Mirrors the old ``solve() -> bool`` semantics so existing call sites
+        that still write ``if result: ...`` keep working without code
+        changes. New code should branch on ``result.token is not None`` for
+        cost-accounting decisions and ``result.injection_succeeded`` for
+        agent-visible outcome — these two are no longer the same thing.
+        """
+        return self.token is not None and self.injection_succeeded
+
 # §11.9 — per-type solver timeout. Each kind enum string maps to the
 # overall solve deadline in milliseconds (sitekey extract → submit →
 # poll-until-ready). The 30s ``httpx`` timeout for individual provider
@@ -176,9 +241,15 @@ _CAPTCHA_TYPE_MAP: dict[str, str] = {
 #
 # 2Captcha
 _2CAPTCHA_TASK_TYPES: dict[str, dict[str, object]] = {
+    # Legacy ``"recaptcha"`` key — kept so the classifier-unknown fallback
+    # in :func:`_classify_captcha` still has somewhere to land. Previously
+    # mapped to ``NormalRecaptchaTaskProxyless`` which 2captcha retired in
+    # April 2026 (submitting it returns ``ERROR_INVALID_TASK_TYPE``).
+    # Aliased to ``RecaptchaV2TaskProxyless`` — the safe v2-checkbox default
+    # — so the legacy task name is no longer sent over the wire.
     "recaptcha": {
-        "proxyless": "NormalRecaptchaTaskProxyless",  # legacy alias
-        "proxy_aware": None,
+        "proxyless": "RecaptchaV2TaskProxyless",
+        "proxy_aware": "RecaptchaV2Task",
         "extra": {},
     },
     "hcaptcha": {
@@ -933,17 +1004,15 @@ class CaptchaSolver:
         # Coordinates breaker reads/writes with health-check init across
         # concurrent agents that share this solver instance.
         self._state_lock: asyncio.Lock = asyncio.Lock()
-        # ── §11.2 last-solve proxy metadata ─────────────────────────────
-        # ``solve()`` stamps these so the BrowserManager caller can pick
-        # them up without changing the public ``solve() -> bool`` return
-        # contract. ``last_used_proxy_aware`` reflects what was actually
-        # sent (proxy-aware task name + creds vs proxyless); the cost
-        # counter uses this to apply proxy-aware pricing. ``last_compat_rejected``
-        # is True when a proxy was configured but the (provider, variant,
-        # type) tuple rejected — caller downgrades ``solver_confidence``
-        # to "low".
-        self.last_used_proxy_aware: bool = False
-        self.last_compat_rejected: bool = False
+        # NOTE: Prior versions of this class exposed ``last_used_proxy_aware``
+        # and ``last_compat_rejected`` instance attributes that ``solve()``
+        # stamped after every call so the BrowserManager could pick up the
+        # proxy-aware billing tier. Those attrs RACED ACROSS CONCURRENT
+        # AGENTS sharing a single CaptchaSolver instance — agent A's solve
+        # could overwrite agent B's flags between B's stamp and B's read.
+        # Replaced by the per-call :class:`SolveResult` dataclass returned
+        # from :meth:`solve`. Subclasses that referenced the old attrs need
+        # to migrate to the new ``solve() -> SolveResult`` shape.
         # ── §11.9 per-type timeout table ────────────────────────────────
         # Resolved once at solver init from the static defaults plus any
         # ``CAPTCHA_TIMEOUT_<KIND_UPPER_UNDERSCORE>_MS`` env overrides.
@@ -994,8 +1063,24 @@ class CaptchaSolver:
 
     # ── §11.16 health check + circuit breaker ──────────────────────────
 
-    def is_solver_unreachable(self) -> bool:
-        """Sticky for the rest of the instance-session once health-check fails."""
+    async def is_solver_unreachable(self) -> bool:
+        """Return ``True`` iff the solver has been marked unreachable.
+
+        Lazy: when the per-process health probe hasn't fired yet, this
+        method drives it before reading the cached state. Prior versions
+        of this method were synchronous and read a pre-set flag —
+        :meth:`solve` was the *only* path that triggered the probe, so
+        the FIRST captcha of a session ALWAYS slipped past the
+        :meth:`_check_captcha` ``is_solver_unreachable()`` gate (which
+        runs BEFORE :meth:`solve`). Lazy + async closes that hole: the
+        probe fires on the gate's read, not on the eventual solve.
+
+        After the probe completes the result is sticky for the rest of
+        the instance-session — subsequent calls return the cached flag
+        without re-probing.
+        """
+        if not self._solver_health_checked:
+            await self._ensure_health_checked()
         return self._solver_unreachable
 
     def is_breaker_open(self) -> bool:
@@ -1191,7 +1276,7 @@ class CaptchaSolver:
         *,
         agent_id: str | None = None,
         kind: str | None = None,
-    ) -> bool:
+    ) -> SolveResult:
         """Attempt to solve a CAPTCHA on the page.
 
         Args:
@@ -1208,24 +1293,29 @@ class CaptchaSolver:
                 signal). Always pass when the caller already has it.
 
         Returns:
-            True if the CAPTCHA was solved and token injected, False
-            otherwise. On unreachable solver / open breaker, returns False
-            without issuing a provider HTTP call. Callers should consult
-            :meth:`is_solver_unreachable` and :meth:`is_breaker_open` to
-            distinguish those cases from a genuine solve failure.
+            :class:`SolveResult` describing the outcome. Fields:
 
-        After every call (success or failure) the caller may inspect
-        :attr:`last_used_proxy_aware` and :attr:`last_compat_rejected`
-        to learn whether the dedicated solver proxy was applied (drives
-        cost-counter pricing tier and ``solver_confidence`` downgrades).
+              * ``token`` — non-``None`` iff a token was retrieved from
+                the provider (regardless of whether injection succeeded).
+                Cost accounting MUST fire on a non-``None`` token because
+                the provider already charged.
+              * ``injection_succeeded`` — ``True`` iff the token landed
+                in the page DOM. Only meaningful when ``token`` is set.
+              * ``used_proxy_aware`` / ``compat_rejected`` — replaces the
+                old per-instance scratch attrs. Read directly off the
+                returned :class:`SolveResult`; concurrent solves on
+                different agents now own their own SolveResult objects
+                instead of racing on shared instance state.
+
+            Short-circuit returns (no provider HTTP call):
+              * solver unreachable → ``token=None, injection_succeeded=False``.
+              * breaker open → same.
         """
-        # Reset the per-call metadata up front so a short-circuit return
-        # (unreachable / breaker) doesn't carry stale flags into the
-        # caller's envelope.
-        self.last_used_proxy_aware = False
-        self.last_compat_rejected = False
-
         # Per-process gate — runs at most once even under concurrent solves.
+        # NOTE: ``is_solver_unreachable`` is the authoritative gate (now
+        # async + lazy in §11.16); awaiting the helper here is kept as a
+        # belt-and-suspenders cache primer for direct callers that don't
+        # go through the gate.
         await self._ensure_health_checked()
 
         if self._solver_unreachable:
@@ -1233,14 +1323,20 @@ class CaptchaSolver:
                 "Skipping solve: solver marked unreachable for this session "
                 "(provider=%s)", self.provider,
             )
-            return False
+            return SolveResult(
+                token=None, injection_succeeded=False,
+                used_proxy_aware=False, compat_rejected=False,
+            )
 
         if self.is_breaker_open():
             logger.warning(
                 "Skipping solve: solver circuit breaker open until %.0f (provider=%s)",
                 self._solver_breaker_until, self.provider,
             )
-            return False
+            return SolveResult(
+                token=None, injection_succeeded=False,
+                used_proxy_aware=False, compat_rejected=False,
+            )
 
         captcha_type = _classify_captcha(selector)
         # §11.1 — when the coarse selector classifier says "recaptcha", run
@@ -1265,7 +1361,10 @@ class CaptchaSolver:
         if not sitekey:
             logger.warning("Could not extract sitekey for %s CAPTCHA", captcha_type)
             await self._record_solver_outcome(success=False)
-            return False
+            return SolveResult(
+                token=None, injection_succeeded=False,
+                used_proxy_aware=False, compat_rejected=False,
+            )
 
         # §11.2 — load the dedicated solver-proxy config (NOT the agent's
         # primary egress proxy; see ``get_solver_proxy_config`` docstring).
@@ -1296,20 +1395,31 @@ class CaptchaSolver:
                 timeout_s, timeout_kind,
             )
             await self._record_solver_outcome(success=False)
-            return False
-        except Exception:
-            logger.exception("CAPTCHA solve failed")
+            return SolveResult(
+                token=None, injection_succeeded=False,
+                used_proxy_aware=False, compat_rejected=False,
+            )
+        except Exception as exc:
+            # Redact the exception text — provider error responses
+            # occasionally echo ``clientKey`` back. Pair with
+            # :func:`redact_url` for any URL-shaped data in ``repr(exc)``.
+            logger.warning(
+                "CAPTCHA solve failed: %s",
+                _redact_clientkey_text(redact_url(repr(exc))),
+            )
             await self._record_solver_outcome(success=False)
-            return False
-
-        # Stamp metadata before returning so the caller can read the
-        # actual task type that was sent.
-        self.last_used_proxy_aware = used_proxy_aware
-        self.last_compat_rejected = compat_rejected
+            return SolveResult(
+                token=None, injection_succeeded=False,
+                used_proxy_aware=False, compat_rejected=False,
+            )
 
         if not token:
             await self._record_solver_outcome(success=False)
-            return False
+            return SolveResult(
+                token=None, injection_succeeded=False,
+                used_proxy_aware=used_proxy_aware,
+                compat_rejected=compat_rejected,
+            )
 
         # §11.11 — solve-pacing Gaussian delay between solver token
         # retrieval and DOM injection. Real users take 5-15s between a
@@ -1328,8 +1438,16 @@ class CaptchaSolver:
             )
         else:
             logger.warning("CAPTCHA solved but token injection failed")
-        await self._record_solver_outcome(success=injected)
-        return injected
+        # Breaker tracks SOLVER reliability (provider returned a token), not
+        # injection success. Provider was paid the moment the token came
+        # back; injection failure is our problem, not theirs.
+        await self._record_solver_outcome(success=True)
+        return SolveResult(
+            token=token,
+            injection_succeeded=bool(injected),
+            used_proxy_aware=used_proxy_aware,
+            compat_rejected=compat_rejected,
+        )
 
     async def _extract_sitekey(self, page, captcha_type: str) -> str | None:
         """Extract the sitekey from the page DOM."""

--- a/src/browser/captcha_cost_counter.py
+++ b/src/browser/captcha_cost_counter.py
@@ -73,6 +73,11 @@ PRICING_CENTS: dict[str, int] = {
     "2captcha-recaptcha-enterprise-v3": 200,
     "2captcha-hcaptcha": 100,
     "2captcha-turnstile": 200,
+    # CF-bound Turnstile (§11.3 ``cf-interstitial-turnstile``) — solver
+    # path is identical to standalone Turnstile; only the envelope ``kind``
+    # differs. Aliased here so :func:`estimate_cents` doesn't return ``None``
+    # for the CF variant and trip the spurious "no published rate" warning.
+    "2captcha-cf-interstitial-turnstile": 200,
     # CapSolver — published https://docs.capsolver.com/guide/captcha/
     "capsolver-recaptcha-v2-checkbox": 80,
     "capsolver-recaptcha-v2-invisible": 80,
@@ -82,6 +87,7 @@ PRICING_CENTS: dict[str, int] = {
     "capsolver-recaptcha-enterprise-v3": 200,
     "capsolver-hcaptcha": 100,
     "capsolver-turnstile": 60,
+    "capsolver-cf-interstitial-turnstile": 60,
 }
 
 # §11.2 — proxy-aware pricing tier (~3× the proxyless rate as published
@@ -100,6 +106,9 @@ PRICING_CENTS_PROXY_AWARE: dict[tuple[str, str], int] = {
     ("2captcha", "recaptcha-enterprise-v2"):  600,
     ("2captcha", "hcaptcha"):                 300,
     ("2captcha", "turnstile"):                600,
+    # CF-bound Turnstile takes the same proxy-aware tier as standalone
+    # Turnstile — the solver task is identical (§11.3).
+    ("2captcha", "cf-interstitial-turnstile"): 600,
     # CapSolver — 3× the proxyless rate
     ("capsolver", "recaptcha-v2-checkbox"):   240,
     ("capsolver", "recaptcha-v2-invisible"):  240,
@@ -108,6 +117,7 @@ PRICING_CENTS_PROXY_AWARE: dict[tuple[str, str], int] = {
     ("capsolver", "recaptcha-enterprise-v3"): 600,
     ("capsolver", "hcaptcha"):                300,
     ("capsolver", "turnstile"):               180,
+    ("capsolver", "cf-interstitial-turnstile"): 180,
 }
 
 
@@ -251,11 +261,26 @@ async def snapshot(path: Path | str | None = None) -> bool:
 
     tmp = target.with_suffix(target.suffix + ".tmp")
     try:
-        with open(tmp, "w", encoding="utf-8") as fh:
-            json.dump(payload, fh)
-            fh.flush()
-            os.fsync(fh.fileno())
+        # Open with 0o600 from the start (umask-aware) so there is no
+        # world-readable window before the explicit chmod below. The
+        # cost ledger is operator-grade billing data — same posture as
+        # ``.env`` files (CLAUDE.md §Security Boundaries).
+        fd = os.open(tmp, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+        try:
+            os.fchmod(fd, 0o600)
+            with os.fdopen(fd, "w", encoding="utf-8") as fh:
+                json.dump(payload, fh)
+                fh.flush()
+                os.fsync(fh.fileno())
+        except Exception:
+            os.close(fd)
+            raise
         os.replace(tmp, target)
+        # ``os.replace`` preserves the destination's mode on most
+        # filesystems but the Python docs are not load-bearing on this;
+        # explicit chmod after replace ensures 0o600 regardless of
+        # whether the target existed (and what its prior mode was).
+        os.chmod(target, 0o600)
     except OSError as e:
         logger.warning("captcha_cost snapshot failed: %s", e)
         try:

--- a/src/browser/service.py
+++ b/src/browser/service.py
@@ -25,9 +25,11 @@ from pathlib import Path
 from urllib.parse import urlparse
 
 from src.browser.captcha import (
+    SolveResult,
     _classify_behavioral,
     _classify_cf_state,
     _classify_recaptcha,
+    _redact_clientkey_text,
     get_solver,
 )
 from src.browser.profile_schema import migrate_profile
@@ -47,6 +49,7 @@ from src.browser.timing import (
     x11_settle_delay,
     x11_step_delay,
 )
+from src.shared.redaction import redact_url
 from src.shared.types import AGENT_ID_RE_PATTERN
 from src.shared.utils import sanitize_for_prompt, setup_logging
 
@@ -84,9 +87,12 @@ logger = setup_logging("browser.service")
 #       fetch followed by a failed injection that we cannot distinguish at
 #       this layer).
 #     - injection_failed: token fetched but injection rejected.
-#       *RESERVED* — the current ``CaptchaSolver.solve()`` returns ``bool``,
-#       so this layer cannot disambiguate it from ``rejected``. Wired up
-#       once the solver returns a richer result (planned alongside §11.18).
+#       Surfaced when ``SolveResult.token`` is non-None but
+#       ``injection_succeeded`` is False — the provider was paid (cost
+#       counted) but our DOM injection failed. ``injection_failure_reason``
+#       is set to ``"injection_failed_unspecified"`` for now; finer
+#       disambiguation (CSP block, textarea_not_found, etc.) is a
+#       §11.6/§11.20 deferred item.
 #     - no_solver: no provider configured (``CAPTCHA_SOLVER_PROVIDER`` empty).
 #     - unsupported: detected kind has no solver path. *RESERVED* until the
 #       kind→provider matrix lands.
@@ -195,6 +201,112 @@ async def _check_solve_rate(agent_id: str, limit_per_hour: int) -> bool:
             return True
         bucket.append(now)
         return False
+
+
+def _resolve_rate_limit(agent_id: str) -> int:
+    """Read the per-hour solve-rate limit for an agent, with fallback default."""
+    from src.browser.flags import get_int
+    return get_int(
+        "CAPTCHA_RATE_LIMIT_PER_HOUR", 20,
+        agent_id=agent_id, min_value=0, max_value=10000,
+    )
+
+
+def _resolve_cost_cap(agent_id: str) -> int:
+    """Read the monthly per-agent cost cap (USD) and convert to cents.
+
+    Returns 0 when unset or invalid (caller treats 0 as "no cap"). Reads
+    via ``flags.get_str`` so per-agent overrides take precedence over the
+    raw env var (matches the pattern used elsewhere for captcha flags).
+    """
+    from src.browser.flags import get_str
+    cap_usd_str = get_str(
+        "CAPTCHA_COST_LIMIT_USD_PER_AGENT_MONTH", "", agent_id=agent_id,
+    )
+    if not cap_usd_str:
+        return 0
+    try:
+        return int(round(float(cap_usd_str) * 100))
+    except ValueError:
+        logger.warning(
+            "Invalid CAPTCHA_COST_LIMIT_USD_PER_AGENT_MONTH=%r — treating "
+            "as unset", cap_usd_str,
+        )
+        return 0
+
+
+# ── §11.14 / §2.7 audit-log aggregator ────────────────────────────────────
+#
+# Operators need to see when the cost-cap / rate-limit / behavioral-skip
+# gates fire — otherwise a misconfigured cap silently blocks every solve
+# without any signal. The §2.7 cadence forbids per-call dashboard events
+# (would flood the WebSocket on a hot loop); aggregate per minute keyed
+# by ``(agent_id, outcome, kind)``.
+#
+# State is module-global because the BrowserManager is a singleton in the
+# browser service container. The flush is driven from
+# :meth:`BrowserManager._emit_metrics` (already on a 60s tick); see
+# ``_drain_captcha_audit`` below.
+_captcha_audit_lock: asyncio.Lock = asyncio.Lock()
+# {(agent_id, outcome, kind): {"count": int, "first_ts": float, "last_url": str}}
+_captcha_audit_buckets: dict[tuple[str, str, str], dict] = {}
+
+
+async def _record_captcha_audit_event(
+    agent_id: str, outcome: str, kind: str, page_url: str,
+) -> None:
+    """Aggregate a captcha gate event into the per-minute bucket.
+
+    Outcomes recorded: ``cost_cap``, ``rate_limited``, ``skipped_behavioral``.
+    Aggregation by ``(agent_id, outcome, kind)`` so a noisy retry loop on
+    one agent doesn't drown out the others. ``page_url`` is redacted via
+    :func:`redact_url` before storage; only the most recent redacted URL
+    in the bucket is retained (the bucket is dashboard signal, not an
+    audit trail).
+    """
+    async with _captcha_audit_lock:
+        key = (agent_id, outcome, kind)
+        bucket = _captcha_audit_buckets.get(key)
+        now = time.time()
+        safe_url = redact_url(page_url) if page_url else ""
+        if bucket is None:
+            _captcha_audit_buckets[key] = {
+                "count": 1,
+                "first_ts": now,
+                "last_url": safe_url,
+            }
+        else:
+            bucket["count"] += 1
+            bucket["last_url"] = safe_url
+
+
+async def _drain_captcha_audit() -> list[dict]:
+    """Atomically swap the audit-bucket dict and return the drained payloads.
+
+    Called once per metrics-emit tick. Each returned dict is one
+    EventBus payload; the caller is responsible for actually emitting
+    via the configured ``metrics_sink``.
+    """
+    async with _captcha_audit_lock:
+        if not _captcha_audit_buckets:
+            return []
+        # Snapshot copy under lock so the subsequent ``clear()`` doesn't
+        # wipe out the in-flight dict (dict assignment is by reference,
+        # not value).
+        buckets = dict(_captcha_audit_buckets)
+        _captcha_audit_buckets.clear()
+    drained = []
+    for (agent_id, outcome, kind), info in buckets.items():
+        drained.append({
+            "type": "captcha_gate",
+            "agent": agent_id,
+            "outcome": outcome,
+            "kind": kind,
+            "count": info["count"],
+            "first_ts": info["first_ts"],
+            "url": info["last_url"],
+        })
+    return drained
 
 
 def _kind_confidence(kind: str) -> str:
@@ -1861,8 +1973,6 @@ class BrowserManager:
         corrupt counter must not abort the emit loop and starve the other
         agents' data.
         """
-        if not self._instances:
-            return
         now = time.time()
         # Take a consistent view of the instance list; ``drain_metrics()``
         # is a fully synchronous read-then-reset so no ``await`` boundary
@@ -1899,6 +2009,31 @@ class BrowserManager:
             except Exception as e:
                 logger.warning(
                     "Metrics sink raised for '%s': %s", inst.agent_id, e,
+                )
+
+        # §11.14 / §2.7 — drain the captcha audit-log buckets so the
+        # cost-cap / rate-limit / behavioral-skip events surface to the
+        # dashboard once per minute (NOT per call). Reuses the same
+        # ``metrics_sink`` plumbing that delivers per-agent metrics.
+        try:
+            audit_events = await _drain_captcha_audit()
+        except Exception as e:
+            logger.warning("captcha audit drain failed: %s", e)
+            audit_events = []
+        for ev in audit_events:
+            ev = dict(ev)
+            self._metrics_seq += 1
+            ev["seq"] = self._metrics_seq
+            ev["ts"] = now
+            self._metrics_history.append(ev)
+            if self._metrics_sink is None:
+                continue
+            try:
+                self._metrics_sink(ev)
+            except Exception as e:
+                logger.warning(
+                    "captcha audit sink raised for '%s': %s",
+                    ev.get("agent", ""), e,
                 )
 
     def get_recent_metrics(self, since_seq: int = 0) -> dict:
@@ -5452,8 +5587,119 @@ class BrowserManager:
             except Exception as e:
                 return {"success": False, "error": str(e)}
 
+    async def _metered_solve(
+        self,
+        inst: CamoufoxInstance,
+        sel: str,
+        kind: str,
+    ) -> SolveResult:
+        """Run rate + cost gates, invoke the solver, account on token retrieval.
+
+        This is the SINGLE entry point to ``self._captcha_solver.solve()``.
+        Centralizing the gates here closes the long-standing bug where
+        ``solve_captcha`` checked the rate-limit + cost-cap AFTER
+        ``_check_captcha`` had already invoked the solver, AND where the
+        navigate / click auto-detect paths bypassed the gates entirely.
+        Now every path that detects a captcha and runs a solver flows
+        through ``_check_captcha`` → ``_metered_solve`` → gates → solver.
+
+        Order of operations:
+
+          1. Rate-limit gate (records a slot only on a real attempt — gates
+             that short-circuit don't burn the per-hour budget).
+          2. Cost-cap gate (read against the agent's monthly bucket).
+          3. Solver HTTP call. ``solve()`` returns :class:`SolveResult`.
+          4. Cost accounting. Increments fire when ``result.token is not
+             None`` regardless of ``injection_succeeded`` — the provider
+             was paid the moment the token came back; injection failure
+             is our problem, not theirs. ``solver_attempted=False`` paths
+             (gates, behavioral, no-solver) skip accounting AND skip the
+             "no published rate" warning (it's not a billing event).
+
+        Returns the :class:`SolveResult` so the caller (``_check_captcha``)
+        can build the §11.13 envelope from the per-call data — no shared
+        instance state to race on.
+        """
+        agent_id = inst.agent_id
+        try:
+            page_url = inst.page.url or ""
+        except Exception:
+            page_url = ""
+
+        # Rate-limit gate. ``_check_solve_rate`` consumes a slot only on
+        # the actual-attempt path (returning False); a True return means
+        # we are over the limit, no slot consumed.
+        rate_limit = _resolve_rate_limit(agent_id)
+        if await _check_solve_rate(agent_id, rate_limit):
+            await _record_captcha_audit_event(
+                agent_id, "rate_limited", kind, page_url,
+            )
+            return SolveResult(
+                token=None, injection_succeeded=False,
+                used_proxy_aware=False, compat_rejected=False,
+                skipped="rate_limited",
+            )
+
+        # Cost-cap gate.
+        cap_cents = _resolve_cost_cap(agent_id)
+        if cap_cents > 0:
+            from src.browser import captcha_cost_counter as _cost
+            if await _cost.over_cap(agent_id, cap_cents):
+                await _record_captcha_audit_event(
+                    agent_id, "cost_cap", kind, page_url,
+                )
+                return SolveResult(
+                    token=None, injection_succeeded=False,
+                    used_proxy_aware=False, compat_rejected=False,
+                    skipped="cost_cap",
+                )
+
+        # Run the actual solver. Any exception bubbles up so the caller can
+        # build the appropriate ``timeout``/``rejected`` envelope; we don't
+        # swallow them here because the envelope-mapping is caller-specific.
+        result = await self._captcha_solver.solve(
+            inst.page, sel, page_url,
+            agent_id=agent_id, kind=kind,
+        )
+
+        # Cost accounting fires on token retrieval, NOT on injection
+        # success — the provider already charged for the token. Skip
+        # accounting when no token came back (gates / sitekey-fail /
+        # provider-reject / breaker / unreachable).
+        if result.token is not None:
+            from src.browser import captcha_cost_counter as _cost
+            provider = getattr(self._captcha_solver, "provider", "")
+            # Defensive: solver mocks in tests sometimes leave provider
+            # as a MagicMock auto-spec child; only proceed when we have
+            # an actual string we can pass to ``estimate_cents``.
+            if isinstance(provider, str) and provider:
+                cents = _cost.estimate_cents(
+                    provider, kind,
+                    proxy_aware=result.used_proxy_aware,
+                )
+                if cents is None:
+                    logger.warning(
+                        "captcha solve: no published rate for "
+                        "provider=%s kind=%s proxy_aware=%s — "
+                        "skipping cost increment "
+                        "(under-count > over-count)",
+                        provider, kind, result.used_proxy_aware,
+                    )
+                else:
+                    await _cost.add_cost(agent_id, cents)
+        return result
+
     async def _check_captcha(self, inst: CamoufoxInstance) -> dict:
         """Check for CAPTCHA elements and attempt auto-solve if configured.
+
+        **Lock hold time.** When the §11.3 CF auto-resolving challenge
+        path fires, this method holds ``inst.lock`` for up to
+        :data:`_CF_AUTO_WAIT_SECONDS` (8s) while awaiting the recheck.
+        Other in-flight requests to the same agent block during this
+        window. This is intentional — the agent should not interact with
+        the page while CF resolves, and the alternative (releasing and
+        re-acquiring) opens a window where ``click()`` could fire on a
+        challenge widget mid-resolution.
 
         Returns the §11.13 structured envelope ``data`` block in all cases:
           - ``{"captcha_found": false}`` when no captcha selector matched.
@@ -5495,7 +5741,11 @@ class BrowserManager:
           provider unreachable for this instance-session. Short-circuits
           to ``solver_outcome="no_solver"`` /
           ``next_action="request_captcha_help"``; the API is never
-          contacted.
+          contacted. The check is async + lazy: when the per-process
+          probe hasn't fired, the read awaits the probe rather than
+          falling through to ``solver.solve()`` and finding out there.
+          This closes the original first-captcha-of-session bug where
+          the gate read fired before the probe ran.
         * ``solver.is_breaker_open()`` — sliding-window circuit breaker
           is tripped. Short-circuits to ``solver_outcome="timeout"`` /
           ``next_action="request_captcha_help"`` plus a top-level
@@ -5503,6 +5753,14 @@ class BrowserManager:
           encoded as a new enum value, to avoid colliding with §11.13's
           ``solver_outcome`` set; a richer ``service_unavailable``
           outcome may land in a follow-up).
+
+        Solver invocation is delegated to :meth:`_metered_solve` which
+        runs the rate-limit + cost-cap gates BEFORE the HTTP call and
+        accounts cost on token retrieval (not injection success). All
+        callers — navigate auto-detect, click auto-detect, ``solve_captcha``,
+        ``detect_captcha`` — flow through this single method, so the
+        gates can no longer be bypassed by reaching the solver from a
+        non-explicit path.
         """
         captcha_selectors = [
             'iframe[src*="recaptcha"]',
@@ -5553,6 +5811,18 @@ class BrowserManager:
                             "skipping solver, escalating to request_captcha_help",
                             behavioral_kind,
                         )
+                        # Audit-log so operators see the activity in the
+                        # dashboard (per §2.7 cadence — aggregated, not
+                        # per-call). URL flows through ``redact_url``
+                        # inside the recorder.
+                        try:
+                            page_url = inst.page.url or ""
+                        except Exception:
+                            page_url = ""
+                        await _record_captcha_audit_event(
+                            inst.agent_id, "skipped_behavioral",
+                            behavioral_kind, page_url,
+                        )
                         return _captcha_envelope(
                             kind=behavioral_kind,
                             solver_attempted=False,
@@ -5575,6 +5845,14 @@ class BrowserManager:
                             "CF interstitial classified as behavioral "
                             "(under-attack / persistent challenge); "
                             "skipping solver",
+                        )
+                        try:
+                            page_url = inst.page.url or ""
+                        except Exception:
+                            page_url = ""
+                        await _record_captcha_audit_event(
+                            inst.agent_id, "skipped_behavioral",
+                            "cf-interstitial-behavioral", page_url,
                         )
                         return _captcha_envelope(
                             kind="cf-interstitial-behavioral",
@@ -5625,6 +5903,14 @@ class BrowserManager:
                             "CF auto-resolving challenge still present "
                             "after wait; treating as behavioral",
                         )
+                        try:
+                            page_url = inst.page.url or ""
+                        except Exception:
+                            page_url = ""
+                        await _record_captcha_audit_event(
+                            inst.agent_id, "skipped_behavioral",
+                            "cf-interstitial-behavioral", page_url,
+                        )
                         return _captcha_envelope(
                             kind="cf-interstitial-behavioral",
                             solver_attempted=False,
@@ -5657,13 +5943,13 @@ class BrowserManager:
                     if self._captcha_solver:
                         # §11.16 short-circuits — check solver health
                         # BEFORE attempting a solve. ``is_solver_unreachable``
-                        # means the per-instance health probe failed; we
-                        # don't even try the API. ``is_breaker_open`` means
-                        # the sliding-window breaker is tripped after
-                        # repeated solve failures; treat as a transient
-                        # outage and surface a top-level ``breaker_open``
-                        # flag (additive — see §11.13 enum docstring).
-                        if self._captcha_solver.is_solver_unreachable():
+                        # is async + lazy: when the per-process health
+                        # probe hasn't fired yet, the read drives it
+                        # under the solver's state-lock so the FIRST
+                        # captcha of a session sees the gate fire (the
+                        # prior synchronous read happened before the
+                        # probe could run inside ``solve()``).
+                        if await self._captcha_solver.is_solver_unreachable():
                             logger.warning(
                                 "CAPTCHA detected (%s), solver marked unreachable; skipping",
                                 sel,
@@ -5692,12 +5978,13 @@ class BrowserManager:
                             envelope["breaker_open"] = True
                             return _finalize(envelope)
                         logger.info("CAPTCHA detected (%s), attempting auto-solve", sel)
+                        # Single entry point for solver invocation. The
+                        # rate-limit + cost-cap gates fire inside
+                        # ``_metered_solve`` BEFORE the solver HTTP call,
+                        # and accounting fires on token retrieval (NOT on
+                        # injection success — provider was paid already).
                         try:
-                            solved = await self._captcha_solver.solve(
-                                inst.page, sel, inst.page.url,
-                                agent_id=inst.agent_id,
-                                kind=kind,
-                            )
+                            result = await self._metered_solve(inst, sel, kind)
                         except asyncio.TimeoutError:
                             # Solver took too long — true "timeout" semantic.
                             return _finalize(_captcha_envelope(
@@ -5711,16 +5998,19 @@ class BrowserManager:
                             # land here. A third-party CaptchaSolver subclass
                             # could let httpx errors bubble up; the bundled
                             # ``CaptchaSolver`` (src/browser/captcha.py)
-                            # swallows them and returns False instead. We
-                            # treat httpx timeouts as "timeout" and other
-                            # exceptions as "rejected" — closest fit in the
-                            # §11.13 enum (no "service_error" exists). A
-                            # richer SolverResult that distinguishes
-                            # transport vs verdict failure is planned
-                            # alongside §11.18.
+                            # converts them into a no-token :class:`SolveResult`
+                            # internally. We treat httpx timeouts as
+                            # "timeout" and other exceptions as "rejected" —
+                            # closest fit in the §11.13 enum.
                             if _is_httpx_timeout(exc):
+                                # Redact ``repr(exc)`` — httpx error strings
+                                # can include the request URL which carries
+                                # the ``clientKey``. Pair with
+                                # :func:`redact_url` like the bundled solver
+                                # already does.
                                 logger.warning(
-                                    "Auto-solve timed out (httpx): %r", exc,
+                                    "Auto-solve timed out (httpx): %s",
+                                    _redact_clientkey_text(redact_url(repr(exc))),
                                 )
                                 return _finalize(_captcha_envelope(
                                     kind=kind, solver_attempted=True,
@@ -5728,55 +6018,89 @@ class BrowserManager:
                                     solver_confidence="low",
                                     next_action="notify_user",
                                 ))
-                            logger.exception("Auto-solve raised, falling back")
+                            # ``logger.exception`` includes the traceback
+                            # which can carry URL-shaped or clientKey-laden
+                            # strings. Use ``logger.warning`` with a
+                            # redacted ``repr(exc)`` instead.
+                            logger.warning(
+                                "Auto-solve raised, falling back: %s",
+                                _redact_clientkey_text(redact_url(repr(exc))),
+                                exc_info=False,
+                            )
                             return _finalize(_captcha_envelope(
                                 kind=kind, solver_attempted=True,
                                 solver_outcome="rejected",
                                 solver_confidence="low",
                                 next_action="notify_user",
                             ))
-                        if solved:
-                            # §11.2 — when the solver-proxy compat table
-                            # rejected the configured proxy for this
-                            # variant, we sent the proxyless task body
-                            # instead. The solve still succeeded, but the
-                            # operator's chosen IP profile didn't reach
-                            # the provider — signal "low" confidence so
-                            # downstream consumers can surface "the token
-                            # came from the provider's pool, not yours".
-                            # Strict ``is True`` so test mocks that
-                            # auto-spec attrs as MagicMocks (truthy) don't
-                            # accidentally trip the downgrade. The §11.3
-                            # ``_finalize`` helper still applies on top —
-                            # CF-Turnstile force-low override converges
-                            # naturally with the compat-rejected downgrade.
-                            confidence = "high"
-                            if getattr(
-                                self._captcha_solver,
-                                "last_compat_rejected", False,
-                            ) is True:
-                                confidence = "low"
+
+                        # ── Map :class:`SolveResult` to §11.13 envelope ──
+                        # Gate-skipped paths return without ``solver_attempted``
+                        # because no provider HTTP call ran.
+                        if result.skipped == "rate_limited":
+                            return _finalize(_captcha_envelope(
+                                kind=kind, solver_attempted=False,
+                                solver_outcome="rate_limited",
+                                solver_confidence=_kind_confidence(kind),
+                                next_action="request_captcha_help",
+                            ))
+                        if result.skipped == "cost_cap":
+                            return _finalize(_captcha_envelope(
+                                kind=kind, solver_attempted=False,
+                                solver_outcome="cost_cap",
+                                solver_confidence=_kind_confidence(kind),
+                                next_action="request_captcha_help",
+                            ))
+
+                        if result.token is None:
+                            # No token retrieved — provider was not
+                            # charged. Conflates (a) provider verdict
+                            # reject / errorId>0, (b) sitekey not
+                            # extractable, (c) outer-deadline timeout
+                            # captured inside ``solve()``. Map all to
+                            # ``rejected`` (closest §11.13 fit).
+                            logger.warning("Auto-solve failed, falling back to manual")
                             return _finalize(_captcha_envelope(
                                 kind=kind, solver_attempted=True,
-                                solver_outcome="solved",
-                                solver_confidence=confidence,
-                                next_action="solved",
+                                solver_outcome="rejected",
+                                solver_confidence="low",
+                                next_action="notify_user",
                             ))
-                        # solver.solve() returned False. Today this conflates
-                        # three failure modes: (a) provider verdict reject /
-                        # errorId>0, (b) sitekey not extractable, (c) token
-                        # fetched but injection failed. The §11.13 spec
-                        # reserves ``injection_failed`` for case (c), but
-                        # the solver surface returns plain bool — we cannot
-                        # distinguish without a richer return type. Map all
-                        # three to ``rejected`` for now and revisit once the
-                        # solver returns structured results.
-                        logger.warning("Auto-solve failed, falling back to manual")
+
+                        # Token retrieved. Provider was charged. Cost was
+                        # already incremented inside ``_metered_solve``.
+                        if not result.injection_succeeded:
+                            # §11.13 ``injection_failed`` outcome — the
+                            # provider returned a valid token but our
+                            # ``_inject_token`` rejected it. The bool
+                            # surface from ``_inject_token`` doesn't tell
+                            # us which case it was (CSP block, textarea
+                            # not found, callback not in config, widget
+                            # not found) — that's a §11.6/§11.20 deferred
+                            # item; surface ``injection_failed_unspecified``
+                            # for now so operators see the case distinctly.
+                            return _finalize(_captcha_envelope(
+                                kind=kind, solver_attempted=True,
+                                solver_outcome="injection_failed",
+                                solver_confidence="low",
+                                next_action="notify_user",
+                                injection_failure_reason=(
+                                    "injection_failed_unspecified"
+                                ),
+                            ))
+
+                        # §11.2 — compat-rejected proxy fallback downgrades
+                        # confidence to "low" even on a successful solve;
+                        # the operator's chosen IP profile didn't reach
+                        # the provider so the token came from the provider's
+                        # pool, not the operator's. ``_finalize`` further
+                        # applies the §11.3 CF-Turnstile force-low.
+                        confidence = "low" if result.compat_rejected else "high"
                         return _finalize(_captcha_envelope(
                             kind=kind, solver_attempted=True,
-                            solver_outcome="rejected",
-                            solver_confidence="low",
-                            next_action="notify_user",
+                            solver_outcome="solved",
+                            solver_confidence=confidence,
+                            next_action="solved",
                         ))
                     # No solver configured — surface to agent for manual VNC.
                     # Confidence reflects how firmly we classified the kind:
@@ -5850,19 +6174,25 @@ class BrowserManager:
     ) -> dict:
         """Agent-triggered CAPTCHA solve.
 
-        Layered around :meth:`_check_captcha` rather than parallel to it so
-        we get §11.13 envelope semantics + §11.16 health-check / breaker
-        short-circuits for free.
+        Layered around :meth:`_check_captcha` so we get §11.13 envelope
+        semantics, §11.16 health/breaker short-circuits, AND the
+        :meth:`_metered_solve` rate-limit + cost-cap gates for free —
+        the pre-refactor implementation duplicated these gates here, but
+        they fired AFTER ``_check_captcha`` had already invoked the
+        solver, defeating the purpose. All gates now sit inside
+        ``_metered_solve`` and apply uniformly across navigate auto-detect,
+        click auto-detect, and explicit ``solve_captcha`` calls.
 
-        Pre-solve gates (in order):
+        Local pre-checks (cheap, no provider involvement):
           1. ``CAPTCHA_DISABLED`` flag — early-return ``no_solver`` envelope.
           2. ``hint`` validation — bad hint → ``invalid_input`` error.
           3. ``retry_previous`` TTL check — stale → ``invalid_input`` error.
           4. No-captcha early return — saves a solver invocation + cost.
-          5. Per-agent rate limit (default 20/hr, ``CAPTCHA_RATE_LIMIT_PER_HOUR``).
-          6. Per-agent monthly cost cap (``CAPTCHA_COST_LIMIT_USD_PER_AGENT_MONTH``).
-          7. Recursive-solve guard — re-entrant ``_check_captcha`` while a
+          5. Recursive-solve guard — re-entrant ``_check_captcha`` while a
              solve is in flight surfaces ``captcha_during_solve``.
+
+        Rate-limit + cost-cap fire INSIDE ``_check_captcha`` →
+        ``_metered_solve`` BEFORE the solver HTTP call.
 
         ``target_ref`` accepts a snapshot ref for selecting one captcha among
         many on the same page; multi-captcha enumeration lands in §11.6.
@@ -5871,7 +6201,7 @@ class BrowserManager:
         targeting precision yet.
         """
         # Gate 1: fleet-wide kill switch.
-        from src.browser.flags import get_bool, get_int, get_str
+        from src.browser.flags import get_bool
         if get_bool("CAPTCHA_DISABLED", False, agent_id=agent_id):
             return {
                 "success": True,
@@ -5920,10 +6250,14 @@ class BrowserManager:
             # Gate 4: no-captcha early return. Set the recursive-solve
             # guard BEFORE the call so a captcha that appears during
             # detection isn't mistaken for one we should now solve.
+            #
+            # NOTE on ``_captcha_solving``: under the current architecture
+            # ``inst.lock`` already serializes all ``solve_captcha`` calls
+            # per agent — concurrent reentry is impossible. The guard is
+            # kept as defensive code: never observed True in practice;
+            # future-proofing against design changes that release the
+            # lock around the solver call. Removing it is safe today.
             if inst._captcha_solving:
-                # Caller is reentering during an in-flight solve. Surface
-                # ``captcha_during_solve`` and let the agent escalate via
-                # request_captcha_help.
                 return {
                     "success": True,
                     "data": _with_legacy_fields(_captcha_envelope(
@@ -5936,13 +6270,21 @@ class BrowserManager:
 
             inst._captcha_solving = True
             try:
-                pre_check = await self._check_captcha(inst)
-                if not pre_check.get("captcha_found"):
-                    # No-captcha early return — short, no solver call,
-                    # no cost. Distinct from the §11.13 ``captcha_found:
-                    # false`` shape we get from the unsolicited
-                    # detection path; here we surface a top-level
-                    # ``message`` for the agent.
+                # ``_check_captcha`` runs the full pipeline:
+                # detection → classifiers → §11.16 health/breaker gates
+                # → ``_metered_solve`` (rate-limit + cost-cap +
+                # provider call + cost increment on token retrieval).
+                # Cost / rate-limit short-circuits surface as
+                # ``solver_outcome="cost_cap"`` / ``"rate_limited"``
+                # in the returned envelope — no extra gate logic needed
+                # here. Cost accounting is handled inside
+                # ``_metered_solve`` so this method no longer touches
+                # the cost counter directly.
+                envelope = await self._check_captcha(inst)
+                if not envelope.get("captcha_found"):
+                    # No-captcha early return — distinct from the §11.13
+                    # ``captcha_found: false`` shape; surface a friendly
+                    # top-level message for the agent.
                     return {
                         "success": True,
                         "data": {
@@ -5951,66 +6293,16 @@ class BrowserManager:
                         },
                     }
 
-                # Gate 5: rate limit (per-agent, sliding 1h window).
-                rate_limit = get_int(
-                    "CAPTCHA_RATE_LIMIT_PER_HOUR", 20,
-                    agent_id=agent_id, min_value=0, max_value=10000,
-                )
-                if await _check_solve_rate(agent_id, rate_limit):
-                    kind = pre_check.get("kind", "unknown")
-                    return {
-                        "success": True,
-                        "data": _with_legacy_fields(_captcha_envelope(
-                            kind=kind, solver_attempted=False,
-                            solver_outcome="rate_limited",
-                            solver_confidence=_kind_confidence(kind),
-                            next_action="request_captcha_help",
-                        )),
-                    }
-
-                # Gate 6: cost cap (per-agent, monthly, USD).
-                cap_usd_str = get_str(
-                    "CAPTCHA_COST_LIMIT_USD_PER_AGENT_MONTH", "",
-                    agent_id=agent_id,
-                )
-                cap_cents = 0
-                if cap_usd_str:
-                    try:
-                        cap_cents = int(round(float(cap_usd_str) * 100))
-                    except ValueError:
-                        logger.warning(
-                            "Invalid CAPTCHA_COST_LIMIT_USD_PER_AGENT_MONTH=%r"
-                            " — treating as unset", cap_usd_str,
-                        )
-                        cap_cents = 0
-                if cap_cents > 0:
-                    from src.browser import captcha_cost_counter as _cost
-                    if await _cost.over_cap(agent_id, cap_cents):
-                        kind = pre_check.get("kind", "unknown")
-                        return {
-                            "success": True,
-                            "data": _with_legacy_fields(_captcha_envelope(
-                                kind=kind, solver_attempted=False,
-                                solver_outcome="cost_cap",
-                                solver_confidence=_kind_confidence(kind),
-                                next_action="request_captcha_help",
-                            )),
-                        }
-
-                # If pre_check already attempted a solve (because
-                # ``_check_captcha`` always tries when a solver is
-                # configured), the result is what we'd return anyway.
-                # Stamp the last_solve_attempt for ``retry_previous``.
-                kind = pre_check.get("kind", "unknown")
+                kind = envelope.get("kind", "unknown")
                 if hint is not None and hint != kind:
                     # Hint overrides the auto-classified kind in the
                     # envelope so downstream consumers see what the
                     # agent declared. We don't re-run the solver with
                     # a different task type here — that's §11.1's
                     # variant-aware solver work; the hint at this layer
-                    # is purely classification metadata until then.
-                    pre_check = dict(pre_check)
-                    pre_check["kind"] = hint
+                    # is purely classification metadata.
+                    envelope = dict(envelope)
+                    envelope["kind"] = hint
 
                 # Stamp the last attempt for ``retry_previous`` (best
                 # effort — page.url access can fail on closed contexts).
@@ -6020,43 +6312,9 @@ class BrowserManager:
                     page_url = ""
                 inst._last_solve_attempt = ("", page_url, time.time())
 
-                # Cost accounting on success: look up published rate by
-                # (provider, kind, proxy_aware) and increment. Skip when
-                # unpriced rather than guess (under-count > over-count
-                # for trust). §11.2: ``proxy_aware`` is read from the
-                # solver's last-call metadata so we bill the tier that
-                # was actually sent (proxy-aware ~3× the proxyless rate).
-                if pre_check.get("solver_outcome") == "solved":
-                    provider = ""
-                    proxy_aware_flag = False
-                    if self._captcha_solver is not None:
-                        provider = getattr(self._captcha_solver, "provider", "")
-                        # Strict ``is True`` so AsyncMock attrs (truthy
-                        # MagicMock instances) don't promote the price tier.
-                        proxy_aware_flag = getattr(
-                            self._captcha_solver,
-                            "last_used_proxy_aware",
-                            False,
-                        ) is True
-                    if provider:
-                        from src.browser import captcha_cost_counter as _cost
-                        cents = _cost.estimate_cents(
-                            provider, kind, proxy_aware=proxy_aware_flag,
-                        )
-                        if cents is None:
-                            logger.warning(
-                                "captcha solve: no published rate for "
-                                "provider=%s kind=%s proxy_aware=%s — "
-                                "skipping cost increment "
-                                "(under-count > over-count)",
-                                provider, kind, proxy_aware_flag,
-                            )
-                        else:
-                            await _cost.add_cost(agent_id, cents)
-
                 return {
                     "success": True,
-                    "data": _with_legacy_fields(pre_check),
+                    "data": _with_legacy_fields(envelope),
                 }
             finally:
                 inst._captcha_solving = False

--- a/tests/test_browser_service.py
+++ b/tests/test_browser_service.py
@@ -7486,7 +7486,9 @@ class TestCaptchaSolverSolve:
         solver._client = mock_client
 
         result = await solver.solve(page, 'iframe[src*="recaptcha"]', "https://example.com")
-        assert result is True
+        # ``solve()`` returns SolveResult post-refactor; ``__bool__`` is
+        # token-set + injection-success, mirroring the old bool contract.
+        assert bool(result) is True
         # Verify token was injected
         page.evaluate.assert_called()
 
@@ -7521,7 +7523,7 @@ class TestCaptchaSolverSolve:
         solver._client = mock_client
 
         result = await solver.solve(page, 'iframe[src*="hcaptcha"]', "https://example.com")
-        assert result is True
+        assert bool(result) is True
 
     @pytest.mark.asyncio
     async def test_solve_timeout(self):
@@ -7556,7 +7558,7 @@ class TestCaptchaSolverSolve:
         solver._solve_timeouts_ms["recaptcha-v2-checkbox"] = 100
         with patch("src.browser.captcha._POLL_INTERVAL", 0.01):
             result = await solver.solve(page, 'iframe[src*="recaptcha"]', "https://example.com")
-        assert result is False
+        assert bool(result) is False
 
     @pytest.mark.asyncio
     async def test_solve_no_sitekey_returns_false(self):
@@ -7571,7 +7573,7 @@ class TestCaptchaSolverSolve:
         page.url = "https://example.com"
 
         result = await solver.solve(page, 'iframe[src*="recaptcha"]', "https://example.com")
-        assert result is False
+        assert bool(result) is False
 
 
 class TestCheckCaptchaAutoSolve:
@@ -7580,12 +7582,18 @@ class TestCheckCaptchaAutoSolve:
     @pytest.mark.asyncio
     async def test_check_captcha_auto_solves(self):
         """When solver succeeds, the §11.13 envelope reports solver_outcome='solved'."""
+        from src.browser.captcha import SolveResult
+
         manager = BrowserManager(profiles_dir="/tmp/test_profiles_captcha1")
 
         mock_solver = AsyncMock()
-        mock_solver.solve = AsyncMock(return_value=True)
-        # §11.16 sync getters — silence unawaited-coroutine warnings.
-        mock_solver.is_solver_unreachable = MagicMock(return_value=False)
+        mock_solver.solve = AsyncMock(return_value=SolveResult(
+            token="tok", injection_succeeded=True,
+            used_proxy_aware=False, compat_rejected=False,
+        ))
+        # §11.16 ``is_solver_unreachable`` is now async (lazy probe);
+        # ``is_breaker_open`` stays sync.
+        mock_solver.is_solver_unreachable = AsyncMock(return_value=False)
         mock_solver.is_breaker_open = MagicMock(return_value=False)
         manager._captcha_solver = mock_solver
 
@@ -7606,14 +7614,17 @@ class TestCheckCaptchaAutoSolve:
     @pytest.mark.asyncio
     async def test_check_captcha_falls_back_on_failure(self):
         """When solver fails, _check_captcha reports solver_outcome='rejected'."""
+        from src.browser.captcha import SolveResult
+
         manager = BrowserManager(profiles_dir="/tmp/test_profiles_captcha2")
 
         mock_solver = AsyncMock()
-        mock_solver.solve = AsyncMock(return_value=False)
-        # §11.16: is_solver_unreachable / is_breaker_open are sync getters.
-        # Without explicit MagicMock the AsyncMock parent returns coroutines
-        # that flunk the truthy-check.
-        mock_solver.is_solver_unreachable = MagicMock(return_value=False)
+        # No-token failure → rejected envelope.
+        mock_solver.solve = AsyncMock(return_value=SolveResult(
+            token=None, injection_succeeded=False,
+            used_proxy_aware=False, compat_rejected=False,
+        ))
+        mock_solver.is_solver_unreachable = AsyncMock(return_value=False)
         mock_solver.is_breaker_open = MagicMock(return_value=False)
         manager._captcha_solver = mock_solver
 

--- a/tests/test_browser_solve_captcha.py
+++ b/tests/test_browser_solve_captcha.py
@@ -22,7 +22,18 @@ import pytest
 
 from src.browser import captcha_cost_counter as cost
 from src.browser import service as svc
+from src.browser.captcha import SolveResult
 from src.browser.service import BrowserManager, CamoufoxInstance
+
+
+def _solved_result() -> SolveResult:
+    """Standard "solved + injected" SolveResult for solver mocks."""
+    return SolveResult(
+        token="tok",
+        injection_succeeded=True,
+        used_proxy_aware=False,
+        compat_rejected=False,
+    )
 
 
 def _mk_inst_with_locator(*, captcha_present: bool, page_url: str = "https://example.com"):
@@ -79,9 +90,9 @@ class TestSolveCaptchaSuccess:
         # Configure a fake solver that succeeds, with provider=2captcha.
         solver = MagicMock()
         solver.provider = "2captcha"
-        solver.is_solver_unreachable = MagicMock(return_value=False)
+        solver.is_solver_unreachable = AsyncMock(return_value=False)
         solver.is_breaker_open = MagicMock(return_value=False)
-        solver.solve = AsyncMock(return_value=True)
+        solver.solve = AsyncMock(return_value=_solved_result())
         mgr._captcha_solver = solver
 
         # The captcha selector that matches (iframe[src*=hcaptcha]) will
@@ -114,9 +125,9 @@ class TestSolveCaptchaCostCap:
 
         solver = MagicMock()
         solver.provider = "2captcha"
-        solver.is_solver_unreachable = MagicMock(return_value=False)
+        solver.is_solver_unreachable = AsyncMock(return_value=False)
         solver.is_breaker_open = MagicMock(return_value=False)
-        solver.solve = AsyncMock(return_value=True)
+        solver.solve = AsyncMock(return_value=_solved_result())
         mgr._captcha_solver = solver
 
         result = await mgr.solve_captcha("agent-1")
@@ -139,9 +150,9 @@ class TestSolveCaptchaRateLimit:
 
         solver = MagicMock()
         solver.provider = "2captcha"
-        solver.is_solver_unreachable = MagicMock(return_value=False)
+        solver.is_solver_unreachable = AsyncMock(return_value=False)
         solver.is_breaker_open = MagicMock(return_value=False)
-        solver.solve = AsyncMock(return_value=True)
+        solver.solve = AsyncMock(return_value=_solved_result())
         mgr._captcha_solver = solver
 
         result = await mgr.solve_captcha("agent-1")
@@ -176,9 +187,9 @@ class TestSolveCaptchaRetryPrevious:
 
         solver = MagicMock()
         solver.provider = "2captcha"
-        solver.is_solver_unreachable = MagicMock(return_value=False)
+        solver.is_solver_unreachable = AsyncMock(return_value=False)
         solver.is_breaker_open = MagicMock(return_value=False)
-        solver.solve = AsyncMock(return_value=True)
+        solver.solve = AsyncMock(return_value=_solved_result())
         mgr._captcha_solver = solver
 
         result = await mgr.solve_captcha("agent-1", retry_previous=True)
@@ -243,9 +254,9 @@ class TestSolveCaptchaHealthAndBreaker:
 
         solver = MagicMock()
         solver.provider = "2captcha"
-        solver.is_solver_unreachable = MagicMock(return_value=True)
+        solver.is_solver_unreachable = AsyncMock(return_value=True)
         solver.is_breaker_open = MagicMock(return_value=False)
-        solver.solve = AsyncMock(return_value=True)
+        solver.solve = AsyncMock(return_value=_solved_result())
         mgr._captcha_solver = solver
 
         result = await mgr.solve_captcha("agent-1")
@@ -261,9 +272,9 @@ class TestSolveCaptchaHealthAndBreaker:
 
         solver = MagicMock()
         solver.provider = "2captcha"
-        solver.is_solver_unreachable = MagicMock(return_value=False)
+        solver.is_solver_unreachable = AsyncMock(return_value=False)
         solver.is_breaker_open = MagicMock(return_value=True)
-        solver.solve = AsyncMock(return_value=True)
+        solver.solve = AsyncMock(return_value=_solved_result())
         mgr._captcha_solver = solver
 
         result = await mgr.solve_captcha("agent-1")

--- a/tests/test_captcha_cf_tristate.py
+++ b/tests/test_captcha_cf_tristate.py
@@ -40,17 +40,45 @@ def _make_manager(*, solver=None) -> BrowserManager:
     """Build a bare ``BrowserManager`` shell with optional solver mock.
 
     The §11.16 solver-health side-channels (``is_solver_unreachable`` /
-    ``is_breaker_open``) are defaulted to ``False`` so the §11.3
-    short-circuits are exercised separately from the §11.16 ones.
+    ``is_breaker_open``) are defaulted to non-tripping (return False) so
+    the §11.3 short-circuits are exercised separately from the §11.16
+    ones. Post-refactor ``is_solver_unreachable`` is async (lazy probe).
+
+    Tests that want to assert the §11.16 short-circuit branches set the
+    attributes WITH a concrete bool ``return_value`` BEFORE calling
+    _make_manager; the helper detects that and leaves them untouched.
     """
     mgr = BrowserManager.__new__(BrowserManager)
     if solver is not None:
-        if not isinstance(getattr(solver, "is_solver_unreachable", None), MagicMock):
-            solver.is_solver_unreachable = MagicMock(return_value=False)
-        if not isinstance(getattr(solver, "is_breaker_open", None), MagicMock):
+        # Detect explicit setup via concrete bool return_value. Auto-spec'd
+        # children of AsyncMock have ``return_value`` that's a Mock, not a
+        # bool — those need our defaults.
+        existing = getattr(solver, "is_solver_unreachable", None)
+        if not (isinstance(existing, (AsyncMock, MagicMock))
+                and isinstance(getattr(existing, "return_value", None), bool)):
+            solver.is_solver_unreachable = AsyncMock(return_value=False)
+        existing_b = getattr(solver, "is_breaker_open", None)
+        if not (isinstance(existing_b, (AsyncMock, MagicMock))
+                and isinstance(getattr(existing_b, "return_value", None), bool)):
             solver.is_breaker_open = MagicMock(return_value=False)
     mgr._captcha_solver = solver
     return mgr
+
+
+def _solved_sr():
+    from src.browser.captcha import SolveResult
+    return SolveResult(
+        token="tok", injection_succeeded=True,
+        used_proxy_aware=False, compat_rejected=False,
+    )
+
+
+def _failed_sr():
+    from src.browser.captcha import SolveResult
+    return SolveResult(
+        token=None, injection_succeeded=False,
+        used_proxy_aware=False, compat_rejected=False,
+    )
 
 
 def _make_inst(
@@ -179,7 +207,7 @@ class TestCfAutoStuck:
         falls through to the behavioral envelope. Solver must NOT be invoked.
         """
         solver = AsyncMock()
-        solver.solve = AsyncMock(return_value=True)
+        solver.solve = AsyncMock(return_value=_solved_sr())
         mgr = _make_manager(solver=solver)
         inst = _make_inst(
             matching_selector='iframe[src*="challenges.cloudflare.com"]',
@@ -214,7 +242,7 @@ class TestCfUnderAttack:
         Solver call would be useless — expect behavioral envelope.
         """
         solver = AsyncMock()
-        solver.solve = AsyncMock(return_value=True)
+        solver.solve = AsyncMock(return_value=_solved_sr())
         mgr = _make_manager(solver=solver)
         inst = _make_inst(
             matching_selector='iframe[src*="challenges.cloudflare.com"]',
@@ -248,7 +276,7 @@ class TestCfTurnstileEmbedded:
         ``solver_confidence`` is forced to ``"low"`` regardless of verdict.
         """
         solver = AsyncMock()
-        solver.solve = AsyncMock(return_value=True)
+        solver.solve = AsyncMock(return_value=_solved_sr())
         mgr = _make_manager(solver=solver)
         inst = _make_inst(
             matching_selector='iframe[src*="challenges.cloudflare.com"]',
@@ -273,7 +301,7 @@ class TestCfTurnstileEmbedded:
     async def test_cf_turnstile_embedded_low_confidence_on_solver_failure(self):
         """Same override applies when solver returns False (rejected)."""
         solver = AsyncMock()
-        solver.solve = AsyncMock(return_value=False)
+        solver.solve = AsyncMock(return_value=_failed_sr())
         mgr = _make_manager(solver=solver)
         inst = _make_inst(
             matching_selector='iframe[src*="challenges.cloudflare.com"]',
@@ -330,7 +358,7 @@ class TestPerimeterXBehavioral:
     async def test_px_legacy_selector_is_behavioral(self):
         """PerimeterX ``#px-captcha`` legacy selector → ``px-press-hold``."""
         solver = AsyncMock()
-        solver.solve = AsyncMock(return_value=True)
+        solver.solve = AsyncMock(return_value=_solved_sr())
         mgr = _make_manager(solver=solver)
         inst = _make_inst(
             matching_selector='[class*="captcha"]',
@@ -352,7 +380,7 @@ class TestPerimeterXBehavioral:
         family, just different DOM markers.
         """
         solver = AsyncMock()
-        solver.solve = AsyncMock(return_value=True)
+        solver.solve = AsyncMock(return_value=_solved_sr())
         mgr = _make_manager(solver=solver)
         inst = _make_inst(
             matching_selector='[class*="captcha"]',
@@ -371,7 +399,7 @@ class TestDataDome:
     async def test_datadome_blocker_is_behavioral(self):
         """``/blocker`` path on captcha-delivery.com → behavioral envelope."""
         solver = AsyncMock()
-        solver.solve = AsyncMock(return_value=True)
+        solver.solve = AsyncMock(return_value=_solved_sr())
         mgr = _make_manager(solver=solver)
         inst = _make_inst(
             matching_selector='iframe[src*="captcha"]',
@@ -447,9 +475,9 @@ class TestBehavioralBeforeSolverGate:
     @pytest.mark.asyncio
     async def test_behavioral_with_unreachable_solver(self):
         solver = AsyncMock()
-        solver.is_solver_unreachable = MagicMock(return_value=True)
+        solver.is_solver_unreachable = AsyncMock(return_value=True)
         solver.is_breaker_open = MagicMock(return_value=False)
-        solver.solve = AsyncMock(return_value=True)
+        solver.solve = AsyncMock(return_value=_solved_sr())
         mgr = _make_manager(solver=solver)
         inst = _make_inst(
             matching_selector='[class*="captcha"]',
@@ -467,9 +495,9 @@ class TestBehavioralBeforeSolverGate:
     @pytest.mark.asyncio
     async def test_behavioral_with_breaker_open(self):
         solver = AsyncMock()
-        solver.is_solver_unreachable = MagicMock(return_value=False)
+        solver.is_solver_unreachable = AsyncMock(return_value=False)
         solver.is_breaker_open = MagicMock(return_value=True)
-        solver.solve = AsyncMock(return_value=True)
+        solver.solve = AsyncMock(return_value=_solved_sr())
         mgr = _make_manager(solver=solver)
         inst = _make_inst(
             matching_selector='iframe[src*="captcha"]',
@@ -489,9 +517,9 @@ class TestBehavioralBeforeSolverGate:
         is the CF behavioral kind, not ``no_solver``.
         """
         solver = AsyncMock()
-        solver.is_solver_unreachable = MagicMock(return_value=True)
+        solver.is_solver_unreachable = AsyncMock(return_value=True)
         solver.is_breaker_open = MagicMock(return_value=False)
-        solver.solve = AsyncMock(return_value=True)
+        solver.solve = AsyncMock(return_value=_solved_sr())
         mgr = _make_manager(solver=solver)
         inst = _make_inst(
             matching_selector='iframe[src*="challenges.cloudflare.com"]',

--- a/tests/test_captcha_envelope.py
+++ b/tests/test_captcha_envelope.py
@@ -23,7 +23,27 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+from src.browser.captcha import SolveResult
 from src.browser.service import BrowserManager
+
+
+def _solved_result(*, used_proxy_aware: bool = False, compat_rejected: bool = False) -> SolveResult:
+    return SolveResult(
+        token="tok",
+        injection_succeeded=True,
+        used_proxy_aware=used_proxy_aware,
+        compat_rejected=compat_rejected,
+    )
+
+
+def _failed_result() -> SolveResult:
+    """Solver returned no token (sitekey-fail / verdict-reject path)."""
+    return SolveResult(
+        token=None,
+        injection_succeeded=False,
+        used_proxy_aware=False,
+        compat_rejected=False,
+    )
 
 # Selectors checked in order by `_check_captcha`. We use this to drive
 # the mock such that exactly one selector "matches" per scenario.
@@ -41,21 +61,17 @@ _SELECTOR_ORDER = [
 def _make_manager(*, solver=None) -> BrowserManager:
     mgr = BrowserManager.__new__(BrowserManager)
     if solver is not None:
-        # §11.16 added two sync side-channel getters on CaptchaSolver
-        # that _check_captcha consults BEFORE attempting solve(). When
-        # the test passes a raw AsyncMock as the solver, the unset
-        # attributes resolve to coroutine-returning AsyncMocks whose
-        # truthy-check trips the §11.16 short-circuit. Default both to
-        # MagicMock returning False so envelope-shape tests exercise
-        # the solve path. Tests that want to assert the short-circuit
-        # branches override these explicitly (see test_captcha_health).
-        if not hasattr(solver, "is_solver_unreachable") or not isinstance(
-            getattr(solver, "is_solver_unreachable", None), MagicMock,
-        ):
-            solver.is_solver_unreachable = MagicMock(return_value=False)
-        if not hasattr(solver, "is_breaker_open") or not isinstance(
-            getattr(solver, "is_breaker_open", None), MagicMock,
-        ):
+        # §11.16 short-circuit getters. ``is_solver_unreachable`` is async
+        # post-refactor (lazy probe); ``is_breaker_open`` stays sync.
+        # Default both to non-tripping (False) UNLESS the test set them
+        # with an explicit bool return_value before calling us.
+        existing = getattr(solver, "is_solver_unreachable", None)
+        if not (isinstance(existing, (AsyncMock, MagicMock))
+                and isinstance(getattr(existing, "return_value", None), bool)):
+            solver.is_solver_unreachable = AsyncMock(return_value=False)
+        existing_b = getattr(solver, "is_breaker_open", None)
+        if not (isinstance(existing_b, (AsyncMock, MagicMock))
+                and isinstance(getattr(existing_b, "return_value", None), bool)):
             solver.is_breaker_open = MagicMock(return_value=False)
     mgr._captcha_solver = solver
     return mgr
@@ -134,7 +150,7 @@ class TestRecaptchaSolverSuccess:
     @pytest.mark.asyncio
     async def test_recaptcha_solved(self):
         solver = AsyncMock()
-        solver.solve = AsyncMock(return_value=True)
+        solver.solve = AsyncMock(return_value=_solved_result())
         mgr = _make_manager(solver=solver)
         inst = _make_inst('iframe[src*="recaptcha"]')
         result = await mgr._check_captcha(inst)
@@ -475,12 +491,12 @@ class TestInjectionFailureReasonShape:
             ('iframe[src*="hcaptcha"]', lambda: None, "no_solver"),
             (
                 'iframe[src*="hcaptcha"]',
-                lambda: AsyncMock(solve=AsyncMock(return_value=True)),
+                lambda: AsyncMock(solve=AsyncMock(return_value=_solved_result())),
                 "solved",
             ),
             (
                 'iframe[src*="hcaptcha"]',
-                lambda: AsyncMock(solve=AsyncMock(return_value=False)),
+                lambda: AsyncMock(solve=AsyncMock(return_value=_failed_result())),
                 "rejected",
             ),
             (
@@ -516,17 +532,22 @@ class TestSolverFalseConflation:
     """
 
     @pytest.mark.asyncio
-    async def test_solver_false_maps_to_rejected_today(self):
+    async def test_solver_no_token_maps_to_rejected(self):
+        """Solver returned no token (sitekey-fail / verdict-reject path).
+
+        The post-refactor :class:`SolveResult` distinguishes:
+          * ``token=None`` → ``rejected`` (no provider charge).
+          * ``token=non-None, injection_succeeded=False`` →
+            ``injection_failed`` (provider charged; see
+            :class:`TestInjectionFailedDistinct` below).
+        """
         solver = AsyncMock()
-        solver.solve = AsyncMock(return_value=False)
+        solver.solve = AsyncMock(return_value=_failed_result())
         mgr = _make_manager(solver=solver)
         inst = _make_inst('iframe[src*="hcaptcha"]')
         result = await mgr._check_captcha(inst)
         assert result["captcha_found"] is True
         assert result["solver_attempted"] is True
-        # ``injection_failed`` is reserved but unreachable today — the
-        # solver returns plain bool. Both injection-fail and verdict-fail
-        # surface as ``rejected``.
         assert result["solver_outcome"] == "rejected"
         assert result["injection_failure_reason"] is None
 

--- a/tests/test_captcha_health.py
+++ b/tests/test_captcha_health.py
@@ -106,8 +106,8 @@ async def test_first_solve_runs_health_check_subsequent_do_not():
         ok1 = await solver.solve(page, 'iframe[src*="recaptcha"]', "https://example.com")
         ok2 = await solver.solve(page, 'iframe[src*="recaptcha"]', "https://example.com")
 
-    assert ok1 is True
-    assert ok2 is True
+    assert bool(ok1) is True
+    assert bool(ok2) is True
     urls_called = [c.args[0] for c in client.post.call_args_list]
     assert urls_called[0].endswith("/getBalance")
     # Only ONE getBalance — the gate is sticky.
@@ -173,13 +173,13 @@ async def test_health_check_unreachable_short_circuits_subsequent_solves():
     solver._client = client
 
     ok = await solver.solve(page, 'iframe[src*="recaptcha"]', "https://example.com")
-    assert ok is False
-    assert solver.is_solver_unreachable() is True
+    assert bool(ok) is False
+    assert await solver.is_solver_unreachable() is True
     assert client.post.await_count == 1  # only the probe
 
     # Subsequent solves don't even probe again — the gate is sticky.
     ok2 = await solver.solve(page, 'iframe[src*="recaptcha"]', "https://example.com")
-    assert ok2 is False
+    assert bool(ok2) is False
     assert client.post.await_count == 1
 
 
@@ -241,7 +241,7 @@ async def test_concurrent_first_solves_share_one_health_check():
 
         results = await asyncio.gather(*tasks)
 
-    assert all(r is True for r in results)
+    assert all(bool(r) is True for r in results)
     assert probe_calls == 1, (
         f"expected exactly one health probe, got {probe_calls} — gate is racy"
     )
@@ -380,7 +380,7 @@ async def test_breaker_auto_clears_after_window():
     ), patch("src.browser.captcha._POLL_INTERVAL", 0.001):
         ok = await solver.solve(page, 'iframe[src*="recaptcha"]', "https://example.com")
 
-    assert ok is True
+    assert bool(ok) is True
     # createTask + getTaskResult, no probe (already checked).
     assert client.post.await_count == 2
 
@@ -520,7 +520,7 @@ async def test_concurrent_solves_short_circuit_when_breaker_open():
         solver.solve(page, 'iframe[src*="recaptcha"]', "https://example.com")
         for _ in range(5)
     ))
-    assert all(r is False for r in results)
+    assert all(bool(r) is False for r in results)
     # No provider HTTP calls — breaker gate ran before any post().
     assert client.post.await_count == 0
 
@@ -679,12 +679,17 @@ async def test_health_check_cancellation_cleans_up():
 async def test_check_captcha_emits_no_solver_when_unreachable():
     """When health-check unreachable, _check_captcha decorates the result
     with solver_outcome='no_solver' + next_action='request_captcha_help'."""
+    from src.browser.captcha import SolveResult as _SR
     from src.browser.service import BrowserManager
 
     mgr = BrowserManager.__new__(BrowserManager)
     fake_solver = AsyncMock()
-    fake_solver.solve = AsyncMock(return_value=False)
-    fake_solver.is_solver_unreachable = MagicMock(return_value=True)
+    fake_solver.solve = AsyncMock(return_value=_SR(
+        token=None, injection_succeeded=False,
+        used_proxy_aware=False, compat_rejected=False,
+    ))
+    # ``is_solver_unreachable`` is now async (lazy probe).
+    fake_solver.is_solver_unreachable = AsyncMock(return_value=True)
     fake_solver.is_breaker_open = MagicMock(return_value=False)
     mgr._captcha_solver = fake_solver
 
@@ -718,12 +723,16 @@ async def test_check_captcha_emits_breaker_open_flag():
     """When breaker is open, _check_captcha sets breaker_open=True
     and solver_outcome='timeout' (the §11.13 follow-up will fold this
     into a structured ``service_unavailable`` value)."""
+    from src.browser.captcha import SolveResult as _SR
     from src.browser.service import BrowserManager
 
     mgr = BrowserManager.__new__(BrowserManager)
     fake_solver = AsyncMock()
-    fake_solver.solve = AsyncMock(return_value=False)
-    fake_solver.is_solver_unreachable = MagicMock(return_value=False)
+    fake_solver.solve = AsyncMock(return_value=_SR(
+        token=None, injection_succeeded=False,
+        used_proxy_aware=False, compat_rejected=False,
+    ))
+    fake_solver.is_solver_unreachable = AsyncMock(return_value=False)
     fake_solver.is_breaker_open = MagicMock(return_value=True)
     mgr._captcha_solver = fake_solver
 
@@ -756,12 +765,17 @@ async def test_check_captcha_no_decoration_when_solver_healthy():
     envelope WITHOUT a top-level ``breaker_open`` flag and with a
     ``solver_outcome`` other than ``no_solver`` (proves the §11.16
     short-circuits did not fire)."""
+    from src.browser.captcha import SolveResult as _SR
     from src.browser.service import BrowserManager
 
     mgr = BrowserManager.__new__(BrowserManager)
     fake_solver = AsyncMock()
-    fake_solver.solve = AsyncMock(return_value=False)  # solve fails normally
-    fake_solver.is_solver_unreachable = MagicMock(return_value=False)
+    # No-token result → "rejected" envelope on a healthy solver.
+    fake_solver.solve = AsyncMock(return_value=_SR(
+        token=None, injection_succeeded=False,
+        used_proxy_aware=False, compat_rejected=False,
+    ))
+    fake_solver.is_solver_unreachable = AsyncMock(return_value=False)
     fake_solver.is_breaker_open = MagicMock(return_value=False)
     mgr._captcha_solver = fake_solver
 

--- a/tests/test_captcha_per_type_timeout.py
+++ b/tests/test_captcha_per_type_timeout.py
@@ -210,7 +210,7 @@ class TestSolvePassesKindThrough:
                 kind="recaptcha-v3",
             )
 
-        assert ok is True
+        assert bool(ok) is True
         # The §11.13 envelope kind is preserved when the caller supplies it.
         assert recorded["kind"] == "recaptcha-v3"
 
@@ -270,7 +270,7 @@ class TestOuterTimeoutEnforced:
                 page, 'iframe[src*="recaptcha"]', "https://example.com",
                 kind="recaptcha-v3",
             )
-        assert ok is False
+        assert bool(ok) is False
         # Failure recorded → breaker counter incremented.
         assert len(solver._solver_failure_timestamps) == 1
 
@@ -297,7 +297,7 @@ class TestOuterTimeoutEnforced:
                 page, 'iframe[src*="cf-turnstile"]', "https://example.com",
                 kind="turnstile",
             )
-        assert ok is True
+        assert bool(ok) is True
 
 
 # ── 6. Polling-loop iteration count respects per-kind timeout ─────────
@@ -350,7 +350,7 @@ class TestPollingLoopIterations:
                 kind="recaptcha-v3",
             )
 
-        assert ok is False
+        assert bool(ok) is False
         # 1 createTask call + N polls (loop never returned ready).
         # The loop is bounded by ``solve()``'s outer wait_for in practice;
         # we just want to confirm the poll-loop iteration cap is FINITE.

--- a/tests/test_captcha_solve_pacing.py
+++ b/tests/test_captcha_solve_pacing.py
@@ -191,7 +191,7 @@ class TestPacingFiresOnSuccess:
                 kind="recaptcha-v3",
             )
 
-        assert ok is True
+        assert bool(ok) is True
         assert pace.await_count == 1
 
 
@@ -224,7 +224,7 @@ class TestPacingSkippedOnFailure:
                 kind="recaptcha-v3",
             )
 
-        assert ok is False
+        assert bool(ok) is False
         assert pace.await_count == 0
 
     @pytest.mark.asyncio
@@ -241,7 +241,7 @@ class TestPacingSkippedOnFailure:
                 kind="recaptcha-v3",
             )
 
-        assert ok is False
+        assert bool(ok) is False
         assert pace.await_count == 0
 
     @pytest.mark.asyncio
@@ -259,7 +259,7 @@ class TestPacingSkippedOnFailure:
                 kind="recaptcha-v3",
             )
 
-        assert ok is False
+        assert bool(ok) is False
         assert pace.await_count == 0
 
     @pytest.mark.asyncio
@@ -281,7 +281,7 @@ class TestPacingSkippedOnFailure:
                 kind="recaptcha-v3",
             )
 
-        assert ok is False
+        assert bool(ok) is False
         # Outer wait_for fired BEFORE the token came back — pacing skipped.
         assert pace.await_count == 0
 
@@ -302,7 +302,7 @@ class TestPacingSkippedOnFailure:
                 kind="recaptcha-v3",
             )
 
-        assert ok is False
+        assert bool(ok) is False
         assert pace.await_count == 0
 
     @pytest.mark.asyncio
@@ -320,5 +320,5 @@ class TestPacingSkippedOnFailure:
                 kind="recaptcha-v3",
             )
 
-        assert ok is False
+        assert bool(ok) is False
         assert pace.await_count == 0

--- a/tests/test_captcha_solver_proxy.py
+++ b/tests/test_captcha_solver_proxy.py
@@ -549,7 +549,8 @@ class TestCredentialLeakCanary:
             page, 'iframe[src*="recaptcha"]', "https://example.com/login",
             agent_id="agent-1",
         )
-        assert result is True, "solver should have succeeded under the mock"
+        assert result.token is not None, "solver should have retrieved a token"
+        assert result.injection_succeeded, "solver should have injected the token"
 
         # ── Step 5: ASSERT — the canary string must NOT appear anywhere
         # in any outbound request.
@@ -662,8 +663,8 @@ class TestCredentialLeakCanary:
     @pytest.mark.asyncio
     async def test_compat_rejection_marks_envelope_low_confidence(self, monkeypatch):
         """When a proxy is configured but the compat table rejects the
-        scheme for the variant, ``last_compat_rejected`` is True so the
-        envelope downgrades to ``solver_confidence='low'``.
+        scheme for the variant, ``SolveResult.compat_rejected`` is True so
+        the envelope downgrades to ``solver_confidence='low'``.
         """
         # 2captcha + https is rejected by the compat table.
         monkeypatch.setenv("CAPTCHA_SOLVER_PROXY_TYPE", "https")
@@ -720,9 +721,10 @@ class TestCredentialLeakCanary:
             page, 'iframe[src*="recaptcha"]', "https://example.com",
             agent_id="agent-1",
         )
-        assert result is True
-        assert solver.last_used_proxy_aware is False
-        assert solver.last_compat_rejected is True
+        assert result.token is not None
+        assert result.injection_succeeded
+        assert result.used_proxy_aware is False
+        assert result.compat_rejected is True
         # Body uses proxyless task name (no proxy creds sent).
         body = captured[0]["json"]
         task = body.get("task", {})

--- a/tests/test_check_captcha_metered.py
+++ b/tests/test_check_captcha_metered.py
@@ -1,0 +1,500 @@
+"""Tests for the post-refactor captcha accounting + metering architecture.
+
+Covers the C1/C2/H1/H2/H3/H4 findings from the §11.13–§11.16 post-merge
+review:
+
+  * Auto-detect via ``_check_captcha`` consults the rate-limit + cost-cap
+    gates BEFORE the solver HTTP call. Pre-refactor, the gates fired
+    only inside ``solve_captcha`` and ran AFTER ``_check_captcha`` had
+    already invoked the solver — defeating their purpose.
+  * Concurrent solves on different agents do NOT clobber each other's
+    ``used_proxy_aware`` / ``compat_rejected`` flags. The old
+    per-instance scratch attrs raced; the new :class:`SolveResult`
+    dataclass is per-call so this is structurally impossible.
+  * Token-retrieved + injection-failed → ``solver_outcome="injection_failed"``,
+    cost IS counted. The provider was paid the moment the token came back.
+  * CF-Turnstile (``cf-interstitial-turnstile``) cost is counted at the
+    Turnstile rate (no spurious "no published rate" warning).
+  * CF-auto cleared → no "no published rate" warning logged
+    (``solver_attempted=False`` paths skip the warning).
+  * Eager / lazy health-check: pre-marked unreachable → no_solver envelope,
+    solver mock NOT contacted.
+  * Audit-log: cap / rate-limit / behavioral events emit on the
+    ``metrics_sink`` (EventBus production wiring) once per minute aggregation.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import time
+from collections import deque
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from src.browser import captcha_cost_counter as cost
+from src.browser import service as svc
+from src.browser.captcha import SolveResult
+from src.browser.service import BrowserManager, CamoufoxInstance
+
+# ── helpers ────────────────────────────────────────────────────────────────
+
+
+def _solved(*, used_proxy_aware: bool = False, compat_rejected: bool = False) -> SolveResult:
+    return SolveResult(
+        token="tok",
+        injection_succeeded=True,
+        used_proxy_aware=used_proxy_aware,
+        compat_rejected=compat_rejected,
+    )
+
+
+def _injection_failed() -> SolveResult:
+    """Token retrieved but DOM injection failed — provider charged us."""
+    return SolveResult(
+        token="tok",
+        injection_succeeded=False,
+        used_proxy_aware=False,
+        compat_rejected=False,
+    )
+
+
+def _mk_inst(*, captcha_present: bool = True, agent_id: str = "agent-1",
+             page_url: str = "https://example.com") -> CamoufoxInstance:
+    """Build a CamoufoxInstance with a page that reports captcha presence."""
+    page = MagicMock()
+    page.url = page_url
+    locator = MagicMock()
+    locator.count = AsyncMock(return_value=1 if captcha_present else 0)
+    page.locator = MagicMock(return_value=locator)
+    return CamoufoxInstance(agent_id, MagicMock(), MagicMock(), page)
+
+
+def _mk_solver(*, return_value: SolveResult, provider: str = "2captcha",
+               unreachable: bool = False, breaker_open: bool = False) -> MagicMock:
+    s = MagicMock()
+    s.provider = provider
+    s.solve = AsyncMock(return_value=return_value)
+    s.is_solver_unreachable = AsyncMock(return_value=unreachable)
+    s.is_breaker_open = MagicMock(return_value=breaker_open)
+    return s
+
+
+@pytest.fixture(autouse=True)
+async def _isolate_state(tmp_path, monkeypatch):
+    """Reset the in-memory cost / rate / audit state between tests."""
+    monkeypatch.setenv(
+        "CAPTCHA_COST_COUNTER_PATH", str(tmp_path / "captcha_costs.json"),
+    )
+    await cost.reset()
+    svc._solve_rate_window.clear()
+    async with svc._captcha_audit_lock:
+        svc._captcha_audit_buckets.clear()
+    yield
+    await cost.reset()
+    svc._solve_rate_window.clear()
+    async with svc._captcha_audit_lock:
+        svc._captcha_audit_buckets.clear()
+
+
+@pytest.fixture()
+def mgr(tmp_path):
+    return BrowserManager(profiles_dir=str(tmp_path / "profiles"))
+
+
+# ── 1. Auto-detect path: cost cap fires BEFORE solver HTTP call ───────────
+
+
+class TestAutoDetectGatesEnforced:
+    """Pre-refactor, ``_check_captcha`` (called by navigate / click /
+    detect_captcha) bypassed the rate-limit + cost-cap entirely; only
+    ``solve_captcha`` enforced them, and even there the gates ran AFTER
+    the solver call. The metered_solve refactor moves the gates inside
+    ``_check_captcha`` so EVERY entry point (navigate auto-detect, click
+    auto-detect, explicit solve_captcha) hits them.
+    """
+
+    @pytest.mark.asyncio
+    async def test_navigate_path_cost_cap_blocks_solver(self, mgr, monkeypatch):
+        """``_check_captcha`` direct call (the navigate auto-detect path)
+        respects the cost cap."""
+        monkeypatch.setenv("CAPTCHA_COST_LIMIT_USD_PER_AGENT_MONTH", "0.50")
+        await cost.add_cost("agent-1", 100)  # already over cap
+
+        solver = _mk_solver(return_value=_solved())
+        mgr._captcha_solver = solver
+        inst = _mk_inst()
+
+        envelope = await mgr._check_captcha(inst)
+        assert envelope["captcha_found"] is True
+        assert envelope["solver_outcome"] == "cost_cap"
+        # The solver mock MUST NOT have been called — gate fires before HTTP.
+        solver.solve.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_navigate_path_rate_limit_blocks_solver(self, mgr, monkeypatch):
+        """Navigate auto-detect respects the rate-limit gate."""
+        monkeypatch.setenv("CAPTCHA_RATE_LIMIT_PER_HOUR", "2")
+        now = time.time()
+        svc._solve_rate_window["agent-1"] = deque([now, now])
+
+        solver = _mk_solver(return_value=_solved())
+        mgr._captcha_solver = solver
+        inst = _mk_inst()
+
+        envelope = await mgr._check_captcha(inst)
+        assert envelope["captcha_found"] is True
+        assert envelope["solver_outcome"] == "rate_limited"
+        solver.solve.assert_not_awaited()
+
+
+# ── 2. Concurrent solves on different agents don't clobber state ──────────
+
+
+class TestConcurrentSolvesNoCrossAgentClobber:
+    """Pre-refactor the shared solver instance had per-call mutable state
+    (``last_used_proxy_aware`` / ``last_compat_rejected``) — concurrent
+    agents could overwrite each other's flags between stamp and read.
+    The :class:`SolveResult` dataclass is per-call so the race is
+    structurally impossible.
+    """
+
+    @pytest.mark.asyncio
+    async def test_two_agents_get_independent_solveresult(self, mgr, tmp_path):
+        # Two real instances on the same manager.
+        inst_a = _mk_inst(agent_id="agent-a")
+        inst_b = _mk_inst(agent_id="agent-b")
+        mgr._instances["agent-a"] = inst_a
+        mgr._instances["agent-b"] = inst_b
+
+        # Solver returns DIFFERENT SolveResults for each call. The
+        # AsyncMock side-effect cycles through these, so a serial
+        # gather of two concurrent solves yields one of each.
+        result_a = SolveResult(
+            token="tok-a", injection_succeeded=True,
+            used_proxy_aware=True, compat_rejected=False,
+        )
+        result_b = SolveResult(
+            token="tok-b", injection_succeeded=True,
+            used_proxy_aware=False, compat_rejected=True,
+        )
+        solver = MagicMock()
+        solver.provider = "2captcha"
+        solver.is_solver_unreachable = AsyncMock(return_value=False)
+        solver.is_breaker_open = MagicMock(return_value=False)
+        solver.solve = AsyncMock(side_effect=[result_a, result_b])
+        mgr._captcha_solver = solver
+
+        env_a, env_b = await asyncio.gather(
+            mgr._check_captcha(inst_a),
+            mgr._check_captcha(inst_b),
+        )
+
+        # Both agents see "solved"; both envelopes were built from
+        # their OWN per-call SolveResult — no cross-agent flag clobber.
+        assert env_a["solver_outcome"] == "solved"
+        assert env_b["solver_outcome"] == "solved"
+        # Confidence reflects each call's compat_rejected flag separately:
+        # agent_a's call had compat_rejected=False (high confidence);
+        # agent_b's call had compat_rejected=True (low confidence).
+        assert env_a["solver_confidence"] == "high"
+        assert env_b["solver_confidence"] == "low"
+
+
+# ── 3. Token retrieved + injection failed → injection_failed + count cost ─
+
+
+class TestInjectionFailedCountsCost:
+    """When the provider returns a valid token but our DOM injection
+    fails, the §11.13 envelope reports ``solver_outcome="injection_failed"``
+    AND the cost counter increments — because the provider was paid.
+    Pre-refactor, cost increment was gated on ``injection_succeeded`` so
+    the failed-injection case silently dropped a real billing event.
+    """
+
+    @pytest.mark.asyncio
+    async def test_injection_failed_envelope_and_cost(self, mgr):
+        solver = _mk_solver(return_value=_injection_failed())
+        mgr._captcha_solver = solver
+        inst = _mk_inst()
+
+        envelope = await mgr._check_captcha(inst)
+        assert envelope["solver_outcome"] == "injection_failed"
+        assert envelope["solver_attempted"] is True
+        assert envelope["next_action"] == "notify_user"
+        assert envelope["injection_failure_reason"] == "injection_failed_unspecified"
+        # Cost IS counted — provider was paid.
+        # First selector match is recaptcha → kind=recaptcha-v2-checkbox →
+        # 100¢ at 2captcha proxyless.
+        assert await cost.get_cents("agent-1") == 100
+
+
+# ── 4. CF-Turnstile pricing is in the table ───────────────────────────────
+
+
+class TestCfTurnstilePricing:
+    @pytest.mark.asyncio
+    async def test_cf_turnstile_solved_increments_cost(self, mgr, monkeypatch):
+        """CF-bound Turnstile (``cf-interstitial-turnstile``) takes the same
+        rate as standalone Turnstile. Without the alias entries added in
+        the refactor, the cost counter would emit a "no published rate"
+        warning and skip the increment for every CF-Turnstile solve.
+        """
+        # Force the CF tri-state classifier to land on "turnstile".
+        async def fake_cf_state(page):
+            return "turnstile"
+        async def fake_behavioral(page):
+            return None
+        async def fake_recaptcha(page):
+            return {"variant": "unknown", "sitekey": None, "action": None,
+                    "min_score": None}
+
+        monkeypatch.setattr(svc, "_classify_cf_state", fake_cf_state)
+        monkeypatch.setattr(svc, "_classify_behavioral", fake_behavioral)
+        monkeypatch.setattr(svc, "_classify_recaptcha", fake_recaptcha)
+
+        solver = _mk_solver(return_value=_solved(), provider="2captcha")
+        mgr._captcha_solver = solver
+
+        # Custom inst whose locator only matches the CF challenge selector.
+        page = MagicMock()
+        page.url = "https://example.com"
+        def loc_for(sel):
+            loc = MagicMock()
+            loc.count = AsyncMock(return_value=(
+                1 if sel == 'iframe[src*="challenges.cloudflare.com"]' else 0
+            ))
+            return loc
+        page.locator = MagicMock(side_effect=loc_for)
+        inst = CamoufoxInstance("agent-1", MagicMock(), MagicMock(), page)
+
+        envelope = await mgr._check_captcha(inst)
+        assert envelope["kind"] == "cf-interstitial-turnstile"
+        assert envelope["solver_outcome"] == "solved"
+        # 2captcha turnstile = 200¢. CF-bound alias picks up the same rate.
+        assert await cost.get_cents("agent-1") == 200
+
+
+# ── 5. CF-auto cleared → no "no published rate" warning logged ────────────
+
+
+class TestCfAutoNoPriceWarning:
+    @pytest.mark.asyncio
+    async def test_cf_auto_cleared_emits_no_warning(self, mgr, caplog, monkeypatch):
+        """``cf-interstitial-auto`` resolves without a solver call —
+        ``solver_attempted=False`` paths must NOT trigger the cost
+        counter's "no published rate" warning. Pre-refactor a CF-auto
+        clear path could trip the warning if any code path tried to
+        estimate cents on a non-priced kind."""
+        # Drive the CF classifier to "auto" + still_present=False so the
+        # path returns the "solved" envelope without any solver call.
+        async def fake_cf_state(page):
+            return "auto"
+        async def fake_behavioral(page):
+            return None
+        async def fake_recaptcha(page):
+            return {"variant": "unknown"}
+
+        monkeypatch.setattr(svc, "_classify_cf_state", fake_cf_state)
+        monkeypatch.setattr(svc, "_classify_behavioral", fake_behavioral)
+        monkeypatch.setattr(svc, "_classify_recaptcha", fake_recaptcha)
+
+        # Page locator: first match present, post-recheck absent.
+        page = MagicMock()
+        page.url = "https://example.com"
+        call_counts: dict[str, int] = {}
+
+        def loc_for(sel):
+            loc = MagicMock()
+
+            async def _count():
+                n = call_counts.get(sel, 0)
+                call_counts[sel] = n + 1
+                if sel != 'iframe[src*="challenges.cloudflare.com"]':
+                    return 0
+                return 1 if n == 0 else 0  # cleared on recheck
+            loc.count = _count
+            return loc
+
+        page.locator = MagicMock(side_effect=loc_for)
+        inst = CamoufoxInstance("agent-1", MagicMock(), MagicMock(), page)
+
+        # No solver mock at all on the manager — but it shouldn't matter,
+        # the auto-path returns before any solver branch.
+        mgr._captcha_solver = None
+
+        # Patch asyncio.sleep inside _check_captcha so the 8s wait collapses.
+        from unittest.mock import patch
+        with caplog.at_level(logging.WARNING, logger="browser.captcha_cost"), \
+             patch("src.browser.service.asyncio.sleep", new=AsyncMock()):
+            envelope = await mgr._check_captcha(inst)
+
+        assert envelope["solver_outcome"] == "solved"
+        assert envelope["kind"] == "cf-interstitial-auto"
+        # No "no published rate" warning emitted.
+        joined = "\n".join(rec.getMessage() for rec in caplog.records)
+        assert "no published rate" not in joined
+
+
+# ── 6. Eager/lazy health-check — first captcha sees the gate ──────────────
+
+
+class TestLazyHealthCheckGatesFirstCall:
+    @pytest.mark.asyncio
+    async def test_unreachable_solver_not_contacted_first_call(self, mgr):
+        """Solver pre-marked unreachable → ``no_solver`` envelope; the
+        ``solve()`` mock is NOT called. Pre-refactor, the gate read was
+        sync but the probe ran inside ``solve()`` — so the FIRST captcha
+        of a session always slipped past the unreachable gate. Lazy +
+        async ``is_solver_unreachable()`` closes that hole.
+        """
+        solver = _mk_solver(return_value=_solved(), unreachable=True)
+        mgr._captcha_solver = solver
+        inst = _mk_inst()
+
+        envelope = await mgr._check_captcha(inst)
+        assert envelope["solver_outcome"] == "no_solver"
+        assert envelope["solver_attempted"] is False
+        assert envelope["next_action"] == "request_captcha_help"
+        # Critical: the solver mock was NEVER awaited. Pre-refactor the
+        # FIRST call of a session would have invoked the mock before the
+        # gate fired.
+        solver.solve.assert_not_awaited()
+
+
+# ── 7. Audit log: cap / rate-limit / behavioral events drain via metrics ──
+
+
+class TestAuditLogAggregation:
+    """The metered-solve gates and the behavioral classifier both record
+    events to a per-minute aggregation bucket. ``_emit_metrics`` drains
+    the buckets and forwards each as a ``captcha_gate`` event through
+    the ``metrics_sink`` (EventBus in production)."""
+
+    @pytest.mark.asyncio
+    async def test_cost_cap_event_drains_via_sink(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("CAPTCHA_COST_LIMIT_USD_PER_AGENT_MONTH", "0.50")
+        await cost.add_cost("agent-1", 100)
+
+        events: list[dict] = []
+        m = BrowserManager(
+            profiles_dir=str(tmp_path / "profiles"),
+            metrics_sink=events.append,
+        )
+        m._captcha_solver = _mk_solver(return_value=_solved())
+        inst = _mk_inst()
+        m._instances["agent-1"] = inst
+
+        # Trigger TWO cap-blocked solves so we exercise aggregation.
+        await m._check_captcha(inst)
+        await m._check_captcha(inst)
+
+        # Drain.
+        await m._emit_metrics()
+
+        captcha_events = [e for e in events if e.get("type") == "captcha_gate"]
+        assert len(captcha_events) == 1, f"expected one aggregated event, got {captcha_events}"
+        ev = captcha_events[0]
+        assert ev["agent"] == "agent-1"
+        assert ev["outcome"] == "cost_cap"
+        # Aggregated count, not per-call.
+        assert ev["count"] == 2
+
+    @pytest.mark.asyncio
+    async def test_rate_limit_event_drains_via_sink(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("CAPTCHA_RATE_LIMIT_PER_HOUR", "1")
+        now = time.time()
+        svc._solve_rate_window["agent-1"] = deque([now])
+
+        events: list[dict] = []
+        m = BrowserManager(
+            profiles_dir=str(tmp_path / "profiles"),
+            metrics_sink=events.append,
+        )
+        m._captcha_solver = _mk_solver(return_value=_solved())
+        inst = _mk_inst()
+        m._instances["agent-1"] = inst
+
+        await m._check_captcha(inst)
+        await m._emit_metrics()
+
+        rate_events = [e for e in events
+                       if e.get("type") == "captcha_gate"
+                       and e.get("outcome") == "rate_limited"]
+        assert len(rate_events) == 1
+        assert rate_events[0]["count"] == 1
+
+    @pytest.mark.asyncio
+    async def test_behavioral_skip_event_drains_via_sink(self, tmp_path, monkeypatch):
+        events: list[dict] = []
+        m = BrowserManager(
+            profiles_dir=str(tmp_path / "profiles"),
+            metrics_sink=events.append,
+        )
+        m._captcha_solver = _mk_solver(return_value=_solved())
+
+        # Force the behavioral classifier to find a Press & Hold.
+        async def fake_behavioral(page):
+            return "px-press-hold"
+        async def fake_cf_state(page):
+            return "none"
+        async def fake_recaptcha(page):
+            return {"variant": "unknown"}
+
+        monkeypatch.setattr(svc, "_classify_behavioral", fake_behavioral)
+        monkeypatch.setattr(svc, "_classify_cf_state", fake_cf_state)
+        monkeypatch.setattr(svc, "_classify_recaptcha", fake_recaptcha)
+
+        inst = _mk_inst()
+        m._instances["agent-1"] = inst
+
+        envelope = await m._check_captcha(inst)
+        assert envelope["solver_outcome"] == "skipped_behavioral"
+
+        await m._emit_metrics()
+        beh = [e for e in events
+               if e.get("type") == "captcha_gate"
+               and e.get("outcome") == "skipped_behavioral"]
+        assert len(beh) == 1
+        assert beh[0]["count"] == 1
+        assert beh[0]["kind"] == "px-press-hold"
+
+    @pytest.mark.asyncio
+    async def test_aggregation_keys_distinct_outcomes_separately(
+        self, tmp_path, monkeypatch,
+    ):
+        """Different ``(agent, outcome, kind)`` tuples should NOT merge —
+        cap and rate-limit events on the same agent emit two separate
+        aggregated payloads.
+        """
+        monkeypatch.setenv("CAPTCHA_COST_LIMIT_USD_PER_AGENT_MONTH", "0.50")
+        await cost.add_cost("agent-1", 100)
+
+        events: list[dict] = []
+        m = BrowserManager(
+            profiles_dir=str(tmp_path / "profiles"),
+            metrics_sink=events.append,
+        )
+        m._captcha_solver = _mk_solver(return_value=_solved())
+        inst = _mk_inst()
+        m._instances["agent-1"] = inst
+
+        # First call: cost-cap fires.
+        await m._check_captcha(inst)
+
+        # Drain so we know cap-event is in the queue.
+        # Then trigger rate-limit on a fresh window.
+        monkeypatch.delenv("CAPTCHA_COST_LIMIT_USD_PER_AGENT_MONTH", raising=False)
+        await cost.reset()
+        monkeypatch.setenv("CAPTCHA_RATE_LIMIT_PER_HOUR", "1")
+        now = time.time()
+        svc._solve_rate_window["agent-1"] = deque([now])
+        await m._check_captcha(inst)
+
+        await m._emit_metrics()
+
+        cap_events = [e for e in events if e.get("outcome") == "cost_cap"]
+        rate_events = [e for e in events if e.get("outcome") == "rate_limited"]
+        assert len(cap_events) == 1
+        assert len(rate_events) == 1


### PR DESCRIPTION
## Summary

Foundational fix-up for the captcha cost-counter / rate-limit / solver-state architecture, addressing the principal-engineer + product post-merge review of PRs #765–#775. Three structural bugs landed across the nine merged Phase 8 PRs.

## Findings addressed

### CRITICAL — gates were non-functional (C1)
Pre-refactor: `solve_captcha` checked rate-limit + cost-cap **AFTER** `_check_captcha` had already invoked the solver, AND most callers (`navigate`, `click`, `detect_captcha`) bypassed the gates entirely by going through `_check_captcha` directly. Net effect: a misconfigured cap silently allowed every solve, and rate-limit was bypassable by every auto-detect path.

**Fix.** New `BrowserManager._metered_solve` method centralizes rate-limit + cost-cap gates → solver call → cost increment. Single entry point to `self._captcha_solver.solve()`. All callers flow through `_check_captcha → _metered_solve`. `solve_captcha` drops its now-redundant gate logic and trusts the metered solve.

### HIGH — cross-agent solver-state clobber (H1)
The shared `CaptchaSolver` instance had per-call mutable scratch attributes (`last_used_proxy_aware`, `last_compat_rejected`) that raced across concurrent agents.

**Fix.** New frozen `SolveResult` dataclass (top of `src/browser/captcha.py`); `solve()` returns it. The old per-instance scratch attrs are removed. `__bool__` mirrors the old `solve() -> bool` contract for callers that branched on truthiness. Concurrent solves on different agents own their own SolveResult; cross-agent clobber is structurally impossible.

### HIGH — injection-failed silently lost a billing event (H2)
Cost was gated on `injection_succeeded`, but the provider charged us the moment the token came back.

**Fix.** Cost increment fires when `result.token is not None`, regardless of `injection_succeeded`. Token-retrieved-but-injection-failed surfaces `solver_outcome="injection_failed"` + `injection_failure_reason="injection_failed_unspecified"` (finer disambiguation deferred to §11.6/§11.20).

### HIGH — first-captcha-of-session bypassed health-check gate (H3)
The eager health-check probe ran INSIDE `solve()`, while `_check_captcha`'s `is_solver_unreachable()` gate read ran BEFORE `solve()` — so the FIRST captcha of a session always slipped past the gate.

**Fix.** `is_solver_unreachable()` is now async + lazy. When the per-process probe hasn't fired, the gate read drives it under the state-lock. Sticky thereafter.

### HIGH — CF-Turnstile spurious "no published rate" warning (H4)
`cf-interstitial-turnstile` had no pricing table entry, so every solve emitted a "no published rate" warning and skipped the cost increment.

**Fix.** Aliased to the standalone Turnstile rate in `PRICING_CENTS` and `PRICING_CENTS_PROXY_AWARE`. CF-auto / CF-behavioral kinds remain intentionally unpriced (`solver_attempted=False` paths skip the warning).

### MEDIUM — deprecated 2captcha task name (M1)
`NormalRecaptchaTaskProxyless` was retired by 2captcha (April 2026); submitting it returns `ERROR_INVALID_TASK_TYPE`.

**Fix.** Aliased to `RecaptchaV2TaskProxyless` (the safe v2-checkbox default).

### MEDIUM — cost JSON sidecar permissions (M2)
**Fix.** Written 0o600 from `os.open(..., 0o600)` + explicit chmod after `os.replace`. No world-readable window.

### MEDIUM — audit-log of gate fires (M3)
**Fix.** Per-minute aggregated `metrics_sink` events for `cost_cap` / `rate_limited` / `skipped_behavioral`. Aggregation key `(agent_id, outcome, kind)`. Reuses the existing 60s metrics-emit tick (no parallel emitter); URL flows through `redact_url`.

### LOW — exception-log redaction (L1)
**Fix.** `_check_captcha` now passes `repr(exc)` through `_redact_clientkey_text(redact_url(...))` like the bundled solver already does.

### LOW — recursive guard documentation (L2)
**Fix.** `_captcha_solving` left in place as defensive code; comment notes it's never observed True under current architecture (`inst.lock` serializes calls per agent), kept for future-proofing.

### LOW — 8s lock-hold documentation (L3)
**Fix.** `_check_captcha` docstring documents the up-to-8s lock-hold during CF auto-resolving challenge wait.

## Tests

New `tests/test_check_captcha_metered.py` covers each finding:
- Auto-detect (navigate / click) hits cost-cap → solver NOT called.
- Auto-detect hits rate-limit → solver NOT called.
- Concurrent solves on different agents don't clobber state (`asyncio.gather` + per-call `SolveResult`).
- Token retrieved + injection failed → `injection_failed` envelope, cost IS counted.
- CF-Turnstile solved → cost counted at Turnstile rate.
- CF-auto cleared → no "no published rate" warning logged.
- Pre-marked unreachable solver → `no_solver` envelope on first call, solver mock NOT contacted.
- Audit-log aggregation: cap / rate-limit / behavioral events drain via `metrics_sink` with per-`(agent,outcome,kind)` aggregation.

Existing tests updated:
- `solver.is_solver_unreachable` mocks switched to `AsyncMock`.
- `solver.solve` mocks return `SolveResult` instead of bool.
- `test_captcha_solver_proxy.py` reads `result.used_proxy_aware` / `result.compat_rejected` from the per-call `SolveResult` instead of the (removed) per-instance attrs.

## Test plan
- [x] `pytest tests/ --ignore=tests/test_e2e.py --ignore=tests/test_e2e_chat.py --ignore=tests/test_e2e_memory.py --ignore=tests/test_e2e_triggering.py` → 4224 passed, 1 pre-existing unrelated failure (`test_version_flag` — fails on `main` too with `'openlegion' is not installed`).
- [x] `ruff check src/ tests/` → clean.
- [x] `tests/test_captcha_solver_proxy.py::TestCredentialLeakCanary::test_primary_proxy_creds_never_leak` still passes.
- [ ] Wait for CI on Python 3.11 + 3.12 (PR #774's inspect_requests fix is preserved; no changes near that surface).
- [ ] Manual smoke: confirm `_metered_solve` recorded a `captcha_gate` event when a misconfigured cap fires in dev.

Originating PRs: #765–#775.