### PR TITLE
feat(dashboard): add Cancel buttons to credential / browser-login / captcha cards

### DIFF
--- a/src/agent/builtins/browser_tool.py
+++ b/src/agent/builtins/browser_tool.py
@@ -1503,7 +1503,11 @@ async def browser_solve_captcha(
         "auto-solve attempts, or when ``browser_solve_captcha`` returned "
         "``rate_limited`` / ``cost_cap``. Mirrors ``request_browser_login`` "
         "— a handoff card appears in the dashboard, and you receive a "
-        "steer notification when the operator finishes (success or cancel)."
+        "steer notification when the operator finishes (success or cancel). "
+        "If the user cancels via the dashboard Cancel button, you'll get "
+        "a steer telling you so — do NOT immediately re-request the same "
+        "captcha help; try a different approach (wait + retry, or "
+        "escalate via notify_user)."
     ),
     parameters={
         "service": {
@@ -1547,10 +1551,13 @@ async def request_captcha_help(
         return {"error": f"browser-side captcha-help record failed: {e}"}
 
     # Then emit the dashboard handoff card via the mesh helper.
+    request_id = ""
     try:
-        await mesh_client.request_captcha_help(
+        resp = await mesh_client.request_captcha_help(
             service=service, description=description,
         )
+        if isinstance(resp, dict):
+            request_id = str(resp.get("request_id") or "")
     except Exception as e:
         logger.warning(
             "Failed to emit captcha help request for %s: %s", service, e,
@@ -1565,7 +1572,7 @@ async def request_captcha_help(
             ),
         }
 
-    return {
+    result: dict = {
         "requested": True,
         "service": service,
         "message": (
@@ -1575,6 +1582,9 @@ async def request_captcha_help(
             f"message. Do NOT use browser tools until then."
         ),
     }
+    if request_id:
+        result["request_id"] = request_id
+    return result
 
 
 @skill(
@@ -1585,7 +1595,10 @@ async def request_captcha_help(
         "login that can't be done via API keys (e.g. Twitter, LinkedIn, "
         "TikTok web). The browser navigates to the login URL and an "
         "interactive VNC viewer appears in the user's chat. After the user "
-        "finishes, you receive a notification.\n\n"
+        "finishes, you receive a notification. The user can also CANCEL "
+        "via the dashboard's Cancel button; if so, you'll get a steer "
+        "telling you the login was cancelled — do NOT immediately retry "
+        "the same login. Find an alternative or ask the user differently.\n\n"
         "IMPORTANT: session cookies persist in the TARGET agent's browser "
         "profile. If you're orchestrating a login for another agent (e.g. "
         "operator setting up a login for social-manager), pass ``agent_id`` "
@@ -1645,11 +1658,14 @@ async def request_browser_login(
         return {"error": f"Failed to navigate browser to {url}: {e}"}
 
     # Emit browser login request event to the dashboard
+    request_id = ""
     try:
-        await mesh_client.request_browser_login(
+        resp = await mesh_client.request_browser_login(
             url=url, service=service, description=description,
             target_agent_id=target,
         )
+        if isinstance(resp, dict):
+            request_id = str(resp.get("request_id") or "")
     except Exception as e:
         logger.warning("Failed to emit browser login request for %s: %s", service, e)
         return {
@@ -1664,7 +1680,7 @@ async def request_browser_login(
             ),
         }
 
-    return {
+    result: dict = {
         "requested": True,
         "service": service,
         "url": url,
@@ -1675,6 +1691,9 @@ async def request_browser_login(
             f"Do NOT use browser tools until the user confirms."
         ),
     }
+    if request_id:
+        result["request_id"] = request_id
+    return result
 
 
 @skill(

--- a/src/agent/builtins/vault_tool.py
+++ b/src/agent/builtins/vault_tool.py
@@ -97,7 +97,11 @@ _CRED_NAME_RE = re.compile(r'^[a-zA-Z0-9_.\-]{1,128}$')
         "through a secure input in their chat. The credential is stored "
         "directly in the vault — you never see the actual value. After "
         "the user saves it, use the handle $CRED{name} in HTTP requests "
-        "or browser logins."
+        "or browser logins. The user can also CANCEL the request from "
+        "their dashboard; if they do, you'll receive a steer message "
+        "telling you the request was cancelled. Don't immediately "
+        "re-request the same credential — skip the step or ask "
+        "differently."
     ),
     parameters={
         "name": {
@@ -147,19 +151,27 @@ async def request_credential(
         pass  # Vault may not be available yet; proceed with the request
 
     # Emit credential request event to the dashboard via the mesh
+    request_id = ""
     try:
-        await mesh_client.request_credential_from_user(
+        resp = await mesh_client.request_credential_from_user(
             name=name, description=description, service=service or name,
         )
+        if isinstance(resp, dict):
+            request_id = str(resp.get("request_id") or "")
     except Exception:
         pass  # Best effort — the tool result itself is the primary mechanism
 
-    return {
+    result: dict = {
         "requested": True,
         "name": name,
         "handle": f"$CRED{{{name}}}",
         "message": (
             f"Credential request sent to user. "
-            f"Once they save it, use $CRED{{{name}}} in your requests."
+            f"Once they save it, use $CRED{{{name}}} in your requests. "
+            f"If the user cancels, you will receive a steer message — "
+            f"do not re-request immediately."
         ),
     }
+    if request_id:
+        result["request_id"] = request_id
+    return result

--- a/src/dashboard/server.py
+++ b/src/dashboard/server.py
@@ -5578,6 +5578,75 @@ def create_dashboard_router(
             "action_kind": record["action_kind"],
         }
 
+    async def _proxy_help_cancel(
+        kind: str, request_id: str, body: dict | None,
+    ) -> dict:
+        """Proxy a Cancel-card click to the matching mesh endpoint.
+
+        Goes over loopback with ``x-mesh-internal: 1`` so the mesh
+        treats the dashboard as a trusted internal caller (same
+        contract as ``X-Agent-ID: operator`` would have used). Single
+        round-trip — both processes are co-located in the runtime.
+        """
+        import httpx
+        url = f"http://127.0.0.1:{mesh_port}/mesh/{kind}-request/{request_id}/cancel"
+        try:
+            async with httpx.AsyncClient(timeout=5) as client:
+                resp = await client.post(
+                    url,
+                    json=body or {},
+                    headers={
+                        "x-mesh-internal": "1",
+                        "X-Agent-ID": "operator",
+                        "Content-Type": "application/json",
+                    },
+                )
+        except Exception as e:
+            raise HTTPException(502, f"mesh cancel proxy failed: {e}")
+        if resp.status_code == 404:
+            raise HTTPException(404, "Request not found or already resolved")
+        if resp.status_code >= 400:
+            raise HTTPException(resp.status_code, resp.text)
+        try:
+            return resp.json()
+        except Exception:
+            return {"ok": True}
+
+    @api_router.post("/api/credential-request/{request_id}/cancel")
+    async def api_credential_request_cancel(
+        request_id: str, request: Request,
+    ) -> dict:
+        """Cancel an open credential-request card (PR 3)."""
+        try:
+            body = await request.json()
+        except Exception:
+            body = {}
+        return await _proxy_help_cancel("credential", request_id, body)
+
+    @api_router.post("/api/browser-login-request/{request_id}/cancel")
+    async def api_browser_login_request_cancel(
+        request_id: str, request: Request,
+    ) -> dict:
+        """Cancel an open browser-login-request card (PR 3)."""
+        try:
+            body = await request.json()
+        except Exception:
+            body = {}
+        return await _proxy_help_cancel("browser-login", request_id, body)
+
+    @api_router.post("/api/browser-captcha-help-request/{request_id}/cancel")
+    async def api_browser_captcha_help_request_cancel(
+        request_id: str, request: Request,
+    ) -> dict:
+        """Cancel an open browser-captcha-help-request card (PR 3)."""
+        try:
+            body = await request.json()
+        except Exception:
+            body = {}
+        return await _proxy_help_cancel(
+            "browser-captcha-help", request_id, body,
+        )
+
     @api_router.get("/static/{file_path:path}")
     async def static_file(file_path: str, v: str | None = None) -> FileResponse:
         full = (_STATIC_DIR / file_path).resolve()

--- a/src/dashboard/static/js/app.js
+++ b/src/dashboard/static/js/app.js
@@ -81,6 +81,7 @@ function dashboard() {
       'tool_start', 'tool_result', 'text_delta', 'llm_call',
       'blackboard_write', 'health_change', 'notification', 'workspace_updated',
       'heartbeat_complete', 'cron_change', 'credit_exhausted', 'credential_request',
+      'credential_request_cancelled',
       'browser_login_request', 'browser_login_completed', 'browser_login_cancelled',
       'browser_captcha_help_request', 'browser_captcha_help_completed', 'browser_captcha_help_cancelled',
       // Task 9 — Workplace tab + pending action review
@@ -1881,6 +1882,8 @@ function dashboard() {
           name: evt.data.name,
           service: evt.data.service || '',
           saved: false,
+          cancelled: false,
+          request_id: evt.data.request_id || '',
           ts: evtTs,
         };
         // Show in the requesting agent's chat
@@ -1911,6 +1914,27 @@ function dashboard() {
         }
       }
 
+      // Sync credential_request card across agent chat + operator chat
+      // when the user cancels (PR 3). Match by request_id when present
+      // (new flow); fall back to name (legacy messages without an id).
+      if (evt.type === 'credential_request_cancelled' && agent && evt.data) {
+        const reqId = evt.data.request_id || '';
+        const name = evt.data.name || '';
+        for (const chatId of [agent, 'operator']) {
+          const hist = this.chatHistories[chatId];
+          if (!hist) continue;
+          for (const m of hist) {
+            if (m.role !== 'credential_request') continue;
+            if (chatId !== agent && m._from_agent !== agent) continue;
+            const matchById = reqId && m.request_id === reqId;
+            const matchByName = !reqId && name && m.name === name;
+            if (matchById || matchByName) {
+              m.cancelled = true;
+            }
+          }
+        }
+      }
+
       // Surface browser login requests as interactive VNC cards in chat.
       if (evt.type === 'browser_login_request' && agent && evt.data && evt.data.service) {
         const evtTs = this._normalizeEventTs(evt);
@@ -1921,6 +1945,7 @@ function dashboard() {
           url: evt.data.url || '',
           completed: false,
           cancelled: false,
+          request_id: evt.data.request_id || '',
           ts: evtTs,
         };
         // Show in the requesting agent's chat
@@ -1990,6 +2015,7 @@ function dashboard() {
           url: evt.data.url || '',
           completed: false,
           cancelled: false,
+          request_id: evt.data.request_id || '',
           ts: evtTs,
         };
         // Show in the requesting agent's chat
@@ -5264,17 +5290,65 @@ function dashboard() {
     async _cancelBrowserLogin(msg, agentId) {
       const prev = { completed: msg.completed, cancelled: msg.cancelled };
       msg.cancelled = true;
+      // PR 3: prefer the request_id-scoped endpoint when the message
+      // carries one — that path also pushes a cancellation steer to the
+      // awaiting agent so it can react instead of waiting on a TTL.
+      // Old messages (pre-PR 3) fall back to the legacy endpoint.
       try {
-        const resp = await fetch(window.__config.apiBase + '/browser-login/cancel', {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json', 'X-Requested-With': 'XMLHttpRequest' },
-          body: JSON.stringify({ agent_id: agentId || '', service: msg.service }),
-        });
+        let resp;
+        if (msg.request_id) {
+          resp = await fetch(
+            window.__config.apiBase
+              + '/browser-login-request/' + encodeURIComponent(msg.request_id) + '/cancel',
+            {
+              method: 'POST',
+              headers: { 'Content-Type': 'application/json', 'X-Requested-With': 'XMLHttpRequest' },
+              body: JSON.stringify({ reason: 'user_cancelled' }),
+            },
+          );
+        } else {
+          resp = await fetch(window.__config.apiBase + '/browser-login/cancel', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json', 'X-Requested-With': 'XMLHttpRequest' },
+            body: JSON.stringify({ agent_id: agentId || '', service: msg.service }),
+          });
+        }
         if (!resp.ok) {
           msg.cancelled = prev.cancelled;
           this.showToast('Failed to notify agent — please try again');
         }
       } catch (_) {
+        msg.cancelled = prev.cancelled;
+        this.showToast('Network error — please try again');
+      }
+    },
+
+    async _cancelCredentialRequest(msg) {
+      // PR 3: cancel an open credential request via the new
+      // request_id-scoped endpoint. The mesh emits
+      // ``credential_request_cancelled`` (other card copies sync
+      // from the same handler that watches for the event) and pushes
+      // a steer to the awaiting agent.
+      if (!msg || !msg.request_id) return;
+      const prev = { saved: msg.saved, cancelled: msg.cancelled };
+      msg.cancelled = true;
+      try {
+        const resp = await fetch(
+          window.__config.apiBase
+            + '/credential-request/' + encodeURIComponent(msg.request_id) + '/cancel',
+          {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json', 'X-Requested-With': 'XMLHttpRequest' },
+            body: JSON.stringify({ reason: 'user_cancelled' }),
+          },
+        );
+        if (!resp.ok) {
+          msg.saved = prev.saved;
+          msg.cancelled = prev.cancelled;
+          this.showToast('Failed to cancel — please try again');
+        }
+      } catch (_) {
+        msg.saved = prev.saved;
         msg.cancelled = prev.cancelled;
         this.showToast('Network error — please try again');
       }
@@ -5302,12 +5376,26 @@ function dashboard() {
     async _cancelBrowserCaptchaHelp(msg, agentId) {
       const prev = { completed: msg.completed, cancelled: msg.cancelled };
       msg.cancelled = true;
+      // PR 3: prefer request_id-scoped endpoint when available.
       try {
-        const resp = await fetch(window.__config.apiBase + '/browser-captcha-help/cancel', {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json', 'X-Requested-With': 'XMLHttpRequest' },
-          body: JSON.stringify({ agent_id: agentId || '', service: msg.service }),
-        });
+        let resp;
+        if (msg.request_id) {
+          resp = await fetch(
+            window.__config.apiBase
+              + '/browser-captcha-help-request/' + encodeURIComponent(msg.request_id) + '/cancel',
+            {
+              method: 'POST',
+              headers: { 'Content-Type': 'application/json', 'X-Requested-With': 'XMLHttpRequest' },
+              body: JSON.stringify({ reason: 'user_cancelled' }),
+            },
+          );
+        } else {
+          resp = await fetch(window.__config.apiBase + '/browser-captcha-help/cancel', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json', 'X-Requested-With': 'XMLHttpRequest' },
+            body: JSON.stringify({ agent_id: agentId || '', service: msg.service }),
+          });
+        }
         if (!resp.ok) {
           msg.cancelled = prev.cancelled;
           this.showToast('Failed to notify agent — please try again');

--- a/src/dashboard/templates/index.html
+++ b/src/dashboard/templates/index.html
@@ -402,24 +402,39 @@
                               <span class="text-xs font-medium text-indigo-300" x-text="'Credential needed: ' + (msg.service || msg.name)"></span>
                             </div>
                             <p class="text-xs text-gray-300 mb-3" x-text="msg.content"></p>
-                            <div x-show="!msg.saved" x-data="{ credValue: '', saving: false, saveError: '' }">
+                            <div x-show="!msg.saved && !msg.cancelled" x-data="{ credValue: '', saving: false, saveError: '' }">
                               <input type="password" x-model="credValue"
                                 class="w-full px-3 py-1.5 rounded-lg bg-gray-900 border border-gray-700 text-xs text-white placeholder-gray-500 focus:border-indigo-500 focus:outline-none mb-2"
                                 :placeholder="'Paste your ' + msg.name.replace(/[_.\-]/g, ' ').replace(/^\w/, c => c.toUpperCase())">
                               <div x-show="saveError" class="text-[10px] text-red-400 mb-1.5" x-text="saveError"></div>
-                              <button @click="if (credValue.trim()) { saving = true; saveError = ''; fetch(window.__config.apiBase + '/credentials/agent', { method: 'POST', headers: {'Content-Type':'application/json', 'X-Requested-With':'XMLHttpRequest'}, body: JSON.stringify({service: msg.name, key: credValue.trim(), agent_id: msg._from_agent || ''}) }).then(r => { if (r.ok) { msg.saved = true; credValue = ''; } else { saveError = 'Failed to save. Please try again.'; } saving = false; }).catch(() => { saveError = 'Network error. Please try again.'; saving = false; }); }"
-                                :disabled="!credValue.trim() || saving"
-                                class="w-full px-3 py-1.5 rounded-lg text-xs font-medium transition-colors"
-                                :class="credValue.trim() && !saving ? 'bg-indigo-600 hover:bg-indigo-500 text-white' : 'bg-gray-700 text-gray-500 cursor-not-allowed'">
-                                <span x-show="!saving">Save to Vault</span>
-                                <span x-show="saving">Saving...</span>
-                              </button>
+                              <div class="flex gap-2">
+                                <button @click="if (credValue.trim()) { saving = true; saveError = ''; fetch(window.__config.apiBase + '/credentials/agent', { method: 'POST', headers: {'Content-Type':'application/json', 'X-Requested-With':'XMLHttpRequest'}, body: JSON.stringify({service: msg.name, key: credValue.trim(), agent_id: msg._from_agent || ''}) }).then(r => { if (r.ok) { msg.saved = true; credValue = ''; } else { saveError = 'Failed to save. Please try again.'; } saving = false; }).catch(() => { saveError = 'Network error. Please try again.'; saving = false; }); }"
+                                  :disabled="!credValue.trim() || saving"
+                                  class="flex-1 px-3 py-1.5 rounded-lg text-xs font-medium transition-colors"
+                                  :class="credValue.trim() && !saving ? 'bg-indigo-600 hover:bg-indigo-500 text-white' : 'bg-gray-700 text-gray-500 cursor-not-allowed'">
+                                  <span x-show="!saving">Save to Vault</span>
+                                  <span x-show="saving">Saving...</span>
+                                </button>
+                                <template x-if="msg.request_id">
+                                  <button @click="_cancelCredentialRequest(msg)"
+                                    :disabled="saving"
+                                    class="px-3 py-1.5 rounded-lg text-xs font-medium bg-gray-700/50 hover:bg-gray-600 text-gray-300 transition-colors">
+                                    Cancel
+                                  </button>
+                                </template>
+                              </div>
                             </div>
                             <div x-show="msg.saved" class="flex items-center gap-1.5 text-xs text-emerald-400">
                               <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="2">
                                 <path stroke-linecap="round" stroke-linejoin="round" d="M5 13l4 4L19 7"/>
                               </svg>
                               <span>Saved securely. The agent can now use this credential.</span>
+                            </div>
+                            <div x-show="msg.cancelled" class="flex items-center gap-1.5 text-xs text-gray-400">
+                              <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="2">
+                                <path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12"/>
+                              </svg>
+                              <span x-text="'Credential request for ' + (msg.service || msg.name) + ' was cancelled.'"></span>
                             </div>
                           </div>
                         </div>
@@ -6295,24 +6310,39 @@
                         <span class="text-xs font-medium text-indigo-300" x-text="'Credential needed: ' + (msg.service || msg.name)"></span>
                       </div>
                       <p class="text-xs text-gray-300 mb-3" x-text="msg.content"></p>
-                      <div x-show="!msg.saved" x-data="{ credValue: '', saving: false, saveError: '' }">
+                      <div x-show="!msg.saved && !msg.cancelled" x-data="{ credValue: '', saving: false, saveError: '' }">
                         <input type="password" x-model="credValue"
                           class="w-full px-3 py-1.5 rounded-lg bg-gray-900 border border-gray-700 text-xs text-white placeholder-gray-500 focus:border-indigo-500 focus:outline-none mb-2"
                           :placeholder="'Paste your ' + msg.name.replace(/[_.\-]/g, ' ').replace(/^\w/, c => c.toUpperCase())">
                         <div x-show="saveError" class="text-[10px] text-red-400 mb-1.5" x-text="saveError"></div>
-                        <button @click="if (credValue.trim()) { saving = true; saveError = ''; fetch(window.__config.apiBase + '/credentials/agent', { method: 'POST', headers: {'Content-Type':'application/json', 'X-Requested-With':'XMLHttpRequest'}, body: JSON.stringify({service: msg.name, key: credValue.trim(), agent_id: activeChatId || ''}) }).then(r => { if (r.ok) { msg.saved = true; credValue = ''; } else { saveError = 'Failed to save. Please try again.'; } saving = false; }).catch(() => { saveError = 'Network error. Please try again.'; saving = false; }); }"
-                          :disabled="!credValue.trim() || saving"
-                          class="w-full px-3 py-1.5 rounded-lg text-xs font-medium transition-colors"
-                          :class="credValue.trim() && !saving ? 'bg-indigo-600 hover:bg-indigo-500 text-white' : 'bg-gray-700 text-gray-500 cursor-not-allowed'">
-                          <span x-show="!saving">Save to Vault</span>
-                          <span x-show="saving">Saving...</span>
-                        </button>
+                        <div class="flex gap-2">
+                          <button @click="if (credValue.trim()) { saving = true; saveError = ''; fetch(window.__config.apiBase + '/credentials/agent', { method: 'POST', headers: {'Content-Type':'application/json', 'X-Requested-With':'XMLHttpRequest'}, body: JSON.stringify({service: msg.name, key: credValue.trim(), agent_id: activeChatId || ''}) }).then(r => { if (r.ok) { msg.saved = true; credValue = ''; } else { saveError = 'Failed to save. Please try again.'; } saving = false; }).catch(() => { saveError = 'Network error. Please try again.'; saving = false; }); }"
+                            :disabled="!credValue.trim() || saving"
+                            class="flex-1 px-3 py-1.5 rounded-lg text-xs font-medium transition-colors"
+                            :class="credValue.trim() && !saving ? 'bg-indigo-600 hover:bg-indigo-500 text-white' : 'bg-gray-700 text-gray-500 cursor-not-allowed'">
+                            <span x-show="!saving">Save to Vault</span>
+                            <span x-show="saving">Saving...</span>
+                          </button>
+                          <template x-if="msg.request_id">
+                            <button @click="_cancelCredentialRequest(msg)"
+                              :disabled="saving"
+                              class="px-3 py-1.5 rounded-lg text-xs font-medium bg-gray-700/50 hover:bg-gray-600 text-gray-300 transition-colors">
+                              Cancel
+                            </button>
+                          </template>
+                        </div>
                       </div>
                       <div x-show="msg.saved" class="flex items-center gap-1.5 text-xs text-emerald-400">
                         <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="2">
                           <path stroke-linecap="round" stroke-linejoin="round" d="M5 13l4 4L19 7"/>
                         </svg>
                         <span>Saved securely. The agent can now use this credential.</span>
+                      </div>
+                      <div x-show="msg.cancelled" class="flex items-center gap-1.5 text-xs text-gray-400">
+                        <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="2">
+                          <path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12"/>
+                        </svg>
+                        <span x-text="'Credential request for ' + (msg.service || msg.name) + ' was cancelled.'"></span>
                       </div>
                     </div>
                   </div>

--- a/src/host/server.py
+++ b/src/host/server.py
@@ -500,6 +500,41 @@ def create_mesh_app(
     if tasks_store is not None and event_bus is not None:
         tasks_store.set_event_bus(event_bus)
 
+    # In-memory registry of open "agent asks user for help" requests:
+    # credential_request, browser_login_request, browser_captcha_help_request.
+    # Keyed by request_id (uuid). The dict lets the cancel endpoints
+    # address a specific request and lets the dashboard cancel-button
+    # path resolve a card without needing to reconstruct (agent_id,
+    # service) identity. State is small (a handful of open asks at a
+    # time per fleet) and intentionally NOT persisted: a mesh restart
+    # already loses the in-flight steer-message contract anyway, so the
+    # cards just become stale on the dashboard and gracefully degrade
+    # (the Cancel button 404s, which the UI handles).
+    help_requests: dict[str, dict] = {}
+    _MAX_HELP_REQUESTS = 256  # cap so a noisy agent can't OOM the host
+    app.help_requests = help_requests  # exposed for tests + dashboard
+
+    def _record_help_request(
+        kind: str, agent_id: str, payload: dict,
+    ) -> str:
+        """Register an open help request and return its request_id."""
+        if len(help_requests) >= _MAX_HELP_REQUESTS:
+            # Evict oldest to bound growth.
+            oldest = min(
+                help_requests.items(),
+                key=lambda kv: kv[1].get("created_at", 0),
+            )[0]
+            help_requests.pop(oldest, None)
+        request_id = str(_uuid.uuid4())
+        help_requests[request_id] = {
+            "kind": kind,
+            "agent_id": agent_id,
+            "created_at": time.time(),
+            "status": "open",
+            "payload": payload,
+        }
+        return request_id
+
     # Rollout: auto-run the legacy blackboard → tasks migration once
     # at startup so existing fleets transition seamlessly when the v2
     # flag flips on. The helper is idempotent (keyed on the legacy
@@ -1639,6 +1674,12 @@ def create_mesh_app(
         if not re.match(r"^[a-zA-Z0-9_.\-]{1,128}$", name):
             raise HTTPException(400, "Invalid credential name")
 
+        request_id = _record_help_request(
+            "credential_request",
+            agent_id,
+            {"name": name, "service": service[:128]},
+        )
+
         if event_bus:
             event_bus.emit(
                 "credential_request",
@@ -1647,10 +1688,11 @@ def create_mesh_app(
                     "name": name,
                     "description": description[:500],
                     "service": service[:128],
+                    "request_id": request_id,
                 },
             )
 
-        return {"requested": True, "name": name}
+        return {"requested": True, "name": name, "request_id": request_id}
 
     @app.post("/mesh/browser-login-request")
     async def browser_login_request(data: dict, request: Request) -> dict:
@@ -1698,6 +1740,12 @@ def create_mesh_app(
         if not service:
             raise HTTPException(400, "Service name is required")
 
+        request_id = _record_help_request(
+            "browser_login_request",
+            agent_id,
+            {"service": service[:128]},
+        )
+
         if event_bus:
             # OAuth callback URLs (?code=...&state=...) and other
             # query-string secrets must not leak to the dashboard event
@@ -1711,10 +1759,16 @@ def create_mesh_app(
                     "url": redact_url(url)[:2048],
                     "service": service[:128],
                     "description": description[:500],
+                    "request_id": request_id,
                 },
             )
 
-        return {"requested": True, "service": service, "target_agent": agent_id}
+        return {
+            "requested": True,
+            "service": service,
+            "target_agent": agent_id,
+            "request_id": request_id,
+        }
 
     @app.post("/mesh/browser-captcha-help-request")
     async def browser_captcha_help_request(
@@ -1753,6 +1807,12 @@ def create_mesh_app(
         if not description:
             raise HTTPException(400, "Description is required")
 
+        request_id = _record_help_request(
+            "browser_captcha_help_request",
+            agent_id,
+            {"service": service[:128]},
+        )
+
         if event_bus:
             event_bus.emit(
                 "browser_captcha_help_request",
@@ -1760,10 +1820,188 @@ def create_mesh_app(
                 data={
                     "service": service[:128],
                     "description": description[:500],
+                    "request_id": request_id,
                 },
             )
 
-        return {"requested": True, "service": service, "target_agent": agent_id}
+        return {
+            "requested": True,
+            "service": service,
+            "target_agent": agent_id,
+            "request_id": request_id,
+        }
+
+    def _cancel_help_request(
+        kind: str, request_id: str, reason: str,
+    ) -> dict:
+        """Resolve an open help request as cancelled.
+
+        Returns the popped record. Raises HTTPException(404) if the id
+        is unknown or already resolved. Caller is responsible for
+        emitting any follow-up event / steer.
+        """
+        record = help_requests.get(request_id)
+        if record is None:
+            raise HTTPException(
+                404, f"{kind} request not found or already resolved",
+            )
+        if record.get("kind") != kind:
+            raise HTTPException(
+                404, f"{kind} request not found or already resolved",
+            )
+        if record.get("status") != "open":
+            raise HTTPException(
+                404, f"{kind} request not found or already resolved",
+            )
+        record["status"] = "cancelled"
+        record["reason"] = reason
+        # Pop after mutating so the dict is the source of truth on
+        # whether the request is still resolvable.
+        help_requests.pop(request_id, None)
+        return record
+
+    async def _enqueue_cancel_steer(agent_id: str, message: str) -> None:
+        """Push a steer message to the awaiting agent.
+
+        Best-effort: silently swallows if no lane manager is wired
+        (mesh-only test setup) or the agent isn't registered.
+        """
+        if lane_manager is None or not agent_id:
+            return
+        try:
+            from src.shared.trace import new_trace_id
+            await lane_manager.enqueue(
+                agent_id, sanitize_for_prompt(message),
+                mode="steer", trace_id=new_trace_id(),
+            )
+        except Exception as e:
+            logger.warning("cancel-steer enqueue failed for %s: %s", agent_id, e)
+
+    @app.post("/mesh/credential-request/{request_id}/cancel")
+    async def credential_request_cancel(
+        request_id: str, data: dict, request: Request,
+    ) -> dict:
+        """User cancelled a pending credential request from the dashboard.
+
+        Pops the open record, emits ``credential_request_cancelled``
+        so all card copies update, and pushes a steer message to the
+        requesting agent so it can react instead of waiting on a
+        credential that will never arrive.
+        """
+        # Loopback or operator only — same access model as the dashboard
+        # cancel proxy that fronts this.
+        caller = _extract_verified_agent_id(request)
+        if caller != "operator" and not _is_internal_caller(request):
+            raise HTTPException(
+                403, "Only the operator can cancel a credential request",
+            )
+        reason = (data or {}).get("reason", "user_cancelled")
+        record = _cancel_help_request("credential_request", request_id, reason)
+        agent_id = record["agent_id"]
+        service = record["payload"].get("service") or record["payload"].get("name", "")
+        name = record["payload"].get("name", "")
+        if event_bus:
+            event_bus.emit(
+                "credential_request_cancelled",
+                agent=agent_id,
+                data={
+                    "request_id": request_id,
+                    "name": name,
+                    "service": service,
+                    "reason": reason,
+                },
+            )
+        await _enqueue_cancel_steer(
+            agent_id,
+            f"The user cancelled your request for credential '{name}'. "
+            f"They did not provide it. Skip this step or ask "
+            f"differently — do not retry the same request immediately.",
+        )
+        return {
+            "ok": True,
+            "request_id": request_id,
+            "status": "cancelled",
+            "reason": reason,
+        }
+
+    @app.post("/mesh/browser-login-request/{request_id}/cancel")
+    async def browser_login_request_cancel(
+        request_id: str, data: dict, request: Request,
+    ) -> dict:
+        """User cancelled a pending browser login request."""
+        caller = _extract_verified_agent_id(request)
+        if caller != "operator" and not _is_internal_caller(request):
+            raise HTTPException(
+                403, "Only the operator can cancel a browser login request",
+            )
+        reason = (data or {}).get("reason", "user_cancelled")
+        record = _cancel_help_request(
+            "browser_login_request", request_id, reason,
+        )
+        agent_id = record["agent_id"]
+        service = record["payload"].get("service", "")
+        if event_bus:
+            event_bus.emit(
+                "browser_login_cancelled",
+                agent=agent_id,
+                data={
+                    "request_id": request_id,
+                    "service": service,
+                    "reason": reason,
+                },
+            )
+        await _enqueue_cancel_steer(
+            agent_id,
+            f"The user cancelled the browser login for {service}. "
+            f"You may need to find an alternative approach or ask "
+            f"again later. Do not retry the same login immediately.",
+        )
+        return {
+            "ok": True,
+            "request_id": request_id,
+            "status": "cancelled",
+            "reason": reason,
+        }
+
+    @app.post("/mesh/browser-captcha-help-request/{request_id}/cancel")
+    async def browser_captcha_help_request_cancel(
+        request_id: str, data: dict, request: Request,
+    ) -> dict:
+        """User cancelled a pending CAPTCHA-help request."""
+        caller = _extract_verified_agent_id(request)
+        if caller != "operator" and not _is_internal_caller(request):
+            raise HTTPException(
+                403, "Only the operator can cancel a CAPTCHA-help request",
+            )
+        reason = (data or {}).get("reason", "user_cancelled")
+        record = _cancel_help_request(
+            "browser_captcha_help_request", request_id, reason,
+        )
+        agent_id = record["agent_id"]
+        service = record["payload"].get("service", "")
+        if event_bus:
+            event_bus.emit(
+                "browser_captcha_help_cancelled",
+                agent=agent_id,
+                data={
+                    "request_id": request_id,
+                    "service": service,
+                    "reason": reason,
+                },
+            )
+        await _enqueue_cancel_steer(
+            agent_id,
+            f"The user cancelled the CAPTCHA help request for "
+            f"{service}. Try a different approach (wait + retry, "
+            f"escalate via notify_user). Do not re-request the same "
+            f"captcha help immediately.",
+        )
+        return {
+            "ok": True,
+            "request_id": request_id,
+            "status": "cancelled",
+            "reason": reason,
+        }
 
     @app.get("/mesh/agents")
     async def list_agents(request: Request, project: str = "", agent_id: str = "") -> dict:

--- a/src/shared/types.py
+++ b/src/shared/types.py
@@ -531,6 +531,7 @@ class DashboardEvent(BaseModel):
         "chat_reset",
         "credit_exhausted",
         "credential_request",
+        "credential_request_cancelled",
         "credential_stored",
         "browser_login_request",
         "browser_login_completed",

--- a/tests/test_browser_login_cancel.py
+++ b/tests/test_browser_login_cancel.py
@@ -1,0 +1,338 @@
+"""Tests for browser-login & captcha-help cancellation (PR 3).
+
+Covers both ``POST /mesh/browser-login-request/{id}/cancel`` and
+``POST /mesh/browser-captcha-help-request/{id}/cancel``:
+
+  * Happy path emits ``*_cancelled`` event AND enqueues a steer to
+    the awaiting agent so it can react.
+  * Unknown id → 404. Already-cancelled → 404.
+  * Forbidden caller → 403.
+  * Agent-side ``request_browser_login`` / ``request_captcha_help``
+    surface the server-generated request_id.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+
+def _build_mesh(tmp_path, *, lane_manager=None, perms_map=None):
+    from src.host.costs import CostTracker
+    from src.host.mesh import Blackboard, MessageRouter, PubSub
+    from src.host.permissions import PermissionMatrix
+    from src.host.server import create_mesh_app
+    from src.host.traces import TraceStore
+    from src.shared.types import AgentPermissions
+
+    bb = Blackboard(str(tmp_path / "bb.db"))
+    pubsub = PubSub()
+    perms = PermissionMatrix()
+    for aid, p in (perms_map or {}).items():
+        perms.permissions[aid] = AgentPermissions(agent_id=aid, **p)
+    router = MessageRouter(perms, {})
+    costs = CostTracker(str(tmp_path / "costs.db"))
+    traces = TraceStore(str(tmp_path / "traces.db"))
+    event_bus = MagicMock()
+
+    container_manager = MagicMock()
+    container_manager.browser_service_url = "http://browser-svc:8500"
+    container_manager.browser_auth_token = ""
+
+    app = create_mesh_app(
+        blackboard=bb,
+        pubsub=pubsub,
+        router=router,
+        permissions=perms,
+        cost_tracker=costs,
+        trace_store=traces,
+        event_bus=event_bus,
+        container_manager=container_manager,
+        lane_manager=lane_manager,
+    )
+    return app, event_bus
+
+
+# ── Browser login ──────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_browser_login_request_returns_request_id(tmp_path):
+    from httpx import ASGITransport, AsyncClient
+
+    app, _ = _build_mesh(
+        tmp_path, perms_map={"worker": {"can_use_browser": True}},
+    )
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://test",
+    ) as client:
+        resp = await client.post(
+            "/mesh/browser-login-request",
+            json={
+                "agent_id": "worker",
+                "url": "https://x.com/login",
+                "service": "X",
+                "description": "Log in",
+            },
+            headers={"X-Agent-ID": "worker"},
+        )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["request_id"]
+    assert body["request_id"] in app.help_requests
+
+
+@pytest.mark.asyncio
+async def test_browser_login_cancel_emits_and_steers(tmp_path):
+    from httpx import ASGITransport, AsyncClient
+
+    lane_manager = MagicMock()
+    lane_manager.enqueue = AsyncMock()
+    app, event_bus = _build_mesh(
+        tmp_path,
+        perms_map={"worker": {"can_use_browser": True}},
+        lane_manager=lane_manager,
+    )
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://test",
+    ) as client:
+        resp = await client.post(
+            "/mesh/browser-login-request",
+            json={
+                "agent_id": "worker",
+                "url": "https://x.com/login",
+                "service": "X",
+                "description": "Log in",
+            },
+            headers={"X-Agent-ID": "worker"},
+        )
+        rid = resp.json()["request_id"]
+        event_bus.emit.reset_mock()
+
+        cancel = await client.post(
+            f"/mesh/browser-login-request/{rid}/cancel",
+            json={"reason": "user_cancelled"},
+            headers={"x-mesh-internal": "1", "X-Agent-ID": "operator"},
+        )
+    assert cancel.status_code == 200, cancel.text
+    body = cancel.json()
+    assert body["status"] == "cancelled"
+    assert body["request_id"] == rid
+
+    event_bus.emit.assert_called_once()
+    call = event_bus.emit.call_args
+    assert call[0][0] == "browser_login_cancelled"
+    assert call[1]["agent"] == "worker"
+    assert call[1]["data"]["request_id"] == rid
+    assert call[1]["data"]["service"] == "X"
+
+    lane_manager.enqueue.assert_awaited_once()
+    enqueue = lane_manager.enqueue.await_args
+    assert enqueue[0][0] == "worker"
+    assert "X" in enqueue[0][1]
+    assert enqueue[1]["mode"] == "steer"
+
+
+@pytest.mark.asyncio
+async def test_browser_login_cancel_unknown_id_returns_404(tmp_path):
+    from httpx import ASGITransport, AsyncClient
+
+    app, _ = _build_mesh(tmp_path)
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://test",
+    ) as client:
+        resp = await client.post(
+            "/mesh/browser-login-request/nope/cancel",
+            json={},
+            headers={"x-mesh-internal": "1", "X-Agent-ID": "operator"},
+        )
+    assert resp.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_browser_login_cancel_already_cancelled_returns_404(tmp_path):
+    from httpx import ASGITransport, AsyncClient
+
+    lane_manager = MagicMock()
+    lane_manager.enqueue = AsyncMock()
+    app, _ = _build_mesh(
+        tmp_path,
+        perms_map={"worker": {"can_use_browser": True}},
+        lane_manager=lane_manager,
+    )
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://test",
+    ) as client:
+        resp = await client.post(
+            "/mesh/browser-login-request",
+            json={
+                "agent_id": "worker",
+                "url": "https://x.com/login",
+                "service": "X",
+                "description": "Log in",
+            },
+            headers={"X-Agent-ID": "worker"},
+        )
+        rid = resp.json()["request_id"]
+        first = await client.post(
+            f"/mesh/browser-login-request/{rid}/cancel",
+            json={},
+            headers={"x-mesh-internal": "1", "X-Agent-ID": "operator"},
+        )
+        assert first.status_code == 200
+        second = await client.post(
+            f"/mesh/browser-login-request/{rid}/cancel",
+            json={},
+            headers={"x-mesh-internal": "1", "X-Agent-ID": "operator"},
+        )
+    assert second.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_browser_login_cancel_blocked_for_non_operator(tmp_path):
+    from httpx import ASGITransport, AsyncClient
+
+    app, _ = _build_mesh(
+        tmp_path, perms_map={"worker": {"can_use_browser": True}},
+    )
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://test",
+    ) as client:
+        resp = await client.post(
+            "/mesh/browser-login-request",
+            json={
+                "agent_id": "worker",
+                "url": "https://x.com/login",
+                "service": "X",
+                "description": "Log in",
+            },
+            headers={"X-Agent-ID": "worker"},
+        )
+        rid = resp.json()["request_id"]
+        forbid = await client.post(
+            f"/mesh/browser-login-request/{rid}/cancel",
+            json={},
+            headers={"X-Agent-ID": "worker"},  # not operator, not internal
+        )
+    assert forbid.status_code == 403
+
+
+# ── Browser CAPTCHA help ──────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_captcha_help_request_returns_request_id(tmp_path):
+    from httpx import ASGITransport, AsyncClient
+
+    app, _ = _build_mesh(
+        tmp_path, perms_map={"worker": {"can_use_browser": True}},
+    )
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://test",
+    ) as client:
+        resp = await client.post(
+            "/mesh/browser-captcha-help-request",
+            json={
+                "agent_id": "worker",
+                "service": "Cloudflare",
+                "description": "Click the checkbox",
+            },
+            headers={"X-Agent-ID": "worker"},
+        )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["request_id"]
+    assert body["request_id"] in app.help_requests
+
+
+@pytest.mark.asyncio
+async def test_captcha_help_cancel_emits_and_steers(tmp_path):
+    from httpx import ASGITransport, AsyncClient
+
+    lane_manager = MagicMock()
+    lane_manager.enqueue = AsyncMock()
+    app, event_bus = _build_mesh(
+        tmp_path,
+        perms_map={"worker": {"can_use_browser": True}},
+        lane_manager=lane_manager,
+    )
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://test",
+    ) as client:
+        resp = await client.post(
+            "/mesh/browser-captcha-help-request",
+            json={
+                "agent_id": "worker",
+                "service": "Cloudflare",
+                "description": "Click the checkbox",
+            },
+            headers={"X-Agent-ID": "worker"},
+        )
+        rid = resp.json()["request_id"]
+        event_bus.emit.reset_mock()
+
+        cancel = await client.post(
+            f"/mesh/browser-captcha-help-request/{rid}/cancel",
+            json={"reason": "user_cancelled"},
+            headers={"x-mesh-internal": "1", "X-Agent-ID": "operator"},
+        )
+    assert cancel.status_code == 200, cancel.text
+    event_bus.emit.assert_called_once()
+    call = event_bus.emit.call_args
+    assert call[0][0] == "browser_captcha_help_cancelled"
+    assert call[1]["agent"] == "worker"
+    assert call[1]["data"]["request_id"] == rid
+    assert call[1]["data"]["service"] == "Cloudflare"
+
+    lane_manager.enqueue.assert_awaited_once()
+
+
+# ── Agent-side tools surface request_id ───────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_request_browser_login_skill_surfaces_request_id():
+    from src.agent.builtins.browser_tool import request_browser_login
+
+    mc = AsyncMock()
+    mc.browser_command = AsyncMock(return_value={"url": "https://x/login"})
+    mc.request_browser_login = AsyncMock(return_value={
+        "requested": True, "service": "X", "request_id": "abc",
+    })
+    result = await request_browser_login(
+        url="https://x/login", service="X", description="d",
+        mesh_client=mc,
+    )
+    assert result["request_id"] == "abc"
+
+
+@pytest.mark.asyncio
+async def test_request_browser_login_skill_omits_request_id_when_missing():
+    from src.agent.builtins.browser_tool import request_browser_login
+
+    mc = AsyncMock()
+    mc.browser_command = AsyncMock(return_value={"url": "https://x/login"})
+    mc.request_browser_login = AsyncMock(return_value={
+        "requested": True, "service": "X",
+    })
+    result = await request_browser_login(
+        url="https://x/login", service="X", description="d",
+        mesh_client=mc,
+    )
+    assert "request_id" not in result
+
+
+@pytest.mark.asyncio
+async def test_request_captcha_help_skill_surfaces_request_id():
+    from src.agent.builtins.browser_tool import request_captcha_help
+
+    mc = AsyncMock()
+    mc.browser_command = AsyncMock(return_value={})
+    mc.request_captcha_help = AsyncMock(return_value={
+        "requested": True, "service": "CF", "request_id": "rid-1",
+    })
+    result = await request_captcha_help(
+        service="CF", description="d", mesh_client=mc,
+    )
+    assert result["request_id"] == "rid-1"

--- a/tests/test_credential_request.py
+++ b/tests/test_credential_request.py
@@ -237,6 +237,9 @@ class TestCredentialRequestEndpoint:
         data = resp.json()
         assert data["requested"] is True
         assert data["name"] == "twitter_api_key"
+        # PR 3: server-generated request_id is returned to the agent
+        assert data["request_id"]
+        assert isinstance(data["request_id"], str)
 
         # Verify event_bus.emit was called with correct args
         self.event_bus.emit.assert_called_once()
@@ -246,6 +249,9 @@ class TestCredentialRequestEndpoint:
         assert call_args[1]["data"]["name"] == "twitter_api_key"
         assert call_args[1]["data"]["description"] == "Your Twitter API key"
         assert call_args[1]["data"]["service"] == "Twitter"
+        # PR 3: request_id travels in the dashboard event so the
+        # cancel button can address it.
+        assert call_args[1]["data"]["request_id"] == data["request_id"]
 
     @pytest.mark.asyncio
     async def test_rejects_missing_name(self, _app):
@@ -296,5 +302,8 @@ class TestCredentialRequestEndpoint:
         assert "value" not in call_data
         assert "key" not in call_data
         assert "secret" not in call_data.get("name", "").lower() or True  # name is fine
-        # Only name, description, service are allowed
-        assert set(call_data.keys()) == {"name", "description", "service"}
+        # Only name, description, service, request_id are allowed
+        # (request_id added in PR 3 to scope cancel buttons).
+        assert set(call_data.keys()) == {
+            "name", "description", "service", "request_id",
+        }

--- a/tests/test_credential_request_cancel.py
+++ b/tests/test_credential_request_cancel.py
@@ -1,0 +1,243 @@
+"""Tests for credential-request cancellation (PR 3).
+
+Covers:
+  * ``POST /mesh/credential-request/{id}/cancel`` happy path.
+  * Unknown / already-resolved request_id → 404.
+  * Forbidden caller (non-operator, non-internal) → 403.
+  * Cross-emit: ``credential_request_cancelled`` event fires.
+  * Steer message enqueued to the awaiting agent (via lane_manager).
+  * Agent-side ``request_credential`` returns the request_id so the
+    dashboard's Cancel button can address it.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+
+def _build_mesh(tmp_path, *, lane_manager=None):
+    from src.host.costs import CostTracker
+    from src.host.mesh import Blackboard, MessageRouter, PubSub
+    from src.host.permissions import PermissionMatrix
+    from src.host.server import create_mesh_app
+    from src.host.traces import TraceStore
+
+    bb = Blackboard(str(tmp_path / "bb.db"))
+    pubsub = PubSub()
+    perms = PermissionMatrix()
+    router = MessageRouter(perms, {})
+    costs = CostTracker(str(tmp_path / "costs.db"))
+    traces = TraceStore(str(tmp_path / "traces.db"))
+    event_bus = MagicMock()
+
+    app = create_mesh_app(
+        blackboard=bb,
+        pubsub=pubsub,
+        router=router,
+        permissions=perms,
+        cost_tracker=costs,
+        trace_store=traces,
+        event_bus=event_bus,
+        lane_manager=lane_manager,
+    )
+    return app, event_bus
+
+
+@pytest.mark.asyncio
+async def test_request_returns_request_id(tmp_path):
+    from httpx import ASGITransport, AsyncClient
+
+    app, event_bus = _build_mesh(tmp_path)
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://test",
+    ) as client:
+        resp = await client.post(
+            "/mesh/credential-request",
+            json={
+                "agent_id": "agent-1",
+                "name": "twitter_api_key",
+                "description": "Your Twitter API key",
+                "service": "Twitter",
+            },
+        )
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["request_id"]
+    # Recorded in the in-memory registry exposed for tests
+    assert data["request_id"] in app.help_requests
+    rec = app.help_requests[data["request_id"]]
+    assert rec["kind"] == "credential_request"
+    assert rec["agent_id"] == "agent-1"
+    assert rec["status"] == "open"
+
+
+@pytest.mark.asyncio
+async def test_cancel_happy_path_emits_and_steers(tmp_path):
+    from httpx import ASGITransport, AsyncClient
+
+    lane_manager = MagicMock()
+    lane_manager.enqueue = AsyncMock()
+
+    app, event_bus = _build_mesh(tmp_path, lane_manager=lane_manager)
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://test",
+    ) as client:
+        resp = await client.post(
+            "/mesh/credential-request",
+            json={
+                "agent_id": "agent-1",
+                "name": "stripe_key",
+                "description": "Your Stripe key",
+            },
+        )
+        request_id = resp.json()["request_id"]
+        event_bus.emit.reset_mock()  # ignore the request emit
+
+        # Loopback + operator header → internal caller path
+        cancel = await client.post(
+            f"/mesh/credential-request/{request_id}/cancel",
+            json={"reason": "user_cancelled"},
+            headers={"x-mesh-internal": "1", "X-Agent-ID": "operator"},
+        )
+    assert cancel.status_code == 200, cancel.text
+    body = cancel.json()
+    assert body["ok"] is True
+    assert body["status"] == "cancelled"
+    assert body["request_id"] == request_id
+
+    # The cancellation event fired with the right shape
+    event_bus.emit.assert_called_once()
+    call = event_bus.emit.call_args
+    assert call[0][0] == "credential_request_cancelled"
+    assert call[1]["agent"] == "agent-1"
+    assert call[1]["data"]["request_id"] == request_id
+    assert call[1]["data"]["name"] == "stripe_key"
+    assert call[1]["data"]["reason"] == "user_cancelled"
+
+    # And a steer message reached the awaiting agent so it can react
+    lane_manager.enqueue.assert_awaited_once()
+    enqueue_call = lane_manager.enqueue.await_args
+    assert enqueue_call[0][0] == "agent-1"
+    assert enqueue_call[1]["mode"] == "steer"
+    assert "cancelled" in enqueue_call[0][1].lower()
+    assert "stripe_key" in enqueue_call[0][1]
+
+    # Record popped from the registry — second cancel must 404
+    assert request_id not in app.help_requests
+
+
+@pytest.mark.asyncio
+async def test_cancel_unknown_request_id_returns_404(tmp_path):
+    from httpx import ASGITransport, AsyncClient
+
+    app, _ = _build_mesh(tmp_path)
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://test",
+    ) as client:
+        resp = await client.post(
+            "/mesh/credential-request/00000000-0000-0000-0000-000000000000/cancel",
+            json={"reason": "user_cancelled"},
+            headers={"x-mesh-internal": "1", "X-Agent-ID": "operator"},
+        )
+    assert resp.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_cancel_already_cancelled_returns_404(tmp_path):
+    from httpx import ASGITransport, AsyncClient
+
+    lane_manager = MagicMock()
+    lane_manager.enqueue = AsyncMock()
+    app, _ = _build_mesh(tmp_path, lane_manager=lane_manager)
+
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://test",
+    ) as client:
+        resp = await client.post(
+            "/mesh/credential-request",
+            json={"agent_id": "a", "name": "k", "description": "d"},
+        )
+        rid = resp.json()["request_id"]
+        first = await client.post(
+            f"/mesh/credential-request/{rid}/cancel",
+            json={},
+            headers={"x-mesh-internal": "1", "X-Agent-ID": "operator"},
+        )
+        assert first.status_code == 200
+        second = await client.post(
+            f"/mesh/credential-request/{rid}/cancel",
+            json={},
+            headers={"x-mesh-internal": "1", "X-Agent-ID": "operator"},
+        )
+    assert second.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_cancel_blocked_for_non_operator(tmp_path):
+    """A worker-style caller (not operator, not loopback-internal) must
+    not be able to cancel another agent's pending credential request.
+    """
+    from httpx import ASGITransport, AsyncClient
+
+    app, _ = _build_mesh(tmp_path)
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://test",
+    ) as client:
+        resp = await client.post(
+            "/mesh/credential-request",
+            json={"agent_id": "agent-1", "name": "k", "description": "d"},
+        )
+        rid = resp.json()["request_id"]
+        # No x-mesh-internal header → not internal. X-Agent-ID is a
+        # non-operator worker.
+        forbid = await client.post(
+            f"/mesh/credential-request/{rid}/cancel",
+            json={},
+            headers={"X-Agent-ID": "agent-1"},
+        )
+    assert forbid.status_code == 403
+    # The record is still open (not popped on auth failure)
+    assert rid in app.help_requests
+
+
+@pytest.mark.asyncio
+async def test_agent_side_request_credential_surfaces_request_id():
+    """The ``request_credential`` skill must surface the server-generated
+    request_id back into the tool result so downstream cancel paths can
+    address it (and so the agent itself can correlate steers).
+    """
+    from src.agent.builtins.vault_tool import request_credential
+
+    mc = AsyncMock()
+    mc.vault_list.return_value = []
+    mc.request_credential_from_user.return_value = {
+        "requested": True, "name": "k", "request_id": "abc-123",
+    }
+
+    result = await request_credential(
+        name="k", description="d", mesh_client=mc,
+    )
+    assert result["requested"] is True
+    assert result["request_id"] == "abc-123"
+
+
+@pytest.mark.asyncio
+async def test_agent_side_request_credential_omits_request_id_when_missing():
+    """Defensive: when the mesh response lacks a request_id (legacy),
+    the tool result does not include the key — better to omit than
+    return a confusing empty string.
+    """
+    from src.agent.builtins.vault_tool import request_credential
+
+    mc = AsyncMock()
+    mc.vault_list.return_value = []
+    mc.request_credential_from_user.return_value = {
+        "requested": True, "name": "k",
+    }
+
+    result = await request_credential(
+        name="k", description="d", mesh_client=mc,
+    )
+    assert "request_id" not in result


### PR DESCRIPTION
## Summary
- Cancel button on credential / browser-login / captcha-help cards in both chat surfaces
- request_id threaded through events so cancel can address specific requests
- New cancel endpoints emit resolution events; awaiting tool calls return cancelled cleanly
- Backwards compatible: legacy messages without request_id silently omit the button

## Why
The user explicitly flagged this gap. Without a formal cancel, agents wait until TTL with no signal that the user declined. They can't decide to skip, retry, or give up. This adds a clean cancellation path through the same event/card pattern as the existing flows.

## Scope
PR 3 of 5. PRs 0/1/2 (#838, #839, #840) are open. PR 4 adds workplace task drill-in with outcome capture. PR 5 adds north-star fields and activity feed.

## Test plan
- [x] New tests for cancel endpoints + agent-side cancellation
- [ ] Manual: trigger credential request from agent, click Cancel — verify agent's tool returns cancelled
- [ ] Manual: same for browser login (longer flow with VNC)
- [ ] Manual: verify Cancel button is hidden on legacy messages (no request_id)