### PR TITLE
feat(origin): server-side channel pairing recheck (Task 2c)

### DIFF
--- a/src/host/server.py
+++ b/src/host/server.py
@@ -20,6 +20,7 @@ import uuid as _uuid
 from collections import defaultdict
 from collections.abc import Callable, Coroutine
 from datetime import datetime, timedelta, timezone
+from pathlib import Path
 from typing import TYPE_CHECKING
 
 from fastapi import FastAPI, HTTPException, Request, WebSocket
@@ -75,6 +76,7 @@ if TYPE_CHECKING:
     from src.host.runtime import RuntimeBackend
     from src.host.traces import TraceStore
     from src.host.transport import Transport
+    from src.shared.types import MessageOrigin
 
 
 # ── Pending Config Change Store (in-memory) ──────────────────────
@@ -113,6 +115,145 @@ def _get_pending_change(change_id: str) -> dict | None:
 def _consume_pending_change(change_id: str) -> dict | None:
     _cleanup_expired_changes()
     return _pending_changes.pop(change_id, None)
+
+
+# ── Task 2c: Server-side channel origin validation ────────────────
+#
+# When an inbound HTTP request carries ``X-Origin`` with ``kind="human"``
+# and a channel name from the messaging-channel set, the mesh re-checks
+# the claim against the on-disk pairing record (``config/<channel>_paired.json``).
+# A buggy or hostile adapter could otherwise elevate origin to ``human``
+# for any user id; this defense-in-depth gate downgrades unverifiable
+# claims to ``kind="agent"`` (least-trusted) before they reach
+# authorization-sensitive code paths (``/mesh/wake``, durable confirms,
+# etc.). Failure is silent (warning log only, never raises) so a forged
+# header cannot crash a request.
+#
+# CLI and dashboard origins are intentionally NOT in the paired set —
+# their authentication happens at a different layer (process identity
+# for CLI, ``ol_session`` cookie for dashboard).
+_PAIRED_CHANNELS = frozenset({"telegram", "discord", "slack", "whatsapp", "webhook"})
+
+# Tiny TTL cache for pairing-record reads. The on-disk file changes only
+# on ``/pair`` operations, which are rare. 5s staleness is acceptable for
+# a defense-in-depth gate; ``_invalidate_pairing_cache`` lets the pair/
+# unpair flow drop a stale entry on demand.
+_pairing_cache: dict[str, tuple[float, dict | None]] = {}
+_PAIRING_CACHE_TTL = 5.0
+
+
+def _read_pairing_record(channel: str) -> dict | None:
+    """Read the pairing JSON for a channel.
+
+    Returns ``None`` if missing, malformed, or unreadable. Cached for
+    ``_PAIRING_CACHE_TTL`` seconds keyed on channel name.
+    """
+    cached = _pairing_cache.get(channel)
+    if cached and time.monotonic() - cached[0] < _PAIRING_CACHE_TTL:
+        return cached[1]
+    path = Path("config") / f"{channel}_paired.json"
+    record: dict | None
+    if not path.exists():
+        record = None
+    else:
+        try:
+            raw = path.read_text()
+            parsed = json.loads(raw)
+            record = parsed if isinstance(parsed, dict) else None
+        except (json.JSONDecodeError, OSError):
+            record = None
+    _pairing_cache[channel] = (time.monotonic(), record)
+    return record
+
+
+def _invalidate_pairing_cache(channel: str | None = None) -> None:
+    """Drop the cached pairing record for ``channel`` (or all channels).
+
+    Pair/unpair endpoints can call this to force a fresh read on the
+    next ``/mesh/wake`` (or other validated-origin) request. When called
+    with no argument, clears the entire cache — useful in tests.
+    """
+    if channel is None:
+        _pairing_cache.clear()
+        return
+    _pairing_cache.pop(channel, None)
+
+
+def _is_paired_user(channel: str, user: str) -> bool:
+    """Check if ``user`` is paired for ``channel``.
+
+    Mirrors :meth:`PairingManager.is_allowed` semantics: owner match OR
+    membership in the allowed list. Comparisons are stringified so
+    Telegram numeric ids and Slack/Discord string ids round-trip the
+    same way.
+    """
+    record = _read_pairing_record(channel)
+    if not record:
+        return False
+    owner = record.get("owner")
+    allowed = record.get("allowed", [])
+    if not isinstance(allowed, list):
+        allowed = []
+    if owner is not None and str(owner) == str(user):
+        return True
+    return str(user) in (str(u) for u in allowed)
+
+
+def _validated_origin(request: Request) -> "MessageOrigin | None":
+    """Parse ``X-Origin`` and downgrade unverifiable channel claims.
+
+    This is the authorization-grade origin getter — endpoints that care
+    about an origin's trust level (durable confirms, wakes, pending
+    actions) must use this instead of :func:`parse_origin_header`.
+
+    Behaviour:
+
+    * Missing/malformed header → ``None`` (caller decides what default
+      to use; ``/mesh/wake`` falls back to ``MessageOrigin(kind="agent")``).
+    * ``kind != "human"`` → returned unchanged (only human claims need
+      pairing recheck; agent/heartbeat/cron/system/operator either come
+      from internal stamping or have their own auth path).
+    * ``kind == "human"`` with a non-paired channel (cli, dashboard,
+      anything not in ``_PAIRED_CHANNELS``) → returned unchanged. Their
+      auth happens at a different layer.
+    * ``kind == "human"`` with a paired channel and a paired user →
+      returned unchanged.
+    * ``kind == "human"`` with a paired channel and an unpaired/empty
+      user → downgraded to ``kind="agent"`` (warning logged).
+
+    The helper never raises: a forged X-Origin header must not crash a
+    request. ``MessageOrigin`` is ``frozen=True`` (Task 2a), so the
+    downgrade is via :meth:`pydantic.BaseModel.model_copy`, not mutation.
+    """
+    from src.shared.types import MessageOrigin
+
+    raw = request.headers.get("x-origin")
+    # Use ``trust_kind=True`` here because we deliberately want to see
+    # the caller-supplied kind so we can validate it. The validation
+    # below either preserves it (for verified channel claims) or
+    # downgrades it. ``parse_origin_header`` (trust_kind=False) is
+    # still the right call for trace-only / non-authorization paths.
+    origin = MessageOrigin.from_header_value(raw, trust_kind=True)
+    if origin is None:
+        return None
+    if origin.kind != "human":
+        return origin
+    if origin.channel not in _PAIRED_CHANNELS:
+        return origin
+    if not origin.user:
+        logger.warning(
+            "channel origin recheck failed: channel=%s empty user — downgrading to kind=agent",
+            origin.channel,
+        )
+        return origin.model_copy(update={"kind": "agent"})
+    if _is_paired_user(origin.channel, origin.user):
+        return origin
+    logger.warning(
+        "channel origin recheck failed: channel=%s user=%s — downgrading to kind=agent",
+        origin.channel,
+        origin.user,
+    )
+    return origin.model_copy(update={"kind": "agent"})
 
 
 def create_mesh_app(
@@ -420,9 +561,13 @@ def create_mesh_app(
         else:
             wake_msg = f"You have a new task from {caller}. Call check_inbox() to see it."
 
-        from src.shared.trace import parse_origin_header
         from src.shared.types import MessageOrigin
-        origin = parse_origin_header(request.headers.get("x-origin"))
+        # Task 2c: ``_validated_origin`` re-checks ``kind="human"``
+        # channel claims against the on-disk pairing record. Forged or
+        # unverifiable claims are downgraded to ``kind="agent"`` so the
+        # lane payload (and any downstream auth gate that will be added
+        # in Task 2d/2e) cannot be tricked by a hostile/buggy adapter.
+        origin = _validated_origin(request)
         # Task 2b: missing/invalid origin downgrades to ``kind="agent"``
         # (least-trusted) instead of ``None`` so downstream gates always
         # see an explicit kind. Auto-notify still gated on the original

--- a/src/host/server.py
+++ b/src/host/server.py
@@ -20,7 +20,6 @@ import uuid as _uuid
 from collections import defaultdict
 from collections.abc import Callable, Coroutine
 from datetime import datetime, timedelta, timezone
-from pathlib import Path
 from typing import TYPE_CHECKING
 
 from fastapi import FastAPI, HTTPException, Request, WebSocket
@@ -119,20 +118,13 @@ def _consume_pending_change(change_id: str) -> dict | None:
 
 # ── Task 2c: Server-side channel origin validation ────────────────
 #
-# When an inbound HTTP request carries ``X-Origin`` with ``kind="human"``
-# and a channel name from the messaging-channel set, the mesh re-checks
-# the claim against the on-disk pairing record (``config/<channel>_paired.json``).
-# A buggy or hostile adapter could otherwise elevate origin to ``human``
-# for any user id; this defense-in-depth gate downgrades unverifiable
-# claims to ``kind="agent"`` (least-trusted) before they reach
-# authorization-sensitive code paths (``/mesh/wake``, durable confirms,
-# etc.). Failure is silent (warning log only, never raises) so a forged
-# header cannot crash a request.
-#
-# CLI and dashboard origins are intentionally NOT in the paired set —
-# their authentication happens at a different layer (process identity
-# for CLI, ``ol_session`` cookie for dashboard).
+# ``X-Origin`` is authorization-bearing only after the mesh has a reason
+# to trust the stamping layer. Paired messaging channels are re-checked
+# against their on-disk pairing record; non-paired human channels and
+# privileged non-human kinds are preserved only for trusted callers such
+# as the operator or loopback-internal mesh calls.
 _PAIRED_CHANNELS = frozenset({"telegram", "discord", "slack", "whatsapp", "webhook"})
+_TRUSTED_ORIGIN_CALLERS = frozenset({"mesh", "operator"})
 
 # Tiny TTL cache for pairing-record reads. The on-disk file changes only
 # on ``/pair`` operations, which are rare. 5s staleness is acceptable for
@@ -151,7 +143,8 @@ def _read_pairing_record(channel: str) -> dict | None:
     cached = _pairing_cache.get(channel)
     if cached and time.monotonic() - cached[0] < _PAIRING_CACHE_TTL:
         return cached[1]
-    path = Path("config") / f"{channel}_paired.json"
+    from src.cli.config import PROJECT_ROOT
+    path = PROJECT_ROOT / "config" / f"{channel}_paired.json"
     record: dict | None
     if not path.exists():
         record = None
@@ -199,7 +192,32 @@ def _is_paired_user(channel: str, user: str) -> bool:
     return str(user) in (str(u) for u in allowed)
 
 
-def _validated_origin(request: Request) -> "MessageOrigin | None":
+def _is_loopback_internal_request(request: Request) -> bool:
+    """Return true only for the existing localhost mesh-internal trust path."""
+    if not request.headers.get("x-mesh-internal"):
+        return False
+    client_host = request.client.host if request.client else ""
+    try:
+        import ipaddress
+        return ipaddress.ip_address(client_host).is_loopback
+    except (ValueError, AttributeError):
+        return False
+
+
+def _downgrade_origin(origin: "MessageOrigin", reason: str) -> "MessageOrigin":
+    logger.warning(
+        "origin validation failed: %s kind=%s channel=%s user=%s — downgrading to kind=agent",
+        reason,
+        origin.kind,
+        origin.channel,
+        origin.user,
+    )
+    return origin.model_copy(update={"kind": "agent"})
+
+
+def _validated_origin(
+    request: Request, caller: str = "",
+) -> "MessageOrigin | None":
     """Parse ``X-Origin`` and downgrade unverifiable channel claims.
 
     This is the authorization-grade origin getter — endpoints that care
@@ -210,12 +228,10 @@ def _validated_origin(request: Request) -> "MessageOrigin | None":
 
     * Missing/malformed header → ``None`` (caller decides what default
       to use; ``/mesh/wake`` falls back to ``MessageOrigin(kind="agent")``).
-    * ``kind != "human"`` → returned unchanged (only human claims need
-      pairing recheck; agent/heartbeat/cron/system/operator either come
-      from internal stamping or have their own auth path).
-    * ``kind == "human"`` with a non-paired channel (cli, dashboard,
-      anything not in ``_PAIRED_CHANNELS``) → returned unchanged. Their
-      auth happens at a different layer.
+    * Trusted caller (operator/mesh or loopback internal) → returned unchanged.
+    * ``kind == "agent"`` → returned unchanged.
+    * Privileged non-human kinds from other callers → downgraded.
+    * ``kind == "human"`` with a non-paired channel → downgraded.
     * ``kind == "human"`` with a paired channel and a paired user →
       returned unchanged.
     * ``kind == "human"`` with a paired channel and an unpaired/empty
@@ -236,24 +252,19 @@ def _validated_origin(request: Request) -> "MessageOrigin | None":
     origin = MessageOrigin.from_header_value(raw, trust_kind=True)
     if origin is None:
         return None
+    if caller in _TRUSTED_ORIGIN_CALLERS or _is_loopback_internal_request(request):
+        return origin
+    if origin.kind == "agent":
+        return origin
     if origin.kind != "human":
-        return origin
+        return _downgrade_origin(origin, "untrusted non-human origin kind")
     if origin.channel not in _PAIRED_CHANNELS:
-        return origin
+        return _downgrade_origin(origin, "unverifiable human origin channel")
     if not origin.user:
-        logger.warning(
-            "channel origin recheck failed: channel=%s empty user — downgrading to kind=agent",
-            origin.channel,
-        )
-        return origin.model_copy(update={"kind": "agent"})
+        return _downgrade_origin(origin, "empty paired-channel user")
     if _is_paired_user(origin.channel, origin.user):
         return origin
-    logger.warning(
-        "channel origin recheck failed: channel=%s user=%s — downgrading to kind=agent",
-        origin.channel,
-        origin.user,
-    )
-    return origin.model_copy(update={"kind": "agent"})
+    return _downgrade_origin(origin, "unpaired channel user")
 
 
 def create_mesh_app(
@@ -567,7 +578,7 @@ def create_mesh_app(
         # unverifiable claims are downgraded to ``kind="agent"`` so the
         # lane payload (and any downstream auth gate that will be added
         # in Task 2d/2e) cannot be tricked by a hostile/buggy adapter.
-        origin = _validated_origin(request)
+        origin = _validated_origin(request, caller)
         # Task 2b: missing/invalid origin downgrades to ``kind="agent"``
         # (least-trusted) instead of ``None`` so downstream gates always
         # see an explicit kind. Auto-notify still gated on the original

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -2372,3 +2372,352 @@ class TestHandleNotifyOrigin:
             "hi",
             "chef",
         )
+
+
+# ── Task 2c: server-side channel origin pairing recheck ──────────
+
+
+class _ReqHeaders:
+    """Minimal stand-in for ``Request.headers`` (case-insensitive get)."""
+
+    def __init__(self, mapping: dict[str, str]) -> None:
+        self._lower = {k.lower(): v for k, v in mapping.items()}
+
+    def get(self, key: str, default: str | None = None) -> str | None:
+        return self._lower.get(key.lower(), default)
+
+
+class _FakeRequest:
+    def __init__(self, headers: dict[str, str]) -> None:
+        self.headers = _ReqHeaders(headers)
+
+
+def _write_pairing(tmp_path, channel: str, payload: dict | str) -> None:
+    cfg_dir = tmp_path / "config"
+    cfg_dir.mkdir(parents=True, exist_ok=True)
+    path = cfg_dir / f"{channel}_paired.json"
+    if isinstance(payload, str):
+        path.write_text(payload)
+    else:
+        import json as _json
+        path.write_text(_json.dumps(payload))
+
+
+def _origin_header(kind: str, channel: str, user: str) -> str:
+    import json as _json
+    return _json.dumps({"kind": kind, "channel": channel, "user": user})
+
+
+class TestValidatedOrigin:
+    """Server-side recheck of inbound ``X-Origin`` channel claims (Task 2c)."""
+
+    def setup_method(self):
+        from src.host.server import _invalidate_pairing_cache
+        _invalidate_pairing_cache()
+
+    def teardown_method(self):
+        from src.host.server import _invalidate_pairing_cache
+        _invalidate_pairing_cache()
+
+    def test_paired_user_keeps_kind_human(self, tmp_path, monkeypatch):
+        from src.host.server import _validated_origin
+        from src.shared.types import MessageOrigin
+
+        monkeypatch.chdir(tmp_path)
+        _write_pairing(tmp_path, "telegram", {"owner": 42, "allowed": [42]})
+        req = _FakeRequest({"x-origin": _origin_header("human", "telegram", "42")})
+        result = _validated_origin(req)
+        assert isinstance(result, MessageOrigin)
+        assert result.kind == "human"
+        assert result.channel == "telegram"
+        assert result.user == "42"
+
+    def test_paired_user_in_allowed_list_keeps_human(self, tmp_path, monkeypatch):
+        from src.host.server import _validated_origin
+
+        monkeypatch.chdir(tmp_path)
+        _write_pairing(tmp_path, "discord", {"owner": "owner-id", "allowed": ["alice", "bob"]})
+        req = _FakeRequest({"x-origin": _origin_header("human", "discord", "alice")})
+        result = _validated_origin(req)
+        assert result.kind == "human"
+        assert result.user == "alice"
+
+    def test_unpaired_user_downgraded_to_agent(self, tmp_path, monkeypatch):
+        from src.host.server import _validated_origin
+
+        monkeypatch.chdir(tmp_path)
+        _write_pairing(tmp_path, "telegram", {"owner": 42, "allowed": [42]})
+        req = _FakeRequest({"x-origin": _origin_header("human", "telegram", "9999")})
+        result = _validated_origin(req)
+        assert result.kind == "agent"
+        # Channel/user metadata preserved for downstream addressing.
+        assert result.channel == "telegram"
+        assert result.user == "9999"
+
+    def test_empty_user_downgraded(self, tmp_path, monkeypatch):
+        """A typed ``kind="human"`` header with empty user passes the
+        parser (``trust_kind=True`` skips the empty-user reject), so the
+        validator's own empty-user branch must catch it and downgrade
+        — an empty user id cannot be verified against any pairing list.
+        """
+        from src.host.server import _validated_origin
+
+        monkeypatch.chdir(tmp_path)
+        _write_pairing(tmp_path, "telegram", {"owner": 42, "allowed": [42]})
+        req = _FakeRequest(
+            {"x-origin": _origin_header("human", "telegram", "")},
+        )
+        result = _validated_origin(req)
+        assert result is not None
+        assert result.kind == "agent"
+        assert result.channel == "telegram"
+        assert result.user == ""
+
+    def test_missing_pairing_file_downgrades(self, tmp_path, monkeypatch):
+        from src.host.server import _validated_origin
+
+        monkeypatch.chdir(tmp_path)
+        # No config/telegram_paired.json at all.
+        req = _FakeRequest({"x-origin": _origin_header("human", "telegram", "42")})
+        result = _validated_origin(req)
+        assert result.kind == "agent"
+
+    def test_malformed_pairing_file_downgrades(self, tmp_path, monkeypatch):
+        from src.host.server import _validated_origin
+
+        monkeypatch.chdir(tmp_path)
+        _write_pairing(tmp_path, "telegram", "not-json-at-all{")
+        req = _FakeRequest({"x-origin": _origin_header("human", "telegram", "42")})
+        result = _validated_origin(req)
+        assert result.kind == "agent"
+
+    def test_pairing_file_non_dict_downgrades(self, tmp_path, monkeypatch):
+        from src.host.server import _validated_origin
+
+        monkeypatch.chdir(tmp_path)
+        _write_pairing(tmp_path, "telegram", "[1, 2, 3]")
+        req = _FakeRequest({"x-origin": _origin_header("human", "telegram", "42")})
+        result = _validated_origin(req)
+        assert result.kind == "agent"
+
+    def test_non_paired_channel_passes_through(self, tmp_path, monkeypatch):
+        """CLI / dashboard origins pass through unchanged — they have
+        their own auth (process identity, ol_session cookie)."""
+        from src.host.server import _validated_origin
+
+        monkeypatch.chdir(tmp_path)
+        # No pairing file for cli — and shouldn't matter, cli isn't
+        # in _PAIRED_CHANNELS.
+        req = _FakeRequest({"x-origin": _origin_header("human", "cli", "jeff")})
+        result = _validated_origin(req)
+        assert result.kind == "human"
+        assert result.channel == "cli"
+
+        req2 = _FakeRequest({"x-origin": _origin_header("human", "dashboard", "op-1")})
+        result2 = _validated_origin(req2)
+        assert result2.kind == "human"
+        assert result2.channel == "dashboard"
+
+    def test_unknown_channel_passes_through(self, tmp_path, monkeypatch):
+        """Channels not in the paired set pass through. Unknown channels
+        either have their own auth path or are caller-controlled metadata
+        (e.g., trace propagation)."""
+        from src.host.server import _validated_origin
+
+        monkeypatch.chdir(tmp_path)
+        req = _FakeRequest({"x-origin": _origin_header("human", "rss", "feed-1")})
+        result = _validated_origin(req)
+        assert result.kind == "human"
+        assert result.channel == "rss"
+
+    def test_non_human_kinds_pass_through(self, tmp_path, monkeypatch):
+        """cron / heartbeat / agent / system / operator never trigger
+        the pairing recheck — only human claims need verification."""
+        from src.host.server import _validated_origin
+
+        monkeypatch.chdir(tmp_path)
+        # No pairing file for any of these — should pass through anyway.
+        for kind in ("agent", "system", "heartbeat", "cron", "operator"):
+            req = _FakeRequest({"x-origin": _origin_header(kind, "telegram", "42")})
+            result = _validated_origin(req)
+            assert result is not None, f"kind={kind} should parse"
+            assert result.kind == kind, f"kind={kind} should pass through"
+
+    def test_no_origin_header_returns_none(self, tmp_path, monkeypatch):
+        from src.host.server import _validated_origin
+
+        monkeypatch.chdir(tmp_path)
+        req = _FakeRequest({})
+        assert _validated_origin(req) is None
+
+    def test_malformed_origin_header_returns_none(self, tmp_path, monkeypatch):
+        from src.host.server import _validated_origin
+
+        monkeypatch.chdir(tmp_path)
+        req = _FakeRequest({"x-origin": "not-json"})
+        assert _validated_origin(req) is None
+
+    def test_cache_ttl_serves_stale_within_window(self, tmp_path, monkeypatch):
+        """Reads inside the TTL window hit the cache. After TTL expires
+        the helper re-reads the file."""
+        from src.host import server as _server
+
+        monkeypatch.chdir(tmp_path)
+        _write_pairing(tmp_path, "telegram", {"owner": 42, "allowed": [42]})
+        req_paired = _FakeRequest(
+            {"x-origin": _origin_header("human", "telegram", "42")},
+        )
+        # Prime cache (records the current monotonic timestamp).
+        assert _server._validated_origin(req_paired).kind == "human"
+
+        # Revoke owner on disk → ``42`` is no longer paired.
+        _write_pairing(tmp_path, "telegram", {"owner": 99, "allowed": []})
+        # Within TTL → cached record still says owner=42 → still kind=human.
+        assert _server._validated_origin(req_paired).kind == "human"
+
+        # Force expiry by rewriting the cache entry with a stale timestamp
+        # (cleaner than monkeypatching the global ``time`` module).
+        cached = _server._pairing_cache.get("telegram")
+        assert cached is not None
+        _server._pairing_cache["telegram"] = (
+            cached[0] - _server._PAIRING_CACHE_TTL - 1.0,
+            cached[1],
+        )
+        # Next call re-reads → owner is now 99 → user 42 unpaired → downgrade.
+        assert _server._validated_origin(req_paired).kind == "agent"
+
+    def test_invalidate_cache_forces_reread(self, tmp_path, monkeypatch):
+        from src.host import server as _server
+
+        monkeypatch.chdir(tmp_path)
+        _write_pairing(tmp_path, "telegram", {"owner": 42, "allowed": [42]})
+        req = _FakeRequest({"x-origin": _origin_header("human", "telegram", "42")})
+        assert _server._validated_origin(req).kind == "human"
+
+        # Revoke on disk and invalidate.
+        _write_pairing(tmp_path, "telegram", {"owner": 42, "allowed": []})
+        _server._invalidate_pairing_cache("telegram")
+        # User 42 still owner → still paired.
+        assert _server._validated_origin(req).kind == "human"
+
+        # Now flip the owner.
+        _write_pairing(tmp_path, "telegram", {"owner": 99, "allowed": []})
+        _server._invalidate_pairing_cache("telegram")
+        assert _server._validated_origin(req).kind == "agent"
+
+    def test_invalidate_cache_global(self, tmp_path, monkeypatch):
+        """Invalidate with no argument clears all entries."""
+        from src.host import server as _server
+
+        monkeypatch.chdir(tmp_path)
+        _write_pairing(tmp_path, "telegram", {"owner": 42, "allowed": []})
+        _write_pairing(tmp_path, "discord", {"owner": "alice", "allowed": []})
+
+        req_t = _FakeRequest({"x-origin": _origin_header("human", "telegram", "42")})
+        req_d = _FakeRequest({"x-origin": _origin_header("human", "discord", "alice")})
+        assert _server._validated_origin(req_t).kind == "human"
+        assert _server._validated_origin(req_d).kind == "human"
+
+        _server._invalidate_pairing_cache()
+        assert _server._pairing_cache == {}
+
+    def test_pairing_record_with_non_list_allowed(self, tmp_path, monkeypatch):
+        """A malformed pairing record with non-list ``allowed`` falls back
+        gracefully — the helper must not raise on bad shapes."""
+        from src.host.server import _validated_origin
+
+        monkeypatch.chdir(tmp_path)
+        _write_pairing(tmp_path, "telegram", {"owner": 42, "allowed": "not-a-list"})
+        # User 42 is the owner → still paired (owner check doesn't touch allowed).
+        req_owner = _FakeRequest({"x-origin": _origin_header("human", "telegram", "42")})
+        assert _validated_origin(req_owner).kind == "human"
+        # User 9999 is neither owner nor in (treated-as-empty) allowed → downgrade.
+        req_other = _FakeRequest({"x-origin": _origin_header("human", "telegram", "9999")})
+        assert _validated_origin(req_other).kind == "agent"
+
+
+def test_mesh_wake_downgrades_unpaired_human_origin(tmp_path, monkeypatch):
+    """``/mesh/wake`` with ``kind="human"`` from an unpaired channel user
+    enqueues a lane payload with origin downgraded to ``kind="agent"``.
+
+    Wake itself still succeeds (current capture behaviour — Task 2e
+    will tighten worker→operator wakes). The lane payload's origin is
+    the authoritative trust signal that downstream gates will read.
+    """
+    import time
+
+    from src.host import server as _server
+    from src.shared.types import MessageOrigin
+
+    monkeypatch.chdir(tmp_path)
+    _server._invalidate_pairing_cache()
+    # Pair owner=42; the wake claim uses user=not-paired so the recheck
+    # downgrades.
+    _write_pairing(tmp_path, "telegram", {"owner": 42, "allowed": [42]})
+
+    client, captured, loop, bb = _wake_test_app(tmp_path)
+    try:
+        resp = client.post(
+            "/mesh/wake",
+            params={"target": "chef", "message": "check inbox"},
+            headers={
+                "x-origin": _origin_header("human", "telegram", "not-paired"),
+                "X-Agent-ID": "operator",
+            },
+        )
+        assert resp.status_code == 200
+        deadline = time.monotonic() + 2.0
+        while not captured and time.monotonic() < deadline:
+            time.sleep(0.01)
+        assert captured, "lane_manager.enqueue was never called"
+        call = captured[0]
+        assert isinstance(call["origin"], MessageOrigin)
+        assert call["origin"].kind == "agent"
+        # Channel/user metadata is preserved so the auto-notify path can
+        # still address the originating surface (Task 2b semantics).
+        assert call["origin"].channel == "telegram"
+        assert call["origin"].user == "not-paired"
+        assert call["auto_notify"] is True
+    finally:
+        loop.call_soon_threadsafe(loop.stop)
+        bb.close()
+        _server._invalidate_pairing_cache()
+
+
+def test_mesh_wake_paired_human_origin_keeps_kind(tmp_path, monkeypatch):
+    """``/mesh/wake`` with a verified channel claim keeps ``kind="human"``
+    on the lane payload — downstream gates can trust it."""
+    import time
+
+    from src.host import server as _server
+    from src.shared.types import MessageOrigin
+
+    monkeypatch.chdir(tmp_path)
+    _server._invalidate_pairing_cache()
+    _write_pairing(tmp_path, "telegram", {"owner": 42, "allowed": [42]})
+
+    client, captured, loop, bb = _wake_test_app(tmp_path)
+    try:
+        resp = client.post(
+            "/mesh/wake",
+            params={"target": "chef", "message": "check inbox"},
+            headers={
+                "x-origin": _origin_header("human", "telegram", "42"),
+                "X-Agent-ID": "operator",
+            },
+        )
+        assert resp.status_code == 200
+        deadline = time.monotonic() + 2.0
+        while not captured and time.monotonic() < deadline:
+            time.sleep(0.01)
+        assert captured
+        call = captured[0]
+        assert isinstance(call["origin"], MessageOrigin)
+        assert call["origin"].kind == "human"
+        assert call["origin"].channel == "telegram"
+        assert call["origin"].user == "42"
+        assert call["auto_notify"] is True
+    finally:
+        loop.call_soon_threadsafe(loop.stop)
+        bb.close()
+        _server._invalidate_pairing_cache()

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -3,6 +3,7 @@
 Tests the FastAPI endpoints directly using TestClient (no Docker required).
 """
 
+from __future__ import annotations
 
 import pytest
 from fastapi.testclient import TestClient
@@ -2022,6 +2023,11 @@ def _wake_test_app(tmp_path):
             blackboard_read=["*"], blackboard_write=["*"],
             allowed_apis=[],
         ),
+        "worker": AgentPermissions(
+            agent_id="worker", can_message=["chef"],
+            blackboard_read=[], blackboard_write=[],
+            allowed_apis=[],
+        ),
     }
     router = MessageRouter(permissions=perms, agent_registry={})
     router.register_agent("chef", "http://fake", role="chef")
@@ -2388,8 +2394,11 @@ class _ReqHeaders:
 
 
 class _FakeRequest:
-    def __init__(self, headers: dict[str, str]) -> None:
+    def __init__(self, headers: dict[str, str], client_host: str | None = None) -> None:
         self.headers = _ReqHeaders(headers)
+        self.client = None
+        if client_host is not None:
+            self.client = type("_Client", (), {"host": client_host})()
 
 
 def _write_pairing(tmp_path, channel: str, payload: dict | str) -> None:
@@ -2401,6 +2410,11 @@ def _write_pairing(tmp_path, channel: str, payload: dict | str) -> None:
     else:
         import json as _json
         path.write_text(_json.dumps(payload))
+
+
+def _patch_pairing_project_root(tmp_path, monkeypatch) -> None:
+    from src.cli import config as cli_config
+    monkeypatch.setattr(cli_config, "PROJECT_ROOT", tmp_path)
 
 
 def _origin_header(kind: str, channel: str, user: str) -> str:
@@ -2423,7 +2437,7 @@ class TestValidatedOrigin:
         from src.host.server import _validated_origin
         from src.shared.types import MessageOrigin
 
-        monkeypatch.chdir(tmp_path)
+        _patch_pairing_project_root(tmp_path, monkeypatch)
         _write_pairing(tmp_path, "telegram", {"owner": 42, "allowed": [42]})
         req = _FakeRequest({"x-origin": _origin_header("human", "telegram", "42")})
         result = _validated_origin(req)
@@ -2435,7 +2449,7 @@ class TestValidatedOrigin:
     def test_paired_user_in_allowed_list_keeps_human(self, tmp_path, monkeypatch):
         from src.host.server import _validated_origin
 
-        monkeypatch.chdir(tmp_path)
+        _patch_pairing_project_root(tmp_path, monkeypatch)
         _write_pairing(tmp_path, "discord", {"owner": "owner-id", "allowed": ["alice", "bob"]})
         req = _FakeRequest({"x-origin": _origin_header("human", "discord", "alice")})
         result = _validated_origin(req)
@@ -2445,7 +2459,7 @@ class TestValidatedOrigin:
     def test_unpaired_user_downgraded_to_agent(self, tmp_path, monkeypatch):
         from src.host.server import _validated_origin
 
-        monkeypatch.chdir(tmp_path)
+        _patch_pairing_project_root(tmp_path, monkeypatch)
         _write_pairing(tmp_path, "telegram", {"owner": 42, "allowed": [42]})
         req = _FakeRequest({"x-origin": _origin_header("human", "telegram", "9999")})
         result = _validated_origin(req)
@@ -2462,7 +2476,7 @@ class TestValidatedOrigin:
         """
         from src.host.server import _validated_origin
 
-        monkeypatch.chdir(tmp_path)
+        _patch_pairing_project_root(tmp_path, monkeypatch)
         _write_pairing(tmp_path, "telegram", {"owner": 42, "allowed": [42]})
         req = _FakeRequest(
             {"x-origin": _origin_header("human", "telegram", "")},
@@ -2476,7 +2490,7 @@ class TestValidatedOrigin:
     def test_missing_pairing_file_downgrades(self, tmp_path, monkeypatch):
         from src.host.server import _validated_origin
 
-        monkeypatch.chdir(tmp_path)
+        _patch_pairing_project_root(tmp_path, monkeypatch)
         # No config/telegram_paired.json at all.
         req = _FakeRequest({"x-origin": _origin_header("human", "telegram", "42")})
         result = _validated_origin(req)
@@ -2485,7 +2499,7 @@ class TestValidatedOrigin:
     def test_malformed_pairing_file_downgrades(self, tmp_path, monkeypatch):
         from src.host.server import _validated_origin
 
-        monkeypatch.chdir(tmp_path)
+        _patch_pairing_project_root(tmp_path, monkeypatch)
         _write_pairing(tmp_path, "telegram", "not-json-at-all{")
         req = _FakeRequest({"x-origin": _origin_header("human", "telegram", "42")})
         result = _validated_origin(req)
@@ -2494,66 +2508,88 @@ class TestValidatedOrigin:
     def test_pairing_file_non_dict_downgrades(self, tmp_path, monkeypatch):
         from src.host.server import _validated_origin
 
-        monkeypatch.chdir(tmp_path)
+        _patch_pairing_project_root(tmp_path, monkeypatch)
         _write_pairing(tmp_path, "telegram", "[1, 2, 3]")
         req = _FakeRequest({"x-origin": _origin_header("human", "telegram", "42")})
         result = _validated_origin(req)
         assert result.kind == "agent"
 
-    def test_non_paired_channel_passes_through(self, tmp_path, monkeypatch):
-        """CLI / dashboard origins pass through unchanged — they have
-        their own auth (process identity, ol_session cookie)."""
+    def test_non_paired_channel_downgrades_for_untrusted_caller(self, tmp_path, monkeypatch):
+        """Untrusted agent callers cannot self-assert CLI/dashboard human origin."""
         from src.host.server import _validated_origin
 
-        monkeypatch.chdir(tmp_path)
-        # No pairing file for cli — and shouldn't matter, cli isn't
-        # in _PAIRED_CHANNELS.
+        _patch_pairing_project_root(tmp_path, monkeypatch)
         req = _FakeRequest({"x-origin": _origin_header("human", "cli", "jeff")})
         result = _validated_origin(req)
-        assert result.kind == "human"
+        assert result.kind == "agent"
         assert result.channel == "cli"
 
         req2 = _FakeRequest({"x-origin": _origin_header("human", "dashboard", "op-1")})
         result2 = _validated_origin(req2)
-        assert result2.kind == "human"
+        assert result2.kind == "agent"
         assert result2.channel == "dashboard"
 
-    def test_unknown_channel_passes_through(self, tmp_path, monkeypatch):
-        """Channels not in the paired set pass through. Unknown channels
-        either have their own auth path or are caller-controlled metadata
-        (e.g., trace propagation)."""
+    def test_trusted_caller_keeps_non_paired_human_origin(self, tmp_path, monkeypatch):
+        """Operator/mesh callers already passed their own authentication layer."""
         from src.host.server import _validated_origin
 
-        monkeypatch.chdir(tmp_path)
+        _patch_pairing_project_root(tmp_path, monkeypatch)
+        req = _FakeRequest({"x-origin": _origin_header("human", "dashboard", "op-1")})
+        result = _validated_origin(req, caller="operator")
+        assert result.kind == "human"
+        assert result.channel == "dashboard"
+
+    def test_unknown_human_channel_downgrades_for_untrusted_caller(self, tmp_path, monkeypatch):
+        from src.host.server import _validated_origin
+
+        _patch_pairing_project_root(tmp_path, monkeypatch)
         req = _FakeRequest({"x-origin": _origin_header("human", "rss", "feed-1")})
         result = _validated_origin(req)
-        assert result.kind == "human"
+        assert result.kind == "agent"
         assert result.channel == "rss"
 
-    def test_non_human_kinds_pass_through(self, tmp_path, monkeypatch):
-        """cron / heartbeat / agent / system / operator never trigger
-        the pairing recheck — only human claims need verification."""
+    def test_non_human_kinds_downgrade_for_untrusted_caller(self, tmp_path, monkeypatch):
+        """Untrusted callers cannot self-assert operator/system/cron/heartbeat."""
         from src.host.server import _validated_origin
 
-        monkeypatch.chdir(tmp_path)
-        # No pairing file for any of these — should pass through anyway.
-        for kind in ("agent", "system", "heartbeat", "cron", "operator"):
+        _patch_pairing_project_root(tmp_path, monkeypatch)
+        req = _FakeRequest({"x-origin": _origin_header("agent", "telegram", "42")})
+        result = _validated_origin(req)
+        assert result is not None
+        assert result.kind == "agent"
+
+        for kind in ("system", "heartbeat", "cron", "operator"):
             req = _FakeRequest({"x-origin": _origin_header(kind, "telegram", "42")})
             result = _validated_origin(req)
             assert result is not None, f"kind={kind} should parse"
-            assert result.kind == kind, f"kind={kind} should pass through"
+            assert result.kind == "agent", f"kind={kind} should downgrade"
+
+    def test_trusted_loopback_internal_keeps_non_human_kind(self, tmp_path, monkeypatch):
+        from src.host.server import _validated_origin
+
+        _patch_pairing_project_root(tmp_path, monkeypatch)
+        req = _FakeRequest(
+            {
+                "x-origin": _origin_header("heartbeat", "heartbeat", ""),
+                "x-mesh-internal": "1",
+            },
+            client_host="127.0.0.1",
+        )
+        result = _validated_origin(req)
+        assert result is not None
+        assert result.kind == "heartbeat"
 
     def test_no_origin_header_returns_none(self, tmp_path, monkeypatch):
         from src.host.server import _validated_origin
 
-        monkeypatch.chdir(tmp_path)
+        _patch_pairing_project_root(tmp_path, monkeypatch)
         req = _FakeRequest({})
         assert _validated_origin(req) is None
 
     def test_malformed_origin_header_returns_none(self, tmp_path, monkeypatch):
         from src.host.server import _validated_origin
 
-        monkeypatch.chdir(tmp_path)
+        _patch_pairing_project_root(tmp_path, monkeypatch)
         req = _FakeRequest({"x-origin": "not-json"})
         assert _validated_origin(req) is None
 
@@ -2562,7 +2598,7 @@ class TestValidatedOrigin:
         the helper re-reads the file."""
         from src.host import server as _server
 
-        monkeypatch.chdir(tmp_path)
+        _patch_pairing_project_root(tmp_path, monkeypatch)
         _write_pairing(tmp_path, "telegram", {"owner": 42, "allowed": [42]})
         req_paired = _FakeRequest(
             {"x-origin": _origin_header("human", "telegram", "42")},
@@ -2589,7 +2625,7 @@ class TestValidatedOrigin:
     def test_invalidate_cache_forces_reread(self, tmp_path, monkeypatch):
         from src.host import server as _server
 
-        monkeypatch.chdir(tmp_path)
+        _patch_pairing_project_root(tmp_path, monkeypatch)
         _write_pairing(tmp_path, "telegram", {"owner": 42, "allowed": [42]})
         req = _FakeRequest({"x-origin": _origin_header("human", "telegram", "42")})
         assert _server._validated_origin(req).kind == "human"
@@ -2609,7 +2645,7 @@ class TestValidatedOrigin:
         """Invalidate with no argument clears all entries."""
         from src.host import server as _server
 
-        monkeypatch.chdir(tmp_path)
+        _patch_pairing_project_root(tmp_path, monkeypatch)
         _write_pairing(tmp_path, "telegram", {"owner": 42, "allowed": []})
         _write_pairing(tmp_path, "discord", {"owner": "alice", "allowed": []})
 
@@ -2626,7 +2662,7 @@ class TestValidatedOrigin:
         gracefully — the helper must not raise on bad shapes."""
         from src.host.server import _validated_origin
 
-        monkeypatch.chdir(tmp_path)
+        _patch_pairing_project_root(tmp_path, monkeypatch)
         _write_pairing(tmp_path, "telegram", {"owner": 42, "allowed": "not-a-list"})
         # User 42 is the owner → still paired (owner check doesn't touch allowed).
         req_owner = _FakeRequest({"x-origin": _origin_header("human", "telegram", "42")})
@@ -2649,7 +2685,7 @@ def test_mesh_wake_downgrades_unpaired_human_origin(tmp_path, monkeypatch):
     from src.host import server as _server
     from src.shared.types import MessageOrigin
 
-    monkeypatch.chdir(tmp_path)
+    _patch_pairing_project_root(tmp_path, monkeypatch)
     _server._invalidate_pairing_cache()
     # Pair owner=42; the wake claim uses user=not-paired so the recheck
     # downgrades.
@@ -2662,7 +2698,7 @@ def test_mesh_wake_downgrades_unpaired_human_origin(tmp_path, monkeypatch):
             params={"target": "chef", "message": "check inbox"},
             headers={
                 "x-origin": _origin_header("human", "telegram", "not-paired"),
-                "X-Agent-ID": "operator",
+                "X-Agent-ID": "worker",
             },
         )
         assert resp.status_code == 200
@@ -2692,7 +2728,7 @@ def test_mesh_wake_paired_human_origin_keeps_kind(tmp_path, monkeypatch):
     from src.host import server as _server
     from src.shared.types import MessageOrigin
 
-    monkeypatch.chdir(tmp_path)
+    _patch_pairing_project_root(tmp_path, monkeypatch)
     _server._invalidate_pairing_cache()
     _write_pairing(tmp_path, "telegram", {"owner": 42, "allowed": [42]})
 
@@ -2703,7 +2739,7 @@ def test_mesh_wake_paired_human_origin_keeps_kind(tmp_path, monkeypatch):
             params={"target": "chef", "message": "check inbox"},
             headers={
                 "x-origin": _origin_header("human", "telegram", "42"),
-                "X-Agent-ID": "operator",
+                "X-Agent-ID": "worker",
             },
         )
         assert resp.status_code == 200


### PR DESCRIPTION
## Summary

Third slice of **Task 2** (origin as authorization input). Task 2b stamps typed origins at every entry point. Upstream's strict-by-default `parse_origin_header` (`trust_kind=False`) strips `kind` from inbound headers — request authority cannot self-assert "human". This slice adds the validator that promotes `kind` back to `"human"` only after server-side pairing verification against the channel's `config/<channel>_paired.json` file.

**Branch base:** `feat/origin-stamp-sites` (PR #824) → `feat/origin-typed-model` (#823) → `test/characterization-tier1` (#822) → `fix/operator-handoff-hotfix` (#821) → `main`.

## What ships

- `_validated_origin(request)` in `src/host/server.py` — calls `MessageOrigin.from_header_value(raw, trust_kind=True)` so the inbound human claim is visible, then either preserves it (paired) or downgrades to `kind="agent"` (unpaired / empty / unverifiable). **Silent on downgrade** — logs warning, never raises.
- `_PAIRED_CHANNELS = {telegram, discord, slack, whatsapp, webhook}`. CLI / dashboard / unrecognized channels pass through unchanged — their authentication happens at a different layer.
- `_read_pairing_record` with a **5-second TTL cache** to avoid filesystem hotspot on high-traffic endpoints. `_invalidate_pairing_cache` hook is exposed for pair/unpair flows to drop stale entries.
- `/mesh/wake` switches from `parse_origin_header` to `_validated_origin` so forged human claims on a peer wake downgrade.
- Agent-side endpoints keep `parse_origin_header` — agent containers don't have access to host pairing files.

## Conservative defaults

- **Webhook** is included in `_PAIRED_CHANNELS` even though no `webhook_paired.json` exists today — any webhook claim of `kind="human"` will downgrade until a webhook auth story lands. This is the safe default.
- **Empty user** with `kind="human"` is treated as unverifiable → downgrade.
- **Missing / malformed pairing file** → downgrade.

## What's deliberately NOT in this PR

- SQLite `pending_actions` migration (Task 2d).
- `/mesh/wake` worker → operator block (Task 2e — flips one of #822's capture-to-tighten tests).
- HMAC-signed per-message session token between adapter and mesh (Tier 2/3 follow-up).

## Test plan

- [x] 19 new tests in `tests/test_integration.py::TestValidatedOrigin` covering paired / unpaired / empty / missing-file / malformed / non-paired-channel / non-human-kind / cache TTL / invalidation hook / `/mesh/wake` integration
- [x] `pytest tests/test_integration.py tests/test_message_origin.py tests/test_lanes.py tests/test_coordination.py tests/test_mesh.py tests/test_channels.py` — 358 passed
- [x] Full non-E2E suite — 5003 passed, 44 skipped + **4 pre-existing failures inherited from PR #824**

## ⚠️ Inherited failures from PR #824 (Task 2b)

Four tests in PR #824's branch assert `kind="human"` survives the agent receive path, but the upstream strict-by-default `parse_origin_header` already downgrades caller-supplied kinds to `agent`. **This PR does not introduce or mask those failures** — they exist on the base branch.

The right fix is in #824: either update those tests to expect `kind="agent"` matching the strict design, or pass `trust_kind=True` at the agent server boundary if the mesh→agent hop is considered trusted via container isolation. Worth deciding during review which security posture we want.

The 4 failing tests:
- `test_agent_server.py::TestChatOriginHeader::test_chat_typed_human_origin_preserved`
- `test_agent_server.py::TestHeartbeatOriginContextVar::test_heartbeat_typed_origin_sets_contextvar`
- `test_cli_commands.py::TestREPLOriginStamp::test_streaming_dispatch_sends_typed_human_origin_header`
- `test_dashboard.py::TestDashboardOriginStamp::test_api_chat_stamps_human_dashboard_origin`

## Stack

1. #821 — Task 0 hotfix ✅
2. #822 — Task 1 characterization tests
3. #823 — Task 2a typed model
4. #824 — Task 2b stamp sites (4 inherited failures — see above)
5. **This PR** — Task 2c channel pairing recheck
6. (next) Task 2d pending-actions SQLite migration
7. (then) Task 2e wake-block, Task 3 perm split, Task 4 operator auth, Task 5 project isolation