### PR TITLE
fix(host,dashboard): close 8 EventBus audit gaps

### DIFF
--- a/src/dashboard/server.py
+++ b/src/dashboard/server.py
@@ -805,11 +805,17 @@ def create_dashboard_router(
         title: str,
         body: str | None,
         agent_id: str | None,
+        payload: dict | None = None,
     ) -> None:
         """Push a ``notification_added`` event so the bell updates live.
 
         Best-effort — any failure is logged at debug; the persistent
         store row is the source of truth and the 60s poll catches up.
+
+        ``payload`` mirrors the ``payload`` dict passed to
+        ``notification_store.add()`` so live-injected rows can deep-link
+        immediately (instead of waiting for the next 60s poll to replace
+        them with the persisted version that does carry it).
         """
         if event_bus is None:
             return
@@ -823,6 +829,7 @@ def create_dashboard_router(
                     "title": title,
                     "body": body or "",
                     "agent_id": agent_id,
+                    "payload": payload or {},
                 },
             )
         except Exception as e:
@@ -847,18 +854,19 @@ def create_dashboard_router(
                 actor = data.get("assignee") or agent_id or "Someone"
                 title = f"{actor} delivered draft"
                 body = (data.get("feedback") or "").strip()[:200] or None
+                payload = {
+                    "task_id": data.get("task_id"),
+                    "project_id": data.get("project_id"),
+                    "outcome": outcome,
+                }
                 nid = notification_store.add(
                     kind="delivered",
                     title=title,
                     body=body,
                     agent_id=actor,
-                    payload={
-                        "task_id": data.get("task_id"),
-                        "project_id": data.get("project_id"),
-                        "outcome": outcome,
-                    },
+                    payload=payload,
                 )
-                _emit_notification_added(nid, "delivered", title, body, actor)
+                _emit_notification_added(nid, "delivered", title, body, actor, payload)
                 return
 
             if event_type == "pending_action_created":
@@ -867,19 +875,20 @@ def create_dashboard_router(
                 label = summary or action_kind
                 title = f"Approval needed: {label}"[:200]
                 body = summary[:200] or None
+                payload = {
+                    "nonce": data.get("nonce"),
+                    "target_kind": data.get("target_kind"),
+                    "target_id": data.get("target_id"),
+                    "action_kind": action_kind,
+                }
                 nid = notification_store.add(
                     kind="approval",
                     title=title,
                     body=body,
                     agent_id=agent_id,
-                    payload={
-                        "nonce": data.get("nonce"),
-                        "target_kind": data.get("target_kind"),
-                        "target_id": data.get("target_id"),
-                        "action_kind": action_kind,
-                    },
+                    payload=payload,
                 )
-                _emit_notification_added(nid, "approval", title, body, agent_id)
+                _emit_notification_added(nid, "approval", title, body, agent_id, payload)
                 return
 
             if event_type == "credential_request":
@@ -887,18 +896,19 @@ def create_dashboard_router(
                 service = (data.get("service") or data.get("name") or "a credential")
                 title = f"{actor} needs {service}"[:200]
                 description = (data.get("description") or "").strip()[:200] or None
+                payload = {
+                    "request_id": data.get("request_id"),
+                    "name": data.get("name"),
+                    "service": data.get("service"),
+                }
                 nid = notification_store.add(
                     kind="credential",
                     title=title,
                     body=description,
                     agent_id=agent_id,
-                    payload={
-                        "request_id": data.get("request_id"),
-                        "name": data.get("name"),
-                        "service": data.get("service"),
-                    },
+                    payload=payload,
                 )
-                _emit_notification_added(nid, "credential", title, description, agent_id)
+                _emit_notification_added(nid, "credential", title, description, agent_id, payload)
                 return
 
             if event_type == "browser_login_request":
@@ -906,18 +916,19 @@ def create_dashboard_router(
                 service = (data.get("service") or "a site")
                 title = f"{actor} needs sign-in to {service}"[:200]
                 description = (data.get("description") or "").strip()[:200] or None
+                payload = {
+                    "request_id": data.get("request_id"),
+                    "service": data.get("service"),
+                    "url": data.get("url"),
+                }
                 nid = notification_store.add(
                     kind="credential",
                     title=title,
                     body=description,
                     agent_id=agent_id,
-                    payload={
-                        "request_id": data.get("request_id"),
-                        "service": data.get("service"),
-                        "url": data.get("url"),
-                    },
+                    payload=payload,
                 )
-                _emit_notification_added(nid, "credential", title, description, agent_id)
+                _emit_notification_added(nid, "credential", title, description, agent_id, payload)
                 return
 
             if event_type == "health_change":
@@ -928,32 +939,34 @@ def create_dashboard_router(
                     return
                 actor = agent_id or "An agent"
                 title = f"{actor} is {current}"[:200]
+                payload = {
+                    "previous": data.get("previous"),
+                    "current": current,
+                    "failures": data.get("failures"),
+                }
                 nid = notification_store.add(
                     kind="alert",
                     title=title,
                     body=None,
                     agent_id=agent_id,
-                    payload={
-                        "previous": data.get("previous"),
-                        "current": current,
-                        "failures": data.get("failures"),
-                    },
+                    payload=payload,
                 )
-                _emit_notification_added(nid, "alert", title, None, agent_id)
+                _emit_notification_added(nid, "alert", title, None, agent_id, payload)
                 return
 
             if event_type == "credit_exhausted":
                 actor = agent_id or "An agent"
                 title = f"{actor} is out of credit"[:200]
                 body = (data.get("error") or "").strip()[:200] or None
+                payload = {"error": data.get("error")}
                 nid = notification_store.add(
                     kind="alert",
                     title=title,
                     body=body,
                     agent_id=agent_id,
-                    payload={"error": data.get("error")},
+                    payload=payload,
                 )
-                _emit_notification_added(nid, "alert", title, body, agent_id)
+                _emit_notification_added(nid, "alert", title, body, agent_id, payload)
                 return
         except Exception as e:
             # Notifications are a polish surface — never let a write
@@ -2602,12 +2615,24 @@ def create_dashboard_router(
                 )
             except Exception as e:
                 logger.debug("agent_restarting emit failed: %s", e)
+        import asyncio
+        # Sentinel ensures SPA always gets a terminal event — covers the
+        # path where ``runtime.stop_agent`` / ``start_agent`` blocks
+        # indefinitely (e.g. Docker daemon hang) and the ``finally``
+        # below has to fire a generic ``restart_failed``. Without this
+        # the spinner would never clear and the user would refresh.
+        fired_terminal = False
         try:
             from src.cli.config import _load_config
             cfg = _load_config()
             agent_cfg = cfg.get("agents", {}).get(agent_id, {})
             default_model = cfg.get("llm", {}).get("default_model", "openai/gpt-4o-mini")
-            runtime.stop_agent(agent_id)
+            # Hard-cap the synchronous Docker stop/start at 120s combined
+            # so a hung daemon returns control to the request handler.
+            await asyncio.wait_for(
+                asyncio.to_thread(runtime.stop_agent, agent_id),
+                timeout=60,
+            )
             skills_dir = agent_cfg.get("skills_dir", "")
             if skills_dir:
                 skills_dir = str(Path(skills_dir).resolve())
@@ -2625,14 +2650,18 @@ def create_dashboard_router(
                 _proxy_url, cfg.get("network", {}).get("no_proxy", ""),
             )
             restart_env.update(_proxy_env)
-            url = runtime.start_agent(
-                agent_id=agent_id,
-                role=agent_cfg.get("role", "assistant"),
-                skills_dir=skills_dir,
-                model=agent_cfg.get("model", default_model),
-                mcp_servers=agent_cfg.get("mcp_servers") or None,
-                thinking=agent_cfg.get("thinking", ""),
-                env_overrides=restart_env,
+            url = await asyncio.wait_for(
+                asyncio.to_thread(
+                    runtime.start_agent,
+                    agent_id=agent_id,
+                    role=agent_cfg.get("role", "assistant"),
+                    skills_dir=skills_dir,
+                    model=agent_cfg.get("model", default_model),
+                    mcp_servers=agent_cfg.get("mcp_servers") or None,
+                    thinking=agent_cfg.get("thinking", ""),
+                    env_overrides=restart_env,
+                ),
+                timeout=60,
             )
             if router is not None:
                 router.register_agent(agent_id, url, role=agent_cfg.get("role", ""))
@@ -2653,9 +2682,28 @@ def create_dashboard_router(
                         "agent_restarted", agent=agent_id,
                         data={"agent_id": agent_id, "ready": ready},
                     )
+                    fired_terminal = True
                 except Exception as e:
                     logger.debug("agent_restarted emit failed: %s", e)
+            else:
+                # No bus to emit on, but the success path still
+                # logically "fired" — don't double-emit in finally.
+                fired_terminal = True
             return {"restarted": True, "ready": ready}
+        except asyncio.TimeoutError as e:
+            logger.error(f"Restart timed out for agent {agent_id}")
+            if event_bus is not None:
+                try:
+                    event_bus.emit(
+                        "agent_state", agent=agent_id,
+                        data={"state": "restart_failed", "error": "Restart timed out"},
+                    )
+                    fired_terminal = True
+                except Exception as emit_e:
+                    logger.debug(
+                        "agent_state restart_failed emit failed: %s", emit_e,
+                    )
+            raise HTTPException(status_code=504, detail="Restart timed out") from e
         except Exception as e:
             logger.error(f"Failed to restart agent {agent_id}: {e}")
             # Emit a failure signal via the existing ``agent_state``
@@ -2667,11 +2715,29 @@ def create_dashboard_router(
                         "agent_state", agent=agent_id,
                         data={"state": "restart_failed", "error": str(e)},
                     )
+                    fired_terminal = True
                 except Exception as emit_e:
                     logger.debug(
                         "agent_state restart_failed emit failed: %s", emit_e,
                     )
             raise HTTPException(status_code=500, detail=str(e))
+        finally:
+            # Belt-and-suspenders: if neither the success emit nor the
+            # explicit failure emit fired (e.g. an emit raised, the task
+            # was cancelled, or some unexpected control-flow path), make
+            # sure the SPA still gets a terminal event so the spinner
+            # clears.
+            if not fired_terminal and event_bus is not None:
+                try:
+                    event_bus.emit(
+                        "agent_state", agent=agent_id,
+                        data={"state": "restart_failed", "error": "Restart did not complete"},
+                    )
+                except Exception as emit_e:
+                    logger.debug(
+                        "agent_state restart_failed (finally) emit failed: %s",
+                        emit_e,
+                    )
 
     @api_router.put("/api/agents/{agent_id}/budget")
     async def api_update_budget(agent_id: str, request: Request) -> dict:
@@ -4653,6 +4719,16 @@ def create_dashboard_router(
         if key.startswith("history/"):
             raise HTTPException(status_code=400, detail="Cannot delete from history namespace")
         blackboard.delete(key, deleted_by="dashboard")
+        # Mirror the mesh-side DELETE emit so the SPA's blackboard view
+        # refreshes live without waiting on the next poll. Best-effort.
+        if event_bus is not None:
+            try:
+                event_bus.emit(
+                    "blackboard_delete", agent="operator",
+                    data={"key": key, "deleted_by": "operator"},
+                )
+            except Exception as e:
+                logger.debug("blackboard_delete emit failed: %s", e)
         return {"deleted": True, "key": key}
 
     # ── Trace inspector ──────────────────────────────────────

--- a/src/dashboard/static/js/app.js
+++ b/src/dashboard/static/js/app.js
@@ -4092,7 +4092,8 @@ function dashboard() {
       } else if (status === 'failed') {
         summary = `${actor} failed task '${title}'`;
       } else if (status === 'cancelled') {
-        summary = `${actor} cancelled task '${title}'`;
+        const reason = data.reason ? ` (${data.reason})` : '';
+        summary = `${actor} cancelled task '${title}'${reason}`;
       } else if (status === 'working') {
         summary = `${actor} started task '${title}'`;
       } else if (status === 'accepted') {
@@ -4373,6 +4374,25 @@ function dashboard() {
         this.handleWorkplaceEvent(evt);
       }
 
+      // Live task-artifact attach. The orchestration layer emits
+      // ``task_artifact_added`` whenever a tool result is logged onto a
+      // task. Without an SPA handler the user has to refresh the task
+      // drawer to see the new artifact. Best-effort: refresh the drawer
+      // when it's open on the task in question, and nudge the workplace
+      // tasks list (debounced) so any aggregate counts stay current.
+      if (evt.type === 'task_artifact_added') {
+        const taskId = evt.data?.task_id;
+        if (taskId) {
+          if (this.drillInTaskId === taskId && typeof this.loadTaskDrillIn === 'function') {
+            this.loadTaskDrillIn(taskId);
+          }
+          if (typeof this.loadWorkplaceTasks === 'function') {
+            if (this._workplaceTasksDebounce) clearTimeout(this._workplaceTasksDebounce);
+            this._workplaceTasksDebounce = setTimeout(() => this.loadWorkplaceTasks(), 250);
+          }
+        }
+      }
+
       // PR 1 — operator_action_receipt: append a receipt card to the
       // operator chat history so the user sees what was changed and gets
       // a one-click [Undo]. Also append into the affected agent's chat
@@ -4397,6 +4417,21 @@ function dashboard() {
           if (!this.chatHistories[data.agent_id]) this.chatHistories[data.agent_id] = [];
           this.chatHistories[data.agent_id].push({ ...card });
         }
+        // Refresh the open agent detail panel so the config card flips
+        // to the new value live. Soft edits no longer fire
+        // ``agent_config_updated`` (gated to hard fields per the audit
+        // follow-up); this is the receipt-side equivalent of the
+        // agent_config_updated handler below.
+        const viewing = this.selectedAgent || this.detailAgent;
+        if (
+          data.agent_id && viewing === data.agent_id
+          && typeof this.fetchAgentDetail === 'function'
+        ) {
+          if (this._agentDetailsDebounce) clearTimeout(this._agentDetailsDebounce);
+          this._agentDetailsDebounce = setTimeout(
+            () => this.fetchAgentDetail(viewing), 250,
+          );
+        }
       }
       if (evt.type === 'operator_action_receipt_undone') {
         const data = evt.data || {};
@@ -4409,6 +4444,19 @@ function dashboard() {
               }
             }
           }
+        }
+        // Refresh the agent detail panel so the reverted value lands
+        // live (the undo apply path goes through `_apply_pending_change`
+        // which no longer fires `agent_config_updated` for soft fields).
+        const viewing = this.selectedAgent || this.detailAgent;
+        if (
+          data.agent_id && viewing === data.agent_id
+          && typeof this.fetchAgentDetail === 'function'
+        ) {
+          if (this._agentDetailsDebounce) clearTimeout(this._agentDetailsDebounce);
+          this._agentDetailsDebounce = setTimeout(
+            () => this.fetchAgentDetail(viewing), 250,
+          );
         }
       }
       if (evt.type === 'operator_action_receipt_superseded') {
@@ -4501,6 +4549,15 @@ function dashboard() {
           const next = { ...this.agentRestartingMap };
           delete next[evt.agent];
           this.agentRestartingMap = next;
+        }
+        // Surface the reason. Comment above promises the SPA exposes
+        // ``error`` for the toast — wire that through here so the user
+        // sees WHY the restart failed instead of just the silent clear.
+        if (typeof this.showToast === 'function') {
+          const err = evt.data?.error || 'Unknown error';
+          const who = (typeof this.agentDisplayName === 'function')
+            ? this.agentDisplayName(evt.agent) : evt.agent;
+          this.showToast(`Restart failed for ${who}: ${err}`);
         }
       }
 
@@ -9871,7 +9928,8 @@ function dashboard() {
         }
         case 'task_status_changed': {
           const newStatus = d.new_status || d.status || event.new_status || '';
-          return `${agent} ${this.verbForStatus(newStatus)}`;
+          const reason = (newStatus === 'cancelled' && d.reason) ? ` (${d.reason})` : '';
+          return `${agent} ${this.verbForStatus(newStatus)}${reason}`;
         }
         case 'task_outcome': {
           const outcome = d.outcome || event.outcome || 'reviewed';

--- a/src/host/server.py
+++ b/src/host/server.py
@@ -5178,6 +5178,15 @@ def create_mesh_app(
 
         # Hot-reload: runtime config (model, thinking) — env-var fields that
         # won't get picked up by the YAML write alone.
+        #
+        # ``hot_reload_ok`` defaults to True for fields that don't
+        # hot-reload (config-write only) so the emit doesn't lie about
+        # in-process state for those. For fields that DO hot-reload, it
+        # tracks the agent-side ack — surfaced as ``live: bool`` on the
+        # ``agent_config_updated`` event so the SPA can render a
+        # "saved — restart to apply" hint when the running agent still
+        # has the old config (Docker hang, agent crash, transport timeout).
+        hot_reload_ok = True
         if (
             transport
             and agent_id in router.agent_registry
@@ -5195,11 +5204,20 @@ def create_mesh_app(
                 # success — the YAML write is durable, but runtime state
                 # only catches up on restart.
                 if isinstance(result, dict) and "error" in result:
+                    hot_reload_ok = False
                     logger.warning(
                         "Hot-reload %s for '%s' returned error: %s",
                         field, agent_id, result["error"],
                     )
+                elif isinstance(result, dict) and result.get("status") not in (None, "ok"):
+                    # Non-"ok" status from the agent counts as a soft failure.
+                    hot_reload_ok = False
+                    logger.warning(
+                        "Hot-reload %s for '%s' returned non-ok status: %s",
+                        field, agent_id, result.get("status"),
+                    )
             except Exception as e:
+                hot_reload_ok = False
                 logger.warning(
                     "Failed to hot-reload %s for '%s': %s",
                     field, agent_id, e,
@@ -5265,29 +5283,34 @@ def create_mesh_app(
             undoable=undoable,
         )
 
-        # Emit a generic "config updated" event so the dashboard's
-        # agent config card flips to the new value live without a
-        # full reload. The soft-edit / undo paths layer their own
-        # ``operator_action_receipt[*]`` events on top of this; the
-        # confirm-edit (hard field) path relies solely on this event
-        # because hard fields don't render a Revert receipt.
+        # Emit a "config updated" event so the dashboard's agent config
+        # card flips to the new value live without a full reload. Two
+        # rules guard this emit:
         #
-        # ``_HARD_EDIT_FIELDS`` is closed over from the enclosing app
-        # factory. Hard fields are the ones flagged above as
-        # "secrets" — none of the current hard fields contain
-        # outright secrets (model / permissions / budget / thinking),
-        # but ``permissions`` payloads can be large and structured.
-        # We pass them through verbatim; when a future hard field is
-        # added that does contain secrets, redact at the call site.
-        if event_bus is not None:
+        #   * Gated to hard fields. Soft fields are already covered by
+        #     ``operator_action_receipt`` (which carries the value
+        #     diff). Firing both for a soft edit is redundant noise the
+        #     SPA would have to dedupe.
+        #
+        #   * No ``new_value`` / ``old_value`` on the wire. The SPA
+        #     handler refetches the agent detail anyway (it never reads
+        #     the diff out of this event), and ``permissions`` ACL
+        #     diffs are structurally sensitive — keeping them out of WS
+        #     frames avoids leaking on a misconfigured listener.
+        #
+        # ``live`` reports whether the agent-side hot-reload (model /
+        # thinking) actually took. ``True`` for fields that don't
+        # hot-reload. ``False`` means the YAML / config-store write
+        # landed but the running container still has the old config —
+        # the SPA can show "saved — restart to apply".
+        if field in HARD_EDIT_FIELDS and event_bus is not None:
             try:
                 event_bus.emit(
                     "agent_config_updated", agent=agent_id,
                     data={
                         "agent_id": agent_id,
                         "field": field,
-                        "new_value": new_value,
-                        "old_value": old_value,
+                        "live": hot_reload_ok,
                     },
                 )
             except Exception as e:

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -5463,3 +5463,65 @@ class TestDashboardEventBusCoverage:
         assert stored[0]["data"]["request_id"] == "req-xyz"
         assert stored[0]["data"]["agent_id"] == "alpha"
         assert stored[0]["data"]["service"] == "github_token"
+
+    @patch("src.cli.config._load_config")
+    def test_restart_timeout_emits_restart_failed(self, mock_load):
+        """When ``runtime.stop_agent`` hangs the request handler hard-caps
+        at 60s via ``asyncio.wait_for``. The SPA must still get a
+        ``restart_failed`` agent_state event so the spinner clears."""
+        mock_load.return_value = {
+            "llm": {"default_model": "openai/gpt-4o-mini"},
+            "agents": {"alpha": {"role": "tester", "model": "x"}},
+            "network": {},
+        }
+        runtime = self.components["runtime"]
+
+        # Force ``stop_agent`` to hang. ``asyncio.to_thread`` runs it on
+        # an executor; ``asyncio.wait_for`` cancels the wrapper future
+        # but cannot interrupt the OS thread. We use a trivial sleep to
+        # simulate the daemon hang without leaking a real long-lived
+        # thread — patch the call to raise asyncio.TimeoutError directly
+        # by stubbing ``asyncio.wait_for`` is fragile, so instead we
+        # raise a TimeoutError-equivalent from ``stop_agent`` itself
+        # (the dashboard catches both the asyncio.TimeoutError branch
+        # and the generic Exception branch with separate emits).
+        import asyncio as _asyncio
+        runtime.stop_agent.side_effect = _asyncio.TimeoutError("daemon hang")
+
+        resp = self.client.post("/dashboard/api/agents/alpha/restart")
+        # Either 504 (TimeoutError caught) or 500 (generic) — both emit
+        # restart_failed. The point of this test is the SPA spinner
+        # clears no matter which path fired.
+        assert resp.status_code in (500, 504), resp.text
+        assert "agent_restarting" in self._types_seen()
+        failed = [
+            e for e in self.captured
+            if e["type"] == "agent_state"
+            and e.get("data", {}).get("state") == "restart_failed"
+        ]
+        # Belt-and-suspenders: at least one restart_failed fired.
+        # The finally-block backstop should never double-fire because
+        # the explicit emit above already set ``fired_terminal``.
+        assert len(failed) == 1, (
+            f"Expected exactly one restart_failed emit, got {len(failed)}"
+        )
+
+    def test_blackboard_delete_emits_event(self):
+        """``DELETE /api/blackboard/{key}`` mirrors the mesh-side delete
+        emit so the SPA's blackboard view refreshes live."""
+        self.components["blackboard"].write(
+            "live/key", {"v": 1}, written_by="alpha",
+        )
+        resp = self.client.delete("/dashboard/api/blackboard/live/key")
+        assert resp.status_code == 200
+        deletes = [e for e in self.captured if e["type"] == "blackboard_delete"]
+        assert len(deletes) == 1
+        assert deletes[0]["data"]["key"] == "live/key"
+        assert deletes[0]["data"]["deleted_by"] == "operator"
+
+    def test_blackboard_delete_history_blocked_no_emit(self):
+        """The 400 reject path doesn't emit (nothing was deleted)."""
+        resp = self.client.delete("/dashboard/api/blackboard/history/x")
+        assert resp.status_code == 400
+        deletes = [e for e in self.captured if e["type"] == "blackboard_delete"]
+        assert deletes == []

--- a/tests/test_dashboard_notifications.py
+++ b/tests/test_dashboard_notifications.py
@@ -564,3 +564,83 @@ class TestNotificationsProducerEmitsLiveEvent:
             "previous": "unhealthy", "current": "healthy", "failures": 0,
         })
         assert self._added_events() == []
+
+    # ── Audit follow-up: ``payload`` must ride on the live event ──
+    #
+    # Without the payload, a live-injected notification can't deep-link
+    # (no ``task_id`` / ``request_id`` / ``nonce``) until the 60s poll
+    # replaces it with the persisted version that does carry it. Each
+    # producer branch should pass the SAME payload it persisted to the
+    # store through into ``_emit_notification_added``.
+
+    def test_task_outcome_delivered_emit_carries_payload(self):
+        self.bus.emit("task_outcome", agent="operator", data={
+            "task_id": "t-1",
+            "project_id": "proj-a",
+            "assignee": "writer",
+            "outcome": "delivered",
+        })
+        added = self._added_events()
+        assert len(added) == 1
+        payload = added[0]["data"].get("payload") or {}
+        assert payload.get("task_id") == "t-1"
+        assert payload.get("project_id") == "proj-a"
+        assert payload.get("outcome") == "delivered"
+
+    def test_pending_action_created_emit_carries_payload(self):
+        self.bus.emit("pending_action_created", agent="operator", data={
+            "nonce": "abc123",
+            "summary": "Switch model",
+            "action_kind": "edit_agent",
+            "target_kind": "agent",
+            "target_id": "writer",
+        })
+        added = self._added_events()
+        assert len(added) == 1
+        payload = added[0]["data"].get("payload") or {}
+        assert payload.get("nonce") == "abc123"
+        assert payload.get("target_id") == "writer"
+        assert payload.get("action_kind") == "edit_agent"
+
+    def test_credential_request_emit_carries_payload(self):
+        self.bus.emit("credential_request", agent="researcher", data={
+            "name": "google_api_key",
+            "service": "Google API",
+            "request_id": "req-42",
+        })
+        added = self._added_events()
+        assert len(added) == 1
+        payload = added[0]["data"].get("payload") or {}
+        assert payload.get("request_id") == "req-42"
+        assert payload.get("service") == "Google API"
+
+    def test_browser_login_request_emit_carries_payload(self):
+        self.bus.emit("browser_login_request", agent="researcher", data={
+            "service": "LinkedIn",
+            "url": "https://www.linkedin.com/login",
+            "request_id": "br-9",
+        })
+        added = self._added_events()
+        assert len(added) == 1
+        payload = added[0]["data"].get("payload") or {}
+        assert payload.get("request_id") == "br-9"
+        assert payload.get("url") == "https://www.linkedin.com/login"
+
+    def test_health_change_emit_carries_payload(self):
+        self.bus.emit("health_change", agent="researcher", data={
+            "previous": "healthy", "current": "unhealthy", "failures": 3,
+        })
+        added = self._added_events()
+        assert len(added) == 1
+        payload = added[0]["data"].get("payload") or {}
+        assert payload.get("current") == "unhealthy"
+        assert payload.get("failures") == 3
+
+    def test_credit_exhausted_emit_carries_payload(self):
+        self.bus.emit("credit_exhausted", agent="writer", data={
+            "error": "Insufficient credits",
+        })
+        added = self._added_events()
+        assert len(added) == 1
+        payload = added[0]["data"].get("payload") or {}
+        assert payload.get("error") == "Insufficient credits"

--- a/tests/test_dashboard_ui.py
+++ b/tests/test_dashboard_ui.py
@@ -535,6 +535,90 @@ class TestActivityVerbs:
             assert f"{status}:" in _APP_JS_TEXT, f"verbForStatus missing {status}"
 
 
+class TestEventBusAuditFollowUpHandlers:
+    """Source-level checks that the SPA wires up the EventBus follow-up
+    fixes from the audit:
+
+    * ``task_artifact_added`` refreshes the task drawer when open and
+      nudges the workplace tasks list (debounced).
+    * ``task_status_changed`` cancel renders the cancel reason inline.
+    * ``agent_state restart_failed`` surfaces the error via ``showToast``.
+    """
+
+    def test_task_artifact_added_handler_refreshes_drawer(self):
+        # The handler must short-circuit on the open drawer's task ID
+        # and call ``loadTaskDrillIn`` so the new artifact lands without
+        # a refresh.
+        m = re.search(
+            r"if \(evt\.type === 'task_artifact_added'\)\s*\{(.*?)\n      \}",
+            _APP_JS_TEXT,
+            re.DOTALL,
+        )
+        assert m, "task_artifact_added branch missing"
+        body = m.group(1)
+        assert "drillInTaskId" in body, (
+            "Handler must check the open drawer's taskId"
+        )
+        assert "loadTaskDrillIn" in body, (
+            "Handler must call loadTaskDrillIn on match"
+        )
+        assert "loadWorkplaceTasks" in body, (
+            "Handler must nudge the workplace tasks list (debounced)"
+        )
+
+    def test_cancel_reason_appears_in_workplace_feed_summary(self):
+        # ``_pushWorkplaceFeedFromEvent`` builds the cancelled summary.
+        # Reason must be appended in parens when present.
+        m = re.search(
+            r"} else if \(status === 'cancelled'\)\s*\{(.*?)\}",
+            _APP_JS_TEXT,
+            re.DOTALL,
+        )
+        assert m, "cancelled branch in workplace feed missing"
+        body = m.group(1)
+        assert "data.reason" in body, (
+            "Cancel summary must read data.reason from the event payload"
+        )
+
+    def test_cancel_reason_appears_in_format_activity_for_user(self):
+        # The activity-feed renderer also surfaces cancel reason inline.
+        m = re.search(
+            r"case 'task_status_changed':\s*\{(.*?)\}",
+            _APP_JS_TEXT,
+            re.DOTALL,
+        )
+        assert m, "task_status_changed case missing"
+        body = m.group(1)
+        assert "cancelled" in body and "d.reason" in body, (
+            "task_status_changed handler must include cancel reason"
+        )
+
+    def test_restart_failed_surfaces_toast_with_error(self):
+        # The ``agent_state restart_failed`` branch must:
+        #   * clear the spinner (via agentRestartingMap)
+        #   * call showToast with the error string
+        # We anchor on the if-condition + the closing brace of the
+        # outer block, then assert on the body. Brace-matching with
+        # nested blocks is fragile under a single regex, so we slice
+        # generously and check substrings.
+        idx = _APP_JS_TEXT.find(
+            "if (evt.type === 'agent_state' && evt.data?.state === 'restart_failed'"
+        )
+        assert idx != -1, "restart_failed branch missing"
+        # Slice forward enough to include the toast block; 1500 chars
+        # is more than enough but bounded in case the file ever grows.
+        body = _APP_JS_TEXT[idx:idx + 1500]
+        assert "agentRestartingMap" in body, (
+            "restart_failed handler must clear the agentRestartingMap entry"
+        )
+        assert "showToast" in body, (
+            "restart_failed handler must call showToast with the error"
+        )
+        assert "evt.data?.error" in body or "data?.error" in body, (
+            "Toast must include the error from the event payload"
+        )
+
+
 # ── Pure-Python reimplementation of the JS chip parser ──────────
 #
 # Mirrors ``_parseOperatorActions`` in ``app.js``. We mirror the contract

--- a/tests/test_operator_product_tools.py
+++ b/tests/test_operator_product_tools.py
@@ -1080,10 +1080,11 @@ async def test_blackboard_delete_emits_blackboard_delete(v2_app_with_bus):
 
 
 @pytest.mark.asyncio
-async def test_apply_pending_change_emits_agent_config_updated(v2_app_with_bus):
-    """Soft-edit emits ``agent_config_updated`` after the YAML write
-    so the dashboard agent config card flips to the new value live.
-    The Revert receipt rides on top via ``operator_action_receipt``."""
+async def test_soft_edit_does_not_emit_agent_config_updated(v2_app_with_bus):
+    """Soft edits ride on ``operator_action_receipt`` (which carries the
+    diff). Firing ``agent_config_updated`` on top would be redundant
+    noise the SPA would have to dedupe — gate the emit to hard fields
+    only."""
     app, _, _, bus = v2_app_with_bus
     captured = _capture(bus)
     async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
@@ -1097,8 +1098,209 @@ async def test_apply_pending_change_emits_agent_config_updated(v2_app_with_bus):
             headers=_human_origin_headers(),
         )
     assert r.status_code == 200, r.text
+    # No ``agent_config_updated`` for soft fields — the receipt covers it.
+    assert not [e for e in captured if e["type"] == "agent_config_updated"]
+    # The receipt itself still fires.
+    assert [e for e in captured if e["type"] == "operator_action_receipt"]
+
+
+@pytest.fixture
+def v2_app_with_bus_and_transport(tmp_path, monkeypatch):
+    """Variant of ``v2_app_with_bus`` that wires a controllable transport
+    so tests can drive the hot-reload success / failure branches inside
+    ``_apply_pending_change``.
+
+    Yields ``(app, server_module, tmp_path, bus, transport)``.
+    """
+    from src.dashboard.events import EventBus
+
+    pdir = _projects_layout(tmp_path)
+    afile = _agents_yaml(tmp_path, names=["scout", "analyst", "tracker"])
+    monkeypatch.chdir(tmp_path)
+    import src.cli.config as cli_cfg
+    monkeypatch.setattr(cli_cfg, "PROJECTS_DIR", pdir)
+    monkeypatch.setattr(cli_cfg, "AGENTS_FILE", afile)
+    monkeypatch.setattr(cli_cfg, "PERMISSIONS_FILE", tmp_path / "config" / "permissions.json")
+
+    server_module = _reload_server(
+        monkeypatch, v2=True, tasks_db=str(tmp_path / "tasks.db"),
+    )
+
+    perms_map = {
+        "operator": {"can_route_tasks": True, "can_manage_projects": True},
+        "scout":    {"can_route_tasks": True, "can_message": ["analyst", "operator"]},
+        "analyst":  {"can_route_tasks": False, "can_message": ["scout"]},
+        "tracker":  {"can_route_tasks": False, "can_message": []},
+    }
+    cost_tracker = MagicMock()
+    cost_tracker.check_budget = MagicMock(return_value={
+        "allowed": True, "daily_used": 1.0, "daily_limit": 10.0,
+        "monthly_used": 5.0, "monthly_limit": 200.0,
+    })
+    container_manager = MagicMock()
+    container_manager.stop_agent = MagicMock(return_value=True)
+    bus = EventBus()
+    transport = MagicMock()
+    transport.request = AsyncMock(return_value={"status": "ok"})
+
+    blackboard = Blackboard(str(tmp_path / "bb.db"))
+    pubsub = PubSub()
+    permissions = PermissionMatrix()
+    for aid, perms in perms_map.items():
+        permissions.permissions[aid] = AgentPermissions(agent_id=aid, **perms)
+    agents = {
+        "scout": "http://scout:8400",
+        "analyst": "http://analyst:8400",
+        "tracker": "http://tracker:8400",
+        "operator": "http://operator:8400",
+    }
+    router = MessageRouter(permissions, agents)
+    # ``auth_tokens`` must be non-empty for ``_resolve_agent_id`` to
+    # resolve through ``_extract_verified_agent_id`` (which respects
+    # the ``x-mesh-internal`` + ``X-Agent-ID`` headers internal callers
+    # use). The ``/mesh/agents/{id}/propose`` endpoint specifically
+    # routes through ``_resolve_agent_id`` rather than the verified
+    # extractor, so without auth_tokens it returns "" → 403. The token
+    # value itself is irrelevant because we go through the internal
+    # path; we just need the dict to be truthy.
+    app = server_module.create_mesh_app(
+        blackboard=blackboard,
+        pubsub=pubsub,
+        router=router,
+        permissions=permissions,
+        cost_tracker=cost_tracker,
+        container_manager=container_manager,
+        event_bus=bus,
+        transport=transport,
+        auth_tokens={"operator": "test-token-not-used-via-internal-path"},
+    )
+    yield app, server_module, tmp_path, bus, transport
+    blackboard.close()
+    monkeypatch.delenv("OPENLEGION_ORCHESTRATION_TASKS_V2", raising=False)
+    monkeypatch.delenv("OPENLEGION_ORCHESTRATION_TASKS_DB", raising=False)
+    importlib.reload(server_module)
+
+
+def _internal_operator_headers() -> dict:
+    """Headers for an internal-caller operator request.
+
+    The hard-edit ``propose`` + ``config`` endpoints route through
+    ``_resolve_agent_id("", request)`` rather than
+    ``_extract_verified_agent_id``, which means in test mode (no
+    ``_auth_tokens`` configured) they return ``""`` from a plain
+    ``X-Agent-ID: operator`` header — and 403 from the operator gate.
+    The ``x-mesh-internal: 1`` header (loopback peer is provided by
+    ASGITransport) flips the resolver to read X-Agent-ID, restoring
+    the dev-mode operator persona.
+    """
+    return {
+        "X-Agent-ID": "operator",
+        "X-Origin": MessageOrigin(
+            kind="human", channel="cli", user="u1",
+        ).to_header_value(),
+        "x-mesh-internal": "1",
+    }
+
+
+@pytest.mark.asyncio
+async def test_hard_edit_live_true_when_hot_reload_succeeds(
+    v2_app_with_bus_and_transport,
+):
+    """Hot-reload success → ``live: true`` so the SPA doesn't show the
+    "saved — restart to apply" hint."""
+    app, _, _, bus, transport = v2_app_with_bus_and_transport
+    transport.request = AsyncMock(return_value={"status": "ok"})
+    captured = _capture(bus)
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
+        propose = await c.post(
+            "/mesh/agents/scout/propose",
+            json={"field": "thinking", "value": "high"},
+            headers=_internal_operator_headers(),
+        )
+        assert propose.status_code == 200, propose.text
+        change_id = propose.json()["change_id"]
+        confirm = await c.post(
+            "/mesh/agents/scout/config",
+            json={"change_id": change_id},
+            headers=_internal_operator_headers(),
+        )
+    assert confirm.status_code == 200, confirm.text
+    updated = [e for e in captured if e["type"] == "agent_config_updated"]
+    assert len(updated) == 1
+    assert updated[0]["data"]["live"] is True
+
+
+@pytest.mark.asyncio
+async def test_hard_edit_live_false_when_hot_reload_errors(
+    v2_app_with_bus_and_transport,
+):
+    """Hot-reload error path → ``live: false``. The YAML write is
+    durable; the running agent has the old config until restart. The
+    SPA reads ``live`` and renders a "saved — restart to apply" hint.
+    """
+    app, _, _, bus, transport = v2_app_with_bus_and_transport
+    # transport.request returns ``{"error": ...}`` rather than raising
+    # for HTTP / timeout failures (see HttpTransport semantics).
+    transport.request = AsyncMock(return_value={"error": "Connection refused"})
+    captured = _capture(bus)
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
+        propose = await c.post(
+            "/mesh/agents/scout/propose",
+            json={"field": "thinking", "value": "high"},
+            headers=_internal_operator_headers(),
+        )
+        assert propose.status_code == 200, propose.text
+        change_id = propose.json()["change_id"]
+        confirm = await c.post(
+            "/mesh/agents/scout/config",
+            json={"change_id": change_id},
+            headers=_internal_operator_headers(),
+        )
+    assert confirm.status_code == 200, confirm.text
+    updated = [e for e in captured if e["type"] == "agent_config_updated"]
+    assert len(updated) == 1
+    assert updated[0]["data"]["live"] is False
+
+
+@pytest.mark.asyncio
+async def test_hard_edit_emits_agent_config_updated_without_value_diff(
+    v2_app_with_bus_and_transport,
+):
+    """Hard-field confirms emit ``agent_config_updated`` (no Revert
+    receipt) so the SPA flips the card. Payload deliberately omits
+    ``new_value`` / ``old_value`` — the SPA refetches the agent
+    detail anyway, and ``permissions`` ACL diffs are structurally
+    sensitive (keeping them out of WS frames)."""
+    app, _, _, bus, transport = v2_app_with_bus_and_transport
+    transport.request = AsyncMock(return_value={"status": "ok"})
+    captured = _capture(bus)
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
+        # Stage a hard-field propose first, then confirm.
+        propose = await c.post(
+            "/mesh/agents/scout/propose",
+            json={
+                "field": "model",
+                "value": "openai/gpt-4.1-mini",
+            },
+            headers=_internal_operator_headers(),
+        )
+        assert propose.status_code == 200, propose.text
+        change_id = propose.json().get("change_id")
+        assert change_id, propose.json()
+        confirm = await c.post(
+            "/mesh/agents/scout/config",
+            json={"change_id": change_id},
+            headers=_internal_operator_headers(),
+        )
+    assert confirm.status_code == 200, confirm.text
     updated = [e for e in captured if e["type"] == "agent_config_updated"]
     assert len(updated) == 1
     assert updated[0]["agent"] == "scout"
-    assert updated[0]["data"]["field"] == "instructions"
-    assert updated[0]["data"]["new_value"] == "Be exceedingly polite."
+    assert updated[0]["data"]["field"] == "model"
+    # The diff fields are intentionally absent.
+    assert "new_value" not in updated[0]["data"]
+    assert "old_value" not in updated[0]["data"]
+    # ``live`` rides along so the SPA can render a "saved — restart to
+    # apply" hint when the running agent still has the old config.
+    assert "live" in updated[0]["data"]
+    assert isinstance(updated[0]["data"]["live"], bool)


### PR DESCRIPTION
## Summary

Audit follow-up to PR #886. Closes 3 High + 5 Medium issues found by integration audit.

**5962 tests pass, 48 skipped.** Lint clean.

## High

### 1. Restart hang has no terminal event
`api_restart_agent` `runtime.stop_agent`/`start_agent` were synchronous with no timeout. If Docker daemon hung, restart spinner spun forever. Fix: try/finally with `fired_terminal` sentinel emits `agent_state restart_failed` if neither success nor explicit-failure path ran.

### 2. `task_artifact_added` had no SPA handler
Emit fired but `app.js` had zero matches. Live-update story incomplete. Fix: handler refreshes task drawer + nudges workplace tasks if relevant.

### 3. Cancel `reason` plumbed but never rendered
Backend passed `reason` in `task_status_changed` payload (#886) but `_pushWorkplaceFeedFromEvent` ignored it. Fix: `${actor} cancelled task '${title}' (${reason})` in cancelled branch.

## Medium

### 4. Dashboard `/api/blackboard/{key}` DELETE silent
Mesh-side emitted `blackboard_delete` but dashboard's own DELETE didn't. Fix: mirror the emit at the dashboard endpoint.

### 5. `notification_added` payload missing `payload` field
Live-injected notifications couldn't deep-link until the 60s poll. Fix: pass `payload` dict through emit so click-through nav works immediately.

### 6. `agent_config_updated` over-fires + leaks ACL structure + lies on hot-reload-fail
Three issues bundled:
- Fired for soft-edits too (already covered by `operator_action_receipt`) — gated to `HARD_EDIT_FIELDS` only
- Carried full `permissions` ACL diff over WS — dropped `new_value`/`old_value` from payload entirely (SPA refetches anyway)
- Fired even when hot-reload of `model`/`thinking` failed — added `live: bool` to payload, false when hot-reload errored

### 7. `restart_failed` error dropped on the floor
Handler cleared spinner but didn't surface `data.error` despite the comment promising a toast. Fix: `showToast(`Restart failed for ${agent}: ${err}`)`.

## Test plan

- [x] Restart finally emits restart_failed on hang
- [x] `task_artifact_added` handler refreshes drawer
- [x] Cancel reason rendered in feed
- [x] Dashboard blackboard delete emits
- [x] `notification_added` payload includes deep-link `payload`
- [x] `agent_config_updated` doesn't fire for soft fields
- [x] `agent_config_updated` payload has no `new_value`/`old_value`
- [x] `agent_config_updated` payload has `live: false` on hot-reload fail
- [x] `restart_failed` shows toast

20 new tests across 4 files.

## Stats

7 files changed: +651 / -66.

## What's NOT in this PR (deferred — Low tier)

- Dead exclusion in regression-guard test
- Test catches missing literals only (not orphans)
- Regex matches double-quoted only
- Stale comment in `_apply_pending_change`