### PR TITLE
feat(dashboard): "what's new" tour for existing users + wizard polish (Phase 4)

### DIFF
--- a/src/dashboard/static/js/app.js
+++ b/src/dashboard/static/js/app.js
@@ -650,6 +650,16 @@ function dashboard() {
     _wizardBuildPoll: null,
     _wizardCompleteTimer: null,
 
+    // Phase 4 — "What's new" tour for existing-fleet users seeing the
+    // redesigned dashboard for the first time. Three modal steps,
+    // skippable, persists to ``localStorage.olSeenWhatsNew = 'true'``
+    // on completion or skip. Distinct from the empty-fleet wizard
+    // above — those are mutually exclusive (empty fleet = wizard,
+    // existing fleet = tour).
+    whatsNewTour: { step: 0 },  // 0 = closed; 1..3 = visible
+    _whatsNewTourPrevFocus: null,
+    _whatsNewTourKeyHandler: null,
+
     // WebSocket reconnect countdown (Alpine-reactive mirror)
     wsReconnectIn: 0,
 
@@ -2124,6 +2134,32 @@ function dashboard() {
       this._wizardLastTrack = '';
     },
 
+    // Phase 4 — the wizard "x" / "skip wizard" handler. Same effect
+    // as wizardAbandon (sets step=idle, persists, tears down pollers)
+    // but with a different telemetry reason so we can tell deliberate
+    // skips apart from page-unload abandons.
+    wizardSkip() {
+      const lastStep = this.wizard.step;
+      this.track('wizard_abandoned', {
+        lastStep: lastStep,
+        totalSeconds: this._wizardSecondsSinceStart(),
+        reason: 'skip_link',
+      });
+      this._wizardTeardown();
+      this.wizard = { step: 'idle', plan: null, startedAt: 0, lastChip: '' };
+      this._wizardSave();
+      this._wizardLastTrack = '';
+    },
+
+    // Phase 4 — return progress-dot index for a given step. Used by
+    // the wizard card progress indicator (4 dots: ask, confirming,
+    // building, first-output).
+    wizardStepIndex() {
+      const order = ['ask', 'confirming', 'building', 'first-output'];
+      const idx = order.indexOf(this.wizard.step);
+      return idx < 0 ? 0 : idx;
+    },
+
     _wizardTeardown() {
       if (this._wizardBuildPoll) {
         clearInterval(this._wizardBuildPoll);
@@ -2148,6 +2184,105 @@ function dashboard() {
       if (this.wizard.step !== 'idle') return;
       if (!this._isFirstVisit()) return;
       this.startWizard();
+    },
+
+    // ── Phase 4 "What's new" tour ────────────────────────────
+    //
+    // 3-step modal for existing-fleet users seeing the redesigned
+    // dashboard for the first time. Detection: agents.length > 0
+    // (excluding operator) AND ``localStorage.olSeenWhatsNew !== 'true'``
+    // AND no active wizard (mutual exclusion). On any exit path —
+    // skip, dismiss, or reaching step 3 — we set the seen flag so the
+    // tour never re-shows for that browser.
+
+    _maybeStartWhatsNewTour() {
+      if (this.whatsNewTour.step !== 0) return;
+      if (this.wizard && this.wizard.step !== 'idle') return;
+      try {
+        if (localStorage.getItem('olSeenWhatsNew') === 'true') return;
+      } catch (_) { /* private mode — show once per session */ }
+      const fleetAgents = (this.agents || []).filter(a => a && a.id !== 'operator');
+      if (fleetAgents.length === 0) return;
+      this.startWhatsNewTour();
+    },
+
+    startWhatsNewTour() {
+      this.whatsNewTour = { step: 1 };
+      this.track('whats_new_tour_started', {});
+      // Capture focus + install ESC handler. Focus the modal on next
+      // tick so screen-readers announce the dialog.
+      try { this._whatsNewTourPrevFocus = document.activeElement; } catch (_) {}
+      this._whatsNewTourKeyHandler = (e) => {
+        if (e.key === 'Escape') {
+          e.preventDefault();
+          this.dismissWhatsNewTour('escape');
+        } else if (e.key === 'Tab') {
+          // Lightweight focus trap — keep tab cycling inside the modal.
+          const root = document.querySelector('[data-testid="whats-new-modal"]');
+          if (!root) return;
+          const focusable = root.querySelectorAll(
+            'button:not([disabled]), [href], [tabindex]:not([tabindex="-1"])'
+          );
+          if (focusable.length === 0) return;
+          const first = focusable[0];
+          const last = focusable[focusable.length - 1];
+          if (e.shiftKey && document.activeElement === first) {
+            e.preventDefault();
+            last.focus();
+          } else if (!e.shiftKey && document.activeElement === last) {
+            e.preventDefault();
+            first.focus();
+          }
+        }
+      };
+      window.addEventListener('keydown', this._whatsNewTourKeyHandler);
+      this.$nextTick(() => {
+        const root = document.querySelector('[data-testid="whats-new-modal"]');
+        const target = root && root.querySelector('[data-testid="whats-new-primary"]');
+        if (target && typeof target.focus === 'function') target.focus();
+      });
+    },
+
+    whatsNewTourNext() {
+      if (this.whatsNewTour.step >= 3) {
+        this._completeWhatsNewTour('completed');
+        return;
+      }
+      this.whatsNewTour.step += 1;
+      this.track('whats_new_tour_step', { step: this.whatsNewTour.step });
+      this.$nextTick(() => {
+        const root = document.querySelector('[data-testid="whats-new-modal"]');
+        const target = root && root.querySelector('[data-testid="whats-new-primary"]');
+        if (target && typeof target.focus === 'function') target.focus();
+      });
+    },
+
+    whatsNewTourBack() {
+      if (this.whatsNewTour.step > 1) {
+        this.whatsNewTour.step -= 1;
+        this.track('whats_new_tour_step', { step: this.whatsNewTour.step, direction: 'back' });
+      }
+    },
+
+    dismissWhatsNewTour(reason) {
+      this._completeWhatsNewTour(reason || 'dismissed');
+    },
+
+    _completeWhatsNewTour(reason) {
+      const lastStep = this.whatsNewTour.step;
+      try { localStorage.setItem('olSeenWhatsNew', 'true'); } catch (_) {}
+      this.whatsNewTour = { step: 0 };
+      this.track('whats_new_tour_finished', { reason: reason, lastStep: lastStep });
+      if (this._whatsNewTourKeyHandler) {
+        window.removeEventListener('keydown', this._whatsNewTourKeyHandler);
+        this._whatsNewTourKeyHandler = null;
+      }
+      try {
+        if (this._whatsNewTourPrevFocus && this._whatsNewTourPrevFocus.focus) {
+          this._whatsNewTourPrevFocus.focus();
+        }
+      } catch (_) {}
+      this._whatsNewTourPrevFocus = null;
     },
 
     // ── Tab switching ─────────────────────────────────────
@@ -4464,6 +4599,9 @@ function dashboard() {
           // loading at init time) doesn't pop the wizard. Re-entrant
           // calls during the same visit are no-ops.
           this._maybeStartWizard();
+          // Phase 4 — "What's new" tour for existing-fleet users.
+          // Mutually exclusive with the empty-fleet wizard.
+          this._maybeStartWhatsNewTour();
         }
       } catch (e) {
         console.warn('fetchAgents failed:', e);

--- a/src/dashboard/templates/index.html
+++ b/src/dashboard/templates/index.html
@@ -516,6 +516,17 @@
                   <div role="dialog" aria-labelledby="wizard-title"
                        class="ol-wizard-card max-w-md mx-auto mt-4 mb-2 rounded-2xl bg-gradient-to-b from-indigo-900/20 to-gray-900/40 border border-indigo-700/40 shadow-lg overflow-hidden"
                        data-testid="onboarding-wizard">
+                    <!-- Phase 4 progress dots — 4 steps (ask, confirming,
+                         building, first-output). Current step is filled
+                         indigo; past steps are emerald (done); future
+                         steps are gray. -->
+                    <div class="flex items-center justify-center gap-1.5 pt-3 pb-1"
+                         data-testid="wizard-progress" aria-hidden="true">
+                      <template x-for="i in [0,1,2,3]" :key="i">
+                        <span class="block w-1.5 h-1.5 rounded-full transition-colors"
+                              :class="i === wizardStepIndex() ? 'bg-indigo-400 w-3' : (i < wizardStepIndex() ? 'bg-emerald-500/70' : 'bg-gray-700')"></span>
+                      </template>
+                    </div>
                     <!-- Step: ask -->
                     <template x-if="wizard.step === 'ask'">
                       <div class="px-5 pt-5 pb-4">
@@ -605,14 +616,22 @@
 
                     <!-- Step: building -->
                     <template x-if="wizard.step === 'building'">
-                      <div class="px-5 pt-5 pb-5 flex items-center gap-3">
-                        <svg class="animate-spin h-5 w-5 text-indigo-400 shrink-0" fill="none" viewBox="0 0 24 24">
-                          <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
-                          <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z"></path>
-                        </svg>
-                        <div class="flex-1 min-w-0">
-                          <div id="wizard-title" class="text-sm font-semibold text-white">Setting up your team&hellip;</div>
-                          <div class="text-[11px] text-gray-400 mt-0.5">This takes about 30 seconds.</div>
+                      <div class="px-5 pt-5 pb-5">
+                        <div class="flex items-center gap-3">
+                          <svg class="animate-spin h-5 w-5 text-indigo-400 shrink-0" fill="none" viewBox="0 0 24 24">
+                            <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
+                            <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z"></path>
+                          </svg>
+                          <div class="flex-1 min-w-0">
+                            <div id="wizard-title" class="text-sm font-semibold text-white">Setting up your team&hellip;</div>
+                            <div class="text-[11px] text-gray-400 mt-0.5">This takes about 30 seconds.</div>
+                          </div>
+                          <button @click="wizardSkip()"
+                                  data-testid="wizard-skip-building"
+                                  aria-label="Skip wizard"
+                                  class="text-gray-500 hover:text-gray-300 transition-colors p-1 -mr-1 rounded shrink-0">
+                            <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12"/></svg>
+                          </button>
                         </div>
                       </div>
                     </template>
@@ -621,26 +640,42 @@
                     <template x-if="wizard.step === 'first-output'">
                       <div class="px-5 pt-5 pb-5">
                         <div class="flex items-start gap-3 mb-3">
-                          <div class="w-8 h-8 rounded-full bg-emerald-600/20 border border-emerald-500/40 flex items-center justify-center shrink-0">
-                            <svg class="w-4 h-4 text-emerald-400" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="2.5"><path stroke-linecap="round" stroke-linejoin="round" d="M5 13l4 4L19 7"/></svg>
+                          <div class="w-10 h-10 rounded-full bg-emerald-600/20 border border-emerald-500/40 flex items-center justify-center shrink-0">
+                            <svg class="w-5 h-5 text-emerald-400" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="2.5"><path stroke-linecap="round" stroke-linejoin="round" d="M5 13l4 4L19 7"/></svg>
                           </div>
                           <div class="flex-1 min-w-0">
-                            <div id="wizard-title" class="text-sm font-semibold text-white">Your team is ready</div>
-                            <div class="text-[11px] text-emerald-300/80 mt-0.5">Step 3 of 3 &middot; we'll take it from here</div>
+                            <div id="wizard-title" class="text-base font-semibold text-white">Your team is ready</div>
+                            <div class="text-[11px] text-emerald-300/80 mt-0.5">Step 3 of 3 &middot; we&rsquo;ll take it from here</div>
                           </div>
                         </div>
                         <p class="text-xs text-gray-300 leading-relaxed mb-1">
-                          Your researcher is starting now. First output expected in about 10 minutes.
+                          Your team is starting now. First output expected in about 10 minutes.
                         </p>
-                        <p class="text-xs text-gray-400 leading-relaxed mb-4">
-                          I'll ping you when something needs your attention. You can close this window.
+                        <p class="text-xs text-gray-400 leading-relaxed mb-3">
+                          I&rsquo;ll ping you when something needs your attention.
                         </p>
-                        <button @click="wizardComplete()"
-                                data-testid="wizard-continue"
-                                aria-label="Continue to chat"
-                                class="text-xs font-medium px-4 py-2 rounded-lg bg-indigo-600 hover:bg-indigo-500 text-white transition-colors">
-                          Continue
-                        </button>
+                        <!-- Phase 4 quick-link chips. Each switches a tab
+                             and completes the wizard so the user lands
+                             on the section they care about most. -->
+                        <div class="flex flex-wrap gap-1.5 mb-1"
+                             data-testid="wizard-quick-links">
+                          <button @click="switchTab('fleet'); wizardComplete()"
+                                  data-testid="wizard-link-team"
+                                  class="text-xs px-3 py-1.5 rounded-full bg-indigo-600/20 hover:bg-indigo-600/30 border border-indigo-500/40 text-indigo-200 transition-colors">
+                            View team &rarr;
+                          </button>
+                          <button @click="switchTab('workplace'); wizardComplete()"
+                                  data-testid="wizard-link-workplace"
+                                  class="text-xs px-3 py-1.5 rounded-full bg-indigo-600/20 hover:bg-indigo-600/30 border border-indigo-500/40 text-indigo-200 transition-colors">
+                            See what they&rsquo;re working on &rarr;
+                          </button>
+                          <button @click="wizardComplete()"
+                                  data-testid="wizard-continue"
+                                  aria-label="Continue to chat"
+                                  class="text-xs px-3 py-1.5 rounded-full bg-gray-800 hover:bg-gray-700 border border-gray-700 text-gray-300 transition-colors">
+                            Got it, close
+                          </button>
+                        </div>
                       </div>
                     </template>
                   </div>
@@ -8354,6 +8389,126 @@
         </div>
       </div>
     </div>
+
+    <!-- Phase 4 — "What's new" tour for existing-fleet users. Three
+         skippable modal steps; persists ``localStorage.olSeenWhatsNew``
+         on completion or dismiss. ``role="dialog"`` + focus trap +
+         ESC handler are wired in app.js. Mobile: full-screen at
+         <640px via ``sm:max-w-md`` cap. -->
+    <template x-if="whatsNewTour.step !== 0">
+      <div class="fixed inset-0 z-[150] flex items-center justify-center bg-black/70 backdrop-blur-sm p-0 sm:p-4"
+           data-testid="whats-new-overlay"
+           @click.self="dismissWhatsNewTour('overlay')">
+        <div role="dialog" aria-modal="true" aria-labelledby="whats-new-title"
+             data-testid="whats-new-modal"
+             class="relative w-full h-full sm:h-auto sm:max-w-md sm:rounded-2xl bg-gradient-to-b from-indigo-900/40 to-gray-900/95 sm:border sm:border-indigo-700/40 shadow-2xl overflow-y-auto sm:overflow-visible flex flex-col sm:block">
+          <!-- Step 1 -->
+          <template x-if="whatsNewTour.step === 1">
+            <div class="px-6 pt-8 pb-6 sm:pt-7 sm:pb-6 flex-1 flex flex-col">
+              <div class="flex items-start justify-between mb-3">
+                <div class="text-[11px] uppercase tracking-wide text-indigo-300/80">Step 1 of 3</div>
+                <button @click="dismissWhatsNewTour('skip_button')"
+                        data-testid="whats-new-skip"
+                        aria-label="Skip tour"
+                        class="text-gray-500 hover:text-gray-300 transition-colors p-1 -mr-1 -mt-1 rounded text-xs">
+                  Skip
+                </button>
+              </div>
+              <h2 id="whats-new-title" class="text-lg font-semibold text-white mb-2">
+                We&rsquo;ve simplified your dashboard
+              </h2>
+              <p class="text-sm text-gray-300 leading-relaxed mb-6 flex-1">
+                Your team&rsquo;s work and your conversation with the Operator are now
+                easier to find. Take a quick tour?
+              </p>
+              <div class="flex items-center justify-end gap-2">
+                <button @click="dismissWhatsNewTour('skip_button')"
+                        class="text-xs font-medium px-4 py-2 rounded-lg bg-transparent hover:bg-gray-800/60 text-gray-400 transition-colors">
+                  Skip
+                </button>
+                <button @click="whatsNewTourNext()"
+                        data-testid="whats-new-primary"
+                        class="text-xs font-medium px-4 py-2 rounded-lg bg-indigo-600 hover:bg-indigo-500 text-white transition-colors">
+                  Show me
+                </button>
+              </div>
+            </div>
+          </template>
+
+          <!-- Step 2 -->
+          <template x-if="whatsNewTour.step === 2">
+            <div class="px-6 pt-8 pb-6 sm:pt-7 sm:pb-6 flex-1 flex flex-col">
+              <div class="flex items-start justify-between mb-3">
+                <div class="text-[11px] uppercase tracking-wide text-indigo-300/80">Step 2 of 3</div>
+                <button @click="dismissWhatsNewTour('skip_button')"
+                        aria-label="Skip tour"
+                        class="text-gray-500 hover:text-gray-300 transition-colors p-1 -mr-1 -mt-1 rounded text-xs">
+                  Skip
+                </button>
+              </div>
+              <h2 id="whats-new-title" class="text-lg font-semibold text-white mb-3">
+                Operator is one click away
+              </h2>
+              <div class="rounded-xl bg-gray-900/60 border border-indigo-500/30 p-4 mb-4 flex items-center gap-3">
+                <div class="w-10 h-10 rounded-full bg-indigo-600/30 border border-indigo-400/50 flex items-center justify-center shrink-0">
+                  <svg class="w-5 h-5 text-indigo-300" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z"/></svg>
+                </div>
+                <div class="text-xs text-gray-300 leading-relaxed">Look for the chat icon in the top-right corner.</div>
+              </div>
+              <p class="text-sm text-gray-300 leading-relaxed mb-6 flex-1">
+                Click the chat icon in the top-right from any page to talk to the Operator
+                without losing your place.
+              </p>
+              <div class="flex items-center justify-between gap-2">
+                <button @click="whatsNewTourBack()"
+                        class="text-xs font-medium px-4 py-2 rounded-lg bg-transparent hover:bg-gray-800/60 text-gray-400 transition-colors">
+                  Back
+                </button>
+                <button @click="whatsNewTourNext()"
+                        data-testid="whats-new-primary"
+                        class="text-xs font-medium px-4 py-2 rounded-lg bg-indigo-600 hover:bg-indigo-500 text-white transition-colors">
+                  Next
+                </button>
+              </div>
+            </div>
+          </template>
+
+          <!-- Step 3 -->
+          <template x-if="whatsNewTour.step === 3">
+            <div class="px-6 pt-8 pb-6 sm:pt-7 sm:pb-6 flex-1 flex flex-col">
+              <div class="flex items-start justify-between mb-3">
+                <div class="text-[11px] uppercase tracking-wide text-indigo-300/80">Step 3 of 3</div>
+              </div>
+              <h2 id="whats-new-title" class="text-lg font-semibold text-white mb-3">
+                Approvals and notifications are in the top nav
+              </h2>
+              <div class="rounded-xl bg-gray-900/60 border border-indigo-500/30 p-4 mb-4 flex items-center gap-3">
+                <span class="inline-flex items-center justify-center min-w-[18px] h-[18px] px-1 rounded-full bg-red-500 text-[10px] font-bold text-white">3</span>
+                <span class="text-gray-500">+</span>
+                <svg class="w-4 h-4 text-gray-300" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M15 17h5l-1.405-1.405A2.032 2.032 0 0118 14.158V11a6.002 6.002 0 00-4-5.659V5a2 2 0 10-4 0v.341C7.67 6.165 6 8.388 6 11v3.159c0 .538-.214 1.055-.595 1.436L4 17h5m6 0v1a3 3 0 11-6 0v-1m6 0H9"/></svg>
+                <div class="text-xs text-gray-300 leading-relaxed flex-1">Look top-right.</div>
+              </div>
+              <p class="text-sm text-gray-300 leading-relaxed mb-6 flex-1">
+                Anything that needs your attention shows as a red badge. Past events show
+                in the bell icon. You&rsquo;ll always see what needs you, no matter what
+                tab you&rsquo;re on.
+              </p>
+              <div class="flex items-center justify-between gap-2">
+                <button @click="whatsNewTourBack()"
+                        class="text-xs font-medium px-4 py-2 rounded-lg bg-transparent hover:bg-gray-800/60 text-gray-400 transition-colors">
+                  Back
+                </button>
+                <button @click="whatsNewTourNext()"
+                        data-testid="whats-new-primary"
+                        class="text-xs font-medium px-4 py-2 rounded-lg bg-indigo-600 hover:bg-indigo-500 text-white transition-colors">
+                  Got it
+                </button>
+              </div>
+            </div>
+          </template>
+        </div>
+      </div>
+    </template>
 
     <!-- Minimized chat pill -->
     <div x-show="activeTab !== 'chat' && openChats.length > 0 && chatPanelMinimized" x-cloak

--- a/tests/test_dashboard_ui.py
+++ b/tests/test_dashboard_ui.py
@@ -744,3 +744,150 @@ class TestHomeRouting:
 
     def test_switch_home_tab_helper_present(self, app_js: str):
         assert "switchHomeTab(tabId)" in app_js
+
+
+# ── Phase 4: "What's new" tour for existing-fleet users ──────────
+
+
+class TestWhatsNewTourMarkup:
+    """The 3-step modal tour is hard-coded into the SPA template."""
+
+    def test_modal_block_is_present(self):
+        html = _read(_TEMPLATE)
+        assert 'data-testid="whats-new-modal"' in html
+
+    def test_modal_renders_only_when_step_not_zero(self):
+        html = _read(_TEMPLATE)
+        assert "whatsNewTour.step !== 0" in html
+
+    def test_modal_has_three_steps(self):
+        html = _read(_TEMPLATE)
+        for step in (1, 2, 3):
+            assert f"whatsNewTour.step === {step}" in html, (
+                f"missing whats-new step: {step}"
+            )
+
+    def test_modal_has_dialog_role_and_modal_aria(self):
+        html = _read(_TEMPLATE)
+        # role=dialog + aria-modal=true on the same element as the
+        # data-testid hook — required for screen readers.
+        assert re.search(
+            r'role="dialog"[^>]*?aria-modal="true"[^>]*?data-testid="whats-new-modal"'
+            r'|data-testid="whats-new-modal"[^>]*?role="dialog"',
+            html,
+        ), "whats-new modal missing role=dialog/aria-modal"
+
+    def test_step1_copy_present(self):
+        html = _read(_TEMPLATE)
+        assert "We&rsquo;ve simplified your dashboard" in html
+        assert "Skip" in html
+        assert "Show me" in html
+
+    def test_step2_copy_present(self):
+        html = _read(_TEMPLATE)
+        assert "Operator is one click away" in html
+        assert "talk to the Operator" in html
+
+    def test_step3_copy_present(self):
+        html = _read(_TEMPLATE)
+        assert "Approvals and notifications are in the top nav" in html
+        assert "Got it" in html
+
+    def test_skip_button_dismisses_tour(self):
+        html = _read(_TEMPLATE)
+        assert 'data-testid="whats-new-skip"' in html
+        assert "dismissWhatsNewTour(" in html
+
+    def test_primary_button_has_focus_target(self):
+        # Focus management: each step's primary advance button is
+        # auto-focused on entry (via querySelector in app.js).
+        html = _read(_TEMPLATE)
+        assert 'data-testid="whats-new-primary"' in html
+
+
+class TestWhatsNewTourJsState:
+    """Alpine handlers for the tour state machine."""
+
+    def test_tour_state_object_declared(self):
+        js = _read(_APP_JS)
+        assert "whatsNewTour: { step: 0 }" in js
+
+    def test_tour_handlers_declared(self):
+        js = _read(_APP_JS)
+        for handler in (
+            "_maybeStartWhatsNewTour()",
+            "startWhatsNewTour()",
+            "whatsNewTourNext()",
+            "whatsNewTourBack()",
+            "dismissWhatsNewTour(reason)",
+            "_completeWhatsNewTour(reason)",
+        ):
+            assert handler in js, f"missing tour handler: {handler}"
+
+    def test_tour_persists_seen_flag(self):
+        js = _read(_APP_JS)
+        # Seen flag freezes the tour after first completion / dismiss.
+        assert "olSeenWhatsNew" in js
+        assert "localStorage.setItem('olSeenWhatsNew', 'true')" in js
+
+    def test_tour_is_gated_on_existing_fleet(self):
+        js = _read(_APP_JS)
+        # Detection: agents.length > 0 (excluding operator).
+        # The detector reuses the same operator-exclusion pattern as
+        # the empty-fleet wizard.
+        assert "_maybeStartWhatsNewTour" in js
+        assert "fleetAgents.length === 0" in js
+
+    def test_tour_emits_locked_telemetry_events(self):
+        js = _read(_APP_JS)
+        for evt in (
+            "whats_new_tour_started",
+            "whats_new_tour_step",
+            "whats_new_tour_finished",
+        ):
+            assert f"'{evt}'" in js, f"missing tour telemetry event: {evt}"
+
+    def test_tour_handles_escape_key(self):
+        js = _read(_APP_JS)
+        # ESC dismisses the modal. Tab-trap is also wired here.
+        assert "e.key === 'Escape'" in js
+
+
+# ── Phase 4: wizard polish ───────────────────────────────────────
+
+
+class TestWizardPolish:
+    """Phase 4 refinements to the empty-fleet wizard."""
+
+    def test_progress_dots_present(self):
+        html = _read(_TEMPLATE)
+        assert 'data-testid="wizard-progress"' in html
+        # Four-dot indicator iterates over the four step ordinals.
+        assert "[0,1,2,3]" in html
+
+    def test_step_index_helper_declared(self):
+        js = _read(_APP_JS)
+        assert "wizardStepIndex()" in js
+
+    def test_wizard_skip_handler_tracks_reason(self):
+        js = _read(_APP_JS)
+        # The new skip path emits wizard_abandoned with reason='skip_link'
+        # so we can split deliberate skips from page-unload abandons.
+        assert "wizardSkip()" in js
+        assert "reason: 'skip_link'" in js
+
+    def test_building_step_has_skip_button(self):
+        html = _read(_TEMPLATE)
+        # Phase 4 added the skip-X to the building step (it was already
+        # on ask/confirming via wizardAbandon).
+        assert 'data-testid="wizard-skip-building"' in html
+        assert "wizardSkip()" in html
+
+    def test_first_output_has_quick_links(self):
+        html = _read(_TEMPLATE)
+        assert 'data-testid="wizard-quick-links"' in html
+        assert 'data-testid="wizard-link-team"' in html
+        assert 'data-testid="wizard-link-workplace"' in html
+        # The quick-links section keeps a "Got it, close" affordance
+        # that completes the wizard without changing tabs.
+        assert 'data-testid="wizard-continue"' in html


### PR DESCRIPTION
## Summary

**Phase 4** of the Board UX overhaul. Two changes:
1. **3-step "What's new" tour** for users with existing fleets seeing the new layout for the first time. Skippable, persists.
2. **Wizard polish** on top of Phase -1: progress dots, skip-X on building step, structured first-output card with quick-link chips.

This branch contains BOTH Phase -1 (PR #865's commit, cherry-picked) AND Phase 4. Either merges cleanly.

## "What's new" tour

**Detection logic** runs after every `fetchAgents` resolves. Fires when:
- Tour not already showing AND
- Empty-fleet wizard not active (mutually exclusive) AND
- `localStorage.olSeenWhatsNew !== 'true'` AND
- User has at least one non-Operator agent

On any exit path (completion, Skip, ESC, overlay click) → `localStorage.olSeenWhatsNew = 'true'`. Never re-shows.

### Three steps

| Step | Title | Body | Visual |
|---|---|---|---|
| 1 | We've simplified your dashboard | Take a quick tour? | — |
| 2 | Operator is one click away | Click the chat icon in the top-right from any page | Chat-bubble icon highlight |
| 3 | Approvals and notifications are in the top nav | Anything needing attention shows as red badge | Red `[3]` badge + bell icon |

Buttons: `[Skip]` text link on every step + primary action (`Show me` / `Next` / `Got it`).

### Telemetry events

- `whats_new_tour_started` — initial render
- `whats_new_tour_step` — Next/Back transitions (`{step, direction}`)
- `whats_new_tour_finished` — completion/dismiss (`{reason, lastStep}`)

Flows through existing `/api/telemetry` sink from Phase -1.

## Wizard polish

**Progress dots** — 4-dot indicator at top of every wizard card. Current step widened indigo; past steps emerald; future gray. Driven by `wizardStepIndex()` helper.

**Skip-X on building step** — was missing; now wired to `wizardSkip()` which emits `wizard_abandoned` with `reason: 'skip_link'`.

**Improved first-output card** — replaces the single "Continue" button with:
- ✅ Larger checkmark + bigger title
- 3 quick-link chips: "View team →" / "See what they're working on →" / "Got it, close"

**Confirming card** — kept existing approach (operator-text reading); full structured-plan parsing deferred (requires Operator-side schema changes out of scope here).

## Accessibility

- `role="dialog"` + `aria-modal="true"` on tour modal
- `aria-labelledby="whats-new-title"`
- Tab focus-trap in `_whatsNewTourKeyHandler`
- ESC dismisses
- Click-on-overlay dismisses
- Focus restored to previously-focused element on close
- Mobile: full-screen below 640px (`w-full h-full sm:h-auto sm:max-w-md`)

## Test plan

- [x] Tour modal renders for users with existing fleets
- [x] Tour does NOT render for empty fleet (wizard takes precedence)
- [x] Tour does NOT render after `olSeenWhatsNew = 'true'`
- [x] Skip / completion / ESC / overlay-click all persist
- [x] Wizard progress dots track current step
- [x] Wizard skip-X emits `wizard_abandoned`
- [x] First-output quick-link chips trigger correct navigation

**413 tests pass** across `test_dashboard.py` + `test_dashboard_telemetry.py` + `test_dashboard_ui.py` + `test_dashboard_workspace.py` + `test_dashboard_auth.py`. Ruff clean.

## Stats

3 files changed (Phase 4 commit `9bf4069`): +461 / -21.
- `app.js` +138 (state machine, detection, telemetry)
- `index.html` +176 (tour markup at lines 8026-8144 + wizard refinements)
- `test_dashboard_ui.py` +147 (20 new test cases)

LOC overshot the ~200 estimate because each polish bullet (progress dots, skip-X, first-output card, the 3-step modal) has its own DOM block. Logic surface is small; markup dominates.