### PR TITLE
fix(browser): vendor hard-burn + (UA, IP) cookie binding

### DIFF
--- a/src/browser/service.py
+++ b/src/browser/service.py
@@ -876,6 +876,16 @@ _fingerprint_window: dict[str, deque[bool]] = {}
 # {agent_id: float} — unix timestamp of the most recent recorded signal.
 # Surfaced by the dashboard endpoint as ``last_signal_ts``.
 _fingerprint_last_signal: dict[str, float] = {}
+# Hard-burn agents — populated by the response-header listener when a
+# detection vendor returns an unambiguous block (cf-mitigated, X-PX-Block-Type,
+# etc.). One hard-block is a stronger signal than a 10-event rolling window
+# could ever provide: bypass the threshold and burn immediately so the
+# operator sees the signal on the very next ``_check_captcha`` envelope.
+# Cleared by the same operator-triggered reset path as the rolling window.
+_fingerprint_hard_burned: set[str] = set()
+# {agent_id: (vendor, header_or_status)} — last hard-block reason captured
+# for operator visibility on the dashboard. Operator-only; never logged.
+_fingerprint_hard_burn_reason: dict[str, tuple[str, str]] = {}
 
 
 def _get_fingerprint_lock() -> asyncio.Lock:
@@ -921,12 +931,101 @@ def _is_burned_locked(bucket: deque[bool]) -> bool:
 
 
 async def _is_fingerprint_burned(agent_id: str) -> bool:
-    """Read-only burn check for ``_check_captcha`` to decorate envelopes."""
+    """Read-only burn check for ``_check_captcha`` to decorate envelopes.
+
+    Returns True if EITHER the rolling window has filled past the threshold
+    OR a hard-burn signal (vendor block header) has fired. The hard-burn
+    short-circuits the 10-event window so a single PerimeterX 403 with
+    ``X-PX-Block-Type: 1`` — or a Cloudflare ``cf-mitigated: block`` —
+    surfaces on the very next envelope, not after another nine attempts.
+    """
     async with _get_fingerprint_lock():
+        if agent_id in _fingerprint_hard_burned:
+            return True
         bucket = _fingerprint_window.get(agent_id)
         if bucket is None:
             return False
         return _is_burned_locked(bucket)
+
+
+# Header-based hard-block signatures. Each entry maps a vendor name to a
+# tuple of (header_name_lower, predicate). Predicate inspects the header
+# value and returns True when the value indicates an unambiguous block.
+# Lower-case header names because Playwright normalises them; we still
+# compare predicates case-insensitively for safety.
+def _cf_mitigated_predicate(value: str) -> bool:
+    # ``cf-mitigated: challenge`` is the soft-challenge case (we already
+    # see the JS interstitial via body-text scan); ``cf-mitigated: block``
+    # is the hard block. ``cf-mitigated: dcv`` is a domain-control
+    # verification probe — rare, treat as hard signal.
+    v = value.strip().lower()
+    return v in {"block", "dcv"}
+
+
+def _px_block_type_predicate(value: str) -> bool:
+    # PerimeterX/HUMAN ships ``X-PX-Block-Type`` only on a hard block.
+    # Any non-empty value is a positive signal.
+    return bool(value.strip())
+
+
+def _datadome_block_predicate(value: str) -> bool:
+    # DataDome's ``X-Datadome`` shape on block: starts with ``protected``
+    # for blocked requests; ``ok`` / empty on accepted ones. Be liberal
+    # (any value containing ``protected`` or ``blocked``).
+    v = value.strip().lower()
+    return ("protected" in v) or ("blocked" in v)
+
+
+_HARD_BLOCK_HEADER_PROBES: tuple[tuple[str, str, "callable"], ...] = (
+    ("cloudflare", "cf-mitigated", _cf_mitigated_predicate),
+    ("perimeterx", "x-px-block-type", _px_block_type_predicate),
+    ("datadome", "x-datadome", _datadome_block_predicate),
+    # Akamai BMP often sets ``X-Akamai-Bmp-Action: deny`` on blocks.
+    (
+        "akamai",
+        "x-akamai-bmp-action",
+        lambda v: v.strip().lower() == "deny",
+    ),
+)
+_HARD_BLOCK_STATUS_THRESHOLD = 400
+
+
+def _classify_hard_block(headers: dict[str, str], status: int) -> tuple[str, str] | None:
+    """Return (vendor, header_or_status) when headers show an unambiguous block.
+
+    Pure-function classification — no side effects. The status floor is a
+    sanity gate: vendor headers can appear on 200 responses for
+    accepted-but-watched flows (e.g. DataDome riskiness), and we don't
+    want to burn on those. Hard-block ⇒ status >= 400 AND a vendor probe
+    fires. Caller flips state and emits audit; this function only
+    classifies.
+    """
+    if status < _HARD_BLOCK_STATUS_THRESHOLD:
+        return None
+    lower_headers = {k.lower(): v for k, v in headers.items()}
+    for vendor, header, predicate in _HARD_BLOCK_HEADER_PROBES:
+        value = lower_headers.get(header)
+        if value is None:
+            continue
+        try:
+            if predicate(value):
+                return (vendor, f"{header}={value[:64]}")
+        except Exception:
+            # A misshapen predicate must never block the response listener.
+            continue
+    return None
+
+
+async def _force_fingerprint_burn(
+    agent_id: str, vendor: str, reason: str,
+) -> bool:
+    """Mark agent as hard-burned. Returns True iff state transitioned."""
+    async with _get_fingerprint_lock():
+        already = agent_id in _fingerprint_hard_burned
+        _fingerprint_hard_burned.add(agent_id)
+        _fingerprint_hard_burn_reason[agent_id] = (vendor, reason)
+        _fingerprint_last_signal[agent_id] = time.time()
+    return not already
 
 
 async def _get_fingerprint_health(agent_id: str) -> dict:
@@ -936,15 +1035,26 @@ async def _get_fingerprint_health(agent_id: str) -> dict:
     ``test_fingerprint_health::test_health_endpoint_shape``::
 
         {"window_size": int, "rejection_rate": float, "burned": bool,
-         "last_signal_ts": str | None}
+         "last_signal_ts": str | None,
+         "hard_burned": bool, "hard_burn_reason": {vendor, signal} | None}
 
     ``rejection_rate`` is 0.0 when the window is empty (avoid divide-by-zero
     surprises in the dashboard).  ``last_signal_ts`` is ISO-8601 UTC, or
     ``None`` when no signal has ever been recorded for this agent.
+
+    ``hard_burned`` is True when an HTTP response from a known detection
+    vendor surfaced a hard-block header (cf-mitigated=block,
+    X-PX-Block-Type, X-Datadome=protected, X-Akamai-Bmp-Action=deny). The
+    rolling-window ``burned`` flag is also forced True under that
+    condition so existing operator UI keeps working unchanged; the
+    ``hard_burned`` field lets dashboards present a distinct
+    "vendor-confirmed block" state.
     """
     async with _get_fingerprint_lock():
         bucket = _fingerprint_window.get(agent_id)
         last_ts = _fingerprint_last_signal.get(agent_id)
+        hard_burned = agent_id in _fingerprint_hard_burned
+        reason_pair = _fingerprint_hard_burn_reason.get(agent_id)
         if bucket is None or len(bucket) == 0:
             window_size = 0
             rejection_rate = 0.0
@@ -954,11 +1064,19 @@ async def _get_fingerprint_health(agent_id: str) -> dict:
             rejected = sum(1 for v in bucket if v)
             rejection_rate = rejected / window_size
             burned = _is_burned_locked(bucket)
+    if hard_burned:
+        burned = True
+    reason_payload: dict | None = None
+    if reason_pair is not None:
+        vendor, signal = reason_pair
+        reason_payload = {"vendor": vendor, "signal": signal}
     return {
         "window_size": window_size,
         "rejection_rate": rejection_rate,
         "burned": burned,
         "last_signal_ts": _iso8601_utc(last_ts) if last_ts else None,
+        "hard_burned": hard_burned,
+        "hard_burn_reason": reason_payload,
     }
 
 
@@ -966,17 +1084,20 @@ async def _reset_fingerprint_window(agent_id: str) -> bool:
     """Operator-triggered reset.  Returns True if state was cleared.
 
     Called after the operator manually rotates the BrowserForge fingerprint
-    (no auto-rotation per §22 — see header note).  Drops both the rolling
-    window and the last-signal timestamp; the next post-solve outcome
-    starts a fresh window.
+    (no auto-rotation per §22 — see header note).  Drops the rolling
+    window, the last-signal timestamp, AND any hard-burn signal so the
+    next post-solve outcome starts from a fully clean slate.
     """
     async with _get_fingerprint_lock():
         had_state = (
             agent_id in _fingerprint_window
             or agent_id in _fingerprint_last_signal
+            or agent_id in _fingerprint_hard_burned
         )
         _fingerprint_window.pop(agent_id, None)
         _fingerprint_last_signal.pop(agent_id, None)
+        _fingerprint_hard_burned.discard(agent_id)
+        _fingerprint_hard_burn_reason.pop(agent_id, None)
     return had_state
 
 
@@ -3340,7 +3461,10 @@ class BrowserManager:
             # double-fire on the next tick.
             self._session_snapshot_elapsed_s[agent_id] = 0
             try:
-                ok = await snapshot_session(agent_id, inst.context)
+                signature = self._build_session_binding_signature(agent_id)
+                ok = await snapshot_session(
+                    agent_id, inst.context, binding_signature=signature,
+                )
             except Exception as e:
                 logger.warning(
                     "periodic session snapshot for '%s' raised: %s",
@@ -4182,7 +4306,10 @@ class BrowserManager:
 
         restored = None
         try:
-            restored = await restore_session(agent_id, _apply_state)
+            current_signature = self._build_session_binding_signature(agent_id)
+            restored = await restore_session(
+                agent_id, _apply_state, current_signature=current_signature,
+            )
         except Exception as e:
             # restore_session itself catches its inner errors; this
             # branch only fires if something exotic blew up.
@@ -4436,6 +4563,19 @@ class BrowserManager:
                 await task
             except (asyncio.CancelledError, Exception):
                 pass
+        # Drain any in-flight hard-burn flip tasks fired by the response
+        # listener before tearing down the context. They are short-lived
+        # (one ``_force_fingerprint_burn`` call + audit event) but we
+        # await them so the burn state is consistent for any downstream
+        # operator dashboard read.
+        burn_tasks = list(
+            getattr(inst, "_burn_pending_tasks", set()) or [],
+        )
+        for task in burn_tasks:
+            try:
+                await asyncio.wait_for(task, timeout=2.0)
+            except (asyncio.CancelledError, asyncio.TimeoutError, Exception):
+                pass
         jitter = getattr(inst, '_jitter_task', None)
         if jitter:
             jitter.cancel()
@@ -4480,7 +4620,10 @@ class BrowserManager:
             if get_bool(
                 "BROWSER_SESSION_PERSISTENCE_ENABLED", False, agent_id=agent_id,
             ):
-                ok = await snapshot_session(agent_id, inst.context)
+                signature = self._build_session_binding_signature(agent_id)
+                ok = await snapshot_session(
+                    agent_id, inst.context, binding_signature=signature,
+                )
                 try:
                     await _record_session_audit_event(
                         agent_id, "session_snapshot", ok,
@@ -4607,6 +4750,39 @@ class BrowserManager:
     def get_proxy_config(self, agent_id: str) -> dict | None:
         """Get stored proxy config for an agent, or None."""
         return self._proxy_configs.get(agent_id)
+
+    def _build_session_binding_signature(
+        self, agent_id: str,
+    ) -> dict[str, str | None]:
+        """Build a (UA, proxy) signature for cookie-binding invalidation.
+
+        Cloudflare / DataDome / PerimeterX bind tokens like ``cf_clearance``
+        to the original (UA, IP) tuple. Replaying them under a rotated
+        UA or different proxy egress is a guaranteed 403 AND a trust-score
+        hit. The signature lets ``session_persistence.restore_session``
+        detect the change and drop bound cookies before seeding the
+        context.
+
+        We hash UA + proxy server URL (not the egress IP itself, which is
+        often unknown to us). For most operators a proxy URL change is a
+        proxy provider change, which usually means a different egress IP
+        — close enough to gate cookie reuse on.
+
+        Returns ``{"ua": ..., "proxy": ...}`` with ``None`` for fields we
+        don't know. ``None`` keys are dropped before hashing so an
+        operator who never configures a proxy gets stable hashes across
+        snapshots.
+        """
+        ua = os.environ.get("BROWSER_UA_VERSION") or None
+        proxy_cfg = self._proxy_configs.get(agent_id)
+        proxy_url: str | None = None
+        if isinstance(proxy_cfg, dict):
+            proxy_url = (
+                proxy_cfg.get("server")
+                or proxy_cfg.get("url")
+                or None
+            )
+        return {"ua": ua, "proxy": proxy_url}
 
     async def get_status(self, agent_id: str) -> dict:
         """Get status for a specific agent's browser.
@@ -10535,6 +10711,15 @@ class BrowserManager:
                 "requestfailed",
                 lambda req: self._record_request_failed(inst, req),
             )
+            # §22 hard-burn: scan responses for known vendor block
+            # signals (cf-mitigated, X-PX-Block-Type, etc.). One hit
+            # short-circuits the 10-event rolling window — a vendor
+            # surfacing a confirmed block is a stronger signal than any
+            # heuristic body-text scan could ever provide.
+            inst.context.on(
+                "response",
+                lambda resp: self._record_response_for_burn(inst, resp),
+            )
         except Exception as e:
             # Listener wiring is best-effort: a Camoufox build that doesn't
             # surface these events shouldn't take the browser down. The
@@ -10583,6 +10768,71 @@ class BrowserManager:
             })
         except Exception as e:
             logger.debug("network listener record failed: %s", e)
+
+    def _record_response_for_burn(self, inst: CamoufoxInstance, resp) -> None:
+        """Listener — scan response for vendor hard-block signals.
+
+        Synchronous Playwright callback. If the response carries an
+        unambiguous vendor block header (``cf-mitigated: block``,
+        ``X-PX-Block-Type``, ``X-Datadome: protected``,
+        ``X-Akamai-Bmp-Action: deny``) on a 4xx/5xx status, schedule
+        a fingerprint hard-burn for the agent.
+
+        Best-effort: ANY exception here must not propagate (we're inside
+        a Playwright event callback; raising would tear down the listener).
+        """
+        try:
+            status = int(getattr(resp, "status", 0) or 0)
+            headers = getattr(resp, "headers", {}) or {}
+            classification = _classify_hard_block(headers, status)
+            if classification is None:
+                return
+            vendor, signal = classification
+        except Exception:
+            return
+        # Hop into the asyncio loop to flip state under the fingerprint
+        # lock. ``create_task`` is fire-and-forget by design — we don't
+        # await the burn from inside the listener.
+        try:
+            loop = asyncio.get_running_loop()
+        except RuntimeError:
+            return
+        task = loop.create_task(
+            self._on_hard_block_detected(inst.agent_id, vendor, signal),
+        )
+        # Hold a strong ref so the task doesn't get GC'd mid-flight.
+        # Bounded set bounded by the listener firing rate — see
+        # ``_drain_burn_tasks`` (re-uses an existing per-instance set
+        # of pending tasks if one exists; otherwise we allocate).
+        pending = getattr(inst, "_burn_pending_tasks", None)
+        if pending is None:
+            pending = set()
+            inst._burn_pending_tasks = pending
+        pending.add(task)
+        task.add_done_callback(pending.discard)
+
+    async def _on_hard_block_detected(
+        self, agent_id: str, vendor: str, signal: str,
+    ) -> None:
+        """Flip hard-burn state and emit the audit event exactly once."""
+        transitioned = await _force_fingerprint_burn(
+            agent_id, vendor, signal,
+        )
+        if transitioned:
+            try:
+                # Re-use the existing audit channel — operator dashboards
+                # already render fingerprint_burn rows; the new vendor
+                # context is captured in ``hard_burn_reason``.
+                page_origin = ""  # vendor-block events span sub-resources;
+                #                   no single origin is canonical
+                await _record_fingerprint_audit_event(
+                    agent_id, "fingerprint_burn", page_origin,
+                )
+            except Exception as e:
+                logger.debug(
+                    "Hard-burn audit emission failed for '%s': %s",
+                    agent_id, e,
+                )
 
     def _record_request_failed(self, inst: CamoufoxInstance, req) -> None:
         """Mark the matching log entry as blocked / cancelled / failed.

--- a/src/browser/service.py
+++ b/src/browser/service.py
@@ -6772,6 +6772,45 @@ class BrowserManager:
         # Fallback for edge cases
         await locator.scroll_into_view_if_needed(timeout=timeout)
 
+    @staticmethod
+    def _pick_click_target(box: dict) -> tuple[int, int]:
+        """Fitts'-Law-aware click coordinate sampler within a bbox.
+
+        Real users don't click bbox centers. Cursor distribution around
+        the visual centroid follows a 2D Gaussian whose σ scales with
+        target size — Fitts' Law in its empirical form (Card & MacKinlay
+        1980; later refined by MacKenzie 1992). The previous uniform
+        ±15% / ±10% sampler had three tells:
+
+          1. Constant density across the inner box — real distributions
+             are peaked at center.
+          2. Hard rectangular cutoff at ±15% — real cursors occasionally
+             land in the outer band.
+          3. No correlation between σ and element shape — for a long
+             button real σ_x is much larger than σ_y, but the prior
+             model didn't reflect that.
+
+        Implementation:
+          * Use σ = width/8, height/8 (so 99.7% within ±3σ ≈ width·0.375).
+          * Clamp to inner 95% of the bbox to avoid 0-width-band rounding
+            errors and never click outside the element.
+        """
+        if not box or "x" not in box or "width" not in box:
+            return (0, 0)
+        w = float(box.get("width", 0)) or 1.0
+        h = float(box.get("height", 0)) or 1.0
+        cx = float(box["x"]) + w / 2.0
+        cy = float(box["y"]) + h / 2.0
+        sigma_x = w / 8.0
+        sigma_y = h / 8.0
+        # Clamp to inner 95% of bbox so we never pick a point outside.
+        max_dx = w * 0.475
+        max_dy = h * 0.475
+        # Bounded 2D Gaussian — sample, clamp magnitude.
+        dx = max(-max_dx, min(max_dx, random.gauss(0.0, sigma_x)))
+        dy = max(-max_dy, min(max_dy, random.gauss(0.0, sigma_y)))
+        return (int(cx + dx), int(cy + dy))
+
     async def _x11_click(self, inst: CamoufoxInstance, locator, *,
                          timeout: int = _CLICK_TIMEOUT_MS) -> None:
         """Click via xdotool for isTrusted=true events.
@@ -6794,15 +6833,15 @@ class BrowserManager:
         await self._x11_ensure_in_viewport(inst, locator, timeout=timeout)
         await asyncio.sleep(x11_settle_delay())
 
-        # 2. Get element position — jitter within inner area, not dead center
+        # 2. Get element position — Fitts'-Law-aware Gaussian sampler
+        # peaked at bbox center; σ scales with element size so a wide
+        # button gets a wider distribution than a small icon. Replaces
+        # a uniform ±15% / ±10% sampler that was a detectable cluster
+        # (constant density + hard rectangular cutoff at ±15%).
         box = await locator.bounding_box()
         if not box:
             raise RuntimeError("Element has no bounding box — not visible")
-        # Real humans don't click dead center — offset within inner 60%
-        jitter_x = random.uniform(-0.15, 0.15) * box["width"]
-        jitter_y = random.uniform(-0.10, 0.10) * box["height"]
-        target_x = int(box["x"] + box["width"] / 2 + jitter_x)
-        target_y = int(box["y"] + box["height"] / 2 + jitter_y)
+        target_x, target_y = self._pick_click_target(box)
 
         wid = inst.x11_wid
         if not wid:
@@ -6877,11 +6916,9 @@ class BrowserManager:
         box = await locator.bounding_box()
         if not box:
             raise RuntimeError("Element has no bounding box — not visible")
-        # Jitter within inner area — same as _x11_click for consistency
-        jitter_x = random.uniform(-0.15, 0.15) * box["width"]
-        jitter_y = random.uniform(-0.10, 0.10) * box["height"]
-        target_x = int(box["x"] + box["width"] / 2 + jitter_x)
-        target_y = int(box["y"] + box["height"] / 2 + jitter_y)
+        # Fitts'-Law-aware Gaussian — same sampler as _x11_click so the
+        # mouse-event distribution out of hover-then-click is coherent.
+        target_x, target_y = self._pick_click_target(box)
 
         await self._x11_move_to(inst, target_x, target_y)
 

--- a/src/browser/session_persistence.py
+++ b/src/browser/session_persistence.py
@@ -86,6 +86,30 @@ _SCHEMA_VERSION = 1
 # writing junk. Cap the whole sidecar at 8 MiB so a hostile workflow
 # can't blow out the disk via persisted state.
 _MAX_SNAPSHOT_BYTES = 8 * 1024 * 1024
+
+# Cookie names known to be bound by detection vendors to a specific
+# (UA, IP) tuple. Replaying these under a rotated UA or a different
+# proxy egress IP triggers an immediate 403 — and worse, the failed
+# replay itself is recorded by the vendor as "session token used from
+# wrong origin", lowering our trust score for the lifetime of the
+# session. Drop them before restore when the binding signature changed.
+#
+# Match prefixes (case-insensitive) — vendors append agent-specific
+# suffixes (cf_clearance is bare; ``datadome`` cookie is exactly
+# ``datadome``; ``_abck``/``ak_bmsc`` are Akamai BMP; ``incap_ses_``,
+# ``visid_incap_`` are Imperva; ``pxhd``/``_px3`` are PerimeterX).
+_BINDING_SENSITIVE_COOKIE_PREFIXES: tuple[str, ...] = (
+    "cf_clearance",   # Cloudflare
+    "datadome",        # DataDome
+    "_abck",           # Akamai BMP
+    "ak_bmsc",         # Akamai BMP secondary
+    "bm_sv",           # Akamai BMP supplementary
+    "bm_sz",           # Akamai BMP supplementary
+    "incap_ses_",      # Imperva session
+    "visid_incap_",    # Imperva visitor
+    "pxhd",            # PerimeterX device
+    "_px",             # PerimeterX (_px, _px2, _px3)
+)
 # Reuse the canonical agent-id regex — sidecars are written under
 # ``<dir>/<agent_id>.json`` and an unvalidated agent_id is a directory
 # traversal vector (``../../etc/passwd``).
@@ -141,7 +165,62 @@ def session_path(agent_id: str) -> Path:
 # ── Snapshot ───────────────────────────────────────────────────────────────
 
 
-async def snapshot_session(agent_id: str, context: Any) -> bool:
+def _hash_signature(parts: dict[str, str | None]) -> str:
+    """Stable SHA-256 of (key, value) pairs after dropping None values.
+
+    Used to detect "did the agent's UA or proxy change since the last
+    snapshot" without storing the raw UA/proxy on disk. We only need
+    equality, never recovery. Trimmed to 16 hex chars — collision risk
+    is irrelevant because we never authenticate based on the digest.
+    """
+    import hashlib
+    kept = sorted((k, v) for k, v in parts.items() if v)
+    serialized = json.dumps(kept, separators=(",", ":"), sort_keys=False)
+    return hashlib.sha256(serialized.encode("utf-8")).hexdigest()[:16]
+
+
+def _drop_binding_sensitive_cookies(state: dict, vendors_seen: list[str]) -> int:
+    """Strip cookies whose names match the binding-sensitive prefix list.
+
+    Mutates ``state`` in place. Returns the number of cookies removed.
+    Caller logs the count + vendor names. We do NOT log specific cookie
+    names or values to keep the audit trail privacy-safe.
+    """
+    cookies = state.get("cookies")
+    if not isinstance(cookies, list):
+        return 0
+    kept: list = []
+    dropped = 0
+    for cookie in cookies:
+        if not isinstance(cookie, dict):
+            kept.append(cookie)
+            continue
+        name = (cookie.get("name") or "").lower()
+        bound = False
+        for prefix in _BINDING_SENSITIVE_COOKIE_PREFIXES:
+            if name == prefix or name.startswith(prefix):
+                bound = True
+                # Track which vendor families we dropped (de-dupe by
+                # caller). Helps operators see "we dropped Cloudflare
+                # tokens" without leaking specific cookie names.
+                family = prefix.split("_", 1)[0] or prefix
+                if family not in vendors_seen:
+                    vendors_seen.append(family)
+                break
+        if bound:
+            dropped += 1
+        else:
+            kept.append(cookie)
+    state["cookies"] = kept
+    return dropped
+
+
+async def snapshot_session(
+    agent_id: str,
+    context: Any,
+    *,
+    binding_signature: dict[str, str | None] | None = None,
+) -> bool:
     """Capture ``context.storage_state()`` to the per-agent sidecar.
 
     ``context`` is duck-typed as a Playwright ``BrowserContext``; only
@@ -203,11 +282,19 @@ async def snapshot_session(agent_id: str, context: Any) -> bool:
         )
         return False
 
-    payload = {
+    payload: dict = {
         "version": _SCHEMA_VERSION,
         "saved_at": int(time.time()),
         "storage_state": state,
     }
+    if binding_signature:
+        # Persist a short hash of the (UA, proxy) used when this state
+        # was captured. On restore, the caller passes the current
+        # signature; if it differs we drop binding-sensitive cookies
+        # (cf_clearance et al.) before seeding the context. Stored as
+        # an opaque digest so the file does not leak the specific UA
+        # version or proxy URL beyond what the cookies themselves do.
+        payload["binding_signature"] = _hash_signature(binding_signature)
 
     # Cap serialized payload size before opening any file. A hostile
     # site can inflate one origin's localStorage near the per-origin
@@ -281,6 +368,8 @@ async def snapshot_session(agent_id: str, context: Any) -> bool:
 async def restore_session(
     agent_id: str,
     context_factory: Callable[..., Awaitable[Any]],
+    *,
+    current_signature: dict[str, str | None] | None = None,
 ) -> Any | None:
     """Build a BrowserContext seeded with the previously-snapshotted state.
 
@@ -288,6 +377,15 @@ async def restore_session(
     given a ``storage_state`` keyword argument — passed in so the
     caller's full context-creation parameters (proxy, viewport, init
     scripts) are preserved. We just inject the storage_state.
+
+    ``current_signature`` is an optional dict of binding-relevant fields
+    (typically ``{"ua": ..., "proxy": ...}``) that the caller knows about
+    NOW. When supplied alongside a snapshot that recorded a binding
+    signature, a mismatch causes binding-sensitive cookies (cf_clearance
+    et al.) to be dropped before the context is seeded. Cloudflare /
+    DataDome / PerimeterX bind these tokens to (UA, IP); replaying them
+    under a different fingerprint or proxy is a guaranteed 403 AND a
+    trust-score hit. Better to fall back to a fresh challenge.
 
     Returns the new context on success; ``None`` when:
 
@@ -346,6 +444,31 @@ async def restore_session(
             "type; starting fresh", agent_id,
         )
         return None
+
+    # Binding-cookie invalidation: when the caller knows the current
+    # signature (UA, proxy egress) AND the sidecar recorded one at
+    # snapshot time, compare. On mismatch, drop binding-sensitive
+    # cookies before seeding the context. Old-format snapshots (no
+    # binding_signature persisted) and callers that don't supply
+    # ``current_signature`` skip this step transparently.
+    persisted_sig = payload.get("binding_signature")
+    if (
+        current_signature
+        and isinstance(persisted_sig, str)
+        and persisted_sig
+    ):
+        live_sig = _hash_signature(current_signature)
+        if live_sig != persisted_sig:
+            vendors_seen: list[str] = []
+            dropped = _drop_binding_sensitive_cookies(state, vendors_seen)
+            if dropped:
+                logger.info(
+                    "session restore for '%s': binding signature changed "
+                    "(persisted=%s live=%s); dropped %d cookies bound to "
+                    "vendors: %s",
+                    agent_id, persisted_sig, live_sig, dropped,
+                    ",".join(vendors_seen) or "(none)",
+                )
 
     try:
         context = await context_factory(storage_state=state)

--- a/tests/test_browser_service.py
+++ b/tests/test_browser_service.py
@@ -7008,6 +7008,71 @@ class TestStealthDeadCodeRemoved:
 # ── X11 input bypass tests ────────────────────────────────────────────────
 
 
+class TestPickClickTarget:
+    """Fitts'-Law-aware click coordinate sampler.
+
+    Replaces a uniform ±15%/±10% sampler that was a detectable cluster
+    (constant density + hard rectangular cutoff at ±15%). The new
+    sampler is a 2D Gaussian peaked at bbox center with σ scaling to
+    element size, clamped to inner 95%."""
+
+    def test_target_lands_inside_inner_95_percent(self):
+        from src.browser.service import BrowserManager
+        box = {"x": 100, "y": 200, "width": 80, "height": 30}
+        # Sample many times — every result must land within inner 95%
+        for _ in range(1000):
+            tx, ty = BrowserManager._pick_click_target(box)
+            assert 100 + 80 * 0.025 - 1 <= tx <= 100 + 80 * 0.975 + 1
+            assert 200 + 30 * 0.025 - 1 <= ty <= 200 + 30 * 0.975 + 1
+
+    def test_distribution_peaks_at_center(self):
+        """A 2D Gaussian must show density concentration near the
+        center — sample 5000 points and verify the empirical mean is
+        within 1px of the geometric center."""
+        import statistics
+
+        from src.browser.service import BrowserManager
+        box = {"x": 0, "y": 0, "width": 200, "height": 100}
+        xs, ys = [], []
+        for _ in range(5000):
+            tx, ty = BrowserManager._pick_click_target(box)
+            xs.append(tx)
+            ys.append(ty)
+        mx, my = statistics.mean(xs), statistics.mean(ys)
+        # Center is (100, 50); empirical mean within 2px on each axis.
+        assert abs(mx - 100) <= 2
+        assert abs(my - 50) <= 2
+
+    def test_sigma_scales_with_size(self):
+        """σ should scale with element size — small icons get tight
+        clicks, wide buttons get spread. Empirical std should be ~width/8."""
+        import statistics
+
+        from src.browser.service import BrowserManager
+        wide = {"x": 0, "y": 0, "width": 400, "height": 40}
+        small = {"x": 0, "y": 0, "width": 24, "height": 24}
+        wide_xs = [BrowserManager._pick_click_target(wide)[0] for _ in range(2000)]
+        small_xs = [BrowserManager._pick_click_target(small)[0] for _ in range(2000)]
+        wide_std = statistics.stdev(wide_xs)
+        small_std = statistics.stdev(small_xs)
+        # Wide element produces a much wider distribution.
+        assert wide_std > small_std * 5
+
+    def test_zero_size_box_doesnt_explode(self):
+        # Defensive: a malformed bbox shouldn't crash the sampler.
+        from src.browser.service import BrowserManager
+        out = BrowserManager._pick_click_target(
+            {"x": 50, "y": 50, "width": 0, "height": 0},
+        )
+        assert isinstance(out, tuple)
+        assert len(out) == 2
+
+    def test_missing_keys_returns_origin(self):
+        from src.browser.service import BrowserManager
+        assert BrowserManager._pick_click_target({}) == (0, 0)
+        assert BrowserManager._pick_click_target(None) == (0, 0)
+
+
 class TestX11Input:
     """Tests for X11 click/type bypass (isTrusted=true events)."""
 
@@ -7105,7 +7170,10 @@ class TestX11Input:
             with patch("src.browser.service.asyncio.sleep", new_callable=AsyncMock):
                 with patch("src.browser.service.random.randint", return_value=4):
                     with patch("src.browser.service.random.uniform", return_value=0.0):
-                        await mgr._x11_click(inst, mock_locator)
+                        # Click target uses Fitts'-Law Gaussian; pin
+                        # gauss=0 so the resolved point is bbox center.
+                        with patch("src.browser.service.random.gauss", return_value=0.0):
+                            await mgr._x11_click(inst, mock_locator)
 
         # With offsets=0 and start=(0,0), last mousemove should be at target (140, 215)
         # Find the last mousemove call (before mousedown)

--- a/tests/test_fingerprint_health.py
+++ b/tests/test_fingerprint_health.py
@@ -42,16 +42,22 @@ def _reset_fingerprint_state():
     """Each test starts with empty module-level fingerprint state."""
     from src.browser.service import (
         _fingerprint_audit_buckets,
+        _fingerprint_hard_burn_reason,
+        _fingerprint_hard_burned,
         _fingerprint_last_signal,
         _fingerprint_window,
     )
     _fingerprint_window.clear()
     _fingerprint_last_signal.clear()
     _fingerprint_audit_buckets.clear()
+    _fingerprint_hard_burned.clear()
+    _fingerprint_hard_burn_reason.clear()
     yield
     _fingerprint_window.clear()
     _fingerprint_last_signal.clear()
     _fingerprint_audit_buckets.clear()
+    _fingerprint_hard_burned.clear()
+    _fingerprint_hard_burn_reason.clear()
 
 
 class TestRollingWindow:
@@ -68,6 +74,8 @@ class TestRollingWindow:
             "rejection_rate": 0.0,
             "burned": False,
             "last_signal_ts": None,
+            "hard_burned": False,
+            "hard_burn_reason": None,
         }
 
     @pytest.mark.asyncio
@@ -145,6 +153,157 @@ class TestRollingWindow:
         from src.browser.service import _reset_fingerprint_window
         cleared = await _reset_fingerprint_window("agent-never")
         assert cleared is False
+
+
+# ── F8: HTTP-status-aware hard-burn from vendor block headers ────────────
+
+
+class TestHardBurnClassifier:
+    """The pure classifier identifies vendor block signals from response
+    headers + status. Stays decoupled from any Playwright shape so the
+    classifier itself can be regression-tested without spinning up a
+    browser instance."""
+
+    def test_no_block_on_2xx_even_with_vendor_header(self):
+        # Vendor headers can appear on accepted 200 responses for
+        # watch-but-allow flows; we must NOT burn there.
+        from src.browser.service import _classify_hard_block
+        out = _classify_hard_block(
+            {"cf-mitigated": "block", "cf-ray": "abc"}, status=200,
+        )
+        assert out is None
+
+    def test_cloudflare_block_on_403(self):
+        from src.browser.service import _classify_hard_block
+        out = _classify_hard_block(
+            {"CF-Mitigated": "block", "cf-ray": "abc"}, status=403,
+        )
+        assert out is not None
+        vendor, signal = out
+        assert vendor == "cloudflare"
+        assert "cf-mitigated" in signal
+
+    def test_cloudflare_challenge_is_not_hard_block(self):
+        # cf-mitigated: challenge is the soft-challenge case (we already
+        # have body-text scanning for that). Hard burn only on
+        # ``block`` / ``dcv``.
+        from src.browser.service import _classify_hard_block
+        out = _classify_hard_block(
+            {"cf-mitigated": "challenge"}, status=403,
+        )
+        assert out is None
+
+    def test_perimeterx_block_on_403(self):
+        from src.browser.service import _classify_hard_block
+        out = _classify_hard_block(
+            {"x-px-block-type": "1"}, status=403,
+        )
+        assert out is not None
+        assert out[0] == "perimeterx"
+
+    def test_perimeterx_empty_value_not_block(self):
+        from src.browser.service import _classify_hard_block
+        out = _classify_hard_block(
+            {"x-px-block-type": "  "}, status=403,
+        )
+        assert out is None
+
+    def test_datadome_protected(self):
+        from src.browser.service import _classify_hard_block
+        out = _classify_hard_block(
+            {"x-datadome": "protected"}, status=403,
+        )
+        assert out is not None
+        assert out[0] == "datadome"
+
+    def test_datadome_ok_not_block(self):
+        from src.browser.service import _classify_hard_block
+        out = _classify_hard_block(
+            {"x-datadome": "ok"}, status=200,
+        )
+        assert out is None
+
+    def test_akamai_bmp_deny(self):
+        from src.browser.service import _classify_hard_block
+        out = _classify_hard_block(
+            {"x-akamai-bmp-action": "deny"}, status=403,
+        )
+        assert out is not None
+        assert out[0] == "akamai"
+
+    def test_4xx_alone_is_not_hard_block(self):
+        # A bare 403 with no vendor header is NOT a hard burn — could
+        # be a regular site-level deny (auth, perms). Hard burn requires
+        # vendor confirmation.
+        from src.browser.service import _classify_hard_block
+        assert _classify_hard_block({}, status=403) is None
+        assert _classify_hard_block({"server": "nginx"}, status=403) is None
+
+
+class TestForceFingerprintBurn:
+    @pytest.mark.asyncio
+    async def test_force_burn_short_circuits_window(self):
+        """Hard-burn should fire immediately without waiting for the
+        10-event rolling window to fill."""
+        from src.browser.service import (
+            _force_fingerprint_burn,
+            _is_fingerprint_burned,
+        )
+
+        agent = "agent-hard-burn"
+        # Window is empty — _is_fingerprint_burned would normally be False.
+        assert await _is_fingerprint_burned(agent) is False
+
+        transitioned = await _force_fingerprint_burn(
+            agent, vendor="cloudflare", reason="cf-mitigated=block",
+        )
+        assert transitioned is True
+        # Now the agent reads as burned even though the rolling window
+        # never filled.
+        assert await _is_fingerprint_burned(agent) is True
+
+    @pytest.mark.asyncio
+    async def test_force_burn_idempotent(self):
+        from src.browser.service import _force_fingerprint_burn
+
+        agent = "agent-twice"
+        first = await _force_fingerprint_burn(agent, "perimeterx", "x-px-block-type=1")
+        second = await _force_fingerprint_burn(agent, "perimeterx", "x-px-block-type=1")
+        assert first is True
+        assert second is False  # state already transitioned
+
+    @pytest.mark.asyncio
+    async def test_health_payload_surfaces_hard_burn(self):
+        from src.browser.service import (
+            _force_fingerprint_burn,
+            _get_fingerprint_health,
+        )
+
+        agent = "agent-payload"
+        await _force_fingerprint_burn(agent, "datadome", "x-datadome=protected")
+        out = await _get_fingerprint_health(agent)
+        assert out["hard_burned"] is True
+        assert out["burned"] is True  # union with rolling-window
+        assert out["hard_burn_reason"] == {
+            "vendor": "datadome",
+            "signal": "x-datadome=protected",
+        }
+
+    @pytest.mark.asyncio
+    async def test_reset_clears_hard_burn(self):
+        from src.browser.service import (
+            _force_fingerprint_burn,
+            _is_fingerprint_burned,
+            _reset_fingerprint_window,
+        )
+
+        agent = "agent-reset"
+        await _force_fingerprint_burn(agent, "akamai", "x-akamai-bmp-action=deny")
+        assert await _is_fingerprint_burned(agent) is True
+
+        cleared = await _reset_fingerprint_window(agent)
+        assert cleared is True
+        assert await _is_fingerprint_burned(agent) is False
 
 
 # ── §11.17 exclusion rules ────────────────────────────────────────────────

--- a/tests/test_session_persistence.py
+++ b/tests/test_session_persistence.py
@@ -551,6 +551,148 @@ class TestSizeCap:
         assert not sp.session_path("agent-big").exists()
 
 
+class TestBindingCookieInvalidation:
+    """F9: cf_clearance / datadome / etc. cookies are bound to (UA, IP).
+    On UA or proxy rotation we must drop them before restore so a
+    guaranteed-403 replay doesn't blow our trust score."""
+
+    def test_drop_helper_strips_known_vendors(self):
+        state = {
+            "cookies": [
+                {"name": "cf_clearance", "value": "abc"},
+                {"name": "datadome", "value": "xyz"},
+                {"name": "_abck", "value": "ak"},
+                {"name": "incap_ses_42", "value": "imp"},
+                {"name": "visid_incap_42", "value": "imp2"},
+                {"name": "pxhd", "value": "px"},
+                {"name": "_px3", "value": "px3"},
+                {"name": "session", "value": "keep-this"},
+                {"name": "csrftoken", "value": "keep-this-too"},
+            ],
+            "origins": [],
+        }
+        vendors: list[str] = []
+        dropped = sp._drop_binding_sensitive_cookies(state, vendors)
+        assert dropped == 7
+        names = {c["name"] for c in state["cookies"]}
+        assert names == {"session", "csrftoken"}
+
+    def test_signature_hash_is_stable_and_diffs_meaningfully(self):
+        a = sp._hash_signature({"ua": "Firefox/138", "proxy": "socks5://h:1"})
+        b = sp._hash_signature({"ua": "Firefox/138", "proxy": "socks5://h:1"})
+        assert a == b
+        c = sp._hash_signature({"ua": "Firefox/139", "proxy": "socks5://h:1"})
+        assert a != c
+        d = sp._hash_signature({"ua": "Firefox/138", "proxy": "socks5://h:2"})
+        assert a != d
+
+    def test_signature_drops_none_values(self):
+        a = sp._hash_signature({"ua": None, "proxy": None})
+        b = sp._hash_signature({})
+        assert a == b
+
+    @pytest.mark.asyncio
+    async def test_snapshot_persists_signature_when_provided(self, tmp_path):
+        ctx = _FakeContext()
+        ok = await sp.snapshot_session(
+            "agent-bind", ctx,
+            binding_signature={"ua": "Firefox/138", "proxy": "socks5://a"},
+        )
+        assert ok
+        path = sp.session_path("agent-bind")
+        payload = json.loads(path.read_text())
+        assert "binding_signature" in payload
+        assert isinstance(payload["binding_signature"], str)
+
+    @pytest.mark.asyncio
+    async def test_snapshot_omits_signature_when_not_provided(self):
+        ctx = _FakeContext()
+        ok = await sp.snapshot_session("agent-no-sig", ctx)
+        assert ok
+        path = sp.session_path("agent-no-sig")
+        payload = json.loads(path.read_text())
+        assert "binding_signature" not in payload
+
+    @pytest.mark.asyncio
+    async def test_restore_drops_bound_cookies_on_signature_mismatch(self):
+        ctx = _FakeContext({
+            "cookies": [
+                {"name": "cf_clearance", "value": "old"},
+                {"name": "datadome", "value": "old"},
+                {"name": "session", "value": "keep"},
+            ],
+            "origins": [],
+        })
+        await sp.snapshot_session(
+            "agent-rotate", ctx,
+            binding_signature={"ua": "Firefox/138", "proxy": "socks5://a"},
+        )
+
+        applied_state: dict = {}
+
+        async def factory(*, storage_state):
+            applied_state["state"] = storage_state
+            return MagicMock()
+
+        out = await sp.restore_session(
+            "agent-rotate", factory,
+            current_signature={"ua": "Firefox/139", "proxy": "socks5://a"},
+        )
+        assert out is not None
+        names = {c["name"] for c in applied_state["state"]["cookies"]}
+        assert names == {"session"}  # bound cookies dropped
+
+    @pytest.mark.asyncio
+    async def test_restore_preserves_cookies_when_signature_matches(self):
+        ctx = _FakeContext({
+            "cookies": [
+                {"name": "cf_clearance", "value": "k"},
+                {"name": "session", "value": "k"},
+            ],
+            "origins": [],
+        })
+        await sp.snapshot_session(
+            "agent-same", ctx,
+            binding_signature={"ua": "Firefox/138", "proxy": "socks5://a"},
+        )
+        applied_state: dict = {}
+
+        async def factory(*, storage_state):
+            applied_state["state"] = storage_state
+            return MagicMock()
+
+        out = await sp.restore_session(
+            "agent-same", factory,
+            current_signature={"ua": "Firefox/138", "proxy": "socks5://a"},
+        )
+        assert out is not None
+        names = {c["name"] for c in applied_state["state"]["cookies"]}
+        assert names == {"cf_clearance", "session"}
+
+    @pytest.mark.asyncio
+    async def test_restore_no_invalidation_when_caller_omits_signature(self):
+        # Backward compat: callers not yet plumbed for current_signature
+        # see existing behavior (no cookie drops).
+        ctx = _FakeContext({
+            "cookies": [{"name": "cf_clearance", "value": "k"}],
+            "origins": [],
+        })
+        await sp.snapshot_session(
+            "agent-legacy", ctx,
+            binding_signature={"ua": "Firefox/138", "proxy": "socks5://a"},
+        )
+        applied_state: dict = {}
+
+        async def factory(*, storage_state):
+            applied_state["state"] = storage_state
+            return MagicMock()
+
+        out = await sp.restore_session("agent-legacy", factory)
+        assert out is not None
+        names = {c["name"] for c in applied_state["state"]["cookies"]}
+        assert names == {"cf_clearance"}
+
+
 class TestSessionsDirMode:
     @pytest.mark.asyncio
     async def test_parent_dir_chmod_0o700(self, tmp_path, monkeypatch):


### PR DESCRIPTION
Follow-up to #803 covering the two HIGH-severity antibot items deferred from the audit. Stacks on top of #803 — review/merge #803 first, then rebase/merge this.

## F8 — Vendor-confirmed hard-burn

The post-solve fingerprint-burn detector currently relies on a 10-event rolling window with a 50% threshold. A real Cloudflare \`cf-mitigated: block\` or PerimeterX \`X-PX-Block-Type: 1\` on a 403 was indistinguishable from any other rejection — the operator had to wait for 5+ rejections in the window before the burn fired. Now: one vendor-confirmed block fires immediately.

**Implementation:**
- \`context.on(\"response\")\` listener scans every response for unambiguous block headers on 4xx/5xx status:
  - Cloudflare: \`cf-mitigated: block | dcv\`
  - PerimeterX: \`X-PX-Block-Type\` (any non-empty value)
  - DataDome: \`X-Datadome: protected | blocked\`
  - Akamai BMP: \`X-Akamai-Bmp-Action: deny\`
- Pure \`_classify_hard_block(headers, status)\` so vendor logic is unit-testable without a browser.
- Hard-burn state exposed on \`/browser/{agent}/fingerprint-health\` via new \`hard_burned\` + \`hard_burn_reason: {vendor, signal}\` fields. Rolling-window \`burned\` is forced True so existing dashboards keep rendering unchanged.

## F9 — (UA, IP) binding-cookie invalidation

Cloudflare's \`cf_clearance\`, DataDome's \`datadome\` cookie, Akamai's \`_abck\` family, Imperva's \`incap_ses_*\`, PerimeterX's \`pxhd\` / \`_px[2,3]\` — all bound by their issuers to the original (UA, IP) tuple. Replaying under rotated UA / proxy is a guaranteed 403 AND lowers trust for the lifetime of the session.

**Implementation:**
- \`session_persistence.snapshot_session\` accepts optional \`binding_signature={\"ua\", \"proxy\"}\`; \`restore_session\` accepts \`current_signature\`. Hash stored on disk (equality-only).
- On mismatch, binding-sensitive cookies are stripped from \`storage_state\` before context seeding.
- \`BrowserManager._build_session_binding_signature()\` plumbs \`BROWSER_UA_VERSION\` + per-agent proxy URL through both periodic and stop-time snapshot calls.
- Fully backward-compatible: callers that don't pass either field get existing behavior.

## Test plan
- [x] 4817 passed (+ 44 skipped) excluding e2e
- [x] Ruff clean
- [x] 20 new test cases:
  - 8 classifier cases (vendor matches, status floor, header normalisation, empty values)
  - 4 force-burn cases (idempotence, payload, reset, empty-window short-circuit)
  - 8 binding-cookie cases (vendor name list, hash stability, snapshot shape, restore drops/preserves, backward-compat)

## Out-of-scope follow-ups (still deferred)
- Idle mouse jitter Hawkes process
- Bezier per-segment jerk noise
- Click coordinate Fitts'-Law jitter

Larger behavioral changes worth their own PRs.