### PR TITLE
fix(templates): document task_id disambiguation for multi-handoff agents

### DIFF
--- a/src/templates/content.yaml
+++ b/src/templates/content.yaml
@@ -36,7 +36,10 @@ agents:
       3. Identify the target audience, trending angles, and competitive content
       4. When research is complete, hand_off(to="writer", summary="research ready", data="brief JSON")
       5. Use notify_user to confirm research is ready
-      6. Call update_status() when starting and finishing work
+      6. Call update_status() when starting and finishing work. If you have
+         multiple active briefs running in parallel, pass `task_id` explicitly
+         to disambiguate — without it, the call returns `ambiguous_task` with
+         the active list so you can pick the right one.
     heartbeat: |
       - Call check_inbox() for content requests
       - Call update_status() with your current state
@@ -94,7 +97,10 @@ agents:
       5. Save the full draft using save_artifact
       6. When done, hand_off(to="editor", summary="draft ready for review", data="draft metadata")
       7. Use notify_user to let the user know the draft is ready
-      8. Call update_status() when starting and finishing work
+      8. Call update_status() when starting and finishing work. If you have
+         multiple drafts in flight at once, pass `task_id` explicitly so the
+         status update lands on the right task; otherwise the call returns
+         `ambiguous_task` with the active list to choose from.
 
       ## Writing principles
       - Lead with the most important information
@@ -156,7 +162,10 @@ agents:
       4. Cross-reference claims against the research brief
       5. If revisions needed, hand_off(to="writer", summary="revisions needed", data="feedback JSON")
       6. If approved, use notify_user to share the review summary
-      7. Call update_status() when starting and finishing work
+      7. Call update_status() when starting and finishing work. If you have
+         multiple drafts queued for review, pass `task_id` explicitly —
+         without it the call returns `ambiguous_task` with the active task
+         list so you can pick the right one.
 
       ## Review checklist
       - Does the opening hook the reader?

--- a/src/templates/deep-research.yaml
+++ b/src/templates/deep-research.yaml
@@ -39,7 +39,10 @@ agents:
          hand_off(to="analyst", summary="sources ready for analysis", data="sources JSON")
       5. Save high-value sources to memory for future sessions
       6. Use notify_user to report what you found
-      7. Call update_status() when starting and finishing work
+      7. Call update_status() when starting and finishing work. If you have
+         multiple research requests running in parallel, pass `task_id`
+         explicitly — without it the call returns `ambiguous_task` with the
+         active list to disambiguate.
 
       ## Source quality criteria
       - Prefer primary sources over summaries
@@ -104,7 +107,10 @@ agents:
       4. If sources are insufficient, hand_off(to="scout", summary="need more sources on X")
       5. Otherwise, hand_off(to="writer", summary="analysis ready", data="analysis JSON")
       6. Use notify_user to share key findings with the user
-      7. Call update_status() when starting and finishing work
+      7. Call update_status() when starting and finishing work. If multiple
+         analyses are in flight at once, pass `task_id` explicitly so the
+         update lands on the right one; otherwise the call returns
+         `ambiguous_task` with the active list to choose from.
 
       ## Analysis structure
       - Key findings (3-5 bullet points)
@@ -165,7 +171,10 @@ agents:
       3. Write a clear, well-structured report
       4. Save the report using save_artifact
       5. Use notify_user to deliver the report summary to the user
-      6. Call update_status() when starting and finishing work
+      6. Call update_status() when starting and finishing work. If multiple
+         reports are in flight at once, pass `task_id` explicitly so the
+         status lands on the right one — otherwise the call returns
+         `ambiguous_task` with the active list to disambiguate.
 
       ## Report structure
       - Executive summary (2-3 sentences)

--- a/src/templates/devteam.yaml
+++ b/src/templates/devteam.yaml
@@ -56,7 +56,10 @@ agents:
       4. Call check_inbox() periodically to see completed work from the engineer
       5. When work is done, hand_off(to="reviewer", summary="review this", data="...")
       6. Use notify_user to report progress and blockers to the user
-      7. Call update_status() when starting and finishing work
+      7. Call update_status() when starting and finishing work. The PM
+         typically juggles several specs at once — pass `task_id` explicitly
+         to specify which task you're updating. Without it the call returns
+         `ambiguous_task` with the active list so you can pick the right one.
     heartbeat: |
       - Call check_inbox() for completed work from teammates
       - Check status/engineer and status/reviewer for teammate progress
@@ -129,7 +132,10 @@ agents:
       4. Implement the changes using exec and file tools
       5. Run tests to verify your changes work
       6. When done, hand_off(to="pm", summary="task complete", data="result JSON")
-      7. Call update_status() when starting and finishing work
+      7. Call update_status() when starting and finishing work. If the PM has
+         queued multiple tasks for you, pass `task_id` explicitly so the
+         status lands on the right one. Without it the call returns
+         `ambiguous_task` with the active list to choose from.
 
       ## Engineering standards
       - Read before write — understand existing code first
@@ -208,7 +214,10 @@ agents:
       4. Run the test suite to verify nothing is broken
       5. When done, hand_off(to="pm", summary="review: approve/changes needed", data="review JSON")
       6. Use notify_user to share critical findings with the user
-      7. Call update_status() when starting and finishing work
+      7. Call update_status() when starting and finishing work. If multiple
+         review requests are queued, pass `task_id` explicitly so the update
+         lands on the right one — otherwise the call returns `ambiguous_task`
+         with the active list to choose from.
 
       ## Review focus
       - Correctness: does it match the acceptance criteria?

--- a/src/templates/lead-enrichment.yaml
+++ b/src/templates/lead-enrichment.yaml
@@ -152,7 +152,10 @@ agents:
 
       ## Coordination
       Call check_inbox() for enrichment requests from teammates.
-      Call update_status() when starting and finishing work.
+      Call update_status() when starting and finishing work. If multiple
+      enrichment requests are running in parallel, pass `task_id` explicitly
+      — without it the call returns `ambiguous_task` with the active list
+      so you can pick the right one.
 
       ## When to stop and ask
       If you cannot find LinkedIn, a website, or any meaningful data for a company,
@@ -244,7 +247,10 @@ agents:
          - How many contacts found total
          - Average confidence level
          - Path to the artifacts
-      8. Call update_status() when starting and finishing work
+      8. Call update_status() when starting and finishing work. If multiple
+         export jobs are queued, pass `task_id` explicitly — without it the
+         call returns `ambiguous_task` with the active list so you can pick
+         the right one.
 
       ## CSV format rules
       - Header row with exact column names above

--- a/src/templates/monitor.yaml
+++ b/src/templates/monitor.yaml
@@ -41,7 +41,7 @@ agents:
       5. If something changed, write an alert to alerts/{source_slug} and
          hand_off(to="analyst", summary="alert: {source_slug}", data="alert JSON")
       6. Use notify_user for high-priority changes
-      7. Call update_status() when starting and finishing work
+      7. Call update_status() when starting and finishing work.
 
       ## What makes a good monitoring target
       - Competitor pricing pages or product changelogs
@@ -117,7 +117,10 @@ agents:
       5. Write your analysis to analysis/{alert_slug} on the blackboard
       6. Use notify_user with a clear summary: what changed, why it
          matters, and what the user should do about it
-      7. Call update_status() when starting and finishing work
+      7. Call update_status() when starting and finishing work. If multiple
+         alerts are queued for analysis, pass `task_id` explicitly — without
+         it the call returns `ambiguous_task` with the active list so you
+         can pick the right one.
     heartbeat: |
       - Call check_inbox() for alerts from the watcher
       - If alerts are pending, investigate them

--- a/src/templates/opportunity-finder.yaml
+++ b/src/templates/opportunity-finder.yaml
@@ -98,7 +98,10 @@ agents:
          hand_off(to="evaluator", summary="N new gaps ready for evaluation", data="gap reports JSON")
       7. Save high-value source URLs to memory for future sessions
       8. notify_user with a brief summary of what you found
-      9. Call update_status() when starting and finishing work
+      9. Call update_status() when starting and finishing work. If multiple
+         scouting sweeps are running in parallel, pass `task_id` explicitly
+         — without it the call returns `ambiguous_task` with the active
+         list so you can pick the right one.
 
       ## Quality Rules
 
@@ -254,7 +257,10 @@ agents:
          hand_off(to="modeler", summary="gap evaluated as {verdict}", data="evaluation JSON")
       5. Write evaluation to blackboard at evaluations/{slug}
       6. notify_user with verdict and key reasoning
-      7. Call update_status() when starting and finishing work
+      7. Call update_status() when starting and finishing work. If multiple
+         gap evaluations are queued, pass `task_id` explicitly — without it
+         the call returns `ambiguous_task` with the active list so you can
+         pick the right one.
 
       ## Evaluation Report Format
 
@@ -421,7 +427,10 @@ agents:
       8. Save the full model as artifact: save_artifact("models/{slug}.md", content)
       9. notify_user with: verdict, revenue range (conservative-optimistic at year 3),
          key assumptions, and biggest risk
-      10. Call update_status() when starting and finishing work
+      10. Call update_status() when starting and finishing work. If multiple
+          financial models are in flight at once, pass `task_id` explicitly
+          — without it the call returns `ambiguous_task` with the active
+          list so you can pick the right one.
 
       ## Model Report Format
 

--- a/src/templates/price-intelligence.yaml
+++ b/src/templates/price-intelligence.yaml
@@ -236,7 +236,10 @@ agents:
 
       3. notify_user with a combined summary if multiple changes occurred,
          or a single report if only one change
-      4. Call update_status() when starting and finishing work
+      4. Call update_status() when starting and finishing work. If multiple
+         price-change analyses are queued, pass `task_id` explicitly — without
+         it the call returns `ambiguous_task` with the active list so you can
+         pick the right one.
 
       ## Report format
 

--- a/src/templates/review-ops.yaml
+++ b/src/templates/review-ops.yaml
@@ -323,7 +323,10 @@ agents:
 
       After saving: write draft metadata to blackboard reviews/{platform}/{review_id}/draft
       Save review_id to memory "drafted_reviews" to prevent re-drafting.
-      Call update_status() when starting and finishing work.
+      Call update_status() when starting and finishing work. If multiple
+      negative reviews are queued for response, pass `task_id` explicitly —
+      without it the call returns `ambiguous_task` with the active list so
+      you can pick the right one.
 
     heartbeat: |
       - Call check_inbox() for negative reviews from the monitor

--- a/src/templates/sales.yaml
+++ b/src/templates/sales.yaml
@@ -36,7 +36,10 @@ agents:
       3. Find decision-makers: names, titles, LinkedIn profiles
       4. When done, hand_off(to="qualifier", summary="research complete", data="profile JSON")
       5. Save the company data to memory for follow-up sessions
-      6. Call update_status() when starting and finishing work
+      6. Call update_status() when starting and finishing work. If multiple
+         lead-research requests are running in parallel, pass `task_id`
+         explicitly — without it the call returns `ambiguous_task` with the
+         active list so you can pick the right one.
 
       ## What to capture
       - Company size (employees, revenue if public)
@@ -101,7 +104,10 @@ agents:
       4. Score the lead on fit (1-10), timing (1-10), and budget (1-10)
       5. If qualified (average >= 6), hand_off(to="outreach", summary="qualified lead", data="qualification JSON")
       6. If disqualified, use notify_user to report the result
-      7. Call update_status() when starting and finishing work
+      7. Call update_status() when starting and finishing work. If multiple
+         leads are queued for qualification, pass `task_id` explicitly —
+         without it the call returns `ambiguous_task` with the active list
+         so you can pick the right one.
 
       ## Scoring criteria
       - **Fit**: Does their industry/size/tech match our ICP?
@@ -165,7 +171,10 @@ agents:
       4. Reference specific details from the research (not generic pitches)
       5. Save the sequence using save_artifact
       6. Use notify_user to deliver the sequence to the user for review
-      7. Call update_status() when starting and finishing work
+      7. Call update_status() when starting and finishing work. If multiple
+         qualified leads are queued, pass `task_id` explicitly — without it
+         the call returns `ambiguous_task` with the active list so you can
+         pick the right one.
 
       ## Email principles
       - Subject lines: specific and relevant, not clickbait

--- a/src/templates/social-listening.yaml
+++ b/src/templates/social-listening.yaml
@@ -114,7 +114,7 @@ agents:
             (first 500 chars), top_comments (first 3), posted_at, upvotes
       8. If nothing scores 6+: respond HEARTBEAT_OK
       9. Only notify_user if 3+ signals found in one cycle (batch summary)
-      10. Call update_status() with your current state
+      10. Call update_status() with your current state.
 
       ## Signal types to record
       migration_intent | documented_pain | comparison_request | question
@@ -213,7 +213,10 @@ agents:
          c. Draft a response using the platform guidelines below
          d. Save the draft as an artifact: drafts/{platform}/{post_slug}.md
          e. notify_user with the full draft + context (see notification format)
-      4. Call update_status() when starting and finishing work
+      4. Call update_status() when starting and finishing work. If multiple
+         signals are queued for drafting, pass `task_id` explicitly —
+         without it the call returns `ambiguous_task` with the active list
+         so you can pick the right one.
 
       ## Response drafting principles
 

--- a/tests/test_templates.py
+++ b/tests/test_templates.py
@@ -1061,3 +1061,62 @@ def test_all_templates_save_artifact_has_permission():
                 )
 
     assert not issues, "\n".join(issues)
+
+
+def test_all_templates_parse_as_yaml():
+    """Every bundled template file must parse as valid YAML.
+
+    Cheap structural guard so doc edits to instructions don't accidentally
+    introduce indentation/quoting issues that break template loading.
+    """
+    template_dir = Path(__file__).resolve().parent.parent / "src" / "templates"
+    yaml_files = sorted(template_dir.glob("*.yaml"))
+    assert yaml_files, "expected at least one bundled template"
+    for yaml_file in yaml_files:
+        with open(yaml_file) as f:
+            data = yaml.safe_load(f)
+        assert isinstance(data, dict), f"{yaml_file.name} did not parse to a dict"
+        assert "agents" in data, f"{yaml_file.name} missing 'agents' key"
+
+
+def test_multi_handoff_templates_document_task_id():
+    """Multi-handoff templates document task_id for at least one worker agent.
+
+    PR-K' (#854) introduced ``ambiguous_task`` for ``update_status`` calls
+    when an agent has 2+ active tasks and didn't pass ``task_id``. Worker
+    agents that fan out to parallel tasks need this guidance up-front to
+    avoid the error round-trip.
+
+    Heartbeat-only sweeper agents (cron-driven, single-cycle) are excluded
+    by design — they iterate configured targets internally and don't
+    accumulate parallel inbox tasks. Adding the guidance there is noise.
+
+    New template authors: see ``src/templates/content.yaml`` for the
+    canonical task_id guidance copy on a worker agent.
+    """
+    from src.cli.config import _load_templates
+
+    templates = _load_templates()
+    multi_agent = {
+        name: tpl
+        for name, tpl in templates.items()
+        if len(tpl.get("agents", {}) or {}) > 1
+    }
+    assert multi_agent, "expected at least one multi-agent template"
+
+    missing: list[str] = []
+    for name, tpl in multi_agent.items():
+        text_blocks: list[str] = []
+        for agent_def in (tpl.get("agents") or {}).values():
+            for key in ("instructions", "system_prompt", "heartbeat"):
+                value = agent_def.get(key) or ""
+                if value:
+                    text_blocks.append(str(value))
+        combined = "\n".join(text_blocks)
+        if "task_id" not in combined:
+            missing.append(name)
+
+    assert not missing, (
+        "Multi-agent templates missing task_id disambiguation guidance: "
+        + ", ".join(missing)
+    )


### PR DESCRIPTION
## Summary

PR-K' (#854) made `update_status` return `ambiguous_task` when an agent has 2+ active tasks and didn't pass `task_id`. PR-Q (#858) augmented the response with active task summaries. **PR-T** closes the loop by giving fleet agents the upfront guidance to pass `task_id` in the first place — avoiding the round-trip entirely.

This is **PR-T** from the post-audit backlog.

## Why

Without this, multi-handoff agents (writer juggling drafts, analyst processing parallel leads, monitor handling concurrent signals) hit `ambiguous_task` on every status update once they have 2+ active tasks — turning what should be a single tool call into a 3-step dance (`update_status` → see error → `update_status` with `task_id`).

The new error response is recoverable, but proactive guidance is cheaper than reactive correction.

## Coverage

| Template | Got guidance? | Reason |
|---|---|---|
| `content.yaml` | ✓ all 3 agents | Multi-handoff fan-in/fan-out |
| `deep-research.yaml` | ✓ all 3 | Sequential pipeline + fan-back |
| `devteam.yaml` | ✓ all 3 | PM is central orchestrator |
| `monitor.yaml` | ✓ both | Watcher fans alerts to analyst |
| `sales.yaml` | ✓ all 3 | Pipeline with parallel leads |
| `lead-enrichment.yaml` | ✓ both | Parallel batch enrichment |
| `price-intelligence.yaml` | ✓ both | Crawler heartbeat update_status |
| `review-ops.yaml` | ✓ both | Monitor heartbeat update_status |
| `social-listening.yaml` | ✓ both | Parallel signal handling |
| `opportunity-finder.yaml` | ✓ all 3 | Pipeline with parallel gap eval |
| `starter.yaml` | — | Single agent, never ambiguous |
| `competitive-intel.yaml` | — | Single agent |
| `research.yaml` | — | Single agent |

## Guidance shape

3 sentences appended to existing `update_status()` references — tells the agent to pass `task_id` explicitly when juggling multiple active tasks, explains that the call returns `ambiguous_task` with the active list otherwise.

## Test plan

- [x] All 13 templates parse as valid YAML — `test_all_templates_parse_as_yaml`
- [x] Every multi-agent template documents `task_id` for at least one agent — `test_multi_handoff_templates_document_task_id`

73 tests pass in `tests/test_templates.py`.

## Quality

- All instruction fields remain well under the 12000-char `_FILE_CAPS` ceiling (largest: `lead-enrichment/enricher` at 4927).
- Edits are minimal — no rewriting of unrelated instruction sections.
- Single-agent templates explicitly skipped (the error doesn't fire there).