### PR TITLE
fix(browser): install uvicorn[standard] so WS upgrades work

### DIFF
--- a/Dockerfile.browser
+++ b/Dockerfile.browser
@@ -122,10 +122,19 @@ RUN mkdir -p /opt/openlegion/extensions \
 # Pillow ships with bundled libwebp on manylinux wheels, so no apt-level WebP
 # library is required. The encode path in src/browser/service.py uses
 # Image.save(..., format="WEBP") which is Pillow's built-in encoder.
+#
+# ``uvicorn[standard]`` is required (not plain ``uvicorn``): the
+# ``[standard]`` extra pulls in the ``websockets`` package, which
+# uvicorn needs to handle WebSocket upgrades. Without it, every WS
+# request to ``/agent-vnc/{agent_id}/{path}`` returns HTTP 404 at the
+# protocol layer before our route handler ever runs — which is what
+# the per-agent VNC iframe was hitting in production. The package is
+# also used by ``vnc_ws`` to connect upstream to the per-agent
+# KasmVNC.
 COPY pyproject.toml .
 RUN pip install --no-cache-dir --root-user-action=ignore --upgrade pip \
     && pip install --no-cache-dir --root-user-action=ignore \
-    "camoufox[geoip]" fastapi uvicorn pydantic httpx \
+    "camoufox[geoip]" fastapi "uvicorn[standard]" pydantic httpx \
     "Pillow>=10.0"
 
 # Application code

--- a/src/browser/__main__.py
+++ b/src/browser/__main__.py
@@ -21,6 +21,25 @@ from src.shared.utils import setup_logging
 
 logger = setup_logging("browser.main")
 
+# Fail fast if the WebSocket transport library is missing. uvicorn ships
+# WebSocket support only via the ``[standard]`` extra (which pulls in
+# ``websockets``); plain ``uvicorn`` rejects every WS upgrade with HTTP
+# 404 at the protocol layer, BEFORE our route handler runs. The
+# per-agent VNC iframe needs WS upgrades to work, so a missing
+# ``websockets`` package silently breaks the dashboard. Catching it
+# here turns "users see a broken VNC iframe" into "container exits
+# loud at boot".
+try:
+    import websockets as _ws_check  # noqa: F401
+except ImportError:  # pragma: no cover — regression guard
+    logger.critical(
+        "websockets package not installed. The browser service cannot "
+        "serve WS upgrades for /agent-vnc/{agent_id}/{path}. Install "
+        "``uvicorn[standard]`` (or add ``websockets`` explicitly) in "
+        "Dockerfile.browser.",
+    )
+    sys.exit(1)
+
 _API_PORT = int(os.environ.get("API_PORT", "8500"))
 
 


### PR DESCRIPTION
## Summary
**Per-agent VNC iframe was showing only the X root background because the browser container's uvicorn was missing WebSocket support.** ``Dockerfile.browser:128`` installed plain ``uvicorn`` (not ``uvicorn[standard]``), so the ``websockets`` package wasn't present and uvicorn 404'd every WS upgrade at the protocol layer — before our ``vnc_ws`` route handler ever ran.

## Root cause
- HTTP fetches to ``/agent-vnc/{agent_id}/index.html`` worked (uvicorn handles HTTP fine).
- WebSocket upgrades to ``/agent-vnc/{agent_id}/websockify`` were rejected with HTTP 404 by uvicorn.
- noVNC couldn't connect → no framebuffer streamed → iframe showed only the ``xsetroot -solid #1e1e2e`` blue background.

The Camoufox process was running, the per-agent Xvnc + Openbox + unclutter were up, the browser window was painted on the per-agent display — only the WS transport between noVNC and KasmVNC was broken.

Reproduced from the host:
```python
async with websockets.connect("ws://127.0.0.1:8401/agent-vnc/social-manager/websockify", ...) as ws: ...
# InvalidStatus: server rejected WebSocket connection: HTTP 404
```

Confirmed missing dep:
```
docker exec openlegion_browser python3 -c "import websockets"
# ModuleNotFoundError
```

## Fix
1. **``Dockerfile.browser:128``**: ``uvicorn`` → ``uvicorn[standard]``. Pulls the ``websockets`` package (plus uvloop, httptools, etc.) so uvicorn can upgrade WS connections and our ``vnc_ws`` handler can in turn connect to the per-agent KasmVNC port.
2. **``src/browser/__main__.py``**: fail-fast import check at boot. If ``websockets`` ever goes missing again (Dockerfile drift, dependency-pinning regression, bad merge), the container exits loud at startup with a critical log instead of silently breaking the dashboard.

## Why CI didn't catch this
Tests run via ``starlette.testclient.TestClient``, which simulates ASGI directly without going through uvicorn — the "uvicorn lacks WS support" path was never exercised in CI. The fail-fast import check is the test surface for the next regression: if the Dockerfile drifts, ``__main__.py`` will refuse to boot.

## Test plan
- [x] Reproduced the failure mode on a production instance
- [x] Confirmed ``websockets`` not installed in container (root cause)
- [x] Confirmed ``uvicorn[standard]`` adds it via the engine's pyproject.toml (already declared as ``websockets>=13.0``)
- [x] ruff clean on ``__main__.py``
- [ ] After merge + ``/update-all``: open agent settings → browser button → iframe streams the live browser window (not just blue bg)