### PR TITLE
stealth-browser: multi-provider CAPTCHA solver failover (§11.8)

### DIFF
--- a/src/browser/captcha.py
+++ b/src/browser/captcha.py
@@ -628,15 +628,55 @@ _DEFAULT_V3_ACTION = "verify"
 _DEFAULT_V3_MIN_SCORE = 0.7
 
 
-def get_solver() -> CaptchaSolver | None:
-    """Return the configured solver, or ``None`` if no provider is set.
+def _build_single_solver(
+    provider_flag: str, key_flag: str, *, label: str,
+) -> CaptchaSolver | None:
+    """Resolve one ``(provider, key)`` flag pair into a :class:`CaptchaSolver`.
 
-    Reads ``CAPTCHA_SOLVER_PROVIDER`` and ``CAPTCHA_SOLVER_KEY`` at
+    Shared loader for the primary and secondary solver slots used by
+    :func:`get_solver`. Returns ``None`` when either flag is unset or the
+    provider name isn't in :data:`_SUPPORTED_PROVIDERS` — the latter logs
+    a warning so an operator typo (``CAPTCHA_SOLVER_PROVIDER_SECONDARY=foo``)
+    surfaces cleanly instead of silently degrading to single-provider.
+    """
+    provider = flags.get_str(provider_flag, "").strip().lower()
+    api_key = flags.get_str(key_flag, "").strip()
+    if not provider or not api_key:
+        return None
+    if provider not in _SUPPORTED_PROVIDERS:
+        logger.warning(
+            "Unknown %s %r (expected one of %s), %s solver disabled",
+            provider_flag, provider, ", ".join(_SUPPORTED_PROVIDERS), label,
+        )
+        return None
+    logger.info("CAPTCHA %s solver configured: provider=%s", label, provider)
+    return CaptchaSolver(provider, api_key)
+
+
+def get_solver() -> "MultiProviderSolver | None":
+    """Return the configured solver wrapper, or ``None`` if none configured.
+
+    Reads ``CAPTCHA_SOLVER_PROVIDER`` / ``CAPTCHA_SOLVER_KEY`` for the
+    primary slot and ``CAPTCHA_SOLVER_PROVIDER_SECONDARY`` /
+    ``CAPTCHA_SOLVER_KEY_SECONDARY`` for the §11.8 failover slot at
     process startup. **Per-agent overrides are NOT supported for
     provider/key** — the solver is constructed once in
     ``BrowserManager.__init__`` and shared process-wide. The returned
-    instance carries stateful breaker / health-check / cost-counter
-    coupling that would not be safe to swap per-call.
+    wrapper carries stateful breaker / health-check / cost-counter
+    coupling on each underlying :class:`CaptchaSolver` that would not
+    be safe to swap per-call.
+
+    Returns:
+      * ``None`` — neither slot configured (no solver).
+      * :class:`MultiProviderSolver` with ``secondary=None`` —
+        single-provider deployment; failover paths are no-ops.
+      * :class:`MultiProviderSolver` with both slots populated —
+        full §11.8 failover behavior.
+
+    The wrapper exposes the same public surface as :class:`CaptchaSolver`
+    (``solve``, ``is_solver_unreachable``, ``is_breaker_open``,
+    ``health_check``, ``close``, ``provider``) so the rest of
+    :mod:`src.browser.service` stays unchanged.
 
     Use ``CAPTCHA_DISABLED`` per-agent to disable solving for a specific
     agent. Solver-proxy creds DO support per-agent override (see
@@ -645,19 +685,22 @@ def get_solver() -> CaptchaSolver | None:
     Live-reload requires browser-service restart; flag changes via
     ``config/settings.json`` take effect on the next process start.
     """
-    provider = flags.get_str("CAPTCHA_SOLVER_PROVIDER", "").strip().lower()
-    api_key = flags.get_str("CAPTCHA_SOLVER_KEY", "").strip()
-    if not provider or not api_key:
+    primary = _build_single_solver(
+        "CAPTCHA_SOLVER_PROVIDER", "CAPTCHA_SOLVER_KEY", label="primary",
+    )
+    if primary is None:
         return None
-    if provider not in _SUPPORTED_PROVIDERS:
-        logger.warning(
-            "Unknown CAPTCHA_SOLVER_PROVIDER %r (expected one of %s), solver disabled",
-            provider,
-            ", ".join(_SUPPORTED_PROVIDERS),
+    secondary = _build_single_solver(
+        "CAPTCHA_SOLVER_PROVIDER_SECONDARY",
+        "CAPTCHA_SOLVER_KEY_SECONDARY",
+        label="secondary",
+    )
+    if secondary is not None:
+        logger.info(
+            "CAPTCHA failover armed: primary=%s secondary=%s",
+            primary.provider, secondary.provider,
         )
-        return None
-    logger.info("CAPTCHA solver configured: provider=%s", provider)
-    return CaptchaSolver(provider, api_key)
+    return MultiProviderSolver(primary, secondary)
 
 
 def _classify_captcha(selector: str) -> str:
@@ -2257,3 +2300,247 @@ class CaptchaSolver:
         except Exception:
             logger.debug("Token injection error", exc_info=True)
         return False
+
+
+# ── §11.8 multi-provider failover wrapper ──────────────────────────────────
+
+
+class MultiProviderSolver:
+    """Failover wrapper around two :class:`CaptchaSolver` instances.
+
+    Public surface intentionally mirrors :class:`CaptchaSolver` so the
+    BrowserManager's :meth:`_metered_solve` and the up-stream gates in
+    ``service.py`` keep working without changes:
+
+      * :attr:`provider` — *active* solver's provider name (the one used
+        for the most recent solve, or the one that WILL be used when read
+        before a solve). Drives cost-counter pricing tier lookups.
+      * :meth:`solve` — async; routes to primary unless primary is
+        unreachable / breaker-open, then secondary. Mid-call fatal
+        primary failures (``token=None`` + ``_solver_unreachable`` newly
+        flipped) trigger one transparent retry on the secondary.
+      * :meth:`is_solver_unreachable` — async; True iff BOTH solvers are
+        unreachable (single-provider config: True iff primary is).
+      * :meth:`is_breaker_open` — sync; True iff BOTH breakers are open.
+      * :meth:`health_check` — runs both, returns the worst outcome
+        (``unreachable`` > ``degraded`` > ``healthy``).
+      * :meth:`close` — closes both underlying clients.
+
+    State isolation: each underlying :class:`CaptchaSolver` keeps its own
+    breaker, health-check flag, and failure window. A fatal-config error
+    on the primary does not affect the secondary, and vice versa — that
+    independence is the entire point of the wrapper.
+
+    Single-provider deployments (``secondary=None``) get a transparent
+    pass-through: every method behaves exactly as if the primary were
+    being used directly. Failover paths short-circuit cheaply.
+    """
+
+    def __init__(
+        self,
+        primary: CaptchaSolver,
+        secondary: CaptchaSolver | None,
+    ) -> None:
+        self.primary: CaptchaSolver = primary
+        self.secondary: CaptchaSolver | None = secondary
+        # The provider name that will be used for the NEXT solve under
+        # current state. Mutated by :meth:`_pick_solver` before a solve
+        # and again on mid-call failover so ``self.provider`` returns
+        # the right tier for cost accounting reads in
+        # :meth:`BrowserManager._metered_solve`.
+        self._active_solver: CaptchaSolver = primary
+
+    # ── pricing-tier surface for ``_metered_solve`` ─────────────────────
+
+    @property
+    def provider(self) -> str:
+        """Active solver's provider name.
+
+        Read by ``_metered_solve`` BEFORE :meth:`solve` to pick the
+        cost-cap reservation tier and AFTER :meth:`solve` to pick the
+        accounting tier. The wrapper updates ``_active_solver`` based on
+        current health state in :meth:`_pick_solver` so a pre-solve read
+        sees the solver that will actually be used.
+        """
+        return self._active_solver.provider
+
+    # ── routing ─────────────────────────────────────────────────────────
+
+    async def _pick_solver(self) -> CaptchaSolver | None:
+        """Choose the solver for the next solve attempt.
+
+        Returns the secondary when the primary is unreachable OR has an
+        open breaker; otherwise returns the primary. Returns ``None``
+        when both are unavailable — caller surfaces a no-token result
+        without contacting either provider.
+
+        Side effect: updates ``self._active_solver`` so the
+        :attr:`provider` property reads the right tier for cost
+        accounting on the upcoming solve.
+        """
+        primary_unreachable = await self.primary.is_solver_unreachable()
+        primary_breaker_open = self.primary.is_breaker_open()
+        primary_skip = primary_unreachable or primary_breaker_open
+
+        if not primary_skip:
+            self._active_solver = self.primary
+            return self.primary
+
+        if self.secondary is None:
+            # Single-provider config — no failover available. Keep
+            # ``_active_solver`` pointing at primary so the provider
+            # property remains consistent with what the caller would
+            # have seen pre-failover-feature.
+            self._active_solver = self.primary
+            return None
+
+        secondary_unreachable = await self.secondary.is_solver_unreachable()
+        secondary_breaker_open = self.secondary.is_breaker_open()
+        if secondary_unreachable or secondary_breaker_open:
+            # Both out — surface the same "no solver path" semantics as
+            # today's unreachable / breaker-open envelopes.
+            self._active_solver = self.primary
+            return None
+
+        self._active_solver = self.secondary
+        return self.secondary
+
+    async def solve(
+        self,
+        page,
+        selector: str,
+        page_url: str,
+        *,
+        agent_id: str | None = None,
+        kind: str | None = None,
+    ) -> SolveResult:
+        """Solve a CAPTCHA using primary, falling over to secondary on failure.
+
+        Routing decisions:
+
+          1. Primary healthy → call ``primary.solve()``. On a clean
+             ``token is None`` AND ``_solver_unreachable`` newly flipped
+             (commit 2e889bd's fatal-config gate), retry once on the
+             secondary in the same call. The flag is sticky so all
+             subsequent solves bypass primary.
+          2. Primary unreachable / breaker-open → skip primary entirely,
+             call ``secondary.solve()``.
+          3. Both unreachable / breaker-open → return a no-token
+             :class:`SolveResult` without contacting either provider,
+             matching today's "no solver" envelope path.
+        """
+        target = await self._pick_solver()
+        if target is None:
+            # Both primary and secondary are unavailable. Mirror the
+            # short-circuit shape used by the underlying solver's own
+            # unreachable / breaker-open paths.
+            logger.info(
+                "Skipping solve: both solvers unavailable "
+                "(primary=%s secondary=%s)",
+                self.primary.provider,
+                self.secondary.provider if self.secondary else "<unset>",
+            )
+            return SolveResult(
+                token=None, injection_succeeded=False,
+                used_proxy_aware=False, compat_rejected=False,
+            )
+
+        result = await target.solve(
+            page, selector, page_url,
+            agent_id=agent_id, kind=kind,
+        )
+
+        # §11.8 mid-call failover: primary's fatal-config gate
+        # (``_handle_provider_error_response`` from commit 2e889bd) flips
+        # ``_solver_unreachable`` AFTER the provider HTTP call has already
+        # returned a no-token outcome. The pre-solve gate in
+        # :meth:`_pick_solver` couldn't see that yet. When it happens on
+        # the primary AND a secondary is configured, retry once.
+        if (
+            target is self.primary
+            and result.token is None
+            and self.primary._solver_unreachable
+            and self.secondary is not None
+        ):
+            secondary_unreachable = await self.secondary.is_solver_unreachable()
+            secondary_breaker_open = self.secondary.is_breaker_open()
+            if not (secondary_unreachable or secondary_breaker_open):
+                logger.warning(
+                    "Primary solver flipped unreachable mid-call; "
+                    "retrying on secondary (primary=%s secondary=%s)",
+                    self.primary.provider, self.secondary.provider,
+                )
+                self._active_solver = self.secondary
+                return await self.secondary.solve(
+                    page, selector, page_url,
+                    agent_id=agent_id, kind=kind,
+                )
+
+        return result
+
+    # ── health surface ──────────────────────────────────────────────────
+
+    async def is_solver_unreachable(self) -> bool:
+        """True iff BOTH solvers are unreachable.
+
+        Drives the pre-solve gate in :meth:`_check_captcha`. Returning
+        True yields the existing ``no_solver`` envelope path;
+        single-provider deployments collapse to "primary unreachable".
+        """
+        if not await self.primary.is_solver_unreachable():
+            return False
+        if self.secondary is None:
+            return True
+        return await self.secondary.is_solver_unreachable()
+
+    def is_breaker_open(self) -> bool:
+        """True iff BOTH breakers are open.
+
+        Drives the pre-solve breaker gate in :meth:`_check_captcha`.
+        Single-provider deployments collapse to "primary breaker open".
+        """
+        if not self.primary.is_breaker_open():
+            return False
+        if self.secondary is None:
+            return True
+        return self.secondary.is_breaker_open()
+
+    async def health_check(
+        self, provider: str | None = None,
+    ) -> Literal["healthy", "degraded", "unreachable"]:
+        """Probe both solvers and return the worst outcome.
+
+        Worst-case ranking: ``unreachable`` > ``degraded`` > ``healthy``.
+        Operators reading this signal want to know whether at least one
+        provider is reachable; ``healthy`` here means "both healthy",
+        ``degraded`` means "at least one degraded but neither
+        unreachable", ``unreachable`` means "both unreachable" — the
+        only state where solving is truly unavailable.
+
+        ``provider`` argument is accepted for parity with
+        :meth:`CaptchaSolver.health_check` but ignored (the wrapper
+        always probes both underlying solvers).
+        """
+        primary_outcome = await self.primary.health_check()
+        if self.secondary is None:
+            return primary_outcome
+        secondary_outcome = await self.secondary.health_check()
+        # Worst-case fold: any "unreachable" wins only when BOTH agree;
+        # otherwise downgrade to the worse of the two non-unreachable
+        # outcomes.
+        if primary_outcome == "unreachable" and secondary_outcome == "unreachable":
+            return "unreachable"
+        if primary_outcome == "degraded" or secondary_outcome == "degraded":
+            return "degraded"
+        if primary_outcome == "unreachable" or secondary_outcome == "unreachable":
+            # One side unreachable, the other healthy/degraded — surface
+            # ``degraded`` so operators see the partial fault without
+            # the wrapper claiming "totally unreachable".
+            return "degraded"
+        return "healthy"
+
+    async def close(self) -> None:
+        """Close both underlying solver clients."""
+        await self.primary.close()
+        if self.secondary is not None:
+            await self.secondary.close()

--- a/src/browser/service.py
+++ b/src/browser/service.py
@@ -7526,6 +7526,20 @@ class BrowserManager:
                 )
                 raise
 
+            # §11.8 multi-provider: re-read the wrapper's ``provider``
+            # AFTER ``solve()`` so the cost-accounting tier matches the
+            # provider that actually served the solve, not the one we
+            # captured pre-call. On a mid-call failover (primary fatal
+            # at ``createTask`` → wrapper retries on secondary inside
+            # the same ``solve()`` call) the active solver flips, and
+            # using the stale pre-call snapshot would charge the agent
+            # at primary's pricing for a secondary-served solve. The
+            # post-solve read is single-coroutine-safe — there is no
+            # await between this read and the cost-counter update.
+            actual_provider = getattr(self._captcha_solver, "provider", "")
+            if not (isinstance(actual_provider, str) and actual_provider):
+                actual_provider = provider
+
             # Cost accounting fires on token retrieval, NOT on
             # injection success — the provider already charged for the
             # token. Skip accounting when no token came back (gates /
@@ -7538,9 +7552,9 @@ class BrowserManager:
                 # was warned above; here we just skip the increment
                 # silently and let the finally-refund clean up the
                 # reservation.
-                if isinstance(provider, str) and provider:
+                if isinstance(actual_provider, str) and actual_provider:
                     millicents = _cost.estimate_millicents(
-                        provider, kind,
+                        actual_provider, kind,
                         proxy_aware=result.used_proxy_aware,
                     )
                     if millicents is None:
@@ -7550,7 +7564,7 @@ class BrowserManager:
                             "keeping any reserved cost-cap charge; "
                             "otherwise skipping cost increment "
                             "(under-count > over-count)",
-                            provider, kind, result.used_proxy_aware,
+                            actual_provider, kind, result.used_proxy_aware,
                         )
                         # With a configured cap, we reserved the max
                         # published tier before the provider call. If

--- a/tests/test_browser_service.py
+++ b/tests/test_browser_service.py
@@ -7594,20 +7594,31 @@ class TestGetSolver:
                 flags.reload_operator_settings()
 
     def test_get_solver_returns_solver_when_configured(self):
-        """Valid provider + key env flags → CaptchaSolver instance."""
+        """Valid provider + key env flags → MultiProviderSolver instance.
+
+        §11.8: ``get_solver`` now returns the failover wrapper. With only
+        the primary slot configured the wrapper holds ``secondary=None``
+        and behaves as a single-provider solver — the existing call
+        sites (``BrowserManager._captcha_solver`` and
+        ``_metered_solve``) read ``solver.provider`` through the
+        wrapper's property, so ``MultiProviderSolver`` is the correct
+        public surface.
+        """
         with patch.dict("os.environ", {
             "CAPTCHA_SOLVER_PROVIDER": "2captcha",
             "CAPTCHA_SOLVER_KEY": "test-key-123",
         }):
             from src.browser import flags
-            from src.browser.captcha import CaptchaSolver, get_solver
+            from src.browser.captcha import MultiProviderSolver, get_solver
 
             flags.reload_operator_settings()
             try:
                 solver = get_solver()
-                assert isinstance(solver, CaptchaSolver)
+                assert isinstance(solver, MultiProviderSolver)
                 assert solver.provider == "2captcha"
-                assert solver.api_key == "test-key-123"
+                assert solver.primary.api_key == "test-key-123"
+                # Single-provider config — secondary slot empty.
+                assert solver.secondary is None
             finally:
                 flags.reload_operator_settings()
 
@@ -7629,16 +7640,16 @@ class TestGetSolver:
             "CAPTCHA_SOLVER_KEY": "env-key-789",
         }, clear=True):
             from src.browser import flags
-            from src.browser.captcha import CaptchaSolver, get_solver
+            from src.browser.captcha import MultiProviderSolver, get_solver
 
             flags.reload_operator_settings()
             try:
                 solver = get_solver()
-                assert isinstance(solver, CaptchaSolver)
+                assert isinstance(solver, MultiProviderSolver)
                 assert solver.provider == "capsolver"
                 # The env-var key WINS — settings.json plaintext key was
                 # ignored at load time per the env-only flag policy.
-                assert solver.api_key == "env-key-789"
+                assert solver.primary.api_key == "env-key-789"
             finally:
                 flags.reload_operator_settings()
 

--- a/tests/test_solver_failover.py
+++ b/tests/test_solver_failover.py
@@ -1,0 +1,553 @@
+"""Tests for §11.8: multi-provider CAPTCHA solver failover.
+
+Covers the :class:`MultiProviderSolver` wrapper that fronts a primary +
+optional secondary :class:`CaptchaSolver` so the BrowserManager can
+transparently route around primary outages without hard-restarting.
+
+Test surface (numbered to match the spec):
+
+  1. Primary healthy + secondary configured → primary wins, secondary
+     untouched.
+  2. Primary ``_solver_unreachable=True`` (e.g. fatal-config error from
+     a prior call) → wrapper routes to secondary on next solve.
+  3. Primary breaker open → wrapper routes to secondary.
+  4. Primary fatal-error mid-call (returns ``token=None`` AND flips
+     ``_solver_unreachable``) → wrapper retries on secondary inside the
+     SAME ``solve()`` call.
+  5. Both primary and secondary unreachable → no-token result, no
+     provider HTTP issued.
+  6. Single-provider config (``secondary=None``) → wrapper transparent;
+     behaves identically to the underlying primary.
+  7. Cost accounting: when secondary wins, ``solver.provider`` returns
+     the secondary's provider name so :meth:`_metered_solve` looks up
+     the right pricing tier.
+  8. ``health_check()`` runs both and returns the worst outcome.
+  9. Typo'd ``CAPTCHA_SOLVER_PROVIDER_SECONDARY`` (unsupported value)
+     → secondary falls back to ``None``; wrapper degrades gracefully to
+     single-provider behavior.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import httpx
+import pytest
+
+from src.browser.captcha import (
+    CaptchaSolver,
+    MultiProviderSolver,
+    SolveResult,
+    get_solver,
+)
+
+# ── helpers ─────────────────────────────────────────────────────────────
+
+
+def _make_solver(provider: str = "2captcha", key: str = "SECRET-PRIMARY") -> CaptchaSolver:
+    return CaptchaSolver(provider, key)
+
+
+def _ok_balance_resp(balance: float = 12.34) -> MagicMock:
+    resp = MagicMock()
+    resp.status_code = 200
+    resp.json = MagicMock(return_value={"errorId": 0, "balance": balance})
+    return resp
+
+
+def _stub_create_then_poll(token: str | None) -> list[MagicMock]:
+    """Build a (createTask, getTaskResult) response pair for the solve flow."""
+    create = MagicMock()
+    create.json = MagicMock(return_value={"errorId": 0, "taskId": "T-1"})
+    create.raise_for_status = MagicMock()
+    poll = MagicMock()
+    if token is None:
+        poll.json = MagicMock(return_value={"errorId": 1, "errorDescription": "fail"})
+    else:
+        poll.json = MagicMock(return_value={
+            "errorId": 0, "status": "ready",
+            "solution": {"gRecaptchaResponse": token},
+        })
+    poll.raise_for_status = MagicMock()
+    return [create, poll]
+
+
+def _stub_fatal_create() -> MagicMock:
+    """A createTask response carrying a fatal-config marker.
+
+    Provider returns ``errorId>0`` with one of the operator-actionable
+    descriptions (drained balance, revoked key). Triggers
+    :meth:`CaptchaSolver._handle_provider_error_response` to flip
+    ``_solver_unreachable`` to ``True``.
+    """
+    create = MagicMock()
+    create.json = MagicMock(return_value={
+        "errorId": 10,
+        "errorDescription": "ERROR_ZERO_BALANCE",
+    })
+    create.raise_for_status = MagicMock()
+    return create
+
+
+def _solve_page() -> MagicMock:
+    """Mock Playwright page that returns a sitekey + accepts injection."""
+    page = AsyncMock()
+    page.evaluate = AsyncMock(return_value="site-key-abc")
+    page.url = "https://example.com"
+    return page
+
+
+def _attach_client(solver: CaptchaSolver, *, responses) -> AsyncMock:
+    """Mount an AsyncMock httpx client on ``solver`` with scripted responses.
+
+    ``responses`` may be a list (consumed in order) or any side_effect
+    accepted by ``AsyncMock``.
+    """
+    client = AsyncMock(spec=httpx.AsyncClient)
+    client.is_closed = False
+    client.post = AsyncMock(side_effect=responses)
+    solver._client = client
+    return client
+
+
+# ── 1: primary healthy → primary wins, secondary untouched ──────────────
+
+
+@pytest.mark.asyncio
+async def test_primary_healthy_secondary_untouched():
+    """When primary is healthy, every solve hits the primary; the
+    secondary's HTTP client is never invoked."""
+    primary = _make_solver("2captcha")
+    secondary = _make_solver("capsolver", "SECRET-SECONDARY")
+    wrapper = MultiProviderSolver(primary, secondary)
+
+    primary_client = _attach_client(primary, responses=[
+        _ok_balance_resp(),
+        *_stub_create_then_poll("tok-primary"),
+    ])
+    secondary_client = _attach_client(secondary, responses=[])
+
+    page = _solve_page()
+    with patch("src.browser.captcha._POLL_INTERVAL", 0.001):
+        result = await wrapper.solve(
+            page, 'iframe[src*="recaptcha"]', "https://example.com",
+        )
+
+    assert result.token == "tok-primary"
+    # Primary saw the probe + createTask + poll; secondary saw nothing.
+    assert primary_client.post.await_count == 3
+    assert secondary_client.post.await_count == 0
+    assert wrapper.provider == "2captcha"
+
+
+# ── 2: primary unreachable → wrapper routes to secondary ────────────────
+
+
+@pytest.mark.asyncio
+async def test_primary_unreachable_routes_to_secondary():
+    """Primary's sticky ``_solver_unreachable`` flag (e.g. set by a prior
+    fatal-config response) must steer the wrapper to the secondary on
+    subsequent solves WITHOUT contacting the primary at all."""
+    primary = _make_solver("2captcha")
+    secondary = _make_solver("capsolver", "SECRET-SECONDARY")
+    wrapper = MultiProviderSolver(primary, secondary)
+
+    # Pre-flip the primary's sticky unreachable flag and the
+    # health-checked latch so the wrapper sees "primary out" without
+    # firing a new probe.
+    primary._solver_unreachable = True
+    primary._solver_health_checked = True
+
+    primary_client = _attach_client(primary, responses=[])
+    secondary_client = _attach_client(secondary, responses=[
+        _ok_balance_resp(),
+        *_stub_create_then_poll("tok-secondary"),
+    ])
+
+    page = _solve_page()
+    with patch("src.browser.captcha._POLL_INTERVAL", 0.001):
+        result = await wrapper.solve(
+            page, 'iframe[src*="recaptcha"]', "https://example.com",
+        )
+
+    assert result.token == "tok-secondary"
+    assert primary_client.post.await_count == 0
+    assert secondary_client.post.await_count == 3
+    # Provider property reflects the active (winning) solver so cost
+    # accounting picks up the secondary's pricing tier.
+    assert wrapper.provider == "capsolver"
+
+
+# ── 3: primary breaker open → wrapper routes to secondary ───────────────
+
+
+@pytest.mark.asyncio
+async def test_primary_breaker_open_routes_to_secondary():
+    """Trip the primary's breaker (3 failures in 5 min) and verify the
+    wrapper bypasses primary on the next solve, going straight to
+    secondary."""
+    import time
+
+    primary = _make_solver("2captcha")
+    secondary = _make_solver("capsolver", "SECRET-SECONDARY")
+    wrapper = MultiProviderSolver(primary, secondary)
+
+    primary._solver_health_checked = True
+    base = 1_000_000.0
+    with patch("src.browser.captcha.time.time", return_value=base):
+        for _ in range(3):
+            await primary._record_solver_outcome(success=False)
+        assert primary.is_breaker_open() is True
+
+    primary_client = _attach_client(primary, responses=[])
+    secondary_client = _attach_client(secondary, responses=[
+        _ok_balance_resp(),
+        *_stub_create_then_poll("tok-secondary-2"),
+    ])
+
+    page = _solve_page()
+    with patch("src.browser.captcha.time.time", return_value=base), \
+         patch("src.browser.captcha._POLL_INTERVAL", 0.001):
+        result = await wrapper.solve(
+            page, 'iframe[src*="recaptcha"]', "https://example.com",
+        )
+
+    assert result.token == "tok-secondary-2"
+    assert primary_client.post.await_count == 0
+    assert secondary_client.post.await_count == 3
+    assert wrapper.provider == "capsolver"
+    # Primary breaker still open, primary's local state untouched.
+    with patch("src.browser.captcha.time.time", return_value=base):
+        assert primary.is_breaker_open() is True
+    _ = time  # silence unused-import in narrow scope
+
+
+# ── 4: primary fatal-error mid-call → automatic retry on secondary ──────
+
+
+@pytest.mark.asyncio
+async def test_primary_fatal_mid_call_retries_on_secondary():
+    """The §11.8 mid-call failover path: primary appears healthy at the
+    routing decision, gets called, and the provider returns a
+    fatal-config error (``ERROR_ZERO_BALANCE``) which flips
+    ``_solver_unreachable``. The wrapper must retry on secondary inside
+    the SAME ``solve()`` call so the agent gets a token instead of an
+    immediate ``no_solver`` envelope."""
+    primary = _make_solver("2captcha")
+    secondary = _make_solver("capsolver", "SECRET-SECONDARY")
+    wrapper = MultiProviderSolver(primary, secondary)
+
+    # Primary: getBalance succeeds, then createTask returns a fatal
+    # config error (drains balance scenario). After this the
+    # ``_handle_provider_error_response`` path inside ``_solve_2captcha``
+    # flips ``_solver_unreachable=True``.
+    primary_client = _attach_client(primary, responses=[
+        _ok_balance_resp(),
+        _stub_fatal_create(),
+    ])
+    secondary_client = _attach_client(secondary, responses=[
+        _ok_balance_resp(),
+        *_stub_create_then_poll("tok-failover"),
+    ])
+
+    page = _solve_page()
+    with patch("src.browser.captcha._POLL_INTERVAL", 0.001):
+        result = await wrapper.solve(
+            page, 'iframe[src*="recaptcha"]', "https://example.com",
+        )
+
+    # Token came from the secondary (failover succeeded).
+    assert result.token == "tok-failover"
+    # Primary issued the probe + the fatal createTask.
+    assert primary_client.post.await_count == 2
+    # Secondary issued probe + create + poll.
+    assert secondary_client.post.await_count == 3
+    # Primary's flag flipped; subsequent solves go straight to secondary.
+    assert primary._solver_unreachable is True
+    # Provider property now reflects the secondary (cost tier).
+    assert wrapper.provider == "capsolver"
+
+    # Subsequent solve: primary is now sticky-unreachable so the wrapper
+    # short-circuits to secondary directly with no further primary
+    # traffic.
+    secondary_client.post = AsyncMock(side_effect=_stub_create_then_poll("tok-2"))
+    primary_post_count_before = primary_client.post.await_count
+    with patch("src.browser.captcha._POLL_INTERVAL", 0.001):
+        result2 = await wrapper.solve(
+            page, 'iframe[src*="recaptcha"]', "https://example.com",
+        )
+    assert result2.token == "tok-2"
+    assert primary_client.post.await_count == primary_post_count_before
+
+
+# ── 5: both unreachable → no-token result, no provider HTTP ────────────
+
+
+@pytest.mark.asyncio
+async def test_both_unreachable_returns_no_token_no_http():
+    """If both solvers are marked unreachable, the wrapper must NOT
+    contact either provider. The result mirrors today's no-solver
+    envelope so the caller surfaces ``solver_outcome="no_solver"``."""
+    primary = _make_solver("2captcha")
+    secondary = _make_solver("capsolver", "SECRET-SECONDARY")
+    wrapper = MultiProviderSolver(primary, secondary)
+
+    primary._solver_unreachable = True
+    primary._solver_health_checked = True
+    secondary._solver_unreachable = True
+    secondary._solver_health_checked = True
+
+    primary_client = _attach_client(primary, responses=[])
+    secondary_client = _attach_client(secondary, responses=[])
+
+    page = _solve_page()
+    result = await wrapper.solve(
+        page, 'iframe[src*="recaptcha"]', "https://example.com",
+    )
+
+    assert isinstance(result, SolveResult)
+    assert result.token is None
+    assert result.injection_succeeded is False
+    assert primary_client.post.await_count == 0
+    assert secondary_client.post.await_count == 0
+
+    # Wrapper-level gate also reports both-unreachable to the caller.
+    assert await wrapper.is_solver_unreachable() is True
+
+
+# ── 6: single-provider config → transparent pass-through ────────────────
+
+
+@pytest.mark.asyncio
+async def test_single_provider_config_transparent_passthrough():
+    """``secondary=None`` collapses every wrapper method to the
+    underlying primary's behavior. Failover paths become no-ops."""
+    primary = _make_solver("2captcha")
+    wrapper = MultiProviderSolver(primary, None)
+
+    primary_client = _attach_client(primary, responses=[
+        _ok_balance_resp(),
+        *_stub_create_then_poll("tok-only"),
+    ])
+
+    page = _solve_page()
+    with patch("src.browser.captcha._POLL_INTERVAL", 0.001):
+        result = await wrapper.solve(
+            page, 'iframe[src*="recaptcha"]', "https://example.com",
+        )
+
+    assert result.token == "tok-only"
+    assert wrapper.provider == "2captcha"
+    assert primary_client.post.await_count == 3
+
+    # is_solver_unreachable / is_breaker_open delegate to primary alone.
+    assert await wrapper.is_solver_unreachable() is False
+    primary._solver_unreachable = True
+    primary._solver_health_checked = True
+    assert await wrapper.is_solver_unreachable() is True
+
+    assert wrapper.is_breaker_open() is False
+
+
+# ── 7: cost accounting picks up secondary's provider tier ──────────────
+
+
+@pytest.mark.asyncio
+async def test_cost_accounting_uses_secondary_provider_after_failover():
+    """When the secondary wins, ``wrapper.provider`` must equal the
+    secondary's provider name so ``_metered_solve``'s pricing lookup
+    (via ``estimate_millicents(provider, kind, ...)``) picks the right
+    tier. This is the property exercised by every reservation /
+    accounting test in ``test_check_captcha_metered.py``."""
+    primary = _make_solver("2captcha")
+    secondary = _make_solver("capsolver", "SECRET-SECONDARY")
+    wrapper = MultiProviderSolver(primary, secondary)
+
+    # Pre-solve provider is the primary's by default — the
+    # ``_metered_solve`` reservation reads ``solver.provider`` *before*
+    # calling solve, and at that point we haven't routed yet. The pick
+    # is updated as soon as a solve attempt is committed.
+    assert wrapper.provider == "2captcha"
+
+    # Mark primary out; the next ``_pick_solver`` call (driven by
+    # ``solve``) updates the active solver to the secondary.
+    primary._solver_unreachable = True
+    primary._solver_health_checked = True
+    secondary_client = _attach_client(secondary, responses=[
+        _ok_balance_resp(),
+        *_stub_create_then_poll("tok-from-secondary"),
+    ])
+    page = _solve_page()
+    with patch("src.browser.captcha._POLL_INTERVAL", 0.001):
+        result = await wrapper.solve(
+            page, 'iframe[src*="recaptcha"]', "https://example.com",
+        )
+
+    assert result.token == "tok-from-secondary"
+    # After the routing decision the property reflects the active
+    # solver — this is what ``_metered_solve`` reads to pick the
+    # accounting tier.
+    assert wrapper.provider == "capsolver"
+    _ = secondary_client
+
+
+# ── 8: health_check folds both solvers into a worst-case verdict ───────
+
+
+@pytest.mark.asyncio
+async def test_health_check_runs_both_and_reports_worst():
+    """The wrapper's ``health_check`` calls each underlying probe and
+    returns the worst outcome the operator should see:
+
+      * both healthy → ``healthy``
+      * one degraded, one healthy → ``degraded``
+      * both unreachable → ``unreachable``
+      * one unreachable, one healthy → ``degraded`` (partial fault, not
+        a total outage; operator wants to know the wrapper is still
+        usable through the survivor).
+    """
+    primary = _make_solver("2captcha")
+    secondary = _make_solver("capsolver", "SECRET-SECONDARY")
+    wrapper = MultiProviderSolver(primary, secondary)
+
+    # Both healthy
+    primary.health_check = AsyncMock(return_value="healthy")
+    secondary.health_check = AsyncMock(return_value="healthy")
+    assert await wrapper.health_check() == "healthy"
+
+    # One degraded, one healthy → degraded
+    primary.health_check = AsyncMock(return_value="degraded")
+    secondary.health_check = AsyncMock(return_value="healthy")
+    assert await wrapper.health_check() == "degraded"
+
+    # Both unreachable → unreachable
+    primary.health_check = AsyncMock(return_value="unreachable")
+    secondary.health_check = AsyncMock(return_value="unreachable")
+    assert await wrapper.health_check() == "unreachable"
+
+    # One unreachable, one healthy → degraded (partial fault)
+    primary.health_check = AsyncMock(return_value="unreachable")
+    secondary.health_check = AsyncMock(return_value="healthy")
+    assert await wrapper.health_check() == "degraded"
+
+    # One unreachable, one degraded → degraded
+    primary.health_check = AsyncMock(return_value="unreachable")
+    secondary.health_check = AsyncMock(return_value="degraded")
+    assert await wrapper.health_check() == "degraded"
+
+    # Single-provider config — health_check defers to primary alone.
+    wrapper_solo = MultiProviderSolver(primary, None)
+    primary.health_check = AsyncMock(return_value="degraded")
+    assert await wrapper_solo.health_check() == "degraded"
+
+
+# ── 9: typo'd secondary provider → graceful single-provider fallback ───
+
+
+_SOLVER_FLAG_KEYS = (
+    "CAPTCHA_SOLVER_PROVIDER",
+    "CAPTCHA_SOLVER_KEY",
+    "CAPTCHA_SOLVER_PROVIDER_SECONDARY",
+    "CAPTCHA_SOLVER_KEY_SECONDARY",
+)
+
+
+def _patch_env(values: dict[str, str]):
+    """Patch ``os.environ`` for the four solver flag keys.
+
+    ``flags.get_str`` reads through ``os.environ.get`` after walking the
+    per-agent + operator-settings layers, so patching the environment
+    is the simplest way to drive :func:`get_solver` end-to-end without
+    touching the test settings file.
+    """
+    import os
+
+    cleaned: dict[str, str] = {k: "" for k in _SOLVER_FLAG_KEYS}
+    cleaned.update(values)
+    return patch.dict(os.environ, cleaned, clear=False)
+
+
+def test_get_solver_unsupported_secondary_falls_back_to_single():
+    """An unrecognised ``CAPTCHA_SOLVER_PROVIDER_SECONDARY`` value
+    (``foo``) MUST NOT silently degrade the primary or raise. The
+    wrapper builds with ``secondary=None`` and behaves exactly like a
+    single-provider deployment."""
+    with _patch_env({
+        "CAPTCHA_SOLVER_PROVIDER": "2captcha",
+        "CAPTCHA_SOLVER_KEY": "PRIMARY-KEY",
+        "CAPTCHA_SOLVER_PROVIDER_SECONDARY": "foo",   # typo
+        "CAPTCHA_SOLVER_KEY_SECONDARY": "SECONDARY-KEY",
+    }):
+        wrapper = get_solver()
+
+    assert isinstance(wrapper, MultiProviderSolver)
+    assert wrapper.primary.provider == "2captcha"
+    assert wrapper.secondary is None
+    # Provider exposed for cost lookups still resolves cleanly.
+    assert wrapper.provider == "2captcha"
+
+
+def test_get_solver_no_secondary_yields_wrapper_with_secondary_none():
+    """The common single-provider deployment path: only the primary
+    flags are set; the wrapper is built with ``secondary=None`` and
+    every failover path becomes a no-op."""
+    with _patch_env({
+        "CAPTCHA_SOLVER_PROVIDER": "capsolver",
+        "CAPTCHA_SOLVER_KEY": "ONLY-KEY",
+    }):
+        wrapper = get_solver()
+
+    assert isinstance(wrapper, MultiProviderSolver)
+    assert wrapper.primary.provider == "capsolver"
+    assert wrapper.secondary is None
+
+
+def test_get_solver_no_provider_yields_none():
+    """Neither slot configured → ``get_solver`` returns ``None`` so the
+    BrowserManager skips wrapper construction entirely (existing
+    behavior)."""
+    with _patch_env({}):
+        assert get_solver() is None
+
+
+def test_get_solver_both_configured_yields_armed_wrapper():
+    """Happy path: both slots set, both supported → wrapper has both
+    primary and secondary populated."""
+    with _patch_env({
+        "CAPTCHA_SOLVER_PROVIDER": "2captcha",
+        "CAPTCHA_SOLVER_KEY": "PRIMARY-KEY",
+        "CAPTCHA_SOLVER_PROVIDER_SECONDARY": "capsolver",
+        "CAPTCHA_SOLVER_KEY_SECONDARY": "SECONDARY-KEY",
+    }):
+        wrapper = get_solver()
+
+    assert isinstance(wrapper, MultiProviderSolver)
+    assert wrapper.primary.provider == "2captcha"
+    assert wrapper.secondary is not None
+    assert wrapper.secondary.provider == "capsolver"
+
+
+# ── close() closes both underlying clients ────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_close_closes_both_underlying_clients():
+    """``close`` must propagate to BOTH solvers so neither leaks a
+    connection pool on shutdown."""
+    primary = _make_solver("2captcha")
+    secondary = _make_solver("capsolver", "SECRET-SECONDARY")
+    wrapper = MultiProviderSolver(primary, secondary)
+
+    primary.close = AsyncMock()
+    secondary.close = AsyncMock()
+    await wrapper.close()
+    primary.close.assert_awaited_once()
+    secondary.close.assert_awaited_once()
+
+    # Single-provider variant: only primary is closed; secondary is
+    # untouched (it doesn't exist).
+    primary2 = _make_solver("2captcha")
+    wrapper2 = MultiProviderSolver(primary2, None)
+    primary2.close = AsyncMock()
+    await wrapper2.close()
+    primary2.close.assert_awaited_once()

--- a/tests/test_solver_failover.py
+++ b/tests/test_solver_failover.py
@@ -551,3 +551,70 @@ async def test_close_closes_both_underlying_clients():
     primary2.close = AsyncMock()
     await wrapper2.close()
     primary2.close.assert_awaited_once()
+
+
+# ── 14: post-solve provider-tier read for cost accounting ──────────────
+
+
+@pytest.mark.asyncio
+async def test_provider_property_reflects_active_solver_after_pick():
+    """Pre-solve cost-cap reservation reads ``wrapper.provider`` to pick
+    the pricing tier. When primary is unreachable and secondary is
+    healthy, the wrapper should expose secondary's provider so the
+    reservation matches the solver that will actually be charged."""
+    primary = _make_solver("2captcha")
+    primary._solver_health_checked = True
+    primary._solver_unreachable = True  # primary out
+    secondary = _make_solver("capsolver", "SECRET-S")
+    secondary._solver_health_checked = True
+
+    wrapper = MultiProviderSolver(primary, secondary)
+    chosen = await wrapper._pick_solver()
+    assert chosen is secondary
+    # Property reflects the chosen secondary so cost accounting reads
+    # capsolver's tier, not 2captcha's stale pre-failover snapshot.
+    assert wrapper.provider == "capsolver"
+
+
+@pytest.mark.asyncio
+async def test_provider_flips_on_mid_call_failover():
+    """Mid-call failover (primary returns no token + flips
+    ``_solver_unreachable``) must update ``_active_solver`` so a
+    post-solve ``wrapper.provider`` read sees the secondary that
+    served the retry."""
+    primary = _make_solver("2captcha")
+    primary._solver_health_checked = True
+    secondary = _make_solver("capsolver", "SECRET-S")
+    secondary._solver_health_checked = True
+
+    wrapper = MultiProviderSolver(primary, secondary)
+
+    # Primary's solve flips unreachable mid-call (fatal-config gate).
+    fatal_solve = AsyncMock(return_value=SolveResult(
+        token=None, injection_succeeded=False,
+        used_proxy_aware=False, compat_rejected=False,
+    ))
+
+    def _flip_then_call(*a, **kw):
+        primary._solver_unreachable = True
+        return fatal_solve(*a, **kw)
+    primary.solve = MagicMock(side_effect=_flip_then_call)
+
+    # Secondary returns a normal token.
+    secondary.solve = AsyncMock(return_value=SolveResult(
+        token="tok-from-secondary", injection_succeeded=True,
+        used_proxy_aware=False, compat_rejected=False,
+    ))
+
+    page = MagicMock()
+    page.evaluate = AsyncMock()
+    page.url = "https://example.com/"
+    result = await wrapper.solve(page, "selector", "https://example.com/")
+
+    assert result.token == "tok-from-secondary"
+    primary.solve.assert_called_once()
+    secondary.solve.assert_awaited_once()
+    # Post-solve, the wrapper exposes secondary's provider — the cost
+    # accounting in ``_metered_solve`` reads this AFTER ``solve()``
+    # returns, so secondary's pricing tier applies to the actual charge.
+    assert wrapper.provider == "capsolver"


### PR DESCRIPTION
Wires the previously-stubbed `CAPTCHA_SOLVER_PROVIDER_SECONDARY` / `CAPTCHA_SOLVER_KEY_SECONDARY` flags so a secondary solver transparently takes over when the primary is unreachable, has an open breaker, or flips into a fatal-config state mid-call. Companion to the anti-bot-task-types PR — that one stacks on this branch.

## What's new

`MultiProviderSolver` wraps two `CaptchaSolver` instances with the same public surface (`solve`, `is_solver_unreachable`, `is_breaker_open`, `health_check`, `close`, `provider`). `BrowserManager._metered_solve` keeps using the same interface — no rewrites elsewhere.

Routing decisions:

1. **Primary healthy** → `primary.solve()`. Active solver = primary.
2. **Primary unreachable / breaker-open** → `secondary.solve()`. Active = secondary.
3. **Mid-call failover** — primary's fatal-config gate (`_handle_provider_error_response` from the parent commit) flips `_solver_unreachable=True` AFTER the provider HTTP call returned. The wrapper catches this, retries once on the secondary in the same `solve()` call, and updates `_active_solver` so the post-call provider read sees the right tier.
4. **Both unreachable** → no-token `SolveResult` without contacting either provider; matches the existing `no_solver` envelope path.

Each underlying solver keeps its own breaker, health-check flag, and failure window — a fatal-config error on one doesn't poison the other's state.

## Cost-accounting fix

`_metered_solve` previously captured `solver.provider` ONCE pre-solve and used the stale snapshot for the actual-cost calculation. On a mid-call failover, the cost-counter charged the agent at primary's pricing for a secondary-served solve. Fixed in `084d1b8`: re-read `solver.provider` AFTER `solve()` returns. The read is single-coroutine-safe (no await between solve return and cost-counter update). Reservation tier still uses the pre-call snapshot (we MUST commit before issuing the call); actual-cost computation now uses the active solver. The existing `_cost.adjust_cost(actual − reserved)` reconciliation remains the settlement mechanism.

## Tests

- 15 new tests in `tests/test_solver_failover.py` covering: both healthy → primary used; primary unreachable → secondary; primary breaker open → secondary; mid-call fatal failover with retry on secondary; both down → no-solver shape; single-provider config (secondary=None) → transparent pass-through; cost-accounting tier reflects active solver post-failover; `health_check` worst-case fold; unknown secondary provider → graceful degrade.
- 125 regression tests pass across the captcha suite (`test_captcha_health`, `test_browser_solve_captcha`, `test_check_captcha_metered`, `test_captcha_envelope`).
- Two existing `TestGetSolver` tests in `test_browser_service.py` updated to reflect the new return type (`MultiProviderSolver` wrapping a `CaptchaSolver`).
- ruff clean.

## Stacking note

`claude/feat-antibot-task-types` builds directly on this. Suggest merging this PR first.

---
_Generated by [Claude Code](https://claude.ai/code/session_019BMxHfdu7SqFZf84DQoLQi)_