### PR TITLE
perf(tests): zero browser human-pacing helpers in unit tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,85 @@
+"""Shared pytest configuration.
+
+Zeroes the human-pacing helpers in ``src.browser.timing`` for tests that
+don't care about real wall-clock behavior. Production code calls these on
+every keystroke / scroll step / click to look human (clamped Gaussians,
+μ≈80ms scroll pause × hundreds of actions per test). Logic-level tests
+of the surrounding browser code pay that pacing incidentally and
+dominate CI wall time — the slowest five test files account for ~43 %
+of the serial run.
+
+Tests that *do* assert on the helpers themselves (range checks, pacing
+distributions) opt out via ``@pytest.mark.real_timing``. Apply at module
+level with ``pytestmark = pytest.mark.real_timing`` for whole-file opt-out
+(see ``tests/test_captcha_solve_pacing.py``).
+
+Why patch bound names on the consumer modules instead of patching
+``src.browser.timing`` directly: ``src/browser/service.py`` does
+``from src.browser.timing import action_delay`` (and friends), so the
+bound names live on the service module — patching the timing module
+would have no effect on those existing await sites. Tests in
+``TestHumanTiming`` re-import directly from ``src.browser.timing`` and
+must keep seeing the real distributions; patching only the service
+module leaves those tests untouched.
+
+``captcha_solve_delay`` is the one exception: it's awaited via
+``timing.captcha_solve_delay()`` (dotted access from
+``src/browser/captcha.py``), so we patch it on the timing module and
+rely on the ``real_timing`` opt-out for the dedicated pacing tests.
+"""
+
+from __future__ import annotations
+
+import sys
+from typing import Any
+
+import pytest
+
+# Time-returning helpers consumed by ``src.browser.service`` via
+# ``from src.browser.timing import X``. ``scroll_increment`` and
+# ``scroll_ramp`` are intentionally excluded — they return pixel counts
+# and ramp multipliers, not durations, and zeroing them would deadlock
+# the scroll loop.
+_SYNC_TIMING_FUNCS = (
+    "action_delay",
+    "navigation_jitter",
+    "keystroke_delay",
+    "think_pause",
+    "scroll_pause",
+    "x11_step_delay",
+    "x11_settle_delay",
+    "click_dwell",
+    "pre_click_settle",
+)
+
+
+def _zero(*_args: Any, **_kwargs: Any) -> float:
+    return 0.0
+
+
+async def _async_noop(*_args: Any, **_kwargs: Any) -> None:
+    return None
+
+
+def pytest_configure(config: pytest.Config) -> None:
+    config.addinivalue_line(
+        "markers",
+        "real_timing: opt out of the autouse fast-timing fixture and use "
+        "the real human-pacing delays from src.browser.timing.",
+    )
+
+
+@pytest.fixture(autouse=True)
+def _fast_browser_timing(request: pytest.FixtureRequest, monkeypatch: pytest.MonkeyPatch) -> None:
+    if request.node.get_closest_marker("real_timing"):
+        return
+
+    service = sys.modules.get("src.browser.service")
+    if service is not None:
+        for name in _SYNC_TIMING_FUNCS:
+            if hasattr(service, name):
+                monkeypatch.setattr(service, name, _zero, raising=False)
+
+    timing = sys.modules.get("src.browser.timing")
+    if timing is not None:
+        monkeypatch.setattr(timing, "captcha_solve_delay", _async_noop, raising=False)

--- a/tests/test_browser_service.py
+++ b/tests/test_browser_service.py
@@ -4067,6 +4067,7 @@ class TestTypoInjection:
         assert len(backspace_calls) == 2, f"Expected 2 typo corrections, got {len(backspace_calls)}"
 
 
+@pytest.mark.real_timing
 class TestClickRandomDelay:
     """Verify click delay is not a fixed 0.3s."""
 
@@ -4095,6 +4096,7 @@ class TestClickRandomDelay:
         assert len(set(f"{d:.4f}" for d in delays)) > 1
 
 
+@pytest.mark.real_timing
 class TestTypeWithVariance:
     """Verify per-char execCommand calls with keyboard.type fallback and varying delays."""
 
@@ -5010,6 +5012,7 @@ class TestScrollParameterized:
             assert delta < 0
 
 
+@pytest.mark.real_timing
 class TestWordBoundaryPause:
     """Verify think_pause fires at word boundaries with higher probability."""
 

--- a/tests/test_captcha_solve_pacing.py
+++ b/tests/test_captcha_solve_pacing.py
@@ -28,6 +28,10 @@ import pytest
 from src.browser import timing
 from src.browser.captcha import CaptchaSolver
 
+# This file directly exercises ``timing.captcha_solve_delay``; the autouse
+# fast-timing fixture in tests/conftest.py would replace it with a no-op.
+pytestmark = pytest.mark.real_timing
+
 # ── helpers ───────────────────────────────────────────────────────────
 
 


### PR DESCRIPTION
## Summary

The browser service awaits Gaussian-clamped delays on every keystroke, scroll step, and click to look human in production. Logic-level tests were paying that pacing incidentally and dominated CI wall time — the slowest five files alone accounted for ~43% of the serial suite, and the longest single test (17.5s) set the floor for any parallel run.

This PR adds `tests/conftest.py` with an autouse fixture that zeroes the time-returning timing helpers at their bound names on `src.browser.service`. Tests that assert on the helpers themselves opt out via `@pytest.mark.real_timing`.

### Per-test wins (measured locally, serial)

| Test | Before | After |
|---|---|---|
| `test_solver_failover` (whole file) | 17s | 0.3s |
| `test_captcha_health` (whole file) | 13s | 0.6s |
| `test_solve_capsolver_success` | 17s | 5s |
| Slowest individual test (parallel floor) | 17.5s | 12.1s |

### Why this design

- **Patch bound names on the consumer module, not the source.** `src/browser/service.py:58-70` does `from src.browser.timing import action_delay` (and friends), so the bound names live on the service module. Patching `src.browser.timing.action_delay` would have no effect on the existing await sites.
- **Don't touch the timing module.** `TestHumanTiming` re-imports directly from `src.browser.timing` to assert distributions — patching the timing module itself would break those tests.
- **`captcha_solve_delay` is the exception.** It's awaited via dotted access (`timing.captcha_solve_delay()`) from `src/browser/captcha.py:2061`, so we patch it on the timing module and rely on the `real_timing` opt-out for `tests/test_captcha_solve_pacing.py`.
- **Excluded from patching:** `scroll_increment` and `scroll_ramp` return pixel counts and ramp multipliers, not durations — zeroing them would deadlock the scroll loop.

### Coverage of opt-out

| File / class | Why opt-out is needed |
|---|---|
| `tests/test_captcha_solve_pacing.py` (module) | Directly tests `captcha_solve_delay` clamp and Gaussian shape |
| `TestClickRandomDelay` | Patches `service.asyncio.sleep` to capture and assert delay range |
| `TestTypeWithVariance` | Same — captures keystroke distributions |
| `TestWordBoundaryPause` | Same — asserts `think_pause` fires only at boundaries |

`TestHumanTiming` does NOT need the marker because it imports `from src.browser.timing import X` directly and the timing module isn't patched.

### Out of scope

- `test_account_warmup.py` (32s) and `test_navigate_referer.py::test_recent_referers_capped_at_5` (12s) use bare `asyncio.sleep` and `wait_ms` arguments, not timing helpers — different fix.
- Drop CI matrix to single Python on PR — saves CI minutes, not wall time.

## Test plan

- [x] `TestHumanTiming` (17/17) passes — verifies timing module is untouched
- [x] `test_captcha_solve_pacing.py` (15/15) passes — verifies module-level opt-out works
- [x] `TestClickRandomDelay`, `TestTypeWithVariance`, `TestWordBoundaryPause` pass — class-level opt-out works
- [x] Full unit suite: 4913 passed / 12 known pre-existing failures / 23 skipped — zero new regressions
- [ ] CI confirms wall-time improvement on 4-vCPU GHA runner