### PR TITLE
chore(cleanup): drop post-rollout transition shims

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -86,9 +86,4 @@ markers = [
     # playwright && playwright install firefox``). CI honours the same
     # skipif and does NOT install playwright.
     "browser: real-browser test requiring playwright (CI does not run)",
-    # Tests pinning behavior that a later task will deliberately change.
-    # Each marked test asserts today's accidental or over-broad behavior so
-    # future tasks can locate them by filter (``pytest -m characterization``)
-    # and flip or delete them in lockstep with the production change.
-    "characterization: tests pinning behavior to be changed in a later task",
 ]

--- a/src/agent/builtins/coordination_tool.py
+++ b/src/agent/builtins/coordination_tool.py
@@ -167,14 +167,10 @@ async def hand_off(
     if output_key:
         task_record["output_key"] = output_key
     if origin:
-        # ``origin`` may be a typed ``MessageOrigin`` (post-Task-2a stamp
-        # sites) or a legacy raw dict. Persist as plain dict so the
-        # blackboard JSON write doesn't choke on a Pydantic instance and
-        # downstream readers continue to see the same shape.
-        if hasattr(origin, "model_dump"):
-            task_record["origin"] = origin.model_dump()
-        elif isinstance(origin, dict):
-            task_record["origin"] = dict(origin)
+        # Persist as plain dict so the blackboard JSON write doesn't
+        # choke on a Pydantic instance and downstream readers see the
+        # same shape they always have.
+        task_record["origin"] = origin.model_dump()
 
     task_key = (
         f"global/tasks/{to}/{handoff_id}"

--- a/src/agent/loop.py
+++ b/src/agent/loop.py
@@ -1648,7 +1648,7 @@ class AgentLoop:
 
     async def chat(
         self, user_message: str, *, trace_id: str | None = None,
-        origin: "MessageOrigin | dict[str, str] | None" = None,
+        origin: "MessageOrigin | None" = None,
     ) -> dict:
         """Handle a single chat turn with persistent conversation history.
 
@@ -2471,7 +2471,7 @@ class AgentLoop:
 
     async def chat_stream(
         self, user_message: str, *, trace_id: str | None = None,
-        origin: "MessageOrigin | dict[str, str] | None" = None,
+        origin: "MessageOrigin | None" = None,
     ):
         """Streaming chat that yields SSE events as they happen.
 

--- a/src/agent/mesh_client.py
+++ b/src/agent/mesh_client.py
@@ -260,7 +260,7 @@ class MeshClient:
 
     async def wake_agent(
         self, target: str, message: str = "",
-        origin: "MessageOrigin | dict | None" = None,
+        origin: "MessageOrigin | None" = None,
     ) -> dict:
         """Wake a target agent so it processes work immediately."""
         from src.shared.trace import origin_header

--- a/src/channels/base.py
+++ b/src/channels/base.py
@@ -191,7 +191,7 @@ class Channel(abc.ABC):
 
     async def dispatch(
         self, agent: str, message: str,
-        origin: "MessageOrigin | dict[str, str] | None" = None,
+        origin: "MessageOrigin | None" = None,
     ) -> str:
         """Route a message to an agent and return the response.
 

--- a/src/cli/runtime.py
+++ b/src/cli/runtime.py
@@ -162,7 +162,7 @@ class RuntimeContext:
     def dispatch(
         self, agent: str, message: str, mode: str = "followup",
         trace_id: str | None = None,
-        origin: "MessageOrigin | dict[str, str] | None" = None,
+        origin: "MessageOrigin | None" = None,
         auto_notify: bool = False,
     ) -> str:
         """Thread-safe synchronous message dispatch.
@@ -182,7 +182,7 @@ class RuntimeContext:
     async def async_dispatch(
         self, agent: str, message: str, mode: str = "followup",
         trace_id: str | None = None,
-        origin: "MessageOrigin | dict[str, str] | None" = None,
+        origin: "MessageOrigin | None" = None,
         auto_notify: bool = False,
     ) -> str:
         """Async dispatch: schedules onto the dedicated dispatch loop."""
@@ -475,7 +475,7 @@ class RuntimeContext:
 
         async def _direct_dispatch(
             agent_name: str, message: str,
-            origin: "MessageOrigin | dict | None" = None,
+            origin: "MessageOrigin | None" = None,
             **_kwargs,
         ) -> str:
             from src.shared.trace import current_trace_id, origin_header
@@ -558,7 +558,7 @@ class RuntimeContext:
             ), return_exceptions=True)
 
     async def _handle_notify_origin(
-        self, origin: dict, message: str, agent_name: str = "",
+        self, origin: "MessageOrigin", message: str, agent_name: str = "",
     ) -> None:
         """Route a completed task result back to the originating channel+user.
 
@@ -578,8 +578,8 @@ class RuntimeContext:
         """
         if not origin or not self.channel_manager:
             return
-        channel_type = origin.get("channel")
-        user = origin.get("user")
+        channel_type = origin.channel
+        user = origin.user
         if not channel_type or not user:
             return
         ch = self.channel_manager._channel_map.get(channel_type)

--- a/src/host/lanes.py
+++ b/src/host/lanes.py
@@ -36,10 +36,7 @@ class QueuedTask:
     message: str
     mode: str = "followup"
     trace_id: str | None = None
-    # Task 2b: stamp sites now produce typed ``MessageOrigin``. Legacy
-    # dict shape still accepted during the migration window for paths
-    # that have not been flipped yet (Task 2c will do the recheck).
-    origin: MessageOrigin | dict[str, str] | None = None
+    origin: MessageOrigin | None = None
     auto_notify: bool = False
     future: asyncio.Future = field(default_factory=asyncio.Future)
 
@@ -84,7 +81,7 @@ class LaneManager:
     async def enqueue(
         self, agent: str, message: str, *, mode: str = "followup",
         trace_id: str | None = None,
-        origin: MessageOrigin | dict[str, str] | None = None,
+        origin: MessageOrigin | None = None,
         auto_notify: bool = False,
     ) -> str:
         """Queue a message for an agent with the specified mode.
@@ -112,7 +109,7 @@ class LaneManager:
 
     async def _handle_followup(
         self, agent: str, message: str, *, trace_id: str | None = None,
-        origin: MessageOrigin | dict[str, str] | None = None,
+        origin: MessageOrigin | None = None,
         auto_notify: bool = False,
     ) -> str:
         """Standard FIFO enqueue."""
@@ -262,25 +259,25 @@ class LaneManager:
                     and result != SILENT_REPLY_TOKEN
                 ):
                     fn = self._notify_fn
-                    origin_copy = dict(task.origin)
+                    forward_origin = task.origin
                     task_agent = task.agent
                     task_result = result
 
                     async def _forward():
                         try:
                             await asyncio.wait_for(
-                                fn(origin_copy, task_result, task_agent),
+                                fn(forward_origin, task_result, task_agent),
                                 timeout=_NOTIFY_FORWARD_TIMEOUT,
                             )
                         except asyncio.TimeoutError:
                             logger.warning(
                                 "Lane auto-notify to origin %s timed out after %ds",
-                                origin_copy, _NOTIFY_FORWARD_TIMEOUT,
+                                forward_origin, _NOTIFY_FORWARD_TIMEOUT,
                             )
                         except Exception as fwd_e:
                             logger.warning(
                                 "Lane auto-notify to origin %s failed: %s",
-                                origin_copy, fwd_e,
+                                forward_origin, fwd_e,
                             )
 
                     forward_task = asyncio.create_task(_forward())

--- a/src/host/server.py
+++ b/src/host/server.py
@@ -100,22 +100,20 @@ if TYPE_CHECKING:
 
 # ── Pending Config Change Store (SQLite-backed) ──────────────────
 #
-# Task 2d migrated this from an in-memory dict to a SQLite-backed
-# ``PendingActions`` store (``data/pending_actions.db``) so pending
-# operator-config edits survive mesh restarts. Schema carries the
-# payload digest (replay protection) and origin kind (so confirm-side
-# gates can require ``origin_kind="human"``). The mesh app picks the
-# canonical instance up via ``_get_pending_actions_store()`` below;
-# the module-level helpers (kept for backward compatibility with
-# external test imports) delegate to that singleton.
+# Pending operator-config edits live in ``PendingActions``
+# (``data/pending_actions.db``) so they survive mesh restarts. Schema
+# carries the payload digest (replay protection) and origin kind (so
+# confirm-side gates can require ``origin_kind="human"``). The mesh
+# app picks the canonical instance up via ``_get_pending_actions_store()``
+# below; the module-level helpers delegate to that singleton.
 _MAX_PENDING = 10
 _CHANGE_TTL_SECONDS = 300
 
 # Module-level singleton used by the ``_store_pending_change`` /
-# ``_get_pending_change`` / ``_consume_pending_change`` shims below.
+# ``_get_pending_change`` / ``_consume_pending_change`` helpers below.
 # ``create_mesh_app`` sets this to its own instance so the helpers and
 # the app share one store; tests that import the helpers directly get
-# an in-memory store the first time they touch one of the shims.
+# an in-memory store the first time they touch one of the helpers.
 _pending_actions_singleton: PendingActions | None = None
 
 
@@ -135,77 +133,8 @@ def _get_pending_actions_store() -> PendingActions:
     return _pending_actions_singleton
 
 
-# ── Backward-compat dict view ───────────────────────────────────────
-# Existing tests (``tests/test_operator_audit.py``) imported the legacy
-# ``_pending_changes`` dict directly. They want to ``.clear()`` it,
-# index into it, and mutate ``expires_at`` on a row to force expiry.
-# We expose a thin proxy that forwards each operation to the SQLite
-# store so those existing tests keep passing without leaking the old
-# in-memory dict semantics back into production code.
-
-class _PendingChangesProxy:
-    """Dict-like view over the SQLite pending_actions store.
-
-    Keeps the legacy ``_pending_changes`` import working: ``.clear()``,
-    ``__contains__``, ``__getitem__`` for tests; production code uses
-    :class:`PendingActions` directly.
-    """
-
-    def _store(self) -> PendingActions:
-        return _get_pending_actions_store()
-
-    def clear(self) -> None:
-        with self._store()._conn() as conn:
-            conn.execute("DELETE FROM pending_actions")
-
-    def __contains__(self, change_id: object) -> bool:
-        if not isinstance(change_id, str):
-            return False
-        return self._store().peek(change_id) is not None
-
-    def __len__(self) -> int:
-        return len(self._store().list_pending())
-
-    def __getitem__(self, change_id: str) -> dict:
-        rec = self._store().peek(change_id)
-        if rec is None:
-            raise KeyError(change_id)
-        # Translate from the new schema back to the legacy fields the
-        # old tests asserted on. ``payload`` carries the (old, new)
-        # value pair as a dict, plus ``field`` lives on the row itself.
-        payload = rec.get("payload") or {}
-        return {
-            "agent_id": rec["target_id"],
-            "field": rec["action_kind"],
-            "old_value": payload.get("old_value", ""),
-            "new_value": payload.get("new_value", ""),
-            "expires_at": datetime.fromtimestamp(rec["expires_at"], tz=timezone.utc),
-        }
-
-    def __setitem__(self, change_id: str, value: dict) -> None:
-        # Only the ``expires_at`` mutation is supported -- it's the
-        # only mutation legacy tests perform on this dict (to force
-        # expiry). Other writes go through ``_store_pending_change``.
-        if not isinstance(value, dict) or "expires_at" not in value:
-            raise NotImplementedError(
-                "Use _store_pending_change to insert; only expires_at "
-                "mutations are supported on this proxy.",
-            )
-        new_expiry = value["expires_at"]
-        if isinstance(new_expiry, datetime):
-            new_expiry = new_expiry.timestamp()
-        with self._store()._conn() as conn:
-            conn.execute(
-                "UPDATE pending_actions SET expires_at=? WHERE nonce=?",
-                (new_expiry, change_id),
-            )
-
-
-_pending_changes = _PendingChangesProxy()
-
-
 def _cleanup_expired_changes() -> None:
-    """Reap expired pending actions. Kept for backward compatibility."""
+    """Reap expired pending actions."""
     _get_pending_actions_store().reap_expired()
 
 
@@ -539,10 +468,9 @@ def create_mesh_app(
     # agent state when agents are removed.
     app.cleanup_agent = lambda agent_id: None  # replaced below
 
-    # Task 2d: persistent pending-action store (replaces the in-memory
-    # ``_pending_changes`` dict). Mirrors the path convention of
+    # Persistent pending-action store. Mirrors the path convention of
     # ``data/costs.db`` / ``data/traces.db``. The disk-backed instance
-    # is also assigned to the module-level singleton so the legacy
+    # is also assigned to the module-level singleton so the
     # ``_store_pending_change`` / ``_consume_pending_change`` helpers
     # share state with the endpoints below.
     pending_actions = PendingActions(db_path="data/pending_actions.db")

--- a/src/shared/trace.py
+++ b/src/shared/trace.py
@@ -10,13 +10,6 @@ via the ``X-Origin`` HTTP header.  It carries an authorization-bearing
 so downstream gates can distinguish a human-initiated wake from an
 agent-initiated one.
 
-Backward-compat (Task 2a → 2b): until stamp sites are migrated, the
-contextvar may still hold a raw ``{"channel": ..., "user": ...}`` dict.
-The helpers in this module accept either shape; readers can use
-attribute access (``origin.channel``) on a typed origin or fall back to
-dict-style access (``origin.get("channel")``) which works on both via
-:class:`MessageOrigin`'s dict-compat shim.
-
 Separate module (not utils.py) to keep tracing concerns isolated and
 avoid import cycles.
 """
@@ -24,7 +17,6 @@ avoid import cycles.
 from __future__ import annotations
 
 import contextvars
-import json
 import uuid
 
 from src.shared.types import (
@@ -43,12 +35,8 @@ current_trace_id: contextvars.ContextVar[str | None] = contextvars.ContextVar(
     "current_trace_id", default=None,
 )
 
-# Accepts either a typed :class:`MessageOrigin` (preferred) or a raw
-# ``{"channel": ..., "user": ...}`` dict (legacy stamp sites being
-# migrated in Task 2b). Readers should use attribute access on the
-# typed model or ``.get()`` (which works on both shapes).
 current_origin: contextvars.ContextVar[
-    "MessageOrigin | dict[str, str] | None"
+    "MessageOrigin | None"
 ] = contextvars.ContextVar("current_origin", default=None)
 
 
@@ -63,39 +51,15 @@ def trace_headers() -> dict[str, str]:
     return {TRACE_HEADER: tid} if tid else {}
 
 
-def origin_header(
-    origin: "MessageOrigin | dict[str, str] | None",
-) -> dict[str, str]:
+def origin_header(origin: "MessageOrigin | None") -> dict[str, str]:
     """Serialize an origin to an ``X-Origin`` header dict.
 
-    Accepts either a typed :class:`MessageOrigin` or a legacy
-    ``{"channel": ..., "user": ...}`` dict. Returns ``{}`` when origin
-    is empty so it can be spread into a headers dict unconditionally.
-
-    Dict input without a ``kind`` field is upgraded to ``kind="agent"``
-    (least-trusted) before serialization so the wire format always
-    carries an explicit kind for the next hop.
+    Returns ``{}`` when origin is empty so it can be spread into a
+    headers dict unconditionally.
     """
-    if not origin:
-        return {}
     if isinstance(origin, MessageOrigin):
         return {ORIGIN_HEADER: origin.to_header_value()}
-    # Legacy dict — emit with ``kind="agent"`` if not provided.
-    if not isinstance(origin, dict):
-        return {}
-    # Task 2a deprecation breadcrumb: stamp sites still emitting raw
-    # dicts will be migrated in Task 2b. Logging at debug keeps the
-    # signal available for the migration audit without spamming logs.
-    logger.debug(
-        "origin_header received legacy dict (kind=%s); migrate stamp site to MessageOrigin",
-        origin.get("kind", "agent"),
-    )
-    payload = {
-        "kind": origin.get("kind", "agent"),
-        "channel": origin.get("channel", ""),
-        "user": origin.get("user", ""),
-    }
-    return {ORIGIN_HEADER: json.dumps(payload, separators=(",", ":"))}
+    return {}
 
 
 def parse_origin_header(raw: str | None) -> "MessageOrigin | None":
@@ -109,7 +73,7 @@ def parse_origin_header(raw: str | None) -> "MessageOrigin | None":
 
     Field length bounds: ``channel`` ≤ 32 chars, ``user`` ≤ 128 chars,
     raw blob ≤ 512 chars. Legacy headers (no ``kind``) still require
-    non-empty ``channel`` and ``user`` to match the pre-Task-2a parser
+    non-empty ``channel`` and ``user`` to match the pre-typed-origin parser
     contract.
     """
     return MessageOrigin.from_header_value(raw, trust_kind=False)

--- a/src/shared/types.py
+++ b/src/shared/types.py
@@ -40,25 +40,18 @@ AGENT_ID_RE_PATTERN = r"^[a-zA-Z0-9][a-zA-Z0-9_-]{0,63}$"
 class MessageOrigin(BaseModel):
     """Typed origin for a message flowing through the mesh.
 
-    The ``kind`` field is the authorization-relevant piece: future tasks
-    gate durable actions on ``kind == "human"`` (Task 2d's pending-action
-    confirm), block worker → operator wakes when ``kind == "agent"``
-    (Task 2e), and downgrade unverifiable channel claims (Task 2c).
+    The ``kind`` field is the authorization-relevant piece: durable
+    actions gate on ``kind == "human"`` (pending-action confirm), worker
+    → operator wakes are blocked when ``kind == "agent"``, and
+    unverifiable channel claims are downgraded.
 
-    ``channel`` and ``user`` are free-form for now; they identify which
-    surface the message came from (cli, dashboard, telegram, …) and the
-    end-user id when one is available.
+    ``channel`` and ``user`` are free-form; they identify which surface
+    the message came from (cli, dashboard, telegram, …) and the end-user
+    id when one is available.
 
     The model is ``frozen=True`` — origins are stamped once at the entry
     point (CLI REPL, dashboard chat, channel adapter, cron tick, …) and
     must not be mutated mid-flight.
-
-    Backward-compat: this PR (Task 2a) introduces the model but does not
-    flip stamp sites yet (Task 2b). Existing call sites that construct
-    raw ``{"channel": ..., "user": ...}`` dicts continue to work; the
-    helpers in ``src.shared.trace`` accept both shapes. Dict-style
-    accessors (``__getitem__`` / ``get``) are provided so readers do not
-    need to branch on type during the migration.
     """
 
     kind: Literal["human", "operator", "agent", "system", "heartbeat", "cron"]
@@ -66,20 +59,6 @@ class MessageOrigin(BaseModel):
     user: str = ""
 
     model_config = {"frozen": True}
-
-    # Dict-style accessors — let readers that still treat origin as a
-    # ``dict[str, str]`` keep working through the Task 2b migration.
-    def __getitem__(self, key: str) -> str:
-        if key in {"kind", "channel", "user"}:
-            return getattr(self, key)
-        raise KeyError(key)
-
-    def get(self, key: str, default: Any = None) -> Any:
-        # Match ``dict.get`` semantics: present-but-empty returns the
-        # empty string, only an unknown key falls back to ``default``.
-        if key in {"kind", "channel", "user"}:
-            return getattr(self, key)
-        return default
 
     def to_header_value(self) -> str:
         """Serialize to a JSON ``X-Origin`` header value.

--- a/tests/test_coordination.py
+++ b/tests/test_coordination.py
@@ -563,11 +563,12 @@ class TestHandOffOriginPropagation:
         """hand_off reads current_origin contextvar and passes it to wake_agent."""
         from src.agent.builtins.coordination_tool import hand_off
         from src.shared.trace import current_origin
+        from src.shared.types import MessageOrigin
 
         mc = _make_mesh_client(agent_id="operator")
         mc.list_agents.return_value = {"chef": {"role": "chef"}}
 
-        origin = {"channel": "whatsapp", "user": "+1234"}
+        origin = MessageOrigin(kind="human", channel="whatsapp", user="+1234")
         token = current_origin.set(origin)
         try:
             result = await hand_off(
@@ -589,11 +590,12 @@ class TestHandOffOriginPropagation:
         """Origin is stored in the task_record written to the blackboard."""
         from src.agent.builtins.coordination_tool import hand_off
         from src.shared.trace import current_origin
+        from src.shared.types import MessageOrigin
 
         mc = _make_mesh_client(agent_id="operator")
         mc.list_agents.return_value = {"chef": {"role": "chef"}}
 
-        origin = {"channel": "telegram", "user": "99"}
+        origin = MessageOrigin(kind="human", channel="telegram", user="99")
         token = current_origin.set(origin)
         try:
             await hand_off(to="chef", summary="do work", mesh_client=mc)
@@ -603,7 +605,9 @@ class TestHandOffOriginPropagation:
         # The task_record write is the last write_blackboard call
         last_call = mc.write_blackboard.call_args_list[-1]
         task_record = last_call.args[1]
-        assert task_record.get("origin") == origin
+        # Origin is persisted as a plain dict so the JSON write doesn't
+        # choke on a Pydantic instance.
+        assert task_record.get("origin") == origin.model_dump()
 
     @pytest.mark.asyncio
     async def test_hand_off_stores_typed_origin_as_plain_dict(self):

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1952,10 +1952,6 @@ class TestParseOriginHeader:
         assert result.kind == "agent"
         assert result.channel == "whatsapp"
         assert result.user == "+1234"
-        # Dict-compat shim — readers in flight during the Task 2b
-        # migration can still treat it as a dict.
-        assert result.get("channel") == "whatsapp"
-        assert result.get("user") == "+1234"
 
     def test_none_returns_none(self):
         from src.shared.trace import parse_origin_header
@@ -2476,10 +2472,12 @@ class _FakeChannel:
 class TestHandleNotifyOrigin:
     @pytest.mark.asyncio
     async def test_routes_to_channel_with_agent_label(self):
+        from src.shared.types import MessageOrigin
+
         ch = _FakeChannel()
         rt = _stub_runtime_with_channel("whatsapp", ch)
         await rt._handle_notify_origin(
-            {"channel": "whatsapp", "user": "+1234"},
+            MessageOrigin(kind="human", channel="whatsapp", user="+1234"),
             "dinner is ready",
             "chef",
         )
@@ -2487,10 +2485,12 @@ class TestHandleNotifyOrigin:
 
     @pytest.mark.asyncio
     async def test_no_agent_label_when_agent_name_empty(self):
+        from src.shared.types import MessageOrigin
+
         ch = _FakeChannel()
         rt = _stub_runtime_with_channel("whatsapp", ch)
         await rt._handle_notify_origin(
-            {"channel": "whatsapp", "user": "+1234"},
+            MessageOrigin(kind="human", channel="whatsapp", user="+1234"),
             "raw message",
             "",
         )
@@ -2501,12 +2501,13 @@ class TestHandleNotifyOrigin:
         from unittest.mock import MagicMock
 
         from src.cli.runtime import RuntimeContext
+        from src.shared.types import MessageOrigin
         rt = RuntimeContext.__new__(RuntimeContext)
         rt.channel_manager = MagicMock()
         rt.channel_manager._channel_map = {}  # empty
         # No exception raised, no call made
         await rt._handle_notify_origin(
-            {"channel": "discord", "user": "99"},
+            MessageOrigin(kind="human", channel="discord", user="99"),
             "hi",
             "chef",
         )
@@ -2514,37 +2515,48 @@ class TestHandleNotifyOrigin:
     @pytest.mark.asyncio
     async def test_drops_when_channel_manager_missing(self):
         from src.cli.runtime import RuntimeContext
+        from src.shared.types import MessageOrigin
         rt = RuntimeContext.__new__(RuntimeContext)
         rt.channel_manager = None
         # Must be a no-op, not raise
         await rt._handle_notify_origin(
-            {"channel": "whatsapp", "user": "+1"},
+            MessageOrigin(kind="human", channel="whatsapp", user="+1"),
             "hi",
             "chef",
         )
 
     @pytest.mark.asyncio
     async def test_drops_on_invalid_origin(self):
+        from src.shared.types import MessageOrigin
+
         ch = _FakeChannel()
         rt = _stub_runtime_with_channel("whatsapp", ch)
-        # Missing user
-        await rt._handle_notify_origin({"channel": "whatsapp"}, "hi", "chef")
+        # Missing user (empty string user)
+        await rt._handle_notify_origin(
+            MessageOrigin(kind="human", channel="whatsapp", user=""),
+            "hi", "chef",
+        )
         # Missing channel
-        await rt._handle_notify_origin({"user": "+1"}, "hi", "chef")
-        # Empty dict
-        await rt._handle_notify_origin({}, "hi", "chef")
+        await rt._handle_notify_origin(
+            MessageOrigin(kind="human", channel="", user="+1"),
+            "hi", "chef",
+        )
+        # No origin at all
+        await rt._handle_notify_origin(None, "hi", "chef")
         assert ch.sent == []
 
     @pytest.mark.asyncio
     async def test_send_failure_is_caught_not_raised(self):
         from unittest.mock import AsyncMock
 
+        from src.shared.types import MessageOrigin
+
         ch = _FakeChannel()
         ch.send_to_user = AsyncMock(side_effect=RuntimeError("boom"))
         rt = _stub_runtime_with_channel("whatsapp", ch)
         # Must not raise — the warning is logged and swallowed
         await rt._handle_notify_origin(
-            {"channel": "whatsapp", "user": "+1"},
+            MessageOrigin(kind="human", channel="whatsapp", user="+1"),
             "hi",
             "chef",
         )

--- a/tests/test_message_origin.py
+++ b/tests/test_message_origin.py
@@ -1,20 +1,19 @@
 """Tests for the typed ``MessageOrigin`` model and ``trace.py`` helpers.
 
-Task 2a (operator orchestration roadmap) introduces ``MessageOrigin`` as
-a typed Pydantic model carrying ``kind``, ``channel``, and ``user``.
+``MessageOrigin`` is a typed Pydantic model carrying ``kind``,
+``channel``, and ``user``.
 
 The test surface here covers three concerns:
 
-* The model itself — validation, defaults, immutability, dict-compat.
+* The model itself — validation, defaults, immutability.
 * The ``X-Origin`` wire format — JSON shape, additive ``kind`` segment,
   legacy back-compat (no ``kind`` → ``kind="agent"``).
 * The ``parse_origin_header`` / ``origin_header`` helpers in
-  ``src.shared.trace`` — accepts both typed and dict input, returns
-  typed output.
+  ``src.shared.trace``.
 
 The "legacy header → kind=agent" case is the security-critical default:
 unauthenticated paths must NOT be able to claim ``kind="human"`` by
-sending the pre-Task-2a header shape.
+sending the pre-typed-origin header shape.
 """
 
 from __future__ import annotations
@@ -64,30 +63,12 @@ class TestMessageOriginModel:
         with pytest.raises(ValidationError):
             m.user = "+1"  # type: ignore[misc]
 
-    def test_dict_style_getitem(self):
-        m = MessageOrigin(kind="human", channel="cli", user="jeff")
-        assert m["kind"] == "human"
-        assert m["channel"] == "cli"
-        assert m["user"] == "jeff"
-        with pytest.raises(KeyError):
-            _ = m["nope"]
-
-    def test_dict_style_get(self):
-        m = MessageOrigin(kind="cron")
-        # Empty channel/user return ``""`` (matches dict semantics where
-        # the key is present but the value is empty).
-        assert m.get("channel") == ""
-        assert m.get("user") == ""
-        assert m.get("kind") == "cron"
-        # Unknown key falls back to default.
-        assert m.get("nope") is None
-        assert m.get("nope", "fallback") == "fallback"
-
     def test_dict_conversion_roundtrip(self):
-        # ``lanes.py`` does ``dict(task.origin)`` — must produce a plain
-        # dict containing all three fields.
+        # ``coordination_tool.hand_off`` persists ``origin.model_dump()``
+        # to the blackboard — must produce a plain dict containing all
+        # three fields.
         m = MessageOrigin(kind="operator", channel="dashboard", user="op-1")
-        d = dict(m)
+        d = m.model_dump()
         assert d == {"kind": "operator", "channel": "dashboard", "user": "op-1"}
 
 
@@ -236,32 +217,8 @@ class TestTraceHelpers:
         parsed = json.loads(h["X-Origin"])
         assert parsed == {"kind": "human", "channel": "cli", "user": "jeff"}
 
-    def test_origin_header_dict_input_back_compat(self):
-        # Stamps not yet migrated still pass dicts. Must serialize.
-        h = origin_header({"kind": "human", "channel": "cli", "user": "jeff"})
-        parsed = json.loads(h["X-Origin"])
-        assert parsed == {"kind": "human", "channel": "cli", "user": "jeff"}
-
-    def test_origin_header_typed_and_dict_produce_identical_payload(self):
-        m = MessageOrigin(kind="operator", channel="dashboard", user="op-1")
-        h_typed = origin_header(m)
-        h_dict = origin_header(
-            {"kind": "operator", "channel": "dashboard", "user": "op-1"}
-        )
-        assert h_typed == h_dict
-
-    def test_origin_header_legacy_dict_no_kind_upgrades_to_agent(self):
-        # Dict without ``kind`` must serialize with ``kind="agent"`` so
-        # the next hop never sees a kind-less origin on the wire.
-        h = origin_header({"channel": "cli", "user": "jeff"})
-        parsed = json.loads(h["X-Origin"])
-        assert parsed["kind"] == "agent"
-        assert parsed["channel"] == "cli"
-        assert parsed["user"] == "jeff"
-
     def test_origin_header_none_returns_empty_dict(self):
         assert origin_header(None) == {}
-        assert origin_header({}) == {}
 
     def test_round_trip_through_helpers(self):
         m = MessageOrigin(kind="human", channel="telegram", user="+99")

--- a/tests/test_operator_audit.py
+++ b/tests/test_operator_audit.py
@@ -12,8 +12,8 @@ from src.host.server import (
     _CHANGE_TTL_SECONDS,
     _cleanup_expired_changes,
     _consume_pending_change,
+    _get_pending_actions_store,
     _get_pending_change,
-    _pending_changes,
     _store_pending_change,
 )
 
@@ -146,12 +146,19 @@ def test_audit_log_empty(blackboard):
 # === Pending Change Store Tests ===
 
 
+def _clear_pending_actions() -> None:
+    """Drop every row from the pending-actions store (test helper)."""
+    store = _get_pending_actions_store()
+    with store._conn() as conn:
+        conn.execute("DELETE FROM pending_actions")
+
+
 @pytest.fixture(autouse=True)
 def clear_pending_changes():
     """Clear the pending changes store before each test."""
-    _pending_changes.clear()
+    _clear_pending_actions()
     yield
-    _pending_changes.clear()
+    _clear_pending_actions()
 
 
 def test_store_and_get_pending_change():
@@ -184,16 +191,17 @@ def test_consume_nonexistent_change():
 def test_expired_changes_cleaned_up():
     """Expired changes are removed during cleanup."""
     change_id = _store_pending_change("alpha", "model", "old", "new")
-    # Manually expire it. ``_pending_changes`` is a SQLite-backed proxy
-    # (Task 2d), so the in-place mutation pattern ``[cid]["expires_at"]
-    # = ...`` no longer round-trips. Use the proxy's ``__setitem__``
-    # which performs a single-column UPDATE on the row.
-    _pending_changes[change_id] = {
-        "expires_at": datetime.now(timezone.utc) - timedelta(seconds=1),
-    }
+    # Force expiry by backdating ``expires_at`` directly on the store.
+    store = _get_pending_actions_store()
+    expired_ts = (datetime.now(timezone.utc) - timedelta(seconds=1)).timestamp()
+    with store._conn() as conn:
+        conn.execute(
+            "UPDATE pending_actions SET expires_at=? WHERE nonce=?",
+            (expired_ts, change_id),
+        )
 
     _cleanup_expired_changes()
-    assert change_id not in _pending_changes
+    assert _get_pending_change(change_id) is None
 
 
 def test_max_pending_evicts_oldest():
@@ -207,7 +215,7 @@ def test_max_pending_evicts_oldest():
 
     # Store one more — should evict the oldest
     new_id = _store_pending_change("alpha", "extra", "old", "new")
-    assert len(_pending_changes) == _MAX_PENDING
+    assert len(_get_pending_actions_store().list_pending()) == _MAX_PENDING
     # The first stored should be gone
     assert _get_pending_change(ids[0]) is None
     # The new one should exist
@@ -222,7 +230,8 @@ def test_get_nonexistent_change():
 def test_change_ttl():
     """Changes have a TTL matching _CHANGE_TTL_SECONDS."""
     change_id = _store_pending_change("alpha", "model", "old", "new")
-    change = _pending_changes[change_id]
+    change = _get_pending_change(change_id)
+    assert change is not None
     expected = datetime.now(timezone.utc) + timedelta(seconds=_CHANGE_TTL_SECONDS)
     # Allow 5 seconds tolerance
     assert abs((change["expires_at"] - expected).total_seconds()) < 5

--- a/tests/test_operator_create_agent.py
+++ b/tests/test_operator_create_agent.py
@@ -323,16 +323,13 @@ class TestCreateCustomAgent:
         assert resp.status_code == 200
         perms.reload.assert_called()
 
-    @pytest.mark.characterization
     def test_default_capabilities_seed_full_coordination_protocol(
         self, mesh_app, tmp_path,
     ):
-        # CAPTURE-TO-TIGHTEN — this asserts today's broad bootstrap defaults.
-        # Task 3/5 should replace wildcard read plus browser/cron grants with
-        # explicit operator-managed capabilities and project-scoped visibility.
-        """Today operator-created agents get broad coordination defaults written
+        """Operator-created agents get broad coordination defaults written
         to ``permissions.json`` so their imminent ``/mesh/register`` call does
-        not fall through to deny-all. Specifically:
+        not fall through to deny-all. Regression guard for ``3b90a0a``.
+        Specifically:
 
           * ``blackboard_read``  ⊇ ``["*"]``
           * ``blackboard_write`` ⊇ the five coordination namespaces
@@ -341,11 +338,6 @@ class TestCreateCustomAgent:
           * ``can_use_browser``  is True
           * ``can_manage_cron``  is True
           * ``allowed_apis``     ⊇ ``{"llm", "image_gen"}``
-
-        This protects the historical 3b90a0a regression, but the breadth is
-        not a permanent security invariant. Future least-privilege work should
-        flip this test while preserving a narrower "agent can coordinate"
-        bootstrap path.
         """
         import json as _json
 

--- a/tests/test_pending_actions.py
+++ b/tests/test_pending_actions.py
@@ -1,7 +1,6 @@
-"""Tests for the SQLite-backed PendingActions store (Task 2d).
+"""Tests for the SQLite-backed PendingActions store.
 
-The legacy in-memory ``_pending_changes`` dict in ``src/host/server.py``
-was replaced with a persistent SQLite-backed store. These tests cover:
+These tests cover:
 
 * basic store / peek / consume semantics
 * atomic single-shot consume (replay protection)


### PR DESCRIPTION
## Summary

Pure cleanup pass. The 15-PR operator orchestration roadmap landed on `main`; this drops the backward-compat layers that existed solely for the staged-rollout migration window. **No production behavior change** — the cleanup is subtractive only.

**Net delta: 16 files, +114 / −282 (−168 lines)**

## What was removed

### A. `MessageOrigin` dict-compat shim (`src/shared/types.py`)
- Deleted `__getitem__` and `get` methods that let legacy dict-style readers access `origin["channel"]` / `origin.get("user")` during the Task 2b stamp-site migration.
- The two reader sites in `src/cli/runtime.py:_handle_notify_origin` migrated to attribute access.

### B. `current_origin` ContextVar union (`src/shared/trace.py`)
- Narrowed to `ContextVar[MessageOrigin | None]`.
- `origin_header()` collapsed to the typed-only form. Dropped the legacy-dict deprecation breadcrumb.
- `MessageOrigin | dict | None` annotations narrowed to `MessageOrigin | None` across `loop.py` / `mesh_client.py` / `channels/base.py` / `cli/runtime.py` / `lanes.py` — the unions existed only because of the contextvar shape.

### C. Coordination tool origin duck-type (`src/agent/builtins/coordination_tool.py`)
- Replaced `hasattr(origin, "model_dump")` / `isinstance(origin, dict)` branch with the direct call.

### D. `_PendingChangesProxy` shim (`src/host/server.py`)
- Deleted the dict-like proxy class (~60 lines) and the module-level `_pending_changes` singleton.
- Migrated `tests/test_operator_audit.py` to the proper `PendingActions` API (`.peek` / direct UPDATE for the expires_at mutation idiom / `.list_pending()` for `len`).
- Kept `_store_pending_change` / `_get_pending_change` / `_consume_pending_change` / `_cleanup_expired_changes` — they're still the propose/confirm endpoint API.

### E. Stray `@pytest.mark.characterization` (`tests/test_operator_create_agent.py`)
- Removed the marker on `test_default_capabilities_seed_full_coordination_protocol` — it's a forever-pin regression guard, not a flip target.
- `pytest -m characterization --collect-only` now matches 0 tests.
- Removed the marker registration from `pyproject.toml`.

### F. Tests of the dict-compat shim (`tests/test_message_origin.py`)
- Deleted 5 tests that exercised the now-removed `__getitem__` / `get` / dict-input paths.
- Kept all security-relevant tests: kind validation, `frozen=True`, header round-trip, **legacy-header `kind="agent"` security default**, rolling-deploy safety, `trust_kind=True` path.

## What was deliberately NOT touched

- `OPENLEGION_PROJECT_SCOPE_MODE` flag retirement — needs production soak before the flag goes away.
- `OPENLEGION_ORCHESTRATION_TASKS_V2` flag retirement — same.
- Legacy blackboard handoff branch in `coordination_tool.hand_off` (the `if v2_enabled:` switch) — depends on flag retirement.
- `global/output/{agent_id}/*` permissions carve-out — depends on hot-path enforcement.
- Hot-path `can_read_blackboard` / `can_write_blackboard` enforcement on wildcard ACLs — separate follow-up.
- Agent-side `x-mesh-internal` asymmetry hardening — separate follow-up.
- `capabilities` (runtime tool list) → `runtime_tools` rename to free up `capabilities` for the human-routing field — breaking change, separate.

## Test plan

- [x] `ruff check src/ tests/` — All checks passed
- [x] `pytest tests/ --ignore=tests/test_e2e*.py` — 5280 passed, 44 skipped, **0 failed**
- [x] `pytest -m characterization --collect-only` — 0 collected (5340 deselected; marker registration also removed)
- [x] Targeted: `test_message_origin.py + test_operator_audit.py + test_operator_create_agent.py + test_coordination.py + test_pending_actions.py + test_integration.py` → 279 passed