### PR TITLE
feat(dashboard): unify pending confirmations into inline chat cards

### DIFF
--- a/src/dashboard/static/js/app.js
+++ b/src/dashboard/static/js/app.js
@@ -1441,6 +1441,22 @@ function dashboard() {
         if (!resp.ok) return;
         const data = await resp.json();
         this.workplacePending = data.pending || [];
+        // Backfill the inline chat-card surface so a page reload still
+        // shows any open pending actions in the operator chat. The
+        // injection helper is idempotent on event_id so this is safe
+        // to call alongside the live WS stream.
+        for (const p of this.workplacePending) {
+          this._injectPendingActionCard({
+            nonce: p.nonce,
+            actor: p.actor,
+            target_kind: p.target_kind,
+            target_id: p.target_id,
+            action_kind: p.action_kind,
+            summary: p.summary,
+            preview_diff: p.preview_diff,
+            expires_at: p.expires_at,
+          });
+        }
       } catch (e) {
         console.error('Failed to load workplace pending actions:', e);
       }
@@ -1496,6 +1512,93 @@ function dashboard() {
       }
     },
 
+    // Confirm-button handler for the inline pending_action_card.
+    // Routes through the legacy ``/mesh/pending/{nonce}/confirm`` thin
+    // wrapper which dispatches to the right backend (config edit vs.
+    // destructive delete) by inspecting the stored row. The card's
+    // ``resolved_status`` flips to ``confirmed`` when the
+    // ``pending_action_resolved`` WS event lands; we don't mutate the
+    // message here so the round-trip stays the source of truth.
+    async confirmPendingActionCard(msg) {
+      try {
+        const resp = await fetch(`/mesh/pending/${encodeURIComponent(msg.event_id)}/confirm`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json', 'X-Requested-With': 'XMLHttpRequest' },
+          body: JSON.stringify({ payload_digest: msg.payload_digest || undefined }),
+        });
+        if (!resp.ok) {
+          const data = await resp.json().catch(() => ({}));
+          this.showToast(`Confirm failed: ${data.detail || resp.status}`);
+          return;
+        }
+      } catch (e) {
+        this.showToast(`Confirm failed: ${e.message || e}`);
+      }
+    },
+
+    async cancelPendingActionCard(msg) {
+      try {
+        const resp = await fetch(`/mesh/pending/${encodeURIComponent(msg.event_id)}/cancel`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json', 'X-Requested-With': 'XMLHttpRequest' },
+          body: '{}',
+        });
+        if (!resp.ok) {
+          const data = await resp.json().catch(() => ({}));
+          this.showToast(`Cancel failed: ${data.detail || resp.status}`);
+          return;
+        }
+      } catch (e) {
+        this.showToast(`Cancel failed: ${e.message || e}`);
+      }
+    },
+
+    // Inject a pending_action_card into the operator's chat history (and,
+    // if the user is currently viewing the operator in the main chat,
+    // into ``activeChatId === 'operator'`` — which is the same array
+    // because chatHistories is keyed by agent ID). Idempotent on
+    // event_id so a reload that re-fires the WS event doesn't duplicate
+    // the card.
+    _injectPendingActionCard(data) {
+      const target = 'operator';
+      if (!this.chatHistories[target]) this.chatHistories[target] = [];
+      const existing = this.chatHistories[target].find(
+        m => m.role === 'pending_action_card' && m.event_id === data.nonce,
+      );
+      if (existing) return;
+      const isDestructive = (
+        data.action_kind === 'delete'
+        && (data.target_kind === 'project' || data.target_kind === 'agent')
+      );
+      this.chatHistories[target].push({
+        role: 'pending_action_card',
+        event_id: data.nonce,
+        actor: data.actor || 'operator',
+        target_kind: data.target_kind || '',
+        target_id: data.target_id || '',
+        action_kind: data.action_kind || '',
+        summary: data.summary || '',
+        preview_diff: data.preview_diff || '',
+        expires_at: data.expires_at || 0,
+        _isDestructive: isDestructive,
+        resolved_status: null,
+        ts: Date.now() / 1000,
+      });
+    },
+
+    // Find the matching card by event_id and stamp a terminal state.
+    // Skips silently if the card isn't in history (e.g. WS event arrived
+    // for a nonce we never injected because the operator chat wasn't
+    // loaded yet).
+    _resolvePendingActionCard(eventId, status) {
+      for (const key of Object.keys(this.chatHistories || {})) {
+        const arr = this.chatHistories[key];
+        if (!Array.isArray(arr)) continue;
+        const m = arr.find(x => x.role === 'pending_action_card' && x.event_id === eventId);
+        if (m) m.resolved_status = status;
+      }
+    },
+
     // Apply a live event from the WebSocket to the in-memory workplace
     // state so the user sees changes without reloading. Each handler is
     // a small upsert into one of the lists; misses are tolerated (the
@@ -1532,12 +1635,23 @@ function dashboard() {
             target_kind: data.target_kind,
             target_id: data.target_id,
             action_kind: data.action_kind,
+            summary: data.summary,
+            preview_diff: data.preview_diff,
             expires_at: data.expires_at,
             created_at: Date.now() / 1000,
           });
         }
-      } else if (evt.type === 'pending_action_resolved' || evt.type === 'pending_action_expired') {
+        // Also surface as an inline chat card in the operator chat —
+        // the new single visual language for "operator wants the human
+        // to act." Idempotent on event_id.
+        this._injectPendingActionCard(data);
+      } else if (evt.type === 'pending_action_resolved') {
         this.workplacePending = this.workplacePending.filter(p => p.nonce !== data.nonce);
+        // ``status`` is "confirmed" (success) or "cancelled".
+        this._resolvePendingActionCard(data.nonce, data.status || 'confirmed');
+      } else if (evt.type === 'pending_action_expired') {
+        this.workplacePending = this.workplacePending.filter(p => p.nonce !== data.nonce);
+        this._resolvePendingActionCard(data.nonce, 'expired');
       }
     },
 

--- a/src/dashboard/templates/index.html
+++ b/src/dashboard/templates/index.html
@@ -297,41 +297,20 @@
                 </div>
               </div>
 
-              <!-- Task 9 — Inline pending-action review.
-                   Renders one bubble per open pending nonce above the
-                   operator chat so the human can confirm/cancel in
-                   context. Backed by the same state as the System >
-                   Operator panel. -->
-              <div x-show="operatorReady && workplacePending.length" x-cloak
-                   class="px-4 pt-3 space-y-2"
-                   x-init="loadWorkplacePending()">
-                <template x-for="p in workplacePending" :key="p.nonce">
-                  <div class="bg-amber-900/15 border border-amber-700/30 rounded-2xl px-3 py-2">
-                    <div class="text-[11px] text-amber-200 font-medium">
-                      Pending action awaiting confirmation
-                    </div>
-                    <div class="text-xs text-gray-200 mt-0.5">
-                      <span class="font-medium" x-text="p.action_kind"></span>
-                      <span class="text-gray-400" x-text="' on ' + (p.target_kind || '?') + ' ' + (p.target_id || '?')"></span>
-                    </div>
-                    <div class="text-[11px] text-gray-400 mt-0.5"
-                         x-text="'expires in ' + workplaceFormatExpiry(p.expires_at) + ' · proposed by ' + (p.actor || '?')"></div>
-                    <div class="flex gap-2 mt-2">
-                      <button @click="confirmPendingAction(p.nonce)"
-                        class="text-[11px] px-2.5 py-1 rounded bg-emerald-700/40 hover:bg-emerald-700/60 text-emerald-200 transition-colors">
-                        Confirm
-                      </button>
-                      <button @click="cancelPendingAction(p.nonce)"
-                        class="text-[11px] px-2.5 py-1 rounded bg-gray-700 hover:bg-gray-600 text-gray-300 transition-colors">
-                        Cancel
-                      </button>
-                    </div>
-                  </div>
-                </template>
-              </div>
+              <!-- Pending operator-proposed actions render inline as
+                   ``pending_action_card`` chat messages (see template
+                   below) — matching the credential / browser-login
+                   pattern. The legacy amber bubble that used to live
+                   here was removed to keep one visual language for
+                   "operator wants the human to act." -->
 
-              <!-- Messages area — reuses existing chatHistories binding -->
-              <div x-show="operatorReady" id="chat-messages-operator" class="flex-1 overflow-y-auto overflow-x-hidden px-4 py-3 space-y-3">
+              <!-- Messages area — reuses existing chatHistories binding.
+                   On mount we backfill any open pending actions so the
+                   inline card surface survives a page reload (the WS
+                   stream alone only delivers events going forward). -->
+              <div x-show="operatorReady" id="chat-messages-operator"
+                   x-init="loadWorkplacePending()"
+                   class="flex-1 overflow-y-auto overflow-x-hidden px-4 py-3 space-y-3">
                 <!-- Render messages from chatHistories['operator'] -->
                 <template x-for="(msg, i) in (chatHistories['operator'] || [])" :key="i">
                   <div>
@@ -606,6 +585,109 @@
                                   <path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12"/>
                                 </svg>
                                 <span x-text="'CAPTCHA help for ' + msg.service + ' was cancelled.'"></span>
+                              </div>
+                            </template>
+                          </div>
+                        </div>
+                      </div>
+                    </template>
+                    <!-- Pending operator action card. One visual
+                         language for "operator wants the human to act":
+                         matches the credential / browser-login pattern.
+                         Renders a one-line summary, a collapsible diff
+                         (config edits), an optional type-to-confirm gate
+                         (destructive ops), Confirm/Cancel buttons, and
+                         a TTL countdown. Auto-transitions to Confirmed,
+                         Cancelled, or Expired in place when the
+                         ``pending_action_resolved`` / ``..._expired``
+                         event lands. -->
+                    <template x-if="msg.role === 'pending_action_card'">
+                      <div class="flex justify-start gap-2.5">
+                        <div class="shrink-0 mt-1">
+                          <img src="/dashboard/static/avatars/operator.png" alt="Operator" class="w-6 h-6 rounded-full">
+                        </div>
+                        <div class="max-w-[80%] min-w-0">
+                          <div class="px-4 py-3 rounded-2xl rounded-bl-md bg-gray-800"
+                            :class="msg._isDestructive ? 'border border-rose-600/40' : 'border border-indigo-600/30'"
+                            x-data="{ diffOpen: false, typed: '', acting: false }">
+                            <!-- Pending state -->
+                            <template x-if="!msg.resolved_status">
+                              <div>
+                                <div class="flex items-center gap-2 mb-2">
+                                  <template x-if="msg._isDestructive">
+                                    <svg class="w-4 h-4 text-rose-400 shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="2">
+                                      <path stroke-linecap="round" stroke-linejoin="round" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6M1 7h22M9 7V4a2 2 0 012-2h2a2 2 0 012 2v3"/>
+                                    </svg>
+                                  </template>
+                                  <template x-if="!msg._isDestructive">
+                                    <svg class="w-4 h-4 text-indigo-400 shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="2">
+                                      <path stroke-linecap="round" stroke-linejoin="round" d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.065 2.572c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.572 1.065c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.065-2.572c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z"/>
+                                      <path stroke-linecap="round" stroke-linejoin="round" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z"/>
+                                    </svg>
+                                  </template>
+                                  <span class="text-xs font-medium shrink-0"
+                                    :class="msg._isDestructive ? 'text-rose-300' : 'text-indigo-300'"
+                                    x-text="msg._isDestructive ? 'Confirm destructive action' : 'Confirm change'"></span>
+                                  <span class="ml-auto text-[10px] text-gray-500 shrink-0"
+                                    x-text="'Expires in ' + workplaceFormatExpiry(msg.expires_at)"></span>
+                                </div>
+                                <p class="text-xs text-gray-200 mb-2" x-text="msg.summary || (msg.action_kind + ' on ' + (msg.target_kind || '?') + ' ' + (msg.target_id || '?'))"></p>
+                                <template x-if="msg.preview_diff">
+                                  <div class="mb-3">
+                                    <button @click="diffOpen = !diffOpen"
+                                      class="text-[10px] text-gray-400 hover:text-gray-200 transition-colors flex items-center gap-1">
+                                      <svg class="w-2.5 h-2.5 transition-transform" :class="diffOpen && 'rotate-90'" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M9 5l7 7-7 7"/></svg>
+                                      <span x-text="diffOpen ? 'Hide diff' : 'View diff'"></span>
+                                    </button>
+                                    <pre x-show="diffOpen" x-cloak
+                                      class="mt-2 text-[10px] font-mono whitespace-pre-wrap break-all max-h-48 overflow-y-auto bg-gray-900/60 rounded px-2 py-2 text-gray-300 custom-scrollbar"
+                                      x-text="msg.preview_diff"></pre>
+                                  </div>
+                                </template>
+                                <template x-if="msg._isDestructive">
+                                  <div class="mb-2">
+                                    <label class="block text-[10px] text-gray-400 mb-1"
+                                      x-text="'Type ' + (msg.target_id || '') + ' to confirm'"></label>
+                                    <input type="text" x-model="typed"
+                                      class="w-full px-3 py-1.5 rounded-lg bg-gray-900 border border-gray-700 text-xs text-white placeholder-gray-500 focus:border-rose-500 focus:outline-none"
+                                      :placeholder="msg.target_id || ''">
+                                  </div>
+                                </template>
+                                <div class="flex gap-2">
+                                  <button
+                                    @click="acting = true; confirmPendingActionCard(msg).finally(() => acting = false)"
+                                    :disabled="acting || (msg._isDestructive && typed !== msg.target_id)"
+                                    class="flex-1 px-3 py-1.5 rounded-lg text-xs font-medium transition-colors"
+                                    :class="(acting || (msg._isDestructive && typed !== msg.target_id))
+                                      ? 'bg-gray-700 text-gray-500 cursor-not-allowed'
+                                      : (msg._isDestructive ? 'bg-rose-600 hover:bg-rose-500 text-white' : 'bg-indigo-600 hover:bg-indigo-500 text-white')"
+                                    x-text="acting ? 'Working...' : 'Confirm'"></button>
+                                  <button
+                                    @click="acting = true; cancelPendingActionCard(msg).finally(() => acting = false)"
+                                    :disabled="acting"
+                                    class="px-3 py-1.5 rounded-lg text-xs font-medium bg-gray-700 hover:bg-gray-600 text-gray-300 transition-colors">
+                                    Cancel
+                                  </button>
+                                </div>
+                              </div>
+                            </template>
+                            <!-- Resolved (confirmed / cancelled / expired) -->
+                            <template x-if="msg.resolved_status === 'confirmed'">
+                              <div class="flex items-center gap-1.5 text-xs text-emerald-400">
+                                <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M5 13l4 4L19 7"/></svg>
+                                <span x-text="(msg.summary || 'Action') + ' — confirmed.'"></span>
+                              </div>
+                            </template>
+                            <template x-if="msg.resolved_status === 'cancelled'">
+                              <div class="flex items-center gap-1.5 text-xs text-gray-400">
+                                <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12"/></svg>
+                                <span x-text="(msg.summary || 'Action') + ' — cancelled.'"></span>
+                              </div>
+                            </template>
+                            <template x-if="msg.resolved_status === 'expired'">
+                              <div class="flex items-center gap-1.5 text-xs text-amber-400/80">
+                                <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z"/></svg>
+                                <span x-text="(msg.summary || 'Action') + ' — expired without confirmation.'"></span>
                               </div>
                             </template>
                           </div>
@@ -5000,46 +5082,23 @@
             </div>
           </div>
 
-          <!-- Task 9 — Pending actions review panel.
-               Lists every open propose-edit nonce so the human operator
-               can confirm or cancel before the action lands. CSRF on
-               POST is auto-injected by app.js. -->
-          <div class="bg-gray-900 border border-gray-800 rounded-lg p-5"
-               x-init="loadWorkplacePending(); $watch('systemTab', v => { if (v === 'operator') loadWorkplacePending(); })">
-            <div class="flex items-center justify-between mb-4">
-              <div>
-                <h3 class="text-sm font-medium text-gray-200">Pending actions</h3>
-                <p class="text-[10px] text-gray-500 mt-0.5">Operator-proposed edits awaiting human confirmation</p>
-              </div>
-              <button @click="loadWorkplacePending()" class="text-xs px-2.5 py-1 rounded bg-gray-800 hover:bg-gray-700 text-gray-400 hover:text-white transition-colors">Refresh</button>
+          <!-- Pending actions surface — replaced by the inline
+               ``pending_action_card`` chat message. Kept as a small
+               empty-state pointer so users coming from the previous
+               UX know where to look now. -->
+          <div class="bg-gray-900 border border-gray-800 rounded-lg p-5">
+            <div class="flex items-center gap-2 mb-2">
+              <svg class="w-4 h-4 text-gray-500 shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="2">
+                <path stroke-linecap="round" stroke-linejoin="round" d="M8 12h.01M12 12h.01M16 12h.01M21 12c0 4.418-4.03 8-9 8a9.863 9.863 0 01-4.255-.949L3 20l1.395-3.72C3.512 15.042 3 13.574 3 12c0-4.418 4.03-8 9-8s9 3.582 9 8z"/>
+              </svg>
+              <h3 class="text-sm font-medium text-gray-200">Pending actions</h3>
             </div>
-            <div x-show="!workplacePending.length" class="text-center py-6 text-gray-600 text-xs">
-              No pending actions. Proposed edits and destructive deletes will surface here for review.
-            </div>
-            <div x-show="workplacePending.length" class="space-y-2">
-              <template x-for="p in workplacePending" :key="p.nonce">
-                <div class="bg-gray-800/40 border border-gray-700/50 rounded-md p-3">
-                  <div class="flex items-center justify-between mb-1">
-                    <div class="text-xs text-gray-300">
-                      <span class="font-medium" x-text="p.action_kind"></span>
-                      <span class="text-gray-500 ml-1" x-text="' on ' + (p.target_kind || '?') + ' ' + (p.target_id || '?')"></span>
-                    </div>
-                    <div class="text-[11px] text-gray-500" x-text="'expires in ' + workplaceFormatExpiry(p.expires_at)"></div>
-                  </div>
-                  <div class="text-[11px] text-gray-500 mb-2" x-text="'proposed by ' + (p.actor || '?')"></div>
-                  <div class="flex gap-2">
-                    <button @click="confirmPendingAction(p.nonce)"
-                      class="text-[11px] px-2.5 py-1 rounded bg-emerald-700/40 hover:bg-emerald-700/60 text-emerald-200 transition-colors">
-                      Confirm
-                    </button>
-                    <button @click="cancelPendingAction(p.nonce)"
-                      class="text-[11px] px-2.5 py-1 rounded bg-gray-700 hover:bg-gray-600 text-gray-300 transition-colors">
-                      Cancel
-                    </button>
-                  </div>
-                </div>
-              </template>
-            </div>
+            <p class="text-xs text-gray-500">
+              Pending confirmations now appear inline in the operator chat — look for the
+              <span class="text-indigo-300">Confirm change</span> /
+              <span class="text-rose-300">Confirm destructive action</span>
+              cards there.
+            </p>
           </div>
 
           <!-- Audit log -->
@@ -6499,8 +6558,100 @@
                   </div>
                 </div>
               </template>
+              <!-- Pending operator action card. Mirror of the
+                   operator-panel template above so the same card
+                   renders in the main chat when the active surface is
+                   the operator. See app.js for the dispatch logic. -->
+              <template x-if="msg.role === 'pending_action_card'">
+                <div class="flex justify-start">
+                  <div class="max-w-[80%] min-w-0">
+                    <div class="px-4 py-3 rounded-2xl rounded-bl-md bg-gray-800"
+                      :class="msg._isDestructive ? 'border border-rose-600/40' : 'border border-indigo-600/30'"
+                      x-data="{ diffOpen: false, typed: '', acting: false }">
+                      <template x-if="!msg.resolved_status">
+                        <div>
+                          <div class="flex items-center gap-2 mb-2">
+                            <template x-if="msg._isDestructive">
+                              <svg class="w-4 h-4 text-rose-400 shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="2">
+                                <path stroke-linecap="round" stroke-linejoin="round" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6M1 7h22M9 7V4a2 2 0 012-2h2a2 2 0 012 2v3"/>
+                              </svg>
+                            </template>
+                            <template x-if="!msg._isDestructive">
+                              <svg class="w-4 h-4 text-indigo-400 shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="2">
+                                <path stroke-linecap="round" stroke-linejoin="round" d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.065 2.572c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.572 1.065c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.065-2.572c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z"/>
+                                <path stroke-linecap="round" stroke-linejoin="round" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z"/>
+                              </svg>
+                            </template>
+                            <span class="text-xs font-medium shrink-0"
+                              :class="msg._isDestructive ? 'text-rose-300' : 'text-indigo-300'"
+                              x-text="msg._isDestructive ? 'Confirm destructive action' : 'Confirm change'"></span>
+                            <span class="ml-auto text-[10px] text-gray-500 shrink-0"
+                              x-text="'Expires in ' + workplaceFormatExpiry(msg.expires_at)"></span>
+                          </div>
+                          <p class="text-xs text-gray-200 mb-2" x-text="msg.summary || (msg.action_kind + ' on ' + (msg.target_kind || '?') + ' ' + (msg.target_id || '?'))"></p>
+                          <template x-if="msg.preview_diff">
+                            <div class="mb-3">
+                              <button @click="diffOpen = !diffOpen"
+                                class="text-[10px] text-gray-400 hover:text-gray-200 transition-colors flex items-center gap-1">
+                                <svg class="w-2.5 h-2.5 transition-transform" :class="diffOpen && 'rotate-90'" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M9 5l7 7-7 7"/></svg>
+                                <span x-text="diffOpen ? 'Hide diff' : 'View diff'"></span>
+                              </button>
+                              <pre x-show="diffOpen" x-cloak
+                                class="mt-2 text-[10px] font-mono whitespace-pre-wrap break-all max-h-48 overflow-y-auto bg-gray-900/60 rounded px-2 py-2 text-gray-300 custom-scrollbar"
+                                x-text="msg.preview_diff"></pre>
+                            </div>
+                          </template>
+                          <template x-if="msg._isDestructive">
+                            <div class="mb-2">
+                              <label class="block text-[10px] text-gray-400 mb-1"
+                                x-text="'Type ' + (msg.target_id || '') + ' to confirm'"></label>
+                              <input type="text" x-model="typed"
+                                class="w-full px-3 py-1.5 rounded-lg bg-gray-900 border border-gray-700 text-xs text-white placeholder-gray-500 focus:border-rose-500 focus:outline-none"
+                                :placeholder="msg.target_id || ''">
+                            </div>
+                          </template>
+                          <div class="flex gap-2">
+                            <button
+                              @click="acting = true; confirmPendingActionCard(msg).finally(() => acting = false)"
+                              :disabled="acting || (msg._isDestructive && typed !== msg.target_id)"
+                              class="flex-1 px-3 py-1.5 rounded-lg text-xs font-medium transition-colors"
+                              :class="(acting || (msg._isDestructive && typed !== msg.target_id))
+                                ? 'bg-gray-700 text-gray-500 cursor-not-allowed'
+                                : (msg._isDestructive ? 'bg-rose-600 hover:bg-rose-500 text-white' : 'bg-indigo-600 hover:bg-indigo-500 text-white')"
+                              x-text="acting ? 'Working...' : 'Confirm'"></button>
+                            <button
+                              @click="acting = true; cancelPendingActionCard(msg).finally(() => acting = false)"
+                              :disabled="acting"
+                              class="px-3 py-1.5 rounded-lg text-xs font-medium bg-gray-700 hover:bg-gray-600 text-gray-300 transition-colors">
+                              Cancel
+                            </button>
+                          </div>
+                        </div>
+                      </template>
+                      <template x-if="msg.resolved_status === 'confirmed'">
+                        <div class="flex items-center gap-1.5 text-xs text-emerald-400">
+                          <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M5 13l4 4L19 7"/></svg>
+                          <span x-text="(msg.summary || 'Action') + ' — confirmed.'"></span>
+                        </div>
+                      </template>
+                      <template x-if="msg.resolved_status === 'cancelled'">
+                        <div class="flex items-center gap-1.5 text-xs text-gray-400">
+                          <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12"/></svg>
+                          <span x-text="(msg.summary || 'Action') + ' — cancelled.'"></span>
+                        </div>
+                      </template>
+                      <template x-if="msg.resolved_status === 'expired'">
+                        <div class="flex items-center gap-1.5 text-xs text-amber-400/80">
+                          <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z"/></svg>
+                          <span x-text="(msg.summary || 'Action') + ' — expired without confirmation.'"></span>
+                        </div>
+                      </template>
+                    </div>
+                  </div>
+                </div>
+              </template>
               <!-- Chat bubble -->
-              <template x-if="msg.role !== 'system' && msg.role !== 'credential_request' && msg.role !== 'credit_exhausted' && msg.role !== 'browser_login_request' && msg.role !== 'browser_captcha_help_request'">
+              <template x-if="msg.role !== 'system' && msg.role !== 'credential_request' && msg.role !== 'credit_exhausted' && msg.role !== 'browser_login_request' && msg.role !== 'browser_captcha_help_request' && msg.role !== 'pending_action_card'">
               <div :class="msg.role === 'user' ? 'flex justify-end' : 'flex justify-start'">
               <div class="max-w-[80%] px-3 py-2 rounded-2xl text-xs"
                 :class="{

--- a/src/host/pending_actions.py
+++ b/src/host/pending_actions.py
@@ -128,6 +128,12 @@ class PendingActions:
 
         Idempotent -- safe to call repeatedly (used in __init__ but also
         survives schema-evolution callers that init multiple times).
+
+        ``summary`` and ``preview_diff`` were added so the dashboard's
+        inline pending-action card can render a human-readable headline
+        and a diff preview without a follow-up round-trip. They are
+        nullable so older rows (and callers that don't compute them)
+        remain valid.
         """
         Path(self.db_path).parent.mkdir(parents=True, exist_ok=True)
         with self._conn() as conn:
@@ -143,13 +149,26 @@ class PendingActions:
                     origin_kind TEXT,
                     created_at REAL NOT NULL,
                     expires_at REAL NOT NULL,
-                    status TEXT NOT NULL DEFAULT 'pending'
+                    status TEXT NOT NULL DEFAULT 'pending',
+                    summary TEXT,
+                    preview_diff TEXT
                 );
                 CREATE INDEX IF NOT EXISTS idx_pending_expires
                     ON pending_actions (expires_at);
                 CREATE INDEX IF NOT EXISTS idx_pending_target
                     ON pending_actions (target_kind, target_id);
             """)
+            # Migrate legacy databases that pre-date the summary/preview_diff
+            # columns. SQLite's ``ALTER TABLE ... ADD COLUMN`` is cheap and
+            # idempotent enough — wrap in try/except to swallow the
+            # "duplicate column" error on already-migrated DBs.
+            for col in ("summary", "preview_diff"):
+                try:
+                    conn.execute(
+                        f"ALTER TABLE pending_actions ADD COLUMN {col} TEXT",
+                    )
+                except sqlite3.OperationalError:
+                    pass
 
     # ── Core API ────────────────────────────────────────────────────
 
@@ -164,6 +183,8 @@ class PendingActions:
         payload: Any,
         origin_kind: str | None = None,
         ttl: int = _DEFAULT_TTL_SEC,
+        summary: str | None = None,
+        preview_diff: str | None = None,
     ) -> dict:
         """Persist a pending action. Returns the record dict.
 
@@ -171,6 +192,13 @@ class PendingActions:
         ``payload``. Confirm-side replay protection: callers can pass
         the digest of the payload they hold in their request body to
         ``consume`` via ``expected_payload_digest`` to catch tampering.
+
+        ``summary`` is a short human-readable headline for the action
+        (e.g. ``"Switch alpha's model from gpt-4o to claude-opus"``) and
+        ``preview_diff`` is the multi-line unified diff (config edits
+        only). Both are surfaced through ``pending_action_created`` so
+        the dashboard's inline chat card can render them without a
+        follow-up round-trip.
         """
         now = time.time()
         digest = _payload_digest(payload)
@@ -184,11 +212,12 @@ class PendingActions:
                 "INSERT OR REPLACE INTO pending_actions "
                 "(nonce, actor, target_kind, target_id, action_kind, "
                 "payload_json, payload_digest, origin_kind, created_at, "
-                "expires_at, status) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 'pending')",
+                "expires_at, status, summary, preview_diff) "
+                "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 'pending', ?, ?)",
                 (
                     nonce, actor, target_kind, target_id, action_kind,
                     json.dumps(payload, default=str), digest, origin_kind,
-                    now, expires_at,
+                    now, expires_at, summary, preview_diff,
                 ),
             )
         # Task 9 — surface to the dashboard so the System > Operator
@@ -203,6 +232,8 @@ class PendingActions:
                 "target_id": target_id,
                 "action_kind": action_kind,
                 "expires_at": expires_at,
+                "summary": summary,
+                "preview_diff": preview_diff,
             },
         )
         return {
@@ -217,6 +248,8 @@ class PendingActions:
             "created_at": now,
             "expires_at": expires_at,
             "status": "pending",
+            "summary": summary,
+            "preview_diff": preview_diff,
         }
 
     def peek(self, nonce: str) -> dict | None:
@@ -231,7 +264,8 @@ class PendingActions:
             row = conn.execute(
                 "SELECT actor, target_kind, target_id, action_kind, "
                 "payload_json, payload_digest, origin_kind, created_at, "
-                "expires_at, status FROM pending_actions WHERE nonce=?",
+                "expires_at, status, summary, preview_diff "
+                "FROM pending_actions WHERE nonce=?",
                 (nonce,),
             ).fetchone()
         if not row:
@@ -250,6 +284,8 @@ class PendingActions:
             "created_at": row[7],
             "expires_at": row[8],
             "status": row[9],
+            "summary": row[10],
+            "preview_diff": row[11],
         }
 
     def consume(
@@ -283,7 +319,8 @@ class PendingActions:
                 row = conn.execute(
                     "SELECT actor, target_kind, target_id, action_kind, "
                     "payload_json, payload_digest, origin_kind, created_at, "
-                    "expires_at, status FROM pending_actions WHERE nonce=?",
+                    "expires_at, status, summary, preview_diff "
+                    "FROM pending_actions WHERE nonce=?",
                     (nonce,),
                 ).fetchone()
                 if not row:
@@ -348,6 +385,8 @@ class PendingActions:
             "created_at": row[7],
             "expires_at": row[8],
             "status": "consumed",
+            "summary": row[10],
+            "preview_diff": row[11],
         }
 
     def cancel(
@@ -375,7 +414,8 @@ class PendingActions:
                 row = conn.execute(
                     "SELECT actor, target_kind, target_id, action_kind, "
                     "payload_json, payload_digest, origin_kind, created_at, "
-                    "expires_at, status FROM pending_actions WHERE nonce=?",
+                    "expires_at, status, summary, preview_diff "
+                    "FROM pending_actions WHERE nonce=?",
                     (nonce,),
                 ).fetchone()
                 if not row:
@@ -422,6 +462,8 @@ class PendingActions:
             "created_at": row[7],
             "expires_at": row[8],
             "status": "cancelled",
+            "summary": row[10],
+            "preview_diff": row[11],
         }
 
     # ── Maintenance / surfacing ────────────────────────────────────
@@ -479,7 +521,8 @@ class PendingActions:
             rows = conn.execute(
                 "SELECT nonce, actor, target_kind, target_id, action_kind, "
                 "payload_json, payload_digest, origin_kind, created_at, "
-                "expires_at, status FROM pending_actions "
+                "expires_at, status, summary, preview_diff "
+                "FROM pending_actions "
                 "WHERE expires_at >= ? ORDER BY created_at ASC",
                 (time.time(),),
             ).fetchall()
@@ -496,6 +539,8 @@ class PendingActions:
                 "created_at": r[8],
                 "expires_at": r[9],
                 "status": r[10],
+                "summary": r[11],
+                "preview_diff": r[12],
             }
             for r in rows
         ]

--- a/src/host/server.py
+++ b/src/host/server.py
@@ -3896,10 +3896,11 @@ def create_mesh_app(
                 )
         nonce = str(_uuid.uuid4())
         members = projects[name].get("members", []) or []
+        # Short headline shown in the inline chat card (max ~80 chars
+        # so it doesn't wrap awkwardly). The longer policy explanation
+        # is kept in the payload for the legacy CLI surface.
         summary = (
-            f"Delete project {name!r} and unlink {len(members)} agent(s). "
-            "Workspaces and per-agent history are retained; project metadata, "
-            "project.md, and project blackboard rows are removed."
+            f"Delete project {name!r} and unlink {len(members)} agent(s)"
         )
         payload = {
             "name": name,
@@ -3915,6 +3916,8 @@ def create_mesh_app(
             payload=payload,
             origin_kind=origin_kind,
             ttl=_CHANGE_TTL_SECONDS,
+            summary=summary,
+            preview_diff=None,
         )
         return {
             "change_id": nonce,
@@ -3963,10 +3966,7 @@ def create_mesh_app(
                     (oldest["nonce"],),
                 )
         nonce = str(_uuid.uuid4())
-        summary = (
-            f"Delete agent {agent_id!r}. Container stopped, config and "
-            "permissions removed, workspace dropped."
-        )
+        summary = f"Delete agent {agent_id!r} permanently"
         payload = {
             "agent_id": agent_id,
             "summary": summary,
@@ -3980,6 +3980,8 @@ def create_mesh_app(
             payload=payload,
             origin_kind=origin_kind,
             ttl=_CHANGE_TTL_SECONDS,
+            summary=summary,
+            preview_diff=None,
         )
         return {
             "change_id": nonce,
@@ -4168,18 +4170,10 @@ def create_mesh_app(
 
         change_id = str(_uuid.uuid4())
         payload = {"old_value": old_value, "new_value": new_value}
-        record = pending_actions.store(
-            nonce=change_id,
-            actor="operator",
-            target_kind="agent",
-            target_id=agent_id,
-            action_kind=field,
-            payload=payload,
-            origin_kind=origin_kind,
-            ttl=_CHANGE_TTL_SECONDS,
-        )
 
-        # Generate preview diff
+        # Generate preview diff. Computed up-front so we can persist it
+        # alongside the row — the dashboard's inline pending-action card
+        # renders the diff inline without an extra round-trip.
         old_str = json.dumps(old_value, indent=2) if not isinstance(old_value, str) else old_value
         new_str = json.dumps(new_value, indent=2) if not isinstance(new_value, str) else new_value
 
@@ -4194,8 +4188,40 @@ def create_mesh_app(
                 if line not in old_lines:
                     preview += f"+ {line}\n"
 
+        # Build a one-line summary for the chat-card title. Free-text
+        # fields (instructions, soul) get a "(updated)" pseudo-summary
+        # because the diff is what carries the meaning; scalar fields
+        # show old → new with the values truncated to keep the headline
+        # readable. Full diff lives in ``preview_diff``.
+        humanized_field = field.replace("_", " ")
+        if field in ("instructions", "soul", "permissions"):
+            summary = f"Update {agent_id}'s {humanized_field}"
+        else:
+            def _short(v: object, n: int = 40) -> str:
+                s = v if isinstance(v, str) else json.dumps(v, default=str)
+                s = s.replace("\n", " ").strip()
+                return s if len(s) <= n else s[: n - 1] + "…"
+            summary = (
+                f"Switch {agent_id}'s {humanized_field} "
+                f"from {_short(old_value)} to {_short(new_value)}"
+            )
+
+        record = pending_actions.store(
+            nonce=change_id,
+            actor="operator",
+            target_kind="agent",
+            target_id=agent_id,
+            action_kind=field,
+            payload=payload,
+            origin_kind=origin_kind,
+            ttl=_CHANGE_TTL_SECONDS,
+            summary=summary,
+            preview_diff=preview,
+        )
+
         return {
             "change_id": change_id,
+            "summary": summary,
             "preview_diff": preview,
             "expires_at": datetime.fromtimestamp(
                 record["expires_at"], tz=timezone.utc,

--- a/tests/test_operator_product_tools.py
+++ b/tests/test_operator_product_tools.py
@@ -730,8 +730,14 @@ async def test_endpoint_delete_project_happy_path(v2_app):
         r = await c.post("/mesh/projects/research/propose-delete",
                          headers=_human_origin_headers())
         assert r.status_code == 200, r.text
-        nonce = r.json()["change_id"]
-        digest = r.json()["payload_digest"]
+        body = r.json()
+        nonce = body["change_id"]
+        digest = body["payload_digest"]
+        # PR #2: response carries the human-readable summary so the
+        # inline pending-action card can render without a follow-up
+        # round-trip.
+        assert "delete project" in body["summary"].lower()
+        assert "'research'" in body["summary"]
         # Confirm with human origin succeeds
         r = await c.post("/mesh/config/confirm",
                          json={"change_id": nonce, "payload_digest": digest},
@@ -783,8 +789,13 @@ async def test_endpoint_archive_agent_then_delete(v2_app):
         r = await c.post("/mesh/agents/scout/propose-delete",
                          headers=_human_origin_headers())
         assert r.status_code == 200, r.text
-        nonce = r.json()["change_id"]
-        digest = r.json()["payload_digest"]
+        body = r.json()
+        nonce = body["change_id"]
+        digest = body["payload_digest"]
+        # PR #2: agent-delete summary is short and names the target
+        # so the inline pending-action card is self-describing.
+        assert "delete agent" in body["summary"].lower()
+        assert "'scout'" in body["summary"]
         # Confirm
         r = await c.post("/mesh/config/confirm",
                          json={"change_id": nonce, "payload_digest": digest},

--- a/tests/test_pending_actions.py
+++ b/tests/test_pending_actions.py
@@ -512,3 +512,67 @@ def test_event_bus_unset_disables_emit(tmp_path):
         target_id="alpha", action_kind="model", payload={},
     )
     assert captured == []
+
+
+# ── Inline pending-action card metadata (PR #2) ──────────────────
+
+
+def test_store_persists_summary_and_preview_diff(tmp_path):
+    """The dashboard's inline pending-action card needs both the
+    summary and the preview_diff to render without a follow-up
+    round-trip. ``store`` accepts both, persists them to the row,
+    and ``peek`` / ``list_pending`` / ``consume`` / ``cancel`` all
+    return them."""
+    pa = _make_store(tmp_path)
+    rec = pa.store(
+        nonce="n1", actor="operator", target_kind="agent",
+        target_id="alpha", action_kind="model", payload={"x": 1},
+        summary="Switch alpha's model from gpt-4o to claude-opus",
+        preview_diff="--- model\n+++ model\n- gpt-4o\n+ claude-opus\n",
+    )
+    assert rec["summary"].startswith("Switch alpha")
+    assert "+ claude-opus" in rec["preview_diff"]
+
+    peeked = pa.peek("n1")
+    assert peeked is not None
+    assert peeked["summary"] == rec["summary"]
+    assert peeked["preview_diff"] == rec["preview_diff"]
+
+    listed = pa.list_pending()
+    assert len(listed) == 1
+    assert listed[0]["summary"] == rec["summary"]
+    assert listed[0]["preview_diff"] == rec["preview_diff"]
+
+    consumed = pa.consume("n1", confirmer="operator")
+    assert consumed is not None
+    assert consumed["summary"] == rec["summary"]
+    assert consumed["preview_diff"] == rec["preview_diff"]
+
+
+def test_store_summary_and_preview_diff_default_to_none(tmp_path):
+    """Existing call sites that don't pass the new args must keep
+    working — the columns are nullable and the dict carries None."""
+    pa = _make_store(tmp_path)
+    rec = pa.store(
+        nonce="n1", actor="operator", target_kind="agent",
+        target_id="alpha", action_kind="model", payload={"x": 1},
+    )
+    assert rec["summary"] is None
+    assert rec["preview_diff"] is None
+    assert pa.peek("n1")["summary"] is None
+
+
+def test_pending_action_created_event_carries_summary_and_diff(tmp_path):
+    """The event payload must carry summary + preview_diff so the
+    dashboard can render the inline card from the event alone."""
+    pa = _make_store(tmp_path)
+    captured = _attach_recording_bus(pa)
+    pa.store(
+        nonce="n1", actor="operator", target_kind="agent",
+        target_id="alpha", action_kind="model", payload={"x": 1},
+        summary="Switch alpha's model from gpt-4o to claude",
+        preview_diff="diff goes here",
+    )
+    evt = next(c for c in captured if c[0] == "pending_action_created")
+    assert evt[2]["summary"] == "Switch alpha's model from gpt-4o to claude"
+    assert evt[2]["preview_diff"] == "diff goes here"


### PR DESCRIPTION
## Summary
- One visual language for confirmations: inline chat card matching the existing credential_request / browser_login_request pattern
- pending_actions table gets summary + preview_diff columns so cards render without extra fetches
- Type-to-confirm gate on destructive cards
- Removes redundant pending surfaces (workplace amber bubble, System > Operator panel)

## Why
Today hard-edit and delete confirmations surface in three places — workplace tab, System > Operator, and (until PR 1) above the operator chat input. The amber-bubble visual language differs from the credential/browser cards. Result: the user has to learn two patterns and check three locations. This PR collapses to one.

## Scope
PR 2 of 5. PRs 0 + 1 (#838, #839) are open. PR 3 adds Cancel buttons to credential/browser cards. PR 4 adds workplace task drill-in with outcome capture. PR 5 adds north-star fields and activity feed.

## Implementation notes
- `PendingActions.store()` now accepts `summary` and `preview_diff` kwargs; both are nullable on disk, so legacy callers that don't pass them keep working.
- Three propose endpoints (`propose_delete_project`, `propose_delete_agent`, `propose_agent_config_change`) compute the summary/preview eagerly and pass them in so the WS event payload + `peek` / `list_pending` results carry the metadata the card needs.
- Schema migration: nullable `ALTER TABLE ADD COLUMN` wrapped in try/except so re-running on already-migrated DBs is a no-op.
- The dashboard's `loadWorkplacePending()` polling endpoint is preserved (Step 4 backwards compat) — its result feeds `_injectPendingActionCard()` so a page reload backfills the inline cards. Legacy `confirmPendingAction` / `cancelPendingAction` JS methods remain but no template calls them.

## Files modified
- `src/host/pending_actions.py` — schema + store/peek/consume/cancel/list now carry summary + preview_diff
- `src/host/server.py` — three propose endpoints populate summary + preview_diff
- `src/dashboard/templates/index.html` — new `pending_action_card` template (in both chat surfaces); amber bubble + System > Operator pending panel removed
- `src/dashboard/static/js/app.js` — WS handler injects + resolves cards; new `confirmPendingActionCard` / `cancelPendingActionCard` methods
- `tests/test_pending_actions.py` — three new tests covering the new fields + event payload
- `tests/test_operator_product_tools.py` — propose-delete tests assert the new `summary` field on the response

## Test plan
- [x] `tests/test_pending_actions.py` — 32 tests pass (3 new)
- [x] `tests/test_operator_product_tools.py` — pass (assert new summary on propose-delete responses)
- [x] Full suite: 5263 passed, 80 skipped, 0 failed
- [ ] Manual: ask operator to switch a worker's model — verify inline card appears with diff, Confirm applies, Cancel rolls back
- [ ] Manual: ask operator to delete an archived agent — verify type-to-confirm gate, Confirm executes, Cancel dismisses
- [ ] Manual: verify same card appears in both main chat (when operator is active) and operator chat panel