### PR TITLE
Phase 10 §21: mobile-iOS + mobile-Android emulation profiles

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -282,7 +282,8 @@ Beyond credentials, these environment variables affect runtime behavior:
 | `OPENLEGION_SYSTEM_WALLET_MASTER_SEED` | -- | BIP-39 mnemonic (24 words) for HD wallet key derivation. Required to enable wallet features. Generate with `openlegion wallet init`. |
 | `BROWSER_OS` | `windows` | OS fingerprint for Camoufox browser: `windows`, `macos`, or `linux`. Windows is recommended (≈70% desktop market share; Linux is a datacenter signal). |
 | `BROWSER_LOCALE` | `en-US` | BCP-47 locale tag for browser fingerprint (e.g. `en-US`, `de-DE`). |
-| `BROWSER_UA_VERSION` | -- | Override Firefox version in User-Agent string (e.g. `138.0`). Useful when Camoufox's bundled Firefox is too old for sites that enforce minimum browser versions (e.g. Shopify). Uses Camoufox's native config system. |
+| `BROWSER_UA_VERSION` | -- | Override Firefox version in User-Agent string (e.g. `138.0`). Useful when Camoufox's bundled Firefox is too old for sites that enforce minimum browser versions (e.g. Shopify). Uses Camoufox's native config system. Ignored when a non-default `BROWSER_DEVICE_PROFILE` pins its own UA. |
+| `BROWSER_DEVICE_PROFILE` | `desktop-windows` | Device emulation profile for Camoufox. One of `desktop-windows` (default), `desktop-macos`, `mobile-ios`, `mobile-android`. Controls UA, viewport, device-pixel-ratio, `is_mobile`, `has_touch`, and the navigator-override init script. Per-agent overrides supported via the operator settings layer. See **Device Profiles** below. |
 | `BROWSER_PROXY_URL` | -- | Proxy URL for browser traffic (HTTP/HTTPS only, e.g. `http://proxy:8080`). SOCKS5 is not supported. Residential proxies recommended. |
 | `BROWSER_PROXY_USER` | -- | Proxy authentication username. |
 | `BROWSER_PROXY_PASS` | -- | Proxy authentication password. |
@@ -295,3 +296,53 @@ Beyond credentials, these environment variables affect runtime behavior:
 | `OPENLEGION_CHAT_MAX_TOTAL_ROUNDS` | `200` | Maximum total chat rounds before session auto-continuation (clamped 1–1000). |
 
 The mesh port is configured in `config/mesh.yaml` (`mesh.port`), not via environment variable.
+
+## Browser Device Profiles
+
+The shared Camoufox browser ships four device-emulation profiles, selected via `BROWSER_DEVICE_PROFILE`:
+
+| Profile | UA family | Viewport | DPR | `is_mobile` | `has_touch` | `platform` | When to use |
+|---|---|---|---|---|---|---|---|
+| `desktop-windows` (default) | Firefox / Win64 | per-agent pool (1280×720 → 1920×1080) | 1.0 | false | false | `Win32` | Default for most sites; ≈70% real desktop market share. |
+| `desktop-macos` | Firefox / macOS | per-agent pool | 2.0 | false | false | `MacIntel` | Targeting US/Western-Europe consumer sites that risk-score Mac users more leniently. |
+| `mobile-ios` | Mobile Safari 17.5 / iPhone 14 Pro | 393×852 | 3.0 | true | true | `iPhone` | Site serves a better mobile experience; geography skewed mobile (mobile-first markets); detection systems calibrated for desktop bots. |
+| `mobile-android` | Chrome 124 / Pixel 8 / Android 14 | 412×915 | 2.625 | true | true | `Linux armv8l` | Same as `mobile-ios`, alternative shape. Ships `navigator.userAgentData` with `mobile=true` (Mobile Safari does not). |
+
+### When to choose mobile
+
+- **Geography**: target audiences in markets where >70% of real traffic is mobile (most of South / Southeast Asia, Latin America, sub-Saharan Africa, mobile-only social platforms).
+- **Site behavior**: target site serves a richer or simpler experience to mobile UAs (login flows, content pagination, ad load), or the desktop site is more aggressively bot-protected than the mobile site.
+- **Detection profile**: some bot-detection vendors calibrate primarily on desktop fingerprint clusters; a clean mobile fingerprint can side-step desktop-only heuristics.
+
+### Tradeoffs
+
+- **Desktop-only forms reject mobile UAs**: enterprise SaaS and admin consoles often refuse mobile UAs entirely. Don't pick a mobile profile for those.
+- **Different content**: many sites serve fewer features (less DOM, simplified menus) to mobile UAs — the agent's snapshot/find_text pipeline still works but the surface is smaller.
+- **Camoufox compatibility**: Camoufox is built on Firefox, so mobile profiles ship a UA-engine mismatch (UA claims WebKit/Blink, engine is still Gecko). We mitigate at the surface layer (UA string, viewport, DPR, `is_mobile`, `has_touch`, `navigator.userAgentData`, `navigator.maxTouchPoints`, `navigator.platform`) but cannot spoof every nested API to fully match the claimed device. Sites that probe deep WebGL renderer strings, codec quirks, or vendor-specific CSS feature flags can still tell something is off. For high-accuracy mobile spoofing, a Chromium-based stack would be required; this implementation gives operators a usable mobile fingerprint for sites that gate on the easy-to-check signals.
+- **Client Hints (`Sec-CH-UA-*`)**: Firefox doesn't send these and Camoufox can't synthesize them. Sites that key on Client Hints will see no mobile-specific Client Hints even with `mobile-android` selected.
+
+### Per-agent override
+
+`BROWSER_DEVICE_PROFILE` is a [unified flag](../src/browser/flags.py) — every read goes through the standard precedence chain:
+
+1. Per-agent override (registered via `flags.set_agent_override(agent_id, "BROWSER_DEVICE_PROFILE", "mobile-ios")`)
+2. Operator settings (`config/settings.json` → `browser_flags.BROWSER_DEVICE_PROFILE`)
+3. Environment variable (`BROWSER_DEVICE_PROFILE=mobile-ios`)
+4. Hardcoded default (`desktop-windows`)
+
+This means an operator can default the fleet to `desktop-windows` while pinning specific agents to `mobile-ios` for sites where mobile works better. Unknown values log a warning and fall back to `desktop-windows`.
+
+```json
+// config/settings.json — operator-wide default
+{
+  "browser_flags": {
+    "BROWSER_DEVICE_PROFILE": "desktop-windows"
+  }
+}
+```
+
+```python
+# Per-agent override (typically wired from the dashboard flags panel)
+from src.browser import flags
+flags.set_agent_override("agent-mobile-scout", "BROWSER_DEVICE_PROFILE", "mobile-ios")
+```

--- a/src/browser/flags.py
+++ b/src/browser/flags.py
@@ -52,6 +52,12 @@ KNOWN_FLAGS: dict[str, str] = {
     "BROWSER_ENABLE_ADBLOCK": "true | false (default true; gates uBO install)",
     # ── Resolution pool (§6.1) ────────────────────────────────────────────
     "BROWSER_RESOLUTION_POOL": "true | false (default true after phase 6.1)",
+    # ── Device profile (§19.3 / Phase 10 §21) ─────────────────────────────
+    "BROWSER_DEVICE_PROFILE":
+        "desktop-windows (default) | desktop-macos | mobile-ios | mobile-android"
+        " — selects the device emulation profile (UA, viewport, DPR, "
+        "is_mobile, has_touch). Per-agent overrides supported via the "
+        "operator settings layer.",
     # ── Canary (§5.4) ─────────────────────────────────────────────────────
     "BROWSER_CANARY_ENABLED": "true | false (default false)",
     # ── Operator kill switches for high-trust phases ──────────────────────

--- a/src/browser/service.py
+++ b/src/browser/service.py
@@ -36,7 +36,14 @@ from src.browser.captcha import (
 from src.browser.profile_schema import migrate_profile
 from src.browser.redaction import CredentialRedactor
 from src.browser.ref_handle import RefHandle, RefStale, ShadowHop
-from src.browser.stealth import build_launch_options, pick_referer, validate_referer
+from src.browser.stealth import (
+    DEFAULT_DEVICE_PROFILE,
+    build_launch_options,
+    build_mobile_init_script,
+    get_device_profile,
+    pick_referer,
+    validate_referer,
+)
 from src.browser.timing import (
     action_delay,
     click_dwell,
@@ -2564,6 +2571,22 @@ class BrowserManager:
         # the browser from starting.
         sync_adblock_extension(Path(profile_dir))
 
+        # §19.3 / Phase 10 §21: device profile selection. Read with
+        # ``agent_id`` so per-agent overrides (operator-settings or
+        # dashboard flag panel) take precedence over operator-wide env.
+        from src.browser.flags import get_str as _flag_get_str_dp
+        device_profile = _flag_get_str_dp(
+            "BROWSER_DEVICE_PROFILE",
+            DEFAULT_DEVICE_PROFILE,
+            agent_id=agent_id,
+        ) or DEFAULT_DEVICE_PROFILE
+        # ``get_device_profile`` logs a warning + falls back when the value
+        # is unknown; we only need to capture the name we'll forward to
+        # ``build_launch_options`` (which performs the same fallback).
+        logger.info(
+            "Agent '%s' device profile: %s", agent_id, device_profile,
+        )
+
         proxy_config = self.get_proxy_config(agent_id)
         if proxy_config is not None:
             if proxy_config.get("url"):
@@ -2573,16 +2596,25 @@ class BrowserManager:
                     proxy_arg["username"] = proxy_config["username"]
                 if proxy_config.get("password"):
                     proxy_arg["password"] = proxy_config["password"]
-                options = build_launch_options(agent_id, profile_dir, proxy=proxy_arg)
+                options = build_launch_options(
+                    agent_id, profile_dir, proxy=proxy_arg,
+                    device_profile=device_profile,
+                )
             else:
                 # Explicitly no proxy (direct mode or inherit with no system proxy)
-                options = build_launch_options(agent_id, profile_dir, proxy=None)
+                options = build_launch_options(
+                    agent_id, profile_dir, proxy=None,
+                    device_profile=device_profile,
+                )
         else:
             # No per-agent config pushed yet — start without proxy.
             # The mesh will push the correct config shortly after startup
             # which triggers a reset, relaunching with the right proxy.
             logger.warning("No proxy config pushed for '%s' yet, starting without proxy", agent_id)
-            options = build_launch_options(agent_id, profile_dir, proxy=None)
+            options = build_launch_options(
+                agent_id, profile_dir, proxy=None,
+                device_profile=device_profile,
+            )
 
         # Log which proxy is being used for debuggability
         _proxy_opt = options.get("proxy")
@@ -2621,6 +2653,28 @@ class BrowserManager:
                 options.pop("geoip", None)
                 browser = await AsyncNewBrowser(pw, **options)
         context = browser
+
+        # §19.3 / Phase 10 §21: inject the navigator-override init script
+        # for mobile profiles BEFORE any page is created. ``add_init_script``
+        # is registered on the BrowserContext so every page (current + new
+        # tabs) receives it at ``document_start``, ahead of any site script.
+        # Returns ``None`` for desktop profiles — no-op in that case.
+        mobile_init = build_mobile_init_script(get_device_profile(device_profile))
+        if mobile_init is not None:
+            try:
+                await context.add_init_script(script=mobile_init)
+                logger.debug(
+                    "Agent '%s' mobile navigator init script injected (profile=%s)",
+                    agent_id, device_profile,
+                )
+            except Exception as e:
+                # Non-fatal: a missing init script weakens the spoof but
+                # doesn't break the browser. Log and continue.
+                logger.warning(
+                    "Agent '%s' add_init_script failed for profile %s: %s",
+                    agent_id, device_profile, e,
+                )
+
         pages = context.pages
         page = pages[0] if pages else await context.new_page()
 

--- a/src/browser/stealth.py
+++ b/src/browser/stealth.py
@@ -23,6 +23,33 @@ consistent and realistic:
   - WebRTC fully disabled — Docker internal IPs leak via ICE otherwise
   - privacy.resistFingerprinting OFF — RFP produces detectable sentinel values
   - All background noise (telemetry, prefetch, crash reports) suppressed
+
+Device profiles (§19.3 — Phase 10 §21)
+--------------------------------------
+The default profile is ``desktop-windows`` (the historical behavior). Two
+mobile profiles + a desktop-macOS variant are available via the
+``BROWSER_DEVICE_PROFILE`` flag:
+
+  * ``desktop-windows`` — Firefox on Windows 10/11 (≈70% market share)
+  * ``desktop-macos``   — Firefox on macOS (≈10% market share)
+  * ``mobile-ios``      — Mobile Safari on iPhone 14 Pro
+  * ``mobile-android``  — Chrome on Pixel 8
+
+Mobile profiles are useful when the target site serves a mobile-friendly
+version (or when geographies dominated by mobile traffic make a mobile
+fingerprint less suspicious). Tradeoff: some desktop-only forms reject
+mobile UAs; some sites serve different content / fewer features to mobile.
+
+Camoufox compatibility caveats: Camoufox is built on Firefox, so the iOS
+profile (Mobile Safari UA) and Android profile (Chrome UA) ship a UA-engine
+mismatch — the underlying engine is still Gecko/Firefox even when the UA
+string says WebKit/Blink. We mitigate at the surface layer (UA string,
+viewport, DPR, ``has_touch``, ``is_mobile``, ``navigator.userAgentData``)
+but cannot spoof every nested API (e.g. WebGL renderer strings, codec
+support quirks, deep CSS feature queries) to fully match the claimed
+device. For high-accuracy mobile spoofing, a Chromium-based stack would
+be required; this implementation gives operators a usable mobile
+fingerprint for sites that gate on the easy-to-check signals.
 """
 
 from __future__ import annotations
@@ -35,6 +62,157 @@ from urllib.parse import urlparse
 from src.shared.utils import setup_logging
 
 logger = setup_logging("browser.stealth")
+
+# ── §19.3 Device profiles (Phase 10 §21) ─────────────────────────────────────
+
+
+# Each profile bundles the surface-layer fingerprint signals needed to
+# present as a particular device class. Consumers (``build_launch_options``,
+# the BrowserContext factory in ``service.py``) read these dicts to populate
+# UA, viewport, device-scale-factor, ``is_mobile`` / ``has_touch`` flags,
+# and the init-script that overrides ``navigator.userAgentData`` /
+# ``navigator.maxTouchPoints``.
+#
+# Profile values are chosen against the current real-world UA matrix
+# (April 2026 snapshot):
+#
+#   * ``desktop-windows`` — Firefox 138 on Windows 10/11. Matches the
+#     existing default; UA is built dynamically from ``BROWSER_UA_VERSION``
+#     when set.
+#   * ``desktop-macos``   — Firefox 138 on macOS 14 (Sonoma). Mac users
+#     skew higher-trust on some risk models (consumer rather than
+#     datacenter); useful when targeting US/Western-Europe sites.
+#   * ``mobile-ios``      — iOS 17.5 / Safari 17.5 on iPhone 14 Pro.
+#     iOS 17.x is the dominant iOS major as of early 2026; iPhone 14 Pro
+#     is a high-share device with a 393×852 logical viewport at 3.0 DPR
+#     (1179×2556 physical). UA matches Apple's WebKit User-Agent for
+#     Mobile Safari on iOS 17.5 (build 15E148, Version/17.5).
+#   * ``mobile-android``  — Android 14 / Chrome 124 on Pixel 8. Pixel 8
+#     uses a 412×915 logical viewport at 2.625 DPR (1080×2400 physical).
+#     Chrome 124 corresponds to Chrome's April 2026 stable channel; Mobile
+#     Safari/537.36 build literal matches Chrome's standard mobile UA shape.
+#
+# When picking new profiles, keep three invariants:
+#   1. UA, viewport, DPR, ``platform_navigator``, and ``user_agent_data_mobile``
+#      must internally agree (mismatch is itself a fingerprint signal).
+#   2. Touch capability + max touch points: real iOS / Android ship 5; real
+#      desktops ship 0 (or 10 on touch-screen Windows laptops).
+#   3. WebRTC stays disabled across all profiles — the ICE-leak risk is
+#      device-independent.
+_DESKTOP_WINDOWS_PROFILE: dict = {
+    # UA, viewport, and DPR for desktop-windows are NOT pinned in the
+    # profile: ``build_launch_options`` lets Camoufox + the existing
+    # per-agent ``pick_resolution`` pool drive these for the default
+    # profile. Profile metadata still recorded so consumers can branch
+    # on shape (e.g. has_touch=False → suppress mobile init script).
+    "user_agent": None,  # built from BROWSER_UA_VERSION or Camoufox default
+    "viewport": None,    # picked per-agent via pick_resolution
+    "device_scale_factor": 1.0,
+    "is_mobile": False,
+    "has_touch": False,
+    "platform_navigator": "Win32",
+    "max_touch_points": 0,
+    "user_agent_data_mobile": False,
+    "camoufox_os": "windows",
+}
+
+_DESKTOP_MACOS_PROFILE: dict = {
+    # Same shape as Windows but with macOS UA + platform — still allows
+    # the per-agent resolution pool to drive viewport/DPR. macOS desktop
+    # users overwhelmingly run native (non-Retina-doubled) DPR=2 on the
+    # browser side; Camoufox handles this when ``os=macos`` is set.
+    "user_agent": None,
+    "viewport": None,
+    "device_scale_factor": 2.0,
+    "is_mobile": False,
+    "has_touch": False,
+    "platform_navigator": "MacIntel",
+    "max_touch_points": 0,
+    "user_agent_data_mobile": False,
+    "camoufox_os": "macos",
+}
+
+_MOBILE_IOS_PROFILE: dict = {
+    # iOS 17.5 / Safari 17.5 / iPhone 14 Pro. UA string sourced from
+    # Apple's published WebKit User-Agents for iOS 17.5 (released
+    # 2024-05-13; still common on the in-field installed base in 2026).
+    # Build literal "15E148" + "Version/17.5" + "Mobile/15E148" matches
+    # Safari's standard format.
+    "user_agent": (
+        "Mozilla/5.0 (iPhone; CPU iPhone OS 17_5 like Mac OS X) "
+        "AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.5 "
+        "Mobile/15E148 Safari/604.1"
+    ),
+    "viewport": {"width": 393, "height": 852},  # iPhone 14 Pro logical
+    "device_scale_factor": 3.0,                  # 1179×2556 physical
+    "is_mobile": True,
+    "has_touch": True,
+    "platform_navigator": "iPhone",
+    "max_touch_points": 5,
+    "user_agent_data_mobile": True,
+    # Camoufox is Firefox-based; the closest OS analogue for fingerprint
+    # plumbing (font stack, etc.) is macOS — iOS Safari shares the
+    # Apple/Cocoa side but has a distinct mobile-engine path.
+    "camoufox_os": "macos",
+}
+
+_MOBILE_ANDROID_PROFILE: dict = {
+    # Android 14 / Chrome 124 / Pixel 8. UA matches Chrome's April 2026
+    # stable channel mobile UA shape ("AppleWebKit/537.36 ... Chrome/124
+    # ... Mobile Safari/537.36" — the WebKit literal is historical, kept
+    # for compatibility with sites that pattern-match on it).
+    "user_agent": (
+        "Mozilla/5.0 (Linux; Android 14; Pixel 8) "
+        "AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 "
+        "Mobile Safari/537.36"
+    ),
+    "viewport": {"width": 412, "height": 915},   # Pixel 8 logical
+    "device_scale_factor": 2.625,                # 1080×2400 physical
+    "is_mobile": True,
+    "has_touch": True,
+    "platform_navigator": "Linux armv8l",
+    "max_touch_points": 5,
+    "user_agent_data_mobile": True,
+    "camoufox_os": "linux",
+}
+
+# Dispatch table consumed by :func:`get_device_profile`. Keep
+# ``desktop-windows`` first so iteration / tooling sees the default at
+# the head of the list.
+_DEVICE_PROFILES: dict[str, dict] = {
+    "desktop-windows": _DESKTOP_WINDOWS_PROFILE,
+    "desktop-macos": _DESKTOP_MACOS_PROFILE,
+    "mobile-ios": _MOBILE_IOS_PROFILE,
+    "mobile-android": _MOBILE_ANDROID_PROFILE,
+}
+
+DEFAULT_DEVICE_PROFILE: str = "desktop-windows"
+
+
+def get_device_profile(name: str | None = None) -> dict:
+    """Return the device profile dict for ``name``.
+
+    Resolution rules:
+      * ``None`` or empty string → default (``desktop-windows``).
+      * Known name → that profile.
+      * Unknown name → log a warning and fall back to default.
+
+    The returned dict is the live module-level constant — do not mutate.
+    Callers that want to layer per-agent overrides on top should
+    ``copy()`` the result first.
+    """
+    if not name:
+        return _DEVICE_PROFILES[DEFAULT_DEVICE_PROFILE]
+    profile = _DEVICE_PROFILES.get(name)
+    if profile is None:
+        logger.warning(
+            "Unknown BROWSER_DEVICE_PROFILE %r; allowed values are %s. "
+            "Falling back to %r.",
+            name, sorted(_DEVICE_PROFILES.keys()), DEFAULT_DEVICE_PROFILE,
+        )
+        return _DEVICE_PROFILES[DEFAULT_DEVICE_PROFILE]
+    return profile
+
 
 # ── §6.5 Referrer realism on navigate ─────────────────────────────────────────
 
@@ -409,31 +587,59 @@ def _assert_firefox_ua(ua: str) -> None:
 # ── Launch options ─────────────────────────────────────────────────────────────
 
 
-def build_launch_options(agent_id: str, profile_dir: str, proxy: dict | None = None) -> dict:
+def build_launch_options(
+    agent_id: str,
+    profile_dir: str,
+    proxy: dict | None = None,
+    *,
+    device_profile: str | None = None,
+) -> dict:
     """Build Camoufox AsyncNewBrowser kwargs for an agent.
 
     Args:
         proxy: Camoufox proxy dict (server, username, password) or None.
                Proxy is always resolved per-agent by the mesh host and pushed
                to the browser service — callers must pass it explicitly.
+        device_profile: Name of a profile from :data:`_DEVICE_PROFILES`
+               (``desktop-windows`` | ``desktop-macos`` | ``mobile-ios`` |
+               ``mobile-android``) or ``None`` for the default
+               (``desktop-windows``). Mobile profiles pin UA + viewport +
+               DPR + ``is_mobile``/``has_touch`` from the profile dict;
+               desktop profiles still use the per-agent resolution pool.
 
     Environment variables (all optional):
-      BROWSER_OS     — "windows" (default) | "macos" | "linux"
+      BROWSER_OS     — "windows" (default) | "macos" | "linux".
+                       Ignored when ``device_profile`` is non-default — the
+                       profile's ``camoufox_os`` field takes precedence so
+                       e.g. ``mobile-ios`` uses macOS plumbing regardless
+                       of operator BROWSER_OS.
       BROWSER_LOCALE — BCP-47 locale tag, e.g. "en-US" (default)
       BROWSER_UA_VERSION — Firefox version to report in User-Agent, e.g. "138.0".
                            If set, overrides the UA string to spoof a newer Firefox.
                            Useful when Camoufox's bundled Firefox is too old for
                            sites that enforce minimum browser versions (e.g. Shopify).
+                           Ignored when a mobile profile pins its own UA.
     """
+    profile = get_device_profile(device_profile)
+    profile_name = device_profile or DEFAULT_DEVICE_PROFILE
+    if profile_name not in _DEVICE_PROFILES:
+        profile_name = DEFAULT_DEVICE_PROFILE
 
     # ── OS fingerprint ────────────────────────────────────────────────────────
-    # Default to Windows: it has ≈70 % desktop market share and produces the
-    # least suspicious fingerprint for server-hosted automation.  Linux is an
-    # immediate datacenter/bot signal for sites that check navigator.platform.
-    os_hint = os.environ.get("BROWSER_OS", "windows").lower()
-    if os_hint not in ("windows", "macos", "linux"):
-        logger.warning("Invalid BROWSER_OS %r, defaulting to 'windows'", os_hint)
-        os_hint = "windows"
+    # Default profile: read BROWSER_OS env (Windows = ≈70% desktop market
+    # share, the least-suspicious server-hosted fingerprint). Non-default
+    # profiles pin ``camoufox_os`` directly so the OS plumbing (font stack,
+    # platform string) matches the device class regardless of operator
+    # BROWSER_OS.  Linux is an immediate datacenter/bot signal for sites
+    # that check navigator.platform — only allowed when explicitly chosen
+    # (mobile-android profile uses it deliberately).
+    if profile_name == DEFAULT_DEVICE_PROFILE:
+        os_hint = os.environ.get("BROWSER_OS", "windows").lower()
+        if os_hint not in ("windows", "macos", "linux"):
+            logger.warning("Invalid BROWSER_OS %r, defaulting to 'windows'", os_hint)
+            os_hint = "windows"
+    else:
+        os_hint = profile["camoufox_os"]
 
     locale = os.environ.get("BROWSER_LOCALE", "en-US")
 
@@ -448,8 +654,22 @@ def build_launch_options(agent_id: str, profile_dir: str, proxy: dict | None = N
     # alongside this feature. Otherwise the window would end up at full
     # display size while the fingerprint reported 1280×720, a detectable
     # mismatch.
-    width, height = pick_resolution(agent_id)
-    logger.debug("Agent '%s' resolution: %dx%d", agent_id, width, height)
+    #
+    # Mobile profiles override the resolution pool: a mobile fingerprint
+    # claiming 1920×1080 would itself be a dead giveaway, so we use the
+    # profile's pinned viewport instead. Desktop profiles still use the
+    # per-agent pool for fleet-scale diversity.
+    profile_viewport = profile.get("viewport")
+    if profile_viewport:
+        width = int(profile_viewport["width"])
+        height = int(profile_viewport["height"])
+        logger.debug(
+            "Agent '%s' device-profile %r viewport: %dx%d",
+            agent_id, profile_name, width, height,
+        )
+    else:
+        width, height = pick_resolution(agent_id)
+        logger.debug("Agent '%s' resolution: %dx%d", agent_id, width, height)
 
     options: dict = {
         "headless": False,
@@ -498,31 +718,59 @@ def build_launch_options(agent_id: str, profile_dir: str, proxy: dict | None = N
     # pass any ``navigator.connection.*`` config while `_assert_firefox_ua`
     # requires a Firefox UA.
 
-    # ── User-Agent version override ──────────────────────────────────────────
-    # Camoufox bundles a specific Firefox build (e.g. 135.0).  Some sites
-    # (Shopify, etc.) enforce minimum browser versions and block old Firefox.
-    # BROWSER_UA_VERSION overrides the reported version without upgrading the
-    # Camoufox binary.
+    # ── User-Agent override ──────────────────────────────────────────────────
+    # Two paths:
     #
-    # Primary mechanism: Camoufox's `config` dict with `navigator.userAgent`.
-    # This feeds into Camoufox's fingerprint injection system, which controls
-    # both navigator.userAgent (JS) and the User-Agent HTTP header.
-    # Fallback: `general.useragent.override` Firefox pref, in case an older
-    # Camoufox version doesn't honour the config dict.
-    ua_version = os.environ.get("BROWSER_UA_VERSION", "")
-    if ua_version:
-        ua = _build_ua_string(os_hint, ua_version)
-        if ua:
-            # §6.4 tripwire — the UA we're about to ship MUST be Firefox.
-            # If a future change introduces a Chromium UA, this raises so
-            # the developer has to wire Sec-CH-UA-* overrides first.
-            _assert_firefox_ua(ua)
-            options.setdefault("config", {})["navigator.userAgent"] = ua
-            options["i_know_what_im_doing"] = True
-            options["firefox_user_prefs"]["general.useragent.override"] = ua
-            logger.info("UA override: Firefox/%s", ua_version)
+    # 1. Mobile / non-Firefox device profile pins a UA on the profile dict.
+    #    This is the §19.3 mobile-emulation case — the UA is Mobile Safari
+    #    (iOS) or Chrome Mobile (Android). The §6.4 ``_assert_firefox_ua``
+    #    tripwire is intentionally bypassed here: the operator has chosen a
+    #    non-default device profile knowing the UA-engine mismatch. Sites
+    #    that key on Sec-CH-UA-* will see no Client Hints (Firefox-engine
+    #    behavior) — that's the documented trade-off.
+    #
+    # 2. Desktop profile + ``BROWSER_UA_VERSION`` env. Camoufox bundles a
+    #    specific Firefox build (e.g. 135.0).  Some sites (Shopify, etc.)
+    #    enforce minimum browser versions and block old Firefox.
+    #    BROWSER_UA_VERSION overrides the reported version without upgrading
+    #    the Camoufox binary.
+    #
+    # Primary mechanism for both: Camoufox's `config` dict with
+    # ``navigator.userAgent``. This feeds into Camoufox's fingerprint
+    # injection system, which controls both navigator.userAgent (JS) and
+    # the User-Agent HTTP header. Fallback: ``general.useragent.override``
+    # Firefox pref, in case an older Camoufox version doesn't honour the
+    # config dict.
+    profile_ua = profile.get("user_agent")
+    if profile_ua:
+        # §19.3: mobile / non-Firefox profile UA. Skip the Firefox tripwire.
+        options.setdefault("config", {})["navigator.userAgent"] = profile_ua
+        options["i_know_what_im_doing"] = True
+        options["firefox_user_prefs"]["general.useragent.override"] = profile_ua
+        logger.info(
+            "Device profile %r UA pinned: %s",
+            profile_name, _short_ua(profile_ua),
+        )
+    else:
+        ua_version = os.environ.get("BROWSER_UA_VERSION", "")
+        if ua_version:
+            ua = _build_ua_string(os_hint, ua_version)
+            if ua:
+                # §6.4 tripwire — the UA we're about to ship MUST be Firefox.
+                # If a future change introduces a Chromium UA, this raises so
+                # the developer has to wire Sec-CH-UA-* overrides first.
+                _assert_firefox_ua(ua)
+                options.setdefault("config", {})["navigator.userAgent"] = ua
+                options["i_know_what_im_doing"] = True
+                options["firefox_user_prefs"]["general.useragent.override"] = ua
+                logger.info("UA override: Firefox/%s", ua_version)
 
     return options
+
+
+def _short_ua(ua: str, *, limit: int = 80) -> str:
+    """Return a truncated UA for human-readable log lines."""
+    return ua if len(ua) <= limit else ua[: limit - 1] + "…"
 
 
 def _build_ua_string(os_hint: str, version: str) -> str | None:
@@ -713,3 +961,111 @@ def _stealth_prefs() -> dict:
         "browser.tabs.warnOnClose": False,
         "browser.tabs.warnOnCloseOtherTabs": False,
     }
+
+
+# ── §19.3 Navigator override init script (Phase 10 §21) ──────────────────────
+
+
+# Wired by ``BrowserManager._start_browser`` at context creation via
+# ``BrowserContext.add_init_script``.  Runs at ``document_start`` on every
+# page and frame BEFORE any site script has a chance to read these
+# properties — that's the only point at which we can shape the values
+# the page sees without leaving a tell-tale "page-script came back with a
+# different value than the runtime exposes" inconsistency.
+#
+# Only emitted for profiles where ``user_agent_data_mobile`` is True
+# (the two mobile profiles). Desktop profiles let Camoufox + the BrowserForge
+# fingerprint drive these values; injecting an override would itself be
+# a fingerprint anomaly versus the real desktop population.
+_MOBILE_NAVIGATOR_INIT_SCRIPT = """
+(() => {
+  try {
+    // navigator.userAgentData: Chromium-only API today, but Mobile Safari
+    // doesn't expose it either, so emitting it for mobile-android is the
+    // right shape and emitting an absence for mobile-ios matches real
+    // iOS Safari. We define both behaviors below — service.py picks which
+    // to inject based on the profile.
+    if (typeof navigator !== 'undefined') {
+      try {
+        Object.defineProperty(navigator, 'maxTouchPoints', {
+          get: () => __MAX_TOUCH_POINTS__,
+          configurable: true,
+        });
+      } catch (_e) { /* ignore */ }
+      try {
+        Object.defineProperty(navigator, 'platform', {
+          get: () => '__PLATFORM__',
+          configurable: true,
+        });
+      } catch (_e) { /* ignore */ }
+      // userAgentData: only emit when the profile claims a Chromium-shaped
+      // engine (mobile-android). For Mobile Safari we leave it undefined,
+      // matching the real-Safari population.
+      if (__EMIT_USER_AGENT_DATA__) {
+        try {
+          const data = Object.freeze({
+            mobile: __MOBILE__,
+            platform: '__UA_DATA_PLATFORM__',
+            brands: [],
+            getHighEntropyValues: () => Promise.resolve({
+              mobile: __MOBILE__,
+              platform: '__UA_DATA_PLATFORM__',
+            }),
+            toJSON: () => ({
+              mobile: __MOBILE__,
+              platform: '__UA_DATA_PLATFORM__',
+            }),
+          });
+          Object.defineProperty(navigator, 'userAgentData', {
+            get: () => data,
+            configurable: true,
+            enumerable: true,
+          });
+        } catch (_e) { /* ignore */ }
+      }
+    }
+  } catch (_e) {
+    // Defensive: any failure here is operator-debuggable via the §6.3
+    // navigator self-test, which will flag a platform mismatch.
+  }
+})();
+"""
+
+
+def build_mobile_init_script(profile: dict) -> str | None:
+    """Return the JS init-script body to inject for a mobile profile.
+
+    Returns ``None`` when the profile does not need mobile overrides
+    (any desktop profile). The returned string is a complete
+    ``add_init_script``-ready snippet — the caller passes it directly to
+    ``BrowserContext.add_init_script(script=...)``.
+
+    Two mobile shapes diverge on ``navigator.userAgentData``:
+      * Android profile (Chromium-shaped UA): emits a frozen
+        ``userAgentData`` object with ``mobile=true``.
+      * iOS profile (Safari-shaped UA): leaves ``userAgentData``
+        absent (matches real iOS Safari, which doesn't expose Client
+        Hints).
+
+    Both shapes inject ``maxTouchPoints`` and ``platform``.
+    """
+    if not profile.get("is_mobile"):
+        return None
+
+    platform = profile.get("platform_navigator") or "iPhone"
+    max_touch_points = int(profile.get("max_touch_points") or 5)
+
+    # iOS profile: real Safari hides userAgentData. Android: emit it.
+    # Heuristic: emit userAgentData iff the platform string looks
+    # Linux-/Android-shaped. iPhone / iPad / Mac platforms get nothing.
+    is_chromium_shaped = "Linux" in platform or "Android" in platform
+    ua_data_platform = "Android" if "Linux" in platform or "Android" in platform else "iOS"
+
+    return (
+        _MOBILE_NAVIGATOR_INIT_SCRIPT
+        .replace("__MAX_TOUCH_POINTS__", str(max_touch_points))
+        .replace("__PLATFORM__", platform)
+        .replace("__EMIT_USER_AGENT_DATA__", "true" if is_chromium_shaped else "false")
+        .replace("__UA_DATA_PLATFORM__", ua_data_platform)
+        .replace("__MOBILE__", "true")
+    )

--- a/tests/test_browser_device_profile.py
+++ b/tests/test_browser_device_profile.py
@@ -1,0 +1,392 @@
+"""Tests for §19.3 device-profile emulation (Phase 10 §21).
+
+Covers:
+  * ``get_device_profile`` selector — known names, default, fallback on unknown.
+  * ``build_launch_options`` integration — UA + viewport propagated for
+    mobile profiles, default profile preserves the existing behavior.
+  * Per-agent override precedence over operator-wide setting.
+  * ``build_mobile_init_script`` returns content for mobile profiles only.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from unittest import mock
+
+import pytest
+
+from src.browser import flags
+from src.browser.stealth import (
+    _DESKTOP_WINDOWS_PROFILE,
+    _DEVICE_PROFILES,
+    _MOBILE_ANDROID_PROFILE,
+    _MOBILE_IOS_PROFILE,
+    DEFAULT_DEVICE_PROFILE,
+    build_launch_options,
+    build_mobile_init_script,
+    get_device_profile,
+)
+
+# ── get_device_profile ──────────────────────────────────────────────────────
+
+
+class TestGetDeviceProfile:
+    def test_default_returns_desktop_windows(self):
+        assert get_device_profile() is _DESKTOP_WINDOWS_PROFILE
+
+    def test_none_returns_default(self):
+        assert get_device_profile(None) is _DESKTOP_WINDOWS_PROFILE
+
+    def test_empty_string_returns_default(self):
+        assert get_device_profile("") is _DESKTOP_WINDOWS_PROFILE
+
+    def test_desktop_windows(self):
+        prof = get_device_profile("desktop-windows")
+        assert prof is _DESKTOP_WINDOWS_PROFILE
+        assert prof["is_mobile"] is False
+        assert prof["has_touch"] is False
+
+    def test_desktop_macos(self):
+        prof = get_device_profile("desktop-macos")
+        assert prof["is_mobile"] is False
+        assert prof["platform_navigator"] == "MacIntel"
+        assert prof["camoufox_os"] == "macos"
+
+    def test_mobile_ios_documented_shape(self):
+        prof = get_device_profile("mobile-ios")
+        # UA matches the published Mobile Safari 17.5 / iOS 17.5 string.
+        assert prof["user_agent"] == (
+            "Mozilla/5.0 (iPhone; CPU iPhone OS 17_5 like Mac OS X) "
+            "AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.5 "
+            "Mobile/15E148 Safari/604.1"
+        )
+        # iPhone 14 Pro logical viewport at 3.0 DPR.
+        assert prof["viewport"] == {"width": 393, "height": 852}
+        assert prof["device_scale_factor"] == 3.0
+        assert prof["is_mobile"] is True
+        assert prof["has_touch"] is True
+        assert prof["max_touch_points"] == 5
+        assert prof["platform_navigator"] == "iPhone"
+        assert prof["user_agent_data_mobile"] is True
+
+    def test_mobile_android_documented_shape(self):
+        prof = get_device_profile("mobile-android")
+        # Chrome 124 / Android 14 / Pixel 8 UA.
+        assert prof["user_agent"] == (
+            "Mozilla/5.0 (Linux; Android 14; Pixel 8) "
+            "AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 "
+            "Mobile Safari/537.36"
+        )
+        # Pixel 8 logical viewport at 2.625 DPR.
+        assert prof["viewport"] == {"width": 412, "height": 915}
+        assert prof["device_scale_factor"] == 2.625
+        assert prof["is_mobile"] is True
+        assert prof["has_touch"] is True
+        assert prof["platform_navigator"] == "Linux armv8l"
+        assert prof["user_agent_data_mobile"] is True
+
+    def test_unknown_falls_back_to_default_with_warning(self, caplog):
+        with caplog.at_level(logging.WARNING, logger="browser.stealth"):
+            prof = get_device_profile("unknown-profile")
+        assert prof is _DESKTOP_WINDOWS_PROFILE
+        # Warning was emitted naming the bad value
+        assert any(
+            "Unknown BROWSER_DEVICE_PROFILE" in rec.message
+            and "unknown-profile" in rec.message
+            for rec in caplog.records
+        )
+
+    def test_dispatch_table_has_expected_keys(self):
+        # Lock the public surface so a typo in a future rename triggers
+        # a test failure rather than silently shipping a renamed profile.
+        assert set(_DEVICE_PROFILES.keys()) == {
+            "desktop-windows", "desktop-macos", "mobile-ios", "mobile-android",
+        }
+        assert DEFAULT_DEVICE_PROFILE == "desktop-windows"
+
+
+# ── build_launch_options propagation ───────────────────────────────────────
+
+
+class TestBuildLaunchOptionsProfile:
+    def test_default_profile_preserves_existing_shape(self):
+        # No device_profile passed → behaves exactly as before
+        # (Camoufox-driven UA, per-agent resolution pool).
+        with mock.patch.dict(os.environ, {}, clear=True):
+            opts = build_launch_options("agent-default", "/tmp/p")
+        # No pinned UA in config — Camoufox supplies its own.
+        assert "navigator.userAgent" not in opts.get("config", {})
+        # Window comes from the resolution pool (one of the 6 slots).
+        from src.browser.stealth import _RESOLUTION_POOL
+        valid = {res for res, _ in _RESOLUTION_POOL}
+        assert opts["window"] in valid
+        # OS hint is "windows" (default).
+        assert opts["os"] == "windows"
+
+    def test_explicit_desktop_windows_matches_default(self):
+        with mock.patch.dict(os.environ, {}, clear=True):
+            opts_default = build_launch_options("agent-x", "/tmp/p")
+            opts_explicit = build_launch_options(
+                "agent-x", "/tmp/p", device_profile="desktop-windows",
+            )
+        # Same agent_id → same resolution; same OS hint.
+        assert opts_default["window"] == opts_explicit["window"]
+        assert opts_default["os"] == opts_explicit["os"]
+
+    def test_mobile_ios_sets_ua_viewport_os(self):
+        with mock.patch.dict(os.environ, {}, clear=True):
+            opts = build_launch_options(
+                "agent-iphone", "/tmp/p",
+                device_profile="mobile-ios",
+            )
+        # UA is the iOS profile UA.
+        cfg = opts.get("config", {})
+        assert cfg.get("navigator.userAgent", "").startswith(
+            "Mozilla/5.0 (iPhone; CPU iPhone OS 17_5 like Mac OS X)"
+        )
+        # Viewport pinned to iPhone 14 Pro.
+        assert opts["window"] == (393, 852)
+        # camoufox_os bound to "macos" for the iOS-Safari plumbing path.
+        assert opts["os"] == "macos"
+        # i_know_what_im_doing flag is set whenever a UA is pinned.
+        assert opts.get("i_know_what_im_doing") is True
+
+    def test_mobile_android_sets_ua_viewport_os(self):
+        with mock.patch.dict(os.environ, {}, clear=True):
+            opts = build_launch_options(
+                "agent-pixel", "/tmp/p",
+                device_profile="mobile-android",
+            )
+        cfg = opts.get("config", {})
+        assert cfg.get("navigator.userAgent", "").startswith(
+            "Mozilla/5.0 (Linux; Android 14; Pixel 8)"
+        )
+        assert opts["window"] == (412, 915)
+        # mobile-android profile pins Linux for the OS plumbing.
+        assert opts["os"] == "linux"
+
+    def test_mobile_profile_overrides_browser_os_env(self):
+        # Operator set BROWSER_OS=windows; mobile profile must win and use
+        # its own ``camoufox_os`` instead.
+        with mock.patch.dict(os.environ, {"BROWSER_OS": "windows"}):
+            opts = build_launch_options(
+                "agent-x", "/tmp/p", device_profile="mobile-ios",
+            )
+        assert opts["os"] == "macos"
+
+    def test_unknown_profile_falls_back_to_default(self):
+        with mock.patch.dict(os.environ, {}, clear=True):
+            opts_unknown = build_launch_options(
+                "agent-x", "/tmp/p", device_profile="bogus-profile",
+            )
+            opts_default = build_launch_options("agent-x", "/tmp/p")
+        # Unknown name → fallback to desktop-windows shape.
+        assert opts_unknown["os"] == opts_default["os"]
+        assert opts_unknown["window"] == opts_default["window"]
+
+    def test_browser_ua_version_ignored_when_mobile_profile_pins_ua(self):
+        # On the default profile, BROWSER_UA_VERSION normally rewrites
+        # the UA. With a mobile profile that pins its own UA, the env
+        # var must NOT override the profile's UA.
+        with mock.patch.dict(os.environ, {"BROWSER_UA_VERSION": "200.0"}):
+            opts = build_launch_options(
+                "agent-x", "/tmp/p", device_profile="mobile-ios",
+            )
+        ua = opts["config"]["navigator.userAgent"]
+        assert "iPhone" in ua
+        assert "Firefox/200.0" not in ua
+
+
+# ── Init script ────────────────────────────────────────────────────────────
+
+
+class TestMobileInitScript:
+    def test_desktop_profiles_return_none(self):
+        for name in ("desktop-windows", "desktop-macos"):
+            prof = get_device_profile(name)
+            assert build_mobile_init_script(prof) is None, name
+
+    def test_mobile_ios_emits_script_without_user_agent_data(self):
+        # iOS Safari does NOT expose userAgentData — script must not
+        # define it.
+        prof = get_device_profile("mobile-ios")
+        script = build_mobile_init_script(prof)
+        assert script is not None
+        assert "maxTouchPoints" in script
+        # Touch points pinned to 5
+        assert "5" in script
+        # Platform string injected
+        assert "iPhone" in script
+        # The userAgentData branch is gated on a flag — check the literal
+        # gating value reflects "false" for iOS.
+        assert "__EMIT_USER_AGENT_DATA__" not in script  # placeholders replaced
+        # Search for the literal "if (false)" pattern that disables the
+        # userAgentData branch (templated value collapsed to "false").
+        assert "if (false)" in script
+
+    def test_mobile_android_emits_script_with_user_agent_data(self):
+        prof = get_device_profile("mobile-android")
+        script = build_mobile_init_script(prof)
+        assert script is not None
+        assert "Linux armv8l" in script
+        assert "if (true)" in script  # userAgentData branch enabled
+        # mobile flag is True
+        assert "mobile: true" in script
+
+
+# ── Per-agent override precedence ──────────────────────────────────────────
+
+
+class TestPerAgentOverride:
+    @pytest.fixture(autouse=True)
+    def _isolate(self):
+        flags._agent_overrides.clear()
+        flags.reload_operator_settings()
+        yield
+        flags._agent_overrides.clear()
+        flags.reload_operator_settings()
+
+    def test_agent_override_beats_env(self):
+        # Operator sets desktop-windows via env; one specific agent
+        # gets mobile-ios via per-agent override.
+        with mock.patch.dict(os.environ, {
+            "BROWSER_DEVICE_PROFILE": "desktop-windows",
+        }):
+            flags.set_agent_override(
+                "agent-mobile-target", "BROWSER_DEVICE_PROFILE", "mobile-ios",
+            )
+            # Targeted agent sees the override
+            assert flags.get_str(
+                "BROWSER_DEVICE_PROFILE",
+                DEFAULT_DEVICE_PROFILE,
+                agent_id="agent-mobile-target",
+            ) == "mobile-ios"
+            # Other agents see the operator-wide value
+            assert flags.get_str(
+                "BROWSER_DEVICE_PROFILE",
+                DEFAULT_DEVICE_PROFILE,
+                agent_id="agent-other",
+            ) == "desktop-windows"
+
+    def test_no_override_no_env_returns_default(self):
+        with mock.patch.dict(os.environ, {}, clear=True):
+            assert flags.get_str(
+                "BROWSER_DEVICE_PROFILE",
+                DEFAULT_DEVICE_PROFILE,
+                agent_id="agent-any",
+            ) == DEFAULT_DEVICE_PROFILE
+
+    def test_clear_override_falls_through_to_env(self):
+        with mock.patch.dict(os.environ, {
+            "BROWSER_DEVICE_PROFILE": "mobile-android",
+        }):
+            flags.set_agent_override(
+                "agent-x", "BROWSER_DEVICE_PROFILE", "mobile-ios",
+            )
+            assert flags.get_str(
+                "BROWSER_DEVICE_PROFILE", DEFAULT_DEVICE_PROFILE,
+                agent_id="agent-x",
+            ) == "mobile-ios"
+            # Clear → back to env layer
+            flags.set_agent_override(
+                "agent-x", "BROWSER_DEVICE_PROFILE", None,
+            )
+            assert flags.get_str(
+                "BROWSER_DEVICE_PROFILE", DEFAULT_DEVICE_PROFILE,
+                agent_id="agent-x",
+            ) == "mobile-android"
+
+
+# ── Integration: profiles + flag → build_launch_options end-to-end ─────────
+
+
+class TestEndToEndProfileWiring:
+    @pytest.fixture(autouse=True)
+    def _isolate(self):
+        flags._agent_overrides.clear()
+        flags.reload_operator_settings()
+        yield
+        flags._agent_overrides.clear()
+        flags.reload_operator_settings()
+
+    def test_flag_value_drives_build_launch_options_shape(self):
+        # Simulate: operator sets BROWSER_DEVICE_PROFILE=mobile-android,
+        # build_launch_options is called with that name → mobile shape.
+        with mock.patch.dict(os.environ, {
+            "BROWSER_DEVICE_PROFILE": "mobile-android",
+        }):
+            chosen = flags.get_str(
+                "BROWSER_DEVICE_PROFILE", DEFAULT_DEVICE_PROFILE,
+                agent_id="agent-x",
+            )
+            opts = build_launch_options(
+                "agent-x", "/tmp/p", device_profile=chosen,
+            )
+        assert opts["window"] == (412, 915)
+        assert "Pixel 8" in opts["config"]["navigator.userAgent"]
+
+    def test_per_agent_override_drives_build_launch_options(self):
+        # Operator runs desktop-windows; one agent overridden to mobile-ios.
+        with mock.patch.dict(os.environ, {
+            "BROWSER_DEVICE_PROFILE": "desktop-windows",
+        }):
+            flags.set_agent_override(
+                "agent-mobile", "BROWSER_DEVICE_PROFILE", "mobile-ios",
+            )
+            chosen_mobile = flags.get_str(
+                "BROWSER_DEVICE_PROFILE", DEFAULT_DEVICE_PROFILE,
+                agent_id="agent-mobile",
+            )
+            chosen_other = flags.get_str(
+                "BROWSER_DEVICE_PROFILE", DEFAULT_DEVICE_PROFILE,
+                agent_id="agent-other",
+            )
+        assert chosen_mobile == "mobile-ios"
+        assert chosen_other == "desktop-windows"
+
+        opts_mobile = build_launch_options(
+            "agent-mobile", "/tmp/p", device_profile=chosen_mobile,
+        )
+        opts_other = build_launch_options(
+            "agent-other", "/tmp/p", device_profile=chosen_other,
+        )
+        # Targeted agent gets iOS UA + viewport
+        assert opts_mobile["window"] == (393, 852)
+        assert "iPhone" in opts_mobile["config"]["navigator.userAgent"]
+        # Other agent stays on the desktop default shape
+        assert "config" not in opts_other or "navigator.userAgent" not in opts_other.get("config", {})
+        # Other agent's window is from the resolution pool (not iPhone)
+        assert opts_other["window"] != (393, 852)
+
+
+# ── Reference data sanity ──────────────────────────────────────────────────
+
+
+class TestProfileConsistency:
+    def test_mobile_profiles_have_required_fields(self):
+        for name in ("mobile-ios", "mobile-android"):
+            prof = _DEVICE_PROFILES[name]
+            for field in (
+                "user_agent", "viewport", "device_scale_factor",
+                "is_mobile", "has_touch", "platform_navigator",
+                "max_touch_points", "user_agent_data_mobile", "camoufox_os",
+            ):
+                assert field in prof, f"{name} missing {field}"
+            assert prof["is_mobile"] is True
+            assert prof["has_touch"] is True
+            assert prof["max_touch_points"] >= 1
+
+    def test_desktop_profiles_share_invariants(self):
+        for name in ("desktop-windows", "desktop-macos"):
+            prof = _DEVICE_PROFILES[name]
+            assert prof["is_mobile"] is False
+            assert prof["has_touch"] is False
+            assert prof["max_touch_points"] == 0
+            assert prof["user_agent_data_mobile"] is False
+
+    def test_ios_and_android_profile_constants_are_exported(self):
+        # The module-level constants are part of the public surface
+        # for tests + import paths in service.py.
+        assert _MOBILE_IOS_PROFILE is _DEVICE_PROFILES["mobile-ios"]
+        assert _MOBILE_ANDROID_PROFILE is _DEVICE_PROFILES["mobile-android"]


### PR DESCRIPTION
## Summary

Adds operator-selectable device emulation profiles to the shared Camoufox browser. The default behavior is unchanged (Windows desktop fingerprint), but two mobile profiles + a desktop-macOS variant are now available via the `BROWSER_DEVICE_PROFILE` flag — wired through the standard flags precedence chain so per-agent overrides Just Work.

## Why mobile

Some sites are friendlier to mobile fingerprints — either because the geographic mix is mobile-dominated, the mobile site version is less aggressively bot-protected, or detection systems are calibrated on desktop fingerprint clusters. Today we're desktop-only; this gives operators a usable mobile shape without forking the launch path.

## Profile table

| Profile | UA family | Viewport | DPR | `is_mobile` | `has_touch` | `platform` | Camoufox `os` |
|---|---|---|---|---|---|---|---|
| `desktop-windows` (default) | Firefox / Win64 | per-agent pool | 1.0 | false | false | `Win32` | `windows` |
| `desktop-macos` | Firefox / macOS | per-agent pool | 2.0 | false | false | `MacIntel` | `macos` |
| `mobile-ios` | Mobile Safari 17.5 / iPhone 14 Pro | 393x852 | 3.0 | true | true | `iPhone` | `macos` |
| `mobile-android` | Chrome 124 / Pixel 8 / Android 14 | 412x915 | 2.625 | true | true | `Linux armv8l` | `linux` |

## Wiring

- **`stealth.py`**: `_DEVICE_PROFILES` dispatch table + `get_device_profile()` selector with default-fallback. `build_launch_options()` now takes `device_profile=` and applies the profile's pinned UA, viewport, and `camoufox_os`. The §6.4 Firefox-UA tripwire is bypassed for mobile profiles (operator opt-in to UA-engine mismatch).
- **`stealth.py`**: `build_mobile_init_script()` builds a navigator-override init script (touch points, `navigator.platform`, `navigator.userAgentData`). iOS hides `userAgentData` (matches real Safari); Android emits it with `mobile=true`.
- **`flags.py`**: `BROWSER_DEVICE_PROFILE` registered in `KNOWN_FLAGS` with the four-value enum.
- **`service.py`**: `_start_browser` reads the flag with `agent_id=` for per-agent precedence; passes the resolved name to `build_launch_options`; injects the mobile init script via `BrowserContext.add_init_script` BEFORE any page is created so `document_start` sees it. Logs the chosen profile at INFO.

## Tradeoffs (also in `docs/configuration.md`)

- **Desktop-only forms reject mobile UAs**: enterprise SaaS / admin consoles often refuse mobile UAs entirely.
- **Different content**: many sites serve fewer features (less DOM, simplified menus) to mobile UAs.
- **Camoufox compatibility**: Camoufox is built on Firefox, so mobile profiles ship a UA-engine mismatch (UA claims WebKit/Blink, engine is still Gecko). Surface-layer signals (UA, viewport, DPR, `is_mobile`, `has_touch`, `navigator.userAgentData`, `navigator.maxTouchPoints`, `navigator.platform`) are mitigated; deep API quirks (WebGL renderers, codec quirks, Sec-CH-UA-* Client Hints — Firefox doesn't send these and Camoufox can't synthesize them) are NOT. Sites that probe deep can still tell something is off.
- **For high-accuracy mobile spoofing**, a Chromium-based stack would be required; this implementation gives operators a usable mobile fingerprint for sites that gate on the easy-to-check signals.

## Per-agent override path

`BROWSER_DEVICE_PROFILE` flows through the standard `flags.get_str(name, default, agent_id=...)` precedence:

1. Per-agent override (`flags.set_agent_override("agent-id", "BROWSER_DEVICE_PROFILE", "mobile-ios")`)
2. Operator settings (`config/settings.json` → `browser_flags.BROWSER_DEVICE_PROFILE`)
3. Environment variable (`BROWSER_DEVICE_PROFILE=...`)
4. Hardcoded default (`desktop-windows`)

Verified end-to-end in `TestEndToEndProfileWiring::test_per_agent_override_drives_build_launch_options`: an agent with a per-agent override gets the mobile UA + viewport while operator-default agents stay on desktop.

## UA string sourcing

- **iOS**: Apple's published WebKit User-Agent for Mobile Safari on iOS 17.5 (build `15E148`, `Version/17.5`). iOS 17.x is the dominant iOS major as of early 2026; iPhone 14 Pro is high-share.
- **Android**: Chrome 124 stable channel (April 2026) on Pixel 8 / Android 14. UA matches Chrome's standard mobile shape.
- **Firefox-desktop UAs** continue to flow through `BROWSER_UA_VERSION` for the desktop-windows / desktop-macos paths (unchanged).

## Test plan

- [x] `pytest tests/test_browser_device_profile.py -v` — 27 passing
- [x] `pytest tests/test_stealth.py tests/test_browser_flags.py tests/test_browser_service.py tests/test_browser_device_profile.py` — 525 passing
- [x] `ruff check src/ tests/` — clean
- [ ] Smoke-test in browser container: confirm Camoufox honors `config["navigator.userAgent"]` for mobile UA; confirm `add_init_script` runs before `document_start`; confirm `navigator.maxTouchPoints` reads as 5 on a real page under `mobile-ios`
- [ ] Smoke-test that `BROWSER_DEVICE_PROFILE=desktop-windows` (the default) produces an identical Camoufox launch shape to the pre-PR behavior