### PR TITLE
feat(agents): structured routing fields on AgentConfig (Task 8)

### DIFF
--- a/src/agent/workspace.py
+++ b/src/agent/workspace.py
@@ -102,6 +102,129 @@ _CORRECTION_SIGNALS = frozenset({
 _MAX_LEARNINGS_SIZE = 50_000
 
 
+# ── INTERFACE.md → structured capabilities derivation ─────────
+#
+# Task 8 introduces structured routing fields on AgentConfig
+# (capabilities / preferred_inputs / expected_outputs / escalation_to /
+# forbidden). For agents created before Task 8 the structured fields are
+# absent; their INTERFACE.md may already declare the same information
+# free-form via headings. ``_derive_capabilities_from_interface`` parses
+# those headings and returns a dict shaped for back-fill into agents.yaml.
+# Best-effort + idempotent: it is intended to run once when
+# ``capabilities`` is missing/empty AND INTERFACE.md is on disk; the
+# caller persists the result and the structured field becomes the source
+# of truth thereafter.
+
+_HEADING_RE = re.compile(r"^\s*##+\s+(.+?)\s*$")
+_BULLET_RE = re.compile(r"^\s*[-*]\s+(.+?)\s*$")
+
+# Heading aliases — case-insensitive. Same header may have alternate
+# phrasings across templates.
+_INTERFACE_SECTIONS: dict[str, tuple[str, ...]] = {
+    "capabilities": ("capabilities", "what i do", "role"),
+    "preferred_inputs": ("preferred inputs", "accepts", "inputs"),
+    "expected_outputs": ("expected outputs", "produces", "outputs"),
+    "forbidden": ("forbidden", "do not", "refuses", "never"),
+}
+_ESCALATION_HEADINGS: tuple[str, ...] = ("escalation", "escalate to", "escalation to")
+
+
+def _empty_interface_fields() -> dict[str, list[str] | str | None]:
+    """Default-empty shape for the derived structured fields."""
+    return {
+        "capabilities": [],
+        "preferred_inputs": [],
+        "expected_outputs": [],
+        "escalation_to": None,
+        "forbidden": [],
+    }
+
+
+def _parse_interface_text(content: str) -> dict[str, list[str] | str | None]:
+    """Parse INTERFACE.md text into structured routing fields.
+
+    Walks markdown headings; for each known section, slurps following
+    bullets up to the next heading. Headings are matched
+    case-insensitively against the alias table. Returns the same shape
+    as :func:`_derive_capabilities_from_interface` — empty defaults
+    when no matching headings are present.
+    """
+    if not content:
+        return _empty_interface_fields()
+
+    current: str | None = None
+    sections: dict[str, list[str]] = {k: [] for k in _INTERFACE_SECTIONS}
+    escalation_lines: list[str] = []
+
+    for raw_line in content.splitlines():
+        m = _HEADING_RE.match(raw_line)
+        if m:
+            heading = m.group(1).strip().lower()
+            current = None
+            for key, aliases in _INTERFACE_SECTIONS.items():
+                if heading in aliases:
+                    current = key
+                    break
+            else:
+                if heading in _ESCALATION_HEADINGS:
+                    current = "__escalation__"
+            continue
+
+        if current is None:
+            continue
+
+        bullet = _BULLET_RE.match(raw_line)
+        if not bullet:
+            continue
+        item = bullet.group(1).strip()
+        if not item:
+            continue
+        if current == "__escalation__":
+            escalation_lines.append(item)
+        else:
+            sections[current].append(item)
+
+    return {
+        "capabilities": sections["capabilities"],
+        "preferred_inputs": sections["preferred_inputs"],
+        "expected_outputs": sections["expected_outputs"],
+        "forbidden": sections["forbidden"],
+        "escalation_to": escalation_lines[0] if escalation_lines else None,
+    }
+
+
+def _derive_capabilities_from_interface(
+    workspace_path: str | Path,
+) -> dict[str, list[str] | str | None]:
+    """Parse INTERFACE.md headings into structured routing fields.
+
+    Returns a dict with the keys ``capabilities``, ``preferred_inputs``,
+    ``expected_outputs``, ``forbidden`` (lists) and ``escalation_to``
+    (string or ``None``). Missing sections produce empty defaults.
+
+    Best-effort: a missing file, unreadable file, or unparseable content
+    yields the empty defaults — never raises. Intended to run once on
+    first read; callers persist the result back to agents.yaml so the
+    derivation is not repeated.
+
+    The parser recognises the standard section headings used by the
+    Task-8 templates (``## Capabilities``, ``## Accepts``, ``## Produces``,
+    ``## Escalation``, ``## Forbidden``) and a few common synonyms used by
+    pre-Task-8 templates (``## Role`` → capabilities, ``## Inputs`` →
+    preferred_inputs, etc.).
+    """
+    path = Path(workspace_path) / "INTERFACE.md"
+    if not path.exists() or not path.is_file():
+        return _empty_interface_fields()
+
+    try:
+        content = path.read_text(errors="replace")
+    except Exception:
+        return _empty_interface_fields()
+
+    return _parse_interface_text(content)
+
+
 class WorkspaceManager:
     """Reads and writes the agent's persistent workspace files."""
 

--- a/src/cli/config.py
+++ b/src/cli/config.py
@@ -403,8 +403,21 @@ def _add_agent_to_config(
     thinking: str = "",
     budget: dict | None = None,
     resources: dict | None = None,
+    capabilities: list[str] | None = None,
+    preferred_inputs: list[str] | None = None,
+    expected_outputs: list[str] | None = None,
+    escalation_to: str | None = None,
+    forbidden: list[str] | None = None,
 ) -> None:
-    """Add an agent entry to agents.yaml."""
+    """Add an agent entry to agents.yaml.
+
+    Task 8 adds five structured routing fields (``capabilities``,
+    ``preferred_inputs``, ``expected_outputs``, ``escalation_to``,
+    ``forbidden``). Each defaults to its empty form so existing
+    callers that don't pass them continue to work unchanged. They are
+    only persisted when non-empty so untouched yaml entries don't grow
+    noisy default keys.
+    """
     agents_cfg: dict = {"agents": {}}
     if AGENTS_FILE.exists():
         with open(AGENTS_FILE) as f:
@@ -431,6 +444,18 @@ def _add_agent_to_config(
         entry["budget"] = budget
     if resources:
         entry["resources"] = resources
+    # Task 8 — structured routing fields. Persist only when non-empty
+    # so existing minimal yaml entries don't grow empty default keys.
+    if capabilities:
+        entry["capabilities"] = list(capabilities)
+    if preferred_inputs:
+        entry["preferred_inputs"] = list(preferred_inputs)
+    if expected_outputs:
+        entry["expected_outputs"] = list(expected_outputs)
+    if escalation_to:
+        entry["escalation_to"] = escalation_to
+    if forbidden:
+        entry["forbidden"] = list(forbidden)
     agents_cfg["agents"][name] = entry
     AGENTS_FILE.parent.mkdir(parents=True, exist_ok=True)
     with open(AGENTS_FILE, "w") as f:
@@ -734,6 +759,79 @@ def _set_project_status(name: str, status: str) -> None:
         yaml.dump(data, f, default_flow_style=False, sort_keys=False)
 
 
+def _backfill_capabilities_for_existing_agents() -> None:
+    """One-shot Task 8 back-fill of structured routing fields on agents.yaml.
+
+    For any agent that has an empty ``capabilities`` list AND a non-empty
+    ``initial_interface`` block, parse the markdown headings and persist
+    the derived structured fields back to ``agents.yaml``. Skips agents
+    that already declare ``capabilities`` (idempotent: a populated field
+    is the source of truth).
+
+    This runs once at startup. Failure to parse any single agent never
+    raises — the field stays empty and routing falls back to existing
+    behaviour.
+    """
+    if not AGENTS_FILE.exists():
+        return
+    try:
+        with open(AGENTS_FILE) as f:
+            agents_cfg = yaml.safe_load(f) or {"agents": {}}
+    except Exception:
+        return
+
+    agents = agents_cfg.get("agents", {})
+    if not isinstance(agents, dict) or not agents:
+        return
+
+    from src.agent.workspace import _parse_interface_text
+
+    changed = False
+    for _agent_name, entry in agents.items():
+        if not isinstance(entry, dict):
+            continue
+        # Already declared — structured field wins, do nothing.
+        if entry.get("capabilities"):
+            continue
+        interface_text = entry.get("initial_interface") or ""
+        if not interface_text:
+            continue
+
+        try:
+            derived = _parse_interface_text(interface_text)
+        except Exception:
+            continue
+
+        # Only persist when the derivation produced something useful.
+        if not (
+            derived.get("capabilities")
+            or derived.get("preferred_inputs")
+            or derived.get("expected_outputs")
+            or derived.get("escalation_to")
+            or derived.get("forbidden")
+        ):
+            continue
+
+        if derived.get("capabilities"):
+            entry["capabilities"] = list(derived["capabilities"])
+        if derived.get("preferred_inputs"):
+            entry["preferred_inputs"] = list(derived["preferred_inputs"])
+        if derived.get("expected_outputs"):
+            entry["expected_outputs"] = list(derived["expected_outputs"])
+        if derived.get("escalation_to"):
+            entry["escalation_to"] = derived["escalation_to"]
+        if derived.get("forbidden"):
+            entry["forbidden"] = list(derived["forbidden"])
+        changed = True
+
+    if changed:
+        try:
+            with open(AGENTS_FILE, "w") as f:
+                yaml.dump(agents_cfg, f, default_flow_style=False, sort_keys=False)
+        except Exception:
+            logger.exception("Failed to persist back-filled agent capabilities")
+
+
 def _archive_project(name: str) -> None:
     """Mark a project as archived without deleting its data."""
     _set_project_status(name, "archived")
@@ -986,8 +1084,65 @@ def _pick_model_interactive(
     return models[model_choice - 1]
 
 
+def _validate_agent_template(template: dict) -> list[str]:
+    """Lightweight validator for fleet templates (Task 8).
+
+    Returns a list of human-readable warnings — informational, not
+    rejection. Callers (``_load_templates``) log them at info level so
+    template authors notice missing routing metadata without breaking
+    existing workflows.
+
+    Validates:
+    - If ``capabilities`` is empty AND there is no ``initial_interface``
+      / ``interface`` block to derive from, warn naming the agent.
+    - If ``escalation_to`` references an agent ID that doesn't exist in
+      the same template, warn naming both.
+
+    Empty templates / missing ``agents`` keys produce no warnings —
+    that's an unrelated structural issue surfaced elsewhere.
+    """
+    warnings: list[str] = []
+    tpl_name = template.get("name", "<unnamed>")
+    agents = template.get("agents") or {}
+    if not isinstance(agents, dict):
+        return warnings
+
+    agent_ids = set(agents.keys())
+    for agent_name, agent_def in agents.items():
+        if not isinstance(agent_def, dict):
+            continue
+        capabilities = agent_def.get("capabilities") or []
+        interface_text = (
+            agent_def.get("initial_interface")
+            or agent_def.get("interface")
+            or ""
+        )
+        if not capabilities and not interface_text:
+            warnings.append(
+                f"template '{tpl_name}' agent '{agent_name}': no "
+                "structured 'capabilities' and no INTERFACE.md to derive "
+                "from — operator routing will see an empty interface."
+            )
+
+        escalation = agent_def.get("escalation_to")
+        if escalation and isinstance(escalation, str):
+            if escalation not in agent_ids:
+                warnings.append(
+                    f"template '{tpl_name}' agent '{agent_name}': "
+                    f"escalation_to='{escalation}' is not defined in "
+                    "this template (cross-template escalations should "
+                    "use a fleet-global agent like 'operator')."
+                )
+    return warnings
+
+
 def _load_templates() -> dict[str, dict]:
-    """Load available team templates from src/templates/."""
+    """Load available team templates from src/templates/.
+
+    Each template is run through ``_validate_agent_template`` for
+    lightweight informational validation (Task 8). Warnings are logged
+    at info level — they never reject a template.
+    """
     available: dict[str, dict] = {}
     if not TEMPLATES_DIR.exists():
         return available
@@ -996,6 +1151,8 @@ def _load_templates() -> dict[str, dict]:
             tpl = yaml.safe_load(f) or {}
         name = tpl.get("name", tpl_file.stem)
         available[name] = tpl
+        for warning in _validate_agent_template(tpl):
+            logger.info("template-validate: %s", warning)
     return available
 
 
@@ -1039,6 +1196,11 @@ def _apply_template(template_name: str, tpl: dict) -> list[str]:
             thinking=thinking,
             budget=budget,
             resources=resources,
+            capabilities=agent_def.get("capabilities") or [],
+            preferred_inputs=agent_def.get("preferred_inputs") or [],
+            expected_outputs=agent_def.get("expected_outputs") or [],
+            escalation_to=agent_def.get("escalation_to"),
+            forbidden=agent_def.get("forbidden") or [],
         )
         _add_agent_permissions(agent_name, permissions=agent_permissions)
         skills_dir = PROJECT_ROOT / "skills" / agent_name
@@ -1120,6 +1282,11 @@ def _create_agent_from_template(
         thinking=thinking,
         budget=budget,
         resources=resources,
+        capabilities=agent_def.get("capabilities") or [],
+        preferred_inputs=agent_def.get("preferred_inputs") or [],
+        expected_outputs=agent_def.get("expected_outputs") or [],
+        escalation_to=agent_def.get("escalation_to"),
+        forbidden=agent_def.get("forbidden") or [],
     )
     _add_agent_permissions(name, permissions=agent_permissions)
     skills_dir = PROJECT_ROOT / "skills" / name

--- a/src/cli/runtime.py
+++ b/src/cli/runtime.py
@@ -242,7 +242,10 @@ class RuntimeContext:
             _ensure_docker_image()
 
     def _create_components(self) -> None:
-        from src.cli.config import _ensure_all_agent_permissions
+        from src.cli.config import (
+            _backfill_capabilities_for_existing_agents,
+            _ensure_all_agent_permissions,
+        )
         from src.dashboard.events import EventBus
         from src.host.costs import CostTracker
         from src.host.credentials import CredentialVault
@@ -252,6 +255,10 @@ class RuntimeContext:
 
         # Backfill permissions for agents missing from permissions.json
         _ensure_all_agent_permissions()
+        # Task 8 — derive structured routing fields from INTERFACE.md for
+        # agents that pre-date the structured schema. Idempotent: only
+        # runs for agents whose ``capabilities`` field is empty.
+        _backfill_capabilities_for_existing_agents()
 
         # Ensure collaborative permissions are up to date before loading
         if self.cfg.get("collaboration", False):

--- a/src/host/server.py
+++ b/src/host/server.py
@@ -1821,9 +1821,32 @@ def create_mesh_app(
                 caller = "unknown"
         caller_is_global = caller_is_internal or caller == "operator"
 
+        # Task 8 — pull structured routing fields from agents.yaml. The
+        # ``capabilities`` key on the entry is the runtime tool list
+        # (router.get_capabilities) — keep that name as-is. Surface the
+        # human-routing capabilities + the four siblings under explicit
+        # keys so callers can distinguish them from tool capabilities.
+        from src.cli.config import _load_config as _load_cfg_for_listing
+        try:
+            _cfg_for_listing = _load_cfg_for_listing()
+        except Exception:
+            _cfg_for_listing = {"agents": {}}
+        _agents_cfg_listing = _cfg_for_listing.get("agents", {}) or {}
+
         def _agent_entry(aid: str, url: str) -> dict:
             entry: dict = {"url": url, "role": router.agent_roles.get(aid, "")}
             entry["capabilities"] = router.get_capabilities(aid)
+            acfg = _agents_cfg_listing.get(aid) or {}
+            # Structured routing fields (Task 8). The ``interface_*`` keys
+            # are the human-facing routing surface; the bare
+            # ``capabilities`` key remains the runtime tool/skill list to
+            # avoid breaking back-compat with existing dashboard / CLI
+            # consumers.
+            entry["interface_capabilities"] = list(acfg.get("capabilities") or [])
+            entry["preferred_inputs"] = list(acfg.get("preferred_inputs") or [])
+            entry["expected_outputs"] = list(acfg.get("expected_outputs") or [])
+            entry["escalation_to"] = acfg.get("escalation_to")
+            entry["forbidden"] = list(acfg.get("forbidden") or [])
             proj = _agent_projects.get(aid)
             if proj:
                 entry["project"] = proj
@@ -2641,6 +2664,23 @@ def create_mesh_app(
             except Exception:
                 logger.debug("Could not fetch INTERFACE.md from %s (direct)", agent_id)
 
+        # Task 8 — structured routing fields from agents.yaml. ``capabilities``
+        # remains the runtime tool/skill list (router.get_capabilities); the
+        # human-routing capabilities live under ``interface_capabilities`` to
+        # avoid the naming collision. The other four sibling fields keep
+        # their natural names (no collision).
+        from src.cli.config import _load_config as _load_cfg_for_profile
+        try:
+            _cfg_for_profile = _load_cfg_for_profile()
+        except Exception:
+            _cfg_for_profile = {"agents": {}}
+        _acfg_profile = (_cfg_for_profile.get("agents", {}) or {}).get(agent_id, {}) or {}
+        interface_capabilities = list(_acfg_profile.get("capabilities") or [])
+        preferred_inputs = list(_acfg_profile.get("preferred_inputs") or [])
+        expected_outputs = list(_acfg_profile.get("expected_outputs") or [])
+        escalation_to = _acfg_profile.get("escalation_to")
+        forbidden = list(_acfg_profile.get("forbidden") or [])
+
         return {
             "agent_id": agent_id,
             "role": role,
@@ -2652,6 +2692,12 @@ def create_mesh_app(
             "recent_writes": recent_writes,
             "capabilities": capabilities,
             "interface": interface,
+            # Task 8 structured routing fields.
+            "interface_capabilities": interface_capabilities,
+            "preferred_inputs": preferred_inputs,
+            "expected_outputs": expected_outputs,
+            "escalation_to": escalation_to,
+            "forbidden": forbidden,
         }
 
     # === Request Traces ===

--- a/src/shared/types.py
+++ b/src/shared/types.py
@@ -319,6 +319,54 @@ class AgentPermissions(BaseModel):
     wallet_allowed_contracts: list[str] = []
 
 
+# === Agent Configuration ===
+
+
+class AgentConfig(BaseModel):
+    """Structured fields for an agent entry in ``config/agents.yaml``.
+
+    Today an entry is a free-form dict (role/model/initial_instructions/…).
+    Task 8 introduces five structured fields for routing — what the agent
+    does, what it accepts, what it produces, where it escalates, what it
+    refuses. These fields are the source of truth for the operator and
+    routing layer; ``INTERFACE.md`` is preserved as a free-text companion
+    for the agent's own context but is no longer parsed at routing time.
+
+    The model is read-only metadata: the loader still persists yaml as a
+    dict (for back-compat with existing tooling that diffs the file). The
+    model is used by callers that want a typed view of the entry, by
+    tests, and by the `/mesh/agents/{id}/profile` endpoint to validate
+    the surfaced shape.
+
+    All five new fields default cleanly so existing agents.yaml files
+    without them load unchanged. ``_derive_capabilities_from_interface``
+    in ``src/agent/workspace.py`` provides a one-shot back-fill from
+    ``INTERFACE.md`` headings on first read; the structured field is the
+    source of truth thereafter.
+    """
+
+    role: str = ""
+    model: str = ""
+    skills_dir: str = ""
+    initial_instructions: str = ""
+    initial_soul: str = ""
+    initial_heartbeat: str = ""
+    initial_interface: str = ""
+    thinking: str = ""
+    status: str = "active"
+    budget: dict[str, Any] | None = None
+    resources: dict[str, Any] | None = None
+
+    # Task 8 — structured routing metadata.
+    capabilities: list[str] = Field(default_factory=list)
+    preferred_inputs: list[str] = Field(default_factory=list)
+    expected_outputs: list[str] = Field(default_factory=list)
+    escalation_to: str | None = None
+    forbidden: list[str] = Field(default_factory=list)
+
+    model_config = {"extra": "allow"}
+
+
 # === Projects ===
 
 

--- a/src/templates/devteam.yaml
+++ b/src/templates/devteam.yaml
@@ -5,6 +5,21 @@ agents:
     role: Product manager — breaks down features, writes specs, coordinates work
     model: "{default_model}"
 
+    capabilities:
+      - Break down feature requests into engineering specs
+      - Coordinate handoffs between engineer and reviewer
+      - Report progress to the user
+    preferred_inputs:
+      - User feature requests, bug reports, product questions
+      - Hand-offs from reviewer with completed review results
+    expected_outputs:
+      - Task specs with acceptance criteria handed off to engineer
+      - Review requests handed off to reviewer
+    escalation_to: null
+    forbidden:
+      - Writing implementation code directly
+      - Approving merges without a reviewer pass
+
     initial_interface: |
       # Interface: pm
 
@@ -67,6 +82,19 @@ agents:
   engineer:
     role: Software engineer — writes code, runs tests, implements tasks
     model: "{default_model}"
+
+    capabilities:
+      - Implement task specs with code + tests
+      - Run shell commands and the test suite
+      - Hand completed work back to pm
+    preferred_inputs:
+      - Hand-offs from pm with task specs (description, acceptance criteria, dependencies)
+    expected_outputs:
+      - Implemented code changes with passing tests, returned to pm
+    escalation_to: pm
+    forbidden:
+      - Refactoring code outside of the assigned task
+      - Marking work complete with failing tests
 
     initial_interface: |
       # Interface: engineer
@@ -132,6 +160,19 @@ agents:
   reviewer:
     role: Code reviewer — reviews changes, identifies bugs, verifies tests
     model: "{default_model}"
+
+    capabilities:
+      - Review completed code for correctness and security
+      - Verify test coverage and run the full test suite
+      - Approve or request changes back to pm
+    preferred_inputs:
+      - Hand-offs from pm with completed task specs and engineering results
+    expected_outputs:
+      - Review verdicts (approve / changes needed) with feedback, returned to pm
+    escalation_to: pm
+    forbidden:
+      - Implementing fixes directly (delegate via pm → engineer)
+      - Blocking on style preferences
 
     initial_interface: |
       # Interface: reviewer

--- a/src/templates/research.yaml
+++ b/src/templates/research.yaml
@@ -6,6 +6,18 @@ agents:
     model: "{default_model}"
     thinking: medium
 
+    capabilities:
+      - Web research via search and full-page browsing
+      - Synthesize findings into structured reports
+      - Save reports as artifacts and notify the user
+    preferred_inputs:
+      - Direct messages or hand-offs with topic, questions, scope
+    expected_outputs:
+      - Research reports saved as artifacts and delivered via notify_user
+    escalation_to: null
+    forbidden:
+      - Returning unsourced or speculative findings as fact
+
     initial_interface: |
       # Interface: researcher
 

--- a/src/templates/starter.yaml
+++ b/src/templates/starter.yaml
@@ -5,6 +5,22 @@ agents:
     role: General-purpose assistant
     model: "{default_model}"
 
+    # Task 8 — structured routing metadata. Operator + routing layer
+    # read these directly; INTERFACE.md remains a free-text companion.
+    capabilities:
+      - General-purpose task execution
+      - Web research via search and browser
+      - Shell automation and file I/O
+      - Memory retention across sessions
+    preferred_inputs:
+      - Direct user messages with tasks or questions
+    expected_outputs:
+      - Notify user with results
+      - Persisted artifacts for substantial outputs
+    escalation_to: null
+    forbidden:
+      - Long-running unattended workflows without status updates
+
     initial_interface: |
       # Interface: assistant
 

--- a/tests/test_mesh.py
+++ b/tests/test_mesh.py
@@ -1659,3 +1659,151 @@ async def test_list_agents_internal_caller_unaffected(
             cleanup()
             monkeypatch.delenv("OPENLEGION_PROJECT_SCOPE_MODE", raising=False)
             importlib.reload(server_module)
+
+
+# === Task 8: structured routing fields on /mesh/agents and /profile ===
+
+
+@pytest.mark.asyncio
+async def test_list_agents_carries_structured_routing_fields(tmp_path):
+    """`/mesh/agents` entries surface Task-8 routing fields under
+    distinct keys from the runtime tool ``capabilities`` list."""
+    from unittest.mock import patch
+
+    import yaml as yaml_mod
+    from httpx import ASGITransport, AsyncClient
+
+    from src.host.costs import CostTracker
+    from src.host.server import create_mesh_app
+    from src.host.traces import TraceStore
+
+    cfg_dir = tmp_path / "config"
+    cfg_dir.mkdir(parents=True)
+    agents_path = cfg_dir / "agents.yaml"
+    agents_path.write_text(yaml_mod.dump({"agents": {
+        "scout": {
+            "role": "researcher", "model": "x",
+            "capabilities": ["Web research", "Source analysis"],
+            "preferred_inputs": ["User questions"],
+            "expected_outputs": ["Research reports"],
+            "escalation_to": "operator",
+            "forbidden": ["Speculation as fact"],
+        },
+        "plain": {"role": "x", "model": "y"},
+    }}))
+    (cfg_dir / "mesh.yaml").write_text(yaml_mod.dump({"mesh": {"port": 8420}}))
+    projects_dir = cfg_dir / "projects"
+    projects_dir.mkdir()
+
+    bb = Blackboard(db_path=str(tmp_path / "bb.db"))
+    pubsub = PubSub()
+    perms = PermissionMatrix()
+    router = MessageRouter(perms, {})
+    costs = CostTracker(str(tmp_path / "costs.db"))
+    traces = TraceStore(str(tmp_path / "traces.db"))
+    router.register_agent("scout", "http://scout:8400", ["browser_navigate"])
+    router.register_agent("plain", "http://plain:8400", [])
+
+    app = create_mesh_app(
+        blackboard=bb, pubsub=pubsub, router=router, permissions=perms,
+        cost_tracker=costs, trace_store=traces,
+    )
+
+    try:
+        with patch("src.cli.config.AGENTS_FILE", agents_path), \
+             patch("src.cli.config.CONFIG_FILE", cfg_dir / "mesh.yaml"), \
+             patch("src.cli.config.PROJECTS_DIR", projects_dir):
+            async with AsyncClient(
+                transport=ASGITransport(app=app), base_url="http://test",
+            ) as client:
+                resp = await client.get("/mesh/agents")
+        assert resp.status_code == 200
+        data = resp.json()
+
+        scout = data["scout"]
+        assert scout["interface_capabilities"] == ["Web research", "Source analysis"]
+        assert scout["preferred_inputs"] == ["User questions"]
+        assert scout["expected_outputs"] == ["Research reports"]
+        assert scout["escalation_to"] == "operator"
+        assert scout["forbidden"] == ["Speculation as fact"]
+        # Runtime tool capabilities preserved separately.
+        assert scout["capabilities"] == ["browser_navigate"]
+
+        plain = data["plain"]
+        assert plain["interface_capabilities"] == []
+        assert plain["preferred_inputs"] == []
+        assert plain["expected_outputs"] == []
+        assert plain["escalation_to"] is None
+        assert plain["forbidden"] == []
+    finally:
+        bb.close()
+        costs.close()
+        traces.close()
+
+
+@pytest.mark.asyncio
+async def test_get_agent_profile_carries_structured_routing_fields(tmp_path):
+    """`/mesh/agents/{id}/profile` surfaces Task-8 routing fields."""
+    from unittest.mock import patch
+
+    import yaml as yaml_mod
+    from httpx import ASGITransport, AsyncClient
+
+    from src.host.costs import CostTracker
+    from src.host.server import create_mesh_app
+    from src.host.traces import TraceStore
+
+    cfg_dir = tmp_path / "config"
+    cfg_dir.mkdir(parents=True)
+    agents_path = cfg_dir / "agents.yaml"
+    agents_path.write_text(yaml_mod.dump({"agents": {
+        "writer": {
+            "role": "writer", "model": "x",
+            "capabilities": ["Long-form writing"],
+            "preferred_inputs": ["Outlines"],
+            "expected_outputs": ["Drafts"],
+            "escalation_to": "editor",
+            "forbidden": ["Plagiarism"],
+        },
+    }}))
+    (cfg_dir / "mesh.yaml").write_text(yaml_mod.dump({"mesh": {"port": 8420}}))
+    projects_dir = cfg_dir / "projects"
+    projects_dir.mkdir()
+
+    bb = Blackboard(db_path=str(tmp_path / "bb.db"))
+    pubsub = PubSub()
+    perms = PermissionMatrix()
+    router = MessageRouter(perms, {})
+    costs = CostTracker(str(tmp_path / "costs.db"))
+    traces = TraceStore(str(tmp_path / "traces.db"))
+    router.register_agent("writer", "http://writer:8400", ["file_write"])
+
+    app = create_mesh_app(
+        blackboard=bb, pubsub=pubsub, router=router, permissions=perms,
+        cost_tracker=costs, trace_store=traces,
+    )
+
+    try:
+        with patch("src.cli.config.AGENTS_FILE", agents_path), \
+             patch("src.cli.config.CONFIG_FILE", cfg_dir / "mesh.yaml"), \
+             patch("src.cli.config.PROJECTS_DIR", projects_dir):
+            async with AsyncClient(
+                transport=ASGITransport(app=app), base_url="http://test",
+            ) as client:
+                resp = await client.get(
+                    "/mesh/agents/writer/profile",
+                    headers={"x-mesh-internal": "1"},
+                )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["agent_id"] == "writer"
+        assert data["interface_capabilities"] == ["Long-form writing"]
+        assert data["preferred_inputs"] == ["Outlines"]
+        assert data["expected_outputs"] == ["Drafts"]
+        assert data["escalation_to"] == "editor"
+        assert data["forbidden"] == ["Plagiarism"]
+        assert data["capabilities"] == ["file_write"]
+    finally:
+        bb.close()
+        costs.close()
+        traces.close()

--- a/tests/test_operator_product_tools.py
+++ b/tests/test_operator_product_tools.py
@@ -202,6 +202,33 @@ async def test_get_agent_profile_calls_mesh():
     assert result["agent_id"] == "writer"
 
 
+@pytest.mark.asyncio
+async def test_get_agent_profile_returns_structured_routing_fields():
+    """Task 8 — operator profile read surfaces the new structured routing
+    fields (capabilities are tool list; the four siblings + the
+    interface_capabilities field carry the human-routing data)."""
+    from src.agent.builtins.operator_tools import get_agent_profile
+    mc = MagicMock()
+    mc.get_agent_profile = AsyncMock(return_value={
+        "agent_id": "researcher",
+        "role": "researcher",
+        "capabilities": ["browser_navigate", "web_search"],  # tool list
+        "interface_capabilities": ["Web research", "Synthesize findings"],
+        "preferred_inputs": ["User questions"],
+        "expected_outputs": ["Research reports"],
+        "escalation_to": "operator",
+        "forbidden": ["Speculative findings as fact"],
+    })
+    result = await get_agent_profile("researcher", mesh_client=mc)
+    assert result["interface_capabilities"] == ["Web research", "Synthesize findings"]
+    assert result["preferred_inputs"] == ["User questions"]
+    assert result["expected_outputs"] == ["Research reports"]
+    assert result["escalation_to"] == "operator"
+    assert result["forbidden"] == ["Speculative findings as fact"]
+    # Tool capabilities still distinct.
+    assert result["capabilities"] == ["browser_navigate", "web_search"]
+
+
 # ── Action tool: reroute_task with cost gate ──────────────────
 
 

--- a/tests/test_templates.py
+++ b/tests/test_templates.py
@@ -152,6 +152,38 @@ class TestAddAgentToConfig(_TempConfigMixin):
         assert agent["budget"]["daily_usd"] == 10.0
         assert agent["resources"]["memory_limit"] == "512m"
 
+    def test_structured_routing_fields_persisted(self):
+        """Task 8 — structured fields round-trip through agents.yaml."""
+        _add_agent_to_config(
+            "router", "researcher", "openai/gpt-4o",
+            capabilities=["Web research", "File I/O"],
+            preferred_inputs=["User questions"],
+            expected_outputs=["Research reports"],
+            escalation_to="operator",
+            forbidden=["Long unattended tasks"],
+        )
+        with open(self._agents_path) as f:
+            cfg = yaml.safe_load(f)
+        agent = cfg["agents"]["router"]
+        assert agent["capabilities"] == ["Web research", "File I/O"]
+        assert agent["preferred_inputs"] == ["User questions"]
+        assert agent["expected_outputs"] == ["Research reports"]
+        assert agent["escalation_to"] == "operator"
+        assert agent["forbidden"] == ["Long unattended tasks"]
+
+    def test_empty_structured_fields_not_written(self):
+        """Empty Task-8 fields should not appear in yaml — keeps minimal
+        agent entries from accumulating empty default keys."""
+        _add_agent_to_config("plain", "helper", "openai/gpt-4o")
+        with open(self._agents_path) as f:
+            cfg = yaml.safe_load(f)
+        agent = cfg["agents"]["plain"]
+        for key in (
+            "capabilities", "preferred_inputs", "expected_outputs",
+            "escalation_to", "forbidden",
+        ):
+            assert key not in agent, f"unexpected empty key {key!r} in agents.yaml"
+
 
 class TestAddAgentPermissions(_TempConfigMixin):
     def test_default_permissions(self):
@@ -540,6 +572,164 @@ class TestLoadTemplates:
         for tpl_name, tpl in templates.items():
             for agent_name in tpl.get("agents", {}):
                 _validate_agent_name(agent_name)  # raises on invalid
+
+    def test_starter_has_structured_fields(self):
+        """Task 8 — starter template declares the new fields directly."""
+        from src.cli.config import _load_templates
+        templates = _load_templates()
+        starter = templates.get("starter") or {}
+        assistant = (starter.get("agents") or {}).get("assistant") or {}
+        assert assistant.get("capabilities"), \
+            "starter/assistant must declare structured 'capabilities'"
+        assert assistant.get("preferred_inputs"), \
+            "starter/assistant must declare 'preferred_inputs'"
+        assert assistant.get("expected_outputs"), \
+            "starter/assistant must declare 'expected_outputs'"
+
+    def test_devteam_has_structured_fields(self):
+        """Task 8 — devteam template declares the new fields directly."""
+        from src.cli.config import _load_templates
+        templates = _load_templates()
+        devteam = templates.get("devteam") or {}
+        agents = devteam.get("agents") or {}
+        for role in ("pm", "engineer", "reviewer"):
+            entry = agents.get(role) or {}
+            assert entry.get("capabilities"), \
+                f"devteam/{role} must declare structured 'capabilities'"
+            assert entry.get("preferred_inputs"), \
+                f"devteam/{role} must declare 'preferred_inputs'"
+        # engineer + reviewer escalate to pm
+        assert agents["engineer"].get("escalation_to") == "pm"
+        assert agents["reviewer"].get("escalation_to") == "pm"
+
+    def test_research_has_structured_fields(self):
+        """Task 8 — research template declares the new fields directly."""
+        from src.cli.config import _load_templates
+        templates = _load_templates()
+        research = templates.get("research") or {}
+        researcher = (research.get("agents") or {}).get("researcher") or {}
+        assert researcher.get("capabilities"), \
+            "research/researcher must declare structured 'capabilities'"
+
+class TestBackfillCapabilities(_TempConfigMixin):
+    def test_lazy_derives_for_legacy_agent(self):
+        """Legacy agent entries (no structured fields, only initial_interface)
+        get back-filled on first load."""
+        from src.cli.config import _backfill_capabilities_for_existing_agents
+        _add_agent_to_config(
+            "legacy", "researcher", "openai/gpt-4o",
+            initial_interface=(
+                "# Interface: legacy\n\n"
+                "## Capabilities\n"
+                "- Old-school research\n"
+                "- Source verification\n\n"
+                "## Accepts\n"
+                "- User questions\n\n"
+                "## Produces\n"
+                "- Reports\n"
+            ),
+        )
+        with open(self._agents_path) as f:
+            before = yaml.safe_load(f)
+        assert "capabilities" not in before["agents"]["legacy"]
+
+        _backfill_capabilities_for_existing_agents()
+
+        with open(self._agents_path) as f:
+            after = yaml.safe_load(f)
+        entry = after["agents"]["legacy"]
+        assert "Old-school research" in entry["capabilities"]
+        assert entry["preferred_inputs"] == ["User questions"]
+        assert entry["expected_outputs"] == ["Reports"]
+
+    def test_idempotent_with_existing_capabilities(self):
+        """Back-fill skips agents that already declare structured capabilities."""
+        from src.cli.config import _backfill_capabilities_for_existing_agents
+        _add_agent_to_config(
+            "already", "x", "openai/gpt-4o",
+            capabilities=["Hand-curated"],
+            initial_interface=(
+                "## Capabilities\n- Should not overwrite hand-curated\n"
+            ),
+        )
+        _backfill_capabilities_for_existing_agents()
+        with open(self._agents_path) as f:
+            cfg = yaml.safe_load(f)
+        assert cfg["agents"]["already"]["capabilities"] == ["Hand-curated"]
+
+    def test_no_interface_no_change(self):
+        """Agents with neither structured fields nor INTERFACE.md text
+        are left alone — back-fill never invents content."""
+        from src.cli.config import _backfill_capabilities_for_existing_agents
+        _add_agent_to_config("bare", "x", "openai/gpt-4o")
+        _backfill_capabilities_for_existing_agents()
+        with open(self._agents_path) as f:
+            cfg = yaml.safe_load(f)
+        assert "capabilities" not in cfg["agents"]["bare"]
+
+
+class TestValidateAgentTemplate:
+    def test_warns_on_missing_capabilities_and_no_interface(self):
+        from src.cli.config import _validate_agent_template
+        warnings = _validate_agent_template({
+            "name": "thin",
+            "agents": {"a1": {"role": "x", "model": "y"}},
+        })
+        assert any("capabilities" in w for w in warnings)
+
+    def test_no_warning_when_capabilities_set(self):
+        from src.cli.config import _validate_agent_template
+        warnings = _validate_agent_template({
+            "name": "ok",
+            "agents": {"a1": {
+                "role": "x", "model": "y",
+                "capabilities": ["does things"],
+            }},
+        })
+        assert not any("capabilities" in w for w in warnings)
+
+    def test_no_warning_when_interface_present(self):
+        """Interface text is enough — derivation will fill structured fields."""
+        from src.cli.config import _validate_agent_template
+        warnings = _validate_agent_template({
+            "name": "interfaced",
+            "agents": {"a1": {
+                "role": "x", "model": "y",
+                "initial_interface": "## Capabilities\n- X\n",
+            }},
+        })
+        assert not any("capabilities" in w for w in warnings)
+
+    def test_warns_on_unknown_escalation_target(self):
+        from src.cli.config import _validate_agent_template
+        warnings = _validate_agent_template({
+            "name": "broken-escalation",
+            "agents": {
+                "a1": {
+                    "role": "x", "model": "y",
+                    "capabilities": ["a"],
+                    "escalation_to": "missing",
+                },
+                "a2": {"role": "y", "model": "y", "capabilities": ["b"]},
+            },
+        })
+        assert any("escalation_to" in w and "missing" in w for w in warnings)
+
+    def test_no_warning_for_known_escalation(self):
+        from src.cli.config import _validate_agent_template
+        warnings = _validate_agent_template({
+            "name": "good-escalation",
+            "agents": {
+                "a1": {
+                    "role": "x", "model": "y",
+                    "capabilities": ["a"],
+                    "escalation_to": "a2",
+                },
+                "a2": {"role": "y", "model": "y", "capabilities": ["b"]},
+            },
+        })
+        assert not warnings
+
 
 class TestLoadSkillTemplates:
     def test_returns_flat_list(self):

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -1,6 +1,7 @@
 """Unit tests for shared Pydantic types."""
 
 from src.shared.types import (
+    AgentConfig,
     AgentMessage,
     AgentStatus,
     TaskAssignment,
@@ -60,5 +61,52 @@ def test_token_budget_record_usage_uses_unified_costs():
     budget2 = TokenBudget(max_tokens=1_000_000)
     budget2.record_usage(1000, "unknown/model")
     assert budget2.estimated_cost_usd > 0
+
+
+# ── Task 8: AgentConfig structured routing fields ──
+
+
+def test_agent_config_defaults_empty():
+    """All five Task-8 routing fields default cleanly so existing
+    agents.yaml entries without them load unchanged."""
+    cfg = AgentConfig(role="researcher", model="openai/gpt-4o-mini")
+    assert cfg.capabilities == []
+    assert cfg.preferred_inputs == []
+    assert cfg.expected_outputs == []
+    assert cfg.escalation_to is None
+    assert cfg.forbidden == []
+
+
+def test_agent_config_accepts_structured_fields():
+    cfg = AgentConfig(
+        role="pm",
+        model="openai/gpt-4o-mini",
+        capabilities=["Break down specs", "Coordinate handoffs"],
+        preferred_inputs=["User requests"],
+        expected_outputs=["Task specs"],
+        escalation_to="operator",
+        forbidden=["Writing code directly"],
+    )
+    assert cfg.capabilities == ["Break down specs", "Coordinate handoffs"]
+    assert cfg.preferred_inputs == ["User requests"]
+    assert cfg.expected_outputs == ["Task specs"]
+    assert cfg.escalation_to == "operator"
+    assert cfg.forbidden == ["Writing code directly"]
+
+
+def test_agent_config_extra_fields_allowed():
+    """Extra keys (e.g., legacy ``initial_interface``) round-trip via
+    ``extra='allow'`` so loading isn't a strict-validation gate."""
+    cfg = AgentConfig(role="pm", model="x", initial_interface="hello")
+    assert cfg.initial_interface == "hello"
+    cfg2 = AgentConfig(
+        role="pm",
+        model="x",
+        capabilities=["a"],
+        legacy_field="ignored-but-kept",  # type: ignore[call-arg]
+    )
+    dumped = cfg2.model_dump()
+    assert dumped["legacy_field"] == "ignored-but-kept"
+    assert dumped["capabilities"] == ["a"]
 
 

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -1013,3 +1013,106 @@ class TestActivityLog:
         )
         entries = self.ws.load_activity()
         assert len(entries) == 2
+
+
+# ── Task 8: INTERFACE.md → structured capabilities derivation ──
+
+
+class TestDeriveCapabilitiesFromInterface:
+    def setup_method(self):
+        self._tmpdir = tempfile.mkdtemp()
+
+    def teardown_method(self):
+        shutil.rmtree(self._tmpdir, ignore_errors=True)
+
+    def test_missing_file_returns_empty_defaults(self):
+        from src.agent.workspace import _derive_capabilities_from_interface
+
+        result = _derive_capabilities_from_interface(self._tmpdir)
+        assert result == {
+            "capabilities": [],
+            "preferred_inputs": [],
+            "expected_outputs": [],
+            "escalation_to": None,
+            "forbidden": [],
+        }
+
+    def test_empty_file_returns_empty_defaults(self):
+        from src.agent.workspace import _derive_capabilities_from_interface
+
+        (Path(self._tmpdir) / "INTERFACE.md").write_text("")
+        result = _derive_capabilities_from_interface(self._tmpdir)
+        assert result["capabilities"] == []
+        assert result["escalation_to"] is None
+
+    def test_parses_canonical_headings(self):
+        from src.agent.workspace import _derive_capabilities_from_interface
+
+        (Path(self._tmpdir) / "INTERFACE.md").write_text(
+            "# Interface\n"
+            "\n"
+            "## Capabilities\n"
+            "- Web research\n"
+            "- File I/O\n"
+            "\n"
+            "## Preferred Inputs\n"
+            "- Direct user messages\n"
+            "\n"
+            "## Expected Outputs\n"
+            "- Notify user with findings\n"
+            "\n"
+            "## Escalation\n"
+            "- pm\n"
+            "\n"
+            "## Forbidden\n"
+            "- Long unattended workflows\n"
+        )
+        result = _derive_capabilities_from_interface(self._tmpdir)
+        assert result["capabilities"] == ["Web research", "File I/O"]
+        assert result["preferred_inputs"] == ["Direct user messages"]
+        assert result["expected_outputs"] == ["Notify user with findings"]
+        assert result["escalation_to"] == "pm"
+        assert result["forbidden"] == ["Long unattended workflows"]
+
+    def test_parses_legacy_synonyms(self):
+        from src.agent.workspace import _derive_capabilities_from_interface
+
+        # Pre-Task-8 templates use ## Accepts / ## Produces. The fallback
+        # ## Role bullet maps to capabilities so legacy interfaces still
+        # populate something useful.
+        (Path(self._tmpdir) / "INTERFACE.md").write_text(
+            "## Role\n"
+            "- Product manager that breaks down features\n"
+            "\n"
+            "## Accepts\n"
+            "- User requests\n"
+            "\n"
+            "## Produces\n"
+            "- Task specs\n"
+        )
+        result = _derive_capabilities_from_interface(self._tmpdir)
+        assert "Product manager that breaks down features" in result["capabilities"]
+        assert result["preferred_inputs"] == ["User requests"]
+        assert result["expected_outputs"] == ["Task specs"]
+
+    def test_unparseable_content_returns_empty(self):
+        from src.agent.workspace import _derive_capabilities_from_interface
+
+        (Path(self._tmpdir) / "INTERFACE.md").write_text(
+            "Just some prose with no headings or bullets at all.\n"
+            "\n"
+            "Another paragraph.\n"
+        )
+        result = _derive_capabilities_from_interface(self._tmpdir)
+        assert result["capabilities"] == []
+        assert result["expected_outputs"] == []
+
+    def test_directory_path_instead_of_file_returns_empty(self):
+        from src.agent.workspace import _derive_capabilities_from_interface
+
+        # If INTERFACE.md is a directory (impossible in practice but
+        # exercises the is_file guard) the function returns empties
+        # rather than raising.
+        (Path(self._tmpdir) / "INTERFACE.md").mkdir()
+        result = _derive_capabilities_from_interface(self._tmpdir)
+        assert result["capabilities"] == []


### PR DESCRIPTION
## Summary

Today the operator and routing layer grep `INTERFACE.md` to figure out what an agent does. Task 8 introduces typed fields directly on `AgentConfig` / `agents.yaml` so capabilities are queryable as data, not parsed text. INTERFACE.md remains a free-text companion for the agent's own context.

**Branch base:** `feat/operator-product-tools` (PR #832) → … → `main`.

## New `AgentConfig` Pydantic model (`src/shared/types.py`)

```
capabilities:       list[str]      = []
preferred_inputs:   list[str]      = []
expected_outputs:   list[str]      = []
escalation_to:      str | None     = None
forbidden:          list[str]      = []
```

`model_config = {"extra": "allow"}` so legacy yaml entries with extra keys round-trip cleanly.

## Naming-collision resolution

The existing `capabilities` key on `_agent_entry` / `/profile` means *runtime tool list* (from `router.get_capabilities`). Kept that semantics. Added the new Task-8 human-routing list under **`interface_capabilities`**. The four siblings keep natural names — no collision. So on the wire:

- `capabilities` → runtime tool list (unchanged)
- `interface_capabilities` → human routing capabilities (Task 8)
- `preferred_inputs`, `expected_outputs`, `escalation_to`, `forbidden` → Task 8

## Backward-compat backfill

`_backfill_capabilities_for_existing_agents` runs once at runtime startup. For any agent missing `capabilities`, it parses `INTERFACE.md` (`## Capabilities` / `## Preferred Inputs` / `## Expected Outputs` / `## Escalation` / `## Forbidden`, plus legacy synonyms `## Role` / `## Accepts` / `## Produces`) and persists the result. Idempotent — agents that already declare `capabilities` are skipped. Failure-safe: missing / empty / unparseable INTERFACE.md → empty defaults.

## Templates updated

Three of 13 — remaining lazy-derive on first read via the back-fill helper:

- `starter.yaml` — assistant gets all five
- `devteam.yaml` — pm / engineer / reviewer all get five; engineer + reviewer escalate to `pm`
- `research.yaml` — researcher gets all five

## Lightweight validator

`_validate_agent_template(template)` returns warnings (not rejection) for: missing capabilities + no INTERFACE.md to derive from; unknown `escalation_to` targets within the same template. Called from `_load_templates` and logged at info level.

## Test plan

- [x] `test_types.py`: AgentConfig defaults / accepts new fields / extras allowed (3)
- [x] `test_workspace.py::TestDeriveCapabilitiesFromInterface`: 6 (missing / empty / canonical headings / legacy synonyms / unparseable / dir-instead-of-file)
- [x] `test_templates.py`: persist + skip-empty (`_add_agent_to_config`), three updated templates have populated fields, lazy-derive back-fill is idempotent and respects pre-existing values
- [x] `test_templates.py::TestValidateAgentTemplate`: 5 (missing capabilities + interface, capabilities present, interface present, unknown escalation, known escalation)
- [x] `test_mesh.py`: `/mesh/agents` and `/mesh/agents/{id}/profile` carry the five fields
- [x] `test_operator_product_tools.py`: `get_agent_profile` returns the five fields
- [x] `pytest tests/test_types.py tests/test_workspace.py tests/test_templates.py tests/test_projects.py tests/test_mesh.py tests/test_operator_product_tools.py tests/test_cli_commands.py` — 452 passed
- [x] Full non-E2E suite — 5215 passed, 44 skipped, 5 deselected. **No new failures.**

## What's deliberately NOT in this PR

- Updating remaining 10 templates with explicit fields. They lazy-derive on first read and persist — the in-PR templates are illustrative.
- Removing INTERFACE.md from workspace bootstrap. It stays as the agent's own free-text companion.
- Operator routing logic that consumes these fields (the operator's prompt machinery already reads `get_agent_profile` from Task 7; templates set the fields directly).

## Stack

1. #821 — Task 0 hotfix ✅
2. #822 — Task 1 characterization tests
3. #823 — Task 2a typed model
4. #824 — Task 2b stamp sites
5. #825 — Task 2c channel pairing recheck
6. #826 — Task 2d pending-actions SQLite
7. #827 — Task 2e wake block
8. #828 — Task 3 perm split
9. #829 — Task 4 operator cryptographic registration
10. #830 — Task 5 project isolation warn mode
11. #831 — Task 6 durable task records
12. #832 — Task 7 operator product tools
13. **This PR** — Task 8 structured routing fields
14. (next, final) Task 9 dashboard / CLI surfaces