### PR TITLE
fix(host): mesh auth honors internal callers — fixes dashboard cancel proxy

### DIFF
--- a/src/host/server.py
+++ b/src/host/server.py
@@ -828,13 +828,25 @@ def create_mesh_app(
         return token if token else None
 
     def _extract_verified_agent_id(request: Request) -> str:
-        """Extract and verify agent identity from a Bearer token.
+        """Extract and verify agent identity.
 
-        Derives the agent_id from the token itself, preventing
-        identity spoofing via headers or query parameters.
+        Internal callers (loopback + ``x-mesh-internal`` header) are
+        trusted based on the network boundary — they don't need a Bearer
+        token. Dashboard proxies, the mesh dispatcher, the CLI manager,
+        and health checks all reach the mesh this way and don't have
+        access to per-agent Bearer tokens (which are server-side
+        secrets). For these callers we trust the ``X-Agent-ID`` header
+        and default to ``"operator"`` (the dashboard's persona for
+        cross-cutting actions).
+
+        Public callers must present a valid Bearer token. The agent_id
+        is derived from the token itself, preventing identity spoofing
+        via headers or query parameters.
 
         Returns 'unknown' when auth is not configured (dev/test mode).
         """
+        if _is_internal_caller(request):
+            return request.headers.get("X-Agent-ID", "operator")
         if not _auth_tokens:
             # Auth not configured (dev/test mode) — fall back to header hint
             return request.headers.get("X-Agent-ID", "unknown")

--- a/tests/test_orchestration_endpoints.py
+++ b/tests/test_orchestration_endpoints.py
@@ -458,3 +458,146 @@ async def test_pending_cancel_unknown_returns_404(v2_app):
             headers={"X-Agent-ID": "operator", "X-Mesh-Internal": "1"},
         )
         assert r.status_code == 404
+
+
+# ── Hotfix: _extract_verified_agent_id honors internal callers ──────
+#
+# In production (auth tokens configured), the dashboard cancel proxy
+# hits ``/mesh/tasks/{id}/cancel`` over loopback with
+# ``x-mesh-internal: 1`` + ``X-Agent-ID: operator`` but NO Bearer token
+# (Bearer tokens are server-side secrets the dashboard doesn't have).
+# The previous ``_extract_verified_agent_id`` rejected those callers
+# with 401 "Missing authentication token". Trust the loopback boundary
+# instead.
+
+
+@pytest.fixture
+def v2_app_with_auth(tmp_path, monkeypatch):
+    """v2 mesh app with auth tokens configured (production-like)."""
+    server_module = _reload_server(
+        monkeypatch, v2=True, tasks_db=str(tmp_path / "tasks.db"),
+    )
+    perms_map = {
+        "operator": {"can_route_tasks": True},
+        "scout":    {"can_route_tasks": True, "can_message": ["analyst", "operator"]},
+        "analyst":  {"can_route_tasks": False, "can_message": ["scout"]},
+    }
+    blackboard = Blackboard(str(tmp_path / "bb.db"))
+    pubsub = PubSub()
+    permissions = PermissionMatrix()
+    for aid, perms in perms_map.items():
+        permissions.permissions[aid] = AgentPermissions(agent_id=aid, **perms)
+    router = MessageRouter(permissions, {
+        "scout": "http://scout:8400",
+        "analyst": "http://analyst:8400",
+        "operator": "http://operator:8400",
+    })
+    app = server_module.create_mesh_app(
+        blackboard=blackboard,
+        pubsub=pubsub,
+        router=router,
+        permissions=permissions,
+        # Auth tokens configured — public callers must Bearer-auth.
+        auth_tokens={
+            "operator": "tok_operator",
+            "scout":    "tok_scout",
+            "analyst":  "tok_analyst",
+        },
+    )
+    yield app, server_module
+    blackboard.close()
+    monkeypatch.delenv("OPENLEGION_ORCHESTRATION_TASKS_V2", raising=False)
+    monkeypatch.delenv("OPENLEGION_ORCHESTRATION_TASKS_DB", raising=False)
+    importlib.reload(server_module)
+
+
+@pytest.mark.asyncio
+async def test_internal_caller_skips_bearer_requirement(v2_app_with_auth):
+    """Loopback + ``x-mesh-internal: 1`` + ``X-Agent-ID`` succeeds
+    without a Bearer token. This is the dashboard cancel proxy path.
+    """
+    app, _ = v2_app_with_auth
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
+        # Internal caller creates a task on behalf of operator…
+        r = await c.post(
+            "/mesh/tasks",
+            json={"assignee": "analyst", "title": "internal-create"},
+            headers={"x-mesh-internal": "1", "X-Agent-ID": "operator"},
+        )
+        assert r.status_code == 200, r.text
+        tid = r.json()["id"]
+        # …and then cancels it the same way (no Bearer token).
+        r = await c.post(
+            f"/mesh/tasks/{tid}/cancel",
+            json={"reason": "ops decided no"},
+            headers={"x-mesh-internal": "1", "X-Agent-ID": "operator"},
+        )
+        assert r.status_code == 200, r.text
+        assert r.json()["status"] == "cancelled"
+
+
+@pytest.mark.asyncio
+async def test_cancel_task_via_dashboard_proxy_succeeds_in_production_auth_mode(
+    v2_app_with_auth,
+):
+    """Regression for the kanban Cancel button. With auth tokens
+    configured, a loopback + ``x-mesh-internal`` POST to
+    ``/mesh/tasks/{id}/cancel`` (no Bearer) must NOT 401.
+    """
+    app, _ = v2_app_with_auth
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
+        # Seed via a Bearer-authed worker so the task exists with a
+        # creator we can verify the cancel against.
+        r = await c.post(
+            "/mesh/tasks",
+            json={"assignee": "analyst", "title": "kanban-cancel-target"},
+            headers={
+                "X-Agent-ID": "scout",
+                "Authorization": "Bearer tok_scout",
+            },
+        )
+        assert r.status_code == 200, r.text
+        tid = r.json()["id"]
+        # Dashboard proxies the cancel: loopback + x-mesh-internal,
+        # NO Authorization header.
+        r = await c.post(
+            f"/mesh/tasks/{tid}/cancel",
+            json={"reason": "user clicked Cancel"},
+            headers={"x-mesh-internal": "1", "X-Agent-ID": "operator"},
+        )
+        assert r.status_code != 401, (
+            "Dashboard cancel proxy must not require Bearer when caller "
+            "is loopback + x-mesh-internal"
+        )
+        assert r.status_code == 200, r.text
+
+
+@pytest.mark.asyncio
+async def test_public_caller_without_bearer_still_rejected(v2_app_with_auth):
+    """The fix only exempts internal callers — a public caller
+    without a Bearer token still gets 401.
+    """
+    app, _ = v2_app_with_auth
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
+        r = await c.post(
+            "/mesh/tasks",
+            json={"assignee": "analyst", "title": "public-no-bearer"},
+            headers={"X-Agent-ID": "scout"},
+        )
+        assert r.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_public_caller_with_valid_bearer_succeeds(v2_app_with_auth):
+    """Sanity check: existing Bearer auth path still works."""
+    app, _ = v2_app_with_auth
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
+        r = await c.post(
+            "/mesh/tasks",
+            json={"assignee": "analyst", "title": "with-bearer"},
+            headers={
+                "X-Agent-ID": "scout",
+                "Authorization": "Bearer tok_scout",
+            },
+        )
+        assert r.status_code == 200, r.text


### PR DESCRIPTION
## Production hotfix

User report: kanban Cancel button fails with `Cancel failed: Missing authentication token` in production.

## Root cause

`src/host/server.py` `_extract_verified_agent_id` requires a Bearer token in production. Internal dashboard proxies (loopback + `x-mesh-internal: 1` header) don't have Bearer tokens — those are server-side secrets the dashboard process doesn't access.

The mesh `cancel_task` (line 4793) calls `_extract_verified_agent_id(request)` BEFORE checking `_is_internal_caller`, so the auth check 401s before the route can decide to allow the internal caller.

This affected the kanban Cancel button (PR-H), and likely also `pending_cancel`, `audit_archive`, and any other dashboard→mesh proxy hitting an authed endpoint that nobody had stress-tested in production.

## Fix

Make `_extract_verified_agent_id` honor internal callers — read `X-Agent-ID` header without requiring Bearer when both header AND loopback are present.

```python
def _extract_verified_agent_id(request: Request) -> str:
    if _is_internal_caller(request):
        # Trust X-Agent-ID from internal callers (dashboard proxies,
        # mesh dispatcher, CLI manager). Loopback + header is already
        # the trust boundary used elsewhere.
        return request.headers.get("X-Agent-ID", "operator")
    if not _auth_tokens:
        return request.headers.get("X-Agent-ID", "unknown")
    auth_header = request.headers.get("authorization", "")
    if not auth_header.startswith("Bearer "):
        _record_denial("auth")
        raise HTTPException(401, "Missing authentication token")
    # ... existing Bearer verification, unchanged
```

## Why this is safe

`_is_internal_caller` requires BOTH:
1. `x-mesh-internal: 1` header
2. Peer IP being loopback (`127.0.0.1` / `::1`) — verified via `ipaddress.ip_address(request.client.host).is_loopback`

A public-internet attacker can't spoof either:
- Can't spoof loopback (FastAPI sees real peer IP)
- Header alone is insufficient

Internal callers are already trusted with elevated permissions throughout the mesh. This change just stops requiring them to also present a Bearer (which they don't have access to). Same behavior as dev mode (no `_auth_tokens`).

## Test plan

- [x] Internal caller (loopback + header) returns `X-Agent-ID` without Bearer
- [x] Public caller without Bearer → 401 (unchanged)
- [x] Public caller with valid Bearer → returns matching agent_id (unchanged)
- [x] Cancel task via dashboard proxy succeeds in production auth mode (NEW — reproduces the user's bug)

**4 new tests pass** in `test_orchestration_endpoints.py` (21 total). **437 regression tests pass** across `test_denial_counter` + `test_mesh` + `test_dashboard`. `ruff` clean.

New `auth_tokens=`-configured fixture `v2_app_with_auth` reproduces production behavior — the existing `v2_app` fixture has no tokens so it never triggered this bug.

## Stats

2 files changed: +158 / -3.
- `src/host/server.py` +15 / -3 (4 LOC behavior change + docstring update)
- `tests/test_orchestration_endpoints.py` +143 (new fixture + 4 tests)