### PR TITLE
fix(browser): refuse-on-cap + memory-derived default for browser pool

### DIFF
--- a/src/browser/__main__.py
+++ b/src/browser/__main__.py
@@ -32,6 +32,105 @@ _VNC_PORT = int(os.environ.get("VNC_PORT", "6080"))
 _API_PORT = int(os.environ.get("API_PORT", "8500"))
 
 
+# Memory budget per Camoufox + per-agent X stack, in MiB.  ~400 MB is
+# the high-water mark of a typical Camoufox instance under sustained
+# use; ~50 MB covers the per-agent Xvnc + Openbox + unclutter when
+# OPENLEGION_BROWSER_PER_AGENT_DISPLAY is on.  Sized for the safer of
+# the two paths so the autodetected default is correct in both modes.
+_MEM_PER_BROWSER_MB = 450
+# Reserved for OS + mesh + agent containers + Docker overhead.  The
+# CLAUDE.md resource budget for the engine quotes ~2.5 GB overhead;
+# add a 512 MB buffer so a fresh-install on a small box has slack
+# instead of teetering on the edge of OOM.
+_HEADROOM_MB = 3072
+# Hard ceiling — matches the display-allocator pool size.  Going above
+# this requires raising both knobs together; the comment in
+# src/browser/display_allocator.py:DISPLAY_RANGE_END is the source.
+_MAX_CAP = 64
+# Last-resort floor when memory autodetect fails.  4 GB box × the
+# budget above gives ~2 browsers; 5 was the legacy default and has
+# shipped for a year so we preserve it as the conservative fallback.
+_FALLBACK_DEFAULT = 5
+
+
+def _detect_total_memory_mb() -> int | None:
+    """Return total memory available to this process in MiB, or None.
+
+    Probes cgroups v2 first (the modern container path), falls back to
+    ``/proc/meminfo`` for bare-metal / VM, and gives up silently on
+    anything else.  Catches every exception so a hostile / missing
+    /proc /sys never crashes startup — the caller falls through to
+    :data:`_FALLBACK_DEFAULT`.
+
+    On cgroups v1 (the EOL Hetzner path is already on cgroups v2 since
+    Ubuntu 22.04, and CLAUDE.md pins Ubuntu 24.04) we'd skip the v2
+    file and read /proc/meminfo, which reports the host's memory not
+    the cgroup limit.  That's still useful as a coarse upper bound;
+    misconfigurations report a too-large value but the cap clamp keeps
+    us safe.
+    """
+    try:
+        v2 = Path("/sys/fs/cgroup/memory.max")
+        if v2.exists():
+            raw = v2.read_text().strip()
+            if raw and raw != "max":
+                return int(raw) // (1024 * 1024)
+    except Exception:
+        pass
+    try:
+        for line in Path("/proc/meminfo").read_text().splitlines():
+            if line.startswith("MemTotal:"):
+                # Format: ``MemTotal:       16389184 kB``
+                return int(line.split()[1]) // 1024
+    except Exception:
+        pass
+    return None
+
+
+def _max_from_memory(total_mb: int | None) -> int:
+    """Pure helper — derive a safe cap from a known memory size.
+
+    Split out from :func:`_autodetect_default_max_browsers` so the
+    resolver can share a single ``_detect_total_memory_mb`` reading
+    with its log line, and so tests can exercise the math without
+    mocking ``Path``.
+
+    Math: ``(total_mem_mb - headroom_mb) // mem_per_browser_mb``,
+    clamped to ``[1, _MAX_CAP]``.
+
+    * ``None`` total → :data:`_FALLBACK_DEFAULT` (probes failed,
+      typically a non-Linux dev environment)
+    * available < one browser's budget → 1 (don't fail closed at 0)
+    """
+    if total_mb is None:
+        return _FALLBACK_DEFAULT
+    available = total_mb - _HEADROOM_MB
+    if available < _MEM_PER_BROWSER_MB:
+        # Tiny box — give one browser slot so the service can still
+        # serve a single agent rather than failing closed at zero.
+        return 1
+    return max(1, min(_MAX_CAP, available // _MEM_PER_BROWSER_MB))
+
+
+def _autodetect_default_max_browsers() -> int:
+    """Estimate a safe default cap from observable memory.
+
+    Used only when neither ``OPENLEGION_BROWSER_MAX_CONCURRENT`` nor
+    ``MAX_BROWSERS`` is set — i.e. self-host installs that haven't
+    tuned anything.  Hetzner-provisioned VPSes get the cap from the
+    provisioner, which always wins over the autodetect (the env-var
+    layer is checked first in :func:`_resolve_max_browsers`).
+
+    Reference table:
+
+    * 4 GB box   → (4096 − 3072) / 450 = 2 browsers
+    * 8 GB box   → (8192 − 3072) / 450 = 11 browsers
+    * 16 GB box  → (16384 − 3072) / 450 = 29 browsers
+    * 32 GB box  → (32768 − 3072) / 450 = 64 (clamped)
+    """
+    return _max_from_memory(_detect_total_memory_mb())
+
+
 def _resolve_max_browsers() -> int:
     """Return the per-service browser concurrency cap.
 
@@ -42,24 +141,48 @@ def _resolve_max_browsers() -> int:
     review flagged the runtime path's complexity.
 
     Precedence (highest → lowest):
-      1. ``OPENLEGION_BROWSER_MAX_CONCURRENT`` — canonical name, listed in
-         :data:`src.browser.flags.KNOWN_FLAGS`.
+      1. ``OPENLEGION_BROWSER_MAX_CONCURRENT`` — canonical name, set by
+         the provisioner per VPS plan and overridable by self-hosters.
+         Listed in :data:`src.browser.flags.KNOWN_FLAGS`.
       2. ``MAX_BROWSERS`` — legacy name kept for back-compat with existing
          deployments / Docker compose files. Removable after one release.
-      3. Default of 5.
+      3. Memory-derived autodetect (:func:`_autodetect_default_max_browsers`).
+         Replaces the previous hardcoded ``5`` floor — a 4 GB laptop and
+         a 32 GB VPS deserve different defaults.
     """
     from src.browser.flags import get_int
 
+    # Read memory once and forward the result so the autodetect helper
+    # and the log line stay consistent — calling _detect_total_memory_mb
+    # twice was harmless but cosmetically inconsistent (a thread or
+    # cgroup change between calls could disagree).
+    total_mb = _detect_total_memory_mb()
+    autodetected = _max_from_memory(total_mb)
+
     # ``min_value=1`` rejects nonsense like ``MAX=0`` (would deadlock the
-    # acquire loop). ``max_value=64`` is a soft ceiling — a single VPS won't
-    # have RAM for that many Camoufox instances anyway.
-    legacy_default = get_int("MAX_BROWSERS", 5, min_value=1, max_value=64)
-    return get_int(
+    # acquire loop). ``max_value=64`` matches the display-allocator pool
+    # ceiling — raising one without the other would cause allocator
+    # exhaustion under per-agent display mode.
+    legacy_default = get_int(
+        "MAX_BROWSERS", autodetected, min_value=1, max_value=_MAX_CAP,
+    )
+    final = get_int(
         "OPENLEGION_BROWSER_MAX_CONCURRENT",
         legacy_default,
         min_value=1,
-        max_value=64,
+        max_value=_MAX_CAP,
     )
+    # Single log line carrying both the resolved cap and the autodetect
+    # baseline, so an operator can tell at a glance whether the env
+    # override is doing what they expect.  ``memory_mb=None`` means the
+    # autodetect probes failed (typically a non-Linux dev environment),
+    # in which case ``autodetected`` is the conservative fallback.
+    suffix = " (env override)" if final != autodetected else ""
+    logger.info(
+        "Browser cap: %d%s — autodetect=%d, memory=%s MB",
+        final, suffix, autodetected, total_mb,
+    )
+    return final
 
 
 _MAX_BROWSERS = _resolve_max_browsers()

--- a/src/browser/server.py
+++ b/src/browser/server.py
@@ -16,9 +16,9 @@ import uuid
 from pathlib import Path
 
 from fastapi import FastAPI, HTTPException, Request
-from fastapi.responses import StreamingResponse
+from fastapi.responses import JSONResponse, StreamingResponse
 
-from src.browser.service import BrowserManager
+from src.browser.service import BrowserManager, BrowserPoolExhausted
 from src.shared.trace import TRACE_HEADER, current_trace_id
 from src.shared.utils import setup_logging
 
@@ -46,6 +46,29 @@ def create_browser_app(manager: BrowserManager, lifespan=None) -> FastAPI:
         finally:
             if token is not None:
                 current_trace_id.reset(token)
+
+    # Cap-exhausted handler — converts the typed exception raised by
+    # ``BrowserManager.get_or_start`` into a structured 503 with
+    # ``Retry-After``.  Installed once per app so every endpoint that
+    # transitively calls ``get_or_start`` gets uniform treatment instead
+    # of needing its own try/except.  The agent-side mesh client and the
+    # LLM downstream see ``error="browser_pool_full"`` plus a numeric
+    # cap and retry hint — enough signal to decide whether to wait,
+    # stop a different agent, or escalate.
+    @app.exception_handler(BrowserPoolExhausted)
+    async def _browser_pool_exhausted_handler(
+        request: Request, exc: BrowserPoolExhausted,
+    ):
+        return JSONResponse(
+            status_code=503,
+            headers={"Retry-After": str(exc.retry_after_s)},
+            content={
+                "error": "browser_pool_full",
+                "message": str(exc),
+                "cap": exc.cap,
+                "retry_after_s": exc.retry_after_s,
+            },
+        )
 
     auth_token = os.environ.get("BROWSER_AUTH_TOKEN", "")
     if not auth_token:

--- a/src/browser/service.py
+++ b/src/browser/service.py
@@ -68,6 +68,38 @@ from src.shared.utils import sanitize_for_prompt, setup_logging
 logger = setup_logging("browser.service")
 
 
+class BrowserPoolExhausted(RuntimeError):
+    """Raised when the per-service concurrent-browser cap is reached.
+
+    Replaced the previous silent-LRU-eviction behaviour: hitting the cap
+    used to kill the least-recently-used agent's browser to make room
+    for the new one — destroying its session, cookies, captcha state,
+    and login without surfacing anything beyond an INFO log.  That
+    fails closed for the operator (silent data loss) and silently
+    degrades the user experience under load.
+
+    Refusal lets the caller decide what to do: wait, retry, stop a
+    different agent, or raise visibility to the operator.  The browser
+    service FastAPI app installs an exception handler that converts
+    this to HTTP 503 with ``Retry-After`` and a structured envelope —
+    the agent's model sees ``error="browser_pool_full"`` instead of an
+    opaque 500 and can react.
+
+    The cap itself comes from ``OPENLEGION_BROWSER_MAX_CONCURRENT``;
+    the provisioner sets it per VPS plan, self-hosters can override
+    via env, and the engine auto-detects a sane floor from container
+    memory (see :func:`src.browser.__main__._resolve_max_browsers`).
+    """
+
+    def __init__(self, *, cap: int, retry_after_s: int = 60):
+        self.cap = cap
+        self.retry_after_s = retry_after_s
+        super().__init__(
+            f"Browser pool full (cap={cap}); stop an agent or wait "
+            f"~{retry_after_s}s for an idle slot",
+        )
+
+
 # ── §11.13 structured CAPTCHA detection envelope ──────────────────────────
 # Both helpers below produce literal-string enums (see plan §11.13). We do
 # NOT use Python ``enum.Enum``: the wire format is JSON strings, and a real
@@ -3306,12 +3338,19 @@ class BrowserManager:
                 inst.touch()
                 return inst
 
-            # Enforce max concurrent
+            # Enforce max concurrent — refuse rather than silently evict.
+            # Silent LRU eviction (the previous behaviour) destroyed the
+            # oldest agent's session/cookies/captcha state with only an
+            # INFO log to show for it; refusing surfaces the cap so the
+            # caller can stop a different agent or wait for the idle
+            # cleanup to free a slot.
             if len(self._instances) >= self.max_concurrent:
-                # Stop least recently used
-                oldest_id = min(self._instances, key=lambda a: self._instances[a].last_activity)
-                logger.info("Max browsers reached, stopping LRU '%s'", oldest_id)
-                await self._stop_instance(oldest_id)
+                logger.warning(
+                    "Browser pool full (cap=%d, %d running); refusing "
+                    "to start '%s'",
+                    self.max_concurrent, len(self._instances), agent_id,
+                )
+                raise BrowserPoolExhausted(cap=self.max_concurrent)
 
             # Start while holding lock to prevent duplicate instances for same agent
             instance = await self._start_browser(agent_id)

--- a/tests/test_browser_max_concurrent_autodetect.py
+++ b/tests/test_browser_max_concurrent_autodetect.py
@@ -1,0 +1,301 @@
+"""Tests for the browser cap autodetect logic in :mod:`src.browser.__main__`.
+
+Covers:
+  * autodetect math at representative box sizes (4/8/16/32 GB)
+  * cgroups v2 path takes precedence over /proc/meminfo
+  * graceful fallback when both probes fail
+  * ``OPENLEGION_BROWSER_MAX_CONCURRENT`` env override beats autodetect
+  * legacy ``MAX_BROWSERS`` env override also wins over autodetect
+  * clamp to [1, 64]
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from src.browser.__main__ import (
+    _FALLBACK_DEFAULT,
+    _MAX_CAP,
+    _autodetect_default_max_browsers,
+    _detect_total_memory_mb,
+    _max_from_memory,
+    _resolve_max_browsers,
+)
+
+
+class TestMaxFromMemory:
+    """Tests for the pure :func:`_max_from_memory` helper.
+
+    No filesystem mocking required — these exercise the math directly.
+    Reading /proc/meminfo is tested separately in :class:`TestMemoryDetection`.
+    """
+
+    @pytest.mark.parametrize("total_mb,expected", [
+        (4 * 1024, 2),    # 4 GB box → 2 browsers
+        (8 * 1024, 11),   # 8 GB box → 11 browsers
+        (16 * 1024, 29),  # 16 GB box → 29 browsers
+        (32 * 1024, 64),  # 32 GB box → clamped at 64
+        (64 * 1024, 64),  # 64 GB box → still clamped
+    ])
+    def test_math_at_typical_sizes(self, total_mb, expected):
+        assert _max_from_memory(total_mb) == expected
+
+    def test_tiny_box_gets_minimum_one(self):
+        """A 2 GB box (below the 3 GB headroom) still gets 1 browser slot.
+
+        We never want to fail closed at zero — a single working browser
+        is more useful than a clean refusal at startup.
+        """
+        assert _max_from_memory(2 * 1024) == 1
+
+    def test_exactly_headroom_gets_minimum_one(self):
+        """At exactly headroom, available is 0 → still get 1."""
+        from src.browser.__main__ import _HEADROOM_MB
+        assert _max_from_memory(_HEADROOM_MB) == 1
+
+    def test_below_headroom_gets_minimum_one(self):
+        """Below headroom (negative available) → still get 1, not crash."""
+        from src.browser.__main__ import _HEADROOM_MB
+        assert _max_from_memory(_HEADROOM_MB - 100) == 1
+
+    def test_none_returns_fallback(self):
+        """``None`` total (detection failure) → conservative fallback."""
+        assert _max_from_memory(None) == _FALLBACK_DEFAULT
+
+    def test_clamp_respects_max_cap_constant(self):
+        """Sanity check the clamp uses _MAX_CAP, not a hardcoded number."""
+        assert _max_from_memory(1024 * 1024) == _MAX_CAP
+
+    def test_just_enough_for_two_browsers(self):
+        """Boundary: exactly 2 browsers' worth of available memory → 2."""
+        from src.browser.__main__ import _HEADROOM_MB, _MEM_PER_BROWSER_MB
+        assert _max_from_memory(_HEADROOM_MB + 2 * _MEM_PER_BROWSER_MB) == 2
+
+
+class TestMemoryDetection:
+    """Tests for :func:`_detect_total_memory_mb`."""
+
+    def test_cgroups_v2_path_wins(self, tmp_path):
+        """When /sys/fs/cgroup/memory.max has a numeric value, use it."""
+        cgroup = tmp_path / "memory.max"
+        # 8 GB in bytes.
+        cgroup.write_text(str(8 * 1024 * 1024 * 1024) + "\n")
+        with patch(
+            "src.browser.__main__.Path",
+            side_effect=lambda p: cgroup if p == "/sys/fs/cgroup/memory.max" else Path(p),
+        ):
+            mb = _detect_total_memory_mb()
+        assert mb == 8 * 1024  # 8 GB == 8192 MB
+
+    def test_cgroups_v2_unbounded_falls_through(self, tmp_path):
+        """``memory.max == 'max'`` means no limit; fall through to meminfo."""
+        cgroup = tmp_path / "memory.max"
+        cgroup.write_text("max\n")
+        meminfo = tmp_path / "meminfo"
+        # 4 GB in kB.
+        meminfo.write_text("MemTotal:       4194304 kB\nSomeOther:    foo\n")
+
+        def _path_factory(p):
+            if p == "/sys/fs/cgroup/memory.max":
+                return cgroup
+            if p == "/proc/meminfo":
+                return meminfo
+            return Path(p)
+
+        with patch("src.browser.__main__.Path", side_effect=_path_factory):
+            mb = _detect_total_memory_mb()
+        assert mb == 4 * 1024
+
+    def test_cgroups_v2_garbage_falls_through(self, tmp_path):
+        """A non-numeric, non-'max' memory.max value should fall through.
+
+        Hostile / malformed cgroup files (e.g. truncated reads, unicode
+        garbage) would otherwise raise ValueError on ``int()`` and crash
+        startup if uncaught.  The handler swallows + falls through.
+        """
+        cgroup = tmp_path / "memory.max"
+        cgroup.write_text("not a number\n")
+        meminfo = tmp_path / "meminfo"
+        meminfo.write_text("MemTotal:       8388608 kB\n")  # 8 GB
+
+        def _path_factory(p):
+            if p == "/sys/fs/cgroup/memory.max":
+                return cgroup
+            if p == "/proc/meminfo":
+                return meminfo
+            return Path(p)
+
+        with patch("src.browser.__main__.Path", side_effect=_path_factory):
+            mb = _detect_total_memory_mb()
+        # Garbage in v2 → fell through to meminfo, which had 8 GB.
+        assert mb == 8 * 1024
+
+    def test_no_cgroups_meminfo_fallback(self, tmp_path):
+        """No cgroups file → use /proc/meminfo."""
+        nonexistent = tmp_path / "nope"
+        meminfo = tmp_path / "meminfo"
+        meminfo.write_text("MemTotal:       16777216 kB\n")  # 16 GB
+
+        def _path_factory(p):
+            if p == "/sys/fs/cgroup/memory.max":
+                return nonexistent
+            if p == "/proc/meminfo":
+                return meminfo
+            return Path(p)
+
+        with patch("src.browser.__main__.Path", side_effect=_path_factory):
+            mb = _detect_total_memory_mb()
+        assert mb == 16 * 1024
+
+    def test_meminfo_without_memtotal_returns_none(self, tmp_path):
+        """A /proc/meminfo missing MemTotal returns None (caller falls
+        through to fallback default)."""
+        nonexistent = tmp_path / "nope"
+        meminfo = tmp_path / "meminfo"
+        meminfo.write_text("Buffers:    1234 kB\nCached:    5678 kB\n")
+
+        def _path_factory(p):
+            if p == "/sys/fs/cgroup/memory.max":
+                return nonexistent
+            if p == "/proc/meminfo":
+                return meminfo
+            return Path(p)
+
+        with patch("src.browser.__main__.Path", side_effect=_path_factory):
+            mb = _detect_total_memory_mb()
+        assert mb is None
+
+    def test_meminfo_garbage_memtotal_returns_none(self, tmp_path):
+        """A MemTotal line with non-numeric value returns None safely."""
+        nonexistent = tmp_path / "nope"
+        meminfo = tmp_path / "meminfo"
+        meminfo.write_text("MemTotal:       garbage kB\n")
+
+        def _path_factory(p):
+            if p == "/sys/fs/cgroup/memory.max":
+                return nonexistent
+            if p == "/proc/meminfo":
+                return meminfo
+            return Path(p)
+
+        with patch("src.browser.__main__.Path", side_effect=_path_factory):
+            mb = _detect_total_memory_mb()
+        assert mb is None
+
+    def test_returns_none_when_both_probes_fail(self, tmp_path):
+        """No probe succeeds → None, callers fall through to safe default."""
+        nonexistent = tmp_path / "nope"
+
+        def _path_factory(p):
+            return nonexistent
+
+        with patch("src.browser.__main__.Path", side_effect=_path_factory):
+            mb = _detect_total_memory_mb()
+        assert mb is None
+
+
+class TestAutodetectDefault:
+    """End-to-end :func:`_autodetect_default_max_browsers` — the real
+    function used by the resolver.  Math is delegated to
+    :func:`_max_from_memory` (covered above); this just verifies the
+    composition of probe + math."""
+
+    def test_with_known_memory(self):
+        with patch(
+            "src.browser.__main__._detect_total_memory_mb",
+            return_value=8 * 1024,
+        ):
+            assert _autodetect_default_max_browsers() == 11
+
+    def test_falls_back_when_detection_fails(self):
+        with patch(
+            "src.browser.__main__._detect_total_memory_mb",
+            return_value=None,
+        ):
+            assert _autodetect_default_max_browsers() == _FALLBACK_DEFAULT
+
+
+class TestResolveMaxBrowsers:
+    """Tests for the public :func:`_resolve_max_browsers` precedence chain.
+
+    Patch :func:`_detect_total_memory_mb` (the actual probe) rather than
+    the autodetect helper, because the resolver now reads memory once
+    and forwards the value through :func:`_max_from_memory`.  Patching
+    the probe exercises the real composition end-to-end.
+    """
+
+    def test_canonical_env_wins_over_autodetect(self, monkeypatch):
+        """``OPENLEGION_BROWSER_MAX_CONCURRENT`` is the explicit-override path
+        the provisioner uses; it must win over both legacy and autodetect."""
+        monkeypatch.setenv("OPENLEGION_BROWSER_MAX_CONCURRENT", "20")
+        monkeypatch.delenv("MAX_BROWSERS", raising=False)
+        with patch(
+            "src.browser.__main__._detect_total_memory_mb",
+            return_value=4 * 1024,  # autodetects to 2
+        ):
+            assert _resolve_max_browsers() == 20
+
+    def test_legacy_env_wins_over_autodetect(self, monkeypatch):
+        """``MAX_BROWSERS`` (legacy name) still works when canonical unset."""
+        monkeypatch.delenv("OPENLEGION_BROWSER_MAX_CONCURRENT", raising=False)
+        monkeypatch.setenv("MAX_BROWSERS", "12")
+        with patch(
+            "src.browser.__main__._detect_total_memory_mb",
+            return_value=4 * 1024,
+        ):
+            assert _resolve_max_browsers() == 12
+
+    def test_autodetect_used_when_no_env(self, monkeypatch):
+        """Self-host path: no env → autodetect is the floor.
+
+        16 GB box autodetects to 29 — verify that's what we get when
+        no override is in play.
+        """
+        monkeypatch.delenv("OPENLEGION_BROWSER_MAX_CONCURRENT", raising=False)
+        monkeypatch.delenv("MAX_BROWSERS", raising=False)
+        with patch(
+            "src.browser.__main__._detect_total_memory_mb",
+            return_value=16 * 1024,
+        ):
+            assert _resolve_max_browsers() == 29
+
+    def test_canonical_env_overrides_legacy(self, monkeypatch):
+        """When both are set, the canonical name takes precedence."""
+        monkeypatch.setenv("OPENLEGION_BROWSER_MAX_CONCURRENT", "30")
+        monkeypatch.setenv("MAX_BROWSERS", "5")
+        with patch(
+            "src.browser.__main__._detect_total_memory_mb",
+            return_value=4 * 1024,
+        ):
+            assert _resolve_max_browsers() == 30
+
+    def test_clamp_applies_to_env_overrides(self, monkeypatch):
+        """``OPENLEGION_BROWSER_MAX_CONCURRENT=999`` clamps to 64, not crash."""
+        monkeypatch.setenv("OPENLEGION_BROWSER_MAX_CONCURRENT", "999")
+        with patch(
+            "src.browser.__main__._detect_total_memory_mb",
+            return_value=4 * 1024,
+        ):
+            assert _resolve_max_browsers() == _MAX_CAP
+
+    def test_clamp_rejects_zero(self, monkeypatch):
+        """``MAX=0`` would deadlock; min clamp = 1."""
+        monkeypatch.setenv("OPENLEGION_BROWSER_MAX_CONCURRENT", "0")
+        with patch(
+            "src.browser.__main__._detect_total_memory_mb",
+            return_value=8 * 1024,
+        ):
+            assert _resolve_max_browsers() == 1
+
+    def test_falls_back_to_default_when_memory_undetectable(self, monkeypatch):
+        """Detection failure + no env override → :data:`_FALLBACK_DEFAULT`."""
+        monkeypatch.delenv("OPENLEGION_BROWSER_MAX_CONCURRENT", raising=False)
+        monkeypatch.delenv("MAX_BROWSERS", raising=False)
+        with patch(
+            "src.browser.__main__._detect_total_memory_mb",
+            return_value=None,
+        ):
+            assert _resolve_max_browsers() == _FALLBACK_DEFAULT

--- a/tests/test_browser_service.py
+++ b/tests/test_browser_service.py
@@ -1272,42 +1272,210 @@ class TestEvaluate:
         assert "failed" in result["error"].lower()
 
 
-class TestLRUEviction:
-    """Tests for max_concurrent browser eviction."""
+class TestPoolExhaustion:
+    """Tests for max_concurrent enforcement.
+
+    Behaviour change (was silent LRU eviction): when the cap is reached,
+    ``get_or_start`` now raises :class:`BrowserPoolExhausted` rather than
+    killing the oldest agent's session to make room.  Silent eviction
+    destroyed cookies/captcha/login state with only an INFO log; the
+    typed exception lets callers see the cap and decide what to do.
+    """
 
     @pytest.mark.asyncio
-    async def test_lru_eviction(self):
-        """When max concurrent is reached, least recently used should be stopped."""
+    async def test_refuses_when_cap_reached(self):
+        """At cap, a new agent's request raises BrowserPoolExhausted."""
         import time
 
-        from src.browser.service import BrowserManager, CamoufoxInstance
+        from src.browser.service import (
+            BrowserManager,
+            BrowserPoolExhausted,
+            CamoufoxInstance,
+        )
 
         mgr = BrowserManager(profiles_dir="/tmp/test_profiles", max_concurrent=2)
 
-        # Add two instances — a1 is older
+        # Two existing instances → at cap.
         ctx_a1 = AsyncMock()
         inst_a1 = CamoufoxInstance("a1", MagicMock(), ctx_a1, MagicMock())
-        inst_a1.last_activity = time.time() - 100  # older
+        inst_a1.last_activity = time.time() - 100
         mgr._instances["a1"] = inst_a1
 
         ctx_a2 = AsyncMock()
         inst_a2 = CamoufoxInstance("a2", MagicMock(), ctx_a2, MagicMock())
-        inst_a2.last_activity = time.time()  # newer
+        inst_a2.last_activity = time.time()
         mgr._instances["a2"] = inst_a2
 
-        # Mock _start_browser so get_or_start can create a3
-        mock_page = AsyncMock()
-        mock_page.bring_to_front = AsyncMock()
-        new_inst = CamoufoxInstance("a3", MagicMock(), AsyncMock(), mock_page)
-        mgr._start_browser = AsyncMock(return_value=new_inst)
+        # Stub _start_browser; if the refusal path is wrong this test
+        # would silently pass with eviction, so we assert it was NEVER
+        # called below.
+        mgr._start_browser = AsyncMock()
 
-        await mgr.get_or_start("a3")
+        with pytest.raises(BrowserPoolExhausted) as excinfo:
+            await mgr.get_or_start("a3")
 
-        # a1 (oldest) should have been evicted
-        assert "a1" not in mgr._instances
+        # Cap and retry hint surfaced on the exception so the FastAPI
+        # handler can build a structured 503 envelope without parsing
+        # the message string.
+        assert excinfo.value.cap == 2
+        assert excinfo.value.retry_after_s > 0
+        # Critical: the existing agents' sessions were preserved.
+        assert "a1" in mgr._instances
         assert "a2" in mgr._instances
-        assert "a3" in mgr._instances
-        ctx_a1.close.assert_called_once()
+        ctx_a1.close.assert_not_called()
+        ctx_a2.close.assert_not_called()
+        # And the new browser was never started — no half-up state.
+        mgr._start_browser.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_existing_agent_request_still_succeeds_at_cap(self):
+        """Asking for an already-running agent at cap returns the existing one."""
+        from src.browser.service import BrowserManager, CamoufoxInstance
+
+        mgr = BrowserManager(profiles_dir="/tmp/test_profiles", max_concurrent=2)
+        inst = CamoufoxInstance("a1", MagicMock(), AsyncMock(), MagicMock())
+        mgr._instances["a1"] = inst
+        # Pad to cap.
+        mgr._instances["a2"] = CamoufoxInstance(
+            "a2", MagicMock(), AsyncMock(), MagicMock(),
+        )
+
+        result = await mgr.get_or_start("a1")
+        assert result is inst
+
+    def test_pool_exhausted_returns_503_with_envelope(self):
+        """FastAPI handler converts the exception to a structured 503."""
+        from starlette.testclient import TestClient
+
+        from src.browser.server import create_browser_app
+        from src.browser.service import BrowserManager, BrowserPoolExhausted
+
+        mgr = BrowserManager(profiles_dir="/tmp/test_profiles")
+        app = create_browser_app(mgr)
+
+        # Inject a route that raises so we exercise the handler — keeps
+        # the test isolated from any real navigate/click endpoint plumbing.
+        @app.get("/_test_pool_exhausted")
+        async def _raise():
+            raise BrowserPoolExhausted(cap=5, retry_after_s=42)
+
+        client = TestClient(app, raise_server_exceptions=False)
+        resp = client.get("/_test_pool_exhausted")
+        assert resp.status_code == 503
+        assert resp.headers["Retry-After"] == "42"
+        body = resp.json()
+        assert body["error"] == "browser_pool_full"
+        assert body["cap"] == 5
+        assert body["retry_after_s"] == 42
+        assert "Browser pool full" in body["message"]
+
+    @pytest.mark.asyncio
+    async def test_idle_cleanup_releases_slot_under_cap(self):
+        """The natural pressure-release: an idle browser cleaned up
+        frees a slot, so the next get_or_start succeeds.
+
+        This is the recovery mechanism that replaces silent LRU
+        eviction.  Operators don't have to do anything — agents that
+        haven't been used in :data:`idle_timeout_minutes` get reaped
+        and their slots return to the pool.
+        """
+        import time
+
+        from src.browser.service import (
+            BrowserManager,
+            BrowserPoolExhausted,
+            CamoufoxInstance,
+        )
+
+        mgr = BrowserManager(
+            profiles_dir="/tmp/test_profiles",
+            max_concurrent=2,
+            idle_timeout_minutes=1,
+        )
+        # Pre-populate at cap with one stale, one fresh.
+        ctx_stale = AsyncMock()
+        stale = CamoufoxInstance("stale", MagicMock(), ctx_stale, MagicMock())
+        stale.last_activity = time.time() - 600  # well past 1-min timeout
+        mgr._instances["stale"] = stale
+
+        ctx_fresh = AsyncMock()
+        fresh = CamoufoxInstance("fresh", MagicMock(), ctx_fresh, MagicMock())
+        fresh.last_activity = time.time()
+        mgr._instances["fresh"] = fresh
+
+        # At cap → new agent refused.
+        with pytest.raises(BrowserPoolExhausted):
+            await mgr.get_or_start("newcomer")
+
+        # Idle cleanup runs (the background loop calls this periodically).
+        await mgr._cleanup_idle()
+        assert "stale" not in mgr._instances
+        assert "fresh" in mgr._instances
+
+        # Now there's room.  Stub _start_browser so the success path
+        # doesn't actually try to launch Camoufox.
+        new_inst = CamoufoxInstance(
+            "newcomer", MagicMock(), AsyncMock(), AsyncMock(),
+        )
+        mgr._start_browser = AsyncMock(return_value=new_inst)
+        result = await mgr.get_or_start("newcomer")
+        assert result is new_inst
+        assert "newcomer" in mgr._instances
+
+    @pytest.mark.asyncio
+    async def test_stop_then_start_at_cap_succeeds(self):
+        """``stop(X)`` followed by ``get_or_start(Y)`` at cap should
+        succeed.  Validates that explicit operator-driven slot freeing
+        works the same as idle cleanup.
+        """
+        from src.browser.service import BrowserManager, CamoufoxInstance
+
+        mgr = BrowserManager(profiles_dir="/tmp/test_profiles", max_concurrent=2)
+        for aid in ("a", "b"):
+            mgr._instances[aid] = CamoufoxInstance(
+                aid, MagicMock(), AsyncMock(), MagicMock(),
+            )
+
+        # Free a slot the explicit way.
+        await mgr.stop("a")
+        assert "a" not in mgr._instances
+
+        # New agent now fits.
+        new_inst = CamoufoxInstance(
+            "c", MagicMock(), AsyncMock(), AsyncMock(),
+        )
+        mgr._start_browser = AsyncMock(return_value=new_inst)
+        result = await mgr.get_or_start("c")
+        assert result is new_inst
+
+    @pytest.mark.asyncio
+    async def test_pool_exhaustion_logs_at_warning(self, caplog):
+        """The cap-hit log message is at WARNING so operators monitoring
+        log streams notice it without trawling INFO.  Silent pool
+        exhaustion was a real operational pain point pre-fix; downgrading
+        the log level here would resurrect it.
+        """
+        import logging
+
+        from src.browser.service import (
+            BrowserManager,
+            BrowserPoolExhausted,
+            CamoufoxInstance,
+        )
+
+        mgr = BrowserManager(profiles_dir="/tmp/test_profiles", max_concurrent=1)
+        mgr._instances["a"] = CamoufoxInstance(
+            "a", MagicMock(), AsyncMock(), MagicMock(),
+        )
+
+        with caplog.at_level(logging.WARNING, logger="browser.service"):
+            with pytest.raises(BrowserPoolExhausted):
+                await mgr.get_or_start("b")
+
+        assert any(
+            "Browser pool full" in r.message and r.levelno == logging.WARNING
+            for r in caplog.records
+        )
 
 
 class TestIdleCleanup:

--- a/tests/test_dashboard_browser_metrics.py
+++ b/tests/test_dashboard_browser_metrics.py
@@ -603,12 +603,28 @@ class TestBrowserMetricsEventBusContract:
 
 
 class TestMaxConcurrentEnvVar:
-    """Phase 7 §10.2 — startup-only ``OPENLEGION_BROWSER_MAX_CONCURRENT``."""
+    """Phase 7 §10.2 — startup-only ``OPENLEGION_BROWSER_MAX_CONCURRENT``.
+
+    These tests exercise the env-var precedence chain.  We mock
+    ``_detect_total_memory_mb`` to ``None`` so the autodetect fallback
+    deterministically returns :data:`_FALLBACK_DEFAULT` (5) regardless
+    of the host the test runs on — CI runners report large memory
+    sizes via /proc/meminfo and would otherwise produce machine-
+    dependent autodetect results.
+    """
+
+    @staticmethod
+    def _patch_no_memory():
+        """Force the autodetect probes to report None (CI-stable)."""
+        return mock.patch(
+            "src.browser.__main__._detect_total_memory_mb",
+            return_value=None,
+        )
 
     def test_default_when_unset(self):
         # Importing inside the test so each invocation gets a fresh read
         # against the patched environment.
-        with mock.patch.dict(os.environ, {}, clear=False):
+        with mock.patch.dict(os.environ, {}, clear=False), self._patch_no_memory():
             os.environ.pop("OPENLEGION_BROWSER_MAX_CONCURRENT", None)
             os.environ.pop("MAX_BROWSERS", None)
             from src.browser.__main__ import _resolve_max_browsers
@@ -618,12 +634,12 @@ class TestMaxConcurrentEnvVar:
         with mock.patch.dict(os.environ, {
             "OPENLEGION_BROWSER_MAX_CONCURRENT": "12",
             "MAX_BROWSERS": "3",
-        }):
+        }), self._patch_no_memory():
             from src.browser.__main__ import _resolve_max_browsers
             assert _resolve_max_browsers() == 12
 
     def test_legacy_var_used_when_canonical_unset(self):
-        with mock.patch.dict(os.environ, {"MAX_BROWSERS": "9"}, clear=False):
+        with mock.patch.dict(os.environ, {"MAX_BROWSERS": "9"}, clear=False), self._patch_no_memory():
             os.environ.pop("OPENLEGION_BROWSER_MAX_CONCURRENT", None)
             from src.browser.__main__ import _resolve_max_browsers
             assert _resolve_max_browsers() == 9
@@ -631,29 +647,29 @@ class TestMaxConcurrentEnvVar:
     def test_clamped_to_min(self):
         with mock.patch.dict(os.environ, {
             "OPENLEGION_BROWSER_MAX_CONCURRENT": "0",
-        }):
+        }), self._patch_no_memory():
             from src.browser.__main__ import _resolve_max_browsers
             assert _resolve_max_browsers() == 1  # clamped up
 
     def test_clamped_to_max(self):
         with mock.patch.dict(os.environ, {
             "OPENLEGION_BROWSER_MAX_CONCURRENT": "9999",
-        }):
+        }), self._patch_no_memory():
             from src.browser.__main__ import _resolve_max_browsers
             assert _resolve_max_browsers() == 64  # clamped down
 
     def test_garbage_falls_back_to_default(self):
         with mock.patch.dict(os.environ, {
             "OPENLEGION_BROWSER_MAX_CONCURRENT": "not-a-number",
-        }):
+        }), self._patch_no_memory():
             os.environ.pop("MAX_BROWSERS", None)
             from src.browser.__main__ import _resolve_max_browsers
             # flags.get_int falls back to its default (legacy) which is 5
-            # when MAX_BROWSERS is also absent.
+            # via the autodetect fallback when MAX_BROWSERS is also absent.
             assert _resolve_max_browsers() == 5
 
     def test_garbage_legacy_var_does_not_crash_import(self):
-        with mock.patch.dict(os.environ, {"MAX_BROWSERS": "not-a-number"}):
+        with mock.patch.dict(os.environ, {"MAX_BROWSERS": "not-a-number"}), self._patch_no_memory():
             os.environ.pop("OPENLEGION_BROWSER_MAX_CONCURRENT", None)
             from src.browser.__main__ import _resolve_max_browsers
 


### PR DESCRIPTION
## Summary

Fixes two related browser-pool issues: silent LRU eviction at the cap (data loss) and a hardcoded default of 5 (wrong for both 4 GB laptops and 16+ GB VPSes).

## Changes

**Refusal not eviction** — `BrowserManager.get_or_start` raises `BrowserPoolExhausted` instead of killing the LRU agent's browser. New FastAPI exception handler returns HTTP 503 with `Retry-After`, structured `{ error, cap, retry_after_s, message }` envelope. Models see `error="browser_pool_full"` and can react.

**Memory-derived default** — replaces hardcoded 5 with `(total_mem_mb - 3072) / 450`, clamped to [1, 64]. cgroups v2 first, `/proc/meminfo` fallback. Self-host on 16 GB → 29; on 4 GB → 2; non-Linux → 5 (legacy fallback). Provisioner-set `OPENLEGION_BROWSER_MAX_CONCURRENT` always wins.

**Improved log line** — single message showing both resolved cap and autodetect baseline with `(env override)` indicator.

## Why

- Pro plan customers were silently capped at 5 despite `plans.ts` declaring `browsers=10`. (Cross-repo plumbing PR follows in app+provisioner.)
- Silent LRU eviction destroyed sessions/captcha state/cookies with only an INFO log. Operators had no signal pool exhaustion was happening.

## Test plan

- [x] 27 new autodetect tests (`tests/test_browser_max_concurrent_autodetect.py`) covering math at 4/8/16/32 GB, malformed `memory.max`, malformed `/proc/meminfo`, missing MemTotal, env precedence chain, clamp bounds.
- [x] 6 new `TestPoolExhaustion` tests: refusal at cap, existing-agent passthrough, structured 503 envelope, idle-cleanup pressure release, stop-then-start at cap, WARNING-level log regression guard.
- [x] Full `tests/test_browser_service.py` (456 pass) — zero regressions vs. main.
- [ ] CI green