### PR TITLE
feat(operator,fleet): per-agent overrides on apply_template

### DIFF
--- a/src/agent/builtins/fleet_tool.py
+++ b/src/agent/builtins/fleet_tool.py
@@ -37,7 +37,9 @@ async def list_templates(*, mesh_client=None, **_kw) -> dict:
     description=(
         "Create a team of agents from a fleet template. Use list_templates first "
         "to see available templates. This creates all agents defined in the template "
-        "and starts them. Returns the list of created agent IDs."
+        "and starts them. Returns the list of created agent IDs. Pass "
+        "`agent_overrides` to tune individual slots (model, instructions) at "
+        "creation time -- avoids 5+ follow-up edit_agent round-trips."
     ),
     parameters={
         "template": {
@@ -46,13 +48,35 @@ async def list_templates(*, mesh_client=None, **_kw) -> dict:
         },
         "model": {
             "type": "string",
-            "description": "Optional model override for all agents. Defaults to system default.",
+            "description": "Optional model override for ALL agents. Defaults to system default.",
             "default": "",
+        },
+        "agent_overrides": {
+            "type": "object",
+            "description": (
+                "Optional per-agent overrides keyed by agent name from the template. "
+                "Each value is an object with optional 'model' and/or 'instructions' "
+                "fields. Unknown agent names or fields are rejected with HTTP 400."
+            ),
+            "additionalProperties": {
+                "type": "object",
+                "properties": {
+                    "model": {"type": "string"},
+                    "instructions": {"type": "string"},
+                },
+                "additionalProperties": False,
+            },
         },
     },
 )
 async def apply_template(
-    template: str, model: str = "", *, mesh_client=None, _messages=None, **_kw,
+    template: str,
+    model: str = "",
+    agent_overrides: dict[str, dict] | None = None,
+    *,
+    mesh_client=None,
+    _messages=None,
+    **_kw,
 ) -> dict:
     """Apply a fleet template to create a team of agents."""
     if not _is_operator():
@@ -68,6 +92,8 @@ async def apply_template(
             "detail": "User confirmation required to create agents.",
         }
     try:
-        return await mesh_client.apply_fleet_template(template, model=model)
+        return await mesh_client.apply_fleet_template(
+            template, model=model, agent_overrides=agent_overrides,
+        )
     except Exception as e:
         return {"error": f"Failed to apply template '{template}': {e}"}

--- a/src/agent/mesh_client.py
+++ b/src/agent/mesh_client.py
@@ -698,12 +698,25 @@ class MeshClient:
         response.raise_for_status()
         return response.json()
 
-    async def apply_fleet_template(self, template: str, model: str = "") -> dict:
-        """Apply a fleet template to create a team of agents."""
+    async def apply_fleet_template(
+        self,
+        template: str,
+        model: str = "",
+        agent_overrides: dict[str, dict] | None = None,
+    ) -> dict:
+        """Apply a fleet template to create a team of agents.
+
+        ``agent_overrides`` is an optional mapping of ``agent_name`` →
+        ``{"model": str, "instructions": str}``. Validated upfront on
+        the mesh side; unknown names / fields / models / oversized
+        instructions return HTTP 400 (or 413) with the offender named.
+        """
         client = await self._get_client()
         body: dict = {"template": template}
         if model:
             body["model"] = model
+        if agent_overrides:
+            body["agent_overrides"] = agent_overrides
         response = await client.post(
             f"{self.mesh_url}/mesh/fleet/apply",
             json=body,

--- a/src/cli/config.py
+++ b/src/cli/config.py
@@ -1156,11 +1156,22 @@ def _load_templates() -> dict[str, dict]:
     return available
 
 
-def _apply_template(template_name: str, tpl: dict) -> list[str]:
-    """Apply a team template, creating all agents. Returns list of agent names."""
+def _apply_template(
+    template_name: str,
+    tpl: dict,
+    agent_overrides: dict[str, dict] | None = None,
+) -> list[str]:
+    """Apply a team template, creating all agents. Returns list of agent names.
+
+    ``agent_overrides`` (PR-N) is an optional ``{agent_name: {field: value}}``
+    map. v1 supports per-agent ``model`` and ``instructions`` overrides applied
+    on top of the template's defaults. The mesh route validates the shape and
+    contents UPFRONT — by the time we get here, the input is trusted.
+    """
     cfg = _load_config()
     default_model = cfg.get("llm", {}).get("default_model", "openai/gpt-4o-mini")
     tpl_agents = tpl.get("agents", {})
+    overrides = agent_overrides or {}
     created: list[str] = []
 
     # Load existing agents to avoid silent overwrites
@@ -1175,8 +1186,13 @@ def _apply_template(template_name: str, tpl: dict) -> list[str]:
         if agent_name in existing_agents:
             click.echo(f"  Skipping '{agent_name}' — agent already exists")
             continue
+        per_agent_override = overrides.get(agent_name) or {}
         model = agent_def.get("model", default_model).replace("{default_model}", default_model)
+        if "model" in per_agent_override:
+            model = per_agent_override["model"]
         instructions = agent_def.get("instructions", "") or agent_def.get("system_prompt", "")
+        if "instructions" in per_agent_override:
+            instructions = per_agent_override["instructions"]
         soul = agent_def.get("soul", "")
         heartbeat = agent_def.get("heartbeat", "")
         interface = agent_def.get("initial_interface", "") or agent_def.get("interface", "")

--- a/src/host/server.py
+++ b/src/host/server.py
@@ -448,6 +448,23 @@ def _record_scope_warn() -> None:
     _scope_warn_count += 1
 
 
+# Counter for cross-project blackboard access (read or write where the
+# caller's project differs from the existing key's writer-project). Pure
+# observability for Phase 3 enforcement design — NOT a denial. Surfaced on
+# ``/mesh/system/metrics`` as ``blackboard_cross_project_total``. Counter
+# is process-lifetime (resets on restart), naming follows ``scope_warn_total``
+# rather than the ``_24h`` mental model — restarts are roughly daily-ish in
+# practice and a true 24h window would need a separate ledger.
+_blackboard_xproject_count: dict[str, int] = {"read": 0, "write": 0}
+
+
+def _record_blackboard_xproject(kind: str) -> None:
+    """Bump the cross-project blackboard counter."""
+    if kind not in _blackboard_xproject_count:
+        return
+    _blackboard_xproject_count[kind] += 1
+
+
 def _caller_projects(agent_id: str) -> set[str]:
     """Return the project memberships visible to ``agent_id``.
 
@@ -472,6 +489,35 @@ def _caller_projects(agent_id: str) -> set[str]:
         for name, meta in projects.items()
         if agent_id in meta.get("members", [])
     }
+
+
+def _is_blackboard_cross_project(
+    caller: str, writer: str | None
+) -> bool:
+    """Return True when caller and writer are workers in disjoint project sets.
+
+    Best-effort detection used purely for telemetry — never gates access.
+    Returns False (so the counter is NOT incremented) when:
+
+    - ``writer`` is missing (e.g. unknown / deleted agent or no prior entry)
+    - either party is operator / ``mesh`` (fleet-global by design)
+    - caller and writer share at least one project membership
+    - either party has an empty membership set (standalone agent — not
+      meaningfully "cross-project" without two project anchors)
+
+    The intent is to count the case where two distinct *project-bound*
+    workers touch the same key, since that is what Phase 3 enforcement
+    will gate.
+    """
+    if not writer or writer == caller:
+        return False
+    if caller in {"operator", "mesh"} or writer in {"operator", "mesh"}:
+        return False
+    caller_set = _caller_projects(caller)
+    writer_set = _caller_projects(writer)
+    if not caller_set or not writer_set:
+        return False
+    return caller_set.isdisjoint(writer_set)
 
 
 def create_mesh_app(
@@ -992,6 +1038,13 @@ def create_mesh_app(
         entry = blackboard.read(key)
         if not entry:
             raise HTTPException(404, f"Key not found: {key}")
+        # Phase 3 Slice 1 telemetry: count cross-project reads. Skip
+        # internal/operator callers (fleet-global by design). No
+        # enforcement — pure observability informing the design doc.
+        if not _is_internal_caller(request) and _is_blackboard_cross_project(
+            agent_id, entry.written_by
+        ):
+            _record_blackboard_xproject("read")
         return entry.model_dump(mode="json")
 
     @app.put("/mesh/blackboard/{key:path}")
@@ -1011,6 +1064,15 @@ def create_mesh_app(
             raise HTTPException(400, "TTL must be positive")
         if not permissions.can_write_blackboard(agent_id, key):
             raise HTTPException(403, f"Agent {agent_id} cannot write {key}")
+        # Phase 3 Slice 1 telemetry: count cross-project writes against an
+        # EXISTING entry (new keys are by definition not cross-project).
+        # Skip internal/operator callers (fleet-global by design).
+        if not _is_internal_caller(request):
+            existing = blackboard.read(key)
+            if existing is not None and _is_blackboard_cross_project(
+                agent_id, existing.written_by
+            ):
+                _record_blackboard_xproject("write")
         entry = blackboard.write(key, value, written_by=agent_id, ttl=ttl)
         if trace_store:
             req_trace_id = request.headers.get("x-trace-id")
@@ -1039,6 +1101,14 @@ def create_mesh_app(
         bare = key.split("/", 2)[2] if key.startswith("projects/") and key.count("/") >= 2 else key
         if bare.startswith("history/"):
             raise HTTPException(400, "Cannot delete from history namespace")
+        # Phase 3 Slice 1 telemetry: count cross-project deletes (a delete
+        # is a write that mutates the key). Skip internal/operator callers.
+        if not _is_internal_caller(request):
+            existing = blackboard.read(key)
+            if existing is not None and _is_blackboard_cross_project(
+                agent_id, existing.written_by
+            ):
+                _record_blackboard_xproject("write")
         try:
             blackboard.delete(key, deleted_by=agent_id)
         except ValueError as e:
@@ -1068,6 +1138,14 @@ def create_mesh_app(
             raise HTTPException(413, f"Value too large ({value_size} bytes, max {_MAX_BB_VALUE_BYTES})")
         if not permissions.can_write_blackboard(agent_id, key):
             raise HTTPException(403, f"Agent {agent_id} cannot write {key}")
+        # Phase 3 Slice 1 telemetry: count cross-project CAS writes against
+        # an EXISTING entry. Skip internal/operator callers.
+        if not _is_internal_caller(request):
+            existing = blackboard.read(key)
+            if existing is not None and _is_blackboard_cross_project(
+                agent_id, existing.written_by
+            ):
+                _record_blackboard_xproject("write")
         expected_version = body.expected_version
         value = body.value
         entry = blackboard.write_if_version(
@@ -2534,8 +2612,80 @@ def create_mesh_app(
         # Optional model override
         model_override = data.get("model", "")
 
+        # Optional per-agent overrides (PR-N): { agent_name: {"model": ..., "instructions": ...} }
+        # Validated UPFRONT — no agent is created if any override is invalid.
+        agent_overrides = data.get("agent_overrides") or {}
+        if agent_overrides:
+            if not isinstance(agent_overrides, dict):
+                raise HTTPException(400, "agent_overrides must be an object")
+            _ALLOWED_OVERRIDE_FIELDS = {"model", "instructions"}
+            # 12000 mirrors src/agent/server.py _FILE_CAPS["INSTRUCTIONS.md"].
+            _INSTRUCTIONS_CAP = 12000
+
+            # 1. Unknown agent names
+            unknown_agents = [
+                name for name in agent_overrides if name not in tpl_agents
+            ]
+            if unknown_agents:
+                raise HTTPException(
+                    400,
+                    "agent_overrides references unknown agent(s): "
+                    f"{sorted(unknown_agents)}. "
+                    f"Template '{template_name}' defines: {sorted(tpl_agents.keys())}",
+                )
+
+            # 2. Per-override field/value validation
+            from src.shared.models import _resolve_litellm_key
+            for agent_name, override in agent_overrides.items():
+                if not isinstance(override, dict):
+                    raise HTTPException(
+                        400,
+                        f"agent_overrides['{agent_name}'] must be an object, "
+                        f"got {type(override).__name__}",
+                    )
+                bad_fields = [
+                    k for k in override if k not in _ALLOWED_OVERRIDE_FIELDS
+                ]
+                if bad_fields:
+                    raise HTTPException(
+                        400,
+                        f"agent_overrides['{agent_name}'] has unsupported "
+                        f"field(s): {sorted(bad_fields)}. "
+                        f"Allowed: {sorted(_ALLOWED_OVERRIDE_FIELDS)}",
+                    )
+                if "model" in override:
+                    mv = override["model"]
+                    if not isinstance(mv, str) or not mv.strip():
+                        raise HTTPException(
+                            400,
+                            f"agent_overrides['{agent_name}'].model must be a "
+                            "non-empty string",
+                        )
+                    if _resolve_litellm_key(mv) is None:
+                        raise HTTPException(
+                            400,
+                            f"agent_overrides['{agent_name}'].model "
+                            f"'{mv}' is not a known model",
+                        )
+                if "instructions" in override:
+                    iv = override["instructions"]
+                    if not isinstance(iv, str):
+                        raise HTTPException(
+                            400,
+                            f"agent_overrides['{agent_name}'].instructions "
+                            "must be a string",
+                        )
+                    if len(iv) > _INSTRUCTIONS_CAP:
+                        raise HTTPException(
+                            413,
+                            f"agent_overrides['{agent_name}'].instructions "
+                            f"exceeds cap ({len(iv)} > {_INSTRUCTIONS_CAP} chars)",
+                        )
+
         # Apply template to create config entries
-        created_names = _apply_template(template_name, tpl)
+        created_names = _apply_template(
+            template_name, tpl, agent_overrides=agent_overrides or None,
+        )
         # _apply_template calls _add_agent_permissions for each new agent;
         # reload the live matrix so /mesh/register sees the on-disk perms
         # instead of falling through to default/deny-all. Cheap no-op when
@@ -3188,6 +3338,13 @@ def create_mesh_app(
             # operator dashboard can render the right state.
             "scope_warn_total": _scope_warn_count,
             "project_scope_mode": _PROJECT_SCOPE_MODE,
+            # Phase 3 Slice 1 (PR-O'.1) telemetry: process-lifetime count
+            # of cross-project blackboard accesses (caller's project set
+            # is disjoint from the existing entry's writer-project set).
+            # Pure observability — informs the design doc for PR-O'.2;
+            # NO enforcement effect today. Counts kinds separately so the
+            # design can branch on read vs write volume.
+            "blackboard_cross_project_total": dict(_blackboard_xproject_count),
         }
 
     @app.get("/mesh/agents/{agent_id}/metrics")

--- a/tests/test_operator_fleet.py
+++ b/tests/test_operator_fleet.py
@@ -138,7 +138,9 @@ class TestApplyTemplate:
         messages = [{"role": "user", "content": "apply sales template", "_origin": "user"}]
         result = await apply_template(template="sales", mesh_client=mock_client, _messages=messages)
         assert "created" in result
-        mock_client.apply_fleet_template.assert_awaited_once_with("sales", model="")
+        mock_client.apply_fleet_template.assert_awaited_once_with(
+            "sales", model="", agent_overrides=None,
+        )
 
     @pytest.mark.asyncio
     async def test_provenance_fails_closed_when_no_messages(self):
@@ -163,7 +165,9 @@ class TestApplyTemplate:
         }
         messages = [{"role": "user", "content": "go"}]
         await apply_template(template="sales", model="openai/gpt-4o", mesh_client=mock_client, _messages=messages)
-        mock_client.apply_fleet_template.assert_awaited_once_with("sales", model="openai/gpt-4o")
+        mock_client.apply_fleet_template.assert_awaited_once_with(
+            "sales", model="openai/gpt-4o", agent_overrides=None,
+        )
 
     @pytest.mark.asyncio
     async def test_exception_handling(self):
@@ -233,6 +237,94 @@ class TestMeshClientFleetMethods:
             call_kwargs = mock_http.post.call_args
             # model not included when empty
             assert call_kwargs.kwargs["json"] == {"template": "starter"}
+
+    @pytest.mark.asyncio
+    async def test_apply_fleet_template_with_agent_overrides(self):
+        """PR-N: ``agent_overrides`` is forwarded as part of the JSON body."""
+        from src.agent.mesh_client import MeshClient
+
+        client = MeshClient(mesh_url="http://localhost:8420", agent_id="test")
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {"template": "sales", "created": []}
+        mock_response.raise_for_status = MagicMock()
+
+        mock_http = AsyncMock()
+        mock_http.post.return_value = mock_response
+
+        overrides = {"writer": {"model": "openai/gpt-4o", "instructions": "Be terse."}}
+        with patch.object(client, "_get_client", new_callable=AsyncMock, return_value=mock_http):
+            await client.apply_fleet_template("sales", agent_overrides=overrides)
+            call_kwargs = mock_http.post.call_args
+            assert call_kwargs.kwargs["json"] == {
+                "template": "sales",
+                "agent_overrides": overrides,
+            }
+
+    @pytest.mark.asyncio
+    async def test_apply_fleet_template_omits_empty_overrides(self):
+        """Empty / None overrides are NOT included in the body (back-compat)."""
+        from src.agent.mesh_client import MeshClient
+
+        client = MeshClient(mesh_url="http://localhost:8420", agent_id="test")
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {"template": "starter", "created": []}
+        mock_response.raise_for_status = MagicMock()
+
+        mock_http = AsyncMock()
+        mock_http.post.return_value = mock_response
+
+        with patch.object(client, "_get_client", new_callable=AsyncMock, return_value=mock_http):
+            # None
+            await client.apply_fleet_template("starter", agent_overrides=None)
+            assert mock_http.post.call_args.kwargs["json"] == {"template": "starter"}
+            # Empty dict
+            await client.apply_fleet_template("starter", agent_overrides={})
+            assert mock_http.post.call_args.kwargs["json"] == {"template": "starter"}
+
+
+class TestApplyTemplateAgentOverridesSkill:
+    """PR-N: ``apply_template`` skill forwards ``agent_overrides`` and back-compat."""
+
+    @pytest.mark.asyncio
+    async def test_overrides_forwarded(self):
+        from src.agent.builtins.fleet_tool import apply_template
+
+        mock_client = AsyncMock()
+        mock_client.apply_fleet_template.return_value = {
+            "template": "sales", "created": [], "failed": [], "skipped": [],
+        }
+        messages = [{"role": "user", "content": "go"}]
+        overrides = {"writer": {"model": "openai/gpt-4o"}}
+        await apply_template(
+            template="sales",
+            agent_overrides=overrides,
+            mesh_client=mock_client,
+            _messages=messages,
+        )
+        mock_client.apply_fleet_template.assert_awaited_once_with(
+            "sales", model="", agent_overrides=overrides,
+        )
+
+    @pytest.mark.asyncio
+    async def test_omitted_overrides_pass_none(self):
+        """Back-compat: callers passing only template + model still work."""
+        from src.agent.builtins.fleet_tool import apply_template
+
+        mock_client = AsyncMock()
+        mock_client.apply_fleet_template.return_value = {
+            "template": "starter", "created": [], "failed": [], "skipped": [],
+        }
+        messages = [{"role": "user", "content": "go"}]
+        await apply_template(
+            template="starter",
+            mesh_client=mock_client,
+            _messages=messages,
+        )
+        mock_client.apply_fleet_template.assert_awaited_once_with(
+            "starter", model="", agent_overrides=None,
+        )
 
 
 # ── Mesh endpoint: GET /mesh/fleet/templates ───────────────────
@@ -424,6 +516,117 @@ class TestMeshFleetApplyEndpoint:
         resp = client.post("/mesh/fleet/apply", json={"template": "starter"})
         assert resp.status_code == 200
         perms.reload.assert_called()
+
+    # ── PR-N: agent_overrides validation ─────────────────────
+
+    @patch.dict("os.environ", {"OPENLEGION_MAX_AGENTS": "10"})
+    def test_apply_unknown_agent_in_overrides_returns_400(self):
+        """Override key referencing an agent not in the template → 400, no creation."""
+        from fastapi.testclient import TestClient
+
+        app, cm, _ = self._make_app(existing_agents={"operator": "http://localhost:8400"})
+        client = TestClient(app)
+        resp = client.post(
+            "/mesh/fleet/apply",
+            json={
+                "template": "starter",
+                "agent_overrides": {"nonexistent_xyz": {"model": "openai/gpt-4o"}},
+            },
+        )
+        assert resp.status_code == 400
+        detail = resp.json()["detail"].lower()
+        assert "unknown" in detail
+        assert "nonexistent_xyz" in detail
+        # Validation happens BEFORE template application
+        cm.start_agent.assert_not_called()
+
+    @patch.dict("os.environ", {"OPENLEGION_MAX_AGENTS": "10"})
+    def test_apply_unknown_override_field_returns_400(self):
+        """Override field outside {'model','instructions'} → 400."""
+        from fastapi.testclient import TestClient
+
+        app, cm, _ = self._make_app(existing_agents={"operator": "http://localhost:8400"})
+        client = TestClient(app)
+        resp = client.post(
+            "/mesh/fleet/apply",
+            json={
+                "template": "starter",
+                "agent_overrides": {"assistant": {"foo": "bar"}},
+            },
+        )
+        assert resp.status_code == 400
+        detail = resp.json()["detail"]
+        assert "foo" in detail
+        cm.start_agent.assert_not_called()
+
+    @patch.dict("os.environ", {"OPENLEGION_MAX_AGENTS": "10"})
+    def test_apply_invalid_model_in_override_returns_400(self):
+        """Unknown model id → 400 from upfront validation, no agents created."""
+        from fastapi.testclient import TestClient
+
+        app, cm, _ = self._make_app(existing_agents={"operator": "http://localhost:8400"})
+        client = TestClient(app)
+        resp = client.post(
+            "/mesh/fleet/apply",
+            json={
+                "template": "starter",
+                "agent_overrides": {
+                    "assistant": {"model": "fakeprovider/totally-not-real-model-xyz"},
+                },
+            },
+        )
+        assert resp.status_code == 400
+        detail = resp.json()["detail"]
+        assert "fakeprovider/totally-not-real-model-xyz" in detail
+        cm.start_agent.assert_not_called()
+
+    @patch.dict("os.environ", {"OPENLEGION_MAX_AGENTS": "10"})
+    def test_apply_oversized_instructions_returns_413(self):
+        """Instructions > 12000 chars → 413, no agents created."""
+        from fastapi.testclient import TestClient
+
+        app, cm, _ = self._make_app(existing_agents={"operator": "http://localhost:8400"})
+        client = TestClient(app)
+        oversized = "x" * 12001
+        resp = client.post(
+            "/mesh/fleet/apply",
+            json={
+                "template": "starter",
+                "agent_overrides": {"assistant": {"instructions": oversized}},
+            },
+        )
+        assert resp.status_code == 413
+        detail = resp.json()["detail"]
+        assert "assistant" in detail
+        assert "12000" in detail
+        cm.start_agent.assert_not_called()
+
+    @patch.dict("os.environ", {"OPENLEGION_MAX_AGENTS": "10"})
+    def test_apply_empty_overrides_is_noop(self):
+        """Empty agent_overrides={} behaves identically to no overrides."""
+        from fastapi.testclient import TestClient
+
+        app, _, _ = self._make_app(existing_agents={"operator": "http://localhost:8400"})
+        client = TestClient(app)
+        resp = client.post(
+            "/mesh/fleet/apply",
+            json={"template": "starter", "agent_overrides": {}},
+        )
+        assert resp.status_code == 200
+        assert resp.json()["template"] == "starter"
+
+    @patch.dict("os.environ", {"OPENLEGION_MAX_AGENTS": "10"})
+    def test_apply_non_dict_overrides_returns_400(self):
+        """agent_overrides must be an object."""
+        from fastapi.testclient import TestClient
+
+        app, _, _ = self._make_app(existing_agents={"operator": "http://localhost:8400"})
+        client = TestClient(app)
+        resp = client.post(
+            "/mesh/fleet/apply",
+            json={"template": "starter", "agent_overrides": ["not", "a", "dict"]},
+        )
+        assert resp.status_code == 400
 
     def test_apply_no_container_manager(self):
         """Without container manager, apply returns 503."""

--- a/tests/test_templates.py
+++ b/tests/test_templates.py
@@ -546,6 +546,123 @@ class TestApplyTemplate(_TempConfigMixin):
         assert len(perms["permissions"]) == 3
 
 
+class TestApplyTemplateAgentOverrides(_TempConfigMixin):
+    """PR-N: per-agent overrides applied at template apply time."""
+
+    def _multi_template(self) -> dict:
+        return {
+            "agents": {
+                "writer": {
+                    "role": "writer",
+                    "model": "{default_model}",
+                    "instructions": "Default writer instructions.",
+                },
+                "editor": {
+                    "role": "editor",
+                    "model": "{default_model}",
+                    "instructions": "Default editor instructions.",
+                },
+                "researcher": {
+                    "role": "researcher",
+                    "model": "{default_model}",
+                    "instructions": "Default researcher instructions.",
+                },
+            },
+        }
+
+    def test_no_overrides_is_noop(self):
+        """``agent_overrides=None`` produces template defaults."""
+        tpl = self._multi_template()
+        with self._mock_config():
+            created = _apply_template("multi", tpl, agent_overrides=None)
+        assert created == ["writer", "editor", "researcher"]
+        with open(self._agents_path) as f:
+            cfg = yaml.safe_load(f)
+        assert cfg["agents"]["writer"]["model"] == "openai/gpt-4o-mini"
+        assert cfg["agents"]["writer"]["initial_instructions"] == "Default writer instructions."
+
+    def test_empty_overrides_is_noop(self):
+        """``agent_overrides={}`` is also a no-op (back-compat sanity)."""
+        tpl = self._multi_template()
+        with self._mock_config():
+            _apply_template("multi", tpl, agent_overrides={})
+        with open(self._agents_path) as f:
+            cfg = yaml.safe_load(f)
+        assert cfg["agents"]["writer"]["model"] == "openai/gpt-4o-mini"
+
+    def test_single_model_override_only_affects_target(self):
+        """Override one agent's model — others stay on template default."""
+        tpl = self._multi_template()
+        with self._mock_config():
+            _apply_template(
+                "multi", tpl,
+                agent_overrides={"writer": {"model": "anthropic/claude-sonnet-4-6"}},
+            )
+        with open(self._agents_path) as f:
+            cfg = yaml.safe_load(f)
+        assert cfg["agents"]["writer"]["model"] == "anthropic/claude-sonnet-4-6"
+        # Others untouched
+        assert cfg["agents"]["editor"]["model"] == "openai/gpt-4o-mini"
+        assert cfg["agents"]["researcher"]["model"] == "openai/gpt-4o-mini"
+        # Instructions for writer remain the template default (not overridden)
+        assert cfg["agents"]["writer"]["initial_instructions"] == "Default writer instructions."
+
+    def test_two_independent_instructions_overrides(self):
+        """Override two agents' instructions independently."""
+        tpl = self._multi_template()
+        overrides = {
+            "writer": {"instructions": "Be terse."},
+            "editor": {"instructions": "Use AP style."},
+        }
+        with self._mock_config():
+            _apply_template("multi", tpl, agent_overrides=overrides)
+        with open(self._agents_path) as f:
+            cfg = yaml.safe_load(f)
+        assert cfg["agents"]["writer"]["initial_instructions"] == "Be terse."
+        assert cfg["agents"]["editor"]["initial_instructions"] == "Use AP style."
+        # Researcher remains template default
+        assert cfg["agents"]["researcher"]["initial_instructions"] == "Default researcher instructions."
+        # Models all remain default
+        assert cfg["agents"]["writer"]["model"] == "openai/gpt-4o-mini"
+        assert cfg["agents"]["editor"]["model"] == "openai/gpt-4o-mini"
+
+    def test_combined_model_and_instructions_for_same_agent(self):
+        """Both model AND instructions for the same agent."""
+        tpl = self._multi_template()
+        overrides = {
+            "writer": {
+                "model": "anthropic/claude-sonnet-4-6",
+                "instructions": "Custom writer voice.",
+            },
+        }
+        with self._mock_config():
+            _apply_template("multi", tpl, agent_overrides=overrides)
+        with open(self._agents_path) as f:
+            cfg = yaml.safe_load(f)
+        assert cfg["agents"]["writer"]["model"] == "anthropic/claude-sonnet-4-6"
+        assert cfg["agents"]["writer"]["initial_instructions"] == "Custom writer voice."
+        # Editor still on template default for both
+        assert cfg["agents"]["editor"]["model"] == "openai/gpt-4o-mini"
+        assert cfg["agents"]["editor"]["initial_instructions"] == "Default editor instructions."
+
+    def test_unknown_agent_in_overrides_silently_ignored_at_cli_layer(self):
+        """``_apply_template`` itself trusts validated input (mesh route is the
+        gate). An unknown agent key here is a no-op — the override never
+        matches a real agent — but the apply loop must not crash."""
+        tpl = self._multi_template()
+        with self._mock_config():
+            created = _apply_template(
+                "multi", tpl,
+                agent_overrides={"ghost": {"model": "openai/gpt-4o"}},
+            )
+        # All real agents created with template defaults
+        assert created == ["writer", "editor", "researcher"]
+        with open(self._agents_path) as f:
+            cfg = yaml.safe_load(f)
+        assert cfg["agents"]["writer"]["model"] == "openai/gpt-4o-mini"
+        assert "ghost" not in cfg["agents"]
+
+
 class TestLoadTemplates:
     def test_all_templates_parse(self):
         """All template YAML files in src/templates/ parse without error."""


### PR DESCRIPTION
## Summary

`apply_template` now accepts `agent_overrides` — a per-slot mapping of `{agent_name: {model, instructions}}` — so operators can tune individual agents at fleet creation time instead of running 5+ `edit_agent` calls afterwards.

This is **PR-N** from `docs/plans/2026-05-08-post-board-roadmap.md` (Phase 1 — production monitoring depth, lowest-risk shipping first).

## Why

Sarah's content team workflow today: `apply_template content` → 1 round-trip. Then `edit_agent writer model=...` → round-trip 2. Then `edit_agent researcher instructions=...` → round-trip 3. Then `edit_agent strategist instructions=...` → round-trip 4. Etc.

That's 5+ tool calls, 5+ Undo receipts, 5+ chances for the operator to lose track of what's pending. With this PR it's one call.

## Contract change

```python
@skill apply_template(
    template: str,
    model: str = "",                                      # existing fleet-wide
    agent_overrides: dict[str, dict] | None = None,       # NEW
)
```

`agent_overrides` keys are agent slot names from the template; values may contain `model` and/or `instructions` (v1 allowed fields). Unknown agents and unknown fields are rejected upfront with HTTP 400 — no agents created on validation failure.

## Validation (upfront, atomic-ish)

Before any agent is created, the mesh route validates:
- All `agent_overrides` keys exist in the template (else 400 with offending names)
- All override fields are in `{model, instructions}` (else 400)
- Each `model` value resolves through `_resolve_litellm_key` (else 400)
- Each `instructions` length ≤ 12000 (matches `_FILE_CAPS["INSTRUCTIONS.md"]`, else 413)

The CLI-layer `_apply_template` treats unknown override keys as silent no-ops; the mesh route is the user-visible validation gate.

## Test plan

- [x] Single agent `model` override → only that agent gets the override
- [x] Two agents' `instructions` overridden independently
- [x] Combined `model` + `instructions` for the same agent
- [x] Unknown agent name → HTTP 400 with the offending name
- [x] Unknown override field → HTTP 400 listing offenders
- [x] Invalid model id → HTTP 400, NO agents created
- [x] Oversized `instructions` → HTTP 413, NO agents created
- [x] `agent_overrides={}` no-op (back-compat)
- [x] `agent_overrides=None` no-op (back-compat)
- [x] Existing callers passing only `template`/`model` continue working

109 tests pass in `tests/test_templates.py` + `tests/test_operator_fleet.py` (14 new tests for PR-N). `ruff check` clean.

## Tool count discipline

Zero new top-level `@skill` tools. `agent_overrides` is a new parameter on the existing `apply_template` skill — the operator's tool surface stays at 30.