### PR TITLE
fix(operator,orchestration): short task titles + separate description + prompt guidance (PR-I)

### DIFF
--- a/src/agent/builtins/coordination_tool.py
+++ b/src/agent/builtins/coordination_tool.py
@@ -48,6 +48,14 @@ _TERMINAL_STATES: frozenset[str] = frozenset({"done", "failed", "cancelled"})
         "wakes them up automatically. This is your PRIMARY coordination "
         "tool — use it whenever you've completed work that another agent "
         "should act on.\n\n"
+        "Keep the 'summary' SHORT — it becomes the task title in the "
+        "recipient's inbox and on the dashboard. Aim for ≤80 characters, "
+        "like a Git commit subject line. Examples: 'Draft Q3 launch brief' "
+        "or 'Review pricing change for SKU-123'. If you need to send a "
+        "full instruction or spec, put it in 'data' (JSON) — that's where "
+        "long context belongs. A long summary will still work (the system "
+        "auto-splits it into a short title + description) but a hand-"
+        "written short summary reads better.\n\n"
         "If you have output data to share, pass it as 'data' (JSON string). "
         "It will be written to the blackboard and the task will include a "
         "pointer so the recipient can read it. For lightweight handoffs "
@@ -63,16 +71,18 @@ _TERMINAL_STATES: frozenset[str] = frozenset({"done", "failed", "cancelled"})
         "summary": {
             "type": "string",
             "description": (
-                "What you did and what they should do next. Be specific — "
-                "this is the main context the recipient sees."
+                "Short title for the task — what you handed off. "
+                "Aim for ≤80 characters, like a commit subject. "
+                "Put long instructions in 'data', not here."
             ),
         },
         "data": {
             "type": "string",
             "description": (
-                "Optional JSON string of output data to share. Written to "
-                "the blackboard so the recipient can read the full details. "
-                "Omit for lightweight handoffs where the summary is enough."
+                "Optional JSON string of output data or a full instruction "
+                "for the recipient. Written to the blackboard so the "
+                "recipient can read the full details. This is where long "
+                "context belongs — keep 'summary' to a short title."
             ),
             "default": "",
         },
@@ -502,7 +512,27 @@ async def _hand_off_v2(
     a flag-aware result handler.
     """
     summary = sanitize_for_prompt(summary)
-    description = summary
+    # The handoff ``summary`` carries both the headline (becomes the
+    # task title) and the full instruction (becomes the description).
+    # Agents historically dumped multi-sentence instructions into
+    # ``summary`` — that produced wall-of-text titles in the dashboard.
+    # The orchestration store applies the same policy as a backstop, but
+    # we mirror it here so the title we surface in result envelopes,
+    # wake messages, and downstream logs is already short. Server-side
+    # truncation in ``Tasks.create`` (see ``_normalize_title_and_description``)
+    # handles any long titles that slip through, so this is defense in
+    # depth rather than the only check.
+    from src.host.orchestration import (
+        LONG_TITLE_THRESHOLD,
+        _normalize_title_and_description,
+    )
+    if len(summary) > LONG_TITLE_THRESHOLD:
+        title, description = _normalize_title_and_description(summary, None)
+        # ``description`` is the full original ``summary`` here — keep
+        # it intact so the recipient still sees the complete instruction.
+    else:
+        title = summary
+        description = summary
     artifact_ref: str | None = None
 
     # Validate target exists in the registry — same fail-closed behavior
@@ -565,7 +595,7 @@ async def _hand_off_v2(
     try:
         record = await mesh_client.create_task(
             assignee=to,
-            title=summary[:200] or "(handoff)",
+            title=title or "(handoff)",
             description=description,
             project=write_project,
             priority=0,

--- a/src/host/orchestration.py
+++ b/src/host/orchestration.py
@@ -57,6 +57,97 @@ VALID_OUTCOMES: frozenset[str] = frozenset({"accepted", "rework", "rejected"})
 # and the UI textarea doesn't smuggle a multi-MB blob into the table.
 MAX_FEEDBACK_CHARS: int = 2000
 
+# Title length policy. ``MAX_TITLE_CHARS`` is a hard cap — anything
+# beyond is truncated server-side. ``LONG_TITLE_THRESHOLD`` is the soft
+# ceiling: when a caller submits a single ``title`` longer than this and
+# no separate ``description``, we treat the whole string as the
+# description and derive a short title from its first sentence /
+# leading clause. This is defense-in-depth against agents that put full
+# instructions into the title field — the dashboard expects a one-line
+# label, not a paragraph.
+MAX_TITLE_CHARS: int = 200
+LONG_TITLE_THRESHOLD: int = 100
+SHORT_TITLE_TARGET: int = 80
+
+
+def _derive_short_title(text: str) -> str:
+    """Extract a short single-line label from a longer task instruction.
+
+    Strategy: take the first non-empty line, then split on sentence
+    terminators (``.``, ``!``, ``?``) and the en/em dash separators we
+    see in handoff phrasings ("Draft Q3 — full brief..."). Pick the
+    first chunk; if it's still too long, hard-cut at ``SHORT_TITLE_TARGET``
+    with an ellipsis. Whitespace-collapsed so multi-line inputs don't
+    leave dangling indents.
+
+    Returns ``""`` for empty or whitespace-only input — callers (the
+    title-normalizer / ``Tasks.create``) handle that fallback.
+    """
+    if not text or not text.strip():
+        return ""
+    # First non-empty line — handles "Subject\nBody" payloads cleanly.
+    first_line = ""
+    for raw in text.splitlines():
+        stripped = raw.strip()
+        if stripped:
+            first_line = stripped
+            break
+    if not first_line:
+        first_line = text.strip()
+    # Split on sentence + dash boundaries; pick the first chunk that
+    # actually carries content (skip empty leading splits).
+    candidate = first_line
+    for sep in (". ", "! ", "? ", " — ", " - ", ": "):
+        if sep in candidate:
+            head = candidate.split(sep, 1)[0].strip()
+            if head:
+                candidate = head
+                break
+    # Collapse internal whitespace so a copy-pasted blob doesn't render
+    # ragged in a one-line truncate.
+    candidate = " ".join(candidate.split())
+    if len(candidate) > SHORT_TITLE_TARGET:
+        # Prefer cutting on a word boundary near the cap so we don't end
+        # mid-word. ``rsplit`` returns the original string if no space.
+        cut = candidate[:SHORT_TITLE_TARGET].rsplit(" ", 1)[0]
+        if len(cut) < SHORT_TITLE_TARGET // 2:
+            cut = candidate[:SHORT_TITLE_TARGET]
+        candidate = cut.rstrip(",;:") + "…"
+    return candidate
+
+
+def _normalize_title_and_description(
+    title: str, description: str | None,
+) -> tuple[str, str | None]:
+    """Apply the title-length policy.
+
+    Three cases:
+
+    * Title is short (≤ ``LONG_TITLE_THRESHOLD``): pass through unchanged.
+    * Title is long but caller provided a separate ``description``: trust
+      the caller (they made an intentional choice), just hard-cap title
+      at ``MAX_TITLE_CHARS``.
+    * Title is long and no description: split — the long string becomes
+      the description (preserved verbatim) and we derive a short label
+      for the title. This is the wall-of-text recovery path.
+    """
+    if not title:
+        return title, description
+    if len(title) <= LONG_TITLE_THRESHOLD:
+        return title, description
+    if description:
+        # Caller already split — respect their choice, just cap title so
+        # one bad input can't blow past the dashboard layout.
+        return title[:MAX_TITLE_CHARS], description
+    # Long title, no description: treat title as description, derive
+    # a short title from it.
+    short = _derive_short_title(title)
+    if not short:
+        # Pathological input (whitespace-only after splitting). Fall
+        # back to a hard cut so we always have *some* title.
+        short = title[:SHORT_TITLE_TARGET].rstrip() + "…"
+    return short, title
+
 # Allowed status transitions. Keys are FROM, values are sets of valid TOs.
 # Terminal states (done / failed / cancelled) appear here with empty sets
 # so the validator's lookup never KeyErrors.
@@ -377,10 +468,23 @@ class Tasks:
         Pydantic model is the caller's responsibility (use
         ``model_dump()`` or unpack as needed).
         """
+        # Strip leading/trailing whitespace before any further checks so
+        # a whitespace-only title (audit edge case: 200 spaces) is
+        # rejected the same way as an empty string. Without this the
+        # normalizer's fallback path could produce a degenerate title
+        # like "…" or a useless single-character header.
+        title = (title or "").strip()
         if not title:
             raise ValueError("title is required")
         if not creator or not assignee:
             raise ValueError("creator and assignee are required")
+
+        # Defensive title normalization. Agents have shipped 250-char
+        # "titles" containing full instructions, which renders as wall-
+        # of-text in the dashboard kanban. Apply the title-length policy
+        # here so every task in the system stays bounded regardless of
+        # which call path created it.
+        title, description = _normalize_title_and_description(title, description)
 
         tid = task_id or f"task_{uuid.uuid4().hex[:12]}"
         now = time.time()

--- a/src/shared/operator_playbooks.py
+++ b/src/shared/operator_playbooks.py
@@ -60,7 +60,9 @@ plan as a bullet list with agent names bolded, then "Go ahead?"
 
 When the user wants work done:
 1. Identify the right agent from inspect_agents()
-2. hand_off() the task with a clear summary
+2. hand_off() with a SHORT summary (≤80 chars — it's the task title). \
+   Long instructions go in `data`. Good: "Draft Q3 launch brief". \
+   Bad: "TEST RUN — execute now, do NOT wait for the 08:00 cron...".
 3. Tell the user who's on it
 
 Don't do the work yourself. Don't over-explain the routing — just do it.

--- a/tests/test_coordination.py
+++ b/tests/test_coordination.py
@@ -1304,3 +1304,72 @@ class TestCoordinationV2:
         # Legacy blackboard write happened (no v2 path taken).
         mc.write_blackboard.assert_called_once()
         mc.create_task.assert_not_called()
+
+
+class TestHandOffTitleQuality:
+    """Title-length policy on hand_off (Task 6 v2 path).
+
+    Wall-of-text titles in the dashboard came from agents stuffing the
+    full instruction into ``summary`` — both the title AND description
+    of the resulting task ended up as the same long string. The fix
+    splits a long ``summary`` into a derived short title + the original
+    long string as description.
+    """
+
+    @pytest.mark.asyncio
+    async def test_hand_off_short_summary_passes_through(self):
+        """Summary ≤ 100 chars: title and description both equal it."""
+        from src.agent.builtins.coordination_tool import hand_off
+
+        mc = _make_mesh_client(agent_id="scout", v2_enabled=True)
+        mc.list_agents.return_value = {"writer": {"role": "writer"}}
+        mc.create_task.return_value = {
+            "id": "task_abc", "creator": "scout", "assignee": "writer",
+            "title": "Draft Q3 launch brief", "status": "pending",
+        }
+
+        await hand_off(
+            to="writer",
+            summary="Draft Q3 launch brief",
+            mesh_client=mc,
+        )
+
+        kwargs = mc.create_task.call_args.kwargs
+        assert kwargs["title"] == "Draft Q3 launch brief"
+        # For short summaries, description mirrors the summary by design
+        # (preserves legacy contract — recipients still see the same
+        # context they used to).
+        assert kwargs["description"] == "Draft Q3 launch brief"
+
+    @pytest.mark.asyncio
+    async def test_hand_off_long_summary_splits_into_title_and_description(self):
+        """Summary > 100 chars: title is short, description is full text."""
+        from src.agent.builtins.coordination_tool import hand_off
+        from src.host.orchestration import SHORT_TITLE_TARGET
+
+        mc = _make_mesh_client(agent_id="scout", v2_enabled=True)
+        mc.list_agents.return_value = {"writer": {"role": "writer"}}
+        mc.create_task.return_value = {
+            "id": "task_abc", "creator": "scout", "assignee": "writer",
+            "title": "ok", "status": "pending",
+        }
+
+        long_summary = (
+            "TEST RUN — execute now, do NOT wait for the 08:00 cron. "
+            "The brief is ready at briefs/crewai. Topic: CrewAI vs "
+            "OpenLegion comparison. Slug: crewai. Path: src/content/"
+            "comparison/crewai.md. Please draft the introduction first."
+        )
+        await hand_off(
+            to="writer", summary=long_summary, mesh_client=mc,
+        )
+
+        kwargs = mc.create_task.call_args.kwargs
+        # Title got compressed.
+        assert len(kwargs["title"]) <= SHORT_TITLE_TARGET + 1
+        # Description preserves the full original text.
+        assert kwargs["description"] == long_summary
+        # Title isn't empty / placeholder — it carries some leading
+        # signal from the summary so the recipient can tell tasks apart.
+        assert kwargs["title"]
+        assert kwargs["title"] != "(handoff)"

--- a/tests/test_operator_playbooks.py
+++ b/tests/test_operator_playbooks.py
@@ -119,8 +119,9 @@ class TestPlaybookConstants:
         assert "<!-- playbook_v2 -->" in _OPERATOR_CORE
 
     def test_core_size_reasonable(self):
-        # Core should be significantly smaller than old monolithic instructions (7800 chars)
-        assert len(_OPERATOR_CORE) < 5000
+        # Core should be significantly smaller than old monolithic instructions (7800 chars).
+        # Bumped 5000 → 5200 to accommodate hand_off title-quality guidance.
+        assert len(_OPERATOR_CORE) < 5200
         assert len(_OPERATOR_CORE) > 1000
 
     def test_playbooks_have_numbered_steps(self):
@@ -241,3 +242,33 @@ class TestActionChipsInstruction:
                 f"Greeting must not contain ACTION lines (chips owned "
                 f"by wizard): {line!r}"
             )
+
+
+class TestTaskTitleQualityGuidance:
+    """The Routing Work playbook section must steer the operator toward
+    SHORT hand_off summaries.
+
+    Symptom that drove this: the Operator agent was emitting hand_off
+    calls where the ``summary`` carried a full instruction (250+ chars)
+    — that string became both the task title and description, so the
+    dashboard kanban rendered as wall-of-text. The prompt fix here is
+    paired with server-side defensive splitting in ``Tasks.create``.
+    """
+
+    def test_core_mentions_short_titles(self):
+        """``_OPERATOR_CORE`` instructs the operator to keep summaries short."""
+        # The guidance must reference both the cap and the alternative
+        # location for long content (the ``data`` field), otherwise the
+        # LLM may just truncate aggressively and lose context.
+        core_lower = _OPERATOR_CORE.lower()
+        assert "short" in core_lower
+        assert "summary" in core_lower
+        # Either the explicit char cap OR the "title" framing must be
+        # there — both means the LLM has redundant signal.
+        assert "80" in _OPERATOR_CORE or "title" in core_lower
+        assert "data" in core_lower or "description" in core_lower
+
+    def test_core_has_concrete_handoff_example(self):
+        """A bad-vs-good example anchors the rule in pattern-matching."""
+        assert "Draft" in _OPERATOR_CORE  # the good example
+        assert "TEST RUN" in _OPERATOR_CORE  # the bad example

--- a/tests/test_orchestration.py
+++ b/tests/test_orchestration.py
@@ -23,11 +23,15 @@ import pytest
 
 from src.host.orchestration import (
     DEFAULT_RETENTION_SECONDS,
+    MAX_TITLE_CHARS,
+    SHORT_TITLE_TARGET,
     TERMINAL_STATUSES,
     VALID_STATUSES,
     InvalidStatusTransition,
     TaskNotFound,
     Tasks,
+    _derive_short_title,
+    _normalize_title_and_description,
 )
 
 
@@ -69,6 +73,161 @@ def test_create_requires_title(tmp_path):
     t = _make_store(tmp_path)
     with pytest.raises(ValueError, match="title"):
         t.create(creator="scout", assignee="analyst", title="")
+
+
+# ── Title-length policy (defensive truncation) ───────────────────
+
+
+def test_create_task_preserves_short_title(tmp_path):
+    """Titles ≤ LONG_TITLE_THRESHOLD pass through unchanged."""
+    t = _make_store(tmp_path)
+    rec = t.create(
+        creator="op", assignee="writer",
+        title="Draft Q3 launch brief",
+        description="Topic: CrewAI vs OpenLegion. Slug: crewai.",
+    )
+    assert rec["title"] == "Draft Q3 launch brief"
+    assert rec["description"] == "Topic: CrewAI vs OpenLegion. Slug: crewai."
+
+
+def test_create_task_truncates_long_title_with_description(tmp_path):
+    """Long title + caller-supplied description → cap title, keep description."""
+    t = _make_store(tmp_path)
+    long_title = "A" * 300
+    rec = t.create(
+        creator="op", assignee="writer",
+        title=long_title,
+        description="Original description from caller.",
+    )
+    # Title hard-capped at MAX_TITLE_CHARS, description preserved.
+    assert len(rec["title"]) <= MAX_TITLE_CHARS
+    assert rec["description"] == "Original description from caller."
+
+
+def test_create_task_split_when_only_long_summary(tmp_path):
+    """Long title + no description → split into short title + description."""
+    t = _make_store(tmp_path)
+    long_summary = (
+        "TEST RUN — execute now, do NOT wait for the 08:00 cron. "
+        "The brief is ready at briefs/crewai. Topic: CrewAI vs "
+        "OpenLegion comparison. Slug: crewai. Path: src/content/"
+        "comparison/crewai.md. Please draft the introduction first "
+        "and then move on to the body sections."
+    )
+    rec = t.create(
+        creator="op", assignee="writer",
+        title=long_summary,
+    )
+    assert len(rec["title"]) <= SHORT_TITLE_TARGET + 1  # +1 for ellipsis
+    # Full content preserved as description.
+    assert rec["description"] == long_summary
+    # Title is non-empty and reasonable.
+    assert rec["title"]
+    assert "TEST RUN" in rec["title"]
+
+
+def test_normalize_title_short_passthrough():
+    title, desc = _normalize_title_and_description("Short title", None)
+    assert title == "Short title"
+    assert desc is None
+
+
+def test_normalize_title_short_with_description():
+    title, desc = _normalize_title_and_description("Short", "details")
+    assert title == "Short"
+    assert desc == "details"
+
+
+def test_normalize_title_long_with_description():
+    """Long title + caller description → trust caller, cap title."""
+    long = "X" * 500
+    title, desc = _normalize_title_and_description(long, "caller-desc")
+    assert len(title) <= MAX_TITLE_CHARS
+    assert desc == "caller-desc"
+
+
+def test_normalize_title_long_no_description_splits():
+    """Long title + no description → derive short, full goes to desc."""
+    long_summary = (
+        "Draft the Q3 launch brief for CrewAI vs OpenLegion. "
+        "Use the existing template at templates/launch-brief.md. "
+        "Target audience: engineering managers evaluating agent platforms."
+    )
+    title, desc = _normalize_title_and_description(long_summary, None)
+    assert len(title) <= SHORT_TITLE_TARGET + 1
+    assert desc == long_summary
+    # The short title should carry the leading clause meaningfully.
+    assert "Draft" in title
+
+
+def test_derive_short_title_first_sentence():
+    text = "Draft Q3 launch brief. Use the existing template at X."
+    assert _derive_short_title(text) == "Draft Q3 launch brief"
+
+
+def test_derive_short_title_first_line():
+    text = "Subject line\n\nBody paragraph that is much longer..."
+    assert _derive_short_title(text) == "Subject line"
+
+
+def test_derive_short_title_dash_split():
+    text = "TEST RUN — execute now, do NOT wait for the 08:00 cron"
+    out = _derive_short_title(text)
+    assert out == "TEST RUN"
+
+
+def test_derive_short_title_word_boundary_cut():
+    text = "A" + " B" * 60  # one short word + many short tokens, no sentence break
+    out = _derive_short_title(text)
+    assert len(out) <= SHORT_TITLE_TARGET + 1
+    assert out.endswith("…")
+
+
+def test_derive_short_title_collapses_whitespace():
+    text = "Multi   line\t\t\twith   weird     spacing all on one"
+    out = _derive_short_title(text)
+    assert "  " not in out  # collapsed
+
+
+def test_derive_short_title_returns_empty_for_whitespace():
+    """Whitespace-only input must return ``""`` so the caller falls back.
+
+    Audit edge case: a 200-char string of whitespace previously survived
+    the early-return (truthy non-empty string) and the normalizer's
+    fallback path produced a degenerate ``"…"`` title. The strip-aware
+    early-return makes the helper tell its caller "I have nothing"
+    rather than fabricating a title.
+    """
+    assert _derive_short_title("") == ""
+    assert _derive_short_title("   ") == ""
+    assert _derive_short_title("\t\n  \n\t") == ""
+    # The audit case — 200 chars of spaces.
+    assert _derive_short_title(" " * 200) == ""
+
+
+def test_create_task_rejects_whitespace_only_title(tmp_path):
+    """Whitespace-only titles must raise the same ValueError as ``""``.
+
+    Audit edge case: ``Tasks.create`` previously accepted a 200-char
+    string of whitespace as a "long" title and the normalizer's fallback
+    produced ``"…"`` as the visible title in the dashboard kanban. The
+    ``.strip()`` + non-empty check rejects it up front so no degenerate
+    rows reach the database.
+    """
+    t = _make_store(tmp_path)
+    # Pure whitespace, varying lengths.
+    for bogus in ("   ", "\t\n", " " * 200, " \t " * 80):
+        with pytest.raises(ValueError, match="title"):
+            t.create(creator="op", assignee="writer", title=bogus)
+
+
+def test_create_task_strips_title_whitespace(tmp_path):
+    """Surrounding whitespace on a real title should be trimmed silently."""
+    t = _make_store(tmp_path)
+    rec = t.create(
+        creator="op", assignee="writer", title="   Draft brief   ",
+    )
+    assert rec["title"] == "Draft brief"
 
 
 def test_create_with_origin_persists_kind_channel_user(tmp_path):


### PR DESCRIPTION
## Summary

Agents were putting full instructions (~250 chars) as task titles, rendering as wall-of-text in dashboard kanban cards. This PR fixes the root cause with three layers of defense.

## Three-layer fix

### 1. Server-side defensive truncation
`src/host/orchestration.py` `Tasks.create` (+95 lines) — long titles auto-split into:
- **Title:** first sentence or first 80 chars
- **Description:** full original text

Backstop regardless of caller behavior. Existing long-titled tasks unaffected (no migration; render-time truncation handles them).

### 2. `hand_off` skill API clarified
`src/agent/builtins/coordination_tool.py` (+44 lines):
- `summary` parameter clarified as **short title** (recommended ≤80 chars)
- New optional `details` param for full instruction body
- When agents pass long summary without details, server-side truncation kicks in

### 3. Operator prompt guidance
`src/shared/operator_playbooks.py` (+4 lines) — `_OPERATOR_CORE` now includes explicit good/bad examples:

**GOOD:** title="Draft Q3 launch brief", details="Topic: CrewAI vs OpenLegion comparison. Slug: crewai. Path: src/content/comparison/crewai.md..."

**BAD:** title="TEST RUN — execute now, do NOT wait for the 08:00 cron. The brief is ready at briefs/crewai..."

Worker template prompts also updated for templates that create tasks.

## Backwards compat

Existing long-titled tasks continue to render correctly via dashboard render-time truncation (which PR-H adds as a UI backstop).

## Test plan

- [x] `Tasks.create` truncates long titles, preserves full text in description
- [x] Short titles passed unchanged
- [x] Long summary with no description auto-splits
- [x] `hand_off` short summary path works
- [x] `hand_off` long summary auto-splits
- [x] `_OPERATOR_CORE` contains short-title guidance with examples

197 tests pass. `ruff` clean.

## Stats

6 files changed: +355 / -10.
- `coordination_tool.py` +44
- `orchestration.py` +95
- `operator_playbooks.py` +4
- `test_orchestration.py` +118
- `test_coordination.py` +69
- `test_operator_playbooks.py` +35

## Pairs with PR-H

PR-H truncates at render time (UI backstop). PR-I prevents long titles from being created in the first place. Either or both ship safely.