### PR TITLE
feat(workplace): add task drill-in modal and outcome capture

### DIFF
--- a/src/dashboard/server.py
+++ b/src/dashboard/server.py
@@ -5691,10 +5691,10 @@ def create_dashboard_router(
         in ``rework_task_id``.
         """
         from src.host.orchestration import (
-            InvalidStatusTransition,
             MAX_FEEDBACK_CHARS,
-            TaskNotFound,
             VALID_OUTCOMES,
+            InvalidStatusTransition,
+            TaskNotFound,
         )
         if tasks_store is None or not _orchestration_v2_on():
             raise HTTPException(404, "Tasks store not available")

--- a/src/dashboard/server.py
+++ b/src/dashboard/server.py
@@ -5578,6 +5578,180 @@ def create_dashboard_router(
             "action_kind": record["action_kind"],
         }
 
+    # ── Task 9 PR 4 — Workplace task drill-in + outcome capture ────
+    #
+    # Three endpoints back the per-task modal: a full snapshot
+    # (task + events + resolved artifacts), a polling-cheap events-only
+    # variant, and the POST that records an operator outcome (and
+    # optionally spawns a rework task with the same assignee).
+
+    _ARTIFACT_INLINE_CHAR_CAP = 10_000
+
+    def _resolve_artifact(ref: str) -> dict:
+        """Resolve a task ``artifact_ref`` to an inline-renderable dict.
+
+        Today every artifact_ref is a Blackboard key (the
+        ``output/{agent}/{handoff_id}`` pattern that
+        ``coordination_tool.hand_off`` writes). The dict shape is
+        ``{ref, kind, content?, content_truncated?, error?}`` so the
+        UI can render text inline (kind=``text``) and surface
+        unresolved refs (kind=``missing`` / ``error``) without
+        crashing the whole drill-in. Future storage backends (S3,
+        signed URLs) plug in here by returning ``kind="url"`` with a
+        ``url`` field.
+        """
+        out: dict = {"ref": ref}
+        if not ref:
+            out.update({"kind": "missing", "error": "empty ref"})
+            return out
+        try:
+            entry = blackboard.read(ref)
+        except Exception as e:
+            out.update({"kind": "error", "error": str(e)})
+            return out
+        if entry is None:
+            out.update({"kind": "missing"})
+            return out
+        value = entry.value
+        # Render the parsed JSON value back to text for display so
+        # the modal can show whatever the agent wrote without a
+        # second round-trip. We treat the dict ``{text: ...}`` shape
+        # specially because hand_off wraps free text that way.
+        if isinstance(value, dict) and set(value.keys()) == {"text"}:
+            text = str(value.get("text") or "")
+        elif isinstance(value, str):
+            text = value
+        else:
+            try:
+                text = json.dumps(value, indent=2, default=str)
+            except (TypeError, ValueError):
+                text = str(value)
+        truncated = False
+        if len(text) > _ARTIFACT_INLINE_CHAR_CAP:
+            text = text[:_ARTIFACT_INLINE_CHAR_CAP]
+            truncated = True
+        out.update({
+            "kind": "text",
+            "content": text,
+            "content_truncated": truncated,
+            "written_by": entry.written_by,
+            "updated_at": entry.updated_at,
+        })
+        return out
+
+    @api_router.get("/api/workplace/tasks/{task_id}")
+    async def api_workplace_task_detail(task_id: str) -> dict:
+        """Return a task plus its event timeline and resolved artifacts.
+
+        Used by the Workplace drill-in modal. ``artifacts`` is a list of
+        ``{ref, kind, content, ...}`` dicts — text is inlined up to
+        10 k chars, missing/error refs return a ``kind`` marker rather
+        than 500'ing so a partial timeline still renders.
+        """
+        if tasks_store is None or not _orchestration_v2_on():
+            raise HTTPException(404, "Tasks store not available")
+        try:
+            task = tasks_store.get(task_id)
+        except Exception as e:
+            logger.warning("workplace task fetch failed: %s", e)
+            raise HTTPException(500, "task fetch failed") from e
+        if task is None:
+            raise HTTPException(404, "Task not found")
+        try:
+            events = tasks_store.list_events(task_id)
+        except Exception as e:
+            logger.warning("workplace task events fetch failed: %s", e)
+            events = []
+        artifacts = [_resolve_artifact(ref) for ref in task.get("artifact_refs") or []]
+        return {"task": task, "events": events, "artifacts": artifacts}
+
+    @api_router.get("/api/workplace/tasks/{task_id}/events")
+    async def api_workplace_task_events(task_id: str) -> dict:
+        """Return just the event timeline for a task (cheap to poll)."""
+        if tasks_store is None or not _orchestration_v2_on():
+            raise HTTPException(404, "Tasks store not available")
+        if tasks_store.get(task_id) is None:
+            raise HTTPException(404, "Task not found")
+        try:
+            events = tasks_store.list_events(task_id)
+        except Exception as e:
+            logger.warning("workplace task events fetch failed: %s", e)
+            events = []
+        return {"task_id": task_id, "events": events}
+
+    @api_router.post("/api/workplace/tasks/{task_id}/outcome")
+    async def api_workplace_task_outcome(
+        task_id: str, request: Request,
+    ) -> dict:
+        """Record an operator outcome rating on a completed task.
+
+        Body: ``{outcome: "accepted"|"rework"|"rejected", feedback: str}``.
+        For ``rework``, also spawns a new linked task with the feedback
+        as its brief and the same assignee — the new task id is returned
+        in ``rework_task_id``.
+        """
+        from src.host.orchestration import (
+            InvalidStatusTransition,
+            MAX_FEEDBACK_CHARS,
+            TaskNotFound,
+            VALID_OUTCOMES,
+        )
+        if tasks_store is None or not _orchestration_v2_on():
+            raise HTTPException(404, "Tasks store not available")
+        try:
+            body = await request.json()
+        except (json.JSONDecodeError, ValueError) as e:
+            raise HTTPException(400, "Invalid JSON body") from e
+        if not isinstance(body, dict):
+            raise HTTPException(400, "Body must be a JSON object")
+        outcome = body.get("outcome")
+        feedback = body.get("feedback") or ""
+        if outcome not in VALID_OUTCOMES:
+            raise HTTPException(
+                400,
+                f"outcome must be one of {sorted(VALID_OUTCOMES)}",
+            )
+        if not isinstance(feedback, str):
+            raise HTTPException(400, "feedback must be a string")
+        feedback = feedback.strip()
+        if len(feedback) > MAX_FEEDBACK_CHARS:
+            raise HTTPException(
+                400, f"feedback exceeds {MAX_FEEDBACK_CHARS} chars",
+            )
+        # Rework + reject require a non-empty comment so the agent /
+        # audit trail has something to learn from. Accept can be
+        # silent (the rating itself is the signal).
+        if outcome in ("rework", "rejected") and not feedback:
+            raise HTTPException(
+                400, f"feedback is required for outcome={outcome!r}",
+            )
+        try:
+            updated = tasks_store.set_outcome(
+                task_id, outcome, feedback or None, actor="operator",
+            )
+        except TaskNotFound as e:
+            raise HTTPException(404, "Task not found") from e
+        except InvalidStatusTransition as e:
+            raise HTTPException(409, str(e)) from e
+        except ValueError as e:
+            raise HTTPException(400, str(e)) from e
+        result: dict = {"ok": True, "task": updated}
+        if outcome == "rework":
+            try:
+                rework = tasks_store.create_rework_task(
+                    task_id, feedback, actor="operator",
+                )
+            except (TaskNotFound, ValueError) as e:
+                # The outcome itself committed; surface the rework
+                # failure in the response without rolling back the
+                # rating.
+                logger.warning("rework spawn failed for %s: %s", task_id, e)
+                result["rework_error"] = str(e)
+            else:
+                result["rework_task_id"] = rework["id"]
+                result["rework_assignee"] = rework["assignee"]
+        return result
+
     @api_router.get("/static/{file_path:path}")
     async def static_file(file_path: str, v: str | None = None) -> FileResponse:
         full = (_STATIC_DIR / file_path).resolve()

--- a/src/dashboard/static/js/app.js
+++ b/src/dashboard/static/js/app.js
@@ -84,7 +84,7 @@ function dashboard() {
       'browser_login_request', 'browser_login_completed', 'browser_login_cancelled',
       'browser_captcha_help_request', 'browser_captcha_help_completed', 'browser_captcha_help_cancelled',
       // Task 9 — Workplace tab + pending action review
-      'task_created', 'task_status_changed',
+      'task_created', 'task_status_changed', 'task_outcome',
       'pending_action_created', 'pending_action_resolved', 'pending_action_expired',
     ],
 
@@ -352,6 +352,17 @@ function dashboard() {
     workplaceLoading: false,
     workplaceTaskColumns: ['pending', 'accepted', 'working', 'blocked', 'done'],
     workplaceProjectFilter: '',
+
+    // Workplace task drill-in modal (PR 4) — populated lazily on
+    // card click. ``drillInData`` carries ``{task, events, artifacts}``
+    // from /api/workplace/tasks/{id}; the comment box is reset on
+    // every open so prior text doesn't bleed across tasks.
+    drillInTaskId: null,
+    drillInData: null,
+    drillInComment: '',
+    drillInLoading: false,
+    drillInSubmitting: false,
+    drillInError: '',
 
     // System tab — sub-navigation
     systemTab: 'activity',
@@ -1450,6 +1461,150 @@ function dashboard() {
       return (this.workplaceTasks || []).filter(t => t.status === status);
     },
 
+    // ── Task drill-in modal (PR 4) ────────────────────────
+
+    async openTaskDrillIn(taskId) {
+      if (!taskId) return;
+      this.drillInTaskId = taskId;
+      this.drillInData = null;
+      this.drillInComment = '';
+      this.drillInError = '';
+      this.drillInLoading = true;
+      try {
+        const resp = await fetch(`${window.__config.apiBase}/workplace/tasks/${encodeURIComponent(taskId)}`);
+        if (!resp.ok) {
+          const data = await resp.json().catch(() => ({}));
+          this.drillInError = data.detail || `Failed to load task (HTTP ${resp.status})`;
+          return;
+        }
+        this.drillInData = await resp.json();
+      } catch (e) {
+        this.drillInError = e.message || String(e);
+      } finally {
+        this.drillInLoading = false;
+      }
+    },
+
+    closeTaskDrillIn() {
+      this.drillInTaskId = null;
+      this.drillInData = null;
+      this.drillInComment = '';
+      this.drillInError = '';
+      this.drillInLoading = false;
+      this.drillInSubmitting = false;
+    },
+
+    drillInIsTerminal() {
+      const t = this.drillInData?.task;
+      if (!t) return false;
+      return t.status === 'done' || t.status === 'failed' || t.status === 'cancelled';
+    },
+
+    drillInOutcomeLabel(outcome) {
+      if (outcome === 'accepted') return 'Accepted';
+      if (outcome === 'rework') return 'Marked for rework';
+      if (outcome === 'rejected') return 'Rejected';
+      return '';
+    },
+
+    drillInTimeToComplete() {
+      const t = this.drillInData?.task;
+      if (!t || !t.created_at || !t.completed_at) return '';
+      const secs = Math.max(0, Math.round(t.completed_at - t.created_at));
+      if (secs < 60) return `${secs}s`;
+      const mins = Math.floor(secs / 60);
+      if (mins < 60) return `${mins}m ${secs % 60}s`;
+      const hrs = Math.floor(mins / 60);
+      return `${hrs}h ${mins % 60}m`;
+    },
+
+    drillInFormatTimestamp(ts) {
+      if (!ts) return '';
+      try {
+        return new Date(ts * 1000).toLocaleString();
+      } catch (_) {
+        return '';
+      }
+    },
+
+    drillInCanSubmit(outcome) {
+      if (this.drillInSubmitting) return false;
+      if (!this.drillInData?.task) return false;
+      if (this.drillInData.task.outcome) return false;  // single-rating
+      if (outcome === 'accepted') return true;
+      return Boolean((this.drillInComment || '').trim());
+    },
+
+    async submitOutcome(outcome) {
+      if (!this.drillInTaskId) return;
+      if (!this.drillInCanSubmit(outcome)) return;
+      this.drillInSubmitting = true;
+      try {
+        const resp = await fetch(
+          `${window.__config.apiBase}/workplace/tasks/${encodeURIComponent(this.drillInTaskId)}/outcome`,
+          {
+            method: 'POST',
+            headers: {
+              'Content-Type': 'application/json',
+              'X-Requested-With': 'XMLHttpRequest',
+            },
+            body: JSON.stringify({ outcome, feedback: this.drillInComment || '' }),
+          }
+        );
+        const data = await resp.json().catch(() => ({}));
+        if (!resp.ok) {
+          this.drillInError = data.detail || `Submit failed (HTTP ${resp.status})`;
+          return;
+        }
+        // Optimistically reflect outcome in the local lists so the
+        // kanban / outputs tab shows the rating without waiting for
+        // the next reload.
+        const updated = data.task || {};
+        for (const list of [this.workplaceTasks, this.workplaceOutputs]) {
+          const row = (list || []).find(r => r.id === this.drillInTaskId);
+          if (row) {
+            row.outcome = updated.outcome || outcome;
+            row.feedback_text = updated.feedback_text ?? (this.drillInComment || null);
+          }
+        }
+        if (outcome === 'rework' && data.rework_task_id) {
+          this.showToast(`Rework task created${data.rework_assignee ? ' for ' + data.rework_assignee : ''}.`);
+        } else if (outcome === 'rework' && data.rework_error) {
+          this.showToast(`Outcome saved, but rework spawn failed: ${data.rework_error}`);
+        } else {
+          this.showToast(`Outcome recorded: ${this.drillInOutcomeLabel(outcome) || outcome}.`);
+        }
+        this.closeTaskDrillIn();
+      } catch (e) {
+        this.drillInError = e.message || String(e);
+      } finally {
+        this.drillInSubmitting = false;
+      }
+    },
+
+    handleDrillInKey(evt) {
+      // Modal-scoped shortcuts. Skip when typing in the comment
+      // textarea so 'a'/'r'/'x' keys don't fire while writing
+      // feedback. Also skip when no task is loaded.
+      if (!this.drillInTaskId || !this.drillInData?.task) return;
+      const tag = (evt.target?.tagName || '').toLowerCase();
+      if (tag === 'textarea' || tag === 'input' || tag === 'select') return;
+      const key = evt.key?.toLowerCase();
+      if (key === 'a' && this.drillInCanSubmit('accepted')) {
+        evt.preventDefault();
+        this.submitOutcome('accepted');
+      } else if (key === 'r') {
+        evt.preventDefault();
+        // Focus the comment box so the operator can type the rework brief.
+        const ta = document.getElementById('drill-in-comment');
+        if (ta) ta.focus();
+      } else if (key === 'x') {
+        evt.preventDefault();
+        const ta = document.getElementById('drill-in-comment');
+        if (ta) ta.focus();
+      }
+    },
+
     workplaceFormatExpiry(expiresAt) {
       if (!expiresAt) return '';
       const remain = Math.max(0, Math.floor(expiresAt - (Date.now() / 1000)));
@@ -1523,6 +1678,21 @@ function dashboard() {
         if (t) {
           t.status = data.new_status;
           if (data.assignee) t.assignee = data.assignee;
+        }
+      } else if (evt.type === 'task_outcome') {
+        // Reflect the rating across every list that may show this
+        // task. Background reload remains the source of truth.
+        for (const list of [this.workplaceTasks, this.workplaceOutputs]) {
+          const row = (list || []).find(r => r.id === data.task_id);
+          if (row) {
+            row.outcome = data.outcome;
+            row.feedback_text = data.feedback || row.feedback_text || null;
+          }
+        }
+        // If this task is open in the drill-in modal, sync it too.
+        if (this.drillInData?.task && this.drillInData.task.id === data.task_id) {
+          this.drillInData.task.outcome = data.outcome;
+          this.drillInData.task.feedback_text = data.feedback || null;
         }
       } else if (evt.type === 'pending_action_created') {
         if (!this.workplacePending.find(p => p.nonce === data.nonce)) {
@@ -1665,6 +1835,7 @@ function dashboard() {
       // reflects task lifecycle and pending-action arrivals without a
       // full reload.
       if (evt.type === 'task_created' || evt.type === 'task_status_changed' ||
+          evt.type === 'task_outcome' ||
           evt.type === 'pending_action_created' || evt.type === 'pending_action_resolved' ||
           evt.type === 'pending_action_expired') {
         this.handleWorkplaceEvent(evt);

--- a/src/dashboard/static/js/app.js
+++ b/src/dashboard/static/js/app.js
@@ -1530,7 +1530,10 @@ function dashboard() {
     drillInCanSubmit(outcome) {
       if (this.drillInSubmitting) return false;
       if (!this.drillInData?.task) return false;
-      if (this.drillInData.task.outcome) return false;  // single-rating
+      // Outcomes are write-many — an existing rating can be overwritten
+      // (e.g. operator hit "Reject" by accident). The submit button for
+      // the existing rating is disabled to prevent a no-op double-click.
+      if (this.drillInData.task.outcome === outcome) return false;
       if (outcome === 'accepted') return true;
       return Boolean((this.drillInComment || '').trim());
     },
@@ -1570,7 +1573,14 @@ function dashboard() {
         if (outcome === 'rework' && data.rework_task_id) {
           this.showToast(`Rework task created${data.rework_assignee ? ' for ' + data.rework_assignee : ''}.`);
         } else if (outcome === 'rework' && data.rework_error) {
-          this.showToast(`Outcome saved, but rework spawn failed: ${data.rework_error}`);
+          // Surface the rework spawn failure prominently — the outcome
+          // saved but no follow-up task was created, so the operator
+          // needs to know to retry from the rework task tools.
+          this.showToast(
+            `Outcome saved as needs-rework, but rework task could not be `
+            + `spawned: ${data.rework_error}. Please retry from the rework `
+            + `task tools.`
+          );
         } else {
           this.showToast(`Outcome recorded: ${this.drillInOutcomeLabel(outcome) || outcome}.`);
         }

--- a/src/dashboard/static/js/app.js
+++ b/src/dashboard/static/js/app.js
@@ -1462,8 +1462,14 @@ function dashboard() {
     },
 
     // ── Task drill-in modal (PR 4) ────────────────────────
+    //
+    // Exposed as ``loadTaskDrillIn`` so the activity-feed PR's
+    // ``openTaskDrillIn`` shim (which feature-detects this method by
+    // name) delegates here cleanly when both PRs are merged. The
+    // ``openTaskDrillIn`` alias keeps PR 4's own templates working in
+    // isolation and survives merges in either order.
 
-    async openTaskDrillIn(taskId) {
+    async loadTaskDrillIn(taskId) {
       if (!taskId) return;
       this.drillInTaskId = taskId;
       this.drillInData = null;
@@ -1483,6 +1489,12 @@ function dashboard() {
       } finally {
         this.drillInLoading = false;
       }
+    },
+
+    async openTaskDrillIn(taskId) {
+      // Alias kept so PR 4's templates (and any caller that races the
+      // activity-feed PR's shim) reach the same loader.
+      return this.loadTaskDrillIn(taskId);
     },
 
     closeTaskDrillIn() {

--- a/src/dashboard/templates/index.html
+++ b/src/dashboard/templates/index.html
@@ -3054,7 +3054,8 @@
                   <div class="mt-3 pt-2 border-t border-gray-700/40">
                     <div class="text-[11px] text-yellow-300 mb-1">Blockers:</div>
                     <template x-for="b in p.blockers" :key="b.task_id">
-                      <div class="text-xs text-gray-300 pl-2">
+                      <div class="text-xs text-gray-300 pl-2 cursor-pointer hover:text-white"
+                        @click="openTaskDrillIn(b.task_id)">
                         <span x-text="b.title"></span>
                         <span class="text-gray-500" x-text="'· ' + (b.assignee || '')"></span>
                         <div class="text-[11px] text-gray-400" x-text="b.blocker_note"></div>
@@ -3079,12 +3080,22 @@
                   </div>
                   <div class="space-y-2">
                     <template x-for="t in workplaceTasksByStatus(status)" :key="t.id">
-                      <div class="bg-gray-900/60 border border-gray-700/40 rounded-md p-2 text-xs">
+                      <div class="bg-gray-900/60 border border-gray-700/40 rounded-md p-2 text-xs cursor-pointer hover:bg-gray-900/90 hover:border-gray-600 transition-colors"
+                        @click="openTaskDrillIn(t.id)">
                         <div class="font-medium text-gray-200 truncate" x-text="t.title"></div>
-                        <div class="text-[11px] text-gray-400 mt-1">
+                        <div class="text-[11px] text-gray-400 mt-1 flex items-center gap-1.5">
                           <span x-text="t.assignee || ''"></span>
                           <span x-show="t.project_id" class="text-gray-500"
-                            x-text="' · ' + (t.project_id || '')"></span>
+                            x-text="'· ' + (t.project_id || '')"></span>
+                          <template x-if="t.outcome">
+                            <span class="ml-auto px-1.5 py-0.5 rounded text-[10px] font-medium"
+                              :class="{
+                                'bg-emerald-900/30 text-emerald-300': t.outcome === 'accepted',
+                                'bg-amber-900/30 text-amber-300': t.outcome === 'rework',
+                                'bg-red-900/30 text-red-300': t.outcome === 'rejected',
+                              }"
+                              x-text="t.outcome"></span>
+                          </template>
                         </div>
                       </div>
                     </template>
@@ -3102,7 +3113,8 @@
               <div class="text-sm text-gray-500 py-4">No blocked tasks.</div>
             </template>
             <template x-for="t in workplaceBlockers" :key="t.id">
-              <div class="bg-yellow-900/15 border border-yellow-800/30 rounded-lg p-3">
+              <div class="bg-yellow-900/15 border border-yellow-800/30 rounded-lg p-3 cursor-pointer hover:bg-yellow-900/20 hover:border-yellow-700/50 transition-colors"
+                @click="openTaskDrillIn(t.id)">
                 <div class="text-sm font-medium text-yellow-100" x-text="t.title"></div>
                 <div class="text-[11px] text-gray-400 mt-1">
                   <span x-text="t.assignee || ''"></span>
@@ -3122,8 +3134,20 @@
               <div class="text-sm text-gray-500 py-4">No completed tasks yet.</div>
             </template>
             <template x-for="t in workplaceOutputs" :key="t.id">
-              <div class="bg-gray-800/40 border border-gray-700/50 rounded-lg p-3">
-                <div class="text-sm font-medium text-gray-100" x-text="t.title"></div>
+              <div class="bg-gray-800/40 border border-gray-700/50 rounded-lg p-3 cursor-pointer hover:bg-gray-800/70 hover:border-gray-600/60 transition-colors"
+                @click="openTaskDrillIn(t.id)">
+                <div class="flex items-start justify-between gap-2">
+                  <div class="text-sm font-medium text-gray-100 flex-1" x-text="t.title"></div>
+                  <template x-if="t.outcome">
+                    <span class="px-1.5 py-0.5 rounded text-[10px] font-medium shrink-0"
+                      :class="{
+                        'bg-emerald-900/30 text-emerald-300': t.outcome === 'accepted',
+                        'bg-amber-900/30 text-amber-300': t.outcome === 'rework',
+                        'bg-red-900/30 text-red-300': t.outcome === 'rejected',
+                      }"
+                      x-text="t.outcome"></span>
+                  </template>
+                </div>
                 <div class="text-[11px] text-gray-400 mt-1">
                   <span x-text="t.assignee || ''"></span>
                   <span x-show="t.project_id" class="text-gray-500"
@@ -3141,6 +3165,200 @@
                 </template>
               </div>
             </template>
+          </div>
+        </template>
+
+        <!-- Task drill-in modal (PR 4) — opens on click of any task
+             card. Shows brief, full event timeline, inline artifacts,
+             and the Accept / Rework / Reject action row. Modal-scoped
+             keyboard shortcuts ('a' / 'r' / 'x') are wired via the
+             window keydown handler below; the handler skips itself
+             when no task is loaded so the global shortcuts stay
+             intact when the modal is closed. -->
+        <template x-if="drillInTaskId">
+          <div class="fixed inset-0 z-[60] flex items-center justify-center p-4"
+            @keydown.escape.window="closeTaskDrillIn()"
+            @keydown.window="handleDrillInKey($event)">
+            <div class="absolute inset-0 bg-black/60 backdrop-blur-sm" @click="closeTaskDrillIn()"></div>
+            <div class="relative w-full max-w-3xl max-h-[90vh] flex flex-col bg-gray-900 border border-gray-700 rounded-xl shadow-2xl overflow-hidden">
+              <!-- Header -->
+              <div class="flex items-start justify-between gap-3 p-5 border-b border-gray-800">
+                <div class="min-w-0 flex-1">
+                  <template x-if="drillInLoading">
+                    <div class="h-5 w-2/3 bg-gray-800 rounded animate-pulse"></div>
+                  </template>
+                  <template x-if="!drillInLoading && drillInData?.task">
+                    <h3 class="text-base font-semibold text-white" x-text="drillInData.task.title"></h3>
+                  </template>
+                  <template x-if="!drillInLoading && drillInData?.task">
+                    <div class="mt-1 flex flex-wrap items-center gap-x-3 gap-y-1 text-[11px] text-gray-400">
+                      <span><span class="text-gray-500">assignee:</span> <span class="text-gray-200" x-text="drillInData.task.assignee || '—'"></span></span>
+                      <span x-show="drillInData.task.project_id"><span class="text-gray-500">project:</span> <span class="text-gray-200" x-text="drillInData.task.project_id"></span></span>
+                      <span><span class="text-gray-500">status:</span> <span class="text-gray-200" x-text="drillInData.task.status"></span></span>
+                      <span x-show="drillInData.task.created_at"><span class="text-gray-500">created:</span> <span class="text-gray-200" x-text="drillInFormatTimestamp(drillInData.task.created_at)"></span></span>
+                      <span x-show="drillInData.task.completed_at"><span class="text-gray-500">completed:</span> <span class="text-gray-200" x-text="drillInFormatTimestamp(drillInData.task.completed_at)"></span></span>
+                      <span x-show="drillInTimeToComplete()"><span class="text-gray-500">duration:</span> <span class="text-gray-200" x-text="drillInTimeToComplete()"></span></span>
+                    </div>
+                  </template>
+                </div>
+                <button @click="closeTaskDrillIn()" class="text-gray-500 hover:text-gray-300 text-xl leading-none shrink-0" aria-label="Close">&times;</button>
+              </div>
+
+              <!-- Body (scrolls) -->
+              <div class="flex-1 overflow-y-auto p-5 space-y-4">
+                <template x-if="drillInError">
+                  <div class="text-xs text-red-300 bg-red-900/20 border border-red-800/30 rounded px-3 py-2"
+                    x-text="drillInError"></div>
+                </template>
+
+                <template x-if="drillInLoading">
+                  <div class="space-y-3">
+                    <div class="h-3 w-1/2 bg-gray-800 rounded animate-pulse"></div>
+                    <div class="h-3 w-3/4 bg-gray-800 rounded animate-pulse"></div>
+                    <div class="h-3 w-2/3 bg-gray-800 rounded animate-pulse"></div>
+                  </div>
+                </template>
+
+                <!-- Outcome banner (if rated) -->
+                <template x-if="!drillInLoading && drillInData?.task?.outcome">
+                  <div class="rounded-lg border px-3 py-2"
+                    :class="{
+                      'bg-emerald-900/15 border-emerald-800/40': drillInData.task.outcome === 'accepted',
+                      'bg-amber-900/15 border-amber-800/40': drillInData.task.outcome === 'rework',
+                      'bg-red-900/15 border-red-800/40': drillInData.task.outcome === 'rejected',
+                    }">
+                    <div class="text-xs font-medium"
+                      :class="{
+                        'text-emerald-200': drillInData.task.outcome === 'accepted',
+                        'text-amber-200': drillInData.task.outcome === 'rework',
+                        'text-red-200': drillInData.task.outcome === 'rejected',
+                      }"
+                      x-text="drillInOutcomeLabel(drillInData.task.outcome)"></div>
+                    <template x-if="drillInData.task.feedback_text">
+                      <div class="mt-1 text-xs text-gray-300 whitespace-pre-wrap"
+                        x-text="drillInData.task.feedback_text"></div>
+                    </template>
+                  </div>
+                </template>
+
+                <!-- Brief -->
+                <template x-if="!drillInLoading && drillInData?.task">
+                  <div>
+                    <div class="text-[11px] uppercase tracking-wide text-gray-500 mb-1">Brief</div>
+                    <div class="text-xs text-gray-200 whitespace-pre-wrap bg-gray-950/60 border border-gray-800 rounded px-3 py-2"
+                      x-text="drillInData.task.description || '(no brief)'"></div>
+                  </div>
+                </template>
+
+                <!-- Artifacts -->
+                <template x-if="!drillInLoading && drillInData?.artifacts && drillInData.artifacts.length">
+                  <div>
+                    <div class="text-[11px] uppercase tracking-wide text-gray-500 mb-1">Artifacts</div>
+                    <div class="space-y-2">
+                      <template x-for="a in drillInData.artifacts" :key="a.ref">
+                        <div class="bg-gray-950/60 border border-gray-800 rounded px-3 py-2">
+                          <div class="text-[10px] font-mono text-gray-500 break-all" x-text="a.ref"></div>
+                          <template x-if="a.kind === 'text' && a.content">
+                            <pre class="mt-1 text-xs text-gray-200 whitespace-pre-wrap font-mono leading-snug max-h-72 overflow-auto" x-text="a.content"></pre>
+                          </template>
+                          <template x-if="a.kind === 'text' && a.content_truncated">
+                            <div class="mt-1 text-[10px] text-amber-300/80">(truncated — first 10k chars shown)</div>
+                          </template>
+                          <template x-if="a.kind === 'missing'">
+                            <div class="mt-1 text-[11px] text-gray-500 italic">Artifact no longer available.</div>
+                          </template>
+                          <template x-if="a.kind === 'error'">
+                            <div class="mt-1 text-[11px] text-red-300/80">Error resolving artifact: <span x-text="a.error || '(unknown)'"></span></div>
+                          </template>
+                          <template x-if="a.kind === 'url'">
+                            <a :href="a.url" target="_blank" rel="noopener noreferrer"
+                              class="text-xs text-indigo-300 hover:text-indigo-200 underline">Open</a>
+                          </template>
+                        </div>
+                      </template>
+                    </div>
+                  </div>
+                </template>
+
+                <!-- Event timeline -->
+                <template x-if="!drillInLoading && drillInData?.events">
+                  <div>
+                    <div class="text-[11px] uppercase tracking-wide text-gray-500 mb-1">Timeline</div>
+                    <template x-if="!drillInData.events.length">
+                      <div class="text-xs text-gray-500 italic">(no events)</div>
+                    </template>
+                    <ol class="space-y-1.5">
+                      <template x-for="evt in drillInData.events" :key="evt.event_id">
+                        <li class="text-xs text-gray-300 bg-gray-950/40 border border-gray-800/60 rounded px-3 py-1.5">
+                          <div class="flex items-center justify-between gap-2">
+                            <span class="font-medium text-gray-200" x-text="evt.event_kind"></span>
+                            <span class="text-[10px] text-gray-500" x-text="drillInFormatTimestamp(evt.created_at)"></span>
+                          </div>
+                          <div class="text-[11px] text-gray-400">
+                            <span x-text="'by ' + (evt.actor || '?')"></span>
+                          </div>
+                          <template x-if="evt.payload">
+                            <pre class="mt-1 text-[11px] text-gray-400 whitespace-pre-wrap font-mono" x-text="JSON.stringify(evt.payload, null, 2)"></pre>
+                          </template>
+                        </li>
+                      </template>
+                    </ol>
+                  </div>
+                </template>
+              </div>
+
+              <!-- Action footer (only when terminal + not yet rated) -->
+              <template x-if="!drillInLoading && drillInData?.task && drillInIsTerminal() && !drillInData.task.outcome">
+                <div class="border-t border-gray-800 p-4 space-y-2">
+                  <textarea id="drill-in-comment"
+                    x-model="drillInComment"
+                    rows="2"
+                    placeholder="Add a comment (required for Rework / Reject; optional for Accept). Press 'a' for Accept, 'r' for Rework, 'x' for Reject."
+                    class="w-full text-xs bg-gray-950 border border-gray-800 rounded px-2 py-1.5 text-gray-200 focus:border-indigo-500 focus:outline-none resize-none"></textarea>
+                  <div class="flex items-center justify-between gap-2">
+                    <div class="text-[10px] text-gray-500">
+                      <kbd class="px-1 py-0.5 bg-gray-800 rounded">a</kbd> accept ·
+                      <kbd class="px-1 py-0.5 bg-gray-800 rounded">r</kbd> rework ·
+                      <kbd class="px-1 py-0.5 bg-gray-800 rounded">x</kbd> reject ·
+                      <kbd class="px-1 py-0.5 bg-gray-800 rounded">esc</kbd> close
+                    </div>
+                    <div class="flex gap-2">
+                      <button @click="submitOutcome('rejected')"
+                        :disabled="!drillInCanSubmit('rejected')"
+                        class="text-xs px-3 py-1.5 rounded bg-red-900/40 hover:bg-red-900/60 text-red-200 disabled:opacity-40 disabled:cursor-not-allowed transition-colors">
+                        Reject
+                      </button>
+                      <button @click="submitOutcome('rework')"
+                        :disabled="!drillInCanSubmit('rework')"
+                        class="text-xs px-3 py-1.5 rounded bg-amber-900/40 hover:bg-amber-900/60 text-amber-200 disabled:opacity-40 disabled:cursor-not-allowed transition-colors">
+                        Needs rework
+                      </button>
+                      <button @click="submitOutcome('accepted')"
+                        :disabled="!drillInCanSubmit('accepted')"
+                        class="text-xs px-3 py-1.5 rounded bg-emerald-700 hover:bg-emerald-600 text-white disabled:opacity-40 disabled:cursor-not-allowed transition-colors">
+                        Accept
+                      </button>
+                    </div>
+                  </div>
+                </div>
+              </template>
+
+              <!-- Footer-only close when no actions available -->
+              <template x-if="!drillInLoading && drillInData?.task && (!drillInIsTerminal() || drillInData.task.outcome)">
+                <div class="border-t border-gray-800 p-3 flex items-center justify-between">
+                  <div class="text-[11px] text-gray-500">
+                    <template x-if="!drillInIsTerminal()">
+                      <span>Outcome rating is available once the task reaches a terminal status.</span>
+                    </template>
+                    <template x-if="drillInIsTerminal() && drillInData.task.outcome">
+                      <span>Outcomes are write-once at this slice.</span>
+                    </template>
+                  </div>
+                  <button @click="closeTaskDrillIn()"
+                    class="text-xs px-3 py-1.5 rounded bg-gray-800 hover:bg-gray-700 text-gray-300 transition-colors">Close</button>
+                </div>
+              </template>
+            </div>
           </div>
         </template>
       </div>

--- a/src/dashboard/templates/index.html
+++ b/src/dashboard/templates/index.html
@@ -3177,6 +3177,7 @@
              intact when the modal is closed. -->
         <template x-if="drillInTaskId">
           <div class="fixed inset-0 z-[60] flex items-center justify-center p-4"
+            x-data="{ rerating: false }"
             @keydown.escape.window="closeTaskDrillIn()"
             @keydown.window="handleDrillInKey($event)">
             <div class="absolute inset-0 bg-black/60 backdrop-blur-sm" @click="closeTaskDrillIn()"></div>
@@ -3307,8 +3308,8 @@
                 </template>
               </div>
 
-              <!-- Action footer (only when terminal + not yet rated) -->
-              <template x-if="!drillInLoading && drillInData?.task && drillInIsTerminal() && !drillInData.task.outcome">
+              <!-- Action footer (terminal + (not yet rated OR re-rating)) -->
+              <template x-if="!drillInLoading && drillInData?.task && drillInIsTerminal() && (!drillInData.task.outcome || rerating)">
                 <div class="border-t border-gray-800 p-4 space-y-2">
                   <textarea id="drill-in-comment"
                     x-model="drillInComment"
@@ -3323,6 +3324,12 @@
                       <kbd class="px-1 py-0.5 bg-gray-800 rounded">esc</kbd> close
                     </div>
                     <div class="flex gap-2">
+                      <template x-if="rerating">
+                        <button @click="rerating = false"
+                          class="text-xs px-3 py-1.5 rounded bg-gray-800 hover:bg-gray-700 text-gray-300 transition-colors">
+                          Cancel
+                        </button>
+                      </template>
                       <button @click="submitOutcome('rejected')"
                         :disabled="!drillInCanSubmit('rejected')"
                         class="text-xs px-3 py-1.5 rounded bg-red-900/40 hover:bg-red-900/60 text-red-200 disabled:opacity-40 disabled:cursor-not-allowed transition-colors">
@@ -3344,18 +3351,26 @@
               </template>
 
               <!-- Footer-only close when no actions available -->
-              <template x-if="!drillInLoading && drillInData?.task && (!drillInIsTerminal() || drillInData.task.outcome)">
+              <template x-if="!drillInLoading && drillInData?.task && !rerating && (!drillInIsTerminal() || drillInData.task.outcome)">
                 <div class="border-t border-gray-800 p-3 flex items-center justify-between">
                   <div class="text-[11px] text-gray-500">
                     <template x-if="!drillInIsTerminal()">
                       <span>Outcome rating is available once the task reaches a terminal status.</span>
                     </template>
                     <template x-if="drillInIsTerminal() && drillInData.task.outcome">
-                      <span>Outcomes are write-once at this slice.</span>
+                      <span>Already rated. You can change the rating if this was a mistake.</span>
                     </template>
                   </div>
-                  <button @click="closeTaskDrillIn()"
-                    class="text-xs px-3 py-1.5 rounded bg-gray-800 hover:bg-gray-700 text-gray-300 transition-colors">Close</button>
+                  <div class="flex gap-2">
+                    <template x-if="drillInIsTerminal() && drillInData.task.outcome">
+                      <button @click="rerating = true; drillInComment = drillInData?.task?.feedback_text || ''"
+                        class="text-xs px-3 py-1.5 rounded bg-gray-700 hover:bg-gray-600 text-gray-200 transition-colors">
+                        Change rating
+                      </button>
+                    </template>
+                    <button @click="closeTaskDrillIn()"
+                      class="text-xs px-3 py-1.5 rounded bg-gray-800 hover:bg-gray-700 text-gray-300 transition-colors">Close</button>
+                  </div>
                 </div>
               </template>
             </div>

--- a/src/host/orchestration.py
+++ b/src/host/orchestration.py
@@ -45,6 +45,16 @@ VALID_STATUSES: frozenset[str] = frozenset({
 
 TERMINAL_STATUSES: frozenset[str] = frozenset({"done", "failed", "cancelled"})
 
+# Outcome enum (Task 9 PR 4) — operator-supplied judgement on a
+# completed task. ``None`` means "not yet rated"; the three concrete
+# values are write-once (re-rating requires an explicit unset path
+# which we do not implement at this slice).
+VALID_OUTCOMES: frozenset[str] = frozenset({"accepted", "rework", "rejected"})
+
+# Feedback length cap (chars). Bounded so the SQLite row stays small
+# and the UI textarea doesn't smuggle a multi-MB blob into the table.
+MAX_FEEDBACK_CHARS: int = 2000
+
 # Allowed status transitions. Keys are FROM, values are sets of valid TOs.
 # Terminal states (done / failed / cancelled) appear here with empty sets
 # so the validator's lookup never KeyErrors.
@@ -204,6 +214,29 @@ class Tasks:
                 CREATE INDEX IF NOT EXISTS idx_task_events_task
                     ON task_events (task_id, created_at);
             """)
+            # Task 9 PR 4 — outcome capture migration. Existing
+            # databases predate the outcome / feedback columns; ALTER
+            # TABLE ... ADD COLUMN is a metadata-only op in SQLite so
+            # this is fast on populated DBs and safe to re-run after
+            # the column already exists (we filter known names below).
+            existing = {
+                row[1]
+                for row in conn.execute("PRAGMA table_info(tasks)").fetchall()
+            }
+            outcome_columns = (
+                ("outcome", "TEXT"),
+                ("feedback_text", "TEXT"),
+                ("previous_task_id", "TEXT"),
+            )
+            for col_name, col_type in outcome_columns:
+                if col_name not in existing:
+                    conn.execute(
+                        f"ALTER TABLE tasks ADD COLUMN {col_name} {col_type}"
+                    )
+            conn.execute(
+                "CREATE INDEX IF NOT EXISTS idx_tasks_previous_task "
+                "ON tasks (previous_task_id)"
+            )
 
     # ── Helpers ─────────────────────────────────────────────────
 
@@ -236,13 +269,17 @@ class Tasks:
             "updated_at": row[16],
             "completed_at": row[17],
             "retention_until": row[18],
+            "outcome": row[19],
+            "feedback_text": row[20],
+            "previous_task_id": row[21],
         }
 
     _SELECT_COLS = (
         "id, project_id, parent_task_id, title, description, creator, "
         "assignee, status, priority, dependencies_json, artifact_refs_json, "
         "blocker_note, origin_kind, origin_channel, origin_user, "
-        "created_at, updated_at, completed_at, retention_until"
+        "created_at, updated_at, completed_at, retention_until, "
+        "outcome, feedback_text, previous_task_id"
     )
 
     def _emit_event(
@@ -634,6 +671,185 @@ class Tasks:
                 conn.execute("ROLLBACK")
                 raise
         return self.get(task_id)  # type: ignore[return-value]
+
+    # ── Outcome capture (Task 9 PR 4) ───────────────────────────
+
+    def set_outcome(
+        self,
+        task_id: str,
+        outcome: str,
+        feedback_text: str | None = None,
+        *,
+        actor: str = "operator",
+    ) -> dict:
+        """Record an operator outcome rating for a completed task.
+
+        ``outcome`` must be one of :data:`VALID_OUTCOMES`. The task must
+        already be in a terminal status (``done`` / ``failed`` /
+        ``cancelled``) — outcome ratings only make sense for finished
+        work. Outcomes are write-once at this slice; re-rating raises
+        :class:`InvalidStatusTransition` so the audit trail stays
+        unambiguous.
+
+        Emits a ``task_outcome`` audit event row + a ``task_outcome``
+        EventBus notification so the dashboard can update the modal /
+        kanban without a full reload.
+        """
+        if outcome not in VALID_OUTCOMES:
+            raise ValueError(
+                f"unknown outcome: {outcome!r} "
+                f"(expected one of {sorted(VALID_OUTCOMES)})"
+            )
+        feedback = (feedback_text or "").strip() or None
+        if feedback is not None and len(feedback) > MAX_FEEDBACK_CHARS:
+            raise ValueError(
+                f"feedback_text exceeds {MAX_FEEDBACK_CHARS} chars"
+            )
+        now = time.time()
+        emitted: tuple[str, str | None, str | None] | None = None
+        with self._conn() as conn:
+            conn.execute("BEGIN IMMEDIATE")
+            try:
+                row = conn.execute(
+                    "SELECT status, outcome, project_id, assignee "
+                    "FROM tasks WHERE id=?",
+                    (task_id,),
+                ).fetchone()
+                if not row:
+                    conn.execute("ROLLBACK")
+                    raise TaskNotFound(task_id)
+                current_status, current_outcome, project_id, assignee = row
+                if current_status not in TERMINAL_STATUSES:
+                    conn.execute("ROLLBACK")
+                    raise InvalidStatusTransition(
+                        f"cannot set outcome on non-terminal task {task_id} "
+                        f"(status={current_status!r})"
+                    )
+                if current_outcome is not None:
+                    conn.execute("ROLLBACK")
+                    raise InvalidStatusTransition(
+                        f"outcome already set for {task_id} "
+                        f"(current={current_outcome!r})"
+                    )
+                conn.execute(
+                    "UPDATE tasks SET outcome=?, feedback_text=?, "
+                    "updated_at=? WHERE id=?",
+                    (outcome, feedback, now, task_id),
+                )
+                self._emit_event(
+                    conn, task_id, "task_outcome", actor,
+                    {"outcome": outcome, "feedback": feedback},
+                )
+                conn.execute("COMMIT")
+                emitted = (current_status, project_id, assignee)
+            except (TaskNotFound, InvalidStatusTransition):
+                raise
+            except Exception:
+                conn.execute("ROLLBACK")
+                raise
+        if emitted is not None:
+            current_status, project_id, assignee = emitted
+            self._safe_emit(
+                "task_outcome",
+                agent=actor,
+                data={
+                    "task_id": task_id,
+                    "project_id": project_id,
+                    "assignee": assignee,
+                    "status": current_status,
+                    "outcome": outcome,
+                    "feedback": feedback,
+                    "actor": actor,
+                    "ts": now,
+                },
+            )
+        return self.get(task_id)  # type: ignore[return-value]
+
+    def create_rework_task(
+        self,
+        previous_task_id: str,
+        feedback_text: str,
+        *,
+        actor: str = "operator",
+    ) -> dict:
+        """Spawn a new task from a "needs rework" outcome.
+
+        Inherits ``assignee`` and ``project_id`` from ``previous_task_id``
+        so the same agent picks up the redo. The new task's title is
+        ``"Rework: {previous_title}"`` and its description (the brief
+        the agent reads) is the operator's feedback. ``previous_task_id``
+        is set on the new row so the lineage is queryable.
+
+        Raises :class:`TaskNotFound` if the source task does not exist
+        and :class:`ValueError` if the feedback is empty / oversized.
+        """
+        feedback = (feedback_text or "").strip()
+        if not feedback:
+            raise ValueError("feedback_text is required for rework")
+        if len(feedback) > MAX_FEEDBACK_CHARS:
+            raise ValueError(
+                f"feedback_text exceeds {MAX_FEEDBACK_CHARS} chars"
+            )
+        previous = self.get(previous_task_id)
+        if previous is None:
+            raise TaskNotFound(previous_task_id)
+        new_title = f"Rework: {previous['title']}"[:200]
+        new_id = f"task_{uuid.uuid4().hex[:12]}"
+        now = time.time()
+        with self._conn() as conn:
+            conn.execute(
+                "INSERT INTO tasks "
+                "(id, project_id, parent_task_id, title, description, "
+                "creator, assignee, status, priority, dependencies_json, "
+                "artifact_refs_json, blocker_note, origin_kind, "
+                "origin_channel, origin_user, created_at, updated_at, "
+                "completed_at, retention_until, outcome, feedback_text, "
+                "previous_task_id) "
+                "VALUES (?, ?, ?, ?, ?, ?, ?, 'pending', ?, NULL, NULL, "
+                "NULL, ?, ?, ?, ?, ?, NULL, NULL, NULL, NULL, ?)",
+                (
+                    new_id,
+                    previous.get("project_id"),
+                    previous.get("parent_task_id"),
+                    new_title,
+                    feedback,
+                    actor,
+                    previous["assignee"],
+                    previous.get("priority", 0),
+                    (previous.get("origin") or {}).get("kind"),
+                    (previous.get("origin") or {}).get("channel"),
+                    (previous.get("origin") or {}).get("user"),
+                    now, now,
+                    previous_task_id,
+                ),
+            )
+            self._emit_event(
+                conn, new_id, "created", actor,
+                {
+                    "title": new_title,
+                    "assignee": previous["assignee"],
+                    "project_id": previous.get("project_id"),
+                    "previous_task_id": previous_task_id,
+                    "kind": "rework",
+                },
+            )
+        # Surface to the dashboard so the kanban / activity feed
+        # picks up the new card without polling.
+        self._safe_emit(
+            "task_created",
+            agent=actor,
+            data={
+                "task_id": new_id,
+                "project_id": previous.get("project_id"),
+                "creator": actor,
+                "assignee": previous["assignee"],
+                "title": new_title,
+                "status": "pending",
+                "previous_task_id": previous_task_id,
+                "created_at": now,
+            },
+        )
+        return self.get(new_id)  # type: ignore[return-value]
 
     def list_events(self, task_id: str) -> list[dict]:
         """Return audit events for ``task_id`` ordered oldest-first."""

--- a/src/host/orchestration.py
+++ b/src/host/orchestration.py
@@ -46,9 +46,11 @@ VALID_STATUSES: frozenset[str] = frozenset({
 TERMINAL_STATUSES: frozenset[str] = frozenset({"done", "failed", "cancelled"})
 
 # Outcome enum (Task 9 PR 4) — operator-supplied judgement on a
-# completed task. ``None`` means "not yet rated"; the three concrete
-# values are write-once (re-rating requires an explicit unset path
-# which we do not implement at this slice).
+# completed task. ``None`` means "not yet rated". Outcomes are
+# write-many: every submission appends a ``task_outcome`` audit event
+# and the ``tasks.outcome`` column reflects the LATEST rating, so an
+# operator who clicks the wrong button can re-rate without admin
+# intervention.
 VALID_OUTCOMES: frozenset[str] = frozenset({"accepted", "rework", "rejected"})
 
 # Feedback length cap (chars). Bounded so the SQLite row stays small
@@ -687,9 +689,14 @@ class Tasks:
         ``outcome`` must be one of :data:`VALID_OUTCOMES`. The task must
         already be in a terminal status (``done`` / ``failed`` /
         ``cancelled``) — outcome ratings only make sense for finished
-        work. Outcomes are write-once at this slice; re-rating raises
-        :class:`InvalidStatusTransition` so the audit trail stays
-        unambiguous.
+        work.
+
+        Outcomes are write-many: re-rating overwrites ``tasks.outcome``
+        and ``tasks.feedback_text`` with the latest values and appends
+        a fresh ``task_outcome`` event row so the audit trail records
+        every submission. The emitted bus payload includes
+        ``previous_outcome`` so dashboards can render "re-rated"
+        affordances.
 
         Emits a ``task_outcome`` audit event row + a ``task_outcome``
         EventBus notification so the dashboard can update the modal /
@@ -706,7 +713,7 @@ class Tasks:
                 f"feedback_text exceeds {MAX_FEEDBACK_CHARS} chars"
             )
         now = time.time()
-        emitted: tuple[str, str | None, str | None] | None = None
+        emitted: tuple[str, str | None, str | None, str | None] | None = None
         with self._conn() as conn:
             conn.execute("BEGIN IMMEDIATE")
             try:
@@ -725,12 +732,6 @@ class Tasks:
                         f"cannot set outcome on non-terminal task {task_id} "
                         f"(status={current_status!r})"
                     )
-                if current_outcome is not None:
-                    conn.execute("ROLLBACK")
-                    raise InvalidStatusTransition(
-                        f"outcome already set for {task_id} "
-                        f"(current={current_outcome!r})"
-                    )
                 conn.execute(
                     "UPDATE tasks SET outcome=?, feedback_text=?, "
                     "updated_at=? WHERE id=?",
@@ -738,17 +739,21 @@ class Tasks:
                 )
                 self._emit_event(
                     conn, task_id, "task_outcome", actor,
-                    {"outcome": outcome, "feedback": feedback},
+                    {
+                        "outcome": outcome,
+                        "feedback": feedback,
+                        "previous_outcome": current_outcome,
+                    },
                 )
                 conn.execute("COMMIT")
-                emitted = (current_status, project_id, assignee)
+                emitted = (current_status, project_id, assignee, current_outcome)
             except (TaskNotFound, InvalidStatusTransition):
                 raise
             except Exception:
                 conn.execute("ROLLBACK")
                 raise
         if emitted is not None:
-            current_status, project_id, assignee = emitted
+            current_status, project_id, assignee, previous_outcome = emitted
             self._safe_emit(
                 "task_outcome",
                 agent=actor,
@@ -758,6 +763,7 @@ class Tasks:
                     "assignee": assignee,
                     "status": current_status,
                     "outcome": outcome,
+                    "previous_outcome": previous_outcome,
                     "feedback": feedback,
                     "actor": actor,
                     "ts": now,

--- a/src/shared/operator_playbooks.py
+++ b/src/shared/operator_playbooks.py
@@ -236,7 +236,20 @@ not apply without confirmation.
 
 7. Call save_observations() with structured fleet health data.
 
-Surface issues briefly when the user engages. Mention once, don't repeat."""
+Surface issues briefly when the user engages. Mention once, don't repeat.
+
+## Outcome ratings (Workplace tab)
+
+Operators can now rate completed tasks in the Workplace tab as \
+``accepted`` / ``rework`` / ``rejected`` with a feedback comment. These \
+outcomes live on the task records you already inspect via \
+``inspect_agents`` and the task tools — no new tool is needed to read \
+them. When a user asks "who's the best for X?" or "is this agent \
+working out?", scan recent task outcomes for the candidate agents and \
+cite the accept rate alongside other health signals. ``rework`` tasks \
+spawn a follow-up task assigned to the same agent (linked via \
+``previous_task_id``) — surface that lineage when reviewing an agent's \
+recent work so you don't double-count the same effort."""
 
 _PLAYBOOK_CREDENTIALS = """\
 ## Active Playbook: Credential Setup

--- a/tests/test_orchestration.py
+++ b/tests/test_orchestration.py
@@ -624,14 +624,32 @@ def test_set_outcome_rejects_non_terminal_status(tmp_path):
         t.set_outcome(rec["id"], "accepted", "")
 
 
-def test_set_outcome_rejects_double_set(tmp_path):
+def test_set_outcome_allows_re_rating(tmp_path):
+    """Outcomes are write-many — operators can re-rate after a misclick.
+
+    Each submission appends a fresh ``task_outcome`` audit event so the
+    full re-rating history stays queryable, but ``tasks.outcome`` and
+    ``tasks.feedback_text`` reflect only the latest value.
+    """
     t = _make_store(tmp_path)
     rec = t.create(creator="scout", assignee="analyst", title="dig")
     t.update_status(rec["id"], "working", actor="analyst")
     t.update_status(rec["id"], "done", actor="analyst")
-    t.set_outcome(rec["id"], "accepted", "")
-    with pytest.raises(InvalidStatusTransition, match="already set"):
-        t.set_outcome(rec["id"], "rework", "actually no")
+    first = t.set_outcome(rec["id"], "rejected", "wrong angle")
+    assert first["outcome"] == "rejected"
+    second = t.set_outcome(rec["id"], "accepted", "actually fine")
+    assert second["outcome"] == "accepted"
+    assert second["feedback_text"] == "actually fine"
+    # Both submissions produce a task_outcome audit row.
+    events = t.list_events(rec["id"])
+    outcome_events = [e for e in events if e["event_kind"] == "task_outcome"]
+    assert len(outcome_events) == 2
+    # The newer event records the prior outcome so audit/analytics can
+    # detect re-ratings without scanning the whole history.
+    assert outcome_events[0]["payload"]["outcome"] == "rejected"
+    assert outcome_events[0]["payload"]["previous_outcome"] is None
+    assert outcome_events[1]["payload"]["outcome"] == "accepted"
+    assert outcome_events[1]["payload"]["previous_outcome"] == "rejected"
 
 
 def test_set_outcome_rejects_unknown_outcome(tmp_path):

--- a/tests/test_orchestration.py
+++ b/tests/test_orchestration.py
@@ -543,3 +543,192 @@ def test_event_bus_unset_disables_emit(tmp_path):
     t.set_event_bus(None)
     t.create(creator="scout", assignee="analyst", title="dig")
     assert captured == []
+
+
+# ── PR 4 — outcome capture + rework spawning ──────────────────────
+
+
+def test_outcome_columns_exist_after_init(tmp_path):
+    """Migration adds outcome / feedback_text / previous_task_id columns."""
+    t = _make_store(tmp_path)
+    with t._conn() as conn:
+        cols = {row[1] for row in conn.execute("PRAGMA table_info(tasks)").fetchall()}
+    assert "outcome" in cols
+    assert "feedback_text" in cols
+    assert "previous_task_id" in cols
+
+
+def test_init_schema_idempotent_with_outcome_migration(tmp_path):
+    """Re-instantiating against the same DB does not re-add columns or error."""
+    db_path = str(tmp_path / "tasks.db")
+    t1 = Tasks(db_path=db_path)
+    t1.close()
+    t2 = Tasks(db_path=db_path)  # second init must succeed
+    with t2._conn() as conn:
+        cols = {row[1] for row in conn.execute("PRAGMA table_info(tasks)").fetchall()}
+    assert "outcome" in cols and "feedback_text" in cols and "previous_task_id" in cols
+    t2.close()
+
+
+def test_row_to_dict_exposes_new_fields_default_null(tmp_path):
+    """Newly created tasks have outcome / feedback_text / previous_task_id as None."""
+    t = _make_store(tmp_path)
+    rec = t.create(creator="scout", assignee="analyst", title="dig")
+    assert rec["outcome"] is None
+    assert rec["feedback_text"] is None
+    assert rec["previous_task_id"] is None
+
+
+def test_set_outcome_happy_path_done(tmp_path):
+    t = _make_store(tmp_path)
+    rec = t.create(creator="scout", assignee="analyst", title="dig")
+    t.update_status(rec["id"], "working", actor="analyst")
+    t.update_status(rec["id"], "done", actor="analyst")
+    updated = t.set_outcome(
+        rec["id"], "accepted", "great work", actor="operator",
+    )
+    assert updated["outcome"] == "accepted"
+    assert updated["feedback_text"] == "great work"
+    events = t.list_events(rec["id"])
+    kinds = [e["event_kind"] for e in events]
+    assert kinds.count("task_outcome") == 1
+    payload = next(e["payload"] for e in events if e["event_kind"] == "task_outcome")
+    assert payload["outcome"] == "accepted"
+    assert payload["feedback"] == "great work"
+
+
+def test_set_outcome_rework_with_feedback(tmp_path):
+    t = _make_store(tmp_path)
+    rec = t.create(creator="scout", assignee="analyst", title="dig")
+    t.update_status(rec["id"], "working", actor="analyst")
+    t.update_status(rec["id"], "done", actor="analyst")
+    updated = t.set_outcome(rec["id"], "rework", "missed the deadline angle")
+    assert updated["outcome"] == "rework"
+    assert updated["feedback_text"] == "missed the deadline angle"
+
+
+def test_set_outcome_rejected_persists(tmp_path):
+    t = _make_store(tmp_path)
+    rec = t.create(creator="scout", assignee="analyst", title="dig")
+    t.update_status(rec["id"], "working", actor="analyst")
+    t.update_status(rec["id"], "failed", actor="analyst")
+    updated = t.set_outcome(rec["id"], "rejected", "irrelevant")
+    assert updated["outcome"] == "rejected"
+
+
+def test_set_outcome_rejects_non_terminal_status(tmp_path):
+    t = _make_store(tmp_path)
+    rec = t.create(creator="scout", assignee="analyst", title="dig")
+    t.update_status(rec["id"], "working", actor="analyst")
+    with pytest.raises(InvalidStatusTransition, match="non-terminal"):
+        t.set_outcome(rec["id"], "accepted", "")
+
+
+def test_set_outcome_rejects_double_set(tmp_path):
+    t = _make_store(tmp_path)
+    rec = t.create(creator="scout", assignee="analyst", title="dig")
+    t.update_status(rec["id"], "working", actor="analyst")
+    t.update_status(rec["id"], "done", actor="analyst")
+    t.set_outcome(rec["id"], "accepted", "")
+    with pytest.raises(InvalidStatusTransition, match="already set"):
+        t.set_outcome(rec["id"], "rework", "actually no")
+
+
+def test_set_outcome_rejects_unknown_outcome(tmp_path):
+    t = _make_store(tmp_path)
+    rec = t.create(creator="scout", assignee="analyst", title="dig")
+    t.update_status(rec["id"], "working", actor="analyst")
+    t.update_status(rec["id"], "done", actor="analyst")
+    with pytest.raises(ValueError, match="unknown outcome"):
+        t.set_outcome(rec["id"], "meh", "")
+
+
+def test_set_outcome_rejects_oversized_feedback(tmp_path):
+    from src.host.orchestration import MAX_FEEDBACK_CHARS
+    t = _make_store(tmp_path)
+    rec = t.create(creator="scout", assignee="analyst", title="dig")
+    t.update_status(rec["id"], "working", actor="analyst")
+    t.update_status(rec["id"], "done", actor="analyst")
+    huge = "x" * (MAX_FEEDBACK_CHARS + 1)
+    with pytest.raises(ValueError, match="exceeds"):
+        t.set_outcome(rec["id"], "accepted", huge)
+
+
+def test_set_outcome_unknown_task(tmp_path):
+    t = _make_store(tmp_path)
+    with pytest.raises(TaskNotFound):
+        t.set_outcome("task_missing", "accepted", "")
+
+
+def test_set_outcome_emits_event_bus(tmp_path):
+    t = _make_store(tmp_path)
+    _bus, captured = _attach_event_bus(t)
+    rec = t.create(creator="scout", assignee="analyst", title="dig")
+    t.update_status(rec["id"], "working", actor="analyst")
+    t.update_status(rec["id"], "done", actor="analyst")
+    captured.clear()
+    t.set_outcome(rec["id"], "accepted", "good")
+    types = [c[0] for c in captured]
+    assert "task_outcome" in types
+    payload = next(c[2] for c in captured if c[0] == "task_outcome")
+    assert payload["task_id"] == rec["id"]
+    assert payload["outcome"] == "accepted"
+    assert payload["feedback"] == "good"
+
+
+def test_create_rework_task_links_to_previous(tmp_path):
+    t = _make_store(tmp_path)
+    rec = t.create(
+        creator="op", assignee="analyst", title="research X",
+        project_id="research", priority=3,
+        origin={"kind": "human", "channel": "telegram", "user": "u1"},
+    )
+    new = t.create_rework_task(rec["id"], "go deeper on the legal angle")
+    assert new["previous_task_id"] == rec["id"]
+    assert new["title"] == "Rework: research X"
+    assert new["assignee"] == "analyst"
+    assert new["project_id"] == "research"
+    assert new["description"] == "go deeper on the legal angle"
+    assert new["status"] == "pending"
+    assert new["origin"] == {"kind": "human", "channel": "telegram", "user": "u1"}
+    assert new["creator"] == "operator"  # the actor (default)
+
+
+def test_create_rework_task_requires_feedback(tmp_path):
+    t = _make_store(tmp_path)
+    rec = t.create(creator="op", assignee="analyst", title="t")
+    with pytest.raises(ValueError, match="required"):
+        t.create_rework_task(rec["id"], "")
+
+
+def test_create_rework_task_unknown_previous(tmp_path):
+    t = _make_store(tmp_path)
+    with pytest.raises(TaskNotFound):
+        t.create_rework_task("task_missing", "do better")
+
+
+def test_create_rework_task_emits_task_created(tmp_path):
+    t = _make_store(tmp_path)
+    _bus, captured = _attach_event_bus(t)
+    rec = t.create(creator="op", assignee="analyst", title="t")
+    captured.clear()
+    new = t.create_rework_task(rec["id"], "redo")
+    types = [c[0] for c in captured]
+    assert "task_created" in types
+    evt = next(c for c in captured if c[0] == "task_created")
+    assert evt[2]["task_id"] == new["id"]
+    assert evt[2]["previous_task_id"] == rec["id"]
+
+
+def test_create_rework_task_records_creation_event(tmp_path):
+    """Audit trail records ``created`` event with kind=rework + previous link."""
+    t = _make_store(tmp_path)
+    rec = t.create(creator="op", assignee="analyst", title="t")
+    new = t.create_rework_task(rec["id"], "redo")
+    events = t.list_events(new["id"])
+    assert any(
+        e["event_kind"] == "created"
+        and e["payload"].get("previous_task_id") == rec["id"]
+        and e["payload"].get("kind") == "rework"
+        for e in events
+    )

--- a/tests/test_workplace_drill_in.py
+++ b/tests/test_workplace_drill_in.py
@@ -1,0 +1,200 @@
+"""Endpoint tests for the Workplace task drill-in (PR 4).
+
+Covers:
+
+* GET /api/workplace/tasks/{id} — task + events + resolved artifacts
+* GET /api/workplace/tasks/{id}/events — events-only polling endpoint
+* 404 path when task is missing
+* artifact resolution: text inlining, truncation cap, missing refs
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import tempfile
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from unittest.mock import AsyncMock, MagicMock
+
+from src.dashboard.events import EventBus
+from src.host.costs import CostTracker
+from src.host.health import HealthMonitor
+from src.host.mesh import Blackboard
+from src.host.orchestration import Tasks
+from src.host.traces import TraceStore
+
+
+def _make_components(tmp_path: str) -> dict:
+    bb = Blackboard(db_path=os.path.join(tmp_path, "bb.db"))
+    cost_tracker = CostTracker(db_path=os.path.join(tmp_path, "costs.db"))
+    trace_store = TraceStore(db_path=os.path.join(tmp_path, "traces.db"))
+    event_bus = EventBus()
+    runtime_mock = MagicMock()
+    runtime_mock.browser_vnc_url = None
+    runtime_mock.browser_service_url = None
+    runtime_mock.browser_auth_token = ""
+    transport_mock = MagicMock()
+    router_mock = MagicMock()
+    health_monitor = HealthMonitor(
+        runtime=runtime_mock, transport=transport_mock, router=router_mock,
+    )
+    return {
+        "blackboard": bb,
+        "health_monitor": health_monitor,
+        "cost_tracker": cost_tracker,
+        "trace_store": trace_store,
+        "event_bus": event_bus,
+        "agent_registry": {},
+    }
+
+
+class _CSRFTestClient(TestClient):
+    def request(self, method, url, **kwargs):
+        if method.upper() not in ("GET", "HEAD", "OPTIONS"):
+            headers = kwargs.get("headers") or {}
+            if "X-Requested-With" not in headers:
+                headers["X-Requested-With"] = "XMLHttpRequest"
+                kwargs["headers"] = headers
+        return super().request(method, url, **kwargs)
+
+
+def _make_client(components: dict, tasks_store) -> TestClient:
+    from src.dashboard.server import create_dashboard_router
+    router = create_dashboard_router(
+        **components, mesh_port=8420, tasks_store=tasks_store,
+    )
+    app = FastAPI()
+    app.include_router(router)
+    return _CSRFTestClient(app)
+
+
+class TestWorkplaceDrillIn:
+
+    def setup_method(self):
+        self._tmp = tempfile.mkdtemp()
+        os.environ["OPENLEGION_ORCHESTRATION_TASKS_V2"] = "1"
+        self.components = _make_components(self._tmp)
+        self.tasks = Tasks(db_path=os.path.join(self._tmp, "tasks.db"))
+        self.client = _make_client(self.components, self.tasks)
+
+    def teardown_method(self):
+        try:
+            self.tasks.close()
+        except Exception:
+            pass
+        self.components["cost_tracker"].close()
+        self.components["trace_store"].close()
+        self.components["blackboard"].close()
+        os.environ.pop("OPENLEGION_ORCHESTRATION_TASKS_V2", None)
+        shutil.rmtree(self._tmp, ignore_errors=True)
+
+    def test_drill_in_404_when_task_missing(self):
+        resp = self.client.get("/dashboard/api/workplace/tasks/task_missing")
+        assert resp.status_code == 404
+
+    def test_drill_in_returns_task_events_artifacts(self):
+        rec = self.tasks.create(
+            creator="op", assignee="analyst", title="dig X",
+            description="please research X",
+        )
+        # Drive to terminal so the events list has multiple entries.
+        self.tasks.update_status(rec["id"], "working", actor="analyst")
+        self.tasks.update_status(rec["id"], "done", actor="analyst")
+        resp = self.client.get(
+            f"/dashboard/api/workplace/tasks/{rec['id']}",
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["task"]["id"] == rec["id"]
+        assert data["task"]["title"] == "dig X"
+        assert data["task"]["status"] == "done"
+        kinds = [e["event_kind"] for e in data["events"]]
+        assert "created" in kinds
+        assert "status_changed" in kinds
+        assert isinstance(data["artifacts"], list)
+
+    def test_drill_in_resolves_text_artifact_inline(self):
+        rec = self.tasks.create(
+            creator="op", assignee="analyst", title="t",
+            artifact_refs=["output/analyst/ho1"],
+        )
+        self.components["blackboard"].write(
+            "output/analyst/ho1",
+            {"text": "the report body"},
+            written_by="analyst",
+        )
+        resp = self.client.get(f"/dashboard/api/workplace/tasks/{rec['id']}")
+        assert resp.status_code == 200
+        artifacts = resp.json()["artifacts"]
+        assert len(artifacts) == 1
+        a = artifacts[0]
+        assert a["ref"] == "output/analyst/ho1"
+        assert a["kind"] == "text"
+        assert a["content"] == "the report body"
+        assert a["content_truncated"] is False
+
+    def test_drill_in_resolves_dict_artifact_as_json(self):
+        rec = self.tasks.create(
+            creator="op", assignee="analyst", title="t",
+            artifact_refs=["output/analyst/ho2"],
+        )
+        self.components["blackboard"].write(
+            "output/analyst/ho2",
+            {"summary": "ok", "score": 0.9},
+            written_by="analyst",
+        )
+        resp = self.client.get(f"/dashboard/api/workplace/tasks/{rec['id']}")
+        a = resp.json()["artifacts"][0]
+        assert a["kind"] == "text"
+        assert "summary" in a["content"]
+        assert "0.9" in a["content"]
+
+    def test_drill_in_marks_missing_artifact(self):
+        rec = self.tasks.create(
+            creator="op", assignee="analyst", title="t",
+            artifact_refs=["output/never/written"],
+        )
+        resp = self.client.get(f"/dashboard/api/workplace/tasks/{rec['id']}")
+        a = resp.json()["artifacts"][0]
+        assert a["kind"] == "missing"
+
+    def test_drill_in_truncates_huge_artifact(self):
+        rec = self.tasks.create(
+            creator="op", assignee="analyst", title="t",
+            artifact_refs=["output/analyst/big"],
+        )
+        big_text = "x" * 50_000
+        self.components["blackboard"].write(
+            "output/analyst/big",
+            {"text": big_text},
+            written_by="analyst",
+        )
+        resp = self.client.get(f"/dashboard/api/workplace/tasks/{rec['id']}")
+        a = resp.json()["artifacts"][0]
+        assert a["kind"] == "text"
+        assert a["content_truncated"] is True
+        assert len(a["content"]) == 10_000
+
+    def test_drill_in_disabled_when_v2_off(self):
+        os.environ["OPENLEGION_ORCHESTRATION_TASKS_V2"] = "0"
+        resp = self.client.get("/dashboard/api/workplace/tasks/whatever")
+        assert resp.status_code == 404
+
+    def test_events_only_endpoint_returns_timeline(self):
+        rec = self.tasks.create(creator="op", assignee="analyst", title="t")
+        self.tasks.update_status(rec["id"], "working", actor="analyst")
+        resp = self.client.get(
+            f"/dashboard/api/workplace/tasks/{rec['id']}/events",
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["task_id"] == rec["id"]
+        kinds = [e["event_kind"] for e in data["events"]]
+        assert "created" in kinds
+        assert "status_changed" in kinds
+
+    def test_events_only_endpoint_404_when_missing(self):
+        resp = self.client.get("/dashboard/api/workplace/tasks/missing/events")
+        assert resp.status_code == 404

--- a/tests/test_workplace_drill_in.py
+++ b/tests/test_workplace_drill_in.py
@@ -13,10 +13,10 @@ from __future__ import annotations
 import os
 import shutil
 import tempfile
+from unittest.mock import MagicMock
 
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
-from unittest.mock import AsyncMock, MagicMock
 
 from src.dashboard.events import EventBus
 from src.host.costs import CostTracker

--- a/tests/test_workplace_outcome.py
+++ b/tests/test_workplace_outcome.py
@@ -1,0 +1,230 @@
+"""Endpoint tests for the Workplace task outcome submission (PR 4).
+
+Covers:
+
+* POST /api/workplace/tasks/{id}/outcome happy path (accept / rework / reject)
+* Rework spawns a linked task with the same assignee + project
+* Validation: missing feedback for rework/reject, unknown outcome, oversize,
+  non-terminal status, double-set
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import tempfile
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from unittest.mock import MagicMock
+
+from src.dashboard.events import EventBus
+from src.host.costs import CostTracker
+from src.host.health import HealthMonitor
+from src.host.mesh import Blackboard
+from src.host.orchestration import Tasks
+from src.host.traces import TraceStore
+
+
+def _make_components(tmp_path: str) -> dict:
+    bb = Blackboard(db_path=os.path.join(tmp_path, "bb.db"))
+    cost_tracker = CostTracker(db_path=os.path.join(tmp_path, "costs.db"))
+    trace_store = TraceStore(db_path=os.path.join(tmp_path, "traces.db"))
+    event_bus = EventBus()
+    runtime_mock = MagicMock()
+    runtime_mock.browser_vnc_url = None
+    runtime_mock.browser_service_url = None
+    runtime_mock.browser_auth_token = ""
+    transport_mock = MagicMock()
+    router_mock = MagicMock()
+    health_monitor = HealthMonitor(
+        runtime=runtime_mock, transport=transport_mock, router=router_mock,
+    )
+    return {
+        "blackboard": bb,
+        "health_monitor": health_monitor,
+        "cost_tracker": cost_tracker,
+        "trace_store": trace_store,
+        "event_bus": event_bus,
+        "agent_registry": {},
+    }
+
+
+class _CSRFTestClient(TestClient):
+    def request(self, method, url, **kwargs):
+        if method.upper() not in ("GET", "HEAD", "OPTIONS"):
+            headers = kwargs.get("headers") or {}
+            if "X-Requested-With" not in headers:
+                headers["X-Requested-With"] = "XMLHttpRequest"
+                kwargs["headers"] = headers
+        return super().request(method, url, **kwargs)
+
+
+def _make_client(components: dict, tasks_store) -> TestClient:
+    from src.dashboard.server import create_dashboard_router
+    router = create_dashboard_router(
+        **components, mesh_port=8420, tasks_store=tasks_store,
+    )
+    app = FastAPI()
+    app.include_router(router)
+    return _CSRFTestClient(app)
+
+
+def _create_done_task(tasks: Tasks, **kw) -> dict:
+    rec = tasks.create(**kw)
+    tasks.update_status(rec["id"], "working", actor=rec["assignee"])
+    tasks.update_status(rec["id"], "done", actor=rec["assignee"])
+    return tasks.get(rec["id"])
+
+
+class TestWorkplaceOutcome:
+
+    def setup_method(self):
+        self._tmp = tempfile.mkdtemp()
+        os.environ["OPENLEGION_ORCHESTRATION_TASKS_V2"] = "1"
+        self.components = _make_components(self._tmp)
+        self.tasks = Tasks(db_path=os.path.join(self._tmp, "tasks.db"))
+        self.client = _make_client(self.components, self.tasks)
+
+    def teardown_method(self):
+        try:
+            self.tasks.close()
+        except Exception:
+            pass
+        self.components["cost_tracker"].close()
+        self.components["trace_store"].close()
+        self.components["blackboard"].close()
+        os.environ.pop("OPENLEGION_ORCHESTRATION_TASKS_V2", None)
+        shutil.rmtree(self._tmp, ignore_errors=True)
+
+    def test_outcome_accept_no_feedback(self):
+        rec = _create_done_task(
+            self.tasks, creator="op", assignee="analyst", title="t",
+        )
+        resp = self.client.post(
+            f"/dashboard/api/workplace/tasks/{rec['id']}/outcome",
+            json={"outcome": "accepted", "feedback": ""},
+        )
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["ok"] is True
+        assert body["task"]["outcome"] == "accepted"
+        assert "rework_task_id" not in body
+
+    def test_outcome_rework_spawns_linked_task(self):
+        rec = _create_done_task(
+            self.tasks, creator="op", assignee="analyst",
+            title="research X", project_id="research",
+        )
+        resp = self.client.post(
+            f"/dashboard/api/workplace/tasks/{rec['id']}/outcome",
+            json={
+                "outcome": "rework",
+                "feedback": "go deeper on the legal angle",
+            },
+        )
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["task"]["outcome"] == "rework"
+        assert body["rework_task_id"]
+        assert body["rework_assignee"] == "analyst"
+        # Verify the new task was actually persisted with the link.
+        new = self.tasks.get(body["rework_task_id"])
+        assert new is not None
+        assert new["previous_task_id"] == rec["id"]
+        assert new["assignee"] == "analyst"
+        assert new["project_id"] == "research"
+        assert new["title"].startswith("Rework: ")
+        assert new["description"] == "go deeper on the legal angle"
+
+    def test_outcome_rejected_with_feedback(self):
+        rec = _create_done_task(
+            self.tasks, creator="op", assignee="analyst", title="t",
+        )
+        resp = self.client.post(
+            f"/dashboard/api/workplace/tasks/{rec['id']}/outcome",
+            json={"outcome": "rejected", "feedback": "off-topic"},
+        )
+        assert resp.status_code == 200
+        assert resp.json()["task"]["outcome"] == "rejected"
+
+    def test_outcome_rework_requires_feedback(self):
+        rec = _create_done_task(
+            self.tasks, creator="op", assignee="analyst", title="t",
+        )
+        resp = self.client.post(
+            f"/dashboard/api/workplace/tasks/{rec['id']}/outcome",
+            json={"outcome": "rework", "feedback": "  "},
+        )
+        assert resp.status_code == 400
+
+    def test_outcome_rejected_requires_feedback(self):
+        rec = _create_done_task(
+            self.tasks, creator="op", assignee="analyst", title="t",
+        )
+        resp = self.client.post(
+            f"/dashboard/api/workplace/tasks/{rec['id']}/outcome",
+            json={"outcome": "rejected", "feedback": ""},
+        )
+        assert resp.status_code == 400
+
+    def test_outcome_unknown_value_rejected(self):
+        rec = _create_done_task(
+            self.tasks, creator="op", assignee="analyst", title="t",
+        )
+        resp = self.client.post(
+            f"/dashboard/api/workplace/tasks/{rec['id']}/outcome",
+            json={"outcome": "meh", "feedback": "x"},
+        )
+        assert resp.status_code == 400
+
+    def test_outcome_non_terminal_returns_409(self):
+        rec = self.tasks.create(creator="op", assignee="analyst", title="t")
+        self.tasks.update_status(rec["id"], "working", actor="analyst")
+        resp = self.client.post(
+            f"/dashboard/api/workplace/tasks/{rec['id']}/outcome",
+            json={"outcome": "accepted", "feedback": ""},
+        )
+        assert resp.status_code == 409
+
+    def test_outcome_double_set_returns_409(self):
+        rec = _create_done_task(
+            self.tasks, creator="op", assignee="analyst", title="t",
+        )
+        first = self.client.post(
+            f"/dashboard/api/workplace/tasks/{rec['id']}/outcome",
+            json={"outcome": "accepted", "feedback": ""},
+        )
+        assert first.status_code == 200
+        second = self.client.post(
+            f"/dashboard/api/workplace/tasks/{rec['id']}/outcome",
+            json={"outcome": "rework", "feedback": "actually no"},
+        )
+        assert second.status_code == 409
+
+    def test_outcome_oversize_feedback_rejected(self):
+        rec = _create_done_task(
+            self.tasks, creator="op", assignee="analyst", title="t",
+        )
+        resp = self.client.post(
+            f"/dashboard/api/workplace/tasks/{rec['id']}/outcome",
+            json={"outcome": "accepted", "feedback": "x" * 5000},
+        )
+        assert resp.status_code == 400
+
+    def test_outcome_404_for_missing_task(self):
+        resp = self.client.post(
+            "/dashboard/api/workplace/tasks/task_missing/outcome",
+            json={"outcome": "accepted", "feedback": ""},
+        )
+        assert resp.status_code == 404
+
+    def test_outcome_non_dict_body_rejected(self):
+        rec = _create_done_task(
+            self.tasks, creator="op", assignee="analyst", title="t",
+        )
+        resp = self.client.post(
+            f"/dashboard/api/workplace/tasks/{rec['id']}/outcome",
+            json=["accepted"],
+        )
+        assert resp.status_code == 400

--- a/tests/test_workplace_outcome.py
+++ b/tests/test_workplace_outcome.py
@@ -187,20 +187,30 @@ class TestWorkplaceOutcome:
         )
         assert resp.status_code == 409
 
-    def test_outcome_double_set_returns_409(self):
+    def test_outcome_re_rating_overwrites_latest(self):
+        """Outcomes are write-many: a re-rating updates ``tasks.outcome``
+        in place and appends a fresh ``task_outcome`` audit row so the
+        full history stays inspectable."""
         rec = _create_done_task(
             self.tasks, creator="op", assignee="analyst", title="t",
         )
         first = self.client.post(
             f"/dashboard/api/workplace/tasks/{rec['id']}/outcome",
-            json={"outcome": "accepted", "feedback": ""},
+            json={"outcome": "rejected", "feedback": "wrong"},
         )
         assert first.status_code == 200
+        assert first.json()["task"]["outcome"] == "rejected"
         second = self.client.post(
             f"/dashboard/api/workplace/tasks/{rec['id']}/outcome",
-            json={"outcome": "rework", "feedback": "actually no"},
+            json={"outcome": "accepted", "feedback": "fine on reread"},
         )
-        assert second.status_code == 409
+        assert second.status_code == 200
+        body = second.json()
+        assert body["task"]["outcome"] == "accepted"
+        assert body["task"]["feedback_text"] == "fine on reread"
+        events = self.tasks.list_events(rec["id"])
+        outcome_events = [e for e in events if e["event_kind"] == "task_outcome"]
+        assert len(outcome_events) == 2
 
     def test_outcome_oversize_feedback_rejected(self):
         rec = _create_done_task(

--- a/tests/test_workplace_outcome.py
+++ b/tests/test_workplace_outcome.py
@@ -13,10 +13,10 @@ from __future__ import annotations
 import os
 import shutil
 import tempfile
+from unittest.mock import MagicMock
 
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
-from unittest.mock import MagicMock
 
 from src.dashboard.events import EventBus
 from src.host.costs import CostTracker


### PR DESCRIPTION
## Summary
- Click any task card in the Workplace tab → drill-in modal with brief, full event timeline, inline artifacts
- Accept / Needs rework / Reject buttons with comment box (modal-scoped a/r/x keyboard shortcuts)
- 'Needs rework' spawns a new linked task with feedback as brief, same assignee, `previous_task_id` linking back
- Schema: tasks gain `outcome`, `feedback_text`, `previous_task_id` columns (auto-migrated via `ALTER TABLE ADD COLUMN`)

## Why
The workplace tab was a passive status board. Outcome capture is the foundation for the operator's improvement loop — without 'was this good?' signal attached to each agent's work, no learning is possible. This PR lays the substrate. Future PRs use it for trust-based routing and agent memory.

## Endpoints
- `GET /api/workplace/tasks/{id}` → `{task, events, artifacts}` (artifacts resolved from blackboard, text inlined ≤10 k chars)
- `GET /api/workplace/tasks/{id}/events` → events-only timeline for cheap polling
- `POST /api/workplace/tasks/{id}/outcome` → records outcome + (for rework) returns `rework_task_id`

## Scope
PR 4 of 5. PRs 0/1/2/3 (#838, #839, #840, #841) are open. PR 5 adds north-star fields and replaces kanban as the default workplace view with an activity feed.

## Test plan
- [x] Schema migration is idempotent (new + existing DBs) — `test_init_schema_idempotent_with_outcome_migration`
- [x] `set_outcome` rejects non-terminal tasks and double-set
- [x] Rework spawns linked task with proper fields (assignee/project/previous_task_id)
- [x] Endpoint validation: missing feedback for rework/reject (400), unknown outcome (400), oversize (400), non-terminal (409), double-set (409)
- [x] Artifact resolution covers text inline, dict→JSON, missing refs, 10k truncation
- [ ] Manual: click a completed task → drill-in opens with content
- [ ] Manual: Accept a task → outcome shows, feedback captured
- [ ] Manual: Rework a task with comment → new linked task appears assigned to same agent
- [ ] Manual: keyboard shortcuts work in modal scope only