### PR TITLE
Display operator in standalone fleet view; block project assignment

### DIFF
--- a/src/cli/config.py
+++ b/src/cli/config.py
@@ -644,6 +644,10 @@ def _create_project(
 ) -> None:
     """Create a new project: directory, metadata.yaml, scaffold project.md."""
     name = _validate_project_name(name)
+    # Validate members upfront before any filesystem writes — prevents partial project creation.
+    members = list(members or [])
+    if "operator" in members:
+        raise ValueError("Operator is a system agent and cannot be assigned to projects")
     project_dir = PROJECTS_DIR / name
     if project_dir.exists():
         raise ValueError(f"Project '{name}' already exists")
@@ -671,7 +675,7 @@ def _create_project(
     )
 
     # Add initial members (handles removing from old projects + permissions)
-    for agent in (members or []):
+    for agent in members:
         _add_agent_to_project(name, agent)
 
 
@@ -700,6 +704,8 @@ def _delete_project(name: str) -> None:
 
 def _add_agent_to_project(project: str, agent: str) -> None:
     """Assign an agent to a project. Removes from old project if any."""
+    if agent == "operator":
+        raise ValueError("Operator is a system agent and cannot be assigned to projects")
     project_dir = PROJECTS_DIR / project
     meta_file = project_dir / "metadata.yaml"
     if not meta_file.exists():

--- a/src/dashboard/static/js/app.js
+++ b/src/dashboard/static/js/app.js
@@ -728,13 +728,20 @@ function dashboard() {
     },
 
     get filteredAgents() {
-      // Hide the operator system agent from the fleet view — it's managed via the Chat tab
+      // User-fleet view: excludes the operator system agent. Drives all stats (cost, tokens, health),
+      // count-against-quota displays, and broadcast targeting. Operator is rendered separately via displayAgents.
       if (this.activeProject) {
         return this.agents.filter(a => a.id !== 'operator' && a.project === this.activeProject);
       }
-      // When projects exist, show only standalone (unassigned) agents
       const base = this.projects.length > 0 ? this.unassignedAgents : this.agents;
       return base.filter(a => a.id !== 'operator');
+    },
+
+    /** Agent grid render list. Standalone view prepends the operator card (system agent, links to operator settings). */
+    get displayAgents() {
+      if (this.activeProject) return this.filteredAgents;
+      const operator = this.agents.find(a => a.id === 'operator');
+      return operator ? [operator, ...this.filteredAgents] : this.filteredAgents;
     },
 
     get filteredFleetCost() {
@@ -2628,13 +2635,13 @@ function dashboard() {
       } catch (e) { this.showToast(`Remove failed: ${e.message}`); }
     },
 
-    /** Agents in the registry that are not in any project. */
+    /** Agents in the registry that are not in any project. Excludes operator (system agent, not project-assignable). */
     get unassignedAgents() {
       const assigned = new Set();
       for (const p of this.projects) {
         for (const m of (p.members || [])) assigned.add(m);
       }
-      return this.agents.filter(a => !assigned.has(a.id));
+      return this.agents.filter(a => a.id !== 'operator' && !assigned.has(a.id));
     },
 
     /** Get the active project object. */
@@ -4730,12 +4737,12 @@ function dashboard() {
     },
 
     get broadcastTargets() {
-      // Project selected → project members; no project → standalone agents only
-      // Exclude over-limit (locked) agents — they aren't running
+      // Project selected → project members; no project → standalone agents only.
+      // Exclude over-limit (locked) agents — they aren't running. Always exclude operator (system agent, has its own chat).
       if (this.activeProject) {
         return this.filteredAgents.filter(a => !a.over_limit);
       }
-      return this.agents.filter(a => !a.over_limit && !a.project);
+      return this.agents.filter(a => a.id !== 'operator' && !a.over_limit && !a.project);
     },
 
     sendBroadcast() {
@@ -5684,6 +5691,17 @@ function dashboard() {
     // ── Agent drill-down ──────────────────────────────────
 
     drillDown(agentId) {
+      // Operator is a system agent — route to its dedicated settings page instead of the generic agent detail panel.
+      // Centralizes operator routing for all callers (card clicks, URL routes, search results).
+      if (agentId === 'operator') {
+        // Suppress switchTab's URL push so the back button returns to the source page, not the intermediate /system/<previous-tab>.
+        // Save/restore _skipPush so we don't clobber the outer invariant (e.g. _applyRoute holds _skipPush=true).
+        const prevSkip = this._skipPush;
+        this._skipPush = true;
+        try { this.switchTab('system'); } finally { this._skipPush = prevSkip; }
+        this.switchSystemTab('operator');
+        return;
+      }
       this._detailReturnProject = this.activeProject;
       this.activeTab = 'fleet';
       this.selectedAgent = agentId;

--- a/src/dashboard/templates/index.html
+++ b/src/dashboard/templates/index.html
@@ -1444,7 +1444,7 @@
           :class="openChats.length > 0 && !chatPanelMinimized && !chatFullScreen
             ? 'grid-cols-1 lg:grid-cols-2'
             : 'grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4'">
-          <template x-for="agent in filteredAgents" :key="agent.id">
+          <template x-for="agent in displayAgents" :key="agent.id">
             <div
               role="article"
               :aria-label="'Agent ' + agent.id"
@@ -1459,7 +1459,9 @@
 
               <!-- Header: Avatar + Name + Health -->
               <div class="flex items-start gap-3 mb-3 relative">
-                <div class="agent-avatar cursor-pointer" :class="'agent-color-' + agentColorIndex(agent.id)" @click="drillDown(agent.id)" title="View agent details">
+                <div class="agent-avatar cursor-pointer" :class="'agent-color-' + agentColorIndex(agent.id)"
+                  @click="drillDown(agent.id)"
+                  :title="agent.id === 'operator' ? 'Open operator settings' : 'View agent details'">
                   <img :src="agentAvatarUrl(agent.id)" :alt="agent.id">
                   <!-- Activity indicator dot -->
                   <span class="activity-dot"
@@ -1474,8 +1476,13 @@
                 </div>
                 <div class="flex-1 min-w-0">
                   <div class="flex items-center gap-2">
-                    <span class="font-semibold text-white group-hover:text-indigo-300 transition-colors truncate cursor-pointer" @click="drillDown(agent.id)" :title="agent.id" x-text="agent.id"></span>
-                    <svg class="w-3 h-3 text-gray-600 group-hover:text-indigo-400 transition-colors shrink-0 cursor-pointer" @click="drillDown(agent.id)" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7"/></svg>
+                    <span class="font-semibold text-white group-hover:text-indigo-300 transition-colors truncate cursor-pointer"
+                      @click="drillDown(agent.id)"
+                      :title="agent.id" x-text="agent.id"></span>
+                    <span x-show="agent.id === 'operator'" class="text-[10px] px-1.5 py-0.5 rounded bg-indigo-900/30 text-indigo-400 border border-indigo-800/40 shrink-0">system</span>
+                    <svg class="w-3 h-3 text-gray-600 group-hover:text-indigo-400 transition-colors shrink-0 cursor-pointer"
+                      @click="drillDown(agent.id)"
+                      fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7"/></svg>
                   </div>
                   <div class="text-xs text-gray-500 truncate mt-0.5" x-show="agent.model"
                     x-text="formatModelName(agent.model)"></div>
@@ -1575,7 +1582,7 @@
                     <svg fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z"/></svg>
                     <span x-text="openChats.includes(agent.id) ? 'Chatting' : 'Chat'"></span>
                   </button>
-                  <button x-show="agent.heartbeat_job_id" @click="toggleHeartbeat(agent)"
+                  <button x-show="agent.id !== 'operator' && agent.heartbeat_job_id" @click="toggleHeartbeat(agent)"
                     :disabled="cronPauseLoading[agent.heartbeat_job_id] === true"
                     class="action-btn action-btn-warn disabled:opacity-50">
                     <svg x-show="cronPauseLoading[agent.heartbeat_job_id] !== true && agent.heartbeat_enabled" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="6" y="4" width="4" height="16"/><rect x="14" y="4" width="4" height="16"/></svg>

--- a/tests/test_projects.py
+++ b/tests/test_projects.py
@@ -244,6 +244,22 @@ class TestCreateProject:
             with pytest.raises(ValueError, match="already exists"):
                 _create_project("existing")
 
+    def test_create_with_operator_member_rejected_no_partial_state(self, tmp_path):
+        """Operator in initial members must raise BEFORE the project dir is created (no partial state)."""
+        projects_dir = tmp_path / "projects"
+        projects_dir.mkdir(parents=True)
+        perms_file = tmp_path / "permissions.json"
+        perms_file.write_text(json.dumps({"permissions": {}}))
+
+        with (
+            patch("src.cli.config.PROJECTS_DIR", projects_dir),
+            patch("src.cli.config.PERMISSIONS_FILE", perms_file),
+        ):
+            with pytest.raises(ValueError, match="system agent"):
+                _create_project("new-proj", members=["agent1", "operator"])
+        # Project directory must not exist — rejection happens before any filesystem writes
+        assert not (projects_dir / "new-proj").exists()
+
 
 class TestDeleteProject:
     def test_delete_project(self, tmp_path):
@@ -352,6 +368,25 @@ class TestAddRemoveAgentProject:
         ):
             with pytest.raises(ValueError, match="not found"):
                 _add_agent_to_project("ghost", "agent1")
+
+    def test_add_operator_rejected(self, tmp_path):
+        """Operator is a system agent and must never be assignable to a project."""
+        projects_dir = tmp_path / "projects"
+        proj_dir = projects_dir / "proj1"
+        proj_dir.mkdir(parents=True)
+        (proj_dir / "metadata.yaml").write_text(yaml.dump({"name": "proj1", "members": []}))
+        perms_file = tmp_path / "permissions.json"
+        perms_file.write_text(json.dumps({"permissions": {"operator": {}}}))
+
+        with (
+            patch("src.cli.config.PROJECTS_DIR", projects_dir),
+            patch("src.cli.config.PERMISSIONS_FILE", perms_file),
+        ):
+            with pytest.raises(ValueError, match="system agent"):
+                _add_agent_to_project("proj1", "operator")
+        # Members list must remain empty — no partial write before the rejection
+        meta = yaml.safe_load((proj_dir / "metadata.yaml").read_text())
+        assert meta["members"] == []
 
     def test_remove_agent(self, tmp_path):
         projects_dir = tmp_path / "projects"


### PR DESCRIPTION
## Summary

- Operator (system agent) now appears as the first card in the standalone fleet view with a "system" badge, replacing its prior invisibility on the agents page. Avatar/name/arrow clicks route to the **System → Operator** settings page.
- Operator stays **excluded** from quota math, fleet stats (cost/tokens/health), broadcasts, and project membership — so a basic plan's 1-agent quota reflects only user agents.
- Backend rejects operator at every project-assignment choke point (`_add_agent_to_project`, `_create_project`) and validates members upfront so a rejection can't leave a partially-created project on disk.
- Pre-existing fix: `broadcastTargets` no longer includes operator in the standalone case.

## Why

The operator chat tab was the only entry point — users had to know to look there. Surfacing it as a card on the fleet page (with a clear link to its settings) makes it discoverable. Keeping it out of project pickers and quota math preserves the system-tier separation.

## Implementation

| Surface | Change |
|---|---|
| `app.js` `filteredAgents` | Original (excludes operator) — drives stats/quota/broadcasts |
| `app.js` `displayAgents` (new) | Prepends operator in standalone view — drives grid only |
| `app.js` `unassignedAgents` | Excludes operator (project member picker) |
| `app.js` `broadcastTargets` | Excludes operator in standalone case |
| `app.js` `drillDown` | Early-return redirect for operator (single source of truth for all callers) |
| `index.html` operator card | "system" badge, heartbeat Pause/Resume hidden, Chat button kept |
| `config.py` `_add_agent_to_project` | Raises ValueError on operator |
| `config.py` `_create_project` | Validates members upfront, no partial creation |

## Test plan

- [x] `pytest tests/test_projects.py` — 44/44 pass (2 new cases)
- [x] `pytest tests/test_dashboard.py -k 'project or member or operator'` — 29/29 pass
- [x] `node -c src/dashboard/static/js/app.js` — JS syntax valid
- [ ] Manual: standalone view shows operator card; project view hides it
- [ ] Manual: clicking operator card avatar/name lands on `/system/operator` (single history entry)
- [ ] Manual: project member picker omits operator
- [ ] Manual: `POST /api/projects/<p>/members {agent: "operator"}` returns HTTP 400
- [ ] Manual: basic plan (`OPENLEGION_MAX_AGENTS=1`) shows "1/1 agents" with one user agent + operator card visible