### PR TITLE
feat(dashboard): Board redesign — sticky Needs-you panel, kanban icon, recently delivered

### DIFF
--- a/src/dashboard/static/js/app.js
+++ b/src/dashboard/static/js/app.js
@@ -49,7 +49,7 @@ function dashboard() {
     tabs: [
       { id: 'chat', label: 'Chat' },
       { id: 'fleet', label: 'Agents' },
-      { id: 'workplace', label: 'Workplace' },
+      { id: 'workplace', label: 'Board' },
       { id: 'system', label: 'System' },
     ],
     connected: false,
@@ -361,6 +361,12 @@ function dashboard() {
     workplaceLoading: false,
     workplaceTaskColumns: ['pending', 'accepted', 'working', 'blocked', 'done'],
     workplaceProjectFilter: '',
+    // Per-column flag: when true, the kanban column ignores the 14-day
+    // archive cutoff and shows old pending/blocked rows. Keyed by status
+    // so toggling one column doesn't expand the others.
+    boardShowArchived: {},
+    // In-flight audit-log undo so we can disable the button per-row.
+    auditReverting: {},
 
     // Workplace task drill-in modal (PR 4) — populated lazily on
     // card click. ``drillInData`` carries ``{task, events, artifacts}``
@@ -1691,6 +1697,203 @@ function dashboard() {
       if (remain < 60) return `${remain}s`;
       if (remain < 3600) return `${Math.floor(remain / 60)}m`;
       return `${Math.floor(remain / 3600)}h`;
+    },
+
+    // Aggregate every "needs human" surface into one ordered list so the
+    // sticky Board panel can render them with a single x-for. Sources:
+    //   - workplacePending (durable propose/confirm rows)
+    //   - operator-chat credential / browser-login / captcha cards
+    //     (matched on role, not on a separate fetch — these live in
+    //     chatHistories['operator'] alongside the conversation)
+    //   - workplaceBlockers (tasks the agent flagged stuck)
+    // The cards stay rendered in chat too; this just surfaces them in
+    // one place so the user doesn't have to hunt.
+    get needsYouItems() {
+      const items = [];
+      const opChat = (this.chatHistories && this.chatHistories['operator']) || [];
+
+      for (const p of (this.workplacePending || [])) {
+        items.push({
+          id: 'pending-' + p.nonce,
+          kind: 'pending',
+          icon: '!',
+          title: p.summary || `${p.action_kind || 'Action'} on ${p.target_kind || ''} ${p.target_id || ''}`.trim(),
+          subtitle: this._needsYouSubtitle({
+            actor: p.actor,
+            expiresAt: p.expires_at,
+          }),
+          actions: [
+            { label: 'Confirm', style: 'emerald', handler: () => this.confirmPendingAction(p.nonce) },
+            { label: 'Cancel', style: 'gray', handler: () => this.cancelPendingAction(p.nonce) },
+          ],
+        });
+      }
+
+      for (const m of opChat) {
+        if (m.cancelled || m.completed || m.saved) continue;
+        if (m.role === 'credential_request') {
+          items.push({
+            id: 'cred-' + (m.request_id || m.name) + '-' + (m.ts || 0),
+            kind: 'credential',
+            icon: 'K',
+            title: `Credential needed: ${m.service || m.name || 'unknown'}`,
+            subtitle: this._needsYouSubtitle({
+              actor: m._from_agent || 'agent',
+              text: m.content || '',
+            }),
+            actions: [
+              { label: 'Open chat', style: 'indigo', handler: () => { this.activeTab = 'chat'; this.openChat && this.openChat('operator'); } },
+            ],
+          });
+        } else if (m.role === 'browser_login_request') {
+          items.push({
+            id: 'login-' + (m.request_id || m.service) + '-' + (m.ts || 0),
+            kind: 'browser_login',
+            icon: 'W',
+            title: `Browser login: ${m.service || 'unknown service'}`,
+            subtitle: this._needsYouSubtitle({
+              actor: m._from_agent || 'agent',
+              text: m.content || '',
+            }),
+            actions: [
+              { label: 'Open in chat', style: 'indigo', handler: () => { this.activeTab = 'chat'; this.openChat && this.openChat('operator'); } },
+            ],
+          });
+        } else if (m.role === 'browser_captcha_help_request') {
+          items.push({
+            id: 'captcha-' + (m.request_id || m.service) + '-' + (m.ts || 0),
+            kind: 'captcha',
+            icon: 'C',
+            title: `CAPTCHA help: ${m.service || 'unknown service'}`,
+            subtitle: this._needsYouSubtitle({
+              actor: m._from_agent || 'agent',
+              text: m.content || '',
+            }),
+            actions: [
+              { label: 'Open in chat', style: 'indigo', handler: () => { this.activeTab = 'chat'; this.openChat && this.openChat('operator'); } },
+            ],
+          });
+        }
+      }
+
+      for (const b of (this.workplaceBlockers || [])) {
+        items.push({
+          id: 'blocker-' + b.id,
+          kind: 'blocker',
+          icon: 'B',
+          title: b.title || '(untitled blocked task)',
+          subtitle: this._needsYouSubtitle({
+            actor: b.assignee || '',
+            project: b.project_id || '',
+            text: b.blocker_note || '',
+          }),
+          actions: [
+            { label: 'Drill in', style: 'amber', handler: () => this.openTaskDrillIn(b.id) },
+          ],
+        });
+      }
+
+      return items;
+    },
+
+    // Build the small grey sub-line shared by every Needs-you card.
+    // Joins the populated bits with " · " so blank fields don't leave
+    // dangling separators.
+    _needsYouSubtitle({ actor, expiresAt, project, text }) {
+      const parts = [];
+      if (expiresAt) parts.push('expires in ' + this.workplaceFormatExpiry(expiresAt));
+      if (actor) parts.push('from ' + actor);
+      if (project) parts.push('project ' + project);
+      if (text) {
+        const trimmed = text.length > 80 ? text.slice(0, 77) + '...' : text;
+        parts.push(trimmed);
+      }
+      return parts.join(' · ');
+    },
+
+    // Tailwind colour map for Needs-you action buttons. Keeps the
+    // template free of conditionals while letting each item declare
+    // its own intent (emerald confirm, gray cancel, etc.).
+    needsYouButtonClass(style) {
+      switch (style) {
+        case 'emerald':
+          return 'bg-emerald-700 hover:bg-emerald-600 text-emerald-50';
+        case 'amber':
+          return 'bg-amber-700 hover:bg-amber-600 text-amber-50';
+        case 'indigo':
+          return 'bg-indigo-700 hover:bg-indigo-600 text-indigo-50';
+        case 'gray':
+        default:
+          return 'bg-gray-700 hover:bg-gray-600 text-gray-100';
+      }
+    },
+
+    // Recently-delivered list for the Activity feed header. Pulled from
+    // workplaceOutputs so we stay aligned with the Outputs sub-tab; cap
+    // at 5 with a "View all" link so the section stays scannable.
+    recentlyDelivered(limit = 5, days = 7) {
+      const cutoff = (Date.now() / 1000) - days * 86400;
+      const rows = (this.workplaceOutputs || [])
+        .filter(t => (t.completed_at || 0) >= cutoff)
+        .slice()
+        .sort((a, b) => (b.completed_at || 0) - (a.completed_at || 0));
+      return rows.slice(0, limit);
+    },
+
+    // Kanban filter — drop pending/blocked rows older than 14 days
+    // unless the operator opted in for this column. Other statuses
+    // (working/done/accepted) aren't archived: completed work belongs
+    // in the Outputs tab and active work shouldn't disappear.
+    workplaceTasksByStatusFiltered(status) {
+      const all = this.workplaceTasksByStatus(status);
+      if (status !== 'pending' && status !== 'blocked') return all;
+      if (this.boardShowArchived[status]) return all;
+      const cutoff = (Date.now() / 1000) - 14 * 86400;
+      return all.filter(t => {
+        const created = typeof t.created_at === 'number'
+          ? t.created_at
+          : (t.created_at ? new Date(t.created_at).getTime() / 1000 : 0);
+        return !created || created >= cutoff;
+      });
+    },
+
+    workplaceArchivedCount(status) {
+      const total = this.workplaceTasksByStatus(status).length;
+      const visible = this.workplaceTasksByStatusFiltered(status).length;
+      return Math.max(0, total - visible);
+    },
+
+    // Audit-log Revert: re-uses the soft-edit undo endpoint via the
+    // change_id stored on each audit row (which IS the undo_token).
+    // Hard-edit rows have a different change_id shape and the mesh
+    // returns 404 — we surface that as a clean error instead of a
+    // toast spam loop.
+    async revertAuditEntry(entry) {
+      if (!entry || !entry.change_id) {
+        this.showToast('This entry can no longer be reverted.');
+        return;
+      }
+      this.auditReverting = { ...this.auditReverting, [entry.id]: true };
+      try {
+        const resp = await fetch(`${window.__config.apiBase}/changes/undo/${encodeURIComponent(entry.change_id)}`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: '{}',
+        });
+        if (!resp.ok) {
+          const data = await resp.json().catch(() => ({}));
+          this.showToast(`Revert failed: ${data.detail || resp.status}`);
+          return;
+        }
+        this.showToast('Reverted.');
+        await this.fetchAuditLog();
+      } catch (e) {
+        this.showToast(`Revert failed: ${e.message || e}`);
+      } finally {
+        const next = { ...this.auditReverting };
+        delete next[entry.id];
+        this.auditReverting = next;
+      }
     },
 
     async confirmPendingAction(nonce) {

--- a/src/dashboard/static/js/app.js
+++ b/src/dashboard/static/js/app.js
@@ -355,6 +355,11 @@ function dashboard() {
     workplaceTasks: [],
     workplaceBlockers: [],
     workplaceOutputs: [],
+    // Memoised slice for the Activity feed's "Recently delivered"
+    // header — recomputed in ``loadWorkplaceOutputs`` so the template
+    // doesn't re-run the filter on every Alpine reactive read. See
+    // ``_recomputeRecentlyDelivered`` for the coercion rules.
+    recentlyDeliveredItems: [],
     workplaceFeed: [],
     workplaceFeedCap: 200,
     workplacePending: [],
@@ -1457,6 +1462,7 @@ function dashboard() {
         const data = await resp.json();
         this.workplaceEnabled = data.enabled !== false;
         this.workplaceOutputs = data.outputs || [];
+        this._recomputeRecentlyDelivered();
       } catch (e) {
         console.error('Failed to load workplace outputs:', e);
       }
@@ -1828,16 +1834,65 @@ function dashboard() {
       }
     },
 
-    // Recently-delivered list for the Activity feed header. Pulled from
-    // workplaceOutputs so we stay aligned with the Outputs sub-tab; cap
-    // at 5 with a "View all" link so the section stays scannable.
-    recentlyDelivered(limit = 5, days = 7) {
+    // Coerce a wire-shape ``completed_at`` to a numeric epoch in seconds.
+    // The orchestration store has historically returned epoch-seconds as a
+    // float, but legacy / external feeders sometimes hand us strings or
+    // millisecond integers — and a wall-clock skew can yield future
+    // timestamps that should never count as "recent" for the user. We
+    // accept all three shapes and clamp to <= now so the filter stays
+    // monotonic even if the source clock drifts.
+    _coerceCompletedAtSeconds(value) {
+      if (value === null || value === undefined || value === '') return 0;
+      let n;
+      if (typeof value === 'number') {
+        n = value;
+      } else if (typeof value === 'string') {
+        const parsed = Date.parse(value);
+        if (Number.isFinite(parsed)) {
+          n = parsed / 1000;
+        } else {
+          // Numeric string ("1730000000" or "1730000000.5") that
+          // Date.parse refused — fall back to Number().
+          const asNum = Number(value);
+          n = Number.isFinite(asNum) ? asNum : 0;
+        }
+      } else {
+        return 0;
+      }
+      // Heuristic: anything >= 10^12 is almost certainly milliseconds
+      // (10^12 seconds = year ~33658). Drop to seconds.
+      if (n >= 1e12) n = n / 1000;
+      const nowSec = Date.now() / 1000;
+      if (n > nowSec) n = nowSec;
+      if (n < 0) n = 0;
+      return n;
+    },
+
+    // Recompute the memoised "Recently delivered" slice. Called whenever
+    // ``workplaceOutputs`` is refreshed. Coerces ``completed_at`` so the
+    // filter survives string timestamps and clock-skew-induced future
+    // values, then caps at 5 and sorts most-recent-first.
+    _recomputeRecentlyDelivered(limit = 5, days = 7) {
       const cutoff = (Date.now() / 1000) - days * 86400;
-      const rows = (this.workplaceOutputs || [])
-        .filter(t => (t.completed_at || 0) >= cutoff)
-        .slice()
-        .sort((a, b) => (b.completed_at || 0) - (a.completed_at || 0));
-      return rows.slice(0, limit);
+      const rows = [];
+      for (const t of (this.workplaceOutputs || [])) {
+        const sec = this._coerceCompletedAtSeconds(t.completed_at);
+        if (sec >= cutoff) {
+          // Spread + override so the original row isn't mutated and the
+          // template can still rely on ``completed_at`` being numeric
+          // seconds (its formatRelativeTime call multiplies by 1000).
+          rows.push({ ...t, completed_at: sec });
+        }
+      }
+      rows.sort((a, b) => (b.completed_at || 0) - (a.completed_at || 0));
+      this.recentlyDeliveredItems = rows.slice(0, limit);
+    },
+
+    // Back-compat shim — older callers and any future expressions should
+    // read ``recentlyDeliveredItems`` directly. Kept thin so the data
+    // field remains the single source of truth for the template.
+    recentlyDelivered() {
+      return this.recentlyDeliveredItems;
     },
 
     // Kanban filter — drop pending/blocked rows older than 14 days
@@ -1865,11 +1920,11 @@ function dashboard() {
 
     // Audit-log Revert: re-uses the soft-edit undo endpoint via the
     // change_id stored on each audit row (which IS the undo_token).
-    // Hard-edit rows have a different change_id shape and the mesh
-    // returns 404 — we surface that as a clean error instead of a
-    // toast spam loop.
+    // The template already gates the button on ``entry.undoable``, but
+    // we re-check here so a stale row (or a programmatic call) doesn't
+    // hit the endpoint just to receive a 404.
     async revertAuditEntry(entry) {
-      if (!entry || !entry.change_id) {
+      if (!entry || !entry.change_id || !entry.undoable) {
         this.showToast('This entry can no longer be reverted.');
         return;
       }

--- a/src/dashboard/templates/index.html
+++ b/src/dashboard/templates/index.html
@@ -192,7 +192,11 @@
                 <svg fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="3" width="7" height="7" rx="1"/><rect x="14" y="3" width="7" height="7" rx="1"/><rect x="3" y="14" width="7" height="7" rx="1"/><rect x="14" y="14" width="7" height="7" rx="1"/></svg>
               </template>
               <template x-if="tab.id === 'workplace'">
-                <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M9 11H7a2 2 0 0 0-2 2v6a2 2 0 0 0 2 2h10a2 2 0 0 0 2-2v-6a2 2 0 0 0-2-2h-2"/><rect x="9" y="3" width="6" height="8" rx="1"/></svg>
+                <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                  <rect x="4" y="4" width="4" height="16" rx="1"/>
+                  <rect x="10" y="4" width="4" height="10" rx="1"/>
+                  <rect x="16" y="4" width="4" height="13" rx="1"/>
+                </svg>
               </template>
               <template x-if="tab.id === 'system'">
                 <svg fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="4" y1="21" x2="4" y2="14"/><line x1="4" y1="10" x2="4" y2="3"/><line x1="12" y1="21" x2="12" y2="12"/><line x1="12" y1="8" x2="12" y2="3"/><line x1="20" y1="21" x2="20" y2="16"/><line x1="20" y1="12" x2="20" y2="3"/><line x1="1" y1="14" x2="7" y2="14"/><line x1="9" y1="8" x2="15" y2="8"/><line x1="17" y1="16" x2="23" y2="16"/></svg>
@@ -3148,6 +3152,50 @@
            and the pending-action queue (Task 2d) so a human can run an
            agent team end-to-end without inspecting blackboard keys. -->
       <div x-show="activeTab === 'workplace'" x-cloak x-init="loadWorkplace()">
+        <!-- Sticky "Needs you" panel — aggregates every kind of pending
+             decision (durable propose/confirm rows, credential / browser-
+             login / captcha cards in the operator chat, blocked tasks)
+             so the user never has to hunt across sub-tabs to act. The
+             cards still render in chat too; this is an additional
+             surface, not a replacement. Rendered only when there's at
+             least one item so an idle Board has no extra chrome. -->
+        <section x-show="needsYouItems.length > 0" x-cloak
+          role="region" aria-label="Pending items that need you"
+          class="mb-4 bg-amber-900/15 border border-amber-700/30 rounded-xl p-3 sm:p-4 sticky top-0 z-10 backdrop-blur-sm">
+          <div class="flex items-center gap-2 mb-3">
+            <svg class="w-4 h-4 text-amber-300 shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+              <path d="M12 9v4"/><path d="M12 17h.01"/><circle cx="12" cy="12" r="10"/>
+            </svg>
+            <h2 class="text-sm font-semibold text-white">Needs you</h2>
+            <span aria-live="polite"
+              class="text-[11px] font-medium px-2 py-0.5 rounded-full bg-amber-700/50 text-amber-100"
+              x-text="needsYouItems.length"></span>
+          </div>
+          <div class="space-y-2">
+            <template x-for="item in needsYouItems" :key="item.id">
+              <div class="bg-gray-900/50 border border-gray-700/50 rounded-lg p-2.5 sm:p-3 flex flex-col sm:flex-row sm:items-center gap-2 sm:gap-3">
+                <div class="flex items-start gap-2.5 min-w-0 flex-1">
+                  <span class="shrink-0 w-6 h-6 rounded-full bg-amber-700/30 text-amber-200 text-[11px] font-bold flex items-center justify-center"
+                    x-text="item.icon"></span>
+                  <div class="min-w-0 flex-1">
+                    <div class="text-sm text-gray-200 break-words" x-text="item.title"></div>
+                    <div x-show="item.subtitle" class="text-[11px] text-gray-400 mt-0.5 break-words" x-text="item.subtitle"></div>
+                  </div>
+                </div>
+                <div class="flex flex-wrap gap-1.5 shrink-0 sm:justify-end">
+                  <template x-for="action in item.actions" :key="action.label">
+                    <button type="button"
+                      @click="action.handler()"
+                      :class="needsYouButtonClass(action.style)"
+                      class="text-[11px] font-medium px-2.5 py-1 rounded transition-colors whitespace-nowrap"
+                      x-text="action.label"></button>
+                  </template>
+                </div>
+              </div>
+            </template>
+          </div>
+        </section>
+
         <!-- Sub-tab bar -->
         <div class="flex flex-wrap gap-0.5 bg-gray-800/50 rounded-lg p-0.5 mb-4">
           <template x-for="wt in workplaceTabs" :key="wt.id">
@@ -3162,7 +3210,7 @@
         <!-- Empty state when orchestration v2 is disabled -->
         <template x-if="!workplaceEnabled">
           <div class="bg-gray-800/40 border border-gray-700/50 rounded-xl p-6 text-center">
-            <div class="text-gray-300 text-sm font-medium mb-2">Workplace is disabled</div>
+            <div class="text-gray-300 text-sm font-medium mb-2">Board is disabled</div>
             <div class="text-xs text-gray-400 max-w-md mx-auto">
               Set <code class="text-gray-200 bg-gray-900/60 px-1 rounded">OPENLEGION_ORCHESTRATION_TASKS_V2=1</code>
               and restart the runtime to enable durable task records, project status rollups, blocker review,
@@ -3174,38 +3222,42 @@
         <!-- Activity feed sub-tab (default) -->
         <template x-if="workplaceEnabled && workplaceTab === 'feed'">
           <div class="space-y-3">
-            <!-- Pinned blockers strip — visible whenever any tasks are blocked. -->
-            <template x-if="workplaceBlockers && workplaceBlockers.length">
-              <div class="bg-yellow-900/15 border border-yellow-800/30 rounded-lg p-3">
-                <div class="text-xs font-medium text-yellow-200 mb-2">
-                  <span>&#9888;</span>
-                  <span x-text="workplaceBlockers.length + ' blocked task' + (workplaceBlockers.length === 1 ? '' : 's') + ' need attention'"></span>
+            <!-- Recently delivered — last 7 days of completed outputs.
+                 Surfaces "what's done" up front so the user gets a fast
+                 sense of velocity without having to switch to the
+                 Outputs sub-tab. Auto-hides when empty. -->
+            <template x-if="recentlyDelivered().length">
+              <div>
+                <div class="flex items-center justify-between mb-1.5">
+                  <div class="text-[11px] uppercase tracking-wide text-gray-500 font-medium">Recently delivered</div>
+                  <button type="button" @click="workplaceTab = 'team-outputs'; loadWorkplace()"
+                    class="text-[11px] text-gray-400 hover:text-gray-200">View all &rarr;</button>
                 </div>
                 <div class="space-y-1.5">
-                  <template x-for="b in workplaceBlockers" :key="b.id">
-                    <div class="flex items-start justify-between gap-2 text-xs text-gray-200 bg-yellow-900/10 rounded px-2 py-1.5">
-                      <div class="min-w-0">
-                        <span class="font-medium" x-text="b.title"></span>
-                        <span class="text-gray-400" x-text="' (' + (b.assignee || '') + (b.project_id ? ', ' + b.project_id : '') + ')'"></span>
-                        <div class="text-[11px] text-gray-400 mt-0.5" x-text="b.blocker_note || '(no note)'"></div>
-                      </div>
-                      <button class="text-[11px] px-2 py-0.5 rounded bg-yellow-800/30 hover:bg-yellow-800/50 text-yellow-100 whitespace-nowrap"
-                        @click="openTaskDrillIn(b.id)">Drill in</button>
+                  <template x-for="t in recentlyDelivered()" :key="'rd-' + t.id">
+                    <div class="flex items-center gap-2 bg-gray-800/40 border border-gray-700/50 rounded-md px-2.5 py-1.5">
+                      <span class="text-emerald-400 text-xs shrink-0">&check;</span>
+                      <div class="min-w-0 flex-1 text-xs text-gray-200 truncate" x-text="t.title || '(untitled)'"></div>
+                      <div class="text-[11px] text-gray-500 hidden sm:block shrink-0" x-text="(t.assignee || '') + (t.completed_at ? ' · ' + (formatRelativeTime((t.completed_at || 0) * 1000) || 'just now') : '')"></div>
+                      <button type="button"
+                        @click.stop="openTaskDrillIn(t.id)"
+                        class="text-[11px] px-2 py-0.5 rounded bg-gray-700 hover:bg-gray-600 text-gray-200 shrink-0">Open</button>
                     </div>
                   </template>
                 </div>
               </div>
             </template>
 
-            <!-- Empty state for the feed itself. When there are no
-                 projects yet, suggest a concrete next step instead of a
-                 plain "no activity" line; once a project exists the
-                 message reverts to the calm waiting state. -->
-            <template x-if="!workplaceFeed.length && !workplaceProjects.length">
-              <div class="text-sm text-gray-400 py-4">
-                No projects yet. Ask the operator to create one — say something like
-                <span class="italic text-gray-200">"create a project for &lt;goal&gt;"</span>
-                in the chat to get started.
+            <!-- Empty state for the feed itself. When there's nothing
+                 anywhere, the message reads as a calm prompt instead of
+                 a "missing data" warning. The hint button switches to
+                 the Chat tab so the user can start work in one click. -->
+            <template x-if="!workplaceFeed.length && !workplaceProjects.length && !needsYouItems.length">
+              <div class="text-sm text-gray-300 py-6 text-center">
+                Your team is idle.
+                <button type="button" @click="activeTab = 'chat'"
+                  class="underline decoration-dotted text-indigo-300 hover:text-indigo-200 transition-colors">Chat with your operator</button>
+                to start something.
               </div>
             </template>
             <template x-if="!workplaceFeed.length && workplaceProjects.length">
@@ -3307,7 +3359,7 @@
                     <span class="text-gray-500 font-mono" x-text="workplaceTasksByStatus(status).length"></span>
                   </div>
                   <div class="space-y-2">
-                    <template x-for="t in workplaceTasksByStatus(status)" :key="t.id">
+                    <template x-for="t in workplaceTasksByStatusFiltered(status)" :key="t.id">
                       <div class="bg-gray-900/60 border border-gray-700/40 rounded-md p-2 text-xs cursor-pointer hover:bg-gray-900/90 hover:border-gray-600 transition-colors"
                         @click="openTaskDrillIn(t.id)">
                         <div class="font-medium text-gray-200 truncate" x-text="t.title"></div>
@@ -3326,6 +3378,19 @@
                           </template>
                         </div>
                       </div>
+                    </template>
+                    <!-- Archived disclosure: only the pending and blocked
+                         columns hide rows older than 14 days, since they
+                         can grow unbounded when a project stalls. Other
+                         statuses keep showing every row. -->
+                    <template x-if="workplaceArchivedCount(status) > 0">
+                      <button type="button"
+                        @click="boardShowArchived = { ...boardShowArchived, [status]: !boardShowArchived[status] }"
+                        class="w-full text-[11px] text-gray-400 hover:text-gray-200 px-2 py-1 rounded border border-dashed border-gray-700/60 hover:border-gray-600 transition-colors text-left">
+                        <span x-show="!boardShowArchived[status]"
+                          x-text="'Show ' + workplaceArchivedCount(status) + ' archived ▸'"></span>
+                        <span x-show="boardShowArchived[status]" x-cloak>Hide archived &#9662;</span>
+                      </button>
                     </template>
                   </div>
                 </div>
@@ -5491,6 +5556,20 @@
                       <span class="text-xs text-white font-medium truncate" x-text="entry.target"></span>
                       <span x-show="entry.field" class="text-[10px] text-gray-500 truncate" x-text="'· ' + entry.field"></span>
                     </div>
+                    <!-- Revert reuses the soft-edit /changes/undo endpoint;
+                         the audit row's change_id is the same uuid as the
+                         undo_token. Hard-edit and non-soft entries return
+                         404 (token consumed/expired or never existed) and
+                         we surface that via toast — no special UI gating
+                         needed. -->
+                    <button x-show="entry.change_id"
+                      type="button"
+                      @click.stop="revertAuditEntry(entry)"
+                      :disabled="auditReverting[entry.id]"
+                      class="text-[10px] px-2 py-0.5 rounded bg-gray-700 hover:bg-gray-600 text-gray-200 disabled:opacity-50 transition-colors shrink-0">
+                      <span x-show="!auditReverting[entry.id]">Revert</span>
+                      <span x-show="auditReverting[entry.id]" x-cloak>...</span>
+                    </button>
                     <svg class="w-3 h-3 text-gray-600 transition-transform shrink-0" :class="expanded && 'rotate-90'" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7"/></svg>
                   </div>
                   <template x-if="expanded">

--- a/src/dashboard/templates/index.html
+++ b/src/dashboard/templates/index.html
@@ -3160,6 +3160,7 @@
              surface, not a replacement. Rendered only when there's at
              least one item so an idle Board has no extra chrome. -->
         <section x-show="needsYouItems.length > 0" x-cloak
+          x-data="{ needsYouExpanded: false, needsYouCollapsedCap: 5 }"
           role="region" aria-label="Pending items that need you"
           class="mb-4 bg-amber-900/15 border border-amber-700/30 rounded-xl p-3 sm:p-4 sticky top-0 z-10 backdrop-blur-sm">
           <div class="flex items-center gap-2 mb-3">
@@ -3171,8 +3172,14 @@
               class="text-[11px] font-medium px-2 py-0.5 rounded-full bg-amber-700/50 text-amber-100"
               x-text="needsYouItems.length"></span>
           </div>
-          <div class="space-y-2">
-            <template x-for="item in needsYouItems" :key="item.id">
+          <!-- Cap the visible items at ~40vh and scroll inside the panel
+               so a long pending queue can never push the sub-tab bar off
+               the viewport on mobile. The "Show N more" disclosure below
+               keeps the default render to 5 rows so the panel stays small
+               in the common case; once expanded it stays expanded for the
+               session (no re-collapse behavior). -->
+          <div class="space-y-2 max-h-[40vh] overflow-y-auto custom-scrollbar pr-0.5">
+            <template x-for="item in (needsYouExpanded ? needsYouItems : needsYouItems.slice(0, needsYouCollapsedCap))" :key="item.id">
               <div class="bg-gray-900/50 border border-gray-700/50 rounded-lg p-2.5 sm:p-3 flex flex-col sm:flex-row sm:items-center gap-2 sm:gap-3">
                 <div class="flex items-start gap-2.5 min-w-0 flex-1">
                   <span class="shrink-0 w-6 h-6 rounded-full bg-amber-700/30 text-amber-200 text-[11px] font-bold flex items-center justify-center"
@@ -3194,6 +3201,11 @@
               </div>
             </template>
           </div>
+          <button type="button"
+            x-show="!needsYouExpanded && needsYouItems.length > needsYouCollapsedCap"
+            @click="needsYouExpanded = true"
+            class="mt-2 text-[11px] text-amber-200 hover:text-amber-100 transition-colors"
+            x-text="'Show ' + (needsYouItems.length - needsYouCollapsedCap) + ' more'"></button>
         </section>
 
         <!-- Sub-tab bar -->
@@ -3226,7 +3238,7 @@
                  Surfaces "what's done" up front so the user gets a fast
                  sense of velocity without having to switch to the
                  Outputs sub-tab. Auto-hides when empty. -->
-            <template x-if="recentlyDelivered().length">
+            <template x-if="recentlyDeliveredItems.length">
               <div>
                 <div class="flex items-center justify-between mb-1.5">
                   <div class="text-[11px] uppercase tracking-wide text-gray-500 font-medium">Recently delivered</div>
@@ -3234,7 +3246,7 @@
                     class="text-[11px] text-gray-400 hover:text-gray-200">View all &rarr;</button>
                 </div>
                 <div class="space-y-1.5">
-                  <template x-for="t in recentlyDelivered()" :key="'rd-' + t.id">
+                  <template x-for="t in recentlyDeliveredItems" :key="'rd-' + t.id">
                     <div class="flex items-center gap-2 bg-gray-800/40 border border-gray-700/50 rounded-md px-2.5 py-1.5">
                       <span class="text-emerald-400 text-xs shrink-0">&check;</span>
                       <div class="min-w-0 flex-1 text-xs text-gray-200 truncate" x-text="t.title || '(untitled)'"></div>
@@ -5558,11 +5570,13 @@
                     </div>
                     <!-- Revert reuses the soft-edit /changes/undo endpoint;
                          the audit row's change_id is the same uuid as the
-                         undo_token. Hard-edit and non-soft entries return
-                         404 (token consumed/expired or never existed) and
-                         we surface that via toast — no special UI gating
-                         needed. -->
-                    <button x-show="entry.change_id"
+                         undo_token, but only when the row was logged with
+                         ``undoable=True`` (the soft-edit path). Hard-edit
+                         and delete rows also write a change_id (the
+                         pending-action nonce), so we gate on the explicit
+                         ``undoable`` flag instead — a button that can
+                         only fail with 404 is worse than no button. -->
+                    <button x-show="entry.undoable"
                       type="button"
                       @click.stop="revertAuditEntry(entry)"
                       :disabled="auditReverting[entry.id]"

--- a/src/host/mesh.py
+++ b/src/host/mesh.py
@@ -96,11 +96,32 @@ class Blackboard:
                 before_value TEXT,
                 after_value TEXT,
                 change_id TEXT,
-                provenance TEXT DEFAULT 'user'
+                provenance TEXT DEFAULT 'user',
+                undoable INTEGER NOT NULL DEFAULT 0
             );
             CREATE INDEX IF NOT EXISTS idx_audit_log_timestamp ON audit_log(timestamp);
             CREATE INDEX IF NOT EXISTS idx_audit_log_target ON audit_log(target);
         """)
+        # Migrate legacy DBs that pre-date the ``undoable`` column.
+        # Without this, the dashboard's Revert button would show on every
+        # row that has a ``change_id`` — including hard-edit and delete
+        # rows whose change_id was never an undo_token, producing 404
+        # toasts on click. Default 0 means "not undoable" so historic
+        # rows fail closed; only the soft-edit endpoint sets it to 1.
+        existing_audit_cols = {
+            row[1]
+            for row in self.db.execute("PRAGMA table_info(audit_log)").fetchall()
+        }
+        if "undoable" not in existing_audit_cols:
+            try:
+                self.db.execute(
+                    "ALTER TABLE audit_log ADD COLUMN undoable INTEGER NOT NULL DEFAULT 0"
+                )
+            except sqlite3.OperationalError as e:
+                # Race: another worker added it between PRAGMA and ALTER.
+                # Anything else is a real error worth surfacing.
+                if "duplicate column" not in str(e).lower():
+                    raise
         self.db.commit()
         self._load_watchers()
 
@@ -324,14 +345,23 @@ class Blackboard:
     def log_audit(self, action: str, target: str, field: str = "",
                   before_value: str = "", after_value: str = "",
                   change_id: str = "", actor: str = "operator",
-                  provenance: str = "user") -> None:
-        """Log an operator action to the audit trail."""
+                  provenance: str = "user", undoable: bool = False) -> None:
+        """Log an operator action to the audit trail.
+
+        ``undoable`` marks rows whose ``change_id`` is a real undo_token
+        (the ``change_history`` UUID issued by the soft-edit path). Hard
+        edits and deletes also write a ``change_id`` — but it's the
+        propose/confirm pending-action nonce, not an undo_token, and the
+        ``/changes/undo`` endpoint will 404 on it. The dashboard reads
+        this flag to gate the Revert button so the user never sees a
+        button that can only fail.
+        """
         with self._write_lock:
             self.db.execute(
                 "INSERT INTO audit_log"
-                " (action, actor, target, field, before_value, after_value, change_id, provenance)"
-                " VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
-                (action, actor, target, field, before_value, after_value, change_id, provenance),
+                " (action, actor, target, field, before_value, after_value, change_id, provenance, undoable)"
+                " VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                (action, actor, target, field, before_value, after_value, change_id, provenance, 1 if undoable else 0),
             )
             self.db.commit()
 
@@ -363,11 +393,18 @@ class Blackboard:
 
         entries = []
         for row in rows:
+            # ``undoable`` was added later via ALTER TABLE; it lands at
+            # position 10 (after the original 10 columns 0..9). Older
+            # databases that haven't been migrated yet won't have it,
+            # so fall back to False — same posture as a fresh row whose
+            # ``undoable`` flag was never set explicitly.
+            undoable_raw = row[10] if len(row) > 10 else 0
             entries.append({
                 "id": row[0], "timestamp": row[1], "action": row[2],
                 "actor": row[3], "target": row[4], "field": row[5],
                 "before_value": row[6], "after_value": row[7],
                 "change_id": row[8], "provenance": row[9],
+                "undoable": bool(undoable_raw),
             })
 
         return {"entries": entries, "total": count, "page": page, "per_page": per_page}

--- a/src/host/server.py
+++ b/src/host/server.py
@@ -4572,8 +4572,16 @@ def create_mesh_app(
             ),
         }
 
-    async def _apply_pending_change(change_id: str, change: dict) -> dict:
-        """Apply a consumed pending change — shared by both config endpoints."""
+    async def _apply_pending_change(change_id: str, change: dict, *, undoable: bool = False) -> dict:
+        """Apply a consumed pending change — shared by soft, confirm, and undo paths.
+
+        ``undoable`` flags the audit row as Revert-eligible. Only the
+        soft-edit caller passes True (the change_id is the
+        ``change_history`` undo_token there). Hard-edit confirms and the
+        undo apply itself pass False — their change_id is a pending-action
+        nonce or already-consumed undo token, so the dashboard's Revert
+        button must not show on those rows.
+        """
         agent_id = change["agent_id"]
         field = change["field"]
         old_value = change["old_value"]
@@ -4703,6 +4711,7 @@ def create_mesh_app(
             before_value=json.dumps(old_value) if not isinstance(old_value, str) else old_value,
             after_value=json.dumps(new_value) if not isinstance(new_value, str) else new_value,
             change_id=change_id,
+            undoable=undoable,
         )
 
         return {"success": True, "agent_id": agent_id, "field": field}
@@ -4793,6 +4802,10 @@ def create_mesh_app(
         # Apply directly via the same write helper used by the confirm
         # path. ``_apply_pending_change`` is async and handles audit
         # logging, hot-reload, and heartbeat schedule sync.
+        # ``undoable=True`` here marks the audit row as Revert-eligible
+        # — the change_id IS the undo_token for the change_history row
+        # we record below, so the dashboard can wire Revert directly to
+        # ``/changes/undo/{change_id}``.
         undo_token = str(_uuid.uuid4())
         await _apply_pending_change(
             undo_token,
@@ -4802,6 +4815,7 @@ def create_mesh_app(
                 "old_value": old_value,
                 "new_value": new_value,
             },
+            undoable=True,
         )
 
         # Detect older unconsumed receipts on the same field BEFORE we

--- a/tests/test_operator_audit.py
+++ b/tests/test_operator_audit.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import sqlite3
 from datetime import datetime, timedelta, timezone
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -141,6 +142,88 @@ def test_audit_log_empty(blackboard):
     assert result["total"] == 0
     assert result["entries"] == []
     assert result["page"] == 1
+
+
+def test_audit_log_undoable_default_false(blackboard):
+    """A row written without ``undoable=`` defaults to False so the
+    dashboard's Revert button stays hidden on legacy / hard-edit rows."""
+    blackboard.log_audit(
+        action="edit_agent", target="alpha", field="model",
+        change_id="some-nonce",
+    )
+    entry = blackboard.get_audit_log()["entries"][0]
+    assert entry["undoable"] is False
+
+
+def test_audit_log_undoable_true_when_set(blackboard):
+    """The soft-edit path passes ``undoable=True`` so the audit row
+    advertises that ``change_id`` is a valid undo_token."""
+    blackboard.log_audit(
+        action="edit_agent", target="alpha", field="instructions",
+        change_id="undo-uuid", undoable=True,
+    )
+    entry = blackboard.get_audit_log()["entries"][0]
+    assert entry["undoable"] is True
+
+
+def test_audit_log_undoable_column_migration(tmp_path):
+    """Legacy DBs without the ``undoable`` column get the column added
+    by Blackboard.__init__ and existing rows surface as undoable=False."""
+    db_path = tmp_path / "legacy.db"
+    # Create the table in the *old* shape — no ``undoable`` column.
+    legacy = sqlite3.connect(str(db_path))
+    legacy.executescript("""
+        CREATE TABLE audit_log (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            timestamp TEXT NOT NULL DEFAULT (datetime('now')),
+            action TEXT NOT NULL,
+            actor TEXT NOT NULL DEFAULT 'operator',
+            target TEXT NOT NULL,
+            field TEXT,
+            before_value TEXT,
+            after_value TEXT,
+            change_id TEXT,
+            provenance TEXT DEFAULT 'user'
+        );
+    """)
+    legacy.execute(
+        "INSERT INTO audit_log (action, target, field, change_id) "
+        "VALUES (?, ?, ?, ?)",
+        ("edit_agent", "alpha", "model", "legacy-nonce"),
+    )
+    legacy.commit()
+    legacy.close()
+
+    # Opening the Blackboard should ALTER the table and not raise.
+    bb = Blackboard(db_path=str(db_path))
+    try:
+        cols = {
+            row[1]
+            for row in bb.db.execute("PRAGMA table_info(audit_log)").fetchall()
+        }
+        assert "undoable" in cols
+
+        # Legacy row should be readable and report undoable=False.
+        result = bb.get_audit_log()
+        assert result["total"] == 1
+        legacy_entry = result["entries"][0]
+        assert legacy_entry["change_id"] == "legacy-nonce"
+        assert legacy_entry["undoable"] is False
+
+        # Re-running the migration on an already-migrated DB is a no-op.
+        bb2 = Blackboard(db_path=str(db_path))
+        try:
+            cols2 = {
+                row[1]
+                for row in bb2.db.execute(
+                    "PRAGMA table_info(audit_log)"
+                ).fetchall()
+            }
+            assert "undoable" in cols2
+        finally:
+            bb2.close()
+    finally:
+        bb.close()
 
 
 # === Pending Change Store Tests ===


### PR DESCRIPTION
## Summary

Renames the Workplace tab to **Board** (with a 3-column kanban icon) and restructures the landing so generic, non-technical users never have to hunt for pending decisions. The headline change is a sticky **Needs you** panel pinned above the sub-tab bar that aggregates *every* kind of pending decision in one place: durable propose/confirm rows from the workplace pending queue, the credential / browser-login / captcha cards already living in the operator chat, and tasks the agent flagged as blocked. The cards still render in chat too — this is an additional surface, not a replacement.

Also in this PR:
- **Recently delivered** strip above the activity feed (last 7 days, up to 5 rows, with a link out to the Outputs sub-tab) — surfaces "what's done" up front so the user gets a fast sense of velocity.
- Empty-state copy now reads "Your team is idle. Chat with your operator to start something." (the inline link switches to the Chat tab).
- Kanban's `pending` and `blocked` columns now hide rows older than 14 days with a per-column "Show N archived" disclosure (client-side filter only — true server-side archival can come in a follow-up).
- **Revert** button on every operator audit row, wired to the existing `/dashboard/api/changes/undo/{token}` endpoint via the row's stored `change_id` (which is the same UUID as the soft-edit `undo_token`). Hard-edit rows return 404 and surface a clean toast.

> **Note: the route id stays `'workplace'`** — only the user-facing label and UI changed. Server endpoints (`/api/workplace/...`), URL state, persistence, and existing tests keep working.

## Test plan

- [x] `ruff check src/` — passes
- [x] `pytest tests/test_dashboard.py` — 306 passed
- [x] `pytest tests/test_workplace_drill_in.py tests/test_workplace_feed.py tests/test_workplace_outcome.py tests/test_dashboard_workspace.py` — 51 passed
- [x] `node` syntax check on `app.js` — parses cleanly
- [ ] Visual smoke test in a running dashboard — Board tab renders with kanban icon; Needs-you panel auto-hides when empty and shows aggregated items when present; Recently delivered cap of 5 with View-all link; revert button on audit rows hits undo endpoint
- [ ] Responsive check at 375px / 768px / 1280px — Needs-you cards stack vertically on mobile, inline on desktop