### PR TITLE
perf(host): defer litellm import for faster test collection

### DIFF
--- a/src/channels/base.py
+++ b/src/channels/base.py
@@ -16,7 +16,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 from src.channels import AT_MENTION_RE
-from src.host.credentials import SYSTEM_CREDENTIAL_PROVIDERS, is_system_credential
+from src.host.credentials import is_system_credential
 from src.shared.utils import sanitize_for_prompt, setup_logging
 
 if TYPE_CHECKING:
@@ -349,7 +349,12 @@ class Channel(abc.ABC):
             if len(args) < 2:
                 return "Usage: /addkey <service> <key>"
             service = args[1]
-            # Normalize bare provider names to include _api_key suffix
+            # Normalize bare provider names to include _api_key suffix.
+            # Local import: importing SYSTEM_CREDENTIAL_PROVIDERS at module
+            # scope would trigger src.host.credentials' lazy __getattr__
+            # at channel-import time, which transitively pulls litellm
+            # (~2.25s).  Defer until the user actually runs /addkey.
+            from src.host.credentials import SYSTEM_CREDENTIAL_PROVIDERS
             if service.lower() in SYSTEM_CREDENTIAL_PROVIDERS and not service.lower().endswith("_api_key"):
                 service = f"{service}_api_key"
             key = args[2] if len(args) > 2 else ""

--- a/src/host/credentials.py
+++ b/src/host/credentials.py
@@ -195,7 +195,12 @@ AGENT_PREFIX = "OPENLEGION_CRED_"
 # auto-detecting LLM provider keys.  Derived dynamically from the
 # model registry (src/shared/models.py) so adding a provider in one
 # place propagates everywhere.
-SYSTEM_CREDENTIAL_PROVIDERS = get_known_provider_names()
+#
+# ``SYSTEM_CREDENTIAL_PROVIDERS`` is exposed as a lazy module attribute
+# via PEP 562 ``__getattr__`` below — populating it eagerly imports
+# litellm transitively (~2.25s wall clock), which every test that
+# touches the host paid during collection.  Deferring the call lets
+# importing this module stay cheap.
 # Providers where LiteLLM handles routing natively (built-in support).
 # Custom providers like 'openlegion' are NOT in this set — they use
 # api_base with OpenAI-compatible rewrite in _rewrite_model_for_litellm().
@@ -205,6 +210,14 @@ _LITELLM_NATIVE_PROVIDERS = frozenset({
     "minimax", "moonshot", "xai", "zai", "ollama",
 })
 SYSTEM_CREDENTIAL_SUFFIXES = ("_api_key", "_api_base")
+
+
+def __getattr__(name: str):  # PEP 562 — lazy module attributes
+    if name == "SYSTEM_CREDENTIAL_PROVIDERS":
+        value = get_known_provider_names()
+        globals()[name] = value  # cache after first access
+        return value
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
 
 def is_oauth_token(token: str) -> bool:
@@ -222,7 +235,7 @@ def is_system_credential(name: str) -> bool:
     for suffix in SYSTEM_CREDENTIAL_SUFFIXES:
         if lower.endswith(suffix):
             prefix = lower[: -len(suffix)]
-            if prefix in SYSTEM_CREDENTIAL_PROVIDERS:
+            if prefix in get_known_provider_names():
                 return True
     return False
 
@@ -663,7 +676,7 @@ class CredentialVault:
         for runtime availability.
         """
         providers: set[str] = set()
-        for provider in SYSTEM_CREDENTIAL_PROVIDERS:
+        for provider in get_known_provider_names():
             if provider in KEYLESS_PROVIDERS:
                 if f"{provider}_api_base" in self.api_bases:
                     providers.add(provider)

--- a/tests/test_credentials.py
+++ b/tests/test_credentials.py
@@ -3931,3 +3931,97 @@ async def test_auto_fallback_when_default_model_also_missing(monkeypatch):
     assert "gemini" in used_model
     assert len(call_log) == 1
     assert "gemini" in call_log[0]
+
+
+# ---------------------------------------------------------------------------
+# Lazy-litellm regression tests — guard the optimization where
+# importing src.host.credentials no longer transitively loads litellm.
+#
+# These run in a fresh subprocess because pytest collection has already
+# imported litellm transitively from other modules in the test process,
+# making `'litellm' in sys.modules` checks unreliable here.
+# ---------------------------------------------------------------------------
+
+
+def test_credentials_import_does_not_eagerly_load_litellm():
+    """Importing src.host.credentials must not transitively load litellm.
+
+    Litellm is heavy (~2.25s wall clock cold-import); the credentials module
+    defers the call to get_known_provider_names() behind a PEP 562
+    ``__getattr__`` so importing the module stays cheap. A future
+    contributor could re-introduce a module-scope call (e.g., to
+    get_all_providers, get_known_provider_names, get_all_model_costs,
+    _resolve_litellm_key, etc.) that silently regresses this. This test
+    spawns a fresh interpreter and asserts litellm is NOT in sys.modules
+    after `import src.host.credentials`.
+    """
+    import os
+    import subprocess
+    import sys
+    from pathlib import Path
+
+    repo_root = Path(__file__).resolve().parents[1]
+    code = (
+        "import sys\n"
+        "import src.host.credentials\n"
+        "print('LITELLM_LOADED' if 'litellm' in sys.modules else 'CLEAN')\n"
+    )
+    result = subprocess.run(
+        [sys.executable, "-c", code],
+        cwd=repo_root,
+        env={**os.environ, "PYTHONPATH": str(repo_root)},
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    assert result.returncode == 0, (
+        f"Subprocess failed (rc={result.returncode}).\n"
+        f"stdout: {result.stdout!r}\n"
+        f"stderr: {result.stderr!r}"
+    )
+    output = result.stdout.strip()
+    assert output == "CLEAN", (
+        "Importing src.host.credentials eagerly loaded litellm — check for "
+        "new module-scope calls into src/shared/models.py functions "
+        "(get_all_providers, get_known_provider_names, get_all_model_costs, "
+        "_resolve_litellm_key, etc.) that transitively import litellm. "
+        f"Subprocess output: {output!r}"
+    )
+
+
+def test_lazy_system_credential_providers_still_resolves():
+    """The PEP 562 ``__getattr__`` lazy access path must still work.
+
+    Proves that ``from src.host.credentials import SYSTEM_CREDENTIAL_PROVIDERS``
+    returns a non-empty frozenset, i.e. the lazy attribute trip-wire is wired
+    correctly and the deferral hasn't broken downstream consumers.
+    """
+    import os
+    import subprocess
+    import sys
+    from pathlib import Path
+
+    repo_root = Path(__file__).resolve().parents[1]
+    code = (
+        "from src.host.credentials import SYSTEM_CREDENTIAL_PROVIDERS\n"
+        "assert isinstance(SYSTEM_CREDENTIAL_PROVIDERS, frozenset), "
+        "    f'expected frozenset, got {type(SYSTEM_CREDENTIAL_PROVIDERS).__name__}'\n"
+        "assert len(SYSTEM_CREDENTIAL_PROVIDERS) > 0, 'frozenset is empty'\n"
+        "print('OK', len(SYSTEM_CREDENTIAL_PROVIDERS))\n"
+    )
+    result = subprocess.run(
+        [sys.executable, "-c", code],
+        cwd=repo_root,
+        env={**os.environ, "PYTHONPATH": str(repo_root)},
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    assert result.returncode == 0, (
+        f"Lazy access of SYSTEM_CREDENTIAL_PROVIDERS failed (rc={result.returncode}).\n"
+        f"stdout: {result.stdout!r}\n"
+        f"stderr: {result.stderr!r}"
+    )
+    assert result.stdout.startswith("OK "), (
+        f"Unexpected subprocess output: {result.stdout!r}"
+    )


### PR DESCRIPTION
## Problem

Importing `src.host.credentials` cold takes ~2.27s wall clock on a fast Mac (more on GitHub runners), and ~2.25s of that is spent transitively loading the `litellm` package. The single trigger is a module-level binding at `src/host/credentials.py:198`:

```python
SYSTEM_CREDENTIAL_PROVIDERS = get_known_provider_names()
```

`get_known_provider_names()` (in `src/shared/models.py`) calls `get_all_providers()` which does `from litellm import model_cost`. Every test file that transitively touches the host pays this during collection. `src.host.server` cold-imports in ~3.4s today, ~2.25s of which is this one assignment. Other `litellm` imports in `credentials.py` are already function-local and lazy — this assignment is the only eager trigger.

## Measurement

Cold import of `src.host.credentials`:

| | time | `litellm` in `sys.modules` |
|--|--|--|
| before | 2.269s | True |
| after  | 0.287s | False |

Multiplied by ~123 test files that transitively touch a host module, this is meaningful collection-time savings on every CI run.

## Approach

Replace the module-level binding with a [PEP 562](https://peps.python.org/pep-0562/) `__getattr__` that computes the set on first attribute access and caches it in `globals()`. Subsequent accesses return the cached value with no overhead.

The two in-module references (`is_system_credential` and the provider-detect loop in `system_credentials_for_models`) are switched to direct calls to `get_known_provider_names()` so they don't re-enter `__getattr__` — cleaner, and avoids subtle re-entry edge cases.

### Why PEP 562 over alternatives

- **Drop-in for `from x import Y`.** External callers (`src/channels/base.py`, tests, etc.) keep using `SYSTEM_CREDENTIAL_PROVIDERS` unchanged.
- **No code-shape change.** Stays a frozen-set-shaped read. Wrapping it as `system_credential_providers()` would force every call site to update.
- **Cached.** First access populates `globals()[name] = value`, so subsequent reads are zero-cost.
- **Standard library mechanism.** No metaclass tricks, no module-replacement hacks.

## One structural change

`src/channels/base.py` previously imported `SYSTEM_CREDENTIAL_PROVIDERS` at module scope. That would trigger the lazy `__getattr__` at channel-import time and defeat the optimization for any test that imports channels (a lot of them). Moved that one symbol to a function-local import inside the `/addkey` handler — the only use site, and only hit when a user actually runs the command. `is_system_credential` (a real function, no eager cost) stays at module top.

## Verification

```
$ python -c "import sys; sys.path.insert(0,'.'); import src.host.credentials; print('litellm imported:', 'litellm' in sys.modules)"
litellm imported: False

$ python -c "import sys; sys.path.insert(0,'.'); from src.host.credentials import SYSTEM_CREDENTIAL_PROVIDERS; print(len(SYSTEM_CREDENTIAL_PROVIDERS))"
90

$ pytest tests/test_credentials.py tests/test_channels.py -x -q
275 passed, 15 skipped, 1 warning in 3.01s
```

The two explicit assertions on `SYSTEM_CREDENTIAL_PROVIDERS` at `tests/test_credentials.py:1162` and `:1177` continue to pass — the lazy attribute is fully transparent to consumers.

## Risk

Low. Behavior is identical from the caller's perspective; only the timing of one litellm import shifts from import-time to first-attribute-access (which happens early in any real run, when the first credential check fires). No new public surface, no contract changes.

---

**Do not merge — part of a CI speedup batch under review.**