### PR TITLE
fix(orchestration): track outcome_set_at separately from completed_at

### DIFF
--- a/src/host/orchestration.py
+++ b/src/host/orchestration.py
@@ -259,22 +259,33 @@ class Tasks:
     def _ensure_outcome_set_at_column(conn: sqlite3.Connection) -> None:
         """PR-U: add outcome_set_at column if missing. Idempotent.
 
-        SQLite ALTER TABLE ADD COLUMN does not support IF NOT EXISTS, so
-        we probe column existence via PRAGMA before issuing the DDL.
-        Backfill: existing rows where ``outcome IS NOT NULL`` get
-        ``outcome_set_at = completed_at`` so the heartbeat query keeps
-        seeing them at their original timestamp. Rows with both
-        ``outcome`` and ``completed_at`` NULL are left alone (anomalous;
-        better to not invent data).
+        Both the ALTER and the backfill UPDATE are safe to run repeatedly:
+        the ALTER is gated by PRAGMA inspection (with a duplicate-column
+        catch for concurrent-init races, mirroring the pattern in
+        ``mesh.py``); the UPDATE is WHERE-guarded so already-stamped rows
+        are no-ops. This shape recovers from a mid-init crash where the
+        ALTER committed but the backfill did not — re-init still walks
+        the backfill UPDATE instead of short-circuiting on the column
+        being present. Rows with both ``outcome`` and ``completed_at``
+        NULL are left alone (anomalous; better to not invent data).
         """
         cols = {
             row[1]
             for row in conn.execute("PRAGMA table_info(tasks)").fetchall()
         }
-        if "outcome_set_at" in cols:
-            return
-        conn.execute("ALTER TABLE tasks ADD COLUMN outcome_set_at REAL")
-        # Best-effort backfill — existing rated rows inherit completed_at.
+        if "outcome_set_at" not in cols:
+            try:
+                conn.execute(
+                    "ALTER TABLE tasks ADD COLUMN outcome_set_at REAL"
+                )
+            except sqlite3.OperationalError as e:
+                if "duplicate column" not in str(e).lower():
+                    raise
+                # Another process won the race; column exists — proceed
+                # to backfill.
+        # Always run backfill — WHERE clause makes it idempotent on
+        # already-stamped rows. Recovers from prior partial migrations
+        # (ALTER committed, UPDATE didn't) on a subsequent re-init.
         conn.execute(
             "UPDATE tasks SET outcome_set_at = completed_at "
             "WHERE outcome IS NOT NULL AND outcome_set_at IS NULL "
@@ -907,11 +918,12 @@ class Tasks:
                         f"(status={current_status!r})"
                     )
                 # PR-U — stamp outcome_set_at on first rating only.
-                # Re-rating (write-many) preserves the original timestamp
-                # via COALESCE so the audit trail's "when did the operator
-                # first see this?" answer is stable. The audit event row
-                # below still records every submission with its own
-                # created_at, so re-rating history isn't lost.
+                # COALESCE preserves the FIRST set_outcome call's timestamp
+                # so downstream consumers (heartbeat, audit) see a stable
+                # "first rated at" answer regardless of subsequent
+                # re-rates. The audit event row below captures every
+                # submission with its own created_at, so re-rating
+                # history isn't lost.
                 conn.execute(
                     "UPDATE tasks SET outcome=?, feedback_text=?, "
                     "outcome_set_at=COALESCE(outcome_set_at, ?), "

--- a/src/host/orchestration.py
+++ b/src/host/orchestration.py
@@ -239,6 +239,47 @@ class Tasks:
                 "CREATE INDEX IF NOT EXISTS idx_tasks_previous_task "
                 "ON tasks (previous_task_id)"
             )
+            # PR-U — outcome_set_at column. Tracks when set_outcome was
+            # called, separately from completed_at, so the heartbeat
+            # query (count_outcomes_since) doesn't undercount lagged
+            # operator reviews. See _ensure_outcome_set_at_column for
+            # migration / backfill semantics.
+            self._ensure_outcome_set_at_column(conn)
+            # Partial index on (outcome, outcome_set_at). Most rows have
+            # outcome IS NULL (work isn't rated yet), so the partial
+            # predicate keeps the index small and fast for the
+            # heartbeat's per-outcome scan.
+            conn.execute(
+                "CREATE INDEX IF NOT EXISTS idx_tasks_outcome_set_at "
+                "ON tasks (outcome, outcome_set_at) "
+                "WHERE outcome IS NOT NULL"
+            )
+
+    @staticmethod
+    def _ensure_outcome_set_at_column(conn: sqlite3.Connection) -> None:
+        """PR-U: add outcome_set_at column if missing. Idempotent.
+
+        SQLite ALTER TABLE ADD COLUMN does not support IF NOT EXISTS, so
+        we probe column existence via PRAGMA before issuing the DDL.
+        Backfill: existing rows where ``outcome IS NOT NULL`` get
+        ``outcome_set_at = completed_at`` so the heartbeat query keeps
+        seeing them at their original timestamp. Rows with both
+        ``outcome`` and ``completed_at`` NULL are left alone (anomalous;
+        better to not invent data).
+        """
+        cols = {
+            row[1]
+            for row in conn.execute("PRAGMA table_info(tasks)").fetchall()
+        }
+        if "outcome_set_at" in cols:
+            return
+        conn.execute("ALTER TABLE tasks ADD COLUMN outcome_set_at REAL")
+        # Best-effort backfill — existing rated rows inherit completed_at.
+        conn.execute(
+            "UPDATE tasks SET outcome_set_at = completed_at "
+            "WHERE outcome IS NOT NULL AND outcome_set_at IS NULL "
+            "AND completed_at IS NOT NULL"
+        )
 
     # ── Helpers ─────────────────────────────────────────────────
 
@@ -274,6 +315,7 @@ class Tasks:
             "outcome": row[19],
             "feedback_text": row[20],
             "previous_task_id": row[21],
+            "outcome_set_at": row[22],
         }
 
     _SELECT_COLS = (
@@ -281,7 +323,7 @@ class Tasks:
         "assignee, status, priority, dependencies_json, artifact_refs_json, "
         "blocker_note, origin_kind, origin_channel, origin_user, "
         "created_at, updated_at, completed_at, retention_until, "
-        "outcome, feedback_text, previous_task_id"
+        "outcome, feedback_text, previous_task_id, outcome_set_at"
     )
 
     def _emit_event(
@@ -481,17 +523,19 @@ class Tasks:
     ) -> dict[str, int]:
         """Count tasks per assignee whose latest ``outcome`` was set within ``since_seconds``.
 
-        Mirrors ``SELECT assignee, COUNT(*) FROM tasks WHERE outcome=?
-        AND completed_at >= ? GROUP BY assignee``. Operator is included;
-        callers drop it. Tasks with NULL ``completed_at`` (still running)
-        are excluded by the >= filter.
+        PR-U: filters on ``outcome_set_at`` (when the operator clicked
+        the rating button) rather than ``completed_at`` (when the agent
+        finished). The two diverge whenever review is delayed — a task
+        completed Monday and rated rejected on Wednesday must show up
+        in the Wednesday heartbeat, not Monday's. Tasks rated before
+        the cutoff (or never rated) are excluded by the >= filter.
         """
         cutoff = time.time() - since_seconds
         with self._conn() as conn:
             rows = conn.execute(
                 "SELECT assignee, COUNT(*) FROM tasks "
-                "WHERE outcome = ? AND completed_at IS NOT NULL "
-                "AND completed_at >= ? GROUP BY assignee",
+                "WHERE outcome = ? AND outcome_set_at IS NOT NULL "
+                "AND outcome_set_at >= ? GROUP BY assignee",
                 (outcome, cutoff),
             ).fetchall()
         return {row[0]: int(row[1] or 0) for row in rows if row[0]}
@@ -862,10 +906,17 @@ class Tasks:
                         f"cannot set outcome on non-terminal task {task_id} "
                         f"(status={current_status!r})"
                     )
+                # PR-U — stamp outcome_set_at on first rating only.
+                # Re-rating (write-many) preserves the original timestamp
+                # via COALESCE so the audit trail's "when did the operator
+                # first see this?" answer is stable. The audit event row
+                # below still records every submission with its own
+                # created_at, so re-rating history isn't lost.
                 conn.execute(
                     "UPDATE tasks SET outcome=?, feedback_text=?, "
+                    "outcome_set_at=COALESCE(outcome_set_at, ?), "
                     "updated_at=? WHERE id=?",
-                    (outcome, feedback, now, task_id),
+                    (outcome, feedback, now, now, task_id),
                 )
                 self._emit_event(
                     conn, task_id, "task_outcome", actor,

--- a/src/host/server.py
+++ b/src/host/server.py
@@ -3400,6 +3400,10 @@ def create_mesh_app(
         # are stable, rates on small denominators are noise. The
         # placeholder stays (empty dict) so contract consumers don't need
         # an immediate update; treat ``{}`` as "data unavailable" still.
+        # PR-U: ``outcome_rejected_24h_count`` filters on
+        # ``outcome_set_at`` (when the operator rated the task), not
+        # ``completed_at`` (when the agent finished) — review delay no
+        # longer drops lagged rejections off the heartbeat.
         outcome_rejected_24h: dict[str, int] = {}
         execution_failures_24h: dict[str, int] = {}
         stale_tasks_24h: dict[str, int] = {}

--- a/tests/test_orchestration.py
+++ b/tests/test_orchestration.py
@@ -934,6 +934,61 @@ def test_outcome_set_at_migration_idempotent(tmp_path):
     t2.close()
 
 
+def test_outcome_set_at_migration_recovers_from_partial_init(tmp_path):
+    """PR-U: a prior run that ALTERed the column but crashed before the
+    backfill UPDATE committed must be repaired on re-init.
+
+    Simulates the failure mode: column exists, but rows where
+    ``outcome IS NOT NULL`` still have ``outcome_set_at IS NULL``. The
+    fix moves the early-return guard so the backfill UPDATE always runs;
+    the ``WHERE`` clause makes that idempotent on already-stamped rows.
+    """
+    import sqlite3
+    db_path = str(tmp_path / "tasks.db")
+    # First init creates the full schema (column + index).
+    t = Tasks(db_path=db_path)
+    t.close()
+    # Simulate the partial-migration failure: column exists, but a row
+    # was rated and the backfill UPDATE never landed (e.g. process
+    # killed mid-init on an older deploy that lacked this loop).
+    raw = sqlite3.connect(db_path)
+    completed_ts = time.time() - 3 * 24 * 3600
+    raw.execute(
+        "INSERT INTO tasks "
+        "(id, project_id, parent_task_id, title, description, "
+        "creator, assignee, status, priority, dependencies_json, "
+        "artifact_refs_json, blocker_note, origin_kind, origin_channel, "
+        "origin_user, created_at, updated_at, completed_at, "
+        "retention_until, outcome, feedback_text, previous_task_id, "
+        "outcome_set_at) "
+        "VALUES (?, NULL, NULL, ?, NULL, ?, ?, 'done', 0, NULL, NULL, "
+        "NULL, NULL, NULL, NULL, ?, ?, ?, NULL, 'rejected', NULL, NULL, "
+        "NULL)",
+        (
+            "task_partial", "old", "op", "alpha",
+            completed_ts, completed_ts, completed_ts,
+        ),
+    )
+    raw.commit()
+    # Sanity check — column present, value NULL.
+    cols = {row[1] for row in raw.execute("PRAGMA table_info(tasks)").fetchall()}
+    assert "outcome_set_at" in cols
+    pre = raw.execute(
+        "SELECT outcome, outcome_set_at FROM tasks WHERE id=?",
+        ("task_partial",),
+    ).fetchone()
+    assert pre == ("rejected", None)
+    raw.close()
+    # Re-run init: must walk the backfill UPDATE even though the column
+    # already exists, repairing the orphaned row.
+    t2 = Tasks(db_path=db_path)
+    fetched = t2.get("task_partial")
+    assert fetched is not None
+    assert fetched["outcome"] == "rejected"
+    assert fetched["outcome_set_at"] == completed_ts
+    t2.close()
+
+
 def test_outcome_set_at_backfill_skips_anomalous_rows(tmp_path):
     """PR-U: a rated row missing completed_at stays NULL (don't invent data)."""
     import sqlite3

--- a/tests/test_orchestration.py
+++ b/tests/test_orchestration.py
@@ -775,16 +775,199 @@ def test_count_outcomes_since_groups_by_assignee(tmp_path):
 
 
 def test_count_outcomes_since_excludes_old(tmp_path):
+    """PR-U: rewinding outcome_set_at past the cutoff excludes the row.
+
+    The query filters on ``outcome_set_at`` (when the operator rated)
+    rather than ``completed_at`` (when the agent finished); see the
+    lagged-rejection test below for why that distinction matters.
+    """
     t = _make_store(tmp_path)
     rec = _seed_done_with_outcome(t, assignee="alpha", outcome="rejected")
-    # Manually rewind completed_at to 2 days ago.
+    # Manually rewind outcome_set_at to 2 days ago.
     with t._conn() as conn:
         conn.execute(
-            "UPDATE tasks SET completed_at=? WHERE id=?",
+            "UPDATE tasks SET outcome_set_at=? WHERE id=?",
             (time.time() - 2 * 24 * 3600, rec["id"]),
         )
     counts = t.count_outcomes_since("rejected", since_seconds=24 * 3600)
     assert counts == {}
+
+
+def test_count_outcomes_since_filters_on_outcome_set_at_not_completed_at(tmp_path):
+    """PR-U regression: lagged operator review must still surface.
+
+    Real production scenario — an agent finishes a task on Monday but
+    the operator doesn't review and click "rejected" until Wednesday.
+    The pre-PR-U query filtered on ``completed_at`` and so dropped this
+    rejection from Wednesday's 24h heartbeat. With PR-U the filter is
+    on ``outcome_set_at``, which lands inside the window.
+    """
+    t = _make_store(tmp_path)
+    rec = _seed_done_with_outcome(t, assignee="alpha", outcome="rejected")
+    # Simulate: task completed 5 days ago, but the operator only rated
+    # it just now (helper already stamped outcome_set_at to "now").
+    with t._conn() as conn:
+        conn.execute(
+            "UPDATE tasks SET completed_at=? WHERE id=?",
+            (time.time() - 5 * 24 * 3600, rec["id"]),
+        )
+    counts = t.count_outcomes_since("rejected", since_seconds=24 * 3600)
+    assert counts == {"alpha": 1}
+
+
+def test_count_outcomes_since_excludes_outcome_set_pre_cutoff(tmp_path):
+    """PR-U: the inverse — outcome_set_at older than the window is dropped.
+
+    Sanity check the >= filter: a task whose outcome_set_at is past the
+    cutoff window must NOT be counted, even if completed_at is fresh.
+    (Impossible in practice — completed_at always precedes
+    outcome_set_at — but the filter must hold regardless.)
+    """
+    t = _make_store(tmp_path)
+    rec = _seed_done_with_outcome(t, assignee="alpha", outcome="rejected")
+    # outcome_set_at 5 days ago, completed_at fresh (just now from the helper).
+    with t._conn() as conn:
+        conn.execute(
+            "UPDATE tasks SET outcome_set_at=? WHERE id=?",
+            (time.time() - 5 * 24 * 3600, rec["id"]),
+        )
+    counts = t.count_outcomes_since("rejected", since_seconds=24 * 3600)
+    assert counts == {}
+
+
+def test_set_outcome_stamps_outcome_set_at(tmp_path):
+    """PR-U: set_outcome populates outcome_set_at on first call."""
+    t = _make_store(tmp_path)
+    rec = t.create(creator="op", assignee="alpha", title="t")
+    t.update_status(rec["id"], "working", actor="alpha")
+    t.update_status(rec["id"], "done", actor="alpha")
+    before = time.time()
+    updated = t.set_outcome(rec["id"], "accepted", "ok", actor="op")
+    after = time.time()
+    assert updated["outcome_set_at"] is not None
+    assert before <= updated["outcome_set_at"] <= after
+
+
+def test_set_outcome_idempotent_does_not_clobber_outcome_set_at(tmp_path):
+    """PR-U: re-rating preserves the original outcome_set_at timestamp.
+
+    Outcomes are write-many — operators can re-rate after a misclick.
+    The first stamp wins so the heartbeat's "when did the operator
+    first see this?" answer is stable. Each submission still appends
+    its own task_outcome audit row with its own created_at, so
+    re-rating history isn't lost.
+    """
+    t = _make_store(tmp_path)
+    rec = t.create(creator="op", assignee="alpha", title="t")
+    t.update_status(rec["id"], "working", actor="alpha")
+    t.update_status(rec["id"], "done", actor="alpha")
+    first = t.set_outcome(rec["id"], "rejected", "wrong", actor="op")
+    first_stamp = first["outcome_set_at"]
+    assert first_stamp is not None
+    # Force a measurable delta so the second call would clearly differ
+    # if the implementation overwrote.
+    time.sleep(0.01)
+    second = t.set_outcome(rec["id"], "accepted", "actually fine", actor="op")
+    assert second["outcome_set_at"] == first_stamp
+
+
+def test_outcome_set_at_migration_backfills_existing_rows(tmp_path):
+    """PR-U: pre-migration rated rows backfill outcome_set_at = completed_at.
+
+    Open a fresh DB, drop the new column to simulate a pre-PR-U
+    deployment, manually insert a rated row, then re-run init and
+    confirm the backfill ran.
+    """
+    import sqlite3
+    if sqlite3.sqlite_version_info < (3, 35, 0):
+        pytest.skip("ALTER TABLE DROP COLUMN requires SQLite >= 3.35")
+    db_path = str(tmp_path / "tasks.db")
+    # First init creates the schema (with outcome_set_at).
+    t = Tasks(db_path=db_path)
+    t.close()
+    # Simulate pre-PR-U state: drop the column. CI Pythons (3.11+)
+    # ship with SQLite >= 3.35 so this is reliable; the skip above
+    # guards older builds.
+    raw = sqlite3.connect(db_path)
+    # The index references outcome_set_at — drop it first so the
+    # column drop succeeds.
+    raw.execute("DROP INDEX IF EXISTS idx_tasks_outcome_set_at")
+    raw.execute("ALTER TABLE tasks DROP COLUMN outcome_set_at")
+    # Insert a "pre-migration" rated row — completed_at set, no
+    # outcome_set_at column existed when this row landed.
+    completed_ts = time.time() - 3 * 24 * 3600
+    raw.execute(
+        "INSERT INTO tasks "
+        "(id, project_id, parent_task_id, title, description, "
+        "creator, assignee, status, priority, dependencies_json, "
+        "artifact_refs_json, blocker_note, origin_kind, origin_channel, "
+        "origin_user, created_at, updated_at, completed_at, "
+        "retention_until, outcome, feedback_text, previous_task_id) "
+        "VALUES (?, NULL, NULL, ?, NULL, ?, ?, 'done', 0, NULL, NULL, "
+        "NULL, NULL, NULL, NULL, ?, ?, ?, NULL, 'rejected', NULL, NULL)",
+        (
+            "task_legacy", "old", "op", "alpha",
+            completed_ts, completed_ts, completed_ts,
+        ),
+    )
+    raw.commit()
+    raw.close()
+    # Re-run init: triggers the migration + backfill.
+    t2 = Tasks(db_path=db_path)
+    fetched = t2.get("task_legacy")
+    assert fetched is not None
+    assert fetched["outcome"] == "rejected"
+    assert fetched["outcome_set_at"] == completed_ts
+    t2.close()
+
+
+def test_outcome_set_at_migration_idempotent(tmp_path):
+    """PR-U: running the migration twice is safe (no double-backfill, no error)."""
+    db_path = str(tmp_path / "tasks.db")
+    t1 = Tasks(db_path=db_path)
+    t1.close()
+    # Re-instantiating must not error or duplicate work.
+    t2 = Tasks(db_path=db_path)
+    with t2._conn() as conn:
+        cols = {row[1] for row in conn.execute("PRAGMA table_info(tasks)").fetchall()}
+    assert "outcome_set_at" in cols
+    t2.close()
+
+
+def test_outcome_set_at_backfill_skips_anomalous_rows(tmp_path):
+    """PR-U: a rated row missing completed_at stays NULL (don't invent data)."""
+    import sqlite3
+    if sqlite3.sqlite_version_info < (3, 35, 0):
+        pytest.skip("ALTER TABLE DROP COLUMN requires SQLite >= 3.35")
+    db_path = str(tmp_path / "tasks.db")
+    t = Tasks(db_path=db_path)
+    t.close()
+    raw = sqlite3.connect(db_path)
+    # The index references outcome_set_at — drop it first so the
+    # column drop succeeds.
+    raw.execute("DROP INDEX IF EXISTS idx_tasks_outcome_set_at")
+    raw.execute("ALTER TABLE tasks DROP COLUMN outcome_set_at")
+    # Anomalous row: outcome set but completed_at NULL.
+    raw.execute(
+        "INSERT INTO tasks "
+        "(id, project_id, parent_task_id, title, description, "
+        "creator, assignee, status, priority, dependencies_json, "
+        "artifact_refs_json, blocker_note, origin_kind, origin_channel, "
+        "origin_user, created_at, updated_at, completed_at, "
+        "retention_until, outcome, feedback_text, previous_task_id) "
+        "VALUES (?, NULL, NULL, ?, NULL, ?, ?, 'done', 0, NULL, NULL, "
+        "NULL, NULL, NULL, NULL, ?, ?, NULL, NULL, 'rejected', NULL, NULL)",
+        ("task_anom", "old", "op", "alpha", time.time(), time.time()),
+    )
+    raw.commit()
+    raw.close()
+    t2 = Tasks(db_path=db_path)
+    fetched = t2.get("task_anom")
+    assert fetched is not None
+    assert fetched["outcome"] == "rejected"
+    # No completed_at to copy from → leave outcome_set_at NULL.
+    assert fetched["outcome_set_at"] is None
+    t2.close()
 
 
 def test_count_failed_status_since_excludes_done(tmp_path):


### PR DESCRIPTION
## Summary

Fixes the rejection-lag undercount in `count_outcomes_since`: when an operator marks a task `outcome='rejected'` 2+ days after task completion (review delay), the row's `completed_at` is older than the 24h cutoff, so the rejection is excluded from the heartbeat alert. The operator never sees the late rejection.

Adds an `outcome_set_at REAL` column stamped on `set_outcome` and used as the filter column going forward.

This is **PR-U** from the post-audit backlog.

## Why

Real production scenario:
1. Agent completes a task at T+0
2. Task sits in the operator's review queue
3. Operator reviews 3 days later (T+3) and marks `outcome='rejected'`
4. Heartbeat next runs at T+3+15min and queries `count_outcomes_since(24h)` → row excluded (`completed_at = T+0`, cutoff = T+3-24h)
5. Operator never gets the alert

Filtering on `outcome_set_at` instead of `completed_at` puts the rejection on the operator's radar at the moment the operator first acted on it.

## Schema-naming note

CLAUDE.md and the audit referenced the `tasks_v2` schema, but `tasks_v2` is the feature flag name (`OPENLEGION_ORCHESTRATION_TASKS_V2`). The actual SQLite table is `tasks` in `src/host/orchestration.py`. Verified — no competing migration paths exist; no prior `outcome_set_at` column anywhere. PR uses the actual table name.

## Migration (verbatim)

```python
@staticmethod
def _ensure_outcome_set_at_column(conn: sqlite3.Connection) -> None:
    """PR-U: add outcome_set_at column if missing. Idempotent."""
    cols = {row[1] for row in conn.execute("PRAGMA table_info(tasks)").fetchall()}
    if "outcome_set_at" in cols:
        return
    conn.execute("ALTER TABLE tasks ADD COLUMN outcome_set_at REAL")
    # Best-effort backfill — existing rated rows inherit completed_at.
    conn.execute(
        "UPDATE tasks SET outcome_set_at = completed_at "
        "WHERE outcome IS NOT NULL AND outcome_set_at IS NULL "
        "AND completed_at IS NOT NULL"
    )
```

Followed by:
```sql
CREATE INDEX IF NOT EXISTS idx_tasks_outcome_set_at
ON tasks (outcome, outcome_set_at)
WHERE outcome IS NOT NULL
```

Both idempotent. The `completed_at IS NOT NULL` backfill guard (added beyond plan wording) ensures anomalous rows — rated but no `completed_at` — stay NULL rather than silently inherit a NULL via SQL coalesce.

## Re-rating behavior

`set_outcome` writes `outcome_set_at = COALESCE(outcome_set_at, ?)`. The **first** rating wins — re-ratings preserve the original timestamp so the heartbeat sees the rejection at the moment the operator first acted, even if they later re-rate. Audit event rows still capture every submission with their own `created_at`; re-rating history isn't lost.

## Test plan

- [x] Lagged rejection counted in 24h window — `test_count_outcomes_since_filters_on_outcome_set_at_not_completed_at`
- [x] Pre-cutoff `outcome_set_at` excluded — `test_count_outcomes_since_excludes_outcome_set_pre_cutoff`
- [x] `set_outcome` stamps the column — `test_set_outcome_stamps_outcome_set_at`
- [x] Re-rating preserves first stamp — `test_set_outcome_idempotent_does_not_clobber_outcome_set_at`
- [x] Migration backfills pre-existing rows from `completed_at` — `test_outcome_set_at_migration_backfills_existing_rows`
- [x] Migration is idempotent (second run is no-op) — `test_outcome_set_at_migration_idempotent`
- [x] Backfill skips anomalous rows (NULL completed_at) — `test_outcome_set_at_backfill_skips_anomalous_rows`
- [x] Existing `test_count_outcomes_since_excludes_old` updated to rewind `outcome_set_at` (the new filter column)

**Targeted suite:** 123 passed, 0 failed in 4.05s.
**Full suite:** **5588 passed, 44 skipped, zero regressions** in 253.24s.
`ruff` clean.

## Stats

3 files changed, +248 / -10.