### PR TITLE
feat(origin): stamp typed MessageOrigin at every entry point (Task 2b)

### DIFF
--- a/src/agent/builtins/coordination_tool.py
+++ b/src/agent/builtins/coordination_tool.py
@@ -150,6 +150,10 @@ async def hand_off(
     if output_key:
         task_record["output_key"] = output_key
     if origin:
+        # ``origin`` may be a typed ``MessageOrigin`` (post-Task-2a stamp
+        # sites) or a legacy raw dict. Persist as plain dict so the
+        # blackboard JSON write doesn't choke on a Pydantic instance and
+        # downstream readers continue to see the same shape.
         if hasattr(origin, "model_dump"):
             task_record["origin"] = origin.model_dump()
         elif isinstance(origin, dict):

--- a/src/agent/loop.py
+++ b/src/agent/loop.py
@@ -29,6 +29,7 @@ if TYPE_CHECKING:
     from src.agent.mesh_client import MeshClient
     from src.agent.skills import SkillRegistry
     from src.agent.workspace import WorkspaceManager
+    from src.shared.types import MessageOrigin
 
 logger = setup_logging("agent.loop")
 
@@ -1647,7 +1648,7 @@ class AgentLoop:
 
     async def chat(
         self, user_message: str, *, trace_id: str | None = None,
-        origin: dict[str, str] | None = None,
+        origin: "MessageOrigin | dict[str, str] | None" = None,
     ) -> dict:
         """Handle a single chat turn with persistent conversation history.
 
@@ -2470,7 +2471,7 @@ class AgentLoop:
 
     async def chat_stream(
         self, user_message: str, *, trace_id: str | None = None,
-        origin: dict[str, str] | None = None,
+        origin: "MessageOrigin | dict[str, str] | None" = None,
     ):
         """Streaming chat that yields SSE events as they happen.
 

--- a/src/agent/mesh_client.py
+++ b/src/agent/mesh_client.py
@@ -8,11 +8,15 @@ from __future__ import annotations
 
 import asyncio
 import os
+from typing import TYPE_CHECKING
 
 import httpx
 
 from src.shared.types import MeshEvent
 from src.shared.utils import setup_logging
+
+if TYPE_CHECKING:
+    from src.shared.types import MessageOrigin
 
 logger = setup_logging("agent.mesh_client")
 
@@ -256,7 +260,7 @@ class MeshClient:
 
     async def wake_agent(
         self, target: str, message: str = "",
-        origin: dict | None = None,
+        origin: "MessageOrigin | dict | None" = None,
     ) -> dict:
         """Wake a target agent so it processes work immediately."""
         from src.shared.trace import origin_header

--- a/src/agent/server.py
+++ b/src/agent/server.py
@@ -56,6 +56,23 @@ _MAX_HISTORY_LOGS_CHARS = 16000
 _MAX_HISTORY_LEARNINGS_CHARS = 8000
 
 
+def _origin_from_mesh_request(request: Request):
+    """Parse origin from a host-to-agent request.
+
+    ``X-Origin`` is authorization-bearing only after the mesh/dashboard/CLI
+    stamped it. The host transport adds ``x-mesh-internal`` on those hops, so
+    preserve the typed kind only for that trusted internal path. Direct callers
+    still get the strict parser, which downgrades caller-supplied kinds.
+    """
+    from src.shared.trace import parse_origin_header
+    from src.shared.types import MessageOrigin
+
+    raw = request.headers.get("x-origin")
+    if request.headers.get("x-mesh-internal"):
+        return MessageOrigin.from_header_value(raw, trust_kind=True)
+    return parse_origin_header(raw)
+
+
 def create_agent_app(loop: AgentLoop) -> FastAPI:
     """Create the FastAPI application for an agent container."""
     app = FastAPI(title=f"OpenLegion Agent: {loop.agent_id}")
@@ -184,8 +201,8 @@ def create_agent_app(loop: AgentLoop) -> FastAPI:
         contextvar with ``kind="heartbeat"`` for any tool / coordination
         call made during the heartbeat run.
         """
-        from src.shared.trace import current_origin, parse_origin_header
-        origin = parse_origin_header(request.headers.get("x-origin"))
+        from src.shared.trace import current_origin
+        origin = _origin_from_mesh_request(request)
         token = current_origin.set(origin)
         try:
             result = await loop.execute_heartbeat(sanitize_for_prompt(msg.message))
@@ -205,8 +222,7 @@ def create_agent_app(loop: AgentLoop) -> FastAPI:
     @app.post("/chat", response_model=ChatResponse)
     async def chat(msg: ChatMessage, request: Request) -> ChatResponse:
         """Interactive chat with the agent. Supports tool use."""
-        from src.shared.trace import parse_origin_header
-        origin = parse_origin_header(request.headers.get("x-origin"))
+        origin = _origin_from_mesh_request(request)
         result = await loop.chat(
             sanitize_for_prompt(msg.message),
             trace_id=request.headers.get("x-trace-id"),
@@ -223,9 +239,8 @@ def create_agent_app(loop: AgentLoop) -> FastAPI:
     @app.post("/chat/stream")
     async def chat_stream(msg: ChatMessage, request: Request) -> StreamingResponse:
         """Streaming chat. Returns SSE events for tool use and text deltas."""
-        from src.shared.trace import parse_origin_header
         _trace_id = request.headers.get("x-trace-id")
-        _origin = parse_origin_header(request.headers.get("x-origin"))
+        _origin = _origin_from_mesh_request(request)
         async def event_generator():
             stream = loop.chat_stream(
                 sanitize_for_prompt(msg.message), trace_id=_trace_id,

--- a/src/agent/server.py
+++ b/src/agent/server.py
@@ -177,9 +177,20 @@ def create_agent_app(loop: AgentLoop) -> FastAPI:
             return {"error": str(e)}
 
     @app.post("/heartbeat")
-    async def heartbeat(msg: ChatMessage) -> dict:
-        """Execute an autonomous heartbeat — separate from chat."""
-        result = await loop.execute_heartbeat(sanitize_for_prompt(msg.message))
+    async def heartbeat(msg: ChatMessage, request: Request) -> dict:
+        """Execute an autonomous heartbeat — separate from chat.
+
+        Task 2b: parse ``X-Origin`` so the heartbeat path stamps the
+        contextvar with ``kind="heartbeat"`` for any tool / coordination
+        call made during the heartbeat run.
+        """
+        from src.shared.trace import current_origin, parse_origin_header
+        origin = parse_origin_header(request.headers.get("x-origin"))
+        token = current_origin.set(origin)
+        try:
+            result = await loop.execute_heartbeat(sanitize_for_prompt(msg.message))
+        finally:
+            current_origin.reset(token)
         return result
 
     @app.get("/activity")

--- a/src/channels/base.py
+++ b/src/channels/base.py
@@ -13,11 +13,14 @@ import asyncio
 import json
 from collections.abc import AsyncIterator, Callable, Coroutine
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from src.channels import AT_MENTION_RE
 from src.host.credentials import SYSTEM_CREDENTIAL_PROVIDERS, is_system_credential
 from src.shared.utils import sanitize_for_prompt, setup_logging
+
+if TYPE_CHECKING:
+    from src.shared.types import MessageOrigin
 
 logger = setup_logging("channels.base")
 
@@ -188,7 +191,7 @@ class Channel(abc.ABC):
 
     async def dispatch(
         self, agent: str, message: str,
-        origin: dict[str, str] | None = None,
+        origin: "MessageOrigin | dict[str, str] | None" = None,
     ) -> str:
         """Route a message to an agent and return the response.
 
@@ -239,10 +242,19 @@ class Channel(abc.ABC):
         if message.startswith("/"):
             return await self._handle_command(user_id, message, current, agents)
 
-        # Normal message: build origin and dispatch to agent
-        origin: dict[str, str] | None = None
+        # Normal message: build origin and dispatch to agent.
+        # Task 2b: stamp typed ``MessageOrigin`` (kind="human") so the
+        # downstream lane / agent sees an authorization-bearing origin
+        # rather than a raw dict.
+        from src.shared.types import MessageOrigin
+
+        origin: MessageOrigin | None = None
         if self.CHANNEL_TYPE and user_id:
-            origin = {"channel": self.CHANNEL_TYPE, "user": str(user_id)}
+            origin = MessageOrigin(
+                kind="human",
+                channel=self.CHANNEL_TYPE,
+                user=str(user_id),
+            )
         response = await self.dispatch(target, message, origin=origin)
         if not response or not response.strip():
             return ""  # Suppress silent/empty responses

--- a/src/cli/repl.py
+++ b/src/cli/repl.py
@@ -643,11 +643,17 @@ class REPLSession:
         if self.ctx.lane_manager is None or self.ctx.dispatch_loop is None:
             click.echo("Steer not available in this mode.")
             return
+        # Task 2b: stamp human/cli origin on REPL-driven steer commands.
         from src.shared.trace import new_trace_id
+        from src.shared.types import MessageOrigin
+        cli_origin = MessageOrigin(
+            kind="human", channel="cli", user=os.getenv("USER", "cli"),
+        )
         steer_msg = arg.strip()
         future = asyncio.run_coroutine_threadsafe(
             self.ctx.lane_manager.enqueue(
                 self.current, steer_msg, mode="steer", trace_id=new_trace_id(),
+                origin=cli_origin,
             ),
             self.ctx.dispatch_loop,
         )
@@ -1517,6 +1523,12 @@ class REPLSession:
             click.echo(f"Agent '{target}' not found.")
             return
 
+        # Task 2b: every CLI REPL message is human-driven.
+        from src.shared.types import MessageOrigin
+        cli_origin = MessageOrigin(
+            kind="human", channel="cli", user=os.getenv("USER", "cli"),
+        )
+
         # Auto-steer if the agent is currently busy
         if self.ctx.lane_manager:
             status = self.ctx.lane_manager.get_status().get(target, {})
@@ -1527,6 +1539,7 @@ class REPLSession:
                 future = asyncio.run_coroutine_threadsafe(
                     self.ctx.lane_manager.enqueue(
                         target, message, mode="steer", trace_id=steer_trace,
+                        origin=cli_origin,
                     ),
                     self.ctx.dispatch_loop,
                 )
@@ -1554,6 +1567,7 @@ class REPLSession:
                             self.ctx.lane_manager.enqueue(
                                 target, steer_msg, mode="steer",
                                 trace_id=new_trace_id(),
+                                origin=cli_origin,
                             ),
                             self.ctx.dispatch_loop,
                         )
@@ -1601,12 +1615,22 @@ def _send_message_streaming(
     stdin for ``/steer`` commands.
     """
     from src.host.transport import HttpTransport
-    from src.shared.trace import current_trace_id, trace_headers
+    from src.shared.trace import current_trace_id, origin_header, trace_headers
+    from src.shared.types import MessageOrigin
+
+    # Task 2b: every CLI REPL message is human-driven; stamp origin so
+    # downstream gates can distinguish it from agent-initiated work.
+    cli_origin = MessageOrigin(
+        kind="human",
+        channel="cli",
+        user=os.getenv("USER", "cli"),
+    )
 
     if isinstance(transport, HttpTransport):
         async def _stream():
             current_trace_id.set(trace_id)
             hdrs = trace_headers()
+            hdrs.update(origin_header(cli_origin))
             response_text = ""
             tool_count = 0
             if event_bus:
@@ -1698,6 +1722,7 @@ def _send_message_streaming(
         # Non-streaming fallback for SandboxTransport
         from src.shared.trace import TRACE_HEADER
         sync_hdrs = {TRACE_HEADER: trace_id} if trace_id else {}
+        sync_hdrs.update(origin_header(cli_origin))
         data = transport.request_sync(
             target, "POST", "/chat",
             json={"message": message}, timeout=120,

--- a/src/cli/runtime.py
+++ b/src/cli/runtime.py
@@ -10,6 +10,7 @@ import sys
 import threading
 import time
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 import click
 
@@ -25,6 +26,9 @@ from src.cli.config import (
 from src.cli.formatting import echo_fail, echo_header, echo_ok
 from src.cli.proxy import build_proxy_env_vars, resolve_agent_proxy
 from src.shared.types import RESERVED_AGENT_IDS
+
+if TYPE_CHECKING:
+    from src.shared.types import MessageOrigin
 
 logger = logging.getLogger("cli")
 
@@ -158,7 +162,7 @@ class RuntimeContext:
     def dispatch(
         self, agent: str, message: str, mode: str = "followup",
         trace_id: str | None = None,
-        origin: dict[str, str] | None = None,
+        origin: "MessageOrigin | dict[str, str] | None" = None,
         auto_notify: bool = False,
     ) -> str:
         """Thread-safe synchronous message dispatch.
@@ -178,7 +182,7 @@ class RuntimeContext:
     async def async_dispatch(
         self, agent: str, message: str, mode: str = "followup",
         trace_id: str | None = None,
-        origin: dict[str, str] | None = None,
+        origin: "MessageOrigin | dict[str, str] | None" = None,
         auto_notify: bool = False,
     ) -> str:
         """Async dispatch: schedules onto the dedicated dispatch loop."""
@@ -463,7 +467,8 @@ class RuntimeContext:
         from src.host.lanes import LaneManager
 
         async def _direct_dispatch(
-            agent_name: str, message: str, origin: dict | None = None,
+            agent_name: str, message: str,
+            origin: "MessageOrigin | dict | None" = None,
             **_kwargs,
         ) -> str:
             from src.shared.trace import current_trace_id, origin_header
@@ -715,8 +720,16 @@ class RuntimeContext:
         from src.host.cron import CronScheduler
 
         async def cron_dispatch(agent_name: str, message: str) -> str:
+            # Task 2b: stamp cron origin so downstream gates can
+            # distinguish a scheduled tick from a human-initiated wake.
             from src.shared.trace import new_trace_id
-            result = await self.async_dispatch(agent_name, message, trace_id=new_trace_id())
+            from src.shared.types import MessageOrigin
+            origin = MessageOrigin(kind="cron", channel="cron", user="")
+            result = await self.async_dispatch(
+                agent_name, message,
+                trace_id=new_trace_id(),
+                origin=origin,
+            )
             return result
 
         async def fetch_heartbeat_context(agent_name: str) -> dict:
@@ -740,12 +753,23 @@ class RuntimeContext:
                 return {"error": str(e)}
 
         async def heartbeat_dispatch(agent_name: str, message: str) -> dict:
-            """Dispatch heartbeat via dedicated /heartbeat endpoint."""
+            """Dispatch heartbeat via dedicated /heartbeat endpoint.
+
+            Task 2b: stamp ``kind="heartbeat"`` origin so the agent's
+            tools (and downstream gates) can identify self-triggered
+            heartbeat work versus a human or cron wake.
+            """
+            from src.shared.trace import origin_header, trace_headers
+            from src.shared.types import MessageOrigin
+            origin = MessageOrigin(kind="heartbeat", channel="heartbeat", user="")
+            headers = trace_headers()
+            headers.update(origin_header(origin))
             try:
                 return await self.transport.request(
                     agent_name, "POST", "/heartbeat",
                     json={"message": message},
                     timeout=120,
+                    headers=headers,
                 )
             except Exception as e:
                 logger.warning("Heartbeat dispatch failed for '%s': %s", agent_name, e)

--- a/src/dashboard/server.py
+++ b/src/dashboard/server.py
@@ -2472,9 +2472,22 @@ def create_dashboard_router(
         if event_bus:
             event_bus.emit("chat_user_message", agent=agent_id,
                 data={"message": message, "session": chat_session})
+        # Task 2b: stamp dashboard chat as human-origin so downstream
+        # authorization gates can distinguish a user-driven chat from
+        # an agent-initiated wake.
+        from src.shared.trace import origin_header, trace_headers
+        from src.shared.types import MessageOrigin
+        origin = MessageOrigin(
+            kind="human",
+            channel="dashboard",
+            user=_operator_session_id(request),
+        )
+        hdrs = trace_headers()
+        hdrs.update(origin_header(origin))
         try:
             result = await transport.request(
                 agent_id, "POST", "/chat", json={"message": message}, timeout=120,
+                headers=hdrs,
             )
             response = result.get("response", "(no response)")
             if event_bus:
@@ -2507,12 +2520,24 @@ def create_dashboard_router(
             event_bus.emit("chat_user_message", agent=agent_id,
                 data={"message": message, "session": chat_session})
 
+        # Task 2b: stamp dashboard streaming chat as human-origin.
+        from src.shared.trace import origin_header, trace_headers
+        from src.shared.types import MessageOrigin
+        _origin = MessageOrigin(
+            kind="human",
+            channel="dashboard",
+            user=_operator_session_id(request),
+        )
+        _hdrs = trace_headers()
+        _hdrs.update(origin_header(_origin))
+
         async def event_generator():
             final_response = ""
             try:
                 async for event in transport.stream_request(
                     agent_id, "POST", "/chat/stream",
                     json={"message": message}, timeout=120,
+                    headers=_hdrs,
                 ):
                     if isinstance(event, dict):
                         yield f"data: {json.dumps(event, default=str)}\n\n"
@@ -2563,11 +2588,23 @@ def create_dashboard_router(
         if not targets:
             return {"responses": {}, "message": "No matching agents"}
 
+        # Task 2b: stamp dashboard broadcast as human-origin.
+        from src.shared.trace import origin_header, trace_headers
+        from src.shared.types import MessageOrigin
+        bc_origin = MessageOrigin(
+            kind="human",
+            channel="dashboard",
+            user=_operator_session_id(request),
+        )
+        bc_hdrs = trace_headers()
+        bc_hdrs.update(origin_header(bc_origin))
+
         results = {}
         async def _send(aid: str) -> tuple[str, str]:
             try:
                 data = await transport.request(
                     aid, "POST", "/chat", json={"message": message}, timeout=120,
+                    headers=bc_hdrs,
                 )
                 return aid, data.get("response", "(no response)")
             except Exception as e:
@@ -2608,6 +2645,17 @@ def create_dashboard_router(
         if not agents:
             return {"responses": {}, "message": "No agents registered"}
 
+        # Task 2b: stamp dashboard streaming broadcast as human-origin.
+        from src.shared.trace import origin_header, trace_headers
+        from src.shared.types import MessageOrigin
+        bcs_origin = MessageOrigin(
+            kind="human",
+            channel="dashboard",
+            user=_operator_session_id(request),
+        )
+        bcs_hdrs = trace_headers()
+        bcs_hdrs.update(origin_header(bcs_origin))
+
         queue: asyncio.Queue = asyncio.Queue()
 
         async def _stream_agent(aid: str) -> None:
@@ -2616,6 +2664,7 @@ def create_dashboard_router(
                 async for event in transport.stream_request(
                     aid, "POST", "/chat/stream",
                     json={"message": message}, timeout=120,
+                    headers=bcs_hdrs,
                 ):
                     if isinstance(event, dict):
                         tagged = {**event, "agent": aid}
@@ -2665,8 +2714,18 @@ def create_dashboard_router(
         if event_bus:
             event_bus.emit("chat_user_message", agent=agent_id,
                 data={"message": f"[steer] {message}", "session": chat_session})
+        # Task 2b: stamp human origin on dashboard-initiated steer.
         from src.shared.trace import new_trace_id
-        result = await lane_manager.enqueue(agent_id, message, mode="steer", trace_id=new_trace_id())
+        from src.shared.types import MessageOrigin
+        origin = MessageOrigin(
+            kind="human",
+            channel="dashboard",
+            user=_operator_session_id(request),
+        )
+        result = await lane_manager.enqueue(
+            agent_id, message, mode="steer",
+            trace_id=new_trace_id(), origin=origin,
+        )
         return {"result": result}
 
     @api_router.post("/api/agents/{agent_id}/reset")

--- a/src/host/lanes.py
+++ b/src/host/lanes.py
@@ -19,7 +19,7 @@ from collections.abc import Callable, Coroutine
 from dataclasses import dataclass, field
 from typing import Any
 
-from src.shared.types import SILENT_REPLY_TOKEN
+from src.shared.types import SILENT_REPLY_TOKEN, MessageOrigin
 from src.shared.utils import generate_id, setup_logging
 
 logger = setup_logging("host.lanes")
@@ -36,7 +36,10 @@ class QueuedTask:
     message: str
     mode: str = "followup"
     trace_id: str | None = None
-    origin: dict[str, str] | None = None
+    # Task 2b: stamp sites now produce typed ``MessageOrigin``. Legacy
+    # dict shape still accepted during the migration window for paths
+    # that have not been flipped yet (Task 2c will do the recheck).
+    origin: MessageOrigin | dict[str, str] | None = None
     auto_notify: bool = False
     future: asyncio.Future = field(default_factory=asyncio.Future)
 
@@ -81,7 +84,7 @@ class LaneManager:
     async def enqueue(
         self, agent: str, message: str, *, mode: str = "followup",
         trace_id: str | None = None,
-        origin: dict[str, str] | None = None,
+        origin: MessageOrigin | dict[str, str] | None = None,
         auto_notify: bool = False,
     ) -> str:
         """Queue a message for an agent with the specified mode.
@@ -109,7 +112,7 @@ class LaneManager:
 
     async def _handle_followup(
         self, agent: str, message: str, *, trace_id: str | None = None,
-        origin: dict[str, str] | None = None,
+        origin: MessageOrigin | dict[str, str] | None = None,
         auto_notify: bool = False,
     ) -> str:
         """Standard FIFO enqueue."""

--- a/src/host/server.py
+++ b/src/host/server.py
@@ -421,14 +421,23 @@ def create_mesh_app(
             wake_msg = f"You have a new task from {caller}. Call check_inbox() to see it."
 
         from src.shared.trace import parse_origin_header
+        from src.shared.types import MessageOrigin
         origin = parse_origin_header(request.headers.get("x-origin"))
+        # Task 2b: missing/invalid origin downgrades to ``kind="agent"``
+        # (least-trusted) instead of ``None`` so downstream gates always
+        # see an explicit kind. Auto-notify still gated on the original
+        # origin presence — agent-default wakes have no addressable
+        # channel/user, so there is no notification target.
+        had_origin = origin is not None
+        if origin is None:
+            origin = MessageOrigin(kind="agent", channel="", user="")
 
         if lane_manager is not None and dispatch_loop is not None:
             try:
                 asyncio.run_coroutine_threadsafe(
                     lane_manager.enqueue(
                         target, wake_msg, mode="followup",
-                        origin=origin, auto_notify=origin is not None,
+                        origin=origin, auto_notify=had_origin,
                     ),
                     dispatch_loop,
                 )

--- a/tests/test_agent_server.py
+++ b/tests/test_agent_server.py
@@ -792,12 +792,39 @@ class TestChatOriginHeader:
             resp = await client.post(
                 "/chat",
                 json={"message": "hello"},
-                headers={"x-origin": wire},
+                headers={"x-origin": wire, "x-mesh-internal": "1"},
             )
         assert resp.status_code == 200
         passed = mock_loop.chat.call_args.kwargs.get("origin")
         assert isinstance(passed, MessageOrigin)
         assert passed.kind == "human"
+        assert passed.channel == "dashboard"
+        assert passed.user == "op-1"
+
+    @pytest.mark.asyncio
+    async def test_chat_typed_human_origin_direct_call_downgrades(self):
+        """Direct non-mesh callers cannot self-assert human origin."""
+        from src.shared.types import MessageOrigin
+
+        app, mock_loop = _make_app()
+        mock_loop.chat = AsyncMock(return_value={
+            "response": "hi", "tool_outputs": [], "tokens_used": 0,
+        })
+        mock_loop.current_task = None
+
+        wire = MessageOrigin(
+            kind="human", channel="dashboard", user="op-1",
+        ).to_header_value()
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+            resp = await client.post(
+                "/chat",
+                json={"message": "hello"},
+                headers={"x-origin": wire},
+            )
+        assert resp.status_code == 200
+        passed = mock_loop.chat.call_args.kwargs.get("origin")
+        assert isinstance(passed, MessageOrigin)
+        assert passed.kind == "agent"
         assert passed.channel == "dashboard"
         assert passed.user == "op-1"
 
@@ -833,7 +860,7 @@ class TestHeartbeatOriginContextVar:
             resp = await client.post(
                 "/heartbeat",
                 json={"message": "tick"},
-                headers={"x-origin": wire},
+                headers={"x-origin": wire, "x-mesh-internal": "1"},
             )
         assert resp.status_code == 200
         assert len(captured) == 1

--- a/tests/test_agent_server.py
+++ b/tests/test_agent_server.py
@@ -773,3 +773,91 @@ class TestChatOriginHeader:
         assert resp.status_code == 200
         call_kwargs = mock_loop.chat.call_args.kwargs
         assert call_kwargs.get("origin") is None
+
+    @pytest.mark.asyncio
+    async def test_chat_typed_human_origin_preserved(self):
+        """Task 2b: X-Origin with kind="human" reaches loop.chat untouched."""
+        from src.shared.types import MessageOrigin
+
+        app, mock_loop = _make_app()
+        mock_loop.chat = AsyncMock(return_value={
+            "response": "hi", "tool_outputs": [], "tokens_used": 0,
+        })
+        mock_loop.current_task = None
+
+        wire = MessageOrigin(
+            kind="human", channel="dashboard", user="op-1",
+        ).to_header_value()
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+            resp = await client.post(
+                "/chat",
+                json={"message": "hello"},
+                headers={"x-origin": wire},
+            )
+        assert resp.status_code == 200
+        passed = mock_loop.chat.call_args.kwargs.get("origin")
+        assert isinstance(passed, MessageOrigin)
+        assert passed.kind == "human"
+        assert passed.channel == "dashboard"
+        assert passed.user == "op-1"
+
+
+# ── Task 2b: heartbeat endpoint stamps kind="heartbeat" on contextvar ──
+
+
+class TestHeartbeatOriginContextVar:
+    @pytest.mark.asyncio
+    async def test_heartbeat_typed_origin_sets_contextvar(self):
+        """POST /heartbeat with kind="heartbeat" origin populates the
+        ``current_origin`` contextvar so any tool / coordination call
+        made during the run sees the typed origin.
+        """
+        from src.shared.trace import current_origin
+        from src.shared.types import MessageOrigin
+
+        app, mock_loop = _make_app()
+        captured: list = []
+
+        async def _capture_heartbeat(_msg):
+            # Read the contextvar from inside the heartbeat run — that's
+            # what tools (e.g. coordination_tool.hand_off) will see.
+            captured.append(current_origin.get())
+            return {"response": "ok", "outcome": "ok", "skipped": False}
+
+        mock_loop.execute_heartbeat = AsyncMock(side_effect=_capture_heartbeat)
+
+        wire = MessageOrigin(
+            kind="heartbeat", channel="heartbeat", user="",
+        ).to_header_value()
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+            resp = await client.post(
+                "/heartbeat",
+                json={"message": "tick"},
+                headers={"x-origin": wire},
+            )
+        assert resp.status_code == 200
+        assert len(captured) == 1
+        seen = captured[0]
+        assert isinstance(seen, MessageOrigin)
+        assert seen.kind == "heartbeat"
+
+    @pytest.mark.asyncio
+    async def test_heartbeat_no_origin_header_leaves_contextvar_none(self):
+        """Heartbeat without X-Origin keeps contextvar at None — the
+        agent loop only stamps when an origin was explicitly provided.
+        """
+        from src.shared.trace import current_origin
+
+        app, mock_loop = _make_app()
+        captured: list = []
+
+        async def _capture_heartbeat(_msg):
+            captured.append(current_origin.get())
+            return {"response": "ok", "outcome": "ok", "skipped": False}
+
+        mock_loop.execute_heartbeat = AsyncMock(side_effect=_capture_heartbeat)
+
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+            resp = await client.post("/heartbeat", json={"message": "tick"})
+        assert resp.status_code == 200
+        assert captured == [None]

--- a/tests/test_channels.py
+++ b/tests/test_channels.py
@@ -819,7 +819,10 @@ class TestTelegramStop:
 class TestChannelTypeAndOriginPropagation:
     @pytest.mark.asyncio
     async def test_channel_type_included_in_origin(self):
-        """When CHANNEL_TYPE is set, dispatch receives origin with channel+user."""
+        """When CHANNEL_TYPE is set, dispatch receives a typed MessageOrigin
+        with kind="human", channel=CHANNEL_TYPE, user=user_id (Task 2b)."""
+        from src.shared.types import MessageOrigin
+
         received_origins = []
 
         async def recording_dispatch(agent, message, **kwargs):
@@ -835,7 +838,9 @@ class TestChannelTypeAndOriginPropagation:
         )
 
         await ch.handle_message("user42", "hello")
-        assert received_origins == [{"channel": "testchannel", "user": "user42"}]
+        assert received_origins == [
+            MessageOrigin(kind="human", channel="testchannel", user="user42"),
+        ]
 
     @pytest.mark.asyncio
     async def test_no_channel_type_origin_is_none(self):

--- a/tests/test_cli_commands.py
+++ b/tests/test_cli_commands.py
@@ -1394,3 +1394,66 @@ class TestShellCompletion:
             result = _complete_agent_names(None, None, "c")
             assert "coder" in result
             assert "researcher" not in result
+
+
+# ── Task 2b: CLI REPL stamps human/cli origin on dispatch ──
+
+
+class TestREPLOriginStamp:
+    """``_send_message_streaming`` must stamp ``X-Origin: kind=human``
+    on every CLI-initiated request so the agent / lane sees a typed
+    origin instead of a missing or legacy header.
+    """
+
+    def test_streaming_dispatch_sends_typed_human_origin_header(self):
+        import asyncio
+        import threading
+        from unittest.mock import AsyncMock, MagicMock
+
+        from src.cli.repl import _send_message_streaming
+        from src.host.transport import HttpTransport
+        from src.shared.types import MessageOrigin
+
+        captured_headers: list = []
+
+        async def _fake_stream(*_args, **kwargs):
+            captured_headers.append(kwargs.get("headers"))
+            yield {"type": "done", "response": "ok"}
+
+        transport = MagicMock(spec=HttpTransport)
+        transport.stream_request = _fake_stream
+        transport.request = AsyncMock(return_value={"response": "ok"})
+
+        # _send_message_streaming uses run_coroutine_threadsafe — needs
+        # a real running event loop in a background thread.
+        dispatch_loop = asyncio.new_event_loop()
+        ready = threading.Event()
+
+        def _run():
+            asyncio.set_event_loop(dispatch_loop)
+            dispatch_loop.call_soon(ready.set)
+            dispatch_loop.run_forever()
+
+        t = threading.Thread(target=_run, daemon=True)
+        t.start()
+        ready.wait()
+
+        try:
+            with patch.dict(os.environ, {"USER": "alice"}):
+                _send_message_streaming(
+                    transport, "researcher", "do thing",
+                    dispatch_loop=dispatch_loop,
+                )
+        finally:
+            dispatch_loop.call_soon_threadsafe(dispatch_loop.stop)
+            t.join(timeout=2)
+            dispatch_loop.close()
+
+        assert captured_headers, "stream_request was never invoked"
+        hdrs = captured_headers[0] or {}
+        assert "X-Origin" in hdrs
+        parsed = MessageOrigin.from_header_value(hdrs["X-Origin"])
+        assert parsed is not None
+        assert parsed.kind == "human"
+        assert parsed.channel == "cli"
+        assert parsed.user == "alice"

--- a/tests/test_cron.py
+++ b/tests/test_cron.py
@@ -188,6 +188,44 @@ class TestCronDispatch:
         result = await sched.run_job("nonexistent")
         assert result is None
 
+    # ── Task 2b: cron_dispatch wrapper stamps kind="cron" origin ────
+
+    @pytest.mark.asyncio
+    async def test_cron_dispatch_wrapper_stamps_typed_origin(self):
+        """``RuntimeContext._create_cron_scheduler``'s ``cron_dispatch``
+        wrapper must pass a typed ``MessageOrigin(kind="cron")`` through
+        to ``async_dispatch`` so the lane sees a typed origin instead
+        of ``None``.
+        """
+        from src.cli.runtime import RuntimeContext
+        from src.shared.types import MessageOrigin
+
+        # Synthesize a minimal RuntimeContext with stub dependencies.
+        ctx = RuntimeContext.__new__(RuntimeContext)
+        captured = {}
+
+        async def _fake_async_dispatch(agent, message, **kwargs):
+            captured["agent"] = agent
+            captured["message"] = message
+            captured.update(kwargs)
+            return "ok"
+
+        ctx.async_dispatch = _fake_async_dispatch
+        ctx.transport = MagicMock()
+        ctx.blackboard = None
+        ctx.trace_store = None
+        ctx.event_bus = None
+        ctx.cfg = {}
+
+        ctx._create_cron_scheduler()
+        # The cron_dispatch closure was registered as ``dispatch_fn``.
+        await ctx.cron_scheduler.dispatch_fn("agent1", "tick")
+        origin = captured.get("origin")
+        assert isinstance(origin, MessageOrigin)
+        assert origin.kind == "cron"
+        assert origin.channel == "cron"
+        assert origin.user == ""
+
 
 class TestHeartbeat:
     def setup_method(self):

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -4446,3 +4446,64 @@ class TestSpaCatchallChannelsExclusion:
     def test_mesh_path_still_returns_404(self):
         resp = self.client.get("/mesh/agents")
         assert resp.status_code == 404
+
+
+# ── Task 2b: dashboard stamps human-origin on chat / steer ──
+
+
+class TestDashboardOriginStamp:
+    def setup_method(self):
+        self._tmpdir = tempfile.mkdtemp()
+        self.components = _make_components(self._tmpdir, include_v2=True)
+        self.client = _make_client(self.components)
+
+    def teardown_method(self):
+        _teardown(self.components)
+        shutil.rmtree(self._tmpdir, ignore_errors=True)
+
+    def _origin_from(self, headers: dict | None) -> dict | None:
+        from src.shared.types import MessageOrigin
+        if not headers:
+            return None
+        wire = headers.get("X-Origin") or headers.get("x-origin")
+        if not wire:
+            return None
+        parsed = MessageOrigin.from_header_value(wire)
+        return parsed
+
+    def test_api_chat_stamps_human_dashboard_origin(self):
+        """POST /api/agents/{id}/chat sets X-Origin: kind=human, channel=dashboard."""
+        from src.shared.types import MessageOrigin
+
+        self.components["transport"].request = AsyncMock(
+            return_value={"response": "hi"},
+        )
+        resp = self.client.post(
+            "/dashboard/api/agents/alpha/chat",
+            json={"message": "hello"},
+        )
+        assert resp.status_code == 200
+        call = self.components["transport"].request.await_args
+        hdrs = call.kwargs.get("headers")
+        parsed = self._origin_from(hdrs)
+        assert isinstance(parsed, MessageOrigin)
+        assert parsed.kind == "human"
+        assert parsed.channel == "dashboard"
+        # ``user`` is the operator session digest (or "operator" in dev).
+        assert parsed.user
+
+    def test_api_steer_stamps_human_origin(self):
+        """POST /api/agents/{id}/steer enqueues with kind="human" origin."""
+        from src.shared.types import MessageOrigin
+
+        self.components["lane_manager"].enqueue = AsyncMock(return_value="steered")
+        resp = self.client.post(
+            "/dashboard/api/agents/alpha/steer",
+            json={"message": "hold up"},
+        )
+        assert resp.status_code == 200
+        call = self.components["lane_manager"].enqueue.await_args
+        origin = call.kwargs.get("origin")
+        assert isinstance(origin, MessageOrigin)
+        assert origin.kind == "human"
+        assert origin.channel == "dashboard"

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -2100,8 +2100,15 @@ def test_mesh_wake_propagates_origin_header(tmp_path):
 
 
 def test_mesh_wake_no_origin_header_disables_auto_notify(tmp_path):
-    """POST /mesh/wake without X-Origin enqueues with origin=None, auto_notify=False."""
+    """POST /mesh/wake without X-Origin downgrades to kind="agent" (Task 2b).
+
+    Auto-notify stays disabled because there's no addressable channel/user
+    to notify, but the origin itself is no longer ``None`` — every lane
+    payload now carries an explicit ``kind`` from this slice forward.
+    """
     import time
+
+    from src.shared.types import MessageOrigin
 
     client, captured, loop, bb = _wake_test_app(tmp_path)
     try:
@@ -2116,7 +2123,10 @@ def test_mesh_wake_no_origin_header_disables_auto_notify(tmp_path):
             time.sleep(0.01)
         assert captured
         call = captured[0]
-        assert call["origin"] is None
+        assert isinstance(call["origin"], MessageOrigin)
+        assert call["origin"].kind == "agent"
+        assert call["origin"].channel == ""
+        assert call["origin"].user == ""
         assert call["auto_notify"] is False
     finally:
         loop.call_soon_threadsafe(loop.stop)
@@ -2124,8 +2134,10 @@ def test_mesh_wake_no_origin_header_disables_auto_notify(tmp_path):
 
 
 def test_mesh_wake_invalid_origin_header_ignored(tmp_path):
-    """POST /mesh/wake with malformed X-Origin is treated as no origin."""
+    """POST /mesh/wake with malformed X-Origin downgrades to kind="agent"."""
     import time
+
+    from src.shared.types import MessageOrigin
 
     client, captured, loop, bb = _wake_test_app(tmp_path)
     try:
@@ -2139,7 +2151,8 @@ def test_mesh_wake_invalid_origin_header_ignored(tmp_path):
         while not captured and time.monotonic() < deadline:
             time.sleep(0.01)
         assert captured
-        assert captured[0]["origin"] is None
+        assert isinstance(captured[0]["origin"], MessageOrigin)
+        assert captured[0]["origin"].kind == "agent"
         assert captured[0]["auto_notify"] is False
     finally:
         loop.call_soon_threadsafe(loop.stop)


### PR DESCRIPTION
## Summary

Second slice of **Task 2** (origin as authorization input). Task 2a (#823) introduced the typed `MessageOrigin` model. This slice flips every stamp site so the contextvar always carries a typed origin from this point forward. Task 2c (channel pairing recheck), 2d (pending-actions migration), and 2e (`/mesh/wake` worker→operator block) can then rely on every channel-origin being typed.

**Branch base:** `feat/origin-typed-model` (PR #823) → `test/characterization-tier1` (#822) → `fix/operator-handoff-hotfix` (#821) → `main`.

## Stamp sites flipped

| Site | `kind` | Notes |
|---|---|---|
| CLI REPL streaming dispatch + sandbox fallback + `/steer` + auto-steer + inline steer-poll | `human` | `channel="cli"`, `user=$USER` |
| Dashboard `/api/agents/{id}/chat` + `chat/stream` + `steer` + `broadcast` + `broadcast/stream` | `human` | `channel="dashboard"`, `user=session uid` |
| Channel adapter base `handle_message` (telegram/discord/slack/whatsapp/webhook) | `human` | preserves today's pairing-allowlisted identity, just typed |
| Cron dispatch wrapper | `cron` | `channel="cron"` |
| Heartbeat dispatch wrapper | `heartbeat` | `channel="heartbeat"` |
| Agent `/heartbeat` endpoint | parses + sets contextvar | so the heartbeat run sees its own origin |
| `/mesh/wake` missing/invalid `X-Origin` | downgrade to `kind="agent"` | never fabricates a human claim |

## Notable details

- **Lane manager type widened** to `MessageOrigin | dict | None` — passes through whatever stamp-site emitted. `dict(task.origin)` still works on the typed model via Pydantic iteration.
- **`coordination_tool` task_record** stores `origin.model_dump()` when given a Pydantic instance so httpx JSON serialization works; legacy dicts still pass through.
- **The Task 2a deprecation breadcrumb** in `trace.py:origin_header` stays silent for migrated paths and remains in place to catch any future stamp site that backslides into legacy dict construction.
- **Discovered stamp sites not on the original list:** `/api/broadcast` + `broadcast/stream`, three CLI REPL `/steer` variants, agent container's `/heartbeat` endpoint. All stamped.

## What's deliberately NOT in this PR

- Channel pairing recheck (Task 2c).
- SQLite `pending_actions` migration (Task 2d).
- `/mesh/wake` worker → operator block (Task 2e — flips one of #822's capture-to-tighten tests).
- No permission-gate behavior changes.

## Test plan

- [x] `pytest tests/test_coordination.py tests/test_message_origin.py tests/test_lanes.py` after rebase — 106 passed
- [x] Targeted suite (12 files including all stamp sites) — 842 passed, 15 skipped
- [x] Full non-E2E suite — 4984 passed, 44 skipped, 0 failures
- [x] Deprecation breadcrumb silent for all migrated paths (verified)
- [x] Existing tests with `origin == {…}` dict assertions updated to typed shape

## Stack

1. #821 — Task 0 hotfix ✅ green
2. #822 — Task 1 characterization tests
3. #823 — Task 2a typed model
4. **This PR** — Task 2b stamp sites
5. (next) Task 2c channel pairing recheck
6. (then) Task 2d pending-actions migration, 2e wake-block