### PR TITLE
feat(workplace): add north-star fields and activity feed as default view

### DIFF
--- a/docs/agent-tools.md
+++ b/docs/agent-tools.md
@@ -218,6 +218,7 @@ The following tools are only available to the **operator agent** (when `ALLOWED_
 | `add_agents_to_project` | `project_name`, `agent_ids` | Add one or more agents to a project. |
 | `remove_agents_from_project` | `project_name`, `agent_ids` | Remove one or more agents from a project. |
 | `update_project_context` | `project_name`, `context` | Update the shared context text (`PROJECT.md`) for a project. |
+| `set_project_goal` | `project_name`, `north_star`, `success_criteria` (default []) | Save the project's vision (≤2000 chars) and up to 10 success criteria (each ≤200 chars). Rendered prominently on every project card in the Workplace tab. Pass empty values to clear. |
 
 **Permission ceiling:** The operator cannot grant `can_spawn=true` or `can_use_wallet=true` to agents. Budget limits: daily $0.01–$1000, monthly $0.10–$30000.
 

--- a/src/agent/builtins/operator_tools.py
+++ b/src/agent/builtins/operator_tools.py
@@ -677,7 +677,7 @@ async def update_project_context(
         "north_star": {
             "type": "string",
             "description": (
-                "Free-text vision statement, ≤500 characters. "
+                "Free-text vision statement, ≤2000 characters. "
                 "e.g. 'Ship a $10k MRR SaaS landing page in 2 weeks'."
             ),
         },
@@ -709,8 +709,8 @@ async def set_project_goal(
         return {"error": "project_name is required"}
     if not isinstance(north_star, str):
         return {"error": "north_star must be a string"}
-    if len(north_star) > 500:
-        return {"error": "north_star must be 500 characters or fewer"}
+    if len(north_star) > 2000:
+        return {"error": "north_star must be 2000 characters or fewer"}
 
     cleaned_criteria: list[str] | None
     if success_criteria is None:

--- a/src/agent/builtins/operator_tools.py
+++ b/src/agent/builtins/operator_tools.py
@@ -657,6 +657,91 @@ async def update_project_context(
         return {"error": f"Failed to update project context: {e}"}
 
 
+@skill(
+    name="set_project_goal",
+    description=(
+        "Set or update a project's north star (vision statement) and "
+        "success criteria (measurable outcomes). The north star answers "
+        "'what are we moving toward'; success criteria are the concrete "
+        "checks that tell us we got there. No confirmation required — "
+        "this is meta-config the user explicitly asked for.\n\n"
+        "Call this proactively whenever the user describes a goal for a "
+        "project so it becomes a first-class artifact visible in the "
+        "workplace tab."
+    ),
+    parameters={
+        "project_name": {
+            "type": "string",
+            "description": "Project to set the goal on (use list_projects to find names)",
+        },
+        "north_star": {
+            "type": "string",
+            "description": (
+                "Free-text vision statement, ≤500 characters. "
+                "e.g. 'Ship a $10k MRR SaaS landing page in 2 weeks'."
+            ),
+        },
+        "success_criteria": {
+            "type": "array",
+            "items": {"type": "string"},
+            "description": (
+                "Up to 10 measurable outcomes, each ≤200 characters. "
+                "Optional — pass an empty list or omit to clear."
+            ),
+        },
+    },
+)
+async def set_project_goal(
+    project_name: str,
+    north_star: str,
+    success_criteria: list[str] | None = None,
+    *,
+    mesh_client=None,
+    **_kw,
+) -> dict:
+    """Set the project's north_star + success_criteria. No gate."""
+    if not _is_operator():
+        return {"error": "This tool is only available to the operator agent."}
+    if mesh_client is None:
+        return {"error": "No mesh_client available"}
+
+    if not isinstance(project_name, str) or not project_name.strip():
+        return {"error": "project_name is required"}
+    if not isinstance(north_star, str):
+        return {"error": "north_star must be a string"}
+    if len(north_star) > 500:
+        return {"error": "north_star must be 500 characters or fewer"}
+
+    cleaned_criteria: list[str] | None
+    if success_criteria is None:
+        cleaned_criteria = None
+    else:
+        if not isinstance(success_criteria, list):
+            return {"error": "success_criteria must be a list of strings"}
+        if len(success_criteria) > 10:
+            return {"error": "success_criteria may contain at most 10 items"}
+        cleaned_criteria = []
+        for item in success_criteria:
+            if not isinstance(item, str):
+                return {"error": "each success_criteria entry must be a string"}
+            if len(item) > 200:
+                return {
+                    "error": "each success_criteria entry must be 200 characters or fewer",
+                }
+            stripped = item.strip()
+            if stripped:
+                cleaned_criteria.append(stripped)
+        if not cleaned_criteria:
+            cleaned_criteria = None
+
+    try:
+        return await mesh_client.set_project_goal(
+            project_name, north_star.strip() or None, cleaned_criteria,
+        )
+    except Exception as e:
+        return {"error": f"Failed to set project goal: {e}"}
+
+
 # ── Task 7: Operator product tools ───────────────────────────
 
 

--- a/src/agent/mesh_client.py
+++ b/src/agent/mesh_client.py
@@ -815,6 +815,25 @@ class MeshClient:
         response.raise_for_status()
         return response.json()
 
+    async def set_project_goal(
+        self,
+        project_name: str,
+        north_star: str | None,
+        success_criteria: list[str] | None = None,
+    ) -> dict:
+        """Set a project's north star + success criteria via mesh proxy."""
+        client = await self._get_client()
+        response = await client.post(
+            f"{self.mesh_url}/mesh/projects/{project_name}/goal",
+            json={
+                "north_star": north_star,
+                "success_criteria": success_criteria,
+            },
+            headers=self._trace_headers(),
+        )
+        response.raise_for_status()
+        return response.json()
+
     async def browser_command(
         self, action: str, params: dict | None = None,
         target_agent_id: str | None = None,

--- a/src/cli/config.py
+++ b/src/cli/config.py
@@ -1507,6 +1507,7 @@ _OPERATOR_ALLOWED_TOOLS: list[str] = [
     "read_agent_history", "propose_edit", "confirm_edit", "create_agent",
     "list_projects", "get_project", "create_project",
     "add_agents_to_project", "remove_agents_from_project", "update_project_context",
+    "set_project_goal",
     "vault_list", "request_credential", "request_browser_login",
     # Task 7: operator product surface — read tools
     "list_project_status", "list_agent_queue", "get_team_outputs",

--- a/src/dashboard/server.py
+++ b/src/dashboard/server.py
@@ -190,6 +190,77 @@ def _parse_positive_float(value: Any, field: str, fallback: float) -> float:
     return result
 
 
+def _summarize_task_event(
+    *,
+    event_kind: str,
+    actor: str,
+    title: str,
+    project_id: str,
+    assignee: str,
+    blocker_note: str,
+    payload: dict | None,
+) -> str:
+    """Build a one-line human-readable summary of a task_events row.
+
+    Examples (keep these snappy — the feed renders one per line):
+        "writer-1 completed task 'Draft Q4 plan' in project work"
+        "reviewer-1 marked task 'Edit copy' as blocked: needs SEO data"
+        "ops created task 'Fetch metrics' for analyst-1"
+    """
+    actor = actor or "unknown"
+    where = f" in project {project_id}" if project_id else ""
+    quoted = f"'{title}'"
+
+    if event_kind == "created":
+        for_who = f" for {assignee}" if assignee else ""
+        return f"{actor} created task {quoted}{for_who}{where}"
+
+    if event_kind == "status_changed":
+        # ``orchestration.py`` writes ``from``/``to``; tolerate
+        # ``old_status``/``new_status`` too in case future emitters
+        # standardize on the WS payload's naming.
+        p = payload or {}
+        new_status = p.get("to") or p.get("new_status") or ""
+        old_status = p.get("from") or p.get("old_status") or ""
+        if new_status == "done":
+            return f"{actor} completed task {quoted}{where}"
+        if new_status == "blocked":
+            note = blocker_note or (payload or {}).get("blocker_note") or ""
+            tail = f": {note}" if note else ""
+            return f"{actor} marked task {quoted} as blocked{tail}"
+        if new_status == "failed":
+            return f"{actor} failed task {quoted}{where}"
+        if new_status == "cancelled":
+            return f"{actor} cancelled task {quoted}{where}"
+        if new_status == "working":
+            return f"{actor} started task {quoted}{where}"
+        if new_status == "accepted":
+            return f"{actor} accepted task {quoted}{where}"
+        from_part = f" from {old_status}" if old_status else ""
+        return f"{actor} moved task {quoted} to {new_status}{from_part}{where}"
+
+    if event_kind == "rerouted":
+        # ``orchestration.py`` writes ``to`` (the new assignee).
+        p = payload or {}
+        new_assignee = p.get("to") or p.get("new_assignee") or ""
+        if new_assignee:
+            return f"{actor} rerouted task {quoted} to {new_assignee}{where}"
+        return f"{actor} rerouted task {quoted}{where}"
+
+    if event_kind == "cancelled":
+        reason = (payload or {}).get("reason") or ""
+        tail = f": {reason}" if reason else ""
+        return f"{actor} cancelled task {quoted}{tail}"
+
+    if event_kind == "artifact_added":
+        ref = (payload or {}).get("ref") or ""
+        ref_part = f" ({ref})" if ref else ""
+        return f"{actor} added an artifact to task {quoted}{ref_part}"
+
+    # Fall-through: still useful, just less polished.
+    return f"{actor} {event_kind} on task {quoted}{where}"
+
+
 def _log_cron_task_exception(task: object) -> None:
     """Log unhandled exceptions from fire-and-forget cron tasks."""
     import asyncio
@@ -5495,6 +5566,8 @@ def create_dashboard_router(
                 "description": pdata.get("description", ""),
                 "members": pdata.get("members", []),
                 "status": pdata.get("status", "active"),
+                "north_star": pdata.get("north_star"),
+                "success_criteria": pdata.get("success_criteria"),
                 "counts": counts,
                 "total": len(rows),
                 "blockers": blockers,
@@ -5548,6 +5621,86 @@ def create_dashboard_router(
             logger.warning("workplace outputs listing failed: %s", e)
             rows = []
         return {"enabled": True, "outputs": rows}
+
+    @api_router.get("/api/workplace/feed")
+    async def api_workplace_feed(
+        project_id: str | None = None,
+        limit: int = 100,
+    ) -> dict:
+        """Activity feed for the Workplace > feed tab.
+
+        Returns the most recent ``task_events`` rows joined back to their
+        parent task so each entry can render a humanized one-line summary
+        ("writer-1 completed task 'Draft Q4 plan' in project work").
+        Sorted descending by event timestamp; ``limit`` is clamped to
+        ``[1, 500]``.
+        """
+        if tasks_store is None or not _orchestration_v2_on():
+            return {"enabled": False, "feed": []}
+        limit = max(1, min(int(limit or 100), 500))
+        try:
+            with tasks_store._conn() as conn:
+                if project_id:
+                    sql = (
+                        "SELECT e.event_id, e.task_id, e.event_kind, "
+                        "e.actor, e.payload_json, e.created_at, "
+                        "t.title, t.project_id, t.assignee, t.status, "
+                        "t.blocker_note "
+                        "FROM task_events e "
+                        "JOIN tasks t ON t.id = e.task_id "
+                        "WHERE t.project_id = ? "
+                        "ORDER BY e.created_at DESC, e.event_id DESC "
+                        "LIMIT ?"
+                    )
+                    raw = conn.execute(sql, (project_id, limit)).fetchall()
+                else:
+                    sql = (
+                        "SELECT e.event_id, e.task_id, e.event_kind, "
+                        "e.actor, e.payload_json, e.created_at, "
+                        "t.title, t.project_id, t.assignee, t.status, "
+                        "t.blocker_note "
+                        "FROM task_events e "
+                        "JOIN tasks t ON t.id = e.task_id "
+                        "ORDER BY e.created_at DESC, e.event_id DESC "
+                        "LIMIT ?"
+                    )
+                    raw = conn.execute(sql, (limit,)).fetchall()
+        except Exception as e:
+            logger.warning("workplace feed listing failed: %s", e)
+            return {"enabled": True, "feed": [], "error": str(e)}
+
+        feed: list[dict] = []
+        for row in raw:
+            payload = json.loads(row[4]) if row[4] else None
+            event_kind = row[2]
+            actor = row[3]
+            title = row[6] or "(untitled)"
+            proj = row[7] or ""
+            assignee = row[8] or ""
+            blocker_note = row[10] or ""
+            summary = _summarize_task_event(
+                event_kind=event_kind,
+                actor=actor,
+                title=title,
+                project_id=proj,
+                assignee=assignee,
+                blocker_note=blocker_note,
+                payload=payload,
+            )
+            feed.append({
+                "event_id": row[0],
+                "event_type": event_kind,
+                "task_id": row[1],
+                "task_title": title,
+                "project_id": proj,
+                "assignee": assignee,
+                "actor": actor,
+                "task_status": row[9],
+                "blocker_note": blocker_note,
+                "timestamp": row[5],
+                "summary": summary,
+            })
+        return {"enabled": True, "feed": feed}
 
     @api_router.get("/api/workplace/pending")
     async def api_workplace_pending() -> dict:

--- a/src/dashboard/server.py
+++ b/src/dashboard/server.py
@@ -257,6 +257,17 @@ def _summarize_task_event(
         ref_part = f" ({ref})" if ref else ""
         return f"{actor} added an artifact to task {quoted}{ref_part}"
 
+    if event_kind == "task_outcome":
+        # Emitted by orchestration when the operator grades a finished
+        # task (PR 4). Render the rating cleanly so the feed reads as
+        # "<actor> rated task '<title>' accepted" instead of falling
+        # through to the generic "<actor> task_outcome on task ..." line.
+        p = payload or {}
+        outcome = p.get("outcome") or "rated"
+        previous = p.get("previous_outcome") or ""
+        verb = "re-rated" if previous and previous != outcome else "rated"
+        return f"{actor} {verb} task {quoted} {outcome}{where}"
+
     # Fall-through: still useful, just less polished.
     return f"{actor} {event_kind} on task {quoted}{where}"
 

--- a/src/dashboard/static/js/app.js
+++ b/src/dashboard/static/js/app.js
@@ -1476,6 +1476,7 @@ function dashboard() {
       if (eventType === 'rerouted') return '→';        // →
       if (eventType === 'cancelled') return '✕';        // ✕
       if (eventType === 'artifact_added') return '▻';   // ▻
+      if (eventType === 'task_outcome') return '★';     // ★ — operator graded the task
       if (eventType === 'status_changed') {
         if (taskStatus === 'done') return '✓';          // ✓
         if (taskStatus === 'blocked') return '⚠';       // ⚠

--- a/src/dashboard/static/js/app.js
+++ b/src/dashboard/static/js/app.js
@@ -336,18 +336,23 @@ function dashboard() {
     // ``workplaceEnabled`` mirrors the server-side flag
     // OPENLEGION_ORCHESTRATION_TASKS_V2 so the empty state can hint how
     // to enable the surface without rendering an error.
-    workplaceTab: 'project-status',
+    // PR 5: feed becomes the default workplace landing — kanban demoted
+    // to a non-default Board sub-tab; standalone blockers tab removed
+    // (pinned at the top of the feed instead).
+    workplaceTab: 'feed',
     workplaceTabs: [
-      { id: 'project-status', label: 'Project status' },
-      { id: 'task-board', label: 'Task board' },
-      { id: 'blockers', label: 'Blockers' },
-      { id: 'team-outputs', label: 'Team outputs' },
+      { id: 'feed', label: 'Activity' },
+      { id: 'project-status', label: 'Projects' },
+      { id: 'task-board', label: 'Board' },
+      { id: 'team-outputs', label: 'Outputs' },
     ],
     workplaceEnabled: true,
     workplaceProjects: [],
     workplaceTasks: [],
     workplaceBlockers: [],
     workplaceOutputs: [],
+    workplaceFeed: [],
+    workplaceFeedCap: 200,
     workplacePending: [],
     workplaceLoading: false,
     workplaceTaskColumns: ['pending', 'accepted', 'working', 'blocked', 'done'],
@@ -1378,6 +1383,7 @@ function dashboard() {
           this.loadWorkplaceTasks(),
           this.loadWorkplaceBlockers(),
           this.loadWorkplaceOutputs(),
+          this.loadWorkplaceFeed(),
           this.loadWorkplacePending(),
         ]);
       } finally {
@@ -1446,8 +1452,47 @@ function dashboard() {
       }
     },
 
+    async loadWorkplaceFeed() {
+      try {
+        const params = this.workplaceProjectFilter ? `?project_id=${encodeURIComponent(this.workplaceProjectFilter)}` : '';
+        const resp = await fetch(`${window.__config.apiBase}/workplace/feed${params}`);
+        if (!resp.ok) return;
+        const data = await resp.json();
+        this.workplaceEnabled = data.enabled !== false;
+        this.workplaceFeed = data.feed || [];
+      } catch (e) {
+        console.error('Failed to load workplace feed:', e);
+      }
+    },
+
     workplaceTasksByStatus(status) {
       return (this.workplaceTasks || []).filter(t => t.status === status);
+    },
+
+    // Icon for an activity feed entry. Plain text glyphs keep the
+    // template emoji-free; tweak here without touching the markup.
+    workplaceFeedIcon(eventType, taskStatus) {
+      if (eventType === 'created') return '+';
+      if (eventType === 'rerouted') return '→';        // →
+      if (eventType === 'cancelled') return '✕';        // ✕
+      if (eventType === 'artifact_added') return '▻';   // ▻
+      if (eventType === 'status_changed') {
+        if (taskStatus === 'done') return '✓';          // ✓
+        if (taskStatus === 'blocked') return '⚠';       // ⚠
+        if (taskStatus === 'failed') return '✕';        // ✕
+        if (taskStatus === 'cancelled') return '✕';
+        if (taskStatus === 'working') return '▶';       // ▶
+        return '●';                                      // •
+      }
+      return '●';
+    },
+
+    // Open the task drill-in modal. PR 4 ships the actual modal — until
+    // then this stub at least surfaces the click in the toast queue so
+    // the integration is testable.
+    openTaskDrillIn(taskId) {
+      if (!taskId) return;
+      this.showToast(`Open task ${taskId}`);
     },
 
     workplaceFormatExpiry(expiresAt) {
@@ -1518,12 +1563,16 @@ function dashboard() {
         if (!this.workplaceTasks.find(t => t.id === stub.id)) {
           this.workplaceTasks.unshift(stub);
         }
+        this._pushWorkplaceFeedFromEvent('created', data, stub);
       } else if (evt.type === 'task_status_changed') {
         const t = this.workplaceTasks.find(x => x.id === data.task_id);
         if (t) {
           t.status = data.new_status;
           if (data.assignee) t.assignee = data.assignee;
         }
+        // Surface in feed too. Background reload is source of truth on
+        // reconnect; the client-built summary is best-effort.
+        this._pushWorkplaceFeedFromEvent('status_changed', data, t);
       } else if (evt.type === 'pending_action_created') {
         if (!this.workplacePending.find(p => p.nonce === data.nonce)) {
           this.workplacePending.push({
@@ -1538,6 +1587,57 @@ function dashboard() {
         }
       } else if (evt.type === 'pending_action_resolved' || evt.type === 'pending_action_expired') {
         this.workplacePending = this.workplacePending.filter(p => p.nonce !== data.nonce);
+      }
+    },
+
+    // Build a feed entry from a live WS event and prepend it. Caps the
+    // in-memory feed so long-lived sessions don't grow unbounded; the
+    // periodic full reload is the source of truth.
+    _pushWorkplaceFeedFromEvent(eventType, data, taskHint) {
+      if (!data || !data.task_id) return;
+      const t = taskHint || this.workplaceTasks.find(x => x.id === data.task_id) || {};
+      const title = data.title || t.title || '(untitled)';
+      const projectId = data.project_id || t.project_id || '';
+      const assignee = data.assignee || t.assignee || '';
+      const actor = data.actor || data.creator || data.assignee || 'unknown';
+      const status = data.new_status || t.status || '';
+      let summary;
+      if (eventType === 'created') {
+        const forWho = assignee ? ` for ${assignee}` : '';
+        const where = projectId ? ` in project ${projectId}` : '';
+        summary = `${actor} created task '${title}'${forWho}${where}`;
+      } else if (status === 'done') {
+        summary = `${actor} completed task '${title}'`;
+      } else if (status === 'blocked') {
+        const note = data.blocker_note || '';
+        summary = `${actor} marked task '${title}' as blocked${note ? ': ' + note : ''}`;
+      } else if (status === 'failed') {
+        summary = `${actor} failed task '${title}'`;
+      } else if (status === 'cancelled') {
+        summary = `${actor} cancelled task '${title}'`;
+      } else if (status === 'working') {
+        summary = `${actor} started task '${title}'`;
+      } else if (status === 'accepted') {
+        summary = `${actor} accepted task '${title}'`;
+      } else {
+        summary = `${actor} ${eventType} on task '${title}'`;
+      }
+      const entry = {
+        event_id: `live-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
+        event_type: eventType,
+        task_id: data.task_id,
+        task_title: title,
+        project_id: projectId,
+        assignee: assignee,
+        actor: actor,
+        task_status: status,
+        blocker_note: data.blocker_note || '',
+        timestamp: Date.now() / 1000,
+        summary,
+      };
+      this.workplaceFeed.unshift(entry);
+      if (this.workplaceFeed.length > this.workplaceFeedCap) {
+        this.workplaceFeed.length = this.workplaceFeedCap;
       }
     },
 

--- a/src/dashboard/static/js/app.js
+++ b/src/dashboard/static/js/app.js
@@ -1487,11 +1487,17 @@ function dashboard() {
       return '●';
     },
 
-    // Open the task drill-in modal. PR 4 ships the actual modal — until
-    // then this stub at least surfaces the click in the toast queue so
-    // the integration is testable.
+    // Open the task drill-in modal. PR 4 ships the actual modal loader
+    // (``loadTaskDrillIn``); until that ships we fall back to a toast so
+    // the integration is testable in either merge order. Detect at call
+    // time so a later PR 4 merge "just works" without a re-deploy of the
+    // bundle.
     openTaskDrillIn(taskId) {
       if (!taskId) return;
+      if (typeof this.loadTaskDrillIn === 'function') {
+        this.loadTaskDrillIn(taskId);
+        return;
+      }
       this.showToast(`Open task ${taskId}`);
     },
 
@@ -1566,13 +1572,26 @@ function dashboard() {
         this._pushWorkplaceFeedFromEvent('created', data, stub);
       } else if (evt.type === 'task_status_changed') {
         const t = this.workplaceTasks.find(x => x.id === data.task_id);
+        const prevStatus = t ? t.status : (data.from_status || data.old_status || '');
         if (t) {
           t.status = data.new_status;
           if (data.assignee) t.assignee = data.assignee;
+          if (data.blocker_note !== undefined) t.blocker_note = data.blocker_note;
         }
         // Surface in feed too. Background reload is source of truth on
         // reconnect; the client-built summary is best-effort.
         this._pushWorkplaceFeedFromEvent('status_changed', data, t);
+        // Pinned blockers list lives on a separate endpoint; refresh it
+        // whenever a task transitions in to or out of ``blocked`` (or
+        // when its blocker note may have changed) so the strip at the
+        // top of the feed doesn't go stale.
+        const newStatus = data.new_status || '';
+        if (
+          prevStatus === 'blocked'
+          || newStatus === 'blocked'
+        ) {
+          this.loadWorkplaceBlockers();
+        }
       } else if (evt.type === 'pending_action_created') {
         if (!this.workplacePending.find(p => p.nonce === data.nonce)) {
           this.workplacePending.push({

--- a/src/dashboard/templates/index.html
+++ b/src/dashboard/templates/index.html
@@ -3049,8 +3049,18 @@
               </div>
             </template>
 
-            <!-- Empty state for the feed itself -->
-            <template x-if="!workplaceFeed.length">
+            <!-- Empty state for the feed itself. When there are no
+                 projects yet, suggest a concrete next step instead of a
+                 plain "no activity" line; once a project exists the
+                 message reverts to the calm waiting state. -->
+            <template x-if="!workplaceFeed.length && !workplaceProjects.length">
+              <div class="text-sm text-gray-400 py-4">
+                No projects yet. Ask the operator to create one — say something like
+                <span class="italic text-gray-200">"create a project for &lt;goal&gt;"</span>
+                in the chat to get started.
+              </div>
+            </template>
+            <template x-if="!workplaceFeed.length && workplaceProjects.length">
               <div class="text-sm text-gray-500 py-4">No recent activity. Once agents start working, you'll see it here.</div>
             </template>
 

--- a/src/dashboard/templates/index.html
+++ b/src/dashboard/templates/index.html
@@ -3023,6 +3023,57 @@
           </div>
         </template>
 
+        <!-- Activity feed sub-tab (default) -->
+        <template x-if="workplaceEnabled && workplaceTab === 'feed'">
+          <div class="space-y-3">
+            <!-- Pinned blockers strip — visible whenever any tasks are blocked. -->
+            <template x-if="workplaceBlockers && workplaceBlockers.length">
+              <div class="bg-yellow-900/15 border border-yellow-800/30 rounded-lg p-3">
+                <div class="text-xs font-medium text-yellow-200 mb-2">
+                  <span>&#9888;</span>
+                  <span x-text="workplaceBlockers.length + ' blocked task' + (workplaceBlockers.length === 1 ? '' : 's') + ' need attention'"></span>
+                </div>
+                <div class="space-y-1.5">
+                  <template x-for="b in workplaceBlockers" :key="b.id">
+                    <div class="flex items-start justify-between gap-2 text-xs text-gray-200 bg-yellow-900/10 rounded px-2 py-1.5">
+                      <div class="min-w-0">
+                        <span class="font-medium" x-text="b.title"></span>
+                        <span class="text-gray-400" x-text="' (' + (b.assignee || '') + (b.project_id ? ', ' + b.project_id : '') + ')'"></span>
+                        <div class="text-[11px] text-gray-400 mt-0.5" x-text="b.blocker_note || '(no note)'"></div>
+                      </div>
+                      <button class="text-[11px] px-2 py-0.5 rounded bg-yellow-800/30 hover:bg-yellow-800/50 text-yellow-100 whitespace-nowrap"
+                        @click="openTaskDrillIn(b.id)">Drill in</button>
+                    </div>
+                  </template>
+                </div>
+              </div>
+            </template>
+
+            <!-- Empty state for the feed itself -->
+            <template x-if="!workplaceFeed.length">
+              <div class="text-sm text-gray-500 py-4">No recent activity. Once agents start working, you'll see it here.</div>
+            </template>
+
+            <!-- Chronological activity list, latest first. -->
+            <template x-for="ev in workplaceFeed" :key="ev.event_id">
+              <button type="button"
+                class="w-full text-left bg-gray-800/40 border border-gray-700/50 rounded-lg p-3 hover:bg-gray-800/70 transition-colors"
+                @click="openTaskDrillIn(ev.task_id)">
+                <div class="flex items-start gap-2">
+                  <span class="text-base leading-none mt-0.5" x-text="workplaceFeedIcon(ev.event_type, ev.task_status)"></span>
+                  <div class="min-w-0 flex-1">
+                    <div class="text-sm text-gray-100" x-text="ev.summary"></div>
+                    <div class="text-[11px] text-gray-500 mt-0.5">
+                      <span x-text="formatRelativeTime((ev.timestamp || 0) * 1000) || 'just now'"></span>
+                      <span x-show="ev.project_id" class="ml-2" x-text="'· ' + ev.project_id"></span>
+                    </div>
+                  </div>
+                </div>
+              </button>
+            </template>
+          </div>
+        </template>
+
         <!-- Project status sub-tab -->
         <template x-if="workplaceEnabled && workplaceTab === 'project-status'">
           <div class="space-y-3">
@@ -3040,6 +3091,25 @@
                     <span x-text="p.total + ' task' + (p.total === 1 ? '' : 's')"></span>
                     <span class="ml-2 px-1.5 py-0.5 rounded bg-gray-900/60 text-gray-300" x-text="p.status"></span>
                   </div>
+                </div>
+                <!-- North star + success criteria — the project's goal as a first-class artifact. -->
+                <div class="mb-3 pb-2 border-b border-gray-700/40">
+                  <template x-if="p.north_star">
+                    <div>
+                      <div class="text-[10px] uppercase tracking-wide text-gray-500 mb-1">North star</div>
+                      <div class="text-xs italic text-gray-200" x-text="'“' + p.north_star + '”'"></div>
+                      <template x-if="p.success_criteria && p.success_criteria.length">
+                        <ul class="mt-2 space-y-0.5">
+                          <template x-for="sc in p.success_criteria" :key="sc">
+                            <li class="text-[11px] text-gray-300 pl-3 relative before:content-['\\2022'] before:absolute before:left-0 before:text-gray-500" x-text="sc"></li>
+                          </template>
+                        </ul>
+                      </template>
+                    </div>
+                  </template>
+                  <template x-if="!p.north_star">
+                    <div class="text-[11px] text-gray-500 italic">No goal set yet. Ask the operator to set one.</div>
+                  </template>
                 </div>
                 <div class="flex flex-wrap gap-1.5 text-[11px]">
                   <template x-for="status in workplaceTaskColumns" :key="status">
@@ -3095,25 +3165,8 @@
           </div>
         </template>
 
-        <!-- Blockers sub-tab -->
-        <template x-if="workplaceEnabled && workplaceTab === 'blockers'">
-          <div class="space-y-2">
-            <template x-if="!workplaceBlockers.length">
-              <div class="text-sm text-gray-500 py-4">No blocked tasks.</div>
-            </template>
-            <template x-for="t in workplaceBlockers" :key="t.id">
-              <div class="bg-yellow-900/15 border border-yellow-800/30 rounded-lg p-3">
-                <div class="text-sm font-medium text-yellow-100" x-text="t.title"></div>
-                <div class="text-[11px] text-gray-400 mt-1">
-                  <span x-text="t.assignee || ''"></span>
-                  <span x-show="t.project_id" class="text-gray-500"
-                    x-text="' · ' + (t.project_id || '')"></span>
-                </div>
-                <div class="text-xs text-gray-300 mt-2" x-text="t.blocker_note || '(no note)'"></div>
-              </div>
-            </template>
-          </div>
-        </template>
+        <!-- (Blockers no longer have their own sub-tab — pinned at the top
+             of the activity feed instead.) -->
 
         <!-- Team outputs sub-tab -->
         <template x-if="workplaceEnabled && workplaceTab === 'team-outputs'">

--- a/src/host/server.py
+++ b/src/host/server.py
@@ -3119,6 +3119,83 @@ def create_mesh_app(
 
         return {"updated": True, "project": name}
 
+    @app.post("/mesh/projects/{name}/goal")
+    async def mesh_set_project_goal(name: str, request: Request) -> dict:
+        """Set a project's north star + success criteria (mesh-authed proxy).
+
+        Operator-only (or internal localhost callers). Validates length
+        limits then persists to ``metadata.yaml`` in place. No confirmation
+        gate — this is meta-config the user explicitly asked for.
+        """
+        _require_any_auth(request)
+        caller = _extract_verified_agent_id(request)
+        if caller != "operator" and not _is_internal_caller(request):
+            raise HTTPException(403, "Only the operator can manage projects")
+        from src.cli.config import PROJECTS_DIR, _load_projects
+
+        body = await request.json()
+        north_star_raw = body.get("north_star")
+        success_criteria_raw = body.get("success_criteria")
+
+        # Normalize and validate.
+        if north_star_raw is None:
+            north_star: str | None = None
+        else:
+            north_star = sanitize_for_prompt(str(north_star_raw)).strip()
+            if len(north_star) > 500:
+                raise HTTPException(
+                    400, "north_star must be 500 characters or fewer",
+                )
+            if not north_star:
+                north_star = None
+
+        success_criteria: list[str] | None
+        if success_criteria_raw is None:
+            success_criteria = None
+        else:
+            if not isinstance(success_criteria_raw, list):
+                raise HTTPException(
+                    400, "success_criteria must be a list of strings",
+                )
+            if len(success_criteria_raw) > 10:
+                raise HTTPException(
+                    400, "success_criteria may contain at most 10 items",
+                )
+            cleaned: list[str] = []
+            for item in success_criteria_raw:
+                sc = sanitize_for_prompt(str(item)).strip()
+                if not sc:
+                    continue
+                if len(sc) > 200:
+                    raise HTTPException(
+                        400,
+                        "each success_criteria entry must be 200 characters or fewer",
+                    )
+                cleaned.append(sc)
+            success_criteria = cleaned or None
+
+        projects = _load_projects()
+        if name not in projects:
+            raise HTTPException(404, f"Project '{name}' not found")
+
+        import yaml
+        meta_file = PROJECTS_DIR / name / "metadata.yaml"
+        if not meta_file.exists():
+            raise HTTPException(404, f"Project '{name}' has no metadata file")
+        with open(meta_file) as f:
+            meta = yaml.safe_load(f) or {}
+        meta["north_star"] = north_star
+        meta["success_criteria"] = success_criteria
+        with open(meta_file, "w") as f:
+            yaml.dump(meta, f, default_flow_style=False, sort_keys=False)
+
+        return {
+            "success": True,
+            "project_name": name,
+            "north_star": north_star,
+            "success_criteria": success_criteria,
+        }
+
     # === Orchestration Tasks v2 (Task 6) ===
 
     def _require_tasks_v2() -> Tasks:

--- a/src/host/server.py
+++ b/src/host/server.py
@@ -3142,9 +3142,9 @@ def create_mesh_app(
             north_star: str | None = None
         else:
             north_star = sanitize_for_prompt(str(north_star_raw)).strip()
-            if len(north_star) > 500:
+            if len(north_star) > 2000:
                 raise HTTPException(
-                    400, "north_star must be 500 characters or fewer",
+                    400, "north_star must be 2000 characters or fewer",
                 )
             if not north_star:
                 north_star = None

--- a/src/shared/operator_playbooks.py
+++ b/src/shared/operator_playbooks.py
@@ -138,6 +138,16 @@ default — do not disable these unless the user explicitly requests it.
 update_project_context() with detailed business context that all agents \
 share. Skip for Basic plans.
 
+   **Capture the goal as a north star.** Whenever the user has stated \
+what they're trying to achieve (revenue target, launch milestone, \
+specific outcome), call set_project_goal(project_name, north_star, \
+success_criteria) so the goal becomes a first-class artifact visible \
+on the workplace tab. Examples of good north stars: "Ship a $10k MRR \
+SaaS landing page in 2 weeks", "Publish 4 long-form posts per week \
+about gut health". Success criteria are 2–5 measurable checks, e.g. \
+"100 unique landing-page visitors per day", "Posts ranked on page 1 \
+for target keyword". No confirmation gate — just call it.
+
 4. **Customize instructions**: For each agent, call propose_edit(agent_id, \
 "instructions", value) with instructions tailored to the user's business. \
 Excellent instructions are specific:
@@ -306,6 +316,7 @@ _TOOL_PLAYBOOK_MAP: dict[str, str] = {
     "add_agents_to_project": "team_build",
     "remove_agents_from_project": "team_build",
     "update_project_context": "team_build",
+    "set_project_goal": "team_build",
     "propose_edit": "edit",
     "confirm_edit": "edit",
     "read_agent_history": "monitor",

--- a/src/shared/types.py
+++ b/src/shared/types.py
@@ -356,6 +356,11 @@ class ProjectMetadata(BaseModel):
     ``"archived"`` to stop scheduling and hide the project from default
     list views without deleting its data. Archive is reversible; delete
     requires archive first plus a separate human-confirmed step.
+
+    ``north_star`` and ``success_criteria`` capture the project's goal as
+    first-class fields. Both are nullable for backwards compatibility —
+    projects that predate this schema simply have ``None`` and the UI
+    renders an empty-state placeholder.
     """
 
     name: str
@@ -364,6 +369,8 @@ class ProjectMetadata(BaseModel):
     created_at: str | None = None
     status: str = "active"
     settings: dict[str, Any] = {}
+    north_star: str | None = None
+    success_criteria: list[str] | None = None
 
 
 # === Coordination Requests ===

--- a/tests/test_operator_config.py
+++ b/tests/test_operator_config.py
@@ -244,8 +244,10 @@ class TestOperatorConstants:
 
     def test_allowed_tools_populated(self):
         from src.cli.config import _OPERATOR_ALLOWED_TOOLS, _OPERATOR_HEARTBEAT_TOOLS
-        # Task 7 added the operator product surface (4 read + 7 action tools).
-        assert len(_OPERATOR_ALLOWED_TOOLS) == 34
+        # Task 7 added the operator product surface (4 read + 7 action tools);
+        # PR 5 adds set_project_goal so the operator can save the user's
+        # stated goal as a first-class artifact.
+        assert len(_OPERATOR_ALLOWED_TOOLS) == 35
         assert len(_OPERATOR_HEARTBEAT_TOOLS) == 5
         # Heartbeat tools should be a subset of allowed tools
         assert set(_OPERATOR_HEARTBEAT_TOOLS).issubset(set(_OPERATOR_ALLOWED_TOOLS))
@@ -255,6 +257,8 @@ class TestOperatorConstants:
             "summarize_project_progress",
             "reroute_task", "cancel_task", "retry_failed_task",
             "archive_project", "archive_agent", "delete_project", "delete_agent",
+            # PR 5 — north-star setter is no-confirmation meta-config.
+            "set_project_goal",
         ):
             assert tool in _OPERATOR_ALLOWED_TOOLS
 

--- a/tests/test_operator_playbooks.py
+++ b/tests/test_operator_playbooks.py
@@ -136,7 +136,8 @@ class TestPlaybookConstants:
         expected_tools = {
             "create_agent", "apply_template", "create_project",
             "add_agents_to_project", "remove_agents_from_project",
-            "update_project_context", "propose_edit", "confirm_edit",
+            "update_project_context", "set_project_goal",
+            "propose_edit", "confirm_edit",
             "read_agent_history", "save_observations",
             "request_credential", "vault_list", "request_browser_login",
         }
@@ -154,6 +155,9 @@ class TestPlaybookConstants:
         assert "apply_template" in _PLAYBOOK_TEAM_BUILD
         assert "add_agents_to_project" in _PLAYBOOK_TEAM_BUILD
         assert "update_project_context" in _PLAYBOOK_TEAM_BUILD
+        # PR 5: the operator should proactively save the goal as a north star.
+        assert "set_project_goal" in _PLAYBOOK_TEAM_BUILD
+        assert "north star" in _PLAYBOOK_TEAM_BUILD.lower()
         assert "vault_list" in _PLAYBOOK_TEAM_BUILD
         assert "request_credential" in _PLAYBOOK_TEAM_BUILD
         assert "request_browser_login" in _PLAYBOOK_TEAM_BUILD

--- a/tests/test_project_goal.py
+++ b/tests/test_project_goal.py
@@ -121,10 +121,25 @@ async def test_set_project_goal_requires_operator(monkeypatch):
 async def test_set_project_goal_validates_north_star_length():
     from src.agent.builtins.operator_tools import set_project_goal
 
-    too_long = "x" * 501
+    too_long = "x" * 2001
     result = await set_project_goal("growth", too_long, mesh_client=MagicMock())
     assert "error" in result
-    assert "500" in result["error"]
+    assert "2000" in result["error"]
+
+
+@pytest.mark.asyncio
+async def test_set_project_goal_accepts_long_vision_statement():
+    """A real vision statement at the 2000-char ceiling must round-trip."""
+    from src.agent.builtins.operator_tools import set_project_goal
+
+    mc = MagicMock()
+    mc.set_project_goal = AsyncMock(return_value={"success": True})
+    long_vision = "ship it. " * 200  # ~1800 chars
+    assert 500 < len(long_vision) <= 2000
+    result = await set_project_goal(
+        "growth", long_vision, mesh_client=mc,
+    )
+    assert "error" not in result
 
 
 @pytest.mark.asyncio
@@ -300,7 +315,7 @@ async def test_endpoint_set_goal_north_star_too_long_400(goal_app):
     async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
         r = await c.post(
             "/mesh/projects/growth/goal",
-            json={"north_star": "x" * 501},
+            json={"north_star": "x" * 2001},
             headers={"X-Agent-ID": "operator"},
         )
     assert r.status_code == 400

--- a/tests/test_project_goal.py
+++ b/tests/test_project_goal.py
@@ -1,0 +1,360 @@
+"""Tests for the PR 5 north-star path: ``set_project_goal`` operator
+tool, ``POST /mesh/projects/{name}/goal`` endpoint, and the
+``ProjectMetadata`` schema bump that lets a project carry its goal as a
+first-class artifact.
+
+These exercise:
+- The tool's happy path + validation gates (length limits, types).
+- The mesh endpoint's persistence into ``metadata.yaml`` (round-trip
+  through ``_load_projects`` so the dashboard sees the new fields).
+- Backwards compat — projects predating the new fields load with
+  ``north_star=None`` / ``success_criteria=None``.
+"""
+
+from __future__ import annotations
+
+import importlib
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+import yaml
+from httpx import ASGITransport, AsyncClient
+
+from src.host.mesh import Blackboard, MessageRouter, PubSub
+from src.host.permissions import PermissionMatrix
+from src.shared.types import AgentPermissions, ProjectMetadata
+
+
+@pytest.fixture(autouse=True)
+def _set_operator_env(monkeypatch):
+    """Operator tools require ALLOWED_TOOLS to be set."""
+    monkeypatch.setenv("ALLOWED_TOOLS", "set_project_goal")
+
+
+# ── Schema: ProjectMetadata accepts north_star + success_criteria ─────
+
+
+class TestProjectMetadataSchema:
+    def test_defaults_are_none(self):
+        pm = ProjectMetadata(name="x")
+        assert pm.north_star is None
+        assert pm.success_criteria is None
+
+    def test_round_trip_with_goal(self):
+        pm = ProjectMetadata(
+            name="x",
+            north_star="Ship $10k MRR landing page in 2 weeks",
+            success_criteria=["100 daily uniques", "5 demo bookings/wk"],
+        )
+        dumped = pm.model_dump()
+        assert dumped["north_star"] == "Ship $10k MRR landing page in 2 weeks"
+        assert dumped["success_criteria"] == [
+            "100 daily uniques", "5 demo bookings/wk",
+        ]
+        # Round-trip back through the model so the YAML on-disk shape works.
+        pm2 = ProjectMetadata(**dumped)
+        assert pm2.north_star == pm.north_star
+        assert pm2.success_criteria == pm.success_criteria
+
+    def test_legacy_metadata_without_goal_loads(self):
+        """A project written before this PR has no north_star / success_criteria
+        and must still load cleanly (defaulting to ``None``)."""
+        legacy = {
+            "name": "legacy",
+            "description": "old project",
+            "members": ["a"],
+            "created_at": "2025-12-01T00:00:00+00:00",
+            "status": "active",
+            "settings": {},
+        }
+        pm = ProjectMetadata(**legacy)
+        assert pm.north_star is None
+        assert pm.success_criteria is None
+
+
+# ── set_project_goal tool unit tests (mocked mesh client) ─────────────
+
+
+@pytest.mark.asyncio
+async def test_set_project_goal_happy_path():
+    from src.agent.builtins.operator_tools import set_project_goal
+
+    mc = MagicMock()
+    mc.set_project_goal = AsyncMock(return_value={
+        "success": True,
+        "project_name": "growth",
+        "north_star": "Ship $10k MRR",
+        "success_criteria": ["100 visits/day"],
+    })
+    result = await set_project_goal(
+        "growth", "Ship $10k MRR",
+        success_criteria=["100 visits/day"],
+        mesh_client=mc,
+    )
+    assert result["success"] is True
+    assert result["project_name"] == "growth"
+    mc.set_project_goal.assert_awaited_once_with(
+        "growth", "Ship $10k MRR", ["100 visits/day"],
+    )
+
+
+@pytest.mark.asyncio
+async def test_set_project_goal_no_mesh_client():
+    from src.agent.builtins.operator_tools import set_project_goal
+
+    result = await set_project_goal("growth", "ship it")
+    assert "error" in result
+    assert "mesh_client" in result["error"].lower()
+
+
+@pytest.mark.asyncio
+async def test_set_project_goal_requires_operator(monkeypatch):
+    """Defence-in-depth: tool refuses to run when ALLOWED_TOOLS is unset."""
+    monkeypatch.delenv("ALLOWED_TOOLS", raising=False)
+    from src.agent.builtins.operator_tools import set_project_goal
+    result = await set_project_goal("growth", "ship it", mesh_client=MagicMock())
+    assert "operator" in result["error"].lower()
+
+
+@pytest.mark.asyncio
+async def test_set_project_goal_validates_north_star_length():
+    from src.agent.builtins.operator_tools import set_project_goal
+
+    too_long = "x" * 501
+    result = await set_project_goal("growth", too_long, mesh_client=MagicMock())
+    assert "error" in result
+    assert "500" in result["error"]
+
+
+@pytest.mark.asyncio
+async def test_set_project_goal_validates_success_criteria_count():
+    from src.agent.builtins.operator_tools import set_project_goal
+
+    result = await set_project_goal(
+        "growth", "ship it",
+        success_criteria=[f"sc-{i}" for i in range(11)],
+        mesh_client=MagicMock(),
+    )
+    assert "error" in result
+    assert "10" in result["error"]
+
+
+@pytest.mark.asyncio
+async def test_set_project_goal_validates_success_criteria_length():
+    from src.agent.builtins.operator_tools import set_project_goal
+
+    result = await set_project_goal(
+        "growth", "ship it",
+        success_criteria=["x" * 201],
+        mesh_client=MagicMock(),
+    )
+    assert "error" in result
+    assert "200" in result["error"]
+
+
+@pytest.mark.asyncio
+async def test_set_project_goal_strips_blank_criteria():
+    """Empty / whitespace-only entries should silently drop, not fail."""
+    from src.agent.builtins.operator_tools import set_project_goal
+
+    mc = MagicMock()
+    mc.set_project_goal = AsyncMock(return_value={"success": True})
+    await set_project_goal(
+        "growth", "ship it",
+        success_criteria=["one", "  ", "", "two"],
+        mesh_client=mc,
+    )
+    args = mc.set_project_goal.await_args.args
+    assert args == ("growth", "ship it", ["one", "two"])
+
+
+@pytest.mark.asyncio
+async def test_set_project_goal_mesh_error_surfaces():
+    from src.agent.builtins.operator_tools import set_project_goal
+
+    mc = MagicMock()
+    mc.set_project_goal = AsyncMock(side_effect=RuntimeError("boom"))
+    result = await set_project_goal(
+        "growth", "ship it", mesh_client=mc,
+    )
+    assert "error" in result
+    assert "boom" in result["error"]
+
+
+# ── Endpoint integration: POST /mesh/projects/{name}/goal ────────────
+
+
+def _reload_server(monkeypatch):
+    """Fresh import of the server module with a clean env."""
+    import src.host.server as server_module
+    importlib.reload(server_module)
+    return server_module
+
+
+def _projects_layout(tmp_path) -> Path:
+    """One project on disk so the goal endpoint has something to update."""
+    pdir = tmp_path / "projects"
+    growth = pdir / "growth"
+    growth.mkdir(parents=True)
+    (growth / "metadata.yaml").write_text(yaml.dump({
+        "name": "growth",
+        "description": "growth project",
+        "members": ["writer"],
+        "created_at": "2026-05-02T00:00:00+00:00",
+        "status": "active",
+    }))
+    return pdir
+
+
+def _build_app(tmp_path, server_module, perms_map):
+    blackboard = Blackboard(str(tmp_path / "bb.db"))
+    pubsub = PubSub()
+    permissions = PermissionMatrix()
+    for aid, perms in perms_map.items():
+        permissions.permissions[aid] = AgentPermissions(agent_id=aid, **perms)
+    router = MessageRouter(permissions, {"operator": "http://op:8400"})
+    app = server_module.create_mesh_app(
+        blackboard=blackboard,
+        pubsub=pubsub,
+        router=router,
+        permissions=permissions,
+    )
+    return app, blackboard
+
+
+@pytest.fixture
+def goal_app(tmp_path, monkeypatch):
+    pdir = _projects_layout(tmp_path)
+    monkeypatch.chdir(tmp_path)
+    import src.cli.config as cli_cfg
+    monkeypatch.setattr(cli_cfg, "PROJECTS_DIR", pdir)
+    server_module = _reload_server(monkeypatch)
+    perms_map = {
+        "operator": {"can_route_tasks": True, "can_manage_projects": True},
+        "writer": {"can_route_tasks": False, "can_message": []},
+    }
+    app, bb = _build_app(tmp_path, server_module, perms_map)
+    yield app, pdir
+    bb.close()
+    importlib.reload(server_module)
+
+
+@pytest.mark.asyncio
+async def test_endpoint_set_goal_persists(goal_app):
+    app, pdir = goal_app
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
+        r = await c.post(
+            "/mesh/projects/growth/goal",
+            json={
+                "north_star": "Ship $10k MRR landing page in 2 weeks",
+                "success_criteria": ["100 visits/day", "5 demo bookings/wk"],
+            },
+            headers={"X-Agent-ID": "operator"},
+        )
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["success"] is True
+    assert body["project_name"] == "growth"
+    assert body["north_star"] == "Ship $10k MRR landing page in 2 weeks"
+    assert body["success_criteria"] == ["100 visits/day", "5 demo bookings/wk"]
+
+    # Round-trip via _load_projects so the dashboard would see the same.
+    from src.cli.config import _load_projects
+    projects = _load_projects()
+    assert projects["growth"]["north_star"] == (
+        "Ship $10k MRR landing page in 2 weeks"
+    )
+    assert projects["growth"]["success_criteria"] == [
+        "100 visits/day", "5 demo bookings/wk",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_endpoint_set_goal_unknown_project_returns_404(goal_app):
+    app, _ = goal_app
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
+        r = await c.post(
+            "/mesh/projects/no-such/goal",
+            json={"north_star": "x"},
+            headers={"X-Agent-ID": "operator"},
+        )
+    assert r.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_endpoint_set_goal_non_operator_forbidden(goal_app):
+    app, _ = goal_app
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
+        r = await c.post(
+            "/mesh/projects/growth/goal",
+            json={"north_star": "x"},
+            headers={"X-Agent-ID": "writer"},
+        )
+    assert r.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_endpoint_set_goal_north_star_too_long_400(goal_app):
+    app, _ = goal_app
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
+        r = await c.post(
+            "/mesh/projects/growth/goal",
+            json={"north_star": "x" * 501},
+            headers={"X-Agent-ID": "operator"},
+        )
+    assert r.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_endpoint_set_goal_too_many_criteria_400(goal_app):
+    app, _ = goal_app
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
+        r = await c.post(
+            "/mesh/projects/growth/goal",
+            json={
+                "north_star": "x",
+                "success_criteria": [f"sc-{i}" for i in range(11)],
+            },
+            headers={"X-Agent-ID": "operator"},
+        )
+    assert r.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_endpoint_set_goal_success_criterion_too_long_400(goal_app):
+    app, _ = goal_app
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
+        r = await c.post(
+            "/mesh/projects/growth/goal",
+            json={
+                "north_star": "x",
+                "success_criteria": ["x" * 201],
+            },
+            headers={"X-Agent-ID": "operator"},
+        )
+    assert r.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_endpoint_set_goal_clears_when_empty(goal_app):
+    """Sending blank values clears the goal (north_star=None, success_criteria=None)."""
+    app, _ = goal_app
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
+        # First set something.
+        r = await c.post(
+            "/mesh/projects/growth/goal",
+            json={"north_star": "first", "success_criteria": ["one"]},
+            headers={"X-Agent-ID": "operator"},
+        )
+        assert r.status_code == 200
+        # Now clear it.
+        r = await c.post(
+            "/mesh/projects/growth/goal",
+            json={"north_star": "", "success_criteria": []},
+            headers={"X-Agent-ID": "operator"},
+        )
+    assert r.status_code == 200
+    body = r.json()
+    assert body["north_star"] is None
+    assert body["success_criteria"] is None

--- a/tests/test_workplace_feed.py
+++ b/tests/test_workplace_feed.py
@@ -207,3 +207,45 @@ class TestWorkplaceFeed:
         resp = client.get("/dashboard/api/workplace/feed?limit=2")
         assert resp.status_code == 200
         assert len(resp.json()["feed"]) == 2
+
+
+class TestFeedEventSummarizer:
+    """Direct unit coverage for ``_summarize_task_event``.
+
+    Workplace task drill-in (PR 4) emits ``task_outcome`` events the feed
+    needs to render in plain English. Exercise the summarizer directly so
+    PR 5 doesn't depend on PR 4's ``Tasks.set_outcome`` API to verify the
+    branch.
+    """
+
+    def test_task_outcome_first_rating(self):
+        from src.dashboard.server import _summarize_task_event
+
+        out = _summarize_task_event(
+            event_kind="task_outcome",
+            actor="operator",
+            title="Draft hero",
+            project_id="growth",
+            assignee="writer-1",
+            blocker_note="",
+            payload={"outcome": "accepted", "previous_outcome": None},
+        )
+        assert "operator" in out
+        assert "rated" in out
+        assert "Draft hero" in out
+        assert "accepted" in out
+
+    def test_task_outcome_re_rating_uses_re_rated_verb(self):
+        from src.dashboard.server import _summarize_task_event
+
+        out = _summarize_task_event(
+            event_kind="task_outcome",
+            actor="operator",
+            title="Edit copy",
+            project_id="",
+            assignee="reviewer",
+            blocker_note="",
+            payload={"outcome": "accepted", "previous_outcome": "rejected"},
+        )
+        assert "re-rated" in out
+        assert "accepted" in out

--- a/tests/test_workplace_feed.py
+++ b/tests/test_workplace_feed.py
@@ -16,9 +16,7 @@ import os
 import shutil
 import tempfile
 
-import pytest
 from fastapi import FastAPI
-from fastapi.testclient import TestClient
 
 # Reuse the same component-builder + CSRF client used by the rest of the
 # dashboard suite so this file stays in lockstep with that fixture.

--- a/tests/test_workplace_feed.py
+++ b/tests/test_workplace_feed.py
@@ -1,0 +1,211 @@
+"""Tests for the workplace activity-feed endpoint added in PR 5.
+
+The feed is the new default landing for the workplace tab; it joins
+``task_events`` back to ``tasks`` and renders a humanized summary per
+event so the operator can see what the fleet is doing without inspecting
+columns or drilling into individual records.
+
+Covers: empty state when v2 off, happy path with shape assertions,
+project filter, limit clamping, descending order, and the summary text
+for each event_kind we support.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import tempfile
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+# Reuse the same component-builder + CSRF client used by the rest of the
+# dashboard suite so this file stays in lockstep with that fixture.
+from tests.test_dashboard import _CSRFTestClient, _make_components, _teardown
+
+
+def _make_client_with_stores(components):
+    from src.dashboard.server import create_dashboard_router
+
+    router = create_dashboard_router(**components, mesh_port=8420)
+    app = FastAPI()
+    app.include_router(router)
+    return _CSRFTestClient(app)
+
+
+class TestWorkplaceFeed:
+    def setup_method(self):
+        self._tmpdir = tempfile.mkdtemp()
+        self.components = _make_components(self._tmpdir)
+        from src.host.orchestration import Tasks
+        self.tasks_store = Tasks(
+            db_path=os.path.join(self._tmpdir, "tasks.db"),
+        )
+        self.components["tasks_store"] = self.tasks_store
+
+    def teardown_method(self):
+        try:
+            self.tasks_store.close()
+        except Exception:
+            pass
+        _teardown(self.components)
+        shutil.rmtree(self._tmpdir, ignore_errors=True)
+        os.environ.pop("OPENLEGION_ORCHESTRATION_TASKS_V2", None)
+
+    def _client(self, *, v2: bool):
+        if v2:
+            os.environ["OPENLEGION_ORCHESTRATION_TASKS_V2"] = "1"
+        else:
+            os.environ["OPENLEGION_ORCHESTRATION_TASKS_V2"] = "0"
+        return _make_client_with_stores(self.components)
+
+    # ── Disabled / empty state ────────────────────────────────────
+
+    def test_feed_empty_state_when_v2_off(self):
+        client = self._client(v2=False)
+        resp = client.get("/dashboard/api/workplace/feed")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["enabled"] is False
+        assert data["feed"] == []
+
+    def test_feed_empty_when_no_events(self):
+        client = self._client(v2=True)
+        resp = client.get("/dashboard/api/workplace/feed")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["enabled"] is True
+        assert data["feed"] == []
+
+    # ── Shape + summary ──────────────────────────────────────────
+
+    def test_feed_returns_created_event(self):
+        client = self._client(v2=True)
+        rec = self.tasks_store.create(
+            creator="operator", assignee="writer-1",
+            title="Draft Q4 plan", project_id="growth",
+        )
+        resp = client.get("/dashboard/api/workplace/feed")
+        assert resp.status_code == 200
+        data = resp.json()
+        feed = data["feed"]
+        assert len(feed) == 1
+        ev = feed[0]
+        assert ev["event_type"] == "created"
+        assert ev["task_id"] == rec["id"]
+        assert ev["task_title"] == "Draft Q4 plan"
+        assert ev["project_id"] == "growth"
+        assert ev["actor"] == "operator"
+        assert ev["assignee"] == "writer-1"
+        assert "writer-1" in ev["summary"]
+        assert "Draft Q4 plan" in ev["summary"]
+        assert "growth" in ev["summary"]
+
+    def test_feed_summarizes_status_done(self):
+        client = self._client(v2=True)
+        rec = self.tasks_store.create(
+            creator="op", assignee="writer", title="Task A",
+        )
+        self.tasks_store.update_status(rec["id"], "working", actor="writer")
+        self.tasks_store.update_status(rec["id"], "done", actor="writer")
+
+        resp = client.get("/dashboard/api/workplace/feed")
+        feed = resp.json()["feed"]
+        # Most recent first — done event should be at the top.
+        kinds = [(e["event_type"], e.get("task_status")) for e in feed]
+        assert kinds[0][0] == "status_changed"
+        assert "completed" in feed[0]["summary"]
+
+    def test_feed_summarizes_blocked_with_note(self):
+        client = self._client(v2=True)
+        rec = self.tasks_store.create(
+            creator="op", assignee="reviewer-1", title="Edit copy",
+        )
+        self.tasks_store.update_status(rec["id"], "working", actor="reviewer-1")
+        self.tasks_store.update_status(
+            rec["id"], "blocked", actor="reviewer-1",
+            blocker_note="needs SEO data",
+        )
+
+        resp = client.get("/dashboard/api/workplace/feed")
+        feed = resp.json()["feed"]
+        assert "blocked" in feed[0]["summary"]
+        assert "needs SEO data" in feed[0]["summary"]
+
+    # ── Filtering + ordering ─────────────────────────────────────
+
+    def test_feed_filters_by_project_id(self):
+        client = self._client(v2=True)
+        self.tasks_store.create(
+            creator="op", assignee="a", title="growth-task",
+            project_id="growth",
+        )
+        self.tasks_store.create(
+            creator="op", assignee="a", title="ops-task",
+            project_id="ops",
+        )
+
+        resp = client.get(
+            "/dashboard/api/workplace/feed?project_id=growth",
+        )
+        feed = resp.json()["feed"]
+        assert all(e["project_id"] == "growth" for e in feed)
+        titles = {e["task_title"] for e in feed}
+        assert "growth-task" in titles
+        assert "ops-task" not in titles
+
+    def test_feed_ordered_descending_by_timestamp(self):
+        client = self._client(v2=True)
+        rec_a = self.tasks_store.create(
+            creator="op", assignee="a", title="first",
+        )
+        rec_b = self.tasks_store.create(
+            creator="op", assignee="a", title="second",
+        )
+        self.tasks_store.update_status(rec_a["id"], "working", actor="a")
+
+        resp = client.get("/dashboard/api/workplace/feed")
+        feed = resp.json()["feed"]
+        # The status_changed on rec_a happened last, so it's first.
+        assert feed[0]["task_id"] == rec_a["id"]
+        assert feed[0]["event_type"] == "status_changed"
+        # Timestamps must be monotonically non-increasing.
+        for i in range(len(feed) - 1):
+            assert feed[i]["timestamp"] >= feed[i + 1]["timestamp"]
+        # The two created events for rec_a / rec_b are still in there.
+        ids = {e["task_id"] for e in feed if e["event_type"] == "created"}
+        assert ids == {rec_a["id"], rec_b["id"]}
+
+    # ── Limit clamping ────────────────────────────────────────────
+
+    def test_feed_limit_clamped_to_500(self):
+        """A bogus limit doesn't blow up — server caps to 500."""
+        client = self._client(v2=True)
+        # Just one task so we're really only checking the response shape;
+        # the cap matters at the SQL layer and shouldn't error.
+        self.tasks_store.create(creator="op", assignee="a", title="t")
+        resp = client.get("/dashboard/api/workplace/feed?limit=10000")
+        assert resp.status_code == 200
+        assert len(resp.json()["feed"]) <= 500
+
+    def test_feed_limit_minimum_one(self):
+        client = self._client(v2=True)
+        self.tasks_store.create(creator="op", assignee="a", title="t1")
+        self.tasks_store.create(creator="op", assignee="a", title="t2")
+        # Negative values clamp to the minimum (1) — bogus client input
+        # shouldn't surface as a 500. ``limit=0`` falls back to the
+        # default per ``or`` semantics, matching outputs/tasks routes.
+        resp = client.get("/dashboard/api/workplace/feed?limit=-1")
+        assert resp.status_code == 200
+        assert len(resp.json()["feed"]) == 1
+
+    def test_feed_respects_explicit_limit(self):
+        client = self._client(v2=True)
+        for i in range(5):
+            self.tasks_store.create(
+                creator="op", assignee="a", title=f"t{i}",
+            )
+        resp = client.get("/dashboard/api/workplace/feed?limit=2")
+        assert resp.status_code == 200
+        assert len(resp.json()["feed"]) == 2


### PR DESCRIPTION
## Summary
- Projects get north_star + success_criteria fields, rendered prominently
- New set_project_goal operator tool — no confirmation
- Activity feed becomes default workplace view (was kanban)
- Click feed entry → opens task drill-in modal (PR 4)
- Blockers pinned at top of feed; standalone tab removed
- Kanban demoted to a non-default sub-tab

## Why
The vision is 'set the goal, agent teams move toward it.' Without north_star as a first-class field there was nowhere structured to put the goal. Without an activity feed the workplace was a passive status board with mostly-empty kanban columns. This PR makes the goal unmissable and the team's activity legible at a glance.

## Scope
PR 5 of 5 — completes the operator + workplace redesign sequence. PRs 0/1/2/3/4 (#838-#842) are open and should land before this. With these five merged, the operator is a delegated executive (acts decisively for soft edits, asks for confirmation only on irreversible/expensive changes via a unified inline card pattern), and the workplace tab is a real project HQ with goal context, live activity, and outcome capture for the improvement loop.

## Test plan
- [x] North star round-trip (set → load → render)
- [x] Feed endpoint returns expected shape; respects project filter and limit
- [x] set_project_goal tool wired into operator allowlist
- [ ] Manual: ask operator to set a goal — verify it appears at top of project card
- [ ] Manual: complete a task — verify it appears in feed
- [ ] Manual: feed click → drill-in modal opens
- [ ] Manual: blockers section appears when there are blocked tasks