### PR TITLE
fix(agent): unbreak hand_off — move title helpers to src/shared

### DIFF
--- a/src/agent/builtins/coordination_tool.py
+++ b/src/agent/builtins/coordination_tool.py
@@ -18,6 +18,10 @@ import re
 import time
 
 from src.agent.skills import skill
+from src.shared.task_titles import (
+    LONG_TITLE_THRESHOLD,
+    _normalize_title_and_description,
+)
 from src.shared.types import AGENT_ID_RE_PATTERN
 from src.shared.utils import generate_id, sanitize_for_prompt, setup_logging
 
@@ -516,16 +520,9 @@ async def _hand_off_v2(
     # task title) and the full instruction (becomes the description).
     # Agents historically dumped multi-sentence instructions into
     # ``summary`` — that produced wall-of-text titles in the dashboard.
-    # The orchestration store applies the same policy as a backstop, but
-    # we mirror it here so the title we surface in result envelopes,
-    # wake messages, and downstream logs is already short. Server-side
-    # truncation in ``Tasks.create`` (see ``_normalize_title_and_description``)
-    # handles any long titles that slip through, so this is defense in
-    # depth rather than the only check.
-    from src.host.orchestration import (
-        LONG_TITLE_THRESHOLD,
-        _normalize_title_and_description,
-    )
+    # ``Tasks.create`` applies the same policy as a backstop, but we
+    # mirror it here so the title we surface in result envelopes, wake
+    # messages, and downstream logs is already short.
     if len(summary) > LONG_TITLE_THRESHOLD:
         title, description = _normalize_title_and_description(summary, None)
         # ``description`` is the full original ``summary`` here — keep

--- a/src/agent/builtins/coordination_tool.py
+++ b/src/agent/builtins/coordination_tool.py
@@ -20,7 +20,7 @@ import time
 from src.agent.skills import skill
 from src.shared.task_titles import (
     LONG_TITLE_THRESHOLD,
-    _normalize_title_and_description,
+    normalize_title_and_description,
 )
 from src.shared.types import AGENT_ID_RE_PATTERN
 from src.shared.utils import generate_id, sanitize_for_prompt, setup_logging
@@ -524,7 +524,7 @@ async def _hand_off_v2(
     # mirror it here so the title we surface in result envelopes, wake
     # messages, and downstream logs is already short.
     if len(summary) > LONG_TITLE_THRESHOLD:
-        title, description = _normalize_title_and_description(summary, None)
+        title, description = normalize_title_and_description(summary, None)
         # ``description`` is the full original ``summary`` here — keep
         # it intact so the recipient still sees the complete instruction.
     else:

--- a/src/host/orchestration.py
+++ b/src/host/orchestration.py
@@ -32,6 +32,7 @@ from contextlib import contextmanager
 from pathlib import Path
 from typing import Any
 
+from src.shared.task_titles import _normalize_title_and_description
 from src.shared.utils import setup_logging
 
 logger = setup_logging("host.orchestration")
@@ -57,96 +58,10 @@ VALID_OUTCOMES: frozenset[str] = frozenset({"accepted", "rework", "rejected"})
 # and the UI textarea doesn't smuggle a multi-MB blob into the table.
 MAX_FEEDBACK_CHARS: int = 2000
 
-# Title length policy. ``MAX_TITLE_CHARS`` is a hard cap — anything
-# beyond is truncated server-side. ``LONG_TITLE_THRESHOLD`` is the soft
-# ceiling: when a caller submits a single ``title`` longer than this and
-# no separate ``description``, we treat the whole string as the
-# description and derive a short title from its first sentence /
-# leading clause. This is defense-in-depth against agents that put full
-# instructions into the title field — the dashboard expects a one-line
-# label, not a paragraph.
-MAX_TITLE_CHARS: int = 200
-LONG_TITLE_THRESHOLD: int = 100
-SHORT_TITLE_TARGET: int = 80
-
-
-def _derive_short_title(text: str) -> str:
-    """Extract a short single-line label from a longer task instruction.
-
-    Strategy: take the first non-empty line, then split on sentence
-    terminators (``.``, ``!``, ``?``) and the en/em dash separators we
-    see in handoff phrasings ("Draft Q3 — full brief..."). Pick the
-    first chunk; if it's still too long, hard-cut at ``SHORT_TITLE_TARGET``
-    with an ellipsis. Whitespace-collapsed so multi-line inputs don't
-    leave dangling indents.
-
-    Returns ``""`` for empty or whitespace-only input — callers (the
-    title-normalizer / ``Tasks.create``) handle that fallback.
-    """
-    if not text or not text.strip():
-        return ""
-    # First non-empty line — handles "Subject\nBody" payloads cleanly.
-    first_line = ""
-    for raw in text.splitlines():
-        stripped = raw.strip()
-        if stripped:
-            first_line = stripped
-            break
-    if not first_line:
-        first_line = text.strip()
-    # Split on sentence + dash boundaries; pick the first chunk that
-    # actually carries content (skip empty leading splits).
-    candidate = first_line
-    for sep in (". ", "! ", "? ", " — ", " - ", ": "):
-        if sep in candidate:
-            head = candidate.split(sep, 1)[0].strip()
-            if head:
-                candidate = head
-                break
-    # Collapse internal whitespace so a copy-pasted blob doesn't render
-    # ragged in a one-line truncate.
-    candidate = " ".join(candidate.split())
-    if len(candidate) > SHORT_TITLE_TARGET:
-        # Prefer cutting on a word boundary near the cap so we don't end
-        # mid-word. ``rsplit`` returns the original string if no space.
-        cut = candidate[:SHORT_TITLE_TARGET].rsplit(" ", 1)[0]
-        if len(cut) < SHORT_TITLE_TARGET // 2:
-            cut = candidate[:SHORT_TITLE_TARGET]
-        candidate = cut.rstrip(",;:") + "…"
-    return candidate
-
-
-def _normalize_title_and_description(
-    title: str, description: str | None,
-) -> tuple[str, str | None]:
-    """Apply the title-length policy.
-
-    Three cases:
-
-    * Title is short (≤ ``LONG_TITLE_THRESHOLD``): pass through unchanged.
-    * Title is long but caller provided a separate ``description``: trust
-      the caller (they made an intentional choice), just hard-cap title
-      at ``MAX_TITLE_CHARS``.
-    * Title is long and no description: split — the long string becomes
-      the description (preserved verbatim) and we derive a short label
-      for the title. This is the wall-of-text recovery path.
-    """
-    if not title:
-        return title, description
-    if len(title) <= LONG_TITLE_THRESHOLD:
-        return title, description
-    if description:
-        # Caller already split — respect their choice, just cap title so
-        # one bad input can't blow past the dashboard layout.
-        return title[:MAX_TITLE_CHARS], description
-    # Long title, no description: treat title as description, derive
-    # a short title from it.
-    short = _derive_short_title(title)
-    if not short:
-        # Pathological input (whitespace-only after splitting). Fall
-        # back to a hard cut so we always have *some* title.
-        short = title[:SHORT_TITLE_TARGET].rstrip() + "…"
-    return short, title
+# Title length policy lives in ``src.shared.task_titles`` so the agent
+# coordination tool can import it without crossing the trust boundary.
+# See ``_normalize_title_and_description`` (imported above) — applied in
+# ``Tasks.create`` as the authoritative server-side check.
 
 # Allowed status transitions. Keys are FROM, values are sets of valid TOs.
 # Terminal states (done / failed / cancelled) appear here with empty sets

--- a/src/host/orchestration.py
+++ b/src/host/orchestration.py
@@ -32,7 +32,7 @@ from contextlib import contextmanager
 from pathlib import Path
 from typing import Any
 
-from src.shared.task_titles import _normalize_title_and_description
+from src.shared.task_titles import normalize_title_and_description
 from src.shared.utils import setup_logging
 
 logger = setup_logging("host.orchestration")
@@ -60,7 +60,7 @@ MAX_FEEDBACK_CHARS: int = 2000
 
 # Title length policy lives in ``src.shared.task_titles`` so the agent
 # coordination tool can import it without crossing the trust boundary.
-# See ``_normalize_title_and_description`` (imported above) — applied in
+# See ``normalize_title_and_description`` (imported above) — applied in
 # ``Tasks.create`` as the authoritative server-side check.
 
 # Allowed status transitions. Keys are FROM, values are sets of valid TOs.
@@ -399,7 +399,7 @@ class Tasks:
         # of-text in the dashboard kanban. Apply the title-length policy
         # here so every task in the system stays bounded regardless of
         # which call path created it.
-        title, description = _normalize_title_and_description(title, description)
+        title, description = normalize_title_and_description(title, description)
 
         tid = task_id or f"task_{uuid.uuid4().hex[:12]}"
         now = time.time()

--- a/src/shared/task_titles.py
+++ b/src/shared/task_titles.py
@@ -1,0 +1,102 @@
+"""Title-length policy for task records.
+
+Lives in ``src/shared`` because both the mesh-side task store
+(``src.host.orchestration.Tasks.create``) and the agent-side
+coordination tool (``src.agent.builtins.coordination_tool._hand_off_v2``)
+apply this policy. Agent containers ship only ``src/agent`` +
+``src/shared``, so any helper they reach for must live here — importing
+from ``src.host`` across the trust boundary fails with
+``ModuleNotFoundError`` inside the agent container.
+
+``MAX_TITLE_CHARS`` is a hard cap. ``LONG_TITLE_THRESHOLD`` is the soft
+ceiling: when a caller submits a single ``title`` longer than this and no
+separate ``description``, the long string becomes the description and a
+short label is derived for the title. Defends against agents that stuff
+full instructions into the title field — the dashboard expects a
+one-line label, not a paragraph.
+"""
+
+from __future__ import annotations
+
+MAX_TITLE_CHARS: int = 200
+LONG_TITLE_THRESHOLD: int = 100
+SHORT_TITLE_TARGET: int = 80
+
+
+def _derive_short_title(text: str) -> str:
+    """Extract a short single-line label from a longer task instruction.
+
+    Strategy: take the first non-empty line, then split on sentence
+    terminators (``.``, ``!``, ``?``) and the en/em dash separators we
+    see in handoff phrasings ("Draft Q3 — full brief..."). Pick the
+    first chunk; if it's still too long, hard-cut at ``SHORT_TITLE_TARGET``
+    with an ellipsis. Whitespace-collapsed so multi-line inputs don't
+    leave dangling indents.
+
+    Returns ``""`` for empty or whitespace-only input — callers (the
+    title-normalizer / ``Tasks.create``) handle that fallback.
+    """
+    if not text or not text.strip():
+        return ""
+    # First non-empty line — handles "Subject\nBody" payloads cleanly.
+    first_line = ""
+    for raw in text.splitlines():
+        stripped = raw.strip()
+        if stripped:
+            first_line = stripped
+            break
+    if not first_line:
+        first_line = text.strip()
+    # Split on sentence + dash boundaries; pick the first chunk that
+    # actually carries content (skip empty leading splits).
+    candidate = first_line
+    for sep in (". ", "! ", "? ", " — ", " - ", ": "):
+        if sep in candidate:
+            head = candidate.split(sep, 1)[0].strip()
+            if head:
+                candidate = head
+                break
+    # Collapse internal whitespace so a copy-pasted blob doesn't render
+    # ragged in a one-line truncate.
+    candidate = " ".join(candidate.split())
+    if len(candidate) > SHORT_TITLE_TARGET:
+        # Prefer cutting on a word boundary near the cap so we don't end
+        # mid-word. ``rsplit`` returns the original string if no space.
+        cut = candidate[:SHORT_TITLE_TARGET].rsplit(" ", 1)[0]
+        if len(cut) < SHORT_TITLE_TARGET // 2:
+            cut = candidate[:SHORT_TITLE_TARGET]
+        candidate = cut.rstrip(",;:") + "…"
+    return candidate
+
+
+def _normalize_title_and_description(
+    title: str, description: str | None,
+) -> tuple[str, str | None]:
+    """Apply the title-length policy.
+
+    Three cases:
+
+    * Title is short (≤ ``LONG_TITLE_THRESHOLD``): pass through unchanged.
+    * Title is long but caller provided a separate ``description``: trust
+      the caller (they made an intentional choice), just hard-cap title
+      at ``MAX_TITLE_CHARS``.
+    * Title is long and no description: split — the long string becomes
+      the description (preserved verbatim) and we derive a short label
+      for the title. This is the wall-of-text recovery path.
+    """
+    if not title:
+        return title, description
+    if len(title) <= LONG_TITLE_THRESHOLD:
+        return title, description
+    if description:
+        # Caller already split — respect their choice, just cap title so
+        # one bad input can't blow past the dashboard layout.
+        return title[:MAX_TITLE_CHARS], description
+    # Long title, no description: treat title as description, derive
+    # a short title from it.
+    short = _derive_short_title(title)
+    if not short:
+        # Pathological input (whitespace-only after splitting). Fall
+        # back to a hard cut so we always have *some* title.
+        short = title[:SHORT_TITLE_TARGET].rstrip() + "…"
+    return short, title

--- a/src/shared/task_titles.py
+++ b/src/shared/task_titles.py
@@ -1,12 +1,11 @@
 """Title-length policy for task records.
 
 Lives in ``src/shared`` because both the mesh-side task store
-(``src.host.orchestration.Tasks.create``) and the agent-side
-coordination tool (``src.agent.builtins.coordination_tool._hand_off_v2``)
-apply this policy. Agent containers ship only ``src/agent`` +
-``src/shared``, so any helper they reach for must live here — importing
-from ``src.host`` across the trust boundary fails with
-``ModuleNotFoundError`` inside the agent container.
+(``Tasks.create``) and the agent-side ``hand_off`` tool apply this
+policy. Agent containers ship only ``src/agent`` + ``src/shared``, so
+any helper agents reach for must live here — importing from
+``src.host`` across the trust boundary raises ``ModuleNotFoundError``
+inside the agent container.
 
 ``MAX_TITLE_CHARS`` is a hard cap. ``LONG_TITLE_THRESHOLD`` is the soft
 ceiling: when a caller submits a single ``title`` longer than this and no
@@ -23,7 +22,7 @@ LONG_TITLE_THRESHOLD: int = 100
 SHORT_TITLE_TARGET: int = 80
 
 
-def _derive_short_title(text: str) -> str:
+def derive_short_title(text: str) -> str:
     """Extract a short single-line label from a longer task instruction.
 
     Strategy: take the first non-empty line, then split on sentence
@@ -69,7 +68,7 @@ def _derive_short_title(text: str) -> str:
     return candidate
 
 
-def _normalize_title_and_description(
+def normalize_title_and_description(
     title: str, description: str | None,
 ) -> tuple[str, str | None]:
     """Apply the title-length policy.
@@ -94,7 +93,7 @@ def _normalize_title_and_description(
         return title[:MAX_TITLE_CHARS], description
     # Long title, no description: treat title as description, derive
     # a short title from it.
-    short = _derive_short_title(title)
+    short = derive_short_title(title)
     if not short:
         # Pathological input (whitespace-only after splitting). Fall
         # back to a hard cut so we always have *some* title.

--- a/tests/test_container_imports.py
+++ b/tests/test_container_imports.py
@@ -1,0 +1,72 @@
+"""Static guardrails on the agent / shared / host trust boundary.
+
+The agent container ships only ``src/agent`` + ``src/shared`` (see
+``Dockerfile.agent``). Any import from ``src.host`` inside agent or
+shared code raises ``ModuleNotFoundError`` at runtime inside the
+container — the bug that broke every ``hand_off`` call once
+orchestration v2 was enabled.
+
+These tests parse each ``.py`` under ``src/agent`` and ``src/shared``
+and assert no import targets ``src.host`` (top-level imports and
+function-level imports alike). Both branches of ``if TYPE_CHECKING:``
+are checked too — even though those don't execute at runtime, allowing
+them encodes a phantom dependency that mypy / IDE tooling will follow
+into a module the agent container can't open.
+"""
+
+from __future__ import annotations
+
+import ast
+import pathlib
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent
+
+
+def _host_imports_in(directory: pathlib.Path) -> list[str]:
+    """Return ``path:line: <import>`` for every ``src.host`` import found."""
+    offenders: list[str] = []
+    for py_file in sorted(directory.rglob("*.py")):
+        tree = ast.parse(py_file.read_text(), filename=str(py_file))
+        rel = py_file.relative_to(REPO_ROOT)
+        for node in ast.walk(tree):
+            if isinstance(node, ast.ImportFrom):
+                module = node.module or ""
+                if module == "src.host" or module.startswith("src.host."):
+                    offenders.append(f"{rel}:{node.lineno}: from {module}")
+            elif isinstance(node, ast.Import):
+                for alias in node.names:
+                    if alias.name == "src.host" or alias.name.startswith("src.host."):
+                        offenders.append(
+                            f"{rel}:{node.lineno}: import {alias.name}",
+                        )
+    return offenders
+
+
+def test_src_agent_does_not_import_from_src_host():
+    """Agents run in a container that only ships src/agent + src/shared.
+
+    Any ``from src.host…`` (top-level or function-level) raises
+    ``ModuleNotFoundError`` at runtime. This guardrail caught the
+    ``hand_off`` outage that motivated extracting title-policy helpers
+    into ``src/shared/task_titles``.
+    """
+    offenders = _host_imports_in(REPO_ROOT / "src" / "agent")
+    assert not offenders, (
+        "Agent code must not import from src.host — the agent container "
+        "doesn't ship src/host. Move the helper into src/shared instead. "
+        "Found:\n  " + "\n  ".join(offenders)
+    )
+
+
+def test_src_shared_does_not_import_from_src_host():
+    """Shared code is reachable from both zones — must stay decoupled.
+
+    A ``src.host`` import inside ``src/shared`` would propagate the same
+    runtime failure to every shared-module caller in the agent.
+    """
+    offenders = _host_imports_in(REPO_ROOT / "src" / "shared")
+    assert not offenders, (
+        "Shared code must not import from src.host — it's imported by "
+        "the agent container which doesn't ship src/host. Found:\n  "
+        + "\n  ".join(offenders)
+    )

--- a/tests/test_coordination.py
+++ b/tests/test_coordination.py
@@ -1345,7 +1345,7 @@ class TestHandOffTitleQuality:
     async def test_hand_off_long_summary_splits_into_title_and_description(self):
         """Summary > 100 chars: title is short, description is full text."""
         from src.agent.builtins.coordination_tool import hand_off
-        from src.host.orchestration import SHORT_TITLE_TARGET
+        from src.shared.task_titles import SHORT_TITLE_TARGET
 
         mc = _make_mesh_client(agent_id="scout", v2_enabled=True)
         mc.list_agents.return_value = {"writer": {"role": "writer"}}

--- a/tests/test_orchestration.py
+++ b/tests/test_orchestration.py
@@ -23,13 +23,15 @@ import pytest
 
 from src.host.orchestration import (
     DEFAULT_RETENTION_SECONDS,
-    MAX_TITLE_CHARS,
-    SHORT_TITLE_TARGET,
     TERMINAL_STATUSES,
     VALID_STATUSES,
     InvalidStatusTransition,
     TaskNotFound,
     Tasks,
+)
+from src.shared.task_titles import (
+    MAX_TITLE_CHARS,
+    SHORT_TITLE_TARGET,
     _derive_short_title,
     _normalize_title_and_description,
 )

--- a/tests/test_orchestration.py
+++ b/tests/test_orchestration.py
@@ -32,8 +32,8 @@ from src.host.orchestration import (
 from src.shared.task_titles import (
     MAX_TITLE_CHARS,
     SHORT_TITLE_TARGET,
-    _derive_short_title,
-    _normalize_title_and_description,
+    derive_short_title,
+    normalize_title_and_description,
 )
 
 
@@ -129,13 +129,13 @@ def test_create_task_split_when_only_long_summary(tmp_path):
 
 
 def test_normalize_title_short_passthrough():
-    title, desc = _normalize_title_and_description("Short title", None)
+    title, desc = normalize_title_and_description("Short title", None)
     assert title == "Short title"
     assert desc is None
 
 
 def test_normalize_title_short_with_description():
-    title, desc = _normalize_title_and_description("Short", "details")
+    title, desc = normalize_title_and_description("Short", "details")
     assert title == "Short"
     assert desc == "details"
 
@@ -143,7 +143,7 @@ def test_normalize_title_short_with_description():
 def test_normalize_title_long_with_description():
     """Long title + caller description → trust caller, cap title."""
     long = "X" * 500
-    title, desc = _normalize_title_and_description(long, "caller-desc")
+    title, desc = normalize_title_and_description(long, "caller-desc")
     assert len(title) <= MAX_TITLE_CHARS
     assert desc == "caller-desc"
 
@@ -155,7 +155,7 @@ def test_normalize_title_long_no_description_splits():
         "Use the existing template at templates/launch-brief.md. "
         "Target audience: engineering managers evaluating agent platforms."
     )
-    title, desc = _normalize_title_and_description(long_summary, None)
+    title, desc = normalize_title_and_description(long_summary, None)
     assert len(title) <= SHORT_TITLE_TARGET + 1
     assert desc == long_summary
     # The short title should carry the leading clause meaningfully.
@@ -164,30 +164,30 @@ def test_normalize_title_long_no_description_splits():
 
 def test_derive_short_title_first_sentence():
     text = "Draft Q3 launch brief. Use the existing template at X."
-    assert _derive_short_title(text) == "Draft Q3 launch brief"
+    assert derive_short_title(text) == "Draft Q3 launch brief"
 
 
 def test_derive_short_title_first_line():
     text = "Subject line\n\nBody paragraph that is much longer..."
-    assert _derive_short_title(text) == "Subject line"
+    assert derive_short_title(text) == "Subject line"
 
 
 def test_derive_short_title_dash_split():
     text = "TEST RUN — execute now, do NOT wait for the 08:00 cron"
-    out = _derive_short_title(text)
+    out = derive_short_title(text)
     assert out == "TEST RUN"
 
 
 def test_derive_short_title_word_boundary_cut():
     text = "A" + " B" * 60  # one short word + many short tokens, no sentence break
-    out = _derive_short_title(text)
+    out = derive_short_title(text)
     assert len(out) <= SHORT_TITLE_TARGET + 1
     assert out.endswith("…")
 
 
 def test_derive_short_title_collapses_whitespace():
     text = "Multi   line\t\t\twith   weird     spacing all on one"
-    out = _derive_short_title(text)
+    out = derive_short_title(text)
     assert "  " not in out  # collapsed
 
 
@@ -200,11 +200,11 @@ def test_derive_short_title_returns_empty_for_whitespace():
     early-return makes the helper tell its caller "I have nothing"
     rather than fabricating a title.
     """
-    assert _derive_short_title("") == ""
-    assert _derive_short_title("   ") == ""
-    assert _derive_short_title("\t\n  \n\t") == ""
+    assert derive_short_title("") == ""
+    assert derive_short_title("   ") == ""
+    assert derive_short_title("\t\n  \n\t") == ""
     # The audit case — 200 chars of spaces.
-    assert _derive_short_title(" " * 200) == ""
+    assert derive_short_title(" " * 200) == ""
 
 
 def test_create_task_rejects_whitespace_only_title(tmp_path):


### PR DESCRIPTION
## Summary

- `coordination_tool._hand_off_v2` imported `LONG_TITLE_THRESHOLD` / `_normalize_title_and_description` from `src.host.orchestration`. Agent containers only ship `src/agent` + `src/shared` (see `Dockerfile.agent`), so the import raised `ModuleNotFoundError: No module named 'src.host'` — every `hand_off` failed 100% once orchestration v2 was enabled.
- Move the title-length policy (`MAX_TITLE_CHARS`, `LONG_TITLE_THRESHOLD`, `SHORT_TITLE_TARGET`, `_derive_short_title`, `_normalize_title_and_description`) into a new `src/shared/task_titles.py`. Both `Tasks.create` (host) and `_hand_off_v2` (agent) import from there — no cross-zone reach, no re-export shim.
- Behavior unchanged. Existing assertions on the title-splitting policy still hold; two tests updated to import from the canonical location.

## Test plan

- [x] `pytest tests/test_coordination.py tests/test_orchestration.py tests/test_orchestration_migration.py tests/test_builtins.py tests/test_mesh.py` — 495 passed
- [x] Full fast sweep (`tests/` minus E2E) — 5976 passed, 48 skipped
- [x] `ruff check` on touched files — clean
- [ ] Operator re-runs SEO pipeline `hand_off` after deploy