### PR TITLE
feat(dashboard): browser notifications + long-task progress rollup + connect-channel prompt (PR-E)

### DIFF
--- a/src/dashboard/static/js/app.js
+++ b/src/dashboard/static/js/app.js
@@ -692,6 +692,23 @@ function dashboard() {
     notificationsLoading: false,
     _notificationsRefreshTimer: null,
 
+    // Browser Notification API integration. ``browserNotifyEnabled`` is
+    // the user's local opt-in (persisted to ``olBrowserNotifyEnabled``);
+    // ``browserNotifyPermission`` mirrors ``Notification.permission``
+    // for template gating. We only fire notifications when:
+    //   1. Permission has been granted by the OS,
+    //   2. The user explicitly toggled the in-app opt-in on,
+    //   3. The dashboard tab is not visible (foreground tabs already
+    //      have full UI signal).
+    // Triple-redundant gate keeps us from spamming the user.
+    browserNotifyEnabled: false,
+    browserNotifyPermission: 'default',
+    // Track the highest notification id we've seen so the 60s
+    // fetchNotifications poll only fires browser notifications for
+    // genuinely new arrivals.
+    _lastNotifiedId: 0,
+    _browserNotifyKinds: ['approval', 'credential', 'alert', 'blocker'],
+
     // WebSocket
     _ws: null,
     _refreshInterval: null,
@@ -1264,6 +1281,20 @@ function dashboard() {
         if (saved === '1') this.showTechDetail = true;
       } catch (_) {
         // ignore — localStorage unavailable.
+      }
+
+      // Browser Notification API — restore the user's local opt-in and
+      // sync ``Notification.permission`` so the wizard button renders
+      // the right state on reload. The opt-in toggle is independent of
+      // the OS-level permission; we require both to fire.
+      try {
+        const saved = localStorage.getItem('olBrowserNotifyEnabled');
+        if (saved === 'true') this.browserNotifyEnabled = true;
+      } catch (_) {
+        // ignore — localStorage unavailable.
+      }
+      if (typeof Notification !== 'undefined' && Notification && Notification.permission) {
+        this.browserNotifyPermission = Notification.permission;
       }
 
       // Phase 2 Board UX — initial notifications fetch + 60s poll.
@@ -9552,8 +9583,27 @@ function dashboard() {
           return;
         }
         const data = await resp.json();
-        this.notifications = data.notifications || [];
+        const fresh = data.notifications || [];
+        const previousLastId = this._lastNotifiedId;
+        // Track the high-water mark across the merged set so the next
+        // poll can identify genuinely-new entries.
+        let highestId = previousLastId;
+        for (const n of fresh) {
+          if (typeof n.id === 'number' && n.id > highestId) highestId = n.id;
+        }
+        this.notifications = fresh;
         this.notificationsUnreadCount = data.unread_count || 0;
+        // Fire browser notifications only for entries newer than the
+        // last poll. Skip on the very first fetch (previousLastId === 0)
+        // so reloading the page doesn't replay the inbox.
+        if (previousLastId > 0) {
+          for (const n of fresh) {
+            if (n.id && n.id > previousLastId && !n.read_at) {
+              this._maybeFireBrowserNotification(n);
+            }
+          }
+        }
+        this._lastNotifiedId = highestId;
       } catch (e) {
         // Silent failure; the bell is a polish surface.
         this.notifications = [];
@@ -9561,6 +9611,211 @@ function dashboard() {
       } finally {
         this.notificationsLoading = false;
       }
+    },
+
+    // ── Browser Notification API ─────────────────────────────
+    //
+    // Off-tab signal for users without a messaging channel configured.
+    // Triple-gated: requires browserNotifyEnabled === true AND
+    // Notification.permission === 'granted' AND the dashboard tab is
+    // not currently visible. We never auto-prompt; the user must click
+    // "Enable browser notifications" in the wizard first-output card
+    // (or the equivalent settings affordance).
+    //
+    // This consumes ``notifications`` produced by the existing notification
+    // bell fetch (PR-B). We don't manufacture our own queue.
+    async requestBrowserNotificationPermission() {
+      if (typeof Notification === 'undefined' || !Notification) {
+        return 'unsupported';
+      }
+      let permission = Notification.permission;
+      if (permission === 'default') {
+        try {
+          permission = await Notification.requestPermission();
+        } catch (_) {
+          // Some browsers throw on call-without-gesture; treat as denied.
+          permission = Notification.permission || 'denied';
+        }
+      }
+      this.browserNotifyPermission = permission;
+      if (permission === 'granted') {
+        this.browserNotifyEnabled = true;
+        try {
+          localStorage.setItem('olBrowserNotifyEnabled', 'true');
+        } catch (_) { /* ignore */ }
+      }
+      return permission;
+    },
+
+    // Toggle off without revoking the OS-level permission (browsers
+    // don't let JS revoke that — user must visit site settings). The
+    // localStorage flag is the in-app off-switch.
+    disableBrowserNotifications() {
+      this.browserNotifyEnabled = false;
+      try {
+        localStorage.setItem('olBrowserNotifyEnabled', 'false');
+      } catch (_) { /* ignore */ }
+    },
+
+    // Fire a Notification for a specific notification entry, but only
+    // if all three gates pass. Click handler focuses the window and
+    // routes to the relevant in-app context.
+    _maybeFireBrowserNotification(notification) {
+      if (!notification || !notification.kind) return;
+      if (!this.browserNotifyEnabled) return;
+      if (typeof Notification === 'undefined' || !Notification) return;
+      if (Notification.permission !== 'granted') return;
+      // Only fire when the tab isn't visible — the in-app UI already
+      // signals foreground users plenty.
+      if (typeof document !== 'undefined' && document.visibilityState === 'visible') return;
+      if (this._browserNotifyKinds.indexOf(notification.kind) === -1) return;
+      let title = notification.title || 'OpenLegion';
+      let body = notification.body || '';
+      try {
+        const n = new Notification(title, {
+          body: body || ' ',
+          icon: '/dashboard/static/favicon.png',
+          tag: 'ol-' + notification.id,
+        });
+        n.onclick = (ev) => {
+          try {
+            ev.preventDefault();
+            if (typeof window !== 'undefined' && window.focus) window.focus();
+            this.onNotificationClick(notification);
+          } catch (_) { /* ignore */ }
+          try { n.close(); } catch (_) { /* ignore */ }
+        };
+      } catch (_) {
+        // Notification constructors can throw on unsupported platforms
+        // (e.g. iOS Safari pre-PWA). Fail closed.
+      }
+    },
+
+    // ── Long-task progress rollup ─────────────────────────────
+    //
+    // Presentation-layer aggregation for the activity feed. When the
+    // same agent fires the same tool repeatedly (e.g. a Researcher
+    // running web_search 50 times across a 30-minute task), we collapse
+    // the run into a single row: "Researcher is searching the web (4
+    // queries · 12m elapsed)".
+    //
+    // Reset triggers (per spec):
+    //   - tool changes (different tool name)
+    //   - status changes (task_status_changed in the stream)
+    //   - different agent
+    //
+    // Underlying ``events`` array is unchanged — the "Show technical
+    // detail" toggle still surfaces the raw stream. Returns a list of
+    // entries either ``{kind: 'single', event}`` or
+    // ``{kind: 'rollup', event, count, startTs, endTs}``.
+    _rollupActivityEvents(events) {
+      if (!Array.isArray(events) || events.length === 0) return [];
+      const out = [];
+      let group = null; // {agent, tool, events: [], startTs, endTs}
+      const flush = () => {
+        if (!group) return;
+        if (group.events.length === 1) {
+          out.push({ kind: 'single', event: group.events[0] });
+        } else {
+          out.push({
+            kind: 'rollup',
+            event: group.events[group.events.length - 1],
+            count: group.events.length,
+            startTs: group.startTs,
+            endTs: group.endTs,
+            tool: group.tool,
+          });
+        }
+        group = null;
+      };
+      for (const ev of events) {
+        if (!ev || !ev.type) {
+          flush();
+          continue;
+        }
+        // Status changes always reset grouping (per spec).
+        if (ev.type === 'task_status_changed') {
+          flush();
+          out.push({ kind: 'single', event: ev });
+          continue;
+        }
+        if (ev.type !== 'tool_start') {
+          flush();
+          out.push({ kind: 'single', event: ev });
+          continue;
+        }
+        const toolName = (ev.data && (ev.data.tool || ev.data.name)) || ev.tool_name || '';
+        const agentId = ev.agent || '';
+        const ts = ev.timestamp || ev.ts || 0;
+        if (group && group.agent === agentId && group.tool === toolName) {
+          group.events.push(ev);
+          group.endTs = ts || group.endTs;
+        } else {
+          flush();
+          group = { agent: agentId, tool: toolName, events: [ev], startTs: ts, endTs: ts };
+        }
+      }
+      flush();
+      return out;
+    },
+
+    // Format a rollup entry as a single feed line. Counts use plural
+    // "queries"/"requests"/"actions" depending on the verb category.
+    formatRolledActivityLine(entry) {
+      if (!entry) return null;
+      if (entry.kind !== 'rollup') {
+        return this.formatActivityForUser(entry.event);
+      }
+      const ev = entry.event;
+      const baseLine = this.formatActivityForUser(ev);
+      if (!baseLine) return null;
+      const count = entry.count || 0;
+      const noun = this._rollupNounForTool(entry.tool);
+      const elapsed = this._formatRolledElapsed(entry.startTs, entry.endTs);
+      const elapsedSuffix = elapsed ? ` · ${elapsed} elapsed` : '';
+      return `${baseLine} (${count} ${noun}${elapsedSuffix})`;
+    },
+
+    _rollupNounForTool(toolName) {
+      const map = {
+        web_search: 'queries',
+        web_fetch: 'pages',
+        browser_navigate: 'visits',
+        browser_click: 'clicks',
+        browser_type: 'inputs',
+        browser_screenshot: 'screenshots',
+        browser_get_elements: 'reads',
+        browser_find_text: 'searches',
+        browser_fill_form: 'forms',
+        http_request: 'requests',
+        exec: 'commands',
+        file_read: 'reads',
+        file_write: 'writes',
+        file_list: 'listings',
+        memory_search: 'lookups',
+        memory_save: 'saves',
+        read_blackboard: 'reads',
+        write_blackboard: 'writes',
+      };
+      return map[toolName] || 'actions';
+    },
+
+    _formatRolledElapsed(startTs, endTs) {
+      if (!startTs || !endTs) return '';
+      const startEpoch = typeof startTs === 'string' ? new Date(startTs).getTime() / 1000 : startTs;
+      const endEpoch = typeof endTs === 'string' ? new Date(endTs).getTime() / 1000 : endTs;
+      if (isNaN(startEpoch) || isNaN(endEpoch)) return '';
+      const diff = Math.max(0, endEpoch - startEpoch);
+      if (diff < 1) return '';
+      if (diff < 60) return `${Math.round(diff)}s`;
+      if (diff < 3600) return `${Math.round(diff / 60)}m`;
+      return `${Math.round(diff / 3600)}h`;
+    },
+
+    // Convenience getter — feed-renderer-friendly rollup over the
+    // (already filtered) activity feed.
+    get rolledFilteredEvents() {
+      return this._rollupActivityEvents(this.filteredEvents);
     },
 
     toggleNotifications() {

--- a/src/dashboard/templates/index.html
+++ b/src/dashboard/templates/index.html
@@ -662,6 +662,48 @@
                         <p class="text-xs text-gray-300 leading-relaxed mb-1">
                           Your team is starting now. The Operator checks on them every 15 minutes and will alert you when something needs your attention.
                         </p>
+                        <!-- Browser Notification opt-in. Off-tab signal
+                             for users without a messaging channel
+                             configured. Triple-gated firing in
+                             _maybeFireBrowserNotification — this is just
+                             the affordance to grant permission. -->
+                        <div class="mb-3" data-testid="wizard-browser-notify">
+                          <template x-if="browserNotifyPermission !== 'granted' || !browserNotifyEnabled">
+                            <button @click="requestBrowserNotificationPermission()"
+                                    data-testid="wizard-browser-notify-enable"
+                                    class="w-full text-xs px-3 py-2 rounded-lg bg-indigo-600/20 hover:bg-indigo-600/30 border border-indigo-500/40 text-indigo-200 transition-colors flex items-center justify-center gap-2">
+                              <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M14.857 17.082a23.848 23.848 0 0 0 5.454-1.31A8.967 8.967 0 0 1 18 9.75V9A6 6 0 0 0 6 9v.75a8.967 8.967 0 0 1-2.312 6.022c1.733.64 3.56 1.085 5.455 1.31m5.714 0a24.255 24.255 0 0 1-5.714 0m5.714 0a3 3 0 1 1-5.714 0"/></svg>
+                              <span>Enable browser notifications</span>
+                            </button>
+                          </template>
+                          <template x-if="browserNotifyPermission === 'granted' && browserNotifyEnabled">
+                            <div class="text-[11px] text-emerald-300/90 flex items-center gap-1.5"
+                                 data-testid="wizard-browser-notify-on">
+                              <svg class="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M5 13l4 4L19 7"/></svg>
+                              <span>Browser notifications on</span>
+                            </div>
+                          </template>
+                          <template x-if="browserNotifyPermission === 'denied'">
+                            <div class="text-[11px] text-amber-300/90"
+                                 data-testid="wizard-browser-notify-denied">
+                              Browser notifications blocked. Enable in your browser&rsquo;s site settings.
+                            </div>
+                          </template>
+                        </div>
+                        <!-- Phase: connect-channel prompt. Soft nudge to
+                             configure off-tab notifications via Telegram /
+                             Slack / Discord / WhatsApp. Just a link — the
+                             channel UI lives under Settings →
+                             Integrations. -->
+                        <div class="text-[11px] text-gray-400 mb-3"
+                             data-testid="wizard-connect-channel">
+                          Want updates when you&rsquo;re not on the dashboard?
+                          <button @click="systemTab = 'integrations'; switchTab('system'); wizardComplete()"
+                                  data-testid="wizard-connect-channel-link"
+                                  class="text-indigo-300 hover:text-indigo-200 underline underline-offset-2 transition-colors">
+                            Connect Telegram, Slack, or another channel &rarr;
+                          </button>
+                        </div>
                         <!-- Phase 4 quick-link chips. Each switches a tab
                              and completes the wizard so the user lands
                              on the section they care about most. -->
@@ -6154,28 +6196,66 @@
               Show technical detail
             </label>
           </div>
-          <div class="space-y-1 max-h-[calc(100vh-16rem)] overflow-y-auto custom-scrollbar">
-            <template x-for="(evt, i) in filteredEvents" :key="i">
-              <div x-data="{ open: false }">
-                <div @click="open = !open" class="bg-gray-900/70 border border-gray-800/60 px-3 py-2 flex items-start gap-3 text-sm hover:bg-gray-900 transition-colors cursor-pointer select-none" :class="open ? 'rounded-t-md' : 'rounded-md'">
-                  <svg class="w-3 h-3 shrink-0 mt-1 text-gray-600 transition-transform duration-200" :class="open && 'rotate-90'" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7"/></svg>
-                  <span x-show="showTechDetail" class="event-badge shrink-0 mt-0.5" :class="eventColor(evt.type)" x-text="evt.type"></span>
-                  <span x-show="showTechDetail" class="text-gray-500 shrink-0 w-20 truncate" :title="evt.agent" x-text="evt.agent || '-'"></span>
-                  <span class="text-gray-300 truncate flex-1"
-                    :title="showTechDetail ? eventSummary(evt) : (formatActivityForUser(evt) || eventSummary(evt))"
-                    x-text="showTechDetail ? eventSummary(evt) : (formatActivityForUser(evt) || eventSummary(evt))"></span>
-                  <span class="text-gray-600 text-xs shrink-0 font-mono" x-text="timeAgo(evt.timestamp)"></span>
-                </div>
-                <template x-if="open">
-                  <div class="bg-gray-900 border border-gray-800/80 border-t-gray-700/50 rounded-b-md px-4 py-3">
-                    <div class="grid grid-cols-[auto_1fr] gap-x-4 gap-y-1.5 text-xs">
-                      <template x-for="(field, fi) in eventDetail(evt)" :key="fi">
-                        <div class="contents">
-                          <span class="text-gray-600 whitespace-nowrap" x-text="field.label"></span>
-                          <span class="text-gray-300 font-mono whitespace-pre-wrap break-all max-h-48 overflow-y-auto" x-text="field.value"></span>
-                        </div>
-                      </template>
+          <div class="space-y-1 max-h-[calc(100vh-16rem)] overflow-y-auto custom-scrollbar"
+               data-testid="system-activity-feed">
+            <!-- Tech-detail mode: raw event stream (one row per event). -->
+            <template x-if="showTechDetail">
+              <div>
+                <template x-for="(evt, i) in filteredEvents" :key="i">
+                  <div x-data="{ open: false }">
+                    <div @click="open = !open" class="bg-gray-900/70 border border-gray-800/60 px-3 py-2 flex items-start gap-3 text-sm hover:bg-gray-900 transition-colors cursor-pointer select-none" :class="open ? 'rounded-t-md' : 'rounded-md'">
+                      <svg class="w-3 h-3 shrink-0 mt-1 text-gray-600 transition-transform duration-200" :class="open && 'rotate-90'" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7"/></svg>
+                      <span class="event-badge shrink-0 mt-0.5" :class="eventColor(evt.type)" x-text="evt.type"></span>
+                      <span class="text-gray-500 shrink-0 w-20 truncate" :title="evt.agent" x-text="evt.agent || '-'"></span>
+                      <span class="text-gray-300 truncate flex-1"
+                        :title="eventSummary(evt)"
+                        x-text="eventSummary(evt)"></span>
+                      <span class="text-gray-600 text-xs shrink-0 font-mono" x-text="timeAgo(evt.timestamp)"></span>
                     </div>
+                    <template x-if="open">
+                      <div class="bg-gray-900 border border-gray-800/80 border-t-gray-700/50 rounded-b-md px-4 py-3">
+                        <div class="grid grid-cols-[auto_1fr] gap-x-4 gap-y-1.5 text-xs">
+                          <template x-for="(field, fi) in eventDetail(evt)" :key="fi">
+                            <div class="contents">
+                              <span class="text-gray-600 whitespace-nowrap" x-text="field.label"></span>
+                              <span class="text-gray-300 font-mono whitespace-pre-wrap break-all max-h-48 overflow-y-auto" x-text="field.value"></span>
+                            </div>
+                          </template>
+                        </div>
+                      </div>
+                    </template>
+                  </div>
+                </template>
+              </div>
+            </template>
+            <!-- User-friendly mode: rolled-up consecutive same-tool runs.
+                 Underlying events array is unchanged — toggling
+                 "Show technical detail" reveals the raw stream. -->
+            <template x-if="!showTechDetail">
+              <div>
+                <template x-for="(entry, i) in rolledFilteredEvents" :key="i">
+                  <div x-data="{ open: false }"
+                       :data-rollup="entry.kind"
+                       data-testid="activity-feed-row">
+                    <div @click="open = !open" class="bg-gray-900/70 border border-gray-800/60 px-3 py-2 flex items-start gap-3 text-sm hover:bg-gray-900 transition-colors cursor-pointer select-none" :class="open ? 'rounded-t-md' : 'rounded-md'">
+                      <svg class="w-3 h-3 shrink-0 mt-1 text-gray-600 transition-transform duration-200" :class="open && 'rotate-90'" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7"/></svg>
+                      <span class="text-gray-300 truncate flex-1"
+                        :title="formatRolledActivityLine(entry) || eventSummary(entry.event)"
+                        x-text="formatRolledActivityLine(entry) || eventSummary(entry.event)"></span>
+                      <span class="text-gray-600 text-xs shrink-0 font-mono" x-text="timeAgo(entry.event.timestamp)"></span>
+                    </div>
+                    <template x-if="open">
+                      <div class="bg-gray-900 border border-gray-800/80 border-t-gray-700/50 rounded-b-md px-4 py-3">
+                        <div class="grid grid-cols-[auto_1fr] gap-x-4 gap-y-1.5 text-xs">
+                          <template x-for="(field, fi) in eventDetail(entry.event)" :key="fi">
+                            <div class="contents">
+                              <span class="text-gray-600 whitespace-nowrap" x-text="field.label"></span>
+                              <span class="text-gray-300 font-mono whitespace-pre-wrap break-all max-h-48 overflow-y-auto" x-text="field.value"></span>
+                            </div>
+                          </template>
+                        </div>
+                      </div>
+                    </template>
                   </div>
                 </template>
               </div>

--- a/tests/test_dashboard_ui.py
+++ b/tests/test_dashboard_ui.py
@@ -1323,3 +1323,235 @@ class TestWorkerDmInNeedsYou:
         # naturally for either case.
         assert "'1 unread'" in _APP_JS_TEXT
         assert "${n} unread" in _APP_JS_TEXT
+# ── Browser notification + activity rollup + connect-channel ────
+
+
+class TestBrowserNotifyOptIn:
+    """Browser Notification API integration in the wizard first-output."""
+
+    def test_browser_notify_button_in_wizard_first_output(self):
+        html = _read(_TEMPLATE)
+        # The opt-in button lives inside the first-output card. Assert
+        # both the testid and that it actually wires to the JS handler.
+        assert 'data-testid="wizard-browser-notify"' in html
+        assert 'data-testid="wizard-browser-notify-enable"' in html
+        assert "requestBrowserNotificationPermission()" in html
+        # The "granted + enabled" affordance and "denied" advisory are
+        # both rendered so the user always knows the current state.
+        assert 'data-testid="wizard-browser-notify-on"' in html
+        assert 'data-testid="wizard-browser-notify-denied"' in html
+
+    def test_browser_notify_persists_to_localstorage(self):
+        js = _read(_APP_JS)
+        # The opt-in is persisted under the locked key so we can assert
+        # against a string literal, not a regex.
+        assert "olBrowserNotifyEnabled" in js
+        # Permission grant flips the in-app opt-in on AND writes through
+        # to localStorage in the same code path.
+        assert "localStorage.setItem('olBrowserNotifyEnabled', 'true')" in js
+        # State variables are declared on the Alpine root so the
+        # template bindings work.
+        assert "browserNotifyEnabled: false" in js
+        assert "browserNotifyPermission: 'default'" in js
+
+    def test_browser_notify_fire_is_triple_gated(self):
+        """Defence in depth — opt-in flag, OS permission, and tab visibility."""
+        js = _read(_APP_JS)
+        fire_fn = _extract_function_body(js, "_maybeFireBrowserNotification")
+        assert fire_fn is not None, "missing _maybeFireBrowserNotification"
+        # Gate 1: in-app opt-in.
+        assert "this.browserNotifyEnabled" in fire_fn
+        # Gate 2: OS-level permission. Match either ' === ' or "===" form
+        # so refactors that flip quote style still pass.
+        assert "Notification.permission" in fire_fn
+        assert "'granted'" in fire_fn or '"granted"' in fire_fn
+        # Gate 3: tab visibility — only fire when not visible.
+        assert "document.visibilityState" in fire_fn
+        assert "'visible'" in fire_fn or '"visible"' in fire_fn
+
+    def test_browser_notify_kinds_allowlist(self):
+        js = _read(_APP_JS)
+        # Only fire for high-signal kinds. The list lives in a single
+        # place so future additions don't drift across files.
+        assert "_browserNotifyKinds: ['approval', 'credential', 'alert', 'blocker']" in js
+
+
+class TestActivityRollup:
+    """Long-task progress rollup in the activity feed.
+
+    The rollup is presentation-only — the underlying ``events`` array
+    is unchanged so the "Show technical detail" toggle still surfaces
+    the raw stream.
+    """
+
+    def test_rollup_helper_declared(self):
+        js = _read(_APP_JS)
+        assert "_rollupActivityEvents(events)" in js
+        assert "formatRolledActivityLine(entry)" in js
+        # The feed-renderer uses the ``rolledFilteredEvents`` getter
+        # rather than calling the helper inline.
+        assert "rolledFilteredEvents" in js
+
+    def test_rollup_groups_consecutive_same_tool(self):
+        result = _run_rollup_js([
+            {"type": "tool_start", "agent": "researcher",
+             "data": {"tool": "web_search"}, "timestamp": 1000},
+            {"type": "tool_start", "agent": "researcher",
+             "data": {"tool": "web_search"}, "timestamp": 1060},
+            {"type": "tool_start", "agent": "researcher",
+             "data": {"tool": "web_search"}, "timestamp": 1120},
+        ])
+        assert len(result) == 1
+        assert result[0]["kind"] == "rollup"
+        assert result[0]["count"] == 3
+        assert result[0]["tool"] == "web_search"
+
+    def test_rollup_resets_on_tool_change(self):
+        result = _run_rollup_js([
+            {"type": "tool_start", "agent": "researcher",
+             "data": {"tool": "web_search"}, "timestamp": 1000},
+            {"type": "tool_start", "agent": "researcher",
+             "data": {"tool": "web_search"}, "timestamp": 1060},
+            {"type": "tool_start", "agent": "researcher",
+             "data": {"tool": "browser_navigate"}, "timestamp": 1120},
+        ])
+        assert len(result) == 2
+        # First group: 2x web_search collapsed.
+        assert result[0]["kind"] == "rollup"
+        assert result[0]["count"] == 2
+        assert result[0]["tool"] == "web_search"
+        # Second group: a single browser_navigate, NOT decorated.
+        assert result[1]["kind"] == "single"
+
+    def test_rollup_resets_on_agent_change(self):
+        result = _run_rollup_js([
+            {"type": "tool_start", "agent": "researcher",
+             "data": {"tool": "web_search"}, "timestamp": 1000},
+            {"type": "tool_start", "agent": "writer",
+             "data": {"tool": "web_search"}, "timestamp": 1060},
+        ])
+        # Different agents must NEVER fold into the same rollup, even
+        # for the same tool name.
+        assert len(result) == 2
+        assert all(e["kind"] == "single" for e in result)
+
+    def test_rollup_resets_on_status_change(self):
+        result = _run_rollup_js([
+            {"type": "tool_start", "agent": "researcher",
+             "data": {"tool": "web_search"}, "timestamp": 1000},
+            {"type": "tool_start", "agent": "researcher",
+             "data": {"tool": "web_search"}, "timestamp": 1060},
+            {"type": "task_status_changed", "agent": "researcher",
+             "data": {"new_status": "blocked"}, "timestamp": 1080},
+            {"type": "tool_start", "agent": "researcher",
+             "data": {"tool": "web_search"}, "timestamp": 1100},
+        ])
+        # Group A (2x web_search) → status divider → fresh single
+        # web_search. Status events are always emitted as singles.
+        assert len(result) == 3
+        assert result[0]["kind"] == "rollup"
+        assert result[0]["count"] == 2
+        assert result[1]["kind"] == "single"
+        assert result[1]["event"]["type"] == "task_status_changed"
+        assert result[2]["kind"] == "single"
+
+    def test_rollup_singleton_unchanged(self):
+        result = _run_rollup_js([
+            {"type": "tool_start", "agent": "researcher",
+             "data": {"tool": "web_search"}, "timestamp": 1000},
+        ])
+        assert len(result) == 1
+        # Single events are NOT decorated; the renderer falls back to
+        # formatActivityForUser as before.
+        assert result[0]["kind"] == "single"
+
+    def test_rollup_preserves_raw_events_for_tech_detail(self):
+        """The raw stream renderer is gated on ``showTechDetail`` and
+        iterates over ``filteredEvents``, not the rolled-up list. So
+        flipping the toggle still surfaces every event."""
+        html = _read(_TEMPLATE)
+        # Tech-detail branch iterates over the unaltered filteredEvents.
+        assert 'x-if="showTechDetail"' in html
+        # Roll-up branch iterates over the new getter.
+        assert 'x-if="!showTechDetail"' in html
+        assert 'in rolledFilteredEvents' in html
+
+
+class TestConnectChannelPrompt:
+    """Soft 'Connect a channel' nudge in the wizard first-output."""
+
+    def test_first_output_card_has_connect_channel_link(self):
+        html = _read(_TEMPLATE)
+        assert 'data-testid="wizard-connect-channel"' in html
+        assert 'data-testid="wizard-connect-channel-link"' in html
+        # Click handler hops to Settings → Integrations and completes
+        # the wizard so we don't strand the user on a dismissed card.
+        assert "systemTab = 'integrations'" in html
+        assert "switchTab('system')" in html
+        # The copy is locked — keep the nudge soft.
+        assert "Want updates when you" in html
+        assert "Connect Telegram" in html
+
+
+# ── Helpers — JS-source extraction + node subprocess ────────────
+
+
+def _extract_function_body(js: str, name: str) -> str | None:
+    """Return the body of a top-level method definition.
+
+    Handles the Alpine-component shape ``name(args) { ... }`` by
+    counting brace depth. Returns ``None`` when the method doesn't
+    appear in the source.
+    """
+    needle = re.search(rf"\b{re.escape(name)}\s*\([^)]*\)\s*\{{", js)
+    if not needle:
+        return None
+    start = needle.end()
+    depth = 1
+    i = start
+    while i < len(js) and depth > 0:
+        ch = js[i]
+        if ch == "{":
+            depth += 1
+        elif ch == "}":
+            depth -= 1
+        i += 1
+    if depth != 0:
+        return None
+    return js[start:i - 1]
+
+
+def _run_rollup_js(events: list[dict]) -> list[dict]:
+    """Run ``_rollupActivityEvents`` against a fixed event list under
+    Node.js. Skips when node isn't available so contributors without a
+    Node toolchain still pass the rest of the suite. CI runners
+    (``ubuntu-latest``) have Node preinstalled.
+    """
+    import json as _json
+    import shutil as _shutil
+    import subprocess as _sp
+
+    node_bin = _shutil.which("node")
+    if node_bin is None:
+        pytest.skip("node not available — skipping rollup behaviour test")
+    js = _read(_APP_JS)
+    rollup_body = _extract_function_body(js, "_rollupActivityEvents")
+    if rollup_body is None:
+        pytest.fail("could not locate _rollupActivityEvents in app.js")
+    # Reconstruct a minimal harness that exposes the helper as a
+    # standalone function. ``this`` isn't referenced inside the
+    # rollup body so we don't need Alpine wiring.
+    harness = (
+        "const events = " + _json.dumps(events) + ";\n"
+        "function rollup(events) {" + rollup_body + "}\n"
+        "process.stdout.write(JSON.stringify(rollup(events)));\n"
+    )
+    proc = _sp.run(
+        [node_bin, "-e", harness],
+        capture_output=True,
+        text=True,
+        timeout=15,
+    )
+    if proc.returncode != 0:
+        pytest.fail(f"node harness failed: {proc.stderr}")
+    return _json.loads(proc.stdout)


### PR DESCRIPTION
## Summary

Three features from the user-journey audit: browser notification API for off-tab signals, long-task progress rollup in the activity feed, and a "connect a channel" prompt in the wizard's first-output card.

## 1. Browser Notification API (off-tab signals)

Today, users without configured channels (Telegram/Slack/Discord/WhatsApp) only see notifications when the dashboard tab is open. New users are blind until they return.

**Triple-redundant gate** (verified by `test_browser_notify_fire_is_triple_gated`):
1. `browserNotifyEnabled === true` (in-app opt-in, persisted to `olBrowserNotifyEnabled`)
2. `Notification.permission === 'granted'` (OS-level)
3. `document.visibilityState !== 'visible'` (off-tab only)

Plus a kind allowlist (`approval`, `credential`, `alert`, `blocker`) and `_lastNotifiedId` high-water mark so reloading doesn't replay the inbox.

Click → focus tab + switch to the relevant context (Needs-You modal for approvals, etc.).

## 2. Long-task progress rollup

Today the activity feed shows one line per `tool_start` event. A 30-min web research task creates 50+ "Researcher is searching the web" lines.

New `rolledFilteredEvents` getter aggregates consecutive `(agent, tool_name)` events:

Example sequence (4× web_search → status change → 2× web_fetch → 1× file_write):
```
researcher is searching the web (4 queries · 12m elapsed)
researcher started working
researcher is reading a web page (2 pages · 30s elapsed)
writer is writing a file
```

- Plural noun is tool-aware (`queries` / `pages` / `actions` fallback)
- Resets on tool change, agent change, or `task_status_changed`
- Singletons render unchanged (no decoration noise)
- Presentation-only — raw `events` array unchanged
- "Show technical detail" toggle iterates raw stream as before

## 3. Connect-channel prompt in wizard first-output

The wizard's first-output card now ends with:
- "Want updates when you're not on the dashboard? Connect Telegram, Slack, or another channel →" → `Settings → Integrations`
- "Enable browser notifications" button with `granted` / `denied` state advisories

Existing quick-link chips (View team / See what they're working on / Got it, close) preserved.

## Test plan

- [x] Browser-notify button renders in wizard first-output
- [x] Permission persists to localStorage (`olBrowserNotifyEnabled`)
- [x] Triple-redundant fire gate (in-app opt-in + OS permission + tab not visible)
- [x] Kind allowlist (only approval/credential/alert/blocker fire)
- [x] `_lastNotifiedId` high-water mark prevents replay on reload
- [x] Activity rollup groups consecutive same-tool events
- [x] Rollup resets on tool / agent / status change
- [x] Singleton events render without decoration
- [x] Plural noun is tool-aware
- [x] Connect-channel link routes to Settings → Integrations

**12 new tests pass** in `TestBrowserNotifyOptIn` / `TestActivityRollup` / `TestConnectChannelPrompt`. 333 dashboard tests + 33 events tests + 34 workspace/auth tests all green. `ruff` clean. `node --check` valid JS.

## Stats

3 files changed: +590 / -22.

## Coordination

Depends on **PR-B** (notifications producer wiring) for the `notifications` array to actually populate. Without PR-B, this PR's browser notifications still work but only fire for the empty/manual cases until the producer ships.