### PR TITLE
feat(host): add Pro Max plan tier (cax41) for browser sizing

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -112,7 +112,8 @@ Resources scale with the `OPENLEGION_MAX_AGENTS` environment variable:
 |------|------------------------|-----|-----|-----|-------------|
 | Basic | ≤ 1 | 2GB | 512MB | 1.0 core | 1 |
 | Growth | 2–5 | 4GB | 1GB | 1.5 cores | `max_agents` |
-| Pro | > 5 | 8GB | 2GB | 2.0 cores | `min(max_agents, 10)` |
+| Pro | 6–15 | 8GB | 2GB | 2.0 cores | `min(max_agents, 10)` |
+| Pro Max | > 15 | 16GB | 4GB | 4.0 cores | `min(max_agents, 30)` |
 
 SHM (shared memory) is critical for Firefox compositor IPC — too small causes VNC rendering freezes.
 

--- a/src/host/runtime.py
+++ b/src/host/runtime.py
@@ -373,23 +373,27 @@ class DockerBackend(RuntimeBackend):
         self.browser_auth_token = secrets.token_urlsafe(32)
         mesh_host = "127.0.0.1" if self.use_host_network else "host.docker.internal"
 
-        # Scale browser container resources based on plan size.
-        # Each Camoufox instance uses ~200-400 MB RAM.  We size the
-        # container memory and max concurrent browsers to support as
-        # many agents browsing simultaneously as the VPS can handle.
+        # Resource sizing per plan (mem_limit + shm_size + cpu_quota + max_browsers).
         # shm_size is for Firefox compositor IPC — too small causes VNC freezes.
         #
-        #   Plan    Server         Agents  Mem   SHM   CPU   Max Browsers
-        #   Basic   cax11  4GB 2c    1    2GB  512m  1.0c     1
-        #   Growth  cax21  8GB 4c    5    4GB    1g  1.5c     5
-        #   Pro     cax31 16GB 8c   15    8GB    2g  2.0c    10
+        #   Plan      Server         Agents  Mem   SHM   CPU   Max Browsers
+        #   Basic     cax11  4GB 2c    1    2GB  512m  1.0c     1
+        #   Growth    cax21  8GB 4c    5    4GB    1g  1.5c     5
+        #   Pro       cax31 16GB 8c   15    8GB    2g  2.0c    10  (mem-bound)
+        #   Pro Max   cax41 32GB 16c  30   16GB    4g  4.0c    30
+        #
+        # Pro keeps a 10-browser cap on cax31 deliberately: 15 agents × 384MB +
+        # 8GB browser container + 2GB OS = 15.76GB on a 16GB box. Lifting browsers
+        # to 15 would leave only ~240MB headroom and risk OOM under load.
         max_agents = int(os.environ.get("OPENLEGION_MAX_AGENTS", "0"))
         if max_agents <= 1:
             max_browsers, browser_mem, browser_shm, browser_cpu = 1, "2g", "512m", 100000
         elif max_agents <= 5:
             max_browsers, browser_mem, browser_shm, browser_cpu = max_agents, "4g", "1g", 150000
-        else:
+        elif max_agents <= 15:
             max_browsers, browser_mem, browser_shm, browser_cpu = min(max_agents, 10), "8g", "2g", 200000
+        else:
+            max_browsers, browser_mem, browser_shm, browser_cpu = min(max_agents, 30), "16g", "4g", 400000
 
         # Override browser idle timeout from dashboard config; also bridge
         # the dashboard-saved CAPTCHA solver provider/key into the host
@@ -436,6 +440,12 @@ class DockerBackend(RuntimeBackend):
                     "BROWSER_EGRESS_ALLOWLIST", "BROWSER_EGRESS_DISABLE"):
             if os.environ.get(var):
                 environment[var] = os.environ[var]
+
+        # Forward provisioner-set browser concurrency cap to the browser container
+        # so per-instance scale changes (via OPENLEGION_BROWSER_MAX_CONCURRENT in
+        # .env) take effect on the next engine restart.
+        if os.environ.get("OPENLEGION_BROWSER_MAX_CONCURRENT"):
+            environment["OPENLEGION_BROWSER_MAX_CONCURRENT"] = os.environ["OPENLEGION_BROWSER_MAX_CONCURRENT"]
 
         # If the operator configured a proxy whose host is a literal private IP,
         # the egress filter will block the browser from reaching it unless the

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import json
 from unittest.mock import MagicMock, patch
 
+import pytest
+
 from src.cli.runtime import _default_embedding_model
 from src.host.runtime import (
     DockerBackend,
@@ -507,6 +509,100 @@ class TestDockerBackendSlimResources:
         mock_container.stop.assert_called_once()
         mock_container.remove.assert_called_once()
         assert backend.browser_service_url is None
+
+    @pytest.mark.parametrize(
+        "max_agents,exp_mem,exp_shm,exp_cpu,exp_max_browsers",
+        [
+            # Basic — cax11 (default when env unset == 0)
+            (0, "2g", "512m", 100000, 1),
+            (1, "2g", "512m", 100000, 1),
+            # Growth — cax21 (max_browsers == max_agents in this band)
+            (2, "4g", "1g", 150000, 2),
+            (5, "4g", "1g", 150000, 5),
+            # Pro — cax31 (mem-bound, capped at 10 browsers even with 15 agents)
+            (6, "8g", "2g", 200000, 6),
+            (10, "8g", "2g", 200000, 10),
+            (15, "8g", "2g", 200000, 10),
+            # Pro Max — cax41 (32GB ARM, 30 agents / 30 browsers / 16GB / 4.0 CPU)
+            (16, "16g", "4g", 400000, 16),
+            (30, "16g", "4g", 400000, 30),
+            (50, "16g", "4g", 400000, 30),  # capped at 30
+        ],
+    )
+    def test_browser_tier_sizing(self, max_agents, exp_mem, exp_shm, exp_cpu, exp_max_browsers):
+        """Browser container resources scale across the 4-tier plan table
+        (Basic / Growth / Pro / Pro Max) driven by OPENLEGION_MAX_AGENTS."""
+        import os as _os
+
+        import docker as _docker
+
+        backend = self._make_backend()
+        mock_client = MagicMock()
+        mock_client.containers.run.return_value = MagicMock()
+        mock_client.containers.get.side_effect = _docker.errors.NotFound("nope")
+        backend.client = mock_client
+
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        with patch("httpx.get", return_value=mock_resp), \
+             patch.dict(_os.environ, {"OPENLEGION_MAX_AGENTS": str(max_agents)}):
+            backend.start_browser_service()
+
+        run_call = mock_client.containers.run.call_args
+        assert run_call.kwargs.get("mem_limit") == exp_mem
+        assert run_call.kwargs.get("shm_size") == exp_shm
+        assert run_call.kwargs.get("cpu_quota") == exp_cpu
+        env = run_call.kwargs.get("environment", {})
+        assert env.get("MAX_BROWSERS") == str(exp_max_browsers)
+
+    def test_browser_max_concurrent_env_forwarded(self):
+        """OPENLEGION_BROWSER_MAX_CONCURRENT (provisioner-set per-instance scale
+        cap) must be forwarded into the browser container — otherwise the
+        provisioner's scale_instance write to /opt/openlegion/.env is a no-op."""
+        import os as _os
+
+        import docker as _docker
+
+        backend = self._make_backend()
+        mock_client = MagicMock()
+        mock_client.containers.run.return_value = MagicMock()
+        mock_client.containers.get.side_effect = _docker.errors.NotFound("nope")
+        backend.client = mock_client
+
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        with patch("httpx.get", return_value=mock_resp), \
+             patch.dict(_os.environ, {"OPENLEGION_BROWSER_MAX_CONCURRENT": "7"}):
+            backend.start_browser_service()
+
+        run_call = mock_client.containers.run.call_args
+        env = run_call.kwargs.get("environment", {})
+        assert env.get("OPENLEGION_BROWSER_MAX_CONCURRENT") == "7"
+
+    def test_browser_max_concurrent_env_absent_when_unset(self):
+        """When OPENLEGION_BROWSER_MAX_CONCURRENT is not in the host env, do
+        NOT inject an empty value into the container env (browser container
+        falls back to its own default via _resolve_max_browsers)."""
+        import os as _os
+
+        import docker as _docker
+
+        backend = self._make_backend()
+        mock_client = MagicMock()
+        mock_client.containers.run.return_value = MagicMock()
+        mock_client.containers.get.side_effect = _docker.errors.NotFound("nope")
+        backend.client = mock_client
+
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        with patch("httpx.get", return_value=mock_resp), \
+             patch.dict(_os.environ, {}, clear=False):
+            _os.environ.pop("OPENLEGION_BROWSER_MAX_CONCURRENT", None)
+            backend.start_browser_service()
+
+        run_call = mock_client.containers.run.call_args
+        env = run_call.kwargs.get("environment", {})
+        assert "OPENLEGION_BROWSER_MAX_CONCURRENT" not in env
 
     def test_browser_has_net_admin_in_bridge_mode(self):
         """Browser container gets the minimal cap set its entrypoint needs in bridge mode."""


### PR DESCRIPTION
## Summary

- Adds 4th tier "Pro Max" to the browser-service sizing table in `src/host/runtime.py`, backed by Hetzner cax41 (32GB ARM): up to 30 agents, 30 browsers, 16GB browser container, 4.0 CPU.
- Forwards `OPENLEGION_BROWSER_MAX_CONCURRENT` from the host process env into the browser container — fixes a latent bug where the provisioner's `scale_instance` would write this var to `.env` expecting it to take effect, but the engine never plumbed it through (browser container only saw the engine-computed `MAX_BROWSERS`).
- Pro tier kept at 10 browsers deliberately (mem-bound on 16GB cax31): 15 agents × 384MB + 8GB browser container + 2GB OS = 15.76GB on a 16GB box. Lifting to 15 browsers would leave ~240MB headroom and risk OOM.
- Pro Max math (cax41 32GB): 30 agents × 384MB + 16GB browser + 2GB OS = 29.5GB → 2.5GB headroom, comfortable.

## Test plan

- [x] `pytest tests/test_runtime.py -x -v` — added 96 LOC of tier-table tests (cax11/21/31/41 mappings + edge cases)
- [x] Full suite: 5959 tests pass, 1 deselected (httpbin network)
- [x] `ruff check src/host/runtime.py` clean