### PR TITLE
stealth-browser: per-platform success rollup panel + GET endpoint

### DIFF
--- a/src/browser/service.py
+++ b/src/browser/service.py
@@ -39,6 +39,7 @@ from src.browser.redaction import CredentialRedactor
 from src.browser.ref_handle import RefHandle, RefStale, ShadowHop
 from src.browser.stealth import (
     DEFAULT_DEVICE_PROFILE,
+    _canonical_host,
     build_launch_options,
     build_mobile_init_script,
     get_device_profile,
@@ -548,6 +549,94 @@ async def _drain_session_audit() -> list[dict]:
             "action": action,
             "success": success,
             "count": info["count"],
+            "first_ts": info["first_ts"],
+        })
+    return drained
+
+
+# ── platform pre-nav delay audit aggregator ──────────────────────────────
+#
+# Companion to the per-platform pre-nav dwell (LinkedIn / X / Meta).  Per
+# §2.7 we cannot emit one event per applied dwell — that would flood the
+# WebSocket on a hot navigate loop.  Aggregate by ``(agent_id, host)`` so
+# the dashboard's per-platform success panel can compute count + average
+# dwell duration without scraping the INFO log.
+#
+# State is module-global because the BrowserManager is a singleton in
+# the browser service container.  Drain is driven from
+# :meth:`BrowserManager._emit_metrics` (already on the 60s tick); see
+# ``_drain_platform_timing_audit`` below.
+_platform_timing_audit_lock: asyncio.Lock | None = None
+_platform_timing_audit_lock_loop: asyncio.AbstractEventLoop | None = None
+# {(agent_id, host): {"count": int, "total_delay_s": float, "first_ts": float}}
+_platform_timing_audit_buckets: dict[tuple[str, str], dict] = {}
+
+
+def _get_platform_timing_audit_lock() -> asyncio.Lock:
+    """Return a platform-timing audit lock bound to the active event loop."""
+    global _platform_timing_audit_lock, _platform_timing_audit_lock_loop
+    loop = asyncio.get_running_loop()
+    if (
+        _platform_timing_audit_lock is None
+        or _platform_timing_audit_lock_loop is not loop
+    ):
+        _platform_timing_audit_lock = asyncio.Lock()
+        _platform_timing_audit_lock_loop = loop
+    return _platform_timing_audit_lock
+
+
+async def _record_platform_timing_audit_event(
+    agent_id: str, host: str, delay_s: float,
+) -> None:
+    """Aggregate one applied pre-nav dwell into the per-minute bucket.
+
+    ``host`` is the canonical host (lower-cased, ``www.`` stripped) —
+    callers route through :func:`src.browser.stealth._canonical_host`.
+    Bucket aggregates by ``(agent_id, host)`` so a single agent looping
+    on one platform doesn't drown out the others.  ``delay_s`` is
+    summed so the drain payload can carry a true running average.
+    """
+    if not host or delay_s < 0:
+        return
+    async with _get_platform_timing_audit_lock():
+        key = (agent_id, host)
+        bucket = _platform_timing_audit_buckets.get(key)
+        now = time.time()
+        if bucket is None:
+            _platform_timing_audit_buckets[key] = {
+                "count": 1,
+                "total_delay_s": float(delay_s),
+                "first_ts": now,
+            }
+        else:
+            bucket["count"] += 1
+            bucket["total_delay_s"] += float(delay_s)
+
+
+async def _drain_platform_timing_audit() -> list[dict]:
+    """Atomically swap the platform-timing audit buckets and return payloads.
+
+    Called once per metrics-emit tick. Mirrors
+    :func:`_drain_captcha_audit` — each returned dict is one EventBus
+    payload of type ``platform_pre_nav_delay`` so the dashboard's
+    per-platform success aggregator can route it into the right host
+    bucket.
+    """
+    async with _get_platform_timing_audit_lock():
+        if not _platform_timing_audit_buckets:
+            return []
+        buckets = dict(_platform_timing_audit_buckets)
+        _platform_timing_audit_buckets.clear()
+    drained = []
+    for (agent_id, host), info in buckets.items():
+        drained.append({
+            "type": "platform_pre_nav_delay",
+            # ``agent_id`` (not ``agent``) — same convention as the
+            # captcha / session / fingerprint audit paths.
+            "agent_id": agent_id,
+            "host": host,
+            "count": info["count"],
+            "total_delay_s": round(info["total_delay_s"], 4),
             "first_ts": info["first_ts"],
         })
     return drained
@@ -2894,6 +2983,30 @@ class BrowserManager:
                     ev.get("agent_id", ""), e,
                 )
 
+        # Drain the platform pre-nav-delay audit buckets — feeds the
+        # dashboard's per-platform success panel with count + average
+        # dwell per (agent, host).  Same per-minute aggregation pattern.
+        try:
+            pt_events = await _drain_platform_timing_audit()
+        except Exception as e:
+            logger.warning("platform-timing audit drain failed: %s", e)
+            pt_events = []
+        for ev in pt_events:
+            ev = dict(ev)
+            self._metrics_seq += 1
+            ev["seq"] = self._metrics_seq
+            ev["ts"] = now
+            self._metrics_history.append(ev)
+            if self._metrics_sink is None:
+                continue
+            try:
+                self._metrics_sink(ev)
+            except Exception as e:
+                logger.warning(
+                    "platform-timing audit sink raised for '%s': %s",
+                    ev.get("agent_id", ""), e,
+                )
+
         # Phase 10 §24 — per-tenant spend-threshold alerts. Walks every
         # tenant currently active in the cost counter, asks the threshold
         # tracker which percentages crossed THIS tick, and ships a
@@ -3927,6 +4040,17 @@ class BrowserManager:
             "platform_pre_nav_delay agent=%s platform=%s delay=%.2fs",
             agent_id, label, delay_s,
         )
+        # Record into the per-minute audit aggregator so the dashboard's
+        # per-platform success panel can show count + average dwell.  Use
+        # the canonical host (lower-cased, ``www.`` stripped) so binning
+        # matches the dashboard side and the captcha audit path.  The
+        # call is best-effort — a recording failure must not block the
+        # navigation it's instrumenting.
+        try:
+            host = _canonical_host(url) or label
+            await _record_platform_timing_audit_event(agent_id, host, delay_s)
+        except Exception as e:
+            logger.debug("platform-timing audit record failed: %s", e)
         await asyncio.sleep(delay_s)
 
     def set_proxy_config(self, agent_id: str, config: dict | None) -> None:

--- a/src/dashboard/events.py
+++ b/src/dashboard/events.py
@@ -11,6 +11,7 @@ import asyncio
 import json
 import threading
 from collections import deque
+from collections.abc import Callable
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any
 
@@ -52,6 +53,12 @@ class EventBus:
         self._loop: asyncio.AbstractEventLoop | None = None
         self._seq: int = 0  # monotonic sequence counter
         self._lock = threading.Lock()
+        # In-process listeners — invoked synchronously from emit() so the
+        # dashboard's own aggregators (e.g. per-platform success rollup) can
+        # observe events without going through a WebSocket. Listeners must
+        # be cheap and non-blocking; exceptions are swallowed to keep emit
+        # robust against a buggy aggregator.
+        self._listeners: list[Callable[[dict], None]] = []
 
     def set_loop(self, loop: asyncio.AbstractEventLoop) -> None:
         """Bind to the mesh server's event loop. Idempotent."""
@@ -72,6 +79,17 @@ class EventBus:
             self._seq += 1
             evt_dict["_seq"] = self._seq
             self._buffer.append(evt_dict)
+            listeners = list(self._listeners)
+
+        # In-process listeners run synchronously on the caller's stack —
+        # the dashboard aggregators are O(1) per event so this is cheap.
+        # Catch every exception so a single misbehaving listener cannot
+        # break the broadcast path or starve other listeners.
+        for cb in listeners:
+            try:
+                cb(evt_dict)
+            except Exception as e:
+                logger.debug("EventBus listener raised: %s", e)
 
         if not self._clients:
             return
@@ -108,6 +126,27 @@ class EventBus:
 
     def unsubscribe(self, ws: WebSocket) -> None:
         self._clients = [c for c in self._clients if c.ws is not ws]
+
+    def add_listener(self, cb: Callable[[dict], None]) -> None:
+        """Register an in-process callback invoked synchronously from emit().
+
+        Used by the dashboard's per-platform success aggregator (and any
+        future module-level rollup) so it can observe events without
+        masquerading as a WebSocket subscriber. Idempotent — adding the
+        same callback twice will only call it twice (no dedupe).
+        """
+        with self._lock:
+            self._listeners.append(cb)
+
+    def remove_listener(self, cb: Callable[[dict], None]) -> None:
+        """Remove a previously-registered listener.  No-op if absent.
+
+        Uses equality (``==``) rather than identity so a bound-method
+        round-trip (``agg.handle_event`` evaluates to a fresh
+        ``MethodType`` each access) still matches the registered entry.
+        """
+        with self._lock:
+            self._listeners = [c for c in self._listeners if c != cb]
 
     @property
     def current_seq(self) -> int:

--- a/src/dashboard/platform_success.py
+++ b/src/dashboard/platform_success.py
@@ -1,0 +1,377 @@
+"""Per-platform success aggregation for the dashboard stealth/browser panel.
+
+Subscribes to ``EventBus`` emits and maintains an in-memory rolling
+window of per-host counters covering captcha outcomes, fingerprint burns,
+navigations, and applied platform pre-nav delays.  Operators see
+"which sites is my fleet succeeding on, and which ones flag / burn
+fingerprints" without having to scrape logs or replay events.
+
+State is intentionally process-local — a mesh restart resets the panel.
+The browser-service container's :mod:`src.browser.captcha_cost_counter`
+already persists tenant-level rollups; this module is best-effort
+observability, not an audit trail.
+
+All ingestion is O(1) per event:
+  * One dict lookup + integer/float increment.
+  * Old samples are pruned lazily on read (snapshot()) so a bursty
+    write phase cannot starve the event loop.
+
+The aggregator deliberately does NOT introduce a new SQLite table —
+keeping the lifecycle process-local lets us add the panel without a
+migration story.  An operator who wants persistence can request a
+follow-up.
+"""
+
+from __future__ import annotations
+
+import threading
+import time
+from collections import deque
+from dataclasses import dataclass, field
+from typing import Any
+from urllib.parse import urlparse
+
+from src.shared.utils import setup_logging
+
+logger = setup_logging("dashboard.platform_success")
+
+# ── Configuration ────────────────────────────────────────────────────────
+
+# Rolling-window length.  24h matches the operator's expected debugging
+# horizon: most stealth-regression investigations look at "today vs
+# yesterday".  Longer windows would inflate memory without surfacing any
+# signal that's not also visible in the event stream.
+WINDOW_SECONDS = 24 * 3600
+
+# Cap per-host sample lists at this size — protects against a runaway
+# loop on a single host hammering the aggregator.  At ~1 event/sec
+# sustained, a host fills 24h with 86400 samples; 10000 keeps memory
+# bounded while still preserving enough resolution for averages.
+MAX_SAMPLES_PER_HOST = 10000
+
+# How many platforms to surface in the snapshot response.  Enough to
+# show the long tail (operator can paginate via the EventBus log if they
+# need the rest) without blowing up the JSON payload.
+DEFAULT_TOP_N = 50
+
+
+# ── Helpers ──────────────────────────────────────────────────────────────
+
+
+def canonical_host(value: str) -> str | None:
+    """Lower-cased hostname with leading ``www.`` stripped, or ``None``.
+
+    Mirrors :func:`src.browser.stealth._canonical_host` and
+    :func:`src.browser.captcha_policy._hostname` so the dashboard side
+    bins traffic the same way the browser-service side does.  ``value``
+    may be a full URL (``https://www.linkedin.com/foo``) or a bare
+    hostname (``linkedin.com:443``); both reduce to ``linkedin.com``.
+    """
+    if not value:
+        return None
+    value = value.strip()
+    if not value:
+        return None
+    # Treat anything without a scheme as a bare host.  ``urlparse`` will
+    # otherwise stuff the whole string into ``path`` and yield no
+    # hostname at all.
+    if "://" in value:
+        try:
+            parsed = urlparse(value)
+        except Exception:
+            return None
+        host = (parsed.hostname or "").lower()
+    else:
+        # Strip a trailing ``:port`` if present.
+        host = value.split("/", 1)[0].split(":", 1)[0].lower()
+    if not host:
+        return None
+    if host.startswith("www."):
+        host = host[4:]
+    return host or None
+
+
+def _platform_label(host: str) -> str:
+    """Compress a host into a short label for display.
+
+    ``linkedin.com`` → ``linkedin``; ``api.example.com`` →
+    ``example``.  Falls back to the full host for single-segment
+    inputs (``localhost``).
+    """
+    parts = host.split(".")
+    if len(parts) >= 2:
+        return parts[-2]
+    return host
+
+
+# ── State ────────────────────────────────────────────────────────────────
+
+
+@dataclass
+class _HostState:
+    """Rolling per-host counters for a single platform.
+
+    Each ``deque`` entry is ``(timestamp, count_or_value)``.  Counts
+    use 1 per event; ``pre_nav_delays`` stores the dwell duration so
+    we can compute a true average later.
+    """
+
+    navigations: deque = field(default_factory=deque)
+    captcha_solved: deque = field(default_factory=deque)
+    captcha_failed: deque = field(default_factory=deque)
+    captcha_other: deque = field(default_factory=deque)
+    fingerprint_burns: deque = field(default_factory=deque)
+    pre_nav_delays: deque = field(default_factory=deque)
+
+
+class PlatformSuccessAggregator:
+    """In-memory rolling-window per-platform counter.
+
+    Thread-safe via a single ``threading.Lock``.  All accessors are
+    O(1) per event; ``snapshot`` is O(N) over the active host count.
+    """
+
+    def __init__(self, *, window_s: float = WINDOW_SECONDS,
+                 time_fn: Any = None) -> None:
+        self._window_s = window_s
+        # Inject a clock so tests can stub time without monkey-patching
+        # ``time.time`` globally (the dashboard server runs lots of other
+        # time-dependent code that we don't want to perturb).
+        self._time_fn = time_fn or time.time
+        self._lock = threading.Lock()
+        self._hosts: dict[str, _HostState] = {}
+
+    # ── Mutation ──────────────────────────────────────────────────────
+
+    def record_navigation(self, host: str | None, *, ts: float | None = None) -> None:
+        """Record a nav request to ``host``.  Pre-nav delays count too."""
+        if not host:
+            return
+        ts = ts if ts is not None else self._time_fn()
+        with self._lock:
+            state = self._hosts.setdefault(host, _HostState())
+            _push(state.navigations, ts, 1)
+
+    def record_captcha(
+        self,
+        host: str | None,
+        outcome: str,
+        *,
+        ts: float | None = None,
+    ) -> None:
+        """Record a captcha-gate outcome for ``host``.
+
+        ``outcome`` is one of the strings emitted by
+        :func:`src.browser.service._record_captcha_audit_event`:
+        ``success`` / ``failed`` / ``cost_cap`` / ``rate_limited`` /
+        ``skipped_behavioral`` / ``low_success_failed`` etc.  Anything
+        not explicitly matched is bucketed into ``captcha_other`` so
+        the operator still sees activity volume.
+        """
+        if not host:
+            return
+        ts = ts if ts is not None else self._time_fn()
+        outcome = (outcome or "").lower()
+        with self._lock:
+            state = self._hosts.setdefault(host, _HostState())
+            if outcome == "success":
+                _push(state.captcha_solved, ts, 1)
+            elif outcome in ("failed", "low_success_failed"):
+                _push(state.captcha_failed, ts, 1)
+            else:
+                _push(state.captcha_other, ts, 1)
+
+    def record_fingerprint_burn(
+        self, host: str | None, *, ts: float | None = None,
+    ) -> None:
+        if not host:
+            return
+        ts = ts if ts is not None else self._time_fn()
+        with self._lock:
+            state = self._hosts.setdefault(host, _HostState())
+            _push(state.fingerprint_burns, ts, 1)
+
+    def record_pre_nav_delay(
+        self, host: str | None, delay_s: float,
+        *, ts: float | None = None,
+    ) -> None:
+        """Record ONE applied pre-nav dwell of ``delay_s`` seconds.
+
+        The aggregator stores the dwell duration so the snapshot can
+        report a true mean.  ``record_pre_nav_delay`` also implies a
+        navigation (the dwell only fires immediately before a nav), so
+        callers SHOULD NOT separately call :meth:`record_navigation`
+        for the same event — would double-count.
+        """
+        if not host:
+            return
+        try:
+            d = float(delay_s)
+        except (ValueError, TypeError):
+            return
+        if d < 0:
+            return
+        ts = ts if ts is not None else self._time_fn()
+        with self._lock:
+            state = self._hosts.setdefault(host, _HostState())
+            _push(state.pre_nav_delays, ts, d)
+            _push(state.navigations, ts, 1)
+
+    # ── Reads ─────────────────────────────────────────────────────────
+
+    def snapshot(self, *, top_n: int = DEFAULT_TOP_N) -> dict:
+        """Build the JSON-serializable per-platform success snapshot.
+
+        Returns ``{since: ISO8601, platforms: [...]}`` ordered by
+        ``navigations`` desc.  Empty hosts (every counter pruned out
+        of the window) are dropped.
+        """
+        now = self._time_fn()
+        cutoff = now - self._window_s
+        platforms: list[dict] = []
+        with self._lock:
+            for host, state in self._hosts.items():
+                _prune(state.navigations, cutoff)
+                _prune(state.captcha_solved, cutoff)
+                _prune(state.captcha_failed, cutoff)
+                _prune(state.captcha_other, cutoff)
+                _prune(state.fingerprint_burns, cutoff)
+                _prune(state.pre_nav_delays, cutoff)
+
+                navigations = _sum_count(state.navigations)
+                solved = _sum_count(state.captcha_solved)
+                failed = _sum_count(state.captcha_failed)
+                other = _sum_count(state.captcha_other)
+                burns = _sum_count(state.fingerprint_burns)
+                delay_count = len(state.pre_nav_delays)
+                delay_sum = _sum_value(state.pre_nav_delays)
+                avg_delay = (delay_sum / delay_count) if delay_count else 0.0
+
+                # Drop hosts with absolutely no in-window activity —
+                # they linger as dict keys after a long-idle period.
+                if (
+                    navigations == 0 and solved == 0 and failed == 0
+                    and other == 0 and burns == 0 and delay_count == 0
+                ):
+                    continue
+
+                events = solved + failed + other
+                # Success rate is a fleet-level health number — only
+                # meaningful where at least one captcha gate fired.
+                # Hosts that never tripped a gate are reported as
+                # ``None`` so the frontend can render "—" instead of a
+                # misleading 100%.
+                if events > 0:
+                    success_rate: float | None = solved / events
+                else:
+                    success_rate = None
+
+                platforms.append({
+                    "host": host,
+                    "label": _platform_label(host),
+                    "navigations": navigations,
+                    "captcha_events": events,
+                    "captcha_solved": solved,
+                    "captcha_failed": failed,
+                    "captcha_other": other,
+                    "fingerprint_burns": burns,
+                    "pre_nav_delays_applied": delay_count,
+                    "avg_pre_nav_delay_s": round(avg_delay, 3),
+                    "success_rate": (
+                        round(success_rate, 3)
+                        if success_rate is not None else None
+                    ),
+                })
+
+        platforms.sort(key=lambda p: p["navigations"], reverse=True)
+        if top_n and top_n > 0:
+            platforms = platforms[:top_n]
+
+        from datetime import datetime, timezone
+        since_ts = now - self._window_s
+        since_iso = datetime.fromtimestamp(
+            since_ts, tz=timezone.utc,
+        ).isoformat().replace("+00:00", "Z")
+
+        return {
+            "since": since_iso,
+            "window_seconds": int(self._window_s),
+            "platforms": platforms,
+        }
+
+    # ── EventBus wiring ───────────────────────────────────────────────
+
+    def handle_event(self, evt: dict) -> None:
+        """Single entry point for the EventBus listener.
+
+        Dispatches based on the event ``type`` and the ``data.type``
+        sub-tag used by the browser-service metrics drainer.  Designed
+        to be cheap — pulls a few dict keys, no parsing of large
+        payloads.
+        """
+        try:
+            event_type = evt.get("type", "")
+            data = evt.get("data") or {}
+            if event_type != "browser_metrics":
+                return
+            sub_type = data.get("type", "")
+            if sub_type == "captcha_gate":
+                # ``url`` is a redacted page URL; if absent fall back to
+                # nothing so we never silently bin under "" — that would
+                # gather every host that lost its URL into one bucket.
+                host = canonical_host(data.get("url") or "")
+                outcome = data.get("outcome") or ""
+                count = int(data.get("count") or 1)
+                # Bucket carries an aggregated count — replay each event.
+                for _ in range(max(count, 1)):
+                    self.record_captcha(host, outcome)
+            elif sub_type == "fingerprint_event":
+                signal = data.get("signal") or ""
+                if signal != "fingerprint_burn":
+                    return  # only count burns; rejected/accepted are noisy
+                host = canonical_host(data.get("page_origin") or "")
+                count = int(data.get("count") or 1)
+                for _ in range(max(count, 1)):
+                    self.record_fingerprint_burn(host)
+            elif sub_type == "platform_pre_nav_delay":
+                host = canonical_host(data.get("host") or "")
+                count = int(data.get("count") or 1)
+                total = float(data.get("total_delay_s") or 0.0)
+                # Replay the aggregated count so navigations++ each time;
+                # split the dwell budget evenly.  A perfect-fidelity
+                # reconstruction would need per-sample timestamps, which
+                # would balloon the EventBus payload past §2.7's spirit.
+                per = (total / count) if count > 0 else 0.0
+                for _ in range(max(count, 1)):
+                    self.record_pre_nav_delay(host, per)
+        except Exception as e:
+            # Belt-and-braces: a malformed payload must NOT poison the
+            # EventBus broadcast loop.  Log at debug so an upstream bug
+            # (e.g. a new event shape) is greppable but not noisy.
+            logger.debug("platform_success.handle_event ignored: %s", e)
+
+
+# ── Internals ────────────────────────────────────────────────────────────
+
+
+def _push(d: deque, ts: float, value: float) -> None:
+    """Append a sample, dropping the oldest if we hit the cap."""
+    if len(d) >= MAX_SAMPLES_PER_HOST:
+        d.popleft()
+    d.append((ts, value))
+
+
+def _prune(d: deque, cutoff: float) -> None:
+    """Drop samples older than ``cutoff``.  Lazy — called on read."""
+    while d and d[0][0] < cutoff:
+        d.popleft()
+
+
+def _sum_count(d: deque) -> int:
+    """Sum the count column (each sample contributes ``value``)."""
+    return int(sum(v for _, v in d))
+
+
+def _sum_value(d: deque) -> float:
+    """Sum the value column as float (for delay aggregates)."""
+    return float(sum(v for _, v in d))

--- a/src/dashboard/platform_success.py
+++ b/src/dashboard/platform_success.py
@@ -256,13 +256,20 @@ class PlatformSuccessAggregator:
                     continue
 
                 events = solved + failed + other
-                # Success rate is a fleet-level health number — only
-                # meaningful where at least one captcha gate fired.
-                # Hosts that never tripped a gate are reported as
-                # ``None`` so the frontend can render "—" instead of a
-                # misleading 100%.
-                if events > 0:
-                    success_rate: float | None = solved / events
+                # Success rate must reflect ATTEMPTED solves only —
+                # ``other`` rolls up gate-skipped outcomes (cost_cap,
+                # rate_limited, skipped_behavioral, provider_missing,
+                # price_missing) that never reached the solver. Including
+                # them in the denominator made a fleet that hit cost cap
+                # 100 times and successfully solved 5 captchas show
+                # ``5/105 = 4.7%`` — operator-misleading. The honest
+                # success rate is solver attempts that returned a token
+                # ÷ total attempts (excluding gate skips). Hosts with
+                # zero attempts are reported as ``None`` so the frontend
+                # can render "—" instead of a misleading 100% / 0%.
+                attempted = solved + failed
+                if attempted > 0:
+                    success_rate: float | None = solved / attempted
                 else:
                     success_rate = None
 
@@ -271,6 +278,7 @@ class PlatformSuccessAggregator:
                     "label": _platform_label(host),
                     "navigations": navigations,
                     "captcha_events": events,
+                    "captcha_attempted": attempted,
                     "captcha_solved": solved,
                     "captcha_failed": failed,
                     "captcha_other": other,

--- a/src/dashboard/platform_success.py
+++ b/src/dashboard/platform_success.py
@@ -91,17 +91,38 @@ def canonical_host(value: str) -> str | None:
     return host or None
 
 
+# Multi-segment public suffixes ("effective TLDs"). When a host's last
+# two labels match one of these, the label is the THIRD-from-last
+# component instead of the second. Without this, ``bbc.co.uk`` would
+# label as ``co`` rather than ``bbc``. Kept short and operator-curated
+# rather than pulling in the full publicsuffix list — operators who
+# need exhaustive coverage can add to this set; the wrong label is a
+# cosmetic dashboard issue, not a correctness problem.
+_MULTI_SEGMENT_TLDS: frozenset[str] = frozenset({
+    "co.uk", "co.jp", "co.kr", "co.nz", "co.za",
+    "com.au", "com.br", "com.cn", "com.hk", "com.mx", "com.sg", "com.tw",
+    "ac.uk", "gov.uk", "org.uk", "ne.jp", "or.jp",
+})
+
+
 def _platform_label(host: str) -> str:
     """Compress a host into a short label for display.
 
     ``linkedin.com`` → ``linkedin``; ``api.example.com`` →
-    ``example``.  Falls back to the full host for single-segment
-    inputs (``localhost``).
+    ``example``; ``bbc.co.uk`` → ``bbc`` (multi-segment TLD aware).
+    Falls back to the full host for single-segment inputs
+    (``localhost``).
     """
     parts = host.split(".")
-    if len(parts) >= 2:
-        return parts[-2]
-    return host
+    if len(parts) < 2:
+        return host
+    # Multi-segment TLD: ``bbc.co.uk`` → split is
+    # ["bbc", "co", "uk"], last two joined = "co.uk" → label is parts[-3].
+    if len(parts) >= 3:
+        suffix = ".".join(parts[-2:])
+        if suffix in _MULTI_SEGMENT_TLDS:
+            return parts[-3]
+    return parts[-2]
 
 
 # ── State ────────────────────────────────────────────────────────────────

--- a/src/dashboard/server.py
+++ b/src/dashboard/server.py
@@ -641,6 +641,17 @@ def create_dashboard_router(
         dependencies=[Depends(_verify_dashboard_auth), Depends(_csrf_check)],
     )
 
+    # Per-platform success aggregator — subscribes to EventBus emits and
+    # maintains a 24h rolling window of captcha outcomes / fingerprint
+    # burns / pre-nav dwells per host.  Instantiated even when
+    # ``event_bus`` is None (some dashboards run without a bus) so the
+    # GET endpoint can still return an empty snapshot rather than
+    # 500'ing.
+    from src.dashboard.platform_success import PlatformSuccessAggregator
+    platform_success = PlatformSuccessAggregator()
+    if event_bus is not None:
+        event_bus.add_listener(platform_success.handle_event)
+
     jinja_env = Environment(
         loader=FileSystemLoader(str(_TEMPLATES_DIR)),
         autoescape=True,
@@ -4215,6 +4226,18 @@ def create_dashboard_router(
             "speed": settings.get("browser_speed", 1.0),
             "delay": settings.get("browser_delay", 0.0),
         }
+
+    @api_router.get("/api/dashboard/platform-success")
+    async def api_get_platform_success() -> dict:
+        """Per-platform fleet success rollup over the last 24h.
+
+        Read-only aggregation surfaced from the dashboard's in-memory
+        EventBus listener — no SQLite, no upstream call.  Operators use
+        this to spot "which sites is my fleet succeeding on, and which
+        ones are flagging or burning fingerprints" without scraping
+        logs.  Resets on mesh restart (process-local).
+        """
+        return platform_success.snapshot()
 
     @api_router.post("/api/browser-settings")
     async def api_set_browser_settings(request: Request) -> dict:

--- a/src/dashboard/static/js/app.js
+++ b/src/dashboard/static/js/app.js
@@ -215,6 +215,15 @@ function dashboard() {
     captchaSolverKeyMasked: '',
     captchaSolverSaving: false,
 
+    // Per-platform success rollup (24h rolling window; aggregated by
+    // the dashboard from browser_metrics EventBus payloads).  Refreshed
+    // on a sensible cadence — not the noisy 1s timer; 30s aligns with
+    // the operator's expected debugging cadence and also keeps the
+    // load on the dashboard process modest when the panel is left open.
+    platformSuccessData: { platforms: [], since: null },
+    platformSuccessLoading: false,
+    _platformSuccessTimer: null,
+
     // System settings
     systemSettings: null,
     systemSettingsLoading: false,
@@ -1267,6 +1276,7 @@ function dashboard() {
           this.fetchBrowserSettings();
           this.fetchSystemSettings();
           this.fetchCaptchaSolver();
+          this.startPlatformSuccessRefresh();
         }
         if (this.systemTab === 'activity') {
           if (this.activityView === 'traces') {
@@ -1289,7 +1299,8 @@ function dashboard() {
       if (tabId === 'storage') { this.fetchUploads(); this.fetchStorage(); this.fetchDatabaseDetails(); }
       if (tabId === 'network') { this.loadNetworkProxy(); }
       if (tabId === 'settings') { this.fetchBrowserSettings(); this.fetchSystemSettings(); }
-      if (tabId === 'browser') { this.fetchBrowserSettings(); this.fetchSystemSettings(); this.fetchCaptchaSolver(); }
+      if (tabId === 'browser') { this.fetchBrowserSettings(); this.fetchSystemSettings(); this.fetchCaptchaSolver(); this.startPlatformSuccessRefresh(); }
+      if (tabId !== 'browser') { this.stopPlatformSuccessRefresh(); }
       if (tabId === 'operator') {
         this.fetchAuditLog();
       }
@@ -3669,6 +3680,54 @@ function dashboard() {
     },
 
     // ── Browser settings ─────────────────────────────────
+
+    async fetchPlatformSuccess() {
+      // Pull the rollup; the dashboard aggregates events in-process,
+      // so this is a cheap dict-walk on the server side.  On error we
+      // keep the previous payload visible (operators see a stale row
+      // rather than an empty panel).
+      this.platformSuccessLoading = true;
+      try {
+        const resp = await fetch(`${window.__config.apiBase}/dashboard/platform-success`);
+        if (resp.ok) {
+          this.platformSuccessData = await resp.json();
+        }
+      } catch (e) { console.warn('fetchPlatformSuccess failed:', e); }
+      this.platformSuccessLoading = false;
+    },
+
+    startPlatformSuccessRefresh() {
+      // Idempotent — calling twice will not stack timers.  30s polling
+      // matches the panel's "operator-glance" use case; the live
+      // EventBus already streams the underlying signals to the
+      // browser metrics + fingerprint cards on faster cadences.
+      if (this._platformSuccessTimer) return;
+      this.fetchPlatformSuccess();
+      this._platformSuccessTimer = setInterval(() => {
+        this.fetchPlatformSuccess();
+      }, 30000);
+    },
+
+    stopPlatformSuccessRefresh() {
+      if (this._platformSuccessTimer) {
+        clearInterval(this._platformSuccessTimer);
+        this._platformSuccessTimer = null;
+      }
+    },
+
+    platformSuccessBarClass(rate) {
+      if (rate === null || rate === undefined) return 'bg-gray-700';
+      if (rate >= 0.8) return 'bg-emerald-500';
+      if (rate >= 0.5) return 'bg-yellow-500';
+      return 'bg-red-500';
+    },
+
+    platformSuccessTextClass(rate) {
+      if (rate === null || rate === undefined) return 'text-gray-500';
+      if (rate >= 0.8) return 'text-emerald-400';
+      if (rate >= 0.5) return 'text-yellow-400';
+      return 'text-red-400';
+    },
 
     async fetchBrowserSettings() {
       this.browserSettingsLoading = true;

--- a/src/dashboard/templates/index.html
+++ b/src/dashboard/templates/index.html
@@ -5110,6 +5110,83 @@
             </template>
           </div>
 
+          <!-- ── Per-Platform Success ── -->
+          <div class="bg-gray-900 border border-gray-800 rounded-lg p-5">
+            <div class="flex items-center justify-between mb-1">
+              <div class="flex items-center gap-2">
+                <svg class="w-4 h-4 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 19V6l12-3v13M9 19c0 1.105-1.343 2-3 2s-3-.895-3-2 1.343-2 3-2 3 .895 3 2zm12-3c0 1.105-1.343 2-3 2s-3-.895-3-2 1.343-2 3-2 3 .895 3 2zM9 10l12-3"/></svg>
+                <h3 class="text-sm font-medium text-gray-200">Per-Platform Success</h3>
+              </div>
+              <span class="text-[10px] text-gray-600">last 24h · refreshes 30s</span>
+            </div>
+            <p class="text-[10px] text-gray-500 mb-4 leading-relaxed">
+              Aggregated per host across the fleet. <span class="text-gray-400">Success</span> is the share of CAPTCHA gates that solved cleanly. <span class="text-amber-400">Burns</span> are fingerprints rejected after a solve — the cue to rotate the profile. Hosts without any CAPTCHA activity show "—" for success rate.
+            </p>
+            <template x-if="!platformSuccessLoading && (platformSuccessData.platforms || []).length === 0">
+              <div class="text-xs text-gray-600 italic py-2">
+                No browser activity yet. Platform stats appear here as agents navigate.
+              </div>
+            </template>
+            <template x-if="platformSuccessLoading && (platformSuccessData.platforms || []).length === 0">
+              <div class="text-xs text-gray-600 italic py-2">Loading&hellip;</div>
+            </template>
+            <template x-if="(platformSuccessData.platforms || []).length > 0">
+              <div class="overflow-x-auto">
+                <table class="w-full text-xs">
+                  <thead>
+                    <tr class="text-[10px] uppercase tracking-wide text-gray-500 border-b border-gray-800">
+                      <th class="text-left font-medium pb-2 pr-4">Platform</th>
+                      <th class="text-right font-medium pb-2 pr-4">Navs</th>
+                      <th class="text-right font-medium pb-2 pr-4">CAPTCHA</th>
+                      <th class="text-right font-medium pb-2 pr-4">Burns</th>
+                      <th class="text-right font-medium pb-2 pr-4">Avg dwell</th>
+                      <th class="text-left font-medium pb-2 w-40">Success rate</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    <template x-for="row in (platformSuccessData.platforms || [])" :key="row.host">
+                      <tr class="border-b border-gray-800/40">
+                        <td class="py-2 pr-4">
+                          <div class="text-gray-200 font-medium" x-text="row.label"></div>
+                          <div class="text-[10px] text-gray-600 font-mono truncate max-w-[14rem]" x-text="row.host"></div>
+                        </td>
+                        <td class="py-2 pr-4 text-right font-mono text-gray-300" x-text="row.navigations"></td>
+                        <td class="py-2 pr-4 text-right font-mono text-gray-300">
+                          <span x-text="(row.captcha_solved || 0) + '/' + (row.captcha_events || 0)"></span>
+                          <template x-if="(row.captcha_failed || 0) > 0">
+                            <span class="text-red-400 ml-1" x-text="'(' + row.captcha_failed + ' failed)'"></span>
+                          </template>
+                        </td>
+                        <td class="py-2 pr-4 text-right font-mono"
+                          :class="(row.fingerprint_burns || 0) > 0 ? 'text-amber-400' : 'text-gray-600'"
+                          x-text="row.fingerprint_burns || 0"></td>
+                        <td class="py-2 pr-4 text-right font-mono text-gray-400"
+                          x-text="(row.pre_nav_delays_applied || 0) > 0 ? row.avg_pre_nav_delay_s.toFixed(2) + 's' : '—'"></td>
+                        <td class="py-2 pr-4">
+                          <template x-if="row.success_rate === null">
+                            <span class="text-gray-600">—</span>
+                          </template>
+                          <template x-if="row.success_rate !== null">
+                            <div class="flex items-center gap-2">
+                              <div class="flex-1 h-1.5 rounded-full bg-gray-800 overflow-hidden">
+                                <div class="h-full rounded-full"
+                                  :class="platformSuccessBarClass(row.success_rate)"
+                                  :style="'width: ' + Math.round((row.success_rate || 0) * 100) + '%'"></div>
+                              </div>
+                              <span class="text-[10px] font-mono w-10 text-right"
+                                :class="platformSuccessTextClass(row.success_rate)"
+                                x-text="Math.round((row.success_rate || 0) * 100) + '%'"></span>
+                            </div>
+                          </template>
+                        </td>
+                      </tr>
+                    </template>
+                  </tbody>
+                </table>
+              </div>
+            </template>
+          </div>
+
           <!-- ── Interaction Speed ── -->
           <div class="bg-gray-900 border border-gray-800 rounded-lg p-5">
             <div class="flex items-center gap-2 mb-4">

--- a/src/dashboard/templates/index.html
+++ b/src/dashboard/templates/index.html
@@ -5152,9 +5152,14 @@
                         </td>
                         <td class="py-2 pr-4 text-right font-mono text-gray-300" x-text="row.navigations"></td>
                         <td class="py-2 pr-4 text-right font-mono text-gray-300">
-                          <span x-text="(row.captcha_solved || 0) + '/' + (row.captcha_events || 0)"></span>
+                          <span x-text="(row.captcha_solved || 0) + '/' + (row.captcha_attempted || 0)"></span>
                           <template x-if="(row.captcha_failed || 0) > 0">
                             <span class="text-red-400 ml-1" x-text="'(' + row.captcha_failed + ' failed)'"></span>
+                          </template>
+                          <template x-if="(row.captcha_other || 0) > 0">
+                            <span class="text-amber-400 ml-1 text-[10px]"
+                              :title="'Gate-skipped (cost cap / rate limit / behavioral): ' + row.captcha_other"
+                              x-text="'+' + row.captcha_other + ' skipped'"></span>
                           </template>
                         </td>
                         <td class="py-2 pr-4 text-right font-mono"

--- a/tests/test_dashboard_platform_success.py
+++ b/tests/test_dashboard_platform_success.py
@@ -1,0 +1,527 @@
+"""Tests for the per-platform success aggregation + dashboard endpoint.
+
+Covers the in-memory aggregator (24h rolling window, host
+canonicalization, captcha/burn/dwell ingestion) and the
+``GET /api/dashboard/platform-success`` endpoint wired through
+``EventBus`` listeners.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import tempfile
+from unittest.mock import MagicMock
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from src.dashboard.events import EventBus
+from src.dashboard.platform_success import (
+    PlatformSuccessAggregator,
+    canonical_host,
+)
+
+# ── Aggregator unit tests ──────────────────────────────────────────────
+
+
+class _Clock:
+    """Monotonic injectable clock for window-eviction tests."""
+
+    def __init__(self, start: float = 1_000_000.0) -> None:
+        self.now = start
+
+    def __call__(self) -> float:
+        return self.now
+
+    def advance(self, seconds: float) -> None:
+        self.now += seconds
+
+
+class TestCanonicalHost:
+    def test_full_url_strips_scheme_and_www(self):
+        assert canonical_host("https://www.linkedin.com/foo") == "linkedin.com"
+
+    def test_bare_host_with_port(self):
+        assert canonical_host("LinkedIn.com:443") == "linkedin.com"
+
+    def test_subdomain_preserved(self):
+        # We don't reduce subdomains — the dashboard wants per-host
+        # visibility; the protected-platform timing logic does the
+        # subdomain folding separately.
+        assert canonical_host("https://api.linkedin.com/v2") == "api.linkedin.com"
+
+    def test_empty_returns_none(self):
+        assert canonical_host("") is None
+        assert canonical_host(None) is None  # type: ignore[arg-type]
+
+    def test_malformed_returns_none(self):
+        # urlparse is forgiving — "not-a-url" is treated as a bare host
+        # and lower-cased.  Anything obviously wrong (whitespace-only)
+        # comes back as None.
+        assert canonical_host("   ") is None or canonical_host("   ") == ""
+
+
+class TestRecordCaptcha:
+    def test_solved_failed_other(self):
+        clk = _Clock()
+        agg = PlatformSuccessAggregator(time_fn=clk)
+        agg.record_captcha("linkedin.com", "success")
+        agg.record_captcha("linkedin.com", "failed")
+        agg.record_captcha("linkedin.com", "cost_cap")
+        snap = agg.snapshot()
+        rows = {p["host"]: p for p in snap["platforms"]}
+        assert "linkedin.com" in rows
+        row = rows["linkedin.com"]
+        assert row["captcha_solved"] == 1
+        assert row["captcha_failed"] == 1
+        # cost_cap, rate_limited, etc. → "other"
+        assert row["captcha_other"] == 1
+        assert row["captcha_events"] == 3
+        # 1 solved out of 3 captcha events → 0.333
+        assert abs(row["success_rate"] - 1 / 3) < 1e-3
+
+    def test_no_host_is_dropped(self):
+        agg = PlatformSuccessAggregator()
+        agg.record_captcha(None, "success")
+        agg.record_captcha("", "success")
+        assert agg.snapshot()["platforms"] == []
+
+
+class TestRecordPreNavDelay:
+    def test_average_dwell_computed(self):
+        agg = PlatformSuccessAggregator()
+        agg.record_pre_nav_delay("linkedin.com", 2.0)
+        agg.record_pre_nav_delay("linkedin.com", 4.0)
+        agg.record_pre_nav_delay("linkedin.com", 3.0)
+        snap = agg.snapshot()
+        row = next(p for p in snap["platforms"] if p["host"] == "linkedin.com")
+        # Mean of 2.0, 4.0, 3.0 = 3.0
+        assert abs(row["avg_pre_nav_delay_s"] - 3.0) < 1e-3
+        # And the dwell event implicitly counts as a navigation.
+        assert row["navigations"] == 3
+        assert row["pre_nav_delays_applied"] == 3
+
+    def test_negative_delay_rejected(self):
+        agg = PlatformSuccessAggregator()
+        agg.record_pre_nav_delay("linkedin.com", -1.0)
+        assert agg.snapshot()["platforms"] == []
+
+
+class TestRecordFingerprintBurn:
+    def test_burn_attributed_to_host(self):
+        agg = PlatformSuccessAggregator()
+        agg.record_fingerprint_burn("x.com")
+        snap = agg.snapshot()
+        row = next(p for p in snap["platforms"] if p["host"] == "x.com")
+        assert row["fingerprint_burns"] == 1
+
+
+class TestUnknownPlatformAggregated:
+    def test_arbitrary_host_visible(self):
+        """Operator visibility is platform-agnostic: a captcha event on
+        ``example.com`` (NOT on the protected-platform list) still
+        shows up in the rollup."""
+        agg = PlatformSuccessAggregator()
+        agg.record_captcha("example.com", "success")
+        snap = agg.snapshot()
+        hosts = {p["host"] for p in snap["platforms"]}
+        assert "example.com" in hosts
+
+
+class TestRollingWindow:
+    def test_old_events_drop_out(self):
+        clk = _Clock()
+        agg = PlatformSuccessAggregator(window_s=10.0, time_fn=clk)
+        agg.record_captcha("linkedin.com", "success")
+        clk.advance(5)
+        agg.record_captcha("linkedin.com", "success")
+        # Both are still inside the 10s window
+        snap = agg.snapshot()
+        row = next(p for p in snap["platforms"] if p["host"] == "linkedin.com")
+        assert row["captcha_solved"] == 2
+        # Now jump past the first event's TTL
+        clk.advance(6)  # now=11+ > window of 10s after first
+        snap = agg.snapshot()
+        row = next(p for p in snap["platforms"] if p["host"] == "linkedin.com")
+        assert row["captcha_solved"] == 1
+        # Jump past everything
+        clk.advance(1000)
+        snap = agg.snapshot()
+        # Empty hosts get pruned
+        assert snap["platforms"] == []
+
+
+class TestSnapshotShape:
+    def test_sort_by_navigations_desc(self):
+        agg = PlatformSuccessAggregator()
+        for _ in range(5):
+            agg.record_navigation("a.com")
+        for _ in range(10):
+            agg.record_navigation("b.com")
+        for _ in range(3):
+            agg.record_navigation("c.com")
+        rows = agg.snapshot()["platforms"]
+        assert [p["host"] for p in rows] == ["b.com", "a.com", "c.com"]
+
+    def test_since_present_iso8601(self):
+        agg = PlatformSuccessAggregator()
+        snap = agg.snapshot()
+        # ISO8601 with Z suffix for UTC
+        assert snap["since"].endswith("Z")
+
+    def test_no_captcha_yields_null_success_rate(self):
+        """A row with navigations but no captcha events reports
+        success_rate=null — operators should see "—" not 100%."""
+        agg = PlatformSuccessAggregator()
+        agg.record_navigation("quiet-site.com")
+        snap = agg.snapshot()
+        row = next(p for p in snap["platforms"] if p["host"] == "quiet-site.com")
+        assert row["success_rate"] is None
+
+
+# ── EventBus integration ──────────────────────────────────────────────
+
+
+class TestHandleEvent:
+    """Verify the EventBus listener correctly dispatches by sub-type."""
+
+    def test_captcha_gate_event(self):
+        agg = PlatformSuccessAggregator()
+        evt = {
+            "type": "browser_metrics",
+            "agent": "alpha",
+            "data": {
+                "type": "captcha_gate",
+                "agent_id": "alpha",
+                "outcome": "success",
+                "kind": "cf_turnstile",
+                "url": "https://www.linkedin.com/feed",
+                "count": 3,
+            },
+        }
+        agg.handle_event(evt)
+        snap = agg.snapshot()
+        row = next(p for p in snap["platforms"] if p["host"] == "linkedin.com")
+        # Aggregator replays the count so all three are recorded
+        assert row["captcha_solved"] == 3
+
+    def test_fingerprint_burn_event(self):
+        agg = PlatformSuccessAggregator()
+        evt = {
+            "type": "browser_metrics",
+            "agent": "alpha",
+            "data": {
+                "type": "fingerprint_event",
+                "agent_id": "alpha",
+                "signal": "fingerprint_burn",
+                "page_origin": "https://x.com",
+                "count": 1,
+            },
+        }
+        agg.handle_event(evt)
+        snap = agg.snapshot()
+        row = next(p for p in snap["platforms"] if p["host"] == "x.com")
+        assert row["fingerprint_burns"] == 1
+
+    def test_fingerprint_rejected_signal_ignored(self):
+        agg = PlatformSuccessAggregator()
+        evt = {
+            "type": "browser_metrics",
+            "agent": "alpha",
+            "data": {
+                "type": "fingerprint_event",
+                "agent_id": "alpha",
+                "signal": "rejected",  # NOT a burn — should be ignored
+                "page_origin": "https://x.com",
+                "count": 5,
+            },
+        }
+        agg.handle_event(evt)
+        assert agg.snapshot()["platforms"] == []
+
+    def test_platform_pre_nav_delay_event(self):
+        agg = PlatformSuccessAggregator()
+        evt = {
+            "type": "browser_metrics",
+            "agent": "alpha",
+            "data": {
+                "type": "platform_pre_nav_delay",
+                "agent_id": "alpha",
+                "host": "linkedin.com",
+                "count": 4,
+                "total_delay_s": 12.0,
+            },
+        }
+        agg.handle_event(evt)
+        snap = agg.snapshot()
+        row = next(p for p in snap["platforms"] if p["host"] == "linkedin.com")
+        assert row["pre_nav_delays_applied"] == 4
+        # 12.0 / 4 = 3.0
+        assert abs(row["avg_pre_nav_delay_s"] - 3.0) < 1e-3
+        # Each dwell implies a navigation
+        assert row["navigations"] == 4
+
+    def test_unrelated_event_ignored(self):
+        agg = PlatformSuccessAggregator()
+        evt = {
+            "type": "llm_call",
+            "data": {"type": "captcha_gate", "url": "https://linkedin.com/"},
+        }
+        agg.handle_event(evt)
+        # Only browser_metrics events count
+        assert agg.snapshot()["platforms"] == []
+
+    def test_malformed_event_swallowed(self):
+        agg = PlatformSuccessAggregator()
+        # No "data" key, no "type" — must not raise
+        agg.handle_event({})
+        agg.handle_event({"type": "browser_metrics"})
+        agg.handle_event({"type": "browser_metrics", "data": {"type": "captcha_gate"}})
+        # No exception is the assertion
+
+
+class TestEventBusListener:
+    def test_emit_invokes_listener(self):
+        bus = EventBus()
+        agg = PlatformSuccessAggregator()
+        bus.add_listener(agg.handle_event)
+        bus.emit("browser_metrics", agent="alpha", data={
+            "type": "captcha_gate",
+            "agent_id": "alpha",
+            "outcome": "success",
+            "kind": "cf_turnstile",
+            "url": "https://linkedin.com/",
+            "count": 1,
+        })
+        snap = agg.snapshot()
+        assert snap["platforms"][0]["host"] == "linkedin.com"
+
+    def test_listener_exception_does_not_break_emit(self):
+        bus = EventBus()
+        crashes = []
+
+        def bad(_evt):
+            crashes.append(1)
+            raise RuntimeError("boom")
+
+        bus.add_listener(bad)
+        bus.emit("llm_call")
+        assert crashes == [1]  # listener was called
+        # The event still made it into the buffer
+        assert len(bus._buffer) == 1
+
+    def test_remove_listener(self):
+        bus = EventBus()
+        agg = PlatformSuccessAggregator()
+        bus.add_listener(agg.handle_event)
+        bus.remove_listener(agg.handle_event)
+        bus.emit("browser_metrics", data={
+            "type": "captcha_gate",
+            "outcome": "success",
+            "url": "https://linkedin.com/",
+            "count": 1,
+        })
+        assert agg.snapshot()["platforms"] == []
+
+
+# ── Endpoint integration ──────────────────────────────────────────────
+
+
+def _make_components(tmp_path: str) -> dict:
+    """Minimal dashboard components for the endpoint tests.
+
+    Mirrors :func:`tests.test_dashboard._make_components` with only the
+    fields the platform-success endpoint touches.  Avoids the
+    ``include_v2=True`` machinery (we don't need it).
+    """
+    from src.host.costs import CostTracker
+    from src.host.health import HealthMonitor
+    from src.host.mesh import Blackboard
+    from src.host.traces import TraceStore
+
+    bb = Blackboard(db_path=os.path.join(tmp_path, "bb.db"))
+    cost_tracker = CostTracker(db_path=os.path.join(tmp_path, "costs.db"))
+    trace_store = TraceStore(db_path=os.path.join(tmp_path, "traces.db"))
+    event_bus = EventBus()
+    runtime_mock = MagicMock()
+    runtime_mock.browser_vnc_url = None
+    runtime_mock.browser_service_url = None
+    runtime_mock.browser_auth_token = ""
+    transport_mock = MagicMock()
+    router_mock = MagicMock()
+    health_monitor = HealthMonitor(
+        runtime=runtime_mock, transport=transport_mock, router=router_mock,
+    )
+    return {
+        "blackboard": bb,
+        "health_monitor": health_monitor,
+        "cost_tracker": cost_tracker,
+        "trace_store": trace_store,
+        "event_bus": event_bus,
+        "agent_registry": {},
+    }
+
+
+def _teardown(components: dict) -> None:
+    components["cost_tracker"].close()
+    components["trace_store"].close()
+    components["blackboard"].close()
+
+
+def _make_client(components: dict) -> TestClient:
+    from src.dashboard.server import create_dashboard_router
+
+    router = create_dashboard_router(**components, mesh_port=8420)
+    app = FastAPI()
+    app.include_router(router)
+    return TestClient(app)
+
+
+class TestPlatformSuccessEndpoint:
+    def setup_method(self):
+        self._tmpdir = tempfile.mkdtemp()
+        self.components = _make_components(self._tmpdir)
+        self.client = _make_client(self.components)
+
+    def teardown_method(self):
+        _teardown(self.components)
+        shutil.rmtree(self._tmpdir, ignore_errors=True)
+
+    def test_endpoint_returns_200_for_authenticated_request(self):
+        # Self-hosted mode (no /opt/openlegion/.access_token) — the
+        # auth verifier is a no-op, mirroring the rest of the
+        # dashboard tests.
+        resp = self.client.get("/dashboard/api/dashboard/platform-success")
+        assert resp.status_code == 200
+
+    def test_empty_state(self):
+        resp = self.client.get("/dashboard/api/dashboard/platform-success")
+        data = resp.json()
+        assert data["platforms"] == []
+        assert "since" in data
+        assert data["since"].endswith("Z")
+
+    def test_endpoint_reflects_emitted_events(self):
+        bus: EventBus = self.components["event_bus"]
+        # Emit several captcha events for linkedin.com — the dashboard
+        # listener registered by create_dashboard_router should bin them.
+        for outcome in ("success", "success", "failed"):
+            bus.emit("browser_metrics", agent="alpha", data={
+                "type": "captcha_gate",
+                "agent_id": "alpha",
+                "outcome": outcome,
+                "kind": "cf_turnstile",
+                "url": "https://linkedin.com/feed",
+                "count": 1,
+            })
+        resp = self.client.get("/dashboard/api/dashboard/platform-success")
+        data = resp.json()
+        rows = {p["host"]: p for p in data["platforms"]}
+        assert "linkedin.com" in rows
+        row = rows["linkedin.com"]
+        assert row["captcha_solved"] == 2
+        assert row["captcha_failed"] == 1
+        assert row["captcha_events"] == 3
+
+    def test_endpoint_picks_up_fingerprint_burn(self):
+        bus: EventBus = self.components["event_bus"]
+        bus.emit("browser_metrics", agent="alpha", data={
+            "type": "fingerprint_event",
+            "agent_id": "alpha",
+            "signal": "fingerprint_burn",
+            "page_origin": "https://www.x.com",
+            "count": 1,
+        })
+        resp = self.client.get("/dashboard/api/dashboard/platform-success")
+        rows = {p["host"]: p for p in resp.json()["platforms"]}
+        assert rows["x.com"]["fingerprint_burns"] == 1
+
+    def test_endpoint_picks_up_pre_nav_delay(self):
+        bus: EventBus = self.components["event_bus"]
+        bus.emit("browser_metrics", agent="alpha", data={
+            "type": "platform_pre_nav_delay",
+            "agent_id": "alpha",
+            "host": "linkedin.com",
+            "count": 5,
+            "total_delay_s": 14.7,
+        })
+        resp = self.client.get("/dashboard/api/dashboard/platform-success")
+        rows = {p["host"]: p for p in resp.json()["platforms"]}
+        row = rows["linkedin.com"]
+        assert row["pre_nav_delays_applied"] == 5
+        # 14.7 / 5 = 2.94
+        assert abs(row["avg_pre_nav_delay_s"] - 2.94) < 1e-2
+
+    def test_endpoint_sort_order(self):
+        bus: EventBus = self.components["event_bus"]
+        # 5 navs to a, 1 nav to b — a should come first
+        for _ in range(5):
+            bus.emit("browser_metrics", agent="alpha", data={
+                "type": "platform_pre_nav_delay",
+                "agent_id": "alpha", "host": "a.com",
+                "count": 1, "total_delay_s": 1.0,
+            })
+        bus.emit("browser_metrics", agent="alpha", data={
+            "type": "platform_pre_nav_delay",
+            "agent_id": "alpha", "host": "b.com",
+            "count": 1, "total_delay_s": 1.0,
+        })
+        rows = self.client.get(
+            "/dashboard/api/dashboard/platform-success",
+        ).json()["platforms"]
+        assert [p["host"] for p in rows[:2]] == ["a.com", "b.com"]
+
+    def test_arbitrary_host_visible_endpoint(self):
+        """example.com is not on the protected-platform list, but a
+        captcha event there still surfaces — operator visibility must
+        be platform-agnostic."""
+        bus: EventBus = self.components["event_bus"]
+        bus.emit("browser_metrics", agent="alpha", data={
+            "type": "captcha_gate",
+            "agent_id": "alpha",
+            "outcome": "success",
+            "kind": "cf_turnstile",
+            "url": "https://example.com/foo",
+            "count": 1,
+        })
+        rows = {p["host"]: p for p in self.client.get(
+            "/dashboard/api/dashboard/platform-success",
+        ).json()["platforms"]}
+        assert "example.com" in rows
+
+
+# ── Window eviction integration ──────────────────────────────────────
+
+
+class TestWindowEvictionEndpoint:
+    """Verifies events older than the rolling window drop out of the
+    snapshot.  Uses an injected clock to avoid sleeping."""
+
+    def setup_method(self):
+        self._tmpdir = tempfile.mkdtemp()
+        self.components = _make_components(self._tmpdir)
+        # Build a router with a custom aggregator clock so we can
+        # advance time without the test taking 24h to run.  We
+        # accomplish this by reaching into the listener after-the-fact:
+        # the aggregator is module-level only inside the closure, so
+        # we test the eviction path via the unit-level interface and
+        # then sanity-check the endpoint path with a freshly-emitted
+        # event (no time travel needed).
+        self.client = _make_client(self.components)
+
+    def teardown_method(self):
+        _teardown(self.components)
+        shutil.rmtree(self._tmpdir, ignore_errors=True)
+
+    def test_endpoint_24h_window_eviction(self):
+        """Direct aggregator test (the endpoint path is covered by the
+        sibling tests): events older than the window are evicted."""
+        clk = _Clock()
+        agg = PlatformSuccessAggregator(window_s=86400.0, time_fn=clk)
+        agg.record_captcha("linkedin.com", "success")
+        # Step past the window
+        clk.advance(86400.0 + 1)
+        snap = agg.snapshot()
+        # The host's only event aged out — empty rows are dropped
+        assert snap["platforms"] == []

--- a/tests/test_dashboard_platform_success.py
+++ b/tests/test_dashboard_platform_success.py
@@ -590,3 +590,42 @@ class TestSuccessRateExcludesGateSkips:
         assert row["captcha_attempted"] == 0
         assert row["captcha_other"] == 10
         assert row["success_rate"] is None
+
+
+# ── _platform_label edge cases (multi-segment TLDs) ───────────────────
+
+
+class TestPlatformLabel:
+    def test_two_segment_host(self):
+        from src.dashboard.platform_success import _platform_label
+        assert _platform_label("linkedin.com") == "linkedin"
+
+    def test_subdomain_resolves_to_apex(self):
+        from src.dashboard.platform_success import _platform_label
+        assert _platform_label("api.example.com") == "example"
+        assert _platform_label("mobile.linkedin.com") == "linkedin"
+
+    def test_multi_segment_tld_uk(self):
+        """``bbc.co.uk`` → ``bbc`` (not ``co``).  Pre-fix this was
+        labelling every UK site as "co" which made the dashboard
+        useless for UK fleets."""
+        from src.dashboard.platform_success import _platform_label
+        assert _platform_label("bbc.co.uk") == "bbc"
+        assert _platform_label("guardian.co.uk") == "guardian"
+
+    def test_multi_segment_tld_australia(self):
+        from src.dashboard.platform_success import _platform_label
+        assert _platform_label("news.com.au") == "news"
+
+    def test_subdomain_under_multi_segment_tld(self):
+        """``api.bbc.co.uk`` → ``bbc`` (label is the registrable
+        domain, not the closest subdomain)."""
+        from src.dashboard.platform_success import _platform_label
+        # api.bbc.co.uk splits to [api, bbc, co, uk]; suffix = "co.uk"
+        # is in the multi-segment set; with len >= 3 we look at
+        # parts[-3] = "bbc". That's the correct label.
+        assert _platform_label("api.bbc.co.uk") == "bbc"
+
+    def test_single_segment_falls_back(self):
+        from src.dashboard.platform_success import _platform_label
+        assert _platform_label("localhost") == "localhost"

--- a/tests/test_dashboard_platform_success.py
+++ b/tests/test_dashboard_platform_success.py
@@ -75,11 +75,15 @@ class TestRecordCaptcha:
         row = rows["linkedin.com"]
         assert row["captcha_solved"] == 1
         assert row["captcha_failed"] == 1
-        # cost_cap, rate_limited, etc. → "other"
+        # cost_cap, rate_limited, etc. → "other" (gate-skipped, not
+        # actually attempted at the solver).
         assert row["captcha_other"] == 1
         assert row["captcha_events"] == 3
-        # 1 solved out of 3 captcha events → 0.333
-        assert abs(row["success_rate"] - 1 / 3) < 1e-3
+        # ``captcha_attempted`` excludes gate skips; success_rate uses
+        # the attempted denominator so a fleet hitting cost cap 100x
+        # and solving 5 captchas doesn't show as "5/105 = 4.7%".
+        assert row["captcha_attempted"] == 2
+        assert abs(row["success_rate"] - 0.5) < 1e-3
 
     def test_no_host_is_dropped(self):
         agg = PlatformSuccessAggregator()
@@ -525,3 +529,64 @@ class TestWindowEvictionEndpoint:
         snap = agg.snapshot()
         # The host's only event aged out — empty rows are dropped
         assert snap["platforms"] == []
+
+
+# ── success_rate denominator excludes gate-skipped events ─────────────
+
+
+class TestSuccessRateExcludesGateSkips:
+    """Pre-fix the denominator was ``solved + failed + other``. A fleet
+    that hit cost cap 100 times and solved 5 captchas reported a 4.7%
+    success rate — operator-misleading. The honest rate uses only
+    ``solved + failed`` (the actual solver attempts)."""
+
+    def test_cost_cap_storm_does_not_drag_success_rate_to_zero(self):
+        """100 cost-cap skips + 5 successful solves → 100% (5/5),
+        not 4.7% (5/105). Operator sees the truth: every solve we
+        ATTEMPTED succeeded; we just didn't attempt many because of
+        the cap."""
+        agg = PlatformSuccessAggregator()
+        for _ in range(5):
+            agg.record_captcha("linkedin.com", "success")
+        for _ in range(100):
+            agg.record_captcha("linkedin.com", "cost_cap")
+        snap = agg.snapshot()
+        row = next(p for p in snap["platforms"] if p["host"] == "linkedin.com")
+        assert row["captcha_solved"] == 5
+        assert row["captcha_failed"] == 0
+        assert row["captcha_other"] == 100
+        assert row["captcha_attempted"] == 5
+        # captcha_events still reports the total (operator-visible
+        # volume) so a glance at the row shows "100 cost-cap skips".
+        assert row["captcha_events"] == 105
+        # Success rate excludes the skips → 5/5 = 100%.
+        assert row["success_rate"] == 1.0
+
+    def test_rate_limit_skips_excluded(self):
+        """``rate_limited`` is a gate-skip outcome same as ``cost_cap`` —
+        belongs in ``other``, not in the success-rate denominator."""
+        agg = PlatformSuccessAggregator()
+        agg.record_captcha("x.com", "success")
+        agg.record_captcha("x.com", "failed")
+        agg.record_captcha("x.com", "rate_limited")
+        agg.record_captcha("x.com", "skipped_behavioral")
+        snap = agg.snapshot()
+        row = next(p for p in snap["platforms"] if p["host"] == "x.com")
+        assert row["captcha_attempted"] == 2  # success + failed
+        assert row["captcha_other"] == 2      # rate_limited + skipped_behavioral
+        assert abs(row["success_rate"] - 0.5) < 1e-3
+
+    def test_only_gate_skips_yields_null_success_rate(self):
+        """A platform that only ever hits gate skips (every captcha
+        cost-cap'd, never reached the solver) reports
+        ``success_rate=None`` — there's nothing meaningful to compute,
+        and "0% / 0 attempts" is more honest than "0% / 0 attempts"
+        rendered as "0%"."""
+        agg = PlatformSuccessAggregator()
+        for _ in range(10):
+            agg.record_captcha("instagram.com", "cost_cap")
+        snap = agg.snapshot()
+        row = next(p for p in snap["platforms"] if p["host"] == "instagram.com")
+        assert row["captcha_attempted"] == 0
+        assert row["captcha_other"] == 10
+        assert row["success_rate"] is None


### PR DESCRIPTION
New per-platform success aggregation: dashboard panel + `GET /api/dashboard/platform-success` endpoint. Independent of the captcha PRs.

## Why

Operators today have no aggregated view of "which sites is my fleet succeeding on, and which ones flag / burn fingerprints." Existing data sources (`captcha_audit_event`, `fingerprint_burn`, the new `platform_pre_nav_delay` event from the foundation PR) flow through the EventBus but were never aggregated into an operator-facing rollup.

## What's new

**Backend** (`src/dashboard/platform_success.py` — new file):

- `PlatformSuccessAggregator` — thread-safe in-memory rolling window (24h, configurable `window_s`). O(1) per event; lazy prune on `snapshot()`. Per-host counters for navigations, captcha solved/failed/other, fingerprint burns, applied pre-nav delays.
- `canonical_host()` — mirrors `stealth._canonical_host` so the dashboard bins traffic the same way the browser-service side does.
- `_platform_label()` — short label for display (`linkedin.com` → `linkedin`, `bbc.co.uk` → `bbc`, multi-segment-TLD aware — fixed in `c6a722f`).
- `handle_event(evt)` — single EventBus listener entry point, dispatches by sub-type (`captcha_gate` / `fingerprint_event` / `platform_pre_nav_delay`).

**EventBus** (`src/dashboard/events.py`):

- New `add_listener` / `remove_listener` methods for in-process subscribers (used by the aggregator and any future module-level rollup). Listeners run synchronously inside `emit()` — the aggregator is O(1) per event so this is cheap. Exceptions are swallowed to keep the broadcast path robust.

**Browser service** (`src/browser/service.py`):

- `_apply_platform_pre_nav_delay` now emits a `platform_pre_nav_delay` metric event alongside the existing INFO log so the dashboard aggregator can roll up dwell stats.

**Frontend** (`templates/index.html` + `static/js/app.js`):

- New "Per-Platform Success" card on the Browser sub-tab. Plain table with Tailwind CSS bars for success rate. 30s polling refresh. Wired into `switchSystemTab('browser')` and the deep-link path.

## Success-rate denominator fix

The first commit computed `success_rate = solved / (solved + failed + other)`. `other` is gate-skipped events (`cost_cap`, `rate_limited`, `skipped_behavioral`) — events that never reached the solver. A fleet hitting cost cap 100 times and solving 5 captchas reported `5/105 = 4.7%` instead of 100% (`5/5`). Fixed in `c1441fd`: `success_rate = solved / (solved + failed)` with a separate `captcha_attempted` field; gate-skipped count rendered as a separate amber badge in the UI.

## Tests

- 41 tests in `tests/test_dashboard_platform_success.py` covering aggregator unit behavior (host canonicalization, captcha buckets, dwell averaging, fingerprint burn attribution, rolling window eviction, snapshot shape), label edge cases (multi-segment TLDs), success-rate denominator semantics (cost-cap storm doesn't drag rate to zero, all-skips yields null), and EventBus integration.
- 374 tests pass in the broader dashboard + events + platform-timing regression slice.
- ruff clean.

## Limitations (intentional, documented)

- **Process-local state** — mesh restart resets the panel. SQLite-backed persistence is a follow-up.
- **Per-sample fidelity** — aggregator replays counts via N record-calls per EventBus event since upstream events are already aggregated per §2.7's "aggregates only" cadence rule.

---
_Generated by [Claude Code](https://claude.ai/code/session_019BMxHfdu7SqFZf84DQoLQi)_