### PR TITLE
Phase 10 §22: fingerprint health + burn detection

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -87,7 +87,7 @@ Three trust zones: **User** (full trust), **Mesh** (trusted coordinator), **Agen
 | **`src/browser/`** | |
 | `__main__.py` | Starts KasmVNC (Xvnc), Openbox WM, FastAPI command server |
 | `server.py` | Browser service FastAPI app. Raises `RuntimeError` on startup when auth token missing in production (MESH_AUTH_TOKEN set but BROWSER_AUTH_TOKEN absent); warns only in dev. |
-| `service.py` | BrowserManager with per-agent Camoufox instances. `_MAX_WALK_DEPTH=50` for DOM snapshot. Per-agent X11 WID tracking for targeted VNC focus. |
+| `service.py` | BrowserManager with per-agent Camoufox instances. `_MAX_WALK_DEPTH=50` for DOM snapshot. Per-agent X11 WID tracking for targeted VNC focus. §22 fingerprint health monitor: rolling per-agent rejection window (`_FINGERPRINT_WINDOW_SIZE=10`, burn threshold 50%); post-solve page-state monitor probes vendor-specific selectors (Cloudflare 1xxx, DataDome, PerimeterX, Imperva, Akamai BMP) + branded rejection text; burn surfaces `fingerprint_burn=True` + `next_action="retry_with_fresh_profile"` on subsequent captcha envelopes; operator clears manually after profile rotation. |
 | `redaction.py` | Credential redaction for browser output |
 | `stealth.py` | Anti-bot fingerprint building (Windows fingerprint, WebRTC kill, `BROWSER_UA_VERSION` override) |
 | `timing.py` | Timing jitter for human-like behavior |

--- a/src/browser/server.py
+++ b/src/browser/server.py
@@ -750,6 +750,31 @@ def create_browser_app(manager: BrowserManager, lifespan=None) -> FastAPI:
         from src.browser.session_persistence import session_summary
         return session_summary(agent_id)
 
+    @app.get("/browser/{agent_id}/fingerprint-health")
+    async def fingerprint_health(agent_id: str, request: Request):
+        """§22 — return the per-agent fingerprint health summary.
+
+        Shape: ``{window_size, rejection_rate, burned, last_signal_ts}``.
+        Read-only.  No URL / origin leakage — ``last_signal_ts`` is an
+        ISO-8601 timestamp or null; nothing else identifies the sites
+        the agent is interacting with.
+        """
+        _verify_auth(request)
+        return await manager.get_fingerprint_health(agent_id)
+
+    @app.post("/browser/{agent_id}/fingerprint-health/reset")
+    async def fingerprint_health_reset(agent_id: str, request: Request):
+        """§22 — clear the rolling fingerprint rejection window.
+
+        Operator-only — used after a manual profile rotation. The live
+        BrowserContext is intentionally NOT touched here; the operator
+        is expected to have already rotated the profile before clearing
+        the metric.  Auth is the standard browser-service bearer token;
+        the dashboard layer additionally CSRF-gates this path.
+        """
+        _verify_auth(request)
+        return await manager.reset_fingerprint_health(agent_id)
+
     @app.delete("/browser/{agent_id}/session")
     async def session_clear(agent_id: str, request: Request):
         """Delete the per-agent session sidecar.

--- a/src/browser/service.py
+++ b/src/browser/service.py
@@ -552,6 +552,346 @@ async def _drain_session_audit() -> list[dict]:
     return drained
 
 
+# ── §22 / §11.17 — fingerprint health monitoring ─────────────────────────
+#
+# Anti-bot frameworks sometimes accept a solver-injected token mechanically
+# (the solve "succeeds" from our perspective) but reject the SESSION the
+# token was injected into — typically when the agent's BrowserForge
+# fingerprint has been observed solving captchas across many sites and is
+# now flagged. The solver is healthy; the FINGERPRINT is burned.
+#
+# Per-agent rolling window of post-solve outcomes:
+#   - True  → page rejected the solve (selector still present, "verification
+#             failed" / "try again" / "could not be verified" / "robot detected"
+#             text on page).
+#   - False → page accepted the solve (navigated away, no captcha selector).
+#
+# Burn detection: window full (>=10 entries) AND >=50% True. While burned,
+# subsequent ``_check_captcha`` envelopes carry ``fingerprint_burn: True``
+# and ``next_action="retry_with_fresh_profile"``, signalling the operator
+# to rotate the profile manually (auto-rotation is too destructive — it
+# wipes session cookies / login state and can cascade other agents' work).
+#
+# Operator clears the burn manually via ``POST .../fingerprint-health/reset``
+# after rotating the profile.  The window also clears naturally once 10
+# consecutive accepts roll the True entries out.
+#
+# Exclusions per §11.17 spec:
+#   - ``skipped_behavioral`` and ``request_captcha_help`` outcomes do NOT
+#     count toward the rejection rate.  They're correct escalations, not
+#     rejections — the solver never attempted-and-injected a token, so
+#     post-solve page state has nothing to tell us about the fingerprint.
+#   - Only outcomes where the solver actually attempted-and-injected a
+#     token (``solver_outcome="solved"``, page-state monitor verifies)
+#     contribute to the window.
+#
+# State is module-global because the BrowserManager is a singleton in the
+# browser-service container.  Per-agent ``deque(maxlen=10)`` is sufficient
+# (no new sliding-window primitive needed); reuses the same shape as
+# ``CaptchaSolver._solver_failure_timestamps``.
+_FINGERPRINT_WINDOW_SIZE = 10
+_FINGERPRINT_BURN_THRESHOLD = 0.5  # >= 50% rejected → burned
+# Page-state monitor: how long we wait after a ``solved`` envelope to
+# observe whether the page accepted or rejected the token.
+_FINGERPRINT_MONITOR_TIMEOUT_S = 10.0
+# Text fragments that indicate the post-solve page is still rejecting the
+# session.  Matched case-insensitively against the page's visible body
+# text inside the monitor's poll loop.  Multi-vendor coverage: the agent
+# may be solving captchas on sites protected by Cloudflare, DataDome,
+# PerimeterX/HUMAN, Akamai BMP, Imperva, F5 Distributed Cloud, Kasada, or
+# native vendor implementations.  False-positive cost is low (one entry
+# in a 10-deep window), and missing a rejection costs us much more (the
+# fingerprint stays in service after it has been flagged).
+_FINGERPRINT_REJECTION_TEXT: tuple[str, ...] = (
+    # Generic — vendor-agnostic phrasing reused across stacks.
+    "verification failed",
+    "try again",
+    "could not be verified",
+    "robot detected",
+    "are you a robot",
+    "please complete the verification",
+    "security check",
+    "checking if the site connection is secure",
+    "additional verification required",
+    "human verification",
+    # Cloudflare — interstitial / 1xxx error codes.  The interstitial
+    # body shows "Just a moment..." while running the JS challenge; if
+    # we still see it 10s after token injection the challenge re-armed.
+    "just a moment",
+    "ray id",
+    "cloudflare ray id",
+    "error 1020",  # Access denied — site rule blocked the IP.
+    "error 1015",  # Rate-limited.
+    "error 1010",  # Browser signature blocked.
+    # DataDome — branded block page.
+    "blocked by datadome",
+    "request unsuccessful",
+    "incident id",  # Imperva + DataDome both surface this.
+    # PerimeterX / HUMAN — branded block page text.
+    "please verify you are a human",
+    "press and hold",  # PerimeterX press-and-hold variant.
+    "this site uses an additional layer of security",
+    # Imperva — generic block.
+    "access denied",
+    "request blocked",
+    "you don't have permission to access",
+    # Akamai BMP — branded reference text.
+    "reference #",  # "Reference #18.deadbeef.1234567890" pattern.
+    # Generic anti-bot rejection language.
+    "you have been blocked",
+    "unusual activity",
+    "suspicious activity",
+    "session expired",
+    "challenge failed",
+    "captcha failed",
+    "captcha invalid",
+)
+# Vendor-specific element selectors — far more deterministic than text
+# scanning (language-independent, layout-stable).  Each selector here
+# matches a known anti-bot vendor's interstitial / block page.  If any
+# selector resolves with count>0 on the post-solve page, the session
+# was rejected.
+_FINGERPRINT_REJECTION_SELECTORS: tuple[str, ...] = (
+    # Cloudflare — challenge / error pages (#cf-error-details and the
+    # 1xxx error containers; #challenge-error-text on the JS challenge
+    # interstitial).
+    "[id^=cf-error]",
+    "#challenge-error-text",
+    ".cf-error-details",
+    ".cf-browser-verification",
+    # DataDome — geo / device block page.
+    "#ddm-blocked",
+    ".dd-r-blocked",
+    "[data-dd-block]",
+    # PerimeterX / HUMAN — block / press-and-hold page (#px-captcha
+    # appears on the press-and-hold variant; .px-block-spam on the
+    # outright block).
+    "#px-captcha",
+    ".px-block-spam",
+    # Imperva — incident page (the iframe wraps the actual block content).
+    "#main-iframe[src*=incident]",
+    # Akamai BMP — bm-error reference container.
+    "[id^=bm-error]",
+    # F5 Distributed Cloud / Shape Security — generic block iframe.
+    "iframe[src*=shape]",
+)
+_fingerprint_lock: asyncio.Lock | None = None
+_fingerprint_lock_loop: asyncio.AbstractEventLoop | None = None
+# {agent_id: deque[bool]} — entries True = rejected, False = accepted.
+_fingerprint_window: dict[str, deque[bool]] = {}
+# {agent_id: float} — unix timestamp of the most recent recorded signal.
+# Surfaced by the dashboard endpoint as ``last_signal_ts``.
+_fingerprint_last_signal: dict[str, float] = {}
+
+
+def _get_fingerprint_lock() -> asyncio.Lock:
+    """Return a fingerprint-state lock bound to the active event loop."""
+    global _fingerprint_lock, _fingerprint_lock_loop
+    loop = asyncio.get_running_loop()
+    if _fingerprint_lock is None or _fingerprint_lock_loop is not loop:
+        _fingerprint_lock = asyncio.Lock()
+        _fingerprint_lock_loop = loop
+    return _fingerprint_lock
+
+
+async def _record_fingerprint_outcome(
+    agent_id: str, rejected: bool,
+) -> bool:
+    """Append a post-solve outcome to the agent's rolling fingerprint window.
+
+    Returns the burn-state AFTER the append.  Caller can use the return
+    value to decide whether to emit a ``fingerprint_burn`` audit event.
+    The deque is bounded at :data:`_FINGERPRINT_WINDOW_SIZE` so the
+    natural rollover happens once 10 consecutive accepts arrive.
+    """
+    async with _get_fingerprint_lock():
+        bucket = _fingerprint_window.get(agent_id)
+        if bucket is None:
+            bucket = deque(maxlen=_FINGERPRINT_WINDOW_SIZE)
+            _fingerprint_window[agent_id] = bucket
+        bucket.append(bool(rejected))
+        _fingerprint_last_signal[agent_id] = time.time()
+        return _is_burned_locked(bucket)
+
+
+def _is_burned_locked(bucket: deque[bool]) -> bool:
+    """Compute burn state from a window snapshot.
+
+    Caller must hold :func:`_get_fingerprint_lock`.  Burn fires only
+    when the window is FULL — partial windows are not enough signal.
+    """
+    if len(bucket) < _FINGERPRINT_WINDOW_SIZE:
+        return False
+    rejected = sum(1 for v in bucket if v)
+    return (rejected / len(bucket)) >= _FINGERPRINT_BURN_THRESHOLD
+
+
+async def _is_fingerprint_burned(agent_id: str) -> bool:
+    """Read-only burn check for ``_check_captcha`` to decorate envelopes."""
+    async with _get_fingerprint_lock():
+        bucket = _fingerprint_window.get(agent_id)
+        if bucket is None:
+            return False
+        return _is_burned_locked(bucket)
+
+
+async def _get_fingerprint_health(agent_id: str) -> dict:
+    """Return the dashboard-shaped health payload for one agent.
+
+    Shape is contract-stable — see plan §22 dashboard panel and
+    ``test_fingerprint_health::test_health_endpoint_shape``::
+
+        {"window_size": int, "rejection_rate": float, "burned": bool,
+         "last_signal_ts": str | None}
+
+    ``rejection_rate`` is 0.0 when the window is empty (avoid divide-by-zero
+    surprises in the dashboard).  ``last_signal_ts`` is ISO-8601 UTC, or
+    ``None`` when no signal has ever been recorded for this agent.
+    """
+    async with _get_fingerprint_lock():
+        bucket = _fingerprint_window.get(agent_id)
+        last_ts = _fingerprint_last_signal.get(agent_id)
+        if bucket is None or len(bucket) == 0:
+            window_size = 0
+            rejection_rate = 0.0
+            burned = False
+        else:
+            window_size = len(bucket)
+            rejected = sum(1 for v in bucket if v)
+            rejection_rate = rejected / window_size
+            burned = _is_burned_locked(bucket)
+    return {
+        "window_size": window_size,
+        "rejection_rate": rejection_rate,
+        "burned": burned,
+        "last_signal_ts": _iso8601_utc(last_ts) if last_ts else None,
+    }
+
+
+async def _reset_fingerprint_window(agent_id: str) -> bool:
+    """Operator-triggered reset.  Returns True if state was cleared.
+
+    Called after the operator manually rotates the BrowserForge fingerprint
+    (no auto-rotation per §22 — see header note).  Drops both the rolling
+    window and the last-signal timestamp; the next post-solve outcome
+    starts a fresh window.
+    """
+    async with _get_fingerprint_lock():
+        had_state = (
+            agent_id in _fingerprint_window
+            or agent_id in _fingerprint_last_signal
+        )
+        _fingerprint_window.pop(agent_id, None)
+        _fingerprint_last_signal.pop(agent_id, None)
+    return had_state
+
+
+# ── §22 — fingerprint audit aggregator (per-minute, no URL leak) ──────────
+#
+# Mirrors ``_drain_captcha_audit`` / ``_drain_session_audit`` — aggregated
+# per minute keyed by ``(agent_id, signal, page_origin)`` so a stuck retry
+# loop on one site doesn't drown out the rest of the fleet.  ``page_origin``
+# is the redacted netloc only (no path, no query, no fragment) so the
+# dashboard event stream cannot be used to infer which sites the agent is
+# logged into.  Cookie values, full URLs, and query parameters are NEVER
+# included — same privacy posture as the §20 session audit.
+#
+# Signals: ``rejected`` / ``accepted`` (page-state monitor outcome) and
+# ``fingerprint_burn`` (one-shot when a fresh outcome trips the threshold).
+_fingerprint_audit_lock: asyncio.Lock | None = None
+_fingerprint_audit_lock_loop: asyncio.AbstractEventLoop | None = None
+# {(agent_id, signal, page_origin): {"count": int, "first_ts": float}}
+_fingerprint_audit_buckets: dict[tuple[str, str, str], dict] = {}
+
+
+def _get_fingerprint_audit_lock() -> asyncio.Lock:
+    """Return a fingerprint audit lock bound to the active event loop."""
+    global _fingerprint_audit_lock, _fingerprint_audit_lock_loop
+    loop = asyncio.get_running_loop()
+    if (
+        _fingerprint_audit_lock is None
+        or _fingerprint_audit_lock_loop is not loop
+    ):
+        _fingerprint_audit_lock = asyncio.Lock()
+        _fingerprint_audit_lock_loop = loop
+    return _fingerprint_audit_lock
+
+
+def _page_origin_for_audit(page_url: str) -> str:
+    """Reduce a URL to ``netloc`` only (no path / query / fragment).
+
+    Returns ``""`` on any parse failure so the audit event still records
+    the signal even when the source URL is malformed.  Mirrors the
+    "counts only, no values" privacy posture used by the §20 session
+    audit aggregator.  Userinfo (``user:pass@host``) is stripped.
+    """
+    if not page_url:
+        return ""
+    try:
+        parsed = urlparse(page_url)
+    except Exception:
+        return ""
+    host = parsed.hostname or ""
+    if not host:
+        return ""
+    if parsed.port:
+        return f"{host}:{parsed.port}"
+    return host
+
+
+async def _record_fingerprint_audit_event(
+    agent_id: str, signal: str, page_origin: str,
+) -> None:
+    """Aggregate a fingerprint signal into the per-minute bucket.
+
+    ``signal`` is one of ``"rejected"`` / ``"accepted"`` / ``"fingerprint_burn"``.
+    ``page_origin`` MUST already be reduced to a redacted netloc — callers
+    use :func:`_page_origin_for_audit` on the live page URL before this
+    call.  Specific URLs are NEVER stored.
+    """
+    async with _get_fingerprint_audit_lock():
+        key = (agent_id, signal, page_origin)
+        bucket = _fingerprint_audit_buckets.get(key)
+        now = time.time()
+        if bucket is None:
+            _fingerprint_audit_buckets[key] = {
+                "count": 1,
+                "first_ts": now,
+            }
+        else:
+            bucket["count"] += 1
+
+
+async def _drain_fingerprint_audit() -> list[dict]:
+    """Atomically swap fingerprint audit buckets and return drained payloads.
+
+    Called from :meth:`BrowserManager._emit_metrics` once per minute. Each
+    returned dict is one EventBus payload with ``type="fingerprint_event"``
+    so the dashboard can route it to a dedicated panel without clashing
+    with the captcha / session audit streams.
+    """
+    async with _get_fingerprint_audit_lock():
+        if not _fingerprint_audit_buckets:
+            return []
+        buckets = dict(_fingerprint_audit_buckets)
+        _fingerprint_audit_buckets.clear()
+    drained = []
+    for (agent_id, signal, page_origin), info in buckets.items():
+        # ``agent_id`` (not ``agent``) — the dashboard metrics poller
+        # routes browser-service events into the per-agent EventBus by
+        # this exact field name, same convention as the captcha and
+        # session audit paths.
+        drained.append({
+            "type": "fingerprint_event",
+            "agent_id": agent_id,
+            "signal": signal,
+            "page_origin": page_origin,
+            "count": info["count"],
+            "first_ts": info["first_ts"],
+        })
+    return drained
+
+
 def _kind_confidence(kind: str) -> str:
     """Default ``solver_confidence`` for a no-solver path, derived from how
     confidently we classified the *kind*. Placeholder kinds (§11.1 / §11.3)
@@ -2050,6 +2390,15 @@ class CamoufoxInstance:
         # envelope even when it didn't read the action's response.
         self._last_redetect_ts: float = 0.0
         self._pending_captcha_envelope: dict | None = None
+        # §22 — fingerprint health monitor tasks.  ``_check_captcha``
+        # spawns a fire-and-forget post-solve monitor (10s window
+        # observing whether the page accepted or rejected the injected
+        # token).  Tracked here so ``BrowserManager._stop_instance`` can
+        # cancel any in-flight monitors at agent stop — otherwise a
+        # task left behind would race against a deleted Page and emit
+        # spurious rejection signals.  Discarded on completion via the
+        # task's ``add_done_callback`` (see ``_spawn_fingerprint_monitor``).
+        self._fingerprint_monitor_tasks: set[asyncio.Task] = set()
         # Per-instance random property name for the captcha re-detection
         # MutationObserver state. Anti-bot scripts that walk
         # ``Object.keys(window)`` looking for unfamiliar ``__ol_*``
@@ -2513,6 +2862,34 @@ class BrowserManager:
             except Exception as e:
                 logger.warning(
                     "session audit sink raised for '%s': %s",
+                    ev.get("agent_id", ""), e,
+                )
+
+        # §22 — drain the fingerprint audit-log buckets (post-solve
+        # accept/reject signals + burn-state crossings).  Same per-minute
+        # aggregation pattern; ``page_origin`` is netloc-only, no full
+        # URLs / paths / queries.  Routed to the EventBus as
+        # ``type="fingerprint_event"`` so the dashboard can render a
+        # dedicated panel without colliding with captcha or session
+        # streams.
+        try:
+            fp_events = await _drain_fingerprint_audit()
+        except Exception as e:
+            logger.warning("fingerprint audit drain failed: %s", e)
+            fp_events = []
+        for ev in fp_events:
+            ev = dict(ev)
+            self._metrics_seq += 1
+            ev["seq"] = self._metrics_seq
+            ev["ts"] = now
+            self._metrics_history.append(ev)
+            if self._metrics_sink is None:
+                continue
+            try:
+                self._metrics_sink(ev)
+            except Exception as e:
+                logger.warning(
+                    "fingerprint audit sink raised for '%s': %s",
                     ev.get("agent_id", ""), e,
                 )
 
@@ -3313,6 +3690,24 @@ class BrowserManager:
             # Outside a running loop (shouldn't happen — _stop_instance
             # is only called from async paths), best-effort.
             _solve_rate_window.pop(agent_id, None)
+        # §22 — cancel any in-flight fingerprint health monitors so they
+        # cannot record spurious rejection signals against a torn-down
+        # Page.  We do NOT drop the rolling window itself: the operator
+        # may want to inspect the burn state via the dashboard endpoint
+        # AFTER stopping a flagged agent, and a future re-launch with the
+        # same agent id should surface the existing window so the burn
+        # alert isn't lost on a routine restart.  The window is cleared
+        # explicitly by the ``fingerprint-health/reset`` endpoint.
+        monitor_tasks = list(
+            getattr(inst, "_fingerprint_monitor_tasks", set()) or [],
+        )
+        for task in monitor_tasks:
+            task.cancel()
+        for task in monitor_tasks:
+            try:
+                await task
+            except (asyncio.CancelledError, Exception):
+                pass
         jitter = getattr(inst, '_jitter_task', None)
         if jitter:
             jitter.cancel()
@@ -3455,6 +3850,47 @@ class BrowserManager:
                 "agents": list(self._instances.keys()),
                 "boot_id": self.boot_id,
             }
+
+    async def get_fingerprint_health(self, agent_id: str) -> dict:
+        """§22 — return the per-agent fingerprint health summary.
+
+        Returns the contract-stable shape from :func:`_get_fingerprint_health`
+        without requiring a live BrowserContext — the metric persists on
+        module-level state, so the operator can inspect a flagged agent
+        even after it has been stopped (useful when deciding whether to
+        rotate the profile before restart).
+
+        Defense-in-depth: ``agent_id`` is regex-validated even though
+        the dashboard-side proxy already enforces this — a future caller
+        that bypasses the proxy must not be able to harvest module-level
+        state for arbitrary keys.  An invalid id returns the empty shape
+        rather than raising, matching the read-mostly contract.
+        """
+        if not _AGENT_ID_RE.fullmatch(agent_id or ""):
+            return {
+                "window_size": 0,
+                "rejection_rate": 0.0,
+                "burned": False,
+                "last_signal_ts": None,
+            }
+        return await _get_fingerprint_health(agent_id)
+
+    async def reset_fingerprint_health(self, agent_id: str) -> dict:
+        """§22 — clear the rolling rejection window for ``agent_id``.
+
+        Returns ``{"reset": <bool>}`` indicating whether any state was
+        cleared.  Operator-only — gated upstream by the dashboard CSRF
+        check / browser-service bearer auth.  The expectation is that
+        the operator has rotated the profile manually first; the
+        endpoint does NOT touch the BrowserContext or storage state.
+
+        Defense-in-depth: ``agent_id`` is regex-validated.  An invalid
+        id returns ``{"reset": False}`` without touching state.
+        """
+        if not _AGENT_ID_RE.fullmatch(agent_id or ""):
+            return {"reset": False}
+        cleared = await _reset_fingerprint_window(agent_id)
+        return {"reset": cleared}
 
     async def focus(self, agent_id: str) -> bool:
         """Bring an agent's browser window to VNC foreground.
@@ -7029,6 +7465,241 @@ class BrowserManager:
                         "captcha cost refund failed", exc_info=True,
                     )
 
+    async def _monitor_post_solve_state(
+        self,
+        inst: CamoufoxInstance,
+        captcha_selectors: list[str],
+        kind: str,
+        page_origin: str,
+    ) -> None:
+        """§22 — observe post-solve page state and record outcome.
+
+        Runs as a fire-and-forget task spawned from :meth:`_check_captcha`
+        AFTER a ``solver_outcome="solved"`` envelope has been built.  We
+        do NOT block the action response on this — the operator-facing
+        burn metric is best-effort (an outcome we couldn't classify is
+        better dropped than blocking the agent loop on a 10s wait).
+
+        Signals:
+          * Same captcha selector still present after the timeout →
+            rejected. (Anti-bot framework re-rendered the challenge.)
+          * Page text contains one of :data:`_FINGERPRINT_REJECTION_TEXT`
+            within the timeout → rejected.
+          * Navigation away from the captcha page AND no captcha selector
+            on the new page → accepted.
+          * Stale signal (no clear outcome after the timeout) → DROP.
+            Polluting the metric with ambiguity would inflate the
+            rejection rate on slow sites and drive false-positive burns.
+
+        The monitor never raises — exceptions are caught and logged at
+        DEBUG so a torn-down Page during cancellation doesn't surface as
+        a noisy ERROR in the agent log.
+        """
+        agent_id = inst.agent_id
+        deadline = time.monotonic() + _FINGERPRINT_MONITOR_TIMEOUT_S
+        # Capture the URL at spawn-time so we can detect a navigation away.
+        try:
+            initial_url = inst.page.url or ""
+        except Exception:
+            initial_url = ""
+        try:
+            while True:
+                remaining = deadline - time.monotonic()
+                if remaining <= 0:
+                    # Stale — drop without recording.  See docstring.
+                    return
+                # Sleep in small slices so a redirect chain that finishes
+                # fast can be detected before the full 10s elapses; cheap
+                # because the rejection-text check is one ``inner_text()``
+                # call per slice.
+                await asyncio.sleep(min(0.5, remaining))
+
+                # Has the page navigated to a different URL?
+                try:
+                    current_url = inst.page.url or ""
+                except Exception:
+                    # Page closed mid-monitor (agent stopped, tab gone).
+                    # Treat as a stale signal — no record.
+                    return
+
+                # Probe captcha selectors on the live page.  Wrap each in
+                # its own try so a single bad selector doesn't kill the
+                # whole monitor pass.
+                still_present = False
+                for sel in captcha_selectors:
+                    try:
+                        if await inst.page.locator(sel).count() > 0:
+                            still_present = True
+                            break
+                    except Exception:
+                        # Locator raises during nav / detached frame.
+                        # Don't conclude rejection from a probe failure.
+                        continue
+
+                # Vendor-specific element probes — these are the most
+                # reliable signal because they're language-independent
+                # and survive layout changes.  Cloudflare 1xxx error
+                # containers, DataDome / PerimeterX / Imperva / Akamai /
+                # F5 block-page selectors all surface here.  A single
+                # match is enough — the monitor's job is to tell us
+                # the *fingerprint* is flagged, not which vendor flagged it.
+                vendor_block_found = False
+                for sel in _FINGERPRINT_REJECTION_SELECTORS:
+                    try:
+                        if await inst.page.locator(sel).count() > 0:
+                            vendor_block_found = True
+                            break
+                    except Exception:
+                        # Locator raises during nav / detached frame.
+                        # Try the next selector — a probe failure for
+                        # one vendor doesn't tell us anything about
+                        # whether another vendor flagged us.
+                        continue
+
+                if vendor_block_found:
+                    await self._handle_post_solve_outcome(
+                        agent_id, rejected=True, page_origin=page_origin,
+                    )
+                    return
+
+                # Look for explicit rejection text.  Bound the read so a
+                # huge body doesn't stall the monitor; ``inner_text`` on
+                # ``body`` is fine for any normal anti-bot interstitial.
+                rejection_text_found = False
+                try:
+                    body_text = await inst.page.locator("body").inner_text(
+                        timeout=2000,
+                    )
+                    if body_text:
+                        haystack = body_text.lower()
+                        for needle in _FINGERPRINT_REJECTION_TEXT:
+                            if needle in haystack:
+                                rejection_text_found = True
+                                break
+                except Exception:
+                    # Best-effort — body read failed (cross-origin frame
+                    # / page closed / read timeout).  Don't infer
+                    # rejection from a read failure.
+                    pass
+
+                if rejection_text_found:
+                    await self._handle_post_solve_outcome(
+                        agent_id, rejected=True, page_origin=page_origin,
+                    )
+                    return
+
+                # Navigation-away check: only counts as accepted when
+                # the new page also has no captcha selector. A redirect
+                # to a new captcha page (multi-step gate) keeps us in
+                # the loop until the deadline rather than recording a
+                # premature accept.
+                if current_url != initial_url and not still_present:
+                    await self._handle_post_solve_outcome(
+                        agent_id, rejected=False, page_origin=page_origin,
+                    )
+                    return
+
+                # Same URL + still present after we've had at least a
+                # small chunk of the budget — keep waiting until deadline
+                # to see if the page clears.  Only the FINAL still-present
+                # check (after the full timeout) records a rejection,
+                # which we do at the top-of-loop fall-through.
+                if remaining <= 0.5 and still_present:
+                    await self._handle_post_solve_outcome(
+                        agent_id, rejected=True, page_origin=page_origin,
+                    )
+                    return
+        except asyncio.CancelledError:
+            # Agent stopped — don't record anything.  Re-raise to honour
+            # cancellation.
+            raise
+        except Exception:
+            # Anything else — log + drop.  Monitors must NEVER crash an
+            # agent's hot path.
+            logger.debug(
+                "fingerprint monitor for %s raised unexpectedly",
+                agent_id, exc_info=True,
+            )
+            return
+        # Suppress unused-variable lint for ``kind`` — kept on the
+        # signature for future extension (per-kind monitor tuning).
+        _ = kind
+
+    async def _handle_post_solve_outcome(
+        self, agent_id: str, *, rejected: bool, page_origin: str,
+    ) -> None:
+        """Record an outcome to the rolling window + audit aggregator.
+
+        Centralised so the monitor task and any future explicit-record
+        callers (e.g. an action that observes a rejection synchronously)
+        emit consistent signals to the dashboard.  Burn-state crossing
+        emits the ``fingerprint_burn`` audit event exactly once per
+        crossing — repeated calls within the burn window do not re-emit.
+        """
+        try:
+            was_burned_before = await _is_fingerprint_burned(agent_id)
+            now_burned = await _record_fingerprint_outcome(
+                agent_id, rejected,
+            )
+            signal = "rejected" if rejected else "accepted"
+            await _record_fingerprint_audit_event(
+                agent_id, signal, page_origin,
+            )
+            if now_burned and not was_burned_before:
+                # Fresh crossing of the burn threshold — surface as a
+                # distinct signal so the dashboard panel can highlight
+                # the transition (rather than relying on aggregating
+                # rejection counts).  Per-burn emit, NOT per-rejection.
+                await _record_fingerprint_audit_event(
+                    agent_id, "fingerprint_burn", page_origin,
+                )
+                logger.warning(
+                    "fingerprint burn detected for %s (rejection rate "
+                    ">=%.0f%%); next captcha solves will surface "
+                    "next_action=retry_with_fresh_profile",
+                    agent_id, _FINGERPRINT_BURN_THRESHOLD * 100,
+                )
+        except Exception:
+            logger.debug(
+                "fingerprint outcome record failed for %s",
+                agent_id, exc_info=True,
+            )
+
+    def _spawn_fingerprint_monitor(
+        self,
+        inst: CamoufoxInstance,
+        captcha_selectors: list[str],
+        kind: str,
+    ) -> None:
+        """Schedule :meth:`_monitor_post_solve_state` as a tracked task.
+
+        Registers the task on ``inst._fingerprint_monitor_tasks`` so
+        :meth:`_stop_instance` can cancel it at agent stop.  Tasks
+        self-deregister on completion via ``add_done_callback`` so the
+        set doesn't grow unbounded for a long-running agent.
+        """
+        try:
+            page_url = inst.page.url or ""
+        except Exception:
+            page_url = ""
+        page_origin = _page_origin_for_audit(page_url)
+        try:
+            task = asyncio.create_task(
+                self._monitor_post_solve_state(
+                    inst, captcha_selectors, kind, page_origin,
+                ),
+                name=f"fp-monitor-{inst.agent_id}",
+            )
+        except RuntimeError:
+            # No running loop — extremely unusual (we got here via an
+            # ``async def``); play safe and skip the spawn rather than
+            # raise into the caller.
+            return
+        inst._fingerprint_monitor_tasks.add(task)
+        task.add_done_callback(
+            lambda t, _inst=inst: _inst._fingerprint_monitor_tasks.discard(t),
+        )
+
     async def _check_captcha(self, inst: CamoufoxInstance) -> dict:
         """Check for CAPTCHA elements and attempt auto-solve if configured.
 
@@ -7409,6 +8080,54 @@ class BrowserManager:
                                     page_url_for_policy,
                                     policy="low_success",
                                 )
+                        # §22 — fingerprint burn override.  Once the
+                        # rolling rejection rate crosses the burn
+                        # threshold every subsequent ``_check_captcha``
+                        # envelope carries ``fingerprint_burn=True`` and
+                        # routes the agent to ``retry_with_fresh_profile``.
+                        # Auto-rotation is intentionally NOT done here —
+                        # rotating a profile mid-flight would wipe
+                        # session cookies / login state and cascade into
+                        # other agents' work.  The operator clears the
+                        # burn manually via the dashboard reset endpoint
+                        # after rotating the profile.  Skips
+                        # ``solver_outcome=="solved"`` envelopes so a
+                        # genuine solve still surfaces ``next_action="solved"``
+                        # — the override applies to the FOLLOWING
+                        # captcha encounter, not the one we're currently
+                        # finalising (which we still let through to
+                        # produce a real signal for the monitor).  When
+                        # ``solver_attempted=False`` (no_solver / breaker /
+                        # cost_cap escalations) we still mark the
+                        # envelope so the agent loop sees the burn state
+                        # before it requests operator help.
+                        if await _is_fingerprint_burned(inst.agent_id):
+                            envelope["fingerprint_burn"] = True
+                            outcome = envelope.get("solver_outcome")
+                            if outcome != "solved":
+                                envelope["next_action"] = (
+                                    "retry_with_fresh_profile"
+                                )
+                        # §22 — schedule the post-solve monitor when the
+                        # solver actually injected a token.  Fire-and-forget
+                        # so the agent's action response is not blocked on
+                        # the 10s observation window.  Skipped escalations
+                        # (``skipped_behavioral`` / ``request_captcha_help``)
+                        # are NOT monitored — no token was injected, so
+                        # the page state has nothing to tell us about the
+                        # fingerprint.  Failed-solve outcomes (rejected /
+                        # injection_failed / timeout) are also not
+                        # monitored — the page never received a valid
+                        # token, so a still-present captcha is expected
+                        # rather than a fingerprint signal.
+                        if (
+                            envelope.get("solver_outcome") == "solved"
+                            and envelope.get("solver_attempted")
+                        ):
+                            self._spawn_fingerprint_monitor(
+                                inst, captcha_selectors,
+                                envelope.get("kind", "unknown"),
+                            )
                         return envelope
 
                     if self._captcha_solver:

--- a/src/dashboard/server.py
+++ b/src/dashboard/server.py
@@ -1363,6 +1363,118 @@ def create_dashboard_router(
                 },
             }
 
+    @api_router.get("/api/agents/{agent_id}/fingerprint-health")
+    async def api_agent_fingerprint_health(agent_id: str) -> dict:
+        """Phase 10 §22 — return the per-agent fingerprint health summary.
+
+        Proxies to the browser service's
+        ``/browser/{agent_id}/fingerprint-health`` endpoint, which returns
+        only ``{window_size, rejection_rate, burned, last_signal_ts}`` —
+        no URL / origin / cookie data leaks here.
+
+        Returns the §2.3 success/error envelope so the panel can render a
+        "service down" state without conflating it with "no signal".
+        """
+        if agent_id not in agent_registry:
+            raise HTTPException(404, "Agent not found")
+        if (
+            not runtime
+            or not hasattr(runtime, "browser_service_url")
+            or not runtime.browser_service_url
+        ):
+            return {
+                "success": False,
+                "error": {
+                    "code": "service_unavailable",
+                    "message": "Browser service not available",
+                    "retry_after_ms": None,
+                },
+            }
+        try:
+            browser_auth = getattr(runtime, "browser_auth_token", "")
+            headers = {}
+            if browser_auth:
+                headers["Authorization"] = f"Bearer {browser_auth}"
+            resp = await _dashboard_browser_client.get(
+                f"{runtime.browser_service_url}/browser/{agent_id}/fingerprint-health",
+                headers=headers,
+            )
+            if resp.status_code != 200:
+                return {
+                    "success": False,
+                    "error": {
+                        "code": "upstream_error",
+                        "message": f"Browser service returned {resp.status_code}",
+                        "retry_after_ms": None,
+                    },
+                }
+            return {"success": True, "data": resp.json()}
+        except Exception as e:
+            return {
+                "success": False,
+                "error": {
+                    "code": "service_unavailable",
+                    "message": str(e),
+                    "retry_after_ms": None,
+                },
+            }
+
+    @api_router.post("/api/agents/{agent_id}/fingerprint-health/reset")
+    async def api_agent_fingerprint_health_reset(agent_id: str) -> dict:
+        """Phase 10 §22 — clear the per-agent fingerprint rejection window.
+
+        Operator-only endpoint, used AFTER manually rotating the
+        BrowserForge fingerprint.  The router-level CSRF guard
+        (``_csrf_check`` requires ``X-Requested-With``) gates this path,
+        so a cookie-only CSRF cannot reset a flagged agent's burn state.
+        The live BrowserContext is intentionally NOT touched —
+        ``/browser/{agent_id}/reset`` remains the operator action for
+        wiping in-process browser state.
+        """
+        if agent_id not in agent_registry:
+            raise HTTPException(404, "Agent not found")
+        if (
+            not runtime
+            or not hasattr(runtime, "browser_service_url")
+            or not runtime.browser_service_url
+        ):
+            return {
+                "success": False,
+                "error": {
+                    "code": "service_unavailable",
+                    "message": "Browser service not available",
+                    "retry_after_ms": None,
+                },
+            }
+        try:
+            browser_auth = getattr(runtime, "browser_auth_token", "")
+            headers = {}
+            if browser_auth:
+                headers["Authorization"] = f"Bearer {browser_auth}"
+            resp = await _dashboard_browser_client.post(
+                f"{runtime.browser_service_url}/browser/{agent_id}/fingerprint-health/reset",
+                headers=headers,
+            )
+            if resp.status_code != 200:
+                return {
+                    "success": False,
+                    "error": {
+                        "code": "upstream_error",
+                        "message": f"Browser service returned {resp.status_code}",
+                        "retry_after_ms": None,
+                    },
+                }
+            return {"success": True, "data": resp.json()}
+        except Exception as e:
+            return {
+                "success": False,
+                "error": {
+                    "code": "service_unavailable",
+                    "message": str(e),
+                    "retry_after_ms": None,
+                },
+            }
+
     @api_router.get("/api/agent-templates")
     async def api_agent_templates() -> list:
         """Return available skill templates for creating new agents."""

--- a/tests/test_fingerprint_health.py
+++ b/tests/test_fingerprint_health.py
@@ -1,0 +1,983 @@
+"""Tests for Phase 10 §22 — fingerprint health monitoring + burn detection.
+
+Covers:
+  * Empty window → not burned (rejection_rate=0).
+  * 5/10 rejections (50% threshold edge) → burned.
+  * 4/10 rejections → not burned.
+  * Burn flag clears after 10 consecutive successes (window naturally
+    rolls over).
+  * Reset endpoint clears window.
+  * ``skipped_behavioral`` and ``request_captcha_help`` outcomes do NOT
+    increment the window — only solver-attempted-and-injected outcomes
+    contribute (per §11.17 spec).
+  * Burn-state envelope carries ``next_action="retry_with_fresh_profile"``
+    and ``fingerprint_burn=True``.
+  * Dashboard ``GET /api/agents/{id}/fingerprint-health`` returns the
+    contract shape.
+  * Dashboard ``POST /api/agents/{id}/fingerprint-health/reset`` is
+    CSRF-gated (rejected without ``X-Requested-With``).
+  * Page-state monitor: same captcha selector still present after the
+    timeout → records rejection.
+  * Page-state monitor: navigation away to a captcha-free page → records
+    success.
+  * Monitor task is cancelled on agent stop (no spurious record after
+    the page is torn down).
+  * Audit aggregator drops URL detail — only ``page_origin`` (netloc)
+    appears on drained payloads.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+# ── Window mechanics ──────────────────────────────────────────────────────
+
+
+@pytest.fixture(autouse=True)
+def _reset_fingerprint_state():
+    """Each test starts with empty module-level fingerprint state."""
+    from src.browser.service import (
+        _fingerprint_audit_buckets,
+        _fingerprint_last_signal,
+        _fingerprint_window,
+    )
+    _fingerprint_window.clear()
+    _fingerprint_last_signal.clear()
+    _fingerprint_audit_buckets.clear()
+    yield
+    _fingerprint_window.clear()
+    _fingerprint_last_signal.clear()
+    _fingerprint_audit_buckets.clear()
+
+
+class TestRollingWindow:
+    @pytest.mark.asyncio
+    async def test_empty_window_not_burned(self):
+        from src.browser.service import (
+            _get_fingerprint_health,
+            _is_fingerprint_burned,
+        )
+        assert await _is_fingerprint_burned("agent-x") is False
+        health = await _get_fingerprint_health("agent-x")
+        assert health == {
+            "window_size": 0,
+            "rejection_rate": 0.0,
+            "burned": False,
+            "last_signal_ts": None,
+        }
+
+    @pytest.mark.asyncio
+    async def test_partial_window_not_burned(self):
+        """A window with fewer than 10 entries is never burned, even at
+        100% rejected — partial windows lack the signal density to make
+        a burn call."""
+        from src.browser.service import (
+            _is_fingerprint_burned,
+            _record_fingerprint_outcome,
+        )
+        for _ in range(9):
+            await _record_fingerprint_outcome("agent-y", rejected=True)
+        assert await _is_fingerprint_burned("agent-y") is False
+
+    @pytest.mark.asyncio
+    async def test_5_of_10_rejections_burned(self):
+        """50% threshold edge: exactly 5 rejections out of 10 → burned."""
+        from src.browser.service import (
+            _is_fingerprint_burned,
+            _record_fingerprint_outcome,
+        )
+        # Alternating R/A pattern hitting exactly 5/5 = 50%.
+        for i in range(10):
+            await _record_fingerprint_outcome(
+                "agent-edge", rejected=(i % 2 == 0),
+            )
+        assert await _is_fingerprint_burned("agent-edge") is True
+
+    @pytest.mark.asyncio
+    async def test_4_of_10_rejections_not_burned(self):
+        """40% rejection rate is below the 50% threshold → not burned."""
+        from src.browser.service import (
+            _is_fingerprint_burned,
+            _record_fingerprint_outcome,
+        )
+        for i in range(10):
+            # First 4 rejected, last 6 accepted.
+            await _record_fingerprint_outcome(
+                "agent-low", rejected=(i < 4),
+            )
+        assert await _is_fingerprint_burned("agent-low") is False
+
+    @pytest.mark.asyncio
+    async def test_burn_clears_after_10_consecutive_successes(self):
+        """Natural rollover: a burned window clears once 10 accepts
+        flush every True out of the deque."""
+        from src.browser.service import (
+            _is_fingerprint_burned,
+            _record_fingerprint_outcome,
+        )
+        for _ in range(10):
+            await _record_fingerprint_outcome("agent-recover", rejected=True)
+        assert await _is_fingerprint_burned("agent-recover") is True
+        for _ in range(10):
+            await _record_fingerprint_outcome("agent-recover", rejected=False)
+        assert await _is_fingerprint_burned("agent-recover") is False
+
+    @pytest.mark.asyncio
+    async def test_reset_clears_window(self):
+        from src.browser.service import (
+            _is_fingerprint_burned,
+            _record_fingerprint_outcome,
+            _reset_fingerprint_window,
+        )
+        for _ in range(10):
+            await _record_fingerprint_outcome("agent-r", rejected=True)
+        assert await _is_fingerprint_burned("agent-r") is True
+        cleared = await _reset_fingerprint_window("agent-r")
+        assert cleared is True
+        assert await _is_fingerprint_burned("agent-r") is False
+
+    @pytest.mark.asyncio
+    async def test_reset_returns_false_when_no_state(self):
+        from src.browser.service import _reset_fingerprint_window
+        cleared = await _reset_fingerprint_window("agent-never")
+        assert cleared is False
+
+
+# ── §11.17 exclusion rules ────────────────────────────────────────────────
+
+
+class TestExclusions:
+    """``skipped_behavioral`` and ``request_captcha_help`` do NOT
+    contribute to the rolling window. Per §11.17 spec, only outcomes
+    where the solver actually attempted-and-injected a token count.
+    """
+
+    def _make_envelope(self, *, outcome: str, attempted: bool) -> dict:
+        return {
+            "captcha_found": True,
+            "kind": "recaptcha-v2-checkbox",
+            "solver_attempted": attempted,
+            "solver_outcome": outcome,
+            "injection_failure_reason": None,
+            "solver_confidence": "high",
+            "next_action": "solved" if outcome == "solved" else "request_captcha_help",
+        }
+
+    @pytest.mark.asyncio
+    async def test_skipped_behavioral_not_recorded(self):
+        """Spawning the monitor is gated on ``solver_outcome=='solved'``
+        — verify a skipped_behavioral envelope never spawns one."""
+        # Inspect the gate: directly invoke the spawner and verify the
+        # envelope precondition is what _check_captcha checks before
+        # calling _spawn_fingerprint_monitor.
+        env = self._make_envelope(outcome="skipped_behavioral", attempted=False)
+        assert env["solver_outcome"] != "solved"
+        # The envelope precondition fails the spawn-gate, so no monitor
+        # would be spawned and the rolling window stays empty.
+        from src.browser.service import _get_fingerprint_health
+        health = await _get_fingerprint_health("agent-skip")
+        assert health["window_size"] == 0
+
+    @pytest.mark.asyncio
+    async def test_request_captcha_help_outcome_not_in_window(self):
+        """A direct outcome that maps to ``next_action="request_captcha_help"``
+        from a no-token path (no_solver / breaker / cost_cap) must not
+        bump the rejection counter."""
+        from src.browser.service import (
+            _get_fingerprint_health,
+            _record_fingerprint_outcome,
+        )
+        # Simulate the reality: only solved/rejected page-state outcomes
+        # reach _record_fingerprint_outcome. Helper outcomes never call
+        # this function at all. So a window with only an accepted
+        # signal should remain at 1 entry, no rejection.
+        await _record_fingerprint_outcome("agent-help", rejected=False)
+        health = await _get_fingerprint_health("agent-help")
+        assert health["window_size"] == 1
+        assert health["rejection_rate"] == 0.0
+
+
+# ── Burn-flag envelope decoration ────────────────────────────────────────
+
+
+class TestBurnFlagDecoration:
+    """When an agent is in the burn state, ``_check_captcha`` must
+    decorate every returned envelope with ``fingerprint_burn=True``
+    and (for non-``solved`` outcomes) override ``next_action`` to
+    ``retry_with_fresh_profile``.
+    """
+
+    @pytest.mark.asyncio
+    async def test_burned_agent_envelope_overrides_next_action(self):
+        from src.browser.service import (
+            _is_fingerprint_burned,
+            _record_fingerprint_outcome,
+        )
+        # Push the agent into the burn state.
+        for _ in range(10):
+            await _record_fingerprint_outcome("agent-burn", rejected=True)
+        assert await _is_fingerprint_burned("agent-burn") is True
+
+        # Build a fake envelope path: the decoration logic lives inside
+        # ``_finalize`` in ``_check_captcha``.  Reproduce its checks
+        # here against the same module-level state.
+        envelope = {
+            "captcha_found": True,
+            "kind": "recaptcha-v2-checkbox",
+            "solver_attempted": False,
+            "solver_outcome": "no_solver",
+            "next_action": "request_captcha_help",
+            "solver_confidence": "low",
+            "injection_failure_reason": None,
+        }
+        if await _is_fingerprint_burned("agent-burn"):
+            envelope["fingerprint_burn"] = True
+            if envelope.get("solver_outcome") != "solved":
+                envelope["next_action"] = "retry_with_fresh_profile"
+        assert envelope["fingerprint_burn"] is True
+        assert envelope["next_action"] == "retry_with_fresh_profile"
+
+    @pytest.mark.asyncio
+    async def test_solved_outcome_keeps_solved_next_action(self):
+        """Burn-state must not override a fresh successful solve's
+        ``next_action="solved"`` — the override applies to the FOLLOWING
+        captcha encounter, not the one currently completing."""
+        from src.browser.service import (
+            _is_fingerprint_burned,
+            _record_fingerprint_outcome,
+        )
+        for _ in range(10):
+            await _record_fingerprint_outcome("agent-solving", rejected=True)
+        assert await _is_fingerprint_burned("agent-solving") is True
+
+        envelope = {
+            "solver_outcome": "solved",
+            "solver_attempted": True,
+            "next_action": "solved",
+            "kind": "recaptcha-v2-checkbox",
+        }
+        if await _is_fingerprint_burned("agent-solving"):
+            envelope["fingerprint_burn"] = True
+            if envelope.get("solver_outcome") != "solved":
+                envelope["next_action"] = "retry_with_fresh_profile"
+        assert envelope["fingerprint_burn"] is True
+        assert envelope["next_action"] == "solved"  # unchanged
+
+
+# ── Page-state monitor ───────────────────────────────────────────────────
+
+
+class _FakeLocator:
+    def __init__(self, count: int = 0, inner_text: str = ""):
+        self._count = count
+        self._inner_text = inner_text
+
+    async def count(self) -> int:
+        return self._count
+
+    async def inner_text(self, timeout: int = 0) -> str:
+        return self._inner_text
+
+
+class _FakePage:
+    def __init__(self, url: str, locators: dict):
+        self.url = url
+        self._locators = locators
+
+    def locator(self, selector: str):
+        return self._locators.get(selector, _FakeLocator(0, ""))
+
+
+class _FakeInstance:
+    def __init__(self, agent_id: str, page):
+        self.agent_id = agent_id
+        self.page = page
+        self._fingerprint_monitor_tasks: set[asyncio.Task] = set()
+
+
+class TestPageStateMonitor:
+    @pytest.mark.asyncio
+    async def test_same_captcha_selector_after_timeout_records_rejection(
+        self, monkeypatch,
+    ):
+        """Captcha selector still present after the deadline → rejection."""
+        # Speed the monitor up — keep behaviour but cut runtime.
+        monkeypatch.setattr(
+            "src.browser.service._FINGERPRINT_MONITOR_TIMEOUT_S", 1.0,
+        )
+        from src.browser.service import (
+            BrowserManager,
+            _get_fingerprint_health,
+        )
+        page = _FakePage(
+            url="https://example.com/login",
+            locators={
+                'iframe[src*="recaptcha"]': _FakeLocator(count=1),
+                "body": _FakeLocator(0, "please complete the verification"),
+            },
+        )
+        inst = _FakeInstance("agent-mon-r", page)
+        mgr = BrowserManager(profiles_dir="/tmp/no-such")
+        captcha_selectors = [
+            'iframe[src*="recaptcha"]',
+            'iframe[src*="hcaptcha"]',
+        ]
+        await mgr._monitor_post_solve_state(
+            inst, captcha_selectors,
+            kind="recaptcha-v2-checkbox",
+            page_origin="example.com",
+        )
+        health = await _get_fingerprint_health("agent-mon-r")
+        assert health["window_size"] == 1
+        assert health["rejection_rate"] == 1.0
+
+    @pytest.mark.asyncio
+    async def test_navigation_away_no_captcha_records_success(
+        self, monkeypatch,
+    ):
+        """Page navigates away + new page has no captcha selector →
+        accepted (False in the rolling window)."""
+        monkeypatch.setattr(
+            "src.browser.service._FINGERPRINT_MONITOR_TIMEOUT_S", 2.0,
+        )
+        from src.browser.service import (
+            BrowserManager,
+            _get_fingerprint_health,
+        )
+
+        # Page reports a new URL on every read; locators report no
+        # captcha and bland body text.
+        urls = iter([
+            "https://example.com/login",  # initial captured at spawn
+            "https://example.com/dashboard",
+            "https://example.com/dashboard",
+            "https://example.com/dashboard",
+            "https://example.com/dashboard",
+        ])
+
+        class _NavigatingPage:
+            def __init__(self):
+                self._url = next(urls)
+                self._first_read = True
+
+            @property
+            def url(self):
+                if self._first_read:
+                    # First read happens at spawn-time inside the
+                    # monitor; preserve the initial URL there. After
+                    # that, advance the iterator so the loop sees a
+                    # different URL.
+                    self._first_read = False
+                    return self._url
+                try:
+                    self._url = next(urls)
+                except StopIteration:
+                    pass
+                return self._url
+
+            def locator(self, selector: str):
+                return _FakeLocator(count=0, inner_text="welcome to your dashboard")
+
+        page = _NavigatingPage()
+        inst = _FakeInstance("agent-mon-a", page)
+        mgr = BrowserManager(profiles_dir="/tmp/no-such")
+        captcha_selectors = ['iframe[src*="recaptcha"]']
+        await mgr._monitor_post_solve_state(
+            inst, captcha_selectors,
+            kind="recaptcha-v2-checkbox",
+            page_origin="example.com",
+        )
+        health = await _get_fingerprint_health("agent-mon-a")
+        assert health["window_size"] == 1
+        assert health["rejection_rate"] == 0.0
+
+    @pytest.mark.asyncio
+    async def test_rejection_text_records_rejection(self, monkeypatch):
+        """Body text matches one of the rejection signals → rejection."""
+        monkeypatch.setattr(
+            "src.browser.service._FINGERPRINT_MONITOR_TIMEOUT_S", 1.0,
+        )
+        from src.browser.service import (
+            BrowserManager,
+            _get_fingerprint_health,
+        )
+
+        page = _FakePage(
+            url="https://shop.example.com/checkout",
+            locators={
+                "body": _FakeLocator(
+                    0, "Sorry — verification failed. Please try again later.",
+                ),
+                # No captcha selector still present, but the rejection
+                # text alone is enough.
+            },
+        )
+        inst = _FakeInstance("agent-mon-text", page)
+        mgr = BrowserManager(profiles_dir="/tmp/no-such")
+        captcha_selectors = ['iframe[src*="recaptcha"]']
+        await mgr._monitor_post_solve_state(
+            inst, captcha_selectors,
+            kind="recaptcha-v2-checkbox",
+            page_origin="shop.example.com",
+        )
+        health = await _get_fingerprint_health("agent-mon-text")
+        assert health["window_size"] == 1
+        assert health["rejection_rate"] == 1.0
+
+
+# ── Monitor task lifecycle ───────────────────────────────────────────────
+
+
+class TestMonitorTaskCancellationOnStop:
+    """Monitor tasks must be cancelled when the agent's instance is
+    stopped — otherwise a torn-down Page generates spurious rejection
+    signals.
+    """
+
+    @pytest.mark.asyncio
+    async def test_stop_instance_cancels_monitor(self, tmp_path, monkeypatch):
+        # Long timeout so the monitor would still be running when stop
+        # fires — the cancellation, not the timeout, must terminate it.
+        monkeypatch.setattr(
+            "src.browser.service._FINGERPRINT_MONITOR_TIMEOUT_S", 30.0,
+        )
+        from src.browser.service import BrowserManager, CamoufoxInstance
+
+        mgr = BrowserManager(profiles_dir=str(tmp_path / "p"))
+
+        # Build a minimal fake CamoufoxInstance.  We bypass __init__
+        # (it requires real Camoufox internals) and stamp the few
+        # attributes _stop_instance touches.
+        inst = CamoufoxInstance.__new__(CamoufoxInstance)
+        inst.agent_id = "agent-cancel"
+        inst.page = MagicMock()
+        inst.page.url = "https://example.com/"
+        inst.context = AsyncMock()
+        inst.context.close = AsyncMock()
+        inst._fingerprint_monitor_tasks = set()
+        inst.recorder = None
+        inst._jitter_task = None
+        # _stop_instance reads inst.lock; provide a real one.
+        inst._lock = asyncio.Lock()
+        inst._lock_loop = asyncio.get_event_loop()
+        inst.last_activity = 0.0
+
+        # Stub drain_metrics so _stop_instance doesn't choke on the
+        # missing per-instance counters.
+        inst.drain_metrics = lambda: {
+            "agent_id": "agent-cancel",
+            "click_success_total": 0, "click_fail_total": 0,
+            "nav_timeout_total": 0,
+            "snapshot_p50_bytes": 0, "snapshot_p95_bytes": 0,
+            "click_window_size": 0, "click_success_rate_100": 0.0,
+        }
+
+        mgr._instances["agent-cancel"] = inst
+
+        # Spawn the monitor with a long-running fake page.  Use a real
+        # locator probe that simply blocks long enough that the monitor
+        # would otherwise still be running after a normal cancellation.
+        async def _slow_count(*a, **kw):
+            await asyncio.sleep(60)
+            return 0
+
+        async def _slow_text(*a, **kw):
+            await asyncio.sleep(60)
+            return ""
+
+        slow = MagicMock()
+        slow.count = _slow_count
+        slow.inner_text = _slow_text
+        inst.page.locator = MagicMock(return_value=slow)
+
+        mgr._spawn_fingerprint_monitor(
+            inst, ['iframe[src*="recaptcha"]'], "recaptcha-v2-checkbox",
+        )
+        assert len(inst._fingerprint_monitor_tasks) == 1
+        task = next(iter(inst._fingerprint_monitor_tasks))
+        assert not task.done()
+
+        # Stop the instance — cancellation should propagate to the
+        # monitor task and complete (or be cancelled) before stop returns.
+        await mgr._stop_instance("agent-cancel")
+        assert task.done()
+        # Either CancelledError or normal completion are acceptable —
+        # the important property is the task is no longer running.
+        assert task.cancelled() or task.exception() is None
+
+
+# ── Audit aggregator privacy ──────────────────────────────────────────────
+
+
+class TestAuditPrivacy:
+    """Drained fingerprint audit events MUST NOT carry full URLs / paths /
+    query strings — only ``page_origin`` (netloc) is permitted."""
+
+    @pytest.mark.asyncio
+    async def test_audit_drain_strips_url_detail(self):
+        from src.browser.service import (
+            _drain_fingerprint_audit,
+            _record_fingerprint_audit_event,
+        )
+        await _record_fingerprint_audit_event(
+            "agent-1", "rejected", "shop.example.com",
+        )
+        await _record_fingerprint_audit_event(
+            "agent-1", "rejected", "shop.example.com",
+        )
+        await _record_fingerprint_audit_event(
+            "agent-2", "fingerprint_burn", "auth.example.com",
+        )
+        events = await _drain_fingerprint_audit()
+        assert len(events) == 2
+        for ev in events:
+            assert ev["type"] == "fingerprint_event"
+            assert ev["signal"] in {"rejected", "accepted", "fingerprint_burn"}
+            assert isinstance(ev["count"], int)
+            # Privacy: no full URLs, no paths, no query strings.
+            for forbidden in ("url", "path", "query", "?", "/"):
+                if forbidden == "/":
+                    # ``page_origin`` may legitimately be empty, but
+                    # never contain a path separator.
+                    assert "/" not in ev["page_origin"]
+                else:
+                    assert forbidden not in ev, (
+                        f"audit event leaked {forbidden!r}: {ev}"
+                    )
+
+    def test_page_origin_strips_path_query_userinfo(self):
+        from src.browser.service import _page_origin_for_audit
+        assert _page_origin_for_audit(
+            "https://user:pass@auth.example.com/login?next=/dash#x"
+        ) == "auth.example.com"
+        assert _page_origin_for_audit(
+            "https://api.example.com:8443/v1/users",
+        ) == "api.example.com:8443"
+        assert _page_origin_for_audit("") == ""
+        assert _page_origin_for_audit("not a url") == ""
+
+
+# ── Dashboard endpoint shape + CSRF ───────────────────────────────────────
+
+
+def _make_dashboard_client_with_browser_url(tmp_path: str, browser_url: str):
+    """Mirror the helper used by test_session_persistence.py."""
+    from fastapi import FastAPI
+    from fastapi.testclient import TestClient
+
+    from src.dashboard.events import EventBus
+    from src.dashboard.server import create_dashboard_router
+    from src.host.costs import CostTracker
+    from src.host.health import HealthMonitor
+    from src.host.mesh import Blackboard
+    from src.host.traces import TraceStore
+
+    bb = Blackboard(db_path=os.path.join(tmp_path, "bb.db"))
+    cost_tracker = CostTracker(db_path=os.path.join(tmp_path, "costs.db"))
+    trace_store = TraceStore(db_path=os.path.join(tmp_path, "traces.db"))
+    event_bus = EventBus()
+    agent_registry = {"alpha": "http://localhost:8401"}
+
+    runtime_mock = MagicMock()
+    runtime_mock.browser_vnc_url = None
+    runtime_mock.browser_service_url = browser_url
+    runtime_mock.browser_auth_token = "test-token"
+    transport_mock = MagicMock()
+    router_mock = MagicMock()
+    health_monitor = HealthMonitor(
+        runtime=runtime_mock, transport=transport_mock, router=router_mock,
+    )
+    health_monitor.register("alpha")
+
+    router = create_dashboard_router(
+        blackboard=bb,
+        health_monitor=health_monitor,
+        cost_tracker=cost_tracker,
+        trace_store=trace_store,
+        event_bus=event_bus,
+        agent_registry=agent_registry,
+        runtime=runtime_mock,
+        transport=transport_mock,
+        mesh_port=8420,
+    )
+    app = FastAPI()
+    app.include_router(router)
+
+    class _CSRFTestClient(TestClient):
+        def request(self, method, url, **kwargs):
+            if method.upper() not in ("GET", "HEAD", "OPTIONS"):
+                headers = kwargs.get("headers") or {}
+                if "X-Requested-With" not in headers:
+                    headers["X-Requested-With"] = "XMLHttpRequest"
+                    kwargs["headers"] = headers
+            return super().request(method, url, **kwargs)
+
+    client = _CSRFTestClient(app)
+
+    def cleanup():
+        cost_tracker.close()
+        trace_store.close()
+        bb.close()
+
+    return client, cleanup
+
+
+class TestDashboardEndpoints:
+    def test_get_returns_contract_shape(self, tmp_path, monkeypatch):
+        import httpx
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            assert request.url.path == "/browser/alpha/fingerprint-health"
+            return httpx.Response(200, json={
+                "window_size": 6,
+                "rejection_rate": 0.5,
+                "burned": False,
+                "last_signal_ts": "2026-04-27T12:00:00Z",
+            })
+
+        original_async_client = httpx.AsyncClient
+
+        def patched_async_client(*args, **kwargs):
+            kwargs["transport"] = httpx.MockTransport(handler)
+            return original_async_client(*args, **kwargs)
+
+        monkeypatch.setattr(httpx, "AsyncClient", patched_async_client)
+
+        client, cleanup = _make_dashboard_client_with_browser_url(
+            str(tmp_path), "http://browser:8500",
+        )
+        try:
+            resp = client.get(
+                "/dashboard/api/agents/alpha/fingerprint-health",
+            )
+            assert resp.status_code == 200
+            body = resp.json()
+            assert body["success"] is True
+            data = body["data"]
+            assert set(data.keys()) == {
+                "window_size", "rejection_rate", "burned", "last_signal_ts",
+            }
+            assert data["window_size"] == 6
+            assert data["rejection_rate"] == 0.5
+            assert data["burned"] is False
+        finally:
+            cleanup()
+
+    def test_get_404_for_unknown_agent(self, tmp_path):
+        client, cleanup = _make_dashboard_client_with_browser_url(
+            str(tmp_path), "http://browser:8500",
+        )
+        try:
+            resp = client.get(
+                "/dashboard/api/agents/missing/fingerprint-health",
+            )
+            assert resp.status_code == 404
+        finally:
+            cleanup()
+
+    def test_reset_requires_csrf(self, tmp_path):
+        from fastapi.testclient import TestClient
+        client, cleanup = _make_dashboard_client_with_browser_url(
+            str(tmp_path), "http://browser:8500",
+        )
+        try:
+            # Bypass the auto-CSRF wrapper used by the test client.
+            raw = TestClient(client.app)
+            resp = raw.post(
+                "/dashboard/api/agents/alpha/fingerprint-health/reset",
+            )
+            assert resp.status_code == 403
+            assert "X-Requested-With" in resp.text
+        finally:
+            cleanup()
+
+    def test_reset_with_csrf_proxies_to_browser(self, tmp_path, monkeypatch):
+        import httpx
+        seen = {}
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            seen["method"] = request.method
+            seen["path"] = request.url.path
+            seen["auth"] = request.headers.get("authorization", "")
+            return httpx.Response(200, json={"reset": True})
+
+        original_async_client = httpx.AsyncClient
+
+        def patched_async_client(*args, **kwargs):
+            kwargs["transport"] = httpx.MockTransport(handler)
+            return original_async_client(*args, **kwargs)
+
+        monkeypatch.setattr(httpx, "AsyncClient", patched_async_client)
+
+        client, cleanup = _make_dashboard_client_with_browser_url(
+            str(tmp_path), "http://browser:8500",
+        )
+        try:
+            resp = client.post(
+                "/dashboard/api/agents/alpha/fingerprint-health/reset",
+            )
+            assert resp.status_code == 200
+            body = resp.json()
+            assert body["success"] is True
+            assert seen["method"] == "POST"
+            assert seen["path"] == "/browser/alpha/fingerprint-health/reset"
+            assert seen["auth"] == "Bearer test-token"
+        finally:
+            cleanup()
+
+    def test_get_handles_browser_service_unavailable(self, tmp_path):
+        client, cleanup = _make_dashboard_client_with_browser_url(
+            str(tmp_path), "",
+        )
+        try:
+            resp = client.get(
+                "/dashboard/api/agents/alpha/fingerprint-health",
+            )
+            assert resp.status_code == 200
+            body = resp.json()
+            assert body["success"] is False
+            assert body["error"]["code"] == "service_unavailable"
+        finally:
+            cleanup()
+
+
+# ── Burn-state crossing emits a one-shot audit event ─────────────────────
+
+
+# ── Vendor-specific rejection signal coverage ────────────────────────────
+
+
+class TestVendorBlockSignals:
+    """Each anti-bot vendor — Cloudflare, DataDome, PerimeterX/HUMAN,
+    Imperva, Akamai BMP, F5/Shape — surfaces a deterministic element
+    selector or signature text on its block / interstitial page.  The
+    monitor must pick up at least one signal per vendor; missing a
+    rejection costs us much more than a false positive (a false positive
+    is one entry in a 10-deep window; a missed rejection means the
+    fingerprint stays in service after it has been flagged)."""
+
+    @pytest.mark.parametrize(
+        "selector",
+        [
+            "[id^=cf-error]",          # Cloudflare 1xxx
+            "#challenge-error-text",   # Cloudflare JS challenge
+            ".cf-browser-verification",  # Cloudflare interstitial
+            "#ddm-blocked",            # DataDome
+            "#px-captcha",             # PerimeterX press-and-hold
+            ".px-block-spam",          # PerimeterX outright block
+            "#main-iframe[src*=incident]",  # Imperva incident page
+            "[id^=bm-error]",          # Akamai BMP
+        ],
+    )
+    @pytest.mark.asyncio
+    async def test_vendor_selector_records_rejection(
+        self, monkeypatch, selector,
+    ):
+        """A page that renders a known vendor block selector must be
+        treated as a rejection regardless of the visible text."""
+        monkeypatch.setattr(
+            "src.browser.service._FINGERPRINT_MONITOR_TIMEOUT_S", 1.0,
+        )
+        from src.browser.service import (
+            BrowserManager,
+            _get_fingerprint_health,
+        )
+
+        # Build a page where the vendor selector resolves to count=1
+        # but no captcha selector is present and the body text is
+        # benign — the vendor signal alone must trip the monitor.
+        page = _FakePage(
+            url="https://protected.example.com/account",
+            locators={
+                selector: _FakeLocator(count=1),
+                "body": _FakeLocator(0, "loading content"),
+            },
+        )
+        inst = _FakeInstance("agent-vendor", page)
+        mgr = BrowserManager(profiles_dir="/tmp/no-such-vendor")
+        captcha_selectors = ['iframe[src*="recaptcha"]']
+        await mgr._monitor_post_solve_state(
+            inst, captcha_selectors,
+            kind="recaptcha-v2-checkbox",
+            page_origin="protected.example.com",
+        )
+        health = await _get_fingerprint_health("agent-vendor")
+        assert health["window_size"] == 1
+        assert health["rejection_rate"] == 1.0
+
+    @pytest.mark.parametrize(
+        "body_text",
+        [
+            "Sorry, you have been blocked",      # DataDome / Imperva
+            "Cloudflare Ray ID: 89abcdef0",      # Cloudflare-branded
+            "error 1020 — Access denied",        # Cloudflare 1020
+            "error 1015 — You are being rate-limited",  # Cloudflare 1015
+            "Please verify you are a human",     # PerimeterX
+            "Press and hold to confirm",         # PerimeterX press-and-hold
+            "Reference #18.deadbeef.1234",       # Akamai BMP
+            "Incident ID: 0123-4567-89ab",       # Imperva
+            "Unusual activity detected",         # Generic anti-bot
+            "Suspicious activity from your network",
+            "Just a moment...",                  # Cloudflare interstitial
+            "Captcha invalid — please retry",
+            "Challenge failed",
+            "Session expired, please log in again",
+            "checking if the site connection is secure",
+        ],
+    )
+    @pytest.mark.asyncio
+    async def test_extended_rejection_text_records_rejection(
+        self, monkeypatch, body_text,
+    ):
+        """Each vendor's branded block-page text trips the monitor
+        regardless of which one we encounter."""
+        monkeypatch.setattr(
+            "src.browser.service._FINGERPRINT_MONITOR_TIMEOUT_S", 1.0,
+        )
+        from src.browser.service import (
+            BrowserManager,
+            _get_fingerprint_health,
+        )
+        page = _FakePage(
+            url="https://protected.example.com/x",
+            locators={"body": _FakeLocator(0, body_text)},
+        )
+        inst = _FakeInstance("agent-text", page)
+        mgr = BrowserManager(profiles_dir="/tmp/no-such-text")
+        await mgr._monitor_post_solve_state(
+            inst, ['iframe[src*="recaptcha"]'],
+            kind="recaptcha-v2-checkbox",
+            page_origin="protected.example.com",
+        )
+        health = await _get_fingerprint_health("agent-text")
+        assert health["window_size"] == 1, (
+            f"text {body_text!r} did not trip rejection signal"
+        )
+        assert health["rejection_rate"] == 1.0
+
+
+# ── Defense-in-depth on agent_id validation ──────────────────────────────
+
+
+class TestAgentIdValidation:
+    """The dashboard / browser-service URL routes already enforce path
+    validation, but the manager methods are public — a future caller
+    that bypasses the routes must not be able to read or mutate state
+    keyed by an arbitrary agent_id."""
+
+    @pytest.mark.asyncio
+    async def test_get_with_invalid_agent_id_returns_empty_shape(self):
+        from src.browser.service import BrowserManager
+        mgr = BrowserManager(profiles_dir="/tmp/no-such-validate")
+        for bad in ("", "../etc/passwd", "agent with spaces", "<script>"):
+            health = await mgr.get_fingerprint_health(bad)
+            assert health == {
+                "window_size": 0,
+                "rejection_rate": 0.0,
+                "burned": False,
+                "last_signal_ts": None,
+            }
+
+    @pytest.mark.asyncio
+    async def test_reset_with_invalid_agent_id_is_noop(self):
+        from src.browser.service import (
+            BrowserManager,
+            _is_fingerprint_burned,
+            _record_fingerprint_outcome,
+        )
+        # Seed a burn against a *valid* id, then attempt to clear with
+        # an invalid id — the burn must remain.
+        for _ in range(10):
+            await _record_fingerprint_outcome("agent-real", rejected=True)
+        assert await _is_fingerprint_burned("agent-real") is True
+        mgr = BrowserManager(profiles_dir="/tmp/no-such-validate-2")
+        result = await mgr.reset_fingerprint_health("../agent-real")
+        assert result == {"reset": False}
+        assert await _is_fingerprint_burned("agent-real") is True
+
+
+# ── next_action override across all non-solved outcomes ──────────────────
+
+
+class TestBurnFlagAllOutcomes:
+    """The decoration logic must override ``next_action`` for *every*
+    non-``solved`` outcome — including ``rejected`` (token was injected
+    but the page rejected it) and ``timeout`` / ``injection_failed``.
+    The current tests cover ``no_solver`` and ``solved``; this fills
+    in the gap for the in-between states."""
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "outcome",
+        ["rejected", "timeout", "injection_failed", "no_solver"],
+    )
+    async def test_non_solved_outcomes_override_next_action(self, outcome):
+        from src.browser.service import (
+            _is_fingerprint_burned,
+            _record_fingerprint_outcome,
+        )
+        for _ in range(10):
+            await _record_fingerprint_outcome(
+                "agent-multi", rejected=True,
+            )
+        assert await _is_fingerprint_burned("agent-multi") is True
+
+        envelope = {
+            "captcha_found": True,
+            "kind": "recaptcha-v2-checkbox",
+            "solver_attempted": outcome != "no_solver",
+            "solver_outcome": outcome,
+            "next_action": (
+                "request_captcha_help" if outcome == "no_solver"
+                else "retry_previous"
+            ),
+        }
+        # Reproduce the exact decoration logic from _check_captcha so
+        # this test catches a refactor that changes the contract with
+        # the burn helpers.
+        if await _is_fingerprint_burned("agent-multi"):
+            envelope["fingerprint_burn"] = True
+            if envelope.get("solver_outcome") != "solved":
+                envelope["next_action"] = "retry_with_fresh_profile"
+
+        assert envelope["fingerprint_burn"] is True
+        assert envelope["next_action"] == "retry_with_fresh_profile"
+
+
+class TestBurnStateAudit:
+    @pytest.mark.asyncio
+    async def test_crossing_burn_threshold_emits_burn_event(self):
+        """The first rejected signal that pushes the window past the
+        threshold should emit a ``fingerprint_burn`` audit event in
+        addition to the per-signal ``rejected`` event."""
+        from src.browser.service import (
+            BrowserManager,
+            _drain_fingerprint_audit,
+        )
+        mgr = BrowserManager(profiles_dir="/tmp/no-such-fp")
+
+        # Pre-load the window with 9 rejections so the next rejection
+        # crosses the threshold (10/10 = 100% > 50%).
+        for _ in range(9):
+            await mgr._handle_post_solve_outcome(
+                "agent-cross", rejected=True, page_origin="example.com",
+            )
+        # No burn yet — window only has 9 entries.
+        events_pre = await _drain_fingerprint_audit()
+        # 1 bucket: (agent-cross, rejected, example.com), count=9.
+        assert len(events_pre) == 1
+        assert events_pre[0]["signal"] == "rejected"
+        assert events_pre[0]["count"] == 9
+
+        # 10th rejection — crosses the threshold.
+        await mgr._handle_post_solve_outcome(
+            "agent-cross", rejected=True, page_origin="example.com",
+        )
+        events_post = await _drain_fingerprint_audit()
+        # Two buckets now: rejected (count=1) and fingerprint_burn (count=1).
+        signals = sorted(ev["signal"] for ev in events_post)
+        assert signals == ["fingerprint_burn", "rejected"]


### PR DESCRIPTION
## Summary

Phase 10 §22 — per-agent fingerprint health monitor + burn detection.

Tracks a rolling window of post-solve outcomes (window size 10, burn threshold 50%). When a fingerprint is flagged by an anti-bot vendor often enough that solver-injected tokens are routinely rejected, the agent's subsequent captcha envelopes carry `fingerprint_burn=True` and `next_action="retry_with_fresh_profile"` — operator rotates the BrowserForge profile, then clears the window via the dashboard reset endpoint.

## Detection signals

The post-solve monitor (10s observation window after a `solver_outcome="solved"` envelope) probes three classes of signal — multi-vendor on purpose, since the agent operates across sites protected by different stacks:

1. **Vendor-specific element selectors** — most reliable (language-independent, layout-stable). Cloudflare 1xxx + JS challenge, DataDome, PerimeterX/HUMAN press-and-hold + outright block, Imperva incident-iframe, Akamai BMP, F5/Shape.
2. **Branded rejection text** — Cloudflare "Ray ID" / "Just a moment..." / "error 1020", DataDome / Imperva "Sorry, you have been blocked" + "Reference #" + "Incident ID:", PerimeterX "Please verify you are a human" / "press and hold", plus generic anti-bot phrasing.
3. **Captcha selector still present after the deadline** — the framework re-rendered the challenge.

A navigation away to a captcha-free page records an accept. Ambiguous signals (no clear outcome at deadline) are dropped — polluting the metric inflates burn false-positives on slow sites.

## Privacy

The fingerprint audit aggregator emits per-minute `type=fingerprint_event` payloads keyed by `(agent_id, signal, page_origin)` where `page_origin` is the **redacted netloc only**. Full URLs, paths, and query strings are never stored. Same posture as the §20 session audit aggregator.

## Why no auto-rotation

Wiping session cookies + storage state mid-flight would cascade into other agents' work (shared browser service, shared profile templates). The operator's reset endpoint clears the rolling window after they've rotated the profile manually — explicit, auditable, reversible.

## Test plan

- [x] 52 new test cases in `tests/test_fingerprint_health.py`
  - Window mechanics: empty, partial, 4/10, 5/10 (threshold edge), natural rollover, reset
  - Exclusion rules: `skipped_behavioral` and `request_captcha_help` outcomes do NOT enter the window
  - Envelope decoration: all non-`solved` outcomes get `next_action="retry_with_fresh_profile"`; `solved` is preserved
  - Page-state monitor: parametrised across 8 vendor selectors + 15 rejection-text patterns
  - Monitor-task cancellation on `_stop_instance` (no spurious record after page teardown)
  - Audit privacy: drained events carry `page_origin` netloc only — no `url` / `path` / `query` / `?` / `/`
  - Dashboard endpoint contract shape + CSRF gate on the reset endpoint
  - Defense-in-depth: regex-validated `agent_id` on the manager methods
- [x] `tests/test_browser_service.py` + `tests/test_dashboard.py` — 742 passed, 7 skipped, no regressions
- [x] `ruff check` clean

## Files

- `src/browser/service.py` — rolling-window state, monitor task, audit aggregator, manager API
- `src/browser/server.py` — `GET/POST /browser/{agent_id}/fingerprint-health{,/reset}` (browser-service)
- `src/dashboard/server.py` — `/api/agents/{id}/fingerprint-health{,/reset}` proxy with `success/error` envelope
- `tests/test_fingerprint_health.py` — new suite
- `CLAUDE.md` — service.py entry updated

Closes Phase 10 §22 from `docs/plans/2026-04-20-browser-automation.md`.