### PR TITLE
feat(dashboard): always-visible browser speed sliders

### DIFF
--- a/src/dashboard/templates/index.html
+++ b/src/dashboard/templates/index.html
@@ -5041,25 +5041,35 @@
 
           <!-- ── Browser Speed & Stealth ──
                Two independent axes (per-action cadence + inter-action
-               think time) on one card.  Each axis gets a chip row of
-               named presets; sliders for non-preset values are tucked
-               behind Customize. -->
-          <div class="bg-gray-900 border border-gray-800 rounded-lg p-5"
-            x-data="{ customizeSpeed: false }">
-            <div class="flex items-center justify-between mb-3">
-              <div class="flex items-center gap-2">
-                <svg class="w-4 h-4 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 10V3L4 14h7v7l9-11h-7z"/></svg>
-                <h3 class="text-sm font-medium text-gray-200">Browser Speed &amp; Stealth</h3>
-                <span class="setting-hint" tabindex="0">?<span class="setting-hint-text">Speed controls per-action cadence (typing / click motion / scroll easing). Think time pauses between actions to mimic human deliberation. Slower values are stealthier on bot-defended sites; faster values cut wall-clock time on cooperative ones.</span></span>
-              </div>
-              <button @click="customizeSpeed = !customizeSpeed"
-                class="text-[10px] text-gray-500 hover:text-gray-300 underline transition-colors"
-                x-text="customizeSpeed ? 'Hide sliders' : 'Customize'"></button>
+               think time).  Slider is the primary control; named presets
+               act as quick-jump shortcuts. -->
+          <div class="bg-gray-900 border border-gray-800 rounded-lg p-5">
+            <div class="flex items-center gap-2 mb-4">
+              <svg class="w-4 h-4 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 10V3L4 14h7v7l9-11h-7z"/></svg>
+              <h3 class="text-sm font-medium text-gray-200">Browser Speed &amp; Stealth</h3>
+              <span class="setting-hint" tabindex="0">?<span class="setting-hint-text">Speed controls per-action cadence (typing / click motion / scroll easing). Think time pauses between actions to mimic human deliberation. Slower values are stealthier on bot-defended sites; faster values cut wall-clock time on cooperative ones.</span></span>
             </div>
-            <!-- Action speed row -->
-            <div class="flex items-center gap-3 py-2">
-              <span class="text-[11px] text-gray-400 w-24 shrink-0">Action speed</span>
-              <div class="flex flex-wrap gap-1 flex-1">
+
+            <!-- Action speed -->
+            <div class="mb-5">
+              <div class="flex items-center justify-between mb-1.5">
+                <span class="text-[11px] text-gray-400">Action speed</span>
+                <span class="text-[10px] text-gray-500 font-mono" x-text="browserSpeed.toFixed(2) + '×'"></span>
+              </div>
+              <div class="flex items-center gap-2 mb-2">
+                <span class="text-[10px] text-gray-600 w-8 shrink-0">0.25×</span>
+                <input type="range" min="0.25" max="4.0" step="0.05"
+                  :value="browserSpeed"
+                  @input="saveBrowserSpeed($event.target.value)"
+                  class="flex-1 h-1.5 bg-gray-700 rounded-full appearance-none cursor-pointer
+                    [&::-webkit-slider-thumb]:appearance-none [&::-webkit-slider-thumb]:w-3.5 [&::-webkit-slider-thumb]:h-3.5
+                    [&::-webkit-slider-thumb]:rounded-full [&::-webkit-slider-thumb]:bg-indigo-500 [&::-webkit-slider-thumb]:cursor-pointer
+                    [&::-webkit-slider-thumb]:hover:bg-indigo-400 [&::-webkit-slider-thumb]:transition-colors
+                    [&::-moz-range-thumb]:w-3.5 [&::-moz-range-thumb]:h-3.5 [&::-moz-range-thumb]:rounded-full
+                    [&::-moz-range-thumb]:bg-indigo-500 [&::-moz-range-thumb]:border-0 [&::-moz-range-thumb]:cursor-pointer">
+                <span class="text-[10px] text-gray-600 w-8 text-right shrink-0">4×</span>
+              </div>
+              <div class="flex flex-wrap gap-1">
                 <template x-for="preset in [
                   { value: 0.25, label: 'Stealth' },
                   { value: 0.5, label: 'Careful' },
@@ -5075,12 +5085,28 @@
                     x-text="preset.label"></button>
                 </template>
               </div>
-              <span class="text-[10px] text-gray-500 font-mono w-12 text-right shrink-0" x-text="browserSpeed.toFixed(2) + '×'"></span>
             </div>
-            <!-- Think time row -->
-            <div class="flex items-center gap-3 py-2">
-              <span class="text-[11px] text-gray-400 w-24 shrink-0">Think time</span>
-              <div class="flex flex-wrap gap-1 flex-1">
+
+            <!-- Think time -->
+            <div>
+              <div class="flex items-center justify-between mb-1.5">
+                <span class="text-[11px] text-gray-400">Think time</span>
+                <span class="text-[10px] text-gray-500 font-mono" x-text="browserDelay.toFixed(1) + 's'"></span>
+              </div>
+              <div class="flex items-center gap-2 mb-2">
+                <span class="text-[10px] text-gray-600 w-8 shrink-0">0s</span>
+                <input type="range" min="0" max="10" step="0.5"
+                  :value="browserDelay"
+                  @input="saveBrowserDelay($event.target.value)"
+                  class="flex-1 h-1.5 bg-gray-700 rounded-full appearance-none cursor-pointer
+                    [&::-webkit-slider-thumb]:appearance-none [&::-webkit-slider-thumb]:w-3.5 [&::-webkit-slider-thumb]:h-3.5
+                    [&::-webkit-slider-thumb]:rounded-full [&::-webkit-slider-thumb]:bg-indigo-500 [&::-webkit-slider-thumb]:cursor-pointer
+                    [&::-webkit-slider-thumb]:hover:bg-indigo-400 [&::-webkit-slider-thumb]:transition-colors
+                    [&::-moz-range-thumb]:w-3.5 [&::-moz-range-thumb]:h-3.5 [&::-moz-range-thumb]:rounded-full
+                    [&::-moz-range-thumb]:bg-indigo-500 [&::-moz-range-thumb]:border-0 [&::-moz-range-thumb]:cursor-pointer">
+                <span class="text-[10px] text-gray-600 w-8 text-right shrink-0">10s</span>
+              </div>
+              <div class="flex flex-wrap gap-1">
                 <template x-for="preset in [
                   { value: 0, label: 'Off' },
                   { value: 1.5, label: 'Light' },
@@ -5095,36 +5121,6 @@
                       : 'bg-gray-800 text-gray-500 hover:text-gray-300 hover:bg-gray-700'"
                     x-text="preset.label"></button>
                 </template>
-              </div>
-              <span class="text-[10px] text-gray-500 font-mono w-12 text-right shrink-0" x-text="browserDelay.toFixed(1) + 's'"></span>
-            </div>
-            <!-- Sliders, hidden by default -->
-            <div x-show="customizeSpeed" x-cloak class="space-y-3 mt-3 pt-3 border-t border-gray-800">
-              <div class="flex items-center gap-3">
-                <span class="text-[10px] text-gray-600 w-24 shrink-0">0.25×</span>
-                <input type="range" min="0.25" max="4.0" step="0.05"
-                  :value="browserSpeed"
-                  @input="saveBrowserSpeed($event.target.value)"
-                  class="flex-1 h-1.5 bg-gray-700 rounded-full appearance-none cursor-pointer
-                    [&::-webkit-slider-thumb]:appearance-none [&::-webkit-slider-thumb]:w-3.5 [&::-webkit-slider-thumb]:h-3.5
-                    [&::-webkit-slider-thumb]:rounded-full [&::-webkit-slider-thumb]:bg-indigo-500 [&::-webkit-slider-thumb]:cursor-pointer
-                    [&::-webkit-slider-thumb]:hover:bg-indigo-400 [&::-webkit-slider-thumb]:transition-colors
-                    [&::-moz-range-thumb]:w-3.5 [&::-moz-range-thumb]:h-3.5 [&::-moz-range-thumb]:rounded-full
-                    [&::-moz-range-thumb]:bg-indigo-500 [&::-moz-range-thumb]:border-0 [&::-moz-range-thumb]:cursor-pointer">
-                <span class="text-[10px] text-gray-600 w-12 text-right shrink-0">4×</span>
-              </div>
-              <div class="flex items-center gap-3">
-                <span class="text-[10px] text-gray-600 w-24 shrink-0">0s</span>
-                <input type="range" min="0" max="10" step="0.5"
-                  :value="browserDelay"
-                  @input="saveBrowserDelay($event.target.value)"
-                  class="flex-1 h-1.5 bg-gray-700 rounded-full appearance-none cursor-pointer
-                    [&::-webkit-slider-thumb]:appearance-none [&::-webkit-slider-thumb]:w-3.5 [&::-webkit-slider-thumb]:h-3.5
-                    [&::-webkit-slider-thumb]:rounded-full [&::-webkit-slider-thumb]:bg-indigo-500 [&::-webkit-slider-thumb]:cursor-pointer
-                    [&::-webkit-slider-thumb]:hover:bg-indigo-400 [&::-webkit-slider-thumb]:transition-colors
-                    [&::-moz-range-thumb]:w-3.5 [&::-moz-range-thumb]:h-3.5 [&::-moz-range-thumb]:rounded-full
-                    [&::-moz-range-thumb]:bg-indigo-500 [&::-moz-range-thumb]:border-0 [&::-moz-range-thumb]:cursor-pointer">
-                <span class="text-[10px] text-gray-600 w-12 text-right shrink-0">10s</span>
               </div>
             </div>
           </div>


### PR DESCRIPTION
## Summary

Replace the toggle pattern in System → Browser's "Browser Speed & Stealth" card with always-visible sliders. Named presets remain as quick-jump chips beneath each slider.

### Problem

The card previously rendered preset chips by default and tucked the slider behind a small "Customize" link. When the slider sat on a non-preset value (e.g. 1.25× action speed), no chip was highlighted, so the card read as "nothing selected" — operators looking at the page assumed speed was preset-only and the actual value was invisible until they noticed the tiny toggle.

### New layout

Per axis (Action speed, Think time):

```
Action speed                              1.00×
0.25× [────●──────────────────────────] 4×
[Stealth] [Careful] [Normal] [Fast] [Lightning]
```

- Slider is the primary control with min/max labels framing it and the live numeric value in the header.
- Preset chips sit below and snap the slider to that value when clicked.
- Chip active-state logic unchanged (highlighted when slider value is within tolerance of a preset).

### What changed

- Removed the `x-data="{ customizeSpeed: false }"` state and the Customize toggle button.
- Ungated the two range inputs that were under `x-show="customizeSpeed"`.
- Restructured the card into two stacked blocks (one per axis) instead of two-rows-plus-hidden-sliders.
- Tailwind classes on the sliders preserved verbatim.

### No backend changes

Same `saveBrowserSpeed` / `saveBrowserDelay` handlers, same auto-save debounce, same `browserSpeed` / `browserDelay` Alpine state. Pure layout change in `src/dashboard/templates/index.html`.

## Test plan

- [x] HTML template still parses (`html.parser`)
- [x] `ruff check src/` clean (no Python touched)
- [x] `pytest tests/test_dashboard.py -x -q` — 294 passed
- [ ] Visual smoke check in dashboard System → Browser tab: sliders render, dragging updates the numeric label live, clicking a chip snaps the slider, chip highlights correctly when value is on/off a preset