### PR TITLE
fix: audit follow-ups for PRs #852-#857

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -242,7 +242,7 @@ Provisioner manages engine instances via Docker/systemd on Hetzner VPS:
 - **Runtime**: Python 3.10+, FastAPI, asyncio
 - **Isolation**: Docker containers per agent, bridge network (`openlegion_agents`). `Dockerfile.agent` and `Dockerfile.browser` in repo root.
 - **Browser**: Shared container running one Camoufox + Xvnc + Openbox + unclutter stack per agent (display 100..163, paired KasmVNC ports 6100..6163). Per-agent X11 WID targeting for focus.
-- **Dashboard**: Alpine.js SPA — no React, no build step
+- **Dashboard**: Alpine.js SPA — no React, no build step (Tailwind via CDN at index.html)
 - **CI**: GitHub Actions — lint (ruff) + tests (pytest) on Python 3.11 and 3.12
 - **Dependencies**: `pyproject.toml` uses minimum version bounds (`>=`), no lock file
 

--- a/src/agent/builtins/coordination_tool.py
+++ b/src/agent/builtins/coordination_tool.py
@@ -639,9 +639,20 @@ async def _update_status_v2(
             if str(r.get("status", "")) not in _TERMINAL_STATES
         ]
         if len(active) > 1:
+            # Augment the active list with title + state so the LLM can
+            # pick a ``task_id`` directly without a follow-up
+            # ``check_inbox`` call.
+            active_summaries = [
+                {
+                    "id": r.get("id"),
+                    "title": str(r.get("title", ""))[:80],
+                    "state": str(r.get("status", "")),
+                }
+                for r in active
+            ]
             return {
                 "error": "ambiguous_task",
-                "active": [r.get("id") for r in active],
+                "active": active_summaries,
                 "hint": (
                     "You have multiple active tasks. Pass task_id "
                     "explicitly to update a specific task."
@@ -662,7 +673,13 @@ async def _update_status_v2(
                 "updated": False, "state": state, "reason": "no active tasks",
             }
         else:
-            return {"error": "no_active_task"}
+            # Empty inbox — standalone agents and just-joined agents on a
+            # fresh fleet hit this constantly. Return the legacy
+            # ``{updated: False, ...}`` no-op shape so callers don't see
+            # an LLM-visible error for the common "no work yet" case.
+            return {
+                "updated": False, "state": state, "reason": "no active tasks",
+            }
     else:
         target = next(
             (r for r in rows if r.get("id") == task_id), None,

--- a/src/agent/builtins/fleet_tool.py
+++ b/src/agent/builtins/fleet_tool.py
@@ -39,7 +39,10 @@ async def list_templates(*, mesh_client=None, **_kw) -> dict:
         "to see available templates. This creates all agents defined in the template "
         "and starts them. Returns the list of created agent IDs. Pass "
         "`agent_overrides` to tune individual slots (model, instructions) at "
-        "creation time -- avoids 5+ follow-up edit_agent round-trips."
+        "creation time -- avoids 5+ follow-up edit_agent round-trips. "
+        "Note: agent creation is per-slot — a mid-loop failure leaves "
+        "earlier-created agents in place. Verify the returned `created` "
+        "list matches your intent and inspect the on-disk fleet."
     ),
     parameters={
         "template": {

--- a/src/agent/builtins/operator_tools.py
+++ b/src/agent/builtins/operator_tools.py
@@ -1250,6 +1250,26 @@ async def inspect_agents(
             registry = await mesh_client.list_agents()
         except Exception as e:
             return {"error": f"Failed to list agents: {e}"}
+
+        # Pre-filter: when ``threshold_h`` is set, fetch ``system_metrics``
+        # once and use ``stale_tasks_24h_count`` to identify which agents
+        # actually have non-zero stale work. Skip per-agent fanout for
+        # agents whose count is known-zero. If the system_metrics fetch
+        # fails for any reason, fall through to the full fanout
+        # (defensive — preserves prior behavior).
+        stale_counts: dict[str, int] = {}
+        have_counts = False
+        if threshold_h is not None:
+            try:
+                _metrics = await mesh_client.get_system_metrics()
+                stale_counts = _metrics.get("stale_tasks_24h_count", {}) or {}
+                have_counts = True
+            except Exception as e:
+                logger.debug(
+                    "inspect_agents stale prefilter failed: %s — "
+                    "falling back to full fanout", e,
+                )
+
         agents = []
         for name, info in registry.items():
             entry: dict = {"name": name}
@@ -1257,6 +1277,23 @@ async def inspect_agents(
                 entry["role"] = info.get("role", "")
                 entry["capabilities"] = info.get("capabilities", [])
             if threshold_h is not None:
+                # Operator is excluded from stale-task fanout: it's a
+                # system agent with no user-facing inbox, so its stale
+                # count is always zero. Still attach the empty fields
+                # so the response shape is consistent across agents.
+                if name == "operator":
+                    entry["stale_task_count"] = 0
+                    entry["stale_task_ids"] = []
+                    agents.append(entry)
+                    continue
+                # Skip per-agent fanout when the prefilter says this
+                # agent has zero stale tasks. Still attach the empty
+                # fields so the response shape is consistent.
+                if have_counts and int(stale_counts.get(name, 0) or 0) == 0:
+                    entry["stale_task_count"] = 0
+                    entry["stale_task_ids"] = []
+                    agents.append(entry)
+                    continue
                 # Per-agent stale lookup. Failures degrade to count=0
                 # so a single agent's mesh hiccup doesn't poison the
                 # whole roster response.

--- a/src/agent/mesh_client.py
+++ b/src/agent/mesh_client.py
@@ -12,6 +12,7 @@ from typing import TYPE_CHECKING
 
 import httpx
 
+from src.shared.trace import origin_header
 from src.shared.types import MeshEvent
 from src.shared.utils import setup_logging
 
@@ -263,8 +264,6 @@ class MeshClient:
         origin: "MessageOrigin | None" = None,
     ) -> dict:
         """Wake a target agent so it processes work immediately."""
-        from src.shared.trace import origin_header
-
         client = await self._get_client()
         headers = self._trace_headers()
         headers.update(origin_header(origin))
@@ -1098,8 +1097,6 @@ class MeshClient:
         to the originating channel/user. Without this, ``hand_off`` v2
         loses the origin a sibling ``wake_agent`` call still carries.
         """
-        from src.shared.trace import origin_header
-
         client = await self._get_client()
         body: dict = {
             "assignee": assignee,

--- a/src/cli/config.py
+++ b/src/cli/config.py
@@ -1586,7 +1586,7 @@ in the loop; 8 leaves headroom for the final assistant turn).
 4. Drill in for agents that show concerning signals. PREFER one targeted call
    per drill — don't fan out across the whole fleet:
    - If any agent appears in agents_needing_attention OR has
-     per_agent_cost_vs_yesterday_ratio > 2.0 OR
+     per_agent_cost_vs_yesterday_ratio is not None AND > 2.0 OR
      outcome_rejected_24h_count[agent] > 5 OR
      execution_failures_24h_count[agent] > 3:
      call inspect_agents(agent_id, depth="profile") for that agent.

--- a/src/host/server.py
+++ b/src/host/server.py
@@ -918,11 +918,13 @@ def create_mesh_app(
                 pass  # Not a valid IP — fall through to Bearer token check
         auth_header = request.headers.get("authorization", "")
         if not auth_header.startswith("Bearer "):
+            _record_denial("auth")
             raise HTTPException(401, "Missing authentication token")
         token = auth_header[7:]
         for expected in _auth_tokens.values():
             if hmac.compare_digest(token, expected):
                 return
+        _record_denial("auth")
         raise HTTPException(401, "Invalid authentication token")
 
     def _require_operator_or_internal(request: Request) -> None:
@@ -2614,6 +2616,11 @@ def create_mesh_app(
         """Create a team of agents from a fleet template.
 
         Body: {template: str, model?: str}
+
+        Note: agent creation is per-slot — a mid-loop failure leaves
+        earlier-created agents in place. Callers should verify the
+        returned ``created`` list matches their intent and inspect the
+        on-disk fleet.
         """
         if container_manager is None:
             raise HTTPException(503, "Container manager not available")
@@ -3365,7 +3372,7 @@ def create_mesh_app(
         # agent whose spend is bookkeeping, not user work.
         agent_ids_user = [aid for aid in agents if aid != "operator"]
         per_agent_cost_today: dict[str, float] = {}
-        per_agent_cost_ratio: dict[str, float] = {}
+        per_agent_cost_ratio: dict[str, float | None] = {}
         if cost_tracker:
             for aid in agent_ids_user:
                 today_a = cost_tracker.get_spend(aid, "today").get(
@@ -3378,8 +3385,13 @@ def create_mesh_app(
                 )
                 yest_a = max(since_yest_a - today_a, 0.0)
                 per_agent_cost_today[aid] = round(today_a, 4)
+                # ``None`` when no yesterday baseline; otherwise
+                # today/yesterday ratio rounded to 2 decimals. Returning
+                # ``None`` (rather than ``0.0``) lets the heartbeat
+                # playbook distinguish "agent stopped spending today"
+                # (ratio == 0.0) from "no yesterday baseline" (None).
                 per_agent_cost_ratio[aid] = (
-                    round(today_a / yest_a, 2) if yest_a > 0 else 0.0
+                    round(today_a / yest_a, 2) if yest_a > 0 else None
                 )
 
         # -- Per-agent task outcome / failure / stale counts (PR-J') --
@@ -3456,7 +3468,9 @@ def create_mesh_app(
             # Per-agent cost surface (PR-J'). Empty dicts when no spend
             # has been recorded — that case is meaningfully different
             # from "data unavailable", which would require the cost
-            # tracker to be ``None``.
+            # tracker to be ``None``. ``per_agent_cost_vs_yesterday_ratio``
+            # is ``None`` when no yesterday baseline; otherwise
+            # today/yesterday rounded to 2 decimals.
             "per_agent_cost_today_usd": per_agent_cost_today,
             "per_agent_cost_vs_yesterday_ratio": per_agent_cost_ratio,
             # Per-agent task outcome / failure / stale counts (PR-J').

--- a/tests/test_coordination.py
+++ b/tests/test_coordination.py
@@ -1193,26 +1193,47 @@ class TestCoordinationV2:
 
     @pytest.mark.asyncio
     async def test_update_status_v2_ambiguous_with_multiple_active(self):
-        """2+ active tasks + no task_id → ambiguous_task with active list + hint."""
+        """2+ active tasks + no task_id → ambiguous_task with active list + hint.
+
+        The active list carries ``{id, title, state}`` entries so the LLM
+        can pick a ``task_id`` directly without a follow-up
+        ``check_inbox`` call (PR-Q richer-shape augment).
+        """
         from src.agent.builtins.coordination_tool import update_status
 
         mc = _make_mesh_client(agent_id="analyst", v2_enabled=True)
         mc.list_task_inbox.return_value = [
-            {"id": "task_a", "status": "pending"},
-            {"id": "task_b", "status": "working"},
+            {"id": "task_a", "title": "Draft report", "status": "pending"},
+            {"id": "task_b", "title": "Review pricing", "status": "working"},
         ]
 
         result = await update_status("working", mesh_client=mc)
 
         assert result.get("error") == "ambiguous_task"
-        assert set(result["active"]) == {"task_a", "task_b"}
+        active = result["active"]
+        # Augmented shape: list of {id, title, state} dicts (not bare ids).
+        assert isinstance(active, list)
+        assert {a["id"] for a in active} == {"task_a", "task_b"}
+        for a in active:
+            assert "id" in a and "title" in a and "state" in a
+        by_id = {a["id"]: a for a in active}
+        assert by_id["task_a"]["title"] == "Draft report"
+        assert by_id["task_a"]["state"] == "pending"
+        assert by_id["task_b"]["title"] == "Review pricing"
+        assert by_id["task_b"]["state"] == "working"
         assert "task_id" in result["hint"]
         # Critical: no silent set_task_status call against the wrong task.
         mc.set_task_status.assert_not_called()
 
     @pytest.mark.asyncio
-    async def test_update_status_v2_no_active_returns_no_active_task(self):
-        """Empty inbox → ``no_active_task`` error rather than a silent no-op."""
+    async def test_update_status_v2_empty_inbox_returns_legacy_noop(self):
+        """Empty inbox → legacy ``{updated: False, ...}`` no-op shape.
+
+        Standalone agents and just-joined agents on a fresh fleet hit
+        the empty-inbox case constantly. PR-Q removed the regressed
+        ``{"error": "no_active_task"}`` shape so the LLM doesn't see an
+        error for the common "no work yet" case.
+        """
         from src.agent.builtins.coordination_tool import update_status
 
         mc = _make_mesh_client(agent_id="analyst", v2_enabled=True)
@@ -1220,11 +1241,11 @@ class TestCoordinationV2:
 
         result = await update_status("working", mesh_client=mc)
 
-        # Existing legacy contract: ``updated=False`` when there are no
-        # rows at all. The new ``error=no_active_task`` path is reserved
-        # for the inbox-empty case AFTER filtering away terminal rows.
-        # Either is acceptable — assert the call did NOT mutate state.
-        assert result.get("updated") is False or result.get("error") == "no_active_task"
+        # Legacy success-shape no-op — no error key, updated=False.
+        assert "error" not in result
+        assert result.get("updated") is False
+        assert result.get("state") == "working"
+        assert "no active tasks" in result.get("reason", "")
         mc.set_task_status.assert_not_called()
 
     @pytest.mark.asyncio

--- a/tests/test_denial_counter.py
+++ b/tests/test_denial_counter.py
@@ -234,6 +234,76 @@ class TestDenialCounterAuthAndRole:
             cost_tracker.close()
             bb.close()
 
+    def test_require_any_auth_missing_bearer_increments_auth(
+        self, tmp_path,
+    ):
+        """PR-Q: ``_require_any_auth`` missing-bearer 401 must bump ``auth``."""
+        from src.host import server as host_server
+
+        bb = Blackboard(db_path=str(tmp_path / "bb.db"))
+        pubsub = PubSub()
+        perms = _make_perms_with_blackboard("alpha")
+        router = MessageRouter(permissions=perms, agent_registry={})
+        router.register_agent("alpha", "http://localhost:8401")
+
+        cost_tracker = CostTracker(db_path=str(tmp_path / "costs.db"))
+        lane_manager = MagicMock()
+        lane_manager.get_status.return_value = {}
+
+        app = create_mesh_app(
+            bb, pubsub, router, perms,
+            cost_tracker=cost_tracker,
+            lane_manager=lane_manager,
+            auth_tokens={"alpha": "tok_alpha", "operator": "tok_op"},
+        )
+        client = TestClient(app)
+
+        try:
+            # ``/mesh/traces`` is gated by ``_require_any_auth`` (not
+            # ``_extract_verified_agent_id``). Hit it with no Authorization
+            # header — expect 401 + counter bump.
+            resp = client.get("/mesh/traces")
+            assert resp.status_code == 401
+            assert host_server._denial_counter["auth"] == 1
+        finally:
+            cost_tracker.close()
+            bb.close()
+
+    def test_require_any_auth_invalid_bearer_increments_auth(
+        self, tmp_path,
+    ):
+        """PR-Q: ``_require_any_auth`` invalid-bearer 401 must bump ``auth``."""
+        from src.host import server as host_server
+
+        bb = Blackboard(db_path=str(tmp_path / "bb.db"))
+        pubsub = PubSub()
+        perms = _make_perms_with_blackboard("alpha")
+        router = MessageRouter(permissions=perms, agent_registry={})
+        router.register_agent("alpha", "http://localhost:8401")
+
+        cost_tracker = CostTracker(db_path=str(tmp_path / "costs.db"))
+        lane_manager = MagicMock()
+        lane_manager.get_status.return_value = {}
+
+        app = create_mesh_app(
+            bb, pubsub, router, perms,
+            cost_tracker=cost_tracker,
+            lane_manager=lane_manager,
+            auth_tokens={"alpha": "tok_alpha", "operator": "tok_op"},
+        )
+        client = TestClient(app)
+
+        try:
+            resp = client.get(
+                "/mesh/traces",
+                headers={"Authorization": "Bearer wrong-token"},
+            )
+            assert resp.status_code == 401
+            assert host_server._denial_counter["auth"] == 1
+        finally:
+            cost_tracker.close()
+            bb.close()
+
     def test_non_operator_token_on_operator_endpoint_increments_role(
         self, tmp_path,
     ):

--- a/tests/test_operator_metrics.py
+++ b/tests/test_operator_metrics.py
@@ -203,8 +203,11 @@ class TestSystemMetricsPRJ:
         # alpha got tracked spend; beta did not.
         assert data["per_agent_cost_today_usd"]["alpha"] > 0
         assert data["per_agent_cost_today_usd"]["beta"] == 0
-        # Yesterday baseline is 0 → ratio is 0.0 (not divide-by-zero).
-        assert data["per_agent_cost_vs_yesterday_ratio"]["alpha"] == 0.0
+        # PR-Q: when no yesterday baseline exists the ratio is ``None``
+        # (not ``0.0``) so the heartbeat playbook can distinguish "agent
+        # stopped spending today" (ratio == 0.0) from "no baseline".
+        assert data["per_agent_cost_vs_yesterday_ratio"]["alpha"] is None
+        assert data["per_agent_cost_vs_yesterday_ratio"]["beta"] is None
 
     def test_per_agent_cost_excludes_operator(self, metrics_app):
         # Register operator on the router so it shows up in agents.

--- a/tests/test_operator_tools.py
+++ b/tests/test_operator_tools.py
@@ -587,6 +587,11 @@ async def test_inspect_agents_with_threshold_annotates_roster():
         }
 
     mc.get_agent_stale_tasks = AsyncMock(side_effect=_fake_stale)
+    # PR-Q prefilter: report non-zero counts for both agents so the
+    # fanout still happens for each (preserves the original assertion).
+    mc.get_system_metrics = AsyncMock(return_value={
+        "stale_tasks_24h_count": {"writer": 2, "scout": 1},
+    })
 
     result = await inspect_agents(stale_threshold_hours=24, mesh_client=mc)
     assert result["stale_threshold_hours"] == 24
@@ -635,12 +640,130 @@ async def test_inspect_agents_stale_lookup_failure_degrades_to_zero():
         "writer": {"role": "writer", "capabilities": []},
     })
     mc.get_agent_stale_tasks = AsyncMock(side_effect=RuntimeError("boom"))
+    # PR-Q prefilter: report a non-zero count so the fanout still
+    # happens (and we exercise the per-agent failure-handling path).
+    mc.get_system_metrics = AsyncMock(return_value={
+        "stale_tasks_24h_count": {"writer": 5},
+    })
 
     result = await inspect_agents(stale_threshold_hours=24, mesh_client=mc)
     assert result["stale_threshold_hours"] == 24
     entry = result["agents"][0]
     assert entry["stale_task_count"] == 0
     assert entry["stale_task_ids"] == []
+
+
+# PR-Q — stale-task fanout prefilter + operator exclusion
+
+
+@pytest.mark.asyncio
+async def test_inspect_agents_prefilter_skips_zero_count_agents():
+    """3-agent fleet with counts {a:1, b:0, c:2} → only 2 fanout calls."""
+    from src.agent.builtins.operator_tools import inspect_agents
+
+    mc = MagicMock()
+    mc.list_agents = AsyncMock(return_value={
+        "a": {"role": "writer", "capabilities": []},
+        "b": {"role": "writer", "capabilities": []},
+        "c": {"role": "writer", "capabilities": []},
+    })
+
+    async def _fake_stale(agent_id, threshold_hours=24):
+        return {
+            "agent_id": agent_id,
+            "threshold_hours": threshold_hours,
+            "count": 1 if agent_id == "a" else 2,
+            "task_ids": [f"{agent_id}_task"],
+        }
+
+    mc.get_agent_stale_tasks = AsyncMock(side_effect=_fake_stale)
+    mc.get_system_metrics = AsyncMock(return_value={
+        "stale_tasks_24h_count": {"a": 1, "b": 0, "c": 2},
+    })
+
+    result = await inspect_agents(stale_threshold_hours=24, mesh_client=mc)
+    by_name = {a["name"]: a for a in result["agents"]}
+    # b had count 0 → prefilter skipped the fanout, attached zero values.
+    assert by_name["b"]["stale_task_count"] == 0
+    assert by_name["b"]["stale_task_ids"] == []
+    # a and c got real fanout calls.
+    assert by_name["a"]["stale_task_count"] == 1
+    assert by_name["c"]["stale_task_count"] == 2
+    # Exactly two fanout calls — b was skipped.
+    assert mc.get_agent_stale_tasks.await_count == 2
+    awaited_targets = {
+        call.args[0] for call in mc.get_agent_stale_tasks.await_args_list
+    }
+    assert awaited_targets == {"a", "c"}
+
+
+@pytest.mark.asyncio
+async def test_inspect_agents_skips_operator_in_stale_fanout():
+    """Operator must never be the target of a stale-task fanout call."""
+    from src.agent.builtins.operator_tools import inspect_agents
+
+    mc = MagicMock()
+    mc.list_agents = AsyncMock(return_value={
+        "operator": {"role": "operator", "capabilities": []},
+        "writer": {"role": "writer", "capabilities": []},
+    })
+
+    async def _fake_stale(agent_id, threshold_hours=24):
+        return {
+            "agent_id": agent_id,
+            "threshold_hours": threshold_hours,
+            "count": 1,
+            "task_ids": ["t1"],
+        }
+
+    mc.get_agent_stale_tasks = AsyncMock(side_effect=_fake_stale)
+    # Operator sits in the metrics dict with non-zero — verify exclusion
+    # is by name rather than just by count.
+    mc.get_system_metrics = AsyncMock(return_value={
+        "stale_tasks_24h_count": {"operator": 99, "writer": 1},
+    })
+
+    result = await inspect_agents(stale_threshold_hours=24, mesh_client=mc)
+    by_name = {a["name"]: a for a in result["agents"]}
+    # Operator still surfaces in the roster but with empty fields.
+    assert by_name["operator"]["stale_task_count"] == 0
+    assert by_name["operator"]["stale_task_ids"] == []
+    # writer fanout happened.
+    assert by_name["writer"]["stale_task_count"] == 1
+    # Exactly one fanout call — operator was excluded.
+    assert mc.get_agent_stale_tasks.await_count == 1
+    awaited_targets = {
+        call.args[0] for call in mc.get_agent_stale_tasks.await_args_list
+    }
+    assert awaited_targets == {"writer"}
+
+
+@pytest.mark.asyncio
+async def test_inspect_agents_metrics_failure_falls_back_to_full_fanout():
+    """If get_system_metrics fails, fall through to full fanout (defensive)."""
+    from src.agent.builtins.operator_tools import inspect_agents
+
+    mc = MagicMock()
+    mc.list_agents = AsyncMock(return_value={
+        "writer": {"role": "writer", "capabilities": []},
+        "scout":  {"role": "researcher", "capabilities": []},
+    })
+
+    async def _fake_stale(agent_id, threshold_hours=24):
+        return {
+            "agent_id": agent_id,
+            "threshold_hours": threshold_hours,
+            "count": 0,
+            "task_ids": [],
+        }
+
+    mc.get_agent_stale_tasks = AsyncMock(side_effect=_fake_stale)
+    mc.get_system_metrics = AsyncMock(side_effect=RuntimeError("mesh down"))
+
+    result = await inspect_agents(stale_threshold_hours=24, mesh_client=mc)
+    assert result["count"] == 2
+    # Both agents got fanned out because we couldn't pre-filter.
+    assert mc.get_agent_stale_tasks.await_count == 2
 
 
 # ── create_agent tests ──────────────────────────��───────────


### PR DESCRIPTION
## Summary

Principal-engineer audit of the six PRs that landed today (#852–#857) surfaced 8 issues across Critical / High / Medium tiers. This PR fixes them in one focused pass — strictly correctness, no scope creep.

## Critical

### PR-K': `update_status` empty-inbox error-shape regression
PR-K' (#854) regressed the empty-inbox path from `{"updated": False, ..., "reason": "no active tasks"}` to `{"error": "no_active_task"}`. Standalone agents and just-joined agents on a fresh fleet hit this constantly and now see an LLM-visible error.

`coordination_tool.py:683-689` — empty-inbox case now returns the legacy success-shape no-op, matching the `all-terminal-rows` branch the same PR already correctly preserved.

## High

### PR-J': `per_agent_cost_vs_yesterday_ratio` ambiguity → `None`
`server.py:3382` returned `0.0` for both "agent stopped spending" AND "no yesterday baseline" — semantically distinct, indistinguishable.

Now returns `None` when no baseline. Type annotation widened to `dict[str, float | None]`. Heartbeat playbook updated to filter `None` before threshold comparison.

### PR-J': stale-task fanout filter + operator exclusion
`operator_tools.py:1248-1305` — `inspect_agents(stale_threshold_hours=N)` previously fanned out to **every** agent in the registry (including operator) regardless of whether their `stale_tasks_24h_count` was zero.

Now pre-fetches `system_metrics`, uses the counts dict to skip known-zero agents, and excludes the operator from the fanout entirely. Defensive fall-through to full fanout if `system_metrics` fetch fails.

### PR-K': `_require_any_auth` denial-counter gap
`server.py:921, 927` — the "any authenticated agent" tier (used by 20+ endpoints) raises 401 on missing/invalid bearer but didn't call `_record_denial("auth")`. The denial counter advertised "all auth denials" but undercounted heavily — the highest-traffic auth tier was completely missing.

Both 401 raises now record the auth denial.

### PR-N: atomicity caveat in skill description
`fleet_tool.py:43` skill description and `server.py:2620-2624` route docstring now document that mid-loop creation failure leaves earlier-created agents in place. The LLM should verify the returned `created` list and inspect the on-disk fleet.

### PR-K': inline-import hoist
`mesh_client.py:15` — `from src.shared.trace import origin_header` hoisted to module level. The duplicate inline import in `wake_agent` was removed alongside the `create_task` hoist for consistency. No behavior change.

## Medium

### PR-K': ambiguous-task richer payload
`coordination_tool.py:641-657` — the `ambiguous_task` error response now returns `active: [{id, title, state}, ...]` instead of bare ID list. The LLM can pick the right `task_id` directly without a follow-up `check_inbox` call.

### CLAUDE.md Tailwind correction
Stale claim "Alpine.js SPA — no React, no build step" implied no Tailwind. Updated to acknowledge Tailwind is loaded via CDN at index.html:14.

## Explicitly deferred (with re-entry triggers)

- **Template INSTRUCTIONS.md guidance for ambiguous_task** — separate PR (touches 13 fleet templates).
- **PR-O'.1 cross-project semantic redefinition (disjoint vs strict)** — defer to PR-O'.2 design doc.
- **PR-J' heartbeat budget cap on N drill-ins** — current N=4 fits the 10-iteration budget for typical fleets.
- **PR-N override surface expansion (soul / heartbeat / interface)** — separate PR-N v2 once usage data confirms demand.
- **PR-J' rejection-lag undercount** — needs an `outcome_set_at` schema column.
- **PR-L' validator alignment with legacy `heartbeat`** — legacy path is rare; defer to template-cleanup pass.
- **PR-M concurrency limiter** — 5-row mount isn't a real perf issue today.
- **PR-#852 commit-message attribution** — release-note cosmetic only; code is correct on main.

## Test plan

- [x] PR-K empty-inbox returns legacy `{updated: False, ...}` shape — `test_update_status_v2_empty_inbox_returns_legacy_noop`
- [x] PR-J ratio is `None` when no baseline — `test_per_agent_cost_populated_from_costs_store`
- [x] Fanout pre-filter skips zero-count agents — `test_inspect_agents_prefilter_skips_zero_count_agents`
- [x] Operator excluded from stale fanout — `test_inspect_agents_skips_operator_in_stale_fanout`
- [x] `system_metrics` failure → full-fanout fall-through — `test_inspect_agents_metrics_failure_falls_back_to_full_fanout`
- [x] `_require_any_auth` 401 increments `auth` denial — 2 tests
- [x] `ambiguous_task` returns richer payload — `test_update_status_v2_ambiguous_with_multiple_active`

**204 targeted tests pass.** Full suite: **5586 passed, 44 skipped**, zero regressions. `ruff` clean.

## Stats

11 files changed, +310 / -25.