### PR TITLE
stealth-browser: CapSolver anti-bot task types (Akamai/Imperva/Kasada/DataDome)

### DIFF
--- a/src/browser/captcha.py
+++ b/src/browser/captcha.py
@@ -12,6 +12,7 @@ configured, the existing fallback (ask user via VNC) is preserved.
 from __future__ import annotations
 
 import asyncio
+import json
 import re
 import time
 from collections import deque
@@ -262,14 +263,122 @@ def _redact_clientkey_text(text: str) -> str:
 # ``cookies`` / ``userAgent`` / ``sensorData`` instead of the
 # CAPTCHA-style ``gRecaptchaResponse`` / ``token`` field. Surface the
 # solution as a JSON-serialised string so the caller's accounting path
-# fires (provider was paid) while making clear via the token shape that
-# it isn't a CAPTCHA-injectable token. The ``_inject_token`` path doesn't
-# match the anti-bot families and surfaces ``injection_failed``, which
-# is the honest signal until a future PR threads the cookies / userAgent
-# back into ``page.context`` directly.
+# fires (provider was paid) and :func:`_apply_antibot_solution` can
+# re-parse it on the injection path to apply the cookies via
+# :class:`playwright.async_api.BrowserContext`.
 _ANTIBOT_SOLUTION_KEYS: frozenset[str] = frozenset({
     "cookies", "userAgent", "sensorData", "headers",
 })
+
+
+async def _apply_antibot_solution(page: object, token: str) -> bool:
+    """Apply a CapSolver anti-bot solution payload to the BrowserContext.
+
+    ``token`` is the JSON string produced by :func:`_extract_solution_token`
+    on an anti-bot solve — typically ``{"cookies": [...], "userAgent":
+    "...", "sensorData": "..."}``. We:
+
+    1. Parse the JSON. Bail cleanly on malformed input (provider rotated
+       the response shape — surface as ``injection_failed`` so the
+       operator-handoff path picks up).
+    2. Apply each cookie via ``page.context.add_cookies``. Playwright's
+       cookie shape is well-documented; we forward the canonical fields
+       and use the page URL as a fallback target when the provider
+       didn't include a domain.
+    3. Reload the page so the next request carries the cleared cookies.
+       Anti-bot challenges are STATEFUL — without a reload, the current
+       page DOM still shows the challenge and the agent's next click
+       hits the pre-clear state.
+
+    Returns True iff at least one cookie was applied successfully.
+    Failure modes (malformed JSON, no cookies, ``add_cookies`` raised,
+    no ``page.context``) all return False so the caller correctly
+    records ``injection_failed``.
+    """
+    if not token:
+        return False
+    try:
+        sol = json.loads(token)
+    except (TypeError, ValueError):
+        logger.debug(
+            "anti-bot solution: malformed JSON token — provider may have "
+            "rotated the response shape; falling back to operator handoff"
+        )
+        return False
+    if not isinstance(sol, dict):
+        return False
+
+    raw_cookies = sol.get("cookies")
+    if not isinstance(raw_cookies, list) or not raw_cookies:
+        return False
+
+    # Playwright BrowserContext.add_cookies requires either ``url`` or
+    # both ``domain`` and ``path``. Most providers return ``domain`` +
+    # ``path`` already; we normalize to a small whitelist of known
+    # Playwright fields and fall back to ``url=<page url>`` when the
+    # entry has no domain.
+    page_url = ""
+    try:
+        page_url = page.url or ""
+    except Exception:
+        pass
+
+    normalized: list[dict] = []
+    for c in raw_cookies:
+        if not isinstance(c, dict):
+            continue
+        name = c.get("name")
+        value = c.get("value")
+        if not isinstance(name, str) or not name or "value" not in c:
+            continue
+        norm: dict = {"name": name, "value": str(value)}
+        # Forward Playwright's canonical cookie fields when present.
+        for k in ("domain", "path", "expires", "httpOnly", "secure", "sameSite"):
+            if k in c and c[k] is not None:
+                norm[k] = c[k]
+        # Fallback target — Playwright requires either ``url`` or
+        # (``domain``+``path``). If neither is present, point at the
+        # current page URL so the cookie still lands somewhere usable.
+        if "domain" not in norm and "url" not in norm:
+            if not page_url:
+                continue
+            norm["url"] = page_url
+        normalized.append(norm)
+
+    if not normalized:
+        return False
+
+    context = getattr(page, "context", None)
+    add_cookies = getattr(context, "add_cookies", None) if context is not None else None
+    if not callable(add_cookies):
+        logger.debug(
+            "anti-bot solution: page.context.add_cookies unavailable; "
+            "cookies cannot be applied",
+        )
+        return False
+    try:
+        await add_cookies(normalized)
+    except Exception as e:
+        logger.warning("anti-bot cookie injection failed: %s", e)
+        return False
+
+    # Reload so the cleared-challenge cookies take effect on the next
+    # request. Best-effort — some pages reject reload mid-challenge;
+    # the cookies are still applied to the context for subsequent navs
+    # the agent issues. Use ``domcontentloaded`` (not ``networkidle``)
+    # so we don't block on the cleared page's own background polling.
+    try:
+        reload = getattr(page, "reload", None)
+        if callable(reload):
+            await reload(wait_until="domcontentloaded")
+    except Exception as e:
+        logger.debug("anti-bot post-solve reload failed (non-fatal): %s", e)
+
+    logger.info(
+        "anti-bot solution applied: %d cookies via BrowserContext",
+        len(normalized),
+    )
+    return True
 
 
 def _extract_solution_token(solution: object, captcha_type: str) -> str | None:
@@ -295,12 +404,11 @@ def _extract_solution_token(solution: object, captcha_type: str) -> str | None:
         return token
     if captcha_type in _ANTIBOT_KINDS:
         # Any presence of an anti-bot solution key signals a real
-        # provider-side success. Serialise the whole dict so the agent /
-        # operator can see what was returned without us trying to
-        # inject a cookie set we don't know how to apply yet.
+        # provider-side success. Serialise the whole dict so
+        # :func:`_apply_antibot_solution` can re-parse and apply the
+        # cookies/userAgent/sensorData via the BrowserContext.
         if any(k in solution for k in _ANTIBOT_SOLUTION_KEYS):
             try:
-                import json
                 return json.dumps(solution, sort_keys=True, default=str)
             except (TypeError, ValueError):
                 # Defensive — solution payloads are JSON over the wire
@@ -2299,7 +2407,23 @@ class CaptchaSolver:
         parent textarea, returning ``injection_failed`` even though
         the provider returned a valid token. Walk every frame and
         bubble up "any frame succeeded" as the success bit.
+
+        §22 anti-bot kinds (Akamai BMP / Imperva / Kasada / DataDome) take
+        a different path: the "token" is a JSON-encoded
+        ``{cookies, userAgent?, sensorData?, headers?}`` payload from
+        :func:`_extract_solution_token`. We apply the cookies to the
+        active ``BrowserContext`` and reload the page so the cleared
+        challenge state takes effect on the next request — without this
+        the operator pays for solves that produce no usable session.
         """
+        # §22 — anti-bot kinds carry a structured solution (cookies +
+        # optional userAgent / headers) instead of a CAPTCHA-style
+        # injectable token. Apply the cookies via the BrowserContext;
+        # the ``recaptcha`` / ``hcaptcha`` / ``turnstile`` token-injection
+        # branches below would all return False for these kinds.
+        if captcha_type in _ANTIBOT_KINDS:
+            return await _apply_antibot_solution(page, token)
+
         family = captcha_type
         if captcha_type.startswith("recaptcha"):
             family = "recaptcha"

--- a/src/browser/captcha.py
+++ b/src/browser/captcha.py
@@ -126,6 +126,18 @@ _SOLVE_TIMEOUT_DEFAULTS_MS: dict[str, int] = {
     "turnstile":                 180_000,
     "cf-interstitial-turnstile": 180_000,
     # FunCaptcha / GeeTest / AWS WAF entries reserved for §11.5 deferred work
+    # Anti-bot platform task types (CapSolver-only, see ``_ANTIBOT_KINDS``).
+    # Provider-side solve takes 60-180s; we pick the high end as default
+    # because all four platforms (Akamai BMP, Imperva, Kasada, DataDome)
+    # are known-slow and a tight default would surface as a flood of
+    # ``solver_outcome="timeout"`` envelopes on legitimate solves.
+    # Operators can override per-kind via
+    # ``CAPTCHA_TIMEOUT_<KIND_UPPER_UNDERSCORE>_MS`` (see
+    # :meth:`_timeout_seconds_for_kind`).
+    "js-challenge-akamai":       180_000,
+    "js-challenge-imperva":      180_000,
+    "js-challenge-kasada":       180_000,
+    "datadome-behavioral":       180_000,
 }
 _SOLVE_TIMEOUT_FALLBACK_MS = 120_000  # for unknown / behavioral kinds
 _POLL_INTERVAL = 5    # seconds between result polls
@@ -244,6 +256,60 @@ def _redact_clientkey_text(text: str) -> str:
     return out
 
 
+# §22 — keys carrying a solution payload for CapSolver anti-bot tasks.
+# CapSolver's anti-bot product surface (AntiAkamaiBMPTask /
+# AntiImpervaTask / AntiKasadaTask / DataDomeSliderTask) returns
+# ``cookies`` / ``userAgent`` / ``sensorData`` instead of the
+# CAPTCHA-style ``gRecaptchaResponse`` / ``token`` field. Surface the
+# solution as a JSON-serialised string so the caller's accounting path
+# fires (provider was paid) while making clear via the token shape that
+# it isn't a CAPTCHA-injectable token. The ``_inject_token`` path doesn't
+# match the anti-bot families and surfaces ``injection_failed``, which
+# is the honest signal until a future PR threads the cookies / userAgent
+# back into ``page.context`` directly.
+_ANTIBOT_SOLUTION_KEYS: frozenset[str] = frozenset({
+    "cookies", "userAgent", "sensorData", "headers",
+})
+
+
+def _extract_solution_token(solution: object, captcha_type: str) -> str | None:
+    """Extract a token-shaped string from a provider ``solution`` payload.
+
+    The default behavior (CAPTCHA-family tasks) reads the standard
+    ``gRecaptchaResponse`` / ``token`` fields. For anti-bot kinds the
+    solution carries cookies / userAgent / sensorData instead; we
+    JSON-serialise the dict so the caller's "token retrieved" path fires
+    even though there is no CAPTCHA-style token. Token injection still
+    fails downstream for these kinds (no anti-bot inject path yet) but
+    the cost-accounting + breaker semantics need a non-``None`` value to
+    distinguish "provider charged us" from "provider rejected".
+    """
+    if not isinstance(solution, dict):
+        return None
+    # Standard CAPTCHA fields take precedence regardless of kind — covers
+    # tests that mock anti-bot responses with ``gRecaptchaResponse`` and
+    # the rare case where CapSolver routes an anti-bot task back through
+    # the standard path.
+    token = solution.get("gRecaptchaResponse") or solution.get("token")
+    if token:
+        return token
+    if captcha_type in _ANTIBOT_KINDS:
+        # Any presence of an anti-bot solution key signals a real
+        # provider-side success. Serialise the whole dict so the agent /
+        # operator can see what was returned without us trying to
+        # inject a cookie set we don't know how to apply yet.
+        if any(k in solution for k in _ANTIBOT_SOLUTION_KEYS):
+            try:
+                import json
+                return json.dumps(solution, sort_keys=True, default=str)
+            except (TypeError, ValueError):
+                # Defensive — solution payloads are JSON over the wire
+                # so this shouldn't happen, but fall through cleanly
+                # rather than raising to the caller.
+                return None
+    return None
+
+
 # Map from detected selector pattern to a canonical CAPTCHA type.
 _CAPTCHA_TYPE_MAP: dict[str, str] = {
     "recaptcha": "recaptcha",
@@ -347,6 +413,55 @@ _2CAPTCHA_TASK_TYPES: dict[str, dict[str, object]] = {
     },
 }
 
+# §22 — anti-bot platform task types (CapSolver only).
+#
+# 2Captcha does NOT publish equivalents for these platforms — their
+# product surface is reCAPTCHA / hCaptcha / Turnstile / FunCAPTCHA /
+# GeeTest / image, NOT platform-sensor anti-bot. Adding these kinds to
+# :data:`_2CAPTCHA_TASK_TYPES` would emit ``ERROR_INVALID_TASK_TYPE`` on
+# every solve and trip the §11.16 breaker. The dispatch in
+# :class:`CaptchaSolver.supports_kind` short-circuits anti-bot kinds when
+# the active provider is 2Captcha so the §11.13 envelope routes to
+# operator escalation (matches today's behavior for these kinds).
+#
+# CapSolver task types verified against
+# https://docs.capsolver.com/en/guide/captcha/ as of April 2026:
+#   * AntiAkamaiBMPTask        — Akamai Bot Manager
+#   * AntiImpervaTask          — Imperva Advanced Bot Protection
+#   * AntiKasadaTask           — Kasada
+#   * DataDomeSliderTask       — DataDome behavioral / slider
+#
+# Anti-bot tasks REQUIRE a proxy — CapSolver does not publish any
+# ``Proxyless`` variant for these. ``proxyless`` is intentionally ``None``
+# so :meth:`_build_task_body` returns ``(None, ...)`` (i.e. unsupported)
+# when the operator hasn't configured ``CAPTCHA_SOLVER_PROXY_*`` env
+# vars; the agent then surfaces an operator-escalation envelope rather
+# than silently routing to the always-fail proxyless path.
+#
+# Drift here is silent (``ERROR_INVALID_TASK_TYPE``); re-verify against
+# CapSolver docs when bumping variants. The anti-bot product surface
+# rotates faster than the standard CAPTCHA task types — provider docs
+# drift quarterly. The §11.16 breaker + fatal-error gate keeps the
+# fleet's solver path safe even when our table goes stale (an unknown
+# task name surfaces as a per-call error and the operator sees the
+# audit-log signal long before three failures trip the breaker for
+# kinds the agent loop should never have routed to the solver).
+#
+# Anti-bot kinds are LOW-CONFIDENCE by design: failure rates can exceed
+# 50% even with the right task type because tokens are rejected at the
+# application layer for IP / fingerprint mismatches the solver has no
+# visibility into. The dispatch in :meth:`solve` skips the breaker tick
+# on anti-bot failures (see ``_record_solver_outcome`` call sites) so a
+# burst of legitimate-but-rejected anti-bot solves doesn't lock the
+# whole fleet's solver out of the standard CAPTCHA paths for 10 minutes.
+_ANTIBOT_KINDS: frozenset[str] = frozenset({
+    "js-challenge-akamai",
+    "js-challenge-imperva",
+    "js-challenge-kasada",
+    "datadome-behavioral",
+})
+
+
 # CapSolver
 _CAPSOLVER_TASK_TYPES: dict[str, dict[str, object]] = {
     "recaptcha": {
@@ -392,6 +507,32 @@ _CAPSOLVER_TASK_TYPES: dict[str, dict[str, object]] = {
         "proxy_aware": "ReCaptchaV3EnterpriseTask",
         "extra": {},
     },
+    # §22 — anti-bot platform task types. Proxy-required (no proxyless
+    # variant published). Best-effort: CapSolver's anti-bot product
+    # surface rotates faster than the standard CAPTCHA tasks — operators
+    # who hit ``ERROR_INVALID_TASK_TYPE`` should re-verify the task name
+    # against the live docs (see the comment block on ``_ANTIBOT_KINDS``
+    # for the rationale and the breaker-skip semantics).
+    "js-challenge-akamai": {
+        "proxyless": None,
+        "proxy_aware": "AntiAkamaiBMPTask",
+        "extra": {},
+    },
+    "js-challenge-imperva": {
+        "proxyless": None,
+        "proxy_aware": "AntiImpervaTask",
+        "extra": {},
+    },
+    "js-challenge-kasada": {
+        "proxyless": None,
+        "proxy_aware": "AntiKasadaTask",
+        "extra": {},
+    },
+    "datadome-behavioral": {
+        "proxyless": None,
+        "proxy_aware": "DataDomeSliderTask",
+        "extra": {},
+    },
 }
 
 
@@ -432,6 +573,14 @@ _SOLVER_PROXY_COMPAT: dict[tuple[str, str], set[str]] = {
     ("capsolver", "recaptcha-enterprise-v3"): {"http", "https", "socks4", "socks5"},
     ("capsolver", "hcaptcha"):                {"http", "https", "socks4", "socks5"},
     ("capsolver", "turnstile"):               {"http", "https", "socks4", "socks5"},
+    # §22 — anti-bot tasks accept the same proxy-type set as the
+    # standard CapSolver tasks. CapSolver's anti-bot docs do not
+    # individually enumerate accepted proxyType values; we mirror the
+    # standard set as the safe default.
+    ("capsolver", "js-challenge-akamai"):     {"http", "https", "socks4", "socks5"},
+    ("capsolver", "js-challenge-imperva"):    {"http", "https", "socks4", "socks5"},
+    ("capsolver", "js-challenge-kasada"):     {"http", "https", "socks4", "socks5"},
+    ("capsolver", "datadome-behavioral"):     {"http", "https", "socks4", "socks5"},
 }
 
 
@@ -1233,6 +1382,33 @@ class CaptchaSolver:
         self._solver_failure_timestamps.clear()
         return False
 
+    def supports_kind(self, kind: str | None) -> bool:
+        """True iff this solver's provider has a published task type for ``kind``.
+
+        Drives the §22 routing decision in :meth:`_check_captcha`: anti-bot
+        kinds (Akamai BMP / Imperva / Kasada / DataDome) are dispatched to
+        the solver path only when the active provider declares a task
+        type for them. 2Captcha does not publish anti-bot task types
+        (their product is reCAPTCHA / hCaptcha / Turnstile / FunCAPTCHA /
+        GeeTest / image), so :data:`_2CAPTCHA_TASK_TYPES` returns
+        ``False`` for every anti-bot kind and the caller routes those
+        cleanly to operator escalation instead of contacting an unsupported
+        provider.
+
+        Returns ``False`` for ``None`` and for kinds the provider table
+        doesn't list. Lookup is case-sensitive — the §11.13 envelope
+        kinds are canonical lowercase-hyphen.
+        """
+        if not isinstance(kind, str) or not kind:
+            return False
+        prov = (self.provider or "").lower()
+        if prov == "2captcha":
+            return kind in _2CAPTCHA_TASK_TYPES
+        if prov == "capsolver":
+            return kind in _CAPSOLVER_TASK_TYPES
+        # Unknown provider — fall through to "no" rather than guessing.
+        return False
+
     async def health_check(
         self, provider: str | None = None,
     ) -> Literal["healthy", "degraded", "unreachable"]:
@@ -1502,44 +1678,67 @@ class CaptchaSolver:
                 used_proxy_aware=False, compat_rejected=False,
             )
 
-        captcha_type = _classify_captcha(selector)
-        # §11.1 — when the coarse selector classifier says "recaptcha", run
-        # the precise variant classifier so v3 / v2-invisible / Enterprise
-        # widgets get the right provider task type. Falls back to
-        # ``captcha_type`` when the classifier returns ``unknown`` (e.g. the
-        # registry isn't accessible from this frame); legacy selector-based
-        # behavior is preserved.
+        # §22 — anti-bot platform kinds (Akamai BMP, Imperva, Kasada,
+        # DataDome) take precedence over selector-based classification.
+        # The caller already classified via ``js_challenge.classify_*`` /
+        # ``_classify_behavioral`` and passed the kind; we use it
+        # directly so the §11.13 envelope kind matches what the
+        # ``_check_captcha`` audit trail recorded. These kinds DO NOT use
+        # ``websiteKey``-style sitekey markers and skipping the DOM
+        # extraction below saves a no-op ``page.evaluate`` round-trip.
+        antibot_path = kind is not None and kind in _ANTIBOT_KINDS
+
         page_action: str | None = None
         sitekey: str | None = None
-        if captcha_type == "recaptcha":
-            classified = await _classify_recaptcha(page)
-            variant = classified.get("variant") or "unknown"
-            if variant != "unknown":
-                captcha_type = variant
-            sitekey = classified.get("sitekey")
-            page_action = classified.get("action")
+        if antibot_path:
+            captcha_type = kind  # type: ignore[assignment]
+        else:
+            captcha_type = _classify_captcha(selector)
+            # §11.1 — when the coarse selector classifier says "recaptcha",
+            # run the precise variant classifier so v3 / v2-invisible /
+            # Enterprise widgets get the right provider task type. Falls
+            # back to ``captcha_type`` when the classifier returns
+            # ``unknown`` (e.g. the registry isn't accessible from this
+            # frame); legacy selector-based behavior is preserved.
+            if captcha_type == "recaptcha":
+                classified = await _classify_recaptcha(page)
+                variant = classified.get("variant") or "unknown"
+                if variant != "unknown":
+                    captcha_type = variant
+                sitekey = classified.get("sitekey")
+                page_action = classified.get("action")
         logger.info(
             "Attempting to solve %s CAPTCHA on %s",
             captcha_type,
             redact_url(page_url),
         )
 
-        if not sitekey:
-            sitekey = await self._extract_sitekey(page, captcha_type)
-        if not sitekey:
-            logger.warning("Could not extract sitekey for %s CAPTCHA", captcha_type)
-            # LOCAL failure — sitekey couldn't be extracted from the
-            # page DOM. The provider was never contacted, so the §11.16
-            # breaker MUST NOT count this. Pre-fix, three sitekey-extraction
-            # failures from a single agent (e.g. an unsupported widget
-            # variant the DOM-extractor doesn't recognize) tripped the
-            # breaker for the entire BrowserManager and blocked real
-            # solves for every other agent. The breaker tracks PROVIDER
-            # reliability — local classifier gaps belong elsewhere.
-            return SolveResult(
-                token=None, injection_succeeded=False,
-                used_proxy_aware=False, compat_rejected=False,
-            )
+        if antibot_path:
+            # Anti-bot kinds don't use a sitekey — set to empty string and
+            # skip the DOM extractor. ``_build_task_body`` omits
+            # ``websiteKey`` for these kinds (see the body-builder branch
+            # gated on ``_ANTIBOT_KINDS``).
+            sitekey = ""
+        else:
+            if not sitekey:
+                sitekey = await self._extract_sitekey(page, captcha_type)
+            if not sitekey:
+                logger.warning(
+                    "Could not extract sitekey for %s CAPTCHA", captcha_type,
+                )
+                # LOCAL failure — sitekey couldn't be extracted from the
+                # page DOM. The provider was never contacted, so the
+                # §11.16 breaker MUST NOT count this. Pre-fix, three
+                # sitekey-extraction failures from a single agent (e.g.
+                # an unsupported widget variant the DOM-extractor doesn't
+                # recognize) tripped the breaker for the entire
+                # BrowserManager and blocked real solves for every other
+                # agent. The breaker tracks PROVIDER reliability — local
+                # classifier gaps belong elsewhere.
+                return SolveResult(
+                    token=None, injection_succeeded=False,
+                    used_proxy_aware=False, compat_rejected=False,
+                )
 
         # §11.2 — load the dedicated solver-proxy config (NOT the agent's
         # primary egress proxy; see ``get_solver_proxy_config`` docstring).
@@ -1579,7 +1778,15 @@ class CaptchaSolver:
             # already been issued (the task-body builder + provider HTTP
             # call complete in well under a second; the deadline only
             # bites during the poll loop). Treat as provider-contacted.
-            await self._record_solver_outcome(success=False)
+            #
+            # §22 — anti-bot kinds skip the breaker tick. Failure rates
+            # for Akamai BMP / Imperva / Kasada / DataDome are inherently
+            # high (token-IP / fingerprint binding rejections at the
+            # application layer); a burst of legitimate-but-rejected
+            # anti-bot solves shouldn't lock the whole fleet's solver
+            # out of the standard CAPTCHA path for 10 minutes.
+            if not antibot_path:
+                await self._record_solver_outcome(success=False)
             return SolveResult(
                 token=None, injection_succeeded=False,
                 used_proxy_aware=False, compat_rejected=False,
@@ -1596,8 +1803,10 @@ class CaptchaSolver:
             # both per-provider helpers catch and convert into ``None``
             # tokens. When it does happen, conservatively treat it as
             # provider-contacted so a programmer-error flood doesn't
-            # silently mask a real provider outage.
-            await self._record_solver_outcome(success=False)
+            # silently mask a real provider outage. Anti-bot kinds still
+            # skip the tick (§22 rationale above).
+            if not antibot_path:
+                await self._record_solver_outcome(success=False)
             return SolveResult(
                 token=None, injection_succeeded=False,
                 used_proxy_aware=False, compat_rejected=False,
@@ -1616,7 +1825,14 @@ class CaptchaSolver:
             # Those need operator intervention, not breaker backoff;
             # skipping the tick keeps a misconfigured key from locking
             # the whole BrowserManager out of solver duty for 10 minutes.
-            if provider_contacted and not self._solver_unreachable:
+            #
+            # §22 — anti-bot kinds skip the tick by design (see the
+            # exception-path comment block above for the rationale).
+            if (
+                provider_contacted
+                and not self._solver_unreachable
+                and not antibot_path
+            ):
                 await self._record_solver_outcome(success=False)
             return SolveResult(
                 token=None, injection_succeeded=False,
@@ -1814,10 +2030,20 @@ class CaptchaSolver:
             proxy_aware_name = None
             static_extras = {k: v for k, v in entry.items() if k != "type"}
 
+        # §22 — anti-bot platform task types don't use ``websiteKey``
+        # (no DOM sitekey marker on Akamai BMP / Imperva / Kasada /
+        # DataDome challenges; those tasks identify the site by URL +
+        # the proxy-bound IP fingerprint). Including an empty
+        # ``websiteKey`` field would cause CapSolver to reject the task
+        # with ``ERROR_KEY_MUST_NOT_BE_EMPTY``; omit the field entirely
+        # for anti-bot kinds. ``sitekey`` is always ``""`` for these
+        # variants because :meth:`solve` skips DOM extraction and passes
+        # an empty string in.
         body: dict[str, object] = {
             "websiteURL": page_url,
-            "websiteKey": sitekey,
         }
+        if captcha_type not in _ANTIBOT_KINDS:
+            body["websiteKey"] = sitekey
         # Merge static extras (``isInvisible``, ``isEnterprise``).
         for k, v in static_extras.items():
             body[k] = v
@@ -1980,7 +2206,7 @@ class CaptchaSolver:
                 return None, used_proxy_aware, compat_rejected, True
             if data.get("status") == "ready":
                 solution = data.get("solution", {})
-                token = solution.get("gRecaptchaResponse") or solution.get("token")
+                token = _extract_solution_token(solution, captcha_type)
                 return token, used_proxy_aware, compat_rejected, True
             # status == "processing" — keep polling
         return None, used_proxy_aware, compat_rejected, True
@@ -2052,7 +2278,7 @@ class CaptchaSolver:
                 return None, used_proxy_aware, compat_rejected, True
             if data.get("status") == "ready":
                 solution = data.get("solution", {})
-                token = solution.get("gRecaptchaResponse") or solution.get("token")
+                token = _extract_solution_token(solution, captcha_type)
                 return token, used_proxy_aware, compat_rejected, True
         return None, used_proxy_aware, compat_rejected, True
 
@@ -2366,13 +2592,28 @@ class MultiProviderSolver:
 
     # ── routing ─────────────────────────────────────────────────────────
 
-    async def _pick_solver(self) -> CaptchaSolver | None:
+    async def _pick_solver(
+        self, kind: str | None = None,
+    ) -> CaptchaSolver | None:
         """Choose the solver for the next solve attempt.
 
         Returns the secondary when the primary is unreachable OR has an
         open breaker; otherwise returns the primary. Returns ``None``
         when both are unavailable — caller surfaces a no-token result
         without contacting either provider.
+
+        §22 — when ``kind`` names an anti-bot platform task type that the
+        primary doesn't support (e.g. primary is 2Captcha, kind is
+        ``js-challenge-akamai``) the wrapper PREFERS the secondary even
+        though the primary is healthy. This is the kind-aware routing
+        the BrowserManager relies on so a 2Captcha-primary deployment
+        with a CapSolver secondary still surfaces anti-bot solves
+        through the secondary instead of routing to operator escalation.
+        Without this branch, ``_pick_solver`` would always return the
+        healthy primary and the per-provider task-table lookup inside
+        ``_solve_2captcha`` would emit a no-token local-failure result.
+        For non-anti-bot kinds and for kinds the primary supports, the
+        existing primary-first routing is preserved.
 
         Side effect: updates ``self._active_solver`` so the
         :attr:`provider` property reads the right tier for cost
@@ -2381,6 +2622,30 @@ class MultiProviderSolver:
         primary_unreachable = await self.primary.is_solver_unreachable()
         primary_breaker_open = self.primary.is_breaker_open()
         primary_skip = primary_unreachable or primary_breaker_open
+
+        # §22 — kind-aware routing for anti-bot kinds. We only consult
+        # the support table when ``kind`` is provided AND the primary
+        # doesn't declare support; that keeps the existing primary-first
+        # bias for every other code path (the prior failover branch's
+        # tests assume an unconditional primary preference).
+        kind_aware_route = (
+            kind in _ANTIBOT_KINDS
+            and not self.primary.supports_kind(kind)
+            and self.secondary is not None
+            and self.secondary.supports_kind(kind)
+        )
+        if kind_aware_route:
+            secondary_unreachable = await self.secondary.is_solver_unreachable()
+            secondary_breaker_open = self.secondary.is_breaker_open()
+            if not (secondary_unreachable or secondary_breaker_open):
+                self._active_solver = self.secondary
+                return self.secondary
+            # Secondary is the only provider that supports the kind, but
+            # it's down. Surface the no-solver shape rather than letting
+            # a doomed primary call generate an ``ERROR_INVALID_TASK_TYPE``
+            # response that would tick its breaker.
+            self._active_solver = self.primary
+            return None
 
         if not primary_skip:
             self._active_solver = self.primary
@@ -2429,7 +2694,7 @@ class MultiProviderSolver:
              :class:`SolveResult` without contacting either provider,
              matching today's "no solver" envelope path.
         """
-        target = await self._pick_solver()
+        target = await self._pick_solver(kind=kind)
         if target is None:
             # Both primary and secondary are unavailable. Mirror the
             # short-circuit shape used by the underlying solver's own
@@ -2504,6 +2769,26 @@ class MultiProviderSolver:
         if self.secondary is None:
             return True
         return self.secondary.is_breaker_open()
+
+    def supports_kind(self, kind: str | None) -> bool:
+        """True iff at least one underlying solver supports ``kind``.
+
+        Mirrors :meth:`CaptchaSolver.supports_kind` but folds across both
+        primary + secondary so an operator with CapSolver as the secondary
+        can still route §22 anti-bot kinds (Akamai BMP / Imperva /
+        Kasada / DataDome) to the solver even when 2Captcha is primary.
+        Pre-solve gate semantics: when ``False`` the caller skips the
+        solver path entirely and emits the existing operator-escalation
+        envelope. Health gating (``is_solver_unreachable`` /
+        ``is_breaker_open``) is checked separately in
+        :meth:`_check_captcha`; this method only answers "does any
+        configured provider declare a task type for this kind".
+        """
+        if self.primary.supports_kind(kind):
+            return True
+        if self.secondary is not None and self.secondary.supports_kind(kind):
+            return True
+        return False
 
     async def health_check(
         self, provider: str | None = None,

--- a/src/browser/captcha.py
+++ b/src/browser/captcha.py
@@ -271,6 +271,90 @@ _ANTIBOT_SOLUTION_KEYS: frozenset[str] = frozenset({
 })
 
 
+# Playwright's ``BrowserContext.add_cookies`` accepts only this exact
+# enum for ``sameSite``. Providers and real-browser cookie exports use
+# every casing under the sun (``"Lax"``, ``"lax"``, ``"LAX"``,
+# ``"unspecified"``, ``"no_restriction"``...). Map all known shapes
+# down to the canonical case; anything unrecognized returns ``None``
+# so we drop the field rather than fail the whole add_cookies call.
+_SAMESITE_PLAYWRIGHT_MAP: dict[str, str] = {
+    "strict": "Strict",
+    "lax": "Lax",
+    "none": "None",
+    "no_restriction": "None",
+    "norestriction": "None",
+}
+
+
+def _normalize_cookie_same_site(value: object) -> str | None:
+    """Coerce a provider-supplied ``sameSite`` value to Playwright's enum.
+
+    Returns ``None`` for unset / unrecognized values so the caller drops
+    the field — Playwright treats absence as "Lax" by default, which
+    matches the common case for anti-bot session cookies.
+    """
+    if value is None:
+        return None
+    if not isinstance(value, str):
+        return None
+    return _SAMESITE_PLAYWRIGHT_MAP.get(value.strip().lower())
+
+
+def _normalize_cookie_expires(value: object) -> float | None:
+    """Coerce a provider-supplied ``expires`` value to seconds-since-epoch.
+
+    Accepts:
+      * Numeric seconds-since-epoch (``1735689600``).
+      * Numeric milliseconds-since-epoch (``1735689600000``) — divided by
+        1000 when the value is implausibly large for seconds.
+      * ``-1`` — Playwright's "session cookie" sentinel; preserved.
+      * ISO-8601 strings (``"2025-12-31T23:59:59Z"``) — parsed via
+        :meth:`datetime.fromisoformat`. Some providers emit a trailing
+        ``Z`` that ``fromisoformat`` rejects on Python < 3.11; rewrite
+        to ``+00:00`` before parsing.
+
+    Returns ``None`` for anything unparseable so the caller drops the
+    field rather than fail the whole add_cookies call.
+    """
+    if value is None:
+        return None
+    # Sentinel pass-through.
+    if value == -1 or value == -1.0:
+        return -1.0
+    if isinstance(value, bool):
+        # ``isinstance(True, int)`` is True in Python, so guard explicitly.
+        return None
+    if isinstance(value, (int, float)):
+        as_float = float(value)
+        # Heuristic: anything past year 9999 in seconds (≥ 2.5e11) is
+        # almost certainly milliseconds. Year-2200 in seconds is ~7.3e9.
+        # Threshold of 1e12 (year 33658 in seconds) is safely past any
+        # plausible "real seconds" value while comfortably under the
+        # millis-for-real-dates range (2024 in millis ≈ 1.7e12).
+        if as_float > 1e12:
+            as_float /= 1000.0
+        return as_float
+    if isinstance(value, str):
+        s = value.strip()
+        if not s:
+            return None
+        # Numeric string ⇒ recurse via float coercion.
+        try:
+            return _normalize_cookie_expires(float(s))
+        except ValueError:
+            pass
+        # ISO-8601. Python ≤ 3.10 doesn't accept trailing 'Z' in
+        # ``fromisoformat`` so rewrite it; ≥ 3.11 handles both.
+        from datetime import datetime
+        try:
+            iso = s[:-1] + "+00:00" if s.endswith("Z") else s
+            dt = datetime.fromisoformat(iso)
+            return dt.timestamp()
+        except ValueError:
+            return None
+    return None
+
+
 async def _apply_antibot_solution(page: object, token: str) -> bool:
     """Apply a CapSolver anti-bot solution payload to the BrowserContext.
 
@@ -316,7 +400,13 @@ async def _apply_antibot_solution(page: object, token: str) -> bool:
     # both ``domain`` and ``path``. Most providers return ``domain`` +
     # ``path`` already; we normalize to a small whitelist of known
     # Playwright fields and fall back to ``url=<page url>`` when the
-    # entry has no domain.
+    # entry has no domain. Field-shape normalization handles common
+    # provider drift:
+    #   * ``sameSite`` — Playwright requires the exact-case enum
+    #     {"Strict", "Lax", "None"}; providers commonly return
+    #     ``"strict"``/``"lax"``/``"unspecified"`` or omit it.
+    #   * ``expires`` — Playwright wants seconds-since-epoch as a
+    #     number; some providers return ISO-8601 strings or millis.
     page_url = ""
     try:
         page_url = page.url or ""
@@ -333,9 +423,23 @@ async def _apply_antibot_solution(page: object, token: str) -> bool:
             continue
         norm: dict = {"name": name, "value": str(value)}
         # Forward Playwright's canonical cookie fields when present.
-        for k in ("domain", "path", "expires", "httpOnly", "secure", "sameSite"):
+        for k in ("domain", "path", "httpOnly", "secure"):
             if k in c and c[k] is not None:
                 norm[k] = c[k]
+        # ``sameSite`` — coerce to Playwright's exact-case enum. An
+        # unrecognized / unspecified value is dropped (Playwright treats
+        # absence as "Lax" by default, which is the common-case shape
+        # for the cookies anti-bot solvers return).
+        ss = _normalize_cookie_same_site(c.get("sameSite"))
+        if ss is not None:
+            norm["sameSite"] = ss
+        # ``expires`` — coerce numeric / ISO-8601 / millis-since-epoch
+        # to seconds-since-epoch (float). Drop unparseable values
+        # rather than failing the whole cookie. ``-1`` is the
+        # session-cookie sentinel; preserve it verbatim.
+        exp = _normalize_cookie_expires(c.get("expires"))
+        if exp is not None:
+            norm["expires"] = exp
         # Fallback target — Playwright requires either ``url`` or
         # (``domain``+``path``). If neither is present, point at the
         # current page URL so the cookie still lands somewhere usable.
@@ -1968,7 +2072,17 @@ class CaptchaSolver:
         # Breaker tracks SOLVER reliability (provider returned a token), not
         # injection success. Provider was paid the moment the token came
         # back; injection failure is our problem, not theirs.
-        await self._record_solver_outcome(success=True)
+        #
+        # §22 — anti-bot kinds are NEUTRAL to the breaker: the failure
+        # paths above already skip the tick (anti-bot solves have
+        # inherently high failure rates that shouldn't trip a fleet-
+        # wide breaker), and the success path skips it too for
+        # symmetry. Without this skip, anti-bot successes silently
+        # CLEAR a breaker that real standard-path failures had ticked,
+        # masking genuine provider outages on the kinds the breaker
+        # is actually meant to guard.
+        if not antibot_path:
+            await self._record_solver_outcome(success=True)
         return SolveResult(
             token=token,
             injection_succeeded=bool(injected),

--- a/src/browser/captcha_cost_counter.py
+++ b/src/browser/captcha_cost_counter.py
@@ -136,6 +136,23 @@ PRICING_MILLICENTS: dict[str, int] = {
     "capsolver-hcaptcha": 100,
     "capsolver-turnstile": 60,
     "capsolver-cf-interstitial-turnstile": 60,
+    # §22 — anti-bot platform task types (CapSolver only).
+    # Published as "approximately $3 / 1000 solves" on
+    # https://docs.capsolver.com/en/guide/captcha/ for the AntiBot
+    # family; we encode 300 millicents = $0.003/solve. CapSolver's
+    # actual rate fluctuates ($2.50–$5/1000) so this is the midpoint
+    # high-end. Entries are proxyless-keyed for parity with the rest
+    # of the table; the proxy-aware tier inherits the same value via
+    # :data:`PRICING_MILLICENTS_PROXY_AWARE` below (anti-bot tasks
+    # have no proxyless variant — every solve is proxy-aware). The
+    # entry on the proxyless table is what
+    # ``_max_published_solve_cost_millicents`` reads to compute the
+    # cost-cap reservation BEFORE the solver call (when the actual
+    # tier isn't yet known).
+    "capsolver-js-challenge-akamai": 300,
+    "capsolver-js-challenge-imperva": 300,
+    "capsolver-js-challenge-kasada": 300,
+    "capsolver-datadome-behavioral": 300,
 }
 
 # §11.2 — proxy-aware pricing tier (~3× the proxyless rate as published
@@ -167,6 +184,17 @@ PRICING_MILLICENTS_PROXY_AWARE: dict[tuple[str, str], int] = {
     ("capsolver", "hcaptcha"):                300,
     ("capsolver", "turnstile"):               180,
     ("capsolver", "cf-interstitial-turnstile"): 180,
+    # §22 — anti-bot platform task types are proxy-aware ONLY (no
+    # proxyless variant published). Pricing matches the proxyless table
+    # — CapSolver doesn't differentiate proxy vs non-proxy tiers for
+    # the AntiBot family because the proxy is required by the task type
+    # itself (the operator's bring-your-own proxy, not CapSolver's
+    # pool). 300 millicents = $0.003/solve; see comment block on the
+    # proxyless table for the source.
+    ("capsolver", "js-challenge-akamai"):     300,
+    ("capsolver", "js-challenge-imperva"):    300,
+    ("capsolver", "js-challenge-kasada"):     300,
+    ("capsolver", "datadome-behavioral"):     300,
 }
 
 # Back-compat aliases — third-party subclasses or future callers that

--- a/src/browser/service.py
+++ b/src/browser/service.py
@@ -26,6 +26,7 @@ from urllib.parse import urlparse
 
 from src.browser import captcha_policy
 from src.browser.captcha import (
+    _ANTIBOT_KINDS,
     SolveResult,
     _classify_behavioral,
     _classify_cf_state,
@@ -238,6 +239,32 @@ def _sanitize_download_filename(suggested: str) -> str:
     if len(name) < 2:
         name = name + "_"
     return name
+
+
+# ── §22 anti-bot solver opt-in helper ─────────────────────────────────────
+def _solver_supports_kind(solver: object, kind: str) -> bool:
+    """Return ``True`` iff ``solver.supports_kind(kind)`` is genuinely True.
+
+    Three-state defensive read: the bundled ``CaptchaSolver`` and the
+    ``MultiProviderSolver`` wrapper both expose
+    :meth:`supports_kind`; legacy / mocked solvers may not. We require
+    a strict ``is True`` comparison rather than truthiness so that
+    ``MagicMock`` auto-attribute children (which test suites attach to
+    ``BrowserManager._captcha_solver``) don't accidentally enable the
+    anti-bot solver path. Tests opt-in by configuring
+    ``solver.supports_kind = MagicMock(return_value=True)``.
+
+    Returns ``False`` on any exception so a buggy third-party subclass
+    can't crash the upstream :meth:`_check_captcha` flow.
+    """
+    method = getattr(solver, "supports_kind", None)
+    if not callable(method):
+        return False
+    try:
+        return method(kind) is True
+    except Exception:
+        logger.debug("supports_kind raised", exc_info=True)
+        return False
 
 
 # ── §11.14 per-agent solve rate limiter ───────────────────────────────────
@@ -7945,74 +7972,149 @@ class BrowserManager:
                                 "coarse kind=%s", kind, exc_info=True,
                             )
 
+                    # §22 — anti-bot kind solver path. When the active
+                    # solver provider declares a task type for the
+                    # detected anti-bot kind (CapSolver publishes
+                    # AntiAkamaiBMPTask / AntiImpervaTask / AntiKasadaTask /
+                    # DataDomeSliderTask; 2Captcha publishes none) we
+                    # OPT-IN to the solver path with forced low
+                    # confidence. Otherwise we keep the legacy
+                    # operator-escalation path. The two-step gate
+                    # (``supports_kind`` + low-confidence forcing) is
+                    # what keeps a 2Captcha-only deployment from spilling
+                    # ``ERROR_INVALID_TASK_TYPE`` errors that would trip
+                    # the §11.16 breaker.
+                    antibot_force_low_confidence = False
+
                     # §19 — tier-1 anti-bot JS-challenge classifier runs
                     # BEFORE the §11.3 behavioral classifier. JS challenges
                     # (Akamai Bot Manager, Kasada, FingerprintJS Pro,
                     # Imperva ABP, F5 Bot Defense) typically nest ABOVE
                     # CAPTCHA in the typical site stack — they fire first
                     # and gate access entirely, so detecting them takes
-                    # precedence over the §11.3 behavioral pass. None are
-                    # API-solvable (vendor design, no third-party solver);
-                    # the only correct response is to escalate via
-                    # ``request_captcha_help`` so the operator can
-                    # intervene through the VNC handoff (§19.1).
+                    # precedence over the §11.3 behavioral pass.
+                    #
+                    # §22 — kinds with a CapSolver task type (Akamai,
+                    # Imperva, Kasada) fall through to the solver path
+                    # IFF the active solver supports them. FingerprintJS
+                    # and F5 have no CapSolver task type and remain
+                    # operator-escalation-only.
                     js_vendor = await classify_js_challenge(inst.page)
                     if js_vendor:
                         js_kind = f"js-challenge-{js_vendor}"
-                        logger.info(
-                            "JS-challenge detected (%s); skipping solver, "
-                            "escalating to request_captcha_help",
-                            js_kind,
-                        )
                         try:
                             page_url = inst.page.url or ""
                         except Exception:
                             page_url = ""
-                        await _record_captcha_audit_event(
-                            inst.agent_id, "skipped_behavioral",
-                            js_kind, page_url,
-                        )
-                        return _captcha_envelope(
-                            kind=js_kind,
-                            solver_attempted=False,
-                            solver_outcome="skipped_behavioral",
-                            solver_confidence="behavioral-only",
-                            next_action="request_captcha_help",
-                        )
+                        # Anti-bot solver opt-in. Three-step gate:
+                        #   1. Kind must be in :data:`_ANTIBOT_KINDS`
+                        #      (excludes ``js-challenge-fingerprintjs``
+                        #      and ``js-challenge-f5`` — no published
+                        #      CapSolver task type).
+                        #   2. Solver must be configured.
+                        #   3. Active solver must declare a task type
+                        #      for the kind via ``supports_kind`` —
+                        #      keeps 2Captcha from spilling
+                        #      ``ERROR_INVALID_TASK_TYPE``.
+                        if (
+                            js_kind in _ANTIBOT_KINDS
+                            and self._captcha_solver is not None
+                            and _solver_supports_kind(
+                                self._captcha_solver, js_kind,
+                            )
+                        ):
+                            logger.info(
+                                "JS-challenge detected (%s); active solver "
+                                "supports the kind, attempting solver path "
+                                "with forced low confidence",
+                                js_kind,
+                            )
+                            kind = js_kind
+                            antibot_force_low_confidence = True
+                            # Fall through to the standard solver path
+                            # (cf_force_low_confidence is set below).
+                        else:
+                            logger.info(
+                                "JS-challenge detected (%s); skipping solver, "
+                                "escalating to request_captcha_help",
+                                js_kind,
+                            )
+                            await _record_captcha_audit_event(
+                                inst.agent_id, "skipped_behavioral",
+                                js_kind, page_url,
+                            )
+                            return _captcha_envelope(
+                                kind=js_kind,
+                                solver_attempted=False,
+                                solver_outcome="skipped_behavioral",
+                                solver_confidence="behavioral-only",
+                                next_action="request_captcha_help",
+                            )
 
                     # §11.3 — behavioral-only classifier runs BEFORE the
                     # solver health/breaker gates so behavioral-only flows
                     # (PerimeterX Press & Hold, DataDome blocker) don't
-                    # consume health-check or breaker quota. The solver
-                    # genuinely cannot help with these challenges; the
-                    # only correct response is to escalate via
-                    # ``request_captcha_help`` (§11.14).
-                    behavioral_kind = await _classify_behavioral(inst.page)
-                    if behavioral_kind:
-                        logger.info(
-                            "Behavioral-only challenge detected (%s); "
-                            "skipping solver, escalating to request_captcha_help",
-                            behavioral_kind,
-                        )
-                        # Audit-log so operators see the activity in the
-                        # dashboard (per §2.7 cadence — aggregated, not
-                        # per-call). URL flows through ``redact_url``
-                        # inside the recorder.
-                        try:
-                            page_url = inst.page.url or ""
-                        except Exception:
-                            page_url = ""
-                        await _record_captcha_audit_event(
-                            inst.agent_id, "skipped_behavioral",
-                            behavioral_kind, page_url,
-                        )
-                        return _captcha_envelope(
-                            kind=behavioral_kind,
-                            solver_attempted=False,
-                            solver_outcome="skipped_behavioral",
-                            solver_confidence="behavioral-only",
-                            next_action="request_captcha_help",
-                        )
+                    # consume health-check or breaker quota. PerimeterX
+                    # remains operator-escalation-only — no published
+                    # CapSolver task type as of April 2026.
+                    #
+                    # §22 — DataDome behavioral routes through the solver
+                    # path IFF the active solver supports
+                    # ``datadome-behavioral`` (CapSolver does;
+                    # ``DataDomeSliderTask``).
+                    if not antibot_force_low_confidence:
+                        behavioral_kind = await _classify_behavioral(inst.page)
+                        if behavioral_kind:
+                            try:
+                                page_url = inst.page.url or ""
+                            except Exception:
+                                page_url = ""
+                            # Same three-step opt-in gate as the JS-challenge
+                            # branch. ``px-press-hold`` is excluded by the
+                            # ``_ANTIBOT_KINDS`` check (no published CapSolver
+                            # task type) and stays on the operator-escalation
+                            # path; ``datadome-behavioral`` opts in when
+                            # CapSolver is the active provider.
+                            if (
+                                behavioral_kind in _ANTIBOT_KINDS
+                                and self._captcha_solver is not None
+                                and _solver_supports_kind(
+                                    self._captcha_solver, behavioral_kind,
+                                )
+                            ):
+                                logger.info(
+                                    "Behavioral-only challenge detected (%s); "
+                                    "active solver supports the kind, "
+                                    "attempting solver path with forced "
+                                    "low confidence",
+                                    behavioral_kind,
+                                )
+                                kind = behavioral_kind
+                                antibot_force_low_confidence = True
+                                # Fall through to standard solver path.
+                            else:
+                                logger.info(
+                                    "Behavioral-only challenge detected (%s); "
+                                    "skipping solver, escalating to "
+                                    "request_captcha_help",
+                                    behavioral_kind,
+                                )
+                                # Audit-log so operators see the activity
+                                # in the dashboard (per §2.7 cadence —
+                                # aggregated, not per-call). URL flows
+                                # through ``redact_url`` inside the
+                                # recorder.
+                                await _record_captcha_audit_event(
+                                    inst.agent_id, "skipped_behavioral",
+                                    behavioral_kind, page_url,
+                                )
+                                return _captcha_envelope(
+                                    kind=behavioral_kind,
+                                    solver_attempted=False,
+                                    solver_outcome="skipped_behavioral",
+                                    solver_confidence="behavioral-only",
+                                    next_action="request_captcha_help",
+                                )
 
                     # §11.3 — Cloudflare interstitial tri-state classifier.
                     # ``auto`` waits once and re-checks; ``behavioral``
@@ -8201,6 +8303,22 @@ class BrowserManager:
                         # lock).
                         if cf_force_low_confidence:
                             envelope["solver_confidence"] = "low"
+                        # §22 — anti-bot kinds (Akamai BMP / Imperva /
+                        # Kasada / DataDome behavioral) are inherently
+                        # low-confidence: the solver token can be
+                        # rejected at the application layer for IP /
+                        # fingerprint mismatches the solver has no
+                        # visibility into. Force ``low`` confidence and,
+                        # on a non-``solved`` outcome, upgrade
+                        # ``next_action`` to ``request_captcha_help`` so
+                        # the agent doesn't retry — anti-bot challenges
+                        # have low success rates by design and retries
+                        # rarely improve the result.
+                        if antibot_force_low_confidence:
+                            envelope["solver_confidence"] = "low"
+                            outcome = envelope.get("solver_outcome")
+                            if outcome and outcome != "solved":
+                                envelope["next_action"] = "request_captcha_help"
                         if low_success:
                             envelope["solver_confidence"] = "low"
                             outcome = envelope.get("solver_outcome")

--- a/tests/test_antibot_task_types.py
+++ b/tests/test_antibot_task_types.py
@@ -34,6 +34,7 @@ from src.browser.captcha import (
     _SOLVE_TIMEOUT_DEFAULTS_MS,
     CaptchaSolver,
     MultiProviderSolver,
+    _apply_antibot_solution,
     _extract_solution_token,
 )
 from src.browser.captcha_cost_counter import (
@@ -452,3 +453,181 @@ class TestPricing:
         for kind in _ANTIBOT_KINDS:
             assert f"2captcha-{kind}" not in PRICING_MILLICENTS
             assert ("2captcha", kind) not in PRICING_MILLICENTS_PROXY_AWARE
+
+
+# ── 10: _apply_antibot_solution — cookies → BrowserContext ────────────
+
+
+class TestApplyAntibotSolution:
+    """Wires the JSON-encoded anti-bot token into a real
+    :class:`playwright.async_api.BrowserContext`. Pre-fix the token was
+    extracted but never applied, so every anti-bot solve cost money and
+    produced ``injection_failed``."""
+
+    def _make_page_with_context(self):
+        """Build a page mock with a working ``page.context.add_cookies``
+        and ``page.reload``. Returns ``(page, calls)`` where ``calls``
+        is a list capturing the args of each add_cookies invocation."""
+        page = MagicMock()
+        page.url = "https://protected.site/landing"
+        ctx = MagicMock()
+        calls: list[list[dict]] = []
+
+        async def _add_cookies(cookies):
+            # Playwright takes a list-of-dicts; capture for assertion.
+            calls.append(list(cookies))
+        ctx.add_cookies = _add_cookies
+
+        async def _reload(**kw):
+            return None
+        page.reload = _reload
+
+        page.context = ctx
+        return page, calls
+
+    @pytest.mark.asyncio
+    async def test_applies_canonical_cookie_shape(self):
+        page, calls = self._make_page_with_context()
+        token = json.dumps({
+            "cookies": [
+                {"name": "_abck", "value": "abc123", "domain": ".target.com",
+                 "path": "/", "secure": True, "httpOnly": True},
+                {"name": "bm_sz", "value": "xyz", "domain": ".target.com",
+                 "path": "/"},
+            ],
+        })
+        ok = await _apply_antibot_solution(page, token)
+        assert ok is True
+        assert len(calls) == 1
+        applied = calls[0]
+        assert len(applied) == 2
+        # Canonical fields forwarded.
+        assert applied[0]["name"] == "_abck"
+        assert applied[0]["value"] == "abc123"
+        assert applied[0]["domain"] == ".target.com"
+        assert applied[0]["secure"] is True
+
+    @pytest.mark.asyncio
+    async def test_uses_page_url_when_cookie_lacks_domain(self):
+        page, calls = self._make_page_with_context()
+        token = json.dumps({
+            "cookies": [
+                {"name": "session", "value": "v"},  # no domain/url
+            ],
+        })
+        ok = await _apply_antibot_solution(page, token)
+        assert ok is True
+        assert calls[0][0]["url"] == "https://protected.site/landing"
+
+    @pytest.mark.asyncio
+    async def test_skips_cookie_with_no_name(self):
+        page, calls = self._make_page_with_context()
+        token = json.dumps({
+            "cookies": [
+                {"value": "orphan"},  # no name → skipped
+                {"name": "good", "value": "v", "domain": ".x.com"},
+            ],
+        })
+        ok = await _apply_antibot_solution(page, token)
+        assert ok is True
+        # Only the well-formed cookie was applied.
+        assert len(calls[0]) == 1
+        assert calls[0][0]["name"] == "good"
+
+    @pytest.mark.asyncio
+    async def test_reload_called_after_apply(self):
+        page, calls = self._make_page_with_context()
+        reload_calls: list = []
+
+        async def _reload(**kw):
+            reload_calls.append(kw)
+        page.reload = _reload
+
+        token = json.dumps({
+            "cookies": [{"name": "x", "value": "v", "domain": ".x.com"}],
+        })
+        ok = await _apply_antibot_solution(page, token)
+        assert ok is True
+        assert len(reload_calls) == 1
+        # Use domcontentloaded so we don't block on the cleared page's
+        # background polling.
+        assert reload_calls[0].get("wait_until") == "domcontentloaded"
+
+    @pytest.mark.asyncio
+    async def test_malformed_json_returns_false(self):
+        page, _ = self._make_page_with_context()
+        ok = await _apply_antibot_solution(page, "{ not valid json")
+        assert ok is False
+
+    @pytest.mark.asyncio
+    async def test_empty_token_returns_false(self):
+        page, _ = self._make_page_with_context()
+        ok = await _apply_antibot_solution(page, "")
+        assert ok is False
+
+    @pytest.mark.asyncio
+    async def test_no_cookies_returns_false(self):
+        page, _ = self._make_page_with_context()
+        token = json.dumps({"userAgent": "Mozilla/5.0", "sensorData": "..."})
+        ok = await _apply_antibot_solution(page, token)
+        assert ok is False
+
+    @pytest.mark.asyncio
+    async def test_add_cookies_failure_returns_false(self):
+        page = MagicMock()
+        page.url = "https://x.com/"
+        ctx = MagicMock()
+
+        async def _failing_add(cookies):
+            raise RuntimeError("playwright rejected cookie shape")
+        ctx.add_cookies = _failing_add
+        page.context = ctx
+        page.reload = AsyncMock()
+
+        token = json.dumps({
+            "cookies": [{"name": "x", "value": "v", "domain": ".x.com"}],
+        })
+        ok = await _apply_antibot_solution(page, token)
+        assert ok is False
+        # Reload must NOT fire when the cookie apply failed — there's
+        # nothing for it to apply on the next request.
+        page.reload.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_no_context_returns_false(self):
+        page = MagicMock()
+        page.url = "https://x.com/"
+        page.context = None  # legacy / mock without context
+        page.reload = AsyncMock()
+
+        token = json.dumps({
+            "cookies": [{"name": "x", "value": "v", "domain": ".x.com"}],
+        })
+        ok = await _apply_antibot_solution(page, token)
+        assert ok is False
+
+    @pytest.mark.asyncio
+    async def test_inject_token_routes_antibot_kind_through_apply(self):
+        """End-to-end: ``CaptchaSolver._inject_token`` routes anti-bot
+        kinds through ``_apply_antibot_solution`` rather than the
+        recaptcha/hcaptcha/turnstile branches."""
+        solver = CaptchaSolver("capsolver", "fake-key")
+        page = MagicMock()
+        page.url = "https://protected.site/"
+        ctx = MagicMock()
+        ctx.add_cookies = AsyncMock()
+        page.context = ctx
+        page.reload = AsyncMock()
+        # Stop ``_eval_in_all_frames`` from being called — the anti-bot
+        # branch should short-circuit before any frame evaluation.
+        page.evaluate = AsyncMock(side_effect=AssertionError(
+            "anti-bot path must NOT call page.evaluate",
+        ))
+
+        token = json.dumps({
+            "cookies": [{"name": "_abck", "value": "v", "domain": ".x.com"}],
+        })
+        ok = await solver._inject_token(page, "js-challenge-akamai", token)
+        assert ok is True
+        ctx.add_cookies.assert_awaited_once()
+        page.reload.assert_awaited_once()

--- a/tests/test_antibot_task_types.py
+++ b/tests/test_antibot_task_types.py
@@ -1,0 +1,454 @@
+"""§22 — anti-bot platform task types (CapSolver-only).
+
+Covers:
+* Per-provider task-type table membership: ``_CAPSOLVER_TASK_TYPES``
+  carries the four anti-bot kinds; ``_2CAPTCHA_TASK_TYPES`` does NOT.
+* Per-type timeout defaults (180s for anti-bot kinds).
+* ``CaptchaSolver.supports_kind`` semantics.
+* ``MultiProviderSolver.supports_kind`` folds across both providers.
+* ``MultiProviderSolver._pick_solver`` kind-aware routing: prefers the
+  secondary when primary doesn't support an anti-bot kind.
+* ``solve()`` for an anti-bot kind:
+  - skips DOM sitekey extraction
+  - body builder omits ``websiteKey``
+  - failures DON'T tick the §11.16 breaker (anti-bot is low-confidence
+    by design)
+* ``_extract_solution_token`` accepts the anti-bot solution shape
+  (cookies / userAgent / sensorData) and returns a JSON-encoded string.
+* Cost-counter pricing for anti-bot kinds is registered (proxyless +
+  proxy-aware tables).
+"""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import httpx
+import pytest
+
+from src.browser.captcha import (
+    _2CAPTCHA_TASK_TYPES,
+    _ANTIBOT_KINDS,
+    _CAPSOLVER_TASK_TYPES,
+    _SOLVE_TIMEOUT_DEFAULTS_MS,
+    CaptchaSolver,
+    MultiProviderSolver,
+    _extract_solution_token,
+)
+from src.browser.captcha_cost_counter import (
+    PRICING_MILLICENTS,
+    PRICING_MILLICENTS_PROXY_AWARE,
+)
+
+# ── 1: per-provider table membership ──────────────────────────────────
+
+
+class TestTaskTypeTables:
+    def test_capsolver_has_all_antibot_kinds(self):
+        for kind in _ANTIBOT_KINDS:
+            assert kind in _CAPSOLVER_TASK_TYPES, (
+                f"{kind} missing from _CAPSOLVER_TASK_TYPES"
+            )
+
+    def test_2captcha_has_none_of_the_antibot_kinds(self):
+        """Regression guard: copy-pasting these into _2CAPTCHA_TASK_TYPES
+        would produce ERROR_INVALID_TASK_TYPE on every solve and trip
+        the §11.16 breaker for the whole BrowserManager."""
+        for kind in _ANTIBOT_KINDS:
+            assert kind not in _2CAPTCHA_TASK_TYPES, (
+                f"{kind} must NOT be in _2CAPTCHA_TASK_TYPES — "
+                f"2Captcha has no equivalent task type"
+            )
+
+    def test_antibot_kinds_have_no_proxyless_variant(self):
+        """CapSolver does not publish proxyless variants for the
+        anti-bot family; ``proxyless: None`` is what the body builder
+        keys on to require operator-configured solver-proxy creds."""
+        for kind in _ANTIBOT_KINDS:
+            entry = _CAPSOLVER_TASK_TYPES[kind]
+            assert entry["proxyless"] is None, (
+                f"{kind} proxyless should be None"
+            )
+            assert isinstance(entry["proxy_aware"], str), (
+                f"{kind} proxy_aware must be a task-type string"
+            )
+
+    def test_antibot_canonical_task_names(self):
+        """Snapshot the names we send over the wire so a future drift
+        in the table is surfaced explicitly (the actual provider may
+        rename — re-verify against CapSolver docs when tests fail)."""
+        expected = {
+            "js-challenge-akamai":   "AntiAkamaiBMPTask",
+            "js-challenge-imperva":  "AntiImpervaTask",
+            "js-challenge-kasada":   "AntiKasadaTask",
+            "datadome-behavioral":   "DataDomeSliderTask",
+        }
+        for kind, task_name in expected.items():
+            assert _CAPSOLVER_TASK_TYPES[kind]["proxy_aware"] == task_name
+
+
+# ── 2: per-type timeouts ──────────────────────────────────────────────
+
+
+class TestPerTypeTimeouts:
+    def test_each_antibot_kind_has_180s_default(self):
+        for kind in _ANTIBOT_KINDS:
+            assert _SOLVE_TIMEOUT_DEFAULTS_MS[kind] == 180_000, (
+                f"{kind} should default to 180s — anti-bot solves are "
+                f"known-slow, a tighter default surfaces as a flood "
+                f"of timeout envelopes on legitimate solves"
+            )
+
+
+# ── 3: supports_kind semantics ────────────────────────────────────────
+
+
+class TestSupportsKind:
+    def test_capsolver_supports_antibot_kinds(self):
+        s = CaptchaSolver("capsolver", "fake-key")
+        for kind in _ANTIBOT_KINDS:
+            assert s.supports_kind(kind) is True
+
+    def test_2captcha_does_not_support_antibot_kinds(self):
+        s = CaptchaSolver("2captcha", "fake-key")
+        for kind in _ANTIBOT_KINDS:
+            assert s.supports_kind(kind) is False
+
+    def test_unknown_provider_returns_false(self):
+        s = CaptchaSolver("nopecha", "fake-key")  # not in supported list
+        assert s.supports_kind("js-challenge-akamai") is False
+        assert s.supports_kind("recaptcha") is False
+
+    def test_none_kind_returns_false(self):
+        s = CaptchaSolver("capsolver", "fake-key")
+        assert s.supports_kind(None) is False
+        assert s.supports_kind("") is False
+
+    def test_standard_kinds_still_supported_on_both(self):
+        cap = CaptchaSolver("capsolver", "fake-key")
+        two = CaptchaSolver("2captcha", "fake-key")
+        for kind in ("recaptcha", "hcaptcha", "turnstile"):
+            assert cap.supports_kind(kind) is True
+            assert two.supports_kind(kind) is True
+
+
+# ── 4: MultiProviderSolver fold ───────────────────────────────────────
+
+
+class TestMultiProviderSupportsKind:
+    def test_only_secondary_supports(self):
+        primary = CaptchaSolver("2captcha", "k1")
+        secondary = CaptchaSolver("capsolver", "k2")
+        wrapper = MultiProviderSolver(primary, secondary)
+        for kind in _ANTIBOT_KINDS:
+            assert wrapper.supports_kind(kind) is True
+
+    def test_only_primary_supports(self):
+        primary = CaptchaSolver("capsolver", "k1")
+        secondary = CaptchaSolver("2captcha", "k2")
+        wrapper = MultiProviderSolver(primary, secondary)
+        for kind in _ANTIBOT_KINDS:
+            assert wrapper.supports_kind(kind) is True
+
+    def test_neither_supports(self):
+        primary = CaptchaSolver("2captcha", "k1")
+        secondary = CaptchaSolver("2captcha", "k2")
+        wrapper = MultiProviderSolver(primary, secondary)
+        for kind in _ANTIBOT_KINDS:
+            assert wrapper.supports_kind(kind) is False
+
+    def test_no_secondary(self):
+        primary = CaptchaSolver("2captcha", "k1")
+        wrapper = MultiProviderSolver(primary, None)
+        # 2Captcha doesn't support anti-bot.
+        assert wrapper.supports_kind("js-challenge-akamai") is False
+        # Standard kinds still supported.
+        assert wrapper.supports_kind("recaptcha") is True
+
+
+# ── 5: kind-aware routing in _pick_solver ─────────────────────────────
+
+
+class TestKindAwareRouting:
+    """When primary is healthy but doesn't support the kind AND the
+    secondary does support it, the wrapper must prefer the secondary —
+    overrides the existing primary-first preference."""
+
+    @pytest.mark.asyncio
+    async def test_routes_to_secondary_for_antibot_when_primary_lacks_support(self):
+        primary = CaptchaSolver("2captcha", "k1")
+        primary._solver_health_checked = True  # skip probe
+        secondary = CaptchaSolver("capsolver", "k2")
+        secondary._solver_health_checked = True
+
+        wrapper = MultiProviderSolver(primary, secondary)
+        chosen = await wrapper._pick_solver(kind="js-challenge-akamai")
+        assert chosen is secondary
+        assert wrapper.provider == "capsolver"
+
+    @pytest.mark.asyncio
+    async def test_routes_to_primary_for_standard_kind(self):
+        primary = CaptchaSolver("capsolver", "k1")
+        primary._solver_health_checked = True
+        secondary = CaptchaSolver("2captcha", "k2")
+        secondary._solver_health_checked = True
+
+        wrapper = MultiProviderSolver(primary, secondary)
+        # Both support recaptcha — primary wins.
+        chosen = await wrapper._pick_solver(kind="recaptcha")
+        assert chosen is primary
+
+    @pytest.mark.asyncio
+    async def test_returns_none_when_only_supporter_is_unhealthy(self):
+        primary = CaptchaSolver("2captcha", "k1")
+        primary._solver_health_checked = True
+        secondary = CaptchaSolver("capsolver", "k2")
+        secondary._solver_health_checked = True
+        secondary._solver_unreachable = True  # only supporter is down
+
+        wrapper = MultiProviderSolver(primary, secondary)
+        chosen = await wrapper._pick_solver(kind="js-challenge-akamai")
+        assert chosen is None  # surface no-solver shape
+
+    @pytest.mark.asyncio
+    async def test_no_kind_argument_uses_primary_first(self):
+        """Backward compat: callers that don't pass ``kind`` still get
+        the existing primary-first behavior."""
+        primary = CaptchaSolver("capsolver", "k1")
+        primary._solver_health_checked = True
+        secondary = CaptchaSolver("2captcha", "k2")
+        secondary._solver_health_checked = True
+
+        wrapper = MultiProviderSolver(primary, secondary)
+        chosen = await wrapper._pick_solver()
+        assert chosen is primary
+
+
+# ── 6: anti-bot solve path skips sitekey + skips breaker ──────────────
+
+
+def _solve_page_with_url(url: str = "https://example.com/"):
+    page = MagicMock()
+    page.evaluate = AsyncMock()
+    page.url = url
+    return page
+
+
+class TestAntibotSolvePath:
+    """End-to-end ``CaptchaSolver.solve()`` for an anti-bot kind."""
+
+    @pytest.mark.asyncio
+    async def test_skips_sitekey_extraction(self):
+        """For anti-bot kinds, ``_extract_sitekey`` should NOT be called —
+        these task types don't use a DOM sitekey marker."""
+        solver = CaptchaSolver("capsolver", "fake-key")
+        solver._solver_health_checked = True
+
+        # Stub the provider HTTP path so the solve completes without a
+        # network round-trip; we only care that sitekey extraction was
+        # skipped on the way in.
+        async def _no_provider_call(*a, **kw):
+            return (None, False, False, False)
+
+        with (
+            patch.object(solver, "_extract_sitekey", AsyncMock()) as ext_mock,
+            patch.object(solver, "_submit_and_poll", _no_provider_call),
+        ):
+            page = _solve_page_with_url()
+            await solver.solve(
+                page, "any-selector", "https://protected.site/",
+                kind="js-challenge-akamai",
+            )
+
+        ext_mock.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_breaker_not_ticked_on_antibot_failure(self):
+        """Anti-bot kinds are low-confidence by design: failures must
+        NOT tick the §11.16 breaker. Three rejected anti-bot solves in
+        5 minutes should NOT lock the whole fleet's solver out of the
+        standard CAPTCHA path."""
+        solver = CaptchaSolver("capsolver", "fake-key")
+        solver._solver_health_checked = True
+
+        # Provider contacted, returned errorId (transient/non-fatal).
+        async def _provider_failure(*a, **kw):
+            # (token, used_proxy_aware, compat_rejected, provider_contacted)
+            return (None, True, False, True)
+
+        with patch.object(solver, "_submit_and_poll", _provider_failure):
+            page = _solve_page_with_url()
+            for _ in range(5):  # well above the 3-failure trip threshold
+                await solver.solve(
+                    page, "any-selector", "https://protected.site/",
+                    kind="js-challenge-akamai",
+                )
+
+        assert solver.is_breaker_open() is False
+        assert len(solver._solver_failure_timestamps) == 0
+
+    @pytest.mark.asyncio
+    async def test_breaker_still_ticks_on_standard_kind_failure(self):
+        """Regression guard: anti-bot skip must not bleed into standard
+        kinds. Three transient errors on a recaptcha solve still trip
+        the breaker."""
+        solver = CaptchaSolver("capsolver", "fake-key")
+        solver._solver_health_checked = True
+
+        # Provider contacted, transient error (non-fatal description).
+        err_resp = MagicMock()
+        err_resp.json = MagicMock(return_value={
+            "errorId": 1,
+            "errorDescription": "ERROR_NO_SLOT_AVAILABLE",
+        })
+        err_resp.raise_for_status = MagicMock()
+
+        client = AsyncMock(spec=httpx.AsyncClient)
+        client.is_closed = False
+        client.post = AsyncMock(return_value=err_resp)
+        solver._client = client
+
+        with (
+            patch.object(solver, "_extract_sitekey", AsyncMock(return_value="site-key-abc")),
+            patch("src.browser.captcha._POLL_INTERVAL", 0.001),
+        ):
+            page = _solve_page_with_url()
+            for _ in range(3):
+                await solver.solve(
+                    page, 'iframe[src*="recaptcha"]',
+                    "https://example.com/",
+                    kind="recaptcha-v2-checkbox",
+                )
+
+        # Breaker SHOULD be open — standard-kind path is unchanged.
+        assert solver.is_breaker_open() is True
+
+
+# ── 7: body builder omits websiteKey for anti-bot kinds ───────────────
+
+
+class TestBodyBuilderAntibot:
+    def test_websitekey_omitted_for_antibot(self):
+        solver = CaptchaSolver("capsolver", "fake-key")
+        body, used_proxy_aware, compat_rejected = solver._build_task_body(
+            _CAPSOLVER_TASK_TYPES,
+            "js-challenge-akamai",
+            "",  # sitekey — empty for anti-bot
+            "https://protected.site/",
+            page_action=None,
+            proxy_config=None,
+            provider_name="capsolver",
+        )
+        if body is not None:
+            # When solver-proxy is unconfigured AND the kind has no
+            # proxyless variant, the body builder may return None (the
+            # fallback path). Either is acceptable — but if a body is
+            # returned, websiteKey must NOT be present.
+            assert "websiteKey" not in body, (
+                "Anti-bot tasks reject ERROR_KEY_MUST_NOT_BE_EMPTY when "
+                "websiteKey is included as an empty string"
+            )
+
+    def test_websitekey_present_for_standard_kind(self):
+        solver = CaptchaSolver("capsolver", "fake-key")
+        body, _, _ = solver._build_task_body(
+            _CAPSOLVER_TASK_TYPES,
+            "recaptcha-v2-checkbox",
+            "site-key-xyz",
+            "https://example.com/",
+            page_action=None,
+            proxy_config=None,
+            provider_name="capsolver",
+        )
+        assert body is not None
+        assert body.get("websiteKey") == "site-key-xyz"
+
+
+# ── 8: _extract_solution_token ────────────────────────────────────────
+
+
+class TestExtractSolutionToken:
+    def test_standard_grecaptcha_response_path(self):
+        token = _extract_solution_token(
+            {"gRecaptchaResponse": "abc"}, "recaptcha",
+        )
+        assert token == "abc"
+
+    def test_standard_token_field(self):
+        token = _extract_solution_token(
+            {"token": "xyz"}, "turnstile",
+        )
+        assert token == "xyz"
+
+    def test_antibot_solution_with_cookies(self):
+        sol = {"cookies": [{"name": "_abck", "value": "..."}]}
+        token = _extract_solution_token(sol, "js-challenge-akamai")
+        assert token is not None
+        # Should be JSON-encoded so the caller's "token retrieved"
+        # accounting fires; the injection step will gracefully fail
+        # downstream because we don't yet thread cookies into the page.
+        decoded = json.loads(token)
+        assert decoded == sol
+
+    def test_antibot_solution_with_useragent_and_sensor(self):
+        sol = {
+            "userAgent": "Mozilla/5.0 ...",
+            "sensorData": "..."
+        }
+        token = _extract_solution_token(sol, "js-challenge-imperva")
+        assert token is not None
+        decoded = json.loads(token)
+        assert decoded == sol
+
+    def test_antibot_kind_without_solution_keys_returns_none(self):
+        """Empty / unrecognized solution shape → None, even for
+        anti-bot kinds. The provider didn't actually return a usable
+        solution, so the caller should treat as failure."""
+        token = _extract_solution_token({}, "js-challenge-akamai")
+        assert token is None
+
+    def test_non_antibot_kind_with_antibot_shape_returns_none(self):
+        """A solution that LOOKS like an anti-bot response (cookies)
+        but the kind is recaptcha → don't synthesize a fake token.
+        Standard fields take priority."""
+        sol = {"cookies": [...]}
+        token = _extract_solution_token(sol, "recaptcha")
+        assert token is None
+
+    def test_non_dict_solution(self):
+        assert _extract_solution_token(None, "js-challenge-akamai") is None
+        assert _extract_solution_token("string", "js-challenge-akamai") is None
+
+
+# ── 9: cost-counter pricing ───────────────────────────────────────────
+
+
+class TestPricing:
+    def test_proxyless_pricing_registered(self):
+        """Cost-cap reservation reads the proxyless table BEFORE the
+        actual tier is known. Anti-bot kinds must have an entry so the
+        pre-solve reservation gate doesn't fail closed."""
+        for kind in _ANTIBOT_KINDS:
+            key = f"capsolver-{kind}"
+            assert key in PRICING_MILLICENTS, (
+                f"{key} missing from PRICING_MILLICENTS — cost-cap "
+                f"reservation will fail closed"
+            )
+            assert PRICING_MILLICENTS[key] > 0
+
+    def test_proxy_aware_pricing_registered(self):
+        for kind in _ANTIBOT_KINDS:
+            key = ("capsolver", kind)
+            assert key in PRICING_MILLICENTS_PROXY_AWARE, (
+                f"{key} missing from PRICING_MILLICENTS_PROXY_AWARE"
+            )
+            assert PRICING_MILLICENTS_PROXY_AWARE[key] > 0
+
+    def test_no_2captcha_antibot_pricing(self):
+        """Regression guard: 2Captcha doesn't support anti-bot kinds,
+        and adding entries to the pricing table would suggest the
+        solver path is wired (it isn't)."""
+        for kind in _ANTIBOT_KINDS:
+            assert f"2captcha-{kind}" not in PRICING_MILLICENTS
+            assert ("2captcha", kind) not in PRICING_MILLICENTS_PROXY_AWARE

--- a/tests/test_antibot_task_types.py
+++ b/tests/test_antibot_task_types.py
@@ -631,3 +631,211 @@ class TestApplyAntibotSolution:
         assert ok is True
         ctx.add_cookies.assert_awaited_once()
         page.reload.assert_awaited_once()
+
+
+# ── 11: cookie field normalization (sameSite, expires) ────────────────
+
+
+class TestCookieNormalization:
+    """Playwright's ``BrowserContext.add_cookies`` is strict about
+    enum casing and field types. Provider responses drift across
+    casings / formats; pre-fix every drift silently failed the whole
+    add_cookies call (operator pays for solves that don't apply)."""
+
+    def test_samesite_canonical_casing(self):
+        from src.browser.captcha import _normalize_cookie_same_site
+        assert _normalize_cookie_same_site("Lax") == "Lax"
+        assert _normalize_cookie_same_site("Strict") == "Strict"
+        assert _normalize_cookie_same_site("None") == "None"
+
+    def test_samesite_lowercase_coerced(self):
+        from src.browser.captcha import _normalize_cookie_same_site
+        assert _normalize_cookie_same_site("lax") == "Lax"
+        assert _normalize_cookie_same_site("strict") == "Strict"
+        assert _normalize_cookie_same_site("none") == "None"
+        assert _normalize_cookie_same_site("LAX") == "Lax"
+
+    def test_samesite_no_restriction_alias(self):
+        from src.browser.captcha import _normalize_cookie_same_site
+        # Some providers / Chrome devtools use this spelling.
+        assert _normalize_cookie_same_site("no_restriction") == "None"
+        assert _normalize_cookie_same_site("noRestriction") == "None"
+
+    def test_samesite_unrecognized_dropped(self):
+        from src.browser.captcha import _normalize_cookie_same_site
+        # Unrecognized value → None (drop the field; Playwright defaults
+        # absence to "Lax", which is the right shape for these cookies).
+        assert _normalize_cookie_same_site("unspecified") is None
+        assert _normalize_cookie_same_site("garbage") is None
+        assert _normalize_cookie_same_site(None) is None
+        assert _normalize_cookie_same_site("") is None
+        # Non-string input → None.
+        assert _normalize_cookie_same_site(42) is None
+
+    def test_expires_seconds_passthrough(self):
+        from src.browser.captcha import _normalize_cookie_expires
+        assert _normalize_cookie_expires(1735689600) == 1735689600.0
+        assert _normalize_cookie_expires(1735689600.5) == 1735689600.5
+
+    def test_expires_session_sentinel(self):
+        from src.browser.captcha import _normalize_cookie_expires
+        # -1 is Playwright's session-cookie sentinel; preserved.
+        assert _normalize_cookie_expires(-1) == -1.0
+        assert _normalize_cookie_expires(-1.0) == -1.0
+
+    def test_expires_milliseconds_coerced(self):
+        from src.browser.captcha import _normalize_cookie_expires
+        # Some providers return millis-since-epoch (JavaScript's
+        # ``Date.now()`` shape). 1735689600000 ms = 1735689600 s
+        # = 2025-01-01.
+        assert _normalize_cookie_expires(1735689600000) == 1735689600.0
+
+    def test_expires_iso8601_string(self):
+        from src.browser.captcha import _normalize_cookie_expires
+        # ISO with trailing 'Z' (Python ≤3.10's fromisoformat rejects
+        # this; the normalizer rewrites to '+00:00').
+        ts = _normalize_cookie_expires("2025-01-01T00:00:00Z")
+        assert ts is not None
+        assert abs(ts - 1735689600.0) < 1.0  # within 1s
+
+    def test_expires_numeric_string(self):
+        from src.browser.captcha import _normalize_cookie_expires
+        assert _normalize_cookie_expires("1735689600") == 1735689600.0
+
+    def test_expires_unparseable_dropped(self):
+        from src.browser.captcha import _normalize_cookie_expires
+        assert _normalize_cookie_expires("not-a-date") is None
+        assert _normalize_cookie_expires(None) is None
+        assert _normalize_cookie_expires("") is None
+        # Booleans are NOT treated as numbers (defensive — ``isinstance(
+        # True, int)`` is True in Python).
+        assert _normalize_cookie_expires(True) is None
+        assert _normalize_cookie_expires(False) is None
+
+    @pytest.mark.asyncio
+    async def test_apply_solution_normalizes_provider_drift(self):
+        """End-to-end: a CapSolver-shaped response with lowercase
+        ``sameSite`` and ISO-8601 ``expires`` lands in
+        ``add_cookies`` with the canonical Playwright shape."""
+        from src.browser.captcha import _apply_antibot_solution
+
+        page = MagicMock()
+        page.url = "https://protected.site/"
+        ctx = MagicMock()
+        captured: list = []
+
+        async def _add_cookies(cookies):
+            captured.append(list(cookies))
+        ctx.add_cookies = _add_cookies
+        page.context = ctx
+        page.reload = AsyncMock()
+
+        token = json.dumps({
+            "cookies": [
+                {
+                    "name": "_abck",
+                    "value": "v",
+                    "domain": ".target.com",
+                    "path": "/",
+                    "sameSite": "lax",                       # lowercase
+                    "expires": "2025-01-01T00:00:00Z",       # ISO
+                    "secure": True,
+                },
+            ],
+        })
+        ok = await _apply_antibot_solution(page, token)
+        assert ok is True
+        assert len(captured) == 1
+        applied = captured[0][0]
+        # sameSite normalized to canonical case.
+        assert applied["sameSite"] == "Lax"
+        # expires coerced to numeric seconds-since-epoch.
+        assert isinstance(applied["expires"], float)
+        assert abs(applied["expires"] - 1735689600.0) < 1.0
+        # Other fields passed through.
+        assert applied["domain"] == ".target.com"
+        assert applied["secure"] is True
+
+
+# ── 12: anti-bot kinds are NEUTRAL to the breaker (no clear on success) ─
+
+
+class TestAntibotBreakerNeutrality:
+    """Anti-bot kinds skip the breaker on FAILURE (commit 0b4b8c6) and
+    must also skip on SUCCESS — otherwise a successful anti-bot solve
+    silently CLEARS a breaker that genuine standard-path failures had
+    ticked, masking real provider outages."""
+
+    @pytest.mark.asyncio
+    async def test_antibot_success_does_not_clear_breaker(self):
+        from src.browser.captcha import CaptchaSolver
+
+        solver = CaptchaSolver("capsolver", "fake-key")
+        solver._solver_health_checked = True
+
+        # Pre-load the failure window with TWO failures — below the
+        # threshold, so the breaker isn't tripped (which would
+        # short-circuit the solve below). The point of the test is the
+        # FAILURE WINDOW state, not the breaker-open state.
+        await solver._record_solver_outcome(success=False)
+        await solver._record_solver_outcome(success=False)
+        assert len(solver._solver_failure_timestamps) == 2
+
+        # An anti-bot solve succeeds.
+        async def _success_submit(*a, **kw):
+            return (
+                json.dumps({
+                    "cookies": [{"name": "x", "value": "v",
+                                 "domain": ".x.com"}],
+                }),
+                True,   # used_proxy_aware
+                False,  # compat_rejected
+                True,   # provider_contacted
+            )
+
+        page = MagicMock()
+        page.url = "https://protected.site/"
+        ctx = MagicMock()
+        ctx.add_cookies = AsyncMock()
+        page.context = ctx
+        page.reload = AsyncMock()
+        page.evaluate = AsyncMock()
+
+        with patch.object(solver, "_submit_and_poll", _success_submit):
+            result = await solver.solve(
+                page, "any-selector", "https://protected.site/",
+                kind="js-challenge-akamai",
+            )
+
+        # The standard-path failure window MUST still be intact —
+        # pre-fix, the success path called
+        # ``_record_solver_outcome(success=True)`` which clears the
+        # window (and would set ``len == 0`` here). With the symmetry
+        # fix, anti-bot kinds skip the breaker tick on success too.
+        assert len(solver._solver_failure_timestamps) == 2, (
+            "anti-bot success must not clear the standard-path "
+            "failure window"
+        )
+        assert result.token is not None  # solve itself succeeded
+
+    @pytest.mark.asyncio
+    async def test_standard_kind_success_still_clears_breaker(self):
+        """Regression guard: the standard-kind success path must still
+        clear the breaker — that's the whole point of the failure
+        window. Three failures + one success → breaker reset."""
+        from src.browser.captcha import (
+            _BREAKER_FAILURE_THRESHOLD,
+            CaptchaSolver,
+        )
+
+        solver = CaptchaSolver("capsolver", "fake-key")
+        solver._solver_health_checked = True
+        # Tick the breaker.
+        from unittest.mock import patch as _patch
+        with _patch("src.browser.captcha.time.time", return_value=1_000_000.0):
+            for _ in range(_BREAKER_FAILURE_THRESHOLD):
+                await solver._record_solver_outcome(success=False)
+        # A standard-kind success clears it.
+        await solver._record_solver_outcome(success=True)
+        assert solver.is_breaker_open() is False
+        assert len(solver._solver_failure_timestamps) == 0

--- a/tests/test_captcha_per_type_timeout.py
+++ b/tests/test_captcha_per_type_timeout.py
@@ -93,6 +93,10 @@ class TestDefaultLookup:
 
     def test_default_table_matches_spec(self):
         # Spec: §11.9 — sanity check the static defaults haven't drifted.
+        # §22 added the four anti-bot platform kinds at 180s each (the
+        # AntiBot family is known-slow; 180s matches the documented
+        # provider response window and the per-type rationale on
+        # ``_CAPSOLVER_TASK_TYPES``).
         assert _SOLVE_TIMEOUT_DEFAULTS_MS == {
             "recaptcha-v2-checkbox":     120_000,
             "recaptcha-v2-invisible":    120_000,
@@ -102,6 +106,10 @@ class TestDefaultLookup:
             "hcaptcha":                  120_000,
             "turnstile":                 180_000,
             "cf-interstitial-turnstile": 180_000,
+            "js-challenge-akamai":       180_000,
+            "js-challenge-imperva":      180_000,
+            "js-challenge-kasada":       180_000,
+            "datadome-behavioral":       180_000,
         }
 
     def test_fallback_constant(self):
@@ -162,9 +170,12 @@ class TestEnvOverride:
 class TestFallback:
     def test_unknown_kind_returns_fallback(self):
         solver = _make_solver()
-        # Behavioral kinds are not solver kinds; they hit the fallback.
+        # Behavioral kinds without a CapSolver task type still hit the
+        # fallback. ``px-press-hold`` is HUMAN Security's "Press & Hold"
+        # — operator escalation only, no solver path.
+        # ``datadome-behavioral`` got a 180s entry in §22 (CapSolver
+        # publishes ``DataDomeSliderTask``); it no longer falls back.
         assert solver._timeout_seconds_for_kind("px-press-hold") == 120.0
-        assert solver._timeout_seconds_for_kind("datadome-behavioral") == 120.0
 
     def test_completely_bogus_kind_returns_fallback(self):
         solver = _make_solver()


### PR DESCRIPTION
Wires CapSolver-published anti-bot platform task types into the existing CAPTCHA pipeline so behavioral / sensor-data challenges that today route to operator escalation can be auto-solved when CapSolver is configured (primary or secondary). Stacks on top of the multi-provider failover PR (#793, just merged).

## New kinds → CapSolver task names

Verified against `docs.capsolver.com/en/guide/captcha/` as of recent provider docs:

* `js-challenge-akamai` → `AntiAkamaiBMPTask`
* `js-challenge-imperva` → `AntiImpervaTask`
* `js-challenge-kasada` → `AntiKasadaTask`
* `datadome-behavioral` → `DataDomeSliderTask`

2Captcha does NOT publish equivalents — entries appear ONLY in `_CAPSOLVER_TASK_TYPES`. The dispatch in `BrowserManager._check_captcha` calls `solver.supports_kind(kind)` BEFORE entering the solver path, so a 2Captcha-only deployment continues to route these kinds to operator escalation (no `ERROR_INVALID_TASK_TYPE` flood). With the failover wrapper, deployments running 2Captcha primary + CapSolver secondary route anti-bot kinds to the secondary via `MultiProviderSolver._pick_solver`'s kind-aware branch.

## Cookie injection (the big one)

The first commit extracted the JSON solution token (`{cookies, userAgent, sensorData}`) but routed it to `_inject_token`, where it fell through every CAPTCHA-family branch and surfaced `injection_failed`. Operator paid for solves that produced no usable session.

Fixed in `f545fe9`:

- `_inject_token` short-circuits to `_apply_antibot_solution` when `captcha_type in _ANTIBOT_KINDS`.
- `_apply_antibot_solution(page, token)` parses the JSON, applies cookies via `page.context.add_cookies()` with field whitelist + page-URL fallback, reloads the page so the cleared-challenge cookies take effect on the next request.

Further hardened in `67a5e25`:

- **Cookie field normalization.** Playwright is strict: `sameSite ∈ {"Strict","Lax","None"}` exact-case; `expires` as numeric seconds-since-epoch. Providers return `"strict"`/`"lax"`/`"unspecified"` and ISO-8601 / millis-since-epoch. New `_normalize_cookie_same_site` and `_normalize_cookie_expires` helpers map known shapes to canonical Playwright form; unrecognized values are dropped (Playwright defaults absence to "Lax", which matches the common-case shape for these cookies).
- **Breaker symmetry on anti-bot success.** Pre-fix anti-bot kinds skipped the breaker tick on FAILURE but unconditionally called `_record_solver_outcome(success=True)` on success — anti-bot solves could only HEAL the breaker, never trip it, masking real provider issues on the standard CAPTCHA path. Now anti-bot is fully NEUTRAL to the breaker.

## Why anti-bot kinds are LOW-CONFIDENCE by design

- Anti-bot tokens are rejected at the application layer for IP / fingerprint mismatches the solver has no visibility into; real-world success rates are 30-80% even with the right task type.
- Failures DO NOT tick the §11.16 breaker — three rejected anti-bot solves shouldn't lock the whole fleet's solver out for 10 minutes.
- Envelope is force-stamped `solver_confidence="low"`. On any non-`solved` outcome, `next_action` upgrades to `request_captcha_help` so the agent doesn't retry.

## Tests

- 56 tests in `tests/test_antibot_task_types.py` covering: per-provider table membership, per-type timeouts, `supports_kind` semantics on both `CaptchaSolver` and `MultiProviderSolver`, kind-aware routing, anti-bot solve path (sitekey skipped, breaker neutral), `_extract_solution_token`, cookie normalization (`sameSite` casing, `expires` formats), end-to-end cookie application via `_inject_token`.
- 194 tests pass across the regression suite.
- ruff clean.

## Caveats (documented in code comments)

- Provider docs drift quarterly. CapSolver's AntiBot product surface rotates faster than the standard CAPTCHA tasks. The §11.16 breaker + fatal-error gate keep the fleet's solver path safe even when our task-type table goes stale.
- `px-press-hold` / FingerprintJS / F5 have no published CapSolver task type and remain operator-escalation-only.
- `userAgent` / `sensorData` from anti-bot solutions are NOT currently threaded into `BrowserContext.set_extra_http_headers`. Cookies are the primary signal; UA threading is a follow-up if real-world success rates indicate it's needed.

---
_Generated by [Claude Code](https://claude.ai/code/session_019BMxHfdu7SqFZf84DQoLQi)_