### PR TITLE
stealth-browser: browser_warmup agent skill (search engine + apex hop)

### DIFF
--- a/src/agent/builtins/browser_tool.py
+++ b/src/agent/builtins/browser_tool.py
@@ -6,6 +6,7 @@ service container. Agent containers no longer bundle Chrome or VNC.
 
 from __future__ import annotations
 
+import asyncio
 import random
 import time
 from urllib.parse import urlparse
@@ -113,13 +114,61 @@ async def browser_navigate(
 # trail before the agent navigates to a behavior-fingerprinting target.
 # Mirrors ``stealth._SEARCH_REFERERS`` — kept in sync intentionally so the
 # warmup hits the same hosts the server-side referer picker expects to see
-# in a session's history. We pick one per call (rolling-5 anti-repeat is
-# the server's job once we hand off to ``navigate``).
-_WARMUP_SEARCH_ENGINES: tuple[str, ...] = (
-    "https://www.google.com/",
-    "https://www.bing.com/",
-    "https://duckduckgo.com/",
+# in a session's history. Weighted by realistic market share (StatCounter
+# global 2025 desktop) so the fleet doesn't cluster on the unusual non-
+# Google engines. ``random.choices(weights=...)`` does not normalize, so
+# the weights below sum to 1.0 by construction. Tuple of (url, weight)
+# pairs — ``random.choices`` consumes them via ``zip``.
+_WARMUP_SEARCH_ENGINES: tuple[tuple[str, float], ...] = (
+    ("https://www.google.com/",  0.85),
+    ("https://www.bing.com/",    0.10),
+    ("https://duckduckgo.com/",  0.05),
 )
+
+
+def _pick_warmup_search_engine(rng: random.Random | None = None) -> str:
+    """Sample a search-engine URL from the weighted distribution.
+
+    Exposed for testability — operators inspecting warmup behavior on
+    stealth canaries can replay the same RNG seed to get a deterministic
+    engine choice. Default ``rng`` uses the global ``random`` module
+    state, which is shared across all skills in the agent process.
+    """
+    rng = rng or random
+    urls = [u for u, _ in _WARMUP_SEARCH_ENGINES]
+    weights = [w for _, w in _WARMUP_SEARCH_ENGINES]
+    return rng.choices(urls, weights=weights, k=1)[0]
+
+
+# Gaussian SERP-dwell parameters. After landing on a search engine,
+# real users spend 3–12 seconds reading results before clicking
+# through. A zero-or-near-zero pause between SERP load and apex nav
+# is itself a behavioral signal — even with a clean fingerprint, the
+# arrival-timing distribution clusters at sub-second handoffs that
+# the in-house behavioral models on LinkedIn / X / Meta key on.
+# Truncated normal: μ=4s, σ=1.5s, clamped to [2.0s, 9.0s] so the
+# dwell stays in the "user glances at results" range and never blows
+# past the agent's reasonable patience budget.
+_SERP_DWELL_MU_S: float = 4.0
+_SERP_DWELL_SIGMA_S: float = 1.5
+_SERP_DWELL_MIN_S: float = 2.0
+_SERP_DWELL_MAX_S: float = 9.0
+
+
+def _sample_serp_dwell(rng: random.Random | None = None) -> float:
+    """Truncated-normal sample of the SERP-to-apex dwell time, in seconds.
+
+    Exposed for testability. Reuses the same ``random.Random`` injection
+    pattern as :func:`_pick_warmup_search_engine` so an operator can
+    replay an exact warmup from logs.
+    """
+    rng = rng or random
+    sample = rng.gauss(_SERP_DWELL_MU_S, _SERP_DWELL_SIGMA_S)
+    if sample < _SERP_DWELL_MIN_S:
+        sample = _SERP_DWELL_MIN_S
+    elif sample > _SERP_DWELL_MAX_S:
+        sample = _SERP_DWELL_MAX_S
+    return sample
 
 
 def _warmup_apex_url(target_url: str) -> str | None:
@@ -208,7 +257,7 @@ async def browser_warmup(
     steps: list[dict] = []
 
     # Step 1: search-engine landing. Recoverable.
-    search_url = random.choice(_WARMUP_SEARCH_ENGINES)
+    search_url = _pick_warmup_search_engine()
     search_step: dict = {
         "kind": "search_engine",
         "url": search_url,
@@ -262,6 +311,27 @@ async def browser_warmup(
         # nav since that's all we promised to do.
         success = bool(steps[0].get("ok"))
     else:
+        # SERP dwell — pause on the search-engine page before clicking
+        # through. Real users spend several seconds reading results;
+        # zero-or-near-zero handoff between SERP load and apex nav is
+        # itself a behavioral signal the in-house behavioral models on
+        # LinkedIn / X / Meta key on. Only fires when we actually got
+        # past the search-engine load (skip the dwell if the SERP nav
+        # failed; pausing on a failed page produces no fingerprint
+        # benefit and just wastes the agent's budget). Recorded as a
+        # step so operators can see the dwell in the warmup trace.
+        # ``asyncio.CancelledError`` is a BaseException — it propagates
+        # cleanly through the bare ``await`` and short-circuits the
+        # whole warmup, which is the right behavior on caller timeout.
+        if steps[0].get("ok"):
+            dwell_s = _sample_serp_dwell()
+            steps.append({
+                "kind": "serp_dwell",
+                "delay_s": round(dwell_s, 2),
+                "ok": True,
+            })
+            await asyncio.sleep(dwell_s)
+
         apex_step: dict = {
             "kind": "apex",
             "url": apex_url,

--- a/src/agent/builtins/browser_tool.py
+++ b/src/agent/builtins/browser_tool.py
@@ -6,6 +6,8 @@ service container. Agent containers no longer bundle Chrome or VNC.
 
 from __future__ import annotations
 
+import random
+import time
 from urllib.parse import urlparse
 
 from src.agent.skills import skill
@@ -105,6 +107,220 @@ async def browser_navigate(
     if referer is not None:
         params["referer"] = referer
     return await _browser_command(mesh_client, "navigate", params)
+
+
+# Pre-task warmup: search-engine landings used to seed a believable arrival
+# trail before the agent navigates to a behavior-fingerprinting target.
+# Mirrors ``stealth._SEARCH_REFERERS`` — kept in sync intentionally so the
+# warmup hits the same hosts the server-side referer picker expects to see
+# in a session's history. We pick one per call (rolling-5 anti-repeat is
+# the server's job once we hand off to ``navigate``).
+_WARMUP_SEARCH_ENGINES: tuple[str, ...] = (
+    "https://www.google.com/",
+    "https://www.bing.com/",
+    "https://duckduckgo.com/",
+)
+
+
+def _warmup_apex_url(target_url: str) -> str | None:
+    """Return the target's apex-host URL, or None if ``target_url`` is invalid.
+
+    For ``https://www.linkedin.com/in/x?foo=1`` returns ``https://linkedin.com/``.
+    Strips a leading ``www.`` so the apex nav matches what real users type.
+    Only ``http``/``https`` URLs with a hostname are accepted.
+    """
+    try:
+        parsed = urlparse(target_url)
+    except Exception:
+        return None
+    scheme = (parsed.scheme or "").lower()
+    if scheme not in ("http", "https"):
+        return None
+    host = (parsed.hostname or "").lower()
+    if not host:
+        return None
+    if host.startswith("www."):
+        host = host[4:]
+    return f"{scheme}://{host}/"
+
+
+@skill(
+    name="browser_warmup",
+    description=(
+        "Pre-task warmup: navigate to a search engine and the target's home "
+        "page before starting the main task. Use this once at the start of "
+        "an automation session against LinkedIn / X / Twitter / Facebook / "
+        "Instagram (and other behavior-fingerprinting targets) so the "
+        "session has a realistic browsing trail. NOT needed for casual "
+        "sites without bot detection. Do NOT call this multiple times per "
+        "session — once at the start is enough; the session already has a "
+        "referer history after that. Returns a structured summary of the "
+        "steps that ran so the agent can log what happened."
+    ),
+    parameters={
+        "target_url": {
+            "type": "string",
+            "description": (
+                "The URL the agent will navigate to AFTER warmup completes. "
+                "Used to derive the apex host (e.g. linkedin.com) for the "
+                "same-origin warmup hop. Must be http:// or https://."
+            ),
+        },
+        "intensity": {
+            "type": "string",
+            "description": (
+                "Warmup depth. 'light' = search engine only (1 nav, fastest). "
+                "'normal' (default) = search engine + apex host (2 navs). "
+                "'deep' = search engine + scroll + apex host + scroll on apex "
+                "(4 actions, highest realism)."
+            ),
+            "default": "normal",
+        },
+    },
+    parallel_safe=False,
+)
+async def browser_warmup(
+    target_url: str,
+    intensity: str = "normal",
+    *,
+    mesh_client=None,
+) -> dict:
+    """Run a pre-task browsing warmup against a target's apex host.
+
+    Composes existing ``navigate`` and ``scroll`` browser commands. All
+    failures EXCEPT the apex nav are recoverable — a search-engine timeout
+    is logged into ``steps`` and the apex hop still runs. ``success`` is
+    False only when the apex navigation itself fails (or when input
+    validation rejects the request before any navs run).
+    """
+    apex_url = _warmup_apex_url(target_url)
+    if apex_url is None:
+        return {"error": "invalid target_url"}
+
+    intensity_norm = (intensity or "normal").strip().lower()
+    if intensity_norm not in ("light", "normal", "deep"):
+        intensity_norm = "normal"
+
+    if not mesh_client:
+        return {"error": "Browser requires mesh connectivity"}
+
+    started = time.monotonic()
+    steps: list[dict] = []
+
+    # Step 1: search-engine landing. Recoverable.
+    search_url = random.choice(_WARMUP_SEARCH_ENGINES)
+    search_step: dict = {
+        "kind": "search_engine",
+        "url": search_url,
+    }
+    try:
+        search_result = await _browser_command(
+            mesh_client,
+            "navigate",
+            {
+                "url": search_url,
+                "wait_ms": 500,
+                "wait_until": "domcontentloaded",
+                "snapshot_after": False,
+            },
+        )
+        if isinstance(search_result, dict) and "error" in search_result:
+            search_step["ok"] = False
+            search_step["error"] = search_result["error"]
+        else:
+            search_step["ok"] = True
+    except Exception as exc:  # noqa: BLE001 — log and continue
+        search_step["ok"] = False
+        search_step["error"] = str(exc)
+    steps.append(search_step)
+
+    # Step 2 (deep only): a single scroll-down on the search engine to
+    # mimic "looking at results" before clicking through. Recoverable.
+    if intensity_norm == "deep":
+        scroll_step: dict = {"kind": "scroll", "where": "search_engine"}
+        try:
+            scroll_result = await _browser_command(
+                mesh_client,
+                "scroll",
+                {"direction": "down", "amount": 0},
+            )
+            if isinstance(scroll_result, dict) and "error" in scroll_result:
+                scroll_step["ok"] = False
+                scroll_step["error"] = scroll_result["error"]
+            else:
+                scroll_step["ok"] = True
+        except Exception as exc:  # noqa: BLE001
+            scroll_step["ok"] = False
+            scroll_step["error"] = str(exc)
+        steps.append(scroll_step)
+
+    # Step 3: apex-host nav. THE critical step — failure means warmup
+    # failed. Skipped at "light" intensity (search-engine-only mode).
+    success = True
+    if intensity_norm == "light":
+        # No apex hop at light intensity. Success tracks the search-engine
+        # nav since that's all we promised to do.
+        success = bool(steps[0].get("ok"))
+    else:
+        apex_step: dict = {
+            "kind": "apex",
+            "url": apex_url,
+        }
+        try:
+            apex_result = await _browser_command(
+                mesh_client,
+                "navigate",
+                {
+                    "url": apex_url,
+                    "wait_ms": 1000,
+                    "wait_until": "domcontentloaded",
+                    "snapshot_after": False,
+                },
+            )
+            if isinstance(apex_result, dict) and "error" in apex_result:
+                apex_step["ok"] = False
+                apex_step["error"] = apex_result["error"]
+                success = False
+            else:
+                apex_step["ok"] = True
+        except Exception as exc:  # noqa: BLE001
+            apex_step["ok"] = False
+            apex_step["error"] = str(exc)
+            success = False
+        steps.append(apex_step)
+
+        # Step 4 (deep only): a small scroll on the apex page so the
+        # session also looks like a human "glanced at the home page"
+        # before the agent's targeted nav. Recoverable.
+        if intensity_norm == "deep" and success:
+            apex_scroll_step: dict = {"kind": "scroll", "where": "apex"}
+            try:
+                apex_scroll_result = await _browser_command(
+                    mesh_client,
+                    "scroll",
+                    {"direction": "down", "amount": 0},
+                )
+                if (
+                    isinstance(apex_scroll_result, dict)
+                    and "error" in apex_scroll_result
+                ):
+                    apex_scroll_step["ok"] = False
+                    apex_scroll_step["error"] = apex_scroll_result["error"]
+                else:
+                    apex_scroll_step["ok"] = True
+            except Exception as exc:  # noqa: BLE001
+                apex_scroll_step["ok"] = False
+                apex_scroll_step["error"] = str(exc)
+            steps.append(apex_scroll_step)
+
+    total_ms = int((time.monotonic() - started) * 1000)
+    return {
+        "success": success,
+        "intensity": intensity_norm,
+        "target_apex": apex_url,
+        "steps": steps,
+        "total_ms": total_ms,
+    }
 
 
 @skill(

--- a/tests/test_account_warmup.py
+++ b/tests/test_account_warmup.py
@@ -1,0 +1,451 @@
+"""Tests for the agent-side ``browser_warmup`` skill.
+
+The skill composes existing ``navigate`` and ``scroll`` browser commands
+into a believable pre-task browsing trail. Tests pin:
+
+  * the registered skill schema
+  * the per-intensity action shape (light=1 nav, normal=2 navs, deep=mix)
+  * apex-host extraction (``www.linkedin.com/in/x`` → ``linkedin.com/``)
+  * input validation (rejects non-http URLs without making nav calls)
+  * recoverability (search-engine failure ⇒ warmup continues to apex)
+  * apex failure ⇒ ``success=False``
+  * the returned envelope shape (``steps``, ``total_ms``, ``target_apex``)
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+
+def _make_mesh(side_effect=None, return_value=None):
+    """Build a mesh client with a mocked ``browser_command``.
+
+    ``side_effect`` takes priority; falls back to ``return_value`` (or a
+    plain success dict). Caller can inspect ``.browser_command`` to assert
+    on the call sequence.
+    """
+    mc = AsyncMock()
+    if side_effect is not None:
+        mc.browser_command = AsyncMock(side_effect=side_effect)
+    else:
+        mc.browser_command = AsyncMock(
+            return_value=return_value or {"url": "https://example.com/"},
+        )
+    return mc
+
+
+# ── schema ─────────────────────────────────────────────────────
+
+
+class TestBrowserWarmupSchema:
+    def test_skill_is_registered_with_expected_schema(self):
+        # Force-import the module so the @skill decorator runs.
+        import src.agent.builtins.browser_tool  # noqa: F401
+        from src.agent.skills import _skill_staging
+
+        assert "browser_warmup" in _skill_staging
+        info = _skill_staging["browser_warmup"]
+
+        assert info["name"] == "browser_warmup"
+        assert "warmup" in info["description"].lower()
+        assert info["_parallel_safe"] is False  # browser is per-agent, sequential
+
+        params = info["parameters"]
+        assert "target_url" in params
+        assert params["target_url"]["type"] == "string"
+        assert "intensity" in params
+        assert params["intensity"]["type"] == "string"
+        assert params["intensity"].get("default") == "normal"
+
+    def test_required_params_only_target_url(self):
+        from src.agent.skills import _skill_staging
+
+        required = _skill_staging["browser_warmup"]["_sig_required_params"]
+        # ``intensity`` has a default ⇒ not required; mesh_client is
+        # keyword-only auto-injected and also has a default.
+        assert "target_url" in required
+        assert "intensity" not in required
+
+
+# ── per-intensity action shape ─────────────────────────────────
+
+
+class TestBrowserWarmupIntensities:
+    @pytest.mark.asyncio
+    async def test_light_intensity_makes_one_navigate_call(self):
+        from src.agent.builtins.browser_tool import browser_warmup
+
+        mc = _make_mesh(return_value={"url": "ok"})
+        result = await browser_warmup(
+            target_url="https://www.linkedin.com/in/someone",
+            intensity="light",
+            mesh_client=mc,
+        )
+
+        # light = search engine only, no apex hop, no scroll.
+        nav_calls = [
+            call for call in mc.browser_command.await_args_list
+            if call.args[0] == "navigate"
+        ]
+        scroll_calls = [
+            call for call in mc.browser_command.await_args_list
+            if call.args[0] == "scroll"
+        ]
+        assert len(nav_calls) == 1
+        assert len(scroll_calls) == 0
+        # The single nav targets a search engine, not the apex.
+        nav_url = nav_calls[0].args[1]["url"]
+        assert nav_url in (
+            "https://www.google.com/",
+            "https://www.bing.com/",
+            "https://duckduckgo.com/",
+        )
+        assert result["success"] is True
+        assert result["intensity"] == "light"
+        assert len(result["steps"]) == 1
+
+    @pytest.mark.asyncio
+    async def test_normal_intensity_makes_two_navigate_calls(self):
+        from src.agent.builtins.browser_tool import browser_warmup
+
+        mc = _make_mesh(return_value={"url": "ok"})
+        result = await browser_warmup(
+            target_url="https://www.linkedin.com/in/someone",
+            intensity="normal",
+            mesh_client=mc,
+        )
+
+        nav_calls = [
+            call for call in mc.browser_command.await_args_list
+            if call.args[0] == "navigate"
+        ]
+        scroll_calls = [
+            call for call in mc.browser_command.await_args_list
+            if call.args[0] == "scroll"
+        ]
+        assert len(nav_calls) == 2
+        assert len(scroll_calls) == 0
+        # First call: search engine. Second call: apex host.
+        first_url = nav_calls[0].args[1]["url"]
+        second_url = nav_calls[1].args[1]["url"]
+        assert first_url in (
+            "https://www.google.com/",
+            "https://www.bing.com/",
+            "https://duckduckgo.com/",
+        )
+        assert second_url == "https://linkedin.com/"
+        assert result["success"] is True
+        assert result["target_apex"] == "https://linkedin.com/"
+
+    @pytest.mark.asyncio
+    async def test_normal_is_default_intensity(self):
+        from src.agent.builtins.browser_tool import browser_warmup
+
+        mc = _make_mesh(return_value={"url": "ok"})
+        result = await browser_warmup(
+            target_url="https://www.linkedin.com/in/someone",
+            mesh_client=mc,
+        )
+        assert result["intensity"] == "normal"
+        nav_calls = [
+            c for c in mc.browser_command.await_args_list
+            if c.args[0] == "navigate"
+        ]
+        assert len(nav_calls) == 2
+
+    @pytest.mark.asyncio
+    async def test_deep_intensity_mixes_nav_and_scroll(self):
+        from src.agent.builtins.browser_tool import browser_warmup
+
+        mc = _make_mesh(return_value={"url": "ok"})
+        result = await browser_warmup(
+            target_url="https://www.linkedin.com/in/x",
+            intensity="deep",
+            mesh_client=mc,
+        )
+
+        action_kinds = [c.args[0] for c in mc.browser_command.await_args_list]
+        # deep = search-nav, scroll, apex-nav, scroll-on-apex
+        assert action_kinds.count("navigate") == 2
+        assert action_kinds.count("scroll") == 2
+        assert len(action_kinds) == 4
+        # Order matters: scroll comes after the search-engine nav, before
+        # the apex nav, and another scroll comes after the apex nav.
+        assert action_kinds == ["navigate", "scroll", "navigate", "scroll"]
+        assert result["success"] is True
+        # Step kinds in the returned envelope mirror the action sequence.
+        step_kinds = [s["kind"] for s in result["steps"]]
+        assert step_kinds == ["search_engine", "scroll", "apex", "scroll"]
+
+    @pytest.mark.asyncio
+    async def test_unknown_intensity_falls_back_to_normal(self):
+        from src.agent.builtins.browser_tool import browser_warmup
+
+        mc = _make_mesh(return_value={"url": "ok"})
+        result = await browser_warmup(
+            target_url="https://www.linkedin.com/in/x",
+            intensity="bogus",
+            mesh_client=mc,
+        )
+        assert result["intensity"] == "normal"
+        nav_calls = [
+            c for c in mc.browser_command.await_args_list
+            if c.args[0] == "navigate"
+        ]
+        assert len(nav_calls) == 2
+
+
+# ── apex-host extraction ───────────────────────────────────────
+
+
+class TestApexExtraction:
+    @pytest.mark.asyncio
+    async def test_strips_www_and_path(self):
+        from src.agent.builtins.browser_tool import browser_warmup
+
+        mc = _make_mesh(return_value={"url": "ok"})
+        result = await browser_warmup(
+            target_url="https://www.linkedin.com/in/x?foo=1",
+            mesh_client=mc,
+        )
+        assert result["target_apex"] == "https://linkedin.com/"
+
+    @pytest.mark.asyncio
+    async def test_preserves_scheme(self):
+        from src.agent.builtins.browser_tool import browser_warmup
+
+        mc = _make_mesh(return_value={"url": "ok"})
+        result = await browser_warmup(
+            target_url="http://example.com/foo",
+            mesh_client=mc,
+        )
+        assert result["target_apex"] == "http://example.com/"
+
+    @pytest.mark.asyncio
+    async def test_keeps_subdomains_other_than_www(self):
+        from src.agent.builtins.browser_tool import browser_warmup
+
+        mc = _make_mesh(return_value={"url": "ok"})
+        result = await browser_warmup(
+            target_url="https://mobile.linkedin.com/foo",
+            mesh_client=mc,
+        )
+        # Only ``www.`` is stripped; other subdomains stay (they're real
+        # apex shapes for those services).
+        assert result["target_apex"] == "https://mobile.linkedin.com/"
+
+
+# ── input validation ───────────────────────────────────────────
+
+
+class TestBrowserWarmupValidation:
+    @pytest.mark.asyncio
+    async def test_rejects_non_http_url_without_navigating(self):
+        from src.agent.builtins.browser_tool import browser_warmup
+
+        mc = _make_mesh(return_value={"url": "ok"})
+        result = await browser_warmup(
+            target_url="ftp://example.com/foo",
+            mesh_client=mc,
+        )
+        assert result == {"error": "invalid target_url"}
+        # CRITICAL: no nav calls were made.
+        mc.browser_command.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_rejects_empty_string_without_navigating(self):
+        from src.agent.builtins.browser_tool import browser_warmup
+
+        mc = _make_mesh(return_value={"url": "ok"})
+        result = await browser_warmup(target_url="", mesh_client=mc)
+        assert "error" in result
+        mc.browser_command.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_rejects_javascript_url_without_navigating(self):
+        from src.agent.builtins.browser_tool import browser_warmup
+
+        mc = _make_mesh(return_value={"url": "ok"})
+        result = await browser_warmup(
+            target_url="javascript:alert(1)", mesh_client=mc,
+        )
+        assert "error" in result
+        mc.browser_command.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_no_mesh_client_returns_error(self):
+        from src.agent.builtins.browser_tool import browser_warmup
+
+        result = await browser_warmup(
+            target_url="https://linkedin.com/", mesh_client=None,
+        )
+        assert "error" in result
+
+
+# ── recoverability ─────────────────────────────────────────────
+
+
+class TestBrowserWarmupRecoverability:
+    @pytest.mark.asyncio
+    async def test_search_engine_failure_does_not_abort(self):
+        """Search-engine timeout is recoverable — apex nav still runs."""
+        from src.agent.builtins.browser_tool import browser_warmup
+
+        # First call (search engine) raises; second call (apex) succeeds.
+        side_effect = [
+            RuntimeError("search engine timed out"),
+            {"url": "https://linkedin.com/", "title": "LinkedIn"},
+        ]
+        mc = _make_mesh(side_effect=side_effect)
+        result = await browser_warmup(
+            target_url="https://www.linkedin.com/in/x",
+            intensity="normal",
+            mesh_client=mc,
+        )
+
+        # Apex nav was still attempted despite search-engine failure.
+        nav_calls = [
+            c for c in mc.browser_command.await_args_list
+            if c.args[0] == "navigate"
+        ]
+        assert len(nav_calls) == 2
+        assert nav_calls[1].args[1]["url"] == "https://linkedin.com/"
+
+        # Apex nav succeeded ⇒ overall success is True.
+        assert result["success"] is True
+        # The search-engine step is recorded as failed.
+        steps = result["steps"]
+        search_step = next(s for s in steps if s["kind"] == "search_engine")
+        assert search_step["ok"] is False
+        assert "error" in search_step
+        # The apex step is recorded as ok.
+        apex_step = next(s for s in steps if s["kind"] == "apex")
+        assert apex_step["ok"] is True
+
+    @pytest.mark.asyncio
+    async def test_search_engine_error_dict_does_not_abort(self):
+        """``_browser_command`` returns ``{"error": ...}`` on transport
+        failures (not exceptions). Same recoverability rule applies."""
+        from src.agent.builtins.browser_tool import browser_warmup
+
+        # The error dict comes back wrapped by ``_browser_command`` only
+        # when ``mesh_client.browser_command`` itself raises. Simulating
+        # that here — the second call succeeds.
+        side_effect = [
+            Exception("transport closed"),
+            {"url": "ok"},
+        ]
+        mc = _make_mesh(side_effect=side_effect)
+        result = await browser_warmup(
+            target_url="https://www.linkedin.com/in/x",
+            mesh_client=mc,
+        )
+        assert result["success"] is True
+
+
+# ── apex failure ───────────────────────────────────────────────
+
+
+class TestBrowserWarmupApexFailure:
+    @pytest.mark.asyncio
+    async def test_apex_navigation_failure_returns_success_false(self):
+        from src.agent.builtins.browser_tool import browser_warmup
+
+        # Search engine ok, apex hop fails.
+        side_effect = [
+            {"url": "search-engine-ok"},
+            RuntimeError("apex unreachable"),
+        ]
+        mc = _make_mesh(side_effect=side_effect)
+        result = await browser_warmup(
+            target_url="https://www.linkedin.com/in/x",
+            intensity="normal",
+            mesh_client=mc,
+        )
+
+        assert result["success"] is False
+        apex_step = next(s for s in result["steps"] if s["kind"] == "apex")
+        assert apex_step["ok"] is False
+        assert "error" in apex_step
+
+    @pytest.mark.asyncio
+    async def test_apex_skip_at_deep_when_apex_fails(self):
+        """At deep intensity, if the apex nav fails, the apex-scroll
+        step should NOT run (no point scrolling a non-loaded page)."""
+        from src.agent.builtins.browser_tool import browser_warmup
+
+        side_effect = [
+            {"url": "search-engine-ok"},
+            {"data": {}},  # search-engine scroll ok
+            RuntimeError("apex unreachable"),
+        ]
+        mc = _make_mesh(side_effect=side_effect)
+        result = await browser_warmup(
+            target_url="https://www.linkedin.com/in/x",
+            intensity="deep",
+            mesh_client=mc,
+        )
+
+        assert result["success"] is False
+        # Only 3 underlying calls — the post-apex scroll was skipped.
+        assert mc.browser_command.await_count == 3
+        kinds = [s["kind"] for s in result["steps"]]
+        # search_engine + scroll + apex (apex-failed); no second scroll.
+        assert kinds == ["search_engine", "scroll", "apex"]
+
+
+# ── returned envelope shape ────────────────────────────────────
+
+
+class TestBrowserWarmupEnvelope:
+    @pytest.mark.asyncio
+    async def test_returns_structured_envelope(self):
+        from src.agent.builtins.browser_tool import browser_warmup
+
+        mc = _make_mesh(return_value={"url": "ok"})
+        result = await browser_warmup(
+            target_url="https://www.linkedin.com/in/x",
+            mesh_client=mc,
+        )
+
+        # All required keys present.
+        assert "success" in result
+        assert "steps" in result
+        assert "total_ms" in result
+        assert "target_apex" in result
+        assert "intensity" in result
+
+        assert isinstance(result["success"], bool)
+        assert isinstance(result["steps"], list)
+        assert isinstance(result["total_ms"], int)
+        assert isinstance(result["target_apex"], str)
+
+        # ``total_ms`` is a non-negative duration.
+        assert result["total_ms"] >= 0
+
+        # Each step records ``kind`` and ``ok``.
+        for step in result["steps"]:
+            assert "kind" in step
+            assert "ok" in step
+
+    @pytest.mark.asyncio
+    async def test_uses_lightweight_wait_until(self):
+        """Warmup navs should use ``domcontentloaded`` (not ``load`` or
+        ``networkidle``) since the goal is to LOAD the page, not wait
+        for full SPA hydration. Keeps the warmup under 30s budget."""
+        from src.agent.builtins.browser_tool import browser_warmup
+
+        mc = _make_mesh(return_value={"url": "ok"})
+        await browser_warmup(
+            target_url="https://www.linkedin.com/in/x",
+            mesh_client=mc,
+        )
+
+        nav_calls = [
+            c for c in mc.browser_command.await_args_list
+            if c.args[0] == "navigate"
+        ]
+        for call in nav_calls:
+            assert call.args[1]["wait_until"] == "domcontentloaded"

--- a/tests/test_account_warmup.py
+++ b/tests/test_account_warmup.py
@@ -14,7 +14,7 @@ into a believable pre-task browsing trail. Tests pin:
 
 from __future__ import annotations
 
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, patch
 
 import pytest
 
@@ -157,17 +157,23 @@ class TestBrowserWarmupIntensities:
 
     @pytest.mark.asyncio
     async def test_deep_intensity_mixes_nav_and_scroll(self):
+        from src.agent.builtins import browser_tool as bt
         from src.agent.builtins.browser_tool import browser_warmup
 
         mc = _make_mesh(return_value={"url": "ok"})
-        result = await browser_warmup(
-            target_url="https://www.linkedin.com/in/x",
-            intensity="deep",
-            mesh_client=mc,
-        )
+        # Stub asyncio.sleep so the SERP dwell doesn't actually sleep.
+        async def _fake_sleep(s):
+            return None
+        with patch.object(bt.asyncio, "sleep", _fake_sleep):
+            result = await browser_warmup(
+                target_url="https://www.linkedin.com/in/x",
+                intensity="deep",
+                mesh_client=mc,
+            )
 
         action_kinds = [c.args[0] for c in mc.browser_command.await_args_list]
-        # deep = search-nav, scroll, apex-nav, scroll-on-apex
+        # deep = search-nav, scroll, apex-nav, scroll-on-apex (the SERP
+        # dwell is an asyncio.sleep, not a mesh action).
         assert action_kinds.count("navigate") == 2
         assert action_kinds.count("scroll") == 2
         assert len(action_kinds) == 4
@@ -175,9 +181,12 @@ class TestBrowserWarmupIntensities:
         # the apex nav, and another scroll comes after the apex nav.
         assert action_kinds == ["navigate", "scroll", "navigate", "scroll"]
         assert result["success"] is True
-        # Step kinds in the returned envelope mirror the action sequence.
+        # Step kinds in the returned envelope include the SERP dwell
+        # between the search-engine scroll and the apex nav.
         step_kinds = [s["kind"] for s in result["steps"]]
-        assert step_kinds == ["search_engine", "scroll", "apex", "scroll"]
+        assert step_kinds == [
+            "search_engine", "scroll", "serp_dwell", "apex", "scroll",
+        ]
 
     @pytest.mark.asyncio
     async def test_unknown_intensity_falls_back_to_normal(self):
@@ -374,6 +383,7 @@ class TestBrowserWarmupApexFailure:
     async def test_apex_skip_at_deep_when_apex_fails(self):
         """At deep intensity, if the apex nav fails, the apex-scroll
         step should NOT run (no point scrolling a non-loaded page)."""
+        from src.agent.builtins import browser_tool as bt
         from src.agent.builtins.browser_tool import browser_warmup
 
         side_effect = [
@@ -382,18 +392,23 @@ class TestBrowserWarmupApexFailure:
             RuntimeError("apex unreachable"),
         ]
         mc = _make_mesh(side_effect=side_effect)
-        result = await browser_warmup(
-            target_url="https://www.linkedin.com/in/x",
-            intensity="deep",
-            mesh_client=mc,
-        )
+        # Stub the SERP dwell sleep so the test runs quickly.
+        async def _fake_sleep(s):
+            return None
+        with patch.object(bt.asyncio, "sleep", _fake_sleep):
+            result = await browser_warmup(
+                target_url="https://www.linkedin.com/in/x",
+                intensity="deep",
+                mesh_client=mc,
+            )
 
         assert result["success"] is False
         # Only 3 underlying calls — the post-apex scroll was skipped.
         assert mc.browser_command.await_count == 3
         kinds = [s["kind"] for s in result["steps"]]
-        # search_engine + scroll + apex (apex-failed); no second scroll.
-        assert kinds == ["search_engine", "scroll", "apex"]
+        # search_engine + scroll + serp_dwell + apex (apex-failed);
+        # no second scroll.
+        assert kinds == ["search_engine", "scroll", "serp_dwell", "apex"]
 
 
 # ── returned envelope shape ────────────────────────────────────
@@ -449,3 +464,167 @@ class TestBrowserWarmupEnvelope:
         ]
         for call in nav_calls:
             assert call.args[1]["wait_until"] == "domcontentloaded"
+
+
+# ── 8: weighted search-engine selection ───────────────────────────────
+
+
+class TestWeightedSearchEngine:
+    def test_weighted_distribution_skews_to_google(self):
+        """Real distribution is ~85% Google / ~10% Bing / ~5% DDG.
+        Verify the picker honors the weights at fleet-scale by sampling
+        many times with a seeded rng — Google should dominate."""
+        import random as _random
+
+        from src.agent.builtins.browser_tool import _pick_warmup_search_engine
+
+        rng = _random.Random(42)
+        counts = {"google": 0, "bing": 0, "duckduckgo": 0}
+        for _ in range(2000):
+            url = _pick_warmup_search_engine(rng=rng)
+            for k in counts:
+                if k in url:
+                    counts[k] += 1
+                    break
+        # Google must be the dominant pick (85% target, ±5% slack).
+        assert counts["google"] / 2000 > 0.78
+        # Non-Google should be present but rare.
+        assert counts["bing"] > 0
+        assert counts["duckduckgo"] > 0
+        # No unweighted clustering — Bing should not approach Google.
+        assert counts["bing"] < counts["google"] / 2
+
+    def test_picker_reproducible_with_seeded_rng(self):
+        """Operator audit: same rng seed → same engine choice. Lets a
+        canary run replay an exact warmup from logs."""
+        import random as _random
+
+        from src.agent.builtins.browser_tool import _pick_warmup_search_engine
+
+        rng_a = _random.Random(123)
+        rng_b = _random.Random(123)
+        urls_a = [_pick_warmup_search_engine(rng=rng_a) for _ in range(20)]
+        urls_b = [_pick_warmup_search_engine(rng=rng_b) for _ in range(20)]
+        assert urls_a == urls_b
+
+
+# ── 9: SERP dwell ─────────────────────────────────────────────────────
+
+
+class TestSerpDwell:
+    def test_sample_within_clamp_window(self):
+        import random as _random
+
+        from src.agent.builtins.browser_tool import _sample_serp_dwell
+
+        rng = _random.Random(777)
+        for _ in range(500):
+            d = _sample_serp_dwell(rng=rng)
+            assert 2.0 <= d <= 9.0  # _SERP_DWELL_MIN_S / MAX_S
+
+    def test_sample_clamped_to_min(self):
+        from src.agent.builtins.browser_tool import _sample_serp_dwell
+
+        class _StubRng:
+            def gauss(self, mu, sigma):
+                return -10.0  # below min
+
+        d = _sample_serp_dwell(rng=_StubRng())
+        assert d == 2.0
+
+    def test_sample_clamped_to_max(self):
+        from src.agent.builtins.browser_tool import _sample_serp_dwell
+
+        class _StubRng:
+            def gauss(self, mu, sigma):
+                return 999.0  # above max
+
+        d = _sample_serp_dwell(rng=_StubRng())
+        assert d == 9.0
+
+    @pytest.mark.asyncio
+    async def test_warmup_normal_intensity_includes_serp_dwell_step(self):
+        """At ``normal`` intensity, after the search-engine nav
+        succeeds, a ``serp_dwell`` step must appear in the warmup trace
+        BEFORE the apex nav."""
+        from src.agent.builtins import browser_tool as bt
+        from src.agent.builtins.browser_tool import browser_warmup
+
+        mc = _make_mesh(return_value={"url": "ok"})
+
+        # Stub asyncio.sleep so the test doesn't actually wait 4s.
+        slept: list[float] = []
+
+        async def _fake_sleep(s):
+            slept.append(s)
+        with patch.object(bt.asyncio, "sleep", _fake_sleep):
+            result = await browser_warmup(
+                target_url="https://linkedin.com/in/x",
+                intensity="normal",
+                mesh_client=mc,
+            )
+
+        kinds = [s["kind"] for s in result["steps"]]
+        # Order: search_engine → serp_dwell → apex
+        assert "serp_dwell" in kinds
+        assert kinds.index("serp_dwell") < kinds.index("apex")
+        # Sleep was actually called with a positive duration in the
+        # SERP-dwell window.
+        assert len(slept) >= 1
+        assert 2.0 <= slept[0] <= 9.0
+
+    @pytest.mark.asyncio
+    async def test_warmup_skips_serp_dwell_when_search_failed(self):
+        """SERP-dwell should NOT fire when the search-engine nav failed
+        — pausing on a failed page produces no fingerprint benefit."""
+        from src.agent.builtins import browser_tool as bt
+        from src.agent.builtins.browser_tool import browser_warmup
+
+        # First call (search) returns error; second call (apex) succeeds.
+        mc = _make_mesh()
+        mc.browser_command = AsyncMock(side_effect=[
+            {"error": "search-engine timeout"},  # SERP nav fails
+            {"url": "ok"},                       # apex nav succeeds
+        ])
+
+        slept: list[float] = []
+
+        async def _fake_sleep(s):
+            slept.append(s)
+        with patch.object(bt.asyncio, "sleep", _fake_sleep):
+            result = await browser_warmup(
+                target_url="https://linkedin.com/in/x",
+                intensity="normal",
+                mesh_client=mc,
+            )
+
+        kinds = [s["kind"] for s in result["steps"]]
+        assert "serp_dwell" not in kinds, (
+            "SERP-dwell must skip when the search engine load failed"
+        )
+        # No asyncio.sleep should have been called for the SERP dwell.
+        assert slept == []
+
+    @pytest.mark.asyncio
+    async def test_warmup_light_intensity_no_serp_dwell(self):
+        """Light intensity = search-engine only, no apex hop, no SERP
+        dwell (the dwell only matters as a hand-off pause to the apex
+        nav)."""
+        from src.agent.builtins import browser_tool as bt
+        from src.agent.builtins.browser_tool import browser_warmup
+
+        mc = _make_mesh(return_value={"url": "ok"})
+        slept: list[float] = []
+
+        async def _fake_sleep(s):
+            slept.append(s)
+        with patch.object(bt.asyncio, "sleep", _fake_sleep):
+            result = await browser_warmup(
+                target_url="https://linkedin.com/in/x",
+                intensity="light",
+                mesh_client=mc,
+            )
+
+        kinds = [s["kind"] for s in result["steps"]]
+        assert "serp_dwell" not in kinds
+        assert slept == []


### PR DESCRIPTION
New `browser_warmup(target_url, *, intensity="normal")` agent skill. Composes existing `navigate` + `scroll` mesh actions to seed a session with a realistic browsing trail before the agent's main task. Independent of the failover / anti-bot PRs.

## Why

Cold landings on PerimeterX/HUMAN-protected (LinkedIn), in-house "Bird"-protected (X), and Meta-protected sites trip risk scoring even when JS / TLS / IP all look clean. Real users almost always arrive via search engines, prior-session cookies, or social click-throughs. A request to `https://www.linkedin.com/in/someone` from a fresh session with no prior history is itself a behavioral signal.

## What it does

1. **Search-engine landing** — Google / Bing / DuckDuckGo, weighted by real market share (~85/10/5). Was uniform random in the first commit; fixed in `b3aaa7c` because uniform sampling clusters fleets on the unusual non-Google engines.
2. **SERP dwell** — Gaussian pause (μ=4s, σ=1.5s, clamped [2s, 9s]) between SERP load and apex hop. Real users spend several seconds reading results; instant handoff is itself a signal. Skipped when SERP nav fails (no fingerprint benefit pausing on a failed page).
3. **Apex hop** — navigate to the target's apex host (`https://www.linkedin.com/in/x` → `https://linkedin.com/`). Seeds the session so the agent's actual target nav sees a same-origin previous-URL and the server-side referer picker emits a same-origin Referer.

## Intensities

- `light` — search engine only (1 nav). Fastest.
- `normal` (default) — search engine + SERP dwell + apex (2 navs + dwell). Balanced.
- `deep` — search + scroll + SERP dwell + apex + scroll-on-apex. Highest realism. Total ~12-18s on a protected platform (combines with the per-platform pre-nav delay).

Errors in any single step are RECOVERABLE — search-engine timeout doesn't kill the warmup; only an apex-nav failure returns `success=False`.

## Tests

- 28 tests in `tests/test_account_warmup.py` covering: schema validation, intensity dispatch, apex extraction, weighted search-engine distribution, deterministic seeded RNG, SERP-dwell clamping (min/max/distribution), dwell skip on SERP failure, no dwell at light intensity, end-to-end step ordering.
- 246 tests pass in the broader skills + nav-probe regression slice.
- ruff clean.

## What this doesn't cover (intentional)

- No multi-language search engines (`google.de`, etc.) — operator-supplied locale is already in the browser fingerprint; routing to a country-specific search would conflict with that. Stick to the global `.com` variants.
- No "deep journey" with multiple inter-site hops — that's overkill for routine LinkedIn / X / Meta browsing. Bounded scope.

---
_Generated by [Claude Code](https://claude.ai/code/session_019BMxHfdu7SqFZf84DQoLQi)_