### PR TITLE
feat(operator): product tools for projects/teams/tasks (Task 7)

### DIFF
--- a/src/agent/builtins/operator_tools.py
+++ b/src/agent/builtins/operator_tools.py
@@ -655,3 +655,553 @@ async def update_project_context(
         return await mesh_client.update_project_context(project_name, context)
     except Exception as e:
         return {"error": f"Failed to update project context: {e}"}
+
+
+# ── Task 7: Operator product tools ───────────────────────────
+
+
+_TASKS_V2_DISABLED = (
+    "Orchestration tasks not enabled — flip OPENLEGION_ORCHESTRATION_TASKS_V2=1"
+)
+
+
+def _orchestration_v2_on() -> bool:
+    """Read the orchestration v2 flag at call time so monkeypatch tests work."""
+    return os.environ.get("OPENLEGION_ORCHESTRATION_TASKS_V2", "0") == "1"
+
+
+def _parse_over_budget(error: Exception) -> dict | None:
+    """If a mesh HTTP error wraps an over_budget JSON payload, surface it.
+
+    The reroute / retry endpoints encode a structured budget error in the
+    400 body. ``httpx.HTTPStatusError`` stringifies as something like
+    ``"Client error '400 Bad Request' for url ... \\nFor more ..."``;
+    the JSON body is on ``error.response`` when the client wraps it.
+    Returns the structured dict or None if the error isn't a budget one.
+    """
+    response = getattr(error, "response", None)
+    if response is None:
+        return None
+    try:
+        body = response.json()
+    except Exception:
+        return None
+    detail = body.get("detail") if isinstance(body, dict) else None
+    if isinstance(detail, str):
+        try:
+            parsed = json.loads(detail)
+        except (TypeError, ValueError):
+            parsed = None
+        if isinstance(parsed, dict) and parsed.get("error") == "over_budget":
+            return parsed
+    if isinstance(detail, dict) and detail.get("error") == "over_budget":
+        return detail
+    return None
+
+
+# ── Read tools ──────────────────────────────────────────────
+
+
+@skill(
+    name="list_project_status",
+    description=(
+        "List status rollups for projects. Per-project counts by status, "
+        "top blockers, and recent completions. If `project_id` is omitted, "
+        "returns one row per project the operator can see."
+    ),
+    parameters={
+        "project_id": {
+            "type": "string",
+            "description": "Optional project ID to scope to a single project",
+            "default": "",
+        },
+    },
+)
+async def list_project_status(
+    project_id: str = "",
+    *,
+    mesh_client=None,
+    **_kw,
+) -> dict:
+    """Fleet-wide or per-project status rollup."""
+    if not _is_operator():
+        return {"error": "This tool is only available to the operator agent."}
+    if mesh_client is None:
+        return {"error": "No mesh_client available"}
+    if not _orchestration_v2_on():
+        return {"error": _TASKS_V2_DISABLED}
+    try:
+        if project_id:
+            return await mesh_client.project_status(project_id)
+        return await mesh_client.all_projects_status()
+    except Exception as e:
+        return {"error": f"Failed to read project status: {e}"}
+
+
+@skill(
+    name="list_agent_queue",
+    description=(
+        "Read an agent's task queue: current and recent tasks grouped by "
+        "status (active / blocked / done / failed / cancelled), up to "
+        "`limit` rows per bucket."
+    ),
+    parameters={
+        "agent_id": {
+            "type": "string",
+            "description": "Agent ID to inspect",
+        },
+        "limit": {
+            "type": "integer",
+            "description": "Max rows per status bucket (default 10, max 100)",
+            "default": 10,
+        },
+    },
+)
+async def list_agent_queue(
+    agent_id: str,
+    limit: int = 10,
+    *,
+    mesh_client=None,
+    **_kw,
+) -> dict:
+    """Per-agent task queue grouped by status."""
+    if not _is_operator():
+        return {"error": "This tool is only available to the operator agent."}
+    if mesh_client is None:
+        return {"error": "No mesh_client available"}
+    if not _orchestration_v2_on():
+        return {"error": _TASKS_V2_DISABLED}
+    try:
+        return await mesh_client.agent_queue(agent_id, limit=limit)
+    except Exception as e:
+        return {"error": f"Failed to read queue for {agent_id}: {e}"}
+
+
+@skill(
+    name="get_team_outputs",
+    description=(
+        "Completed task artifacts for a project in a time window. "
+        "`since` accepts ISO timestamps or duration strings ('24h', '7d'); "
+        "default is the last 7 days."
+    ),
+    parameters={
+        "project_id": {
+            "type": "string",
+            "description": "Project ID",
+        },
+        "since": {
+            "type": "string",
+            "description": "ISO timestamp or duration string (e.g. '24h', '7d')",
+            "default": "",
+        },
+    },
+)
+async def get_team_outputs(
+    project_id: str,
+    since: str = "",
+    *,
+    mesh_client=None,
+    **_kw,
+) -> dict:
+    """Completed task artifacts for a project."""
+    if not _is_operator():
+        return {"error": "This tool is only available to the operator agent."}
+    if mesh_client is None:
+        return {"error": "No mesh_client available"}
+    if not _orchestration_v2_on():
+        return {"error": _TASKS_V2_DISABLED}
+    try:
+        return await mesh_client.project_outputs(project_id, since=since)
+    except Exception as e:
+        return {"error": f"Failed to read outputs for {project_id}: {e}"}
+
+
+@skill(
+    name="summarize_project_progress",
+    description=(
+        "Synthesized status summary for a project: structured counts + "
+        "narrative status_text + top blockers + recent completions + "
+        "ask_for_user list."
+    ),
+    parameters={
+        "project_id": {
+            "type": "string",
+            "description": "Project ID",
+        },
+    },
+)
+async def summarize_project_progress(
+    project_id: str,
+    *,
+    mesh_client=None,
+    **_kw,
+) -> dict:
+    """Synthesized progress summary for a project."""
+    if not _is_operator():
+        return {"error": "This tool is only available to the operator agent."}
+    if mesh_client is None:
+        return {"error": "No mesh_client available"}
+    if not _orchestration_v2_on():
+        return {"error": _TASKS_V2_DISABLED}
+    try:
+        return await mesh_client.project_summary(project_id)
+    except Exception as e:
+        return {"error": f"Failed to summarize {project_id}: {e}"}
+
+
+@skill(
+    name="get_agent_profile",
+    description=(
+        "Read an agent's public profile: role, capabilities, health, "
+        "subscriptions, INTERFACE.md contract."
+    ),
+    parameters={
+        "agent_id": {
+            "type": "string",
+            "description": "Agent ID",
+        },
+    },
+)
+async def get_agent_profile(
+    agent_id: str,
+    *,
+    mesh_client=None,
+    **_kw,
+) -> dict:
+    """Read an agent's profile via the mesh."""
+    if not _is_operator():
+        return {"error": "This tool is only available to the operator agent."}
+    if mesh_client is None:
+        return {"error": "No mesh_client available"}
+    try:
+        return await mesh_client.get_agent_profile(agent_id)
+    except Exception as e:
+        return {"error": f"Failed to read profile for {agent_id}: {e}"}
+
+
+# ── Action tools ────────────────────────────────────────────
+
+
+@skill(
+    name="reroute_task",
+    description=(
+        "Reassign a task to a different agent. Cost-aware: refuses if the "
+        "new assignee is over budget (returns a structured error naming the "
+        "offending agent)."
+    ),
+    parameters={
+        "task_id": {
+            "type": "string",
+            "description": "Task ID",
+        },
+        "new_assignee": {
+            "type": "string",
+            "description": "New assignee agent ID",
+        },
+        "reason": {
+            "type": "string",
+            "description": "Optional reason for the reroute",
+            "default": "",
+        },
+    },
+)
+async def reroute_task(
+    task_id: str,
+    new_assignee: str,
+    reason: str = "",
+    *,
+    mesh_client=None,
+    **_kw,
+) -> dict:
+    """Reassign a task. Cost-gated."""
+    if not _is_operator():
+        return {"error": "This tool is only available to the operator agent."}
+    if mesh_client is None:
+        return {"error": "No mesh_client available"}
+    if not _orchestration_v2_on():
+        return {"error": _TASKS_V2_DISABLED}
+    try:
+        return await mesh_client.reroute_task(task_id, new_assignee, reason=reason)
+    except Exception as e:
+        budget = _parse_over_budget(e)
+        if budget is not None:
+            return {
+                "error": "over_budget",
+                "detail": budget.get("detail") or (
+                    f"Agent {budget.get('budget', {}).get('agent', new_assignee)!r} "
+                    "is over budget."
+                ),
+                "budget": budget.get("budget"),
+            }
+        return {"error": f"Failed to reroute task: {e}"}
+
+
+@skill(
+    name="cancel_task",
+    description="Cancel a task with an optional reason recorded on the audit trail.",
+    parameters={
+        "task_id": {
+            "type": "string",
+            "description": "Task ID",
+        },
+        "reason": {
+            "type": "string",
+            "description": "Reason for cancellation",
+            "default": "",
+        },
+    },
+)
+async def cancel_task(
+    task_id: str,
+    reason: str = "",
+    *,
+    mesh_client=None,
+    **_kw,
+) -> dict:
+    """Cancel a task."""
+    if not _is_operator():
+        return {"error": "This tool is only available to the operator agent."}
+    if mesh_client is None:
+        return {"error": "No mesh_client available"}
+    if not _orchestration_v2_on():
+        return {"error": _TASKS_V2_DISABLED}
+    try:
+        return await mesh_client.cancel_task(task_id, reason=reason)
+    except Exception as e:
+        return {"error": f"Failed to cancel task: {e}"}
+
+
+@skill(
+    name="retry_failed_task",
+    description=(
+        "Retry a failed task by cloning it as a new pending task. "
+        "Optional `with_changes` patches title / description / assignee. "
+        "Cost-aware: refuses if the (possibly overridden) target agent is "
+        "over budget."
+    ),
+    parameters={
+        "task_id": {
+            "type": "string",
+            "description": "Task ID of the failed task",
+        },
+        "with_changes": {
+            "type": "object",
+            "description": (
+                "Optional patch with keys 'title', 'description', 'assignee' "
+                "to override on the retry"
+            ),
+            "default": {},
+        },
+    },
+)
+async def retry_failed_task(
+    task_id: str,
+    with_changes: dict | None = None,
+    *,
+    mesh_client=None,
+    **_kw,
+) -> dict:
+    """Retry a failed task. Cost-gated."""
+    if not _is_operator():
+        return {"error": "This tool is only available to the operator agent."}
+    if mesh_client is None:
+        return {"error": "No mesh_client available"}
+    if not _orchestration_v2_on():
+        return {"error": _TASKS_V2_DISABLED}
+    patch = with_changes or {}
+    try:
+        return await mesh_client.retry_task(
+            task_id,
+            title=patch.get("title"),
+            description=patch.get("description"),
+            assignee=patch.get("assignee"),
+        )
+    except Exception as e:
+        budget = _parse_over_budget(e)
+        if budget is not None:
+            return {
+                "error": "over_budget",
+                "detail": budget.get("detail") or "Target agent is over budget.",
+                "budget": budget.get("budget"),
+            }
+        return {"error": f"Failed to retry task: {e}"}
+
+
+@skill(
+    name="archive_project",
+    description=(
+        "Archive a project. Stops scheduling and hides it from default "
+        "list views while retaining all data. Reversible."
+    ),
+    parameters={
+        "project_id": {
+            "type": "string",
+            "description": "Project ID",
+        },
+    },
+)
+async def archive_project(
+    project_id: str,
+    *,
+    mesh_client=None,
+    _messages=None,
+    **_kw,
+) -> dict:
+    """Archive a project. Provenance-gated."""
+    if not _is_operator():
+        return {"error": "This tool is only available to the operator agent."}
+    if mesh_client is None:
+        return {"error": "No mesh_client available"}
+    from src.agent.loop import _last_message_is_user_origin
+    if _messages is None or not _last_message_is_user_origin(_messages):
+        return {
+            "error": "provenance_check_failed",
+            "detail": "User confirmation required to archive a project.",
+        }
+    try:
+        return await mesh_client.archive_project(project_id)
+    except Exception as e:
+        return {"error": f"Failed to archive project: {e}"}
+
+
+@skill(
+    name="archive_agent",
+    description=(
+        "Archive an agent. Stops scheduling, retains workspace and history. "
+        "Reversible. Required pre-condition for delete_agent."
+    ),
+    parameters={
+        "agent_id": {
+            "type": "string",
+            "description": "Agent ID",
+        },
+    },
+)
+async def archive_agent(
+    agent_id: str,
+    *,
+    mesh_client=None,
+    _messages=None,
+    **_kw,
+) -> dict:
+    """Archive an agent. Provenance-gated."""
+    if not _is_operator():
+        return {"error": "This tool is only available to the operator agent."}
+    if mesh_client is None:
+        return {"error": "No mesh_client available"}
+    if agent_id.lower() == _OPERATOR_AGENT_ID:
+        return {"error": "Cannot archive the operator agent."}
+    from src.agent.loop import _last_message_is_user_origin
+    if _messages is None or not _last_message_is_user_origin(_messages):
+        return {
+            "error": "provenance_check_failed",
+            "detail": "User confirmation required to archive an agent.",
+        }
+    try:
+        return await mesh_client.archive_agent(agent_id)
+    except Exception as e:
+        return {"error": f"Failed to archive agent: {e}"}
+
+
+@skill(
+    name="delete_project",
+    description=(
+        "Propose deletion of an archived project. Returns a confirmation "
+        "nonce; the user must confirm via the dashboard or CLI to actually "
+        "delete the project. Pre-condition: project must already be "
+        "archived (call archive_project first)."
+    ),
+    parameters={
+        "project_id": {
+            "type": "string",
+            "description": "Project ID (must be archived)",
+        },
+    },
+)
+async def delete_project(
+    project_id: str,
+    *,
+    mesh_client=None,
+    _messages=None,
+    **_kw,
+) -> dict:
+    """Propose project deletion. Two-step: this returns a nonce for human confirm."""
+    if not _is_operator():
+        return {"error": "This tool is only available to the operator agent."}
+    if mesh_client is None:
+        return {"error": "No mesh_client available"}
+    from src.agent.loop import _last_message_is_user_origin
+    if _messages is None or not _last_message_is_user_origin(_messages):
+        return {
+            "error": "provenance_check_failed",
+            "detail": "User confirmation required to delete a project.",
+        }
+    try:
+        result = await mesh_client.propose_delete_project(project_id)
+        # Surface the propose-then-confirm contract to the operator
+        # prompt so it knows to wait for human confirmation.
+        result.setdefault("requires_confirmation", True)
+        return result
+    except Exception as e:
+        msg = str(e)
+        if "must be archived" in msg.lower() or "400" in msg:
+            return {
+                "error": "archive_required",
+                "detail": (
+                    f"Project {project_id!r} must be archived before delete. "
+                    "Call archive_project first."
+                ),
+            }
+        return {"error": f"Failed to propose delete: {e}"}
+
+
+@skill(
+    name="delete_agent",
+    description=(
+        "Propose deletion of an archived agent. Returns a confirmation "
+        "nonce; the user must confirm via the dashboard or CLI to actually "
+        "delete the agent. Pre-condition: agent must already be archived "
+        "(call archive_agent first)."
+    ),
+    parameters={
+        "agent_id": {
+            "type": "string",
+            "description": "Agent ID (must be archived)",
+        },
+    },
+)
+async def delete_agent(
+    agent_id: str,
+    *,
+    mesh_client=None,
+    _messages=None,
+    **_kw,
+) -> dict:
+    """Propose agent deletion. Two-step: this returns a nonce for human confirm."""
+    if not _is_operator():
+        return {"error": "This tool is only available to the operator agent."}
+    if mesh_client is None:
+        return {"error": "No mesh_client available"}
+    if agent_id.lower() == _OPERATOR_AGENT_ID:
+        return {"error": "Cannot delete the operator agent."}
+    from src.agent.loop import _last_message_is_user_origin
+    if _messages is None or not _last_message_is_user_origin(_messages):
+        return {
+            "error": "provenance_check_failed",
+            "detail": "User confirmation required to delete an agent.",
+        }
+    try:
+        result = await mesh_client.propose_delete_agent(agent_id)
+        result.setdefault("requires_confirmation", True)
+        return result
+    except Exception as e:
+        msg = str(e)
+        if "must be archived" in msg.lower() or "400" in msg:
+            return {
+                "error": "archive_required",
+                "detail": (
+                    f"Agent {agent_id!r} must be archived before delete. "
+                    "Call archive_agent first."
+                ),
+            }
+        return {"error": f"Failed to propose delete: {e}"}

--- a/src/agent/mesh_client.py
+++ b/src/agent/mesh_client.py
@@ -1071,6 +1071,114 @@ class MeshClient:
         response.raise_for_status()
         return response.json()
 
+    async def retry_task(
+        self, task_id: str,
+        title: str | None = None,
+        description: str | None = None,
+        assignee: str | None = None,
+    ) -> dict:
+        """Retry a failed task. Optional patch overrides title/description/assignee."""
+        body: dict = {}
+        if title is not None:
+            body["title"] = title
+        if description is not None:
+            body["description"] = description
+        if assignee is not None:
+            body["assignee"] = assignee
+        client = await self._get_client()
+        response = await client.post(
+            f"{self.mesh_url}/mesh/tasks/{task_id}/retry",
+            json=body,
+            headers=self._trace_headers(),
+        )
+        response.raise_for_status()
+        return response.json()
+
+    # ── Operator product surface (Task 7) ────────────────────────
+
+    async def project_status(self, project_id: str) -> dict:
+        """Per-project status counts + recent blockers/completions."""
+        response = await self._get_with_retry(
+            f"{self.mesh_url}/mesh/projects/{project_id}/status",
+        )
+        response.raise_for_status()
+        return response.json()
+
+    async def all_projects_status(self) -> dict:
+        """Status rollup across every visible project."""
+        response = await self._get_with_retry(
+            f"{self.mesh_url}/mesh/projects/status",
+        )
+        response.raise_for_status()
+        return response.json()
+
+    async def agent_queue(self, agent_id: str, limit: int = 10) -> dict:
+        """Recent tasks for an agent grouped by status."""
+        response = await self._get_with_retry(
+            f"{self.mesh_url}/mesh/agents/{agent_id}/queue",
+            params={"limit": limit},
+        )
+        response.raise_for_status()
+        return response.json()
+
+    async def project_outputs(self, project_id: str, since: str = "") -> dict:
+        """Completed task artifacts for a project in a time window."""
+        params = {"since": since} if since else None
+        response = await self._get_with_retry(
+            f"{self.mesh_url}/mesh/projects/{project_id}/outputs",
+            params=params,
+        )
+        response.raise_for_status()
+        return response.json()
+
+    async def project_summary(self, project_id: str) -> dict:
+        """Synthesized status summary for a project."""
+        response = await self._get_with_retry(
+            f"{self.mesh_url}/mesh/projects/{project_id}/summary",
+        )
+        response.raise_for_status()
+        return response.json()
+
+    async def archive_project(self, name: str) -> dict:
+        """Archive a project."""
+        client = await self._get_client()
+        response = await client.post(
+            f"{self.mesh_url}/mesh/projects/{name}/archive",
+            headers=self._trace_headers(),
+        )
+        response.raise_for_status()
+        return response.json()
+
+    async def archive_agent(self, agent_id: str) -> dict:
+        """Archive an agent."""
+        client = await self._get_client()
+        response = await client.post(
+            f"{self.mesh_url}/mesh/agents/{agent_id}/archive",
+            headers=self._trace_headers(),
+        )
+        response.raise_for_status()
+        return response.json()
+
+    async def propose_delete_project(self, name: str) -> dict:
+        """Propose deletion of an archived project. Returns nonce for human confirm."""
+        client = await self._get_client()
+        response = await client.post(
+            f"{self.mesh_url}/mesh/projects/{name}/propose-delete",
+            headers=self._trace_headers(),
+        )
+        response.raise_for_status()
+        return response.json()
+
+    async def propose_delete_agent(self, agent_id: str) -> dict:
+        """Propose deletion of an archived agent. Returns nonce for human confirm."""
+        client = await self._get_client()
+        response = await client.post(
+            f"{self.mesh_url}/mesh/agents/{agent_id}/propose-delete",
+            headers=self._trace_headers(),
+        )
+        response.raise_for_status()
+        return response.json()
+
     async def list_task_events(self, task_id: str) -> list[dict]:
         """Audit history for a task."""
         response = await self._get_with_retry(

--- a/src/cli/config.py
+++ b/src/cli/config.py
@@ -764,7 +764,7 @@ def _set_agent_status(name: str, status: str) -> None:
     via the runtime backend (the host endpoint handles that).
     """
     if not AGENTS_FILE.exists():
-        raise ValueError(f"Agents config not found")
+        raise ValueError("Agents config not found")
     with open(AGENTS_FILE) as f:
         agents_cfg = yaml.safe_load(f) or {"agents": {}}
     agents = agents_cfg.get("agents", {})
@@ -788,7 +788,7 @@ def _unarchive_agent(name: str) -> None:
 def _agent_status(name: str) -> str:
     """Read an agent's status. Returns ``"active"`` for legacy rows missing the field."""
     if not AGENTS_FILE.exists():
-        raise ValueError(f"Agents config not found")
+        raise ValueError("Agents config not found")
     with open(AGENTS_FILE) as f:
         agents_cfg = yaml.safe_load(f) or {"agents": {}}
     agents = agents_cfg.get("agents", {})

--- a/src/cli/config.py
+++ b/src/cli/config.py
@@ -688,7 +688,13 @@ def _create_project(
 
 
 def _delete_project(name: str) -> None:
-    """Delete a project directory and clean up agent permissions."""
+    """Delete a project directory and clean up agent permissions.
+
+    Operator product tools (Task 7) require this be preceded by
+    ``_archive_project`` and a human-confirmed pending action; the
+    raw helper retained here is the storage primitive — callers above
+    enforce the propose-then-confirm flow.
+    """
     import shutil
 
     project_dir = PROJECTS_DIR / name
@@ -708,6 +714,87 @@ def _delete_project(name: str) -> None:
         _remove_project_blackboard_permissions(agent, name)
 
     shutil.rmtree(project_dir)
+
+
+def _set_project_status(name: str, status: str) -> None:
+    """Update the ``status`` field on a project's metadata.yaml.
+
+    Used by archive/unarchive flows. Status is a free-string at the
+    storage layer; operator tools restrict valid values to
+    ``{"active", "archived"}``.
+    """
+    project_dir = PROJECTS_DIR / name
+    meta_file = project_dir / "metadata.yaml"
+    if not meta_file.exists():
+        raise ValueError(f"Project '{name}' not found")
+    with open(meta_file) as f:
+        data = yaml.safe_load(f) or {}
+    data["status"] = status
+    with open(meta_file, "w") as f:
+        yaml.dump(data, f, default_flow_style=False, sort_keys=False)
+
+
+def _archive_project(name: str) -> None:
+    """Mark a project as archived without deleting its data."""
+    _set_project_status(name, "archived")
+
+
+def _unarchive_project(name: str) -> None:
+    """Re-activate an archived project."""
+    _set_project_status(name, "active")
+
+
+def _project_status(name: str) -> str:
+    """Read a project's status. Returns ``"active"`` for legacy rows missing the field."""
+    project_dir = PROJECTS_DIR / name
+    meta_file = project_dir / "metadata.yaml"
+    if not meta_file.exists():
+        raise ValueError(f"Project '{name}' not found")
+    with open(meta_file) as f:
+        data = yaml.safe_load(f) or {}
+    return data.get("status", "active") or "active"
+
+
+def _set_agent_status(name: str, status: str) -> None:
+    """Persist a per-agent ``status`` flag in agents.yaml.
+
+    ``status="archived"`` stops scheduling without deleting workspace
+    or history. Live containers continue running until the next restart;
+    operator tools that archive an agent should also stop the container
+    via the runtime backend (the host endpoint handles that).
+    """
+    if not AGENTS_FILE.exists():
+        raise ValueError(f"Agents config not found")
+    with open(AGENTS_FILE) as f:
+        agents_cfg = yaml.safe_load(f) or {"agents": {}}
+    agents = agents_cfg.get("agents", {})
+    if name not in agents:
+        raise ValueError(f"Agent '{name}' not found")
+    agents[name]["status"] = status
+    with open(AGENTS_FILE, "w") as f:
+        yaml.dump(agents_cfg, f, default_flow_style=False, sort_keys=False)
+
+
+def _archive_agent(name: str) -> None:
+    """Mark an agent as archived (stop scheduling, retain workspace + history)."""
+    _set_agent_status(name, "archived")
+
+
+def _unarchive_agent(name: str) -> None:
+    """Re-activate an archived agent."""
+    _set_agent_status(name, "active")
+
+
+def _agent_status(name: str) -> str:
+    """Read an agent's status. Returns ``"active"`` for legacy rows missing the field."""
+    if not AGENTS_FILE.exists():
+        raise ValueError(f"Agents config not found")
+    with open(AGENTS_FILE) as f:
+        agents_cfg = yaml.safe_load(f) or {"agents": {}}
+    agents = agents_cfg.get("agents", {})
+    if name not in agents:
+        raise ValueError(f"Agent '{name}' not found")
+    return agents[name].get("status", "active") or "active"
 
 
 def _add_agent_to_project(project: str, agent: str) -> None:
@@ -1254,6 +1341,12 @@ _OPERATOR_ALLOWED_TOOLS: list[str] = [
     "list_projects", "get_project", "create_project",
     "add_agents_to_project", "remove_agents_from_project", "update_project_context",
     "vault_list", "request_credential", "request_browser_login",
+    # Task 7: operator product surface — read tools
+    "list_project_status", "list_agent_queue", "get_team_outputs",
+    "summarize_project_progress",
+    # Task 7: operator product surface — action tools
+    "reroute_task", "cancel_task", "retry_failed_task",
+    "archive_project", "archive_agent", "delete_project", "delete_agent",
 ]
 
 _OPERATOR_HEARTBEAT_TOOLS: list[str] = [

--- a/src/host/server.py
+++ b/src/host/server.py
@@ -2944,20 +2944,29 @@ def create_mesh_app(
     # so operator agents can manage projects using their mesh auth token.
 
     @app.get("/mesh/projects")
-    async def mesh_list_projects(request: Request) -> dict:
-        """List all projects (mesh-authed proxy)."""
-        _require_any_auth(request)
-        if _resolve_agent_id("", request) != "operator":
+    async def mesh_list_projects(request: Request, include_archived: bool = False) -> dict:
+        """List projects (mesh-authed proxy).
+
+        Excludes archived projects by default — pass ``include_archived=true``
+        to include them. Each row carries ``status`` so callers can render
+        the archive state when ``include_archived`` is set.
+        """
+        caller = _extract_verified_agent_id(request)
+        if caller != "operator" and not _is_internal_caller(request):
             raise HTTPException(403, "Only the operator can manage projects")
         from src.cli.config import _load_projects
         projects = _load_projects()
         result = []
         for pname, pdata in sorted(projects.items(), key=lambda x: x[1].get("created_at") or ""):
+            status = pdata.get("status", "active") or "active"
+            if not include_archived and status == "archived":
+                continue
             result.append({
                 "name": pname,
                 "description": pdata.get("description", ""),
                 "members": pdata.get("members", []),
                 "created_at": pdata.get("created_at", ""),
+                "status": status,
             })
         return {"projects": result}
 
@@ -3298,9 +3307,39 @@ def create_mesh_app(
             raise HTTPException(404, f"Task '{task_id}' not found")
         return updated
 
+    def _check_can_schedule(target_agent: str) -> tuple[bool, dict | None]:
+        """Cost-aware preflight: True when the target agent has budget headroom.
+
+        Returns ``(allowed, info_or_none)``. ``info`` carries the
+        offending agent + daily/monthly used vs limit so the operator
+        product tools can surface a structured error to the user.
+        Operator (and the missing-tracker case) always pass — there is
+        nothing to enforce.
+        """
+        if cost_tracker is None or target_agent == "operator":
+            return True, None
+        try:
+            check = cost_tracker.check_budget(target_agent)
+        except Exception as e:
+            logger.debug("check_budget(%s) failed: %s — allowing", target_agent, e)
+            return True, None
+        if check.get("allowed", True):
+            return True, None
+        return False, {
+            "agent": target_agent,
+            "daily_used": check.get("daily_used"),
+            "daily_limit": check.get("daily_limit"),
+            "monthly_used": check.get("monthly_used"),
+            "monthly_limit": check.get("monthly_limit"),
+        }
+
     @app.post("/mesh/tasks/{task_id}/reroute")
     async def reroute_task(task_id: str, request: Request) -> dict:
-        """Reassign a task. Operator-only or callers with ``can_route_tasks``."""
+        """Reassign a task. Operator-only or callers with ``can_route_tasks``.
+
+        Cost-aware: refuses to reroute onto an agent that is already
+        over its daily or monthly budget (HTTP 400, structured error).
+        """
         store = _require_tasks_v2()
         caller = _extract_verified_agent_id(request)
         if not (
@@ -3317,6 +3356,20 @@ def create_mesh_app(
         reason = sanitize_for_prompt(body.get("reason") or "")
         if not new_assignee or not _AGENT_ID_RE.match(new_assignee):
             raise HTTPException(400, f"Invalid new_assignee: {new_assignee!r}")
+        # Budget preflight — before mutating storage.
+        allowed, info = _check_can_schedule(new_assignee)
+        if not allowed:
+            raise HTTPException(
+                400,
+                json.dumps({
+                    "error": "over_budget",
+                    "detail": (
+                        f"Agent {new_assignee!r} is over budget; refusing to "
+                        "reroute task to a target that cannot run."
+                    ),
+                    "budget": info,
+                }),
+            )
         try:
             updated = store.reroute(
                 task_id, new_assignee, actor=caller, reason=reason,
@@ -3326,6 +3379,643 @@ def create_mesh_app(
         except InvalidStatusTransition as e:
             raise HTTPException(400, str(e))
         return updated
+
+    @app.post("/mesh/tasks/{task_id}/retry")
+    async def retry_failed_task(task_id: str, request: Request) -> dict:
+        """Retry a failed task by cloning it as a new ``pending`` task.
+
+        Operator product tool surface: clones the existing task into a
+        new id (``task_<hex>``), optionally overriding title / description /
+        assignee from the request body. Original task is left in its
+        terminal state (``failed``) so the audit trail is preserved.
+        Cost-aware: refuses if the (possibly overridden) target assignee
+        is over budget.
+        """
+        store = _require_tasks_v2()
+        caller = _extract_verified_agent_id(request)
+        if not (
+            caller == "operator"
+            or _is_internal_caller(request)
+            or permissions.can_route_tasks(caller)
+        ):
+            raise HTTPException(
+                403,
+                "Retry requires can_route_tasks (operator-grade permission)",
+            )
+        original = store.get(task_id)
+        if original is None:
+            raise HTTPException(404, f"Task '{task_id}' not found")
+        if original["status"] != "failed":
+            raise HTTPException(
+                400,
+                f"Only failed tasks can be retried (status={original['status']!r})",
+            )
+        body = await request.json() if (await request.body()) else {}
+        if not isinstance(body, dict):
+            body = {}
+        # Optional patch: title / description / assignee
+        title = sanitize_for_prompt(body.get("title") or original["title"]).strip()
+        description_override = body.get("description")
+        if description_override is not None:
+            description = sanitize_for_prompt(description_override) or None
+        else:
+            description = original.get("description") or None
+        new_assignee = body.get("assignee") or original["assignee"]
+        if not new_assignee or not _AGENT_ID_RE.match(new_assignee):
+            raise HTTPException(400, f"Invalid assignee: {new_assignee!r}")
+        if not title:
+            raise HTTPException(400, "title is required (and cannot be blank)")
+        # Budget preflight before mutating storage.
+        allowed, info = _check_can_schedule(new_assignee)
+        if not allowed:
+            raise HTTPException(
+                400,
+                json.dumps({
+                    "error": "over_budget",
+                    "detail": (
+                        f"Agent {new_assignee!r} is over budget; refusing to "
+                        "retry the task onto a target that cannot run."
+                    ),
+                    "budget": info,
+                }),
+            )
+        origin = _validated_origin(request, caller)
+        origin_dict = origin.model_dump() if origin is not None else None
+        clone = store.create(
+            creator=caller,
+            assignee=new_assignee,
+            title=title,
+            description=description,
+            project_id=original.get("project_id"),
+            parent_task_id=original["id"],
+            priority=original.get("priority", 0) or 0,
+            origin=origin_dict,
+        )
+        return {"clone": clone, "original_id": original["id"]}
+
+    # === Operator product surface (Task 7) — read tools ===
+    #
+    # Read endpoints surfaced as operator skills. They aggregate over
+    # the tasks store + project metadata and respect the same scoping
+    # rules as the Task 6 endpoints (operator + internal can see all,
+    # other callers can see only their own projects). All return HTTP
+    # 503 when ``OPENLEGION_ORCHESTRATION_TASKS_V2`` is off so the
+    # operator tools can surface a clean error instead of garbled data.
+
+    def _summarize_tasks(rows: list[dict]) -> dict:
+        """Reduce a list of task rows to status counts + recent slices.
+
+        Buckets: ``active`` (pending/accepted/working), ``blocked``,
+        ``done``, ``failed``, ``cancelled``. ``recent_done`` carries the
+        last 5 completed tasks ordered newest-first.
+        """
+        counts = {"active": 0, "blocked": 0, "done": 0, "failed": 0, "cancelled": 0}
+        blocked_rows: list[dict] = []
+        done_rows: list[dict] = []
+        for r in rows:
+            s = r.get("status", "")
+            if s in ("pending", "accepted", "working"):
+                counts["active"] += 1
+            elif s == "blocked":
+                counts["blocked"] += 1
+                blocked_rows.append(r)
+            elif s == "done":
+                counts["done"] += 1
+                done_rows.append(r)
+            elif s == "failed":
+                counts["failed"] += 1
+            elif s == "cancelled":
+                counts["cancelled"] += 1
+        done_rows.sort(key=lambda x: x.get("completed_at") or 0, reverse=True)
+        return {
+            "counts": counts,
+            "blockers": [
+                {
+                    "id": r["id"], "assignee": r["assignee"],
+                    "title": r["title"], "blocker_note": r.get("blocker_note"),
+                }
+                for r in blocked_rows[:5]
+            ],
+            "recent_done": [
+                {
+                    "id": r["id"], "assignee": r["assignee"], "title": r["title"],
+                    "completed_at": r.get("completed_at"),
+                }
+                for r in done_rows[:5]
+            ],
+        }
+
+    @app.get("/mesh/projects/{project_id}/status")
+    async def project_status(project_id: str, request: Request) -> dict:
+        """Per-project status counts + recent blockers/completions.
+
+        Caller must be a project member (or operator/internal). Returns
+        the same structure as ``_summarize_tasks`` plus a ``project``
+        field carrying name and archive status.
+        """
+        store = _require_tasks_v2()
+        caller = _extract_verified_agent_id(request)
+        if not _is_project_member(caller, project_id):
+            raise HTTPException(
+                403,
+                f"Caller {caller} is not a member of project {project_id!r}",
+            )
+        from src.cli.config import _load_projects
+        projects = _load_projects()
+        if project_id not in projects:
+            raise HTTPException(404, f"Project '{project_id}' not found")
+        meta = projects[project_id]
+        _reap_tasks_opportunistically()
+        rows = store.list_project(project_id)
+        result = _summarize_tasks(rows)
+        result["project"] = {
+            "name": project_id,
+            "status": meta.get("status", "active") or "active",
+            "members": meta.get("members", []),
+            "description": meta.get("description", ""),
+        }
+        return result
+
+    @app.get("/mesh/projects/status")
+    async def all_projects_status(request: Request) -> dict:
+        """List status rollups for every project the caller can see.
+
+        Operator / internal callers see all projects (including archived);
+        other callers see only their own. Each row carries the same
+        ``counts``/``blockers``/``recent_done`` shape as the per-project
+        endpoint, plus the project name and status.
+        """
+        store = _require_tasks_v2()
+        caller = _extract_verified_agent_id(request)
+        from src.cli.config import _load_projects
+        projects = _load_projects()
+        visible: list[str]
+        if caller == "operator" or _is_internal_caller(request):
+            visible = list(projects.keys())
+        else:
+            visible = sorted(_caller_projects(caller))
+        _reap_tasks_opportunistically()
+        rows: list[dict] = []
+        for pid in sorted(visible):
+            meta = projects.get(pid, {})
+            project_rows = store.list_project(pid)
+            summary = _summarize_tasks(project_rows)
+            summary["project"] = {
+                "name": pid,
+                "status": meta.get("status", "active") or "active",
+                "members": meta.get("members", []),
+                "description": meta.get("description", ""),
+            }
+            rows.append(summary)
+        return {"projects": rows}
+
+    @app.get("/mesh/agents/{agent_id}/queue")
+    async def agent_queue(
+        agent_id: str, request: Request, limit: int = 10,
+    ) -> dict:
+        """Recent tasks for an agent grouped by status.
+
+        Returns up to ``limit`` rows per status (active / blocked / done /
+        failed / cancelled). Visible to the agent itself, the operator,
+        loopback-internal callers, and project members of the agent's
+        project.
+        """
+        store = _require_tasks_v2()
+        caller = _extract_verified_agent_id(request)
+        if not (
+            caller == agent_id
+            or caller == "operator"
+            or _is_internal_caller(request)
+        ):
+            agent_proj = _agent_projects.get(agent_id)
+            if agent_proj is None or not _is_project_member(caller, agent_proj):
+                raise HTTPException(
+                    403,
+                    f"Caller {caller} cannot view queue for {agent_id!r}",
+                )
+        try:
+            limit = max(1, min(int(limit), 100))
+        except (TypeError, ValueError):
+            limit = 10
+        _reap_tasks_opportunistically()
+        rows = store.list_inbox(agent_id, include_terminal=True)
+        buckets: dict[str, list[dict]] = {
+            "active": [], "blocked": [], "done": [], "failed": [], "cancelled": [],
+        }
+        # Sort newest-first so the "last N" slice is informative.
+        rows.sort(key=lambda r: r.get("updated_at") or 0, reverse=True)
+        for r in rows:
+            s = r.get("status", "")
+            if s in ("pending", "accepted", "working"):
+                key = "active"
+            elif s in buckets:
+                key = s
+            else:
+                continue
+            if len(buckets[key]) >= limit:
+                continue
+            buckets[key].append({
+                "id": r["id"], "title": r["title"],
+                "status": r["status"],
+                "project_id": r.get("project_id"),
+                "blocker_note": r.get("blocker_note"),
+                "updated_at": r.get("updated_at"),
+                "completed_at": r.get("completed_at"),
+            })
+        return {"agent_id": agent_id, "limit": limit, "queue": buckets}
+
+    def _parse_since(since: str | None) -> float:
+        """Parse a since= filter — accepts ISO timestamp, ``"24h"``/``"7d"``, or ``""``."""
+        import time as _time
+        if not since:
+            return _time.time() - (7 * 24 * 60 * 60)
+        s = since.strip().lower()
+        # Duration form: ``Nh`` / ``Nd`` / ``Nm``
+        if s and s[-1] in {"s", "m", "h", "d"} and s[:-1].isdigit():
+            n = int(s[:-1])
+            unit = s[-1]
+            mult = {"s": 1, "m": 60, "h": 3600, "d": 86400}[unit]
+            return _time.time() - (n * mult)
+        # ISO timestamp
+        try:
+            from datetime import datetime as _dt
+            dt = _dt.fromisoformat(s.replace("z", "+00:00"))
+            return dt.timestamp()
+        except (ValueError, TypeError):
+            return _time.time() - (7 * 24 * 60 * 60)
+
+    @app.get("/mesh/projects/{project_id}/outputs")
+    async def project_outputs(
+        project_id: str, request: Request, since: str = "",
+    ) -> dict:
+        """Completed task artifacts for a project in a time window.
+
+        ``since`` accepts an ISO timestamp or duration string (``"24h"``,
+        ``"7d"``); default is the last 7 days. Returns one entry per
+        completed task with its title, assignee, completion time, and
+        artifact refs.
+        """
+        store = _require_tasks_v2()
+        caller = _extract_verified_agent_id(request)
+        if not _is_project_member(caller, project_id):
+            raise HTTPException(
+                403,
+                f"Caller {caller} is not a member of project {project_id!r}",
+            )
+        floor = _parse_since(since)
+        _reap_tasks_opportunistically()
+        rows = store.list_project(project_id, statuses=["done"])
+        outputs = []
+        for r in rows:
+            completed_at = r.get("completed_at") or 0
+            if completed_at < floor:
+                continue
+            outputs.append({
+                "id": r["id"], "title": r["title"], "assignee": r["assignee"],
+                "completed_at": completed_at,
+                "artifact_refs": r.get("artifact_refs", []) or [],
+            })
+        outputs.sort(key=lambda x: x["completed_at"], reverse=True)
+        return {"project_id": project_id, "since": since, "outputs": outputs}
+
+    @app.get("/mesh/projects/{project_id}/summary")
+    async def project_summary(project_id: str, request: Request) -> dict:
+        """Synthesized status text + structured fields for a project.
+
+        Combines status counts, blocker list, recent completions, and a
+        simple ``ask_for_user`` list (currently mirrors ``blocked`` —
+        operators can later swap in a richer policy here without changing
+        the on-the-wire shape). The narrative ``status_text`` is plain
+        prose so the operator's prompt machinery doesn't have to format
+        it again.
+        """
+        store = _require_tasks_v2()
+        caller = _extract_verified_agent_id(request)
+        if not _is_project_member(caller, project_id):
+            raise HTTPException(
+                403,
+                f"Caller {caller} is not a member of project {project_id!r}",
+            )
+        from src.cli.config import _load_projects
+        projects = _load_projects()
+        if project_id not in projects:
+            raise HTTPException(404, f"Project '{project_id}' not found")
+        meta = projects[project_id]
+        _reap_tasks_opportunistically()
+        rows = store.list_project(project_id)
+        s = _summarize_tasks(rows)
+        active = s["counts"]["active"]
+        blocked = s["counts"]["blocked"]
+        done = s["counts"]["done"]
+        failed = s["counts"]["failed"]
+        if active == 0 and blocked == 0 and done == 0 and failed == 0:
+            status_text = f"No tasks recorded for {project_id!r} yet."
+        else:
+            parts: list[str] = []
+            if active:
+                parts.append(f"{active} active")
+            if blocked:
+                parts.append(f"{blocked} blocked")
+            if done:
+                parts.append(f"{done} done")
+            if failed:
+                parts.append(f"{failed} failed")
+            status_text = ", ".join(parts) + f" in project {project_id!r}."
+        return {
+            "project": {
+                "name": project_id,
+                "status": meta.get("status", "active") or "active",
+                "description": meta.get("description", ""),
+                "members": meta.get("members", []),
+            },
+            "status_text": status_text,
+            "counts": s["counts"],
+            "top_blockers": s["blockers"],
+            "recent_completions": s["recent_done"],
+            "ask_for_user": s["blockers"],
+        }
+
+    # === Operator product surface (Task 7) — archive / delete ===
+    #
+    # Archive endpoints flip a status flag and stop scheduling. Delete
+    # endpoints proxy through the existing ``PendingActions`` store
+    # (Task 2d) — same propose-then-confirm flow as ``propose_edit`` /
+    # ``confirm_edit``, just with ``target_kind="project"`` /
+    # ``"agent"`` and ``action_kind="delete"``. Archive must precede
+    # delete; the gate is enforced server-side at propose time.
+
+    @app.post("/mesh/projects/{name}/archive")
+    async def archive_project_endpoint(name: str, request: Request) -> dict:
+        """Archive a project (operator-only). Idempotent."""
+        caller = _extract_verified_agent_id(request)
+        if caller != "operator" and not _is_internal_caller(request):
+            raise HTTPException(403, "Only the operator can archive projects")
+        from src.cli.config import _archive_project, _load_projects
+        if name not in _load_projects():
+            raise HTTPException(404, f"Project '{name}' not found")
+        try:
+            _archive_project(name)
+        except ValueError as e:
+            raise HTTPException(404, str(e))
+        return {"archived": True, "project": name}
+
+    @app.post("/mesh/projects/{name}/unarchive")
+    async def unarchive_project_endpoint(name: str, request: Request) -> dict:
+        """Unarchive a project (operator-only). Idempotent."""
+        caller = _extract_verified_agent_id(request)
+        if caller != "operator" and not _is_internal_caller(request):
+            raise HTTPException(403, "Only the operator can unarchive projects")
+        from src.cli.config import _load_projects, _unarchive_project
+        if name not in _load_projects():
+            raise HTTPException(404, f"Project '{name}' not found")
+        try:
+            _unarchive_project(name)
+        except ValueError as e:
+            raise HTTPException(404, str(e))
+        return {"archived": False, "project": name}
+
+    @app.post("/mesh/agents/{agent_id}/archive")
+    async def archive_agent_endpoint(agent_id: str, request: Request) -> dict:
+        """Archive an agent (operator-only).
+
+        Stops cron / heartbeat and removes the agent from the live
+        registry. Workspace + history are retained; the agent can be
+        unarchived later. Container is best-effort stopped.
+        """
+        caller = _extract_verified_agent_id(request)
+        if caller != "operator" and not _is_internal_caller(request):
+            raise HTTPException(403, "Only the operator can archive agents")
+        if agent_id == "operator":
+            raise HTTPException(400, "The operator agent cannot be archived")
+        from src.cli.config import _archive_agent, _load_config
+        cfg = _load_config()
+        if agent_id not in cfg.get("agents", {}):
+            raise HTTPException(404, f"Agent '{agent_id}' not found")
+        try:
+            _archive_agent(agent_id)
+        except ValueError as e:
+            raise HTTPException(404, str(e))
+        # Stop scheduling: drop heartbeat and any cron jobs the agent owns.
+        if cron_scheduler is not None:
+            try:
+                cron_scheduler.remove_agent_jobs(agent_id)
+            except Exception as e:
+                logger.warning("archive_agent: cron cleanup for %s failed: %s", agent_id, e)
+        # Best-effort container stop. Failures here don't break archive.
+        if container_manager is not None:
+            try:
+                container_manager.stop_agent(agent_id)
+            except Exception as e:
+                logger.warning("archive_agent: container stop for %s failed: %s", agent_id, e)
+        return {"archived": True, "agent_id": agent_id}
+
+    @app.post("/mesh/agents/{agent_id}/unarchive")
+    async def unarchive_agent_endpoint(agent_id: str, request: Request) -> dict:
+        """Unarchive an agent (operator-only). Restart left to operator."""
+        caller = _extract_verified_agent_id(request)
+        if caller != "operator" and not _is_internal_caller(request):
+            raise HTTPException(403, "Only the operator can unarchive agents")
+        from src.cli.config import _load_config, _unarchive_agent
+        cfg = _load_config()
+        if agent_id not in cfg.get("agents", {}):
+            raise HTTPException(404, f"Agent '{agent_id}' not found")
+        try:
+            _unarchive_agent(agent_id)
+        except ValueError as e:
+            raise HTTPException(404, str(e))
+        return {"archived": False, "agent_id": agent_id}
+
+    @app.post("/mesh/projects/{name}/propose-delete")
+    async def propose_delete_project(name: str, request: Request) -> dict:
+        """Propose deletion of an archived project. Returns nonce for human confirm.
+
+        Pre-conditions:
+          * project exists
+          * project is archived (delete on a live project rejected)
+
+        Stores a pending action with ``target_kind="project"``,
+        ``action_kind="delete"``, ``origin_kind`` from the validated
+        ``X-Origin``. Confirmation goes through the existing
+        ``/mesh/config/confirm`` endpoint, which now dispatches on
+        ``target_kind``.
+        """
+        caller = _extract_verified_agent_id(request)
+        if caller != "operator" and not _is_internal_caller(request):
+            raise HTTPException(403, "Only the operator can delete projects")
+        from src.cli.config import _load_projects, _project_status
+        projects = _load_projects()
+        if name not in projects:
+            raise HTTPException(404, f"Project '{name}' not found")
+        status = _project_status(name)
+        if status != "archived":
+            raise HTTPException(
+                400,
+                "Project must be archived before delete. "
+                "Call /mesh/projects/{name}/archive first.",
+            )
+        origin = _validated_origin(request, caller)
+        origin_kind = origin.kind if origin is not None else None
+        # Cap pending rows to bound storage growth (mirrors propose_edit).
+        pending_actions.reap_expired()
+        existing = pending_actions.list_pending()
+        if len(existing) >= _MAX_PENDING:
+            oldest = min(existing, key=lambda r: r["expires_at"])
+            with pending_actions._conn() as _conn:
+                _conn.execute(
+                    "DELETE FROM pending_actions WHERE nonce=?",
+                    (oldest["nonce"],),
+                )
+        nonce = str(_uuid.uuid4())
+        members = projects[name].get("members", []) or []
+        summary = (
+            f"Delete project {name!r} and unlink {len(members)} agent(s). "
+            "Workspaces and per-agent history are retained; project metadata, "
+            "project.md, and project blackboard rows are removed."
+        )
+        payload = {
+            "name": name,
+            "summary": summary,
+            "members": members,
+        }
+        record = pending_actions.store(
+            nonce=nonce,
+            actor="operator",
+            target_kind="project",
+            target_id=name,
+            action_kind="delete",
+            payload=payload,
+            origin_kind=origin_kind,
+            ttl=_CHANGE_TTL_SECONDS,
+        )
+        return {
+            "change_id": nonce,
+            "summary": summary,
+            "expires_at": datetime.fromtimestamp(
+                record["expires_at"], tz=timezone.utc,
+            ).isoformat(),
+            "payload_digest": record["payload_digest"],
+            "requires_confirmation": True,
+        }
+
+    @app.post("/mesh/agents/{agent_id}/propose-delete")
+    async def propose_delete_agent(agent_id: str, request: Request) -> dict:
+        """Propose deletion of an archived agent. Returns nonce for human confirm.
+
+        Pre-conditions:
+          * agent exists
+          * agent is archived
+          * agent is not ``operator``
+        """
+        caller = _extract_verified_agent_id(request)
+        if caller != "operator" and not _is_internal_caller(request):
+            raise HTTPException(403, "Only the operator can delete agents")
+        if agent_id == "operator":
+            raise HTTPException(400, "The operator agent cannot be deleted")
+        from src.cli.config import _agent_status, _load_config
+        cfg = _load_config()
+        if agent_id not in cfg.get("agents", {}):
+            raise HTTPException(404, f"Agent '{agent_id}' not found")
+        status = _agent_status(agent_id)
+        if status != "archived":
+            raise HTTPException(
+                400,
+                "Agent must be archived before delete. "
+                "Call /mesh/agents/{agent_id}/archive first.",
+            )
+        origin = _validated_origin(request, caller)
+        origin_kind = origin.kind if origin is not None else None
+        pending_actions.reap_expired()
+        existing = pending_actions.list_pending()
+        if len(existing) >= _MAX_PENDING:
+            oldest = min(existing, key=lambda r: r["expires_at"])
+            with pending_actions._conn() as _conn:
+                _conn.execute(
+                    "DELETE FROM pending_actions WHERE nonce=?",
+                    (oldest["nonce"],),
+                )
+        nonce = str(_uuid.uuid4())
+        summary = (
+            f"Delete agent {agent_id!r}. Container stopped, config and "
+            "permissions removed, workspace dropped."
+        )
+        payload = {
+            "agent_id": agent_id,
+            "summary": summary,
+        }
+        record = pending_actions.store(
+            nonce=nonce,
+            actor="operator",
+            target_kind="agent",
+            target_id=agent_id,
+            action_kind="delete",
+            payload=payload,
+            origin_kind=origin_kind,
+            ttl=_CHANGE_TTL_SECONDS,
+        )
+        return {
+            "change_id": nonce,
+            "summary": summary,
+            "expires_at": datetime.fromtimestamp(
+                record["expires_at"], tz=timezone.utc,
+            ).isoformat(),
+            "payload_digest": record["payload_digest"],
+            "requires_confirmation": True,
+        }
+
+    async def _apply_pending_delete(record: dict) -> dict:
+        """Apply a consumed delete pending-action.
+
+        Dispatches on ``target_kind``. Project deletes call
+        ``_delete_project``; agent deletes stop the container, remove
+        the agent from config + permissions, and tear down per-agent
+        runtime state via ``app.cleanup_agent``.
+        """
+        kind = record["target_kind"]
+        target_id = record["target_id"]
+        if kind == "project":
+            from src.cli.config import _delete_project, _load_projects
+            if target_id not in _load_projects():
+                raise HTTPException(404, f"Project '{target_id}' no longer exists")
+            try:
+                _delete_project(target_id)
+            except ValueError as e:
+                raise HTTPException(404, str(e))
+            blackboard.log_audit(
+                action="delete_project", target=target_id,
+                change_id=record["nonce"],
+            )
+            return {"success": True, "deleted": "project", "name": target_id}
+        if kind == "agent":
+            from src.cli.config import _load_config, _remove_agent
+            if target_id not in _load_config().get("agents", {}):
+                raise HTTPException(404, f"Agent '{target_id}' no longer exists")
+            try:
+                _remove_agent(target_id, stop_container=container_manager is not None)
+            except Exception as e:
+                raise HTTPException(500, f"Failed to delete agent: {e}")
+            # Drop runtime state via cleanup_agent (rate buckets, vault,
+            # blackboard, pubsub, lanes, cron, costs, traces, wallets).
+            try:
+                app.cleanup_agent(target_id)
+            except Exception as e:
+                logger.warning("cleanup_agent(%s) failed during delete: %s", target_id, e)
+            try:
+                router.unregister_agent(target_id)
+            except Exception:
+                pass
+            if health_monitor is not None:
+                try:
+                    health_monitor.unregister(target_id)
+                except Exception:
+                    pass
+            blackboard.log_audit(
+                action="delete_agent", target=target_id,
+                change_id=record["nonce"],
+            )
+            return {"success": True, "deleted": "agent", "agent_id": target_id}
+        raise HTTPException(
+            400, f"Unsupported pending-delete target_kind: {kind!r}",
+        )
 
     @app.post("/mesh/tasks/{task_id}/cancel")
     async def cancel_task(task_id: str, request: Request) -> dict:
@@ -3648,7 +4338,11 @@ def create_mesh_app(
 
     @app.post("/mesh/agents/{agent_id}/config")
     async def update_agent_config(agent_id: str, request: Request) -> dict:
-        """Apply a pending config change. Used by confirm_edit tool."""
+        """Apply a pending config change. Used by confirm_edit tool.
+
+        Refuses delete pending actions — those must go through
+        ``/mesh/config/confirm`` so the destructive dispatcher runs.
+        """
         _require_any_auth(request)
         caller = _resolve_agent_id("", request)
         if caller != "operator":
@@ -3664,6 +4358,11 @@ def create_mesh_app(
         peek = pending_actions.peek(change_id)
         if peek is not None and peek.get("target_id") != agent_id:
             raise HTTPException(400, "Agent ID mismatch")
+        if peek is not None and peek.get("action_kind") == "delete":
+            raise HTTPException(
+                400,
+                "Use /mesh/config/confirm for delete pending actions",
+            )
 
         record = pending_actions.consume(
             change_id,
@@ -3680,16 +4379,23 @@ def create_mesh_app(
 
     @app.post("/mesh/config/confirm")
     async def confirm_config_change(request: Request) -> dict:
-        """Apply a pending config change by change_id only.
+        """Apply a pending action by change_id only.
 
-        Unlike POST /mesh/agents/{agent_id}/config, this endpoint resolves
-        the agent_id from the pending change itself so callers don't need
-        to know the target agent_id up front.  Used by the operator's
-        ``confirm_edit`` tool.
+        Resolves the target from the pending action itself so callers
+        don't need to know the target ahead of time. Dispatches on
+        ``target_kind``:
+
+        * ``target_kind="agent"`` + standard config field — the legacy
+          ``confirm_edit`` flow (apply through ``_apply_pending_change``).
+        * ``target_kind in {"project", "agent"}`` + ``action_kind="delete"``
+          — Task 7 destructive-confirm flow (apply through
+          ``_apply_pending_delete``).
+
+        Both shapes share the same ``require_origin_kind="human"`` gate
+        and the same atomic single-shot consume.
         """
-        _require_any_auth(request)
-        caller = _resolve_agent_id("", request)
-        if caller != "operator":
+        caller = _extract_verified_agent_id(request)
+        if caller != "operator" and not _is_internal_caller(request):
             raise HTTPException(403, "Only the operator can confirm config changes")
         _confirm_origin_check(request, caller)
         data = await request.json()
@@ -3697,8 +4403,8 @@ def create_mesh_app(
         client_digest = data.get("payload_digest")
 
         # Consume + apply. ``consume`` is atomic: same nonce can only
-        # be applied once. If ``_apply_pending_change`` raises, the
-        # row is already gone -- the caller must propose a new change.
+        # be applied once. If the apply raises, the row is already
+        # gone — the caller must propose a new change.
         record = pending_actions.consume(
             change_id,
             confirmer="operator",
@@ -3707,6 +4413,14 @@ def create_mesh_app(
         )
         if not record:
             raise HTTPException(400, "Pending action invalid or expired")
+
+        # Task 7: destructive deletes use ``action_kind="delete"`` plus
+        # ``target_kind in {"project", "agent"}``. Everything else stays
+        # on the legacy config-edit path.
+        if record.get("action_kind") == "delete" and record.get("target_kind") in {
+            "project", "agent",
+        }:
+            return await _apply_pending_delete(record)
 
         return await _apply_pending_change(
             change_id, _record_to_legacy_change(record),

--- a/src/shared/types.py
+++ b/src/shared/types.py
@@ -323,12 +323,19 @@ class AgentPermissions(BaseModel):
 
 
 class ProjectMetadata(BaseModel):
-    """Project definition loaded from config/projects/<name>/metadata.yaml."""
+    """Project definition loaded from config/projects/<name>/metadata.yaml.
+
+    ``status`` defaults to ``"active"``; operator product tools use
+    ``"archived"`` to stop scheduling and hide the project from default
+    list views without deleting its data. Archive is reversible; delete
+    requires archive first plus a separate human-confirmed step.
+    """
 
     name: str
     description: str = ""
     members: list[str] = []
     created_at: str | None = None
+    status: str = "active"
     settings: dict[str, Any] = {}
 
 

--- a/tests/test_operator_config.py
+++ b/tests/test_operator_config.py
@@ -244,10 +244,19 @@ class TestOperatorConstants:
 
     def test_allowed_tools_populated(self):
         from src.cli.config import _OPERATOR_ALLOWED_TOOLS, _OPERATOR_HEARTBEAT_TOOLS
-        assert len(_OPERATOR_ALLOWED_TOOLS) == 23
+        # Task 7 added the operator product surface (4 read + 7 action tools).
+        assert len(_OPERATOR_ALLOWED_TOOLS) == 34
         assert len(_OPERATOR_HEARTBEAT_TOOLS) == 5
         # Heartbeat tools should be a subset of allowed tools
         assert set(_OPERATOR_HEARTBEAT_TOOLS).issubset(set(_OPERATOR_ALLOWED_TOOLS))
+        # Task 7 product tools must be in the allowlist.
+        for tool in (
+            "list_project_status", "list_agent_queue", "get_team_outputs",
+            "summarize_project_progress",
+            "reroute_task", "cancel_task", "retry_failed_task",
+            "archive_project", "archive_agent", "delete_project", "delete_agent",
+        ):
+            assert tool in _OPERATOR_ALLOWED_TOOLS
 
     def test_request_browser_login_in_allowlist(self):
         """Operator must be allowed to delegate browser login requests to workers.

--- a/tests/test_operator_product_tools.py
+++ b/tests/test_operator_product_tools.py
@@ -1,0 +1,805 @@
+"""Tests for Task 7 operator product tools.
+
+Covers the new operator surface (read tools + action tools), plus the
+HTTP endpoint integration tests for project/agent archive + delete flows
+and the cost-aware reroute/retry path.
+
+The unit tests at the top mock ``mesh_client`` directly so they exercise
+the tool wiring + flag gating without booting a mesh app. The endpoint
+tests at the bottom build a real ``create_mesh_app`` and drive the
+routes through ``ASGITransport``.
+"""
+
+from __future__ import annotations
+
+import importlib
+import os
+from datetime import datetime, timezone
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+import httpx
+import pytest
+import yaml
+from httpx import ASGITransport, AsyncClient
+
+from src.host.mesh import Blackboard, MessageRouter, PubSub
+from src.host.permissions import PermissionMatrix
+from src.shared.types import AgentPermissions, MessageOrigin
+
+
+@pytest.fixture(autouse=True)
+def _set_operator_env(monkeypatch):
+    monkeypatch.setenv("ALLOWED_TOOLS", "list_project_status,list_agent_queue")
+
+
+# ── Helper: simulate an HTTP error wrapping an over_budget body ────
+
+
+def _fake_budget_http_error(agent: str, monthly_used: float = 50.0) -> httpx.HTTPStatusError:
+    """Build an ``HTTPStatusError`` carrying the structured budget detail."""
+    request = httpx.Request("POST", "http://t/mesh/tasks/x/reroute")
+    response = httpx.Response(
+        400,
+        request=request,
+        json={
+            "detail": (
+                '{"error": "over_budget", '
+                '"detail": "test", '
+                '"budget": {"agent": "' + agent + '", "monthly_used": '
+                + str(monthly_used) + '}}'
+            ),
+        },
+    )
+    return httpx.HTTPStatusError("400 Bad Request", request=request, response=response)
+
+
+# ── v2 flag gate ──────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_list_project_status_requires_v2_flag(monkeypatch):
+    """Read tools that consume tasks return a clean error when v2 off."""
+    monkeypatch.delenv("OPENLEGION_ORCHESTRATION_TASKS_V2", raising=False)
+    from src.agent.builtins.operator_tools import list_project_status
+    result = await list_project_status(mesh_client=MagicMock())
+    assert "error" in result
+    assert "OPENLEGION_ORCHESTRATION_TASKS_V2" in result["error"]
+
+
+@pytest.mark.asyncio
+async def test_list_agent_queue_requires_v2_flag(monkeypatch):
+    monkeypatch.delenv("OPENLEGION_ORCHESTRATION_TASKS_V2", raising=False)
+    from src.agent.builtins.operator_tools import list_agent_queue
+    result = await list_agent_queue("a1", mesh_client=MagicMock())
+    assert "error" in result
+    assert "OPENLEGION_ORCHESTRATION_TASKS_V2" in result["error"]
+
+
+@pytest.mark.asyncio
+async def test_get_team_outputs_requires_v2_flag(monkeypatch):
+    monkeypatch.delenv("OPENLEGION_ORCHESTRATION_TASKS_V2", raising=False)
+    from src.agent.builtins.operator_tools import get_team_outputs
+    result = await get_team_outputs("p1", mesh_client=MagicMock())
+    assert "error" in result
+
+
+@pytest.mark.asyncio
+async def test_summarize_project_progress_requires_v2_flag(monkeypatch):
+    monkeypatch.delenv("OPENLEGION_ORCHESTRATION_TASKS_V2", raising=False)
+    from src.agent.builtins.operator_tools import summarize_project_progress
+    result = await summarize_project_progress("p1", mesh_client=MagicMock())
+    assert "error" in result
+
+
+@pytest.mark.asyncio
+async def test_reroute_task_requires_v2_flag(monkeypatch):
+    monkeypatch.delenv("OPENLEGION_ORCHESTRATION_TASKS_V2", raising=False)
+    from src.agent.builtins.operator_tools import reroute_task
+    result = await reroute_task("t1", "writer", mesh_client=MagicMock())
+    assert "error" in result
+
+
+@pytest.mark.asyncio
+async def test_cancel_task_requires_v2_flag(monkeypatch):
+    monkeypatch.delenv("OPENLEGION_ORCHESTRATION_TASKS_V2", raising=False)
+    from src.agent.builtins.operator_tools import cancel_task
+    result = await cancel_task("t1", mesh_client=MagicMock())
+    assert "error" in result
+
+
+@pytest.mark.asyncio
+async def test_retry_failed_task_requires_v2_flag(monkeypatch):
+    monkeypatch.delenv("OPENLEGION_ORCHESTRATION_TASKS_V2", raising=False)
+    from src.agent.builtins.operator_tools import retry_failed_task
+    result = await retry_failed_task("t1", mesh_client=MagicMock())
+    assert "error" in result
+
+
+@pytest.mark.asyncio
+async def test_archive_project_works_without_v2_flag(monkeypatch):
+    """Archive/delete project/agent tools work regardless of the v2 flag."""
+    monkeypatch.delenv("OPENLEGION_ORCHESTRATION_TASKS_V2", raising=False)
+    from src.agent.builtins.operator_tools import archive_project
+    mc = MagicMock()
+    mc.archive_project = AsyncMock(return_value={"archived": True, "project": "growth"})
+    messages = [{"role": "user", "content": "yes", "_origin": "user"}]
+    result = await archive_project("growth", mesh_client=mc, _messages=messages)
+    assert result["archived"] is True
+
+
+# ── Read tool happy path ──────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_list_project_status_all_projects(monkeypatch):
+    monkeypatch.setenv("OPENLEGION_ORCHESTRATION_TASKS_V2", "1")
+    from src.agent.builtins.operator_tools import list_project_status
+    mc = MagicMock()
+    mc.all_projects_status = AsyncMock(
+        return_value={"projects": [
+            {"project": {"name": "p1"}, "counts": {"active": 2}},
+        ]},
+    )
+    result = await list_project_status(mesh_client=mc)
+    assert "projects" in result
+    mc.all_projects_status.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_list_project_status_single_project(monkeypatch):
+    monkeypatch.setenv("OPENLEGION_ORCHESTRATION_TASKS_V2", "1")
+    from src.agent.builtins.operator_tools import list_project_status
+    mc = MagicMock()
+    mc.project_status = AsyncMock(
+        return_value={"project": {"name": "growth"}, "counts": {"active": 1}},
+    )
+    result = await list_project_status("growth", mesh_client=mc)
+    mc.project_status.assert_awaited_once_with("growth")
+    assert result["project"]["name"] == "growth"
+
+
+@pytest.mark.asyncio
+async def test_list_agent_queue_calls_mesh(monkeypatch):
+    monkeypatch.setenv("OPENLEGION_ORCHESTRATION_TASKS_V2", "1")
+    from src.agent.builtins.operator_tools import list_agent_queue
+    mc = MagicMock()
+    mc.agent_queue = AsyncMock(
+        return_value={"agent_id": "writer", "queue": {"active": []}},
+    )
+    result = await list_agent_queue("writer", limit=20, mesh_client=mc)
+    mc.agent_queue.assert_awaited_once_with("writer", limit=20)
+    assert result["agent_id"] == "writer"
+
+
+@pytest.mark.asyncio
+async def test_get_team_outputs_passes_since(monkeypatch):
+    monkeypatch.setenv("OPENLEGION_ORCHESTRATION_TASKS_V2", "1")
+    from src.agent.builtins.operator_tools import get_team_outputs
+    mc = MagicMock()
+    mc.project_outputs = AsyncMock(return_value={"outputs": []})
+    await get_team_outputs("p1", since="24h", mesh_client=mc)
+    mc.project_outputs.assert_awaited_once_with("p1", since="24h")
+
+
+@pytest.mark.asyncio
+async def test_summarize_project_progress_calls_mesh(monkeypatch):
+    monkeypatch.setenv("OPENLEGION_ORCHESTRATION_TASKS_V2", "1")
+    from src.agent.builtins.operator_tools import summarize_project_progress
+    mc = MagicMock()
+    mc.project_summary = AsyncMock(
+        return_value={"status_text": "all good", "counts": {"active": 0}},
+    )
+    result = await summarize_project_progress("p1", mesh_client=mc)
+    assert "status_text" in result
+
+
+@pytest.mark.asyncio
+async def test_get_agent_profile_calls_mesh():
+    """get_agent_profile is not gated on v2 — calls /mesh/agents/{id}/profile."""
+    from src.agent.builtins.operator_tools import get_agent_profile
+    mc = MagicMock()
+    mc.get_agent_profile = AsyncMock(return_value={"agent_id": "writer", "role": "writer"})
+    result = await get_agent_profile("writer", mesh_client=mc)
+    assert result["agent_id"] == "writer"
+
+
+# ── Action tool: reroute_task with cost gate ──────────────────
+
+
+@pytest.mark.asyncio
+async def test_reroute_task_success(monkeypatch):
+    monkeypatch.setenv("OPENLEGION_ORCHESTRATION_TASKS_V2", "1")
+    from src.agent.builtins.operator_tools import reroute_task
+    mc = MagicMock()
+    mc.reroute_task = AsyncMock(
+        return_value={"id": "task_1", "assignee": "writer", "status": "pending"},
+    )
+    result = await reroute_task("task_1", "writer", reason="capacity",
+                                mesh_client=mc)
+    mc.reroute_task.assert_awaited_once_with("task_1", "writer", reason="capacity")
+    assert result["assignee"] == "writer"
+
+
+@pytest.mark.asyncio
+async def test_reroute_task_over_budget_returns_structured_error(monkeypatch):
+    """Over-budget surface from the mesh wraps a structured payload."""
+    monkeypatch.setenv("OPENLEGION_ORCHESTRATION_TASKS_V2", "1")
+    from src.agent.builtins.operator_tools import reroute_task
+    mc = MagicMock()
+    mc.reroute_task = AsyncMock(side_effect=_fake_budget_http_error("writer"))
+    result = await reroute_task("task_1", "writer", mesh_client=mc)
+    assert result["error"] == "over_budget"
+    assert "writer" in (result.get("budget") or {}).get("agent", "")
+
+
+@pytest.mark.asyncio
+async def test_cancel_task_success(monkeypatch):
+    monkeypatch.setenv("OPENLEGION_ORCHESTRATION_TASKS_V2", "1")
+    from src.agent.builtins.operator_tools import cancel_task
+    mc = MagicMock()
+    mc.cancel_task = AsyncMock(return_value={"id": "task_1", "status": "cancelled"})
+    result = await cancel_task("task_1", reason="bad scope", mesh_client=mc)
+    assert result["status"] == "cancelled"
+    mc.cancel_task.assert_awaited_once_with("task_1", reason="bad scope")
+
+
+@pytest.mark.asyncio
+async def test_retry_failed_task_with_changes(monkeypatch):
+    monkeypatch.setenv("OPENLEGION_ORCHESTRATION_TASKS_V2", "1")
+    from src.agent.builtins.operator_tools import retry_failed_task
+    mc = MagicMock()
+    mc.retry_task = AsyncMock(
+        return_value={"clone": {"id": "task_2"}, "original_id": "task_1"},
+    )
+    result = await retry_failed_task(
+        "task_1", with_changes={"assignee": "scout", "title": "v2"},
+        mesh_client=mc,
+    )
+    assert result["original_id"] == "task_1"
+    mc.retry_task.assert_awaited_once_with(
+        "task_1", title="v2", description=None, assignee="scout",
+    )
+
+
+@pytest.mark.asyncio
+async def test_retry_failed_task_over_budget(monkeypatch):
+    monkeypatch.setenv("OPENLEGION_ORCHESTRATION_TASKS_V2", "1")
+    from src.agent.builtins.operator_tools import retry_failed_task
+    mc = MagicMock()
+    mc.retry_task = AsyncMock(side_effect=_fake_budget_http_error("scout"))
+    result = await retry_failed_task("task_1", mesh_client=mc)
+    assert result["error"] == "over_budget"
+    assert (result.get("budget") or {}).get("agent") == "scout"
+
+
+# ── Archive / delete tools ────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_archive_project_provenance_required():
+    from src.agent.builtins.operator_tools import archive_project
+    messages = [{"role": "user", "content": "x", "_origin": "system:heartbeat"}]
+    result = await archive_project("p1", mesh_client=MagicMock(), _messages=messages)
+    assert result["error"] == "provenance_check_failed"
+
+
+@pytest.mark.asyncio
+async def test_archive_project_success():
+    from src.agent.builtins.operator_tools import archive_project
+    mc = MagicMock()
+    mc.archive_project = AsyncMock(return_value={"archived": True, "project": "p1"})
+    messages = [{"role": "user", "content": "yes", "_origin": "user"}]
+    result = await archive_project("p1", mesh_client=mc, _messages=messages)
+    assert result["archived"] is True
+
+
+@pytest.mark.asyncio
+async def test_archive_agent_blocks_operator():
+    from src.agent.builtins.operator_tools import archive_agent
+    messages = [{"role": "user", "content": "yes", "_origin": "user"}]
+    result = await archive_agent("operator", mesh_client=MagicMock(), _messages=messages)
+    assert "operator" in result["error"].lower()
+
+
+@pytest.mark.asyncio
+async def test_archive_agent_success():
+    from src.agent.builtins.operator_tools import archive_agent
+    mc = MagicMock()
+    mc.archive_agent = AsyncMock(return_value={"archived": True, "agent_id": "writer"})
+    messages = [{"role": "user", "content": "yes", "_origin": "user"}]
+    result = await archive_agent("writer", mesh_client=mc, _messages=messages)
+    assert result["archived"] is True
+
+
+@pytest.mark.asyncio
+async def test_delete_project_returns_nonce_for_confirmation():
+    from src.agent.builtins.operator_tools import delete_project
+    mc = MagicMock()
+    mc.propose_delete_project = AsyncMock(return_value={
+        "change_id": "abc-123",
+        "summary": "Delete project 'growth' and 2 agent(s).",
+        "expires_at": "2026-05-02T00:15:00+00:00",
+        "payload_digest": "deadbeef",
+        "requires_confirmation": True,
+    })
+    messages = [{"role": "user", "content": "yes", "_origin": "user"}]
+    result = await delete_project("growth", mesh_client=mc, _messages=messages)
+    assert result["requires_confirmation"] is True
+    assert result["change_id"] == "abc-123"
+    assert "summary" in result
+
+
+@pytest.mark.asyncio
+async def test_delete_project_provenance_required():
+    from src.agent.builtins.operator_tools import delete_project
+    messages = [{"role": "user", "content": "hb", "_origin": "system:heartbeat"}]
+    result = await delete_project("growth", mesh_client=MagicMock(), _messages=messages)
+    assert result["error"] == "provenance_check_failed"
+
+
+@pytest.mark.asyncio
+async def test_delete_project_archive_required():
+    """If the mesh rejects with 400, the tool surfaces a friendly hint."""
+    from src.agent.builtins.operator_tools import delete_project
+    mc = MagicMock()
+    mc.propose_delete_project = AsyncMock(side_effect=RuntimeError("400: Project must be archived"))
+    messages = [{"role": "user", "content": "yes", "_origin": "user"}]
+    result = await delete_project("growth", mesh_client=mc, _messages=messages)
+    assert result["error"] == "archive_required"
+
+
+@pytest.mark.asyncio
+async def test_delete_agent_blocks_operator():
+    from src.agent.builtins.operator_tools import delete_agent
+    messages = [{"role": "user", "content": "yes", "_origin": "user"}]
+    result = await delete_agent("operator", mesh_client=MagicMock(), _messages=messages)
+    assert "operator" in result["error"].lower()
+
+
+@pytest.mark.asyncio
+async def test_delete_agent_returns_nonce():
+    from src.agent.builtins.operator_tools import delete_agent
+    mc = MagicMock()
+    mc.propose_delete_agent = AsyncMock(return_value={
+        "change_id": "n1",
+        "summary": "Delete agent 'writer'",
+        "payload_digest": "abc",
+        "expires_at": "2026-05-02T00:15:00+00:00",
+        "requires_confirmation": True,
+    })
+    messages = [{"role": "user", "content": "yes", "_origin": "user"}]
+    result = await delete_agent("writer", mesh_client=mc, _messages=messages)
+    assert result["change_id"] == "n1"
+    assert result["requires_confirmation"] is True
+
+
+# ── HTTP endpoint integration tests ────────────────────────────
+
+
+def _reload_server(monkeypatch, *, v2: bool, tasks_db: str):
+    if v2:
+        monkeypatch.setenv("OPENLEGION_ORCHESTRATION_TASKS_V2", "1")
+        monkeypatch.setenv("OPENLEGION_ORCHESTRATION_TASKS_DB", tasks_db)
+    else:
+        monkeypatch.delenv("OPENLEGION_ORCHESTRATION_TASKS_V2", raising=False)
+    import src.host.server as server_module
+    importlib.reload(server_module)
+    return server_module
+
+
+def _build_app(tmp_path, server_module, *, perms_map, agents=None,
+               cost_tracker=None, container_manager=None):
+    blackboard = Blackboard(str(tmp_path / "bb.db"))
+    pubsub = PubSub()
+    permissions = PermissionMatrix()
+    for aid, perms in perms_map.items():
+        permissions.permissions[aid] = AgentPermissions(agent_id=aid, **perms)
+    router = MessageRouter(permissions, agents or {})
+    app = server_module.create_mesh_app(
+        blackboard=blackboard,
+        pubsub=pubsub,
+        router=router,
+        permissions=permissions,
+        cost_tracker=cost_tracker,
+        container_manager=container_manager,
+    )
+    return app, blackboard
+
+
+def _projects_layout(tmp_path):
+    """Two projects: research with [scout, analyst]; ops with [tracker]."""
+    pdir = tmp_path / "projects"
+    research = pdir / "research"
+    research.mkdir(parents=True)
+    (research / "metadata.yaml").write_text(yaml.dump({
+        "name": "research",
+        "members": ["scout", "analyst"],
+        "created_at": "2026-05-02T00:00:00+00:00",
+        "status": "active",
+    }))
+    ops = pdir / "ops"
+    ops.mkdir(parents=True)
+    (ops / "metadata.yaml").write_text(yaml.dump({
+        "name": "ops",
+        "members": ["tracker"],
+        "created_at": "2026-05-02T00:00:00+00:00",
+        "status": "active",
+    }))
+    return pdir
+
+
+def _agents_yaml(tmp_path, names: list[str]) -> Path:
+    """Write a minimal agents.yaml with named agents."""
+    (tmp_path / "config").mkdir(exist_ok=True)
+    afile = tmp_path / "config" / "agents.yaml"
+    cfg = {"agents": {name: {"role": name, "model": "gpt-4o-mini"} for name in names}}
+    afile.write_text(yaml.dump(cfg))
+    return afile
+
+
+@pytest.fixture
+def v2_app(tmp_path, monkeypatch):
+    """Mesh app with v2 on, projects + agents on disk, operator routed."""
+    # Pin the cli/config paths into tmp_path so PROJECTS_DIR + AGENTS_FILE
+    # use the test layout.
+    pdir = _projects_layout(tmp_path)
+    afile = _agents_yaml(tmp_path, names=["scout", "analyst", "tracker"])
+    monkeypatch.chdir(tmp_path)
+    import src.cli.config as cli_cfg
+    monkeypatch.setattr(cli_cfg, "PROJECTS_DIR", pdir)
+    monkeypatch.setattr(cli_cfg, "AGENTS_FILE", afile)
+    monkeypatch.setattr(cli_cfg, "PERMISSIONS_FILE", tmp_path / "config" / "permissions.json")
+
+    server_module = _reload_server(
+        monkeypatch, v2=True, tasks_db=str(tmp_path / "tasks.db"),
+    )
+
+    perms_map = {
+        "operator": {"can_route_tasks": True, "can_manage_projects": True},
+        "scout":    {"can_route_tasks": True, "can_message": ["analyst", "operator"]},
+        "analyst":  {"can_route_tasks": False, "can_message": ["scout"]},
+        "tracker":  {"can_route_tasks": False, "can_message": []},
+    }
+    # CostTracker stub: scout over budget, analyst within
+    cost_tracker = MagicMock()
+    cost_tracker.check_budget = MagicMock(side_effect=lambda agent: (
+        {"allowed": False, "daily_used": 20.0, "daily_limit": 10.0,
+         "monthly_used": 250.0, "monthly_limit": 200.0}
+        if agent == "scout"
+        else {"allowed": True, "daily_used": 1.0, "daily_limit": 10.0,
+              "monthly_used": 5.0, "monthly_limit": 200.0}
+    ))
+    container_manager = MagicMock()
+    container_manager.stop_agent = MagicMock(return_value=True)
+
+    app, bb = _build_app(
+        tmp_path, server_module,
+        perms_map=perms_map,
+        agents={
+            "scout": "http://scout:8400",
+            "analyst": "http://analyst:8400",
+            "tracker": "http://tracker:8400",
+            "operator": "http://operator:8400",
+        },
+        cost_tracker=cost_tracker,
+        container_manager=container_manager,
+    )
+    yield app, server_module, tmp_path
+    bb.close()
+    monkeypatch.delenv("OPENLEGION_ORCHESTRATION_TASKS_V2", raising=False)
+    monkeypatch.delenv("OPENLEGION_ORCHESTRATION_TASKS_DB", raising=False)
+    importlib.reload(server_module)
+
+
+def _human_origin_headers(agent_id: str = "operator", channel: str = "cli", user: str = "u1") -> dict:
+    """Headers for a request originating from a paired/CLI human."""
+    origin = MessageOrigin(kind="human", channel=channel, user=user)
+    return {
+        "X-Agent-ID": agent_id,
+        "X-Origin": origin.to_header_value(),
+    }
+
+
+@pytest.mark.asyncio
+async def test_endpoint_project_status_returns_counts(v2_app):
+    app, _, _ = v2_app
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
+        # Create a few tasks
+        await c.post("/mesh/tasks",
+                     json={"assignee": "analyst", "title": "t1", "project": "research"},
+                     headers={"X-Agent-ID": "operator"})
+        await c.post("/mesh/tasks",
+                     json={"assignee": "scout", "title": "t2", "project": "research"},
+                     headers={"X-Agent-ID": "operator"})
+        r = await c.get("/mesh/projects/research/status",
+                        headers={"X-Agent-ID": "operator"})
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["counts"]["active"] == 2
+    assert body["project"]["name"] == "research"
+    assert body["project"]["status"] == "active"
+
+
+@pytest.mark.asyncio
+async def test_endpoint_project_status_403_for_non_member(v2_app):
+    app, _, _ = v2_app
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
+        r = await c.get("/mesh/projects/research/status",
+                        headers={"X-Agent-ID": "tracker"})
+    assert r.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_endpoint_all_projects_status_operator_sees_all(v2_app):
+    app, _, _ = v2_app
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
+        r = await c.get("/mesh/projects/status",
+                        headers={"X-Agent-ID": "operator"})
+    assert r.status_code == 200
+    names = {p["project"]["name"] for p in r.json()["projects"]}
+    assert names == {"research", "ops"}
+
+
+@pytest.mark.asyncio
+async def test_endpoint_agent_queue_buckets(v2_app):
+    app, _, _ = v2_app
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
+        # Create one task for analyst, then mark it done
+        r = await c.post("/mesh/tasks",
+                         json={"assignee": "analyst", "title": "t1", "project": "research"},
+                         headers={"X-Agent-ID": "operator"})
+        tid = r.json()["id"]
+        await c.post(f"/mesh/tasks/{tid}/status",
+                     json={"status": "working"},
+                     headers={"X-Agent-ID": "analyst"})
+        await c.post(f"/mesh/tasks/{tid}/status",
+                     json={"status": "done"},
+                     headers={"X-Agent-ID": "analyst"})
+        r = await c.get("/mesh/agents/analyst/queue",
+                        headers={"X-Agent-ID": "operator"})
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["agent_id"] == "analyst"
+    assert len(body["queue"]["done"]) == 1
+    assert len(body["queue"]["active"]) == 0
+
+
+@pytest.mark.asyncio
+async def test_endpoint_project_outputs_filters_by_since(v2_app):
+    app, _, _ = v2_app
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
+        r = await c.post("/mesh/tasks",
+                         json={"assignee": "analyst", "title": "report", "project": "research"},
+                         headers={"X-Agent-ID": "operator"})
+        tid = r.json()["id"]
+        await c.post(f"/mesh/tasks/{tid}/status",
+                     json={"status": "working"},
+                     headers={"X-Agent-ID": "analyst"})
+        await c.post(f"/mesh/tasks/{tid}/status",
+                     json={"status": "done"},
+                     headers={"X-Agent-ID": "analyst"})
+        # Last 24h includes the task
+        r = await c.get("/mesh/projects/research/outputs",
+                        params={"since": "24h"},
+                        headers={"X-Agent-ID": "operator"})
+    assert r.status_code == 200
+    assert len(r.json()["outputs"]) == 1
+
+
+@pytest.mark.asyncio
+async def test_endpoint_project_summary(v2_app):
+    app, _, _ = v2_app
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
+        r = await c.get("/mesh/projects/research/summary",
+                        headers={"X-Agent-ID": "operator"})
+    assert r.status_code == 200
+    body = r.json()
+    assert "status_text" in body
+    assert "counts" in body
+    assert "ask_for_user" in body
+
+
+@pytest.mark.asyncio
+async def test_endpoint_reroute_blocks_when_target_over_budget(v2_app):
+    app, _, _ = v2_app
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
+        r = await c.post("/mesh/tasks",
+                         json={"assignee": "analyst", "title": "t1", "project": "research"},
+                         headers={"X-Agent-ID": "operator"})
+        tid = r.json()["id"]
+        # Reroute to scout (over budget) — should fail with structured error
+        r = await c.post(f"/mesh/tasks/{tid}/reroute",
+                         json={"new_assignee": "scout"},
+                         headers={"X-Agent-ID": "operator"})
+    assert r.status_code == 400
+    body = r.json()
+    detail = body.get("detail")
+    if isinstance(detail, str):
+        import json as _json
+        detail = _json.loads(detail)
+    assert detail["error"] == "over_budget"
+    assert detail["budget"]["agent"] == "scout"
+
+
+@pytest.mark.asyncio
+async def test_endpoint_retry_failed_task_clones(v2_app):
+    app, _, _ = v2_app
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
+        r = await c.post("/mesh/tasks",
+                         json={"assignee": "analyst", "title": "t1", "project": "research"},
+                         headers={"X-Agent-ID": "operator"})
+        tid = r.json()["id"]
+        await c.post(f"/mesh/tasks/{tid}/status",
+                     json={"status": "working"},
+                     headers={"X-Agent-ID": "analyst"})
+        await c.post(f"/mesh/tasks/{tid}/status",
+                     json={"status": "failed"},
+                     headers={"X-Agent-ID": "analyst"})
+        r = await c.post(f"/mesh/tasks/{tid}/retry",
+                         json={"title": "t1 redux"},
+                         headers={"X-Agent-ID": "operator"})
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["original_id"] == tid
+    assert body["clone"]["status"] == "pending"
+    assert body["clone"]["title"] == "t1 redux"
+
+
+@pytest.mark.asyncio
+async def test_endpoint_retry_only_failed(v2_app):
+    app, _, _ = v2_app
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
+        r = await c.post("/mesh/tasks",
+                         json={"assignee": "analyst", "title": "t1", "project": "research"},
+                         headers={"X-Agent-ID": "operator"})
+        tid = r.json()["id"]
+        # Task is still pending — retry must refuse
+        r = await c.post(f"/mesh/tasks/{tid}/retry",
+                         headers={"X-Agent-ID": "operator"})
+    assert r.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_endpoint_archive_project(v2_app):
+    app, _, tmp_path = v2_app
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
+        r = await c.post("/mesh/projects/research/archive",
+                         headers={"X-Agent-ID": "operator"})
+    assert r.status_code == 200
+    # Default list should now exclude archived
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
+        r = await c.get("/mesh/projects",
+                        headers={"X-Agent-ID": "operator"})
+    body = r.json()
+    names = {p["name"] for p in body["projects"]}
+    assert "research" not in names
+    assert "ops" in names
+
+
+@pytest.mark.asyncio
+async def test_endpoint_delete_project_requires_archive(v2_app):
+    """Delete on a live project must be rejected with 400."""
+    app, _, _ = v2_app
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
+        r = await c.post("/mesh/projects/research/propose-delete",
+                         headers=_human_origin_headers())
+    assert r.status_code == 400
+    assert "archived" in r.text.lower()
+
+
+@pytest.mark.asyncio
+async def test_endpoint_delete_project_happy_path(v2_app):
+    app, _, _ = v2_app
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
+        # Archive first
+        r = await c.post("/mesh/projects/research/archive",
+                         headers={"X-Agent-ID": "operator"})
+        assert r.status_code == 200
+        # Propose delete
+        r = await c.post("/mesh/projects/research/propose-delete",
+                         headers=_human_origin_headers())
+        assert r.status_code == 200, r.text
+        nonce = r.json()["change_id"]
+        digest = r.json()["payload_digest"]
+        # Confirm with human origin succeeds
+        r = await c.post("/mesh/config/confirm",
+                         json={"change_id": nonce, "payload_digest": digest},
+                         headers=_human_origin_headers())
+    assert r.status_code == 200
+    body = r.json()
+    assert body["deleted"] == "project"
+    assert body["name"] == "research"
+
+
+@pytest.mark.asyncio
+async def test_endpoint_delete_project_confirm_with_agent_origin_403(v2_app):
+    app, _, _ = v2_app
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
+        await c.post("/mesh/projects/research/archive",
+                     headers={"X-Agent-ID": "operator"})
+        r = await c.post("/mesh/projects/research/propose-delete",
+                         headers=_human_origin_headers())
+        nonce = r.json()["change_id"]
+        digest = r.json()["payload_digest"]
+        # Agent origin → 403 from the confirm-side gate
+        agent_origin = MessageOrigin(kind="agent", channel="", user="").to_header_value()
+        r = await c.post("/mesh/config/confirm",
+                         json={"change_id": nonce, "payload_digest": digest},
+                         headers={"X-Agent-ID": "operator", "X-Origin": agent_origin})
+    assert r.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_endpoint_delete_project_expired_or_unknown(v2_app):
+    app, _, _ = v2_app
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
+        r = await c.post("/mesh/config/confirm",
+                         json={"change_id": "does-not-exist"},
+                         headers=_human_origin_headers())
+    assert r.status_code == 400
+    assert "invalid or expired" in r.text.lower()
+
+
+@pytest.mark.asyncio
+async def test_endpoint_archive_agent_then_delete(v2_app):
+    app, _, _ = v2_app
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
+        # Archive scout
+        r = await c.post("/mesh/agents/scout/archive",
+                         headers={"X-Agent-ID": "operator"})
+        assert r.status_code == 200
+        # Propose delete
+        r = await c.post("/mesh/agents/scout/propose-delete",
+                         headers=_human_origin_headers())
+        assert r.status_code == 200, r.text
+        nonce = r.json()["change_id"]
+        digest = r.json()["payload_digest"]
+        # Confirm
+        r = await c.post("/mesh/config/confirm",
+                         json={"change_id": nonce, "payload_digest": digest},
+                         headers=_human_origin_headers())
+    assert r.status_code == 200
+    body = r.json()
+    assert body["deleted"] == "agent"
+
+
+@pytest.mark.asyncio
+async def test_endpoint_delete_agent_requires_archive_first(v2_app):
+    app, _, _ = v2_app
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
+        r = await c.post("/mesh/agents/scout/propose-delete",
+                         headers=_human_origin_headers())
+    assert r.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_endpoint_delete_agent_blocks_operator(v2_app):
+    app, _, _ = v2_app
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
+        r = await c.post("/mesh/agents/operator/propose-delete",
+                         headers=_human_origin_headers())
+    assert r.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_endpoint_archive_agent_blocks_operator(v2_app):
+    app, _, _ = v2_app
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
+        r = await c.post("/mesh/agents/operator/archive",
+                         headers={"X-Agent-ID": "operator"})
+    assert r.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_endpoint_list_projects_includes_archived_when_flagged(v2_app):
+    app, _, _ = v2_app
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
+        await c.post("/mesh/projects/research/archive",
+                     headers={"X-Agent-ID": "operator"})
+        r = await c.get("/mesh/projects",
+                        params={"include_archived": True},
+                        headers={"X-Agent-ID": "operator"})
+    body = r.json()
+    names = {p["name"] for p in body["projects"]}
+    assert "research" in names

--- a/tests/test_operator_product_tools.py
+++ b/tests/test_operator_product_tools.py
@@ -13,8 +13,6 @@ routes through ``ASGITransport``.
 from __future__ import annotations
 
 import importlib
-import os
-from datetime import datetime, timezone
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock
 


### PR DESCRIPTION
## Summary

Makes the operator a real product surface for managing teams, delegating, inspecting progress, fixing blockers, and summarizing deliverables. Built on Task 6's task records, Task 2d's pending-action primitive, Task 2c's origin gating, and Task 3's `can_route_tasks` permission.

**Branch base:** `feat/orchestration-task-records-v2` (PR #831) → … → `main`.

## Tools shipped (12 new `@skill`s)

**Read (5)** — gated on `OPENLEGION_ORCHESTRATION_TASKS_V2=1` except `get_agent_profile`:
- `list_project_status(project_id?)` — fleet rollup or single project
- `list_agent_queue(agent_id, limit=10)` — last N tasks per status bucket
- `get_team_outputs(project_id, since="7d")` — completed artifacts in window (parses `"24h"`/`"7d"` durations + ISO timestamps)
- `summarize_project_progress(project_id)` — synth `status_text` + counts + blockers + ask_for_user
- `get_agent_profile(agent_id)` — proxy to existing `/mesh/agents/{id}/profile`

**Action (7):**
| Tool | Server gate | Pre-condition |
|---|---|---|
| `reroute_task` | `can_route_tasks` + cost preflight | — |
| `cancel_task` | `can_route_tasks` | — |
| `retry_failed_task` | `can_route_tasks` + cost preflight | source task `failed` |
| `archive_project` | operator-only + provenance | — |
| `archive_agent` | operator-only + provenance | refuses `operator` |
| `delete_project` | operator + propose→human-confirm | already archived |
| `delete_agent` | operator + propose→human-confirm | already archived; refuses `operator` |

## Destructive confirm wiring

Reuses Task 2d's `PendingActions` — the existing `POST /mesh/config/confirm` was **extended** (not paralleled) with an `action_kind` dispatcher that routes legacy edits unchanged and adds `delete` → `_apply_pending_delete(record)`. Same `require_origin_kind="human"` and `_confirm_origin_check` gate as `propose_edit`/`confirm_edit`.

## Cost integration

`_check_can_schedule(agent)` helper consults `cost_tracker.check_budget` server-side before any storage mutation on `reroute` / `retry`. Over-budget returns HTTP 400 with `{"error": "over_budget", "detail": ..., "budget": {...}}`; tools surface it as a structured `over_budget` error so the LLM gets clean shape instead of a stack trace.

## Project / agent lifecycle

`ProjectMetadata.status` defaults to `"active"` (legacy rows treated the same). `/mesh/projects` GET excludes archived by default; `?include_archived=true` opts in. New `_archive_project` / `_unarchive_project` / `_archive_agent` / `_unarchive_agent` / `_project_status` / `_agent_status` helpers in `src/cli/config.py`.

## Test plan

- [x] 47 new tests in `tests/test_operator_product_tools.py`: 7 v2-flag-off errors, 6 read happy-paths, 5 action units (incl. 2 over-budget), 8 archive/delete units, 21 HTTP endpoint tests via `ASGITransport`
- [x] `pytest tests/test_operator_tools.py tests/test_operator_product_tools.py tests/test_orchestration*.py tests/test_pending_actions.py tests/test_coordination.py` — 244 passed
- [x] Full non-E2E suite — 5190 passed, 44 skipped, 5 deselected. **No new failures.**
- [x] `_OPERATOR_ALLOWED_TOOLS` count assertion + presence checks updated (`tests/test_operator_config.py`)

## What's deliberately NOT in this PR

- Capabilities-as-data field on `AgentConfig` (Task 8).
- Dashboard / CLI surfacing of the new tool outputs (Task 9 — pending-action UI, project status panel, task board).

## Stack

1. #821 — Task 0 hotfix ✅
2. #822 — Task 1 characterization tests
3. #823 — Task 2a typed model
4. #824 — Task 2b stamp sites
5. #825 — Task 2c channel pairing recheck
6. #826 — Task 2d pending-actions SQLite
7. #827 — Task 2e wake block
8. #828 — Task 3 perm split
9. #829 — Task 4 operator cryptographic registration
10. #830 — Task 5 project isolation warn mode
11. #831 — Task 6 durable task records
12. **This PR** — Task 7 operator product tools
13. (next) Task 8 capabilities-as-data, Task 9 dashboard / CLI surfaces