### PR TITLE
fix(operator,agent): cap heartbeat drill-ins + raise iteration headroom

### DIFF
--- a/src/agent/loop.py
+++ b/src/agent/loop.py
@@ -43,7 +43,7 @@ _FLEET_ROSTER_TTL = 600  # seconds — cache TTL for fleet roster
 _GOALS_TTL = 300  # seconds — cache TTL for goals fetch
 _FALLBACK_MAX_TOKENS = 100_000  # context trim fallback when no context manager
 _TOOL_HISTORY_LIMIT = 10  # recent tool outcomes in system prompt
-HEARTBEAT_MAX_ITERATIONS = 10  # tighter bound for heartbeat (cheaper than task/chat)
+HEARTBEAT_MAX_ITERATIONS = 12  # tighter bound for heartbeat (cheaper than task/chat)
 
 # Markdown heading pattern for detecting effectively-empty heartbeat files
 _HEADING_OR_EMPTY_RE = re.compile(r"^(#+\s.*|\s*)$")

--- a/src/cli/config.py
+++ b/src/cli/config.py
@@ -1567,8 +1567,8 @@ _OPERATOR_HEARTBEAT = """\
 You are running an autonomous fleet health check. You have access ONLY to monitoring tools.
 Your previous observations are included above in OBSERVATIONS.md.
 
-Step budget: stay at or under 8 tool calls per cycle (HEARTBEAT_MAX_ITERATIONS=10
-in the loop; 8 leaves headroom for the final assistant turn).
+Step budget: stay at or under 10 tool calls per cycle (HEARTBEAT_MAX_ITERATIONS=12
+in the loop; 10 leaves headroom for the final assistant turn).
 
 1. Review your previous observations (above) to check what you flagged last cycle.
    Do not re-alert on known issues unless they have escalated in severity.
@@ -1583,13 +1583,17 @@ in the loop; 8 leaves headroom for the final assistant turn).
 
 3. Call inspect_agents() for the roster summary.
 
-4. Drill in for agents that show concerning signals. PREFER one targeted call
+4. Drill into at most THREE most-concerning agents. PREFER one targeted call
    per drill — don't fan out across the whole fleet:
-   - If any agent appears in agents_needing_attention OR has
+   - Candidates are agents that appear in agents_needing_attention OR have
      per_agent_cost_vs_yesterday_ratio is not None AND > 2.0 OR
      outcome_rejected_24h_count[agent] > 5 OR
-     execution_failures_24h_count[agent] > 3:
-     call inspect_agents(agent_id, depth="profile") for that agent.
+     execution_failures_24h_count[agent] > 3.
+   - If more than 3 agents trigger any of the above thresholds, focus on
+     the top-3 worst (highest cost outlier, highest rejected count, longest
+     stale duration) and note in OBSERVATIONS.md that additional agents
+     need follow-up next cycle.
+   - For each selected agent, call inspect_agents(agent_id, depth="profile").
    - If stale_tasks_24h_count has any non-zero entry, call
      inspect_agents(stale_threshold_hours=24) ONCE to pull the offending
      task IDs (the result annotates every roster entry — don't loop).

--- a/tests/test_loop.py
+++ b/tests/test_loop.py
@@ -1768,6 +1768,17 @@ async def test_trim_context_handles_multimodal_tool_content():
 # ── Heartbeat mode ─────────────────────────────────────────────
 
 
+def test_heartbeat_max_iterations_constant():
+    """PR-V — bumped from 10 to 12 for defensive headroom.
+
+    Worst-case operator heartbeat (cap-3 drill-ins): 1 status + 1 roster +
+    3 drill-ins + 1 stale fanout + 1 save_observations + 1 notify_user =
+    8 tool calls plus the final assistant turn — well inside the 12-iter
+    ceiling, with budget for future playbook additions.
+    """
+    assert HEARTBEAT_MAX_ITERATIONS == 12
+
+
 @pytest.mark.asyncio
 async def test_heartbeat_simple_completion():
     """Heartbeat returns structured result when LLM gives final answer."""
@@ -1973,14 +1984,19 @@ async def test_heartbeat_windup_nudge_messages():
     """Nudge messages are injected at _remaining==2 and _remaining==1."""
     tool_defs = [{"type": "function", "function": {"name": "search"}}]
     captured_messages: list[list[dict]] = []
+    # Vary arguments per call so the tool-loop detector's terminate
+    # threshold (9 identical params) doesn't trip before the iteration
+    # cap — the cap is what this test exercises.
+    call_idx = {"n": 0}
 
     async def _capture_llm(*, system, messages, tools=None, **kw):
         # Snapshot the message list the LLM receives on each call
         captured_messages.append([m.copy() for m in messages])
         if tools:
+            call_idx["n"] += 1
             return LLMResponse(
                 content="",
-                tool_calls=[ToolCallInfo(name="search", arguments={"q": "x"})],
+                tool_calls=[ToolCallInfo(name="search", arguments={"q": f"x{call_idx['n']}"})],
                 tokens_used=10,
             )
         return LLMResponse(content="Done.", tool_calls=[], tokens_used=10)
@@ -2011,12 +2027,16 @@ async def test_heartbeat_forced_wrapup_on_unexpected_tool_calls():
     """If the LLM returns tool_calls on the last iteration (tools withheld),
     they are ignored and the text content is used as the final answer."""
     tool_defs = [{"type": "function", "function": {"name": "search"}}]
+    # Vary arguments per call so the tool-loop detector's terminate
+    # threshold doesn't trip before the iteration cap.
+    call_idx = {"n": 0}
 
     async def _stubborn_llm(*, system, messages, tools=None, **kw):
         # Always returns tool_calls, even when tools=None
+        call_idx["n"] += 1
         return LLMResponse(
             content="Almost done",
-            tool_calls=[ToolCallInfo(name="search", arguments={"q": "x"})],
+            tool_calls=[ToolCallInfo(name="search", arguments={"q": f"x{call_idx['n']}"})],
             tokens_used=10,
         )
 
@@ -2039,11 +2059,15 @@ async def test_heartbeat_forced_wrapup_empty_content():
     """When forced wrap-up discards tool_calls and content is empty,
     a fallback message is used."""
     tool_defs = [{"type": "function", "function": {"name": "search"}}]
+    # Vary arguments per call so the tool-loop detector's terminate
+    # threshold doesn't trip before the iteration cap.
+    call_idx = {"n": 0}
 
     async def _empty_llm(*, system, messages, tools=None, **kw):
+        call_idx["n"] += 1
         return LLMResponse(
             content="",
-            tool_calls=[ToolCallInfo(name="search", arguments={"q": "x"})],
+            tool_calls=[ToolCallInfo(name="search", arguments={"q": f"x{call_idx['n']}"})],
             tokens_used=10,
         )
 

--- a/tests/test_operator_config.py
+++ b/tests/test_operator_config.py
@@ -330,21 +330,50 @@ class TestOperatorConstants:
         assert "stale_threshold_hours=24" in _OPERATOR_HEARTBEAT
 
     def test_heartbeat_step_count_within_budget(self):
-        """Total numbered steps stay within the HEARTBEAT_MAX_ITERATIONS=10 budget.
+        """Total numbered steps stay within the HEARTBEAT_MAX_ITERATIONS=12 budget.
 
         Counting numbered top-level steps (``1.`` through ``N.``) — each
-        step that calls a tool burns one iteration. 8 leaves headroom
-        for the final assistant turn that emits the heartbeat summary.
+        step that calls a tool burns one iteration. PR-V capped per-cycle
+        drill-ins at 3, and bumped the loop ceiling from 10 to 12 to give
+        headroom. The worst-case fan-out is now:
+        1 status + 1 roster + 3 drill-ins + 1 stale fanout + 1 save_observations
+        + 1 notify_user = 8 tool calls, plus the final assistant turn that
+        emits the heartbeat summary.
         """
         import re
 
         from src.cli.config import _OPERATOR_HEARTBEAT
         steps = re.findall(r"^\s*(\d+)\.\s", _OPERATOR_HEARTBEAT, re.MULTILINE)
         max_step = max(int(s) for s in steps)
-        assert max_step <= 9, (
-            f"heartbeat has {max_step} numbered steps; budget is 9 "
-            f"(HEARTBEAT_MAX_ITERATIONS=10 minus the final assistant turn)"
+        assert max_step <= 11, (
+            f"heartbeat has {max_step} numbered steps; budget is 11 "
+            f"(HEARTBEAT_MAX_ITERATIONS=12 minus the final assistant turn)"
         )
+
+    def test_heartbeat_caps_drill_ins_at_three(self):
+        """PR-V — drill-ins capped at 3 per cycle to stay under the budget.
+
+        Without a cap, N concerning agents → N drill calls + 4 fixed steps,
+        which blows past HEARTBEAT_MAX_ITERATIONS at N>=6. The playbook now
+        instructs the operator to focus on the top-3 worst offenders and
+        defer the rest to the next cycle via OBSERVATIONS.md.
+        """
+        from src.cli.config import _OPERATOR_HEARTBEAT
+        # Cap-3 wording must be unambiguous.
+        assert "at most THREE" in _OPERATOR_HEARTBEAT or "at most 3" in _OPERATOR_HEARTBEAT
+        # Overflow guidance must reference AGENTS, not THRESHOLDS, so the LLM
+        # cannot misread the subject of the count (audit follow-up).
+        assert "more than 3 agents trigger" in _OPERATOR_HEARTBEAT
+        assert "top-3 worst" in _OPERATOR_HEARTBEAT
+        # Overflow agents must be queued for the next cycle in OBSERVATIONS.md.
+        assert "OBSERVATIONS.md" in _OPERATOR_HEARTBEAT
+        assert "next cycle" in _OPERATOR_HEARTBEAT
+
+    def test_heartbeat_budget_header_matches_loop_constant(self):
+        """PR-V — the playbook's stated budget tracks HEARTBEAT_MAX_ITERATIONS."""
+        from src.agent.loop import HEARTBEAT_MAX_ITERATIONS
+        from src.cli.config import _OPERATOR_HEARTBEAT
+        assert f"HEARTBEAT_MAX_ITERATIONS={HEARTBEAT_MAX_ITERATIONS}" in _OPERATOR_HEARTBEAT
 
     def test_core_has_key_sections(self):
         from src.shared.operator_playbooks import _OPERATOR_CORE


### PR DESCRIPTION
## Summary

PR-J's operator heartbeat playbook does worst-case `5 + N` tool calls where `N` = concerning agents. With N=4 → 9 calls (tight against `HEARTBEAT_MAX_ITERATIONS=10`). With N=5+ → blows the budget.

Two-pronged fix: cap drill-ins at 3 per cycle + raise the iteration ceiling from 10 to 12 as defensive headroom.

This is **PR-V** from the post-audit backlog.

## Why

The audit flagged the budget as tight under realistic dense-problem-fleet scenarios — exactly when alerting matters most. A heartbeat that runs out of iterations gives the operator partial coverage and silently drops the rest. Capping drill-ins lets the operator focus on the worst offenders and record overflow for the next cycle.

## Changes

- `src/agent/loop.py`: `HEARTBEAT_MAX_ITERATIONS` 10 → 12 (no env override exists; pure constant)
- `src/cli/config.py`: playbook step 4 rewritten to require "at most THREE" drill-ins, with overflow guidance routing to OBSERVATIONS.md so the next 15-min cycle picks up where this one left off

## Budget math after this PR

`1 (status) + 1 (roster) + ≤3 (drill) + ≤1 (stale fanout) + 1 (save_observations) + 1 (notify_user) = ≤8 calls` against new ceiling 12 → **4-call defensive margin**.

## Test plan

- [x] `HEARTBEAT_MAX_ITERATIONS == 12` constant pinned
- [x] Playbook contains the cap-3 instruction
- [x] Step-count budget assertion updated to ≤11 (was ≤9)
- [x] Three heartbeat exhaustion tests in `test_loop.py` updated to vary tool-call args (the `ToolLoopDetector` 9-identical-params terminate threshold was firing before the new 12-iter cap, masking the cap reach)

260 tests pass across loop / chat / operator_config / operator_playbooks / projects. `ruff` clean.

## Stats

4 files changed, +68 / -16.