### PR TITLE
feat(dashboard): replace what's-new tour with new-user onboarding tutorial (PR-J)

### DIFF
--- a/src/dashboard/static/js/app.js
+++ b/src/dashboard/static/js/app.js
@@ -650,15 +650,16 @@ function dashboard() {
     _wizardBuildPoll: null,
     _wizardCompleteTimer: null,
 
-    // Phase 4 — "What's new" tour for existing-fleet users seeing the
-    // redesigned dashboard for the first time. Three modal steps,
-    // skippable, persists to ``localStorage.olSeenWhatsNew = 'true'``
-    // on completion or skip. Distinct from the empty-fleet wizard
-    // above — those are mutually exclusive (empty fleet = wizard,
-    // existing fleet = tour).
-    whatsNewTour: { step: 0 },  // 0 = closed; 1..3 = visible
-    _whatsNewTourPrevFocus: null,
-    _whatsNewTourKeyHandler: null,
+    // New-user onboarding tutorial. Three modal steps that orient a
+    // brand-new user on the layout + Operator concept. Skippable;
+    // persists to ``localStorage.olSeenTutorial = 'true'`` on completion
+    // or skip. Repurposed from the Phase-4 "What's new" tour
+    // infrastructure, but the audience is inverted: tutorial fires for
+    // EMPTY fleets (new users) and runs BEFORE the empty-fleet wizard.
+    // Once tutorial completes, ``_maybeStartWizard`` takes over.
+    newUserTutorial: { step: 0 },  // 0 = closed; 1..3 = visible
+    _newUserTutorialPrevFocus: null,
+    _newUserTutorialKeyHandler: null,
 
     // Track the element focused before the side panel opened so ESC
     // restores focus to the original trigger on close.
@@ -1175,6 +1176,21 @@ function dashboard() {
         const v = localStorage.getItem('ol_messenger_side_panel_open');
         if (v === '1') this.messengerSidePanelOpen = true;
       } catch (e) { /* ignore */ }
+
+      // Migration: users who saw the legacy "What's new" tour (Phase 4)
+      // had the ``olSeenWhatsNew`` flag set. Those users had non-empty
+      // fleets — they're not new — and shouldn't see the new-user
+      // tutorial either. Carry the flag forward so the tutorial stays
+      // suppressed for everyone who already passed through the legacy
+      // tour. Idempotent — only writes when ``olSeenTutorial`` is unset.
+      try {
+        if (
+          localStorage.getItem('olSeenWhatsNew') === 'true' &&
+          !localStorage.getItem('olSeenTutorial')
+        ) {
+          localStorage.setItem('olSeenTutorial', 'true');
+        }
+      } catch (_) { /* private mode — ignore */ }
 
       // Build credential service options from server-injected providers
       const allProviders = cfg.allProviders || [];
@@ -1728,7 +1744,7 @@ function dashboard() {
       try {
         if (this.messengerSidePanelOpen) {
           // Capture the previously focused element so ESC can restore
-          // focus on close (mirrors _whatsNewTourPrevFocus pattern).
+          // focus on close (mirrors _newUserTutorialPrevFocus pattern).
           try { this._messengerSidePanelPrevFocus = document.activeElement; } catch (_) {}
           localStorage.setItem('ol_messenger_side_panel_open', '1');
           // Open Operator by default if no chat is active.
@@ -1850,6 +1866,7 @@ function dashboard() {
       // wizard. Without this, an operator that boots slowly (e.g.
       // first start) would have skipped wizard kickoff at fetchAgents.
       if (!wasReady && this.operatorReady) {
+        try { this._maybeStartTutorial(); } catch (_) { /* ignore */ }
         try { this._maybeStartWizard(); } catch (_) { /* ignore */ }
       }
     },
@@ -2341,42 +2358,55 @@ function dashboard() {
       if (this.wizard.step !== 'idle') return;
       if (!this.operatorReady) return;
       if (!this._isFirstVisit()) return;
+      // Tutorial takes precedence — wizard fires only after the
+      // tutorial completes (or was already seen). The completion
+      // handler in ``_completeTutorial`` re-invokes ``_maybeStartWizard``
+      // when the user reaches the final step naturally.
+      if (this.newUserTutorial && this.newUserTutorial.step !== 0) return;
       this.startWizard();
     },
 
-    // ── Phase 4 "What's new" tour ────────────────────────────
+    // ── New-user onboarding tutorial ──────────────────────────
     //
-    // 3-step modal for existing-fleet users seeing the redesigned
-    // dashboard for the first time. Detection: agents.length > 0
-    // (excluding operator) AND ``localStorage.olSeenWhatsNew !== 'true'``
-    // AND no active wizard (mutual exclusion). On any exit path —
-    // skip, dismiss, or reaching step 3 — we set the seen flag so the
-    // tour never re-shows for that browser.
+    // 3-step modal that orients a brand-new user on the layout +
+    // Operator concept. Detection: agents.length === 0 (excluding
+    // operator) AND ``localStorage.olSeenTutorial !== 'true'`` AND no
+    // active wizard. Runs BEFORE the empty-fleet wizard — the wizard
+    // is gated on ``newUserTutorial.step === 0`` so the two never
+    // overlap. On completion of step 3, we dismiss the tutorial and
+    // immediately fire the wizard so the user lands directly in the
+    // team-building flow. On any exit path — skip, dismiss, or
+    // reaching step 3 — we set the seen flag so the tutorial never
+    // re-shows for that browser.
 
-    _maybeStartWhatsNewTour() {
-      if (this.whatsNewTour.step !== 0) return;
+    _maybeStartTutorial() {
+      if (this.newUserTutorial.step !== 0) return;
       if (this.wizard && this.wizard.step !== 'idle') return;
       try {
-        if (localStorage.getItem('olSeenWhatsNew') === 'true') return;
+        if (localStorage.getItem('olSeenTutorial') === 'true') return;
       } catch (_) { /* private mode — show once per session */ }
-      const fleetAgents = (this.agents || []).filter(a => a && a.id !== 'operator');
-      if (fleetAgents.length === 0) return;
-      this.startWhatsNewTour();
+      // Use the canonical first-visit detector — covers empty fleet AND
+      // "no real user message in operator history". A returning user
+      // who deleted their fleet but already chatted with the operator
+      // is NOT a new user; suppressing the tutorial in that case
+      // matches the wizard's gating semantics.
+      if (!this._isFirstVisit()) return;
+      this.startTutorial();
     },
 
-    startWhatsNewTour() {
-      this.whatsNewTour = { step: 1 };
-      this.track('whats_new_tour_started', {});
+    startTutorial() {
+      this.newUserTutorial = { step: 1 };
+      this.track('tutorial_started', {});
       // Capture focus + install ESC handler. Focus the modal on next
       // tick so screen-readers announce the dialog.
-      try { this._whatsNewTourPrevFocus = document.activeElement; } catch (_) {}
-      this._whatsNewTourKeyHandler = (e) => {
+      try { this._newUserTutorialPrevFocus = document.activeElement; } catch (_) {}
+      this._newUserTutorialKeyHandler = (e) => {
         if (e.key === 'Escape') {
           e.preventDefault();
-          this.dismissWhatsNewTour('escape');
+          this.dismissTutorial('escape');
         } else if (e.key === 'Tab') {
           // Lightweight focus trap — keep tab cycling inside the modal.
-          const root = document.querySelector('[data-testid="whats-new-modal"]');
+          const root = document.querySelector('[data-testid="tutorial-modal"]');
           if (!root) return;
           const focusable = root.querySelectorAll(
             'button:not([disabled]), [href], [tabindex]:not([tabindex="-1"])'
@@ -2393,54 +2423,62 @@ function dashboard() {
           }
         }
       };
-      window.addEventListener('keydown', this._whatsNewTourKeyHandler);
+      window.addEventListener('keydown', this._newUserTutorialKeyHandler);
       this.$nextTick(() => {
-        const root = document.querySelector('[data-testid="whats-new-modal"]');
-        const target = root && root.querySelector('[data-testid="whats-new-primary"]');
+        const root = document.querySelector('[data-testid="tutorial-modal"]');
+        const target = root && root.querySelector('[data-testid="tutorial-primary"]');
         if (target && typeof target.focus === 'function') target.focus();
       });
     },
 
-    whatsNewTourNext() {
-      if (this.whatsNewTour.step >= 3) {
-        this._completeWhatsNewTour('completed');
+    tutorialNext() {
+      if (this.newUserTutorial.step >= 3) {
+        this._completeTutorial('completed');
         return;
       }
-      this.whatsNewTour.step += 1;
-      this.track('whats_new_tour_step', { step: this.whatsNewTour.step });
+      this.newUserTutorial.step += 1;
+      this.track('tutorial_step', { step: this.newUserTutorial.step });
       this.$nextTick(() => {
-        const root = document.querySelector('[data-testid="whats-new-modal"]');
-        const target = root && root.querySelector('[data-testid="whats-new-primary"]');
+        const root = document.querySelector('[data-testid="tutorial-modal"]');
+        const target = root && root.querySelector('[data-testid="tutorial-primary"]');
         if (target && typeof target.focus === 'function') target.focus();
       });
     },
 
-    whatsNewTourBack() {
-      if (this.whatsNewTour.step > 1) {
-        this.whatsNewTour.step -= 1;
-        this.track('whats_new_tour_step', { step: this.whatsNewTour.step, direction: 'back' });
+    tutorialBack() {
+      if (this.newUserTutorial.step > 1) {
+        this.newUserTutorial.step -= 1;
+        this.track('tutorial_step', { step: this.newUserTutorial.step, direction: 'back' });
       }
     },
 
-    dismissWhatsNewTour(reason) {
-      this._completeWhatsNewTour(reason || 'dismissed');
+    dismissTutorial(reason) {
+      this._completeTutorial(reason || 'dismissed');
     },
 
-    _completeWhatsNewTour(reason) {
-      const lastStep = this.whatsNewTour.step;
-      try { localStorage.setItem('olSeenWhatsNew', 'true'); } catch (_) {}
-      this.whatsNewTour = { step: 0 };
-      this.track('whats_new_tour_finished', { reason: reason, lastStep: lastStep });
-      if (this._whatsNewTourKeyHandler) {
-        window.removeEventListener('keydown', this._whatsNewTourKeyHandler);
-        this._whatsNewTourKeyHandler = null;
+    _completeTutorial(reason) {
+      const lastStep = this.newUserTutorial.step;
+      try { localStorage.setItem('olSeenTutorial', 'true'); } catch (_) {}
+      this.newUserTutorial = { step: 0 };
+      this.track('tutorial_finished', { reason: reason, lastStep: lastStep });
+      if (this._newUserTutorialKeyHandler) {
+        window.removeEventListener('keydown', this._newUserTutorialKeyHandler);
+        this._newUserTutorialKeyHandler = null;
       }
       try {
-        if (this._whatsNewTourPrevFocus && this._whatsNewTourPrevFocus.focus) {
-          this._whatsNewTourPrevFocus.focus();
+        if (this._newUserTutorialPrevFocus && this._newUserTutorialPrevFocus.focus) {
+          this._newUserTutorialPrevFocus.focus();
         }
       } catch (_) {}
-      this._whatsNewTourPrevFocus = null;
+      this._newUserTutorialPrevFocus = null;
+      // On natural completion (Got it on step 3), hand off to the
+      // empty-fleet wizard so the user lands directly in team-building.
+      // Skip / ESC / overlay-click do NOT auto-fire the wizard — the
+      // user signaled they want out, respect that.
+      if (reason === 'completed') {
+        this.track('tutorial_to_wizard_transition', {});
+        try { this._maybeStartWizard(); } catch (_) { /* ignore */ }
+      }
     },
 
     // ── Tab switching ─────────────────────────────────────
@@ -4802,14 +4840,17 @@ function dashboard() {
           this._fetchCoordination();
           // Update operator readiness for the Chat tab
           this.checkOperatorReady();
+          // New-user onboarding tutorial — runs FIRST when both are
+          // eligible. ``_maybeStartWizard`` gates on
+          // ``newUserTutorial.step === 0`` so the wizard never fires
+          // while the tutorial is open. On natural completion of the
+          // tutorial, ``_completeTutorial`` re-invokes the wizard.
+          this._maybeStartTutorial();
           // Phase -1 wizard — first-visit detection runs after every
           // ``fetchAgents`` resolve so a freshly-spawned agent (still
           // loading at init time) doesn't pop the wizard. Re-entrant
           // calls during the same visit are no-ops.
           this._maybeStartWizard();
-          // Phase 4 — "What's new" tour for existing-fleet users.
-          // Mutually exclusive with the empty-fleet wizard.
-          this._maybeStartWhatsNewTour();
         }
       } catch (e) {
         console.warn('fetchAgents failed:', e);

--- a/src/dashboard/templates/index.html
+++ b/src/dashboard/templates/index.html
@@ -8498,89 +8498,89 @@
       </div>
     </div>
 
-    <!-- Phase 4 — "What's new" tour for existing-fleet users. Three
-         skippable modal steps; persists ``localStorage.olSeenWhatsNew``
-         on completion or dismiss. ``role="dialog"`` + focus trap +
-         ESC handler are wired in app.js. Mobile: full-screen at
-         <640px via ``sm:max-w-md`` cap. -->
-    <template x-if="whatsNewTour.step !== 0">
+    <!-- New-user onboarding tutorial. Three skippable modal steps;
+         persists ``localStorage.olSeenTutorial`` on completion or
+         dismiss. Repurposed from the Phase-4 "What's new" tour
+         infrastructure — same modal chrome, focus trap, ESC handler
+         (wired in app.js), and mobile full-screen via ``sm:max-w-md``.
+         The audience is inverted: this fires for EMPTY fleets and runs
+         BEFORE the empty-fleet wizard. On natural completion, the
+         wizard auto-fires so the user lands directly in team-building. -->
+    <template x-if="newUserTutorial.step !== 0">
       <div class="fixed inset-0 z-[150] flex items-center justify-center bg-black/70 backdrop-blur-sm p-0 sm:p-4"
-           data-testid="whats-new-overlay"
-           @click.self="dismissWhatsNewTour('overlay')">
-        <div role="dialog" aria-modal="true" :aria-labelledby="'whats-new-title-' + whatsNewTour.step"
-             data-testid="whats-new-modal"
+           data-testid="tutorial-overlay"
+           @click.self="dismissTutorial('overlay')">
+        <div role="dialog" aria-modal="true" :aria-labelledby="'tutorial-title-' + newUserTutorial.step"
+             data-testid="tutorial-modal"
              class="relative w-full h-full sm:h-auto sm:max-w-md sm:rounded-2xl bg-gradient-to-b from-indigo-900/40 to-gray-900/95 sm:border sm:border-indigo-700/40 shadow-2xl overflow-y-auto sm:overflow-visible flex flex-col sm:block">
-          <!-- Step 1 -->
-          <template x-if="whatsNewTour.step === 1">
+          <!-- Step 1 — Welcome / what is OpenLegion -->
+          <template x-if="newUserTutorial.step === 1">
             <div class="px-6 pt-8 pb-6 sm:pt-7 sm:pb-6 flex-1 flex flex-col">
               <div class="flex items-start justify-between mb-3">
                 <div class="text-[11px] uppercase tracking-wide text-indigo-300/80">Step 1 of 3</div>
-                <button @click="dismissWhatsNewTour('skip_button')"
-                        data-testid="whats-new-skip"
-                        aria-label="Skip tour"
+                <button @click="dismissTutorial('skip_button')"
+                        data-testid="tutorial-skip"
+                        aria-label="Skip tutorial"
                         class="text-gray-500 hover:text-gray-300 transition-colors p-1 -mr-1 -mt-1 rounded text-xs">
                   Skip
                 </button>
               </div>
-              <h2 id="whats-new-title-1" class="text-lg font-semibold text-white mb-2">
-                We&rsquo;ve simplified your dashboard
+              <h2 id="tutorial-title-1" class="text-lg font-semibold text-white mb-2">
+                Welcome to OpenLegion
               </h2>
               <p class="text-sm text-gray-300 leading-relaxed mb-6 flex-1">
-                Your team&rsquo;s work and your conversation with the Operator are now
-                easier to find. Take a quick tour?
+                OpenLegion is your AI team manager. You hire AI workers, give them tasks,
+                and watch them deliver &mdash; like a small remote team.
               </p>
               <div class="flex items-center justify-end gap-2">
-                <button @click="dismissWhatsNewTour('skip_button')"
+                <button @click="dismissTutorial('skip_button')"
                         class="text-xs font-medium px-4 py-2 rounded-lg bg-transparent hover:bg-gray-800/60 text-gray-400 transition-colors">
                   Skip
                 </button>
-                <button @click="whatsNewTourNext()"
-                        data-testid="whats-new-primary"
+                <button @click="tutorialNext()"
+                        data-testid="tutorial-primary"
                         class="text-xs font-medium px-4 py-2 rounded-lg bg-indigo-600 hover:bg-indigo-500 text-white transition-colors">
-                  Show me
+                  Show me how
                 </button>
               </div>
             </div>
           </template>
 
-          <!-- Step 2 -->
-          <template x-if="whatsNewTour.step === 2">
+          <!-- Step 2 — Meet your Operator -->
+          <template x-if="newUserTutorial.step === 2">
             <div class="px-6 pt-8 pb-6 sm:pt-7 sm:pb-6 flex-1 flex flex-col">
               <div class="flex items-start justify-between mb-3">
                 <div class="text-[11px] uppercase tracking-wide text-indigo-300/80">Step 2 of 3</div>
-                <button @click="dismissWhatsNewTour('skip_button')"
-                        aria-label="Skip tour"
+                <button @click="dismissTutorial('skip_button')"
+                        aria-label="Skip tutorial"
                         class="text-gray-500 hover:text-gray-300 transition-colors p-1 -mr-1 -mt-1 rounded text-xs">
                   Skip
                 </button>
               </div>
-              <h2 id="whats-new-title-2" class="text-lg font-semibold text-white mb-3">
-                Operator is one click away
+              <h2 id="tutorial-title-2" class="text-lg font-semibold text-white mb-3">
+                Meet your Operator
               </h2>
               <div class="rounded-xl bg-gray-900/60 border border-indigo-500/30 p-4 mb-4 flex items-center gap-3">
                 <div class="w-10 h-10 rounded-full bg-indigo-600/30 border border-indigo-400/50 flex items-center justify-center shrink-0">
-                  <!-- Mirrors the side-panel toggle pictogram (rectangle
-                       + divider + arrow) so the tour points at the right
-                       control instead of the Chat tab's chat-bubble. -->
+                  <!-- Chat-bubble pictogram pointing at the Chat tab. -->
                   <svg class="w-5 h-5 text-indigo-300" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-                    <rect x="3" y="4" width="18" height="16" rx="2"/>
-                    <line x1="14" y1="4" x2="14" y2="20"/>
-                    <polyline points="8 10 11 12 8 14"/>
+                    <path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z"/>
                   </svg>
                 </div>
-                <div class="text-xs text-gray-300 leading-relaxed">Look for the panel icon in the top-right corner.</div>
+                <div class="text-xs text-gray-300 leading-relaxed">You&rsquo;re in <span class="font-semibold text-indigo-200">Chat</span> &mdash; talk to your Operator here.</div>
               </div>
               <p class="text-sm text-gray-300 leading-relaxed mb-6 flex-1">
-                Click the panel icon in the top-right from any page to talk to the Operator
-                without losing your place.
+                The Operator is your team lead. You talk to them in Chat (you&rsquo;re here
+                now). They route work, manage your team, and ping you when you&rsquo;re
+                needed.
               </p>
               <div class="flex items-center justify-between gap-2">
-                <button @click="whatsNewTourBack()"
+                <button @click="tutorialBack()"
                         class="text-xs font-medium px-4 py-2 rounded-lg bg-transparent hover:bg-gray-800/60 text-gray-400 transition-colors">
                   Back
                 </button>
-                <button @click="whatsNewTourNext()"
-                        data-testid="whats-new-primary"
+                <button @click="tutorialNext()"
+                        data-testid="tutorial-primary"
                         class="text-xs font-medium px-4 py-2 rounded-lg bg-indigo-600 hover:bg-indigo-500 text-white transition-colors">
                   Next
                 </button>
@@ -8588,35 +8588,35 @@
             </div>
           </template>
 
-          <!-- Step 3 -->
-          <template x-if="whatsNewTour.step === 3">
+          <!-- Step 3 — See what your team is doing -->
+          <template x-if="newUserTutorial.step === 3">
             <div class="px-6 pt-8 pb-6 sm:pt-7 sm:pb-6 flex-1 flex flex-col">
               <div class="flex items-start justify-between mb-3">
                 <div class="text-[11px] uppercase tracking-wide text-indigo-300/80">Step 3 of 3</div>
               </div>
-              <h2 id="whats-new-title-3" class="text-lg font-semibold text-white mb-3">
-                Approvals and notifications are in the top nav
+              <h2 id="tutorial-title-3" class="text-lg font-semibold text-white mb-3">
+                See what your team is doing
               </h2>
               <div class="rounded-xl bg-gray-900/60 border border-indigo-500/30 p-4 mb-4 flex items-center gap-3">
                 <span class="inline-flex items-center justify-center min-w-[18px] h-[18px] px-1 rounded-full bg-red-500 text-[10px] font-bold text-white">3</span>
                 <span class="text-gray-500">+</span>
                 <svg class="w-4 h-4 text-gray-300" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M15 17h5l-1.405-1.405A2.032 2.032 0 0118 14.158V11a6.002 6.002 0 00-4-5.659V5a2 2 0 10-4 0v.341C7.67 6.165 6 8.388 6 11v3.159c0 .538-.214 1.055-.595 1.436L4 17h5m6 0v1a3 3 0 11-6 0v-1m6 0H9"/></svg>
-                <div class="text-xs text-gray-300 leading-relaxed flex-1">Look top-right.</div>
+                <div class="text-xs text-gray-300 leading-relaxed flex-1">A red badge means something needs you.</div>
               </div>
               <p class="text-sm text-gray-300 leading-relaxed mb-6 flex-1">
-                Anything that needs your attention shows as a red badge. Past events show
-                in the bell icon. You&rsquo;ll always see what needs you, no matter what
-                tab you&rsquo;re on.
+                <span class="font-semibold text-indigo-200">Work</span> shows what your team
+                has delivered and what&rsquo;s in progress. Anything that needs you shows
+                as a red badge in the top-right &mdash; across every tab.
               </p>
               <div class="flex items-center justify-between gap-2">
-                <button @click="whatsNewTourBack()"
+                <button @click="tutorialBack()"
                         class="text-xs font-medium px-4 py-2 rounded-lg bg-transparent hover:bg-gray-800/60 text-gray-400 transition-colors">
                   Back
                 </button>
-                <button @click="whatsNewTourNext()"
-                        data-testid="whats-new-primary"
+                <button @click="tutorialNext()"
+                        data-testid="tutorial-primary"
                         class="text-xs font-medium px-4 py-2 rounded-lg bg-indigo-600 hover:bg-indigo-500 text-white transition-colors">
-                  Got it
+                  Got it, let&rsquo;s build a team
                 </button>
               </div>
             </div>

--- a/tests/test_dashboard_ui.py
+++ b/tests/test_dashboard_ui.py
@@ -778,25 +778,25 @@ class TestHomeRouting:
         assert "switchHomeTab(tabId)" in app_js
 
 
-# ── Phase 4: "What's new" tour for existing-fleet users ──────────
+# ── New-user onboarding tutorial ─────────────────────────────────
 
 
-class TestWhatsNewTourMarkup:
-    """The 3-step modal tour is hard-coded into the SPA template."""
+class TestNewUserTutorialMarkup:
+    """The 3-step tutorial modal is hard-coded into the SPA template."""
 
     def test_modal_block_is_present(self):
         html = _read(_TEMPLATE)
-        assert 'data-testid="whats-new-modal"' in html
+        assert 'data-testid="tutorial-modal"' in html
 
     def test_modal_renders_only_when_step_not_zero(self):
         html = _read(_TEMPLATE)
-        assert "whatsNewTour.step !== 0" in html
+        assert "newUserTutorial.step !== 0" in html
 
     def test_modal_has_three_steps(self):
         html = _read(_TEMPLATE)
         for step in (1, 2, 3):
-            assert f"whatsNewTour.step === {step}" in html, (
-                f"missing whats-new step: {step}"
+            assert f"newUserTutorial.step === {step}" in html, (
+                f"missing tutorial step: {step}"
             )
 
     def test_modal_has_dialog_role_and_modal_aria(self):
@@ -804,85 +804,225 @@ class TestWhatsNewTourMarkup:
         # role=dialog + aria-modal=true on the same element as the
         # data-testid hook — required for screen readers.
         assert re.search(
-            r'role="dialog"[^>]*?aria-modal="true"[^>]*?data-testid="whats-new-modal"'
-            r'|data-testid="whats-new-modal"[^>]*?role="dialog"',
+            r'role="dialog"[^>]*?aria-modal="true"[^>]*?data-testid="tutorial-modal"'
+            r'|data-testid="tutorial-modal"[^>]*?role="dialog"',
             html,
-        ), "whats-new modal missing role=dialog/aria-modal"
+        ), "tutorial modal missing role=dialog/aria-modal"
 
     def test_step1_copy_present(self):
         html = _read(_TEMPLATE)
-        assert "We&rsquo;ve simplified your dashboard" in html
-        assert "Skip" in html
-        assert "Show me" in html
+        assert "Welcome to OpenLegion" in html
+        assert "AI team manager" in html
+        assert "Show me how" in html
 
     def test_step2_copy_present(self):
         html = _read(_TEMPLATE)
-        assert "Operator is one click away" in html
-        assert "talk to the Operator" in html
+        assert "Meet your Operator" in html
+        assert "team lead" in html
 
     def test_step3_copy_present(self):
         html = _read(_TEMPLATE)
-        assert "Approvals and notifications are in the top nav" in html
-        assert "Got it" in html
+        assert "See what your team is doing" in html
+        assert "Got it, let&rsquo;s build a team" in html
 
-    def test_skip_button_dismisses_tour(self):
+    def test_skip_button_dismisses_tutorial(self):
         html = _read(_TEMPLATE)
-        assert 'data-testid="whats-new-skip"' in html
-        assert "dismissWhatsNewTour(" in html
+        assert 'data-testid="tutorial-skip"' in html
+        assert "dismissTutorial(" in html
 
     def test_primary_button_has_focus_target(self):
         # Focus management: each step's primary advance button is
         # auto-focused on entry (via querySelector in app.js).
         html = _read(_TEMPLATE)
-        assert 'data-testid="whats-new-primary"' in html
+        assert 'data-testid="tutorial-primary"' in html
 
 
-class TestWhatsNewTourJsState:
-    """Alpine handlers for the tour state machine."""
+class TestNewUserTutorialJsState:
+    """Alpine handlers for the tutorial state machine."""
 
-    def test_tour_state_object_declared(self):
+    def test_tutorial_state_object_declared(self):
         js = _read(_APP_JS)
-        assert "whatsNewTour: { step: 0 }" in js
+        assert "newUserTutorial: { step: 0 }" in js
 
-    def test_tour_handlers_declared(self):
+    def test_tutorial_handlers_declared(self):
         js = _read(_APP_JS)
         for handler in (
-            "_maybeStartWhatsNewTour()",
-            "startWhatsNewTour()",
-            "whatsNewTourNext()",
-            "whatsNewTourBack()",
-            "dismissWhatsNewTour(reason)",
-            "_completeWhatsNewTour(reason)",
+            "_maybeStartTutorial()",
+            "startTutorial()",
+            "tutorialNext()",
+            "tutorialBack()",
+            "dismissTutorial(reason)",
+            "_completeTutorial(reason)",
         ):
-            assert handler in js, f"missing tour handler: {handler}"
+            assert handler in js, f"missing tutorial handler: {handler}"
 
-    def test_tour_persists_seen_flag(self):
+    def test_tutorial_persists_seen_flag(self):
         js = _read(_APP_JS)
-        # Seen flag freezes the tour after first completion / dismiss.
-        assert "olSeenWhatsNew" in js
-        assert "localStorage.setItem('olSeenWhatsNew', 'true')" in js
+        # Seen flag freezes the tutorial after first completion/dismiss.
+        assert "olSeenTutorial" in js
+        assert "localStorage.setItem('olSeenTutorial', 'true')" in js
 
-    def test_tour_is_gated_on_existing_fleet(self):
+    def test_tutorial_fires_for_new_users_only(self):
         js = _read(_APP_JS)
-        # Detection: agents.length > 0 (excluding operator).
-        # The detector reuses the same operator-exclusion pattern as
-        # the empty-fleet wizard.
-        assert "_maybeStartWhatsNewTour" in js
-        assert "fleetAgents.length === 0" in js
+        # Detection delegates to ``_isFirstVisit()`` — empty fleet AND
+        # no real user message in the operator transcript. The wizard
+        # uses the same detector so the two stay in lockstep.
+        assert "_maybeStartTutorial" in js
+        m = re.search(
+            r"_maybeStartTutorial\(\)\s*\{(.*?)\n    \},",
+            _APP_JS_TEXT,
+            re.DOTALL,
+        )
+        assert m, "_maybeStartTutorial body missing"
+        body = m.group(1)
+        assert "_isFirstVisit()" in body, (
+            "tutorial gate should delegate to _isFirstVisit"
+        )
 
-    def test_tour_emits_locked_telemetry_events(self):
+    def test_tutorial_does_not_fire_for_existing_users(self):
+        # The detector early-returns when ``_isFirstVisit()`` is false —
+        # any non-empty fleet OR any prior user message in the operator
+        # transcript skips the tutorial.
+        m = re.search(
+            r"_maybeStartTutorial\(\)\s*\{(.*?)\n    \},",
+            _APP_JS_TEXT,
+            re.DOTALL,
+        )
+        assert m, "_maybeStartTutorial body missing"
+        body = m.group(1)
+        assert "if (!this._isFirstVisit()) return" in body, (
+            "tutorial should bail when _isFirstVisit() is false"
+        )
+
+    def test_tutorial_does_not_fire_for_returning_user_with_chat_history(self):
+        # Audit fix: the legacy gate checked only ``fleetAgents.length``
+        # which mis-classified a returning user who deleted their fleet
+        # but already chatted with the operator as "new". Delegating to
+        # ``_isFirstVisit()`` adds the "no user message in
+        # chatHistories.operator" check, so a returning chat-only user
+        # is correctly excluded.
+        m_first_visit = re.search(
+            r"_isFirstVisit\(\)\s*\{(.*?)\n    \},",
+            _APP_JS_TEXT,
+            re.DOTALL,
+        )
+        assert m_first_visit, "_isFirstVisit body missing"
+        first_visit_body = m_first_visit.group(1)
+        # Confirm _isFirstVisit covers BOTH conditions: empty fleet AND
+        # no prior user message in operator chatHistories.
+        assert "this.agents.some" in first_visit_body, (
+            "_isFirstVisit must check the agents list"
+        )
+        assert "chatHistories['operator']" in first_visit_body, (
+            "_isFirstVisit must check operator chat history"
+        )
+        assert "m.role === 'user'" in first_visit_body, (
+            "_isFirstVisit must filter on user-role messages"
+        )
+        # And confirm the tutorial actually delegates to it (not an
+        # inline fleetAgents-only check).
+        m_tut = re.search(
+            r"_maybeStartTutorial\(\)\s*\{(.*?)\n    \},",
+            _APP_JS_TEXT,
+            re.DOTALL,
+        )
+        assert m_tut, "_maybeStartTutorial body missing"
+        tut_body = m_tut.group(1)
+        assert "_isFirstVisit()" in tut_body
+        # The legacy fleetAgents.length-only inline check should be
+        # gone — _isFirstVisit replaces it.
+        assert "fleetAgents.length !== 0" not in tut_body, (
+            "legacy fleet-only check should be removed in favor of _isFirstVisit"
+        )
+
+    def test_tutorial_emits_locked_telemetry_events(self):
         js = _read(_APP_JS)
         for evt in (
-            "whats_new_tour_started",
-            "whats_new_tour_step",
-            "whats_new_tour_finished",
+            "tutorial_started",
+            "tutorial_step",
+            "tutorial_finished",
+            "tutorial_to_wizard_transition",
         ):
-            assert f"'{evt}'" in js, f"missing tour telemetry event: {evt}"
+            assert f"'{evt}'" in js, f"missing tutorial telemetry event: {evt}"
 
-    def test_tour_handles_escape_key(self):
+    def test_tutorial_handles_escape_key(self):
         js = _read(_APP_JS)
         # ESC dismisses the modal. Tab-trap is also wired here.
         assert "e.key === 'Escape'" in js
+
+
+class TestTutorialWizardSequencing:
+    """The tutorial must run BEFORE the empty-fleet wizard."""
+
+    def test_tutorial_fires_before_wizard_when_both_eligible(self):
+        # ``fetchAgents`` invokes _maybeStartTutorial BEFORE
+        # _maybeStartWizard so a brand-new user sees the tutorial first.
+        js = _APP_JS_TEXT
+        idx_tutorial = js.find("this._maybeStartTutorial()")
+        idx_wizard = js.find("this._maybeStartWizard()")
+        assert idx_tutorial != -1, "fetchAgents should call _maybeStartTutorial"
+        assert idx_wizard != -1, "fetchAgents should call _maybeStartWizard"
+        assert idx_tutorial < idx_wizard, (
+            "tutorial must be invoked before wizard so it gets first dibs"
+        )
+
+    def test_wizard_does_not_fire_while_tutorial_active(self):
+        # _maybeStartWizard early-returns when newUserTutorial.step !== 0.
+        m = re.search(
+            r"_maybeStartWizard\(\)\s*\{(.*?)\n    \},",
+            _APP_JS_TEXT,
+            re.DOTALL,
+        )
+        assert m, "_maybeStartWizard body missing"
+        body = m.group(1)
+        assert "newUserTutorial" in body, (
+            "wizard should gate on tutorial state to avoid double-mount"
+        )
+        assert re.search(
+            r"newUserTutorial\.step\s*!==\s*0", body
+        ), "wizard guard should bail when tutorial is open"
+
+    def test_wizard_fires_after_tutorial_completes(self):
+        # _completeTutorial calls _maybeStartWizard on natural
+        # completion (reason === 'completed') so the user lands in
+        # the team-building flow without an extra click.
+        m = re.search(
+            r"_completeTutorial\(reason\)\s*\{(.*?)\n    \},",
+            _APP_JS_TEXT,
+            re.DOTALL,
+        )
+        assert m, "_completeTutorial body missing"
+        body = m.group(1)
+        assert "tutorial_to_wizard_transition" in body, (
+            "completion handler should emit transition telemetry"
+        )
+        assert "_maybeStartWizard" in body, (
+            "completion handler should invoke the wizard"
+        )
+        assert "reason === 'completed'" in body, (
+            "wizard should only auto-fire on natural completion, not skip/escape"
+        )
+
+
+class TestTutorialBackCompatMigration:
+    """Users who saw the legacy whats-new tour should not see the
+    tutorial — they're not new users."""
+
+    def test_old_olSeenWhatsNew_users_do_not_see_tutorial_again(self):
+        # init() should migrate olSeenWhatsNew='true' → olSeenTutorial='true'.
+        js = _APP_JS_TEXT
+        # The migration check looks at olSeenWhatsNew and, if set,
+        # writes olSeenTutorial. We grep for the combined fragment.
+        assert "olSeenWhatsNew" in js, "migration must reference legacy flag"
+        m = re.search(
+            r"localStorage\.getItem\('olSeenWhatsNew'\)\s*===\s*'true'\s*&&\s*"
+            r"!localStorage\.getItem\('olSeenTutorial'\)",
+            js,
+        )
+        assert m, "migration check missing — old whats-new users would see tutorial"
+        assert (
+            "localStorage.setItem('olSeenTutorial', 'true')" in js
+        ), "migration must write olSeenTutorial flag"
 
 
 # ── Phase 4: wizard polish ───────────────────────────────────────
@@ -1257,8 +1397,8 @@ class TestUndoReceiptCountdown:
 
 class TestSidePanelToggleIcon:
     """The side-panel toggle SVG should not be the same chat-bubble
-    glyph used by the Chat tab; the tour copy must match the new
-    pictogram."""
+    glyph used by the Chat tab — keeps the side-panel pictogram
+    distinct from the Chat tab so users don't confuse the two."""
 
     def test_side_panel_toggle_is_not_chat_bubble(self):
         # The Chat tab uses a chat-bubble path; the side-panel toggle
@@ -1275,7 +1415,7 @@ class TestSidePanelToggleIcon:
         button_block = _INDEX_HTML[idx : idx + 1500]
         assert chat_bubble_path not in button_block, (
             "Side-panel toggle still uses the chat-bubble SVG path; "
-            "it should be a distinct pictogram so the tour is unambiguous."
+            "it should be a distinct pictogram."
         )
 
     def test_side_panel_toggle_uses_panel_pictogram(self):
@@ -1287,14 +1427,6 @@ class TestSidePanelToggleIcon:
         assert '<rect x="3" y="4" width="18" height="16"' in snippet
         assert '<line x1="14" y1="4" x2="14" y2="20"' in snippet
         assert '<polyline points="8 10 11 12 8 14"' in snippet
-
-    def test_tour_copy_references_panel_icon(self):
-        # The tour Step 2 copy must talk about the "panel icon", not
-        # the "chat icon".
-        assert "Look for the panel icon in the top-right corner." in _INDEX_HTML
-        assert "Click the panel icon in the top-right" in _INDEX_HTML
-        # Negative: the old wording must be gone.
-        assert "Look for the chat icon in the top-right corner." not in _INDEX_HTML
 
 
 class TestWorkerDmInNeedsYou:
@@ -2099,39 +2231,71 @@ class TestActionChipDuringStream:
         )
 
 
-# ── What's-new tour gating edge cases ────────────────────────────
+# ── Tutorial gating edge cases ───────────────────────────────────
 
 
-class TestWhatsNewTourGatingEdgeCases:
-    """The tour's gating logic must be defensive about edge conditions."""
+class TestTutorialGatingEdgeCases:
+    """The tutorial's gating logic must be defensive about edge conditions."""
 
-    def test_empty_fleet_does_not_fire_tour(self):
-        """Fleet size 0 (operator-only) suppresses the tour."""
-        # _maybeStartWhatsNewTour bails when fleetAgents.length === 0.
-        m = re.search(
-            r"_maybeStartWhatsNewTour\(\)\s*\{(.*?)\n    \},",
+    def test_existing_fleet_does_not_fire_tutorial(self):
+        """Fleet size > 0 (non-operator) suppresses the tutorial."""
+        # The empty-fleet check now lives in _isFirstVisit() and
+        # _maybeStartTutorial delegates to it. Confirm both halves of
+        # the contract are wired.
+        m_first_visit = re.search(
+            r"_isFirstVisit\(\)\s*\{(.*?)\n    \},",
             _APP_JS_TEXT,
             re.DOTALL,
         )
-        assert m, "_maybeStartWhatsNewTour body missing"
-        body = m.group(1)
-        assert "fleetAgents.length === 0" in body, (
-            "empty-fleet guard missing — tour would fire on fresh installs"
+        assert m_first_visit, "_isFirstVisit body missing"
+        first_visit_body = m_first_visit.group(1)
+        # The fleet check happens inside _isFirstVisit (returns false
+        # when any non-operator agent exists).
+        assert "a.id !== 'operator'" in first_visit_body, (
+            "_isFirstVisit should exclude the operator from the fleet check"
+        )
+        assert "if (hasFleetAgents) return false" in first_visit_body, (
+            "_isFirstVisit must return false when fleet is non-empty"
         )
 
+        m = re.search(
+            r"_maybeStartTutorial\(\)\s*\{(.*?)\n    \},",
+            _APP_JS_TEXT,
+            re.DOTALL,
+        )
+        assert m, "_maybeStartTutorial body missing"
+        body = m.group(1)
+        assert "if (!this._isFirstVisit()) return" in body, (
+            "non-empty-fleet guard missing — tutorial would fire on existing fleets"
+        )
+
+    def test_skip_persists_seen_flag(self):
+        """Skip path writes olSeenTutorial just like completion."""
+        # Skip → dismissTutorial('skip_button') → _completeTutorial →
+        # localStorage.setItem('olSeenTutorial', 'true'). The shared
+        # _completeTutorial path is the single write site.
+        m = re.search(
+            r"_completeTutorial\(reason\)\s*\{(.*?)\n    \},",
+            _APP_JS_TEXT,
+            re.DOTALL,
+        )
+        assert m, "_completeTutorial body missing"
+        body = m.group(1)
+        assert "localStorage.setItem('olSeenTutorial', 'true')" in body
+
     def test_localstorage_unavailable_falls_through_to_show_once(self):
-        """When localStorage throws (private mode) the tour still fires.
+        """When localStorage throws (private mode) the tutorial still fires.
 
         The seen-flag check is wrapped in try/catch. The ``catch`` arm
         is a no-op so the function continues to the agent check — i.e.
-        the tour shows once per session in private mode.
+        the tutorial shows once per session in private mode.
         """
         m = re.search(
-            r"_maybeStartWhatsNewTour\(\)\s*\{(.*?)\n    \},",
+            r"_maybeStartTutorial\(\)\s*\{(.*?)\n    \},",
             _APP_JS_TEXT,
             re.DOTALL,
         )
-        assert m, "_maybeStartWhatsNewTour body missing"
+        assert m, "_maybeStartTutorial body missing"
         body = m.group(1)
         # The catch must not return — only the try return early-exits.
         # The simplest contract check: the comment marks the private-
@@ -2141,28 +2305,28 @@ class TestWhatsNewTourGatingEdgeCases:
             body,
         ), "private-mode catch arm should be a documented no-op"
 
-    def test_tour_state_does_not_persist_across_reload(self):
-        """Tour state lives in memory only — reload aborts mid-flight."""
-        # The wizard persists to localStorage.ol_wizard; the tour
-        # explicitly does NOT. _maybeStartWhatsNewTour gates only on
-        # the seen flag, not on a stored step. We assert the tour
+    def test_tutorial_state_does_not_persist_across_reload(self):
+        """Tutorial state lives in memory only — reload aborts mid-flight."""
+        # The wizard persists to localStorage.ol_wizard; the tutorial
+        # explicitly does NOT. _maybeStartTutorial gates only on the
+        # seen flag, not on a stored step. We assert the tutorial
         # bootstrap reads neither a stored step nor calls a persist
         # helper from the seen-flag branch.
         m = re.search(
-            r"_maybeStartWhatsNewTour\(\)\s*\{(.*?)\n    \},",
+            r"_maybeStartTutorial\(\)\s*\{(.*?)\n    \},",
             _APP_JS_TEXT,
             re.DOTALL,
         )
-        assert m, "_maybeStartWhatsNewTour body missing"
+        assert m, "_maybeStartTutorial body missing"
         body = m.group(1)
-        # Tour state object must not be hydrated from localStorage.
+        # Tutorial state object must not be hydrated from localStorage.
         # (The seen flag is the only persisted bit.)
-        assert "ol_whats_new_tour_step" not in _APP_JS_TEXT, (
-            "tour step should not be persisted — reload must abort the tour"
+        assert "ol_tutorial_step" not in _APP_JS_TEXT, (
+            "tutorial step should not be persisted — reload must abort the tutorial"
         )
-        # The function reads only ``olSeenWhatsNew``, not a stored step.
-        assert "getItem('olSeenWhatsNew')" in body
-        assert "getItem('ol_whats_new_step'" not in body
+        # The function reads only ``olSeenTutorial``, not a stored step.
+        assert "getItem('olSeenTutorial')" in body
+        assert "getItem('ol_tutorial_step'" not in body
 
 
 # ── Polish fix tests (verify the audit fixes landed) ─────────────
@@ -2171,26 +2335,30 @@ class TestWhatsNewTourGatingEdgeCases:
 class TestPolishFixesApplied:
     """Verify each polish fix from the user-journey audit is in place."""
 
-    def test_tour_modal_uses_unique_title_ids(self):
+    def test_tutorial_modal_uses_unique_title_ids(self):
         """Each step's <h2> has a unique id; aria-labelledby is dynamic.
 
-        The audit caught all three steps using the same id="whats-new-title"
-        which is invalid HTML and breaks screen readers when multiple
-        steps render in sequence.
+        Inherited from the original whats-new audit fix — each step
+        carries a distinct ``tutorial-title-N`` so screen readers
+        announce the correct dialog title when steps render in sequence.
         """
         for n in (1, 2, 3):
-            assert f'id="whats-new-title-{n}"' in _INDEX_HTML, (
+            assert f'id="tutorial-title-{n}"' in _INDEX_HTML, (
                 f"missing unique title id for step {n}"
             )
         # The aria-labelledby binding must reference the dynamic id.
         assert (
-            ":aria-labelledby=\"'whats-new-title-' + whatsNewTour.step\""
+            ":aria-labelledby=\"'tutorial-title-' + newUserTutorial.step\""
             in _INDEX_HTML
         ), "aria-labelledby should bind dynamically to the active step"
-        # The legacy duplicated id should be gone.
+        # The legacy whats-new ids should be gone.
         assert 'id="whats-new-title"' not in _INDEX_HTML, (
-            "legacy duplicate id still present"
+            "legacy whats-new title id still present"
         )
+        for n in (1, 2, 3):
+            assert f'id="whats-new-title-{n}"' not in _INDEX_HTML, (
+                f"legacy whats-new title id (step {n}) still present"
+            )
 
     def test_credential_notification_icon_is_plain_text(self):
         """The 'credential' kind icon is 'K' — markup is emoji-free."""
@@ -2230,7 +2398,7 @@ class TestPolishFixesApplied:
 
     def test_side_panel_esc_restores_focus(self):
         """closeSidePanel restores focus captured on toggleSidePanel open."""
-        # Mirrors the _whatsNewTourPrevFocus pattern.
+        # Mirrors the _newUserTutorialPrevFocus pattern.
         assert "_messengerSidePanelPrevFocus" in _APP_JS_TEXT, (
             "side-panel previous-focus tracker missing"
         )


### PR DESCRIPTION
## Summary

CPO call: the Phase 4 "What's new" tour was built for **existing users** seeing the redesigned UI. That's the wrong audience — existing users figure out the new layout. **New users not understanding the product** is the actual activation gap. This PR repurposes the modal infrastructure for them.

## Changes

### Repurposed detection
- **Was:** existing fleet (>0 agents, excluding operator) AND `localStorage.olSeenWhatsNew !== 'true'`
- **Now:** empty fleet (no agents, excluding operator) AND `localStorage.olSeenTutorial !== 'true'`

### New 3-step tutorial copy

**Step 1: "Welcome to OpenLegion"** — frames the product mental model: "AI team manager. You hire AI workers, give them tasks, watch them deliver — like a small remote team."

**Step 2: "Meet your Operator"** — the central abstraction. "The Operator is your team lead. You talk to them in Chat. They route work, manage your team, and ping you when you're needed."

**Step 3: "See what your team is doing"** — orientation on Work tab + cross-tab Needs-You badge. Final CTA: "Got it, let's build a team →" which dismisses + auto-fires the existing onboarding wizard.

### Sequencing

```
New user lands → operator chat ready → tutorial auto-fires
  → user clicks through 3 steps OR skips
  → wizard auto-fires (existing chip-based flow)
  → user picks chip → team builds
```

Tutorial fires FIRST when both are eligible. Wizard doesn't fire while tutorial is active. Once tutorial completes/skipped → wizard takes over.

### Migration of existing localStorage

Users who already have `olSeenWhatsNew = 'true'` are NOT new users (they had a fleet when they saw the old tour). On app init:

```js
if (localStorage.getItem('olSeenWhatsNew') === 'true' && !localStorage.getItem('olSeenTutorial')) {
  localStorage.setItem('olSeenTutorial', 'true');  // existing users skip new tutorial
}
```

So existing users who saw the old tour don't get re-tutorialled.

### Telemetry events renamed

- `whats_new_tour_started` → `tutorial_started`
- `whats_new_tour_step` → `tutorial_step` (`{step, direction}`)
- `whats_new_tour_finished` → `tutorial_finished` (`{reason, lastStep}`)
- New: `tutorial_to_wizard_transition` — measures completion-to-team-building conversion

### Dropped the existing-user "what's new" tour

Code path removed (option A from the spec). Existing users figure out the new layout from in-app discovery. If we need future change-comms, that's a separate channel.

## Test plan

- [x] Tutorial fires for new users (empty fleet + no flag)
- [x] Tutorial does NOT fire for existing users (fleet > 0)
- [x] Tutorial fires BEFORE wizard when both eligible
- [x] Wizard fires AFTER tutorial completes
- [x] Skip persists `olSeenTutorial = 'true'`
- [x] Completion persists the flag
- [x] Existing `olSeenWhatsNew = 'true'` users skip tutorial (back-compat migration)

## Stats

3 files changed: +344 / -209.
- `app.js` +157 / -53 net (state machine repurpose, sequencing, migration)
- `index.html` +106 / -75 net (modal copy)
- `test_dashboard_ui.py` +290 / -81 net (tutorial tests + sequencing)

## Why this matters

User reported they're seeing "tasks stuck in pending" and the dashboard isn't intuitive enough — both symptoms of a deeper activation problem. Tutorial-first onboarding addresses the fundamental "Sarah doesn't know what this is" gap that the wizard alone can't fix (the wizard assumes you already understand "Operator builds a team for me" — the tutorial teaches that first).