### PR TITLE
fix(vnc): browser button missing after flag flip (hotfix)

### DIFF
--- a/src/dashboard/server.py
+++ b/src/dashboard/server.py
@@ -733,7 +733,12 @@ def create_dashboard_router(
 
         Returns ``None`` if the browser service hasn't been initialized.
         """
-        if not runtime or not hasattr(runtime, 'browser_vnc_url') or not runtime.browser_vnc_url:
+        # Readiness gate: the browser SERVICE is what matters here, not
+        # the legacy ``browser_vnc_url`` (which indicated the global
+        # ``KasmVNC :6080`` and is unset under the per-agent default).
+        # ``browser_service_url`` is set as soon as the FastAPI ``/status``
+        # health probe passes — the right "is the service up" signal.
+        if not runtime or not getattr(runtime, "browser_service_url", None):
             return None
 
         from src.browser.display_allocator import is_per_agent_display_enabled

--- a/src/host/runtime.py
+++ b/src/host/runtime.py
@@ -594,25 +594,15 @@ class DockerBackend(RuntimeBackend):
             logger.warning("Browser service API failed to become ready after 15 attempts")
             return
 
-        # Verify KasmVNC is also reachable — it starts independently of the
-        # FastAPI service and can fail even when the API is healthy.
-        vnc_url = f"http://127.0.0.1:{vnc_port}"
-        vnc_ready = False
-        for attempt in range(10):
-            try:
-                resp = _httpx.get(f"{vnc_url}/index.html", timeout=2)
-                if resp.status_code == 200:
-                    vnc_ready = True
-                    break
-            except Exception as e:
-                logger.debug("KasmVNC not ready (attempt %d): %s", attempt + 1, e)
-            time.sleep(1)
-
-        if not vnc_ready:
-            logger.warning("KasmVNC failed to become reachable on port %d", vnc_port)
-            return
-
-        self.browser_vnc_url = f"http://127.0.0.1:{vnc_port}/index.html?autoconnect=true&path=&resize=scale"
+        # Per-agent KasmVNCs spawn lazily inside
+        # ``BrowserManager._spawn_per_agent_x_stack`` when an agent
+        # starts a browser — there is no global KasmVNC to health-check
+        # at boot. The legacy ``self.browser_vnc_url`` setter (which
+        # pointed at ``:6080``) is preserved here as a non-empty marker
+        # so any stale dashboard code that still reads it sees a
+        # truthy value; the actual per-agent URLs are constructed from
+        # ``browser_service_url`` by the dashboard's URL builder.
+        self.browser_vnc_url = self.browser_service_url
 
         # Push saved browser settings (speed + inter-action delay) so
         # they survive container restarts. Pre-fix, only ``browser_speed``

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -508,38 +508,6 @@ class TestDockerBackendSlimResources:
         mock_container.remove.assert_called_once()
         assert backend.browser_service_url is None
 
-    def test_browser_service_vnc_health_fail(self):
-        """browser_vnc_url stays None when KasmVNC is unreachable."""
-        import docker as _docker
-
-        backend = self._make_backend()
-        mock_container = MagicMock()
-        mock_client = MagicMock()
-        mock_client.containers.run.return_value = mock_container
-        mock_client.containers.get.side_effect = _docker.errors.NotFound("not found")
-        backend.client = mock_client
-
-        call_count = 0
-
-        def _fake_get(url, **kwargs):
-            nonlocal call_count
-            call_count += 1
-            # API health check succeeds
-            if "/browser/status" in url:
-                resp = MagicMock()
-                resp.status_code = 200
-                return resp
-            # VNC health check fails
-            import httpx
-            raise httpx.ConnectError("refused")
-
-        with patch("httpx.get", side_effect=_fake_get), \
-             patch("time.sleep"):
-            backend.start_browser_service()
-
-        assert backend.browser_service_url is not None
-        assert backend.browser_vnc_url is None
-
     def test_browser_has_net_admin_in_bridge_mode(self):
         """Browser container gets the minimal cap set its entrypoint needs in bridge mode."""
         import docker as _docker


### PR DESCRIPTION
## Summary
Hotfix for the browser button vanishing from agent settings after PR 810 (per-agent VNC default flipped to True) was deployed.

## Root cause
Two compounding bugs:
1. ``src/host/runtime.py`` health-checked the legacy global KasmVNC port (``:6080``) at boot. With per-agent default on, ``__main__.py`` no longer spawns that — so the probe fails after 10s, the function ``return``s early, and ``runtime.browser_vnc_url`` is never set. The browser-settings push from disk also got skipped (operator's saved speed/delay reverted on restart).
2. ``_browser_vnc_url_for_request`` in the dashboard used ``runtime.browser_vnc_url`` as its readiness gate. With (1) leaving it ``None``, every agent's ``vnc_url`` was None, ``agentDetail.vnc_url`` was falsy, and the ``x-show="agentDetail?.vnc_url"`` button disappeared.

## Fix
- Drop the legacy KasmVNC health check entirely. Per-agent KasmVNCs spawn lazily inside ``BrowserManager._spawn_per_agent_x_stack`` when an agent's browser starts — there is no global KasmVNC to probe.
- Switch the dashboard readiness gate to ``runtime.browser_service_url`` (always set when the browser service API is up).
- ``self.browser_vnc_url = self.browser_service_url`` so any stale code still reading it sees a truthy value; per-agent URLs are constructed by the dashboard URL builder.

## Test plan
- [x] Dropped the test that asserted ``browser_vnc_url is None`` on KasmVNC health-check failure — that path no longer exists
- [x] 397 tests pass (test_runtime, test_per_agent_vnc, test_dashboard)
- [x] ruff clean
- [ ] Manual verify post-deploy: browser button visible on agent settings; iframe loads agent-scoped per-agent VNC