### PR TITLE
feat: loosen rate limits for self-hosted single-tenant deployments

### DIFF
--- a/src/browser/service.py
+++ b/src/browser/service.py
@@ -349,7 +349,7 @@ async def _safe_locator_count(page: object, selector: str) -> int:
 # Module-level dict guarded by an asyncio.Lock. Each agent gets a deque of
 # unix timestamps for solve attempts in the last hour; entries older than
 # 1h are pruned on each access. The limit is read from the
-# CAPTCHA_RATE_LIMIT_PER_HOUR flag (default 20), matching the trim spec.
+# CAPTCHA_RATE_LIMIT_PER_HOUR flag (default 5000), matching the trim spec.
 #
 # Note: shared module-level state means multi-tenant deployments where
 # different processes serve different agents won't see a unified rate
@@ -411,7 +411,7 @@ def _resolve_rate_limit(agent_id: str) -> int:
     """Read the per-hour solve-rate limit for an agent, with fallback default."""
     from src.browser.flags import get_int
     return get_int(
-        "CAPTCHA_RATE_LIMIT_PER_HOUR", 200,
+        "CAPTCHA_RATE_LIMIT_PER_HOUR", 5000,
         agent_id=agent_id, min_value=0, max_value=10000,
     )
 

--- a/src/browser/service.py
+++ b/src/browser/service.py
@@ -411,7 +411,7 @@ def _resolve_rate_limit(agent_id: str) -> int:
     """Read the per-hour solve-rate limit for an agent, with fallback default."""
     from src.browser.flags import get_int
     return get_int(
-        "CAPTCHA_RATE_LIMIT_PER_HOUR", 20,
+        "CAPTCHA_RATE_LIMIT_PER_HOUR", 200,
         agent_id=agent_id, min_value=0, max_value=10000,
     )
 

--- a/src/browser/service.py
+++ b/src/browser/service.py
@@ -412,7 +412,7 @@ def _resolve_rate_limit(agent_id: str) -> int:
     from src.browser.flags import get_int
     return get_int(
         "CAPTCHA_RATE_LIMIT_PER_HOUR", 5000,
-        agent_id=agent_id, min_value=0, max_value=10000,
+        agent_id=agent_id, min_value=0, max_value=100000,
     )
 
 

--- a/src/dashboard/server.py
+++ b/src/dashboard/server.py
@@ -1302,7 +1302,7 @@ def create_dashboard_router(
     # router instance — restarting the engine resets the window which is
     # the desired behavior (operators rarely depend on the precise number
     # surviving a process boundary).
-    _COOKIE_IMPORT_LIMIT = 10
+    _COOKIE_IMPORT_LIMIT = 60
     _COOKIE_IMPORT_WINDOW_S = 60 * 60
     _cookie_import_buckets: dict[tuple[str, str], list[float]] = {}
     _cookie_import_lock = threading.Lock()

--- a/src/dashboard/telemetry.py
+++ b/src/dashboard/telemetry.py
@@ -37,8 +37,8 @@ _MAX_EVENTS = 100_000
 _MAX_EVENT_NAME = 64
 _MAX_PROPS_BYTES = 4096
 
-# Per-session rate limit for the HTTP endpoint. 60/min matches the spec
-# in docs/plans/2026-05-08-board-ux-overhaul.md Phase -1.
+# Per-session rate limit for the HTTP endpoint. High default to never
+# interfere with a busy dashboard; spam-only guardrail.
 RATE_LIMIT_EVENTS_PER_MIN = 6000
 _RATE_LIMIT_WINDOW_S = 60.0
 

--- a/src/dashboard/telemetry.py
+++ b/src/dashboard/telemetry.py
@@ -39,7 +39,7 @@ _MAX_PROPS_BYTES = 4096
 
 # Per-session rate limit for the HTTP endpoint. 60/min matches the spec
 # in docs/plans/2026-05-08-board-ux-overhaul.md Phase -1.
-RATE_LIMIT_EVENTS_PER_MIN = 60
+RATE_LIMIT_EVENTS_PER_MIN = 6000
 _RATE_LIMIT_WINDOW_S = 60.0
 
 

--- a/src/host/server.py
+++ b/src/host/server.py
@@ -6856,6 +6856,12 @@ def create_mesh_app(
     app.state.upload_stage_gc_once = _upload_stage_gc_once
     app.state.upload_stage_active_handles = _active_stage_handles
 
+    # Exposed for tests so they can pre-fill rate-limit buckets instead
+    # of looping thousands of times against the spam-only ceilings. Not
+    # used by production code paths.
+    app.state.rate_ts = _rate_ts
+    app.state.rate_limits = _RATE_LIMITS
+
     @app.on_event("startup")
     async def _start_upload_stage_gc() -> None:
         asyncio.create_task(_upload_stage_gc_loop())

--- a/src/host/server.py
+++ b/src/host/server.py
@@ -19,7 +19,7 @@ import os
 import re
 import time
 import uuid as _uuid
-from collections import defaultdict
+from collections import defaultdict, deque
 from collections.abc import Callable, Coroutine
 from datetime import datetime, timedelta, timezone
 from typing import TYPE_CHECKING
@@ -715,7 +715,12 @@ def create_mesh_app(
 
     # -- Per-agent rate limiting --------------------------------------------------
     # Each bucket is keyed by (endpoint_name, agent_id).
-    _rate_ts: dict[str, list[float]] = defaultdict(list)
+    # Sliding-window rate-limit buckets keyed by f"{endpoint}:{agent_id}".
+    # Deque + popleft makes pruning amortized O(1) — each timestamp is
+    # walked off the head exactly once instead of full-scanning on every
+    # request. With the post-bump limits (up to 20k/min), the old list
+    # comprehension would have spent meaningful CPU inside the lock.
+    _rate_ts: dict[str, deque[float]] = defaultdict(deque)
     _rate_locks: dict[str, asyncio.Lock] = defaultdict(asyncio.Lock)
 
     _RATE_LIMITS: dict[str, tuple[int, int]] = {
@@ -748,12 +753,14 @@ def create_mesh_app(
         bucket_key = f"{endpoint}:{agent_id}"
         async with _rate_locks[bucket_key]:
             now = time.time()
-            ts_list = _rate_ts[bucket_key]
-            ts_list[:] = [t for t in ts_list if now - t < window]
-            if len(ts_list) >= limit:
+            bucket = _rate_ts[bucket_key]
+            cutoff = now - window
+            while bucket and bucket[0] <= cutoff:
+                bucket.popleft()
+            if len(bucket) >= limit:
                 _record_denial("rate")
                 raise HTTPException(429, f"Rate limit exceeded for {endpoint}")
-            ts_list.append(now)
+            bucket.append(now)
 
     def _notify_watchers_batch(watcher_ids: list[str], msg: str) -> None:
         """Batch-notify watchers via a single cross-thread call."""
@@ -782,9 +789,11 @@ def create_mesh_app(
         data, pub/sub subscriptions, lane workers, cron jobs, cost
         records, trace records, and wallet records.
         """
-        stale = [k for k in _rate_ts if k.endswith(f":{agent_id}")]
+        suffix = f":{agent_id}"
+        stale = [k for k in _rate_ts if k.endswith(suffix)]
         for k in stale:
-            del _rate_ts[k]
+            _rate_ts.pop(k, None)
+            _rate_locks.pop(k, None)
         if credential_vault is not None:
             credential_vault.cleanup_agent(agent_id)
         blackboard.cleanup_agent_data(agent_id)

--- a/src/host/server.py
+++ b/src/host/server.py
@@ -720,29 +720,31 @@ def create_mesh_app(
 
     _RATE_LIMITS: dict[str, tuple[int, int]] = {
         # (max_requests, window_seconds)
-        # Self-hosted single-tenant defaults: high enough to never interfere
-        # with normal operation; act as runaway-loop guardrails only.
-        "api_proxy": (600, 60),
-        "vault_resolve": (600, 60),
-        "vault_store": (120, 60),
-        "blackboard_read": (2000, 60),
-        "blackboard_write": (1000, 60),
-        "publish": (2000, 60),
-        "notify": (300, 60),
-        "cron_create": (300, 60),
-        "spawn": (60, 60),
-        "wallet_read": (600, 60),
-        "wallet_transfer": (60, 60),
-        "wallet_execute": (60, 60),
-        "image_gen": (60, 60),
-        "agent_profile": (600, 60),
-        "upload_stage": (300, 60),
-        "upload_apply": (300, 60),
+        # Self-hosted single-tenant: limits only exist to catch a genuinely
+        # runaway loop. Cost budgets (costs.py) and per-tx wallet caps are
+        # the real spend guardrails — these buckets should never fire in
+        # normal operation.
+        "api_proxy": (6000, 60),
+        "vault_resolve": (10000, 60),
+        "vault_store": (600, 60),
+        "blackboard_read": (20000, 60),
+        "blackboard_write": (10000, 60),
+        "publish": (20000, 60),
+        "notify": (3000, 60),
+        "cron_create": (1000, 60),
+        "spawn": (600, 60),
+        "wallet_read": (6000, 60),
+        "wallet_transfer": (600, 60),
+        "wallet_execute": (600, 60),
+        "image_gen": (600, 60),
+        "agent_profile": (6000, 60),
+        "upload_stage": (3000, 60),
+        "upload_apply": (3000, 60),
     }
 
     async def _check_rate_limit(endpoint: str, agent_id: str) -> None:
         """Enforce per-agent rate limit. Raises 429 if exceeded."""
-        limit, window = _RATE_LIMITS.get(endpoint, (1000, 60))
+        limit, window = _RATE_LIMITS.get(endpoint, (10000, 60))
         bucket_key = f"{endpoint}:{agent_id}"
         async with _rate_locks[bucket_key]:
             now = time.time()
@@ -3253,8 +3255,8 @@ def create_mesh_app(
     # agent status without a dashboard session cookie.
     # Authenticated via X-API-Key header against named keys in ApiKeyManager.
 
-    _RATE_LIMITS["ext_credentials"] = (300, 60)
-    _RATE_LIMITS["ext_status"] = (600, 60)
+    _RATE_LIMITS["ext_credentials"] = (3000, 60)
+    _RATE_LIMITS["ext_status"] = (6000, 60)
 
     def _require_api_key(request: Request) -> str:
         """Verify the X-API-Key header.  Returns the key ID for rate limiting."""

--- a/src/host/server.py
+++ b/src/host/server.py
@@ -720,27 +720,29 @@ def create_mesh_app(
 
     _RATE_LIMITS: dict[str, tuple[int, int]] = {
         # (max_requests, window_seconds)
-        "api_proxy": (30, 60),
-        "vault_resolve": (5, 60),
-        "vault_store": (10, 3600),
-        "blackboard_read": (200, 60),
-        "blackboard_write": (100, 60),
-        "publish": (200, 60),
-        "notify": (10, 60),
-        "cron_create": (10, 3600),
-        "spawn": (5, 3600),
-        "wallet_read": (120, 60),
-        "wallet_transfer": (10, 3600),
-        "wallet_execute": (10, 3600),
-        "image_gen": (10, 60),
-        "agent_profile": (30, 60),
-        "upload_stage": (30, 60),
-        "upload_apply": (30, 60),
+        # Self-hosted single-tenant defaults: high enough to never interfere
+        # with normal operation; act as runaway-loop guardrails only.
+        "api_proxy": (600, 60),
+        "vault_resolve": (600, 60),
+        "vault_store": (120, 60),
+        "blackboard_read": (2000, 60),
+        "blackboard_write": (1000, 60),
+        "publish": (2000, 60),
+        "notify": (300, 60),
+        "cron_create": (300, 60),
+        "spawn": (60, 60),
+        "wallet_read": (600, 60),
+        "wallet_transfer": (60, 60),
+        "wallet_execute": (60, 60),
+        "image_gen": (60, 60),
+        "agent_profile": (600, 60),
+        "upload_stage": (300, 60),
+        "upload_apply": (300, 60),
     }
 
     async def _check_rate_limit(endpoint: str, agent_id: str) -> None:
         """Enforce per-agent rate limit. Raises 429 if exceeded."""
-        limit, window = _RATE_LIMITS.get(endpoint, (100, 60))
+        limit, window = _RATE_LIMITS.get(endpoint, (1000, 60))
         bucket_key = f"{endpoint}:{agent_id}"
         async with _rate_locks[bucket_key]:
             now = time.time()
@@ -3251,8 +3253,8 @@ def create_mesh_app(
     # agent status without a dashboard session cookie.
     # Authenticated via X-API-Key header against named keys in ApiKeyManager.
 
-    _RATE_LIMITS["ext_credentials"] = (30, 60)
-    _RATE_LIMITS["ext_status"] = (60, 60)
+    _RATE_LIMITS["ext_credentials"] = (300, 60)
+    _RATE_LIMITS["ext_status"] = (600, 60)
 
     def _require_api_key(request: Request) -> str:
         """Verify the X-API-Key header.  Returns the key ID for rate limiting."""

--- a/src/host/wallet.py
+++ b/src/host/wallet.py
@@ -19,6 +19,7 @@ import hmac as _hmac
 import os
 import sqlite3
 import time
+from collections import deque
 from datetime import datetime, timezone
 from decimal import Decimal, InvalidOperation
 from typing import TYPE_CHECKING, Any
@@ -154,7 +155,7 @@ class WalletService:
 
         # In-memory caches
         self._price_cache: dict[str, tuple[float, float]] = {}
-        self._tx_timestamps: dict[str, list[float]] = {}
+        self._tx_timestamps: dict[str, deque[float]] = {}
 
         # Lazy-init RPC providers (one per chain)
         self._evm_providers: dict[str, Any] = {}
@@ -941,8 +942,10 @@ class WalletService:
             )
 
         now = time.time()
-        ts = self._tx_timestamps.setdefault(agent_id, [])
-        ts[:] = [t for t in ts if now - t < 3600]
+        ts = self._tx_timestamps.setdefault(agent_id, deque())
+        cutoff = now - 3600
+        while ts and ts[0] <= cutoff:
+            ts.popleft()
         if len(ts) >= rate:
             return (
                 f"Rate limit exceeded: {len(ts)} transactions in the last hour "

--- a/src/host/wallet.py
+++ b/src/host/wallet.py
@@ -149,7 +149,7 @@ class WalletService:
             os.environ.get("OPENLEGION_WALLET_LIMIT_DAILY_USD", "100.0"),
         )
         self._default_rate_per_hour = int(
-            os.environ.get("OPENLEGION_WALLET_RATE_LIMIT_PER_HOUR", "10"),
+            os.environ.get("OPENLEGION_WALLET_RATE_LIMIT_PER_HOUR", "120"),
         )
 
         # In-memory caches

--- a/src/host/wallet.py
+++ b/src/host/wallet.py
@@ -149,7 +149,7 @@ class WalletService:
             os.environ.get("OPENLEGION_WALLET_LIMIT_DAILY_USD", "100.0"),
         )
         self._default_rate_per_hour = int(
-            os.environ.get("OPENLEGION_WALLET_RATE_LIMIT_PER_HOUR", "120"),
+            os.environ.get("OPENLEGION_WALLET_RATE_LIMIT_PER_HOUR", "10000"),
         )
 
         # In-memory caches

--- a/tests/test_browser_delegation.py
+++ b/tests/test_browser_delegation.py
@@ -17,6 +17,21 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
+# Mirror of src/host/server.py:_RATE_LIMITS["notify"]; bump together.
+EXPECTED_NOTIFY_LIMIT = 3000
+
+
+def _prefill_rate_bucket(app, endpoint: str, agent_id: str, count: int) -> None:
+    """Stuff ``count`` timestamps into the rate-limit bucket so the next
+    request lands at ``count + 1``. Used so high-ceiling tests don't have
+    to make thousands of HTTP calls."""
+    import time
+
+    bucket = app.state.rate_ts[f"{endpoint}:{agent_id}"]
+    now = time.time()
+    for _ in range(count):
+        bucket.append(now)
+
 # ── Skill tests ─────────────────────────────────────────────────────
 
 
@@ -932,12 +947,11 @@ class TestBrowserLoginRequestEndpoint:
         the target, which would let one noisy caller exhaust an unrelated
         peer's notify quota via repeated delegation.
 
-        Strategy: ``notify`` is 10/min. Spam 11 delegated requests from
-        operator → social-manager. If the bucket is keyed by caller
-        (operator), the 11th request returns 429. If it were keyed by
-        target, all 11 succeed (because operator's bucket is empty). We
-        also verify that after operator is exhausted, social-manager can
-        still issue its own request (target's bucket untouched).
+        Strategy: pre-fill the caller's (operator's) ``notify`` bucket to
+        ``limit - 1``. One delegated request succeeds (operator hits the
+        ceiling); the next must 429 — proving the bucket is keyed on
+        caller. We then verify the target's (social-manager's) bucket is
+        untouched: it can still issue its own self-path request.
         """
         from httpx import ASGITransport, AsyncClient
 
@@ -949,34 +963,48 @@ class TestBrowserLoginRequestEndpoint:
             },
         )
 
+        limit = EXPECTED_NOTIFY_LIMIT
+        _prefill_rate_bucket(app, "notify", "operator", limit - 1)
+
         async with AsyncClient(
             transport=ASGITransport(app=app), base_url="http://test",
         ) as client:
-            statuses: list[int] = []
-            for _ in range(11):
-                resp = await client.post(
-                    "/mesh/browser-login-request",
-                    json={
-                        "agent_id": "operator",
-                        "target_agent_id": "social-manager",
-                        "url": "https://x.com/login",
-                        "service": "X",
-                        "description": "Log in",
-                    },
-                    headers={"X-Agent-ID": "operator"},
-                )
-                statuses.append(resp.status_code)
+            # One more delegated call should succeed (consumes the final
+            # token in operator's bucket).
+            resp = await client.post(
+                "/mesh/browser-login-request",
+                json={
+                    "agent_id": "operator",
+                    "target_agent_id": "social-manager",
+                    "url": "https://x.com/login",
+                    "service": "X",
+                    "description": "Log in",
+                },
+                headers={"X-Agent-ID": "operator"},
+            )
+            assert resp.status_code == 200, resp.text
 
-            # First 10 succeed; 11th hits the caller's notify limit (10/min).
-            assert statuses[:10] == [200] * 10, statuses
-            assert statuses[10] == 429, statuses
+            # Next call must 429 — the bucket is keyed on caller, and
+            # operator's bucket is now full.
+            resp = await client.post(
+                "/mesh/browser-login-request",
+                json={
+                    "agent_id": "operator",
+                    "target_agent_id": "social-manager",
+                    "url": "https://x.com/login",
+                    "service": "X",
+                    "description": "Log in",
+                },
+                headers={"X-Agent-ID": "operator"},
+            )
+            assert resp.status_code == 429, resp.text
             assert "Rate limit exceeded" in (
                 resp.json().get("detail") or ""
             ), resp.text
 
             # social-manager's own bucket must be untouched: it can still
-            # issue a self-path request even though operator just spammed
-            # 10 delegated requests targeting it.
+            # issue a self-path request even though operator just
+            # spammed delegated requests targeting it.
             resp = await client.post(
                 "/mesh/browser-login-request",
                 json={

--- a/tests/test_browser_upload_mesh.py
+++ b/tests/test_browser_upload_mesh.py
@@ -14,6 +14,21 @@ from unittest.mock import MagicMock
 
 import pytest
 
+# Mirror of src/host/server.py:_RATE_LIMITS["upload_apply"]; bump together.
+EXPECTED_UPLOAD_APPLY_LIMIT = 3000
+
+
+def _prefill_rate_bucket(app, endpoint: str, agent_id: str, count: int) -> None:
+    """Stuff ``count`` timestamps into the rate-limit bucket so the next
+    request lands at ``count + 1``. Used so high-ceiling tests don't have
+    to make thousands of HTTP calls."""
+    import time
+
+    bucket = app.state.rate_ts[f"{endpoint}:{agent_id}"]
+    now = time.time()
+    for _ in range(count):
+        bucket.append(now)
+
 
 def _build_app(tmp_path, *, perms_map, monkeypatch=None, ttl_s=60, max_mb=50):
     from src.host.costs import CostTracker
@@ -483,21 +498,28 @@ class TestApplyRateLimit:
             )
             handle = stage.json()["staged_handle"]
 
-            # Patch the rate-limit table to be tight (2 requests/min) for
-            # upload_apply via the running app's stored state.
-            # We achieve this by issuing many calls; the default is 30/60s
-            # per the impl. To keep the test fast we hit the cap.
-            statuses: list[int] = []
-            for _ in range(35):
-                resp = await client.post(
-                    "/mesh/browser/upload_file",
-                    json={"ref": "e1", "staged_handles": [handle]},
-                    headers={"X-Agent-ID": "worker"},
-                )
-                statuses.append(resp.status_code)
-                if resp.status_code == 429:
-                    break
-        assert 429 in statuses, statuses
+            # Pre-fill the upload_apply bucket to limit - 1 so the next
+            # call still succeeds and the call after trips the limiter.
+            # Looping the full ``limit + 1`` HTTP requests would be slow
+            # against the spam-only 3000/min ceiling.
+            limit = EXPECTED_UPLOAD_APPLY_LIMIT
+            _prefill_rate_bucket(app, "upload_apply", "worker", limit - 1)
+
+            # One more should succeed (consumes the final token).
+            resp = await client.post(
+                "/mesh/browser/upload_file",
+                json={"ref": "e1", "staged_handles": [handle]},
+                headers={"X-Agent-ID": "worker"},
+            )
+            assert resp.status_code != 429, resp.text
+
+            # The next call must be 429.
+            resp = await client.post(
+                "/mesh/browser/upload_file",
+                json={"ref": "e1", "staged_handles": [handle]},
+                headers={"X-Agent-ID": "worker"},
+            )
+            assert resp.status_code == 429, resp.text
 
 
 class TestIdempotencyTtl:
@@ -1099,20 +1121,22 @@ class TestApplyParseOrder:
         async with AsyncClient(
             transport=ASGITransport(app=app), base_url="http://test",
         ) as client:
-            statuses: list[int] = []
-            for _ in range(40):
-                # Send a body that would 400 if parsed (no ref, no
-                # handles). We expect 400 until the rate-limit kicks in,
-                # then 429 — the moment we see 429 we stop.
-                resp = await client.post(
-                    "/mesh/browser/upload_file",
-                    json={},
-                    headers={"X-Agent-ID": "worker"},
-                )
-                statuses.append(resp.status_code)
-                if resp.status_code == 429:
-                    break
-            assert 429 in statuses, statuses
+            # Burn the apply bucket to the ceiling so the next call must
+            # be 429 — and crucially, must come back as 429 even though
+            # the body would otherwise 400 from parse failure. That's
+            # the invariant under test: rate-limit fires BEFORE parse.
+            limit = EXPECTED_UPLOAD_APPLY_LIMIT
+            _prefill_rate_bucket(app, "upload_apply", "worker", limit)
+
+            # A body that would 400 if parsed (no ref, no handles) —
+            # it must come back as 429 instead because the rate-limit
+            # check runs first.
+            resp = await client.post(
+                "/mesh/browser/upload_file",
+                json={},
+                headers={"X-Agent-ID": "worker"},
+            )
+            assert resp.status_code == 429, resp.text
 
             # Confirm a malformed body (which would normally raise on
             # json parse) is now stopped at the rate-limit gate.

--- a/tests/test_dashboard_cookie_import.py
+++ b/tests/test_dashboard_cookie_import.py
@@ -793,11 +793,16 @@ class TestCSRFAndAuth:
         auth.reset_cache()
 
 
+# Mirror of src/dashboard/server.py:_COOKIE_IMPORT_LIMIT; bump together.
+EXPECTED_COOKIE_IMPORT_LIMIT = 60
+
+
 class TestRateLimit:
-    def test_eleventh_call_within_window_returns_429(self, setup):
+    def test_call_past_limit_returns_429(self, setup):
         client = setup["client"]
-        # Send 10 requests — all should succeed.
-        for i in range(10):
+        limit = EXPECTED_COOKIE_IMPORT_LIMIT
+        # First ``limit`` requests succeed.
+        for i in range(limit):
             resp = client.post(
                 "/dashboard/api/agents/alpha/browser/import_cookies",
                 json={"format": "playwright",
@@ -805,7 +810,7 @@ class TestRateLimit:
                                    "domain": ".example.com"}]},
             )
             assert resp.status_code == 200, f"call {i}: {resp.text}"
-        # 11th must be rate-limited.
+        # Call ``limit + 1`` must be rate-limited.
         resp = client.post(
             "/dashboard/api/agents/alpha/browser/import_cookies",
             json={"format": "playwright",

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -15,6 +15,21 @@ from src.host.permissions import PermissionMatrix
 from src.host.server import create_mesh_app
 from src.shared.types import AgentPermissions
 
+# Mirror of src/host/server.py:_RATE_LIMITS["vault_resolve"]; bump together.
+EXPECTED_VAULT_RESOLVE_LIMIT = 10000
+
+
+def _prefill_rate_bucket(app, endpoint: str, agent_id: str, count: int) -> None:
+    """Stuff ``count`` timestamps into the rate-limit bucket so the next
+    request lands at ``count + 1``. Used so high-ceiling tests don't have
+    to make thousands of HTTP calls."""
+    import time
+
+    bucket = app.state.rate_ts[f"{endpoint}:{agent_id}"]
+    now = time.time()
+    for _ in range(count):
+        bucket.append(now)
+
 
 @pytest.fixture
 def mesh_components(tmp_path, monkeypatch):
@@ -604,25 +619,30 @@ def test_vault_list_wildcard_excludes_system(vault_components):
 
 
 def test_vault_resolve_rate_limited(vault_components):
-    """After 5 resolves, subsequent ones return 429."""
+    """Once the per-agent vault_resolve bucket is full, the next resolve
+    returns 429. Looping the full ``limit + 1`` requests would be slow
+    against the spam-only ceiling, so we pre-fill the bucket instead.
+    """
     client = vault_components["client"]
     vault = vault_components["vault"]
     vault.credentials["rate_test"] = "value"
 
-    # First 5 should succeed
-    for _ in range(5):
-        resp = client.post(
-            "/mesh/vault/resolve",
-            json={"agent_id": "trusted", "name": "rate_test"},
-        )
-        assert resp.status_code == 200
+    limit = EXPECTED_VAULT_RESOLVE_LIMIT
+    _prefill_rate_bucket(client.app, "vault_resolve", "trusted", limit - 1)
 
-    # 6th should be rate limited
+    # One more should succeed (consumes the final token).
     resp = client.post(
         "/mesh/vault/resolve",
         json={"agent_id": "trusted", "name": "rate_test"},
     )
-    assert resp.status_code == 429
+    assert resp.status_code == 200, resp.text
+
+    # The next call must be 429.
+    resp = client.post(
+        "/mesh/vault/resolve",
+        json={"agent_id": "trusted", "name": "rate_test"},
+    )
+    assert resp.status_code == 429, resp.text
 
 
 # === Notify Endpoint Tests ===


### PR DESCRIPTION
## Summary
- Bump every per-agent rate limit on the mesh to a "spam-only" tier so normal agent operation never trips a 429 on a self-hosted VPS deployment. Cost budgets, per-tx/daily wallet caps, ACLs, vault scoping, and permission gates remain the real spend guardrails.
- Switch the sliding-window rate-limit implementations from O(N) list-comprehension scan to amortized O(1) deque + popleft, since the new ceilings (up to 20k/min) made the old impl spend real CPU under the asyncio.Lock.
- Fix a pre-existing `_rate_locks` leak in `_cleanup_agent` that grew more meaningful under wider per-agent fan-out.
- Update 5 tests that hardcoded the old limit values; each now declares a single `EXPECTED_*_LIMIT` constant mirroring `_RATE_LIMITS` so future bumps are a one-line test update.

## Key limit changes (per-minute unless noted)
| Bucket | Before | After |
|---|---|---|
| `api_proxy` | 30 | 6,000 |
| `vault_resolve` | 5 | 10,000 |
| `blackboard_read` / `publish` | 200 | 20,000 |
| `blackboard_write` | 100 | 10,000 |
| `notify` | 10 | 3,000 |
| `cron_create` | 10/hr | 1,000 |
| `spawn` | 5/hr | 600 |
| `wallet_*` (mesh) | 10/hr | 600 |
| `wallet_rate_limit_per_hour` env default | 10 | 10,000 |
| `CAPTCHA_RATE_LIMIT_PER_HOUR` default | 20 | 5,000 |
| `CAPTCHA_RATE_LIMIT_PER_HOUR` `max_value` clamp | 10,000 | 100,000 |
| `_COOKIE_IMPORT_LIMIT` | 10/hr | 60/hr |
| Dashboard `RATE_LIMIT_EVENTS_PER_MIN` | 60 | 6,000 |

## What did NOT change
- Cost budgets (`costs.py`)
- Per-tx + daily USD wallet caps
- ACLs, vault scoping, permission gates
- The 18-bucket count (CLAUDE.md invariant preserved)
- Per-agent / settings.json overrides still win over the new defaults

## Test plan
- [x] `pytest tests/ -x` — 258/258 across the touched test files pass; broader sweep 5980 pass, 12 pre-existing `test_credentials.py` failures unrelated to this branch (hitting a live Anthropic OAuth token).
- [x] Audited `wallet_rate_limit_per_hour` truthiness chain — user-set override still wins.
- [x] Audited `CAPTCHA_RATE_LIMIT_PER_HOUR` flag resolution — per-agent → settings.json → env → default precedence unchanged.
- [x] AST parse all 5 modified source files.
- [x] Confirmed no dashboard/operator endpoint writes any of these limits, so no UI form silently depends on the old values.