### PR TITLE
Phase 9 §18.1: validation harness + runbook + report template

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,8 @@ uv.lock
 .claude/
 .openlegion
 config/
+# Phase 9 §18.1 captcha-validation harness — operator-supplied configs
+# (real URLs + creds-refs) MUST NOT enter version control. The shipped
+# config.example.yaml stays tracked.
+tools/captcha_validation/config.local.yaml
+config.local.yaml

--- a/tests/test_captcha_validation_harness.py
+++ b/tests/test_captcha_validation_harness.py
@@ -1,0 +1,624 @@
+"""Self-tests for the Phase 9 §18.1 validation harness.
+
+The harness lives at ``tools/captcha_validation``; these tests exercise
+schema validation, runner orchestration (with a mocked BrowserManager so we
+never touch a real browser), report generation, cost-budget enforcement,
+fingerprint-burn skip behavior, and URL redaction in the rendered report.
+
+NO real solver provider, NO live Playwright, NO real captcha — every
+external surface is mocked.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from collections.abc import Iterable
+from pathlib import Path
+
+import pytest
+import yaml
+from pydantic import ValidationError
+
+from src.browser import captcha_cost_counter as cost
+from tools.captcha_validation import report as report_mod
+from tools.captcha_validation import runner as runner_mod
+from tools.captcha_validation.report import generate_report
+from tools.captcha_validation.runner import (
+    BURN_STREAK_THRESHOLD,
+    BudgetExceeded,
+    load_campaign,
+    main,
+    run_campaign,
+)
+from tools.captcha_validation.schema import (
+    AttemptOutcome,
+    CampaignConfig,
+    SiteConfig,
+)
+
+# ── Schema validation tests ─────────────────────────────────────────────────
+
+
+class TestSchema:
+    def test_site_config_minimal(self) -> None:
+        site = SiteConfig(
+            url="https://example.com/login",
+            expected_kind="recaptcha-v3",
+            category="google_signin",
+        )
+        assert site.attempt_count == 10
+        assert site.interaction == "navigate_only"
+
+    def test_site_config_rejects_unknown_kind(self) -> None:
+        with pytest.raises(ValidationError) as excinfo:
+            SiteConfig(
+                url="https://example.com/login",
+                expected_kind="not-a-real-kind",
+                category="google_signin",
+            )
+        assert "expected_kind" in str(excinfo.value)
+
+    def test_site_config_rejects_unknown_category(self) -> None:
+        with pytest.raises(ValidationError) as excinfo:
+            SiteConfig(
+                url="https://example.com/login",
+                expected_kind="recaptcha-v3",
+                category="zoom_signin",
+            )
+        assert "category" in str(excinfo.value)
+
+    def test_site_config_rejects_placeholder_url(self) -> None:
+        with pytest.raises(ValidationError) as excinfo:
+            SiteConfig(
+                url="https://accounts.google.com/...",
+                expected_kind="recaptcha-v3",
+                category="google_signin",
+            )
+        assert "placeholder" in str(excinfo.value)
+
+    def test_site_config_attempt_count_must_be_positive(self) -> None:
+        with pytest.raises(ValidationError):
+            SiteConfig(
+                url="https://example.com/login",
+                expected_kind="recaptcha-v3",
+                category="google_signin",
+                attempt_count=0,
+            )
+
+    def test_campaign_config_requires_at_least_one_site(self) -> None:
+        with pytest.raises(ValidationError):
+            CampaignConfig(sites=[])
+
+    def test_campaign_config_loads_from_yaml(self, tmp_path: Path) -> None:
+        cfg_path = tmp_path / "config.yaml"
+        cfg_path.write_text(
+            yaml.safe_dump({
+                "cost_budget_usd": 1.5,
+                "attempts_per_day": 3,
+                "sites": [
+                    {
+                        "url": "https://example.com/login",
+                        "expected_kind": "hcaptcha",
+                        "category": "hcaptcha_saas",
+                        "attempt_count": 2,
+                    },
+                ],
+            }),
+        )
+        cfg = load_campaign(cfg_path)
+        assert len(cfg.sites) == 1
+        assert cfg.cost_budget_usd == 1.5
+        assert cfg.attempts_per_day == 3
+
+    def test_load_campaign_rejects_empty_file(self, tmp_path: Path) -> None:
+        cfg_path = tmp_path / "empty.yaml"
+        cfg_path.write_text("")
+        with pytest.raises(ValueError):
+            load_campaign(cfg_path)
+
+    def test_example_yaml_rejects_due_to_placeholders(self) -> None:
+        # The shipped example file uses ``...``-suffixed placeholder URLs
+        # so a copy-paste-and-run cannot accidentally fire a real campaign.
+        # Verify the schema actually catches it.
+        example = Path(__file__).resolve().parents[1] / "tools" / "captcha_validation" / "config.example.yaml"
+        with open(example, encoding="utf-8") as fh:
+            raw = yaml.safe_load(fh)
+        with pytest.raises(ValidationError):
+            CampaignConfig(**raw)
+
+
+# ── Mock BrowserManager for runner tests ───────────────────────────────────
+
+
+class _MockSolver:
+    """Minimal solver stub. Holds a provider name + a controllable per-call
+    behavior; the runner reads ``provider`` for cost reconciliation.
+    """
+
+    def __init__(self, provider: str = "2captcha") -> None:
+        self.provider = provider
+
+
+class _ScriptedManager:
+    """A BrowserManager-shaped stub for runner tests.
+
+    The runner calls (in order, per attempt):
+
+        navigate(agent_id, url, wait_ms=, wait_until=)
+        [click(agent_id, selector=)]   # only when interaction != navigate_only
+        solve_captcha(agent_id, retry_previous=)
+
+    Plus, between sites:
+        stop(agent_id)
+        stop_all()  # final teardown
+
+    The scripted envelopes drive the per-attempt outcomes. ``cost_seq``
+    drives the in-memory ``captcha_cost_counter`` increments — one entry
+    per attempt; the manager calls ``cost.add_cost(agent_id, delta)``
+    BEFORE returning the envelope so the runner's after-read sees the
+    delta.
+    """
+
+    def __init__(
+        self,
+        envelopes: Iterable[dict],
+        cost_deltas_millicents: Iterable[int] | None = None,
+        provider: str = "2captcha",
+    ) -> None:
+        self._envelopes = list(envelopes)
+        self._cost_deltas = list(cost_deltas_millicents or [])
+        self._idx = 0
+        self._captcha_solver = _MockSolver(provider=provider)
+        self.navigated: list[tuple[str, str]] = []
+        self.clicked: list[tuple[str, str | None]] = []
+        self.stops: list[str] = []
+        self.stop_all_called = False
+
+    async def navigate(
+        self, agent_id: str, url: str, wait_ms: int = 1000,
+        wait_until: str = "domcontentloaded", **_: object,
+    ) -> dict:
+        self.navigated.append((agent_id, url))
+        return {"success": True, "data": {"url": url}}
+
+    async def click(
+        self, agent_id: str, selector: str | None = None, **_: object,
+    ) -> dict:
+        self.clicked.append((agent_id, selector))
+        return {"success": True}
+
+    async def solve_captcha(
+        self, agent_id: str, **_: object,
+    ) -> dict:
+        if self._idx >= len(self._envelopes):
+            envelope = {
+                "captcha_found": False,
+                "kind": "unknown",
+                "solver_outcome": "no_solver",
+                "solver_confidence": "low",
+                "next_action": "operator_review",
+            }
+            delta = 0
+        else:
+            envelope = self._envelopes[self._idx]
+            delta = (
+                self._cost_deltas[self._idx]
+                if self._idx < len(self._cost_deltas) else 0
+            )
+        self._idx += 1
+        if delta:
+            await cost.add_cost(agent_id, delta)
+        return {"success": True, "data": dict(envelope)}
+
+    async def stop(self, agent_id: str) -> None:
+        self.stops.append(agent_id)
+
+    async def stop_all(self) -> None:
+        self.stop_all_called = True
+
+
+@pytest.fixture(autouse=True)
+async def _isolate_cost(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Each test gets its own ``captcha_costs.json`` and an empty counter."""
+    monkeypatch.setenv(
+        "CAPTCHA_COST_COUNTER_PATH", str(tmp_path / "captcha_costs.json"),
+    )
+    await cost.reset()
+    yield
+    await cost.reset()
+
+
+def _site(
+    *, url: str = "https://example.com/login",
+    expected_kind: str = "hcaptcha",
+    attempts: int = 3,
+    interaction: str = "navigate_only",
+    interaction_selector: str | None = None,
+    category: str = "hcaptcha_saas",
+) -> SiteConfig:
+    return SiteConfig(
+        url=url,
+        expected_kind=expected_kind,
+        attempt_count=attempts,
+        interaction=interaction,
+        interaction_selector=interaction_selector,
+        category=category,
+    )
+
+
+def _solved_envelope(kind: str = "hcaptcha") -> dict:
+    return {
+        "captcha_found": True,
+        "kind": kind,
+        "solver_outcome": "solved",
+        "solver_confidence": "high",
+        "next_action": "continue",
+        "solver_used_proxy_aware": False,
+    }
+
+
+def _rejected_envelope(kind: str = "hcaptcha") -> dict:
+    return {
+        "captcha_found": True,
+        "kind": kind,
+        "solver_outcome": "rejected",
+        "solver_confidence": "low",
+        "next_action": "request_captcha_help",
+    }
+
+
+def _unsupported_envelope(kind: str = "funcaptcha") -> dict:
+    return {
+        "captcha_found": True,
+        "kind": kind,
+        "solver_outcome": "unsupported",
+        "solver_confidence": "low",
+        "next_action": "request_captcha_help",
+    }
+
+
+# ── Runner orchestration tests ─────────────────────────────────────────────
+
+
+class TestRunnerHappyPath:
+    @pytest.mark.asyncio
+    async def test_three_solved_attempts_produce_three_outcomes(
+        self, tmp_path: Path,
+    ) -> None:
+        site = _site(attempts=3)
+        cfg = CampaignConfig(sites=[site], cost_budget_usd=1.0)
+        envelopes = [_solved_envelope() for _ in range(3)]
+        # 100 millicents each = 0.1 cents = $0.001 — the proxyless 2captcha
+        # hcaptcha rate. Total counted: 300 millicents = $0.003.
+        deltas = [100, 100, 100]
+        manager = _ScriptedManager(envelopes, cost_deltas_millicents=deltas)
+
+        report = await run_campaign(
+            cfg, tmp_path / "out",
+            timeout_s=5.0, pace_seconds=0.0,
+            browser_manager_factory=lambda: _wrap(manager),
+        )
+
+        assert len(report.attempts) == 3
+        for a in report.attempts:
+            assert a.envelope["solver_outcome"] == "solved"
+            assert a.classifier_match is True
+            assert a.cost_counted_millicents == 100
+            # Estimate from estimate_millicents("2captcha", "hcaptcha") = 100mc
+            # → cents = round(100/1000) = 0
+            # The estimate is integer cents; 0.1 cent rounds to 0 cents. The
+            # test asserts the rounding is intentional (not a bug).
+            assert a.cost_charged_cents_estimated == 0
+        # Manager should have stopped between/after sites.
+        assert manager.stop_all_called is True
+
+    @pytest.mark.asyncio
+    async def test_navigate_then_click_invokes_click(
+        self, tmp_path: Path,
+    ) -> None:
+        site = _site(
+            attempts=1,
+            interaction="navigate_then_click_submit",
+            interaction_selector="#submit",
+        )
+        cfg = CampaignConfig(sites=[site], cost_budget_usd=1.0)
+        manager = _ScriptedManager([_solved_envelope()])
+        await run_campaign(
+            cfg, tmp_path / "out",
+            timeout_s=5.0, pace_seconds=0.0,
+            browser_manager_factory=lambda: _wrap(manager),
+        )
+        assert len(manager.clicked) == 1
+        assert manager.clicked[0][1] == "#submit"
+
+
+class TestRunnerOutputFiles:
+    @pytest.mark.asyncio
+    async def test_jsonl_ledger_is_written(self, tmp_path: Path) -> None:
+        site = _site(attempts=2)
+        cfg = CampaignConfig(sites=[site], cost_budget_usd=1.0)
+        manager = _ScriptedManager(
+            [_solved_envelope(), _solved_envelope()],
+            cost_deltas_millicents=[100, 100],
+        )
+        out = tmp_path / "out"
+        await run_campaign(
+            cfg, out,
+            timeout_s=5.0, pace_seconds=0.0,
+            browser_manager_factory=lambda: _wrap(manager),
+        )
+        ledger = out / "attempts.jsonl"
+        assert ledger.exists()
+        lines = ledger.read_text().strip().splitlines()
+        assert len(lines) == 2
+        for line in lines:
+            payload = json.loads(line)
+            # Schema-shape sanity — every recorded outcome is loadable
+            # back into AttemptOutcome.
+            AttemptOutcome(**payload)
+
+
+# ── Cost-budget enforcement ─────────────────────────────────────────────────
+
+
+class TestBudget:
+    @pytest.mark.asyncio
+    async def test_budget_aborts_after_two_solves(self, tmp_path: Path) -> None:
+        # $0.01 budget = 1000 millicents. 500 mc/solve. Two solves = 1000 mc
+        # (=$0.01) which crosses the >= threshold → abort BEFORE the third
+        # attempt records.
+        site = _site(attempts=4)
+        cfg = CampaignConfig(sites=[site], cost_budget_usd=0.01)
+        manager = _ScriptedManager(
+            [_solved_envelope() for _ in range(4)],
+            cost_deltas_millicents=[500, 500, 500, 500],
+        )
+        report = await run_campaign(
+            cfg, tmp_path / "out",
+            timeout_s=5.0, pace_seconds=0.0,
+            browser_manager_factory=lambda: _wrap(manager),
+        )
+        assert report.budget_exceeded is True
+        # Two attempts persisted (the second crossed the threshold and the
+        # exception fired AFTER its outcome was appended).
+        assert len(report.attempts) == 2
+
+    def test_budget_exceeded_class_inherits_runtimeerror(self) -> None:
+        assert issubclass(BudgetExceeded, RuntimeError)
+
+
+# ── Burn-signal abort ───────────────────────────────────────────────────────
+
+
+class TestBurnSignal:
+    @pytest.mark.asyncio
+    async def test_five_consecutive_rejected_skips_remaining_attempts(
+        self, tmp_path: Path,
+    ) -> None:
+        # Five rejects on site A trip the burn streak — site A's remaining
+        # attempts should be skipped. Site B (subsequent in the config)
+        # continues normally. Site B's lone attempt produces a solved
+        # envelope and is recorded.
+        site_a = _site(
+            url="https://burned.example.com/login",
+            attempts=8,  # 5 rejected + 3 that should be skipped
+            category="hcaptcha_saas",
+        )
+        site_b = _site(
+            url="https://other.example.com/login",
+            attempts=1,
+            category="cloudflare_saas",
+            expected_kind="cf-interstitial-turnstile",
+        )
+        cfg = CampaignConfig(sites=[site_a, site_b], cost_budget_usd=10.0)
+        envelopes = [_rejected_envelope() for _ in range(5)] + [
+            _solved_envelope(kind="cf-interstitial-turnstile"),
+        ]
+        manager = _ScriptedManager(envelopes)
+        report = await run_campaign(
+            cfg, tmp_path / "out",
+            timeout_s=5.0, pace_seconds=0.0,
+            browser_manager_factory=lambda: _wrap(manager),
+        )
+        # 5 rejects on A + 1 solved on B = 6 outcomes total (3 attempts of
+        # site A skipped).
+        assert len(report.attempts) == 6
+        assert "https://burned.example.com/login" in report.aborted_sites
+        # Site B's lone attempt landed.
+        assert report.attempts[-1].envelope["kind"] == "cf-interstitial-turnstile"
+
+    def test_burn_threshold_is_five(self) -> None:
+        # Sanity gate — the threshold is part of the harness contract.
+        # Bumping it requires updating the README + the §18.1 spec note.
+        assert BURN_STREAK_THRESHOLD == 5
+
+
+# ── Report generation + URL redaction ───────────────────────────────────────
+
+
+class TestReport:
+    def test_report_contains_expected_sections(self, tmp_path: Path) -> None:
+        attempts = [
+            AttemptOutcome(
+                site_url="https://example.com/login",
+                attempt_index=i,
+                wall_clock_ms=1234 + i,
+                envelope=_solved_envelope(),
+                cost_charged_cents_estimated=0,
+                cost_counted_millicents=100,
+                fingerprint_burn_signal=False,
+                classifier_match=True,
+                error=None,
+                timestamp_utc="2026-04-27T00:00:00+00:00",
+            )
+            for i in range(2)
+        ]
+        out = tmp_path / "report.md"
+        generate_report(attempts, out)
+        content = out.read_text()
+        # Each section header should appear once.
+        for section in [
+            "# Phase 9 §18.1",
+            "## Summary",
+            "## Per-site outcome distribution",
+            "## Top 5 `unsupported` examples",
+            "## Top 5 `rejected` examples",
+            "## Classifier accuracy",
+            "## Cost reconciliation",
+            "## §11.20 promotion recommendations",
+        ]:
+            assert section in content, f"missing section: {section!r}"
+
+    def test_report_redacts_query_string_secrets(self, tmp_path: Path) -> None:
+        # The site URL contains a sensitive query param (``token``) that
+        # MUST be redacted in the rendered report. Use the harness
+        # url-redaction contract described in src/shared/redaction.py.
+        secret = "ya29.A0AfH6SMBmockTokenForTestOnlyXXXXXXXXXX"
+        attempts = [
+            AttemptOutcome(
+                site_url=f"https://example.com/cb?code=abc&token={secret}",
+                attempt_index=0,
+                wall_clock_ms=42,
+                envelope=_solved_envelope(),
+                cost_charged_cents_estimated=0,
+                cost_counted_millicents=100,
+                fingerprint_burn_signal=False,
+                classifier_match=True,
+                error=None,
+                timestamp_utc="2026-04-27T00:00:00+00:00",
+            ),
+        ]
+        out = tmp_path / "report.md"
+        generate_report(attempts, out)
+        content = out.read_text()
+        # No raw token in the rendered markdown.
+        assert secret not in content
+        # And the token-shaped string also shouldn't leak via deep_redact
+        # heuristics — the [REDACTED] sentinel should appear instead.
+        assert "[REDACTED]" in content
+
+    def test_report_promotes_unsupported_funcaptcha(
+        self, tmp_path: Path,
+    ) -> None:
+        # 5/5 attempts on FunCaptcha return unsupported → recommend promote.
+        attempts = [
+            AttemptOutcome(
+                site_url="https://twitter.example.com/signup",
+                attempt_index=i,
+                wall_clock_ms=42,
+                envelope=_unsupported_envelope("funcaptcha"),
+                cost_charged_cents_estimated=0,
+                cost_counted_millicents=0,
+                fingerprint_burn_signal=False,
+                classifier_match=True,
+                error=None,
+                timestamp_utc="2026-04-27T00:00:00+00:00",
+            )
+            for i in range(5)
+        ]
+        out = tmp_path / "report.md"
+        generate_report(attempts, out)
+        content = out.read_text()
+        assert "FunCaptcha" in content
+        assert "recommend promote" in content
+
+    def test_cost_reconciliation_flags_large_delta(
+        self, tmp_path: Path,
+    ) -> None:
+        # Counted = 5_000_000 mc ($50), Estimate = 100 cents ($1) — delta
+        # is 5000% which must trip the ⚠ flag.
+        attempts = [
+            AttemptOutcome(
+                site_url="https://example.com/login",
+                attempt_index=0,
+                wall_clock_ms=42,
+                envelope=_solved_envelope(),
+                cost_charged_cents_estimated=100,
+                cost_counted_millicents=5_000_000,
+                fingerprint_burn_signal=False,
+                classifier_match=True,
+                error=None,
+                timestamp_utc="2026-04-27T00:00:00+00:00",
+            ),
+        ]
+        out = tmp_path / "report.md"
+        generate_report(attempts, out)
+        content = out.read_text()
+        assert "⚠" in content
+
+
+# ── CLI surface tests ──────────────────────────────────────────────────────
+
+
+class TestCli:
+    def test_help_returns_clean_usage(self, capsys: pytest.CaptureFixture[str]) -> None:
+        with pytest.raises(SystemExit) as ex:
+            main(["--help"])
+        assert ex.value.code == 0
+        out = capsys.readouterr().out
+        assert "captcha-validation" in out
+        assert "--dry-run" in out
+
+    def test_dry_run_validates_config_without_network(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        cfg_path = tmp_path / "config.yaml"
+        cfg_path.write_text(yaml.safe_dump({
+            "cost_budget_usd": 1.0,
+            "sites": [
+                {
+                    "url": "https://example.com/login",
+                    "expected_kind": "hcaptcha",
+                    "category": "hcaptcha_saas",
+                    "attempt_count": 2,
+                },
+            ],
+        }))
+        rc = main([str(cfg_path), "--dry-run"])
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert "Dry-run" in out
+        # The dry-run never touches a BrowserManager or HTTP. Sanity-check
+        # that no stray attempts.jsonl was written.
+        assert not (tmp_path / "out" / "attempts.jsonl").exists()
+
+    def test_cli_rejects_missing_config(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        rc = main([str(tmp_path / "no-such.yaml"), "--dry-run"])
+        assert rc == 2
+
+    def test_dry_run_on_example_yaml_fails_validation(
+        self, capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        # The shipped example contains placeholder URLs the schema rejects
+        # — so even ``--dry-run`` against the example exits non-zero. This
+        # is the property that makes the example file safe to ship.
+        example = Path(__file__).resolve().parents[1] / "tools" / "captcha_validation" / "config.example.yaml"
+        rc = main([str(example), "--dry-run"])
+        assert rc == 2
+
+
+# ── Helpers ────────────────────────────────────────────────────────────────
+
+
+def _wrap(manager) -> object:
+    """Wrap a sync manager into the async-factory shape the runner expects."""
+    async def factory() -> object:
+        return manager
+    return factory()
+
+
+# Smoke test: importing the runner does NOT auto-fire any HTTP / browser
+# work. Catches accidental top-level side effects (a class of bugs that
+# would otherwise only surface in CI when ``import tools.captcha_validation``
+# happens during collection).
+def test_runner_import_has_no_side_effects() -> None:
+    # Already imported at module load; the assertion is that test
+    # collection got to this line without an HTTP request firing.
+    assert "tools.captcha_validation.runner" in sys.modules
+    # And the report module is independently importable without the runner
+    # attempting to touch a config file at import time.
+    assert report_mod is not None
+    assert runner_mod.ATTEMPT_TIMEOUT_S > 0

--- a/tools/captcha_validation/README.md
+++ b/tools/captcha_validation/README.md
@@ -1,0 +1,164 @@
+# Phase 9 §18.1 — Captcha validation harness (operator runbook)
+
+Reproducible tooling to drive the production browser-service codepath
+end-to-end against operator-curated protected sites and capture structured
+outcome evidence. Drives §11.20 promotion decisions: which deferred items
+should ship, which stay deferred, and what trigger to attach to each.
+
+The harness is **infrastructure**. It ships ready-to-use; live runs require
+an operator-provided target URL list + solver creds + test accounts.
+
+## Pre-requisites
+
+Before a real run, the operator must have:
+
+1. **Solver provider account** with a funded balance — either
+   [2captcha](https://2captcha.com) or [CapSolver](https://capsolver.com).
+   The harness reads the same provider config the production browser
+   service uses (env vars consumed by `src/browser/captcha.py:get_solver`).
+
+2. **Solver-side proxy credentials** — a *separate* proxy from the agent's
+   primary egress proxy. See plan §11.2: handing your scraping-proxy creds
+   to a third-party solver is a credential-leak vector. Set ALL FIVE:
+
+   ```
+   export CAPTCHA_SOLVER_PROXY_TYPE=socks5
+   export CAPTCHA_SOLVER_PROXY_ADDRESS=...
+   export CAPTCHA_SOLVER_PROXY_PORT=...
+   export CAPTCHA_SOLVER_PROXY_LOGIN=...
+   export CAPTCHA_SOLVER_PROXY_PASSWORD=...
+   ```
+
+   The harness verifies the env-var family is configured at startup; partial
+   config falls back to proxyless (the captcha module logs a once-per-session
+   warning).
+
+3. **Test accounts** for every site whose category is a signin / signup
+   target (`google_signin`, `twitter_signup`, `linkedin_auth`,
+   `aws_waf`). Don't use production accounts — the campaign deliberately
+   stresses fingerprint detection.
+
+4. **Curated target URLs** for each of the 10 categories from plan §18.1.
+   The example config (`config.example.yaml`) lists categories with
+   placeholder URLs (`https://accounts.google.com/...`); the schema
+   validator REJECTS placeholder URLs so a copy-paste-and-run can never
+   accidentally exercise the example file.
+
+## Quick start
+
+```bash
+# 1. Copy the example to a local config (gitignored).
+cp tools/captcha_validation/config.example.yaml config.local.yaml
+
+# 2. Edit config.local.yaml — fill in real URLs + creds-refs per site.
+
+# 3. Export solver-proxy env vars from your vault.
+source ~/.openlegion/captcha_solver_proxy.env
+
+# 4. Validate the config without making HTTP calls.
+python -m tools.captcha_validation.runner config.local.yaml --dry-run
+
+# 5. Run the full campaign.
+python -m tools.captcha_validation.runner config.local.yaml \
+       data/captcha_validation
+```
+
+Outputs land in `data/captcha_validation/`:
+
+* `attempts.jsonl` — per-attempt outcome ledger (one record per line).
+* `validation-report-YYYY-MM-DD.md` — the markdown report described in
+  plan §18.1.
+* `profiles/` — one Camoufox profile directory per agent-id, retained for
+  forensics. Safe to delete between runs.
+
+## Interpreting the report
+
+The report contains five sections:
+
+* **Per-site outcome distribution** — for each site, the count of each
+  `solver_outcome` value (solved / rejected / unsupported / timeout /
+  cost_cap / rate_limited / skipped_behavioral / no_solver / harness_*).
+  Wide variance across sites of the same category is the operator's first
+  signal that fingerprint hygiene needs work.
+
+* **Top 5 unsupported / rejected examples** — URL-redacted (via
+  `src.shared.redaction.redact_url`). Useful for pasting into §11.20
+  trigger-evidence lines.
+
+* **Classifier accuracy** — % of attempts where the envelope's `kind`
+  matched the configured `expected_kind`. Sub-80% on a category is a
+  §11.6 (sitekey extraction hardening) promotion signal.
+
+* **Cost reconciliation** — counted (from `captcha_cost_counter`) vs
+  estimated (from `estimate_millicents`). A delta exceeding 10% is
+  flagged ⚠ and means the cost counter is missing increments — file a
+  §11.10 follow-up.
+
+* **§11.20 promotion recommendations** — concrete `recommend promote /
+  keep deferred / investigate` lines per deferred item, derived from the
+  campaign data. Carry these directly into your §11.20 trigger update.
+
+## Cost expectations
+
+A full 10-site × 10-attempt campaign at default solver rates costs
+**roughly $1–$5** depending on which kinds the operator targets:
+
+* recaptcha-v2 / hcaptcha: ~$0.10 per 100 attempts (proxyless)
+* recaptcha-enterprise / turnstile: ~$0.20 per 100 attempts (proxyless)
+* proxy-aware tasks: ~3× the proxyless rate
+
+The campaign's `cost_budget_usd` (default `$5.00`) is a HARD ceiling. The
+runner aborts the campaign once the cumulative *counted* spend (read from
+`captcha_cost_counter`) reaches the budget. This is checked AFTER every
+attempt — it is not possible for the harness to overshoot the budget by
+more than one solve's published rate.
+
+## Fingerprint hygiene
+
+The campaign deliberately hammers protected sites; doing so back-to-back
+on a single fingerprint corrupts the per-site outcome distributions. The
+harness mitigates this two ways:
+
+* **Per-site fresh profile.** Between sites the harness calls
+  `BrowserManager.stop(agent_id)` so the next site opens with a clean
+  Camoufox instance. The profile lives under `output_dir/profiles/`; the
+  next site uses a new agent-id (UUID-suffixed) and therefore a separate
+  profile dir.
+
+* **Per-site burn detection.** If 5 consecutive attempts on a single site
+  return a burn-shaped outcome (`rejected`, `injection_failed`,
+  `captcha_during_solve`), the runner skips the rest of that site's
+  attempts and continues with the next site. The burned site URL is
+  recorded in `CampaignReport.aborted_sites`.
+
+* **Daily quota.** `attempts_per_day` (default 5) caps how many attempts
+  the harness will make against any one site within a single same-day
+  session. To complete a 10-attempt site in one calendar day, schedule
+  two runs separated by a few hours (the harness preserves `attempts.jsonl`
+  across runs — the report aggregates the lot).
+
+If a site burns mid-campaign and you want to retry, change the agent-id
+prefix (it's UUID-suffixed automatically) by re-running the campaign
+against just that one site in a fresh `output_dir`. There's no surgical
+"retry one site" flag — by design, the harness pushes operators toward
+fresh fingerprints rather than partial retries.
+
+## Legal note
+
+Some sites' Terms of Service forbid automated access. Verifying that the
+operator's chosen target list is acceptable for *their* deployment is
+**the operator's responsibility**. The harness does not maintain an
+allowlist of "OK to test" sites. When in doubt, target self-owned staging
+infrastructure or vendor sandbox environments (most major captcha
+providers offer test pages — those are always safe to target).
+
+## Self-tests
+
+```bash
+pytest tests/test_captcha_validation_harness.py -v
+```
+
+The self-tests use mock Camoufox + a local `http.server` serving the
+fixture pages under `fixtures/`. No real solver provider is contacted; no
+real network captcha is encountered. CI can run these even without the
+optional `playwright` dependency installed.

--- a/tools/captcha_validation/__init__.py
+++ b/tools/captcha_validation/__init__.py
@@ -1,0 +1,10 @@
+"""Phase 9 §18.1 captcha-validation harness.
+
+Operator-driven tooling that drives the production browser-service codepath
+end-to-end against curated protected sites and captures structured outcome
+records. The harness is *infrastructure* — the live runs that drive §11.20
+promotion decisions are kicked off by an operator with their own target list
+and solver creds. NEVER auto-runs against live sites at import time.
+
+See ``tools/captcha_validation/README.md`` for the operator runbook.
+"""

--- a/tools/captcha_validation/config.example.yaml
+++ b/tools/captcha_validation/config.example.yaml
@@ -1,0 +1,112 @@
+# Phase 9 §18.1 validation campaign config — EXAMPLE TEMPLATE
+#
+# Operators: copy this file to ``config.local.yaml`` (which is gitignored)
+# and fill in real target URLs + creds-refs. The ``url: ...`` entries below
+# are intentionally placeholder strings ending in ``/...`` so the schema
+# validator REJECTS this file before any real run can begin.
+#
+# Workflow:
+#   1. cp tools/captcha_validation/config.example.yaml config.local.yaml
+#   2. Open config.local.yaml in your editor; fill in ``url`` for each site.
+#   3. Export CAPTCHA_SOLVER_PROXY_TYPE/ADDRESS/PORT/LOGIN/PASSWORD env vars
+#      from your dedicated solver-proxy vault entry.
+#   4. python -m tools.captcha_validation.runner config.local.yaml --dry-run
+#      → confirms the config loads + lists categories WITHOUT making any
+#      HTTP calls.
+#   5. python -m tools.captcha_validation.runner config.local.yaml
+#      → runs the campaign; outputs to data/captcha_validation/.
+
+solver_proxy_creds_ref: vault://captcha_solver_proxy
+cost_budget_usd: 5.0
+attempts_per_day: 5
+
+sites:
+  # 1. Google account flow — reCAPTCHA Enterprise v2 / v3
+  - url: https://accounts.google.com/...
+    expected_kind: recaptcha-enterprise-v3
+    category: google_signin
+    attempt_count: 10
+    interaction: navigate_then_click_submit
+    interaction_selector: "#identifierNext"
+    account_creds_ref: vault://test_google_account
+    notes: "Google signin; expect Enterprise v3 with bot-detection."
+
+  # 2. Twitter / X — FunCaptcha (Arkose); §11.5 deferred coverage
+  - url: https://twitter.com/i/flow/signup/...
+    expected_kind: funcaptcha
+    category: twitter_signup
+    attempt_count: 10
+    interaction: navigate_then_click_submit
+    interaction_selector: "[data-testid='ocfSignupNextLink']"
+    account_creds_ref: vault://test_twitter_account
+    notes: "X signup flow; surfaces FunCaptcha after the email step."
+
+  # 3. LinkedIn auth — FunCaptcha
+  - url: https://www.linkedin.com/uas/login/...
+    expected_kind: funcaptcha
+    category: linkedin_auth
+    attempt_count: 10
+    interaction: navigate_then_click_submit
+    interaction_selector: "button[type='submit']"
+    account_creds_ref: vault://test_linkedin_account
+    notes: "LinkedIn login; FunCaptcha appears on suspicious-IP login."
+
+  # 4. Cloudflare-protected SaaS — CF interstitial + Turnstile
+  - url: https://...
+    expected_kind: cf-interstitial-turnstile
+    category: cloudflare_saas
+    attempt_count: 10
+    interaction: navigate_only
+    notes: "Operator picks a CF-protected SaaS where Turnstile fires on first nav."
+
+  # 5. AWS console signin — AWS WAF CAPTCHA; §11.5 deferred
+  - url: https://signin.aws.amazon.com/...
+    expected_kind: aws-waf
+    category: aws_waf
+    attempt_count: 10
+    interaction: navigate_then_click_submit
+    interaction_selector: "input[type='submit']"
+    account_creds_ref: vault://test_aws_account
+    notes: "AWS console login; WAF CAPTCHA on flagged IPs."
+
+  # 6. GeeTest — §11.5 deferred
+  - url: https://...
+    expected_kind: geetest-v4
+    category: geetest
+    attempt_count: 10
+    interaction: navigate_then_click_submit
+    interaction_selector: "button.geetest-trigger"
+    notes: "Operator picks a GeeTest v4 site (often China-region SaaS)."
+
+  # 7. Invisible reCAPTCHA v2 — §11.7 candidate
+  - url: https://...
+    expected_kind: recaptcha-v2-invisible
+    category: invisible_v2
+    attempt_count: 10
+    interaction: navigate_then_click_submit
+    interaction_selector: "button[type='submit']"
+    notes: "SaaS with invisible v2 — token injection succeeds but app may reject."
+
+  # 8. Standard hCaptcha SaaS
+  - url: https://...
+    expected_kind: hcaptcha
+    category: hcaptcha_saas
+    attempt_count: 10
+    interaction: navigate_only
+    notes: "Operator picks a SaaS that fires hCaptcha on every visit."
+
+  # 9. HUMAN / PerimeterX — Press & Hold; §11.5 deferred
+  - url: https://...
+    expected_kind: px-press-hold
+    category: human_perimeterx
+    attempt_count: 10
+    interaction: navigate_only
+    notes: "PerimeterX-protected. Behavioral-only; expect skipped_behavioral."
+
+  # 10. DataDome
+  - url: https://...
+    expected_kind: datadome-behavioral
+    category: datadome
+    attempt_count: 10
+    interaction: navigate_only
+    notes: "DataDome-blocked target; behavioral-only outcome expected."

--- a/tools/captcha_validation/fixtures/mock_cf_interstitial.html
+++ b/tools/captcha_validation/fixtures/mock_cf_interstitial.html
@@ -1,0 +1,21 @@
+<!--
+  Mock Cloudflare Under-Attack interstitial for harness self-tests.
+  Static page only — no real challenge logic. The production
+  ``_classify_cf_state`` looks at the title + body text + Turnstile
+  presence to tri-state the page; this fixture exercises the
+  "interstitial without Turnstile widget" → behavioral-only branch.
+-->
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Just a moment...</title>
+</head>
+<body>
+  <main>
+    <h1>Checking your browser before accessing the site.</h1>
+    <p>This process is automatic. Your browser will redirect to your requested content shortly.</p>
+    <p>Please allow up to 5 seconds...</p>
+  </main>
+</body>
+</html>

--- a/tools/captcha_validation/fixtures/mock_hcaptcha.html
+++ b/tools/captcha_validation/fixtures/mock_hcaptcha.html
@@ -1,0 +1,18 @@
+<!--
+  Mock hCaptcha page for harness self-tests.
+  See mock_recaptcha.html for the threat-model note.
+-->
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>mock hcaptcha page</title>
+</head>
+<body>
+  <h1>mock hcaptcha page</h1>
+  <form action="/submit" method="post">
+    <div class="h-captcha" data-sitekey="00000000-0000-0000-0000-000000000000"></div>
+    <button id="submit" type="submit">Submit</button>
+  </form>
+</body>
+</html>

--- a/tools/captcha_validation/fixtures/mock_recaptcha.html
+++ b/tools/captcha_validation/fixtures/mock_recaptcha.html
@@ -1,0 +1,20 @@
+<!--
+  Mock reCAPTCHA v2 page for harness self-tests.
+  Renders the structural shape (g-recaptcha element + sitekey attribute)
+  the production captcha module looks for. NEVER served from a real
+  recaptcha.net origin — this is a local file only.
+-->
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>mock recaptcha v2 page</title>
+</head>
+<body>
+  <h1>mock recaptcha v2 page</h1>
+  <form action="/submit" method="post">
+    <div class="g-recaptcha" data-sitekey="6LfMockSitekeyForLocalHarnessTestUseOnly_AAAA"></div>
+    <button id="submit" type="submit">Submit</button>
+  </form>
+</body>
+</html>

--- a/tools/captcha_validation/fixtures/mock_turnstile.html
+++ b/tools/captcha_validation/fixtures/mock_turnstile.html
@@ -1,0 +1,18 @@
+<!--
+  Mock Cloudflare Turnstile page for harness self-tests.
+  See mock_recaptcha.html for the threat-model note.
+-->
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>mock turnstile page</title>
+</head>
+<body>
+  <h1>mock turnstile page</h1>
+  <form action="/submit" method="post">
+    <div class="cf-turnstile" data-sitekey="0x4AAAAAAAMockTurnstileTestKey"></div>
+    <button id="submit" type="submit">Submit</button>
+  </form>
+</body>
+</html>

--- a/tools/captcha_validation/report.py
+++ b/tools/captcha_validation/report.py
@@ -1,0 +1,426 @@
+"""Markdown report generator for the §18.1 validation campaign.
+
+Consumes a list of :class:`AttemptOutcome` records and produces the report
+template described in plan §18.1:
+
+* Per-site outcome distribution table (counts per ``solver_outcome``).
+* Top-5 ``unsupported`` and ``rejected`` outcomes (URL-redacted).
+* Classifier accuracy table (expected vs emitted ``kind``, % match).
+* Cost reconciliation table per site, flagging deltas >10%.
+* Promotion recommendations for §11.20 deferred items.
+
+Reuse contract: every URL appearing in the report flows through
+:func:`src.shared.redaction.redact_url`. Tests assert no raw query strings
+or token-shaped path segments leak.
+"""
+
+from __future__ import annotations
+
+import statistics
+from collections import Counter, defaultdict
+from datetime import datetime, timezone
+from pathlib import Path
+
+from src.shared.redaction import redact_url
+from tools.captcha_validation.schema import AttemptOutcome
+
+# Outcome buckets we always render in the per-site distribution table, in a
+# stable order. Outcomes that appear in the data but aren't in this list
+# get a row appended at the end. Keeping the canonical order makes
+# cross-site comparison immediate (the operator's eye lands on
+# ``solved`` / ``rejected`` first regardless of which site row).
+_CANONICAL_OUTCOMES: tuple[str, ...] = (
+    "solved",
+    "rejected",
+    "unsupported",
+    "timeout",
+    "cost_cap",
+    "rate_limited",
+    "skipped_behavioral",
+    "no_solver",
+    "harness_timeout",
+    "harness_error",
+    "navigate_failed",
+    "injection_failed",
+    "captcha_during_solve",
+)
+
+
+# Cost-reconciliation tolerance — counted vs estimate within this fraction
+# is considered a match. The plan calls out 10% explicitly. Below that
+# is reported as informational; above is flagged for operator follow-up
+# (suggests the cost counter is missing increments).
+_COST_DELTA_FLAG_THRESHOLD: float = 0.10
+
+
+# §11.20 deferred items keyed by the §11.13 ``kind`` they would unblock.
+# Used by ``_promotion_recommendations`` to surface concrete trigger
+# evidence ("recommend promote" / "no signal yet"). Ordered to match the
+# plan's deferred-list narrative.
+_DEFERRED_KINDS_TO_ITEM: dict[str, str] = {
+    "funcaptcha":          "§11.5 (FunCaptcha) — Twitter/LinkedIn signup",
+    "geetest":             "§11.5 (GeeTest) — Asia-targeted SaaS",
+    "geetest-v3":          "§11.5 (GeeTest) — v3 site",
+    "geetest-v4":          "§11.5 (GeeTest) — v4 site",
+    "aws-waf":             "§11.5 (AWS WAF) — AWS console signin",
+    "datadome-behavioral": "§11.5 (DataDome) — DataDome-protected target",
+    "px-press-hold":       "§11.5 (PerimeterX) — Press & Hold",
+}
+
+
+def _redact_attempt_url(url: str) -> str:
+    """Redact a target URL for inclusion in the report."""
+    return redact_url(url) if url else url
+
+
+def _outcome_counter(attempts: list[AttemptOutcome]) -> Counter[str]:
+    """Count outcomes across an attempt list, slotting unknowns under
+    ``unknown_outcome`` so the totals always reconcile to ``len(attempts)``.
+    """
+    c: Counter[str] = Counter()
+    for a in attempts:
+        outcome = a.envelope.get("solver_outcome")
+        if not isinstance(outcome, str) or not outcome:
+            outcome = "unknown_outcome"
+        c[outcome] += 1
+    return c
+
+
+def _ordered_outcomes(seen: Counter[str]) -> list[str]:
+    """Return outcomes in canonical order, then any extras alphabetically.
+
+    Stable across runs so diffs between reports stay readable.
+    """
+    canonical = [o for o in _CANONICAL_OUTCOMES if o in seen]
+    extras = sorted(o for o in seen if o not in _CANONICAL_OUTCOMES)
+    return canonical + extras
+
+
+def _percent(part: int, total: int) -> str:
+    if total <= 0:
+        return "0%"
+    return f"{(part / total) * 100:.0f}%"
+
+
+def _format_cost_delta(counted_mc: int, estimate_cents: int) -> tuple[str, bool]:
+    """Format ``counted vs estimate`` for the reconciliation table.
+
+    Returns ``(formatted, flag)`` — ``flag=True`` means the delta exceeds
+    the operator-visible threshold and should be highlighted in the report.
+    """
+    counted_cents_f = counted_mc / 1000.0
+    if estimate_cents == 0 and counted_mc == 0:
+        return "$0.00 / $0.00", False
+    counted_dollars = counted_mc / 100_000.0
+    estimate_dollars = estimate_cents / 100.0
+    base = f"${counted_dollars:.4f} / ${estimate_dollars:.4f}"
+    if estimate_cents == 0:
+        # Counted cost without an estimate row — operator should review the
+        # provider list; usually means the kind isn't priced.
+        return base + " (no published rate)", counted_mc > 0
+    delta = abs(counted_cents_f - estimate_cents) / max(estimate_cents, 1)
+    if delta > _COST_DELTA_FLAG_THRESHOLD:
+        return base + f" ⚠ Δ={delta * 100:.0f}%", True
+    return base + f" Δ={delta * 100:.0f}%", False
+
+
+def _group_by_site(
+    attempts: list[AttemptOutcome],
+) -> dict[str, list[AttemptOutcome]]:
+    """Group outcomes by ``site_url`` preserving insertion order."""
+    grouped: dict[str, list[AttemptOutcome]] = defaultdict(list)
+    for a in attempts:
+        grouped[a.site_url].append(a)
+    return grouped
+
+
+def _per_site_table(grouped: dict[str, list[AttemptOutcome]]) -> str:
+    """Render the per-site outcome distribution table in markdown."""
+    if not grouped:
+        return "_No attempts recorded._\n"
+    # Discover all outcome buckets that appear across the campaign.
+    overall: Counter[str] = Counter()
+    site_counters: dict[str, Counter[str]] = {}
+    for url, group in grouped.items():
+        c = _outcome_counter(group)
+        site_counters[url] = c
+        overall.update(c)
+    columns = _ordered_outcomes(overall)
+
+    header = "| Site | Total | " + " | ".join(columns) + " |"
+    sep = "|---|---:|" + "|".join(["---:"] * len(columns)) + "|"
+    rows = [header, sep]
+    for url, group in grouped.items():
+        c = site_counters[url]
+        cells = [str(c.get(col, 0)) for col in columns]
+        rows.append(
+            f"| {_redact_attempt_url(url)} | {len(group)} | "
+            + " | ".join(cells) + " |",
+        )
+    return "\n".join(rows) + "\n"
+
+
+def _classifier_accuracy_table(
+    grouped: dict[str, list[AttemptOutcome]],
+) -> str:
+    """Render the classifier accuracy table.
+
+    Per site: total attempts, expected_kind, count of envelopes whose
+    ``kind`` matched expected, % match. Flags sites where the match rate
+    is <80% so §11.6 promotion has concrete evidence.
+    """
+    if not grouped:
+        return "_No attempts recorded._\n"
+    rows = ["| Site | Expected kind | Match | Total | % match |"]
+    rows.append("|---|---|---:|---:|---:|")
+    for url, group in grouped.items():
+        if not group:
+            continue
+        # Every attempt in a site's group shares the expected_kind in the
+        # campaign config — but that lives on SiteConfig, not on the
+        # outcome. Recover it from the classifier_match boolean against
+        # the emitted kind: when match=True we know what expected was
+        # (the emitted kind); when match=False we surface "(see notes)".
+        # Tests + report consumers can re-derive against SiteConfig if
+        # they need the strict expected value, but per-site classification
+        # rate doesn't depend on knowing it.
+        match_count = sum(1 for a in group if a.classifier_match)
+        # Pick the modal expected kind from the matched attempts; fall
+        # back to "(unknown)" when none matched.
+        expected_kinds = Counter(
+            a.envelope.get("kind", "unknown")
+            for a in group if a.classifier_match
+        )
+        expected = expected_kinds.most_common(1)[0][0] if expected_kinds else "(unknown)"
+        rows.append(
+            f"| {_redact_attempt_url(url)} | {expected} | "
+            f"{match_count} | {len(group)} | "
+            f"{_percent(match_count, len(group))} |",
+        )
+    return "\n".join(rows) + "\n"
+
+
+def _cost_reconciliation_table(
+    grouped: dict[str, list[AttemptOutcome]],
+) -> str:
+    """Render the cost-reconciliation table per site."""
+    if not grouped:
+        return "_No attempts recorded._\n"
+    rows = ["| Site | Counted / Estimate (USD) | Flagged? |"]
+    rows.append("|---|---|---:|")
+    any_flag = False
+    for url, group in grouped.items():
+        counted_total = sum(a.cost_counted_millicents for a in group)
+        estimate_total = sum(a.cost_charged_cents_estimated for a in group)
+        formatted, flag = _format_cost_delta(counted_total, estimate_total)
+        any_flag = any_flag or flag
+        rows.append(
+            f"| {_redact_attempt_url(url)} | {formatted} | "
+            f"{'⚠ yes' if flag else 'no'} |",
+        )
+    rows.append("")
+    if any_flag:
+        rows.append(
+            "> **Note.** Sites flagged ⚠ exceeded the 10% counted-vs-estimate "
+            "tolerance. Operator should compare provider invoice totals "
+            "against the cost-counter snapshot for the affected sites.",
+        )
+    return "\n".join(rows) + "\n"
+
+
+def _top_n_outcome_examples(
+    attempts: list[AttemptOutcome],
+    outcome: str,
+    n: int = 5,
+) -> list[str]:
+    """Return up to ``n`` redacted URLs of attempts with ``solver_outcome==outcome``.
+
+    Sorted by ``site_url`` (stable across re-runs) and then earliest
+    ``timestamp_utc`` so the same examples surface every time.
+    """
+    matching = [
+        a for a in attempts
+        if a.envelope.get("solver_outcome") == outcome
+    ]
+    matching.sort(key=lambda a: (a.site_url, a.timestamp_utc))
+    seen: set[str] = set()
+    out: list[str] = []
+    for a in matching:
+        red = _redact_attempt_url(a.site_url)
+        if red in seen:
+            continue
+        seen.add(red)
+        out.append(red)
+        if len(out) >= n:
+            break
+    return out
+
+
+def _promotion_recommendations(attempts: list[AttemptOutcome]) -> list[str]:
+    """Generate concrete promotion recommendations per §11.20 deferred item.
+
+    For each kind the harness might surface that maps to a deferred item,
+    we count how often the campaign saw it and generate a recommendation
+    line with the evidence:
+
+    * ``unsupported`` ≥ 50% on a category → recommend promote.
+    * ``rejected`` consistently with classifier_match=True → recommend
+      promote (the solver has the wrong shape for this site).
+    * No signal for the kind → recommend keeping deferred with tightened
+      trigger.
+
+    Output is a list of lines suitable for direct inclusion in markdown.
+    """
+    lines: list[str] = []
+    by_kind: dict[str, list[AttemptOutcome]] = defaultdict(list)
+    for a in attempts:
+        kind = a.envelope.get("kind") or "unknown"
+        by_kind[kind].append(a)
+
+    for kind, item in _DEFERRED_KINDS_TO_ITEM.items():
+        observations = by_kind.get(kind, [])
+        if not observations:
+            lines.append(
+                f"- **{item}** — no occurrences in this campaign; keep deferred.",
+            )
+            continue
+        unsupported_count = sum(
+            1 for a in observations
+            if a.envelope.get("solver_outcome") == "unsupported"
+        )
+        rejected_count = sum(
+            1 for a in observations
+            if a.envelope.get("solver_outcome") == "rejected"
+        )
+        total = len(observations)
+        if unsupported_count >= max(1, total // 2):
+            lines.append(
+                f"- **{item}** — observed {unsupported_count}/{total} "
+                f"`unsupported` outcomes; **recommend promote**.",
+            )
+        elif rejected_count >= max(1, total // 2):
+            lines.append(
+                f"- **{item}** — observed {rejected_count}/{total} "
+                f"`rejected` outcomes; **investigate before promote** "
+                f"(could be solver-task-shape mismatch rather than "
+                f"missing coverage).",
+            )
+        else:
+            lines.append(
+                f"- **{item}** — {total} observation(s); no decisive "
+                f"signal yet. Keep deferred; broaden the campaign target "
+                f"list to gather more evidence.",
+            )
+
+    # Classifier accuracy → §11.1 / §11.6 promotion signal.
+    unknown_count = sum(
+        1 for a in attempts if (a.envelope.get("kind") or "unknown") == "unknown"
+    )
+    if unknown_count and attempts:
+        share = unknown_count / len(attempts)
+        if share > 0.20:
+            lines.append(
+                f"- **§11.6 (robust sitekey extraction / classifier hardening)** "
+                f"— {unknown_count}/{len(attempts)} attempts produced "
+                f"`kind=unknown` ({share * 100:.0f}%); **recommend promote**.",
+            )
+    return lines
+
+
+def _campaign_summary(attempts: list[AttemptOutcome]) -> dict[str, object]:
+    """Produce the top-of-report summary block."""
+    total = len(attempts)
+    counted_mc = sum(a.cost_counted_millicents for a in attempts)
+    estimate_cents = sum(a.cost_charged_cents_estimated for a in attempts)
+    wall_clocks = [a.wall_clock_ms for a in attempts] or [0]
+    classifier_match = sum(1 for a in attempts if a.classifier_match)
+    return {
+        "total": total,
+        "counted_dollars": counted_mc / 100_000.0,
+        "estimate_dollars": estimate_cents / 100.0,
+        "median_ms": int(statistics.median(wall_clocks)),
+        "max_ms": max(wall_clocks),
+        "classifier_match_pct": _percent(classifier_match, total),
+    }
+
+
+def generate_report(
+    attempts: list[AttemptOutcome],
+    output_path: Path,
+) -> None:
+    """Generate a markdown campaign report at ``output_path``.
+
+    The report is fully self-contained — it does NOT inline raw URLs.
+    Operator can attach the file to a §11.20 review without further redaction.
+    """
+    summary = _campaign_summary(attempts)
+    grouped = _group_by_site(attempts)
+
+    lines: list[str] = []
+    lines.append("# Phase 9 §18.1 — Captcha validation campaign")
+    lines.append("")
+    lines.append(
+        f"_Generated: {datetime.now(timezone.utc).isoformat(timespec='seconds')}_",
+    )
+    lines.append("")
+    lines.append("## Summary")
+    lines.append("")
+    lines.append(f"- Total attempts: **{summary['total']}**")
+    lines.append(f"- Sites covered: **{len(grouped)}**")
+    lines.append(
+        f"- Cost: counted **${summary['counted_dollars']:.4f}** vs "
+        f"estimated **${summary['estimate_dollars']:.4f}**",
+    )
+    lines.append(
+        f"- Wall-clock per attempt: median **{summary['median_ms']}ms**, "
+        f"max **{summary['max_ms']}ms**",
+    )
+    lines.append(
+        f"- Classifier kind-match rate: **{summary['classifier_match_pct']}**",
+    )
+    lines.append("")
+
+    lines.append("## Per-site outcome distribution")
+    lines.append("")
+    lines.append(_per_site_table(grouped))
+
+    # Top-5 unsupported / rejected
+    lines.append("## Top 5 `unsupported` examples")
+    lines.append("")
+    examples = _top_n_outcome_examples(attempts, "unsupported", n=5)
+    if examples:
+        for ex in examples:
+            lines.append(f"- {ex}")
+    else:
+        lines.append("_No `unsupported` outcomes._")
+    lines.append("")
+
+    lines.append("## Top 5 `rejected` examples")
+    lines.append("")
+    examples = _top_n_outcome_examples(attempts, "rejected", n=5)
+    if examples:
+        for ex in examples:
+            lines.append(f"- {ex}")
+    else:
+        lines.append("_No `rejected` outcomes._")
+    lines.append("")
+
+    lines.append("## Classifier accuracy")
+    lines.append("")
+    lines.append(_classifier_accuracy_table(grouped))
+
+    lines.append("## Cost reconciliation")
+    lines.append("")
+    lines.append(_cost_reconciliation_table(grouped))
+
+    lines.append("## §11.20 promotion recommendations")
+    lines.append("")
+    recs = _promotion_recommendations(attempts)
+    if recs:
+        lines.extend(recs)
+    else:
+        lines.append("_No data — campaign produced zero attempts._")
+    lines.append("")
+
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text("\n".join(lines), encoding="utf-8")

--- a/tools/captcha_validation/runner.py
+++ b/tools/captcha_validation/runner.py
@@ -1,0 +1,651 @@
+"""Phase 9 §18.1 validation campaign runner.
+
+Drives a real :class:`BrowserManager` end-to-end against operator-curated
+target sites, captures the §11.13 envelope per attempt, reconciles cost
+counter delta against the published estimate, and produces a JSONL outcome
+ledger plus a markdown report.
+
+NEVER auto-runs at import time. Entry point:
+
+  python -m tools.captcha_validation.runner config.local.yaml [output_dir]
+  python -m tools.captcha_validation.runner config.local.yaml --dry-run
+
+Threading model: a single ``BrowserManager`` is created per campaign run and
+re-used across all sites. A *fresh* ``CamoufoxInstance`` is opened per site
+(via ``mgr.stop(site_agent_id)`` between sites) so the fingerprint resets —
+critical for the validity of the campaign data; otherwise burn signals
+correlate across sites and corrupt the per-site outcome distributions.
+
+Per-attempt budget: every attempt is wrapped in ``asyncio.wait_for(180s)`` so
+a stuck Playwright page can never stall the campaign. Wall-clock failures
+become harness errors (``error`` field on the ``AttemptOutcome``) so the
+report can flag flaky targets.
+
+Cost reconciliation: before/after each attempt the runner reads
+``captcha_cost_counter.get_millicents(agent_id)`` to derive
+``cost_counted_millicents``. The ``cost_charged_cents_estimated`` is
+computed from the envelope's emitted ``kind`` + the solver's provider via
+``estimate_millicents``. Discrepancy >10% per site is flagged in the
+report — drives §11.10 promotion decisions.
+
+Cost-budget abort: cumulative counted spend is checked AFTER every attempt;
+crossing the campaign's ``cost_budget_usd`` raises :class:`BudgetExceeded`
+which terminates the loop with a clear log line.
+
+Fingerprint-burn abort: 5 consecutive ``solver_outcome="rejected"`` (or any
+of the burn-shaped outcomes) for one site marks that site as burned and
+skips its remaining attempts. Other sites continue.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import contextlib
+import dataclasses
+import logging
+import os
+import sys
+import time
+import uuid
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+import yaml
+
+from src.browser import captcha_cost_counter as cost
+from tools.captcha_validation.schema import (
+    AttemptOutcome,
+    CampaignConfig,
+    SiteConfig,
+)
+
+if TYPE_CHECKING:  # pragma: no cover - type-only
+    from src.browser.service import BrowserManager
+
+logger = logging.getLogger("tools.captcha_validation.runner")
+
+
+# Per-attempt hard timeout. Even if the production solver disagrees with the
+# kind's documented timeout (§11.9), the harness must not block the whole
+# campaign on one attempt. Generous default; tests override this directly.
+ATTEMPT_TIMEOUT_S: float = 180.0
+
+# Pacing — how long to wait between same-site attempts in a non-test run.
+# Defaults to a short jitter so attempts within a single same-day session
+# don't fire back-to-back. Tests set this to 0 via the ``pace_seconds`` arg
+# on :func:`run_campaign`.
+DEFAULT_PACE_SECONDS: float = 1.5
+
+# Number of consecutive "rejected"-shaped outcomes before we declare the
+# fingerprint burned for that site and skip the rest of its attempts.
+BURN_STREAK_THRESHOLD: int = 5
+
+# Outcomes that strongly suggest the fingerprint is burned (token rejected
+# by target server; repeated challenge after solve). These count toward the
+# ``BURN_STREAK_THRESHOLD``. ``rate_limited``/``cost_cap``/``timeout`` do NOT
+# — those are operational, not fingerprint-driven.
+_BURN_SHAPED_OUTCOMES: frozenset[str] = frozenset({
+    "rejected",
+    "injection_failed",
+    "captcha_during_solve",
+})
+
+
+class BudgetExceeded(RuntimeError):
+    """Raised when the cumulative counted spend crosses ``cost_budget_usd``."""
+
+
+@dataclasses.dataclass
+class CampaignReport:
+    """Return value of :func:`run_campaign` — drives the markdown report.
+
+    ``attempts`` is the in-memory mirror of ``output_dir/attempts.jsonl``
+    (one :class:`AttemptOutcome` per attempt, in execution order).
+    ``aborted_sites`` lists site URLs that hit the burn-streak threshold.
+    ``budget_exceeded`` is True when the campaign aborted on cost cap.
+    ``output_dir`` is the directory containing the JSONL ledger + the
+    generated markdown report.
+    """
+
+    attempts: list[AttemptOutcome]
+    aborted_sites: list[str]
+    budget_exceeded: bool
+    output_dir: Path
+    report_path: Path | None
+
+
+def load_campaign(config_path: Path) -> CampaignConfig:
+    """Load and validate the YAML config file.
+
+    Raises ``pydantic.ValidationError`` on malformed configs — the exception
+    message is the operator's error UX. We never fail open on bad input.
+    """
+    with open(config_path, encoding="utf-8") as fh:
+        raw = yaml.safe_load(fh)
+    if raw is None:
+        raise ValueError(f"{config_path} is empty or contains only whitespace")
+    if not isinstance(raw, dict):
+        raise ValueError(f"{config_path} top-level must be a mapping, got {type(raw).__name__}")
+    return CampaignConfig(**raw)
+
+
+def _utc_now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat(timespec="seconds")
+
+
+def _is_burn_shaped(envelope: dict) -> bool:
+    """True iff the envelope's ``solver_outcome`` is fingerprint-burn-shaped."""
+    outcome = envelope.get("solver_outcome")
+    if not isinstance(outcome, str):
+        return False
+    return outcome in _BURN_SHAPED_OUTCOMES
+
+
+def _envelope_kind(envelope: dict) -> str:
+    """Return the envelope's ``kind`` string, defaulting to 'unknown'."""
+    k = envelope.get("kind")
+    return k if isinstance(k, str) and k else "unknown"
+
+
+def _solver_provider(mgr: "BrowserManager") -> str:
+    """Return the provider name attached to the solver, or 'unknown'.
+
+    The solver may be ``None`` when the operator hasn't configured a solver
+    — in that case every attempt's ``solver_outcome`` will be ``no_solver``
+    and the cost reconciliation is trivially zero on both sides.
+    """
+    solver = getattr(mgr, "_captcha_solver", None)
+    if solver is None:
+        return "unknown"
+    provider = getattr(solver, "provider", "")
+    return provider if isinstance(provider, str) and provider else "unknown"
+
+
+def _estimate_charge_cents(provider: str, envelope: dict) -> int:
+    """Compute ``cost_charged_cents_estimated`` from the envelope.
+
+    Returns 0 when the variant has no published rate, when the solver
+    short-circuited, or when the envelope reported no successful charge.
+    """
+    outcome = envelope.get("solver_outcome")
+    if outcome != "solved":
+        # Provider only charges on a delivered token. Other outcomes
+        # (rejected, timeout, cost_cap, rate_limited, no_solver) cost zero.
+        return 0
+    kind = _envelope_kind(envelope)
+    proxy_aware = bool(envelope.get("solver_used_proxy_aware", False))
+    mc = cost.estimate_millicents(provider, kind, proxy_aware=proxy_aware)
+    if mc is None:
+        return 0
+    # millicents → cents (rounded — operators want a whole-cent estimate).
+    return int(round(mc / 1000))
+
+
+async def _ensure_fresh_instance(mgr: "BrowserManager", agent_id: str) -> None:
+    """Tear down any prior instance for ``agent_id`` so the next nav opens
+    a fresh Camoufox profile (clean fingerprint for the new site).
+
+    This is safe to call when no instance exists — :meth:`BrowserManager.stop`
+    is a no-op in that case.
+    """
+    with contextlib.suppress(Exception):
+        await mgr.stop(agent_id)
+
+
+async def _drive_attempt(
+    mgr: "BrowserManager",
+    agent_id: str,
+    site: SiteConfig,
+) -> dict:
+    """Run a single attempt: navigate → optionally click → solve_captcha.
+
+    Returns the §11.13 envelope dict (the ``data`` field of the
+    ``solve_captcha`` response). Caller wraps this in ``asyncio.wait_for``
+    so a stuck Playwright page can't pin the campaign.
+    """
+    nav_result = await mgr.navigate(
+        agent_id, site.url,
+        wait_ms=2000, wait_until="load",
+    )
+    if not nav_result.get("success"):
+        # Surface the navigate error as a synthetic envelope so the report
+        # can group it under "harness-side failures" without a special
+        # branch in the outcome aggregator.
+        return {
+            "captcha_found": False,
+            "kind": "unknown",
+            "solver_outcome": "navigate_failed",
+            "solver_confidence": "low",
+            "next_action": "operator_review",
+            "error": nav_result.get("error", "navigate failed"),
+        }
+
+    if site.interaction == "navigate_then_click_submit":
+        if not site.interaction_selector:
+            return {
+                "captcha_found": False,
+                "kind": "unknown",
+                "solver_outcome": "config_error",
+                "solver_confidence": "low",
+                "next_action": "operator_review",
+                "error": "interaction_then_click requires interaction_selector",
+            }
+        click_result = await mgr.click(
+            agent_id, selector=site.interaction_selector,
+        )
+        if not click_result.get("success"):
+            # Clicks failing isn't necessarily a captcha failure — the page
+            # may have changed shape. Record the harness-side error and let
+            # solve_captcha probe whatever the current page looks like.
+            logger.warning(
+                "click %r on attempt for %s failed: %s",
+                site.interaction_selector,
+                site.category,
+                click_result.get("error"),
+            )
+
+    solve_result = await mgr.solve_captcha(
+        agent_id,
+        retry_previous=True,
+    )
+    if not solve_result.get("success"):
+        return {
+            "captcha_found": False,
+            "kind": "unknown",
+            "solver_outcome": "harness_error",
+            "solver_confidence": "low",
+            "next_action": "operator_review",
+            "error": solve_result.get("error", "solve_captcha returned success=false"),
+        }
+    return solve_result.get("data", {}) or {}
+
+
+async def _run_one_attempt(
+    mgr: "BrowserManager",
+    agent_id: str,
+    site: SiteConfig,
+    attempt_index: int,
+    *,
+    timeout_s: float,
+    cumulative_counted_millicents_before: int,
+) -> tuple[AttemptOutcome, int]:
+    """Execute one attempt and produce an :class:`AttemptOutcome`.
+
+    Returns ``(outcome, cumulative_counted_millicents_after)`` where the
+    cumulative number folds in the per-attempt cost-counter delta. Caller
+    persists the outcome to the JSONL ledger AND THEN runs
+    :func:`_budget_check` to decide whether to abort — keeping budget
+    enforcement out of this routine guarantees every attempt the harness
+    actually runs reaches the ledger, even when the campaign aborts.
+    """
+    started = _utc_now_iso()
+    t0 = time.monotonic()
+    counted_before = await cost.get_millicents(agent_id)
+
+    error: str | None = None
+    envelope: dict[str, Any] = {}
+    try:
+        envelope = await asyncio.wait_for(
+            _drive_attempt(mgr, agent_id, site),
+            timeout=timeout_s,
+        )
+    except asyncio.TimeoutError:
+        error = f"attempt timed out after {timeout_s:.0f}s"
+        envelope = {
+            "captcha_found": False,
+            "kind": "unknown",
+            "solver_outcome": "harness_timeout",
+            "solver_confidence": "low",
+            "next_action": "operator_review",
+        }
+    except Exception as e:  # noqa: BLE001 — defensive: any exception from
+        # navigate/click/solve must NOT stall the campaign loop.
+        error = f"{type(e).__name__}: {e}"
+        envelope = {
+            "captcha_found": False,
+            "kind": "unknown",
+            "solver_outcome": "harness_error",
+            "solver_confidence": "low",
+            "next_action": "operator_review",
+        }
+
+    elapsed_ms = int((time.monotonic() - t0) * 1000)
+    counted_after = await cost.get_millicents(agent_id)
+    counted_delta = max(0, counted_after - counted_before)
+
+    cumulative = cumulative_counted_millicents_before + counted_delta
+
+    provider = _solver_provider(mgr)
+    estimate_cents = _estimate_charge_cents(provider, envelope)
+
+    outcome = AttemptOutcome(
+        site_url=site.url,
+        attempt_index=attempt_index,
+        wall_clock_ms=elapsed_ms,
+        envelope=envelope,
+        cost_charged_cents_estimated=estimate_cents,
+        cost_counted_millicents=counted_delta,
+        fingerprint_burn_signal=_is_burn_shaped(envelope),
+        classifier_match=(_envelope_kind(envelope) == site.expected_kind),
+        error=error,
+        timestamp_utc=started,
+    )
+    return outcome, cumulative
+
+
+def _budget_check(
+    *,
+    cumulative_millicents: int,
+    budget_millicents: int,
+    site_category: str,
+    attempt_index: int,
+) -> None:
+    """Raise :class:`BudgetExceeded` when ``cumulative >= budget``.
+
+    Called by the campaign loop AFTER the attempt's outcome has been
+    persisted. Keeping the budget check separate from outcome construction
+    means the budget abort never strands an attempt's data — every
+    attempt the harness ran reaches the JSONL ledger regardless of the
+    abort fate of the campaign.
+    """
+    if budget_millicents > 0 and cumulative_millicents >= budget_millicents:
+        raise BudgetExceeded(
+            f"Campaign aborted: cumulative counted spend "
+            f"{cumulative_millicents} millicents "
+            f"(≈${cumulative_millicents / 100_000:.4f}) reached budget "
+            f"{budget_millicents} millicents "
+            f"(≈${budget_millicents / 100_000:.2f}) "
+            f"after attempt {attempt_index} on {site_category}",
+        )
+
+
+def _write_outcome_jsonl(path: Path, outcome: AttemptOutcome) -> None:
+    """Append one outcome record to the JSONL ledger.
+
+    Each record is a single JSON line so the file is streamable and
+    durable across mid-campaign aborts.
+    """
+    with open(path, "a", encoding="utf-8") as fh:
+        fh.write(outcome.model_dump_json() + "\n")
+
+
+def _site_agent_id(site: SiteConfig) -> str:
+    """Synthesize a per-site agent id used by ``BrowserManager``.
+
+    Embedding the category + a short uuid suffix means a re-run of the same
+    config doesn't collide with leftover ledger state from a prior run.
+    """
+    short = uuid.uuid4().hex[:8]
+    return f"validation-{site.category}-{short}"
+
+
+async def run_campaign(
+    config: CampaignConfig,
+    output_dir: Path,
+    *,
+    timeout_s: float = ATTEMPT_TIMEOUT_S,
+    pace_seconds: float = DEFAULT_PACE_SECONDS,
+    browser_manager_factory=None,
+    write_report: bool = True,
+) -> CampaignReport:
+    """Run the campaign end-to-end.
+
+    Args:
+        config: validated :class:`CampaignConfig`.
+        output_dir: directory for ``attempts.jsonl`` + the markdown report.
+            Created if missing.
+        timeout_s: per-attempt hard timeout (asyncio.wait_for).
+        pace_seconds: sleep between attempts on the same site. Tests pass 0.
+        browser_manager_factory: zero-arg async callable that returns a
+            ready ``BrowserManager``. Defaults to a function that imports
+            and instantiates :class:`BrowserManager` directly. Tests inject
+            a mock manager to avoid spinning real Playwright.
+        write_report: when True (default) generate the markdown report at
+            campaign end. Tests can pass False to inspect ``CampaignReport``
+            without disk-writing the report.
+    """
+    output_dir.mkdir(parents=True, exist_ok=True)
+    jsonl_path = output_dir / "attempts.jsonl"
+
+    if browser_manager_factory is None:
+        async def _default_factory() -> "BrowserManager":
+            from src.browser.service import BrowserManager
+            mgr = BrowserManager(profiles_dir=str(output_dir / "profiles"))
+            return mgr
+        browser_manager_factory = _default_factory
+
+    mgr = await browser_manager_factory()
+
+    cost_budget_millicents = int(round(config.cost_budget_usd * 100_000))
+    attempts: list[AttemptOutcome] = []
+    aborted_sites: list[str] = []
+    budget_exceeded = False
+    cumulative_counted_millicents = 0
+
+    try:
+        for site in config.sites:
+            agent_id = _site_agent_id(site)
+            await _ensure_fresh_instance(mgr, agent_id)
+
+            burn_streak = 0
+            attempts_today = 0
+
+            for attempt_index in range(site.attempt_count):
+                # Pacing: sleep between attempts to avoid hammering the
+                # site within a single second. Tests pass 0 to skip.
+                if attempt_index > 0 and pace_seconds > 0:
+                    await asyncio.sleep(pace_seconds)
+
+                # ``attempts_per_day`` is the operator's stated comfort
+                # level — when we'd cross it we abort the SITE rather
+                # than block the campaign on a long sleep. The runbook
+                # tells operators to schedule a follow-up run on the
+                # next day to pick up the remaining attempts.
+                if attempts_today >= config.attempts_per_day:
+                    logger.info(
+                        "Daily quota %d reached for site=%s; "
+                        "skipping remaining %d attempt(s)",
+                        config.attempts_per_day,
+                        site.category,
+                        site.attempt_count - attempt_index,
+                    )
+                    break
+
+                outcome, cumulative_counted_millicents = await _run_one_attempt(
+                    mgr,
+                    agent_id,
+                    site,
+                    attempt_index,
+                    timeout_s=timeout_s,
+                    cumulative_counted_millicents_before=cumulative_counted_millicents,
+                )
+                attempts.append(outcome)
+                _write_outcome_jsonl(jsonl_path, outcome)
+                attempts_today += 1
+
+                # Budget gate runs AFTER the outcome is persisted so a
+                # campaign that hits the cap mid-flight still has every
+                # attempt it actually ran in the ledger. The exception
+                # exits the outer loop via the surrounding try/except.
+                try:
+                    _budget_check(
+                        cumulative_millicents=cumulative_counted_millicents,
+                        budget_millicents=cost_budget_millicents,
+                        site_category=site.category,
+                        attempt_index=attempt_index,
+                    )
+                except BudgetExceeded as bx:
+                    logger.warning("%s", bx)
+                    budget_exceeded = True
+                    raise
+
+                if outcome.fingerprint_burn_signal:
+                    burn_streak += 1
+                else:
+                    burn_streak = 0
+                if burn_streak >= BURN_STREAK_THRESHOLD:
+                    logger.warning(
+                        "Fingerprint burn detected on category=%s after %d "
+                        "consecutive burn-shaped outcomes; skipping "
+                        "remaining %d attempt(s)",
+                        site.category, burn_streak,
+                        site.attempt_count - (attempt_index + 1),
+                    )
+                    aborted_sites.append(site.url)
+                    break
+
+            await _ensure_fresh_instance(mgr, agent_id)
+    except BudgetExceeded:
+        # Caller-visible as a flag on CampaignReport; not re-raised.
+        pass
+    finally:
+        with contextlib.suppress(Exception):
+            await mgr.stop_all()
+
+    report_path: Path | None = None
+    if write_report:
+        # Local import — avoids circular ``runner ↔ report`` imports during
+        # type-stub evaluation and keeps ``--dry-run`` strictly free of any
+        # report-writer dependencies.
+        from tools.captcha_validation.report import generate_report
+        report_path = output_dir / (
+            f"validation-report-{datetime.now(timezone.utc).strftime('%Y-%m-%d')}.md"
+        )
+        generate_report(attempts, report_path)
+
+    return CampaignReport(
+        attempts=attempts,
+        aborted_sites=aborted_sites,
+        budget_exceeded=budget_exceeded,
+        output_dir=output_dir,
+        report_path=report_path,
+    )
+
+
+# ── CLI entry point ────────────────────────────────────────────────────────
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="python -m tools.captcha_validation.runner",
+        description=(
+            "Phase 9 §18.1 captcha-validation campaign runner. Drives the "
+            "production browser-service codepath against operator-curated "
+            "target sites and produces a §11.20-promotion-grade evidence "
+            "report.\n\n"
+            "Reads a YAML config (see config.example.yaml). NEVER auto-runs "
+            "against live sites at import time; --dry-run loads + validates "
+            "the config without making any HTTP calls."
+        ),
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument(
+        "config",
+        type=Path,
+        help="Path to the campaign YAML config (e.g. config.local.yaml).",
+    )
+    parser.add_argument(
+        "output_dir",
+        nargs="?",
+        type=Path,
+        default=Path("data/captcha_validation"),
+        help=(
+            "Directory for attempts.jsonl + the markdown report. "
+            "Created if missing. Default: data/captcha_validation."
+        ),
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help=(
+            "Load + validate the config and print a summary; do not "
+            "instantiate a BrowserManager and do not make any HTTP "
+            "calls. Use this to verify config.local.yaml before a real run."
+        ),
+    )
+    parser.add_argument(
+        "--timeout-seconds",
+        type=float,
+        default=ATTEMPT_TIMEOUT_S,
+        help=f"Per-attempt hard timeout in seconds (default: {ATTEMPT_TIMEOUT_S}).",
+    )
+    parser.add_argument(
+        "--pace-seconds",
+        type=float,
+        default=DEFAULT_PACE_SECONDS,
+        help=(
+            f"Sleep between attempts on the same site (default: "
+            f"{DEFAULT_PACE_SECONDS}). Operators MAY raise this to spread "
+            "attempts further within a session."
+        ),
+    )
+    return parser
+
+
+def _print_dry_run_summary(config: CampaignConfig) -> None:
+    """Print a human-readable summary of the loaded config.
+
+    Crucially: NEVER prints the full URLs (only host + path-prefix) and
+    NEVER prints creds-refs. Operator can sanity-check categories +
+    attempt counts before a real run.
+    """
+    print(f"Loaded {len(config.sites)} site(s)")
+    print(f"Cost budget: ${config.cost_budget_usd:.2f}")
+    print(f"Attempts per day per site: {config.attempts_per_day}")
+    print()
+    print("Sites:")
+    for site in config.sites:
+        # Print only the netloc + first path segment so casual scrollback
+        # never reveals OAuth callback paths or test-account user-handles.
+        from urllib.parse import urlsplit
+        parts = urlsplit(site.url)
+        loc = parts.netloc or "(unknown)"
+        head = parts.path.split("/", 2)
+        first_seg = "/" + head[1] if len(head) > 1 and head[1] else ""
+        print(
+            f"  - [{site.category:>20}] {loc}{first_seg}/...  "
+            f"expected_kind={site.expected_kind} "
+            f"attempts={site.attempt_count} "
+            f"interaction={site.interaction}",
+        )
+
+
+def main(argv: list[str] | None = None) -> int:
+    """CLI entry point. Returns process exit code."""
+    parser = _build_parser()
+    args = parser.parse_args(argv)
+
+    logging.basicConfig(
+        level=os.environ.get("OPENLEGION_LOG_LEVEL", "INFO"),
+        format="%(asctime)s %(levelname)s %(name)s %(message)s",
+    )
+
+    try:
+        config = load_campaign(args.config)
+    except FileNotFoundError:
+        print(f"Config file not found: {args.config}", file=sys.stderr)
+        return 2
+    except Exception as e:
+        print(f"Failed to load config: {e}", file=sys.stderr)
+        return 2
+
+    if args.dry_run:
+        print(f"Dry-run: loaded {args.config}; no HTTP calls will be made.")
+        _print_dry_run_summary(config)
+        return 0
+
+    asyncio.run(
+        run_campaign(
+            config,
+            args.output_dir,
+            timeout_s=args.timeout_seconds,
+            pace_seconds=args.pace_seconds,
+        ),
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/captcha_validation/schema.py
+++ b/tools/captcha_validation/schema.py
@@ -1,0 +1,285 @@
+"""Typed contracts for the Phase 9 §18.1 validation harness.
+
+Three Pydantic models:
+
+* :class:`SiteConfig` — one row of an operator-curated target list. The URL,
+  expected §11.13 ``kind``, and how to provoke the captcha (navigate-only or
+  navigate-then-click).
+* :class:`CampaignConfig` — top-level YAML shape: a list of sites plus
+  campaign-wide caps (cost budget, attempts-per-day pacing, optional
+  solver-proxy creds reference).
+* :class:`AttemptOutcome` — one row of the JSONL outcome ledger. The §11.13
+  envelope is preserved verbatim; cost and timing are reconciled at the
+  harness layer.
+
+The schema deliberately treats credentials as opaque references — the YAML
+contains *names* (``vault://test_google_account``) that the operator
+resolves out-of-band, never raw secrets. Defends against accidental commits
+of ``config.local.yaml`` containing real tokens.
+"""
+
+from __future__ import annotations
+
+from typing import Literal
+
+from pydantic import BaseModel, Field, field_validator
+
+# §11.13 envelope ``kind`` enum. Must stay in sync with
+# ``src/browser/captcha.py:_VALID_CAPTCHA_KINDS`` plus the broader list of
+# kinds the §18.1 campaign deliberately exercises (FunCaptcha, GeeTest, AWS
+# WAF, DataDome, PerimeterX) — those are §11.20 deferred items that the
+# campaign is supposed to surface as ``unsupported`` outcomes for evidence.
+# Validating expected_kind against this set catches typos early; the runner
+# still records whatever the production envelope emits, even if the live
+# kind isn't in this set.
+KNOWN_CAPTCHA_KINDS: frozenset[str] = frozenset({
+    # Currently supported (Phase 8 merged)
+    "recaptcha-v2-checkbox",
+    "recaptcha-v2-invisible",
+    "recaptcha-v3",
+    "recaptcha-enterprise-v2",
+    "recaptcha-enterprise-v3",
+    "hcaptcha",
+    "turnstile",
+    "cf-interstitial-turnstile",
+    "cf-interstitial-auto",
+    "cf-interstitial-behavioral",
+    # §11.20 deferred — campaign expects ``unsupported`` outcome here
+    "funcaptcha",
+    "geetest",
+    "geetest-v3",
+    "geetest-v4",
+    "aws-waf",
+    "datadome-behavioral",
+    "px-press-hold",
+    # Catchall when the classifier hasn't picked a variant
+    "unknown",
+})
+
+
+# 10 operator-facing categories from the plan §18.1 site list. Used for
+# report grouping and to enforce that the campaign covers each category at
+# most once (the spec calls for one URL per category, more attempts in any
+# category that turns out flaky).
+KNOWN_CATEGORIES: frozenset[str] = frozenset({
+    "google_signin",
+    "twitter_signup",
+    "linkedin_auth",
+    "cloudflare_saas",
+    "aws_waf",
+    "geetest",
+    "invisible_v2",
+    "hcaptcha_saas",
+    "human_perimeterx",
+    "datadome",
+    # Operator escape hatch for one-off targets that don't fit a category.
+    "other",
+})
+
+
+class SiteConfig(BaseModel):
+    """One operator-curated target site."""
+
+    url: str = Field(
+        ...,
+        description="Target URL. Operator-curated; never logged un-redacted in the report.",
+    )
+    expected_kind: str = Field(
+        ...,
+        description="§11.13 envelope kind enum the operator expects this site to emit.",
+    )
+    attempt_count: int = Field(
+        10,
+        ge=1,
+        le=100,
+        description="How many solve attempts to make against this site in the campaign.",
+    )
+    interaction: Literal["navigate_only", "navigate_then_click_submit"] = Field(
+        "navigate_only",
+        description=(
+            "How to provoke the captcha. ``navigate_only`` = the captcha "
+            "fires on page load. ``navigate_then_click_submit`` = navigate, "
+            "then click ``interaction_selector`` to surface the captcha."
+        ),
+    )
+    interaction_selector: str | None = Field(
+        None,
+        description=(
+            "CSS selector for the click in ``navigate_then_click_submit``. "
+            "Required iff interaction == 'navigate_then_click_submit'."
+        ),
+    )
+    account_creds_ref: str | None = Field(
+        None,
+        description=(
+            "Opaque reference to a vault entry (e.g. ``vault://test_google``). "
+            "The harness NEVER reads creds from the YAML — operator resolves "
+            "the reference out-of-band before running. Stored only to "
+            "annotate the report with which test account was used."
+        ),
+    )
+    category: str = Field(
+        ...,
+        description=(
+            "One of the 10 §18.1 categories (e.g. ``google_signin``, "
+            "``twitter_signup``). See KNOWN_CATEGORIES."
+        ),
+    )
+    notes: str | None = Field(
+        None,
+        description="Operator-facing free-form notes; appears in the report.",
+    )
+
+    @field_validator("expected_kind")
+    @classmethod
+    def _validate_kind(cls, v: str) -> str:
+        if v not in KNOWN_CAPTCHA_KINDS:
+            raise ValueError(
+                f"expected_kind={v!r} is not a known §11.13 kind. "
+                f"Known: {sorted(KNOWN_CAPTCHA_KINDS)}",
+            )
+        return v
+
+    @field_validator("category")
+    @classmethod
+    def _validate_category(cls, v: str) -> str:
+        if v not in KNOWN_CATEGORIES:
+            raise ValueError(
+                f"category={v!r} is not a known §18.1 category. "
+                f"Known: {sorted(KNOWN_CATEGORIES)}",
+            )
+        return v
+
+    @field_validator("url")
+    @classmethod
+    def _validate_url(cls, v: str) -> str:
+        v = v.strip()
+        if not v:
+            raise ValueError("url must be non-empty")
+        # Reject obvious placeholder URLs that operators forgot to fill in.
+        # These are the literal strings used in ``config.example.yaml``.
+        if v.endswith("/...") or v.startswith("vault://"):
+            raise ValueError(
+                f"url={v!r} looks like an unfilled placeholder — "
+                f"replace with a real target URL before running",
+            )
+        return v
+
+
+class CampaignConfig(BaseModel):
+    """Top-level YAML shape — one campaign run."""
+
+    sites: list[SiteConfig] = Field(
+        ...,
+        description="The curated target list. One row per site.",
+    )
+    solver_proxy_creds_ref: str | None = Field(
+        None,
+        description=(
+            "Opaque reference to a vault entry holding the dedicated "
+            "solver-proxy creds (NOT the agent's primary egress proxy — "
+            "see §11.2 security note). The harness expects the operator to "
+            "have already exported these as ``CAPTCHA_SOLVER_PROXY_*`` env "
+            "vars before invoking the runner; this field is documentary."
+        ),
+    )
+    cost_budget_usd: float = Field(
+        5.0,
+        gt=0,
+        le=100.0,
+        description=(
+            "Hard ceiling on the campaign's solver spend in USD. The runner "
+            "aborts the entire campaign once the cumulative counted spend "
+            "(via ``captcha_cost_counter``) crosses this threshold."
+        ),
+    )
+    attempts_per_day: int = Field(
+        5,
+        ge=1,
+        le=100,
+        description=(
+            "Per-site pacing — how many attempts to make on a given calendar "
+            "day for any single site. The runner spreads ``attempt_count`` "
+            "across multiple days when ``attempt_count > attempts_per_day`` "
+            "by sleeping until the next day before resuming. In practice "
+            "operators run two short same-day sessions."
+        ),
+    )
+
+    @field_validator("sites")
+    @classmethod
+    def _validate_non_empty(cls, v: list[SiteConfig]) -> list[SiteConfig]:
+        if not v:
+            raise ValueError("sites must contain at least one entry")
+        return v
+
+
+class AttemptOutcome(BaseModel):
+    """One row of the per-attempt outcome ledger.
+
+    Persisted as JSONL under ``output_dir/attempts.jsonl``. The §11.13
+    envelope is captured verbatim under ``envelope`` so the report writer
+    can group outcomes without re-deriving anything; cost reconciliation
+    fields live alongside.
+    """
+
+    site_url: str = Field(
+        ..., description="Source URL of the attempt (will be redacted in the report).",
+    )
+    attempt_index: int = Field(
+        ..., ge=0, description="0-based index of this attempt within its site.",
+    )
+    wall_clock_ms: int = Field(
+        ..., ge=0, description="Wall-clock ms from detection start to envelope return.",
+    )
+    envelope: dict = Field(
+        ...,
+        description=(
+            "§11.13 envelope verbatim. Common keys: ``kind``, "
+            "``solver_outcome``, ``solver_confidence``, ``next_action``, "
+            "``captcha_found``."
+        ),
+    )
+    cost_charged_cents_estimated: int = Field(
+        0,
+        ge=0,
+        description=(
+            "Estimated provider charge in cents (=millicents/1000) computed "
+            "from ``estimate_millicents(provider, kind, proxy_aware=...)``. "
+            "Zero when the variant has no published rate or when the solve "
+            "short-circuited before any provider charge."
+        ),
+    )
+    cost_counted_millicents: int = Field(
+        0,
+        ge=0,
+        description=(
+            "Per-attempt delta from ``captcha_cost_counter.get_millicents`` "
+            "(after - before). Zero when no cost was counted."
+        ),
+    )
+    fingerprint_burn_signal: bool = Field(
+        False,
+        description=(
+            "True when the envelope's ``solver_outcome`` indicates the "
+            "site has flagged the fingerprint (token rejected, repeated "
+            "challenge after solve). Five consecutive True values for one "
+            "site triggers the runner's per-site abort."
+        ),
+    )
+    classifier_match: bool = Field(
+        ...,
+        description="True iff envelope.kind == site.expected_kind.",
+    )
+    error: str | None = Field(
+        None,
+        description=(
+            "Harness-side exception summary (e.g. timeout reaching the "
+            "browser, invalid_input from solve_captcha). Distinct from "
+            "envelope-level errors — those live inside ``envelope``."
+        ),
+    )
+    timestamp_utc: str = Field(
+        ...,
+        description="ISO-8601 UTC timestamp at attempt start.",
+    )


### PR DESCRIPTION
## Summary

Phase 9 §18.1 closes the validation gap left by Phase 8. Every Phase 8 captcha classifier was tested against mocks; this PR adds the **infrastructure** to drive the production browser-service pipeline against real protected sites so we can promote §11.20 deferred items based on evidence, not speculation.

The harness ships **ready-to-use** at `tools/captcha_validation/`. Live runs come AFTER merge — they require operator-supplied target URLs + solver creds + test accounts.

- `runner.py` drives `BrowserManager.navigate` → optional `click` → `solve_captcha` end-to-end. Per-attempt `asyncio.wait_for(180s)` so a stuck Playwright page never stalls the campaign. Hard cost-budget ceiling (default `$5`) and 5-consecutive-burn site skip both enforced.
- `report.py` produces the §18.1 markdown template — outcome distribution, classifier accuracy, cost reconciliation (flags >10% counted-vs-estimate delta), promotion recommendations.
- `schema.py` is Pydantic-validated; placeholder-URL detection makes the shipped `config.example.yaml` impossible to copy-paste-and-run accidentally.
- 25 self-tests use a scripted `_ScriptedManager` stub — no real browser, no real solver provider.
- Reuse-map honored: `redact_url` from `src.shared.redaction`, `estimate_millicents` + `get_millicents` from `captcha_cost_counter`, §11.13 envelope verbatim. No new HTTP clients (httpx already a dep). No new YAML libs (pyyaml already a dep).
- `.gitignore` updated so operator-supplied `config.local.yaml` cannot enter version control.

Plan reference: `docs/plans/2026-04-20-browser-automation.md` §18.1.

## Test plan

- [x] `pytest tests/test_captcha_validation_harness.py -v` — 25 passed.
- [x] `pytest tests/ --ignore=tests/test_e2e* --deselect tests/test_cli_commands.py::TestVersion::test_version_flag` — 4301 passed, 43 skipped (the deselected test is a pre-existing failure on `main` from running pytest without `pip install -e .`; reproduced on a clean tree).
- [x] `ruff check src/ tests/ tools/` — All checks passed.
- [x] `python -m tools.captcha_validation.runner --help` — clean usage message, exit 0.
- [x] `python -m tools.captcha_validation.runner tools/captcha_validation/config.example.yaml --dry-run` — exits 2 with placeholder-URL validation errors (the property that makes the example file safe to ship).
- [x] `python -m tools.captcha_validation.runner /tmp/valid_test.yaml --dry-run` — loads + summarizes without making any HTTP calls; confirmed no `attempts.jsonl` is created during dry-run.
- [ ] **Operator follow-up after merge**: copy `config.example.yaml` to `config.local.yaml`, fill real URLs + creds-refs, source the dedicated solver-proxy env vars, run the campaign, file the report under `docs/plans/2026-04-2X-phase9-validation-report.md`, then update §11.20 trigger lines per §18.4.