### PR TITLE
fix(test): anchor captcha tenant since-filter to month start

### DIFF
--- a/tests/test_captcha_cost_tenant.py
+++ b/tests/test_captcha_cost_tenant.py
@@ -175,10 +175,16 @@ class TestGetTenantTotal:
             await cost.add_cost("alpha", 100)
             await cost.add_cost("beta", 50)
             now = datetime.now(timezone.utc)
-            seven_days_ago = now - timedelta(days=7)
-            # ``since`` falling within the current month → live total.
+            # Anchor ``since`` to the first instant of the current
+            # calendar month. The previous ``now - timedelta(days=7)``
+            # crossed the month boundary on days 1–7, so the helper
+            # (which only stores current-month state in memory)
+            # correctly returned 0 — the assertion was the bug.
+            month_start = now.replace(
+                day=1, hour=0, minute=0, second=0, microsecond=0,
+            )
             assert await cost.get_tenant_total(
-                "tenant-a", since=seven_days_ago,
+                "tenant-a", since=month_start,
             ) == 150
 
     @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- ``test_since_filter_current_month_returns_live_total`` was failing on days 1–7 of any month because it used ``now - timedelta(days=7)`` for the ``since`` arg, which crosses the previous month boundary. The in-memory tenant cost state is current-month-only, so the helper correctly returned 0 — the test's expectation was the bug.
- Anchored ``since`` to the first instant of the current calendar month. Always inside the live window. Preserves the test's intent (since-filter passes through to the live aggregator when scoped to the current month).

## Test plan
- [x] ``pytest tests/test_captcha_cost_tenant.py`` — 29 passed
- [x] Reproduced the failure on pristine main (today is May 1; failure first surfaced in CI on a date-1 run)