### PR TITLE
fix(dashboard): browser tab title + cmd palette vocab align with Work/Team rename

### DIFF
--- a/src/dashboard/static/js/app.js
+++ b/src/dashboard/static/js/app.js
@@ -779,9 +779,9 @@ function dashboard() {
         return (st ? st.label : 'System') + ' \u2014 OpenLegion';
       }
       if (this.activeTab === 'workplace') {
-        return this.homeTab === 'activity' ? 'Activity \u2014 OpenLegion' : 'Board \u2014 OpenLegion';
+        return this.homeTab === 'activity' ? 'Activity \u2014 OpenLegion' : 'Work \u2014 OpenLegion';
       }
-      return 'Agents \u2014 OpenLegion';
+      return 'Team \u2014 OpenLegion';
     },
 
     _parsePath(path) {
@@ -7942,8 +7942,10 @@ function dashboard() {
       }
       // Match tabs with keywords
       const tabKeywords = {
-        fleet: ['agents', 'fleet', 'cards', 'project'],
-        system: ['system', 'costs', 'cron', 'schedules', 'automation', 'credentials', 'api keys', 'connections', 'integrations', 'infrastructure', 'pricing', 'browsers', 'pubsub', 'blackboard', 'comms', 'communication', 'workflows', 'storage', 'uploads', 'disk', 'network', 'proxy', 'socks'],
+        chat: ['chat', 'operator', 'message', 'talk', 'ask'],
+        workplace: ['work', 'home', 'board', 'kanban', 'tasks', 'activity', 'delivered', 'in progress', 'stuck'],
+        fleet: ['team', 'agents', 'fleet', 'cards', 'project'],
+        system: ['settings', 'system', 'costs', 'cron', 'schedules', 'automation', 'credentials', 'api keys', 'connections', 'integrations', 'infrastructure', 'pricing', 'browsers', 'pubsub', 'blackboard', 'comms', 'communication', 'workflows', 'storage', 'uploads', 'disk', 'network', 'proxy', 'socks'],
       };
       for (const [tabId, keywords] of Object.entries(tabKeywords)) {
         const tab = this.tabs.find(t => t.id === tabId);


### PR DESCRIPTION
## Summary

Final integration audit caught two vocab leaks from PR #877's Home → Work + Agents → Team rename. Both user-visible.

## Fixes

1. **`pageTitle()` returned 'Board — OpenLegion' / 'Agents — OpenLegion'** in the browser tab and bookmark titles. Updated to 'Work' and 'Team' to match the in-app top-nav labels. (`app.js:782, 784`)

2. **Command palette `tabKeywords`** only registered keywords for `fleet` and `system` tabs. Searching the palette for "tasks", "kanban", "operator", or "settings" wouldn't surface Chat/Work tabs. Extended for all four tabs with synonyms covering both old and new vocabulary so power-user search keeps working through the rename. (`app.js:7944`)

User-visible only — no logic changes, no test impact.

## Stats

1 file, +6/-4.