### PR TITLE
feat(rollout): orchestration goes official — defaults flipped on

### DIFF
--- a/docs/plans/2026-05-02-operator-orchestration-roadmap.md
+++ b/docs/plans/2026-05-02-operator-orchestration-roadmap.md
@@ -1,0 +1,99 @@
+# Operator Orchestration Roadmap
+
+**Goal:** Give operators a coherent control plane for project-scoped fleets — durable task records, hard project isolation, structured routing, dashboard + CLI surfaces — so a human can drive a multi-agent team end-to-end without inspecting blackboard keys.
+
+**Core invariant:** A worker only ever sees its own project's agents and tasks. The operator and trusted internal callers (mesh, dashboard, CLI manager) remain fleet-global.
+
+---
+
+## Tasks
+
+| Task | Description | PR |
+|---|---|---|
+| Task 2c | Server-side channel pairing recheck on every origin downgrade. | #819 |
+| Task 2d | SQLite-backed pending-action store (replaces in-memory dict). | #821 |
+| Task 2e | Block worker → operator synchronous wakes. | #823 |
+| Task 3 | Split ``can_spawn`` into a control-plane permission set. | #824 |
+| Task 4 | Cryptographic operator authentication on register. | #826 |
+| Task 5 | Server-side project isolation (warn → enforce). | #828 |
+| Task 6 | Durable orchestration task records behind ``OPENLEGION_ORCHESTRATION_TASKS_V2``. | #830 |
+| Task 7 | Operator product tools for projects / teams / tasks. | #831 |
+| Task 8 | Structured routing fields on ``AgentConfig``. | #832 |
+| Task 9 | Dashboard Workplace tab + CLI ``tasks`` / ``pending`` surfaces. | #834 |
+| Rollout | Flip the two opt-in flags to default-on; auto-run migration. | this PR |
+
+---
+
+## Feature flags
+
+| Flag | Default | Behavior when default | Off-switch (rollback) |
+|---|---|---|---|
+| ``OPENLEGION_PROJECT_SCOPE_MODE`` | ``enforce`` | Workers see only own-project members on ``/mesh/agents`` and project-scoped blackboard ACLs. Operators + internal callers remain fleet-global. | Set to ``warn`` to restore legacy fleet-wide visibility while still emitting structured ``scope-warn`` log lines. |
+| ``OPENLEGION_ORCHESTRATION_TASKS_V2`` | ``1`` | Mesh constructs a ``Tasks`` SQLite store; coordination tool routes ``hand_off`` / ``check_inbox`` / ``update_status`` / ``complete_task`` through ``/mesh/tasks*``; legacy blackboard task migration auto-runs once at startup. | Set to ``0`` to disable v2: ``/mesh/tasks*`` returns 503, coordination falls back to the legacy blackboard-dict path, migration does not auto-run. |
+| ``OPENLEGION_STRICT_HUMAN_CONFIRMATION`` | ``1`` (already on) | Pending actions strictly require a human confirmation envelope. | Set to ``0`` only for break-glass debugging. |
+
+Both flags read the env var once at module import — runtime flips require a mesh restart.
+
+---
+
+## Rollout sequence
+
+**Shipped official: defaults flipped on in ``feat/orchestration-rollout-official``.**
+
+The roadmap shipped each piece behind an opt-in env flag so we could soak before flipping defaults. After landing Tasks 2c through 9 the user decided to skip the staged rollout and ship everything live in one PR. This PR:
+
+1. Flips ``OPENLEGION_PROJECT_SCOPE_MODE`` default ``warn`` → ``enforce``.
+2. Flips ``OPENLEGION_ORCHESTRATION_TASKS_V2`` default ``0`` → ``1``.
+3. Auto-runs ``migrate_blackboard_to_tasks`` once at mesh startup (idempotent — subsequent restarts are no-ops).
+
+### Rollback plan
+
+The off-switches still work for emergency rollback:
+
+- ``OPENLEGION_PROJECT_SCOPE_MODE=warn`` — restores legacy fleet-wide ``/mesh/agents`` visibility for workers; the structured ``scope-warn`` log lines and ``scope_warn_total`` metric stay live so operators can still measure what would have been denied.
+- ``OPENLEGION_ORCHESTRATION_TASKS_V2=0`` — disables the v2 path; ``/mesh/tasks*`` returns 503; coordination falls back to the legacy blackboard-dict path; the auto-run migration is skipped (existing legacy keys stay where they are).
+
+Restart the mesh after flipping either env var.
+
+---
+
+## Reality check by task
+
+### Task 5 — project scope isolation
+
+- Worker calls to ``/mesh/agents`` filter to own-project members + always-global operator under ``enforce``.
+- ``warn`` mode emits a structured ``scope-warn`` log line and bumps ``scope_warn_total`` on every call that *would* have been denied — operators read these to size impact before flipping the env var.
+- Operator + internal (loopback ``x-mesh-internal: 1``) callers are exempt from filtering by design — dashboard, CLI manager, health monitor all rely on fleet-wide visibility.
+
+### Task 6 — durable orchestration task records
+
+Storage layer: ``Tasks`` SQLite table keyed by ``task_id``. Endpoints under ``/mesh/tasks*`` (``create``, ``get``, ``list_inbox``, ``list_project``, ``update_status``, ``reroute``, ``cancel``, ``add_artifact``, ``reap_expired``). Permission gates by ``can_route_tasks`` + per-project membership. Coordination tool probes ``/mesh/orchestration/status`` once and caches the result.
+
+#### Migration
+
+The blackboard → tasks migration (``src/host/orchestration_migration.py``) auto-runs **once at mesh startup** when the v2 flag is on and a ``tasks_store`` was constructed. It is idempotent — keyed on the legacy ``handoff_id`` → new ``task_id`` — so subsequent restarts find nothing to migrate and are no-ops. Migration failures are logged but never crash startup; the legacy keys stay in place and operators can re-run the helper manually via the standalone import.
+
+The auto-run skips entirely when the v2 flag is off (someone deliberately disabled v2; respect that).
+
+### Task 7 — operator product tools
+
+Operator skills layer over the Task 6 endpoints: ``list_project_status``, ``list_agent_queue``, ``get_team_outputs``, ``reroute_task``, ``retry_task``. All return ``{"error": ...}`` referencing ``OPENLEGION_ORCHESTRATION_TASKS_V2`` when the flag is off so operators get a clean signal instead of garbled data.
+
+### Task 8 — structured routing fields
+
+``AgentConfig`` carries ``role``, ``project``, ``capabilities`` so the dashboard Workplace tab and the operator product tools can group agents by role/project without parsing free-form ``instructions``.
+
+### Task 9 — dashboard + CLI surfaces
+
+- Workplace tab on the dashboard (peer of Chat / Agents / System): board view of tasks grouped by project / assignee, pending-action review pane.
+- CLI: ``openlegion tasks`` and ``openlegion pending`` print the same data via ``/dashboard/api/workplace/*``.
+- Both degrade to a clean empty state with a hint to flip ``OPENLEGION_ORCHESTRATION_TASKS_V2=1`` when the flag is off.
+
+---
+
+## Test plan
+
+- ``tests/test_rollout_defaults.py`` — verifies default-on for both flags + that the off-switches still work.
+- ``tests/test_orchestration_migration.py`` — extended with auto-run-at-startup, idempotence, and failure-doesn't-crash coverage.
+- Existing ``tests/test_orchestration_endpoints.py`` and ``tests/test_operator_product_tools.py`` already explicitly set the env vars; updated as needed.
+- Existing ``tests/test_mesh.py`` (Task 5 scope tests) already explicitly set ``OPENLEGION_PROJECT_SCOPE_MODE`` for both warn and enforce paths.

--- a/src/agent/builtins/operator_tools.py
+++ b/src/agent/builtins/operator_tools.py
@@ -666,8 +666,12 @@ _TASKS_V2_DISABLED = (
 
 
 def _orchestration_v2_on() -> bool:
-    """Read the orchestration v2 flag at call time so monkeypatch tests work."""
-    return os.environ.get("OPENLEGION_ORCHESTRATION_TASKS_V2", "0") == "1"
+    """Read the orchestration v2 flag at call time so monkeypatch tests work.
+
+    Default-on (rollout). Setting the env var to ``0`` disables the v2
+    path; any other value is treated as on.
+    """
+    return os.environ.get("OPENLEGION_ORCHESTRATION_TASKS_V2", "1") != "0"
 
 
 def _parse_over_budget(error: Exception) -> dict | None:

--- a/src/dashboard/server.py
+++ b/src/dashboard/server.py
@@ -5416,7 +5416,10 @@ def create_dashboard_router(
     # called from a test harness that didn't pass the stores).
 
     def _orchestration_v2_on() -> bool:
-        return os.environ.get("OPENLEGION_ORCHESTRATION_TASKS_V2", "0") == "1"
+        # Default-on (rollout). Setting the env var to ``0`` disables
+        # the v2 path; any other value is treated as on so misconfigured
+        # operators don't silently fall back to the legacy path.
+        return os.environ.get("OPENLEGION_ORCHESTRATION_TASKS_V2", "1") != "0"
 
     @api_router.get("/api/workplace/tasks")
     async def api_workplace_tasks(

--- a/src/host/server.py
+++ b/src/host/server.py
@@ -425,36 +425,38 @@ def _validated_origin(
     return _downgrade_origin(origin, "unpaired channel user")
 
 
-# ── Task 5: Project scope isolation (warn → enforce) ──────────────────
+# ── Task 5: Project scope isolation (default enforce) ─────────────────
 #
 # ``OPENLEGION_PROJECT_SCOPE_MODE`` is the kill switch for the project
-# isolation rollout. ``warn`` (the default for the first release) keeps
-# legacy behavior — fleet-wide visibility on ``/mesh/agents``, additive
-# blackboard ACLs — but emits structured warnings whenever a call would
-# be denied under ``enforce``. Operators read the warn telemetry, then
-# flip to ``enforce`` once the soak window is clean. Read once at module
-# import (env vars don't change at runtime); invalid values fall back to
-# ``warn`` with a logged warning.
-_PROJECT_SCOPE_MODE = os.environ.get("OPENLEGION_PROJECT_SCOPE_MODE", "warn").lower()
+# isolation rollout. Default ``enforce`` — workers see only their own
+# project members on ``/mesh/agents`` and only their own project
+# blackboard ACLs. ``warn`` is preserved as an emergency rollback that
+# restores the legacy fleet-wide visibility while still emitting
+# structured warnings on every call that would have been denied under
+# enforce. Read once at module import (env vars don't change at
+# runtime); invalid values fall back to ``enforce`` with a logged
+# warning.
+_PROJECT_SCOPE_MODE = os.environ.get("OPENLEGION_PROJECT_SCOPE_MODE", "enforce").lower()
 if _PROJECT_SCOPE_MODE not in {"warn", "enforce"}:
     logger.warning(
-        "Invalid OPENLEGION_PROJECT_SCOPE_MODE=%r, defaulting to warn",
+        "Invalid OPENLEGION_PROJECT_SCOPE_MODE=%r, defaulting to enforce",
         _PROJECT_SCOPE_MODE,
     )
-    _PROJECT_SCOPE_MODE = "warn"
+    _PROJECT_SCOPE_MODE = "enforce"
 
 
 # ── Task 6: Durable orchestration task records ────────────────────────
 #
 # ``OPENLEGION_ORCHESTRATION_TASKS_V2`` is the kill switch for the
-# durable-tasks rollout. Default ``0`` (disabled) — the legacy
-# blackboard-dict path in ``coordination_tool`` runs unchanged. When
-# set to ``1`` the mesh constructs a ``Tasks`` SQLite store and the
-# coordination tool routes hand_off / check_inbox / update_status /
-# complete_task through the new endpoints. **No dual-write.**
-# Read once at module import; runtime flips require a restart.
+# durable-tasks rollout. Default ``1`` (enabled) — the mesh constructs
+# a ``Tasks`` SQLite store and the coordination tool routes hand_off /
+# check_inbox / update_status / complete_task through the new
+# endpoints. Setting the env var to ``0`` is preserved as an emergency
+# rollback that falls back to the legacy blackboard-dict path in
+# ``coordination_tool``. **No dual-write.** Read once at module import;
+# runtime flips require a restart.
 _ORCHESTRATION_TASKS_V2 = (
-    os.environ.get("OPENLEGION_ORCHESTRATION_TASKS_V2", "0") == "1"
+    os.environ.get("OPENLEGION_ORCHESTRATION_TASKS_V2", "1") == "1"
 )
 
 
@@ -557,6 +559,39 @@ def create_mesh_app(
     # cancel emit ``task_*`` events to the dashboard.
     if tasks_store is not None and event_bus is not None:
         tasks_store.set_event_bus(event_bus)
+
+    # Rollout: auto-run the legacy blackboard → tasks migration once
+    # at startup so existing fleets transition seamlessly when the v2
+    # flag flips on. The helper is idempotent (keyed on the legacy
+    # ``handoff_id`` → new ``task_id``) so subsequent restarts find
+    # nothing to migrate and are no-ops. Migration failures are logged
+    # but never crash mesh startup — the legacy keys remain in place
+    # and operators can re-run the helper manually.
+    if _ORCHESTRATION_TASKS_V2 and tasks_store is not None:
+        from src.host.orchestration_migration import migrate_blackboard_to_tasks
+        try:
+            _migration_result = migrate_blackboard_to_tasks(blackboard, tasks_store)
+            _migrated = int(_migration_result.get("migrated", 0) or 0)
+            _skipped = int(_migration_result.get("skipped", 0) or 0)
+            _deleted = int(_migration_result.get("deleted", 0) or 0)
+            _errors = _migration_result.get("errors", []) or []
+            _error_count = len(_errors) if isinstance(_errors, list) else int(_errors)
+            if _migrated > 0 or _deleted > 0:
+                logger.info(
+                    "orchestration migration: migrated=%d skipped=%d deleted=%d errors=%d",
+                    _migrated, _skipped, _deleted, _error_count,
+                )
+            else:
+                logger.debug("orchestration migration: no legacy tasks found")
+        except Exception as e:
+            # Migration failure must not crash mesh startup. Logged
+            # loudly so ops can investigate; legacy tasks stay in place
+            # and can be migrated manually later.
+            logger.error(
+                "orchestration migration failed at startup: %s — legacy tasks preserved",
+                e,
+                exc_info=True,
+            )
 
     _auth_tokens = auth_tokens if auth_tokens is not None else {}
     _agent_projects = agent_projects if agent_projects is not None else {}

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -5,6 +5,8 @@ Tests the FastAPI endpoints directly using TestClient (no Docker required).
 
 from __future__ import annotations
 
+import importlib
+
 import pytest
 from fastapi.testclient import TestClient
 
@@ -15,8 +17,23 @@ from src.shared.types import AgentPermissions
 
 
 @pytest.fixture
-def mesh_components(tmp_path):
-    """Create all mesh components with test configuration."""
+def mesh_components(tmp_path, monkeypatch):
+    """Create all mesh components with test configuration.
+
+    Pinned to ``OPENLEGION_PROJECT_SCOPE_MODE=warn`` because these tests
+    hit ``/mesh/agents`` with anonymous TestClient calls; the new
+    ``enforce`` default would filter the response down to {operator}
+    and break the contract assertions.
+    """
+    monkeypatch.setenv("OPENLEGION_PROJECT_SCOPE_MODE", "warn")
+    import src.host.server as server_module
+    importlib.reload(server_module)
+    # Use the freshly-reloaded module's factory so the new
+    # ``_PROJECT_SCOPE_MODE`` value is honored. Other fixtures in this
+    # file still use the top-level ``create_mesh_app`` import — they
+    # don't drive ``/mesh/agents`` so the default is fine for them.
+    fresh_create_mesh_app = server_module.create_mesh_app
+
     bb = Blackboard(db_path=str(tmp_path / "bb.db"))
 
     pubsub = PubSub()
@@ -43,10 +60,13 @@ def mesh_components(tmp_path):
 
     router = MessageRouter(permissions=perms, agent_registry={})
 
-    app = create_mesh_app(bb, pubsub, router, perms, credential_vault=None)
+    app = fresh_create_mesh_app(bb, pubsub, router, perms, credential_vault=None)
     client = TestClient(app)
 
-    return {"client": client, "blackboard": bb, "pubsub": pubsub, "router": router, "perms": perms}
+    yield {"client": client, "blackboard": bb, "pubsub": pubsub, "router": router, "perms": perms}
+
+    monkeypatch.delenv("OPENLEGION_PROJECT_SCOPE_MODE", raising=False)
+    importlib.reload(server_module)
 
 
 def test_register_agent(mesh_components):

--- a/tests/test_mesh.py
+++ b/tests/test_mesh.py
@@ -1096,18 +1096,29 @@ def test_inbox_watch_fires_on_handoff_write(tmp_path):
 
 
 @pytest.mark.asyncio
-async def test_list_agents_endpoint_includes_capabilities(tmp_path):
+async def test_list_agents_endpoint_includes_capabilities(tmp_path, monkeypatch):
     """`/mesh/agents` must include a `capabilities` key per agent.
 
     The list_agents builtin (src/agent/builtins/mesh_tool.py) reads
     info.get("capabilities", []) — without this the dashboard and
     coordination tools see every agent as having zero capabilities.
+
+    Pinned to ``OPENLEGION_PROJECT_SCOPE_MODE=warn`` because this test
+    hits the unscoped path with no auth tokens (caller resolves to
+    ``"unknown"``); the new ``enforce`` default would filter the
+    response down to {operator}.
     """
+    import importlib
+
     from httpx import ASGITransport, AsyncClient
 
     from src.host.costs import CostTracker
-    from src.host.server import create_mesh_app
     from src.host.traces import TraceStore
+
+    monkeypatch.setenv("OPENLEGION_PROJECT_SCOPE_MODE", "warn")
+    import src.host.server as server_module
+    importlib.reload(server_module)
+    create_mesh_app = server_module.create_mesh_app
 
     bb = Blackboard(db_path=str(tmp_path / "bb.db"))
     pubsub = PubSub()
@@ -1147,10 +1158,12 @@ async def test_list_agents_endpoint_includes_capabilities(tmp_path):
         bb.close()
         costs.close()
         traces.close()
+        monkeypatch.delenv("OPENLEGION_PROJECT_SCOPE_MODE", raising=False)
+        importlib.reload(server_module)
 
 
 @pytest.mark.asyncio
-async def test_list_agents_project_scope_always_includes_operator(tmp_path):
+async def test_list_agents_project_scope_always_includes_operator(tmp_path, monkeypatch):
     """`/mesh/agents?project=X` must include the operator entry alongside
     project members. The operator is fleet-global by design — project agents
     have to discover it to hand off back. Without this, project_agent →
@@ -1158,15 +1171,25 @@ async def test_list_agents_project_scope_always_includes_operator(tmp_path):
 
     Also verifies the operator entry carries scope=global so coordination
     tools can route the handoff to the global namespace.
+
+    Pinned to ``OPENLEGION_PROJECT_SCOPE_MODE=warn`` because this test
+    uses an unauthenticated caller hitting ``?project=growth`` — under
+    enforce, the caller is not a project member and the response would
+    be empty.
     """
+    import importlib
     from unittest.mock import patch
 
     import yaml
     from httpx import ASGITransport, AsyncClient
 
     from src.host.costs import CostTracker
-    from src.host.server import create_mesh_app
     from src.host.traces import TraceStore
+
+    monkeypatch.setenv("OPENLEGION_PROJECT_SCOPE_MODE", "warn")
+    import src.host.server as server_module
+    importlib.reload(server_module)
+    create_mesh_app = server_module.create_mesh_app
 
     # Minimal project on disk with one member.
     projects_dir = tmp_path / "projects"
@@ -1211,18 +1234,31 @@ async def test_list_agents_project_scope_always_includes_operator(tmp_path):
         bb.close()
         costs.close()
         traces.close()
+        monkeypatch.delenv("OPENLEGION_PROJECT_SCOPE_MODE", raising=False)
+        importlib.reload(server_module)
 
 
 @pytest.mark.asyncio
-async def test_list_agents_unscoped_marks_operator_global(tmp_path):
+async def test_list_agents_unscoped_marks_operator_global(tmp_path, monkeypatch):
     """The fleet-wide /mesh/agents response must also tag the operator with
     scope=global so dashboards and the operator's own list_agents call can
-    distinguish it from per-project agents."""
+    distinguish it from per-project agents.
+
+    Pinned to ``OPENLEGION_PROJECT_SCOPE_MODE=warn`` because the
+    unauthenticated caller resolves to ``"unknown"`` and the unscoped
+    ``enforce`` path would filter the response down to {operator}.
+    """
+    import importlib
+
     from httpx import ASGITransport, AsyncClient
 
     from src.host.costs import CostTracker
-    from src.host.server import create_mesh_app
     from src.host.traces import TraceStore
+
+    monkeypatch.setenv("OPENLEGION_PROJECT_SCOPE_MODE", "warn")
+    import src.host.server as server_module
+    importlib.reload(server_module)
+    create_mesh_app = server_module.create_mesh_app
 
     bb = Blackboard(db_path=str(tmp_path / "bb.db"))
     pubsub = PubSub()
@@ -1253,27 +1289,38 @@ async def test_list_agents_unscoped_marks_operator_global(tmp_path):
         bb.close()
         costs.close()
         traces.close()
+        monkeypatch.delenv("OPENLEGION_PROJECT_SCOPE_MODE", raising=False)
+        importlib.reload(server_module)
 
 
 # ── Task 1 (characterization): /mesh/agents per-caller-type visibility ─
 
 
 @pytest.mark.asyncio
-async def test_list_agents_project_scope_excludes_other_project_members(tmp_path):
+async def test_list_agents_project_scope_excludes_other_project_members(tmp_path, monkeypatch):
     """When ``/mesh/agents?project=X`` is called, members of project Y must
     NOT appear in the response. The endpoint reads members from the project
     metadata on disk and only includes registered agents whose id is a
     member, plus the operator (which is fleet-global). This pins the
     project-isolation invariant for the response shape.
+
+    Pinned to ``OPENLEGION_PROJECT_SCOPE_MODE=warn`` because the
+    unauthenticated caller is not a member of project ``alpha`` — under
+    enforce, the response would be empty rather than scoped-to-members.
     """
+    import importlib
     from unittest.mock import patch
 
     import yaml
     from httpx import ASGITransport, AsyncClient
 
     from src.host.costs import CostTracker
-    from src.host.server import create_mesh_app
     from src.host.traces import TraceStore
+
+    monkeypatch.setenv("OPENLEGION_PROJECT_SCOPE_MODE", "warn")
+    import src.host.server as server_module
+    importlib.reload(server_module)
+    create_mesh_app = server_module.create_mesh_app
 
     projects_dir = tmp_path / "projects"
     # Project alpha has scout.
@@ -1333,19 +1380,32 @@ async def test_list_agents_project_scope_excludes_other_project_members(tmp_path
         bb.close()
         costs.close()
         traces.close()
+        monkeypatch.delenv("OPENLEGION_PROJECT_SCOPE_MODE", raising=False)
+        importlib.reload(server_module)
 
 
 @pytest.mark.asyncio
-async def test_list_agents_internal_caller_sees_full_fleet(tmp_path):
+async def test_list_agents_internal_caller_sees_full_fleet(tmp_path, monkeypatch):
     """Internal callers (loopback / dashboard / mesh-internal) hitting
     ``/mesh/agents`` with no project filter receive every registered
     agent. This pins the unscoped path that dashboards rely on.
+
+    Pinned to ``OPENLEGION_PROJECT_SCOPE_MODE=warn`` to assert legacy
+    fleet-wide behavior under the documented rollback path. The
+    sibling ``test_list_agents_internal_caller_unaffected`` covers
+    enforce mode.
     """
+    import importlib
+
     from httpx import ASGITransport, AsyncClient
 
     from src.host.costs import CostTracker
-    from src.host.server import create_mesh_app
     from src.host.traces import TraceStore
+
+    monkeypatch.setenv("OPENLEGION_PROJECT_SCOPE_MODE", "warn")
+    import src.host.server as server_module
+    importlib.reload(server_module)
+    create_mesh_app = server_module.create_mesh_app
 
     bb = Blackboard(db_path=str(tmp_path / "bb.db"))
     pubsub = PubSub()
@@ -1378,6 +1438,8 @@ async def test_list_agents_internal_caller_sees_full_fleet(tmp_path):
         bb.close()
         costs.close()
         traces.close()
+        monkeypatch.delenv("OPENLEGION_PROJECT_SCOPE_MODE", raising=False)
+        importlib.reload(server_module)
 
 
 @pytest.mark.asyncio
@@ -1665,17 +1727,27 @@ async def test_list_agents_internal_caller_unaffected(
 
 
 @pytest.mark.asyncio
-async def test_list_agents_carries_structured_routing_fields(tmp_path):
+async def test_list_agents_carries_structured_routing_fields(tmp_path, monkeypatch):
     """`/mesh/agents` entries surface Task-8 routing fields under
-    distinct keys from the runtime tool ``capabilities`` list."""
+    distinct keys from the runtime tool ``capabilities`` list.
+
+    Pinned to ``OPENLEGION_PROJECT_SCOPE_MODE=warn`` because the
+    unauthenticated caller resolves to ``"unknown"``; the new enforce
+    default would filter out non-member agents from the response.
+    """
+    import importlib
     from unittest.mock import patch
 
     import yaml as yaml_mod
     from httpx import ASGITransport, AsyncClient
 
     from src.host.costs import CostTracker
-    from src.host.server import create_mesh_app
     from src.host.traces import TraceStore
+
+    monkeypatch.setenv("OPENLEGION_PROJECT_SCOPE_MODE", "warn")
+    import src.host.server as server_module
+    importlib.reload(server_module)
+    create_mesh_app = server_module.create_mesh_app
 
     cfg_dir = tmp_path / "config"
     cfg_dir.mkdir(parents=True)
@@ -1739,6 +1811,8 @@ async def test_list_agents_carries_structured_routing_fields(tmp_path):
         bb.close()
         costs.close()
         traces.close()
+        monkeypatch.delenv("OPENLEGION_PROJECT_SCOPE_MODE", raising=False)
+        importlib.reload(server_module)
 
 
 @pytest.mark.asyncio

--- a/tests/test_operator_product_tools.py
+++ b/tests/test_operator_product_tools.py
@@ -57,8 +57,13 @@ def _fake_budget_http_error(agent: str, monthly_used: float = 50.0) -> httpx.HTT
 
 @pytest.mark.asyncio
 async def test_list_project_status_requires_v2_flag(monkeypatch):
-    """Read tools that consume tasks return a clean error when v2 off."""
-    monkeypatch.delenv("OPENLEGION_ORCHESTRATION_TASKS_V2", raising=False)
+    """Read tools that consume tasks return a clean error when v2 off.
+
+    The flag now defaults to ``1`` (rollout) so the off path must
+    explicitly set ``OPENLEGION_ORCHESTRATION_TASKS_V2=0`` rather than
+    relying on the env var being unset.
+    """
+    monkeypatch.setenv("OPENLEGION_ORCHESTRATION_TASKS_V2", "0")
     from src.agent.builtins.operator_tools import list_project_status
     result = await list_project_status(mesh_client=MagicMock())
     assert "error" in result
@@ -67,7 +72,7 @@ async def test_list_project_status_requires_v2_flag(monkeypatch):
 
 @pytest.mark.asyncio
 async def test_list_agent_queue_requires_v2_flag(monkeypatch):
-    monkeypatch.delenv("OPENLEGION_ORCHESTRATION_TASKS_V2", raising=False)
+    monkeypatch.setenv("OPENLEGION_ORCHESTRATION_TASKS_V2", "0")
     from src.agent.builtins.operator_tools import list_agent_queue
     result = await list_agent_queue("a1", mesh_client=MagicMock())
     assert "error" in result
@@ -76,7 +81,7 @@ async def test_list_agent_queue_requires_v2_flag(monkeypatch):
 
 @pytest.mark.asyncio
 async def test_get_team_outputs_requires_v2_flag(monkeypatch):
-    monkeypatch.delenv("OPENLEGION_ORCHESTRATION_TASKS_V2", raising=False)
+    monkeypatch.setenv("OPENLEGION_ORCHESTRATION_TASKS_V2", "0")
     from src.agent.builtins.operator_tools import get_team_outputs
     result = await get_team_outputs("p1", mesh_client=MagicMock())
     assert "error" in result

--- a/tests/test_orchestration_endpoints.py
+++ b/tests/test_orchestration_endpoints.py
@@ -24,12 +24,17 @@ def _reload_server(monkeypatch, *, v2: bool, tasks_db: str):
     The orchestration v2 flag is read at module import. Tests that
     flip the flag must reload the module so ``_ORCHESTRATION_TASKS_V2``
     picks up the new value.
+
+    Note: the v2 flag now defaults to ``1`` (rollout) so the off path
+    must explicitly set ``OPENLEGION_ORCHESTRATION_TASKS_V2=0`` rather
+    than relying on the env var being unset.
     """
     if v2:
         monkeypatch.setenv("OPENLEGION_ORCHESTRATION_TASKS_V2", "1")
         monkeypatch.setenv("OPENLEGION_ORCHESTRATION_TASKS_DB", tasks_db)
     else:
-        monkeypatch.delenv("OPENLEGION_ORCHESTRATION_TASKS_V2", raising=False)
+        monkeypatch.setenv("OPENLEGION_ORCHESTRATION_TASKS_V2", "0")
+        monkeypatch.delenv("OPENLEGION_ORCHESTRATION_TASKS_DB", raising=False)
     import src.host.server as server_module
     importlib.reload(server_module)
     return server_module

--- a/tests/test_orchestration_migration.py
+++ b/tests/test_orchestration_migration.py
@@ -1,10 +1,21 @@
-"""One-shot blackboard → tasks migration tests (Task 6)."""
+"""One-shot blackboard → tasks migration tests (Task 6).
+
+Includes auto-run-at-startup coverage for the rollout PR — the
+``create_mesh_app`` factory invokes ``migrate_blackboard_to_tasks`` once
+when the v2 flag is on so existing fleets transition seamlessly.
+"""
 
 from __future__ import annotations
 
-from src.host.mesh import Blackboard
+import importlib
+import logging
+
+import pytest
+
+from src.host.mesh import Blackboard, MessageRouter, PubSub
 from src.host.orchestration import Tasks
 from src.host.orchestration_migration import migrate_blackboard_to_tasks
+from src.host.permissions import PermissionMatrix
 
 
 def _make_blackboard(tmp_path) -> Blackboard:
@@ -163,3 +174,207 @@ def test_migration_handles_corrupt_value_gracefully(tmp_path):
     rec = t.get("ho_corrupt")
     # Title falls back to "(migrated handoff)" since no summary key.
     assert rec is not None
+
+
+# ── Auto-run at mesh startup (rollout PR) ─────────────────────────
+
+
+def _reload_server(monkeypatch, *, v2_on: bool, tasks_db: str):
+    """Reload ``src.host.server`` after pinning the env vars so the
+    module-level ``_ORCHESTRATION_TASKS_V2`` constant picks up the new
+    value.
+    """
+    if v2_on:
+        monkeypatch.setenv("OPENLEGION_ORCHESTRATION_TASKS_V2", "1")
+        monkeypatch.setenv("OPENLEGION_ORCHESTRATION_TASKS_DB", tasks_db)
+    else:
+        monkeypatch.delenv("OPENLEGION_ORCHESTRATION_TASKS_V2", raising=False)
+        monkeypatch.delenv("OPENLEGION_ORCHESTRATION_TASKS_DB", raising=False)
+    import src.host.server as server_module
+    importlib.reload(server_module)
+    return server_module
+
+
+def _build_app(server_module, blackboard):
+    """Build a minimal mesh app reusing the supplied blackboard so the
+    auto-run migration sees its rows.
+    """
+    pubsub = PubSub()
+    permissions = PermissionMatrix()
+    router = MessageRouter(permissions, {})
+    return server_module.create_mesh_app(
+        blackboard=blackboard,
+        pubsub=pubsub,
+        router=router,
+        permissions=permissions,
+    )
+
+
+def test_migration_auto_runs_at_startup(tmp_path, monkeypatch):
+    """Building a mesh app with v2 on migrates legacy task rows once."""
+    bb_path = str(tmp_path / "bb.db")
+    bb = Blackboard(db_path=bb_path)
+    bb.write(
+        "tasks/scout/ho_xxx",
+        {"from": "operator", "summary": "auto-migrate me", "status": "pending"},
+        written_by="operator",
+    )
+
+    try:
+        server_module = _reload_server(
+            monkeypatch, v2_on=True, tasks_db=str(tmp_path / "tasks.db"),
+        )
+        app = _build_app(server_module, bb)
+
+        # Auto-run lands the row in the tasks store.
+        ts: Tasks | None = app.tasks_store
+        assert ts is not None
+        rec = ts.get("ho_xxx")
+        assert rec is not None
+        assert rec["assignee"] == "scout"
+        assert rec["title"] == "auto-migrate me"
+        # Legacy key was deleted.
+        assert bb.read("tasks/scout/ho_xxx") is None
+    finally:
+        bb.close()
+        # Restore the suite's idea of "default" by reloading once more
+        # without the env vars set.
+        monkeypatch.delenv("OPENLEGION_ORCHESTRATION_TASKS_V2", raising=False)
+        monkeypatch.delenv("OPENLEGION_ORCHESTRATION_TASKS_DB", raising=False)
+        import src.host.server as server_module
+        importlib.reload(server_module)
+
+
+def test_migration_auto_runs_idempotent(tmp_path, monkeypatch):
+    """Building the mesh app twice over the same blackboard is a no-op
+    on the second pass — idempotence keyed on the legacy ``handoff_id``.
+    """
+    bb_path = str(tmp_path / "bb.db")
+    bb = Blackboard(db_path=bb_path)
+    bb.write(
+        "tasks/scout/ho_idem",
+        {"from": "operator", "summary": "first pass migrates me"},
+        written_by="operator",
+    )
+
+    try:
+        tasks_db = str(tmp_path / "tasks.db")
+        server_module = _reload_server(
+            monkeypatch, v2_on=True, tasks_db=tasks_db,
+        )
+
+        # First pass.
+        app1 = _build_app(server_module, bb)
+        ts1: Tasks | None = app1.tasks_store
+        assert ts1 is not None
+        assert ts1.get("ho_idem") is not None
+        # Close the first store handle so the second pass reopens
+        # cleanly against the same on-disk file.
+        try:
+            ts1.close()
+        except Exception:
+            pass
+
+        # Second pass — same on-disk tasks db, should find nothing to do.
+        app2 = _build_app(server_module, bb)
+        ts2: Tasks | None = app2.tasks_store
+        assert ts2 is not None
+        rec = ts2.get("ho_idem")
+        # Row is still present (persisted across reopen), the second
+        # auto-run did NOT re-create or duplicate it.
+        assert rec is not None
+        # No legacy key resurrected.
+        assert bb.read("tasks/scout/ho_idem") is None
+    finally:
+        bb.close()
+        monkeypatch.delenv("OPENLEGION_ORCHESTRATION_TASKS_V2", raising=False)
+        monkeypatch.delenv("OPENLEGION_ORCHESTRATION_TASKS_DB", raising=False)
+        import src.host.server as server_module
+        importlib.reload(server_module)
+
+
+def test_migration_failure_does_not_crash_startup(tmp_path, monkeypatch, caplog):
+    """A migration helper that raises must not bubble out of
+    ``create_mesh_app``. The error is logged and the app still
+    constructs.
+    """
+    bb_path = str(tmp_path / "bb.db")
+    bb = Blackboard(db_path=bb_path)
+
+    def _boom(*args, **kwargs):
+        raise RuntimeError("synthetic migration failure")
+
+    try:
+        server_module = _reload_server(
+            monkeypatch, v2_on=True, tasks_db=str(tmp_path / "tasks.db"),
+        )
+        # Patch the helper inside the migration module the server
+        # imports lazily. The lazy import means we patch the source
+        # module, not the server's local binding.
+        monkeypatch.setattr(
+            "src.host.orchestration_migration.migrate_blackboard_to_tasks",
+            _boom,
+        )
+
+        with caplog.at_level(logging.ERROR, logger="host.server"):
+            app = _build_app(server_module, bb)
+
+        # App still constructed.
+        assert app is not None
+        # The tasks store is still attached — the failure was the
+        # migration, not the store init.
+        assert app.tasks_store is not None
+        # Error was logged.
+        err_lines = [
+            r.message for r in caplog.records
+            if "orchestration migration failed" in r.message
+        ]
+        assert err_lines, (
+            f"expected an error log line, got {[r.message for r in caplog.records]}"
+        )
+    finally:
+        bb.close()
+        monkeypatch.delenv("OPENLEGION_ORCHESTRATION_TASKS_V2", raising=False)
+        monkeypatch.delenv("OPENLEGION_ORCHESTRATION_TASKS_DB", raising=False)
+        import src.host.server as server_module
+        importlib.reload(server_module)
+
+
+def test_migration_skipped_when_v2_disabled(tmp_path, monkeypatch):
+    """When v2 is OFF, the auto-run is skipped — legacy keys remain in
+    place so an operator who deliberately disabled v2 doesn't have
+    their data silently moved.
+    """
+    bb_path = str(tmp_path / "bb.db")
+    bb = Blackboard(db_path=bb_path)
+    bb.write(
+        "tasks/scout/ho_skip",
+        {"from": "operator", "summary": "do not auto-migrate"},
+        written_by="operator",
+    )
+
+    try:
+        server_module = _reload_server(monkeypatch, v2_on=False, tasks_db="")
+        # Set v2 explicitly off.
+        monkeypatch.setenv("OPENLEGION_ORCHESTRATION_TASKS_V2", "0")
+        importlib.reload(server_module)
+
+        app = _build_app(server_module, bb)
+
+        # No tasks store was constructed.
+        assert app.tasks_store is None
+        # Legacy key is still present.
+        entry = bb.read("tasks/scout/ho_skip")
+        assert entry is not None
+    finally:
+        bb.close()
+        monkeypatch.delenv("OPENLEGION_ORCHESTRATION_TASKS_V2", raising=False)
+        monkeypatch.delenv("OPENLEGION_ORCHESTRATION_TASKS_DB", raising=False)
+        import src.host.server as server_module
+        importlib.reload(server_module)
+
+
+# Reference an unused symbol so ruff's F401 is happy after the import
+# block was extended for the new tests.
+_ = pytest
+

--- a/tests/test_rollout_defaults.py
+++ b/tests/test_rollout_defaults.py
@@ -1,0 +1,109 @@
+"""Rollout defaults — opt-in flags flipped to default-on.
+
+Verifies the orchestration roadmap rollout: ``OPENLEGION_PROJECT_SCOPE_MODE``
+defaults to ``enforce`` and ``OPENLEGION_ORCHESTRATION_TASKS_V2`` defaults
+to ``1``. Also confirms the emergency-rollback off-switches still work
+(setting either env var back to its legacy value re-enters the legacy
+behavior path).
+
+The flags are read once at module import in ``src.host.server`` so the
+tests reload the module after each ``monkeypatch.setenv`` /
+``monkeypatch.delenv`` to exercise the new value. Subsequent tests in
+the suite read the live module attribute, which means we always restore
+the unset state at the end of each test.
+"""
+
+from __future__ import annotations
+
+import importlib
+
+import pytest
+
+
+def _reload_server():
+    import src.host.server as server_module
+    importlib.reload(server_module)
+    return server_module
+
+
+def test_project_scope_mode_default_is_enforce(monkeypatch):
+    """With the env var unset, ``_PROJECT_SCOPE_MODE`` is ``enforce``."""
+    monkeypatch.delenv("OPENLEGION_PROJECT_SCOPE_MODE", raising=False)
+    server_module = _reload_server()
+    try:
+        assert server_module._PROJECT_SCOPE_MODE == "enforce"
+    finally:
+        # Reload once more to leave the module in a clean default state
+        # for the rest of the suite.
+        _reload_server()
+
+
+def test_orchestration_tasks_v2_default_on(monkeypatch):
+    """With the env var unset, ``_ORCHESTRATION_TASKS_V2`` is True."""
+    monkeypatch.delenv("OPENLEGION_ORCHESTRATION_TASKS_V2", raising=False)
+    server_module = _reload_server()
+    try:
+        assert server_module._ORCHESTRATION_TASKS_V2 is True
+    finally:
+        _reload_server()
+
+
+def test_orchestration_tasks_v2_can_be_disabled(monkeypatch):
+    """``OPENLEGION_ORCHESTRATION_TASKS_V2=0`` is the rollback off-switch."""
+    monkeypatch.setenv("OPENLEGION_ORCHESTRATION_TASKS_V2", "0")
+    server_module = _reload_server()
+    try:
+        assert server_module._ORCHESTRATION_TASKS_V2 is False
+    finally:
+        monkeypatch.delenv("OPENLEGION_ORCHESTRATION_TASKS_V2", raising=False)
+        _reload_server()
+
+
+def test_project_scope_mode_can_be_warn(monkeypatch):
+    """``OPENLEGION_PROJECT_SCOPE_MODE=warn`` is the rollback kill-switch."""
+    monkeypatch.setenv("OPENLEGION_PROJECT_SCOPE_MODE", "warn")
+    server_module = _reload_server()
+    try:
+        assert server_module._PROJECT_SCOPE_MODE == "warn"
+    finally:
+        monkeypatch.delenv("OPENLEGION_PROJECT_SCOPE_MODE", raising=False)
+        _reload_server()
+
+
+def test_invalid_project_scope_mode_falls_back_to_enforce(monkeypatch, caplog):
+    """An unknown value coerces to the new default (``enforce``)."""
+    import logging
+
+    monkeypatch.setenv("OPENLEGION_PROJECT_SCOPE_MODE", "bogus")
+    with caplog.at_level(logging.WARNING, logger="host.server"):
+        server_module = _reload_server()
+    try:
+        assert server_module._PROJECT_SCOPE_MODE == "enforce"
+        # The warning mentions the new fallback default explicitly.
+        warn_lines = [r.message for r in caplog.records if "defaulting to" in r.message]
+        assert any("enforce" in m for m in warn_lines), (
+            f"expected fallback-to-enforce warning, got {warn_lines}"
+        )
+    finally:
+        monkeypatch.delenv("OPENLEGION_PROJECT_SCOPE_MODE", raising=False)
+        _reload_server()
+
+
+@pytest.mark.parametrize("value", ["", "true", "yes", "on"])
+def test_orchestration_tasks_v2_only_zero_disables(monkeypatch, value):
+    """The flag uses ``== "1"`` so anything else parses as off — but the
+    server module currently treats only the literal ``"1"`` as on. The
+    intent of the rollout is "default-on, ``0`` disables"; this guards
+    that the literal-1 contract on the **server** module still holds
+    after the flip (i.e. an empty string env var still parses as off).
+
+    The agent + dashboard read sites use the more permissive
+    ``!= "0"`` parse — those have separate coverage.
+    """
+    monkeypatch.setenv("OPENLEGION_ORCHESTRATION_TASKS_V2", value)
+    server_module = _reload_server()
+    try:
+        assert server_module._ORCHESTRATION_TASKS_V2 is False
+    finally:
+        monkeypatch.delenv("OPENLEGION_ORCHESTRATION_TASKS_V2", raising=False)
+        _reload_server()


### PR DESCRIPTION
## Summary

Skips the staged `warn → enforce` / v2-flag rollout the roadmap planned for. Ships the full operator orchestration stack with both opt-in flags default-on so existing fleets transition seamlessly on the next mesh restart.

**Branch base:** `feat/dashboard-cli-orchestration-surfaces` (PR #834) → … → `main`. This PR is the cap on the 14-PR stack.

## Defaults flipped

| Flag | Old default | New default | Off-switch |
|---|---|---|---|
| `OPENLEGION_PROJECT_SCOPE_MODE` | `warn` | `enforce` | `=warn` to fall back |
| `OPENLEGION_ORCHESTRATION_TASKS_V2` | `0` | `1` | `=0` to disable |

Both off-switches still work for emergency rollback.

## Migration auto-runs at startup

`create_mesh_app()` invokes `migrate_blackboard_to_tasks(blackboard, tasks_store)` immediately after the orchestration store is constructed and before any FastAPI route registers. The migration is **idempotent** — second restart finds nothing to migrate. Failures are logged at ERROR with full traceback but **never crash startup**; legacy tasks stay in place and can be migrated manually with the same helper.

## Operator surface that activates on merge

- Task 6 task records v2 endpoints + `coordination_tool` consuming them
- Task 7 product tools (`list_project_status`, `summarize_project_progress`, `reroute_task`, `retry_failed_task`, `cancel_task`, archive/delete project + agent)
- Task 9 Workplace dashboard tab fully populated
- Task 5 `/mesh/agents` per-caller filter enforced (workers see own-project + operator)
- Membership-mutation wildcard strip (already on regardless of mode)

Hot-path `can_read_blackboard` / `can_write_blackboard` enforcement remains a future follow-up — pre-existing in-place `["*"]` ACLs that haven't been touched by membership mutation still grant fleet-wide access. **Audit `permissions.json` for `'"*"'` entries on non-operator agents before relying on full project isolation at the data layer.**

## Tests

**New `tests/test_rollout_defaults.py`** (6 functions, 9 cases):
- `test_project_scope_mode_default_is_enforce`
- `test_orchestration_tasks_v2_default_on`
- `test_orchestration_tasks_v2_can_be_disabled` (off-switch still works)
- `test_project_scope_mode_can_be_warn` (off-switch still works)
- `test_invalid_project_scope_mode_falls_back_to_enforce`
- `test_orchestration_tasks_v2_only_zero_disables` (parametrized over 4 values)

**Extended `tests/test_orchestration_migration.py`** (4 new tests):
- Auto-run at startup migrates legacy rows
- Auto-run is idempotent (run twice → no-op second pass)
- Migration failure does not crash startup (caplog asserts ERROR is logged)
- Auto-run skipped when `_V2=0` (legacy key preserved)

**Existing tests updated for env-override semantics:**
- `test_orchestration_endpoints.py` — `_reload_server(v2=False)` now `setenv("…_V2", "0")` instead of `delenv`
- `test_operator_product_tools.py` — 3 v2-flag-off tests switched to explicit `setenv`
- `test_integration.py::mesh_components` fixture pins `OPENLEGION_PROJECT_SCOPE_MODE=warn` — anonymous `TestClient` calls filter to `{operator}` under enforce because `_caller_projects("unknown")` returns empty; the pin keeps legacy contract for the ~50 non-scope tests
- `test_mesh.py` — 6 unauthenticated `/mesh/agents` tests pinned to `warn` for the same reason

## Test plan

- [x] `pytest tests/test_rollout_defaults.py tests/test_orchestration_migration.py tests/test_orchestration*.py tests/test_mesh.py tests/test_dashboard.py tests/test_coordination.py` — 540 passed
- [x] Full non-E2E suite — 5277 passed, 44 skipped, **0 deselections** (Task 2b inherited failures + version-flag both resolved by PR #826's `f3b7ce47`)
- [x] Ruff clean on `src/` and `tests/`

## Stack

1. #821 — Task 0 hotfix
2. #822 — Task 1 characterization tests
3. #823 — Task 2a typed model
4. #824 — Task 2b stamp sites
5. #825 — Task 2c channel pairing recheck
6. #826 — Task 2d pending-actions SQLite
7. #827 — Task 2e wake block
8. #828 — Task 3 perm split
9. #829 — Task 4 operator cryptographic registration
10. #830 — Task 5 project isolation (now default-enforce)
11. #831 — Task 6 durable task records (now default-on)
12. #832 — Task 7 operator product tools
13. #833 — Task 8 structured routing fields
14. #834 — Task 9 dashboard + CLI surfaces
15. **This PR** — rollout: defaults official, migration auto-runs

## Rollback

If something regresses in production, ops can set `.env`:

```
OPENLEGION_ORCHESTRATION_TASKS_V2=0
OPENLEGION_PROJECT_SCOPE_MODE=warn
```

and restart. Both off-switches preserve legacy semantics. Already-migrated tasks stay in the SQLite table; new handoffs go back to the blackboard path.