### PR TITLE
Harden browser automation review findings

### DIFF
--- a/Dockerfile.browser
+++ b/Dockerfile.browser
@@ -15,7 +15,7 @@ FROM python:3.12-slim
 # profiles is handled by src/browser/profile_schema.py migration v2.
 RUN apt-get update && apt-get install -y --no-install-recommends \
     tini openbox wmctrl xdotool x11-xserver-utils unclutter-xfixes procps curl \
-    iptables gosu \
+    iptables gosu tzdata \
     libgtk-3-0 libatk1.0-0 libasound2 \
     libxcomposite1 libxdamage1 libxrandr2 libxkbcommon0 libgbm1 \
     libpango-1.0-0 libcairo2 libdbus-glib-1-2 \
@@ -27,6 +27,16 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && apt-get install -y --no-install-recommends /tmp/kasmvnc.deb \
     && rm /tmp/kasmvnc.deb \
     && rm -rf /var/lib/apt/lists/*
+
+# Pin the container timezone to a sensible en-US default. Without this,
+# ``Intl.DateTimeFormat().resolvedOptions().timeZone`` resolves to ``UTC``
+# (Docker's default), which is itself a strong fingerprint cluster: zero
+# real en-US users sit on UTC. Operators can override at runtime via
+# ``-e TZ=...`` (or via the systemd unit) to match their proxy egress
+# region. America/New_York is the most common en-US timezone by population.
+ENV TZ=America/New_York
+RUN ln -fs /usr/share/zoneinfo/${TZ} /etc/localtime \
+    && echo "${TZ}" > /etc/timezone
 
 # Install fontconfig alias file that redirects Windows typeface names to
 # the metric-compatible substitutes installed above. Must live under

--- a/Dockerfile.browser
+++ b/Dockerfile.browser
@@ -80,20 +80,34 @@ WORKDIR /app
 # existing profiles re-install the new XPI on next launch.
 #
 # The ``.firefox.signed.xpi`` naming covers all stable uBO 1.x releases
-# we'd reasonably ship. Pre-release / beta builds (1.70.1b1 etc.) ship
-# only ``.firefox.xpi`` (unsigned) — fall back to that name so a tester
-# can pin to a beta without hand-editing the URL. Camoufox's patched
-# Firefox accepts unsigned XPIs because xpinstall.signatures.required
-# is set to False in stealth prefs.
+# we'd reasonably ship. Camoufox's patched Firefox loads AMO-signed
+# extensions cleanly; the unsigned ``.firefox.xpi`` fallback is removed
+# because (a) silently substituting an unsigned XPI on a tag yank made
+# the build susceptible to upstream tampering, and (b)
+# ``xpinstall.signatures.required=false`` in stealth prefs would have
+# loaded ANY tampered substitute without warning.
+#
+# Bumping ``UBLOCK_VERSION`` REQUIRES updating ``UBLOCK_SHA256`` to the
+# corresponding release's SHA-256 — recorded in upstream release notes
+# or computed via ``sha256sum`` after a verified download. The build
+# fails closed if the hash mismatches, so a compromised release-asset
+# substitution can't silently land in agent profiles.
+#
+# To compute: download the URL below, run ``sha256sum`` on the result,
+# then paste the hex digest into ``UBLOCK_SHA256``. Verify against
+# the GitHub release page's published checksum (or PGP signature
+# verification of the corresponding ``.sig`` if upstream ships one).
+#
+# The build can be overridden via ``--build-arg UBLOCK_SHA256=...``;
+# the default below is INTENTIONALLY a placeholder so a fresh build
+# fails closed until the maintainer pins the verified hash.
 ARG UBLOCK_VERSION=1.62.0
+ARG UBLOCK_SHA256=PLACEHOLDER_PIN_BEFORE_BUILD
 RUN mkdir -p /opt/openlegion/extensions \
-    && ( \
-       curl -fSL -o /opt/openlegion/extensions/uBlock0.xpi \
-          "https://github.com/gorhill/uBlock/releases/download/${UBLOCK_VERSION}/uBlock0_${UBLOCK_VERSION}.firefox.signed.xpi" \
-       || curl -fSL -o /opt/openlegion/extensions/uBlock0.xpi \
-          "https://github.com/gorhill/uBlock/releases/download/${UBLOCK_VERSION}/uBlock0_${UBLOCK_VERSION}.firefox.xpi" \
-       ) \
-    && test -s /opt/openlegion/extensions/uBlock0.xpi \
+    && curl -fSL -o /opt/openlegion/extensions/uBlock0.xpi \
+        "https://github.com/gorhill/uBlock/releases/download/${UBLOCK_VERSION}/uBlock0_${UBLOCK_VERSION}.firefox.signed.xpi" \
+    && echo "${UBLOCK_SHA256}  /opt/openlegion/extensions/uBlock0.xpi" \
+        | sha256sum -c - \
     && chmod 0644 /opt/openlegion/extensions/uBlock0.xpi
 
 # Python dependencies — upgrade pip first to avoid resolver bugs with stale base images

--- a/Dockerfile.browser
+++ b/Dockerfile.browser
@@ -98,11 +98,9 @@ WORKDIR /app
 # the GitHub release page's published checksum (or PGP signature
 # verification of the corresponding ``.sig`` if upstream ships one).
 #
-# The build can be overridden via ``--build-arg UBLOCK_SHA256=...``;
-# the default below is INTENTIONALLY a placeholder so a fresh build
-# fails closed until the maintainer pins the verified hash.
+# The build can be overridden via ``--build-arg UBLOCK_SHA256=...``.
 ARG UBLOCK_VERSION=1.62.0
-ARG UBLOCK_SHA256=PLACEHOLDER_PIN_BEFORE_BUILD
+ARG UBLOCK_SHA256=8a9e02aa838c302fb14e2b5bc88a6036d36358aadd6f95168a145af2018ef1a3
 RUN mkdir -p /opt/openlegion/extensions \
     && curl -fSL -o /opt/openlegion/extensions/uBlock0.xpi \
         "https://github.com/gorhill/uBlock/releases/download/${UBLOCK_VERSION}/uBlock0_${UBLOCK_VERSION}.firefox.signed.xpi" \

--- a/src/browser/__main__.py
+++ b/src/browser/__main__.py
@@ -154,7 +154,8 @@ def _cleanup_orphan_downloads() -> None:
 
     Idempotent and non-fatal; logs but never raises.
     """
-    dl_dir = Path(os.environ.get("BROWSER_DOWNLOAD_DIR", "/tmp/downloads"))
+    from src.browser.flags import get_str
+    dl_dir = Path(get_str("BROWSER_DOWNLOAD_DIR", "/tmp/downloads"))
     if not dl_dir.is_dir():
         return
     removed = 0

--- a/src/browser/__main__.py
+++ b/src/browser/__main__.py
@@ -53,7 +53,7 @@ def _resolve_max_browsers() -> int:
     # ``min_value=1`` rejects nonsense like ``MAX=0`` (would deadlock the
     # acquire loop). ``max_value=64`` is a soft ceiling — a single VPS won't
     # have RAM for that many Camoufox instances anyway.
-    legacy_default = int(os.environ.get("MAX_BROWSERS", "5"))
+    legacy_default = get_int("MAX_BROWSERS", 5, min_value=1, max_value=64)
     return get_int(
         "OPENLEGION_BROWSER_MAX_CONCURRENT",
         legacy_default,

--- a/src/browser/captcha.py
+++ b/src/browser/captcha.py
@@ -2011,8 +2011,9 @@ class CaptchaSolver:
                 return bool(injected)
 
             if family == "turnstile":
-                injected = await page.evaluate("""(token) => {
+                injected_obj = await page.evaluate("""(token) => {
                     let updated = false;
+                    let widget_count = 0;
                     const fire = (el) => {
                         try {
                             el.dispatchEvent(new Event('input', { bubbles: true }));
@@ -2027,19 +2028,43 @@ class CaptchaSolver:
                         fire(input);
                         updated = true;
                     }
-                    // Trigger callback if available
+                    // Trigger callback if available. On pages with
+                    // multiple Turnstile widgets we fire the callback
+                    // for ALL of them — picking just the first widget
+                    // (the prior behavior) silently routed the solved
+                    // token to the wrong form on multi-form pages.
                     if (typeof turnstile !== 'undefined') {
                         try {
-                            const widgetId = Object.keys(turnstile._widgets || {})[0];
-                            if (widgetId && typeof turnstile._widgets[widgetId]?.callback === 'function') {
-                                turnstile._widgets[widgetId].callback(token);
-                                updated = true;
+                            const widgets = turnstile._widgets || {};
+                            const ids = Object.keys(widgets);
+                            widget_count = ids.length;
+                            for (const id of ids) {
+                                const cb = widgets[id]?.callback;
+                                if (typeof cb === 'function') {
+                                    try { cb(token); updated = true; }
+                                    catch (e) {}
+                                }
                             }
                         } catch(e) {}
                     }
-                    return updated;
+                    return { updated: updated, widget_count: widget_count };
                 }""", token)
-                return bool(injected)
+                if (
+                    isinstance(injected_obj, dict)
+                    and injected_obj.get("widget_count", 0) > 1
+                ):
+                    logger.info(
+                        "Turnstile injection saw %d widgets on page; "
+                        "fired callback on all (prior behavior fired only "
+                        "the first widget)",
+                        injected_obj.get("widget_count"),
+                    )
+                injected = (
+                    bool(injected_obj.get("updated"))
+                    if isinstance(injected_obj, dict)
+                    else bool(injected_obj)
+                )
+                return injected
 
         except Exception:
             logger.debug("Token injection error", exc_info=True)

--- a/src/browser/captcha.py
+++ b/src/browser/captcha.py
@@ -3,16 +3,15 @@
 Supports 2Captcha and CapSolver as solving providers.  Both are called via
 their public HTTP APIs using httpx — no additional dependencies required.
 
-When configured (via CAPTCHA_SOLVER_PROVIDER and CAPTCHA_SOLVER_KEY env vars),
-the browser service will automatically attempt to solve CAPTCHAs detected
-after navigation.  If solving fails or no solver is configured, the existing
-fallback (ask user via VNC) is preserved.
+When configured (via browser flags ``CAPTCHA_SOLVER_PROVIDER`` and
+``CAPTCHA_SOLVER_KEY``), the browser service will automatically attempt to
+solve CAPTCHAs detected after navigation. If solving fails or no solver is
+configured, the existing fallback (ask user via VNC) is preserved.
 """
 
 from __future__ import annotations
 
 import asyncio
-import os
 import re
 import time
 from collections import deque
@@ -584,9 +583,9 @@ _DEFAULT_V3_MIN_SCORE = 0.7
 
 
 def get_solver() -> CaptchaSolver | None:
-    """Create a CaptchaSolver from environment variables, or None if not configured."""
-    provider = os.environ.get("CAPTCHA_SOLVER_PROVIDER", "").strip().lower()
-    api_key = os.environ.get("CAPTCHA_SOLVER_KEY", "").strip()
+    """Create a CaptchaSolver from browser flags, or None if not configured."""
+    provider = flags.get_str("CAPTCHA_SOLVER_PROVIDER", "").strip().lower()
+    api_key = flags.get_str("CAPTCHA_SOLVER_KEY", "").strip()
     if not provider or not api_key:
         return None
     if provider not in _SUPPORTED_PROVIDERS:
@@ -1360,7 +1359,11 @@ class CaptchaSolver:
                 captcha_type = variant
             sitekey = classified.get("sitekey")
             page_action = classified.get("action")
-        logger.info("Attempting to solve %s CAPTCHA on %s", captcha_type, page_url)
+        logger.info(
+            "Attempting to solve %s CAPTCHA on %s",
+            captcha_type,
+            redact_url(page_url),
+        )
 
         if not sitekey:
             sitekey = await self._extract_sitekey(page, captcha_type)
@@ -1914,15 +1917,26 @@ class CaptchaSolver:
             family = "recaptcha"
         try:
             if family == "recaptcha":
-                await page.evaluate("""(token) => {
+                injected = await page.evaluate("""(token) => {
+                    let updated = false;
+                    const fire = (el) => {
+                        try {
+                            el.dispatchEvent(new Event('input', { bubbles: true }));
+                            el.dispatchEvent(new Event('change', { bubbles: true }));
+                        } catch (e) {}
+                    };
                     const textarea = document.getElementById('g-recaptcha-response');
                     if (textarea) {
                         textarea.style.display = '';
                         textarea.value = token;
+                        fire(textarea);
+                        updated = true;
                     }
                     // Also try hidden textareas in iframes
                     document.querySelectorAll('[name="g-recaptcha-response"]').forEach(el => {
                         el.value = token;
+                        fire(el);
+                        updated = true;
                     });
                     // Trigger callback if available
                     if (typeof ___grecaptcha_cfg !== 'undefined') {
@@ -1935,7 +1949,10 @@ class CaptchaSolver:
                                     if (depth > 5 || !obj) return;
                                     for (const key in obj) {
                                         if (typeof obj[key] === 'function' && key === 'callback') {
-                                            obj[key](token);
+                                            try {
+                                                obj[key](token);
+                                                updated = true;
+                                            } catch (e) {}
                                             return;
                                         }
                                         if (typeof obj[key] === 'object') walk(obj[key], depth + 1);
@@ -1945,40 +1962,68 @@ class CaptchaSolver:
                             }
                         }
                     }
+                    return updated;
                 }""", token)
-                return True
+                return bool(injected)
 
             if family == "hcaptcha":
-                await page.evaluate("""(token) => {
+                injected = await page.evaluate("""(token) => {
+                    let updated = false;
+                    const fire = (el) => {
+                        try {
+                            el.dispatchEvent(new Event('input', { bubbles: true }));
+                            el.dispatchEvent(new Event('change', { bubbles: true }));
+                        } catch (e) {}
+                    };
                     const textarea = document.querySelector('[name="h-captcha-response"]');
-                    if (textarea) textarea.value = token;
+                    if (textarea) {
+                        textarea.value = token;
+                        fire(textarea);
+                        updated = true;
+                    }
                     document.querySelectorAll('[name="g-recaptcha-response"]').forEach(el => {
                         el.value = token;
+                        fire(el);
+                        updated = true;
                     });
                     // Trigger hcaptcha callback
                     if (typeof hcaptcha !== 'undefined' && hcaptcha.getRespKey) {
                         try { hcaptcha.execute(); } catch(e) {}
                     }
+                    return updated;
                 }""", token)
-                return True
+                return bool(injected)
 
             if family == "turnstile":
-                await page.evaluate("""(token) => {
+                injected = await page.evaluate("""(token) => {
+                    let updated = false;
+                    const fire = (el) => {
+                        try {
+                            el.dispatchEvent(new Event('input', { bubbles: true }));
+                            el.dispatchEvent(new Event('change', { bubbles: true }));
+                        } catch (e) {}
+                    };
                     // Find the Turnstile response input
                     const input = document.querySelector('[name="cf-turnstile-response"]')
                         || document.querySelector('input[name*="turnstile"]');
-                    if (input) input.value = token;
+                    if (input) {
+                        input.value = token;
+                        fire(input);
+                        updated = true;
+                    }
                     // Trigger callback if available
                     if (typeof turnstile !== 'undefined') {
                         try {
-                            const widgetId = turnstile.getResponse ? null : Object.keys(turnstile._widgets || {})[0];
-                            if (widgetId && turnstile._widgets[widgetId]?.callback) {
+                            const widgetId = Object.keys(turnstile._widgets || {})[0];
+                            if (widgetId && typeof turnstile._widgets[widgetId]?.callback === 'function') {
                                 turnstile._widgets[widgetId].callback(token);
+                                updated = true;
                             }
                         } catch(e) {}
                     }
+                    return updated;
                 }""", token)
-                return True
+                return bool(injected)
 
         except Exception:
             logger.debug("Token injection error", exc_info=True)

--- a/src/browser/captcha.py
+++ b/src/browser/captcha.py
@@ -1008,7 +1008,8 @@ class CaptchaSolver:
         self._solver_breaker_until: float = 0.0
         # Coordinates breaker reads/writes with health-check init across
         # concurrent agents that share this solver instance.
-        self._state_lock: asyncio.Lock = asyncio.Lock()
+        self._state_lock: asyncio.Lock | None = None
+        self._state_lock_loop: asyncio.AbstractEventLoop | None = None
         # NOTE: Prior versions of this class exposed ``last_used_proxy_aware``
         # and ``last_compat_rejected`` instance attributes that ``solve()``
         # stamped after every call so the BrowserManager could pick up the
@@ -1024,6 +1025,21 @@ class CaptchaSolver:
         # Operator-tunable but not per-call — restart the browser service
         # to pick up env var changes.
         self._solve_timeouts_ms: dict[str, int] = self._resolve_solve_timeouts()
+
+    def _get_state_lock(self) -> asyncio.Lock:
+        """Return a lock bound to the currently running event loop.
+
+        Python 3.9 binds ``asyncio.Lock`` at construction time. Creating the
+        solver from synchronous startup/test code after a previous loop closed
+        raises ``RuntimeError``. Lazily creating the lock inside async paths
+        keeps the solver safe for sync construction and normal browser-service
+        use.
+        """
+        loop = asyncio.get_running_loop()
+        if self._state_lock is None or self._state_lock_loop is not loop:
+            self._state_lock = asyncio.Lock()
+            self._state_lock_loop = loop
+        return self._state_lock
 
     def _get_client(self) -> httpx.AsyncClient:
         if self._client is None or self._client.is_closed:
@@ -1235,7 +1251,7 @@ class CaptchaSolver:
         """
         if self._solver_health_checked:
             return
-        async with self._state_lock:
+        async with self._get_state_lock():
             if self._solver_health_checked:
                 return
             outcome = await self.health_check()
@@ -1252,7 +1268,7 @@ class CaptchaSolver:
         On failure: append a timestamp, prune entries older than the 5-min
         window, then trip the breaker if 3+ entries remain.
         """
-        async with self._state_lock:
+        async with self._get_state_lock():
             now = time.time()
             if success:
                 self._solver_failure_timestamps.clear()

--- a/src/browser/captcha.py
+++ b/src/browser/captcha.py
@@ -1931,13 +1931,66 @@ class CaptchaSolver:
         ``hcaptcha``, ``turnstile``); the §11.1 reCAPTCHA variants
         (``recaptcha-v2-checkbox`` / ``...-v3`` / ``...-enterprise-v2`` / etc.)
         all share the same ``g-recaptcha-response`` injection path.
+
+        Iframe handling: hCaptcha and Turnstile render their
+        ``<input name="*-response">`` element INSIDE the widget iframe.
+        Running injection JS only in the top-level document would miss
+        the response input on widgets that don't auto-mirror to a
+        parent textarea, returning ``injection_failed`` even though
+        the provider returned a valid token. Walk every frame and
+        bubble up "any frame succeeded" as the success bit.
         """
         family = captcha_type
         if captcha_type.startswith("recaptcha"):
             family = "recaptcha"
+
+        async def _eval_in_all_frames(js: str) -> list:
+            """Run ``js`` in every frame; return the list of per-frame
+            return values. Failures (cross-origin frame, frame detached,
+            ...) are swallowed per-frame so one bad frame doesn't
+            abort the rest of the walk.
+
+            Always evaluates against ``page`` first (the top-level
+            document) so existing single-frame tests/mocks still see
+            their evaluate call. Then walks ``page.frames`` if
+            available; cross-origin / mock objects that don't yield a
+            real iterable degrade cleanly to the page-only path.
+            """
+            results: list = []
+            # Always try the top-level page first — covers single-frame
+            # mocks in tests and the common case where the response
+            # input is mirrored at the top level.
+            try:
+                results.append(await page.evaluate(js, token))
+            except Exception:
+                pass
+            # Walk the frame tree if Playwright exposes one. ``frames``
+            # may be missing (test mocks), non-iterable (AsyncMock
+            # auto-attr), or include the main frame already covered
+            # above; iterating defensively skips all of those.
+            frames = getattr(page, "frames", None)
+            try:
+                frame_iter = list(frames) if frames is not None else []
+            except TypeError:
+                frame_iter = []
+            for frame in frame_iter:
+                if frame is page:
+                    continue
+                evaluator = getattr(frame, "evaluate", None)
+                if not callable(evaluator):
+                    continue
+                try:
+                    results.append(await evaluator(js, token))
+                except Exception:
+                    # Cross-origin / detached / SecurityError — common
+                    # for the captcha provider's iframe origin. Don't
+                    # propagate; one bad frame shouldn't kill the walk.
+                    continue
+            return results
+
         try:
             if family == "recaptcha":
-                injected = await page.evaluate("""(token) => {
+                results = await _eval_in_all_frames("""(token) => {
                     let updated = false;
                     const fire = (el) => {
                         try {
@@ -1983,11 +2036,20 @@ class CaptchaSolver:
                         }
                     }
                     return updated;
-                }""", token)
-                return bool(injected)
+                }""")
+                return any(bool(r) for r in results)
 
             if family == "hcaptcha":
-                injected = await page.evaluate("""(token) => {
+                # hCaptcha widget renders the response input inside its
+                # iframe. Set the textarea BEFORE calling
+                # ``hcaptcha.execute()`` would risk the SDK re-running
+                # the challenge and clobbering our token; we just set
+                # the textarea + dispatch input/change events and let
+                # the embedding form's submit handler pick it up.
+                # Real-world flow: provider verifies the token
+                # server-side from the form post; the SDK callback is
+                # not strictly required.
+                results = await _eval_in_all_frames("""(token) => {
                     let updated = false;
                     const fire = (el) => {
                         try {
@@ -2006,16 +2068,17 @@ class CaptchaSolver:
                         fire(el);
                         updated = true;
                     });
-                    // Trigger hcaptcha callback
-                    if (typeof hcaptcha !== 'undefined' && hcaptcha.getRespKey) {
-                        try { hcaptcha.execute(); } catch(e) {}
-                    }
                     return updated;
-                }""", token)
-                return bool(injected)
+                }""")
+                return any(bool(r) for r in results)
 
             if family == "turnstile":
-                injected_obj = await page.evaluate("""(token) => {
+                # Turnstile renders the response input inside the
+                # widget iframe; the embedding form often holds a
+                # mirror ``[name="cf-turnstile-response"]`` at the top
+                # level too. Walk both so we hit whichever variant the
+                # site uses.
+                per_frame = await _eval_in_all_frames("""(token) => {
                     let updated = false;
                     let widget_count = 0;
                     const fire = (el) => {
@@ -2052,23 +2115,23 @@ class CaptchaSolver:
                         } catch(e) {}
                     }
                     return { updated: updated, widget_count: widget_count };
-                }""", token)
-                if (
-                    isinstance(injected_obj, dict)
-                    and injected_obj.get("widget_count", 0) > 1
-                ):
-                    logger.info(
-                        "Turnstile injection saw %d widgets on page; "
-                        "fired callback on all (prior behavior fired only "
-                        "the first widget)",
-                        injected_obj.get("widget_count"),
-                    )
-                injected = (
-                    bool(injected_obj.get("updated"))
-                    if isinstance(injected_obj, dict)
-                    else bool(injected_obj)
+                }""")
+                total_widgets = sum(
+                    int(r.get("widget_count", 0))
+                    for r in per_frame
+                    if isinstance(r, dict)
                 )
-                return injected
+                if total_widgets > 1:
+                    logger.info(
+                        "Turnstile injection saw %d widgets across all "
+                        "frames; fired callback on all (prior behavior "
+                        "fired only the first widget)",
+                        total_widgets,
+                    )
+                return any(
+                    bool(r.get("updated") if isinstance(r, dict) else r)
+                    for r in per_frame
+                )
 
         except Exception:
             logger.debug("Token injection error", exc_info=True)

--- a/src/browser/captcha.py
+++ b/src/browser/captcha.py
@@ -1967,14 +1967,17 @@ class CaptchaSolver:
             # Walk the frame tree if Playwright exposes one. ``frames``
             # may be missing (test mocks), non-iterable (AsyncMock
             # auto-attr), or include the main frame already covered
-            # above; iterating defensively skips all of those.
+            # above; iterating defensively skips all of those. Playwright
+            # includes ``page.main_frame`` in ``page.frames``; skip it so
+            # callbacks do not fire twice in the top-level document.
             frames = getattr(page, "frames", None)
             try:
                 frame_iter = list(frames) if frames is not None else []
             except TypeError:
                 frame_iter = []
+            main_frame = getattr(page, "main_frame", None)
             for frame in frame_iter:
-                if frame is page:
+                if frame is page or frame is main_frame:
                     continue
                 evaluator = getattr(frame, "evaluate", None)
                 if not callable(evaluator):

--- a/src/browser/captcha.py
+++ b/src/browser/captcha.py
@@ -71,6 +71,10 @@ class SolveResult:
               * ``"provider_missing"`` — solver lacks a string ``provider``
                 attribute AND a cost cap is configured; we fail closed
                 rather than let an untrackable charge slip past the cap.
+              * ``"price_missing"`` — solver/provider exists but the
+                ``(provider, kind)`` tuple has no published cost while a
+                cost cap is configured; we fail closed for the same
+                reason.
             ``None`` for a real solver attempt (success or failure).
 
     Field-population guarantee for ``_metered_solve`` consumers:

--- a/src/browser/captcha_cost_counter.py
+++ b/src/browser/captcha_cost_counter.py
@@ -30,7 +30,11 @@ existing `int` storage / JSON shape unchanged.
 Public surface:
   * :func:`add_cost(agent_id, millicents)` — increment a per-agent
     monthly bucket. Resets when the calendar month rolls over.
+  * :func:`adjust_cost(agent_id, delta_millicents)` — apply a signed
+    correction, clamped at zero. Used to refund pre-solve reservations.
   * :func:`over_cap(agent_id, cap_millicents)` — read-only check.
+  * :func:`check_and_charge(agent_id, cap_millicents, millicents)` —
+    atomic under-cap reservation/charge helper.
   * :func:`snapshot()` / :func:`restore()` — JSON file persistence. Atomic
     write via ``os.replace`` after ``fsync``. The on-disk schema migrates
     legacy ``cents`` snapshots by multiplying ×1000 on load (logged once).
@@ -260,6 +264,22 @@ async def add_cost(agent_id: str, millicents: int) -> int:
         return bucket["millicents"]
 
 
+async def adjust_cost(agent_id: str, delta_millicents: int) -> int:
+    """Apply a signed correction to the current-month bucket.
+
+    Positive deltas behave like :func:`add_cost`; negative deltas refund a
+    reservation or over-estimate. The bucket is clamped at zero so a double
+    refund or process-restart mismatch cannot create negative spend.
+    """
+    if delta_millicents == 0:
+        return await get_millicents(agent_id)
+    async with _get_lock():
+        bucket = _bucket_for(agent_id)
+        current = int(bucket["millicents"])
+        bucket["millicents"] = max(0, current + int(delta_millicents))
+        return bucket["millicents"]
+
+
 async def over_cap(agent_id: str, cap_millicents: int) -> bool:
     """Return ``True`` iff current-month spend ≥ ``cap_millicents``.
 
@@ -297,7 +317,10 @@ async def check_and_charge(
     Closes the race between separate ``over_cap`` / ``add_cost`` lock
     spans where two concurrent solves could each see ``bucket < cap``,
     each call ``add_cost``, and together push the bucket above cap. Hold
-    the lock across both reads and writes here.
+    the lock across both reads and writes here. BrowserManager uses this
+    as a pre-solve reservation for the maximum published price, then calls
+    :func:`adjust_cost` to refund or correct after the provider result is
+    known.
 
     ``cap_millicents <= 0`` means "no cap": always allowed; cost is still
     charged. ``millicents <= 0`` means "free attempt": always allowed;

--- a/src/browser/captcha_cost_counter.py
+++ b/src/browser/captcha_cost_counter.py
@@ -285,6 +285,35 @@ async def get_millicents(agent_id: str) -> int:
         return int(bucket["millicents"])
 
 
+async def check_and_charge(
+    agent_id: str, cap_millicents: int, millicents: int,
+) -> tuple[bool, int]:
+    """Atomically gate ``millicents`` against ``cap_millicents``.
+
+    Returns ``(allowed, new_total)``:
+      * ``allowed=True``  → bucket was UNDER cap; ``millicents`` was added.
+      * ``allowed=False`` → bucket was AT/OVER cap; nothing was charged.
+
+    Closes the race between separate ``over_cap`` / ``add_cost`` lock
+    spans where two concurrent solves could each see ``bucket < cap``,
+    each call ``add_cost``, and together push the bucket above cap. Hold
+    the lock across both reads and writes here.
+
+    ``cap_millicents <= 0`` means "no cap": always allowed; cost is still
+    charged. ``millicents <= 0`` means "free attempt": always allowed;
+    nothing is charged.
+    """
+    async with _get_lock():
+        bucket = _bucket_for(agent_id)
+        current = int(bucket["millicents"])
+        if cap_millicents > 0 and current >= int(cap_millicents):
+            return False, current
+        if millicents > 0:
+            bucket["millicents"] = current + int(millicents)
+            return True, bucket["millicents"]
+        return True, current
+
+
 # Back-compat alias for an external caller that used to read cents. The
 # name is preserved but the units are now MILLICENTS — the caller almost
 # certainly wants ``get_millicents`` directly, but this avoids a hard

--- a/src/browser/captcha_cost_counter.py
+++ b/src/browser/captcha_cost_counter.py
@@ -203,7 +203,23 @@ estimate_cents = estimate_millicents
 
 # {agent_id: {"month": "YYYY-MM", "millicents": int}}
 _state: dict[str, dict] = {}
-_lock: asyncio.Lock = asyncio.Lock()
+# Created lazily inside async paths to stay loop-safe — pytest-asyncio
+# uses one event loop per test, so an import-time ``asyncio.Lock()``
+# would bind to the first loop and fail on the second. Mirrors the
+# pattern in ``service.py`` (``_get_solve_rate_lock`` etc.) and
+# ``captcha.py`` (``CaptchaSolver._get_state_lock``).
+_lock: asyncio.Lock | None = None
+_lock_loop: asyncio.AbstractEventLoop | None = None
+
+
+def _get_lock() -> asyncio.Lock:
+    """Return a cost-counter lock bound to the active event loop."""
+    global _lock, _lock_loop
+    loop = asyncio.get_running_loop()
+    if _lock is None or _lock_loop is not loop:
+        _lock = asyncio.Lock()
+        _lock_loop = loop
+    return _lock
 
 
 def _current_month() -> str:
@@ -238,7 +254,7 @@ async def add_cost(agent_id: str, millicents: int) -> int:
     """
     if millicents <= 0:
         return await get_millicents(agent_id)
-    async with _lock:
+    async with _get_lock():
         bucket = _bucket_for(agent_id)
         bucket["millicents"] = int(bucket["millicents"]) + int(millicents)
         return bucket["millicents"]
@@ -257,14 +273,14 @@ async def over_cap(agent_id: str, cap_millicents: int) -> bool:
     """
     if cap_millicents <= 0:
         return False
-    async with _lock:
+    async with _get_lock():
         bucket = _bucket_for(agent_id)
         return int(bucket["millicents"]) >= int(cap_millicents)
 
 
 async def get_millicents(agent_id: str) -> int:
     """Return the current-month spend for ``agent_id`` in millicents."""
-    async with _lock:
+    async with _get_lock():
         bucket = _bucket_for(agent_id)
         return int(bucket["millicents"])
 
@@ -278,7 +294,7 @@ get_cents = get_millicents
 
 async def reset(agent_id: str | None = None) -> None:
     """Clear state. ``agent_id=None`` clears everything (test harness)."""
-    async with _lock:
+    async with _get_lock():
         if agent_id is None:
             _state.clear()
         else:
@@ -305,7 +321,7 @@ async def snapshot(path: Path | str | None = None) -> bool:
         logger.warning("captcha_cost snapshot: cannot create parent dir: %s", e)
         return False
 
-    async with _lock:
+    async with _get_lock():
         # JSON-serializable copy. Bucket dicts are already plain
         # ``{month, cents}`` so no custom encoder is needed.
         payload = {
@@ -384,7 +400,7 @@ async def restore(path: Path | str | None = None) -> int:
     cm = _current_month()
     loaded = 0
     migrated = 0
-    async with _lock:
+    async with _get_lock():
         _state.clear()
         for agent_id, bucket in buckets.items():
             if not isinstance(bucket, dict):

--- a/src/browser/flags.py
+++ b/src/browser/flags.py
@@ -206,6 +206,28 @@ def _lookup_raw(name: str, agent_id: str | None) -> str | None:
     return os.environ.get(name)
 
 
+def _lookup_raw_candidates(name: str, agent_id: str | None) -> list[tuple[str, str]]:
+    """Return all configured values in precedence order.
+
+    Typed accessors use this to fall through when a higher-precedence
+    value is malformed. A bad per-agent override should not mask a valid
+    operator setting or environment fallback.
+    """
+    candidates: list[tuple[str, str]] = []
+    with _lock:
+        if agent_id is not None:
+            bucket = _agent_overrides.get(agent_id)
+            if bucket and name in bucket:
+                candidates.append(("agent_override", bucket[name]))
+        settings = _load_operator_settings()
+        if name in settings:
+            candidates.append(("operator_settings", settings[name]))
+    raw_env = os.environ.get(name)
+    if raw_env is not None:
+        candidates.append(("environment", raw_env))
+    return candidates
+
+
 # ── Typed accessors ────────────────────────────────────────────────────────
 
 
@@ -224,19 +246,18 @@ _FALSE = frozenset({"false", "0", "no", "off", ""})
 def get_bool(name: str, default: bool, *, agent_id: str | None = None) -> bool:
     """Return the boolean value for ``name``, coercing ``true|1|yes|on`` to
     ``True`` and ``false|0|no|off|<empty>`` to ``False``. Anything else logs
-    a warning and returns ``default``."""
-    raw = _lookup_raw(name, agent_id)
-    if raw is None:
-        return default
-    lowered = raw.strip().lower()
-    if lowered in _TRUE:
-        return True
-    if lowered in _FALSE:
-        return False
-    logger.warning(
-        "Flag %s has non-boolean value %r; falling back to default %r",
-        name, raw, default,
-    )
+    a warning and falls through to the next precedence layer."""
+    for source, raw in _lookup_raw_candidates(name, agent_id):
+        lowered = raw.strip().lower()
+        if lowered in _TRUE:
+            return True
+        if lowered in _FALSE:
+            return False
+        logger.warning(
+            "Flag %s from %s has non-boolean value %r; "
+            "falling through to next layer",
+            name, source, raw,
+        )
     return default
 
 
@@ -250,23 +271,23 @@ def get_int(
 ) -> int:
     """Return the integer value for ``name``, clamped to
     ``[min_value, max_value]`` when bounds are provided. Invalid ints log
-    a warning and return ``default``."""
-    raw = _lookup_raw(name, agent_id)
-    if raw is None:
-        return default
-    try:
-        value = int(raw.strip())
-    except (ValueError, AttributeError):
-        logger.warning(
-            "Flag %s has non-integer value %r; falling back to default %d",
-            name, raw, default,
-        )
-        return default
-    if min_value is not None and value < min_value:
-        return min_value
-    if max_value is not None and value > max_value:
-        return max_value
-    return value
+    a warning and fall through to the next precedence layer."""
+    for source, raw in _lookup_raw_candidates(name, agent_id):
+        try:
+            value = int(raw.strip())
+        except (ValueError, AttributeError):
+            logger.warning(
+                "Flag %s from %s has non-integer value %r; "
+                "falling through to next layer",
+                name, source, raw,
+            )
+            continue
+        if min_value is not None and value < min_value:
+            return min_value
+        if max_value is not None and value > max_value:
+            return max_value
+        return value
+    return default
 
 
 def get_float(
@@ -278,22 +299,22 @@ def get_float(
     max_value: float | None = None,
 ) -> float:
     """Return the float value for ``name``, clamped to bounds when provided."""
-    raw = _lookup_raw(name, agent_id)
-    if raw is None:
-        return default
-    try:
-        value = float(raw.strip())
-    except (ValueError, AttributeError):
-        logger.warning(
-            "Flag %s has non-float value %r; falling back to default %r",
-            name, raw, default,
-        )
-        return default
-    if min_value is not None and value < min_value:
-        return min_value
-    if max_value is not None and value > max_value:
-        return max_value
-    return value
+    for source, raw in _lookup_raw_candidates(name, agent_id):
+        try:
+            value = float(raw.strip())
+        except (ValueError, AttributeError):
+            logger.warning(
+                "Flag %s from %s has non-float value %r; "
+                "falling through to next layer",
+                name, source, raw,
+            )
+            continue
+        if min_value is not None and value < min_value:
+            return min_value
+        if max_value is not None and value > max_value:
+            return max_value
+        return value
+    return default
 
 
 def snapshot_all(*, agent_id: str | None = None) -> dict[str, Any]:

--- a/src/browser/flags.py
+++ b/src/browser/flags.py
@@ -67,6 +67,8 @@ KNOWN_FLAGS: dict[str, str] = {
     "OPENLEGION_UPLOAD_STAGE_DIR": "mesh staging dir (default /tmp/openlegion-upload-stage)",
     "OPENLEGION_UPLOAD_RECV_DIR": "browser receive dir (default /tmp/upload-recv)",
     "OPENLEGION_UPLOAD_STAGE_TTL_S": "orphan staging TTL in seconds (default 60)",
+    "BROWSER_DOWNLOAD_DIR": "browser-side download dir (default /tmp/downloads)",
+    "BROWSER_DOWNLOAD_TTL_S": "stale download GC TTL seconds (default 60)",
     # ── CAPTCHA solver (§11) ──────────────────────────────────────────────
     "CAPTCHA_SOLVER_PROVIDER": "2captcha | capsolver | unset",
     "CAPTCHA_SOLVER_KEY": "API key for the primary provider",

--- a/src/browser/profile_schema.py
+++ b/src/browser/profile_schema.py
@@ -95,8 +95,9 @@ def _adblock_enabled() -> bool:
     extension (cleanly uninstalling Firefox extensions in-place is
     fragile; operators wanting a hard reset should ``openlegion reset``).
     """
-    raw = os.environ.get("BROWSER_ENABLE_ADBLOCK", "true").strip().lower()
-    return raw not in ("false", "0", "no", "off", "")
+    from src.browser.flags import get_bool
+
+    return get_bool("BROWSER_ENABLE_ADBLOCK", True)
 
 
 def _v2_clear_font_caches(profile: Path) -> None:

--- a/src/browser/redaction.py
+++ b/src/browser/redaction.py
@@ -14,7 +14,7 @@ from __future__ import annotations
 from src.shared.redaction import (
     _REDACT_PATTERNS,  # noqa: F401  — re-export for old imports
     deep_redact,
-    redact_string,
+    redact_url,
 )
 
 
@@ -26,8 +26,8 @@ class CredentialRedactor:
     """
 
     def redact(self, agent_id: str, text: str) -> str:
-        """Apply pattern-based redaction to ``text``."""
-        return redact_string(text)
+        """Apply URL-aware and pattern-based redaction to ``text``."""
+        return redact_url(text)
 
     def deep_redact(self, agent_id: str, obj):
         """Recursively redact credential values from a JSON-shaped structure."""

--- a/src/browser/ref_handle.py
+++ b/src/browser/ref_handle.py
@@ -67,6 +67,14 @@ class ShadowHop:
             raise ValueError("ShadowHop.selector must be non-empty")
         if not self.discriminator:
             raise ValueError("ShadowHop.discriminator must be non-empty")
+        # ``occurrence`` flows into element-key hashing and JS selector
+        # indexing on the resolver side; a negative value silently
+        # produces a wrong resolution rather than failing fast.
+        if not isinstance(self.occurrence, int) or self.occurrence < 0:
+            raise ValueError(
+                f"ShadowHop.occurrence must be non-negative int, "
+                f"got {self.occurrence!r}",
+            )
 
 
 # ── Ref handle (the canonical identity of a snapshot ref) ───────────────────

--- a/src/browser/ref_handle.py
+++ b/src/browser/ref_handle.py
@@ -308,8 +308,11 @@ def _is_stable_id(candidate: str) -> bool:
     """Return True when ``candidate`` looks author-chosen, not generated."""
     if not candidate:
         return False
-    # React useId shape:  ":r0:", ":R12aB:", "r:r0:"
-    if candidate.startswith((":r", "r:", ":R")) and candidate.endswith(":"):
+    # React useId shape:  ":r0:", ":R12aB:". Real React always wraps in
+    # leading colons; an author id like ``r:radio-group:`` does not.
+    # Drop the bogus ``"r:"`` prefix that previously rejected legitimate
+    # author ids whose name happened to start with ``r:``.
+    if candidate.startswith((":r", ":R")) and candidate.endswith(":"):
         return False
     # UUID v4 shape (eight-four-four-four-twelve hex)
     if (

--- a/src/browser/server.py
+++ b/src/browser/server.py
@@ -528,14 +528,19 @@ def create_browser_app(manager: BrowserManager, lifespan=None) -> FastAPI:
         ref = body.get("ref", "")
         if not ref:
             raise HTTPException(400, "ref required")
-        timeout_ms = int(body.get("timeout_ms", 30000))
+        try:
+            timeout_ms = int(body.get("timeout_ms", 30000))
+        except (TypeError, ValueError):
+            raise HTTPException(400, "timeout_ms must be an integer")
+        timeout_ms = max(1000, min(timeout_ms, 180000))
         result = await manager.download(agent_id, ref, timeout_ms=timeout_ms)
         return result
 
     _NONCE_RE = re.compile(r"^[a-f0-9]{12}$")
 
     def _download_dir() -> Path:
-        return Path(os.environ.get("BROWSER_DOWNLOAD_DIR", "/tmp/downloads"))
+        from src.browser.flags import get_str as _flag_str
+        return Path(_flag_str("BROWSER_DOWNLOAD_DIR", "/tmp/downloads"))
 
     def _resolve_download_path(nonce: str) -> Path | None:
         if not _NONCE_RE.match(nonce):

--- a/src/browser/service.py
+++ b/src/browser/service.py
@@ -1480,6 +1480,15 @@ def _encode_screenshot(
         )
         return png_bytes, "png"
 
+    # Decompression-bomb protection. A page rendering a giant <canvas>
+    # could hand us back a multi-hundred-megapixel PNG that Pillow
+    # would happily allocate. Cap at 50 MP — covers any realistic
+    # browser viewport (8K screen ≈ 33 MP) but blocks adversarial
+    # blowups. Pillow raises ``DecompressionBombError`` once the cap
+    # is exceeded; we catch and return the raw PNG bytes so the agent
+    # still gets diagnostic data.
+    Image.MAX_IMAGE_PIXELS = 50_000_000
+
     try:
         img = Image.open(BytesIO(png_bytes))
         # Downscale via Lanczos when requested. Avoids the no-op resize
@@ -1705,12 +1714,23 @@ class CamoufoxInstance:
         # Per-Page stable UUID maps. Page objects survive navigation within a
         # tab; UUIDs are stable for the life of the Page. Refs carry a
         # ``page_id`` so resolution can detect a closed tab as stale (§4.2).
+        #
+        # ``page_ids`` is a WeakKeyDictionary so closed Pages drop out of
+        # the forward map automatically. The earlier ``dict[int, str]``
+        # keyed by ``id(page)`` had a silent re-bind bug: once a Page is
+        # GC'd Python recycles its ``id()``, so a freshly-opened tab
+        # could land on the SAME ``id`` value as a closed one. The
+        # reverse map (already weak) had dropped the entry, but the
+        # forward lookup found the stale UUID and re-bound it to the
+        # new Page — so an old ref with the recycled UUID resolved to
+        # a different tab. WeakKey closes that hole.
         self._page_id_counter: int = 0
-        self.page_ids: dict = {}              # id(Page) -> str
-        # WeakValueDictionary so closed Pages (GC'd by Playwright on tab
-        # close) drop out of the reverse lookup automatically. Plain dict
-        # here would pin every Page ever opened for the lifetime of the
-        # CamoufoxInstance — a slow leak on agents that churn tabs.
+        self.page_ids: weakref.WeakKeyDictionary = (
+            weakref.WeakKeyDictionary()
+        )
+        # WeakValueDictionary so closed Pages drop out of the reverse
+        # lookup automatically. Plain dict would pin every Page ever
+        # opened for the lifetime of the CamoufoxInstance.
         self.page_ids_inv: weakref.WeakValueDictionary = (
             weakref.WeakValueDictionary()
         )
@@ -1838,12 +1858,12 @@ class CamoufoxInstance:
         Called on CamoufoxInstance creation (for the initial page) and will
         be called again by ``browser_open_tab`` (§8.6) for new tabs.
         """
-        existing = self.page_ids.get(id(page))
+        existing = self.page_ids.get(page)
         if existing is not None:
             return existing
         self._page_id_counter += 1
         new_id = f"p{self._page_id_counter}-{uuid.uuid4().hex[:8]}"
-        self.page_ids[id(page)] = new_id
+        self.page_ids[page] = new_id
         self.page_ids_inv[new_id] = page
         return new_id
 
@@ -2103,11 +2123,17 @@ class BrowserManager:
         otherwise leak files into ``BROWSER_DOWNLOAD_DIR`` until the
         container restarts. Janitor mirrors the upload-stage GC.
         """
-        ttl = max(1, int(os.environ.get("BROWSER_DOWNLOAD_TTL_S", "60")))
+        from src.browser.flags import get_int as _flag_int
+        from src.browser.flags import get_str as _flag_str
+        ttl = _flag_int(
+            "BROWSER_DOWNLOAD_TTL_S", 60, min_value=1, max_value=86400,
+        )
         while True:
             await asyncio.sleep(30)
             try:
-                dl_dir = Path(os.environ.get("BROWSER_DOWNLOAD_DIR", "/tmp/downloads"))
+                dl_dir = Path(_flag_str(
+                    "BROWSER_DOWNLOAD_DIR", "/tmp/downloads",
+                ))
                 if not dl_dir.is_dir():
                     continue
                 now = time.time()
@@ -2597,22 +2623,30 @@ class BrowserManager:
                 temp_page = None
             probe_page = inst.page
 
+        # Cap the probe so a hung renderer (rare but observed under
+        # heavy CPU pressure or stuck Camoufox stacks) cannot block
+        # ``get_or_start`` indefinitely. The probe holds the manager
+        # lock through this call site, so a stall here freezes every
+        # other agent's start/stop/touch.
         try:
-            signals = await probe_page.evaluate(
-                "() => ({"
-                "  webdriver: navigator.webdriver,"
-                "  plugins_len: navigator.plugins ? navigator.plugins.length : -1,"
-                "  mimeTypes_len: navigator.mimeTypes ? navigator.mimeTypes.length : -1,"
-                "  hardwareConcurrency: navigator.hardwareConcurrency,"
-                "  deviceMemory: navigator.deviceMemory,"
-                "  userAgent: navigator.userAgent,"
-                "  platform: navigator.platform,"
-                "  language: navigator.language,"
-                "  timezone: Intl.DateTimeFormat().resolvedOptions().timeZone,"
-                "  conn_effective: navigator.connection ? navigator.connection.effectiveType : null,"
-                "  conn_downlink: navigator.connection ? navigator.connection.downlink : null,"
-                "  conn_rtt: navigator.connection ? navigator.connection.rtt : null"
-                "})",
+            signals = await asyncio.wait_for(
+                probe_page.evaluate(
+                    "() => ({"
+                    "  webdriver: navigator.webdriver,"
+                    "  plugins_len: navigator.plugins ? navigator.plugins.length : -1,"
+                    "  mimeTypes_len: navigator.mimeTypes ? navigator.mimeTypes.length : -1,"
+                    "  hardwareConcurrency: navigator.hardwareConcurrency,"
+                    "  deviceMemory: navigator.deviceMemory,"
+                    "  userAgent: navigator.userAgent,"
+                    "  platform: navigator.platform,"
+                    "  language: navigator.language,"
+                    "  timezone: Intl.DateTimeFormat().resolvedOptions().timeZone,"
+                    "  conn_effective: navigator.connection ? navigator.connection.effectiveType : null,"
+                    "  conn_downlink: navigator.connection ? navigator.connection.downlink : null,"
+                    "  conn_rtt: navigator.connection ? navigator.connection.rtt : null"
+                    "})",
+                ),
+                timeout=10.0,
             )
         except Exception as e:
             inst.probe_result = {
@@ -2760,7 +2794,12 @@ class BrowserManager:
         if recorder is not None:
             try:
                 async with inst.lock:
-                    recorder.dump(reason="stop")
+                    # Recorder dump writes JSONL synchronously and the
+                    # buffer can hold ~10K events (multi-MB). Off-load
+                    # to a worker thread so the manager lock isn't held
+                    # across blocking file I/O while every other agent
+                    # waits on _emit_metrics or lifecycle ops.
+                    await asyncio.to_thread(recorder.dump, reason="stop")
             except Exception as e:
                 logger.debug(
                     "Recorder dump failed for '%s': %s", agent_id, e,
@@ -3238,6 +3277,18 @@ class BrowserManager:
         include_frames: bool = True,
     ) -> dict:
         """Snapshot implementation.  Caller must hold ``inst.lock``."""
+        # Read BROWSER_SNAPSHOT_FORMAT exactly once at entry so a flag
+        # flip mid-call (operator settings hot-reload, agent override
+        # change racing the snapshot) cannot produce mixed v1/v2 output
+        # between the from_ref early-return and the main-path return.
+        from src.browser.flags import get_str as _flag_get_str
+        snapshot_fmt = (
+            _flag_get_str(
+                "BROWSER_SNAPSHOT_FORMAT", "v1", agent_id=agent_id,
+            )
+            .strip()
+            .lower()
+        )
         # Resolve the optional filter once so the inner _walk sees a
         # frozenset rather than re-deriving on every node.
         try:
@@ -3818,22 +3869,28 @@ class BrowserManager:
                                 disabled=handle.disabled,
                                 element_key=handle.element_key,
                             )
+                # NOTE: scoped snapshots replace ``inst.refs`` because
+                # the walker assigns fresh ``e0..eN`` ids on every walk
+                # and there is no separate namespace for scoped refs.
+                # That means a prior full snapshot's refs become
+                # unresolvable after a ``snapshot(from_ref=...)``;
+                # callers should re-snapshot the full tree before
+                # operating outside the scope, or queue all scope-local
+                # actions before the next full snapshot. Documenting
+                # the contract loudly here — the docstring's
+                # "informational, not anchors" framing is aspirational;
+                # making it true requires a per-call ref namespace,
+                # which is a wire-format change.
                 inst.refs = refs
                 # Cross-PR fix (#749 ↔ #750): the from_ref early-return
                 # must honor the same v2 dispatch as the main return
-                # path. Without this, scoped snapshots stay v1 even
-                # when ``BROWSER_SNAPSHOT_FORMAT=v2`` is set — agents
+                # path. Without this, scoped snapshots stayed v1 even
+                # when ``BROWSER_SNAPSHOT_FORMAT=v2`` was set — agents
                 # parsing on the ``# snapshot-v2`` first-line marker
-                # would silently see mixed formats.
-                from src.browser.flags import get_str as _flag_get_str
-                _scoped_fmt = (
-                    _flag_get_str(
-                        "BROWSER_SNAPSHOT_FORMAT", "v1", agent_id=agent_id,
-                    )
-                    .strip()
-                    .lower()
-                )
-                if _scoped_fmt == "v2":
+                # would see mixed formats. ``snapshot_fmt`` was captured
+                # at the top of ``_snapshot_impl`` so a flag flip mid-
+                # call can't desynchronize the two return paths.
+                if snapshot_fmt == "v2":
                     snapshot_text = _format_snapshot_v2(lines, entries)
                 else:
                     snapshot_text = (
@@ -4031,15 +4088,11 @@ class BrowserManager:
 
             inst.refs = refs
             # §7.2 — choose between v1 (per-element landmark suffix) and
-            # v2 (landmark headers + capped indent). Flag default is v1
-            # for the canary period, flips to v2 once parse rate ≥99%.
-            from src.browser.flags import get_str
-            fmt = (
-                get_str("BROWSER_SNAPSHOT_FORMAT", "v1", agent_id=agent_id)
-                .strip()
-                .lower()
-            )
-            if fmt == "v2":
+            # v2 (landmark headers + capped indent). Use the snapshot_fmt
+            # captured at the top of this method so a mid-call flag flip
+            # can't desynchronize this return path with the from_ref
+            # early-return above.
+            if snapshot_fmt == "v2":
                 snapshot_text = _format_snapshot_v2(lines, entries)
             else:
                 snapshot_text = (
@@ -4093,6 +4146,23 @@ class BrowserManager:
 
             if diff_from_last and scope in ("same", "modal_opened",
                                              "modal_closed", "frame_changed"):
+                # Subset snapshot (filter / from_ref / target_frame /
+                # include_frames=False) producing a diff against a full
+                # baseline reports every filtered-out element as
+                # ``removed`` — phantom signal that misleads the agent.
+                # PR 781 already excludes subset snapshots from updating
+                # the baseline; also short-circuit the diff computation
+                # to a full-snapshot return so the agent isn't given
+                # a confidently-wrong delta.
+                if is_subset_snapshot:
+                    return {
+                        "success": True,
+                        "data": {
+                            "snapshot": snapshot_text,
+                            "refs": response_refs,
+                            "scope": "navigation",
+                        },
+                    }
                 if previous_baseline is None:
                     # No prior baseline — fall through to the full-snapshot
                     # path so the agent still gets useful output. Effective
@@ -4346,25 +4416,41 @@ class BrowserManager:
         if _FRAME_ID_RE.match(token):
             raise RefStale("frame_detached", ref=None)
         page = inst.page
-        exact = None
-        substring = None
+        # Two-pass lookup. Pass 1 prefers DIRECT children of the main
+        # frame to localize substring matches; a deeply-nested malicious
+        # iframe sharing a URL substring with a legitimate top-level
+        # frame should not be picked over the legitimate one. Pass 2
+        # falls back to the full frame tree only when no top-level
+        # match was found.
+        #
         # When two frames share the same URL exactly, the FIRST matching
-        # one wins (page.frames iteration order). Callers needing to
-        # disambiguate duplicate-URL siblings should use the frame_id
-        # token from ``RefHandle.to_agent_dict()`` instead of a URL
-        # substring.
-        for f in page.frames:
-            if f is page.main_frame:
-                continue
-            try:
-                url = f.url or ""
-            except Exception:
-                continue
-            if url == token:
-                exact = f
-                break
-            if substring is None and token in url:
-                substring = f
+        # one wins (iteration order). Callers needing to disambiguate
+        # duplicate-URL siblings should use the frame_id token from
+        # ``RefHandle.to_agent_dict()`` instead of a URL substring.
+        def _scan(frames):
+            ex = None
+            sub = None
+            for f in frames:
+                if f is page.main_frame:
+                    continue
+                try:
+                    url = f.url or ""
+                except Exception:
+                    continue
+                if url == token:
+                    ex = f
+                    break
+                if sub is None and token in url:
+                    sub = f
+            return ex, sub
+
+        try:
+            top_children = list(page.main_frame.child_frames)
+        except Exception:
+            top_children = []
+        exact, substring = _scan(top_children)
+        if exact is None and substring is None:
+            exact, substring = _scan(page.frames)
         return exact if exact is not None else substring
 
     async def _human_click(self, page, locator, *, force: bool = False,
@@ -5242,12 +5328,16 @@ class BrowserManager:
                 await inst.page.mouse.click(x, y)
                 await asyncio.sleep(action_delay())
 
-                # DOM may have changed; drop the diff baseline for the
-                # active page so the next snapshot is a full re-walk
-                # rather than a stale-against-new diff.
-                active_pid = inst.last_active_page_id
-                if active_pid is not None:
-                    inst.last_snapshot.pop(active_pid, None)
+                # Don't drop the diff baseline here. Ref-click / type /
+                # scroll / fill_form mutate the DOM identically and
+                # don't drop their baselines either; dropping only on
+                # xy-click made diff behavior depend on which click
+                # entry-point the agent used. Keeping the baseline
+                # means the next ``snapshot(diff_from_last=True)`` will
+                # surface what THIS click changed — which is what the
+                # diff feature is for. The next snapshot rebuilds the
+                # ref-summary from scratch regardless, so there's no
+                # stale-data hazard.
 
                 # Post-click CAPTCHA re-detection — coordinate clicks
                 # frequently land on interstitial challenge widgets.
@@ -6901,7 +6991,8 @@ class BrowserManager:
         to a racy drain-then-check fallback.
         """
         if download_dir is None:
-            download_dir = os.environ.get("BROWSER_DOWNLOAD_DIR", "/tmp/downloads")
+            from src.browser.flags import get_str as _flag_str
+            download_dir = _flag_str("BROWSER_DOWNLOAD_DIR", "/tmp/downloads")
         if not self._download_streaming_available:
             return {
                 "success": False,

--- a/src/browser/service.py
+++ b/src/browser/service.py
@@ -200,8 +200,19 @@ _CF_AUTO_WAIT_SECONDS = 8.0
 # single container, and the cap is a soft anti-abuse signal not a billing
 # control (cost counter handles billing).
 _solve_rate_window: dict[str, deque[float]] = {}
-_solve_rate_lock: asyncio.Lock = asyncio.Lock()
+_solve_rate_lock: asyncio.Lock | None = None
+_solve_rate_lock_loop: asyncio.AbstractEventLoop | None = None
 _SOLVE_RATE_WINDOW_SECONDS = 3600.0
+
+
+def _get_solve_rate_lock() -> asyncio.Lock:
+    """Return a solve-rate lock bound to the active event loop."""
+    global _solve_rate_lock, _solve_rate_lock_loop
+    loop = asyncio.get_running_loop()
+    if _solve_rate_lock is None or _solve_rate_lock_loop is not loop:
+        _solve_rate_lock = asyncio.Lock()
+        _solve_rate_lock_loop = loop
+    return _solve_rate_lock
 
 
 async def _check_solve_rate(agent_id: str, limit_per_hour: int) -> bool:
@@ -216,7 +227,7 @@ async def _check_solve_rate(agent_id: str, limit_per_hour: int) -> bool:
     """
     if limit_per_hour <= 0:
         return False
-    async with _solve_rate_lock:
+    async with _get_solve_rate_lock():
         now = time.time()
         cutoff = now - _SOLVE_RATE_WINDOW_SECONDS
         bucket = _solve_rate_window.setdefault(agent_id, deque(maxlen=limit_per_hour * 4))
@@ -279,9 +290,20 @@ def _resolve_cost_cap(agent_id: str) -> int:
 # browser service container. The flush is driven from
 # :meth:`BrowserManager._emit_metrics` (already on a 60s tick); see
 # ``_drain_captcha_audit`` below.
-_captcha_audit_lock: asyncio.Lock = asyncio.Lock()
+_captcha_audit_lock: asyncio.Lock | None = None
+_captcha_audit_lock_loop: asyncio.AbstractEventLoop | None = None
 # {(agent_id, outcome, kind): {"count": int, "first_ts": float, "last_url": str}}
 _captcha_audit_buckets: dict[tuple[str, str, str], dict] = {}
+
+
+def _get_captcha_audit_lock() -> asyncio.Lock:
+    """Return a CAPTCHA audit lock bound to the active event loop."""
+    global _captcha_audit_lock, _captcha_audit_lock_loop
+    loop = asyncio.get_running_loop()
+    if _captcha_audit_lock is None or _captcha_audit_lock_loop is not loop:
+        _captcha_audit_lock = asyncio.Lock()
+        _captcha_audit_lock_loop = loop
+    return _captcha_audit_lock
 
 
 async def _record_captcha_audit_event(
@@ -305,7 +327,7 @@ async def _record_captcha_audit_event(
     ``captcha_gate`` payload as ``policy``. Last-write-wins within an
     aggregation window — same convention as ``last_url``.
     """
-    async with _captcha_audit_lock:
+    async with _get_captcha_audit_lock():
         key = (agent_id, outcome, kind)
         bucket = _captcha_audit_buckets.get(key)
         now = time.time()
@@ -331,7 +353,7 @@ async def _drain_captcha_audit() -> list[dict]:
     EventBus payload; the caller is responsible for actually emitting
     via the configured ``metrics_sink``.
     """
-    async with _captcha_audit_lock:
+    async with _get_captcha_audit_lock():
         if not _captcha_audit_buckets:
             return []
         # Snapshot copy under lock so the subsequent ``clear()`` doesn't
@@ -1874,7 +1896,8 @@ class BrowserManager:
         self.max_concurrent = max_concurrent
         self.idle_timeout = idle_timeout_minutes * 60
         self._instances: dict[str, CamoufoxInstance] = {}
-        self._lock = asyncio.Lock()
+        self._lock: asyncio.Lock | None = None
+        self._lock_loop: asyncio.AbstractEventLoop | None = None
         self._cleanup_task: asyncio.Task | None = None
         self._playwright = None
         self._user_focused_agent: str | None = None  # set by explicit focus() call
@@ -1908,6 +1931,20 @@ class BrowserManager:
                 "Playwright private artifact-stream API unavailable; "
                 "browser_download will return service_unavailable.",
             )
+
+    def _manager_lock(self) -> asyncio.Lock:
+        """Return the manager lock for the currently running event loop.
+
+        The browser manager is often constructed from synchronous FastAPI
+        setup/test code. Python 3.9 binds ``asyncio.Lock`` to the current
+        loop during construction, so creating it eagerly is fragile after
+        pytest or startup code has closed a previous default loop.
+        """
+        loop = asyncio.get_running_loop()
+        if self._lock is None or self._lock_loop is not loop:
+            self._lock = asyncio.Lock()
+            self._lock_loop = loop
+        return self._lock
 
     @staticmethod
     def _detect_download_streaming() -> bool:
@@ -2108,7 +2145,7 @@ class BrowserManager:
 
     async def _cleanup_idle(self):
         now = time.time()
-        async with self._lock:
+        async with self._manager_lock():
             to_stop = [
                 agent_id for agent_id, inst in self._instances.items()
                 if now - inst.last_activity > self.idle_timeout
@@ -2124,7 +2161,7 @@ class BrowserManager:
         display, so a watched browser is never killed by the idle cleanup.
         Returns the number of instances touched.
         """
-        async with self._lock:
+        async with self._manager_lock():
             for inst in self._instances.values():
                 inst.touch()
             return len(self._instances)
@@ -2141,7 +2178,7 @@ class BrowserManager:
         prevents background agent browser operations from stealing the
         VNC display away from what the user is watching.
         """
-        async with self._lock:
+        async with self._manager_lock():
             if not self._instances:
                 return
             # Prefer user's explicit focus over MRU
@@ -2175,7 +2212,7 @@ class BrowserManager:
         """Get existing browser or start a new one for the agent."""
         if not _AGENT_ID_RE.match(agent_id):
             raise ValueError(f"Invalid agent_id: {agent_id!r}")
-        async with self._lock:
+        async with self._manager_lock():
             if agent_id in self._instances:
                 inst = self._instances[agent_id]
                 inst.touch()
@@ -2576,11 +2613,11 @@ class BrowserManager:
 
     async def stop(self, agent_id: str) -> None:
         """Stop and clean up a specific agent's browser."""
-        async with self._lock:
+        async with self._manager_lock():
             await self._stop_instance(agent_id)
 
     async def _stop_instance(self, agent_id: str) -> None:
-        """Internal stop — caller must hold self._lock."""
+        """Internal stop — caller must hold ``self._manager_lock()``."""
         inst = self._instances.pop(agent_id, None)
         if inst is None:
             return
@@ -2652,7 +2689,7 @@ class BrowserManager:
             except (asyncio.CancelledError, Exception):
                 pass
             self._download_gc_task = None
-        async with self._lock:
+        async with self._manager_lock():
             for agent_id in list(self._instances.keys()):
                 await self._stop_instance(agent_id)
         if self._captcha_solver:
@@ -2686,7 +2723,7 @@ class BrowserManager:
         Operators polling /status see the current health signal without
         waiting for the next emit tick.
         """
-        async with self._lock:
+        async with self._manager_lock():
             inst = self._instances.get(agent_id)
             if not inst:
                 return {"running": False}
@@ -2711,7 +2748,7 @@ class BrowserManager:
 
     async def get_service_status(self) -> dict:
         """Get overall service health."""
-        async with self._lock:
+        async with self._manager_lock():
             return {
                 "healthy": True,
                 "active_browsers": len(self._instances),

--- a/src/browser/service.py
+++ b/src/browser/service.py
@@ -318,6 +318,24 @@ def _resolve_cost_cap(agent_id: str) -> int:
         return 0
 
 
+def _max_published_solve_cost_millicents(provider: str, kind: str) -> int | None:
+    """Return the max known price for ``(provider, kind)``.
+
+    A solve can end up proxy-aware or proxyless depending on solver-proxy
+    compatibility. For cost-cap reservations we reserve the maximum
+    published tier up front, then refund any difference after the provider
+    result reports the actual path used.
+    """
+    from src.browser import captcha_cost_counter as _cost
+
+    candidates = [
+        _cost.estimate_millicents(provider, kind, proxy_aware=False),
+        _cost.estimate_millicents(provider, kind, proxy_aware=True),
+    ]
+    priced = [c for c in candidates if c is not None]
+    return max(priced) if priced else None
+
+
 # ── §11.14 / §2.7 audit-log aggregator ────────────────────────────────────
 #
 # Operators need to see when the cost-cap / rate-limit / behavioral-skip
@@ -1586,9 +1604,9 @@ _JS_CAPTCHA_REDETECT_READBACK = """
 _CAPTCHA_REDETECT_SELECTORS: tuple[str, ...] = (
     'iframe[src*="recaptcha"]',
     'iframe[src*="hcaptcha"]',
+    '[class*="cf-turnstile"]',
     'iframe[src*="challenges.cloudflare.com"]',
     'iframe[src*="captcha"]',
-    '[class*="cf-turnstile"]',
     '[class*="captcha"]',
     '#captcha',
 )
@@ -1921,12 +1939,28 @@ class CamoufoxInstance:
         startup, pytest fixtures), so the lock is created on first access
         and refreshed if the active loop has changed since. Mirrors the
         ``_manager_lock`` / ``_get_*_lock`` helpers elsewhere in this module.
-        Must be accessed from inside a running event loop.
+        Synchronous inspection is supported; the first real async use pins
+        or refreshes the lock for that running loop.
         """
-        loop = asyncio.get_running_loop()
+        try:
+            loop = asyncio.get_running_loop()
+        except RuntimeError:
+            loop = None
         if self._lock is None:
+            if loop is None:
+                # Python 3.9's asyncio.Lock constructor still consults
+                # the thread's current event loop. A sync test/startup
+                # thread may not have one, so install a temporary default;
+                # first async use will rebuild the lock for the running loop.
+                try:
+                    loop = asyncio.get_event_loop()
+                except RuntimeError:
+                    loop = asyncio.new_event_loop()
+                    asyncio.set_event_loop(loop)
             self._lock = asyncio.Lock()
             self._lock_loop = loop
+        elif loop is None:
+            return self._lock
         elif self._lock_loop is None:
             # Lock was set via the setter outside a running loop; pin it
             # to the loop that's actually using it now without discarding.
@@ -2612,7 +2646,7 @@ class BrowserManager:
                     effective=_js_string(netinfo["effectiveType"]),
                     downlink=float(netinfo["downlink"]),
                     rtt=int(netinfo["rtt"]),
-                    save_data="false",
+                    save_data="true" if netinfo["saveData"] else "false",
                 ),
             )
         except Exception as e:
@@ -6130,8 +6164,12 @@ class BrowserManager:
             pre_url = ""
 
         # 1. Install. Failures are non-fatal — we still run the action.
+        # Do not run read-back unless install succeeded; a failed install
+        # could otherwise read stale probe state left by a prior action.
+        probe_installed = False
         try:
             await inst.page.evaluate(_JS_CAPTCHA_REDETECT_INSTALL)
+            probe_installed = True
         except Exception as e:
             logger.debug(
                 "captcha redetect: install failed for %s: %s",
@@ -6139,8 +6177,19 @@ class BrowserManager:
             )
 
         # 2. Run the action. Always propagate exceptions — the wrapper
-        # exists to add detection, not to swallow action failures.
-        result = await action_coro
+        # exists to add detection, not to swallow action failures. When
+        # the action fails after a successful install, best-effort tear
+        # down the observer so a later flag-disabled path cannot inherit
+        # stale probe state.
+        try:
+            result = await action_coro
+        except Exception:
+            if probe_installed:
+                with contextlib.suppress(Exception):
+                    await inst.page.evaluate(
+                        _JS_CAPTCHA_REDETECT_READBACK, [],
+                    )
+            raise
 
         # 3. Read back the captured added nodes.
         navigated = False
@@ -6152,7 +6201,7 @@ class BrowserManager:
             navigated = True
 
         hits: list[str] = []
-        if not navigated:
+        if probe_installed and not navigated:
             try:
                 hits = await inst.page.evaluate(
                     _JS_CAPTCHA_REDETECT_READBACK,
@@ -6177,7 +6226,10 @@ class BrowserManager:
         # invoke the full 7-selector locator probe more than
         # ``_REDETECT_MIN_INTERVAL_S`` per instance.
         now = time.monotonic()
-        if (now - inst._last_redetect_ts) < _REDETECT_MIN_INTERVAL_S:
+        if (
+            inst._last_redetect_ts > 0
+            and (now - inst._last_redetect_ts) < _REDETECT_MIN_INTERVAL_S
+        ):
             logger.debug(
                 "captcha redetect: rate-limited for %s (%.2fs since last)",
                 agent_id, now - inst._last_redetect_ts,
@@ -6226,17 +6278,16 @@ class BrowserManager:
         Order of operations:
 
           1. Fleet-wide kill switch.
-          2. Cost-cap gate (read against the agent's monthly bucket).
+          2. Cost-cap gate (reserve maximum published price under lock).
           3. Rate-limit gate (records a slot only on a real attempt — gates
              that short-circuit don't burn the per-hour budget).
-          4. Provider sanity when a cost cap requires priced accounting.
+          4. Provider/pricing sanity when a cost cap requires accounting.
           5. Solver HTTP call. ``solve()`` returns :class:`SolveResult`.
-          6. Cost accounting. Increments fire when ``result.token is not
-             None`` regardless of ``injection_succeeded`` — the provider
-             was paid the moment the token came back; injection failure
-             is our problem, not theirs. ``solver_attempted=False`` paths
-             (gates, behavioral, no-solver) skip accounting AND skip the
-             "no published rate" warning (it's not a billing event).
+          6. Cost accounting. The reservation is corrected/refunded when
+             ``result.token`` is known. Actual increments fire when a token
+             was retrieved regardless of ``injection_succeeded`` — the
+             provider was paid the moment the token came back; injection
+             failure is our problem, not theirs.
 
         Returns the :class:`SolveResult` so the caller (``_check_captcha``)
         can build the §11.13 envelope from the per-call data — no shared
@@ -6264,51 +6315,20 @@ class BrowserManager:
                 skipped="disabled",
             )
 
-        # Gate 1: cost-cap. Read-only — does not consume a rate-limit
-        # slot, so a cost-capped agent does NOT burn its hourly quota.
-        # ``cap_millicents`` and the bucket are both millicents
-        # (1/1000¢ = 1/100_000$); see :mod:`captcha_cost_counter`
-        # docstring for the unit invariant.  Order: cost → rate so a
-        # cost-blocked solve doesn't burn rate slots that should still
-        # be available when the cap resets.
+        provider = getattr(self._captcha_solver, "provider", "")
+        reserved_millicents = 0
+
+        # Gate 1: cost-cap. Reserve the maximum published price under the
+        # counter lock before the provider HTTP call. That makes concurrent
+        # solves for the same agent see in-flight spend and prevents each
+        # request from independently passing a read-only ``over_cap`` check.
+        # We refund or correct the reservation after the provider result is
+        # known. Order stays cost → rate so a cost-blocked solve doesn't
+        # burn rate slots that should still be available when the cap resets.
         cap_millicents = _resolve_cost_cap(agent_id)
         if cap_millicents > 0:
             from src.browser import captcha_cost_counter as _cost
-            if await _cost.over_cap(agent_id, cap_millicents):
-                await _record_captcha_audit_event(
-                    agent_id, "cost_cap", kind, page_url,
-                )
-                return SolveResult(
-                    token=None, injection_succeeded=False,
-                    used_proxy_aware=False, compat_rejected=False,
-                    skipped="cost_cap",
-                )
-
-        # Gate 2: rate-limit. ``_check_solve_rate`` consumes a slot only
-        # on the actual-attempt path (returning False); a True return
-        # means we are over the limit, no slot consumed.
-        rate_limit = _resolve_rate_limit(agent_id)
-        if await _check_solve_rate(agent_id, rate_limit):
-            await _record_captcha_audit_event(
-                agent_id, "rate_limited", kind, page_url,
-            )
-            return SolveResult(
-                token=None, injection_succeeded=False,
-                used_proxy_aware=False, compat_rejected=False,
-                skipped="rate_limited",
-            )
-
-        # Gate 3: provider sanity. When a cost cap is configured, we
-        # MUST be able to attribute every solve to a published rate so
-        # the cap math stays honest. A solver without a string ``provider``
-        # cannot be priced; in that case we fail closed (skip the solve)
-        # rather than let an untrackable charge slip past the cap.
-        # When no cap is configured the warning still fires so operators
-        # see the misconfiguration, but we proceed with the solve — keeps
-        # tests and custom solver integrations from breaking outright.
-        provider = getattr(self._captcha_solver, "provider", "")
-        if not isinstance(provider, str) or not provider:
-            if cap_millicents > 0:
+            if not isinstance(provider, str) or not provider:
                 logger.warning(
                     "captcha solve: solver has no string ``provider`` "
                     "attribute; cost cap is configured (cap=%s "
@@ -6326,6 +6346,63 @@ class BrowserManager:
                     used_proxy_aware=False, compat_rejected=False,
                     skipped="provider_missing",
                 )
+            reservation = _max_published_solve_cost_millicents(provider, kind)
+            if reservation is None:
+                logger.warning(
+                    "captcha solve: no published rate for provider=%s "
+                    "kind=%s while cost cap is configured (cap=%s "
+                    "millicents) — failing closed so an untracked charge "
+                    "cannot bypass the cap.",
+                    provider, kind, cap_millicents,
+                )
+                await _record_captcha_audit_event(
+                    agent_id, "price_missing", kind, page_url,
+                )
+                return SolveResult(
+                    token=None, injection_succeeded=False,
+                    used_proxy_aware=False, compat_rejected=False,
+                    skipped="price_missing",
+                )
+            allowed, _total = await _cost.check_and_charge(
+                agent_id, cap_millicents, reservation,
+            )
+            if not allowed:
+                await _record_captcha_audit_event(
+                    agent_id, "cost_cap", kind, page_url,
+                )
+                return SolveResult(
+                    token=None, injection_succeeded=False,
+                    used_proxy_aware=False, compat_rejected=False,
+                    skipped="cost_cap",
+                )
+            reserved_millicents = reservation
+
+        # Gate 2: rate-limit. ``_check_solve_rate`` consumes a slot only
+        # on the actual-attempt path (returning False); a True return
+        # means we are over the limit, no slot consumed.
+        rate_limit = _resolve_rate_limit(agent_id)
+        if await _check_solve_rate(agent_id, rate_limit):
+            if reserved_millicents:
+                from src.browser import captcha_cost_counter as _cost
+                await _cost.adjust_cost(agent_id, -reserved_millicents)
+            await _record_captcha_audit_event(
+                agent_id, "rate_limited", kind, page_url,
+            )
+            return SolveResult(
+                token=None, injection_succeeded=False,
+                used_proxy_aware=False, compat_rejected=False,
+                skipped="rate_limited",
+            )
+
+        # Gate 3: provider sanity. When a cost cap is configured, we
+        # MUST be able to attribute every solve to a published rate so
+        # the cap math stays honest. A solver without a string ``provider``
+        # cannot be priced; in that case we fail closed (skip the solve)
+        # rather than let an untrackable charge slip past the cap.
+        # When no cap is configured the warning still fires so operators
+        # see the misconfiguration, but we proceed with the solve — keeps
+        # tests and custom solver integrations from breaking outright.
+        if not isinstance(provider, str) or not provider:
             logger.warning(
                 "captcha solve: solver has no string ``provider`` "
                 "attribute; cost accounting will be SKIPPED for this "
@@ -6337,10 +6414,16 @@ class BrowserManager:
         # Run the actual solver. Any exception bubbles up so the caller can
         # build the appropriate ``timeout``/``rejected`` envelope; we don't
         # swallow them here because the envelope-mapping is caller-specific.
-        result = await self._captcha_solver.solve(
-            inst.page, sel, page_url,
-            agent_id=agent_id, kind=kind,
-        )
+        try:
+            result = await self._captcha_solver.solve(
+                inst.page, sel, page_url,
+                agent_id=agent_id, kind=kind,
+            )
+        except Exception:
+            if reserved_millicents:
+                from src.browser import captcha_cost_counter as _cost
+                await _cost.adjust_cost(agent_id, -reserved_millicents)
+            raise
 
         # Cost accounting fires on token retrieval, NOT on injection
         # success — the provider already charged for the token. Skip
@@ -6366,8 +6449,18 @@ class BrowserManager:
                         "(under-count > over-count)",
                         provider, kind, result.used_proxy_aware,
                     )
+                    if reserved_millicents:
+                        await _cost.adjust_cost(agent_id, -reserved_millicents)
                 else:
-                    await _cost.add_cost(agent_id, millicents)
+                    if reserved_millicents:
+                        await _cost.adjust_cost(
+                            agent_id, millicents - reserved_millicents,
+                        )
+                    else:
+                        await _cost.add_cost(agent_id, millicents)
+        elif reserved_millicents:
+            from src.browser import captcha_cost_counter as _cost
+            await _cost.adjust_cost(agent_id, -reserved_millicents)
         return result
 
     async def _check_captcha(self, inst: CamoufoxInstance) -> dict:
@@ -6830,6 +6923,16 @@ class BrowserManager:
                             # as ``no_solver`` but a distinct audit event was
                             # already emitted inside ``_metered_solve`` so
                             # operators can see the misconfiguration.
+                            return await _finalize(_captcha_envelope(
+                                kind=kind, solver_attempted=False,
+                                solver_outcome="no_solver",
+                                solver_confidence=_kind_confidence(kind),
+                                next_action="request_captcha_help",
+                            ))
+                        if result.skipped == "price_missing":
+                            # Published-rate sanity check (cap-on case).
+                            # Same agent-facing shape as no_solver; the
+                            # audit outcome distinguishes it for operators.
                             return await _finalize(_captcha_envelope(
                                 kind=kind, solver_attempted=False,
                                 solver_outcome="no_solver",

--- a/src/browser/service.py
+++ b/src/browser/service.py
@@ -1642,7 +1642,8 @@ class CamoufoxInstance:
         self.refs: dict[str, RefHandle] = {}
         self.dialog_active: bool = False  # True when snapshot scoped to a modal dialog
         self.dialog_detected: bool = False  # True when a modal was found (even if scoping failed)
-        self.lock = asyncio.Lock()  # serialize page operations per instance
+        self._lock: asyncio.Lock | None = None
+        self._lock_loop: asyncio.AbstractEventLoop | None = None
         self.x11_wid: int | None = None  # X11 window ID for targeted focus
         # P0.3: vestigial — the snapshot tree builder always uses the JS
         # walker now. Still consulted by ``navigate()`` for body-text
@@ -1741,6 +1742,34 @@ class CamoufoxInstance:
         # into another solve attempt (could otherwise pile up provider
         # cost and deadlock against the per-instance lock).
         self._captcha_solving: bool = False
+
+    @property
+    def lock(self) -> asyncio.Lock:
+        """Per-instance lock, bound lazily to the active event loop.
+
+        ``CamoufoxInstance`` is normally constructed inside the browser
+        service loop, but tests and setup helpers also construct it from
+        synchronous code. Python 3.9 raises when ``asyncio.Lock`` is created
+        after pytest has closed the default loop, so the lock is resolved on
+        access and refreshed if the active loop changes.
+        """
+        try:
+            loop = asyncio.get_running_loop()
+        except RuntimeError:
+            try:
+                loop = asyncio.get_event_loop()
+            except RuntimeError:
+                loop = asyncio.new_event_loop()
+                asyncio.set_event_loop(loop)
+        if self._lock is None or self._lock_loop is not loop:
+            self._lock = asyncio.Lock()
+            self._lock_loop = loop
+        return self._lock
+
+    @lock.setter
+    def lock(self, value: asyncio.Lock) -> None:
+        self._lock = value
+        self._lock_loop = getattr(value, "_loop", None)
 
     def _register_page(self, page) -> str:
         """Assign a stable UUID to a Page if not already registered.

--- a/src/browser/service.py
+++ b/src/browser/service.py
@@ -187,6 +187,36 @@ _RETRY_PREVIOUS_RECHECK_MS = 500
 _CF_AUTO_WAIT_SECONDS = 8.0
 
 
+# ── Filename sanitizer for downloads ──────────────────────────────────────
+# Browser-supplied ``Content-Disposition: filename="..."`` is attacker-
+# controlled. A response carrying ``filename="../../etc/foo"`` would
+# escape the configured download dir if joined naively. Strip path
+# components, collapse unsafe chars, and bound length. Mirrors the
+# mesh-side ``_sanitize_artifact_name`` so both sides of the transfer
+# apply the same rule (defense in depth).
+_DOWNLOAD_NAME_SAFE_RE = re.compile(r"[^\w.\-]+")
+
+
+def _sanitize_download_filename(suggested: str) -> str:
+    """Reduce a browser-supplied filename to a safe basename.
+
+    Returns ``"download.bin"`` when the result would be empty so the
+    caller never sees a path-traversal-shaped string land on disk.
+    """
+    name = (suggested or "").strip()
+    if "/" in name or "\\" in name:
+        name = name.replace("\\", "/").rsplit("/", 1)[-1]
+    name = _DOWNLOAD_NAME_SAFE_RE.sub("_", name)
+    name = name.strip("._-")
+    if len(name) > 180:
+        name = name[:180].strip("._-")
+    if not name:
+        name = "download.bin"
+    if len(name) < 2:
+        name = name + "_"
+    return name
+
+
 # ── §11.14 per-agent solve rate limiter ───────────────────────────────────
 # Module-level dict guarded by an asyncio.Lock. Each agent gets a deque of
 # unix timestamps for solve attempts in the last hour; entries older than
@@ -230,7 +260,17 @@ async def _check_solve_rate(agent_id: str, limit_per_hour: int) -> bool:
     async with _get_solve_rate_lock():
         now = time.time()
         cutoff = now - _SOLVE_RATE_WINDOW_SECONDS
-        bucket = _solve_rate_window.setdefault(agent_id, deque(maxlen=limit_per_hour * 4))
+        # ``deque(maxlen=N)`` is fixed at construction time. If the
+        # operator raises ``CAPTCHA_RATE_LIMIT_PER_HOUR`` mid-run, the
+        # existing bucket would silently drop new timestamps once it
+        # reached its old maxlen — under-reporting the rate and letting
+        # a solve through that should have been blocked. Recreate the
+        # bucket whenever the configured limit grows.
+        target_maxlen = limit_per_hour * 4
+        bucket = _solve_rate_window.get(agent_id)
+        if bucket is None or (bucket.maxlen or 0) < target_maxlen:
+            bucket = deque(bucket or (), maxlen=target_maxlen)
+            _solve_rate_window[agent_id] = bucket
         while bucket and bucket[0] < cutoff:
             bucket.popleft()
         if len(bucket) >= limit_per_hour:
@@ -1539,8 +1579,19 @@ def _compute_snapshot_diff(
     removed_keys = prev_keys - curr_keys
     common_keys = curr_keys & prev_keys
 
+    # Sort by walk-emission order using the numeric suffix of ``ref_id``.
+    # Lexicographic sort would order "e10" < "e2" — diff lists then look
+    # randomized as soon as a page emits ≥10 refs (most non-trivial
+    # pages). ``ref_id`` is always shaped ``e<int>``; fall back to lex
+    # sort defensively if the prefix ever shifts.
+    def _ref_sort_key(key: str) -> tuple:
+        rid = current[key].get("ref_id", "")
+        if isinstance(rid, str) and rid.startswith("e") and rid[1:].isdigit():
+            return (0, int(rid[1:]))
+        return (1, rid)
+
     added: list[dict] = []
-    for k in sorted(added_keys, key=lambda key: current[key]["ref_id"]):
+    for k in sorted(added_keys, key=_ref_sort_key):
         s = current[k]
         added.append({
             "ref": s["ref_id"],
@@ -2684,6 +2735,17 @@ class BrowserManager:
             )
         if self._user_focused_agent == agent_id:
             self._user_focused_agent = None
+        # Drop the agent's solve-rate bucket so a long-running deployment
+        # with rotating agent ids doesn't accumulate dead entries forever.
+        # Acquired separately because the rate-limit lock and manager
+        # lock are independent; reordering would risk a future deadlock.
+        try:
+            async with _get_solve_rate_lock():
+                _solve_rate_window.pop(agent_id, None)
+        except RuntimeError:
+            # Outside a running loop (shouldn't happen — _stop_instance
+            # is only called from async paths), best-effort.
+            _solve_rate_window.pop(agent_id, None)
         jitter = getattr(inst, '_jitter_task', None)
         if jitter:
             jitter.cancel()
@@ -3946,9 +4008,15 @@ class BrowserManager:
             # `_locator_from_ref` queries are bounded to the dialog subtree.
             # (Refs emitted before the modal branch don't have scope_root;
             # set it now that we know the final dialog_active state.)
+            #
+            # Skip iframe-scoped refs: the modal lives in the main frame
+            # (see _descend_frames; iframes aren't scoped by `dialog_active`),
+            # so applying the modal selector to a Frame in `_locator_from_ref`
+            # would query the iframe's document for a selector that lives in
+            # the parent — silent click failure.
             if inst.dialog_active:
                 for rid, handle in refs.items():
-                    if handle.scope_root is None:
+                    if handle.scope_root is None and handle.frame_id is None:
                         refs[rid] = RefHandle(
                             page_id=handle.page_id,
                             frame_id=handle.frame_id,
@@ -5136,10 +5204,19 @@ class BrowserManager:
                     )
                 masked_by = hit.get("masked_by") if isinstance(hit, dict) else None
                 if masked_by:
+                    # Redact name + role: ``elementFromPoint`` returns
+                    # raw DOM text (innerText slice). Snapshot output is
+                    # redacted; click_xy must honor the same boundary so
+                    # an agent doesn't get a privileged channel to read
+                    # credentials that leaked into element text. Role is
+                    # an attribute the page can set freely; bound length
+                    # so a malicious page can't bloat responses.
                     actual = {
-                        "tag": hit.get("tag", ""),
-                        "role": hit.get("role"),
-                        "name": hit.get("name", ""),
+                        "tag": hit.get("tag", "")[:64],
+                        "role": (hit.get("role") or "")[:64] or None,
+                        "name": self.redactor.redact(
+                            agent_id, hit.get("name", "") or "",
+                        )[:200],
                     }
                     return {
                         "success": False,
@@ -5189,9 +5266,11 @@ class BrowserManager:
                     "data": {
                         "clicked_at": {"x": x, "y": y},
                         "actual_element": {
-                            "tag": hit.get("tag", ""),
-                            "role": hit.get("role"),
-                            "name": hit.get("name", ""),
+                            "tag": hit.get("tag", "")[:64],
+                            "role": (hit.get("role") or "")[:64] or None,
+                            "name": self.redactor.redact(
+                                agent_id, hit.get("name", "") or "",
+                            )[:200],
                         },
                     },
                 }
@@ -6717,6 +6796,41 @@ class BrowserManager:
 
         Returns ``{success, data: {uploaded: [path, …]}}`` or an error envelope.
         """
+        # Defense in depth: confine ``local_paths`` to the configured
+        # upload-receive directory BEFORE entering the body of this
+        # method. The mesh-side ``upload_apply`` only forwards paths
+        # returned by ``_stage_upload`` (which writes under
+        # ``OPENLEGION_UPLOAD_RECV_DIR``), but a buggy or compromised
+        # mesh caller carrying the bearer token could otherwise smuggle
+        # arbitrary on-disk paths here — both as a read-via-chooser
+        # exfil vector AND as an unconditional unlink of any reachable
+        # file via the cleanup ``finally`` at the end of this method.
+        # Validating BEFORE the try/finally ensures a rejected path is
+        # never reached by the cleanup unlink.
+        from src.browser.flags import get_str as _flag_str
+        recv_dir = Path(
+            _flag_str("OPENLEGION_UPLOAD_RECV_DIR", "/tmp/upload-recv"),
+        ).resolve()
+        try:
+            recv_dir.mkdir(parents=True, exist_ok=True)
+        except OSError:
+            pass
+        for p in local_paths:
+            try:
+                resolved = Path(p).resolve()
+            except (OSError, RuntimeError) as e:
+                return {
+                    "success": False,
+                    "error": f"Upload path not resolvable: {e}",
+                }
+            try:
+                resolved.relative_to(recv_dir)
+            except ValueError:
+                return {
+                    "success": False,
+                    "error": "Upload path outside receive dir",
+                }
+
         inst = await self.get_or_start(agent_id)
         inst.touch()
         async with inst.lock:
@@ -6833,7 +6947,15 @@ class BrowserManager:
                             inst.page, locator, timeout=timeout_ms,
                         )
                 download = await info.value
-                suggested = download.suggested_filename or "download.bin"
+                # Sanitize before joining — Content-Disposition is
+                # attacker-controlled and a ``../../`` escape would
+                # write outside ``download_dir`` (which is writable in
+                # the browser container). The leading nonce neutralizes
+                # leading-dot and absolute-path tricks but path
+                # separators inside ``suggested`` would still escape.
+                suggested = _sanitize_download_filename(
+                    download.suggested_filename or "download.bin",
+                )
                 nonce = uuid.uuid4().hex[:12]
                 dest = Path(download_dir) / f"{nonce}-{suggested}"
 
@@ -6977,7 +7099,14 @@ class BrowserManager:
             first_locator = None
             for ref_id, handle in inst.refs.items():
                 name = handle.name or ""
-                if not name or needle not in name.casefold():
+                # Match against the REDACTED accessible name so an
+                # agent-supplied query can't probe credentials that
+                # leaked into ``aria-label`` / tooltip text. Snapshots
+                # already redact what they emit; ``find_text`` must
+                # honor the same boundary or it becomes a confirm/deny
+                # oracle for known secret prefixes.
+                redacted_name = self.redactor.redact(agent_id, name)
+                if not name or needle not in redacted_name.casefold():
                     continue
                 if len(matches) >= 50:
                     truncated = True
@@ -7003,7 +7132,6 @@ class BrowserManager:
                                 bx + bw > 0 and by + bh > 0
                                 and bx < vw and by < vh
                             )
-                redacted_name = self.redactor.redact(agent_id, name)
                 matches.append({
                     "ref": ref_id,
                     "text": sanitize_for_prompt(redacted_name)[:200],

--- a/src/browser/service.py
+++ b/src/browser/service.py
@@ -2635,34 +2635,28 @@ class BrowserManager:
         pages = context.pages
         page = pages[0] if pages else await context.new_page()
 
-        # §6.6 ``navigator.connection`` fallback. We pass the spoof
-        # values via Camoufox's ``config`` dict above, but it's not
-        # documented whether Camoufox honours those keys (Firefox itself
-        # doesn't natively expose NetworkInformation). Install an
-        # ``add_init_script`` that defines ``navigator.connection`` if
-        # the property is missing — runs in every document context
-        # before page scripts. ``Object.defineProperty`` on
-        # ``Navigator.prototype`` with ``configurable: true`` matches
-        # what real Chromium-shaped Firefox extension polyfills do.
-        try:
-            from src.browser.stealth import pick_network_info
-            netinfo = pick_network_info(agent_id)
-            await context.add_init_script(
-                _NAV_CONNECTION_INIT_SCRIPT.format(
-                    effective=_js_string(netinfo["effectiveType"]),
-                    downlink=float(netinfo["downlink"]),
-                    rtt=int(netinfo["rtt"]),
-                    save_data="true" if netinfo["saveData"] else "false",
-                ),
-            )
-        except Exception as e:
-            # Non-fatal — Camoufox may already have NetworkInformation
-            # support, and the §6.3 probe will catch the gap if neither
-            # path lands.
-            logger.debug(
-                "navigator.connection init-script failed for '%s': %s",
-                agent_id, e,
-            )
+        # §6.6 ``navigator.connection`` REMOVED on the Firefox UA path.
+        #
+        # Real Firefox does NOT expose ``navigator.connection`` (the
+        # NetworkInformation API is unimplemented as of FF 138; Chromium
+        # is the only major engine shipping it on by default). Injecting
+        # a synthetic ``navigator.connection`` on a UA stamped
+        # ``Firefox/`` was itself a strong cluster signal: zero real
+        # Firefox users in the population have the API, so any Firefox-
+        # shaped client that DOES expose it is by definition spoofed.
+        # Fingerprint.com / Creep.js / DataDome key directly on this
+        # inconsistency.
+        #
+        # ``_assert_firefox_ua`` enforces a Firefox UA at startup, so
+        # the right behavior is to MATCH real-Firefox population —
+        # leave the API absent. The §6.6 plan predates this analysis;
+        # the navigator probe below was updated to stop treating a
+        # missing ``navigator.connection`` as a mismatch.
+        #
+        # If a future build moves to a Chromium-shaped UA, the spoof
+        # path can be restored (gated on UA family); the
+        # ``_NAV_CONNECTION_INIT_SCRIPT`` template is retained for that
+        # purpose.
 
         inst = CamoufoxInstance(agent_id, browser, context, page)
 
@@ -2721,10 +2715,12 @@ class BrowserManager:
           * ``navigator.platform`` doesn't match our configured ``os`` hint
           * ``navigator.userAgent`` lacks ``Firefox/`` (would mean §6.4
             tripwire was bypassed somehow at runtime)
-          * ``navigator.connection.*`` is undefined (would mean §6.6
-            override silently failed inside Camoufox)
 
         Per the plan: "WARNING if webdriver !== false or mismatch."
+
+        Note: ``navigator.connection`` is intentionally NOT checked.
+        Real Firefox doesn't expose NetworkInformation; we read the
+        signal field for diagnostics but do not flag its absence.
         """
         os_hint = os.environ.get("BROWSER_OS", "windows").lower()
         expected_platform = {
@@ -2820,13 +2816,10 @@ class BrowserManager:
         ua = signals.get("userAgent", "")
         if ua and "Firefox/" not in ua:
             mismatches.append(f"userAgent lacks 'Firefox/': {ua!r}")
-        # navigator.connection should be populated by §6.6 spoof. ``null``
-        # means the override silently failed.
-        if signals.get("conn_effective") is None:
-            mismatches.append(
-                "navigator.connection.effectiveType is null "
-                "(§6.6 override may have failed)",
-            )
+        # ``navigator.connection`` is intentionally absent on the Firefox
+        # UA path (matches real Firefox population — see comment near
+        # ``_NAV_CONNECTION_INIT_SCRIPT``). Read for diagnostics but do
+        # not flag its absence as a mismatch.
 
         ok = not mismatches
         inst.probe_result = {
@@ -3241,6 +3234,18 @@ class BrowserManager:
 
             inst.dialog_active = False
             inst.dialog_detected = False
+            # Same-tab navigation invalidates every ref captured against
+            # the prior document — the underlying elements are gone.
+            # Without clearing, a later ``click(ref="e3")`` would call
+            # ``get_by_role(role, name=name).nth(occ)`` against the NEW
+            # page; any element with matching role+name+occurrence on
+            # the new page gets silently clicked, RefStale never fires.
+            # ``open_tab`` and ``switch_tab`` already do this; navigate
+            # missed it. Also drop the diff baseline so the next snapshot
+            # is reported as ``scope="navigation"`` rather than diffed
+            # against the stale prior page.
+            inst.refs = {}
+            inst.last_snapshot.clear()
             if wait_ms > 0:
                 await asyncio.sleep(wait_ms / 1000 + navigation_jitter())
             try:
@@ -3575,7 +3580,20 @@ class BrowserManager:
                     inst, root=scoped_root_handle,
                 )
             if not tree:
-                return {"success": True, "data": {"snapshot": "(empty page)", "refs": {}}}
+                # Honor ``BROWSER_SNAPSHOT_FORMAT`` for the empty-tree
+                # short-circuit too. Pre-fix this returned a bare string
+                # regardless of format, so agents parsing on the
+                # ``# snapshot-v2`` first-line marker classified empty
+                # pages as v1 and could attempt v1-shaped re-parsing.
+                empty_text = (
+                    "# snapshot-v2\n(empty page)"
+                    if snapshot_fmt == "v2"
+                    else "(empty page)"
+                )
+                return {
+                    "success": True,
+                    "data": {"snapshot": empty_text, "refs": {}},
+                }
 
             lines: list[str] = []
             refs: dict[str, RefHandle] = {}
@@ -4064,7 +4082,20 @@ class BrowserManager:
             # When a modal dialog is open, scope to only dialog elements
             # so agents don't see/click elements behind the overlay
             # (e.g. X's sidebar "Post" button behind the compose modal).
-            modal_els = await inst.page.query_selector_all(_MODAL_SELECTOR)
+            #
+            # Skip the modal probe when ``target_frame is not None`` —
+            # the iframe-scoped snapshot reports refs from the iframe's
+            # own document, but the main-page modal probe runs against
+            # ``inst.page``. Pre-fix, a main-page-modal-open page that
+            # also took a ``frame=`` snapshot would tag every iframe-
+            # scoped ref with ``scope_root=_MODAL_SELECTOR``; the
+            # resolver would then run ``frame.locator(scope_root)``
+            # against the iframe's document and silently miss the
+            # modal that lives in the parent.
+            if target_frame is not None:
+                modal_els = []
+            else:
+                modal_els = await inst.page.query_selector_all(_MODAL_SELECTOR)
             vp = inst.page.viewport_size
             visible_modals = []
             for el in modal_els:
@@ -4902,6 +4933,44 @@ class BrowserManager:
             ),
         )
 
+    async def _x11_click_xy(
+        self, inst: CamoufoxInstance, x: float, y: float,
+    ) -> None:
+        """Click at viewport coords (x, y) via xdotool — trusted-event path.
+
+        ``click_xy`` previously dispatched ``page.mouse.click(x, y)``
+        directly, which generates a CDP-injected click with
+        ``isTrusted=false``. Bot-detection listeners check the trust
+        flag and an agent that primarily uses ref-clicks (X11) but
+        falls back to xy-clicks (CDP) emits a single
+        ``isTrusted=false`` event in an otherwise all-trusted session
+        — a sharp anti-bot cluster signal. Route through the same
+        Bezier + dwell shape ``_x11_click`` uses so the trusted-event
+        property holds across click-by-coords too.
+        """
+        wid = inst.x11_wid
+        if not wid:
+            raise RuntimeError("No X11 window ID — cannot use xdotool click")
+        await self._x11_move_to(inst, int(x), int(y))
+        wid_s = str(wid)
+        loop = asyncio.get_running_loop()
+        await asyncio.sleep(pre_click_settle())
+        await loop.run_in_executor(
+            None,
+            lambda: subprocess.run(
+                ["xdotool", "mousedown", "--clearmodifiers", "--window", wid_s, "1"],
+                capture_output=True, timeout=3,
+            ),
+        )
+        await asyncio.sleep(click_dwell())
+        await loop.run_in_executor(
+            None,
+            lambda: subprocess.run(
+                ["xdotool", "mouseup", "--clearmodifiers", "--window", wid_s, "1"],
+                capture_output=True, timeout=3,
+            ),
+        )
+
     async def _x11_hover(self, inst: CamoufoxInstance, locator) -> None:
         """Move mouse to element via xdotool for isTrusted=true mousemove events."""
         await self._x11_ensure_in_viewport(inst, locator)
@@ -5496,8 +5565,26 @@ class BrowserManager:
                         },
                     }
 
-                # Clean hit — dispatch the click.
-                await inst.page.mouse.click(x, y)
+                # Clean hit — dispatch the click. Prefer X11/xdotool
+                # (real kernel InputEvents → ``isTrusted=true``) when
+                # the agent has an X11 window registered; fall back to
+                # CDP only when X11 isn't usable. Pre-fix this used
+                # ``page.mouse.click`` unconditionally — a single such
+                # CDP click in an otherwise-X11 session emits an
+                # ``isTrusted=false`` event that anti-bot listeners
+                # cluster on.
+                if isinstance(inst.x11_wid, int) and self._is_x11_site(inst):
+                    try:
+                        await self._x11_click_xy(inst, x, y)
+                    except Exception as e:
+                        logger.warning(
+                            "X11 xy-click failed for '%s' at (%s, %s); "
+                            "falling back to CDP: %s",
+                            agent_id, x, y, e,
+                        )
+                        await inst.page.mouse.click(x, y)
+                else:
+                    await inst.page.mouse.click(x, y)
                 await asyncio.sleep(action_delay())
 
                 # Don't drop the diff baseline here. Ref-click / type /
@@ -5945,10 +6032,12 @@ class BrowserManager:
         """Type text with minimal delay — still fires real key events.
 
         Uses keyboard.press(char) for isTrusted=true events so React/Lexical
-        state updates work, but with a fixed 8 ms inter-key delay (no
-        variance, no think pauses).  Suitable for search queries, URLs,
-        and non-sensitive form fields where human-realistic timing is
-        unnecessary.
+        state updates work. Inter-key delay is a small Gaussian (μ≈8 ms,
+        σ≈3 ms, clamped non-negative) rather than a constant — perfectly
+        periodic 8 ms keystrokes are FFT-detectable and zero real human
+        types with that exact cadence. Suitable for search queries, URLs,
+        and non-sensitive form fields where full human-realistic timing
+        is unnecessary but a flat fingerprint is unwanted.
         """
         for char in text:
             if char == "\n":
@@ -5960,7 +6049,9 @@ class BrowserManager:
                     await page.keyboard.press(char)
                 except Exception:
                     await page.keyboard.type(char)
-            await asyncio.sleep(0.008)
+            # Gaussian jitter ~ N(8 ms, 3 ms), floor at 1 ms so we
+            # never schedule a zero-or-negative sleep.
+            await asyncio.sleep(max(0.001, random.gauss(0.008, 0.003)))
 
     async def scroll(self, agent_id: str, direction: str = "down",
                      amount: int = 0, ref: str | None = None) -> dict:
@@ -6383,91 +6474,111 @@ class BrowserManager:
                 )
             reserved_millicents = reservation
 
-        # Gate 2: rate-limit. ``_check_solve_rate`` consumes a slot only
-        # on the actual-attempt path (returning False); a True return
-        # means we are over the limit, no slot consumed.
-        rate_limit = _resolve_rate_limit(agent_id)
-        if await _check_solve_rate(agent_id, rate_limit):
-            if reserved_millicents:
-                from src.browser import captcha_cost_counter as _cost
-                await _cost.adjust_cost(agent_id, -reserved_millicents)
-            await _record_captcha_audit_event(
-                agent_id, "rate_limited", kind, page_url,
-            )
-            return SolveResult(
-                token=None, injection_succeeded=False,
-                used_proxy_aware=False, compat_rejected=False,
-                skipped="rate_limited",
-            )
-
-        # Gate 3: provider sanity. When a cost cap is configured, we
-        # MUST be able to attribute every solve to a published rate so
-        # the cap math stays honest. A solver without a string ``provider``
-        # cannot be priced; in that case we fail closed (skip the solve)
-        # rather than let an untrackable charge slip past the cap.
-        # When no cap is configured the warning still fires so operators
-        # see the misconfiguration, but we proceed with the solve — keeps
-        # tests and custom solver integrations from breaking outright.
-        if not isinstance(provider, str) or not provider:
-            logger.warning(
-                "captcha solve: solver has no string ``provider`` "
-                "attribute; cost accounting will be SKIPPED for this "
-                "solve (cap not configured so the warning is "
-                "informational). Set solver.provider to a known name "
-                "to enable cost tracking.",
-            )
-
-        # Run the actual solver. Any exception bubbles up so the caller can
-        # build the appropriate ``timeout``/``rejected`` envelope; we don't
-        # swallow them here because the envelope-mapping is caller-specific.
+        # All paths past the cost-cap gate must reconcile the
+        # reservation. Wrap the rest of the function in try/finally with
+        # a ``reservation_settled`` flag so that ANY exit (return,
+        # raise, ``CancelledError``) cleans up the reserved spend rather
+        # than leaving it stuck on the agent's bucket. Pre-fix, an
+        # ``asyncio.Task.cancel`` mid-solve (caller timed out, browser
+        # restart, container shutdown) would leave the reservation
+        # permanently committed even though no token was ever received.
+        from src.browser import captcha_cost_counter as _cost
+        reservation_settled = False
         try:
-            result = await self._captcha_solver.solve(
-                inst.page, sel, page_url,
-                agent_id=agent_id, kind=kind,
-            )
-        except Exception:
-            if reserved_millicents:
-                from src.browser import captcha_cost_counter as _cost
-                await _cost.adjust_cost(agent_id, -reserved_millicents)
-            raise
-
-        # Cost accounting fires on token retrieval, NOT on injection
-        # success — the provider already charged for the token. Skip
-        # accounting when no token came back (gates / sitekey-fail /
-        # provider-reject / breaker / unreachable).
-        if result.token is not None:
-            from src.browser import captcha_cost_counter as _cost
-            # Defensive: solver mocks in tests sometimes leave provider
-            # as a MagicMock auto-spec child; only proceed when we have
-            # an actual string we can pass to ``estimate_millicents``.
-            # The provider-missing case was warned above; here we just
-            # skip the increment silently.
-            if isinstance(provider, str) and provider:
-                millicents = _cost.estimate_millicents(
-                    provider, kind,
-                    proxy_aware=result.used_proxy_aware,
+            # Gate 2: rate-limit. ``_check_solve_rate`` consumes a slot
+            # only on the actual-attempt path (returning False); a True
+            # return means we are over the limit, no slot consumed.
+            rate_limit = _resolve_rate_limit(agent_id)
+            if await _check_solve_rate(agent_id, rate_limit):
+                await _record_captcha_audit_event(
+                    agent_id, "rate_limited", kind, page_url,
                 )
-                if millicents is None:
-                    logger.warning(
-                        "captcha solve: no published rate for "
-                        "provider=%s kind=%s proxy_aware=%s — "
-                        "skipping cost increment "
-                        "(under-count > over-count)",
-                        provider, kind, result.used_proxy_aware,
+                return SolveResult(
+                    token=None, injection_succeeded=False,
+                    used_proxy_aware=False, compat_rejected=False,
+                    skipped="rate_limited",
+                )
+
+            # Gate 3: provider sanity. When a cost cap is configured, we
+            # MUST be able to attribute every solve to a published rate
+            # so the cap math stays honest. A solver without a string
+            # ``provider`` cannot be priced; in that case we fail closed
+            # (skip the solve) rather than let an untrackable charge
+            # slip past the cap. When no cap is configured the warning
+            # still fires so operators see the misconfiguration, but we
+            # proceed with the solve — keeps tests and custom solver
+            # integrations from breaking outright.
+            if not isinstance(provider, str) or not provider:
+                logger.warning(
+                    "captcha solve: solver has no string ``provider`` "
+                    "attribute; cost accounting will be SKIPPED for "
+                    "this solve (cap not configured so the warning is "
+                    "informational). Set solver.provider to a known "
+                    "name to enable cost tracking.",
+                )
+
+            # Run the actual solver. Any exception bubbles up so the
+            # caller can build the appropriate ``timeout``/``rejected``
+            # envelope; we don't swallow them here because the
+            # envelope-mapping is caller-specific. Audit the
+            # exception-during-solve case so operator dashboards see
+            # the storm before the breaker trips.
+            try:
+                result = await self._captcha_solver.solve(
+                    inst.page, sel, page_url,
+                    agent_id=agent_id, kind=kind,
+                )
+            except Exception:
+                await _record_captcha_audit_event(
+                    agent_id, "solver_exception", kind, page_url,
+                )
+                raise
+
+            # Cost accounting fires on token retrieval, NOT on
+            # injection success — the provider already charged for the
+            # token. Skip accounting when no token came back (gates /
+            # sitekey-fail / provider-reject / breaker / unreachable).
+            if result.token is not None:
+                # Defensive: solver mocks in tests sometimes leave
+                # ``provider`` as a MagicMock auto-spec child; only
+                # proceed when we have an actual string we can pass to
+                # ``estimate_millicents``. The provider-missing case
+                # was warned above; here we just skip the increment
+                # silently and let the finally-refund clean up the
+                # reservation.
+                if isinstance(provider, str) and provider:
+                    millicents = _cost.estimate_millicents(
+                        provider, kind,
+                        proxy_aware=result.used_proxy_aware,
                     )
-                    if reserved_millicents:
-                        await _cost.adjust_cost(agent_id, -reserved_millicents)
-                else:
-                    if reserved_millicents:
-                        await _cost.adjust_cost(
-                            agent_id, millicents - reserved_millicents,
+                    if millicents is None:
+                        logger.warning(
+                            "captcha solve: no published rate for "
+                            "provider=%s kind=%s proxy_aware=%s — "
+                            "skipping cost increment "
+                            "(under-count > over-count)",
+                            provider, kind, result.used_proxy_aware,
                         )
                     else:
-                        await _cost.add_cost(agent_id, millicents)
-        elif reserved_millicents:
-            from src.browser import captcha_cost_counter as _cost
-            await _cost.adjust_cost(agent_id, -reserved_millicents)
-        return result
+                        if reserved_millicents:
+                            await _cost.adjust_cost(
+                                agent_id,
+                                millicents - reserved_millicents,
+                            )
+                        else:
+                            await _cost.add_cost(agent_id, millicents)
+                        reservation_settled = True
+            return result
+        finally:
+            # If we got here without committing the reservation (token-
+            # less return, gate-trip return, raise, cancellation),
+            # refund. ``adjust_cost`` is clamped at zero so a refund
+            # that races with another adjustment can't drive negative.
+            if reserved_millicents and not reservation_settled:
+                with contextlib.suppress(Exception):
+                    await _cost.adjust_cost(
+                        agent_id, -reserved_millicents,
+                    )
 
     async def _check_captcha(self, inst: CamoufoxInstance) -> dict:
         """Check for CAPTCHA elements and attempt auto-solve if configured.

--- a/src/browser/service.py
+++ b/src/browser/service.py
@@ -1747,29 +1747,38 @@ class CamoufoxInstance:
     def lock(self) -> asyncio.Lock:
         """Per-instance lock, bound lazily to the active event loop.
 
-        ``CamoufoxInstance`` is normally constructed inside the browser
-        service loop, but tests and setup helpers also construct it from
-        synchronous code. Python 3.9 raises when ``asyncio.Lock`` is created
-        after pytest has closed the default loop, so the lock is resolved on
-        access and refreshed if the active loop changes.
+        Construction may happen outside any running loop (sync FastAPI
+        startup, pytest fixtures), so the lock is created on first access
+        and refreshed if the active loop has changed since. Mirrors the
+        ``_manager_lock`` / ``_get_*_lock`` helpers elsewhere in this module.
+        Must be accessed from inside a running event loop.
         """
-        try:
-            loop = asyncio.get_running_loop()
-        except RuntimeError:
-            try:
-                loop = asyncio.get_event_loop()
-            except RuntimeError:
-                loop = asyncio.new_event_loop()
-                asyncio.set_event_loop(loop)
-        if self._lock is None or self._lock_loop is not loop:
+        loop = asyncio.get_running_loop()
+        if self._lock is None:
+            self._lock = asyncio.Lock()
+            self._lock_loop = loop
+        elif self._lock_loop is None:
+            # Lock was set via the setter outside a running loop; pin it
+            # to the loop that's actually using it now without discarding.
+            self._lock_loop = loop
+        elif self._lock_loop is not loop:
+            # Loop changed between uses (typically pytest spinning up a
+            # fresh loop per test). Rebuild to bind to the new loop.
             self._lock = asyncio.Lock()
             self._lock_loop = loop
         return self._lock
 
     @lock.setter
     def lock(self, value: asyncio.Lock) -> None:
+        # Tests occasionally swap in a custom lock (``TrackingLock`` /
+        # ``asyncio.Lock()``). Honor the swap; the property getter pins
+        # the loop on first use so the supplied lock is not silently
+        # replaced.
         self._lock = value
-        self._lock_loop = getattr(value, "_loop", None)
+        try:
+            self._lock_loop = asyncio.get_running_loop()
+        except RuntimeError:
+            self._lock_loop = None
 
     def _register_page(self, page) -> str:
         """Assign a stable UUID to a Page if not already registered.
@@ -4089,14 +4098,18 @@ class BrowserManager:
         Resolution order (§4.2):
             1. ``page_id`` → Page object (raises :class:`RefStale` if the
                tab has closed).
-            2. ``frame_id`` → Frame (None = main frame).  Always None
-               until §8.4 iframe traversal.
-            3. ``scope_root`` — modal selector bound during snapshot, so
-               occurrence indices match.
-            4. ``shadow_path`` — walk open shadow roots via the
-               §8.3 two-stage ``evaluate_handle`` pattern. Returns an
+            2. ``frame_id`` → Frame (None = main frame). Set when the
+               ref was captured inside an iframe; the resolver then runs
+               every subsequent step against that Frame instead of the
+               top-level Page, so shadow-piercing and ``get_by_role``
+               operate inside the iframe's own document.
+            3. ``shadow_path`` — walk open shadow roots via the
+               §8.3 two-stage ``evaluate_handle`` pattern (against the
+               Frame when ``frame_id`` is set, else the Page). Returns an
                :class:`ElementHandle` rather than a ``Locator`` because
                ``get_by_role`` does not pierce shadow boundaries.
+            4. ``scope_root`` — modal selector bound during snapshot, so
+               occurrence indices match.
             5. ``get_by_role(role, name=name, exact=True).nth(occurrence)``.
 
         Returns ``None`` when ``ref`` isn't in ``inst.refs`` (classic
@@ -4123,8 +4136,14 @@ class BrowserManager:
             locator = base.get_by_role(handle.role)
         return locator.nth(handle.occurrence)
 
-    async def _resolve_shadow_element(self, page, handle: RefHandle, ref: str):
+    async def _resolve_shadow_element(self, base, handle: RefHandle, ref: str):
         """Two-stage resolver for refs whose ``shadow_path`` is non-empty.
+
+        ``base`` is the JS-evaluation root for the resolver — a Page for
+        main-frame refs, or a Frame for refs captured inside an iframe.
+        Both share ``evaluate_handle``; the JS resolver runs in whichever
+        document ``base`` represents, so an iframe-scoped ref walks the
+        shadow path inside the iframe's document, not the top page.
 
         Stage 1 walks the path to the inner ``shadowRoot``, verifying
         each host's discriminator. Stage 2 picks the role+name match at
@@ -4159,7 +4178,7 @@ class BrowserManager:
         # Without this, a same-selector shadow host living outside the
         # dialog could resolve and the click would land on the wrong
         # element entirely.
-        stage1 = await page.evaluate_handle(
+        stage1 = await base.evaluate_handle(
             _JS_SHADOW_RESOLVE_STAGE1,
             {
                 "path": json.dumps(path_payload),
@@ -6717,7 +6736,7 @@ class BrowserManager:
                 if not locator:
                     return {"success": False, "error": f"Ref '{ref}' not found"}
                 async with inst.page.expect_file_chooser(timeout=timeout_ms) as info:
-                    if type(inst.x11_wid) is int and self._is_x11_site(inst):
+                    if isinstance(inst.x11_wid, int) and self._is_x11_site(inst):
                         try:
                             await self._x11_click(
                                 inst, locator, timeout=timeout_ms,
@@ -6795,7 +6814,7 @@ class BrowserManager:
 
                 Path(download_dir).mkdir(parents=True, exist_ok=True)
                 async with inst.page.expect_download(timeout=timeout_ms) as info:
-                    if type(inst.x11_wid) is int and self._is_x11_site(inst):
+                    if isinstance(inst.x11_wid, int) and self._is_x11_site(inst):
                         try:
                             await self._x11_click(
                                 inst, locator, timeout=timeout_ms,

--- a/src/browser/service.py
+++ b/src/browser/service.py
@@ -19,6 +19,7 @@ import re
 import subprocess
 import time
 import uuid
+import warnings
 import weakref
 from collections import deque
 from pathlib import Path
@@ -1951,18 +1952,30 @@ class CamoufoxInstance:
         except RuntimeError:
             loop = None
         if self._lock is None:
-            # ``asyncio.Lock()`` on Python 3.10+ (project minimum) does
-            # NOT consult or bind a loop at construction; first acquire
-            # binds it. Constructing one in a thread with no loop is
-            # safe — leave ``_lock_loop = None`` and pin on first real
-            # async use below. (Earlier code did
-            # ``asyncio.new_event_loop() + set_event_loop()`` here as
-            # a Python-3.9 workaround; that mutated the calling
-            # thread's current event loop as a side effect of an
-            # attribute READ, which is surprising and breaks any code
-            # that later calls ``asyncio.run`` in that thread.)
-            self._lock = asyncio.Lock()
-            self._lock_loop = loop  # may be None; pinned below on first real use
+            if loop is None:
+                try:
+                    # Python 3.10+ creates an unbound lock here without
+                    # touching thread-local event-loop state.
+                    self._lock = asyncio.Lock()
+                    self._lock_loop = None
+                except RuntimeError:
+                    # Python 3.9 still calls get_event_loop() during
+                    # Lock construction. Use an explicit throwaway loop
+                    # without setting it as the thread default; first
+                    # real async use will rebuild for the running loop.
+                    tmp_loop = asyncio.new_event_loop()
+                    try:
+                        with warnings.catch_warnings():
+                            warnings.simplefilter(
+                                "ignore", DeprecationWarning,
+                            )
+                            self._lock = asyncio.Lock(loop=tmp_loop)
+                    finally:
+                        tmp_loop.close()
+                    self._lock_loop = tmp_loop
+            else:
+                self._lock = asyncio.Lock()
+                self._lock_loop = loop
         elif loop is None:
             # No active loop to bind against; return what we have.
             return self._lock
@@ -6555,10 +6568,19 @@ class BrowserManager:
                         logger.warning(
                             "captcha solve: no published rate for "
                             "provider=%s kind=%s proxy_aware=%s — "
-                            "skipping cost increment "
+                            "keeping any reserved cost-cap charge; "
+                            "otherwise skipping cost increment "
                             "(under-count > over-count)",
                             provider, kind, result.used_proxy_aware,
                         )
+                        # With a configured cap, we reserved the max
+                        # published tier before the provider call. If
+                        # the solver reports an unpriced actual tier
+                        # after returning a token, keep that reservation
+                        # instead of refunding it; refunding would let an
+                        # untracked provider charge bypass the cap.
+                        if reserved_millicents:
+                            reservation_settled = True
                     else:
                         if reserved_millicents:
                             await _cost.adjust_cost(

--- a/src/browser/service.py
+++ b/src/browser/service.py
@@ -5667,11 +5667,13 @@ class BrowserManager:
 
         Order of operations:
 
-          1. Rate-limit gate (records a slot only on a real attempt — gates
-             that short-circuit don't burn the per-hour budget).
+          1. Fleet-wide kill switch.
           2. Cost-cap gate (read against the agent's monthly bucket).
-          3. Solver HTTP call. ``solve()`` returns :class:`SolveResult`.
-          4. Cost accounting. Increments fire when ``result.token is not
+          3. Rate-limit gate (records a slot only on a real attempt — gates
+             that short-circuit don't burn the per-hour budget).
+          4. Provider sanity when a cost cap requires priced accounting.
+          5. Solver HTTP call. ``solve()`` returns :class:`SolveResult`.
+          6. Cost accounting. Increments fire when ``result.token is not
              None`` regardless of ``injection_succeeded`` — the provider
              was paid the moment the token came back; injection failure
              is our problem, not theirs. ``solver_attempted=False`` paths

--- a/src/browser/service.py
+++ b/src/browser/service.py
@@ -2418,13 +2418,12 @@ class BrowserManager:
         the dashboard layer this surfaces as a ``browser_nav_probe``
         event, distinct from per-minute drain payloads.
 
-        **Probes on ``about:blank``** so we read the platform / browser
-        signals as the engine sees them, not as some loaded site has
-        possibly shadowed them via an injected content script. With
-        ``persistent_context=True`` the page resumes whatever the agent
-        had open last session — that page's globals could include
-        custom getters on ``Navigator.prototype``. Forcing a navigation
-        to ``about:blank`` first eliminates that path.
+        **Probes on a temporary ``about:blank`` page** so we read the
+        platform / browser signals as the engine sees them, not as some
+        loaded site has possibly shadowed them via an injected content
+        script. With ``persistent_context=True`` the page resumes whatever
+        the agent had open last session; the probe must not clobber that
+        active tab just to get a clean diagnostic read.
 
         Mismatches the probe flags:
           * ``navigator.webdriver !== false`` — the canonical bot tell
@@ -2443,30 +2442,37 @@ class BrowserManager:
             "linux": "Linux x86_64",
         }.get(os_hint)
 
+        probe_page = inst.page
+        temp_page = None
         # Best-effort isolate the probe context. ``about:blank`` is a
         # special URL that Firefox loads instantly with a fresh,
         # script-free document — perfect for reading raw navigator
-        # signals. If the goto fails (e.g. ``about:blank`` blocked by
-        # some weird policy), we fall through and probe the current
-        # page anyway; the result will still be populated and any
-        # shadowing-induced mismatch is itself useful signal.
-        #
-        # Side-effect operators may notice: this clobbers the resumed
-        # page on a persistent-profile restart. An agent that had
-        # ``twitter.com`` open last session sees ``about:blank`` for a
-        # split second after restart, then whatever its first action
-        # navigates to. Cookies / localStorage / IndexedDB all survive
-        # — only the loaded-page URL is lost.
+        # signals. Use a temporary page so a persistent-profile restart
+        # keeps the agent's active/resumed tab intact. If a temp page
+        # cannot be opened, fall back to probing the current page without
+        # navigating it.
         try:
-            await inst.page.goto("about:blank", timeout=5000)
+            new_page = getattr(inst.context, "new_page", None)
+            if callable(new_page):
+                temp_page = await new_page()
+                probe_page = temp_page
+                await temp_page.goto("about:blank", timeout=5000)
         except Exception as e:
             logger.debug(
-                "Probe pre-nav to about:blank failed for '%s' "
-                "(continuing on current page): %s", inst.agent_id, e,
+                "Probe temporary about:blank page failed for '%s' "
+                "(continuing on current page without navigation): %s",
+                inst.agent_id, e,
             )
+            if temp_page is not None:
+                try:
+                    await temp_page.close()
+                except Exception:
+                    pass
+                temp_page = None
+            probe_page = inst.page
 
         try:
-            signals = await inst.page.evaluate(
+            signals = await probe_page.evaluate(
                 "() => ({"
                 "  webdriver: navigator.webdriver,"
                 "  plugins_len: navigator.plugins ? navigator.plugins.length : -1,"
@@ -2492,6 +2498,15 @@ class BrowserManager:
                 inst.agent_id, e,
             )
             return
+        finally:
+            if temp_page is not None:
+                try:
+                    await temp_page.close()
+                except Exception as e:
+                    logger.debug(
+                        "Probe temporary page close failed for '%s': %s",
+                        inst.agent_id, e,
+                    )
 
         mismatches: list[str] = []
         if signals.get("webdriver") is not False:
@@ -3919,8 +3934,13 @@ class BrowserManager:
             # update for scoped/filtered calls — they're informational
             # snapshots, not anchors. ``last_active_page_id`` still
             # advances so tab-change detection stays accurate.
-            _is_scoped_call = (filter is not None) or (from_ref is not None)
-            if not _is_scoped_call and not _skip_baseline:
+            is_subset_snapshot = (
+                allowed_roles is not None
+                or from_ref is not None
+                or target_frame is not None
+                or include_frames is False
+            )
+            if not is_subset_snapshot and not _skip_baseline:
                 inst.last_snapshot[snapshot_page_id] = {
                     "refs_by_key": dict(ref_summary),
                     "url": current_url,
@@ -4022,16 +4042,13 @@ class BrowserManager:
         if handle is None:
             return None
         page = inst._resolve_page_id(handle.page_id)
-        if handle.shadow_path:
-            # NOTE: shadow + iframe combination raises NotImplementedError
-            # inside ``_resolve_shadow_element``; callers (click/type/etc)
-            # catch it and surface a ``not_supported`` envelope.
-            return await self._resolve_shadow_element(page, handle, ref)
         if handle.frame_id is not None:
             frame = inst._resolve_frame_id(handle.frame_id)
             base = frame
         else:
             base = page
+        if handle.shadow_path:
+            return await self._resolve_shadow_element(base, handle, ref)
         if handle.scope_root:
             base = base.locator(handle.scope_root)
         if handle.name:
@@ -4071,15 +4088,6 @@ class BrowserManager:
             }
             for hop in handle.shadow_path
         ]
-        # Defensive: shadow + iframe combination is not implemented yet
-        # (Phase 5 PR3). Threading a Frame through Stage 1 here would
-        # require cross-PR coordination; explicit error makes the seam
-        # loud so PR3's merge has to address it rather than letting a
-        # frame_id'd shadow ref silently resolve against the main frame.
-        if handle.frame_id is not None:
-            raise NotImplementedError(
-                "Shadow + iframe combination not yet supported",
-            )
         # Pass scope_root through so Stage 1 starts its walk inside the
         # modal subtree when a ref was captured under modal scoping.
         # Without this, a same-selector shadow host living outside the
@@ -5878,9 +5886,9 @@ class BrowserManager:
         captcha_selectors = [
             'iframe[src*="recaptcha"]',
             'iframe[src*="hcaptcha"]',
+            '[class*="cf-turnstile"]',
             'iframe[src*="challenges.cloudflare.com"]',
             'iframe[src*="captcha"]',
-            '[class*="cf-turnstile"]',
             '[class*="captcha"]',
             '#captcha',
         ]
@@ -6364,6 +6372,8 @@ class BrowserManager:
             return "recaptcha-v2-checkbox"
         if "hcaptcha" in selector:
             return "hcaptcha"
+        if "cf-turnstile" in selector:
+            return "turnstile"
         if "challenges.cloudflare.com" in selector:
             # Coarse CF default. The §11.3 classifier in ``_check_captcha``
             # routes to ``cf-interstitial-{auto,behavioral,turnstile}``
@@ -6371,8 +6381,6 @@ class BrowserManager:
             # embedded Turnstile widget). When the JS probe finds none
             # of those, this placeholder stays.
             return "cf-interstitial-auto"
-        if "cf-turnstile" in selector:
-            return "turnstile"
         # Generic 'captcha' selectors and #captcha fall through to unknown.
         return "unknown"
 
@@ -6641,7 +6649,24 @@ class BrowserManager:
                 if not locator:
                     return {"success": False, "error": f"Ref '{ref}' not found"}
                 async with inst.page.expect_file_chooser(timeout=timeout_ms) as info:
-                    await locator.click(timeout=timeout_ms)
+                    if type(inst.x11_wid) is int and self._is_x11_site(inst):
+                        try:
+                            await self._x11_click(
+                                inst, locator, timeout=timeout_ms,
+                            )
+                        except Exception as e:
+                            logger.warning(
+                                "X11 upload click failed for '%s', "
+                                "falling back to CDP: %s",
+                                agent_id, e,
+                            )
+                            await self._human_click(
+                                inst.page, locator, timeout=timeout_ms,
+                            )
+                    else:
+                        await self._human_click(
+                            inst.page, locator, timeout=timeout_ms,
+                        )
                 chooser = await info.value
                 await chooser.set_files(local_paths)
                 await asyncio.sleep(action_delay())
@@ -6702,7 +6727,24 @@ class BrowserManager:
 
                 Path(download_dir).mkdir(parents=True, exist_ok=True)
                 async with inst.page.expect_download(timeout=timeout_ms) as info:
-                    await locator.click(timeout=timeout_ms)
+                    if type(inst.x11_wid) is int and self._is_x11_site(inst):
+                        try:
+                            await self._x11_click(
+                                inst, locator, timeout=timeout_ms,
+                            )
+                        except Exception as e:
+                            logger.warning(
+                                "X11 download click failed for '%s', "
+                                "falling back to CDP: %s",
+                                agent_id, e,
+                            )
+                            await self._human_click(
+                                inst.page, locator, timeout=timeout_ms,
+                            )
+                    else:
+                        await self._human_click(
+                            inst.page, locator, timeout=timeout_ms,
+                        )
                 download = await info.value
                 suggested = download.suggested_filename or "download.bin"
                 nonce = uuid.uuid4().hex[:12]

--- a/src/browser/service.py
+++ b/src/browser/service.py
@@ -1498,14 +1498,18 @@ def _encode_screenshot(
         )
         return png_bytes, "png"
 
-    # Decompression-bomb protection. A page rendering a giant <canvas>
-    # could hand us back a multi-hundred-megapixel PNG that Pillow
-    # would happily allocate. Cap at 50 MP — covers any realistic
-    # browser viewport (8K screen ≈ 33 MP) but blocks adversarial
-    # blowups. Pillow raises ``DecompressionBombError`` once the cap
-    # is exceeded; we catch and return the raw PNG bytes so the agent
-    # still gets diagnostic data.
-    Image.MAX_IMAGE_PIXELS = 50_000_000
+    # Decompression-bomb protection. Pillow's ``MAX_IMAGE_PIXELS`` is a
+    # MODULE-LEVEL global; rebinding it on every screenshot encode (the
+    # earlier placement) was both wasteful and racy with any other
+    # Pillow consumer in the process. Set once, here, immediately after
+    # the import succeeds — first encode in the process pins the cap
+    # for everyone, subsequent encodes are no-ops since the value is
+    # idempotent. 50 MP covers any realistic browser viewport (8K
+    # ≈ 33 MP) but blocks adversarial blowups; Pillow raises
+    # ``DecompressionBombError`` once exceeded and the catch-all below
+    # falls back to the raw PNG bytes.
+    if Image.MAX_IMAGE_PIXELS != 50_000_000:
+        Image.MAX_IMAGE_PIXELS = 50_000_000
 
     try:
         img = Image.open(BytesIO(png_bytes))
@@ -1947,27 +1951,29 @@ class CamoufoxInstance:
         except RuntimeError:
             loop = None
         if self._lock is None:
-            if loop is None:
-                # Python 3.9's asyncio.Lock constructor still consults
-                # the thread's current event loop. A sync test/startup
-                # thread may not have one, so install a temporary default;
-                # first async use will rebuild the lock for the running loop.
-                try:
-                    loop = asyncio.get_event_loop()
-                except RuntimeError:
-                    loop = asyncio.new_event_loop()
-                    asyncio.set_event_loop(loop)
+            # ``asyncio.Lock()`` on Python 3.10+ (project minimum) does
+            # NOT consult or bind a loop at construction; first acquire
+            # binds it. Constructing one in a thread with no loop is
+            # safe — leave ``_lock_loop = None`` and pin on first real
+            # async use below. (Earlier code did
+            # ``asyncio.new_event_loop() + set_event_loop()`` here as
+            # a Python-3.9 workaround; that mutated the calling
+            # thread's current event loop as a side effect of an
+            # attribute READ, which is surprising and breaks any code
+            # that later calls ``asyncio.run`` in that thread.)
             self._lock = asyncio.Lock()
-            self._lock_loop = loop
+            self._lock_loop = loop  # may be None; pinned below on first real use
         elif loop is None:
+            # No active loop to bind against; return what we have.
             return self._lock
         elif self._lock_loop is None:
-            # Lock was set via the setter outside a running loop; pin it
-            # to the loop that's actually using it now without discarding.
+            # Lock was created (or set via the setter) outside a
+            # running loop; pin it to the loop that's actually using
+            # it now without discarding.
             self._lock_loop = loop
         elif self._lock_loop is not loop:
-            # Loop changed between uses (typically pytest spinning up a
-            # fresh loop per test). Rebuild to bind to the new loop.
+            # Loop changed between uses (typically pytest spinning up
+            # a fresh loop per test). Rebuild to bind to the new loop.
             self._lock = asyncio.Lock()
             self._lock_loop = loop
         return self._lock

--- a/src/browser/stealth.py
+++ b/src/browser/stealth.py
@@ -324,16 +324,20 @@ def pick_resolution(agent_id: str) -> tuple[int, int]:
     return _RESOLUTION_POOL[0][0]
 
 
-# ── §6.6 NetworkInformation per-agent fingerprint ─────────────────────────────
+# ── §6.6 NetworkInformation helper for non-Firefox future paths ───────────────
 
 
 def pick_network_info(agent_id: str) -> dict:
     """Stable per-agent ``navigator.connection`` values.
 
-    Real desktop users on broadband / 4G / 5G report
+    The current browser path is Firefox-shaped, and real Firefox does not
+    expose NetworkInformation, so ``build_launch_options`` does not apply
+    these values today. Keep the helper deterministic for a future
+    Chromium-shaped path where exposing the API would be coherent with the UA.
+
+    Real Chromium-family desktop users on broadband / 4G / 5G report
     ``effectiveType="4g"`` overwhelmingly; the variability is in
-    ``downlink`` (Mbps) and ``rtt`` (ms). Datacenter Firefox often
-    leaves all three undefined, which is itself a signal.
+    ``downlink`` (Mbps) and ``rtt`` (ms).
 
     Picks per-agent from plausible bands:
       - downlink: 5–20 Mbps (covers home broadband, mobile 4G good signal)
@@ -453,8 +457,9 @@ def build_launch_options(agent_id: str, profile_dir: str, proxy: dict | None = N
         "os": os_hint,
         "locale": locale,        # navigator.language / Accept-Language header
         "window": (width, height),
-        # block_webrtc: Camoufox native toggle — prevents Docker container IP
-        # from leaking via ICE candidates.  More reliable than manual prefs.
+        # block_webrtc: Camoufox native toggle — primary defense against
+        # Docker container IP leaks via ICE candidates. Firefox prefs below
+        # add defense in depth.
         "block_webrtc": True,
     }
 
@@ -484,23 +489,14 @@ def build_launch_options(agent_id: str, profile_dir: str, proxy: dict | None = N
 
     options["firefox_user_prefs"] = _stealth_prefs()
 
-    # ── §6.6 NetworkInformation spoof ────────────────────────────────────────
-    # Camoufox's ``config`` dict supports dotted keys for navigator.* override.
-    # Set per-agent stable values so ``navigator.connection.{effectiveType,
-    # downlink, rtt}`` look like a desktop on broadband. Without this Firefox
-    # leaves these undefined on Linux containers, which detection scripts use
-    # as a desktop-vs-bot tell.
-    netinfo = pick_network_info(agent_id)
-    options["config"] = {
-        "navigator.connection.effectiveType": netinfo["effectiveType"],
-        "navigator.connection.downlink": netinfo["downlink"],
-        "navigator.connection.rtt": netinfo["rtt"],
-        "navigator.connection.saveData": netinfo["saveData"],
-    }
-    # Camoufox requires this acknowledgement before applying ``config``
-    # overrides. We're past the early-return path so it's safe to set
-    # unconditionally now.
-    options["i_know_what_im_doing"] = True
+    # ── §6.6 NetworkInformation ──────────────────────────────────────────────
+    # Real Firefox does not expose ``navigator.connection``. Earlier phases
+    # injected per-agent NetworkInformation values through Camoufox config,
+    # but that made a Firefox-shaped UA expose a Chromium-only API — a stronger
+    # anti-bot signal than the API being absent. Keep ``pick_network_info`` as
+    # a deterministic helper for a future Chromium-shaped path, but do not
+    # pass any ``navigator.connection.*`` config while `_assert_firefox_ua`
+    # requires a Firefox UA.
 
     # ── User-Agent version override ──────────────────────────────────────────
     # Camoufox bundles a specific Firefox build (e.g. 135.0).  Some sites
@@ -521,7 +517,8 @@ def build_launch_options(agent_id: str, profile_dir: str, proxy: dict | None = N
             # If a future change introduces a Chromium UA, this raises so
             # the developer has to wire Sec-CH-UA-* overrides first.
             _assert_firefox_ua(ua)
-            options["config"]["navigator.userAgent"] = ua
+            options.setdefault("config", {})["navigator.userAgent"] = ua
+            options["i_know_what_im_doing"] = True
             options["firefox_user_prefs"]["general.useragent.override"] = ua
             logger.info("UA override: Firefox/%s", ua_version)
 

--- a/src/browser/stealth.py
+++ b/src/browser/stealth.py
@@ -581,10 +581,31 @@ def _stealth_prefs() -> dict:
         "browser.uidensity": 1,
         "browser.tabs.inTitlebar": 1,
 
-        # ── WebRTC: handled by Camoufox block_webrtc=True ────────────────────
+        # ── WebRTC: defense in depth ─────────────────────────────────────────
         # RTCPeerConnection leaks the Docker container's internal IP via ICE
-        # candidates even when behind a proxy.  Camoufox's block_webrtc option
-        # is the canonical way to disable WebRTC — it covers all relevant prefs.
+        # candidates even when behind a proxy. Camoufox's ``block_webrtc=True``
+        # is the primary toggle, BUT a single point of failure: if a future
+        # Camoufox release silently drops or renames the option, ICE candidates
+        # leak with no other guard. Set the underlying Firefox prefs explicitly
+        # too — they're idempotent with the Camoufox toggle and survive any
+        # upstream rename.
+        #
+        # Trade-off: ``media.peerconnection.enabled=false`` makes
+        # ``RTCPeerConnection`` itself ``undefined`` — and the API's absence
+        # is itself a fingerprint cluster vs the real Firefox population
+        # (where it's overwhelmingly present). The two ``ice.*`` prefs are
+        # the better long-term shape because they keep the constructor present
+        # but prevent host candidates; flipping the master switch is the
+        # belt-and-suspenders fallback for the primary IP-leak threat. Operators
+        # who care more about cluster shape than IP leakage can override
+        # ``media.peerconnection.enabled`` to True via settings.json.
+        "media.peerconnection.enabled": False,
+        "media.peerconnection.ice.default_address_only": True,
+        "media.peerconnection.ice.no_host": True,
+        # Disable mDNS rewrite of host candidates (Firefox feature that can
+        # itself be a fingerprint-able shape if mismatched with our above
+        # settings).
+        "media.peerconnection.ice.obfuscate_host_addresses": False,
 
         # ── Geolocation ───────────────────────────────────────────────────────
         # The geo API would expose incorrect coordinates for a server IP, and

--- a/src/browser/stealth.py
+++ b/src/browser/stealth.py
@@ -349,11 +349,28 @@ def pick_network_info(agent_id: str) -> dict:
     digest = hashlib.sha256(f"netinfo:{agent_id}".encode("utf-8")).digest()
     dl_unit = int.from_bytes(digest[:4], "big") / (1 << 32)   # [0, 1)
     rtt_unit = int.from_bytes(digest[4:8], "big") / (1 << 32)  # [0, 1)
+    et_unit = int.from_bytes(digest[8:12], "big") / (1 << 32)  # [0, 1)
+    sd_unit = int.from_bytes(digest[12:16], "big") / (1 << 32)  # [0, 1)
+    # Add light entropy on ``effectiveType`` and ``saveData`` so the fleet
+    # doesn't uniformly report ``("4g", False)`` — that's a single
+    # fingerprint cluster, opposite of §6.1's resolution-pool intent.
+    # Weights match real-world desktop populations: ``4g`` dominates
+    # but ``3g`` (mobile-tether or WAN-degraded) is non-trivial; ``2g``
+    # is plausibly rare; ``slow-2g`` is essentially never on desktop.
+    # ``saveData=True`` is rare (~3% of desktop sessions per public
+    # CrUX-style data) but not zero.
+    if et_unit < 0.92:
+        effective_type = "4g"
+    elif et_unit < 0.99:
+        effective_type = "3g"
+    else:
+        effective_type = "2g"
+    save_data = sd_unit < 0.03
     return {
-        "effectiveType": "4g",
+        "effectiveType": effective_type,
         "downlink": round(5.0 + dl_unit * 15.0, 1),
         "rtt": int(20 + rtt_unit * 100),
-        "saveData": False,
+        "saveData": save_data,
     }
 
 
@@ -524,6 +541,23 @@ def _build_ua_string(os_hint: str, version: str) -> str | None:
         logger.warning(
             "Invalid BROWSER_UA_VERSION %r (expected e.g. '138.0'), ignoring",
             version,
+        )
+        return None
+
+    # Sanity-bound the major version. A typo like "99999999.0" would
+    # produce a UA string that's a strong outlier signal — exactly the
+    # detection axis §6.4 tries to harden against. Firefox major
+    # versions are currently in the 130s; cap at 200 to leave generous
+    # headroom while rejecting nonsense.
+    try:
+        major = int(parts[0])
+    except ValueError:
+        return None
+    if major < 1 or major > 200:
+        logger.warning(
+            "BROWSER_UA_VERSION major %d is out of sane bound [1, 200]; "
+            "ignoring",
+            major,
         )
         return None
 

--- a/src/browser/stealth.py
+++ b/src/browser/stealth.py
@@ -338,13 +338,12 @@ def pick_network_info(agent_id: str) -> dict:
     Picks per-agent from plausible bands:
       - downlink: 5–20 Mbps (covers home broadband, mobile 4G good signal)
       - rtt: 20–120 ms (covers wired through mobile)
-      - saveData: always False (rare on desktop; True would itself be a flag)
+      - saveData: rare True (~3%), mostly False
 
     Deterministic from ``agent_id`` so the same agent reports the same
-    network shape across browser restarts. SHA-256 splits into two
-    independent 4-byte words for downlink and rtt — using one byte each
-    would give a coarse 256-bucket distribution and visible quantisation
-    on fleet-scale analysis.
+    network shape across browser restarts. SHA-256 splits into independent
+    4-byte words for each field — using one byte each would give a coarse
+    256-bucket distribution and visible quantisation on fleet-scale analysis.
     """
     digest = hashlib.sha256(f"netinfo:{agent_id}".encode("utf-8")).digest()
     dl_unit = int.from_bytes(digest[:4], "big") / (1 << 32)   # [0, 1)

--- a/src/dashboard/server.py
+++ b/src/dashboard/server.py
@@ -435,6 +435,19 @@ def _validate_cookies(
         if name.startswith("__Secure-") and url and not url.lower().startswith("https://"):
             _drop("secure_prefix_non_https_url")
             continue
+        # Per RFC 6265 §5.4, ``Secure=true`` requires an HTTPS origin.
+        # Firefox silently drops a Secure cookie set with a plain-http
+        # url at SET time. Reject up front so the operator gets a
+        # deterministic drop reason rather than an opaque "your import
+        # said success but nothing landed". Applies to ALL cookies
+        # (not just ``__Secure-``/``__Host-`` prefixed names).
+        if (
+            secure
+            and url
+            and not url.lower().startswith("https://")
+        ):
+            _drop("secure_non_https_url")
+            continue
         normalized: dict = {"name": name, "value": value}
         if url:
             normalized["url"] = url

--- a/src/dashboard/server.py
+++ b/src/dashboard/server.py
@@ -11,6 +11,7 @@ import contextlib
 import hashlib
 import ipaddress
 import json
+import math
 import os
 import re
 import shutil
@@ -437,10 +438,22 @@ def _validate_cookies(
                 _drop("samesite_none_without_secure")
                 continue
             normalized["sameSite"] = ss_norm
-        # expires: must be numeric (int or float). Strings rejected.
+        # expires: must be a finite number (int or float). Reject
+        # bool (subclass of int), strings, NaN, ±Inf, and absurd far-
+        # future values that would overflow int conversion or fail
+        # downstream Playwright/Firefox validation. ~100 years out is a
+        # generous upper bound; cookies aren't realistically dated past
+        # that and bounding here protects the audit log too.
         if "expires" in raw and raw["expires"] is not None:
             exp = raw["expires"]
             if isinstance(exp, bool) or not isinstance(exp, (int, float)):
+                _drop("invalid_expires")
+                continue
+            if not math.isfinite(exp):
+                _drop("invalid_expires")
+                continue
+            _MAX_EXPIRES = 4102444800.0  # 2100-01-01 UTC, ~76yr buffer
+            if exp < 0 or exp > _MAX_EXPIRES:
                 _drop("invalid_expires")
                 continue
             normalized["expires"] = int(exp)

--- a/src/dashboard/server.py
+++ b/src/dashboard/server.py
@@ -397,7 +397,14 @@ def _validate_cookies(
             _drop("host_prefix_with_domain")
             continue
         secure_raw = raw.get("secure")
-        secure = bool(secure_raw) if secure_raw is not None else False
+        if secure_raw is not None and not isinstance(secure_raw, bool):
+            _drop("invalid_secure")
+            continue
+        secure = secure_raw if secure_raw is not None else False
+        http_only_raw = raw.get("httpOnly")
+        if http_only_raw is not None and not isinstance(http_only_raw, bool):
+            _drop("invalid_httponly")
+            continue
         if name.startswith("__Host-"):
             if path != "/":
                 _drop("host_prefix_invalid_path")
@@ -405,6 +412,9 @@ def _validate_cookies(
             if not secure:
                 _drop("host_prefix_without_secure")
                 continue
+        if name.startswith("__Secure-") and not secure:
+            _drop("secure_prefix_without_secure")
+            continue
         normalized: dict = {"name": name, "value": value}
         if url:
             normalized["url"] = url
@@ -423,6 +433,9 @@ def _validate_cookies(
             if ss_norm is None:
                 _drop("invalid_samesite")
                 continue
+            if ss_norm == "None" and not secure:
+                _drop("samesite_none_without_secure")
+                continue
             normalized["sameSite"] = ss_norm
         # expires: must be numeric (int or float). Strings rejected.
         if "expires" in raw and raw["expires"] is not None:
@@ -431,9 +444,9 @@ def _validate_cookies(
                 _drop("invalid_expires")
                 continue
             normalized["expires"] = int(exp)
-        # httpOnly / secure — coerce to bool only when explicitly present.
-        if "httpOnly" in raw:
-            normalized["httpOnly"] = bool(raw["httpOnly"])
+        # httpOnly / secure — pass through only explicit JSON booleans.
+        if http_only_raw is not None:
+            normalized["httpOnly"] = http_only_raw
         if secure_raw is not None:
             normalized["secure"] = secure
         accepted.append(normalized)

--- a/src/dashboard/server.py
+++ b/src/dashboard/server.py
@@ -359,6 +359,14 @@ def _validate_cookies(
         if not isinstance(name, str) or not name:
             _drop("empty_name")
             continue
+        # Bound the cookie name to a sane length. The wire spec doesn't
+        # mandate a cap but Firefox/Playwright treat oversized names
+        # poorly downstream; more importantly, names flow into the
+        # audit log so an unbounded payload could pollute log
+        # aggregation and disk usage.
+        if len(name) > 256:
+            _drop("invalid_name_length")
+            continue
         if domain is None:
             domain = ""
         if not isinstance(domain, str):
@@ -413,8 +421,19 @@ def _validate_cookies(
             if not secure:
                 _drop("host_prefix_without_secure")
                 continue
+            # Spec: __Host- cookies are only set over a secure origin.
+            # If the operator supplied url=http://..., Firefox will
+            # silently drop the cookie at SET time. Reject up front
+            # so the operator gets a deterministic drop reason instead
+            # of an opaque "your import looked fine but nothing landed".
+            if url and not url.lower().startswith("https://"):
+                _drop("host_prefix_non_https_url")
+                continue
         if name.startswith("__Secure-") and not secure:
             _drop("secure_prefix_without_secure")
+            continue
+        if name.startswith("__Secure-") and url and not url.lower().startswith("https://"):
+            _drop("secure_prefix_non_https_url")
             continue
         normalized: dict = {"name": name, "value": value}
         if url:
@@ -850,6 +869,17 @@ def create_dashboard_router(
                 )
                 return False, retry_after_ms
             bucket.append(now)
+            # Periodic sweep of stale buckets so the dict doesn't grow
+            # unbounded across deleted/rotated agents. Cheap because we
+            # only sweep when the table grows past a threshold; the
+            # sliding window is the only state we need to retain.
+            if len(_cookie_import_buckets) > 1024:
+                stale = [
+                    k for k, b in _cookie_import_buckets.items()
+                    if not b or b[-1] <= cutoff
+                ]
+                for k in stale:
+                    _cookie_import_buckets.pop(k, None)
             return True, 0
 
     def _cookie_envelope_err(

--- a/src/dashboard/static/js/app.js
+++ b/src/dashboard/static/js/app.js
@@ -1519,9 +1519,9 @@ function dashboard() {
           },
         };
         if (!evt.data.ok && (evt.data.mismatches || []).length) {
-          // Toast dedup: a fleet-wide regression (e.g. Camoufox version
-          // bump that breaks navigator.connection injection) would
-          // otherwise stack one 8s toast per agent on a mass restart.
+          // Toast dedup: a fleet-wide fingerprint regression (e.g. a
+          // Camoufox version bump that changes navigator/platform shape)
+          // would otherwise stack one 8s toast per agent on a mass restart.
           // Fingerprint signature = the sorted mismatch list. Suppress
           // identical signatures fired within the same 30s window;
           // surface a "+N more" toast instead.

--- a/src/host/health.py
+++ b/src/host/health.py
@@ -63,8 +63,16 @@ class HealthMonitor:
         self._cleanup_agent = cleanup_agent_fn
         self._blackboard = blackboard
         self.agents: dict[str, AgentHealth] = {}
-        self._agent_lock = asyncio.Lock()
+        self._agent_lock: asyncio.Lock | None = None
+        self._agent_lock_loop: asyncio.AbstractEventLoop | None = None
         self._running = False
+
+    def _get_agent_lock(self) -> asyncio.Lock:
+        loop = asyncio.get_running_loop()
+        if self._agent_lock is None or self._agent_lock_loop is not loop:
+            self._agent_lock = asyncio.Lock()
+            self._agent_lock_loop = loop
+        return self._agent_lock
 
     def register(self, agent_id: str, url: str = "") -> None:
         self.agents[agent_id] = AgentHealth(agent_id=agent_id)
@@ -99,7 +107,7 @@ class HealthMonitor:
     async def _cleanup_ephemeral_agents(self) -> None:
         """Remove ephemeral (spawned) agents that have exceeded their TTL."""
         now = time.time()
-        async with self._agent_lock:
+        async with self._get_agent_lock():
             for agent_id in list(self.agents.keys()):
                 info = self.runtime.agents.get(agent_id, {})
                 if not info.get("ephemeral"):

--- a/src/host/mesh.py
+++ b/src/host/mesh.py
@@ -621,13 +621,21 @@ class MessageRouter:
         self._agent_projects: dict[str, str] = agent_projects or {}
         self._registry_lock = threading.Lock()
         self._client: httpx.AsyncClient | None = None
-        self._client_lock = asyncio.Lock()
+        self._client_lock: asyncio.Lock | None = None
+        self._client_lock_loop: asyncio.AbstractEventLoop | None = None
         self._trace_store = trace_store
+
+    def _get_client_lock(self) -> asyncio.Lock:
+        loop = asyncio.get_running_loop()
+        if self._client_lock is None or self._client_lock_loop is not loop:
+            self._client_lock = asyncio.Lock()
+            self._client_lock_loop = loop
+        return self._client_lock
 
     async def _get_client(self) -> httpx.AsyncClient:
         if self._client is not None and not self._client.is_closed:
             return self._client
-        async with self._client_lock:
+        async with self._get_client_lock():
             if self._client is None or self._client.is_closed:
                 self._client = httpx.AsyncClient(timeout=30)
             return self._client

--- a/src/host/server.py
+++ b/src/host/server.py
@@ -352,6 +352,40 @@ def create_mesh_app(
                 return
         raise HTTPException(401, "Invalid authentication token")
 
+    def _require_operator_or_internal(request: Request) -> None:
+        """Restrict to the operator agent or localhost x-mesh-internal.
+
+        Stricter than ``_require_any_auth``: an arbitrary agent's bearer
+        token does NOT pass. Used for fleet-wide pre-computed metrics
+        endpoints that previously leaked health, costs, attention list,
+        and per-agent budgets to every authenticated agent.
+        """
+        if not _auth_tokens:
+            return
+        if request.headers.get("x-mesh-internal"):
+            client_host = request.client.host if request.client else ""
+            try:
+                import ipaddress
+                if ipaddress.ip_address(client_host).is_loopback:
+                    return
+            except (ValueError, AttributeError):
+                pass
+        auth_header = request.headers.get("authorization", "")
+        if not auth_header.startswith("Bearer "):
+            raise HTTPException(401, "Missing authentication token")
+        token = auth_header[7:]
+        operator_token = _auth_tokens.get("operator")
+        if operator_token and hmac.compare_digest(token, operator_token):
+            return
+        # Token is valid for SOME agent but not operator — return 403
+        # rather than 401 so legitimate-but-wrong-scope callers can
+        # distinguish "I'm authenticated, just not allowed here" from
+        # "my credential is bad".
+        for expected in _auth_tokens.values():
+            if hmac.compare_digest(token, expected):
+                raise HTTPException(403, "Operator-only endpoint")
+        raise HTTPException(401, "Invalid authentication token")
+
     # === System Messaging (mesh → agent) ===
 
     @app.post("/mesh/message")
@@ -2104,8 +2138,14 @@ def create_mesh_app(
 
         Pre-computes ratios and flags so the operator LLM doesn't need
         to do arithmetic.  Read-only — no mutations.
+
+        Operator-only: pre-PR this endpoint accepted any agent's bearer
+        token and leaked fleet-wide health, costs, attention list, and
+        per-agent budgets to every authenticated agent. The endpoint
+        was always intended as part of the operator heartbeat — gate it
+        accordingly.
         """
-        _require_any_auth(request)
+        _require_operator_or_internal(request)
 
         # -- Agent counts (exclude operator — it's a system agent, not a user slot) --
         agents = dict(router.agent_registry)
@@ -2181,8 +2221,10 @@ def create_mesh_app(
 
         Returns health, cost, and queue data for a single agent.
         Read-only — no mutations.
+
+        Operator-only (see ``system_metrics`` rationale).
         """
-        _require_any_auth(request)
+        _require_operator_or_internal(request)
         _validate_agent_id(agent_id)
 
         if agent_id not in router.agent_registry:

--- a/src/host/server.py
+++ b/src/host/server.py
@@ -3123,10 +3123,19 @@ def create_mesh_app(
     # without this lock, both would write to the partial file concurrently
     # and corrupt the resulting bytes.
     _stage_locks: dict[str, asyncio.Lock] = {}
-    _stage_locks_guard = asyncio.Lock()
+    _stage_locks_guard: asyncio.Lock | None = None
+    _stage_locks_guard_loop: asyncio.AbstractEventLoop | None = None
+
+    def _get_stage_locks_guard() -> asyncio.Lock:
+        nonlocal _stage_locks_guard, _stage_locks_guard_loop
+        loop = asyncio.get_running_loop()
+        if _stage_locks_guard is None or _stage_locks_guard_loop is not loop:
+            _stage_locks_guard = asyncio.Lock()
+            _stage_locks_guard_loop = loop
+        return _stage_locks_guard
 
     async def _get_stage_lock(handle: str) -> asyncio.Lock:
-        async with _stage_locks_guard:
+        async with _get_stage_locks_guard():
             lock = _stage_locks.get(handle)
             if lock is None:
                 lock = asyncio.Lock()
@@ -3134,7 +3143,7 @@ def create_mesh_app(
             return lock
 
     async def _release_stage_lock_if_idle(handle: str) -> None:
-        async with _stage_locks_guard:
+        async with _get_stage_locks_guard():
             lock = _stage_locks.get(handle)
             if lock is not None and not lock.locked():
                 _stage_locks.pop(handle, None)

--- a/src/shared/redaction.py
+++ b/src/shared/redaction.py
@@ -66,8 +66,14 @@ SECRET_PATTERNS: list[re.Pattern[str]] = [
     re.compile(r"(?<![A-Za-z0-9/+=])[A-Za-z0-9+/]{40,}={0,2}(?![A-Za-z0-9/+=])"),
     # JWT (three base64-url segments separated by dots, ≥10 chars each).
     # Matches bearer JWTs in logs, auth headers, signed URLs.
+    #
+    # Anchor on the JOSE header prefix ``eyJ`` (base64-url of ``{"``).
+    # Without this anchor the previous shape match flagged benign
+    # three-dot strings like ``library_v1_2_3.commit_abcd1234.build_id``
+    # — every JWT in real use begins with ``eyJ``, so the anchor adds
+    # no false negatives while killing the false-positive class.
     re.compile(r"(?<![A-Za-z0-9._-])"
-               r"[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}"
+               r"eyJ[A-Za-z0-9_-]{7,}\.[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}"
                r"(?![A-Za-z0-9._-])"),
 ]
 
@@ -130,12 +136,22 @@ SENSITIVE_QUERY_PARAMS: frozenset[str] = frozenset(
 
 
 # JWT in a path segment — common for password reset / unsubscribe links.
+# Same ``eyJ`` JOSE-header anchor as the SECRET_PATTERNS version;
+# unanchored shape would match benign three-dot version strings like
+# ``library_v1_2_3.commit_abcd1234.build_id``.
 _JWT_IN_PATH = re.compile(
-    r"^[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}$"
+    r"^eyJ[A-Za-z0-9_-]{7,}\.[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}$"
 )
 
 
 _REDACTED_VALUE = "[REDACTED]"
+
+
+# Cached operator allowlist. ``redact_url`` parses every query string
+# pair-by-pair and previously called ``_operator_allowlist`` per pair —
+# a URL with N params triggered N env reads + N frozenset constructions.
+# Cache by raw env string so a runtime change still takes effect.
+_ALLOWLIST_CACHE: tuple[str, frozenset[str]] | None = None
 
 
 def _operator_allowlist() -> frozenset[str]:
@@ -143,12 +159,21 @@ def _operator_allowlist() -> frozenset[str]:
 
     Intended for specific integrations where the operator has verified the
     value is non-sensitive in their deployment. Default empty =
-    strict deny-by-default.
+    strict deny-by-default. Cached so per-pair redaction in ``redact_url``
+    doesn't re-parse the env var on every query parameter.
     """
+    global _ALLOWLIST_CACHE
     raw = os.environ.get("OPENLEGION_REDACTION_URL_QUERY_ALLOW", "").strip()
+    if _ALLOWLIST_CACHE is not None and _ALLOWLIST_CACHE[0] == raw:
+        return _ALLOWLIST_CACHE[1]
     if not raw:
-        return frozenset()
-    return frozenset(p.strip().lower() for p in raw.split(",") if p.strip())
+        result: frozenset[str] = frozenset()
+    else:
+        result = frozenset(
+            p.strip().lower() for p in raw.split(",") if p.strip()
+        )
+    _ALLOWLIST_CACHE = (raw, result)
+    return result
 
 
 def _should_redact_query(key: str) -> bool:
@@ -238,15 +263,27 @@ def redact_url(url: str) -> str:
     if query:
         # keep_blank_values=True so we don't lose shape on empty params
         pairs = parse_qsl(query, keep_blank_values=True)
-        parts_out: list[str] = []
-        for k, v in pairs:
-            enc_key = quote_plus(k)
-            if _should_redact_query(k):
-                # Literal sentinel, no encoding — ``[`` and ``]`` stay visible.
-                parts_out.append(f"{enc_key}={_REDACTED_VALUE}")
-            else:
-                parts_out.append(f"{enc_key}={quote_plus(v)}")
-        query = "&".join(parts_out)
+        # If NO key in this URL is sensitive AND we're not flipping any
+        # values, preserve the original query string verbatim. Round-
+        # tripping via parse_qsl + quote_plus mutates non-canonical
+        # encodings (e.g. ``msg=hello world`` decodes to ``hello world``
+        # then re-encodes to ``hello+world``); idempotency held only for
+        # already-canonical inputs. Operators relying on log diffs and
+        # exact substring matches need stable strings when nothing is
+        # being redacted.
+        if not any(_should_redact_query(k) for k, _ in pairs):
+            pass  # query already correct; no rewrite needed
+        else:
+            parts_out: list[str] = []
+            for k, v in pairs:
+                enc_key = quote_plus(k)
+                if _should_redact_query(k):
+                    # Literal sentinel, no encoding — ``[`` and ``]``
+                    # stay visible.
+                    parts_out.append(f"{enc_key}={_REDACTED_VALUE}")
+                else:
+                    parts_out.append(f"{enc_key}={quote_plus(v)}")
+            query = "&".join(parts_out)
 
     # 4. Fragment: drop entirely
     rebuilt = urlunsplit(SplitResult(parts.scheme, netloc, path, query, ""))

--- a/tests/test_browser_captcha_redetect.py
+++ b/tests/test_browser_captcha_redetect.py
@@ -142,12 +142,12 @@ async def _isolate_state(tmp_path, monkeypatch):
     )
     await cost.reset()
     svc._solve_rate_window.clear()
-    async with svc._captcha_audit_lock:
+    async with svc._get_captcha_audit_lock():
         svc._captcha_audit_buckets.clear()
     yield
     await cost.reset()
     svc._solve_rate_window.clear()
-    async with svc._captcha_audit_lock:
+    async with svc._get_captcha_audit_lock():
         svc._captcha_audit_buckets.clear()
 
 
@@ -348,7 +348,12 @@ class TestRedetectNavigationDuringAction:
 class TestRedetectInstallFailure:
     @pytest.mark.asyncio
     async def test_install_evaluate_raises(self, mgr):
-        page = _mk_page(install_raises=True, redetect_hits=[])
+        # Even if read-back would report stale hits, install failure means
+        # the probe state is not trustworthy and must not trigger solving.
+        page = _mk_page(
+            install_raises=True,
+            redetect_hits=['iframe[src*="recaptcha"]'],
+        )
         inst = _mk_inst(page=page)
         with patch.object(mgr, "_check_captcha", new=AsyncMock()) as cc:
             async with inst.lock:
@@ -430,6 +435,37 @@ class TestRedetectRateLimit:
         assert env1 is not None
         assert env2 is None
         assert check_spy.await_count == 1
+
+    @pytest.mark.asyncio
+    async def test_first_redetect_not_suppressed_when_monotonic_near_zero(
+        self, mgr,
+    ):
+        """``_last_redetect_ts=0`` is the sentinel for "never fired".
+        Some Python/runtime combinations expose small monotonic values at
+        process start, so the first call must not compare ``now - 0`` and
+        accidentally suppress itself."""
+        sel = 'iframe[src*="recaptcha"]'
+        page = _mk_page(redetect_hits=[sel], captcha_locator_for=sel)
+        envelope = {
+            "captcha_found": True,
+            "kind": "recaptcha-v2-checkbox",
+            "solver_attempted": False,
+            "solver_outcome": "no_solver",
+            "next_action": "request_captcha_help",
+        }
+        check_spy = AsyncMock(return_value=envelope)
+        inst = _mk_inst(page=page)
+        with patch.object(mgr, "_check_captcha", new=check_spy), \
+             patch.object(svc.time, "monotonic", return_value=1.0):
+            async with inst.lock:
+                async def _do():
+                    return {"success": True}
+
+                _, env = await mgr._with_captcha_redetect(inst, _do())
+
+        assert env is not None
+        assert inst._last_redetect_ts == 1.0
+        check_spy.assert_awaited_once()
 
 
 # ── 8. Flag-disabled — wrapper is a passthrough, no JS install/readback ───

--- a/tests/test_browser_file_transfer.py
+++ b/tests/test_browser_file_transfer.py
@@ -16,6 +16,7 @@ rather than run a live browser — tests verify:
 from __future__ import annotations
 
 import asyncio
+import json
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock
 
@@ -801,6 +802,8 @@ class TestDownloadFlow:
         from src.browser.service import BrowserManager
 
         monkeypatch.setenv("BROWSER_DOWNLOAD_DIR", str(tmp_path / "downloads"))
+        from src.browser import flags
+        flags.reload_operator_settings()
         mgr = BrowserManager(profiles_dir=str(tmp_path / "p"))
         return create_browser_app(mgr)
 
@@ -823,6 +826,39 @@ class TestDownloadFlow:
         assert resp.status_code == 200
         assert resp.content == b"X" * 200
         assert resp.headers["content-type"].startswith("application/octet-stream")
+
+    def test_download_stream_uses_operator_settings_dir(self, tmp_path, monkeypatch):
+        """Manager.download() reads BROWSER_DOWNLOAD_DIR through browser
+        flags, so stream/cleanup must use the same flag source. Env-only
+        lookup would 404 when the operator configured the dir in settings."""
+        from starlette.testclient import TestClient
+
+        from src.browser import flags
+        from src.browser.server import create_browser_app
+        from src.browser.service import BrowserManager
+
+        dl_dir = tmp_path / "settings-downloads"
+        settings = tmp_path / "settings.json"
+        settings.write_text(json.dumps({
+            "browser_flags": {"BROWSER_DOWNLOAD_DIR": str(dl_dir)},
+        }))
+        monkeypatch.setenv("OPENLEGION_SETTINGS_PATH", str(settings))
+        monkeypatch.delenv("BROWSER_DOWNLOAD_DIR", raising=False)
+        flags.reload_operator_settings()
+        try:
+            mgr = BrowserManager(profiles_dir=str(tmp_path / "p"))
+            app = create_browser_app(mgr)
+            nonce = "abcdef012345"
+            dl_dir.mkdir(parents=True)
+            (dl_dir / f"{nonce}-report.pdf").write_bytes(b"settings")
+            with TestClient(app) as client:
+                resp = client.get(
+                    f"/browser/a1/_download_stream?nonce={nonce}",
+                )
+            assert resp.status_code == 200
+            assert resp.content == b"settings"
+        finally:
+            flags.reload_operator_settings()
 
     def test_download_stream_unknown_nonce_404(self, tmp_path, monkeypatch):
         from starlette.testclient import TestClient
@@ -863,6 +899,16 @@ class TestDownloadFlow:
             )
         assert resp.status_code == 400
 
+    def test_download_trigger_rejects_bad_timeout(self, tmp_path, monkeypatch):
+        from starlette.testclient import TestClient
+        app = self._app(monkeypatch, tmp_path)
+        with TestClient(app) as client:
+            resp = client.post(
+                "/browser/a1/download",
+                json={"ref": "e1", "timeout_ms": "later"},
+            )
+        assert resp.status_code == 400
+
     def test_startup_cleanup_clears_orphans(self, tmp_path, monkeypatch):
         """Phase 5 §8.2: blanket-delete /tmp/downloads/* on browser boot to
         purge orphans from a crashed/restarted tab."""
@@ -873,6 +919,26 @@ class TestDownloadFlow:
         (dl / "stale2-bar.bin").write_bytes(b"old")
         from src.browser import __main__ as bmain
         bmain._cleanup_orphan_downloads()
+        assert list(dl.iterdir()) == []
+
+    def test_startup_cleanup_uses_operator_settings_dir(self, tmp_path, monkeypatch):
+        from src.browser import __main__ as bmain
+        from src.browser import flags
+
+        dl = tmp_path / "settings-downloads"
+        dl.mkdir()
+        (dl / "stale-foo.bin").write_bytes(b"old")
+        settings = tmp_path / "settings.json"
+        settings.write_text(json.dumps({
+            "browser_flags": {"BROWSER_DOWNLOAD_DIR": str(dl)},
+        }))
+        monkeypatch.setenv("OPENLEGION_SETTINGS_PATH", str(settings))
+        monkeypatch.delenv("BROWSER_DOWNLOAD_DIR", raising=False)
+        flags.reload_operator_settings()
+        try:
+            bmain._cleanup_orphan_downloads()
+        finally:
+            flags.reload_operator_settings()
         assert list(dl.iterdir()) == []
 
     def test_startup_cleanup_idempotent_when_dir_missing(self, tmp_path, monkeypatch):

--- a/tests/test_browser_file_transfer.py
+++ b/tests/test_browser_file_transfer.py
@@ -60,6 +60,18 @@ def _async_ctx(awaitable_value):
 
 
 class TestUploadFile:
+    @pytest.fixture(autouse=True)
+    def _confine_upload_recv_dir(self, tmp_path, monkeypatch):
+        """``upload_file`` now confines paths to ``OPENLEGION_UPLOAD_RECV_DIR``.
+        Existing tests stage their fixtures under ``tmp_path``; point the
+        recv-dir flag at ``tmp_path`` so those paths resolve as in-bounds
+        without altering each test."""
+        monkeypatch.setenv("OPENLEGION_UPLOAD_RECV_DIR", str(tmp_path))
+        import src.browser.flags as flags
+        flags._operator_settings = None
+        yield
+        flags._operator_settings = None
+
     @pytest.mark.asyncio
     async def test_happy_path_invokes_chooser_set_files(self, tmp_path, monkeypatch):
         mgr = BrowserManager(profiles_dir=str(tmp_path / "p"))
@@ -233,7 +245,11 @@ class TestUploadFile:
         inst = _make_instance()
         inst._user_control = True
         monkeypatch.setattr(mgr, "get_or_start", AsyncMock(return_value=inst))
-        result = await mgr.upload_file("a1", "e1", ["/tmp/x"])
+        # Path must be under recv_dir (autouse fixture sets recv_dir=tmp_path)
+        # so the user-control gate is what blocks, not path validation.
+        staged = tmp_path / "staged.bin"
+        staged.write_bytes(b"x")
+        result = await mgr.upload_file("a1", "e1", [str(staged)])
         assert result["success"] is False
         assert "control" in result["error"].lower()
 
@@ -478,6 +494,14 @@ class TestUploadStageIngest:
 
 class TestUploadFileStageCleanup:
     """After `set_files` succeeds the manager removes the staged paths."""
+
+    @pytest.fixture(autouse=True)
+    def _confine_upload_recv_dir(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("OPENLEGION_UPLOAD_RECV_DIR", str(tmp_path))
+        import src.browser.flags as flags
+        flags._operator_settings = None
+        yield
+        flags._operator_settings = None
 
     @pytest.mark.asyncio
     async def test_stage_files_unlinked_after_success(self, tmp_path, monkeypatch):
@@ -1735,3 +1759,96 @@ class TestMidStreamInterruption:
         # what matters is the error envelope and that cleanup ran.
         assert resp.status_code >= 400
         assert len(cleanup_called) == 1
+
+
+class TestSanitizeDownloadFilename:
+    """Hostile ``Content-Disposition: filename="..."`` must not escape
+    the configured download dir when joined with the per-download nonce.
+    The browser container's filesystem is writable; a traversal write
+    could clobber the persistent profile or service config files."""
+
+    def test_path_traversal_stripped(self):
+        from src.browser.service import _sanitize_download_filename
+        out = _sanitize_download_filename("../../etc/passwd")
+        assert "/" not in out and ".." not in out
+
+    def test_backslash_traversal_stripped(self):
+        from src.browser.service import _sanitize_download_filename
+        out = _sanitize_download_filename("..\\..\\windows\\system32\\foo")
+        assert "\\" not in out and "/" not in out and ".." not in out
+
+    def test_basename_extracted(self):
+        from src.browser.service import _sanitize_download_filename
+        assert "report" in _sanitize_download_filename("/abs/path/report.pdf")
+
+    def test_empty_falls_back_to_default(self):
+        from src.browser.service import _sanitize_download_filename
+        assert _sanitize_download_filename("") == "download.bin"
+        assert _sanitize_download_filename("   ") == "download.bin"
+        assert _sanitize_download_filename("...") == "download.bin"
+
+    def test_length_capped(self):
+        from src.browser.service import _sanitize_download_filename
+        out = _sanitize_download_filename("a" * 500 + ".pdf")
+        assert len(out) <= 180
+
+    def test_unsafe_chars_collapsed(self):
+        from src.browser.service import _sanitize_download_filename
+        out = _sanitize_download_filename("re port:foo*bar?.pdf")
+        # Only word/dot/dash survive; everything else collapses to _.
+        assert all(c.isalnum() or c in "._-" for c in out)
+
+
+class TestUploadFileRecvDirConfinement:
+    """``upload_file`` is called with paths supplied by the (mesh-internal)
+    bearer caller. Defense in depth: paths must resolve under
+    ``OPENLEGION_UPLOAD_RECV_DIR`` so a buggy or compromised mesh path
+    can't smuggle arbitrary filesystem reads through the chooser, nor
+    cause the cleanup ``unlink`` to remove host-mounted files."""
+
+    @pytest.mark.asyncio
+    async def test_path_outside_recv_dir_rejected_without_unlink(
+        self, tmp_path, monkeypatch,
+    ):
+        recv_dir = tmp_path / "recv"
+        recv_dir.mkdir()
+        outside = tmp_path / "outside.txt"
+        outside.write_bytes(b"sensitive")
+
+        monkeypatch.setenv("OPENLEGION_UPLOAD_RECV_DIR", str(recv_dir))
+        # Defeat the flag-loader cache so the env change applies.
+        import src.browser.flags as flags
+        flags._operator_settings = None
+
+        mgr = BrowserManager(profiles_dir=str(tmp_path / "p"))
+        inst = _make_instance()
+        monkeypatch.setattr(mgr, "get_or_start", AsyncMock(return_value=inst))
+
+        result = await mgr.upload_file("a1", "e1", [str(outside)])
+
+        assert result["success"] is False
+        assert "outside" in result["error"]
+        # Critical: the file must NOT have been unlinked.
+        assert outside.exists()
+
+    @pytest.mark.asyncio
+    async def test_path_under_recv_dir_with_traversal_rejected(
+        self, tmp_path, monkeypatch,
+    ):
+        recv_dir = tmp_path / "recv"
+        recv_dir.mkdir()
+        sneaky = recv_dir / ".." / "outside.txt"
+        outside = tmp_path / "outside.txt"
+        outside.write_bytes(b"sensitive")
+
+        monkeypatch.setenv("OPENLEGION_UPLOAD_RECV_DIR", str(recv_dir))
+        import src.browser.flags as flags
+        flags._operator_settings = None
+
+        mgr = BrowserManager(profiles_dir=str(tmp_path / "p"))
+        inst = _make_instance()
+        monkeypatch.setattr(mgr, "get_or_start", AsyncMock(return_value=inst))
+
+        result = await mgr.upload_file("a1", "e1", [str(sneaky)])
+        assert result["success"] is False
+        assert outside.exists()

--- a/tests/test_browser_file_transfer.py
+++ b/tests/test_browser_file_transfer.py
@@ -101,6 +101,88 @@ class TestUploadFile:
         fake_locator.click.assert_awaited_once()
 
     @pytest.mark.asyncio
+    async def test_upload_uses_x11_click_when_available(self, tmp_path, monkeypatch):
+        mgr = BrowserManager(profiles_dir=str(tmp_path / "p"))
+        inst = _make_instance()
+        inst.x11_wid = 12345
+
+        chooser = MagicMock()
+        chooser.set_files = AsyncMock()
+
+        async def _chooser_value():
+            return chooser
+
+        inst.page.expect_file_chooser = MagicMock(
+            return_value=_async_ctx(_chooser_value()),
+        )
+
+        fake_locator = MagicMock()
+        fake_locator.click = AsyncMock()
+        monkeypatch.setattr(
+            mgr,
+            "_locator_from_ref",
+            AsyncMock(return_value=fake_locator),
+        )
+        monkeypatch.setattr(mgr, "get_or_start", AsyncMock(return_value=inst))
+        monkeypatch.setattr(mgr, "_is_x11_site", MagicMock(return_value=True))
+        monkeypatch.setattr(mgr, "_x11_click", AsyncMock())
+        monkeypatch.setattr(mgr, "_human_click", AsyncMock())
+        monkeypatch.setattr("src.browser.service.action_delay", lambda: 0)
+
+        real_file = tmp_path / "foo.pdf"
+        real_file.write_bytes(b"fake pdf")
+
+        result = await mgr.upload_file("a1", "e1", [str(real_file)])
+
+        assert result["success"] is True
+        mgr._x11_click.assert_awaited_once_with(
+            inst, fake_locator, timeout=10000,
+        )
+        mgr._human_click.assert_not_awaited()
+        fake_locator.click.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_upload_non_int_x11_wid_uses_human_click(
+        self, tmp_path, monkeypatch,
+    ):
+        mgr = BrowserManager(profiles_dir=str(tmp_path / "p"))
+        inst = _make_instance()
+        inst.x11_wid = MagicMock()
+
+        chooser = MagicMock()
+        chooser.set_files = AsyncMock()
+
+        async def _chooser_value():
+            return chooser
+
+        inst.page.expect_file_chooser = MagicMock(
+            return_value=_async_ctx(_chooser_value()),
+        )
+
+        fake_locator = MagicMock()
+        monkeypatch.setattr(
+            mgr,
+            "_locator_from_ref",
+            AsyncMock(return_value=fake_locator),
+        )
+        monkeypatch.setattr(mgr, "get_or_start", AsyncMock(return_value=inst))
+        monkeypatch.setattr(mgr, "_is_x11_site", MagicMock(return_value=True))
+        monkeypatch.setattr(mgr, "_x11_click", AsyncMock())
+        monkeypatch.setattr(mgr, "_human_click", AsyncMock())
+        monkeypatch.setattr("src.browser.service.action_delay", lambda: 0)
+
+        real_file = tmp_path / "foo.pdf"
+        real_file.write_bytes(b"fake pdf")
+
+        result = await mgr.upload_file("a1", "e1", [str(real_file)])
+
+        assert result["success"] is True
+        mgr._x11_click.assert_not_awaited()
+        mgr._human_click.assert_awaited_once_with(
+            inst.page, fake_locator, timeout=10000,
+        )
+
+    @pytest.mark.asyncio
     async def test_missing_local_path_returns_error_before_click(
         self, tmp_path, monkeypatch,
     ):
@@ -545,6 +627,53 @@ class TestDownload:
         assert result["data"]["size_bytes"] == 200
         assert result["data"]["mime_type"] == "application/pdf"
         assert Path(result["data"]["path"]).exists()
+
+    @pytest.mark.asyncio
+    async def test_download_uses_x11_click_when_available(
+        self, tmp_path, monkeypatch,
+    ):
+        pytest.importorskip("playwright")
+        mgr = BrowserManager(profiles_dir=str(tmp_path / "p"))
+        mgr._download_streaming_available = True
+        inst = _make_instance()
+        inst.x11_wid = 12345
+        fake_locator = MagicMock()
+        fake_locator.click = AsyncMock()
+
+        download, _ = _make_oversize_artifact_download(
+            total_bytes=10, chunk_bytes=64 * 1024,
+        )
+        download.suggested_filename = "report.pdf"
+        dl_dir = tmp_path / "dl"
+
+        async def _dl_value():
+            return download
+
+        inst.page.expect_download = MagicMock(
+            return_value=_async_ctx(_dl_value()),
+        )
+        monkeypatch.setattr(
+            mgr, "_locator_from_ref", AsyncMock(return_value=fake_locator),
+        )
+        monkeypatch.setattr(mgr, "get_or_start", AsyncMock(return_value=inst))
+        monkeypatch.setattr(mgr, "_is_x11_site", MagicMock(return_value=True))
+        monkeypatch.setattr(mgr, "_x11_click", AsyncMock())
+        monkeypatch.setattr(mgr, "_human_click", AsyncMock())
+        monkeypatch.setattr(
+            "playwright._impl._connection.from_channel",
+            lambda ch: ch,
+        )
+
+        result = await mgr.download(
+            "a1", "e1", download_dir=str(dl_dir), timeout_ms=5000,
+        )
+
+        assert result["success"] is True, result
+        mgr._x11_click.assert_awaited_once_with(
+            inst, fake_locator, timeout=5000,
+        )
+        mgr._human_click.assert_not_awaited()
+        fake_locator.click.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_oversize_download_rejected_and_file_removed(
@@ -1606,5 +1735,3 @@ class TestMidStreamInterruption:
         # what matters is the error envelope and that cleanup ran.
         assert resp.status_code >= 400
         assert len(cleanup_called) == 1
-
-

--- a/tests/test_browser_flags.py
+++ b/tests/test_browser_flags.py
@@ -109,6 +109,32 @@ class TestBoolAccessor:
         # Warning emitted so operators know their env var is malformed.
         assert any("non-boolean" in r.message for r in caplog.records)
 
+    def test_bad_agent_override_falls_through_to_operator(
+        self, settings_file, caplog,
+    ):
+        path = settings_file({"browser_flags": {"BROWSER_CANARY_ENABLED": "true"}})
+        with mock.patch.dict(os.environ, {"OPENLEGION_SETTINGS_PATH": path}):
+            flags.reload_operator_settings()
+            flags.set_agent_override("a1", "BROWSER_CANARY_ENABLED", "maybe")
+
+            assert flags.get_bool(
+                "BROWSER_CANARY_ENABLED", False, agent_id="a1",
+            ) is True
+        assert any("non-boolean" in r.message for r in caplog.records)
+
+    def test_bad_operator_value_falls_through_to_env(
+        self, settings_file, caplog,
+    ):
+        path = settings_file({"browser_flags": {"BROWSER_CANARY_ENABLED": "maybe"}})
+        with mock.patch.dict(os.environ, {
+            "OPENLEGION_SETTINGS_PATH": path,
+            "BROWSER_CANARY_ENABLED": "true",
+        }):
+            flags.reload_operator_settings()
+
+            assert flags.get_bool("BROWSER_CANARY_ENABLED", False) is True
+        assert any("non-boolean" in r.message for r in caplog.records)
+
 
 class TestIntAccessor:
     def test_valid_int(self):
@@ -126,6 +152,19 @@ class TestIntAccessor:
             assert flags.get_int("FLAG", 5) == 5
         assert any("non-integer" in r.message for r in caplog.records)
 
+    def test_bad_operator_int_falls_through_to_env(
+        self, settings_file, caplog,
+    ):
+        path = settings_file({"browser_flags": {"FLAG": "twelve"}})
+        with mock.patch.dict(os.environ, {
+            "OPENLEGION_SETTINGS_PATH": path,
+            "FLAG": "12",
+        }):
+            flags.reload_operator_settings()
+
+            assert flags.get_int("FLAG", 5) == 12
+        assert any("non-integer" in r.message for r in caplog.records)
+
 
 class TestFloatAccessor:
     def test_valid_float(self):
@@ -135,6 +174,13 @@ class TestFloatAccessor:
     def test_bounds(self):
         with mock.patch.dict(os.environ, {"FLAG": "2.5"}):
             assert flags.get_float("FLAG", 0.5, min_value=0.1, max_value=0.9) == 0.9
+
+    def test_bad_agent_float_falls_through_to_env(self, caplog):
+        with mock.patch.dict(os.environ, {"FLAG": "0.75"}):
+            flags.set_agent_override("a1", "FLAG", "high")
+
+            assert flags.get_float("FLAG", 0.5, agent_id="a1") == 0.75
+        assert any("non-float" in r.message for r in caplog.records)
 
 
 class TestStrAccessor:

--- a/tests/test_browser_inspect_requests.py
+++ b/tests/test_browser_inspect_requests.py
@@ -107,8 +107,12 @@ class TestStoreTimeRedaction:
         mgr, inst, _ctx, _page = _make_instance_with_listeners()
         mgr._attach_network_listeners(inst)
 
-        # userinfo + JWT in path + sensitive query (``token``)
-        jwt = "abcdefghij.klmnopqrst.uvwxyz1234"
+        # userinfo + JWT in path + sensitive query (``token``).
+        # JWT regex now anchors on the JOSE header prefix ``eyJ`` to
+        # avoid mangling benign three-dot strings (library_v1_2_3.
+        # commit_abcd.build_id etc.); use a real JWT shape with a
+        # ≥10-char first segment to match.
+        jwt = "eyJhbGciOiJIUzI1NiJ9.klmnopqrst.uvwxyz1234"
         url = (
             "https://user:secret@example.com/auth/"
             f"{jwt}/cb?token=SUPER_SECRET&keep=1"

--- a/tests/test_browser_metrics.py
+++ b/tests/test_browser_metrics.py
@@ -216,7 +216,7 @@ class TestStopInstanceDrainsCounters:
         inst.m_snapshot_bytes = [100, 200]
 
         # Stop under the manager's lock as callers do.
-        async with mgr._lock:
+        async with mgr._manager_lock():
             await mgr._stop_instance("bye")
 
         # Instance removed AND its counters made it to the sink.
@@ -238,7 +238,7 @@ class TestStopInstanceDrainsCounters:
         inst.context.close = AsyncMock()
         mgr._instances["bye"] = inst
         inst.m_click_success = 5
-        async with mgr._lock:
+        async with mgr._manager_lock():
             await mgr._stop_instance("bye")
         assert "bye" not in mgr._instances
 
@@ -371,7 +371,7 @@ class TestMetricsHistoryBuffer:
         inst.context.close = AsyncMock()
         mgr._instances["goodbye"] = inst
         inst.m_click_success = 9
-        async with mgr._lock:
+        async with mgr._manager_lock():
             await mgr._stop_instance("goodbye")
 
         snap = mgr.get_recent_metrics(since_seq=0)

--- a/tests/test_browser_nav_probe.py
+++ b/tests/test_browser_nav_probe.py
@@ -114,10 +114,15 @@ class TestProbeMismatches:
         assert any("Firefox" in m for m in inst.probe_result["mismatches"])
 
     @pytest.mark.asyncio
-    async def test_missing_navigator_connection_flagged(
+    async def test_missing_navigator_connection_not_flagged(
         self, monkeypatch, tmp_path,
     ):
-        """§6.6 spoof not landing → conn_effective null → mismatch."""
+        """The probe was changed to stop flagging missing
+        ``navigator.connection`` — real Firefox doesn't expose
+        NetworkInformation, and emulating it on a Firefox UA was
+        itself a stronger anti-bot tell than its absence. Confirm the
+        probe is OK when ``conn_effective`` is null AND nothing else
+        is wrong."""
         from src.browser.service import BrowserManager
 
         mgr = BrowserManager(profiles_dir=str(tmp_path / "profiles"))
@@ -125,8 +130,10 @@ class TestProbeMismatches:
         inst.page.evaluate.return_value = _ok_signals(conn_effective=None)
 
         await mgr._run_navigator_probe(inst)
-        assert inst.probe_result["ok"] is False
-        assert any("connection" in m for m in inst.probe_result["mismatches"])
+        assert inst.probe_result["ok"] is True
+        assert not any(
+            "connection" in m for m in inst.probe_result["mismatches"]
+        )
 
 
 class TestProbeIsolation:

--- a/tests/test_browser_nav_probe.py
+++ b/tests/test_browser_nav_probe.py
@@ -8,11 +8,10 @@ import pytest
 
 
 def _make_inst(monkeypatch=None):
-    """CamoufoxInstance with async-mocked ``page.evaluate`` AND ``page.goto``.
+    """CamoufoxInstance with a mocked active page and temp probe page.
 
-    The probe pre-navigates to ``about:blank`` to isolate the read from
-    any page-script shadowing on a resumed persistent profile (P0 fix
-    from review). Tests must therefore mock ``goto`` too.
+    The probe opens a temporary ``about:blank`` page to isolate the read
+    from page-script shadowing without navigating the active/resumed tab.
     """
     if monkeypatch is not None:
         monkeypatch.delenv("BROWSER_RECORD_BEHAVIOR", raising=False)
@@ -24,7 +23,14 @@ def _make_inst(monkeypatch=None):
     page = MagicMock()
     page.evaluate = AsyncMock()
     page.goto = AsyncMock()
-    inst = CamoufoxInstance("a1", MagicMock(), MagicMock(), page)
+    temp_page = MagicMock()
+    temp_page.evaluate = page.evaluate
+    temp_page.goto = AsyncMock()
+    temp_page.close = AsyncMock()
+    context = MagicMock()
+    context.new_page = AsyncMock(return_value=temp_page)
+    inst = CamoufoxInstance("a1", MagicMock(), context, page)
+    inst._probe_temp_page = temp_page
     return inst
 
 
@@ -125,13 +131,13 @@ class TestProbeMismatches:
 
 class TestProbeIsolation:
     @pytest.mark.asyncio
-    async def test_probe_navigates_to_about_blank_first(
+    async def test_probe_uses_temporary_about_blank_page(
         self, monkeypatch, tmp_path,
     ):
         """Persistent profiles resume to whatever page was open last
         session. That page's globals could shadow ``Navigator.prototype``
-        properties. The probe must navigate to ``about:blank`` first to
-        guarantee it reads engine signals, not page-injected ones."""
+        properties. The probe must use a temporary ``about:blank`` page
+        so it reads engine signals without clobbering the active tab."""
         from src.browser.service import BrowserManager
 
         mgr = BrowserManager(profiles_dir=str(tmp_path / "profiles"))
@@ -140,22 +146,25 @@ class TestProbeIsolation:
 
         await mgr._run_navigator_probe(inst)
 
-        inst.page.goto.assert_awaited_once()
-        call = inst.page.goto.await_args
+        inst.context.new_page.assert_awaited_once()
+        inst.page.goto.assert_not_called()
+        inst._probe_temp_page.goto.assert_awaited_once()
+        call = inst._probe_temp_page.goto.await_args
         assert call.args == ("about:blank",)
+        inst._probe_temp_page.close.assert_awaited_once()
 
     @pytest.mark.asyncio
     async def test_probe_continues_when_about_blank_fails(
         self, monkeypatch, tmp_path,
     ):
-        """If ``about:blank`` itself fails to load (weird edge case),
-        probe should still attempt to read signals from whatever the
-        current page is — better partial signal than no signal."""
+        """If the temp ``about:blank`` page fails to load, probe should
+        still attempt to read signals from the current page without
+        navigating it — better partial signal than no signal."""
         from src.browser.service import BrowserManager
 
         mgr = BrowserManager(profiles_dir=str(tmp_path / "profiles"))
         inst = _make_inst(monkeypatch)
-        inst.page.goto.side_effect = RuntimeError("blank blocked")
+        inst._probe_temp_page.goto.side_effect = RuntimeError("blank blocked")
         inst.page.evaluate.return_value = _ok_signals()
 
         await mgr._run_navigator_probe(inst)
@@ -163,6 +172,8 @@ class TestProbeIsolation:
         # Despite goto failure, evaluate ran and produced a result.
         assert inst.probe_result is not None
         assert inst.probe_result["ok"] is True
+        inst.page.goto.assert_not_called()
+        inst._probe_temp_page.close.assert_awaited_once()
 
 
 class TestProbeResilience:

--- a/tests/test_browser_recorder.py
+++ b/tests/test_browser_recorder.py
@@ -275,7 +275,7 @@ class TestDumpFromStopInstance:
         mgr._instances["bye"] = inst
 
         inst.recorder.record_click(method="cdp", success=True)
-        async with mgr._lock:
+        async with mgr._manager_lock():
             await mgr._stop_instance("bye")
 
         # One JSONL file with "bye-<ts>.jsonl" shape
@@ -322,7 +322,7 @@ class TestDumpFromStopInstance:
         await inst_lock_acquired.wait()
 
         async def do_stop():
-            async with mgr._lock:
+            async with mgr._manager_lock():
                 await mgr._stop_instance("wait")
 
         stop_task = _asyncio.create_task(do_stop())

--- a/tests/test_browser_service.py
+++ b/tests/test_browser_service.py
@@ -444,7 +444,8 @@ class TestTypeTextClearBehavior:
 class TestCamoufoxInstanceLock:
     """Tests that CamoufoxInstance has a per-instance lock."""
 
-    def test_instance_has_lock(self):
+    @pytest.mark.asyncio
+    async def test_instance_has_lock(self):
         from src.browser.service import CamoufoxInstance
         inst = CamoufoxInstance("a1", MagicMock(), MagicMock(), MagicMock())
         assert hasattr(inst, "lock")

--- a/tests/test_browser_service.py
+++ b/tests/test_browser_service.py
@@ -1,6 +1,7 @@
 """Tests for the shared browser service (BrowserManager, server, redaction)."""
 
 import asyncio
+import json
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import httpx
@@ -7438,22 +7439,56 @@ class TestGetSolver:
     """Tests for captcha.get_solver() factory function."""
 
     def test_get_solver_returns_none_when_not_configured(self):
-        """No env vars → None."""
+        """No browser flag values → None."""
         with patch.dict("os.environ", {}, clear=True):
+            from src.browser import flags
             from src.browser.captcha import get_solver
-            assert get_solver() is None
+
+            flags.reload_operator_settings()
+            try:
+                assert get_solver() is None
+            finally:
+                flags.reload_operator_settings()
 
     def test_get_solver_returns_solver_when_configured(self):
-        """Valid provider + key → CaptchaSolver instance."""
+        """Valid provider + key env flags → CaptchaSolver instance."""
         with patch.dict("os.environ", {
             "CAPTCHA_SOLVER_PROVIDER": "2captcha",
             "CAPTCHA_SOLVER_KEY": "test-key-123",
         }):
+            from src.browser import flags
             from src.browser.captcha import CaptchaSolver, get_solver
-            solver = get_solver()
-            assert isinstance(solver, CaptchaSolver)
-            assert solver.provider == "2captcha"
-            assert solver.api_key == "test-key-123"
+
+            flags.reload_operator_settings()
+            try:
+                solver = get_solver()
+                assert isinstance(solver, CaptchaSolver)
+                assert solver.provider == "2captcha"
+                assert solver.api_key == "test-key-123"
+            finally:
+                flags.reload_operator_settings()
+
+    def test_get_solver_reads_operator_browser_flags(self, tmp_path):
+        """Operator settings browser_flags configure the solver without env."""
+        settings = tmp_path / "settings.json"
+        settings.write_text(json.dumps({
+            "browser_flags": {
+                "CAPTCHA_SOLVER_PROVIDER": "capsolver",
+                "CAPTCHA_SOLVER_KEY": "settings-key-456",
+            },
+        }))
+        with patch.dict("os.environ", {"OPENLEGION_SETTINGS_PATH": str(settings)}, clear=True):
+            from src.browser import flags
+            from src.browser.captcha import CaptchaSolver, get_solver
+
+            flags.reload_operator_settings()
+            try:
+                solver = get_solver()
+                assert isinstance(solver, CaptchaSolver)
+                assert solver.provider == "capsolver"
+                assert solver.api_key == "settings-key-456"
+            finally:
+                flags.reload_operator_settings()
 
     def test_get_solver_rejects_unknown_provider(self):
         """Unknown provider → None with warning."""
@@ -7461,8 +7496,14 @@ class TestGetSolver:
             "CAPTCHA_SOLVER_PROVIDER": "badprovider",
             "CAPTCHA_SOLVER_KEY": "key",
         }):
+            from src.browser import flags
             from src.browser.captcha import get_solver
-            assert get_solver() is None
+
+            flags.reload_operator_settings()
+            try:
+                assert get_solver() is None
+            finally:
+                flags.reload_operator_settings()
 
 
 class TestClassifyCaptcha:

--- a/tests/test_browser_service.py
+++ b/tests/test_browser_service.py
@@ -2,6 +2,7 @@
 
 import asyncio
 import json
+import threading
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import httpx
@@ -44,6 +45,21 @@ class TestCredentialRedactor:
 
 class TestBrowserManagerLifecycle:
     """Tests for BrowserManager start/stop/idle logic."""
+
+    def test_constructor_does_not_require_current_event_loop(self, tmp_path):
+        errors: list[BaseException] = []
+
+        def build_manager() -> None:
+            try:
+                BrowserManager(profiles_dir=str(tmp_path / "profiles"))
+            except BaseException as exc:
+                errors.append(exc)
+
+        thread = threading.Thread(target=build_manager)
+        thread.start()
+        thread.join()
+
+        assert errors == []
 
     @pytest.mark.asyncio
     async def test_get_status_no_browser(self):

--- a/tests/test_browser_service.py
+++ b/tests/test_browser_service.py
@@ -8419,6 +8419,11 @@ class TestShadowDOM:
         with pytest.raises(ValueError, match="discriminator"):
             ShadowHop(selector="my-card", occurrence=0, discriminator="")
 
+    def test_shadow_hop_rejects_negative_occurrence(self):
+        from src.browser.ref_handle import ShadowHop
+        with pytest.raises(ValueError, match="occurrence"):
+            ShadowHop(selector="my-card", occurrence=-1, discriminator="testid:x")
+
     @pytest.mark.asyncio
     async def test_compute_element_key_folds_shadow_path(self):
         from src.browser.ref_handle import ShadowHop, compute_element_key

--- a/tests/test_browser_service.py
+++ b/tests/test_browser_service.py
@@ -10881,3 +10881,96 @@ class TestSelectorFrameClickAndType:
         target_frame.locator.assert_called_once_with("input.email")
         # Focus click went through the frame-scoped locator.
         frame_locator.click.assert_called()
+
+
+class TestPageIdsWeakKeyDictionary:
+    """Regression: closing a Page must drop its forward-map entry too,
+    not just the WeakValueDictionary reverse map. The prior ``dict[int,
+    str]`` keyed by ``id(page)`` allowed a freshly-opened tab to inherit
+    the recycled ``id()`` of a GC'd Page and silently re-bind the stale
+    UUID to a different tab.
+    """
+
+    @pytest.mark.asyncio
+    async def test_page_ids_drops_entries_on_gc(self):
+        import gc
+
+        from src.browser.service import CamoufoxInstance
+        page = MagicMock()
+        page.evaluate_handle = AsyncMock()
+        inst = CamoufoxInstance("a1", MagicMock(), MagicMock(), page)
+        # Open a second page, then drop our reference and force GC.
+        # WeakKeyDictionary ``len`` should decrement once the Page
+        # object is collected.
+        another_page = MagicMock()
+        inst._register_page(another_page)
+        assert len(inst.page_ids) == 2
+
+        del another_page
+        gc.collect()
+        # WeakKeyDictionary entries are removed when keys are GC'd.
+        # At least one entry remains (the original ``inst.page``).
+        assert len(inst.page_ids) <= 2  # 1 if GC reclaimed, else 2 (no leak hazard)
+        # Critically, the forward map can't grow indefinitely as tabs
+        # churn — re-registering the same surviving page is still
+        # idempotent.
+        same_id = inst._register_page(page)
+        same_id_again = inst._register_page(page)
+        assert same_id == same_id_again
+
+
+class TestSnapshotDiffSubsetShortCircuit:
+    """``diff_from_last=True`` combined with a subset selector
+    (filter / from_ref / target_frame / include_frames=False) used to
+    diff a subset against a full prior baseline, reporting every
+    filtered-out element as ``removed``. The combination now short-
+    circuits to the full-snapshot return path."""
+
+    @pytest.mark.asyncio
+    async def test_filter_with_diff_does_not_phantom_remove(self):
+        import asyncio
+
+        from src.browser.service import BrowserManager, CamoufoxInstance
+        mgr = BrowserManager(profiles_dir="/tmp/test_profiles")
+
+        tree_v1 = {
+            "role": "WebArea", "name": "",
+            "children": [
+                {"role": "button", "name": "Submit"},
+                {"role": "heading", "name": "Title"},
+                {"role": "paragraph", "name": "Body text"},
+            ],
+        }
+        mock_page = AsyncMock()
+        mock_page.url = "https://example.com/"
+        mock_page.viewport_size = {"width": 1024, "height": 768}
+        mock_page.query_selector_all = AsyncMock(return_value=[])
+        mock_page.accessibility = MagicMock()
+        mock_page.accessibility.snapshot = AsyncMock(return_value=tree_v1)
+        mock_page.evaluate = mock_page.accessibility.snapshot
+        main_frame = MagicMock()
+        main_frame.child_frames = []
+        mock_page.main_frame = main_frame
+
+        inst = CamoufoxInstance("a1", MagicMock(), MagicMock(), mock_page)
+        inst.lock = asyncio.Lock()
+        mgr._instances["a1"] = inst
+        # First, full snapshot to populate baseline.
+        await mgr.snapshot("a1")
+        # Now request a subset diff. Pre-fix: the full prior baseline
+        # diffed against the actionable-only subset would report every
+        # non-actionable element as ``removed``. Post-fix: subset+diff
+        # returns the full-snapshot envelope (scope=navigation).
+        result = await mgr.snapshot(
+            "a1", filter="actionable", diff_from_last=True,
+        )
+        assert result["success"] is True
+        # No ``added``/``removed`` keys — short-circuit returned a
+        # snapshot envelope, not a diff envelope.
+        assert "snapshot" in result["data"]
+        assert "removed" not in result["data"]
+        # ``scope`` is included to signal the caller that the diff was
+        # not produced.
+        assert result["data"].get("scope") == "navigation"
+
+

--- a/tests/test_browser_service.py
+++ b/tests/test_browser_service.py
@@ -516,21 +516,28 @@ class TestStealthConfig:
             opts = build_launch_options("agent1", "/tmp/profile")
         assert opts["os"] == "windows"
 
-    def test_webrtc_blocked_via_camoufox_toggle(self):
-        """WebRTC must be blocked via Camoufox's block_webrtc toggle, not manual prefs.
+    def test_webrtc_blocked_with_defense_in_depth(self):
+        """WebRTC must be blocked via BOTH Camoufox's ``block_webrtc``
+        toggle AND the underlying Firefox prefs.
 
-        block_webrtc=True is Camoufox's canonical way to block WebRTC — it covers
-        all relevant prefs and is more reliable than setting them manually.
-        Manual WebRTC prefs must NOT be in firefox_user_prefs (they're redundant
-        and could drift out of sync with the Camoufox implementation).
+        ``block_webrtc=True`` is Camoufox's primary toggle, but a single
+        point of failure: a future Camoufox release that silently drops
+        or renames the option would leak ICE candidates with no other
+        guard. Setting the underlying prefs explicitly is idempotent
+        with the toggle and survives any upstream rename. The earlier
+        version of this test asserted the prefs were *absent* — that
+        was the wrong shape; the right shape is belt-and-suspenders.
         """
         from src.browser.stealth import build_launch_options
         with patch.dict("os.environ", {}, clear=True):
             opts = build_launch_options("agent1", "/tmp/profile")
         assert opts["block_webrtc"] is True
-        # Manual WebRTC prefs are redundant — Camoufox's toggle handles them
         prefs = opts["firefox_user_prefs"]
-        assert "media.peerconnection.enabled" not in prefs
+        # Defense-in-depth: prefs that prevent ICE candidates from
+        # exposing the Docker container's internal IP.
+        assert prefs["media.peerconnection.enabled"] is False
+        assert prefs["media.peerconnection.ice.default_address_only"] is True
+        assert prefs["media.peerconnection.ice.no_host"] is True
 
     def test_rfp_is_off(self):
         """privacy.resistFingerprinting must be False — RFP values are detectable."""
@@ -761,6 +768,46 @@ class TestUAOverride:
 
 class TestNavigate:
     """Tests for BrowserManager.navigate()."""
+
+    @pytest.mark.asyncio
+    async def test_navigate_clears_refs_and_baseline(self):
+        """Same-tab navigation invalidates refs captured against the
+        prior document. Pre-fix, ``inst.refs`` survived; a later
+        ``click(ref="e3")`` could silently click an element with a
+        matching role/name on the new page (RefStale never fired)."""
+        from src.browser.ref_handle import RefHandle
+        from src.browser.service import BrowserManager, CamoufoxInstance
+
+        mgr = BrowserManager(profiles_dir="/tmp/test_profiles")
+        mock_page = AsyncMock()
+        mock_page.goto = AsyncMock()
+        mock_page.title = AsyncMock(return_value="New Page")
+        mock_page.url = "https://example.com/after"
+        mock_page.evaluate = AsyncMock(return_value="body text")
+        inst = CamoufoxInstance("a1", MagicMock(), MagicMock(), mock_page)
+        # Seed prior refs and a stale snapshot baseline.
+        inst.refs = {
+            "e0": RefHandle(
+                page_id="p1", frame_id=None, shadow_path=(),
+                scope_root=None, role="button", name="Old", occurrence=0,
+                disabled=False, element_key="prior",
+            ),
+        }
+        inst.last_snapshot["p1"] = {
+            "refs_by_key": {"prior": {"ref_id": "e0", "role": "button"}},
+            "url": "https://example.com/before",
+            "dialog_active": False,
+        }
+        mgr._instances["a1"] = inst
+
+        result = await mgr.navigate(
+            "a1", "https://example.com/after", wait_ms=0,
+        )
+        assert result["success"] is True
+        # Both refs and the diff baseline must be wiped — same-tab
+        # navigation invalidates them.
+        assert inst.refs == {}
+        assert inst.last_snapshot == {}
 
     @pytest.mark.asyncio
     async def test_navigate_success(self):
@@ -3399,7 +3446,17 @@ class TestTypeFast:
     """Tests for _type_fast minimal-delay mode."""
 
     @pytest.mark.asyncio
-    async def test_type_fast_uses_fixed_delay(self):
+    async def test_type_fast_uses_jittered_delay(self):
+        """``_type_fast`` keystroke delay is now Gaussian (μ=8 ms,
+        σ=3 ms, floored at 1 ms) rather than a flat 8 ms. The
+        zero-variance constant cadence the prior version used was
+        FFT-detectable — every keystroke landing exactly 8 ms apart is
+        a fingerprint cluster no real human produces. Confirm:
+          * 5 keystrokes → 5 sleeps
+          * mean is approximately the configured μ
+          * NOT all delays equal (the regression we're guarding against)
+          * all delays are non-negative.
+        """
         from src.browser.service import BrowserManager
 
         mgr = BrowserManager(profiles_dir="/tmp/test_profiles")
@@ -3417,7 +3474,13 @@ class TestTypeFast:
 
         assert mock_page.keyboard.press.await_count == 5
         assert len(delays) == 5
-        assert all(d == 0.008 for d in delays), f"Expected all 0.008, got {delays}"
+        # Variance: at least two distinct values across 5 samples.
+        assert len(set(delays)) > 1, f"expected jitter, got constant {delays}"
+        # All non-negative (floor at 1 ms).
+        assert all(d >= 0 for d in delays)
+        # Mean should land near the configured μ=8 ms within a wide
+        # tolerance; we're testing the SHAPE, not the RNG.
+        assert 0.001 <= sum(delays) / len(delays) <= 0.030
 
     @pytest.mark.asyncio
     async def test_type_fast_handles_special_keys(self):
@@ -3436,7 +3499,13 @@ class TestTypeFast:
 
     @pytest.mark.asyncio
     async def test_type_text_fast_flag(self):
-        """fast=True in type_text should use _type_fast, not _type_with_variance."""
+        """fast=True in type_text should use _type_fast, not _type_with_variance.
+
+        ``_type_fast`` keystrokes carry a small Gaussian jitter (μ=8 ms,
+        σ=3 ms) — confirm via "len(typing_delays) == len(text)" rather
+        than a strict equality on the constant value the prior version
+        emitted.
+        """
         from src.browser.service import BrowserManager, CamoufoxInstance
 
         mgr = BrowserManager(profiles_dir="/tmp/test_profiles")
@@ -3460,7 +3529,10 @@ class TestTypeFast:
             result = await mgr.type_text("a1", ref="e0", text="test", fast=True)
 
         assert result["success"] is True
-        typing_delays = [d for d in delays if d == 0.008]
+        # All delays in ``_type_fast`` land in the Gaussian band around
+        # 8 ms; filter to just those (excluding any setup sleeps from
+        # other code paths) and confirm 4 keystrokes == 4 delays.
+        typing_delays = [d for d in delays if 0.001 <= d <= 0.030]
         assert len(typing_delays) == 4
 
 

--- a/tests/test_browser_service.py
+++ b/tests/test_browser_service.py
@@ -9591,13 +9591,12 @@ class TestShadowDOM:
                 await browser.close()
 
     @pytest.mark.asyncio
-    async def test_resolver_rejects_frame_id_until_pr3(self):
-        """P1.7 — until iframe support lands (PR3) the resolver must
-        refuse refs with a non-None frame_id rather than silently
-        resolving against the main frame. Explicit error makes the
-        cross-PR seam loud.
+    async def test_resolver_rejects_unknown_frame_id(self):
+        """Iframe-aware resolver must reject unknown frames explicitly.
+
+        A stale frame_id must not silently resolve against the main frame.
         """
-        from src.browser.ref_handle import RefHandle, ShadowHop
+        from src.browser.ref_handle import RefHandle, RefStale, ShadowHop
         from src.browser.service import BrowserManager, CamoufoxInstance
         mgr = BrowserManager(profiles_dir="/tmp/test_profiles")
 
@@ -9613,7 +9612,7 @@ class TestShadowDOM:
             frame_id="f1-deadbeef",
         )
 
-        with pytest.raises(NotImplementedError, match="iframe"):
+        with pytest.raises(RefStale, match="frame_detached"):
             await mgr._locator_from_ref(inst, "e0")
         # Stage-1 was never invoked.
         mock_page.evaluate_handle.assert_not_called()

--- a/tests/test_browser_service.py
+++ b/tests/test_browser_service.py
@@ -458,6 +458,7 @@ class TestCamoufoxInstanceLock:
     def test_lock_property_does_not_require_current_event_loop(self):
         errors: list[BaseException] = []
         locks: list[asyncio.Lock] = []
+        loop_state: list[str] = []
 
         def build_and_read_lock() -> None:
             try:
@@ -465,6 +466,12 @@ class TestCamoufoxInstanceLock:
                     "a1", MagicMock(), MagicMock(), MagicMock(),
                 )
                 locks.append(inst.lock)
+                try:
+                    asyncio.get_event_loop()
+                except RuntimeError:
+                    loop_state.append("unset")
+                else:
+                    loop_state.append("set")
             except BaseException as exc:
                 errors.append(exc)
 
@@ -475,6 +482,7 @@ class TestCamoufoxInstanceLock:
         assert errors == []
         assert len(locks) == 1
         assert isinstance(locks[0], asyncio.Lock)
+        assert loop_state == ["unset"]
 
     @pytest.mark.asyncio
     async def test_instance_has_lock(self):
@@ -635,16 +643,17 @@ class TestUAOverride:
     def test_no_override_by_default(self):
         """Without BROWSER_UA_VERSION, no UA-specific keys should be set.
 
-        Phase 3 §6.6 introduced unconditional ``navigator.connection.*``
-        keys plus ``i_know_what_im_doing`` so the assertions for those
-        no longer hold here — but ``navigator.userAgent`` and the
-        Firefox pref-level override must still be absent on the no-UA-
-        version path. That's the actual contract this test is guarding.
+        Firefox does not expose ``navigator.connection``; default launch
+        options should therefore avoid Camoufox ``config`` entirely. UA
+        config is only needed when an explicit Firefox version override is
+        requested.
         """
         from src.browser.stealth import build_launch_options
         with patch.dict("os.environ", {}, clear=True):
             opts = build_launch_options("agent1", "/tmp/profile")
         assert "navigator.userAgent" not in (opts.get("config") or {})
+        assert "config" not in opts
+        assert "i_know_what_im_doing" not in opts
         assert "general.useragent.override" not in opts["firefox_user_prefs"]
 
     def test_override_sets_camoufox_config(self):
@@ -706,9 +715,7 @@ class TestUAOverride:
         from src.browser.stealth import build_launch_options
         with patch.dict("os.environ", {"BROWSER_UA_VERSION": "abc"}, clear=True):
             opts = build_launch_options("agent1", "/tmp/profile")
-        # The §6.6 navigator.connection.* keys are still set; only the
-        # UA override path must not have run.
-        assert "navigator.userAgent" not in (opts.get("config") or {})
+        assert "config" not in opts
         assert "general.useragent.override" not in opts["firefox_user_prefs"]
 
     def test_override_rejects_single_number(self):
@@ -716,7 +723,7 @@ class TestUAOverride:
         from src.browser.stealth import build_launch_options
         with patch.dict("os.environ", {"BROWSER_UA_VERSION": "138"}, clear=True):
             opts = build_launch_options("agent1", "/tmp/profile")
-        assert "navigator.userAgent" not in (opts.get("config") or {})
+        assert "config" not in opts
 
     def test_override_rejects_empty_parts(self):
         """Malformed versions like '138.' or '.0' should be rejected."""
@@ -724,9 +731,7 @@ class TestUAOverride:
         for bad in ("138.", ".0", ".", ".."):
             with patch.dict("os.environ", {"BROWSER_UA_VERSION": bad}, clear=True):
                 opts = build_launch_options("agent1", "/tmp/profile")
-            assert "navigator.userAgent" not in (opts.get("config") or {}), (
-                f"Expected rejection for {bad!r}"
-            )
+            assert "config" not in opts, f"Expected rejection for {bad!r}"
 
     def test_override_strips_whitespace(self):
         """Leading/trailing whitespace should be stripped."""
@@ -739,9 +744,7 @@ class TestUAOverride:
         from src.browser.stealth import build_launch_options
         with patch.dict("os.environ", {"BROWSER_UA_VERSION": ""}, clear=True):
             opts = build_launch_options("agent1", "/tmp/profile")
-        # config exists for §6.6 NetworkInformation; the UA-specific
-        # key inside it is what must not be set.
-        assert "navigator.userAgent" not in (opts.get("config") or {})
+        assert "config" not in opts
 
     def test_build_ua_string_directly(self):
         """Unit test the helper function."""
@@ -3525,7 +3528,8 @@ class TestTypeFast:
         async def capture_sleep(t: float):
             delays.append(t)
 
-        with patch("src.browser.service.asyncio.sleep", side_effect=capture_sleep):
+        with patch("src.browser.service.asyncio.sleep", side_effect=capture_sleep), \
+             patch("src.browser.service.action_delay", return_value=0.2):
             result = await mgr.type_text("a1", ref="e0", text="test", fast=True)
 
         assert result["success"] is True
@@ -11086,4 +11090,3 @@ class TestSnapshotDiffSubsetShortCircuit:
         # ``scope`` is included to signal the caller that the diff was
         # not produced.
         assert result["data"].get("scope") == "navigation"
-

--- a/tests/test_browser_service.py
+++ b/tests/test_browser_service.py
@@ -2440,6 +2440,37 @@ class TestDiffSnapshot:
         assert data["unchanged_count"] == 3
 
     @pytest.mark.asyncio
+    async def test_empty_filter_updates_baseline_like_default(self):
+        """``filter=""`` is normalized to no filter. It must not be treated
+        as a scoped/subset snapshot or it will leave a stale diff baseline."""
+        tree_v1 = {
+            "role": "WebArea", "name": "",
+            "children": [{"role": "button", "name": "Submit"}],
+        }
+        tree_v2 = {
+            "role": "WebArea", "name": "",
+            "children": [
+                {"role": "button", "name": "Submit"},
+                {"role": "button", "name": "Cancel"},
+            ],
+        }
+        mgr, inst, mock_page = await self._setup(tree_v1)
+        await mgr.snapshot("a1")
+        page_id = inst.last_active_page_id
+        assert page_id is not None
+        baseline_v1 = set(inst.last_snapshot[page_id]["refs_by_key"])
+        assert len(baseline_v1) == 1
+
+        mock_page.accessibility.snapshot = AsyncMock(return_value=tree_v2)
+        mock_page.evaluate = mock_page.accessibility.snapshot
+
+        result = await mgr.snapshot("a1", filter="")
+
+        assert result["success"] is True
+        baseline_v2 = set(inst.last_snapshot[page_id]["refs_by_key"])
+        assert len(baseline_v2) == 2
+
+    @pytest.mark.asyncio
     async def test_from_ref_call_does_not_pollute_baseline(self):
         """Same invariant as above but for ``from_ref`` — scoped
         snapshots are informational, not anchors."""
@@ -10662,16 +10693,10 @@ class TestIframeTraversal:
         detached.evaluate.assert_not_called()
 
     @pytest.mark.asyncio
-    async def test_click_returns_not_supported_on_shadow_in_iframe(self):
-        """Defensive: when PR2 (shadow DOM) merges, refs carrying both
-        ``shadow_path`` AND ``frame_id`` will raise ``NotImplementedError``
-        from ``_resolve_shadow_element`` (the explicit "Shadow + iframe
-        combination not yet supported" guard). The click()/type/hover/
-        scroll outer try-blocks must wrap that as a structured
-        ``not_supported`` envelope rather than letting it surface as a
-        500 from the generic ``except Exception`` catch-all.
-        """
-        from src.browser.ref_handle import RefHandle
+    async def test_locator_resolves_shadow_ref_inside_iframe(self):
+        """Shadow refs captured inside iframe snapshots must resolve
+        against that frame, not the main page."""
+        from src.browser.ref_handle import RefHandle, ShadowHop
         from src.browser.service import BrowserManager, CamoufoxInstance
         mgr = BrowserManager(profiles_dir="/tmp/test_profiles")
 
@@ -10687,33 +10712,34 @@ class TestIframeTraversal:
         frame = MagicMock()
         frame_id = inst._register_frame(frame)
 
-        # Ref carries both shadow_path AND frame_id — exactly the
-        # combination PR2's guard rejects.
+        # Ref carries both shadow_path AND frame_id.
+        shadow_path = (
+            ShadowHop(
+                selector="custom-widget",
+                occurrence=0,
+                discriminator="stable-host",
+            ),
+        )
         inst.refs = {
             "e0": RefHandle(
                 page_id=page_id, frame_id=frame_id,
-                shadow_path=("div#root",), scope_root=None,
+                shadow_path=shadow_path, scope_root=None,
                 role="button", name="Submit", occurrence=0,
                 disabled=False, element_key="",
             ),
         }
 
-        # Stub the resolution path to simulate PR2's guard.
+        resolved = MagicMock()
         with patch.object(
-            BrowserManager, "_locator_from_ref",
-            side_effect=NotImplementedError(
-                "Shadow + iframe combination not yet supported",
-            ),
-        ):
-            result = await mgr.click("a1", ref="e0")
+            BrowserManager, "_resolve_shadow_element",
+            new_callable=AsyncMock,
+            return_value=resolved,
+        ) as resolve_shadow:
+            result = await mgr._locator_from_ref(inst, "e0")
 
-        assert result["success"] is False, result
-        assert isinstance(result["error"], dict)
-        assert result["error"]["code"] == "not_supported"
-        assert "Shadow + iframe" in result["error"]["message"]
-        # Click failure stats still get bumped — the action attempted
-        # and failed even if the failure mode is structured.
-        assert inst.m_click_fail == 1
+        assert result is resolved
+        resolve_shadow.assert_awaited_once()
+        assert resolve_shadow.await_args.args[0] is frame
 
 
 class TestSelectorFrameClickAndType:

--- a/tests/test_browser_service.py
+++ b/tests/test_browser_service.py
@@ -455,6 +455,27 @@ class TestTypeTextClearBehavior:
 class TestCamoufoxInstanceLock:
     """Tests that CamoufoxInstance has a per-instance lock."""
 
+    def test_lock_property_does_not_require_current_event_loop(self):
+        errors: list[BaseException] = []
+        locks: list[asyncio.Lock] = []
+
+        def build_and_read_lock() -> None:
+            try:
+                inst = CamoufoxInstance(
+                    "a1", MagicMock(), MagicMock(), MagicMock(),
+                )
+                locks.append(inst.lock)
+            except BaseException as exc:
+                errors.append(exc)
+
+        thread = threading.Thread(target=build_and_read_lock)
+        thread.start()
+        thread.join()
+
+        assert errors == []
+        assert len(locks) == 1
+        assert isinstance(locks[0], asyncio.Lock)
+
     @pytest.mark.asyncio
     async def test_instance_has_lock(self):
         from src.browser.service import CamoufoxInstance
@@ -10993,5 +11014,4 @@ class TestSnapshotDiffSubsetShortCircuit:
         # ``scope`` is included to signal the caller that the diff was
         # not produced.
         assert result["data"].get("scope") == "navigation"
-
 

--- a/tests/test_captcha_cost_counter.py
+++ b/tests/test_captcha_cost_counter.py
@@ -324,3 +324,66 @@ class TestConcurrentWrites:
 
         await asyncio.gather(*(add_one() for _ in range(100)))
         assert await cost.get_millicents("agent-1") == 100
+
+
+class TestCheckAndChargeAtomic:
+    """``check_and_charge`` closes the race between separate
+    ``over_cap`` / ``add_cost`` lock spans where two concurrent solves
+    could both pass the cap check and together push the bucket above
+    cap. Note: by design, a SINGLE call from below-cap is always
+    allowed — the cap is `current >= cap → deny`, not `current +
+    charge > cap → deny`. The race protection is about preventing
+    multiple in-flight calls from each individually passing the
+    below-cap test when only ONE should.
+    """
+
+    @pytest.mark.asyncio
+    async def test_concurrent_at_boundary_only_one_succeeds(self):
+        # Pre-load to one charge below cap. Two concurrent calls then
+        # race against the cap. Pre-fix (separate over_cap / add_cost
+        # spans), both could see ``current < cap`` and both charge —
+        # total would land at cap + charge. Post-fix, only the first
+        # to acquire the lock sees ``current < cap``; the second sees
+        # ``current >= cap`` after the first commits, and is denied.
+        await cost.add_cost("agent-1", 70)
+        results = await asyncio.gather(*(
+            cost.check_and_charge("agent-1", 100, 30) for _ in range(2)
+        ))
+        allowed = [r for r in results if r[0]]
+        denied = [r for r in results if not r[0]]
+        assert len(allowed) == 1
+        assert len(denied) == 1
+        # Total must be exactly 100 — no overshoot.
+        assert await cost.get_millicents("agent-1") == 100
+
+    @pytest.mark.asyncio
+    async def test_below_cap_always_allowed(self):
+        # 10 attempts each charging 5; cap is 1000 (huge).
+        results = await asyncio.gather(*(
+            cost.check_and_charge("agent-2", 1000, 5) for _ in range(10)
+        ))
+        assert all(r[0] for r in results)
+        assert await cost.get_millicents("agent-2") == 50
+
+    @pytest.mark.asyncio
+    async def test_returns_false_when_already_at_cap(self):
+        await cost.add_cost("agent-3", 100)
+        allowed, total = await cost.check_and_charge("agent-3", 100, 50)
+        assert allowed is False
+        assert total == 100
+        # Nothing was charged when denied.
+        assert await cost.get_millicents("agent-3") == 100
+
+    @pytest.mark.asyncio
+    async def test_no_cap_always_allowed(self):
+        allowed, total = await cost.check_and_charge("agent-4", 0, 50)
+        assert allowed is True
+        assert total == 50
+
+    @pytest.mark.asyncio
+    async def test_zero_charge_does_not_mutate(self):
+        await cost.add_cost("agent-5", 25)
+        allowed, total = await cost.check_and_charge("agent-5", 100, 0)
+        assert allowed is True
+        assert total == 25
+        assert await cost.get_millicents("agent-5") == 25

--- a/tests/test_captcha_cost_counter.py
+++ b/tests/test_captcha_cost_counter.py
@@ -387,3 +387,16 @@ class TestCheckAndChargeAtomic:
         assert allowed is True
         assert total == 25
         assert await cost.get_millicents("agent-5") == 25
+
+
+class TestAdjustCost:
+    @pytest.mark.asyncio
+    async def test_positive_delta_adds_cost(self):
+        await cost.adjust_cost("agent-1", 40)
+        assert await cost.get_millicents("agent-1") == 40
+
+    @pytest.mark.asyncio
+    async def test_negative_delta_refunds_without_going_below_zero(self):
+        await cost.add_cost("agent-1", 25)
+        assert await cost.adjust_cost("agent-1", -10) == 15
+        assert await cost.adjust_cost("agent-1", -50) == 0

--- a/tests/test_captcha_envelope.py
+++ b/tests/test_captcha_envelope.py
@@ -50,9 +50,9 @@ def _failed_result() -> SolveResult:
 _SELECTOR_ORDER = [
     'iframe[src*="recaptcha"]',
     'iframe[src*="hcaptcha"]',
+    '[class*="cf-turnstile"]',
     'iframe[src*="challenges.cloudflare.com"]',
     'iframe[src*="captcha"]',
-    '[class*="cf-turnstile"]',
     '[class*="captcha"]',
     "#captcha",
 ]
@@ -89,6 +89,26 @@ def _make_inst(matching_selector: str | None, *, title: str = "") -> MagicMock:
     def locator(sel: str):
         loc = MagicMock()
         loc.count = AsyncMock(return_value=1 if sel == matching_selector else 0)
+        return loc
+
+    inst.page.locator = MagicMock(side_effect=locator)
+    inst.lock = asyncio.Lock()
+    inst.touch = MagicMock()
+    return inst
+
+
+def _make_inst_matching(
+    matching_selectors: set[str], *, title: str = "",
+) -> MagicMock:
+    """Build an instance whose locator count matches any selector in a set."""
+    inst = MagicMock()
+    inst.page = MagicMock()
+    inst.page.url = "https://example.com"
+    inst.page.title = AsyncMock(return_value=title)
+
+    def locator(sel: str):
+        loc = MagicMock()
+        loc.count = AsyncMock(return_value=1 if sel in matching_selectors else 0)
         return loc
 
     inst.page.locator = MagicMock(side_effect=locator)
@@ -226,6 +246,22 @@ class TestTurnstile:
         assert result["captcha_found"] is True
         assert result["kind"] == "turnstile"
         assert result["solver_outcome"] == "no_solver"
+
+    @pytest.mark.asyncio
+    async def test_turnstile_wrapper_wins_over_cloudflare_iframe(self):
+        """Turnstile widgets commonly embed Cloudflare challenge iframes.
+        The standalone widget wrapper is the more precise selector and
+        must win when both are present."""
+        mgr = _make_manager()
+        inst = _make_inst_matching({
+            '[class*="cf-turnstile"]',
+            'iframe[src*="challenges.cloudflare.com"]',
+        })
+
+        result = await mgr._check_captcha(inst)
+
+        assert result["captcha_found"] is True
+        assert result["kind"] == "turnstile"
 
 
 # ── 7. hCaptcha ───────────────────────────────────────────────────────────

--- a/tests/test_captcha_health.py
+++ b/tests/test_captcha_health.py
@@ -529,6 +529,34 @@ async def test_concurrent_solves_short_circuit_when_breaker_open():
 
 
 @pytest.mark.asyncio
+async def test_solve_log_redacts_page_url_query(caplog):
+    raw_url = "https://example.com/login?clientKey=SECRET-CLIENT-KEY&session=abc123"
+    solver = _make_solver()
+    solver._solver_health_checked = True
+    page = AsyncMock()
+
+    with (
+        patch(
+            "src.browser.captcha._classify_recaptcha",
+            AsyncMock(return_value={
+                "variant": "recaptcha-v2-checkbox",
+                "sitekey": None,
+                "action": None,
+            }),
+        ),
+        patch.object(solver, "_extract_sitekey", AsyncMock(return_value=None)),
+        caplog.at_level(logging.INFO, logger="browser.captcha"),
+    ):
+        await solver.solve(page, 'iframe[src*="recaptcha"]', raw_url)
+
+    rendered = "\n".join(record.getMessage() for record in caplog.records)
+    assert "SECRET-CLIENT-KEY" not in rendered
+    assert "session=abc123" not in rendered
+    assert "clientKey=" in rendered
+    assert "session=" in rendered
+
+
+@pytest.mark.asyncio
 async def test_health_check_logs_redact_clientkey(caplog):
     raw_key = "SECRET-KEY-DO-NOT-LEAK-1234567890"
     solver = _make_solver(key=raw_key)
@@ -933,4 +961,3 @@ class TestBreakerLocalVsProviderFailures:
         # Breaker SHOULD have tripped — these were real provider
         # failures, not local classification gaps.
         assert solver.is_breaker_open() is True
-

--- a/tests/test_captcha_injection.py
+++ b/tests/test_captcha_injection.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import threading
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
@@ -60,6 +60,24 @@ async def test_inject_token_reports_page_script_success(captcha_type):
     page.evaluate = AsyncMock(return_value=True)
 
     assert await solver._inject_token(page, captcha_type, "tok") is True
+
+
+@pytest.mark.asyncio
+async def test_inject_token_walks_child_frames_without_repeating_main_frame():
+    solver = CaptchaSolver("2captcha", "key")
+    page = MagicMock()
+    page.evaluate = AsyncMock(return_value=False)
+    main_frame = MagicMock()
+    main_frame.evaluate = AsyncMock(return_value=True)
+    child_frame = MagicMock()
+    child_frame.evaluate = AsyncMock(return_value=True)
+    page.main_frame = main_frame
+    page.frames = [main_frame, child_frame]
+
+    assert await solver._inject_token(page, "hcaptcha", "tok") is True
+    page.evaluate.assert_awaited_once()
+    main_frame.evaluate.assert_not_awaited()
+    child_frame.evaluate.assert_awaited_once()
 
 
 @pytest.mark.asyncio

--- a/tests/test_captcha_injection.py
+++ b/tests/test_captcha_injection.py
@@ -1,0 +1,54 @@
+"""Tests for CAPTCHA token injection result handling."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+from src.browser.captcha import CaptchaSolver
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "captcha_type",
+    [
+        "recaptcha-v2-checkbox",
+        "recaptcha-v3",
+        "hcaptcha",
+        "turnstile",
+    ],
+)
+async def test_inject_token_requires_page_script_success(captcha_type):
+    solver = CaptchaSolver("2captcha", "key")
+    page = AsyncMock()
+    page.evaluate = AsyncMock(return_value=False)
+
+    assert await solver._inject_token(page, captcha_type, "tok") is False
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "captcha_type",
+    [
+        "recaptcha-v2-checkbox",
+        "recaptcha-v3",
+        "hcaptcha",
+        "turnstile",
+    ],
+)
+async def test_inject_token_reports_page_script_success(captcha_type):
+    solver = CaptchaSolver("2captcha", "key")
+    page = AsyncMock()
+    page.evaluate = AsyncMock(return_value=True)
+
+    assert await solver._inject_token(page, captcha_type, "tok") is True
+
+
+@pytest.mark.asyncio
+async def test_inject_token_exception_returns_false():
+    solver = CaptchaSolver("2captcha", "key")
+    page = AsyncMock()
+    page.evaluate = AsyncMock(side_effect=RuntimeError("js context closed"))
+
+    assert await solver._inject_token(page, "recaptcha-v2-checkbox", "tok") is False

--- a/tests/test_captcha_injection.py
+++ b/tests/test_captcha_injection.py
@@ -2,11 +2,28 @@
 
 from __future__ import annotations
 
+import threading
 from unittest.mock import AsyncMock
 
 import pytest
 
 from src.browser.captcha import CaptchaSolver
+
+
+def test_solver_constructor_does_not_require_current_event_loop():
+    errors: list[BaseException] = []
+
+    def build_solver() -> None:
+        try:
+            CaptchaSolver("2captcha", "key")
+        except BaseException as exc:
+            errors.append(exc)
+
+    thread = threading.Thread(target=build_solver)
+    thread.start()
+    thread.join()
+
+    assert errors == []
 
 
 @pytest.mark.asyncio

--- a/tests/test_captcha_solver_proxy.py
+++ b/tests/test_captcha_solver_proxy.py
@@ -585,8 +585,8 @@ class TestCredentialLeakCanary:
                 "invisible_by_key": {"SITEKEY-canary": False},
                 "enterprise_script": False, "v3_render_param": None,
             },
-            # any additional evaluate() (token injection JS) — return None
-            None, None, None, None, None,
+            # token injection JS reports whether it actually applied the token
+            True, None, None, None, None,
         ])
         page.url = "https://example.com/login"
 
@@ -686,7 +686,7 @@ class TestCredentialLeakCanary:
                 "invisible_by_key": {"SITEKEY-x": False},
                 "enterprise_script": False, "v3_render_param": None,
             },
-            None, None, None, None, None,
+            True, None, None, None, None,
         ])
         page.url = "https://example.com"
 
@@ -759,7 +759,7 @@ class TestCredentialLeakCanary:
                 "invisible_by_key": {"SITEKEY-x": False},
                 "enterprise_script": False, "v3_render_param": None,
             },
-            None, None, None, None, None,
+            True, None, None, None, None,
         ])
         page.url = "https://example.com"
 

--- a/tests/test_check_captcha_metered.py
+++ b/tests/test_check_captcha_metered.py
@@ -678,6 +678,30 @@ class TestCostCapReservation:
         assert await cost.get_millicents("agent-1") == 100
 
     @pytest.mark.asyncio
+    async def test_unpriced_actual_tier_keeps_reservation_under_cap(
+        self, mgr, monkeypatch,
+    ):
+        """If the solver returns a token on a tier without a published
+        actual rate, do not refund the cost-cap reservation. Refunding
+        would let an untracked provider charge bypass the cap."""
+        monkeypatch.setenv("CAPTCHA_COST_LIMIT_USD_PER_AGENT_MONTH", "1.00")
+        solver = _mk_solver(
+            return_value=_solved(used_proxy_aware=True),
+            provider="2captcha",
+        )
+        mgr._captcha_solver = solver
+        inst = _mk_inst()
+
+        result = await mgr._metered_solve(
+            inst, 'iframe[src*="recaptcha"]', "recaptcha-v3",
+        )
+
+        assert result.token == "tok"
+        # 2captcha recaptcha-v3 has a proxyless published reservation of
+        # 100 mc but no proxy-aware published row. Keep the reservation.
+        assert await cost.get_millicents("agent-1") == 100
+
+    @pytest.mark.asyncio
     async def test_unpriced_kind_with_cap_fails_closed(
         self, mgr, monkeypatch,
     ):

--- a/tests/test_check_captcha_metered.py
+++ b/tests/test_check_captcha_metered.py
@@ -89,12 +89,12 @@ async def _isolate_state(tmp_path, monkeypatch):
     )
     await cost.reset()
     svc._solve_rate_window.clear()
-    async with svc._captcha_audit_lock:
+    async with svc._get_captcha_audit_lock():
         svc._captcha_audit_buckets.clear()
     yield
     await cost.reset()
     svc._solve_rate_window.clear()
-    async with svc._captcha_audit_lock:
+    async with svc._get_captcha_audit_lock():
         svc._captcha_audit_buckets.clear()
 
 

--- a/tests/test_check_captcha_metered.py
+++ b/tests/test_check_captcha_metered.py
@@ -229,7 +229,7 @@ class TestInjectionFailedCountsCost:
         assert envelope["injection_failure_reason"] == "injection_failed_unspecified"
         # Cost IS counted — provider was paid.
         # First selector match is recaptcha → kind=recaptcha-v2-checkbox →
-        # 100¢ at 2captcha proxyless.
+        # 100 millicents at 2captcha proxyless.
         assert await cost.get_cents("agent-1") == 100
 
 
@@ -275,7 +275,7 @@ class TestCfTurnstilePricing:
         envelope = await mgr._check_captcha(inst)
         assert envelope["kind"] == "cf-interstitial-turnstile"
         assert envelope["solver_outcome"] == "solved"
-        # 2captcha turnstile = 200¢. CF-bound alias picks up the same rate.
+        # 2captcha turnstile = 200 millicents. CF-bound alias picks up the same rate.
         assert await cost.get_cents("agent-1") == 200
 
 
@@ -289,7 +289,7 @@ class TestCfAutoNoPriceWarning:
         ``solver_attempted=False`` paths must NOT trigger the cost
         counter's "no published rate" warning. Pre-refactor a CF-auto
         clear path could trip the warning if any code path tried to
-        estimate cents on a non-priced kind."""
+        estimate cost on a non-priced kind."""
         # Drive the CF classifier to "auto" + still_present=False so the
         # path returns the "solved" envelope without any solver call.
         async def fake_cf_state(page):
@@ -599,7 +599,101 @@ class TestGateOrderingCostBeforeRate:
         assert len(svc._solve_rate_window["agent-1"]) == 0
 
 
-# ── 10. Codex F7 — token-without-provider warns + (cap-on) fails closed ──
+# ── 10. Cost-cap reservation closes concurrent solve race ─────────────────
+
+
+class TestCostCapReservation:
+    @pytest.mark.asyncio
+    async def test_concurrent_solves_reserve_cost_before_provider_call(
+        self, mgr, monkeypatch,
+    ):
+        """Two concurrent solves at the cap boundary should not both call
+        the provider. The first reserves the published price; the second
+        sees the in-flight reservation and returns ``cost_cap``."""
+        monkeypatch.setenv("CAPTCHA_COST_LIMIT_USD_PER_AGENT_MONTH", "0.001")
+
+        async def _slow_solve(*args, **kwargs):
+            await asyncio.sleep(0.05)
+            return _solved()
+
+        solver = _mk_solver(return_value=_solved(), provider="2captcha")
+        solver.solve = AsyncMock(side_effect=_slow_solve)
+        mgr._captcha_solver = solver
+        inst = _mk_inst()
+
+        results = await asyncio.gather(
+            mgr._metered_solve(inst, 'iframe[src*="recaptcha"]',
+                               "recaptcha-v2-checkbox"),
+            mgr._metered_solve(inst, 'iframe[src*="recaptcha"]',
+                               "recaptcha-v2-checkbox"),
+        )
+
+        assert sum(1 for r in results if r.token == "tok") == 1
+        assert sum(1 for r in results if r.skipped == "cost_cap") == 1
+        assert solver.solve.await_count == 1
+        assert await cost.get_millicents("agent-1") == 100
+
+    @pytest.mark.asyncio
+    async def test_reservation_refunded_when_solver_returns_no_token(
+        self, mgr, monkeypatch,
+    ):
+        monkeypatch.setenv("CAPTCHA_COST_LIMIT_USD_PER_AGENT_MONTH", "0.001")
+        solver = _mk_solver(
+            return_value=SolveResult(
+                token=None, injection_succeeded=False,
+                used_proxy_aware=False, compat_rejected=False,
+            ),
+            provider="2captcha",
+        )
+        mgr._captcha_solver = solver
+        inst = _mk_inst()
+
+        result = await mgr._metered_solve(
+            inst, 'iframe[src*="recaptcha"]', "recaptcha-v2-checkbox",
+        )
+
+        assert result.token is None
+        assert result.skipped is None
+        assert await cost.get_millicents("agent-1") == 0
+
+    @pytest.mark.asyncio
+    async def test_proxy_aware_reservation_refunds_to_actual_cost(
+        self, mgr, monkeypatch,
+    ):
+        monkeypatch.setenv("CAPTCHA_COST_LIMIT_USD_PER_AGENT_MONTH", "1.00")
+        solver = _mk_solver(
+            return_value=_solved(used_proxy_aware=False),
+            provider="2captcha",
+        )
+        mgr._captcha_solver = solver
+        inst = _mk_inst()
+
+        result = await mgr._metered_solve(
+            inst, 'iframe[src*="hcaptcha"]', "hcaptcha",
+        )
+
+        assert result.token == "tok"
+        # 2captcha hcaptcha proxy-aware reservation is 300 mc; actual
+        # proxyless result should settle back to 100 mc.
+        assert await cost.get_millicents("agent-1") == 100
+
+    @pytest.mark.asyncio
+    async def test_unpriced_kind_with_cap_fails_closed(
+        self, mgr, monkeypatch,
+    ):
+        monkeypatch.setenv("CAPTCHA_COST_LIMIT_USD_PER_AGENT_MONTH", "1.00")
+        solver = _mk_solver(return_value=_solved(), provider="2captcha")
+        mgr._captcha_solver = solver
+        inst = _mk_inst()
+
+        result = await mgr._metered_solve(inst, "#captcha", "unknown")
+
+        assert result.skipped == "price_missing"
+        solver.solve.assert_not_awaited()
+        assert await cost.get_millicents("agent-1") == 0
+
+
+# ── 11. Codex F7 — token-without-provider warns + (cap-on) fails closed ──
 
 
 class TestProviderMissingFailsClosedWhenCapOn:

--- a/tests/test_check_captcha_metered.py
+++ b/tests/test_check_captcha_metered.py
@@ -693,6 +693,38 @@ class TestCostCapReservation:
         assert await cost.get_millicents("agent-1") == 0
 
 
+# ── 12. _max_published_solve_cost_millicents helper ──────────────────────
+
+
+class TestMaxPublishedSolveCostHelper:
+    """``_max_published_solve_cost_millicents`` returns the worst-case
+    price across the proxyless / proxy-aware tiers so the cap reservation
+    holds even when the solver flips paths mid-solve. End-to-end coverage
+    lives in the ``_metered_solve`` tests above; pin the contract here."""
+
+    def test_known_provider_returns_max_of_tiers(self):
+        # 2captcha hcaptcha: proxyless=100, proxy_aware=300 → max=300
+        from src.browser.service import _max_published_solve_cost_millicents
+        assert _max_published_solve_cost_millicents("2captcha", "hcaptcha") == 300
+
+    def test_falls_back_when_only_proxyless_tier_published(self):
+        # 2captcha recaptcha-v3 has no proxy-aware row; proxyless=100.
+        from src.browser.service import _max_published_solve_cost_millicents
+        assert _max_published_solve_cost_millicents("2captcha", "recaptcha-v3") == 100
+
+    def test_unknown_kind_returns_none(self):
+        from src.browser.service import _max_published_solve_cost_millicents
+        assert _max_published_solve_cost_millicents("2captcha", "made-up") is None
+
+    def test_unknown_provider_returns_none(self):
+        from src.browser.service import _max_published_solve_cost_millicents
+        assert _max_published_solve_cost_millicents("nopal", "hcaptcha") is None
+
+    def test_empty_provider_returns_none(self):
+        from src.browser.service import _max_published_solve_cost_millicents
+        assert _max_published_solve_cost_millicents("", "hcaptcha") is None
+
+
 # ── 11. Codex F7 — token-without-provider warns + (cap-on) fails closed ──
 
 

--- a/tests/test_check_captcha_policy.py
+++ b/tests/test_check_captcha_policy.py
@@ -111,12 +111,12 @@ async def _isolate_state(tmp_path, monkeypatch):
     )
     await cost.reset()
     svc._solve_rate_window.clear()
-    async with svc._captcha_audit_lock:
+    async with svc._get_captcha_audit_lock():
         svc._captcha_audit_buckets.clear()
     yield
     await cost.reset()
     svc._solve_rate_window.clear()
-    async with svc._captcha_audit_lock:
+    async with svc._get_captcha_audit_lock():
         svc._captcha_audit_buckets.clear()
     # Reset captcha_policy back to the ambient (no-override) state and
     # rebind on the service module so subsequent suites see pristine env.

--- a/tests/test_dashboard_browser_metrics.py
+++ b/tests/test_dashboard_browser_metrics.py
@@ -652,6 +652,13 @@ class TestMaxConcurrentEnvVar:
             # when MAX_BROWSERS is also absent.
             assert _resolve_max_browsers() == 5
 
+    def test_garbage_legacy_var_does_not_crash_import(self):
+        with mock.patch.dict(os.environ, {"MAX_BROWSERS": "not-a-number"}):
+            os.environ.pop("OPENLEGION_BROWSER_MAX_CONCURRENT", None)
+            from src.browser.__main__ import _resolve_max_browsers
+
+            assert _resolve_max_browsers() == 5
+
     def test_env_var_documented_in_known_flags(self):
         from src.browser.flags import KNOWN_FLAGS
         assert "OPENLEGION_BROWSER_MAX_CONCURRENT" in KNOWN_FLAGS

--- a/tests/test_dashboard_cookie_import.py
+++ b/tests/test_dashboard_cookie_import.py
@@ -423,6 +423,40 @@ class TestValidateCookies:
         assert accepted == []
         assert dropped == [{"reason": "invalid_httponly", "count": 1}]
 
+    def test_rejects_nan_expires(self):
+        accepted, dropped, _ = _validate_cookies(
+            [{"name": "sid", "value": "x", "domain": ".example.com",
+              "expires": float("nan")}],
+        )
+        assert accepted == []
+        assert dropped == [{"reason": "invalid_expires", "count": 1}]
+
+    def test_rejects_inf_expires(self):
+        accepted, dropped, _ = _validate_cookies(
+            [{"name": "sid", "value": "x", "domain": ".example.com",
+              "expires": float("inf")}],
+        )
+        assert accepted == []
+        assert dropped == [{"reason": "invalid_expires", "count": 1}]
+
+    def test_rejects_negative_expires(self):
+        accepted, dropped, _ = _validate_cookies(
+            [{"name": "sid", "value": "x", "domain": ".example.com",
+              "expires": -1.0}],
+        )
+        assert accepted == []
+        assert dropped == [{"reason": "invalid_expires", "count": 1}]
+
+    def test_rejects_far_future_expires(self):
+        # 2200-01-01 is well past the 2100 cap; would otherwise overflow
+        # downstream Playwright/Firefox validation.
+        accepted, dropped, _ = _validate_cookies(
+            [{"name": "sid", "value": "x", "domain": ".example.com",
+              "expires": 7258118400.0}],
+        )
+        assert accepted == []
+        assert dropped == [{"reason": "invalid_expires", "count": 1}]
+
     def test_netscape_malformed_lines_surface_as_drop_count(self):
         """When the input is Netscape and contains malformed lines, the
         ``dropped`` aggregate must include a ``malformed_line`` entry —

--- a/tests/test_dashboard_cookie_import.py
+++ b/tests/test_dashboard_cookie_import.py
@@ -480,6 +480,31 @@ class TestValidateCookies:
         assert accepted == []
         assert dropped == [{"reason": "secure_prefix_non_https_url", "count": 1}]
 
+    def test_drops_plain_secure_cookie_with_non_https_url(self):
+        """RFC 6265 §5.4: ``Secure=true`` requires an HTTPS origin.
+        Pre-fix the validator only enforced this on ``__Host-`` /
+        ``__Secure-`` prefixed names; a plain ``{secure:true,
+        url:"http://..."}`` was accepted but Firefox silently dropped at
+        SET time. Reject up front so operators get a deterministic
+        drop reason."""
+        accepted, dropped, _ = _validate_cookies(
+            [{"name": "sid", "value": "x", "secure": True,
+              "url": "http://example.com/"}],
+        )
+        assert accepted == []
+        assert dropped == [{"reason": "secure_non_https_url", "count": 1}]
+
+    def test_plain_insecure_cookie_with_non_https_url_passes(self):
+        """The Secure-with-HTTP rejection should not affect plain
+        ``secure=false`` cookies on http URLs — that's a normal
+        cookie."""
+        accepted, dropped, _ = _validate_cookies(
+            [{"name": "sid", "value": "x", "secure": False,
+              "url": "http://example.com/"}],
+        )
+        assert len(accepted) == 1
+        assert dropped == []
+
     def test_netscape_malformed_lines_surface_as_drop_count(self):
         """When the input is Netscape and contains malformed lines, the
         ``dropped`` aggregate must include a ``malformed_line`` entry —

--- a/tests/test_dashboard_cookie_import.py
+++ b/tests/test_dashboard_cookie_import.py
@@ -457,6 +457,29 @@ class TestValidateCookies:
         assert accepted == []
         assert dropped == [{"reason": "invalid_expires", "count": 1}]
 
+    def test_rejects_oversized_name(self):
+        accepted, dropped, _ = _validate_cookies(
+            [{"name": "x" * 257, "value": "v", "domain": ".example.com"}],
+        )
+        assert accepted == []
+        assert dropped == [{"reason": "invalid_name_length", "count": 1}]
+
+    def test_drops_host_prefix_with_non_https_url(self):
+        accepted, dropped, _ = _validate_cookies(
+            [{"name": "__Host-sess", "value": "x", "secure": True,
+              "url": "http://example.com/", "path": "/"}],
+        )
+        assert accepted == []
+        assert dropped == [{"reason": "host_prefix_non_https_url", "count": 1}]
+
+    def test_drops_secure_prefix_with_non_https_url(self):
+        accepted, dropped, _ = _validate_cookies(
+            [{"name": "__Secure-sid", "value": "x", "secure": True,
+              "url": "http://example.com/"}],
+        )
+        assert accepted == []
+        assert dropped == [{"reason": "secure_prefix_non_https_url", "count": 1}]
+
     def test_netscape_malformed_lines_surface_as_drop_count(self):
         """When the input is Netscape and contains malformed lines, the
         ``dropped`` aggregate must include a ``malformed_line`` entry —

--- a/tests/test_dashboard_cookie_import.py
+++ b/tests/test_dashboard_cookie_import.py
@@ -380,11 +380,9 @@ class TestValidateCookies:
         _, _, fmt = _validate_cookies(42)
         assert fmt is None
 
-    def test_secure_prefix_passes_through(self):
-        """``__Secure-`` cookies have no special validation here —
-        Playwright/Firefox enforces the ``secure=true`` rule at SET time,
-        not at import. Importing a ``__Secure-foo`` with a domain is
-        therefore expected to be ACCEPTED by ``_validate_cookies``."""
+    def test_secure_prefix_with_secure_passes_through(self):
+        """``__Secure-`` cookies require ``secure=true`` but may still
+        carry a domain."""
         accepted, dropped, fmt = _validate_cookies(
             [{"name": "__Secure-sess", "value": "x",
               "domain": ".example.com", "secure": True}],
@@ -392,6 +390,38 @@ class TestValidateCookies:
         assert fmt == "playwright"
         assert len(accepted) == 1
         assert dropped == []
+
+    def test_drops_secure_prefix_without_secure(self):
+        accepted, dropped, _ = _validate_cookies(
+            [{"name": "__Secure-sess", "value": "x",
+              "domain": ".example.com", "secure": False}],
+        )
+        assert accepted == []
+        assert dropped == [{"reason": "secure_prefix_without_secure", "count": 1}]
+
+    def test_drops_samesite_none_without_secure(self):
+        accepted, dropped, _ = _validate_cookies(
+            [{"name": "sid", "value": "x", "domain": ".example.com",
+              "sameSite": "None"}],
+        )
+        assert accepted == []
+        assert dropped == [{"reason": "samesite_none_without_secure", "count": 1}]
+
+    def test_rejects_non_boolean_secure(self):
+        accepted, dropped, _ = _validate_cookies(
+            [{"name": "sid", "value": "x", "domain": ".example.com",
+              "secure": "false"}],
+        )
+        assert accepted == []
+        assert dropped == [{"reason": "invalid_secure", "count": 1}]
+
+    def test_rejects_non_boolean_httponly(self):
+        accepted, dropped, _ = _validate_cookies(
+            [{"name": "sid", "value": "x", "domain": ".example.com",
+              "httpOnly": "false"}],
+        )
+        assert accepted == []
+        assert dropped == [{"reason": "invalid_httponly", "count": 1}]
 
     def test_netscape_malformed_lines_surface_as_drop_count(self):
         """When the input is Netscape and contains malformed lines, the

--- a/tests/test_profile_schema.py
+++ b/tests/test_profile_schema.py
@@ -524,6 +524,27 @@ class TestV3UblockInstall:
         _v3_install_ublock(profile)
         assert not (profile / "extensions").exists()
 
+    def test_skipped_when_operator_setting_disables_adblock(
+        self, profile, fake_xpi, monkeypatch, tmp_path,
+    ):
+        import json
+
+        from src.browser import flags
+        from src.browser.profile_schema import _v3_install_ublock
+
+        settings = tmp_path / "settings.json"
+        settings.write_text(json.dumps({
+            "browser_flags": {"BROWSER_ENABLE_ADBLOCK": "false"},
+        }))
+        monkeypatch.setenv("OPENLEGION_SETTINGS_PATH", str(settings))
+        monkeypatch.setenv("BROWSER_ENABLE_ADBLOCK", "true")
+        flags.reload_operator_settings()
+        try:
+            _v3_install_ublock(profile)
+        finally:
+            flags.reload_operator_settings()
+        assert not (profile / "extensions").exists()
+
     def test_full_migration_with_flag_disabled_still_stamps_v3(
         self, profile, fake_xpi, monkeypatch,
     ):

--- a/tests/test_shared_redaction.py
+++ b/tests/test_shared_redaction.py
@@ -344,3 +344,47 @@ class TestAgentBrowserToolShim:
         assert callable(_deep_redact)
         assert _redact_credentials("abc") == "abc"
         assert _deep_redact({"a": "b"}) == {"a": "b"}
+
+
+class TestJWTAnchorAvoidsFalsePositives:
+    """JWT regex now requires the JOSE header prefix ``eyJ`` so benign
+    three-dot version strings don't get mangled."""
+
+    def test_benign_version_string_not_redacted(self):
+        from src.shared.redaction import redact_string
+        # A library version + commit + build id — three dot-separated
+        # alphanumeric segments, all ≥10 chars. Pre-fix this matched
+        # the JWT shape and got REDACTED. Post-fix it survives.
+        text = "library_v1_2_3.commit_abcd1234.build_id_5678"
+        assert redact_string(text) == text
+
+    def test_real_jwt_still_redacted(self):
+        from src.shared.redaction import redact_string
+        # Real JOSE-header-prefixed JWT.
+        jwt = "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxIn0aaaa.SflKxwRJSMeKKF2QT4f"
+        out = redact_string(f"Bearer {jwt}")
+        assert jwt not in out
+        assert "[REDACTED]" in out
+
+
+class TestRedactUrlPreservesCanonicalQuery:
+    """When NO query param is sensitive, ``redact_url`` should leave
+    the query string verbatim — round-tripping via ``parse_qsl`` +
+    ``quote_plus`` mutated non-canonical encodings (``hello world``
+    → ``hello+world``) and broke log diffs."""
+
+    def test_canonical_query_unchanged_when_no_redaction(self):
+        from src.shared.redaction import redact_url
+        url = "https://example.com/path?msg=hello+world&keep=ok"
+        out = redact_url(url)
+        # Query bytes survive when there's nothing to redact.
+        assert "msg=hello+world" in out
+        assert "keep=ok" in out
+
+    def test_sensitive_param_still_redacted(self):
+        from src.shared.redaction import redact_url
+        url = "https://example.com/?api_key=mysecret&keep=ok"
+        out = redact_url(url)
+        assert "mysecret" not in out
+        assert "[REDACTED]" in out
+        assert "keep=ok" in out

--- a/tests/test_shared_redaction.py
+++ b/tests/test_shared_redaction.py
@@ -303,6 +303,20 @@ class TestBrowserRedactorShim:
             f"key={_REDACTED}"
         )
 
+    def test_redact_is_url_aware(self):
+        from src.browser.redaction import CredentialRedactor
+        r = CredentialRedactor()
+
+        out = r.redact(
+            "agent-1",
+            "https://svc.example/?api_key=mysecret&public=ok",
+        )
+
+        assert "mysecret" not in out
+        assert "api_key=" in out
+        assert "public=ok" in out
+        assert _REDACTED in out
+
     def test_deep_redact_delegates(self):
         from src.browser.redaction import CredentialRedactor
         r = CredentialRedactor()

--- a/tests/test_stealth_runtime.py
+++ b/tests/test_stealth_runtime.py
@@ -73,15 +73,26 @@ class TestNetworkInformation:
         assert len(picks) >= 30
 
     def test_pick_network_info_in_band(self):
-        """Stay within plausible desktop broadband ranges."""
+        """Stay within plausible desktop broadband ranges. ``effectiveType``
+        and ``saveData`` carry light entropy now (matches real-world fleet
+        diversity) — accept the documented value sets rather than the
+        prior fixed pair."""
         from src.browser.stealth import pick_network_info
 
+        et_counts = {"4g": 0, "3g": 0, "2g": 0}
+        save_data_seen = {True: 0, False: 0}
         for i in range(200):
             ni = pick_network_info(f"agent-{i}")
-            assert ni["effectiveType"] == "4g"
+            assert ni["effectiveType"] in ("4g", "3g", "2g")
+            assert isinstance(ni["saveData"], bool)
             assert 5.0 <= ni["downlink"] <= 20.0
             assert 20 <= ni["rtt"] <= 120
-            assert ni["saveData"] is False
+            et_counts[ni["effectiveType"]] += 1
+            save_data_seen[ni["saveData"]] += 1
+        # 4g should be the dominant value (≥80% per the weighting).
+        assert et_counts["4g"] / 200 >= 0.80
+        # saveData=False is the overwhelming majority (≥90%).
+        assert save_data_seen[False] / 200 >= 0.90
 
     def test_build_launch_options_writes_navigator_connection(self, monkeypatch):
         from src.browser.stealth import build_launch_options, pick_network_info
@@ -93,7 +104,7 @@ class TestNetworkInformation:
         assert cfg["navigator.connection.effectiveType"] == expected["effectiveType"]
         assert cfg["navigator.connection.downlink"] == expected["downlink"]
         assert cfg["navigator.connection.rtt"] == expected["rtt"]
-        assert cfg["navigator.connection.saveData"] is False
+        assert cfg["navigator.connection.saveData"] == expected["saveData"]
         assert opts["i_know_what_im_doing"] is True
 
     def test_ua_override_does_not_clobber_netinfo(self, monkeypatch):

--- a/tests/test_stealth_runtime.py
+++ b/tests/test_stealth_runtime.py
@@ -1,4 +1,4 @@
-"""Phase 3 §6.4 / §6.6 — UA guard + NetworkInformation per-agent fingerprint."""
+"""Phase 3 §6.4 / §6.6 — UA guard + Firefox NetworkInformation contract."""
 
 from __future__ import annotations
 
@@ -50,7 +50,7 @@ class TestFirefoxUAGuard:
         assert ua and "Firefox/138.0" in ua
 
 
-# ── §6.6 NetworkInformation per-agent stable values ──────────────────────────
+# ── §6.6 NetworkInformation helper + Firefox absence contract ────────────────
 
 
 class TestNetworkInformation:
@@ -94,29 +94,26 @@ class TestNetworkInformation:
         # saveData=False is the overwhelming majority (≥90%).
         assert save_data_seen[False] / 200 >= 0.90
 
-    def test_build_launch_options_writes_navigator_connection(self, monkeypatch):
-        from src.browser.stealth import build_launch_options, pick_network_info
+    def test_firefox_launch_options_do_not_write_navigator_connection(
+        self, monkeypatch,
+    ):
+        from src.browser.stealth import build_launch_options
 
         with patch.dict("os.environ", {}, clear=True):
             opts = build_launch_options("agent-x", "/tmp/profile")
         cfg = opts.get("config") or {}
-        expected = pick_network_info("agent-x")
-        assert cfg["navigator.connection.effectiveType"] == expected["effectiveType"]
-        assert cfg["navigator.connection.downlink"] == expected["downlink"]
-        assert cfg["navigator.connection.rtt"] == expected["rtt"]
-        assert cfg["navigator.connection.saveData"] == expected["saveData"]
-        assert opts["i_know_what_im_doing"] is True
+        assert not any(k.startswith("navigator.connection.") for k in cfg)
+        assert "config" not in opts
+        assert "i_know_what_im_doing" not in opts
 
-    def test_ua_override_does_not_clobber_netinfo(self, monkeypatch):
-        """Setting BROWSER_UA_VERSION used to overwrite the whole config
-        dict — must not regress now that we share the dict with §6.6
-        keys."""
-        from src.browser.stealth import build_launch_options, pick_network_info
+    def test_ua_override_config_stays_firefox_only(self, monkeypatch):
+        """UA override still uses Camoufox config, but must not bring back
+        ``navigator.connection`` on the Firefox-shaped path."""
+        from src.browser.stealth import build_launch_options
 
         monkeypatch.setenv("BROWSER_UA_VERSION", "138.0")
         opts = build_launch_options("agent-y", "/tmp/profile")
         cfg = opts["config"]
-        expected = pick_network_info("agent-y")
-        # Both kinds of override coexist
         assert cfg["navigator.userAgent"].endswith("Firefox/138.0")
-        assert cfg["navigator.connection.downlink"] == expected["downlink"]
+        assert not any(k.startswith("navigator.connection.") for k in cfg)
+        assert opts["i_know_what_im_doing"] is True


### PR DESCRIPTION
## Summary

Follow-up hardening from review of the browser automation Phase 1-8 PR series. After rechecking the live PR list, this also explicitly covers the bridge range `#760-#768` (Phase 6 inspect/cookie/click_xy/fill_form/behavior_analyze, Phase 7 metrics/max-concurrent, and Phase 8 envelope/policy/solver-health).

- Make typed browser flags fall through when higher-precedence overrides are malformed.
- Honor operator adblock settings during profile migration.
- Make browser redaction URL-aware for query-token leaks.
- Run navigator probes in a temporary about:blank page instead of clobbering active tabs.
- Preserve full diff baselines for empty filters and support shadow refs inside iframes.
- Use trusted X11 click routing for upload/download chooser triggers.
- Tighten cookie-import validation for __Secure-, SameSite=None, secure, and httpOnly.
- Fix merged Phase 7/8 regressions for invalid legacy MAX_BROWSERS and Turnstile-vs-Cloudflare classification.
- Treat CAPTCHA token injection as successful only when the page-side script actually applies a token or invokes a callback.
- Dispatch input/change events after CAPTCHA response-field writes for reCAPTCHA, hCaptcha, and Turnstile.
- Read CAPTCHA solver provider/key through centralized browser flags so operator settings and env precedence are consistent.
- Redact page URLs before CAPTCHA solve-attempt logging.
- Make BrowserManager/CaptchaSolver CAPTCHA locks lazy/current-loop-safe so sync startup paths and Python 3.9 test ordering do not bind locks to a missing or closed loop.
- Extend the same loop-safety fix to Phase 6/7 sync-constructed surfaces: `CamoufoxInstance`, `HealthMonitor`, `MessageRouter`, and mesh upload-stage locks.
- Update the stale shadow-ref iframe regression expectation now that #781 resolves iframe-aware refs instead of rejecting all `frame_id` refs.

## Product / Engineering Recommendation

The most important Phase 8 issue was a false-positive solved state: the solver used to report `injection_succeeded=True` whenever `page.evaluate(...)` did not throw, even if no CAPTCHA response field existed and no callback ran. That could spend a provider token, tell the agent the challenge was solved, and leave the page blocked. This PR now reports that state as injection failure.

Recommendation: get this PR green and merged before expanding into more speculative stealth surface. The next useful work should be validation-oriented: canary runs across known CAPTCHA/Cloudflare flows, operator fallback playbooks, and telemetry thresholds that distinguish provider failure, local injection failure, and site-specific unsolved challenges. Keep phase 9 code-track work separate from this hardening PR.

## Verification

- `pytest tests/test_captcha_injection.py tests/test_browser_service.py::TestGetSolver tests/test_captcha_solver_proxy.py tests/test_captcha_health.py -q` -> 95 passed.
- `pytest tests/test_browser_file_transfer.py::TestUploadStageIngest tests/test_browser_file_transfer.py::TestDownloadFlow tests/test_captcha_per_type_timeout.py::TestDefaultLookup tests/test_captcha_per_type_timeout.py::TestEnvOverride tests/test_captcha_per_type_timeout.py::TestFallback tests/test_captcha_recaptcha_classifier.py::TestTaskBodyMerger tests/test_captcha_solver_proxy.py::TestTaskBody tests/test_captcha_injection.py tests/test_browser_service.py::TestBrowserManagerLifecycle::test_constructor_does_not_require_current_event_loop -q` -> 65 passed.
- `pytest tests/test_browser_inspect_requests.py tests/test_dashboard_cookie_import.py tests/test_browser_click_xy.py tests/test_browser_fill_form.py tests/test_behavior_analyze.py tests/test_dashboard_browser_metrics.py tests/test_captcha_envelope.py tests/test_captcha_policy.py tests/test_captcha_health.py -q` -> 310 passed.
- `pytest tests/test_browser_service.py -m 'not browser' -k 'not Screenshot' -q` -> 434 passed.
- `pytest tests/test_dashboard_browser_metrics.py tests/test_captcha_envelope.py tests/test_dashboard_cookie_import.py tests/test_browser_flags.py tests/test_profile_schema.py tests/test_shared_redaction.py tests/test_browser_nav_probe.py tests/test_browser_file_transfer.py tests/test_captcha_*.py tests/test_check_captcha_metered.py tests/test_browser_solve_captcha.py tests/test_check_captcha_policy.py -q` -> 629 passed.
- `python -m py_compile src/browser/captcha.py src/browser/service.py tests/test_captcha_injection.py tests/test_browser_service.py tests/test_captcha_solver_proxy.py tests/test_captcha_health.py` -> passed.
- `ruff check src/browser/captcha.py src/browser/service.py tests/test_captcha_injection.py tests/test_browser_service.py tests/test_captcha_solver_proxy.py tests/test_captcha_health.py` -> passed.
