### PR TITLE
fix(dashboard): portal setting-hint tooltips + lift nav-bar stacking

### DIFF
--- a/src/dashboard/static/css/dashboard.css
+++ b/src/dashboard/static/css/dashboard.css
@@ -206,6 +206,12 @@
   border-bottom: 1px solid rgba(42, 42, 58, 0.4);
   backdrop-filter: blur(16px);
   -webkit-backdrop-filter: blur(16px);
+  /* backdrop-filter already creates a stacking context, but its z-index is
+     auto — siblings later in the DOM (main content) paint above it. Lift it
+     so absolute children (notification bell dropdown, etc.) stack above
+     main without each dropdown needing its own portal. */
+  position: relative;
+  z-index: 50;
 }
 
 .nav-tab {
@@ -504,7 +510,11 @@ select:focus-visible,
   outline: none;
 }
 
-.setting-hint .setting-hint-text {
+/* Tooltip body — flat selector so the JS-portaled instance on <body>
+   gets the full styling (the original markup nests this inside
+   .setting-hint, but the runtime portal lives at the body level to
+   escape backdrop-filter/transform containing-block traps). */
+.setting-hint-text {
   display: none;
   position: fixed;
   background: rgba(17, 17, 24, 0.97);
@@ -523,7 +533,7 @@ select:focus-visible,
   pointer-events: none;
 }
 
-.setting-hint .setting-hint-text::after {
+.setting-hint-text::after {
   content: '';
   position: absolute;
   top: 100%;
@@ -533,7 +543,7 @@ select:focus-visible,
 }
 
 /* Flipped: tooltip appears below the icon */
-.setting-hint .setting-hint-text.hint-below::after {
+.setting-hint-text.hint-below::after {
   top: auto;
   bottom: 100%;
   border-top-color: transparent;

--- a/src/dashboard/static/js/app.js
+++ b/src/dashboard/static/js/app.js
@@ -1493,52 +1493,67 @@ function dashboard() {
         }
       });
 
-      // ── Tooltip positioning for .setting-hint elements ──
-      // Uses position:fixed to escape overflow:hidden ancestors.
+      // ── Tooltip portal for .setting-hint elements ──
+      // .agent-card has `backdrop-filter` and a hover `transform`; .nav-bar
+      // has `backdrop-filter`. All three properties create a new containing
+      // block for position:fixed descendants AND a new stacking context, so
+      // a tooltip rendered inside one of these ancestors gets trapped:
+      // it's clipped by the card's `overflow: hidden`, and its z-index can't
+      // escape the ancestor's stacking layer. We sidestep this with a single
+      // shared portal node parked on <body>, populated on hover.
+      const _hintPortal = (() => {
+        let el = null;
+        return () => {
+          if (!el || !document.body.contains(el)) {
+            el = document.createElement('span');
+            el.className = 'setting-hint-text';
+            el.setAttribute('role', 'tooltip');
+            el.style.display = 'none';
+            document.body.appendChild(el);
+          }
+          return el;
+        };
+      })();
       const _positionHint = (hint) => {
-        const text = hint.querySelector('.setting-hint-text');
-        if (!text) return;
+        const source = hint.querySelector('.setting-hint-text');
+        if (!source) return;
+        const portal = _hintPortal();
+        // Current tooltips are plain text. If HTML is ever needed,
+        // swap textContent for cloned childNodes.
+        portal.textContent = source.textContent;
+        portal.classList.remove('hint-below');
         const r = hint.getBoundingClientRect();
         const gap = 6;
-        // Measure tooltip (show off-screen briefly)
-        text.style.visibility = 'hidden';
-        text.style.display = 'block';
-        text.style.top = '-9999px';
-        text.style.left = '-9999px';
-        const tw = text.offsetWidth;
-        const th = text.offsetHeight;
-        // Default: above, left-aligned with icon
+        // Measure off-screen
+        portal.style.visibility = 'hidden';
+        portal.style.display = 'block';
+        portal.style.top = '-9999px';
+        portal.style.left = '-9999px';
+        const tw = portal.offsetWidth;
+        const th = portal.offsetHeight;
+        // Default: above the icon, left-aligned
         let top = r.top - gap - th;
         let left = r.left;
         let below = false;
-        // Flip below if clipped at top
         if (top < 8) {
           top = r.bottom + gap;
           below = true;
         }
-        // Clamp to right edge
         if (left + tw > window.innerWidth - 8) {
           left = window.innerWidth - tw - 8;
         }
-        // Clamp to left edge
         if (left < 8) left = 8;
-        // Arrow points at icon center
         const arrowX = Math.min(Math.max(r.left + r.width / 2 - left, 8), tw - 8);
-        text.style.setProperty('--arrow-x', arrowX + 'px');
-        text.style.top = top + 'px';
-        text.style.left = left + 'px';
-        text.style.visibility = '';
-        text.classList.toggle('hint-below', below);
+        portal.style.setProperty('--arrow-x', arrowX + 'px');
+        portal.style.top = top + 'px';
+        portal.style.left = left + 'px';
+        portal.style.visibility = '';
+        portal.classList.toggle('hint-below', below);
       };
-      const _hideHint = (hint) => {
-        const text = hint.querySelector('.setting-hint-text');
-        if (!text) return;
-        text.style.display = '';
-        text.style.top = '';
-        text.style.left = '';
-        text.style.visibility = '';
-        text.classList.remove('hint-below');
-        text.style.removeProperty('--arrow-x');
+      const _hideHint = () => {
+        const portal = _hintPortal();
+        portal.style.display = 'none';
+        portal.classList.remove('hint-below');
       };
       document.addEventListener('mouseenter', (e) => {
         const hint = e.target.closest('.setting-hint');


### PR DESCRIPTION
## Summary

Two related stacking-context bugs in the dashboard:

- **`?` help tooltips on agent cards were clipped / appeared behind sibling cards.** `.agent-card` has `backdrop-filter: blur(8px)` and adds `transform: translateY(-2px)` on hover. Both properties create a new containing block for `position: fixed` descendants *and* a new stacking context. The tooltip was rendered inside the card, so its `position: fixed` was resolved against the card (not the viewport), and `z-index: 9999` couldn't escape the card's stacking layer. Same trap on `.nav-bar` (`backdrop-filter: blur(16px)`).
- **Notification-bell dropdown could be covered by `<main>`.** The nav establishes a stacking context via `backdrop-filter` but at `z-index: auto`, so later DOM siblings (main content) painted on top.

## Fix

- **Tooltip portal**: single shared `.setting-hint-text` node parked on `<body>` and populated on hover (textContent copied from the source span). Source DOM is never mutated, so Alpine re-renders are safe. `role="tooltip"` added.
- **CSS selectors flattened** from `.setting-hint .setting-hint-text` to `.setting-hint-text` so the portaled instance retains full styling (position, bg, padding, z-9999, etc.). Verified via grep that the class is only used in this tooltip pattern.
- **Nav-bar**: `position: relative; z-index: 50`. Audited the codebase's z-index inventory: z-10/20/40 below; z-60/70/100/150 (modals/toasts/overlays) above; no upward-opening dropdowns in main.

## Test plan

- [ ] Hover any `?` icon inside an agent card (Activity / Auto-checkup / Cost today / Last activity rows) — tooltip should render fully styled, above all sibling cards, not clipped.
- [ ] Tab to a `?` icon via keyboard — tooltip appears (focusin handler).
- [ ] Open the notification bell — dropdown sits above agent cards / project tabs.
- [ ] Open any modal (confirm dialog, command palette, full-screen overlay) — still paints above nav.
- [ ] Open the messenger side panel — still sits below nav (z-40 < z-50).