### PR TITLE
fix(browser): harden final browser trace

### DIFF
--- a/docker/browser-entrypoint.sh
+++ b/docker/browser-entrypoint.sh
@@ -65,15 +65,17 @@ install_egress_filter() {
   fi
 
   if ! command -v iptables-restore >/dev/null 2>&1; then
-    log "iptables-restore not installed — skipping firewall setup"
-    return 0
+    log "ERROR: iptables-restore not installed; refusing to start without the egress filter."
+    log "  Set BROWSER_EGRESS_DISABLE=1 to start without the filter (insecure)."
+    exit 1
   fi
 
   # Sanity check: can we actually read the OUTPUT chain? If NET_ADMIN is absent
-  # (dev setups, restricted runtimes) bail out loudly instead of failing boot.
+  # (dev setups, restricted runtimes) fail closed instead of running unfiltered.
   if ! iptables -L OUTPUT -n >/dev/null 2>&1; then
-    log "WARNING: cannot access iptables (missing NET_ADMIN?). Egress filter NOT installed."
-    return 0
+    log "ERROR: cannot access iptables (missing NET_ADMIN?). Egress filter NOT installed."
+    log "  Set BROWSER_EGRESS_DISABLE=1 to start without the filter (insecure)."
+    exit 1
   fi
 
   # Build ACCEPT rules for configured nameservers so DNS keeps working. Docker's

--- a/src/browser/server.py
+++ b/src/browser/server.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 import asyncio
 import contextlib
 import hmac
+import inspect
 import json
 import os
 import re
@@ -32,6 +33,17 @@ logger = setup_logging("browser.server")
 # uploads via /browser/.../upload still fit.
 _MAX_BODY_BYTES = 8 * 1024 * 1024
 _AGENT_ID_RE = re.compile(AGENT_ID_RE_PATTERN)
+
+
+def _websockets_headers_kw(connect, headers: dict[str, str]) -> dict:
+    """Return the header kwarg name supported by the installed websockets."""
+    try:
+        params = inspect.signature(connect).parameters
+    except (TypeError, ValueError):
+        return {"additional_headers": headers}
+    if "additional_headers" in params:
+        return {"additional_headers": headers}
+    return {"extra_headers": headers}
 
 
 def create_browser_app(manager: BrowserManager, lifespan=None) -> FastAPI:
@@ -987,7 +999,7 @@ def create_browser_app(manager: BrowserManager, lifespan=None) -> FastAPI:
             async with _websockets.connect(
                 target,
                 subprotocols=["binary"],
-                additional_headers=extra_headers,
+                **_websockets_headers_kw(_websockets.connect, extra_headers),
                 compression=None,
                 # noVNC handles application-level keepalive; auto-ping
                 # on the websockets library would tear down the link

--- a/src/browser/service.py
+++ b/src/browser/service.py
@@ -3027,9 +3027,14 @@ class BrowserManager:
 
     async def start_cleanup_loop(self):
         """Start background task that cleans up idle browsers."""
-        self._cleanup_task = asyncio.create_task(self._cleanup_loop())
-        self._upload_recv_gc_task = asyncio.create_task(self._upload_recv_gc_loop())
-        self._download_gc_task = asyncio.create_task(self._download_gc_loop())
+        if self._cleanup_task is None or self._cleanup_task.done():
+            self._cleanup_task = asyncio.create_task(self._cleanup_loop())
+        if self._upload_recv_gc_task is None or self._upload_recv_gc_task.done():
+            self._upload_recv_gc_task = asyncio.create_task(
+                self._upload_recv_gc_loop(),
+            )
+        if self._download_gc_task is None or self._download_gc_task.done():
+            self._download_gc_task = asyncio.create_task(self._download_gc_loop())
 
     async def _upload_recv_gc_once(self) -> int:
         """Reap orphan upload-recv files older than the stage TTL.
@@ -4599,6 +4604,11 @@ class BrowserManager:
         """Stop all browser instances and clean up Playwright."""
         if self._cleanup_task:
             self._cleanup_task.cancel()
+            try:
+                await self._cleanup_task
+            except (asyncio.CancelledError, Exception):
+                pass
+            self._cleanup_task = None
         if getattr(self, "_upload_recv_gc_task", None):
             self._upload_recv_gc_task.cancel()
             try:

--- a/src/browser/stealth.py
+++ b/src/browser/stealth.py
@@ -35,10 +35,11 @@ mobile profiles + a desktop-macOS variant are available via the
   * ``mobile-ios``      — Mobile Safari on iPhone 14 Pro
   * ``mobile-android``  — Chrome on Pixel 8
 
-Mobile profiles are useful when the target site serves a mobile-friendly
-version (or when geographies dominated by mobile traffic make a mobile
-fingerprint less suspicious). Tradeoff: some desktop-only forms reject
-mobile UAs; some sites serve different content / fewer features to mobile.
+Mobile profiles are opt-in via ``OPENLEGION_BROWSER_ALLOW_ENGINE_MISMATCH=1``.
+They can be useful when the target site serves a mobile-friendly version
+(or when geographies dominated by mobile traffic make a mobile fingerprint
+less suspicious). Tradeoff: some desktop-only forms reject mobile UAs; some
+sites serve different content / fewer features to mobile.
 
 Camoufox compatibility caveats: Camoufox is built on Firefox, so the iOS
 profile (Mobile Safari UA) and Android profile (Chrome UA) ship a UA-engine
@@ -196,14 +197,14 @@ def get_device_profile(name: str | None = None) -> dict:
       * ``None`` or empty string → default (``desktop-windows``).
       * Known name → that profile.
       * Unknown name → log a warning and fall back to default.
-      * Engine-mismatch profiles (``mobile-android``) → require explicit
-        ``OPENLEGION_BROWSER_ALLOW_ENGINE_MISMATCH=1`` opt-in. The Android
-        profile ships a Chrome UA + ``platform_navigator: "Linux armv8l"``
-        on top of a Gecko/Firefox engine (Camoufox). Detection products
+      * Engine-mismatch profiles (``mobile-ios`` / ``mobile-android``) →
+        require explicit ``OPENLEGION_BROWSER_ALLOW_ENGINE_MISMATCH=1``
+        opt-in. These profiles ship Safari/Chrome UA surfaces on top of a
+        Gecko/Firefox engine (Camoufox). Detection products
         catch this via ``WebGL2RenderingContext.prototype.getParameter``,
         ``RTCRtpSender.getCapabilities`` codec ordering, and
-        ``navigator.userActivation`` shape (Chromium-only). Without the
-        flag this profile is more harmful than helpful — fall back to
+        engine-specific API shape. Without the flag these profiles are more
+        harmful than helpful — fall back to
         the default and surface a loud warning.
 
     The returned dict is the live module-level constant — do not mutate.
@@ -222,7 +223,7 @@ def get_device_profile(name: str | None = None) -> dict:
         return _DEVICE_PROFILES[DEFAULT_DEVICE_PROFILE]
     if name in _ENGINE_MISMATCH_PROFILES and not _engine_mismatch_allowed():
         logger.warning(
-            "BROWSER_DEVICE_PROFILE=%r ships a Chrome UA on a Firefox "
+            "BROWSER_DEVICE_PROFILE=%r ships a non-Firefox UA on a Firefox "
             "engine — strong bot signal on any FP-aware site. Set "
             "OPENLEGION_BROWSER_ALLOW_ENGINE_MISMATCH=1 to opt in. "
             "Falling back to %r.",
@@ -235,7 +236,7 @@ def get_device_profile(name: str | None = None) -> dict:
 # Profiles whose UA + JS surface declare a different engine than the
 # underlying Camoufox (Gecko/Firefox). Each one is a strong tell on any
 # FP-aware site and is opt-in only.
-_ENGINE_MISMATCH_PROFILES = frozenset({"mobile-android"})
+_ENGINE_MISMATCH_PROFILES = frozenset({"mobile-ios", "mobile-android"})
 
 
 def _engine_mismatch_allowed() -> bool:

--- a/src/host/server.py
+++ b/src/host/server.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 import asyncio
 import contextlib
 import hmac
+import inspect
 import json
 import re
 import time
@@ -45,6 +46,17 @@ logger = setup_logging("host.server")
 _MAX_SYSTEM_PROMPT = 10_000  # chars — caps agent-supplied system prompt to limit context cost
 _MAX_BB_KEY_LEN = 512  # chars — prevents abusive key lengths in blackboard
 _MAX_BB_VALUE_BYTES = 262_144  # 256 KB — bounds per-key storage to keep SQLite WAL manageable
+
+
+def _websockets_headers_kw(connect, headers: dict[str, str]) -> dict:
+    """Return the header kwarg name supported by the installed websockets."""
+    try:
+        params = inspect.signature(connect).parameters
+    except (TypeError, ValueError):
+        return {"additional_headers": headers}
+    if "additional_headers" in params:
+        return {"additional_headers": headers}
+    return {"extra_headers": headers}
 
 
 def _extract_prompt_preview(params: dict, max_len: int = 500) -> str:
@@ -4078,9 +4090,10 @@ def create_mesh_app(
             async with websockets.connect(
                 target,
                 subprotocols=["binary"],
-                additional_headers={
-                    "Authorization": f"Bearer {svc_token}",
-                },
+                **_websockets_headers_kw(
+                    websockets.connect,
+                    {"Authorization": f"Bearer {svc_token}"},
+                ),
                 compression=None,
                 ping_interval=None,
             ) as upstream:

--- a/tests/test_browser_device_profile.py
+++ b/tests/test_browser_device_profile.py
@@ -53,7 +53,8 @@ class TestGetDeviceProfile:
         assert prof["platform_navigator"] == "MacIntel"
         assert prof["camoufox_os"] == "macos"
 
-    def test_mobile_ios_documented_shape(self):
+    def test_mobile_ios_documented_shape(self, monkeypatch):
+        monkeypatch.setenv("OPENLEGION_BROWSER_ALLOW_ENGINE_MISMATCH", "1")
         prof = get_device_profile("mobile-ios")
         # UA matches the published Mobile Safari 17.5 / iOS 17.5 string.
         assert prof["user_agent"] == (
@@ -89,6 +90,16 @@ class TestGetDeviceProfile:
         assert prof["has_touch"] is True
         assert prof["platform_navigator"] == "Linux armv8l"
         assert prof["user_agent_data_mobile"] is True
+
+    def test_mobile_ios_requires_engine_mismatch_opt_in(self, monkeypatch, caplog):
+        monkeypatch.delenv("OPENLEGION_BROWSER_ALLOW_ENGINE_MISMATCH", raising=False)
+        with caplog.at_level(logging.WARNING, logger="browser.stealth"):
+            prof = get_device_profile("mobile-ios")
+        assert prof is _DESKTOP_WINDOWS_PROFILE
+        assert any(
+            "mobile-ios" in rec.message and "non-Firefox UA" in rec.message
+            for rec in caplog.records
+        )
 
     def test_unknown_falls_back_to_default_with_warning(self, caplog):
         with caplog.at_level(logging.WARNING, logger="browser.stealth"):
@@ -139,7 +150,11 @@ class TestBuildLaunchOptionsProfile:
         assert opts_default["os"] == opts_explicit["os"]
 
     def test_mobile_ios_sets_ua_viewport_os(self):
-        with mock.patch.dict(os.environ, {}, clear=True):
+        with mock.patch.dict(
+            os.environ,
+            {"OPENLEGION_BROWSER_ALLOW_ENGINE_MISMATCH": "1"},
+            clear=True,
+        ):
             opts = build_launch_options(
                 "agent-iphone", "/tmp/p",
                 device_profile="mobile-ios",
@@ -177,7 +192,10 @@ class TestBuildLaunchOptionsProfile:
     def test_mobile_profile_overrides_browser_os_env(self):
         # Operator set BROWSER_OS=windows; mobile profile must win and use
         # its own ``camoufox_os`` instead.
-        with mock.patch.dict(os.environ, {"BROWSER_OS": "windows"}):
+        with mock.patch.dict(os.environ, {
+            "BROWSER_OS": "windows",
+            "OPENLEGION_BROWSER_ALLOW_ENGINE_MISMATCH": "1",
+        }):
             opts = build_launch_options(
                 "agent-x", "/tmp/p", device_profile="mobile-ios",
             )
@@ -197,7 +215,10 @@ class TestBuildLaunchOptionsProfile:
         # On the default profile, BROWSER_UA_VERSION normally rewrites
         # the UA. With a mobile profile that pins its own UA, the env
         # var must NOT override the profile's UA.
-        with mock.patch.dict(os.environ, {"BROWSER_UA_VERSION": "200.0"}):
+        with mock.patch.dict(os.environ, {
+            "BROWSER_UA_VERSION": "200.0",
+            "OPENLEGION_BROWSER_ALLOW_ENGINE_MISMATCH": "1",
+        }):
             opts = build_launch_options(
                 "agent-x", "/tmp/p", device_profile="mobile-ios",
             )
@@ -218,7 +239,12 @@ class TestMobileInitScript:
     def test_mobile_ios_emits_script_without_user_agent_data(self):
         # iOS Safari does NOT expose userAgentData — script must not
         # define it.
-        prof = get_device_profile("mobile-ios")
+        with mock.patch.dict(
+            os.environ,
+            {"OPENLEGION_BROWSER_ALLOW_ENGINE_MISMATCH": "1"},
+            clear=True,
+        ):
+            prof = get_device_profile("mobile-ios")
         script = build_mobile_init_script(prof)
         assert script is not None
         assert "maxTouchPoints" in script
@@ -344,6 +370,7 @@ class TestEndToEndProfileWiring:
         # Operator runs desktop-windows; one agent overridden to mobile-ios.
         with mock.patch.dict(os.environ, {
             "BROWSER_DEVICE_PROFILE": "desktop-windows",
+            "OPENLEGION_BROWSER_ALLOW_ENGINE_MISMATCH": "1",
         }):
             flags.set_agent_override(
                 "agent-mobile", "BROWSER_DEVICE_PROFILE", "mobile-ios",
@@ -359,12 +386,15 @@ class TestEndToEndProfileWiring:
         assert chosen_mobile == "mobile-ios"
         assert chosen_other == "desktop-windows"
 
-        opts_mobile = build_launch_options(
-            "agent-mobile", "/tmp/p", device_profile=chosen_mobile,
-        )
-        opts_other = build_launch_options(
-            "agent-other", "/tmp/p", device_profile=chosen_other,
-        )
+        with mock.patch.dict(os.environ, {
+            "OPENLEGION_BROWSER_ALLOW_ENGINE_MISMATCH": "1",
+        }):
+            opts_mobile = build_launch_options(
+                "agent-mobile", "/tmp/p", device_profile=chosen_mobile,
+            )
+            opts_other = build_launch_options(
+                "agent-other", "/tmp/p", device_profile=chosen_other,
+            )
         # Targeted agent gets iOS UA + viewport
         assert opts_mobile["window"] == (393, 852)
         assert "iPhone" in opts_mobile["config"]["navigator.userAgent"]

--- a/tests/test_browser_service.py
+++ b/tests/test_browser_service.py
@@ -112,6 +112,26 @@ class TestBrowserManagerLifecycle:
         assert len(mgr._instances) == 0
 
     @pytest.mark.asyncio
+    async def test_cleanup_loop_start_stop_is_idempotent(self, tmp_path):
+        from src.browser.service import BrowserManager
+
+        mgr = BrowserManager(profiles_dir=str(tmp_path / "profiles"))
+        await mgr.start_cleanup_loop()
+        cleanup_task = mgr._cleanup_task
+        upload_task = mgr._upload_recv_gc_task
+        download_task = mgr._download_gc_task
+        try:
+            await mgr.start_cleanup_loop()
+            assert mgr._cleanup_task is cleanup_task
+            assert mgr._upload_recv_gc_task is upload_task
+            assert mgr._download_gc_task is download_task
+        finally:
+            await mgr.stop_all()
+        assert mgr._cleanup_task is None
+        assert mgr._upload_recv_gc_task is None
+        assert mgr._download_gc_task is None
+
+    @pytest.mark.asyncio
     async def test_focus_auto_starts_browser(self):
         """Focus auto-starts a browser if one isn't running."""
         from src.browser.service import BrowserManager, CamoufoxInstance
@@ -294,13 +314,27 @@ class TestPerAgentXStack:
     @pytest.mark.asyncio
     async def test_teardown_releases_slot_and_kills_processes(self, monkeypatch):
         """Real teardown SIGTERMs the process group, waits, releases slot."""
-        from src.browser.display_allocator import DisplayAllocator
+        from src.browser.display_allocator import (
+            DisplayAllocator,
+            _port_is_bindable,
+            port_for_display,
+        )
         from src.browser.service import BrowserManager, CamoufoxInstance
 
         mgr = BrowserManager(profiles_dir="/tmp/test_profiles")
-        # Use a contained allocator so we don't fight the real /tmp/.X*-lock files.
+        # Use a contained allocator whose VNC ports are free on this host.
+        for display_start in range(200, 500):
+            if all(
+                _port_is_bindable(port_for_display(d))
+                for d in range(display_start, display_start + 5)
+            ):
+                break
+        else:
+            pytest.skip("no free display/VNC test range available")
         alloc = DisplayAllocator(
-            display_start=200, display_end=205, run_boot_sweep=False,
+            display_start=display_start,
+            display_end=display_start + 5,
+            run_boot_sweep=False,
         )
         slot = alloc.allocate()
         mgr._display_allocator = alloc

--- a/tests/test_display_allocator.py
+++ b/tests/test_display_allocator.py
@@ -12,10 +12,9 @@ Covers:
 
 from __future__ import annotations
 
-import socket
-
 import pytest
 
+import src.browser.display_allocator as display_allocator
 from src.browser.display_allocator import (
     DISPLAY_RANGE_END,
     DISPLAY_RANGE_START,
@@ -30,23 +29,24 @@ from src.browser.display_allocator import (
     port_for_display,
 )
 
+TEST_DISPLAY_START = 800
+TEST_DISPLAY_END = 805
+
 
 @pytest.fixture(autouse=True)
-def _isolate_lockfile_residue():
-    """Each test starts with /tmp/.X{N}-lock files removed in our test range.
-
-    Tests use a small range (200..205) that doesn't overlap with the
-    production allocator range (100..164) or the legacy shared display
-    (:99 / port 6080).  Cleanup runs both before and after so a failed
-    test doesn't poison the next one.
-    """
-    test_start, test_end = 200, 205
-    _force_clear_residue_for_tests(test_start, test_end)
+def _isolate_lockfile_residue(monkeypatch):
+    """Keep allocator unit tests independent of host TCP bind permissions."""
+    monkeypatch.setattr(display_allocator, "_port_is_bindable", lambda _port: True)
+    _force_clear_residue_for_tests(TEST_DISPLAY_START, TEST_DISPLAY_END)
     yield
-    _force_clear_residue_for_tests(test_start, test_end)
+    _force_clear_residue_for_tests(TEST_DISPLAY_START, TEST_DISPLAY_END)
 
 
-def _alloc_in_range(start: int = 200, end: int = 205, **kwargs) -> DisplayAllocator:
+def _alloc_in_range(
+    start: int = TEST_DISPLAY_START,
+    end: int = TEST_DISPLAY_END,
+    **kwargs,
+) -> DisplayAllocator:
     return DisplayAllocator(
         display_start=start, display_end=end, **kwargs,
     )
@@ -79,7 +79,7 @@ class TestModuleConstants:
 
 class TestAllocatorBasics:
     def test_capacity_reflects_range(self):
-        alloc = _alloc_in_range(200, 205, run_boot_sweep=False)
+        alloc = _alloc_in_range(run_boot_sweep=False)
         assert alloc.capacity == 5
         assert alloc.free_count == 5
         assert alloc.allocated_count == 0
@@ -93,24 +93,27 @@ class TestAllocatorBasics:
             DisplayAllocator(display_start=0, display_end=10)
 
     def test_allocate_returns_lowest_free(self):
-        alloc = _alloc_in_range(200, 205, run_boot_sweep=False)
+        alloc = _alloc_in_range(run_boot_sweep=False)
+        start = alloc._range.start
         s1 = alloc.allocate()
         s2 = alloc.allocate()
         # Lowest-first ordering means deterministic tests + readable logs.
-        assert s1.display == 200
-        assert s2.display == 201
-        assert s1.vnc_port == port_for_display(200)
-        assert s2.vnc_port == port_for_display(201)
+        assert s1.display == start
+        assert s2.display == start + 1
+        assert s1.vnc_port == port_for_display(start)
+        assert s2.vnc_port == port_for_display(start + 1)
 
     def test_allocate_raises_when_exhausted(self):
-        alloc = _alloc_in_range(200, 202, run_boot_sweep=False)
+        start, end = TEST_DISPLAY_START, TEST_DISPLAY_START + 2
+        alloc = _alloc_in_range(start, end, run_boot_sweep=False)
         alloc.allocate()
         alloc.allocate()
         with pytest.raises(PoolExhausted):
             alloc.allocate()
 
     def test_release_returns_slot_to_pool(self):
-        alloc = _alloc_in_range(200, 202, run_boot_sweep=False)
+        start, end = TEST_DISPLAY_START, TEST_DISPLAY_START + 2
+        alloc = _alloc_in_range(start, end, run_boot_sweep=False)
         s = alloc.allocate()
         alloc.allocate()
         alloc.release(s)
@@ -119,10 +122,11 @@ class TestAllocatorBasics:
         assert s2.display == s.display
 
     def test_release_unallocated_is_idempotent(self, caplog):
-        alloc = _alloc_in_range(200, 205, run_boot_sweep=False)
+        alloc = _alloc_in_range(run_boot_sweep=False)
+        start = alloc._range.start
         # Releasing a slot that was never allocated must NOT raise — error
         # recovery paths can call release on a Slot that wasn't claimed.
-        alloc.release(Slot(display=200, vnc_port=port_for_display(200)))
+        alloc.release(Slot(display=start, vnc_port=port_for_display(start)))
         # And after a real alloc+release, double-release also tolerated.
         s = alloc.allocate()
         alloc.release(s)
@@ -130,7 +134,7 @@ class TestAllocatorBasics:
 
     def test_release_cleans_lock_residue(self, tmp_path, monkeypatch):
         """Residue files on the slot's display number are cleaned by release."""
-        alloc = _alloc_in_range(200, 205, run_boot_sweep=False)
+        alloc = _alloc_in_range(run_boot_sweep=False)
         s = alloc.allocate()
         # Plant a fake lock; release must clean it.
         _write_fake_lock_for_tests(s, pid=11111)
@@ -139,7 +143,7 @@ class TestAllocatorBasics:
         assert not s.lock_path.exists()
 
     def test_is_allocated_reflects_state(self):
-        alloc = _alloc_in_range(200, 205, run_boot_sweep=False)
+        alloc = _alloc_in_range(run_boot_sweep=False)
         s = alloc.allocate()
         assert alloc.is_allocated(s.display)
         alloc.release(s)
@@ -153,45 +157,45 @@ class TestBootSweep:
     def test_clean_start_no_logs(self, caplog):
         """When /tmp is clean and no port is bound, sweep is silent."""
         with caplog.at_level("INFO", logger="browser.display_allocator"):
-            _alloc_in_range(200, 205)
+            _alloc_in_range()
         # We don't pin exact log absence — just verify no slots were
         # mistakenly dropped from the pool.
 
     def test_stale_lock_removed_when_port_free(self):
         """Lock-file residue without a live process is removed."""
         # Plant a stale lock file in our test range.
-        slot = Slot(display=200, vnc_port=port_for_display(200))
+        start, end = TEST_DISPLAY_START, TEST_DISPLAY_END
+        slot = Slot(display=start, vnc_port=port_for_display(start))
         _write_fake_lock_for_tests(slot, pid=99999)
         assert slot.lock_path.exists()
         # Boot sweep should remove it (port is free).
-        alloc = _alloc_in_range(200, 205)
+        alloc = _alloc_in_range(start, end)
         assert not slot.lock_path.exists()
         # And the slot should be allocate-able.
         assert alloc.is_allocated(slot.display) is False
         s = alloc.allocate()
-        assert s.display == 200
+        assert s.display == start
 
     def test_slot_dropped_when_port_bound(self):
         """A slot whose paired port is currently bound is not allocate-able."""
-        # Bind port for display 200 to simulate a live X server.
-        port = port_for_display(200)
-        sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-        sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        start, end = TEST_DISPLAY_START, TEST_DISPLAY_END
+        port = port_for_display(start)
+        monkeypatch = pytest.MonkeyPatch()
+        monkeypatch.setattr(
+            display_allocator,
+            "_port_is_bindable",
+            lambda candidate: candidate != port,
+        )
         try:
-            try:
-                sock.bind(("0.0.0.0", port))
-            except OSError:
-                pytest.skip(f"port {port} unavailable in this environment")
-            sock.listen(1)
-            alloc = _alloc_in_range(200, 205)
-            # Display 200 should have been removed from the pool.
-            with pytest.raises(PoolExhausted):
-                # We have 4 free slots (201-204); the 5th allocate should
-                # trip pool exhaustion since 200 was dropped.
-                for _ in range(5):
-                    alloc.allocate()
+            alloc = _alloc_in_range(start, end)
         finally:
-            sock.close()
+            monkeypatch.undo()
+        # The bound display should have been removed from the pool.
+        with pytest.raises(PoolExhausted):
+            # We have width-1 free slots; the width-th allocate should
+            # trip pool exhaustion since the first display was dropped.
+            for _ in range(5):
+                alloc.allocate()
 
 
 # ── port-collision recovery on allocate ─────────────────────────────────────
@@ -200,23 +204,23 @@ class TestBootSweep:
 class TestAllocateRecovery:
     def test_allocate_skips_slot_whose_port_just_got_bound(self):
         """If the boot sweep missed a slot, allocate() drops it on probe."""
-        alloc = _alloc_in_range(200, 205, run_boot_sweep=False)
+        start, end = TEST_DISPLAY_START, TEST_DISPLAY_END
+        alloc = _alloc_in_range(start, end, run_boot_sweep=False)
 
-        # Bind 200's port AFTER construction (sweep can't see this).
-        port = port_for_display(200)
-        sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-        sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        # Bind the first display's port AFTER construction (sweep can't see this).
+        port = port_for_display(start)
+        monkeypatch = pytest.MonkeyPatch()
+        monkeypatch.setattr(
+            display_allocator,
+            "_port_is_bindable",
+            lambda candidate: candidate != port,
+        )
         try:
-            try:
-                sock.bind(("0.0.0.0", port))
-            except OSError:
-                pytest.skip(f"port {port} unavailable in this environment")
-            sock.listen(1)
-            # First allocate should skip 200 and give us 201.
+            # First allocate should skip the bound slot and give us the next one.
             s = alloc.allocate()
-            assert s.display == 201
         finally:
-            sock.close()
+            monkeypatch.undo()
+        assert s.display == start + 1
 
 
 # ── port/display helpers ────────────────────────────────────────────────────
@@ -233,7 +237,8 @@ class TestHelpers:
         assert slot.display_str == ":100"
 
     def test_read_lock_pid_round_trip(self):
-        slot = Slot(display=200, vnc_port=port_for_display(200))
+        start = TEST_DISPLAY_START
+        slot = Slot(display=start, vnc_port=port_for_display(start))
         try:
             _write_fake_lock_for_tests(slot, pid=12345)
             assert _read_lock_pid(slot.lock_path) == 12345

--- a/tests/test_per_agent_vnc.py
+++ b/tests/test_per_agent_vnc.py
@@ -38,6 +38,38 @@ def _make_instance(agent_id: str):
     )
 
 
+class TestWebsocketsCompatibility:
+    def test_browser_service_uses_new_header_kwarg(self):
+        from src.browser.server import _websockets_headers_kw
+
+        def connect(uri, *, additional_headers=None):  # pragma: no cover
+            return uri, additional_headers
+
+        assert _websockets_headers_kw(connect, {"A": "B"}) == {
+            "additional_headers": {"A": "B"},
+        }
+
+    def test_browser_service_uses_legacy_header_kwarg(self):
+        from src.browser.server import _websockets_headers_kw
+
+        def connect(uri, *, extra_headers=None):  # pragma: no cover
+            return uri, extra_headers
+
+        assert _websockets_headers_kw(connect, {"A": "B"}) == {
+            "extra_headers": {"A": "B"},
+        }
+
+    def test_host_proxy_uses_legacy_header_kwarg(self):
+        from src.host.server import _websockets_headers_kw
+
+        def connect(uri, *, extra_headers=None):  # pragma: no cover
+            return uri, extra_headers
+
+        assert _websockets_headers_kw(connect, {"A": "B"}) == {
+            "extra_headers": {"A": "B"},
+        }
+
+
 # ── BrowserManager accessors ─────────────────────────────────────────────
 
 
@@ -350,5 +382,3 @@ class TestBrowserStatusActiveAgents:
         body = resp.json()
         assert body.get("active_browsers", -1) == 0
         assert body.get("agents", "missing") == []
-
-

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -1249,6 +1249,26 @@ class TestEntrypointHelpers:
         )
         return result.returncode == 0
 
+    @staticmethod
+    def _run_entrypoint_function(function_name: str, *, env: dict[str, str]):
+        import shlex
+        import subprocess
+        from pathlib import Path
+
+        repo_root = Path(__file__).resolve().parent.parent
+        script = repo_root / "docker" / "browser-entrypoint.sh"
+        if not script.exists():
+            import pytest
+            pytest.skip(f"entrypoint script not found at {script}")
+        cmd = f"source {shlex.quote(str(script))} && {function_name}"
+        return subprocess.run(
+            ["/bin/bash", "-c", cmd],
+            capture_output=True,
+            text=True,
+            timeout=10,
+            env=env,
+        )
+
     # ── is_valid_ipv4 ─────────────────────────────────────────
 
     def test_ipv4_accepts_typical_addresses(self):
@@ -1305,3 +1325,19 @@ class TestEntrypointHelpers:
     def test_cidr_rejects_empty(self):
         assert not self._call("is_valid_ipv4_cidr", "")
 
+    def test_egress_filter_fails_closed_without_iptables_restore(self, tmp_path):
+        result = self._run_entrypoint_function(
+            "install_egress_filter",
+            env={"PATH": str(tmp_path)},
+        )
+        assert result.returncode == 1
+        assert "iptables-restore not installed" in result.stderr
+        assert "refusing to start" in result.stderr
+
+    def test_egress_filter_explicit_disable_still_skips(self, tmp_path):
+        result = self._run_entrypoint_function(
+            "install_egress_filter",
+            env={"PATH": str(tmp_path), "BROWSER_EGRESS_DISABLE": "1"},
+        )
+        assert result.returncode == 0
+        assert "skipping firewall setup" in result.stderr

--- a/tests/test_stealth.py
+++ b/tests/test_stealth.py
@@ -161,8 +161,7 @@ class TestAcceptLanguageCoherence:
 
 
 class TestEngineMismatchOptIn:
-    """``mobile-android`` ships Chrome UA on Firefox engine — strong bot
-    signal on FP-aware sites. Must be opt-in via env flag, not silent."""
+    """Mobile profiles that claim a non-Firefox UA on Firefox are opt-in."""
 
     def test_mobile_android_requires_opt_in(self, monkeypatch):
         from src.browser.stealth import (
@@ -183,12 +182,20 @@ class TestEngineMismatchOptIn:
         out = get_device_profile("mobile-android")
         assert out is _DEVICE_PROFILES["mobile-android"]
 
-    def test_mobile_ios_does_not_require_opt_in(self):
-        # iOS profile (Mobile Safari UA on Gecko) is also engine-mismatched
-        # but the docstring's stated trade-off was already accepted; not
-        # gating to avoid breaking existing iOS-mode operators. Documented
-        # via the explicit allow-list — only ``mobile-android`` is gated.
+    def test_mobile_ios_requires_opt_in(self, monkeypatch):
+        from src.browser.stealth import (
+            _DEVICE_PROFILES,
+            DEFAULT_DEVICE_PROFILE,
+            get_device_profile,
+        )
+
+        monkeypatch.delenv("OPENLEGION_BROWSER_ALLOW_ENGINE_MISMATCH", raising=False)
+        out = get_device_profile("mobile-ios")
+        assert out is _DEVICE_PROFILES[DEFAULT_DEVICE_PROFILE]
+
+    def test_mobile_ios_returns_profile_when_flag_set(self, monkeypatch):
         from src.browser.stealth import _DEVICE_PROFILES, get_device_profile
 
+        monkeypatch.setenv("OPENLEGION_BROWSER_ALLOW_ENGINE_MISMATCH", "1")
         out = get_device_profile("mobile-ios")
         assert out is _DEVICE_PROFILES["mobile-ios"]


### PR DESCRIPTION
Final end-to-end browser-system hardening pass.\n\nSummary:\n- Fail closed when browser egress firewall support is missing unless explicitly disabled.\n- Gate both mobile engine-mismatch profiles behind OPENLEGION_BROWSER_ALLOW_ENGINE_MISMATCH=1.\n- Make browser cleanup-loop lifecycle idempotent.\n- Add websockets header kwarg compatibility for VNC proxies.\n- Stabilize display allocator tests.\n\nValidation:\n- ruff passed\n- compileall passed\n- browser-focused pytest slice: 684 passed, 17 skipped