### PR TITLE
feat(vnc): flip per-agent VNC default to ON (PR 3)

### DIFF
--- a/src/browser/display_allocator.py
+++ b/src/browser/display_allocator.py
@@ -299,8 +299,12 @@ def is_per_agent_display_enabled(*, agent_id: str | None = None) -> bool:
 
     Reads ``OPENLEGION_BROWSER_PER_AGENT_DISPLAY`` via the centralised
     flag layer so operators can flip it via ``config/settings.json`` or
-    the agent-override path without redeploying.  Defaults to ``False``
-    so PR 1 ships dark — PR 2's mesh+dashboard work flips the default.
+    the agent-override path without redeploying.  Default flipped from
+    ``False`` to ``True`` once PR 1 (per-agent X stack lifecycle) and
+    PR 2 (per-agent mesh + dashboard routing) were both on main and
+    fully tested. The legacy shared-display path remains in the tree
+    as an env-var rollback (set ``OPENLEGION_BROWSER_PER_AGENT_DISPLAY=0``)
+    until the planned cleanup PR drops it entirely.
     """
     # Local import to avoid a hard dependency on the flag module from
     # tests that exercise the allocator standalone.
@@ -314,7 +318,7 @@ def is_per_agent_display_enabled(*, agent_id: str | None = None) -> bool:
 
 
 # Indirection so tests can patch the default without touching env state.
-_DEFAULT_PER_AGENT_DISPLAY = False
+_DEFAULT_PER_AGENT_DISPLAY = True
 
 
 # Convenience for tests / debugging — clear the env so a fresh allocator


### PR DESCRIPTION
## Summary
- One-line flag flip: ``_DEFAULT_PER_AGENT_DISPLAY = False`` → ``True``.
- Activates the per-agent VNC routing fleet-wide on next restart. Fixes the user-visible bug from PR 1: opening one agent's settings page now shows that agent's browser (no more shared-display foreground confusion).
- Legacy paths kept as an env-var rollback (``OPENLEGION_BROWSER_PER_AGENT_DISPLAY=0``); cleanup PR removes them later.

## Why now
- PR 1 (#801) added the per-agent X stack lifecycle (4-30, on main since).
- PR 2 (#807) wired dashboard URL + mesh proxy + browser-service routing (today).
- Both have full test coverage. The default-off posture has earned out.

## Rollout
1. Merge.
2. ``POST /update-all`` on provisioner — pulls new code on every instance, restarts engine + browser-service container.
3. New default is True; instances spawn per-agent X stacks at boot.

If anything misbehaves in production, set ``OPENLEGION_BROWSER_PER_AGENT_DISPLAY=0`` via provisioner ``/configure`` to revert to legacy without a redeploy.

## Test plan
- [x] 516 tests pass (per-agent VNC, display allocator, browser service)
- [x] Flag-state tests use explicit env values (`""` → False, `"1"` → True), so they exercise the same code paths regardless of which side of the default we're on
- [ ] Manual verification post-deploy: open agent 2's settings while agent 1 is automating, confirm agent 2's browser shows