### PR TITLE
Polish: simplify retry_previous + hint validation + tests + bounds

### DIFF
--- a/src/agent/builtins/browser_tool.py
+++ b/src/agent/builtins/browser_tool.py
@@ -1145,18 +1145,23 @@ async def browser_upload_file(
                 "Optional override for captcha kind classification. "
                 "One of: recaptcha-v2-checkbox, recaptcha-v2-invisible, "
                 "recaptcha-v3, recaptcha-enterprise-v2, "
-                "recaptcha-enterprise-v3, recaptcha-enterprise (legacy "
-                "alias), hcaptcha, turnstile, cf-interstitial-auto, "
-                "cf-interstitial-behavioral, unknown."
+                "recaptcha-enterprise-v3, hcaptcha, turnstile, "
+                "cf-interstitial-turnstile, unknown. Behavioral-only "
+                "kinds (cf-interstitial-auto / cf-interstitial-behavioral "
+                "/ px-press-hold / datadome-behavioral) are rejected — "
+                "use request_captcha_help for those."
             ),
             "default": "",
         },
         "retry_previous": {
             "type": "boolean",
             "description": (
-                "Retry the most recent solve attempt on this instance "
-                "(60-second TTL). Use when a transient solver error "
-                "left the captcha unsolved and the page still shows it."
+                "Skip the no-captcha early-return: wait briefly and "
+                "re-check ONCE for a captcha. Use when the page just "
+                "navigated and the captcha widget may not have rendered "
+                "yet. Does NOT replay a prior solve attempt — the "
+                "solver is invoked freshly against whatever the second "
+                "detection finds."
             ),
             "default": False,
         },

--- a/src/browser/captcha.py
+++ b/src/browser/captcha.py
@@ -1610,22 +1610,19 @@ class CaptchaSolver:
         # v3 extras — applied to both standard and enterprise v3 task entries.
         is_v3 = captcha_type in ("recaptcha-v3", "recaptcha-enterprise-v3")
         if is_v3:
-            # Operator-configured min score. ``flags.get_float`` clamps;
-            # we additionally clamp 0.1-0.9 to match the env-var doc.
-            try:
-                from src.browser import flags as _flags
-                min_score = _flags.get_float(
-                    "CAPTCHA_RECAPTCHA_V3_MIN_SCORE",
-                    _DEFAULT_V3_MIN_SCORE,
-                    min_value=0.1,
-                    max_value=0.9,
-                )
-            except Exception:
-                # Defensive: if flags import fails (shouldn't, but the
-                # solver module is sometimes imported in test contexts
-                # without ``src.browser`` initialized) fall back to the
-                # default rather than aborting the solve.
-                min_score = _DEFAULT_V3_MIN_SCORE
+            # Operator-configured min score. ``flags.get_float`` is
+            # contracted not to raise — bad values fall back to the
+            # default at the flag-helper level. The previous defensive
+            # try/except was swallowing programmer errors in the flag
+            # module silently; let any future bug there surface
+            # immediately.
+            from src.browser import flags as _flags
+            min_score = _flags.get_float(
+                "CAPTCHA_RECAPTCHA_V3_MIN_SCORE",
+                _DEFAULT_V3_MIN_SCORE,
+                min_value=0.1,
+                max_value=0.9,
+            )
             body["minScore"] = min_score
             action = (page_action or "").strip()
             if not action:

--- a/src/browser/service.py
+++ b/src/browser/service.py
@@ -68,7 +68,8 @@ logger = setup_logging("browser.service")
 #
 #   kind:
 #     "recaptcha-v2-checkbox" | "recaptcha-v2-invisible" | "recaptcha-v3"
-#     | "recaptcha-enterprise" | "hcaptcha" | "turnstile"
+#     | "recaptcha-enterprise-v2" | "recaptcha-enterprise-v3"
+#     | "hcaptcha" | "turnstile"
 #     | "cf-interstitial-auto" | "cf-interstitial-behavioral"
 #     | "cf-interstitial-turnstile" | "px-press-hold"
 #     | "datadome-behavioral" | "unknown"
@@ -135,14 +136,15 @@ _FIRM_KINDS = frozenset({
 # Kept in sync with the docstring at the top of this module. New kinds added
 # here as §11.1 / §11.3 land richer classification.
 #
-# §11.1 splits the prior coarse ``recaptcha-enterprise`` placeholder into
-# the v2/v3 enterprise variants ``recaptcha-enterprise-v{2,3}``. The old
-# ``recaptcha-enterprise`` value is kept as a back-compat alias so agents
-# whose stored hints reference the coarse kind keep working — the
-# classifier never emits it for new detections.
+# §11.1 split the prior coarse ``recaptcha-enterprise`` placeholder into
+# the v2/v3 enterprise variants ``recaptcha-enterprise-v{2,3}``. The legacy
+# coarse alias was REMOVED from this enum (review polish, finding F16) — it
+# had no operational effect (no task-table entry, no pricing entry), so
+# accepting it here just papered over miswired agent hints. Agents using
+# the alias now get a clean ``invalid_input`` error pointing at the precise
+# variants.
 _VALID_CAPTCHA_KINDS: frozenset[str] = frozenset({
     "recaptcha-v2-checkbox", "recaptcha-v2-invisible", "recaptcha-v3",
-    "recaptcha-enterprise",  # legacy alias for back-compat
     "recaptcha-enterprise-v2", "recaptcha-enterprise-v3",
     "hcaptcha", "turnstile",
     # §11.3 — CF interstitial tri-state + behavioral-only kinds.
@@ -151,6 +153,28 @@ _VALID_CAPTCHA_KINDS: frozenset[str] = frozenset({
     "px-press-hold", "datadome-behavioral",
     "unknown",
 })
+
+
+# ── Behavioral-only hint rejection (§11.14 polish) ────────────────────────
+# These kinds have no task-table entry — passing them as ``hint=`` to
+# ``solve_captcha`` would cause a silent no-op (provider call skipped, the
+# envelope's auto-classified kind is overridden but the solver was never
+# going to engage anyway). Reject at the validator with a message that
+# points at the correct path (``request_captcha_help``).
+_BEHAVIORAL_KINDS: frozenset[str] = frozenset({
+    "px-press-hold",
+    "datadome-behavioral",
+    "cf-interstitial-auto",
+    "cf-interstitial-behavioral",
+})
+
+
+# Patience window for ``solve_captcha(retry_previous=True)`` (§11.14 polish).
+# When the agent says "the captcha may not have rendered yet" we wait up
+# to this many milliseconds AND re-check ONCE before returning the
+# ``no captcha on current page`` envelope. Bound at the call site so the
+# overall solve_captcha latency stays predictable.
+_RETRY_PREVIOUS_RECHECK_MS = 500
 
 
 # §11.3 — wait duration for CF auto-resolving JS challenge ("Just a moment").
@@ -1653,7 +1677,7 @@ class CamoufoxInstance:
         # idempotency flag for ``BrowserManager._attach_network_listeners``.
         self.network_log: deque[dict] = deque(maxlen=200)
         self._network_attached: bool = False
-        # §11.14 explicit-solve guards.
+        # §11.14 explicit-solve guard.
         # ``_captcha_solving`` is set for the duration of a manager-level
         # ``solve_captcha`` invocation; if a NEW captcha is detected by
         # ``_check_captcha`` while this flag is set we surface
@@ -1661,10 +1685,6 @@ class CamoufoxInstance:
         # into another solve attempt (could otherwise pile up provider
         # cost and deadlock against the per-instance lock).
         self._captcha_solving: bool = False
-        # ``_last_solve_attempt`` records (sitekey, url, started_unix_ts)
-        # for the most recent solve so ``retry_previous=True`` can replay
-        # within a 60-second TTL. ``None`` until first attempt.
-        self._last_solve_attempt: tuple[str, str, float] | None = None
 
     def _register_page(self, page) -> str:
         """Assign a stable UUID to a Page if not already registered.
@@ -6186,9 +6206,15 @@ class BrowserManager:
         Local pre-checks (cheap, no provider involvement):
           1. ``CAPTCHA_DISABLED`` flag — early-return ``no_solver`` envelope.
           2. ``hint`` validation — bad hint → ``invalid_input`` error.
-          3. ``retry_previous`` TTL check — stale → ``invalid_input`` error.
-          4. No-captcha early return — saves a solver invocation + cost.
-          5. Recursive-solve guard — re-entrant ``_check_captcha`` while a
+             Behavioral-only kinds (PerimeterX, DataDome, CF interstitial)
+             are also rejected here because the solver has no task entry
+             for them; the correct path is ``request_captcha_help``.
+          3. No-captcha early return — saves a solver invocation + cost.
+             When ``retry_previous=True`` and the initial detection finds
+             nothing, we wait :data:`_RETRY_PREVIOUS_RECHECK_MS` and
+             re-check ONCE; this covers the "page just navigated, captcha
+             is rendering" race.
+          4. Recursive-solve guard — re-entrant ``_check_captcha`` while a
              solve is in flight surfaces ``captcha_during_solve``.
 
         Rate-limit + cost-cap fire INSIDE ``_check_captcha`` →
@@ -6199,6 +6225,16 @@ class BrowserManager:
         Until then, we LOG and IGNORE — the top-ranked visible widget gets
         solved. Documented in the skill description so agents don't expect
         targeting precision yet.
+
+        ``retry_previous`` semantics (review polish): the original
+        "retry the most recent failed solve attempt against (sitekey, url)"
+        spec required tracking solver internals across calls and racing
+        with the auto-classifier on whether the displayed captcha is the
+        same one. The new, simpler semantic is: **"be patient — the
+        captcha may not have rendered yet"**. If the initial detection
+        returns ``captcha_found=False`` we sleep briefly and re-detect
+        once. Bounded by :data:`_RETRY_PREVIOUS_RECHECK_MS` so total
+        latency stays predictable.
         """
         # Gate 1: fleet-wide kill switch.
         from src.browser.flags import get_bool
@@ -6215,12 +6251,26 @@ class BrowserManager:
 
         # Gate 2: hint validation (cheap, before lock).
         if hint is not None:
-            if not isinstance(hint, str) or hint.strip() not in _VALID_CAPTCHA_KINDS:
+            if not isinstance(hint, str):
                 return _err(
                     "invalid_input",
                     f"hint must be one of: {sorted(_VALID_CAPTCHA_KINDS)}",
                 )
             hint = hint.strip()
+            # Behavioral-only kinds are valid classifier outputs but
+            # have no solver task entry — treating them as a hint would
+            # be a silent no-op on the solver path. Reject loudly so the
+            # agent sees the correct routing immediately.
+            if hint in _BEHAVIORAL_KINDS:
+                return _err(
+                    "invalid_input",
+                    f"hint={hint!r} is behavioral-only — use request_captcha_help",
+                )
+            if hint not in _VALID_CAPTCHA_KINDS:
+                return _err(
+                    "invalid_input",
+                    f"hint must be one of: {sorted(_VALID_CAPTCHA_KINDS)}",
+                )
 
         if target_ref:
             logger.warning(
@@ -6233,21 +6283,7 @@ class BrowserManager:
         inst.touch()
 
         async with inst.lock:
-            # Gate 3: retry_previous TTL check.
-            if retry_previous:
-                last = inst._last_solve_attempt
-                if last is None or (time.time() - last[2]) > 60.0:
-                    return _err(
-                        "invalid_input", "no_recent_attempt_to_retry",
-                    )
-                # The retry path just re-runs the normal flow; the
-                # solver itself is idempotent against (sitekey, url),
-                # and we don't preserve the last classified kind here
-                # because the page may have changed. Stamp the
-                # restarted timestamp so further retries chain.
-                inst._last_solve_attempt = (last[0], last[1], time.time())
-
-            # Gate 4: no-captcha early return. Set the recursive-solve
+            # Gate 3: no-captcha early return. Set the recursive-solve
             # guard BEFORE the call so a captcha that appears during
             # detection isn't mistaken for one we should now solve.
             #
@@ -6281,6 +6317,18 @@ class BrowserManager:
                 # ``_metered_solve`` so this method no longer touches
                 # the cost counter directly.
                 envelope = await self._check_captcha(inst)
+
+                # ``retry_previous`` patience window: when the agent
+                # signals "the captcha may not have rendered yet", give
+                # the page a brief moment and re-check ONCE before
+                # giving up. Bounded by ``_RETRY_PREVIOUS_RECHECK_MS``.
+                if (
+                    retry_previous
+                    and not envelope.get("captcha_found")
+                ):
+                    await asyncio.sleep(_RETRY_PREVIOUS_RECHECK_MS / 1000.0)
+                    envelope = await self._check_captcha(inst)
+
                 if not envelope.get("captcha_found"):
                     # No-captcha early return — distinct from the §11.13
                     # ``captcha_found: false`` shape; surface a friendly
@@ -6303,14 +6351,6 @@ class BrowserManager:
                     # is purely classification metadata.
                     envelope = dict(envelope)
                     envelope["kind"] = hint
-
-                # Stamp the last attempt for ``retry_previous`` (best
-                # effort — page.url access can fail on closed contexts).
-                try:
-                    page_url = inst.page.url or ""
-                except Exception:
-                    page_url = ""
-                inst._last_solve_attempt = ("", page_url, time.time())
 
                 return {
                     "success": True,

--- a/src/browser/timing.py
+++ b/src/browser/timing.py
@@ -213,6 +213,18 @@ def inter_action_delay() -> float:
 # ── CAPTCHA solve pacing (§11.11) ─────────────────────────────
 
 
+_CAPTCHA_PACING_DEFAULTS = {
+    "mu_ms": 6000,
+    "sigma_ms": 2500,
+    "min_ms": 3000,
+    "max_ms": 12000,
+}
+# Hard ceiling on any individual captcha-pacing knob — 10 minutes is well
+# beyond any sane operator override and prevents a misconfigured env var
+# from stalling a solve indefinitely.
+_CAPTCHA_PACING_HARD_MAX_MS = 600_000
+
+
 async def captcha_solve_delay() -> None:
     """Gaussian-with-clamp delay between solver token retrieval and DOM injection.
 
@@ -225,6 +237,13 @@ async def captcha_solve_delay() -> None:
     * ``CAPTCHA_PACING_MS_MIN`` — clamp lower bound (default 3000).
     * ``CAPTCHA_PACING_MS_MAX`` — clamp upper bound (default 12000).
 
+    Each env var is bounded to ``[0, 600_000]`` (10 minutes) at the
+    flag-loader layer to prevent a typo from producing a multi-hour
+    sleep. We additionally validate ``min_ms < max_ms`` — an inverted
+    pair (operator typo, e.g. ``MIN=20000, MAX=10000``) would silently
+    produce a degenerate clamp where every sample lands at the lower
+    bound; we log a warning and fall back to defaults instead.
+
     The existing ``human_delay`` / ``keystroke_delay`` helpers operate on
     millisecond-scale clamps and are unsuitable for the 3-12s scale of
     post-solve pacing — this helper exists specifically for that range.
@@ -232,10 +251,44 @@ async def captcha_solve_delay() -> None:
     human reading time, which is independent of the operator's "go fast"
     knob for intra-action timing.
     """
-    mu_ms = flags.get_int("CAPTCHA_SOLVE_PACING_MU_MS", 6000)
-    sigma_ms = flags.get_int("CAPTCHA_SOLVE_PACING_SIGMA_MS", 2500)
-    min_ms = flags.get_int("CAPTCHA_PACING_MS_MIN", 3000)
-    max_ms = flags.get_int("CAPTCHA_PACING_MS_MAX", 12000)
+    mu_ms = flags.get_int(
+        "CAPTCHA_SOLVE_PACING_MU_MS",
+        _CAPTCHA_PACING_DEFAULTS["mu_ms"],
+        min_value=0, max_value=_CAPTCHA_PACING_HARD_MAX_MS,
+    )
+    sigma_ms = flags.get_int(
+        "CAPTCHA_SOLVE_PACING_SIGMA_MS",
+        _CAPTCHA_PACING_DEFAULTS["sigma_ms"],
+        min_value=0, max_value=_CAPTCHA_PACING_HARD_MAX_MS,
+    )
+    min_ms = flags.get_int(
+        "CAPTCHA_PACING_MS_MIN",
+        _CAPTCHA_PACING_DEFAULTS["min_ms"],
+        min_value=0, max_value=_CAPTCHA_PACING_HARD_MAX_MS,
+    )
+    max_ms = flags.get_int(
+        "CAPTCHA_PACING_MS_MAX",
+        _CAPTCHA_PACING_DEFAULTS["max_ms"],
+        min_value=0, max_value=_CAPTCHA_PACING_HARD_MAX_MS,
+    )
+    if min_ms >= max_ms:
+        # Inverted / equal clamp — operator misconfig. Log once-shaped
+        # warning (no rate gate; this fires per-call but only when
+        # misconfigured) and fall back to the documented defaults so
+        # the solve still paces realistically rather than landing on
+        # a degenerate bound.
+        import logging
+        logging.getLogger("browser.timing").warning(
+            "CAPTCHA pacing clamp is inverted (MIN=%d, MAX=%d); "
+            "falling back to defaults [%d, %d].",
+            min_ms, max_ms,
+            _CAPTCHA_PACING_DEFAULTS["min_ms"],
+            _CAPTCHA_PACING_DEFAULTS["max_ms"],
+        )
+        mu_ms = _CAPTCHA_PACING_DEFAULTS["mu_ms"]
+        sigma_ms = _CAPTCHA_PACING_DEFAULTS["sigma_ms"]
+        min_ms = _CAPTCHA_PACING_DEFAULTS["min_ms"]
+        max_ms = _CAPTCHA_PACING_DEFAULTS["max_ms"]
     delay_ms = _clamped_gauss(float(mu_ms), float(sigma_ms),
                               float(min_ms), float(max_ms))
     await asyncio.sleep(delay_ms / 1000.0)

--- a/tests/fixtures/redaction_corpus.json
+++ b/tests/fixtures/redaction_corpus.json
@@ -239,5 +239,12 @@
     "expect_redacted": ["ckey0123456789abcdef0123456789abcdef0123456789"],
     "expect_preserved": ["api.2captcha.com", "getTaskResult", "taskId="],
     "note": "Provider task IDs are not themselves secrets but appear in error logs; captcha module's redactor strips them in plain text. URL-form redaction here only targets clientKey."
+  },
+  {
+    "name": "captcha_solver_taskid_integer_in_url",
+    "input": "https://api.2captcha.com/getTaskResult?clientKey=ckey0123456789abcdef0123456789abcdef0123456789&taskId=9876543210",
+    "expect_redacted": ["ckey0123456789abcdef0123456789abcdef0123456789"],
+    "expect_preserved": ["api.2captcha.com", "getTaskResult", "taskId="],
+    "note": "2Captcha returns integer task IDs (CapSolver returns UUIDs). URL-form redaction strips clientKey; integer task IDs themselves are not secrets but the captcha module's _redact_clientkey_text scrubs them from plain-text logs (see test_redact_clientkey_text_strips_taskid)."
   }
 ]

--- a/tests/test_browser_solve_captcha.py
+++ b/tests/test_browser_solve_captcha.py
@@ -6,9 +6,13 @@ Covers:
   * Cost-cap exceeded → ``cost_cap`` outcome.
   * Rate-limit exceeded → ``rate_limited`` outcome.
   * Recursive-solve guard → ``captcha_during_solve``.
-  * ``retry_previous=True`` within 60s replays last attempt.
-  * ``retry_previous=True`` after 60s returns invalid_input.
+  * ``retry_previous=True`` waits then re-checks once when the initial
+    detection found nothing (covers the "page just navigated, captcha
+    still rendering" race). A second-detection hit still solves.
+  * ``retry_previous=True`` does NOT block when the first detection
+    already found a captcha (no extra wait).
   * Bad ``hint`` returns invalid_input.
+  * Behavioral-only ``hint`` values are rejected with a routing message.
   * Health-unreachable + breaker-open paths still return §11.13 envelopes.
 """
 
@@ -177,11 +181,19 @@ class TestSolveCaptchaRecursiveGuard:
 
 
 class TestSolveCaptchaRetryPrevious:
+    """``retry_previous=True`` is a "be patient" hint — when the initial
+    detection finds no captcha, wait briefly and re-check ONCE. Useful
+    when the page just navigated and the widget is still rendering.
+
+    Does NOT replay any prior solve attempt — there is no per-instance
+    state about previous solves. The solver runs freshly against
+    whatever the second detection finds.
+    """
+
     @pytest.mark.asyncio
-    async def test_retry_within_ttl_works(self, mgr):
+    async def test_retry_does_not_wait_when_captcha_already_present(self, mgr):
+        """Captcha visible on first detection → no patience window, normal solve."""
         inst = _mk_inst_with_locator(captcha_present=True)
-        # Stamp a prior attempt 1 second ago.
-        inst._last_solve_attempt = ("sk", "https://example.com", time.time() - 1)
         mgr._instances["agent-1"] = inst
         mgr.get_or_start = AsyncMock(return_value=inst)
 
@@ -192,32 +204,95 @@ class TestSolveCaptchaRetryPrevious:
         solver.solve = AsyncMock(return_value=_solved_result())
         mgr._captcha_solver = solver
 
-        result = await mgr.solve_captcha("agent-1", retry_previous=True)
+        # Patch the patience-window sleep so we can assert it WASN'T called.
+        with pytest.MonkeyPatch.context() as mp:
+            sleep_mock = AsyncMock()
+            mp.setattr("src.browser.service.asyncio.sleep", sleep_mock)
+            result = await mgr.solve_captcha("agent-1", retry_previous=True)
+
+        assert result["success"] is True
+        assert result["data"]["solver_outcome"] == "solved"
+        sleep_mock.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_retry_waits_then_finds_captcha_on_second_detection(self, mgr):
+        """First detection: nothing. Wait ~500ms, re-detect: captcha present → solve."""
+        # Build an instance whose first locator().count() returns 0,
+        # second returns 1. We need a locator that toggles based on call
+        # count across selectors.
+        mock_page = MagicMock()
+        mock_page.url = "https://example.com"
+
+        # The detection loop iterates over multiple selectors. We want
+        # the FIRST full pass (all selectors) to return 0, and the
+        # SECOND full pass (after the patience window) to return 1 on
+        # the first selector.
+        pass_counter = {"n": 0}
+        selector_counter = {"n": 0}
+
+        def locator_factory(sel):
+            loc = MagicMock()
+
+            async def _count():
+                # Track per-call "which pass are we in?" — every 7
+                # calls (we have 7 selectors) we move to a new pass.
+                idx = selector_counter["n"]
+                selector_counter["n"] += 1
+                pass_idx = idx // 7
+                if pass_idx == 0:
+                    return 0  # first detection: empty
+                return 1 if (idx % 7) == 0 else 0
+
+            loc.count = _count
+            return loc
+
+        mock_page.locator = MagicMock(side_effect=locator_factory)
+        inst = CamoufoxInstance(
+            "agent-1", MagicMock(), MagicMock(), mock_page,
+        )
+        mgr._instances["agent-1"] = inst
+        mgr.get_or_start = AsyncMock(return_value=inst)
+
+        solver = MagicMock()
+        solver.provider = "2captcha"
+        solver.is_solver_unreachable = AsyncMock(return_value=False)
+        solver.is_breaker_open = MagicMock(return_value=False)
+        solver.solve = AsyncMock(return_value=_solved_result())
+        mgr._captcha_solver = solver
+
+        with pytest.MonkeyPatch.context() as mp:
+            sleep_mock = AsyncMock()
+            mp.setattr("src.browser.service.asyncio.sleep", sleep_mock)
+            result = await mgr.solve_captcha("agent-1", retry_previous=True)
+            del pass_counter  # silence unused-var lint
+            # Patience window MUST have been awaited exactly once with
+            # the documented bound (500ms → 0.5s).
+            sleep_calls = [c.args[0] for c in sleep_mock.await_args_list]
+            assert 0.5 in sleep_calls, (
+                f"expected 500ms patience sleep; got {sleep_calls}"
+            )
+
         assert result["success"] is True
         assert result["data"]["solver_outcome"] == "solved"
 
     @pytest.mark.asyncio
-    async def test_retry_after_ttl_returns_invalid_input(self, mgr):
-        inst = _mk_inst_with_locator(captcha_present=True)
-        # Stamp a prior attempt 90 seconds ago — past the 60s TTL.
-        inst._last_solve_attempt = ("sk", "https://example.com", time.time() - 90)
+    async def test_retry_returns_no_captcha_when_second_detection_also_empty(self, mgr):
+        """Both detections empty → no captcha message, no solver call."""
+        inst = _mk_inst_with_locator(captcha_present=False)
         mgr._instances["agent-1"] = inst
         mgr.get_or_start = AsyncMock(return_value=inst)
 
-        result = await mgr.solve_captcha("agent-1", retry_previous=True)
-        assert result["success"] is False
-        assert result["error"]["code"] == "invalid_input"
-        assert result["error"]["message"] == "no_recent_attempt_to_retry"
+        with pytest.MonkeyPatch.context() as mp:
+            sleep_mock = AsyncMock()
+            mp.setattr("src.browser.service.asyncio.sleep", sleep_mock)
+            result = await mgr.solve_captcha("agent-1", retry_previous=True)
 
-    @pytest.mark.asyncio
-    async def test_retry_with_no_prior_attempt_returns_invalid_input(self, mgr):
-        inst = _mk_inst_with_locator(captcha_present=True)
-        mgr._instances["agent-1"] = inst
-        mgr.get_or_start = AsyncMock(return_value=inst)
-
-        result = await mgr.solve_captcha("agent-1", retry_previous=True)
-        assert result["success"] is False
-        assert result["error"]["code"] == "invalid_input"
+        assert result["success"] is True
+        assert result["data"]["captcha_found"] is False
+        assert "No captcha" in result["data"]["message"]
+        # Patience window fired exactly once (500ms).
+        sleep_args = [c.args[0] for c in sleep_mock.await_args_list]
+        assert sleep_args.count(0.5) == 1
 
 
 class TestSolveCaptchaHintValidation:
@@ -243,6 +318,51 @@ class TestSolveCaptchaHintValidation:
         result = await mgr.solve_captcha("agent-1", hint="hcaptcha")
         assert result["success"] is True
         assert result["data"]["kind"] == "hcaptcha"
+
+    @pytest.mark.parametrize(
+        "behavioral_hint",
+        [
+            "px-press-hold",
+            "datadome-behavioral",
+            "cf-interstitial-auto",
+            "cf-interstitial-behavioral",
+        ],
+    )
+    @pytest.mark.asyncio
+    async def test_behavioral_only_hint_rejected_with_routing_message(
+        self, mgr, behavioral_hint,
+    ):
+        """Behavioral kinds have no solver task entry; passing them as a
+        ``hint`` would produce a silent no-op. Validator must reject loudly
+        and point at ``request_captcha_help``.
+        """
+        inst = _mk_inst_with_locator(captcha_present=True)
+        mgr._instances["agent-1"] = inst
+        mgr.get_or_start = AsyncMock(return_value=inst)
+
+        result = await mgr.solve_captcha("agent-1", hint=behavioral_hint)
+        assert result["success"] is False
+        assert result["error"]["code"] == "invalid_input"
+        assert behavioral_hint in result["error"]["message"]
+        assert "request_captcha_help" in result["error"]["message"]
+
+    @pytest.mark.asyncio
+    async def test_legacy_recaptcha_enterprise_alias_rejected(self, mgr):
+        """The legacy coarse ``recaptcha-enterprise`` alias was kept as
+        a back-compat hint but had no operational effect (no task-table
+        entry, no pricing entry). Removed in favor of the precise
+        v2/v3 variants — agents using the alias get a clean error
+        pointing at the valid set.
+        """
+        inst = _mk_inst_with_locator(captcha_present=True)
+        mgr._instances["agent-1"] = inst
+        mgr.get_or_start = AsyncMock(return_value=inst)
+
+        result = await mgr.solve_captcha("agent-1", hint="recaptcha-enterprise")
+        assert result["success"] is False
+        assert result["error"]["code"] == "invalid_input"
+        # Suggest the precise variants.
+        assert "recaptcha-enterprise-v2" in result["error"]["message"]
 
 
 class TestSolveCaptchaHealthAndBreaker:

--- a/tests/test_captcha_cf_tristate.py
+++ b/tests/test_captcha_cf_tristate.py
@@ -590,3 +590,46 @@ class TestCfStateNone:
         assert result["solver_outcome"] == "no_solver"
         # Placeholder kind → "low" confidence per ``_kind_confidence``.
         assert result["solver_confidence"] == "low"
+
+
+# ── 12. All-three-signals precedence regression (security finding F10) ───
+
+
+class TestCfAllThreeSignals:
+    @pytest.mark.asyncio
+    async def test_cf_all_three_signals_routes_behavioral(self):
+        """Pathological CF page with EVERY discriminating signal set
+        simultaneously: ``has_cf_error_1020`` + ``has_turnstile`` +
+        ``has_challenge_running`` + ``has_challenge_error_text``.
+
+        Per ``_classify_cf_state`` precedence (highest-to-lowest):
+          1. error_1020 / challenge_error_text → behavioral
+          2. turnstile + "Just a moment" → turnstile
+          3. challenge_running + "Just a moment" → auto
+
+        Error markers win — under-attack mode is the most dangerous
+        state and the solver genuinely cannot help. This test pins
+        that precedence so a future refactor of the classifier doesn't
+        silently route an under-attack page through the Turnstile
+        solver path (which would burn provider credit + leak the
+        attempt to CF for nothing).
+        """
+        solver = AsyncMock()
+        solver.solve = AsyncMock(return_value=_solved_sr())
+        mgr = _make_manager(solver=solver)
+        inst = _make_inst(
+            matching_selector='iframe[src*="challenges.cloudflare.com"]',
+            cf_probe={
+                "has_cf_error_1020": True,
+                "has_turnstile": True,
+                "has_challenge_running": True,
+                "has_challenge_error_text": True,
+            },
+            title="Just a moment...",
+        )
+        result = await mgr._check_captcha(inst)
+        assert result["kind"] == "cf-interstitial-behavioral"
+        assert result["solver_attempted"] is False
+        assert result["solver_outcome"] == "skipped_behavioral"
+        assert result["next_action"] == "request_captcha_help"
+        solver.solve.assert_not_awaited()

--- a/tests/test_captcha_health.py
+++ b/tests/test_captcha_health.py
@@ -629,6 +629,9 @@ def test_redact_clientkey_text_strips_taskid():
     error responses. The shared redactor strips them so a hostile
     provider error containing a stitched-together secret-like string
     can't leak via the taskId path.
+
+    2Captcha returns integer task IDs ("taskId": 9876543210); CapSolver
+    returns UUID-shape strings. Both forms must be scrubbed.
     """
     shapes_with_uuid = [
         'taskId=8d2c1f3a-aaaa-4444-bbbb-1234567890ab',
@@ -639,6 +642,21 @@ def test_redact_clientkey_text_strips_taskid():
     for shape in shapes_with_uuid:
         out = _redact_clientkey_text(shape)
         assert "[REDACTED]" in out, f"taskId not redacted in {shape!r}: {out!r}"
+
+    # Pure integer-form (2Captcha-style) — explicit coverage. Both quoted
+    # and unquoted shapes must be scrubbed.
+    integer_shapes = [
+        'taskId=9876543210',
+        'taskId="9876543210"',
+        '{"errorId": 1, "taskId": 9876543210}',
+        "got back taskId: 9876543210 from provider",
+    ]
+    for shape in integer_shapes:
+        out = _redact_clientkey_text(shape)
+        assert "9876543210" not in out, (
+            f"integer taskId leaked in {shape!r}: {out!r}"
+        )
+        assert "[REDACTED]" in out
 
 
 # ── 12: cancellation cleans up in-flight health_check ─────────────────

--- a/tests/test_captcha_recaptcha_classifier.py
+++ b/tests/test_captcha_recaptcha_classifier.py
@@ -158,6 +158,46 @@ class TestEnterpriseDetection:
         result = await _classify_recaptcha(page)
         assert result["variant"] == "recaptcha-enterprise-v2"
 
+    @pytest.mark.asyncio
+    async def test_classifier_consumer_plus_enterprise_picks_enterprise(self):
+        """Multi-tenant page with BOTH consumer ``api.js`` and enterprise
+        ``enterprise.js`` scripts loaded simultaneously, and BOTH a
+        consumer sitekey and an enterprise sitekey present in the registry.
+
+        Per security finding F11: the JS probe sets ``enterprise=True``
+        when ANY signal points at enterprise (script tag OR global), and
+        the first sitekey from the ``sitekeys`` list wins. This documents
+        the current behavior — when the agent is intending to solve the
+        consumer widget on a page that ALSO embeds an enterprise widget
+        for an unrelated flow, the classifier may misalign with intent.
+
+        Fix is deferred (architectural — requires per-widget targeting,
+        §11.6 territory). When the deferred-trigger fires in production
+        we'll need either snapshot-ref-based selection or a per-sitekey
+        enterprise/consumer disambiguation pass.
+        """
+        page = _make_page({
+            # Both scripts loaded → enterprise wins.
+            "enterprise": True,
+            "enterprise_script": True,
+            "v3": False,
+            # Consumer key first, enterprise key second. Current
+            # classifier picks ``sitekeys[0]`` — but classifies as
+            # enterprise based on the script signal. Misalignment risk.
+            "sitekeys": ["CONSUMER_SITEKEY", "ENTERPRISE_SITEKEY"],
+            "actions_by_key": {},
+            "invisible_by_key": {
+                "CONSUMER_SITEKEY": False,
+                "ENTERPRISE_SITEKEY": False,
+            },
+            "v3_render_param": None,
+        })
+        result = await _classify_recaptcha(page)
+        # Documented current behavior — pin so a future refactor of the
+        # classifier surfaces here, not in production.
+        assert result["variant"] == "recaptcha-enterprise-v2"
+        assert result["sitekey"] == "CONSUMER_SITEKEY"
+
 
 # ── 3. v3 detection paths ─────────────────────────────────────────────────
 

--- a/tests/test_captcha_solve_pacing.py
+++ b/tests/test_captcha_solve_pacing.py
@@ -194,6 +194,114 @@ class TestPacingFiresOnSuccess:
         assert bool(ok) is True
         assert pace.await_count == 1
 
+    @pytest.mark.asyncio
+    async def test_pacing_runs_before_token_injection(self):
+        """Pace MUST come before inject — otherwise the form submit lands
+        before the human-style pause and the anti-bot signal fires.
+        Witness an event list capturing the order across the live solve.
+        """
+        solver = _make_solver()
+        solver._solver_health_checked = True
+        page = _solve_page()
+
+        client = AsyncMock(spec=httpx.AsyncClient)
+        client.is_closed = False
+        client.post = AsyncMock(side_effect=_stub_create_then_ready())
+        solver._client = client
+
+        events: list[str] = []
+
+        async def record_pace():
+            events.append("pace")
+
+        async def record_inject(self_, page_, captcha_type, token):
+            events.append("inject")
+            return True
+
+        with patch("src.browser.timing.captcha_solve_delay", new=record_pace), \
+             patch("src.browser.captcha.CaptchaSolver._inject_token",
+                   new=record_inject), \
+             patch("src.browser.captcha._POLL_INTERVAL", 0.001):
+            ok = await solver.solve(
+                page, 'iframe[src*="recaptcha"]', "https://example.com",
+                kind="recaptcha-v3",
+            )
+
+        assert bool(ok) is True
+        assert events == ["pace", "inject"], (
+            f"expected pace-then-inject, got {events}"
+        )
+
+
+# ── 3b. Env-var bounds + inverted-clamp recovery ──────────────────────
+
+
+class TestEnvVarBounds:
+    @pytest.mark.asyncio
+    async def test_inverted_clamp_falls_back_to_defaults_with_warning(
+        self, monkeypatch, caplog,
+    ):
+        """Operator typo: ``MIN=20000, MAX=10000``. The clamp would
+        otherwise produce a degenerate distribution where every sample
+        lands at the lower bound. Code path: detect inversion, log a
+        warning, and use the documented defaults so the solve still
+        paces realistically.
+        """
+        monkeypatch.setenv("CAPTCHA_PACING_MS_MIN", "20000")
+        monkeypatch.setenv("CAPTCHA_PACING_MS_MAX", "10000")
+        # flags.py caches operator settings — reload after the env mutation.
+        from src.browser import flags as _flags
+        _flags.reload_operator_settings()
+
+        observed: list[float] = []
+
+        async def fake_sleep(s):
+            observed.append(s)
+
+        with patch("asyncio.sleep", new=fake_sleep), \
+             caplog.at_level("WARNING", logger="browser.timing"):
+            for _ in range(50):
+                await timing.captcha_solve_delay()
+
+        # Defaults: [3.0, 12.0].
+        for s in observed:
+            assert 3.0 <= s <= 12.0, (
+                f"inverted clamp didn't recover; got {s}s"
+            )
+        assert any("inverted" in rec.getMessage().lower()
+                   for rec in caplog.records), (
+            "inverted-clamp warning did not fire"
+        )
+
+    @pytest.mark.asyncio
+    async def test_absurd_high_value_clamped_at_loader(self, monkeypatch):
+        """A typo of 60_000_000ms (≈16h) would stall the solver. The
+        flag-loader bounds (max=600_000ms = 10min) clip it before the
+        Gaussian sampler ever sees it.
+        """
+        # MU = 60_000_000ms (16h+) — bounded to 600_000ms by the loader.
+        monkeypatch.setenv("CAPTCHA_SOLVE_PACING_MU_MS", "60000000")
+        # Open the clamp so MU isn't the limiting factor.
+        monkeypatch.setenv("CAPTCHA_PACING_MS_MIN", "1000")
+        monkeypatch.setenv("CAPTCHA_PACING_MS_MAX", "600000")
+        # Tight sigma so MU dominates.
+        monkeypatch.setenv("CAPTCHA_SOLVE_PACING_SIGMA_MS", "10")
+        from src.browser import flags as _flags
+        _flags.reload_operator_settings()
+
+        observed: list[float] = []
+
+        async def fake_sleep(s):
+            observed.append(s)
+
+        with patch("asyncio.sleep", new=fake_sleep):
+            for _ in range(20):
+                await timing.captcha_solve_delay()
+
+        # MU loader cap is 600_000ms = 600s. Every sample bounded.
+        for s in observed:
+            assert s <= 600.0, f"sample {s}s exceeded loader cap"
+
 
 # ── 4. Helper NOT called on failure paths ─────────────────────────────
 

--- a/tests/test_captcha_solver_proxy.py
+++ b/tests/test_captcha_solver_proxy.py
@@ -392,6 +392,54 @@ class TestTaskBody:
         )
         assert body is None
 
+    def test_password_with_newlines_round_trips_via_json(self, monkeypatch):
+        """Header-injection-style attack: an operator-supplied proxy
+        password containing newlines / control chars must end up
+        JSON-escaped in the request body, never raw-injected into the
+        outbound HTTP serialization. Per security finding F9.
+
+        ``CAPTCHA_SOLVER_PROXY_PASSWORD`` flows through ``flags.get_str``
+        (raw env-var string), into :class:`SolverProxyConfig.password`,
+        and finally into the JSON body via :meth:`to_request_fields`.
+        Because both 2captcha and CapSolver receive the body via
+        ``json=...`` (httpx's JSON encoder), control chars are escaped
+        rather than emitted as raw bytes — they cannot break out of the
+        JSON string into raw HTTP headers.
+        """
+        import json
+        _set_full_proxy_env(monkeypatch)
+        # Override the password with control chars.
+        monkeypatch.setenv(
+            "CAPTCHA_SOLVER_PROXY_PASSWORD", "p\nwith\rnewlines\t",
+        )
+        from src.browser import flags as _flags
+        _flags.reload_operator_settings()
+
+        cfg = get_solver_proxy_config()
+        assert cfg is not None
+        # Build a task body and serialize as JSON.
+        s = self._solver(provider="2captcha")
+        body, _, _ = s._build_task_body(
+            _2CAPTCHA_TASK_TYPES, "recaptcha-v2-checkbox",
+            "SITEKEY", "https://example.com",
+            page_action=None, proxy_config=cfg,
+        )
+        assert body is not None
+        # The Python dict still holds the raw control chars (correct —
+        # they're Python strings, not HTTP).
+        assert body["proxyPassword"] == "p\nwith\rnewlines\t"
+        # JSON-serialize the way httpx does; control chars MUST be
+        # escaped, never raw.
+        serialized = json.dumps(body)
+        assert "\\n" in serialized, (
+            "newline not JSON-escaped — would slip into raw HTTP headers"
+        )
+        assert "\\r" in serialized
+        assert "\\t" in serialized
+        # Raw newline characters must not survive into the wire form.
+        assert "\n" not in serialized
+        assert "\r" not in serialized
+
 
 # ── 5. Cost counter respects proxy_aware flag ─────────────────────────────
 


### PR DESCRIPTION
## Summary

Apply remaining post-merge review findings as a single polish pass. No behavioral change for healthy paths; tightens operator-misconfig handling and rejects classes of agent input that were previously silent no-ops.

## Findings addressed

| # | Severity | Reviewer | Finding |
|---|---|---|---|
| H8 | HIGH | correctness | `retry_previous` semantics broken — "retry last solve" never actually retargeted, and the 60s TTL was stamped on SUCCESSFUL solves. Simplified to a "be patient, re-check once" flag (`_RETRY_PREVIOUS_RECHECK_MS = 500`); dropped `_last_solve_attempt` field + 60s TTL machinery. |
| M1 | MEDIUM | correctness | `time.time()` vs `time.monotonic()` for retry TTL — moot, the TTL is gone. |
| M3 | MEDIUM | correctness | `_VALID_CAPTCHA_KINDS` accepted unsolvable behavioral hints. New `_BEHAVIORAL_KINDS` frozenset rejects `px-press-hold` / `datadome-behavioral` / `cf-interstitial-auto` / `cf-interstitial-behavioral` with a routing message pointing at `request_captcha_help`. |
| F16 | LOW | correctness | Legacy `recaptcha-enterprise` alias accepted but had no operational effect. Removed from `_VALID_CAPTCHA_KINDS`; agents now get a clean error pointing at the v2/v3 variants. |
| F9 | LOW | security | Header-injection-style proxy passwords. New canary test asserts newlines/control chars in `CAPTCHA_SOLVER_PROXY_PASSWORD` JSON-escape rather than slip into raw HTTP. |
| F10 | LOW | security | All-three-CF-signals precedence. New regression test pins `_classify_cf_state` precedence (1020 wins) under the pathological "every signal set" probe. |
| F11 | LOW | security | Multi-tenant consumer+enterprise reCAPTCHA. New regression test documents current classifier behavior (enterprise wins, first sitekey wins). Architectural fix deferred per §11.20. |
| F12 | LOW | security | Pacing ordering test. New event-list witness asserts `["pace", "inject"]` order. |
| F15 | LOW | security | Integer-form taskId in redaction corpus + helper test. |
| — | LOW | integration | Pacing env-var bounds + inversion recovery. Each `CAPTCHA_PACING_*` knob now bounded to `[0, 600_000ms]` via `flags.get_int(min_value=, max_value=)` (reused); inverted clamp falls back to defaults with a single warning. |
| — | LOW | correctness | Bare `except Exception` in `_build_task_body` flag lookup dropped — flag helpers are contracted not to raise. |

## Reuse-map enforcement

- Reused `flags.get_int(min_value=, max_value=)` for the pacing bounds — no new env-loading layer.
- Reused existing test fixtures (`tests/fixtures/redaction_corpus.json`, `_make_inst` in `test_captcha_cf_tristate.py`, `_make_solver` in `test_captcha_solve_pacing.py`).

## Judgment call: retry_previous semantic

The original spec ("retry the most recent failed solve attempt on this instance — same sitekey, same URL") required tracking solver internals across calls and racing with the auto-classifier. The new "be patient, re-check once" semantic is genuinely useful (covers the common "page just navigated, captcha still rendering" race) AND is honest about what the layer actually does. Considered just removing the param entirely; kept it because the rendering-race scenario is real and the agent has no other mechanism to express "wait briefly and look again". Reviewer feedback welcome on whether to remove instead.

## Test plan

- [x] `pytest tests/ --ignore=tests/test_e2e*` green (4244 passed, 1 unrelated pre-existing failure on `test_cli_commands.py::TestVersion::test_version_flag` — package-not-installed env issue, exists on `main`)
- [x] `ruff check src/ tests/` clean
- [x] All directly-touched test files pass: `test_browser_solve_captcha`, `test_captcha_solve_pacing`, `test_captcha_cf_tristate`, `test_captcha_recaptcha_classifier`, `test_captcha_solver_proxy`, `test_captcha_health`, `test_shared_redaction`, `test_browser_service` — 655 passed