### PR TITLE
test(characterization): pin Tier 1 baselines and capture-to-tighten gates

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -86,4 +86,9 @@ markers = [
     # playwright && playwright install firefox``). CI honours the same
     # skipif and does NOT install playwright.
     "browser: real-browser test requiring playwright (CI does not run)",
+    # Tests pinning behavior that a later task will deliberately change.
+    # Each marked test asserts today's accidental or over-broad behavior so
+    # future tasks can locate them by filter (``pytest -m characterization``)
+    # and flip or delete them in lockstep with the production change.
+    "characterization: tests pinning behavior to be changed in a later task",
 ]

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -2121,6 +2121,113 @@ def test_mesh_wake_invalid_origin_header_ignored(tmp_path):
         bb.close()
 
 
+# ── Task 1 (characterization): worker → operator wake is permitted ────
+
+
+@pytest.mark.characterization
+def test_project_worker_can_wake_operator_today(tmp_path):
+    # CAPTURE-TO-TIGHTEN — Task 2/4 will block worker → operator wakes;
+    # tasks-records polling replaces direct wake. After Task 2 (origin as
+    # authz) and Task 4 (operator authentication & registration), workers
+    # should signal completion via blackboard task records and the
+    # operator polls them, rather than waking the operator synchronously.
+    # When those tasks land: flip this to assert 403 (or whatever the
+    # gate becomes), and replace it with a positive test asserting the
+    # task-record polling path works for the same hand-off scenario.
+    """Today ``/mesh/wake?target=operator`` is allowed for any caller
+    whose ``can_message`` allowlist permits the operator. A project
+    worker with ``can_message=["*"]`` therefore can wake the operator
+    directly. This pins the un-gated direct-wake path that Task 2/4 will
+    remove in favour of task-record polling.
+    """
+    import asyncio
+    import threading
+    import time
+
+    from fastapi.testclient import TestClient
+
+    from src.host.mesh import Blackboard, MessageRouter, PubSub
+    from src.host.permissions import PermissionMatrix
+    from src.host.server import create_mesh_app
+    from src.shared.types import AgentPermissions
+
+    bb = Blackboard(db_path=str(tmp_path / "wake_op_bb.db"))
+    pubsub = PubSub()
+
+    # Project worker has ``can_message=["*"]`` — the only gate today.
+    perms = PermissionMatrix.__new__(PermissionMatrix)
+    perms.permissions = {
+        "scout": AgentPermissions(
+            agent_id="scout",
+            can_message=["*"],
+            blackboard_read=["projects/growth/*"],
+            blackboard_write=["projects/growth/*"],
+        ),
+        "operator": AgentPermissions(
+            agent_id="operator",
+            can_message=["*"],
+            blackboard_read=["*"],
+            blackboard_write=["*"],
+        ),
+    }
+
+    router = MessageRouter(permissions=perms, agent_registry={})
+    router.register_agent("scout", "http://scout:8400", role="scout")
+    router.register_agent("operator", "http://operator:8400", role="operator")
+
+    captured: list[dict] = []
+
+    class _FakeLane:
+        async def enqueue(self, agent, message, **kwargs):
+            captured.append({"agent": agent, "message": message, **kwargs})
+            return ""
+
+    lane_manager = _FakeLane()
+
+    loop = asyncio.new_event_loop()
+    ready = threading.Event()
+
+    def _run():
+        asyncio.set_event_loop(loop)
+        loop.call_soon(ready.set)
+        loop.run_forever()
+
+    t = threading.Thread(target=_run, daemon=True)
+    t.start()
+    ready.wait()
+
+    app = create_mesh_app(
+        bb, pubsub, router, perms,
+        lane_manager=lane_manager,
+        dispatch_loop=loop,
+    )
+    client = TestClient(app)
+
+    try:
+        # No auth tokens are configured on this app, so the route reads
+        # the caller from the X-Agent-ID header — pin the worker as the
+        # caller. This mirrors what a real bearer token would resolve to.
+        resp = client.post(
+            "/mesh/wake",
+            params={"target": "operator", "message": "task done"},
+            headers={"X-Agent-ID": "scout"},
+        )
+        # Pin: today this is permitted.
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        assert body.get("woken") is True
+
+        # The lane was driven — the operator received a wake-up.
+        deadline = time.monotonic() + 2.0
+        while not captured and time.monotonic() < deadline:
+            time.sleep(0.01)
+        assert captured, "operator was not woken via lane"
+        assert captured[0]["agent"] == "operator"
+    finally:
+        loop.call_soon_threadsafe(loop.stop)
+        bb.close()
+
+
 # ── Fix 4: RuntimeContext._handle_notify_origin routing ───────────
 
 

--- a/tests/test_mesh.py
+++ b/tests/test_mesh.py
@@ -1253,3 +1253,177 @@ async def test_list_agents_unscoped_marks_operator_global(tmp_path):
         bb.close()
         costs.close()
         traces.close()
+
+
+# ── Task 1 (characterization): /mesh/agents per-caller-type visibility ─
+
+
+@pytest.mark.asyncio
+async def test_list_agents_project_scope_excludes_other_project_members(tmp_path):
+    """When ``/mesh/agents?project=X`` is called, members of project Y must
+    NOT appear in the response. The endpoint reads members from the project
+    metadata on disk and only includes registered agents whose id is a
+    member, plus the operator (which is fleet-global). This pins the
+    project-isolation invariant for the response shape.
+    """
+    from unittest.mock import patch
+
+    import yaml
+    from httpx import ASGITransport, AsyncClient
+
+    from src.host.costs import CostTracker
+    from src.host.server import create_mesh_app
+    from src.host.traces import TraceStore
+
+    projects_dir = tmp_path / "projects"
+    # Project alpha has scout.
+    alpha_dir = projects_dir / "alpha"
+    alpha_dir.mkdir(parents=True)
+    (alpha_dir / "metadata.yaml").write_text(
+        yaml.dump({
+            "name": "alpha", "members": ["scout"],
+            "created_at": "2026-05-02T00:00:00+00:00",
+        }),
+    )
+    # Project beta has analyst.
+    beta_dir = projects_dir / "beta"
+    beta_dir.mkdir(parents=True)
+    (beta_dir / "metadata.yaml").write_text(
+        yaml.dump({
+            "name": "beta", "members": ["analyst"],
+            "created_at": "2026-05-02T00:00:00+00:00",
+        }),
+    )
+
+    bb = Blackboard(db_path=str(tmp_path / "bb.db"))
+    pubsub = PubSub()
+    perms = PermissionMatrix()
+    router = MessageRouter(perms, {})
+    costs = CostTracker(str(tmp_path / "costs.db"))
+    traces = TraceStore(str(tmp_path / "traces.db"))
+
+    router.register_agent("scout", "http://scout:8400", [])
+    router.register_agent("analyst", "http://analyst:8400", [])
+    router.register_agent("operator", "http://operator:8400", [])
+    # A standalone agent that is in NO project.
+    router.register_agent("loner", "http://loner:8400", [])
+
+    app = create_mesh_app(
+        blackboard=bb, pubsub=pubsub, router=router, permissions=perms,
+        cost_tracker=costs, trace_store=traces,
+    )
+
+    try:
+        with patch("src.cli.config.PROJECTS_DIR", projects_dir):
+            async with AsyncClient(
+                transport=ASGITransport(app=app), base_url="http://test",
+            ) as client:
+                resp = await client.get("/mesh/agents", params={"project": "alpha"})
+        assert resp.status_code == 200
+        data = resp.json()
+        # Project member present.
+        assert "scout" in data
+        # Operator is always visible.
+        assert "operator" in data
+        # Other project's member is NOT visible.
+        assert "analyst" not in data
+        # Standalone non-member is NOT visible.
+        assert "loner" not in data
+    finally:
+        bb.close()
+        costs.close()
+        traces.close()
+
+
+@pytest.mark.asyncio
+async def test_list_agents_internal_caller_sees_full_fleet(tmp_path):
+    """Internal callers (loopback / dashboard / mesh-internal) hitting
+    ``/mesh/agents`` with no project filter receive every registered
+    agent. This pins the unscoped path that dashboards rely on.
+    """
+    from httpx import ASGITransport, AsyncClient
+
+    from src.host.costs import CostTracker
+    from src.host.server import create_mesh_app
+    from src.host.traces import TraceStore
+
+    bb = Blackboard(db_path=str(tmp_path / "bb.db"))
+    pubsub = PubSub()
+    perms = PermissionMatrix()
+    router = MessageRouter(perms, {})
+    costs = CostTracker(str(tmp_path / "costs.db"))
+    traces = TraceStore(str(tmp_path / "traces.db"))
+
+    # Mixed fleet across projects + standalone.
+    router.register_agent("operator", "http://operator:8400", [])
+    router.register_agent("scout", "http://scout:8400", [])
+    router.register_agent("analyst", "http://analyst:8400", [])
+    router.register_agent("loner", "http://loner:8400", [])
+
+    app = create_mesh_app(
+        blackboard=bb, pubsub=pubsub, router=router, permissions=perms,
+        cost_tracker=costs, trace_store=traces,
+    )
+
+    try:
+        async with AsyncClient(
+            transport=ASGITransport(app=app), base_url="http://test",
+        ) as client:
+            resp = await client.get("/mesh/agents")
+        assert resp.status_code == 200
+        data = resp.json()
+        # Full fleet visible — every registered agent appears.
+        assert set(data.keys()) == {"operator", "scout", "analyst", "loner"}
+    finally:
+        bb.close()
+        costs.close()
+        traces.close()
+
+
+@pytest.mark.asyncio
+async def test_list_agents_unknown_project_returns_empty(tmp_path):
+    """``/mesh/agents?project=X`` for an unknown project name returns an
+    empty mapping — the endpoint logs a warning but does not 404. This
+    pins the 'silent empty' contract that callers (mesh_client) rely on
+    when an agent's project metadata is stale.
+    """
+    from unittest.mock import patch
+
+    from httpx import ASGITransport, AsyncClient
+
+    from src.host.costs import CostTracker
+    from src.host.server import create_mesh_app
+    from src.host.traces import TraceStore
+
+    projects_dir = tmp_path / "projects"
+    projects_dir.mkdir()  # exists but no projects inside
+
+    bb = Blackboard(db_path=str(tmp_path / "bb.db"))
+    pubsub = PubSub()
+    perms = PermissionMatrix()
+    router = MessageRouter(perms, {})
+    costs = CostTracker(str(tmp_path / "costs.db"))
+    traces = TraceStore(str(tmp_path / "traces.db"))
+
+    router.register_agent("operator", "http://operator:8400", [])
+    router.register_agent("scout", "http://scout:8400", [])
+
+    app = create_mesh_app(
+        blackboard=bb, pubsub=pubsub, router=router, permissions=perms,
+        cost_tracker=costs, trace_store=traces,
+    )
+
+    try:
+        with patch("src.cli.config.PROJECTS_DIR", projects_dir):
+            async with AsyncClient(
+                transport=ASGITransport(app=app), base_url="http://test",
+            ) as client:
+                resp = await client.get("/mesh/agents", params={"project": "ghost"})
+        assert resp.status_code == 200
+        # Empty body (no project members + no operator carve-out — the
+        # operator carve-out only fires on an existing project).
+        assert resp.json() == {}
+    finally:
+        bb.close()
+        costs.close()
+        traces.close()

--- a/tests/test_operator_create_agent.py
+++ b/tests/test_operator_create_agent.py
@@ -321,6 +321,120 @@ class TestCreateCustomAgent:
         assert resp.status_code == 200
         perms.reload.assert_called()
 
+    @pytest.mark.characterization
+    def test_default_capabilities_seed_full_coordination_protocol(
+        self, mesh_app, tmp_path,
+    ):
+        # CAPTURE-TO-TIGHTEN — this asserts today's broad bootstrap defaults.
+        # Task 3/5 should replace wildcard read plus browser/cron grants with
+        # explicit operator-managed capabilities and project-scoped visibility.
+        """Today operator-created agents get broad coordination defaults written
+        to ``permissions.json`` so their imminent ``/mesh/register`` call does
+        not fall through to deny-all. Specifically:
+
+          * ``blackboard_read``  ⊇ ``["*"]``
+          * ``blackboard_write`` ⊇ the five coordination namespaces
+          * ``can_publish``      ⊇ ``["*"]``
+          * ``can_subscribe``    ⊇ ``["*"]``
+          * ``can_use_browser``  is True
+          * ``can_manage_cron``  is True
+          * ``allowed_apis``     ⊇ ``{"llm", "image_gen"}``
+
+        This protects the historical 3b90a0a regression, but the breadth is
+        not a permanent security invariant. Future least-privilege work should
+        flip this test while preserving a narrower "agent can coordinate"
+        bootstrap path.
+        """
+        import json as _json
+
+        client = mesh_app["client"]
+        resp = client.post(
+            "/mesh/agents/create",
+            json={
+                "agent_id": "operator",
+                "name": "freshie",
+                "role": "fresh agent",
+                "model": "openai/gpt-4o-mini",
+                "instructions": "do things",
+            },
+        )
+        assert resp.status_code == 200, resp.text
+
+        # Inspect the on-disk permissions written by _add_agent_permissions.
+        perms_path = tmp_path / "config" / "permissions.json"
+        on_disk = _json.loads(perms_path.read_text())
+        agent_perms = on_disk["permissions"]["freshie"]
+
+        # Blackboard reads — wildcard so the agent can discover any topic.
+        assert "*" in agent_perms["blackboard_read"]
+
+        # Blackboard writes — five coordination namespaces.
+        write = set(agent_perms["blackboard_write"])
+        assert {
+            "tasks/*", "context/*", "status/*", "output/*", "artifacts/*",
+        }.issubset(write), f"missing namespaces from {write!r}"
+
+        # Pubsub.
+        assert "*" in agent_perms["can_publish"]
+        assert "*" in agent_perms["can_subscribe"]
+
+        # Browser + cron capability bits.
+        assert agent_perms["can_use_browser"] is True
+        assert agent_perms["can_manage_cron"] is True
+
+        # API surface — at minimum LLM (so the agent can run) + image_gen.
+        allowed_apis = set(agent_perms.get("allowed_apis", []))
+        assert {"llm", "image_gen"}.issubset(allowed_apis), \
+            f"expected llm + image_gen in {allowed_apis!r}"
+
+        # And the LIVE PermissionMatrix must agree once it's been reloaded
+        # — the in-memory object backs every mesh permission gate the
+        # newly-registered agent will hit. Without reload the agent
+        # registers and immediately gets deny-all.
+        perms = mesh_app["perms"]
+        perms.reload()
+        live = perms.get_permissions("freshie")
+        assert "*" in live.blackboard_read
+        assert "tasks/*" in live.blackboard_write
+        assert live.can_use_browser is True
+        assert live.can_manage_cron is True
+
+    def test_default_capabilities_omit_can_spawn(
+        self, mesh_app, tmp_path,
+    ):
+        """Pin: a newly-created agent does NOT inherit ``can_spawn`` —
+        only the operator (the one calling create) is allowed to create
+        agents. Without this, every operator-created agent could turn
+        around and create more agents itself, defeating the operator
+        gate. The current implementation writes the defaults dict via
+        ``_add_agent_permissions`` and that dict deliberately excludes
+        ``can_spawn`` so the field defaults to False on read.
+        """
+        import json as _json
+
+        client = mesh_app["client"]
+        resp = client.post(
+            "/mesh/agents/create",
+            json={
+                "agent_id": "operator", "name": "noprivs", "role": "fresh",
+                "model": "openai/gpt-4o-mini",
+            },
+        )
+        assert resp.status_code == 200, resp.text
+
+        perms_path = tmp_path / "config" / "permissions.json"
+        on_disk = _json.loads(perms_path.read_text())
+        agent_perms = on_disk["permissions"]["noprivs"]
+        # Field is omitted from the on-disk record (defaults to False at
+        # ``AgentPermissions`` construction time) — the agent has no
+        # spawn ability. We accept either: (a) key absent, or (b) key
+        # present but explicitly False.
+        assert agent_perms.get("can_spawn", False) is False
+
+        # And the live matrix agrees.
+        mesh_app["perms"].reload()
+        assert mesh_app["perms"].can_spawn("noprivs") is False
+
 
 class TestCreateCustomAgentMeshClient:
     """Tests for MeshClient.create_custom_agent."""

--- a/tests/test_permissions.py
+++ b/tests/test_permissions.py
@@ -652,3 +652,300 @@ class TestOperatorInboxGlobalCarveOut:
         assert m.can_read_blackboard("scout", "global/output/analyst/ho_1") is False
         # Sender may inspect only its own submitted output.
         assert m.can_read_blackboard("scout", "global/output/scout/ho_1") is True
+
+# ── Task 1 (characterization): can_spawn over-broad gate ──────────────
+#
+# Today ``can_spawn=True`` is one bit gating BOTH ephemeral-worker spawning
+# (subagent / cron / template apply) AND durable fleet operations (creating
+# named agents). Task 3 will introduce ``can_manage_fleet`` and split the
+# durable-fleet path off ``can_spawn``. The tests below pin three current
+# call sites:
+#
+#   * ``permissions.can_spawn`` at ``host/server.py:1531``  → ``POST /mesh/spawn``
+#   * ``permissions.can_spawn`` at ``host/server.py:1608``  → ``POST /mesh/fleet/apply``
+#   * ``permissions.can_spawn`` at ``host/server.py:1754``  → ``POST /mesh/agents/create``
+#
+# The first is ephemeral; the other two are durable fleet operations that
+# Task 3 wants to require ``can_manage_fleet`` for.
+
+class _SpawnRouteFixture:
+    """Helper that builds a mesh app with a permissive ``container_manager``
+    so the three ``can_spawn`` gates can be exercised end-to-end. We bypass
+    the actual container start by pre-creating an in-memory ``MagicMock``."""
+
+    @staticmethod
+    def build(tmp_path, monkeypatch, *, can_spawn: bool):
+        from unittest.mock import AsyncMock, MagicMock
+
+        from fastapi.testclient import TestClient
+
+        from src.host.mesh import Blackboard, MessageRouter, PubSub
+        from src.host.permissions import PermissionMatrix
+        from src.host.server import create_mesh_app
+
+        cfg_dir = tmp_path / "config"
+        cfg_dir.mkdir()
+        skills_dir = tmp_path / "skills"
+        skills_dir.mkdir()
+        templates_dir = tmp_path / "templates"
+        templates_dir.mkdir()
+        # Minimal one-agent template for /mesh/fleet/apply.
+        import yaml
+        (templates_dir / "tinybot.yaml").write_text(yaml.dump({
+            "name": "tinybot",
+            "description": "single-agent template for tests",
+            "agents": {
+                "tinybot": {
+                    "role": "tester",
+                    "model": "openai/gpt-4o-mini",
+                    "instructions": "be tiny",
+                },
+            },
+        }))
+
+        monkeypatch.setattr("src.cli.config.PROJECT_ROOT", tmp_path)
+        monkeypatch.setattr("src.cli.config.AGENTS_FILE", cfg_dir / "agents.yaml")
+        monkeypatch.setattr("src.cli.config.PERMISSIONS_FILE",
+                            cfg_dir / "permissions.json")
+        monkeypatch.setattr("src.cli.config.CONFIG_FILE", cfg_dir / "mesh.yaml")
+        monkeypatch.setattr("src.cli.config.TEMPLATES_DIR", templates_dir)
+
+        # Seed the permissions file so reload() preserves our caller.
+        cfg_dir_perms = cfg_dir / "permissions.json"
+        import json as _json
+        cfg_dir_perms.write_text(_json.dumps({
+            "permissions": {
+                "worker": {
+                    "can_spawn": can_spawn,
+                    "can_message": ["mesh"],
+                    "blackboard_read": [],
+                    "blackboard_write": [],
+                },
+            },
+        }))
+
+        # Real PermissionMatrix loaded from the seeded file so reload()
+        # in the create route picks up the on-disk write.
+        perms = PermissionMatrix(config_path=str(cfg_dir_perms))
+        # Sanity: the seeded entry was loaded.
+        assert "worker" in perms.permissions
+
+        bb = Blackboard(db_path=str(tmp_path / "bb.db"))
+        pubsub = PubSub()
+        router = MessageRouter(perms, {})
+
+        # Fake container manager — accepts spawn / start, returns a URL.
+        cm = MagicMock()
+        cm.project_root = tmp_path
+        cm.spawn_agent.return_value = "http://localhost:9100"
+        cm.start_agent.return_value = "http://localhost:9101"
+        cm.wait_for_agent = AsyncMock(return_value=True)
+        cm.agents = {}
+
+        app = create_mesh_app(
+            bb, pubsub, router, perms,
+            container_manager=cm,
+        )
+        client = TestClient(app)
+        return {
+            "client": client,
+            "perms": perms,
+            "router": router,
+            "container_manager": cm,
+            "bb": bb,
+        }
+
+
+def test_can_spawn_today_gates_mesh_spawn_endpoint(tmp_path, monkeypatch):
+    """Pin (positive): an agent with ``can_spawn=True`` can call
+    ``POST /mesh/spawn``. This is the *legitimate* ephemeral-worker path
+    that should keep working when Task 3 splits ``can_manage_fleet``
+    out — ``can_spawn`` retains ephemeral semantics. Acts as the
+    success-baseline alongside the two capture-to-tighten tests below.
+    No characterization marker: this is a forever-pin.
+    """
+    fx = _SpawnRouteFixture.build(tmp_path, monkeypatch, can_spawn=True)
+    client = fx["client"]
+    resp = client.post(
+        "/mesh/spawn",
+        json={"spawned_by": "worker", "role": "subhelper", "ttl": 120},
+        headers={"X-Agent-ID": "worker"},
+    )
+    # Should NOT be the 403 from the can_spawn gate.
+    assert resp.status_code != 403, resp.text
+    # The fake container manager returns success, so the route should 200.
+    assert resp.status_code == 200, resp.text
+    fx["bb"].close()
+
+
+@pytest.mark.characterization
+def test_can_spawn_today_also_gates_fleet_apply_endpoint(tmp_path, monkeypatch):
+    # CAPTURE-TO-TIGHTEN — this test asserts today's over-broad behavior.
+    # After Task 3 (split can_spawn), this endpoint requires can_manage_fleet.
+    # When Task 3 lands: flip the assertion or delete this test, and add a
+    # negative test in test_permissions.py.
+    """A worker with ``can_spawn=True`` and otherwise-narrow permissions
+    can today reach ``POST /mesh/fleet/apply`` — applying a fleet template
+    is treated as just another spawn. After Task 3 it should require the
+    new ``can_manage_fleet`` capability instead.
+    """
+    fx = _SpawnRouteFixture.build(tmp_path, monkeypatch, can_spawn=True)
+    client = fx["client"]
+    # Auth is not configured on the test app, so the route reads
+    # ``data["spawned_by"]`` directly. We pass our worker.
+    resp = client.post(
+        "/mesh/fleet/apply",
+        json={"spawned_by": "worker", "template": "tinybot"},
+        headers={"X-Agent-ID": "worker"},
+    )
+    # Pin: today's behavior — succeeds because can_spawn is enough.
+    assert resp.status_code != 403, resp.text
+    # Either 200 (succeeded) or 5xx from a downstream stub failing — what
+    # we are pinning is "not 403 from the can_spawn gate."
+    assert resp.status_code < 500, resp.text
+    fx["bb"].close()
+
+
+@pytest.mark.characterization
+def test_can_spawn_today_also_gates_agents_create_endpoint(tmp_path, monkeypatch):
+    # CAPTURE-TO-TIGHTEN — this test asserts today's over-broad behavior.
+    # After Task 3 (split can_spawn), this endpoint requires can_manage_fleet.
+    # When Task 3 lands: flip the assertion or delete this test, and add a
+    # negative test in test_permissions.py.
+    """A worker with ``can_spawn=True`` and otherwise-narrow permissions
+    can today reach ``POST /mesh/agents/create`` — creating a durable
+    custom agent is treated as just another spawn. After Task 3 it
+    should require the new ``can_manage_fleet`` capability instead.
+    """
+    fx = _SpawnRouteFixture.build(tmp_path, monkeypatch, can_spawn=True)
+    client = fx["client"]
+    resp = client.post(
+        "/mesh/agents/create",
+        json={
+            "agent_id": "worker",
+            "name": "freshbot",
+            "role": "tester",
+            "model": "openai/gpt-4o-mini",
+        },
+        headers={"X-Agent-ID": "worker"},
+    )
+    # Pin: today's behavior — succeeds because can_spawn is enough.
+    assert resp.status_code != 403, resp.text
+    # We don't lock to 200 — the downstream container manager is mocked
+    # and may return a 200 or a 500 depending on its internals; the key
+    # invariant here is we did NOT get the 403 from the can_spawn gate.
+    fx["bb"].close()
+
+
+# ── Task 1 (characterization): wildcard blackboard ACL survives project moves ─
+
+
+@pytest.mark.characterization
+def test_wildcard_blackboard_acl_survives_project_add(tmp_path, monkeypatch):
+    # CAPTURE-TO-TIGHTEN — this test asserts today's over-broad behavior.
+    # After Task 5 (project scope warn → enforce), an agent with a wildcard
+    # ACL who is added to a project should have the wildcard narrowed (or
+    # at least denied at the read/write gate when the key is outside the
+    # project namespace). When Task 5 lands: flip the assertion to verify
+    # the wildcard is removed / superseded, or delete this test and replace
+    # it with a positive test asserting "added agent can NOT read other
+    # projects' keys".
+    """``_add_project_blackboard_permissions`` is purely additive: it
+    appends ``projects/{name}/*`` to the agent's existing patterns and
+    never touches a pre-existing ``*``. The wildcard therefore survives
+    the move and the agent retains fleet-wide blackboard access — Task 5
+    will make this scope warn-then-enforce.
+    """
+    from src.cli.config import _add_project_blackboard_permissions
+
+    perms_file = tmp_path / "permissions.json"
+    perms_file.write_text(json.dumps({
+        "permissions": {
+            "rover": {
+                "blackboard_read": ["*"],
+                "blackboard_write": ["*"],
+            },
+        },
+    }))
+    monkeypatch.setattr("src.cli.config.PERMISSIONS_FILE", perms_file)
+
+    _add_project_blackboard_permissions("rover", "alpha")
+
+    perms = json.loads(perms_file.read_text())
+    read = perms["permissions"]["rover"]["blackboard_read"]
+    write = perms["permissions"]["rover"]["blackboard_write"]
+    # Wildcard survives — Task 5 should narrow.
+    assert "*" in read
+    assert "*" in write
+    # Project pattern was appended next to the wildcard.
+    assert "projects/alpha/*" in read
+    assert "projects/alpha/*" in write
+
+
+@pytest.mark.characterization
+def test_wildcard_blackboard_acl_survives_project_remove(tmp_path, monkeypatch):
+    # CAPTURE-TO-TIGHTEN — this test asserts today's over-broad behavior.
+    # After Task 5 (project scope warn → enforce), removing an agent from
+    # a project should leave it standalone, not still wildcarded. When
+    # Task 5 lands: flip the assertion to verify the wildcard was removed
+    # at project-leave time, or delete this test and add a negative test
+    # in this file asserting the agent can no longer read arbitrary keys.
+    """``_remove_project_blackboard_permissions`` only strips the project
+    pattern — a pre-existing ``*`` survives. Combined with the add-side
+    behavior above, this means an agent that ever had ``*`` retains
+    fleet-wide access through any number of project moves.
+    """
+    from src.cli.config import _remove_project_blackboard_permissions
+
+    perms_file = tmp_path / "permissions.json"
+    perms_file.write_text(json.dumps({
+        "permissions": {
+            "rover": {
+                # Both wildcard and project pattern present (the add-side
+                # state from the previous test).
+                "blackboard_read": ["*", "projects/alpha/*"],
+                "blackboard_write": ["*", "projects/alpha/*"],
+            },
+        },
+    }))
+    monkeypatch.setattr("src.cli.config.PERMISSIONS_FILE", perms_file)
+
+    _remove_project_blackboard_permissions("rover", "alpha")
+
+    perms = json.loads(perms_file.read_text())
+    read = perms["permissions"]["rover"]["blackboard_read"]
+    write = perms["permissions"]["rover"]["blackboard_write"]
+    # Project pattern was removed.
+    assert "projects/alpha/*" not in read
+    assert "projects/alpha/*" not in write
+    # But the wildcard survives — Task 5 should narrow.
+    assert "*" in read
+    assert "*" in write
+
+
+@pytest.mark.characterization
+def test_wildcard_blackboard_acl_grants_arbitrary_keys_after_project_remove(tmp_path):
+    # CAPTURE-TO-TIGHTEN — this test asserts today's over-broad behavior.
+    # After Task 5 (project scope warn → enforce), an agent that has been
+    # removed from project alpha should NOT be able to read keys from
+    # project beta. When Task 5 lands: flip these assertions to ``False``
+    # for cross-project keys, or delete this test in favour of a
+    # cross-project-isolation test in this file.
+    """End-to-end check that the surviving wildcard from the two tests
+    above actually grants live access via ``PermissionMatrix``: a
+    standalone-by-membership agent can still read another project's keys.
+    """
+    perms_file = tmp_path / "permissions.json"
+    perms_file.write_text(json.dumps({
+        "permissions": {
+            "rover": {
+                "blackboard_read": ["*"],
+                "blackboard_write": ["*"],
+            },
+        },
+    }))
+    pm = PermissionMatrix(config_path=str(perms_file))
+    # Wildcard reach across namespaces is what Task 5 will enforce away.
+    assert pm.can_read_blackboard("rover", "projects/alpha/secret")
+    assert pm.can_read_blackboard("rover", "projects/beta/secret")
+    assert pm.can_write_blackboard("rover", "projects/beta/note")

--- a/tests/test_projects.py
+++ b/tests/test_projects.py
@@ -480,6 +480,38 @@ class TestBlackboardPermissions:
         assert read == ["projects/marketing/*"]
         assert write == ["projects/marketing/*"]
 
+    def test_add_permissions_appends_alongside_existing_patterns(self, tmp_path):
+        """``_add_project_blackboard_permissions`` appends the project
+        pattern; pre-existing narrower patterns survive. Pin: the helper
+        is additive, never a full replacement of the agent's existing
+        ACL. Other tests rely on this when an agent is moved between
+        projects (the ``_add_agent_to_project`` move sequence calls
+        remove-then-add, so the appended pattern is the only project
+        pattern that ever co-exists with non-project patterns)."""
+        perms_file = tmp_path / "permissions.json"
+        perms_file.write_text(json.dumps({
+            "permissions": {
+                "bot": {
+                    "blackboard_read": ["context/global", "tasks/bot/*"],
+                    "blackboard_write": ["output/bot/*"],
+                },
+            },
+        }))
+
+        with patch("src.cli.config.PERMISSIONS_FILE", perms_file):
+            _add_project_blackboard_permissions("bot", "marketing")
+
+        perms = json.loads(perms_file.read_text())
+        read = perms["permissions"]["bot"]["blackboard_read"]
+        write = perms["permissions"]["bot"]["blackboard_write"]
+        # Existing patterns survived.
+        assert "context/global" in read
+        assert "tasks/bot/*" in read
+        assert "output/bot/*" in write
+        # Project pattern was appended.
+        assert "projects/marketing/*" in read
+        assert "projects/marketing/*" in write
+
     def test_remove_permissions(self, tmp_path):
         """Removing project permissions clears ALL blackboard access."""
         perms_file = tmp_path / "permissions.json"
@@ -498,6 +530,44 @@ class TestBlackboardPermissions:
         perms = json.loads(perms_file.read_text())
         assert perms["permissions"]["bot"]["blackboard_read"] == []
         assert perms["permissions"]["bot"]["blackboard_write"] == []
+
+    def test_remove_permissions_only_strips_target_project(self, tmp_path):
+        """``_remove_project_blackboard_permissions`` is targeted: it strips
+        the named project's pattern only. Other patterns (including other
+        projects' patterns and non-project patterns like ``context/global``)
+        survive. Pin: leaving project A does not nuke an agent's access
+        to project B or to fleet-wide / per-agent patterns."""
+        perms_file = tmp_path / "permissions.json"
+        perms_file.write_text(json.dumps({
+            "permissions": {
+                "bot": {
+                    "blackboard_read": [
+                        "context/global",
+                        "projects/marketing/*",
+                        "projects/sales/*",
+                    ],
+                    "blackboard_write": [
+                        "output/bot/*",
+                        "projects/marketing/*",
+                    ],
+                },
+            },
+        }))
+
+        with patch("src.cli.config.PERMISSIONS_FILE", perms_file):
+            _remove_project_blackboard_permissions("bot", "marketing")
+
+        perms = json.loads(perms_file.read_text())
+        read = perms["permissions"]["bot"]["blackboard_read"]
+        write = perms["permissions"]["bot"]["blackboard_write"]
+        # Marketing is gone.
+        assert "projects/marketing/*" not in read
+        assert "projects/marketing/*" not in write
+        # Sales survives (other project).
+        assert "projects/sales/*" in read
+        # Non-project patterns survive.
+        assert "context/global" in read
+        assert "output/bot/*" in write
 
 
 class TestLoadConfigWithProjects:


### PR DESCRIPTION
## Summary

Implements **Task 1** from `docs/plans/2026-05-02-operator-orchestration-roadmap.md`. Lays the characterization layer that future Tier 2-5 work depends on: pin tests for today's intended behavior, capture-to-tighten tests for today's accidental or over-broad behavior. Each capture is marked `@pytest.mark.characterization` and carries a `CAPTURE-TO-TIGHTEN` comment block naming the future task and the expected flip.

**Branch base:** `fix/operator-handoff-hotfix` (PR #821 — Task 0). Tests assume Task 0's coordination changes are present. Will rebase onto `main` after #821 merges.

## What's pinned

- `/mesh/agents` project-scoped response excludes other-project members and standalone non-members; unknown project returns `{}`.
- `/mesh/agents` unscoped response returns the full fleet.
- `_add_project_blackboard_permissions` is additive; `_remove_project_blackboard_permissions` strips only the named project (sibling and non-project patterns survive).
- Operator-created agents seed the full coordination ACL (regression of #812 / commit 3b90a0a) and explicitly do NOT inherit `can_spawn`.

## What's marked capture-to-tighten

| Test | Future task | Expected flip |
|---|---|---|
| `can_spawn` gates `/mesh/fleet/apply` | Task 3 | will require `can_manage_fleet` |
| `can_spawn` gates `/mesh/agents/create` | Task 3 | will require `can_manage_fleet` |
| Wildcard `*` blackboard ACL survives project add | Task 5 (enforce) | broad ACLs replaced on membership mutation |
| Wildcard `*` blackboard ACL survives project remove | Task 5 (enforce) | broad ACLs replaced on membership mutation |
| Wildcard ACL grants arbitrary keys after project remove | Task 5 (enforce) | scope-bounded reads only |
| `/mesh/wake?target=operator` permitted for any worker | Task 2 / Task 4 | worker → operator wake replaced with task-record polling |

## Surprise (worth noting for Task 5)

`/mesh/agents` does not filter by caller identity today — it filters only when `?project=` is set in the query string. A standalone agent's `MeshClient` call returns the full registry. Task 5's plan to "scope worker tokens to own project-visible agents only" is therefore *introducing* a new server-side filter, not enforcing an existing one. The pin tests in this PR document the current shape so the plan-vs-reality delta is visible.

## Test plan

- [x] `pytest tests/test_mesh.py tests/test_permissions.py tests/test_lanes.py tests/test_projects.py tests/test_operator_create_agent.py tests/test_coordination.py -x -v` — 255 passed
- [x] Full non-E2E suite — 4938 passed, 44 skipped
- [x] `pytest -m characterization --collect-only -q` — 6 tests collected (matches expected count)
- [x] No production source code changed (tests only)
- [x] `pyproject.toml` registers the new `characterization` marker

## Notes

- 8 pin tests + 6 capture-to-tighten tests = 14 new tests across 5 test files plus marker registration.
- Capture tests are deliberately easy to find by filter so each future task can flip them in lockstep with the production change.