### PR TITLE
feat(dashboard,cli): orchestration surfaces (Task 9)

### DIFF
--- a/src/cli/main.py
+++ b/src/cli/main.py
@@ -596,6 +596,213 @@ def status(port: int, wide: bool, watch_interval: int | None, as_json: bool):
     _print_status(agents_data, mesh_online, configured)
 
 
+# ── Task 9 — Workplace / orchestration CLI commands ──────────
+
+
+def _mesh_get(port: int, path: str) -> dict | list:
+    """GET against the local mesh, raise SystemExit(1) on failure."""
+    import httpx
+
+    try:
+        resp = httpx.get(f"http://localhost:{port}{path}", timeout=10)
+    except httpx.ConnectError:
+        _fail("Mesh is not running. Start it first: openlegion start")
+    except Exception as e:
+        _fail(f"Error contacting mesh: {e}")
+    if resp.status_code >= 400:
+        _fail(f"HTTP {resp.status_code}: {resp.text}")
+    try:
+        return resp.json()
+    except Exception:
+        return {}
+
+
+def _mesh_post(port: int, path: str, body: dict | None = None) -> dict:
+    """POST against the local mesh with the dashboard CSRF header."""
+    import httpx
+
+    headers = {
+        "X-Requested-With": "XMLHttpRequest",
+        "X-Origin": f"kind=human,channel=cli,user={os.getenv('USER', 'cli')}",
+    }
+    try:
+        resp = httpx.post(
+            f"http://localhost:{port}{path}",
+            json=body or {}, headers=headers, timeout=15,
+        )
+    except httpx.ConnectError:
+        _fail("Mesh is not running. Start it first: openlegion start")
+    except Exception as e:
+        _fail(f"Error contacting mesh: {e}")
+    if resp.status_code >= 400:
+        _fail(f"HTTP {resp.status_code}: {resp.text}")
+    try:
+        return resp.json()
+    except Exception:
+        return {}
+
+
+@cli.command("projects")
+@click.option("--port", default=8420, type=int, help="Mesh host port")
+@click.option("--json", "as_json", is_flag=True, help="Output as JSON")
+def projects_cmd(port: int, as_json: bool):
+    """List active projects (Task 9)."""
+    as_json = as_json or _json_mode
+    data = _mesh_get(port, "/dashboard/api/workplace/projects")
+    projects = data.get("projects", []) if isinstance(data, dict) else []
+    if as_json:
+        click.echo(_json.dumps({"projects": projects}, default=str))
+        return
+    if not projects:
+        click.echo("No active projects.")
+        return
+    click.echo(f"{'Project':<24} {'Status':<10} {'Tasks':<8} {'Members'}")
+    click.echo("-" * 70)
+    for p in projects:
+        members = ", ".join(p.get("members", [])) or "-"
+        if len(members) > 30:
+            members = members[:27] + "..."
+        click.echo(
+            f"{p.get('name', '?'):<24} {p.get('status', 'active'):<10} "
+            f"{p.get('total', 0):<8} {members}"
+        )
+
+
+@cli.command("project")
+@click.argument("project_id")
+@click.option("--port", default=8420, type=int, help="Mesh host port")
+@click.option("--json", "as_json", is_flag=True, help="Output as JSON")
+def project_cmd(project_id: str, port: int, as_json: bool):
+    """Show status for a single project."""
+    as_json = as_json or _json_mode
+    data = _mesh_get(port, "/dashboard/api/workplace/projects")
+    projects = data.get("projects", []) if isinstance(data, dict) else []
+    match = next((p for p in projects if p.get("name") == project_id), None)
+    if match is None:
+        _fail(f"Project '{project_id}' not found")
+    if as_json:
+        click.echo(_json.dumps(match, default=str))
+        return
+    click.echo(f"Project: {match.get('name')}")
+    click.echo(f"  Status:      {match.get('status', 'active')}")
+    click.echo(f"  Description: {match.get('description', '') or '-'}")
+    click.echo(f"  Members:     {', '.join(match.get('members', []) or ['-'])}")
+    click.echo(f"  Total tasks: {match.get('total', 0)}")
+    counts = match.get("counts") or {}
+    if counts:
+        click.echo("  By status:")
+        for status, n in sorted(counts.items()):
+            click.echo(f"    {status:<10} {n}")
+    blockers = match.get("blockers") or []
+    if blockers:
+        click.echo(f"  Blockers ({len(blockers)}):")
+        for b in blockers:
+            click.echo(
+                f"    - {b.get('title', '?')} ({b.get('assignee', '?')}): "
+                f"{b.get('blocker_note', '')}"
+            )
+
+
+@cli.command("tasks")
+@click.option("--agent", default=None, help="Filter by assignee")
+@click.option("--project", default=None, help="Filter by project ID")
+@click.option(
+    "--status", default=None,
+    help="Filter by status (pending/accepted/working/blocked/done/failed/cancelled)",
+)
+@click.option("--port", default=8420, type=int, help="Mesh host port")
+@click.option("--json", "as_json", is_flag=True, help="Output as JSON")
+def tasks_cmd(agent, project, status, port, as_json):
+    """List/filter durable task records (Task 9)."""
+    as_json = as_json or _json_mode
+    qs = []
+    if agent:
+        qs.append(f"assignee={agent}")
+    if project:
+        qs.append(f"project_id={project}")
+    if status:
+        qs.append(f"status={status}")
+    suffix = ("?" + "&".join(qs)) if qs else ""
+    data = _mesh_get(port, f"/dashboard/api/workplace/tasks{suffix}")
+    if not isinstance(data, dict):
+        data = {}
+    if not data.get("enabled", True):
+        if as_json:
+            click.echo(_json.dumps(data, default=str))
+        else:
+            click.echo("Workplace disabled. Set OPENLEGION_ORCHESTRATION_TASKS_V2=1 and restart.")
+        return
+    tasks = data.get("tasks", [])
+    if as_json:
+        click.echo(_json.dumps({"tasks": tasks}, default=str))
+        return
+    if not tasks:
+        click.echo("No tasks.")
+        return
+    click.echo(f"{'ID':<22} {'Status':<10} {'Assignee':<14} {'Project':<14} {'Title'}")
+    click.echo("-" * 90)
+    for t in tasks:
+        title = (t.get("title") or "")[:30]
+        click.echo(
+            f"{(t.get('id') or '')[:22]:<22} {t.get('status', '?'):<10} "
+            f"{(t.get('assignee') or '')[:14]:<14} "
+            f"{(t.get('project_id') or '')[:14]:<14} {title}"
+        )
+
+
+@cli.command("pending")
+@click.option("--port", default=8420, type=int, help="Mesh host port")
+@click.option("--json", "as_json", is_flag=True, help="Output as JSON")
+def pending_cmd(port: int, as_json: bool):
+    """List open pending actions awaiting human confirmation."""
+    as_json = as_json or _json_mode
+    data = _mesh_get(port, "/dashboard/api/workplace/pending")
+    rows = data.get("pending", []) if isinstance(data, dict) else []
+    if as_json:
+        click.echo(_json.dumps({"pending": rows}, default=str))
+        return
+    if not rows:
+        click.echo("No pending actions.")
+        return
+    click.echo(f"{'Nonce':<38} {'Actor':<12} {'Action':<14} {'Target'}")
+    click.echo("-" * 90)
+    for r in rows:
+        target = f"{r.get('target_kind', '?')}/{r.get('target_id', '?')}"
+        click.echo(
+            f"{(r.get('nonce') or '')[:38]:<38} "
+            f"{(r.get('actor') or '')[:12]:<12} "
+            f"{(r.get('action_kind') or '')[:14]:<14} {target}"
+        )
+
+
+@cli.command("confirm")
+@click.argument("nonce")
+@click.option("--port", default=8420, type=int, help="Mesh host port")
+@click.option("--json", "as_json", is_flag=True, help="Output as JSON")
+def confirm_cmd(nonce: str, port: int, as_json: bool):
+    """Confirm a pending action by nonce (Task 9)."""
+    as_json = as_json or _json_mode
+    result = _mesh_post(port, f"/mesh/pending/{nonce}/confirm")
+    if as_json:
+        click.echo(_json.dumps(result, default=str))
+    else:
+        click.echo(f"Confirmed: {nonce}")
+
+
+@cli.command("cancel")
+@click.argument("nonce")
+@click.option("--port", default=8420, type=int, help="Mesh host port")
+@click.option("--json", "as_json", is_flag=True, help="Output as JSON")
+def cancel_cmd(nonce: str, port: int, as_json: bool):
+    """Cancel a pending action by nonce (Task 9)."""
+    as_json = as_json or _json_mode
+    result = _mesh_post(port, f"/mesh/pending/{nonce}/cancel")
+    if as_json:
+        click.echo(_json.dumps(result, default=str))
+    else:
+        click.echo(f"Cancelled: {nonce}")
+
+
 # ── stop ─────────────────────────────────────────────────────
 
 @cli.command()

--- a/src/cli/runtime.py
+++ b/src/cli/runtime.py
@@ -658,6 +658,9 @@ class RuntimeContext:
 
         from src.dashboard.server import create_dashboard_router, create_spa_catchall_router
 
+        # Task 9 — pass the mesh's pending-action and tasks stores into
+        # the dashboard so the new ``/api/workplace/*`` endpoints can
+        # render the Workplace tab without a second HTTP hop.
         dashboard_router = create_dashboard_router(
             blackboard=self.blackboard,
             health_monitor=self.health_monitor,
@@ -678,6 +681,8 @@ class RuntimeContext:
             channel_manager=self.channel_manager,
             wallet_service_ref=wallet_ref,
             api_key_manager=self._api_key_manager,
+            pending_actions=getattr(app, "pending_actions", None),
+            tasks_store=getattr(app, "tasks_store", None),
         )
         app.include_router(dashboard_router)
         app.include_router(create_spa_catchall_router())  # Must be last — SPA deep linking

--- a/src/dashboard/server.py
+++ b/src/dashboard/server.py
@@ -572,6 +572,12 @@ def create_dashboard_router(
     channel_manager: Any = None,
     wallet_service_ref: list | None = None,
     api_key_manager: Any = None,
+    # Task 9 — Workplace tab + pending action review surface. Both are
+    # optional so existing dashboard tests that don't construct them
+    # keep working; the new endpoints fall back to empty/disabled when
+    # the relevant store is absent.
+    pending_actions: Any = None,
+    tasks_store: Any = None,
 ) -> APIRouter:
     """Create the dashboard FastAPI router."""
     # Plan limits — read once at startup; provisioner restarts engine after updating .env
@@ -5398,6 +5404,176 @@ def create_dashboard_router(
             parent.rmdir()
             parent = parent.parent
         return {"deleted": True, "name": name}
+
+    # ── Task 9 — Workplace tab + pending-action review ──────────────
+    #
+    # The Workplace tab is a top-level peer of Chat / Agents / System
+    # under ``src/dashboard/static/js/app.js``. It surfaces the durable
+    # task records (Task 6) and the pending-action queue (Task 2d) so a
+    # human can run an agent team end-to-end without inspecting
+    # blackboard keys directly. All endpoints degrade gracefully when
+    # the underlying store is None (orchestration v2 disabled, or
+    # called from a test harness that didn't pass the stores).
+
+    def _orchestration_v2_on() -> bool:
+        return os.environ.get("OPENLEGION_ORCHESTRATION_TASKS_V2", "0") == "1"
+
+    @api_router.get("/api/workplace/tasks")
+    async def api_workplace_tasks(
+        project_id: str | None = None,
+        assignee: str | None = None,
+        status: str | None = None,
+    ) -> dict:
+        """List task records for the Workplace board.
+
+        Returns ``{"enabled": False, ...}`` when orchestration v2 is
+        disabled so the SPA can render the empty state with a hint to
+        flip the flag — matches the contract in tests.
+        """
+        if tasks_store is None or not _orchestration_v2_on():
+            return {
+                "enabled": False,
+                "tasks": [],
+                "hint": (
+                    "Set OPENLEGION_ORCHESTRATION_TASKS_V2=1 to enable durable "
+                    "task records and the Workplace board."
+                ),
+            }
+        try:
+            if assignee:
+                rows = tasks_store.list_inbox(
+                    assignee, project_id=project_id, include_terminal=True,
+                )
+            elif project_id:
+                rows = tasks_store.list_project(project_id)
+            else:
+                # Fleet-wide listing — operator-only data is acceptable
+                # because the dashboard is operator-authenticated.
+                with tasks_store._conn() as conn:
+                    sql = (
+                        f"SELECT {tasks_store._SELECT_COLS} FROM tasks "
+                        "ORDER BY created_at DESC LIMIT 500"
+                    )
+                    raw = conn.execute(sql).fetchall()
+                rows = [tasks_store._row_to_dict(r) for r in raw]
+            if status:
+                rows = [r for r in rows if r.get("status") == status]
+            return {"enabled": True, "tasks": rows}
+        except Exception as e:
+            logger.warning("workplace tasks listing failed: %s", e)
+            return {"enabled": True, "tasks": [], "error": str(e)}
+
+    @api_router.get("/api/workplace/projects")
+    async def api_workplace_projects() -> dict:
+        """Project status rollups for the Workplace > project-status tab."""
+        if tasks_store is None or not _orchestration_v2_on():
+            return {"enabled": False, "projects": []}
+        from src.cli.config import _load_projects
+        projects = _load_projects()
+        result = []
+        for pname, pdata in projects.items():
+            try:
+                rows = tasks_store.list_project(pname)
+            except Exception:
+                rows = []
+            counts: dict[str, int] = {}
+            blockers: list[dict] = []
+            for r in rows:
+                counts[r["status"]] = counts.get(r["status"], 0) + 1
+                if r["status"] == "blocked":
+                    blockers.append({
+                        "task_id": r["id"],
+                        "title": r["title"],
+                        "assignee": r["assignee"],
+                        "blocker_note": r.get("blocker_note") or "",
+                    })
+            result.append({
+                "name": pname,
+                "description": pdata.get("description", ""),
+                "members": pdata.get("members", []),
+                "status": pdata.get("status", "active"),
+                "counts": counts,
+                "total": len(rows),
+                "blockers": blockers,
+            })
+        return {"enabled": True, "projects": result}
+
+    @api_router.get("/api/workplace/blockers")
+    async def api_workplace_blockers() -> dict:
+        """Fleet-wide blocked-task list for the Workplace > blockers tab."""
+        if tasks_store is None or not _orchestration_v2_on():
+            return {"enabled": False, "blockers": []}
+        try:
+            with tasks_store._conn() as conn:
+                sql = (
+                    f"SELECT {tasks_store._SELECT_COLS} FROM tasks "
+                    "WHERE status='blocked' ORDER BY updated_at DESC LIMIT 200"
+                )
+                raw = conn.execute(sql).fetchall()
+            rows = [tasks_store._row_to_dict(r) for r in raw]
+        except Exception as e:
+            logger.warning("workplace blockers listing failed: %s", e)
+            rows = []
+        return {"enabled": True, "blockers": rows}
+
+    @api_router.get("/api/workplace/outputs")
+    async def api_workplace_outputs(
+        project_id: str | None = None,
+        limit: int = 100,
+    ) -> dict:
+        """Completed task artifacts for the Workplace > team-outputs tab."""
+        if tasks_store is None or not _orchestration_v2_on():
+            return {"enabled": False, "outputs": []}
+        limit = max(1, min(int(limit or 100), 500))
+        try:
+            with tasks_store._conn() as conn:
+                if project_id:
+                    sql = (
+                        f"SELECT {tasks_store._SELECT_COLS} FROM tasks "
+                        "WHERE status='done' AND project_id=? "
+                        "ORDER BY completed_at DESC LIMIT ?"
+                    )
+                    raw = conn.execute(sql, (project_id, limit)).fetchall()
+                else:
+                    sql = (
+                        f"SELECT {tasks_store._SELECT_COLS} FROM tasks "
+                        "WHERE status='done' ORDER BY completed_at DESC LIMIT ?"
+                    )
+                    raw = conn.execute(sql, (limit,)).fetchall()
+            rows = [tasks_store._row_to_dict(r) for r in raw]
+        except Exception as e:
+            logger.warning("workplace outputs listing failed: %s", e)
+            rows = []
+        return {"enabled": True, "outputs": rows}
+
+    @api_router.get("/api/workplace/pending")
+    async def api_workplace_pending() -> dict:
+        """List open pending actions for inline + System>Operator review."""
+        if pending_actions is None:
+            return {"pending": []}
+        try:
+            pending_actions.reap_expired()
+            rows = pending_actions.list_pending()
+        except Exception as e:
+            logger.warning("workplace pending listing failed: %s", e)
+            rows = []
+        return {"pending": rows}
+
+    @api_router.post("/api/workplace/pending/{nonce}/cancel")
+    async def api_workplace_pending_cancel(nonce: str) -> dict:
+        """Cancel a pending action — backs the dashboard "Cancel" button."""
+        if pending_actions is None:
+            raise HTTPException(404, "Pending action store not available")
+        record = pending_actions.cancel(nonce, actor="operator")
+        if record is None:
+            raise HTTPException(404, "Pending action not found or already expired")
+        return {
+            "ok": True,
+            "nonce": nonce,
+            "target_kind": record["target_kind"],
+            "target_id": record["target_id"],
+            "action_kind": record["action_kind"],
+        }
 
     @api_router.get("/static/{file_path:path}")
     async def static_file(file_path: str, v: str | None = None) -> FileResponse:

--- a/src/dashboard/static/js/app.js
+++ b/src/dashboard/static/js/app.js
@@ -49,6 +49,7 @@ function dashboard() {
     tabs: [
       { id: 'chat', label: 'Chat' },
       { id: 'fleet', label: 'Agents' },
+      { id: 'workplace', label: 'Workplace' },
       { id: 'system', label: 'System' },
     ],
     connected: false,
@@ -82,6 +83,9 @@ function dashboard() {
       'heartbeat_complete', 'cron_change', 'credit_exhausted', 'credential_request',
       'browser_login_request', 'browser_login_completed', 'browser_login_cancelled',
       'browser_captcha_help_request', 'browser_captcha_help_completed', 'browser_captcha_help_cancelled',
+      // Task 9 — Workplace tab + pending action review
+      'task_created', 'task_status_changed',
+      'pending_action_created', 'pending_action_resolved', 'pending_action_expired',
     ],
 
     // Agent detail
@@ -326,6 +330,28 @@ function dashboard() {
     cmdPaletteQuery: '',
     cmdPaletteResults: [],
     cmdPaletteIdx: 0,
+
+    // Task 9 — Workplace tab (peer of Chat / Agents / System).
+    // Sub-tabs: project status, kanban task board, blockers, team outputs.
+    // ``workplaceEnabled`` mirrors the server-side flag
+    // OPENLEGION_ORCHESTRATION_TASKS_V2 so the empty state can hint how
+    // to enable the surface without rendering an error.
+    workplaceTab: 'project-status',
+    workplaceTabs: [
+      { id: 'project-status', label: 'Project status' },
+      { id: 'task-board', label: 'Task board' },
+      { id: 'blockers', label: 'Blockers' },
+      { id: 'team-outputs', label: 'Team outputs' },
+    ],
+    workplaceEnabled: true,
+    workplaceProjects: [],
+    workplaceTasks: [],
+    workplaceBlockers: [],
+    workplaceOutputs: [],
+    workplacePending: [],
+    workplaceLoading: false,
+    workplaceTaskColumns: ['pending', 'accepted', 'working', 'blocked', 'done'],
+    workplaceProjectFilter: '',
 
     // System tab — sub-navigation
     systemTab: 'activity',
@@ -1342,6 +1368,179 @@ function dashboard() {
       }
     },
 
+    // ── Task 9 — Workplace tab loaders / event handlers ────────
+
+    async loadWorkplace() {
+      this.workplaceLoading = true;
+      try {
+        await Promise.all([
+          this.loadWorkplaceProjects(),
+          this.loadWorkplaceTasks(),
+          this.loadWorkplaceBlockers(),
+          this.loadWorkplaceOutputs(),
+          this.loadWorkplacePending(),
+        ]);
+      } finally {
+        this.workplaceLoading = false;
+      }
+    },
+
+    async loadWorkplaceProjects() {
+      try {
+        const resp = await fetch(`${window.__config.apiBase}/workplace/projects`);
+        if (!resp.ok) return;
+        const data = await resp.json();
+        this.workplaceEnabled = data.enabled !== false;
+        this.workplaceProjects = data.projects || [];
+      } catch (e) {
+        console.error('Failed to load workplace projects:', e);
+      }
+    },
+
+    async loadWorkplaceTasks() {
+      try {
+        const params = this.workplaceProjectFilter ? `?project_id=${encodeURIComponent(this.workplaceProjectFilter)}` : '';
+        const resp = await fetch(`${window.__config.apiBase}/workplace/tasks${params}`);
+        if (!resp.ok) return;
+        const data = await resp.json();
+        this.workplaceEnabled = data.enabled !== false;
+        this.workplaceTasks = data.tasks || [];
+      } catch (e) {
+        console.error('Failed to load workplace tasks:', e);
+      }
+    },
+
+    async loadWorkplaceBlockers() {
+      try {
+        const resp = await fetch(`${window.__config.apiBase}/workplace/blockers`);
+        if (!resp.ok) return;
+        const data = await resp.json();
+        this.workplaceEnabled = data.enabled !== false;
+        this.workplaceBlockers = data.blockers || [];
+      } catch (e) {
+        console.error('Failed to load workplace blockers:', e);
+      }
+    },
+
+    async loadWorkplaceOutputs() {
+      try {
+        const params = this.workplaceProjectFilter ? `?project_id=${encodeURIComponent(this.workplaceProjectFilter)}` : '';
+        const resp = await fetch(`${window.__config.apiBase}/workplace/outputs${params}`);
+        if (!resp.ok) return;
+        const data = await resp.json();
+        this.workplaceEnabled = data.enabled !== false;
+        this.workplaceOutputs = data.outputs || [];
+      } catch (e) {
+        console.error('Failed to load workplace outputs:', e);
+      }
+    },
+
+    async loadWorkplacePending() {
+      try {
+        const resp = await fetch(`${window.__config.apiBase}/workplace/pending`);
+        if (!resp.ok) return;
+        const data = await resp.json();
+        this.workplacePending = data.pending || [];
+      } catch (e) {
+        console.error('Failed to load workplace pending actions:', e);
+      }
+    },
+
+    workplaceTasksByStatus(status) {
+      return (this.workplaceTasks || []).filter(t => t.status === status);
+    },
+
+    workplaceFormatExpiry(expiresAt) {
+      if (!expiresAt) return '';
+      const remain = Math.max(0, Math.floor(expiresAt - (Date.now() / 1000)));
+      if (remain < 60) return `${remain}s`;
+      if (remain < 3600) return `${Math.floor(remain / 60)}m`;
+      return `${Math.floor(remain / 3600)}h`;
+    },
+
+    async confirmPendingAction(nonce) {
+      try {
+        const resp = await fetch(`/mesh/pending/${encodeURIComponent(nonce)}/confirm`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: '{}',
+        });
+        if (!resp.ok) {
+          const data = await resp.json().catch(() => ({}));
+          this.showToast(`Confirm failed: ${data.detail || resp.status}`);
+          return;
+        }
+        this.workplacePending = this.workplacePending.filter(p => p.nonce !== nonce);
+        this.showToast('Pending action confirmed.');
+      } catch (e) {
+        this.showToast(`Confirm failed: ${e.message || e}`);
+      }
+    },
+
+    async cancelPendingAction(nonce) {
+      try {
+        const resp = await fetch(`${window.__config.apiBase}/workplace/pending/${encodeURIComponent(nonce)}/cancel`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: '{}',
+        });
+        if (!resp.ok) {
+          const data = await resp.json().catch(() => ({}));
+          this.showToast(`Cancel failed: ${data.detail || resp.status}`);
+          return;
+        }
+        this.workplacePending = this.workplacePending.filter(p => p.nonce !== nonce);
+        this.showToast('Pending action cancelled.');
+      } catch (e) {
+        this.showToast(`Cancel failed: ${e.message || e}`);
+      }
+    },
+
+    // Apply a live event from the WebSocket to the in-memory workplace
+    // state so the user sees changes without reloading. Each handler is
+    // a small upsert into one of the lists; misses are tolerated (the
+    // periodic full-load is the source of truth on reconnect).
+    handleWorkplaceEvent(evt) {
+      if (!evt || !evt.type) return;
+      const data = evt.data || {};
+      if (evt.type === 'task_created') {
+        // Add stub row so the kanban shows the task immediately;
+        // background reload will fill in the rest.
+        const stub = {
+          id: data.task_id,
+          project_id: data.project_id,
+          creator: data.creator,
+          assignee: data.assignee,
+          title: data.title || '(untitled)',
+          status: data.status || 'pending',
+          created_at: data.created_at,
+        };
+        if (!this.workplaceTasks.find(t => t.id === stub.id)) {
+          this.workplaceTasks.unshift(stub);
+        }
+      } else if (evt.type === 'task_status_changed') {
+        const t = this.workplaceTasks.find(x => x.id === data.task_id);
+        if (t) {
+          t.status = data.new_status;
+          if (data.assignee) t.assignee = data.assignee;
+        }
+      } else if (evt.type === 'pending_action_created') {
+        if (!this.workplacePending.find(p => p.nonce === data.nonce)) {
+          this.workplacePending.push({
+            nonce: data.nonce,
+            actor: data.actor,
+            target_kind: data.target_kind,
+            target_id: data.target_id,
+            action_kind: data.action_kind,
+            expires_at: data.expires_at,
+            created_at: Date.now() / 1000,
+          });
+        }
+      } else if (evt.type === 'pending_action_resolved' || evt.type === 'pending_action_expired') {
+        this.workplacePending = this.workplacePending.filter(p => p.nonce !== data.nonce);
+      }
+    },
+
     // ── Markdown rendering for chat messages ─────────────
 
     renderMarkdown(text) {
@@ -1459,6 +1658,16 @@ function dashboard() {
       if (evt.type === 'cron_change') {
         if (this._cronDebounce) clearTimeout(this._cronDebounce);
         this._cronDebounce = setTimeout(() => this.fetchCronJobs(), 500);
+      }
+
+      // Task 9 — Workplace tab + pending action review live updates.
+      // The handler upserts into the Alpine.js state lists so the SPA
+      // reflects task lifecycle and pending-action arrivals without a
+      // full reload.
+      if (evt.type === 'task_created' || evt.type === 'task_status_changed' ||
+          evt.type === 'pending_action_created' || evt.type === 'pending_action_resolved' ||
+          evt.type === 'pending_action_expired') {
+        this.handleWorkplaceEvent(evt);
       }
 
       // Refresh model health on health_change events

--- a/src/dashboard/templates/index.html
+++ b/src/dashboard/templates/index.html
@@ -191,6 +191,9 @@
               <template x-if="tab.id === 'fleet'">
                 <svg fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="3" width="7" height="7" rx="1"/><rect x="14" y="3" width="7" height="7" rx="1"/><rect x="3" y="14" width="7" height="7" rx="1"/><rect x="14" y="14" width="7" height="7" rx="1"/></svg>
               </template>
+              <template x-if="tab.id === 'workplace'">
+                <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M9 11H7a2 2 0 0 0-2 2v6a2 2 0 0 0 2 2h10a2 2 0 0 0 2-2v-6a2 2 0 0 0-2-2h-2"/><rect x="9" y="3" width="6" height="8" rx="1"/></svg>
+              </template>
               <template x-if="tab.id === 'system'">
                 <svg fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="4" y1="21" x2="4" y2="14"/><line x1="4" y1="10" x2="4" y2="3"/><line x1="12" y1="21" x2="12" y2="12"/><line x1="12" y1="8" x2="12" y2="3"/><line x1="20" y1="21" x2="20" y2="16"/><line x1="20" y1="12" x2="20" y2="3"/><line x1="1" y1="14" x2="7" y2="14"/><line x1="9" y1="8" x2="15" y2="8"/><line x1="17" y1="16" x2="23" y2="16"/></svg>
               </template>
@@ -292,6 +295,39 @@
                   <div class="text-sm text-gray-400">Your operator is starting up...</div>
                   <div class="text-[10px] text-gray-600 mt-1">This usually takes about 15&ndash;30 seconds.</div>
                 </div>
+              </div>
+
+              <!-- Task 9 — Inline pending-action review.
+                   Renders one bubble per open pending nonce above the
+                   operator chat so the human can confirm/cancel in
+                   context. Backed by the same state as the System >
+                   Operator panel. -->
+              <div x-show="operatorReady && workplacePending.length" x-cloak
+                   class="px-4 pt-3 space-y-2"
+                   x-init="loadWorkplacePending()">
+                <template x-for="p in workplacePending" :key="p.nonce">
+                  <div class="bg-amber-900/15 border border-amber-700/30 rounded-2xl px-3 py-2">
+                    <div class="text-[11px] text-amber-200 font-medium">
+                      Pending action awaiting confirmation
+                    </div>
+                    <div class="text-xs text-gray-200 mt-0.5">
+                      <span class="font-medium" x-text="p.action_kind"></span>
+                      <span class="text-gray-400" x-text="' on ' + (p.target_kind || '?') + ' ' + (p.target_id || '?')"></span>
+                    </div>
+                    <div class="text-[11px] text-gray-400 mt-0.5"
+                         x-text="'expires in ' + workplaceFormatExpiry(p.expires_at) + ' · proposed by ' + (p.actor || '?')"></div>
+                    <div class="flex gap-2 mt-2">
+                      <button @click="confirmPendingAction(p.nonce)"
+                        class="text-[11px] px-2.5 py-1 rounded bg-emerald-700/40 hover:bg-emerald-700/60 text-emerald-200 transition-colors">
+                        Confirm
+                      </button>
+                      <button @click="cancelPendingAction(p.nonce)"
+                        class="text-[11px] px-2.5 py-1 rounded bg-gray-700 hover:bg-gray-600 text-gray-300 transition-colors">
+                        Cancel
+                      </button>
+                    </div>
+                  </div>
+                </template>
               </div>
 
               <!-- Messages area — reuses existing chatHistories binding -->
@@ -2960,6 +2996,155 @@
         </template>
       </div>
 
+      <!-- Task 9 — Workplace tab. Surfaces durable task records (Task 6)
+           and the pending-action queue (Task 2d) so a human can run an
+           agent team end-to-end without inspecting blackboard keys. -->
+      <div x-show="activeTab === 'workplace'" x-cloak x-init="loadWorkplace()">
+        <!-- Sub-tab bar -->
+        <div class="flex flex-wrap gap-0.5 bg-gray-800/50 rounded-lg p-0.5 mb-4">
+          <template x-for="wt in workplaceTabs" :key="wt.id">
+            <button @click="workplaceTab = wt.id; loadWorkplace()"
+              class="px-3 py-1.5 rounded-md text-sm font-medium transition-all relative whitespace-nowrap"
+              :class="workplaceTab === wt.id ? 'bg-gray-700 text-white shadow-sm' : 'text-gray-400 hover:text-gray-200 hover:bg-gray-800/70'">
+              <span x-text="wt.label"></span>
+            </button>
+          </template>
+        </div>
+
+        <!-- Empty state when orchestration v2 is disabled -->
+        <template x-if="!workplaceEnabled">
+          <div class="bg-gray-800/40 border border-gray-700/50 rounded-xl p-6 text-center">
+            <div class="text-gray-300 text-sm font-medium mb-2">Workplace is disabled</div>
+            <div class="text-xs text-gray-400 max-w-md mx-auto">
+              Set <code class="text-gray-200 bg-gray-900/60 px-1 rounded">OPENLEGION_ORCHESTRATION_TASKS_V2=1</code>
+              and restart the runtime to enable durable task records, project status rollups, blocker review,
+              and team-output history on this tab.
+            </div>
+          </div>
+        </template>
+
+        <!-- Project status sub-tab -->
+        <template x-if="workplaceEnabled && workplaceTab === 'project-status'">
+          <div class="space-y-3">
+            <template x-if="!workplaceProjects.length">
+              <div class="text-sm text-gray-500 py-4">No active projects.</div>
+            </template>
+            <template x-for="p in workplaceProjects" :key="p.name">
+              <div class="bg-gray-800/40 border border-gray-700/50 rounded-lg p-4">
+                <div class="flex items-center justify-between mb-2">
+                  <div>
+                    <div class="text-sm font-medium text-white" x-text="p.name"></div>
+                    <div class="text-xs text-gray-400" x-text="p.description || ''"></div>
+                  </div>
+                  <div class="text-xs text-gray-400">
+                    <span x-text="p.total + ' task' + (p.total === 1 ? '' : 's')"></span>
+                    <span class="ml-2 px-1.5 py-0.5 rounded bg-gray-900/60 text-gray-300" x-text="p.status"></span>
+                  </div>
+                </div>
+                <div class="flex flex-wrap gap-1.5 text-[11px]">
+                  <template x-for="status in workplaceTaskColumns" :key="status">
+                    <span class="px-2 py-0.5 rounded bg-gray-900/60 text-gray-300"
+                      x-show="(p.counts && p.counts[status]) || 0">
+                      <span x-text="status"></span>:
+                      <span class="font-mono" x-text="(p.counts && p.counts[status]) || 0"></span>
+                    </span>
+                  </template>
+                </div>
+                <template x-if="p.blockers && p.blockers.length">
+                  <div class="mt-3 pt-2 border-t border-gray-700/40">
+                    <div class="text-[11px] text-yellow-300 mb-1">Blockers:</div>
+                    <template x-for="b in p.blockers" :key="b.task_id">
+                      <div class="text-xs text-gray-300 pl-2">
+                        <span x-text="b.title"></span>
+                        <span class="text-gray-500" x-text="'· ' + (b.assignee || '')"></span>
+                        <div class="text-[11px] text-gray-400" x-text="b.blocker_note"></div>
+                      </div>
+                    </template>
+                  </div>
+                </template>
+              </div>
+            </template>
+          </div>
+        </template>
+
+        <!-- Task board (kanban) sub-tab -->
+        <template x-if="workplaceEnabled && workplaceTab === 'task-board'">
+          <div>
+            <div class="grid grid-cols-1 md:grid-cols-5 gap-3">
+              <template x-for="status in workplaceTaskColumns" :key="status">
+                <div class="bg-gray-800/40 border border-gray-700/50 rounded-lg p-3">
+                  <div class="text-xs font-medium text-gray-300 uppercase tracking-wide mb-2 flex items-center justify-between">
+                    <span x-text="status"></span>
+                    <span class="text-gray-500 font-mono" x-text="workplaceTasksByStatus(status).length"></span>
+                  </div>
+                  <div class="space-y-2">
+                    <template x-for="t in workplaceTasksByStatus(status)" :key="t.id">
+                      <div class="bg-gray-900/60 border border-gray-700/40 rounded-md p-2 text-xs">
+                        <div class="font-medium text-gray-200 truncate" x-text="t.title"></div>
+                        <div class="text-[11px] text-gray-400 mt-1">
+                          <span x-text="t.assignee || ''"></span>
+                          <span x-show="t.project_id" class="text-gray-500"
+                            x-text="' · ' + (t.project_id || '')"></span>
+                        </div>
+                      </div>
+                    </template>
+                  </div>
+                </div>
+              </template>
+            </div>
+          </div>
+        </template>
+
+        <!-- Blockers sub-tab -->
+        <template x-if="workplaceEnabled && workplaceTab === 'blockers'">
+          <div class="space-y-2">
+            <template x-if="!workplaceBlockers.length">
+              <div class="text-sm text-gray-500 py-4">No blocked tasks.</div>
+            </template>
+            <template x-for="t in workplaceBlockers" :key="t.id">
+              <div class="bg-yellow-900/15 border border-yellow-800/30 rounded-lg p-3">
+                <div class="text-sm font-medium text-yellow-100" x-text="t.title"></div>
+                <div class="text-[11px] text-gray-400 mt-1">
+                  <span x-text="t.assignee || ''"></span>
+                  <span x-show="t.project_id" class="text-gray-500"
+                    x-text="' · ' + (t.project_id || '')"></span>
+                </div>
+                <div class="text-xs text-gray-300 mt-2" x-text="t.blocker_note || '(no note)'"></div>
+              </div>
+            </template>
+          </div>
+        </template>
+
+        <!-- Team outputs sub-tab -->
+        <template x-if="workplaceEnabled && workplaceTab === 'team-outputs'">
+          <div class="space-y-2">
+            <template x-if="!workplaceOutputs.length">
+              <div class="text-sm text-gray-500 py-4">No completed tasks yet.</div>
+            </template>
+            <template x-for="t in workplaceOutputs" :key="t.id">
+              <div class="bg-gray-800/40 border border-gray-700/50 rounded-lg p-3">
+                <div class="text-sm font-medium text-gray-100" x-text="t.title"></div>
+                <div class="text-[11px] text-gray-400 mt-1">
+                  <span x-text="t.assignee || ''"></span>
+                  <span x-show="t.project_id" class="text-gray-500"
+                    x-text="' · ' + (t.project_id || '')"></span>
+                  <span x-show="t.completed_at" class="text-gray-500"
+                    x-text="' · completed ' + new Date((t.completed_at || 0) * 1000).toLocaleString()"></span>
+                </div>
+                <template x-if="t.artifact_refs && t.artifact_refs.length">
+                  <div class="mt-2 text-xs text-gray-300">
+                    <span class="text-gray-500">Artifacts:</span>
+                    <template x-for="ref in t.artifact_refs" :key="ref">
+                      <code class="ml-1 px-1.5 py-0.5 rounded bg-gray-900/60 text-gray-200" x-text="ref"></code>
+                    </template>
+                  </div>
+                </template>
+              </div>
+            </template>
+          </div>
+        </template>
+      </div>
+
       <!-- System (Activity + Costs + Automation + Integrations + API Keys + Wallet + Storage + Audit + Settings) -->
       <div x-show="activeTab === 'system'" x-cloak>
         <!-- System sub-tab bar -->
@@ -4812,6 +4997,48 @@
                 <svg class="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="2"><path d="M3 12a9 9 0 1 0 9-9 9.75 9.75 0 0 0-6.74 2.74L3 8"/><path d="M3 3v5h5"/></svg>
                 Restart
               </button>
+            </div>
+          </div>
+
+          <!-- Task 9 — Pending actions review panel.
+               Lists every open propose-edit nonce so the human operator
+               can confirm or cancel before the action lands. CSRF on
+               POST is auto-injected by app.js. -->
+          <div class="bg-gray-900 border border-gray-800 rounded-lg p-5"
+               x-init="loadWorkplacePending(); $watch('systemTab', v => { if (v === 'operator') loadWorkplacePending(); })">
+            <div class="flex items-center justify-between mb-4">
+              <div>
+                <h3 class="text-sm font-medium text-gray-200">Pending actions</h3>
+                <p class="text-[10px] text-gray-500 mt-0.5">Operator-proposed edits awaiting human confirmation</p>
+              </div>
+              <button @click="loadWorkplacePending()" class="text-xs px-2.5 py-1 rounded bg-gray-800 hover:bg-gray-700 text-gray-400 hover:text-white transition-colors">Refresh</button>
+            </div>
+            <div x-show="!workplacePending.length" class="text-center py-6 text-gray-600 text-xs">
+              No pending actions. Proposed edits and destructive deletes will surface here for review.
+            </div>
+            <div x-show="workplacePending.length" class="space-y-2">
+              <template x-for="p in workplacePending" :key="p.nonce">
+                <div class="bg-gray-800/40 border border-gray-700/50 rounded-md p-3">
+                  <div class="flex items-center justify-between mb-1">
+                    <div class="text-xs text-gray-300">
+                      <span class="font-medium" x-text="p.action_kind"></span>
+                      <span class="text-gray-500 ml-1" x-text="' on ' + (p.target_kind || '?') + ' ' + (p.target_id || '?')"></span>
+                    </div>
+                    <div class="text-[11px] text-gray-500" x-text="'expires in ' + workplaceFormatExpiry(p.expires_at)"></div>
+                  </div>
+                  <div class="text-[11px] text-gray-500 mb-2" x-text="'proposed by ' + (p.actor || '?')"></div>
+                  <div class="flex gap-2">
+                    <button @click="confirmPendingAction(p.nonce)"
+                      class="text-[11px] px-2.5 py-1 rounded bg-emerald-700/40 hover:bg-emerald-700/60 text-emerald-200 transition-colors">
+                      Confirm
+                    </button>
+                    <button @click="cancelPendingAction(p.nonce)"
+                      class="text-[11px] px-2.5 py-1 rounded bg-gray-700 hover:bg-gray-600 text-gray-300 transition-colors">
+                      Cancel
+                    </button>
+                  </div>
+                </div>
+              </template>
             </div>
           </div>
 

--- a/src/host/orchestration.py
+++ b/src/host/orchestration.py
@@ -90,10 +90,17 @@ class Tasks:
         db_path: str,
         *,
         retention_seconds: int = DEFAULT_RETENTION_SECONDS,
+        event_bus=None,
     ):
         self.db_path = db_path
         self.retention_seconds = retention_seconds
         self._shared_conn: sqlite3.Connection | None = None
+        # Task 9 — optional EventBus for surfacing task lifecycle to the
+        # dashboard. Wired in by ``create_mesh_app`` after construction
+        # via :meth:`set_event_bus` so callers that build the store
+        # eagerly (tests, the legacy in-memory shim path) don't need to
+        # pass a bus.
+        self._event_bus = event_bus
         # In-memory mode keeps a long-lived connection so schema and rows
         # survive across calls inside a single process (mirrors
         # ``PendingActions``).
@@ -107,6 +114,30 @@ class Tasks:
         # connection.
         self._mem_lock = threading.Lock()
         self._init_schema()
+
+    def set_event_bus(self, bus) -> None:
+        """Attach (or replace) the EventBus used for dashboard events.
+
+        Mirrors the ``Blackboard``/``HealthMonitor`` integration pattern.
+        Idempotent — safe to call multiple times. Pass ``None`` to detach.
+        """
+        self._event_bus = bus
+
+    def _safe_emit(self, event_type: str, agent: str, data: dict) -> None:
+        """Emit a dashboard event, swallowing failures.
+
+        The bus is best-effort decoration on top of the durable SQLite
+        write — if emission fails (no bus, bus raises, dashboard is
+        offline) the underlying task transaction has already committed
+        and we must not propagate the error.
+        """
+        bus = self._event_bus
+        if bus is None:
+            return
+        try:
+            bus.emit(event_type, agent=agent, data=data)
+        except Exception as e:
+            logger.debug("Tasks event emit failed (%s): %s", event_type, e)
 
     @contextmanager
     def _conn(self):
@@ -292,6 +323,21 @@ class Tasks:
                     "project_id": project_id,
                 },
             )
+        # Task 9 — surface to the dashboard. Compact payload (title, no
+        # description) so WS frames stay small.
+        self._safe_emit(
+            "task_created",
+            agent=creator,
+            data={
+                "task_id": tid,
+                "project_id": project_id,
+                "creator": creator,
+                "assignee": assignee,
+                "title": title,
+                "status": "pending",
+                "created_at": now,
+            },
+        )
         return self.get(tid)  # type: ignore[return-value]
 
     def get(self, task_id: str) -> dict | None:
@@ -400,16 +446,20 @@ class Tasks:
         if status not in VALID_STATUSES:
             raise ValueError(f"unknown status: {status!r}")
         now = time.time()
+        # Captured outside the txn so the event-emit (which goes through
+        # the bus / asyncio loop) doesn't run while we hold BEGIN IMMEDIATE.
+        emitted_change: tuple[str, str, str | None, str | None] | None = None
         with self._conn() as conn:
             conn.execute("BEGIN IMMEDIATE")
             try:
                 row = conn.execute(
-                    "SELECT status FROM tasks WHERE id=?", (task_id,),
+                    "SELECT status, project_id, assignee FROM tasks WHERE id=?",
+                    (task_id,),
                 ).fetchone()
                 if not row:
                     conn.execute("ROLLBACK")
                     raise TaskNotFound(task_id)
-                current = row[0]
+                current, project_id, assignee = row[0], row[1], row[2]
                 if current == status:
                     # No-op transition. Record the event so the audit
                     # trail still shows the call, but skip the row update.
@@ -451,11 +501,27 @@ class Tasks:
                     },
                 )
                 conn.execute("COMMIT")
+                emitted_change = (current, status, project_id, assignee)
             except (TaskNotFound, InvalidStatusTransition):
                 raise
             except Exception:
                 conn.execute("ROLLBACK")
                 raise
+        if emitted_change is not None:
+            old_status, new_status, project_id, assignee = emitted_change
+            self._safe_emit(
+                "task_status_changed",
+                agent=actor,
+                data={
+                    "task_id": task_id,
+                    "project_id": project_id,
+                    "assignee": assignee,
+                    "old_status": old_status,
+                    "new_status": new_status,
+                    "actor": actor,
+                    "ts": now,
+                },
+            )
         return self.get(task_id)  # type: ignore[return-value]
 
     def reroute(
@@ -465,17 +531,18 @@ class Tasks:
         if not new_assignee:
             raise ValueError("new_assignee is required")
         now = time.time()
+        emitted: tuple[str, str | None] | None = None
         with self._conn() as conn:
             conn.execute("BEGIN IMMEDIATE")
             try:
                 row = conn.execute(
-                    "SELECT assignee, status FROM tasks WHERE id=?",
+                    "SELECT assignee, status, project_id FROM tasks WHERE id=?",
                     (task_id,),
                 ).fetchone()
                 if not row:
                     conn.execute("ROLLBACK")
                     raise TaskNotFound(task_id)
-                old_assignee, current_status = row
+                old_assignee, current_status, project_id = row
                 if current_status in TERMINAL_STATUSES:
                     conn.execute("ROLLBACK")
                     raise InvalidStatusTransition(
@@ -490,11 +557,31 @@ class Tasks:
                     {"from": old_assignee, "to": new_assignee, "reason": reason},
                 )
                 conn.execute("COMMIT")
+                emitted = (current_status, project_id)
             except (TaskNotFound, InvalidStatusTransition):
                 raise
             except Exception:
                 conn.execute("ROLLBACK")
                 raise
+        if emitted is not None:
+            current_status, project_id = emitted
+            # Task 9 — reroute is a status_changed event with old==new
+            # status; the assignee field carries the *new* assignee so
+            # the dashboard sees who picked up the work. The audit row
+            # already records ``rerouted`` separately for full history.
+            self._safe_emit(
+                "task_status_changed",
+                agent=actor,
+                data={
+                    "task_id": task_id,
+                    "project_id": project_id,
+                    "assignee": new_assignee,
+                    "old_status": current_status,
+                    "new_status": current_status,
+                    "actor": actor,
+                    "ts": now,
+                },
+            )
         return self.get(task_id)  # type: ignore[return-value]
 
     def cancel(

--- a/src/host/pending_actions.py
+++ b/src/host/pending_actions.py
@@ -62,8 +62,13 @@ class PendingActions:
     so two simultaneous consumers serialize and only one wins.
     """
 
-    def __init__(self, db_path: str):
+    def __init__(self, db_path: str, *, event_bus=None):
         self.db_path = db_path
+        # Task 9 — optional EventBus for surfacing pending-action
+        # lifecycle to the dashboard. Wired in by ``create_mesh_app``
+        # via :meth:`set_event_bus` (legacy callers in ``server.py``
+        # construct the store before the app builds the bus).
+        self._event_bus = event_bus
         # ``:memory:`` SQLite databases are per-connection -- closing
         # and reopening loses everything. Keep a single long-lived
         # connection for in-memory mode (used in tests + the legacy
@@ -75,6 +80,29 @@ class PendingActions:
             )
             self._shared_conn.execute("PRAGMA busy_timeout=30000")
         self._init_schema()
+
+    def set_event_bus(self, bus) -> None:
+        """Attach (or replace) the EventBus used for dashboard events.
+
+        Mirrors the ``Tasks``/``Blackboard`` integration pattern.
+        Idempotent — pass ``None`` to detach.
+        """
+        self._event_bus = bus
+
+    def _safe_emit(self, event_type: str, agent: str, data: dict) -> None:
+        """Emit a dashboard event, swallowing failures.
+
+        Pending-action mutations are durable in SQLite; the bus emit is a
+        best-effort decoration on top of the commit, so a missing bus or
+        an emit failure must not propagate.
+        """
+        bus = self._event_bus
+        if bus is None:
+            return
+        try:
+            bus.emit(event_type, agent=agent, data=data)
+        except Exception as e:
+            logger.debug("PendingActions event emit failed (%s): %s", event_type, e)
 
     @contextmanager
     def _conn(self):
@@ -163,6 +191,20 @@ class PendingActions:
                     now, expires_at,
                 ),
             )
+        # Task 9 — surface to the dashboard so the System > Operator
+        # panel and the inline chat bubble render the new pending nonce.
+        self._safe_emit(
+            "pending_action_created",
+            agent=actor,
+            data={
+                "nonce": nonce,
+                "actor": actor,
+                "target_kind": target_kind,
+                "target_id": target_id,
+                "action_kind": action_kind,
+                "expires_at": expires_at,
+            },
+        )
         return {
             "nonce": nonce,
             "actor": actor,
@@ -277,6 +319,23 @@ class PendingActions:
             except Exception:
                 conn.execute("ROLLBACK")
                 raise
+        # Task 9 — emit only on successful consume (the row is gone). The
+        # ``status="confirmed"`` payload field distinguishes this from the
+        # ``cancelled`` path emitted by :meth:`cancel`.
+        resolver = confirmer or row[0]
+        self._safe_emit(
+            "pending_action_resolved",
+            agent=resolver,
+            data={
+                "nonce": nonce,
+                "target_kind": row[1],
+                "target_id": row[2],
+                "action_kind": row[3],
+                "status": "confirmed",
+                "resolver": resolver,
+                "ts": time.time(),
+            },
+        )
         return {
             "nonce": nonce,
             "actor": row[0],
@@ -291,16 +350,117 @@ class PendingActions:
             "status": "consumed",
         }
 
+    def cancel(
+        self,
+        nonce: str,
+        *,
+        actor: str | None = None,
+    ) -> dict | None:
+        """Atomically delete a pending action without applying it.
+
+        Used by the Task 9 ``/mesh/pending/{nonce}/cancel`` endpoint and
+        the dashboard's "Cancel" button. Mirrors :meth:`consume` but
+        without the digest / origin / actor gates: cancelling is the
+        operator's escape hatch — they're abandoning the proposed change.
+
+        Returns the record that was cancelled (so the caller can log
+        what was abandoned), or None if the nonce was unknown / already
+        expired. Emits ``pending_action_resolved`` with
+        ``status="cancelled"`` on success so the dashboard can clear
+        the panel and the inline chat bubble.
+        """
+        with self._conn() as conn:
+            conn.execute("BEGIN IMMEDIATE")
+            try:
+                row = conn.execute(
+                    "SELECT actor, target_kind, target_id, action_kind, "
+                    "payload_json, payload_digest, origin_kind, created_at, "
+                    "expires_at, status FROM pending_actions WHERE nonce=?",
+                    (nonce,),
+                ).fetchone()
+                if not row:
+                    conn.execute("COMMIT")
+                    return None
+                if time.time() > row[8]:
+                    # Expired — drop the row and report as None so the
+                    # caller can distinguish "still pending" from "gone".
+                    conn.execute(
+                        "DELETE FROM pending_actions WHERE nonce=?", (nonce,),
+                    )
+                    conn.execute("COMMIT")
+                    return None
+                conn.execute(
+                    "DELETE FROM pending_actions WHERE nonce=?", (nonce,),
+                )
+                conn.execute("COMMIT")
+            except Exception:
+                conn.execute("ROLLBACK")
+                raise
+        resolver = actor or row[0]
+        self._safe_emit(
+            "pending_action_resolved",
+            agent=resolver,
+            data={
+                "nonce": nonce,
+                "target_kind": row[1],
+                "target_id": row[2],
+                "action_kind": row[3],
+                "status": "cancelled",
+                "resolver": resolver,
+                "ts": time.time(),
+            },
+        )
+        return {
+            "nonce": nonce,
+            "actor": row[0],
+            "target_kind": row[1],
+            "target_id": row[2],
+            "action_kind": row[3],
+            "payload": json.loads(row[4]),
+            "payload_digest": row[5],
+            "origin_kind": row[6],
+            "created_at": row[7],
+            "expires_at": row[8],
+            "status": "cancelled",
+        }
+
     # ── Maintenance / surfacing ────────────────────────────────────
 
     def reap_expired(self) -> int:
-        """Delete every row past its expiry. Returns count deleted."""
+        """Delete every row past its expiry. Returns count deleted.
+
+        Task 9 — capture (target_kind, target_id, action_kind, nonce)
+        of each row being dropped so the dashboard can render an
+        ``pending_action_expired`` event per nonce. We snapshot before
+        the DELETE so the emit list reflects what actually went away.
+        """
+        now = time.time()
         with self._conn() as conn:
+            rows = conn.execute(
+                "SELECT nonce, target_kind, target_id, action_kind "
+                "FROM pending_actions WHERE expires_at < ?",
+                (now,),
+            ).fetchall()
             cur = conn.execute(
                 "DELETE FROM pending_actions WHERE expires_at < ?",
-                (time.time(),),
+                (now,),
             )
-            return cur.rowcount
+            count = cur.rowcount
+        # Emit outside the SQLite txn so a slow listener never holds the
+        # connection. ``_safe_emit`` swallows individual failures.
+        for nonce, target_kind, target_id, action_kind in rows:
+            self._safe_emit(
+                "pending_action_expired",
+                agent="",
+                data={
+                    "nonce": nonce,
+                    "target_kind": target_kind,
+                    "target_id": target_id,
+                    "action_kind": action_kind,
+                    "expired_at": now,
+                },
+            )
+        return count
 
     def _safe_reap(self) -> None:
         """Reap-expired wrapper that never raises in a request path."""

--- a/src/host/server.py
+++ b/src/host/server.py
@@ -535,6 +535,10 @@ def create_mesh_app(
     app.pending_actions = pending_actions  # exposed for tests/dashboard
     global _pending_actions_singleton
     _pending_actions_singleton = pending_actions
+    # Task 9 — wire EventBus so store/consume/cancel/reap_expired emit
+    # ``pending_action_*`` events to the dashboard.
+    if event_bus is not None:
+        pending_actions.set_event_bus(event_bus)
 
     # Task 6: durable orchestration task records. The store is only
     # constructed when the feature flag is on; when off, the new
@@ -549,6 +553,10 @@ def create_mesh_app(
         )
         tasks_store = Tasks(db_path=_tasks_db_path)
     app.tasks_store = tasks_store  # exposed for tests/dashboard
+    # Task 9 — wire EventBus so create / update_status / reroute /
+    # cancel emit ``task_*`` events to the dashboard.
+    if tasks_store is not None and event_bus is not None:
+        tasks_store.set_event_bus(event_bus)
 
     _auth_tokens = auth_tokens if auth_tokens is not None else {}
     _agent_projects = agent_projects if agent_projects is not None else {}
@@ -4471,6 +4479,82 @@ def create_mesh_app(
         return await _apply_pending_change(
             change_id, _record_to_legacy_change(record),
         )
+
+    # === Task 9 — Pending action review surface ===
+    #
+    # The dashboard's System > Operator panel and the inline chat
+    # bubble both call these endpoints. Confirm wraps the existing
+    # ``/mesh/config/confirm`` path; cancel is the additive escape
+    # hatch (delete-without-apply) backed by ``PendingActions.cancel``.
+    # Both inherit CSRF protection (X-Requested-With) from the
+    # dashboard's fetch wrapper and the `_csrf_check` middleware.
+
+    @app.get("/mesh/pending")
+    async def list_pending_actions(request: Request) -> dict:
+        """List every non-expired pending action.
+
+        Operator-or-internal only. Reaps expired rows on the read so
+        the response is immediately accurate. Each row is shape-compatible
+        with the dashboard's existing pending-edit display logic.
+        """
+        _require_operator_or_internal(request)
+        pending_actions.reap_expired()
+        rows = pending_actions.list_pending()
+        return {"pending": rows}
+
+    @app.post("/mesh/pending/{nonce}/confirm")
+    async def pending_confirm(nonce: str, request: Request) -> dict:
+        """Confirm a pending action by nonce.
+
+        Thin wrapper over the existing ``/mesh/config/confirm`` flow:
+        injects ``change_id=nonce`` into the body and dispatches to
+        :func:`confirm_config_change`. Keeps the new surface stable
+        without duplicating the destructive-vs-edit branch logic.
+        """
+        # Resolve and inject the nonce so the underlying confirm
+        # handler reads it from the body the same way the legacy
+        # callers do.
+        body = {}
+        try:
+            body = await request.json()
+        except Exception:
+            body = {}
+        body["change_id"] = nonce
+
+        async def _receive():
+            return {
+                "type": "http.request",
+                "body": json.dumps(body).encode("utf-8"),
+                "more_body": False,
+            }
+
+        # Build a shallow copy of the request with the rewritten body.
+        from starlette.requests import Request as _StarletteRequest
+        forwarded = _StarletteRequest(request.scope, _receive)
+        return await confirm_config_change(forwarded)
+
+    @app.post("/mesh/pending/{nonce}/cancel")
+    async def pending_cancel(nonce: str, request: Request) -> dict:
+        """Cancel a pending action by nonce.
+
+        Operator-or-internal only. Calls ``PendingActions.cancel`` which
+        deletes the row + emits ``pending_action_resolved`` with
+        ``status="cancelled"`` so the dashboard panel and chat bubble
+        clear immediately.
+        """
+        caller = _extract_verified_agent_id(request)
+        if caller != "operator" and not _is_internal_caller(request):
+            raise HTTPException(403, "Only the operator can cancel pending actions")
+        record = pending_actions.cancel(nonce, actor=caller or "operator")
+        if record is None:
+            raise HTTPException(404, "Pending action not found or already expired")
+        return {
+            "ok": True,
+            "nonce": nonce,
+            "target_kind": record["target_kind"],
+            "target_id": record["target_id"],
+            "action_kind": record["action_kind"],
+        }
 
     # === Browser Service Proxy ===
 

--- a/src/shared/types.py
+++ b/src/shared/types.py
@@ -567,6 +567,18 @@ class DashboardEvent(BaseModel):
         # DashboardEvent rejects the emit and the panel never renders.
         "browser_metrics",
         "browser_nav_probe",
+        # Task 9 — Workplace tab + pending-action review surfaces.
+        # ``task_*`` are emitted from ``host/orchestration.py`` (Tasks
+        # store) on create / status_change / reroute / cancel.
+        # ``pending_action_*`` are emitted from ``host/pending_actions.py``
+        # on store / consume(success) / reap_expired so the dashboard's
+        # System > Operator panel and inline chat bubbles render the
+        # operator's review queue without polling.
+        "task_created",
+        "task_status_changed",
+        "pending_action_created",
+        "pending_action_resolved",
+        "pending_action_expired",
     ]
     agent: str = ""
     timestamp: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))

--- a/tests/test_cli_commands.py
+++ b/tests/test_cli_commands.py
@@ -1457,3 +1457,149 @@ class TestREPLOriginStamp:
         assert parsed.kind == "human"
         assert parsed.channel == "cli"
         assert parsed.user == "alice"
+
+
+# === Task 9 — Workplace + pending-action CLI commands ===
+
+
+class TestWorkplaceCLICommands:
+    """``openlegion projects / project / tasks / pending / confirm /
+    cancel`` shell out to the local mesh over httpx — patch the client
+    to assert the right path and shape are returned to stdout."""
+
+    def _patched_get(self, payload, status=200):
+        """Return a context-managed ``patch`` that fakes ``httpx.get``."""
+        from unittest.mock import MagicMock
+
+        resp = MagicMock()
+        resp.status_code = status
+        resp.json.return_value = payload
+        resp.text = json.dumps(payload)
+        return patch("httpx.get", return_value=resp)
+
+    def _patched_post(self, payload, status=200):
+        from unittest.mock import MagicMock
+
+        resp = MagicMock()
+        resp.status_code = status
+        resp.json.return_value = payload
+        resp.text = json.dumps(payload)
+        return patch("httpx.post", return_value=resp)
+
+    def test_projects_command_renders_table(self):
+        runner = CliRunner()
+        with self._patched_get({"projects": [
+            {"name": "research", "status": "active", "total": 3,
+             "members": ["alpha", "beta"], "counts": {"working": 2}},
+        ]}):
+            result = runner.invoke(cli, ["projects"])
+        assert result.exit_code == 0
+        assert "research" in result.output
+        assert "active" in result.output
+
+    def test_projects_command_json_mode(self):
+        runner = CliRunner()
+        with self._patched_get({"projects": [{"name": "research", "status": "active", "total": 0}]}):
+            result = runner.invoke(cli, ["--json", "projects"])
+        assert result.exit_code == 0
+        payload = json.loads(result.output)
+        assert payload["projects"][0]["name"] == "research"
+
+    def test_project_command_shows_one(self):
+        runner = CliRunner()
+        body = {"projects": [
+            {"name": "research", "status": "active", "total": 1,
+             "description": "deep dive", "members": ["alpha"],
+             "counts": {"pending": 1}, "blockers": []},
+        ]}
+        with self._patched_get(body):
+            result = runner.invoke(cli, ["project", "research"])
+        assert result.exit_code == 0
+        assert "research" in result.output
+        assert "deep dive" in result.output
+
+    def test_project_command_unknown_exits_1(self):
+        runner = CliRunner()
+        with self._patched_get({"projects": []}):
+            result = runner.invoke(cli, ["project", "missing"])
+        assert result.exit_code == 1
+        assert "not found" in result.output.lower()
+
+    def test_tasks_command_table_render(self):
+        runner = CliRunner()
+        body = {"enabled": True, "tasks": [
+            {"id": "task_abc", "status": "working", "assignee": "alpha",
+             "project_id": "research", "title": "dig"},
+        ]}
+        with self._patched_get(body):
+            result = runner.invoke(cli, ["tasks"])
+        assert result.exit_code == 0
+        assert "task_abc" in result.output
+        assert "working" in result.output
+
+    def test_tasks_command_disabled_state(self):
+        runner = CliRunner()
+        body = {"enabled": False, "tasks": [],
+                "hint": "Set OPENLEGION_ORCHESTRATION_TASKS_V2=1"}
+        with self._patched_get(body):
+            result = runner.invoke(cli, ["tasks"])
+        assert result.exit_code == 0
+        assert "disabled" in result.output.lower()
+
+    def test_pending_command_table(self):
+        runner = CliRunner()
+        body = {"pending": [
+            {"nonce": "n1", "actor": "operator", "action_kind": "model",
+             "target_kind": "agent", "target_id": "alpha"},
+        ]}
+        with self._patched_get(body):
+            result = runner.invoke(cli, ["pending"])
+        assert result.exit_code == 0
+        assert "n1" in result.output
+        assert "model" in result.output
+
+    def test_pending_command_empty(self):
+        runner = CliRunner()
+        with self._patched_get({"pending": []}):
+            result = runner.invoke(cli, ["pending"])
+        assert result.exit_code == 0
+        assert "No pending" in result.output
+
+    def test_confirm_command_calls_mesh(self):
+        runner = CliRunner()
+        with self._patched_post({"success": True}) as m:
+            result = runner.invoke(cli, ["confirm", "abc-nonce"])
+        assert result.exit_code == 0
+        assert "Confirmed" in result.output
+        assert "abc-nonce" in result.output
+        # URL should be the mesh confirm endpoint
+        called_url = m.call_args.args[0]
+        assert "/mesh/pending/abc-nonce/confirm" in called_url
+
+    def test_confirm_command_propagates_error(self):
+        runner = CliRunner()
+        with self._patched_post({"detail": "expired"}, status=400):
+            result = runner.invoke(cli, ["confirm", "abc-nonce"])
+        assert result.exit_code == 1
+
+    def test_cancel_command_calls_mesh(self):
+        runner = CliRunner()
+        with self._patched_post({"ok": True, "nonce": "abc"}) as m:
+            result = runner.invoke(cli, ["cancel", "abc"])
+        assert result.exit_code == 0
+        assert "Cancelled" in result.output
+        called_url = m.call_args.args[0]
+        assert "/mesh/pending/abc/cancel" in called_url
+
+    def test_cancel_command_includes_csrf_header(self):
+        """The CLI commands must inject X-Requested-With so the dashboard
+        CSRF gate doesn't reject the request."""
+        runner = CliRunner()
+        with self._patched_post({"ok": True, "nonce": "abc"}) as m:
+            runner.invoke(cli, ["cancel", "abc"])
+        kwargs = m.call_args.kwargs
+        headers = kwargs.get("headers") or {}
+        assert headers.get("X-Requested-With") == "XMLHttpRequest"
+        # And X-Origin so the human-confirmation gate accepts it
+        assert "kind=human" in headers.get("X-Origin", "")
+        assert "channel=cli" in headers.get("X-Origin", "")

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -4507,3 +4507,161 @@ class TestDashboardOriginStamp:
         assert isinstance(origin, MessageOrigin)
         assert origin.kind == "human"
         assert origin.channel == "dashboard"
+
+
+# === Task 9 — Workplace tab + pending action review ===
+
+
+class TestWorkplaceTabRoutes:
+    """Verify the new /api/workplace/* endpoints respond with the right
+    shape for both ``OPENLEGION_ORCHESTRATION_TASKS_V2=0`` (empty state)
+    and the v2-on / store-attached case (real data)."""
+
+    def setup_method(self):
+        self._tmpdir = tempfile.mkdtemp()
+        self.components = _make_components(self._tmpdir)
+        # The Workplace surface is independent of the v2-included extras
+        # so we don't use include_v2=True; we attach the stores directly.
+        from src.host.orchestration import Tasks
+        from src.host.pending_actions import PendingActions
+        self.tasks_store = Tasks(db_path=os.path.join(self._tmpdir, "tasks.db"))
+        self.pending_actions = PendingActions(
+            db_path=os.path.join(self._tmpdir, "pa.db"),
+        )
+        self.components["tasks_store"] = self.tasks_store
+        self.components["pending_actions"] = self.pending_actions
+
+    def teardown_method(self):
+        try:
+            self.tasks_store.close()
+        except Exception:
+            pass
+        try:
+            self.pending_actions.close()
+        except Exception:
+            pass
+        _teardown(self.components)
+        shutil.rmtree(self._tmpdir, ignore_errors=True)
+        os.environ.pop("OPENLEGION_ORCHESTRATION_TASKS_V2", None)
+
+    def _set_v2(self, enabled: bool):
+        """Set the runtime flag on the live env. Caller is responsible
+        for restoring it via ``teardown_method``'s shutil cleanup of the
+        tmp_path or via ``self._restore_v2()`` when running multiple
+        clients in one test.
+        """
+        if enabled:
+            os.environ["OPENLEGION_ORCHESTRATION_TASKS_V2"] = "1"
+        else:
+            os.environ["OPENLEGION_ORCHESTRATION_TASKS_V2"] = "0"
+
+    def _client_with_v2(self, enabled: bool):
+        self._set_v2(enabled)
+        return _make_client(self.components)
+
+    def test_workplace_tasks_empty_state_when_v2_off(self):
+        client = self._client_with_v2(False)
+        resp = client.get("/dashboard/api/workplace/tasks")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["enabled"] is False
+        assert data["tasks"] == []
+        assert "OPENLEGION_ORCHESTRATION_TASKS_V2" in data["hint"]
+
+    def test_workplace_tasks_returns_rows_when_v2_on(self):
+        client = self._client_with_v2(True)
+        rec = self.tasks_store.create(
+            creator="operator", assignee="alpha", title="dig",
+            project_id="research",
+        )
+        resp = client.get("/dashboard/api/workplace/tasks")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["enabled"] is True
+        ids = [t["id"] for t in data["tasks"]]
+        assert rec["id"] in ids
+
+    def test_workplace_tasks_filter_by_assignee(self):
+        client = self._client_with_v2(True)
+        self.tasks_store.create(creator="op", assignee="alpha", title="A")
+        self.tasks_store.create(creator="op", assignee="beta", title="B")
+        resp = client.get("/dashboard/api/workplace/tasks?assignee=alpha")
+        assert resp.status_code == 200
+        rows = resp.json()["tasks"]
+        assert all(r["assignee"] == "alpha" for r in rows)
+
+    def test_workplace_projects_empty_state(self):
+        client = self._client_with_v2(False)
+        resp = client.get("/dashboard/api/workplace/projects")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["enabled"] is False
+        assert data["projects"] == []
+
+    def test_workplace_blockers_empty_state(self):
+        client = self._client_with_v2(False)
+        resp = client.get("/dashboard/api/workplace/blockers")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["enabled"] is False
+        assert data["blockers"] == []
+
+    def test_workplace_blockers_returns_blocked_tasks(self):
+        client = self._client_with_v2(True)
+        rec = self.tasks_store.create(
+            creator="op", assignee="alpha", title="stuck",
+        )
+        self.tasks_store.update_status(rec["id"], "working", actor="alpha")
+        self.tasks_store.update_status(
+            rec["id"], "blocked", actor="alpha",
+            blocker_note="needs creds",
+        )
+        resp = client.get("/dashboard/api/workplace/blockers")
+        assert resp.status_code == 200
+        rows = resp.json()["blockers"]
+        assert any(r["id"] == rec["id"] for r in rows)
+
+    def test_workplace_outputs_returns_done_tasks(self):
+        client = self._client_with_v2(True)
+        rec = self.tasks_store.create(
+            creator="op", assignee="alpha", title="done one",
+            project_id="research",
+        )
+        self.tasks_store.update_status(rec["id"], "working", actor="alpha")
+        self.tasks_store.update_status(rec["id"], "done", actor="alpha")
+        resp = client.get("/dashboard/api/workplace/outputs?project_id=research")
+        assert resp.status_code == 200
+        rows = resp.json()["outputs"]
+        assert any(r["id"] == rec["id"] for r in rows)
+
+    def test_workplace_pending_lists_open_nonces(self):
+        # No need for v2 — pending list is independent of orchestration.
+        client = self._client_with_v2(False)
+        self.pending_actions.store(
+            nonce="n1", actor="operator", target_kind="agent",
+            target_id="alpha", action_kind="model", payload={"x": 1},
+        )
+        resp = client.get("/dashboard/api/workplace/pending")
+        assert resp.status_code == 200
+        rows = resp.json()["pending"]
+        assert any(r["nonce"] == "n1" for r in rows)
+
+    def test_workplace_pending_cancel_succeeds(self):
+        client = self._client_with_v2(False)
+        self.pending_actions.store(
+            nonce="n1", actor="operator", target_kind="agent",
+            target_id="alpha", action_kind="model", payload={"x": 1},
+        )
+        resp = client.post("/dashboard/api/workplace/pending/n1/cancel")
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["ok"] is True
+        assert body["nonce"] == "n1"
+        # Row gone — second cancel returns 404.
+        resp2 = client.post("/dashboard/api/workplace/pending/n1/cancel")
+        assert resp2.status_code == 404
+
+    def test_workplace_pending_cancel_unknown_returns_404(self):
+        client = self._client_with_v2(False)
+        resp = client.post("/dashboard/api/workplace/pending/missing/cancel")
+        assert resp.status_code == 404

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -34,6 +34,29 @@ def test_dashboard_event_invalid_type():
         DashboardEvent(type="invalid_type")
 
 
+def test_dashboard_event_task_9_event_types_accepted():
+    """Task 9 — five new Workplace + pending-action types are accepted."""
+    new_types = [
+        "task_created",
+        "task_status_changed",
+        "pending_action_created",
+        "pending_action_resolved",
+        "pending_action_expired",
+    ]
+    for t in new_types:
+        evt = DashboardEvent(type=t, agent="operator", data={"key": "v"})
+        assert evt.type == t
+
+
+def test_dashboard_event_task_9_typo_rejected():
+    """A typo'd Task 9 type still trips validation — guards against
+    silent emit of typoed event names."""
+    with pytest.raises(Exception):
+        DashboardEvent(type="task_creates")  # missing 'd'
+    with pytest.raises(Exception):
+        DashboardEvent(type="pending_action_create")  # missing 'd'
+
+
 def test_dashboard_event_serialization():
     """DashboardEvent serializes to JSON-compatible dict."""
     evt = DashboardEvent(type="llm_call", agent="a1", data={"model": "gpt-4o"})

--- a/tests/test_orchestration.py
+++ b/tests/test_orchestration.py
@@ -445,3 +445,101 @@ def test_valid_statuses_constant():
     assert "pending" in VALID_STATUSES
     assert "done" in VALID_STATUSES
     assert "bogus" not in VALID_STATUSES
+
+
+# ── Task 9 — EventBus integration ─────────────────────────────────
+
+
+def _attach_event_bus(store):
+    """Attach a fresh ``EventBus`` and return ``(bus, captured)`` where
+    ``captured`` is a list of (type, agent, data) tuples for assertion.
+    """
+    from src.dashboard.events import EventBus
+    bus = EventBus()
+    captured: list[tuple[str, str, dict]] = []
+
+    class _Recorder:
+        def emit(self, event_type, agent="", data=None):
+            captured.append((event_type, agent, dict(data or {})))
+            bus.emit(event_type, agent=agent, data=data or {})
+
+    store.set_event_bus(_Recorder())
+    return bus, captured
+
+
+def test_event_bus_emits_task_created(tmp_path):
+    """``Tasks.create`` emits ``task_created`` with the documented payload."""
+    t = _make_store(tmp_path)
+    _bus, captured = _attach_event_bus(t)
+    rec = t.create(creator="scout", assignee="analyst", title="dig")
+    types = [c[0] for c in captured]
+    assert "task_created" in types
+    evt = next(c for c in captured if c[0] == "task_created")
+    assert evt[1] == "scout"  # agent = creator
+    assert evt[2]["task_id"] == rec["id"]
+    assert evt[2]["creator"] == "scout"
+    assert evt[2]["assignee"] == "analyst"
+    assert evt[2]["title"] == "dig"
+    assert evt[2]["status"] == "pending"
+
+
+def test_event_bus_emits_task_status_changed(tmp_path):
+    """``Tasks.update_status`` emits ``task_status_changed``."""
+    t = _make_store(tmp_path)
+    _bus, captured = _attach_event_bus(t)
+    rec = t.create(creator="scout", assignee="analyst", title="dig")
+    captured.clear()
+    t.update_status(rec["id"], "accepted", actor="analyst")
+    types = [c[0] for c in captured]
+    assert types == ["task_status_changed"]
+    evt = captured[0]
+    assert evt[2]["task_id"] == rec["id"]
+    assert evt[2]["old_status"] == "pending"
+    assert evt[2]["new_status"] == "accepted"
+    assert evt[2]["actor"] == "analyst"
+
+
+def test_event_bus_no_emit_on_no_op_status_transition(tmp_path):
+    """Repeating a status doesn't emit (the no-op branch)."""
+    t = _make_store(tmp_path)
+    _bus, captured = _attach_event_bus(t)
+    rec = t.create(creator="scout", assignee="analyst", title="dig")
+    captured.clear()
+    t.update_status(rec["id"], "pending", actor="scout")
+    assert not [c for c in captured if c[0] == "task_status_changed"]
+
+
+def test_event_bus_emits_on_reroute(tmp_path):
+    t = _make_store(tmp_path)
+    _bus, captured = _attach_event_bus(t)
+    rec = t.create(creator="scout", assignee="analyst", title="dig")
+    captured.clear()
+    t.reroute(rec["id"], "writer", actor="operator")
+    types = [c[0] for c in captured]
+    assert "task_status_changed" in types
+    evt = next(c for c in captured if c[0] == "task_status_changed")
+    assert evt[2]["assignee"] == "writer"
+    assert evt[2]["actor"] == "operator"
+
+
+def test_event_bus_emits_on_cancel(tmp_path):
+    """``cancel`` chains through ``update_status('cancelled')`` and emits."""
+    t = _make_store(tmp_path)
+    _bus, captured = _attach_event_bus(t)
+    rec = t.create(creator="scout", assignee="analyst", title="dig")
+    t.update_status(rec["id"], "working", actor="analyst")
+    captured.clear()
+    t.cancel(rec["id"], actor="operator", reason="not needed")
+    types = [c[0] for c in captured]
+    assert "task_status_changed" in types
+    evt = next(c for c in captured if c[0] == "task_status_changed")
+    assert evt[2]["new_status"] == "cancelled"
+
+
+def test_event_bus_unset_disables_emit(tmp_path):
+    """Detaching the bus stops emits (without breaking the txn)."""
+    t = _make_store(tmp_path)
+    _bus, captured = _attach_event_bus(t)
+    t.set_event_bus(None)
+    t.create(creator="scout", assignee="analyst", title="dig")
+    assert captured == []

--- a/tests/test_orchestration_endpoints.py
+++ b/tests/test_orchestration_endpoints.py
@@ -403,3 +403,53 @@ async def test_events_endpoint_returns_audit_history(v2_app):
         assert r.status_code == 200
         kinds = [e["event_kind"] for e in r.json()["events"]]
         assert kinds == ["created", "status_changed"]
+
+
+# ── Task 9 — /mesh/pending/* endpoints ─────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_pending_list_endpoint_returns_open_nonces(v2_app):
+    """``GET /mesh/pending`` returns rows from the SQLite store."""
+    app, _, _ = v2_app
+    pa = app.pending_actions
+    pa.store(
+        nonce="n-test", actor="operator", target_kind="agent",
+        target_id="alpha", action_kind="model", payload={"x": 1},
+    )
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
+        r = await c.get("/mesh/pending", headers={"X-Mesh-Internal": "1"})
+        assert r.status_code == 200
+        rows = r.json()["pending"]
+        assert any(p["nonce"] == "n-test" for p in rows)
+
+
+@pytest.mark.asyncio
+async def test_pending_cancel_endpoint_deletes_row(v2_app):
+    """``POST /mesh/pending/{nonce}/cancel`` deletes the row."""
+    app, _, _ = v2_app
+    pa = app.pending_actions
+    pa.store(
+        nonce="n-cancel", actor="operator", target_kind="agent",
+        target_id="alpha", action_kind="model", payload={"x": 1},
+    )
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
+        r = await c.post(
+            "/mesh/pending/n-cancel/cancel",
+            headers={"X-Agent-ID": "operator", "X-Mesh-Internal": "1"},
+        )
+        assert r.status_code == 200
+        assert r.json()["nonce"] == "n-cancel"
+    # Row gone — peek confirms.
+    assert pa.peek("n-cancel") is None
+
+
+@pytest.mark.asyncio
+async def test_pending_cancel_unknown_returns_404(v2_app):
+    app, _, _ = v2_app
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
+        r = await c.post(
+            "/mesh/pending/missing-nonce/cancel",
+            headers={"X-Agent-ID": "operator", "X-Mesh-Internal": "1"},
+        )
+        assert r.status_code == 404

--- a/tests/test_pending_actions.py
+++ b/tests/test_pending_actions.py
@@ -361,3 +361,155 @@ def test_list_pending_ordered_by_created_at(tmp_path):
     )
     rows = pa.list_pending()
     assert [r["nonce"] for r in rows] == ["first", "second"]
+
+
+# ── Task 9 — EventBus integration ─────────────────────────────────
+
+
+def _attach_recording_bus(pa):
+    """Attach a fresh recorder bus to ``pa`` and return the captured list."""
+    captured: list[tuple[str, str, dict]] = []
+
+    class _Recorder:
+        def emit(self, event_type, agent="", data=None):
+            captured.append((event_type, agent, dict(data or {})))
+
+    pa.set_event_bus(_Recorder())
+    return captured
+
+
+def test_event_bus_emits_pending_action_created_on_store(tmp_path):
+    pa = _make_store(tmp_path)
+    captured = _attach_recording_bus(pa)
+    pa.store(
+        nonce="n1", actor="operator", target_kind="agent",
+        target_id="alpha", action_kind="model", payload={"x": 1},
+        origin_kind="human",
+    )
+    types = [c[0] for c in captured]
+    assert "pending_action_created" in types
+    evt = next(c for c in captured if c[0] == "pending_action_created")
+    assert evt[1] == "operator"  # agent = actor
+    assert evt[2]["nonce"] == "n1"
+    assert evt[2]["target_kind"] == "agent"
+    assert evt[2]["target_id"] == "alpha"
+    assert evt[2]["action_kind"] == "model"
+    # expires_at is included so the dashboard can render the countdown
+    assert "expires_at" in evt[2]
+
+
+def test_event_bus_emits_pending_action_resolved_on_consume_success(tmp_path):
+    pa = _make_store(tmp_path)
+    captured = _attach_recording_bus(pa)
+    pa.store(
+        nonce="n1", actor="operator", target_kind="agent",
+        target_id="alpha", action_kind="model", payload={"x": 1},
+        origin_kind="human",
+    )
+    captured.clear()
+    rec = pa.consume("n1", confirmer="operator", require_origin_kind="human")
+    assert rec is not None
+    types = [c[0] for c in captured]
+    assert "pending_action_resolved" in types
+    evt = next(c for c in captured if c[0] == "pending_action_resolved")
+    assert evt[2]["nonce"] == "n1"
+    assert evt[2]["status"] == "confirmed"
+    assert evt[2]["resolver"] == "operator"
+
+
+def test_event_bus_does_not_emit_resolved_on_failed_consume(tmp_path):
+    """Wrong digest / wrong actor / origin mismatch must NOT emit resolved."""
+    pa = _make_store(tmp_path)
+    captured = _attach_recording_bus(pa)
+    pa.store(
+        nonce="n1", actor="operator", target_kind="agent",
+        target_id="alpha", action_kind="model", payload={"x": 1},
+        origin_kind="human",
+    )
+    captured.clear()
+    pa.consume("n1", expected_payload_digest="wrong")
+    assert not [c for c in captured if c[0] == "pending_action_resolved"]
+
+
+def test_event_bus_emits_pending_action_expired_on_reap(tmp_path):
+    pa = _make_store(tmp_path)
+    # Stage rows BEFORE attaching the recorder so the opportunistic
+    # reap that fires on the second store() doesn't drop n1 inside the
+    # bus's history (where it would be a confounder for the assertion
+    # on counts post-clear).
+    pa.store(
+        nonce="n1", actor="operator", target_kind="agent",
+        target_id="alpha", action_kind="model", payload={}, ttl=0,
+    )
+    captured = _attach_recording_bus(pa)
+    time.sleep(0.01)
+    n = pa.reap_expired()
+    assert n == 1
+    expired_events = [c for c in captured if c[0] == "pending_action_expired"]
+    assert len(expired_events) == 1
+    evt = expired_events[0]
+    assert evt[2]["nonce"] == "n1"
+    assert evt[2]["target_kind"] == "agent"
+    assert evt[2]["target_id"] == "alpha"
+    assert evt[2]["action_kind"] == "model"
+    assert "expired_at" in evt[2]
+
+
+def test_event_bus_emits_per_row_on_multi_reap(tmp_path):
+    """When multiple rows expire in one reap pass, one event per row fires."""
+    pa = _make_store(tmp_path)
+    pa.store(
+        nonce="n1", actor="operator", target_kind="agent",
+        target_id="alpha", action_kind="model", payload={}, ttl=60,
+    )
+    pa.store(
+        nonce="n2", actor="operator", target_kind="agent",
+        target_id="beta", action_kind="model", payload={}, ttl=60,
+    )
+    captured = _attach_recording_bus(pa)
+    # Force expiry by hand so the opportunistic ``_safe_reap`` doesn't
+    # drop one row early.
+    with pa._conn() as conn:
+        conn.execute("UPDATE pending_actions SET expires_at = 0 WHERE nonce IN ('n1', 'n2')")
+    n = pa.reap_expired()
+    assert n == 2
+    expired_events = [c for c in captured if c[0] == "pending_action_expired"]
+    assert len(expired_events) == 2
+    nonces = {e[2]["nonce"] for e in expired_events}
+    assert nonces == {"n1", "n2"}
+
+
+def test_event_bus_emits_pending_action_resolved_on_cancel(tmp_path):
+    """``cancel(nonce)`` deletes the row and emits resolved with status='cancelled'."""
+    pa = _make_store(tmp_path)
+    captured = _attach_recording_bus(pa)
+    pa.store(
+        nonce="n1", actor="operator", target_kind="agent",
+        target_id="alpha", action_kind="model", payload={"x": 1},
+    )
+    captured.clear()
+    rec = pa.cancel("n1", actor="operator")
+    assert rec is not None
+    assert rec["status"] == "cancelled"
+    # Row is gone — second cancel returns None (no double-emit).
+    assert pa.cancel("n1") is None
+    resolved = [c for c in captured if c[0] == "pending_action_resolved"]
+    assert len(resolved) == 1
+    assert resolved[0][2]["status"] == "cancelled"
+    assert resolved[0][2]["nonce"] == "n1"
+
+
+def test_cancel_unknown_nonce_returns_none(tmp_path):
+    pa = _make_store(tmp_path)
+    assert pa.cancel("does-not-exist") is None
+
+
+def test_event_bus_unset_disables_emit(tmp_path):
+    pa = _make_store(tmp_path)
+    captured = _attach_recording_bus(pa)
+    pa.set_event_bus(None)
+    pa.store(
+        nonce="n1", actor="operator", target_kind="agent",
+        target_id="alpha", action_kind="model", payload={},
+    )
+    assert captured == []


### PR DESCRIPTION
## Summary

**Final slice of the operator orchestration roadmap.** Surfaces Tier 3's task records and Tier 1's pending-actions on the human-facing dashboard and CLI. After this lands, a human can run an agent team end-to-end without inspecting blackboard keys or pending-action tables directly.

**Branch base:** `feat/agent-capabilities-structured-fields` (PR #833) → … → `main`.

## Five new event types (`DashboardEvent.type`)

| Type | Payload |
|---|---|
| `task_created` | `{task_id, project_id, creator, assignee, title, status, created_at}` |
| `task_status_changed` | `{task_id, project_id, assignee, old_status, new_status, actor, ts}` |
| `pending_action_created` | `{nonce, actor, target_kind, target_id, action_kind, expires_at}` |
| `pending_action_resolved` | `{nonce, target_kind, target_id, action_kind, status: "confirmed\|cancelled", resolver, ts}` |
| `pending_action_expired` | `{nonce, target_kind, target_id, action_kind, expired_at}` |

`Tasks.set_event_bus` / `PendingActions.set_event_bus` mirror the `Blackboard` pattern. Emits are best-effort (`_safe_emit`) so durable SQLite writes never roll back due to a bus problem.

## Workplace tab (top-level)

Peer of Chat / Agents / System with four sub-tabs:
- **project-status** — per-project rollup with status counts + blockers
- **task-board** — 5-column kanban (`pending | accepted | working | blocked | done`)
- **blockers** — fleet-wide blocked task list with `blocker_note`
- **team-outputs** — completed task artifacts

Empty state when `OPENLEGION_ORCHESTRATION_TASKS_V2=0`. Live updates via the existing `/ws/events` socket. No build step — Alpine.js sub-tabs in `index.html`.

## Pending-action review (two surfaces)

1. **System > Operator** sub-tab gets a "Pending actions" panel above the change log — nonce / target / action_kind / expiry countdown / Confirm / Cancel buttons.
2. **Inline amber bubble** above operator chat — same buttons, in context.

Both share `workplacePending[]` state. Backend:
- `GET /mesh/pending` — list open nonces (operator-or-internal gate)
- `POST /mesh/pending/{nonce}/confirm` — wraps existing `/mesh/config/confirm` (synthetic `_receive` injects `change_id=nonce` so we don't duplicate the destructive-vs-edit branching logic)
- `POST /mesh/pending/{nonce}/cancel` — calls `PendingActions.cancel(nonce)`

CSRF (`X-Requested-With`) auto-applies. New `PendingActions.cancel(nonce, *, actor)` method emits `pending_action_resolved` with `status="cancelled"`.

## CLI commands (6 new)

`openlegion projects` / `project <id>` / `tasks [--agent|--project|--status]` / `pending` / `confirm <nonce>` / `cancel <nonce>`

All support `--json`. Inject `X-Requested-With` (CSRF) and `X-Origin: kind=human, channel=cli, user=$USER` so the human-confirmation gate from Task 2d accepts them. CLI REPL origin stamping (Task 2b at `src/cli/repl.py:1623-1627`) verified — no regression.

## Test plan

- [x] 43 new test cases across 6 files
- [x] `test_events.py` +2 (5 new types accepted, typo rejected)
- [x] `test_orchestration.py` +6 (created, status_changed, no-op suppression, reroute, cancel, detach)
- [x] `test_pending_actions.py` +9 (created/resolved/expired emits, cancel method, reap-with-emit, no-emit on failed consume, detach, multi-row reap)
- [x] `test_dashboard.py` +10 (Workplace empty / v2-off / v2-on rows / filters / pending list+cancel / 404s)
- [x] `test_cli_commands.py` +12 (table render / JSON mode / error propagation / CSRF + X-Origin headers)
- [x] `test_orchestration_endpoints.py` +3 (/mesh/pending/* surfaces)
- [x] Targeted suite — 547 passed, 3 deselected
- [x] Full non-E2E suite — 5256 passed, 44 skipped, 5 deselected. **No new failures.**

## Notable implementation choices

- **Reap-on-store ordering nit:** the first run of `test_event_bus_emits_pending_action_expired_on_reap` tripped because `PendingActions.store` runs `_safe_reap` opportunistically — store n1 (ttl=0), store n2 fires the reap and drops n1 before the assertion. Reordered the test to attach the bus after staging and added a separate multi-row test that bypasses the opportunistic reap.
- **In-process kwargs** for the dashboard router (`pending_actions`, `tasks_store`) instead of round-tripping through HTTP. The pre-existing test harness already uses dependency injection.
- **No build step.** Workplace tab is Alpine.js sub-tabs in `index.html` + plain JS in `app.js` — same pattern as System sub-tabs.

## Stack

1. #821 — Task 0 hotfix ✅
2. #822 — Task 1 characterization tests
3. #823 — Task 2a typed model
4. #824 — Task 2b stamp sites
5. #825 — Task 2c channel pairing recheck
6. #826 — Task 2d pending-actions SQLite
7. #827 — Task 2e wake block
8. #828 — Task 3 perm split
9. #829 — Task 4 operator cryptographic registration
10. #830 — Task 5 project isolation warn mode
11. #831 — Task 6 durable task records
12. #832 — Task 7 operator product tools
13. #833 — Task 8 structured routing fields
14. **This PR** — Task 9 dashboard / CLI surfaces (closes the roadmap)