### PR TITLE
feat(dashboard): kanban-default Work tab + task cancel + density polish + activity filtering (PR-H)

### DIFF
--- a/src/dashboard/server.py
+++ b/src/dashboard/server.py
@@ -6477,6 +6477,65 @@ def create_dashboard_router(
             events = []
         return {"task_id": task_id, "events": events}
 
+    @api_router.post("/api/workplace/tasks/{task_id}/cancel")
+    async def api_workplace_task_cancel(
+        task_id: str, request: Request,
+    ) -> dict:
+        """Cancel a task — backs the [×] button on every kanban card.
+
+        Proxies to the mesh's ``POST /mesh/tasks/{task_id}/cancel``
+        endpoint over loopback with ``x-mesh-internal: 1`` +
+        ``X-Agent-ID: operator`` so the mesh treats the dashboard as a
+        trusted internal caller (the mesh route allows creator,
+        assignee, operator, or internal). The dashboard's CSRF guard
+        (``X-Requested-With``) runs ahead of this on the verb, and the
+        cancel itself emits ``status_changed`` + ``task_status_changed``
+        events so the kanban refreshes via the existing WebSocket
+        plumbing without a manual reload.
+
+        Body: ``{reason: str}`` (optional, sanitized by the mesh).
+        Returns: the updated task record (``status="cancelled"``) so
+        the caller can patch the UI optimistically.
+        """
+        if tasks_store is None or not _orchestration_v2_on():
+            raise HTTPException(404, "Tasks store not available")
+        try:
+            body = await request.json() if (await request.body()) else {}
+        except (json.JSONDecodeError, ValueError):
+            body = {}
+        if not isinstance(body, dict):
+            body = {}
+        reason = body.get("reason") or ""
+        import httpx
+        url = f"http://127.0.0.1:{mesh_port}/mesh/tasks/{task_id}/cancel"
+        try:
+            async with httpx.AsyncClient(timeout=10) as client:
+                resp = await client.post(
+                    url,
+                    json={"reason": reason},
+                    headers={
+                        "X-Requested-With": "XMLHttpRequest",
+                        "x-mesh-internal": "1",
+                        "X-Agent-ID": "operator",
+                        "Content-Type": "application/json",
+                    },
+                )
+        except Exception as e:
+            logger.warning("workplace task cancel proxy failed: %s", e)
+            raise HTTPException(502, f"Mesh unreachable: {e}")
+        if resp.status_code == 404:
+            raise HTTPException(404, "Task not found")
+        if resp.status_code >= 400:
+            try:
+                detail = resp.json().get("detail", resp.text)
+            except Exception:
+                detail = resp.text
+            raise HTTPException(resp.status_code, detail)
+        try:
+            return resp.json()
+        except Exception:
+            return {"ok": True, "task_id": task_id}
+
     @api_router.post("/api/workplace/tasks/{task_id}/outcome")
     async def api_workplace_task_outcome(
         task_id: str, request: Request,

--- a/src/dashboard/static/js/app.js
+++ b/src/dashboard/static/js/app.js
@@ -398,17 +398,23 @@ function dashboard() {
       { id: 'task-board', label: 'Tasks' },
       { id: 'team-outputs', label: 'Outputs' },
     ],
-    // Phase 3 — Home single-scroll layout.
-    // ``homeTab`` is the sub-route within the Home (workplace) tab.
-    //   ``main`` (default) → single-scroll layout: Needs You + Just
-    //     delivered + Happening now + In progress.
-    //   ``tasks`` → full kanban sub-page (lifted from the legacy
-    //     ``task-board`` sub-tab content). Reachable via the
-    //     "See full task board →" link or the URL ``/home/tasks``.
-    // Sub-tabs (Activity/Projects/Tasks/Outputs) collapsed; the legacy
-    // ``workplaceTab`` state stays for backward compat with deep links
-    // and any test that still toggles it.
-    homeTab: 'main',
+    // Phase 4 — Board (workplace) restructured around the kanban as
+    // the default surface. ``homeTab`` is the sub-route within the
+    // Board tab.
+    //   ``kanban`` (default) → kanban board: Needs You + Stuck tasks
+    //     + 4-column kanban (Pending / Working / Blocked / Done) with
+    //     a × cancel button on every card. Empty sections hide.
+    //   ``activity`` → single-scroll activity feed: Just delivered +
+    //     Happening now + In progress. Lifted from the legacy
+    //     ``main`` layout; reachable via the "View activity feed →"
+    //     link below the kanban or the URL ``/home/activity``.
+    // Backward compat: the legacy ``main`` value (Phase 3 default)
+    // and ``tasks`` value (Phase 3 kanban sub-page) both resolve to
+    // the new ``kanban`` default — old bookmarks land on the kanban
+    // because the kanban IS the new default. The legacy
+    // ``workplaceTab`` state stays for back-compat with deep links
+    // that still toggle it.
+    homeTab: 'kanban',
     workplaceEnabled: true,
     workplaceProjects: [],
     workplaceTasks: [],
@@ -455,7 +461,6 @@ function dashboard() {
     recentlyDeliveredArtifacts: {},
     recentlyDeliveredExpanded: {},
     _recentlyDeliveredFetching: {},
-    workplaceTaskColumns: ['pending', 'accepted', 'working', 'blocked', 'done'],
     workplaceProjectFilter: '',
     // Per-column flag: when true, the kanban column ignores the 14-day
     // archive cutoff and shows old pending/blocked rows. Keyed by status
@@ -747,12 +752,13 @@ function dashboard() {
         return '/system/' + (this.systemTab || 'activity');
       }
       if (this.activeTab === 'fleet') return '/agents';
-      // Phase 3 — Home (workplace) sub-routing. Default lands on the
-      // single-scroll layout (``/home``); the kanban sub-page is at
-      // ``/home/tasks``. Bookmarks for ``/home`` keep working when the
-      // user switches between Home and other tabs.
+      // Phase 4 — Board (workplace) sub-routing. Default lands on
+      // the kanban (``/home``); the activity feed sub-page is at
+      // ``/home/activity``. Legacy ``/home/tasks`` still maps to
+      // the same default in ``_parsePath`` (kanban IS the default,
+      // so old bookmarks survive without a redirect).
       if (this.activeTab === 'workplace') {
-        return this.homeTab === 'tasks' ? '/home/tasks' : '/home';
+        return this.homeTab === 'activity' ? '/home/activity' : '/home';
       }
       return '/';
     },
@@ -773,24 +779,29 @@ function dashboard() {
         return (st ? st.label : 'System') + ' \u2014 OpenLegion';
       }
       if (this.activeTab === 'workplace') {
-        return this.homeTab === 'tasks' ? 'Tasks \u2014 OpenLegion' : 'Board \u2014 OpenLegion';
+        return this.homeTab === 'activity' ? 'Activity \u2014 OpenLegion' : 'Board \u2014 OpenLegion';
       }
       return 'Agents \u2014 OpenLegion';
     },
 
     _parsePath(path) {
       const clean = path.replace(/^\/+/, '').replace(/\/+$/, '');
-      const route = { tab: 'chat', activityView: 'traces', systemTab: 'activity', agentId: null, identityTab: 'config', homeTab: 'main' };
+      const route = { tab: 'chat', activityView: 'traces', systemTab: 'activity', agentId: null, identityTab: 'config', homeTab: 'kanban' };
       if (!clean) return route;
 
       if (clean === 'chat') { route.tab = 'chat'; return route; }
       if (clean === 'agents' || clean.startsWith('agents/')) { route.tab = 'fleet'; }
-      // Phase 3 — Home sub-routing. ``/home`` → single-scroll layout;
-      // ``/home/tasks`` → kanban sub-page. Anything deeper falls back
-      // to the main layout.
-      if (clean === 'home') { route.tab = 'workplace'; route.homeTab = 'main'; return route; }
+      // Phase 4 — Board sub-routing. ``/home`` → kanban (default);
+      // ``/home/activity`` → single-scroll activity feed. Legacy
+      // ``/home/tasks`` (Phase 3 kanban sub-page URL) still resolves
+      // to the kanban — the kanban IS the default now, so old
+      // bookmarks survive without a redirect.
+      if (clean === 'home') { route.tab = 'workplace'; route.homeTab = 'kanban'; return route; }
+      if (clean === 'home/activity' || clean.startsWith('home/activity')) {
+        route.tab = 'workplace'; route.homeTab = 'activity'; return route;
+      }
       if (clean === 'home/tasks' || clean.startsWith('home/tasks')) {
-        route.tab = 'workplace'; route.homeTab = 'tasks'; return route;
+        route.tab = 'workplace'; route.homeTab = 'kanban'; return route;
       }
 
       const agentMatch = clean.match(/^agents\/([^/]+)(?:\/([^/]+))?$/);
@@ -858,14 +869,14 @@ function dashboard() {
               if (route.systemTab === 'activity') this.activityView = route.activityView;
             }
             if (route.tab === 'workplace') {
-              this.homeTab = route.homeTab || 'main';
+              this.homeTab = route.homeTab || 'kanban';
             }
             this.switchTab(route.tab);
           } else if (route.tab === 'workplace') {
-            // Phase 3 — already on Home; just sync sub-page state
+            // Phase 4 — already on Board; just sync sub-page state
             // without re-running loadWorkplace (no new fetch needed).
-            if (this.homeTab !== (route.homeTab || 'main')) {
-              this.homeTab = route.homeTab || 'main';
+            if (this.homeTab !== (route.homeTab || 'kanban')) {
+              this.homeTab = route.homeTab || 'kanban';
             }
           } else if (route.tab === 'system') {
             if (this.systemTab !== route.systemTab) {
@@ -2559,12 +2570,15 @@ function dashboard() {
       if (!this._skipPush) this._pushUrl(false);
     },
 
-    // Phase 3 — Home sub-page switcher. ``main`` is the default
-    // single-scroll layout; ``tasks`` opens the kanban sub-page. Pushes
-    // a new history entry so the back button returns to the previous
-    // sub-page (or out of Home entirely if the user navigated in).
+    // Phase 4 — Board sub-page switcher. ``kanban`` is the default
+    // (kanban board with cancel buttons); ``activity`` opens the
+    // single-scroll activity feed. Legacy values (``main``,
+    // ``tasks``) are coerced to the kanban default so old call
+    // sites keep working. Pushes a new history entry so the back
+    // button returns to the previous sub-page (or out of Board
+    // entirely if the user navigated in).
     switchHomeTab(tabId) {
-      const target = tabId === 'tasks' ? 'tasks' : 'main';
+      const target = tabId === 'activity' ? 'activity' : 'kanban';
       if (this.homeTab === target) return;
       this.homeTab = target;
       this._pushUrl(false);
@@ -2835,7 +2849,17 @@ function dashboard() {
     },
 
     workplaceTasksByStatus(status) {
-      return (this.workplaceTasks || []).filter(t => t.status === status);
+      // The kanban only has 4 columns (pending/working/blocked/done);
+      // the transient ``accepted`` status — emitted by ``update_status``
+      // when an agent acknowledges a task before they start working —
+      // folds into Pending so it stays visible on the board. Without
+      // this fold, ``accepted`` rows render in zero columns and the
+      // operator can't see (or cancel) them.
+      const tasks = this.workplaceTasks || [];
+      if (status === 'pending') {
+        return tasks.filter(t => t.status === 'pending' || t.status === 'accepted');
+      }
+      return tasks.filter(t => t.status === status);
     },
 
     // Icon for an activity feed entry. Plain text glyphs keep the
@@ -3512,6 +3536,210 @@ function dashboard() {
       const total = this.workplaceTasksByStatus(status).length;
       const visible = this.workplaceTasksByStatusFiltered(status).length;
       return Math.max(0, total - visible);
+    },
+
+    // Phase 4 — title truncation for kanban cards + Stuck tasks
+    // panel. Long titles (some agents accidentally hand off with
+    // their full instruction text — ~250 chars seen in production)
+    // wreck the kanban grid; truncate to 80 chars + ellipsis on
+    // render. The full title still surfaces in the drill-in modal
+    // and via the ``title=`` tooltip on hover.
+    truncateTitle(title, max) {
+      const limit = Number.isFinite(max) ? max : 80;
+      const s = String(title || '').trim();
+      if (s.length <= limit) return s;
+      return s.slice(0, limit - 1).trimEnd() + '…';
+    },
+
+    // Phase 4 — Stuck tasks: tasks that have been pending or working
+    // for >24h with no status change. Computed from ``workplaceTasks``
+    // by checking ``updated_at`` (or ``created_at`` for never-started
+    // tasks). Returns an array of ``{id, title, assignee, project_id,
+    // status, stuck_seconds, stuck_label}`` so the template can
+    // render the count badge + ``Stuck for N days`` caption without
+    // recomputing on every reactive read. Capped at 25 to keep the
+    // panel from blowing past the fold; if a fleet has 25+ stuck
+    // tasks the operator has bigger problems than UI density.
+    get stuckTasks() {
+      const tasks = this.workplaceTasks || [];
+      const now = Date.now() / 1000;
+      const cutoff = 24 * 3600;  // 24 hours in seconds
+      const out = [];
+      for (const t of tasks) {
+        if (t.status !== 'pending' && t.status !== 'working') continue;
+        // Defensive: operator is the orchestrator, not a worker — its
+        // own ledger should never produce user-facing "stuck" rows even
+        // if a future code path accidentally assigns work to it.
+        if (t.assignee === 'operator') continue;
+        const updated = typeof t.updated_at === 'number'
+          ? t.updated_at
+          : (t.updated_at ? new Date(t.updated_at).getTime() / 1000 : 0);
+        const created = typeof t.created_at === 'number'
+          ? t.created_at
+          : (t.created_at ? new Date(t.created_at).getTime() / 1000 : 0);
+        const ts = updated || created || 0;
+        if (!ts) continue;
+        const age = now - ts;
+        if (age < cutoff) continue;
+        const days = Math.floor(age / 86400);
+        const label = days >= 1
+          ? `Stuck for ${days} day${days === 1 ? '' : 's'}`
+          : `Stuck for ${Math.floor(age / 3600)}h`;
+        out.push({
+          id: t.id,
+          title: t.title || '(untitled)',
+          assignee: t.assignee || '',
+          project_id: t.project_id || '',
+          status: t.status,
+          stuck_seconds: age,
+          stuck_label: label,
+        });
+        if (out.length >= 25) break;
+      }
+      // Oldest first so the most painful entries surface at the top.
+      out.sort((a, b) => b.stuck_seconds - a.stuck_seconds);
+      return out;
+    },
+
+    // Phase 4 — kanban activity feed noise filter. The legacy
+    // /workplace/feed payload includes ``status_unchanged`` rows
+    // (emitted when the same status is reported twice — typically
+    // from a heartbeat probe re-affirming "still working"). Those
+    // rows are pure implementation noise from the user's POV; we
+    // hide them by default and surface them only when
+    // ``showTechDetail`` is on. Preserves the original ``workplaceFeed``
+    // array so the WS plumbing keeps appending to one source of truth.
+    get workplaceFeedVisible() {
+      const feed = this.workplaceFeed || [];
+      if (this.showTechDetail) return feed;
+      return feed.filter(ev => ev && ev.event_type !== 'status_unchanged');
+    },
+
+    // Phase 4 — task cancel modal state. ``cancelTaskCandidate`` is
+    // the task object the user is about to cancel; null means the
+    // modal is closed. ``cancelTaskInFlight`` disables the confirm
+    // button while the POST is in flight so a double-click doesn't
+    // fire two cancels.
+    cancelTaskCandidate: null,
+    cancelTaskInFlight: false,
+
+    // Open the cancel-task confirmation modal. Accepts a task object
+    // (from the kanban or stuck-tasks panel) — we copy just the fields
+    // the modal needs so a downstream re-fetch doesn't blow away the
+    // candidate while the user is staring at the dialog.
+    confirmCancelTask(task) {
+      if (!task || !task.id) return;
+      this.cancelTaskCandidate = {
+        id: task.id,
+        title: task.title || '(untitled)',
+        assignee: task.assignee || '',
+        project_id: task.project_id || '',
+      };
+    },
+
+    closeCancelTaskModal() {
+      if (this.cancelTaskInFlight) return;
+      this.cancelTaskCandidate = null;
+    },
+
+    // Fire the cancel — POSTs to the dashboard proxy which forwards
+    // to the mesh's ``/mesh/tasks/{id}/cancel``. On success we close
+    // the modal and reload tasks so the kanban + stuck-tasks panel
+    // both reflect the change immediately. The mesh also emits a
+    // ``task_status_changed`` event so the WS path catches up too.
+    async cancelTaskNow() {
+      const cand = this.cancelTaskCandidate;
+      if (!cand || this.cancelTaskInFlight) return;
+      this.cancelTaskInFlight = true;
+      try {
+        const resp = await fetch(
+          `${window.__config.apiBase}/workplace/tasks/${encodeURIComponent(cand.id)}/cancel`,
+          {
+            method: 'POST',
+            headers: {
+              'Content-Type': 'application/json',
+              'X-Requested-With': 'XMLHttpRequest',
+            },
+            body: JSON.stringify({ reason: 'Cancelled from board' }),
+          },
+        );
+        if (!resp.ok) {
+          let detail = '';
+          try { detail = (await resp.json()).detail || ''; } catch (e) { /* ignore */ }
+          if (typeof this.showToast === 'function') {
+            this.showToast(`Cancel failed: ${detail || resp.status}`);
+          }
+          return;
+        }
+        if (typeof this.showToast === 'function') {
+          this.showToast(`Cancelled "${this.truncateTitle(cand.title, 40)}"`);
+        }
+        this.cancelTaskCandidate = null;
+        // Refresh tasks so the kanban + stuck-tasks panel update.
+        if (typeof this.loadWorkplaceTasks === 'function') {
+          await this.loadWorkplaceTasks();
+        }
+      } catch (e) {
+        if (typeof this.showToast === 'function') {
+          this.showToast(`Cancel failed: ${e.message || e}`);
+        }
+      } finally {
+        this.cancelTaskInFlight = false;
+      }
+    },
+
+    // Restart agent — used by the [Restart agent] button on the
+    // Stuck tasks panel. Hits the existing
+    // ``/api/agents/{id}/restart`` dashboard endpoint; on success we
+    // reload tasks so the panel reflects whatever the agent emits
+    // when it comes back online.
+    //
+    // Routed through ``showConfirm`` (same modal pattern as the regular
+    // Restart Agent button on the agent card — see ``restartAgent``)
+    // so a stray click in the Stuck tasks panel doesn't kill an agent's
+    // active work without an explicit confirmation. The fetch logic
+    // lives in the confirm callback so the modal's spinner state ties
+    // to the actual restart, not just the click.
+    async restartAgentForStuck(agentId) {
+      if (!agentId) return;
+      const display = typeof this.agentDisplayName === 'function'
+        ? this.agentDisplayName(agentId)
+        : agentId;
+      this.showConfirm(
+        'Restart agent?',
+        `This will interrupt any active work for "${display}". Their current task will be cancelled. Continue?`,
+        async () => {
+          try {
+            const resp = await fetch(
+              `${window.__config.apiBase}/agents/${encodeURIComponent(agentId)}/restart`,
+              {
+                method: 'POST',
+                headers: {
+                  'Content-Type': 'application/json',
+                  'X-Requested-With': 'XMLHttpRequest',
+                },
+                body: '{}',
+              },
+            );
+            if (!resp.ok) {
+              let detail = '';
+              try { detail = (await resp.json()).detail || ''; } catch (e) { /* ignore */ }
+              if (typeof this.showToast === 'function') {
+                this.showToast(`Restart failed: ${detail || resp.status}`);
+              }
+              return;
+            }
+            if (typeof this.showToast === 'function') {
+              this.showToast(`Restarting ${agentId}…`);
+            }
+          } catch (e) {
+            if (typeof this.showToast === 'function') {
+              this.showToast(`Restart failed: ${e.message || e}`);
+            }
+          }
+        },
+        true,
+      );
     },
 
     // Audit-log Revert: re-uses the soft-edit undo endpoint via the
@@ -9540,6 +9768,16 @@ function dashboard() {
         case 'message_sent':
         case 'text_delta':
         case 'agent_state':
+          return null;
+        // Phase 4 — heartbeat-driven re-affirmations of the same
+        // status (the orchestration layer emits ``status_unchanged``
+        // when a task transition is requested but already at the
+        // target). Filtered for the same reason as the noise events
+        // above: hidden by default, available via "Show technical
+        // detail" for debugging. The engine emits the single name
+        // ``status_unchanged`` (see orchestration.py) — there is no
+        // alternate spelling on the wire.
+        case 'status_unchanged':
           return null;
         default:
           return event.summary || null;

--- a/src/dashboard/templates/index.html
+++ b/src/dashboard/templates/index.html
@@ -3777,15 +3777,17 @@
             x-text="'Show ' + (needsYouItems.length - needsYouCollapsedCap) + ' more'"></button>
         </section>
 
-        <!-- Phase 3 — sub-tab bar collapsed into a single-scroll layout.
-             ``homeTab === 'main'`` renders Just delivered + Happening now
-             + In progress in one column. ``homeTab === 'tasks'`` lifts
-             the kanban into its own sub-page reachable via the "See full
-             task board →" link below. The legacy ``workplaceTab`` state
-             stays in place for backward compat (in-place outputs/projects
-             links keep working) but no sub-tab bar is rendered. -->
-        <div x-show="homeTab === 'tasks'" x-cloak class="mb-3">
-          <button type="button" @click="switchHomeTab('main')"
+        <!-- Phase 4 — Board redesigned around the kanban as default.
+             ``homeTab === 'kanban'`` (default) renders Needs you +
+             Stuck tasks + 4-column kanban with × cancel buttons.
+             ``homeTab === 'activity'`` lifts the legacy single-scroll
+             layout (Just delivered / Happening now / In progress) into
+             its own sub-page reachable via the "View activity feed →"
+             link below the kanban. The legacy ``workplaceTab`` state
+             stays in place for back-compat with deep links that still
+             toggle it; no sub-tab bar is rendered. -->
+        <div x-show="homeTab === 'activity'" x-cloak class="mb-3">
+          <button type="button" @click="switchHomeTab('kanban')"
             class="text-[12px] text-gray-400 hover:text-gray-200 inline-flex items-center gap-1 transition-colors"
             data-testid="home-back-to-main">
             <svg class="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M19 12H5M12 19l-7-7 7-7"/></svg>
@@ -3803,15 +3805,16 @@
           </div>
         </template>
 
-        <!-- Phase 3 — Home single-scroll layout (homeTab === 'main').
-             All four legacy sub-tabs collapse into one vertical column:
-             Just delivered (recentlyDeliveredItems), Happening now
-             (workplaceFeed, capped at 5 with disclosure), and In
-             progress (a 4-card slice of workplaceTasks with a "See full
-             task board →" link to /home/tasks). Empty sections hide
-             entirely so an idle Board has no extra chrome. -->
-        <template x-if="workplaceEnabled && homeTab === 'main'">
-          <div class="space-y-4" data-testid="home-main">
+        <!-- Phase 4 — Activity sub-page (homeTab === 'activity'). The
+             legacy Phase 3 single-scroll layout: Just delivered
+             (recentlyDeliveredItems), Happening now (workplaceFeed,
+             capped at 5 with disclosure), and In progress (a 4-card
+             slice of workplaceTasks). The kanban is now the default
+             board; this page is reached via the "View activity feed →"
+             link below the kanban. Empty sections hide entirely so an
+             idle activity feed has no extra chrome. -->
+        <template x-if="workplaceEnabled && homeTab === 'activity'">
+          <div class="space-y-4" data-testid="home-activity">
             <!-- Just delivered — last 7 days of completed outputs.
                  Replaces the legacy ``team-outputs`` sub-tab; kept inline
                  with a drill-in for the full artifact preview. -->
@@ -3864,18 +3867,21 @@
 
             <!-- Happening now — capped at 5 events on the main scroll;
                  "See all" disclosure expands inline. Empty section hides
-                 entirely (no header, no chrome). -->
+                 entirely (no header, no chrome). Phase 4: source switched
+                 to ``workplaceFeedVisible`` which strips
+                 ``status_unchanged`` heartbeat noise unless the user
+                 has the "Show technical detail" toggle on. -->
             <div x-data="{ feedExpanded: false }"
-                 x-show="workplaceFeed.length || workplaceSectionLoading.feed || workplaceErrors.feed"
+                 x-show="workplaceFeedVisible.length || workplaceSectionLoading.feed || workplaceErrors.feed"
                  data-testid="home-happening-now">
               <div class="flex items-center justify-between mb-1.5">
                 <div class="text-[11px] uppercase tracking-wide text-gray-500 font-medium">Happening now</div>
                 <button type="button"
-                  x-show="!feedExpanded && workplaceFeed.length > 5"
+                  x-show="!feedExpanded && workplaceFeedVisible.length > 5"
                   @click="feedExpanded = true"
                   class="text-[11px] text-gray-400 hover:text-gray-200">See all &rarr;</button>
                 <button type="button"
-                  x-show="feedExpanded && workplaceFeed.length > 5"
+                  x-show="feedExpanded && workplaceFeedVisible.length > 5"
                   @click="feedExpanded = false"
                   class="text-[11px] text-gray-400 hover:text-gray-200">Show less</button>
               </div>
@@ -3886,7 +3892,7 @@
                    layout doesn't jump when content arrives. Hidden once
                    the load resolves (success or error — the error banner
                    below takes over in the failure case). -->
-              <template x-if="workplaceSectionLoading.feed && !workplaceFeed.length && !workplaceErrors.feed">
+              <template x-if="workplaceSectionLoading.feed && !workplaceFeedVisible.length && !workplaceErrors.feed">
                 <div class="space-y-2" data-testid="workplace-feed-skeleton">
                   <div class="bg-gray-800/40 border border-gray-700/50 rounded-lg p-3">
                     <div class="h-3 w-2/3 bg-gray-800 rounded animate-pulse"></div>
@@ -3915,9 +3921,11 @@
               </template>
 
               <!-- Chronological activity list, capped at 5 unless
-                   ``feedExpanded`` is true. -->
+                   ``feedExpanded`` is true. Source is the noise-filtered
+                   ``workplaceFeedVisible`` (see getter for filtering
+                   rules). -->
               <div class="space-y-2">
-                <template x-for="ev in (feedExpanded ? workplaceFeed : workplaceFeed.slice(0, 5))" :key="ev.event_id">
+                <template x-for="ev in (feedExpanded ? workplaceFeedVisible : workplaceFeedVisible.slice(0, 5))" :key="ev.event_id">
                   <button type="button"
                     class="w-full text-left bg-gray-800/40 border border-gray-700/50 rounded-lg p-3 hover:bg-gray-800/70 transition-colors"
                     @click="openTaskDrillIn(ev.task_id)">
@@ -3938,15 +3946,15 @@
 
             <!-- In progress — 4-card slice of workplaceTasks filtered to
                  working / pending / accepted statuses (most-recent
-                 first). "See full task board →" lifts to the kanban
-                 sub-page (/home/tasks). Empty section hides entirely. -->
+                 first). Phase 4: "Back to Work" links to the kanban
+                 (the new default). Empty section hides entirely. -->
             <template x-if="(workplaceTasks || []).filter(t => ['working','pending','accepted'].includes(t.status)).length">
               <div data-testid="home-in-progress">
                 <div class="flex items-center justify-between mb-1.5">
                   <div class="text-[11px] uppercase tracking-wide text-gray-500 font-medium">In progress</div>
-                  <button type="button" @click="switchHomeTab('tasks')"
+                  <button type="button" @click="switchHomeTab('kanban')"
                     class="text-[11px] text-indigo-300 hover:text-indigo-200"
-                    data-testid="home-see-task-board">See full task board &rarr;</button>
+                    data-testid="home-see-task-board">Back to Work &rarr;</button>
                 </div>
                 <div class="grid grid-cols-1 sm:grid-cols-2 gap-2">
                   <template x-for="t in (workplaceTasks || []).filter(t => ['working','pending','accepted'].includes(t.status)).slice(0, 4)" :key="'ip-' + t.id">
@@ -3967,7 +3975,7 @@
             <!-- Idle empty state — shown only when EVERY section above
                  is empty AND there's nothing pending. Calm prompt,
                  verb-driven CTA. -->
-            <template x-if="!workplaceSectionLoading.feed && !workplaceErrors.feed && !workplaceFeed.length && !recentlyDeliveredItems.length && !needsYouItems.length && !(workplaceTasks || []).filter(t => ['working','pending','accepted'].includes(t.status)).length">
+            <template x-if="!workplaceSectionLoading.feed && !workplaceErrors.feed && !workplaceFeedVisible.length && !recentlyDeliveredItems.length && !needsYouItems.length && !(workplaceTasks || []).filter(t => ['working','pending','accepted'].includes(t.status)).length">
               <div class="text-sm text-gray-300 py-6 text-center" data-testid="home-idle-empty">
                 Your team is idle.
                 <button type="button" @click="activeTab = 'chat'"
@@ -3981,7 +3989,7 @@
                  when every section is empty; this one stays so users with
                  active projects but no fresh activity still see the
                  reassurance copy that Phase 2 promised. -->
-            <template x-if="!workplaceSectionLoading.feed && !workplaceErrors.feed && !workplaceFeed.length && workplaceProjects.length">
+            <template x-if="!workplaceSectionLoading.feed && !workplaceErrors.feed && !workplaceFeedVisible.length && workplaceProjects.length">
               <div class="text-sm text-gray-500 py-4">Once your team starts working, you'll see updates here.</div>
             </template>
           </div>
@@ -4052,7 +4060,7 @@
                   </template>
                 </div>
                 <div class="flex flex-wrap gap-1.5 text-[11px]">
-                  <template x-for="status in workplaceTaskColumns" :key="status">
+                  <template x-for="status in ['pending','accepted','working','blocked','done']" :key="status">
                     <span class="px-2 py-0.5 rounded bg-gray-900/60 text-gray-300"
                       x-show="(p.counts && p.counts[status]) || 0">
                       <span x-text="status"></span>:
@@ -4078,20 +4086,71 @@
           </div>
         </template>
 
-        <!-- Task board (kanban) sub-tab -->
-        <!-- Responsive grid: 1 col on phones (<sm), 2 cols on tablets
-             (sm-lg), 5 cols on desktop (lg+). On the smallest phones the
-             grid still hits 1 column, which is fine for stacked reading;
-             at the awkward 600-1023 px width range we previously crammed
-             5 columns into <=1023 px and produced 153 px cards. The
-             outer ``overflow-x-auto`` + inner ``min-w-[640px]`` give
-             phone users a horizontal-scroll fallback so each column
-             keeps a usable width when they prefer the kanban layout. -->
-        <template x-if="workplaceEnabled && homeTab === 'tasks'">
-          <div>
+        <!-- Phase 4 — Stuck tasks panel. Sits between "Needs you" and
+             the kanban grid so it inherits the sticky-feel of the
+             attention bar above it without claiming a sticky position
+             of its own. Only renders when ``stuckTasks`` is non-empty.
+             Shows tasks that have been pending or working >24h. Each
+             row carries [Cancel] + [Restart agent] for the operator's
+             two-fastest unblockers. -->
+        <template x-if="workplaceEnabled && homeTab === 'kanban' && stuckTasks.length">
+          <section class="bg-amber-950/30 border border-amber-800/50 rounded-xl p-3 mb-3"
+            data-testid="board-stuck-tasks"
+            aria-label="Stuck tasks">
+            <div class="flex items-center justify-between mb-2">
+              <div class="flex items-center gap-2">
+                <span class="text-[11px] uppercase tracking-wide text-amber-300 font-semibold">Stuck tasks</span>
+                <span class="font-mono px-1.5 rounded bg-amber-700/40 text-amber-100 text-[10px]"
+                  x-text="stuckTasks.length"></span>
+              </div>
+              <span class="text-[10px] text-amber-300/70">Pending or working &gt; 24h with no status change</span>
+            </div>
+            <div class="space-y-1.5">
+              <template x-for="s in stuckTasks" :key="'stuck-' + s.id">
+                <div class="flex items-center gap-2 bg-gray-900/40 border border-amber-800/30 rounded-md px-2.5 py-1.5"
+                  data-testid="board-stuck-task-row">
+                  <button type="button" class="min-w-0 flex-1 text-left"
+                    @click="openTaskDrillIn(s.id)">
+                    <div class="text-xs text-gray-100 truncate"
+                      :title="s.title"
+                      x-text="truncateTitle(s.title, 80)"></div>
+                    <div class="text-[10px] text-amber-200/80 mt-0.5">
+                      <span x-text="s.assignee || '(unassigned)'"></span>
+                      <span x-show="s.project_id" class="text-gray-500"
+                        x-text="'· ' + (s.project_id || '')"></span>
+                      <span class="ml-1 text-amber-300" x-text="'· ' + s.stuck_label"></span>
+                    </div>
+                  </button>
+                  <button type="button"
+                    @click.stop="confirmCancelTask(s)"
+                    class="text-[10px] px-2 py-0.5 rounded bg-gray-800 hover:bg-red-800/60 text-gray-300 hover:text-red-100 border border-gray-700 hover:border-red-700/60 transition-colors shrink-0"
+                    data-testid="board-stuck-task-cancel">Cancel</button>
+                  <button type="button"
+                    x-show="s.assignee"
+                    @click.stop="restartAgentForStuck(s.assignee)"
+                    class="text-[10px] px-2 py-0.5 rounded bg-gray-800 hover:bg-amber-800/60 text-gray-300 hover:text-amber-100 border border-gray-700 hover:border-amber-700/60 transition-colors shrink-0"
+                    data-testid="board-stuck-task-restart">Restart agent</button>
+                </div>
+              </template>
+            </div>
+          </section>
+        </template>
+
+        <!-- Phase 4 — Kanban board (default Board view).
+             Responsive grid: 1 col on phones (<sm), 2 cols at 640px+,
+             4 cols on desktop (lg+). On the smallest phones the grid
+             still hits 1 column, which is fine for stacked reading;
+             the outer ``overflow-x-auto`` + inner ``min-w-[640px]``
+             give phone users a horizontal-scroll fallback so each
+             column keeps a usable width when they prefer the kanban
+             layout. Status columns: Pending / Working / Blocked /
+             Done — ``accepted`` (transient) folds into Pending via
+             the existing ``workplaceTasksByStatus`` filter. -->
+        <template x-if="workplaceEnabled && homeTab === 'kanban'">
+          <div data-testid="board-kanban">
             <!-- Error banner for /workplace/tasks. Tasks lives outside
                  the kanban grid because errored loads should still let
-                 the user retry without seeing five empty columns. -->
+                 the user retry without seeing four empty columns. -->
             <template x-if="workplaceErrors.tasks">
               <div class="bg-red-900/20 border border-red-800/40 rounded-lg p-3 mb-3 flex flex-wrap items-center gap-2"
                    role="alert" data-testid="workplace-tasks-error">
@@ -4102,8 +4161,8 @@
             </template>
             <!-- Skeleton kanban while /workplace/tasks is in flight -->
             <template x-if="workplaceSectionLoading.tasks && !workplaceTasks.length && !workplaceErrors.tasks">
-              <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-5 gap-3 mb-3" data-testid="workplace-tasks-skeleton">
-                <template x-for="i in 5" :key="'sk-task-' + i">
+              <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-2.5 mb-3" data-testid="workplace-tasks-skeleton">
+                <template x-for="i in 4" :key="'sk-task-' + i">
                   <div class="bg-gray-800/40 border border-gray-700/50 rounded-lg p-3">
                     <div class="h-3 w-1/2 bg-gray-800 rounded animate-pulse mb-2"></div>
                     <div class="h-8 bg-gray-800 rounded animate-pulse mt-2"></div>
@@ -4113,37 +4172,54 @@
               </div>
             </template>
           <div class="overflow-x-auto custom-scrollbar -mx-3 px-3 sm:mx-0 sm:px-0">
-            <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-5 gap-3 min-w-[640px] sm:min-w-0">
-              <template x-for="status in workplaceTaskColumns" :key="status">
-                <div class="bg-gray-800/40 border border-gray-700/50 rounded-lg p-3">
+            <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-2.5 min-w-[640px] sm:min-w-0">
+              <template x-for="status in ['pending','working','blocked','done']" :key="status">
+                <div class="bg-gray-800/40 border border-gray-700/50 rounded-lg p-2.5">
                   <!-- Sticky column header so cards keep their context
                        when the column scrolls. ``z-10`` keeps it above
                        the cards but below the global Needs-you panel
                        (which sits at z-10 on a different stacking
                        context — they don't overlap visually). -->
-                  <div class="text-xs font-medium text-gray-300 uppercase tracking-wide mb-2 flex items-center justify-between sticky top-0 z-10 bg-gray-800/80 backdrop-blur-sm -mx-3 px-3 py-1.5 border-b border-gray-700/40">
+                  <div class="text-[11px] font-medium text-gray-300 uppercase tracking-wide mb-2 flex items-center justify-between sticky top-0 z-10 bg-gray-800/80 backdrop-blur-sm -mx-2.5 px-2.5 py-1.5 border-b border-gray-700/40">
                     <span x-text="status"></span>
                     <span class="text-gray-500 font-mono" x-text="workplaceTasksByStatus(status).length"></span>
                   </div>
-                  <div class="space-y-2">
+                  <div class="space-y-1.5">
                     <template x-for="t in workplaceTasksByStatusFiltered(status)" :key="t.id">
-                      <div class="bg-gray-900/60 border border-gray-700/40 rounded-md p-2 text-xs cursor-pointer hover:bg-gray-900/90 hover:border-gray-600 transition-colors"
-                        @click="openTaskDrillIn(t.id)">
-                        <div class="font-medium text-gray-200 truncate" x-text="t.title"></div>
-                        <div class="text-[11px] text-gray-400 mt-1 flex items-center gap-1.5">
-                          <span x-text="t.assignee || ''"></span>
-                          <span x-show="t.project_id" class="text-gray-500"
-                            x-text="'· ' + (t.project_id || '')"></span>
-                          <template x-if="t.outcome">
-                            <span class="ml-auto px-1.5 py-0.5 rounded text-[10px] font-medium"
-                              :class="{
-                                'bg-emerald-900/30 text-emerald-300': t.outcome === 'accepted',
-                                'bg-amber-900/30 text-amber-300': t.outcome === 'rework',
-                                'bg-red-900/30 text-red-300': t.outcome === 'rejected',
-                              }"
-                              x-text="t.outcome"></span>
-                          </template>
-                        </div>
+                      <div class="group bg-gray-900/60 border border-gray-700/40 rounded-md px-2 py-1.5 text-[11px] hover:bg-gray-900/90 hover:border-gray-600 transition-colors relative"
+                        data-testid="board-kanban-card">
+                        <!-- Phase 4 cancel button: top-right × on every
+                             card; opens the confirmation modal. Hidden
+                             on the Done column (you can't cancel a
+                             completed task) and on rated cards. The
+                             ``@click.stop`` keeps the row click (drill-in)
+                             from firing. -->
+                        <button type="button"
+                          x-show="status !== 'done' && !t.outcome"
+                          @click.stop="confirmCancelTask(t)"
+                          aria-label="Cancel task"
+                          class="absolute top-1 right-1 w-5 h-5 flex items-center justify-center rounded text-gray-500 hover:text-red-300 hover:bg-red-900/30 transition-colors opacity-0 group-hover:opacity-100 focus:opacity-100"
+                          data-testid="board-kanban-card-cancel">
+                          <svg class="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M18 6L6 18M6 6l12 12"/></svg>
+                        </button>
+                        <button type="button" class="block w-full text-left pr-5"
+                          @click="openTaskDrillIn(t.id)">
+                          <div class="font-medium text-gray-200 leading-snug"
+                            :title="t.title"
+                            x-text="truncateTitle(t.title, 80)"></div>
+                          <div class="text-[10px] text-gray-400 mt-1 flex items-center gap-1.5">
+                            <span class="truncate" x-text="t.assignee || ''"></span>
+                            <template x-if="t.outcome">
+                              <span class="ml-auto px-1.5 py-0.5 rounded text-[9px] font-medium"
+                                :class="{
+                                  'bg-emerald-900/30 text-emerald-300': t.outcome === 'accepted',
+                                  'bg-amber-900/30 text-amber-300': t.outcome === 'rework',
+                                  'bg-red-900/30 text-red-300': t.outcome === 'rejected',
+                                }"
+                                x-text="t.outcome"></span>
+                            </template>
+                          </div>
+                        </button>
                       </div>
                     </template>
                     <!-- Archived disclosure: only the pending and blocked
@@ -4153,7 +4229,7 @@
                     <template x-if="workplaceArchivedCount(status) > 0">
                       <button type="button"
                         @click="boardShowArchived = { ...boardShowArchived, [status]: !boardShowArchived[status] }"
-                        class="w-full text-[11px] text-gray-400 hover:text-gray-200 px-2 py-1 rounded border border-dashed border-gray-700/60 hover:border-gray-600 transition-colors text-left">
+                        class="w-full text-[10px] text-gray-400 hover:text-gray-200 px-2 py-1 rounded border border-dashed border-gray-700/60 hover:border-gray-600 transition-colors text-left">
                         <span x-show="!boardShowArchived[status]"
                           x-text="'Show ' + workplaceArchivedCount(status) + ' archived ▸'"></span>
                         <span x-show="boardShowArchived[status]" x-cloak>Hide archived &#9662;</span>
@@ -4164,6 +4240,59 @@
               </template>
             </div>
           </div>
+          <!-- Phase 4 — Activity feed link. The single-scroll layout
+               (Just delivered + Happening now + In progress) lives at
+               /home/activity; users land here only if they click in
+               (back-compat with the Phase 3 default that opened the
+               feed first). -->
+          <div class="mt-4 text-center">
+            <button type="button" @click="switchHomeTab('activity')"
+              class="text-[12px] text-gray-400 hover:text-indigo-200 transition-colors"
+              data-testid="board-view-activity">View activity feed &rarr;</button>
+          </div>
+          </div>
+        </template>
+
+        <!-- Phase 4 — task cancel confirmation modal. Opens via
+             ``confirmCancelTask`` (kanban × button or stuck-tasks
+             [Cancel]). Closes via Escape or clicking the backdrop.
+             The mesh-side cancel route is creator/assignee/operator/
+             internal-gated — the dashboard proxy uses ``x-mesh-internal``
+             so any session with an ``ol_session`` cookie can cancel
+             from this UI. -->
+        <template x-if="cancelTaskCandidate">
+          <div class="fixed inset-0 z-[70] flex items-center justify-center p-4"
+            @keydown.escape.window="closeCancelTaskModal()"
+            data-testid="cancel-task-modal">
+            <div class="absolute inset-0 bg-black/60 backdrop-blur-sm"
+              @click="closeCancelTaskModal()"></div>
+            <div class="relative w-full max-w-md bg-gray-900 border border-gray-700 rounded-xl shadow-2xl overflow-hidden">
+              <div class="p-5">
+                <h3 class="text-base font-semibold text-white mb-1">Cancel this task?</h3>
+                <p class="text-sm text-gray-300">
+                  Cancel task
+                  <span class="text-gray-100 font-medium">"<span x-text="truncateTitle(cancelTaskCandidate.title, 60)"></span>"</span>?
+                  <template x-if="cancelTaskCandidate.assignee">
+                    <span>This will stop <span class="text-gray-100" x-text="cancelTaskCandidate.assignee"></span> from working on it.</span>
+                  </template>
+                  You can create a new task for them later.
+                </p>
+              </div>
+              <div class="flex items-center justify-end gap-2 px-5 py-3 bg-gray-950/40 border-t border-gray-800">
+                <button type="button"
+                  @click="closeCancelTaskModal()"
+                  :disabled="cancelTaskInFlight"
+                  class="text-xs px-3 py-1.5 rounded bg-gray-800 hover:bg-gray-700 text-gray-200 transition-colors disabled:opacity-50">Keep it</button>
+                <button type="button"
+                  @click="cancelTaskNow()"
+                  :disabled="cancelTaskInFlight"
+                  class="text-xs px-3 py-1.5 rounded bg-red-700 hover:bg-red-600 text-white transition-colors disabled:opacity-50"
+                  data-testid="cancel-task-confirm">
+                  <span x-show="!cancelTaskInFlight">Cancel task</span>
+                  <span x-show="cancelTaskInFlight" x-cloak>Cancelling…</span>
+                </button>
+              </div>
+            </div>
           </div>
         </template>
 

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -5091,6 +5091,124 @@ class TestWorkplaceTabRoutes:
             resp = client.post("/dashboard/api/workplace/pending/missing/cancel")
         assert resp.status_code == 404
 
+    # ── Phase 4: kanban-default Board + task cancel ─────────────────
+
+    def _patch_task_cancel_proxy(self, *, status_code: int = 200):
+        """Patch httpx so the dashboard task-cancel proxy hits the
+        in-test ``Tasks`` store directly.
+
+        ``/api/workplace/tasks/{id}/cancel`` proxies to the mesh's
+        ``/mesh/tasks/{id}/cancel`` over loopback (operator-or-internal
+        gated). There's no real mesh in unit-test process — we
+        substitute an ``AsyncClient`` whose ``post`` calls
+        ``self.tasks_store.cancel`` directly and returns the updated
+        record.
+        """
+        store = self.tasks_store
+
+        class _StubResp:
+            def __init__(self, code: int, body: dict):
+                self.status_code = code
+                self._body = body
+                self.text = "" if not body else str(body)
+
+            def json(self):
+                return self._body
+
+        class _StubClient:
+            def __init__(self_inner, *a, **kw):
+                pass
+
+            async def __aenter__(self_inner):
+                return self_inner
+
+            async def __aexit__(self_inner, *a):
+                return False
+
+            async def post(self_inner, url, json=None, headers=None):
+                # URL: .../mesh/tasks/{task_id}/cancel
+                parts = url.rstrip("/").split("/")
+                task_id = parts[-2]
+                from src.host.orchestration import (
+                    InvalidStatusTransition,
+                    TaskNotFound,
+                )
+                try:
+                    rec = store.cancel(
+                        task_id, actor="operator",
+                        reason=(json or {}).get("reason") or "",
+                    )
+                except TaskNotFound:
+                    return _StubResp(404, {"detail": "Task not found"})
+                except InvalidStatusTransition as e:
+                    return _StubResp(400, {"detail": str(e)})
+                return _StubResp(200, rec or {"ok": True})
+
+        from unittest.mock import patch
+        return patch("httpx.AsyncClient", _StubClient)
+
+    def test_workplace_task_cancel_succeeds(self):
+        client = self._client_with_v2(True)
+        rec = self.tasks_store.create(
+            creator="operator", assignee="alpha", title="dig",
+            project_id="research",
+        )
+        with self._patch_task_cancel_proxy():
+            resp = client.post(
+                f"/dashboard/api/workplace/tasks/{rec['id']}/cancel",
+                json={"reason": "no longer needed"},
+            )
+        assert resp.status_code == 200
+        body = resp.json()
+        # Cancelled task record returns status="cancelled" (or at
+        # least a truthy ok marker — the mesh route returns the
+        # updated row).
+        assert (
+            body.get("status") == "cancelled"
+            or body.get("ok") is True
+        )
+        # The store actually changed state too.
+        again = self.tasks_store.get(rec["id"])
+        assert again["status"] == "cancelled"
+
+    def test_workplace_task_cancel_unknown_returns_404(self):
+        client = self._client_with_v2(True)
+        with self._patch_task_cancel_proxy():
+            resp = client.post(
+                "/dashboard/api/workplace/tasks/missing-id/cancel",
+                json={},
+            )
+        assert resp.status_code == 404
+
+    def test_workplace_task_cancel_requires_csrf(self):
+        # The CSRF guard runs ahead of the proxy — a POST without
+        # ``X-Requested-With`` should be rejected. We test by
+        # bypassing the test client's auto-injection.
+        client = self._client_with_v2(True)
+        rec = self.tasks_store.create(
+            creator="operator", assignee="alpha", title="csrf-check",
+        )
+        # Strip the CSRF header on this request to verify the guard.
+        from fastapi.testclient import TestClient
+        plain = TestClient(client.app)
+        with self._patch_task_cancel_proxy():
+            resp = plain.post(
+                f"/dashboard/api/workplace/tasks/{rec['id']}/cancel",
+                json={},
+            )
+        # Either 403 (CSRF rejection) or some other error code is
+        # acceptable — the load-bearing assertion is "not 200".
+        assert resp.status_code != 200
+
+    def test_workplace_task_cancel_v2_off_returns_404(self):
+        client = self._client_with_v2(False)
+        with self._patch_task_cancel_proxy():
+            resp = client.post(
+                "/dashboard/api/workplace/tasks/anything/cancel",
+                json={},
+            )
+        assert resp.status_code == 404
+
 
 # ─────────────────────────────────────────────────────────────────────
 # Phase 1 — Board UX overhaul (conversations contract)

--- a/tests/test_dashboard_ui.py
+++ b/tests/test_dashboard_ui.py
@@ -726,25 +726,41 @@ class TestOperatorActionChipsMarkup:
 
 
 class TestHomeSingleScrollLayout:
-    """Phase 3 — Workplace tab restructured into a single scroll page."""
+    """Phase 4 — Board tab restructured around the kanban as default.
 
-    def test_main_layout_gated_on_home_tab(self, index_html: str):
-        # The main scroll renders only when ``homeTab === 'main'``.
-        assert "workplaceEnabled && homeTab === 'main'" in index_html
+    The legacy single-scroll layout (Phase 3) is retained as the
+    ``activity`` sub-page; the kanban is the new default. These tests
+    verify both the new gating and the back-compat for deep links.
+    """
 
-    def test_kanban_subpage_gated_on_home_tab_tasks(self, index_html: str):
-        # The kanban moves to its own sub-page (homeTab === 'tasks').
-        assert "workplaceEnabled && homeTab === 'tasks'" in index_html
+    def test_activity_layout_gated_on_home_tab(self, index_html: str):
+        # The single-scroll activity layout renders only when
+        # ``homeTab === 'activity'`` (Phase 3's ``main`` value).
+        assert "workplaceEnabled && homeTab === 'activity'" in index_html
+
+    def test_kanban_layout_gated_on_home_tab_kanban(self, index_html: str):
+        # The kanban is the new default — gated on ``homeTab === 'kanban'``.
+        assert "workplaceEnabled && homeTab === 'kanban'" in index_html
 
     def test_section_testids_present(self, index_html: str):
         # Every section in the new layout has a testid so a future
         # refactor can't accidentally hide one without tripping a test.
+        # The legacy activity-feed testids stay (still rendered on the
+        # ``activity`` sub-page); the new kanban + stuck-tasks +
+        # cancel-modal testids capture the Phase 4 surface.
         for testid in (
-            "home-main",
+            "home-activity",
             "home-just-delivered",
             "home-happening-now",
             "home-in-progress",
             "home-see-task-board",
+            "board-kanban",
+            "board-kanban-card",
+            "board-kanban-card-cancel",
+            "board-stuck-tasks",
+            "board-view-activity",
+            "cancel-task-modal",
+            "cancel-task-confirm",
         ):
             assert f'data-testid="{testid}"' in index_html, \
                 f"Missing testid: {testid}"
@@ -755,10 +771,11 @@ class TestHomeSingleScrollLayout:
         # no longer find it.
         assert "workplaceTab = wt.id; loadWorkplace()" not in index_html
 
-    def test_back_to_home_link_in_tasks_subpage(self, index_html: str):
-        # Tasks sub-page exposes a back link that returns to ``main``.
+    def test_back_to_board_link_in_activity_subpage(self, index_html: str):
+        # Activity sub-page exposes a back link that returns to the
+        # kanban (the new default).
         assert 'data-testid="home-back-to-main"' in index_html
-        assert "switchHomeTab('main')" in index_html
+        assert "switchHomeTab('kanban')" in index_html
 
     def test_legacy_subtabs_hidden_with_back_compat_gate(self, index_html: str):
         # The old project-status / team-outputs renders are kept in
@@ -770,24 +787,274 @@ class TestHomeSingleScrollLayout:
 
 
 class TestHomeRouting:
-    """Phase 3 — ``/home`` and ``/home/tasks`` URL routes."""
+    """Phase 4 — ``/home`` (kanban) and ``/home/activity`` URL routes.
+
+    Legacy ``/home/tasks`` resolves to the kanban (back-compat — the
+    kanban IS the default now, so old bookmarks survive).
+    """
 
     def test_build_path_emits_home_route(self, app_js: str):
-        # ``_buildPath`` returns ``/home`` and ``/home/tasks`` for the
-        # workplace tab depending on ``homeTab``.
-        assert "this.homeTab === 'tasks' ? '/home/tasks' : '/home'" in app_js
+        # ``_buildPath`` returns ``/home`` (kanban default) and
+        # ``/home/activity`` for the workplace tab depending on
+        # ``homeTab``.
+        assert "this.homeTab === 'activity' ? '/home/activity' : '/home'" in app_js
 
     def test_parse_path_recognizes_home_routes(self, app_js: str):
         # ``_parsePath`` accepts the new routes and maps them to the
-        # workplace tab + correct sub-page.
+        # workplace tab + correct sub-page. ``home/tasks`` (legacy)
+        # still resolves so old bookmarks survive.
         assert "clean === 'home'" in app_js
+        assert "clean === 'home/activity'" in app_js or "home/activity" in app_js
         assert "clean === 'home/tasks'" in app_js or "home/tasks" in app_js
 
     def test_switch_home_tab_helper_present(self, app_js: str):
         assert "switchHomeTab(tabId)" in app_js
 
+    def test_default_home_tab_is_kanban(self, app_js: str):
+        # The Alpine state default is now ``kanban`` (Phase 3 default
+        # was ``main``). This is the load-bearing change for the
+        # CPO call to make the kanban the default Board view.
+        assert "homeTab: 'kanban'" in app_js
 
 # ── New-user onboarding tutorial ─────────────────────────────────
+
+# ── Phase 4 (Board kanban-default): cancel + stuck-tasks + density ──
+
+
+class TestBoardKanbanDefaultUI:
+    """Phase 4 — Board kanban as default + task cancel + Stuck tasks
+    + activity-feed noise filter.
+
+    All assertions are string-level over the rendered template + static
+    JS — same idiom as the rest of this file. Headless-browser checks
+    are tracked separately."""
+
+    def test_work_tab_defaults_to_kanban(self, app_js: str):
+        # Default homeTab is ``kanban`` — the kanban surface IS the
+        # Board home page now.
+        assert "homeTab: 'kanban'" in app_js
+        # _parsePath default route also lands on kanban.
+        assert "homeTab: 'kanban'" in app_js
+
+    def test_kanban_card_renders_cancel_button(self, index_html: str):
+        # The × cancel button is present on every kanban card.
+        assert 'data-testid="board-kanban-card-cancel"' in index_html
+        # And it's wired to the confirm-cancel handler.
+        assert 'confirmCancelTask(t)' in index_html
+
+    def test_cancel_task_shows_confirmation_modal(self, index_html: str):
+        # Modal is present + gated on cancelTaskCandidate.
+        assert 'data-testid="cancel-task-modal"' in index_html
+        assert 'x-if="cancelTaskCandidate"' in index_html
+        # Confirm button calls cancelTaskNow().
+        assert 'data-testid="cancel-task-confirm"' in index_html
+        assert 'cancelTaskNow()' in index_html
+
+    def test_cancel_task_calls_dashboard_proxy(self, app_js: str):
+        # The cancel handler POSTs to the new dashboard cancel route
+        # (which proxies to the mesh).
+        assert "/workplace/tasks/" in app_js
+        assert "/cancel" in app_js
+        assert "cancelTaskNow" in app_js
+
+    def test_truncate_title_helper_present(self, app_js: str):
+        # truncateTitle is the helper backing the 80-char card title cap.
+        assert "truncateTitle(title, max)" in app_js
+
+    def test_kanban_card_uses_truncate_title(self, index_html: str):
+        # Cards render via truncateTitle so long agent-instruction-as-
+        # title strings (~250 chars seen in production) don't blow up
+        # the kanban grid.
+        idx = index_html.find('data-testid="board-kanban-card"')
+        assert idx > 0
+        nearby = index_html[idx:idx + 2500]
+        assert "truncateTitle(t.title, 80)" in nearby
+
+    def test_stuck_tasks_section_present(self, index_html: str):
+        # The Stuck tasks panel sits between Needs you and the kanban.
+        assert 'data-testid="board-stuck-tasks"' in index_html
+        # Each row has cancel + restart buttons.
+        assert 'data-testid="board-stuck-task-cancel"' in index_html
+        assert 'data-testid="board-stuck-task-restart"' in index_html
+
+    def test_stuck_tasks_section_hidden_when_empty(self, index_html: str):
+        # The section only renders when stuckTasks is non-empty —
+        # gated on ``stuckTasks.length`` in the x-if expression.
+        idx = index_html.find('data-testid="board-stuck-tasks"')
+        assert idx > 0
+        # Walk back to find the enclosing template open tag.
+        slice_ = index_html[max(0, idx - 600):idx]
+        assert "stuckTasks.length" in slice_
+
+    def test_stuck_tasks_getter_filters_pending_over_24h(self, app_js: str):
+        # The getter checks status pending/working AND age > 24h.
+        idx = app_js.find("get stuckTasks()")
+        assert idx > 0
+        body = app_js[idx:idx + 2000]
+        assert "'pending'" in body and "'working'" in body
+        assert "24 * 3600" in body  # the cutoff constant
+
+    def test_status_unchanged_filtered_from_activity_feed(self, app_js: str):
+        # formatActivityForUser returns null for status_unchanged so
+        # heartbeat noise stays out of the user-facing feed.
+        idx = app_js.find("formatActivityForUser(event)")
+        assert idx > 0
+        body = app_js[idx:idx + 4000]
+        assert "case 'status_unchanged':" in body
+        # The feed itself uses the noise-filtered view via the getter.
+        assert "get workplaceFeedVisible()" in app_js
+        assert "event_type !== 'status_unchanged'" in app_js
+
+    def test_activity_sub_page_accessible_via_link(self, index_html: str):
+        # The kanban surface ends with a "View activity feed →" link
+        # that switches to the activity sub-page.
+        assert 'data-testid="board-view-activity"' in index_html
+        idx = index_html.find('data-testid="board-view-activity"')
+        nearby = index_html[max(0, idx - 200):idx + 200]
+        assert "switchHomeTab('activity')" in nearby
+
+    def test_legacy_home_tasks_url_resolves_to_kanban(self, app_js: str):
+        # ``/home/tasks`` (Phase 3 kanban URL) maps to the kanban
+        # default — old bookmarks survive without a redirect.
+        assert "clean === 'home/tasks'" in app_js
+        # The branch sets homeTab = 'kanban' (not 'tasks') so the
+        # default UI lights up.
+        idx = app_js.find("clean === 'home/tasks'")
+        assert idx > 0
+        body = app_js[idx:idx + 200]
+        assert "homeTab = 'kanban'" in body
+
+
+# ── Phase 4 audit fixes: kanban accepted-fold + restart confirm + ──
+# ── vocab + stale code cleanup. ──────────────────────────────────
+
+
+class TestBoardKanbanAuditFixes:
+    """Audit-driven follow-ups on the Phase 4 kanban-default surface.
+
+    Each test maps to one finding from the post-merge audit on
+    ``feat/work-tab-kanban-default-cancel-density``. They cover:
+
+    - Critical #1: ``accepted`` tasks fold into the Pending column so
+      they stay visible on the board.
+    - Critical #2: ``restartAgentForStuck`` routes through ``showConfirm``
+      before issuing the destructive POST.
+    - High #1: Activity sub-page back-link reads "Back to Work" (not the
+      stale "Back to Board" copy that conflicts with the renamed top-nav
+      tab from PR-G).
+    - High #2: Cancel-task modal copy doesn't claim the task is
+      "re-assignable" — ``cancelled`` is a terminal state in the
+      orchestration ledger.
+    - Medium #1: Dead ``task_status_unchanged`` switch arm dropped (the
+      engine emits the single name ``status_unchanged``).
+    - Medium #2: Dead ``workplaceTaskColumns`` Alpine state removed.
+    - Medium #3: Stale ``home-main`` testid renamed to ``home-activity``.
+    - Medium #4: ``stuckTasks`` getter filters out the operator agent.
+    """
+
+    # ── Critical #1: kanban accepted-fold ─────────────────────────
+
+    def test_kanban_pending_column_includes_accepted_tasks(self, app_js: str):
+        # The kanban template hard-codes 4 columns; ``accepted`` is a
+        # transient status emitted by ``update_status`` between pending
+        # and working. The filter folds it into the Pending column so
+        # those tasks remain visible (and cancellable) on the board.
+        idx = app_js.find("workplaceTasksByStatus(status)")
+        assert idx > 0
+        body = app_js[idx:idx + 1000]
+        # Both pending and accepted are matched in the pending branch.
+        assert "t.status === 'pending'" in body
+        assert "t.status === 'accepted'" in body
+        # Other statuses still match by exact equality.
+        assert "t.status === status" in body
+
+    # ── Critical #2: restart confirmation modal ───────────────────
+
+    def test_restart_agent_for_stuck_routes_through_show_confirm(self, app_js: str):
+        # The Stuck-tasks panel's [Restart agent] button is destructive;
+        # it now goes through ``showConfirm`` so a stray click can't
+        # interrupt active work without an explicit confirmation.
+        idx = app_js.find("async restartAgentForStuck(agentId)")
+        assert idx > 0
+        body = app_js[idx:idx + 2500]
+        assert "this.showConfirm(" in body, \
+            "restartAgentForStuck must route through showConfirm"
+        # Confirm callback wraps the destructive fetch so the modal's
+        # spinner ties to the actual restart.
+        assert "/restart" in body
+        # The confirmation copy mentions the active-work interruption.
+        assert "interrupt any active work" in body
+
+    # ── High #1: "Back to Work" copy ──────────────────────────────
+
+    def test_back_to_board_renamed_to_back_to_work(self, index_html: str):
+        # PR-G renamed the top-nav tab from Home to Work. The two
+        # back-links on the Activity sub-page must match the new label.
+        assert "Back to Work" in index_html
+        # No stale "Back to Board" copy survives.
+        assert "Back to Board" not in index_html
+
+    # ── High #2: cancel-modal copy doesn't claim re-assignability ──
+
+    def test_cancel_modal_copy_does_not_claim_reassignability(self, index_html: str):
+        # ``cancelled`` is terminal in orchestration.py — there is no
+        # transition out, so the modal must not claim the task is
+        # re-assignable. New copy points at creating a new task instead.
+        idx = index_html.find('data-testid="cancel-task-modal"')
+        assert idx > 0
+        # Window the modal block (~1.5KB is enough to cover the body
+        # text + buttons).
+        block = index_html[idx:idx + 1500]
+        assert "re-assigned" not in block, \
+            "cancel-modal must not claim cancelled tasks are re-assignable"
+        assert "create a new task" in block
+
+    # ── Medium #1: drop dead task_status_unchanged switch arm ─────
+
+    def test_task_status_unchanged_switch_arm_dropped(self, app_js: str):
+        # The engine emits ``status_unchanged`` (single name) — the
+        # ``task_status_unchanged`` arm was dead.
+        idx = app_js.find("formatActivityForUser(event)")
+        assert idx > 0
+        body = app_js[idx:idx + 4000]
+        assert "case 'status_unchanged':" in body
+        assert "case 'task_status_unchanged':" not in body, \
+            "dead task_status_unchanged switch arm must be removed"
+
+    # ── Medium #2: workplaceTaskColumns state removed ─────────────
+
+    def test_workplace_task_columns_state_removed(self, app_js: str, index_html: str):
+        # Dead Alpine state — the kanban inlines the column array; the
+        # only remaining template usage was for project count pills,
+        # which now also inlines its own array.
+        assert "workplaceTaskColumns:" not in app_js, \
+            "dead workplaceTaskColumns Alpine state must be removed"
+        assert "workplaceTaskColumns" not in index_html, \
+            "no template should reference the removed workplaceTaskColumns"
+
+    # ── Medium #3: home-main testid renamed to home-activity ──────
+
+    def test_home_main_testid_renamed_to_home_activity(self, index_html: str):
+        # The activity sub-page's container testid lines up with the
+        # surrounding ``home-just-delivered`` / ``home-happening-now``
+        # naming.
+        assert 'data-testid="home-activity"' in index_html
+        assert 'data-testid="home-main"' not in index_html
+
+    # ── Medium #4: stuckTasks filters operator ────────────────────
+
+    def test_stuck_tasks_filters_operator_assignee(self, app_js: str):
+        # Defensive filter: operator is the orchestrator, not a worker.
+        # Even if a future code path accidentally assigns work to it,
+        # the Stuck panel must not surface those rows.
+        idx = app_js.find("get stuckTasks()")
+        assert idx > 0
+        body = app_js[idx:idx + 2000]
+        assert "t.assignee === 'operator'" in body, \
+            "stuckTasks must filter out operator-assigned rows"
+
+
+# ── Phase 4: \"What's new\" tour for existing-fleet users ──────────
 
 
 class TestNewUserTutorialMarkup:


### PR DESCRIPTION
## Summary

CPO call after seeing dense single-scroll production data with tasks stuck in pending for 5+ days, wall-of-text task titles, and repetitive `status_unchanged` heartbeat noise: redesign Work tab around the kanban board as the default.

## Changes

### Default view = kanban board

- **Was:** single-scroll layout (Just Delivered → Recent Activity → Tasks summary)
- **Now:** kanban board with status columns: Pending / Working / Blocked / Done

Old single-scroll content moved to a secondary `/work/activity` sub-page accessible via "View activity feed →" link at the bottom of the kanban.

### Task cancel button on every kanban card

`×` icon on each card. Click → confirmation modal → cancel via mesh endpoint. Users can finally clear stuck tasks without asking the Operator.

### Stuck tasks sticky section

Between Needs You and the kanban. Surfaces tasks pending or unchanged >24h. Each entry: title (truncated), agent name, "Stuck for X days" caption, `[Cancel]` and `[Restart agent]` buttons. Hidden when empty.

### Title truncation

Render-time truncation at ≤80 chars with hover for full text. Acts as backstop regardless of how long the task title is in the data (PR-I addresses the root cause server-side).

### Activity feed noise filtered

`status_unchanged` events filtered from default activity feed (heartbeat noise). Visible only via "Show technical detail" toggle. Repeated stuck-task notices for the same task aggregate into the new Stuck Tasks section instead of separate feed entries.

### Backwards compat

Deep links to `/home/tasks` (the Phase 3 sub-page) still work — they now redirect to the default kanban view.

## Test plan

- [x] Work tab defaults to kanban
- [x] Each card has cancel button
- [x] Cancel shows confirmation modal
- [x] Cancel calls mesh endpoint
- [x] Title truncated at 80 chars
- [x] Stuck Tasks section shows pending >24h
- [x] Stuck Tasks hidden when empty
- [x] `status_unchanged` filtered from activity feed
- [x] Activity sub-page accessible via link
- [x] Cancel endpoint requires auth, returns 200 on success, 404 on unknown

525 tests pass, 4 skipped. `ruff` clean.

## Stats

5 files changed: +767 / -115.

## Coordination

Pairs with **PR-I (#TBD)** — task title quality fix at the data source. PR-H truncates at render time as a backstop; PR-I prevents long titles from being created in the first place. Either or both ship safely.

Touches `app.js` + `index.html` heavily — likely conflicts with PR-G/PR-J at merge time. Standard rebase + preserve-both-sides resolution.