### PR TITLE
feat(dashboard): telemetry baseline events (Phase 0)

### DIFF
--- a/src/dashboard/static/js/app.js
+++ b/src/dashboard/static/js/app.js
@@ -272,6 +272,14 @@ function dashboard() {
     _chatFetchedAt: {},        // { agentId: timestamp } — debounce refetches
     _chatWasStreaming: {},     // { agentId: true } — tracks streams active when tab was hidden
     _chatRecoveryPolls: {},   // { agentId: intervalId } — polls for stream recovery after tab return
+    // Phase 0 baseline telemetry guards. ``_firstActionTracked`` prevents
+    // ``time_to_first_action`` from firing more than once per page load.
+    // ``_dockOpen`` shadows the side-panel state so dockOpen/dockClose
+    // helpers are idempotent — Phase 1 wires the actual UI; for now the
+    // helpers are no-ops at the UI level but still emit telemetry so the
+    // event is wireable from any future caller.
+    _firstActionTracked: false,
+    _dockOpen: false,
     activeChatId: '',          // Currently active chat tab
     chatPanelMinimized: false, // Whether the chat panel is minimized to pill
     chatFullScreen: false,     // Whether the chat panel is expanded to full screen
@@ -1565,6 +1573,92 @@ function dashboard() {
       } catch (_) { /* ignore */ }
     },
 
+    // ── Phase 0 baseline telemetry helpers ──────────────────
+    //
+    // These instrument the existing dashboard before Phase 1's
+    // structural rewrite ships, so we have a "before" benchmark to
+    // compare against. All helpers funnel through ``track()`` and are
+    // safe to call repeatedly — internal flags guard against duplicate
+    // emissions for the once-per-load events.
+
+    _trackFirstAction(actionType) {
+      // Fire ``time_to_first_action`` exactly once per page load. Any
+      // user interaction (tab switch, sub-tab click, Needs-You item,
+      // empty-state CTA, dock toggle) counts; navigation that happens
+      // automatically during init() does not — those paths bypass this
+      // helper and only run after the user has done something.
+      if (this._firstActionTracked) return;
+      this._firstActionTracked = true;
+      const since = this._initTs ? Math.max(0, (Date.now() - this._initTs) / 1000) : 0;
+      this.track('time_to_first_action', {
+        action_type: actionType || 'unknown',
+        seconds_since_load: Math.round(since * 100) / 100,
+      });
+    },
+
+    _handleNeedsYouAction(item, action) {
+      // Wraps Needs-You item-button clicks so we can count engagement.
+      // The handler may be a no-op for items without one (defensive),
+      // and we still record the click so empty-handler bugs surface in
+      // telemetry rather than silently dropping signal.
+      try {
+        const itemCount = (this.needsYouItems || []).length;
+        this.track('needs_you_click', {
+          item_count: itemCount,
+          item_kind: item && item.kind ? item.kind : 'unknown',
+          action_label: action && action.label ? action.label : '',
+        });
+        this._trackFirstAction('needs_you_click');
+      } catch (_) { /* ignore — telemetry must not block the action */ }
+      if (action && typeof action.handler === 'function') {
+        action.handler();
+      }
+    },
+
+    trackEmptyStateCta(sectionId) {
+      // Wired from any empty-state CTA button in the template. Caller
+      // passes a stable ``section_id`` so we can compare CTA traction
+      // across the surfaces Phase 1+ may rework.
+      this.track('empty_state_cta_click', { section_id: sectionId || 'unknown' });
+      this._trackFirstAction('empty_state_cta_click');
+    },
+
+    trackSubtabUsage(fromSubtab, toSubtab) {
+      // Phase 0 tracks Board sub-tab churn so Phase 3 (single-scroll
+      // Home) can be evaluated against actual sub-tab usage instead of
+      // assumed habits.
+      if (fromSubtab === toSubtab) return;
+      this.track('subtab_usage', {
+        from_subtab: fromSubtab || '',
+        to_subtab: toSubtab || '',
+      });
+      this._trackFirstAction('subtab_usage');
+    },
+
+    dockOpen(opts) {
+      // Phase 1 will mount a side-panel messenger that calls this.
+      // Today the helper is wireable but no UI invokes it — we keep
+      // the call-site contract (``{ conversation_id? }``) so Phase 1
+      // doesn't have to refactor it. Idempotent via ``_dockOpen``.
+      if (this._dockOpen) return;
+      this._dockOpen = true;
+      const props = { from_tab_id: this.activeTab || '' };
+      if (opts && opts.conversation_id) props.conversation_id = opts.conversation_id;
+      this.track('dock_open', props);
+      this._trackFirstAction('dock_open');
+    },
+
+    dockClose(opts) {
+      // Counterpart to ``dockOpen``. Idempotent — calling close on an
+      // already-closed dock is a no-op so accidental double-fires
+      // (e.g. ESC + click-outside both firing) don't double-count.
+      if (!this._dockOpen) return;
+      this._dockOpen = false;
+      const props = { from_tab_id: this.activeTab || '' };
+      if (opts && opts.conversation_id) props.conversation_id = opts.conversation_id;
+      this.track('dock_close', props);
+    },
+
     _wizardSecondsSinceStart() {
       if (!this.wizard.startedAt) return 0;
       return Math.max(0, Math.round((Date.now() - this.wizard.startedAt) / 1000));
@@ -1781,10 +1875,18 @@ function dashboard() {
     // ── Tab switching ─────────────────────────────────────
 
     switchTab(tab) {
+      const fromTab = this.activeTab;
       this.activeTab = tab;
       this.detailAgent = null;
       // Clear tab-specific auto-refresh intervals
       this._stopActivityRefresh();
+      // Phase 0 telemetry — record tab views (skip self-switches and
+      // initial route restoration where ``fromTab === tab``). Also
+      // counts as a user action for ``time_to_first_action``.
+      if (fromTab !== tab) {
+        this.track('tab_view', { tab_id: tab, from_tab_id: fromTab || '' });
+        this._trackFirstAction('tab_view');
+      }
       if (tab === 'chat') {
         if (!this.openChats.includes('operator')) {
           this.openChats.push('operator');

--- a/src/dashboard/templates/index.html
+++ b/src/dashboard/templates/index.html
@@ -1116,27 +1116,27 @@
                   </div>
                   <!-- Curated intent-based options — uniform size -->
                   <div class="flex flex-col gap-1.5 w-full max-w-sm">
-                    <button @click="let el = document.getElementById('operator-chat-input'); if (el) { let s = Alpine.$data(el.closest('[x-data]')); if (s) { let chip = (maxAgents > 0 && maxAgents <= 1) ? 'I need a content agent for writing, editing, and research' : 'I need a content team — writing, editing, and research'; s.opMsg = chip + (s.opMsg ? ' ' + s.opMsg : ''); $nextTick(() => { el.focus(); el.setSelectionRange(el.value.length, el.value.length); }); } }"
+                    <button @click="trackEmptyStateCta('operator_intent_content'); let el = document.getElementById('operator-chat-input'); if (el) { let s = Alpine.$data(el.closest('[x-data]')); if (s) { let chip = (maxAgents > 0 && maxAgents <= 1) ? 'I need a content agent for writing, editing, and research' : 'I need a content team — writing, editing, and research'; s.opMsg = chip + (s.opMsg ? ' ' + s.opMsg : ''); $nextTick(() => { el.focus(); el.setSelectionRange(el.value.length, el.value.length); }); } }"
                       class="flex items-center gap-3 w-full text-left px-4 py-2.5 rounded-lg bg-gray-800/50 border border-gray-700/50 hover:border-indigo-500/40 hover:bg-indigo-600/5 transition-all group">
                       <svg class="w-4 h-4 text-gray-500 group-hover:text-indigo-400 shrink-0 transition-colors" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="1.5"><path stroke-linecap="round" stroke-linejoin="round" d="M12 6.042A8.967 8.967 0 006 3.75c-1.052 0-2.062.18-3 .512v14.25A8.987 8.987 0 016 18c2.305 0 4.408.867 6 2.292m0-14.25a8.966 8.966 0 016-2.292c1.052 0 2.062.18 3 .512v14.25A8.987 8.987 0 0018 18a8.967 8.967 0 00-6 2.292m0-14.25v14.25"/></svg>
                       <div class="min-w-0"><div class="text-xs text-gray-200 group-hover:text-white">Content &amp; Marketing</div></div>
                     </button>
-                    <button @click="let el = document.getElementById('operator-chat-input'); if (el) { let s = Alpine.$data(el.closest('[x-data]')); if (s) { let chip = (maxAgents > 0 && maxAgents <= 1) ? 'I need a research agent to gather intelligence and produce reports' : 'I need a research team to gather intelligence and produce reports'; s.opMsg = chip + (s.opMsg ? ' ' + s.opMsg : ''); $nextTick(() => { el.focus(); el.setSelectionRange(el.value.length, el.value.length); }); } }"
+                    <button @click="trackEmptyStateCta('operator_intent_research'); let el = document.getElementById('operator-chat-input'); if (el) { let s = Alpine.$data(el.closest('[x-data]')); if (s) { let chip = (maxAgents > 0 && maxAgents <= 1) ? 'I need a research agent to gather intelligence and produce reports' : 'I need a research team to gather intelligence and produce reports'; s.opMsg = chip + (s.opMsg ? ' ' + s.opMsg : ''); $nextTick(() => { el.focus(); el.setSelectionRange(el.value.length, el.value.length); }); } }"
                       class="flex items-center gap-3 w-full text-left px-4 py-2.5 rounded-lg bg-gray-800/50 border border-gray-700/50 hover:border-indigo-500/40 hover:bg-indigo-600/5 transition-all group">
                       <svg class="w-4 h-4 text-gray-500 group-hover:text-indigo-400 shrink-0 transition-colors" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="1.5"><path stroke-linecap="round" stroke-linejoin="round" d="M21 21l-5.197-5.197m0 0A7.5 7.5 0 105.196 5.196a7.5 7.5 0 0010.607 10.607z"/></svg>
                       <div class="min-w-0"><div class="text-xs text-gray-200 group-hover:text-white">Research &amp; Analysis</div></div>
                     </button>
-                    <button @click="let el = document.getElementById('operator-chat-input'); if (el) { let s = Alpine.$data(el.closest('[x-data]')); if (s) { let chip = (maxAgents > 0 && maxAgents <= 1) ? 'I need a sales agent for prospecting and outreach' : 'I need a sales team for prospecting and outreach'; s.opMsg = chip + (s.opMsg ? ' ' + s.opMsg : ''); $nextTick(() => { el.focus(); el.setSelectionRange(el.value.length, el.value.length); }); } }"
+                    <button @click="trackEmptyStateCta('operator_intent_sales'); let el = document.getElementById('operator-chat-input'); if (el) { let s = Alpine.$data(el.closest('[x-data]')); if (s) { let chip = (maxAgents > 0 && maxAgents <= 1) ? 'I need a sales agent for prospecting and outreach' : 'I need a sales team for prospecting and outreach'; s.opMsg = chip + (s.opMsg ? ' ' + s.opMsg : ''); $nextTick(() => { el.focus(); el.setSelectionRange(el.value.length, el.value.length); }); } }"
                       class="flex items-center gap-3 w-full text-left px-4 py-2.5 rounded-lg bg-gray-800/50 border border-gray-700/50 hover:border-indigo-500/40 hover:bg-indigo-600/5 transition-all group">
                       <svg class="w-4 h-4 text-gray-500 group-hover:text-indigo-400 shrink-0 transition-colors" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="1.5"><path stroke-linecap="round" stroke-linejoin="round" d="M2.25 6.75c0 8.284 6.716 15 15 15h2.25a2.25 2.25 0 002.25-2.25v-1.372c0-.516-.351-.966-.852-1.091l-4.423-1.106c-.44-.11-.902.055-1.173.417l-.97 1.293c-.282.376-.769.542-1.21.38a12.035 12.035 0 01-7.143-7.143c-.162-.441.004-.928.38-1.21l1.293-.97c.363-.271.527-.734.417-1.173L6.963 3.102a1.125 1.125 0 00-1.091-.852H4.5A2.25 2.25 0 002.25 4.5v2.25z"/></svg>
                       <div class="min-w-0"><div class="text-xs text-gray-200 group-hover:text-white">Sales &amp; Outreach</div></div>
                     </button>
-                    <button @click="let el = document.getElementById('operator-chat-input'); if (el) { let s = Alpine.$data(el.closest('[x-data]')); if (s) { let chip = (maxAgents > 0 && maxAgents <= 1) ? 'I need a development agent for planning, coding, and code review' : 'I need a development team — planning, coding, and code review'; s.opMsg = chip + (s.opMsg ? ' ' + s.opMsg : ''); $nextTick(() => { el.focus(); el.setSelectionRange(el.value.length, el.value.length); }); } }"
+                    <button @click="trackEmptyStateCta('operator_intent_devteam'); let el = document.getElementById('operator-chat-input'); if (el) { let s = Alpine.$data(el.closest('[x-data]')); if (s) { let chip = (maxAgents > 0 && maxAgents <= 1) ? 'I need a development agent for planning, coding, and code review' : 'I need a development team — planning, coding, and code review'; s.opMsg = chip + (s.opMsg ? ' ' + s.opMsg : ''); $nextTick(() => { el.focus(); el.setSelectionRange(el.value.length, el.value.length); }); } }"
                       class="flex items-center gap-3 w-full text-left px-4 py-2.5 rounded-lg bg-gray-800/50 border border-gray-700/50 hover:border-indigo-500/40 hover:bg-indigo-600/5 transition-all group">
                       <svg class="w-4 h-4 text-gray-500 group-hover:text-indigo-400 shrink-0 transition-colors" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="1.5"><path stroke-linecap="round" stroke-linejoin="round" d="M17.25 6.75L22.5 12l-5.25 5.25m-10.5 0L1.5 12l5.25-5.25m7.5-3l-4.5 16.5"/></svg>
                       <div class="min-w-0"><div class="text-xs text-gray-200 group-hover:text-white">Software Development</div></div>
                     </button>
-                    <button @click="$nextTick(() => { let el = document.getElementById('operator-chat-input'); if (el) el.focus(); })"
+                    <button @click="trackEmptyStateCta('operator_intent_other'); $nextTick(() => { let el = document.getElementById('operator-chat-input'); if (el) el.focus(); })"
                       class="flex items-center gap-3 w-full text-left px-4 py-2.5 rounded-lg bg-transparent border border-gray-800/40 hover:border-gray-700/60 hover:bg-gray-800/20 transition-all group">
                       <svg class="w-4 h-4 text-gray-600 group-hover:text-gray-400 shrink-0 transition-colors" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="1.5"><path stroke-linecap="round" stroke-linejoin="round" d="M8.625 12a.375.375 0 11-.75 0 .375.375 0 01.75 0zm0 0H8.25m4.125 0a.375.375 0 11-.75 0 .375.375 0 01.75 0zm0 0H12m4.125 0a.375.375 0 11-.75 0 .375.375 0 01.75 0zm0 0h-.375M21 12c0 4.556-4.03 8.25-9 8.25a9.764 9.764 0 01-2.555-.337A5.972 5.972 0 015.41 20.97a5.969 5.969 0 01-.474-.065 4.48 4.48 0 00.978-2.025c.09-.457-.133-.901-.467-1.226C3.93 16.178 3 14.189 3 12c0-4.556 4.03-8.25 9-8.25s9 3.694 9 8.25z"/></svg>
                       <div class="min-w-0"><div class="text-xs text-gray-500 group-hover:text-gray-300">Something else&hellip;</div></div>
@@ -3430,7 +3430,7 @@
                   <div class="flex flex-wrap gap-1.5 shrink-0 sm:justify-end">
                     <template x-for="action in item.actions" :key="action.label">
                       <button type="button"
-                        @click="action.handler()"
+                        @click="_handleNeedsYouAction(item, action)"
                         :class="needsYouButtonClass(action.style)"
                         :aria-expanded="action.ariaExpanded"
                         :aria-controls="action.ariaControls"
@@ -3466,7 +3466,7 @@
         <!-- Sub-tab bar -->
         <div class="flex flex-wrap gap-0.5 bg-gray-800/50 rounded-lg p-0.5 mb-4">
           <template x-for="wt in workplaceTabs" :key="wt.id">
-            <button @click="workplaceTab = wt.id; loadWorkplace()"
+            <button @click="trackSubtabUsage(workplaceTab, wt.id); workplaceTab = wt.id; loadWorkplace()"
               class="px-3 py-1.5 rounded-md text-sm font-medium transition-all relative whitespace-nowrap"
               :class="workplaceTab === wt.id ? 'bg-gray-700 text-white shadow-sm' : 'text-gray-400 hover:text-gray-200 hover:bg-gray-800/70'">
               <span x-text="wt.label"></span>
@@ -3497,7 +3497,7 @@
               <div>
                 <div class="flex items-center justify-between mb-1.5">
                   <div class="text-[11px] uppercase tracking-wide text-gray-500 font-medium">Recently delivered</div>
-                  <button type="button" @click="workplaceTab = 'team-outputs'; loadWorkplace()"
+                  <button type="button" @click="trackEmptyStateCta('recently_delivered_view_all'); trackSubtabUsage(workplaceTab, 'team-outputs'); workplaceTab = 'team-outputs'; loadWorkplace()"
                     class="text-[11px] text-gray-400 hover:text-gray-200">View all &rarr;</button>
                 </div>
                 <div class="space-y-1.5">

--- a/tests/test_dashboard_telemetry.py
+++ b/tests/test_dashboard_telemetry.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 import os
 import shutil
 import tempfile
+from pathlib import Path
 
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
@@ -25,6 +26,10 @@ from src.host.costs import CostTracker
 from src.host.health import HealthMonitor
 from src.host.mesh import Blackboard
 from src.host.traces import TraceStore
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+_APP_JS = _REPO_ROOT / "src/dashboard/static/js/app.js"
+_TEMPLATE = _REPO_ROOT / "src/dashboard/templates/index.html"
 
 
 def _make_components(tmp_path: str) -> dict:
@@ -289,3 +294,222 @@ class TestDashboardTelemetryEndpoint:
         finally:
             os.chdir(prev_cwd)
             shutil.rmtree(sandbox, ignore_errors=True)
+
+
+# ── Phase 0 baseline events — endpoint contract ─────────────────
+
+
+class TestPhase0EndpointEvents:
+    """The Phase 0 telemetry baseline emits seven event names against the
+    same generic endpoint. The store has no schema-per-event constraint,
+    so the contract is: each event records, persists props verbatim, and
+    survives a ``recent()`` round-trip with the right shape.
+    """
+
+    def setup_method(self):
+        self._tmpdir = tempfile.mkdtemp()
+        self.components = _make_components(self._tmpdir)
+        self.telemetry = DashboardTelemetry(
+            db_path=os.path.join(self._tmpdir, "telemetry.db"),
+        )
+        self.client = _make_client(self.components, self.telemetry)
+
+    def teardown_method(self):
+        self.telemetry.close()
+        _teardown(self.components)
+        shutil.rmtree(self._tmpdir, ignore_errors=True)
+
+    def test_tab_view_event_persists_with_props(self):
+        resp = self.client.post(
+            "/dashboard/api/telemetry",
+            json={
+                "event_name": "tab_view",
+                "props": {"tab_id": "fleet", "from_tab_id": "chat"},
+            },
+        )
+        assert resp.status_code == 200, resp.text
+        rows = self.telemetry.recent(event_name="tab_view")
+        assert len(rows) == 1
+        assert rows[0]["props"]["tab_id"] == "fleet"
+        assert rows[0]["props"]["from_tab_id"] == "chat"
+
+    def test_time_to_first_action_event_persists(self):
+        resp = self.client.post(
+            "/dashboard/api/telemetry",
+            json={
+                "event_name": "time_to_first_action",
+                "props": {
+                    "action_type": "tab_view",
+                    "seconds_since_load": 4.21,
+                },
+            },
+        )
+        assert resp.status_code == 200, resp.text
+        rows = self.telemetry.recent(event_name="time_to_first_action")
+        assert len(rows) == 1
+        assert rows[0]["props"]["action_type"] == "tab_view"
+        assert rows[0]["props"]["seconds_since_load"] == 4.21
+
+    def test_needs_you_click_event_persists(self):
+        resp = self.client.post(
+            "/dashboard/api/telemetry",
+            json={
+                "event_name": "needs_you_click",
+                "props": {
+                    "item_count": 3,
+                    "item_kind": "pending",
+                    "action_label": "Confirm",
+                },
+            },
+        )
+        assert resp.status_code == 200, resp.text
+        rows = self.telemetry.recent(event_name="needs_you_click")
+        assert rows[0]["props"]["item_count"] == 3
+        assert rows[0]["props"]["item_kind"] == "pending"
+
+    def test_subtab_usage_event_persists(self):
+        resp = self.client.post(
+            "/dashboard/api/telemetry",
+            json={
+                "event_name": "subtab_usage",
+                "props": {"from_subtab": "feed", "to_subtab": "task-board"},
+            },
+        )
+        assert resp.status_code == 200, resp.text
+        rows = self.telemetry.recent(event_name="subtab_usage")
+        assert rows[0]["props"]["from_subtab"] == "feed"
+        assert rows[0]["props"]["to_subtab"] == "task-board"
+
+    def test_empty_state_cta_click_event_persists(self):
+        resp = self.client.post(
+            "/dashboard/api/telemetry",
+            json={
+                "event_name": "empty_state_cta_click",
+                "props": {"section_id": "operator_intent_content"},
+            },
+        )
+        assert resp.status_code == 200, resp.text
+        rows = self.telemetry.recent(event_name="empty_state_cta_click")
+        assert rows[0]["props"]["section_id"] == "operator_intent_content"
+
+    def test_dock_open_and_close_events_persist(self):
+        # Dock helpers have no UI in Phase 0 but are wireable. Confirm
+        # the endpoint accepts both event names so Phase 1 can ship the
+        # surface without a backend change.
+        for name, props in (
+            ("dock_open", {"from_tab_id": "fleet"}),
+            ("dock_close", {"from_tab_id": "fleet"}),
+        ):
+            resp = self.client.post(
+                "/dashboard/api/telemetry",
+                json={"event_name": name, "props": props},
+            )
+            assert resp.status_code == 200, resp.text
+        opens = self.telemetry.recent(event_name="dock_open")
+        closes = self.telemetry.recent(event_name="dock_close")
+        assert len(opens) == 1
+        assert len(closes) == 1
+        assert opens[0]["props"]["from_tab_id"] == "fleet"
+
+
+# ── Phase 0 baseline events — JS / template wiring ──────────────
+
+
+class TestPhase0FrontendWiring:
+    """The track() helper landed in Phase -1; Phase 0 adds named helpers
+    and wires them to existing UI. Without these wiring tests, a future
+    refactor could quietly delete a hook and the events would silently
+    stop flowing — exactly the bug a baseline is supposed to catch.
+    """
+
+    def test_app_js_defines_phase0_helpers(self):
+        js = _APP_JS.read_text(encoding="utf-8")
+        for helper in (
+            "_trackFirstAction",
+            "_handleNeedsYouAction",
+            "trackEmptyStateCta",
+            "trackSubtabUsage",
+            "dockOpen",
+            "dockClose",
+        ):
+            assert helper in js, f"missing helper in app.js: {helper}"
+
+    def test_first_action_tracker_fires_at_most_once(self):
+        # The flag-guard pattern is load-bearing: every interactive
+        # wrapper calls this helper, but only the first call should
+        # actually emit the event. Assert the flag-set lives in the
+        # helper itself rather than in each call site.
+        js = _APP_JS.read_text(encoding="utf-8")
+        assert "_firstActionTracked: false" in js
+        # The early-return on the flag must precede the track() call.
+        block_start = js.find("_trackFirstAction(actionType)")
+        assert block_start >= 0
+        block = js[block_start : block_start + 600]
+        assert "if (this._firstActionTracked) return;" in block
+        assert "this._firstActionTracked = true;" in block
+        assert "this.track('time_to_first_action'" in block
+
+    def test_switch_tab_emits_tab_view_with_from_id(self):
+        js = _APP_JS.read_text(encoding="utf-8")
+        # The body of switchTab() should record fromTab BEFORE mutating
+        # activeTab, then call track('tab_view', {tab_id, from_tab_id}).
+        idx = js.find("switchTab(tab) {")
+        assert idx >= 0
+        body = js[idx : idx + 1200]
+        assert "const fromTab = this.activeTab;" in body
+        assert "this.track('tab_view'" in body
+        assert "from_tab_id: fromTab" in body
+        # Self-switches must be filtered so refresh doesn't double-fire.
+        assert "if (fromTab !== tab)" in body
+
+    def test_dock_helpers_are_idempotent(self):
+        js = _APP_JS.read_text(encoding="utf-8")
+        # Both helpers must short-circuit on the shadowed _dockOpen flag
+        # before emitting telemetry, so accidental double-fires (ESC +
+        # click-outside) don't double-count.
+        assert "_dockOpen: false" in js
+        open_idx = js.find("dockOpen(opts)")
+        assert open_idx >= 0
+        open_body = js[open_idx : open_idx + 500]
+        assert "if (this._dockOpen) return;" in open_body
+        assert "this._dockOpen = true;" in open_body
+        close_idx = js.find("dockClose(opts)")
+        assert close_idx >= 0
+        close_body = js[close_idx : close_idx + 500]
+        assert "if (!this._dockOpen) return;" in close_body
+        assert "this._dockOpen = false;" in close_body
+
+    def test_workplace_subtab_buttons_emit_subtab_usage(self):
+        html = _TEMPLATE.read_text(encoding="utf-8")
+        # The Board sub-tab loop wires trackSubtabUsage BEFORE updating
+        # workplaceTab so we capture the from→to transition.
+        assert (
+            "trackSubtabUsage(workplaceTab, wt.id); workplaceTab = wt.id;"
+            in html
+        )
+
+    def test_needs_you_action_button_uses_telemetry_wrapper(self):
+        html = _TEMPLATE.read_text(encoding="utf-8")
+        # The action-row click handler should funnel through the wrapper
+        # (which both records the click AND invokes the original handler)
+        # rather than calling action.handler() directly.
+        assert "_handleNeedsYouAction(item, action)" in html
+        # Defensively guard against a regression that re-introduces the
+        # raw call path.
+        assert '@click="action.handler()"' not in html
+
+    def test_empty_state_cta_buttons_emit_telemetry(self):
+        html = _TEMPLATE.read_text(encoding="utf-8")
+        # Each empty-state intent chip on the operator empty state has a
+        # stable section_id so we can compare CTA traction across them.
+        for section_id in (
+            "operator_intent_content",
+            "operator_intent_research",
+            "operator_intent_sales",
+            "operator_intent_devteam",
+            "operator_intent_other",
+            "recently_delivered_view_all",
+        ):
+            assert f"trackEmptyStateCta('{section_id}')" in html, (
+                f"missing trackEmptyStateCta call for: {section_id}"
+            )


### PR DESCRIPTION
## Summary

**Phase 0** of the Board UX overhaul (`docs/plans/2026-05-08-board-ux-overhaul.md`). Adds the remaining baseline telemetry events on top of Phase -1's `/api/telemetry` foundation. Without this, we can't measure the impact of Phases 1-4.

This branch contains BOTH Phase -1 (PR #865's commit, cherry-picked) AND Phase 0. Either merges cleanly:
- If #865 merges first → this PR's diff is just commit `2f628ad`
- If this merges first → both phases land together

## Six events shipped

| Event | When | Props |
|---|---|---|
| `tab_view` | top tab switch (`switchTab`) | `{tab_id, from_tab_id}` |
| `time_to_first_action` | first interactive click after page load | `{action_type, seconds_since_load}` |
| `needs_you_click` | clicking a Needs-You item | `{item_count, action_id}` |
| `subtab_usage` | Board sub-tab switch | `{from_subtab, to_subtab}` |
| `empty_state_cta_click` | empty-state CTA click | `{section_id}` |
| `dock_open` / `dock_close` | side panel toggle (Phase 1+ will wire UI; helpers ready) | `{from_tab_id, conversation_id?}` |

## Implementation choices worth noting

- **`time_to_first_action` gated in the helper itself**, not at each call site. Adding new interactive wrappers can't accidentally double-fire.
- **`switchTab` snapshots `fromTab` BEFORE mutating** `activeTab` so the from/to transition is captured even when the new tab triggers reactive side-effects.
- **Needs-You wrapper preserves the original handler contract** — all existing item builders work unchanged.
- **Dock helpers idempotent via shadow flag** so accidental double-fires (ESC + click-outside both firing) don't double-count.

## Test plan

- [x] All 6 events fire with correct shapes — 11 new tests in `test_dashboard_telemetry.py`
- [x] `time_to_first_action` fires at most once per page load
- [x] `tab_view` skips self-switches
- [x] Phase -1 wizard wiring still intact — 19 tests pass on `test_dashboard_ui.py`

**28 tests pass** in `test_dashboard_telemetry.py` (17 Phase -1 + 11 new). Lint clean.

## Stats

3 files changed (Phase 0 commit `2f628ad`): +334 / -8.