### PR TITLE
feat(operator): consolidate tool surface for context efficiency

### DIFF
--- a/docs/agent-tools.md
+++ b/docs/agent-tools.md
@@ -207,13 +207,15 @@ The following tools are only available to the **operator agent** (when `ALLOWED_
 
 | Tool | Parameters | Description |
 |------|-----------|-------------|
+| `inspect_agents` | `agent_id` (default ""), `depth` (default `"summary"`; values: `summary` / `profile` / `history`) | Look up agents. Empty `agent_id` lists the fleet at `summary` depth; passing an `agent_id` with `profile` returns the collaboration interface, or with `history` returns recent conversation history. Replaces `list_agents` / `get_agent_profile` / `read_agent_history` for the operator. |
+| `inspect_projects` | `detail` (default `"names"`; values: `names` / `status` / `full`), `project_name` (default "") | Look up projects. With no `project_name`, `names` returns name+description, `status` returns task-count rollups. Passing a `project_name` returns the full record. Replaces `list_projects` / `list_project_status` / `get_project` for the operator. |
+| `manage_project` | `project_name`, `action` (enum: `archive` / `delete`) | Lifecycle for a project. `delete` requires the project to already be archived. Replaces `archive_project` / `delete_project`. |
+| `manage_agent` | `agent_id`, `action` (enum: `archive` / `delete`) | Lifecycle for an agent. Same archive-then-delete contract as `manage_project`. Replaces `archive_agent` / `delete_agent`. |
+| `manage_task` | `task_id`, `action` (enum: `cancel` / `reroute` / `retry`), `new_assignee` (default "", only for `reroute`) | Single entry point for task ops. Replaces `cancel_task` / `reroute_task` / `retry_failed_task`. |
 | `propose_edit` | `agent_id`, `field` (enum: `instructions` / `soul` / `model` / `role` / `heartbeat` / `thinking` / `budget` / `permissions`), `value` | Propose a config change for an agent. Returns a `change_id` that must be confirmed. |
 | `confirm_edit` | `change_id` | Apply a previously proposed edit. |
 | `save_observations` | `fleet_summary`, `agents_attention` (default []), `cost_trend`, `notes` (default "") | Persist fleet health observations for human review. |
-| `read_agent_history` | `agent_id`, `period` (default "today"; values: `today` / `yesterday` / `week`) | Read an agent's conversation history with period filtering (operator version). |
 | `create_agent` | `name`, `role`, `model` (default ""), `instructions`, `soul` (default "") | Create a new agent. |
-| `list_projects` | -- | List all projects. |
-| `get_project` | `project_name` | Get details for a project. |
 | `create_project` | `name`, `description`, `agent_ids` (default []) | Create a new project and optionally add agents. |
 | `add_agents_to_project` | `project_name`, `agent_ids` | Add one or more agents to a project. |
 | `remove_agents_from_project` | `project_name`, `agent_ids` | Remove one or more agents from a project. |

--- a/src/agent/builtins/operator_tools.py
+++ b/src/agent/builtins/operator_tools.py
@@ -40,20 +40,14 @@ _OPERATOR_AGENT_ID = "operator"
 @skill(
     name="propose_edit",
     description=(
-        "Propose a change to an agent's configuration. Returns a preview diff "
-        "and change_id for confirmation. Always show the preview to the user "
-        "and wait for their approval before calling confirm_edit.\n\n"
-        "Fields: instructions, soul, model, role, heartbeat, interface, thinking, budget, permissions.\n"
-        "Value format: string for text fields, object for budget/permissions.\n"
-        "- budget: {\"daily_usd\": float, \"monthly_usd\": float}\n"
-        "- permissions: {\"can_use_browser\": bool, ...}\n"
-        "- thinking: \"off\", \"low\", \"medium\", \"high\"\n"
-        "- model: e.g. \"anthropic/claude-sonnet-4-20250514\""
+        "Propose a change to an agent's config. Returns a preview diff and "
+        "change_id; show the preview and get user approval before calling "
+        "confirm_edit. See INSTRUCTIONS.md for field formats."
     ),
     parameters={
         "agent_id": {
             "type": "string",
-            "description": "Target agent ID (use list_agents to find IDs)",
+            "description": "Target agent ID",
         },
         "field": {
             "type": "string",
@@ -300,60 +294,14 @@ async def save_observations(
     return {"saved": True, "timestamp": timestamp, "chars": len(content)}
 
 
-# ── Agent History ────────────────────────────────────────────
-
-
-@skill(
-    name="read_agent_history",
-    description=(
-        "Read an agent's activity history for a time period. "
-        "Shows tasks completed, failures, and key events."
-    ),
-    parameters={
-        "agent_id": {
-            "type": "string",
-            "description": "Agent ID to check",
-        },
-        "period": {
-            "type": "string",
-            "description": "Time period",
-            "enum": ["today", "yesterday", "week"],
-            "default": "today",
-        },
-    },
-)
-async def read_agent_history(
-    agent_id: str,
-    period: str = "today",
-    *,
-    mesh_client=None,
-    **_kw,
-) -> dict:
-    """Read an agent's activity history via the mesh."""
-    if not _is_operator():
-        return {"error": "This tool is only available to the operator agent."}
-    if mesh_client is None:
-        return {"error": "No mesh_client available"}
-    try:
-        response = await mesh_client._get_with_retry(
-            f"{mesh_client.mesh_url}/mesh/agents/{agent_id}/history",
-            params={"period": period},
-        )
-        response.raise_for_status()
-        return response.json()
-    except Exception as e:
-        return {"error": f"Failed to read history: {e}"}
-
-
 # ── Create Agent ─────────────────────────────────────────────
 
 
 @skill(
     name="create_agent",
     description=(
-        "Create a new custom agent with specified role, model, and instructions. "
-        "Essential for Basic plan users who need a custom agent that doesn't "
-        "match any template. Requires user confirmation."
+        "Create a new custom agent with role/model/instructions. "
+        "Requires user confirmation."
     ),
     parameters={
         "name": {
@@ -421,47 +369,65 @@ async def create_agent(
 
 
 @skill(
-    name="list_projects",
-    description="List all projects with their members and descriptions.",
-    parameters={},
+    name="inspect_projects",
+    description=(
+        "Read project info. detail='names' lists name+description; "
+        "detail='status' adds task-count rollups (requires v2). "
+        "Setting project_name returns full detail for that project."
+    ),
+    parameters={
+        "detail": {
+            "type": "string",
+            "description": "names | status | full",
+            "enum": ["names", "status", "full"],
+            "default": "names",
+        },
+        "project_name": {
+            "type": "string",
+            "description": "Optional — return full detail for this project only",
+            "default": "",
+        },
+    },
 )
-async def list_projects(*, mesh_client=None, **_kw) -> dict:
-    """List all projects (read-only, no provenance gate)."""
+async def inspect_projects(
+    detail: str = "names",
+    project_name: str = "",
+    *,
+    mesh_client=None,
+    **_kw,
+) -> dict:
+    """Consolidated project read tool (replaces list_projects /
+    get_project / list_project_status).
+    """
     if not _is_operator():
         return {"error": "This tool is only available to the operator agent."}
     if mesh_client is None:
         return {"error": "No mesh_client available"}
+
+    # Single-project lookup always returns full detail.
+    if project_name:
+        try:
+            result = await mesh_client.list_projects()
+        except Exception as e:
+            return {"error": f"Failed to inspect project: {e}"}
+        for p in result.get("projects", []):
+            if p.get("name") == project_name:
+                return p
+        return {"error": f"Project '{project_name}' not found"}
+
+    if detail == "status":
+        if not _orchestration_v2_on():
+            return {"error": _TASKS_V2_DISABLED}
+        try:
+            return await mesh_client.all_projects_status()
+        except Exception as e:
+            return {"error": f"Failed to read project status: {e}"}
+
+    # detail == "names" (also the default for "full" without project_name)
     try:
         return await mesh_client.list_projects()
     except Exception as e:
         return {"error": f"Failed to list projects: {e}"}
-
-
-@skill(
-    name="get_project",
-    description="Get details for a specific project including members and description.",
-    parameters={
-        "project_name": {
-            "type": "string",
-            "description": "Project name",
-        },
-    },
-)
-async def get_project(project_name: str, *, mesh_client=None, **_kw) -> dict:
-    """Get a single project's details (read-only, no provenance gate)."""
-    if not _is_operator():
-        return {"error": "This tool is only available to the operator agent."}
-    if mesh_client is None:
-        return {"error": "No mesh_client available"}
-    try:
-        result = await mesh_client.list_projects()
-        projects = result.get("projects", [])
-        for p in projects:
-            if p.get("name") == project_name:
-                return p
-        return {"error": f"Project '{project_name}' not found"}
-    except Exception as e:
-        return {"error": f"Failed to get project: {e}"}
 
 
 @skill(
@@ -707,42 +673,6 @@ def _parse_over_budget(error: Exception) -> dict | None:
 
 
 @skill(
-    name="list_project_status",
-    description=(
-        "List status rollups for projects. Per-project counts by status, "
-        "top blockers, and recent completions. If `project_id` is omitted, "
-        "returns one row per project the operator can see."
-    ),
-    parameters={
-        "project_id": {
-            "type": "string",
-            "description": "Optional project ID to scope to a single project",
-            "default": "",
-        },
-    },
-)
-async def list_project_status(
-    project_id: str = "",
-    *,
-    mesh_client=None,
-    **_kw,
-) -> dict:
-    """Fleet-wide or per-project status rollup."""
-    if not _is_operator():
-        return {"error": "This tool is only available to the operator agent."}
-    if mesh_client is None:
-        return {"error": "No mesh_client available"}
-    if not _orchestration_v2_on():
-        return {"error": _TASKS_V2_DISABLED}
-    try:
-        if project_id:
-            return await mesh_client.project_status(project_id)
-        return await mesh_client.all_projects_status()
-    except Exception as e:
-        return {"error": f"Failed to read project status: {e}"}
-
-
-@skill(
     name="list_agent_queue",
     description=(
         "Read an agent's task queue: current and recent tasks grouped by "
@@ -854,29 +784,63 @@ async def summarize_project_progress(
 
 
 @skill(
-    name="get_agent_profile",
+    name="inspect_agents",
     description=(
-        "Read an agent's public profile: role, capabilities, health, "
-        "subscriptions, INTERFACE.md contract."
+        "Read agents. Without agent_id: roster summary. With agent_id: "
+        "depth='profile' returns role/capabilities/INTERFACE; "
+        "depth='history' adds recent activity log. depth defaults to summary."
     ),
     parameters={
         "agent_id": {
             "type": "string",
-            "description": "Agent ID",
+            "description": "Optional — target agent for profile/history",
+            "default": "",
+        },
+        "depth": {
+            "type": "string",
+            "description": "summary | profile | history",
+            "enum": ["summary", "profile", "history"],
+            "default": "summary",
         },
     },
 )
-async def get_agent_profile(
-    agent_id: str,
+async def inspect_agents(
+    agent_id: str = "",
+    depth: str = "summary",
     *,
     mesh_client=None,
     **_kw,
 ) -> dict:
-    """Read an agent's profile via the mesh."""
+    """Consolidated agent read tool (replaces operator's use of list_agents
+    / get_agent_profile / read_agent_history).
+    """
     if not _is_operator():
         return {"error": "This tool is only available to the operator agent."}
     if mesh_client is None:
         return {"error": "No mesh_client available"}
+
+    # No agent_id → roster (always summary regardless of depth).
+    if not agent_id:
+        try:
+            registry = await mesh_client.list_agents()
+        except Exception as e:
+            return {"error": f"Failed to list agents: {e}"}
+        agents = []
+        for name, info in registry.items():
+            entry: dict = {"name": name}
+            if isinstance(info, dict):
+                entry["role"] = info.get("role", "")
+                entry["capabilities"] = info.get("capabilities", [])
+            agents.append(entry)
+        return {"agents": agents, "count": len(agents)}
+
+    if depth == "history":
+        try:
+            return await mesh_client.get_agent_history(agent_id)
+        except Exception as e:
+            return {"error": f"Failed to read history for {agent_id}: {e}"}
+
+    # depth == "profile" or "summary" with an agent_id → profile call
     try:
         return await mesh_client.get_agent_profile(agent_id)
     except Exception as e:
@@ -887,171 +851,146 @@ async def get_agent_profile(
 
 
 @skill(
-    name="reroute_task",
+    name="manage_task",
     description=(
-        "Reassign a task to a different agent. Cost-aware: refuses if the "
-        "new assignee is over budget (returns a structured error naming the "
-        "offending agent)."
+        "Cancel, reroute, or retry a task. action='cancel' stops the task; "
+        "action='reroute' moves it to new_assignee (required); "
+        "action='retry' clones a failed task (optionally overriding "
+        "assignee/title/description via with_changes). Reroute and retry "
+        "refuse if the target agent is over budget."
     ),
     parameters={
         "task_id": {
             "type": "string",
             "description": "Task ID",
+        },
+        "action": {
+            "type": "string",
+            "description": "cancel | reroute | retry",
+            "enum": ["cancel", "reroute", "retry"],
         },
         "new_assignee": {
             "type": "string",
-            "description": "New assignee agent ID",
+            "description": "Required for reroute; optional override for retry",
+            "default": "",
         },
         "reason": {
             "type": "string",
-            "description": "Optional reason for the reroute",
+            "description": "Optional reason recorded on the audit trail",
             "default": "",
-        },
-    },
-)
-async def reroute_task(
-    task_id: str,
-    new_assignee: str,
-    reason: str = "",
-    *,
-    mesh_client=None,
-    **_kw,
-) -> dict:
-    """Reassign a task. Cost-gated."""
-    if not _is_operator():
-        return {"error": "This tool is only available to the operator agent."}
-    if mesh_client is None:
-        return {"error": "No mesh_client available"}
-    if not _orchestration_v2_on():
-        return {"error": _TASKS_V2_DISABLED}
-    try:
-        return await mesh_client.reroute_task(task_id, new_assignee, reason=reason)
-    except Exception as e:
-        budget = _parse_over_budget(e)
-        if budget is not None:
-            return {
-                "error": "over_budget",
-                "detail": budget.get("detail") or (
-                    f"Agent {budget.get('budget', {}).get('agent', new_assignee)!r} "
-                    "is over budget."
-                ),
-                "budget": budget.get("budget"),
-            }
-        return {"error": f"Failed to reroute task: {e}"}
-
-
-@skill(
-    name="cancel_task",
-    description="Cancel a task with an optional reason recorded on the audit trail.",
-    parameters={
-        "task_id": {
-            "type": "string",
-            "description": "Task ID",
-        },
-        "reason": {
-            "type": "string",
-            "description": "Reason for cancellation",
-            "default": "",
-        },
-    },
-)
-async def cancel_task(
-    task_id: str,
-    reason: str = "",
-    *,
-    mesh_client=None,
-    **_kw,
-) -> dict:
-    """Cancel a task."""
-    if not _is_operator():
-        return {"error": "This tool is only available to the operator agent."}
-    if mesh_client is None:
-        return {"error": "No mesh_client available"}
-    if not _orchestration_v2_on():
-        return {"error": _TASKS_V2_DISABLED}
-    try:
-        return await mesh_client.cancel_task(task_id, reason=reason)
-    except Exception as e:
-        return {"error": f"Failed to cancel task: {e}"}
-
-
-@skill(
-    name="retry_failed_task",
-    description=(
-        "Retry a failed task by cloning it as a new pending task. "
-        "Optional `with_changes` patches title / description / assignee. "
-        "Cost-aware: refuses if the (possibly overridden) target agent is "
-        "over budget."
-    ),
-    parameters={
-        "task_id": {
-            "type": "string",
-            "description": "Task ID of the failed task",
         },
         "with_changes": {
             "type": "object",
             "description": (
-                "Optional patch with keys 'title', 'description', 'assignee' "
-                "to override on the retry"
+                "retry only: optional patch with 'title', 'description', "
+                "'assignee' overrides"
             ),
             "default": {},
         },
     },
 )
-async def retry_failed_task(
+async def manage_task(
     task_id: str,
+    action: str,
+    new_assignee: str = "",
+    reason: str = "",
     with_changes: dict | None = None,
     *,
     mesh_client=None,
     **_kw,
 ) -> dict:
-    """Retry a failed task. Cost-gated."""
+    """Consolidated task action tool (replaces cancel_task / reroute_task /
+    retry_failed_task).
+    """
     if not _is_operator():
         return {"error": "This tool is only available to the operator agent."}
     if mesh_client is None:
         return {"error": "No mesh_client available"}
     if not _orchestration_v2_on():
         return {"error": _TASKS_V2_DISABLED}
-    patch = with_changes or {}
-    try:
-        return await mesh_client.retry_task(
-            task_id,
-            title=patch.get("title"),
-            description=patch.get("description"),
-            assignee=patch.get("assignee"),
-        )
-    except Exception as e:
-        budget = _parse_over_budget(e)
-        if budget is not None:
-            return {
-                "error": "over_budget",
-                "detail": budget.get("detail") or "Target agent is over budget.",
-                "budget": budget.get("budget"),
-            }
-        return {"error": f"Failed to retry task: {e}"}
+
+    if action == "cancel":
+        try:
+            return await mesh_client.cancel_task(task_id, reason=reason)
+        except Exception as e:
+            return {"error": f"Failed to cancel task: {e}"}
+
+    if action == "reroute":
+        if not new_assignee:
+            return {"error": "reroute requires new_assignee"}
+        try:
+            return await mesh_client.reroute_task(
+                task_id, new_assignee, reason=reason,
+            )
+        except Exception as e:
+            budget = _parse_over_budget(e)
+            if budget is not None:
+                return {
+                    "error": "over_budget",
+                    "detail": budget.get("detail") or (
+                        f"Agent "
+                        f"{budget.get('budget', {}).get('agent', new_assignee)!r} "
+                        "is over budget."
+                    ),
+                    "budget": budget.get("budget"),
+                }
+            return {"error": f"Failed to reroute task: {e}"}
+
+    if action == "retry":
+        patch = dict(with_changes or {})
+        # `new_assignee` is a convenience shortcut for retry overrides.
+        if new_assignee and "assignee" not in patch:
+            patch["assignee"] = new_assignee
+        try:
+            return await mesh_client.retry_task(
+                task_id,
+                title=patch.get("title"),
+                description=patch.get("description"),
+                assignee=patch.get("assignee"),
+            )
+        except Exception as e:
+            budget = _parse_over_budget(e)
+            if budget is not None:
+                return {
+                    "error": "over_budget",
+                    "detail": budget.get("detail") or "Target agent is over budget.",
+                    "budget": budget.get("budget"),
+                }
+            return {"error": f"Failed to retry task: {e}"}
+
+    return {"error": f"Unknown action {action!r}; use cancel|reroute|retry"}
 
 
 @skill(
-    name="archive_project",
+    name="manage_project",
     description=(
-        "Archive a project. Stops scheduling and hides it from default "
-        "list views while retaining all data. Reversible."
+        "Archive or delete a project. action='archive' is reversible and "
+        "stops scheduling. action='delete' returns a confirmation nonce; "
+        "the project must already be archived."
     ),
     parameters={
-        "project_id": {
+        "project_name": {
             "type": "string",
-            "description": "Project ID",
+            "description": "Project name",
+        },
+        "action": {
+            "type": "string",
+            "description": "archive | delete",
+            "enum": ["archive", "delete"],
         },
     },
 )
-async def archive_project(
-    project_id: str,
+async def manage_project(
+    project_name: str,
+    action: str,
     *,
     mesh_client=None,
     _messages=None,
     **_kw,
 ) -> dict:
-    """Archive a project. Provenance-gated."""
+    """Consolidated project lifecycle tool (archive | delete).
+    Provenance-gated.
+    """
     if not _is_operator():
         return {"error": "This tool is only available to the operator agent."}
     if mesh_client is None:
@@ -1060,152 +999,99 @@ async def archive_project(
     if _messages is None or not _last_message_is_user_origin(_messages):
         return {
             "error": "provenance_check_failed",
-            "detail": "User confirmation required to archive a project.",
+            "detail": f"User confirmation required to {action} a project.",
         }
-    try:
-        return await mesh_client.archive_project(project_id)
-    except Exception as e:
-        return {"error": f"Failed to archive project: {e}"}
+
+    if action == "archive":
+        try:
+            return await mesh_client.archive_project(project_name)
+        except Exception as e:
+            return {"error": f"Failed to archive project: {e}"}
+
+    if action == "delete":
+        try:
+            result = await mesh_client.propose_delete_project(project_name)
+            result.setdefault("requires_confirmation", True)
+            return result
+        except Exception as e:
+            msg = str(e)
+            if "must be archived" in msg.lower() or "400" in msg:
+                return {
+                    "error": "archive_required",
+                    "detail": (
+                        f"Project {project_name!r} must be archived first. "
+                        "Call manage_project(action='archive') first."
+                    ),
+                }
+            return {"error": f"Failed to propose delete: {e}"}
+
+    return {"error": f"Unknown action {action!r}; use archive|delete"}
 
 
 @skill(
-    name="archive_agent",
+    name="manage_agent",
     description=(
-        "Archive an agent. Stops scheduling, retains workspace and history. "
-        "Reversible. Required pre-condition for delete_agent."
+        "Archive or delete an agent. action='archive' is reversible and "
+        "stops scheduling. action='delete' returns a confirmation nonce; "
+        "the agent must already be archived."
     ),
     parameters={
         "agent_id": {
             "type": "string",
             "description": "Agent ID",
         },
+        "action": {
+            "type": "string",
+            "description": "archive | delete",
+            "enum": ["archive", "delete"],
+        },
     },
 )
-async def archive_agent(
+async def manage_agent(
     agent_id: str,
+    action: str,
     *,
     mesh_client=None,
     _messages=None,
     **_kw,
 ) -> dict:
-    """Archive an agent. Provenance-gated."""
+    """Consolidated agent lifecycle tool (archive | delete).
+    Provenance-gated.
+    """
     if not _is_operator():
         return {"error": "This tool is only available to the operator agent."}
     if mesh_client is None:
         return {"error": "No mesh_client available"}
     if agent_id.lower() == _OPERATOR_AGENT_ID:
-        return {"error": "Cannot archive the operator agent."}
+        return {"error": f"Cannot {action} the operator agent."}
     from src.agent.loop import _last_message_is_user_origin
     if _messages is None or not _last_message_is_user_origin(_messages):
         return {
             "error": "provenance_check_failed",
-            "detail": "User confirmation required to archive an agent.",
+            "detail": f"User confirmation required to {action} an agent.",
         }
-    try:
-        return await mesh_client.archive_agent(agent_id)
-    except Exception as e:
-        return {"error": f"Failed to archive agent: {e}"}
 
+    if action == "archive":
+        try:
+            return await mesh_client.archive_agent(agent_id)
+        except Exception as e:
+            return {"error": f"Failed to archive agent: {e}"}
 
-@skill(
-    name="delete_project",
-    description=(
-        "Propose deletion of an archived project. Returns a confirmation "
-        "nonce; the user must confirm via the dashboard or CLI to actually "
-        "delete the project. Pre-condition: project must already be "
-        "archived (call archive_project first)."
-    ),
-    parameters={
-        "project_id": {
-            "type": "string",
-            "description": "Project ID (must be archived)",
-        },
-    },
-)
-async def delete_project(
-    project_id: str,
-    *,
-    mesh_client=None,
-    _messages=None,
-    **_kw,
-) -> dict:
-    """Propose project deletion. Two-step: this returns a nonce for human confirm."""
-    if not _is_operator():
-        return {"error": "This tool is only available to the operator agent."}
-    if mesh_client is None:
-        return {"error": "No mesh_client available"}
-    from src.agent.loop import _last_message_is_user_origin
-    if _messages is None or not _last_message_is_user_origin(_messages):
-        return {
-            "error": "provenance_check_failed",
-            "detail": "User confirmation required to delete a project.",
-        }
-    try:
-        result = await mesh_client.propose_delete_project(project_id)
-        # Surface the propose-then-confirm contract to the operator
-        # prompt so it knows to wait for human confirmation.
-        result.setdefault("requires_confirmation", True)
-        return result
-    except Exception as e:
-        msg = str(e)
-        if "must be archived" in msg.lower() or "400" in msg:
-            return {
-                "error": "archive_required",
-                "detail": (
-                    f"Project {project_id!r} must be archived before delete. "
-                    "Call archive_project first."
-                ),
-            }
-        return {"error": f"Failed to propose delete: {e}"}
+    if action == "delete":
+        try:
+            result = await mesh_client.propose_delete_agent(agent_id)
+            result.setdefault("requires_confirmation", True)
+            return result
+        except Exception as e:
+            msg = str(e)
+            if "must be archived" in msg.lower() or "400" in msg:
+                return {
+                    "error": "archive_required",
+                    "detail": (
+                        f"Agent {agent_id!r} must be archived first. "
+                        "Call manage_agent(action='archive') first."
+                    ),
+                }
+            return {"error": f"Failed to propose delete: {e}"}
 
-
-@skill(
-    name="delete_agent",
-    description=(
-        "Propose deletion of an archived agent. Returns a confirmation "
-        "nonce; the user must confirm via the dashboard or CLI to actually "
-        "delete the agent. Pre-condition: agent must already be archived "
-        "(call archive_agent first)."
-    ),
-    parameters={
-        "agent_id": {
-            "type": "string",
-            "description": "Agent ID (must be archived)",
-        },
-    },
-)
-async def delete_agent(
-    agent_id: str,
-    *,
-    mesh_client=None,
-    _messages=None,
-    **_kw,
-) -> dict:
-    """Propose agent deletion. Two-step: this returns a nonce for human confirm."""
-    if not _is_operator():
-        return {"error": "This tool is only available to the operator agent."}
-    if mesh_client is None:
-        return {"error": "No mesh_client available"}
-    if agent_id.lower() == _OPERATOR_AGENT_ID:
-        return {"error": "Cannot delete the operator agent."}
-    from src.agent.loop import _last_message_is_user_origin
-    if _messages is None or not _last_message_is_user_origin(_messages):
-        return {
-            "error": "provenance_check_failed",
-            "detail": "User confirmation required to delete an agent.",
-        }
-    try:
-        result = await mesh_client.propose_delete_agent(agent_id)
-        result.setdefault("requires_confirmation", True)
-        return result
-    except Exception as e:
-        msg = str(e)
-        if "must be archived" in msg.lower() or "400" in msg:
-            return {
-                "error": "archive_required",
-                "detail": (
-                    f"Agent {agent_id!r} must be archived before delete. "
-                    "Call archive_agent first."
-                ),
-            }
-        return {"error": f"Failed to propose delete: {e}"}
+    return {"error": f"Unknown action {action!r}; use archive|delete"}

--- a/src/cli/config.py
+++ b/src/cli/config.py
@@ -1500,24 +1500,27 @@ def _setup_agent_wizard(model: str) -> str:
 _OPERATOR_AGENT_ID = "operator"
 
 _OPERATOR_ALLOWED_TOOLS: list[str] = [
-    # Heartbeat tier (5)
-    "list_agents", "get_agent_profile", "get_system_status", "notify_user", "save_observations",
-    # Chat tier (+18)
-    "list_templates", "apply_template", "hand_off", "check_inbox", "update_status",
-    "read_agent_history", "propose_edit", "confirm_edit", "create_agent",
-    "list_projects", "get_project", "create_project",
+    # Monitoring + heartbeat
+    "get_system_status", "notify_user", "save_observations",
+    # Inspection (consolidated read tools)
+    "inspect_agents", "inspect_projects",
+    "list_agent_queue", "get_team_outputs", "summarize_project_progress",
+    # Coordination + chat
+    "list_templates", "apply_template", "hand_off", "check_inbox",
+    # Configuration edits
+    "propose_edit", "confirm_edit",
+    # Creation
+    "create_agent", "create_project",
+    # Project membership + context
     "add_agents_to_project", "remove_agents_from_project", "update_project_context",
-    "vault_list", "request_credential", "request_browser_login",
-    # Task 7: operator product surface — read tools
-    "list_project_status", "list_agent_queue", "get_team_outputs",
-    "summarize_project_progress",
-    # Task 7: operator product surface — action tools
-    "reroute_task", "cancel_task", "retry_failed_task",
-    "archive_project", "archive_agent", "delete_project", "delete_agent",
+    # Lifecycle (consolidated archive/delete)
+    "manage_project", "manage_agent", "manage_task",
+    # Credential + browser handoff
+    "request_credential", "request_browser_login",
 ]
 
 _OPERATOR_HEARTBEAT_TOOLS: list[str] = [
-    "list_agents", "get_agent_profile", "get_system_status", "notify_user", "save_observations",
+    "inspect_agents", "get_system_status", "notify_user", "save_observations",
 ]
 
 _OPERATOR_SOUL = """\
@@ -1547,11 +1550,11 @@ Your previous observations are included above in OBSERVATIONS.md.
    - Pre-computed agents_needing_attention list
    - Plan limits and current usage
 
-3. Call list_agents() for per-agent status overview.
+3. Call inspect_agents() for per-agent status overview.
 
 4. For agents flagged in agents_needing_attention or with new concerning signals
    (unhealthy, failure_rate > 0.30, cost_vs_yesterday_ratio > 2.0),
-   call get_agent_profile() for details.
+   call inspect_agents(agent_id, depth="profile") for details.
 
 5. Call save_observations() with:
    - fleet_summary: one-line health (e.g. "5/6 healthy, cost stable")

--- a/src/shared/operator_playbooks.py
+++ b/src/shared/operator_playbooks.py
@@ -59,7 +59,7 @@ plan as a bullet list with agent names bolded, then "Go ahead?"
 ## Routing Work
 
 When the user wants work done:
-1. Identify the right agent from list_agents()
+1. Identify the right agent from inspect_agents()
 2. hand_off() the task with a clear summary
 3. Tell the user who's on it
 
@@ -149,8 +149,7 @@ Excellent instructions are specific:
 Call propose_edit() for each agent, then show all proposed changes together. \
 After one user confirmation, call confirm_edit() for each change_id.
 
-5. **Set up credentials**: Call vault_list() to check existing credentials. \
-Triage what each agent needs:
+5. **Set up credentials**: Triage what each agent needs:
    - **Secrets** (API keys, tokens, passwords) → request_credential()
    - **Simple values** (email addresses, usernames, URLs, brand names) → \
      put directly in agent instructions via propose_edit(). Do NOT vault \
@@ -173,10 +172,11 @@ this chat. Example: request_browser_login(url="https://mail.google.com", \
 service="Email", description="Log in to listings@example.com", \
 agent_id="content-writer").
 
-7. **Verify setup**: Call get_agent_profile() for each new agent. Confirm \
-it is healthy, has the expected capabilities (browser tools, etc.), and \
-has a heartbeat schedule if one was configured. If an agent is unhealthy \
-or missing expected capabilities, investigate before confirming ready.
+7. **Verify setup**: Call inspect_agents(agent_id, depth="profile") for \
+each new agent. Confirm it is healthy, has the expected capabilities \
+(browser tools, etc.), and has a heartbeat schedule if one was \
+configured. If an agent is unhealthy or missing expected capabilities, \
+investigate before confirming ready.
 
 8. **Confirm ready**: State what each agent does and how they work together. \
 Tell the user who to talk to first and what to try: "Start by asking \
@@ -209,7 +209,12 @@ instead of long blog posts" rather than "Updated instructions field."
 5. Mention when changes take effect: instructions and heartbeat changes \
 apply on the agent's next task or heartbeat cycle.
 
-Fields: instructions, soul, model, role, heartbeat, thinking, budget, permissions."""
+Fields and value formats for propose_edit:
+- instructions, soul, role, heartbeat, interface — string
+- model — string, e.g. "anthropic/claude-sonnet-4-20250514"
+- thinking — one of "off", "low", "medium", "high"
+- budget — object: {"daily_usd": float, "monthly_usd": float}
+- permissions — object: {"can_use_browser": bool, ...}"""
 
 _PLAYBOOK_MONITOR = """\
 ## Active Playbook: Fleet Monitoring & Improvement
@@ -222,7 +227,8 @@ You're reviewing fleet health and looking for improvements.
 counts, agents needing attention.
 
 3. For flagged agents (unhealthy, high failure rate, cost spikes), call \
-get_agent_profile() and read_agent_history() for details.
+inspect_agents(agent_id, depth="profile") and \
+inspect_agents(agent_id, depth="history") for details.
 
 4. Assess whether agents are delivering on the original goals. Are they \
 producing useful output? Is the team shape still right for what the user \
@@ -264,37 +270,34 @@ Not everything belongs in the vault. Triage each external service:
 
 ## Steps
 
-1. Call vault_list() to check what credentials already exist.
-
-2. Review the agents — what external services will they use? For each, \
+1. Review the agents — what external services will they use? For each, \
 decide: vault, instructions, or browser login (see above).
 
-3. For secrets, call request_credential() with a plain-language \
+2. For secrets, call request_credential() with a plain-language \
 explanation: what service it connects to, why the agent needs it, and \
 where to find the key. For example: "This connects to Twitter so your \
 content agent can post directly. You can find your API key at \
 developer.twitter.com under your app settings."
 
-4. For simple values, use propose_edit() to embed them in the agent's \
+3. For simple values, use propose_edit() to embed them in the agent's \
 instructions. For example, an email address goes in the instructions, \
 not the vault.
 
-5. For cookie-based logins, call request_browser_login() with the target \
+4. For cookie-based logins, call request_browser_login() with the target \
 agent's ID. For example: request_browser_login(url="https://mail.google.com", \
 service="Email", description="Log in to listings@example.com", \
 agent_id="content-writer").
 
-6. Distinguish required credentials (agent cannot function without them) \
+5. Distinguish required credentials (agent cannot function without them) \
 from optional ones (agent works but with reduced capability). Tell the \
 user what can run today without any credentials.
 
-7. Request all vaulted credentials at once. Tell the user: "Fill in the \
+6. Request all vaulted credentials at once. Tell the user: "Fill in the \
 cards above and let me know when you're done. If you don't have a key \
 yet, that's fine — the agent will ask again when it needs it."
 
-8. When the user confirms, call vault_list() to verify vaulted \
-credentials. For browser logins, check whether the user completed each \
-login before marking the agent as ready. Report what's connected, what's \
+7. When the user confirms, check whether browser logins were completed \
+before marking each agent as ready. Report what's connected, what's \
 logged in, and what's still pending."""
 
 # ── Tool-to-playbook mapping ─────────────────────────────────
@@ -308,10 +311,8 @@ _TOOL_PLAYBOOK_MAP: dict[str, str] = {
     "update_project_context": "team_build",
     "propose_edit": "edit",
     "confirm_edit": "edit",
-    "read_agent_history": "monitor",
     "save_observations": "monitor",
     "request_credential": "credentials",
-    "vault_list": "credentials",
     "request_browser_login": "credentials",
 }
 

--- a/tests/test_operator_config.py
+++ b/tests/test_operator_config.py
@@ -244,19 +244,29 @@ class TestOperatorConstants:
 
     def test_allowed_tools_populated(self):
         from src.cli.config import _OPERATOR_ALLOWED_TOOLS, _OPERATOR_HEARTBEAT_TOOLS
-        # Task 7 added the operator product surface (4 read + 7 action tools).
-        assert len(_OPERATOR_ALLOWED_TOOLS) == 34
-        assert len(_OPERATOR_HEARTBEAT_TOOLS) == 5
+        # Operator's chat-tier surface after PR 0 consolidation.
+        assert len(_OPERATOR_ALLOWED_TOOLS) == 24
+        assert len(_OPERATOR_HEARTBEAT_TOOLS) == 4
         # Heartbeat tools should be a subset of allowed tools
         assert set(_OPERATOR_HEARTBEAT_TOOLS).issubset(set(_OPERATOR_ALLOWED_TOOLS))
-        # Task 7 product tools must be in the allowlist.
+        # Consolidated product tools (read + lifecycle) must be present.
         for tool in (
-            "list_project_status", "list_agent_queue", "get_team_outputs",
+            "inspect_projects", "inspect_agents",
+            "list_agent_queue", "get_team_outputs",
             "summarize_project_progress",
-            "reroute_task", "cancel_task", "retry_failed_task",
-            "archive_project", "archive_agent", "delete_project", "delete_agent",
+            "manage_project", "manage_agent", "manage_task",
         ):
             assert tool in _OPERATOR_ALLOWED_TOOLS
+        # Dropped dead-weight + replaced tools must be gone.
+        for tool in (
+            "update_status", "vault_list",
+            "list_projects", "get_project", "list_project_status",
+            "list_agents", "get_agent_profile", "read_agent_history",
+            "archive_project", "delete_project",
+            "archive_agent", "delete_agent",
+            "reroute_task", "cancel_task", "retry_failed_task",
+        ):
+            assert tool not in _OPERATOR_ALLOWED_TOOLS
 
     def test_request_browser_login_in_allowlist(self):
         """Operator must be allowed to delegate browser login requests to workers.
@@ -302,8 +312,8 @@ class TestOperatorConstants:
 
         assert "propose_edit" in _PLAYBOOK_TEAM_BUILD
         assert "confirm_edit" in _PLAYBOOK_EDIT
-        assert "get_agent_profile" in _PLAYBOOK_MONITOR
-        assert "vault_list" in _PLAYBOOK_CREDENTIALS
+        assert "inspect_agents" in _PLAYBOOK_MONITOR
+        assert "request_credential" in _PLAYBOOK_CREDENTIALS
 
     def test_core_has_plan_tiers(self):
         from src.shared.operator_playbooks import _OPERATOR_CORE

--- a/tests/test_operator_playbooks.py
+++ b/tests/test_operator_playbooks.py
@@ -132,13 +132,15 @@ class TestPlaybookConstants:
             assert "1." in content, f"{name} should have numbered steps"
 
     def test_tool_map_covers_all_action_tools(self):
-        # All action tools should be mapped
+        # All action tools should be mapped after the PR 0 consolidation
+        # (vault_list and read_agent_history were dropped from the operator
+        # surface, so they're no longer trigger tools).
         expected_tools = {
             "create_agent", "apply_template", "create_project",
             "add_agents_to_project", "remove_agents_from_project",
             "update_project_context", "propose_edit", "confirm_edit",
-            "read_agent_history", "save_observations",
-            "request_credential", "vault_list", "request_browser_login",
+            "save_observations",
+            "request_credential", "request_browser_login",
         }
         assert set(_TOOL_PLAYBOOK_MAP.keys()) == expected_tools
 
@@ -154,7 +156,6 @@ class TestPlaybookConstants:
         assert "apply_template" in _PLAYBOOK_TEAM_BUILD
         assert "add_agents_to_project" in _PLAYBOOK_TEAM_BUILD
         assert "update_project_context" in _PLAYBOOK_TEAM_BUILD
-        assert "vault_list" in _PLAYBOOK_TEAM_BUILD
         assert "request_credential" in _PLAYBOOK_TEAM_BUILD
         assert "request_browser_login" in _PLAYBOOK_TEAM_BUILD
 
@@ -165,7 +166,6 @@ class TestPlaybookConstants:
         assert "get_system_status" in _PLAYBOOK_MONITOR
         assert "save_observations" in _PLAYBOOK_MONITOR
 
-        assert "vault_list" in _PLAYBOOK_CREDENTIALS
         assert "request_credential" in _PLAYBOOK_CREDENTIALS
         assert "request_browser_login" in _PLAYBOOK_CREDENTIALS
 

--- a/tests/test_operator_product_tools.py
+++ b/tests/test_operator_product_tools.py
@@ -28,7 +28,7 @@ from src.shared.types import AgentPermissions, MessageOrigin
 
 @pytest.fixture(autouse=True)
 def _set_operator_env(monkeypatch):
-    monkeypatch.setenv("ALLOWED_TOOLS", "list_project_status,list_agent_queue")
+    monkeypatch.setenv("ALLOWED_TOOLS", "inspect_projects,list_agent_queue")
 
 
 # ── Helper: simulate an HTTP error wrapping an over_budget body ────
@@ -56,7 +56,7 @@ def _fake_budget_http_error(agent: str, monthly_used: float = 50.0) -> httpx.HTT
 
 
 @pytest.mark.asyncio
-async def test_list_project_status_requires_v2_flag(monkeypatch):
+async def test_inspect_projects_status_requires_v2_flag(monkeypatch):
     """Read tools that consume tasks return a clean error when v2 off.
 
     The flag now defaults to ``1`` (rollout) so the off path must
@@ -64,8 +64,8 @@ async def test_list_project_status_requires_v2_flag(monkeypatch):
     relying on the env var being unset.
     """
     monkeypatch.setenv("OPENLEGION_ORCHESTRATION_TASKS_V2", "0")
-    from src.agent.builtins.operator_tools import list_project_status
-    result = await list_project_status(mesh_client=MagicMock())
+    from src.agent.builtins.operator_tools import inspect_projects
+    result = await inspect_projects(detail="status", mesh_client=MagicMock())
     assert "error" in result
     assert "OPENLEGION_ORCHESTRATION_TASKS_V2" in result["error"]
 
@@ -96,38 +96,40 @@ async def test_summarize_project_progress_requires_v2_flag(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_reroute_task_requires_v2_flag(monkeypatch):
+async def test_manage_task_reroute_requires_v2_flag(monkeypatch):
     monkeypatch.delenv("OPENLEGION_ORCHESTRATION_TASKS_V2", raising=False)
-    from src.agent.builtins.operator_tools import reroute_task
-    result = await reroute_task("t1", "writer", mesh_client=MagicMock())
+    from src.agent.builtins.operator_tools import manage_task
+    result = await manage_task("t1", "reroute", new_assignee="writer",
+                                mesh_client=MagicMock())
     assert "error" in result
 
 
 @pytest.mark.asyncio
-async def test_cancel_task_requires_v2_flag(monkeypatch):
+async def test_manage_task_cancel_requires_v2_flag(monkeypatch):
     monkeypatch.delenv("OPENLEGION_ORCHESTRATION_TASKS_V2", raising=False)
-    from src.agent.builtins.operator_tools import cancel_task
-    result = await cancel_task("t1", mesh_client=MagicMock())
+    from src.agent.builtins.operator_tools import manage_task
+    result = await manage_task("t1", "cancel", mesh_client=MagicMock())
     assert "error" in result
 
 
 @pytest.mark.asyncio
-async def test_retry_failed_task_requires_v2_flag(monkeypatch):
+async def test_manage_task_retry_requires_v2_flag(monkeypatch):
     monkeypatch.delenv("OPENLEGION_ORCHESTRATION_TASKS_V2", raising=False)
-    from src.agent.builtins.operator_tools import retry_failed_task
-    result = await retry_failed_task("t1", mesh_client=MagicMock())
+    from src.agent.builtins.operator_tools import manage_task
+    result = await manage_task("t1", "retry", mesh_client=MagicMock())
     assert "error" in result
 
 
 @pytest.mark.asyncio
-async def test_archive_project_works_without_v2_flag(monkeypatch):
-    """Archive/delete project/agent tools work regardless of the v2 flag."""
+async def test_manage_project_archive_works_without_v2_flag(monkeypatch):
+    """Archive/delete project tools work regardless of the v2 flag."""
     monkeypatch.delenv("OPENLEGION_ORCHESTRATION_TASKS_V2", raising=False)
-    from src.agent.builtins.operator_tools import archive_project
+    from src.agent.builtins.operator_tools import manage_project
     mc = MagicMock()
     mc.archive_project = AsyncMock(return_value={"archived": True, "project": "growth"})
     messages = [{"role": "user", "content": "yes", "_origin": "user"}]
-    result = await archive_project("growth", mesh_client=mc, _messages=messages)
+    result = await manage_project("growth", "archive",
+                                   mesh_client=mc, _messages=messages)
     assert result["archived"] is True
 
 
@@ -135,31 +137,18 @@ async def test_archive_project_works_without_v2_flag(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_list_project_status_all_projects(monkeypatch):
+async def test_inspect_projects_status_all_projects(monkeypatch):
     monkeypatch.setenv("OPENLEGION_ORCHESTRATION_TASKS_V2", "1")
-    from src.agent.builtins.operator_tools import list_project_status
+    from src.agent.builtins.operator_tools import inspect_projects
     mc = MagicMock()
     mc.all_projects_status = AsyncMock(
         return_value={"projects": [
             {"project": {"name": "p1"}, "counts": {"active": 2}},
         ]},
     )
-    result = await list_project_status(mesh_client=mc)
+    result = await inspect_projects(detail="status", mesh_client=mc)
     assert "projects" in result
     mc.all_projects_status.assert_awaited_once()
-
-
-@pytest.mark.asyncio
-async def test_list_project_status_single_project(monkeypatch):
-    monkeypatch.setenv("OPENLEGION_ORCHESTRATION_TASKS_V2", "1")
-    from src.agent.builtins.operator_tools import list_project_status
-    mc = MagicMock()
-    mc.project_status = AsyncMock(
-        return_value={"project": {"name": "growth"}, "counts": {"active": 1}},
-    )
-    result = await list_project_status("growth", mesh_client=mc)
-    mc.project_status.assert_awaited_once_with("growth")
-    assert result["project"]["name"] == "growth"
 
 
 @pytest.mark.asyncio
@@ -198,21 +187,21 @@ async def test_summarize_project_progress_calls_mesh(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_get_agent_profile_calls_mesh():
-    """get_agent_profile is not gated on v2 — calls /mesh/agents/{id}/profile."""
-    from src.agent.builtins.operator_tools import get_agent_profile
+async def test_inspect_agents_profile_calls_mesh():
+    """inspect_agents(depth='profile') calls /mesh/agents/{id}/profile."""
+    from src.agent.builtins.operator_tools import inspect_agents
     mc = MagicMock()
     mc.get_agent_profile = AsyncMock(return_value={"agent_id": "writer", "role": "writer"})
-    result = await get_agent_profile("writer", mesh_client=mc)
+    result = await inspect_agents("writer", depth="profile", mesh_client=mc)
     assert result["agent_id"] == "writer"
 
 
 @pytest.mark.asyncio
-async def test_get_agent_profile_returns_structured_routing_fields():
+async def test_inspect_agents_profile_returns_structured_routing_fields():
     """Task 8 — operator profile read surfaces the new structured routing
     fields (capabilities are tool list; the four siblings + the
     interface_capabilities field carry the human-routing data)."""
-    from src.agent.builtins.operator_tools import get_agent_profile
+    from src.agent.builtins.operator_tools import inspect_agents
     mc = MagicMock()
     mc.get_agent_profile = AsyncMock(return_value={
         "agent_id": "researcher",
@@ -224,7 +213,7 @@ async def test_get_agent_profile_returns_structured_routing_fields():
         "escalation_to": "operator",
         "forbidden": ["Speculative findings as fact"],
     })
-    result = await get_agent_profile("researcher", mesh_client=mc)
+    result = await inspect_agents("researcher", depth="profile", mesh_client=mc)
     assert result["interface_capabilities"] == ["Web research", "Synthesize findings"]
     assert result["preferred_inputs"] == ["User questions"]
     assert result["expected_outputs"] == ["Research reports"]
@@ -234,56 +223,69 @@ async def test_get_agent_profile_returns_structured_routing_fields():
     assert result["capabilities"] == ["browser_navigate", "web_search"]
 
 
-# ── Action tool: reroute_task with cost gate ──────────────────
+# ── Action tool: manage_task with cost gate ──────────────────
 
 
 @pytest.mark.asyncio
-async def test_reroute_task_success(monkeypatch):
+async def test_manage_task_reroute_success(monkeypatch):
     monkeypatch.setenv("OPENLEGION_ORCHESTRATION_TASKS_V2", "1")
-    from src.agent.builtins.operator_tools import reroute_task
+    from src.agent.builtins.operator_tools import manage_task
     mc = MagicMock()
     mc.reroute_task = AsyncMock(
         return_value={"id": "task_1", "assignee": "writer", "status": "pending"},
     )
-    result = await reroute_task("task_1", "writer", reason="capacity",
-                                mesh_client=mc)
+    result = await manage_task("task_1", "reroute", new_assignee="writer",
+                                reason="capacity", mesh_client=mc)
     mc.reroute_task.assert_awaited_once_with("task_1", "writer", reason="capacity")
     assert result["assignee"] == "writer"
 
 
 @pytest.mark.asyncio
-async def test_reroute_task_over_budget_returns_structured_error(monkeypatch):
+async def test_manage_task_reroute_requires_new_assignee(monkeypatch):
+    """`reroute` action without new_assignee returns a clear error."""
+    monkeypatch.setenv("OPENLEGION_ORCHESTRATION_TASKS_V2", "1")
+    from src.agent.builtins.operator_tools import manage_task
+    result = await manage_task("task_1", "reroute", mesh_client=MagicMock())
+    assert "error" in result
+    assert "new_assignee" in result["error"]
+
+
+@pytest.mark.asyncio
+async def test_manage_task_reroute_over_budget_returns_structured_error(monkeypatch):
     """Over-budget surface from the mesh wraps a structured payload."""
     monkeypatch.setenv("OPENLEGION_ORCHESTRATION_TASKS_V2", "1")
-    from src.agent.builtins.operator_tools import reroute_task
+    from src.agent.builtins.operator_tools import manage_task
     mc = MagicMock()
     mc.reroute_task = AsyncMock(side_effect=_fake_budget_http_error("writer"))
-    result = await reroute_task("task_1", "writer", mesh_client=mc)
+    result = await manage_task("task_1", "reroute", new_assignee="writer",
+                                mesh_client=mc)
     assert result["error"] == "over_budget"
     assert "writer" in (result.get("budget") or {}).get("agent", "")
 
 
 @pytest.mark.asyncio
-async def test_cancel_task_success(monkeypatch):
+async def test_manage_task_cancel_success(monkeypatch):
     monkeypatch.setenv("OPENLEGION_ORCHESTRATION_TASKS_V2", "1")
-    from src.agent.builtins.operator_tools import cancel_task
+    from src.agent.builtins.operator_tools import manage_task
     mc = MagicMock()
     mc.cancel_task = AsyncMock(return_value={"id": "task_1", "status": "cancelled"})
-    result = await cancel_task("task_1", reason="bad scope", mesh_client=mc)
+    result = await manage_task("task_1", "cancel", reason="bad scope",
+                                mesh_client=mc)
     assert result["status"] == "cancelled"
     mc.cancel_task.assert_awaited_once_with("task_1", reason="bad scope")
 
 
 @pytest.mark.asyncio
-async def test_retry_failed_task_with_changes(monkeypatch):
+async def test_manage_task_retry_with_changes(monkeypatch):
     monkeypatch.setenv("OPENLEGION_ORCHESTRATION_TASKS_V2", "1")
-    from src.agent.builtins.operator_tools import retry_failed_task
+    from src.agent.builtins.operator_tools import manage_task
     mc = MagicMock()
     mc.retry_task = AsyncMock(
         return_value={"clone": {"id": "task_2"}, "original_id": "task_1"},
     )
-    result = await retry_failed_task(
-        "task_1", with_changes={"assignee": "scout", "title": "v2"},
+    result = await manage_task(
+        "task_1", "retry",
+        with_changes={"assignee": "scout", "title": "v2"},
         mesh_client=mc,
     )
     assert result["original_id"] == "task_1"
@@ -293,12 +295,12 @@ async def test_retry_failed_task_with_changes(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_retry_failed_task_over_budget(monkeypatch):
+async def test_manage_task_retry_over_budget(monkeypatch):
     monkeypatch.setenv("OPENLEGION_ORCHESTRATION_TASKS_V2", "1")
-    from src.agent.builtins.operator_tools import retry_failed_task
+    from src.agent.builtins.operator_tools import manage_task
     mc = MagicMock()
     mc.retry_task = AsyncMock(side_effect=_fake_budget_http_error("scout"))
-    result = await retry_failed_task("task_1", mesh_client=mc)
+    result = await manage_task("task_1", "retry", mesh_client=mc)
     assert result["error"] == "over_budget"
     assert (result.get("budget") or {}).get("agent") == "scout"
 
@@ -307,44 +309,48 @@ async def test_retry_failed_task_over_budget(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_archive_project_provenance_required():
-    from src.agent.builtins.operator_tools import archive_project
+async def test_manage_project_archive_provenance_required():
+    from src.agent.builtins.operator_tools import manage_project
     messages = [{"role": "user", "content": "x", "_origin": "system:heartbeat"}]
-    result = await archive_project("p1", mesh_client=MagicMock(), _messages=messages)
+    result = await manage_project("p1", "archive",
+                                    mesh_client=MagicMock(), _messages=messages)
     assert result["error"] == "provenance_check_failed"
 
 
 @pytest.mark.asyncio
-async def test_archive_project_success():
-    from src.agent.builtins.operator_tools import archive_project
+async def test_manage_project_archive_success():
+    from src.agent.builtins.operator_tools import manage_project
     mc = MagicMock()
     mc.archive_project = AsyncMock(return_value={"archived": True, "project": "p1"})
     messages = [{"role": "user", "content": "yes", "_origin": "user"}]
-    result = await archive_project("p1", mesh_client=mc, _messages=messages)
+    result = await manage_project("p1", "archive",
+                                    mesh_client=mc, _messages=messages)
     assert result["archived"] is True
 
 
 @pytest.mark.asyncio
-async def test_archive_agent_blocks_operator():
-    from src.agent.builtins.operator_tools import archive_agent
+async def test_manage_agent_archive_blocks_operator():
+    from src.agent.builtins.operator_tools import manage_agent
     messages = [{"role": "user", "content": "yes", "_origin": "user"}]
-    result = await archive_agent("operator", mesh_client=MagicMock(), _messages=messages)
+    result = await manage_agent("operator", "archive",
+                                  mesh_client=MagicMock(), _messages=messages)
     assert "operator" in result["error"].lower()
 
 
 @pytest.mark.asyncio
-async def test_archive_agent_success():
-    from src.agent.builtins.operator_tools import archive_agent
+async def test_manage_agent_archive_success():
+    from src.agent.builtins.operator_tools import manage_agent
     mc = MagicMock()
     mc.archive_agent = AsyncMock(return_value={"archived": True, "agent_id": "writer"})
     messages = [{"role": "user", "content": "yes", "_origin": "user"}]
-    result = await archive_agent("writer", mesh_client=mc, _messages=messages)
+    result = await manage_agent("writer", "archive",
+                                  mesh_client=mc, _messages=messages)
     assert result["archived"] is True
 
 
 @pytest.mark.asyncio
-async def test_delete_project_returns_nonce_for_confirmation():
-    from src.agent.builtins.operator_tools import delete_project
+async def test_manage_project_delete_returns_nonce_for_confirmation():
+    from src.agent.builtins.operator_tools import manage_project
     mc = MagicMock()
     mc.propose_delete_project = AsyncMock(return_value={
         "change_id": "abc-123",
@@ -354,42 +360,46 @@ async def test_delete_project_returns_nonce_for_confirmation():
         "requires_confirmation": True,
     })
     messages = [{"role": "user", "content": "yes", "_origin": "user"}]
-    result = await delete_project("growth", mesh_client=mc, _messages=messages)
+    result = await manage_project("growth", "delete",
+                                    mesh_client=mc, _messages=messages)
     assert result["requires_confirmation"] is True
     assert result["change_id"] == "abc-123"
     assert "summary" in result
 
 
 @pytest.mark.asyncio
-async def test_delete_project_provenance_required():
-    from src.agent.builtins.operator_tools import delete_project
+async def test_manage_project_delete_provenance_required():
+    from src.agent.builtins.operator_tools import manage_project
     messages = [{"role": "user", "content": "hb", "_origin": "system:heartbeat"}]
-    result = await delete_project("growth", mesh_client=MagicMock(), _messages=messages)
+    result = await manage_project("growth", "delete",
+                                    mesh_client=MagicMock(), _messages=messages)
     assert result["error"] == "provenance_check_failed"
 
 
 @pytest.mark.asyncio
-async def test_delete_project_archive_required():
+async def test_manage_project_delete_archive_required():
     """If the mesh rejects with 400, the tool surfaces a friendly hint."""
-    from src.agent.builtins.operator_tools import delete_project
+    from src.agent.builtins.operator_tools import manage_project
     mc = MagicMock()
     mc.propose_delete_project = AsyncMock(side_effect=RuntimeError("400: Project must be archived"))
     messages = [{"role": "user", "content": "yes", "_origin": "user"}]
-    result = await delete_project("growth", mesh_client=mc, _messages=messages)
+    result = await manage_project("growth", "delete",
+                                    mesh_client=mc, _messages=messages)
     assert result["error"] == "archive_required"
 
 
 @pytest.mark.asyncio
-async def test_delete_agent_blocks_operator():
-    from src.agent.builtins.operator_tools import delete_agent
+async def test_manage_agent_delete_blocks_operator():
+    from src.agent.builtins.operator_tools import manage_agent
     messages = [{"role": "user", "content": "yes", "_origin": "user"}]
-    result = await delete_agent("operator", mesh_client=MagicMock(), _messages=messages)
+    result = await manage_agent("operator", "delete",
+                                  mesh_client=MagicMock(), _messages=messages)
     assert "operator" in result["error"].lower()
 
 
 @pytest.mark.asyncio
-async def test_delete_agent_returns_nonce():
-    from src.agent.builtins.operator_tools import delete_agent
+async def test_manage_agent_delete_returns_nonce():
+    from src.agent.builtins.operator_tools import manage_agent
     mc = MagicMock()
     mc.propose_delete_agent = AsyncMock(return_value={
         "change_id": "n1",
@@ -399,7 +409,8 @@ async def test_delete_agent_returns_nonce():
         "requires_confirmation": True,
     })
     messages = [{"role": "user", "content": "yes", "_origin": "user"}]
-    result = await delete_agent("writer", mesh_client=mc, _messages=messages)
+    result = await manage_agent("writer", "delete",
+                                  mesh_client=mc, _messages=messages)
     assert result["change_id"] == "n1"
     assert result["requires_confirmation"] is True
 

--- a/tests/test_operator_tools.py
+++ b/tests/test_operator_tools.py
@@ -472,51 +472,68 @@ async def test_save_observations_history_cap(tmp_path):
     assert last_entry["fleet_summary"] == "check 54"
 
 
-# ── read_agent_history tests ────────────────────────────────
+# ── inspect_agents tests ────────────────────────────────────
 
 
 @pytest.mark.asyncio
-async def test_read_agent_history_no_mesh_client():
-    from src.agent.builtins.operator_tools import read_agent_history
+async def test_inspect_agents_no_mesh_client():
+    from src.agent.builtins.operator_tools import inspect_agents
 
-    result = await read_agent_history("writer")
+    result = await inspect_agents()
     assert "error" in result
     assert "mesh_client" in result["error"].lower()
 
 
 @pytest.mark.asyncio
-async def test_read_agent_history_success():
-    from src.agent.builtins.operator_tools import read_agent_history
-
-    mock_response = MagicMock()
-    mock_response.status_code = 200
-    mock_response.raise_for_status = MagicMock()
-    mock_response.json.return_value = {
-        "agent_id": "writer",
-        "entries": [{"time": "10:00", "event": "task_completed"}],
-    }
+async def test_inspect_agents_summary_returns_roster():
+    """No agent_id → roster summary built from list_agents()."""
+    from src.agent.builtins.operator_tools import inspect_agents
 
     mc = MagicMock()
-    mc.mesh_url = "http://localhost:8420"
-    mc._get_with_retry = AsyncMock(return_value=mock_response)
-
-    result = await read_agent_history("writer", period="today", mesh_client=mc)
-    assert result["agent_id"] == "writer"
-    mc._get_with_retry.assert_awaited_once()
-    call_args = mc._get_with_retry.call_args
-    assert "/mesh/agents/writer/history" in call_args[0][0]
-    assert call_args[1]["params"]["period"] == "today"
+    mc.list_agents = AsyncMock(return_value={
+        "writer": {"role": "writer", "capabilities": ["http_request"]},
+        "scout":  {"role": "researcher", "capabilities": ["web_search"]},
+    })
+    result = await inspect_agents(mesh_client=mc)
+    assert result["count"] == 2
+    names = {a["name"] for a in result["agents"]}
+    assert names == {"writer", "scout"}
 
 
 @pytest.mark.asyncio
-async def test_read_agent_history_error():
-    from src.agent.builtins.operator_tools import read_agent_history
+async def test_inspect_agents_profile_calls_get_agent_profile():
+    from src.agent.builtins.operator_tools import inspect_agents
 
     mc = MagicMock()
-    mc.mesh_url = "http://localhost:8420"
-    mc._get_with_retry = AsyncMock(side_effect=RuntimeError("connection refused"))
+    mc.get_agent_profile = AsyncMock(return_value={
+        "agent_id": "writer", "role": "writer",
+    })
+    result = await inspect_agents("writer", depth="profile", mesh_client=mc)
+    assert result["agent_id"] == "writer"
+    mc.get_agent_profile.assert_awaited_once_with("writer")
 
-    result = await read_agent_history("writer", mesh_client=mc)
+
+@pytest.mark.asyncio
+async def test_inspect_agents_history_calls_get_agent_history():
+    from src.agent.builtins.operator_tools import inspect_agents
+
+    mc = MagicMock()
+    mc.get_agent_history = AsyncMock(return_value={
+        "agent_id": "writer",
+        "entries": [{"time": "10:00", "event": "task_completed"}],
+    })
+    result = await inspect_agents("writer", depth="history", mesh_client=mc)
+    assert result["agent_id"] == "writer"
+    mc.get_agent_history.assert_awaited_once_with("writer")
+
+
+@pytest.mark.asyncio
+async def test_inspect_agents_error_surfaces():
+    from src.agent.builtins.operator_tools import inspect_agents
+
+    mc = MagicMock()
+    mc.get_agent_history = AsyncMock(side_effect=RuntimeError("connection refused"))
+    result = await inspect_agents("writer", depth="history", mesh_client=mc)
     assert "error" in result
     assert "connection refused" in result["error"]
 
@@ -598,36 +615,57 @@ async def test_create_agent_no_messages_fails_closed():
     assert result["error"] == "provenance_check_failed"
 
 
-# ── list_projects tests ─────────────────────────────────────
+# ── inspect_projects tests ──────────────────────────────────
 
 
 @pytest.mark.asyncio
-async def test_list_projects_no_mesh_client():
-    from src.agent.builtins.operator_tools import list_projects
+async def test_inspect_projects_no_mesh_client():
+    from src.agent.builtins.operator_tools import inspect_projects
 
-    result = await list_projects()
+    result = await inspect_projects()
     assert "error" in result
 
 
 @pytest.mark.asyncio
-async def test_list_projects_success():
-    from src.agent.builtins.operator_tools import list_projects
+async def test_inspect_projects_names_lists_all():
+    from src.agent.builtins.operator_tools import inspect_projects
 
     mc = MagicMock()
     mc.list_projects = AsyncMock(
         return_value={"projects": [{"name": "proj1", "members": ["a1"]}]},
     )
-    result = await list_projects(mesh_client=mc)
+    result = await inspect_projects(detail="names", mesh_client=mc)
     assert len(result["projects"]) == 1
     assert result["projects"][0]["name"] == "proj1"
 
 
-# ── get_project tests ───────────────────────────────────────
+@pytest.mark.asyncio
+async def test_inspect_projects_status_calls_all_projects_status(monkeypatch):
+    """detail='status' calls the v2 endpoint."""
+    monkeypatch.setenv("OPENLEGION_ORCHESTRATION_TASKS_V2", "1")
+    from src.agent.builtins.operator_tools import inspect_projects
+
+    mc = MagicMock()
+    mc.all_projects_status = AsyncMock(
+        return_value={"projects": [{"project": {"name": "p1"}, "counts": {"active": 2}}]},
+    )
+    result = await inspect_projects(detail="status", mesh_client=mc)
+    assert "projects" in result
+    mc.all_projects_status.assert_awaited_once()
 
 
 @pytest.mark.asyncio
-async def test_get_project_found():
-    from src.agent.builtins.operator_tools import get_project
+async def test_inspect_projects_status_requires_v2_flag(monkeypatch):
+    monkeypatch.setenv("OPENLEGION_ORCHESTRATION_TASKS_V2", "0")
+    from src.agent.builtins.operator_tools import inspect_projects
+
+    result = await inspect_projects(detail="status", mesh_client=MagicMock())
+    assert "error" in result
+
+
+@pytest.mark.asyncio
+async def test_inspect_projects_named_returns_full_detail():
+    from src.agent.builtins.operator_tools import inspect_projects
 
     mc = MagicMock()
     mc.list_projects = AsyncMock(
@@ -636,19 +674,19 @@ async def test_get_project_found():
             {"name": "proj2", "members": ["a2"]},
         ]},
     )
-    result = await get_project("proj2", mesh_client=mc)
+    result = await inspect_projects(project_name="proj2", mesh_client=mc)
     assert result["name"] == "proj2"
 
 
 @pytest.mark.asyncio
-async def test_get_project_not_found():
-    from src.agent.builtins.operator_tools import get_project
+async def test_inspect_projects_named_not_found():
+    from src.agent.builtins.operator_tools import inspect_projects
 
     mc = MagicMock()
     mc.list_projects = AsyncMock(
         return_value={"projects": [{"name": "proj1"}]},
     )
-    result = await get_project("nonexistent", mesh_client=mc)
+    result = await inspect_projects(project_name="nonexistent", mesh_client=mc)
     assert "error" in result
     assert "not found" in result["error"]
 


### PR DESCRIPTION
## Summary
- Drops 2 dead-weight tools from operator chat-tier allowlist (update_status, vault_list)
- Consolidates 11 redundant tools into 5 new ones (inspect_projects, inspect_agents, manage_project, manage_agent, manage_task)
- Trims verbose `propose_edit` / `create_agent` descriptions; field-format reference moves into the edit playbook
- Net: 34 -> 24 operator tools

## Why
Operator's tool surface had grown organically with overlapping read tools (list+get+history triples) and dual archive/delete entry points. Each tool schema costs hundreds of tokens — 34 tools is a meaningful chunk of overhead before the conversation starts. Consolidation makes the operator faster, cheaper, and gives the LLM a cleaner mental model of available capabilities.

## Scope
PR 0 of a multi-PR sequence to make the operator a true delegated executive. Subsequent PRs revise the confirmation flow (PR 1), unify inline confirmation cards (PR 2), add cancel buttons to credential/browser cards (PR 3), add task drill-in with outcome capture (PR 4), and add north-star fields + activity feed (PR 5).

## Notes for review
- `list_agents` / `get_agent_profile` / `read_agent_history` remain defined in `mesh_tool.py` (used by every worker for peer coordination). Only the operator's allowlist drops them — operator routes through `inspect_agents` instead.
- `_OPERATOR_HEARTBEAT_TOOLS` shrinks from 5 to 4 (heartbeat now uses `inspect_agents` in place of `list_agents` + `get_agent_profile`); heartbeat playbook text updated to match.
- `read_agent_history` was duplicated in both `operator_tools.py` and `mesh_tool.py`. The operator-side copy is removed; the shared one stays.
- PR scoped to `_OPERATOR_ALLOWED_TOOLS`, the operator-only `operator_tools.py`, and the playbooks/instructions that reference these tool names. No HTTP endpoints, dashboard UI, or permissions changed.

## Test plan
- [x] All existing tests pass after rename pass (5193 passed, 80 skipped)
- [x] `tests/test_operator_config.py` updated to assert the new size + the consolidated tool names + that dropped tools are absent
- [x] `tests/test_operator_tools.py` and `tests/test_operator_product_tools.py` updated with happy-path and gating tests for each new consolidated tool
- [ ] Manual: spin up dashboard, talk to operator, verify it can still do every capability the old tools provided
- [ ] Verify token count drop in operator's first-turn LLM call (compare before/after)