### PR TITLE
feat(origin): introduce typed MessageOrigin model (Task 2a foundation)

### DIFF
--- a/src/agent/builtins/coordination_tool.py
+++ b/src/agent/builtins/coordination_tool.py
@@ -150,7 +150,10 @@ async def hand_off(
     if output_key:
         task_record["output_key"] = output_key
     if origin:
-        task_record["origin"] = origin
+        if hasattr(origin, "model_dump"):
+            task_record["origin"] = origin.model_dump()
+        elif isinstance(origin, dict):
+            task_record["origin"] = dict(origin)
 
     task_key = (
         f"global/tasks/{to}/{handoff_id}"

--- a/src/shared/trace.py
+++ b/src/shared/trace.py
@@ -5,9 +5,17 @@ gets a unique trace ID (``tr_<hex12>``) that propagates through all hops
 via the ``X-Trace-Id`` HTTP header and a ``contextvars.ContextVar``.
 
 ``current_origin`` travels alongside ``current_trace_id`` and propagates
-via the ``X-Origin`` HTTP header.  It carries ``{"channel": ..., "user": ...}``
-so lane workers can auto-forward task results back to the originating user
-on their messaging channel after a hand-off completes.
+via the ``X-Origin`` HTTP header.  It carries an authorization-bearing
+:class:`~src.shared.types.MessageOrigin` (``kind`` + ``channel`` + ``user``)
+so downstream gates can distinguish a human-initiated wake from an
+agent-initiated one.
+
+Backward-compat (Task 2a → 2b): until stamp sites are migrated, the
+contextvar may still hold a raw ``{"channel": ..., "user": ...}`` dict.
+The helpers in this module accept either shape; readers can use
+attribute access (``origin.channel``) on a typed origin or fall back to
+dict-style access (``origin.get("channel")``) which works on both via
+:class:`MessageOrigin`'s dict-compat shim.
 
 Separate module (not utils.py) to keep tracing concerns isolated and
 avoid import cycles.
@@ -19,6 +27,15 @@ import contextvars
 import json
 import uuid
 
+from src.shared.types import (
+    _MAX_ORIGIN_CHANNEL_LEN,
+    _MAX_ORIGIN_USER_LEN,
+    MessageOrigin,
+)
+from src.shared.utils import setup_logging
+
+logger = setup_logging("shared.trace")
+
 TRACE_HEADER = "X-Trace-Id"
 ORIGIN_HEADER = "X-Origin"
 
@@ -26,9 +43,13 @@ current_trace_id: contextvars.ContextVar[str | None] = contextvars.ContextVar(
     "current_trace_id", default=None,
 )
 
-current_origin: contextvars.ContextVar[dict[str, str] | None] = contextvars.ContextVar(
-    "current_origin", default=None,
-)
+# Accepts either a typed :class:`MessageOrigin` (preferred) or a raw
+# ``{"channel": ..., "user": ...}`` dict (legacy stamp sites being
+# migrated in Task 2b). Readers should use attribute access on the
+# typed model or ``.get()`` (which works on both shapes).
+current_origin: contextvars.ContextVar[
+    "MessageOrigin | dict[str, str] | None"
+] = contextvars.ContextVar("current_origin", default=None)
 
 
 def new_trace_id() -> str:
@@ -42,43 +63,68 @@ def trace_headers() -> dict[str, str]:
     return {TRACE_HEADER: tid} if tid else {}
 
 
-def origin_header(origin: dict[str, str] | None) -> dict[str, str]:
-    """Serialize an origin dict to an ``X-Origin`` header dict.
+def origin_header(
+    origin: "MessageOrigin | dict[str, str] | None",
+) -> dict[str, str]:
+    """Serialize an origin to an ``X-Origin`` header dict.
 
-    Returns ``{}`` when origin is empty so it can be spread into a headers
-    dict unconditionally.
+    Accepts either a typed :class:`MessageOrigin` or a legacy
+    ``{"channel": ..., "user": ...}`` dict. Returns ``{}`` when origin
+    is empty so it can be spread into a headers dict unconditionally.
+
+    Dict input without a ``kind`` field is upgraded to ``kind="agent"``
+    (least-trusted) before serialization so the wire format always
+    carries an explicit kind for the next hop.
     """
     if not origin:
         return {}
-    return {ORIGIN_HEADER: json.dumps(origin, separators=(",", ":"))}
+    if isinstance(origin, MessageOrigin):
+        return {ORIGIN_HEADER: origin.to_header_value()}
+    # Legacy dict — emit with ``kind="agent"`` if not provided.
+    if not isinstance(origin, dict):
+        return {}
+    # Task 2a deprecation breadcrumb: stamp sites still emitting raw
+    # dicts will be migrated in Task 2b. Logging at debug keeps the
+    # signal available for the migration audit without spamming logs.
+    logger.debug(
+        "origin_header received legacy dict (kind=%s); migrate stamp site to MessageOrigin",
+        origin.get("kind", "agent"),
+    )
+    payload = {
+        "kind": origin.get("kind", "agent"),
+        "channel": origin.get("channel", ""),
+        "user": origin.get("user", ""),
+    }
+    return {ORIGIN_HEADER: json.dumps(payload, separators=(",", ":"))}
 
 
-_MAX_ORIGIN_CHANNEL_LEN = 32
-_MAX_ORIGIN_USER_LEN = 128
+def parse_origin_header(raw: str | None) -> "MessageOrigin | None":
+    """Parse an X-Origin header.
 
+    Returns a typed :class:`MessageOrigin` on success, ``None`` on any
+    error or invalid shape (never a partial model). Request headers are
+    parsed as untrusted by default: any caller-supplied kind is downgraded
+    to ``kind="agent"`` so downstream auth gates cannot accept forged
+    human/operator/system claims from raw headers.
 
-def parse_origin_header(raw: str | None) -> dict[str, str] | None:
-    """Parse an X-Origin header. Returns None on any error or invalid shape.
-
-    Only ``channel`` and ``user`` fields propagate — all other keys are dropped.
-    Both must be non-empty strings within reasonable length bounds so a
-    malicious or malformed header cannot inflate downstream payloads.
+    Field length bounds: ``channel`` ≤ 32 chars, ``user`` ≤ 128 chars,
+    raw blob ≤ 512 chars. Legacy headers (no ``kind``) still require
+    non-empty ``channel`` and ``user`` to match the pre-Task-2a parser
+    contract.
     """
-    if not raw or len(raw) > 512:
-        return None
-    try:
-        parsed = json.loads(raw)
-    except json.JSONDecodeError:
-        return None
-    if not isinstance(parsed, dict):
-        return None
-    ch = parsed.get("channel")
-    us = parsed.get("user")
-    if not isinstance(ch, str) or not isinstance(us, str):
-        return None
-    if not ch or not us:
-        return None
-    if len(ch) > _MAX_ORIGIN_CHANNEL_LEN or len(us) > _MAX_ORIGIN_USER_LEN:
-        return None
-    # Whitelist: only `channel` and `user` fields propagate.
-    return {"channel": ch, "user": us}
+    return MessageOrigin.from_header_value(raw, trust_kind=False)
+
+
+# Re-export the field-length caps so existing imports keep working.
+__all__ = [
+    "TRACE_HEADER",
+    "ORIGIN_HEADER",
+    "current_trace_id",
+    "current_origin",
+    "new_trace_id",
+    "trace_headers",
+    "origin_header",
+    "parse_origin_header",
+    "_MAX_ORIGIN_CHANNEL_LEN",
+    "_MAX_ORIGIN_USER_LEN",
+]

--- a/src/shared/types.py
+++ b/src/shared/types.py
@@ -37,6 +37,138 @@ AGENT_ID_RE_PATTERN = r"^[a-zA-Z0-9][a-zA-Z0-9_-]{0,63}$"
 # === Inter-Component Messages ===
 
 
+class MessageOrigin(BaseModel):
+    """Typed origin for a message flowing through the mesh.
+
+    The ``kind`` field is the authorization-relevant piece: future tasks
+    gate durable actions on ``kind == "human"`` (Task 2d's pending-action
+    confirm), block worker → operator wakes when ``kind == "agent"``
+    (Task 2e), and downgrade unverifiable channel claims (Task 2c).
+
+    ``channel`` and ``user`` are free-form for now; they identify which
+    surface the message came from (cli, dashboard, telegram, …) and the
+    end-user id when one is available.
+
+    The model is ``frozen=True`` — origins are stamped once at the entry
+    point (CLI REPL, dashboard chat, channel adapter, cron tick, …) and
+    must not be mutated mid-flight.
+
+    Backward-compat: this PR (Task 2a) introduces the model but does not
+    flip stamp sites yet (Task 2b). Existing call sites that construct
+    raw ``{"channel": ..., "user": ...}`` dicts continue to work; the
+    helpers in ``src.shared.trace`` accept both shapes. Dict-style
+    accessors (``__getitem__`` / ``get``) are provided so readers do not
+    need to branch on type during the migration.
+    """
+
+    kind: Literal["human", "operator", "agent", "system", "heartbeat", "cron"]
+    channel: str = ""
+    user: str = ""
+
+    model_config = {"frozen": True}
+
+    # Dict-style accessors — let readers that still treat origin as a
+    # ``dict[str, str]`` keep working through the Task 2b migration.
+    def __getitem__(self, key: str) -> str:
+        if key in {"kind", "channel", "user"}:
+            return getattr(self, key)
+        raise KeyError(key)
+
+    def get(self, key: str, default: Any = None) -> Any:
+        # Match ``dict.get`` semantics: present-but-empty returns the
+        # empty string, only an unknown key falls back to ``default``.
+        if key in {"kind", "channel", "user"}:
+            return getattr(self, key)
+        return default
+
+    def to_header_value(self) -> str:
+        """Serialize to a JSON ``X-Origin`` header value.
+
+        Format keeps the existing JSON shape (``{"channel": ..., "user": ...}``)
+        and adds a ``kind`` key. Old mesh nodes parsing this with the
+        legacy parser whitelist only ``channel`` and ``user`` and silently
+        drop ``kind`` — so the rolling-deploy invariant holds.
+        """
+        import json as _json
+        return _json.dumps(
+            {"kind": self.kind, "channel": self.channel, "user": self.user},
+            separators=(",", ":"),
+        )
+
+    @classmethod
+    def from_header_value(
+        cls, value: str | None, *, trust_kind: bool = False,
+    ) -> "MessageOrigin | None":
+        """Parse an ``X-Origin`` header value back into a model.
+
+        Returns ``None`` on missing or malformed input (never a partial
+        model). Treats a missing ``kind`` segment as ``kind="agent"``
+        (the least-trusted origin). Unless ``trust_kind`` is true, an
+        explicit privileged kind from the header is also downgraded to
+        ``kind="agent"`` so request headers cannot self-assert human,
+        operator, system, heartbeat, or cron authority.
+
+        Field length bounds match the legacy parser
+        (``channel`` ≤ 32, ``user`` ≤ 128, raw blob ≤ 512).
+        """
+        if not value or len(value) > 512:
+            return None
+        import json as _json
+        try:
+            parsed = _json.loads(value)
+        except _json.JSONDecodeError:
+            return None
+        if not isinstance(parsed, dict):
+            return None
+
+        ch = parsed.get("channel", "")
+        us = parsed.get("user", "")
+        kind = parsed.get("kind")
+
+        # Channel/user are required for legacy compatibility unless this
+        # is a typed origin without an addressable surface (cron, system,
+        # heartbeat). The legacy parser rejected empty channel/user, so
+        # legacy headers without ``kind`` must still meet that bar.
+        if not isinstance(ch, str) or not isinstance(us, str):
+            return None
+
+        if kind is None:
+            # Legacy header — least-trusted default.
+            kind = "agent"
+            if not ch or not us:
+                # Legacy parser rejected empty channel/user for headers
+                # without a ``kind`` segment. Preserve that behavior so
+                # downstream auto-notify paths do not see a half-shaped
+                # legacy origin.
+                return None
+
+        if not isinstance(kind, str):
+            return None
+
+        if not trust_kind:
+            # Inbound request headers are not authority. Preserve addressable
+            # channel/user metadata, but downgrade all caller-supplied kinds.
+            kind = "agent"
+            if not ch or not us:
+                return None
+
+        if len(ch) > _MAX_ORIGIN_CHANNEL_LEN or len(us) > _MAX_ORIGIN_USER_LEN:
+            return None
+
+        try:
+            return cls(kind=kind, channel=ch, user=us)
+        except Exception:
+            # Pydantic validation error — bad ``kind`` value.
+            return None
+
+
+# Field-length caps used by ``MessageOrigin.from_header_value`` and
+# ``src.shared.trace.parse_origin_header``. Kept here so the type module
+# is self-contained.
+_MAX_ORIGIN_CHANNEL_LEN = 32
+_MAX_ORIGIN_USER_LEN = 128
+
+
 class AgentMessage(BaseModel):
     """Every message between agents passes through the mesh in this format."""
 

--- a/tests/test_agent_server.py
+++ b/tests/test_agent_server.py
@@ -731,7 +731,14 @@ class TestChatOriginHeader:
         assert resp.status_code == 200
         mock_loop.chat.assert_awaited_once()
         call_kwargs = mock_loop.chat.call_args.kwargs
-        assert call_kwargs.get("origin") == origin
+        # Task 2a: ``parse_origin_header`` returns a typed ``MessageOrigin``;
+        # legacy headers (no ``kind``) default to least-trusted ``kind="agent"``.
+        from src.shared.types import MessageOrigin
+        passed = call_kwargs.get("origin")
+        assert isinstance(passed, MessageOrigin)
+        assert passed.kind == "agent"
+        assert passed.channel == "whatsapp"
+        assert passed.user == "+1234"
 
     @pytest.mark.asyncio
     async def test_chat_no_origin_header_passes_none(self):

--- a/tests/test_coordination.py
+++ b/tests/test_coordination.py
@@ -588,6 +588,30 @@ class TestHandOffOriginPropagation:
         assert task_record.get("origin") == origin
 
     @pytest.mark.asyncio
+    async def test_hand_off_stores_typed_origin_as_plain_dict(self):
+        """Typed origins must be JSON-serializable when written to blackboard."""
+        from src.agent.builtins.coordination_tool import hand_off
+        from src.shared.trace import current_origin
+        from src.shared.types import MessageOrigin
+
+        mc = _make_mesh_client(agent_id="operator")
+        mc.list_agents.return_value = {"chef": {"role": "chef"}}
+
+        origin = MessageOrigin(kind="human", channel="cli", user="jeff")
+        token = current_origin.set(origin)
+        try:
+            await hand_off(to="chef", summary="do work", mesh_client=mc)
+        finally:
+            current_origin.reset(token)
+
+        task_record = mc.write_blackboard.call_args_list[-1].args[1]
+        assert task_record.get("origin") == {
+            "kind": "human",
+            "channel": "cli",
+            "user": "jeff",
+        }
+
+    @pytest.mark.asyncio
     async def test_hand_off_no_origin_no_origin_in_task_record(self):
         """When current_origin is None, task_record has no 'origin' key."""
         from src.agent.builtins.coordination_tool import hand_off

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1923,9 +1923,18 @@ def test_agent_profile_permission_denied(mesh_components):
 class TestParseOriginHeader:
     def test_valid_header(self):
         from src.shared.trace import parse_origin_header
-        assert parse_origin_header('{"channel":"whatsapp","user":"+1234"}') == {
-            "channel": "whatsapp", "user": "+1234",
-        }
+        from src.shared.types import MessageOrigin
+
+        result = parse_origin_header('{"channel":"whatsapp","user":"+1234"}')
+        assert isinstance(result, MessageOrigin)
+        # Legacy header (no ``kind``) → least-trusted ``kind="agent"``.
+        assert result.kind == "agent"
+        assert result.channel == "whatsapp"
+        assert result.user == "+1234"
+        # Dict-compat shim — readers in flight during the Task 2b
+        # migration can still treat it as a dict.
+        assert result.get("channel") == "whatsapp"
+        assert result.get("user") == "+1234"
 
     def test_none_returns_none(self):
         from src.shared.trace import parse_origin_header
@@ -1949,6 +1958,7 @@ class TestParseOriginHeader:
 
     def test_empty_fields_returns_none(self):
         from src.shared.trace import parse_origin_header
+        # Legacy header (no ``kind``) still requires non-empty channel/user.
         assert parse_origin_header('{"channel":"","user":"+1"}') is None
         assert parse_origin_header('{"channel":"whatsapp","user":""}') is None
 
@@ -1959,10 +1969,18 @@ class TestParseOriginHeader:
 
     def test_extra_fields_stripped(self):
         from src.shared.trace import parse_origin_header
+        from src.shared.types import MessageOrigin
+
         result = parse_origin_header(
             '{"channel":"whatsapp","user":"+1","extra":"dropped","nested":{}}'
         )
-        assert result == {"channel": "whatsapp", "user": "+1"}
+        assert isinstance(result, MessageOrigin)
+        # Only ``kind`` / ``channel`` / ``user`` survive.
+        assert result.channel == "whatsapp"
+        assert result.user == "+1"
+        # No way for arbitrary keys to leak onto the model.
+        assert not hasattr(result, "extra")
+        assert not hasattr(result, "nested")
 
     def test_oversized_raw_header_returns_none(self):
         from src.shared.trace import parse_origin_header
@@ -2067,7 +2085,14 @@ def test_mesh_wake_propagates_origin_header(tmp_path):
         call = captured[0]
         assert call["agent"] == "chef"
         assert call["mode"] == "followup"
-        assert call["origin"] == {"channel": "whatsapp", "user": "+1234"}
+        # ``parse_origin_header`` returns a typed ``MessageOrigin``; legacy
+        # ``X-Origin`` headers without a ``kind`` segment default to
+        # ``kind="agent"`` (least-trusted).
+        from src.shared.types import MessageOrigin
+        assert isinstance(call["origin"], MessageOrigin)
+        assert call["origin"].kind == "agent"
+        assert call["origin"].channel == "whatsapp"
+        assert call["origin"].user == "+1234"
         assert call["auto_notify"] is True
     finally:
         loop.call_soon_threadsafe(loop.stop)

--- a/tests/test_message_origin.py
+++ b/tests/test_message_origin.py
@@ -1,0 +1,303 @@
+"""Tests for the typed ``MessageOrigin`` model and ``trace.py`` helpers.
+
+Task 2a (operator orchestration roadmap) introduces ``MessageOrigin`` as
+a typed Pydantic model carrying ``kind``, ``channel``, and ``user``.
+
+The test surface here covers three concerns:
+
+* The model itself — validation, defaults, immutability, dict-compat.
+* The ``X-Origin`` wire format — JSON shape, additive ``kind`` segment,
+  legacy back-compat (no ``kind`` → ``kind="agent"``).
+* The ``parse_origin_header`` / ``origin_header`` helpers in
+  ``src.shared.trace`` — accepts both typed and dict input, returns
+  typed output.
+
+The "legacy header → kind=agent" case is the security-critical default:
+unauthenticated paths must NOT be able to claim ``kind="human"`` by
+sending the pre-Task-2a header shape.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+from pydantic import ValidationError
+
+from src.shared.trace import origin_header, parse_origin_header
+from src.shared.types import MessageOrigin
+
+# ── MessageOrigin model ─────────────────────────────────────────
+
+
+class TestMessageOriginModel:
+    def test_construction_with_all_fields(self):
+        m = MessageOrigin(kind="human", channel="cli", user="jeff")
+        assert m.kind == "human"
+        assert m.channel == "cli"
+        assert m.user == "jeff"
+
+    def test_default_channel_and_user_are_empty_strings(self):
+        m = MessageOrigin(kind="cron")
+        assert m.channel == ""
+        assert m.user == ""
+
+    @pytest.mark.parametrize(
+        "kind",
+        ["human", "operator", "agent", "system", "heartbeat", "cron"],
+    )
+    def test_all_documented_kinds_accepted(self, kind):
+        m = MessageOrigin(kind=kind)
+        assert m.kind == kind
+
+    @pytest.mark.parametrize("kind", ["", "user", "HUMAN", "haxxor", "admin"])
+    def test_unknown_kind_rejected(self, kind):
+        with pytest.raises(ValidationError):
+            MessageOrigin(kind=kind)
+
+    def test_frozen_blocks_mutation(self):
+        m = MessageOrigin(kind="human", channel="cli", user="jeff")
+        with pytest.raises(ValidationError):
+            m.kind = "agent"  # type: ignore[misc]
+        with pytest.raises(ValidationError):
+            m.channel = "telegram"  # type: ignore[misc]
+        with pytest.raises(ValidationError):
+            m.user = "+1"  # type: ignore[misc]
+
+    def test_dict_style_getitem(self):
+        m = MessageOrigin(kind="human", channel="cli", user="jeff")
+        assert m["kind"] == "human"
+        assert m["channel"] == "cli"
+        assert m["user"] == "jeff"
+        with pytest.raises(KeyError):
+            _ = m["nope"]
+
+    def test_dict_style_get(self):
+        m = MessageOrigin(kind="cron")
+        # Empty channel/user return ``""`` (matches dict semantics where
+        # the key is present but the value is empty).
+        assert m.get("channel") == ""
+        assert m.get("user") == ""
+        assert m.get("kind") == "cron"
+        # Unknown key falls back to default.
+        assert m.get("nope") is None
+        assert m.get("nope", "fallback") == "fallback"
+
+    def test_dict_conversion_roundtrip(self):
+        # ``lanes.py`` does ``dict(task.origin)`` — must produce a plain
+        # dict containing all three fields.
+        m = MessageOrigin(kind="operator", channel="dashboard", user="op-1")
+        d = dict(m)
+        assert d == {"kind": "operator", "channel": "dashboard", "user": "op-1"}
+
+
+# ── X-Origin wire format ────────────────────────────────────────
+
+
+class TestHeaderRoundTrip:
+    def test_round_trip_preserves_all_fields(self):
+        original = MessageOrigin(kind="human", channel="telegram", user="+99")
+        wire = original.to_header_value()
+        restored = MessageOrigin.from_header_value(wire, trust_kind=True)
+        assert restored == original
+
+    def test_to_header_value_emits_json(self):
+        m = MessageOrigin(kind="human", channel="cli", user="jeff")
+        # JSON shape lets old mesh nodes parse it through the legacy
+        # ``channel``/``user`` whitelist; ``kind`` falls through.
+        parsed = json.loads(m.to_header_value())
+        assert parsed == {"kind": "human", "channel": "cli", "user": "jeff"}
+
+    def test_from_header_value_none_or_empty_returns_none(self):
+        assert MessageOrigin.from_header_value(None) is None
+        assert MessageOrigin.from_header_value("") is None
+
+    def test_from_header_value_malformed_returns_none_not_partial(self):
+        # Malformed → ``None``, never a half-built model.
+        assert MessageOrigin.from_header_value("not-json") is None
+        assert MessageOrigin.from_header_value("{") is None
+        assert MessageOrigin.from_header_value('"just-a-string"') is None
+        assert MessageOrigin.from_header_value("[1, 2, 3]") is None
+        assert MessageOrigin.from_header_value("null") is None
+
+    def test_from_header_value_oversized_returns_none(self):
+        big = '{"kind":"human","channel":"x","user":"' + ("y" * 600) + '"}'
+        assert MessageOrigin.from_header_value(big) is None
+
+    def test_from_header_value_extra_fields_dropped(self):
+        # Whitelist-only — extras must not survive onto the model.
+        result = MessageOrigin.from_header_value(
+            '{"kind":"human","channel":"cli","user":"jeff","extra":"dropped"}'
+        )
+        assert result is not None
+        assert not hasattr(result, "extra")
+
+
+# ── Security-critical: legacy header default ────────────────────
+
+
+class TestLegacyHeaderSecurityDefault:
+    """A legacy ``X-Origin`` header (no ``kind``) MUST default to
+    ``kind="agent"`` (least-trusted). This is the load-bearing security
+    property — without it, an unauthenticated path could forge a
+    ``human``-origin claim simply by sending the pre-Task-2a header.
+    """
+
+    def test_legacy_header_defaults_to_kind_agent(self):
+        result = MessageOrigin.from_header_value(
+            '{"channel":"cli","user":"jeff"}'
+        )
+        assert result is not None
+        assert result.kind == "agent"
+        assert result.channel == "cli"
+        assert result.user == "jeff"
+
+    def test_untrusted_typed_header_downgrades_privileged_kind(self):
+        result = MessageOrigin.from_header_value(
+            '{"kind":"human","channel":"cli","user":"jeff"}'
+        )
+        assert result is not None
+        assert result.kind == "agent"
+
+    def test_trusted_typed_header_preserves_stamped_kind(self):
+        result = MessageOrigin.from_header_value(
+            '{"kind":"human","channel":"cli","user":"jeff"}',
+            trust_kind=True,
+        )
+        assert result is not None
+        assert result.kind == "human"
+
+    def test_legacy_header_with_empty_channel_or_user_rejected(self):
+        # Pre-Task-2a parser rejected empty channel/user; preserve that
+        # for legacy headers so half-shaped origins never reach
+        # auto-notify.
+        assert MessageOrigin.from_header_value(
+            '{"channel":"","user":"jeff"}'
+        ) is None
+        assert MessageOrigin.from_header_value(
+            '{"channel":"cli","user":""}'
+        ) is None
+
+    def test_typed_header_allows_empty_channel_user(self):
+        # Cron / system / heartbeat origins have no addressable user.
+        # The typed parser must accept them.
+        for kind in ("cron", "system", "heartbeat"):
+            result = MessageOrigin.from_header_value(
+                f'{{"kind":"{kind}","channel":"","user":""}}',
+                trust_kind=True,
+            )
+            assert result is not None, kind
+            assert result.kind == kind
+
+    def test_rolling_deploy_safety_old_parser_can_drop_kind(self):
+        """A new-format header parsed by an *old* parser (which only
+        whitelists ``channel`` / ``user``) must yield a usable origin
+        with the minimum-trust default ``kind="agent"``.
+
+        Simulated by stripping ``kind`` from the new-format JSON and
+        feeding the result back through ``from_header_value``.
+        """
+        new_format = MessageOrigin(
+            kind="human", channel="cli", user="jeff",
+        ).to_header_value()
+        parsed = json.loads(new_format)
+        parsed.pop("kind")
+        legacy_blob = json.dumps(parsed, separators=(",", ":"))
+        result = MessageOrigin.from_header_value(legacy_blob)
+        assert result is not None
+        assert result.kind == "agent"
+
+
+# ── trace.parse_origin_header / origin_header helpers ───────────
+
+
+class TestTraceHelpers:
+    def test_parse_origin_header_returns_typed_model(self):
+        result = parse_origin_header(
+            '{"kind":"human","channel":"cli","user":"jeff"}'
+        )
+        assert isinstance(result, MessageOrigin)
+        assert result.kind == "agent"
+
+    def test_parse_origin_header_legacy_defaults_to_agent(self):
+        result = parse_origin_header('{"channel":"cli","user":"jeff"}')
+        assert isinstance(result, MessageOrigin)
+        assert result.kind == "agent"
+
+    def test_parse_origin_header_invalid_returns_none(self):
+        assert parse_origin_header(None) is None
+        assert parse_origin_header("") is None
+        assert parse_origin_header("not-json") is None
+
+    def test_origin_header_typed_input(self):
+        m = MessageOrigin(kind="human", channel="cli", user="jeff")
+        h = origin_header(m)
+        assert "X-Origin" in h
+        parsed = json.loads(h["X-Origin"])
+        assert parsed == {"kind": "human", "channel": "cli", "user": "jeff"}
+
+    def test_origin_header_dict_input_back_compat(self):
+        # Stamps not yet migrated still pass dicts. Must serialize.
+        h = origin_header({"kind": "human", "channel": "cli", "user": "jeff"})
+        parsed = json.loads(h["X-Origin"])
+        assert parsed == {"kind": "human", "channel": "cli", "user": "jeff"}
+
+    def test_origin_header_typed_and_dict_produce_identical_payload(self):
+        m = MessageOrigin(kind="operator", channel="dashboard", user="op-1")
+        h_typed = origin_header(m)
+        h_dict = origin_header(
+            {"kind": "operator", "channel": "dashboard", "user": "op-1"}
+        )
+        assert h_typed == h_dict
+
+    def test_origin_header_legacy_dict_no_kind_upgrades_to_agent(self):
+        # Dict without ``kind`` must serialize with ``kind="agent"`` so
+        # the next hop never sees a kind-less origin on the wire.
+        h = origin_header({"channel": "cli", "user": "jeff"})
+        parsed = json.loads(h["X-Origin"])
+        assert parsed["kind"] == "agent"
+        assert parsed["channel"] == "cli"
+        assert parsed["user"] == "jeff"
+
+    def test_origin_header_none_returns_empty_dict(self):
+        assert origin_header(None) == {}
+        assert origin_header({}) == {}
+
+    def test_round_trip_through_helpers(self):
+        m = MessageOrigin(kind="human", channel="telegram", user="+99")
+        wire = origin_header(m)["X-Origin"]
+        restored = parse_origin_header(wire)
+        assert restored == MessageOrigin(kind="agent", channel="telegram", user="+99")
+
+
+# ── Request-level integration with parse_origin_header ──────────
+
+
+class _FakeRequestHeaders:
+    """Minimal stand-in for ``Request.headers`` (case-insensitive get)."""
+
+    def __init__(self, mapping: dict[str, str]) -> None:
+        self._lower = {k.lower(): v for k, v in mapping.items()}
+
+    def get(self, key: str, default: str | None = None) -> str | None:
+        return self._lower.get(key.lower(), default)
+
+
+class TestRequestHeaderParse:
+    def test_legacy_request_header_yields_kind_agent(self):
+        req_headers = _FakeRequestHeaders(
+            {"x-origin": '{"channel":"cli","user":"jeff"}'},
+        )
+        origin = parse_origin_header(req_headers.get("x-origin"))
+        assert isinstance(origin, MessageOrigin)
+        assert origin.kind == "agent"
+        assert origin.channel == "cli"
+        assert origin.user == "jeff"
+
+    def test_typed_request_header_yields_stamped_kind(self):
+        req_headers = _FakeRequestHeaders(
+            {"x-origin": '{"kind":"human","channel":"cli","user":"jeff"}'},
+        )
+        origin = parse_origin_header(req_headers.get("x-origin"))
+        assert isinstance(origin, MessageOrigin)
+        assert origin.kind == "agent"


### PR DESCRIPTION
## Summary

Foundation slice of **Task 2** (origin as authorization input). Introduces a typed `MessageOrigin` Pydantic model so subsequent slices (2b stamps, 2c channel validation, 2d pending-actions, 2e wake-block) have a typed origin to gate on. **No stamp sites, permission gates, or wire-format-incompatible changes in this PR.**

**Branch base:** `test/characterization-tier1` (PR #822) → `fix/operator-handoff-hotfix` (PR #821) → `main`. Will rebase as the stack lands.

## What ships

- `MessageOrigin` model in `src/shared/types.py` — `Literal["human", "operator", "agent", "system", "heartbeat", "cron"]` × `channel` × `user`. `frozen=True`.
- `to_header_value` / `from_header_value` keep the existing JSON-on-`X-Origin` wire format and add a `kind` key. Old mesh nodes parsing the new format whitelist `channel`/`user` only and silently drop `kind` → **rolling-deploy safe**.
- A legacy header (no `kind`) parses with `kind="agent"` — the least-trusted default. Unauthenticated paths cannot forge `kind="human"` via a pre-Task-2a header.
- `current_origin` ContextVar widened to `MessageOrigin | dict | None` during the migration window. Stamp sites continue to write dicts; helpers accept both. Task 2b will flip them.
- Dict-compat shim (`__getitem__`, `get`) on `MessageOrigin` so reader call sites that already use `origin.get("channel")` keep working without source churn.
- `origin_header` emits a `logger.debug` breadcrumb when fed a legacy dict so Task 2b's stamp-site migration can audit by log scrape.

## What's deliberately NOT in this PR

- Stamp-site migration (CLI REPL / dashboard chat / channels / cron / heartbeat) — Task 2b.
- Channel server-side `PairingManager` recheck — Task 2c.
- SQLite `pending_actions` table replacing `_pending_changes` in-memory dict — Task 2d.
- `/mesh/wake` worker → operator block — Task 2e (flips one of #822's capture-to-tighten tests).

## Test plan

- [x] `pytest tests/test_message_origin.py tests/test_lanes.py tests/test_coordination.py tests/test_mesh.py` — 183 passed
- [x] Full non-E2E suite — 4977 passed, 44 skipped, 0 failures
- [x] 39 new tests in `tests/test_message_origin.py` covering: model validation, default channel/user, header round-trip, legacy security default (`kind="agent"`), `frozen=True` mutation rejection, dict-compat shim (`__getitem__`, `get`, `dict()` conversion), rolling-deploy safety (old parser drops `kind`), `origin_header` accepting both shapes, malformed headers returning `None` not partial models
- [x] Two existing tests updated to compare against the typed shape (`test_integration.py::TestParseOriginHeader`, `test_agent_server.py::TestChatOriginHeader::test_chat_passes_origin_to_loop`) — same wire format, just typed return
- [x] `current_origin` survey: 2 real reader sites (both use `.get(...)`), no source-churn migration needed in this slice

## Notes

- Survey output: only `src/cli/runtime.py:569-570` reads `origin.get("channel"/"user")`. `coordination_tool.py:122` is `ContextVar.get()`, not dict access. Decision documented inline: keep both readers untouched and use the dict-compat shim — cleaner than partial migration.
- Format stayed JSON (existing `parse_origin_header` was already JSON-based, despite my spec assuming `key=value;…`) — verified by reading the current code first.

## Stack

This PR is part of the operator orchestration roadmap stack:
1. #821 — Task 0 hotfix (project agent → operator handoff) ✅ green
2. #822 — Task 1 characterization tests (CI pending)
3. **This PR** — Task 2a origin model
4. (next) Task 2b stamp sites
5. (then) Task 2c channel validation, Task 2d pending-actions, Task 2e wake-block