### PR TITLE
feat(host): blackboard cross-project access counter

### DIFF
--- a/src/host/server.py
+++ b/src/host/server.py
@@ -448,6 +448,23 @@ def _record_scope_warn() -> None:
     _scope_warn_count += 1
 
 
+# Counter for cross-project blackboard access (read or write where the
+# caller's project differs from the existing key's writer-project). Pure
+# observability for Phase 3 enforcement design — NOT a denial. Surfaced on
+# ``/mesh/system/metrics`` as ``blackboard_cross_project_total``. Counter
+# is process-lifetime (resets on restart), naming follows ``scope_warn_total``
+# rather than the ``_24h`` mental model — restarts are roughly daily-ish in
+# practice and a true 24h window would need a separate ledger.
+_blackboard_xproject_count: dict[str, int] = {"read": 0, "write": 0}
+
+
+def _record_blackboard_xproject(kind: str) -> None:
+    """Bump the cross-project blackboard counter."""
+    if kind not in _blackboard_xproject_count:
+        return
+    _blackboard_xproject_count[kind] += 1
+
+
 def _caller_projects(agent_id: str) -> set[str]:
     """Return the project memberships visible to ``agent_id``.
 
@@ -472,6 +489,35 @@ def _caller_projects(agent_id: str) -> set[str]:
         for name, meta in projects.items()
         if agent_id in meta.get("members", [])
     }
+
+
+def _is_blackboard_cross_project(
+    caller: str, writer: str | None
+) -> bool:
+    """Return True when caller and writer are workers in disjoint project sets.
+
+    Best-effort detection used purely for telemetry — never gates access.
+    Returns False (so the counter is NOT incremented) when:
+
+    - ``writer`` is missing (e.g. unknown / deleted agent or no prior entry)
+    - either party is operator / ``mesh`` (fleet-global by design)
+    - caller and writer share at least one project membership
+    - either party has an empty membership set (standalone agent — not
+      meaningfully "cross-project" without two project anchors)
+
+    The intent is to count the case where two distinct *project-bound*
+    workers touch the same key, since that is what Phase 3 enforcement
+    will gate.
+    """
+    if not writer or writer == caller:
+        return False
+    if caller in {"operator", "mesh"} or writer in {"operator", "mesh"}:
+        return False
+    caller_set = _caller_projects(caller)
+    writer_set = _caller_projects(writer)
+    if not caller_set or not writer_set:
+        return False
+    return caller_set.isdisjoint(writer_set)
 
 
 def create_mesh_app(
@@ -992,6 +1038,13 @@ def create_mesh_app(
         entry = blackboard.read(key)
         if not entry:
             raise HTTPException(404, f"Key not found: {key}")
+        # Phase 3 Slice 1 telemetry: count cross-project reads. Skip
+        # internal/operator callers (fleet-global by design). No
+        # enforcement — pure observability informing the design doc.
+        if not _is_internal_caller(request) and _is_blackboard_cross_project(
+            agent_id, entry.written_by
+        ):
+            _record_blackboard_xproject("read")
         return entry.model_dump(mode="json")
 
     @app.put("/mesh/blackboard/{key:path}")
@@ -1011,6 +1064,15 @@ def create_mesh_app(
             raise HTTPException(400, "TTL must be positive")
         if not permissions.can_write_blackboard(agent_id, key):
             raise HTTPException(403, f"Agent {agent_id} cannot write {key}")
+        # Phase 3 Slice 1 telemetry: count cross-project writes against an
+        # EXISTING entry (new keys are by definition not cross-project).
+        # Skip internal/operator callers (fleet-global by design).
+        if not _is_internal_caller(request):
+            existing = blackboard.read(key)
+            if existing is not None and _is_blackboard_cross_project(
+                agent_id, existing.written_by
+            ):
+                _record_blackboard_xproject("write")
         entry = blackboard.write(key, value, written_by=agent_id, ttl=ttl)
         if trace_store:
             req_trace_id = request.headers.get("x-trace-id")
@@ -1039,6 +1101,14 @@ def create_mesh_app(
         bare = key.split("/", 2)[2] if key.startswith("projects/") and key.count("/") >= 2 else key
         if bare.startswith("history/"):
             raise HTTPException(400, "Cannot delete from history namespace")
+        # Phase 3 Slice 1 telemetry: count cross-project deletes (a delete
+        # is a write that mutates the key). Skip internal/operator callers.
+        if not _is_internal_caller(request):
+            existing = blackboard.read(key)
+            if existing is not None and _is_blackboard_cross_project(
+                agent_id, existing.written_by
+            ):
+                _record_blackboard_xproject("write")
         try:
             blackboard.delete(key, deleted_by=agent_id)
         except ValueError as e:
@@ -1068,6 +1138,14 @@ def create_mesh_app(
             raise HTTPException(413, f"Value too large ({value_size} bytes, max {_MAX_BB_VALUE_BYTES})")
         if not permissions.can_write_blackboard(agent_id, key):
             raise HTTPException(403, f"Agent {agent_id} cannot write {key}")
+        # Phase 3 Slice 1 telemetry: count cross-project CAS writes against
+        # an EXISTING entry. Skip internal/operator callers.
+        if not _is_internal_caller(request):
+            existing = blackboard.read(key)
+            if existing is not None and _is_blackboard_cross_project(
+                agent_id, existing.written_by
+            ):
+                _record_blackboard_xproject("write")
         expected_version = body.expected_version
         value = body.value
         entry = blackboard.write_if_version(
@@ -3188,6 +3266,13 @@ def create_mesh_app(
             # operator dashboard can render the right state.
             "scope_warn_total": _scope_warn_count,
             "project_scope_mode": _PROJECT_SCOPE_MODE,
+            # Phase 3 Slice 1 (PR-O'.1) telemetry: process-lifetime count
+            # of cross-project blackboard accesses (caller's project set
+            # is disjoint from the existing entry's writer-project set).
+            # Pure observability — informs the design doc for PR-O'.2;
+            # NO enforcement effect today. Counts kinds separately so the
+            # design can branch on read vs write volume.
+            "blackboard_cross_project_total": dict(_blackboard_xproject_count),
         }
 
     @app.get("/mesh/agents/{agent_id}/metrics")

--- a/tests/test_blackboard_observability.py
+++ b/tests/test_blackboard_observability.py
@@ -1,0 +1,369 @@
+"""PR-O'.1 — cross-project blackboard access counter (observability slice).
+
+Pure telemetry. No enforcement. Counter is process-lifetime, surfaced on
+``GET /mesh/system/metrics`` as ``blackboard_cross_project_total``.
+
+The plan (`docs/plans/2026-05-08-post-board-roadmap.md`, Phase 3 PR-O'.1)
+calls out the increment/no-increment matrix exercised below:
+
+  - cross-project read   → ``read`` += 1
+  - cross-project write  → ``write`` += 1
+  - same-project access  → no change
+  - operator caller      → no change
+  - x-mesh-internal      → no change
+  - new key (no prior)   → no change
+  - counter visible on operator-gated metrics endpoint
+"""
+
+from __future__ import annotations
+
+import importlib
+from unittest.mock import patch
+
+import pytest
+import yaml
+from httpx import ASGITransport, AsyncClient
+
+
+def _build_mesh(tmp_path, monkeypatch, *, auth_tokens=None):
+    """Build a mesh app + isolated blackboard with two projects on disk.
+
+    Project layout:
+        proj-a: members=[agent-a]
+        proj-b: members=[agent-b]
+        agent-c is standalone (no project)
+
+    Returns ``(app, blackboard, projects_dir, server_module)`` so callers
+    can ``patch('src.cli.config.PROJECTS_DIR', projects_dir)`` for the
+    duration of their HTTP calls.
+    """
+    # Pin the scope flag to warn so the unrelated /mesh/agents enforce
+    # path doesn't interfere with anything; reload to pick it up.
+    monkeypatch.setenv("OPENLEGION_PROJECT_SCOPE_MODE", "warn")
+    import src.host.server as server_module
+    importlib.reload(server_module)
+
+    from src.host.costs import CostTracker
+    from src.host.mesh import Blackboard, MessageRouter, PubSub
+    from src.host.permissions import PermissionMatrix
+    from src.host.traces import TraceStore
+    from src.shared.types import AgentPermissions
+
+    projects_dir = tmp_path / "projects"
+    (projects_dir / "proj-a").mkdir(parents=True)
+    (projects_dir / "proj-b").mkdir(parents=True)
+    (projects_dir / "proj-a" / "metadata.yaml").write_text(
+        yaml.dump({
+            "name": "proj-a",
+            "members": ["agent-a"],
+            "created_at": "2026-05-08T00:00:00+00:00",
+        }),
+    )
+    (projects_dir / "proj-b" / "metadata.yaml").write_text(
+        yaml.dump({
+            "name": "proj-b",
+            "members": ["agent-b"],
+            "created_at": "2026-05-08T00:00:00+00:00",
+        }),
+    )
+
+    perms = PermissionMatrix()
+    # Permissive — the enforcement layer is NOT under test here.
+    for aid in ("agent-a", "agent-b", "agent-c", "operator"):
+        perms.permissions[aid] = AgentPermissions(
+            agent_id=aid,
+            blackboard_read=["*"],
+            blackboard_write=["*"],
+        )
+
+    bb = Blackboard(db_path=str(tmp_path / "bb.db"))
+    pubsub = PubSub()
+    router = MessageRouter(perms, {})
+    router.register_agent("agent-a", "http://agent-a:8400", [])
+    router.register_agent("agent-b", "http://agent-b:8400", [])
+    router.register_agent("agent-c", "http://agent-c:8400", [])
+    router.register_agent("operator", "http://operator:8400", [])
+
+    costs = CostTracker(str(tmp_path / "costs.db"))
+    traces = TraceStore(str(tmp_path / "traces.db"))
+
+    app = server_module.create_mesh_app(
+        blackboard=bb, pubsub=pubsub, router=router, permissions=perms,
+        cost_tracker=costs, trace_store=traces, auth_tokens=auth_tokens,
+    )
+    # Reset the module-level counter so each test starts at zero.
+    server_module._blackboard_xproject_count["read"] = 0
+    server_module._blackboard_xproject_count["write"] = 0
+    # Stash teardown handles on the app for the test caller.
+    app.state._test_bb = bb
+    app.state._test_costs = costs
+    app.state._test_traces = traces
+    return app, bb, projects_dir, server_module
+
+
+def _teardown(app, monkeypatch, server_module):
+    try:
+        app.state._test_bb.close()
+        app.state._test_costs.close()
+        app.state._test_traces.close()
+    finally:
+        monkeypatch.delenv("OPENLEGION_PROJECT_SCOPE_MODE", raising=False)
+        importlib.reload(server_module)
+
+
+@pytest.mark.asyncio
+async def test_cross_project_read_increments_counter(tmp_path, monkeypatch):
+    """agent-a writes a key (proj-a); agent-b (proj-b) reads it → read += 1."""
+    app, bb, projects_dir, server_module = _build_mesh(tmp_path, monkeypatch)
+    try:
+        bb.write("scratch/note", {"hello": "world"}, written_by="agent-a")
+        with patch("src.cli.config.PROJECTS_DIR", projects_dir):
+            async with AsyncClient(
+                transport=ASGITransport(app=app), base_url="http://test",
+            ) as client:
+                resp = await client.get(
+                    "/mesh/blackboard/scratch/note",
+                    params={"agent_id": "agent-b"},
+                )
+        assert resp.status_code == 200
+        assert server_module._blackboard_xproject_count == {"read": 1, "write": 0}
+    finally:
+        _teardown(app, monkeypatch, server_module)
+
+
+@pytest.mark.asyncio
+async def test_cross_project_write_against_existing_increments(tmp_path, monkeypatch):
+    """PUT existing key written by another project → write += 1."""
+    app, bb, projects_dir, server_module = _build_mesh(tmp_path, monkeypatch)
+    try:
+        bb.write("scratch/note", {"v": 1}, written_by="agent-a")
+        with patch("src.cli.config.PROJECTS_DIR", projects_dir):
+            async with AsyncClient(
+                transport=ASGITransport(app=app), base_url="http://test",
+            ) as client:
+                resp = await client.put(
+                    "/mesh/blackboard/scratch/note",
+                    params={"agent_id": "agent-b"},
+                    json={"v": 2},
+                )
+        assert resp.status_code == 200
+        assert server_module._blackboard_xproject_count == {"read": 0, "write": 1}
+    finally:
+        _teardown(app, monkeypatch, server_module)
+
+
+@pytest.mark.asyncio
+async def test_same_project_does_not_increment(tmp_path, monkeypatch):
+    """Two members of the same project touching the same key → no increment."""
+    app, bb, projects_dir, server_module = _build_mesh(tmp_path, monkeypatch)
+    try:
+        # Add a second member to proj-a so two callers share one project.
+        (projects_dir / "proj-a" / "metadata.yaml").write_text(
+            yaml.dump({
+                "name": "proj-a",
+                "members": ["agent-a", "agent-c"],
+                "created_at": "2026-05-08T00:00:00+00:00",
+            }),
+        )
+        bb.write("scratch/note", {"hello": "world"}, written_by="agent-a")
+        with patch("src.cli.config.PROJECTS_DIR", projects_dir):
+            async with AsyncClient(
+                transport=ASGITransport(app=app), base_url="http://test",
+            ) as client:
+                resp = await client.get(
+                    "/mesh/blackboard/scratch/note",
+                    params={"agent_id": "agent-c"},
+                )
+                resp2 = await client.put(
+                    "/mesh/blackboard/scratch/note",
+                    params={"agent_id": "agent-c"},
+                    json={"hello": "again"},
+                )
+        assert resp.status_code == 200
+        assert resp2.status_code == 200
+        assert server_module._blackboard_xproject_count == {"read": 0, "write": 0}
+    finally:
+        _teardown(app, monkeypatch, server_module)
+
+
+@pytest.mark.asyncio
+async def test_operator_caller_does_not_increment(tmp_path, monkeypatch):
+    """Operator is fleet-global by definition — never counted."""
+    app, bb, projects_dir, server_module = _build_mesh(tmp_path, monkeypatch)
+    try:
+        bb.write("scratch/note", {"v": 1}, written_by="agent-a")
+        with patch("src.cli.config.PROJECTS_DIR", projects_dir):
+            async with AsyncClient(
+                transport=ASGITransport(app=app), base_url="http://test",
+            ) as client:
+                resp = await client.get(
+                    "/mesh/blackboard/scratch/note",
+                    params={"agent_id": "operator"},
+                )
+                resp2 = await client.put(
+                    "/mesh/blackboard/scratch/note",
+                    params={"agent_id": "operator"},
+                    json={"v": 2},
+                )
+        assert resp.status_code == 200
+        assert resp2.status_code == 200
+        assert server_module._blackboard_xproject_count == {"read": 0, "write": 0}
+    finally:
+        _teardown(app, monkeypatch, server_module)
+
+
+@pytest.mark.asyncio
+async def test_internal_caller_does_not_increment(tmp_path, monkeypatch):
+    """``x-mesh-internal: 1`` from loopback bypasses the counter."""
+    app, bb, projects_dir, server_module = _build_mesh(tmp_path, monkeypatch)
+    try:
+        bb.write("scratch/note", {"v": 1}, written_by="agent-a")
+        with patch("src.cli.config.PROJECTS_DIR", projects_dir):
+            async with AsyncClient(
+                transport=ASGITransport(app=app), base_url="http://test",
+            ) as client:
+                # ASGITransport synthesises a 127.0.0.1 client peer, so
+                # the loopback half of ``_is_internal_caller`` is satisfied.
+                resp = await client.get(
+                    "/mesh/blackboard/scratch/note",
+                    params={"agent_id": "agent-b"},
+                    headers={"x-mesh-internal": "1"},
+                )
+                resp2 = await client.put(
+                    "/mesh/blackboard/scratch/note",
+                    params={"agent_id": "agent-b"},
+                    json={"v": 2},
+                    headers={"x-mesh-internal": "1"},
+                )
+        assert resp.status_code == 200
+        assert resp2.status_code == 200
+        assert server_module._blackboard_xproject_count == {"read": 0, "write": 0}
+    finally:
+        _teardown(app, monkeypatch, server_module)
+
+
+@pytest.mark.asyncio
+async def test_new_key_write_does_not_increment(tmp_path, monkeypatch):
+    """First write to a key has no prior entry → cannot be cross-project."""
+    app, bb, projects_dir, server_module = _build_mesh(tmp_path, monkeypatch)
+    try:
+        with patch("src.cli.config.PROJECTS_DIR", projects_dir):
+            async with AsyncClient(
+                transport=ASGITransport(app=app), base_url="http://test",
+            ) as client:
+                resp = await client.put(
+                    "/mesh/blackboard/scratch/fresh",
+                    params={"agent_id": "agent-b"},
+                    json={"v": 1},
+                )
+        assert resp.status_code == 200
+        assert server_module._blackboard_xproject_count == {"read": 0, "write": 0}
+    finally:
+        _teardown(app, monkeypatch, server_module)
+
+
+@pytest.mark.asyncio
+async def test_counter_surfaced_on_system_metrics(tmp_path, monkeypatch):
+    """Counter is reflected on ``/mesh/system/metrics`` (operator-gated)."""
+    auth_tokens = {"operator": "tok-op", "agent-a": "tok-a", "agent-b": "tok-b"}
+    app, bb, projects_dir, server_module = _build_mesh(
+        tmp_path, monkeypatch, auth_tokens=auth_tokens,
+    )
+    try:
+        bb.write("scratch/note", {"v": 1}, written_by="agent-a")
+        with patch("src.cli.config.PROJECTS_DIR", projects_dir):
+            async with AsyncClient(
+                transport=ASGITransport(app=app), base_url="http://test",
+            ) as client:
+                # Trigger a cross-project read as agent-b.
+                read_resp = await client.get(
+                    "/mesh/blackboard/scratch/note",
+                    params={"agent_id": "agent-b"},
+                    headers={"Authorization": "Bearer tok-b"},
+                )
+                assert read_resp.status_code == 200
+
+                # Non-operator hitting metrics → 403 (gated endpoint).
+                worker_metrics = await client.get(
+                    "/mesh/system/metrics",
+                    headers={"Authorization": "Bearer tok-b"},
+                )
+                assert worker_metrics.status_code == 403
+
+                # Operator can read the counter.
+                op_metrics = await client.get(
+                    "/mesh/system/metrics",
+                    headers={"Authorization": "Bearer tok-op"},
+                )
+        assert op_metrics.status_code == 200
+        body = op_metrics.json()
+        assert "blackboard_cross_project_total" in body
+        assert body["blackboard_cross_project_total"] == {"read": 1, "write": 0}
+    finally:
+        _teardown(app, monkeypatch, server_module)
+
+
+@pytest.mark.asyncio
+async def test_delete_existing_cross_project_increments_write(tmp_path, monkeypatch):
+    """DELETE counts as a write — kind=write when prior entry is cross-project."""
+    app, bb, projects_dir, server_module = _build_mesh(tmp_path, monkeypatch)
+    try:
+        bb.write("scratch/note", {"v": 1}, written_by="agent-a")
+        with patch("src.cli.config.PROJECTS_DIR", projects_dir):
+            async with AsyncClient(
+                transport=ASGITransport(app=app), base_url="http://test",
+            ) as client:
+                resp = await client.delete(
+                    "/mesh/blackboard/scratch/note",
+                    params={"agent_id": "agent-b"},
+                )
+        assert resp.status_code == 200
+        assert server_module._blackboard_xproject_count == {"read": 0, "write": 1}
+    finally:
+        _teardown(app, monkeypatch, server_module)
+
+
+@pytest.mark.asyncio
+async def test_claim_existing_cross_project_increments_write(tmp_path, monkeypatch):
+    """Atomic CAS write counts as kind=write when key was last written by other project."""
+    app, bb, projects_dir, server_module = _build_mesh(tmp_path, monkeypatch)
+    try:
+        existing = bb.write("scratch/note", {"v": 1}, written_by="agent-a")
+        with patch("src.cli.config.PROJECTS_DIR", projects_dir):
+            async with AsyncClient(
+                transport=ASGITransport(app=app), base_url="http://test",
+            ) as client:
+                resp = await client.post(
+                    "/mesh/blackboard/claim",
+                    json={
+                        "agent_id": "agent-b",
+                        "key": "scratch/note",
+                        "value": {"v": 2},
+                        "expected_version": existing.version,
+                    },
+                )
+        assert resp.status_code == 200
+        assert server_module._blackboard_xproject_count == {"read": 0, "write": 1}
+    finally:
+        _teardown(app, monkeypatch, server_module)
+
+
+@pytest.mark.asyncio
+async def test_standalone_agent_does_not_increment(tmp_path, monkeypatch):
+    """Standalone agent (no project membership) → not "cross-project"."""
+    app, bb, projects_dir, server_module = _build_mesh(tmp_path, monkeypatch)
+    try:
+        # agent-c is standalone; agent-a is in proj-a.
+        bb.write("scratch/note", {"v": 1}, written_by="agent-a")
+        with patch("src.cli.config.PROJECTS_DIR", projects_dir):
+            async with AsyncClient(
+                transport=ASGITransport(app=app), base_url="http://test",
+            ) as client:
+                resp = await client.get(
+                    "/mesh/blackboard/scratch/note",
+                    params={"agent_id": "agent-c"},
+                )
+        assert resp.status_code == 200
+        assert server_module._blackboard_xproject_count == {"read": 0, "write": 0}
+    finally:
+        _teardown(app, monkeypatch, server_module)


### PR DESCRIPTION
## Summary

Adds a process-lifetime counter for cross-project blackboard reads/writes. **Pure telemetry — no enforcement change.**

This is **PR-O'.1** from `docs/plans/2026-05-08-post-board-roadmap.md` (Phase 3, observability slice). It precedes the multi-tenant blackboard design doc — we want real numbers on cross-project access volume in live fleets before we lock the key namespace and migration shape.

## Why

Phase 3 enforcement (key prefixes vs out-of-band metadata, warn vs enforce mode, migration tooling) is a 600-900 LOC effort that hinges on whether real fleets actually cross project boundaries today, and how often. Shipping observability first means the design doc has data to point at, not vibes.

## What

- `_blackboard_xproject_count: dict[str, int]` with `read` / `write` keys (module-level, parallel to existing `_scope_warn_count`).
- `_record_blackboard_xproject(kind)` helper.
- Wired into the 4 mutating/reading blackboard endpoints — `GET /mesh/blackboard/{key}`, `PUT`, `DELETE`, `POST /claim`. Watch endpoint skipped (too noisy).
- Surfaced on `/mesh/system/metrics` as `blackboard_cross_project_total` (matching the `scope_warn_total` naming for consistency; renamed from spec's `_24h` since the counter is process-lifetime).
- Operator-or-internal gated via existing `_require_operator_or_internal`.

## Detection logic

After permission check passes, before returning success:
- Skip operator + internal (`x-mesh-internal`) callers — fleet-global by design.
- Skip standalone agents (no project membership).
- For reads: look up existing entry's `written_by`, resolve writer's projects.
- For writes: look up existing entry at the same key (new keys can't be cross-project). Same logic.
- Cross-project iff caller's project set and writer's project set are **non-empty disjoint** (no shared project membership).

The "non-empty disjoint" semantics is a judgment call worth surfacing during the Slice 2 design review — a worker in `{A, B}` reading a key written by a worker in `{B, C}` is collaborating on shared project `B`, not crossing boundaries.

## Privacy

Counter does NOT store or log project identity per access — just two integers.

## Test plan

- [x] Cross-project read → `read` increments
- [x] Cross-project write against existing entry → `write` increments
- [x] Same-project access → no increment
- [x] Operator caller → no increment
- [x] Internal (`x-mesh-internal`) caller → no increment
- [x] New key write (no prior entry) → no increment
- [x] Standalone agent (no projects) → no increment
- [x] Cross-project DELETE → `write` increments
- [x] Cross-project CAS claim → `write` increments
- [x] Counter visible on `/mesh/system/metrics`

10 new tests pass. 86 existing `tests/test_mesh.py` tests regression-free. `ruff` clean.

## Cost note

`_caller_projects` does a disk scan of `config/projects/*/metadata.yaml` per call, twice per blackboard access (caller + writer). For typical fleets (<20 projects) this is comparable to the existing `_scope_warn` overhead. If profiling shows it on a hot path we can add an LRU cache; not doing it now to avoid premature optimization.