### PR TITLE
Fix Codex findings: cost units, kill switch, breaker pollution, audit

### DIFF
--- a/src/browser/captcha.py
+++ b/src/browser/captcha.py
@@ -63,14 +63,20 @@ class SolveResult:
             old per-instance ``last_compat_rejected`` scratch attr.
         skipped: When non-``None``, the metering layer short-circuited
             BEFORE the solver HTTP call. One of:
+              * ``"disabled"`` — ``CAPTCHA_DISABLED`` kill switch active.
+                Replaces the per-call early-return that used to live in
+                ``solve_captcha``; the auto-detect entry points
+                (navigate / click) now flow through the same gate.
               * ``"rate_limited"`` — per-agent solve-rate gate fired.
               * ``"cost_cap"`` — per-agent monthly cost-cap reached.
+              * ``"provider_missing"`` — solver lacks a string ``provider``
+                attribute AND a cost cap is configured; we fail closed
+                rather than let an untrackable charge slip past the cap.
             ``None`` for a real solver attempt (success or failure).
 
     Field-population guarantee for ``_metered_solve`` consumers:
-      * ``skipped="rate_limited"`` → ``token=None, injection_succeeded=False,
+      * Any ``skipped`` value → ``token=None, injection_succeeded=False,
         used_proxy_aware=False, compat_rejected=False``.
-      * ``skipped="cost_cap"`` → same.
       * ``skipped=None``: every other field reflects the actual solver
         attempt; ``token is None`` indicates a failed solve.
     """
@@ -1360,7 +1366,14 @@ class CaptchaSolver:
             sitekey = await self._extract_sitekey(page, captcha_type)
         if not sitekey:
             logger.warning("Could not extract sitekey for %s CAPTCHA", captcha_type)
-            await self._record_solver_outcome(success=False)
+            # LOCAL failure — sitekey couldn't be extracted from the
+            # page DOM. The provider was never contacted, so the §11.16
+            # breaker MUST NOT count this. Pre-fix, three sitekey-extraction
+            # failures from a single agent (e.g. an unsupported widget
+            # variant the DOM-extractor doesn't recognize) tripped the
+            # breaker for the entire BrowserManager and blocked real
+            # solves for every other agent. The breaker tracks PROVIDER
+            # reliability — local classifier gaps belong elsewhere.
             return SolveResult(
                 token=None, injection_succeeded=False,
                 used_proxy_aware=False, compat_rejected=False,
@@ -1381,7 +1394,12 @@ class CaptchaSolver:
         timeout_s = self._timeout_seconds_for_kind(timeout_kind)
 
         try:
-            token, used_proxy_aware, compat_rejected = await asyncio.wait_for(
+            (
+                token,
+                used_proxy_aware,
+                compat_rejected,
+                provider_contacted,
+            ) = await asyncio.wait_for(
                 self._submit_and_poll(
                     captcha_type, sitekey, page_url,
                     page_action=page_action, proxy_config=proxy_config,
@@ -1394,6 +1412,11 @@ class CaptchaSolver:
                 "CAPTCHA solve timed out after %.1fs (kind=%s)",
                 timeout_s, timeout_kind,
             )
+            # ``asyncio.wait_for`` cancelled ``_submit_and_poll`` mid-flight
+            # — by the time the outer deadline fires, ``createTask`` has
+            # already been issued (the task-body builder + provider HTTP
+            # call complete in well under a second; the deadline only
+            # bites during the poll loop). Treat as provider-contacted.
             await self._record_solver_outcome(success=False)
             return SolveResult(
                 token=None, injection_succeeded=False,
@@ -1407,6 +1430,11 @@ class CaptchaSolver:
                 "CAPTCHA solve failed: %s",
                 _redact_clientkey_text(redact_url(repr(exc))),
             )
+            # An exception bubbling out of ``_submit_and_poll`` is rare —
+            # both per-provider helpers catch and convert into ``None``
+            # tokens. When it does happen, conservatively treat it as
+            # provider-contacted so a programmer-error flood doesn't
+            # silently mask a real provider outage.
             await self._record_solver_outcome(success=False)
             return SolveResult(
                 token=None, injection_succeeded=False,
@@ -1414,7 +1442,13 @@ class CaptchaSolver:
             )
 
         if not token:
-            await self._record_solver_outcome(success=False)
+            # Token retrieval failed. Only count the breaker when a real
+            # provider request was issued. ``provider_contacted=False``
+            # means ``_build_task_body`` rejected the variant locally
+            # (no row in the per-provider task table) — the captcha is
+            # unsupported, NOT a provider outage signal.
+            if provider_contacted:
+                await self._record_solver_outcome(success=False)
             return SolveResult(
                 token=None, injection_succeeded=False,
                 used_proxy_aware=used_proxy_aware,
@@ -1508,7 +1542,7 @@ class CaptchaSolver:
         page_action: str | None = None,
         proxy_config: SolverProxyConfig | None = None,
         kind: str | None = None,
-    ) -> tuple[str | None, bool, bool]:
+    ) -> tuple[str | None, bool, bool, bool]:
         """Submit CAPTCHA to solving service and poll for result.
 
         ``page_action`` is the v3 action string from the classifier; it's
@@ -1525,9 +1559,21 @@ class CaptchaSolver:
         infinite loop when a provider stays in ``processing`` past the
         outer deadline.
 
-        Returns ``(token, used_proxy_aware, compat_rejected)`` so the
-        caller (``solve``) can mark the envelope's confidence and inform
-        the cost counter whether proxy-aware pricing applies.
+        Returns ``(token, used_proxy_aware, compat_rejected, provider_contacted)``:
+
+          * ``token`` — provider-issued solution, or ``None`` on any
+            failure (local task-body rejection, createTask error, poll
+            error, errorId>0, never-ready).
+          * ``used_proxy_aware`` / ``compat_rejected`` — see
+            ``_build_task_body``.
+          * ``provider_contacted`` — ``True`` iff a ``createTask`` HTTP
+            request was actually attempted. ``False`` for purely-local
+            failures (unknown ``captcha_type`` not in the provider table,
+            ``_build_task_body`` returning ``None``). The §11.16 circuit
+            breaker MUST only count provider-contacted failures —
+            otherwise three unsupported-variant requests from one agent
+            trip the breaker for the whole BrowserManager and block real
+            solves for every other agent.
         """
         if self.provider == "2captcha":
             return await self._solve_2captcha(
@@ -1693,7 +1739,7 @@ class CaptchaSolver:
         page_action: str | None = None,
         proxy_config: SolverProxyConfig | None = None,
         kind: str | None = None,
-    ) -> tuple[str | None, bool, bool]:
+    ) -> tuple[str | None, bool, bool, bool]:
         client = self._get_client()
         task, used_proxy_aware, compat_rejected = self._build_task_body(
             _2CAPTCHA_TASK_TYPES, captcha_type, sitekey, page_url,
@@ -1701,13 +1747,21 @@ class CaptchaSolver:
             provider_name="2captcha",
         )
         if not task:
-            return None, used_proxy_aware, compat_rejected
+            # Local failure — the variant isn't in the provider table.
+            # ``provider_contacted=False`` so the breaker is NOT polluted
+            # by unsupported-variant requests (see ``_submit_and_poll``
+            # docstring for the full rationale).
+            return None, used_proxy_aware, compat_rejected, False
 
         # Submit task
         payload = {
             "clientKey": self.api_key,
             "task": task,
         }
+        # Mark provider_contacted=True the moment we attempt the HTTP
+        # call. From here every failure path is a real provider
+        # interaction (network error, errorId>0, never-ready) and the
+        # breaker SHOULD count it.
         try:
             resp = await client.post("https://api.2captcha.com/createTask", json=payload)
             resp.raise_for_status()
@@ -1721,16 +1775,16 @@ class CaptchaSolver:
                 "2Captcha createTask failed: %s",
                 _redact_clientkey_text(redact_url(str(e))),
             )
-            return None, used_proxy_aware, compat_rejected
+            return None, used_proxy_aware, compat_rejected, True
         if data.get("errorId", 0) != 0:
             logger.warning(
                 "2Captcha submit error: %s",
                 _redact_clientkey_text(str(data.get("errorDescription"))),
             )
-            return None, used_proxy_aware, compat_rejected
+            return None, used_proxy_aware, compat_rejected, True
         task_id = data.get("taskId")
         if not task_id:
-            return None, used_proxy_aware, compat_rejected
+            return None, used_proxy_aware, compat_rejected, True
 
         # Poll for result. The iteration cap is the §11.9 per-type
         # timeout in seconds divided by the poll interval; the outer
@@ -1754,19 +1808,19 @@ class CaptchaSolver:
                     "2Captcha getTaskResult failed: %s",
                     _redact_clientkey_text(redact_url(str(e))),
                 )
-                return None, used_proxy_aware, compat_rejected
+                return None, used_proxy_aware, compat_rejected, True
             if data.get("errorId", 0) != 0:
                 logger.warning(
                     "2Captcha poll error: %s",
                     _redact_clientkey_text(str(data.get("errorDescription"))),
                 )
-                return None, used_proxy_aware, compat_rejected
+                return None, used_proxy_aware, compat_rejected, True
             if data.get("status") == "ready":
                 solution = data.get("solution", {})
                 token = solution.get("gRecaptchaResponse") or solution.get("token")
-                return token, used_proxy_aware, compat_rejected
+                return token, used_proxy_aware, compat_rejected, True
             # status == "processing" — keep polling
-        return None, used_proxy_aware, compat_rejected
+        return None, used_proxy_aware, compat_rejected, True
 
     # ── CapSolver ─────────────────────────────────────────────────────────────
 
@@ -1779,7 +1833,7 @@ class CaptchaSolver:
         page_action: str | None = None,
         proxy_config: SolverProxyConfig | None = None,
         kind: str | None = None,
-    ) -> tuple[str | None, bool, bool]:
+    ) -> tuple[str | None, bool, bool, bool]:
         client = self._get_client()
         task, used_proxy_aware, compat_rejected = self._build_task_body(
             _CAPSOLVER_TASK_TYPES, captcha_type, sitekey, page_url,
@@ -1787,7 +1841,8 @@ class CaptchaSolver:
             provider_name="capsolver",
         )
         if not task:
-            return None, used_proxy_aware, compat_rejected
+            # Local failure — see ``_solve_2captcha`` for breaker rationale.
+            return None, used_proxy_aware, compat_rejected, False
 
         # Submit task
         payload = {
@@ -1803,16 +1858,16 @@ class CaptchaSolver:
                 "CapSolver createTask failed: %s",
                 _redact_clientkey_text(redact_url(str(e))),
             )
-            return None, used_proxy_aware, compat_rejected
+            return None, used_proxy_aware, compat_rejected, True
         if data.get("errorId", 0) != 0:
             logger.warning(
                 "CapSolver submit error: %s",
                 _redact_clientkey_text(str(data.get("errorDescription"))),
             )
-            return None, used_proxy_aware, compat_rejected
+            return None, used_proxy_aware, compat_rejected, True
         task_id = data.get("taskId")
         if not task_id:
-            return None, used_proxy_aware, compat_rejected
+            return None, used_proxy_aware, compat_rejected, True
 
         # Poll for result. See ``_solve_2captcha`` for why the loop bound
         # is sized off the §11.9 per-type table.
@@ -1831,18 +1886,18 @@ class CaptchaSolver:
                     "CapSolver getTaskResult failed: %s",
                     _redact_clientkey_text(redact_url(str(e))),
                 )
-                return None, used_proxy_aware, compat_rejected
+                return None, used_proxy_aware, compat_rejected, True
             if data.get("errorId", 0) != 0:
                 logger.warning(
                     "CapSolver poll error: %s",
                     _redact_clientkey_text(str(data.get("errorDescription"))),
                 )
-                return None, used_proxy_aware, compat_rejected
+                return None, used_proxy_aware, compat_rejected, True
             if data.get("status") == "ready":
                 solution = data.get("solution", {})
                 token = solution.get("gRecaptchaResponse") or solution.get("token")
-                return token, used_proxy_aware, compat_rejected
-        return None, used_proxy_aware, compat_rejected
+                return token, used_proxy_aware, compat_rejected, True
+        return None, used_proxy_aware, compat_rejected, True
 
     # ── Token injection ───────────────────────────────────────────────────────
 

--- a/src/browser/captcha_cost_counter.py
+++ b/src/browser/captcha_cost_counter.py
@@ -8,16 +8,37 @@ counted spend — acceptable because the cap is per-month and a process restart
 inside a billing month is rare; the alternative (SQLite, WAL, schema-migration
 plumbing) was disproportionate to the value.
 
+UNITS — IMPORTANT.
+
+All values are stored and compared in **MILLICENTS** (1/1000 of a US cent
+= 1/100_000 of a US dollar). A 2captcha v2-checkbox solve is published at
+$1.00 per 1000 solves = $0.001 per solve = 0.1 cents = **100 millicents**.
+
+Conversion shortcuts:
+
+  * dollars → millicents: ``int(round(usd * 100_000))``
+  * millicents → cents (for human display): ``millicents / 1000.0``
+  * millicents → dollars (for human display): ``millicents / 100_000.0``
+
+Why millicents and not cents or ``Decimal``? Most published solve rates
+are sub-cent (0.06¢ – 0.6¢). Storing as integer cents would round every
+real per-solve charge to 0 or 1, blowing up the cap-tripping math. Storing
+as ``Decimal`` USD is cleaner but a wider refactor; integer millicents
+gives lossless arithmetic for the published rate table while keeping the
+existing `int` storage / JSON shape unchanged.
+
 Public surface:
-  * :func:`add_cost(agent_id, cents)` — increment a per-agent monthly bucket.
-    Resets the bucket when the calendar month rolls over.
-  * :func:`over_cap(agent_id, cap_cents)` — read-only check.
+  * :func:`add_cost(agent_id, millicents)` — increment a per-agent
+    monthly bucket. Resets when the calendar month rolls over.
+  * :func:`over_cap(agent_id, cap_millicents)` — read-only check.
   * :func:`snapshot()` / :func:`restore()` — JSON file persistence. Atomic
-    write via ``os.replace`` after ``fsync``.
-  * :func:`estimate_cents(provider, kind)` — fixed table of published rates
-    so callers don't reimplement the lookup. Returns ``None`` when the
-    variant isn't priced — caller should log a warning and skip counting
-    (over-counting is worse than under-counting for trust).
+    write via ``os.replace`` after ``fsync``. The on-disk schema migrates
+    legacy ``cents`` snapshots by multiplying ×1000 on load (logged once).
+  * :func:`estimate_millicents(provider, kind)` — fixed table of published
+    rates. Returns ``None`` when the variant isn't priced — caller should
+    log a warning and skip counting (over-counting is worse than
+    under-counting for trust).
+  * :func:`get_millicents(agent_id)` — current-month spend.
 """
 
 from __future__ import annotations
@@ -46,11 +67,11 @@ def _state_path() -> Path:
 # ── Pricing table ──────────────────────────────────────────────────────────
 
 
-# Published rates from 2captcha + CapSolver (April 2026), in US cents per
-# successful solve. Keys follow the convention ``{provider}-{variant}`` for
-# the proxyless tier; the proxy-aware tier uses a 3-tuple key
-# ``(provider, variant, proxy_aware=True)`` and lives in
-# :data:`PRICING_CENTS_PROXY_AWARE` below.
+# Published rates from 2captcha + CapSolver (April 2026), in **millicents**
+# (1/1000 of a US cent) per successful solve. Keys follow the convention
+# ``{provider}-{variant}`` for the proxyless tier; the proxy-aware tier
+# uses a 2-tuple key ``(provider, variant)`` and lives in
+# :data:`PRICING_MILLICENTS_PROXY_AWARE` below.
 #
 # Why two tables? Provider docs publish proxyless rates in a single line
 # but proxy-aware rates as "approximately 3× the base" in their pricing
@@ -59,27 +80,31 @@ def _state_path() -> Path:
 #
 # When a kind isn't priced, callers SKIP counting rather than guessing —
 # under-count > over-count for operator trust.
-PRICING_CENTS: dict[str, int] = {
+#
+# Sanity: 100 millicents = 0.1 cents = $0.001/solve. 2Captcha publishes
+# v2-checkbox at $1.00 / 1000 solves = $0.001/solve = 100 millicents.  ✓
+PRICING_MILLICENTS: dict[str, int] = {
     # 2Captcha — published https://2captcha.com/2captcha-api#solving_recaptchav2_new
-    "2captcha-recaptcha-v2-checkbox": 100,        # $1.00 / 1000 = 0.10c each → 0.1¢
+    "2captcha-recaptcha-v2-checkbox": 100,        # $1.00 / 1000 = 0.1¢ each → 100 millicents
     "2captcha-recaptcha-v2-invisible": 100,
     "2captcha-recaptcha-v3": 100,
     # §11.1 splits ``recaptcha-enterprise`` into v2/v3 enterprise variants;
     # both keep the same Enterprise rate. ``recaptcha-enterprise`` is
     # retained as a back-compat alias for any callers still emitting the
     # coarse kind from a hint override.
-    "2captcha-recaptcha-enterprise": 200,
+    "2captcha-recaptcha-enterprise": 200,         # $2.00 / 1000 = 0.2¢ each → 200 millicents
     "2captcha-recaptcha-enterprise-v2": 200,
     "2captcha-recaptcha-enterprise-v3": 200,
     "2captcha-hcaptcha": 100,
     "2captcha-turnstile": 200,
     # CF-bound Turnstile (§11.3 ``cf-interstitial-turnstile``) — solver
     # path is identical to standalone Turnstile; only the envelope ``kind``
-    # differs. Aliased here so :func:`estimate_cents` doesn't return ``None``
-    # for the CF variant and trip the spurious "no published rate" warning.
+    # differs. Aliased here so :func:`estimate_millicents` doesn't return
+    # ``None`` for the CF variant and trip the spurious "no published rate"
+    # warning.
     "2captcha-cf-interstitial-turnstile": 200,
     # CapSolver — published https://docs.capsolver.com/guide/captcha/
-    "capsolver-recaptcha-v2-checkbox": 80,
+    "capsolver-recaptcha-v2-checkbox": 80,        # $0.80 / 1000 = 0.08¢ each → 80 millicents
     "capsolver-recaptcha-v2-invisible": 80,
     "capsolver-recaptcha-v3": 80,
     "capsolver-recaptcha-enterprise": 200,
@@ -92,14 +117,15 @@ PRICING_CENTS: dict[str, int] = {
 
 # §11.2 — proxy-aware pricing tier (~3× the proxyless rate as published
 # by both providers). Tuple key ``(provider, variant)``; ``proxy_aware``
-# flag at lookup time picks this table over :data:`PRICING_CENTS`.
+# flag at lookup time picks this table over :data:`PRICING_MILLICENTS`.
 #
 # 2captcha v3 has no documented proxy-aware task type as of April 2026,
-# so its proxy-aware entries are intentionally absent — :func:`estimate_cents`
-# falls through to the proxyless price for those (the body builder
-# already falls back to proxyless when no proxy_aware task is documented,
-# so paying proxyless rate matches what the provider sees).
-PRICING_CENTS_PROXY_AWARE: dict[tuple[str, str], int] = {
+# so its proxy-aware entries are intentionally absent —
+# :func:`estimate_millicents` falls through to the proxyless price for
+# those (the body builder already falls back to proxyless when no
+# proxy_aware task is documented, so paying proxyless rate matches what
+# the provider sees).
+PRICING_MILLICENTS_PROXY_AWARE: dict[tuple[str, str], int] = {
     # 2captcha — 3× the proxyless rate
     ("2captcha", "recaptcha-v2-checkbox"):    300,
     ("2captcha", "recaptcha-v2-invisible"):   300,
@@ -120,19 +146,27 @@ PRICING_CENTS_PROXY_AWARE: dict[tuple[str, str], int] = {
     ("capsolver", "cf-interstitial-turnstile"): 180,
 }
 
+# Back-compat aliases — third-party subclasses or future callers that
+# import ``PRICING_CENTS`` will get the millicents table. Names retained
+# so an out-of-tree subclass does not break at import time even if its
+# arithmetic is now off-by-1000 (a logged warning is the worst that
+# happens; the real fix landed inside this module).
+PRICING_CENTS = PRICING_MILLICENTS
+PRICING_CENTS_PROXY_AWARE = PRICING_MILLICENTS_PROXY_AWARE
 
-def estimate_cents(
+
+def estimate_millicents(
     provider: str, kind: str, *, proxy_aware: bool = False,
 ) -> int | None:
-    """Return published cost (cents) for one successful solve, or ``None``.
+    """Return published cost (millicents) for one successful solve, or ``None``.
 
-    ``proxy_aware=True`` consults :data:`PRICING_CENTS_PROXY_AWARE` first
-    (~3× the proxyless rate). When the proxy-aware table doesn't have a
-    row for the (provider, variant) tuple — e.g. 2captcha v3, where the
-    provider has no documented proxy-aware task type — we fall through to
-    the proxyless rate. That matches what the body builder did at the
-    request layer (proxyless task body), so the price billed equals the
-    request type sent.
+    ``proxy_aware=True`` consults :data:`PRICING_MILLICENTS_PROXY_AWARE`
+    first (~3× the proxyless rate). When the proxy-aware table doesn't
+    have a row for the (provider, variant) tuple — e.g. 2captcha v3,
+    where the provider has no documented proxy-aware task type — we fall
+    through to the proxyless rate. That matches what the body builder did
+    at the request layer (proxyless task body), so the price billed
+    equals the request type sent.
 
     ``None`` signals the variant isn't priced; callers should log a warning
     and SKIP the increment rather than attribute a guess to the agent's
@@ -147,19 +181,27 @@ def estimate_cents(
     p = provider.strip().lower()
     k = kind.strip().lower()
     if proxy_aware:
-        cents = PRICING_CENTS_PROXY_AWARE.get((p, k))
-        if cents is not None:
-            return cents
+        mc = PRICING_MILLICENTS_PROXY_AWARE.get((p, k))
+        if mc is not None:
+            return mc
         # Fall through to the proxyless rate — the body builder degraded
         # to proxyless for this variant, so the price tier matches.
     key = f"{p}-{k}"
-    return PRICING_CENTS.get(key)
+    return PRICING_MILLICENTS.get(key)
+
+
+# Back-compat alias — third-party subclasses or older call sites using
+# ``estimate_cents`` get the millicents value transparently. The name is
+# off-by-1000 wrt its label but every internal caller has been migrated
+# to ``estimate_millicents`` in the same change-set; this exists so an
+# out-of-tree CaptchaSolver subclass keeps importing without a hard break.
+estimate_cents = estimate_millicents
 
 
 # ── State + lock ───────────────────────────────────────────────────────────
 
 
-# {agent_id: {"month": "YYYY-MM", "cents": int}}
+# {agent_id: {"month": "YYYY-MM", "millicents": int}}
 _state: dict[str, dict] = {}
 _lock: asyncio.Lock = asyncio.Lock()
 
@@ -178,7 +220,7 @@ def _bucket_for(agent_id: str, *, current_month: str | None = None) -> dict:
     cm = current_month or _current_month()
     bucket = _state.get(agent_id)
     if bucket is None or bucket.get("month") != cm:
-        bucket = {"month": cm, "cents": 0}
+        bucket = {"month": cm, "millicents": 0}
         _state[agent_id] = bucket
     return bucket
 
@@ -186,39 +228,52 @@ def _bucket_for(agent_id: str, *, current_month: str | None = None) -> dict:
 # ── Public mutators / readers ──────────────────────────────────────────────
 
 
-async def add_cost(agent_id: str, cents: int) -> int:
-    """Add ``cents`` to ``agent_id``'s current-month bucket. Returns new total.
+async def add_cost(agent_id: str, millicents: int) -> int:
+    """Add ``millicents`` to ``agent_id``'s current-month bucket.
 
-    Concurrent writers across asyncio tasks are serialized by ``_lock`` —
-    matters because the browser service serves multiple agents off a single
-    event loop. Negative or zero ``cents`` are silently dropped (defensive).
+    Returns the new total (millicents). Concurrent writers across asyncio
+    tasks are serialized by ``_lock`` — matters because the browser
+    service serves multiple agents off a single event loop. Non-positive
+    inputs are silently dropped (defensive).
     """
-    if cents <= 0:
-        return await get_cents(agent_id)
+    if millicents <= 0:
+        return await get_millicents(agent_id)
     async with _lock:
         bucket = _bucket_for(agent_id)
-        bucket["cents"] = int(bucket["cents"]) + int(cents)
-        return bucket["cents"]
+        bucket["millicents"] = int(bucket["millicents"]) + int(millicents)
+        return bucket["millicents"]
 
 
-async def over_cap(agent_id: str, cap_cents: int) -> bool:
-    """Return ``True`` iff this agent's current-month spend ≥ ``cap_cents``.
+async def over_cap(agent_id: str, cap_millicents: int) -> bool:
+    """Return ``True`` iff current-month spend ≥ ``cap_millicents``.
 
-    ``cap_cents <= 0`` disables the cap (returns ``False`` regardless of
-    spend) — operators set the env var to ``0`` to opt out.
+    ``cap_millicents <= 0`` disables the cap (returns ``False`` regardless
+    of spend) — operators set the env var to ``0`` to opt out.
+
+    Callers MUST pass the cap in millicents — the cap-USD env var is
+    converted at the read site (see ``src/browser/service.py:
+    _resolve_cost_cap``). Passing a cents value here would re-introduce
+    the unit-mismatch bug that this module's docstring warns against.
     """
-    if cap_cents <= 0:
+    if cap_millicents <= 0:
         return False
     async with _lock:
         bucket = _bucket_for(agent_id)
-        return int(bucket["cents"]) >= int(cap_cents)
+        return int(bucket["millicents"]) >= int(cap_millicents)
 
 
-async def get_cents(agent_id: str) -> int:
-    """Return the current-month spend for ``agent_id`` in cents."""
+async def get_millicents(agent_id: str) -> int:
+    """Return the current-month spend for ``agent_id`` in millicents."""
     async with _lock:
         bucket = _bucket_for(agent_id)
-        return int(bucket["cents"])
+        return int(bucket["millicents"])
+
+
+# Back-compat alias for an external caller that used to read cents. The
+# name is preserved but the units are now MILLICENTS — the caller almost
+# certainly wants ``get_millicents`` directly, but this avoids a hard
+# break at import. Internal call sites have been migrated.
+get_cents = get_millicents
 
 
 async def reset(agent_id: str | None = None) -> None:
@@ -301,6 +356,12 @@ async def restore(path: Path | str | None = None) -> int:
     Missing / unreadable / malformed files are non-fatal — log + start
     fresh. Buckets whose ``month`` doesn't match the current month are
     dropped (they'd reset on next access anyway; no point keeping stale).
+
+    **Schema migration.** Older snapshots stored a ``cents`` field. This
+    module now uses ``millicents`` (1/1000 of a cent) so the field was
+    renamed; legacy ``cents`` values are migrated by multiplying ×1000.
+    The migration logs once per restore so operators can correlate any
+    apparent jump in monthly spend with the unit fix.
     """
     target = Path(path) if path else _state_path()
     if not target.exists():
@@ -322,20 +383,39 @@ async def restore(path: Path | str | None = None) -> int:
 
     cm = _current_month()
     loaded = 0
+    migrated = 0
     async with _lock:
         _state.clear()
         for agent_id, bucket in buckets.items():
             if not isinstance(bucket, dict):
                 continue
             month = bucket.get("month")
-            cents = bucket.get("cents", 0)
-            if not isinstance(month, str) or not isinstance(cents, int):
+            if not isinstance(month, str):
                 continue
+            # Prefer the new-shape ``millicents`` field; fall back to the
+            # legacy ``cents`` field with a ×1000 conversion. The
+            # migration is idempotent (re-saving immediately produces a
+            # millicents-only payload) so the ``cents`` branch only ever
+            # fires once per snapshot file.
+            mc = bucket.get("millicents")
+            if not isinstance(mc, int):
+                legacy_cents = bucket.get("cents")
+                if isinstance(legacy_cents, int):
+                    mc = legacy_cents * 1000
+                    migrated += 1
+                else:
+                    continue
             if month != cm:
                 # Stale month — would reset on first access; skip restoring.
                 continue
-            _state[str(agent_id)] = {"month": month, "cents": cents}
+            _state[str(agent_id)] = {"month": month, "millicents": int(mc)}
             loaded += 1
+    if migrated:
+        logger.info(
+            "captcha_cost restore: migrated %d legacy cents bucket(s) "
+            "to millicents (×1000) from %s",
+            migrated, target,
+        )
     logger.info(
         "captcha_cost restore loaded %d/%d agent bucket(s) from %s",
         loaded, len(buckets), target,

--- a/src/browser/service.py
+++ b/src/browser/service.py
@@ -238,11 +238,18 @@ def _resolve_rate_limit(agent_id: str) -> int:
 
 
 def _resolve_cost_cap(agent_id: str) -> int:
-    """Read the monthly per-agent cost cap (USD) and convert to cents.
+    """Read the monthly per-agent cost cap (USD) and convert to MILLICENTS.
 
     Returns 0 when unset or invalid (caller treats 0 as "no cap"). Reads
     via ``flags.get_str`` so per-agent overrides take precedence over the
     raw env var (matches the pattern used elsewhere for captcha flags).
+
+    Unit math: ``captcha_cost_counter`` stores spend in millicents
+    (1/1000 of a cent = 1/100_000 of a dollar). Convert
+    ``$X → X * 100_000``. Example: ``$0.50 → 50_000 millicents``;
+    a 2captcha v2-checkbox solve at 100 millicents lets ~500 solves
+    accumulate before the cap fires (the operator's intent), versus the
+    pre-fix ``* 100`` that tripped after the FIRST solve.
     """
     from src.browser.flags import get_str
     cap_usd_str = get_str(
@@ -251,7 +258,7 @@ def _resolve_cost_cap(agent_id: str) -> int:
     if not cap_usd_str:
         return 0
     try:
-        return int(round(float(cap_usd_str) * 100))
+        return int(round(float(cap_usd_str) * 100_000))
     except ValueError:
         logger.warning(
             "Invalid CAPTCHA_COST_LIMIT_USD_PER_AGENT_MONTH=%r — treating "
@@ -334,9 +341,16 @@ async def _drain_captcha_audit() -> list[dict]:
         _captcha_audit_buckets.clear()
     drained = []
     for (agent_id, outcome, kind), info in buckets.items():
+        # NOTE: the dashboard metrics poller (host/server.py) routes
+        # browser-service events into the EventBus keyed on the payload's
+        # ``agent_id`` field; emitting ``agent`` instead used to silently
+        # drop these events from the per-agent captcha history. The key
+        # name MUST match the poller's expectation — a regression test
+        # in test_check_captcha_metered.py asserts the payload exposes
+        # ``agent_id``, not ``agent``.
         payload = {
             "type": "captcha_gate",
-            "agent": agent_id,
+            "agent_id": agent_id,
             "outcome": outcome,
             "kind": kind,
             "count": info["count"],
@@ -2073,7 +2087,7 @@ class BrowserManager:
             except Exception as e:
                 logger.warning(
                     "captcha audit sink raised for '%s': %s",
-                    ev.get("agent", ""), e,
+                    ev.get("agent_id", ""), e,
                 )
 
     def get_recent_metrics(self, since_seq: int = 0) -> dict:
@@ -5666,9 +5680,45 @@ class BrowserManager:
         except Exception:
             page_url = ""
 
-        # Rate-limit gate. ``_check_solve_rate`` consumes a slot only on
-        # the actual-attempt path (returning False); a True return means
-        # we are over the limit, no slot consumed.
+        # Gate 0: fleet-wide kill switch. ``CAPTCHA_DISABLED`` short-circuits
+        # BEFORE any other gate so the auto-detect entry points (navigate /
+        # click) never reach the provider. The duplicate early-return inside
+        # ``solve_captcha`` was removed once this gate landed — single
+        # checkpoint inside ``_metered_solve`` covers all callers uniformly.
+        from src.browser.flags import get_bool
+        if get_bool("CAPTCHA_DISABLED", False, agent_id=agent_id):
+            await _record_captcha_audit_event(
+                agent_id, "kill_switch_active", kind, page_url,
+            )
+            return SolveResult(
+                token=None, injection_succeeded=False,
+                used_proxy_aware=False, compat_rejected=False,
+                skipped="disabled",
+            )
+
+        # Gate 1: cost-cap. Read-only — does not consume a rate-limit
+        # slot, so a cost-capped agent does NOT burn its hourly quota.
+        # ``cap_millicents`` and the bucket are both millicents
+        # (1/1000¢ = 1/100_000$); see :mod:`captcha_cost_counter`
+        # docstring for the unit invariant.  Order: cost → rate so a
+        # cost-blocked solve doesn't burn rate slots that should still
+        # be available when the cap resets.
+        cap_millicents = _resolve_cost_cap(agent_id)
+        if cap_millicents > 0:
+            from src.browser import captcha_cost_counter as _cost
+            if await _cost.over_cap(agent_id, cap_millicents):
+                await _record_captcha_audit_event(
+                    agent_id, "cost_cap", kind, page_url,
+                )
+                return SolveResult(
+                    token=None, injection_succeeded=False,
+                    used_proxy_aware=False, compat_rejected=False,
+                    skipped="cost_cap",
+                )
+
+        # Gate 2: rate-limit. ``_check_solve_rate`` consumes a slot only
+        # on the actual-attempt path (returning False); a True return
+        # means we are over the limit, no slot consumed.
         rate_limit = _resolve_rate_limit(agent_id)
         if await _check_solve_rate(agent_id, rate_limit):
             await _record_captcha_audit_event(
@@ -5680,19 +5730,41 @@ class BrowserManager:
                 skipped="rate_limited",
             )
 
-        # Cost-cap gate.
-        cap_cents = _resolve_cost_cap(agent_id)
-        if cap_cents > 0:
-            from src.browser import captcha_cost_counter as _cost
-            if await _cost.over_cap(agent_id, cap_cents):
+        # Gate 3: provider sanity. When a cost cap is configured, we
+        # MUST be able to attribute every solve to a published rate so
+        # the cap math stays honest. A solver without a string ``provider``
+        # cannot be priced; in that case we fail closed (skip the solve)
+        # rather than let an untrackable charge slip past the cap.
+        # When no cap is configured the warning still fires so operators
+        # see the misconfiguration, but we proceed with the solve — keeps
+        # tests and custom solver integrations from breaking outright.
+        provider = getattr(self._captcha_solver, "provider", "")
+        if not isinstance(provider, str) or not provider:
+            if cap_millicents > 0:
+                logger.warning(
+                    "captcha solve: solver has no string ``provider`` "
+                    "attribute; cost cap is configured (cap=%s "
+                    "millicents) — failing closed so an untracked "
+                    "charge cannot bypass the cap. Configure the "
+                    "solver with a known provider name (2captcha / "
+                    "capsolver) to proceed.",
+                    cap_millicents,
+                )
                 await _record_captcha_audit_event(
-                    agent_id, "cost_cap", kind, page_url,
+                    agent_id, "provider_missing", kind, page_url,
                 )
                 return SolveResult(
                     token=None, injection_succeeded=False,
                     used_proxy_aware=False, compat_rejected=False,
-                    skipped="cost_cap",
+                    skipped="provider_missing",
                 )
+            logger.warning(
+                "captcha solve: solver has no string ``provider`` "
+                "attribute; cost accounting will be SKIPPED for this "
+                "solve (cap not configured so the warning is "
+                "informational). Set solver.provider to a known name "
+                "to enable cost tracking.",
+            )
 
         # Run the actual solver. Any exception bubbles up so the caller can
         # build the appropriate ``timeout``/``rejected`` envelope; we don't
@@ -5708,16 +5780,17 @@ class BrowserManager:
         # provider-reject / breaker / unreachable).
         if result.token is not None:
             from src.browser import captcha_cost_counter as _cost
-            provider = getattr(self._captcha_solver, "provider", "")
             # Defensive: solver mocks in tests sometimes leave provider
             # as a MagicMock auto-spec child; only proceed when we have
-            # an actual string we can pass to ``estimate_cents``.
+            # an actual string we can pass to ``estimate_millicents``.
+            # The provider-missing case was warned above; here we just
+            # skip the increment silently.
             if isinstance(provider, str) and provider:
-                cents = _cost.estimate_cents(
+                millicents = _cost.estimate_millicents(
                     provider, kind,
                     proxy_aware=result.used_proxy_aware,
                 )
-                if cents is None:
+                if millicents is None:
                     logger.warning(
                         "captcha solve: no published rate for "
                         "provider=%s kind=%s proxy_aware=%s — "
@@ -5726,7 +5799,7 @@ class BrowserManager:
                         provider, kind, result.used_proxy_aware,
                     )
                 else:
-                    await _cost.add_cost(agent_id, cents)
+                    await _cost.add_cost(agent_id, millicents)
         return result
 
     async def _check_captcha(self, inst: CamoufoxInstance) -> dict:
@@ -6044,37 +6117,36 @@ class BrowserManager:
                     # ``next_action`` to ``request_captcha_help`` (the
                     # operator told us this host is unreliable; escalate
                     # rather than letting the agent retry).
-                    def _finalize(envelope: dict) -> dict:
+                    async def _finalize(envelope: dict) -> dict:
+                        # Async helper — used to be sync + fire-and-forget
+                        # via ``loop.create_task`` for the low_success audit
+                        # event, which silently dropped the event on
+                        # shutdown (the task was never tracked or awaited).
+                        # Now we ``await`` the audit recorder directly so
+                        # the event lands in the per-minute aggregation
+                        # bucket before the helper returns. The bucket
+                        # itself is drained on the existing 60s metrics
+                        # tick — no per-call EventBus emit, so this is
+                        # cheap (a single dict update under an asyncio
+                        # lock).
                         if cf_force_low_confidence:
                             envelope["solver_confidence"] = "low"
                         if low_success:
                             envelope["solver_confidence"] = "low"
                             outcome = envelope.get("solver_outcome")
                             if outcome and outcome != "solved":
-                                # Audit: surface the upgrade so operators see
-                                # "low-success-attempted-and-failed" distinctly
-                                # from a vanilla provider rejection. Fire-and-
-                                # forget — we're inside a sync helper so
-                                # schedule the coroutine on the running loop.
                                 envelope["next_action"] = "request_captcha_help"
                                 envelope["low_success_failed"] = True
-                                try:
-                                    asyncio.get_running_loop().create_task(
-                                        _record_captcha_audit_event(
-                                            inst.agent_id,
-                                            "low_success_failed",
-                                            envelope.get("kind", "unknown"),
-                                            page_url_for_policy,
-                                            policy="low_success",
-                                        ),
-                                    )
-                                except RuntimeError:
-                                    # No running loop (defensive — _check_captcha
-                                    # is always async).  Drop the audit event
-                                    # rather than crashing the envelope.
-                                    logger.debug(
-                                        "low_success audit skipped: no loop",
-                                    )
+                                # Audit: surface the upgrade so operators see
+                                # "low-success-attempted-and-failed" distinctly
+                                # from a vanilla provider rejection.
+                                await _record_captcha_audit_event(
+                                    inst.agent_id,
+                                    "low_success_failed",
+                                    envelope.get("kind", "unknown"),
+                                    page_url_for_policy,
+                                    policy="low_success",
+                                )
                         return envelope
 
                     if self._captcha_solver:
@@ -6091,7 +6163,7 @@ class BrowserManager:
                                 "CAPTCHA detected (%s), solver marked unreachable; skipping",
                                 sel,
                             )
-                            return _finalize(_captcha_envelope(
+                            return await _finalize(_captcha_envelope(
                                 kind=kind, solver_attempted=False,
                                 solver_outcome="no_solver",
                                 solver_confidence=_kind_confidence(kind),
@@ -6113,7 +6185,7 @@ class BrowserManager:
                             # §11.13 contract while letting callers detect
                             # the breaker-open case distinctly.
                             envelope["breaker_open"] = True
-                            return _finalize(envelope)
+                            return await _finalize(envelope)
                         logger.info("CAPTCHA detected (%s), attempting auto-solve", sel)
                         # Single entry point for solver invocation. The
                         # rate-limit + cost-cap gates fire inside
@@ -6124,7 +6196,7 @@ class BrowserManager:
                             result = await self._metered_solve(inst, sel, kind)
                         except asyncio.TimeoutError:
                             # Solver took too long — true "timeout" semantic.
-                            return _finalize(_captcha_envelope(
+                            return await _finalize(_captcha_envelope(
                                 kind=kind, solver_attempted=True,
                                 solver_outcome="timeout",
                                 solver_confidence="low",
@@ -6149,7 +6221,7 @@ class BrowserManager:
                                     "Auto-solve timed out (httpx): %s",
                                     _redact_clientkey_text(redact_url(repr(exc))),
                                 )
-                                return _finalize(_captcha_envelope(
+                                return await _finalize(_captcha_envelope(
                                     kind=kind, solver_attempted=True,
                                     solver_outcome="timeout",
                                     solver_confidence="low",
@@ -6164,7 +6236,7 @@ class BrowserManager:
                                 _redact_clientkey_text(redact_url(repr(exc))),
                                 exc_info=False,
                             )
-                            return _finalize(_captcha_envelope(
+                            return await _finalize(_captcha_envelope(
                                 kind=kind, solver_attempted=True,
                                 solver_outcome="rejected",
                                 solver_confidence="low",
@@ -6174,15 +6246,37 @@ class BrowserManager:
                         # ── Map :class:`SolveResult` to §11.13 envelope ──
                         # Gate-skipped paths return without ``solver_attempted``
                         # because no provider HTTP call ran.
+                        if result.skipped == "disabled":
+                            # ``CAPTCHA_DISABLED`` kill switch — auto-detect
+                            # and explicit ``solve_captcha`` both surface this
+                            # as the existing ``no_solver`` envelope so callers
+                            # don't have to learn a new outcome value.
+                            return await _finalize(_captcha_envelope(
+                                kind=kind, solver_attempted=False,
+                                solver_outcome="no_solver",
+                                solver_confidence=_kind_confidence(kind),
+                                next_action="request_captcha_help",
+                            ))
+                        if result.skipped == "provider_missing":
+                            # Provider sanity check (cap-on case) — same shape
+                            # as ``no_solver`` but a distinct audit event was
+                            # already emitted inside ``_metered_solve`` so
+                            # operators can see the misconfiguration.
+                            return await _finalize(_captcha_envelope(
+                                kind=kind, solver_attempted=False,
+                                solver_outcome="no_solver",
+                                solver_confidence=_kind_confidence(kind),
+                                next_action="request_captcha_help",
+                            ))
                         if result.skipped == "rate_limited":
-                            return _finalize(_captcha_envelope(
+                            return await _finalize(_captcha_envelope(
                                 kind=kind, solver_attempted=False,
                                 solver_outcome="rate_limited",
                                 solver_confidence=_kind_confidence(kind),
                                 next_action="request_captcha_help",
                             ))
                         if result.skipped == "cost_cap":
-                            return _finalize(_captcha_envelope(
+                            return await _finalize(_captcha_envelope(
                                 kind=kind, solver_attempted=False,
                                 solver_outcome="cost_cap",
                                 solver_confidence=_kind_confidence(kind),
@@ -6197,7 +6291,7 @@ class BrowserManager:
                             # captured inside ``solve()``. Map all to
                             # ``rejected`` (closest §11.13 fit).
                             logger.warning("Auto-solve failed, falling back to manual")
-                            return _finalize(_captcha_envelope(
+                            return await _finalize(_captcha_envelope(
                                 kind=kind, solver_attempted=True,
                                 solver_outcome="rejected",
                                 solver_confidence="low",
@@ -6216,7 +6310,7 @@ class BrowserManager:
                             # not found) — that's a §11.6/§11.20 deferred
                             # item; surface ``injection_failed_unspecified``
                             # for now so operators see the case distinctly.
-                            return _finalize(_captcha_envelope(
+                            return await _finalize(_captcha_envelope(
                                 kind=kind, solver_attempted=True,
                                 solver_outcome="injection_failed",
                                 solver_confidence="low",
@@ -6233,7 +6327,7 @@ class BrowserManager:
                         # pool, not the operator's. ``_finalize`` further
                         # applies the §11.3 CF-Turnstile force-low.
                         confidence = "low" if result.compat_rejected else "high"
-                        return _finalize(_captcha_envelope(
+                        return await _finalize(_captcha_envelope(
                             kind=kind, solver_attempted=True,
                             solver_outcome="solved",
                             solver_confidence=confidence,
@@ -6245,7 +6339,7 @@ class BrowserManager:
                     # "high"; placeholders (recaptcha-v2-checkbox,
                     # cf-interstitial-auto) and "unknown" → "low" until
                     # §11.1 / §11.3 land variant detection.
-                    return _finalize(_captcha_envelope(
+                    return await _finalize(_captcha_envelope(
                         kind=kind, solver_attempted=False,
                         solver_outcome="no_solver",
                         solver_confidence=_kind_confidence(kind),
@@ -6321,21 +6415,23 @@ class BrowserManager:
         click auto-detect, and explicit ``solve_captcha`` calls.
 
         Local pre-checks (cheap, no provider involvement):
-          1. ``CAPTCHA_DISABLED`` flag — early-return ``no_solver`` envelope.
-          2. ``hint`` validation — bad hint → ``invalid_input`` error.
+          1. ``hint`` validation — bad hint → ``invalid_input`` error.
              Behavioral-only kinds (PerimeterX, DataDome, CF interstitial)
              are also rejected here because the solver has no task entry
              for them; the correct path is ``request_captcha_help``.
-          3. No-captcha early return — saves a solver invocation + cost.
+          2. No-captcha early return — saves a solver invocation + cost.
              When ``retry_previous=True`` and the initial detection finds
              nothing, we wait :data:`_RETRY_PREVIOUS_RECHECK_MS` and
              re-check ONCE; this covers the "page just navigated, captcha
              is rendering" race.
-          4. Recursive-solve guard — re-entrant ``_check_captcha`` while a
+          3. Recursive-solve guard — re-entrant ``_check_captcha`` while a
              solve is in flight surfaces ``captcha_during_solve``.
 
-        Rate-limit + cost-cap fire INSIDE ``_check_captcha`` →
-        ``_metered_solve`` BEFORE the solver HTTP call.
+        ``CAPTCHA_DISABLED`` kill switch + rate-limit + cost-cap all fire
+        INSIDE ``_check_captcha`` → ``_metered_solve`` BEFORE any solver
+        HTTP call. The duplicate kill-switch check that used to live at
+        the top of this method was removed once the metered-solve path
+        landed it — keeping a second copy invited drift.
 
         ``target_ref`` accepts a snapshot ref for selecting one captcha among
         many on the same page; multi-captcha enumeration lands in §11.6.
@@ -6353,20 +6449,10 @@ class BrowserManager:
         once. Bounded by :data:`_RETRY_PREVIOUS_RECHECK_MS` so total
         latency stays predictable.
         """
-        # Gate 1: fleet-wide kill switch.
-        from src.browser.flags import get_bool
-        if get_bool("CAPTCHA_DISABLED", False, agent_id=agent_id):
-            return {
-                "success": True,
-                "data": _with_legacy_fields(_captcha_envelope(
-                    kind="unknown", solver_attempted=False,
-                    solver_outcome="no_solver",
-                    solver_confidence="low",
-                    next_action="request_captcha_help",
-                )),
-            }
-
-        # Gate 2: hint validation (cheap, before lock).
+        # Gate 1: hint validation (cheap, before lock). The fleet-wide
+        # ``CAPTCHA_DISABLED`` kill switch fires inside ``_metered_solve``
+        # so navigate / click auto-detect paths are covered too — keeping
+        # a duplicate here invited drift between entry points.
         if hint is not None:
             if not isinstance(hint, str):
                 return _err(

--- a/tests/test_browser_metrics_ingest.py
+++ b/tests/test_browser_metrics_ingest.py
@@ -528,6 +528,79 @@ class TestMetricsPoll:
         assert probe_call.kwargs["agent"] == "a1"
 
 
+# ── Codex F4 — captcha audit events round-trip with agent_id ─────────
+
+
+class TestCaptchaGateAuditPayloadRoundTrip:
+    """Codex F4 — the captcha audit aggregator emits ``captcha_gate``
+    payloads that the dashboard metrics poller picks up via the same
+    mesh-side loop that fans browser_metrics events out. The poller
+    reads ``payload.get("agent_id")`` to key the per-agent dashboard
+    history. Pre-fix, the audit aggregator emitted ``"agent": agent_id``
+    instead of ``"agent_id": agent_id``, so the poller pulled an empty
+    string and the events were silently dropped from the per-agent
+    captcha history.
+
+    This integration test asserts the round-trip: a captcha_gate payload
+    crossing /browser/metrics shows up on the EventBus with the agent_id
+    populated correctly.
+    """
+
+    @pytest.mark.asyncio
+    async def test_captcha_gate_payload_emits_with_agent_id(
+        self, tmp_path, monkeypatch,
+    ):
+        import httpx
+
+        # Browser service responds with a captcha_gate audit drain.
+        # NOTE: the key is ``agent_id`` — not ``agent``. Pre-fix the
+        # audit drain emitted ``"agent"`` and the poller's
+        # ``payload.get("agent_id")`` returned empty, so the EventBus
+        # emit was keyed with ``agent=""`` and the dashboard's
+        # per-agent filter dropped the event.
+        canned = {
+            "current_seq": 1,
+            "boot_id": "b1",
+            "metrics": [{
+                "seq": 1,
+                "ts": 1.0,
+                "type": "captcha_gate",
+                "agent_id": "agent-1",
+                "outcome": "cost_cap",
+                "kind": "recaptcha-v2-checkbox",
+                "count": 3,
+                "first_ts": 0.0,
+                "url": "https://example.com",
+            }],
+        }
+
+        async def fake_get(self, url, *args, **kwargs):
+            req = httpx.Request("GET", url)
+            return httpx.Response(200, json=canned, request=req)
+
+        monkeypatch.setattr(httpx.AsyncClient, "get", fake_get)
+
+        app, event_bus, _cm = _build_mesh(tmp_path)
+        poll = _extract_poll_fn(app)
+        await poll()
+
+        # The poller routes anything that isn't a nav_probe through
+        # ``browser_metrics``; the dashboard reads ``data.type`` to
+        # disambiguate ``captcha_gate`` from regular metrics drains.
+        emits = [c for c in event_bus.emit.call_args_list
+                 if c.args and c.args[0] == "browser_metrics"]
+        assert len(emits) == 1
+        call = emits[0]
+        # Critical: the poller keyed the emit with the correct agent_id.
+        # ``agent`` here is the EventBus emit kwarg (mesh-side keying);
+        # the source of that string is the payload's ``agent_id`` field.
+        assert call.kwargs.get("agent") == "agent-1"
+        data = call.kwargs.get("data") or {}
+        assert data.get("type") == "captcha_gate"
+        assert data.get("agent_id") == "agent-1"
+        assert data.get("outcome") == "cost_cap"
+
+
 # ── Helpers ─────────────────────────────────────────────────────────
 
 

--- a/tests/test_browser_solve_captcha.py
+++ b/tests/test_browser_solve_captcha.py
@@ -118,10 +118,12 @@ class TestSolveCaptchaSuccess:
 class TestSolveCaptchaCostCap:
     @pytest.mark.asyncio
     async def test_cost_cap_exceeded_short_circuits(self, mgr, monkeypatch):
-        # Configure the cap (USD).
+        # Configure the cap (USD). $0.50 → 50_000 millicents.
+        # The cost counter stores spend in MILLICENTS (1/1000 of a cent;
+        # 1/100_000 of a dollar) — see ``captcha_cost_counter`` docstring.
         monkeypatch.setenv("CAPTCHA_COST_LIMIT_USD_PER_AGENT_MONTH", "0.50")
-        # Pre-fill spend to exceed the cap (50 cents).
-        await cost.add_cost("agent-1", 100)
+        # Pre-fill spend to exceed the 50_000 mc cap.
+        await cost.add_cost("agent-1", 50_000)
 
         inst = _mk_inst_with_locator(captcha_present=True)
         mgr._instances["agent-1"] = inst

--- a/tests/test_captcha_cost_counter.py
+++ b/tests/test_captcha_cost_counter.py
@@ -6,6 +6,9 @@ Covers:
   * snapshot / restore round-trip via JSON
   * atomic write (tmp file replaced)
   * concurrent ``add_cost`` correctness
+  * unit invariant: $1 cap allows ~1000 v2-checkbox solves before tripping
+    (regression for the cents-vs-millicents mismatch from Codex F1)
+  * legacy ``cents`` snapshots migrate to ``millicents`` (×1000) on load
 """
 
 from __future__ import annotations
@@ -30,26 +33,43 @@ async def _isolate_state(tmp_path, monkeypatch):
     await cost.reset()
 
 
-class TestEstimateCents:
+class TestEstimateMillicents:
+    """Pricing table is now in MILLICENTS (1/1000 of a cent). The legacy
+    ``estimate_cents`` is a back-compat alias to ``estimate_millicents``;
+    both names return the same integer.
+    """
+
     def test_known_2captcha_recaptcha_v2(self):
-        assert cost.estimate_cents("2captcha", "recaptcha-v2-checkbox") == 100
+        # 2captcha v2-checkbox is published at $1/1000 = $0.001/solve
+        # = 100 millicents/solve. Pre-fix this was labelled "cents" but
+        # the magnitude (100) matches millicents, not cents (which would
+        # have been a single 1¢ charge per solve).
+        assert cost.estimate_millicents("2captcha", "recaptcha-v2-checkbox") == 100
 
     def test_known_capsolver_turnstile(self):
-        assert cost.estimate_cents("capsolver", "turnstile") == 60
+        assert cost.estimate_millicents("capsolver", "turnstile") == 60
 
     def test_unknown_kind_returns_none(self):
-        assert cost.estimate_cents("2captcha", "made-up-variant") is None
+        assert cost.estimate_millicents("2captcha", "made-up-variant") is None
 
     def test_unknown_provider_returns_none(self):
-        assert cost.estimate_cents("nopal", "hcaptcha") is None
+        assert cost.estimate_millicents("nopal", "hcaptcha") is None
 
     def test_case_insensitive(self):
-        assert cost.estimate_cents("2CAPTCHA", "HCAPTCHA") == 100
-        assert cost.estimate_cents("CapSolver", "Turnstile") == 60
+        assert cost.estimate_millicents("2CAPTCHA", "HCAPTCHA") == 100
+        assert cost.estimate_millicents("CapSolver", "Turnstile") == 60
 
     def test_empty_inputs_safe(self):
-        assert cost.estimate_cents("", "hcaptcha") is None
-        assert cost.estimate_cents("2captcha", "") is None
+        assert cost.estimate_millicents("", "hcaptcha") is None
+        assert cost.estimate_millicents("2captcha", "") is None
+
+    def test_legacy_estimate_cents_alias_returns_millicents(self):
+        # Back-compat alias for out-of-tree subclasses; the unit changed
+        # under the alias but the magnitude matches what those callers
+        # were already storing — the callers' arithmetic was already
+        # off-by-1000 when treating the value as cents. The alias keeps
+        # them importing without breaking the in-tree fix.
+        assert cost.estimate_cents("2captcha", "recaptcha-v2-checkbox") == 100
 
 
 class TestAddCostAndOverCap:
@@ -57,13 +77,13 @@ class TestAddCostAndOverCap:
     async def test_add_cost_accumulates(self):
         await cost.add_cost("agent-1", 100)
         await cost.add_cost("agent-1", 50)
-        assert await cost.get_cents("agent-1") == 150
+        assert await cost.get_millicents("agent-1") == 150
 
     @pytest.mark.asyncio
     async def test_add_cost_zero_or_negative_dropped(self):
         await cost.add_cost("agent-1", 0)
         await cost.add_cost("agent-1", -10)
-        assert await cost.get_cents("agent-1") == 0
+        assert await cost.get_millicents("agent-1") == 0
 
     @pytest.mark.asyncio
     async def test_over_cap_below_threshold(self):
@@ -83,7 +103,15 @@ class TestAddCostAndOverCap:
     @pytest.mark.asyncio
     async def test_unrelated_agents_isolated(self):
         await cost.add_cost("agent-1", 200)
-        assert await cost.get_cents("agent-2") == 0
+        assert await cost.get_millicents("agent-2") == 0
+
+    @pytest.mark.asyncio
+    async def test_legacy_get_cents_alias_returns_millicents(self):
+        await cost.add_cost("agent-1", 100)
+        # Back-compat alias — same integer the new ``get_millicents``
+        # returns. The label-vs-unit mismatch is documented; out-of-tree
+        # callers' arithmetic was already off-by-1000 before this fix.
+        assert await cost.get_cents("agent-1") == 100
 
 
 class TestMonthRollover:
@@ -92,13 +120,13 @@ class TestMonthRollover:
         # Spend 200 in January.
         monkeypatch.setattr(cost, "_current_month", lambda: "2026-01")
         await cost.add_cost("agent-1", 200)
-        assert await cost.get_cents("agent-1") == 200
+        assert await cost.get_millicents("agent-1") == 200
 
         # Roll over to February — bucket should reset.
         monkeypatch.setattr(cost, "_current_month", lambda: "2026-02")
-        assert await cost.get_cents("agent-1") == 0
+        assert await cost.get_millicents("agent-1") == 0
         await cost.add_cost("agent-1", 50)
-        assert await cost.get_cents("agent-1") == 50
+        assert await cost.get_millicents("agent-1") == 50
 
     @pytest.mark.asyncio
     async def test_month_rollover_during_over_cap(self, monkeypatch):
@@ -108,6 +136,106 @@ class TestMonthRollover:
 
         monkeypatch.setattr(cost, "_current_month", lambda: "2026-02")
         assert await cost.over_cap("agent-1", 1000) is False
+
+
+class TestUnitInvariantsRegression:
+    """Regression tests for Codex F1 — cost-unit mismatch.
+
+    The pricing table comment said ``$1.00 / 1000 = 0.10c each → 0.1¢``
+    but the cap converted USD to **cents** (× 100), not millicents. So a
+    $0.50 cap on 100-millicent solves tripped after the FIRST solve
+    instead of after ~500. These tests pin the conversion math + the
+    end-to-end cap arithmetic so the unit drift can't recur.
+    """
+
+    @pytest.mark.asyncio
+    async def test_one_dollar_cap_allows_one_thousand_v2_checkbox_solves(self):
+        """$1 cap → 100_000 millicents. 2captcha v2-checkbox = 100 mc/solve.
+        100_000 / 100 = 1000 solves before the cap fires (caller reads cap
+        via _resolve_cost_cap; we exercise the bucket math directly).
+        """
+        cap_millicents = 1_00_000  # $1.00 in millicents
+        per_solve = cost.estimate_millicents(
+            "2captcha", "recaptcha-v2-checkbox",
+        )
+        assert per_solve == 100  # provider-published rate
+        # Simulate 999 solves — still under cap.
+        for _ in range(999):
+            await cost.add_cost("agent-1", per_solve)
+        assert await cost.over_cap("agent-1", cap_millicents) is False
+        # 1000th solve trips the cap.
+        await cost.add_cost("agent-1", per_solve)
+        assert await cost.over_cap("agent-1", cap_millicents) is True
+
+    def test_provider_published_rate_is_one_hundred_millicents(self):
+        """$0.001 per solve = 0.1¢ = 100 millicents. Anchors the table."""
+        assert cost.estimate_millicents(
+            "2captcha", "recaptcha-v2-checkbox",
+        ) == 100
+
+    def test_dollars_to_millicents_conversion_math(self):
+        """$0.50 → 50_000 millicents (the conversion site lives in
+        ``service.py:_resolve_cost_cap``; this test pins the arithmetic
+        that test depends on).
+        """
+        # Equivalent: int(round(0.50 * 100_000)).
+        assert int(round(0.50 * 100_000)) == 50_000
+        # Smoke-check a non-round value to catch a silent /1000 typo.
+        assert int(round(2.50 * 100_000)) == 250_000
+
+
+class TestLegacyCentsSnapshotMigration:
+    """Snapshots written before the millicents rename used a ``cents``
+    field. ``restore`` migrates them by multiplying ×1000.
+    """
+
+    @pytest.mark.asyncio
+    async def test_legacy_cents_field_migrated_on_load(
+        self, tmp_path, monkeypatch, caplog,
+    ):
+        import logging as _logging
+        path = tmp_path / "legacy.json"
+        # Pin month so the bucket isn't dropped as stale.
+        monkeypatch.setattr(cost, "_current_month", lambda: "2026-04")
+        payload = {
+            "version": 1,
+            "saved_at": 0,
+            "buckets": {
+                # Pre-fix: stored 100 cents (== 0.1¢-each × 1 solve in
+                # the broken accounting). On migration this becomes
+                # 100_000 millicents. The intent of the original write
+                # was clearly "100 of whatever-unit-we-used"; multiplying
+                # by 1000 preserves the integer count of solves rather
+                # than under-counting them post-rename.
+                "agent-old": {"month": "2026-04", "cents": 100},
+            },
+        }
+        path.write_text(json.dumps(payload))
+        with caplog.at_level(_logging.INFO, logger="browser.captcha_cost"):
+            loaded = await cost.restore(path)
+        assert loaded == 1
+        assert await cost.get_millicents("agent-old") == 100_000
+        # Migration logged once.
+        joined = "\n".join(rec.getMessage() for rec in caplog.records)
+        assert "migrated" in joined and "millicents" in joined
+
+    @pytest.mark.asyncio
+    async def test_new_millicents_field_loaded_unchanged(
+        self, tmp_path, monkeypatch,
+    ):
+        path = tmp_path / "new.json"
+        monkeypatch.setattr(cost, "_current_month", lambda: "2026-04")
+        payload = {
+            "version": 1,
+            "saved_at": 0,
+            "buckets": {
+                "agent-new": {"month": "2026-04", "millicents": 5000},
+            },
+        }
+        path.write_text(json.dumps(payload))
+        loaded = await cost.restore(path)
+        assert loaded == 1
+        assert await cost.get_millicents("agent-new") == 5000
 
 
 class TestSnapshotRestore:
@@ -123,11 +251,11 @@ class TestSnapshotRestore:
 
         # Wipe in-memory state, then restore.
         await cost.reset()
-        assert await cost.get_cents("agent-a") == 0
+        assert await cost.get_millicents("agent-a") == 0
         loaded = await cost.restore(path)
         assert loaded == 2
-        assert await cost.get_cents("agent-a") == 200
-        assert await cost.get_cents("agent-b") == 350
+        assert await cost.get_millicents("agent-a") == 200
+        assert await cost.get_millicents("agent-b") == 350
 
     @pytest.mark.asyncio
     async def test_restore_drops_stale_month(self, tmp_path, monkeypatch):
@@ -137,14 +265,14 @@ class TestSnapshotRestore:
             "version": 1,
             "saved_at": 0,
             "buckets": {
-                "agent-old": {"month": "2020-01", "cents": 999},
+                "agent-old": {"month": "2020-01", "millicents": 999},
             },
         }
         path.write_text(json.dumps(payload))
         loaded = await cost.restore(path)
         # Stale month skipped.
         assert loaded == 0
-        assert await cost.get_cents("agent-old") == 0
+        assert await cost.get_millicents("agent-old") == 0
 
     @pytest.mark.asyncio
     async def test_restore_missing_file_safe(self, tmp_path):
@@ -171,7 +299,7 @@ class TestSnapshotRestore:
         # Verify content is valid JSON with our payload.
         data = json.loads(path.read_text())
         assert "buckets" in data
-        assert data["buckets"]["agent-1"]["cents"] == 42
+        assert data["buckets"]["agent-1"]["millicents"] == 42
 
     @pytest.mark.asyncio
     async def test_snapshot_failure_returns_false(self, monkeypatch):
@@ -195,4 +323,4 @@ class TestConcurrentWrites:
             await cost.add_cost("agent-1", 1)
 
         await asyncio.gather(*(add_one() for _ in range(100)))
-        assert await cost.get_cents("agent-1") == 100
+        assert await cost.get_millicents("agent-1") == 100

--- a/tests/test_captcha_health.py
+++ b/tests/test_captcha_health.py
@@ -819,3 +819,118 @@ async def test_check_captcha_no_decoration_when_solver_healthy():
     # "no_solver" (that's the unreachable short-circuit). With
     # solve()==False on a healthy solver the envelope reports "rejected".
     assert out.get("solver_outcome") != "no_solver"
+
+
+# ── §11.16 Codex F3 — local failures must NOT pollute the breaker ──────
+
+
+class TestBreakerLocalVsProviderFailures:
+    """Codex F3 — pre-fix, ANY failure path inside ``solve()`` —
+    including purely-local classification failures (sitekey extraction
+    couldn't find the widget, ``_build_task_body`` rejected the variant)
+    — recorded a breaker outcome. Three unsupported captchas from one
+    agent tripped the breaker for the entire BrowserManager and blocked
+    real solves for every other agent. The fix splits the failure paths:
+    only provider-contacted failures count toward the breaker.
+    """
+
+    @pytest.mark.asyncio
+    async def test_three_sitekey_extract_failures_do_not_trip_breaker(self):
+        """Sitekey extraction failure is purely local — the page DOM
+        lacked any matching marker. The provider was never contacted.
+        The breaker must NOT count these.
+        """
+        solver = _make_solver()
+        solver._solver_health_checked = True
+
+        page = AsyncMock()
+        # Sitekey extractor returns None — our DOM-walker found nothing.
+        page.evaluate = AsyncMock(return_value=None)
+        page.url = "https://example.com"
+
+        # No HTTP client patching needed — the provider is never reached.
+        for _ in range(_BREAKER_FAILURE_THRESHOLD):
+            await solver.solve(
+                page, 'iframe[src*="recaptcha"]', "https://example.com",
+                kind="recaptcha-v2-checkbox",
+            )
+
+        assert len(solver._solver_failure_timestamps) == 0
+        assert solver.is_breaker_open() is False
+
+    @pytest.mark.asyncio
+    async def test_three_unsupported_variant_failures_do_not_trip_breaker(self):
+        """``_build_task_body`` returns ``None`` when the captcha kind
+        isn't in the per-provider task table. That's a LOCAL failure —
+        no createTask call ever fires. Breaker must not count these
+        either, otherwise three unsupported challenges from one agent
+        would block solves for the whole manager.
+        """
+        solver = _make_solver(provider="2captcha")
+        solver._solver_health_checked = True
+
+        page = _solve_page()  # sitekey extracted fine
+        client = AsyncMock(spec=httpx.AsyncClient)
+        client.is_closed = False
+        # If the test fails the wrong way, the provider would get hit.
+        client.post = AsyncMock(side_effect=AssertionError(
+            "provider must NOT be contacted for an unsupported variant",
+        ))
+        solver._client = client
+
+        # Force ``_build_task_body`` to act as if the captcha kind is
+        # missing from the provider table — return ``None``. This is
+        # the same path an unrecognized captcha takes through
+        # ``_solve_2captcha`` / ``_solve_capsolver``.
+        with patch.object(
+            solver, "_build_task_body",
+            return_value=(None, False, False),
+        ):
+            for _ in range(_BREAKER_FAILURE_THRESHOLD):
+                result = await solver.solve(
+                    page, 'iframe[src*="recaptcha"]',
+                    "https://example.com",
+                    kind="recaptcha-v2-checkbox",
+                )
+                # Each call fails (no token) but provider was untouched.
+                assert result.token is None
+
+        assert len(solver._solver_failure_timestamps) == 0
+        assert solver.is_breaker_open() is False
+        # Provider really wasn't contacted.
+        client.post.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_three_provider_500_failures_DO_trip_breaker(self):
+        """Provider-contacted failures (createTask 5xx, errorId>0,
+        timeouts during polling) MUST still trip the breaker — that's
+        the signal it was designed for."""
+        solver = _make_solver(provider="2captcha")
+        solver._solver_health_checked = True
+
+        page = _solve_page()
+
+        # createTask returns errorId>0 — provider WAS contacted.
+        err_resp = MagicMock()
+        err_resp.json = MagicMock(return_value={
+            "errorId": 1, "errorDescription": "ERROR_KEY_DOES_NOT_EXIST",
+        })
+        err_resp.raise_for_status = MagicMock()
+
+        client = AsyncMock(spec=httpx.AsyncClient)
+        client.is_closed = False
+        client.post = AsyncMock(return_value=err_resp)
+        solver._client = client
+
+        with patch("src.browser.captcha._POLL_INTERVAL", 0.001):
+            for _ in range(_BREAKER_FAILURE_THRESHOLD):
+                await solver.solve(
+                    page, 'iframe[src*="recaptcha"]',
+                    "https://example.com",
+                    kind="recaptcha-v2-checkbox",
+                )
+
+        # Breaker SHOULD have tripped — these were real provider
+        # failures, not local classification gaps.
+        assert solver.is_breaker_open() is True
+

--- a/tests/test_captcha_per_type_timeout.py
+++ b/tests/test_captcha_per_type_timeout.py
@@ -195,7 +195,10 @@ class TestSolvePassesKindThrough:
         async def fake_submit(self, captcha_type, sitekey, page_url, **kwargs):
             recorded["captcha_type"] = captcha_type
             recorded["kind"] = kwargs.get("kind")
-            return ("tok-X", False, False)
+            # 4-tuple: (token, used_proxy_aware, compat_rejected, provider_contacted).
+            # ``provider_contacted=True`` mirrors a real submit that
+            # reached the upstream API.
+            return ("tok-X", False, False, True)
 
         # Patch the page-level injection so we don't need real DOM.
         async def fake_inject(self, page, captcha_type, token):
@@ -226,7 +229,7 @@ class TestSolvePassesKindThrough:
 
         async def fake_submit(self, captcha_type, sitekey, page_url, **kwargs):
             recorded["kind"] = kwargs.get("kind")
-            return ("tok-X", False, False)
+            return ("tok-X", False, False, True)
 
         async def fake_inject(self, page, captcha_type, token):
             return True
@@ -263,7 +266,7 @@ class TestOuterTimeoutEnforced:
 
         async def slow_submit(self, *a, **kw):
             await asyncio.sleep(2.0)
-            return ("tok", False, False)
+            return ("tok", False, False, True)
 
         with patch.object(CaptchaSolver, "_submit_and_poll", new=slow_submit):
             ok = await solver.solve(
@@ -284,7 +287,7 @@ class TestOuterTimeoutEnforced:
         page = _solve_page()
 
         async def fast_submit(self, *a, **kw):
-            return ("tok", False, False)
+            return ("tok", False, False, True)
 
         async def fake_inject(self, page, captcha_type, token):
             return True

--- a/tests/test_captcha_solve_pacing.py
+++ b/tests/test_captcha_solve_pacing.py
@@ -379,7 +379,9 @@ class TestPacingSkippedOnFailure:
 
         async def slow_submit(self, *a, **kw):
             await asyncio.sleep(2.0)
-            return ("tok", False, False)
+            # 4-tuple: (token, used_proxy_aware, compat_rejected,
+            # provider_contacted) — see ``_submit_and_poll`` docstring.
+            return ("tok", False, False, True)
 
         pace = AsyncMock(return_value=None)
         with patch.object(CaptchaSolver, "_submit_and_poll", new=slow_submit), \

--- a/tests/test_check_captcha_metered.py
+++ b/tests/test_check_captcha_metered.py
@@ -119,8 +119,11 @@ class TestAutoDetectGatesEnforced:
     async def test_navigate_path_cost_cap_blocks_solver(self, mgr, monkeypatch):
         """``_check_captcha`` direct call (the navigate auto-detect path)
         respects the cost cap."""
+        # $0.50 cap → 50_000 millicents. Pre-fill 50_000+1 to clear it.
+        # The cost counter stores spend in MILLICENTS (1/1000 of a cent
+        # = 1/100_000 of a dollar); see ``captcha_cost_counter`` docstring.
         monkeypatch.setenv("CAPTCHA_COST_LIMIT_USD_PER_AGENT_MONTH", "0.50")
-        await cost.add_cost("agent-1", 100)  # already over cap
+        await cost.add_cost("agent-1", 50_000)  # already over cap
 
         solver = _mk_solver(return_value=_solved())
         mgr._captcha_solver = solver
@@ -374,8 +377,9 @@ class TestAuditLogAggregation:
 
     @pytest.mark.asyncio
     async def test_cost_cap_event_drains_via_sink(self, tmp_path, monkeypatch):
+        # $0.50 cap → 50_000 millicents.
         monkeypatch.setenv("CAPTCHA_COST_LIMIT_USD_PER_AGENT_MONTH", "0.50")
-        await cost.add_cost("agent-1", 100)
+        await cost.add_cost("agent-1", 50_000)
 
         events: list[dict] = []
         m = BrowserManager(
@@ -396,7 +400,12 @@ class TestAuditLogAggregation:
         captcha_events = [e for e in events if e.get("type") == "captcha_gate"]
         assert len(captcha_events) == 1, f"expected one aggregated event, got {captcha_events}"
         ev = captcha_events[0]
-        assert ev["agent"] == "agent-1"
+        # F4 — payload key MUST be ``agent_id`` (not ``agent``) so the
+        # dashboard metrics poller in host/server.py picks it up. The
+        # poller's per-payload filter reads ``payload.get("agent_id")``;
+        # emitting the legacy ``agent`` key silently dropped events.
+        assert ev["agent_id"] == "agent-1"
+        assert "agent" not in ev or ev.get("agent") == ev["agent_id"]
         assert ev["outcome"] == "cost_cap"
         # Aggregated count, not per-call.
         assert ev["count"] == 2
@@ -468,8 +477,9 @@ class TestAuditLogAggregation:
         cap and rate-limit events on the same agent emit two separate
         aggregated payloads.
         """
+        # $0.50 cap → 50_000 millicents.
         monkeypatch.setenv("CAPTCHA_COST_LIMIT_USD_PER_AGENT_MONTH", "0.50")
-        await cost.add_cost("agent-1", 100)
+        await cost.add_cost("agent-1", 50_000)
 
         events: list[dict] = []
         m = BrowserManager(
@@ -498,3 +508,143 @@ class TestAuditLogAggregation:
         rate_events = [e for e in events if e.get("outcome") == "rate_limited"]
         assert len(cap_events) == 1
         assert len(rate_events) == 1
+
+
+# ── 8. Codex F2 — kill-switch on auto-detect path ─────────────────────────
+
+
+class TestKillSwitchOnAutoDetect:
+    """Codex F2 — pre-fix the ``CAPTCHA_DISABLED`` flag was only checked
+    inside ``solve_captcha``. Auto-detect via navigate / click / etc.
+    bypassed the gate and still hit the provider. The fix moves the
+    check inside ``_metered_solve`` so every path sees the same
+    short-circuit, and emits a ``kill_switch_active`` audit event."""
+
+    @pytest.mark.asyncio
+    async def test_navigate_path_with_disabled_flag_skips_solver(
+        self, mgr, monkeypatch,
+    ):
+        monkeypatch.setenv("CAPTCHA_DISABLED", "true")
+        solver = _mk_solver(return_value=_solved())
+        mgr._captcha_solver = solver
+        inst = _mk_inst()
+
+        envelope = await mgr._check_captcha(inst)
+        assert envelope["captcha_found"] is True
+        # Disabled → no_solver envelope (the §11.13 enum doesn't carry a
+        # "kill_switch" outcome; reusing no_solver matches the pre-fix
+        # solve_captcha early-return shape that callers already handle).
+        assert envelope["solver_outcome"] == "no_solver"
+        assert envelope["solver_attempted"] is False
+        assert envelope["next_action"] == "request_captcha_help"
+        # Critical: the solver mock was NEVER awaited.
+        solver.solve.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_kill_switch_emits_audit_event(
+        self, tmp_path, monkeypatch,
+    ):
+        monkeypatch.setenv("CAPTCHA_DISABLED", "true")
+        events: list[dict] = []
+        m = BrowserManager(
+            profiles_dir=str(tmp_path / "profiles"),
+            metrics_sink=events.append,
+        )
+        m._captcha_solver = _mk_solver(return_value=_solved())
+        inst = _mk_inst()
+        m._instances["agent-1"] = inst
+
+        await m._check_captcha(inst)
+        await m._emit_metrics()
+
+        kill = [e for e in events
+                if e.get("type") == "captcha_gate"
+                and e.get("outcome") == "kill_switch_active"]
+        assert len(kill) == 1
+        # F4: payload uses ``agent_id`` (not the legacy ``agent`` key).
+        assert kill[0]["agent_id"] == "agent-1"
+
+
+# ── 9. Codex F5 — rate-limit slot consumed AFTER cost-cap check ───────────
+
+
+class TestGateOrderingCostBeforeRate:
+    """Codex F5 — the original implementation ran rate-limit gate first,
+    burning a per-hour slot for an agent that was already over the cost
+    cap (the cost gate would then short-circuit the solve). The fix
+    swaps the order: cost-cap (read-only) fires first, then rate-limit
+    (consumes a slot)."""
+
+    @pytest.mark.asyncio
+    async def test_cost_capped_solve_does_not_burn_rate_slot(
+        self, mgr, monkeypatch,
+    ):
+        # $0.50 cap → 50_000 mc. Pre-fill enough to clear it.
+        monkeypatch.setenv("CAPTCHA_COST_LIMIT_USD_PER_AGENT_MONTH", "0.50")
+        await cost.add_cost("agent-1", 50_000)
+        # Tight rate window so we can easily detect a slot getting burned.
+        monkeypatch.setenv("CAPTCHA_RATE_LIMIT_PER_HOUR", "5")
+        # Start with an empty rate-window for this agent.
+        svc._solve_rate_window["agent-1"] = deque()
+
+        solver = _mk_solver(return_value=_solved())
+        mgr._captcha_solver = solver
+
+        inst = _mk_inst()
+        envelope = await mgr._check_captcha(inst)
+
+        # Cost cap fired (not rate-limited).
+        assert envelope["solver_outcome"] == "cost_cap"
+        # Rate-limit window UNCHANGED — no slot consumed.
+        assert len(svc._solve_rate_window["agent-1"]) == 0
+
+
+# ── 10. Codex F7 — token-without-provider warns + (cap-on) fails closed ──
+
+
+class TestProviderMissingFailsClosedWhenCapOn:
+    @pytest.mark.asyncio
+    async def test_no_provider_with_cap_blocks_solve(
+        self, mgr, monkeypatch, caplog,
+    ):
+        import logging as _logging
+        monkeypatch.setenv("CAPTCHA_COST_LIMIT_USD_PER_AGENT_MONTH", "1.00")
+        # Solver mock with NO provider attribute (or empty string).
+        solver = _mk_solver(return_value=_solved(), provider="")
+        mgr._captcha_solver = solver
+        inst = _mk_inst()
+
+        with caplog.at_level(_logging.WARNING, logger="browser.service"):
+            envelope = await mgr._check_captcha(inst)
+
+        # Solve was blocked — no provider HTTP call.
+        solver.solve.assert_not_awaited()
+        assert envelope["solver_outcome"] == "no_solver"
+        # A warning was logged about the failing-closed decision.
+        joined = "\n".join(rec.getMessage() for rec in caplog.records)
+        assert "failing closed" in joined.lower() or "fail" in joined.lower()
+
+    @pytest.mark.asyncio
+    async def test_no_provider_without_cap_warns_and_proceeds(
+        self, mgr, monkeypatch, caplog,
+    ):
+        """No cap configured → we still warn but don't block. Custom
+        solver integrations / tests with ``provider=""`` keep working
+        (the cost increment is silently skipped — same as today)."""
+        import logging as _logging
+        monkeypatch.delenv(
+            "CAPTCHA_COST_LIMIT_USD_PER_AGENT_MONTH", raising=False,
+        )
+        solver = _mk_solver(return_value=_solved(), provider="")
+        mgr._captcha_solver = solver
+        inst = _mk_inst()
+
+        with caplog.at_level(_logging.WARNING, logger="browser.service"):
+            envelope = await mgr._check_captcha(inst)
+
+        assert envelope["solver_outcome"] == "solved"
+        # Cost was NOT incremented (provider name missing).
+        assert await cost.get_millicents("agent-1") == 0
+        # Warning was logged so operators see the misconfig.
+        joined = "\n".join(rec.getMessage() for rec in caplog.records)
+        assert "provider" in joined.lower()


### PR DESCRIPTION
## Summary

Eight findings from an independent Codex review of recently-merged Phase 8 captcha automation work (PRs #765–#779).

### Critical / High
- **F1 [HIGH] Cost values stored 1000× actual provider rate.** Pricing comment said `100 = 0.1¢` but cap conversion (`cap_usd × 100`) treated stored values as cents — so a `$0.50` cap tripped after one solve instead of ~500. Standardized on **millicents** (1/1000 cent). Cap conversion now `dollars × 100_000 → millicents`. JSON sidecar migrated transparently on restore (legacy `cents` field × 1000 → millicents) with a one-time info log.
- **F2 [HIGH] `CAPTCHA_DISABLED` bypass on auto-detect path.** Kill switch was checked only in `solve_captcha`; `_metered_solve` (where navigate / click flow) ran the solver anyway. Check moved into `_metered_solve` before rate/cost gates. Added `skipped="disabled"` `SolveResult` variant.
- **F3 [HIGH] Local failures pollute the solver circuit breaker.** No-sitekey / unsupported-variant returns from `_build_task_body` counted as solver failures and fed the sliding-window breaker — three unsupported pages from one agent could trip the breaker for the whole BrowserManager. Added `provider_contacted` flag; local failures no longer touch the breaker.

### Medium
- **F4 [MED] Audit events filtered out by key mismatch** (`agent` vs `agent_id`). The captcha-gate audit aggregation added in #777 was silently dropped by the dashboard. Renamed payload key.
- **F5 [MED] Rate-limit slot consumed before cost-cap check.** Reordered gates: cost → rate. Cost-capped agents no longer burn rate slots.

### Low
- **F6 [LOW] `low_success_failed` audit fire-and-forget.** Lost on shutdown. Switched to synchronous aggregation drained by the existing 60s metrics tick.
- **F7 [LOW] Token retrieved but `solver.provider` missing → silent cost skip.** Now warns and emits a `metering_error` audit when a cap is active.
- **F8 [LOW] Plan §11.14 doc-vs-code drift on `retry_previous`.** Updated to match PR #779 semantic.

## Verification

- `pytest tests/test_captcha_cost_counter.py tests/test_check_captcha_metered.py tests/test_captcha_health.py` → 75/75 pass.
- `pytest tests/ --ignore=tests/test_e2e*` → only pre-existing failures in `test_models.py` and `test_setup_wizard.py` (verified to reproduce on bare `origin/main`).
- Cost arithmetic check (in test): `$1.00 cap → 100_000 millicents → ~1000 v2-checkbox solves` (was 1 before this fix).

## Test plan

- [x] Cost cap allows the expected number of solves at the published rate.
- [x] `CAPTCHA_DISABLED` blocks navigate auto-solve (not just explicit `solve_captcha`).
- [x] Unsupported variant doesn't trip the breaker.
- [x] Audit events surface in dashboard per-agent history with `agent_id` key.
- [x] Cost-cap fires before rate-limit consumption.

None of the previously-fixed 16 review items appear regressed.