### PR TITLE
fix(browser): Hawkes idle jitter + Bezier per-segment jerk noise

### DIFF
--- a/src/browser/service.py
+++ b/src/browser/service.py
@@ -6638,29 +6638,46 @@ class BrowserManager:
         cp2_x = start_x + dx * 0.75 + perp_x * off2
         cp2_y = start_y + dy * 0.75 + perp_y * off2
 
-        # Scale step count with distance — short moves stay snappy,
-        # long moves stay smooth.  Range: 3 steps (tiny) to 14 (across screen).
-        steps = max(3, min(14, int(dist / 80) + random.randint(2, 4)))
+        # Step density: real mousemove streams fire at ~125 Hz on Linux.
+        # The prior heuristic capped at 14 waypoints — for a 600 px move
+        # that's only ~9 events at ~67 px each, much coarser than a
+        # real cursor and a detectable cluster signal. Scale to roughly
+        # one waypoint per 15 px instead, with a hard cap so we don't
+        # generate hundreds of xdotool calls on full-screen sweeps.
+        steps = max(8, min(60, int(dist / 15) + random.randint(2, 4)))
 
         for i in range(1, steps + 1):
             # Raw parameter
             raw_t = i / steps
             # Cubic ease-in-out: slow start, fast middle, slow landing
-            # Models Fitts' Law deceleration as cursor approaches target
+            # Models Fitts' Law deceleration as cursor approaches target.
             if raw_t < 0.5:
                 t = 4 * raw_t * raw_t * raw_t
             else:
                 t = 1 - ((-2 * raw_t + 2) ** 3) / 2
 
             u = 1 - t
-            wp_x = int(
+            wp_x_f = (
                 u**3 * start_x + 3 * u**2 * t * cp1_x
                 + 3 * u * t**2 * cp2_x + t**3 * target_x
             )
-            wp_y = int(
+            wp_y_f = (
                 u**3 * start_y + 3 * u**2 * t * cp1_y
                 + 3 * u * t**2 * cp2_y + t**3 * target_y
             )
+            # Per-step jerk noise: real human cursors carry wrist micro-
+            # tremor (3rd-derivative noise). The C∞-smooth cubic is
+            # detectable as a clean signal-vs-noise cluster. Add small
+            # Gaussian perturbation perpendicular to the path, scaled
+            # by velocity (curve speed): cursors are more jittery while
+            # accelerating mid-cruise than at the slow end-points.
+            # Velocity proxy: ds/dt at this step ≈ |dt'/dt|.
+            vel_factor = math.sin(math.pi * raw_t)  # 0 at endpoints, 1 mid-path
+            tremor_sigma = 0.6 + 1.2 * vel_factor   # px
+            jx = random.gauss(0.0, tremor_sigma) * perp_x
+            jy = random.gauss(0.0, tremor_sigma) * perp_y
+            wp_x = int(wp_x_f + jx)
+            wp_y = int(wp_y_f + jy)
             wp_x = max(0, wp_x)
             wp_y = max(0, wp_y)
             mv_result = await loop.run_in_executor(
@@ -6922,6 +6939,41 @@ class BrowserManager:
 
         await self._x11_move_to(inst, target_x, target_y)
 
+    @staticmethod
+    def _next_jitter_event() -> tuple[float, int]:
+        """Return (sleep_seconds, burst_count) for the next idle-jitter cycle.
+
+        Replaces the prior uniform ``random.uniform(2.0, 7.0)`` schedule
+        with an on-off (Hawkes-like) process closer to real cursor
+        traces. Real users sit still for long stretches (reading) then
+        produce 2–4 corrective micro-movements in a quick burst before
+        going still again. The flat 2–7s schedule produced a constant
+        autocorrelation in the mousemove stream — a free cluster signal
+        for ArkoseLabs / DataDome / PerimeterX behavioral models.
+
+        Distribution:
+          * 80% of cycles → "quiet" period: lognormal mean ~22s, σ that
+            yields a heavy right tail (so occasional 60s+ stretches
+            occur naturally), single movement.
+          * 20% of cycles → "burst" period: short pause (0.4–1.2s)
+            then 2–4 movements back-to-back.
+
+        Returns ``(sleep_before_next_event, burst_count)``. The caller
+        treats burst_count > 1 as "fire that many movements with short
+        intra-burst gaps" — the gaps are sampled separately.
+        """
+        if random.random() < 0.20:
+            # Burst arrival: short hand-off gap.
+            sleep_s = random.uniform(0.4, 1.2)
+            burst_count = random.randint(2, 4)
+        else:
+            # Quiet period: lognormal so the mean is ~22s but the tail
+            # reaches >60s. random.lognormvariate(mu=ln(20), sigma=0.5)
+            # produces a median ≈ 20s, mean ≈ 23s, p99 ≈ 70s.
+            sleep_s = min(120.0, random.lognormvariate(math.log(20.0), 0.5))
+            burst_count = 1
+        return (sleep_s, burst_count)
+
     async def _idle_mouse_jitter(self, inst: CamoufoxInstance) -> None:
         """Periodic mouse micro-movement to simulate human fidgeting.
 
@@ -6929,30 +6981,54 @@ class BrowserManager:
         drifts, twitches, and repositioning. A mouse that is perfectly
         still for seconds between actions is a textbook bot pattern
         detected by ArkoseLabs and DataDome.
+
+        Schedule shape: long quiet periods interleaved with bursts of
+        2–4 corrective movements (see ``_next_jitter_event``). Within
+        a burst the displacement vectors are auto-correlated (next
+        ``(dx, dy)`` is a small perturbation of the prior one) — real
+        cursor twitches don't randomly switch direction frame to frame.
         """
+        last_dx = 0
+        last_dy = 0
         while True:
-            await asyncio.sleep(random.uniform(2.0, 7.0))
+            sleep_s, burst_count = self._next_jitter_event()
+            await asyncio.sleep(sleep_s)
             if not inst.x11_wid or inst.lock.locked() or inst._user_control:
                 continue
-            try:
-                dx = random.randint(-3, 3)
-                dy = random.randint(-2, 2)
+            for i in range(burst_count):
+                if i > 0:
+                    # Intra-burst gap: short, lognormal.
+                    await asyncio.sleep(
+                        random.uniform(0.08, 0.35),
+                    )
+                # Auto-correlated displacement — next movement carries
+                # ~50% of the prior direction plus a small random delta,
+                # so a burst looks like a continuous corrective drift
+                # rather than independent twitches.
+                dx = int(round(0.5 * last_dx + random.gauss(0, 1.6)))
+                dy = int(round(0.5 * last_dy + random.gauss(0, 1.2)))
+                # Clamp to ±5 px so we don't drift far from the cursor's
+                # actual reading position.
+                dx = max(-5, min(5, dx))
+                dy = max(-5, min(5, dy))
                 if dx == 0 and dy == 0:
                     continue
-                loop = asyncio.get_running_loop()
-                await loop.run_in_executor(
-                    None,
-                    lambda _dx=dx, _dy=dy: subprocess.run(
-                        ["xdotool", "mousemove_relative", "--sync",
-                         "--", str(_dx), str(_dy)],
-                        capture_output=True, timeout=2,
-                        env=inst.subprocess_env(),
-                    ),
-                )
-            except asyncio.CancelledError:
-                return
-            except Exception:
-                pass
+                last_dx, last_dy = dx, dy
+                try:
+                    loop = asyncio.get_running_loop()
+                    await loop.run_in_executor(
+                        None,
+                        lambda _dx=dx, _dy=dy: subprocess.run(
+                            ["xdotool", "mousemove_relative", "--sync",
+                             "--", str(_dx), str(_dy)],
+                            capture_output=True, timeout=2,
+                            env=inst.subprocess_env(),
+                        ),
+                    )
+                except asyncio.CancelledError:
+                    return
+                except Exception:
+                    pass
 
     async def _x11_type(self, inst: CamoufoxInstance, text: str,
                         *, typos: bool = True) -> None:

--- a/tests/test_browser_service.py
+++ b/tests/test_browser_service.py
@@ -7008,6 +7008,57 @@ class TestStealthDeadCodeRemoved:
 # ── X11 input bypass tests ────────────────────────────────────────────────
 
 
+class TestIdleJitterScheduler:
+    """Hawkes-like on-off schedule. The prior uniform 2–7s cycle was
+    a constant-autocorrelation signal in the mousemove stream — easy
+    cluster signal for ArkoseLabs / DataDome / PerimeterX. Real cursors
+    show long quiet periods + bursts of corrective movements."""
+
+    def test_quiet_periods_dominate_at_80_percent(self):
+        from src.browser.service import BrowserManager
+        single = 0
+        burst = 0
+        for _ in range(2000):
+            _sleep, count = BrowserManager._next_jitter_event()
+            if count == 1:
+                single += 1
+            else:
+                burst += 1
+        ratio = single / (single + burst)
+        # Allow ±5pp of empirical drift around the 0.80 target.
+        assert 0.75 <= ratio <= 0.85
+
+    def test_burst_count_is_2_to_4(self):
+        from src.browser.service import BrowserManager
+        for _ in range(500):
+            _sleep, count = BrowserManager._next_jitter_event()
+            assert count == 1 or 2 <= count <= 4
+
+    def test_quiet_period_has_heavy_tail(self):
+        """Lognormal tail: should produce some sleeps >40s out of 2000."""
+        from src.browser.service import BrowserManager
+        long_sleeps = 0
+        max_sleep = 0.0
+        for _ in range(2000):
+            sleep_s, count = BrowserManager._next_jitter_event()
+            if count == 1:
+                if sleep_s > 40:
+                    long_sleeps += 1
+                max_sleep = max(max_sleep, sleep_s)
+        # Heavy right tail: at least 1% of quiet periods exceed 40s.
+        assert long_sleeps > 5
+        # Capped at 120s to avoid runaway sleeps.
+        assert max_sleep <= 120.0
+
+    def test_burst_sleep_is_short(self):
+        """Burst arrivals fire after a short hand-off pause (0.4–1.2s)."""
+        from src.browser.service import BrowserManager
+        for _ in range(500):
+            sleep_s, count = BrowserManager._next_jitter_event()
+            if count > 1:
+                assert 0.4 <= sleep_s <= 1.2
+
+
 class TestPickClickTarget:
     """Fitts'-Law-aware click coordinate sampler.
 


### PR DESCRIPTION
Final two HIGH-severity behavioral items from the system audit (PR #803). Both close shape-of-distribution gaps that detection products use as cluster signals — the prior code worked correctly but produced detectable patterns in the mousemove stream.

## F4 — Hawkes-style on-off idle jitter

Replace \`random.uniform(2.0, 7.0)\` with an on-off process closer to real cursor traces:

- **80% of cycles → \"quiet\" period**: lognormal sleep (median ~20s, mean ~23s, p99 ~70s, hard cap 120s) + single movement.
- **20% of cycles → \"burst\" period**: short hand-off (0.4–1.2s) then 2–4 corrective movements with intra-burst gaps of 0.08–0.35s.
- Within a burst, displacement vectors are auto-correlated: next (dx, dy) carries ~50% of the prior direction plus N(0, ~1.5px). Real cursor twitches don't randomly switch direction frame-to-frame — burst movements look like a continuous corrective drift.
- \`_next_jitter_event()\` is a pure static helper so schedule shape is unit-testable without mocking subprocess.

## F5 — Bezier per-step jerk noise + denser waypoints

- **Step density**: scale to ~one waypoint per 15px (cap 60). Prior cap of 14 produced ~9 events for a 600px move at ~67px each — far coarser than a real ~125Hz mousemove stream.
- **Per-step Gaussian jerk noise** perpendicular to the path, scaled by velocity (sin(πt) — peaks mid-cruise, ~0 at endpoints). Real cursors carry wrist micro-tremor (3rd-derivative noise); the prior C∞-smooth cubic produced a clean signal-vs-noise cluster.

## Test plan
- [x] 479 browser_service tests pass
- [x] Ruff clean
- [x] 4 new \`TestIdleJitterScheduler\` cases:
  - 80/20 quiet/burst ratio empirical check (±5pp)
  - burst count range (2–4)
  - lognormal heavy tail (>1% of quiet periods >40s) + 120s cap
  - burst sleep range (0.4–1.2s)
- [x] Existing X11 click/scroll tests pass — no regression in trusted-event paths

## Audit closure
This wraps the antibot/security audit started in #803. All HIGH-severity findings from the audit are now fixed across #803 (12 issues), #804 (3 issues), and this PR (2 issues) — 17 total fixes, ~70 new test cases.