### PR TITLE
feat(operator,host): per-agent cost + outcome + stale-task metrics for heartbeat

### DIFF
--- a/src/agent/builtins/operator_tools.py
+++ b/src/agent/builtins/operator_tools.py
@@ -1139,7 +1139,9 @@ async def summarize_project_progress(
     description=(
         "Read agents. Without agent_id: roster summary. With agent_id: "
         "depth='profile' returns role/capabilities/INTERFACE; "
-        "depth='history' adds recent activity log. depth defaults to summary."
+        "depth='history' adds recent activity log. depth defaults to summary. "
+        "Pass stale_threshold_hours=N to also annotate each agent in the "
+        "roster with its stale-task count and up-to-5 oldest stale task IDs."
     ),
     parameters={
         "agent_id": {
@@ -1153,11 +1155,21 @@ async def summarize_project_progress(
             "enum": ["summary", "profile", "history"],
             "default": "summary",
         },
+        "stale_threshold_hours": {
+            "type": "integer",
+            "description": (
+                "When set, roster entries gain stale_task_count + "
+                "stale_task_ids (top 5 oldest). Counts non-terminal "
+                "tasks created more than N hours ago. Range 1-168."
+            ),
+            "default": 0,
+        },
     },
 )
 async def inspect_agents(
     agent_id: str = "",
     depth: str = "summary",
+    stale_threshold_hours: int | None = None,
     *,
     mesh_client=None,
     **_kw,
@@ -1169,6 +1181,18 @@ async def inspect_agents(
         return {"error": "This tool is only available to the operator agent."}
     if mesh_client is None:
         return {"error": "No mesh_client available"}
+
+    # ``0`` is the JSON-schema default for the optional integer param;
+    # treat 0 the same as None (param not supplied) so the LLM can omit
+    # it without triggering a stale-task lookup.
+    threshold_h = stale_threshold_hours or None
+    if threshold_h is not None and not (1 <= threshold_h <= 168):
+        return {
+            "error": (
+                "stale_threshold_hours must be between 1 and 168 "
+                "(1 hour to 7 days)"
+            ),
+        }
 
     # No agent_id → roster (always summary regardless of depth).
     if not agent_id:
@@ -1182,8 +1206,27 @@ async def inspect_agents(
             if isinstance(info, dict):
                 entry["role"] = info.get("role", "")
                 entry["capabilities"] = info.get("capabilities", [])
+            if threshold_h is not None:
+                # Per-agent stale lookup. Failures degrade to count=0
+                # so a single agent's mesh hiccup doesn't poison the
+                # whole roster response.
+                try:
+                    stale = await mesh_client.get_agent_stale_tasks(
+                        name, threshold_hours=threshold_h,
+                    )
+                    entry["stale_task_count"] = int(stale.get("count", 0) or 0)
+                    entry["stale_task_ids"] = list(stale.get("task_ids", []))
+                except Exception as e:
+                    logger.debug(
+                        "inspect_agents stale lookup failed for %s: %s", name, e,
+                    )
+                    entry["stale_task_count"] = 0
+                    entry["stale_task_ids"] = []
             agents.append(entry)
-        return {"agents": agents, "count": len(agents)}
+        result: dict = {"agents": agents, "count": len(agents)}
+        if threshold_h is not None:
+            result["stale_threshold_hours"] = threshold_h
+        return result
 
     if depth == "history":
         try:

--- a/src/agent/mesh_client.py
+++ b/src/agent/mesh_client.py
@@ -1320,4 +1320,20 @@ class MeshClient:
         response.raise_for_status()
         return response.json()
 
+    async def get_agent_stale_tasks(
+        self, agent_id: str, threshold_hours: int = 24,
+    ) -> dict:
+        """Get up to 5 oldest stale task IDs for ``agent_id``.
+
+        Powers ``inspect_agents(stale_threshold_hours=N)`` in the
+        operator heartbeat. Returns ``{"agent_id", "threshold_hours",
+        "count", "task_ids"}``. Operator-only on the mesh side.
+        """
+        response = await self._get_with_retry(
+            f"{self.mesh_url}/mesh/agents/{agent_id}/stale-tasks"
+            f"?threshold_hours={int(threshold_hours)}",
+        )
+        response.raise_for_status()
+        return response.json()
+
 

--- a/src/cli/config.py
+++ b/src/cli/config.py
@@ -1567,30 +1567,43 @@ _OPERATOR_HEARTBEAT = """\
 You are running an autonomous fleet health check. You have access ONLY to monitoring tools.
 Your previous observations are included above in OBSERVATIONS.md.
 
+Step budget: stay at or under 8 tool calls per cycle (HEARTBEAT_MAX_ITERATIONS=10
+in the loop; 8 leaves headroom for the final assistant turn).
+
 1. Review your previous observations (above) to check what you flagged last cycle.
    Do not re-alert on known issues unless they have escalated in severity.
 
 2. Call get_system_status() for fleet-wide metrics:
    - Total cost, cost trend vs yesterday
-   - Agent health counts
-   - Pre-computed agents_needing_attention list
+   - Per-agent cost (per_agent_cost_today_usd, per_agent_cost_vs_yesterday_ratio)
+   - Per-agent task health: outcome_rejected_24h_count, execution_failures_24h_count,
+     stale_tasks_24h_count
+   - Agent health counts and pre-computed agents_needing_attention list
    - Plan limits and current usage
 
-3. Call inspect_agents() for per-agent status overview.
+3. Call inspect_agents() for the roster summary.
 
-4. For agents flagged in agents_needing_attention or with new concerning signals
-   (unhealthy, cost_vs_yesterday_ratio > 2.0), call
-   inspect_agents(agent_id, depth="profile") for details.
+4. Drill in for agents that show concerning signals. PREFER one targeted call
+   per drill — don't fan out across the whole fleet:
+   - If any agent appears in agents_needing_attention OR has
+     per_agent_cost_vs_yesterday_ratio > 2.0 OR
+     outcome_rejected_24h_count[agent] > 5 OR
+     execution_failures_24h_count[agent] > 3:
+     call inspect_agents(agent_id, depth="profile") for that agent.
+   - If stale_tasks_24h_count has any non-zero entry, call
+     inspect_agents(stale_threshold_hours=24) ONCE to pull the offending
+     task IDs (the result annotates every roster entry — don't loop).
 
 5. Call save_observations() with:
    - fleet_summary: one-line health (e.g. "5/6 healthy, cost stable")
    - agents_attention: list of agents needing attention with issue and severity
    - cost_trend: up/down/stable with percentage
-   - notes: anything unusual not captured above
+   - notes: stale task IDs, rejected outcomes, anything unusual not captured above
 
-6. If any agent is CRITICAL (failed state, budget exceeded),
-   call notify_user() with a brief alert. Do not re-notify on issues you already
-   alerted on last cycle unless severity has increased.
+6. If any agent is CRITICAL (failed state, budget exceeded, >5 rejected outcomes,
+   or stale work blocking a project), call notify_user() with a brief alert.
+   Do not re-notify on issues you already alerted on last cycle unless severity
+   has increased.
 
 If any tool call fails, record the failure in save_observations and continue.
 Do not hallucinate data you could not retrieve.

--- a/src/host/orchestration.py
+++ b/src/host/orchestration.py
@@ -464,6 +464,114 @@ class Tasks:
             rows = conn.execute(sql, params).fetchall()
         return [self._row_to_dict(r) for r in rows]
 
+    # ── Per-agent aggregates for the operator heartbeat (PR-J') ─────
+    #
+    # The system_metrics endpoint surfaces per-agent counts so the
+    # operator's heartbeat playbook can drill in only when something
+    # actually broke. Counts (not rates) so single-task agents don't
+    # produce noisy 100% denominators. Operator exclusion is handled
+    # by the caller — these helpers run unfiltered and the caller
+    # drops ``operator`` from the dict before serialising.
+
+    def count_outcomes_since(
+        self,
+        outcome: str,
+        *,
+        since_seconds: float,
+    ) -> dict[str, int]:
+        """Count tasks per assignee whose latest ``outcome`` was set within ``since_seconds``.
+
+        Mirrors ``SELECT assignee, COUNT(*) FROM tasks WHERE outcome=?
+        AND completed_at >= ? GROUP BY assignee``. Operator is included;
+        callers drop it. Tasks with NULL ``completed_at`` (still running)
+        are excluded by the >= filter.
+        """
+        cutoff = time.time() - since_seconds
+        with self._conn() as conn:
+            rows = conn.execute(
+                "SELECT assignee, COUNT(*) FROM tasks "
+                "WHERE outcome = ? AND completed_at IS NOT NULL "
+                "AND completed_at >= ? GROUP BY assignee",
+                (outcome, cutoff),
+            ).fetchall()
+        return {row[0]: int(row[1] or 0) for row in rows if row[0]}
+
+    def count_failed_status_since(
+        self,
+        *,
+        since_seconds: float,
+    ) -> dict[str, int]:
+        """Count tasks per assignee that landed in ``failed`` within ``since_seconds``.
+
+        ``status='failed'`` always sets ``completed_at`` (terminal
+        transitions stamp both), so we filter on ``completed_at`` rather
+        than ``updated_at`` — keeps the metric stable even if an
+        operator no-op-edits a failed task later.
+        """
+        cutoff = time.time() - since_seconds
+        with self._conn() as conn:
+            rows = conn.execute(
+                "SELECT assignee, COUNT(*) FROM tasks "
+                "WHERE status = 'failed' AND completed_at IS NOT NULL "
+                "AND completed_at >= ? GROUP BY assignee",
+                (cutoff,),
+            ).fetchall()
+        return {row[0]: int(row[1] or 0) for row in rows if row[0]}
+
+    def count_stale_since(
+        self,
+        *,
+        threshold_seconds: float,
+    ) -> dict[str, int]:
+        """Count non-terminal tasks per assignee created more than ``threshold_seconds`` ago.
+
+        Stale = open work that's been sitting around longer than the
+        operator's patience window. Done / failed / cancelled rows are
+        excluded so the count means "still owed".
+        """
+        cutoff = time.time() - threshold_seconds
+        placeholders = ",".join("?" * len(TERMINAL_STATUSES))
+        params: list[Any] = sorted(TERMINAL_STATUSES)
+        params.append(cutoff)
+        with self._conn() as conn:
+            rows = conn.execute(
+                "SELECT assignee, COUNT(*) FROM tasks "
+                f"WHERE status NOT IN ({placeholders}) "
+                "AND created_at < ? GROUP BY assignee",
+                params,
+            ).fetchall()
+        return {row[0]: int(row[1] or 0) for row in rows if row[0]}
+
+    def list_stale_for_assignee(
+        self,
+        assignee: str,
+        *,
+        threshold_seconds: float,
+        limit: int = 5,
+    ) -> list[str]:
+        """Return up to ``limit`` stale task IDs for ``assignee``, oldest first.
+
+        Used by ``inspect_agents(stale_threshold_hours=N)`` so the
+        operator drills into a small set of representative IDs without
+        fetching the full row payloads.
+        """
+        cutoff = time.time() - threshold_seconds
+        placeholders = ",".join("?" * len(TERMINAL_STATUSES))
+        params: list[Any] = [assignee]
+        params.extend(sorted(TERMINAL_STATUSES))
+        params.append(cutoff)
+        params.append(int(limit))
+        with self._conn() as conn:
+            rows = conn.execute(
+                "SELECT id FROM tasks "
+                "WHERE assignee = ? "
+                f"AND status NOT IN ({placeholders}) "
+                "AND created_at < ? "
+                "ORDER BY created_at ASC LIMIT ?",
+                params,
+            ).fetchall()
+        return [row[0] for row in rows]
+
     def update_status(
         self,
         task_id: str,

--- a/src/host/server.py
+++ b/src/host/server.py
@@ -3285,14 +3285,71 @@ def create_mesh_app(
 
         cost_ratio = round(cost_today / cost_yesterday, 2) if cost_yesterday > 0 else 0
 
-        # -- Per-agent failure rates (placeholder — needs task tracking) --
-        # TODO: compute per-agent failure rates from recent task outcomes.
-        # The shape ``{agent_id: float in [0,1]}`` is reserved on the
-        # contract; consumers must continue to handle the empty-dict
-        # case as "data unavailable, not zero-failure". Until this is
-        # wired, the operator heartbeat instructions intentionally do
-        # NOT reference ``failure_rate`` thresholds (see _OPERATOR_HEARTBEAT
-        # in src/cli/config.py).
+        # -- Per-agent cost (PR-J') --
+        # Mirrors the ``agent_metrics`` per-agent cost / ratio pattern but
+        # rolled up across the fleet so the operator heartbeat can spot
+        # outliers in a single call. Operator excluded — it's a system
+        # agent whose spend is bookkeeping, not user work.
+        agent_ids_user = [aid for aid in agents if aid != "operator"]
+        per_agent_cost_today: dict[str, float] = {}
+        per_agent_cost_ratio: dict[str, float] = {}
+        if cost_tracker:
+            for aid in agent_ids_user:
+                today_a = cost_tracker.get_spend(aid, "today").get(
+                    "total_cost", 0.0,
+                )
+                # ``yesterday`` is "since yesterday midnight" (includes
+                # today). Subtract today to isolate yesterday-only spend.
+                since_yest_a = cost_tracker.get_spend(aid, "yesterday").get(
+                    "total_cost", 0.0,
+                )
+                yest_a = max(since_yest_a - today_a, 0.0)
+                per_agent_cost_today[aid] = round(today_a, 4)
+                per_agent_cost_ratio[aid] = (
+                    round(today_a / yest_a, 2) if yest_a > 0 else 0.0
+                )
+
+        # -- Per-agent task outcome / failure / stale counts (PR-J') --
+        # The two count fields supersede the legacy ``failure_rate_by_agent``
+        # placeholder for the operator heartbeat: counts on small fleets
+        # are stable, rates on small denominators are noise. The
+        # placeholder stays (empty dict) so contract consumers don't need
+        # an immediate update; treat ``{}`` as "data unavailable" still.
+        outcome_rejected_24h: dict[str, int] = {}
+        execution_failures_24h: dict[str, int] = {}
+        stale_tasks_24h: dict[str, int] = {}
+        if tasks_store is not None:
+            try:
+                _day_seconds = 24 * 60 * 60
+                outcome_rejected_24h = {
+                    aid: count
+                    for aid, count in tasks_store.count_outcomes_since(
+                        "rejected", since_seconds=_day_seconds,
+                    ).items()
+                    if aid != "operator"
+                }
+                execution_failures_24h = {
+                    aid: count
+                    for aid, count in tasks_store.count_failed_status_since(
+                        since_seconds=_day_seconds,
+                    ).items()
+                    if aid != "operator"
+                }
+                stale_tasks_24h = {
+                    aid: count
+                    for aid, count in tasks_store.count_stale_since(
+                        threshold_seconds=_day_seconds,
+                    ).items()
+                    if aid != "operator"
+                }
+            except Exception as e:
+                # Telemetry is best-effort; never block the heartbeat
+                # endpoint on a tasks_v2 hiccup.
+                logger.debug("system_metrics task aggregates failed: %s", e)
+
+        # Legacy placeholder — kept on the contract so consumers
+        # treating ``{}`` as "data unavailable" don't break. The two
+        # count dicts above are what the heartbeat playbook keys on now.
         failure_rates: dict[str, float] = {}
 
         # -- Agents needing attention (exclude operator) --
@@ -3323,6 +3380,17 @@ def create_mesh_app(
             "busy": busy,
             "total_cost_today_usd": round(cost_today, 4),
             "cost_vs_yesterday_ratio": cost_ratio,
+            # Per-agent cost surface (PR-J'). Empty dicts when no spend
+            # has been recorded — that case is meaningfully different
+            # from "data unavailable", which would require the cost
+            # tracker to be ``None``.
+            "per_agent_cost_today_usd": per_agent_cost_today,
+            "per_agent_cost_vs_yesterday_ratio": per_agent_cost_ratio,
+            # Per-agent task outcome / failure / stale counts (PR-J').
+            # Empty dicts when tasks_v2 is disabled OR no rows match.
+            "outcome_rejected_24h_count": outcome_rejected_24h,
+            "execution_failures_24h_count": execution_failures_24h,
+            "stale_tasks_24h_count": stale_tasks_24h,
             "failure_rate_by_agent": failure_rates,
             "agents_needing_attention": agents_attention,
             "plan_limits": {
@@ -3410,6 +3478,45 @@ def create_mesh_app(
             "tasks_failed_24h": 0,
             "failure_rate": 0.0,
             "avg_task_duration_s": 0,
+        }
+
+    @app.get("/mesh/agents/{agent_id}/stale-tasks")
+    async def agent_stale_tasks(
+        agent_id: str, request: Request, threshold_hours: int = 24,
+    ) -> dict:
+        """List up to 5 oldest stale (non-terminal, created >threshold ago) tasks.
+
+        Operator-only. Powers ``inspect_agents(stale_threshold_hours=N)``
+        in the operator heartbeat. Returns ``{"agent_id", "threshold_hours",
+        "count", "task_ids"}``. When tasks_v2 is disabled or the agent has
+        no stale tasks, ``count`` is 0 and ``task_ids`` is empty.
+        """
+        _require_operator_or_internal(request)
+        _validate_agent_id(agent_id)
+        if not (1 <= threshold_hours <= 168):
+            raise HTTPException(
+                400, "threshold_hours must be between 1 and 168 (1 hour to 7 days)",
+            )
+        if tasks_store is None:
+            return {
+                "agent_id": agent_id,
+                "threshold_hours": threshold_hours,
+                "count": 0,
+                "task_ids": [],
+            }
+        threshold_seconds = float(threshold_hours) * 3600.0
+        try:
+            ids = tasks_store.list_stale_for_assignee(
+                agent_id, threshold_seconds=threshold_seconds, limit=5,
+            )
+        except Exception as e:
+            logger.debug("stale-tasks lookup failed for %s: %s", agent_id, e)
+            ids = []
+        return {
+            "agent_id": agent_id,
+            "threshold_hours": threshold_hours,
+            "count": len(ids),
+            "task_ids": ids,
         }
 
     # === Mesh Project Proxy Endpoints ===

--- a/tests/test_operator_config.py
+++ b/tests/test_operator_config.py
@@ -316,6 +316,36 @@ class TestOperatorConstants:
         assert "save_observations" in _OPERATOR_HEARTBEAT
         assert "notify_user" in _OPERATOR_HEARTBEAT
 
+    def test_heartbeat_references_prj_metric_keys(self):
+        """PR-J' — heartbeat keys on the new metric fields, not failure_rate."""
+        from src.cli.config import _OPERATOR_HEARTBEAT
+        # New keys must appear so the LLM knows to look at them.
+        assert "outcome_rejected_24h_count" in _OPERATOR_HEARTBEAT
+        assert "stale_tasks_24h_count" in _OPERATOR_HEARTBEAT
+        assert "execution_failures_24h_count" in _OPERATOR_HEARTBEAT
+        assert "per_agent_cost_vs_yesterday_ratio" in _OPERATOR_HEARTBEAT
+        # The dead failure_rate threshold rule must NOT be back.
+        assert "failure_rate > 0.30" not in _OPERATOR_HEARTBEAT
+        # Stale-task drill-in references the new inspect_agents parameter.
+        assert "stale_threshold_hours=24" in _OPERATOR_HEARTBEAT
+
+    def test_heartbeat_step_count_within_budget(self):
+        """Total numbered steps stay within the HEARTBEAT_MAX_ITERATIONS=10 budget.
+
+        Counting numbered top-level steps (``1.`` through ``N.``) — each
+        step that calls a tool burns one iteration. 8 leaves headroom
+        for the final assistant turn that emits the heartbeat summary.
+        """
+        import re
+
+        from src.cli.config import _OPERATOR_HEARTBEAT
+        steps = re.findall(r"^\s*(\d+)\.\s", _OPERATOR_HEARTBEAT, re.MULTILINE)
+        max_step = max(int(s) for s in steps)
+        assert max_step <= 9, (
+            f"heartbeat has {max_step} numbered steps; budget is 9 "
+            f"(HEARTBEAT_MAX_ITERATIONS=10 minus the final assistant turn)"
+        )
+
     def test_core_has_key_sections(self):
         from src.shared.operator_playbooks import _OPERATOR_CORE
         assert "Routing Work" in _OPERATOR_CORE

--- a/tests/test_operator_metrics.py
+++ b/tests/test_operator_metrics.py
@@ -11,7 +11,6 @@ from src.host.costs import CostTracker
 from src.host.health import HealthMonitor
 from src.host.mesh import Blackboard, MessageRouter, PubSub
 from src.host.permissions import PermissionMatrix
-from src.host.server import create_mesh_app
 from src.shared.types import AgentPermissions
 
 
@@ -31,8 +30,20 @@ def _make_perms(*agent_ids: str) -> PermissionMatrix:
 
 
 @pytest.fixture
-def metrics_app(tmp_path):
+def metrics_app(tmp_path, monkeypatch):
     """Build a mesh app with health monitor, cost tracker, and lane manager."""
+    # PR-J' — point tasks_v2 at a per-test sqlite file so the stale /
+    # outcome / failure counts surface in ``system_metrics`` without
+    # touching ``data/tasks.db`` on the developer's machine.
+    monkeypatch.setenv("OPENLEGION_ORCHESTRATION_TASKS_V2", "1")
+    monkeypatch.setenv(
+        "OPENLEGION_ORCHESTRATION_TASKS_DB", str(tmp_path / "tasks.db"),
+    )
+    import importlib
+
+    import src.host.server as server_module
+    importlib.reload(server_module)
+
     bb = Blackboard(db_path=str(tmp_path / "bb.db"))
     pubsub = PubSub()
     perms = _make_perms("alpha", "beta")
@@ -65,7 +76,7 @@ def metrics_app(tmp_path):
         "beta": {"queued": 0, "busy": False, "pending": 0, "collected": 0},
     }
 
-    app = create_mesh_app(
+    app = server_module.create_mesh_app(
         bb, pubsub, router, perms,
         health_monitor=health,
         cost_tracker=cost_tracker,
@@ -80,10 +91,16 @@ def metrics_app(tmp_path):
         "health": health,
         "router": router,
         "lane_manager": lane_manager,
+        "tasks_store": getattr(app, "tasks_store", None),
     }
 
     cost_tracker.close()
     bb.close()
+    # Reload the module so the env var change doesn't leak into other
+    # tests that run later in the session.
+    monkeypatch.delenv("OPENLEGION_ORCHESTRATION_TASKS_V2", raising=False)
+    monkeypatch.delenv("OPENLEGION_ORCHESTRATION_TASKS_DB", raising=False)
+    importlib.reload(server_module)
 
 
 class TestSystemMetrics:
@@ -156,6 +173,177 @@ class TestSystemMetrics:
         assert data["healthy"] == 2
         assert data["failed"] == 0
         assert len(data["agents_needing_attention"]) == 0
+
+
+class TestSystemMetricsPRJ:
+    """PR-J' — per-agent cost + outcome + stale-task fields on system_metrics."""
+
+    def test_new_fields_present_with_correct_shape(self, metrics_app):
+        client = metrics_app["client"]
+        resp = client.get("/mesh/system/metrics")
+        data = resp.json()
+        # All five new fields exist and are dicts.
+        for field in (
+            "per_agent_cost_today_usd",
+            "per_agent_cost_vs_yesterday_ratio",
+            "outcome_rejected_24h_count",
+            "execution_failures_24h_count",
+            "stale_tasks_24h_count",
+        ):
+            assert field in data, f"missing field {field!r}"
+            assert isinstance(data[field], dict), f"{field} should be a dict"
+
+    def test_per_agent_cost_populated_from_costs_store(self, metrics_app):
+        cost_tracker = metrics_app["cost_tracker"]
+        cost_tracker.track("alpha", "claude-3-5-sonnet-20241022", 1000, 500)
+
+        client = metrics_app["client"]
+        resp = client.get("/mesh/system/metrics")
+        data = resp.json()
+        # alpha got tracked spend; beta did not.
+        assert data["per_agent_cost_today_usd"]["alpha"] > 0
+        assert data["per_agent_cost_today_usd"]["beta"] == 0
+        # Yesterday baseline is 0 → ratio is 0.0 (not divide-by-zero).
+        assert data["per_agent_cost_vs_yesterday_ratio"]["alpha"] == 0.0
+
+    def test_per_agent_cost_excludes_operator(self, metrics_app):
+        # Register operator on the router so it shows up in agents.
+        router = metrics_app["router"]
+        router.register_agent("operator", "http://localhost:8400")
+        cost_tracker = metrics_app["cost_tracker"]
+        cost_tracker.track("operator", "claude-3-5-sonnet-20241022", 500, 200)
+
+        client = metrics_app["client"]
+        resp = client.get("/mesh/system/metrics")
+        data = resp.json()
+        # Operator must NOT appear in any per-agent dict (mirrors the
+        # exclusion pattern used by total_agents / healthy / failed).
+        assert "operator" not in data["per_agent_cost_today_usd"]
+        assert "operator" not in data["per_agent_cost_vs_yesterday_ratio"]
+        assert "operator" not in data["outcome_rejected_24h_count"]
+        assert "operator" not in data["execution_failures_24h_count"]
+        assert "operator" not in data["stale_tasks_24h_count"]
+
+    def test_outcome_rejected_attribution(self, metrics_app):
+        store = metrics_app["tasks_store"]
+        assert store is not None, "tasks_store should be wired in PR-J' fixture"
+        # alpha: 2 rejected, beta: 1 rejected, alpha: 1 accepted (filtered)
+        for assignee, outcome in [
+            ("alpha", "rejected"),
+            ("alpha", "rejected"),
+            ("beta", "rejected"),
+            ("alpha", "accepted"),
+        ]:
+            rec = store.create(creator="op", assignee=assignee, title="t")
+            store.update_status(rec["id"], "working", actor=assignee)
+            store.update_status(rec["id"], "done", actor=assignee)
+            store.set_outcome(rec["id"], outcome, actor="op")
+
+        client = metrics_app["client"]
+        resp = client.get("/mesh/system/metrics")
+        data = resp.json()
+        assert data["outcome_rejected_24h_count"] == {"alpha": 2, "beta": 1}
+
+    def test_execution_failures_distinct_from_rejected(self, metrics_app):
+        store = metrics_app["tasks_store"]
+        assert store is not None
+        # alpha: 1 failed; beta: 1 done+rejected (NOT execution failure)
+        failed = store.create(creator="op", assignee="alpha", title="x")
+        store.update_status(failed["id"], "failed", actor="alpha")
+
+        rejected = store.create(creator="op", assignee="beta", title="y")
+        store.update_status(rejected["id"], "working", actor="beta")
+        store.update_status(rejected["id"], "done", actor="beta")
+        store.set_outcome(rejected["id"], "rejected", actor="op")
+
+        client = metrics_app["client"]
+        resp = client.get("/mesh/system/metrics")
+        data = resp.json()
+        assert data["execution_failures_24h_count"] == {"alpha": 1}
+        assert data["outcome_rejected_24h_count"] == {"beta": 1}
+
+    def test_stale_tasks_excludes_terminal_and_fresh(self, metrics_app):
+        import time as _time
+        store = metrics_app["tasks_store"]
+        assert store is not None
+        # alpha: stale pending (created 2 days ago)
+        stale = store.create(creator="op", assignee="alpha", title="stale")
+        with store._conn() as conn:
+            conn.execute(
+                "UPDATE tasks SET created_at=? WHERE id=?",
+                (_time.time() - 2 * 24 * 3600, stale["id"]),
+            )
+        # beta: stale done (created 2 days ago, then completed) — excluded
+        done = store.create(creator="op", assignee="beta", title="done")
+        with store._conn() as conn:
+            conn.execute(
+                "UPDATE tasks SET created_at=? WHERE id=?",
+                (_time.time() - 2 * 24 * 3600, done["id"]),
+            )
+        store.update_status(done["id"], "working", actor="beta")
+        store.update_status(done["id"], "done", actor="beta")
+        # alpha: fresh pending — excluded
+        store.create(creator="op", assignee="alpha", title="fresh")
+
+        client = metrics_app["client"]
+        resp = client.get("/mesh/system/metrics")
+        data = resp.json()
+        assert data["stale_tasks_24h_count"] == {"alpha": 1}
+
+    def test_failure_rate_placeholder_still_present(self, metrics_app):
+        """Legacy placeholder stays on the contract as ``{}`` for back-compat."""
+        client = metrics_app["client"]
+        resp = client.get("/mesh/system/metrics")
+        data = resp.json()
+        assert "failure_rate_by_agent" in data
+        assert data["failure_rate_by_agent"] == {}
+
+
+class TestStaleTasksEndpoint:
+    """PR-J' — /mesh/agents/{agent_id}/stale-tasks for inspect_agents drill-in."""
+
+    def test_returns_empty_when_no_stale(self, metrics_app):
+        client = metrics_app["client"]
+        resp = client.get("/mesh/agents/alpha/stale-tasks?threshold_hours=24")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["agent_id"] == "alpha"
+        assert data["threshold_hours"] == 24
+        assert data["count"] == 0
+        assert data["task_ids"] == []
+
+    def test_returns_oldest_first_capped_at_5(self, metrics_app):
+        import time as _time
+        store = metrics_app["tasks_store"]
+        assert store is not None
+        ids = []
+        base = _time.time() - 2 * 24 * 3600
+        for i in range(7):
+            rec = store.create(creator="op", assignee="alpha", title=f"t{i}")
+            with store._conn() as conn:
+                conn.execute(
+                    "UPDATE tasks SET created_at=? WHERE id=?",
+                    (base + i, rec["id"]),
+                )
+            ids.append(rec["id"])
+
+        client = metrics_app["client"]
+        resp = client.get("/mesh/agents/alpha/stale-tasks?threshold_hours=24")
+        data = resp.json()
+        assert data["count"] == 5
+        assert data["task_ids"] == ids[:5]
+
+    def test_invalid_threshold_400(self, metrics_app):
+        client = metrics_app["client"]
+        resp = client.get("/mesh/agents/alpha/stale-tasks?threshold_hours=0")
+        assert resp.status_code == 400
+        resp = client.get("/mesh/agents/alpha/stale-tasks?threshold_hours=999")
+        assert resp.status_code == 400
+
+    def test_invalid_agent_id_400(self, metrics_app):
+        client = metrics_app["client"]
+        resp = client.get("/mesh/agents/!!!bad!!!/stale-tasks?threshold_hours=24")
+        assert resp.status_code == 400
 
 
 class TestAgentMetrics:

--- a/tests/test_operator_tools.py
+++ b/tests/test_operator_tools.py
@@ -538,6 +538,111 @@ async def test_inspect_agents_error_surfaces():
     assert "connection refused" in result["error"]
 
 
+# PR-J' — stale_threshold_hours parameter on inspect_agents
+
+
+@pytest.mark.asyncio
+async def test_inspect_agents_no_threshold_unchanged_shape():
+    """Roster summary without ``stale_threshold_hours`` looks unchanged."""
+    from src.agent.builtins.operator_tools import inspect_agents
+
+    mc = MagicMock()
+    mc.list_agents = AsyncMock(return_value={
+        "writer": {"role": "writer", "capabilities": []},
+    })
+    # get_agent_stale_tasks should NOT be called when threshold is omitted.
+    mc.get_agent_stale_tasks = AsyncMock()
+
+    result = await inspect_agents(mesh_client=mc)
+    assert result["count"] == 1
+    assert "stale_threshold_hours" not in result
+    assert "stale_task_count" not in result["agents"][0]
+    mc.get_agent_stale_tasks.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_inspect_agents_with_threshold_annotates_roster():
+    """Setting stale_threshold_hours adds count + ids to each roster entry."""
+    from src.agent.builtins.operator_tools import inspect_agents
+
+    mc = MagicMock()
+    mc.list_agents = AsyncMock(return_value={
+        "writer": {"role": "writer", "capabilities": []},
+        "scout":  {"role": "researcher", "capabilities": []},
+    })
+
+    async def _fake_stale(agent_id, threshold_hours=24):
+        if agent_id == "writer":
+            return {
+                "agent_id": "writer",
+                "threshold_hours": threshold_hours,
+                "count": 2,
+                "task_ids": ["task_a", "task_b"],
+            }
+        return {
+            "agent_id": agent_id,
+            "threshold_hours": threshold_hours,
+            "count": 0,
+            "task_ids": [],
+        }
+
+    mc.get_agent_stale_tasks = AsyncMock(side_effect=_fake_stale)
+
+    result = await inspect_agents(stale_threshold_hours=24, mesh_client=mc)
+    assert result["stale_threshold_hours"] == 24
+    by_name = {a["name"]: a for a in result["agents"]}
+    assert by_name["writer"]["stale_task_count"] == 2
+    assert by_name["writer"]["stale_task_ids"] == ["task_a", "task_b"]
+    assert by_name["scout"]["stale_task_count"] == 0
+    assert by_name["scout"]["stale_task_ids"] == []
+
+
+@pytest.mark.asyncio
+async def test_inspect_agents_threshold_zero_treated_as_omitted():
+    """``stale_threshold_hours=0`` (JSON-schema default) means 'not supplied'."""
+    from src.agent.builtins.operator_tools import inspect_agents
+
+    mc = MagicMock()
+    mc.list_agents = AsyncMock(return_value={
+        "writer": {"role": "writer", "capabilities": []},
+    })
+    mc.get_agent_stale_tasks = AsyncMock()
+
+    result = await inspect_agents(stale_threshold_hours=0, mesh_client=mc)
+    assert "stale_threshold_hours" not in result
+    mc.get_agent_stale_tasks.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_inspect_agents_threshold_out_of_range_rejected():
+    from src.agent.builtins.operator_tools import inspect_agents
+
+    mc = MagicMock()
+    mc.list_agents = AsyncMock(return_value={})
+
+    result = await inspect_agents(stale_threshold_hours=200, mesh_client=mc)
+    assert "error" in result
+    assert "168" in result["error"]
+
+
+@pytest.mark.asyncio
+async def test_inspect_agents_stale_lookup_failure_degrades_to_zero():
+    """Per-agent stale lookup failure should NOT poison the whole roster."""
+    from src.agent.builtins.operator_tools import inspect_agents
+
+    mc = MagicMock()
+    mc.list_agents = AsyncMock(return_value={
+        "writer": {"role": "writer", "capabilities": []},
+    })
+    mc.get_agent_stale_tasks = AsyncMock(side_effect=RuntimeError("boom"))
+
+    result = await inspect_agents(stale_threshold_hours=24, mesh_client=mc)
+    assert result["stale_threshold_hours"] == 24
+    entry = result["agents"][0]
+    assert entry["stale_task_count"] == 0
+    assert entry["stale_task_ids"] == []
+
+
 # ── create_agent tests ──────────────────────────��───────────
 
 

--- a/tests/test_orchestration.py
+++ b/tests/test_orchestration.py
@@ -750,3 +750,143 @@ def test_create_rework_task_records_creation_event(tmp_path):
         and e["payload"].get("kind") == "rework"
         for e in events
     )
+
+
+# ── PR-J' per-agent aggregates for the operator heartbeat ──────────
+
+
+def _seed_done_with_outcome(store, *, assignee, outcome):
+    """Helper — create a task, complete it, set the outcome rating."""
+    rec = store.create(creator="op", assignee=assignee, title="t")
+    store.update_status(rec["id"], "working", actor=assignee)
+    store.update_status(rec["id"], "done", actor=assignee)
+    store.set_outcome(rec["id"], outcome, actor="op")
+    return rec
+
+
+def test_count_outcomes_since_groups_by_assignee(tmp_path):
+    t = _make_store(tmp_path)
+    _seed_done_with_outcome(t, assignee="alpha", outcome="rejected")
+    _seed_done_with_outcome(t, assignee="alpha", outcome="rejected")
+    _seed_done_with_outcome(t, assignee="beta", outcome="rejected")
+    _seed_done_with_outcome(t, assignee="beta", outcome="accepted")  # filtered
+    counts = t.count_outcomes_since("rejected", since_seconds=24 * 3600)
+    assert counts == {"alpha": 2, "beta": 1}
+
+
+def test_count_outcomes_since_excludes_old(tmp_path):
+    t = _make_store(tmp_path)
+    rec = _seed_done_with_outcome(t, assignee="alpha", outcome="rejected")
+    # Manually rewind completed_at to 2 days ago.
+    with t._conn() as conn:
+        conn.execute(
+            "UPDATE tasks SET completed_at=? WHERE id=?",
+            (time.time() - 2 * 24 * 3600, rec["id"]),
+        )
+    counts = t.count_outcomes_since("rejected", since_seconds=24 * 3600)
+    assert counts == {}
+
+
+def test_count_failed_status_since_excludes_done(tmp_path):
+    t = _make_store(tmp_path)
+    failed = t.create(creator="op", assignee="alpha", title="x")
+    t.update_status(failed["id"], "failed", actor="alpha")
+    done = t.create(creator="op", assignee="alpha", title="y")
+    t.update_status(done["id"], "working", actor="alpha")
+    t.update_status(done["id"], "done", actor="alpha")
+    counts = t.count_failed_status_since(since_seconds=24 * 3600)
+    assert counts == {"alpha": 1}
+
+
+def test_count_failed_status_since_excludes_old(tmp_path):
+    t = _make_store(tmp_path)
+    rec = t.create(creator="op", assignee="alpha", title="x")
+    t.update_status(rec["id"], "failed", actor="alpha")
+    with t._conn() as conn:
+        conn.execute(
+            "UPDATE tasks SET completed_at=? WHERE id=?",
+            (time.time() - 2 * 24 * 3600, rec["id"]),
+        )
+    counts = t.count_failed_status_since(since_seconds=24 * 3600)
+    assert counts == {}
+
+
+def test_count_stale_since_excludes_terminal(tmp_path):
+    t = _make_store(tmp_path)
+    # alpha: pending task created 2 days ago — stale.
+    stale = t.create(creator="op", assignee="alpha", title="stale")
+    with t._conn() as conn:
+        conn.execute(
+            "UPDATE tasks SET created_at=? WHERE id=?",
+            (time.time() - 2 * 24 * 3600, stale["id"]),
+        )
+    # alpha: done task created 2 days ago — NOT stale (terminal).
+    done = t.create(creator="op", assignee="alpha", title="done")
+    with t._conn() as conn:
+        conn.execute(
+            "UPDATE tasks SET created_at=? WHERE id=?",
+            (time.time() - 2 * 24 * 3600, done["id"]),
+        )
+    t.update_status(done["id"], "working", actor="alpha")
+    t.update_status(done["id"], "done", actor="alpha")
+    # alpha: fresh pending task — NOT stale (created within window).
+    t.create(creator="op", assignee="alpha", title="fresh")
+    counts = t.count_stale_since(threshold_seconds=24 * 3600)
+    assert counts == {"alpha": 1}
+
+
+def test_count_stale_since_groups_by_assignee(tmp_path):
+    t = _make_store(tmp_path)
+    for assignee, n in [("alpha", 2), ("beta", 1)]:
+        for _ in range(n):
+            rec = t.create(creator="op", assignee=assignee, title="x")
+            with t._conn() as conn:
+                conn.execute(
+                    "UPDATE tasks SET created_at=? WHERE id=?",
+                    (time.time() - 2 * 24 * 3600, rec["id"]),
+                )
+    counts = t.count_stale_since(threshold_seconds=24 * 3600)
+    assert counts == {"alpha": 2, "beta": 1}
+
+
+def test_list_stale_for_assignee_returns_oldest_first_capped(tmp_path):
+    t = _make_store(tmp_path)
+    ids = []
+    base = time.time() - 2 * 24 * 3600
+    for i in range(7):
+        rec = t.create(creator="op", assignee="alpha", title=f"t{i}")
+        with t._conn() as conn:
+            conn.execute(
+                "UPDATE tasks SET created_at=? WHERE id=?",
+                (base + i, rec["id"]),
+            )
+        ids.append(rec["id"])
+    rows = t.list_stale_for_assignee(
+        "alpha", threshold_seconds=24 * 3600, limit=5,
+    )
+    # Oldest 5 — created in insertion order, so first 5 ids.
+    assert rows == ids[:5]
+
+
+def test_list_stale_for_assignee_excludes_terminal(tmp_path):
+    t = _make_store(tmp_path)
+    rec = t.create(creator="op", assignee="alpha", title="cancelled")
+    with t._conn() as conn:
+        conn.execute(
+            "UPDATE tasks SET created_at=? WHERE id=?",
+            (time.time() - 2 * 24 * 3600, rec["id"]),
+        )
+    t.cancel(rec["id"], actor="op")
+    rows = t.list_stale_for_assignee(
+        "alpha", threshold_seconds=24 * 3600, limit=5,
+    )
+    assert rows == []
+
+
+def test_list_stale_for_assignee_excludes_fresh(tmp_path):
+    t = _make_store(tmp_path)
+    t.create(creator="op", assignee="alpha", title="fresh")
+    rows = t.list_stale_for_assignee(
+        "alpha", threshold_seconds=24 * 3600, limit=5,
+    )
+    assert rows == []


### PR DESCRIPTION
## Summary

Fills in five real per-agent metrics on `/mesh/system/metrics` so the operator's heartbeat playbook can actually fire on real signals. Closes the TODO PR-F (#851) added when it removed dead `failure_rate > 0.30` rules.

This is **PR-J'** from `docs/plans/2026-05-08-post-board-roadmap.md` (Phase 1, monitoring depth).

## Why

After PR-F, the operator's heartbeat has been operating without per-agent visibility into:
- cost spikes (today vs yesterday)
- user-rejected outcomes
- execution failures
- tasks stuck in non-terminal states

The `failure_rate_by_agent` placeholder was returning `{}`; rules keying on it never fired. PR-F removed those rules; this PR replaces them with metrics that actually reflect fleet state.

## What

### Five new fields on `system_metrics` (operator excluded everywhere)

```jsonc
"per_agent_cost_today_usd": {agent_id: float},      // costs.get_spend(agent, "today")
"per_agent_cost_vs_yesterday_ratio": {agent_id: float},  // 0.0 if no baseline
"outcome_rejected_24h_count": {agent_id: int},      // tasks_v2 outcome='rejected' last 24h
"execution_failures_24h_count": {agent_id: int},    // tasks_v2 status='failed' last 24h
"stale_tasks_24h_count": {agent_id: int}            // non-terminal status, created >24h ago
```

`failure_rate_by_agent` placeholder remains `{}` with a comment that the two new count fields supersede it for now (rates on small denominators are noise — graduate later).

### `inspect_agents(stale_threshold_hours: int | None = None)`

When set, response per-agent includes `stale_task_count` + `stale_task_ids` (top 5). When `None`, behavior unchanged.

### New mesh endpoint `/mesh/agents/{id}/stale-tasks`

Backs the `inspect_agents` parameter. Permission-gated like other agent introspection routes.

### Heartbeat playbook updated (≤9 step budget)

1. Review previous OBSERVATIONS.md (no tool call)
2. `get_system_status()` — fleet metrics including new fields
3. `inspect_agents()` — roster summary
4. Conditional drill-in: `inspect_agents(agent_id, depth="profile")` per concerning agent OR `inspect_agents(stale_threshold_hours=24)` once if any stale entry
5. `save_observations()`
6. `notify_user()` if CRITICAL

Worst case ≤8 tool calls within `HEARTBEAT_MAX_ITERATIONS=10`.

## Implementation notes

- `costs.get_spend(agent, "yesterday")` returns "since yesterday midnight" (includes today). Per-agent ratio subtracts today from that, mirroring the existing `agent_metrics` pattern.
- `execution_failures_24h_count` filters on `completed_at` (terminal transitions always stamp it) — keeps count stable if an operator no-op-edits a failed task later.
- Operator excluded from every per-agent dict via `if aid != "operator"` (mirrors the existing `_compute_fleet_metrics` pattern).
- Used existing `idx_tasks_assignee_status` index — no new indices.

## Sample response

```json
{
  "per_agent_cost_today_usd": {"alpha": 0.0105, "beta": 0},
  "per_agent_cost_vs_yesterday_ratio": {"alpha": 0.0, "beta": 0.0},
  "outcome_rejected_24h_count": {"alpha": 2},
  "execution_failures_24h_count": {"alpha": 1},
  "stale_tasks_24h_count": {"alpha": 1, "beta": 1}
}
```

## Tool count discipline

Zero new top-level `@skill` tools. `stale_threshold_hours` is a new parameter on existing `inspect_agents`. New mesh endpoint is implementation backing, not a new tool surface.

## Test plan

- [x] Three new metric dicts on `system_metrics`, correct shape, operator excluded
- [x] Multi-agent attribution
- [x] `per_agent_cost_vs_yesterday_ratio` 0.0 when baseline is 0
- [x] `outcome_rejected_24h_count` filters older outcomes
- [x] `execution_failures_24h_count` distinct from outcome_rejected
- [x] `stale_tasks_24h_count` excludes terminal statuses
- [x] `inspect_agents(stale_threshold_hours=24)` adds new fields per agent
- [x] Heartbeat playbook contains new metric rules
- [x] Heartbeat step budget ≤9

695 operator-related tests pass. Full unit/integration suite: 5520 passed, 44 skipped. `ruff` clean.