### PR TITLE
feat(scope): server-side project isolation in warn mode (Task 5)

### DIFF
--- a/src/cli/config.py
+++ b/src/cli/config.py
@@ -759,11 +759,18 @@ def _remove_agent_from_project(project: str, agent: str) -> None:
 def _add_project_blackboard_permissions(agent: str, project: str) -> None:
     """Grant blackboard access for a project member.
 
-    Only grants ``projects/{project}/*``.  The MeshClient auto-prefixes
-    all blackboard keys with the project namespace, so agents use natural
-    keys (``context/market``) which are transparently stored as
-    ``projects/{project}/context/market``.  This prevents cross-project
-    leakage — each project's data lives under its own namespace.
+    Grants ``projects/{project}/*`` and strips any pre-existing ``*``
+    wildcard so an agent cannot accumulate fleet-wide reach via project
+    moves (Task 5). The MeshClient auto-prefixes all blackboard keys
+    with the project namespace, so agents use natural keys
+    (``context/market``) which are transparently stored as
+    ``projects/{project}/context/market``. Each project's data lives
+    under its own namespace.
+
+    Pre-Task-5 fleets had ``["*"]`` ACLs that survived membership churn;
+    actively-managed fleets are narrowed here at every join. Legacy
+    in-place ``*`` ACLs that haven't been touched stay intact until
+    enforce mode tightens the read/write hot path.
     """
     perms = _load_permissions()
     agent_perms = perms.get("permissions", {}).get(agent)
@@ -772,17 +779,27 @@ def _add_project_blackboard_permissions(agent: str, project: str) -> None:
     project_pattern = f"projects/{project}/*"
     for field in ("blackboard_read", "blackboard_write"):
         patterns = agent_perms.get(field, [])
-        if project_pattern not in patterns:
-            patterns.append(project_pattern)
-        agent_perms[field] = patterns
+        # Strip any wildcard — replaced by the explicit project pattern
+        # below. This is the active narrowing for Task 5: an agent that
+        # previously had ``["*"]`` and is then added to a project ends
+        # up with ``["projects/{project}/*"]``.
+        narrowed = [p for p in patterns if p != "*"]
+        if project_pattern not in narrowed:
+            narrowed.append(project_pattern)
+        agent_perms[field] = narrowed
     _save_permissions(perms)
 
 
 def _remove_project_blackboard_permissions(agent: str, project: str) -> None:
-    """Revoke all blackboard access when an agent leaves a project.
+    """Revoke project blackboard access when an agent leaves a project.
 
-    Clears the project namespace pattern, restoring the agent to
-    standalone state (no blackboard access).
+    Strips the project namespace pattern AND any pre-existing ``*``
+    wildcard. Leaves an agent with whatever non-wildcard, non-target
+    patterns it had — typically empty for a project member, restoring
+    the agent to a standalone (no-blackboard) state. Wildcard stripping
+    matches the add-side narrowing so an agent that ever had ``*`` does
+    not reacquire fleet-wide reach by being added to and then removed
+    from a project (Task 5).
     """
     perms = _load_permissions()
     agent_perms = perms.get("permissions", {}).get(agent)
@@ -791,9 +808,13 @@ def _remove_project_blackboard_permissions(agent: str, project: str) -> None:
     project_pattern = f"projects/{project}/*"
     for field in ("blackboard_read", "blackboard_write"):
         patterns = agent_perms.get(field, [])
-        if project_pattern in patterns:
-            patterns.remove(project_pattern)
-        agent_perms[field] = patterns
+        # Drop both the target project pattern and any surviving ``*``.
+        # The wildcard strip is the safety net for an agent whose ACL
+        # was never re-narrowed (e.g. config-edited directly): once the
+        # membership system touches it on remove, the wildcard goes.
+        agent_perms[field] = [
+            p for p in patterns if p != project_pattern and p != "*"
+        ]
     _save_permissions(perms)
 
 

--- a/src/host/server.py
+++ b/src/host/server.py
@@ -14,6 +14,7 @@ import asyncio
 import contextlib
 import hmac
 import json
+import os
 import re
 import time
 import uuid as _uuid
@@ -416,6 +417,64 @@ def _validated_origin(
     if _is_paired_user(origin.channel, origin.user):
         return origin
     return _downgrade_origin(origin, "unpaired channel user")
+
+
+# ── Task 5: Project scope isolation (warn → enforce) ──────────────────
+#
+# ``OPENLEGION_PROJECT_SCOPE_MODE`` is the kill switch for the project
+# isolation rollout. ``warn`` (the default for the first release) keeps
+# legacy behavior — fleet-wide visibility on ``/mesh/agents``, additive
+# blackboard ACLs — but emits structured warnings whenever a call would
+# be denied under ``enforce``. Operators read the warn telemetry, then
+# flip to ``enforce`` once the soak window is clean. Read once at module
+# import (env vars don't change at runtime); invalid values fall back to
+# ``warn`` with a logged warning.
+_PROJECT_SCOPE_MODE = os.environ.get("OPENLEGION_PROJECT_SCOPE_MODE", "warn").lower()
+if _PROJECT_SCOPE_MODE not in {"warn", "enforce"}:
+    logger.warning(
+        "Invalid OPENLEGION_PROJECT_SCOPE_MODE=%r, defaulting to warn",
+        _PROJECT_SCOPE_MODE,
+    )
+    _PROJECT_SCOPE_MODE = "warn"
+
+
+# Counter surfaced on ``/mesh/system/metrics`` as ``scope_warn_total``.
+# Incremented every time a worker's call would have returned a smaller
+# response under enforce mode. Lets ops gauge soak-window readiness
+# before flipping the env var to ``enforce``.
+_scope_warn_count = 0
+
+
+def _record_scope_warn() -> None:
+    """Bump the warn-mode counter (visible on ``/mesh/system/metrics``)."""
+    global _scope_warn_count
+    _scope_warn_count += 1
+
+
+def _caller_projects(agent_id: str) -> set[str]:
+    """Return the project memberships visible to ``agent_id``.
+
+    Workers see only projects whose ``metadata.yaml`` lists them as
+    members. The operator and trusted internal callers (``mesh``) are
+    fleet-global by design — they get a sentinel meaning "all projects",
+    represented here as an empty set with the caller_is_global flag the
+    caller computes separately. Use the helper purely as a lookup of
+    *worker* memberships and branch on operator/internal in the caller.
+    """
+    if agent_id in {"operator", "mesh"}:
+        # Operator and the mesh-internal pseudo-id are global; the caller
+        # branches on those identities directly. Returning an empty set
+        # here forces callers to think about the global path and not
+        # silently include "every project" in a worker-style filter.
+        return set()
+    from src.cli.config import _load_projects
+
+    projects = _load_projects()
+    return {
+        name
+        for name, meta in projects.items()
+        if agent_id in meta.get("members", [])
+    }
 
 
 def create_mesh_app(
@@ -1695,12 +1754,39 @@ def create_mesh_app(
 
         - project set: return only that project's members
         - agent_id set (standalone): return only that agent
-        - neither (dashboard/internal): return all
+        - neither (dashboard/internal): return all (under enforce mode,
+          worker callers see only their own projects + operator)
+
+        Task 5 layered a per-caller filter on the unscoped path. Today's
+        legacy behavior is "every authenticated agent sees the full
+        fleet" — under ``OPENLEGION_PROJECT_SCOPE_MODE=enforce`` workers
+        see only members of their own projects (plus the always-global
+        operator). Under ``warn`` (the default), the response shape
+        stays legacy and a structured ``scope-warn`` log line is emitted
+        so operators can soak before flipping.
         """
         if agent_id:
             agent_id = _resolve_agent_id(agent_id, request)
         else:
             _require_any_auth(request)
+
+        # Resolve the caller for scope filtering. ``_extract_verified_agent_id``
+        # handles dev/test mode (no auth tokens → ``X-Agent-ID`` header
+        # hint or ``"unknown"``) and production (Bearer token → identity).
+        # Internal loopback callers are treated as global; their
+        # ``X-Agent-ID`` hint is ignored. The endpoint already gated
+        # auth above, so caller resolution can't 401 here.
+        caller_is_internal = _is_internal_caller(request)
+        if caller_is_internal:
+            caller = "mesh"
+        else:
+            try:
+                caller = _extract_verified_agent_id(request)
+            except HTTPException:
+                # Already passed _require_any_auth, but be defensive.
+                caller = "unknown"
+        caller_is_global = caller_is_internal or caller == "operator"
+
         def _agent_entry(aid: str, url: str) -> dict:
             entry: dict = {"url": url, "role": router.agent_roles.get(aid, "")}
             entry["capabilities"] = router.get_capabilities(aid)
@@ -1719,6 +1805,20 @@ def create_mesh_app(
                 logger.warning("list_agents: unknown project %r", project)
                 return {}
             members = set(pdata.get("members", []))
+
+            # Task 5: only members of the requested project (or global
+            # callers) may scope by it. Under warn mode, log but allow;
+            # under enforce, return empty.
+            if not caller_is_global and caller not in members:
+                _record_scope_warn()
+                logger.warning(
+                    "scope-warn: caller=%s requested /mesh/agents?project=%s "
+                    "but is not a member; mode=%s",
+                    caller, project, _PROJECT_SCOPE_MODE,
+                )
+                if _PROJECT_SCOPE_MODE == "enforce":
+                    return {}
+
             result = {
                 aid: _agent_entry(aid, url)
                 for aid, url in router.agent_registry.items()
@@ -1735,10 +1835,47 @@ def create_mesh_app(
             if url:
                 return {agent_id: _agent_entry(agent_id, url)}
             return {}
-        return {
+
+        # Unscoped path: full fleet for global callers; per-caller-project
+        # filter for workers (warn-logged, enforce-applied).
+        full_fleet = {
             aid: _agent_entry(aid, url)
             for aid, url in router.agent_registry.items()
         }
+        if caller_is_global:
+            return full_fleet
+
+        own_projects = _caller_projects(caller)
+        # Visible set: members of any project the caller belongs to,
+        # plus the always-global operator, plus the caller itself
+        # (a worker should always see its own entry — including
+        # standalone agents who belong to no project).
+        visible_members: set[str] = {caller}
+        if own_projects:
+            from src.cli.config import _load_projects
+            projects = _load_projects()
+            for pname in own_projects:
+                visible_members.update(projects.get(pname, {}).get("members", []))
+        if "operator" in router.agent_registry:
+            visible_members.add("operator")
+
+        filtered = {
+            aid: entry for aid, entry in full_fleet.items()
+            if aid in visible_members
+        }
+
+        # If the filter would have shrunk the response, emit warn
+        # telemetry so ops can size the soak before flipping the flag.
+        if len(filtered) < len(full_fleet):
+            _record_scope_warn()
+            logger.warning(
+                "scope-warn: caller=%s requested /mesh/agents (no project filter); "
+                "would return %d under enforce, returning %d under %s",
+                caller, len(filtered), len(full_fleet), _PROJECT_SCOPE_MODE,
+            )
+            if _PROJECT_SCOPE_MODE == "enforce":
+                return filtered
+        return full_fleet
 
     # === Agent Introspection ===
 
@@ -2694,6 +2831,13 @@ def create_mesh_app(
                 "max_projects": max_projects,
                 "current_projects": current_projects,
             },
+            # Task 5: count of warn-mode "would have denied" hits since
+            # process start. Operators watch this number drop toward
+            # zero before flipping ``OPENLEGION_PROJECT_SCOPE_MODE`` to
+            # ``enforce``. The flag itself is reported alongside so the
+            # operator dashboard can render the right state.
+            "scope_warn_total": _scope_warn_count,
+            "project_scope_mode": _PROJECT_SCOPE_MODE,
         }
 
     @app.get("/mesh/agents/{agent_id}/metrics")

--- a/tests/test_mesh.py
+++ b/tests/test_mesh.py
@@ -1427,3 +1427,235 @@ async def test_list_agents_unknown_project_returns_empty(tmp_path):
         bb.close()
         costs.close()
         traces.close()
+
+
+# ── Task 5: per-caller project scope filter on /mesh/agents ───────────
+
+
+def _build_scope_test_app(tmp_path, suffix: str = ""):
+    """Helper: build a mesh app + projects layout for Task 5 scope tests.
+
+    Lays out two projects (alpha with scout, beta with analyst) plus a
+    standalone ``loner`` and an ``operator``. Returns (app, projects_dir,
+    cleanup_fns) — caller wraps the projects_dir with the
+    ``PROJECTS_DIR`` patch and runs requests through ASGITransport.
+
+    ``suffix`` lets a single test build multiple isolated apps off the
+    same ``tmp_path`` (for tests that loop over modes).
+    """
+    import yaml
+
+    from src.host.costs import CostTracker
+    from src.host.server import create_mesh_app
+    from src.host.traces import TraceStore
+
+    base = tmp_path / f"scope{suffix}"
+    base.mkdir(parents=True, exist_ok=True)
+    projects_dir = base / "projects"
+    alpha_dir = projects_dir / "alpha"
+    alpha_dir.mkdir(parents=True)
+    (alpha_dir / "metadata.yaml").write_text(
+        yaml.dump({
+            "name": "alpha", "members": ["scout"],
+            "created_at": "2026-05-02T00:00:00+00:00",
+        }),
+    )
+    beta_dir = projects_dir / "beta"
+    beta_dir.mkdir(parents=True)
+    (beta_dir / "metadata.yaml").write_text(
+        yaml.dump({
+            "name": "beta", "members": ["analyst"],
+            "created_at": "2026-05-02T00:00:00+00:00",
+        }),
+    )
+
+    bb = Blackboard(db_path=str(base / "bb.db"))
+    pubsub = PubSub()
+    perms = PermissionMatrix()
+    router = MessageRouter(perms, {})
+    costs = CostTracker(str(base / "costs.db"))
+    traces = TraceStore(str(base / "traces.db"))
+
+    router.register_agent("operator", "http://operator:8400", [])
+    router.register_agent("scout", "http://scout:8400", [])
+    router.register_agent("analyst", "http://analyst:8400", [])
+    router.register_agent("loner", "http://loner:8400", [])
+
+    app = create_mesh_app(
+        blackboard=bb, pubsub=pubsub, router=router, permissions=perms,
+        cost_tracker=costs, trace_store=traces,
+    )
+
+    def _cleanup():
+        bb.close()
+        costs.close()
+        traces.close()
+
+    return app, projects_dir, _cleanup
+
+
+@pytest.mark.asyncio
+async def test_list_agents_worker_caller_warn_mode_logs_but_returns_legacy(
+    tmp_path, monkeypatch, caplog,
+):
+    """Task 5 warn mode: a worker calling unscoped ``/mesh/agents`` still
+    receives the full fleet (legacy behavior preserved during the soak
+    window) but a structured ``scope-warn`` log line is emitted so ops
+    can size the impact before flipping to enforce.
+    """
+    import importlib
+    import logging
+    from unittest.mock import patch
+
+    from httpx import ASGITransport, AsyncClient
+
+    monkeypatch.setenv("OPENLEGION_PROJECT_SCOPE_MODE", "warn")
+    import src.host.server as server_module
+    importlib.reload(server_module)
+
+    app, projects_dir, cleanup = _build_scope_test_app(tmp_path)
+
+    try:
+        with patch("src.cli.config.PROJECTS_DIR", projects_dir):
+            with caplog.at_level(logging.WARNING, logger="host.server"):
+                async with AsyncClient(
+                    transport=ASGITransport(app=app), base_url="http://test",
+                ) as client:
+                    resp = await client.get(
+                        "/mesh/agents",
+                        headers={"X-Agent-ID": "scout"},
+                    )
+        assert resp.status_code == 200
+        data = resp.json()
+        # Warn mode: full fleet still returned (legacy preserved).
+        assert set(data.keys()) == {"operator", "scout", "analyst", "loner"}
+        # But a structured scope-warn was emitted.
+        warn_lines = [r.message for r in caplog.records if "scope-warn" in r.message]
+        assert warn_lines, f"expected a scope-warn log line, got {[r.message for r in caplog.records]}"
+        assert any("caller=scout" in m for m in warn_lines)
+    finally:
+        cleanup()
+        # Restore default mode for other tests.
+        monkeypatch.delenv("OPENLEGION_PROJECT_SCOPE_MODE", raising=False)
+        importlib.reload(server_module)
+
+
+@pytest.mark.asyncio
+async def test_list_agents_worker_caller_enforce_mode_filters(
+    tmp_path, monkeypatch,
+):
+    """Task 5 enforce mode: a worker call returns only members of the
+    caller's own projects + the always-global operator. Other projects'
+    members and standalone non-members are stripped.
+    """
+    import importlib
+    from unittest.mock import patch
+
+    from httpx import ASGITransport, AsyncClient
+
+    monkeypatch.setenv("OPENLEGION_PROJECT_SCOPE_MODE", "enforce")
+    import src.host.server as server_module
+    importlib.reload(server_module)
+
+    app, projects_dir, cleanup = _build_scope_test_app(tmp_path)
+
+    try:
+        with patch("src.cli.config.PROJECTS_DIR", projects_dir):
+            async with AsyncClient(
+                transport=ASGITransport(app=app), base_url="http://test",
+            ) as client:
+                resp = await client.get(
+                    "/mesh/agents",
+                    headers={"X-Agent-ID": "scout"},
+                )
+        assert resp.status_code == 200
+        data = resp.json()
+        # Enforce mode: scout sees only own-project members + operator.
+        assert "scout" in data        # caller itself
+        assert "operator" in data     # always-global
+        assert "analyst" not in data  # other project
+        assert "loner" not in data    # standalone non-member
+    finally:
+        cleanup()
+        monkeypatch.delenv("OPENLEGION_PROJECT_SCOPE_MODE", raising=False)
+        importlib.reload(server_module)
+
+
+@pytest.mark.asyncio
+async def test_list_agents_operator_caller_unaffected(
+    tmp_path, monkeypatch,
+):
+    """The operator is fleet-global by design. Both warn and enforce
+    modes return the full fleet for the operator's unscoped call.
+    """
+    import importlib
+    from unittest.mock import patch
+
+    from httpx import ASGITransport, AsyncClient
+
+    for mode in ("warn", "enforce"):
+        monkeypatch.setenv("OPENLEGION_PROJECT_SCOPE_MODE", mode)
+        import src.host.server as server_module
+        importlib.reload(server_module)
+
+        app, projects_dir, cleanup = _build_scope_test_app(tmp_path, suffix=f"-op-{mode}")
+
+        try:
+            with patch("src.cli.config.PROJECTS_DIR", projects_dir):
+                async with AsyncClient(
+                    transport=ASGITransport(app=app), base_url="http://test",
+                ) as client:
+                    resp = await client.get(
+                        "/mesh/agents",
+                        headers={"X-Agent-ID": "operator"},
+                    )
+            assert resp.status_code == 200, f"mode={mode}"
+            data = resp.json()
+            assert set(data.keys()) == {"operator", "scout", "analyst", "loner"}, (
+                f"mode={mode}: expected full fleet, got {set(data.keys())}"
+            )
+        finally:
+            cleanup()
+            monkeypatch.delenv("OPENLEGION_PROJECT_SCOPE_MODE", raising=False)
+            importlib.reload(server_module)
+
+
+@pytest.mark.asyncio
+async def test_list_agents_internal_caller_unaffected(
+    tmp_path, monkeypatch,
+):
+    """Internal callers (loopback + ``x-mesh-internal: 1``) are
+    fleet-global like the operator. Both warn and enforce modes return
+    the full fleet — dashboards and the CLI manager process rely on
+    this for fleet rendering.
+    """
+    import importlib
+    from unittest.mock import patch
+
+    from httpx import ASGITransport, AsyncClient
+
+    for mode in ("warn", "enforce"):
+        monkeypatch.setenv("OPENLEGION_PROJECT_SCOPE_MODE", mode)
+        import src.host.server as server_module
+        importlib.reload(server_module)
+
+        app, projects_dir, cleanup = _build_scope_test_app(tmp_path, suffix=f"-int-{mode}")
+
+        try:
+            with patch("src.cli.config.PROJECTS_DIR", projects_dir):
+                async with AsyncClient(
+                    transport=ASGITransport(app=app), base_url="http://test",
+                ) as client:
+                    resp = await client.get(
+                        "/mesh/agents",
+                        headers={"x-mesh-internal": "1"},
+                    )
+            assert resp.status_code == 200, f"mode={mode}"
+            data = resp.json()
+            assert set(data.keys()) == {"operator", "scout", "analyst", "loner"}, (
+                f"mode={mode}: expected full fleet, got {set(data.keys())}"
+            )
+        finally:
+            cleanup()
+            monkeypatch.delenv("OPENLEGION_PROJECT_SCOPE_MODE", raising=False)
+            importlib.reload(server_module)

--- a/tests/test_permissions.py
+++ b/tests/test_permissions.py
@@ -976,24 +976,14 @@ class TestControlPlanePermissions:
         assert m.can_request_user_credentials("mesh") is True
 
 
-# ── Task 1 (characterization): wildcard blackboard ACL survives project moves ─
+# ── Task 5: wildcard blackboard ACLs replaced on project membership churn ─
 
 
-@pytest.mark.characterization
-def test_wildcard_blackboard_acl_survives_project_add(tmp_path, monkeypatch):
-    # CAPTURE-TO-TIGHTEN — this test asserts today's over-broad behavior.
-    # After Task 5 (project scope warn → enforce), an agent with a wildcard
-    # ACL who is added to a project should have the wildcard narrowed (or
-    # at least denied at the read/write gate when the key is outside the
-    # project namespace). When Task 5 lands: flip the assertion to verify
-    # the wildcard is removed / superseded, or delete this test and replace
-    # it with a positive test asserting "added agent can NOT read other
-    # projects' keys".
-    """``_add_project_blackboard_permissions`` is purely additive: it
-    appends ``projects/{name}/*`` to the agent's existing patterns and
-    never touches a pre-existing ``*``. The wildcard therefore survives
-    the move and the agent retains fleet-wide blackboard access — Task 5
-    will make this scope warn-then-enforce.
+def test_wildcard_blackboard_acl_replaced_on_project_add(tmp_path, monkeypatch):
+    """Pin: ``_add_project_blackboard_permissions`` strips any
+    pre-existing ``*`` wildcard and replaces it with the project-scoped
+    grant. An agent with broad fleet-wide reach can no longer carry it
+    forward through a project join.
     """
     from src.cli.config import _add_project_blackboard_permissions
 
@@ -1013,67 +1003,24 @@ def test_wildcard_blackboard_acl_survives_project_add(tmp_path, monkeypatch):
     perms = json.loads(perms_file.read_text())
     read = perms["permissions"]["rover"]["blackboard_read"]
     write = perms["permissions"]["rover"]["blackboard_write"]
-    # Wildcard survives — Task 5 should narrow.
-    assert "*" in read
-    assert "*" in write
-    # Project pattern was appended next to the wildcard.
+    # Wildcard is gone — replaced by the project pattern.
+    assert "*" not in read
+    assert "*" not in write
     assert "projects/alpha/*" in read
     assert "projects/alpha/*" in write
 
 
-@pytest.mark.characterization
-def test_wildcard_blackboard_acl_survives_project_remove(tmp_path, monkeypatch):
-    # CAPTURE-TO-TIGHTEN — this test asserts today's over-broad behavior.
-    # After Task 5 (project scope warn → enforce), removing an agent from
-    # a project should leave it standalone, not still wildcarded. When
-    # Task 5 lands: flip the assertion to verify the wildcard was removed
-    # at project-leave time, or delete this test and add a negative test
-    # in this file asserting the agent can no longer read arbitrary keys.
-    """``_remove_project_blackboard_permissions`` only strips the project
-    pattern — a pre-existing ``*`` survives. Combined with the add-side
-    behavior above, this means an agent that ever had ``*`` retains
-    fleet-wide access through any number of project moves.
+def test_wildcard_blackboard_acl_replaced_then_stripped_on_remove(tmp_path, monkeypatch):
+    """Pin: add-then-remove leaves the agent without ``*`` and without
+    the project pattern. Task 5 narrows on add, and the remove path
+    strips both the project pattern and any surviving wildcard so an
+    agent cannot reacquire fleet-wide reach by leaving a project.
     """
-    from src.cli.config import _remove_project_blackboard_permissions
+    from src.cli.config import (
+        _add_project_blackboard_permissions,
+        _remove_project_blackboard_permissions,
+    )
 
-    perms_file = tmp_path / "permissions.json"
-    perms_file.write_text(json.dumps({
-        "permissions": {
-            "rover": {
-                # Both wildcard and project pattern present (the add-side
-                # state from the previous test).
-                "blackboard_read": ["*", "projects/alpha/*"],
-                "blackboard_write": ["*", "projects/alpha/*"],
-            },
-        },
-    }))
-    monkeypatch.setattr("src.cli.config.PERMISSIONS_FILE", perms_file)
-
-    _remove_project_blackboard_permissions("rover", "alpha")
-
-    perms = json.loads(perms_file.read_text())
-    read = perms["permissions"]["rover"]["blackboard_read"]
-    write = perms["permissions"]["rover"]["blackboard_write"]
-    # Project pattern was removed.
-    assert "projects/alpha/*" not in read
-    assert "projects/alpha/*" not in write
-    # But the wildcard survives — Task 5 should narrow.
-    assert "*" in read
-    assert "*" in write
-
-
-@pytest.mark.characterization
-def test_wildcard_blackboard_acl_grants_arbitrary_keys_after_project_remove(tmp_path):
-    # CAPTURE-TO-TIGHTEN — this test asserts today's over-broad behavior.
-    # After Task 5 (project scope warn → enforce), an agent that has been
-    # removed from project alpha should NOT be able to read keys from
-    # project beta. When Task 5 lands: flip these assertions to ``False``
-    # for cross-project keys, or delete this test in favour of a
-    # cross-project-isolation test in this file.
-    """End-to-end check that the surviving wildcard from the two tests
-    above actually grants live access via ``PermissionMatrix``: a
-    standalone-by-membership agent can still read another project's keys.
-    """
     perms_file = tmp_path / "permissions.json"
     perms_file.write_text(json.dumps({
         "permissions": {
@@ -1083,8 +1030,48 @@ def test_wildcard_blackboard_acl_grants_arbitrary_keys_after_project_remove(tmp_
             },
         },
     }))
+    monkeypatch.setattr("src.cli.config.PERMISSIONS_FILE", perms_file)
+
+    _add_project_blackboard_permissions("rover", "alpha")
+    _remove_project_blackboard_permissions("rover", "alpha")
+
+    perms = json.loads(perms_file.read_text())
+    read = perms["permissions"]["rover"]["blackboard_read"]
+    write = perms["permissions"]["rover"]["blackboard_write"]
+    # No wildcard, no project pattern — agent is back to standalone.
+    assert "*" not in read
+    assert "*" not in write
+    assert "projects/alpha/*" not in read
+    assert "projects/alpha/*" not in write
+
+
+def test_arbitrary_keys_blocked_after_project_remove_strips_wildcard(tmp_path, monkeypatch):
+    """Pin: live ``PermissionMatrix`` checks reject cross-project reads
+    after the membership system has touched the agent. The wildcard
+    strip on add+remove leaves no pattern that matches another
+    project's keys.
+    """
+    from src.cli.config import (
+        _add_project_blackboard_permissions,
+        _remove_project_blackboard_permissions,
+    )
+
+    perms_file = tmp_path / "permissions.json"
+    perms_file.write_text(json.dumps({
+        "permissions": {
+            "rover": {
+                "blackboard_read": ["*"],
+                "blackboard_write": ["*"],
+            },
+        },
+    }))
+    monkeypatch.setattr("src.cli.config.PERMISSIONS_FILE", perms_file)
+
+    _add_project_blackboard_permissions("rover", "alpha")
+    _remove_project_blackboard_permissions("rover", "alpha")
+
     pm = PermissionMatrix(config_path=str(perms_file))
-    # Wildcard reach across namespaces is what Task 5 will enforce away.
-    assert pm.can_read_blackboard("rover", "projects/alpha/secret")
-    assert pm.can_read_blackboard("rover", "projects/beta/secret")
-    assert pm.can_write_blackboard("rover", "projects/beta/note")
+    # No more wildcard reach across namespaces — Task 5 enforced.
+    assert not pm.can_read_blackboard("rover", "projects/alpha/secret")
+    assert not pm.can_read_blackboard("rover", "projects/beta/secret")
+    assert not pm.can_write_blackboard("rover", "projects/beta/note")


### PR DESCRIPTION
## Summary

Server-side project isolation rolling out behind a default-`warn` flag. **Flips the remaining 3 wildcard-blackboard captures from PR #822** and introduces the per-caller `/mesh/agents` filter the plan called out as a new behavior (per Task 1's surprise finding).

**Branch base:** `feat/operator-cryptographic-registration` (PR #829) → … → `main`.

## What ships

**Mode flag.** `OPENLEGION_PROJECT_SCOPE_MODE=warn|enforce` (default `warn`). Read once at module import. Invalid values fall back to `warn` with a logged warning. Surfaced as `project_scope_mode` on `/mesh/system/metrics` alongside the new `scope_warn_total` counter — ops watch the counter to gauge soak readiness before flipping to `enforce`.

**`_caller_projects(agent_id)` helper.** Returns the set of projects a worker is a member of; operator / trusted-internal effectively belong to every project.

**`/mesh/agents` per-caller filter.**

- operator / internal caller → full fleet (unchanged)
- worker `?project=X` → must be a member of X (or operator/internal); otherwise `{}` + scope-warn log
- worker without `?project=` → under `enforce`, returns own-project members + operator (always visible per Task 0); under `warn`, returns the legacy full fleet AND emits a `scope-warn` log so ops can see what would have been filtered

**Membership-mutation wildcard strip** in `src/cli/config.py`:

- `_add_project_blackboard_permissions` strips any pre-existing `["*"]` from `blackboard_read` / `blackboard_write` before appending the project-scoped pattern.
- `_remove_project_blackboard_permissions` also strips wildcards in addition to its existing targeted strip of the named project's pattern. Empty ACLs after removal stay empty — no silent re-grant of `*`.

## Captures flipped

| Was | Now |
|---|---|
| `test_wildcard_blackboard_acl_survives_project_add` | `test_wildcard_blackboard_acl_replaced_on_project_add` |
| `test_wildcard_blackboard_acl_survives_project_remove` | `test_wildcard_blackboard_acl_replaced_then_stripped_on_remove` |
| `test_wildcard_blackboard_acl_grants_arbitrary_keys_after_project_remove` | `test_arbitrary_keys_blocked_after_project_remove_strips_wildcard` |

`@pytest.mark.characterization` removed; verbose `CAPTURE-TO-TIGHTEN` preamble replaced with brief pin docstrings.

## What's deliberately NOT in this PR

- **Default flip to `enforce`**. The plan calls for that as a follow-up after a soak window. Workers continue to see the full fleet in production until ops opt in.
- **Hot-path enforcement** on `can_read_blackboard` / `can_write_blackboard`. The membership-mutation strip narrows actively-managed fleets on every join/leave; pre-existing in-place `["*"]` ACLs that haven't been touched stay intact. Hot-path enforcement is a follow-up.

## Test plan

- [x] 4 new positive tests in `tests/test_mesh.py` covering both modes for worker / operator / internal callers, plus `caplog` assertion that warn mode logs while keeping legacy response shape
- [x] `pytest tests/test_permissions.py tests/test_projects.py tests/test_mesh.py tests/test_dashboard.py` — 481 passed
- [x] Full non-E2E suite — 5059 passed, 44 skipped, 5 deselected (4 inherited Task 2b failures + version flag). **No new failures.**
- [x] `pytest -m characterization --collect-only` — 4 → 1 (only one unrelated pin remains)

## Stack

1. #821 — Task 0 hotfix ✅
2. #822 — Task 1 characterization tests
3. #823 — Task 2a typed model
4. #824 — Task 2b stamp sites
5. #825 — Task 2c channel pairing recheck
6. #826 — Task 2d pending-actions SQLite
7. #827 — Task 2e wake block
8. #828 — Task 3 perm split
9. #829 — Task 4 operator cryptographic registration
10. **This PR** — Task 5 project isolation in warn mode (closes Tier 2)

Tier 3+ (Task 6 durable orchestration records, Task 7 operator product tools, Task 8 capabilities-as-data, Task 9 dashboard surfaces) are larger architectural shifts and warrant separate planning.