### PR TITLE
feat(operator,fleet): extend agent_overrides to soul/heartbeat/interface (PR-N v2)

### DIFF
--- a/src/agent/builtins/fleet_tool.py
+++ b/src/agent/builtins/fleet_tool.py
@@ -38,11 +38,12 @@ async def list_templates(*, mesh_client=None, **_kw) -> dict:
         "Create a team of agents from a fleet template. Use list_templates first "
         "to see available templates. This creates all agents defined in the template "
         "and starts them. Returns the list of created agent IDs. Pass "
-        "`agent_overrides` to tune individual slots (model, instructions) at "
-        "creation time -- avoids 5+ follow-up edit_agent round-trips. "
-        "Note: agent creation is per-slot — a mid-loop failure leaves "
-        "earlier-created agents in place. Verify the returned `created` "
-        "list matches your intent and inspect the on-disk fleet."
+        "`agent_overrides` to tune individual slots (model, instructions, soul, "
+        "heartbeat, interface) at creation time -- avoids 5+ follow-up edit_agent "
+        "round-trips. Note: `role` is fixed by the template and cannot be overridden. "
+        "Note: agent creation is per-slot -- a mid-loop failure leaves earlier-created "
+        "agents in place. Verify the returned `created` list matches your intent and "
+        "inspect the on-disk fleet."
     ),
     parameters={
         "template": {
@@ -58,14 +59,21 @@ async def list_templates(*, mesh_client=None, **_kw) -> dict:
             "type": "object",
             "description": (
                 "Optional per-agent overrides keyed by agent name from the template. "
-                "Each value is an object with optional 'model' and/or 'instructions' "
-                "fields. Unknown agent names or fields are rejected with HTTP 400."
+                "Each value is an object with any of: 'model', 'instructions' "
+                "(<=12000 chars), 'soul' (<=4000 chars), 'heartbeat' (no cap), "
+                "'interface' (<=4000 chars). Unknown agent names or fields are "
+                "rejected with HTTP 400; oversized fields with HTTP 413. "
+                "Note: `role` is intentionally NOT overrideable; templates fix the "
+                "role per slot. Use a separate fleet template if you need different roles."
             ),
             "additionalProperties": {
                 "type": "object",
                 "properties": {
                     "model": {"type": "string"},
                     "instructions": {"type": "string"},
+                    "soul": {"type": "string"},
+                    "heartbeat": {"type": "string"},
+                    "interface": {"type": "string"},
                 },
                 "additionalProperties": False,
             },

--- a/src/agent/mesh_client.py
+++ b/src/agent/mesh_client.py
@@ -706,9 +706,13 @@ class MeshClient:
         """Apply a fleet template to create a team of agents.
 
         ``agent_overrides`` is an optional mapping of ``agent_name`` →
-        ``{"model": str, "instructions": str}``. Validated upfront on
-        the mesh side; unknown names / fields / models / oversized
-        instructions return HTTP 400 (or 413) with the offender named.
+        per-slot dict with any of: ``model``, ``instructions``, ``soul``,
+        ``heartbeat``, ``interface`` (PR-N v2). Validated upfront on the
+        mesh side; unknown names / fields / models return HTTP 400, oversized
+        string fields return HTTP 413, with the offender named.
+
+        Per-slot creation is non-atomic: a mid-loop failure leaves
+        earlier-created agents in place; check the returned ``created`` list.
         """
         client = await self._get_client()
         body: dict = {"template": template}

--- a/src/cli/config.py
+++ b/src/cli/config.py
@@ -1164,9 +1164,10 @@ def _apply_template(
     """Apply a team template, creating all agents. Returns list of agent names.
 
     ``agent_overrides`` (PR-N) is an optional ``{agent_name: {field: value}}``
-    map. v1 supports per-agent ``model`` and ``instructions`` overrides applied
-    on top of the template's defaults. The mesh route validates the shape and
-    contents UPFRONT — by the time we get here, the input is trusted.
+    map. v2 supports per-agent ``model``, ``instructions``, ``soul``,
+    ``heartbeat`` and ``interface`` overrides applied on top of the template's
+    defaults. The mesh route validates the shape and contents UPFRONT — by the
+    time we get here, the input is trusted.
     """
     cfg = _load_config()
     default_model = cfg.get("llm", {}).get("default_model", "openai/gpt-4o-mini")
@@ -1194,8 +1195,14 @@ def _apply_template(
         if "instructions" in per_agent_override:
             instructions = per_agent_override["instructions"]
         soul = agent_def.get("soul", "")
+        if "soul" in per_agent_override:
+            soul = per_agent_override["soul"]
         heartbeat = agent_def.get("heartbeat", "")
+        if "heartbeat" in per_agent_override:
+            heartbeat = per_agent_override["heartbeat"]
         interface = agent_def.get("initial_interface", "") or agent_def.get("interface", "")
+        if "interface" in per_agent_override:
+            interface = per_agent_override["interface"]
         thinking = agent_def.get("thinking", "")
         budget = agent_def.get("budget")
         agent_permissions = agent_def.get("permissions")

--- a/src/host/server.py
+++ b/src/host/server.py
@@ -2671,15 +2671,27 @@ def create_mesh_app(
         # Optional model override
         model_override = data.get("model", "")
 
-        # Optional per-agent overrides (PR-N): { agent_name: {"model": ..., "instructions": ...} }
+        # Optional per-agent overrides (PR-N v2): allowed fields are
+        # {model, instructions, soul, heartbeat, interface}. `role` is
+        # intentionally NOT overrideable here — templates define role per slot
+        # and changing it post-creation is a different operation (rename).
         # Validated UPFRONT — no agent is created if any override is invalid.
         agent_overrides = data.get("agent_overrides") or {}
         if agent_overrides:
             if not isinstance(agent_overrides, dict):
                 raise HTTPException(400, "agent_overrides must be an object")
-            _ALLOWED_OVERRIDE_FIELDS = {"model", "instructions"}
-            # 12000 mirrors src/agent/server.py _FILE_CAPS["INSTRUCTIONS.md"].
-            _INSTRUCTIONS_CAP = 12000
+            _ALLOWED_OVERRIDE_FIELDS = {
+                "model", "instructions", "soul", "heartbeat", "interface",
+            }
+            # Per-field length caps mirror src/agent/server.py _FILE_CAPS:
+            #   INSTRUCTIONS.md: 12000, SOUL.md: 4000, INTERFACE.md: 4000,
+            #   HEARTBEAT.md: None (uncapped).
+            _STRING_FIELD_CAPS: dict[str, int | None] = {
+                "instructions": 12000,
+                "soul": 4000,
+                "heartbeat": None,
+                "interface": 4000,
+            }
 
             # 1. Unknown agent names
             unknown_agents = [
@@ -2726,19 +2738,21 @@ def create_mesh_app(
                             f"agent_overrides['{agent_name}'].model "
                             f"'{mv}' is not a known model",
                         )
-                if "instructions" in override:
-                    iv = override["instructions"]
-                    if not isinstance(iv, str):
+                for _field, _cap in _STRING_FIELD_CAPS.items():
+                    if _field not in override:
+                        continue
+                    val = override[_field]
+                    if not isinstance(val, str):
                         raise HTTPException(
                             400,
-                            f"agent_overrides['{agent_name}'].instructions "
+                            f"agent_overrides['{agent_name}'].{_field} "
                             "must be a string",
                         )
-                    if len(iv) > _INSTRUCTIONS_CAP:
+                    if _cap is not None and len(val) > _cap:
                         raise HTTPException(
                             413,
-                            f"agent_overrides['{agent_name}'].instructions "
-                            f"exceeds cap ({len(iv)} > {_INSTRUCTIONS_CAP} chars)",
+                            f"agent_overrides['{agent_name}'].{_field} "
+                            f"exceeds cap ({len(val)} > {_cap} chars)",
                         )
 
         # Apply template to create config entries

--- a/tests/test_operator_fleet.py
+++ b/tests/test_operator_fleet.py
@@ -601,6 +601,120 @@ class TestMeshFleetApplyEndpoint:
         assert "12000" in detail
         cm.start_agent.assert_not_called()
 
+    # ── PR-N v2: soul/heartbeat/interface validation ─────────
+
+    @patch.dict("os.environ", {"OPENLEGION_MAX_AGENTS": "10"})
+    def test_apply_oversized_soul_returns_413(self):
+        """Soul > 4000 chars → 413, names offending agent, no creation."""
+        from fastapi.testclient import TestClient
+
+        app, cm, _ = self._make_app(existing_agents={"operator": "http://localhost:8400"})
+        client = TestClient(app)
+        oversized = "s" * 4001
+        resp = client.post(
+            "/mesh/fleet/apply",
+            json={
+                "template": "starter",
+                "agent_overrides": {"assistant": {"soul": oversized}},
+            },
+        )
+        assert resp.status_code == 413
+        detail = resp.json()["detail"]
+        assert "assistant" in detail
+        assert "soul" in detail
+        assert "4000" in detail
+        cm.start_agent.assert_not_called()
+
+    @patch.dict("os.environ", {"OPENLEGION_MAX_AGENTS": "10"})
+    def test_apply_oversized_interface_returns_413(self):
+        """Interface > 4000 chars → 413, names offending agent."""
+        from fastapi.testclient import TestClient
+
+        app, cm, _ = self._make_app(existing_agents={"operator": "http://localhost:8400"})
+        client = TestClient(app)
+        oversized = "i" * 4001
+        resp = client.post(
+            "/mesh/fleet/apply",
+            json={
+                "template": "starter",
+                "agent_overrides": {"assistant": {"interface": oversized}},
+            },
+        )
+        assert resp.status_code == 413
+        detail = resp.json()["detail"]
+        assert "assistant" in detail
+        assert "interface" in detail
+        assert "4000" in detail
+        cm.start_agent.assert_not_called()
+
+    @patch.dict("os.environ", {"OPENLEGION_MAX_AGENTS": "10"})
+    def test_apply_role_override_field_rejected(self):
+        """`role` is intentionally NOT in the allowed fields → 400."""
+        from fastapi.testclient import TestClient
+
+        app, cm, _ = self._make_app(existing_agents={"operator": "http://localhost:8400"})
+        client = TestClient(app)
+        resp = client.post(
+            "/mesh/fleet/apply",
+            json={
+                "template": "starter",
+                "agent_overrides": {"assistant": {"role": "renamed-role"}},
+            },
+        )
+        assert resp.status_code == 400
+        detail = resp.json()["detail"]
+        assert "role" in detail
+        # Allowed list should be present in the error
+        assert "soul" in detail or "instructions" in detail
+        cm.start_agent.assert_not_called()
+
+    @patch.dict("os.environ", {"OPENLEGION_MAX_AGENTS": "10"})
+    def test_apply_non_string_soul_returns_400(self):
+        """soul must be a string."""
+        from fastapi.testclient import TestClient
+
+        app, cm, _ = self._make_app(existing_agents={"operator": "http://localhost:8400"})
+        client = TestClient(app)
+        resp = client.post(
+            "/mesh/fleet/apply",
+            json={
+                "template": "starter",
+                "agent_overrides": {"assistant": {"soul": 123}},
+            },
+        )
+        assert resp.status_code == 400
+        detail = resp.json()["detail"]
+        assert "soul" in detail
+        assert "string" in detail
+        cm.start_agent.assert_not_called()
+
+    @patch.dict("os.environ", {"OPENLEGION_MAX_AGENTS": "10"})
+    def test_apply_large_heartbeat_accepted(self):
+        """heartbeat has no length cap — validation lets large strings through."""
+        from fastapi.testclient import TestClient
+
+        app, _, _ = self._make_app(existing_agents={"operator": "http://localhost:8400"})
+        client = TestClient(app)
+        # 8000 chars -- well above SOUL/INTERFACE 4000 cap. Reflects
+        # HEARTBEAT.md _FILE_CAPS = None (uncapped).
+        big_heartbeat = "h" * 8000
+        # Patch _apply_template so we don't pollute real config/agents.yaml;
+        # we only care that validation passes.
+        with patch(
+            "src.cli.config._apply_template", return_value=["assistant"],
+        ) as mock_apply:
+            resp = client.post(
+                "/mesh/fleet/apply",
+                json={
+                    "template": "starter",
+                    "agent_overrides": {"assistant": {"heartbeat": big_heartbeat}},
+                },
+            )
+        assert resp.status_code == 200, resp.text
+        # Confirm the override was forwarded intact
+        _, kwargs = mock_apply.call_args
+        assert kwargs["agent_overrides"]["assistant"]["heartbeat"] == big_heartbeat
+
     @patch.dict("os.environ", {"OPENLEGION_MAX_AGENTS": "10"})
     def test_apply_empty_overrides_is_noop(self):
         """Empty agent_overrides={} behaves identically to no overrides."""

--- a/tests/test_templates.py
+++ b/tests/test_templates.py
@@ -662,6 +662,115 @@ class TestApplyTemplateAgentOverrides(_TempConfigMixin):
         assert cfg["agents"]["writer"]["model"] == "openai/gpt-4o-mini"
         assert "ghost" not in cfg["agents"]
 
+    # ── PR-N v2: soul / heartbeat / interface overrides ────────
+
+    def _multi_template_with_souls(self) -> dict:
+        """Like ``_multi_template`` but with default soul/heartbeat/interface
+        on each agent so we can verify per-slot overrides win over defaults."""
+        return {
+            "agents": {
+                "writer": {
+                    "role": "writer",
+                    "model": "{default_model}",
+                    "instructions": "Default writer instructions.",
+                    "soul": "Default writer soul.",
+                    "heartbeat": "Default writer heartbeat.",
+                    "initial_interface": "Default writer interface.",
+                },
+                "editor": {
+                    "role": "editor",
+                    "model": "{default_model}",
+                    "instructions": "Default editor instructions.",
+                    "soul": "Default editor soul.",
+                    "heartbeat": "Default editor heartbeat.",
+                    "initial_interface": "Default editor interface.",
+                },
+            },
+        }
+
+    def test_soul_override_persists_to_disk(self):
+        """Override ``soul`` for one agent — others stay on template default."""
+        tpl = self._multi_template_with_souls()
+        with self._mock_config():
+            _apply_template(
+                "multi", tpl,
+                agent_overrides={"writer": {"soul": "Custom writer soul."}},
+            )
+        with open(self._agents_path) as f:
+            cfg = yaml.safe_load(f)
+        assert cfg["agents"]["writer"]["initial_soul"] == "Custom writer soul."
+        # Editor untouched
+        assert cfg["agents"]["editor"]["initial_soul"] == "Default editor soul."
+        # Other fields untouched on writer
+        assert (
+            cfg["agents"]["writer"]["initial_instructions"]
+            == "Default writer instructions."
+        )
+
+    def test_heartbeat_override_persists_to_disk(self):
+        """Override ``heartbeat`` for one agent."""
+        tpl = self._multi_template_with_souls()
+        with self._mock_config():
+            _apply_template(
+                "multi", tpl,
+                agent_overrides={"writer": {"heartbeat": "Beat every hour."}},
+            )
+        with open(self._agents_path) as f:
+            cfg = yaml.safe_load(f)
+        assert cfg["agents"]["writer"]["initial_heartbeat"] == "Beat every hour."
+        assert (
+            cfg["agents"]["editor"]["initial_heartbeat"]
+            == "Default editor heartbeat."
+        )
+
+    def test_interface_override_persists_to_disk(self):
+        """Override ``interface`` for one agent."""
+        tpl = self._multi_template_with_souls()
+        with self._mock_config():
+            _apply_template(
+                "multi", tpl,
+                agent_overrides={"writer": {"interface": "Accepts X, produces Y."}},
+            )
+        with open(self._agents_path) as f:
+            cfg = yaml.safe_load(f)
+        assert (
+            cfg["agents"]["writer"]["initial_interface"]
+            == "Accepts X, produces Y."
+        )
+        assert (
+            cfg["agents"]["editor"]["initial_interface"]
+            == "Default editor interface."
+        )
+
+    def test_all_four_fields_combined_for_one_agent(self):
+        """Model + instructions + soul + interface all together for one slot."""
+        tpl = self._multi_template_with_souls()
+        overrides = {
+            "writer": {
+                "model": "anthropic/claude-sonnet-4-6",
+                "instructions": "Custom writer voice.",
+                "soul": "Custom writer soul.",
+                "interface": "Accepts briefs, produces drafts.",
+            },
+        }
+        with self._mock_config():
+            _apply_template("multi", tpl, agent_overrides=overrides)
+        with open(self._agents_path) as f:
+            cfg = yaml.safe_load(f)
+        writer = cfg["agents"]["writer"]
+        assert writer["model"] == "anthropic/claude-sonnet-4-6"
+        assert writer["initial_instructions"] == "Custom writer voice."
+        assert writer["initial_soul"] == "Custom writer soul."
+        assert writer["initial_interface"] == "Accepts briefs, produces drafts."
+        # Heartbeat NOT overridden — stays on template default
+        assert (
+            writer["initial_heartbeat"] == "Default writer heartbeat."
+        )
+        # Editor entirely on template defaults
+        editor = cfg["agents"]["editor"]
+        assert editor["model"] == "openai/gpt-4o-mini"
+        assert editor["initial_soul"] == "Default editor soul."
+
 
 class TestLoadTemplates:
     def test_all_templates_parse(self):


### PR DESCRIPTION
## Summary

PR-N (#852) shipped per-agent template overrides for `model` and `instructions`. The audit flagged `soul`, `heartbeat`, `interface` as commonly tuned per-slot — each is already a `SOFT_EDIT_FIELD` and forces post-apply round-trips today. PR-S extends `agent_overrides` to accept all five.

`role` is intentionally **NOT** added — it's part of agent identity, fixed by the template, not a tunable.

This is **PR-S** from the post-audit backlog.

## Why

A typical fleet-tuning session for Sarah looked like:
1. `apply_template content` → 5 agents created
2. `edit_agent writer instructions=...` → round-trip 1
3. `edit_agent writer soul=...` → round-trip 2
4. `edit_agent researcher soul=...` → round-trip 3
5. `edit_agent strategist heartbeat=...` → round-trip 4

PR-N collapsed (2)–(3) for two fields. PR-S collapses all five. One `apply_template` call.

## Contract change

```python
@skill apply_template(
    template: str,
    model: str = "",                                      # fleet-wide
    agent_overrides: dict[str, dict] | None = None,       # per-slot, v2 fields
)
```

`agent_overrides` value shape (each field optional):
- `model`: existing `_resolve_litellm_key` validation
- `instructions`: ≤ 12000 chars
- `soul`: ≤ 4000 chars (matches `_FILE_CAPS["SOUL.md"]`)
- `heartbeat`: no cap (matches `_FILE_CAPS["HEARTBEAT.md"] = None`)
- `interface`: ≤ 4000 chars (matches `_FILE_CAPS["INTERFACE.md"]`)

Unknown agent names / unknown fields / oversized fields rejected upfront with HTTP 400 / 413 — atomicity guarantee from PR-N preserved.

## Implementation note

Validation in `host/server.py` was refactored from a single `if "instructions" in override` block to a `_STRING_FIELD_CAPS` dict + loop. Adding more capped soft-fields in the future is now a one-line dict edit. `heartbeat`'s `None` cap is honored explicitly.

## Test plan

- [x] Override `soul` → on-disk soul matches override
- [x] Override `heartbeat` → on-disk heartbeat matches override (large 8000-char value accepted)
- [x] Override `interface` → on-disk interface matches override
- [x] All four fields combined for one agent
- [x] Oversized soul (>4000) → HTTP 413 with offending agent
- [x] Oversized interface (>4000) → HTTP 413
- [x] `role` override rejected as unknown field → HTTP 400
- [x] Non-string soul value → HTTP 400
- [x] Existing PR-N callers (model+instructions only) unchanged

118 tests pass in `test_operator_fleet.py` + `test_templates.py`. `ruff` clean.

## Tool count discipline

Zero new top-level `@skill` tools. Just an extended parameter shape on `apply_template`. Operator stays at 30 tools.

## Stats

6 files changed, +272 / -21.