### PR TITLE
fix: give operator-created agents proper default capabilities

### DIFF
--- a/src/agent/builtins/operator_tools.py
+++ b/src/agent/builtins/operator_tools.py
@@ -26,7 +26,7 @@ _OPERATOR_PERMISSION_CEILING = {
     "can_manage_cron": True,
     "can_use_wallet": False,  # Requires explicit user setup
     "blackboard_read": ["*"],
-    "blackboard_write": ["tasks/*", "context/*", "status/*", "output/*"],
+    "blackboard_write": ["tasks/*", "context/*", "status/*", "output/*", "artifacts/*"],
 }
 
 _VALID_FIELDS = frozenset({

--- a/src/host/mesh.py
+++ b/src/host/mesh.py
@@ -758,3 +758,12 @@ class MessageRouter:
             self.agent_registry.pop(agent_id, None)
             self._capabilities_cache.pop(agent_id, None)
             self.agent_roles.pop(agent_id, None)
+
+    def get_capabilities(self, agent_id: str) -> list[str]:
+        """Return the cached capability list for an agent (empty if unknown).
+
+        Returns a copy under the registry lock so callers can't observe a
+        mid-write mutation of the cache.
+        """
+        with self._registry_lock:
+            return list(self._capabilities_cache.get(agent_id, []))

--- a/src/host/server.py
+++ b/src/host/server.py
@@ -1054,8 +1054,8 @@ def create_mesh_app(
         agent_id = _validate_agent_id(data.get("agent_id", ""))
         agent_id = _resolve_agent_id(agent_id, request)
         capabilities = data.get("capabilities", [])
-        if not isinstance(capabilities, list) or len(capabilities) > 50:
-            raise HTTPException(400, "capabilities must be a list of at most 50 items")
+        if not isinstance(capabilities, list) or len(capabilities) > 200:
+            raise HTTPException(400, "capabilities must be a list of at most 200 items")
         port = _validate_port(data.get("port", 8400))
 
         existing = router.agent_registry.get(agent_id)
@@ -1273,6 +1273,10 @@ def create_mesh_app(
             _require_any_auth(request)
         def _agent_entry(aid: str, url: str) -> dict:
             entry: dict = {"url": url, "role": router.agent_roles.get(aid, "")}
+            # list_agents (mesh_tool) reads info["capabilities"] — emit it
+            # unconditionally (empty list is fine when the cache has no
+            # entry for that agent).
+            entry["capabilities"] = router._capabilities_cache.get(aid, [])
             proj = _agent_projects.get(aid)
             if proj:
                 entry["project"] = proj
@@ -1793,7 +1797,21 @@ def create_mesh_app(
             initial_instructions=instructions, initial_soul=soul,
         )
         _update_agent_field(name, "avatar", random.randint(1, 50))
-        _add_agent_permissions(name)
+        # Operator-created agents need the same coordination defaults as
+        # template-created agents — empty blackboard_read/write would lock
+        # them out of the coordination protocol entirely (and skip the
+        # auto-watch setup at /mesh/register, which is gated on
+        # blackboard_read being truthy). Mirrors the operator-permission
+        # ceiling in operator_tools.py and the starter.yaml template.
+        default_perms = {
+            "blackboard_read":  ["*"],
+            "blackboard_write": ["tasks/*", "context/*", "status/*", "output/*", "artifacts/*"],
+            "can_publish":      ["*"],
+            "can_subscribe":    ["*"],
+            "can_use_browser":  True,
+            "can_manage_cron":  True,
+        }
+        _add_agent_permissions(name, permissions=default_perms)
         skills_dir = PROJECT_ROOT / "skills" / name
         skills_dir.mkdir(parents=True, exist_ok=True)
 

--- a/src/host/server.py
+++ b/src/host/server.py
@@ -1273,10 +1273,7 @@ def create_mesh_app(
             _require_any_auth(request)
         def _agent_entry(aid: str, url: str) -> dict:
             entry: dict = {"url": url, "role": router.agent_roles.get(aid, "")}
-            # list_agents (mesh_tool) reads info["capabilities"] — emit it
-            # unconditionally (empty list is fine when the cache has no
-            # entry for that agent).
-            entry["capabilities"] = router._capabilities_cache.get(aid, [])
+            entry["capabilities"] = router.get_capabilities(aid)
             proj = _agent_projects.get(aid)
             if proj:
                 entry["project"] = proj
@@ -1638,6 +1635,11 @@ def create_mesh_app(
 
         # Apply template to create config entries
         created_names = _apply_template(template_name, tpl)
+        # _apply_template calls _add_agent_permissions for each new agent;
+        # reload the live matrix so /mesh/register sees the on-disk perms
+        # instead of falling through to default/deny-all. Cheap no-op when
+        # created_names is empty.
+        permissions.reload()
         if not created_names:
             return {
                 "template": template_name,
@@ -1812,6 +1814,11 @@ def create_mesh_app(
             "can_manage_cron":  True,
         }
         _add_agent_permissions(name, permissions=default_perms)
+        # _add_agent_permissions writes to config/permissions.json on disk;
+        # the live PermissionMatrix has to reload or the agent's imminent
+        # /mesh/register call will fall through to default/deny-all (cf. PR
+        # #656 which added the same reload for the no-defaults case).
+        permissions.reload()
         skills_dir = PROJECT_ROOT / "skills" / name
         skills_dir.mkdir(parents=True, exist_ok=True)
 
@@ -1942,7 +1949,7 @@ def create_mesh_app(
 
         # -- Mesh-derived metadata (verifiable, always fresh) --
         role = router.agent_roles.get(agent_id, "")
-        capabilities = router._capabilities_cache.get(agent_id, [])
+        capabilities = router.get_capabilities(agent_id)
 
         # Health status
         status = "unknown"

--- a/tests/test_mesh.py
+++ b/tests/test_mesh.py
@@ -1090,3 +1090,60 @@ def test_inbox_watch_fires_on_handoff_write(tmp_path):
     assert agent_id in watchers
     assert writer_id not in watchers
     bb.close()
+
+
+# === /mesh/agents endpoint shape ===
+
+
+@pytest.mark.asyncio
+async def test_list_agents_endpoint_includes_capabilities(tmp_path):
+    """`/mesh/agents` must include a `capabilities` key per agent.
+
+    The list_agents builtin (src/agent/builtins/mesh_tool.py) reads
+    info.get("capabilities", []) — without this the dashboard and
+    coordination tools see every agent as having zero capabilities.
+    """
+    from httpx import ASGITransport, AsyncClient
+
+    from src.host.costs import CostTracker
+    from src.host.server import create_mesh_app
+    from src.host.traces import TraceStore
+
+    bb = Blackboard(db_path=str(tmp_path / "bb.db"))
+    pubsub = PubSub()
+    perms = PermissionMatrix()
+    router = MessageRouter(perms, {})
+    costs = CostTracker(str(tmp_path / "costs.db"))
+    traces = TraceStore(str(tmp_path / "traces.db"))
+
+    # Register two agents — one with capabilities, one without (the cache
+    # only gets populated when capabilities is non-empty, so this exercises
+    # the empty-list fallback too).
+    router.register_agent("alice", "http://alice:8400", ["search", "summarize"])
+    router.register_agent("bob",   "http://bob:8400",   [])
+
+    app = create_mesh_app(
+        blackboard=bb, pubsub=pubsub, router=router, permissions=perms,
+        cost_tracker=costs, trace_store=traces,
+    )
+
+    try:
+        async with AsyncClient(
+            transport=ASGITransport(app=app), base_url="http://test",
+        ) as client:
+            resp = await client.get("/mesh/agents")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert set(data.keys()) == {"alice", "bob"}
+        # Both entries must carry the key (even if empty list).
+        assert "capabilities" in data["alice"]
+        assert "capabilities" in data["bob"]
+        assert sorted(data["alice"]["capabilities"]) == ["search", "summarize"]
+        assert data["bob"]["capabilities"] == []
+        # Existing fields preserved.
+        assert data["alice"]["url"] == "http://alice:8400"
+        assert "role" in data["alice"]
+    finally:
+        bb.close()
+        costs.close()
+        traces.close()

--- a/tests/test_operator_create_agent.py
+++ b/tests/test_operator_create_agent.py
@@ -40,6 +40,26 @@ def container_mgr():
 def mesh_app(tmp_path, _mesh_env, container_mgr):
     bb = Blackboard(db_path=str(tmp_path / "bb.db"))
     pubsub = PubSub()
+    # Seed the on-disk permissions file with operator + other so that
+    # permissions.reload() (called by the create route after writing the
+    # new agent's perms) preserves them across the reload.
+    import json as _json
+    perms_file = tmp_path / "config" / "permissions.json"
+    perms_file.parent.mkdir(parents=True, exist_ok=True)
+    perms_file.write_text(_json.dumps({
+        "permissions": {
+            "operator": {
+                "can_message": ["*"],
+                "can_spawn": True,
+                "blackboard_read": ["*"],
+                "blackboard_write": ["*"],
+            },
+            "other": {
+                "can_message": ["mesh"],
+                "can_spawn": False,
+            },
+        },
+    }))
     perms = PermissionMatrix.__new__(PermissionMatrix)
     perms.permissions = {
         "operator": AgentPermissions(
@@ -55,6 +75,10 @@ def mesh_app(tmp_path, _mesh_env, container_mgr):
             can_spawn=False,
         ),
     }
+    # _config_path points at the seeded permissions file so reload()
+    # in the create route picks up the on-disk write without losing the
+    # operator/other entries the fixture set in memory.
+    perms._config_path = str(perms_file)
     router = MessageRouter(permissions=perms, agent_registry={})
     app = create_mesh_app(
         bb, pubsub, router, perms,
@@ -279,6 +303,23 @@ class TestCreateCustomAgent:
         assert resp.status_code == 200
         router = mesh_app["router"]
         assert "routed" in router.agent_registry
+
+    def test_permissions_reload_after_disk_write(self, mesh_app):
+        """Regression: _add_agent_permissions writes to disk; the live
+        PermissionMatrix has to reload, otherwise the agent's imminent
+        /mesh/register call falls through to default/deny-all and the
+        coordination defaults applied here are silently negated until
+        process restart (cf. PR #656)."""
+        perms = mesh_app["perms"]
+        perms.reload = MagicMock()
+
+        client = mesh_app["client"]
+        resp = client.post(
+            "/mesh/agents/create",
+            json={"agent_id": "operator", "name": "reloadtest", "role": "test"},
+        )
+        assert resp.status_code == 200
+        perms.reload.assert_called()
 
 
 class TestCreateCustomAgentMeshClient:

--- a/tests/test_operator_fleet.py
+++ b/tests/test_operator_fleet.py
@@ -309,7 +309,10 @@ class TestMeshFleetApplyEndpoint:
         pubsub = PubSub()
         perms = PermissionMatrix.__new__(PermissionMatrix)
         perms.permissions = {}
-        perms._config_path = ""
+        # Point at a path that doesn't exist — _load() handles missing files
+        # gracefully (warns + clears). The fleet apply route now reloads
+        # permissions after writing to disk, so _config_path must be set.
+        perms._config_path = "/tmp/__nonexistent_permissions_for_test.json"
         perms._reload_lock = __import__("threading").Lock()
         agent_registry: dict[str, str] = {}
         router = MessageRouter(permissions=perms, agent_registry=agent_registry)
@@ -375,6 +378,53 @@ class TestMeshFleetApplyEndpoint:
         data = resp.json()
         assert data["template"] == "starter"
 
+    @patch.dict("os.environ", {"OPENLEGION_MAX_AGENTS": "10"})
+    def test_apply_reloads_permissions_after_disk_write(self):
+        """Regression: _apply_template calls _add_agent_permissions for
+        every new agent (writing to config/permissions.json on disk). The
+        live PermissionMatrix has to reload, otherwise every template-
+        spawned agent's /mesh/register call falls through to default/
+        deny-all and they're locked out of coordination until restart."""
+        from fastapi.testclient import TestClient
+
+        app, _, _ = self._make_app(existing_agents={"operator": "http://localhost:8400"})
+        # Find the live PermissionMatrix bound to the app and stub reload
+        # so we can assert it ran. (state_for the matrix instance so we can
+        # find it again — _make_app stores it on perms.)
+        # The mesh app holds permissions in a closure; we pick it up via
+        # the perms passed into _make_app via attribute access on router.
+        router = app.state if hasattr(app, "state") else None  # noqa: F841
+        # Easier: rebuild with a stubbed perms.reload
+        from src.host.mesh import Blackboard, MessageRouter, PubSub
+        from src.host.permissions import PermissionMatrix
+        from src.host.server import create_mesh_app
+
+        bb = Blackboard(db_path=":memory:")
+        pubsub = PubSub()
+        perms = PermissionMatrix.__new__(PermissionMatrix)
+        perms.permissions = {}
+        perms._config_path = ""
+        perms._reload_lock = __import__("threading").Lock()
+        perms.reload = MagicMock()
+
+        agent_registry: dict[str, str] = {"operator": "http://localhost:8400"}
+        router = MessageRouter(permissions=perms, agent_registry=agent_registry)
+        from pathlib import Path
+        cm = MagicMock()
+        cm.project_root = Path("/tmp/test_project")
+        cm.extra_env = {}
+        cm.start_agent.return_value = "http://localhost:8401"
+        cm.wait_for_agent = AsyncMock(return_value=True)
+
+        app2 = create_mesh_app(
+            blackboard=bb, pubsub=pubsub, router=router,
+            permissions=perms, container_manager=cm,
+        )
+        client = TestClient(app2)
+        resp = client.post("/mesh/fleet/apply", json={"template": "starter"})
+        assert resp.status_code == 200
+        perms.reload.assert_called()
+
     def test_apply_no_container_manager(self):
         """Without container manager, apply returns 503."""
         from fastapi.testclient import TestClient
@@ -387,7 +437,7 @@ class TestMeshFleetApplyEndpoint:
         pubsub = PubSub()
         perms = PermissionMatrix.__new__(PermissionMatrix)
         perms.permissions = {}
-        perms._config_path = ""
+        perms._config_path = "/tmp/__nonexistent_permissions_for_test.json"
         perms._reload_lock = __import__("threading").Lock()
         agent_registry: dict[str, str] = {}
         router = MessageRouter(permissions=perms, agent_registry=agent_registry)

--- a/tests/test_operator_tools.py
+++ b/tests/test_operator_tools.py
@@ -106,6 +106,28 @@ async def test_propose_edit_permission_ceiling_allows_permitted():
 
 
 @pytest.mark.asyncio
+async def test_propose_edit_permission_ceiling_allows_artifacts_write():
+    """artifacts/* must be inside the ceiling because save_artifact relies on
+    that namespace; without it the operator could observe an agent that has
+    artifacts/* write but couldn't reproduce that pattern via propose_edit."""
+    from src.agent.builtins.operator_tools import propose_edit
+
+    mc = MagicMock()
+    mc.propose_config_change = AsyncMock(
+        return_value={"change_id": "art1", "preview_diff": "..."},
+    )
+    result = await propose_edit(
+        "writer", "permissions", {"blackboard_write": ["artifacts/*"]},
+        mesh_client=mc,
+    )
+    assert "error" not in result
+    assert result["change_id"] == "art1"
+    mc.propose_config_change.assert_awaited_once_with(
+        "writer", "permissions", {"blackboard_write": ["artifacts/*"]},
+    )
+
+
+@pytest.mark.asyncio
 async def test_propose_edit_budget_validation_daily_too_low():
     from src.agent.builtins.operator_tools import propose_edit
 

--- a/tests/test_templates.py
+++ b/tests/test_templates.py
@@ -261,6 +261,45 @@ class TestAddAgentPermissions(_TempConfigMixin):
         # Invalid types are ignored, defaults preserved
         assert isinstance(gus["blackboard_read"], list)
 
+    def test_operator_created_agent_defaults_grant_coordination(self):
+        """Operator-created agents (POST /mesh/agents/create) must receive
+        the coordination defaults so they can participate in the
+        hand_off / check_inbox / blackboard r/w protocol.
+
+        Mirrors the defaults block in src/host/server.py:create_custom_agent
+        (operator-permission ceiling). Without these, blackboard_read is
+        empty and the auto-watch setup at /mesh/register skips the agent's
+        task inbox entirely.
+        """
+        _add_agent_to_config("hank", "helper", "openai/gpt-4o")
+        # Same dict the create_custom_agent route now passes.
+        default_perms = {
+            "blackboard_read":  ["*"],
+            "blackboard_write": ["tasks/*", "context/*", "status/*", "output/*", "artifacts/*"],
+            "can_publish":      ["*"],
+            "can_subscribe":    ["*"],
+            "can_use_browser":  True,
+            "can_manage_cron":  True,
+        }
+        _add_agent_permissions("hank", permissions=default_perms)
+        with open(self._perms_path) as f:
+            perms = json.load(f)
+        hank = perms["permissions"]["hank"]
+        # Coordination read access — wildcard so the auto-watch setup at
+        # mesh/register installs the tasks/{agent}/* watcher.
+        assert hank["blackboard_read"] == ["*"]
+        # Coordination write namespaces — must include tasks/* (hand_off)
+        # and the other standard prefixes.
+        for pattern in ("tasks/*", "context/*", "status/*", "output/*", "artifacts/*"):
+            assert pattern in hank["blackboard_write"], (
+                f"missing required write pattern {pattern!r} in {hank['blackboard_write']!r}"
+            )
+        # Boolean capability flags carried through.
+        assert hank["can_use_browser"] is True
+        assert hank["can_manage_cron"] is True
+        # Defaults still present.
+        assert "llm" in hank["allowed_apis"]
+
 
 class TestApplyTemplate(_TempConfigMixin):
     def test_creates_agents_with_new_fields(self):


### PR DESCRIPTION
## Summary

Five bugs were combining to leave operator-created agents with empty/missing capabilities and no working coordination. Three were spotted in the initial review; two more (one critical) surfaced during a follow-up principal-engineer review of the first commit.

**Fix 1 — Default permissions for operator-created agents.** `create_custom_agent` (`POST /mesh/agents/create`) called `_add_agent_permissions(name)` with no permissions, so agents got `blackboard_read=[]` / `blackboard_write=[]` from the `cli/config.py:_add_agent_permissions` defaults. That both locked them out of coordination AND skipped the auto-watch setup at `/mesh/register` (gated on `blackboard_read` being truthy). The route now passes a defaults block — wildcard read plus the standard `tasks/*`, `context/*`, `status/*`, `output/*`, `artifacts/*` write namespaces.

**Fix 2 — Raise the `/mesh/register` capabilities cap from 50 to 200.** A default agent loads ~80 builtins today, so every fresh self-registration silently failed with HTTP 400. Symptom: `router._capabilities_cache` stayed empty, `capability:foo` routing broke, pubsub auto-subscribe never ran, the inbox watch never installed. Cap raised to 200 (kept as a sanity bound).

**Fix 3 — `/mesh/agents` returns capabilities.** The `_agent_entry` helper omitted `capabilities`, so the `list_agents` builtin (which reads `info["capabilities"]`) always saw `[]`. Now sourced unconditionally from the router cache.

**Fix 4 — CRITICAL: `permissions.reload()` after disk write.** `create_custom_agent` and `apply_fleet_template` both wrote permissions to `config/permissions.json` but never told the live `PermissionMatrix` to reload. The agent's imminent `/mesh/register` would fall through to default/deny-all, silently negating Fix 1 (and PR #656 had been sitting open for the no-defaults variant of the same bug). Both routes now reload after the disk write — same pattern as #656.

**Fix 5 — Cleanup.**
- `_OPERATOR_PERMISSION_CEILING` in `operator_tools.py` was missing `artifacts/*` from `blackboard_write` while Fix 1's defaults included it. Result: operator could observe an agent with `artifacts/*` write but couldn't reproduce that pattern via `propose_edit` (the ceiling check rejected it as excess). `save_artifact` writes to `artifacts/{aid}/...` and silently failed registration on every operator-edited agent. Added `artifacts/*` to the ceiling.
- Two `host/server.py` call sites reached into `router._capabilities_cache` directly. Added a public `MessageRouter.get_capabilities(agent_id)` accessor that returns a copy under the registry lock; both call sites switched to it.

## Test plan

- [x] `tests/test_templates.py::TestAddAgentPermissions::test_operator_created_agent_defaults_grant_coordination` — defaults block produces correct read/write/booleans
- [x] `tests/test_mesh.py::test_list_agents_endpoint_includes_capabilities` — `/mesh/agents` response includes `capabilities` key for both populated and empty-cache entries
- [x] `tests/test_operator_create_agent.py::TestCreateCustomAgent::test_permissions_reload_after_disk_write` — `create_custom_agent` calls `permissions.reload()`
- [x] `tests/test_operator_fleet.py::TestMeshFleetApplyEndpoint::test_apply_reloads_permissions_after_disk_write` — `apply_fleet_template` calls `permissions.reload()`
- [x] `tests/test_operator_tools.py::test_propose_edit_permission_ceiling_allows_artifacts_write` — `propose_edit` accepts `blackboard_write=["artifacts/*"]` after ceiling extension
- [x] Full pass of `tests/test_permissions.py tests/test_mesh.py tests/test_dashboard.py tests/test_agent_server.py tests/test_operator_tools.py tests/test_templates.py tests/test_operator_create_agent.py tests/test_operator_fleet.py` — 613 passed
- [x] No new test for Fix 2 — bumping a constant is self-evident; no existing test pinned the 50-cap
- [ ] CI green on Python 3.11 and 3.12

## Rollout note

Existing operator-created agents already on disk were created with empty blackboard ACLs and won't pick up the new defaults until either re-created or edited via the dashboard / `propose_edit`. Fix 4's reload only helps newly-created agents from this point on.
