### PR TITLE
feat(pending-actions): SQLite-backed pending action store (Task 2d)

### DIFF
--- a/src/agent/builtins/operator_tools.py
+++ b/src/agent/builtins/operator_tools.py
@@ -184,7 +184,16 @@ async def confirm_edit(change_id: str, *, mesh_client=None, _messages=None, **_k
         return result
     except Exception as e:
         error_str = str(e)
-        if "404" in error_str or "not found" in error_str.lower():
+        # Task 2d migrated /mesh/config/confirm from 404 -> 400 with
+        # "Pending action invalid or expired" for unknown/expired/
+        # digest-mismatch/origin-failure rows. Match either form so
+        # existing operator UX (re-propose) keeps working.
+        lower = error_str.lower()
+        if (
+            "404" in error_str
+            or "not found" in lower
+            or "invalid or expired" in lower
+        ):
             return {
                 "error": "change_expired_or_lost",
                 "detail": (

--- a/src/cli/main.py
+++ b/src/cli/main.py
@@ -15,6 +15,8 @@ from __future__ import annotations
 import json as _json
 import logging
 import os
+from pathlib import Path
+import re
 import subprocess
 import sys
 import threading
@@ -30,6 +32,25 @@ from src.cli.config import (
 logger = logging.getLogger("cli")
 
 _json_mode = False
+
+
+def _project_version() -> str:
+    """Return installed package version, falling back for source-tree tests."""
+    from importlib.metadata import PackageNotFoundError, version as pkg_version
+
+    try:
+        return pkg_version("openlegion")
+    except PackageNotFoundError:
+        pyproject = Path(__file__).resolve().parents[2] / "pyproject.toml"
+        try:
+            match = re.search(
+                r'^version\s*=\s*"([^"]+)"',
+                pyproject.read_text(encoding="utf-8"),
+                re.MULTILINE,
+            )
+        except OSError:
+            match = None
+        return match.group(1) if match else "dev"
 
 
 def _set_json(ctx: click.Context, _param: click.Parameter, value: bool) -> None:
@@ -61,7 +82,7 @@ def _complete_agent_names(ctx, param, incomplete):
 # ── Main group ───────────────────────────────────────────────
 
 @click.group()
-@click.version_option(package_name="openlegion")
+@click.version_option(version=_project_version(), prog_name="openlegion")
 @click.option(
     "--json", "json_flag", is_flag=True, is_eager=True, expose_value=False,
     callback=_set_json, help="Output in JSON format (where supported)",
@@ -701,12 +722,7 @@ def reset(yes: bool):
 def version_cmd(verbose: bool):
     """Show version and environment information."""
     import platform
-    from importlib.metadata import version as pkg_version
-
-    try:
-        ver = pkg_version("openlegion")
-    except Exception:
-        ver = "dev"
+    ver = _project_version()
     click.echo(f"OpenLegion v{ver}")
     if verbose:
         click.echo(f"Python {sys.version.split()[0]}")

--- a/src/cli/main.py
+++ b/src/cli/main.py
@@ -15,11 +15,11 @@ from __future__ import annotations
 import json as _json
 import logging
 import os
-from pathlib import Path
 import re
 import subprocess
 import sys
 import threading
+from pathlib import Path
 
 import click
 
@@ -36,7 +36,8 @@ _json_mode = False
 
 def _project_version() -> str:
     """Return installed package version, falling back for source-tree tests."""
-    from importlib.metadata import PackageNotFoundError, version as pkg_version
+    from importlib.metadata import PackageNotFoundError
+    from importlib.metadata import version as pkg_version
 
     try:
         return pkg_version("openlegion")

--- a/src/host/pending_actions.py
+++ b/src/host/pending_actions.py
@@ -1,0 +1,341 @@
+"""Persistent storage for operator-proposed actions awaiting human confirmation.
+
+Each pending action has a nonce (idempotency key + propose -> confirm pairing),
+a payload digest (replay protection), an origin kind (so confirm-side gates
+can require ``origin_kind="human"``), and an expiry (default 300s -- same as
+the legacy in-memory TTL, configurable per call).
+
+Schema mirrors the Blackboard pattern in ``src/host/mesh.py``: SQLite WAL,
+``busy_timeout=30000``, schema migration via ``executescript()``.
+
+External contract: ``store(nonce, actor, target_kind, target_id, action_kind,
+payload, origin_kind, ttl)`` returns a record dict; ``consume(nonce, *,
+require_origin_kind, expected_payload_digest, confirmer)`` returns the record
+or None (expired/missing/wrong-digest/wrong-origin/wrong-actor) and atomically
+deletes on success.
+
+Reaping is opportunistic: ``store`` and ``consume`` call ``reap_expired``
+themselves so callers do not need to wire a periodic task. A background
+reaper could be added later if pressure rises, but the opportunistic path
+is enough for correctness given pending records are short-lived and bounded.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import sqlite3
+import time
+from contextlib import contextmanager
+from pathlib import Path
+from typing import Any
+
+from src.shared.utils import setup_logging
+
+logger = setup_logging("host.pending_actions")
+
+_DEFAULT_TTL_SEC = 300
+
+
+def _payload_digest(payload: Any) -> str:
+    """Stable digest of the proposed payload for replay protection.
+
+    Uses ``sort_keys=True`` so structurally equivalent payloads produce
+    matching digests regardless of dict iteration order, and
+    ``default=str`` so datetime / Decimal / etc. don't blow up serialization.
+    """
+    blob = json.dumps(payload, sort_keys=True, separators=(",", ":"), default=str)
+    return hashlib.sha256(blob.encode("utf-8")).hexdigest()
+
+
+class PendingActions:
+    """SQLite-backed pending-action store.
+
+    One row per nonce. Same nonce stored twice replaces the row
+    (``INSERT OR REPLACE``) -- intentional: the propose endpoint generates
+    fresh UUIDs so a collision indicates the caller wants to re-propose
+    the same change; replacing the prior payload is the correct semantic.
+
+    Connections are short-lived (one per call, opened lazily via
+    :meth:`_conn`). All write paths use a single SQL statement -- the only
+    explicit transaction is in :meth:`consume`, which uses ``BEGIN IMMEDIATE``
+    so two simultaneous consumers serialize and only one wins.
+    """
+
+    def __init__(self, db_path: str):
+        self.db_path = db_path
+        # ``:memory:`` SQLite databases are per-connection -- closing
+        # and reopening loses everything. Keep a single long-lived
+        # connection for in-memory mode (used in tests + the legacy
+        # shim path) so schema and rows survive across calls.
+        self._shared_conn: sqlite3.Connection | None = None
+        if db_path == ":memory:":
+            self._shared_conn = sqlite3.connect(
+                db_path, isolation_level=None, check_same_thread=False,
+            )
+            self._shared_conn.execute("PRAGMA busy_timeout=30000")
+        self._init_schema()
+
+    @contextmanager
+    def _conn(self):
+        if self._shared_conn is not None:
+            yield self._shared_conn
+            return
+        conn = sqlite3.connect(self.db_path, isolation_level=None)
+        try:
+            conn.execute("PRAGMA journal_mode=WAL")
+            conn.execute("PRAGMA busy_timeout=30000")
+            yield conn
+        finally:
+            conn.close()
+
+    def close(self) -> None:
+        """Close the in-memory connection if any. Tests use this."""
+        if self._shared_conn is not None:
+            self._shared_conn.close()
+            self._shared_conn = None
+
+    def _init_schema(self) -> None:
+        """Create the pending_actions table if it doesn't exist.
+
+        Idempotent -- safe to call repeatedly (used in __init__ but also
+        survives schema-evolution callers that init multiple times).
+        """
+        Path(self.db_path).parent.mkdir(parents=True, exist_ok=True)
+        with self._conn() as conn:
+            conn.executescript("""
+                CREATE TABLE IF NOT EXISTS pending_actions (
+                    nonce TEXT PRIMARY KEY,
+                    actor TEXT NOT NULL,
+                    target_kind TEXT NOT NULL,
+                    target_id TEXT NOT NULL,
+                    action_kind TEXT NOT NULL,
+                    payload_json TEXT NOT NULL,
+                    payload_digest TEXT NOT NULL,
+                    origin_kind TEXT,
+                    created_at REAL NOT NULL,
+                    expires_at REAL NOT NULL,
+                    status TEXT NOT NULL DEFAULT 'pending'
+                );
+                CREATE INDEX IF NOT EXISTS idx_pending_expires
+                    ON pending_actions (expires_at);
+                CREATE INDEX IF NOT EXISTS idx_pending_target
+                    ON pending_actions (target_kind, target_id);
+            """)
+
+    # ── Core API ────────────────────────────────────────────────────
+
+    def store(
+        self,
+        *,
+        nonce: str,
+        actor: str,
+        target_kind: str,
+        target_id: str,
+        action_kind: str,
+        payload: Any,
+        origin_kind: str | None = None,
+        ttl: int = _DEFAULT_TTL_SEC,
+    ) -> dict:
+        """Persist a pending action. Returns the record dict.
+
+        ``payload_digest`` is computed from a stable serialization of
+        ``payload``. Confirm-side replay protection: callers can pass
+        the digest of the payload they hold in their request body to
+        ``consume`` via ``expected_payload_digest`` to catch tampering.
+        """
+        now = time.time()
+        digest = _payload_digest(payload)
+        expires_at = now + ttl
+        # Opportunistic reap on the write path keeps the table bounded
+        # without a separate scheduler. Failures are logged and swallowed
+        # so a corrupt-row sweep never blocks a legitimate store.
+        self._safe_reap()
+        with self._conn() as conn:
+            conn.execute(
+                "INSERT OR REPLACE INTO pending_actions "
+                "(nonce, actor, target_kind, target_id, action_kind, "
+                "payload_json, payload_digest, origin_kind, created_at, "
+                "expires_at, status) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 'pending')",
+                (
+                    nonce, actor, target_kind, target_id, action_kind,
+                    json.dumps(payload, default=str), digest, origin_kind,
+                    now, expires_at,
+                ),
+            )
+        return {
+            "nonce": nonce,
+            "actor": actor,
+            "target_kind": target_kind,
+            "target_id": target_id,
+            "action_kind": action_kind,
+            "payload": payload,
+            "payload_digest": digest,
+            "origin_kind": origin_kind,
+            "created_at": now,
+            "expires_at": expires_at,
+            "status": "pending",
+        }
+
+    def peek(self, nonce: str) -> dict | None:
+        """Read a pending action without consuming it.
+
+        Returns None for unknown or expired nonces. Does NOT delete
+        expired rows -- use :meth:`reap_expired` for cleanup. Useful for
+        previews / dashboard surfaces that want to display a pending
+        change without committing to it.
+        """
+        with self._conn() as conn:
+            row = conn.execute(
+                "SELECT actor, target_kind, target_id, action_kind, "
+                "payload_json, payload_digest, origin_kind, created_at, "
+                "expires_at, status FROM pending_actions WHERE nonce=?",
+                (nonce,),
+            ).fetchone()
+        if not row:
+            return None
+        if time.time() > row[8]:  # expires_at
+            return None
+        return {
+            "nonce": nonce,
+            "actor": row[0],
+            "target_kind": row[1],
+            "target_id": row[2],
+            "action_kind": row[3],
+            "payload": json.loads(row[4]),
+            "payload_digest": row[5],
+            "origin_kind": row[6],
+            "created_at": row[7],
+            "expires_at": row[8],
+            "status": row[9],
+        }
+
+    def consume(
+        self,
+        nonce: str,
+        *,
+        confirmer: str | None = None,
+        require_origin_kind: str | None = None,
+        expected_payload_digest: str | None = None,
+    ) -> dict | None:
+        """Atomically consume a pending action.
+
+        Returns the record on success and deletes the row.
+
+        Returns None on:
+          * unknown nonce
+          * expired (also deletes the expired row inside the same txn)
+          * payload digest mismatch (replay protection -- row preserved)
+          * confirmer != actor (only the proposer can confirm -- row preserved)
+          * origin kind below required level (e.g. ``require="human"`` but
+            row has ``"agent"`` -- row preserved)
+
+        On a successful consume, the row is deleted in the same
+        transaction so the same nonce cannot be replayed.
+        """
+        # Opportunistic reap on the read path. Cheap, swallowed on error.
+        self._safe_reap()
+        with self._conn() as conn:
+            conn.execute("BEGIN IMMEDIATE")
+            try:
+                row = conn.execute(
+                    "SELECT actor, target_kind, target_id, action_kind, "
+                    "payload_json, payload_digest, origin_kind, created_at, "
+                    "expires_at, status FROM pending_actions WHERE nonce=?",
+                    (nonce,),
+                ).fetchone()
+                if not row:
+                    conn.execute("COMMIT")
+                    return None
+                now = time.time()
+                if now > row[8]:
+                    # Expired -- delete and report None
+                    conn.execute(
+                        "DELETE FROM pending_actions WHERE nonce=?", (nonce,),
+                    )
+                    conn.execute("COMMIT")
+                    return None
+                if expected_payload_digest and row[5] != expected_payload_digest:
+                    # Replay-protection mismatch -- preserve the row so the
+                    # legitimate confirmer can still consume it.
+                    conn.execute("COMMIT")
+                    return None
+                if confirmer and row[0] != confirmer:
+                    # Wrong confirmer -- preserve the row.
+                    conn.execute("COMMIT")
+                    return None
+                if require_origin_kind and row[6] != require_origin_kind:
+                    # Origin not strong enough -- preserve the row so
+                    # nothing prevents a legitimate retry from the right
+                    # caller, but refuse to apply.
+                    conn.execute("COMMIT")
+                    return None
+                conn.execute(
+                    "DELETE FROM pending_actions WHERE nonce=?", (nonce,),
+                )
+                conn.execute("COMMIT")
+            except Exception:
+                conn.execute("ROLLBACK")
+                raise
+        return {
+            "nonce": nonce,
+            "actor": row[0],
+            "target_kind": row[1],
+            "target_id": row[2],
+            "action_kind": row[3],
+            "payload": json.loads(row[4]),
+            "payload_digest": row[5],
+            "origin_kind": row[6],
+            "created_at": row[7],
+            "expires_at": row[8],
+            "status": "consumed",
+        }
+
+    # ── Maintenance / surfacing ────────────────────────────────────
+
+    def reap_expired(self) -> int:
+        """Delete every row past its expiry. Returns count deleted."""
+        with self._conn() as conn:
+            cur = conn.execute(
+                "DELETE FROM pending_actions WHERE expires_at < ?",
+                (time.time(),),
+            )
+            return cur.rowcount
+
+    def _safe_reap(self) -> None:
+        """Reap-expired wrapper that never raises in a request path."""
+        try:
+            self.reap_expired()
+        except Exception as e:
+            logger.debug("opportunistic reap_expired failed: %s", e)
+
+    def list_pending(self) -> list[dict]:
+        """Return every non-expired pending action.
+
+        Used by future dashboard / CLI surfaces to display review queues.
+        Not a consume-style call -- rows are left in place.
+        """
+        with self._conn() as conn:
+            rows = conn.execute(
+                "SELECT nonce, actor, target_kind, target_id, action_kind, "
+                "payload_json, payload_digest, origin_kind, created_at, "
+                "expires_at, status FROM pending_actions "
+                "WHERE expires_at >= ? ORDER BY created_at ASC",
+                (time.time(),),
+            ).fetchall()
+        return [
+            {
+                "nonce": r[0],
+                "actor": r[1],
+                "target_kind": r[2],
+                "target_id": r[3],
+                "action_kind": r[4],
+                "payload": json.loads(r[5]),
+                "payload_digest": r[6],
+                "origin_kind": r[7],
+                "created_at": r[8],
+                "expires_at": r[9],
+                "status": r[10],
+            }
+            for r in rows
+        ]

--- a/src/host/server.py
+++ b/src/host/server.py
@@ -26,6 +26,7 @@ from fastapi import FastAPI, HTTPException, Request, WebSocket
 from fastapi.responses import StreamingResponse
 
 from src.host.credentials import is_system_credential
+from src.host.pending_actions import PendingActions
 from src.shared.redaction import redact_url
 from src.shared.types import (
     AGENT_ID_RE_PATTERN,
@@ -78,42 +79,178 @@ if TYPE_CHECKING:
     from src.shared.types import MessageOrigin
 
 
-# ── Pending Config Change Store (in-memory) ──────────────────────
-
-_pending_changes: dict[str, dict] = {}
+# ── Pending Config Change Store (SQLite-backed) ──────────────────
+#
+# Task 2d migrated this from an in-memory dict to a SQLite-backed
+# ``PendingActions`` store (``data/pending_actions.db``) so pending
+# operator-config edits survive mesh restarts. Schema carries the
+# payload digest (replay protection) and origin kind (so confirm-side
+# gates can require ``origin_kind="human"``). The mesh app picks the
+# canonical instance up via ``_get_pending_actions_store()`` below;
+# the module-level helpers (kept for backward compatibility with
+# external test imports) delegate to that singleton.
 _MAX_PENDING = 10
 _CHANGE_TTL_SECONDS = 300
 
+# Module-level singleton used by the ``_store_pending_change`` /
+# ``_get_pending_change`` / ``_consume_pending_change`` shims below.
+# ``create_mesh_app`` sets this to its own instance so the helpers and
+# the app share one store; tests that import the helpers directly get
+# an in-memory store the first time they touch one of the shims.
+_pending_actions_singleton: PendingActions | None = None
+
+
+def _get_pending_actions_store() -> PendingActions:
+    """Lazy-init the module-level pending-action store.
+
+    Tests that import ``_store_pending_change`` directly without going
+    through ``create_mesh_app`` will land here; we use ``:memory:`` so
+    they don't pollute the cwd. Production callers run through
+    ``create_mesh_app``, which constructs a disk-backed instance and
+    assigns it to ``_pending_actions_singleton`` before the helpers
+    are ever called.
+    """
+    global _pending_actions_singleton
+    if _pending_actions_singleton is None:
+        _pending_actions_singleton = PendingActions(db_path=":memory:")
+    return _pending_actions_singleton
+
+
+# ── Backward-compat dict view ───────────────────────────────────────
+# Existing tests (``tests/test_operator_audit.py``) imported the legacy
+# ``_pending_changes`` dict directly. They want to ``.clear()`` it,
+# index into it, and mutate ``expires_at`` on a row to force expiry.
+# We expose a thin proxy that forwards each operation to the SQLite
+# store so those existing tests keep passing without leaking the old
+# in-memory dict semantics back into production code.
+
+class _PendingChangesProxy:
+    """Dict-like view over the SQLite pending_actions store.
+
+    Keeps the legacy ``_pending_changes`` import working: ``.clear()``,
+    ``__contains__``, ``__getitem__`` for tests; production code uses
+    :class:`PendingActions` directly.
+    """
+
+    def _store(self) -> PendingActions:
+        return _get_pending_actions_store()
+
+    def clear(self) -> None:
+        with self._store()._conn() as conn:
+            conn.execute("DELETE FROM pending_actions")
+
+    def __contains__(self, change_id: object) -> bool:
+        if not isinstance(change_id, str):
+            return False
+        return self._store().peek(change_id) is not None
+
+    def __len__(self) -> int:
+        return len(self._store().list_pending())
+
+    def __getitem__(self, change_id: str) -> dict:
+        rec = self._store().peek(change_id)
+        if rec is None:
+            raise KeyError(change_id)
+        # Translate from the new schema back to the legacy fields the
+        # old tests asserted on. ``payload`` carries the (old, new)
+        # value pair as a dict, plus ``field`` lives on the row itself.
+        payload = rec.get("payload") or {}
+        return {
+            "agent_id": rec["target_id"],
+            "field": rec["action_kind"],
+            "old_value": payload.get("old_value", ""),
+            "new_value": payload.get("new_value", ""),
+            "expires_at": datetime.fromtimestamp(rec["expires_at"], tz=timezone.utc),
+        }
+
+    def __setitem__(self, change_id: str, value: dict) -> None:
+        # Only the ``expires_at`` mutation is supported -- it's the
+        # only mutation legacy tests perform on this dict (to force
+        # expiry). Other writes go through ``_store_pending_change``.
+        if not isinstance(value, dict) or "expires_at" not in value:
+            raise NotImplementedError(
+                "Use _store_pending_change to insert; only expires_at "
+                "mutations are supported on this proxy.",
+            )
+        new_expiry = value["expires_at"]
+        if isinstance(new_expiry, datetime):
+            new_expiry = new_expiry.timestamp()
+        with self._store()._conn() as conn:
+            conn.execute(
+                "UPDATE pending_actions SET expires_at=? WHERE nonce=?",
+                (new_expiry, change_id),
+            )
+
+
+_pending_changes = _PendingChangesProxy()
+
 
 def _cleanup_expired_changes() -> None:
-    now = datetime.now(timezone.utc)
-    expired = [k for k, v in _pending_changes.items() if v["expires_at"] < now]
-    for k in expired:
-        del _pending_changes[k]
+    """Reap expired pending actions. Kept for backward compatibility."""
+    _get_pending_actions_store().reap_expired()
 
 
 def _store_pending_change(agent_id: str, field: str, old_value: object, new_value: object) -> str:
-    _cleanup_expired_changes()
-    if len(_pending_changes) >= _MAX_PENDING:
-        oldest = min(_pending_changes, key=lambda k: _pending_changes[k]["expires_at"])
-        del _pending_changes[oldest]
+    """Persist a pending config change. Returns a change_id (nonce).
+
+    Backed by ``PendingActions`` (SQLite). Capped at ``_MAX_PENDING``
+    rows per process; oldest expires-first row is evicted to make room.
+    """
+    store = _get_pending_actions_store()
+    store.reap_expired()
+    pending = store.list_pending()
+    if len(pending) >= _MAX_PENDING:
+        # Evict the row whose ``expires_at`` is soonest -- matches the
+        # legacy behavior (``min(...)`` over ``expires_at``).
+        oldest = min(pending, key=lambda r: r["expires_at"])
+        with store._conn() as conn:
+            conn.execute(
+                "DELETE FROM pending_actions WHERE nonce=?", (oldest["nonce"],),
+            )
     change_id = str(_uuid.uuid4())
-    _pending_changes[change_id] = {
-        "agent_id": agent_id, "field": field,
-        "old_value": old_value, "new_value": new_value,
-        "expires_at": datetime.now(timezone.utc) + timedelta(seconds=_CHANGE_TTL_SECONDS),
-    }
+    payload = {"old_value": old_value, "new_value": new_value}
+    store.store(
+        nonce=change_id,
+        actor="operator",
+        target_kind="agent",
+        target_id=agent_id,
+        action_kind=field,
+        payload=payload,
+        ttl=_CHANGE_TTL_SECONDS,
+    )
     return change_id
 
 
 def _get_pending_change(change_id: str) -> dict | None:
-    _cleanup_expired_changes()
-    return _pending_changes.get(change_id)
+    """Read a pending change. Returns the legacy dict shape or None."""
+    store = _get_pending_actions_store()
+    rec = store.peek(change_id)
+    if rec is None:
+        return None
+    payload = rec.get("payload") or {}
+    return {
+        "agent_id": rec["target_id"],
+        "field": rec["action_kind"],
+        "old_value": payload.get("old_value", ""),
+        "new_value": payload.get("new_value", ""),
+        "expires_at": datetime.fromtimestamp(rec["expires_at"], tz=timezone.utc),
+    }
 
 
 def _consume_pending_change(change_id: str) -> dict | None:
-    _cleanup_expired_changes()
-    return _pending_changes.pop(change_id, None)
+    """Atomically consume a pending change. Returns legacy dict shape or None."""
+    store = _get_pending_actions_store()
+    rec = store.consume(change_id)
+    if rec is None:
+        return None
+    payload = rec.get("payload") or {}
+    return {
+        "agent_id": rec["target_id"],
+        "field": rec["action_kind"],
+        "old_value": payload.get("old_value", ""),
+        "new_value": payload.get("new_value", ""),
+        "expires_at": datetime.fromtimestamp(rec["expires_at"], tz=timezone.utc),
+    }
 
 
 # ── Task 2c: Server-side channel origin validation ────────────────
@@ -294,6 +431,17 @@ def create_mesh_app(
     # Exposed for external callers (dashboard, health monitor) to clean up
     # agent state when agents are removed.
     app.cleanup_agent = lambda agent_id: None  # replaced below
+
+    # Task 2d: persistent pending-action store (replaces the in-memory
+    # ``_pending_changes`` dict). Mirrors the path convention of
+    # ``data/costs.db`` / ``data/traces.db``. The disk-backed instance
+    # is also assigned to the module-level singleton so the legacy
+    # ``_store_pending_change`` / ``_consume_pending_change`` helpers
+    # share state with the endpoints below.
+    pending_actions = PendingActions(db_path="data/pending_actions.db")
+    app.pending_actions = pending_actions  # exposed for tests/dashboard
+    global _pending_actions_singleton
+    _pending_actions_singleton = pending_actions
 
     _auth_tokens = auth_tokens if auth_tokens is not None else {}
     _agent_projects = agent_projects if agent_projects is not None else {}
@@ -2699,7 +2847,37 @@ def create_mesh_app(
             yaml_key = _CONFIG_FIELD_MAP.get(field, field)
             old_value = agents[agent_id].get(yaml_key, "")
 
-        change_id = _store_pending_change(agent_id, field, old_value, new_value)
+        # Capture the proposer's origin kind so the confirm side can
+        # gate on ``origin_kind="human"`` (Task 2d). When the X-Origin
+        # header is missing or unverifiable the row stores ``None`` and
+        # the confirm endpoint will refuse to apply.
+        origin = _validated_origin(request)
+        origin_kind = origin.kind if origin is not None else None
+
+        # Cap to ``_MAX_PENDING`` rows to bound storage growth -- mirrors
+        # the legacy in-memory eviction behavior.
+        pending_actions.reap_expired()
+        existing = pending_actions.list_pending()
+        if len(existing) >= _MAX_PENDING:
+            oldest = min(existing, key=lambda r: r["expires_at"])
+            with pending_actions._conn() as _conn:
+                _conn.execute(
+                    "DELETE FROM pending_actions WHERE nonce=?",
+                    (oldest["nonce"],),
+                )
+
+        change_id = str(_uuid.uuid4())
+        payload = {"old_value": old_value, "new_value": new_value}
+        record = pending_actions.store(
+            nonce=change_id,
+            actor="operator",
+            target_kind="agent",
+            target_id=agent_id,
+            action_kind=field,
+            payload=payload,
+            origin_kind=origin_kind,
+            ttl=_CHANGE_TTL_SECONDS,
+        )
 
         # Generate preview diff
         old_str = json.dumps(old_value, indent=2) if not isinstance(old_value, str) else old_value
@@ -2719,7 +2897,29 @@ def create_mesh_app(
         return {
             "change_id": change_id,
             "preview_diff": preview,
-            "expires_at": _pending_changes[change_id]["expires_at"].isoformat(),
+            "expires_at": datetime.fromtimestamp(
+                record["expires_at"], tz=timezone.utc,
+            ).isoformat(),
+            "payload_digest": record["payload_digest"],
+        }
+
+    def _record_to_legacy_change(record: dict) -> dict:
+        """Map a ``PendingActions`` record to the legacy change dict.
+
+        ``_apply_pending_change`` was written against the old in-memory
+        shape (``agent_id`` / ``field`` / ``old_value`` / ``new_value``).
+        Rather than rewrite it, the SQLite-backed endpoints translate
+        records on the way in.
+        """
+        payload = record.get("payload") or {}
+        return {
+            "agent_id": record["target_id"],
+            "field": record["action_kind"],
+            "old_value": payload.get("old_value", ""),
+            "new_value": payload.get("new_value", ""),
+            "expires_at": datetime.fromtimestamp(
+                record["expires_at"], tz=timezone.utc,
+            ),
         }
 
     async def _apply_pending_change(change_id: str, change: dict) -> dict:
@@ -2848,24 +3048,53 @@ def create_mesh_app(
 
         return {"success": True, "agent_id": agent_id, "field": field}
 
+    def _confirm_origin_check(request: Request) -> None:
+        """Task 2d: confirm-side gate — refuse non-human origins.
+
+        Pending operator-config edits are durable, so an agent that
+        spoofed an X-Origin header (or a buggy adapter that promoted a
+        non-human origin) must not be able to flip the lever. The
+        propose endpoint records the proposer's origin kind on the row;
+        ``pending_actions.consume(require_origin_kind="human")`` then
+        rejects rows whose stored origin is not ``human``. We *also*
+        re-check the *current* request's origin here so a confirm
+        attempt that arrives without a human X-Origin is refused
+        immediately, before we ever consume the row.
+        """
+        confirm_origin = _validated_origin(request)
+        if confirm_origin is None or confirm_origin.kind != "human":
+            raise HTTPException(403, "Confirmation requires human origin")
+
     @app.post("/mesh/agents/{agent_id}/config")
     async def update_agent_config(agent_id: str, request: Request) -> dict:
         """Apply a pending config change. Used by confirm_edit tool."""
         _require_any_auth(request)
         if _resolve_agent_id("", request) != "operator":
             raise HTTPException(403, "Only the operator can apply config changes")
+        _confirm_origin_check(request)
         data = await request.json()
         change_id = data.get("change_id", "")
+        client_digest = data.get("payload_digest")
 
-        change = _get_pending_change(change_id)
-        if not change:
-            raise HTTPException(404, "Change not found or expired")
-        if change["agent_id"] != agent_id:
+        # Pre-flight: peek so we can preserve the legacy "agent ID
+        # mismatch" 400 (different from the generic invalid/expired
+        # response). Only ``consume`` actually deletes the row.
+        peek = pending_actions.peek(change_id)
+        if peek is not None and peek.get("target_id") != agent_id:
             raise HTTPException(400, "Agent ID mismatch")
-        # Consume only after validation passes
-        _consume_pending_change(change_id)
 
-        return await _apply_pending_change(change_id, change)
+        record = pending_actions.consume(
+            change_id,
+            confirmer="operator",
+            require_origin_kind="human",
+            expected_payload_digest=client_digest,
+        )
+        if not record:
+            raise HTTPException(400, "Pending action invalid or expired")
+
+        return await _apply_pending_change(
+            change_id, _record_to_legacy_change(record),
+        )
 
     @app.post("/mesh/config/confirm")
     async def confirm_config_change(request: Request) -> dict:
@@ -2879,18 +3108,26 @@ def create_mesh_app(
         _require_any_auth(request)
         if _resolve_agent_id("", request) != "operator":
             raise HTTPException(403, "Only the operator can confirm config changes")
+        _confirm_origin_check(request)
         data = await request.json()
         change_id = data.get("change_id", "")
+        client_digest = data.get("payload_digest")
 
-        change = _get_pending_change(change_id)
-        if not change:
-            raise HTTPException(404, "Change not found or expired")
-        # Consume before apply to prevent double-apply on retry. If
-        # _apply_pending_change raises, the change is already gone — the
-        # caller must propose a new change rather than retry this one.
-        _consume_pending_change(change_id)
+        # Consume + apply. ``consume`` is atomic: same nonce can only
+        # be applied once. If ``_apply_pending_change`` raises, the
+        # row is already gone -- the caller must propose a new change.
+        record = pending_actions.consume(
+            change_id,
+            confirmer="operator",
+            require_origin_kind="human",
+            expected_payload_digest=client_digest,
+        )
+        if not record:
+            raise HTTPException(400, "Pending action invalid or expired")
 
-        return await _apply_pending_change(change_id, change)
+        return await _apply_pending_change(
+            change_id, _record_to_legacy_change(record),
+        )
 
     # === Browser Service Proxy ===
 

--- a/src/host/server.py
+++ b/src/host/server.py
@@ -2805,7 +2805,8 @@ def create_mesh_app(
     async def propose_agent_config_change(agent_id: str, request: Request) -> dict:
         """Create a pending config change for review."""
         _require_any_auth(request)
-        if _resolve_agent_id("", request) != "operator":
+        caller = _resolve_agent_id("", request)
+        if caller != "operator":
             raise HTTPException(403, "Only the operator can propose config changes")
         data = await request.json()
 
@@ -2851,7 +2852,7 @@ def create_mesh_app(
         # gate on ``origin_kind="human"`` (Task 2d). When the X-Origin
         # header is missing or unverifiable the row stores ``None`` and
         # the confirm endpoint will refuse to apply.
-        origin = _validated_origin(request)
+        origin = _validated_origin(request, caller)
         origin_kind = origin.kind if origin is not None else None
 
         # Cap to ``_MAX_PENDING`` rows to bound storage growth -- mirrors
@@ -3048,7 +3049,7 @@ def create_mesh_app(
 
         return {"success": True, "agent_id": agent_id, "field": field}
 
-    def _confirm_origin_check(request: Request) -> None:
+    def _confirm_origin_check(request: Request, caller: str = "") -> None:
         """Task 2d: confirm-side gate — refuse non-human origins.
 
         Pending operator-config edits are durable, so an agent that
@@ -3061,7 +3062,7 @@ def create_mesh_app(
         attempt that arrives without a human X-Origin is refused
         immediately, before we ever consume the row.
         """
-        confirm_origin = _validated_origin(request)
+        confirm_origin = _validated_origin(request, caller)
         if confirm_origin is None or confirm_origin.kind != "human":
             raise HTTPException(403, "Confirmation requires human origin")
 
@@ -3069,9 +3070,10 @@ def create_mesh_app(
     async def update_agent_config(agent_id: str, request: Request) -> dict:
         """Apply a pending config change. Used by confirm_edit tool."""
         _require_any_auth(request)
-        if _resolve_agent_id("", request) != "operator":
+        caller = _resolve_agent_id("", request)
+        if caller != "operator":
             raise HTTPException(403, "Only the operator can apply config changes")
-        _confirm_origin_check(request)
+        _confirm_origin_check(request, caller)
         data = await request.json()
         change_id = data.get("change_id", "")
         client_digest = data.get("payload_digest")
@@ -3106,9 +3108,10 @@ def create_mesh_app(
         ``confirm_edit`` tool.
         """
         _require_any_auth(request)
-        if _resolve_agent_id("", request) != "operator":
+        caller = _resolve_agent_id("", request)
+        if caller != "operator":
             raise HTTPException(403, "Only the operator can confirm config changes")
-        _confirm_origin_check(request)
+        _confirm_origin_check(request, caller)
         data = await request.json()
         change_id = data.get("change_id", "")
         client_digest = data.get("payload_digest")

--- a/tests/test_cli_commands.py
+++ b/tests/test_cli_commands.py
@@ -1452,7 +1452,7 @@ class TestREPLOriginStamp:
         assert captured_headers, "stream_request was never invoked"
         hdrs = captured_headers[0] or {}
         assert "X-Origin" in hdrs
-        parsed = MessageOrigin.from_header_value(hdrs["X-Origin"])
+        parsed = MessageOrigin.from_header_value(hdrs["X-Origin"], trust_kind=True)
         assert parsed is not None
         assert parsed.kind == "human"
         assert parsed.channel == "cli"

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -4468,7 +4468,7 @@ class TestDashboardOriginStamp:
         wire = headers.get("X-Origin") or headers.get("x-origin")
         if not wire:
             return None
-        parsed = MessageOrigin.from_header_value(wire)
+        parsed = MessageOrigin.from_header_value(wire, trust_kind=True)
         return parsed
 
     def test_api_chat_stamps_human_dashboard_origin(self):

--- a/tests/test_operator_audit.py
+++ b/tests/test_operator_audit.py
@@ -184,8 +184,13 @@ def test_consume_nonexistent_change():
 def test_expired_changes_cleaned_up():
     """Expired changes are removed during cleanup."""
     change_id = _store_pending_change("alpha", "model", "old", "new")
-    # Manually expire it
-    _pending_changes[change_id]["expires_at"] = datetime.now(timezone.utc) - timedelta(seconds=1)
+    # Manually expire it. ``_pending_changes`` is a SQLite-backed proxy
+    # (Task 2d), so the in-place mutation pattern ``[cid]["expires_at"]
+    # = ...`` no longer round-trips. Use the proxy's ``__setitem__``
+    # which performs a single-column UPDATE on the row.
+    _pending_changes[change_id] = {
+        "expires_at": datetime.now(timezone.utc) - timedelta(seconds=1),
+    }
 
     _cleanup_expired_changes()
     assert change_id not in _pending_changes

--- a/tests/test_pending_actions.py
+++ b/tests/test_pending_actions.py
@@ -1,0 +1,363 @@
+"""Tests for the SQLite-backed PendingActions store (Task 2d).
+
+The legacy in-memory ``_pending_changes`` dict in ``src/host/server.py``
+was replaced with a persistent SQLite-backed store. These tests cover:
+
+* basic store / peek / consume semantics
+* atomic single-shot consume (replay protection)
+* expiry cleanup
+* origin / actor / payload-digest gates on consume
+* list_pending excludes expired
+* schema migration is idempotent
+* persistence across reopen
+* concurrent consumes serialize via ``BEGIN IMMEDIATE``
+"""
+
+from __future__ import annotations
+
+import threading
+import time
+
+from src.host.pending_actions import PendingActions, _payload_digest
+
+
+def _make_store(tmp_path) -> PendingActions:
+    return PendingActions(db_path=str(tmp_path / "pending.db"))
+
+
+# ── Basic API ─────────────────────────────────────────────────────
+
+
+def test_store_and_peek_returns_record_without_consuming(tmp_path):
+    pa = _make_store(tmp_path)
+    rec = pa.store(
+        nonce="n1",
+        actor="operator",
+        target_kind="agent",
+        target_id="alpha",
+        action_kind="model",
+        payload={"old_value": "gpt-4o", "new_value": "claude"},
+        origin_kind="human",
+    )
+    assert rec["nonce"] == "n1"
+    assert rec["payload_digest"]
+    assert rec["origin_kind"] == "human"
+
+    # Peek twice -- both should return the record (no consumption).
+    p1 = pa.peek("n1")
+    p2 = pa.peek("n1")
+    assert p1 is not None and p2 is not None
+    assert p1["target_id"] == "alpha"
+    assert p1["action_kind"] == "model"
+    assert p1["payload"] == {"old_value": "gpt-4o", "new_value": "claude"}
+
+
+def test_store_then_consume_returns_record_then_none(tmp_path):
+    pa = _make_store(tmp_path)
+    pa.store(
+        nonce="n1", actor="operator", target_kind="agent",
+        target_id="alpha", action_kind="model", payload={"x": 1},
+    )
+    first = pa.consume("n1")
+    second = pa.consume("n1")
+    assert first is not None
+    assert first["target_id"] == "alpha"
+    assert second is None  # already consumed
+
+
+def test_consume_unknown_nonce_returns_none(tmp_path):
+    pa = _make_store(tmp_path)
+    assert pa.consume("does-not-exist") is None
+
+
+def test_peek_unknown_nonce_returns_none(tmp_path):
+    pa = _make_store(tmp_path)
+    assert pa.peek("does-not-exist") is None
+
+
+# ── Expiry ────────────────────────────────────────────────────────
+
+
+def test_expired_peek_returns_none(tmp_path):
+    pa = _make_store(tmp_path)
+    pa.store(
+        nonce="n1", actor="operator", target_kind="agent",
+        target_id="alpha", action_kind="model", payload={"x": 1},
+        ttl=0,  # already expired
+    )
+    # Force the boundary by sleeping a hair to ensure now > expires_at.
+    time.sleep(0.01)
+    assert pa.peek("n1") is None
+
+
+def test_expired_consume_returns_none_and_deletes_row(tmp_path):
+    pa = _make_store(tmp_path)
+    pa.store(
+        nonce="n1", actor="operator", target_kind="agent",
+        target_id="alpha", action_kind="model", payload={"x": 1},
+        ttl=0,
+    )
+    time.sleep(0.01)
+    assert pa.consume("n1") is None
+    # Row should be gone -- a fresh store with the same nonce works.
+    pa.store(
+        nonce="n1", actor="operator", target_kind="agent",
+        target_id="beta", action_kind="model", payload={"y": 2},
+    )
+    assert pa.peek("n1")["target_id"] == "beta"
+
+
+def test_reap_expired_only_drops_expired(tmp_path):
+    pa = _make_store(tmp_path)
+    pa.store(
+        nonce="alive", actor="operator", target_kind="agent",
+        target_id="alpha", action_kind="model", payload={"x": 1},
+        ttl=300,
+    )
+    pa.store(
+        nonce="dead", actor="operator", target_kind="agent",
+        target_id="beta", action_kind="model", payload={"y": 2},
+        ttl=0,
+    )
+    time.sleep(0.01)
+    deleted = pa.reap_expired()
+    assert deleted == 1
+    assert pa.peek("alive") is not None
+    assert pa.peek("dead") is None
+
+
+def test_list_pending_excludes_expired(tmp_path):
+    pa = _make_store(tmp_path)
+    pa.store(
+        nonce="a", actor="operator", target_kind="agent",
+        target_id="alpha", action_kind="model", payload={}, ttl=300,
+    )
+    pa.store(
+        nonce="b", actor="operator", target_kind="agent",
+        target_id="beta", action_kind="model", payload={}, ttl=0,
+    )
+    time.sleep(0.01)
+    rows = pa.list_pending()
+    assert [r["nonce"] for r in rows] == ["a"]
+
+
+# ── Confirm-side gates ────────────────────────────────────────────
+
+
+def test_consume_wrong_confirmer_preserves_row(tmp_path):
+    pa = _make_store(tmp_path)
+    pa.store(
+        nonce="n1", actor="operator", target_kind="agent",
+        target_id="alpha", action_kind="model", payload={"x": 1},
+    )
+    # Wrong confirmer -- returns None and does NOT delete.
+    assert pa.consume("n1", confirmer="someone-else") is None
+    assert pa.peek("n1") is not None
+    # Right confirmer -- succeeds.
+    assert pa.consume("n1", confirmer="operator") is not None
+
+
+def test_consume_wrong_payload_digest_preserves_row(tmp_path):
+    pa = _make_store(tmp_path)
+    rec = pa.store(
+        nonce="n1", actor="operator", target_kind="agent",
+        target_id="alpha", action_kind="model", payload={"x": 1},
+    )
+    bogus_digest = "0" * 64
+    assert pa.consume("n1", expected_payload_digest=bogus_digest) is None
+    assert pa.peek("n1") is not None
+    # Real digest -- succeeds.
+    assert pa.consume("n1", expected_payload_digest=rec["payload_digest"]) is not None
+
+
+def test_consume_origin_kind_mismatch_preserves_row(tmp_path):
+    pa = _make_store(tmp_path)
+    pa.store(
+        nonce="n1", actor="operator", target_kind="agent",
+        target_id="alpha", action_kind="model", payload={"x": 1},
+        origin_kind="agent",
+    )
+    # Require human, row says agent -- refuse.
+    assert pa.consume("n1", require_origin_kind="human") is None
+    # Row preserved.
+    assert pa.peek("n1") is not None
+
+
+def test_consume_origin_kind_match_succeeds(tmp_path):
+    pa = _make_store(tmp_path)
+    pa.store(
+        nonce="n1", actor="operator", target_kind="agent",
+        target_id="alpha", action_kind="model", payload={"x": 1},
+        origin_kind="human",
+    )
+    assert pa.consume("n1", require_origin_kind="human") is not None
+
+
+def test_consume_origin_kind_required_but_missing(tmp_path):
+    """A row without origin_kind cannot satisfy require_origin_kind="human"."""
+    pa = _make_store(tmp_path)
+    pa.store(
+        nonce="n1", actor="operator", target_kind="agent",
+        target_id="alpha", action_kind="model", payload={"x": 1},
+        origin_kind=None,
+    )
+    assert pa.consume("n1", require_origin_kind="human") is None
+    assert pa.peek("n1") is not None  # still there
+
+
+def test_payload_digest_is_stable_across_dict_orderings():
+    """Equivalent payloads with reordered keys must hash identically."""
+    a = _payload_digest({"a": 1, "b": 2})
+    b = _payload_digest({"b": 2, "a": 1})
+    c = _payload_digest({"a": 1, "b": 3})
+    assert a == b
+    assert a != c
+
+
+# ── Schema / migration ────────────────────────────────────────────
+
+
+def test_init_schema_is_idempotent(tmp_path):
+    pa = _make_store(tmp_path)
+    # Calling twice must not blow up.
+    pa._init_schema()
+    pa._init_schema()
+    # Sanity: store still works after re-init.
+    pa.store(
+        nonce="n1", actor="operator", target_kind="agent",
+        target_id="alpha", action_kind="model", payload={"x": 1},
+    )
+    assert pa.peek("n1") is not None
+
+
+def test_persistence_across_reopen(tmp_path):
+    """Records survive reopening the database (mesh-restart scenario)."""
+    db_path = str(tmp_path / "pending.db")
+    pa1 = PendingActions(db_path=db_path)
+    pa1.store(
+        nonce="n1", actor="operator", target_kind="agent",
+        target_id="alpha", action_kind="model",
+        payload={"old_value": "gpt-4o", "new_value": "claude"},
+        origin_kind="human", ttl=300,
+    )
+    # Drop the first instance entirely.
+    del pa1
+    # Reopen.
+    pa2 = PendingActions(db_path=db_path)
+    rec = pa2.peek("n1")
+    assert rec is not None
+    assert rec["target_id"] == "alpha"
+    assert rec["origin_kind"] == "human"
+    assert rec["payload"] == {"old_value": "gpt-4o", "new_value": "claude"}
+
+
+# ── Concurrency ──────────────────────────────────────────────────
+
+
+def test_concurrent_consume_serializes(tmp_path):
+    """BEGIN IMMEDIATE in consume serializes two threads on the same nonce.
+
+    Two threads race to consume the same nonce. Exactly one wins; the
+    other returns None. (The losing thread's BEGIN IMMEDIATE waits on
+    SQLite's busy_timeout for the winner to commit; once that happens,
+    the loser sees an empty row and returns None.)
+    """
+    pa = _make_store(tmp_path)
+    pa.store(
+        nonce="n1", actor="operator", target_kind="agent",
+        target_id="alpha", action_kind="model", payload={"x": 1},
+    )
+    results: list = []
+    barrier = threading.Barrier(2)
+
+    def worker():
+        barrier.wait()
+        results.append(pa.consume("n1"))
+
+    t1 = threading.Thread(target=worker)
+    t2 = threading.Thread(target=worker)
+    t1.start()
+    t2.start()
+    t1.join()
+    t2.join()
+
+    successes = [r for r in results if r is not None]
+    assert len(successes) == 1, f"expected exactly one success, got {results}"
+
+
+# ── Replace-on-duplicate behavior ─────────────────────────────────
+
+
+def test_duplicate_nonce_replaces_row(tmp_path):
+    """INSERT OR REPLACE: storing the same nonce twice replaces the row.
+
+    Rationale (documented in PendingActions docstring): the propose
+    endpoint generates fresh UUIDs, so a collision in production
+    indicates a deliberate re-propose. Replacing the prior payload is
+    the correct semantic.
+    """
+    pa = _make_store(tmp_path)
+    pa.store(
+        nonce="n1", actor="operator", target_kind="agent",
+        target_id="alpha", action_kind="model",
+        payload={"old_value": "x", "new_value": "y"},
+    )
+    pa.store(
+        nonce="n1", actor="operator", target_kind="agent",
+        target_id="alpha", action_kind="model",
+        payload={"old_value": "x", "new_value": "z"},
+    )
+    rec = pa.peek("n1")
+    # New payload won.
+    assert rec["payload"]["new_value"] == "z"
+    # And only one row exists.
+    assert len(pa.list_pending()) == 1
+
+
+# ── Reap on consume / store ──────────────────────────────────────
+
+
+def test_opportunistic_reap_runs_on_store(tmp_path):
+    pa = _make_store(tmp_path)
+    pa.store(
+        nonce="dead", actor="operator", target_kind="agent",
+        target_id="alpha", action_kind="model", payload={}, ttl=0,
+    )
+    time.sleep(0.01)
+    # Storing a fresh row triggers opportunistic reap.
+    pa.store(
+        nonce="alive", actor="operator", target_kind="agent",
+        target_id="beta", action_kind="model", payload={}, ttl=300,
+    )
+    assert pa.peek("dead") is None
+    assert pa.peek("alive") is not None
+
+
+def test_safe_reap_swallows_errors(tmp_path, monkeypatch):
+    """_safe_reap must never raise even when reap_expired raises."""
+    pa = _make_store(tmp_path)
+
+    def boom():
+        raise RuntimeError("simulated database failure")
+
+    monkeypatch.setattr(pa, "reap_expired", boom)
+    # Must not raise.
+    pa._safe_reap()
+
+
+# ── Optional edge: list_pending returns ordered ──────────────────
+
+
+def test_list_pending_ordered_by_created_at(tmp_path):
+    pa = _make_store(tmp_path)
+    pa.store(
+        nonce="first", actor="operator", target_kind="agent",
+        target_id="alpha", action_kind="model", payload={}, ttl=300,
+    )
+    time.sleep(0.005)
+    pa.store(
+        nonce="second", actor="operator", target_kind="agent",
+        target_id="beta", action_kind="model", payload={}, ttl=300,
+    )
+    rows = pa.list_pending()
+    assert [r["nonce"] for r in rows] == ["first", "second"]


### PR DESCRIPTION
## Summary

Fourth slice of **Task 2** (origin as authorization input). Replaces the in-memory `_pending_changes` dict with a SQLite-backed `pending_actions` table. Pending operator-config edits now survive mesh restarts. Adds payload digest (replay protection), origin kind enforcement at confirm time, and an audit-shaped schema for future Task 9 dashboard surfacing.

**Branch base:** `feat/origin-channel-pairing-recheck` (PR #825) → 824 → 823 → 822 → 821 → main.

## What ships

**New module** `src/host/pending_actions.py` (341 lines):
- Schema: `(nonce PRIMARY KEY, actor, target_kind, target_id, action_kind, payload_json, payload_digest, origin_kind, created_at, expires_at, status)` with indexes on `expires_at` and `(target_kind, target_id)`. WAL + `busy_timeout=30000` — mirrors `Blackboard`.
- `store(...)`, `peek(nonce)`, `consume(nonce, *, confirmer, require_origin_kind, expected_payload_digest)`, `reap_expired()`, `list_pending()`.
- `consume` is atomic — either deletes the row and returns it, or returns `None` on unknown / expired / digest-mismatch / wrong-actor / origin-below-required.
- Reaper runs opportunistically on each store/consume — no new scheduler.

**`src/host/server.py` integration:**
- Module-level singleton wired by `create_mesh_app` to `data/pending_actions.db`.
- **Backward-compat shim:** `_pending_changes` presents a dict-like proxy over the SQLite store so existing tests that did `__getitem__`, `__setitem__` (single-column update), `__contains__`, `.clear()`, `len()` keep working. Documented as a Task 2d shim to be removed after callers migrate.
- Confirm endpoint uses **Task 2c's `_validated_origin`** to fetch the origin (with pairing recheck), then consumes with `require_origin_kind="human"`. Three confirm-side gates: caller must match proposer (anti-impersonation), payload digest must match (anti-replay), origin must be human (no agent-driven durable confirms).

**Operator tool** (`src/agent/builtins/operator_tools.py`):
- `confirm_edit` handles the new HTTP 400 "Pending action invalid or expired" alongside the legacy 404 "not found" so the re-propose UX keeps working through the migration.

## Tests

- 21 new in `tests/test_pending_actions.py`: store/peek/consume atomicity, expired-then-consume cleanup, wrong confirmer rejection, payload digest mismatch, origin-kind gate, reap_expired, list_pending exclusion of expired rows, schema migration idempotent, concurrent consume race (only one wins), persist across reopen, INSERT-OR-REPLACE replay behavior documented.
- 1 update in `tests/test_operator_audit.py` so an in-place `expires_at` mutation uses the dict-proxy `__setitem__` pattern (in-place dict mutation doesn't round-trip to SQLite).

## Test plan

- [x] `pytest tests/test_pending_actions.py` — 21 passed
- [x] Full non-E2E suite — 5024 passed, 44 skipped, 5 deselected (4 inherited Task 2b failures + version flag pre-existing). **No new failures.**
- [x] Replay protection: same `(nonce, payload)` consumed twice returns the record on first call, `None` on second
- [x] Persist across reopen: row survives DB connection close/reopen

## What's deliberately NOT in this PR

- `/mesh/wake` worker → operator block (Task 2e — flips one of #822's capture-to-tighten tests).
- HMAC-signed origin token across mesh→agent hop (Tier 2/3 follow-up).
- Dashboard / CLI surfacing of `list_pending()` (Task 9).

## Stack

1. #821 — Task 0 hotfix ✅
2. #822 — Task 1 characterization tests
3. #823 — Task 2a typed model
4. #824 — Task 2b stamp sites (4 inherited failures — see #825 description)
5. #825 — Task 2c channel pairing recheck
6. **This PR** — Task 2d pending-actions SQLite
7. (next) Task 2e wake-block, Task 3 perm split, Task 4 operator auth, Task 5 project isolation