### PR TITLE
stealth-browser: halve typing speed; force-click now scrolls into view

### DIFF
--- a/src/browser/service.py
+++ b/src/browser/service.py
@@ -5660,9 +5660,28 @@ class BrowserManager:
            current mouse position (already on the element from the hover).
 
         When ``force=True``, falls back to ``locator.click(force=True)`` since
-        hover may fail on elements obscured by overlays.
+        hover may fail on elements obscured by overlays. We still call
+        ``scroll_into_view_if_needed`` first — Playwright's ``force=True``
+        skips ALL actionability checks INCLUDING the implicit scroll-
+        into-view, so a forced click on an off-fold element fires the
+        click event at the element's geometric position which can land
+        OUTSIDE the visible viewport. From the operator's VNC view, the
+        click visually "lands nowhere." This bites in particular on
+        SPA frameworks (X / Twitter / Gmail) that use ``aria-disabled``
+        on visually-active buttons — the click loop auto-applies
+        ``force=True`` for those (see ``_ARIA_FORCE_ROLES`` gate in
+        :meth:`click`), so the force path is hit MORE often than
+        operators expect. Scrolling explicitly is cheap and additive.
         """
         if force:
+            try:
+                await locator.scroll_into_view_if_needed(timeout=timeout)
+            except Exception:
+                # Element may be detached / cross-origin / have no box;
+                # the forced click below will still attempt at the last-
+                # known position. Better to log via the click error path
+                # than to fail-fast here.
+                pass
             await locator.click(timeout=timeout, force=True)
             return
         try:
@@ -5678,8 +5697,17 @@ class BrowserManager:
         """Like _human_click but takes a CSS selector instead of a locator.
 
         Hovers first to generate natural mouse movement, then clicks.
+        On the ``force=True`` path, scrolls the locator into view BEFORE
+        the forced click — Playwright's ``force=True`` skips
+        scroll-into-view; without this an off-fold force-click fires
+        outside the viewport and visibly lands nowhere on VNC. Mirror
+        of :meth:`_human_click`'s force path.
         """
         if force:
+            try:
+                await page.locator(selector).scroll_into_view_if_needed(timeout=timeout)
+            except Exception:
+                pass
             await page.click(selector, timeout=timeout, force=True)
             return
         try:

--- a/src/browser/timing.py
+++ b/src/browser/timing.py
@@ -91,17 +91,24 @@ def keystroke_delay(char: str) -> float:
     """Per-key delay (seconds). Symbols/digits are slower than letters.
 
     Base values (scaled by speed factor):
-    Letters: μ=0.045, σ=0.015, range 0.020–0.090.
-    Symbols/digits: μ=0.065, σ=0.020, range 0.025–0.110.
-    Spaces: μ=0.035, σ=0.010, range 0.018–0.070 (faster, word boundary rhythm).
+    Letters: μ=0.090, σ=0.030, range 0.040–0.180.
+    Symbols/digits: μ=0.130, σ=0.040, range 0.050–0.220.
+    Spaces: μ=0.070, σ=0.020, range 0.036–0.140 (faster, word boundary rhythm).
 
-    At speed=1.0, this is ≈270 CPM / 54 WPM — a moderate typist.
+    At speed=1.0, this is ≈135 CPM / 27 WPM — a moderate-to-slow typist
+    that better matches the real-user population (StatCounter / Typing.com
+    benchmarks put the modal user at 30–40 WPM). Pre-2026-04 values
+    were halved (μ=0.045 → 54 WPM); operators reported the typing-vs-
+    mouse speed mismatch was an obvious behavioral signal — keystrokes
+    fired in ~500ms while a click+settle takes ~300ms, so an "agent
+    types 11 chars in the time of one mouse click" pattern was visible
+    in VNC playback. Halving brings the ratio into a believable range.
     """
     if char == " ":
-        return _scaled(0.035, 0.010, 0.018, 0.070)
+        return _scaled(0.070, 0.020, 0.036, 0.140)
     if char.isalpha():
-        return _scaled(0.045, 0.015, 0.020, 0.090)
-    return _scaled(0.065, 0.020, 0.025, 0.110)
+        return _scaled(0.090, 0.030, 0.040, 0.180)
+    return _scaled(0.130, 0.040, 0.050, 0.220)
 
 
 def think_pause() -> float:

--- a/tests/test_browser_service.py
+++ b/tests/test_browser_service.py
@@ -912,6 +912,61 @@ class TestClick:
         assert result["data"]["clicked"] == "e0"
 
     @pytest.mark.asyncio
+    async def test_human_click_force_scrolls_into_view_first(self):
+        """Force-click must call ``scroll_into_view_if_needed`` BEFORE
+        the forced click. Pre-fix the force path skipped scroll-into-
+        view (Playwright's ``force=True`` skips ALL actionability
+        checks), so an off-fold force-click landed at the element's
+        geometric position outside the visible viewport — visibly
+        clicking nowhere on VNC. Bug bites SPA frameworks (X /
+        Twitter / Gmail) hard because they use ``aria-disabled`` on
+        visually-active buttons, which auto-triggers force=True
+        in the click loop."""
+        from src.browser.service import BrowserManager
+        mgr = BrowserManager(profiles_dir="/tmp/test_profiles")
+        page = MagicMock()
+        locator = AsyncMock()
+        locator.scroll_into_view_if_needed = AsyncMock()
+        locator.click = AsyncMock()
+
+        await mgr._human_click(page, locator, force=True, timeout=1000)
+        locator.scroll_into_view_if_needed.assert_awaited_once()
+        locator.click.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_human_click_force_tolerates_scroll_failure(self):
+        """If the element is detached / cross-origin / has no box,
+        ``scroll_into_view_if_needed`` raises. The forced click
+        should still proceed — we attempt the click at the last-known
+        position rather than fail-fast on the scroll."""
+        from src.browser.service import BrowserManager
+        mgr = BrowserManager(profiles_dir="/tmp/test_profiles")
+        page = MagicMock()
+        locator = AsyncMock()
+        locator.scroll_into_view_if_needed = AsyncMock(
+            side_effect=RuntimeError("element detached"),
+        )
+        locator.click = AsyncMock()
+
+        await mgr._human_click(page, locator, force=True, timeout=1000)
+        locator.click.assert_awaited_once()  # click still attempted
+
+    @pytest.mark.asyncio
+    async def test_human_click_selector_force_scrolls_into_view_first(self):
+        """Mirror of the locator-based force test for the selector path."""
+        from src.browser.service import BrowserManager
+        mgr = BrowserManager(profiles_dir="/tmp/test_profiles")
+        page = AsyncMock()
+        sub_locator = AsyncMock()
+        sub_locator.scroll_into_view_if_needed = AsyncMock()
+        page.locator = MagicMock(return_value=sub_locator)
+        page.click = AsyncMock()
+
+        await mgr._human_click_selector(page, "#submit", force=True, timeout=1000)
+        sub_locator.scroll_into_view_if_needed.assert_awaited_once()
+        page.click.assert_awaited_once()
+
+    @pytest.mark.asyncio
     async def test_click_by_selector(self):
         from src.browser.service import BrowserManager, CamoufoxInstance
         mgr = BrowserManager(profiles_dir="/tmp/test_profiles")
@@ -2787,11 +2842,30 @@ class TestHumanTiming:
         assert 0.04 <= mean <= 0.12
 
     def test_keystroke_delay_alpha(self):
+        """Halved from 54 WPM (μ=0.045) → 27 WPM (μ=0.090) so the
+        typing-vs-mouse-speed ratio looks human in VNC playback."""
         from src.browser.timing import keystroke_delay
         samples = [keystroke_delay("a") for _ in range(1000)]
-        assert all(0.020 <= s <= 0.090 for s in samples)
+        assert all(0.040 <= s <= 0.180 for s in samples)
         mean = sum(samples) / len(samples)
-        assert 0.035 <= mean <= 0.055
+        assert 0.075 <= mean <= 0.105
+
+    def test_keystroke_delay_alpha_below_realistic_typing_speed_floor(self):
+        """27 WPM = ~135 CPM = ~0.444 ms/char is the realistic-floor
+        target. Sub-30 WPM is the documented design point. Sample mean
+        across 5k draws must fall in the 0.07–0.11 s window — well
+        within the realistic-typing-speed range and clearly slower
+        than the original 0.045 s baseline."""
+        from src.browser.timing import keystroke_delay
+        samples = [keystroke_delay("a") for _ in range(5000)]
+        mean = sum(samples) / len(samples)
+        # Anti-regression: previous 54 WPM mean was ~0.045s. New
+        # baseline must be at least ~50% slower.
+        assert mean > 0.07, (
+            f"keystroke_delay regressed to {mean:.3f}s — should be ≥0.07s "
+            f"(27 WPM target)"
+        )
+        assert mean < 0.11
 
     def test_keystroke_delay_symbol_slower(self):
         from src.browser.timing import keystroke_delay
@@ -3397,7 +3471,9 @@ class TestTypeWithVariance:
         press_chars = [c[0][0] for c in mock_page.keyboard.press.call_args_list]
         assert press_chars == ["H", "i", "!"]
         assert len(delays) == 3
-        assert all(0.020 <= d <= 0.110 for d in delays)
+        # Bounds widened in 2026-04 keystroke-speed halving: alpha/symbol
+        # delays are now in [0.040, 0.220] s.
+        assert all(0.040 <= d <= 0.220 for d in delays)
 
     @pytest.mark.asyncio
     async def test_type_with_variance_falls_back_to_keyboard_type(self):


### PR DESCRIPTION
Two real behavioral-fingerprint bugs flagged by an operator watching VNC playback. Both predate the recent stealth-review series.

## 1. Typing was abnormally fast vs. mouse pace

`keystroke_delay` baseline (μ=45 ms/letter) modeled a 54 WPM typist. Compared to a click+settle (~300 ms total), an 11-char word fired in ~500 ms — visibly faster than human typing-vs-mouse ratios. Halved the base values to ~27 WPM (μ=90 ms/letter), which sits on the conservative side of the real-user distribution (StatCounter / Typing.com data puts the modal user at 30–40 WPM). Operators who need faster typing for specific agents can still dial up via the per-agent speed multiplier; the BASE now leans stealth-conservative.

| Char class | Old μ | New μ | Old range | New range |
|---|---|---|---|---|
| Letters | 45 ms | **90 ms** | 20–90 | 40–180 |
| Symbols/digits | 65 ms | **130 ms** | 25–110 | 50–220 |
| Spaces | 35 ms | **70 ms** | 18–70 | 36–140 |

## 2. Force-clicks could land off-screen

`_human_click(force=True)` and `_human_click_selector(force=True)` called Playwright's `click(force=True)` directly. Playwright's `force=True` skips ALL actionability checks **including** the implicit `scroll_into_view_if_needed`. Result: a forced click on an off-fold element fires the click event at the element's geometric position — outside the visible viewport. From the operator's VNC view, the click visually "lands nowhere."

The bug bit hardest on SPA frameworks (X / Twitter / Gmail / Notion) that use `aria-disabled` on visually-active buttons. The click loop in `BrowserManager.click` auto-applies `force=True` for those roles (see `_ARIA_FORCE_ROLES`), so the force path was hit MORE often than operators realized.

Fix: explicit `scroll_into_view_if_needed` BEFORE the forced click in both `_human_click` and `_human_click_selector`. Tolerant of failure (detached / cross-origin / no-bounding-box elements) — the forced click still proceeds at the last-known position to match pre-fix behavior in those edge cases. The X11 click path (`_x11_click`) was already fine — it always calls `_x11_ensure_in_viewport` and doesn't take a `force` parameter.

## Tests

- Updated `test_keystroke_delay_alpha` for new bounds and added `test_keystroke_delay_alpha_below_realistic_typing_speed_floor` as an anti-regression guard.
- Updated `test_type_with_variance_uses_keyboard_press` delay-bound assertion.
- 3 new tests for the force-click scroll fix: locator path scrolls; tolerates scroll failure; selector path mirrors.
- 452 tests pass in `test_browser_service.py`. ruff clean.

## Stacking note

This branch is off `main` (which already has the merged review-foundation + solver-failover PRs). Independent of the remaining open PRs (#794 warmup, #795 dashboard, #796 antibot). Can merge in any order relative to those.

---
_Generated by [Claude Code](https://claude.ai/code/session_019BMxHfdu7SqFZf84DQoLQi)_