### PR TITLE
feat(operator): heartbeat_schedule soft field, persisted greeting, activity surface

### DIFF
--- a/src/agent/__main__.py
+++ b/src/agent/__main__.py
@@ -88,6 +88,19 @@ def main() -> None:
         initial_interface=initial_interface,
     )
 
+    # PR-L' — first-message greeting seeded into the chat transcript.
+    # Fires only on the very first boot of a fresh agent (gated on a
+    # sentinel file that lives in the persistent /data volume so it
+    # survives container restarts AND chat resets). The greeting is
+    # tagged with ``_origin == "bootstrap_greeting"`` so the LLM
+    # context layer can distinguish it from genuine assistant output.
+    initial_greeting = os.environ.get("INITIAL_GREETING", "")
+    if initial_greeting:
+        try:
+            workspace.seed_bootstrap_greeting(initial_greeting)
+        except Exception as e:
+            logger.debug("Greeting seed skipped: %s", e)
+
     # Copy host-mounted PROJECT.md into workspace (mounted at /app to avoid
     # Docker creating /data/workspace as root and breaking permissions)
     host_project = Path("/app/PROJECT.md")

--- a/src/agent/builtins/operator_tools.py
+++ b/src/agent/builtins/operator_tools.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import json
 import os
+import re as _re
 from datetime import datetime, timezone
 
 from src.agent.skills import skill
@@ -32,8 +33,45 @@ _OPERATOR_PERMISSION_CEILING = {
 
 _VALID_FIELDS = frozenset({
     "instructions", "soul", "model", "role", "heartbeat",
+    "heartbeat_schedule",
     "interface", "thinking", "budget", "permissions",
 })
+
+# Heartbeat schedule validator. Accepts the same forms cron.py accepts:
+#  * 5-field cron expressions ("*/15 * * * *", "0 9 * * 1-5")
+#  * "every Ns / Nm / Nh / Nd" interval shorthand
+# 6-field (seconds) cron is explicitly rejected here because cron.py
+# rejects it too — keep the error consistent at both layers.
+_HEARTBEAT_INTERVAL_RE = _re.compile(r"^every\s+\d+[smhd]$", _re.IGNORECASE)
+_HEARTBEAT_CRON_FIELD_RE = _re.compile(r"^[\d,\-\*/]+$")
+
+
+def _validate_heartbeat_schedule(value) -> str | None:
+    """Return an error string when ``value`` is not a valid schedule, else ``None``.
+
+    Keeps the surface narrow — only the two forms cron.py honours
+    (5-field cron + ``every N[smhd]``). Free-form named intervals
+    like ``hourly``/``daily`` are intentionally NOT accepted because
+    the cron scheduler's ``_is_due`` path doesn't recognise them.
+    """
+    if not isinstance(value, str) or not value.strip():
+        return "heartbeat_schedule must be a non-empty string"
+    sched = value.strip()
+    if _HEARTBEAT_INTERVAL_RE.match(sched):
+        return None
+    parts = sched.split()
+    if len(parts) == 6:
+        return (
+            "6-field (seconds) cron is not supported. Use 5-field cron "
+            "(minute resolution) or 'every Ns'. Example: '*/15 * * * *' "
+            "or 'every 15m'."
+        )
+    if len(parts) == 5 and all(_HEARTBEAT_CRON_FIELD_RE.match(p) for p in parts):
+        return None
+    return (
+        f"Invalid schedule: {sched!r}. Use 5-field cron "
+        "('*/15 * * * *') or 'every N[smhd]' ('every 15m')."
+    )
 
 # PR 1 — soft edits apply immediately + emit a receipt with 5min Undo;
 # hard edits keep the propose+confirm dance (model swap, budget change,
@@ -111,7 +149,14 @@ def _validate_edit(agent_id: str, field: str, value) -> dict | None:
                 f"got '{value}'"
             ),
         }
+    if field == "heartbeat_schedule":
+        err = _validate_heartbeat_schedule(value)
+        if err:
+            return {"error": err}
     return None
+
+
+_PROPOSE_EDIT_FIELDS = _VALID_FIELDS - {"heartbeat_schedule"}
 
 
 @skill(
@@ -156,12 +201,14 @@ async def propose_edit(agent_id: str, field: str, value, *, mesh_client=None, **
             ),
         }
 
-    # Validate field
-    if field not in _VALID_FIELDS:
+    # Validate field. ``heartbeat_schedule`` is soft-only — the propose
+    # path is for hard fields, so reject the schedule here and route the
+    # caller to ``edit_agent`` instead.
+    if field not in _PROPOSE_EDIT_FIELDS:
         return {
             "error": (
                 f"Invalid field '{field}'. "
-                f"Must be one of: {sorted(_VALID_FIELDS)}"
+                f"Must be one of: {sorted(_PROPOSE_EDIT_FIELDS)}"
             ),
         }
 
@@ -279,10 +326,10 @@ async def confirm_edit(change_id: str, *, mesh_client=None, _messages=None, **_k
     name="edit_agent",
     description=(
         "Change an agent's configuration. Branches internally on field severity:\n"
-        "- Soft fields (instructions, soul, heartbeat, interface, role) "
-        "apply IMMEDIATELY. The user sees a receipt card with [View diff] "
-        "[Undo] (5-minute undo window). No confirmation step needed — "
-        "act decisively on what the user asked for.\n"
+        "- Soft fields (instructions, soul, heartbeat, heartbeat_schedule, "
+        "interface, role) apply IMMEDIATELY. The user sees a receipt card "
+        "with [View diff] [Undo] (5-minute undo window). No confirmation "
+        "step needed — act decisively on what the user asked for.\n"
         "- Hard fields (model, budget, permissions, thinking) return a "
         "preview + change_id (expires in 5 minutes for most actions, "
         "30 minutes for hard-field edits so the user has time to think). "
@@ -291,6 +338,8 @@ async def confirm_edit(change_id: str, *, mesh_client=None, _messages=None, **_k
         "Always pass `reason` so the audit trail captures intent.\n\n"
         "Fields & value formats:\n"
         "- instructions/soul/heartbeat/interface/role: string\n"
+        "- heartbeat_schedule: 5-field cron ('*/15 * * * *') OR "
+        "'every N[smhd]' ('every 15m', 'every 2h')\n"
         "- budget: {\"daily_usd\": float, \"monthly_usd\": float}\n"
         "- permissions: {\"can_use_browser\": bool, ...}\n"
         "- thinking: \"off\" | \"low\" | \"medium\" | \"high\"\n"
@@ -306,6 +355,7 @@ async def confirm_edit(change_id: str, *, mesh_client=None, _messages=None, **_k
             "description": "Config field to change",
             "enum": [
                 "instructions", "soul", "model", "role", "heartbeat",
+                "heartbeat_schedule",
                 "interface", "thinking", "budget", "permissions",
             ],
         },

--- a/src/agent/workspace.py
+++ b/src/agent/workspace.py
@@ -640,6 +640,43 @@ class WorkspaceManager:
     # ── Chat transcript ───────────────────────────────────────
 
     _MAX_TRANSCRIPT_SIZE = 2_000_000  # 2 MB — rotate if larger
+    _GREETING_SENTINEL = ".greeting_seeded"
+
+    def seed_bootstrap_greeting(self, greeting: str) -> bool:
+        """Seed a one-shot greeting into the chat transcript (idempotent).
+
+        Writes a single ``role=assistant`` entry tagged with
+        ``_origin == "bootstrap_greeting"`` so the LLM context layer
+        can distinguish it from a real model-authored message and
+        skip provenance gates that would otherwise reject it.
+
+        Idempotency is enforced via a sentinel file under the
+        workspace root — once written, subsequent calls are no-ops
+        even after a chat reset (which archives the transcript but
+        leaves the sentinel intact). Returns ``True`` when the
+        greeting was actually written, ``False`` when skipped.
+        """
+        if not greeting or not greeting.strip():
+            return False
+        sentinel = self.root / self._GREETING_SENTINEL
+        if sentinel.exists():
+            return False
+        path = self.root / self.CHAT_TRANSCRIPT
+        entry: dict = {
+            "role": "assistant",
+            "content": greeting,
+            "ts": time.time(),
+            "_origin": "bootstrap_greeting",
+        }
+        try:
+            self.root.mkdir(parents=True, exist_ok=True)
+            with path.open("a") as f:
+                f.write(json.dumps(entry, default=str) + "\n")
+            sentinel.touch()
+            return True
+        except OSError as e:
+            logger.debug("Failed to seed bootstrap greeting: %s", e)
+            return False
 
     def append_chat_message(
         self, role: str, content: str, *,

--- a/src/cli/runtime.py
+++ b/src/cli/runtime.py
@@ -394,6 +394,12 @@ class RuntimeContext:
                 agent_env["INITIAL_INTERFACE"] = initial_interface
             if agent_id == _OPERATOR_AGENT_ID:
                 agent_env["ALLOWED_TOOLS"] = ",".join(_OPERATOR_ALLOWED_TOOLS)
+                # PR-L' — pass the boot greeting so the agent can seed
+                # its chat transcript on first start. Idempotency is
+                # gated agent-side on a sentinel file in /data/workspace,
+                # so subsequent restarts and chat-resets do NOT re-emit.
+                from src.shared.operator_playbooks import _OPERATOR_GREETING
+                agent_env["INITIAL_GREETING"] = _OPERATOR_GREETING
 
             # Project env vars
             project_name = agent_projects.get(agent_id)
@@ -459,6 +465,7 @@ class RuntimeContext:
                 self.runtime.extra_env.pop("INITIAL_SOUL", None)
                 self.runtime.extra_env.pop("INITIAL_HEARTBEAT", None)
                 self.runtime.extra_env.pop("INITIAL_INTERFACE", None)
+                self.runtime.extra_env.pop("INITIAL_GREETING", None)
                 self.runtime.extra_env.pop("PROJECT_MD_PATH", None)
                 self.runtime.extra_env.pop("PROJECT_NAME", None)
                 self.runtime.extra_env.pop("HTTP_PROXY", None)

--- a/src/dashboard/server.py
+++ b/src/dashboard/server.py
@@ -888,6 +888,16 @@ def create_dashboard_router(
             h = health_map.get(agent_id, {})
             c = cost_map.get(agent_id, {})
             acfg = agents_cfg.get(agent_id, {})
+            # PR-L' — surface the most recent task event timestamp so
+            # the agent card can render "Last task Nm ago" alongside
+            # "Last seen" (health probe). Best-effort: ``None`` when
+            # tasks_v2 is disabled or the agent has no events yet.
+            last_task_ts: float | None = None
+            if tasks_store is not None:
+                try:
+                    last_task_ts = tasks_store.last_event_ts_for_agent(agent_id)
+                except Exception:
+                    last_task_ts = None
             entry = {
                 "id": agent_id,
                 "url": url,
@@ -898,6 +908,7 @@ def create_dashboard_router(
                 "restarts": h.get("restarts", 0),
                 "last_check": h.get("last_check", 0),
                 "last_healthy": h.get("last_healthy", 0),
+                "last_task_event_ts": last_task_ts,
                 "daily_cost": c.get("cost", 0),
                 "daily_tokens": c.get("tokens", 0),
                 "role": acfg.get("role", ""),
@@ -932,6 +943,7 @@ def create_dashboard_router(
                     "restarts": 0,
                     "last_check": 0,
                     "last_healthy": 0,
+                    "last_task_event_ts": None,
                     "daily_cost": 0,
                     "daily_tokens": 0,
                     "role": acfg.get("role", ""),

--- a/src/dashboard/static/js/app.js
+++ b/src/dashboard/static/js/app.js
@@ -2615,6 +2615,26 @@ function dashboard() {
       return d.toLocaleDateString([], { month: 'short', day: 'numeric' }) + ', ' + time;
     },
 
+    // PR-L' — render "Last seen Nm ago · Last task Mm ago" on the
+    // agent card. ``last_healthy`` is epoch SECONDS (HealthMonitor),
+    // ``last_task_event_ts`` is epoch SECONDS (Tasks.task_events).
+    // Fresh-enough timestamps (<1 min) yield empty strings from
+    // formatRelativeTime — fall back to "just now" for legibility.
+    agentActivityLabel(agent) {
+      const fmt = (sec) => {
+        if (!sec) return '';
+        const ms = sec * 1000;
+        const rel = this.formatRelativeTime(ms);
+        return rel || 'just now';
+      };
+      const seen = fmt(agent.last_healthy);
+      const task = fmt(agent.last_task_event_ts);
+      const parts = [];
+      if (seen) parts.push('Seen ' + seen);
+      if (task) parts.push('Task ' + task);
+      return parts.join(' · ');
+    },
+
     healthLabel(status) {
       const map = { healthy: 'Online', unhealthy: 'Degraded', restarting: 'Degraded', failed: 'Offline', unknown: 'Starting' };
       return map[status] || 'Starting';

--- a/src/dashboard/templates/index.html
+++ b/src/dashboard/templates/index.html
@@ -1847,6 +1847,13 @@
                   </span>
                   <span class="stat-value" x-text="formatCost(agent.daily_cost)"></span>
                 </div>
+                <div class="stat-row" x-show="agent.last_healthy || agent.last_task_event_ts">
+                  <span class="stat-label">
+                    <svg fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><polyline points="12 6 12 12 16 14"/></svg>
+                    Last activity<span class="setting-hint setting-hint-sm ml-0.5" tabindex="0">?<span class="setting-hint-text">"Last seen" is the most recent successful health probe; "Last task" is the most recent task event (status change, comment, completion). The two diverge when an agent is healthy but idle, or has finished work but is now offline.</span></span>
+                  </span>
+                  <span class="stat-value text-[11px]" x-text="agentActivityLabel(agent)"></span>
+                </div>
               </div>
 
               <!-- Agent actions: Chat + heartbeat Pause/Resume (hidden when locked) -->

--- a/src/host/orchestration.py
+++ b/src/host/orchestration.py
@@ -542,6 +542,28 @@ class Tasks:
             ).fetchall()
         return {row[0]: int(row[1] or 0) for row in rows if row[0]}
 
+    def last_event_ts_for_agent(self, agent_id: str) -> float | None:
+        """Return the most recent ``task_events.created_at`` for ``agent_id``.
+
+        Joins ``task_events`` against ``tasks`` and matches against the
+        task's ``creator``, ``assignee``, OR the event's ``actor`` —
+        any of those three roles count as "this agent participated".
+        Returns ``None`` when the agent has no events at all (fresh
+        fleet, or store disabled). Used by the dashboard agent card to
+        render a "Last task" timestamp alongside the health-derived
+        "Last seen" (PR-L').
+        """
+        with self._conn() as conn:
+            row = conn.execute(
+                "SELECT MAX(te.created_at) FROM task_events te "
+                "LEFT JOIN tasks t ON te.task_id = t.id "
+                "WHERE te.actor = ? OR t.creator = ? OR t.assignee = ?",
+                (agent_id, agent_id, agent_id),
+            ).fetchone()
+        if not row or row[0] is None:
+            return None
+        return float(row[0])
+
     def list_stale_for_assignee(
         self,
         assignee: str,

--- a/src/host/server.py
+++ b/src/host/server.py
@@ -3073,6 +3073,26 @@ def create_mesh_app(
                         h.last_healthy, tz=timezone.utc,
                     ).isoformat()
 
+        # PR-L' — most recent task_events row for this agent. Distinct
+        # from ``last_active`` (health probe response) so the dashboard
+        # card can render "Last seen 4m ago · Last task 12m ago" — the
+        # two diverge when an agent is healthy but hasn't picked up
+        # work, OR completed work but is now offline.
+        last_task_event_ts: str | None = None
+        if tasks_store is not None:
+            try:
+                ts = tasks_store.last_event_ts_for_agent(agent_id)
+                if ts is not None:
+                    from datetime import datetime, timezone
+                    last_task_event_ts = datetime.fromtimestamp(
+                        ts, tz=timezone.utc,
+                    ).isoformat()
+            except Exception as e:
+                logger.debug(
+                    "last_event_ts_for_agent failed for '%s': %s",
+                    agent_id, e,
+                )
+
         # Heartbeat schedule
         heartbeat_schedule = None
         if cron_scheduler is not None:
@@ -3151,6 +3171,7 @@ def create_mesh_app(
             "role": role,
             "status": status,
             "last_active": last_active,
+            "last_task_event_ts": last_task_event_ts,
             "heartbeat_schedule": heartbeat_schedule,
             "subscriptions": subscriptions,
             "watches": watches,
@@ -4973,6 +4994,12 @@ def create_mesh_app(
             # Hot-reload the in-memory permission matrix
             if permissions is not None:
                 permissions.reload()
+        elif field == "heartbeat_schedule":
+            # Source of truth is the cron table — not agents.yaml. The
+            # cron update happens in the heartbeat-schedule sync block
+            # below (shared with the legacy ``heartbeat`` field path so
+            # both write paths converge on the same scheduler call).
+            pass
         else:
             yaml_key = _CONFIG_FIELD_MAP.get(field, field)
             agents[agent_id][yaml_key] = new_value
@@ -5047,11 +5074,17 @@ def create_mesh_app(
                     field, agent_id, e,
                 )
 
-        # Heartbeat schedule sync: if the value looks like a cron schedule
-        # (5-field expression or "every Xm/h/d"), update the cron job too.
-        # This handles the common case where the operator edits heartbeat
-        # frequency — the cron scheduler schedule must match.
-        if field == "heartbeat" and cron_scheduler is not None and isinstance(new_value, str):
+        # Heartbeat schedule sync. Two trigger paths converge here:
+        #
+        #   * ``field == "heartbeat"`` — legacy: when the operator edits
+        #     the heartbeat-rules markdown and the new content happens to
+        #     parse as a schedule, update the cron job too. Best-effort
+        #     pattern match.
+        #
+        #   * ``field == "heartbeat_schedule"`` — PR-L': dedicated soft
+        #     field for cadence only. Always retargets the cron job;
+        #     value is pre-validated by the operator-tool layer.
+        if cron_scheduler is not None and isinstance(new_value, str) and field in ("heartbeat", "heartbeat_schedule"):
             sched = new_value.strip()
             _is_schedule = (
                 bool(re.fullmatch(r"every\s+\d+[smhd]", sched, re.IGNORECASE))
@@ -5061,7 +5094,26 @@ def create_mesh_app(
             )
             if _is_schedule:
                 hb_job = cron_scheduler.find_heartbeat_job(agent_id)
-                if hb_job:
+                if hb_job is None and field == "heartbeat_schedule":
+                    # ``heartbeat_schedule`` always implies a heartbeat
+                    # job exists or should be created — agents start
+                    # with one via ``ensure_heartbeat`` at registration.
+                    # Auto-create here too so the soft-edit doesn't
+                    # silently no-op against an agent that never
+                    # registered (test fixtures, partial bring-up).
+                    try:
+                        hb_job = cron_scheduler.ensure_heartbeat(agent_id, schedule=sched)
+                        logger.info(
+                            "Created heartbeat job for '%s': %s",
+                            agent_id, sched,
+                        )
+                    except Exception as e:
+                        logger.warning(
+                            "Failed to create heartbeat job for '%s': %s",
+                            agent_id, e,
+                        )
+                        hb_job = None
+                if hb_job is not None and hb_job.schedule != sched:
                     try:
                         await cron_scheduler.update_job(hb_job.id, schedule=sched)
                         logger.info(
@@ -5101,6 +5153,7 @@ def create_mesh_app(
             "instructions": "instructions",
             "soul": "personality",
             "heartbeat": "heartbeat",
+            "heartbeat_schedule": "heartbeat schedule",
             "interface": "interface contract",
             "role": "role",
         }.get(field, field)
@@ -5164,8 +5217,19 @@ def create_mesh_app(
         if agent_id not in agents:
             raise HTTPException(404, f"Agent '{agent_id}' not found")
 
-        yaml_key = _CONFIG_FIELD_MAP.get(field, field)
-        old_value = agents[agent_id].get(yaml_key, "")
+        # ``heartbeat_schedule`` is sourced from the live cron job, not
+        # YAML — the cron table is the source of truth for an agent's
+        # actual heartbeat cadence (PR-L'). Read the current schedule
+        # so the audit/Undo flow restores the right value.
+        if field == "heartbeat_schedule":
+            old_value = ""
+            if cron_scheduler is not None:
+                hb_job = cron_scheduler.find_heartbeat_job(agent_id)
+                if hb_job is not None:
+                    old_value = hb_job.schedule
+        else:
+            yaml_key = _CONFIG_FIELD_MAP.get(field, field)
+            old_value = agents[agent_id].get(yaml_key, "")
 
         # Apply directly via the same write helper used by the confirm
         # path. ``_apply_pending_change`` is async and handles audit

--- a/src/shared/operator_playbooks.py
+++ b/src/shared/operator_playbooks.py
@@ -110,6 +110,28 @@ Wait for the user to respond or for the issue to resolve.
 
 <!-- playbook_v2 -->"""
 
+# ── Boot greeting (seeded once on first operator creation) ────
+
+_OPERATOR_GREETING = """\
+Hi — I'm your Operator. I'm here to help you build and run AI agent \
+teams without you having to drive every step.
+
+Tell me what you're trying to accomplish — like:
+- "I want to monitor my competitors' pricing weekly"
+- "I need a content team to ship 3 blog posts a week"
+- "I want to enrich my lead list with company info"
+
+I'll suggest a team, set them up, and check on their work for you. You \
+can always ask me what's happening, change a teammate, or pause anything \
+that's not working.
+"""
+"""First-message greeting seeded into the operator's chat transcript on
+fresh creation. Rendered as an ``assistant``-role message tagged with
+``_origin == "bootstrap_greeting"`` so the dashboard / context layer can
+distinguish it from real LLM-authored output. NOT re-emitted on chat
+reset (see Decision #3 in the Post-Board roadmap).
+"""
+
 # ── Playbooks (loaded on demand) ──────────────────────────────
 
 _PLAYBOOK_TEAM_BUILD = """\

--- a/src/shared/types.py
+++ b/src/shared/types.py
@@ -52,10 +52,16 @@ Single source of truth — imported by :mod:`src.host.server` and
 """
 
 SOFT_EDIT_FIELDS = frozenset({
-    "instructions", "soul", "heartbeat", "interface", "role",
+    "instructions", "soul", "heartbeat", "heartbeat_schedule",
+    "interface", "role",
 })
 """Agent-config fields that apply immediately with a 5-min Undo receipt
 (the "soft" review path). See :data:`HARD_EDIT_FIELDS` for the inverse.
+
+``heartbeat_schedule`` retargets the agent's cron job in lockstep with
+the YAML write — the operator can adjust monitoring cadence without a
+new tool surface (PR-L'). Validation lives in
+:func:`src.agent.builtins.operator_tools._validate_heartbeat_schedule`.
 """
 
 # === Inter-Component Messages ===

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -252,6 +252,49 @@ class TestDashboardAgentsAPI:
         data = resp.json()
         assert data["agents"] == []
 
+    @patch("src.cli.config._load_config", return_value={
+        "llm": {"default_model": "openai/gpt-4o-mini"}, "agents": {},
+    })
+    def test_api_agents_includes_last_task_event_ts_field(self, _mock_load):
+        """PR-L' — agent cards expose last_task_event_ts (None when no store)."""
+        resp = self.client.get("/dashboard/api/agents")
+        data = resp.json()
+        for agent in data["agents"]:
+            # Field is always present; value is None when tasks_v2 is
+            # disabled or the agent has no events yet.
+            assert "last_task_event_ts" in agent
+
+    @patch("src.cli.config._load_config", return_value={
+        "llm": {"default_model": "openai/gpt-4o-mini"}, "agents": {},
+    })
+    def test_api_agents_last_task_event_ts_none_without_tasks_store(self, _mock_load):
+        resp = self.client.get("/dashboard/api/agents")
+        data = resp.json()
+        for agent in data["agents"]:
+            assert agent["last_task_event_ts"] is None
+
+    @patch("src.cli.config._load_config", return_value={
+        "llm": {"default_model": "openai/gpt-4o-mini"}, "agents": {},
+    })
+    def test_api_agents_last_task_event_ts_populated_when_store_has_event(self, _mock_load):
+        """PR-L' — agent-card timestamp resolves from tasks_v2 events."""
+        from src.host.orchestration import Tasks
+        store = Tasks(db_path=os.path.join(self._tmpdir, "tasks_recent.db"))
+        try:
+            store.create(creator="alpha", assignee="beta", title="x")
+            self.components["tasks_store"] = store
+            client = _make_client(self.components)
+            resp = client.get("/dashboard/api/agents")
+            data = resp.json()
+            alpha = next(a for a in data["agents"] if a["id"] == "alpha")
+            beta = next(a for a in data["agents"] if a["id"] == "beta")
+            # Both touched the task — alpha as creator, beta as assignee.
+            assert alpha["last_task_event_ts"] is not None
+            assert beta["last_task_event_ts"] is not None
+        finally:
+            store.close()
+            self.components.pop("tasks_store", None)
+
 
 class TestDashboardAgentCRUD:
     """Tests for POST /api/agents and DELETE /api/agents/{id}."""

--- a/tests/test_operator_tools.py
+++ b/tests/test_operator_tools.py
@@ -1168,6 +1168,122 @@ async def test_undo_change_no_mesh_client():
     assert "mesh_client" in result["error"].lower()
 
 
+# ── PR-L' — heartbeat_schedule soft field ──────────────────────
+
+
+@pytest.mark.asyncio
+async def test_edit_agent_heartbeat_schedule_cron_value():
+    """5-field cron value is accepted and routed through edit_soft."""
+    from src.agent.builtins.operator_tools import edit_agent
+
+    mc = MagicMock()
+    mc.edit_soft = AsyncMock(return_value={
+        "success": True, "undo_token": "tok-hs",
+        "expires_at": "2026-05-08T00:05:00+00:00",
+        "summary": "Updated writer's heartbeat schedule",
+    })
+    result = await edit_agent(
+        "writer", "heartbeat_schedule", "*/15 * * * *",
+        reason="user_asked", mesh_client=mc,
+    )
+    assert result["success"] is True
+    assert result["applied"] is True
+    assert result["undo_token"] == "tok-hs"
+    mc.edit_soft.assert_awaited_once_with(
+        "writer", "heartbeat_schedule", "*/15 * * * *", "user_asked",
+    )
+
+
+@pytest.mark.asyncio
+async def test_edit_agent_heartbeat_schedule_interval_value():
+    """``every 15m`` shorthand is accepted and routed through edit_soft."""
+    from src.agent.builtins.operator_tools import edit_agent
+
+    mc = MagicMock()
+    mc.edit_soft = AsyncMock(return_value={
+        "success": True, "undo_token": "tok-hs2",
+        "expires_at": "x", "summary": "ok",
+    })
+    result = await edit_agent(
+        "writer", "heartbeat_schedule", "every 15m",
+        reason="user_asked", mesh_client=mc,
+    )
+    assert result["success"] is True
+    mc.edit_soft.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_edit_agent_heartbeat_schedule_rejects_garbage():
+    """Free-form values are rejected with a clear validation error.
+
+    ``hourly`` looks "named" but cron.py's ``_is_due`` doesn't honour
+    it — accepting silently here would create a soft edit that no-ops
+    against the scheduler. Reject early with a usable error message.
+    """
+    from src.agent.builtins.operator_tools import edit_agent
+
+    for bad in ("garbage", "hourly", "every 0", "* * * *"):
+        result = await edit_agent(
+            "writer", "heartbeat_schedule", bad,
+            mesh_client=MagicMock(),
+        )
+        assert "error" in result, f"value {bad!r} should have errored"
+        assert (
+            "schedule" in result["error"].lower()
+            or "string" in result["error"].lower()
+            or "field" in result["error"].lower()
+        )
+
+
+@pytest.mark.asyncio
+async def test_edit_agent_heartbeat_schedule_rejects_six_field_cron():
+    from src.agent.builtins.operator_tools import edit_agent
+
+    result = await edit_agent(
+        "writer", "heartbeat_schedule", "* * * * * *",
+        mesh_client=MagicMock(),
+    )
+    assert "error" in result
+    assert "6-field" in result["error"] or "seconds" in result["error"].lower()
+
+
+@pytest.mark.asyncio
+async def test_edit_agent_heartbeat_schedule_rejects_non_string():
+    from src.agent.builtins.operator_tools import edit_agent
+
+    result = await edit_agent(
+        "writer", "heartbeat_schedule", 900,
+        mesh_client=MagicMock(),
+    )
+    assert "error" in result
+
+
+@pytest.mark.asyncio
+async def test_edit_agent_heartbeat_schedule_blocks_self_modification():
+    from src.agent.builtins.operator_tools import edit_agent
+
+    result = await edit_agent(
+        "operator", "heartbeat_schedule", "*/15 * * * *",
+        mesh_client=MagicMock(),
+    )
+    assert "error" in result
+    assert "operator" in result["error"].lower()
+
+
+def test_propose_edit_rejects_heartbeat_schedule_field():
+    """Soft-only field; legacy propose_edit must refuse it."""
+    import asyncio
+
+    from src.agent.builtins.operator_tools import propose_edit
+
+    result = asyncio.run(propose_edit(
+        "writer", "heartbeat_schedule", "*/15 * * * *",
+        mesh_client=MagicMock(),
+    ))
+    assert "error" in result
+    assert "heartbeat_schedule" in result["error"] or "Invalid field" in result["error"]
+
+
 # ── list_pending ─────────────────────────────────────────────
 
 

--- a/tests/test_orchestration.py
+++ b/tests/test_orchestration.py
@@ -890,3 +890,49 @@ def test_list_stale_for_assignee_excludes_fresh(tmp_path):
         "alpha", threshold_seconds=24 * 3600, limit=5,
     )
     assert rows == []
+
+
+# ── PR-L' — recent activity surface ───────────────────────────────
+
+
+def test_last_event_ts_for_agent_returns_none_when_no_events(tmp_path):
+    t = _make_store(tmp_path)
+    assert t.last_event_ts_for_agent("nobody") is None
+
+
+def test_last_event_ts_for_agent_picks_up_creator_role(tmp_path):
+    t = _make_store(tmp_path)
+    rec = t.create(creator="alpha", assignee="beta", title="hi")
+    ts = t.last_event_ts_for_agent("alpha")
+    assert ts is not None
+    # Within a couple of seconds of when the row was created.
+    assert abs(ts - rec["created_at"]) < 5
+
+
+def test_last_event_ts_for_agent_picks_up_assignee_role(tmp_path):
+    t = _make_store(tmp_path)
+    t.create(creator="alpha", assignee="beta", title="hi")
+    ts = t.last_event_ts_for_agent("beta")
+    assert ts is not None
+
+
+def test_last_event_ts_for_agent_picks_up_actor_role(tmp_path):
+    """An actor who is neither creator nor assignee still counts."""
+    t = _make_store(tmp_path)
+    rec = t.create(creator="alpha", assignee="beta", title="hi")
+    # Operator-grade emits an event with actor="operator".
+    t.update_status(rec["id"], "working", actor="operator")
+    ts = t.last_event_ts_for_agent("operator")
+    assert ts is not None
+
+
+def test_last_event_ts_for_agent_returns_most_recent(tmp_path):
+    t = _make_store(tmp_path)
+    rec_a = t.create(creator="alpha", assignee="beta", title="early")
+    time.sleep(0.05)
+    rec_b = t.create(creator="alpha", assignee="beta", title="later")
+    ts = t.last_event_ts_for_agent("alpha")
+    assert ts is not None
+    # The later row's event should win.
+    assert ts >= rec_b["created_at"]
+    assert ts >= rec_a["created_at"]

--- a/tests/test_undo_endpoint.py
+++ b/tests/test_undo_endpoint.py
@@ -171,6 +171,108 @@ async def test_undo_403_for_non_operator(mesh_app):
 
 
 @pytest.mark.asyncio
+async def test_heartbeat_schedule_soft_edit_updates_cron(mesh_app):
+    """PR-L' — heartbeat_schedule edits must retarget the agent's cron job."""
+    app, server_module, tmp_path = mesh_app
+
+    blackboard = Blackboard(str(tmp_path / "bb_hs.db"))
+    pubsub = PubSub()
+    permissions = PermissionMatrix()
+    permissions.permissions["operator"] = AgentPermissions(
+        agent_id="operator", can_route_tasks=True,
+    )
+    permissions.permissions["writer"] = AgentPermissions(agent_id="writer")
+    router = MessageRouter(permissions, {})
+
+    from src.host.cron import CronScheduler
+    cron = CronScheduler(config_path=str(tmp_path / "cron.json"))
+    cron.ensure_heartbeat("writer", schedule="every 1h")
+
+    app2 = server_module.create_mesh_app(
+        blackboard=blackboard,
+        pubsub=pubsub,
+        router=router,
+        permissions=permissions,
+        cron_scheduler=cron,
+    )
+    try:
+        async with AsyncClient(transport=ASGITransport(app=app2), base_url="http://t") as c:
+            r = await c.post(
+                "/mesh/agents/writer/edit-soft",
+                json={
+                    "field": "heartbeat_schedule",
+                    "value": "*/15 * * * *",
+                    "reason": "user_asked",
+                },
+                headers=_human_origin_headers(),
+            )
+        assert r.status_code == 200, r.text
+        body = r.json()
+        assert body["success"] is True
+        assert body["field"] == "heartbeat_schedule"
+        # Cron job updated.
+        hb = cron.find_heartbeat_job("writer")
+        assert hb is not None
+        assert hb.schedule == "*/15 * * * *"
+    finally:
+        blackboard.close()
+
+
+@pytest.mark.asyncio
+async def test_heartbeat_schedule_undo_restores_prior_cron(mesh_app):
+    """Undoing a heartbeat_schedule edit must restore the prior schedule."""
+    app, server_module, tmp_path = mesh_app
+
+    blackboard = Blackboard(str(tmp_path / "bb_hs2.db"))
+    pubsub = PubSub()
+    permissions = PermissionMatrix()
+    permissions.permissions["operator"] = AgentPermissions(
+        agent_id="operator", can_route_tasks=True,
+    )
+    permissions.permissions["writer"] = AgentPermissions(agent_id="writer")
+    router = MessageRouter(permissions, {})
+
+    from src.host.cron import CronScheduler
+    cron = CronScheduler(config_path=str(tmp_path / "cron2.json"))
+    cron.ensure_heartbeat("writer", schedule="every 1h")
+
+    app2 = server_module.create_mesh_app(
+        blackboard=blackboard,
+        pubsub=pubsub,
+        router=router,
+        permissions=permissions,
+        cron_scheduler=cron,
+    )
+    try:
+        async with AsyncClient(transport=ASGITransport(app=app2), base_url="http://t") as c:
+            edit = await c.post(
+                "/mesh/agents/writer/edit-soft",
+                json={
+                    "field": "heartbeat_schedule",
+                    "value": "*/15 * * * *",
+                    "reason": "user_asked",
+                },
+                headers=_human_origin_headers(),
+            )
+            assert edit.status_code == 200, edit.text
+            token = edit.json()["undo_token"]
+            r = await c.post(
+                f"/mesh/changes/undo/{token}",
+                json={},
+                headers=_human_origin_headers(),
+            )
+        assert r.status_code == 200, r.text
+        body = r.json()
+        assert body["success"] is True
+        # Cron schedule reverted to the original.
+        hb = cron.find_heartbeat_job("writer")
+        assert hb is not None
+        assert hb.schedule == "every 1h"
+    finally:
+        blackboard.close()
+
+
+@pytest.mark.asyncio
 async def test_undo_emits_undone_event(mesh_app):
     """After a successful undo the bus must see operator_action_receipt_undone."""
     app, server_module, tmp_path = mesh_app

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -938,6 +938,62 @@ class TestChatTranscript:
             WorkspaceManager._MAX_TRANSCRIPT_SIZE = original_max
 
 
+class TestSeedBootstrapGreeting:
+    """PR-L' — greeting seeding is one-shot via a sentinel file."""
+
+    def setup_method(self):
+        self._tmpdir = tempfile.mkdtemp()
+        self.ws = WorkspaceManager(workspace_dir=self._tmpdir)
+
+    def teardown_method(self):
+        shutil.rmtree(self._tmpdir, ignore_errors=True)
+
+    def test_seed_writes_assistant_message_with_origin(self):
+        ok = self.ws.seed_bootstrap_greeting("Hi — I'm your Operator.")
+        assert ok is True
+        msgs = self.ws.load_chat_transcript()
+        assert len(msgs) == 1
+        assert msgs[0]["role"] == "assistant"
+        assert msgs[0]["_origin"] == "bootstrap_greeting"
+        assert "Operator" in msgs[0]["content"]
+
+    def test_seed_creates_sentinel(self):
+        self.ws.seed_bootstrap_greeting("hi")
+        sentinel = Path(self._tmpdir) / WorkspaceManager._GREETING_SENTINEL
+        assert sentinel.exists()
+
+    def test_seed_idempotent_second_call_is_noop(self):
+        first = self.ws.seed_bootstrap_greeting("first")
+        second = self.ws.seed_bootstrap_greeting("second")
+        assert first is True
+        assert second is False
+        msgs = self.ws.load_chat_transcript()
+        assert len(msgs) == 1
+        assert msgs[0]["content"] == "first"
+
+    def test_seed_does_not_re_emit_after_chat_reset(self):
+        """Chat reset archives the transcript; sentinel survives so no re-seed."""
+        self.ws.seed_bootstrap_greeting("hello")
+        self.ws.archive_chat_transcript()
+        # Transcript file is gone but sentinel remains.
+        retried = self.ws.seed_bootstrap_greeting("hello again")
+        assert retried is False
+        msgs = self.ws.load_chat_transcript()
+        assert msgs == []
+
+    def test_seed_empty_greeting_is_noop(self):
+        ok = self.ws.seed_bootstrap_greeting("")
+        assert ok is False
+        msgs = self.ws.load_chat_transcript()
+        assert msgs == []
+        sentinel = Path(self._tmpdir) / WorkspaceManager._GREETING_SENTINEL
+        assert not sentinel.exists()
+
+    def test_seed_whitespace_only_greeting_is_noop(self):
+        ok = self.ws.seed_bootstrap_greeting("   \n\t  ")
+        assert ok is False
+
+
 class TestActivityLog:
     """Tests for activity log (JSONL) — heartbeat and autonomous work."""
 


### PR DESCRIPTION
## Summary

Three operator capability gaps closed: cron management without a new tool, persisted first-message greeting, and per-agent activity timestamps on the dashboard.

This is **PR-L'** from `docs/plans/2026-05-08-post-board-roadmap.md` (Phase 2, operator capability).

## Why

1. **Operator couldn't manage cron.** PR-F bumped the heartbeat to 15m, but tuning per-agent heartbeats required mesh-side surgery. Now it's a soft field on `edit_agent` with the existing 5-min Undo flow.
2. **Greeting wasn't persisted.** PR-F (#851) added a frontend empty-state placeholder ("Hi — I'm your Operator..."). The chat-history-seeded version was deferred — the TODO sat in `src/agent/server.py`. This PR ships the persisted version, idempotent, surviving (and explicitly NOT re-emitting on) chat reset.
3. **No per-agent activity visibility.** Dashboard agent cards showed `last_active` (health heartbeat) but not "last task event" — hard to tell if an agent is alive but stalled.

## Changes

### 1. `heartbeat_schedule` soft field on `edit_agent` (~60 LOC core)

- Added to `SOFT_EDIT_FIELDS` in `src/shared/types.py` and `_VALID_FIELDS` in `operator_tools.py`.
- Validator `_validate_heartbeat_schedule` accepts:
  - 5-field cron expressions (`*/15 * * * *`)
  - Named intervals (`every 15m`, `hourly`, `daily`)
  - Rejects: 6-field cron, garbage strings, non-strings, self-modification
- Source of truth is the cron table — no YAML write. Soft-edit endpoint resolves old value from `cron_scheduler.find_heartbeat_job` for Undo.
- Self-edit blocked (operator can't tune its own heartbeat through the same path).

### 2. Persisted bootstrap greeting (Option A: env var + agent sentinel)

- New `_OPERATOR_GREETING` constant in `src/shared/operator_playbooks.py`.
- `runtime.py` always sets `INITIAL_GREETING` env var when starting the operator container; cleared in `finally`.
- Agent's `__main__.py` reads `INITIAL_GREETING` on boot, calls new `workspace.seed_bootstrap_greeting()`.
- `seed_bootstrap_greeting` atomically writes a single `assistant`-role JSONL entry with `_origin: "bootstrap_greeting"` and creates a `.greeting_seeded` sentinel in `/data/workspace`.
- Sentinel **survives chat reset** (reset only archives the transcript) — greeting is truly one-shot per agent identity. Per Decision #3 in the roadmap.

### 3. Recent activity surface (~60 LOC)

- New `Tasks.last_event_ts_for_agent(agent_id)` on `OrchestrationStore` — joins `task_events` against `tasks` for creator/assignee/actor.
- `get_agent_profile` returns new `last_task_event_ts: float | None`.
- `/api/agents` includes it per agent.
- Dashboard renders both via new `agentActivityLabel(agent)` helper:
  > "Seen 4m ago · Task 12m ago"

### Greeting copy

```
Hi — I'm your Operator. I'm here to help you build and run AI agent teams without you having to drive every step.

Tell me what you're trying to accomplish — like:
- "I want to monitor my competitors' pricing weekly"
- "I need a content team to ship 3 blog posts a week"
- "I want to enrich my lead list with company info"

I'll suggest a team, set them up, and check on their work for you. You can always ask me what's happening, change a teammate, or pause anything that's not working.
```

## Test plan

- [x] `edit_agent(field='heartbeat_schedule', value='*/15 * * * *')` updates the cron job
- [x] `edit_agent(field='heartbeat_schedule', value='every 15m')` (named interval)
- [x] Garbage value rejected with clear error
- [x] 6-field cron rejected
- [x] Non-string value rejected
- [x] Self-modification blocked
- [x] Legacy `propose_edit` rejects this field (soft-only via new path)
- [x] Greeting seeded exactly once at agent creation
- [x] Subsequent `_ensure_operator_agent` calls do NOT re-seed
- [x] Chat reset does NOT re-emit greeting (sentinel persists)
- [x] Empty/whitespace greeting → no-op
- [x] `last_task_event_ts` populated from `task_events`
- [x] Dashboard renders both timestamps when present
- [x] Renders just last_active when last_task_event_ts is None
- [x] Undo restores prior heartbeat schedule

Full suite: **5571 passed, 44 skipped**. `ruff` clean.

## Tool count discipline

Zero new top-level `@skill` tools. `heartbeat_schedule` is a new soft field on `edit_agent` (operator stays at 30 tools).