### PR TITLE
fix(dashboard): Board loading/error states + inline artifact preview + plain-language templates

### DIFF
--- a/src/dashboard/static/js/app.js
+++ b/src/dashboard/static/js/app.js
@@ -373,6 +373,38 @@ function dashboard() {
     workplaceFeedCap: 200,
     workplacePending: [],
     workplaceLoading: false,
+    // Per-section loading + error state. Failures used to be swallowed
+    // silently (console.error) which left the user staring at an empty
+    // panel with no way to retry. Each loadWorkplace* function now flips
+    // its own bucket here so the template can render skeletons during
+    // the in-flight window and a "Couldn't load — Retry" banner on
+    // failure. Banner click handlers clear the error and re-run the
+    // load, keeping the recovery path one click away.
+    workplaceSectionLoading: {
+      projects: false,
+      tasks: false,
+      blockers: false,
+      outputs: false,
+      pending: false,
+      feed: false,
+    },
+    workplaceErrors: {
+      projects: '',
+      tasks: '',
+      blockers: '',
+      outputs: '',
+      pending: '',
+      feed: '',
+    },
+    // Per-task artifact preview cache for the "Recently delivered"
+    // section. Keyed by task_id so each row's preview is fetched once
+    // and reused; the value is the full /api/workplace/tasks/{id}
+    // response so the "Read full" toggle can show the inlined content
+    // without a second round-trip. ``recentlyDeliveredExpanded`` tracks
+    // which rows the user has expanded.
+    recentlyDeliveredArtifacts: {},
+    recentlyDeliveredExpanded: {},
+    _recentlyDeliveredFetching: {},
     workplaceTaskColumns: ['pending', 'accepted', 'working', 'blocked', 'done'],
     workplaceProjectFilter: '',
     // Per-column flag: when true, the kanban column ignores the 14-day
@@ -1585,61 +1617,112 @@ function dashboard() {
       }
     },
 
+    // Per-section retry helper. Banners call ``retryWorkplaceSection``
+    // with the section key — we clear the error first so the banner
+    // hides immediately, then re-run the section's loader. Keeping the
+    // dispatch in one place means the banner handlers in the template
+    // stay short ("@click=\"retryWorkplaceSection('feed')\"").
+    retryWorkplaceSection(section) {
+      this.workplaceErrors[section] = '';
+      const fn = {
+        projects: this.loadWorkplaceProjects,
+        tasks: this.loadWorkplaceTasks,
+        blockers: this.loadWorkplaceBlockers,
+        outputs: this.loadWorkplaceOutputs,
+        pending: this.loadWorkplacePending,
+        feed: this.loadWorkplaceFeed,
+      }[section];
+      if (fn) fn.call(this);
+    },
+
     async loadWorkplaceProjects() {
+      this.workplaceSectionLoading.projects = true;
+      this.workplaceErrors.projects = '';
       try {
         const resp = await fetch(`${window.__config.apiBase}/workplace/projects`);
-        if (!resp.ok) return;
+        if (!resp.ok) {
+          this.workplaceErrors.projects = `Couldn't load projects (HTTP ${resp.status})`;
+          return;
+        }
         const data = await resp.json();
         this.workplaceEnabled = data.enabled !== false;
         this.workplaceProjects = data.projects || [];
       } catch (e) {
-        console.error('Failed to load workplace projects:', e);
+        this.workplaceErrors.projects = (e && e.message) ? `Couldn't load projects: ${e.message}` : "Couldn't load projects";
+      } finally {
+        this.workplaceSectionLoading.projects = false;
       }
     },
 
     async loadWorkplaceTasks() {
+      this.workplaceSectionLoading.tasks = true;
+      this.workplaceErrors.tasks = '';
       try {
         const params = this.workplaceProjectFilter ? `?project_id=${encodeURIComponent(this.workplaceProjectFilter)}` : '';
         const resp = await fetch(`${window.__config.apiBase}/workplace/tasks${params}`);
-        if (!resp.ok) return;
+        if (!resp.ok) {
+          this.workplaceErrors.tasks = `Couldn't load tasks (HTTP ${resp.status})`;
+          return;
+        }
         const data = await resp.json();
         this.workplaceEnabled = data.enabled !== false;
         this.workplaceTasks = data.tasks || [];
       } catch (e) {
-        console.error('Failed to load workplace tasks:', e);
+        this.workplaceErrors.tasks = (e && e.message) ? `Couldn't load tasks: ${e.message}` : "Couldn't load tasks";
+      } finally {
+        this.workplaceSectionLoading.tasks = false;
       }
     },
 
     async loadWorkplaceBlockers() {
+      this.workplaceSectionLoading.blockers = true;
+      this.workplaceErrors.blockers = '';
       try {
         const resp = await fetch(`${window.__config.apiBase}/workplace/blockers`);
-        if (!resp.ok) return;
+        if (!resp.ok) {
+          this.workplaceErrors.blockers = `Couldn't load blockers (HTTP ${resp.status})`;
+          return;
+        }
         const data = await resp.json();
         this.workplaceEnabled = data.enabled !== false;
         this.workplaceBlockers = data.blockers || [];
       } catch (e) {
-        console.error('Failed to load workplace blockers:', e);
+        this.workplaceErrors.blockers = (e && e.message) ? `Couldn't load blockers: ${e.message}` : "Couldn't load blockers";
+      } finally {
+        this.workplaceSectionLoading.blockers = false;
       }
     },
 
     async loadWorkplaceOutputs() {
+      this.workplaceSectionLoading.outputs = true;
+      this.workplaceErrors.outputs = '';
       try {
         const params = this.workplaceProjectFilter ? `?project_id=${encodeURIComponent(this.workplaceProjectFilter)}` : '';
         const resp = await fetch(`${window.__config.apiBase}/workplace/outputs${params}`);
-        if (!resp.ok) return;
+        if (!resp.ok) {
+          this.workplaceErrors.outputs = `Couldn't load outputs (HTTP ${resp.status})`;
+          return;
+        }
         const data = await resp.json();
         this.workplaceEnabled = data.enabled !== false;
         this.workplaceOutputs = data.outputs || [];
         this._recomputeRecentlyDelivered();
       } catch (e) {
-        console.error('Failed to load workplace outputs:', e);
+        this.workplaceErrors.outputs = (e && e.message) ? `Couldn't load outputs: ${e.message}` : "Couldn't load outputs";
+      } finally {
+        this.workplaceSectionLoading.outputs = false;
       }
     },
 
     async loadWorkplacePending() {
+      this.workplaceSectionLoading.pending = true;
+      this.workplaceErrors.pending = '';
       try {
         const resp = await fetch(`${window.__config.apiBase}/workplace/pending`);
-        if (!resp.ok) return;
+        if (!resp.ok) {
+          this.workplaceErrors.pending = `Couldn't load pending actions (HTTP ${resp.status})`;
+          return;
+        }
         const data = await resp.json();
         this.workplacePending = data.pending || [];
         // Backfill the inline chat-card surface so a page reload still
@@ -1659,20 +1742,29 @@ function dashboard() {
           });
         }
       } catch (e) {
-        console.error('Failed to load workplace pending actions:', e);
+        this.workplaceErrors.pending = (e && e.message) ? `Couldn't load pending actions: ${e.message}` : "Couldn't load pending actions";
+      } finally {
+        this.workplaceSectionLoading.pending = false;
       }
     },
 
     async loadWorkplaceFeed() {
+      this.workplaceSectionLoading.feed = true;
+      this.workplaceErrors.feed = '';
       try {
         const params = this.workplaceProjectFilter ? `?project_id=${encodeURIComponent(this.workplaceProjectFilter)}` : '';
         const resp = await fetch(`${window.__config.apiBase}/workplace/feed${params}`);
-        if (!resp.ok) return;
+        if (!resp.ok) {
+          this.workplaceErrors.feed = `Couldn't load activity (HTTP ${resp.status})`;
+          return;
+        }
         const data = await resp.json();
         this.workplaceEnabled = data.enabled !== false;
         this.workplaceFeed = data.feed || [];
       } catch (e) {
-        console.error('Failed to load workplace feed:', e);
+        this.workplaceErrors.feed = (e && e.message) ? `Couldn't load activity: ${e.message}` : "Couldn't load activity";
+      } finally {
+        this.workplaceSectionLoading.feed = false;
       }
     },
 
@@ -2184,6 +2276,119 @@ function dashboard() {
     // field remains the single source of truth for the template.
     recentlyDelivered() {
       return this.recentlyDeliveredItems;
+    },
+
+    // Lazy-fetch the artifact bundle for a "Recently delivered" row so
+    // the user can read the actual output without opening the modal.
+    // The /api/workplace/tasks/{id} endpoint already returns each
+    // artifact_ref resolved to ``{kind, content, content_truncated}``
+    // (see _resolve_artifact in dashboard/server.py); we cache the
+    // first text artifact per task_id. Errors are stored on the same
+    // cache entry so a failed fetch surfaces inline rather than the
+    // row going blank.
+    async _ensureRecentlyDeliveredArtifact(taskId) {
+      if (!taskId) return;
+      if (this.recentlyDeliveredArtifacts[taskId] !== undefined) return;
+      if (this._recentlyDeliveredFetching[taskId]) return;
+      this._recentlyDeliveredFetching[taskId] = true;
+      try {
+        const resp = await fetch(`${window.__config.apiBase}/workplace/tasks/${encodeURIComponent(taskId)}`);
+        if (!resp.ok) {
+          this.recentlyDeliveredArtifacts[taskId] = { error: `HTTP ${resp.status}` };
+          return;
+        }
+        const data = await resp.json();
+        const arts = (data && data.artifacts) || [];
+        // Pick the first text artifact for the inline preview; non-text
+        // (image / pdf / missing / error) keeps the prior link-out
+        // behavior because we can't render bytes inline here.
+        const text = arts.find(a => a && a.kind === 'text' && typeof a.content === 'string');
+        if (text) {
+          this.recentlyDeliveredArtifacts[taskId] = {
+            ref: text.ref,
+            content: text.content,
+            content_truncated: !!text.content_truncated,
+            kind: 'text',
+          };
+        } else if (arts.length) {
+          // Surface the first non-text artifact's kind so the row can
+          // hint at what's there (image/pdf/missing) without crashing.
+          this.recentlyDeliveredArtifacts[taskId] = {
+            ref: arts[0].ref,
+            kind: arts[0].kind || 'unknown',
+            error: arts[0].error || null,
+          };
+        } else {
+          this.recentlyDeliveredArtifacts[taskId] = { kind: 'none' };
+        }
+      } catch (e) {
+        this.recentlyDeliveredArtifacts[taskId] = { error: (e && e.message) || 'fetch failed' };
+      } finally {
+        delete this._recentlyDeliveredFetching[taskId];
+      }
+    },
+
+    // Template helper: short preview (~300 chars) shown by default.
+    // Returns '' when the artifact isn't text or hasn't loaded yet so
+    // the template can hide the preview block until content arrives.
+    recentlyDeliveredPreview(taskId) {
+      const a = this.recentlyDeliveredArtifacts[taskId];
+      if (!a || a.kind !== 'text' || !a.content) return '';
+      const PREVIEW_CAP = 300;
+      if (a.content.length <= PREVIEW_CAP) return a.content;
+      return a.content.slice(0, PREVIEW_CAP) + '…';
+    },
+
+    // Template helper: full content for the expanded view. Falls back
+    // to '' when the artifact isn't text so the toggle can hide
+    // gracefully on non-text artifacts.
+    recentlyDeliveredFull(taskId) {
+      const a = this.recentlyDeliveredArtifacts[taskId];
+      if (!a || a.kind !== 'text') return '';
+      return a.content || '';
+    },
+
+    // True when the artifact has more than the preview cap so the
+    // "Read full" toggle should be shown. Hidden when the content fits
+    // entirely in the preview, when the artifact isn't text, or while
+    // it's still loading.
+    recentlyDeliveredHasMore(taskId) {
+      const a = this.recentlyDeliveredArtifacts[taskId];
+      if (!a || a.kind !== 'text' || !a.content) return false;
+      return a.content.length > 300;
+    },
+
+    toggleRecentlyDeliveredExpanded(taskId) {
+      this.recentlyDeliveredExpanded[taskId] = !this.recentlyDeliveredExpanded[taskId];
+    },
+
+    // Copy the artifact's full text to the clipboard. Uses the modern
+    // clipboard API when available (HTTPS / localhost) and falls back
+    // to a hidden textarea + execCommand for older browsers and the
+    // insecure-context case (file://). The toast feedback comes from
+    // the existing showToast helper so the user sees confirmation
+    // without us inventing a new banner.
+    async copyRecentlyDeliveredText(taskId) {
+      const text = this.recentlyDeliveredFull(taskId);
+      if (!text) return;
+      try {
+        if (navigator.clipboard && navigator.clipboard.writeText) {
+          await navigator.clipboard.writeText(text);
+        } else {
+          const ta = document.createElement('textarea');
+          ta.value = text;
+          ta.setAttribute('readonly', '');
+          ta.style.position = 'absolute';
+          ta.style.left = '-9999px';
+          document.body.appendChild(ta);
+          ta.select();
+          document.execCommand('copy');
+          document.body.removeChild(ta);
+        }
+        if (typeof this.showToast === 'function') this.showToast('Copied to clipboard', 2000);
+      } catch (e) {
+        if (typeof this.showToast === 'function') this.showToast('Copy failed', 3000);
+      }
     },
 
     // Kanban filter — drop pending/blocked rows older than 14 days

--- a/src/dashboard/templates/index.html
+++ b/src/dashboard/templates/index.html
@@ -973,22 +973,22 @@
                   </div>
                   <!-- Curated intent-based options — uniform size -->
                   <div class="flex flex-col gap-1.5 w-full max-w-sm">
-                    <button @click="let el = document.getElementById('operator-chat-input'); if (el) { let s = Alpine.$data(el.closest('[x-data]')); if (s) s.opMsg = (maxAgents > 0 && maxAgents <= 1) ? 'I need a content agent for writing, editing, and research' : 'I need a content team — writing, editing, and research'; el.focus(); }"
+                    <button @click="let el = document.getElementById('operator-chat-input'); if (el) { let s = Alpine.$data(el.closest('[x-data]')); if (s) { let chip = (maxAgents > 0 && maxAgents <= 1) ? 'I need a content agent for writing, editing, and research' : 'I need a content team — writing, editing, and research'; s.opMsg = chip + (s.opMsg ? ' ' + s.opMsg : ''); $nextTick(() => { el.focus(); el.setSelectionRange(el.value.length, el.value.length); }); } }"
                       class="flex items-center gap-3 w-full text-left px-4 py-2.5 rounded-lg bg-gray-800/50 border border-gray-700/50 hover:border-indigo-500/40 hover:bg-indigo-600/5 transition-all group">
                       <svg class="w-4 h-4 text-gray-500 group-hover:text-indigo-400 shrink-0 transition-colors" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="1.5"><path stroke-linecap="round" stroke-linejoin="round" d="M12 6.042A8.967 8.967 0 006 3.75c-1.052 0-2.062.18-3 .512v14.25A8.987 8.987 0 016 18c2.305 0 4.408.867 6 2.292m0-14.25a8.966 8.966 0 016-2.292c1.052 0 2.062.18 3 .512v14.25A8.987 8.987 0 0018 18a8.967 8.967 0 00-6 2.292m0-14.25v14.25"/></svg>
                       <div class="min-w-0"><div class="text-xs text-gray-200 group-hover:text-white">Content &amp; Marketing</div></div>
                     </button>
-                    <button @click="let el = document.getElementById('operator-chat-input'); if (el) { let s = Alpine.$data(el.closest('[x-data]')); if (s) s.opMsg = (maxAgents > 0 && maxAgents <= 1) ? 'I need a research agent to gather intelligence and produce reports' : 'I need a research team to gather intelligence and produce reports'; el.focus(); }"
+                    <button @click="let el = document.getElementById('operator-chat-input'); if (el) { let s = Alpine.$data(el.closest('[x-data]')); if (s) { let chip = (maxAgents > 0 && maxAgents <= 1) ? 'I need a research agent to gather intelligence and produce reports' : 'I need a research team to gather intelligence and produce reports'; s.opMsg = chip + (s.opMsg ? ' ' + s.opMsg : ''); $nextTick(() => { el.focus(); el.setSelectionRange(el.value.length, el.value.length); }); } }"
                       class="flex items-center gap-3 w-full text-left px-4 py-2.5 rounded-lg bg-gray-800/50 border border-gray-700/50 hover:border-indigo-500/40 hover:bg-indigo-600/5 transition-all group">
                       <svg class="w-4 h-4 text-gray-500 group-hover:text-indigo-400 shrink-0 transition-colors" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="1.5"><path stroke-linecap="round" stroke-linejoin="round" d="M21 21l-5.197-5.197m0 0A7.5 7.5 0 105.196 5.196a7.5 7.5 0 0010.607 10.607z"/></svg>
                       <div class="min-w-0"><div class="text-xs text-gray-200 group-hover:text-white">Research &amp; Analysis</div></div>
                     </button>
-                    <button @click="let el = document.getElementById('operator-chat-input'); if (el) { let s = Alpine.$data(el.closest('[x-data]')); if (s) s.opMsg = (maxAgents > 0 && maxAgents <= 1) ? 'I need a sales agent for prospecting and outreach' : 'I need a sales team for prospecting and outreach'; el.focus(); }"
+                    <button @click="let el = document.getElementById('operator-chat-input'); if (el) { let s = Alpine.$data(el.closest('[x-data]')); if (s) { let chip = (maxAgents > 0 && maxAgents <= 1) ? 'I need a sales agent for prospecting and outreach' : 'I need a sales team for prospecting and outreach'; s.opMsg = chip + (s.opMsg ? ' ' + s.opMsg : ''); $nextTick(() => { el.focus(); el.setSelectionRange(el.value.length, el.value.length); }); } }"
                       class="flex items-center gap-3 w-full text-left px-4 py-2.5 rounded-lg bg-gray-800/50 border border-gray-700/50 hover:border-indigo-500/40 hover:bg-indigo-600/5 transition-all group">
                       <svg class="w-4 h-4 text-gray-500 group-hover:text-indigo-400 shrink-0 transition-colors" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="1.5"><path stroke-linecap="round" stroke-linejoin="round" d="M2.25 6.75c0 8.284 6.716 15 15 15h2.25a2.25 2.25 0 002.25-2.25v-1.372c0-.516-.351-.966-.852-1.091l-4.423-1.106c-.44-.11-.902.055-1.173.417l-.97 1.293c-.282.376-.769.542-1.21.38a12.035 12.035 0 01-7.143-7.143c-.162-.441.004-.928.38-1.21l1.293-.97c.363-.271.527-.734.417-1.173L6.963 3.102a1.125 1.125 0 00-1.091-.852H4.5A2.25 2.25 0 002.25 4.5v2.25z"/></svg>
                       <div class="min-w-0"><div class="text-xs text-gray-200 group-hover:text-white">Sales &amp; Outreach</div></div>
                     </button>
-                    <button @click="let el = document.getElementById('operator-chat-input'); if (el) { let s = Alpine.$data(el.closest('[x-data]')); if (s) s.opMsg = (maxAgents > 0 && maxAgents <= 1) ? 'I need a development agent for planning, coding, and code review' : 'I need a development team — planning, coding, and code review'; el.focus(); }"
+                    <button @click="let el = document.getElementById('operator-chat-input'); if (el) { let s = Alpine.$data(el.closest('[x-data]')); if (s) { let chip = (maxAgents > 0 && maxAgents <= 1) ? 'I need a development agent for planning, coding, and code review' : 'I need a development team — planning, coding, and code review'; s.opMsg = chip + (s.opMsg ? ' ' + s.opMsg : ''); $nextTick(() => { el.focus(); el.setSelectionRange(el.value.length, el.value.length); }); } }"
                       class="flex items-center gap-3 w-full text-left px-4 py-2.5 rounded-lg bg-gray-800/50 border border-gray-700/50 hover:border-indigo-500/40 hover:bg-indigo-600/5 transition-all group">
                       <svg class="w-4 h-4 text-gray-500 group-hover:text-indigo-400 shrink-0 transition-colors" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="1.5"><path stroke-linecap="round" stroke-linejoin="round" d="M17.25 6.75L22.5 12l-5.25 5.25m-10.5 0L1.5 12l5.25-5.25m7.5-3l-4.5 16.5"/></svg>
                       <div class="min-w-0"><div class="text-xs text-gray-200 group-hover:text-white">Software Development</div></div>
@@ -3352,16 +3352,79 @@
                 </div>
                 <div class="space-y-1.5">
                   <template x-for="t in recentlyDeliveredItems" :key="'rd-' + t.id">
-                    <div class="flex items-center gap-2 bg-gray-800/40 border border-gray-700/50 rounded-md px-2.5 py-1.5">
-                      <span class="text-emerald-400 text-xs shrink-0">&check;</span>
-                      <div class="min-w-0 flex-1 text-xs text-gray-200 truncate" x-text="t.title || '(untitled)'"></div>
-                      <div class="text-[11px] text-gray-500 hidden sm:block shrink-0" x-text="(t.assignee || '') + (t.completed_at ? ' · ' + (formatRelativeTime((t.completed_at || 0) * 1000) || 'just now') : '')"></div>
-                      <button type="button"
-                        @click.stop="openTaskDrillIn(t.id)"
-                        class="text-[11px] px-2 py-0.5 rounded bg-gray-700 hover:bg-gray-600 text-gray-200 shrink-0">Open</button>
+                    <!-- x-init lazy-fetches the artifact bundle on first
+                         render so the inline preview shows up without
+                         the user having to open the drill-in modal.
+                         The fetch is cached per task_id so flipping
+                         sub-tabs back and forth doesn't refetch. -->
+                    <div class="bg-gray-800/40 border border-gray-700/50 rounded-md px-2.5 py-1.5"
+                         x-init="t.artifact_refs && t.artifact_refs.length && _ensureRecentlyDeliveredArtifact(t.id)">
+                      <div class="flex items-center gap-2">
+                        <span class="text-emerald-400 text-xs shrink-0">&check;</span>
+                        <div class="min-w-0 flex-1 text-xs text-gray-200 truncate" x-text="t.title || '(untitled)'"></div>
+                        <div class="text-[11px] text-gray-500 hidden sm:block shrink-0" x-text="(t.assignee || '') + (t.completed_at ? ' · ' + (formatRelativeTime((t.completed_at || 0) * 1000) || 'just now') : '')"></div>
+                        <button type="button"
+                          @click.stop="openTaskDrillIn(t.id)"
+                          class="text-[11px] px-2 py-0.5 rounded bg-gray-700 hover:bg-gray-600 text-gray-200 shrink-0">Open</button>
+                      </div>
+                      <!-- Inline artifact preview. Hidden until the
+                           lazy fetch completes; collapses again if the
+                           artifact turns out to be non-text or absent. -->
+                      <template x-if="t.artifact_refs && t.artifact_refs.length && recentlyDeliveredPreview(t.id)">
+                        <div class="mt-1.5 pl-5">
+                          <pre class="text-[11px] text-gray-300 whitespace-pre-wrap break-words bg-gray-900/40 rounded px-2 py-1.5 max-h-64 overflow-y-auto custom-scrollbar"
+                               x-text="recentlyDeliveredExpanded[t.id] ? recentlyDeliveredFull(t.id) : recentlyDeliveredPreview(t.id)"></pre>
+                          <div class="flex items-center gap-2 mt-1">
+                            <button type="button"
+                              x-show="recentlyDeliveredHasMore(t.id)"
+                              @click.stop="toggleRecentlyDeliveredExpanded(t.id)"
+                              class="text-[11px] text-indigo-300 hover:text-indigo-200"
+                              x-text="recentlyDeliveredExpanded[t.id] ? 'Show less' : 'Read full'"></button>
+                            <button type="button"
+                              @click.stop="copyRecentlyDeliveredText(t.id)"
+                              class="text-[11px] text-gray-400 hover:text-gray-200">Copy</button>
+                          </div>
+                        </div>
+                      </template>
                     </div>
                   </template>
                 </div>
+              </div>
+            </template>
+
+            <!-- Skeleton loader for the activity feed itself while the
+                 first /workplace/feed fetch is in flight. Three pulsing
+                 rows match the visual rhythm of the real cards so the
+                 layout doesn't jump when content arrives. Hidden once
+                 the load resolves (success or error — the error banner
+                 below takes over in the failure case). -->
+            <template x-if="workplaceSectionLoading.feed && !workplaceFeed.length && !workplaceErrors.feed">
+              <div class="space-y-2" data-testid="workplace-feed-skeleton">
+                <div class="bg-gray-800/40 border border-gray-700/50 rounded-lg p-3">
+                  <div class="h-3 w-2/3 bg-gray-800 rounded animate-pulse"></div>
+                  <div class="h-2.5 w-1/3 bg-gray-800 rounded animate-pulse mt-2"></div>
+                </div>
+                <div class="bg-gray-800/40 border border-gray-700/50 rounded-lg p-3">
+                  <div class="h-3 w-3/4 bg-gray-800 rounded animate-pulse"></div>
+                  <div class="h-2.5 w-1/4 bg-gray-800 rounded animate-pulse mt-2"></div>
+                </div>
+                <div class="bg-gray-800/40 border border-gray-700/50 rounded-lg p-3">
+                  <div class="h-3 w-1/2 bg-gray-800 rounded animate-pulse"></div>
+                  <div class="h-2.5 w-1/3 bg-gray-800 rounded animate-pulse mt-2"></div>
+                </div>
+              </div>
+            </template>
+
+            <!-- Error banner for the activity feed. Rendered when the
+                 /workplace/feed fetch fails. Click "Retry" to clear
+                 the error and re-run the load — the spinner reappears
+                 via the skeleton template above. -->
+            <template x-if="workplaceErrors.feed">
+              <div class="bg-red-900/20 border border-red-800/40 rounded-lg p-3 flex flex-wrap items-center gap-2"
+                   role="alert" data-testid="workplace-feed-error">
+                <span class="text-xs text-red-200 flex-1" x-text="workplaceErrors.feed"></span>
+                <button type="button" @click="retryWorkplaceSection('feed')"
+                  class="text-[11px] font-medium px-2.5 py-1 rounded bg-red-800/40 hover:bg-red-700/50 text-red-100 transition-colors">Retry</button>
               </div>
             </template>
 
@@ -3369,7 +3432,7 @@
                  anywhere, the message reads as a calm prompt instead of
                  a "missing data" warning. The hint button switches to
                  the Chat tab so the user can start work in one click. -->
-            <template x-if="!workplaceFeed.length && !workplaceProjects.length && !needsYouItems.length">
+            <template x-if="!workplaceSectionLoading.feed && !workplaceErrors.feed && !workplaceFeed.length && !workplaceProjects.length && !needsYouItems.length">
               <div class="text-sm text-gray-300 py-6 text-center">
                 Your team is idle.
                 <button type="button" @click="activeTab = 'chat'"
@@ -3377,7 +3440,7 @@
                 to start something.
               </div>
             </template>
-            <template x-if="!workplaceFeed.length && workplaceProjects.length">
+            <template x-if="!workplaceSectionLoading.feed && !workplaceErrors.feed && !workplaceFeed.length && workplaceProjects.length">
               <div class="text-sm text-gray-500 py-4">No recent activity. Once agents start working, you'll see it here.</div>
             </template>
 
@@ -3404,7 +3467,30 @@
         <!-- Project status sub-tab -->
         <template x-if="workplaceEnabled && workplaceTab === 'project-status'">
           <div class="space-y-3">
-            <template x-if="!workplaceProjects.length">
+            <!-- Skeleton while /workplace/projects is in flight -->
+            <template x-if="workplaceSectionLoading.projects && !workplaceProjects.length && !workplaceErrors.projects">
+              <div class="space-y-3" data-testid="workplace-projects-skeleton">
+                <div class="bg-gray-800/40 border border-gray-700/50 rounded-lg p-4">
+                  <div class="h-4 w-1/3 bg-gray-800 rounded animate-pulse"></div>
+                  <div class="h-3 w-2/3 bg-gray-800 rounded animate-pulse mt-2"></div>
+                  <div class="h-3 w-1/2 bg-gray-800 rounded animate-pulse mt-2"></div>
+                </div>
+                <div class="bg-gray-800/40 border border-gray-700/50 rounded-lg p-4">
+                  <div class="h-4 w-1/4 bg-gray-800 rounded animate-pulse"></div>
+                  <div class="h-3 w-3/4 bg-gray-800 rounded animate-pulse mt-2"></div>
+                </div>
+              </div>
+            </template>
+            <!-- Error banner for /workplace/projects -->
+            <template x-if="workplaceErrors.projects">
+              <div class="bg-red-900/20 border border-red-800/40 rounded-lg p-3 flex flex-wrap items-center gap-2"
+                   role="alert" data-testid="workplace-projects-error">
+                <span class="text-xs text-red-200 flex-1" x-text="workplaceErrors.projects"></span>
+                <button type="button" @click="retryWorkplaceSection('projects')"
+                  class="text-[11px] font-medium px-2.5 py-1 rounded bg-red-800/40 hover:bg-red-700/50 text-red-100 transition-colors">Retry</button>
+              </div>
+            </template>
+            <template x-if="!workplaceSectionLoading.projects && !workplaceErrors.projects && !workplaceProjects.length">
               <div class="text-sm text-gray-500 py-4">No active projects.</div>
             </template>
             <template x-for="p in workplaceProjects" :key="p.name">
@@ -3475,6 +3561,30 @@
              phone users a horizontal-scroll fallback so each column
              keeps a usable width when they prefer the kanban layout. -->
         <template x-if="workplaceEnabled && workplaceTab === 'task-board'">
+          <div>
+            <!-- Error banner for /workplace/tasks. Tasks lives outside
+                 the kanban grid because errored loads should still let
+                 the user retry without seeing five empty columns. -->
+            <template x-if="workplaceErrors.tasks">
+              <div class="bg-red-900/20 border border-red-800/40 rounded-lg p-3 mb-3 flex flex-wrap items-center gap-2"
+                   role="alert" data-testid="workplace-tasks-error">
+                <span class="text-xs text-red-200 flex-1" x-text="workplaceErrors.tasks"></span>
+                <button type="button" @click="retryWorkplaceSection('tasks')"
+                  class="text-[11px] font-medium px-2.5 py-1 rounded bg-red-800/40 hover:bg-red-700/50 text-red-100 transition-colors">Retry</button>
+              </div>
+            </template>
+            <!-- Skeleton kanban while /workplace/tasks is in flight -->
+            <template x-if="workplaceSectionLoading.tasks && !workplaceTasks.length && !workplaceErrors.tasks">
+              <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-5 gap-3 mb-3" data-testid="workplace-tasks-skeleton">
+                <template x-for="i in 5" :key="'sk-task-' + i">
+                  <div class="bg-gray-800/40 border border-gray-700/50 rounded-lg p-3">
+                    <div class="h-3 w-1/2 bg-gray-800 rounded animate-pulse mb-2"></div>
+                    <div class="h-8 bg-gray-800 rounded animate-pulse mt-2"></div>
+                    <div class="h-8 bg-gray-800 rounded animate-pulse mt-2"></div>
+                  </div>
+                </template>
+              </div>
+            </template>
           <div class="overflow-x-auto custom-scrollbar -mx-3 px-3 sm:mx-0 sm:px-0">
             <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-5 gap-3 min-w-[640px] sm:min-w-0">
               <template x-for="status in workplaceTaskColumns" :key="status">
@@ -3527,6 +3637,7 @@
               </template>
             </div>
           </div>
+          </div>
         </template>
 
         <!-- (Blockers no longer have their own sub-tab — pinned at the top
@@ -3535,7 +3646,29 @@
         <!-- Team outputs sub-tab -->
         <template x-if="workplaceEnabled && workplaceTab === 'team-outputs'">
           <div class="space-y-2">
-            <template x-if="!workplaceOutputs.length">
+            <!-- Skeleton while /workplace/outputs is in flight -->
+            <template x-if="workplaceSectionLoading.outputs && !workplaceOutputs.length && !workplaceErrors.outputs">
+              <div class="space-y-2" data-testid="workplace-outputs-skeleton">
+                <div class="bg-gray-800/40 border border-gray-700/50 rounded-lg p-3">
+                  <div class="h-3 w-2/3 bg-gray-800 rounded animate-pulse"></div>
+                  <div class="h-2.5 w-1/3 bg-gray-800 rounded animate-pulse mt-2"></div>
+                </div>
+                <div class="bg-gray-800/40 border border-gray-700/50 rounded-lg p-3">
+                  <div class="h-3 w-3/4 bg-gray-800 rounded animate-pulse"></div>
+                  <div class="h-2.5 w-1/4 bg-gray-800 rounded animate-pulse mt-2"></div>
+                </div>
+              </div>
+            </template>
+            <!-- Error banner for /workplace/outputs -->
+            <template x-if="workplaceErrors.outputs">
+              <div class="bg-red-900/20 border border-red-800/40 rounded-lg p-3 flex flex-wrap items-center gap-2"
+                   role="alert" data-testid="workplace-outputs-error">
+                <span class="text-xs text-red-200 flex-1" x-text="workplaceErrors.outputs"></span>
+                <button type="button" @click="retryWorkplaceSection('outputs')"
+                  class="text-[11px] font-medium px-2.5 py-1 rounded bg-red-800/40 hover:bg-red-700/50 text-red-100 transition-colors">Retry</button>
+              </div>
+            </template>
+            <template x-if="!workplaceSectionLoading.outputs && !workplaceErrors.outputs && !workplaceOutputs.length">
               <div class="text-sm text-gray-500 py-4">No completed tasks yet.</div>
             </template>
             <template x-for="t in workplaceOutputs" :key="t.id">

--- a/src/templates/competitive-intel.yaml
+++ b/src/templates/competitive-intel.yaml
@@ -1,5 +1,5 @@
 name: competitive-intel
-description: Competitive intelligence scout — researches competitors and maintains up-to-date markdown reports as blackboard artifacts
+description: Tracks competitor pricing, product changes, and announcements; sends weekly summaries you can act on.
 
 agents:
   scout:

--- a/src/templates/content.yaml
+++ b/src/templates/content.yaml
@@ -1,5 +1,5 @@
 name: content
-description: Content creation team -- research, write, and edit
+description: Drafts blog posts, social copy, and email sequences from your brief; returns ready-to-edit drafts.
 agents:
   researcher:
     role: Content researcher — finds data, sources, and trends

--- a/src/templates/deep-research.yaml
+++ b/src/templates/deep-research.yaml
@@ -1,5 +1,5 @@
 name: deep-research
-description: Research team -- scout finds sources, analyst synthesizes, writer produces reports
+description: Investigates a topic deeply across multiple sources and returns a synthesized report with citations.
 agents:
   scout:
     role: Research scout — discovers sources and raw information

--- a/src/templates/lead-enrichment.yaml
+++ b/src/templates/lead-enrichment.yaml
@@ -1,5 +1,5 @@
 name: lead-enrichment
-description: Lead enrichment team -- enricher builds company profiles from LinkedIn, Crunchbase, and job boards; formatter exports CRM-ready CSV and JSON artifacts
+description: Researches your lead list and adds company size, recent news, and decision-makers; returns CRM-ready CSV.
 
 agents:
   enricher:

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -2483,6 +2483,154 @@ class TestDashboardCaptchaHelpSpaWiring:
         assert "msg.role !== 'browser_captcha_help_request'" in body
 
 
+class TestBoardLoadingAndErrorStates:
+    """PR-M — Board loading/error states + inline artifact preview.
+
+    Each loadWorkplace* function used to swallow errors silently
+    (``console.error``) which left the user staring at an empty
+    panel with no way to retry. These assertions guard the wiring
+    so a regression (someone removing the per-section state or the
+    retry helper) trips a unit test.
+    """
+
+    def setup_method(self):
+        self._tmpdir = tempfile.mkdtemp()
+        self.components = _make_components(self._tmpdir)
+        self.client = _make_client(self.components)
+
+    def teardown_method(self):
+        _teardown(self.components)
+        shutil.rmtree(self._tmpdir, ignore_errors=True)
+
+    def test_app_js_declares_per_section_loading_and_error_state(self):
+        resp = self.client.get("/dashboard/static/js/app.js")
+        assert resp.status_code == 200
+        body = resp.text
+        # Per-section state buckets so the template can render
+        # skeletons + error banners independently per section.
+        assert "workplaceSectionLoading" in body
+        assert "workplaceErrors" in body
+        # Sections covered (matches the loadWorkplace* surface).
+        for key in ("projects", "tasks", "blockers", "outputs", "pending", "feed"):
+            assert f"{key}: false" in body or f"'{key}'" in body or f'"{key}"' in body, \
+                f"app.js missing per-section bucket for {key}"
+
+    def test_app_js_load_functions_set_error_on_failure(self):
+        resp = self.client.get("/dashboard/static/js/app.js")
+        body = resp.text
+        # Error path replaces silent console.error: each loader sets
+        # its bucket so the banner renders.
+        assert "workplaceErrors.feed" in body
+        assert "workplaceErrors.projects" in body
+        assert "workplaceErrors.tasks" in body
+        assert "workplaceErrors.outputs" in body
+
+    def test_app_js_exposes_retry_helper(self):
+        resp = self.client.get("/dashboard/static/js/app.js")
+        body = resp.text
+        # Banners call retryWorkplaceSection(section) which clears
+        # the error and re-runs the section loader.
+        assert "retryWorkplaceSection" in body
+
+    def test_index_html_renders_skeleton_loaders(self):
+        resp = self.client.get("/dashboard/")
+        body = resp.text
+        # Skeleton testid hooks per sub-tab. The pulsing rectangles
+        # use the existing animate-pulse + bg-gray-800 classes for
+        # visual consistency with the drill-in modal skeleton.
+        assert 'data-testid="workplace-feed-skeleton"' in body
+        assert 'data-testid="workplace-projects-skeleton"' in body
+        assert 'data-testid="workplace-tasks-skeleton"' in body
+        assert 'data-testid="workplace-outputs-skeleton"' in body
+        # Each skeleton is gated on workplaceSectionLoading.<section>
+        # so it disappears when the load resolves.
+        assert "workplaceSectionLoading.feed" in body
+        assert "workplaceSectionLoading.projects" in body
+        assert "workplaceSectionLoading.tasks" in body
+        assert "workplaceSectionLoading.outputs" in body
+
+    def test_index_html_renders_error_banners_with_retry(self):
+        resp = self.client.get("/dashboard/")
+        body = resp.text
+        # Error banner testid hooks per sub-tab.
+        assert 'data-testid="workplace-feed-error"' in body
+        assert 'data-testid="workplace-projects-error"' in body
+        assert 'data-testid="workplace-tasks-error"' in body
+        assert 'data-testid="workplace-outputs-error"' in body
+        # Each banner has a "Retry" button bound to
+        # retryWorkplaceSection so the user can recover with one
+        # click without reloading.
+        assert "retryWorkplaceSection('feed')" in body
+        assert "retryWorkplaceSection('projects')" in body
+        assert "retryWorkplaceSection('tasks')" in body
+        assert "retryWorkplaceSection('outputs')" in body
+
+    def test_app_js_recently_delivered_inline_preview_helpers(self):
+        resp = self.client.get("/dashboard/static/js/app.js")
+        body = resp.text
+        # Helpers that back the "Recently delivered" inline preview.
+        assert "_ensureRecentlyDeliveredArtifact" in body
+        assert "recentlyDeliveredPreview" in body
+        assert "recentlyDeliveredFull" in body
+        assert "toggleRecentlyDeliveredExpanded" in body
+        assert "copyRecentlyDeliveredText" in body
+        # Copy uses the modern clipboard API with a fallback so it
+        # works on file:// and older browsers too.
+        assert "navigator.clipboard" in body
+
+    def test_index_html_recently_delivered_inline_preview_wired(self):
+        resp = self.client.get("/dashboard/")
+        body = resp.text
+        # Lazy-fetch on first render of each row.
+        assert "_ensureRecentlyDeliveredArtifact(t.id)" in body
+        # Toggle + copy buttons present on the row.
+        assert "toggleRecentlyDeliveredExpanded(t.id)" in body
+        assert "copyRecentlyDeliveredText(t.id)" in body
+        # Preview vs full content selection happens in the template.
+        assert "recentlyDeliveredFull(t.id)" in body
+        assert "recentlyDeliveredPreview(t.id)" in body
+
+    def test_index_html_chip_prefix_does_not_overwrite(self):
+        resp = self.client.get("/dashboard/")
+        body = resp.text
+        # The four onboarding chips now prepend their suggestion to
+        # whatever the user has already typed (chip + ' ' + opMsg)
+        # rather than clobbering it. Caret moves to the end via
+        # setSelectionRange so typing continues naturally.
+        assert "s.opMsg = chip + (s.opMsg ? ' ' + s.opMsg : '')" in body
+        assert "el.setSelectionRange(el.value.length, el.value.length)" in body
+
+
+class TestBoardTemplateDescriptions:
+    """PR-M — fleet-template descriptions rewritten as user outcomes.
+
+    Sarah-the-founder shouldn't need to know what a "blackboard
+    artifact" is to pick a template. Each description now tells her
+    what the team produces, in plain English.
+    """
+
+    def test_template_descriptions_are_plain_language(self):
+        import yaml
+
+        paths = {
+            "competitive-intel": "src/templates/competitive-intel.yaml",
+            "lead-enrichment": "src/templates/lead-enrichment.yaml",
+            "deep-research": "src/templates/deep-research.yaml",
+            "content": "src/templates/content.yaml",
+        }
+        descs = {}
+        for name, path in paths.items():
+            with open(path) as f:
+                data = yaml.safe_load(f)
+            descs[name] = data.get("description") or ""
+        # Jargon terms that previously leaked into user-facing copy.
+        for name, desc in descs.items():
+            assert "blackboard" not in desc.lower(), f"{name}: still mentions blackboard"
+            assert "artifact" not in desc.lower(), f"{name}: still mentions artifact"
+            # Each rewrite should describe a user-visible outcome.
+            assert len(desc) > 20, f"{name}: description too short"
+
+
 # ── V2 Tests: Messages ──────────────────────────────────────
 
 


### PR DESCRIPTION
## Summary

Makes Board failure modes visible and recently-delivered output readable inline, plus a chip-prefix UX fix and four template-description rewrites in plain English. Cosmetic only — no API contract changes.

This is **PR-M** from `docs/plans/2026-05-08-post-board-roadmap.md` (Phase 2, UX polish).

## Why

Sarah persona — non-technical SaaS founder — currently hits silent failures (silent `console.error` in `loadWorkplace*`) and can't see her recently-delivered output without drilling into a modal. Template descriptions still leak "blackboard artifacts" jargon.

## Changes

### 1. Skeleton loaders + per-section error banners

- `workplaceSectionLoading: { projects, tasks, blockers, outputs, pending, feed }` flipped at start/end of each `loadWorkplaceX`.
- `workplaceErrors: { ... }` per-section; non-empty string renders a banner with a Retry button.
- `retryWorkplaceSection(section)` clears error, sets loading, re-runs the matching load.
- Skeleton uses existing `animate-pulse bg-gray-800 rounded` (Tailwind CDN already loaded at index.html:14 — no new CSS).

### 2. Recently-delivered inline cards

For text artifacts:
- ≤300-char preview inline.
- "Read full" toggle expands; "Copy" button uses `navigator.clipboard.writeText` with a `document.execCommand` fallback for file:// and older browsers.
- Per-row lazy fetch (`x-init`) — keeps cost off the critical path; results cached by task_id.

Non-text kinds (image, PDF, etc.) keep existing modal behavior.

### 3. Chip prefix not overwrite

Onboarding/Board chips now PREPEND to chat input rather than overwrite:
```js
s.opMsg = chip + (s.opMsg ? ' ' + s.opMsg : '')
```

Caret moves to end via `setSelectionRange` on `$nextTick`. Users can chain multiple chips before sending.

### 4. Plain-language template descriptions

| Template | New description |
|---|---|
| `competitive-intel` | Tracks competitor pricing, product changes, and announcements; sends weekly summaries you can act on. |
| `lead-enrichment` | Researches your lead list and adds company size, recent news, and decision-makers; returns CRM-ready CSV. |
| `deep-research` | Investigates a topic deeply across multiple sources and returns a synthesized report with citations. |
| `content` | Drafts blog posts, social copy, and email sequences from your brief; returns ready-to-edit drafts. |

Permission paths and other YAML fields untouched.

## Explicitly NOT in this PR

- Lazy-load per Board sub-tab (deferred per spec — "Needs you" panel forces blockers + pending on initial mount anyway).

## Test plan

- [x] API error response → banner renders with Retry button
- [x] Skeleton loader visible during loading state (Alpine state assertion)
- [x] Recently-delivered artifact fetch + preview cache
- [x] Chip prefix behavior (additive, caret at end)
- [x] Template descriptions parse + render

12 PR-M-targeted tests pass. Full unit + integration suite: 5498 passed, 48 skipped. `ruff` clean.

## Note

CLAUDE.md says the dashboard is "Alpine + plain CSS, no Tailwind". That's stale — Tailwind IS loaded via CDN at index.html:14. PR-M used existing classes (no new CDN, no build step). Worth a follow-up CLAUDE.md update.