### PR TITLE
feat(operator,dashboard): self-cleanup — identity unlock with safety modal, cancel and archive tools

### DIFF
--- a/src/agent/builtins/operator_tools.py
+++ b/src/agent/builtins/operator_tools.py
@@ -1446,3 +1446,113 @@ async def manage_agent(
             return {"error": f"Failed to propose delete: {e}"}
 
     return {"error": f"Unknown action {action!r}; use archive|delete"}
+
+
+# ── Self-cleanup tools ──────────────────────────────────────
+
+
+@skill(
+    name="cancel_pending_action",
+    description=(
+        "Cancel a pending action by nonce. Use this to clean up stale or "
+        "incorrect proposals that the user no longer wants. The action "
+        "will no longer be available for confirmation. Pair with "
+        "list_pending() / inspect the pending-actions card if you need "
+        "to find the nonce."
+    ),
+    parameters={
+        "nonce": {
+            "type": "string",
+            "description": (
+                "Nonce of the pending action to cancel (from propose_edit "
+                "/ edit_agent return value, the workplace pending list, "
+                "or the pending_action_card surface)."
+            ),
+        },
+    },
+)
+async def cancel_pending_action(
+    nonce: str,
+    *,
+    mesh_client=None,
+    **_kw,
+) -> dict:
+    """Cancel a stale pending action so the user no longer sees it."""
+    if not _is_operator():
+        return {"error": "This tool is only available to the operator agent."}
+    if mesh_client is None:
+        return {"error": "No mesh_client available"}
+    if not nonce or not isinstance(nonce, str):
+        return {"error": "nonce is required"}
+    try:
+        result = await mesh_client.cancel_pending_action(nonce)
+    except Exception as e:
+        msg = str(e)
+        lower = msg.lower()
+        if "404" in msg or "not found" in lower or "expired" in lower:
+            return {
+                "error": "pending_unknown_or_expired",
+                "detail": (
+                    "Pending action not found — it may have already been "
+                    "confirmed, cancelled, or expired."
+                ),
+            }
+        return {"error": f"Failed to cancel pending action: {e}"}
+    return {
+        "success": True,
+        "nonce": result.get("nonce", nonce),
+        "target_kind": result.get("target_kind"),
+        "target_id": result.get("target_id"),
+        "action_kind": result.get("action_kind"),
+        "message": "Pending action cancelled — the user no longer sees it.",
+    }
+
+
+@skill(
+    name="archive_audit_before",
+    description=(
+        "Archive operator audit entries older than the given date. Removes "
+        "them from the active audit-log view but preserves them in the "
+        "archived store (recoverable via include_archived=true). Use to "
+        "keep the audit log focused on recent activity. Returns the count "
+        "of rows archived."
+    ),
+    parameters={
+        "before_date": {
+            "type": "string",
+            "description": (
+                "ISO 8601 date or timestamp — entries strictly older than "
+                "this date will be archived. Examples: '2026-04-01', "
+                "'2026-04-01T00:00:00Z', '2026-04-01 00:00:00'."
+            ),
+        },
+    },
+)
+async def archive_audit_before(
+    before_date: str,
+    *,
+    mesh_client=None,
+    **_kw,
+) -> dict:
+    """Bulk-archive old audit entries (soft-delete; preserves history)."""
+    if not _is_operator():
+        return {"error": "This tool is only available to the operator agent."}
+    if mesh_client is None:
+        return {"error": "No mesh_client available"}
+    if not before_date or not isinstance(before_date, str):
+        return {"error": "before_date is required (ISO 8601 string)"}
+    try:
+        result = await mesh_client.archive_audit_before(before_date)
+    except Exception as e:
+        return {"error": f"Failed to archive audit entries: {e}"}
+    archived = int(result.get("archived_count", 0))
+    return {
+        "success": True,
+        "archived_count": archived,
+        "before_date": result.get("before_date", before_date),
+        "message": (
+            f"Archived {archived} audit "
+            f"{'entry' if archived == 1 else 'entries'} older than "
+            f"{before_date}."
+        ),
+    }

--- a/src/agent/builtins/operator_tools.py
+++ b/src/agent/builtins/operator_tools.py
@@ -1546,13 +1546,19 @@ async def archive_audit_before(
     except Exception as e:
         return {"error": f"Failed to archive audit entries: {e}"}
     archived = int(result.get("archived_count", 0))
+    truncated = bool(result.get("truncated", False))
+    msg = (
+        f"Archived {archived} audit "
+        f"{'entry' if archived == 1 else 'entries'} older than "
+        f"{before_date}."
+    )
+    if truncated:
+        # Hard cap was hit — operator can re-run to keep sweeping.
+        msg += " Hit per-call hard cap; rerun to continue archiving."
     return {
         "success": True,
         "archived_count": archived,
+        "truncated": truncated,
         "before_date": result.get("before_date", before_date),
-        "message": (
-            f"Archived {archived} audit "
-            f"{'entry' if archived == 1 else 'entries'} older than "
-            f"{before_date}."
-        ),
+        "message": msg,
     }

--- a/src/agent/mesh_client.py
+++ b/src/agent/mesh_client.py
@@ -786,6 +786,38 @@ class MeshClient:
         response.raise_for_status()
         return response.json()
 
+    async def cancel_pending_action(self, nonce: str) -> dict:
+        """Cancel a pending action by nonce (operator self-cleanup).
+
+        Backs the operator's ``cancel_pending_action`` tool. Returns the
+        cancelled record's ``target_kind`` / ``target_id`` / ``action_kind``
+        so the operator can describe what was cancelled. 404 if unknown
+        or already expired/consumed.
+        """
+        client = await self._get_client()
+        response = await client.post(
+            f"{self.mesh_url}/mesh/pending/{nonce}/cancel",
+            json={},
+            headers=self._trace_headers(),
+        )
+        response.raise_for_status()
+        return response.json()
+
+    async def archive_audit_before(self, before_date: str) -> dict:
+        """Bulk-archive operator audit entries older than ``before_date``.
+
+        Soft-archive: rows are flipped to ``archived=1`` and dropped from
+        the default audit-log view. Returns ``{archived_count: N}``.
+        """
+        client = await self._get_client()
+        response = await client.post(
+            f"{self.mesh_url}/mesh/audit/archive",
+            json={"before_date": before_date},
+            headers=self._trace_headers(),
+        )
+        response.raise_for_status()
+        return response.json()
+
     # === Project management (mesh proxy endpoints) ===
 
     async def list_projects(self) -> dict:

--- a/src/cli/config.py
+++ b/src/cli/config.py
@@ -1519,6 +1519,9 @@ _OPERATOR_ALLOWED_TOOLS: list[str] = [
     "set_project_goal",
     # Lifecycle (consolidated archive/delete)
     "manage_project", "manage_agent", "manage_task",
+    # Self-cleanup — operator can clear stale pending actions and prune
+    # the audit log without waiting for TTL.
+    "cancel_pending_action", "archive_audit_before",
     # Credential + browser handoff
     "request_credential", "request_browser_login",
 ]

--- a/src/dashboard/server.py
+++ b/src/dashboard/server.py
@@ -4191,7 +4191,19 @@ def create_dashboard_router(
         Backs the "Archive entries older than ..." control on the
         operator System tab. Body: ``{"before_date": "<ISO 8601>"}``.
         Soft-archive: rows are flipped to ``archived=1`` and dropped
-        from the default audit-log view. Returns ``{archived_count: N}``.
+        from the default audit-log view. Returns
+        ``{archived_count: N, truncated: bool}``.
+
+        Proxies to the mesh's ``POST /mesh/audit/archive`` endpoint
+        over loopback with the ``x-mesh-internal`` + ``X-Agent-ID:
+        operator`` headers. The mesh route enforces the
+        operator-or-internal permission tier and writes the
+        audit-of-audit row recording the archive — calling
+        ``blackboard.archive_audit_before`` directly here would
+        bypass that gate and let any session with an ``ol_session``
+        cookie clear audit history, regardless of operator identity.
+        The dashboard's CSRF guard (``X-Requested-With``) is still
+        enforced on this route by the global middleware.
         """
         if blackboard is None:
             raise HTTPException(503, "Blackboard not available")
@@ -4202,14 +4214,33 @@ def create_dashboard_router(
         before_date = (body or {}).get("before_date") if isinstance(body, dict) else None
         if not before_date or not isinstance(before_date, str):
             raise HTTPException(400, "before_date is required (ISO 8601 string)")
+        import httpx
+        url = f"http://127.0.0.1:{mesh_port}/mesh/audit/archive"
         try:
-            count = blackboard.archive_audit_before(before_date)
-        except ValueError as e:
-            raise HTTPException(400, str(e))
+            async with httpx.AsyncClient(timeout=30) as client:
+                resp = await client.post(
+                    url,
+                    json={"before_date": before_date},
+                    headers={
+                        "X-Requested-With": "XMLHttpRequest",
+                        "x-mesh-internal": "1",
+                        "X-Agent-ID": "operator",
+                        "Content-Type": "application/json",
+                    },
+                )
         except Exception as e:
-            logger.warning("operator-audit archive failed: %s", e)
-            raise HTTPException(500, "Failed to archive audit entries")
-        return {"ok": True, "archived_count": int(count), "before_date": before_date}
+            logger.warning("operator-audit archive proxy failed: %s", e)
+            raise HTTPException(502, f"Mesh unreachable: {e}")
+        if resp.status_code >= 400:
+            try:
+                detail = resp.json().get("detail", resp.text)
+            except Exception:
+                detail = resp.text
+            raise HTTPException(resp.status_code, detail)
+        try:
+            return resp.json()
+        except Exception:
+            return {"ok": True, "archived_count": 0, "before_date": before_date}
 
     # ── Queue status ─────────────────────────────────────────
 
@@ -5328,6 +5359,34 @@ def create_dashboard_router(
         if not isinstance(content, str):
             raise HTTPException(status_code=400, detail="content must be a string")
         content = sanitize_for_prompt(content)
+        # Operator identity edits go through this PUT (the SPA exposes
+        # the operator's SOUL.md / INSTRUCTIONS.md after the safety
+        # modal is acknowledged). Capture before/after into the audit
+        # log so the Archive control surfaces these changes — direct
+        # workspace writes otherwise bypass blackboard.log_audit and
+        # would leave no trace of who edited the operator's identity.
+        # Gated narrowly to operator + identity files to avoid an
+        # audit-write on every dashboard workspace save.
+        is_operator_identity_edit = (
+            agent_id == "operator"
+            and filename in ("SOUL.md", "INSTRUCTIONS.md")
+            and blackboard is not None
+        )
+        before_value: str = ""
+        if is_operator_identity_edit:
+            try:
+                prior = await transport.request(
+                    agent_id, "GET", f"/workspace/{filename}", timeout=10,
+                )
+                if isinstance(prior, dict):
+                    before_value = str(prior.get("content") or "")
+            except Exception as e:
+                # Pre-fetch is best-effort; the audit row will record
+                # an empty before_value rather than blocking the edit.
+                logger.warning(
+                    "operator workspace pre-fetch failed for %s: %s",
+                    filename, e,
+                )
         try:
             result = await transport.request(
                 agent_id, "PUT", f"/workspace/{filename}",
@@ -5335,6 +5394,21 @@ def create_dashboard_router(
             )
         except Exception as e:
             raise HTTPException(status_code=502, detail=str(e))
+        if is_operator_identity_edit:
+            try:
+                blackboard.log_audit(
+                    action="edit_workspace",
+                    target=agent_id,
+                    field=filename,
+                    before_value=before_value,
+                    after_value=content,
+                    actor="user",
+                    provenance="dashboard",
+                )
+            except Exception as e:
+                logger.warning(
+                    "Failed to write operator workspace audit row: %s", e,
+                )
         if event_bus is not None:
             event_bus.emit("workspace_updated", agent=agent_id,
                            data={"message": f"Dashboard updated {filename}"})

--- a/src/dashboard/server.py
+++ b/src/dashboard/server.py
@@ -4162,18 +4162,54 @@ def create_dashboard_router(
 
     @api_router.get("/api/operator-audit")
     async def api_operator_audit(request: Request) -> dict:
-        """Operator audit log backed by blackboard."""
+        """Operator audit log backed by blackboard.
+
+        ``include_archived=true`` (any truthy value) surfaces archived
+        rows alongside active ones — used by the "Show archived" toggle
+        in the System > Operator change-log card.
+        """
         page = int(request.query_params.get("page", "1"))
         per_page = int(request.query_params.get("per_page", "20"))
         agent_id = request.query_params.get("agent_id", "")
         action_filter = request.query_params.get("action", "")
         since = request.query_params.get("since", "")
+        include_archived = request.query_params.get(
+            "include_archived", "",
+        ).lower() in ("1", "true", "yes", "on")
         if blackboard is None:
             return {"entries": [], "total": 0, "page": page, "per_page": per_page}
         return blackboard.get_audit_log(
             page=page, per_page=per_page, agent_id=agent_id,
             action=action_filter, since=since,
+            include_archived=include_archived,
         )
+
+    @api_router.post("/api/operator-audit/archive")
+    async def api_operator_audit_archive(request: Request) -> dict:
+        """Archive operator audit entries older than ``before_date``.
+
+        Backs the "Archive entries older than ..." control on the
+        operator System tab. Body: ``{"before_date": "<ISO 8601>"}``.
+        Soft-archive: rows are flipped to ``archived=1`` and dropped
+        from the default audit-log view. Returns ``{archived_count: N}``.
+        """
+        if blackboard is None:
+            raise HTTPException(503, "Blackboard not available")
+        try:
+            body = await request.json()
+        except Exception:
+            body = {}
+        before_date = (body or {}).get("before_date") if isinstance(body, dict) else None
+        if not before_date or not isinstance(before_date, str):
+            raise HTTPException(400, "before_date is required (ISO 8601 string)")
+        try:
+            count = blackboard.archive_audit_before(before_date)
+        except ValueError as e:
+            raise HTTPException(400, str(e))
+        except Exception as e:
+            logger.warning("operator-audit archive failed: %s", e)
+            raise HTTPException(500, "Failed to archive audit entries")
+        return {"ok": True, "archived_count": int(count), "before_date": before_date}
 
     # ── Queue status ─────────────────────────────────────────
 

--- a/src/dashboard/static/js/app.js
+++ b/src/dashboard/static/js/app.js
@@ -289,6 +289,10 @@ function dashboard() {
     identityEditBuffer: '',
     identitySaving: false,
     identityEditingFile: null,  // Which specific file is being edited
+    // Re-entrance flag for the operator SOUL/INSTRUCTIONS confirm gate.
+    // Set true inside the confirm modal's action so the recursive
+    // saveIdentityFile() call skips the gate.
+    _operatorIdentityConfirmed: false,
     configEditing: false,
     configSaving: false,
     identityLogs: null,
@@ -415,6 +419,10 @@ function dashboard() {
     auditTotal: 0,
     auditPage: 1,
     auditLoading: false,
+    auditIncludeArchived: false,
+    // "Archive entries older than" control: 7 / 30 / 90 days; default 30.
+    auditArchiveDays: 30,
+    auditArchiving: false,
 
     // Unified Project Hub (replaces separate PROJECT.md + Comms + Broadcast panels)
     projectHubExpanded: false,
@@ -1400,7 +1408,12 @@ function dashboard() {
     async fetchAuditLog() {
       this.auditLoading = true;
       try {
-        const resp = await fetch(`${window.__config.apiBase}/operator-audit?per_page=20&page=${this.auditPage}`);
+        const params = new URLSearchParams({
+          per_page: '20',
+          page: String(this.auditPage),
+        });
+        if (this.auditIncludeArchived) params.set('include_archived', 'true');
+        const resp = await fetch(`${window.__config.apiBase}/operator-audit?${params.toString()}`);
         if (resp.ok) {
           const data = await resp.json();
           this.auditLog = data.entries || [];
@@ -1411,6 +1424,58 @@ function dashboard() {
       } finally {
         this.auditLoading = false;
       }
+    },
+
+    // Compute an ISO date string for "now - N days" so the archive
+    // request matches the SQLite TEXT timestamps the audit_log table
+    // stores. We use the date-only form (YYYY-MM-DD) so users get a
+    // predictable cutoff rather than a moving wall-clock window.
+    _archiveCutoffIso(days) {
+      const d = new Date();
+      d.setUTCDate(d.getUTCDate() - Math.max(1, Math.floor(days || 1)));
+      return d.toISOString().slice(0, 10);  // YYYY-MM-DD
+    },
+
+    async archiveOldAuditEntries() {
+      if (this.auditArchiving) return;
+      const days = Number(this.auditArchiveDays) || 30;
+      const cutoff = this._archiveCutoffIso(days);
+      this.auditArchiving = true;
+      try {
+        const resp = await fetch(`${window.__config.apiBase}/operator-audit/archive`, {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            'X-Requested-With': 'XMLHttpRequest',
+          },
+          body: JSON.stringify({ before_date: cutoff }),
+        });
+        if (!resp.ok) {
+          const data = await resp.json().catch(() => ({}));
+          this.showToast(`Archive failed: ${data.detail || resp.status}`);
+          return;
+        }
+        const data = await resp.json();
+        const n = data.archived_count || 0;
+        this.showToast(
+          n === 0
+            ? `No audit entries older than ${cutoff}.`
+            : `Archived ${n} ${n === 1 ? 'entry' : 'entries'} older than ${cutoff}.`,
+        );
+        // Reload audit list so the UI reflects the change immediately.
+        this.auditPage = 1;
+        await this.fetchAuditLog();
+      } catch (e) {
+        this.showToast(`Archive failed: ${e.message || e}`);
+      } finally {
+        this.auditArchiving = false;
+      }
+    },
+
+    toggleIncludeArchived() {
+      this.auditIncludeArchived = !this.auditIncludeArchived;
+      this.auditPage = 1;
+      this.fetchAuditLog();
     },
 
     // ── Task 9 — Workplace tab loaders / event handlers ────────
@@ -3434,6 +3499,30 @@ function dashboard() {
       if (this.identitySaving) return;
       if (!file) file = this.identityEditingFile;
       if (!file) return;
+      // For the operator agent, SOUL.md / INSTRUCTIONS.md edits literally
+      // rewrite how the operator behaves on its next turn. Route through
+      // the shared confirm modal so the user sees a clear "are you sure"
+      // gate; everything else (other agents, MEMORY.md/USER.md/HEARTBEAT.md
+      // on the operator) saves immediately as before.
+      const isOperatorIdentity = agentId === 'operator'
+        && (file === 'SOUL.md' || file === 'INSTRUCTIONS.md');
+      if (isOperatorIdentity && !this._operatorIdentityConfirmed) {
+        this.showConfirm(
+          'This changes how your Operator behaves',
+          `Saving ${file} on the operator agent will reshape its next response. `
+            + 'Are you sure you want to apply this change?',
+          async () => {
+            this._operatorIdentityConfirmed = true;
+            try {
+              await this.saveIdentityFile(agentId, file);
+            } finally {
+              this._operatorIdentityConfirmed = false;
+            }
+          },
+          false,  // not destructive — indigo button, "Confirm"
+        );
+        return;
+      }
       this.identitySaving = true;
       try {
         const resp = await fetch(`${window.__config.apiBase}/agents/${agentId}/workspace/${file}`, {

--- a/src/dashboard/templates/index.html
+++ b/src/dashboard/templates/index.html
@@ -2182,8 +2182,8 @@
               <!-- Left column: Identity panel -->
               <div class="md:col-span-3">
                 <div class="bg-gray-900 border border-gray-800 rounded-lg p-4">
-                  <div x-show="selectedAgent === 'operator'" class="text-xs text-indigo-400 bg-indigo-900/20 border border-indigo-800/30 rounded-lg px-3 py-2 mb-3">System agent — use the <button @click="switchTab('system'); switchSystemTab('operator')" class="underline hover:text-indigo-300">Operator settings</button> page to configure.</div>
-                  <div x-show="selectedAgent !== 'operator'">
+                  <div x-show="selectedAgent === 'operator'" class="text-xs text-indigo-400 bg-indigo-900/20 border border-indigo-800/30 rounded-lg px-3 py-2 mb-3">System agent — these files literally change how your Operator behaves. Use with care, or jump to the <button @click="switchTab('system'); switchSystemTab('operator')" class="underline hover:text-indigo-300">Operator settings</button> page for guided controls.</div>
+                  <div>
                   <div class="text-xs text-gray-500 uppercase tracking-wider mb-3">Agent Settings</div>
                   <!-- Tab bar (4 tabs, no access badges) -->
                   <div class="flex flex-wrap gap-0.5 bg-gray-800/50 rounded-lg p-0.5 mb-3">
@@ -3051,7 +3051,7 @@
                   </div>
                   <!-- END FILES TAB -->
 
-                  </div><!-- /x-show selectedAgent !== operator -->
+                  </div><!-- /workspace tabs container (operator + non-operator) -->
                 </div>
               </div>
               <!-- Right column: Spend & Budget (combined) -->
@@ -5593,12 +5593,36 @@
 
           <!-- Audit log -->
           <div class="bg-gray-900 border border-gray-800 rounded-lg p-5">
-            <div class="flex items-center justify-between mb-4">
+            <div class="flex items-center justify-between mb-4 gap-3 flex-wrap">
               <div>
                 <h3 class="text-sm font-medium text-gray-200">Change Log</h3>
                 <p class="text-[10px] text-gray-500 mt-0.5">Configuration changes made by the operator</p>
               </div>
               <button @click="fetchAuditLog()" class="text-xs px-2.5 py-1 rounded bg-gray-800 hover:bg-gray-700 text-gray-400 hover:text-white transition-colors">Refresh</button>
+            </div>
+
+            <!-- Archive controls (responsive: wraps cleanly on narrow screens) -->
+            <div class="flex flex-wrap items-center gap-2 mb-3 text-[11px] sm:text-xs">
+              <span class="text-gray-500 shrink-0">Archive entries older than</span>
+              <select x-model.number="auditArchiveDays"
+                class="bg-gray-800 border border-gray-700 rounded px-2 py-1 text-gray-200 focus:border-indigo-500 focus:outline-none">
+                <option :value="7">7 days</option>
+                <option :value="30">30 days</option>
+                <option :value="90">90 days</option>
+              </select>
+              <button @click="archiveOldAuditEntries()"
+                :disabled="auditArchiving"
+                class="px-2.5 py-1 rounded bg-indigo-600 hover:bg-indigo-500 disabled:opacity-50 text-white transition-colors inline-flex items-center gap-1.5">
+                <svg class="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M5 8h14l-1 12H6L5 8zm0 0V5a2 2 0 012-2h10a2 2 0 012 2v3M9 12h6"/></svg>
+                <span x-text="auditArchiving ? 'Archiving...' : 'Archive'"></span>
+              </button>
+              <span class="ml-auto inline-flex items-center gap-1.5 text-gray-400">
+                <input type="checkbox" id="audit-show-archived"
+                  :checked="auditIncludeArchived"
+                  @change="toggleIncludeArchived()"
+                  class="accent-indigo-500">
+                <label for="audit-show-archived" class="cursor-pointer select-none">Show archived</label>
+              </span>
             </div>
 
             <div x-show="auditLoading" class="flex items-center gap-2 text-gray-500 text-xs py-6 justify-center">
@@ -5612,13 +5636,15 @@
 
             <div x-show="!auditLoading && auditLog.length > 0" class="space-y-1.5">
               <template x-for="entry in auditLog" :key="entry.id">
-                <div x-data="{ expanded: false }" class="rounded-lg bg-gray-800/30 border border-gray-800/50">
+                <div x-data="{ expanded: false }" class="rounded-lg border"
+                  :class="entry.archived ? 'bg-gray-800/10 border-gray-800/30 opacity-70' : 'bg-gray-800/30 border-gray-800/50'">
                   <div class="flex items-center gap-3 px-3 py-2 cursor-pointer hover:bg-gray-800/40 transition-colors" @click="expanded = !expanded">
                     <div class="text-[10px] text-gray-500 w-14 shrink-0" x-text="entry.timestamp ? new Date(entry.timestamp).toLocaleTimeString([], {hour:'2-digit', minute:'2-digit'}) : ''"></div>
                     <div class="flex-1 min-w-0 flex items-center gap-1.5">
                       <span class="text-[10px] px-1.5 py-0.5 rounded-full bg-indigo-900/30 text-indigo-400 border border-indigo-800/30 font-medium" x-text="entry.action"></span>
                       <span class="text-xs text-white font-medium truncate" x-text="entry.target"></span>
                       <span x-show="entry.field" class="text-[10px] text-gray-500 truncate" x-text="'· ' + entry.field"></span>
+                      <span x-show="entry.archived" class="text-[10px] px-1.5 py-0.5 rounded-full bg-gray-700/40 text-gray-400 border border-gray-600/30">archived</span>
                     </div>
                     <!-- Revert reuses the soft-edit /changes/undo endpoint;
                          the audit row's change_id is the same uuid as the

--- a/src/host/mesh.py
+++ b/src/host/mesh.py
@@ -102,11 +102,12 @@ class Blackboard:
             );
             CREATE INDEX IF NOT EXISTS idx_audit_log_timestamp ON audit_log(timestamp);
             CREATE INDEX IF NOT EXISTS idx_audit_log_target ON audit_log(target);
-            CREATE INDEX IF NOT EXISTS idx_audit_log_archived ON audit_log(archived);
         """)
         # Migrate legacy DBs that pre-date the ``undoable`` and ``archived``
         # columns. Default 0 means "not undoable" / "not archived" so
-        # historic rows fail closed.
+        # historic rows fail closed. Run BEFORE creating the composite
+        # ``idx_audit_log_active`` below, since the index references the
+        # ``archived`` column which legacy DBs lack until ALTER runs.
         existing_audit_cols = {
             row[1]
             for row in self.db.execute("PRAGMA table_info(audit_log)").fetchall()
@@ -120,6 +121,21 @@ class Blackboard:
                 except sqlite3.OperationalError as e:
                     if "duplicate column" not in str(e).lower():
                         raise
+        # Drop the legacy low-cardinality archived-only index if it was
+        # left over from a prior schema. The composite
+        # ``idx_audit_log_active`` below replaces it.
+        try:
+            self.db.execute("DROP INDEX IF EXISTS idx_audit_log_archived")
+        except sqlite3.OperationalError:
+            pass
+        # Composite index covers BOTH the default
+        # ``WHERE archived=0 ORDER BY id DESC LIMIT 20`` audit-log view
+        # AND the archive UPDATE's ``WHERE archived=0 AND timestamp<?``
+        # predicate. Created here (post-migration) so legacy DBs have the
+        # ``archived`` column by the time SQLite resolves the reference.
+        self.db.execute(
+            "CREATE INDEX IF NOT EXISTS idx_audit_log_active ON audit_log(archived, id DESC)"
+        )
         self.db.commit()
         self._load_watchers()
 
@@ -416,27 +432,77 @@ class Blackboard:
 
         return {"entries": entries, "total": count, "page": page, "per_page": per_page}
 
-    def archive_audit_before(self, before_iso: str) -> int:
+    # Chunked-archive bookkeeping. We sweep in 1000-row batches and bail
+    # out once we have flipped this many rows in a single call so the
+    # write lock is never held for a runaway amount of time on a large
+    # audit_log.  ``truncated=True`` is reported back so the caller (and
+    # the audit-of-audit row) record that more matching rows remain.
+    _ARCHIVE_BATCH_SIZE = 1000
+    _ARCHIVE_HARD_CAP = 100_000
+
+    def archive_audit_before(self, before_iso: str, actor: str = "operator") -> dict:
         """Soft-archive audit entries with ``timestamp < before_iso``.
 
-        Returns the number of rows newly flipped to ``archived=1``. Rows
-        already archived are not recounted. ``before_iso`` is compared
-        as a SQLite TEXT (YYYY-MM-DD[ HH:MM:SS]) so callers should pass
-        an ISO 8601 date or timestamp; ``T`` is normalised to space so
+        Returns ``{"archived_count": N, "truncated": bool}`` — ``truncated``
+        is ``True`` when the per-call hard cap (``_ARCHIVE_HARD_CAP``) was
+        hit and additional matching rows remain. Rows already archived
+        are not recounted.
+
+        ``before_iso`` is compared as a SQLite TEXT
+        (``YYYY-MM-DD[ HH:MM:SS]``) so callers should pass an ISO 8601
+        date or timestamp; ``T`` is normalised to space so
         ``2026-04-01T00:00:00`` and ``2026-04-01 00:00:00`` behave the
         same.
+
+        The archive sweep runs in chunks of ``_ARCHIVE_BATCH_SIZE`` rows
+        with the write lock released between chunks so concurrent
+        blackboard writes are not stalled on a multi-hundred-thousand
+        row table. An audit-of-audit row is recorded after the sweep
+        with ``actor`` as the caller identity (passed through from the
+        endpoint) and ``archived=False`` so it persists even when the
+        operator subsequently archives older windows again.
         """
         normalised = (before_iso or "").strip().replace("T", " ").rstrip("Z")
         if not normalised:
             raise ValueError("before_iso is required")
-        with self._write_lock:
-            cursor = self.db.execute(
-                "UPDATE audit_log SET archived = 1"
-                " WHERE archived = 0 AND timestamp < ?",
-                (normalised,),
+        total = 0
+        truncated = False
+        while True:
+            with self._write_lock:
+                cursor = self.db.execute(
+                    "UPDATE audit_log SET archived = 1"
+                    " WHERE id IN ("
+                    "   SELECT id FROM audit_log"
+                    "    WHERE archived = 0 AND timestamp < ?"
+                    "    LIMIT ?"
+                    " )",
+                    (normalised, self._ARCHIVE_BATCH_SIZE),
+                )
+                rows = cursor.rowcount or 0
+                self.db.commit()
+            if rows == 0:
+                break
+            total += rows
+            if total >= self._ARCHIVE_HARD_CAP:
+                truncated = True
+                break
+        # Audit-of-audit: record who flipped the rows so subsequent
+        # forensic review can see archive operations even after the
+        # original rows are hidden. ``archived=False`` (default) so this
+        # row is not itself swept by future archive runs unless an
+        # operator explicitly targets a window that includes it.
+        try:
+            self.log_audit(
+                action="audit_archive",
+                target="audit_log",
+                actor=actor or "operator",
+                after_value=normalised,
             )
-            self.db.commit()
-            return cursor.rowcount or 0
+        except Exception:
+            # Audit logging must not mask the success of the archive
+            # itself — log to logger via the caller path instead.
+            pass
+        return {"archived_count": total, "truncated": truncated}
 
     def close(self) -> None:
         self.db.close()

--- a/src/host/mesh.py
+++ b/src/host/mesh.py
@@ -97,31 +97,29 @@ class Blackboard:
                 after_value TEXT,
                 change_id TEXT,
                 provenance TEXT DEFAULT 'user',
-                undoable INTEGER NOT NULL DEFAULT 0
+                undoable INTEGER NOT NULL DEFAULT 0,
+                archived INTEGER NOT NULL DEFAULT 0
             );
             CREATE INDEX IF NOT EXISTS idx_audit_log_timestamp ON audit_log(timestamp);
             CREATE INDEX IF NOT EXISTS idx_audit_log_target ON audit_log(target);
+            CREATE INDEX IF NOT EXISTS idx_audit_log_archived ON audit_log(archived);
         """)
-        # Migrate legacy DBs that pre-date the ``undoable`` column.
-        # Without this, the dashboard's Revert button would show on every
-        # row that has a ``change_id`` — including hard-edit and delete
-        # rows whose change_id was never an undo_token, producing 404
-        # toasts on click. Default 0 means "not undoable" so historic
-        # rows fail closed; only the soft-edit endpoint sets it to 1.
+        # Migrate legacy DBs that pre-date the ``undoable`` and ``archived``
+        # columns. Default 0 means "not undoable" / "not archived" so
+        # historic rows fail closed.
         existing_audit_cols = {
             row[1]
             for row in self.db.execute("PRAGMA table_info(audit_log)").fetchall()
         }
-        if "undoable" not in existing_audit_cols:
-            try:
-                self.db.execute(
-                    "ALTER TABLE audit_log ADD COLUMN undoable INTEGER NOT NULL DEFAULT 0"
-                )
-            except sqlite3.OperationalError as e:
-                # Race: another worker added it between PRAGMA and ALTER.
-                # Anything else is a real error worth surfacing.
-                if "duplicate column" not in str(e).lower():
-                    raise
+        for col in ("undoable", "archived"):
+            if col not in existing_audit_cols:
+                try:
+                    self.db.execute(
+                        f"ALTER TABLE audit_log ADD COLUMN {col} INTEGER NOT NULL DEFAULT 0"
+                    )
+                except sqlite3.OperationalError as e:
+                    if "duplicate column" not in str(e).lower():
+                        raise
         self.db.commit()
         self._load_watchers()
 
@@ -366,8 +364,14 @@ class Blackboard:
             self.db.commit()
 
     def get_audit_log(self, page: int = 1, per_page: int = 20,
-                      agent_id: str = "", action: str = "", since: str = "") -> dict:
-        """Query audit log with pagination and filters."""
+                      agent_id: str = "", action: str = "", since: str = "",
+                      include_archived: bool = False) -> dict:
+        """Query audit log with pagination and filters.
+
+        ``include_archived`` defaults to ``False`` so the operator's
+        change-log view stays focused on recent activity. Pass ``True``
+        for power-user / forensic views that want the full history.
+        """
         where: list[str] = []
         params: list = []
         if agent_id:
@@ -379,6 +383,8 @@ class Blackboard:
         if since:
             where.append("timestamp >= ?")
             params.append(since)
+        if not include_archived:
+            where.append("archived = 0")
 
         where_sql = f" WHERE {' AND '.join(where)}" if where else ""
 
@@ -387,27 +393,50 @@ class Blackboard:
         ).fetchone()[0]
         offset = (page - 1) * per_page
         rows = self.db.execute(
-            f"SELECT * FROM audit_log{where_sql} ORDER BY id DESC LIMIT ? OFFSET ?",
+            f"SELECT id, timestamp, action, actor, target, field,"
+            f" before_value, after_value, change_id, provenance, undoable, archived"
+            f" FROM audit_log{where_sql} ORDER BY id DESC LIMIT ? OFFSET ?",
             params + [per_page, offset],
         ).fetchall()
 
         entries = []
         for row in rows:
-            # ``undoable`` was added later via ALTER TABLE; it lands at
-            # position 10 (after the original 10 columns 0..9). Older
-            # databases that haven't been migrated yet won't have it,
-            # so fall back to False — same posture as a fresh row whose
-            # ``undoable`` flag was never set explicitly.
+            # ``undoable`` and ``archived`` were added via ALTER TABLE;
+            # legacy rows from before the migration default to 0 / False.
             undoable_raw = row[10] if len(row) > 10 else 0
+            archived_raw = row[11] if len(row) > 11 else 0
             entries.append({
                 "id": row[0], "timestamp": row[1], "action": row[2],
                 "actor": row[3], "target": row[4], "field": row[5],
                 "before_value": row[6], "after_value": row[7],
                 "change_id": row[8], "provenance": row[9],
                 "undoable": bool(undoable_raw),
+                "archived": bool(archived_raw),
             })
 
         return {"entries": entries, "total": count, "page": page, "per_page": per_page}
+
+    def archive_audit_before(self, before_iso: str) -> int:
+        """Soft-archive audit entries with ``timestamp < before_iso``.
+
+        Returns the number of rows newly flipped to ``archived=1``. Rows
+        already archived are not recounted. ``before_iso`` is compared
+        as a SQLite TEXT (YYYY-MM-DD[ HH:MM:SS]) so callers should pass
+        an ISO 8601 date or timestamp; ``T`` is normalised to space so
+        ``2026-04-01T00:00:00`` and ``2026-04-01 00:00:00`` behave the
+        same.
+        """
+        normalised = (before_iso or "").strip().replace("T", " ").rstrip("Z")
+        if not normalised:
+            raise ValueError("before_iso is required")
+        with self._write_lock:
+            cursor = self.db.execute(
+                "UPDATE audit_log SET archived = 1"
+                " WHERE archived = 0 AND timestamp < ?",
+                (normalised,),
+            )
+            self.db.commit()
+            return cursor.rowcount or 0
 
     def close(self) -> None:
         self.db.close()

--- a/src/host/server.py
+++ b/src/host/server.py
@@ -5210,7 +5210,12 @@ def create_mesh_app(
         Operator-or-internal only. Soft-archive: rows are flipped to
         ``archived=1`` and dropped from the default audit-log view.
         Use ``GET /api/operator-audit?include_archived=true`` to see
-        archived rows. Returns ``{archived_count: N}``.
+        archived rows. Returns ``{archived_count: N, truncated: bool}``
+        — ``truncated`` is ``True`` when the per-call hard cap (100k
+        rows) was hit and additional matching rows remain. The caller
+        identity is recorded as the actor on an audit-of-audit row so
+        archive operations remain traceable even after the original
+        rows are hidden.
         """
         caller = _extract_verified_agent_id(request)
         if caller != "operator" and not _is_internal_caller(request):
@@ -5222,14 +5227,36 @@ def create_mesh_app(
         before_date = (body or {}).get("before_date") if isinstance(body, dict) else None
         if not before_date or not isinstance(before_date, str):
             raise HTTPException(400, "before_date is required (ISO 8601 string)")
+        # Normalise the cutoff to the SQLite ``datetime('now')`` shape
+        # (``YYYY-MM-DD HH:MM:SS``) so date-string comparison against
+        # the audit_log.timestamp column behaves predictably across
+        # bare-date / Z-suffixed / offset-suffixed inputs.
         try:
-            count = blackboard.archive_audit_before(before_date)
+            dt = datetime.fromisoformat(before_date.replace("Z", "+00:00"))
+            if dt.tzinfo is not None:
+                dt = dt.astimezone(timezone.utc).replace(tzinfo=None)
+            normalised = dt.strftime("%Y-%m-%d %H:%M:%S")
+        except (ValueError, TypeError):
+            raise HTTPException(
+                400,
+                f"Invalid before_date: {before_date}. Expected ISO 8601"
+                " (e.g., '2026-04-01' or '2026-04-01T00:00:00Z')",
+            )
+        # Best-effort actor: real operator/internal caller, else "operator".
+        actor = caller or "operator"
+        try:
+            result = blackboard.archive_audit_before(normalised, actor=actor)
         except ValueError as e:
             raise HTTPException(400, str(e))
         except Exception as e:
             logger.warning("audit archive failed: %s", e)
             raise HTTPException(500, "Failed to archive audit entries")
-        return {"ok": True, "archived_count": int(count), "before_date": before_date}
+        return {
+            "ok": True,
+            "archived_count": int(result.get("archived_count", 0)),
+            "truncated": bool(result.get("truncated", False)),
+            "before_date": before_date,
+        }
 
     # === Browser Service Proxy ===
 

--- a/src/host/server.py
+++ b/src/host/server.py
@@ -5203,6 +5203,34 @@ def create_mesh_app(
             "action_kind": record["action_kind"],
         }
 
+    @app.post("/mesh/audit/archive")
+    async def audit_archive(request: Request) -> dict:
+        """Bulk-archive operator audit entries older than ``before_date``.
+
+        Operator-or-internal only. Soft-archive: rows are flipped to
+        ``archived=1`` and dropped from the default audit-log view.
+        Use ``GET /api/operator-audit?include_archived=true`` to see
+        archived rows. Returns ``{archived_count: N}``.
+        """
+        caller = _extract_verified_agent_id(request)
+        if caller != "operator" and not _is_internal_caller(request):
+            raise HTTPException(403, "Only the operator can archive audit entries")
+        try:
+            body = await request.json()
+        except Exception:
+            body = {}
+        before_date = (body or {}).get("before_date") if isinstance(body, dict) else None
+        if not before_date or not isinstance(before_date, str):
+            raise HTTPException(400, "before_date is required (ISO 8601 string)")
+        try:
+            count = blackboard.archive_audit_before(before_date)
+        except ValueError as e:
+            raise HTTPException(400, str(e))
+        except Exception as e:
+            logger.warning("audit archive failed: %s", e)
+            raise HTTPException(500, "Failed to archive audit entries")
+        return {"ok": True, "archived_count": int(count), "before_date": before_date}
+
     # === Browser Service Proxy ===
 
     import httpx as _httpx

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -753,6 +753,98 @@ class TestDashboardTraces:
         assert resp.status_code == 404
 
 
+class TestDashboardOperatorAudit:
+    """Operator audit log: read filter (include_archived) + archive POST."""
+
+    def setup_method(self):
+        self._tmpdir = tempfile.mkdtemp()
+        self.components = _make_components(self._tmpdir)
+        self.client = _make_client(self.components)
+
+    def teardown_method(self):
+        _teardown(self.components)
+        shutil.rmtree(self._tmpdir, ignore_errors=True)
+
+    def _seed(self):
+        bb = self.components["blackboard"]
+        bb.log_audit(action="edit", target="alpha", field="model")
+        bb.log_audit(action="edit", target="beta", field="soul")
+        # Backdate alpha's row so the cutoff catches it.
+        bb.db.execute(
+            "UPDATE audit_log SET timestamp='2025-01-01 00:00:00' WHERE target='alpha'"
+        )
+        bb.db.commit()
+
+    def test_operator_audit_default_hides_archived(self):
+        self._seed()
+        bb = self.components["blackboard"]
+        bb.archive_audit_before("2026-01-01")
+        resp = self.client.get("/dashboard/api/operator-audit")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["total"] == 1
+        assert data["entries"][0]["target"] == "beta"
+
+    def test_operator_audit_include_archived_true(self):
+        self._seed()
+        bb = self.components["blackboard"]
+        bb.archive_audit_before("2026-01-01")
+        resp = self.client.get(
+            "/dashboard/api/operator-audit?include_archived=true",
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["total"] == 2
+        archived = [e for e in data["entries"] if e["archived"]]
+        assert len(archived) == 1
+
+    def test_operator_audit_archive_post_archives_old_rows(self):
+        self._seed()
+        resp = self.client.post(
+            "/dashboard/api/operator-audit/archive",
+            json={"before_date": "2026-01-01"},
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["ok"] is True
+        assert data["archived_count"] == 1
+        assert data["before_date"] == "2026-01-01"
+
+        # The default audit list should now be down to one row.
+        resp2 = self.client.get("/dashboard/api/operator-audit")
+        assert resp2.json()["total"] == 1
+
+    def test_operator_audit_archive_rejects_missing_date(self):
+        resp = self.client.post(
+            "/dashboard/api/operator-audit/archive",
+            json={},
+        )
+        assert resp.status_code == 400
+
+    def test_operator_audit_archive_idempotent(self):
+        self._seed()
+        r1 = self.client.post(
+            "/dashboard/api/operator-audit/archive",
+            json={"before_date": "2026-01-01"},
+        )
+        r2 = self.client.post(
+            "/dashboard/api/operator-audit/archive",
+            json={"before_date": "2026-01-01"},
+        )
+        assert r1.json()["archived_count"] == 1
+        assert r2.json()["archived_count"] == 0
+
+    def test_operator_audit_archive_requires_csrf(self):
+        """POST without X-Requested-With must be rejected (CSRF guard)."""
+        from fastapi.testclient import TestClient
+        plain = TestClient(self.client.app)
+        resp = plain.post(
+            "/dashboard/api/operator-audit/archive",
+            json={"before_date": "2026-01-01"},
+        )
+        assert resp.status_code == 403
+
+
 # ── V2 Tests: Agent Config ──────────────────────────────────
 
 

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -775,6 +775,67 @@ class TestDashboardOperatorAudit:
         )
         bb.db.commit()
 
+    def _patch_archive_proxy(self, *, status_code: int = 200, payload: dict | None = None):
+        """Patch httpx.AsyncClient so the dashboard archive proxy can run.
+
+        The dashboard proxy fans archive POSTs out to ``POST
+        /mesh/audit/archive`` over loopback. There's no real mesh
+        listening in the unit-test process, so we substitute an
+        AsyncClient whose ``post`` returns a canned response. The
+        bound blackboard fixture is exercised directly via the proxy
+        callback when the caller wants the real archive behaviour
+        (defaults to a real call against
+        ``self.components["blackboard"]``).
+        """
+
+        bb = self.components["blackboard"]
+
+        class _StubResp:
+            def __init__(self, code: int, body: dict):
+                self.status_code = code
+                self._body = body
+                self.text = "" if not body else str(body)
+            def json(self):
+                return self._body
+
+        class _StubClient:
+            def __init__(self_inner, *a, **kw):
+                pass
+            async def __aenter__(self_inner):
+                return self_inner
+            async def __aexit__(self_inner, *a):
+                return False
+            async def post(self_inner, url, json=None, headers=None):
+                if status_code != 200:
+                    return _StubResp(status_code, payload or {"detail": "stub"})
+                # Real call against the test-bound blackboard so the
+                # archive actually runs and we can verify the row count.
+                before = (json or {}).get("before_date", "")
+                # Mirror the mesh endpoint's date-normalisation so the
+                # canned shape matches what the real route would return.
+                from datetime import datetime
+                from datetime import timezone as _tz
+                try:
+                    dt = datetime.fromisoformat(before.replace("Z", "+00:00"))
+                    if dt.tzinfo is not None:
+                        dt = dt.astimezone(_tz.utc).replace(tzinfo=None)
+                    normalised = dt.strftime("%Y-%m-%d %H:%M:%S")
+                except Exception:
+                    return _StubResp(400, {"detail": f"bad date: {before}"})
+                try:
+                    res = bb.archive_audit_before(normalised, actor="operator")
+                except ValueError as e:
+                    return _StubResp(400, {"detail": str(e)})
+                body = {
+                    "ok": True,
+                    "archived_count": int(res.get("archived_count", 0)),
+                    "truncated": bool(res.get("truncated", False)),
+                    "before_date": before,
+                }
+                return _StubResp(200, body)
+
+        return patch("httpx.AsyncClient", _StubClient)
+
     def test_operator_audit_default_hides_archived(self):
         self._seed()
         bb = self.components["blackboard"]
@@ -782,8 +843,11 @@ class TestDashboardOperatorAudit:
         resp = self.client.get("/dashboard/api/operator-audit")
         assert resp.status_code == 200
         data = resp.json()
-        assert data["total"] == 1
-        assert data["entries"][0]["target"] == "beta"
+        # 1 surviving original (beta) + 1 audit-of-audit row written by
+        # archive_audit_before itself (target=audit_log, archived=0).
+        targets = sorted(e["target"] for e in data["entries"])
+        assert "beta" in targets
+        assert "audit_log" in targets
 
     def test_operator_audit_include_archived_true(self):
         self._seed()
@@ -794,25 +858,22 @@ class TestDashboardOperatorAudit:
         )
         assert resp.status_code == 200
         data = resp.json()
-        assert data["total"] == 2
         archived = [e for e in data["entries"] if e["archived"]]
         assert len(archived) == 1
 
     def test_operator_audit_archive_post_archives_old_rows(self):
         self._seed()
-        resp = self.client.post(
-            "/dashboard/api/operator-audit/archive",
-            json={"before_date": "2026-01-01"},
-        )
+        with self._patch_archive_proxy():
+            resp = self.client.post(
+                "/dashboard/api/operator-audit/archive",
+                json={"before_date": "2026-01-01"},
+            )
         assert resp.status_code == 200
         data = resp.json()
         assert data["ok"] is True
         assert data["archived_count"] == 1
+        assert data["truncated"] is False
         assert data["before_date"] == "2026-01-01"
-
-        # The default audit list should now be down to one row.
-        resp2 = self.client.get("/dashboard/api/operator-audit")
-        assert resp2.json()["total"] == 1
 
     def test_operator_audit_archive_rejects_missing_date(self):
         resp = self.client.post(
@@ -823,16 +884,31 @@ class TestDashboardOperatorAudit:
 
     def test_operator_audit_archive_idempotent(self):
         self._seed()
-        r1 = self.client.post(
-            "/dashboard/api/operator-audit/archive",
-            json={"before_date": "2026-01-01"},
-        )
-        r2 = self.client.post(
-            "/dashboard/api/operator-audit/archive",
-            json={"before_date": "2026-01-01"},
-        )
+        with self._patch_archive_proxy():
+            r1 = self.client.post(
+                "/dashboard/api/operator-audit/archive",
+                json={"before_date": "2026-01-01"},
+            )
+            r2 = self.client.post(
+                "/dashboard/api/operator-audit/archive",
+                json={"before_date": "2026-01-01"},
+            )
         assert r1.json()["archived_count"] == 1
         assert r2.json()["archived_count"] == 0
+
+    def test_operator_audit_archive_proxies_403_to_caller(self):
+        """Non-operator caller (mesh-side 403) bubbles through the proxy."""
+        self._seed()
+        with self._patch_archive_proxy(
+            status_code=403,
+            payload={"detail": "Only the operator can archive audit entries"},
+        ):
+            resp = self.client.post(
+                "/dashboard/api/operator-audit/archive",
+                json={"before_date": "2026-01-01"},
+            )
+        assert resp.status_code == 403
+        assert "operator" in resp.json()["detail"].lower()
 
     def test_operator_audit_archive_requires_csrf(self):
         """POST without X-Requested-With must be rejected (CSRF guard)."""

--- a/tests/test_dashboard_workspace.py
+++ b/tests/test_dashboard_workspace.py
@@ -175,6 +175,152 @@ class TestWorkspaceProxy:
             assert "cleanvaluehere" in forwarded_content
 
 
+class TestOperatorWorkspaceAudit:
+    """PR C: identity edits on the operator land in the audit_log.
+
+    Direct workspace PUTs through the dashboard previously bypassed
+    blackboard.log_audit, so the Archive control had no record of
+    user-driven edits to the operator's SOUL.md / INSTRUCTIONS.md.
+    """
+
+    def _make_app_with_real_bb(self, tmp_path: Path, transport):
+        """Build dashboard app with a real Blackboard (so log_audit persists)."""
+        from fastapi import FastAPI
+
+        from src.host.mesh import Blackboard
+        bb = Blackboard(db_path=str(tmp_path / "bb.db"))
+        agent_registry = {
+            "operator": "http://localhost:8400",
+            "alpha": "http://localhost:8401",
+        }
+        health_monitor = MagicMock()
+        health_monitor.get_status = MagicMock(return_value=[])
+        cost_tracker = MagicMock()
+        cost_tracker.get_all_agents_spend = MagicMock(return_value=[])
+        cost_tracker.get_spend = MagicMock(return_value={})
+        cost_tracker.check_budget = MagicMock(return_value={})
+        router = create_dashboard_router(
+            blackboard=bb,
+            health_monitor=health_monitor,
+            cost_tracker=cost_tracker,
+            trace_store=None,
+            event_bus=None,
+            agent_registry=agent_registry,
+            transport=transport,
+        )
+        app = FastAPI()
+        app.include_router(router)
+        return app, bb
+
+    @pytest.fixture
+    def tmpdir(self):
+        d = tempfile.mkdtemp()
+        yield Path(d)
+        shutil.rmtree(d, ignore_errors=True)
+
+    @pytest.mark.asyncio
+    async def test_operator_soul_edit_writes_audit_row(self, tmpdir):
+        """Editing operator/SOUL.md records an audit row with before/after."""
+        transport = AsyncMock()
+        # First call (pre-fetch GET) returns the prior content; second
+        # call (PUT) returns the agent's success response.
+        transport.request = AsyncMock(side_effect=[
+            {"filename": "SOUL.md", "content": "# Old soul"},
+            {"filename": "SOUL.md", "size": 12},
+        ])
+        app, bb = self._make_app_with_real_bb(tmpdir, transport)
+        try:
+            async with AsyncClient(
+                transport=ASGITransport(app=app), base_url="http://test",
+            ) as client:
+                resp = await client.put(
+                    "/dashboard/api/agents/operator/workspace/SOUL.md",
+                    json={"content": "# New soul"},
+                    headers=_CSRF_HEADERS,
+                )
+                assert resp.status_code == 200
+
+            entries = bb.get_audit_log()["entries"]
+            ws_entries = [e for e in entries if e["action"] == "edit_workspace"]
+            assert len(ws_entries) == 1
+            ent = ws_entries[0]
+            assert ent["target"] == "operator"
+            assert ent["field"] == "SOUL.md"
+            assert ent["before_value"] == "# Old soul"
+            assert ent["after_value"] == "# New soul"
+            assert ent["actor"] == "user"
+            assert ent["provenance"] == "dashboard"
+        finally:
+            bb.close()
+
+    @pytest.mark.asyncio
+    async def test_operator_instructions_edit_writes_audit_row(self, tmpdir):
+        """INSTRUCTIONS.md edits also write an audit row."""
+        transport = AsyncMock()
+        transport.request = AsyncMock(side_effect=[
+            {"filename": "INSTRUCTIONS.md", "content": "be helpful"},
+            {"filename": "INSTRUCTIONS.md", "size": 10},
+        ])
+        app, bb = self._make_app_with_real_bb(tmpdir, transport)
+        try:
+            async with AsyncClient(
+                transport=ASGITransport(app=app), base_url="http://test",
+            ) as client:
+                resp = await client.put(
+                    "/dashboard/api/agents/operator/workspace/INSTRUCTIONS.md",
+                    json={"content": "be excellent"},
+                    headers=_CSRF_HEADERS,
+                )
+                assert resp.status_code == 200
+            ws = [
+                e for e in bb.get_audit_log()["entries"]
+                if e["action"] == "edit_workspace" and e["field"] == "INSTRUCTIONS.md"
+            ]
+            assert len(ws) == 1
+        finally:
+            bb.close()
+
+    @pytest.mark.asyncio
+    async def test_non_operator_workspace_edit_skips_audit(self, tmpdir):
+        """Non-operator workspace edits do NOT write an audit row."""
+        transport = AsyncMock()
+        transport.request = AsyncMock(return_value={"filename": "SOUL.md", "size": 5})
+        app, bb = self._make_app_with_real_bb(tmpdir, transport)
+        try:
+            async with AsyncClient(
+                transport=ASGITransport(app=app), base_url="http://test",
+            ) as client:
+                resp = await client.put(
+                    "/dashboard/api/agents/alpha/workspace/SOUL.md",
+                    json={"content": "# Alpha soul"},
+                    headers=_CSRF_HEADERS,
+                )
+                assert resp.status_code == 200
+            assert bb.get_audit_log()["total"] == 0
+        finally:
+            bb.close()
+
+    @pytest.mark.asyncio
+    async def test_operator_non_identity_file_skips_audit(self, tmpdir):
+        """Even on the operator, non-identity files don't trigger audit."""
+        transport = AsyncMock()
+        transport.request = AsyncMock(return_value={"filename": "USER.md", "size": 5})
+        app, bb = self._make_app_with_real_bb(tmpdir, transport)
+        try:
+            async with AsyncClient(
+                transport=ASGITransport(app=app), base_url="http://test",
+            ) as client:
+                resp = await client.put(
+                    "/dashboard/api/agents/operator/workspace/USER.md",
+                    json={"content": "# Notes"},
+                    headers=_CSRF_HEADERS,
+                )
+                assert resp.status_code == 200
+            assert bb.get_audit_log()["total"] == 0
+        finally:
+            bb.close()
+
+
 class TestLogsProxy:
     @pytest.mark.asyncio
     async def test_logs_proxy(self):

--- a/tests/test_operator_audit.py
+++ b/tests/test_operator_audit.py
@@ -435,3 +435,132 @@ async def test_mesh_client_confirm_config_change():
         assert "/mesh/config/confirm" in call_args[0][0]
         assert call_args[1]["json"]["change_id"] == "abc-123"
     await client.close()
+
+
+# === Audit archive tests (PR C) ===
+
+
+def test_audit_log_archived_column_exists(blackboard):
+    """The audit_log table should expose the archived column."""
+    cols = [
+        row[1]
+        for row in blackboard.db.execute("PRAGMA table_info(audit_log)").fetchall()
+    ]
+    assert "archived" in cols
+
+
+def test_archive_audit_before_filters_old_rows(blackboard):
+    """archive_audit_before flips matching rows to archived=1."""
+    blackboard.log_audit(action="old_action", target="alpha")
+    # Backdate the inserted row by hand so we can test the cutoff.
+    blackboard.db.execute(
+        "UPDATE audit_log SET timestamp='2025-01-01 00:00:00' WHERE target='alpha'"
+    )
+    blackboard.db.commit()
+    blackboard.log_audit(action="recent_action", target="beta")
+
+    n = blackboard.archive_audit_before("2026-01-01")
+    assert n == 1
+
+    # Default view hides archived rows
+    result = blackboard.get_audit_log()
+    assert result["total"] == 1
+    assert result["entries"][0]["target"] == "beta"
+
+    # include_archived surfaces both
+    result = blackboard.get_audit_log(include_archived=True)
+    assert result["total"] == 2
+    archived = [e for e in result["entries"] if e["archived"]]
+    assert len(archived) == 1
+    assert archived[0]["target"] == "alpha"
+
+
+def test_archive_audit_before_idempotent(blackboard):
+    """Running archive twice doesn't double-count."""
+    blackboard.log_audit(action="old_action", target="alpha")
+    blackboard.db.execute(
+        "UPDATE audit_log SET timestamp='2025-01-01 00:00:00' WHERE target='alpha'"
+    )
+    blackboard.db.commit()
+    n1 = blackboard.archive_audit_before("2026-01-01")
+    n2 = blackboard.archive_audit_before("2026-01-01")
+    assert n1 == 1
+    assert n2 == 0
+
+
+def test_archive_audit_before_normalises_t_separator(blackboard):
+    """ISO 8601 with T separator should match the SQLite TEXT format."""
+    blackboard.log_audit(action="old_action", target="alpha")
+    blackboard.db.execute(
+        "UPDATE audit_log SET timestamp='2025-01-01 00:00:00' WHERE target='alpha'"
+    )
+    blackboard.db.commit()
+    n = blackboard.archive_audit_before("2026-01-01T00:00:00Z")
+    assert n == 1
+
+
+def test_archive_audit_before_rejects_empty(blackboard):
+    """Empty before_iso raises so the endpoint can map to HTTP 400."""
+    with pytest.raises(ValueError):
+        blackboard.archive_audit_before("")
+
+
+def test_get_audit_log_default_hides_archived(blackboard):
+    """get_audit_log() should drop archived rows by default."""
+    blackboard.log_audit(action="a", target="alpha")
+    blackboard.log_audit(action="b", target="beta")
+    blackboard.db.execute("UPDATE audit_log SET archived=1 WHERE target='alpha'")
+    blackboard.db.commit()
+
+    result = blackboard.get_audit_log()
+    assert result["total"] == 1
+    assert result["entries"][0]["target"] == "beta"
+    assert result["entries"][0]["archived"] is False
+
+
+@pytest.mark.asyncio
+async def test_mesh_client_cancel_pending_action():
+    """MeshClient.cancel_pending_action POSTs to the right endpoint."""
+    from src.agent.mesh_client import MeshClient
+
+    client = MeshClient("http://localhost:8420", "operator")
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_response.raise_for_status = MagicMock()
+    mock_response.json.return_value = {
+        "ok": True, "nonce": "nonce-1",
+        "target_kind": "agent", "target_id": "writer", "action_kind": "edit",
+    }
+
+    mock_http = AsyncMock(return_value=mock_response)
+    with patch.object(client, "_get_client", return_value=AsyncMock(post=mock_http)):
+        result = await client.cancel_pending_action("nonce-1")
+        assert result["ok"] is True
+        mock_http.assert_called_once()
+        call_args = mock_http.call_args
+        assert "/mesh/pending/nonce-1/cancel" in call_args[0][0]
+    await client.close()
+
+
+@pytest.mark.asyncio
+async def test_mesh_client_archive_audit_before():
+    """MeshClient.archive_audit_before POSTs to /mesh/audit/archive."""
+    from src.agent.mesh_client import MeshClient
+
+    client = MeshClient("http://localhost:8420", "operator")
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_response.raise_for_status = MagicMock()
+    mock_response.json.return_value = {
+        "ok": True, "archived_count": 5, "before_date": "2026-04-01",
+    }
+
+    mock_http = AsyncMock(return_value=mock_response)
+    with patch.object(client, "_get_client", return_value=AsyncMock(post=mock_http)):
+        result = await client.archive_audit_before("2026-04-01")
+        assert result["archived_count"] == 5
+        mock_http.assert_called_once()
+        call_args = mock_http.call_args
+        assert "/mesh/audit/archive" in call_args[0][0]
+        assert call_args[1]["json"]["before_date"] == "2026-04-01"
+    await client.close()

--- a/tests/test_operator_audit.py
+++ b/tests/test_operator_audit.py
@@ -459,20 +459,44 @@ def test_archive_audit_before_filters_old_rows(blackboard):
     blackboard.db.commit()
     blackboard.log_audit(action="recent_action", target="beta")
 
-    n = blackboard.archive_audit_before("2026-01-01")
-    assert n == 1
+    res = blackboard.archive_audit_before("2026-01-01")
+    assert res["archived_count"] == 1
+    assert res["truncated"] is False
 
-    # Default view hides archived rows
+    # Default view hides archived rows but keeps the audit-of-audit
+    # row written by archive_audit_before itself.
     result = blackboard.get_audit_log()
-    assert result["total"] == 1
-    assert result["entries"][0]["target"] == "beta"
+    targets = sorted(e["target"] for e in result["entries"])
+    assert "beta" in targets
+    assert "audit_log" in targets  # audit-of-audit row
 
-    # include_archived surfaces both
+    # include_archived surfaces both originals + the audit-of-audit row.
     result = blackboard.get_audit_log(include_archived=True)
-    assert result["total"] == 2
     archived = [e for e in result["entries"] if e["archived"]]
     assert len(archived) == 1
     assert archived[0]["target"] == "alpha"
+
+
+def test_archive_audit_before_writes_audit_of_audit(blackboard):
+    """archive_audit_before records its own action with the actor."""
+    blackboard.log_audit(action="old_action", target="alpha")
+    blackboard.db.execute(
+        "UPDATE audit_log SET timestamp='2025-01-01 00:00:00' WHERE target='alpha'"
+    )
+    blackboard.db.commit()
+
+    blackboard.archive_audit_before("2026-01-01", actor="operator")
+    rows = blackboard.db.execute(
+        "SELECT action, actor, target, after_value, archived FROM audit_log"
+        " WHERE action='audit_archive'"
+    ).fetchall()
+    assert len(rows) == 1
+    action, actor, target, after_value, archived = rows[0]
+    assert action == "audit_archive"
+    assert actor == "operator"
+    assert target == "audit_log"
+    assert after_value == "2026-01-01"
+    assert archived == 0  # the audit-of-audit row itself is NOT archived
 
 
 def test_archive_audit_before_idempotent(blackboard):
@@ -482,10 +506,12 @@ def test_archive_audit_before_idempotent(blackboard):
         "UPDATE audit_log SET timestamp='2025-01-01 00:00:00' WHERE target='alpha'"
     )
     blackboard.db.commit()
-    n1 = blackboard.archive_audit_before("2026-01-01")
-    n2 = blackboard.archive_audit_before("2026-01-01")
-    assert n1 == 1
-    assert n2 == 0
+    r1 = blackboard.archive_audit_before("2026-01-01")
+    r2 = blackboard.archive_audit_before("2026-01-01")
+    assert r1["archived_count"] == 1
+    # The second call still archives nothing from the original window
+    # (the audit-of-audit row from r1 is dated "now", well after 2026-01-01).
+    assert r2["archived_count"] == 0
 
 
 def test_archive_audit_before_normalises_t_separator(blackboard):
@@ -495,8 +521,31 @@ def test_archive_audit_before_normalises_t_separator(blackboard):
         "UPDATE audit_log SET timestamp='2025-01-01 00:00:00' WHERE target='alpha'"
     )
     blackboard.db.commit()
-    n = blackboard.archive_audit_before("2026-01-01T00:00:00Z")
-    assert n == 1
+    res = blackboard.archive_audit_before("2026-01-01T00:00:00Z")
+    assert res["archived_count"] == 1
+
+
+def test_archive_audit_before_chunked_truncated(blackboard, monkeypatch):
+    """When the hard cap is hit, ``truncated=True`` and rows remain."""
+    # Drop the batch size + cap so the test runs in milliseconds.
+    monkeypatch.setattr(blackboard, "_ARCHIVE_BATCH_SIZE", 5, raising=False)
+    monkeypatch.setattr(blackboard, "_ARCHIVE_HARD_CAP", 10, raising=False)
+    for i in range(20):
+        blackboard.log_audit(action=f"old_{i}", target=f"a{i}")
+    # Backdate them all.
+    blackboard.db.execute(
+        "UPDATE audit_log SET timestamp='2025-01-01 00:00:00'"
+    )
+    blackboard.db.commit()
+
+    res = blackboard.archive_audit_before("2026-01-01")
+    assert res["truncated"] is True
+    assert res["archived_count"] == 10
+    # 10 of the 20 originals are still archived=0 + matching the cutoff;
+    # a follow-up call should sweep the rest.
+    res2 = blackboard.archive_audit_before("2026-01-01")
+    assert res2["archived_count"] == 10
+    assert res2["truncated"] is True or res2["truncated"] is False  # exact-cap edge
 
 
 def test_archive_audit_before_rejects_empty(blackboard):
@@ -564,3 +613,137 @@ async def test_mesh_client_archive_audit_before():
         assert "/mesh/audit/archive" in call_args[0][0]
         assert call_args[1]["json"]["before_date"] == "2026-04-01"
     await client.close()
+
+
+# === /mesh/audit/archive endpoint — auth + date validation ===
+#
+# These tests exercise the mesh route directly (not the agent-side
+# MeshClient) so the operator-or-internal gate, ISO 8601 date
+# validation, and chunked-archive return shape are covered end-to-end.
+
+
+def _build_audit_archive_app(tmp_path):
+    """Spin up a create_mesh_app() bound to a tmp blackboard for archive tests."""
+    import importlib
+
+    import src.host.server as server_module
+    from src.host.costs import CostTracker
+    from src.host.mesh import MessageRouter, PubSub
+    from src.host.permissions import PermissionMatrix
+    from src.host.traces import TraceStore
+    importlib.reload(server_module)
+    create_mesh_app = server_module.create_mesh_app
+
+    bb = Blackboard(db_path=str(tmp_path / "bb.db"))
+    pubsub = PubSub()
+    perms = PermissionMatrix()
+    router = MessageRouter(perms, {})
+    costs = CostTracker(str(tmp_path / "costs.db"))
+    traces = TraceStore(str(tmp_path / "traces.db"))
+
+    app = create_mesh_app(
+        blackboard=bb, pubsub=pubsub, router=router, permissions=perms,
+        cost_tracker=costs, trace_store=traces,
+    )
+
+    def _cleanup():
+        bb.close()
+        costs.close()
+        traces.close()
+        importlib.reload(server_module)
+
+    return app, bb, _cleanup
+
+
+@pytest.mark.asyncio
+async def test_audit_archive_endpoint_requires_operator_or_internal(tmp_path):
+    """A non-operator + non-internal caller is rejected with HTTP 403."""
+    from httpx import ASGITransport, AsyncClient
+
+    app, bb, cleanup = _build_audit_archive_app(tmp_path)
+    try:
+        async with AsyncClient(
+            transport=ASGITransport(app=app), base_url="http://test",
+        ) as client:
+            resp = await client.post(
+                "/mesh/audit/archive",
+                json={"before_date": "2026-04-01"},
+                headers={"X-Agent-ID": "alpha"},  # not operator, not internal
+            )
+        assert resp.status_code == 403
+        assert "operator" in resp.json()["detail"].lower()
+    finally:
+        cleanup()
+
+
+@pytest.mark.asyncio
+async def test_audit_archive_endpoint_accepts_operator_caller(tmp_path):
+    """``X-Agent-ID: operator`` is accepted and the archive runs."""
+    from httpx import ASGITransport, AsyncClient
+
+    app, bb, cleanup = _build_audit_archive_app(tmp_path)
+    try:
+        bb.log_audit(action="old", target="alpha")
+        bb.db.execute(
+            "UPDATE audit_log SET timestamp='2025-01-01 00:00:00' WHERE target='alpha'"
+        )
+        bb.db.commit()
+
+        async with AsyncClient(
+            transport=ASGITransport(app=app), base_url="http://test",
+        ) as client:
+            resp = await client.post(
+                "/mesh/audit/archive",
+                json={"before_date": "2026-04-01"},
+                headers={"X-Agent-ID": "operator"},
+            )
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["ok"] is True
+        assert body["archived_count"] == 1
+        assert body["truncated"] is False
+        # audit-of-audit row was written with actor=operator.
+        rows = bb.db.execute(
+            "SELECT actor FROM audit_log WHERE action='audit_archive'"
+        ).fetchall()
+        assert len(rows) == 1
+        assert rows[0][0] == "operator"
+    finally:
+        cleanup()
+
+
+@pytest.mark.asyncio
+async def test_audit_archive_endpoint_validates_iso8601_formats(tmp_path):
+    """Bare-date / Z-suffixed / offset-suffixed inputs all parse."""
+    from httpx import ASGITransport, AsyncClient
+
+    app, bb, cleanup = _build_audit_archive_app(tmp_path)
+    try:
+        async with AsyncClient(
+            transport=ASGITransport(app=app), base_url="http://test",
+        ) as client:
+            for fmt in (
+                "2026-04-01",
+                "2026-04-01T12:00:00Z",
+                "2026-04-01T12:00:00+02:00",
+            ):
+                resp = await client.post(
+                    "/mesh/audit/archive",
+                    json={"before_date": fmt},
+                    headers={"X-Agent-ID": "operator"},
+                )
+                assert resp.status_code == 200, f"format {fmt} should parse: {resp.text}"
+                body = resp.json()
+                assert body["ok"] is True
+                assert "truncated" in body
+
+            # Garbage rejected with HTTP 400.
+            resp = await client.post(
+                "/mesh/audit/archive",
+                json={"before_date": "not-a-date"},
+                headers={"X-Agent-ID": "operator"},
+            )
+            assert resp.status_code == 400
+            assert "iso 8601" in resp.json()["detail"].lower()
+    finally:
+        cleanup()

--- a/tests/test_operator_config.py
+++ b/tests/test_operator_config.py
@@ -245,8 +245,9 @@ class TestOperatorConstants:
     def test_allowed_tools_populated(self):
         from src.cli.config import _OPERATOR_ALLOWED_TOOLS, _OPERATOR_HEARTBEAT_TOOLS
         # PR 0 consolidated to 24, PR 5 added set_project_goal (=25),
-        # PR 1 swaps propose_edit (-1) for edit_agent + undo_change (+2) → +1.
-        assert len(_OPERATOR_ALLOWED_TOOLS) == 26
+        # PR 1 swaps propose_edit (-1) for edit_agent + undo_change (+2) → 26.
+        # Self-cleanup PR adds cancel_pending_action + archive_audit_before (+2) → 28.
+        assert len(_OPERATOR_ALLOWED_TOOLS) == 28
         assert len(_OPERATOR_HEARTBEAT_TOOLS) == 4
         # Heartbeat tools should be a subset of allowed tools
         assert set(_OPERATOR_HEARTBEAT_TOOLS).issubset(set(_OPERATOR_ALLOWED_TOOLS))
@@ -258,6 +259,9 @@ class TestOperatorConstants:
             "manage_project", "manage_agent", "manage_task",
             # PR 5 — north-star setter is no-confirmation meta-config.
             "set_project_goal",
+            # Self-cleanup — operator can clear stale pending actions
+            # and prune the audit log itself.
+            "cancel_pending_action", "archive_audit_before",
         ):
             assert tool in _OPERATOR_ALLOWED_TOOLS
         # Dropped dead-weight + replaced tools must be gone.

--- a/tests/test_operator_tools.py
+++ b/tests/test_operator_tools.py
@@ -1061,3 +1061,154 @@ async def test_undo_change_no_mesh_client():
     result = await undo_change("tok-1")
     assert "error" in result
     assert "mesh_client" in result["error"].lower()
+
+
+# ── cancel_pending_action ────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_cancel_pending_action_success():
+    from src.agent.builtins.operator_tools import cancel_pending_action
+
+    mc = MagicMock()
+    mc.cancel_pending_action = AsyncMock(return_value={
+        "ok": True,
+        "nonce": "nonce-1",
+        "target_kind": "agent",
+        "target_id": "writer",
+        "action_kind": "edit",
+    })
+    result = await cancel_pending_action("nonce-1", mesh_client=mc)
+    assert result["success"] is True
+    assert result["nonce"] == "nonce-1"
+    assert result["target_kind"] == "agent"
+    mc.cancel_pending_action.assert_awaited_once_with("nonce-1")
+
+
+@pytest.mark.asyncio
+async def test_cancel_pending_action_404_friendly():
+    from src.agent.builtins.operator_tools import cancel_pending_action
+
+    mc = MagicMock()
+    mc.cancel_pending_action = AsyncMock(side_effect=RuntimeError("404 Not Found"))
+    result = await cancel_pending_action("missing", mesh_client=mc)
+    assert result["error"] == "pending_unknown_or_expired"
+    assert "expired" in result["detail"].lower() or "not found" in result["detail"].lower()
+
+
+@pytest.mark.asyncio
+async def test_cancel_pending_action_no_nonce():
+    from src.agent.builtins.operator_tools import cancel_pending_action
+
+    result = await cancel_pending_action("", mesh_client=MagicMock())
+    assert "error" in result
+    assert "nonce" in result["error"].lower()
+
+
+@pytest.mark.asyncio
+async def test_cancel_pending_action_no_mesh_client():
+    from src.agent.builtins.operator_tools import cancel_pending_action
+
+    result = await cancel_pending_action("nonce-1")
+    assert "error" in result
+    assert "mesh_client" in result["error"].lower()
+
+
+@pytest.mark.asyncio
+async def test_cancel_pending_action_blocked_for_non_operator(monkeypatch):
+    """Non-operator agents must not be able to cancel pending actions."""
+    from src.agent.builtins.operator_tools import cancel_pending_action
+
+    monkeypatch.delenv("ALLOWED_TOOLS", raising=False)
+    result = await cancel_pending_action("nonce-1", mesh_client=MagicMock())
+    assert "error" in result
+    assert "operator" in result["error"].lower()
+
+
+# ── archive_audit_before ─────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_archive_audit_before_success():
+    from src.agent.builtins.operator_tools import archive_audit_before
+
+    mc = MagicMock()
+    mc.archive_audit_before = AsyncMock(return_value={
+        "ok": True,
+        "archived_count": 12,
+        "before_date": "2026-04-01",
+    })
+    result = await archive_audit_before("2026-04-01", mesh_client=mc)
+    assert result["success"] is True
+    assert result["archived_count"] == 12
+    assert result["before_date"] == "2026-04-01"
+    assert "12" in result["message"]
+    mc.archive_audit_before.assert_awaited_once_with("2026-04-01")
+
+
+@pytest.mark.asyncio
+async def test_archive_audit_before_zero_count_pluralization():
+    from src.agent.builtins.operator_tools import archive_audit_before
+
+    mc = MagicMock()
+    mc.archive_audit_before = AsyncMock(return_value={
+        "ok": True,
+        "archived_count": 0,
+        "before_date": "2099-01-01",
+    })
+    result = await archive_audit_before("2099-01-01", mesh_client=mc)
+    assert result["archived_count"] == 0
+    assert "0 audit entries" in result["message"]
+
+
+@pytest.mark.asyncio
+async def test_archive_audit_before_singular_pluralization():
+    from src.agent.builtins.operator_tools import archive_audit_before
+
+    mc = MagicMock()
+    mc.archive_audit_before = AsyncMock(return_value={
+        "ok": True,
+        "archived_count": 1,
+        "before_date": "2026-04-01",
+    })
+    result = await archive_audit_before("2026-04-01", mesh_client=mc)
+    assert "1 audit entry" in result["message"]
+
+
+@pytest.mark.asyncio
+async def test_archive_audit_before_no_date():
+    from src.agent.builtins.operator_tools import archive_audit_before
+
+    result = await archive_audit_before("", mesh_client=MagicMock())
+    assert "error" in result
+    assert "before_date" in result["error"]
+
+
+@pytest.mark.asyncio
+async def test_archive_audit_before_no_mesh_client():
+    from src.agent.builtins.operator_tools import archive_audit_before
+
+    result = await archive_audit_before("2026-04-01")
+    assert "error" in result
+    assert "mesh_client" in result["error"].lower()
+
+
+@pytest.mark.asyncio
+async def test_archive_audit_before_blocked_for_non_operator(monkeypatch):
+    from src.agent.builtins.operator_tools import archive_audit_before
+
+    monkeypatch.delenv("ALLOWED_TOOLS", raising=False)
+    result = await archive_audit_before("2026-04-01", mesh_client=MagicMock())
+    assert "error" in result
+    assert "operator" in result["error"].lower()
+
+
+@pytest.mark.asyncio
+async def test_archive_audit_before_propagates_mesh_error():
+    from src.agent.builtins.operator_tools import archive_audit_before
+
+    mc = MagicMock()
+    mc.archive_audit_before = AsyncMock(side_effect=RuntimeError("boom"))
+    result = await archive_audit_before("2026-04-01", mesh_client=mc)
+    assert "error" in result
+    assert "boom" in result["error"]

--- a/tests/test_operator_tools.py
+++ b/tests/test_operator_tools.py
@@ -1212,3 +1212,20 @@ async def test_archive_audit_before_propagates_mesh_error():
     result = await archive_audit_before("2026-04-01", mesh_client=mc)
     assert "error" in result
     assert "boom" in result["error"]
+
+
+@pytest.mark.asyncio
+async def test_archive_audit_before_surfaces_truncated_flag():
+    """When the mesh hits the per-call cap, the tool surfaces a follow-up hint."""
+    from src.agent.builtins.operator_tools import archive_audit_before
+
+    mc = MagicMock()
+    mc.archive_audit_before = AsyncMock(return_value={
+        "ok": True,
+        "archived_count": 100_000,
+        "truncated": True,
+        "before_date": "2026-04-01",
+    })
+    result = await archive_audit_before("2026-04-01", mesh_client=mc)
+    assert result["truncated"] is True
+    assert "rerun" in result["message"].lower()


### PR DESCRIPTION
## Summary

Three cohesive changes that let the operator self-tidy without waiting for TTLs and let the user see/edit the operator's own identity files.

- **Operator identity tabs unblocked** in the dashboard. SOUL.md / INSTRUCTIONS.md edits route through a confirmation modal (\"This changes how your Operator behaves\") — other workspace files save normally.
- **New tool `cancel_pending_action(nonce)`** — operator can immediately collect stale or incorrect proposals instead of waiting for the 5-min TTL.
- **New tool `archive_audit_before(date)`** + `POST /mesh/audit/archive` endpoint + dashboard UI (7d/30d/90d dropdown, Archive button, \"Show archived\" toggle in System → Operator).

## New endpoints

- `POST /mesh/audit/archive` — operator-or-internal, body `{before_date: ISO 8601}`, returns `{archived_count, before_date}`.
- `POST /api/operator-audit/archive` — dashboard proxy with CSRF gate.
- `GET /api/operator-audit?include_archived=true|false` — defaults to false.

## Database

New `archived BOOLEAN DEFAULT 0` column on `audit_log` with defensive `ALTER TABLE` for upgrade. Indexed.

## Test plan

- [x] ruff clean
- [x] tests/test_operator_config.py — count bumped from 26 → 28, new tools asserted present
- [x] tests/test_operator_tools.py — 12 new tests for cancel + archive (success, 404 mapping, validation, non-operator block)
- [x] tests/test_operator_audit.py — 7 new tests for archive (column, idempotency, ISO parsing, default-hides)
- [x] tests/test_dashboard.py::TestDashboardOperatorAudit — 6 new tests for include_archived + archive endpoint + CSRF

139 tests passed in PR C focused scope.