### PR TITLE
fix(dashboard,operator): wizard race + timeout terminal state + bootstrap greeting dedup (PR-A)

### DIFF
--- a/src/dashboard/static/js/app.js
+++ b/src/dashboard/static/js/app.js
@@ -1776,7 +1776,15 @@ function dashboard() {
 
     checkOperatorReady() {
       const op = this.agents.find(a => a.id === 'operator');
+      const wasReady = this.operatorReady;
       this.operatorReady = op && op.health_status === 'healthy';
+      // Fix #4 — when operator transitions unhealthy → healthy and the
+      // user is still in a first-visit state, retry starting the
+      // wizard. Without this, an operator that boots slowly (e.g.
+      // first start) would have skipped wizard kickoff at fetchAgents.
+      if (!wasReady && this.operatorReady) {
+        try { this._maybeStartWizard(); } catch (_) { /* ignore */ }
+      }
     },
 
     // ── Phase -1 onboarding wizard ───────────────────────
@@ -1790,13 +1798,20 @@ function dashboard() {
     // ``wizard_abandoned``) so we can answer the activation hypothesis.
 
     _wizardLoad() {
+      // Backwards-compatible — unknown step values from older versions
+      // (or hand-edited localStorage) reset to ``idle`` rather than
+      // wedging the UI in a state with no rendering branch.
+      const KNOWN_STEPS = new Set([
+        'idle', 'ask', 'confirming', 'building', 'first-output', 'build_failed',
+      ]);
       try {
         const raw = localStorage.getItem('ol_wizard');
         if (!raw) return;
         const parsed = JSON.parse(raw);
         if (parsed && typeof parsed === 'object' && typeof parsed.step === 'string') {
+          const step = KNOWN_STEPS.has(parsed.step) ? parsed.step : 'idle';
           this.wizard = {
-            step: parsed.step || 'idle',
+            step: step,
             plan: parsed.plan || null,
             startedAt: Number(parsed.startedAt) || 0,
             lastChip: parsed.lastChip || '',
@@ -2082,22 +2097,57 @@ function dashboard() {
     },
 
     _wizardStartBuildPolling() {
+      // Stability-based detection: a multi-agent template is created
+      // slot-by-slot, so a naive ``length >= 1`` check fires the success
+      // card prematurely while the rest of the team is still being
+      // provisioned. We require the non-operator fleet to be NON-EMPTY
+      // and COUNT-STABLE for at least 10 seconds before declaring the
+      // build done. Each new agent resets the stability window.
       if (this._wizardBuildPoll) clearInterval(this._wizardBuildPoll);
       const start = Date.now();
+      let stableSince = 0;
+      let lastCount = 0;
       this._wizardBuildPoll = setInterval(() => {
         const fleetAgents = this.agents.filter(a => a && a.id !== 'operator');
-        if (fleetAgents.length >= 1) {
+        const count = fleetAgents.length;
+        const now = Date.now();
+        if (count === 0) {
+          // No fleet yet — keep waiting and reset the stability window.
+          stableSince = 0;
+          lastCount = 0;
+        } else if (count === lastCount) {
+          // Count unchanged — start (or continue) the stability window.
+          if (!stableSince) stableSince = now;
+          if (now - stableSince >= 10_000) {
+            clearInterval(this._wizardBuildPoll);
+            this._wizardBuildPoll = null;
+            this._wizardAdvance('first-output', {
+              trigger: 'fleet_stable',
+              agents: fleetAgents.map(a => a.id).slice(0, 8),
+              stableSeconds: 10,
+            });
+            return;
+          }
+        } else {
+          // Count changed — reset stability window to current count.
+          stableSince = now;
+          lastCount = count;
+        }
+        if (now - start > 5 * 60 * 1000) {
+          // 5 minute hard cap — if the build never stabilised we
+          // surface a terminal ``build_failed`` card instead of
+          // silently leaving the spinner on screen.
           clearInterval(this._wizardBuildPoll);
           this._wizardBuildPoll = null;
-          this._wizardAdvance('first-output', {
-            trigger: 'fleet_populated',
-            agents: fleetAgents.map(a => a.id).slice(0, 8),
+          this._wizardAdvance('build_failed', {
+            trigger: 'timeout',
+            elapsedMs: now - start,
           });
-        } else if (Date.now() - start > 5 * 60 * 1000) {
-          // 5 minute hard cap — if the Operator never created agents
-          // we give up and let the user fall back to typing.
-          clearInterval(this._wizardBuildPoll);
-          this._wizardBuildPoll = null;
+          this.track('wizard_build_timeout', {
+            elapsedMs: now - start,
+            fleetCount: count,
+          });
+          return;
         }
         // Each poll triggers a fetchAgents to keep the local cache fresh.
         if (typeof this.fetchAgents === 'function') this.fetchAgents();
@@ -2153,11 +2203,45 @@ function dashboard() {
 
     // Phase 4 — return progress-dot index for a given step. Used by
     // the wizard card progress indicator (4 dots: ask, confirming,
-    // building, first-output).
+    // building, first-output). ``build_failed`` is a terminal sad-state
+    // alternative to ``first-output`` and renders the same dot index
+    // (3) so the user can see the progress reached the build phase
+    // before failing.
     wizardStepIndex() {
       const order = ['ask', 'confirming', 'building', 'first-output'];
+      if (this.wizard.step === 'build_failed') return 3;
       const idx = order.indexOf(this.wizard.step);
       return idx < 0 ? 0 : idx;
+    },
+
+    // Fix #2 — terminal ``build_failed`` retry button. Resets the
+    // wizard back to ``ask`` so the user can try again with a new
+    // chip selection.
+    wizardRetryBuild() {
+      this.track('wizard_chip_clicked', {
+        label: 'retry_build',
+        step: this.wizard.step,
+      });
+      this._wizardTeardown();
+      this.wizard = {
+        step: 'ask',
+        plan: null,
+        startedAt: Date.now(),
+        lastChip: '',
+      };
+      this._wizardLastTrack = '';
+      this._wizardSave();
+    },
+
+    // Fix #2 — terminal ``build_failed`` "Type instead" exit button.
+    // Closes the wizard so the user can chat freely with the operator
+    // without the failed-build card lingering.
+    wizardExitToTyping() {
+      this.track('wizard_chip_clicked', {
+        label: 'type_instead',
+        step: this.wizard.step,
+      });
+      this._wizardComplete({ reason: 'build_failed_exit' });
     },
 
     _wizardTeardown() {
@@ -2181,7 +2265,14 @@ function dashboard() {
       // because startWizard guards on step !== 'idle'. We also bail out
       // if the user already advanced past 'ask' (restored from
       // localStorage), so a hot reload mid-build keeps the building UI.
+      //
+      // Fix #4 — operatorReady gate: the wizard card's parent element
+      // has ``x-show="operatorReady"``, so starting the wizard while
+      // the operator is unhealthy would persist ``step='ask'`` to
+      // localStorage and emit telemetry while the user sees nothing.
+      // ``checkOperatorReady`` retries this on health transitions.
       if (this.wizard.step !== 'idle') return;
+      if (!this.operatorReady) return;
       if (!this._isFirstVisit()) return;
       this.startWizard();
     },

--- a/src/dashboard/templates/index.html
+++ b/src/dashboard/templates/index.html
@@ -535,7 +535,7 @@
                                class="w-8 h-8 rounded-full shrink-0">
                           <div class="flex-1 min-w-0">
                             <div id="wizard-title" class="text-sm font-semibold text-white">Welcome</div>
-                            <div class="text-[11px] text-indigo-300/80 mt-0.5">Step 1 of 3 &middot; about a minute</div>
+                            <div class="text-[11px] text-indigo-300/80 mt-0.5">Step 1 of 4 &middot; about a minute</div>
                           </div>
                           <button @click="wizardAbandon()"
                                   aria-label="Dismiss wizard"
@@ -586,7 +586,7 @@
                                class="w-8 h-8 rounded-full shrink-0">
                           <div class="flex-1 min-w-0">
                             <div id="wizard-title" class="text-sm font-semibold text-white">Here's the plan</div>
-                            <div class="text-[11px] text-indigo-300/80 mt-0.5">Step 2 of 3 &middot; review &amp; confirm</div>
+                            <div class="text-[11px] text-indigo-300/80 mt-0.5">Step 2 of 4 &middot; review &amp; confirm</div>
                           </div>
                           <button @click="wizardAbandon()"
                                   aria-label="Dismiss wizard"
@@ -624,13 +624,50 @@
                           </svg>
                           <div class="flex-1 min-w-0">
                             <div id="wizard-title" class="text-sm font-semibold text-white">Setting up your team&hellip;</div>
-                            <div class="text-[11px] text-gray-400 mt-0.5">This takes about 30 seconds.</div>
+                            <div class="text-[11px] text-indigo-300/80 mt-0.5">Step 3 of 4 &middot; this may take a minute or two</div>
                           </div>
                           <button @click="wizardSkip()"
                                   data-testid="wizard-skip-building"
                                   aria-label="Skip wizard"
                                   class="text-gray-500 hover:text-gray-300 transition-colors p-1 -mr-1 rounded shrink-0">
                             <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12"/></svg>
+                          </button>
+                        </div>
+                      </div>
+                    </template>
+
+                    <!-- Step: build_failed (fix #2) — terminal sad-state
+                         alternative to first-output. Surfaces when the
+                         build poller never sees a stable fleet inside
+                         the 5-minute hard cap. Two exits: Retry resets
+                         to ``ask``; Type instead drops the user into
+                         normal Operator chat. -->
+                    <template x-if="wizard.step === 'build_failed'">
+                      <div class="px-5 pt-5 pb-5" data-testid="wizard-build-failed">
+                        <div class="flex items-start gap-3 mb-3">
+                          <div class="w-10 h-10 rounded-full bg-amber-600/20 border border-amber-500/40 flex items-center justify-center shrink-0">
+                            <svg class="w-5 h-5 text-amber-400" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="2.5"><path stroke-linecap="round" stroke-linejoin="round" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z"/></svg>
+                          </div>
+                          <div class="flex-1 min-w-0">
+                            <div id="wizard-title" class="text-base font-semibold text-white">Build didn&rsquo;t finish</div>
+                            <div class="text-[11px] text-amber-300/80 mt-0.5">The Operator might be stuck or busy</div>
+                          </div>
+                        </div>
+                        <p class="text-xs text-gray-300 leading-relaxed mb-3">
+                          I couldn&rsquo;t build the team in 5 minutes. You can try again, or type your request directly to the Operator.
+                        </p>
+                        <div class="flex items-center gap-2">
+                          <button @click="wizardRetryBuild()"
+                                  data-testid="wizard-build-failed-retry"
+                                  aria-label="Retry building the team"
+                                  class="text-xs font-medium px-4 py-2 rounded-lg bg-indigo-600 hover:bg-indigo-500 text-white transition-colors">
+                            Retry
+                          </button>
+                          <button @click="wizardExitToTyping()"
+                                  data-testid="wizard-build-failed-type"
+                                  aria-label="Type instead"
+                                  class="text-xs font-medium px-4 py-2 rounded-lg bg-gray-800 hover:bg-gray-700 text-gray-300 transition-colors">
+                            Type instead
                           </button>
                         </div>
                       </div>
@@ -645,14 +682,11 @@
                           </div>
                           <div class="flex-1 min-w-0">
                             <div id="wizard-title" class="text-base font-semibold text-white">Your team is ready</div>
-                            <div class="text-[11px] text-emerald-300/80 mt-0.5">Step 3 of 3 &middot; we&rsquo;ll take it from here</div>
+                            <div class="text-[11px] text-emerald-300/80 mt-0.5">Step 4 of 4 &middot; we&rsquo;ll take it from here</div>
                           </div>
                         </div>
                         <p class="text-xs text-gray-300 leading-relaxed mb-1">
-                          Your team is starting now. First output expected in about 10 minutes.
-                        </p>
-                        <p class="text-xs text-gray-400 leading-relaxed mb-3">
-                          I&rsquo;ll ping you when something needs your attention.
+                          Your team is starting now. The Operator checks on them every 15 minutes and will alert you when something needs your attention.
                         </p>
                         <!-- Phase 4 quick-link chips. Each switches a tab
                              and completes the wizard so the user lands

--- a/src/shared/operator_playbooks.py
+++ b/src/shared/operator_playbooks.py
@@ -142,17 +142,18 @@ Tell me what you're trying to accomplish — like:
 I'll suggest a team, set them up, and check on their work for you. You \
 can always ask me what's happening, change a teammate, or pause anything \
 that's not working.
-
-ACTION: Monitor competitors weekly
-ACTION: Build a content team
-ACTION: Enrich my lead list
-ACTION: Something else…
 """
 """First-message greeting seeded into the operator's chat transcript on
 fresh creation. Rendered as an ``assistant``-role message tagged with
 ``_origin == "bootstrap_greeting"`` so the dashboard / context layer can
 distinguish it from real LLM-authored output. NOT re-emitted on chat
 reset (see Decision #3 in the Post-Board roadmap).
+
+Prose-only by design — the onboarding wizard supplies the action chips
+on cold start, so duplicating ACTION: lines here would render two chip
+rows on first visit (one parsed from this greeting, one from the wizard
+``ask`` card). See ``app.js:wizardChipClicked`` for the chip source of
+truth and ``test_operator_greeting_no_action_lines`` for the contract.
 """
 
 # ── Playbooks (loaded on demand) ──────────────────────────────

--- a/tests/test_dashboard_ui.py
+++ b/tests/test_dashboard_ui.py
@@ -195,10 +195,13 @@ class TestWizardJsState:
 
     def test_wizard_advances_to_first_output_when_fleet_populated(self):
         js = _read(_APP_JS)
-        # Build poller advances to first-output when ≥1 non-operator
-        # agent exists.
-        assert "fleetAgents.length >= 1" in js
+        # Build poller advances to first-output when the non-operator
+        # fleet has been NON-EMPTY and COUNT-STABLE for ≥10 seconds
+        # (fix #1 — replaces the prior naive ``length >= 1`` check that
+        # fired prematurely on multi-agent templates).
         assert "_wizardAdvance('first-output'" in js
+        assert "fleet_stable" in js
+        assert "stableSeconds" in js
 
     def test_telemetry_events_have_locked_names(self):
         js = _read(_APP_JS)
@@ -891,3 +894,230 @@ class TestWizardPolish:
         # The quick-links section keeps a "Got it, close" affordance
         # that completes the wizard without changing tabs.
         assert 'data-testid="wizard-continue"' in html
+
+
+# ── Wizard correctness fixes (race / timeout / gating / labels) ───────
+
+
+class TestWizardCorrectnessFixes:
+    """Source-level checks for the wizard correctness fixes #1–#6.
+
+    A real headless browser would let us drive the JS state machine
+    directly; instead we assert on the source so the contract changes
+    don't quietly regress. The tests cover:
+
+      #1 stability-based polling (replaces ``length >= 1`` race)
+      #2 ``build_failed`` terminal state on 5-min timeout
+      #3 bootstrap greeting carries no ACTION lines
+      #4 ``_maybeStartWizard`` is operatorReady-gated, retries on
+         unhealthy → healthy transition
+      #5 step labels say "Step N of 4"
+      #6 realistic timing copy on building / first-output cards
+    """
+
+    # Fix #1 — stability-based polling -----------------------------
+
+    def test_polling_uses_stability_window_not_naive_length(self):
+        js = _read(_APP_JS)
+        # The naive ``fleetAgents.length >= 1`` immediate advance is
+        # replaced with a stability window (10 seconds of unchanged
+        # non-zero count).
+        assert "stableSince" in js
+        # Check the literal numeric tolerance — 10_000 ms.
+        assert "10_000" in js or "10000" in js
+        # Telemetry trigger renamed.
+        assert "fleet_stable" in js
+
+    def test_polling_resets_window_when_count_changes(self):
+        js = _read(_APP_JS)
+        # When a new agent appears mid-window the stability clock
+        # MUST reset — otherwise a 4-agent template that takes 12
+        # seconds to provision would fire the success card after the
+        # first agent.
+        m = re.search(
+            r"_wizardStartBuildPolling\(\)\s*\{(.*?)^\s{4}\},",
+            js,
+            re.DOTALL | re.MULTILINE,
+        )
+        assert m, "could not locate _wizardStartBuildPolling body"
+        body = m.group(1)
+        # The reset path runs in the count-changed branch.
+        assert "stableSince = now" in body
+        assert "lastCount = count" in body
+
+    def test_polling_clears_window_when_fleet_drops_to_zero(self):
+        js = _read(_APP_JS)
+        # If fleet count drops to 0 mid-build (agent crashed before
+        # next agent created) we reset the window so we don't declare
+        # success on a transient.
+        m = re.search(
+            r"_wizardStartBuildPolling\(\)\s*\{(.*?)^\s{4}\},",
+            js,
+            re.DOTALL | re.MULTILINE,
+        )
+        assert m
+        body = m.group(1)
+        assert "if (count === 0)" in body
+        assert "stableSince = 0" in body
+
+    # Fix #2 — terminal build_failed state -------------------------
+
+    def test_timeout_advances_to_build_failed(self):
+        js = _read(_APP_JS)
+        # The 5-minute hard cap now transitions to a terminal
+        # ``build_failed`` step (replaces the silent timeout that
+        # left the spinner card on screen).
+        assert "_wizardAdvance('build_failed'" in js
+        assert "trigger: 'timeout'" in js
+        # Telemetry event for the timeout path.
+        assert "'wizard_build_timeout'" in js
+
+    def test_build_failed_card_renders(self):
+        html = _read(_TEMPLATE)
+        # The card itself, plus a header, plus the Retry/Type-instead
+        # buttons that recover the user from the failed state.
+        assert "wizard.step === 'build_failed'" in html
+        assert 'data-testid="wizard-build-failed"' in html
+        assert 'data-testid="wizard-build-failed-retry"' in html
+        assert 'data-testid="wizard-build-failed-type"' in html
+
+    def test_build_failed_retry_handler(self):
+        js = _read(_APP_JS)
+        # Retry resets to the 'ask' step and re-arms startedAt so
+        # the secondsSinceStart counter reflects the new attempt.
+        assert "wizardRetryBuild()" in js
+        m = re.search(
+            r"wizardRetryBuild\(\)\s*\{(.*?)^\s{4}\},",
+            js,
+            re.DOTALL | re.MULTILINE,
+        )
+        assert m, "wizardRetryBuild body missing"
+        body = m.group(1)
+        assert "step: 'ask'" in body
+        assert "_wizardTeardown" in body
+
+    def test_build_failed_type_instead_handler(self):
+        js = _read(_APP_JS)
+        # Type-instead exits the wizard via the standard complete
+        # path so telemetry fires the locked ``wizard_completed`` event.
+        assert "wizardExitToTyping()" in js
+        m = re.search(
+            r"wizardExitToTyping\(\)\s*\{(.*?)^\s{4}\},",
+            js,
+            re.DOTALL | re.MULTILINE,
+        )
+        assert m, "wizardExitToTyping body missing"
+        body = m.group(1)
+        assert "_wizardComplete" in body
+        assert "build_failed_exit" in body
+
+    def test_build_failed_progress_dot_index(self):
+        js = _read(_APP_JS)
+        # build_failed renders the same dot index as first-output
+        # (3) so the user sees the progress reached the build phase
+        # before failing.
+        m = re.search(
+            r"wizardStepIndex\(\)\s*\{(.*?)^\s{4}\},",
+            js,
+            re.DOTALL | re.MULTILINE,
+        )
+        assert m, "wizardStepIndex body missing"
+        body = m.group(1)
+        assert "build_failed" in body
+        assert "return 3" in body
+
+    # Fix #4 — operatorReady gate ----------------------------------
+
+    def test_maybe_start_wizard_gated_on_operator_ready(self):
+        js = _read(_APP_JS)
+        m = re.search(
+            r"_maybeStartWizard\(\)\s*\{(.*?)^\s{4}\},",
+            js,
+            re.DOTALL | re.MULTILINE,
+        )
+        assert m, "_maybeStartWizard body missing"
+        body = m.group(1)
+        # The body bails out if operatorReady is falsy.
+        assert "this.operatorReady" in body
+        assert "if (!this.operatorReady) return" in body
+
+    def test_check_operator_ready_retries_wizard(self):
+        js = _read(_APP_JS)
+        m = re.search(
+            r"checkOperatorReady\(\)\s*\{(.*?)^\s{4}\},",
+            js,
+            re.DOTALL | re.MULTILINE,
+        )
+        assert m, "checkOperatorReady body missing"
+        body = m.group(1)
+        # Transition unhealthy → healthy must retry the wizard kickoff.
+        assert "wasReady" in body
+        assert "_maybeStartWizard" in body
+
+    # Fix #5 — step labels align with 4-dot indicator --------------
+
+    def test_step_labels_say_n_of_four(self):
+        html = _read(_TEMPLATE)
+        # Scope the search to the wizard region only — the What's-new
+        # tour reuses "Step N of 3" markup elsewhere in the template.
+        m = re.search(
+            r'data-testid="onboarding-wizard".*?<!-- Step: building',
+            html,
+            re.DOTALL,
+        )
+        assert m, "could not isolate wizard ask/confirming region"
+        ask_confirming = m.group(0)
+        assert "Step 1 of 4" in ask_confirming
+        assert "Step 2 of 4" in ask_confirming
+        # building + first-output captions further down.
+        m2 = re.search(
+            r"<!-- Step: building -->.*?<!-- Step: build_failed",
+            html,
+            re.DOTALL,
+        )
+        assert m2, "could not isolate building region"
+        building = m2.group(0)
+        assert "Step 3 of 4" in building
+        m3 = re.search(
+            r"<!-- Step: first-output -->.*?</template>\s*</div>\s*</template>",
+            html,
+            re.DOTALL,
+        )
+        assert m3, "could not isolate first-output region"
+        first_output = m3.group(0)
+        assert "Step 4 of 4" in first_output
+        # Legacy 3-step wording must be gone from the wizard cards.
+        assert "Step 1 of 3" not in ask_confirming
+        assert "Step 2 of 3" not in ask_confirming
+        assert "Step 3 of 3" not in first_output
+
+    # Fix #6 — realistic timing copy -------------------------------
+
+    def test_building_card_uses_realistic_timing(self):
+        html = _read(_TEMPLATE)
+        # The "30 seconds" claim is replaced with vague-but-honest copy.
+        assert "About 30 seconds" not in html
+        assert "this may take a minute or two" in html
+
+    def test_first_output_card_describes_heartbeat_behavior(self):
+        html = _read(_TEMPLATE)
+        # The fictitious "10 minutes" ETA is replaced with a heartbeat
+        # mental-model description.
+        assert "First output expected in about 10 minutes" not in html
+        assert "checks on them every 15 minutes" in html
+
+    # Backwards-compat for persisted localStorage ------------------
+
+    def test_wizard_load_resets_unknown_step_to_idle(self):
+        js = _read(_APP_JS)
+        m = re.search(
+            r"_wizardLoad\(\)\s*\{(.*?)^\s{4}\},",
+            js,
+            re.DOTALL | re.MULTILINE,
+        )
+        assert m, "_wizardLoad body missing"
+        body = m.group(1)
+        # Unknown step value from a prior version must reset to idle.
+        assert "KNOWN_STEPS" in body
+        assert "build_failed" in body
+        assert "'idle'" in body

--- a/tests/test_operator_playbooks.py
+++ b/tests/test_operator_playbooks.py
@@ -227,19 +227,17 @@ class TestActionChipsInstruction:
         """ACTION block must appear at the very end of the response."""
         assert "end" in _OPERATOR_CORE.lower()
 
-    def test_greeting_includes_action_example(self):
-        """Bootstrap greeting seeds a working example block of chips so
-        the first-visit user sees them on the very first message."""
-        assert "ACTION:" in _OPERATOR_GREETING
-        # At least 3 sample chips so the rendering path actually exercises
-        # the multi-chip layout on first load.
-        assert _OPERATOR_GREETING.count("ACTION:") >= 3
+    def test_operator_greeting_no_action_lines(self):
+        """Bootstrap greeting must NOT carry ACTION: chip lines.
 
-    def test_greeting_examples_are_short(self):
-        """Sample chips in the greeting respect the ≤40 char constraint."""
+        Before fix #3 the greeting ended with four ACTION: lines that
+        matched the wizard ``ask`` card chips, which caused TWO chip
+        rows to render on cold start (one parsed from the bootstrap
+        greeting, one from the wizard). The wizard now owns the chips;
+        the greeting is prose-only.
+        """
         for line in _OPERATOR_GREETING.splitlines():
-            stripped = line.strip()
-            if not stripped.upper().startswith("ACTION:"):
-                continue
-            label = stripped.split(":", 1)[1].strip()
-            assert len(label) <= 40, f"Greeting chip too long ({len(label)} chars): {label!r}"
+            assert not line.strip().upper().startswith("ACTION:"), (
+                f"Greeting must not contain ACTION lines (chips owned "
+                f"by wizard): {line!r}"
+            )


### PR DESCRIPTION
## Summary

Six fixes from the user-journey audit. All Critical/High wizard correctness issues.

## Fixes

### 1. Wizard race — stability-based polling (was: `>= 1`)
`_wizardStartBuildPolling` rewritten. Today it advanced to "Your team is ready" as soon as any agent was created; a partial `apply_template` (1/4 agents created, 3 pending) wrongly triggered the success card. Now: declares done only after fleet has been non-empty AND count-stable for ≥10s. Resets the stability window if count changes or drops to zero. Telemetry trigger renamed `fleet_populated` → `fleet_stable`.

### 2. Wizard 5-min timeout — terminal `build_failed` state
Today the 5-min hard cap cleared the poller but left `wizard.step === 'building'` — spinner card stayed forever. Now: new `build_failed` step with copy "I couldn't build the team in 5 minutes" + two buttons (Retry → resets to `ask`, Type instead → exits to `idle`). New `wizard_build_timeout` telemetry event.

### 3. Bootstrap greeting + wizard "ask" duplicate chip rows
Removed the 4 trailing `ACTION:` lines from `_OPERATOR_GREETING`. The wizard's ask card supplies them; greeting was double-rendering. Verified `len(action_lines) == 0`.

### 4. Wizard `operatorReady` gate
`_maybeStartWizard` now early-returns on `!this.operatorReady`. Cold-start case: when operator transitions unhealthy → healthy, `checkOperatorReady` re-fires `_maybeStartWizard` so the user doesn't miss the wizard.

### 5. Step labels align with dot indicator
All four wizard steps relabeled "Step N of 4" to match the 4-dot progress indicator. `build_failed` rendered without a step caption — just "Build didn't finish" header.

### 6. Realistic timing copy
- Building card: "Setting up your team — this may take a minute or two." (was "This takes about 30 seconds")
- First-output card: "Your team is starting now. The Operator checks on them every 15 minutes and will alert you when something needs your attention." (was "First output expected in about 10 minutes")

## Backwards compat

`_wizardLoad` now validates persisted step against a `KNOWN_STEPS` set (includes new `build_failed`); unknown values gracefully reset to `'idle'`.

## Test plan

- [x] Stability polling: count grows 1→2→3 over 8s → wizard does NOT advance until 10s of stability
- [x] Build timeout: 5min mock → wizard advances to `build_failed`
- [x] Build failed retry: button click → resets to `ask`
- [x] Build failed exit: "Type instead" button → wizard idles
- [x] Operator not ready → wizard skips
- [x] Operator becomes ready → wizard fires
- [x] Bootstrap greeting has no ACTION lines
- [x] All 4 step labels match the 4-dot indicator
- [x] Persisted unknown step → resets to idle

132 targeted tests pass. 512-test broader sweep clean. `ruff` clean.

## Stats

5 files changed: +396 / -42.

## Coordination with concurrent PRs

Test gates from PR-F coordination tests should pass once this lands. PR-B (notifications producer), PR-C (vocab + Undo countdown), PR-D (session-scope conversations), PR-E (browser notifications + progress rollup), PR-F (test coverage + polish) all running in parallel.