### PR TITLE
Wire captcha_policy + add permission gates to mesh handoff endpoints

### DIFF
--- a/src/browser/service.py
+++ b/src/browser/service.py
@@ -24,6 +24,7 @@ from collections import deque
 from pathlib import Path
 from urllib.parse import urlparse
 
+from src.browser import captcha_policy
 from src.browser.captcha import (
     SolveResult,
     _classify_behavioral,
@@ -254,15 +255,24 @@ _captcha_audit_buckets: dict[tuple[str, str, str], dict] = {}
 
 async def _record_captcha_audit_event(
     agent_id: str, outcome: str, kind: str, page_url: str,
+    *, policy: str | None = None,
 ) -> None:
     """Aggregate a captcha gate event into the per-minute bucket.
 
-    Outcomes recorded: ``cost_cap``, ``rate_limited``, ``skipped_behavioral``.
+    Outcomes recorded: ``cost_cap``, ``rate_limited``, ``skipped_behavioral``,
+    ``low_success_failed`` (§11.18).
     Aggregation by ``(agent_id, outcome, kind)`` so a noisy retry loop on
     one agent doesn't drown out the others. ``page_url`` is redacted via
     :func:`redact_url` before storage; only the most recent redacted URL
     in the bucket is retained (the bucket is dashboard signal, not an
     audit trail).
+
+    ``policy`` (optional) records the §11.18 :func:`captcha_policy.get_site_policy`
+    classification (``"unsolvable"`` / ``"low_success"`` / ``"default"``) that
+    drove the gate decision, so operators can see WHY a solve was skipped or
+    escalated. Stored on the bucket and surfaced on the drained
+    ``captcha_gate`` payload as ``policy``. Last-write-wins within an
+    aggregation window — same convention as ``last_url``.
     """
     async with _captcha_audit_lock:
         key = (agent_id, outcome, kind)
@@ -274,10 +284,13 @@ async def _record_captcha_audit_event(
                 "count": 1,
                 "first_ts": now,
                 "last_url": safe_url,
+                "policy": policy,
             }
         else:
             bucket["count"] += 1
             bucket["last_url"] = safe_url
+            if policy is not None:
+                bucket["policy"] = policy
 
 
 async def _drain_captcha_audit() -> list[dict]:
@@ -297,7 +310,7 @@ async def _drain_captcha_audit() -> list[dict]:
         _captcha_audit_buckets.clear()
     drained = []
     for (agent_id, outcome, kind), info in buckets.items():
-        drained.append({
+        payload = {
             "type": "captcha_gate",
             "agent": agent_id,
             "outcome": outcome,
@@ -305,7 +318,14 @@ async def _drain_captcha_audit() -> list[dict]:
             "count": info["count"],
             "first_ts": info["first_ts"],
             "url": info["last_url"],
-        })
+        }
+        # §11.18 — surface the site-policy classification so operators see
+        # WHY a solve was skipped/escalated.  Older buckets created before
+        # the field was added may be missing it (back-compat with the
+        # ``policy=None`` default in :func:`_record_captcha_audit_event`).
+        if info.get("policy") is not None:
+            payload["policy"] = info["policy"]
+        drained.append(payload)
     return drained
 
 
@@ -5929,15 +5949,112 @@ class BrowserManager:
                     # cf_state == "none" — fall through to existing
                     # standalone-Turnstile / generic flow unchanged.
 
+                    # ── §11.18 — site-policy classification ──────────────
+                    # Resolve the captcha policy for the live page URL once
+                    # so we can route ``unsolvable`` hosts past the solver
+                    # entirely (saves spend on sites the solver can't
+                    # actually crack — CF Under-Attack, HUMAN Security,
+                    # DataDome) and downgrade ``low_success`` hosts to a
+                    # "try once at low confidence, escalate on failure"
+                    # flow (Google / Twitter / LinkedIn auth where token-IP
+                    # binding makes the solve unreliable).
+                    #
+                    # Hook position: AFTER §11.1 reCAPTCHA + §11.3 CF /
+                    # behavioral classifiers (so ``kind`` is precise and
+                    # ``cf_force_low_confidence`` is already known) but
+                    # BEFORE the §11.16 health/breaker gates and the
+                    # ``_metered_solve`` call — i.e. before any solver
+                    # spend.  Operator overrides
+                    # (``OPENLEGION_CAPTCHA_FORCE_SOLVE_DOMAINS`` /
+                    # ``OPENLEGION_CAPTCHA_SKIP_SOLVE_DOMAINS``) are
+                    # applied inside ``get_site_policy``.
+                    try:
+                        page_url_for_policy = inst.page.url or ""
+                    except Exception:
+                        page_url_for_policy = ""
+                    site_policy = captcha_policy.get_site_policy(
+                        page_url_for_policy,
+                    )
+                    # ``unsolvable`` short-circuits exactly like §11.3
+                    # behavioral — same envelope shape, same audit
+                    # outcome — but driven by host classification rather
+                    # than live-page selectors.  The two paths are
+                    # complementary: §11.3 catches behavioral-only
+                    # challenges by their DOM signature; §11.18 catches
+                    # them by the host even if our DOM heuristics miss
+                    # (e.g. a CF Under-Attack page rendered before our
+                    # JS probe gets a chance to run).
+                    if site_policy == "unsolvable":
+                        logger.info(
+                            "Captcha host classified as unsolvable "
+                            "(%s, kind=%s); skipping solver, escalating "
+                            "to request_captcha_help",
+                            redact_url(page_url_for_policy), kind,
+                        )
+                        await _record_captcha_audit_event(
+                            inst.agent_id, "skipped_behavioral",
+                            kind, page_url_for_policy,
+                            policy="unsolvable",
+                        )
+                        return _captcha_envelope(
+                            kind=kind,
+                            solver_attempted=False,
+                            solver_outcome="skipped_behavioral",
+                            solver_confidence="behavioral-only",
+                            next_action="request_captcha_help",
+                        )
+
+                    # ``low_success`` is NOT a short-circuit.  We continue
+                    # to the solver but force ``solver_confidence="low"``
+                    # on the result envelope and, on a non-``solved``
+                    # outcome, upgrade ``next_action`` from ``notify_user``
+                    # to ``request_captcha_help`` so the agent stops
+                    # retrying on sites where retries don't help.
+                    low_success = (site_policy == "low_success")
+
                     # Local helper applies the §11.3 CF-Turnstile
                     # confidence override (see ``cf_force_low_confidence``)
-                    # to every return path through the solver block. Token
+                    # AND the §11.18 ``low_success`` overrides to every
+                    # return path through the solver block. Token
                     # validity is unrelated to the per-call solve verdict
-                    # for CF-bound Turnstile, so the override fires
-                    # regardless of ``solver_outcome``.
+                    # for CF-bound Turnstile, so the CF override fires
+                    # regardless of ``solver_outcome``.  The ``low_success``
+                    # override always forces confidence to "low"; on a
+                    # FAILED solve outcome it ALSO upgrades
+                    # ``next_action`` to ``request_captcha_help`` (the
+                    # operator told us this host is unreliable; escalate
+                    # rather than letting the agent retry).
                     def _finalize(envelope: dict) -> dict:
                         if cf_force_low_confidence:
                             envelope["solver_confidence"] = "low"
+                        if low_success:
+                            envelope["solver_confidence"] = "low"
+                            outcome = envelope.get("solver_outcome")
+                            if outcome and outcome != "solved":
+                                # Audit: surface the upgrade so operators see
+                                # "low-success-attempted-and-failed" distinctly
+                                # from a vanilla provider rejection. Fire-and-
+                                # forget — we're inside a sync helper so
+                                # schedule the coroutine on the running loop.
+                                envelope["next_action"] = "request_captcha_help"
+                                envelope["low_success_failed"] = True
+                                try:
+                                    asyncio.get_running_loop().create_task(
+                                        _record_captcha_audit_event(
+                                            inst.agent_id,
+                                            "low_success_failed",
+                                            envelope.get("kind", "unknown"),
+                                            page_url_for_policy,
+                                            policy="low_success",
+                                        ),
+                                    )
+                                except RuntimeError:
+                                    # No running loop (defensive — _check_captcha
+                                    # is always async).  Drop the audit event
+                                    # rather than crashing the envelope.
+                                    logger.debug(
+                                        "low_success audit skipped: no loop",
+                                    )
                         return envelope
 
                     if self._captcha_solver:

--- a/src/host/permissions.py
+++ b/src/host/permissions.py
@@ -54,6 +54,16 @@ KNOWN_BROWSER_ACTIONS: frozenset[str] = frozenset({
     # narrowed ``browser_actions`` denylist (or set
     # ``CAPTCHA_DISABLED=true`` fleet-wide via flags.py).
     "solve_captcha", "request_captcha_help",
+    # Phase 8 §11.14 + browser-login handoff.  Both endpoints emit a
+    # dashboard handoff card — ``request_browser_login`` for VNC-driven
+    # interactive login, ``request_captcha_help`` for human captcha
+    # assistance — and both are now permission-gated at the dedicated
+    # mesh endpoints (``/mesh/browser-login-request``,
+    # ``/mesh/browser-captcha-help-request``).  Without these names in
+    # the validator set, an operator who narrows ``browser_actions`` to
+    # exclude the handoff would still see the second-call-to-dedicated-
+    # endpoint succeed, defeating permission narrowing.
+    "request_browser_login",
 })
 
 # Back-compat alias — retained so `host/server.py` and test fixtures that

--- a/src/host/server.py
+++ b/src/host/server.py
@@ -1131,6 +1131,19 @@ def create_mesh_app(
             caller_id, data.get("target_agent_id") or "",
         )
 
+        # Per-action gate applies to the EFFECTIVE target (`agent_id`), same
+        # semantics as ``/mesh/browser/command``: an operator with
+        # ``browser_actions=["*"]`` cannot exercise actions the target was
+        # never granted.  Without this check, an operator who narrows a
+        # template to ``browser_actions=["navigate"]`` would see the first
+        # call (``browser_command`` → e.g. navigate) gated correctly but
+        # the dedicated handoff endpoint would still succeed — permission
+        # narrowing wouldn't actually narrow.
+        if not permissions.can_browser_action(agent_id, "request_browser_login"):
+            raise HTTPException(
+                403, "Agent not permitted to perform 'request_browser_login'",
+            )
+
         # Rate-limit on the caller, not the target — otherwise a noisy
         # caller could exhaust an unrelated worker's notify quota.
         await _check_rate_limit("notify", caller_id)
@@ -1171,6 +1184,18 @@ def create_mesh_app(
         agent_id = _resolve_browser_target(
             caller_id, data.get("target_agent_id") or "",
         )
+
+        # Per-action gate (mirrors ``browser_login_request`` and
+        # ``/mesh/browser/command``).  Without this, an operator who
+        # narrows a template's ``browser_actions`` to exclude the captcha
+        # handoff would see the ``browser_command`` route correctly
+        # rejected for ``request_captcha_help`` (PR #769) but the dedicated
+        # endpoint here would still succeed — defeating permission
+        # narrowing.
+        if not permissions.can_browser_action(agent_id, "request_captcha_help"):
+            raise HTTPException(
+                403, "Agent not permitted to perform 'request_captcha_help'",
+            )
 
         await _check_rate_limit("notify", caller_id)
 

--- a/tests/test_check_captcha_policy.py
+++ b/tests/test_check_captcha_policy.py
@@ -1,0 +1,334 @@
+"""Tests for §11.18 site-policy wiring inside ``BrowserManager._check_captcha``.
+
+Phase 8 §11.18 ships :mod:`src.browser.captcha_policy` and these tests
+verify it is actually consumed by the runtime — closing finding H5 from
+the post-merge review (the module shipped DORMANT in PR #767, with no
+caller, so operators setting ``OPENLEGION_CAPTCHA_FORCE_SOLVE_DOMAINS`` /
+``OPENLEGION_CAPTCHA_SKIP_SOLVE_DOMAINS`` saw zero behavior change).
+
+Coverage:
+
+* ``unsolvable`` policy short-circuits before any solver call. Envelope
+  matches the §11.3 behavioral path: ``solver_attempted=False``,
+  ``solver_outcome="skipped_behavioral"``,
+  ``solver_confidence="behavioral-only"``,
+  ``next_action="request_captcha_help"``.  Solver mock is NOT called.
+* ``low_success`` policy DOES call the solver, but on a SUCCESSFUL solve
+  the envelope reports ``solver_confidence="low"`` (token-IP binding
+  makes the solve unreliable even when the verdict was "good").
+* ``low_success`` policy on a FAILED solve upgrades ``next_action`` to
+  ``"request_captcha_help"`` (NOT ``"notify_user"``) AND tags the
+  envelope with ``low_success_failed=True`` so operators see the case
+  distinctly in the audit log.
+* ``default`` policy is unchanged from current behavior.
+* Operator override ``OPENLEGION_CAPTCHA_FORCE_SOLVE_DOMAINS=accounts.google.com``
+  neutralizes the hardcoded ``low_success`` and produces a normal solve.
+* Operator override ``OPENLEGION_CAPTCHA_SKIP_SOLVE_DOMAINS=example.com``
+  forces a default site to ``unsolvable``.
+* The policy classification is recorded on the audit-log event so the
+  dashboard can show WHY a solve was skipped.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import importlib
+import os
+from unittest import mock
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from src.browser import captcha_cost_counter as cost
+from src.browser import captcha_policy
+from src.browser import service as svc
+from src.browser.captcha import SolveResult
+from src.browser.service import BrowserManager, CamoufoxInstance
+
+# ── helpers ────────────────────────────────────────────────────────────────
+
+
+def _solved() -> SolveResult:
+    return SolveResult(
+        token="tok",
+        injection_succeeded=True,
+        used_proxy_aware=False,
+        compat_rejected=False,
+    )
+
+
+def _rejected() -> SolveResult:
+    """Provider returned no token — solver effectively failed."""
+    return SolveResult(
+        token=None,
+        injection_succeeded=False,
+        used_proxy_aware=False,
+        compat_rejected=False,
+    )
+
+
+def _mk_inst(*, page_url: str, agent_id: str = "agent-1") -> CamoufoxInstance:
+    page = MagicMock()
+    page.url = page_url
+    locator = MagicMock()
+    locator.count = AsyncMock(return_value=1)
+    page.locator = MagicMock(return_value=locator)
+    return CamoufoxInstance(agent_id, MagicMock(), MagicMock(), page)
+
+
+def _mk_solver(*, return_value: SolveResult) -> MagicMock:
+    s = MagicMock()
+    s.provider = "2captcha"
+    s.solve = AsyncMock(return_value=return_value)
+    s.is_solver_unreachable = AsyncMock(return_value=False)
+    s.is_breaker_open = MagicMock(return_value=False)
+    return s
+
+
+def _reload_policy_with_env(env: dict[str, str]):
+    """Reload :mod:`src.browser.captcha_policy` with the given env applied
+    AND re-bind ``svc.captcha_policy`` to the freshly-imported module.
+
+    The service module imports captcha_policy by name (``from
+    src.browser import captcha_policy``), so reloading the policy module
+    in-place leaves ``svc.captcha_policy`` pointing at the OLD module
+    object with stale env-var-derived caches. We refresh both.
+    """
+    with mock.patch.dict(os.environ, env, clear=False):
+        fresh = importlib.reload(captcha_policy)
+    # Rebind the name inside the service module so ``_check_captcha``'s
+    # ``captcha_policy.get_site_policy(...)`` call resolves to the fresh
+    # module.  Without this the test sees the unreloaded copy.
+    svc.captcha_policy = fresh
+    return fresh
+
+
+@pytest.fixture(autouse=True)
+async def _isolate_state(tmp_path, monkeypatch):
+    """Reset cost / rate / audit state between tests."""
+    monkeypatch.setenv(
+        "CAPTCHA_COST_COUNTER_PATH", str(tmp_path / "captcha_costs.json"),
+    )
+    await cost.reset()
+    svc._solve_rate_window.clear()
+    async with svc._captcha_audit_lock:
+        svc._captcha_audit_buckets.clear()
+    yield
+    await cost.reset()
+    svc._solve_rate_window.clear()
+    async with svc._captcha_audit_lock:
+        svc._captcha_audit_buckets.clear()
+    # Reset captcha_policy back to the ambient (no-override) state and
+    # rebind on the service module so subsequent suites see pristine env.
+    scrubbed = {
+        k: v for k, v in os.environ.items()
+        if k not in {
+            "OPENLEGION_CAPTCHA_FORCE_SOLVE_DOMAINS",
+            "OPENLEGION_CAPTCHA_SKIP_SOLVE_DOMAINS",
+        }
+    }
+    with mock.patch.dict(os.environ, scrubbed, clear=True):
+        fresh = importlib.reload(captcha_policy)
+    svc.captcha_policy = fresh
+
+
+@pytest.fixture()
+def mgr(tmp_path):
+    return BrowserManager(profiles_dir=str(tmp_path / "profiles"))
+
+
+# ── 1. unsolvable policy → short-circuit, no solver call ─────────────────
+
+
+class TestUnsolvablePolicy:
+    @pytest.mark.asyncio
+    async def test_hardcoded_unsolvable_short_circuits(self, mgr):
+        """``challenges.cloudflare.com`` is hardcoded as unsolvable —
+        solver must not be called even when configured & healthy."""
+        solver = _mk_solver(return_value=_solved())
+        mgr._captcha_solver = solver
+        # CF host triggers the hardcoded UNSOLVABLE bucket.
+        inst = _mk_inst(
+            page_url="https://challenges.cloudflare.com/cdn-cgi/x",
+        )
+
+        envelope = await mgr._check_captcha(inst)
+        assert envelope["captcha_found"] is True
+        assert envelope["solver_attempted"] is False
+        assert envelope["solver_outcome"] == "skipped_behavioral"
+        assert envelope["solver_confidence"] == "behavioral-only"
+        assert envelope["next_action"] == "request_captcha_help"
+        # Solver mock NEVER awaited — gate fired before any HTTP call.
+        solver.solve.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_skip_solve_env_overrides_default(self, mgr, monkeypatch):
+        """``OPENLEGION_CAPTCHA_SKIP_SOLVE_DOMAINS=example.com`` — a domain
+        that would otherwise be ``default`` is forced to ``unsolvable``."""
+        _reload_policy_with_env({
+            "OPENLEGION_CAPTCHA_SKIP_SOLVE_DOMAINS": "example.com",
+            "OPENLEGION_CAPTCHA_FORCE_SOLVE_DOMAINS": "",
+        })
+        solver = _mk_solver(return_value=_solved())
+        mgr._captcha_solver = solver
+        inst = _mk_inst(page_url="https://example.com/protected")
+
+        envelope = await mgr._check_captcha(inst)
+        assert envelope["solver_outcome"] == "skipped_behavioral"
+        assert envelope["next_action"] == "request_captcha_help"
+        solver.solve.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_audit_event_records_policy_classification(
+        self, tmp_path, monkeypatch,
+    ):
+        """The audit-log event MUST include ``policy="unsolvable"`` so the
+        dashboard can show operators WHY a solve was skipped."""
+        events: list[dict] = []
+        m = BrowserManager(
+            profiles_dir=str(tmp_path / "profiles"),
+            metrics_sink=events.append,
+        )
+        m._captcha_solver = _mk_solver(return_value=_solved())
+        inst = _mk_inst(page_url="https://www.humansecurity.com/")
+        m._instances["agent-1"] = inst
+
+        await m._check_captcha(inst)
+        await m._emit_metrics()
+
+        captcha_events = [
+            e for e in events if e.get("type") == "captcha_gate"
+        ]
+        assert len(captcha_events) == 1, captcha_events
+        ev = captcha_events[0]
+        assert ev["outcome"] == "skipped_behavioral"
+        assert ev["policy"] == "unsolvable"
+
+
+# ── 2. low_success policy: solver IS called, confidence forced to low ────
+
+
+class TestLowSuccessPolicy:
+    @pytest.mark.asyncio
+    async def test_solved_envelope_forced_low_confidence(self, mgr, monkeypatch):
+        """``low_success`` host (accounts.google.com) — solver is called,
+        but a SUCCESSFUL solve still surfaces ``solver_confidence="low"``
+        because token-IP binding makes the solve unreliable even when
+        the verdict is good."""
+        solver = _mk_solver(return_value=_solved())
+        mgr._captcha_solver = solver
+        # accounts.google.com is hardcoded LOW_SUCCESS.
+        inst = _mk_inst(page_url="https://accounts.google.com/signup")
+
+        envelope = await mgr._check_captcha(inst)
+        assert envelope["solver_attempted"] is True
+        assert envelope["solver_outcome"] == "solved"
+        # Forced-low even though the underlying SolveResult would normally
+        # give "high" (compat_rejected=False, used_proxy_aware=False).
+        assert envelope["solver_confidence"] == "low"
+        # Solver WAS called — low_success is NOT a short-circuit.
+        solver.solve.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_failed_solve_upgrades_next_action_to_request_captcha_help(
+        self, mgr,
+    ):
+        """``low_success`` host + provider returned no token →
+        ``solver_outcome="rejected"`` per the existing flow, but
+        ``next_action`` is upgraded from ``notify_user`` to
+        ``request_captcha_help`` (escalate after first failure)."""
+        solver = _mk_solver(return_value=_rejected())
+        mgr._captcha_solver = solver
+        inst = _mk_inst(page_url="https://twitter.com/i/flow/signup")
+
+        envelope = await mgr._check_captcha(inst)
+        assert envelope["solver_outcome"] == "rejected"
+        # The KEY assertion: NOT "notify_user".
+        assert envelope["next_action"] == "request_captcha_help"
+        # And the audit-distinctive flag.
+        assert envelope.get("low_success_failed") is True
+
+    @pytest.mark.asyncio
+    async def test_low_success_failed_audit_event_emitted(
+        self, tmp_path,
+    ):
+        """The low_success-failed path emits a dashboard audit event with
+        outcome=``low_success_failed`` and ``policy="low_success"``."""
+        events: list[dict] = []
+        m = BrowserManager(
+            profiles_dir=str(tmp_path / "profiles"),
+            metrics_sink=events.append,
+        )
+        m._captcha_solver = _mk_solver(return_value=_rejected())
+        inst = _mk_inst(page_url="https://www.linkedin.com/login")
+        m._instances["agent-1"] = inst
+
+        await m._check_captcha(inst)
+        # Drain — but the audit event is fired-and-forget via
+        # asyncio.create_task inside ``_finalize``; let the task run.
+        await asyncio.sleep(0)
+        await m._emit_metrics()
+
+        ls_events = [
+            e for e in events
+            if e.get("type") == "captcha_gate"
+            and e.get("outcome") == "low_success_failed"
+        ]
+        assert len(ls_events) == 1, [
+            e for e in events if e.get("type") == "captcha_gate"
+        ]
+        assert ls_events[0]["policy"] == "low_success"
+
+    @pytest.mark.asyncio
+    async def test_force_solve_env_overrides_low_success(self, mgr, monkeypatch):
+        """``OPENLEGION_CAPTCHA_FORCE_SOLVE_DOMAINS=accounts.google.com`` —
+        operator forces a normal solve flow on a hardcoded ``low_success``
+        host. The envelope reports the solver's actual confidence (no
+        forced-low override)."""
+        _reload_policy_with_env({
+            "OPENLEGION_CAPTCHA_FORCE_SOLVE_DOMAINS": "accounts.google.com",
+            "OPENLEGION_CAPTCHA_SKIP_SOLVE_DOMAINS": "",
+        })
+        solver = _mk_solver(return_value=_solved())
+        mgr._captcha_solver = solver
+        inst = _mk_inst(page_url="https://accounts.google.com/signup")
+
+        envelope = await mgr._check_captcha(inst)
+        assert envelope["solver_outcome"] == "solved"
+        # The override neutralizes ``low_success`` — confidence reflects the
+        # underlying solve verdict (compat_rejected=False → "high").
+        assert envelope["solver_confidence"] == "high"
+        assert envelope["next_action"] == "solved"
+        assert "low_success_failed" not in envelope
+
+
+# ── 3. default policy: unchanged from current behavior ────────────────────
+
+
+class TestDefaultPolicy:
+    @pytest.mark.asyncio
+    async def test_default_policy_solved_high_confidence(self, mgr):
+        """A vanilla site → policy=default → unchanged flow."""
+        solver = _mk_solver(return_value=_solved())
+        mgr._captcha_solver = solver
+        inst = _mk_inst(page_url="https://example.com/protected")
+
+        envelope = await mgr._check_captcha(inst)
+        assert envelope["solver_outcome"] == "solved"
+        assert envelope["solver_confidence"] == "high"
+        assert envelope["next_action"] == "solved"
+        assert "low_success_failed" not in envelope
+
+    @pytest.mark.asyncio
+    async def test_default_policy_rejected_keeps_notify_user(self, mgr):
+        """A vanilla site + failed solve → ``next_action`` stays
+        ``notify_user`` (default policy does NOT escalate to
+        ``request_captcha_help``)."""
+        solver = _mk_solver(return_value=_rejected())
+        mgr._captcha_solver = solver
+        inst = _mk_inst(page_url="https://example.com/protected")
+
+        envelope = await mgr._check_captcha(inst)
+        assert envelope["solver_outcome"] == "rejected"
+        assert envelope["next_action"] == "notify_user"
+        assert "low_success_failed" not in envelope

--- a/tests/test_permissions.py
+++ b/tests/test_permissions.py
@@ -325,3 +325,281 @@ class TestDefaultFallbackPropagatesBrowserActions:
         matrix = PermissionMatrix(config_path=str(path))
         for action in ("navigate", "upload_file", "download", "solve_captcha"):
             assert matrix.can_browser_action("unknown", action) is True, action
+
+
+# ── Endpoint-level gates on the dedicated handoff routes ───────────────────
+
+
+def _build_handoff_app(tmp_path, *, perms_map):
+    """Mesh app fixture for the two dedicated handoff endpoints.
+
+    Mirrors :func:`tests.test_browser_delegation._build_app` but lives here
+    so the permission tests stay co-located with the rest of the matrix
+    coverage. Both endpoints (``/mesh/browser-login-request`` and
+    ``/mesh/browser-captcha-help-request``) are gated by
+    ``can_browser_action`` post-PR, so we exercise that gate directly
+    here — the ``browser_command`` path test in ``test_browser_delegation``
+    catches the *other* bypass surface but not these two dedicated routes.
+    """
+    from unittest.mock import MagicMock
+
+    from src.host.costs import CostTracker
+    from src.host.mesh import Blackboard, MessageRouter, PubSub
+    from src.host.server import create_mesh_app
+    from src.host.traces import TraceStore
+    from src.shared.types import AgentPermissions
+
+    blackboard = Blackboard(str(tmp_path / "bb.db"))
+    pubsub = PubSub()
+    matrix = PermissionMatrix()
+    for aid, perms in perms_map.items():
+        matrix.permissions[aid] = AgentPermissions(agent_id=aid, **perms)
+    router = MessageRouter(matrix, {})
+    costs = CostTracker(str(tmp_path / "costs.db"))
+    traces = TraceStore(str(tmp_path / "traces.db"))
+
+    container_manager = MagicMock()
+    container_manager.browser_service_url = "http://browser-svc:8500"
+    container_manager.browser_auth_token = ""
+
+    event_bus = MagicMock()
+    app = create_mesh_app(
+        blackboard=blackboard,
+        pubsub=pubsub,
+        router=router,
+        permissions=matrix,
+        cost_tracker=costs,
+        trace_store=traces,
+        event_bus=event_bus,
+        container_manager=container_manager,
+    )
+    return app, event_bus
+
+
+class TestBrowserCaptchaHelpRequestPermissionGate:
+    """``/mesh/browser-captcha-help-request`` enforces
+    ``can_browser_action(agent_id, "request_captcha_help")``.
+
+    Pre-PR (Phase 8 §11.14 in PR #769) the dedicated endpoint emitted
+    the dashboard handoff card without consulting the per-action gate.
+    An operator who narrowed a template to ``browser_actions=["navigate"]``
+    saw the FIRST call (``browser_command`` → ``request_captcha_help``)
+    rejected, but the SECOND call to this endpoint succeeded — defeating
+    permission narrowing.  These tests pin that the gate now fires here.
+    """
+
+    @pytest.mark.asyncio
+    async def test_narrowed_browser_actions_rejected_403(self, tmp_path):
+        from httpx import ASGITransport, AsyncClient
+
+        app, event_bus = _build_handoff_app(
+            tmp_path,
+            perms_map={
+                "narrow-agent": {
+                    "can_use_browser": True,
+                    "browser_actions": ["navigate"],
+                },
+            },
+        )
+
+        async with AsyncClient(
+            transport=ASGITransport(app=app), base_url="http://test",
+        ) as client:
+            resp = await client.post(
+                "/mesh/browser-captcha-help-request",
+                json={
+                    "agent_id": "narrow-agent",
+                    "service": "Cloudflare",
+                    "description": "Help me solve this CAPTCHA.",
+                },
+                headers={"X-Agent-ID": "narrow-agent"},
+            )
+        assert resp.status_code == 403, resp.text
+        assert "request_captcha_help" in resp.text
+        # Critical: the dashboard event was NOT emitted.
+        event_bus.emit.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_default_allow_browser_actions_succeeds(self, tmp_path):
+        """``browser_actions=None`` → default-allow → endpoint succeeds."""
+        from httpx import ASGITransport, AsyncClient
+
+        app, event_bus = _build_handoff_app(
+            tmp_path,
+            perms_map={
+                "open-agent": {"can_use_browser": True},
+            },
+        )
+
+        async with AsyncClient(
+            transport=ASGITransport(app=app), base_url="http://test",
+        ) as client:
+            resp = await client.post(
+                "/mesh/browser-captcha-help-request",
+                json={
+                    "agent_id": "open-agent",
+                    "service": "Cloudflare",
+                    "description": "Help me solve this CAPTCHA.",
+                },
+                headers={"X-Agent-ID": "open-agent"},
+            )
+        assert resp.status_code == 200, resp.text
+        event_bus.emit.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_explicit_grant_succeeds(self, tmp_path):
+        """``browser_actions=["request_captcha_help"]`` (explicitly
+        granted) → endpoint succeeds even though everything else is
+        blocked."""
+        from httpx import ASGITransport, AsyncClient
+
+        app, event_bus = _build_handoff_app(
+            tmp_path,
+            perms_map={
+                "captcha-only-agent": {
+                    "can_use_browser": True,
+                    "browser_actions": ["request_captcha_help"],
+                },
+            },
+        )
+
+        async with AsyncClient(
+            transport=ASGITransport(app=app), base_url="http://test",
+        ) as client:
+            resp = await client.post(
+                "/mesh/browser-captcha-help-request",
+                json={
+                    "agent_id": "captcha-only-agent",
+                    "service": "Cloudflare",
+                    "description": "Help me.",
+                },
+                headers={"X-Agent-ID": "captcha-only-agent"},
+            )
+        assert resp.status_code == 200, resp.text
+        event_bus.emit.assert_called_once()
+
+
+class TestBrowserLoginRequestPermissionGate:
+    """``/mesh/browser-login-request`` enforces
+    ``can_browser_action(agent_id, "request_browser_login")``.
+
+    Same bypass surface as the captcha-help endpoint.  Pre-PR, an
+    operator who restricted the agent's ``browser_actions`` could not
+    forbid this endpoint because the action name wasn't in
+    ``KNOWN_BROWSER_ACTIONS`` and the route did not consult the gate.
+    """
+
+    @pytest.mark.asyncio
+    async def test_narrowed_browser_actions_rejected_403(self, tmp_path):
+        from httpx import ASGITransport, AsyncClient
+
+        app, event_bus = _build_handoff_app(
+            tmp_path,
+            perms_map={
+                "narrow-agent": {
+                    "can_use_browser": True,
+                    "browser_actions": ["navigate"],
+                },
+            },
+        )
+
+        async with AsyncClient(
+            transport=ASGITransport(app=app), base_url="http://test",
+        ) as client:
+            resp = await client.post(
+                "/mesh/browser-login-request",
+                json={
+                    "agent_id": "narrow-agent",
+                    "url": "https://x.com/login",
+                    "service": "X",
+                    "description": "Log me in.",
+                },
+                headers={"X-Agent-ID": "narrow-agent"},
+            )
+        assert resp.status_code == 403, resp.text
+        assert "request_browser_login" in resp.text
+        event_bus.emit.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_default_allow_browser_actions_succeeds(self, tmp_path):
+        from httpx import ASGITransport, AsyncClient
+
+        app, event_bus = _build_handoff_app(
+            tmp_path,
+            perms_map={
+                "open-agent": {"can_use_browser": True},
+            },
+        )
+
+        async with AsyncClient(
+            transport=ASGITransport(app=app), base_url="http://test",
+        ) as client:
+            resp = await client.post(
+                "/mesh/browser-login-request",
+                json={
+                    "agent_id": "open-agent",
+                    "url": "https://x.com/login",
+                    "service": "X",
+                    "description": "Log me in.",
+                },
+                headers={"X-Agent-ID": "open-agent"},
+            )
+        assert resp.status_code == 200, resp.text
+        event_bus.emit.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_captcha_only_grant_blocks_login(self, tmp_path):
+        """Mirrors the spec scenario: an agent granted ONLY
+        ``request_captcha_help`` can use the captcha endpoint but the
+        login endpoint must 403 — separate per-action grants."""
+        from httpx import ASGITransport, AsyncClient
+
+        app, event_bus = _build_handoff_app(
+            tmp_path,
+            perms_map={
+                "captcha-only-agent": {
+                    "can_use_browser": True,
+                    "browser_actions": ["request_captcha_help"],
+                },
+            },
+        )
+
+        async with AsyncClient(
+            transport=ASGITransport(app=app), base_url="http://test",
+        ) as client:
+            # Captcha succeeds.
+            resp_captcha = await client.post(
+                "/mesh/browser-captcha-help-request",
+                json={
+                    "agent_id": "captcha-only-agent",
+                    "service": "Cloudflare",
+                    "description": "Help me.",
+                },
+                headers={"X-Agent-ID": "captcha-only-agent"},
+            )
+            assert resp_captcha.status_code == 200, resp_captcha.text
+            # Login 403s.
+            resp_login = await client.post(
+                "/mesh/browser-login-request",
+                json={
+                    "agent_id": "captcha-only-agent",
+                    "url": "https://x.com/login",
+                    "service": "X",
+                    "description": "Log me in.",
+                },
+                headers={"X-Agent-ID": "captcha-only-agent"},
+            )
+            assert resp_login.status_code == 403, resp_login.text
+            assert "request_browser_login" in resp_login.text
+
+
+class TestRequestBrowserLoginInKnownActions:
+    """``request_browser_login`` must be in ``KNOWN_BROWSER_ACTIONS`` so
+    operators can grant it explicitly via ``browser_actions=[...]`` and
+    the mesh-side input validator on ``/mesh/browser/command`` accepts
+    it as a known action name (although the dedicated endpoint is the
+    primary call site)."""
+
+    def test_present(self):
+        from src.host.permissions import KNOWN_BROWSER_ACTIONS
+        assert "request_browser_login" in KNOWN_BROWSER_ACTIONS


### PR DESCRIPTION
## Summary

Two small fixes from the post-merge review of Phase 8 captcha PRs (#765–#777). Both findings are in code that's live on `main` but not exercising the behavior operators expect.

### H5 (medium) — `captcha_policy` module shipped DORMANT

Phase 8 §11.18 (PR #767) added `src/browser/captcha_policy.py` with hardcoded UNSOLVABLE / LOW_SUCCESS lists and operator overrides (`OPENLEGION_CAPTCHA_FORCE_SOLVE_DOMAINS`, `OPENLEGION_CAPTCHA_SKIP_SOLVE_DOMAINS`), but no module imported it. Operators setting either env var saw zero behavior change.

Wires the module into `BrowserManager._check_captcha`, just after §11.1 reCAPTCHA variant + §11.3 CF tri-state classifiers (so `kind` is precise) and BEFORE the §11.16 health/breaker gates (so `unsolvable` hosts cost zero solver spend):

- **`unsolvable`** → short-circuit with envelope `solver_attempted=False`, `solver_outcome="skipped_behavioral"`, `solver_confidence="behavioral-only"`, `next_action="request_captcha_help"`. Same shape as the §11.3 behavioral path. Audited as `skipped_behavioral` with `policy="unsolvable"`.
- **`low_success`** → NOT a short-circuit. Solver runs; envelope confidence is forced to `"low"`. On a non-`solved` outcome, `next_action` upgrades to `"request_captcha_help"` (instead of `"notify_user"`) and the envelope is tagged `low_success_failed=True` so operators see the "tried-and-failed" case distinctly. Audit event emitted with outcome `low_success_failed` and `policy="low_success"`.
- **`default`** → unchanged.

Operator overrides reuse the existing `is_force_solve` / `is_skip_solve` helpers via `get_site_policy`'s documented precedence chain — no new override logic in this PR.

`_record_captcha_audit_event` gained an optional `policy` kwarg so the drained dashboard payload surfaces the policy classification.

### H7 (medium-high) — mesh handoff endpoints bypassed `can_browser_action`

`/mesh/browser-login-request` and `/mesh/browser-captcha-help-request` emitted the dashboard handoff card without consulting the per-action permission gate. An operator who narrowed a template to `browser_actions=["navigate"]` would see the first call (`browser_command` → `request_captcha_help`) rejected, but the SECOND call to the dedicated endpoint succeeded — permission narrowing didn't actually narrow.

- Added `can_browser_action(target_id, "request_browser_login")` / `can_browser_action(target_id, "request_captcha_help")` gates immediately after `_resolve_browser_target` in both endpoints. Same semantic as `/mesh/browser/command`: gate fires on the EFFECTIVE target (not the caller) so a wildcard operator cannot delegate actions the target was never granted.
- Added `request_browser_login` to `KNOWN_BROWSER_ACTIONS` so operators can grant it explicitly via `browser_actions=[...]` and the mesh input validator recognizes the name. (`request_captcha_help` was added in PR #769.)

### Tests

- `tests/test_check_captcha_policy.py` (new, 9 tests) — `unsolvable` short-circuits, `low_success` forces low confidence, `low_success` + failed solve upgrades `next_action`, `default` unchanged, `OPENLEGION_CAPTCHA_FORCE_SOLVE_DOMAINS` neutralizes hardcoded `low_success`, `OPENLEGION_CAPTCHA_SKIP_SOLVE_DOMAINS` flips a default site to `unsolvable`, audit event records policy.
- `tests/test_permissions.py` — 7 new endpoint tests hitting the dedicated mesh routes directly via httpx ASGI (not the `browser_command` path), plus a `KNOWN_BROWSER_ACTIONS` regression check for `request_browser_login`.

### Reuse-map enforcement

- `captcha_policy.get_site_policy` / `is_force_solve` / `is_skip_solve` — used as-is from PR #767.
- `permissions.can_browser_action` — used as the gate; no bypass.
- `_record_captcha_audit_event` (PR #777) — extended with a `policy` kwarg rather than introducing a new audit primitive.

### Judgment calls

- **Where `low_success` failure-upgrade fires.** The `low_success_failed → next_action="request_captcha_help"` upgrade lives inside `_finalize`, which is the helper applied to every solver-block return path. This guarantees the upgrade fires regardless of which concrete solver_outcome (`rejected` / `injection_failed` / `timeout` / `cost_cap` / `rate_limited` / `no_solver` / `breaker_open`) the path produced. Verified with `_rejected()` SolveResult test that walks token=None → `rejected` and confirms next_action is upgraded.
- **Audit event for low_success failures is fire-and-forget via `asyncio.create_task`.** `_finalize` is a sync nested helper; calling the async audit recorder synchronously isn't possible. The task is scheduled on the running loop and awaited by the test via `asyncio.sleep(0)`. If no loop is running (defensive — `_check_captcha` is always async), the audit is dropped rather than crashing the envelope.
- **Hook position.** Plan §11.18 said "after selector match + variant classifier"; I went one step further and placed the hook AFTER the §11.3 CF tri-state classifier, so `cf_force_low_confidence` is already known and the precise CF kind (`cf-interstitial-turnstile` etc.) is reported in the audit. The §11.3 behavioral classifier still runs first — its early return covers cases where the live DOM signals behavioral even on a host the policy module doesn't know about.

Reports: post-merge review of PRs #765–#777 (H5 + H7).

## Test plan

- [x] `pytest tests/ --ignore=tests/test_e2e*` → 4249 passed, 1 unrelated pre-existing `test_version_flag` failure (worktree env), 43 skipped.
- [x] `ruff check src/ tests/` → clean.
- [x] All Phase 8 captcha test files pass: `test_check_captcha_policy.py`, `test_check_captcha_metered.py`, `test_captcha_policy.py`, `test_captcha_envelope.py`, `test_browser_request_captcha_help.py`, `test_browser_delegation.py`, `test_permissions.py`.