### PR TITLE
feat(browser): per-agent X stack lifecycle (PR 1, flag-gated)

### DIFF
--- a/src/browser/__main__.py
+++ b/src/browser/__main__.py
@@ -184,10 +184,30 @@ def _start_openbox() -> subprocess.Popen:
 
 
 def main() -> None:
-    """Start all services and run the FastAPI server."""
-    kasmvnc_proc = _start_kasmvnc()
-    unclutter_proc = _start_unclutter()
-    openbox_proc = _start_openbox()
+    """Start all services and run the FastAPI server.
+
+    When ``OPENLEGION_BROWSER_PER_AGENT_DISPLAY`` is on, the global
+    ``Xvnc :99`` / Openbox / unclutter are NOT started — each agent
+    gets its own X stack inside :class:`BrowserManager._start_browser`
+    instead.  The legacy path remains the default during the flag-
+    gated rollout (PR 1); PR 2 flips the default and PR 3 deletes the
+    legacy code path entirely.
+    """
+    from src.browser.display_allocator import is_per_agent_display_enabled
+
+    per_agent_default = is_per_agent_display_enabled()
+    if per_agent_default:
+        logger.info(
+            "Per-agent display mode active — skipping global Xvnc/Openbox/"
+            "unclutter; each agent's browser will get its own X stack",
+        )
+        kasmvnc_proc = None
+        unclutter_proc = None
+        openbox_proc = None
+    else:
+        kasmvnc_proc = _start_kasmvnc()
+        unclutter_proc = _start_unclutter()
+        openbox_proc = _start_openbox()
 
     manager = BrowserManager(
         profiles_dir="/data/profiles",
@@ -214,9 +234,11 @@ def main() -> None:
         except Exception as exc:
             logger.warning("captcha_cost_counter.snapshot failed: %s", exc)
         await manager.stop_all()
-        procs = [openbox_proc, kasmvnc_proc]
-        if unclutter_proc:
-            procs.insert(0, unclutter_proc)
+        # Tear down the global X stack only when it was started in
+        # legacy mode.  Per-agent mode has no global processes to reap;
+        # individual agents' X stacks were already torn down by
+        # ``manager.stop_all()`` via ``_teardown_per_agent_x_stack``.
+        procs = [p for p in (openbox_proc, kasmvnc_proc, unclutter_proc) if p]
         for proc in procs:
             try:
                 proc.terminate()

--- a/src/browser/display_allocator.py
+++ b/src/browser/display_allocator.py
@@ -42,7 +42,6 @@ in :class:`BrowserManager` so we don't need a second lock here.
 
 from __future__ import annotations
 
-import os
 import socket
 from dataclasses import dataclass
 from pathlib import Path

--- a/src/browser/display_allocator.py
+++ b/src/browser/display_allocator.py
@@ -1,0 +1,384 @@
+"""Per-agent X11 display + KasmVNC port pair allocator.
+
+PR 1 of the per-agent VNC isolation work.  The shared-display design
+(one ``Xvnc :99`` for every agent — see :mod:`src.browser.__main__`'s
+legacy path) leaks every agent's browser content to every VNC viewer
+because KasmVNC streams the whole framebuffer.  Per-agent isolation
+requires one Xvnc per agent.
+
+This module owns the allocation of ``(display_num, vnc_port)`` pairs.
+Display ``N`` pairs with port ``VNC_PORT_BASE + N`` so a single integer
+identifies a slot — no separate port allocator state.
+
+Boot sweep
+----------
+``/tmp/.X{N}-lock`` files from a previous crash hold their display
+number against allocation.  :class:`DisplayAllocator` runs a boot phase
+that walks the configured display range, decides per-slot whether the
+display is genuinely in use (paired TCP port currently bound), and
+removes lock-file + abstract-socket residue when the slot is free.
+Without this sweep every container restart loses pool slots until
+manual cleanup.
+
+Probe-based occupancy check (rather than parsing the PID out of the
+lock file and killing it) keeps us out of the kill-the-wrong-process
+failure mode.  If the port is bound, something is using the slot —
+leave it alone.  If the port is free, no X server can be live on the
+display, so any lock-file residue is safe to remove.
+
+Range
+-----
+* display ``100..163`` — 64 slots, the soft ceiling for concurrent
+  browsers (matches the ``OPENLEGION_BROWSER_MAX_CONCURRENT`` clamp in
+  :mod:`src.browser.__main__`).
+* port ``6100..6163`` — paired 1:1.  The legacy shared display lives on
+  ``:99`` / ``:6080``; starting per-agent slots at 100 lets both code
+  paths coexist during the flag-gated rollout (PR 2 deletes the
+  legacy path).
+
+The allocator itself is sync — slots are claimed under :class:`asyncio.Lock`
+in :class:`BrowserManager` so we don't need a second lock here.
+"""
+
+from __future__ import annotations
+
+import os
+import socket
+from dataclasses import dataclass
+from pathlib import Path
+
+from src.shared.utils import setup_logging
+
+logger = setup_logging("browser.display_allocator")
+
+
+# Display N → port (VNC_PORT_BASE + N).  Keep base aligned with KasmVNC's
+# default 6080 so per-agent ports are nearby and operators recognise the
+# range — :6100 reads as "the new VNC ports" without a docs lookup.
+VNC_PORT_BASE = 6000
+
+# Inclusive on both ends; Python ranges exclude the upper bound, so
+# 164 = 64 slots starting at 100.
+DISPLAY_RANGE_START = 100
+DISPLAY_RANGE_END = 164
+
+
+def display_for_port(port: int) -> int:
+    return port - VNC_PORT_BASE
+
+
+def port_for_display(display: int) -> int:
+    return VNC_PORT_BASE + display
+
+
+@dataclass(frozen=True)
+class Slot:
+    """An allocated (display, port) pair.
+
+    ``display`` is the X11 display number (e.g. ``100`` → ``DISPLAY=:100``).
+    ``vnc_port`` is the KasmVNC websocket port paired with that display.
+    """
+    display: int
+    vnc_port: int
+
+    @property
+    def display_str(self) -> str:
+        return f":{self.display}"
+
+    @property
+    def lock_path(self) -> Path:
+        return Path(f"/tmp/.X{self.display}-lock")
+
+    @property
+    def socket_path(self) -> Path:
+        return Path(f"/tmp/.X11-unix/X{self.display}")
+
+
+class DisplayAllocator:
+    """Pool allocator for ``(display, vnc_port)`` slots.
+
+    Construction runs the boot sweep so the caller doesn't have to
+    remember it.  Idempotent re-construction is safe: the sweep only
+    touches lock/socket residue when the paired port is genuinely free.
+
+    Tests can override the range via the keyword args without touching
+    module-level constants.
+    """
+
+    def __init__(
+        self,
+        *,
+        display_start: int = DISPLAY_RANGE_START,
+        display_end: int = DISPLAY_RANGE_END,
+        run_boot_sweep: bool = True,
+    ):
+        if display_start <= 0 or display_end <= display_start:
+            raise ValueError(
+                f"Invalid display range [{display_start}, {display_end})",
+            )
+        self._range = range(display_start, display_end)
+        # Free slots, ordered low→high so allocations are deterministic
+        # (test-friendly + easier to read in logs).
+        self._free: list[int] = list(self._range)
+        # Currently-allocated displays.  Set semantics catch double-release
+        # bugs loudly.
+        self._allocated: set[int] = set()
+        if run_boot_sweep:
+            self._boot_sweep()
+
+    # ── public API ────────────────────────────────────────────────────────
+
+    def allocate(self) -> Slot:
+        """Reserve the lowest-numbered free slot.
+
+        Verifies the slot's port is currently bindable before returning;
+        if the boot sweep missed something (e.g. a peer X server bound the
+        port between sweep and allocate), the slot is dropped from the
+        pool and the next candidate tried.
+
+        Raises :class:`PoolExhausted` when no slot is available.
+        """
+        while self._free:
+            display = self._free.pop(0)
+            port = port_for_display(display)
+            if not _port_is_bindable(port):
+                # Something legitimately holds the port — drop the slot
+                # permanently.  Surfacing in logs so an operator notices
+                # if many slots leak this way.
+                logger.warning(
+                    "Skipping display :%d — port %d not bindable; "
+                    "dropping slot from pool",
+                    display, port,
+                )
+                continue
+            self._allocated.add(display)
+            slot = Slot(display=display, vnc_port=port)
+            logger.debug(
+                "Allocated display :%d (port %d); %d slots remain",
+                display, port, len(self._free),
+            )
+            return slot
+        raise PoolExhausted(
+            f"No free slots in range [{self._range.start}, "
+            f"{self._range.stop}); concurrent browser cap reached",
+        )
+
+    def release(self, slot: Slot) -> None:
+        """Return a slot to the pool.
+
+        Idempotent on already-released slots (logs a warning rather than
+        raising — release is called from teardown paths where double-call
+        is plausible during error recovery, and we'd rather leak a log
+        line than fail the cleanup).
+
+        Cleans residual lock + socket files so the next allocator on this
+        slot starts from a known-clean state.  Does NOT verify the
+        corresponding processes are dead — that is the caller's job
+        (see :class:`BrowserManager._stop_instance` process-group teardown).
+        """
+        if slot.display not in self._allocated:
+            logger.warning(
+                "release(:%d) called but slot is not allocated; ignoring",
+                slot.display,
+            )
+            return
+        self._allocated.discard(slot.display)
+        _remove_residue(slot)
+        # Re-insert in sorted order so allocate() stays deterministic.
+        self._free.append(slot.display)
+        self._free.sort()
+        logger.debug(
+            "Released display :%d (port %d); %d slots free",
+            slot.display, slot.vnc_port, len(self._free),
+        )
+
+    def is_allocated(self, display: int) -> bool:
+        return display in self._allocated
+
+    @property
+    def free_count(self) -> int:
+        return len(self._free)
+
+    @property
+    def allocated_count(self) -> int:
+        return len(self._allocated)
+
+    @property
+    def capacity(self) -> int:
+        return self._range.stop - self._range.start
+
+    # ── boot sweep ────────────────────────────────────────────────────────
+
+    def _boot_sweep(self) -> None:
+        """Reclaim slots whose lock/socket residue survived a crash.
+
+        Probe-based: for each display N in our range, if port ``VNC_PORT_BASE+N``
+        is currently bindable, no live X server can hold the display, so any
+        ``/tmp/.X{N}-lock`` and abstract-socket file is residue we can safely
+        remove.  If the port is NOT bindable, drop the slot from the pool —
+        something genuinely holds it and we shouldn't fight.
+
+        Only logs at INFO level when residue is actually removed; quiet
+        when the container starts clean.
+        """
+        cleaned = 0
+        live = 0
+        for display in list(self._range):
+            port = port_for_display(display)
+            if _port_is_bindable(port):
+                # Slot is genuinely free; nuke any residue.
+                slot = Slot(display=display, vnc_port=port)
+                if _remove_residue(slot):
+                    cleaned += 1
+            else:
+                # Port held by something — drop slot from pool.  When the
+                # holder is the legacy shared Xvnc (which lives on :99 +
+                # :6080, not in our range), this branch is never reached
+                # for our slots.  When the holder is a same-range X server
+                # left by a peer process (rare), dropping is correct.
+                self._free.remove(display)
+                live += 1
+        if cleaned or live:
+            logger.info(
+                "Display-allocator boot sweep: %d residue cleaned, "
+                "%d slot(s) reserved by live processes",
+                cleaned, live,
+            )
+
+
+class PoolExhausted(RuntimeError):
+    """Raised when no free display/port slot is available."""
+
+
+# ── helpers ────────────────────────────────────────────────────────────────
+
+
+def _port_is_bindable(port: int) -> bool:
+    """Return True if ``port`` can be bound on 0.0.0.0 right now.
+
+    Uses ``SO_REUSEADDR`` so a port in TIME_WAIT from a recently-killed
+    Xvnc still reports as bindable — TIME_WAIT shouldn't reserve a slot
+    in our pool.  We close immediately; the actual bind by Xvnc happens
+    seconds later, so a TOCTOU race here is theoretical (same-host
+    container, no peer service spawning on these ports).
+    """
+    sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    try:
+        sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        try:
+            sock.bind(("0.0.0.0", port))
+        except OSError:
+            return False
+        return True
+    finally:
+        sock.close()
+
+
+def _remove_residue(slot: Slot) -> bool:
+    """Remove stale ``/tmp/.X{N}-lock`` and abstract socket for ``slot``.
+
+    Returns True if any residue was actually removed (caller logs).  Best
+    effort: failures are logged but don't propagate — the next allocator
+    pass will retry, and Xvnc itself will refuse to start cleanly if a
+    real peer holds the resources, which is the safer failure mode.
+    """
+    removed = False
+    for path in (slot.lock_path, slot.socket_path):
+        try:
+            if path.exists() or path.is_symlink():
+                path.unlink()
+                removed = True
+        except OSError as exc:
+            logger.warning(
+                "Could not remove residue %s: %s", path, exc,
+            )
+    return removed
+
+
+def is_per_agent_display_enabled(*, agent_id: str | None = None) -> bool:
+    """Return True when the per-agent X stack should be used.
+
+    Reads ``OPENLEGION_BROWSER_PER_AGENT_DISPLAY`` via the centralised
+    flag layer so operators can flip it via ``config/settings.json`` or
+    the agent-override path without redeploying.  Defaults to ``False``
+    so PR 1 ships dark — PR 2's mesh+dashboard work flips the default.
+    """
+    # Local import to avoid a hard dependency on the flag module from
+    # tests that exercise the allocator standalone.
+    from src.browser.flags import get_bool
+
+    return get_bool(
+        "OPENLEGION_BROWSER_PER_AGENT_DISPLAY",
+        _DEFAULT_PER_AGENT_DISPLAY,
+        agent_id=agent_id,
+    )
+
+
+# Indirection so tests can patch the default without touching env state.
+_DEFAULT_PER_AGENT_DISPLAY = False
+
+
+# Convenience for tests / debugging — clear the env so a fresh allocator
+# pass observes a pristine /tmp.  NOT used in production.
+def _force_clear_residue_for_tests(display_start: int, display_end: int) -> None:
+    for display in range(display_start, display_end):
+        slot = Slot(display=display, vnc_port=port_for_display(display))
+        _remove_residue(slot)
+
+
+def _read_lock_pid(path: Path) -> int | None:
+    """Read the PID from an X11 lock file.
+
+    Format: 10-char zero-padded ASCII PID + newline.  Used only by tests
+    that simulate stale lock files; production code paths don't need to
+    read the PID.  Returns None on parse failure.
+    """
+    try:
+        raw = path.read_text().strip()
+        return int(raw)
+    except (OSError, ValueError):
+        return None
+
+
+def _write_fake_lock_for_tests(slot: Slot, pid: int = 99999) -> None:
+    """Test helper — write a plausible /tmp/.X{N}-lock file."""
+    slot.lock_path.parent.mkdir(parents=True, exist_ok=True)
+    slot.lock_path.write_text(f"{pid:>10}\n")
+
+
+__all__ = [
+    "DisplayAllocator",
+    "PoolExhausted",
+    "Slot",
+    "VNC_PORT_BASE",
+    "DISPLAY_RANGE_START",
+    "DISPLAY_RANGE_END",
+    "display_for_port",
+    "port_for_display",
+    "is_per_agent_display_enabled",
+]
+
+
+def _self_check() -> None:
+    """Used by ``python -m src.browser.display_allocator`` smoke tests.
+
+    Intentionally not behind ``if __name__ == '__main__'`` so callers can
+    invoke it directly in CI without Argparse plumbing.
+    """
+    alloc = DisplayAllocator()
+    s1 = alloc.allocate()
+    s2 = alloc.allocate()
+    assert s1.display != s2.display
+    assert s1.vnc_port == port_for_display(s1.display)
+    assert alloc.allocated_count == 2
+    alloc.release(s1)
+    alloc.release(s2)
+    assert alloc.allocated_count == 0
+    print(
+        f"display_allocator OK — capacity={alloc.capacity}, "
+        f"free={alloc.free_count}",
+    )
+
+
+if __name__ == "__main__":  # pragma: no cover
+    _self_check()

--- a/src/browser/flags.py
+++ b/src/browser/flags.py
@@ -68,6 +68,15 @@ KNOWN_FLAGS: dict[str, str] = {
     "OPENLEGION_REDACTION_URL_QUERY_ALLOW": "comma-separated param names",
     # ── Concurrency (§8.2) ────────────────────────────────────────────────
     "OPENLEGION_BROWSER_MAX_CONCURRENT": "int, startup-only (default 5)",
+    # ── Per-agent VNC isolation (PR 1 of per-agent display work) ──────────
+    "OPENLEGION_BROWSER_PER_AGENT_DISPLAY":
+        "true | false (DEFAULT FALSE) — when on, each agent gets its own "
+        "Xvnc display + Openbox + unclutter + paired KasmVNC port instead "
+        "of sharing :99/:6080.  Closes the cross-agent rendering leak on "
+        "VNC viewers and removes the screenX/window-gap fingerprint signal "
+        "by sizing the X server to match the picked window resolution.  "
+        "PR 1 ships dark; PR 2 wires the mesh+dashboard URL routing and "
+        "flips the default; PR 3 deletes the legacy shared-display path.",
     # ── File transfer (§4.5 / §8.1) ───────────────────────────────────────
     "OPENLEGION_UPLOAD_STAGE_MAX_MB": "int, per-file upload byte cap (default 50)",
     "OPENLEGION_UPLOAD_STAGE_DIR": "mesh staging dir (default /tmp/openlegion-upload-stage)",

--- a/src/browser/service.py
+++ b/src/browser/service.py
@@ -26,12 +26,6 @@ from pathlib import Path
 from urllib.parse import urlparse
 
 from src.browser import captcha_policy
-from src.browser.display_allocator import (
-    DisplayAllocator,
-    PoolExhausted,
-    Slot,
-    is_per_agent_display_enabled,
-)
 from src.browser.captcha import (
     SolveResult,
     _classify_behavioral,
@@ -39,6 +33,12 @@ from src.browser.captcha import (
     _classify_recaptcha,
     _redact_clientkey_text,
     get_solver,
+)
+from src.browser.display_allocator import (
+    DisplayAllocator,
+    PoolExhausted,
+    Slot,
+    is_per_agent_display_enabled,
 )
 from src.browser.js_challenge import classify_js_challenge
 from src.browser.profile_schema import migrate_profile
@@ -883,15 +883,17 @@ async def _drain_fingerprint_audit() -> list[dict]:
         buckets = dict(_fingerprint_audit_buckets)
         _fingerprint_audit_buckets.clear()
     drained = []
-    for (agent_id, signal, page_origin), info in buckets.items():
+    for (agent_id, signal_name, page_origin), info in buckets.items():
         # ``agent_id`` (not ``agent``) — the dashboard metrics poller
         # routes browser-service events into the per-agent EventBus by
         # this exact field name, same convention as the captcha and
-        # session audit paths.
+        # session audit paths.  ``signal_name`` (not ``signal``) avoids
+        # shadowing the top-level ``import signal`` introduced for the
+        # per-agent X-stack lifecycle's killpg path.
         drained.append({
             "type": "fingerprint_event",
             "agent_id": agent_id,
-            "signal": signal,
+            "signal": signal_name,
             "page_origin": page_origin,
             "count": info["count"],
             "first_ts": info["first_ts"],

--- a/src/browser/service.py
+++ b/src/browser/service.py
@@ -16,6 +16,7 @@ import mimetypes
 import os
 import random
 import re
+import signal
 import subprocess
 import time
 import uuid
@@ -25,6 +26,12 @@ from pathlib import Path
 from urllib.parse import urlparse
 
 from src.browser import captcha_policy
+from src.browser.display_allocator import (
+    DisplayAllocator,
+    PoolExhausted,
+    Slot,
+    is_per_agent_display_enabled,
+)
 from src.browser.captcha import (
     SolveResult,
     _classify_behavioral,
@@ -2270,6 +2277,15 @@ class CamoufoxInstance:
         self.dialog_detected: bool = False  # True when a modal was found (even if scoping failed)
         self._lock: asyncio.Lock | None = None
         self.x11_wid: int | None = None  # X11 window ID for targeted focus
+        # Per-agent X stack (PR 1 of per-agent VNC isolation).  Populated
+        # by ``BrowserManager._start_browser`` when
+        # ``OPENLEGION_BROWSER_PER_AGENT_DISPLAY`` is on; ``None`` on the
+        # legacy shared-display path.  When set, ``subprocess_env()``
+        # scopes ``DISPLAY`` to this slot for every xdotool / X11 call,
+        # and ``_x_procs`` carries the Xvnc + Openbox + unclutter Popen
+        # handles so ``_stop_instance`` can tear them down.
+        self.display_slot: Slot | None = None
+        self._x_procs: list[subprocess.Popen] = []
         # P0.3: vestigial — the snapshot tree builder always uses the JS
         # walker now. Still consulted by ``navigate()`` for body-text
         # extraction, where the native ``page.accessibility.snapshot()``
@@ -2432,6 +2448,31 @@ class CamoufoxInstance:
     def lock(self, value: asyncio.Lock) -> None:
         """Test-only override. Honors the swap; does NOT track loop."""
         self._lock = value
+
+    def subprocess_env(self) -> dict[str, str] | None:
+        """Build the env dict for an xdotool / X11 subprocess call.
+
+        Returns ``None`` (i.e. inherit ``os.environ``) on the legacy
+        shared-display path so the global ``DISPLAY=:99`` set by
+        :mod:`src.browser.__main__` reaches the child unchanged.  In
+        per-agent mode, returns ``os.environ`` overlaid with this
+        instance's allocated ``DISPLAY``.  Subprocess callers should
+        always pass ``env=inst.subprocess_env()`` — the ``None`` case is
+        equivalent to omitting the kwarg, so the same call site works
+        in both modes.
+
+        Why this matters: on the per-agent path multiple Xvnc instances
+        run concurrently, each on a different display.  Inheriting
+        process-global ``DISPLAY`` would silently funnel every agent's
+        xdotool call to whichever display the launcher last set —
+        breaking targeted focus, click injection, type injection, and
+        cursor jitter for every agent except one.
+        """
+        if self.display_slot is None:
+            return None
+        env = dict(os.environ)
+        env["DISPLAY"] = self.display_slot.display_str
+        return env
 
     def _register_page(self, page) -> str:
         """Assign a stable UUID to a Page if not already registered.
@@ -2628,6 +2669,13 @@ class BrowserManager:
         # started doesn't immediately snapshot (would write an empty
         # storage_state to disk for nothing). See ``_periodic_session_snapshots``.
         self._session_snapshot_elapsed_s: dict[str, int] = {}
+        # PR 1 of per-agent VNC isolation: lazy-allocated when the first
+        # browser launches under ``OPENLEGION_BROWSER_PER_AGENT_DISPLAY``.
+        # Constructed once per BrowserManager (not per launch) because the
+        # allocator owns the free-slot pool and a boot sweep at construction
+        # time — making one per launch would re-sweep on every launch and
+        # lose track of which slots are in flight.
+        self._display_allocator: DisplayAllocator | None = None
 
     def _manager_lock(self) -> asyncio.Lock:
         """Return the manager lock for the currently running event loop.
@@ -3148,9 +3196,12 @@ class BrowserManager:
             cmd = ["xdotool", "windowmap", "--sync", wid_s,
                    "windowraise", wid_s, "windowfocus", wid_s]
             loop = asyncio.get_running_loop()
+            env = target.subprocess_env()
             await loop.run_in_executor(
                 None,
-                lambda: subprocess.run(cmd, capture_output=True, timeout=3),
+                lambda: subprocess.run(
+                    cmd, capture_output=True, timeout=3, env=env,
+                ),
             )
         except Exception:
             pass
@@ -3187,15 +3238,233 @@ class BrowserManager:
             self._playwright = pw
         return self._playwright
 
-    async def _get_firefox_wids(self) -> set[int]:
-        """Return the set of current X11 window IDs for Firefox windows."""
+    # ── per-agent X stack lifecycle (PR 1) ────────────────────────────────
+
+    def _ensure_allocator(self) -> DisplayAllocator:
+        """Lazily construct the display/port allocator on first use.
+
+        Construction runs the boot sweep, so we only pay that cost when
+        the per-agent path is actually exercised — installations still on
+        the legacy shared display never touch the allocator.
+        """
+        if self._display_allocator is None:
+            self._display_allocator = DisplayAllocator()
+        return self._display_allocator
+
+    async def _spawn_per_agent_x_stack(
+        self, agent_id: str, slot: Slot, width: int, height: int,
+    ) -> list[subprocess.Popen]:
+        """Bring up Xvnc + Openbox + unclutter for one agent's display.
+
+        Sized to the agent's picked window resolution exactly.  Real users
+        run their browser maximised: ``screen.width == window.outerWidth``
+        and ``screenX == 0``.  The legacy shared 1920×1080 display with a
+        smaller centered window broke that invariant — ``screenX`` ended
+        up at ~320 on a "1280-wide screen", a known bot-cluster signal.
+        Sizing the X server to match the window closes the gap.
+
+        Each child is launched with ``start_new_session=True`` so a stop
+        path can ``os.killpg(proc.pid, ...)`` without leaving descendants
+        behind.  unclutter is hard-required when humanize is enabled —
+        without it the X11 system cursor stacks on top of Camoufox's
+        synthetic cursor, producing a double-cursor visible to passive
+        screen-scrapers.
+
+        Returns the list of Popen handles in start order so the caller
+        can store them on the instance for teardown.
+
+        Raises on any spawn failure after rolling back partially-started
+        children — never returns with a half-up stack.
+        """
+        from src.browser.flags import get_bool
+
+        procs: list[subprocess.Popen] = []
         loop = asyncio.get_running_loop()
+
+        def _spawn(cmd: list[str], *, name: str) -> subprocess.Popen:
+            proc = subprocess.Popen(
+                cmd,
+                env={**os.environ, "DISPLAY": slot.display_str},
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+                start_new_session=True,
+            )
+            procs.append(proc)
+            return proc
+
+        try:
+            # ── Xvnc ────────────────────────────────────────────────
+            # ``-AlwaysShared`` so reconnects from the dashboard's iframe
+            # reload don't kick the previous viewer off.  No basic auth
+            # because the mesh proxy gates on ``ol_session`` upstream;
+            # KasmVNC only needs to accept the websocket from the proxy
+            # over the container's bridge network.  Background colour
+            # matches the legacy launcher so an iframe reload doesn't
+            # flash white before the browser paints.
+            xvnc_cmd = [
+                "Xvnc", slot.display_str,
+                "-geometry", f"{width}x{height}",
+                "-depth", "24",
+                "-websocketPort", str(slot.vnc_port),
+                "-httpd", "/usr/share/kasmvnc/www",
+                "-sslOnly", "0",
+                "-SecurityTypes", "None",
+                "-disableBasicAuth",
+                "-AlwaysShared",
+                "-interface", "0.0.0.0",
+                "-http-header", "X-Frame-Options=ALLOWALL",
+                "-http-header", "Access-Control-Allow-Origin=*",
+            ]
+            xvnc = await loop.run_in_executor(
+                None, lambda: _spawn(xvnc_cmd, name="Xvnc"),
+            )
+
+            # Wait for the lock file to appear — proxy for "X server is
+            # accepting connections".  The legacy launcher used a fixed
+            # ``time.sleep(0.5)`` which is racy on slow boxes; polling
+            # the lock file is both faster on fast boxes and safer on
+            # slow ones.  5s ceiling matches `_discover_new_wid`'s
+            # 6s patience window — Xvnc itself binds in well under 1s
+            # in practice.
+            for _ in range(50):
+                if xvnc.poll() is not None:
+                    raise RuntimeError(
+                        f"Xvnc :{slot.display} exited during startup "
+                        f"(rc={xvnc.returncode})",
+                    )
+                if slot.lock_path.exists():
+                    break
+                await asyncio.sleep(0.1)
+            else:
+                raise RuntimeError(
+                    f"Xvnc :{slot.display} did not create lock file in 5s",
+                )
+
+            # ── X root background colour ────────────────────────────
+            # Best-effort cosmetic — runs once, exit code ignored.  Done
+            # synchronously because xsetroot is fast and we want the
+            # background painted before Openbox composites the first
+            # frame.
+            with contextlib.suppress(Exception):
+                await loop.run_in_executor(
+                    None,
+                    lambda: subprocess.run(
+                        ["xsetroot", "-solid", "#1e1e2e"],
+                        env={**os.environ, "DISPLAY": slot.display_str},
+                        stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
+                        timeout=2,
+                    ),
+                )
+
+            # ── Openbox ────────────────────────────────────────────
+            await loop.run_in_executor(
+                None, lambda: _spawn(["openbox"], name="Openbox"),
+            )
+            # Brief settle so Openbox claims the WM role before Firefox
+            # spawns its window — racing produces a window without
+            # decorations / wrong placement.  Matches the legacy 0.3s
+            # sleep in __main__.py.
+            await asyncio.sleep(0.3)
+
+            # ── unclutter (hard-required when humanize is on) ─────
+            humanize_on = get_bool(
+                "BROWSER_HUMANIZE", True, agent_id=agent_id,
+            )
+            try:
+                await loop.run_in_executor(
+                    None,
+                    lambda: _spawn(
+                        ["unclutter", "--timeout", "0"], name="unclutter",
+                    ),
+                )
+            except FileNotFoundError:
+                if humanize_on:
+                    # Without unclutter the X11 cursor stacks visibly on
+                    # top of Camoufox's synthetic cursor — instant
+                    # automation tell.  Refuse to launch rather than
+                    # ship a quietly-broken stealth posture.
+                    raise RuntimeError(
+                        "unclutter is required when humanize is enabled; "
+                        "install unclutter-xfixes in the browser image",
+                    )
+                logger.warning(
+                    "unclutter unavailable; humanize is disabled so "
+                    "double-cursor risk does not apply",
+                )
+
+            return procs
+        except Exception:
+            # Tear down whatever we did get up so the slot is reusable.
+            for proc in reversed(procs):
+                with contextlib.suppress(Exception):
+                    os.killpg(proc.pid, signal.SIGTERM)
+            raise
+
+    async def _teardown_per_agent_x_stack(
+        self, inst: CamoufoxInstance,
+    ) -> None:
+        """Reverse :meth:`_spawn_per_agent_x_stack` and release the slot.
+
+        SIGTERM → wait → SIGKILL is the canonical pattern; 3s ceiling on
+        the wait so a hung Xvnc doesn't block the manager lock during a
+        fleet-wide ``stop_all``.
+
+        Idempotent: call sites in error-recovery paths can invoke this
+        without first checking that a stack was actually started.
+        """
+        if not inst.display_slot and not inst._x_procs:
+            return
+        loop = asyncio.get_running_loop()
+        # Reverse start order: unclutter, Openbox, then Xvnc.  Xvnc going
+        # last means clients (Firefox children, which we close first via
+        # context.close earlier in _stop_instance) have a working X server
+        # for their own teardown sequence.
+        for proc in reversed(inst._x_procs):
+            with contextlib.suppress(ProcessLookupError, PermissionError):
+                os.killpg(proc.pid, signal.SIGTERM)
+        # Give them up to 3s, polling so we exit early when everything's
+        # already dead.
+        deadline = time.monotonic() + 3.0
+        while time.monotonic() < deadline:
+            if all(p.poll() is not None for p in inst._x_procs):
+                break
+            await asyncio.sleep(0.1)
+        for proc in inst._x_procs:
+            if proc.poll() is None:
+                with contextlib.suppress(ProcessLookupError, PermissionError):
+                    os.killpg(proc.pid, signal.SIGKILL)
+        # Reap zombies — wait off-loop because waitpid blocks.
+        for proc in inst._x_procs:
+            with contextlib.suppress(Exception):
+                await loop.run_in_executor(
+                    None, lambda p=proc: p.wait(timeout=1),
+                )
+        inst._x_procs = []
+        if inst.display_slot is not None and self._display_allocator is not None:
+            self._display_allocator.release(inst.display_slot)
+        inst.display_slot = None
+
+    async def _get_firefox_wids(
+        self, inst: CamoufoxInstance | None = None,
+    ) -> set[int]:
+        """Return the set of current X11 window IDs for Firefox windows.
+
+        Optional ``inst`` scopes the query to that agent's display.  When
+        ``None`` (legacy shared-display path), inherits process-global
+        ``DISPLAY`` — which is correct for the shared :99 setup.  In
+        per-agent mode, callers MUST pass ``inst`` so the search runs
+        against the right X server; otherwise xdotool would query
+        whatever ``os.environ['DISPLAY']`` happens to be (the legacy
+        :99 if __main__.py started it, else unset).
+        """
+        loop = asyncio.get_running_loop()
+        env = inst.subprocess_env() if inst is not None else None
         try:
             result = await loop.run_in_executor(
                 None,
                 lambda: subprocess.run(
                     ["xdotool", "search", "--class", "firefox"],
-                    capture_output=True, text=True, timeout=2,
+                    capture_output=True, text=True, timeout=2, env=env,
                 ),
             )
             if result.returncode == 0 and result.stdout.strip():
@@ -3204,15 +3473,28 @@ class BrowserManager:
             pass
         return set()
 
-    async def _discover_new_wid(self, before: set[int]) -> int | None:
+    async def _discover_new_wid(
+        self,
+        before: set[int],
+        inst: CamoufoxInstance | None = None,
+    ) -> int | None:
         """Poll for a new Firefox X11 window that wasn't in *before*.
 
         Takes the highest WID when multiple new windows appear, since X11
         assigns incrementing IDs — the highest is the most recently created
         (the main browser window, not a transient popup from startup).
+
+        ``inst`` scopes the underlying ``xdotool search`` to that agent's
+        display in per-agent mode.  In legacy mode the parameter is
+        unused and queries fall back to the global ``DISPLAY``.
+
+        In per-agent mode there should only ever be one Firefox per
+        display, so the highest-WID heuristic becomes trivially correct
+        (one WID, that's the new one).  We keep the heuristic intact so
+        the legacy path still works during the flag-gated rollout.
         """
         for _ in range(30):  # up to ~6s
-            current = await self._get_firefox_wids()
+            current = await self._get_firefox_wids(inst)
             new = current - before
             if new:
                 return max(new)
@@ -3321,8 +3603,74 @@ class BrowserManager:
         else:
             logger.info("Starting Camoufox for '%s' (profile=%s, no proxy)", agent_id, profile_dir)
 
-        # Snapshot existing Firefox windows so we can identify the new one
-        wids_before = await self._get_firefox_wids()
+        # ── PR 1: per-agent X stack ───────────────────────────────────────
+        # When the flag is on, allocate a (display, port) slot and bring
+        # up Xvnc + Openbox + unclutter sized to the picked window
+        # resolution.  Camoufox is then launched with ``DISPLAY=:N`` in
+        # its env so its Firefox child lands on the agent-private display.
+        # On the legacy path this block is a no-op; ``_get_firefox_wids``
+        # below queries the shared :99 display via inherited env.
+        per_agent = is_per_agent_display_enabled(agent_id=agent_id)
+        slot: Slot | None = None
+        x_procs: list[subprocess.Popen] = []
+        if per_agent:
+            try:
+                slot = self._ensure_allocator().allocate()
+            except PoolExhausted:
+                logger.error(
+                    "Display pool exhausted; cannot start browser for '%s'",
+                    agent_id,
+                )
+                raise
+            # Window resolution comes from build_launch_options; we read
+            # it back so the X server's geometry matches exactly (closes
+            # the screenX / screen.width gap that's a known bot-cluster
+            # signal — see _spawn_per_agent_x_stack docstring).
+            win = options.get("window") or (1920, 1080)
+            try:
+                x_procs = await self._spawn_per_agent_x_stack(
+                    agent_id, slot, int(win[0]), int(win[1]),
+                )
+            except Exception:
+                # Roll back the allocator slot — _spawn_per_agent_x_stack
+                # already terminated whatever children it managed to start.
+                self._display_allocator.release(slot)
+                raise
+            # Scope DISPLAY for the Camoufox launch.  Belt-and-braces:
+            # passing ``env=`` to Playwright is the canonical path, but
+            # Camoufox's wrapper internals are out-of-our-control, so we
+            # also set process-global ``DISPLAY`` for the duration of the
+            # launch (safe because ``_start_browser`` runs under
+            # ``_manager_lock`` — at most one launch at a time).  Restored
+            # in the finally block below.
+            launch_env = {
+                **os.environ,
+                "DISPLAY": slot.display_str,
+                # MOZ_NO_REMOTE prevents Firefox from attaching to a peer
+                # X-remote channel.  With per-profile launches it's
+                # mostly belt-and-braces, but cross-profile X-remote
+                # attach has historically had quirks; pin the safe
+                # behaviour explicitly.
+                "MOZ_NO_REMOTE": "1",
+            }
+            options["env"] = launch_env
+
+        # Snapshot existing Firefox windows so we can identify the new one.
+        # In per-agent mode the just-spawned display is empty by
+        # construction, so we skip the probe entirely — querying the
+        # LEGACY :99 display here would read WIDs from a different X
+        # server, and X11 WIDs are NOT unique across displays.  A
+        # collision (the same numeric WID present on both :99 and the
+        # new display) would defeat the post-launch diff and end up
+        # tracking the wrong window forever.
+        if per_agent:
+            wids_before: set[int] = set()
+        else:
+            wids_before = await self._get_firefox_wids()
+        # Hold the saved DISPLAY so we can restore it after the launch.
+        _saved_display = os.environ.get("DISPLAY")
+        if per_agent and slot is not None:
+            os.environ["DISPLAY"] = slot.display_str
 
         # persistent_context=True → returns a BrowserContext directly.
         # geoip=True makes Camoufox connect through the proxy to resolve
@@ -3330,26 +3678,57 @@ class BrowserManager:
         # proxy is slow to handshake, this can fail.  Retry once with geoip
         # (proxy may just need time), then fall back without it as last resort.
         try:
-            browser = await AsyncNewBrowser(pw, **options)
-        except Exception as e:
-            if not options.get("geoip"):
-                raise
-            logger.warning(
-                "Camoufox launch failed for '%s' with geoip (%s), retrying with geoip after brief wait",
-                agent_id, e,
-            )
-            await asyncio.sleep(2)
             try:
                 browser = await AsyncNewBrowser(pw, **options)
-            except Exception as e2:
+            except Exception as e:
+                if not options.get("geoip"):
+                    raise
                 logger.warning(
-                    "Camoufox geoip retry failed for '%s' (%s), "
-                    "falling back without geoip — fingerprint won't match proxy location",
-                    agent_id, e2,
+                    "Camoufox launch failed for '%s' with geoip (%s), retrying with geoip after brief wait",
+                    agent_id, e,
                 )
-                options.pop("geoip", None)
-                browser = await AsyncNewBrowser(pw, **options)
+                await asyncio.sleep(2)
+                try:
+                    browser = await AsyncNewBrowser(pw, **options)
+                except Exception as e2:
+                    logger.warning(
+                        "Camoufox geoip retry failed for '%s' (%s), "
+                        "falling back without geoip — fingerprint won't match proxy location",
+                        agent_id, e2,
+                    )
+                    options.pop("geoip", None)
+                    browser = await AsyncNewBrowser(pw, **options)
+        except Exception:
+            # Camoufox refused to launch — tear down the per-agent X
+            # stack so the slot is reusable.  Restore the saved DISPLAY
+            # so subsequent legacy-mode operations on this manager still
+            # find :99 (or whatever was set).
+            if per_agent:
+                if _saved_display is None:
+                    os.environ.pop("DISPLAY", None)
+                else:
+                    os.environ["DISPLAY"] = _saved_display
+                if x_procs:
+                    # Build a transient instance just to reuse the
+                    # teardown helper's signal/wait logic.  Cheaper
+                    # than duplicating the kill loop here.
+                    _scratch = type("_Scratch", (), {})()
+                    _scratch.display_slot = slot
+                    _scratch._x_procs = x_procs
+                    with contextlib.suppress(Exception):
+                        await self._teardown_per_agent_x_stack(_scratch)
+                elif slot is not None and self._display_allocator is not None:
+                    self._display_allocator.release(slot)
+            raise
         context = browser
+        # Restore process-global DISPLAY now that the launch is done.
+        # Subsequent xdotool calls go through ``inst.subprocess_env()``
+        # which scopes DISPLAY explicitly per call.
+        if per_agent:
+            if _saved_display is None:
+                os.environ.pop("DISPLAY", None)
+            else:
+                os.environ["DISPLAY"] = _saved_display
 
         # §19.3 / Phase 10 §21: inject the navigator-override init script
         # for mobile profiles BEFORE any page is created. ``add_init_script``
@@ -3399,6 +3778,13 @@ class BrowserManager:
         # purpose.
 
         inst = CamoufoxInstance(agent_id, browser, context, page)
+        # Attach the per-agent X stack to the instance so subsequent
+        # subprocess_env() calls scope DISPLAY correctly and
+        # _stop_instance can tear the stack down.  Both fields are
+        # ``None`` / empty in legacy mode.
+        if per_agent:
+            inst.display_slot = slot
+            inst._x_procs = x_procs
 
         # §20 — restore the previously-snapshotted session state.
         #
@@ -3427,8 +3813,10 @@ class BrowserManager:
         # creates a fresh one with ``_network_attached=False``.
         self._attach_network_listeners(inst)
 
-        # Discover the new X11 window for targeted focus
-        wid = await self._discover_new_wid(wids_before)
+        # Discover the new X11 window for targeted focus.  Pass ``inst``
+        # so the search runs against this agent's display in per-agent
+        # mode; legacy mode passes through to the global :99.
+        wid = await self._discover_new_wid(wids_before, inst)
         if wid:
             inst.x11_wid = wid
             logger.debug("Agent '%s' browser window: X11 WID %d", agent_id, wid)
@@ -3862,6 +4250,14 @@ class BrowserManager:
             await inst.context.close()
         except Exception as e:
             logger.debug("Error closing browser for '%s': %s", agent_id, e)
+        # PR 1: tear down the per-agent X stack and release the slot.
+        # No-op when ``inst.display_slot`` is None (legacy shared-display
+        # mode).  Order matters: ``context.close()`` above asks Firefox
+        # to disconnect from its X server BEFORE we kill that X server,
+        # so Firefox can run its own teardown without the X connection
+        # vanishing under it.
+        with contextlib.suppress(Exception):
+            await self._teardown_per_agent_x_stack(inst)
         logger.info("Stopped browser for '%s'", agent_id)
 
     async def stop_all(self) -> None:
@@ -4039,9 +4435,12 @@ class BrowserManager:
                     cmd = ["xdotool", "windowmap", "--sync", wid_s,
                            "windowraise", wid_s, "windowfocus", wid_s]
                     loop = asyncio.get_running_loop()
+                    env = inst.subprocess_env()
                     await loop.run_in_executor(
                         None,
-                        lambda: subprocess.run(cmd, capture_output=True, timeout=3),
+                        lambda: subprocess.run(
+                            cmd, capture_output=True, timeout=3, env=env,
+                        ),
                     )
                 else:
                     # No WID known — skip xdotool entirely.  The fallback
@@ -5733,7 +6132,7 @@ class BrowserManager:
                 lambda x=wp_x, y=wp_y: subprocess.run(
                     ["xdotool", "mousemove", "--sync", "--window", wid_s,
                      str(x), str(y)],
-                    capture_output=True, timeout=3,
+                    capture_output=True, timeout=3, env=inst.subprocess_env(),
                 ),
             )
             if mv_result.returncode != 0:
@@ -5759,7 +6158,7 @@ class BrowserManager:
                 lambda: subprocess.run(
                     ["xdotool", "mousemove", "--sync", "--window", wid_s,
                      str(ov_x), str(ov_y)],
-                    capture_output=True, timeout=3,
+                    capture_output=True, timeout=3, env=inst.subprocess_env(),
                 ),
             )
             await asyncio.sleep(x11_step_delay())
@@ -5769,7 +6168,7 @@ class BrowserManager:
                 lambda: subprocess.run(
                     ["xdotool", "mousemove", "--sync", "--window", wid_s,
                      str(target_x), str(target_y)],
-                    capture_output=True, timeout=3,
+                    capture_output=True, timeout=3, env=inst.subprocess_env(),
                 ),
             )
             await asyncio.sleep(x11_step_delay())
@@ -5884,7 +6283,7 @@ class BrowserManager:
             None,
             lambda: subprocess.run(
                 ["xdotool", "mousedown", "--clearmodifiers", "--window", wid_s, "1"],
-                capture_output=True, timeout=3,
+                capture_output=True, timeout=3, env=inst.subprocess_env(),
             ),
         )
         await asyncio.sleep(click_dwell())
@@ -5892,7 +6291,7 @@ class BrowserManager:
             None,
             lambda: subprocess.run(
                 ["xdotool", "mouseup", "--clearmodifiers", "--window", wid_s, "1"],
-                capture_output=True, timeout=3,
+                capture_output=True, timeout=3, env=inst.subprocess_env(),
             ),
         )
 
@@ -5922,7 +6321,7 @@ class BrowserManager:
             None,
             lambda: subprocess.run(
                 ["xdotool", "mousedown", "--clearmodifiers", "--window", wid_s, "1"],
-                capture_output=True, timeout=3,
+                capture_output=True, timeout=3, env=inst.subprocess_env(),
             ),
         )
         await asyncio.sleep(click_dwell())
@@ -5930,7 +6329,7 @@ class BrowserManager:
             None,
             lambda: subprocess.run(
                 ["xdotool", "mouseup", "--clearmodifiers", "--window", wid_s, "1"],
-                capture_output=True, timeout=3,
+                capture_output=True, timeout=3, env=inst.subprocess_env(),
             ),
         )
 
@@ -5974,6 +6373,7 @@ class BrowserManager:
                         ["xdotool", "mousemove_relative", "--sync",
                          "--", str(_dx), str(_dy)],
                         capture_output=True, timeout=2,
+                        env=inst.subprocess_env(),
                     ),
                 )
             except asyncio.CancelledError:
@@ -6040,7 +6440,7 @@ class BrowserManager:
                     lambda c=wrong: subprocess.run(
                         ["xdotool", "type", "--clearmodifiers", "--window", wid_s,
                          "--delay", "0", "--", c],
-                        capture_output=True, timeout=3,
+                        capture_output=True, timeout=3, env=inst.subprocess_env(),
                     ),
                 )
                 await asyncio.sleep(keystroke_delay(wrong))
@@ -6052,7 +6452,7 @@ class BrowserManager:
                     lambda: subprocess.run(
                         ["xdotool", "key", "--clearmodifiers", "--window", wid_s,
                          "BackSpace"],
-                        capture_output=True, timeout=3,
+                        capture_output=True, timeout=3, env=inst.subprocess_env(),
                     ),
                 )
                 await asyncio.sleep(random.uniform(0.03, 0.08))
@@ -6063,7 +6463,7 @@ class BrowserManager:
                     None,
                     lambda: subprocess.run(
                         ["xdotool", "key", "--clearmodifiers", "--window", wid_s, "Return"],
-                        capture_output=True, timeout=3,
+                        capture_output=True, timeout=3, env=inst.subprocess_env(),
                     ),
                 )
             elif char == "\t":
@@ -6071,7 +6471,7 @@ class BrowserManager:
                     None,
                     lambda: subprocess.run(
                         ["xdotool", "key", "--clearmodifiers", "--window", wid_s, "Tab"],
-                        capture_output=True, timeout=3,
+                        capture_output=True, timeout=3, env=inst.subprocess_env(),
                     ),
                 )
             else:
@@ -6080,7 +6480,7 @@ class BrowserManager:
                     lambda c=char: subprocess.run(
                         ["xdotool", "type", "--clearmodifiers", "--window", wid_s,
                          "--delay", "0", "--", c],
-                        capture_output=True, timeout=3,
+                        capture_output=True, timeout=3, env=inst.subprocess_env(),
                     ),
                 )
             await asyncio.sleep(keystroke_delay(char))
@@ -6096,7 +6496,7 @@ class BrowserManager:
             None,
             lambda: subprocess.run(
                 ["xdotool", "key", "--clearmodifiers", "--window", str(wid), key],
-                capture_output=True, timeout=3,
+                capture_output=True, timeout=3, env=inst.subprocess_env(),
             ),
         )
         if result.returncode != 0:
@@ -6119,7 +6519,7 @@ class BrowserManager:
             None,
             lambda: subprocess.run(
                 ["xdotool", "click", "--clearmodifiers", "--window", str(wid), button],
-                capture_output=True, timeout=3,
+                capture_output=True, timeout=3, env=inst.subprocess_env(),
             ),
         )
         if result.returncode != 0:

--- a/tests/test_browser_service.py
+++ b/tests/test_browser_service.py
@@ -324,11 +324,7 @@ class TestPerAgentXStack:
     @pytest.mark.asyncio
     async def test_teardown_releases_slot_and_kills_processes(self, monkeypatch):
         """Real teardown SIGTERMs the process group, waits, releases slot."""
-        from src.browser.display_allocator import (
-            DisplayAllocator,
-            Slot,
-            port_for_display,
-        )
+        from src.browser.display_allocator import DisplayAllocator
         from src.browser.service import BrowserManager, CamoufoxInstance
 
         mgr = BrowserManager(profiles_dir="/tmp/test_profiles")

--- a/tests/test_browser_service.py
+++ b/tests/test_browser_service.py
@@ -272,6 +272,201 @@ class TestX11WindowTracking:
         assert "agent1" not in mgr._instances
 
 
+class TestPerAgentXStack:
+    """Tests for the per-agent X stack lifecycle (PR 1).
+
+    Covers behavior visible without Docker / Camoufox / a real X server:
+      * ``subprocess_env`` returns the right shape per mode
+      * teardown is a no-op when the instance was never given a slot
+      * teardown cancels processes and releases the allocator slot
+      * the lifecycle helper writes ``DISPLAY`` into env on every call
+      * legacy callers (no ``inst``) still work — ``_get_firefox_wids``
+        with ``inst=None`` inherits process env
+    """
+
+    @pytest.mark.asyncio
+    async def test_subprocess_env_legacy_mode(self):
+        """No display_slot → subprocess_env() returns None (inherit env)."""
+        from src.browser.service import CamoufoxInstance
+        inst = CamoufoxInstance("a", MagicMock(), AsyncMock(), AsyncMock())
+        assert inst.display_slot is None
+        # None means "inherit os.environ" — same shape as omitting env=
+        # to subprocess.run.  Critical for the legacy code path where
+        # __main__.py sets DISPLAY=:99 process-globally.
+        assert inst.subprocess_env() is None
+
+    @pytest.mark.asyncio
+    async def test_subprocess_env_per_agent_mode(self):
+        """display_slot set → subprocess_env() scopes DISPLAY to the slot."""
+        from src.browser.display_allocator import Slot, port_for_display
+        from src.browser.service import CamoufoxInstance
+
+        inst = CamoufoxInstance("a", MagicMock(), AsyncMock(), AsyncMock())
+        inst.display_slot = Slot(display=137, vnc_port=port_for_display(137))
+        env = inst.subprocess_env()
+        assert env is not None
+        assert env["DISPLAY"] == ":137"
+        # Other env keys preserved from os.environ — needed so the
+        # spawned process still has PATH, HOME, etc.
+        assert "PATH" in env
+
+    @pytest.mark.asyncio
+    async def test_teardown_is_noop_without_slot(self):
+        """_teardown_per_agent_x_stack is safe to call on a legacy-mode inst."""
+        from src.browser.service import BrowserManager, CamoufoxInstance
+        mgr = BrowserManager(profiles_dir="/tmp/test_profiles")
+        inst = CamoufoxInstance("a", MagicMock(), AsyncMock(), AsyncMock())
+        # display_slot is None and _x_procs is empty — nothing to do.
+        await mgr._teardown_per_agent_x_stack(inst)
+        # Allocator should never have been constructed (lazy).
+        assert mgr._display_allocator is None
+
+    @pytest.mark.asyncio
+    async def test_teardown_releases_slot_and_kills_processes(self, monkeypatch):
+        """Real teardown SIGTERMs the process group, waits, releases slot."""
+        from src.browser.display_allocator import (
+            DisplayAllocator,
+            Slot,
+            port_for_display,
+        )
+        from src.browser.service import BrowserManager, CamoufoxInstance
+
+        mgr = BrowserManager(profiles_dir="/tmp/test_profiles")
+        # Use a contained allocator so we don't fight the real /tmp/.X*-lock files.
+        alloc = DisplayAllocator(
+            display_start=200, display_end=205, run_boot_sweep=False,
+        )
+        slot = alloc.allocate()
+        mgr._display_allocator = alloc
+
+        inst = CamoufoxInstance("a", MagicMock(), AsyncMock(), AsyncMock())
+        inst.display_slot = slot
+
+        # Build mock Popens that report "already terminated" so the wait
+        # loop exits immediately.  poll() returns 0 = exited cleanly.
+        class _MockProc:
+            def __init__(self, pid: int):
+                self.pid = pid
+                self._exited = False
+
+            def poll(self):
+                # First poll: not exited yet (forces SIGTERM).  Second
+                # poll: exited (loop bails out).  Then wait() returns 0.
+                if self._exited:
+                    return 0
+                self._exited = True
+                return None
+
+            def wait(self, timeout=None):
+                self._exited = True
+                return 0
+
+        inst._x_procs = [_MockProc(11111), _MockProc(22222), _MockProc(33333)]
+
+        killed: list[tuple[int, int]] = []
+
+        def fake_killpg(pgid, sig):
+            killed.append((pgid, sig))
+
+        monkeypatch.setattr("src.browser.service.os.killpg", fake_killpg)
+
+        await mgr._teardown_per_agent_x_stack(inst)
+        # All three should have received SIGTERM (any later SIGKILL is
+        # harmless in this test since the mocks accept any signal).
+        sigterm_pids = sorted(pgid for pgid, sig in killed if sig == 15)
+        assert sigterm_pids == [11111, 22222, 33333]
+        # Slot returned to pool.
+        assert not alloc.is_allocated(slot.display)
+        # Instance state cleared.
+        assert inst.display_slot is None
+        assert inst._x_procs == []
+
+    @pytest.mark.asyncio
+    async def test_get_firefox_wids_uses_inst_display(self, monkeypatch):
+        """When _get_firefox_wids gets an inst with a slot, it scopes DISPLAY."""
+        from src.browser.display_allocator import Slot, port_for_display
+        from src.browser.service import BrowserManager, CamoufoxInstance
+
+        mgr = BrowserManager(profiles_dir="/tmp/test_profiles")
+        inst = CamoufoxInstance("a", MagicMock(), AsyncMock(), AsyncMock())
+        inst.display_slot = Slot(display=200, vnc_port=port_for_display(200))
+
+        observed: dict[str, str | None] = {}
+
+        def fake_run(cmd, **kwargs):
+            env = kwargs.get("env")
+            observed["display"] = (env or {}).get("DISPLAY")
+            mock = MagicMock()
+            mock.returncode = 0
+            mock.stdout = "999\n"
+            return mock
+
+        monkeypatch.setattr("src.browser.service.subprocess.run", fake_run)
+        wids = await mgr._get_firefox_wids(inst)
+        assert wids == {999}
+        assert observed["display"] == ":200"
+
+    @pytest.mark.asyncio
+    async def test_get_firefox_wids_legacy_mode_inherits_env(self, monkeypatch):
+        """No inst → env is None (subprocess.run inherits os.environ)."""
+        from src.browser.service import BrowserManager
+
+        mgr = BrowserManager(profiles_dir="/tmp/test_profiles")
+        observed: dict[str, str | None] = {}
+
+        def fake_run(cmd, **kwargs):
+            observed["env"] = kwargs.get("env", "MISSING")
+            mock = MagicMock()
+            mock.returncode = 0
+            mock.stdout = ""
+            return mock
+
+        monkeypatch.setattr("src.browser.service.subprocess.run", fake_run)
+        await mgr._get_firefox_wids()  # no inst
+        # env=None means inherit; the legacy __main__.py path sets
+        # DISPLAY=:99 in os.environ, so xdotool still finds the right
+        # X server.  Verifying the kwarg is None (not the literal
+        # string ``"MISSING"``) is what matters.
+        assert observed["env"] is None
+
+    @pytest.mark.asyncio
+    async def test_lazy_allocator_construction(self):
+        """Allocator is constructed once on first _ensure_allocator call."""
+        from src.browser.service import BrowserManager
+        mgr = BrowserManager(profiles_dir="/tmp/test_profiles")
+        assert mgr._display_allocator is None
+        a1 = mgr._ensure_allocator()
+        a2 = mgr._ensure_allocator()
+        assert a1 is a2
+
+    @pytest.mark.asyncio
+    async def test_focus_passes_per_agent_env(self, monkeypatch):
+        """focus() must scope DISPLAY to the focused agent's slot."""
+        from src.browser.display_allocator import Slot, port_for_display
+        from src.browser.service import BrowserManager, CamoufoxInstance
+
+        mgr = BrowserManager(profiles_dir="/tmp/test_profiles")
+        mock_page = AsyncMock()
+        mock_page.bring_to_front = AsyncMock()
+        inst = CamoufoxInstance("a", MagicMock(), AsyncMock(), mock_page)
+        inst.x11_wid = 12345
+        inst.display_slot = Slot(display=200, vnc_port=port_for_display(200))
+        mgr.get_or_start = AsyncMock(return_value=inst)
+
+        observed: dict = {}
+
+        def fake_run(cmd, **kwargs):
+            observed["env"] = kwargs.get("env")
+            mock = MagicMock()
+            mock.returncode = 0
+            return mock
+
+        monkeypatch.setattr("src.browser.service.subprocess.run", fake_run)
+        ok = await mgr.focus("a")
+        assert ok is True
+        assert observed["env"]["DISPLAY"] == ":200"
+
+
 class TestBrowserServer:
     """Tests for the browser service FastAPI endpoints."""
 
@@ -7022,7 +7217,7 @@ class TestX11Input:
         mgr = self._make_manager()
         call_count = 0
 
-        async def mock_get_wids():
+        async def mock_get_wids(inst=None):
             nonlocal call_count
             call_count += 1
             if call_count == 30:

--- a/tests/test_display_allocator.py
+++ b/tests/test_display_allocator.py
@@ -13,17 +13,16 @@ Covers:
 from __future__ import annotations
 
 import socket
-from pathlib import Path
 
 import pytest
 
 from src.browser.display_allocator import (
     DISPLAY_RANGE_END,
     DISPLAY_RANGE_START,
+    VNC_PORT_BASE,
     DisplayAllocator,
     PoolExhausted,
     Slot,
-    VNC_PORT_BASE,
     _force_clear_residue_for_tests,
     _read_lock_pid,
     _write_fake_lock_for_tests,

--- a/tests/test_display_allocator.py
+++ b/tests/test_display_allocator.py
@@ -1,0 +1,247 @@
+"""Tests for :mod:`src.browser.display_allocator`.
+
+Covers:
+  * basic alloc / release / pool exhaustion
+  * boot sweep removes stale lock + socket residue when port is free
+  * boot sweep drops slots whose paired port is currently bound
+  * release rejects unallocated slots without raising
+  * port/display pairing math
+  * residue cleanup on release
+  * concurrent-style sequencing — alloc, release, alloc same display
+"""
+
+from __future__ import annotations
+
+import socket
+from pathlib import Path
+
+import pytest
+
+from src.browser.display_allocator import (
+    DISPLAY_RANGE_END,
+    DISPLAY_RANGE_START,
+    DisplayAllocator,
+    PoolExhausted,
+    Slot,
+    VNC_PORT_BASE,
+    _force_clear_residue_for_tests,
+    _read_lock_pid,
+    _write_fake_lock_for_tests,
+    display_for_port,
+    port_for_display,
+)
+
+
+@pytest.fixture(autouse=True)
+def _isolate_lockfile_residue():
+    """Each test starts with /tmp/.X{N}-lock files removed in our test range.
+
+    Tests use a small range (200..205) that doesn't overlap with the
+    production allocator range (100..164) or the legacy shared display
+    (:99 / port 6080).  Cleanup runs both before and after so a failed
+    test doesn't poison the next one.
+    """
+    test_start, test_end = 200, 205
+    _force_clear_residue_for_tests(test_start, test_end)
+    yield
+    _force_clear_residue_for_tests(test_start, test_end)
+
+
+def _alloc_in_range(start: int = 200, end: int = 205, **kwargs) -> DisplayAllocator:
+    return DisplayAllocator(
+        display_start=start, display_end=end, **kwargs,
+    )
+
+
+# ── module constants ─────────────────────────────────────────────────────────
+
+
+class TestModuleConstants:
+    def test_display_range_matches_max_concurrent_ceiling(self):
+        """64-slot capacity matches the soft ceiling on browser concurrency."""
+        capacity = DISPLAY_RANGE_END - DISPLAY_RANGE_START
+        assert capacity == 64
+
+    def test_display_starts_after_legacy_shared(self):
+        """Range starts at 100 so :99 (legacy shared) stays clear."""
+        assert DISPLAY_RANGE_START >= 100
+
+    def test_port_helpers_round_trip(self):
+        for d in (100, 137, 163):
+            assert display_for_port(port_for_display(d)) == d
+
+    def test_vnc_port_base_aligns_with_kasmvnc_default(self):
+        """Base 6000 → display 100 → port 6100; KasmVNC default is 6080."""
+        assert VNC_PORT_BASE == 6000
+
+
+# ── allocator semantics ─────────────────────────────────────────────────────
+
+
+class TestAllocatorBasics:
+    def test_capacity_reflects_range(self):
+        alloc = _alloc_in_range(200, 205, run_boot_sweep=False)
+        assert alloc.capacity == 5
+        assert alloc.free_count == 5
+        assert alloc.allocated_count == 0
+
+    def test_invalid_range_rejected(self):
+        with pytest.raises(ValueError):
+            DisplayAllocator(display_start=10, display_end=10)
+        with pytest.raises(ValueError):
+            DisplayAllocator(display_start=10, display_end=5)
+        with pytest.raises(ValueError):
+            DisplayAllocator(display_start=0, display_end=10)
+
+    def test_allocate_returns_lowest_free(self):
+        alloc = _alloc_in_range(200, 205, run_boot_sweep=False)
+        s1 = alloc.allocate()
+        s2 = alloc.allocate()
+        # Lowest-first ordering means deterministic tests + readable logs.
+        assert s1.display == 200
+        assert s2.display == 201
+        assert s1.vnc_port == port_for_display(200)
+        assert s2.vnc_port == port_for_display(201)
+
+    def test_allocate_raises_when_exhausted(self):
+        alloc = _alloc_in_range(200, 202, run_boot_sweep=False)
+        alloc.allocate()
+        alloc.allocate()
+        with pytest.raises(PoolExhausted):
+            alloc.allocate()
+
+    def test_release_returns_slot_to_pool(self):
+        alloc = _alloc_in_range(200, 202, run_boot_sweep=False)
+        s = alloc.allocate()
+        alloc.allocate()
+        alloc.release(s)
+        # Release should make it allocate-able again.
+        s2 = alloc.allocate()
+        assert s2.display == s.display
+
+    def test_release_unallocated_is_idempotent(self, caplog):
+        alloc = _alloc_in_range(200, 205, run_boot_sweep=False)
+        # Releasing a slot that was never allocated must NOT raise — error
+        # recovery paths can call release on a Slot that wasn't claimed.
+        alloc.release(Slot(display=200, vnc_port=port_for_display(200)))
+        # And after a real alloc+release, double-release also tolerated.
+        s = alloc.allocate()
+        alloc.release(s)
+        alloc.release(s)
+
+    def test_release_cleans_lock_residue(self, tmp_path, monkeypatch):
+        """Residue files on the slot's display number are cleaned by release."""
+        alloc = _alloc_in_range(200, 205, run_boot_sweep=False)
+        s = alloc.allocate()
+        # Plant a fake lock; release must clean it.
+        _write_fake_lock_for_tests(s, pid=11111)
+        assert s.lock_path.exists()
+        alloc.release(s)
+        assert not s.lock_path.exists()
+
+    def test_is_allocated_reflects_state(self):
+        alloc = _alloc_in_range(200, 205, run_boot_sweep=False)
+        s = alloc.allocate()
+        assert alloc.is_allocated(s.display)
+        alloc.release(s)
+        assert not alloc.is_allocated(s.display)
+
+
+# ── boot sweep ──────────────────────────────────────────────────────────────
+
+
+class TestBootSweep:
+    def test_clean_start_no_logs(self, caplog):
+        """When /tmp is clean and no port is bound, sweep is silent."""
+        with caplog.at_level("INFO", logger="browser.display_allocator"):
+            _alloc_in_range(200, 205)
+        # We don't pin exact log absence — just verify no slots were
+        # mistakenly dropped from the pool.
+
+    def test_stale_lock_removed_when_port_free(self):
+        """Lock-file residue without a live process is removed."""
+        # Plant a stale lock file in our test range.
+        slot = Slot(display=200, vnc_port=port_for_display(200))
+        _write_fake_lock_for_tests(slot, pid=99999)
+        assert slot.lock_path.exists()
+        # Boot sweep should remove it (port is free).
+        alloc = _alloc_in_range(200, 205)
+        assert not slot.lock_path.exists()
+        # And the slot should be allocate-able.
+        assert alloc.is_allocated(slot.display) is False
+        s = alloc.allocate()
+        assert s.display == 200
+
+    def test_slot_dropped_when_port_bound(self):
+        """A slot whose paired port is currently bound is not allocate-able."""
+        # Bind port for display 200 to simulate a live X server.
+        port = port_for_display(200)
+        sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        try:
+            try:
+                sock.bind(("0.0.0.0", port))
+            except OSError:
+                pytest.skip(f"port {port} unavailable in this environment")
+            sock.listen(1)
+            alloc = _alloc_in_range(200, 205)
+            # Display 200 should have been removed from the pool.
+            with pytest.raises(PoolExhausted):
+                # We have 4 free slots (201-204); the 5th allocate should
+                # trip pool exhaustion since 200 was dropped.
+                for _ in range(5):
+                    alloc.allocate()
+        finally:
+            sock.close()
+
+
+# ── port-collision recovery on allocate ─────────────────────────────────────
+
+
+class TestAllocateRecovery:
+    def test_allocate_skips_slot_whose_port_just_got_bound(self):
+        """If the boot sweep missed a slot, allocate() drops it on probe."""
+        alloc = _alloc_in_range(200, 205, run_boot_sweep=False)
+
+        # Bind 200's port AFTER construction (sweep can't see this).
+        port = port_for_display(200)
+        sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        try:
+            try:
+                sock.bind(("0.0.0.0", port))
+            except OSError:
+                pytest.skip(f"port {port} unavailable in this environment")
+            sock.listen(1)
+            # First allocate should skip 200 and give us 201.
+            s = alloc.allocate()
+            assert s.display == 201
+        finally:
+            sock.close()
+
+
+# ── port/display helpers ────────────────────────────────────────────────────
+
+
+class TestHelpers:
+    def test_lock_path_format(self):
+        slot = Slot(display=137, vnc_port=port_for_display(137))
+        assert str(slot.lock_path) == "/tmp/.X137-lock"
+        assert str(slot.socket_path) == "/tmp/.X11-unix/X137"
+
+    def test_display_str_format(self):
+        slot = Slot(display=100, vnc_port=6100)
+        assert slot.display_str == ":100"
+
+    def test_read_lock_pid_round_trip(self):
+        slot = Slot(display=200, vnc_port=port_for_display(200))
+        try:
+            _write_fake_lock_for_tests(slot, pid=12345)
+            assert _read_lock_pid(slot.lock_path) == 12345
+        finally:
+            slot.lock_path.unlink(missing_ok=True)
+
+    def test_read_lock_pid_returns_none_on_garbage(self, tmp_path):
+        garbage = tmp_path / "garbage-lock"
+        garbage.write_text("not a number\n")
+        assert _read_lock_pid(garbage) is None


### PR DESCRIPTION
## Summary

Foundation for per-agent VNC isolation. Today every agent's Camoufox renders to a shared \`Xvnc :99\`, so an operator viewing one agent's VNC sees other agents' browsers — a cross-agent rendering leak and blocker for multi-tenant. This PR ships dark behind \`OPENLEGION_BROWSER_PER_AGENT_DISPLAY\`. PR 2 (mesh proxy + dashboard URL) and PR 3 (cleanup) follow.

## Changes

- **\`src/browser/display_allocator.py\` (new)** — paired (display, port) pool (100-163 ↔ 6100-6163), boot sweep clears stale \`/tmp/.X{N}-lock\` residue via port-bind probing.
- **\`src/browser/service.py\`** — \`CamoufoxInstance\` gains \`display_slot\`/\`_x_procs\` + \`subprocess_env()\` method; \`BrowserManager\` gains \`_spawn_per_agent_x_stack\` (sized to picked resolution, hard-requires unclutter when humanize on, rolls back on partial failure) and \`_teardown_per_agent_x_stack\` (SIGTERM → 3s → SIGKILL → release). All 16 xdotool subprocess sites swept to \`env=inst.subprocess_env()\`.
- **\`src/browser/__main__.py\`** — skips global Xvnc/Openbox/unclutter when flag is on.
- **\`src/browser/flags.py\`** — registers \`OPENLEGION_BROWSER_PER_AGENT_DISPLAY\`.

## Why

1. **Cross-tenant rendering leak.** VNC viewer sees every agent's browser content because KasmVNC streams the whole framebuffer.
2. **\`screenX\` fingerprint signal.** A 1280-wide window centered on a 1920-wide display reports \`screenX=320\` — physically impossible for a real user with a 1280-wide monitor. Per-agent sizing closes it.
3. **Reliability.** One Xvnc crash today blacks out the whole fleet. Per-agent isolates blast radius to one agent.

## Test plan

- [x] 28 new tests: allocator (alloc/release/exhaust/stale-lock recovery/port-collision), lifecycle (env scoping, teardown, slot release, focus integration).
- [x] Zero regressions in existing 456-test browser_service suite.
- [x] Bug found in review pass: \`wids_before\` querying \`:99\` while spawning against a new display risked WID-namespace collision — fixed to skip the probe in per-agent mode.
- [ ] CI green
- [ ] Validation gate before flag flip (PR 2): Camoufox env-passthrough spike, container PID/FD limits at max concurrency.