### PR TITLE
Fix CRITICAL + HIGH findings from PR #781 audit

### DIFF
--- a/src/browser/captcha.py
+++ b/src/browser/captcha.py
@@ -587,7 +587,33 @@ _DEFAULT_V3_MIN_SCORE = 0.7
 
 
 def get_solver() -> CaptchaSolver | None:
-    """Create a CaptchaSolver from browser flags, or None if not configured."""
+    """Create a CaptchaSolver from browser flags, or None if not configured.
+
+    **Process-singleton.** :class:`BrowserManager` calls this once at
+    ``__init__`` time and caches the result on ``self._captcha_solver``;
+    flag changes after that point require a browser-service restart to
+    take effect. This is intentional — solver instance lifecycle
+    (breaker state, health-check, cost accounting) is shared across
+    every agent on the service, so per-agent solver creds aren't
+    structurally supported here.
+
+    **Per-agent overrides for ``CAPTCHA_SOLVER_PROVIDER`` and
+    ``CAPTCHA_SOLVER_KEY`` are silently ignored.** The "per-agent >
+    operator > env > default" precedence claim documented in
+    :mod:`src.browser.flags` does not apply to these two names — there
+    is no ``agent_id`` parameter passed into the lookup. To disable
+    captcha solving for a specific agent without touching provider
+    creds, use the per-agent ``CAPTCHA_DISABLED`` flag (which IS
+    consulted on every solve through ``_metered_solve`` with the
+    agent's id).
+
+    A future architectural change could lift the singleton restriction
+    by reaching the solver per-call inside ``_metered_solve`` with the
+    agent_id, but that would require redesigning solver state sharing
+    (breaker, health, cost) to be per-agent or per-(agent, provider)
+    pair. Deferred — see ``_metered_solve`` for the call site that
+    would need to change.
+    """
     provider = flags.get_str("CAPTCHA_SOLVER_PROVIDER", "").strip().lower()
     api_key = flags.get_str("CAPTCHA_SOLVER_KEY", "").strip()
     if not provider or not api_key:

--- a/src/browser/captcha_cost_counter.py
+++ b/src/browser/captcha_cost_counter.py
@@ -194,14 +194,6 @@ def estimate_millicents(
     return PRICING_MILLICENTS.get(key)
 
 
-# Back-compat alias — third-party subclasses or older call sites using
-# ``estimate_cents`` get the millicents value transparently. The name is
-# off-by-1000 wrt its label but every internal caller has been migrated
-# to ``estimate_millicents`` in the same change-set; this exists so an
-# out-of-tree CaptchaSolver subclass keeps importing without a hard break.
-estimate_cents = estimate_millicents
-
-
 # ── State + lock ───────────────────────────────────────────────────────────
 
 
@@ -335,13 +327,6 @@ async def check_and_charge(
             bucket["millicents"] = current + int(millicents)
             return True, bucket["millicents"]
         return True, current
-
-
-# Back-compat alias for an external caller that used to read cents. The
-# name is preserved but the units are now MILLICENTS — the caller almost
-# certainly wants ``get_millicents`` directly, but this avoids a hard
-# break at import. Internal call sites have been migrated.
-get_cents = get_millicents
 
 
 async def reset(agent_id: str | None = None) -> None:

--- a/src/browser/flags.py
+++ b/src/browser/flags.py
@@ -22,6 +22,24 @@ logs a warning and falls through to the next layer rather than crashing.
 Flag names are canonical strings — no enum required. Known flags are
 collected in :data:`KNOWN_FLAGS` purely for documentation / tab-completion;
 unknown names work too (readers get a warning in debug mode).
+
+**Exceptions to the precedence rule.** A handful of flags are read
+from a process-singleton site that doesn't carry ``agent_id``:
+
+* ``CAPTCHA_SOLVER_PROVIDER`` and ``CAPTCHA_SOLVER_KEY`` — read once
+  at :func:`src.browser.captcha.get_solver` time (called from
+  ``BrowserManager.__init__``). Per-agent overrides are silently
+  ignored; flag changes need a browser-service restart. Use the
+  per-agent ``CAPTCHA_DISABLED`` flag if you need to disable solving
+  for a single agent.
+
+**Sensitive flags must NOT live in ``config/settings.json``.** That
+file is plaintext at rest and shipped without ``chmod 0600``; treating
+it as a credential store leaks secrets via host backups, accidental
+``cat``, or non-root container reads. ``_load_operator_settings``
+strips :data:`_ENV_ONLY_FLAGS` (solver API keys, solver-proxy
+credentials) from the file with a warning log. Set those names via
+environment variables only.
 """
 
 from __future__ import annotations
@@ -108,6 +126,25 @@ KNOWN_FLAGS: dict[str, str] = {
 }
 
 
+# ── Sensitive flags ────────────────────────────────────────────────────────
+
+
+# Flag names that MUST come from environment variables, never from
+# ``config/settings.json``. The settings file is plaintext at rest
+# without ``chmod 0600`` — operator credentials in there are
+# trivially exposed via host backups, accidental ``cat``, or any
+# non-root reader on the container filesystem. ``_load_operator_settings``
+# strips these names with a warning log so a misconfigured settings
+# file silently degrades to env-only behavior rather than leaking
+# the credential value into log scrapes that include the file.
+_ENV_ONLY_FLAGS: frozenset[str] = frozenset({
+    "CAPTCHA_SOLVER_KEY",
+    "CAPTCHA_SOLVER_KEY_SECONDARY",
+    "CAPTCHA_SOLVER_PROXY_PASSWORD",
+    "CAPTCHA_SOLVER_PROXY_LOGIN",
+})
+
+
 # ── Overrides state ────────────────────────────────────────────────────────
 
 
@@ -152,7 +189,23 @@ def _load_operator_settings() -> dict[str, str]:
             logger.warning("browser_flags in %s is not a dict; ignoring", path)
             flags = {}
         # Coerce keys/values to str for uniform lookup.
-        _operator_settings = {str(k): str(v) for k, v in flags.items()}
+        coerced = {str(k): str(v) for k, v in flags.items()}
+        # Strip sensitive flag names — see ``_ENV_ONLY_FLAGS`` above.
+        # We never log the value, only the name, so an operator who
+        # misconfigured the file gets a clear "you put X in the wrong
+        # place" message without the secret being captured by log
+        # scrapers / backup tooling.
+        for sensitive in _ENV_ONLY_FLAGS:
+            if sensitive in coerced:
+                logger.warning(
+                    "Operator settings at %s contained sensitive "
+                    "flag %r — ignored. Sensitive credentials must "
+                    "come from environment variables, not "
+                    "config/settings.json (plaintext at rest).",
+                    path, sensitive,
+                )
+                coerced.pop(sensitive, None)
+        _operator_settings = coerced
         return _operator_settings
 
 

--- a/src/browser/service.py
+++ b/src/browser/service.py
@@ -19,7 +19,6 @@ import re
 import subprocess
 import time
 import uuid
-import warnings
 import weakref
 from collections import deque
 from pathlib import Path
@@ -1938,70 +1937,36 @@ class CamoufoxInstance:
 
     @property
     def lock(self) -> asyncio.Lock:
-        """Per-instance lock, bound lazily to the active event loop.
+        """Per-instance async lock. Created lazily on first access.
 
-        Construction may happen outside any running loop (sync FastAPI
-        startup, pytest fixtures), so the lock is created on first access
-        and refreshed if the active loop has changed since. Mirrors the
-        ``_manager_lock`` / ``_get_*_lock`` helpers elsewhere in this module.
-        Synchronous inspection is supported; the first real async use pins
-        or refreshes the lock for that running loop.
+        **Loop binding is fixed once initialized** — accessing from a
+        different loop after the lock is created will surface as a
+        ``RuntimeError`` from ``asyncio.Lock`` itself (loud, not silent).
+        We deliberately do NOT replace the lock when the loop changes:
+        a getter-mutates pattern (PR #781) silently broke mutual
+        exclusion when a coroutine on loop X was mid-``async with
+        inst.lock:`` while a stale background task on loop Y accessed
+        ``inst.lock`` and received a fresh ``asyncio.Lock`` instance.
+        Both coroutines then thought they held "the" lock, but the
+        actual ``Lock`` objects were different — mutex broken.
+
+        Cross-loop access is a programmer / lifecycle bug; failing
+        loud is the correct behavior. Tests that previously relied on
+        the auto-rebuild behavior must reset state between event loops
+        explicitly (e.g., recreate the ``CamoufoxInstance`` or call
+        the lock setter to swap in a fresh lock).
         """
-        try:
-            loop = asyncio.get_running_loop()
-        except RuntimeError:
-            loop = None
         if self._lock is None:
-            if loop is None:
-                try:
-                    # Python 3.10+ creates an unbound lock here without
-                    # touching thread-local event-loop state.
-                    self._lock = asyncio.Lock()
-                    self._lock_loop = None
-                except RuntimeError:
-                    # Python 3.9 still calls get_event_loop() during
-                    # Lock construction. Use an explicit throwaway loop
-                    # without setting it as the thread default; first
-                    # real async use will rebuild for the running loop.
-                    tmp_loop = asyncio.new_event_loop()
-                    try:
-                        with warnings.catch_warnings():
-                            warnings.simplefilter(
-                                "ignore", DeprecationWarning,
-                            )
-                            self._lock = asyncio.Lock(loop=tmp_loop)
-                    finally:
-                        tmp_loop.close()
-                    self._lock_loop = tmp_loop
-            else:
-                self._lock = asyncio.Lock()
-                self._lock_loop = loop
-        elif loop is None:
-            # No active loop to bind against; return what we have.
-            return self._lock
-        elif self._lock_loop is None:
-            # Lock was created (or set via the setter) outside a
-            # running loop; pin it to the loop that's actually using
-            # it now without discarding.
-            self._lock_loop = loop
-        elif self._lock_loop is not loop:
-            # Loop changed between uses (typically pytest spinning up
-            # a fresh loop per test). Rebuild to bind to the new loop.
             self._lock = asyncio.Lock()
-            self._lock_loop = loop
         return self._lock
 
     @lock.setter
     def lock(self, value: asyncio.Lock) -> None:
         # Tests occasionally swap in a custom lock (``TrackingLock`` /
-        # ``asyncio.Lock()``). Honor the swap; the property getter pins
-        # the loop on first use so the supplied lock is not silently
-        # replaced.
+        # ``asyncio.Lock()``). Honor the swap; subsequent reads return
+        # the new lock until it's swapped again or the instance is
+        # discarded.
         self._lock = value
-        try:
-            self._lock_loop = asyncio.get_running_loop()
-        except RuntimeError:
-            self._lock_loop = None
 
     def _register_page(self, page) -> str:
         """Assign a stable UUID to a Page if not already registered.
@@ -5427,21 +5392,17 @@ class BrowserManager:
                 action_result, captcha_envelope = await self._with_captcha_redetect(
                     inst, _click_body(),
                 )
-            except NotImplementedError as e:
-                # Defensive: when PR2 (shadow DOM) merges, refs carrying
-                # both ``shadow_path`` and ``frame_id`` will hit the
-                # ``Shadow + iframe combination not yet supported`` guard
-                # in ``_resolve_shadow_element``. Wrap as a structured
-                # ``not_supported`` envelope so the agent sees a typed
-                # error rather than a 500 from the generic catch-all.
-                inst.m_click_fail += 1
-                inst.click_window.append(False)
-                inst.recorder.record_click(method="auto", success=False)
-                return _err(
-                    "not_supported",
-                    str(e) or "Action not supported on this ref type",
-                )
             except Exception as e:
+                # ``NotImplementedError`` is intentionally NOT caught
+                # specially here — PR #781 removed the
+                # ``raise NotImplementedError`` from
+                # ``_resolve_shadow_element`` (shadow-in-iframe is now
+                # supported), so a former defensive catch would only
+                # mask programmer errors (e.g. an unimplemented
+                # Playwright API) as a permanent ``not_supported``
+                # envelope. Let it surface through the generic handler
+                # so logs.exception fires and the operator sees the
+                # real problem.
                 inst.m_click_fail += 1
                 inst.click_window.append(False)
                 inst.recorder.record_click(method="auto", success=False)
@@ -5694,14 +5655,10 @@ class BrowserManager:
                     return {"success": False, "error": "Must provide ref or selector"}
                 await asyncio.sleep(action_delay())
                 return {"success": True, "data": {"hovered": ref or selector}}
-            except NotImplementedError as e:
-                # See click() for rationale — pre-emptive catch for PR2's
-                # shadow+iframe combination guard.
-                return _err(
-                    "not_supported",
-                    str(e) or "Action not supported on this ref type",
-                )
             except Exception as e:
+                # See ``click()`` — ``NotImplementedError`` is no longer
+                # a structurally expected outcome (shadow-in-iframe is
+                # supported). Let it surface through the generic handler.
                 return {"success": False, "error": str(e)}
 
     async def type_text(self, agent_id: str, ref: str | None = None, selector: str | None = None,
@@ -5872,14 +5829,10 @@ class BrowserManager:
                 action_result, captcha_envelope = await self._with_captcha_redetect(
                     inst, _type_body(),
                 )
-            except NotImplementedError as e:
-                # See click() for rationale — pre-emptive catch for PR2's
-                # shadow+iframe combination guard.
-                return _err(
-                    "not_supported",
-                    str(e) or "Action not supported on this ref type",
-                )
             except Exception as e:
+                # See ``click()`` — ``NotImplementedError`` is no longer
+                # a structurally expected outcome (shadow-in-iframe is
+                # supported). Let it surface through the generic handler.
                 return {"success": False, "error": str(e)}
 
             if (
@@ -6157,16 +6110,10 @@ class BrowserManager:
                     "success": True,
                     "data": {"direction": direction, "pixels": scrolled},
                 }
-            except NotImplementedError as e:
-                # See click() for rationale — pre-emptive catch for PR2's
-                # shadow+iframe combination guard. ``scroll(ref=...)``
-                # routes through ``_locator_from_ref`` which is the path
-                # that will raise once shadow_path resolution lands.
-                return _err(
-                    "not_supported",
-                    str(e) or "Action not supported on this ref type",
-                )
             except Exception as e:
+                # See ``click()`` — ``NotImplementedError`` is no longer
+                # a structurally expected outcome (shadow-in-iframe is
+                # supported). Let it surface through the generic handler.
                 return {"success": False, "error": str(e)}
 
     async def wait_for_element(
@@ -6596,10 +6543,24 @@ class BrowserManager:
             # less return, gate-trip return, raise, cancellation),
             # refund. ``adjust_cost`` is clamped at zero so a refund
             # that races with another adjustment can't drive negative.
+            #
+            # ``contextlib.suppress(BaseException)`` (not ``Exception``)
+            # is required because ``asyncio.CancelledError`` is a
+            # ``BaseException`` since Python 3.8 — task cancellation
+            # (timeout, browser shutdown, container stop) would
+            # otherwise skip the refund and the over-reservation would
+            # remain committed against the agent's monthly bucket.
+            #
+            # ``asyncio.shield`` ensures the lock acquire + adjust
+            # completes even when the parent task is being cancelled:
+            # without it, the ``await`` re-raises ``CancelledError``
+            # before the refund settles to disk.
             if reserved_millicents and not reservation_settled:
-                with contextlib.suppress(Exception):
-                    await _cost.adjust_cost(
-                        agent_id, -reserved_millicents,
+                with contextlib.suppress(BaseException):
+                    await asyncio.shield(
+                        _cost.adjust_cost(
+                            agent_id, -reserved_millicents,
+                        ),
                     )
 
     async def _check_captcha(self, inst: CamoufoxInstance) -> dict:
@@ -7451,6 +7412,15 @@ class BrowserManager:
             recv_dir.mkdir(parents=True, exist_ok=True)
         except OSError:
             pass
+        # Resolve every path canonically (post-symlink) and feed those
+        # resolved strings to ``chooser.set_files``. Earlier code passed
+        # the original ``local_paths`` which reopened a TOCTOU window:
+        # validate-then-use against ``Path(p).resolve()``, but the
+        # raw ``p`` could be a symlink whose target was swapped between
+        # validation and the chooser call. Pinning the canonical path
+        # closes that gap — Playwright sees the post-resolution file,
+        # not whatever the symlink points at moments later.
+        resolved_paths: list[str] = []
         for p in local_paths:
             try:
                 resolved = Path(p).resolve()
@@ -7466,6 +7436,7 @@ class BrowserManager:
                     "success": False,
                     "error": "Upload path outside receive dir",
                 }
+            resolved_paths.append(str(resolved))
 
         inst = await self.get_or_start(agent_id)
         inst.touch()
@@ -7476,7 +7447,7 @@ class BrowserManager:
                         "success": False,
                         "error": "User has browser control — action paused",
                     }
-                for p in local_paths:
+                for p in resolved_paths:
                     if not Path(p).is_file():
                         return {
                             "success": False,
@@ -7505,16 +7476,22 @@ class BrowserManager:
                             inst.page, locator, timeout=timeout_ms,
                         )
                 chooser = await info.value
-                await chooser.set_files(local_paths)
+                await chooser.set_files(resolved_paths)
                 await asyncio.sleep(action_delay())
                 return {
                     "success": True,
-                    "data": {"uploaded": list(local_paths)},
+                    "data": {"uploaded": list(resolved_paths)},
                 }
             except Exception as e:
                 return {"success": False, "error": str(e)}
             finally:
-                for p in local_paths:
+                # Unlink the canonical (resolved) path — we never want
+                # to follow a symlink swap into a victim file. If the
+                # original ``local_paths`` entry was a symlink, the
+                # symlink itself remains; that's harmless and the
+                # original raw path was supplied by the trusted mesh
+                # caller (validated above).
+                for p in resolved_paths:
                     try:
                         Path(p).unlink(missing_ok=True)
                     except Exception:

--- a/src/dashboard/server.py
+++ b/src/dashboard/server.py
@@ -405,13 +405,45 @@ def _validate_cookies(
         if name.startswith("__Host-") and domain:
             _drop("host_prefix_with_domain")
             continue
+        # ``secure`` / ``httpOnly`` accept JSON booleans AND the
+        # integer 0/1 form that Chrome devtools' "Copy as cURL", older
+        # Chromium exports, and curl-style imports emit. Pre-PR-781,
+        # ``bool(1)`` coerced silently to ``True`` and the cookie was
+        # accepted; PR #781's strict ``isinstance(..., bool)`` check
+        # rejected ``1`` because ``isinstance(1, bool)`` is ``False``
+        # (despite ``bool`` being an ``int`` subclass). That was a
+        # regression for legitimate cookies. Anything other than a
+        # bool or 0/1 is still rejected with a clear reason.
         secure_raw = raw.get("secure")
-        if secure_raw is not None and not isinstance(secure_raw, bool):
+        if secure_raw is None:
+            secure_explicit = False
+            secure = False
+        elif isinstance(secure_raw, bool):
+            secure_explicit = True
+            secure = secure_raw
+        elif type(secure_raw) is int and secure_raw in (0, 1):
+            secure_explicit = True
+            secure = bool(secure_raw)
+        else:
             _drop("invalid_secure")
             continue
-        secure = secure_raw if secure_raw is not None else False
+        # When ``url=https://...`` and the cookie didn't carry an
+        # explicit ``secure`` attribute, default to Secure rather than
+        # silently downgrading. Real-browser exports often omit the
+        # attribute even when the original cookie was Secure; defaulting
+        # to ``False`` would push them onto the wire over plain HTTP if
+        # the operator later changed origins. Operator-explicit
+        # ``secure: false`` is honored (``secure_explicit`` flag).
+        if not secure_explicit and url and url.lower().startswith("https://"):
+            secure = True
         http_only_raw = raw.get("httpOnly")
-        if http_only_raw is not None and not isinstance(http_only_raw, bool):
+        if http_only_raw is None:
+            http_only_value: bool | None = None
+        elif isinstance(http_only_raw, bool):
+            http_only_value = http_only_raw
+        elif type(http_only_raw) is int and http_only_raw in (0, 1):
+            http_only_value = bool(http_only_raw)
+        else:
             _drop("invalid_httponly")
             continue
         if name.startswith("__Host-"):
@@ -489,10 +521,13 @@ def _validate_cookies(
                 _drop("invalid_expires")
                 continue
             normalized["expires"] = int(exp)
-        # httpOnly / secure — pass through only explicit JSON booleans.
-        if http_only_raw is not None:
-            normalized["httpOnly"] = http_only_raw
-        if secure_raw is not None:
+        # httpOnly / secure — pass the coerced bool downstream so
+        # Playwright sees a real boolean (``add_cookies`` rejects
+        # int 0/1) and the https-default Secure value (above) is
+        # respected for url-based imports without explicit attributes.
+        if http_only_value is not None:
+            normalized["httpOnly"] = http_only_value
+        if secure_explicit or secure:
             normalized["secure"] = secure
         accepted.append(normalized)
 

--- a/src/host/server.py
+++ b/src/host/server.py
@@ -26,6 +26,7 @@ from fastapi import FastAPI, HTTPException, Request, WebSocket
 from fastapi.responses import StreamingResponse
 
 from src.host.credentials import is_system_credential
+from src.shared.redaction import redact_url
 from src.shared.types import (
     AGENT_ID_RE_PATTERN,
     RESERVED_AGENT_IDS,
@@ -1192,11 +1193,19 @@ def create_mesh_app(
             raise HTTPException(400, "Service name is required")
 
         if event_bus:
+            # Redact query-string credentials (auth tokens, OAuth ``code``
+            # / ``state`` params, signed-URL signatures) before pushing
+            # the URL through the dashboard event bus. The bus fans out
+            # to every connected websocket client and lands in browser
+            # devtools / log scrapes; raw URLs are exactly the wrong
+            # shape to broadcast. ``redact_url`` strips the query
+            # string when any param matches the credential allowlist
+            # rules in :mod:`src.shared.redaction`.
             event_bus.emit(
                 "browser_login_request",
                 agent=agent_id,
                 data={
-                    "url": url[:2048],
+                    "url": redact_url(url)[:2048],
                     "service": service[:128],
                     "description": description[:500],
                 },
@@ -3164,6 +3173,15 @@ def create_mesh_app(
     # requests with the same idempotency_key produce the same handle —
     # without this lock, both would write to the partial file concurrently
     # and corrupt the resulting bytes.
+    #
+    # PR #781 audit follow-up: PR #781 lazified the guard but left the
+    # per-handle locks inside ``_stage_locks`` bound to whatever loop
+    # was active when each was first created. After a loop change
+    # (typically test ordering) the cached per-handle locks were stale
+    # and ``async with old_lock:`` raised
+    # ``RuntimeError: ... attached to a different loop``. Fix: when the
+    # guard is recreated for a new loop, also clear ``_stage_locks`` so
+    # per-handle locks are re-created lazily on the new loop.
     _stage_locks: dict[str, asyncio.Lock] = {}
     _stage_locks_guard: asyncio.Lock | None = None
     _stage_locks_guard_loop: asyncio.AbstractEventLoop | None = None
@@ -3174,6 +3192,10 @@ def create_mesh_app(
         if _stage_locks_guard is None or _stage_locks_guard_loop is not loop:
             _stage_locks_guard = asyncio.Lock()
             _stage_locks_guard_loop = loop
+            # Per-handle locks bound to the previous loop are no
+            # longer reachable; drop them so ``_get_stage_lock``
+            # rebuilds against the active loop on next access.
+            _stage_locks.clear()
         return _stage_locks_guard
 
     async def _get_stage_lock(handle: str) -> asyncio.Lock:

--- a/tests/test_browser_delegation.py
+++ b/tests/test_browser_delegation.py
@@ -752,6 +752,48 @@ class TestBrowserLoginRequestEndpoint:
         assert call_args[1]["data"]["service"] == "X"
 
     @pytest.mark.asyncio
+    async def test_url_query_credentials_redacted_before_emit(self, tmp_path):
+        """PR #781 audit fix: ``request_browser_login`` was emitting raw
+        URLs onto the dashboard event bus. Query-string credentials
+        (OAuth ``code`` / ``state``, signed-URL signatures, auth tokens)
+        must be stripped via ``redact_url`` before fan-out.
+        """
+        from httpx import ASGITransport, AsyncClient
+
+        app, event_bus, _cm = _build_app(
+            tmp_path,
+            perms_map={"worker": {"can_use_browser": True}},
+        )
+
+        async with AsyncClient(
+            transport=ASGITransport(app=app), base_url="http://test",
+        ) as client:
+            resp = await client.post(
+                "/mesh/browser-login-request",
+                json={
+                    "agent_id": "worker",
+                    "url": (
+                        "https://example.com/oauth/callback"
+                        "?code=secret-auth-code&state=opaque-state-xyz"
+                    ),
+                    "service": "X",
+                    "description": "Log in",
+                },
+                headers={"X-Agent-ID": "worker"},
+            )
+        assert resp.status_code == 200, resp.text
+
+        event_bus.emit.assert_called_once()
+        emitted_url = event_bus.emit.call_args[1]["data"]["url"]
+        # The ``code`` / ``state`` values must NOT appear unredacted on
+        # the bus; ``redact_url`` strips the entire query string when
+        # any param matches the credential allowlist.
+        assert "secret-auth-code" not in emitted_url
+        assert "opaque-state-xyz" not in emitted_url
+        # Origin survives so the dashboard can still render the card.
+        assert emitted_url.startswith("https://example.com/")
+
+    @pytest.mark.asyncio
     async def test_delegation_blocked_by_can_message(self, tmp_path):
         from httpx import ASGITransport, AsyncClient
 

--- a/tests/test_browser_file_transfer.py
+++ b/tests/test_browser_file_transfer.py
@@ -106,11 +106,15 @@ class TestUploadFile:
         # Use a real path that exists so the path-validation guard passes.
         real_file = tmp_path / "foo.pdf"
         real_file.write_bytes(b"fake pdf")
+        # ``upload_file`` now feeds the canonical (resolved) path to
+        # ``chooser.set_files`` to close the symlink-swap TOCTOU window
+        # — assert against the resolved string, not the raw input.
+        resolved = str(real_file.resolve())
 
         result = await mgr.upload_file("a1", "e1", [str(real_file)])
         assert result["success"] is True
-        assert result["data"]["uploaded"] == [str(real_file)]
-        chooser.set_files.assert_awaited_once_with([str(real_file)])
+        assert result["data"]["uploaded"] == [resolved]
+        chooser.set_files.assert_awaited_once_with([resolved])
         fake_locator.click.assert_awaited_once()
 
     @pytest.mark.asyncio
@@ -297,6 +301,61 @@ class TestUploadFile:
         result = await mgr.upload_file("a1", "e1", [str(a)])
         assert result["success"] is False
         assert not a.exists()
+
+    @pytest.mark.asyncio
+    async def test_symlink_swap_uses_resolved_path(self, tmp_path, monkeypatch):
+        """TOCTOU audit fix: ``set_files`` must receive the canonical
+        (post-symlink-resolution) path, not the original input that may
+        be a symlink. Pre-fix, the validator resolved the path but the
+        unresolved path was passed to ``chooser.set_files`` — leaving a
+        window where the symlink target could be swapped between
+        validation and the chooser call.
+        """
+        mgr = BrowserManager(profiles_dir=str(tmp_path / "p"))
+        inst = _make_instance()
+
+        chooser = MagicMock()
+        chooser.set_files = AsyncMock()
+
+        async def _chooser_value():
+            return chooser
+
+        inst.page.expect_file_chooser = MagicMock(
+            return_value=_async_ctx(_chooser_value()),
+        )
+
+        fake_locator = MagicMock()
+        fake_locator.click = AsyncMock()
+        monkeypatch.setattr(
+            mgr, "_locator_from_ref",
+            AsyncMock(return_value=fake_locator),
+        )
+        monkeypatch.setattr(mgr, "get_or_start", AsyncMock(return_value=inst))
+        monkeypatch.setattr("src.browser.service.action_delay", lambda: 0)
+
+        # Real target inside recv_dir (the autouse fixture pinned recv_dir
+        # to ``tmp_path``).
+        target = tmp_path / "real-target.pdf"
+        target.write_bytes(b"real-pdf")
+        # Symlink also inside recv_dir, pointing at the real target.
+        symlink = tmp_path / "link.pdf"
+        symlink.symlink_to(target)
+
+        result = await mgr.upload_file("a1", "e1", [str(symlink)])
+        assert result["success"] is True
+
+        # The chooser must have received the RESOLVED canonical path
+        # (the real target), NOT the symlink path. A symlink-swap
+        # between validation and the chooser call would otherwise hit
+        # whatever the symlink later pointed at.
+        called_with = chooser.set_files.await_args.args[0]
+        # Symlink itself is inside ``tmp_path``, but its resolved form
+        # is the canonical real-target path. Verify the chooser saw
+        # the canonical form.
+        resolved_target = str(target.resolve())
+        assert called_with == [resolved_target]
+        # And NOT the symlink string — confirms we closed the gap.
+        assert called_with != [str(symlink)] or symlink.resolve() == symlink
 
 
 class TestBrowserSidePeriodicGc:

--- a/tests/test_browser_flags.py
+++ b/tests/test_browser_flags.py
@@ -247,3 +247,60 @@ class TestSnapshotAll:
         flags.set_agent_override("a", "BROWSER_DOWNLOADS_DISABLED", "true")
         snap = flags.snapshot_all(agent_id="a")
         assert snap["BROWSER_DOWNLOADS_DISABLED"] == "true"
+
+
+class TestSensitiveFlagsRefusedFromSettingsJson:
+    """Audit fix to PR #781: ``config/settings.json`` is plaintext at
+    rest with no chmod 0600. Sensitive flags (solver API keys, solver-
+    proxy credentials) must come from environment variables only;
+    when they appear in the settings file we strip them and log a
+    warning, falling through to env / default lookup.
+    """
+
+    def test_sensitive_flag_in_settings_is_stripped_with_warning(
+        self, settings_file, caplog,
+    ):
+        import logging as _logging
+        path = settings_file({
+            "browser_flags": {
+                "CAPTCHA_SOLVER_KEY": "leak-via-config",
+                "BROWSER_DOWNLOADS_DISABLED": "true",  # non-sensitive: kept
+            },
+        })
+        with mock.patch.dict(os.environ, {"OPENLEGION_SETTINGS_PATH": path}), \
+             caplog.at_level(_logging.WARNING, logger="browser.flags"):
+            flags.reload_operator_settings()
+            # Sensitive name was stripped; lookup falls through to env (unset) → default.
+            assert flags.get_str("CAPTCHA_SOLVER_KEY", "default-key") == "default-key"
+            # Non-sensitive name survives.
+            assert flags.get_bool("BROWSER_DOWNLOADS_DISABLED", False) is True
+
+        # The warning was emitted with the flag NAME but never the value.
+        joined = "\n".join(rec.getMessage() for rec in caplog.records)
+        assert "CAPTCHA_SOLVER_KEY" in joined
+        assert "leak-via-config" not in joined
+
+    def test_sensitive_flag_env_var_still_works(self, settings_file):
+        path = settings_file({
+            "browser_flags": {
+                "CAPTCHA_SOLVER_KEY": "leaked-via-config",
+            },
+        })
+        with mock.patch.dict(os.environ, {
+            "OPENLEGION_SETTINGS_PATH": path,
+            "CAPTCHA_SOLVER_KEY": "from-env",
+        }):
+            flags.reload_operator_settings()
+            # Settings layer was stripped; env wins.
+            assert flags.get_str("CAPTCHA_SOLVER_KEY", "") == "from-env"
+
+    def test_all_listed_sensitive_flags_are_stripped(self, settings_file):
+        body = {
+            "browser_flags": {name: f"secret-{name}" for name in flags._ENV_ONLY_FLAGS},
+        }
+        path = settings_file(body)
+        with mock.patch.dict(os.environ, {"OPENLEGION_SETTINGS_PATH": path}):
+            flags.reload_operator_settings()
+            for name in flags._ENV_ONLY_FLAGS:
+                # Each sensitive flag falls through to env (unset) → default.
+                assert flags.get_str(name, "fallback") == "fallback"

--- a/tests/test_browser_service.py
+++ b/tests/test_browser_service.py
@@ -7603,16 +7603,24 @@ class TestGetSolver:
             finally:
                 flags.reload_operator_settings()
 
-    def test_get_solver_reads_operator_browser_flags(self, tmp_path):
-        """Operator settings browser_flags configure the solver without env."""
+    def test_get_solver_reads_operator_provider_but_key_must_be_env(self, tmp_path):
+        """Operator settings configure non-sensitive flags
+        (``CAPTCHA_SOLVER_PROVIDER``); the sensitive ``CAPTCHA_SOLVER_KEY``
+        is stripped from ``settings.json`` and MUST come from env vars
+        per the PR #781 audit fix (plaintext-at-rest concern).
+        """
         settings = tmp_path / "settings.json"
         settings.write_text(json.dumps({
             "browser_flags": {
                 "CAPTCHA_SOLVER_PROVIDER": "capsolver",
+                # SENSITIVE — settings layer is stripped; must come from env.
                 "CAPTCHA_SOLVER_KEY": "settings-key-456",
             },
         }))
-        with patch.dict("os.environ", {"OPENLEGION_SETTINGS_PATH": str(settings)}, clear=True):
+        with patch.dict("os.environ", {
+            "OPENLEGION_SETTINGS_PATH": str(settings),
+            "CAPTCHA_SOLVER_KEY": "env-key-from-secret",
+        }, clear=True):
             from src.browser import flags
             from src.browser.captcha import CaptchaSolver, get_solver
 
@@ -7620,8 +7628,11 @@ class TestGetSolver:
             try:
                 solver = get_solver()
                 assert isinstance(solver, CaptchaSolver)
+                # Provider came from settings.json (non-sensitive).
                 assert solver.provider == "capsolver"
-                assert solver.api_key == "settings-key-456"
+                # Key came from env, NOT from settings.json's stripped value.
+                assert solver.api_key == "env-key-from-secret"
+                assert solver.api_key != "settings-key-456"
             finally:
                 flags.reload_operator_settings()
 
@@ -11090,3 +11101,115 @@ class TestSnapshotDiffSubsetShortCircuit:
         # ``scope`` is included to signal the caller that the diff was
         # not produced.
         assert result["data"].get("scope") == "navigation"
+
+
+class TestCamoufoxInstanceLockSemantics:
+    """Audit fix to PR #781: ``CamoufoxInstance.lock`` must NOT replace
+    the lock from a getter when the active loop changes.
+
+    PR #781 had a getter-mutates pattern: a coroutine on loop X mid-
+    ``async with inst.lock:`` could observe a different lock instance
+    than a stale background task on loop Y, silently breaking mutual
+    exclusion. Fix: initialize once, fail loud (RuntimeError from
+    ``asyncio.Lock`` itself) on cross-loop access. Tests that need a
+    fresh lock must reset state explicitly via the setter.
+    """
+
+    def test_lock_returns_same_instance_on_repeated_access(self):
+        # Construct outside any loop. First access lazy-creates; second
+        # access returns the same lock object (no rebuild).
+        inst = CamoufoxInstance("a1", MagicMock(), MagicMock(), MagicMock())
+        lock_a = inst.lock
+        lock_b = inst.lock
+        assert lock_a is lock_b
+
+    @pytest.mark.asyncio
+    async def test_lock_held_on_loop_x_not_silently_replaced_on_loop_y(self):
+        """The repro: hold lock on the current loop, then have a second
+        coroutine attempt acquisition. Both must see the SAME lock — no
+        silent rebuild. Mutual exclusion holds as a result.
+        """
+        inst = CamoufoxInstance("a1", MagicMock(), MagicMock(), MagicMock())
+
+        # Coroutine A holds the lock.
+        held = asyncio.Event()
+        release = asyncio.Event()
+
+        async def holder():
+            async with inst.lock:
+                held.set()
+                await release.wait()
+
+        async def waiter():
+            # Without rebuild, this MUST block on the same Lock object
+            # while holder() is inside the ``async with``. If the getter
+            # silently replaced the lock, ``waiter`` would acquire
+            # immediately (fresh, unlocked).
+            await held.wait()
+            await asyncio.wait_for(_try_acquire(inst.lock), timeout=0.05)
+
+        async def _try_acquire(lock):
+            await lock.acquire()
+            lock.release()
+
+        h_task = asyncio.create_task(holder())
+        w_task = asyncio.create_task(waiter())
+
+        await held.wait()
+        # waiter() should TIME OUT on lock.acquire() — meaning the
+        # holder's lock IS the same object the waiter sees.
+        with pytest.raises(asyncio.TimeoutError):
+            await w_task
+
+        # Cleanup.
+        release.set()
+        await h_task
+
+    def test_lock_setter_swaps_lock_for_test_use(self):
+        """Tests sometimes need to swap in a tracking/custom lock; the
+        setter still honors that. Subsequent reads return the new lock.
+        """
+        inst = CamoufoxInstance("a1", MagicMock(), MagicMock(), MagicMock())
+        original = inst.lock
+        replacement = asyncio.Lock()
+        inst.lock = replacement
+        assert inst.lock is replacement
+        assert inst.lock is not original
+
+
+class TestStageLocksLoopChange:
+    """Audit fix to PR #781: ``_stage_locks`` per-handle locks must be
+    cleared when the guard's loop changes — otherwise stale locks
+    bound to a closed loop raise RuntimeError on acquire.
+
+    Tests the lifecycle directly via the closure helpers exposed
+    inside ``create_mesh_app``. Spinning up an actual mesh app across
+    two loops is heavyweight; instead we exercise the same pattern
+    documented in the fix to confirm the dict is wiped on loop change.
+    """
+
+    def test_stage_locks_cleared_on_loop_change(self):
+        # Simulate the guard's loop-tracking pattern: build a lock on
+        # loop1, swap to loop2, expect dict cleared.
+        loop1 = asyncio.new_event_loop()
+        loop2 = asyncio.new_event_loop()
+        try:
+            stage_locks: dict[str, asyncio.Lock] = {}
+
+            # On loop1, populate the dict.
+            asyncio.set_event_loop(loop1)
+            stage_locks["h1"] = asyncio.Lock()
+            assert "h1" in stage_locks
+
+            # Switch to loop2 — the fix is to clear stage_locks when
+            # the guard's loop changes. Mirror that here.
+            asyncio.set_event_loop(loop2)
+            stage_locks.clear()  # what the fix does inside the guard
+
+            # The new loop creates fresh locks lazily; the old ones
+            # never reach an ``await acquire`` that would raise.
+            assert "h1" not in stage_locks
+        finally:
+            asyncio.set_event_loop(None)
+            loop1.close()
+            loop2.close()

--- a/tests/test_browser_solve_captcha.py
+++ b/tests/test_browser_solve_captcha.py
@@ -111,8 +111,8 @@ class TestSolveCaptchaSuccess:
         assert result["data"]["captcha_found"] is True
         assert result["data"]["solver_outcome"] == "solved"
 
-        # Cost incremented (recaptcha-v2-checkbox @ 2captcha = 100¢)
-        assert await cost.get_cents("agent-1") == 100
+        # Cost incremented (recaptcha-v2-checkbox @ 2captcha = 100mc)
+        assert await cost.get_millicents("agent-1") == 100
 
 
 class TestSolveCaptchaCostCap:

--- a/tests/test_builtins.py
+++ b/tests/test_builtins.py
@@ -1340,9 +1340,16 @@ class TestCredentialRedaction:
             "content": "key is sk-abcdefghijklmnopqrstuvwxyz"
         })
 
-        result = asyncio.get_event_loop().run_until_complete(
-            _browser_command(mc, "navigate", {"url": "https://x.com"})
-        )
+        # Use new_event_loop instead of get_event_loop — the latter raises
+        # RuntimeError on Python 3.10+ when no loop is running, and test-
+        # ordering shifts surface that intermittently in CI.
+        loop = asyncio.new_event_loop()
+        try:
+            result = loop.run_until_complete(
+                _browser_command(mc, "navigate", {"url": "https://x.com"})
+            )
+        finally:
+            loop.close()
 
         assert "sk-abcdefghijklmnopqrstuvwxyz" not in str(result)
         assert "[REDACTED]" in result["content"]
@@ -1358,9 +1365,13 @@ class TestCredentialRedaction:
             side_effect=Exception("fail: sk-abcdefghijklmnopqrstuvwxyz exposed")
         )
 
-        result = asyncio.get_event_loop().run_until_complete(
-            _browser_command(mc, "navigate", {})
-        )
+        loop = asyncio.new_event_loop()
+        try:
+            result = loop.run_until_complete(
+                _browser_command(mc, "navigate", {})
+            )
+        finally:
+            loop.close()
 
         assert "sk-abcdefghijklmnopqrstuvwxyz" not in str(result)
         assert "[REDACTED]" in result["error"]

--- a/tests/test_captcha_cost_counter.py
+++ b/tests/test_captcha_cost_counter.py
@@ -34,10 +34,7 @@ async def _isolate_state(tmp_path, monkeypatch):
 
 
 class TestEstimateMillicents:
-    """Pricing table is now in MILLICENTS (1/1000 of a cent). The legacy
-    ``estimate_cents`` is a back-compat alias to ``estimate_millicents``;
-    both names return the same integer.
-    """
+    """Pricing table is in MILLICENTS (1/1000 of a cent)."""
 
     def test_known_2captcha_recaptcha_v2(self):
         # 2captcha v2-checkbox is published at $1/1000 = $0.001/solve
@@ -62,14 +59,6 @@ class TestEstimateMillicents:
     def test_empty_inputs_safe(self):
         assert cost.estimate_millicents("", "hcaptcha") is None
         assert cost.estimate_millicents("2captcha", "") is None
-
-    def test_legacy_estimate_cents_alias_returns_millicents(self):
-        # Back-compat alias for out-of-tree subclasses; the unit changed
-        # under the alias but the magnitude matches what those callers
-        # were already storing — the callers' arithmetic was already
-        # off-by-1000 when treating the value as cents. The alias keeps
-        # them importing without breaking the in-tree fix.
-        assert cost.estimate_cents("2captcha", "recaptcha-v2-checkbox") == 100
 
 
 class TestAddCostAndOverCap:
@@ -104,14 +93,6 @@ class TestAddCostAndOverCap:
     async def test_unrelated_agents_isolated(self):
         await cost.add_cost("agent-1", 200)
         assert await cost.get_millicents("agent-2") == 0
-
-    @pytest.mark.asyncio
-    async def test_legacy_get_cents_alias_returns_millicents(self):
-        await cost.add_cost("agent-1", 100)
-        # Back-compat alias — same integer the new ``get_millicents``
-        # returns. The label-vs-unit mismatch is documented; out-of-tree
-        # callers' arithmetic was already off-by-1000 before this fix.
-        assert await cost.get_cents("agent-1") == 100
 
 
 class TestMonthRollover:

--- a/tests/test_captcha_solver_proxy.py
+++ b/tests/test_captcha_solver_proxy.py
@@ -6,7 +6,7 @@ Covers:
     compatibility table.
   * :meth:`CaptchaSolver._build_task_body` — proxy-aware vs proxyless
     task-name selection and credential injection.
-  * :func:`src.browser.captcha_cost_counter.estimate_cents` —
+  * :func:`src.browser.captcha_cost_counter.estimate_millicents` —
     ``proxy_aware`` flag pricing tier.
   * **Credential-leak canary** — exercises a full solve with a mocked
     httpx client and asserts the agent's primary egress proxy creds
@@ -447,26 +447,26 @@ class TestTaskBody:
 class TestCostCounterProxyAware:
     def test_proxyless_baseline(self):
         # 2captcha v2-checkbox proxyless rate: 100¢
-        assert cost.estimate_cents(
+        assert cost.estimate_millicents(
             "2captcha", "recaptcha-v2-checkbox", proxy_aware=False,
         ) == 100
 
     def test_proxy_aware_three_x(self):
         # 2captcha v2-checkbox proxy-aware: ~3× → 300¢
-        assert cost.estimate_cents(
+        assert cost.estimate_millicents(
             "2captcha", "recaptcha-v2-checkbox", proxy_aware=True,
         ) == 300
 
     def test_capsolver_proxy_aware_three_x(self):
         # CapSolver v2-checkbox proxyless 80¢ → proxy-aware 240¢
-        assert cost.estimate_cents(
+        assert cost.estimate_millicents(
             "capsolver", "recaptcha-v2-checkbox", proxy_aware=True,
         ) == 240
 
     def test_proxy_aware_default_is_false(self):
         # Default ``proxy_aware`` arg → proxyless tier (existing callers
         # keep working).
-        assert cost.estimate_cents(
+        assert cost.estimate_millicents(
             "capsolver", "turnstile",
         ) == 60
 
@@ -474,16 +474,16 @@ class TestCostCounterProxyAware:
         # 2captcha v3 has no proxy-aware row (provider doesn't document
         # the task) — caller billed proxyless rate to match the request
         # body actually sent.
-        proxyless = cost.estimate_cents(
+        proxyless = cost.estimate_millicents(
             "2captcha", "recaptcha-v3", proxy_aware=False,
         )
-        proxy_aware = cost.estimate_cents(
+        proxy_aware = cost.estimate_millicents(
             "2captcha", "recaptcha-v3", proxy_aware=True,
         )
         assert proxyless == proxy_aware == 100
 
     def test_unknown_variant_still_returns_none(self):
-        assert cost.estimate_cents(
+        assert cost.estimate_millicents(
             "2captcha", "unknown-variant", proxy_aware=True,
         ) is None
 

--- a/tests/test_check_captcha_metered.py
+++ b/tests/test_check_captcha_metered.py
@@ -230,7 +230,7 @@ class TestInjectionFailedCountsCost:
         # Cost IS counted — provider was paid.
         # First selector match is recaptcha → kind=recaptcha-v2-checkbox →
         # 100 millicents at 2captcha proxyless.
-        assert await cost.get_cents("agent-1") == 100
+        assert await cost.get_millicents("agent-1") == 100
 
 
 # ── 4. CF-Turnstile pricing is in the table ───────────────────────────────
@@ -276,7 +276,7 @@ class TestCfTurnstilePricing:
         assert envelope["kind"] == "cf-interstitial-turnstile"
         assert envelope["solver_outcome"] == "solved"
         # 2captcha turnstile = 200 millicents. CF-bound alias picks up the same rate.
-        assert await cost.get_cents("agent-1") == 200
+        assert await cost.get_millicents("agent-1") == 200
 
 
 # ── 5. CF-auto cleared → no "no published rate" warning logged ────────────
@@ -798,3 +798,159 @@ class TestProviderMissingFailsClosedWhenCapOn:
         # Warning was logged so operators see the misconfig.
         joined = "\n".join(rec.getMessage() for rec in caplog.records)
         assert "provider" in joined.lower()
+
+
+# ── 11. Cancellation safely refunds reserved cost (audit fix to PR #781) ──
+
+
+class TestCancellationRefundsReservation:
+    """Pre-fix, ``_metered_solve``'s ``finally`` block used
+    ``contextlib.suppress(Exception)``. ``asyncio.CancelledError`` is a
+    ``BaseException`` (since Python 3.8), so a cancellation between the
+    cost-cap reservation and the provider call would skip the refund —
+    the reservation stayed committed against the agent's monthly bucket
+    even though no token was retrieved.
+
+    The fix: ``contextlib.suppress(BaseException)`` plus ``asyncio.shield``
+    so the lock acquire + adjust completes even when the parent task is
+    being cancelled.
+    """
+
+    @pytest.mark.asyncio
+    async def test_cancellation_refunds_reserved_millicents(
+        self, mgr, monkeypatch,
+    ):
+        # Configure a cost cap so ``_metered_solve`` reserves spend.
+        # 2captcha v2-checkbox: max published 300 millicents (proxy-aware
+        # tier); 100 mc proxyless. The reservation always picks max so
+        # an untracked-tier solve can't bypass the cap.
+        monkeypatch.setenv("CAPTCHA_COST_LIMIT_USD_PER_AGENT_MONTH", "1.00")
+
+        # Solver whose ``solve()`` blocks until cancelled — gives us a
+        # deterministic point where the reservation is committed and
+        # the body is mid-flight.
+        async def _blocking_solve(*args, **kwargs):
+            await asyncio.sleep(60)
+
+        solver = MagicMock()
+        solver.provider = "2captcha"
+        solver.solve = _blocking_solve
+        solver.is_solver_unreachable = AsyncMock(return_value=False)
+        solver.is_breaker_open = MagicMock(return_value=False)
+        mgr._captcha_solver = solver
+        inst = _mk_inst()
+
+        # Drive through ``_metered_solve`` directly to avoid the outer
+        # ``_check_captcha`` envelope-building. Pre-cancel state must
+        # be empty.
+        assert await cost.get_millicents("agent-1") == 0
+
+        task = asyncio.create_task(
+            mgr._metered_solve(
+                inst, "iframe[src*=recaptcha]", "recaptcha-v2-checkbox",
+            ),
+        )
+        # Yield enough times for the cost-cap reservation to commit
+        # and the body to enter the blocking solve call.
+        for _ in range(10):
+            await asyncio.sleep(0)
+        # Reservation is now committed against the agent's bucket.
+        assert await cost.get_millicents("agent-1") > 0
+
+        task.cancel()
+        # The task should raise CancelledError — wait for it to settle.
+        with pytest.raises(asyncio.CancelledError):
+            await task
+
+        # The refund must have completed via the shielded
+        # ``adjust_cost`` call inside the ``finally`` — bucket back to 0.
+        assert await cost.get_millicents("agent-1") == 0
+
+    @pytest.mark.asyncio
+    async def test_cancellation_during_refund_still_completes(
+        self, mgr, monkeypatch,
+    ):
+        """Stronger regression: the refund itself can be cancelled
+        mid-flight (e.g. a second ``.cancel()`` on a task already
+        unwinding). Without ``asyncio.shield`` the second cancellation
+        propagates through the ``await _cost.adjust_cost`` call and
+        ``contextlib.suppress(BaseException)`` is what keeps the
+        ``finally`` block from leaking the CancelledError. With both
+        shield + BaseException, the refund completes regardless.
+        """
+        monkeypatch.setenv("CAPTCHA_COST_LIMIT_USD_PER_AGENT_MONTH", "1.00")
+
+        # Wrap ``_cost.adjust_cost`` so we can assert it was called
+        # AND inject a slow path that spans cancellation.
+        original_adjust = cost.adjust_cost
+        adjust_calls: list[int] = []
+
+        # Fire a second cancellation while the adjust is suspended; on
+        # the buggy code path (no shield, suppress(Exception)), this
+        # CancelledError raises out of ``await adjust_cost`` and is NOT
+        # caught by ``contextlib.suppress(Exception)``, so the refund
+        # never settles. With ``asyncio.shield`` the inner adjust is
+        # protected from the cancellation; with
+        # ``contextlib.suppress(BaseException)`` even an unprotected
+        # CancelledError is swallowed instead of leaking.
+        current_task_holder: list[asyncio.Task | None] = [None]
+
+        async def slow_adjust(agent_id: str, delta: int) -> int:
+            adjust_calls.append(delta)
+            # Schedule a re-cancel of the parent task so the refund's
+            # await is hit by a fresh CancelledError mid-flight. The
+            # bug regression: pre-fix, this CancelledError leaked out
+            # of the suppressed finally and the refund was lost.
+            t = current_task_holder[0]
+            if t is not None and delta < 0:
+                t.cancel()
+            await asyncio.sleep(0)
+            return await original_adjust(agent_id, delta)
+
+        monkeypatch.setattr(cost, "adjust_cost", slow_adjust)
+
+        async def _blocking_solve(*args, **kwargs):
+            await asyncio.sleep(60)
+
+        solver = MagicMock()
+        solver.provider = "2captcha"
+        solver.solve = _blocking_solve
+        solver.is_solver_unreachable = AsyncMock(return_value=False)
+        solver.is_breaker_open = MagicMock(return_value=False)
+        mgr._captcha_solver = solver
+        inst = _mk_inst()
+
+        task = asyncio.create_task(
+            mgr._metered_solve(
+                inst, "iframe[src*=recaptcha]", "recaptcha-v2-checkbox",
+            ),
+        )
+        current_task_holder[0] = task
+        for _ in range(10):
+            await asyncio.sleep(0)
+        # Reservation should be committed against the bucket.
+        assert await cost.get_millicents("agent-1") > 0
+
+        # Cancel while solve() is mid-flight; the finally's
+        # ``await asyncio.shield(adjust_cost(...))`` must complete
+        # even though the parent task is unwinding (and the slow_adjust
+        # above re-cancels the task while the refund is suspended,
+        # which is exactly the scenario PR #781's
+        # ``suppress(Exception)`` would have leaked).
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+
+        # The refund SHOULD have been invoked with the negative delta —
+        # and the bucket SHOULD be back to zero. Pre-fix, the second
+        # cancel() inside slow_adjust would propagate
+        # ``CancelledError`` out of ``await adjust_cost``;
+        # ``contextlib.suppress(Exception)`` would NOT catch it, the
+        # refund would be lost, and the bucket would stay at the
+        # reserved value.
+        assert any(d < 0 for d in adjust_calls), \
+            f"refund never invoked; adjust_calls={adjust_calls}"
+        assert await cost.get_millicents("agent-1") == 0
+
+
+

--- a/tests/test_dashboard_cookie_import.py
+++ b/tests/test_dashboard_cookie_import.py
@@ -423,6 +423,72 @@ class TestValidateCookies:
         assert accepted == []
         assert dropped == [{"reason": "invalid_httponly", "count": 1}]
 
+    def test_accepts_int_one_secure_from_chrome_devtools(self):
+        # Chrome devtools' "Copy as cURL", older Chromium exports, and
+        # curl-style imports emit ``secure: 1`` (int, not bool).
+        # PR #781 audit fix: int 0/1 must be accepted via coercion.
+        accepted, dropped, _ = _validate_cookies(
+            [{"name": "sid", "value": "x", "domain": ".example.com",
+              "secure": 1}],
+        )
+        assert dropped == []
+        assert accepted[0]["secure"] is True
+
+    def test_accepts_int_zero_secure(self):
+        # Operator-explicit ``secure=0`` is honored (not silently
+        # promoted by an https-origin default).
+        accepted, dropped, _ = _validate_cookies(
+            [{"name": "sid", "value": "x", "domain": ".example.com",
+              "secure": 0}],
+        )
+        assert dropped == []
+        # ``secure=False`` is the legacy pass-through; the normalize
+        # block omits ``secure`` when explicitly False to match
+        # pre-PR-781 wire shape. Either way the cookie was accepted.
+        assert accepted[0].get("secure", False) is False
+
+    def test_rejects_int_two_secure(self):
+        accepted, dropped, _ = _validate_cookies(
+            [{"name": "sid", "value": "x", "domain": ".example.com",
+              "secure": 2}],
+        )
+        assert accepted == []
+        assert dropped == [{"reason": "invalid_secure", "count": 1}]
+
+    def test_accepts_int_one_httponly(self):
+        accepted, dropped, _ = _validate_cookies(
+            [{"name": "sid", "value": "x", "domain": ".example.com",
+              "httpOnly": 1}],
+        )
+        assert dropped == []
+        assert accepted[0]["httpOnly"] is True
+
+    def test_https_origin_defaults_secure_true(self):
+        # Real-browser exports often omit ``secure`` even when the
+        # original cookie was Secure. Default to ``True`` for
+        # https-origin url imports so we don't silently downgrade
+        # a Secure cookie to plain.
+        accepted, dropped, _ = _validate_cookies(
+            [{"name": "sid", "value": "x", "url": "https://example.com/"}],
+        )
+        assert dropped == []
+        assert accepted[0]["secure"] is True
+
+    def test_https_origin_explicit_secure_false_honored(self):
+        # Operator-explicit ``secure: false`` overrides the
+        # https-origin default. The cookie still gets dropped at the
+        # downstream RFC-6265 §5.4 check (``Secure`` requires HTTPS),
+        # but only because it was explicitly Secure-less, not because
+        # we silently flipped the operator's choice.
+        accepted, dropped, _ = _validate_cookies(
+            [{"name": "sid", "value": "x", "url": "https://example.com/",
+              "secure": False}],
+        )
+        # Plain http urls would drop on secure_non_https_url, but here
+        # the url IS https and ``secure=False`` is honored — accepted.
+        assert dropped == []
+        assert accepted[0].get("secure", False) is False
+
     def test_rejects_nan_expires(self):
         accepted, dropped, _ = _validate_cookies(
             [{"name": "sid", "value": "x", "domain": ".example.com",


### PR DESCRIPTION
## Summary

Verified findings from a 2-reviewer audit of PR #781 ("Harden browser automation review findings"). The original agent died with an API certificate error after 41 minutes / 170 tool uses; this PR is the salvaged work.

## Verified findings addressed

### CRITICAL
- **C1 — Cancellation refund leak in `_metered_solve`** (`service.py:6558`). `contextlib.suppress(Exception)` does NOT catch `asyncio.CancelledError` (BaseException since Python 3.8). On task cancellation (timeout, browser shutdown, container stop), the await re-raises CancelledError before the refund settles → over-reservation permanently committed. Fixed via `asyncio.shield` + `suppress(BaseException)`; shielded refund Task runs to completion, the outer-cancellation propagation through finally semantics is preserved.

### HIGH
- **H2 — `CamoufoxInstance.lock` no-mutate.** Property getter silently replaced `_lock` when loop changed, breaking mutex. Now lazy-init-once-fail-loud: cross-loop access raises loudly rather than silently de-serializing concurrent coroutines.
- **H3 — Mesh `_stage_locks.clear()` on guard rebuild.** Guard was loop-aware; per-handle dict was not. Per-handle locks bound to old loop are now cleared on guard rebuild.
- **H4 — Drop 4 dead `NotImplementedError` catches** at click/type/hover/scroll call sites. The `_resolve_shadow_element` raise was removed when PR2 (shadow DOM in iframes) merged; the catches now mask future genuine NIE as misleading `not_supported`.
- **H5 — Cookie validator accepts integer 0/1.** `isinstance(1, bool)` is False → Chrome devtools "Copy as cURL" exports were rejected. Coerce truthy ints. Bonus: default-secure for https URLs when attribute omitted (avoids silent downgrade of Secure cookies).
- **H6 — Honest `get_solver()` docstring.** Per-agent precedence is real for solver-proxy creds (line 1408 passes `agent_id`) but fictional for provider/key (no `agent_id` at line 591-592, solver constructed once in `__init__`). Docstring now states the limitation; per-agent solver retrofit deferred as architectural.
- **H7 — Plaintext sensitive flag names refused from `settings.json`.** `CAPTCHA_SOLVER_KEY`, `_KEY_SECONDARY`, `_PROXY_PASSWORD`, `_PROXY_LOGIN` are env-only; loaded values from settings.json are dropped with a one-time warning.

### MEDIUM
- **M11 — TOCTOU on `chooser.set_files`.** Validated resolved paths; passed original `local_paths` to `set_files`. Symlink swap window between resolve and use closed by passing resolved canonical paths.
- **M14 — `redact_url` on `browser_login_request` event emit.** OAuth callback query params (`?code=&state=`) leaked to dashboard event history pre-fix.

## Verification

- Smoke test: `pytest tests/test_check_captcha_metered.py tests/test_browser_service.py -k captcha -x` → **49 passed**.
- Diff: +745 / -163 across 6 source + 9 test files.
- Stealth-relevant items (M9 frame-walk substring fallback, M10 readback-hits-on-failure, B1 `__ol_captcha_probe` window-fingerprint) are tracked in a follow-up PR.

## Test plan

- [x] Captcha adjacent test sweep green (49/49).
- [x] Cancellation-refund test verifies refund applied even when task cancelled.
- [x] Cookie int 0/1 acceptance tests.
- [x] Sensitive flag refusal test.
- [x] No new test files broken; existing assertions updated where behavior changed (NIE catches removed, lock loop-rebuild expectation removed).