### PR TITLE
stealth-browser: principal-engineer review pass + dashboard wiring fixes

### DIFF
--- a/src/browser/captcha.py
+++ b/src/browser/captcha.py
@@ -1335,7 +1335,13 @@ class CaptchaSolver:
         not operator-actionable config faults.
         """
         description = data.get("errorDescription")
-        safe_desc = _redact_clientkey_text(str(description))
+        # Render a clean placeholder when the provider returned no
+        # description — ``str(None)`` would log the literal "None"
+        # which is misleading in operator dashboards.
+        if description is None or description == "":
+            safe_desc = f"errorId={data.get('errorId')}"
+        else:
+            safe_desc = _redact_clientkey_text(str(description))
         if _is_fatal_provider_error(description):
             # Sticky for the rest of this process — the docstring on
             # ``_solver_unreachable`` (and the §11.16 breaker test

--- a/src/browser/captcha.py
+++ b/src/browser/captcha.py
@@ -145,6 +145,48 @@ _BREAKER_FAILURE_WINDOW = 300.0    # 5 min
 _BREAKER_FAILURE_THRESHOLD = 3
 _BREAKER_OPEN_DURATION = 600.0      # 10 min
 
+
+# Fatal provider error markers — substring (case-insensitive) matched
+# against the ``errorDescription`` returned by a solver provider. When a
+# response carries one of these, the issue is operator-actionable
+# (revoked / mistyped key, drained balance, banned account) and will not
+# recover until the operator intervenes. We mark the process-wide solver
+# UNREACHABLE so subsequent solves short-circuit cleanly via the existing
+# health-check gate, instead of letting the per-process circuit breaker
+# trip on three of these in a row. The breaker is meant to ride out
+# transient provider outages — three "zero balance" errors from one
+# agent should not lock the whole fleet's solver out for 10 minutes;
+# the operator needs to fix billing, not wait for a backoff window.
+#
+# Both 2Captcha and CapSolver use these or near-identical strings as of
+# 2026-04. Substring + case-insensitive match keeps us robust against
+# minor wording drift ("Invalid API key" vs "ERROR_INVALID_API_KEY").
+_FATAL_PROVIDER_ERROR_MARKERS: frozenset[str] = frozenset({
+    "ERROR_KEY_DOES_NOT_EXIST",
+    "ERROR_WRONG_USER_KEY",
+    "ERROR_ZERO_BALANCE",
+    "ERROR_KEY_DENIED_ACCESS",
+    "ERROR_INVALID_API_KEY",
+    "ERROR_INSUFFICIENT_BALANCE",
+    "ERROR_USER_NOT_FOUND",
+    "ERROR_KEY_BANNED",
+    "ERROR_ACCOUNT_SUSPENDED",
+})
+
+
+def _is_fatal_provider_error(error_description: object) -> bool:
+    """True iff ``error_description`` names an operator-actionable error.
+
+    See :data:`_FATAL_PROVIDER_ERROR_MARKERS` for the rationale and the
+    canonical marker list. ``error_description`` is whatever
+    ``data.get("errorDescription")`` returned — usually a string but
+    occasionally ``None`` or numeric on malformed responses.
+    """
+    if error_description is None:
+        return False
+    upper = str(error_description).upper()
+    return any(marker in upper for marker in _FATAL_PROVIDER_ERROR_MARKERS)
+
 # /getBalance endpoints — both providers expose these and accept the same
 # JSON body shape (``{"clientKey": "..."}``). Both return
 # ``{"errorId": 0, "balance": <float>}`` on success.
@@ -1280,6 +1322,39 @@ class CaptchaSolver:
             elif outcome == "degraded":
                 self._solver_health_degraded = True
 
+    def _handle_provider_error_response(self, data: dict) -> None:
+        """Log + classify an ``errorId>0`` response from a solver provider.
+
+        Always logs the (redacted) ``errorDescription`` so operators can
+        diagnose. When the description matches a known fatal-config
+        marker, additionally flips the per-process unreachable flag so
+        subsequent solves short-circuit through the existing health
+        gate. Without this, three "zero balance" errors from one agent
+        in 5 minutes would trip the §11.16 breaker for the whole
+        BrowserManager — the breaker tracks transient PROVIDER outages,
+        not operator-actionable config faults.
+        """
+        description = data.get("errorDescription")
+        safe_desc = _redact_clientkey_text(str(description))
+        if _is_fatal_provider_error(description):
+            # Sticky for the rest of this process — the docstring on
+            # ``_solver_unreachable`` (and the §11.16 breaker test
+            # suite) treat the flag as one-way; an operator clears it
+            # by restarting the browser service after fixing the key /
+            # balance. This keeps semantics aligned with the existing
+            # health-check unreachable path.
+            self._solver_unreachable = True
+            logger.warning(
+                "%s reported a fatal config error (%s) — disabling solver "
+                "for this session. Operator must fix the API key / balance "
+                "and restart the browser service.",
+                self.provider, safe_desc,
+            )
+            return
+        logger.warning(
+            "%s solver error: %s", self.provider, safe_desc,
+        )
+
     async def _record_solver_outcome(self, success: bool) -> None:
         """Update the breaker state after a solve attempt.
 
@@ -1485,7 +1560,14 @@ class CaptchaSolver:
             # means ``_build_task_body`` rejected the variant locally
             # (no row in the per-provider task table) — the captcha is
             # unsupported, NOT a provider outage signal.
-            if provider_contacted:
+            #
+            # ``_solver_unreachable`` flipping mid-call means the provider
+            # returned a fatal-config error (revoked key, drained balance,
+            # banned account) — see :func:`_is_fatal_provider_error`.
+            # Those need operator intervention, not breaker backoff;
+            # skipping the tick keeps a misconfigured key from locking
+            # the whole BrowserManager out of solver duty for 10 minutes.
+            if provider_contacted and not self._solver_unreachable:
                 await self._record_solver_outcome(success=False)
             return SolveResult(
                 token=None, injection_succeeded=False,
@@ -1815,10 +1897,7 @@ class CaptchaSolver:
             )
             return None, used_proxy_aware, compat_rejected, True
         if data.get("errorId", 0) != 0:
-            logger.warning(
-                "2Captcha submit error: %s",
-                _redact_clientkey_text(str(data.get("errorDescription"))),
-            )
+            self._handle_provider_error_response(data)
             return None, used_proxy_aware, compat_rejected, True
         task_id = data.get("taskId")
         if not task_id:
@@ -1848,10 +1927,7 @@ class CaptchaSolver:
                 )
                 return None, used_proxy_aware, compat_rejected, True
             if data.get("errorId", 0) != 0:
-                logger.warning(
-                    "2Captcha poll error: %s",
-                    _redact_clientkey_text(str(data.get("errorDescription"))),
-                )
+                self._handle_provider_error_response(data)
                 return None, used_proxy_aware, compat_rejected, True
             if data.get("status") == "ready":
                 solution = data.get("solution", {})
@@ -1898,10 +1974,7 @@ class CaptchaSolver:
             )
             return None, used_proxy_aware, compat_rejected, True
         if data.get("errorId", 0) != 0:
-            logger.warning(
-                "CapSolver submit error: %s",
-                _redact_clientkey_text(str(data.get("errorDescription"))),
-            )
+            self._handle_provider_error_response(data)
             return None, used_proxy_aware, compat_rejected, True
         task_id = data.get("taskId")
         if not task_id:
@@ -1926,10 +1999,7 @@ class CaptchaSolver:
                 )
                 return None, used_proxy_aware, compat_rejected, True
             if data.get("errorId", 0) != 0:
-                logger.warning(
-                    "CapSolver poll error: %s",
-                    _redact_clientkey_text(str(data.get("errorDescription"))),
-                )
+                self._handle_provider_error_response(data)
                 return None, used_proxy_aware, compat_rejected, True
             if data.get("status") == "ready":
                 solution = data.get("solution", {})

--- a/src/browser/flags.py
+++ b/src/browser/flags.py
@@ -79,6 +79,16 @@ KNOWN_FLAGS: dict[str, str] = {
     "BROWSER_CAPTCHA_REDETECT_ENABLED":
         "true | false (default true) — gate MutationObserver-based "
         "post-action captcha re-detection on click/type/press_key/fill_form",
+    # ── Per-platform pre-nav timing posture ───────────────────────────────
+    "BROWSER_PLATFORM_TIMING_ENABLED":
+        "true | false (default true) — gate the per-platform pre-navigate "
+        "Gaussian dwell that fires on known high-protection platforms "
+        "(LinkedIn / X / Twitter / Facebook / Instagram). The dwell "
+        "shifts arrival-timing distribution toward the human population "
+        "for sites whose in-house behavioral models score sub-second "
+        "arrivals as bot signal. Operators who run high-volume tests "
+        "against these platforms (or have measured no benefit) can "
+        "disable globally or per-agent.",
     # ── CAPTCHA solver (§11) ──────────────────────────────────────────────
     "CAPTCHA_SOLVER_PROVIDER": "2captcha | capsolver | unset",
     "CAPTCHA_SOLVER_KEY": "API key for the primary provider",

--- a/src/browser/service.py
+++ b/src/browser/service.py
@@ -42,6 +42,7 @@ from src.browser.stealth import (
     build_launch_options,
     build_mobile_init_script,
     get_device_profile,
+    pick_platform_pre_nav_delay,
     pick_referer,
     validate_referer,
 )
@@ -3897,6 +3898,37 @@ class BrowserManager:
         await self.stop(agent_id)
         # Next get_or_start will create a fresh instance with same profile
 
+    async def _apply_platform_pre_nav_delay(
+        self, agent_id: str, url: str,
+    ) -> None:
+        """Sleep a platform-specific Gaussian dwell before navigating.
+
+        No-op when ``url`` is not on the protected-platform list (LinkedIn
+        / X / Twitter / Meta) or when the operator has disabled the
+        feature via ``BROWSER_PLATFORM_TIMING_ENABLED=false``. The flag
+        check lives here (not in ``stealth.py``) so the operator-tuning
+        and per-agent-override paths flow through the standard
+        :mod:`src.browser.flags` precedence chain. See
+        :func:`src.browser.stealth.pick_platform_pre_nav_delay` for the
+        sampling logic and per-platform tuning rationale.
+        """
+        from src.browser.flags import get_bool
+        if not get_bool("BROWSER_PLATFORM_TIMING_ENABLED", True, agent_id=agent_id):
+            return
+        delay_s, label = pick_platform_pre_nav_delay(url)
+        if delay_s <= 0 or label is None:
+            return
+        # Single INFO log per applied delay so operators can correlate
+        # latency reports with the platform-timing posture without
+        # having to chase agent-side traces. URL is intentionally NOT
+        # logged at INFO — the host label is enough; full URLs flow
+        # through the recorder's redaction pipeline elsewhere.
+        logger.info(
+            "platform_pre_nav_delay agent=%s platform=%s delay=%.2fs",
+            agent_id, label, delay_s,
+        )
+        await asyncio.sleep(delay_s)
+
     def set_proxy_config(self, agent_id: str, config: dict | None) -> None:
         """Store proxy config for an agent. Pass None to clear."""
         if config is None:
@@ -4157,6 +4189,12 @@ class BrowserManager:
             # picker can see "we just used a direct/social/search
             # pattern" and rotate accordingly.
             inst.recent_referers.append(resolved_referer)
+
+            # Per-platform pre-nav dwell. Fires only on known high-
+            # protection platforms (LinkedIn / X / Meta) where in-house
+            # behavioral models score sub-second arrivals as bot signal.
+            # No-op for any other host.
+            await self._apply_platform_pre_nav_delay(agent_id, url)
 
             # Playwright accepts ``referer`` for goto and sets both the
             # network header and document.referrer consistently. Empty
@@ -9572,6 +9610,11 @@ class BrowserManager:
                 }
                 if resolved_referer:
                     goto_kwargs["referer"] = resolved_referer
+                # Per-platform pre-nav dwell — same posture as the main
+                # ``navigate`` path. New-tab arrivals on these platforms
+                # are also profiled by the in-house behavioral models, so
+                # the delay applies here too.
+                await self._apply_platform_pre_nav_delay(agent_id, url)
                 try:
                     await new_page.goto(url, **goto_kwargs)
                 except Exception as e:

--- a/src/browser/stealth.py
+++ b/src/browser/stealth.py
@@ -447,7 +447,146 @@ def pick_referer(
     return rng.choice(candidates)
 
 
-# ── Per-agent resolution pool (§6.1) ──────────────────────────────────────────
+# ── Per-platform pre-navigate timing posture ─────────────────────────────────
+
+
+# Why this exists: LinkedIn, X/Twitter, and Meta all stack heavy in-house
+# behavioral risk-scoring on top of standard CAPTCHA/anti-bot. A signal
+# they all key on is "request fired ~0ms after the previous action" —
+# the agent typing a URL, hitting Enter, and pulling a page in 50ms is
+# itself a fingerprint, separate from JS / TLS / IP layers. Real humans
+# pause to focus the address bar, glance at the URL, and only then hit
+# Enter. The sub-second-arrival cluster is a reliable bot signal at
+# fleet scale.
+#
+# This module adds a Gaussian pre-nav dwell that fires ONLY when the
+# target host matches a known high-protection platform. The delay is
+# applied just before ``page.goto(...)`` so it shifts the request-time
+# distribution toward the human population without slowing down nav
+# to less-defended sites.
+#
+# Tuning rationale per platform:
+# * LinkedIn / X / Twitter — moderate (2-3s μ). PerimeterX/HUMAN on
+#   LinkedIn and X's in-house "Bird" risk model both score arrival
+#   timing; 2-3s of dwell falls inside the human bell curve without
+#   feeling noticeable to operators watching VNC.
+# * Meta (facebook.com / instagram.com) — heavier (4s μ). Meta's
+#   behavioral checkpoint logic is the most aggressive of the three;
+#   real users on Meta also page-dwell longer (feed-scroll culture),
+#   so a higher μ is plausible AND less risky.
+#
+# Operators override globally by unsetting ``BROWSER_PLATFORM_TIMING_ENABLED``
+# (default true) or per-agent via the same flag. Per-platform tuning is
+# operator-driven via env: ``BROWSER_PLATFORM_TIMING_<HOSTKEY>_MU_S`` etc.
+# (deferred work — current values are fine for the launch profile and
+# adjustable in code).
+_PLATFORM_TIMING_PROFILES: dict[str, dict[str, float | str]] = {
+    # Maps the bare-domain canonical hostname (matching the same
+    # subdomain semantics as ``captcha_policy._matches`` — bare entry
+    # matches apex AND any subdomain). Keep alphabetical for diff
+    # readability.
+    "facebook.com": {
+        "label": "facebook",
+        "mu_s": 4.0, "sigma_s": 1.2, "min_s": 1.5, "max_s": 8.0,
+    },
+    "instagram.com": {
+        "label": "instagram",
+        "mu_s": 4.0, "sigma_s": 1.2, "min_s": 1.5, "max_s": 8.0,
+    },
+    "linkedin.com": {
+        "label": "linkedin",
+        "mu_s": 3.0, "sigma_s": 1.0, "min_s": 1.0, "max_s": 6.0,
+    },
+    "twitter.com": {
+        "label": "twitter",
+        "mu_s": 2.5, "sigma_s": 0.8, "min_s": 0.8, "max_s": 5.0,
+    },
+    "x.com": {
+        "label": "x",
+        "mu_s": 2.5, "sigma_s": 0.8, "min_s": 0.8, "max_s": 5.0,
+    },
+}
+
+
+def _canonical_host(url: str) -> str | None:
+    """Lower-cased hostname with leading ``www.`` stripped, or None.
+
+    Mirrors ``captcha_policy._hostname`` so the bare-domain matching
+    rules below behave consistently across the two modules.
+    """
+    try:
+        parsed = urlparse(url)
+    except Exception:
+        return None
+    host = (parsed.hostname or "").lower()
+    if not host:
+        return None
+    if host.startswith("www."):
+        host = host[4:]
+    return host
+
+
+def get_platform_timing_profile(url: str) -> dict | None:
+    """Return the timing profile dict for ``url``'s host, or ``None``.
+
+    Bare-domain match: an entry ``"linkedin.com"`` matches both
+    ``linkedin.com`` and any subdomain (``mobile.linkedin.com``,
+    ``api.linkedin.com``). Returns ``None`` when the host isn't on
+    the protected-platform list.
+
+    The returned dict is the live module-level entry — do not mutate.
+    """
+    host = _canonical_host(url)
+    if host is None:
+        return None
+    if host in _PLATFORM_TIMING_PROFILES:
+        return _PLATFORM_TIMING_PROFILES[host]
+    # Subdomain match: walk parents (``mobile.linkedin.com`` →
+    # ``linkedin.com``). Uses the same right-anchored suffix logic as
+    # captcha_policy so behavior is consistent across modules.
+    for entry, profile in _PLATFORM_TIMING_PROFILES.items():
+        if host.endswith("." + entry):
+            return profile
+    return None
+
+
+def pick_platform_pre_nav_delay(
+    url: str,
+    *,
+    rng: random.Random | None = None,
+) -> tuple[float, str | None]:
+    """Sample a pre-nav dwell for ``url`` based on its platform profile.
+
+    Returns ``(delay_seconds, label)``:
+      * ``(0.0, None)`` — host is not on the protected-platform list;
+        caller skips the delay entirely.
+      * ``(delay, label)`` — sample a clamped Gaussian per the
+        profile's μ/σ/min/max. ``label`` is the platform short-name
+        (``"linkedin"``, ``"x"``, ...) for logging.
+
+    Sampling: ``rng.gauss(mu, sigma)`` clamped into ``[min_s, max_s]``.
+    Real-user arrival timing on these platforms is well-modeled by a
+    truncated normal — power-law / log-normal alternatives don't match
+    the underlying behavior any better at this scale and are harder
+    to tune.
+    """
+    profile = get_platform_timing_profile(url)
+    if profile is None:
+        return 0.0, None
+    rng = rng or random
+    mu = float(profile["mu_s"])
+    sigma = float(profile["sigma_s"])
+    lo = float(profile["min_s"])
+    hi = float(profile["max_s"])
+    sample = rng.gauss(mu, sigma)
+    if sample < lo:
+        sample = lo
+    elif sample > hi:
+        sample = hi
+    return sample, str(profile["label"])
+
+
+
 
 
 # Distribution approximates Windows-desktop market share on the most common

--- a/src/host/runtime.py
+++ b/src/host/runtime.py
@@ -388,7 +388,14 @@ class DockerBackend(RuntimeBackend):
         else:
             max_browsers, browser_mem, browser_shm, browser_cpu = min(max_agents, 10), "8g", "2g", 200000
 
-        # Override browser idle timeout from dashboard config
+        # Override browser idle timeout from dashboard config; also bridge
+        # the dashboard-saved CAPTCHA solver provider/key into the host
+        # process env so the env-var translation at the bottom of this
+        # function (``OPENLEGION_CAPTCHA_SOLVER_* → CAPTCHA_SOLVER_*``)
+        # picks them up. Without this bridge, the dashboard's "Save key"
+        # flow only takes effect on the first apply-settings click of
+        # the session — a cold engine restart would silently drop the
+        # solver key until the operator clicked "Apply" again.
         idle_timeout_minutes = 30
         settings_path = self.project_root / "config" / "settings.json"
         if settings_path.exists():
@@ -396,6 +403,22 @@ class DockerBackend(RuntimeBackend):
                 bsettings = json.loads(settings_path.read_text())
                 if "browser_idle_timeout" in bsettings:
                     idle_timeout_minutes = int(bsettings["browser_idle_timeout"])
+                # Captcha solver settings live at the top-level (not under
+                # ``browser_flags``) — the dashboard writes them there.
+                # Only seed env if the operator hasn't already set the
+                # canonical env vars by hand; explicit env always wins.
+                _solver_provider = (bsettings.get("captcha_solver_provider") or "").strip()
+                _solver_key = (bsettings.get("captcha_solver_key") or "").strip()
+                if _solver_provider and not (
+                    os.environ.get("CAPTCHA_SOLVER_PROVIDER")
+                    or os.environ.get("OPENLEGION_CAPTCHA_SOLVER_PROVIDER")
+                ):
+                    os.environ["OPENLEGION_CAPTCHA_SOLVER_PROVIDER"] = _solver_provider
+                if _solver_key and not (
+                    os.environ.get("CAPTCHA_SOLVER_KEY")
+                    or os.environ.get("OPENLEGION_CAPTCHA_SOLVER_KEY")
+                ):
+                    os.environ["OPENLEGION_CAPTCHA_SOLVER_KEY"] = _solver_key
             except (json.JSONDecodeError, OSError, ValueError):
                 pass
 
@@ -591,20 +614,34 @@ class DockerBackend(RuntimeBackend):
 
         self.browser_vnc_url = f"http://127.0.0.1:{vnc_port}/index.html?autoconnect=true&path=&resize=scale"
 
-        # Push saved browser settings (speed) so they survive container restarts
+        # Push saved browser settings (speed + inter-action delay) so
+        # they survive container restarts. Pre-fix, only ``browser_speed``
+        # was pushed — the dashboard-saved ``browser_delay`` silently
+        # reverted to 0 after every browser-service restart, undoing the
+        # operator's stealth tuning. The browser settings endpoint accepts
+        # both keys in a single POST.
         try:
             _settings_path = Path("config/settings.json")
             if _settings_path.exists():
                 _saved = json.loads(_settings_path.read_text())
+                _payload: dict = {}
                 _speed = _saved.get("browser_speed")
                 if _speed is not None:
+                    _payload["speed"] = _speed
+                _delay = _saved.get("browser_delay")
+                if _delay is not None:
+                    _payload["delay"] = _delay
+                if _payload:
                     _httpx.post(
                         f"{self.browser_service_url}/browser/settings",
-                        json={"speed": _speed},
+                        json=_payload,
                         headers={"Authorization": f"Bearer {self.browser_auth_token}"},
                         timeout=5,
                     )
-                    logger.info("Pushed browser speed=%.2f from saved settings", _speed)
+                    logger.info(
+                        "Pushed browser settings from disk: speed=%s delay=%s",
+                        _payload.get("speed"), _payload.get("delay"),
+                    )
         except Exception as e:
             logger.debug("Browser settings push skipped: %s", e)
 

--- a/src/host/server.py
+++ b/src/host/server.py
@@ -2801,6 +2801,7 @@ def create_mesh_app(
 
     async def _deferred_push_browser_proxies() -> None:
         """Push proxy config for all agents after a delay (non-blocking background task)."""
+        nonlocal _last_browser_boot_id, _last_boot_id_check_ts
         await asyncio.sleep(5)  # Wait for agents to register
         if not container_manager:
             return
@@ -2819,6 +2820,30 @@ def create_mesh_app(
             *(_push_browser_proxy(agent_id) for agent_id in agents),
             return_exceptions=True,
         )
+        # Seed ``_last_browser_boot_id`` so the first browser command's
+        # restart-detection probe doesn't fire a redundant re-push for
+        # all agents. If the deferred push above failed (e.g. browser
+        # container slow to start), boot_id stays None and the first-
+        # contact recovery path in ``_check_browser_boot_id_changed``
+        # still corrects the race. We bypass the throttle here — this
+        # is a one-time seed at startup, not the per-command hot path.
+        try:
+            svc_token = getattr(container_manager, "browser_auth_token", "")
+            headers: dict = {}
+            if svc_token:
+                headers["Authorization"] = f"Bearer {svc_token}"
+            resp = await _browser_proxy_client.get(
+                f"{svc_url}/browser/status", headers=headers, timeout=5,
+            )
+            boot_id = resp.json().get("boot_id")
+            if boot_id:
+                _last_browser_boot_id = boot_id
+                _last_boot_id_check_ts = time.monotonic()
+        except Exception:
+            # Browser container not ready yet — leave boot_id unset so
+            # the first-contact branch in `_check_browser_boot_id_changed`
+            # picks up the race correction.
+            pass
         logger.info("Pushed browser proxy config for %d agents", len(agents))
 
     @app.on_event("startup")

--- a/src/host/server.py
+++ b/src/host/server.py
@@ -2700,6 +2700,14 @@ def create_mesh_app(
     _browser_proxy_client = _httpx.AsyncClient(timeout=60)
 
     _last_browser_boot_id: str | None = None
+    # Throttle for `_check_browser_boot_id_changed`. The probe was
+    # previously fired on every browser command (one extra HTTP round-trip
+    # per navigate / click / type), even though the browser service
+    # restarts at most once per deploy. 30s is a good balance: a real
+    # restart is detected within one tick, and the per-command overhead
+    # collapses from "always probe" to "almost never probe."
+    _last_boot_id_check_ts: float = 0.0
+    _BOOT_ID_CHECK_INTERVAL_S = 30.0
 
     async def _push_browser_proxy(agent_id: str) -> None:
         """Push proxy config for an agent to the browser service."""
@@ -2745,14 +2753,28 @@ def create_mesh_app(
             logger.warning("Failed to push proxy config for %s: %s", agent_id, e)
 
     async def _check_browser_boot_id_changed() -> bool:
-        """Check if browser service restarted by comparing boot_id."""
-        nonlocal _last_browser_boot_id
+        """Check if the browser service restarted by comparing boot_id.
+
+        Throttled to one probe per ``_BOOT_ID_CHECK_INTERVAL_S`` seconds
+        so the per-command overhead is bounded; a real restart is
+        detected on the next tick after it happens. Treats the first
+        successful contact (when ``_last_browser_boot_id`` is still
+        ``None``) as a restart so the cold-start race — where the
+        deferred startup push at ``+5s`` ran before the browser service
+        was reachable — self-heals on the first browser command instead
+        of leaving every agent permanently in "no proxy" mode.
+        """
+        nonlocal _last_browser_boot_id, _last_boot_id_check_ts
         if not container_manager:
             return False
         svc_url = getattr(container_manager, "browser_service_url", None)
         svc_token = getattr(container_manager, "browser_auth_token", "")
         if not svc_url:
             return False
+        now = time.monotonic()
+        if now - _last_boot_id_check_ts < _BOOT_ID_CHECK_INTERVAL_S:
+            return False
+        _last_boot_id_check_ts = now
         try:
             headers: dict = {}
             if svc_token:
@@ -2763,8 +2785,13 @@ def create_mesh_app(
             data = resp.json()
             boot_id = data.get("boot_id")
             if _last_browser_boot_id is None:
+                # First successful contact. The deferred startup push at
+                # +5s may have run when the browser service wasn't ready
+                # yet (silently failing per-agent); treating this as a
+                # restart triggers a re-push so agents that missed the
+                # initial window pick up their proxy config.
                 _last_browser_boot_id = boot_id
-                return False
+                return True
             if boot_id != _last_browser_boot_id:
                 _last_browser_boot_id = boot_id
                 return True
@@ -2783,8 +2810,15 @@ def create_mesh_app(
         agents = list(router.agent_registry.keys())
         if not agents:
             return
-        for agent_id in agents:
-            await _push_browser_proxy(agent_id)
+        # Push in parallel — sequential awaits could add seconds of
+        # startup latency on a fleet with many agents. Each
+        # ``_push_browser_proxy`` already swallows its own exceptions
+        # (line ~2745); ``return_exceptions=True`` is belt-and-suspenders
+        # so one transient failure doesn't cancel the rest.
+        await asyncio.gather(
+            *(_push_browser_proxy(agent_id) for agent_id in agents),
+            return_exceptions=True,
+        )
         logger.info("Pushed browser proxy config for %d agents", len(agents))
 
     @app.on_event("startup")
@@ -3054,9 +3088,17 @@ def create_mesh_app(
             restarted = await _check_browser_boot_id_changed()
             if restarted:
                 all_agents = list(router.agent_registry.keys())
-                logger.info("Browser service restarted, re-pushing proxy for %d agents", len(all_agents))
-                for _aid in all_agents:
-                    await _push_browser_proxy(_aid)
+                if all_agents:
+                    logger.info(
+                        "Browser service restarted, re-pushing proxy for %d agents",
+                        len(all_agents),
+                    )
+                    # Parallel — sequential awaits added cumulative latency
+                    # to the triggering agent's command on large fleets.
+                    await asyncio.gather(
+                        *(_push_browser_proxy(_aid) for _aid in all_agents),
+                        return_exceptions=True,
+                    )
         except Exception:
             pass  # Non-blocking — don't fail the browser command
 

--- a/tests/test_browser_platform_timing.py
+++ b/tests/test_browser_platform_timing.py
@@ -1,0 +1,237 @@
+"""Per-platform pre-nav timing posture (LinkedIn / X / Twitter / Meta).
+
+Tests the host-matching logic, Gaussian sampling determinism, and the
+``BrowserManager._apply_platform_pre_nav_delay`` integration including
+the operator override flag.
+"""
+
+from __future__ import annotations
+
+import random
+from unittest.mock import patch
+
+import pytest
+
+from src.browser import flags as _flags_module
+from src.browser.stealth import (
+    _PLATFORM_TIMING_PROFILES,
+    get_platform_timing_profile,
+    pick_platform_pre_nav_delay,
+)
+
+
+@pytest.fixture(autouse=True)
+def _reset_flag_caches():
+    """Operator-settings + per-agent override state is module-global —
+    reset between tests so a leaked override from one case doesn't
+    silently change the next case's gate decision."""
+    _flags_module._operator_settings = None
+    _flags_module._agent_overrides.clear()
+    yield
+    _flags_module._operator_settings = None
+    _flags_module._agent_overrides.clear()
+
+
+# ── 1: host matching ──────────────────────────────────────────────────
+
+
+class TestHostMatching:
+    def test_apex_matches(self):
+        assert get_platform_timing_profile("https://linkedin.com/") is not None
+        assert get_platform_timing_profile("https://x.com/foo") is not None
+        assert get_platform_timing_profile("https://facebook.com/") is not None
+
+    def test_subdomain_matches(self):
+        # Bare-domain semantics: any subdomain of a registered host
+        # should resolve to the parent's profile.
+        for sub in (
+            "https://www.linkedin.com/",
+            "https://mobile.linkedin.com/",
+            "https://api.linkedin.com/v2/foo",
+            "https://m.facebook.com/",
+            "https://touch.facebook.com/",
+        ):
+            assert get_platform_timing_profile(sub) is not None, sub
+
+    def test_unknown_host_returns_none(self):
+        assert get_platform_timing_profile("https://example.com/") is None
+        assert get_platform_timing_profile("https://github.com/") is None
+        # Lookalike — must NOT match.
+        assert get_platform_timing_profile("https://notlinkedin.com/") is None
+        assert get_platform_timing_profile("https://linkedin.com.evil.com/") is None
+
+    def test_malformed_url_returns_none(self):
+        assert get_platform_timing_profile("") is None
+        assert get_platform_timing_profile("not-a-url") is None
+        assert get_platform_timing_profile("javascript:alert(1)") is None
+
+    def test_label_present_for_each_profile(self):
+        # Every profile must carry a non-empty short-label string for
+        # log-line use. A missing label would produce ``None`` in the
+        # logger format string.
+        for host, profile in _PLATFORM_TIMING_PROFILES.items():
+            label = profile.get("label")
+            assert isinstance(label, str) and label, f"{host} missing label"
+
+
+# ── 2: Gaussian sampling ──────────────────────────────────────────────
+
+
+class TestSampling:
+    def test_unknown_host_returns_zero(self):
+        delay, label = pick_platform_pre_nav_delay("https://example.com/")
+        assert delay == 0.0
+        assert label is None
+
+    def test_known_host_returns_label_and_positive_delay(self):
+        rng = random.Random(42)
+        delay, label = pick_platform_pre_nav_delay(
+            "https://linkedin.com/", rng=rng,
+        )
+        assert label == "linkedin"
+        assert delay > 0.0
+
+    def test_clamped_to_min_max(self):
+        # Force the Gaussian to a value far outside the clamp window
+        # via a stub rng; both directions.
+        class StubRng:
+            def __init__(self, value):
+                self.value = value
+            def gauss(self, mu, sigma):
+                return self.value
+
+        # Below min → clamped up.
+        d_lo, _ = pick_platform_pre_nav_delay(
+            "https://x.com/", rng=StubRng(-100.0),
+        )
+        x_profile = _PLATFORM_TIMING_PROFILES["x.com"]
+        assert d_lo == x_profile["min_s"]
+
+        # Above max → clamped down.
+        d_hi, _ = pick_platform_pre_nav_delay(
+            "https://x.com/", rng=StubRng(999.0),
+        )
+        assert d_hi == x_profile["max_s"]
+
+    def test_deterministic_with_seeded_rng(self):
+        # Same seed → same sample. Useful for fleet-scale audit (an
+        # operator can replay a navigate's exact dwell from logs).
+        rng_a = random.Random(1234)
+        rng_b = random.Random(1234)
+        d_a, _ = pick_platform_pre_nav_delay("https://linkedin.com/", rng=rng_a)
+        d_b, _ = pick_platform_pre_nav_delay("https://linkedin.com/", rng=rng_b)
+        assert d_a == d_b
+
+    def test_distribution_within_clamp_window(self):
+        # Sanity-check: 200 samples all fall in [min_s, max_s] for a
+        # given platform. If the clamp logic regressed, this would
+        # surface as out-of-range samples.
+        rng = random.Random(777)
+        profile = _PLATFORM_TIMING_PROFILES["facebook.com"]
+        lo, hi = profile["min_s"], profile["max_s"]
+        for _ in range(200):
+            d, _label = pick_platform_pre_nav_delay(
+                "https://facebook.com/", rng=rng,
+            )
+            assert lo <= d <= hi
+
+
+# ── 3: BrowserManager integration ─────────────────────────────────────
+
+
+class TestNavigateIntegration:
+    """Verifies the manager-side wiring: when navigate is called against
+    a protected platform, the dwell is applied; when called against an
+    unrelated host, it is not; and the operator flag disables it."""
+
+    @pytest.mark.asyncio
+    async def test_dwell_applied_on_protected_platform(self):
+        from src.browser.service import BrowserManager
+
+        mgr = BrowserManager.__new__(BrowserManager)
+
+        sleeps: list[float] = []
+
+        async def _fake_sleep(s):
+            sleeps.append(s)
+
+        with patch("src.browser.service.asyncio.sleep", _fake_sleep):
+            await mgr._apply_platform_pre_nav_delay(
+                "agent-1", "https://linkedin.com/",
+            )
+
+        # Exactly one sleep with a positive duration.
+        assert len(sleeps) == 1
+        assert sleeps[0] > 0.0
+
+    @pytest.mark.asyncio
+    async def test_dwell_skipped_for_unknown_host(self):
+        from src.browser.service import BrowserManager
+
+        mgr = BrowserManager.__new__(BrowserManager)
+        sleeps: list[float] = []
+
+        async def _fake_sleep(s):
+            sleeps.append(s)
+
+        with patch("src.browser.service.asyncio.sleep", _fake_sleep):
+            await mgr._apply_platform_pre_nav_delay(
+                "agent-1", "https://example.com/",
+            )
+
+        assert sleeps == []
+
+    @pytest.mark.asyncio
+    async def test_dwell_skipped_when_flag_disabled(self):
+        """Operator can disable globally via the flag layer."""
+        from src.browser.service import BrowserManager
+
+        mgr = BrowserManager.__new__(BrowserManager)
+        sleeps: list[float] = []
+
+        async def _fake_sleep(s):
+            sleeps.append(s)
+
+        # Disable via the operator-settings layer (mirrors what the
+        # dashboard would write into ``config/settings.json``).
+        _flags_module._operator_settings = {
+            "BROWSER_PLATFORM_TIMING_ENABLED": "false",
+        }
+
+        with patch("src.browser.service.asyncio.sleep", _fake_sleep):
+            await mgr._apply_platform_pre_nav_delay(
+                "agent-1", "https://linkedin.com/",
+            )
+
+        assert sleeps == [], (
+            "flag disabled but dwell was applied — operator override broken"
+        )
+
+    @pytest.mark.asyncio
+    async def test_dwell_skipped_per_agent_override(self):
+        """Per-agent override wins over operator default."""
+        from src.browser.service import BrowserManager
+
+        mgr = BrowserManager.__new__(BrowserManager)
+        sleeps: list[float] = []
+
+        async def _fake_sleep(s):
+            sleeps.append(s)
+
+        _flags_module.set_agent_override(
+            "agent-1", "BROWSER_PLATFORM_TIMING_ENABLED", "false",
+        )
+
+        with patch("src.browser.service.asyncio.sleep", _fake_sleep):
+            await mgr._apply_platform_pre_nav_delay(
+                "agent-1", "https://linkedin.com/",
+            )
+
+        assert sleeps == []
+
+        # Other agents still get the dwell.
+        with patch("src.browser.service.asyncio.sleep", _fake_sleep):
+            await mgr._apply_platform_pre_nav_delay(
+                "agent-2", "https://linkedin.com/",
+            )
+        assert len(sleeps) == 1 and sleeps[0] > 0.0

--- a/tests/test_captcha_health.py
+++ b/tests/test_captcha_health.py
@@ -29,6 +29,7 @@ from src.browser.captcha import (
     _BREAKER_OPEN_DURATION,
     _HEALTH_DEGRADED_LATENCY,
     CaptchaSolver,
+    _is_fatal_provider_error,
     _redact_clientkey,
     _redact_clientkey_text,
 )
@@ -497,6 +498,124 @@ async def test_three_failures_staggered_inside_window_does_trip():
         assert solver.is_breaker_open() is True
 
 
+# ── Fatal provider config errors: mark unreachable, skip breaker ─────
+
+
+def test_is_fatal_provider_error_helper():
+    """Substring + case-insensitive match against the marker set."""
+    assert _is_fatal_provider_error("ERROR_ZERO_BALANCE") is True
+    assert _is_fatal_provider_error("error_key_does_not_exist") is True
+    # Provider sometimes wraps the canonical token in extra prose.
+    assert _is_fatal_provider_error("ERROR_ACCOUNT_SUSPENDED for abuse") is True
+    assert _is_fatal_provider_error("ERROR_INSUFFICIENT_BALANCE: top up at...") is True
+    # Non-fatal errors must NOT match.
+    assert _is_fatal_provider_error("ERROR_INVALID_SITEKEY") is False
+    assert _is_fatal_provider_error("ERROR_NO_SLOT_AVAILABLE") is False
+    assert _is_fatal_provider_error("ERROR_CAPTCHA_UNSOLVABLE") is False
+    # Defensive: None / numeric / empty.
+    assert _is_fatal_provider_error(None) is False
+    assert _is_fatal_provider_error("") is False
+    assert _is_fatal_provider_error(42) is False
+
+
+@pytest.mark.asyncio
+async def test_fatal_provider_error_marks_solver_unreachable():
+    """A `createTask` response carrying a fatal-config errorDescription
+    (zero balance, revoked key, banned account) must mark the
+    process-wide solver UNREACHABLE so subsequent solves short-circuit
+    cleanly through the existing health gate. Without this, three of
+    these in 5 minutes would trip the §11.16 breaker for the whole
+    BrowserManager — the breaker is meant for transient PROVIDER
+    outages, not operator-actionable config faults like 'top up your
+    account'."""
+    solver = _make_solver()
+    solver._solver_health_checked = True  # skip the probe
+
+    fatal_resp = MagicMock()
+    fatal_resp.json = MagicMock(return_value={
+        "errorId": 10,
+        "errorDescription": "ERROR_ZERO_BALANCE",
+    })
+    fatal_resp.raise_for_status = MagicMock()
+
+    client = AsyncMock(spec=httpx.AsyncClient)
+    client.is_closed = False
+    client.post = AsyncMock(return_value=fatal_resp)
+    solver._client = client
+
+    page = _solve_page()
+    result = await solver.solve(page, 'iframe[src*="recaptcha"]', "https://example.com")
+
+    assert bool(result) is False
+    assert solver._solver_unreachable is True
+    # And the breaker MUST be untouched — no transient-failure ticks.
+    assert len(solver._solver_failure_timestamps) == 0
+    assert solver.is_breaker_open() is False
+
+
+@pytest.mark.asyncio
+async def test_three_fatal_errors_do_not_trip_breaker():
+    """Three consecutive fatal-config responses must NOT trip the
+    breaker. Each one marks the solver unreachable and the next
+    `solve()` short-circuits through `_solver_unreachable`. This is the
+    regression case: pre-fix, a user whose key just ran out of balance
+    would burn the fleet's solver capacity for the whole 10-min breaker
+    window."""
+    solver = _make_solver()
+    solver._solver_health_checked = True
+
+    fatal_resp = MagicMock()
+    fatal_resp.json = MagicMock(return_value={
+        "errorId": 10,
+        "errorDescription": "ERROR_ZERO_BALANCE",
+    })
+    fatal_resp.raise_for_status = MagicMock()
+
+    client = AsyncMock(spec=httpx.AsyncClient)
+    client.is_closed = False
+    client.post = AsyncMock(return_value=fatal_resp)
+    solver._client = client
+
+    page = _solve_page()
+    for _ in range(_BREAKER_FAILURE_THRESHOLD):
+        await solver.solve(page, 'iframe[src*="recaptcha"]', "https://example.com")
+
+    assert solver._solver_unreachable is True
+    assert solver.is_breaker_open() is False
+    # First call hit the wire; subsequent two short-circuited via the
+    # unreachable flag, so no extra `createTask` HTTP calls.
+    assert client.post.await_count == 1
+
+
+@pytest.mark.asyncio
+async def test_non_fatal_provider_error_still_ticks_breaker():
+    """Regression check: an `ERROR_INVALID_SITEKEY` (transient/page-
+    specific) must still count toward the §11.16 breaker. Three of
+    those in a row should still trip the breaker — the fatal-error
+    short-circuit must NOT swallow ordinary failure signals."""
+    solver = _make_solver()
+    solver._solver_health_checked = True
+
+    transient_resp = MagicMock()
+    transient_resp.json = MagicMock(return_value={
+        "errorId": 1,
+        "errorDescription": "ERROR_INVALID_SITEKEY",
+    })
+    transient_resp.raise_for_status = MagicMock()
+
+    client = AsyncMock(spec=httpx.AsyncClient)
+    client.is_closed = False
+    client.post = AsyncMock(return_value=transient_resp)
+    solver._client = client
+
+    page = _solve_page()
+    for _ in range(_BREAKER_FAILURE_THRESHOLD):
+        await solver.solve(page, 'iframe[src*="recaptcha"]', "https://example.com")
+
+    assert solver._solver_unreachable is False
+    assert solver.is_breaker_open() is True
+
+
 # ── 10: concurrent solves while breaker open all short-circuit ────────
 
 
@@ -930,18 +1049,23 @@ class TestBreakerLocalVsProviderFailures:
 
     @pytest.mark.asyncio
     async def test_three_provider_500_failures_DO_trip_breaker(self):
-        """Provider-contacted failures (createTask 5xx, errorId>0,
-        timeouts during polling) MUST still trip the breaker — that's
-        the signal it was designed for."""
+        """Provider-contacted TRANSIENT failures (createTask 5xx,
+        non-fatal errorId>0, timeouts during polling) MUST still trip
+        the breaker — that's the signal it was designed for. Fatal
+        config errors (zero balance, revoked key) take a different
+        path — see ``test_three_fatal_errors_do_not_trip_breaker``."""
         solver = _make_solver(provider="2captcha")
         solver._solver_health_checked = True
 
         page = _solve_page()
 
-        # createTask returns errorId>0 — provider WAS contacted.
+        # createTask returns errorId>0 with a NON-fatal description so
+        # the fatal-config short-circuit doesn't fire — provider WAS
+        # contacted and the breaker SHOULD count this as a transient
+        # outage signal.
         err_resp = MagicMock()
         err_resp.json = MagicMock(return_value={
-            "errorId": 1, "errorDescription": "ERROR_KEY_DOES_NOT_EXIST",
+            "errorId": 1, "errorDescription": "ERROR_NO_SLOT_AVAILABLE",
         })
         err_resp.raise_for_status = MagicMock()
 
@@ -959,5 +1083,8 @@ class TestBreakerLocalVsProviderFailures:
                 )
 
         # Breaker SHOULD have tripped — these were real provider
-        # failures, not local classification gaps.
+        # failures, not local classification gaps and not fatal config.
         assert solver.is_breaker_open() is True
+        # And the solver was NOT marked unreachable — the operator
+        # doesn't need to restart for a transient capacity issue.
+        assert solver._solver_unreachable is False


### PR DESCRIPTION
Foundation PR for the stealth-browser review series. Three commits of focused, surgical fixes uncovered by an end-to-end trace of the agent → mesh → browser-service → Camoufox flow. Other roadmap PRs (solver failover, anti-bot task types, account warmup, per-platform dashboard) all stack on top of this one.

## Commits

### 1. `2e889bd` — protect solver breaker from config errors; speed up proxy push paths

Four focused fixes:

- **captcha breaker pollution from fatal config errors.** `_solve_2captcha`/`_solve_capsolver` returned `provider_contacted=True` on every `errorId>0`, so three `ERROR_ZERO_BALANCE` (or `ERROR_KEY_DOES_NOT_EXIST`, etc.) responses inside 5 minutes tripped the per-process breaker for 10 minutes — locking the *entire* BrowserManager (the solver is a process-wide singleton) out of solver duty even after the operator topped up. New `_FATAL_PROVIDER_ERROR_MARKERS` + `_handle_provider_error_response` flips `_solver_unreachable=True` so subsequent solves short-circuit through the existing health gate instead of polluting the breaker.
- **boot_id throttle.** `_check_browser_boot_id_changed` fired a `GET /browser/status` round-trip on every browser command. Bound to one probe per 30s.
- **cold-start race self-heal.** Deferred +5s startup push silently fails when the browser service isn't ready; pre-fix the first command then seeded `_last_browser_boot_id` and never re-pushed. Treat first successful contact as a restart so the auto-recovery path covers the cold-start race.
- **parallel proxy fan-out push** — sequential `for` → `asyncio.gather(return_exceptions=True)`.

### 2. `50f054d` — wire dashboard settings to cold-start path; tighten breaker fix

Three real wiring bugs flagged in self-review:

- **Dashboard CAPTCHA solver key was lost on cold start.** The dashboard saves provider/key to `config/settings.json` and the apply-settings handler bridges into `os.environ`. But `cli/runtime.py`'s startup loop only handled 4 unrelated keys — captcha settings ignored on cold start. Operators had to re-click "Apply Settings" after every host restart. Moved the bridge into `start_browser_service` so cold-start AND dashboard-apply both pick it up.
- **`browser_delay` setting silently reverted on container restart.** `start_browser_service` POSTed `{speed}` only; `delay` was never pushed. Now both are pushed.
- **Redundant first-command re-push.** Self-healing patch above made the first command always trigger a re-push for all agents even when the deferred startup push had succeeded. Seeding `_last_browser_boot_id` after a successful deferred push eliminates this on the happy path while preserving cold-start recovery.
- Polish: `_handle_provider_error_response` no longer logs `"None"` literal when provider returns no description.

### 3. `8020ef5` — per-platform pre-nav dwell for LinkedIn / X / Meta

Adds a Gaussian pre-nav delay that fires only when the target host is on a hard-coded protected-platform list. PerimeterX/HUMAN (LinkedIn), X's "Bird" risk model, and Meta's behavioral checkpoint logic all key on sub-second arrival timing — real users pause to focus the URL bar before hitting Enter. Tuning per platform:

* `linkedin.com`, `twitter.com`, `x.com` — μ=2.5–3s, σ=0.8–1s, clamped [0.8s, 6s].
* `facebook.com`, `instagram.com` — μ=4s, σ=1.2s, clamped [1.5s, 8s].

Operator override via `BROWSER_PLATFORM_TIMING_ENABLED=false` (global or per-agent). Wired into both `BrowserManager.navigate` and the `open_tab` new-tab path. Truncated-normal sampling deterministic with a seeded `Random` for replay-from-logs auditing.

## Tests

- 14 new tests across `tests/test_browser_platform_timing.py` (host matching, sampling, integration with manager + flag override) plus updates to existing captcha-health regression tests for the fatal-error markers.
- Full non-E2E suite: 4604 passed, 64 skipped. Three pre-existing env-dependent failures in `test_builtins.py` (root filesystem perms + outbound network) unchanged from `main`.
- ruff clean across `src/` + `tests/`.

## Stacking note

This is the foundation. Other PRs in the review series build on this:

- `claude/feat-solver-failover` — wraps two CaptchaSolver instances with primary/secondary failover.
- `claude/feat-antibot-task-types` — stacked on solver-failover; adds CapSolver anti-bot task types.
- `claude/feat-account-warmup` — independent; new `browser_warmup` agent skill.
- `claude/feat-platform-success-dashboard` — independent; per-platform success rollup panel.

Suggest merging in that order so each PR's diff against main stays clean.

---
_Generated by [Claude Code](https://claude.ai/code/session_019BMxHfdu7SqFZf84DQoLQi)_