### PR TITLE
fix(dashboard): rename Home → Work + reorder tabs (PR-G)

### DIFF
--- a/src/dashboard/static/js/app.js
+++ b/src/dashboard/static/js/app.js
@@ -49,17 +49,18 @@ function dashboard() {
     tabs: [
       { id: 'chat', label: 'Chat' },
       // Phase 2 Board UX overhaul — engineer-speak → user-speak
-      // (Agents → Team, Board → Home, System → Settings).
+      // (Agents → Team, Board → Work, System → Settings).
+      // Work sits 2nd: it's the second-most-visited tab after Chat.
+      { id: 'workplace', label: 'Work' },
       { id: 'fleet', label: 'Team' },
-      { id: 'workplace', label: 'Home' },
       { id: 'system', label: 'Settings' },
     ],
     // Side panel toggle for non-Chat tabs (Phase 1 Decision 5). Persists
     // across navigation via Alpine root scope; localStorage carries it
     // through reloads so users keep their messenger open as they wander.
     messengerSidePanelOpen: false,
-    // Last time the user viewed the Home tab. Drives the Chat tab
-    // delivery banner ("Writer delivered draft 12m ago — see on Home →")
+    // Last time the user viewed the Work tab. Drives the Chat tab
+    // delivery banner ("Writer delivered draft 12m ago — see on Work →")
     // — banner shows when ``recentlyDeliveredItems`` has entries newer
     // than this timestamp. Persisted to localStorage.
     _lastViewedHomeTs: 0,
@@ -1655,11 +1656,11 @@ function dashboard() {
 
     /**
      * Display label for a top-nav tab. Renames Agents/Board/System to
-     * Team/Home/Settings without touching the tab IDs (URLs, routes,
+     * Team/Work/Settings without touching the tab IDs (URLs, routes,
      * and JS state vars all stay on the legacy IDs).
      */
     tabLabelFor(tab) {
-      const map = { fleet: 'Team', workplace: 'Home', system: 'Settings' };
+      const map = { fleet: 'Team', workplace: 'Work', system: 'Settings' };
       return map[tab.id] || tab.label;
     },
 
@@ -1707,7 +1708,7 @@ function dashboard() {
       const title = (pick.title || 'a task').toString().slice(0, 60);
       const ageMin = Math.max(1, Math.round((Date.now() - pickTs) / 60000));
       const ageStr = ageMin < 60 ? `${ageMin}m ago` : `${Math.round(ageMin / 60)}h ago`;
-      return `${who} delivered ${title} ${ageStr} — see on Home →`;
+      return `${who} delivered ${title} ${ageStr} — see on Work →`;
     },
 
     /** Mark Home as viewed (clears the delivery banner). */

--- a/src/dashboard/templates/index.html
+++ b/src/dashboard/templates/index.html
@@ -202,7 +202,7 @@
                 <svg fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="4" y1="21" x2="4" y2="14"/><line x1="4" y1="10" x2="4" y2="3"/><line x1="12" y1="21" x2="12" y2="12"/><line x1="12" y1="8" x2="12" y2="3"/><line x1="20" y1="21" x2="20" y2="16"/><line x1="20" y1="12" x2="20" y2="3"/><line x1="1" y1="14" x2="7" y2="14"/><line x1="9" y1="8" x2="15" y2="8"/><line x1="17" y1="16" x2="23" y2="16"/></svg>
               </template>
               <!-- Phase 1: ``Agents`` becomes ``Team`` (and the (N)
-                   running counter rides along); ``Board``→``Home``,
+                   running counter rides along); ``Board``→``Work``,
                    ``System``→``Settings``. Tab IDs stay frozen so URLs
                    / routes don't break. -->
               <span x-text="(tab.id === 'fleet' && agents.length)
@@ -3789,14 +3789,14 @@
             class="text-[12px] text-gray-400 hover:text-gray-200 inline-flex items-center gap-1 transition-colors"
             data-testid="home-back-to-main">
             <svg class="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M19 12H5M12 19l-7-7 7-7"/></svg>
-            Back to Home
+            Back to Work
           </button>
         </div>
 
         <!-- Empty state when orchestration v2 is disabled -->
         <template x-if="!workplaceEnabled">
           <div class="bg-gray-800/40 border border-gray-700/50 rounded-xl p-6 text-center">
-            <div class="text-gray-300 text-sm font-medium mb-2">Home is disabled</div>
+            <div class="text-gray-300 text-sm font-medium mb-2">Work is disabled</div>
             <div class="text-xs text-gray-400 max-w-md mx-auto">
               Contact support to enable.
             </div>

--- a/tests/test_dashboard_ui.py
+++ b/tests/test_dashboard_ui.py
@@ -299,7 +299,8 @@ class TestWizardEndpointWiring:
 class TestTabLabelVocabulary:
     def test_tabs_array_uses_user_speak(self):
         # The Alpine ``tabs`` array maps internal IDs to display labels.
-        # Phase 2 renames Agents → Team, Board → Home, System → Settings.
+        # Phase 2 renames Agents → Team, Board → Work, System → Settings.
+        # Work sits 2nd: it's the second-most-visited tab after Chat.
         m = re.search(
             r"tabs:\s*\[(.*?)\],",
             _APP_JS_TEXT,
@@ -308,8 +309,16 @@ class TestTabLabelVocabulary:
         assert m, "Could not locate the tabs array in app.js"
         block = m.group(1)
         assert "id: 'fleet'" in block and "label: 'Team'" in block
-        assert "id: 'workplace'" in block and "label: 'Home'" in block
+        assert "id: 'workplace'" in block and "label: 'Work'" in block
         assert "id: 'system'" in block and "label: 'Settings'" in block
+        # Order: Chat | Work | Team | Settings (Work is 2nd, Team 3rd).
+        chat_idx = block.find("id: 'chat'")
+        work_idx = block.find("id: 'workplace'")
+        team_idx = block.find("id: 'fleet'")
+        system_idx = block.find("id: 'system'")
+        assert chat_idx < work_idx < team_idx < system_idx, (
+            "tabs must be ordered Chat | Work | Team | Settings"
+        )
 
     def test_fleet_running_count_uses_team_word(self):
         # The dynamic-label expression in the top-nav swaps "Agents (N)"
@@ -1195,7 +1204,7 @@ class TestVocabSweepGaps:
         # Sanity check that the replacements actually landed.
         assert "Spawn helpers" in _INDEX_HTML
         assert "Schedules" in _INDEX_HTML
-        assert "Home is disabled" in _INDEX_HTML
+        assert "Work is disabled" in _INDEX_HTML
         assert "Contact support to enable." in _INDEX_HTML
         assert "+ Schedule" in _INDEX_HTML
         assert "New schedule" in _INDEX_HTML


### PR DESCRIPTION
## Summary

CPO call: "Home" was generic and didn't tell users what was on the page. "Work" is action-oriented and accurate. Plus reorder Work to second position because it's the second-most-frequently-visited tab after Chat.

**Tab order changes:**

Before: `Chat | Team | Home | Settings`
After: `Chat | Work | Team | Settings`

Internal route id `'workplace'` UNCHANGED (URL stability). Same ID precedent as the original Board → Home rename.

## Changes

7 user-facing replacements + 3 doc comments brought in sync:
- Tabs array label
- `tabLabelFor` map entry
- Delivery banner copy ("see on Home →" → "see on Work →")
- "Back to Home" link → "Back to Work"
- "Home is disabled" empty state → "Work is disabled"
- 2 test assertions updated

## Verification

- `grep "label: 'Home'" src/dashboard/static/js/app.js` → 0 matches
- `grep "'Work'" src/dashboard/static/js/app.js` → 2 matches (tabs array + tabLabelFor map)
- Internal `'workplace'` route id → 9 occurrences in app.js, untouched
- Slack "App Home" mentions in index.html intentionally untouched (those are Slack's own product naming, not our tab)

## Test plan

- [x] Tabs render in order `Chat | Work | Team | Settings`
- [x] All "Home" → "Work" user-facing strings updated
- [x] Internal route id `'workplace'` preserved
- [x] Existing URL bookmarks still work

**174 tests pass + 4 skipped** in `test_dashboard_ui.py`. **358 tests pass** in `test_dashboard.py` + `test_dashboard_workspace.py`. `ruff` clean.

## Stats

3 files changed: +23 / -13.