### PR TITLE
fix(dashboard): pending-action Confirm hit mesh directly → 401/403

### DIFF
--- a/src/dashboard/server.py
+++ b/src/dashboard/server.py
@@ -6582,6 +6582,82 @@ def create_dashboard_router(
         except Exception:
             return {"pending": []}
 
+    @api_router.post("/api/workplace/pending/{nonce}/confirm")
+    async def api_workplace_pending_confirm(
+        nonce: str, request: Request,
+    ) -> dict:
+        """Confirm a pending action — backs every dashboard "Confirm" button.
+
+        The browser must NOT hit ``/mesh/pending/{nonce}/confirm``
+        directly. The mesh endpoint requires (a) a bearer token (in
+        production with ``OPENLEGION_AUTH_TOKEN`` set) OR
+        ``x-mesh-internal`` + loopback, AND (b) an ``X-Origin`` header
+        with ``kind="human"`` for the ``_confirm_origin_check`` gate.
+        A browser session has neither, so the call returned 401 (prod)
+        or 403 ("Confirmation requires human origin", dev) — the exact
+        symptom users hit when clicking Confirm on a pending action.
+
+        This proxy:
+          * Forwards over loopback with ``x-mesh-internal=1`` +
+            ``X-Agent-ID: operator`` so the mesh trusts identity.
+          * Mints a ``human`` ``MessageOrigin`` from the dashboard
+            session id and stamps it via ``X-Origin`` so
+            ``_confirm_origin_check`` passes.
+          * Threads ``payload_digest`` through from the request body
+            (the inline pending-action chat card sends it to detect
+            in-flight schema drift on hard-field edits).
+
+        Returns the mesh response on success; mirrors 404 / non-2xx
+        upstream codes so the SPA's existing error handling keeps
+        working.
+        """
+        try:
+            body = await request.json()
+        except Exception:
+            body = {}
+        if not isinstance(body, dict):
+            body = {}
+        payload_digest = body.get("payload_digest")
+        from src.shared.trace import origin_header
+        from src.shared.types import MessageOrigin
+        origin = MessageOrigin(
+            kind="human",
+            channel="dashboard",
+            user=_operator_session_id(request),
+        )
+        import httpx
+        url = f"http://127.0.0.1:{mesh_port}/mesh/pending/{nonce}/confirm"
+        fwd_body: dict = {}
+        if payload_digest is not None:
+            fwd_body["payload_digest"] = payload_digest
+        headers = {
+            "X-Requested-With": "XMLHttpRequest",
+            "x-mesh-internal": "1",
+            "X-Agent-ID": "operator",
+            "Content-Type": "application/json",
+        }
+        headers.update(origin_header(origin))
+        try:
+            async with httpx.AsyncClient(timeout=15) as client:
+                resp = await client.post(url, json=fwd_body, headers=headers)
+        except Exception as e:
+            logger.warning("workplace pending confirm proxy failed: %s", e)
+            raise HTTPException(502, f"Mesh unreachable: {e}")
+        if resp.status_code == 404:
+            raise HTTPException(
+                404, "Pending action not found or already expired",
+            )
+        if resp.status_code >= 400:
+            try:
+                detail = resp.json().get("detail", resp.text)
+            except Exception:
+                detail = resp.text
+            raise HTTPException(resp.status_code, detail)
+        try:
+            return resp.json()
+        except Exception:
+            return {"ok": True, "nonce": nonce}
+
     @api_router.post("/api/workplace/pending/{nonce}/cancel")
     async def api_workplace_pending_cancel(nonce: str) -> dict:
         """Cancel a pending action — backs the dashboard "Cancel" button.

--- a/src/dashboard/static/js/app.js
+++ b/src/dashboard/static/js/app.js
@@ -3927,11 +3927,21 @@ function dashboard() {
 
     async confirmPendingAction(nonce) {
       try {
-        const resp = await fetch(`/mesh/pending/${encodeURIComponent(nonce)}/confirm`, {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: '{}',
-        });
+        // Route via the dashboard's loopback proxy so the mesh sees
+        // x-mesh-internal + a human X-Origin. A direct browser-side
+        // fetch to /mesh/pending/.../confirm fails the auth +
+        // human-origin gates (see api_workplace_pending_confirm).
+        const resp = await fetch(
+          `${window.__config.apiBase}/workplace/pending/${encodeURIComponent(nonce)}/confirm`,
+          {
+            method: 'POST',
+            headers: {
+              'Content-Type': 'application/json',
+              'X-Requested-With': 'XMLHttpRequest',
+            },
+            body: '{}',
+          },
+        );
         if (!resp.ok) {
           const data = await resp.json().catch(() => ({}));
           this.showToast(`Confirm failed: ${data.detail || resp.status}`);
@@ -3988,11 +3998,19 @@ function dashboard() {
     // message here so the round-trip stays the source of truth.
     async confirmPendingActionCard(msg) {
       try {
-        const resp = await fetch(`/mesh/pending/${encodeURIComponent(msg.event_id)}/confirm`, {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json', 'X-Requested-With': 'XMLHttpRequest' },
-          body: JSON.stringify({ payload_digest: msg.payload_digest || undefined }),
-        });
+        // Loopback proxy — see confirmPendingAction note. payload_digest
+        // threads through so the mesh's drift check still fires.
+        const resp = await fetch(
+          `${window.__config.apiBase}/workplace/pending/${encodeURIComponent(msg.event_id)}/confirm`,
+          {
+            method: 'POST',
+            headers: {
+              'Content-Type': 'application/json',
+              'X-Requested-With': 'XMLHttpRequest',
+            },
+            body: JSON.stringify({ payload_digest: msg.payload_digest || undefined }),
+          },
+        );
         if (!resp.ok) {
           const data = await resp.json().catch(() => ({}));
           this.showToast(`Confirm failed: ${data.detail || resp.status}`);
@@ -4005,11 +4023,20 @@ function dashboard() {
 
     async cancelPendingActionCard(msg) {
       try {
-        const resp = await fetch(`/mesh/pending/${encodeURIComponent(msg.event_id)}/cancel`, {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json', 'X-Requested-With': 'XMLHttpRequest' },
-          body: '{}',
-        });
+        // Loopback proxy (the cancel endpoint doesn't require human
+        // origin, but a direct browser call still fails in prod
+        // because the mesh requires a bearer token or x-mesh-internal).
+        const resp = await fetch(
+          `${window.__config.apiBase}/workplace/pending/${encodeURIComponent(msg.event_id)}/cancel`,
+          {
+            method: 'POST',
+            headers: {
+              'Content-Type': 'application/json',
+              'X-Requested-With': 'XMLHttpRequest',
+            },
+            body: '{}',
+          },
+        );
         if (!resp.ok) {
           const data = await resp.json().catch(() => ({}));
           this.showToast(`Cancel failed: ${data.detail || resp.status}`);

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -5091,6 +5091,140 @@ class TestWorkplaceTabRoutes:
             resp = client.post("/dashboard/api/workplace/pending/missing/cancel")
         assert resp.status_code == 404
 
+    # ── Pending confirm proxy: dashboard → mesh with X-Origin: human ──
+    #
+    # The confirm button in the workplace panel + the inline
+    # pending_action chat card both POST through this proxy.
+    # Direct browser fetches to ``/mesh/pending/{nonce}/confirm``
+    # used to 401 / 403 because the mesh's ``_confirm_origin_check``
+    # rejects requests without an ``X-Origin: kind=human`` header AND
+    # without a bearer token. The proxy mints both server-side.
+
+    def _patch_pending_confirm_proxy(self, *, status_code: int = 200):
+        """Patch httpx so the confirm proxy can assert request shape.
+
+        Captures the headers + body the proxy hands to the mesh so the
+        tests can verify (a) ``x-mesh-internal`` and ``X-Agent-ID:
+        operator`` are sent (loopback identity), (b) ``X-Origin``
+        encodes ``kind=human;channel=dashboard;user=...``, (c) the
+        ``payload_digest`` body field round-trips.
+        """
+        captured: dict = {"headers": None, "json": None, "url": None}
+
+        class _StubResp:
+            def __init__(self, code: int, body: dict):
+                self.status_code = code
+                self._body = body
+                self.text = "" if not body else str(body)
+
+            def json(self):
+                return self._body
+
+        class _StubClient:
+            def __init__(self_inner, *a, **kw):
+                pass
+
+            async def __aenter__(self_inner):
+                return self_inner
+
+            async def __aexit__(self_inner, *a):
+                return False
+
+            async def post(self_inner, url, json=None, headers=None):
+                captured["url"] = url
+                captured["json"] = json
+                captured["headers"] = dict(headers or {})
+                if status_code == 404:
+                    return _StubResp(
+                        404,
+                        {"detail": "Pending action invalid or expired"},
+                    )
+                if status_code >= 400:
+                    return _StubResp(status_code, {"detail": "mesh error"})
+                return _StubResp(
+                    200,
+                    {
+                        "success": True,
+                        "applied": True,
+                        "agent_id": "alpha",
+                        "field": "model",
+                    },
+                )
+
+        from unittest.mock import patch
+        return patch("httpx.AsyncClient", _StubClient), captured
+
+    def test_workplace_pending_confirm_proxies_with_human_origin(self):
+        client = self._client_with_v2(False)
+        patcher, captured = self._patch_pending_confirm_proxy()
+        with patcher:
+            resp = client.post(
+                "/dashboard/api/workplace/pending/n7/confirm",
+                json={"payload_digest": "abc123"},
+            )
+        assert resp.status_code == 200
+        # URL targets the mesh's nonce-keyed confirm route.
+        assert captured["url"].endswith("/mesh/pending/n7/confirm")
+        # Body propagated payload_digest so the mesh's drift check runs.
+        assert captured["json"] == {"payload_digest": "abc123"}
+        # Loopback identity headers — without these the mesh would
+        # require a bearer token.
+        assert captured["headers"]["x-mesh-internal"] == "1"
+        assert captured["headers"]["X-Agent-ID"] == "operator"
+        # CSRF marker preserved end-to-end so dashboard-side hooks
+        # (and any future strict middleware) still see it.
+        assert captured["headers"]["X-Requested-With"] == "XMLHttpRequest"
+        # The critical fix: X-Origin must decode to ``kind=human`` so
+        # the mesh's ``_confirm_origin_check`` accepts the call. The
+        # header is JSON-encoded by ``origin_header(MessageOrigin(...))``.
+        from src.shared.types import MessageOrigin
+        parsed = MessageOrigin.from_header_value(
+            captured["headers"].get("X-Origin", ""),
+            trust_kind=True,
+        )
+        assert parsed is not None
+        assert parsed.kind == "human"
+        assert parsed.channel == "dashboard"
+        assert parsed.user  # session id populated
+
+    def test_workplace_pending_confirm_no_body_still_works(self):
+        """The workplace-list Confirm button posts an empty body. The
+        proxy must not require ``payload_digest`` — it's an optional
+        drift check used only by the inline chat card."""
+        client = self._client_with_v2(False)
+        patcher, captured = self._patch_pending_confirm_proxy()
+        with patcher:
+            resp = client.post(
+                "/dashboard/api/workplace/pending/n8/confirm",
+            )
+        assert resp.status_code == 200
+        # payload_digest stripped (not None) so the mesh doesn't fail
+        # the optional-digest check with a literal ``None``.
+        assert captured["json"] == {}
+
+    def test_workplace_pending_confirm_propagates_404(self):
+        client = self._client_with_v2(False)
+        patcher, _ = self._patch_pending_confirm_proxy(status_code=404)
+        with patcher:
+            resp = client.post(
+                "/dashboard/api/workplace/pending/missing/confirm",
+                json={},
+            )
+        assert resp.status_code == 404
+
+    def test_workplace_pending_confirm_propagates_mesh_errors(self):
+        client = self._client_with_v2(False)
+        patcher, _ = self._patch_pending_confirm_proxy(status_code=400)
+        with patcher:
+            resp = client.post(
+                "/dashboard/api/workplace/pending/n9/confirm",
+                json={},
+            )
+        # Mesh-side validation failures (e.g. payload_digest mismatch)
+        # must surface to the SPA so its error toast renders, not get
+        # masked as 500.
+        assert resp.status_code == 400
+
     # ── Phase 4: kanban-default Board + task cancel ─────────────────
 
     def _patch_task_cancel_proxy(self, *, status_code: int = 200):


### PR DESCRIPTION
## Summary

**Root cause:** the "Confirm" button on pending-action cards (workplace panel + inline chat card) fetched `/mesh/pending/{nonce}/confirm` **directly from the browser**, bypassing the dashboard's loopback proxy. That route enforces two gates the browser can't satisfy:

1. **Identity** — `_extract_verified_agent_id` (`src/host/server.py:830`) requires either a bearer token (prod, when `OPENLEGION_AUTH_TOKEN` is set) OR `x-mesh-internal=1` from loopback. A browser session has neither → **401 Unauthorized**.
2. **Human origin** — `_confirm_origin_check` (`src/host/server.py:5778`) requires `X-Origin` to decode to `kind="human"`. Browser fetches send no `X-Origin` → **403 "Confirmation requires human origin"**.

The matching Cancel button worked because `cancelPendingAction` already proxies via `/api/workplace/pending/{nonce}/cancel` with loopback identity headers — but its inline-chat sibling `cancelPendingActionCard` was broken the same way.

## Fix

- **New dashboard proxy** `POST /api/workplace/pending/{nonce}/confirm` (`src/dashboard/server.py:6585`): forwards over loopback with `x-mesh-internal=1` + `X-Agent-ID: operator`, mints a human `MessageOrigin` from the dashboard session id, and stamps `X-Origin` so `_confirm_origin_check` passes. Threads `payload_digest` through so the mesh's optional drift check still fires when the inline chat card sends one.
- **Rerouted three direct-to-mesh fetches** in `app.js`:
  - `confirmPendingAction` (workplace list Confirm)
  - `confirmPendingActionCard` (inline chat card Confirm)
  - `cancelPendingActionCard` (inline chat card Cancel)

## Tests (4 new)

- `test_workplace_pending_confirm_proxies_with_human_origin` — parses the captured `X-Origin`, asserts `kind="human"`, `channel="dashboard"`, populated `user`. Verifies loopback identity headers + CSRF marker.
- `test_workplace_pending_confirm_no_body_still_works` — workplace list Confirm posts `{}`; proxy must not require `payload_digest`.
- `test_workplace_pending_confirm_propagates_404` and `..._propagates_mesh_errors` — surface upstream status codes instead of masking as 500.

## Test plan

- [x] Targeted suite: 456 passed (`tests/test_dashboard.py` + `test_pending_actions.py` + `test_operator_product_tools.py` + `test_edit_soft_endpoint.py`)
- [x] Syntax-clean: Python + JS parse
- [x] Mirrors the existing cancel-proxy pattern at `src/dashboard/server.py:6664`

https://claude.ai/code/session_01EvxNojG3mFqqoNjJ8wkNge

---
_Generated by [Claude Code](https://claude.ai/code/session_01EvxNojG3mFqqoNjJ8wkNge)_