### PR TITLE
refactor: rate output, don't approve plans

### DIFF
--- a/src/agent/builtins/operator_tools.py
+++ b/src/agent/builtins/operator_tools.py
@@ -156,21 +156,15 @@ def _validate_edit(agent_id: str, field: str, value) -> dict | None:
     return None
 
 
-_PROPOSE_EDIT_FIELDS = _VALID_FIELDS - {"heartbeat_schedule"}
-
-
 @skill(
     name="propose_edit",
     description=(
-        "Propose a change to an agent's config. Returns a preview diff and "
-        "change_id; show the preview and get user approval before calling "
-        "confirm_edit. See INSTRUCTIONS.md for field formats."
+        "DEPRECATED — calls edit_agent under the hood. All config edits now "
+        "apply immediately and emit an undo receipt; no separate confirm step "
+        "is needed. Prefer edit_agent directly."
     ),
     parameters={
-        "agent_id": {
-            "type": "string",
-            "description": "Target agent ID",
-        },
+        "agent_id": {"type": "string", "description": "Target agent ID"},
         "field": {
             "type": "string",
             "description": "Config field to change",
@@ -185,156 +179,64 @@ _PROPOSE_EDIT_FIELDS = _VALID_FIELDS - {"heartbeat_schedule"}
         },
     },
 )
-async def propose_edit(agent_id: str, field: str, value, *, mesh_client=None, **_kw) -> dict:
-    """Propose a config change for an agent. Returns preview for user review."""
-    if not _is_operator():
-        return {"error": "This tool is only available to the operator agent."}
-    if mesh_client is None:
-        return {"error": "No mesh_client available"}
-
-    # Self-modification prevention
-    if agent_id.lower() == _OPERATOR_AGENT_ID:
-        return {
-            "error": (
-                "Cannot modify the operator agent. "
-                "Use the dashboard to change operator settings."
-            ),
-        }
-
-    # Validate field. ``heartbeat_schedule`` is soft-only — the propose
-    # path is for hard fields, so reject the schedule here and route the
-    # caller to ``edit_agent`` instead.
-    if field not in _PROPOSE_EDIT_FIELDS:
-        return {
-            "error": (
-                f"Invalid field '{field}'. "
-                f"Must be one of: {sorted(_PROPOSE_EDIT_FIELDS)}"
-            ),
-        }
-
-    # Permission ceiling validation
-    if field == "permissions" and isinstance(value, dict):
-        for key, max_val in _OPERATOR_PERMISSION_CEILING.items():
-            if key not in value:
-                continue
-            if isinstance(max_val, bool):
-                if value[key] and not max_val:
-                    return {
-                        "error": (
-                            f"Permission ceiling exceeded: '{key}' cannot be set "
-                            "to True by the operator. Use the dashboard for "
-                            "advanced permissions."
-                        ),
-                    }
-            elif isinstance(max_val, list):
-                requested = set(value.get(key, []))
-                allowed = set(max_val)
-                if "*" not in allowed and not requested.issubset(allowed):
-                    excess = requested - allowed
-                    return {
-                        "error": (
-                            f"Permission ceiling exceeded: '{key}' patterns "
-                            f"{excess} exceed allowed {allowed}. Use the "
-                            "dashboard for advanced permissions."
-                        ),
-                    }
-
-    # Budget validation
-    if field == "budget" and isinstance(value, dict):
-        daily = value.get("daily_usd", 0)
-        monthly = value.get("monthly_usd", 0)
-        if not isinstance(daily, (int, float)) or not (0.01 <= daily <= 1000):
-            return {"error": f"daily_usd must be 0.01-1000, got {daily}"}
-        if not isinstance(monthly, (int, float)) or not (0.10 <= monthly <= 30000):
-            return {"error": f"monthly_usd must be 0.10-30000, got {monthly}"}
-
-    # Thinking validation
-    if field == "thinking" and value not in ("off", "low", "medium", "high"):
-        return {
-            "error": (
-                f"thinking must be 'off', 'low', 'medium', or 'high', "
-                f"got '{value}'"
-            ),
-        }
-
-    try:
-        result = await mesh_client.propose_config_change(agent_id, field, value)
-        return result
-    except Exception as e:
-        return {"error": f"Failed to propose edit: {e}"}
+async def propose_edit(
+    agent_id: str, field: str, value, *,
+    mesh_client=None, _messages=None, **_kw,
+) -> dict:
+    """Deprecated shim — applies the edit immediately via edit_agent."""
+    result = await edit_agent(
+        agent_id, field, value, reason="user_asked",
+        mesh_client=mesh_client, _messages=_messages,
+    )
+    if isinstance(result, dict) and "error" not in result:
+        result.setdefault(
+            "deprecation_notice",
+            "propose_edit is deprecated. The change applied immediately; "
+            "no confirm_edit call is needed. Use edit_agent next time.",
+        )
+    return result
 
 
 @skill(
     name="confirm_edit",
     description=(
-        "Apply a previously proposed agent config change. Only call this after "
-        "the user has seen the preview and explicitly confirmed. Will fail if "
-        "the user has not confirmed in the conversation."
+        "DEPRECATED — no-op. Config edits now apply immediately via "
+        "edit_agent and emit an undo receipt, so there is no pending change "
+        "to confirm. Tool retained only so in-flight conversations don't "
+        "break; do not call from new code."
     ),
     parameters={
         "change_id": {
             "type": "string",
-            "description": "Change ID from propose_edit",
+            "description": "Legacy change_id (ignored)",
         },
     },
 )
 async def confirm_edit(change_id: str, *, mesh_client=None, _messages=None, **_kw) -> dict:
-    """Apply a proposed config change after user confirmation."""
+    """Deprecated no-op. Returns a friendly hint to use edit_agent."""
     if not _is_operator():
         return {"error": "This tool is only available to the operator agent."}
-    if mesh_client is None:
-        return {"error": "No mesh_client available"}
-
-    # Provenance check: require user confirmation
-    from src.agent.loop import _last_message_is_user_origin
-
-    if _messages is None or not _last_message_is_user_origin(_messages):
-        return {
-            "error": "provenance_check_failed",
-            "detail": (
-                "User confirmation required. Please show the proposed change "
-                "to the user and ask them to confirm before calling confirm_edit."
-            ),
-        }
-
-    try:
-        result = await mesh_client.confirm_config_change(change_id)
-        return result
-    except Exception as e:
-        error_str = str(e)
-        # Task 2d migrated /mesh/config/confirm from 404 -> 400 with
-        # "Pending action invalid or expired" for unknown/expired/
-        # digest-mismatch/origin-failure rows. Match either form so
-        # existing operator UX (re-propose) keeps working.
-        lower = error_str.lower()
-        if (
-            "404" in error_str
-            or "not found" in lower
-            or "invalid or expired" in lower
-        ):
-            return {
-                "error": "change_expired_or_lost",
-                "detail": (
-                    "The proposed change was not found (expired or server "
-                    "restarted). Please call propose_edit again."
-                ),
-            }
-        return {"error": f"Failed to confirm edit: {e}"}
+    return {
+        "success": True,
+        "applied": False,
+        "deprecation_notice": (
+            "confirm_edit is a no-op. Config edits now apply immediately "
+            "when you call edit_agent; the user sees an undo receipt with a "
+            "5–30 minute revert window. Don't call confirm_edit anymore."
+        ),
+    }
 
 
 @skill(
     name="edit_agent",
     description=(
-        "Change an agent's configuration. Branches internally on field severity:\n"
-        "- Soft fields (instructions, soul, heartbeat, heartbeat_schedule, "
-        "interface, role) apply IMMEDIATELY. The user sees a receipt card "
-        "with [View diff] [Undo] (5-minute undo window). No confirmation "
-        "step needed — act decisively on what the user asked for.\n"
-        "- Hard fields (model, budget, permissions, thinking) return a "
-        "preview + change_id (expires in 5 minutes for most actions, "
-        "30 minutes for hard-field edits so the user has time to think). "
-        "Show the preview to the user; on explicit "
-        "confirmation call confirm_edit(change_id).\n\n"
+        "Change an agent's configuration. All edits apply IMMEDIATELY and "
+        "emit a receipt card with [View diff] [Undo]. No confirmation step "
+        "— act decisively on what the user asked for. The undo window is "
+        "5 minutes for soft fields (instructions/soul/role/heartbeat/"
+        "heartbeat_schedule/interface) and 30 minutes for hard fields "
+        "(model/permissions/budget/thinking) so the user has more time to "
+        "catch a costly edit.\n\n"
         "Always pass `reason` so the audit trail captures intent.\n\n"
         "Fields & value formats:\n"
         "- instructions/soul/heartbeat/interface/role: string\n"
@@ -385,13 +287,16 @@ async def edit_agent(
     _messages=None,
     **_kw,
 ) -> dict:
-    """Change agent config — soft fields direct-apply, hard fields propose.
+    """Change agent config — apply immediately, emit an undo receipt.
 
-    For soft fields: skips the provenance gate and writes immediately;
-    the receipt card with [Undo] is the safety net (user can always
-    revert within 5 minutes). For hard fields: behaves like the legacy
-    propose_edit — the operator must show preview to the user and wait
-    for explicit confirm before calling confirm_edit(change_id).
+    All fields go through the same path. The mesh records an undo
+    receipt with a TTL of 5 min for soft fields or 30 min for hard
+    fields; the dashboard renders [View diff] [Undo] on the receipt
+    card. Provenance is intentionally NOT required at this layer — the
+    receipt is the safety net, and dropping the gate lets the operator
+    self-tune during heartbeat without a human in the loop. The
+    permission ceiling in :data:`_OPERATOR_PERMISSION_CEILING` still
+    blocks irreversible grants (``can_spawn``, ``can_use_wallet``).
     """
     if not _is_operator():
         return {"error": "This tool is only available to the operator agent."}
@@ -409,60 +314,36 @@ async def edit_agent(
     if err is not None:
         return err
 
-    if field in _SOFT_EDIT_FIELDS:
-        # Soft path: direct write + receipt + undo. Provenance is NOT
-        # required because the receipt card with [Undo] gives the user
-        # a 5-minute reversal window. ``operator_proactive`` is logged
-        # via ``reason`` for audit but doesn't change the gate.
-        if reason == "operator_proactive":
-            logger.info(
-                "operator_proactive soft-edit: agent=%s field=%s",
-                agent_id, field,
-            )
-        try:
-            result = await mesh_client.edit_soft(agent_id, field, value, reason)
-        except Exception as e:
-            return {"error": f"Failed to apply edit: {e}"}
-        return {
-            "success": True,
-            "applied": True,
-            "agent_id": agent_id,
-            "field": field,
-            "undo_token": result.get("undo_token"),
-            "expires_at": result.get("expires_at"),
-            "summary": result.get("summary"),
-            "message": (
-                "Done. The user sees a receipt card and can Undo within 5 minutes."
-            ),
-        }
-
-    # Hard path: provenance gate + propose+confirm. Mirrors the legacy
-    # propose_edit behaviour so existing dashboard surfacing keeps
-    # working until PR 2 swaps the amber bubble for an inline card.
-    from src.agent.loop import _last_message_is_user_origin
-
-    if _messages is None or not _last_message_is_user_origin(_messages):
-        return {
-            "error": "provenance_check_failed",
-            "detail": (
-                f"Hard field {field!r} requires explicit user request. "
-                "Ask the user, then retry edit_agent after they confirm."
-            ),
-        }
-
+    if reason == "operator_proactive":
+        logger.info(
+            "operator_proactive edit: agent=%s field=%s",
+            agent_id, field,
+        )
     try:
-        result = await mesh_client.propose_config_change(agent_id, field, value)
+        result = await mesh_client.edit_soft(agent_id, field, value, reason)
     except Exception as e:
-        return {"error": f"Failed to propose edit: {e}"}
-    # Annotate so the operator's prompt machinery knows it must show the
-    # preview and wait for confirmation before calling confirm_edit.
-    result.setdefault("requires_confirmation", True)
-    result.setdefault(
-        "next_step",
-        "Show the preview_diff to the user. On explicit confirmation, "
-        "call confirm_edit(change_id).",
+        return {"error": f"Failed to apply edit: {e}"}
+
+    field_class = result.get("field_class") or (
+        "hard" if field not in _SOFT_EDIT_FIELDS else "soft"
     )
-    return result
+    ttl_seconds = result.get("ttl_seconds") or (1800 if field_class == "hard" else 300)
+    minutes = ttl_seconds // 60
+    return {
+        "success": True,
+        "applied": True,
+        "agent_id": agent_id,
+        "field": field,
+        "field_class": field_class,
+        "undo_token": result.get("undo_token"),
+        "expires_at": result.get("expires_at"),
+        "ttl_seconds": ttl_seconds,
+        "summary": result.get("summary"),
+        "message": (
+            f"Done. The user sees a receipt card and can Undo within "
+            f"{minutes} minute{'s' if minutes != 1 else ''}."
+        ),
+    }
 
 
 @skill(
@@ -655,20 +536,17 @@ async def create_agent(
     _messages=None,
     **_kw,
 ) -> dict:
-    """Create a new custom agent. Provenance-gated."""
+    """Create a new custom agent.
+
+    Provenance gate dropped: operator can spawn agents autonomously
+    (e.g. during heartbeat in response to its own analysis). The
+    plan-tier budget cap ``OPENLEGION_MAX_AGENTS`` and the permission
+    ceiling (``can_spawn=False`` for created agents) are the real walls.
+    """
     if not _is_operator():
         return {"error": "This tool is only available to the operator agent."}
     if mesh_client is None:
         return {"error": "No mesh_client available"}
-
-    # Provenance check
-    from src.agent.loop import _last_message_is_user_origin
-
-    if _messages is None or not _last_message_is_user_origin(_messages):
-        return {
-            "error": "provenance_check_failed",
-            "detail": "User confirmation required to create an agent.",
-        }
 
     try:
         return await mesh_client.create_custom_agent(
@@ -778,19 +656,16 @@ async def create_project(
     _messages=None,
     **_kw,
 ) -> dict:
-    """Create a new project. Provenance-gated."""
+    """Create a new project.
+
+    Provenance gate dropped — operator can create projects
+    autonomously. Plan-tier cap ``OPENLEGION_MAX_PROJECTS`` is the
+    quota wall.
+    """
     if not _is_operator():
         return {"error": "This tool is only available to the operator agent."}
     if mesh_client is None:
         return {"error": "No mesh_client available"}
-
-    from src.agent.loop import _last_message_is_user_origin
-
-    if _messages is None or not _last_message_is_user_origin(_messages):
-        return {
-            "error": "provenance_check_failed",
-            "detail": "User confirmation required to create a project.",
-        }
 
     try:
         return await mesh_client.create_project(
@@ -823,19 +698,11 @@ async def add_agents_to_project(
     _messages=None,
     **_kw,
 ) -> dict:
-    """Add agents to a project. Provenance-gated."""
+    """Add agents to a project."""
     if not _is_operator():
         return {"error": "This tool is only available to the operator agent."}
     if mesh_client is None:
         return {"error": "No mesh_client available"}
-
-    from src.agent.loop import _last_message_is_user_origin
-
-    if _messages is None or not _last_message_is_user_origin(_messages):
-        return {
-            "error": "provenance_check_failed",
-            "detail": "User confirmation required to add agents to a project.",
-        }
 
     results = []
     for aid in agent_ids:
@@ -870,19 +737,11 @@ async def remove_agents_from_project(
     _messages=None,
     **_kw,
 ) -> dict:
-    """Remove agents from a project. Provenance-gated."""
+    """Remove agents from a project."""
     if not _is_operator():
         return {"error": "This tool is only available to the operator agent."}
     if mesh_client is None:
         return {"error": "No mesh_client available"}
-
-    from src.agent.loop import _last_message_is_user_origin
-
-    if _messages is None or not _last_message_is_user_origin(_messages):
-        return {
-            "error": "provenance_check_failed",
-            "detail": "User confirmation required to remove agents from a project.",
-        }
 
     results = []
     for aid in agent_ids:
@@ -919,19 +778,11 @@ async def update_project_context(
     _messages=None,
     **_kw,
 ) -> dict:
-    """Update project description/context. Provenance-gated."""
+    """Update project description/context."""
     if not _is_operator():
         return {"error": "This tool is only available to the operator agent."}
     if mesh_client is None:
         return {"error": "No mesh_client available"}
-
-    from src.agent.loop import _last_message_is_user_origin
-
-    if _messages is None or not _last_message_is_user_origin(_messages):
-        return {
-            "error": "provenance_check_failed",
-            "detail": "User confirmation required to update project context.",
-        }
 
     try:
         return await mesh_client.update_project_context(project_name, context)
@@ -1470,18 +1321,17 @@ async def manage_project(
     **_kw,
 ) -> dict:
     """Consolidated project lifecycle tool (archive | delete).
-    Provenance-gated.
+
+    Archive is reversible and applies immediately. Delete still goes
+    through a brief confirmation window (mesh-side propose_delete with
+    a short TTL); a follow-up PR will convert delete to immediate-apply
+    with a 72h undo. Operator can call either autonomously — the user's
+    feedback signal on output is the safety net.
     """
     if not _is_operator():
         return {"error": "This tool is only available to the operator agent."}
     if mesh_client is None:
         return {"error": "No mesh_client available"}
-    from src.agent.loop import _last_message_is_user_origin
-    if _messages is None or not _last_message_is_user_origin(_messages):
-        return {
-            "error": "provenance_check_failed",
-            "detail": f"User confirmation required to {action} a project.",
-        }
 
     if action == "archive":
         try:
@@ -1537,7 +1387,11 @@ async def manage_agent(
     **_kw,
 ) -> dict:
     """Consolidated agent lifecycle tool (archive | delete).
-    Provenance-gated.
+
+    Archive is reversible and applies immediately. Delete still goes
+    through a brief confirmation window (mesh-side propose_delete with
+    a short TTL); a follow-up PR will convert delete to immediate-apply
+    with a 72h undo. Operator can call either autonomously.
     """
     if not _is_operator():
         return {"error": "This tool is only available to the operator agent."}
@@ -1545,12 +1399,6 @@ async def manage_agent(
         return {"error": "No mesh_client available"}
     if agent_id.lower() == _OPERATOR_AGENT_ID:
         return {"error": f"Cannot {action} the operator agent."}
-    from src.agent.loop import _last_message_is_user_origin
-    if _messages is None or not _last_message_is_user_origin(_messages):
-        return {
-            "error": "provenance_check_failed",
-            "detail": f"User confirmation required to {action} an agent.",
-        }
 
     if action == "archive":
         try:

--- a/src/agent/builtins/operator_tools.py
+++ b/src/agent/builtins/operator_tools.py
@@ -170,6 +170,7 @@ def _validate_edit(agent_id: str, field: str, value) -> dict | None:
             "description": "Config field to change",
             "enum": [
                 "instructions", "soul", "model", "role", "heartbeat",
+                "heartbeat_schedule",
                 "interface", "thinking", "budget", "permissions",
             ],
         },

--- a/src/agent/mesh_client.py
+++ b/src/agent/mesh_client.py
@@ -760,13 +760,15 @@ class MeshClient:
         return response.json()
 
     async def edit_soft(self, agent_id: str, field: str, value, reason: str) -> dict:
-        """Apply a soft-edit immediately. Returns ``undo_token``+``expires_at``.
+        """Apply an agent-config edit immediately. Returns receipt.
 
-        Backed by ``POST /mesh/agents/{id}/edit-soft``. The endpoint
-        rejects hard fields (model/budget/permissions/thinking) with 400,
-        in which case the operator-tool layer should fall through to the
-        propose+confirm path. Soft edits are revertible for 5 minutes
-        via ``undo_change``.
+        Backed by ``POST /mesh/agents/{id}/edit-soft`` (path name retained
+        for backward compatibility; semantically it is "edit-apply"). All
+        fields — soft (instructions/soul/heartbeat/...) and hard (model/
+        permissions/budget/thinking) — apply immediately. The undo TTL is
+        field-aware: 5 min for soft fields, 30 min for hard fields. The
+        response includes ``undo_token``, ``expires_at``, ``ttl_seconds``,
+        and ``field_class``.
         """
         client = await self._get_client()
         response = await client.post(

--- a/src/cli/config.py
+++ b/src/cli/config.py
@@ -1530,9 +1530,11 @@ _OPERATOR_ALLOWED_TOOLS: list[str] = [
     "list_agent_queue", "get_team_outputs", "summarize_project_progress",
     # Coordination + chat
     "list_templates", "apply_template", "hand_off", "check_inbox",
-    # Configuration edits — PR 1: edit_agent collapses the soft/hard branch
-    # behind one tool; confirm_edit stays for the explicit hard-field step;
-    # undo_change lets the operator self-revert soft edits within the TTL.
+    # Configuration edits — edit_agent applies every field immediately
+    # and emits an undo receipt (5min for soft fields, 30min for hard).
+    # undo_change lets the operator self-revert within the TTL.
+    # confirm_edit kept for back-compat with in-flight conversations
+    # that may still call it; it is a no-op stub.
     "edit_agent", "confirm_edit", "undo_change",
     # Creation
     "create_agent", "create_project",

--- a/src/dashboard/server.py
+++ b/src/dashboard/server.py
@@ -842,31 +842,53 @@ def create_dashboard_router(
         agent_id = evt.get("agent") or None
         data = evt.get("data") or {}
         try:
-            if event_type == "task_outcome":
-                # Only deliveries surface as notifications. Rejections
-                # / rework / re-rates aren't a "you have new finished
-                # work" signal — they're either operator-initiated
-                # (the operator already knows) or surfaced via the
-                # task drawer.
-                outcome = (data.get("outcome") or "").lower()
-                if outcome != "delivered":
+            if event_type == "task_status_changed":
+                # A non-operator worker finishing a task is the
+                # "you have new work to review" signal. Operator-self
+                # status changes are excluded because the operator
+                # doesn't deliver to the user — the user IS the
+                # operator's surface. Also skip already-rated
+                # transitions (e.g. a rework task moving to done was
+                # auto-graded) so we don't double-ping the bell.
+                if (data.get("new_status") or "").lower() != "done":
                     return
-                actor = data.get("assignee") or agent_id or "Someone"
-                title = f"{actor} delivered draft"
-                body = (data.get("feedback") or "").strip()[:200] or None
+                assignee = data.get("assignee") or agent_id
+                if not assignee or assignee == "operator":
+                    return
+                if data.get("outcome"):
+                    # Already rated (auto-graded or pre-rated).
+                    return
+                task_id = data.get("task_id")
+                if not task_id:
+                    return
+                title = data.get("title") or "delivered work"
+                short_title = (title[:80] + "…") if len(title) > 80 else title
+                heading = f"{assignee} delivered: {short_title}"[:200]
+                preview = (data.get("preview_text") or "").strip()[:200] or None
                 payload = {
-                    "task_id": data.get("task_id"),
+                    "task_id": task_id,
                     "project_id": data.get("project_id"),
-                    "outcome": outcome,
+                    "assignee": assignee,
+                    "title": title,
                 }
                 nid = notification_store.add(
                     kind="delivered",
-                    title=title,
-                    body=body,
-                    agent_id=actor,
+                    title=heading,
+                    body=preview,
+                    agent_id=assignee,
                     payload=payload,
                 )
-                _emit_notification_added(nid, "delivered", title, body, actor, payload)
+                _emit_notification_added(
+                    nid, "delivered", heading, preview, assignee, payload,
+                )
+                return
+
+            if event_type == "task_outcome":
+                # Outcome updates (user rated a delivery) do NOT create
+                # new bell notifications — the delivery already pinged
+                # the user when the worker finished. The dashboard's
+                # task drawer listens to ``task_outcome`` directly for
+                # live UI updates on the Recently Delivered panel.
                 return
 
             if event_type == "pending_action_created":
@@ -6759,10 +6781,13 @@ def create_dashboard_router(
     ) -> dict:
         """Record an operator outcome rating on a completed task.
 
-        Body: ``{outcome: "accepted"|"rework"|"rejected", feedback: str}``.
-        For ``rework``, also spawns a new linked task with the feedback
-        as its brief and the same assignee — the new task id is returned
-        in ``rework_task_id``.
+        Body: ``{outcome: "accepted"|"acknowledged"|"rework"|"rejected",
+        feedback: str}``. ``accepted`` and ``acknowledged`` allow empty
+        feedback (the rating itself is the signal). ``rework`` and
+        ``rejected`` require a non-empty comment so the agent / audit
+        trail has something to learn from. For ``rework``, also spawns a
+        new linked task with the feedback as its brief and the same
+        assignee — the new task id is returned in ``rework_task_id``.
         """
         from src.host.orchestration import (
             MAX_FEEDBACK_CHARS,

--- a/src/dashboard/static/js/app.js
+++ b/src/dashboard/static/js/app.js
@@ -461,6 +461,20 @@ function dashboard() {
     recentlyDeliveredArtifacts: {},
     recentlyDeliveredExpanded: {},
     _recentlyDeliveredFetching: {},
+    // Inline rework state for the "Recently delivered" cards — keyed by
+    // task_id. Opens an inline textarea on the card instead of bouncing
+    // through the drillIn modal so the user stays in flow. Cleared by
+    // ``rateDelivery`` after a successful submit. Initialized here in
+    // the data section so Alpine treats them as first-class reactive
+    // state (template helpers ``inlineReworkIsOpen`` / ``inlineReworkText``
+    // read them indirectly, but a future direct-template read should
+    // still react).
+    _inlineReworkOpen: {},
+    _inlineReworkText: {},
+    // Per-task in-flight guard for inline rating clicks — prevents a
+    // user from double-firing rateDelivery while the POST is still
+    // round-tripping. Cleared in the finally block of ``rateDelivery``.
+    _rateDeliveryInflight: {},
     workplaceProjectFilter: '',
     // Per-column flag: when true, the kanban column ignores the 14-day
     // archive cutoff and shows old pending/blocked rows. Keyed by status
@@ -3432,8 +3446,7 @@ function dashboard() {
     //     with the comment populated.
     async rateDelivery(taskId, outcome, feedback = '') {
       if (!taskId) return;
-      if (this._rateDeliveryInflight && this._rateDeliveryInflight[taskId]) return;
-      this._rateDeliveryInflight = this._rateDeliveryInflight || {};
+      if (this._rateDeliveryInflight[taskId]) return;
       this._rateDeliveryInflight[taskId] = true;
       try {
         const resp = await fetch(
@@ -3463,12 +3476,8 @@ function dashboard() {
           }
         }
         // Clear the per-card inline rework state if it was open.
-        if (this._inlineReworkOpen && this._inlineReworkOpen[taskId]) {
-          delete this._inlineReworkOpen[taskId];
-        }
-        if (this._inlineReworkText && this._inlineReworkText[taskId]) {
-          delete this._inlineReworkText[taskId];
-        }
+        delete this._inlineReworkOpen[taskId];
+        delete this._inlineReworkText[taskId];
         if (outcome === 'rework' && data.rework_task_id) {
           this.showToast(`Rework task created${data.rework_assignee ? ' for ' + data.rework_assignee : ''}.`);
         } else if (outcome === 'rework' && data.rework_error) {
@@ -3483,24 +3492,20 @@ function dashboard() {
       }
     },
 
-    // Inline rework state — keyed by task_id. Opens an inline textarea
-    // on the card instead of bouncing through the drillIn modal so the
-    // user stays in flow.
-    _inlineReworkOpen: {},
-    _inlineReworkText: {},
-
+    // ``_inlineReworkOpen`` / ``_inlineReworkText`` / ``_rateDeliveryInflight``
+    // declared in the data section above so Alpine treats them as
+    // reactive state. Method below just read/write them.
     inlineReworkIsOpen(taskId) {
       return !!(this._inlineReworkOpen && this._inlineReworkOpen[taskId]);
     },
 
     openInlineRework(taskId) {
-      this._inlineReworkOpen = this._inlineReworkOpen || {};
       this._inlineReworkOpen[taskId] = true;
     },
 
     closeInlineRework(taskId) {
-      if (this._inlineReworkOpen) delete this._inlineReworkOpen[taskId];
-      if (this._inlineReworkText) delete this._inlineReworkText[taskId];
+      delete this._inlineReworkOpen[taskId];
+      delete this._inlineReworkText[taskId];
     },
 
     inlineReworkText(taskId) {
@@ -3508,7 +3513,6 @@ function dashboard() {
     },
 
     setInlineReworkText(taskId, value) {
-      this._inlineReworkText = this._inlineReworkText || {};
       this._inlineReworkText[taskId] = value;
     },
 

--- a/src/dashboard/static/js/app.js
+++ b/src/dashboard/static/js/app.js
@@ -2940,6 +2940,7 @@ function dashboard() {
 
     drillInOutcomeLabel(outcome) {
       if (outcome === 'accepted') return 'Accepted';
+      if (outcome === 'acknowledged') return 'Acknowledged';
       if (outcome === 'rework') return 'Marked for rework';
       if (outcome === 'rejected') return 'Rejected';
       return '';
@@ -2972,7 +2973,10 @@ function dashboard() {
       // (e.g. operator hit "Reject" by accident). The submit button for
       // the existing rating is disabled to prevent a no-op double-click.
       if (this.drillInData.task.outcome === outcome) return false;
-      if (outcome === 'accepted') return true;
+      // ``accepted`` and ``acknowledged`` are silent-allowed; ``rework``
+      // and ``rejected`` require feedback text so the agent has
+      // something to learn from.
+      if (outcome === 'accepted' || outcome === 'acknowledged') return true;
       return Boolean((this.drillInComment || '').trim());
     },
 
@@ -3227,6 +3231,41 @@ function dashboard() {
         });
       }
 
+      // Unrated deliveries — synthetic singleton entry. The user's
+      // primary feedback signal is the rating on completed work, so we
+      // surface a "N deliveries need rating" nudge once any of the
+      // Recently Delivered cards are unrated. Click jumps to the
+      // Activity sub-tab where the cards (with inline rating buttons)
+      // live.
+      const unrated = (this.recentlyDeliveredItems || []).filter(t => !t.outcome).length;
+      if (unrated > 0) {
+        items.push({
+          id: 'unrated-deliveries',
+          kind: 'unrated',
+          icon: '?',
+          title: unrated === 1
+            ? '1 delivery needs your rating'
+            : `${unrated} deliveries need your rating`,
+          subtitle: this._needsYouSubtitle({ text: 'Thumbs up, neutral, or rework' }),
+          actions: [
+            {
+              label: 'Review',
+              style: 'indigo',
+              handler: () => {
+                this.activeTab = 'workplace';
+                this.homeTab = 'activity';
+                // Scroll the first unrated card into view next tick so
+                // the user lands directly on the rating buttons.
+                requestAnimationFrame(() => {
+                  const el = document.querySelector('[data-testid="home-just-delivered"]');
+                  if (el && el.scrollIntoView) el.scrollIntoView({ behavior: 'smooth', block: 'start' });
+                });
+              },
+            },
+          ],
+        });
+      }
+
       return items;
     },
 
@@ -3379,6 +3418,107 @@ function dashboard() {
       if (n > nowSec) n = nowSec;
       if (n < 0) n = 0;
       return n;
+    },
+
+    // Inline rate handler for the "Recently delivered" cards. Reuses
+    // the dashboard ``/workplace/tasks/{id}/outcome`` endpoint that the
+    // drillIn modal hits. Optimistically updates the local row so the
+    // buttons collapse to a rating chip without waiting for the
+    // ``task_outcome`` event round-trip.
+    //
+    // ``outcome``: 'accepted' | 'acknowledged' | 'rework'
+    //   - 'accepted' / 'acknowledged' send no feedback (silent rating).
+    //   - 'rework' opens the inline textarea; this method is called
+    //     with the comment populated.
+    async rateDelivery(taskId, outcome, feedback = '') {
+      if (!taskId) return;
+      if (this._rateDeliveryInflight && this._rateDeliveryInflight[taskId]) return;
+      this._rateDeliveryInflight = this._rateDeliveryInflight || {};
+      this._rateDeliveryInflight[taskId] = true;
+      try {
+        const resp = await fetch(
+          `${window.__config.apiBase}/workplace/tasks/${encodeURIComponent(taskId)}/outcome`,
+          {
+            method: 'POST',
+            headers: {
+              'Content-Type': 'application/json',
+              'X-Requested-With': 'XMLHttpRequest',
+            },
+            body: JSON.stringify({ outcome, feedback: feedback || '' }),
+          }
+        );
+        const data = await resp.json().catch(() => ({}));
+        if (!resp.ok) {
+          this.showToast(data.detail || `Rate failed (HTTP ${resp.status})`);
+          return;
+        }
+        // Optimistic write-back so the card flips to "Rated" without
+        // waiting on the next ``task_outcome`` WebSocket event.
+        const updated = data.task || {};
+        for (const list of [this.workplaceTasks, this.workplaceOutputs, this.recentlyDeliveredItems]) {
+          const row = (list || []).find(r => r.id === taskId);
+          if (row) {
+            row.outcome = updated.outcome || outcome;
+            row.feedback_text = updated.feedback_text ?? (feedback || null);
+          }
+        }
+        // Clear the per-card inline rework state if it was open.
+        if (this._inlineReworkOpen && this._inlineReworkOpen[taskId]) {
+          delete this._inlineReworkOpen[taskId];
+        }
+        if (this._inlineReworkText && this._inlineReworkText[taskId]) {
+          delete this._inlineReworkText[taskId];
+        }
+        if (outcome === 'rework' && data.rework_task_id) {
+          this.showToast(`Rework task created${data.rework_assignee ? ' for ' + data.rework_assignee : ''}.`);
+        } else if (outcome === 'rework' && data.rework_error) {
+          this.showToast(`Rework noted but follow-up task could not be spawned: ${data.rework_error}`);
+        } else {
+          this.showToast(`Rated: ${this.drillInOutcomeLabel(outcome) || outcome}.`);
+        }
+      } catch (e) {
+        this.showToast(`Rate failed: ${e.message || e}`);
+      } finally {
+        delete this._rateDeliveryInflight[taskId];
+      }
+    },
+
+    // Inline rework state — keyed by task_id. Opens an inline textarea
+    // on the card instead of bouncing through the drillIn modal so the
+    // user stays in flow.
+    _inlineReworkOpen: {},
+    _inlineReworkText: {},
+
+    inlineReworkIsOpen(taskId) {
+      return !!(this._inlineReworkOpen && this._inlineReworkOpen[taskId]);
+    },
+
+    openInlineRework(taskId) {
+      this._inlineReworkOpen = this._inlineReworkOpen || {};
+      this._inlineReworkOpen[taskId] = true;
+    },
+
+    closeInlineRework(taskId) {
+      if (this._inlineReworkOpen) delete this._inlineReworkOpen[taskId];
+      if (this._inlineReworkText) delete this._inlineReworkText[taskId];
+    },
+
+    inlineReworkText(taskId) {
+      return (this._inlineReworkText && this._inlineReworkText[taskId]) || '';
+    },
+
+    setInlineReworkText(taskId, value) {
+      this._inlineReworkText = this._inlineReworkText || {};
+      this._inlineReworkText[taskId] = value;
+    },
+
+    submitInlineRework(taskId) {
+      const text = (this.inlineReworkText(taskId) || '').trim();
+      if (!text) {
+        this.showToast('Add a brief — what should change in the rework?');
+        return;
+      }
+      this.rateDelivery(taskId, 'rework', text);
     },
 
     // Recompute the memoised "Recently delivered" slice. Called whenever

--- a/src/dashboard/templates/index.html
+++ b/src/dashboard/templates/index.html
@@ -3848,14 +3848,17 @@
                             <button type="button"
                               @click.stop="rateDelivery(t.id, 'accepted')"
                               title="Accept — looks good"
+                              aria-label="Accept this delivery"
                               class="text-sm px-1.5 py-0.5 rounded hover:bg-emerald-500/20 text-emerald-300">&#x1F44D;</button>
                             <button type="button"
                               @click.stop="rateDelivery(t.id, 'acknowledged')"
                               title="Acknowledge — reviewed without judgement"
+                              aria-label="Acknowledge this delivery without judgement"
                               class="text-sm px-1.5 py-0.5 rounded hover:bg-gray-500/20 text-gray-400">&#x2796;</button>
                             <button type="button"
                               @click.stop="openInlineRework(t.id)"
                               title="Needs rework — add a brief"
+                              aria-label="Mark this delivery for rework"
                               class="text-sm px-1.5 py-0.5 rounded hover:bg-amber-500/20 text-amber-300">&#x1F44E;</button>
                           </div>
                         </template>

--- a/src/dashboard/templates/index.html
+++ b/src/dashboard/templates/index.html
@@ -3836,10 +3836,62 @@
                         <span class="text-emerald-400 text-xs shrink-0">&check;</span>
                         <div class="min-w-0 flex-1 text-xs text-gray-200 truncate" x-text="t.title || '(untitled)'"></div>
                         <div class="text-[11px] text-gray-500 hidden sm:block shrink-0" x-text="(t.assignee || '') + (t.completed_at ? ' · ' + (formatRelativeTime((t.completed_at || 0) * 1000) || 'just now') : '')"></div>
+                        <!-- Inline rating buttons. Hidden once the task
+                             carries an ``outcome`` — the rating chip
+                             shows instead. ``rateDelivery`` posts to
+                             the existing /workplace/tasks/{id}/outcome
+                             endpoint; the optimistic update flips this
+                             group to the chip without waiting on a
+                             round-trip. -->
+                        <template x-if="!t.outcome">
+                          <div class="flex items-center gap-1 shrink-0" data-testid="rate-buttons">
+                            <button type="button"
+                              @click.stop="rateDelivery(t.id, 'accepted')"
+                              title="Accept — looks good"
+                              class="text-sm px-1.5 py-0.5 rounded hover:bg-emerald-500/20 text-emerald-300">&#x1F44D;</button>
+                            <button type="button"
+                              @click.stop="rateDelivery(t.id, 'acknowledged')"
+                              title="Acknowledge — reviewed without judgement"
+                              class="text-sm px-1.5 py-0.5 rounded hover:bg-gray-500/20 text-gray-400">&#x2796;</button>
+                            <button type="button"
+                              @click.stop="openInlineRework(t.id)"
+                              title="Needs rework — add a brief"
+                              class="text-sm px-1.5 py-0.5 rounded hover:bg-amber-500/20 text-amber-300">&#x1F44E;</button>
+                          </div>
+                        </template>
+                        <template x-if="t.outcome">
+                          <span class="text-[10px] px-1.5 py-0.5 rounded shrink-0"
+                                :class="t.outcome === 'accepted' ? 'bg-emerald-900/40 text-emerald-300 border border-emerald-700/40' : (t.outcome === 'rework' ? 'bg-amber-900/40 text-amber-300 border border-amber-700/40' : (t.outcome === 'rejected' ? 'bg-rose-900/40 text-rose-300 border border-rose-700/40' : 'bg-gray-700/40 text-gray-300 border border-gray-600/40'))"
+                                x-text="drillInOutcomeLabel(t.outcome) || t.outcome"></span>
+                        </template>
                         <button type="button"
                           @click.stop="openTaskDrillIn(t.id)"
                           class="text-[11px] px-2 py-0.5 rounded bg-gray-700 hover:bg-gray-600 text-gray-200 shrink-0">Open</button>
                       </div>
+                      <!-- Inline rework brief. Expands when the user
+                           clicks &#x1F44E; on the card. Submit calls the
+                           same rateDelivery handler with outcome='rework'
+                           which auto-spawns the follow-up task. Cancel
+                           clears the textarea without writing. -->
+                      <template x-if="inlineReworkIsOpen(t.id)">
+                        <div class="mt-1.5 pl-5" data-testid="inline-rework">
+                          <textarea
+                            :value="inlineReworkText(t.id)"
+                            @input="setInlineReworkText(t.id, $event.target.value)"
+                            rows="2"
+                            maxlength="2000"
+                            placeholder="What needs to change? This becomes the rework brief."
+                            class="w-full text-[11px] text-gray-200 bg-gray-900/60 border border-gray-700/50 rounded px-2 py-1.5 focus:outline-none focus:border-amber-500/60"></textarea>
+                          <div class="flex items-center gap-2 mt-1">
+                            <button type="button"
+                              @click.stop="submitInlineRework(t.id)"
+                              class="text-[11px] px-2 py-0.5 rounded bg-amber-600 hover:bg-amber-500 text-white">Submit rework</button>
+                            <button type="button"
+                              @click.stop="closeInlineRework(t.id)"
+                              class="text-[11px] px-2 py-0.5 rounded bg-gray-700 hover:bg-gray-600 text-gray-200">Cancel</button>
+                          </div>
+                        </div>
+                      </template>
                       <!-- Inline artifact preview. Hidden until the
                            lazy fetch completes; collapses again if the
                            artifact turns out to be non-text or absent. -->

--- a/src/host/orchestration.py
+++ b/src/host/orchestration.py
@@ -896,18 +896,22 @@ class Tasks:
         if not new_assignee:
             raise ValueError("new_assignee is required")
         now = time.time()
-        emitted: tuple[str, str | None] | None = None
+        emitted: tuple[str, str | None, str | None, str | None] | None = None
         with self._conn() as conn:
             conn.execute("BEGIN IMMEDIATE")
             try:
                 row = conn.execute(
-                    "SELECT assignee, status, project_id FROM tasks WHERE id=?",
+                    "SELECT assignee, status, project_id, title, outcome "
+                    "FROM tasks WHERE id=?",
                     (task_id,),
                 ).fetchone()
                 if not row:
                     conn.execute("ROLLBACK")
                     raise TaskNotFound(task_id)
-                old_assignee, current_status, project_id = row
+                (
+                    old_assignee, current_status, project_id,
+                    task_title, task_outcome,
+                ) = row
                 if current_status in TERMINAL_STATUSES:
                     conn.execute("ROLLBACK")
                     raise InvalidStatusTransition(
@@ -922,18 +926,22 @@ class Tasks:
                     {"from": old_assignee, "to": new_assignee, "reason": reason},
                 )
                 conn.execute("COMMIT")
-                emitted = (current_status, project_id)
+                emitted = (current_status, project_id, task_title, task_outcome)
             except (TaskNotFound, InvalidStatusTransition):
                 raise
             except Exception:
                 conn.execute("ROLLBACK")
                 raise
         if emitted is not None:
-            current_status, project_id = emitted
-            # Task 9 — reroute is a status_changed event with old==new
-            # status; the assignee field carries the *new* assignee so
-            # the dashboard sees who picked up the work. The audit row
-            # already records ``rerouted`` separately for full history.
+            current_status, project_id, task_title, task_outcome = emitted
+            # Reroute is a status_changed event with old==new status; the
+            # assignee field carries the *new* assignee so the dashboard
+            # sees who picked up the work. The audit row already records
+            # ``rerouted`` separately for full history. ``title`` and
+            # ``outcome`` ride on the payload to match the shape emitted
+            # by ``update_status`` — downstream consumers (notification
+            # producer, activity feed) get a uniform schema regardless
+            # of which transition path fired.
             self._safe_emit(
                 "task_status_changed",
                 agent=actor,
@@ -945,6 +953,8 @@ class Tasks:
                     "new_status": current_status,
                     "actor": actor,
                     "ts": now,
+                    "title": task_title,
+                    "outcome": task_outcome,
                 },
             )
         return self.get(task_id)  # type: ignore[return-value]

--- a/src/host/orchestration.py
+++ b/src/host/orchestration.py
@@ -45,13 +45,23 @@ VALID_STATUSES: frozenset[str] = frozenset({
 
 TERMINAL_STATUSES: frozenset[str] = frozenset({"done", "failed", "cancelled"})
 
-# Outcome enum (Task 9 PR 4) — operator-supplied judgement on a
-# completed task. ``None`` means "not yet rated". Outcomes are
-# write-many: every submission appends a ``task_outcome`` audit event
-# and the ``tasks.outcome`` column reflects the LATEST rating, so an
-# operator who clicks the wrong button can re-rate without admin
-# intervention.
-VALID_OUTCOMES: frozenset[str] = frozenset({"accepted", "rework", "rejected"})
+# Outcome enum — operator-supplied judgement on a completed task.
+# ``None`` means "not yet rated". Outcomes are write-many: every
+# submission appends a ``task_outcome`` audit event and the
+# ``tasks.outcome`` column reflects the LATEST rating, so a re-rate just
+# overwrites without admin intervention.
+#
+# - ``accepted``: positive signal. Writes a reinforcement memory entry.
+# - ``rework``: negative signal with a fix-it brief. Auto-spawns a
+#   rework task AND writes the feedback into the rated agent's memory
+#   so the agent recalls it on the next task.
+# - ``rejected``: terminal negative. Writes feedback to memory; does
+#   NOT auto-spawn a rework.
+# - ``acknowledged``: neutral, "reviewed without judgement". Does not
+#   write to memory and does not spawn rework.
+VALID_OUTCOMES: frozenset[str] = frozenset(
+    {"accepted", "rework", "rejected", "acknowledged"}
+)
 
 # Feedback length cap (chars). Bounded so the SQLite row stays small
 # and the UI textarea doesn't smuggle a multi-MB blob into the table.
@@ -782,13 +792,16 @@ class Tasks:
             conn.execute("BEGIN IMMEDIATE")
             try:
                 row = conn.execute(
-                    "SELECT status, project_id, assignee FROM tasks WHERE id=?",
+                    "SELECT status, project_id, assignee, title, outcome "
+                    "FROM tasks WHERE id=?",
                     (task_id,),
                 ).fetchone()
                 if not row:
                     conn.execute("ROLLBACK")
                     raise TaskNotFound(task_id)
-                current, project_id, assignee = row[0], row[1], row[2]
+                current, project_id, assignee, task_title, task_outcome = (
+                    row[0], row[1], row[2], row[3], row[4],
+                )
                 if current == status:
                     # No-op transition. Record the event so the audit
                     # trail still shows the call, but skip the row update.
@@ -830,14 +843,20 @@ class Tasks:
                     },
                 )
                 conn.execute("COMMIT")
-                emitted_change = (current, status, project_id, assignee)
+                emitted_change = (
+                    current, status, project_id, assignee,
+                    task_title, task_outcome,
+                )
             except (TaskNotFound, InvalidStatusTransition):
                 raise
             except Exception:
                 conn.execute("ROLLBACK")
                 raise
         if emitted_change is not None:
-            old_status, new_status, project_id, assignee = emitted_change
+            (
+                old_status, new_status, project_id, assignee,
+                task_title, task_outcome,
+            ) = emitted_change
             payload: dict = {
                 "task_id": task_id,
                 "project_id": project_id,
@@ -846,6 +865,13 @@ class Tasks:
                 "new_status": new_status,
                 "actor": actor,
                 "ts": now,
+                # ``title`` and ``outcome`` carried on every transition so
+                # downstream consumers (delivery-notification producer,
+                # activity feed) don't need a follow-up task lookup. The
+                # producer short-circuits on ``outcome`` to avoid pinging
+                # the bell for already-rated (e.g. auto-graded) work.
+                "title": task_title,
+                "outcome": task_outcome,
             }
             # Merge caller-supplied context (e.g. cancel ``reason``) so
             # the dashboard activity feed can render rich status_changed

--- a/src/host/server.py
+++ b/src/host/server.py
@@ -5119,8 +5119,17 @@ def create_mesh_app(
         if field == "permissions":
             from src.cli.config import _load_permissions, _save_permissions
             perms = _load_permissions()
-            if agent_id in perms.get("permissions", {}):
-                perms["permissions"][agent_id].update(new_value)
+            # Use setdefault so the write applies even if the agent's
+            # entry was never backfilled (defensive — startup runs
+            # ``_ensure_all_agent_permissions`` so this should be rare,
+            # but the unified edit path now routes more permissions
+            # edits here and a silent no-op would be worse than a
+            # late-init). Falsy ``new_value`` (None, empty dict) is a
+            # caller bug; ``_validate_edit`` rejects bad shapes upstream.
+            if isinstance(new_value, dict):
+                perms.setdefault("permissions", {}).setdefault(
+                    agent_id, {},
+                ).update(new_value)
                 _save_permissions(perms)
             # Hot-reload the in-memory permission matrix
             if permissions is not None:

--- a/src/host/server.py
+++ b/src/host/server.py
@@ -5338,27 +5338,41 @@ def create_mesh_app(
             "heartbeat_schedule": "heartbeat schedule",
             "interface": "interface contract",
             "role": "role",
+            "model": "model",
+            "permissions": "permissions",
+            "budget": "budget",
+            "thinking": "thinking config",
         }.get(field, field)
+
+    _EDITABLE_FIELDS = _SOFT_EDIT_FIELDS | _HARD_EDIT_FIELDS
 
     @app.post("/mesh/agents/{agent_id}/edit-soft")
     async def edit_agent_soft(agent_id: str, request: Request) -> dict:
-        """Apply a soft-edit immediately and emit a revertible receipt.
+        """Apply an agent-config edit immediately and emit a revertible receipt.
 
         Path constraints:
           * Caller must be ``operator`` (or an internal caller for tests).
           * ``X-Origin`` must validate (``_validated_origin``) — the
             operator-tool layer already did its own provenance check, so
             here we just require *some* validatable origin and store the
-            kind on the audit trail. Soft edits intentionally do NOT
+            kind on the audit trail. All edits intentionally do NOT
             require ``kind="human"`` because the receipt+undo card is
-            the safety net (the user can always revert within 5min).
-          * ``field`` must be in :data:`_SOFT_EDIT_FIELDS`. Hard fields
-            return 400 with a "use propose-edit for {field}" message so
-            the operator tool can fall through to the existing path.
+            the safety net (the user can always revert).
+          * ``field`` must be in :data:`_EDITABLE_FIELDS` (the union of
+            soft and hard fields). Both classes apply immediately; the
+            only difference is the undo-receipt TTL — see
+            ``_ttl_for_field`` (5 min for personality/instructions/role
+            cluster, 30 min for model/permissions/budget/thinking).
 
-        Returns ``{success, undo_token, expires_at, summary}``. The
-        ``operator_action_receipt`` event is emitted on the bus so the
-        dashboard can render the inline receipt card immediately.
+        Returns ``{success, undo_token, expires_at, summary, ttl_seconds}``.
+        The ``operator_action_receipt`` event is emitted on the bus so the
+        dashboard can render the inline receipt card immediately. For
+        hard fields, ``agent_config_updated`` ALSO fires (handled by
+        ``_apply_pending_change``).
+
+        Path name retained as ``/edit-soft`` for backward compatibility
+        with the dashboard SPA and any external scripts; semantically it
+        is now "edit-apply".
         """
         _require_any_auth(request)
         caller = _extract_verified_agent_id(request)
@@ -5375,16 +5389,10 @@ def create_mesh_app(
         reason = data.get("reason", "user_asked")
         if not field:
             raise HTTPException(400, "field is required")
-        if field in _HARD_EDIT_FIELDS:
+        if field not in _EDITABLE_FIELDS:
             raise HTTPException(
                 400,
-                f"Use /mesh/agents/{{id}}/propose for {field!r} (hard field — "
-                "requires explicit confirmation).",
-            )
-        if field not in _SOFT_EDIT_FIELDS:
-            raise HTTPException(
-                400,
-                f"Invalid field {field!r}. Soft fields: {sorted(_SOFT_EDIT_FIELDS)}",
+                f"Invalid field {field!r}. Editable fields: {sorted(_EDITABLE_FIELDS)}",
             )
 
         # Self-modification block. The operator-tool layer also blocks
@@ -5392,6 +5400,20 @@ def create_mesh_app(
         # bypasses the tool.
         if agent_id == "operator":
             raise HTTPException(400, "The operator agent cannot be edited via soft-edit")
+
+        # Validate runtime-critical values for hard fields before they
+        # can be persisted. Mirrors the validation block in the now-
+        # deprecated /propose endpoint.
+        if field == "model":
+            if not isinstance(new_value, str) or not new_value:
+                raise HTTPException(400, "model must be a non-empty string")
+        elif field == "thinking":
+            from src.agent.llm import LLMClient
+            if new_value not in LLMClient.VALID_THINKING_LEVELS:
+                raise HTTPException(
+                    400,
+                    f"thinking must be one of: {sorted(LLMClient.VALID_THINKING_LEVELS)}",
+                )
 
         from src.cli.config import _load_config
         agent_cfg = _load_config()
@@ -5401,14 +5423,19 @@ def create_mesh_app(
 
         # ``heartbeat_schedule`` is sourced from the live cron job, not
         # YAML — the cron table is the source of truth for an agent's
-        # actual heartbeat cadence (PR-L'). Read the current schedule
-        # so the audit/Undo flow restores the right value.
+        # actual heartbeat cadence. Permissions live in permissions.json,
+        # not agents.yaml. Everything else (model, budget, thinking,
+        # instructions, soul, ...) reads from the agent's YAML row.
         if field == "heartbeat_schedule":
             old_value = ""
             if cron_scheduler is not None:
                 hb_job = cron_scheduler.find_heartbeat_job(agent_id)
                 if hb_job is not None:
                     old_value = hb_job.schedule
+        elif field == "permissions":
+            from src.cli.config import _load_permissions
+            perms = _load_permissions()
+            old_value = perms.get("permissions", {}).get(agent_id, {})
         else:
             yaml_key = _CONFIG_FIELD_MAP.get(field, field)
             old_value = agents[agent_id].get(yaml_key, "")
@@ -5445,6 +5472,9 @@ def create_mesh_app(
         # Record the change for undo. Summary uses humanized field names
         # so receipt cards read naturally ("Updated writer's personality")
         # without the dashboard having to do its own field translation.
+        # TTL is field-aware: hard fields (model/permissions/budget/
+        # thinking) get the longer 30-min window so the user has more
+        # time to catch a costly edit; soft fields keep the snappy 5 min.
         summary = f"Updated {agent_id}'s {_humanize_field(field)}"
         record = change_history.record(
             undo_token=undo_token,
@@ -5455,7 +5485,7 @@ def create_mesh_app(
             new_value=new_value,
             summary=summary,
             reason=reason,
-            ttl=_CHANGE_TTL_SECONDS,
+            ttl=_ttl_for_field(field),
         )
 
         # Emit the receipt event. Dashboard listens for this and appends
@@ -5520,6 +5550,8 @@ def create_mesh_app(
             "expires_at": datetime.fromtimestamp(
                 record["expires_at"], tz=timezone.utc,
             ).isoformat(),
+            "ttl_seconds": _ttl_for_field(field),
+            "field_class": "hard" if field in _HARD_EDIT_FIELDS else "soft",
             "summary": summary,
             "supersedes_count": len(prior_unconsumed),
         }

--- a/src/shared/operator_playbooks.py
+++ b/src/shared/operator_playbooks.py
@@ -76,12 +76,20 @@ they're set up for exactly this." Don't explain the architecture.
 Team setup flows: create agents → create project → customize instructions → \
 set up credentials. Each phase has detailed guidance that loads automatically.
 
-To change an agent after setup, use edit_agent(). Soft fields \
-(instructions, soul, heartbeat, interface, role) apply immediately and the \
-user sees a receipt with [Undo] for 5 minutes — act decisively, don't ask. \
-Hard fields (model, budget, permissions, thinking) need explicit \
-confirmation: edit_agent() returns a preview, you show it, user confirms, \
-you call confirm_edit(change_id).
+To change an agent after setup, use edit_agent(). All edits apply \
+IMMEDIATELY and the user sees a receipt with [Undo]. The window is \
+5 minutes for soft fields (instructions, soul, heartbeat, interface, role) \
+and 30 minutes for hard fields (model, permissions, budget, thinking) so \
+the user has more time to catch a costly edit. There is no separate \
+"propose then confirm" step — act decisively, don't ask for permission.
+
+The user's primary feedback is the rating they give on completed work \
+(👍 accept / ➖ acknowledge / 👎 rework). Read every 👎 — the feedback \
+text becomes the brief for the rework task that auto-spawns. Watch for \
+patterns: if one agent racks up multiple reworks in a row, that's a \
+signal to tune its instructions or soul. Surface this proactively: \
+"Writer's last 3 drafts got reworked — want me to tighten its \
+instructions based on the feedback?"
 
 After setup, monitor fleet health and proactively improve agent configurations. \
 When the user engages, surface completed work and any issues worth mentioning.
@@ -91,7 +99,7 @@ When the user engages, surface completed work and any issues worth mentioning.
 After the team's first few tasks, proactively offer a tune-up: "Your team's \
 had a few runs now. Want me to review how they're coordinating and tighten \
 anything that's not working smoothly?" When the user engages, call \
-check_inbox() to surface completed work.
+check_inbox() to surface completed work and read the recent outcome ratings.
 
 ## Tool Errors
 
@@ -259,60 +267,53 @@ Once you know the intent, act decisively.
 
 ## Soft fields — apply immediately
 
-For instructions, soul, heartbeat, interface, role: act on what the user \
-asked for. No "let me show you the diff first." The user sees a receipt \
-card in chat with [View diff] [Undo] and has 5 minutes to revert.
+All fields — soft AND hard — apply IMMEDIATELY via edit_agent(). The \
+user sees a receipt card with [View diff] [Undo]. The undo window is \
+5 minutes for soft fields (instructions, soul, role, heartbeat, \
+interface) and 30 minutes for hard fields (model, permissions, budget, \
+thinking) so the user has more time to catch a costly edit. There is no \
+separate "propose then confirm" step. Don't ask permission.
 
 1. Call edit_agent(agent_id, field, value, reason="user_asked") — applies \
-the change immediately. Returns {success, undo_token, summary}.
+the change immediately. Returns {success, undo_token, expires_at, \
+ttl_seconds, field_class, summary}.
 
 2. Tell the user briefly what you did, in business terms. Example: "Tuned \
 @writer toward short-form social posts" — not "Updated instructions field." \
 Mention they have an Undo button if it doesn't land right.
 
 3. Instructions and heartbeat changes take effect on the agent's next task \
-or heartbeat cycle.
+or heartbeat cycle. Model / permissions / budget / thinking hot-reload \
+immediately on the running agent (or land on next start if it's offline).
 
 If the user asks to revert immediately, call undo_change(undo_token).
-
-## Hard fields — preview, then confirm
-
-For model, budget, permissions, thinking: these are too consequential to \
-auto-apply. The flow is two-step:
-
-1. Call edit_agent(agent_id, field, value, reason="user_asked") — returns \
-{change_id, preview_diff, requires_confirmation: true}.
-
-2. Show the preview to the user in business terms. Example: "Switching \
-@writer from gpt-4o-mini to claude-sonnet — slower but better quality on \
-long pieces." Wait for explicit confirmation.
-
-3. On confirmation, call confirm_edit(change_id) to apply.
 
 ## Reason field
 
 Always pass `reason`: "user_asked" when responding to a direct request, \
 "operator_proactive" when you noticed an improvement on your own. The \
-audit trail uses this. Proactive soft edits still apply immediately — the \
+audit trail uses this. Proactive edits still apply immediately — the \
 receipt + undo is the safety net — but the user sees that you initiated it.
 
 ## Field reference
 
-- instructions, soul, role, heartbeat, interface (soft) — string
-- model (hard) — string, e.g. "anthropic/claude-sonnet-4-20250514"
-- thinking (hard) — one of "off", "low", "medium", "high"
-- budget (hard) — object: {"daily_usd": float, "monthly_usd": float}
-- permissions (hard) — object: {"can_use_browser": bool, ...}
+- instructions, soul, role, heartbeat, interface (soft, 5min undo) — string
+- model (hard, 30min undo) — string, e.g. "anthropic/claude-sonnet-4-20250514"
+- thinking (hard, 30min undo) — one of "off", "low", "medium", "high"
+- budget (hard, 30min undo) — object: {"daily_usd": float, "monthly_usd": float}
+- permissions (hard, 30min undo) — object: {"can_use_browser": bool, ...}
+
+## Deprecated
+
+`propose_edit` and `confirm_edit` are deprecated no-op shims. `propose_edit` \
+routes through edit_agent (immediate-apply). `confirm_edit` is a no-op. \
+Don't call either from new conversations — use edit_agent directly.
 
 ## Self-cleanup
 
-If a pending action is stale or no longer wanted, call \
-cancel_pending_action(nonce) to clear it before TTL — soft-edit \
-receipts on the Board collapse to "N actions awaiting you" when 2+ \
-pile up, so prune the ones you abandoned. To trim old audit history, \
-call archive_audit_before(date) (soft-delete; recoverable). Your own \
-SOUL.md and INSTRUCTIONS.md are visible from the dashboard System tab \
-for review."""
+To trim old audit history, call archive_audit_before(date) (soft-delete; \
+recoverable). Your own SOUL.md and INSTRUCTIONS.md are visible from the \
+dashboard System tab for review."""
 
 _PLAYBOOK_MONITOR = """\
 ## Active Playbook: Fleet Monitoring & Improvement
@@ -332,10 +333,11 @@ inspect_agents(agent_id, depth="history") for details.
 producing useful output? Is the team shape still right for what the user \
 needs? If not, propose adjustments.
 
-5. For specific fixes, use edit_agent(): instructions / soul / heartbeat / \
-interface / role apply immediately with an Undo card; model / budget / \
-permissions / thinking return a preview that you must show the user before \
-calling confirm_edit().
+5. For specific fixes, use edit_agent() directly — all fields apply \
+immediately with a receipt card + Undo (5min for soft fields, 30min for \
+hard fields). Act decisively. If patterns of 👎 rework on a particular \
+agent suggest its instructions are off, draft and apply the fix without \
+asking — the user can Undo if you got it wrong.
 
 6. If everything is green, tell the user in one line.
 
@@ -426,14 +428,12 @@ _TOOL_PLAYBOOK_MAP: dict[str, str] = {
     "set_project_goal": "team_build",
     "edit_agent": "edit",
     "undo_change": "edit",
-    # ``propose_edit`` intentionally omitted — the legacy two-step flow
-    # was retired in PR #839 in favor of ``edit_agent`` (act-and-undo
-    # for soft fields, preview-then-confirm for hard fields). The skill
-    # is still registered in operator_tools.py for back-compat with any
-    # caller invoking it via mesh, but the operator's allowed-tools
-    # list and playbook map both advertise only the new flow so the LLM
-    # picks one path.
-    "confirm_edit": "edit",
+    # ``propose_edit`` / ``confirm_edit`` retired as gated flows — they
+    # remain registered in operator_tools.py as deprecated stubs (apply-
+    # immediately for back-compat with any in-flight LLM conversations
+    # that already mentioned them), but the operator's allowed-tools
+    # list and playbook map both advertise only ``edit_agent`` so the
+    # model picks one path.
     "save_observations": "monitor",
     "request_credential": "credentials",
     "request_browser_login": "credentials",

--- a/tests/test_dashboard_notifications.py
+++ b/tests/test_dashboard_notifications.py
@@ -342,34 +342,84 @@ class TestNotificationsProducerWiring:
         _teardown(self.components)
         shutil.rmtree(self._tmpdir, ignore_errors=True)
 
-    def test_task_outcome_delivered_creates_notification(self):
-        self.bus.emit("task_outcome", agent="operator", data={
+    def test_task_status_changed_to_done_creates_delivered_notification(self):
+        """Worker finishes a task (status->done, outcome=NULL): bell
+        pings with kind=delivered so the user knows there's new work
+        to review. This replaces the legacy outcome=='delivered' path
+        which never fired because 'delivered' was never a valid
+        outcome value.
+        """
+        self.bus.emit("task_status_changed", agent="writer", data={
             "task_id": "t-1",
             "project_id": "proj-a",
             "assignee": "writer",
-            "status": "done",
-            "outcome": "delivered",
-            "feedback": "Looks good",
+            "old_status": "working",
+            "new_status": "done",
+            "title": "Q3 launch brief draft",
+            "outcome": None,
         })
         rows = self.store.list_recent()
         assert len(rows) == 1
         row = rows[0]
         assert row["kind"] == "delivered"
         assert "writer" in row["title"]
-        assert "delivered" in row["title"].lower()
+        assert "Q3 launch brief" in row["title"]
         assert row["payload"]["task_id"] == "t-1"
+        assert row["payload"]["assignee"] == "writer"
 
-    def test_task_outcome_rejected_does_not_create_delivery_notification(self):
-        # Only "delivered" outcomes surface — rejection / rework / re-rate
-        # are operator-initiated and surface elsewhere (task drawer).
+    def test_task_status_changed_skips_operator_self_delivery(self):
+        """Operator-self transitions don't ping — the operator IS the
+        user's surface; it doesn't deliver TO the user."""
+        self.bus.emit("task_status_changed", agent="operator", data={
+            "task_id": "t-op",
+            "assignee": "operator",
+            "old_status": "working",
+            "new_status": "done",
+            "title": "operator-self maintenance",
+        })
+        assert self.store.list_recent() == []
+
+    def test_task_status_changed_skips_already_rated(self):
+        """An auto-graded or pre-rated transition doesn't fire a fresh
+        notification — the rating already represents review."""
+        self.bus.emit("task_status_changed", agent="writer", data={
+            "task_id": "t-auto",
+            "assignee": "writer",
+            "old_status": "working",
+            "new_status": "done",
+            "title": "auto-rated delivery",
+            "outcome": "accepted",
+        })
+        assert self.store.list_recent() == []
+
+    def test_task_status_changed_non_done_transition_no_notification(self):
+        self.bus.emit("task_status_changed", agent="writer", data={
+            "task_id": "t-block",
+            "assignee": "writer",
+            "old_status": "working",
+            "new_status": "blocked",
+            "title": "still in flight",
+        })
+        assert self.store.list_recent() == []
+
+    def test_task_outcome_does_not_create_notification(self):
+        """task_outcome events no longer create bell entries — the
+        delivery already pinged when the worker finished. Re-rates,
+        rejections, etc. update the UI via direct WebSocket listeners,
+        not via a fresh notification row."""
         self.bus.emit("task_outcome", agent="operator", data={
-            "task_id": "t-2",
-            "outcome": "rejected",
+            "task_id": "t-r1",
+            "outcome": "rework",
             "assignee": "writer",
         })
         self.bus.emit("task_outcome", agent="operator", data={
-            "task_id": "t-3",
-            "outcome": "needs_rework",
+            "task_id": "t-r2",
+            "outcome": "accepted",
+            "assignee": "writer",
+        })
+        self.bus.emit("task_outcome", agent="operator", data={
+            "task_id": "t-r3",
+            "outcome": "acknowledged",
             "assignee": "writer",
         })
         assert self.store.list_recent() == []
@@ -490,12 +540,13 @@ class TestNotificationsProducerEmitsLiveEvent:
     def _added_events(self) -> list[dict]:
         return [e for e in self.captured if e["type"] == "notification_added"]
 
-    def test_task_outcome_delivered_emits_notification_added(self):
-        self.bus.emit("task_outcome", agent="operator", data={
+    def test_task_status_changed_to_done_emits_notification_added(self):
+        self.bus.emit("task_status_changed", agent="writer", data={
             "task_id": "t-1",
             "assignee": "writer",
-            "outcome": "delivered",
-            "feedback": "Great work",
+            "old_status": "working",
+            "new_status": "done",
+            "title": "Great brief",
         })
         added = self._added_events()
         assert len(added) == 1
@@ -573,19 +624,21 @@ class TestNotificationsProducerEmitsLiveEvent:
     # producer branch should pass the SAME payload it persisted to the
     # store through into ``_emit_notification_added``.
 
-    def test_task_outcome_delivered_emit_carries_payload(self):
-        self.bus.emit("task_outcome", agent="operator", data={
+    def test_task_status_changed_done_emit_carries_payload(self):
+        self.bus.emit("task_status_changed", agent="writer", data={
             "task_id": "t-1",
             "project_id": "proj-a",
             "assignee": "writer",
-            "outcome": "delivered",
+            "old_status": "working",
+            "new_status": "done",
+            "title": "Q3 brief",
         })
         added = self._added_events()
         assert len(added) == 1
         payload = added[0]["data"].get("payload") or {}
         assert payload.get("task_id") == "t-1"
         assert payload.get("project_id") == "proj-a"
-        assert payload.get("outcome") == "delivered"
+        assert payload.get("assignee") == "writer"
 
     def test_pending_action_created_emit_carries_payload(self):
         self.bus.emit("pending_action_created", agent="operator", data={

--- a/tests/test_edit_soft_endpoint.py
+++ b/tests/test_edit_soft_endpoint.py
@@ -117,8 +117,12 @@ async def test_edit_soft_happy_path_writes_yaml_and_returns_undo(mesh_app):
 
 
 @pytest.mark.asyncio
-async def test_edit_soft_rejects_hard_field(mesh_app):
-    """model is a hard field — must 400 with 'use propose-edit'."""
+async def test_edit_soft_accepts_hard_field_model_with_30min_ttl(mesh_app):
+    """Hard fields (model/permissions/budget/thinking) now apply
+    immediately via /edit-soft and emit a receipt with a 30-min undo
+    window. The propose+confirm gate was retired in favor of "all
+    edits apply immediately, undo is the safety net".
+    """
     app, _, _ = mesh_app
     async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
         r = await c.post(
@@ -126,8 +130,78 @@ async def test_edit_soft_rejects_hard_field(mesh_app):
             json={"field": "model", "value": "anthropic/claude-haiku", "reason": "user_asked"},
             headers=_human_origin_headers(),
         )
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["success"] is True
+    assert body["agent_id"] == "writer"
+    assert body["field"] == "model"
+    assert body["undo_token"]
+    # 30-minute TTL on the receipt for hard fields.
+    assert body["ttl_seconds"] == 1800
+    assert body["field_class"] == "hard"
+
+
+@pytest.mark.asyncio
+async def test_edit_soft_accepts_hard_field_permissions(mesh_app):
+    """Permissions edits apply immediately with a 30-min undo window."""
+    app, _, _ = mesh_app
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
+        r = await c.post(
+            "/mesh/agents/writer/edit-soft",
+            json={
+                "field": "permissions",
+                "value": {"can_use_browser": True},
+                "reason": "user_asked",
+            },
+            headers=_human_origin_headers(),
+        )
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["field_class"] == "hard"
+    assert body["ttl_seconds"] == 1800
+    assert body["undo_token"]
+
+
+@pytest.mark.asyncio
+async def test_edit_soft_soft_field_keeps_5min_ttl(mesh_app):
+    """Soft fields keep the snappy 5-minute undo window."""
+    app, _, _ = mesh_app
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
+        r = await c.post(
+            "/mesh/agents/writer/edit-soft",
+            json={"field": "instructions", "value": "# tightened", "reason": "user_asked"},
+            headers=_human_origin_headers(),
+        )
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["field_class"] == "soft"
+    assert body["ttl_seconds"] == 300
+
+
+@pytest.mark.asyncio
+async def test_edit_soft_rejects_invalid_model_value(mesh_app):
+    """Validation still runs — empty model rejected with 400."""
+    app, _, _ = mesh_app
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
+        r = await c.post(
+            "/mesh/agents/writer/edit-soft",
+            json={"field": "model", "value": "", "reason": "user_asked"},
+            headers=_human_origin_headers(),
+        )
     assert r.status_code == 400
-    assert "propose" in r.text.lower()
+    assert "model" in r.text.lower()
+
+
+@pytest.mark.asyncio
+async def test_edit_soft_rejects_invalid_thinking_value(mesh_app):
+    app, _, _ = mesh_app
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
+        r = await c.post(
+            "/mesh/agents/writer/edit-soft",
+            json={"field": "thinking", "value": "ultra", "reason": "user_asked"},
+            headers=_human_origin_headers(),
+        )
+    assert r.status_code == 400
 
 
 @pytest.mark.asyncio

--- a/tests/test_edit_soft_endpoint.py
+++ b/tests/test_edit_soft_endpoint.py
@@ -321,6 +321,69 @@ async def test_edit_soft_emits_receipt_event(mesh_app):
 
 
 @pytest.mark.asyncio
+async def test_edit_soft_hard_field_emits_agent_config_updated(
+    mesh_app, monkeypatch,
+):
+    """Hard-field edits MUST also emit ``agent_config_updated`` so the
+    dashboard's agent config card flips to the new value live. Soft
+    fields are covered by ``operator_action_receipt``; hard fields fire
+    BOTH events (receipt for chat-card rendering + config_updated for
+    the SPA's agent-detail panel). ``live`` reports whether the
+    agent-side hot-reload (model / thinking) succeeded — True here
+    because no agent container is registered with the test mesh, so the
+    push-to-agent branch is skipped and ``hot_reload_ok`` stays True.
+    """
+    app, server_module, tmp_path = mesh_app
+    events: list[tuple[str, str, dict]] = []
+
+    class _Bus:
+        def emit(self, event_type, agent="", data=None):
+            events.append((event_type, agent, data))
+
+    blackboard = Blackboard(str(tmp_path / "bb_cfg.db"))
+    pubsub = PubSub()
+    permissions = PermissionMatrix()
+    permissions.permissions["operator"] = AgentPermissions(
+        agent_id="operator", can_route_tasks=True,
+    )
+    router = MessageRouter(permissions, {})
+    bus = _Bus()
+    app2 = server_module.create_mesh_app(
+        blackboard=blackboard,
+        pubsub=pubsub,
+        router=router,
+        permissions=permissions,
+        event_bus=bus,
+    )
+    try:
+        async with AsyncClient(transport=ASGITransport(app=app2), base_url="http://t") as c:
+            r = await c.post(
+                "/mesh/agents/writer/edit-soft",
+                json={
+                    "field": "permissions",
+                    "value": {"can_use_browser": True},
+                    "reason": "user_asked",
+                },
+                headers=_human_origin_headers(),
+            )
+        assert r.status_code == 200, r.text
+        cfg_events = [e for e in events if e[0] == "agent_config_updated"]
+        assert len(cfg_events) == 1
+        _, agent, data = cfg_events[0]
+        assert agent == "writer"
+        assert data["agent_id"] == "writer"
+        assert data["field"] == "permissions"
+        # No new_value on the wire — permissions diffs are sensitive.
+        assert "new_value" not in data and "old_value" not in data
+        # ``live`` reports hot-reload status. No agent registered, so
+        # the push-to-agent branch is skipped and ``hot_reload_ok``
+        # stays True (default for fields without an agent-side reload).
+        assert data["live"] is True
+    finally:
+        blackboard.close()
+
+
+@pytest.mark.asyncio
 async def test_edit_soft_supersede_emits_marker_for_prior_receipts(mesh_app):
     """A second soft-edit on the same field must mark the prior receipt
     as superseded so the dashboard can warn the operator before they

--- a/tests/test_operator_playbooks.py
+++ b/tests/test_operator_playbooks.py
@@ -120,8 +120,9 @@ class TestPlaybookConstants:
 
     def test_core_size_reasonable(self):
         # Core should be significantly smaller than old monolithic instructions (7800 chars).
-        # Bumped 5000 → 5200 to accommodate hand_off title-quality guidance.
-        assert len(_OPERATOR_CORE) < 5200
+        # Bumped 5200 → 6000 to accommodate the autonomous-by-default
+        # frame copy (immediate-apply edits, ratings-as-feedback guidance).
+        assert len(_OPERATOR_CORE) < 6000
         assert len(_OPERATOR_CORE) > 1000
 
     def test_playbooks_have_numbered_steps(self):
@@ -134,18 +135,18 @@ class TestPlaybookConstants:
             assert "1." in content, f"{name} should have numbered steps"
 
     def test_tool_map_covers_all_action_tools(self):
-        # PR 0 consolidation dropped read_agent_history. PR 5 added
-        # set_project_goal. PR 1 added edit_agent + undo_change to the
-        # edit playbook. The PR-F production-safety pass dropped
-        # propose_edit (legacy two-step retired in PR #839) so the
-        # operator's playbook map advertises only the new edit_agent
-        # flow; confirm_edit remains mapped as the hard-field follow-up.
+        # The approval-workflow redesign dropped both propose_edit and
+        # confirm_edit from the playbook map: edit_agent is the single
+        # immediate-apply path (5-min undo for soft fields, 30-min for
+        # hard). propose_edit/confirm_edit remain registered as
+        # deprecation stubs in operator_tools.py for back-compat, but
+        # the playbook map only advertises the new flow so the LLM
+        # picks one path.
         expected_tools = {
             "create_agent", "apply_template", "create_project",
             "add_agents_to_project", "remove_agents_from_project",
             "update_project_context", "set_project_goal",
             "edit_agent", "undo_change",
-            "confirm_edit",
             "save_observations",
             "request_credential", "request_browser_login",
         }

--- a/tests/test_operator_product_tools.py
+++ b/tests/test_operator_product_tools.py
@@ -309,12 +309,17 @@ async def test_manage_task_retry_over_budget(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_manage_project_archive_provenance_required():
+async def test_manage_project_archive_autonomous_allowed():
+    """The provenance gate was dropped — operator can archive a project
+    autonomously (e.g. during heartbeat). The "undo" comes from
+    archive being reversible via the dedicated unarchive endpoint."""
     from src.agent.builtins.operator_tools import manage_project
+    mc = MagicMock()
+    mc.archive_project = AsyncMock(return_value={"archived": True, "project": "p1"})
     messages = [{"role": "user", "content": "x", "_origin": "system:heartbeat"}]
     result = await manage_project("p1", "archive",
-                                    mesh_client=MagicMock(), _messages=messages)
-    assert result["error"] == "provenance_check_failed"
+                                    mesh_client=mc, _messages=messages)
+    assert result["archived"] is True
 
 
 @pytest.mark.asyncio
@@ -368,12 +373,24 @@ async def test_manage_project_delete_returns_nonce_for_confirmation():
 
 
 @pytest.mark.asyncio
-async def test_manage_project_delete_provenance_required():
+async def test_manage_project_delete_autonomous_allowed():
+    """Delete provenance gate was dropped at the operator-tool layer.
+    Delete still has a mesh-side confirmation TTL window so the brief
+    Confirm step in the dashboard remains; that's tested separately by
+    the propose-delete endpoint tests. The operator-tool itself just
+    forwards the call without checking message origin."""
     from src.agent.builtins.operator_tools import manage_project
+    mc = MagicMock()
+    mc.propose_delete_project = AsyncMock(return_value={
+        "change_id": "n1",
+        "summary": "Delete project 'growth'",
+        "requires_confirmation": True,
+    })
     messages = [{"role": "user", "content": "hb", "_origin": "system:heartbeat"}]
     result = await manage_project("growth", "delete",
-                                    mesh_client=MagicMock(), _messages=messages)
-    assert result["error"] == "provenance_check_failed"
+                                    mesh_client=mc, _messages=messages)
+    assert result["change_id"] == "n1"
+    assert result["requires_confirmation"] is True
 
 
 @pytest.mark.asyncio

--- a/tests/test_operator_tools.py
+++ b/tests/test_operator_tools.py
@@ -47,21 +47,30 @@ async def test_propose_edit_validates_field():
 
 @pytest.mark.asyncio
 async def test_propose_edit_accepts_interface_field():
-    """The 'interface' field should be valid and forwarded to the mesh."""
+    """The 'interface' field should be valid and forwarded to the mesh via edit_soft."""
     from src.agent.builtins.operator_tools import propose_edit
 
     mc = MagicMock()
-    mc.propose_config_change = AsyncMock(
-        return_value={"change_id": "iface1", "preview_diff": "..."},
+    mc.edit_soft = AsyncMock(
+        return_value={
+            "success": True,
+            "undo_token": "tok-iface",
+            "expires_at": "2026-05-13T00:05:00+00:00",
+            "ttl_seconds": 300,
+            "field_class": "soft",
+            "summary": "Updated writer's interface",
+        },
     )
     result = await propose_edit(
         "writer", "interface", "Accepts research, produces notes.",
         mesh_client=mc,
     )
     assert "error" not in result
-    assert result["change_id"] == "iface1"
-    mc.propose_config_change.assert_awaited_once_with(
-        "writer", "interface", "Accepts research, produces notes.",
+    assert result["applied"] is True
+    assert result["undo_token"] == "tok-iface"
+    assert "deprecation_notice" in result
+    mc.edit_soft.assert_awaited_once_with(
+        "writer", "interface", "Accepts research, produces notes.", "user_asked",
     )
 
 
@@ -89,19 +98,28 @@ async def test_propose_edit_permission_ceiling_can_use_wallet():
 
 @pytest.mark.asyncio
 async def test_propose_edit_permission_ceiling_allows_permitted():
-    """Permissions within the ceiling should pass through to mesh."""
+    """Permissions within the ceiling should pass through to mesh via edit_soft (hard field)."""
     from src.agent.builtins.operator_tools import propose_edit
 
     mc = MagicMock()
-    mc.propose_config_change = AsyncMock(
-        return_value={"change_id": "abc", "preview_diff": "..."},
+    mc.edit_soft = AsyncMock(
+        return_value={
+            "success": True,
+            "undo_token": "tok-perm",
+            "expires_at": "2026-05-13T00:30:00+00:00",
+            "ttl_seconds": 1800,
+            "field_class": "hard",
+            "summary": "Updated writer's permissions",
+        },
     )
     result = await propose_edit(
         "writer", "permissions", {"can_use_browser": True}, mesh_client=mc,
     )
-    assert result["change_id"] == "abc"
-    mc.propose_config_change.assert_awaited_once_with(
-        "writer", "permissions", {"can_use_browser": True},
+    assert "error" not in result
+    assert result["applied"] is True
+    assert result["undo_token"] == "tok-perm"
+    mc.edit_soft.assert_awaited_once_with(
+        "writer", "permissions", {"can_use_browser": True}, "user_asked",
     )
 
 
@@ -113,17 +131,25 @@ async def test_propose_edit_permission_ceiling_allows_artifacts_write():
     from src.agent.builtins.operator_tools import propose_edit
 
     mc = MagicMock()
-    mc.propose_config_change = AsyncMock(
-        return_value={"change_id": "art1", "preview_diff": "..."},
+    mc.edit_soft = AsyncMock(
+        return_value={
+            "success": True,
+            "undo_token": "tok-art",
+            "expires_at": "2026-05-13T00:30:00+00:00",
+            "ttl_seconds": 1800,
+            "field_class": "hard",
+            "summary": "Updated writer's permissions",
+        },
     )
     result = await propose_edit(
         "writer", "permissions", {"blackboard_write": ["artifacts/*"]},
         mesh_client=mc,
     )
     assert "error" not in result
-    assert result["change_id"] == "art1"
-    mc.propose_config_change.assert_awaited_once_with(
-        "writer", "permissions", {"blackboard_write": ["artifacts/*"]},
+    assert result["applied"] is True
+    assert result["undo_token"] == "tok-art"
+    mc.edit_soft.assert_awaited_once_with(
+        "writer", "permissions", {"blackboard_write": ["artifacts/*"]}, "user_asked",
     )
 
 
@@ -180,14 +206,25 @@ async def test_propose_edit_budget_valid():
     from src.agent.builtins.operator_tools import propose_edit
 
     mc = MagicMock()
-    mc.propose_config_change = AsyncMock(
-        return_value={"change_id": "b1", "preview_diff": "budget diff"},
+    mc.edit_soft = AsyncMock(
+        return_value={
+            "success": True,
+            "undo_token": "tok-b1",
+            "expires_at": "2026-05-13T00:30:00+00:00",
+            "ttl_seconds": 1800,
+            "field_class": "hard",
+            "summary": "Updated writer's budget",
+        },
     )
     result = await propose_edit(
         "writer", "budget", {"daily_usd": 5, "monthly_usd": 100},
         mesh_client=mc,
     )
-    assert result["change_id"] == "b1"
+    assert result["applied"] is True
+    assert result["undo_token"] == "tok-b1"
+    mc.edit_soft.assert_awaited_once_with(
+        "writer", "budget", {"daily_usd": 5, "monthly_usd": 100}, "user_asked",
+    )
 
 
 @pytest.mark.asyncio
@@ -206,25 +243,48 @@ async def test_propose_edit_thinking_valid():
     from src.agent.builtins.operator_tools import propose_edit
 
     mc = MagicMock()
-    mc.propose_config_change = AsyncMock(
-        return_value={"change_id": "t1", "preview_diff": "..."},
+    mc.edit_soft = AsyncMock(
+        return_value={
+            "success": True,
+            "undo_token": "tok-t1",
+            "expires_at": "2026-05-13T00:30:00+00:00",
+            "ttl_seconds": 1800,
+            "field_class": "hard",
+            "summary": "Updated writer's thinking",
+        },
     )
     result = await propose_edit(
         "writer", "thinking", "high", mesh_client=mc,
     )
-    assert result["change_id"] == "t1"
+    assert result["applied"] is True
+    assert result["undo_token"] == "tok-t1"
 
 
 @pytest.mark.asyncio
 async def test_propose_edit_success():
+    """propose_edit now applies immediately via edit_soft and emits a deprecation notice."""
     from src.agent.builtins.operator_tools import propose_edit
 
     mc = MagicMock()
-    mc.propose_config_change = AsyncMock(
-        return_value={"change_id": "abc", "preview_diff": "..."},
+    mc.edit_soft = AsyncMock(
+        return_value={
+            "success": True,
+            "undo_token": "tok-abc",
+            "expires_at": "2026-05-13T00:05:00+00:00",
+            "ttl_seconds": 300,
+            "field_class": "soft",
+            "summary": "Updated writer's instructions",
+        },
     )
     result = await propose_edit("writer", "instructions", "new text", mesh_client=mc)
-    assert result["change_id"] == "abc"
+    assert result["applied"] is True
+    assert result["undo_token"] == "tok-abc"
+    assert result["field_class"] == "soft"
+    assert result["ttl_seconds"] == 300
+    assert "deprecation_notice" in result
+    mc.edit_soft.assert_awaited_once_with(
+        "writer", "instructions", "new text", "user_asked",
+    )
 
 
 @pytest.mark.asyncio
@@ -241,91 +301,45 @@ async def test_propose_edit_mesh_error():
     from src.agent.builtins.operator_tools import propose_edit
 
     mc = MagicMock()
-    mc.propose_config_change = AsyncMock(side_effect=RuntimeError("connection refused"))
+    mc.edit_soft = AsyncMock(side_effect=RuntimeError("connection refused"))
     result = await propose_edit("writer", "instructions", "new text", mesh_client=mc)
     assert "error" in result
     assert "connection refused" in result["error"]
 
 
 @pytest.mark.asyncio
-async def test_confirm_edit_provenance_rejection():
-    from src.agent.builtins.operator_tools import confirm_edit
-
-    messages = [{"role": "user", "content": "check", "_origin": "system:heartbeat"}]
-    result = await confirm_edit("abc", mesh_client=MagicMock(), _messages=messages)
-    assert result["error"] == "provenance_check_failed"
-    assert "detail" in result
-
-
-@pytest.mark.asyncio
-async def test_confirm_edit_success_with_user_origin():
+async def test_confirm_edit_is_deprecated_noop():
+    """confirm_edit is now a no-op deprecation stub — returns applied=False
+    with a deprecation_notice regardless of arguments. The legacy provenance
+    gate has been removed (config edits now apply immediately via edit_agent
+    with a built-in undo receipt, so there is nothing to confirm)."""
     from src.agent.builtins.operator_tools import confirm_edit
 
     mc = MagicMock()
-    mc.confirm_config_change = AsyncMock(return_value={"success": True})
-    messages = [{"role": "user", "content": "yes do it", "_origin": "user"}]
-    result = await confirm_edit("abc", mesh_client=mc, _messages=messages)
-    assert result["success"] is True
-
-
-@pytest.mark.asyncio
-async def test_confirm_edit_success_no_origin_legacy():
-    """Messages without _origin should be treated as user-originated."""
-    from src.agent.builtins.operator_tools import confirm_edit
-
-    mc = MagicMock()
-    mc.confirm_config_change = AsyncMock(return_value={"success": True})
-    messages = [{"role": "user", "content": "yes"}]
-    result = await confirm_edit("abc", mesh_client=mc, _messages=messages)
-    assert result["success"] is True
-
-
-@pytest.mark.asyncio
-async def test_confirm_edit_no_mesh_client():
-    from src.agent.builtins.operator_tools import confirm_edit
-
-    result = await confirm_edit("abc")
-    assert "error" in result
-    assert "mesh_client" in result["error"].lower()
-
-
-@pytest.mark.asyncio
-async def test_confirm_edit_no_messages_fails_closed():
-    """When _messages is None, provenance fails closed (security: no bypass via cron/invoke)."""
-    from src.agent.builtins.operator_tools import confirm_edit
-
-    mc = MagicMock()
-    mc.confirm_config_change = AsyncMock(return_value={"success": True})
+    mc.confirm_config_change = AsyncMock()  # should NEVER be called
     result = await confirm_edit("abc", mesh_client=mc, _messages=None)
-    assert result["error"] == "provenance_check_failed"
+    assert result["success"] is True
+    assert result["applied"] is False
+    notice = result["deprecation_notice"].lower()
+    assert "no-op" in notice or "deprecat" in notice
+    mc.confirm_config_change.assert_not_awaited()
 
 
 @pytest.mark.asyncio
-async def test_confirm_edit_not_found_error():
+async def test_confirm_edit_deprecation_notice_regardless_of_messages():
+    """confirm_edit no-ops the same way whether or not _messages is set
+    (no provenance check anymore)."""
     from src.agent.builtins.operator_tools import confirm_edit
 
     mc = MagicMock()
-    mc.confirm_config_change = AsyncMock(
-        side_effect=RuntimeError("404 not found"),
-    )
+    mc.confirm_config_change = AsyncMock()
     messages = [{"role": "user", "content": "yes", "_origin": "user"}]
     result = await confirm_edit("abc", mesh_client=mc, _messages=messages)
-    assert result["error"] == "change_expired_or_lost"
-    assert "propose_edit" in result["detail"]
-
-
-@pytest.mark.asyncio
-async def test_confirm_edit_generic_error():
-    from src.agent.builtins.operator_tools import confirm_edit
-
-    mc = MagicMock()
-    mc.confirm_config_change = AsyncMock(
-        side_effect=RuntimeError("server exploded"),
-    )
-    messages = [{"role": "user", "content": "yes", "_origin": "user"}]
-    result = await confirm_edit("abc", mesh_client=mc, _messages=messages)
-    assert "error" in result
-    assert "server exploded" in result["error"]
+    assert result["success"] is True
+    assert result["applied"] is False
+    notice = result["deprecation_notice"].lower()
+    assert "no-op" in notice or "deprecat" in notice
+    mc.confirm_config_change.assert_not_awaited()
 
 
 # ── _last_message_is_user_origin tests ────────────────────
@@ -779,15 +793,22 @@ async def test_create_agent_no_mesh_client():
 
 
 @pytest.mark.asyncio
-async def test_create_agent_provenance_rejected():
+async def test_create_agent_no_provenance_is_accepted():
+    """Provenance gate dropped — create_agent now goes straight through to
+    the mesh whether or not _messages carries a user-origin message."""
     from src.agent.builtins.operator_tools import create_agent
 
-    messages = [{"role": "user", "content": "heartbeat", "_origin": "system:heartbeat"}]
+    mc = MagicMock()
+    mc.create_custom_agent = AsyncMock(
+        return_value={"created": True, "agent": "mybot"},
+    )
+    # No _messages at all — previously a hard reject; now a happy path.
     result = await create_agent(
         "mybot", "helper", "do things",
-        mesh_client=MagicMock(), _messages=messages,
+        mesh_client=mc, _messages=None,
     )
-    assert result["error"] == "provenance_check_failed"
+    assert result["created"] is True
+    mc.create_custom_agent.assert_awaited_once()
 
 
 @pytest.mark.asyncio
@@ -825,22 +846,6 @@ async def test_create_agent_conflict():
         mesh_client=mc, _messages=messages,
     )
     assert "already exists" in result["error"]
-
-
-@pytest.mark.asyncio
-async def test_create_agent_no_messages_fails_closed():
-    """When _messages is None, provenance fails closed (security: no bypass via cron/invoke)."""
-    from src.agent.builtins.operator_tools import create_agent
-
-    mc = MagicMock()
-    mc.create_custom_agent = AsyncMock(
-        return_value={"created": True, "agent": "mybot"},
-    )
-    result = await create_agent(
-        "mybot", "helper", "do things",
-        mesh_client=mc, _messages=None,
-    )
-    assert result["error"] == "provenance_check_failed"
 
 
 # ── inspect_projects tests ──────────────────────────────────
@@ -923,15 +928,20 @@ async def test_inspect_projects_named_not_found():
 
 
 @pytest.mark.asyncio
-async def test_create_project_provenance_rejected():
+async def test_create_project_no_provenance_is_accepted():
+    """Provenance gate dropped — create_project now applies immediately."""
     from src.agent.builtins.operator_tools import create_project
 
-    messages = [{"role": "user", "content": "hb", "_origin": "system:heartbeat"}]
+    mc = MagicMock()
+    mc.create_project = AsyncMock(
+        return_value={"created": True, "name": "myproj"},
+    )
     result = await create_project(
         "myproj", "a project",
-        mesh_client=MagicMock(), _messages=messages,
+        mesh_client=mc, _messages=None,
     )
-    assert result["error"] == "provenance_check_failed"
+    assert result["created"] is True
+    mc.create_project.assert_awaited_once()
 
 
 @pytest.mark.asyncio
@@ -955,15 +965,21 @@ async def test_create_project_success():
 
 
 @pytest.mark.asyncio
-async def test_add_agents_to_project_provenance_rejected():
+async def test_add_agents_to_project_no_provenance_is_accepted():
+    """Provenance gate dropped — add_agents_to_project goes through."""
     from src.agent.builtins.operator_tools import add_agents_to_project
 
-    messages = [{"role": "user", "content": "hb", "_origin": "system:heartbeat"}]
+    mc = MagicMock()
+    mc.add_agent_to_project = AsyncMock(
+        return_value={"added": True, "project": "proj", "agent": "a1"},
+    )
     result = await add_agents_to_project(
         "proj", ["a1"],
-        mesh_client=MagicMock(), _messages=messages,
+        mesh_client=mc, _messages=None,
     )
-    assert result["error"] == "provenance_check_failed"
+    assert result["project"] == "proj"
+    assert result["results"][0]["added"] is True
+    mc.add_agent_to_project.assert_awaited_once()
 
 
 @pytest.mark.asyncio
@@ -1007,15 +1023,21 @@ async def test_add_agents_partial_failure():
 
 
 @pytest.mark.asyncio
-async def test_remove_agents_from_project_provenance_rejected():
+async def test_remove_agents_from_project_no_provenance_is_accepted():
+    """Provenance gate dropped — remove_agents_from_project goes through."""
     from src.agent.builtins.operator_tools import remove_agents_from_project
 
-    messages = [{"role": "user", "content": "hb", "_origin": "system:heartbeat"}]
+    mc = MagicMock()
+    mc.remove_agent_from_project = AsyncMock(
+        return_value={"removed": True, "project": "proj", "agent": "a1"},
+    )
     result = await remove_agents_from_project(
         "proj", ["a1"],
-        mesh_client=MagicMock(), _messages=messages,
+        mesh_client=mc, _messages=None,
     )
-    assert result["error"] == "provenance_check_failed"
+    assert result["project"] == "proj"
+    assert result["results"][0]["removed"] is True
+    mc.remove_agent_from_project.assert_awaited_once()
 
 
 @pytest.mark.asyncio
@@ -1039,15 +1061,20 @@ async def test_remove_agents_from_project_success():
 
 
 @pytest.mark.asyncio
-async def test_update_project_context_provenance_rejected():
+async def test_update_project_context_no_provenance_is_accepted():
+    """Provenance gate dropped — update_project_context goes through."""
     from src.agent.builtins.operator_tools import update_project_context
 
-    messages = [{"role": "user", "content": "hb", "_origin": "system:heartbeat"}]
+    mc = MagicMock()
+    mc.update_project_context = AsyncMock(
+        return_value={"updated": True, "project": "proj"},
+    )
     result = await update_project_context(
         "proj", "new context",
-        mesh_client=MagicMock(), _messages=messages,
+        mesh_client=mc, _messages=None,
     )
-    assert result["error"] == "provenance_check_failed"
+    assert result["updated"] is True
+    mc.update_project_context.assert_awaited_once()
 
 
 @pytest.mark.asyncio
@@ -1141,13 +1168,20 @@ async def test_edit_agent_soft_field_proactive_reason_logs_but_applies():
 
 
 @pytest.mark.asyncio
-async def test_edit_agent_hard_field_proposes_with_provenance():
-    """model is a hard field — must call propose_config_change AFTER provenance."""
+async def test_edit_agent_hard_field_applies_immediately():
+    """Hard fields now apply IMMEDIATELY via edit_soft (no propose+confirm,
+    no provenance gate). Field class on the response is "hard" and the
+    undo TTL is 1800s (30 min)."""
     from src.agent.builtins.operator_tools import edit_agent
 
     mc = MagicMock()
-    mc.propose_config_change = AsyncMock(return_value={
-        "change_id": "cid-1", "preview_diff": "...",
+    mc.edit_soft = AsyncMock(return_value={
+        "success": True,
+        "undo_token": "tok-hard",
+        "expires_at": "2026-05-13T00:30:00+00:00",
+        "ttl_seconds": 1800,
+        "field_class": "hard",
+        "summary": "Updated writer's model",
     })
     messages = [{"role": "user", "content": "switch to opus", "_origin": "user"}]
     result = await edit_agent(
@@ -1155,25 +1189,37 @@ async def test_edit_agent_hard_field_proposes_with_provenance():
         reason="user_asked",
         mesh_client=mc, _messages=messages,
     )
-    assert result["change_id"] == "cid-1"
-    assert result["requires_confirmation"] is True
-    assert "next_step" in result
-    mc.propose_config_change.assert_awaited_once()
+    assert result["success"] is True
+    assert result["applied"] is True
+    assert result["field_class"] == "hard"
+    assert result["ttl_seconds"] == 1800
+    assert result["undo_token"] == "tok-hard"
+    mc.edit_soft.assert_awaited_once_with(
+        "writer", "model", "anthropic/claude-opus-4", "user_asked",
+    )
 
 
 @pytest.mark.asyncio
-async def test_edit_agent_hard_field_no_provenance_fails():
-    """Hard fields keep the provenance gate — no user message → error."""
+async def test_edit_agent_hard_field_no_provenance_still_applies():
+    """Hard fields no longer require provenance — _messages=None works."""
     from src.agent.builtins.operator_tools import edit_agent
 
     mc = MagicMock()
-    mc.propose_config_change = AsyncMock(return_value={"change_id": "x"})
+    mc.edit_soft = AsyncMock(return_value={
+        "success": True,
+        "undo_token": "tok-no-prov",
+        "expires_at": "2026-05-13T00:30:00+00:00",
+        "ttl_seconds": 1800,
+        "field_class": "hard",
+        "summary": "Updated writer's model",
+    })
     result = await edit_agent(
         "writer", "model", "anthropic/claude-opus",
         mesh_client=mc, _messages=None,
     )
-    assert result["error"] == "provenance_check_failed"
-    mc.propose_config_change.assert_not_awaited()
+    assert result["applied"] is True
+    assert result["field_class"] == "hard"
+    mc.edit_soft.assert_awaited_once()
 
 
 @pytest.mark.asyncio
@@ -1393,18 +1439,35 @@ async def test_edit_agent_heartbeat_schedule_blocks_self_modification():
     assert "operator" in result["error"].lower()
 
 
-def test_propose_edit_rejects_heartbeat_schedule_field():
-    """Soft-only field; legacy propose_edit must refuse it."""
+def test_propose_edit_accepts_heartbeat_schedule_via_edit_agent():
+    """Legacy propose_edit now forwards to edit_agent, which DOES accept
+    heartbeat_schedule (a valid soft field). The deprecation shim should
+    not reject it."""
     import asyncio
 
     from src.agent.builtins.operator_tools import propose_edit
 
+    mc = MagicMock()
+    mc.edit_soft = AsyncMock(
+        return_value={
+            "success": True,
+            "undo_token": "tok-hs",
+            "expires_at": "2026-05-13T00:05:00+00:00",
+            "ttl_seconds": 300,
+            "field_class": "soft",
+            "summary": "Updated writer's heartbeat_schedule",
+        },
+    )
     result = asyncio.run(propose_edit(
         "writer", "heartbeat_schedule", "*/15 * * * *",
-        mesh_client=MagicMock(),
+        mesh_client=mc,
     ))
-    assert "error" in result
-    assert "heartbeat_schedule" in result["error"] or "Invalid field" in result["error"]
+    assert "error" not in result
+    assert result["applied"] is True
+    assert "deprecation_notice" in result
+    mc.edit_soft.assert_awaited_once_with(
+        "writer", "heartbeat_schedule", "*/15 * * * *", "user_asked",
+    )
 
 
 # ── list_pending ─────────────────────────────────────────────

--- a/tests/test_orchestration.py
+++ b/tests/test_orchestration.py
@@ -798,6 +798,26 @@ def test_event_bus_unset_disables_emit(tmp_path):
     assert captured == []
 
 
+def test_task_status_changed_payload_carries_title_and_outcome(tmp_path):
+    """The ``task_status_changed`` payload is enriched with ``title`` and
+    ``outcome`` so downstream consumers (the dashboard delivered-
+    notification producer, the activity feed) don't need a follow-up
+    task lookup. ``outcome`` is the row's stored value at read time —
+    ``None`` for never-rated, set for already-rated transitions (the
+    producer uses this to skip pinging the bell on auto-graded work)."""
+    t = _make_store(tmp_path)
+    _bus, captured = _attach_event_bus(t)
+    rec = t.create(
+        creator="scout", assignee="analyst", title="Q3 launch brief",
+    )
+    captured.clear()
+    t.update_status(rec["id"], "accepted", actor="analyst")
+    evt = next(c for c in captured if c[0] == "task_status_changed")
+    assert evt[2]["title"] == "Q3 launch brief"
+    # Never rated yet → outcome is None on the wire.
+    assert evt[2]["outcome"] is None
+
+
 # ── PR 4 — outcome capture + rework spawning ──────────────────────
 
 

--- a/tests/test_workplace_outcome.py
+++ b/tests/test_workplace_outcome.py
@@ -196,6 +196,67 @@ class TestWorkplaceOutcome:
         assert body["task"]["outcome"] == "acknowledged"
         assert "rework_task_id" not in body
 
+    def test_outcome_acknowledged_does_not_spawn_rework(self):
+        """Regression guard: only outcome=='rework' creates a follow-up
+        task. Accept / acknowledged / rejected all stay leaf nodes.
+        Without this we could silently regress to over-spawning when the
+        endpoint logic is touched again."""
+        rec = _create_done_task(
+            self.tasks, creator="op", assignee="analyst",
+            title="research X", project_id="research",
+        )
+        resp = self.client.post(
+            f"/dashboard/api/workplace/tasks/{rec['id']}/outcome",
+            json={"outcome": "acknowledged", "feedback": "noted"},
+        )
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["task"]["outcome"] == "acknowledged"
+        assert "rework_task_id" not in body
+        assert "rework_assignee" not in body
+        # No "Rework: ..." task was persisted (check pending inbox AND
+        # terminal history so we'd see a stray rework either way).
+        rework_titles = [
+            t["title"] for t in self.tasks.list_inbox(
+                "analyst", include_terminal=True,
+            )
+            if t["title"].startswith("Rework: ")
+        ]
+        assert rework_titles == []
+
+    def test_rerate_from_rework_to_acknowledged_leaves_spawned_task(self):
+        """Documents the per-question-2a deferred behavior: re-rating a
+        previously-rework task as 👍 / ➖ does NOT auto-cancel the
+        spawned rework task. The user must cancel it manually. This
+        test exists so a future change that adds auto-cancel breaks
+        this test loudly rather than silently changing semantics.
+        """
+        rec = _create_done_task(
+            self.tasks, creator="op", assignee="analyst", title="t",
+            project_id="research",
+        )
+        # Initial rating: rework — spawns a follow-up task.
+        first = self.client.post(
+            f"/dashboard/api/workplace/tasks/{rec['id']}/outcome",
+            json={"outcome": "rework", "feedback": "tighten the lead"},
+        )
+        assert first.status_code == 200
+        rework_id = first.json().get("rework_task_id")
+        assert rework_id, "first rework rating should spawn a task"
+        # Re-rate as acknowledged — should NOT cancel the spawned task.
+        second = self.client.post(
+            f"/dashboard/api/workplace/tasks/{rec['id']}/outcome",
+            json={"outcome": "acknowledged", "feedback": ""},
+        )
+        assert second.status_code == 200
+        assert second.json()["task"]["outcome"] == "acknowledged"
+        # The previously-spawned rework task is still in the DB and in
+        # a non-terminal state. (Auto-cancel-on-rerate is the deferred
+        # follow-up.)
+        rework_task = self.tasks.get(rework_id)
+        assert rework_task is not None
+        assert rework_task["status"] not in ("cancelled",)
+
     def test_outcome_non_terminal_returns_409(self):
         rec = self.tasks.create(creator="op", assignee="analyst", title="t")
         self.tasks.update_status(rec["id"], "working", actor="analyst")

--- a/tests/test_workplace_outcome.py
+++ b/tests/test_workplace_outcome.py
@@ -178,6 +178,24 @@ class TestWorkplaceOutcome:
         )
         assert resp.status_code == 400
 
+    def test_outcome_acknowledged_no_feedback_allowed(self):
+        """The new 'acknowledged' outcome is the neutral ➖ rating: it
+        records that the user reviewed the work without judgement,
+        accepts an empty feedback string, and does NOT spawn a rework
+        task."""
+        rec = _create_done_task(
+            self.tasks, creator="op", assignee="analyst", title="t",
+        )
+        resp = self.client.post(
+            f"/dashboard/api/workplace/tasks/{rec['id']}/outcome",
+            json={"outcome": "acknowledged", "feedback": ""},
+        )
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        assert body["ok"] is True
+        assert body["task"]["outcome"] == "acknowledged"
+        assert "rework_task_id" not in body
+
     def test_outcome_non_terminal_returns_409(self):
         rec = self.tasks.create(creator="op", assignee="analyst", title="t")
         self.tasks.update_status(rec["id"], "working", actor="analyst")


### PR DESCRIPTION
## Summary

Approving every operator action before it runs was bottlenecking users. This collapses pre-execution gating into post-execution rating wherever the action is reversible, so the user's primary interaction becomes **thumbs-up / neutral / thumbs-down on what was delivered**.

### What's now immediate-apply with an undo receipt

- **Hard-field edits** (model / permissions / budget / thinking) — `/edit-soft` extended to accept the full editable set. Receipt TTL is field-aware: **5 min** for soft fields (instructions/soul/role/heartbeat/heartbeat_schedule/interface), **30 min** for hard fields.
- **`propose_edit` / `confirm_edit`** retired as gated flows. Kept as deprecation stubs so in-flight LLM conversations don't break: `propose_edit` routes through `edit_agent` (immediate), `confirm_edit` returns a friendly no-op response.
- **Provenance gate dropped** on `create_agent`, `create_project`, `add_agents_to_project`, `remove_agents_from_project`, `update_project_context`, `manage_agent`, `manage_project` so the operator can act autonomously during heartbeat. `_OPERATOR_PERMISSION_CEILING` still blocks `can_spawn=True` and `can_use_wallet=True` (irreversible-in-window risk).

### Rate completed work

- New **`acknowledged`** outcome — neutral "reviewed without judgement". No rework spawned. Empty feedback allowed.
- Inline **👍 / ➖ / 👎** buttons on Recently Delivered cards with `aria-label`s. 👎 opens an inline textarea that POSTs to the existing outcome endpoint and auto-spawns a rework task with the feedback as the brief. Rated cards collapse to a status chip.
- "Needs you" panel gains a synthetic **"N deliveries need your rating"** item that scrolls to the cards.

### Fixed: silent delivered-notification bug

`_notifications_producer` was checking `outcome == "delivered"` — never a valid outcome value, so the bell hadn't been pinging on completion. Rewrite fires `delivered` on `task_status_changed` with `new_status="done"`, skipping operator-self and pre-rated transitions. `task_status_changed` payload now carries `title` and `outcome` (in both `update_status` and `reroute` for uniform shape).

### Operator playbook rewritten

Core, edit, and monitor playbooks flipped to autonomous-by-default: drops "propose then wait", frames edits as immediate-with-undo, surfaces user ratings as the primary feedback signal.

### Defensive fix during E2E trace

`_apply_pending_change` permissions branch used `if agent_id in perms` — would silently no-op for any agent without a pre-existing entry. Replaced with `setdefault` chain guarded by `isinstance(new_value, dict)`. Rare in practice (startup backfills entries) but a silent no-op on a successful response with receipt emitted is the wrong failure mode.

## Deferred to follow-up PRs

- Outbound channel push with native rating buttons (Telegram / Slack / Discord / WhatsApp).
- Operator heartbeat auto-grading (exception / empty / schema heuristics).
- Per-agent memory feedback loop (write `user_feedback` to rated agent's memory store).
- Operator auto-instruction-tune in heartbeat (cluster reworks → draft edit).
- Agent/project delete: immediate-apply with 72h undo (still uses 5-min `propose-delete` confirmation in this PR).
- Re-rate auto-cancel of orphan rework tasks (regression-locked by `test_rerate_from_rework_to_acknowledged_leaves_spawned_task`).

## Test plan

- [x] `pytest tests/` excluding E2E: **5959 passed, 68 skipped**, same 3 pre-existing env failures as `main` (file-permission tests under root + httpbin.org 403)
- [x] New tests: `test_edit_soft_accepts_hard_field_model_with_30min_ttl`, `test_edit_soft_accepts_hard_field_permissions`, `test_edit_soft_soft_field_keeps_5min_ttl`, `test_edit_soft_hard_field_emits_agent_config_updated`, `test_task_status_changed_to_done_creates_delivered_notification`, `test_task_status_changed_skips_operator_self_delivery`, `test_task_status_changed_skips_already_rated`, `test_task_status_changed_payload_carries_title_and_outcome`, `test_outcome_acknowledged_no_feedback_allowed`, `test_outcome_acknowledged_does_not_spawn_rework`, `test_rerate_from_rework_to_acknowledged_leaves_spawned_task`
- [x] Updated tests: operator_tools (collapsed propose+confirm into deprecation stubs), operator_product_tools (autonomous archive/delete), operator_playbooks (size cap + tool map without confirm_edit), dashboard_notifications (task_status_changed path replaces broken outcome="delivered" path)
- [x] End-to-end trace through every scenario: soft edit, hard edit, permissions grant, undo, worker completion → bell, all three rating buttons, deprecated propose+confirm flow, autonomous heartbeat creation, project delete (still gated), event subscriptions

## Commits

1. `39ecf20` — refactor(operator,dashboard): rate output, don't approve plans
2. `64654b1` — fix(review): address principal-engineer audit findings (heartbeat_schedule schema, reroute payload, Alpine state hoist, aria-labels, 4 new tests)
3. `fa7610e` — fix(server): permissions write applies even when agent has no prior entry

https://claude.ai/code/session_01EvxNojG3mFqqoNjJ8wkNge

---
_Generated by [Claude Code](https://claude.ai/code/session_01EvxNojG3mFqqoNjJ8wkNge)_