### PR TITLE
feat(permissions): split can_spawn into control-plane permission set (Task 3)

### DIFF
--- a/src/cli/config.py
+++ b/src/cli/config.py
@@ -477,8 +477,16 @@ def _add_agent_permissions(name: str, permissions: dict | None = None) -> None:
                 existing = set(agent_perms.get(key, []))
                 existing.update(tpl_values)
                 agent_perms[key] = sorted(existing)
-        # Boolean flags — template can override defaults
-        for key in ("can_use_browser", "can_spawn", "can_manage_cron"):
+        # Boolean flags — template can override defaults. Includes the
+        # six control-plane permissions from Task 3 so the operator's
+        # explicit grants in ``_ensure_operator_agent`` get persisted to
+        # permissions.json instead of being silently dropped.
+        for key in (
+            "can_use_browser", "can_spawn", "can_manage_cron",
+            "can_manage_fleet", "can_manage_projects", "can_edit_agent_config",
+            "can_view_fleet_metrics", "can_route_tasks",
+            "can_request_user_credentials",
+        ):
             if key in permissions:
                 agent_perms[key] = bool(permissions[key])
 
@@ -1339,6 +1347,26 @@ def _ensure_operator_agent(config_path: Path | None = None, default_model: str =
         if not op_perms.get("blackboard_write"):
             op_perms["blackboard_write"] = ["*"]
             needs_update = True
+        # Control-plane permissions (Task 3). Idempotent: only set when
+        # missing/falsy, so running this block twice is a no-op.
+        if not op_perms.get("can_manage_fleet", False):
+            op_perms["can_manage_fleet"] = True
+            needs_update = True
+        if not op_perms.get("can_manage_projects", False):
+            op_perms["can_manage_projects"] = True
+            needs_update = True
+        if not op_perms.get("can_edit_agent_config", False):
+            op_perms["can_edit_agent_config"] = True
+            needs_update = True
+        if not op_perms.get("can_view_fleet_metrics", False):
+            op_perms["can_view_fleet_metrics"] = True
+            needs_update = True
+        if not op_perms.get("can_route_tasks", False):
+            op_perms["can_route_tasks"] = True
+            needs_update = True
+        if not op_perms.get("can_request_user_credentials", False):
+            op_perms["can_request_user_credentials"] = True
+            needs_update = True
         if needs_update:
             perms.setdefault("permissions", {})[_OPERATOR_AGENT_ID] = op_perms
             _save_permissions(perms)
@@ -1366,6 +1394,13 @@ def _ensure_operator_agent(config_path: Path | None = None, default_model: str =
             "blackboard_write": ["*"],
             "can_publish": ["*"],
             "can_subscribe": ["*"],
+            # Control-plane permissions (Task 3) — operator gets all six.
+            "can_manage_fleet": True,
+            "can_manage_projects": True,
+            "can_edit_agent_config": True,
+            "can_view_fleet_metrics": True,
+            "can_route_tasks": True,
+            "can_request_user_credentials": True,
         },
     )
     # Force can_message=["*"] — _add_agent_permissions sets it to []

--- a/src/host/permissions.py
+++ b/src/host/permissions.py
@@ -117,6 +117,12 @@ class PermissionMatrix:
                 browser_actions=default.browser_actions,
                 can_spawn=default.can_spawn,
                 can_manage_cron=default.can_manage_cron,
+                can_manage_fleet=default.can_manage_fleet,
+                can_manage_projects=default.can_manage_projects,
+                can_edit_agent_config=default.can_edit_agent_config,
+                can_view_fleet_metrics=default.can_view_fleet_metrics,
+                can_route_tasks=default.can_route_tasks,
+                can_request_user_credentials=default.can_request_user_credentials,
                 can_use_wallet=default.can_use_wallet,
                 wallet_allowed_chains=default.wallet_allowed_chains,
                 wallet_spend_limit_per_tx_usd=default.wallet_spend_limit_per_tx_usd,
@@ -222,7 +228,15 @@ class PermissionMatrix:
         return action in allowed
 
     def can_spawn(self, agent_id: str) -> bool:
-        """Check if agent is allowed to spawn ephemeral agents."""
+        """Check if agent is allowed to spawn EPHEMERAL workers.
+
+        Task 3 narrowed the semantics: this gates short-lived spawns
+        (subagent / cron-triggered / template apply for transient
+        helpers) only. Durable fleet operations (creating named agents,
+        managing projects, editing config, viewing fleet metrics,
+        routing tasks, requesting user credentials) live on dedicated
+        control-plane checks below.
+        """
         if self._is_trusted(agent_id):
             return True
         perms = self.get_permissions(agent_id)
@@ -234,6 +248,44 @@ class PermissionMatrix:
             return True
         perms = self.get_permissions(agent_id)
         return perms.can_manage_cron
+
+    # === Control-plane permissions (Task 3) ===
+
+    def can_manage_fleet(self, agent_id: str) -> bool:
+        """Check if agent is allowed to create/register durable named agents."""
+        if self._is_trusted(agent_id):
+            return True
+        return self.get_permissions(agent_id).can_manage_fleet
+
+    def can_manage_projects(self, agent_id: str) -> bool:
+        """Check if agent is allowed to create/archive projects and manage membership."""
+        if self._is_trusted(agent_id):
+            return True
+        return self.get_permissions(agent_id).can_manage_projects
+
+    def can_edit_agent_config(self, agent_id: str) -> bool:
+        """Check if agent is allowed to propose/confirm edits to other agents' config."""
+        if self._is_trusted(agent_id):
+            return True
+        return self.get_permissions(agent_id).can_edit_agent_config
+
+    def can_view_fleet_metrics(self, agent_id: str) -> bool:
+        """Check if agent is allowed to read fleet-wide metrics endpoints."""
+        if self._is_trusted(agent_id):
+            return True
+        return self.get_permissions(agent_id).can_view_fleet_metrics
+
+    def can_route_tasks(self, agent_id: str) -> bool:
+        """Check if agent is allowed to create durable task records (Task 6)."""
+        if self._is_trusted(agent_id):
+            return True
+        return self.get_permissions(agent_id).can_route_tasks
+
+    def can_request_user_credentials(self, agent_id: str) -> bool:
+        """Check if agent is allowed to request credentials/login from the user."""
+        if self._is_trusted(agent_id):
+            return True
+        return self.get_permissions(agent_id).can_request_user_credentials
 
     def can_use_api(self, agent_id: str, service: str) -> bool:
         if self._is_trusted(agent_id):

--- a/src/host/server.py
+++ b/src/host/server.py
@@ -1479,6 +1479,12 @@ def create_mesh_app(
         """
         agent_id = _resolve_agent_id(data.get("agent_id", ""), request)
         await _check_rate_limit("notify", agent_id)
+        # TODO(Task 4): gate on ``permissions.can_request_user_credentials``.
+        # The capability bit is wired in Task 3 (defaults False for workers,
+        # True for operator), but enforcing it here today would block every
+        # non-operator agent from asking the user for a credential.  Task 4
+        # is responsible for populating the field on workers that actually
+        # need it (template-driven) before this gate flips to enforced.
 
         name = data.get("name", "")
         description = data.get("description", "")
@@ -1960,9 +1966,15 @@ def create_mesh_app(
         # Auth + permission check
         spawned_by = _resolve_agent_id(data.get("spawned_by", "unknown"), request)
         if _auth_tokens:
-            # In authenticated mode, require spawn permission
-            if not permissions.can_spawn(spawned_by):
-                raise HTTPException(403, f"Agent {spawned_by} is not allowed to spawn agents")
+            # Applying a fleet template creates DURABLE named agents — Task 3
+            # split this off ``can_spawn`` (which is now ephemeral-only) onto
+            # the new control-plane permission ``can_manage_fleet``.
+            if not permissions.can_manage_fleet(spawned_by):
+                raise HTTPException(
+                    403,
+                    f"Agent {spawned_by} is not allowed to apply fleet templates "
+                    "(requires can_manage_fleet)",
+                )
 
         template_name = data.get("template", "").strip()
         if not template_name:
@@ -2104,11 +2116,17 @@ def create_mesh_app(
         if container_manager is None:
             raise HTTPException(503, "Container manager not available")
 
-        # Auth + spawn permission
+        # Auth + permission check. Creating a durable named agent is a
+        # control-plane action — Task 3 split this off ``can_spawn`` onto
+        # the dedicated ``can_manage_fleet`` capability.
         agent_id = _resolve_agent_id(data.get("agent_id", ""), request)
         await _check_rate_limit("spawn", agent_id)
-        if not permissions.can_spawn(agent_id):
-            raise HTTPException(403, f"Agent {agent_id} is not allowed to create agents")
+        if not permissions.can_manage_fleet(agent_id):
+            raise HTTPException(
+                403,
+                f"Agent {agent_id} is not allowed to create agents "
+                "(requires can_manage_fleet)",
+            )
 
         # Validate inputs
         name = data.get("name", "")

--- a/src/shared/types.py
+++ b/src/shared/types.py
@@ -292,8 +292,25 @@ class AgentPermissions(BaseModel):
                                                # (opt-out restriction).
                                                # [] = no actions (equivalent
                                                # to can_use_browser=False).
+    # ``can_spawn`` (Task 3 narrowed semantics): gates EPHEMERAL spawning
+    # only — subagents, cron-triggered spawns, and template applies that
+    # produce short-lived workers. Durable fleet operations (creating
+    # named agents, managing projects, editing config, viewing fleet
+    # metrics, routing tasks, requesting user credentials) now live on
+    # the dedicated control-plane permissions below. Workers default to
+    # ``can_spawn=False``; the operator gets it via _ensure_operator_agent.
     can_spawn: bool = False
     can_manage_cron: bool = False
+    # Control-plane permissions split from ``can_spawn`` (Task 3).
+    # Workers default to False; operator defaults to True. Missing fields
+    # on existing agent records default to False at load time so
+    # pre-existing configs don't accidentally grant durable powers.
+    can_manage_fleet: bool = False         # /mesh/agents/create, register/deregister
+    can_manage_projects: bool = False      # project create/archive, membership
+    can_edit_agent_config: bool = False    # propose/confirm edits to instructions/soul/etc.
+    can_view_fleet_metrics: bool = False   # /mesh/system/metrics, /mesh/agents/{id}/metrics
+    can_route_tasks: bool = False          # durable task records (Task 6)
+    can_request_user_credentials: bool = False  # request_credential, request_browser_login
     can_use_wallet: bool = False
     wallet_allowed_chains: list[str] = []
     wallet_spend_limit_per_tx_usd: float = 0.0

--- a/tests/test_operator_create_agent.py
+++ b/tests/test_operator_create_agent.py
@@ -51,6 +51,7 @@ def mesh_app(tmp_path, _mesh_env, container_mgr):
             "operator": {
                 "can_message": ["*"],
                 "can_spawn": True,
+                "can_manage_fleet": True,
                 "blackboard_read": ["*"],
                 "blackboard_write": ["*"],
             },
@@ -66,6 +67,7 @@ def mesh_app(tmp_path, _mesh_env, container_mgr):
             agent_id="operator",
             can_message=["*"],
             can_spawn=True,
+            can_manage_fleet=True,
             blackboard_read=["*"],
             blackboard_write=["*"],
         ),

--- a/tests/test_permissions.py
+++ b/tests/test_permissions.py
@@ -653,20 +653,20 @@ class TestOperatorInboxGlobalCarveOut:
         # Sender may inspect only its own submitted output.
         assert m.can_read_blackboard("scout", "global/output/scout/ho_1") is True
 
-# ── Task 1 (characterization): can_spawn over-broad gate ──────────────
+# ── Task 3: can_spawn split ────────────────────────────────────────────
 #
-# Today ``can_spawn=True`` is one bit gating BOTH ephemeral-worker spawning
-# (subagent / cron / template apply) AND durable fleet operations (creating
-# named agents). Task 3 will introduce ``can_manage_fleet`` and split the
-# durable-fleet path off ``can_spawn``. The tests below pin three current
-# call sites:
+# Task 3 narrowed ``can_spawn`` to ephemeral spawning only (``/mesh/spawn``)
+# and moved durable fleet operations onto a new ``can_manage_fleet``
+# capability:
 #
-#   * ``permissions.can_spawn`` at ``host/server.py:1531``  → ``POST /mesh/spawn``
-#   * ``permissions.can_spawn`` at ``host/server.py:1608``  → ``POST /mesh/fleet/apply``
-#   * ``permissions.can_spawn`` at ``host/server.py:1754``  → ``POST /mesh/agents/create``
+#   * ``permissions.can_spawn``         → ``POST /mesh/spawn``       (ephemeral)
+#   * ``permissions.can_manage_fleet``  → ``POST /mesh/fleet/apply`` (durable)
+#   * ``permissions.can_manage_fleet``  → ``POST /mesh/agents/create`` (durable)
 #
-# The first is ephemeral; the other two are durable fleet operations that
-# Task 3 wants to require ``can_manage_fleet`` for.
+# The first test below pins ``can_spawn`` keeping ephemeral semantics; the
+# next two assert the new ``can_manage_fleet`` requirement on the durable
+# endpoints (these used to be characterization captures of today's overly
+# broad ``can_spawn`` gate; Task 3 flipped them to enforce the split).
 
 class _SpawnRouteFixture:
     """Helper that builds a mesh app with a permissive ``container_manager``
@@ -674,7 +674,10 @@ class _SpawnRouteFixture:
     the actual container start by pre-creating an in-memory ``MagicMock``."""
 
     @staticmethod
-    def build(tmp_path, monkeypatch, *, can_spawn: bool):
+    def build(
+        tmp_path, monkeypatch, *, can_spawn: bool,
+        can_manage_fleet: bool = False, auth_tokens: dict | None = None,
+    ):
         from unittest.mock import AsyncMock, MagicMock
 
         from fastapi.testclient import TestClient
@@ -684,11 +687,11 @@ class _SpawnRouteFixture:
         from src.host.server import create_mesh_app
 
         cfg_dir = tmp_path / "config"
-        cfg_dir.mkdir()
+        cfg_dir.mkdir(exist_ok=True)
         skills_dir = tmp_path / "skills"
-        skills_dir.mkdir()
+        skills_dir.mkdir(exist_ok=True)
         templates_dir = tmp_path / "templates"
-        templates_dir.mkdir()
+        templates_dir.mkdir(exist_ok=True)
         # Minimal one-agent template for /mesh/fleet/apply.
         import yaml
         (templates_dir / "tinybot.yaml").write_text(yaml.dump({
@@ -717,6 +720,7 @@ class _SpawnRouteFixture:
             "permissions": {
                 "worker": {
                     "can_spawn": can_spawn,
+                    "can_manage_fleet": can_manage_fleet,
                     "can_message": ["mesh"],
                     "blackboard_read": [],
                     "blackboard_write": [],
@@ -745,6 +749,7 @@ class _SpawnRouteFixture:
         app = create_mesh_app(
             bb, pubsub, router, perms,
             container_manager=cm,
+            auth_tokens=auth_tokens,
         )
         client = TestClient(app)
         return {
@@ -778,48 +783,58 @@ def test_can_spawn_today_gates_mesh_spawn_endpoint(tmp_path, monkeypatch):
     fx["bb"].close()
 
 
-@pytest.mark.characterization
-def test_can_spawn_today_also_gates_fleet_apply_endpoint(tmp_path, monkeypatch):
-    # CAPTURE-TO-TIGHTEN — this test asserts today's over-broad behavior.
-    # After Task 3 (split can_spawn), this endpoint requires can_manage_fleet.
-    # When Task 3 lands: flip the assertion or delete this test, and add a
-    # negative test in test_permissions.py.
-    """A worker with ``can_spawn=True`` and otherwise-narrow permissions
-    can today reach ``POST /mesh/fleet/apply`` — applying a fleet template
-    is treated as just another spawn. After Task 3 it should require the
-    new ``can_manage_fleet`` capability instead.
+def test_fleet_apply_requires_can_manage_fleet(tmp_path, monkeypatch):
+    """Task 3: ``/mesh/fleet/apply`` is now gated on ``can_manage_fleet``,
+    not ``can_spawn``. A worker with only ``can_spawn=True`` is rejected;
+    granting ``can_manage_fleet`` lets the call through.
+
+    The ``/mesh/fleet/apply`` permission gate runs only when the mesh app
+    is built with auth tokens (production posture); pass ``auth_tokens``
+    to the fixture so the gate executes.
     """
-    fx = _SpawnRouteFixture.build(tmp_path, monkeypatch, can_spawn=True)
-    client = fx["client"]
-    # Auth is not configured on the test app, so the route reads
-    # ``data["spawned_by"]`` directly. We pass our worker.
-    resp = client.post(
+    auth = {"worker": "tok"}
+    headers = {"X-Agent-ID": "worker", "Authorization": "Bearer tok"}
+
+    # 1) can_spawn=True alone is no longer sufficient — 403.
+    fx = _SpawnRouteFixture.build(
+        tmp_path, monkeypatch,
+        can_spawn=True, can_manage_fleet=False, auth_tokens=auth,
+    )
+    resp = fx["client"].post(
         "/mesh/fleet/apply",
         json={"spawned_by": "worker", "template": "tinybot"},
-        headers={"X-Agent-ID": "worker"},
+        headers=headers,
     )
-    # Pin: today's behavior — succeeds because can_spawn is enough.
-    assert resp.status_code != 403, resp.text
-    # Either 200 (succeeded) or 5xx from a downstream stub failing — what
-    # we are pinning is "not 403 from the can_spawn gate."
-    assert resp.status_code < 500, resp.text
+    assert resp.status_code == 403, resp.text
+    assert "can_manage_fleet" in resp.text
     fx["bb"].close()
 
+    # 2) Granting can_manage_fleet lets the call past the gate.
+    fx2 = _SpawnRouteFixture.build(
+        tmp_path, monkeypatch,
+        can_spawn=True, can_manage_fleet=True, auth_tokens=auth,
+    )
+    resp2 = fx2["client"].post(
+        "/mesh/fleet/apply",
+        json={"spawned_by": "worker", "template": "tinybot"},
+        headers=headers,
+    )
+    # Past the can_manage_fleet gate — must NOT be 403 from that gate.
+    assert resp2.status_code != 403, resp2.text
+    fx2["bb"].close()
 
-@pytest.mark.characterization
-def test_can_spawn_today_also_gates_agents_create_endpoint(tmp_path, monkeypatch):
-    # CAPTURE-TO-TIGHTEN — this test asserts today's over-broad behavior.
-    # After Task 3 (split can_spawn), this endpoint requires can_manage_fleet.
-    # When Task 3 lands: flip the assertion or delete this test, and add a
-    # negative test in test_permissions.py.
-    """A worker with ``can_spawn=True`` and otherwise-narrow permissions
-    can today reach ``POST /mesh/agents/create`` — creating a durable
-    custom agent is treated as just another spawn. After Task 3 it
-    should require the new ``can_manage_fleet`` capability instead.
+
+def test_agents_create_requires_can_manage_fleet(tmp_path, monkeypatch):
+    """Task 3: ``/mesh/agents/create`` is now gated on ``can_manage_fleet``,
+    not ``can_spawn``. A worker with only ``can_spawn=True`` is rejected;
+    granting ``can_manage_fleet`` lets the call through.
     """
-    fx = _SpawnRouteFixture.build(tmp_path, monkeypatch, can_spawn=True)
-    client = fx["client"]
-    resp = client.post(
+    # 1) can_spawn=True alone is no longer sufficient — 403.
+    fx = _SpawnRouteFixture.build(
+        tmp_path, monkeypatch,
+        can_spawn=True, can_manage_fleet=False,
+    )
+    resp = fx["client"].post(
         "/mesh/agents/create",
         json={
             "agent_id": "worker",
@@ -829,12 +844,136 @@ def test_can_spawn_today_also_gates_agents_create_endpoint(tmp_path, monkeypatch
         },
         headers={"X-Agent-ID": "worker"},
     )
-    # Pin: today's behavior — succeeds because can_spawn is enough.
-    assert resp.status_code != 403, resp.text
-    # We don't lock to 200 — the downstream container manager is mocked
-    # and may return a 200 or a 500 depending on its internals; the key
-    # invariant here is we did NOT get the 403 from the can_spawn gate.
+    assert resp.status_code == 403, resp.text
+    assert "can_manage_fleet" in resp.text
     fx["bb"].close()
+
+    # 2) Granting can_manage_fleet lets the call past the gate.
+    fx2 = _SpawnRouteFixture.build(
+        tmp_path, monkeypatch,
+        can_spawn=True, can_manage_fleet=True,
+    )
+    resp2 = fx2["client"].post(
+        "/mesh/agents/create",
+        json={
+            "agent_id": "worker",
+            "name": "freshbot2",
+            "role": "tester",
+            "model": "openai/gpt-4o-mini",
+        },
+        headers={"X-Agent-ID": "worker"},
+    )
+    # Past the can_manage_fleet gate — not the 403 we get when narrow.
+    # Downstream may fail for other reasons (mocked container manager).
+    assert resp2.status_code != 403, resp2.text
+    fx2["bb"].close()
+
+
+# ── Task 3: control-plane permission methods ──────────────────────────
+
+
+class TestControlPlanePermissions:
+    """Task 3: ``can_spawn`` is now narrow; durable fleet operations
+    require new control-plane permissions.
+
+    The six bits split off ``can_spawn``:
+      * ``can_manage_fleet``           — create/register named agents
+      * ``can_manage_projects``        — create/archive projects, membership
+      * ``can_edit_agent_config``      — propose/confirm config edits
+      * ``can_view_fleet_metrics``     — fleet-wide metrics endpoints
+      * ``can_route_tasks``            — durable task records (Task 6)
+      * ``can_request_user_credentials`` — user-facing credential requests
+    """
+
+    _CONTROL_PLANE_FIELDS = (
+        "can_manage_fleet",
+        "can_manage_projects",
+        "can_edit_agent_config",
+        "can_view_fleet_metrics",
+        "can_route_tasks",
+        "can_request_user_credentials",
+    )
+
+    def _matrix(self, tmp_path, perms_dict: dict) -> PermissionMatrix:
+        path = tmp_path / "permissions.json"
+        path.write_text(json.dumps({"permissions": perms_dict}))
+        return PermissionMatrix(config_path=str(path))
+
+    def test_default_worker_lacks_control_plane_permissions(self, tmp_path):
+        # A bare worker entry without any of the new fields → all six False.
+        m = self._matrix(tmp_path, {"worker": {"can_spawn": True}})
+        for field in self._CONTROL_PLANE_FIELDS:
+            assert getattr(m, field)("worker") is False, field
+
+    def test_operator_has_all_control_plane_permissions(self, tmp_path, monkeypatch):
+        # Drive ``_ensure_operator_agent`` against a temp config and verify
+        # the persisted JSON sets all six bits to True.
+        from src.cli import config as cli_config
+        cfg_dir = tmp_path / "config"
+        cfg_dir.mkdir()
+        monkeypatch.setattr(cli_config, "PROJECT_ROOT", tmp_path)
+        monkeypatch.setattr(cli_config, "AGENTS_FILE", cfg_dir / "agents.yaml")
+        monkeypatch.setattr(cli_config, "PERMISSIONS_FILE", cfg_dir / "permissions.json")
+        monkeypatch.setattr(cli_config, "CONFIG_FILE", cfg_dir / "mesh.yaml")
+        cli_config._ensure_operator_agent(default_model="openai/gpt-4o-mini")
+        on_disk = json.loads((cfg_dir / "permissions.json").read_text())
+        op = on_disk["permissions"]["operator"]
+        for field in self._CONTROL_PLANE_FIELDS:
+            assert op.get(field) is True, field
+
+    def test_can_manage_fleet_method(self, tmp_path):
+        m = self._matrix(tmp_path, {
+            "narrow": {"can_spawn": True},
+            "broad": {"can_manage_fleet": True},
+        })
+        assert m.can_manage_fleet("narrow") is False
+        assert m.can_manage_fleet("broad") is True
+        assert m.can_manage_fleet("mesh") is True  # trusted shortcut
+
+    def test_can_manage_projects_method(self, tmp_path):
+        m = self._matrix(tmp_path, {
+            "narrow": {},
+            "broad": {"can_manage_projects": True},
+        })
+        assert m.can_manage_projects("narrow") is False
+        assert m.can_manage_projects("broad") is True
+        assert m.can_manage_projects("mesh") is True
+
+    def test_can_edit_agent_config_method(self, tmp_path):
+        m = self._matrix(tmp_path, {
+            "narrow": {},
+            "broad": {"can_edit_agent_config": True},
+        })
+        assert m.can_edit_agent_config("narrow") is False
+        assert m.can_edit_agent_config("broad") is True
+        assert m.can_edit_agent_config("mesh") is True
+
+    def test_can_view_fleet_metrics_method(self, tmp_path):
+        m = self._matrix(tmp_path, {
+            "narrow": {},
+            "broad": {"can_view_fleet_metrics": True},
+        })
+        assert m.can_view_fleet_metrics("narrow") is False
+        assert m.can_view_fleet_metrics("broad") is True
+        assert m.can_view_fleet_metrics("mesh") is True
+
+    def test_can_route_tasks_method(self, tmp_path):
+        m = self._matrix(tmp_path, {
+            "narrow": {},
+            "broad": {"can_route_tasks": True},
+        })
+        assert m.can_route_tasks("narrow") is False
+        assert m.can_route_tasks("broad") is True
+        assert m.can_route_tasks("mesh") is True
+
+    def test_can_request_user_credentials_method(self, tmp_path):
+        m = self._matrix(tmp_path, {
+            "narrow": {},
+            "broad": {"can_request_user_credentials": True},
+        })
+        assert m.can_request_user_credentials("narrow") is False
+        assert m.can_request_user_credentials("broad") is True
+        assert m.can_request_user_credentials("mesh") is True
 
 
 # ── Task 1 (characterization): wildcard blackboard ACL survives project moves ─


### PR DESCRIPTION
## Summary

Splits `can_spawn` (today: one bit gating both ephemeral worker spawning AND durable fleet operations) into a typed control-plane permission set. **Flips two of #822's capture-to-tighten tests.**

**Branch base:** `feat/wake-operator-worker-block` (PR #827) → … → `main`.

## New `AgentPermissions` fields

All default `False` — workers without explicit grant cannot reach durable surfaces. Documented `can_spawn`'s narrowed scope in a docstring.

| Field | Surface |
|---|---|
| `can_manage_fleet` | register/deregister, fleet template apply |
| `can_manage_projects` | project create/archive/membership |
| `can_edit_agent_config` | propose/confirm edits |
| `can_view_fleet_metrics` | system-wide metrics endpoints |
| `can_route_tasks` | durable task records (Task 6) |
| `can_request_user_credentials` | `request_credential`, `request_browser_login` |

Six matching methods on `PermissionMatrix` using the existing `_is_trusted` shortcut.

## Wired in this PR (1 of 6)

`can_manage_fleet` gates `/mesh/fleet/apply` and `/mesh/agents/create`, replacing `can_spawn` at those two sites. HTTP 403 messages name the new permission so a worker reading the response knows what to ask the operator for. **`can_spawn` is narrowed** to ephemeral spawning only (kept on `/mesh/spawn`).

## Added but not yet enforced (5 of 6)

| Field | Why deferred |
|---|---|
| `can_manage_projects` | Task 5 wires it on project membership |
| `can_edit_agent_config` | propose/confirm already operator-only via existing flow; not changed in this slice |
| `can_view_fleet_metrics` | Task 5's project-scoping work touches `/mesh/system/metrics` and `/mesh/agents/{id}/metrics` |
| `can_route_tasks` | Task 6 (durable task records) |
| `can_request_user_credentials` | **TODO(Task 4)** — fresh enforcement here would block every non-operator agent (workers default `False`); Task 4 must populate it on workers that need it before flipping the gate |

## Operator defaults

`_ensure_operator_agent` upgrade path adds all six bits idempotently (only when missing/falsy); new-operator path passes all six as `True`. Extended `_add_agent_permissions`'s boolean-merge tuple so the six new keys are honored from a `permissions` dict.

## Test changes

**Flipped 2 captures:**
- `test_can_spawn_today_also_gates_fleet_apply_endpoint` → `test_fleet_apply_requires_can_manage_fleet`
- `test_can_spawn_today_also_gates_agents_create_endpoint` → `test_agents_create_requires_can_manage_fleet`

Both now assert HTTP 403 when `can_spawn=True, can_manage_fleet=False` and ≠403 when `can_manage_fleet=True`. Markers removed.

**New `TestControlPlanePermissions` class** — 8 small tests covering: default worker lacks all six; operator gains all six via `_ensure_operator_agent`; per-method narrow=False / broad=True / trusted=True via `PermissionMatrix`.

**Fixture update** in `test_operator_create_agent.py` — added `can_manage_fleet: True` to the operator entry in `mesh_app` so `/mesh/agents/create` succeeds. The Task 1 pin `test_default_capabilities_seed_full_coordination_protocol` is unchanged and still passes.

## Test plan

- [x] `pytest tests/test_permissions.py tests/test_operator_create_agent.py tests/test_projects.py tests/test_dashboard.py tests/test_mesh.py` — 495 passed
- [x] Full non-E2E suite — 5036 passed, 44 skipped, 5 deselected (same 4 inherited Task 2b failures + version flag). **No new failures.**
- [x] `pytest -m characterization --collect-only` — 6 → 4 (3 wildcard-blackboard captures for Task 5 + 1 pin)
- [x] `_ensure_operator_agent` is idempotent — running twice produces identical persisted JSON

## Stack

1. #821 — Task 0 hotfix ✅
2. #822 — Task 1 characterization tests
3. #823 — Task 2a typed model
4. #824 — Task 2b stamp sites
5. #825 — Task 2c channel pairing recheck
6. #826 — Task 2d pending-actions SQLite
7. #827 — Task 2e wake block (closed Task 2)
8. **This PR** — Task 3 permissions split (flips 2 captures)
9. (next) Task 4 operator auth, Task 5 project isolation (flips 3 captures)