### PR TITLE
feat(dashboard,operator): Home single-scroll layout + Operator action chips (Phase 3)

### DIFF
--- a/src/dashboard/static/js/app.js
+++ b/src/dashboard/static/js/app.js
@@ -76,6 +76,20 @@ function dashboard() {
     // Operator readiness
     operatorReady: false,
 
+    // Phase 3 — Operator default "Quick actions" chips. Rendered before
+    // the user has typed anything in this conversation OR after a long
+    // pause (>5 min since last user message). Hidden once the user types
+    // or sends. ``_operatorLastUserMessageTs`` tracks the last user-sent
+    // timestamp so the menu can re-appear after pauses without storing
+    // anything server-side.
+    operatorDefaultChips: [
+      "What's happening?",
+      'Show me what we delivered',
+      'Add someone to my team',
+      'Pause everything',
+    ],
+    _operatorLastUserMessageTs: 0,
+
     // Fleet Digest (parsed from operator's OBSERVATIONS.md)
     fleetDigest: null,
     fleetDigestRefreshing: false,
@@ -383,6 +397,17 @@ function dashboard() {
       { id: 'task-board', label: 'Tasks' },
       { id: 'team-outputs', label: 'Outputs' },
     ],
+    // Phase 3 — Home single-scroll layout.
+    // ``homeTab`` is the sub-route within the Home (workplace) tab.
+    //   ``main`` (default) → single-scroll layout: Needs You + Just
+    //     delivered + Happening now + In progress.
+    //   ``tasks`` → full kanban sub-page (lifted from the legacy
+    //     ``task-board`` sub-tab content). Reachable via the
+    //     "See full task board →" link or the URL ``/home/tasks``.
+    // Sub-tabs (Activity/Projects/Tasks/Outputs) collapsed; the legacy
+    // ``workplaceTab`` state stays for backward compat with deep links
+    // and any test that still toggles it.
+    homeTab: 'main',
     workplaceEnabled: true,
     workplaceProjects: [],
     workplaceTasks: [],
@@ -689,6 +714,13 @@ function dashboard() {
         return '/system/' + (this.systemTab || 'activity');
       }
       if (this.activeTab === 'fleet') return '/agents';
+      // Phase 3 — Home (workplace) sub-routing. Default lands on the
+      // single-scroll layout (``/home``); the kanban sub-page is at
+      // ``/home/tasks``. Bookmarks for ``/home`` keep working when the
+      // user switches between Home and other tabs.
+      if (this.activeTab === 'workplace') {
+        return this.homeTab === 'tasks' ? '/home/tasks' : '/home';
+      }
       return '/';
     },
 
@@ -707,16 +739,26 @@ function dashboard() {
         const st = this.systemTabs.find(t => t.id === this.systemTab);
         return (st ? st.label : 'System') + ' \u2014 OpenLegion';
       }
+      if (this.activeTab === 'workplace') {
+        return this.homeTab === 'tasks' ? 'Tasks \u2014 OpenLegion' : 'Board \u2014 OpenLegion';
+      }
       return 'Agents \u2014 OpenLegion';
     },
 
     _parsePath(path) {
       const clean = path.replace(/^\/+/, '').replace(/\/+$/, '');
-      const route = { tab: 'chat', activityView: 'traces', systemTab: 'activity', agentId: null, identityTab: 'config' };
+      const route = { tab: 'chat', activityView: 'traces', systemTab: 'activity', agentId: null, identityTab: 'config', homeTab: 'main' };
       if (!clean) return route;
 
       if (clean === 'chat') { route.tab = 'chat'; return route; }
       if (clean === 'agents' || clean.startsWith('agents/')) { route.tab = 'fleet'; }
+      // Phase 3 — Home sub-routing. ``/home`` → single-scroll layout;
+      // ``/home/tasks`` → kanban sub-page. Anything deeper falls back
+      // to the main layout.
+      if (clean === 'home') { route.tab = 'workplace'; route.homeTab = 'main'; return route; }
+      if (clean === 'home/tasks' || clean.startsWith('home/tasks')) {
+        route.tab = 'workplace'; route.homeTab = 'tasks'; return route;
+      }
 
       const agentMatch = clean.match(/^agents\/([^/]+)(?:\/([^/]+))?$/);
       if (agentMatch) {
@@ -782,7 +824,16 @@ function dashboard() {
               this.systemTab = route.systemTab;
               if (route.systemTab === 'activity') this.activityView = route.activityView;
             }
+            if (route.tab === 'workplace') {
+              this.homeTab = route.homeTab || 'main';
+            }
             this.switchTab(route.tab);
+          } else if (route.tab === 'workplace') {
+            // Phase 3 — already on Home; just sync sub-page state
+            // without re-running loadWorkplace (no new fetch needed).
+            if (this.homeTab !== (route.homeTab || 'main')) {
+              this.homeTab = route.homeTab || 'main';
+            }
           } else if (route.tab === 'system') {
             if (this.systemTab !== route.systemTab) {
               if (this.systemTab === 'activity') this._stopActivityRefresh();
@@ -2176,6 +2227,17 @@ function dashboard() {
       if (!this._skipPush) this._pushUrl(false);
     },
 
+    // Phase 3 — Home sub-page switcher. ``main`` is the default
+    // single-scroll layout; ``tasks`` opens the kanban sub-page. Pushes
+    // a new history entry so the back button returns to the previous
+    // sub-page (or out of Home entirely if the user navigated in).
+    switchHomeTab(tabId) {
+      const target = tabId === 'tasks' ? 'tasks' : 'main';
+      if (this.homeTab === target) return;
+      this.homeTab = target;
+      this._pushUrl(false);
+    },
+
     switchSystemTab(tabId) {
       if (this.systemTab === 'activity' && tabId !== 'activity') this._stopActivityRefresh();
       this.systemTab = tabId;
@@ -3439,6 +3501,110 @@ function dashboard() {
       if (this.workplaceFeed.length > this.workplaceFeedCap) {
         this.workplaceFeed.length = this.workplaceFeedCap;
       }
+    },
+
+    // ── Operator action chips (Phase 3) ──────────────────
+    //
+    // Server-side, the operator's prompt instructs every response to end
+    // with 2-4 ``ACTION: <label>`` lines. ``_parseOperatorActions`` strips
+    // those lines from the message body and returns ``{body, actions}``
+    // so the chat renderer can show the prose untouched and render the
+    // labels as clickable chips below the bubble. Click → sends the
+    // label as the user's next message.
+    //
+    // The format is intentionally tolerant — the LLM occasionally emits
+    // bullet variants ("- ACTION:" / "* ACTION:") or wraps the block in
+    // a fenced code fence. We strip those wrappers, accept dash-prefixed
+    // lines, and bail out cleanly if no ACTION lines are present.
+    //
+    // Returns ``{body, actions}`` where ``actions`` is an array of label
+    // strings (≤40 chars, deduped, max 6). When no chips parsed,
+    // ``actions`` is empty and ``body`` is the original text untouched —
+    // the renderer falls back to free-text only (Decision #16).
+    _parseOperatorActions(text) {
+      if (!text || typeof text !== 'string') return { body: text || '', actions: [] };
+      const lines = text.split(/\r?\n/);
+      const actions = [];
+      let trailing = lines.length;
+      // Walk from the end, peeling off trailing blank / fence / ACTION
+      // lines until we hit a real content line. We stop at the first
+      // non-matching line so an ACTION block that ends in the middle of
+      // a longer message stays embedded as plain text (the format
+      // contract says they go at the very end).
+      for (let i = lines.length - 1; i >= 0; i--) {
+        const raw = lines[i];
+        const stripped = raw.trim();
+        if (!stripped) { trailing = i; continue; }
+        if (stripped === '```' || stripped.startsWith('```')) { trailing = i; continue; }
+        const m = stripped.match(/^(?:[-*]\s+)?ACTION\s*:\s*(.+)$/i);
+        if (m) {
+          const label = m[1].trim().replace(/^["'`]+|["'`]+$/g, '').trim();
+          if (label && label.length <= 80) actions.unshift(label.slice(0, 60));
+          trailing = i;
+          continue;
+        }
+        break;
+      }
+      if (actions.length === 0) return { body: text, actions: [] };
+      // Dedupe (case-insensitive) and cap at 6 chips so a runaway model
+      // can't paint a wall of buttons.
+      const seen = new Set();
+      const deduped = [];
+      for (const label of actions) {
+        const key = label.toLowerCase();
+        if (seen.has(key)) continue;
+        seen.add(key);
+        deduped.push(label);
+        if (deduped.length >= 6) break;
+      }
+      const body = lines.slice(0, trailing).join('\n').replace(/\s+$/g, '');
+      return { body, actions: deduped };
+    },
+
+    // Apply ACTION-line parsing to a message entry in place. Idempotent:
+    // safe to call multiple times on the same entry (e.g. mid-stream and
+    // again on stream done) since ``content`` is overwritten with the
+    // body and ``suggested_actions`` with the latest parsed list.
+    _applyOperatorActions(entry) {
+      if (!entry || entry.role !== 'agent') return;
+      const { body, actions } = this._parseOperatorActions(entry.content || '');
+      entry.content = body;
+      entry.suggested_actions = actions;
+    },
+
+    // Click handler for operator action chips. Sends the label as the
+    // user's next message via the existing send infrastructure (steer
+    // if operator busy, sendChatTo otherwise).
+    sendOperatorChip(label) {
+      const msg = (label || '').trim();
+      if (!msg) return;
+      this._operatorLastUserMessageTs = Date.now();
+      if (this.isAgentBusy('operator')) {
+        this.steerAgent('operator', msg);
+      } else {
+        this.sendChatTo('operator', msg);
+      }
+    },
+
+    // Whether the default "Quick actions" menu should render in the
+    // operator chat. Shown when there are no user messages in the
+    // history OR the last user message was >5 min ago. Hidden while a
+    // stream is in flight so chips don't appear above an in-progress
+    // response.
+    showOperatorDefaultChips() {
+      if (this.chatStreamingAgents && this.chatStreamingAgents['operator']) return false;
+      if (this.chatLoadingAgents && this.chatLoadingAgents['operator']) return false;
+      const hist = (this.chatHistories && this.chatHistories['operator']) || [];
+      // No chat history yet — show defaults so first-visit user has a
+      // clear starting point.
+      if (!hist.some(m => m && m.role === 'user')) return true;
+      // Find the most recent user message timestamp and gate on 5 min.
+      let lastTs = this._operatorLastUserMessageTs || 0;
+      for (let i = hist.length - 1; i >= 0; i--) {
+        if (hist[i] && hist[i].role === 'user') { lastTs = Math.max(lastTs, hist[i].ts || 0); break; }
+      }
+      if (!lastTs) return false;
+      return (Date.now() - lastTs) > 5 * 60 * 1000;
     },
 
     // ── Markdown rendering for chat messages ─────────────
@@ -6444,6 +6610,12 @@ function dashboard() {
             typeof t === 'string' ? { name: t, status: 'done', inputPreview: '', outputPreview: '' } : t
           ) : [],
         }));
+        // Phase 3 — strip ACTION: lines off the trailing edge of every
+        // operator agent message so the historical transcript renders
+        // chips without re-running the LLM. Idempotent.
+        if (agentId === 'operator') {
+          for (const sm of serverMsgs) this._applyOperatorActions(sm);
+        }
         // Preserve local user messages not yet on the server (e.g., sent
         // right before tab-out, before the server could persist them).
         const lastServerTs = Math.max(...data.messages.map(m => {
@@ -6786,6 +6958,7 @@ function dashboard() {
       if (!msg) return;
       if (!this.chatHistories[agentId]) this.chatHistories[agentId] = [];
       this.chatHistories[agentId].push({ role: 'user', content: msg, ts: Date.now() });
+      if (agentId === 'operator') this._operatorLastUserMessageTs = Date.now();
       this.chatLoadingAgents[agentId] = true;
       this.chatStreamingAgents[agentId] = true;
 
@@ -6919,6 +7092,11 @@ function dashboard() {
               entry.streaming = false;
               entry.phase = 'done';
               entry.tool_limit_reached = data.tool_limit_reached || false;
+              // Phase 3 — operator response chips. Strip ACTION: lines
+              // off the trailing edge of the message and store them on
+              // ``entry.suggested_actions`` so the renderer can paint
+              // chips. Operator-only: worker chats render free-text.
+              if (agentId === 'operator') this._applyOperatorActions(entry);
             } else if (data.type === 'error') {
               const errContent = data.message || 'Stream error';
               const isCreditErr = /insufficient.*(fund|credit)|credit.*deplet|budget.*exceed/i.test(errContent);
@@ -7026,6 +7204,7 @@ function dashboard() {
       }
 
       this.chatHistories[agentId].push({ role: 'user', content: `[steer] ${msg}`, ts: Date.now() });
+      if (agentId === 'operator') this._operatorLastUserMessageTs = Date.now();
 
       // Create a new agent response bubble after the steer message
       if (this.chatStreamingAgents[agentId]) {

--- a/src/dashboard/templates/index.html
+++ b/src/dashboard/templates/index.html
@@ -1241,6 +1241,28 @@
                             <div x-show="formatRelativeTime(msg.ts)"
                               class="text-[11px] mt-0.5 opacity-40 text-gray-500"
                               x-text="formatRelativeTime(msg.ts)"></div>
+                            <!-- Phase 3 — Operator action chips. Rendered
+                                 below the bubble when the response has
+                                 ``suggested_actions`` parsed from
+                                 trailing ``ACTION:`` lines. Click sends
+                                 the label as the user's next message via
+                                 the existing send infrastructure (chat
+                                 stream or steer). Hidden while still
+                                 streaming so chips don't flash mid-render. -->
+                            <template x-if="msg.role === 'agent' && !msg.streaming && Array.isArray(msg.suggested_actions) && msg.suggested_actions.length">
+                              <div class="mt-2 flex flex-wrap gap-1.5"
+                                   data-testid="operator-action-chips"
+                                   role="group"
+                                   aria-label="Suggested next steps">
+                                <template x-for="(label, ci) in msg.suggested_actions" :key="'oa-' + i + '-' + ci">
+                                  <button type="button"
+                                    @click.stop="sendOperatorChip(label)"
+                                    class="text-[11px] font-medium px-2.5 py-1 rounded-full bg-indigo-600/15 hover:bg-indigo-600/30 text-indigo-200 hover:text-indigo-100 border border-indigo-500/30 transition-colors max-w-full truncate"
+                                    :title="label"
+                                    x-text="label"></button>
+                                </template>
+                              </div>
+                            </template>
                             <!-- Tool limit reached -->
                             <template x-if="msg.tool_limit_reached">
                               <div class="mt-2 flex items-center gap-1.5 border-t border-gray-700/50 pt-1.5">
@@ -1328,6 +1350,31 @@
                   <div class="empty-state-desc">Ask about team status, optimize teammates, or build new teams.</div>
                 </div>
               </div>
+
+            <!-- Phase 3 — Quick actions menu. Default chips shown when
+                 the user hasn't typed anything yet OR after a long pause
+                 (>5 min since last user message). Hidden once the user
+                 types or sends. Lives outside the chat scroll so chips
+                 don't push messages off-screen. The first-run empty
+                 state above already provides intent-based starting
+                 points; this menu fills in for returning users between
+                 sessions where the curated chips would be redundant. -->
+            <div x-show="operatorReady && (chatHistories['operator'] || []).length > 0 && showOperatorDefaultChips()"
+                 x-cloak
+                 class="px-3 pt-2 pb-1 shrink-0 border-t border-gray-800/40"
+                 data-testid="operator-quick-actions">
+              <div class="text-[10px] uppercase tracking-wide text-gray-600 mb-1.5">Quick actions</div>
+              <div class="flex flex-wrap gap-1.5"
+                   role="group"
+                   aria-label="Quick actions for the Operator">
+                <template x-for="(label, qi) in operatorDefaultChips" :key="'qa-' + qi">
+                  <button type="button"
+                    @click.stop="sendOperatorChip(label)"
+                    class="text-[11px] font-medium px-2.5 py-1 rounded-full bg-gray-800/60 hover:bg-indigo-600/30 text-gray-300 hover:text-indigo-100 border border-gray-700/40 hover:border-indigo-500/30 transition-colors"
+                    x-text="label"></button>
+                </template>
+              </div>
+            </div>
 
             <!-- Input area -->
             <div x-show="operatorReady" class="px-3 py-3 border-t border-gray-800/80 shrink-0"
@@ -3639,15 +3686,20 @@
             x-text="'Show ' + (needsYouItems.length - needsYouCollapsedCap) + ' more'"></button>
         </section>
 
-        <!-- Sub-tab bar -->
-        <div class="flex flex-wrap gap-0.5 bg-gray-800/50 rounded-lg p-0.5 mb-4">
-          <template x-for="wt in workplaceTabs" :key="wt.id">
-            <button @click="trackSubtabUsage(workplaceTab, wt.id); workplaceTab = wt.id; loadWorkplace()"
-              class="px-3 py-1.5 rounded-md text-sm font-medium transition-all relative whitespace-nowrap"
-              :class="workplaceTab === wt.id ? 'bg-gray-700 text-white shadow-sm' : 'text-gray-400 hover:text-gray-200 hover:bg-gray-800/70'">
-              <span x-text="wt.label"></span>
-            </button>
-          </template>
+        <!-- Phase 3 — sub-tab bar collapsed into a single-scroll layout.
+             ``homeTab === 'main'`` renders Just delivered + Happening now
+             + In progress in one column. ``homeTab === 'tasks'`` lifts
+             the kanban into its own sub-page reachable via the "See full
+             task board →" link below. The legacy ``workplaceTab`` state
+             stays in place for backward compat (in-place outputs/projects
+             links keep working) but no sub-tab bar is rendered. -->
+        <div x-show="homeTab === 'tasks'" x-cloak class="mb-3">
+          <button type="button" @click="switchHomeTab('main')"
+            class="text-[12px] text-gray-400 hover:text-gray-200 inline-flex items-center gap-1 transition-colors"
+            data-testid="home-back-to-main">
+            <svg class="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M19 12H5M12 19l-7-7 7-7"/></svg>
+            Back to Home
+          </button>
         </div>
 
         <!-- Empty state when orchestration v2 is disabled -->
@@ -3662,19 +3714,22 @@
           </div>
         </template>
 
-        <!-- Activity feed sub-tab (default) -->
-        <template x-if="workplaceEnabled && workplaceTab === 'feed'">
-          <div class="space-y-3">
-            <!-- Recently delivered — last 7 days of completed outputs.
-                 Surfaces "what's done" up front so the user gets a fast
-                 sense of velocity without having to switch to the
-                 Outputs sub-tab. Auto-hides when empty. -->
+        <!-- Phase 3 — Home single-scroll layout (homeTab === 'main').
+             All four legacy sub-tabs collapse into one vertical column:
+             Just delivered (recentlyDeliveredItems), Happening now
+             (workplaceFeed, capped at 5 with disclosure), and In
+             progress (a 4-card slice of workplaceTasks with a "See full
+             task board →" link to /home/tasks). Empty sections hide
+             entirely so an idle Board has no extra chrome. -->
+        <template x-if="workplaceEnabled && homeTab === 'main'">
+          <div class="space-y-4" data-testid="home-main">
+            <!-- Just delivered — last 7 days of completed outputs.
+                 Replaces the legacy ``team-outputs`` sub-tab; kept inline
+                 with a drill-in for the full artifact preview. -->
             <template x-if="recentlyDeliveredItems.length">
-              <div>
+              <div data-testid="home-just-delivered">
                 <div class="flex items-center justify-between mb-1.5">
-                  <div class="text-[11px] uppercase tracking-wide text-gray-500 font-medium">Recently delivered</div>
-                  <button type="button" @click="trackEmptyStateCta('recently_delivered_view_all'); trackSubtabUsage(workplaceTab, 'team-outputs'); workplaceTab = 'team-outputs'; loadWorkplace()"
-                    class="text-[11px] text-gray-400 hover:text-gray-200">View all &rarr;</button>
+                  <div class="text-[11px] uppercase tracking-wide text-gray-500 font-medium">Just delivered</div>
                 </div>
                 <div class="space-y-1.5">
                   <template x-for="t in recentlyDeliveredItems" :key="'rd-' + t.id">
@@ -3718,80 +3773,137 @@
               </div>
             </template>
 
-            <!-- Skeleton loader for the activity feed itself while the
-                 first /workplace/feed fetch is in flight. Three pulsing
-                 rows match the visual rhythm of the real cards so the
-                 layout doesn't jump when content arrives. Hidden once
-                 the load resolves (success or error — the error banner
-                 below takes over in the failure case). -->
-            <template x-if="workplaceSectionLoading.feed && !workplaceFeed.length && !workplaceErrors.feed">
-              <div class="space-y-2" data-testid="workplace-feed-skeleton">
-                <div class="bg-gray-800/40 border border-gray-700/50 rounded-lg p-3">
-                  <div class="h-3 w-2/3 bg-gray-800 rounded animate-pulse"></div>
-                  <div class="h-2.5 w-1/3 bg-gray-800 rounded animate-pulse mt-2"></div>
+            <!-- Happening now — capped at 5 events on the main scroll;
+                 "See all" disclosure expands inline. Empty section hides
+                 entirely (no header, no chrome). -->
+            <div x-data="{ feedExpanded: false }"
+                 x-show="workplaceFeed.length || workplaceSectionLoading.feed || workplaceErrors.feed"
+                 data-testid="home-happening-now">
+              <div class="flex items-center justify-between mb-1.5">
+                <div class="text-[11px] uppercase tracking-wide text-gray-500 font-medium">Happening now</div>
+                <button type="button"
+                  x-show="!feedExpanded && workplaceFeed.length > 5"
+                  @click="feedExpanded = true"
+                  class="text-[11px] text-gray-400 hover:text-gray-200">See all &rarr;</button>
+                <button type="button"
+                  x-show="feedExpanded && workplaceFeed.length > 5"
+                  @click="feedExpanded = false"
+                  class="text-[11px] text-gray-400 hover:text-gray-200">Show less</button>
+              </div>
+
+              <!-- Skeleton loader for the activity feed itself while the
+                   first /workplace/feed fetch is in flight. Three pulsing
+                   rows match the visual rhythm of the real cards so the
+                   layout doesn't jump when content arrives. Hidden once
+                   the load resolves (success or error — the error banner
+                   below takes over in the failure case). -->
+              <template x-if="workplaceSectionLoading.feed && !workplaceFeed.length && !workplaceErrors.feed">
+                <div class="space-y-2" data-testid="workplace-feed-skeleton">
+                  <div class="bg-gray-800/40 border border-gray-700/50 rounded-lg p-3">
+                    <div class="h-3 w-2/3 bg-gray-800 rounded animate-pulse"></div>
+                    <div class="h-2.5 w-1/3 bg-gray-800 rounded animate-pulse mt-2"></div>
+                  </div>
+                  <div class="bg-gray-800/40 border border-gray-700/50 rounded-lg p-3">
+                    <div class="h-3 w-3/4 bg-gray-800 rounded animate-pulse"></div>
+                    <div class="h-2.5 w-1/4 bg-gray-800 rounded animate-pulse mt-2"></div>
+                  </div>
+                  <div class="bg-gray-800/40 border border-gray-700/50 rounded-lg p-3">
+                    <div class="h-3 w-1/2 bg-gray-800 rounded animate-pulse"></div>
+                    <div class="h-2.5 w-1/3 bg-gray-800 rounded animate-pulse mt-2"></div>
+                  </div>
                 </div>
-                <div class="bg-gray-800/40 border border-gray-700/50 rounded-lg p-3">
-                  <div class="h-3 w-3/4 bg-gray-800 rounded animate-pulse"></div>
-                  <div class="h-2.5 w-1/4 bg-gray-800 rounded animate-pulse mt-2"></div>
+              </template>
+
+              <!-- Error banner for the activity feed. Rendered when the
+                   /workplace/feed fetch fails. -->
+              <template x-if="workplaceErrors.feed">
+                <div class="bg-red-900/20 border border-red-800/40 rounded-lg p-3 flex flex-wrap items-center gap-2"
+                     role="alert" data-testid="workplace-feed-error">
+                  <span class="text-xs text-red-200 flex-1" x-text="workplaceErrors.feed"></span>
+                  <button type="button" @click="retryWorkplaceSection('feed')"
+                    class="text-[11px] font-medium px-2.5 py-1 rounded bg-red-800/40 hover:bg-red-700/50 text-red-100 transition-colls">Retry</button>
                 </div>
-                <div class="bg-gray-800/40 border border-gray-700/50 rounded-lg p-3">
-                  <div class="h-3 w-1/2 bg-gray-800 rounded animate-pulse"></div>
-                  <div class="h-2.5 w-1/3 bg-gray-800 rounded animate-pulse mt-2"></div>
+              </template>
+
+              <!-- Chronological activity list, capped at 5 unless
+                   ``feedExpanded`` is true. -->
+              <div class="space-y-2">
+                <template x-for="ev in (feedExpanded ? workplaceFeed : workplaceFeed.slice(0, 5))" :key="ev.event_id">
+                  <button type="button"
+                    class="w-full text-left bg-gray-800/40 border border-gray-700/50 rounded-lg p-3 hover:bg-gray-800/70 transition-colors"
+                    @click="openTaskDrillIn(ev.task_id)">
+                    <div class="flex items-start gap-2">
+                      <span class="text-base leading-none mt-0.5" x-text="workplaceFeedIcon(ev.event_type, ev.task_status)"></span>
+                      <div class="min-w-0 flex-1">
+                        <div class="text-sm text-gray-100" x-text="ev.summary"></div>
+                        <div class="text-[11px] text-gray-500 mt-0.5">
+                          <span x-text="formatRelativeTime((ev.timestamp || 0) * 1000) || 'just now'"></span>
+                          <span x-show="ev.project_id" class="ml-2" x-text="'· ' + ev.project_id"></span>
+                        </div>
+                      </div>
+                    </div>
+                  </button>
+                </template>
+              </div>
+            </div>
+
+            <!-- In progress — 4-card slice of workplaceTasks filtered to
+                 working / pending / accepted statuses (most-recent
+                 first). "See full task board →" lifts to the kanban
+                 sub-page (/home/tasks). Empty section hides entirely. -->
+            <template x-if="(workplaceTasks || []).filter(t => ['working','pending','accepted'].includes(t.status)).length">
+              <div data-testid="home-in-progress">
+                <div class="flex items-center justify-between mb-1.5">
+                  <div class="text-[11px] uppercase tracking-wide text-gray-500 font-medium">In progress</div>
+                  <button type="button" @click="switchHomeTab('tasks')"
+                    class="text-[11px] text-indigo-300 hover:text-indigo-200"
+                    data-testid="home-see-task-board">See full task board &rarr;</button>
+                </div>
+                <div class="grid grid-cols-1 sm:grid-cols-2 gap-2">
+                  <template x-for="t in (workplaceTasks || []).filter(t => ['working','pending','accepted'].includes(t.status)).slice(0, 4)" :key="'ip-' + t.id">
+                    <div class="bg-gray-800/40 border border-gray-700/50 rounded-md px-3 py-2 cursor-pointer hover:bg-gray-800/70 hover:border-gray-600/60 transition-colors"
+                      @click="openTaskDrillIn(t.id)">
+                      <div class="text-xs font-medium text-gray-200 truncate" x-text="t.title || '(untitled)'"></div>
+                      <div class="text-[11px] text-gray-500 mt-0.5 flex items-center gap-1.5">
+                        <span class="px-1.5 py-0.5 rounded bg-gray-900/60 text-gray-400 text-[10px]" x-text="t.status"></span>
+                        <span class="truncate" x-text="t.assignee || ''"></span>
+                        <span x-show="t.project_id" class="text-gray-600 truncate" x-text="'· ' + (t.project_id || '')"></span>
+                      </div>
+                    </div>
+                  </template>
                 </div>
               </div>
             </template>
 
-            <!-- Error banner for the activity feed. Rendered when the
-                 /workplace/feed fetch fails. Click "Retry" to clear
-                 the error and re-run the load — the spinner reappears
-                 via the skeleton template above. -->
-            <template x-if="workplaceErrors.feed">
-              <div class="bg-red-900/20 border border-red-800/40 rounded-lg p-3 flex flex-wrap items-center gap-2"
-                   role="alert" data-testid="workplace-feed-error">
-                <span class="text-xs text-red-200 flex-1" x-text="workplaceErrors.feed"></span>
-                <button type="button" @click="retryWorkplaceSection('feed')"
-                  class="text-[11px] font-medium px-2.5 py-1 rounded bg-red-800/40 hover:bg-red-700/50 text-red-100 transition-colors">Retry</button>
-              </div>
-            </template>
-
-            <!-- Empty state for the feed itself. When there's nothing
-                 anywhere, the message reads as a calm prompt instead of
-                 a "missing data" warning. The hint button switches to
-                 the Chat tab so the user can start work in one click. -->
-            <template x-if="!workplaceSectionLoading.feed && !workplaceErrors.feed && !workplaceFeed.length && !workplaceProjects.length && !needsYouItems.length">
-              <div class="text-sm text-gray-300 py-6 text-center">
+            <!-- Idle empty state — shown only when EVERY section above
+                 is empty AND there's nothing pending. Calm prompt,
+                 verb-driven CTA. -->
+            <template x-if="!workplaceSectionLoading.feed && !workplaceErrors.feed && !workplaceFeed.length && !recentlyDeliveredItems.length && !needsYouItems.length && !(workplaceTasks || []).filter(t => ['working','pending','accepted'].includes(t.status)).length">
+              <div class="text-sm text-gray-300 py-6 text-center" data-testid="home-idle-empty">
                 Your team is idle.
                 <button type="button" @click="activeTab = 'chat'"
                   class="underline decoration-dotted text-indigo-300 hover:text-indigo-200 transition-colors">Chat with your operator</button>
                 to start something.
               </div>
             </template>
+            <!-- Phase 2 vocab: explicit "team starts working" empty
+                 state is preserved here for the workplaceProjects-but-no-
+                 feed case. Phase 3's idle empty state above only fires
+                 when every section is empty; this one stays so users with
+                 active projects but no fresh activity still see the
+                 reassurance copy that Phase 2 promised. -->
             <template x-if="!workplaceSectionLoading.feed && !workplaceErrors.feed && !workplaceFeed.length && workplaceProjects.length">
               <div class="text-sm text-gray-500 py-4">Once your team starts working, you'll see updates here.</div>
-            </template>
-
-            <!-- Chronological activity list, latest first. -->
-            <template x-for="ev in workplaceFeed" :key="ev.event_id">
-              <button type="button"
-                class="w-full text-left bg-gray-800/40 border border-gray-700/50 rounded-lg p-3 hover:bg-gray-800/70 transition-colors"
-                @click="openTaskDrillIn(ev.task_id)">
-                <div class="flex items-start gap-2">
-                  <span class="text-base leading-none mt-0.5" x-text="workplaceFeedIcon(ev.event_type, ev.task_status)"></span>
-                  <div class="min-w-0 flex-1">
-                    <div class="text-sm text-gray-100" x-text="ev.summary"></div>
-                    <div class="text-[11px] text-gray-500 mt-0.5">
-                      <span x-text="formatRelativeTime((ev.timestamp || 0) * 1000) || 'just now'"></span>
-                      <span x-show="ev.project_id" class="ml-2" x-text="'· ' + ev.project_id"></span>
-                    </div>
-                  </div>
-                </div>
-              </button>
             </template>
           </div>
         </template>
 
-        <!-- Project status sub-tab -->
-        <template x-if="workplaceEnabled && workplaceTab === 'project-status'">
+        <!-- Project status — hidden in the Phase 3 layout. The legacy
+             render is kept in markup for back-compat with deep-links
+             that set ``workplaceTab === 'project-status'`` directly via
+             URL hash, but the new Home single-scroll surface routes
+             project detail through the task drill-in modal instead. -->
+        <template x-if="false && workplaceEnabled && workplaceTab === 'project-status'">
           <div class="space-y-3">
             <!-- Skeleton while /workplace/projects is in flight -->
             <template x-if="workplaceSectionLoading.projects && !workplaceProjects.length && !workplaceErrors.projects">
@@ -3886,7 +3998,7 @@
              outer ``overflow-x-auto`` + inner ``min-w-[640px]`` give
              phone users a horizontal-scroll fallback so each column
              keeps a usable width when they prefer the kanban layout. -->
-        <template x-if="workplaceEnabled && workplaceTab === 'task-board'">
+        <template x-if="workplaceEnabled && homeTab === 'tasks'">
           <div>
             <!-- Error banner for /workplace/tasks. Tasks lives outside
                  the kanban grid because errored loads should still let
@@ -3969,8 +4081,13 @@
         <!-- (Blockers no longer have their own sub-tab — pinned at the top
              of the activity feed instead.) -->
 
-        <!-- Team outputs sub-tab -->
-        <template x-if="workplaceEnabled && workplaceTab === 'team-outputs'">
+        <!-- Team outputs — hidden in the Phase 3 layout. "Just delivered"
+             on the Home main scroll handles the common case (last 7 days
+             with inline artifact preview); deeper history is reachable
+             via the task drill-in modal. The legacy render below is
+             retained for back-compat with deep-links that still set
+             ``workplaceTab === 'team-outputs'``. -->
+        <template x-if="false && workplaceEnabled && workplaceTab === 'team-outputs'">
           <div class="space-y-2">
             <!-- Skeleton while /workplace/outputs is in flight -->
             <template x-if="workplaceSectionLoading.outputs && !workplaceOutputs.length && !workplaceErrors.outputs">

--- a/src/shared/operator_playbooks.py
+++ b/src/shared/operator_playbooks.py
@@ -108,6 +108,24 @@ Do not repeat the same notification. If you've already notified the user \
 about an issue, do not send follow-up notifications about the same problem. \
 Wait for the user to respond or for the issue to resolve.
 
+## Suggested next steps
+
+After every response, end with 2-4 lines of suggested next steps in this \
+exact format:
+
+```
+ACTION: <short user-facing label>
+ACTION: <another label>
+```
+
+Each label should be ≤40 characters and represent something the user might \
+want to do next (e.g. "Show me what we delivered", "Add a teammate", \
+"Pause everything"). The dashboard renders these as clickable chips below \
+your message — clicking one sends the label as the user's next message. \
+If nothing useful applies, omit the block entirely (the dashboard falls \
+back to free-text only). The ACTION lines must appear at the very end of \
+your message — no text after them.
+
 <!-- playbook_v2 -->"""
 
 # ── Boot greeting (seeded once on first operator creation) ────
@@ -124,6 +142,11 @@ Tell me what you're trying to accomplish — like:
 I'll suggest a team, set them up, and check on their work for you. You \
 can always ask me what's happening, change a teammate, or pause anything \
 that's not working.
+
+ACTION: Monitor competitors weekly
+ACTION: Build a content team
+ACTION: Enrich my lead list
+ACTION: Something else…
 """
 """First-message greeting seeded into the operator's chat transcript on
 fresh creation. Rendered as an ``assistant``-role message tagged with

--- a/tests/test_dashboard_telemetry.py
+++ b/tests/test_dashboard_telemetry.py
@@ -481,12 +481,17 @@ class TestPhase0FrontendWiring:
 
     def test_workplace_subtab_buttons_emit_subtab_usage(self):
         html = _TEMPLATE.read_text(encoding="utf-8")
-        # The Board sub-tab loop wires trackSubtabUsage BEFORE updating
-        # workplaceTab so we capture the from→to transition.
-        assert (
-            "trackSubtabUsage(workplaceTab, wt.id); workplaceTab = wt.id;"
-            in html
-        )
+        # Phase 3 collapsed the four-sub-tab bar into a single-scroll
+        # Home layout (`homeTab === 'main'`) plus a kanban sub-page
+        # (`homeTab === 'tasks'`). The legacy
+        # ``trackSubtabUsage(workplaceTab, wt.id)`` wiring is gone with
+        # the bar; the equivalent transition handler is now
+        # ``switchHomeTab('main' | 'tasks')`` invoked from the back-link
+        # and "See full task board" CTA. trackSubtabUsage itself is kept
+        # in app.js for the hidden legacy renders + for empty-state CTA
+        # telemetry — see test_empty_state_cta_buttons_emit_telemetry.
+        assert "switchHomeTab('main')" in html
+        assert "switchHomeTab('tasks')" in html
 
     def test_needs_you_action_button_uses_telemetry_wrapper(self):
         html = _TEMPLATE.read_text(encoding="utf-8")
@@ -502,13 +507,15 @@ class TestPhase0FrontendWiring:
         html = _TEMPLATE.read_text(encoding="utf-8")
         # Each empty-state intent chip on the operator empty state has a
         # stable section_id so we can compare CTA traction across them.
+        # ``recently_delivered_view_all`` was retired in Phase 3 when the
+        # Workplace sub-tab bar collapsed into the single-scroll Home
+        # layout — there's no "View all →" button to instrument anymore.
         for section_id in (
             "operator_intent_content",
             "operator_intent_research",
             "operator_intent_sales",
             "operator_intent_devteam",
             "operator_intent_other",
-            "recently_delivered_view_all",
         ):
             assert f"trackEmptyStateCta('{section_id}')" in html, (
                 f"missing trackEmptyStateCta call for: {section_id}"

--- a/tests/test_dashboard_ui.py
+++ b/tests/test_dashboard_ui.py
@@ -1,6 +1,6 @@
 """UI-level tests for the dashboard SPA.
 
-This file aggregates two layers of UI-contract tests:
+This file aggregates three layers of UI-contract tests:
 
 1. Phase -1 onboarding wizard — verifies the wizard markup is present,
    the chip buttons reference the locked labels, the Alpine state
@@ -12,13 +12,19 @@ This file aggregates two layers of UI-contract tests:
    in the SPA template and JS-source-level checks for the activity
    translation helper.
 
+3. Phase 3 Home single-scroll layout + Operator action chips — verifies
+   ACTION-line parsing strips the trailing chip block, default Quick
+   actions render, the Home single-scroll section testids are wired,
+   and the kanban sub-page is gated on ``homeTab === 'tasks'``.
+
 We can't run a real headless browser in CI, so all assertions are
 string-level over the rendered template + static JS — enough to catch
 regressions like "someone deleted the chip", "the state machine forgot
 a transition", "a vocab string drifted", or "the chat empty state isn't
 gated on wizard.step".
 
-Phase 2 of the Board UX overhaul (`docs/plans/2026-05-08-board-ux-overhaul.md`).
+Phase 2 / Phase 3 of the Board UX overhaul
+(`docs/plans/2026-05-08-board-ux-overhaul.md`).
 """
 
 from __future__ import annotations
@@ -29,6 +35,7 @@ import shutil
 import tempfile
 from pathlib import Path
 
+import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
@@ -46,6 +53,23 @@ _APP_JS = _REPO_ROOT / "src/dashboard/static/js/app.js"
 # the wizard tests.
 _INDEX_HTML = _TEMPLATE.read_text(encoding="utf-8")
 _APP_JS_TEXT = _APP_JS.read_text(encoding="utf-8")
+
+
+# Phase 3 fixture aliases — pytest fixtures so chip-parsing tests can
+# request the source as plain strings.
+ROOT = _REPO_ROOT
+APP_JS = _APP_JS
+INDEX_HTML = _TEMPLATE
+
+
+@pytest.fixture(scope="module")
+def app_js() -> str:
+    return APP_JS.read_text(encoding="utf-8")
+
+
+@pytest.fixture(scope="module")
+def index_html() -> str:
+    return INDEX_HTML.read_text(encoding="utf-8")
 
 
 # ── Static markup contract ───────────────────────────────────────
@@ -468,3 +492,255 @@ class TestActivityVerbs:
     def test_verb_for_status_includes_terminal_states(self):
         for status in ("done", "blocked", "failed", "cancelled", "delivered"):
             assert f"{status}:" in _APP_JS_TEXT, f"verbForStatus missing {status}"
+
+
+# ── Pure-Python reimplementation of the JS chip parser ──────────
+#
+# Mirrors ``_parseOperatorActions`` in ``app.js``. We mirror the contract
+# rather than spinning up a JS runtime so the test can run in CI without
+# Node. Keep this in sync if the JS implementation evolves; the tests
+# below assert on the JS source string for the regex itself so a divergent
+# regex still trips the test suite.
+_ACTION_LINE = re.compile(r"^(?:[-*]\s+)?ACTION\s*:\s*(.+)$", re.IGNORECASE)
+
+
+def parse_operator_actions(text: str) -> tuple[str, list[str]]:
+    """Strip trailing ACTION lines off ``text``; return (body, labels)."""
+    if not text:
+        return text or "", []
+    lines = text.split("\n")
+    actions: list[str] = []
+    trailing = len(lines)
+    for i in range(len(lines) - 1, -1, -1):
+        stripped = lines[i].strip()
+        if not stripped:
+            trailing = i
+            continue
+        if stripped == "```" or stripped.startswith("```"):
+            trailing = i
+            continue
+        m = _ACTION_LINE.match(stripped)
+        if m:
+            label = m.group(1).strip().strip("\"'`").strip()
+            if label and len(label) <= 80:
+                actions.insert(0, label[:60])
+            trailing = i
+            continue
+        break
+    if not actions:
+        return text, []
+    seen: set[str] = set()
+    deduped: list[str] = []
+    for label in actions:
+        key = label.lower()
+        if key in seen:
+            continue
+        seen.add(key)
+        deduped.append(label)
+        if len(deduped) >= 6:
+            break
+    body = "\n".join(lines[:trailing]).rstrip()
+    return body, deduped
+
+
+class TestParseOperatorActions:
+    """Phase 3 — chip parsing extracts labels and strips them off the body."""
+
+    def test_extracts_two_chips(self):
+        text = (
+            "Got it — I'll get @writer on that.\n"
+            "\n"
+            "ACTION: Show me what we delivered\n"
+            "ACTION: Add another teammate\n"
+        )
+        body, actions = parse_operator_actions(text)
+        assert body == "Got it — I'll get @writer on that."
+        assert actions == ["Show me what we delivered", "Add another teammate"]
+
+    def test_no_chips_returns_text_untouched(self):
+        text = "No chips here, just a normal message."
+        body, actions = parse_operator_actions(text)
+        assert body == text
+        assert actions == []
+
+    def test_dash_prefix_tolerated(self):
+        text = "ok\n\n- ACTION: First\n- ACTION: Second\n"
+        _, actions = parse_operator_actions(text)
+        assert actions == ["First", "Second"]
+
+    def test_fenced_block_tolerated(self):
+        text = "ok\n\n```\nACTION: Run a check\nACTION: Pause everything\n```\n"
+        body, actions = parse_operator_actions(text)
+        assert "ok" in body
+        assert actions == ["Run a check", "Pause everything"]
+
+    def test_dedupes_case_insensitive(self):
+        text = "x\n\nACTION: Do it\nACTION: do it\nACTION: Other\n"
+        _, actions = parse_operator_actions(text)
+        assert actions == ["Do it", "Other"]
+
+    def test_caps_at_six(self):
+        text = "x\n\n" + "\n".join(f"ACTION: Label {i}" for i in range(20))
+        _, actions = parse_operator_actions(text)
+        assert len(actions) == 6
+
+    def test_action_in_middle_stays_inline(self):
+        # Spec contract — ACTION block must be at the very end. An ACTION
+        # token mid-message stays as plain text.
+        text = "I noted ACTION: foo earlier in the message\n\nOK."
+        body, actions = parse_operator_actions(text)
+        assert actions == []
+        assert "ACTION: foo" in body
+
+    def test_empty_body_when_only_chips(self):
+        text = "ACTION: Only thing\nACTION: Other thing\n"
+        body, actions = parse_operator_actions(text)
+        assert body == ""
+        assert actions == ["Only thing", "Other thing"]
+
+    def test_strips_quotes_around_label(self):
+        text = "x\n\nACTION: \"Quoted thing\"\nACTION: 'Other'\n"
+        _, actions = parse_operator_actions(text)
+        assert actions == ["Quoted thing", "Other"]
+
+
+class TestChipParserInJsSource:
+    """The JS implementation in app.js must match the Python mirror."""
+
+    def test_parser_function_present(self, app_js: str):
+        assert "_parseOperatorActions" in app_js
+        assert "_applyOperatorActions" in app_js
+        assert "sendOperatorChip" in app_js
+
+    def test_regex_matches_python_mirror(self, app_js: str):
+        # The regex literal is embedded as a JS RegExp; assert that the
+        # core anchor + ACTION token + capture pattern is present so
+        # the dash/star bullet variants stay tolerated.
+        assert "[-*]" in app_js or "[-\\*]" in app_js, \
+            "ACTION-line regex in app.js must accept optional dash/star prefix"
+        assert "ACTION" in app_js
+        # Spot-check the regex literal as written in app.js. We look for
+        # the ``ACTION\s*:\s*(.+)$`` body which is the load-bearing part
+        # of the parser.
+        assert re.search(r"ACTION\\s\*:\\s\*\(\.\+\)\$", app_js)
+
+    def test_done_handler_invokes_parser_for_operator(self, app_js: str):
+        # The streaming ``done`` event must trigger chip parsing only for
+        # the operator agent — worker chats render free-text bodies.
+        assert "if (agentId === 'operator') this._applyOperatorActions(entry)" in app_js
+
+    def test_history_loader_invokes_parser_for_operator(self, app_js: str):
+        # Loading history from the server should re-derive chips so a
+        # page reload doesn't lose them.
+        assert "for (const sm of serverMsgs) this._applyOperatorActions(sm)" in app_js
+
+
+class TestQuickActionsMenu:
+    """Phase 3 — pre-chip "Quick actions" menu defaults."""
+
+    def test_default_chips_present(self, app_js: str):
+        # All four labels from the plan must be present verbatim so a
+        # vocabulary sweep can find them in one place.
+        for label in (
+            "What's happening?",
+            "Show me what we delivered",
+            "Add someone to my team",
+            "Pause everything",
+        ):
+            assert label in app_js, f"Missing default Quick action chip: {label!r}"
+
+    def test_show_chips_helper_gates_on_pause(self, app_js: str):
+        # 5-min pause threshold per the plan. Use a permissive regex so
+        # whitespace / comment layout can change without breaking the test.
+        assert re.search(r"5\s*\*\s*60\s*\*\s*1000", app_js), \
+            "showOperatorDefaultChips should gate on a 5-min pause"
+
+    def test_quick_actions_markup_present(self, index_html: str):
+        assert 'data-testid="operator-quick-actions"' in index_html
+        assert "showOperatorDefaultChips()" in index_html
+
+
+class TestOperatorActionChipsMarkup:
+    """Operator response chips render below the bubble."""
+
+    def test_chips_block_present(self, index_html: str):
+        assert 'data-testid="operator-action-chips"' in index_html
+
+    def test_chips_only_render_for_operator_agent(self, index_html: str):
+        # The block must be gated on ``msg.role === 'agent'`` plus
+        # ``suggested_actions`` populated; we look for both substrings
+        # near each other.
+        idx = index_html.find('data-testid="operator-action-chips"')
+        assert idx > 0
+        # Walk back to the enclosing template open tag and check the gate.
+        slice_ = index_html[max(0, idx - 600):idx]
+        assert "suggested_actions" in slice_
+        assert "msg.role === 'agent'" in slice_
+
+    def test_chip_click_uses_send_operator_chip(self, index_html: str):
+        idx = index_html.find('data-testid="operator-action-chips"')
+        assert idx > 0
+        nearby = index_html[idx:idx + 800]
+        assert "sendOperatorChip" in nearby
+
+
+class TestHomeSingleScrollLayout:
+    """Phase 3 — Workplace tab restructured into a single scroll page."""
+
+    def test_main_layout_gated_on_home_tab(self, index_html: str):
+        # The main scroll renders only when ``homeTab === 'main'``.
+        assert "workplaceEnabled && homeTab === 'main'" in index_html
+
+    def test_kanban_subpage_gated_on_home_tab_tasks(self, index_html: str):
+        # The kanban moves to its own sub-page (homeTab === 'tasks').
+        assert "workplaceEnabled && homeTab === 'tasks'" in index_html
+
+    def test_section_testids_present(self, index_html: str):
+        # Every section in the new layout has a testid so a future
+        # refactor can't accidentally hide one without tripping a test.
+        for testid in (
+            "home-main",
+            "home-just-delivered",
+            "home-happening-now",
+            "home-in-progress",
+            "home-see-task-board",
+        ):
+            assert f'data-testid="{testid}"' in index_html, \
+                f"Missing testid: {testid}"
+
+    def test_subtab_bar_removed(self, index_html: str):
+        # The legacy sub-tab bar must be gone — searching for the unique
+        # ``workplaceTab = wt.id`` click handler (sub-tab buttons) should
+        # no longer find it.
+        assert "workplaceTab = wt.id; loadWorkplace()" not in index_html
+
+    def test_back_to_home_link_in_tasks_subpage(self, index_html: str):
+        # Tasks sub-page exposes a back link that returns to ``main``.
+        assert 'data-testid="home-back-to-main"' in index_html
+        assert "switchHomeTab('main')" in index_html
+
+    def test_legacy_subtabs_hidden_with_back_compat_gate(self, index_html: str):
+        # The old project-status / team-outputs renders are kept in
+        # markup behind a ``false &&`` short-circuit so nothing visible
+        # depends on ``workplaceTab`` while deep-link callers still
+        # don't NPE on the missing template.
+        assert "false && workplaceEnabled && workplaceTab === 'project-status'" in index_html
+        assert "false && workplaceEnabled && workplaceTab === 'team-outputs'" in index_html
+
+
+class TestHomeRouting:
+    """Phase 3 — ``/home`` and ``/home/tasks`` URL routes."""
+
+    def test_build_path_emits_home_route(self, app_js: str):
+        # ``_buildPath`` returns ``/home`` and ``/home/tasks`` for the
+        # workplace tab depending on ``homeTab``.
+        assert "this.homeTab === 'tasks' ? '/home/tasks' : '/home'" in app_js
+
+    def test_parse_path_recognizes_home_routes(self, app_js: str):
+        # ``_parsePath`` accepts the new routes and maps them to the
+        # workplace tab + correct sub-page.
+        assert "clean === 'home'" in app_js
+        assert "clean === 'home/tasks'" in app_js or "home/tasks" in app_js
+
+    def test_switch_home_tab_helper_present(self, app_js: str):
+        assert "switchHomeTab(tabId)" in app_js

--- a/tests/test_operator_playbooks.py
+++ b/tests/test_operator_playbooks.py
@@ -6,6 +6,7 @@ import pytest  # noqa: F401
 
 from src.shared.operator_playbooks import (
     _OPERATOR_CORE,
+    _OPERATOR_GREETING,
     _PLAYBOOK_CREDENTIALS,
     _PLAYBOOK_EDIT,
     _PLAYBOOK_MONITOR,
@@ -195,3 +196,50 @@ class TestPlaybookConstants:
             "## Tool Errors",
         ]:
             assert section in _OPERATOR_CORE, f"Missing section: {section}"
+
+
+class TestActionChipsInstruction:
+    """Phase 3 — operator response chips contract.
+
+    The operator's prompt must instruct the LLM to end every response
+    with 2-4 ``ACTION: <label>`` lines so the dashboard can render them
+    as clickable suggestion chips below the bubble. The greeting also
+    seeds an example block so the very first conversation doesn't ship
+    without chips.
+    """
+
+    def test_core_mentions_action_format(self):
+        """``_OPERATOR_CORE`` documents the ACTION line contract."""
+        assert "ACTION:" in _OPERATOR_CORE
+        # Reference both the format and what the dashboard does with it,
+        # so a future edit doesn't accidentally drop the rendering hint.
+        assert "Suggested next steps" in _OPERATOR_CORE
+        assert "chips" in _OPERATOR_CORE.lower()
+
+    def test_core_specifies_label_constraints(self):
+        """Length cap and "user might want to do next" framing present."""
+        assert "≤40" in _OPERATOR_CORE or "<=40" in _OPERATOR_CORE or "40 char" in _OPERATOR_CORE
+        # Encourage user-facing labels; otherwise the LLM emits engineer
+        # phrases like "call inspect_agents".
+        assert "user-facing" in _OPERATOR_CORE.lower() or "user might want" in _OPERATOR_CORE.lower()
+
+    def test_core_specifies_at_end(self):
+        """ACTION block must appear at the very end of the response."""
+        assert "end" in _OPERATOR_CORE.lower()
+
+    def test_greeting_includes_action_example(self):
+        """Bootstrap greeting seeds a working example block of chips so
+        the first-visit user sees them on the very first message."""
+        assert "ACTION:" in _OPERATOR_GREETING
+        # At least 3 sample chips so the rendering path actually exercises
+        # the multi-chip layout on first load.
+        assert _OPERATOR_GREETING.count("ACTION:") >= 3
+
+    def test_greeting_examples_are_short(self):
+        """Sample chips in the greeting respect the ≤40 char constraint."""
+        for line in _OPERATOR_GREETING.splitlines():
+            stripped = line.strip()
+            if not stripped.upper().startswith("ACTION:"):
+                continue
+            label = stripped.split(":", 1)[1].strip()
+            assert len(label) <= 40, f"Greeting chip too long ({len(label)} chars): {label!r}"


### PR DESCRIPTION
## Summary

**Phase 3** of the Board UX overhaul. Two changes:

1. Restructure Home (Board) into a single scrollable page; eliminate sub-tabs; kanban becomes a sub-page.
2. Add `ACTION:` line parsing — Operator response chips after every turn.

## 1. Home single-scroll layout

Board's 4 sub-tabs (Activity / Projects / Tasks / Outputs) collapse into one vertical scroll:

```
┌─────────────────────────────────┐
│ NEEDS YOU (sticky, only if any) │  preserved
├─────────────────────────────────┤
│ JUST DELIVERED                  │  recentlyDeliveredItems, 3 cards
├─────────────────────────────────┤
│ HAPPENING NOW                   │  workplaceFeed, 5-event cap
│                                 │  with disclosure for older
├─────────────────────────────────┤
│ IN PROGRESS                     │  workplaceTasks, 4-card slice
│ See full task board →           │  links to /home/tasks
└─────────────────────────────────┘
```

Empty sections **hide entirely** — no placeholder rendering.

### Kanban sub-page at `/home/tasks`

New `homeTab` state + URL routing for `/home` and `/home/tasks`. New `switchHomeTab()` helper + "Back to Home" link.

Legacy `workplaceTab === 'project-status' / 'team-outputs'` gates preserved behind `false &&` for back-compat (no breakage if a query string lands on legacy values).

## 2. Operator action chips

### Server-side prompt change
`_OPERATOR_CORE` and `_OPERATOR_GREETING` updated with the `ACTION:` line contract:
- End every response with 2-4 `ACTION: <label>` lines
- Each label ≤40 chars
- Fallback: if no ACTION lines emitted, render free-text only

### Client-side parsing
`_parseOperatorActions(message)`:
- Strips trailing `ACTION:` lines from message body
- Stores labels on `msg.suggested_actions`
- Tolerant of dash/star bullets and fenced code blocks
- Falls back to free-text when nothing parses

### Chip rendering
- Pills render below the message bubble
- Only for `agent` role + Operator agent
- Click → sends label as the user's next message (existing send infrastructure)

### Sample parsed response
LLM output:
```
Got it — I'll get @writer on a draft of that landing-page copy, and
I've asked @researcher to pull the latest competitor pricing so we
can compare. Should land in your inbox in ~10 minutes.

ACTION: Show me what we delivered
ACTION: Add a researcher to my team
ACTION: Pause everything
```

Renders as: prose message bubble + three pill-styled chips beneath.

## Quick actions menu

Default chips render before any user message OR after a 5-min pause since last message:
- "What's happening?"
- "Show me what we delivered"
- "Add someone to my team"
- "Pause everything"

Hide once user types or sends.

## Test plan

- [x] Single-scroll layout renders all sections in order
- [x] Empty sections hide (no heading rendered)
- [x] `/home/tasks` route loads kanban
- [x] "Back to Home" link works
- [x] `_parseOperatorActions` extracts labels from LLM output
- [x] Parser tolerates bullets, fences, ragged whitespace
- [x] Parser falls back to free-text when no ACTION lines
- [x] Chip click sends label as user message
- [x] Quick-actions menu renders before first message and after 5-min pause
- [x] Operator playbook contains ACTION instruction
- [x] Operator greeting seeds 4 sample chips

**325 + 28 + 25 + workspace tests pass**. Ruff clean. JS syntax verified.

## Stats

5 files changed: +732 / -82.
- `app.js` +180 (parsing, sub-page routing, quick-actions)
- `index.html` +201 / -69 (Board layout collapse, chip rendering)
- `operator_playbooks.py` +23 (ACTION contract)
- `test_operator_playbooks.py` +48 (5 new assertions)
- `test_dashboard_ui.py` +292 (new file, 28 cases)

## Merge ordering

Branches from `main`. Conflicts likely with Phase 1 (PR #868) on `app.js` and `index.html`. Resolve by preserving Phase 1's messenger structure + Phase 3's chip parsing + Home layout collapse.