### PR TITLE
feat(dashboard): render Fleet pulse — operator observations now visible

### DIFF
--- a/src/agent/server.py
+++ b/src/agent/server.py
@@ -325,7 +325,7 @@ def create_agent_app(loop: AgentLoop) -> FastAPI:
 
     _WORKSPACE_ALLOWLIST = frozenset({
         "SOUL.md", "HEARTBEAT.md", "USER.md", "INSTRUCTIONS.md", "AGENTS.md", "MEMORY.md",
-        "INTERFACE.md",
+        "INTERFACE.md", "OBSERVATIONS.md",
     })
     _DEFAULT_HEARTBEAT_HEADING = "# Heartbeat Rules"
 

--- a/src/dashboard/server.py
+++ b/src/dashboard/server.py
@@ -5250,7 +5250,7 @@ def create_dashboard_router(
 
     _WORKSPACE_ALLOWLIST = frozenset({
         "SOUL.md", "HEARTBEAT.md", "USER.md", "INSTRUCTIONS.md", "AGENTS.md", "MEMORY.md",
-        "INTERFACE.md",
+        "INTERFACE.md", "OBSERVATIONS.md",
     })
 
     @api_router.get("/api/agents/{agent_id}/workspace")

--- a/src/dashboard/static/js/app.js
+++ b/src/dashboard/static/js/app.js
@@ -62,6 +62,7 @@ function dashboard() {
 
     // Fleet Digest (parsed from operator's OBSERVATIONS.md)
     fleetDigest: null,
+    fleetDigestRefreshing: false,
     _fleetDigestTimer: null,
 
     // Fleet
@@ -1248,27 +1249,66 @@ function dashboard() {
     // ── Fleet Digest ─────────────────────────────────────
 
     async fetchFleetDigest() {
+      // Lenient parser — never throws. On any error (network, missing file, bad JSON)
+      // we leave fleetDigest as-is on first call (null) so the empty-state placeholder
+      // renders. We deliberately do not clear a previously-loaded digest on a transient
+      // network blip.
       try {
         const resp = await fetch(`${window.__config.apiBase}/agents/operator/workspace/OBSERVATIONS.md`);
-        if (!resp.ok) { this.fleetDigest = null; return; }
+        if (!resp.ok) {
+          // 404 → operator hasn't run a check yet. Clear so the "never run" state shows.
+          if (resp.status === 404) this.fleetDigest = null;
+          return;
+        }
         const text = await resp.text();
         // Parse JSON block from markdown format
         const match = text.match(/```json\n([\s\S]*?)\n```/);
-        if (match) {
-          this.fleetDigest = JSON.parse(match[1]);
-        } else {
+        if (!match) { this.fleetDigest = null; return; }
+        try {
+          const parsed = JSON.parse(match[1]);
+          // Only accept object-shaped payloads
+          if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+            this.fleetDigest = parsed;
+          } else {
+            this.fleetDigest = null;
+          }
+        } catch (_e) {
           this.fleetDigest = null;
         }
-      } catch (e) {
-        this.fleetDigest = null;
+      } catch (_e) {
+        // Network error — keep previous value if any.
       }
+    },
+
+    async refreshFleetDigest() {
+      // User-initiated refresh — toggles the spinner, ensures a minimum visible
+      // duration so the spin isn't a single frame on cached responses.
+      if (this.fleetDigestRefreshing) return;
+      this.fleetDigestRefreshing = true;
+      const minDelay = new Promise(r => setTimeout(r, 350));
+      try {
+        await Promise.all([this.fetchFleetDigest(), minDelay]);
+      } finally {
+        this.fleetDigestRefreshing = false;
+      }
+    },
+
+    scrollToFleetPulse() {
+      // Defer a tick so the System tab content is in the DOM before we scroll.
+      this.$nextTick(() => {
+        const el = document.getElementById('fleet-pulse-card');
+        if (el) el.scrollIntoView({ behavior: 'smooth', block: 'start' });
+      });
     },
 
     _startFleetDigestRefresh() {
       this.fetchFleetDigest();
       if (!this._fleetDigestTimer) {
         this._fleetDigestTimer = setInterval(() => {
-          if (this.activeTab === 'chat') this.fetchFleetDigest();
+          // Keep the digest fresh anywhere it is rendered (chat sidebar + system tab card).
+          if (this.activeTab === 'chat' || this.activeTab === 'system') {
+            this.fetchFleetDigest();
+          }
         }, 300000); // 5 minutes
       }
     },

--- a/src/dashboard/static/js/app.js
+++ b/src/dashboard/static/js/app.js
@@ -1248,19 +1248,36 @@ function dashboard() {
 
     // ── Fleet Digest ─────────────────────────────────────
 
-    async fetchFleetDigest() {
+    async fetchFleetDigest({ userInitiated = false } = {}) {
       // Lenient parser — never throws. On any error (network, missing file, bad JSON)
       // we leave fleetDigest as-is on first call (null) so the empty-state placeholder
       // renders. We deliberately do not clear a previously-loaded digest on a transient
       // network blip.
+      // 10-second timeout via AbortController so a hung fetch can't strand the spinner.
+      const controller = new AbortController();
+      const timeoutId = setTimeout(() => controller.abort(), 10000);
       try {
-        const resp = await fetch(`${window.__config.apiBase}/agents/operator/workspace/OBSERVATIONS.md`);
+        const resp = await fetch(
+          `${window.__config.apiBase}/agents/operator/workspace/OBSERVATIONS.md`,
+          { signal: controller.signal },
+        );
         if (!resp.ok) {
           // 404 → operator hasn't run a check yet. Clear so the "never run" state shows.
           if (resp.status === 404) this.fleetDigest = null;
           return;
         }
-        const text = await resp.text();
+        // Endpoint returns JSON {filename, content}. Parse the JSON wrapper, then
+        // run the markdown regex against `content` (raw text, real newlines).
+        let text = '';
+        try {
+          const data = await resp.json();
+          text = (data && typeof data === 'object' && typeof data.content === 'string')
+            ? data.content
+            : '';
+        } catch (_e) {
+          this.fleetDigest = null;
+          return;
+        }
         // Parse JSON block from markdown format
         const match = text.match(/```json\n([\s\S]*?)\n```/);
         if (!match) { this.fleetDigest = null; return; }
@@ -1275,8 +1292,13 @@ function dashboard() {
         } catch (_e) {
           this.fleetDigest = null;
         }
-      } catch (_e) {
-        // Network error — keep previous value if any.
+      } catch (e) {
+        if (e && e.name === 'AbortError' && userInitiated) {
+          this.showToast('Fleet pulse refresh timed out');
+        }
+        // Network error / abort — keep previous value if any.
+      } finally {
+        clearTimeout(timeoutId);
       }
     },
 
@@ -1287,10 +1309,33 @@ function dashboard() {
       this.fleetDigestRefreshing = true;
       const minDelay = new Promise(r => setTimeout(r, 350));
       try {
-        await Promise.all([this.fetchFleetDigest(), minDelay]);
+        await Promise.all([this.fetchFleetDigest({ userInitiated: true }), minDelay]);
       } finally {
         this.fleetDigestRefreshing = false;
       }
+    },
+
+    isFleetDigestStale() {
+      // Returns true when the digest is more than 24h old.
+      // Surfaces a "stale" badge in the card header — the operator may have
+      // stopped running.
+      const ts = this.fleetDigest && this.fleetDigest.timestamp;
+      if (!ts) return false;
+      const t = Date.parse(ts);
+      if (!t) return false;
+      return (Date.now() - t) > 86400000;  // 24h
+    },
+
+    drillIntoAttentionEntry(entry) {
+      // Guarded drill-in: surface a toast if the agent has been deleted since
+      // the operator's last observations were saved.
+      if (!entry || !entry.agent_id) return;
+      const exists = (this.agents || []).find(a => a.id === entry.agent_id);
+      if (!exists) {
+        this.showToast(`Agent ${entry.agent_id} no longer exists`);
+        return;
+      }
+      this.drillDown(entry.agent_id);
     },
 
     scrollToFleetPulse() {

--- a/src/dashboard/templates/index.html
+++ b/src/dashboard/templates/index.html
@@ -3625,6 +3625,13 @@
                 class="text-[11px] text-gray-500 truncate"
                 x-text="(() => { const t = Date.parse(fleetDigest.timestamp); if (!t) return ''; const rel = formatRelativeTime(t); return rel ? 'as of ' + rel : 'just now'; })()"
               ></span>
+              <!-- Staleness badge — only operator-stopped signal users get -->
+              <span
+                x-show="isFleetDigestStale()"
+                class="text-[10px] font-semibold uppercase tracking-wide text-red-400 px-1.5 py-0.5 rounded bg-red-900/20 border border-red-800/40 shrink-0"
+                title="Operator hasn't run a check in 24h+"
+                aria-label="Fleet pulse is stale — operator hasn't run a check in 24h or more"
+              >stale</span>
             </div>
             <button
               @click="refreshFleetDigest()"
@@ -3663,8 +3670,8 @@
                       <span
                         class="text-sm shrink-0 leading-5"
                         :title="entry.severity || 'unknown'"
-                        :aria-label="'severity ' + (entry.severity || 'unknown')"
-                        x-text="entry.severity === 'high' ? '🔴' : entry.severity === 'medium' ? '🟡' : entry.severity === 'low' ? '🔵' : '⚪'"
+                        :aria-label="(entry.severity === 'high' || entry.severity === 'critical' || entry.severity === 'medium' || entry.severity === 'low' || entry.severity === 'info') ? ('severity ' + entry.severity) : 'severity unknown'"
+                        x-text="(entry.severity === 'high' || entry.severity === 'critical') ? '🔴' : entry.severity === 'medium' ? '🟡' : entry.severity === 'low' ? '🔵' : entry.severity === 'info' ? '🔵' : '⚠️'"
                       ></span>
                       <span class="text-sm text-gray-200 min-w-0">
                         <span class="font-mono text-gray-100" x-text="entry.agent_id || 'unknown'"></span>
@@ -3674,7 +3681,7 @@
                       </span>
                     </div>
                     <button
-                      @click="drillDown(entry.agent_id)"
+                      @click="drillIntoAttentionEntry(entry)"
                       x-show="entry.agent_id"
                       class="text-xs text-amber-300 hover:text-amber-200 self-start sm:self-auto shrink-0 px-2 py-0.5 rounded hover:bg-amber-900/20 transition-colors"
                       :aria-label="'Drill in to ' + (entry.agent_id || 'agent')"

--- a/src/dashboard/templates/index.html
+++ b/src/dashboard/templates/index.html
@@ -214,6 +214,25 @@
         </button>
       </div>
       <div class="flex items-center gap-4 shrink-0">
+        <!-- Fleet pulse attention badge — surfaces operator's flagged agents -->
+        <button
+          x-show="fleetDigest?.agents_attention?.length > 0"
+          x-cloak
+          @click="switchTab('system'); systemTab = 'activity'; scrollToFleetPulse()"
+          class="flex items-center gap-1.5 px-2 sm:px-2.5 py-1 rounded-md text-xs font-medium bg-amber-900/30 text-amber-300 border border-amber-700/40 hover:bg-amber-900/50 hover:border-amber-600/60 transition-colors cursor-pointer"
+          aria-live="polite"
+          :aria-label="(fleetDigest?.agents_attention?.length || 0) + ' agents need attention. Click to view fleet pulse.'"
+          :title="'View fleet pulse — ' + (fleetDigest?.agents_attention?.length || 0) + ' need attention'"
+        >
+          <svg class="w-3.5 h-3.5 shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M10.29 3.86L1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0z"/><line x1="12" y1="9" x2="12" y2="13"/><line x1="12" y1="17" x2="12.01" y2="17"/></svg>
+          <!-- Mobile: number-only -->
+          <span class="sm:hidden font-mono" x-text="fleetDigest?.agents_attention?.length || 0"></span>
+          <!-- Tablet+: full text -->
+          <span class="hidden sm:inline">
+            <span class="font-mono" x-text="fleetDigest?.agents_attention?.length || 0"></span>
+            <span x-text="(fleetDigest?.agents_attention?.length === 1 ? ' agent needs' : ' agents need') + ' attention'"></span>
+          </span>
+        </button>
         <div class="text-xs text-gray-500 hidden sm:block cursor-pointer hover:text-gray-300 transition-colors" x-show="fleetTotalCost > 0" @click="systemTab = 'costs'; switchTab('system')">
           Today: <span class="text-gray-300 font-medium" x-text="formatCost(fleetTotalCost)"></span>
         </div>
@@ -3590,6 +3609,93 @@
 
       <!-- System (Activity + Costs + Automation + Integrations + API Keys + Wallet + Storage + Audit + Settings) -->
       <div x-show="activeTab === 'system'" x-cloak>
+        <!-- Fleet pulse card — operator's autonomous fleet-health observations.
+             Sits above the sub-tab bar so it's always visible regardless of sub-tab. -->
+        <div
+          id="fleet-pulse-card"
+          role="region"
+          aria-label="Fleet pulse"
+          class="bg-gray-800/40 border border-gray-700/50 rounded-xl p-4 mb-4"
+        >
+          <div class="flex items-center justify-between gap-2 mb-2">
+            <div class="flex items-center gap-2 min-w-0">
+              <h2 class="text-sm font-semibold text-white">Fleet pulse</h2>
+              <span
+                x-show="fleetDigest?.timestamp"
+                class="text-[11px] text-gray-500 truncate"
+                x-text="(() => { const t = Date.parse(fleetDigest.timestamp); if (!t) return ''; const rel = formatRelativeTime(t); return rel ? 'as of ' + rel : 'just now'; })()"
+              ></span>
+            </div>
+            <button
+              @click="refreshFleetDigest()"
+              :disabled="fleetDigestRefreshing"
+              :aria-label="fleetDigestRefreshing ? 'Refreshing fleet pulse' : 'Refresh fleet pulse'"
+              class="text-gray-500 hover:text-gray-200 disabled:opacity-50 disabled:cursor-not-allowed transition-colors p-1 rounded hover:bg-gray-800/60"
+              title="Refresh"
+            >
+              <svg class="w-3.5 h-3.5" :class="fleetDigestRefreshing ? 'animate-spin' : ''" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="23 4 23 10 17 10"/><polyline points="1 20 1 14 7 14"/><path d="M3.51 9a9 9 0 0 1 14.85-3.36L23 10M1 14l4.64 4.36A9 9 0 0 0 20.49 15"/></svg>
+            </button>
+          </div>
+
+          <!-- State A: never run -->
+          <template x-if="!fleetDigest">
+            <div class="text-sm text-gray-400">
+              Operator hasn't run a fleet check yet.
+            </div>
+          </template>
+
+          <!-- State B: ran, all quiet -->
+          <template x-if="fleetDigest && !(fleetDigest.agents_attention?.length)">
+            <div>
+              <div class="text-sm text-gray-200" x-text="fleetDigest.fleet_summary || 'All quiet across the fleet.'"></div>
+              <div x-show="!fleetDigest.fleet_summary" class="text-sm text-gray-300">All quiet across the fleet. &check;</div>
+            </div>
+          </template>
+
+          <!-- State C: ran, has attention items -->
+          <template x-if="fleetDigest && fleetDigest.agents_attention?.length">
+            <div>
+              <div x-show="fleetDigest.fleet_summary" class="text-sm text-gray-200 mb-3" x-text="fleetDigest.fleet_summary"></div>
+              <ul class="space-y-1.5" role="list">
+                <template x-for="entry in fleetDigest.agents_attention" :key="(entry.agent_id || '') + '|' + (entry.issue || '')">
+                  <li class="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-1 sm:gap-3 px-2.5 py-1.5 rounded-md bg-gray-900/40 border border-gray-800/60">
+                    <div class="flex items-start sm:items-center gap-2 min-w-0">
+                      <span
+                        class="text-sm shrink-0 leading-5"
+                        :title="entry.severity || 'unknown'"
+                        :aria-label="'severity ' + (entry.severity || 'unknown')"
+                        x-text="entry.severity === 'high' ? '🔴' : entry.severity === 'medium' ? '🟡' : entry.severity === 'low' ? '🔵' : '⚪'"
+                      ></span>
+                      <span class="text-sm text-gray-200 min-w-0">
+                        <span class="font-mono text-gray-100" x-text="entry.agent_id || 'unknown'"></span>
+                        <template x-if="entry.issue">
+                          <span class="text-gray-400"> &mdash; <span x-text="entry.issue"></span></span>
+                        </template>
+                      </span>
+                    </div>
+                    <button
+                      @click="drillDown(entry.agent_id)"
+                      x-show="entry.agent_id"
+                      class="text-xs text-amber-300 hover:text-amber-200 self-start sm:self-auto shrink-0 px-2 py-0.5 rounded hover:bg-amber-900/20 transition-colors"
+                      :aria-label="'Drill in to ' + (entry.agent_id || 'agent')"
+                    >Drill in &rarr;</button>
+                  </li>
+                </template>
+              </ul>
+              <template x-if="fleetDigest.cost_trend">
+                <div class="text-[11px] text-gray-500 mt-3">
+                  Cost trend: <span class="text-gray-400" x-text="fleetDigest.cost_trend"></span>
+                </div>
+              </template>
+            </div>
+          </template>
+
+          <!-- Footer: last-check timestamp + author -->
+          <div x-show="fleetDigest?.timestamp" class="text-[11px] text-gray-500 mt-3 pt-2 border-t border-gray-800/60">
+            Last check: <span x-text="(() => { const t = Date.parse(fleetDigest.timestamp); if (!t) return '—'; return formatRelativeTime(t) || 'just now'; })()"></span> &middot; by Operator
+          </div>
+        </div>
+
         <!-- System sub-tab bar -->
         <div class="flex flex-wrap gap-0.5 bg-gray-800/50 rounded-lg p-0.5 mb-4">
           <template x-for="st in systemTabs" :key="st.id">

--- a/tests/test_dashboard_workspace.py
+++ b/tests/test_dashboard_workspace.py
@@ -126,6 +126,41 @@ class TestWorkspaceProxy:
             assert resp.status_code == 400
 
     @pytest.mark.asyncio
+    async def test_observations_md_is_allowlisted(self):
+        """OBSERVATIONS.md is the operator's fleet-pulse data file — must be readable.
+
+        Regression: the file was missing from _WORKSPACE_ALLOWLIST, so the dashboard
+        Fleet pulse card permanently rendered the empty state.
+        """
+        observations_body = (
+            "# Fleet Observations\nUpdated: 2026-05-06T12:00:00Z\n\n"
+            '```json\n{"timestamp": "2026-05-06T12:00:00Z", "fleet_summary": "ok"}\n```\n'
+        )
+        transport = AsyncMock()
+        transport.request = AsyncMock(return_value={
+            "filename": "OBSERVATIONS.md", "content": observations_body,
+        })
+        app = _make_dashboard_app(
+            transport=transport, agent_registry={"operator": "http://localhost:8401"},
+        )
+        async with AsyncClient(
+            transport=ASGITransport(app=app), base_url="http://test",
+        ) as client:
+            resp = await client.get(
+                "/dashboard/api/agents/operator/workspace/OBSERVATIONS.md",
+            )
+            # Must NOT be 400 (the bug) — must be 200.
+            assert resp.status_code == 200, (
+                f"Expected 200 but got {resp.status_code}: {resp.text}"
+            )
+            payload = resp.json()
+            # Response must include `content` field — the JS parser reads data.content.
+            assert "content" in payload
+            assert payload["content"] == observations_body
+            # And the parser must be able to find the JSON block in `content`.
+            assert "```json" in payload["content"]
+
+    @pytest.mark.asyncio
     async def test_agent_not_found_returns_404(self):
         """Non-existent agent returns 404."""
         transport = AsyncMock()


### PR DESCRIPTION
## Summary

The operator agent runs a heartbeat fleet-health check (every ~30 min) and writes its observations to `OBSERVATIONS.md`. The dashboard already fetched and parsed that file every 5 minutes (see `app.js` `fleetDigest` state + `fetchFleetDigest()`), but the parsed data was **never rendered anywhere** — silently kept in state and discarded. This PR makes those observations visible.

### What changed

- **Fleet pulse card** at the top of the System tab, **above the sub-tab bar** so it persists across all System sub-tabs (`activity`, `costs`, `automation`, …). Renders `fleet_summary`, a per-agent attention list with severity icons (🔴 high, 🟡 medium, 🔵 low), the `cost_trend` line when present, and a "Drill in →" button per row that routes via the existing `drillDown(agent_id)`. Card has `role="region"` + `aria-label="Fleet pulse"`.
- **Top-nav badge** ("N agents need attention") in the right-side cluster of the main nav, **before** the existing fleet cost display. Hidden when `agents_attention` is empty. On `<sm` collapses to icon + number only. Click switches to System tab → scrolls to the Fleet pulse card. `aria-live="polite"` so screen readers announce changes.
- **Refresh button** on the card with a spinner state (350 ms minimum visible duration). Reuses the same `fetchFleetDigest()` path as the timer.
- **Widened auto-refresh** from chat-only to chat + system so the card stays fresh while it's being viewed.
- **Empty / never-run / all-quiet** placeholders so the card always reads sensibly.
- **Lenient parser** — nested try/catch around `JSON.parse`, transient network blips no longer clobber a previously-loaded digest.

### Data shape (from `src/agent/builtins/operator_tools.py:save_observations`)

The operator writes a JSON code-fenced block with these fields:

```json
{
  "timestamp": "2026-05-04T12:34:56+00:00",
  "fleet_summary": "5/6 healthy, cost stable",
  "agents_attention": [
    { "agent_id": "trend-scout", "issue": "no output for 7 days", "severity": "high" }
  ],
  "cost_trend": "stable",
  "notes": ""
}
```

Severity vocabulary (per render): `high`, `medium`, `low`, otherwise an empty/unknown circle. The card renders only the fields that exist (each guarded with `x-show` / `x-if`).

### Backend

No backend change. The operator already writes `OBSERVATIONS.md`, the dashboard already serves `/agents/operator/workspace/OBSERVATIONS.md` via the workspace endpoint.

## Test plan

- [x] `ruff check src/dashboard/` — All checks passed
- [x] `node --check src/dashboard/static/js/app.js` — JS OK
- [x] `pytest tests/test_dashboard.py` — 306 passed
- [x] `pytest tests/test_operator_tools.py tests/test_operator_e2e.py tests/test_operator_heartbeat.py` — 128 passed
- [x] Counted opening/closing tag pairs in the new template region — balanced
- [ ] Smoke test in browser: load dashboard, verify card hidden when no observations exist, seed an observation and verify card + badge appear, click "Drill in" → opens agent detail