### PR TITLE
fix(coordination): make project agent → operator handoff actually work

### DIFF
--- a/src/agent/builtins/coordination_tool.py
+++ b/src/agent/builtins/coordination_tool.py
@@ -77,10 +77,10 @@ async def hand_off(
     if not re.fullmatch(AGENT_ID_RE_PATTERN, to):
         return {"error": f"Invalid agent ID: '{to}'"}
 
-    # Resolve target agent's project for cross-project coordination.
-    # The operator (standalone) needs to write to the target's project-scoped
-    # blackboard so the recipient finds the task via check_inbox().
+    # Resolve target agent's project for cross-project coordination, and
+    # detect whether it advertises a fleet-global scope (operator-style).
     target_project: str | None = None
+    target_is_global = False
     try:
         registry = await mesh_client.list_agents()
         if to not in registry:
@@ -89,6 +89,7 @@ async def hand_off(
         target_info = registry.get(to, {})
         if isinstance(target_info, dict):
             target_project = target_info.get("project")
+            target_is_global = target_info.get("scope") == "global"
     except Exception as e:
         # Standalone senders MUST resolve the target project to write to
         # the correct namespace.  Fail closed rather than writing to the
@@ -98,11 +99,16 @@ async def hand_off(
         logger.debug("Fleet roster check failed, proceeding with validated ID: %s", e)
 
     # Determine which project scope to use for blackboard writes.
-    # If sender and target are in the same project (or both standalone),
-    # use normal scoping.  Otherwise, use the target's project so the
-    # recipient can find the task.
+    # Fleet-global agents (operator) need their inbox in a global namespace
+    # because they have no project scope to read from. We trigger on the
+    # literal reserved name AND on the registry hint, so the path stays
+    # correct even when the registry roster lookup fails (no hint available)
+    # and forward-compatible if other global agents are added later.
     write_project: str | None = None  # None = use sender's default scope
-    if target_project and target_project != mesh_client.project_name:
+    write_global = False
+    if to == "operator" or target_is_global:
+        write_global = True
+    elif target_project and target_project != mesh_client.project_name:
         write_project = target_project
 
     handoff_id = generate_id("ho")
@@ -121,11 +127,15 @@ async def hand_off(
             parsed_data = json.loads(data)
         except json.JSONDecodeError:
             parsed_data = {"text": data}
-        output_key = f"output/{from_agent}/{handoff_id}"
+        output_key = (
+            f"global/output/{from_agent}/{handoff_id}"
+            if write_global
+            else f"output/{from_agent}/{handoff_id}"
+        )
         try:
             await mesh_client.write_blackboard(
                 output_key, parsed_data, ttl=_HANDOFF_TTL,
-                project=write_project,
+                project=write_project, global_scope=write_global,
             )
         except Exception as e:
             return {"error": f"Failed to write output: {e}"}
@@ -142,11 +152,15 @@ async def hand_off(
     if origin:
         task_record["origin"] = origin
 
-    task_key = f"tasks/{to}/{handoff_id}"
+    task_key = (
+        f"global/tasks/{to}/{handoff_id}"
+        if write_global
+        else f"tasks/{to}/{handoff_id}"
+    )
     try:
         await mesh_client.write_blackboard(
             task_key, task_record, ttl=_HANDOFF_TTL,
-            project=write_project,
+            project=write_project, global_scope=write_global,
         )
     except Exception as e:
         # Clean up orphaned output if task write fails
@@ -195,16 +209,28 @@ async def hand_off(
 async def check_inbox(*, mesh_client=None) -> dict:
     if mesh_client is None:
         return {"error": "No mesh_client available"}
-    if mesh_client.is_standalone:
-        return {"error": _STANDALONE_ERROR}
 
     agent_id = mesh_client.agent_id
-    prefix = f"tasks/{agent_id}/"
+    is_operator = (agent_id == "operator")
 
-    try:
-        entries = await mesh_client.list_blackboard(prefix)
-    except Exception as e:
-        return {"error": f"Failed to check inbox: {e}"}
+    # Standalone agents normally have no inbox (blackboard is project-scoped).
+    # The operator is the exception: its inbox lives in a fleet-global namespace
+    # so cross-project workers can hand off back to it without knowing its scope.
+    if mesh_client.is_standalone and not is_operator:
+        return {"error": _STANDALONE_ERROR}
+
+    if is_operator:
+        prefix = "global/tasks/operator/"
+        try:
+            entries = await mesh_client.list_blackboard(prefix, global_scope=True)
+        except Exception as e:
+            return {"error": f"Failed to check inbox: {e}"}
+    else:
+        prefix = f"tasks/{agent_id}/"
+        try:
+            entries = await mesh_client.list_blackboard(prefix)
+        except Exception as e:
+            return {"error": f"Failed to check inbox: {e}"}
 
     tasks = []
     for entry in entries:
@@ -263,18 +289,27 @@ async def update_status(
 ) -> dict:
     if mesh_client is None:
         return {"error": "No mesh_client available"}
-    if mesh_client.is_standalone:
-        return {"error": _STANDALONE_ERROR}
 
     agent_id = mesh_client.agent_id
+    is_operator = (agent_id == "operator")
+
+    if mesh_client.is_standalone and not is_operator:
+        return {"error": _STANDALONE_ERROR}
+
     status_data = {
         "state": state,
         "summary": sanitize_for_prompt(summary),
         "ts": time.time(),
     }
 
+    # Operator status writes to the fleet-global status namespace so it
+    # is reachable from any project scope (operator has no project of its
+    # own to scope writes to).
+    status_key = f"global/status/{agent_id}" if is_operator else f"status/{agent_id}"
     try:
-        await mesh_client.write_blackboard(f"status/{agent_id}", status_data)
+        await mesh_client.write_blackboard(
+            status_key, status_data, global_scope=is_operator,
+        )
     except Exception as e:
         return {"error": f"Failed to update status: {e}"}
 
@@ -298,23 +333,30 @@ async def update_status(
 async def complete_task(task_key: str, *, mesh_client=None) -> dict:
     if mesh_client is None:
         return {"error": "No mesh_client available"}
-    if mesh_client.is_standalone:
+
+    agent_id = mesh_client.agent_id
+    is_operator = (agent_id == "operator")
+
+    if mesh_client.is_standalone and not is_operator:
         return {"error": _STANDALONE_ERROR}
 
     # Ownership check — only complete tasks in your own inbox
-    agent_id = mesh_client.agent_id
-    expected_prefix = f"tasks/{agent_id}/"
-    if not task_key.startswith(expected_prefix):
+    allowed_prefixes = [f"tasks/{agent_id}/"]
+    if is_operator:
+        allowed_prefixes.append("global/tasks/operator/")
+    if not any(task_key.startswith(p) for p in allowed_prefixes):
         return {"error": f"Can only complete your own tasks (expected prefix: tasks/{agent_id}/)"}
+
+    is_global_task = task_key.startswith("global/")
 
     try:
         # Read task to find associated output for cleanup
-        existing = await mesh_client.read_blackboard(task_key)
+        existing = await mesh_client.read_blackboard(task_key, global_scope=is_global_task)
         if existing is None:
             return {"error": f"Task '{task_key}' not found"}
 
         # Delete the task entry
-        await mesh_client.delete_blackboard(task_key)
+        await mesh_client.delete_blackboard(task_key, global_scope=is_global_task)
 
         # Best-effort cleanup of associated output data
         value = existing.get("value", existing)
@@ -327,7 +369,8 @@ async def complete_task(task_key: str, *, mesh_client=None) -> dict:
             output_key = value.get("output_key")
             if output_key:
                 try:
-                    await mesh_client.delete_blackboard(output_key)
+                    output_global = output_key.startswith("global/")
+                    await mesh_client.delete_blackboard(output_key, global_scope=output_global)
                 except Exception as exc:
                     logger.debug("Output cleanup for %s skipped: %s", output_key, exc)
     except Exception as e:

--- a/src/agent/builtins/coordination_tool.py
+++ b/src/agent/builtins/coordination_tool.py
@@ -367,10 +367,26 @@ async def complete_task(task_key: str, *, mesh_client=None) -> dict:
                 value = {}
         if isinstance(value, dict):
             output_key = value.get("output_key")
-            if output_key:
+            if isinstance(output_key, str) and output_key:
                 try:
-                    output_global = output_key.startswith("global/")
-                    await mesh_client.delete_blackboard(output_key, global_scope=output_global)
+                    handoff_id = task_key.rsplit("/", 1)[-1]
+                    sender = value.get("from")
+                    expected_output = None
+                    if isinstance(sender, str) and re.fullmatch(AGENT_ID_RE_PATTERN, sender):
+                        expected_output = (
+                            f"global/output/{sender}/{handoff_id}"
+                            if is_global_task
+                            else f"output/{sender}/{handoff_id}"
+                        )
+                    if output_key == expected_output:
+                        await mesh_client.delete_blackboard(
+                            output_key, global_scope=is_global_task,
+                        )
+                    else:
+                        logger.debug(
+                            "Skipping unexpected output cleanup for task %s: %s",
+                            task_key, output_key,
+                        )
                 except Exception as exc:
                     logger.debug("Output cleanup for %s skipped: %s", output_key, exc)
     except Exception as e:

--- a/src/agent/builtins/mesh_tool.py
+++ b/src/agent/builtins/mesh_tool.py
@@ -139,10 +139,20 @@ def _sanitize_value(value):
 async def read_blackboard(key: str, *, mesh_client=None) -> dict:
     if mesh_client is None:
         return {"error": "No mesh_client available"}
-    if mesh_client.is_standalone:
+    operator_global_read = (
+        getattr(mesh_client, "agent_id", "") == "operator"
+        and (
+            key.startswith("global/output/")
+            or key.startswith("global/tasks/operator/")
+        )
+    )
+    if mesh_client.is_standalone and not operator_global_read:
         return {"error": _STANDALONE_ERROR}
     try:
-        entry = await mesh_client.read_blackboard(key)
+        if operator_global_read:
+            entry = await mesh_client.read_blackboard(key, global_scope=True)
+        else:
+            entry = await mesh_client.read_blackboard(key)
         if entry is None:
             return {"key": key, "exists": False, "value": None}
         value = _sanitize_value(entry.get("value", entry))

--- a/src/agent/mesh_client.py
+++ b/src/agent/mesh_client.py
@@ -132,9 +132,14 @@ class MeshClient:
         )
         response.raise_for_status()
 
-    async def read_blackboard(self, key: str) -> dict | None:
-        """Read a value from the shared blackboard."""
-        scoped = self._scope_key(key)
+    async def read_blackboard(self, key: str, *, global_scope: bool = False) -> dict | None:
+        """Read a value from the shared blackboard.
+
+        If *global_scope* is True, the key is sent as-is, bypassing the
+        per-agent project scoping. Used to read fleet-global keys such as
+        the operator inbox under ``global/tasks/operator/``.
+        """
+        scoped = key if global_scope else self._scope_key(key)
         response = await self._get_with_retry(
             f"{self.mesh_url}/mesh/blackboard/{scoped}",
             params={"agent_id": self.agent_id},
@@ -146,15 +151,21 @@ class MeshClient:
 
     async def write_blackboard(
         self, key: str, value: dict, ttl: int | None = None,
-        *, project: str | None = None,
+        *, project: str | None = None, global_scope: bool = False,
     ) -> dict:
         """Write a value to the shared blackboard.
 
         If *project* is given, scope the key to that project instead of
         this agent's own project.  Used by cross-project coordination
         (e.g. operator handing off work to a project-scoped agent).
+
+        If *global_scope* is True, the key is sent as-is — bypassing both
+        the explicit ``project=`` override and the auto project prefix.
+        Used for fleet-global namespaces such as the operator inbox.
         """
-        if project is not None:
+        if global_scope:
+            scoped = key
+        elif project is not None:
             scoped = f"projects/{project}/{key}"
         else:
             scoped = self._scope_key(key)
@@ -171,9 +182,13 @@ class MeshClient:
         response.raise_for_status()
         return response.json()
 
-    async def delete_blackboard(self, key: str) -> dict:
-        """Delete an entry from the shared blackboard."""
-        scoped = self._scope_key(key)
+    async def delete_blackboard(self, key: str, *, global_scope: bool = False) -> dict:
+        """Delete an entry from the shared blackboard.
+
+        If *global_scope* is True, the key is sent as-is, bypassing project
+        scoping. Used for keys in the fleet-global namespace.
+        """
+        scoped = key if global_scope else self._scope_key(key)
         client = await self._get_client()
         response = await client.delete(
             f"{self.mesh_url}/mesh/blackboard/{scoped}",
@@ -204,17 +219,24 @@ class MeshClient:
         response.raise_for_status()
         return response.json()
 
-    async def list_blackboard(self, prefix: str) -> list[dict]:
-        """List blackboard entries by key prefix."""
-        scoped = self._scope_key(prefix)
+    async def list_blackboard(
+        self, prefix: str, *, global_scope: bool = False,
+    ) -> list[dict]:
+        """List blackboard entries by key prefix.
+
+        If *global_scope* is True, the prefix is sent as-is, bypassing the
+        per-agent project scoping. Used for fleet-global namespaces such
+        as the operator inbox at ``global/tasks/operator/``.
+        """
+        scoped = prefix if global_scope else self._scope_key(prefix)
         response = await self._get_with_retry(
             f"{self.mesh_url}/mesh/blackboard/",
             params={"agent_id": self.agent_id, "prefix": scoped},
         )
         response.raise_for_status()
         entries = response.json()
-        # Strip project prefix from returned keys so agents see natural keys
-        if self.project_name:
+        # Strip project prefix only when we used project scoping
+        if not global_scope and self.project_name:
             scope = f"projects/{self.project_name}/"
             for entry in entries:
                 k = entry.get("key", "")

--- a/src/host/permissions.py
+++ b/src/host/permissions.py
@@ -158,6 +158,15 @@ class PermissionMatrix:
     def can_write_blackboard(self, agent_id: str, key: str) -> bool:
         if self._is_trusted(agent_id):
             return True
+        # Operator inbox is a fleet-global mailbox: any registered agent can
+        # hand off a task to the operator. The operator is the only reader
+        # (its blackboard_read=["*"] already covers the read side).
+        if key.startswith("global/tasks/operator/"):
+            return True
+        # Output namespace for operator handoffs is per-sender — only the
+        # writing agent can place output under their own prefix.
+        if key.startswith(f"global/output/{agent_id}/"):
+            return True
         perms = self.get_permissions(agent_id)
         return any(fnmatch.fnmatch(key, pattern) for pattern in perms.blackboard_write)
 

--- a/src/host/permissions.py
+++ b/src/host/permissions.py
@@ -152,6 +152,16 @@ class PermissionMatrix:
     def can_read_blackboard(self, agent_id: str, key: str) -> bool:
         if self._is_trusted(agent_id):
             return True
+        # Fleet-global operator handoff data is not covered by normal
+        # wildcard reads.  Workers can write into the operator mailbox, but
+        # only the operator may inspect queued tasks and submitted outputs.
+        if key.startswith("global/tasks/operator/"):
+            return agent_id == "operator"
+        if key.startswith("global/output/"):
+            return (
+                agent_id == "operator"
+                or key.startswith(f"global/output/{agent_id}/")
+            )
         perms = self.get_permissions(agent_id)
         return any(fnmatch.fnmatch(key, pattern) for pattern in perms.blackboard_read)
 

--- a/src/host/server.py
+++ b/src/host/server.py
@@ -1277,6 +1277,8 @@ def create_mesh_app(
             proj = _agent_projects.get(aid)
             if proj:
                 entry["project"] = proj
+            if aid == "operator":
+                entry["scope"] = "global"
             return entry
 
         if project:
@@ -1287,11 +1289,17 @@ def create_mesh_app(
                 logger.warning("list_agents: unknown project %r", project)
                 return {}
             members = set(pdata.get("members", []))
-            return {
+            result = {
                 aid: _agent_entry(aid, url)
                 for aid, url in router.agent_registry.items()
                 if aid in members
             }
+            # Operator is fleet-global by design: project agents must be able to
+            # discover and hand off back to it regardless of project membership.
+            op_url = router.agent_registry.get("operator")
+            if op_url is not None and "operator" not in result:
+                result["operator"] = _agent_entry("operator", op_url)
+            return result
         if agent_id:
             url = router.agent_registry.get(agent_id)
             if url:

--- a/tests/test_builtins.py
+++ b/tests/test_builtins.py
@@ -2129,6 +2129,27 @@ class TestStandaloneBlackboardGuards:
         assert "not assigned to a project" in result["error"]
 
     @pytest.mark.asyncio
+    async def test_operator_can_read_global_handoff_output(self):
+        from src.agent.builtins.mesh_tool import read_blackboard
+        mc = self._standalone_client()
+        mc.agent_id = "operator"
+        mc.read_blackboard = AsyncMock(return_value={
+            "key": "global/output/scout/ho_1",
+            "value": {"result": "done"},
+        })
+
+        result = await read_blackboard(
+            key="global/output/scout/ho_1",
+            mesh_client=mc,
+        )
+
+        assert result["exists"] is True
+        assert result["value"] == {"result": "done"}
+        mc.read_blackboard.assert_awaited_once_with(
+            "global/output/scout/ho_1", global_scope=True,
+        )
+
+    @pytest.mark.asyncio
     async def test_write_blackboard_blocked_for_standalone(self):
         from src.agent.builtins.mesh_tool import write_blackboard
         result = await write_blackboard(

--- a/tests/test_coordination.py
+++ b/tests/test_coordination.py
@@ -713,6 +713,30 @@ class TestOperatorHandoff:
             assert call.kwargs.get("global_scope") is True
 
     @pytest.mark.asyncio
+    async def test_operator_complete_global_task_skips_unexpected_output_key(self):
+        """A queued operator task cannot make complete_task delete arbitrary global keys."""
+        from src.agent.builtins.coordination_tool import complete_task
+
+        mc = _make_mesh_client(agent_id="operator", standalone=True)
+        mc.read_blackboard = AsyncMock(return_value={
+            "value": {
+                "from": "scout",
+                "summary": "follow up",
+                "status": "pending",
+                "output_key": "global/status/operator",
+            },
+        })
+
+        result = await complete_task(
+            task_key="global/tasks/operator/ho_xyz",
+            mesh_client=mc,
+        )
+
+        assert result["completed"] is True
+        deleted = [c.args[0] for c in mc.delete_blackboard.call_args_list]
+        assert deleted == ["global/tasks/operator/ho_xyz"]
+
+    @pytest.mark.asyncio
     async def test_hand_off_uses_registry_scope_hint(self):
         """Defense-in-depth: a registry entry with scope=global triggers
         global writes even if the target name is not the literal 'operator'.

--- a/tests/test_coordination.py
+++ b/tests/test_coordination.py
@@ -605,3 +605,248 @@ class TestHandOffOriginPropagation:
         last_call = mc.write_blackboard.call_args_list[-1]
         task_record = last_call.args[1]
         assert "origin" not in task_record
+
+
+class TestOperatorHandoff:
+    """Coverage for the project_agent → operator handoff path (Task 0 hotfix)."""
+
+    @pytest.mark.asyncio
+    async def test_worker_to_operator_writes_to_global_namespace(self):
+        from src.agent.builtins.coordination_tool import hand_off
+
+        mc = _make_mesh_client(agent_id="scout")
+        mc.project_name = "growth"
+        mc.is_standalone = False
+        mc.list_agents.return_value = {
+            "operator": {"url": "http://operator:8400", "scope": "global"},
+        }
+
+        result = await hand_off(
+            to="operator",
+            summary="follow up with the user",
+            data='{"note": "ok"}',
+            mesh_client=mc,
+        )
+
+        assert result["handed_off"] is True
+        assert result["task_key"].startswith("global/tasks/operator/")
+        assert result["output_key"].startswith("global/output/scout/")
+        # Both writes must use global_scope=True (NOT the sender's project scope)
+        assert mc.write_blackboard.call_count == 2
+        for call in mc.write_blackboard.call_args_list:
+            assert call.kwargs.get("global_scope") is True
+            assert call.kwargs.get("project") is None
+
+    @pytest.mark.asyncio
+    async def test_operator_check_inbox_lists_global_namespace(self):
+        from src.agent.builtins.coordination_tool import check_inbox
+
+        mc = _make_mesh_client(agent_id="operator", standalone=True)
+        mc.list_blackboard.return_value = [
+            {
+                "key": "global/tasks/operator/ho_xyz",
+                "value": {
+                    "from": "scout",
+                    "summary": "user wants a recap",
+                    "status": "pending",
+                    "ts": 1700000000.0,
+                },
+            },
+        ]
+
+        result = await check_inbox(mesh_client=mc)
+
+        assert "error" not in result
+        assert result["count"] == 1
+        assert result["tasks"][0]["from"] == "scout"
+        # Must be called with global_scope=True
+        mc.list_blackboard.assert_called_once()
+        call = mc.list_blackboard.call_args
+        assert call.args[0] == "global/tasks/operator/"
+        assert call.kwargs.get("global_scope") is True
+
+    @pytest.mark.asyncio
+    async def test_non_operator_standalone_still_blocked(self):
+        """Regression: standalone agents that are not the operator still get the standalone error."""
+        from src.agent.builtins.coordination_tool import check_inbox
+
+        mc = _make_mesh_client(agent_id="lone-wolf", standalone=True)
+
+        result = await check_inbox(mesh_client=mc)
+
+        assert "error" in result
+        assert "not assigned" in result["error"]
+        mc.list_blackboard.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_operator_completes_global_task(self):
+        from src.agent.builtins.coordination_tool import complete_task
+
+        mc = _make_mesh_client(agent_id="operator", standalone=True)
+        mc.read_blackboard = AsyncMock(return_value={
+            "value": {
+                "from": "scout",
+                "summary": "follow up",
+                "status": "pending",
+                "output_key": "global/output/scout/ho_xyz",
+            },
+        })
+
+        result = await complete_task(
+            task_key="global/tasks/operator/ho_xyz",
+            mesh_client=mc,
+        )
+
+        assert result["completed"] is True
+        # Read on the task must use global_scope=True so the standalone
+        # operator's MeshClient does not auto-prefix with project scope.
+        mc.read_blackboard.assert_awaited_once()
+        read_call = mc.read_blackboard.call_args
+        assert read_call.args[0] == "global/tasks/operator/ho_xyz"
+        assert read_call.kwargs.get("global_scope") is True
+        # Both task delete and output delete must use global_scope=True
+        delete_calls = mc.delete_blackboard.call_args_list
+        keys_deleted = [c.args[0] for c in delete_calls]
+        assert "global/tasks/operator/ho_xyz" in keys_deleted
+        assert "global/output/scout/ho_xyz" in keys_deleted
+        for call in delete_calls:
+            assert call.kwargs.get("global_scope") is True
+
+    @pytest.mark.asyncio
+    async def test_hand_off_uses_registry_scope_hint(self):
+        """Defense-in-depth: a registry entry with scope=global triggers
+        global writes even if the target name is not the literal 'operator'.
+        Future-proofs against additional global agents being introduced."""
+        from src.agent.builtins.coordination_tool import hand_off
+
+        mc = _make_mesh_client(agent_id="scout")
+        mc.project_name = "growth"
+        mc.is_standalone = False
+        # Hypothetical future global agent — registry advertises scope.
+        mc.list_agents.return_value = {
+            "fleet-monitor": {
+                "url": "http://fleet-monitor:8400",
+                "scope": "global",
+            },
+        }
+
+        result = await hand_off(
+            to="fleet-monitor",
+            summary="alert: agent X failing",
+            mesh_client=mc,
+        )
+
+        assert result["handed_off"] is True
+        assert result["task_key"].startswith("global/tasks/fleet-monitor/")
+        write_call = mc.write_blackboard.call_args
+        assert write_call.kwargs.get("global_scope") is True
+        assert write_call.kwargs.get("project") is None
+
+    @pytest.mark.asyncio
+    async def test_hand_off_to_operator_when_roster_lookup_fails(self):
+        """Resilience: even if list_agents fails, the literal 'operator' name
+        still routes the handoff to the global namespace. The roster-failure
+        path must not silently fall back to project scope, which would make
+        the operator unreachable."""
+        from src.agent.builtins.coordination_tool import hand_off
+
+        mc = _make_mesh_client(agent_id="scout")
+        mc.project_name = "growth"
+        mc.is_standalone = False
+        mc.list_agents.side_effect = Exception("mesh down")
+
+        result = await hand_off(
+            to="operator",
+            summary="user wants a recap",
+            mesh_client=mc,
+        )
+
+        assert result["handed_off"] is True
+        assert result["task_key"].startswith("global/tasks/operator/")
+        write_call = mc.write_blackboard.call_args
+        assert write_call.kwargs.get("global_scope") is True
+
+    @pytest.mark.asyncio
+    async def test_operator_update_status_writes_global(self):
+        """Operator's status update goes to the fleet-global namespace —
+        previously it errored out via the standalone gate, leaving status
+        updates broken for the only agent that legitimately needs to write
+        them at the fleet level."""
+        from src.agent.builtins.coordination_tool import update_status
+
+        mc = _make_mesh_client(agent_id="operator", standalone=True)
+
+        result = await update_status(
+            state="working", summary="reviewing fleet", mesh_client=mc,
+        )
+
+        assert "error" not in result
+        assert result["updated"] is True
+        mc.write_blackboard.assert_awaited_once()
+        call = mc.write_blackboard.call_args
+        assert call.args[0] == "global/status/operator"
+        assert call.kwargs.get("global_scope") is True
+
+    @pytest.mark.asyncio
+    async def test_hand_off_to_operator_survives_wake_failure(self):
+        """Regression: wake_agent failure must not prevent the task from
+        being queued. The operator picks it up on its next heartbeat."""
+        from src.agent.builtins.coordination_tool import hand_off
+
+        mc = _make_mesh_client(agent_id="scout")
+        mc.project_name = "growth"
+        mc.is_standalone = False
+        mc.list_agents.return_value = {
+            "operator": {"url": "http://operator:8400", "scope": "global"},
+        }
+        mc.wake_agent.side_effect = Exception("wake failed: 403")
+
+        result = await hand_off(
+            to="operator", summary="follow up", mesh_client=mc,
+        )
+
+        # Handoff still succeeds — task is queued, wake is best-effort.
+        assert result["handed_off"] is True
+        assert result["task_key"].startswith("global/tasks/operator/")
+        # The task write happened before the wake attempt.
+        mc.write_blackboard.assert_awaited()
+
+    @pytest.mark.asyncio
+    async def test_operator_cannot_complete_other_global_inbox(self):
+        """Defense: operator can only complete its own global tasks."""
+        from src.agent.builtins.coordination_tool import complete_task
+
+        mc = _make_mesh_client(agent_id="operator", standalone=True)
+
+        result = await complete_task(
+            task_key="global/tasks/someone-else/ho_1",
+            mesh_client=mc,
+        )
+
+        assert "error" in result
+        assert "your own tasks" in result["error"]
+
+    @pytest.mark.asyncio
+    async def test_worker_to_project_peer_unaffected(self):
+        """Regression: cross-project worker → worker handoff still uses project scoping."""
+        from src.agent.builtins.coordination_tool import hand_off
+
+        mc = _make_mesh_client(agent_id="scout")
+        mc.project_name = "growth"
+        mc.is_standalone = False
+        mc.list_agents.return_value = {
+            "analyst": {"url": "http://analyst:8400", "project": "research"},
+        }
+
+        result = await hand_off(
+            to="analyst",
+            summary="check this",
+            mesh_client=mc,
+        )
+
+        assert result["handed_off"] is True
+        assert result["task_key"].startswith("tasks/analyst/")
+        # write_project should be the target's project, NOT global
+        write_call = mc.write_blackboard.call_args
+        assert write_call.kwargs.get("project") == "research"
+        assert write_call.kwargs.get("global_scope") is False

--- a/tests/test_mesh.py
+++ b/tests/test_mesh.py
@@ -1147,3 +1147,109 @@ async def test_list_agents_endpoint_includes_capabilities(tmp_path):
         bb.close()
         costs.close()
         traces.close()
+
+
+@pytest.mark.asyncio
+async def test_list_agents_project_scope_always_includes_operator(tmp_path):
+    """`/mesh/agents?project=X` must include the operator entry alongside
+    project members. The operator is fleet-global by design — project agents
+    have to discover it to hand off back. Without this, project_agent →
+    operator handoff fails at the lookup with 'Agent operator not found'.
+
+    Also verifies the operator entry carries scope=global so coordination
+    tools can route the handoff to the global namespace.
+    """
+    from unittest.mock import patch
+
+    import yaml
+    from httpx import ASGITransport, AsyncClient
+
+    from src.host.costs import CostTracker
+    from src.host.server import create_mesh_app
+    from src.host.traces import TraceStore
+
+    # Minimal project on disk with one member.
+    projects_dir = tmp_path / "projects"
+    proj_dir = projects_dir / "growth"
+    proj_dir.mkdir(parents=True)
+    (proj_dir / "metadata.yaml").write_text(
+        yaml.dump({"name": "growth", "members": ["scout"], "created_at": "2026-05-02T00:00:00+00:00"}),
+    )
+
+    bb = Blackboard(db_path=str(tmp_path / "bb.db"))
+    pubsub = PubSub()
+    perms = PermissionMatrix()
+    router = MessageRouter(perms, {})
+    costs = CostTracker(str(tmp_path / "costs.db"))
+    traces = TraceStore(str(tmp_path / "traces.db"))
+
+    router.register_agent("scout", "http://scout:8400", ["recon"])
+    router.register_agent("operator", "http://operator:8400", [])
+    router.register_agent("analyst", "http://analyst:8400", [])  # other project
+
+    app = create_mesh_app(
+        blackboard=bb, pubsub=pubsub, router=router, permissions=perms,
+        cost_tracker=costs, trace_store=traces,
+    )
+
+    try:
+        with patch("src.cli.config.PROJECTS_DIR", projects_dir):
+            async with AsyncClient(
+                transport=ASGITransport(app=app), base_url="http://test",
+            ) as client:
+                resp = await client.get("/mesh/agents", params={"project": "growth"})
+        assert resp.status_code == 200
+        data = resp.json()
+        # Project member is present.
+        assert "scout" in data
+        # Operator is always visible to project agents.
+        assert "operator" in data
+        assert data["operator"].get("scope") == "global"
+        # Non-member, non-operator agents are still scoped out.
+        assert "analyst" not in data
+    finally:
+        bb.close()
+        costs.close()
+        traces.close()
+
+
+@pytest.mark.asyncio
+async def test_list_agents_unscoped_marks_operator_global(tmp_path):
+    """The fleet-wide /mesh/agents response must also tag the operator with
+    scope=global so dashboards and the operator's own list_agents call can
+    distinguish it from per-project agents."""
+    from httpx import ASGITransport, AsyncClient
+
+    from src.host.costs import CostTracker
+    from src.host.server import create_mesh_app
+    from src.host.traces import TraceStore
+
+    bb = Blackboard(db_path=str(tmp_path / "bb.db"))
+    pubsub = PubSub()
+    perms = PermissionMatrix()
+    router = MessageRouter(perms, {})
+    costs = CostTracker(str(tmp_path / "costs.db"))
+    traces = TraceStore(str(tmp_path / "traces.db"))
+
+    router.register_agent("operator", "http://operator:8400", [])
+    router.register_agent("scout", "http://scout:8400", [])
+
+    app = create_mesh_app(
+        blackboard=bb, pubsub=pubsub, router=router, permissions=perms,
+        cost_tracker=costs, trace_store=traces,
+    )
+
+    try:
+        async with AsyncClient(
+            transport=ASGITransport(app=app), base_url="http://test",
+        ) as client:
+            resp = await client.get("/mesh/agents")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["operator"].get("scope") == "global"
+        # Non-operator agents do NOT carry the marker.
+        assert "scope" not in data["scout"]
+    finally:
+        bb.close()
+        costs.close()
+        traces.close()

--- a/tests/test_permissions.py
+++ b/tests/test_permissions.py
@@ -633,3 +633,22 @@ class TestOperatorInboxGlobalCarveOut:
         assert m.can_write_blackboard("scout", "global/output/analyst/ho_1") is False
         # And NOT arbitrary global keys
         assert m.can_write_blackboard("scout", "global/secrets/x") is False
+
+    def test_only_operator_reads_operator_global_handoff_data(self, tmp_path):
+        """Wildcard reads do not expose the operator's global inbox/output."""
+        cfg = {
+            "permissions": {
+                "scout": {"blackboard_read": ["*"]},
+                "operator": {"blackboard_read": ["*"]},
+            },
+        }
+        path = tmp_path / "permissions.json"
+        path.write_text(json.dumps(cfg))
+        m = PermissionMatrix(config_path=str(path))
+
+        assert m.can_read_blackboard("operator", "global/tasks/operator/ho_1") is True
+        assert m.can_read_blackboard("operator", "global/output/scout/ho_1") is True
+        assert m.can_read_blackboard("scout", "global/tasks/operator/ho_1") is False
+        assert m.can_read_blackboard("scout", "global/output/analyst/ho_1") is False
+        # Sender may inspect only its own submitted output.
+        assert m.can_read_blackboard("scout", "global/output/scout/ho_1") is True

--- a/tests/test_permissions.py
+++ b/tests/test_permissions.py
@@ -603,3 +603,33 @@ class TestRequestBrowserLoginInKnownActions:
     def test_present(self):
         from src.host.permissions import KNOWN_BROWSER_ACTIONS
         assert "request_browser_login" in KNOWN_BROWSER_ACTIONS
+
+
+# ── Task 0 hotfix: operator inbox carve-out under global/ ─────────────
+
+
+@pytest.fixture()
+def operator_inbox_matrix(tmp_path):
+    """PermissionMatrix where 'scout' has only narrow project-scoped writes."""
+    cfg = {
+        "permissions": {
+            "scout": {
+                "blackboard_write": ["projects/growth/*"],
+            },
+        },
+    }
+    path = tmp_path / "permissions.json"
+    path.write_text(json.dumps(cfg))
+    return PermissionMatrix(config_path=str(path))
+
+
+class TestOperatorInboxGlobalCarveOut:
+    def test_any_agent_can_write_operator_inbox(self, operator_inbox_matrix):
+        """Operator inbox under global/ is a public mailbox."""
+        m = operator_inbox_matrix
+        assert m.can_write_blackboard("scout", "global/tasks/operator/ho_1") is True
+        assert m.can_write_blackboard("scout", "global/output/scout/ho_1") is True
+        # But NOT another agent's output namespace
+        assert m.can_write_blackboard("scout", "global/output/analyst/ho_1") is False
+        # And NOT arbitrary global keys
+        assert m.can_write_blackboard("scout", "global/secrets/x") is False


### PR DESCRIPTION
## Summary

Fixes the broken project-agent → operator handoff path. Three independent bugs combined to make this flow non-functional in the current release:

1. `/mesh/agents` filtered by project, so the operator (standalone, never a project member) was invisible to project agents. `hand_off("operator", ...)` failed at lookup with "Agent 'operator' not found".
2. Even if discovery succeeded, `hand_off` wrote tasks under the sender's project scope (`projects/X/tasks/operator/{id}`), but the operator (no `PROJECT_NAME`) listed `tasks/operator/` unscoped — keys never matched.
3. `check_inbox` short-circuited with `_STANDALONE_ERROR` whenever `mesh_client.is_standalone == True`. The operator is always standalone, so its inbox was permanently unreadable. The operator's own heartbeat playbook (`src/shared/operator_playbooks.py:88, 219`) calls `check_inbox()` to surface completed work — a no-op for the entire current release.

## Approach

Introduce a fleet-global namespace for operator-bound traffic and let the operator read it:

- **`/mesh/agents`** now always includes the operator (with `scope: "global"`) regardless of the `project` filter.
- **`hand_off`** writes to `global/tasks/operator/{id}` and `global/output/{sender}/{id}` when the target is the operator. Triggers on both the literal `"operator"` name and the registry `scope: "global"` hint (defense-in-depth, future-proof).
- **`check_inbox`** lets `agent_id == "operator"` past the standalone gate and reads from `global/tasks/operator/*`.
- **`complete_task`** accepts `global/tasks/operator/*` keys for the operator and propagates `global_scope` on read/delete.
- **`update_status`** writes to `global/status/operator` for the operator (was also blocked by the standalone gate, also in the operator's tool allowlist).
- **`mesh_client`** gains a `global_scope` keyword on `read/write/list/delete_blackboard` to send the key as-is, bypassing project scoping.
- **Permission carve-out**: any registered agent can write the operator inbox; only the writing agent can place output under their own prefix; reads are unchanged (only the operator's existing `blackboard_read=["*"]` reaches the global namespace).

## Test plan

- [x] `pytest tests/test_coordination.py tests/test_permissions.py tests/test_mesh.py -x -v` — 158 passed
- [x] Full non-E2E suite — 4924 passed, 44 skipped, 0 failures
- [x] Worker → operator writes to `global/...` with `global_scope=True` and `project=None`
- [x] Operator's `check_inbox` lists `global/tasks/operator/` with `global_scope=True`
- [x] Operator completes its own global task and cleans up `global/output/{sender}/{id}`
- [x] Non-operator standalone agents still get `_STANDALONE_ERROR` (regression)
- [x] Cross-project worker → worker handoff still uses project scoping (regression)
- [x] Registry scope hint triggers global writes for hypothetical future global agents
- [x] Roster lookup failure still routes operator handoff correctly
- [x] Operator `update_status` writes `global/status/operator`
- [x] Wake failure does not block handoff (task remains queued for next heartbeat)
- [x] Server-level: `/mesh/agents?project=X` includes operator with `scope: "global"`; non-operator agents have no `scope` field

## Notes

- Legacy in-flight tasks at `projects/X/tasks/operator/...` from the broken pre-fix flow expire via the existing 24h TTL with no impact (those tasks were never delivered anyway).
- This is Task 0 from `docs/plans/2026-05-02-operator-orchestration-roadmap.md`. Tier 1 continues with characterization tests (Task 1) and origin-as-authorization-input (Task 2).