### PR TITLE
Phase 9 §18.2: re-detect captcha after click/type/press_key/fill_form

### DIFF
--- a/src/browser/flags.py
+++ b/src/browser/flags.py
@@ -67,6 +67,10 @@ KNOWN_FLAGS: dict[str, str] = {
     "OPENLEGION_UPLOAD_STAGE_DIR": "mesh staging dir (default /tmp/openlegion-upload-stage)",
     "OPENLEGION_UPLOAD_RECV_DIR": "browser receive dir (default /tmp/upload-recv)",
     "OPENLEGION_UPLOAD_STAGE_TTL_S": "orphan staging TTL in seconds (default 60)",
+    # ── CAPTCHA re-detection after non-navigate actions (§11.4 / §18.2) ───
+    "BROWSER_CAPTCHA_REDETECT_ENABLED":
+        "true | false (default true) — gate MutationObserver-based "
+        "post-action captcha re-detection on click/type/press_key/fill_form",
     # ── CAPTCHA solver (§11) ──────────────────────────────────────────────
     "CAPTCHA_SOLVER_PROVIDER": "2captcha | capsolver | unset",
     "CAPTCHA_SOLVER_KEY": "API key for the primary provider",

--- a/src/browser/service.py
+++ b/src/browser/service.py
@@ -1446,6 +1446,93 @@ def _encode_screenshot(
         return png_bytes, "png"
 
 
+# ── §11.4 / §18.2 captcha re-detection after non-navigate actions ──────────
+#
+# Two-call install/read-back pattern: install a MutationObserver before the
+# action runs, then read back any added DOM nodes after the action returns
+# and intersect them with the existing ``_check_captcha`` selector list. If
+# any added node matches a captcha selector we route through the full
+# ``_check_captcha`` → ``_metered_solve`` chain so the agent gets the §11.13
+# envelope AND every gate (rate-limit, cost-cap, kill-switch, breaker,
+# behavioral classification) fires uniformly. See plan docs §11.4 + §18.2.
+#
+# Probe attaches to ``window.__ol_captcha_probe`` so concurrent observers
+# from prior calls are overwritten cleanly. The probe is torn down in the
+# read-back (``obs.disconnect()`` + ``delete window.__ol_captcha_probe``)
+# so a navigation that happens between install and read-back leaves no
+# residue — the read-back from the new page returns ``[]`` (probe absent)
+# and the caller falls back to the navigate-time ``_check_captcha`` path.
+_JS_CAPTCHA_REDETECT_INSTALL = """
+() => {
+  try {
+    if (window.__ol_captcha_probe && window.__ol_captcha_probe.obs) {
+      try { window.__ol_captcha_probe.obs.disconnect(); } catch (e) {}
+    }
+    window.__ol_captcha_probe = { adds: [], obs: null };
+    if (!document.body) return;
+    const obs = new MutationObserver(records => {
+      for (const r of records) {
+        for (const n of r.addedNodes) {
+          if (n && n.nodeType === 1) {
+            window.__ol_captcha_probe.adds.push(n);
+          }
+        }
+      }
+    });
+    obs.observe(document.body, { childList: true, subtree: true });
+    window.__ol_captcha_probe.obs = obs;
+  } catch (e) {
+    // Swallow — install failure must never break the action.
+  }
+}
+"""
+
+_JS_CAPTCHA_REDETECT_READBACK = """
+(selectors) => {
+  const p = window.__ol_captcha_probe;
+  if (!p) return [];
+  try { if (p.obs) p.obs.disconnect(); } catch (e) {}
+  const hits = new Set();
+  try {
+    for (const n of (p.adds || [])) {
+      for (const sel of selectors) {
+        try {
+          if (n.matches && (n.matches(sel) || (n.querySelector && n.querySelector(sel)))) {
+            hits.add(sel);
+          }
+        } catch (e) {}
+      }
+    }
+  } catch (e) {}
+  try { delete window.__ol_captcha_probe; } catch (e) {}
+  return [...hits];
+}
+"""
+
+# Reused by ``_with_captcha_redetect`` so the JS read-back filter and the
+# Python ``_check_captcha`` selector list cannot drift apart. Mirrors the
+# inline list inside ``_check_captcha``.
+_CAPTCHA_REDETECT_SELECTORS: tuple[str, ...] = (
+    'iframe[src*="recaptcha"]',
+    'iframe[src*="hcaptcha"]',
+    'iframe[src*="challenges.cloudflare.com"]',
+    'iframe[src*="captcha"]',
+    '[class*="cf-turnstile"]',
+    '[class*="captcha"]',
+    '#captcha',
+)
+
+# Rate-limit window for the post-action re-detection trigger. A single
+# action that mutates the DOM heavily (SPA route change, list re-render)
+# can fire dozens of mutation records; without a per-instance throttle a
+# rapid sequence of clicks would each invoke ``_check_captcha`` in full
+# (selector probe + classifiers + locator counts). 2s matches the typical
+# captcha-render delay and keeps the steady-state cost at ≤1 probe / 2s
+# regardless of action cadence. The metered_solve gates downstream are
+# ALSO rate-limited (per-hour) so this is purely a CPU-cost throttle.
+_REDETECT_MIN_INTERVAL_S: float = 2.0
+
+
 def _classify_diff_scope(
     inst,
     *,
@@ -1719,6 +1806,18 @@ class CamoufoxInstance:
         # into another solve attempt (could otherwise pile up provider
         # cost and deadlock against the per-instance lock).
         self._captcha_solving: bool = False
+        # §11.4 / §18.2 post-action captcha re-detection state.
+        # ``_last_redetect_ts`` carries a ``time.monotonic()`` reading
+        # of the most recent successful read-back; the wrapper skips the
+        # full ``_check_captcha`` invocation when within
+        # :data:`_REDETECT_MIN_INTERVAL_S` of the previous trigger so a
+        # heavily-mutating action doesn't hammer the selector probe.
+        # ``_pending_captcha_envelope`` carries the §11.13 envelope from
+        # the most recent post-action detection; the next ``snapshot()``
+        # call surfaces and clears it so a polling agent sees the
+        # envelope even when it didn't read the action's response.
+        self._last_redetect_ts: float = 0.0
+        self._pending_captcha_envelope: dict | None = None
 
     def _register_page(self, page) -> str:
         """Assign a stable UUID to a Page if not already registered.
@@ -3065,7 +3164,7 @@ class BrowserManager:
         inst = await self.get_or_start(agent_id)
         inst.touch()
         async with inst.lock:
-            return await self._snapshot_impl(
+            result = await self._snapshot_impl(
                 inst, agent_id,
                 filter=filter,
                 from_ref=from_ref,
@@ -3073,6 +3172,22 @@ class BrowserManager:
                 frame=frame,
                 include_frames=include_frames,
             )
+            # §11.4 / §18.2 — surface and CLEAR any pending captcha
+            # envelope captured by ``_with_captcha_redetect`` after a
+            # prior click/type/press_key/fill_form. This double-surfaces
+            # the §11.13 envelope: agents that read the action response
+            # see it inline; agents that poll via ``snapshot()`` after
+            # acting see it here. Cleared on this read so a third
+            # poll doesn't repeat the same envelope (the snapshot itself
+            # would have called ``_check_captcha`` if the captcha is
+            # still on the page — but we deliberately don't run a probe
+            # here, snapshot is supposed to be cheap).
+            pending = inst._pending_captcha_envelope
+            if pending is not None and isinstance(result, dict) and result.get("success"):
+                data = result.setdefault("data", {})
+                data.setdefault("captcha", pending)
+                inst._pending_captcha_envelope = None
+            return result
 
     async def _snapshot_impl(
         self,
@@ -4733,7 +4848,7 @@ class BrowserManager:
         inst = await self.get_or_start(agent_id)
         inst.touch()
         async with inst.lock:
-            try:
+            async def _click_body() -> dict:
                 if inst._user_control:
                     return {
                         "success": False,
@@ -4938,6 +5053,11 @@ class BrowserManager:
                     snap = await self._snapshot_impl(inst, agent_id)
                     result["snapshot"] = snap.get("data", {})
                 return result
+
+            try:
+                action_result, captcha_envelope = await self._with_captcha_redetect(
+                    inst, _click_body(),
+                )
             except NotImplementedError as e:
                 # Defensive: when PR2 (shadow DOM) merges, refs carrying
                 # both ``shadow_path`` and ``frame_id`` will hit the
@@ -4957,6 +5077,18 @@ class BrowserManager:
                 inst.click_window.append(False)
                 inst.recorder.record_click(method="auto", success=False)
                 return {"success": False, "error": str(e)}
+
+            # §11.4 / §18.2 — re-detection envelope is ADDITIVE: existing
+            # callers continue to see the original action_result shape;
+            # new agents that read ``"captcha"`` get the §11.13 envelope
+            # when a captcha appeared as a side effect of the click.
+            if (
+                captcha_envelope is not None
+                and isinstance(action_result, dict)
+                and action_result.get("success")
+            ):
+                action_result.setdefault("captcha", captcha_envelope)
+            return action_result
 
     async def click_xy(
         self, agent_id: str, x: float, y: float,
@@ -5184,7 +5316,7 @@ class BrowserManager:
         inst = await self.get_or_start(agent_id)
         inst.touch()
         async with inst.lock:
-            try:
+            async def _type_body() -> dict:
                 if inst._user_control:
                     return {
                         "success": False,
@@ -5333,6 +5465,11 @@ class BrowserManager:
                     snap = await self._snapshot_impl(inst, agent_id)
                     result["snapshot"] = snap.get("data", {})
                 return result
+
+            try:
+                action_result, captcha_envelope = await self._with_captcha_redetect(
+                    inst, _type_body(),
+                )
             except NotImplementedError as e:
                 # See click() for rationale — pre-emptive catch for PR2's
                 # shadow+iframe combination guard.
@@ -5342,6 +5479,14 @@ class BrowserManager:
                 )
             except Exception as e:
                 return {"success": False, "error": str(e)}
+
+            if (
+                captcha_envelope is not None
+                and isinstance(action_result, dict)
+                and action_result.get("success")
+            ):
+                action_result.setdefault("captcha", captcha_envelope)
+            return action_result
 
     async def evaluate(self, agent_id: str, expression: str) -> dict:
         """Execute JavaScript and return result.
@@ -5640,6 +5785,165 @@ class BrowserManager:
                 return {"success": True, "data": {"selector": selector, "state": state}}
             except Exception as e:
                 return {"success": False, "error": str(e)}
+
+    async def _with_captcha_redetect(
+        self,
+        inst: CamoufoxInstance,
+        action_coro,
+    ):
+        """§11.4 / §18.2 — wrap an action with MutationObserver-based
+        post-action captcha re-detection.
+
+        Pattern:
+
+          1. Install a ``MutationObserver`` on ``document.body`` capturing
+             every added Element node.
+          2. Run ``action_coro`` (the original action body).
+          3. Read back the captured nodes against the
+             :data:`_CAPTCHA_REDETECT_SELECTORS` list. If any node matches
+             AND we're outside the per-instance rate-limit window, route
+             through the full :meth:`_check_captcha` chain (which goes
+             through :meth:`_metered_solve` and so respects every gate:
+             rate-limit, cost-cap, kill-switch, breaker, behavioral).
+          4. Stash the resulting §11.13 envelope on
+             ``inst._pending_captcha_envelope`` AND return it alongside
+             the action result so the agent sees it inline.
+
+        **Failure modes — all swallowed.** Install failure (page closed,
+        CSP block) means we run the action with no probe. Read-back
+        failure (navigation between install and read-back, page closed)
+        treats the probe as never having fired — empty hits, no
+        ``_check_captcha`` call.
+
+        **Navigation during action.** When the page navigates away,
+        ``window.__ol_captcha_probe`` lives on the old document and is
+        torn down. The read-back from the new page returns ``[]`` and we
+        skip the auto-trigger; the navigate path's own ``_check_captcha``
+        call (in :meth:`navigate`) is the right defense for the new page.
+
+        **Rate-limit.** The wrapper checks
+        ``inst._last_redetect_ts`` against
+        :data:`_REDETECT_MIN_INTERVAL_S` BEFORE invoking
+        ``_check_captcha`` — a probe-storm during a single mutation-heavy
+        action triggers the full chain at most once per 2s. The
+        ``_metered_solve`` gates remain authoritative for solver cost /
+        rate; this throttle is a CPU-cost guard for the auto-detect path.
+
+        **Empty-probe defense.** Spec calls for triggering only on a
+        match. We respect that — pages that swap captchas via
+        ``innerHTML`` replace (rare) will miss the MutationObserver and
+        agents must fall back to the explicit ``solve_captcha`` skill.
+        Always firing ``_check_captcha`` would defeat the cost-saving
+        purpose of this wrapper (each call walks 7 selectors via
+        ``locator(...).count()``).
+
+        **Flag gate.** ``BROWSER_CAPTCHA_REDETECT_ENABLED=false`` makes
+        the wrapper a passthrough — action runs, no install/read-back,
+        no auto-trigger.
+
+        Returns ``(result, envelope_or_none)`` where ``result`` is the
+        action's own return value (passed through unchanged) and
+        ``envelope_or_none`` is the §11.13 envelope when re-detection
+        fired and matched, or ``None`` otherwise. Callers add the
+        envelope to their action response under a ``"captcha"`` key
+        when present.
+        """
+        from src.browser.flags import get_bool
+
+        agent_id = inst.agent_id
+
+        if not get_bool(
+            "BROWSER_CAPTCHA_REDETECT_ENABLED", True, agent_id=agent_id,
+        ):
+            # Passthrough — operator disabled re-detection. No probe, no
+            # read-back, no auto-trigger.
+            return await action_coro, None
+
+        # Snapshot the page object + URL up front so the read-back can
+        # detect navigation (page swap or URL change) and skip cleanly.
+        pre_page = inst.page
+        try:
+            pre_url = inst.page.url or ""
+        except Exception:
+            pre_url = ""
+
+        # 1. Install. Failures are non-fatal — we still run the action.
+        try:
+            await inst.page.evaluate(_JS_CAPTCHA_REDETECT_INSTALL)
+        except Exception as e:
+            logger.debug(
+                "captcha redetect: install failed for %s: %s",
+                agent_id, e,
+            )
+
+        # 2. Run the action. Always propagate exceptions — the wrapper
+        # exists to add detection, not to swallow action failures.
+        result = await action_coro
+
+        # 3. Read back the captured added nodes.
+        navigated = False
+        try:
+            current_url = inst.page.url or ""
+        except Exception:
+            current_url = ""
+        if inst.page is not pre_page or current_url != pre_url:
+            navigated = True
+
+        hits: list[str] = []
+        if not navigated:
+            try:
+                hits = await inst.page.evaluate(
+                    _JS_CAPTCHA_REDETECT_READBACK,
+                    list(_CAPTCHA_REDETECT_SELECTORS),
+                )
+                if not isinstance(hits, list):
+                    hits = []
+            except Exception as e:
+                logger.debug(
+                    "captcha redetect: read-back failed for %s: %s",
+                    agent_id, e,
+                )
+                hits = []
+
+        if not hits:
+            # No captcha-shaped DOM additions detected — fastest path,
+            # no further work.
+            return result, None
+
+        # 4. Per-instance rate-limit. Probe storms (heavily-mutating
+        # actions, agent loops issuing back-to-back clicks) must not
+        # invoke the full 7-selector locator probe more than
+        # ``_REDETECT_MIN_INTERVAL_S`` per instance.
+        now = time.monotonic()
+        if (now - inst._last_redetect_ts) < _REDETECT_MIN_INTERVAL_S:
+            logger.debug(
+                "captcha redetect: rate-limited for %s (%.2fs since last)",
+                agent_id, now - inst._last_redetect_ts,
+            )
+            return result, None
+        inst._last_redetect_ts = now
+
+        # 5. Full ``_check_captcha`` chain — gates fire inside.
+        try:
+            envelope = await self._check_captcha(inst)
+        except Exception as e:
+            logger.debug(
+                "captcha redetect: _check_captcha raised for %s: %s",
+                agent_id, e,
+            )
+            return result, None
+
+        if not envelope.get("captcha_found"):
+            return result, None
+        if envelope.get("solver_outcome") == "solved":
+            # Solver auto-cleared it — nothing for the agent to do.
+            return result, None
+
+        # Stash for snapshot integration AND return inline so the agent
+        # sees it on whichever code path it consults next.
+        legacy = _with_legacy_fields(envelope)
+        inst._pending_captcha_envelope = legacy
+        return result, legacy
 
     async def _metered_solve(
         self,
@@ -7043,73 +7347,189 @@ class BrowserManager:
         # another action interleave between find_text and fill, breaking
         # the ref freshness guarantee.
         async with inst.lock:
-            if inst._user_control:
-                return _err(
-                    "conflict",
-                    "User has browser control — action paused until control is released.",
-                )
+            async def _fill_body() -> dict:
+                if inst._user_control:
+                    return _err(
+                        "conflict",
+                        "User has browser control — action paused until control is released.",
+                    )
 
-            filled: list[dict] = []
-            last_locator = None
-            # Track whether ANY Enter press has succeeded — per-field
-            # submit_after immediately before the captcha check is the
-            # most common trigger for a mid-flow captcha (submission is
-            # often what gates the challenge). When that happens, the
-            # form may have ALREADY been submitted with partial data, so
-            # the captcha-envelope must report ``submitted=True`` rather
-            # than the agent thinking it can safely resume by re-typing.
-            submitted = False
-            for i, field in enumerate(normalized):
-                label = field["label"]
-                value = field["value"]
-                field_submit = field["submit_after"]
+                filled: list[dict] = []
+                last_locator = None
+                # Track whether ANY Enter press has succeeded — per-field
+                # submit_after immediately before the captcha check is the
+                # most common trigger for a mid-flow captcha (submission is
+                # often what gates the challenge). When that happens, the
+                # form may have ALREADY been submitted with partial data, so
+                # the captcha-envelope must report ``submitted=True`` rather
+                # than the agent thinking it can safely resume by re-typing.
+                submitted = False
+                for i, field in enumerate(normalized):
+                    label = field["label"]
+                    value = field["value"]
+                    field_submit = field["submit_after"]
 
-                # 1) Locate the field via find_text. scroll=True so the
-                #    matched input is brought into view before the fill;
-                #    avoids "element not in viewport" failures on long
-                #    forms.
-                find_res = await self._find_text_impl(
-                    inst, agent_id, label, scroll=True,
-                )
-                # Output-side label hygiene: defensively redact the label
-                # echoed back in ``filled[]``. Mirrors :meth:`_find_text_impl`
-                # line ~5261, which redacts the matched ``text`` it returns.
-                # If an agent passes a label like ``"Token: abc123"`` the
-                # response should not echo the secret in plaintext into the
-                # transcript — same defense as the URL redaction in §9.1.
-                # (``remaining[]`` deliberately keeps labels & values
-                # verbatim — see :meth:`_fill_form_captcha_envelope` — so
-                # the agent can resume after solving without losing data.)
-                safe_label = sanitize_for_prompt(
-                    self.redactor.redact(agent_id, label)
-                )
+                    # 1) Locate the field via find_text. scroll=True so the
+                    #    matched input is brought into view before the fill;
+                    #    avoids "element not in viewport" failures on long
+                    #    forms.
+                    find_res = await self._find_text_impl(
+                        inst, agent_id, label, scroll=True,
+                    )
+                    # Output-side label hygiene: defensively redact the label
+                    # echoed back in ``filled[]``. Mirrors :meth:`_find_text_impl`
+                    # line ~5261, which redacts the matched ``text`` it returns.
+                    # If an agent passes a label like ``"Token: abc123"`` the
+                    # response should not echo the secret in plaintext into the
+                    # transcript — same defense as the URL redaction in §9.1.
+                    # (``remaining[]`` deliberately keeps labels & values
+                    # verbatim — see :meth:`_fill_form_captcha_envelope` — so
+                    # the agent can resume after solving without losing data.)
+                    safe_label = sanitize_for_prompt(
+                        self.redactor.redact(agent_id, label)
+                    )
 
-                if not find_res.get("success"):
-                    # Snapshot/find_text failure is service-side; surface
-                    # as type_failed so the loop continues — the agent
-                    # can re-snapshot and retry.
-                    err = find_res.get("error") or {}
-                    raw_reason = (
-                        str(err.get("message")) if isinstance(err, dict)
-                        else str(err)
-                    ) or "find_text failed"
+                    if not find_res.get("success"):
+                        # Snapshot/find_text failure is service-side; surface
+                        # as type_failed so the loop continues — the agent
+                        # can re-snapshot and retry.
+                        err = find_res.get("error") or {}
+                        raw_reason = (
+                            str(err.get("message")) if isinstance(err, dict)
+                            else str(err)
+                        ) or "find_text failed"
+                        filled.append({
+                            "label": safe_label,
+                            "status": "type_failed",
+                            "reason": self.redactor.redact(agent_id, raw_reason),
+                        })
+                        continue
+
+                    matches = (find_res.get("data") or {}).get("matches") or []
+                    if not matches:
+                        filled.append({"label": safe_label, "status": "not_found"})
+                        # CAPTCHA may have appeared as a result of the snapshot
+                        # itself (rare — e.g. a JS challenge that injects on
+                        # every navigation). Check before continuing so we
+                        # don't keep pummeling a blocked page with snapshots.
+                        # _check_captcha now always returns the §11.13 envelope
+                        # (truthy even with no captcha); only stop the loop
+                        # when a captcha was actually found AND not auto-solved.
+                        envelope = await self._check_captcha(inst)
+                        if (
+                            envelope.get("captcha_found")
+                            and envelope.get("solver_outcome") != "solved"
+                        ):
+                            return self._fill_form_captcha_envelope(
+                                filled, normalized[i + 1:],
+                                _with_legacy_fields(envelope),
+                                submitted=submitted,
+                            )
+                        continue
+
+                    # Prefer fillable controls when the visible label text and
+                    # the input's accessible name both match. Snapshot order can
+                    # put a <label> before its <input>; picking that label first
+                    # would yield a needless not_fillable failure even though the
+                    # correct textbox is present in the same match set.
+                    def _preferred_match(m: dict) -> bool:
+                        ref_id = m.get("ref")
+                        handle = inst.refs.get(ref_id)
+                        role = (getattr(handle, "role", "") or "").lower()
+                        disabled = bool(getattr(handle, "disabled", False))
+                        return (
+                            role in self._FILL_FORM_PREFERRED_ROLES
+                            and not disabled
+                        )
+
+                    pick = (
+                        next(
+                            (
+                                m for m in matches
+                                if m.get("in_viewport") and _preferred_match(m)
+                            ),
+                            None,
+                        )
+                        or next((m for m in matches if _preferred_match(m)), None)
+                        or next((m for m in matches if m.get("in_viewport")), None)
+                        or matches[0]
+                    )
+                    ref = pick.get("ref")
+
+                    try:
+                        locator = await self._locator_from_ref(inst, ref)
+                    except RefStale as rs:
+                        filled.append({
+                            "label": safe_label,
+                            "ref": ref,
+                            "status": "type_failed",
+                            "reason": self.redactor.redact(agent_id, str(rs)),
+                        })
+                        continue
+                    if locator is None:
+                        filled.append({
+                            "label": safe_label,
+                            "ref": ref,
+                            "status": "type_failed",
+                            "reason": "ref not found",
+                        })
+                        continue
+
+                    try:
+                        await locator.fill(value)
+                    except Exception as e:
+                        # Element no longer attached / disabled / hidden /
+                        # not-fillable (label-element returned by find_text).
+                        # Don't bail the whole form: subsequent fields may still
+                        # be reachable. ``reason`` is a structured code (see
+                        # :meth:`_classify_fill_error`) so the agent can plan a
+                        # specific recovery — e.g. re-snapshot on ``detached``,
+                        # fall back to ``browser_get_elements`` on
+                        # ``not_fillable``.
+                        reason_code = self._classify_fill_error(e)
+                        filled.append({
+                            "label": safe_label,
+                            "ref": ref,
+                            "status": "type_failed",
+                            "reason": reason_code,
+                            "detail": self.redactor.redact(agent_id, str(e))[:200],
+                        })
+                        continue
+
                     filled.append({
                         "label": safe_label,
-                        "status": "type_failed",
-                        "reason": self.redactor.redact(agent_id, raw_reason),
+                        "ref": ref,
+                        "status": "filled",
                     })
-                    continue
+                    last_locator = locator
 
-                matches = (find_res.get("data") or {}).get("matches") or []
-                if not matches:
-                    filled.append({"label": safe_label, "status": "not_found"})
-                    # CAPTCHA may have appeared as a result of the snapshot
-                    # itself (rare — e.g. a JS challenge that injects on
-                    # every navigation). Check before continuing so we
-                    # don't keep pummeling a blocked page with snapshots.
-                    # _check_captcha now always returns the §11.13 envelope
-                    # (truthy even with no captcha); only stop the loop
-                    # when a captcha was actually found AND not auto-solved.
+                    # Per-field submit_after fires after a successful fill but
+                    # BEFORE the captcha check, because submitting can be what
+                    # triggers the captcha. If the press succeeds we mark
+                    # ``submitted=True`` so a follow-up captcha envelope tells
+                    # the agent the form was already submitted (possibly with
+                    # partial data) — the agent must NOT just resume typing
+                    # the remaining fields without first re-checking page
+                    # state.
+                    if field_submit:
+                        try:
+                            await locator.press("Enter")
+                            submitted = True
+                        except Exception as e:
+                            logger.debug(
+                                "fill_form per-field submit failed for %s "
+                                "label=%r: %s", agent_id, label, e,
+                            )
+
+                    # 2) After each successful fill (or per-field submit), check
+                    #    for a captcha. If found, stop the loop and return
+                    #    partial_success — the agent must solve before resuming.
+                    #    Captcha mid-flow takes priority over top-level
+                    #    submit_after: we never auto-submit a half-completed
+                    #    form behind a captcha.
+                    #    _check_captcha now always returns the §11.13 envelope
+                    #    (truthy even with no captcha); only break out when a
+                    #    captcha was actually found AND not auto-solved.
                     envelope = await self._check_captcha(inst)
                     if (
                         envelope.get("captcha_found")
@@ -7120,150 +7540,62 @@ class BrowserManager:
                             _with_legacy_fields(envelope),
                             submitted=submitted,
                         )
-                    continue
 
-                # Prefer fillable controls when the visible label text and
-                # the input's accessible name both match. Snapshot order can
-                # put a <label> before its <input>; picking that label first
-                # would yield a needless not_fillable failure even though the
-                # correct textbox is present in the same match set.
-                def _preferred_match(m: dict) -> bool:
-                    ref_id = m.get("ref")
-                    handle = inst.refs.get(ref_id)
-                    role = (getattr(handle, "role", "") or "").lower()
-                    disabled = bool(getattr(handle, "disabled", False))
-                    return (
-                        role in self._FILL_FORM_PREFERRED_ROLES
-                        and not disabled
-                    )
-
-                pick = (
-                    next(
-                        (
-                            m for m in matches
-                            if m.get("in_viewport") and _preferred_match(m)
-                        ),
-                        None,
-                    )
-                    or next((m for m in matches if _preferred_match(m)), None)
-                    or next((m for m in matches if m.get("in_viewport")), None)
-                    or matches[0]
-                )
-                ref = pick.get("ref")
-
-                try:
-                    locator = await self._locator_from_ref(inst, ref)
-                except RefStale as rs:
-                    filled.append({
-                        "label": safe_label,
-                        "ref": ref,
-                        "status": "type_failed",
-                        "reason": self.redactor.redact(agent_id, str(rs)),
-                    })
-                    continue
-                if locator is None:
-                    filled.append({
-                        "label": safe_label,
-                        "ref": ref,
-                        "status": "type_failed",
-                        "reason": "ref not found",
-                    })
-                    continue
-
-                try:
-                    await locator.fill(value)
-                except Exception as e:
-                    # Element no longer attached / disabled / hidden /
-                    # not-fillable (label-element returned by find_text).
-                    # Don't bail the whole form: subsequent fields may still
-                    # be reachable. ``reason`` is a structured code (see
-                    # :meth:`_classify_fill_error`) so the agent can plan a
-                    # specific recovery — e.g. re-snapshot on ``detached``,
-                    # fall back to ``browser_get_elements`` on
-                    # ``not_fillable``.
-                    reason_code = self._classify_fill_error(e)
-                    filled.append({
-                        "label": safe_label,
-                        "ref": ref,
-                        "status": "type_failed",
-                        "reason": reason_code,
-                        "detail": self.redactor.redact(agent_id, str(e))[:200],
-                    })
-                    continue
-
-                filled.append({
-                    "label": safe_label,
-                    "ref": ref,
-                    "status": "filled",
-                })
-                last_locator = locator
-
-                # Per-field submit_after fires after a successful fill but
-                # BEFORE the captcha check, because submitting can be what
-                # triggers the captcha. If the press succeeds we mark
-                # ``submitted=True`` so a follow-up captcha envelope tells
-                # the agent the form was already submitted (possibly with
-                # partial data) — the agent must NOT just resume typing
-                # the remaining fields without first re-checking page
-                # state.
-                if field_submit:
+                all_filled = all(f.get("status") == "filled" for f in filled)
+                # 3) Final submit — only if no captcha interrupted us AND every
+                #    requested field was filled. Top-level submit_after is the
+                #    "submit the completed form" affordance; submitting after a
+                #    not_found/type_failed field would send partial data without
+                #    the caller explicitly opting into that via per-field
+                #    submit_after.
+                if submit_after and last_locator is not None and all_filled:
                     try:
-                        await locator.press("Enter")
+                        await last_locator.press("Enter")
                         submitted = True
                     except Exception as e:
                         logger.debug(
-                            "fill_form per-field submit failed for %s "
-                            "label=%r: %s", agent_id, label, e,
+                            "fill_form final submit failed for %s: %s",
+                            agent_id, e,
                         )
 
-                # 2) After each successful fill (or per-field submit), check
-                #    for a captcha. If found, stop the loop and return
-                #    partial_success — the agent must solve before resuming.
-                #    Captcha mid-flow takes priority over top-level
-                #    submit_after: we never auto-submit a half-completed
-                #    form behind a captcha.
-                #    _check_captcha now always returns the §11.13 envelope
-                #    (truthy even with no captcha); only break out when a
-                #    captcha was actually found AND not auto-solved.
-                envelope = await self._check_captcha(inst)
-                if (
-                    envelope.get("captcha_found")
-                    and envelope.get("solver_outcome") != "solved"
-                ):
-                    return self._fill_form_captcha_envelope(
-                        filled, normalized[i + 1:],
-                        _with_legacy_fields(envelope),
-                        submitted=submitted,
-                    )
+                partial = not all_filled
+                return {
+                    "success": True,
+                    "data": {
+                        "partial_success": partial,
+                        "captcha_required": False,
+                        "filled": filled,
+                        "remaining": [],
+                        "submitted": submitted,
+                    },
+                }
 
-            all_filled = all(f.get("status") == "filled" for f in filled)
-            # 3) Final submit — only if no captcha interrupted us AND every
-            #    requested field was filled. Top-level submit_after is the
-            #    "submit the completed form" affordance; submitting after a
-            #    not_found/type_failed field would send partial data without
-            #    the caller explicitly opting into that via per-field
-            #    submit_after.
-            if submit_after and last_locator is not None and all_filled:
-                try:
-                    await last_locator.press("Enter")
-                    submitted = True
-                except Exception as e:
-                    logger.debug(
-                        "fill_form final submit failed for %s: %s",
-                        agent_id, e,
-                    )
+            # §11.4 / §18.2 — outer wrapper. The body itself fires
+            # ``_check_captcha`` after each field; the wrapper adds a
+            # final post-action probe so a captcha that appears AFTER
+            # the final submit (e.g. submit-triggered challenge that
+            # renders too late for the inner check) is still surfaced.
+            try:
+                action_result, captcha_envelope = await self._with_captcha_redetect(
+                    inst, _fill_body(),
+                )
+            except Exception as e:
+                return {"success": False, "error": str(e)}
 
-            partial = not all_filled
-            return {
-                "success": True,
-                "data": {
-                    "partial_success": partial,
-                    "captcha_required": False,
-                    "filled": filled,
-                    "remaining": [],
-                    "submitted": submitted,
-                },
-            }
+            # If the body already returned a captcha envelope under the
+            # §9.4 partial-success path (``data.captcha_required=True``)
+            # we leave it alone. The outer wrapper only adds the
+            # ``"captcha"`` field on the SUCCESS / no-captcha-yet path
+            # to avoid duplicating the same envelope.
+            if (
+                captcha_envelope is not None
+                and isinstance(action_result, dict)
+                and action_result.get("success")
+                and not (action_result.get("data") or {}).get("captcha_required")
+            ):
+                data = action_result.setdefault("data", {})
+                data.setdefault("captcha", captcha_envelope)
+            return action_result
 
     @staticmethod
     def _fill_form_captcha_envelope(
@@ -7667,7 +7999,7 @@ class BrowserManager:
         inst = await self.get_or_start(agent_id)
         inst.touch()
         async with inst.lock:
-            try:
+            async def _press_body() -> dict:
                 if inst._user_control:
                     return {
                         "success": False,
@@ -7687,8 +8019,21 @@ class BrowserManager:
                     await inst.page.keyboard.press(key)
                 await asyncio.sleep(action_delay())
                 return {"success": True, "data": {"pressed": key}}
+
+            try:
+                action_result, captcha_envelope = await self._with_captcha_redetect(
+                    inst, _press_body(),
+                )
             except Exception as e:
                 return {"success": False, "error": str(e)}
+
+            if (
+                captcha_envelope is not None
+                and isinstance(action_result, dict)
+                and action_result.get("success")
+            ):
+                action_result.setdefault("captcha", captcha_envelope)
+            return action_result
 
     async def go_back(self, agent_id: str) -> dict:
         """Navigate back in browser history."""

--- a/tests/test_browser_captcha_redetect.py
+++ b/tests/test_browser_captcha_redetect.py
@@ -1,0 +1,728 @@
+"""Tests for §11.4 / §18.2 — re-detect captcha after non-navigate actions.
+
+Covers the post-action MutationObserver-based redetect path that wraps
+``click`` / ``type_text`` / ``press_key`` / ``fill_form``:
+
+  * Happy path — action adds a captcha iframe → redetect fires →
+    ``_check_captcha`` invoked → action response carries §11.13 envelope.
+  * Empty-mutation path — action with no captcha-shaped DOM additions →
+    no ``_check_captcha`` call → no ``captcha`` field on the response.
+  * Pre-existing captcha — captcha was already on the page (no DOM
+    mutation during the action) → redetect read-back returns empty →
+    no ``_check_captcha`` call (correct: navigate-time
+    ``_check_captcha`` is the right defense for pre-existing captchas).
+  * Navigation during action — page swap or URL change between install
+    and read-back → probe is gone → redetect skips, action still
+    succeeds (the navigate-time ``_check_captcha`` covers the new page).
+  * Install failure — ``page.evaluate`` raises on install → action
+    still runs, no read-back attempted, no ``_check_captcha`` call.
+  * Read-back failure — ``page.evaluate`` raises on read-back → no
+    ``_check_captcha`` call, action still returns its result.
+  * Rate-limit — back-to-back actions inside
+    :data:`_REDETECT_MIN_INTERVAL_S` only fire ``_check_captcha`` once.
+  * Flag-disabled — ``BROWSER_CAPTCHA_REDETECT_ENABLED=false`` →
+    ``page.evaluate`` never invoked at all.
+  * Metered-solve cost-cap — auto-triggered redetect inherits the
+    full :meth:`_metered_solve` gate stack; envelope reports
+    ``solver_outcome="cost_cap"`` when over cap.
+  * Behavioral classifier — auto-triggered redetect on a CF-behavioral
+    page → envelope reports ``solver_outcome="skipped_behavioral"``.
+  * Snapshot integration — snapshot following a redetect-triggering
+    action carries the pending envelope and clears it on first read.
+"""
+
+from __future__ import annotations
+
+import time
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from src.browser import captcha_cost_counter as cost
+from src.browser import service as svc
+from src.browser.captcha import SolveResult
+from src.browser.service import (
+    _CAPTCHA_REDETECT_SELECTORS,
+    BrowserManager,
+    CamoufoxInstance,
+)
+
+# ── helpers ────────────────────────────────────────────────────────────────
+
+
+def _solved() -> SolveResult:
+    return SolveResult(
+        token="tok",
+        injection_succeeded=True,
+        used_proxy_aware=False,
+        compat_rejected=False,
+    )
+
+
+def _mk_solver(
+    *,
+    return_value: SolveResult | None = None,
+    provider: str = "2captcha",
+    unreachable: bool = False,
+    breaker_open: bool = False,
+) -> MagicMock:
+    s = MagicMock()
+    s.provider = provider
+    s.solve = AsyncMock(return_value=return_value or _solved())
+    s.is_solver_unreachable = AsyncMock(return_value=unreachable)
+    s.is_breaker_open = MagicMock(return_value=breaker_open)
+    return s
+
+
+def _mk_page(
+    *,
+    redetect_hits: list[str] | None = None,
+    captcha_locator_for: str | None = None,
+    install_raises: bool = False,
+    readback_raises: bool = False,
+    url: str = "https://example.com",
+):
+    """Build a Playwright-shaped page mock with controllable
+    evaluate / locator behaviour.
+
+    ``redetect_hits`` — selectors to return from the read-back call.
+    ``captcha_locator_for`` — selector that ``_check_captcha`` should
+    see as present (its locator(...).count() returns 1); all others
+    return 0. ``None`` means no captcha visible to ``_check_captcha``.
+    """
+    page = MagicMock()
+    page.url = url
+
+    async def _evaluate(js, *args):
+        if install_raises and "MutationObserver" in js:
+            raise RuntimeError("install fail")
+        if readback_raises and "p.adds" in js:
+            raise RuntimeError("readback fail")
+        if "MutationObserver" in js:
+            return None
+        if "p.adds" in js:
+            return list(redetect_hits or [])
+        return None
+
+    page.evaluate = AsyncMock(side_effect=_evaluate)
+
+    def _locator(sel):
+        loc = MagicMock()
+        if captcha_locator_for is not None and sel == captcha_locator_for:
+            loc.count = AsyncMock(return_value=1)
+        else:
+            loc.count = AsyncMock(return_value=0)
+        return loc
+
+    page.locator = MagicMock(side_effect=_locator)
+    page.keyboard = MagicMock()
+    page.keyboard.press = AsyncMock()
+    page.viewport_size = {"width": 1280, "height": 720}
+    page.query_selector_all = AsyncMock(return_value=[])
+    page.title = AsyncMock(return_value="title")
+    return page
+
+
+def _mk_inst(page=None, agent_id: str = "agent-1") -> CamoufoxInstance:
+    page = page if page is not None else _mk_page()
+    return CamoufoxInstance(agent_id, MagicMock(), MagicMock(), page)
+
+
+@pytest.fixture(autouse=True)
+async def _isolate_state(tmp_path, monkeypatch):
+    """Reset shared in-memory state so tests don't leak into each other.
+
+    ``CAPTCHA_COST_COUNTER_PATH`` is redirected to a per-test file so
+    cost-cap tests don't pollute peer cases. The solve-rate window and
+    audit buckets are module-globals; clearing them here keeps each
+    test starting from a clean slate.
+    """
+    monkeypatch.setenv(
+        "CAPTCHA_COST_COUNTER_PATH", str(tmp_path / "captcha_costs.json"),
+    )
+    await cost.reset()
+    svc._solve_rate_window.clear()
+    async with svc._captcha_audit_lock:
+        svc._captcha_audit_buckets.clear()
+    yield
+    await cost.reset()
+    svc._solve_rate_window.clear()
+    async with svc._captcha_audit_lock:
+        svc._captcha_audit_buckets.clear()
+
+
+@pytest.fixture()
+def mgr(tmp_path):
+    m = BrowserManager(profiles_dir=str(tmp_path / "profiles"))
+    m._captcha_solver = _mk_solver()
+    return m
+
+
+# ── 1. Happy path — captcha appears mid-click via DOM mutation ─────────────
+
+
+class TestRedetectHappyPath:
+    @pytest.mark.asyncio
+    async def test_click_with_added_captcha_iframe_surfaces_envelope(self, mgr):
+        """A click that adds a captcha iframe to the DOM fires the
+        redetect path; an unsolved-captcha envelope is surfaced inline
+        AND stashed for the next snapshot. The "auto-solved" case is
+        deliberately NOT surfaced (matching navigate-path semantics) —
+        nothing for the agent to do."""
+        # Build a page where the read-back captures a recaptcha iframe
+        # AND the locator probe in ``_check_captcha`` sees it as present.
+        sel = 'iframe[src*="recaptcha"]'
+        page = _mk_page(
+            redetect_hits=[sel],
+            captcha_locator_for=sel,
+        )
+        # Force the no-solver path so the envelope is surfaced (the
+        # "solved" path is a no-op for the agent and is correctly
+        # filtered by the wrapper).
+        mgr._captcha_solver = _mk_solver(unreachable=True)
+
+        async def _no_recap(p):
+            return {"variant": "unknown"}
+
+        async def _no_behavioral(p):
+            return None
+
+        with patch.object(svc, "_classify_recaptcha", new=_no_recap), \
+             patch.object(svc, "_classify_behavioral", new=_no_behavioral):
+            inst = _mk_inst(page=page)
+            inst.touch()
+            async with inst.lock:
+                async def _do():
+                    return {"success": True, "data": {"clicked": "btn"}}
+
+                result, envelope = await mgr._with_captcha_redetect(
+                    inst, _do(),
+                )
+
+        assert result == {"success": True, "data": {"clicked": "btn"}}
+        assert envelope is not None
+        assert envelope.get("captcha_found") is True
+        assert envelope.get("solver_outcome") == "no_solver"
+        # Inst.pending stash carries the same envelope so a follow-up
+        # snapshot can surface it.
+        assert inst._pending_captcha_envelope is not None
+
+    @pytest.mark.asyncio
+    async def test_solved_envelope_is_filtered_inline(self, mgr):
+        """When the solver auto-clears the captcha, there's nothing for
+        the agent to do — the wrapper deliberately returns ``None`` for
+        the envelope so the action response stays clean. Mirrors the
+        ``navigate`` path which also drops solved envelopes."""
+        sel = 'iframe[src*="recaptcha"]'
+        page = _mk_page(redetect_hits=[sel], captcha_locator_for=sel)
+
+        async def _no_recap(p):
+            return {"variant": "unknown"}
+
+        async def _no_behavioral(p):
+            return None
+
+        with patch.object(svc, "_classify_recaptcha", new=_no_recap), \
+             patch.object(svc, "_classify_behavioral", new=_no_behavioral):
+            inst = _mk_inst(page=page)
+            async with inst.lock:
+                async def _do():
+                    return {"success": True}
+
+                _, envelope = await mgr._with_captcha_redetect(
+                    inst, _do(),
+                )
+
+        assert envelope is None
+        assert inst._pending_captcha_envelope is None
+
+
+# ── 2. No captcha — added nodes don't match selectors → no _check_captcha ──
+
+
+class TestRedetectNoMatch:
+    @pytest.mark.asyncio
+    async def test_no_captcha_means_no_check_captcha_call(self, mgr):
+        # Read-back returns empty list — no captcha-shaped additions.
+        page = _mk_page(redetect_hits=[])
+        inst = _mk_inst(page=page)
+
+        with patch.object(mgr, "_check_captcha", new=AsyncMock()) as cc:
+            async with inst.lock:
+                async def _do():
+                    return {"success": True, "data": {"x": 1}}
+
+                result, envelope = await mgr._with_captcha_redetect(
+                    inst, _do(),
+                )
+
+        assert result == {"success": True, "data": {"x": 1}}
+        assert envelope is None
+        cc.assert_not_awaited()
+
+
+# ── 3. Pre-existing captcha (no DOM mutation during action) ────────────────
+
+
+class TestRedetectPreExisting:
+    @pytest.mark.asyncio
+    async def test_pre_existing_captcha_with_no_mutation_skipped(self, mgr):
+        """Captcha was already on the page; the action did not add new
+        captcha-shaped nodes. The MutationObserver only sees additions —
+        so no hits → no ``_check_captcha`` call. Pre-existing captchas
+        are the navigate-time ``_check_captcha``'s job.
+        """
+        sel = 'iframe[src*="hcaptcha"]'
+        # Read-back empty (no NEW additions). But a locator probe WOULD
+        # find the pre-existing captcha if we asked — we explicitly
+        # don't, so verify _check_captcha is never called.
+        page = _mk_page(
+            redetect_hits=[],
+            captcha_locator_for=sel,
+        )
+        inst = _mk_inst(page=page)
+        with patch.object(mgr, "_check_captcha", new=AsyncMock()) as cc:
+            async with inst.lock:
+                async def _do():
+                    return {"success": True}
+
+                result, envelope = await mgr._with_captcha_redetect(
+                    inst, _do(),
+                )
+
+        assert result == {"success": True}
+        assert envelope is None
+        cc.assert_not_awaited()
+
+
+# ── 4. Navigation during action — probe gone, fall through ────────────────
+
+
+class TestRedetectNavigationDuringAction:
+    @pytest.mark.asyncio
+    async def test_url_change_between_install_and_readback(self, mgr):
+        page = _mk_page(redetect_hits=['iframe[src*="recaptcha"]'])
+        inst = _mk_inst(page=page)
+
+        # Simulate URL change DURING the action by mutating page.url
+        # before the read-back runs.
+        async def _do():
+            page.url = "https://example.com/after-nav"
+            return {"success": True}
+
+        with patch.object(mgr, "_check_captcha", new=AsyncMock()) as cc:
+            async with inst.lock:
+                result, envelope = await mgr._with_captcha_redetect(
+                    inst, _do(),
+                )
+
+        assert result == {"success": True}
+        # Navigation was detected — read-back skipped, no _check_captcha.
+        assert envelope is None
+        cc.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_page_swap_during_action(self, mgr):
+        page = _mk_page(redetect_hits=['iframe[src*="captcha"]'])
+        inst = _mk_inst(page=page)
+
+        async def _do():
+            # Simulate tab swap: inst.page now points at a brand-new mock.
+            inst.page = _mk_page(redetect_hits=[])
+            return {"success": True}
+
+        with patch.object(mgr, "_check_captcha", new=AsyncMock()) as cc:
+            async with inst.lock:
+                result, envelope = await mgr._with_captcha_redetect(
+                    inst, _do(),
+                )
+
+        assert result == {"success": True}
+        assert envelope is None
+        cc.assert_not_awaited()
+
+
+# ── 5. Install failure — action still runs, no read-back attempt ──────────
+
+
+class TestRedetectInstallFailure:
+    @pytest.mark.asyncio
+    async def test_install_evaluate_raises(self, mgr):
+        page = _mk_page(install_raises=True, redetect_hits=[])
+        inst = _mk_inst(page=page)
+        with patch.object(mgr, "_check_captcha", new=AsyncMock()) as cc:
+            async with inst.lock:
+                async def _do():
+                    return {"success": True, "data": "ok"}
+
+                result, envelope = await mgr._with_captcha_redetect(
+                    inst, _do(),
+                )
+
+        assert result == {"success": True, "data": "ok"}
+        assert envelope is None
+        cc.assert_not_awaited()
+
+
+# ── 6. Read-back failure — action still succeeds, no auto-trigger ─────────
+
+
+class TestRedetectReadbackFailure:
+    @pytest.mark.asyncio
+    async def test_readback_evaluate_raises_skips_check_captcha(self, mgr):
+        """Read-back failure (e.g. CSP blocked the eval, page race) must
+        not break the action OR fire ``_check_captcha`` against
+        unverified probe state. Behavioural choice documented in the
+        wrapper docstring: empty-hits semantics on failure.
+        """
+        page = _mk_page(readback_raises=True, redetect_hits=[])
+        inst = _mk_inst(page=page)
+        with patch.object(mgr, "_check_captcha", new=AsyncMock()) as cc:
+            async with inst.lock:
+                async def _do():
+                    return {"success": True}
+
+                result, envelope = await mgr._with_captcha_redetect(
+                    inst, _do(),
+                )
+
+        assert result == {"success": True}
+        assert envelope is None
+        cc.assert_not_awaited()
+
+
+# ── 7. Rate-limit — only first of two back-to-back actions fires ──────────
+
+
+class TestRedetectRateLimit:
+    @pytest.mark.asyncio
+    async def test_back_to_back_actions_invoke_check_captcha_once(self, mgr):
+        sel = 'iframe[src*="recaptcha"]'
+        page = _mk_page(redetect_hits=[sel], captcha_locator_for=sel)
+
+        # Stub _check_captcha so we count calls and don't depend on
+        # solver / classifier behavior here.
+        envelope = {
+            "captcha_found": True,
+            "kind": "recaptcha-v2-checkbox",
+            "solver_attempted": False,
+            "solver_outcome": "no_solver",
+            "next_action": "request_captcha_help",
+        }
+        check_spy = AsyncMock(return_value=envelope)
+        inst = _mk_inst(page=page)
+        with patch.object(mgr, "_check_captcha", new=check_spy):
+            async with inst.lock:
+                async def _do():
+                    return {"success": True}
+
+                # First call — fires (within the rate-limit window
+                # since ``_last_redetect_ts`` is 0).
+                _, env1 = await mgr._with_captcha_redetect(
+                    inst, _do(),
+                )
+                # Second call immediately after — within the
+                # ``_REDETECT_MIN_INTERVAL_S`` window → suppressed.
+                _, env2 = await mgr._with_captcha_redetect(
+                    inst, _do(),
+                )
+
+        assert env1 is not None
+        assert env2 is None
+        assert check_spy.await_count == 1
+
+
+# ── 8. Flag-disabled — wrapper is a passthrough, no JS install/readback ───
+
+
+class TestRedetectFlagDisabled:
+    @pytest.mark.asyncio
+    async def test_flag_off_skips_all_observer_work(self, mgr, monkeypatch):
+        monkeypatch.setenv("BROWSER_CAPTCHA_REDETECT_ENABLED", "false")
+        page = _mk_page(redetect_hits=['iframe[src*="recaptcha"]'])
+        inst = _mk_inst(page=page)
+        with patch.object(mgr, "_check_captcha", new=AsyncMock()) as cc:
+            async with inst.lock:
+                async def _do():
+                    return {"success": True, "data": "x"}
+
+                result, envelope = await mgr._with_captcha_redetect(
+                    inst, _do(),
+                )
+
+        assert result == {"success": True, "data": "x"}
+        assert envelope is None
+        cc.assert_not_awaited()
+        # Probe install/read-back never invoked.
+        assert page.evaluate.await_count == 0
+
+
+# ── 9. Metered-solve gates — cost cap fires on auto-triggered path ────────
+
+
+class TestRedetectMeteredSolveCostCap:
+    @pytest.mark.asyncio
+    async def test_cost_cap_envelope_on_redetect_path(self, mgr, monkeypatch):
+        """Auto-triggered ``_check_captcha`` from the redetect wrapper
+        flows through ``_metered_solve``, so the cost-cap gate fires
+        identically to the navigate auto-detect path."""
+        monkeypatch.setenv("CAPTCHA_COST_LIMIT_USD_PER_AGENT_MONTH", "0.50")
+        # 50_000 millicents = $0.50 cap; pre-fill to exceed it.
+        await cost.add_cost("agent-1", 60_000)
+
+        sel = 'iframe[src*="recaptcha"]'
+        page = _mk_page(redetect_hits=[sel], captcha_locator_for=sel)
+
+        async def _no_recap(p):
+            return {"variant": "unknown"}
+
+        async def _no_behavioral(p):
+            return None
+
+        with patch.object(svc, "_classify_recaptcha", new=_no_recap), \
+             patch.object(svc, "_classify_behavioral", new=_no_behavioral):
+            inst = _mk_inst(page=page)
+            async with inst.lock:
+                async def _do():
+                    return {"success": True}
+
+                _, envelope = await mgr._with_captcha_redetect(
+                    inst, _do(),
+                )
+
+        assert envelope is not None
+        assert envelope.get("captcha_found") is True
+        assert envelope.get("solver_outcome") == "cost_cap"
+        # Solver mock was NEVER awaited — gate fired before the HTTP call.
+        mgr._captcha_solver.solve.assert_not_awaited()
+
+
+# ── 10. Behavioral classifier — CF-behavioral envelope on redetect path ───
+
+
+class TestRedetectBehavioralClassification:
+    @pytest.mark.asyncio
+    async def test_cf_behavioral_envelope_on_redetect_path(self, mgr):
+        """When the redetect-driven ``_check_captcha`` lands on a
+        CF-behavioral page, the §11.3 classifier short-circuits to
+        ``skipped_behavioral`` BEFORE any solver gate runs. Auto-trigger
+        path inherits the classification identically."""
+        sel = 'iframe[src*="challenges.cloudflare.com"]'
+        page = _mk_page(redetect_hits=[sel], captcha_locator_for=sel)
+
+        async def _no_recap(p):
+            return {"variant": "unknown"}
+
+        async def _no_behavioral(p):
+            return None
+
+        async def _cf_behavioral(p):
+            return "behavioral"
+
+        with patch.object(svc, "_classify_recaptcha", new=_no_recap), \
+             patch.object(svc, "_classify_behavioral", new=_no_behavioral), \
+             patch.object(svc, "_classify_cf_state", new=_cf_behavioral):
+            inst = _mk_inst(page=page)
+            async with inst.lock:
+                async def _do():
+                    return {"success": True}
+
+                _, envelope = await mgr._with_captcha_redetect(
+                    inst, _do(),
+                )
+
+        assert envelope is not None
+        assert envelope.get("captcha_found") is True
+        assert envelope.get("solver_outcome") == "skipped_behavioral"
+        assert envelope.get("kind") == "cf-interstitial-behavioral"
+        # Solver was never contacted.
+        mgr._captcha_solver.solve.assert_not_awaited()
+
+
+# ── 11. Selector list parity — JS read-back uses the same list as Python ──
+
+
+class TestRedetectSelectorListParity:
+    """The read-back JS must intersect added nodes against the SAME
+    selector list ``_check_captcha`` walks; otherwise the auto-trigger
+    can fire on additions that ``_check_captcha`` won't recognise (or
+    vice-versa). The shared :data:`_CAPTCHA_REDETECT_SELECTORS` tuple
+    enforces the invariant statically — this test asserts it covers
+    every selector ``_check_captcha`` actually probes for, so a future
+    edit that touches one list and not the other shows up here."""
+
+    def test_redetect_selectors_match_check_captcha_selectors(self):
+        # The selector list inside ``_check_captcha`` (string-literal
+        # near top of the method body). We can't introspect it
+        # programmatically without executing the method, so we
+        # hard-code the expected set and rely on a single source of
+        # truth: when the inline list in ``_check_captcha`` changes,
+        # whoever changes it must also update ``_CAPTCHA_REDETECT_SELECTORS``
+        # AND this test.
+        expected = {
+            'iframe[src*="recaptcha"]',
+            'iframe[src*="hcaptcha"]',
+            'iframe[src*="challenges.cloudflare.com"]',
+            'iframe[src*="captcha"]',
+            '[class*="cf-turnstile"]',
+            '[class*="captcha"]',
+            '#captcha',
+        }
+        assert set(_CAPTCHA_REDETECT_SELECTORS) == expected
+
+
+# ── 12. Snapshot integration — pending envelope surfaces and clears ───────
+
+
+class TestSnapshotPendingEnvelope:
+    @pytest.mark.asyncio
+    async def test_snapshot_surfaces_then_clears_pending_envelope(self, mgr):
+        """An envelope stashed by a prior action's redetect must surface
+        on the next snapshot AND get cleared so a third snapshot
+        doesn't repeat the same envelope.
+        """
+        # Pre-stash a pending envelope to simulate a prior action's
+        # redetect having fired.
+        pending = {
+            "captcha_found": True,
+            "kind": "recaptcha-v2-checkbox",
+            "solver_attempted": False,
+            "solver_outcome": "no_solver",
+            "next_action": "request_captcha_help",
+        }
+        page = MagicMock()
+        page.url = "https://example.com"
+        inst = _mk_inst(page=page)
+        inst._pending_captcha_envelope = pending
+        mgr._instances["agent-1"] = inst
+
+        async def _fresh_snapshot(*args, **kwargs):
+            return {
+                "success": True,
+                "data": {"snapshot": "(text)", "refs": {}},
+            }
+
+        with patch.object(
+            mgr,
+            "_snapshot_impl",
+            new=AsyncMock(side_effect=_fresh_snapshot),
+        ):
+            r1 = await mgr.snapshot("agent-1")
+            r2 = await mgr.snapshot("agent-1")
+
+        # First snapshot carries the envelope.
+        assert r1["data"].get("captcha") == pending
+        # Second snapshot does not — pending was cleared on first read.
+        assert "captcha" not in r2["data"]
+        assert inst._pending_captcha_envelope is None
+
+
+# ── 13. Action-response shape — captcha is ADDITIVE, not breaking ─────────
+
+
+class TestActionResponseShape:
+    """The wrapper exposes the §11.13 envelope under a ``"captcha"`` key
+    on the action response. Existing callers that don't read this key
+    must continue to work unchanged. The wrapper uses
+    :py:meth:`dict.setdefault` so a body that already populated the key
+    (e.g. ``fill_form``'s mid-flow envelope path) is not overwritten.
+    """
+
+    @pytest.mark.asyncio
+    async def test_existing_response_keys_unchanged(self, mgr):
+        sel = 'iframe[src*="recaptcha"]'
+        page = _mk_page(redetect_hits=[sel], captcha_locator_for=sel)
+        # Force the no-solver envelope so the wrapper actually returns
+        # the captcha envelope (the solved/auto-clear path is filtered).
+        mgr._captcha_solver = _mk_solver(unreachable=True)
+
+        async def _no_recap(p):
+            return {"variant": "unknown"}
+
+        async def _no_behavioral(p):
+            return None
+
+        with patch.object(svc, "_classify_recaptcha", new=_no_recap), \
+             patch.object(svc, "_classify_behavioral", new=_no_behavioral):
+            inst = _mk_inst(page=page)
+            async with inst.lock:
+                original = {
+                    "success": True,
+                    "data": {"clicked": "submit"},
+                    "extra": {"k": "v"},
+                }
+
+                async def _do():
+                    return original
+
+                result, envelope = await mgr._with_captcha_redetect(
+                    inst, _do(),
+                )
+
+        # All original keys preserved verbatim — wrapper does not
+        # rewrite the action result, only stashes the envelope for the
+        # caller to attach.
+        assert result is original
+        assert result["data"]["clicked"] == "submit"
+        assert result["extra"] == {"k": "v"}
+        assert envelope is not None
+
+
+# ── 14. Disabled-flag rate-limit — flag short-circuit doesn't poison TS ───
+
+
+class TestRedetectDisabledDoesNotConsumeRateBudget:
+    """When the flag disables redetect, the wrapper is a passthrough.
+    It must NOT update ``inst._last_redetect_ts`` — otherwise toggling
+    the flag back on later would silently rate-limit the first real
+    re-detection in surprising ways.
+    """
+
+    @pytest.mark.asyncio
+    async def test_disabled_flag_keeps_redetect_ts_zero(self, mgr, monkeypatch):
+        monkeypatch.setenv("BROWSER_CAPTCHA_REDETECT_ENABLED", "false")
+        page = _mk_page()
+        inst = _mk_inst(page=page)
+        async with inst.lock:
+            async def _do():
+                return {"success": True}
+
+            await mgr._with_captcha_redetect(inst, _do())
+        assert inst._last_redetect_ts == 0.0
+
+
+# ── 15. Rate-limit honors clock — once outside the window, fires again ────
+
+
+class TestRedetectRateLimitClockExpiry:
+    @pytest.mark.asyncio
+    async def test_after_window_expires_redetect_fires_again(self, mgr):
+        sel = 'iframe[src*="recaptcha"]'
+        page = _mk_page(redetect_hits=[sel], captcha_locator_for=sel)
+
+        async def _no_recap(p):
+            return {"variant": "unknown"}
+
+        async def _no_behavioral(p):
+            return None
+
+        with patch.object(svc, "_classify_recaptcha", new=_no_recap), \
+             patch.object(svc, "_classify_behavioral", new=_no_behavioral):
+            inst = _mk_inst(page=page)
+            check_spy = AsyncMock(wraps=mgr._check_captcha)
+            with patch.object(mgr, "_check_captcha", new=check_spy):
+                async with inst.lock:
+                    async def _do():
+                        return {"success": True}
+
+                    # First call — fires.
+                    await mgr._with_captcha_redetect(inst, _do())
+                    # Push the timestamp far enough into the past that
+                    # the next call is outside the rate-limit window.
+                    inst._last_redetect_ts = (
+                        time.monotonic() - svc._REDETECT_MIN_INTERVAL_S - 0.5
+                    )
+                    # Second call — fires again.
+                    await mgr._with_captcha_redetect(inst, _do())
+
+        assert check_spy.await_count == 2

--- a/tests/test_browser_service.py
+++ b/tests/test_browser_service.py
@@ -399,7 +399,13 @@ class TestTypeTextClearBehavior:
         # Printable chars now go through keyboard.press, not evaluate
         press_calls = [c[0][0] for c in mock_page.keyboard.press.call_args_list]
         assert all(c in press_calls for c in list("hello"))
-        assert mock_page.evaluate.await_count == 0
+        # evaluate is permitted for the §11.4/§18.2 captcha redetect probe
+        # (install + read-back) but MUST NOT carry insertText / clipboard
+        # / contenteditable patches that would bypass keystroke trust.
+        for call in mock_page.evaluate.call_args_list:
+            js = call.args[0] if call.args else ""
+            assert "insertText" not in js
+            assert "execCommand" not in js
 
     @pytest.mark.asyncio
     async def test_clear_false_types_without_select_all(self):
@@ -421,7 +427,12 @@ class TestTypeTextClearBehavior:
         assert "Control+a" not in press_calls
         # keyboard.press used for each char, not evaluate
         assert "a" in press_calls and "b" in press_calls
-        assert mock_page.evaluate.await_count == 0
+        # evaluate is permitted for the §11.4/§18.2 captcha redetect probe
+        # but MUST NOT carry insertText / execCommand patches.
+        for call in mock_page.evaluate.call_args_list:
+            js = call.args[0] if call.args else ""
+            assert "insertText" not in js
+            assert "execCommand" not in js
 
 
 class TestCamoufoxInstanceLock:
@@ -2535,7 +2546,12 @@ class TestTypeTextWithRef:
         press_calls = [c[0][0] for c in mock_page.keyboard.press.call_args_list]
         for ch in "test@example.com":
             assert ch in press_calls
-        assert mock_page.evaluate.await_count == 0
+        # evaluate is permitted for the §11.4/§18.2 captcha redetect probe
+        # but MUST NOT carry insertText / execCommand patches.
+        for call in mock_page.evaluate.call_args_list:
+            js = call.args[0] if call.args else ""
+            assert "insertText" not in js
+            assert "execCommand" not in js
 
     @pytest.mark.asyncio
     async def test_type_by_ref_no_clear(self):
@@ -2561,7 +2577,12 @@ class TestTypeTextWithRef:
         press_calls = [c[0][0] for c in mock_page.keyboard.press.call_args_list]
         assert "Control+a" not in press_calls
         assert "a" in press_calls and "b" in press_calls
-        assert mock_page.evaluate.await_count == 0
+        # evaluate is permitted for the §11.4/§18.2 captcha redetect probe
+        # but MUST NOT carry insertText / execCommand patches.
+        for call in mock_page.evaluate.call_args_list:
+            js = call.args[0] if call.args else ""
+            assert "insertText" not in js
+            assert "execCommand" not in js
 
     @pytest.mark.asyncio
     async def test_type_no_ref_or_selector(self):


### PR DESCRIPTION
## Summary

Wires a MutationObserver-based captcha re-detection probe into the epilogue of `click` / `type_text` / `press_key` / `fill_form`. Previously, only `navigate` auto-detected CAPTCHAs — modern flows (SPA logins, fetch-loaded widgets, post-XHR modals) often render the challenge after click/submit, forcing agents to explicitly call `solve_captcha` after every suspect action.

The wrapper (`BrowserManager._with_captcha_redetect`) follows the §11.4 two-call install/read-back pattern:

1. **Install** a `MutationObserver` on `document.body` capturing every added Element node (`window.__ol_captcha_probe`).
2. **Run** the action.
3. **Read-back** the captured nodes, intersecting them with the same selector list `_check_captcha` walks. The selector list is shared (`_CAPTCHA_REDETECT_SELECTORS`) so the JS filter and Python check cannot drift.
4. **On match** (and outside a 2s per-instance throttle), route through `_check_captcha` → `_metered_solve` so every gate (rate-limit, cost-cap, kill-switch, breaker, behavioral classifier) fires uniformly with the auto-detect path.
5. Surface the §11.13 envelope inline in the action response under `"captcha"` AND stash on `inst._pending_captcha_envelope` so the next `snapshot()` also surfaces it (cleared on first read).

Failure modes (install failure, read-back failure, navigation between install and read-back) are swallowed: the action runs to completion, no auto-trigger fires. Page-swap or URL-change during the action skips the read-back — the navigate-time `_check_captcha` on the new page is the right defense.

## Key design points

- **Action-response shape is additive.** Wrapper uses `dict.setdefault` so existing callers continue to work; only new agents that read `"captcha"` see the envelope. `fill_form`'s mid-flow partial-success path stays authoritative when it already populated the field.
- **Per-instance rate-limit** (`_REDETECT_MIN_INTERVAL_S = 2.0`) prevents probe storms on heavily-mutating actions. `_metered_solve` gates remain authoritative for solver cost / hourly rate; this throttle is a CPU-cost guard for the auto-detect path itself.
- **Empty-probe defense (judgment call).** Spec calls for triggering only on a probe match. We respect that — pages that swap captchas via `innerHTML` replace (rare) miss the MutationObserver and require explicit `solve_captcha`. Always firing `_check_captcha` would defeat the cost-saving purpose (each call walks 7 selectors via `locator(...).count()`).
- **`BROWSER_CAPTCHA_REDETECT_ENABLED` flag (default `true`).** Operators can disable globally; disabled-mode is a passthrough (no install/read-back, no rate-limit timestamp consumed).
- **`_metered_solve` gates verified on the auto-triggered path:** cost cap, rate-limit, kill switch (`CAPTCHA_DISABLED`), breaker, and the §11.3 behavioral classifier all fire identically — the auto-trigger goes through the same `_check_captcha` chain as `navigate`, `detect_captcha`, and `solve_captcha`.

Plan refs: §11.4 (full spec), §18.2 (Phase 9 promotion).

## Test plan

- [x] `tests/test_browser_captcha_redetect.py` (17 new tests):
  - Happy path: action adds captcha iframe → redetect fires → `_check_captcha` invoked → envelope surfaced inline + stashed for snapshot
  - Solved-envelope filter: `solver_outcome="solved"` is dropped (no agent action needed)
  - No captcha: empty mutations → no `_check_captcha` call
  - Pre-existing captcha (no DOM mutation): correctly skipped — navigate-time `_check_captcha` is the right defense
  - Navigation during action: URL change + page swap → probe gone → fall through
  - Install failure: action proceeds normally
  - Read-back failure: action proceeds, no auto-trigger
  - Rate-limit: within window suppressed; after window expiry fires again
  - Flag-disabled: `page.evaluate` never invoked
  - `_metered_solve` cost-cap: envelope reports `solver_outcome="cost_cap"`
  - Behavioral classifier: CF-behavioral page → `solver_outcome="skipped_behavioral"`
  - Selector-list parity test: shared `_CAPTCHA_REDETECT_SELECTORS` matches `_check_captcha`'s inline list
  - Snapshot integration: pending envelope surfaces on snapshot AND clears on first read
  - Disabled-flag rate-limit: passthrough does not consume `_last_redetect_ts`
- [x] `pytest tests/ --ignore=tests/test_e2e*` green on changes (4293 passed; 1 pre-existing CLI test failure unrelated to this PR — also fails on bare `origin/main`)
- [x] `ruff check src/ tests/` clean