### PR TITLE
fix(coordination): surface wake_agent failures in hand_off response

### DIFF
--- a/src/agent/builtins/coordination_tool.py
+++ b/src/agent/builtins/coordination_tool.py
@@ -210,13 +210,19 @@ async def hand_off(
     # Wake the target agent so it processes the task immediately
     # instead of waiting for its next heartbeat.  Pass origin so
     # the mesh lane worker can auto-notify the originating user.
+    # Wake failures are surfaced to the caller via ``wake_failed`` +
+    # ``wake_error`` (handed_off stays True — the task IS queued in
+    # SQLite, only the wake signal failed; the caller can decide
+    # whether to retry the wake or wait for cron).
+    wake_error: str | None = None
     try:
         await mesh_client.wake_agent(
             to, f"New task from {from_agent}: {summary[:200]}",
             origin=origin,
         )
     except Exception as e:
-        logger.debug("Wake for %s failed (task still queued): %s", to, e)
+        wake_error = str(e)[:200]
+        logger.warning("Wake for %s failed (task still queued): %s", to, e)
 
     result = {
         "handed_off": True,
@@ -226,6 +232,9 @@ async def hand_off(
     }
     if output_key:
         result["output_key"] = output_key
+    if wake_error is not None:
+        result["wake_failed"] = True
+        result["wake_error"] = wake_error
     return result
 
 
@@ -604,15 +613,19 @@ async def _hand_off_v2(
 
     task_id = record.get("id", "")
 
-    # Wake the target so they pick up the task immediately. Failures
-    # are logged and swallowed — the task is queued either way.
+    # Wake the target so they pick up the task immediately. The task
+    # is queued in SQLite either way; wake failures are surfaced to the
+    # caller via ``wake_failed`` + ``wake_error`` so they can decide
+    # whether to retry the wake or wait for the recipient's next cron.
+    wake_error: str | None = None
     try:
         await mesh_client.wake_agent(
             to, f"New task from {mesh_client.agent_id}: {summary[:200]}",
             origin=origin,
         )
     except Exception as e:
-        logger.debug("Wake for %s failed (task still queued): %s", to, e)
+        wake_error = str(e)[:200]
+        logger.warning("Wake for %s failed (task still queued): %s", to, e)
 
     result = {
         "handed_off": True,
@@ -623,6 +636,9 @@ async def _hand_off_v2(
     }
     if artifact_ref:
         result["output_key"] = artifact_ref
+    if wake_error is not None:
+        result["wake_failed"] = True
+        result["wake_error"] = wake_error
     return result
 
 

--- a/tests/test_coordination.py
+++ b/tests/test_coordination.py
@@ -1373,3 +1373,114 @@ class TestHandOffTitleQuality:
         # signal from the summary so the recipient can tell tasks apart.
         assert kwargs["title"]
         assert kwargs["title"] != "(handoff)"
+
+
+# ── Bug 4: surface wake_agent failures in hand_off response ──────
+
+
+class TestHandOffWakeFailureSurfacing:
+    """Operator-reported Bug 4: wake_agent failures were silently swallowed.
+
+    The task IS queued in SQLite/blackboard either way, so ``handed_off``
+    stays True. But callers need visibility into wake failures so they
+    can retry the wake or warn the user, instead of silently relying on
+    the recipient's next cron tick.
+    """
+
+    @pytest.mark.asyncio
+    async def test_hand_off_returns_wake_failed_when_wake_raises(self):
+        """Legacy path: wake failure surfaces ``wake_failed`` + ``wake_error``."""
+        from src.agent.builtins.coordination_tool import hand_off
+
+        mc = _make_mesh_client(agent_id="scout")
+        mc.list_agents.return_value = {"analyst": {"role": "analyst"}}
+        mc.wake_agent.side_effect = RuntimeError("agent container 503")
+
+        result = await hand_off(
+            to="analyst",
+            summary="research done",
+            mesh_client=mc,
+        )
+
+        # Task is still queued — handed_off stays True.
+        assert result["handed_off"] is True
+        # Wake failure is surfaced.
+        assert result["wake_failed"] is True
+        assert "agent container 503" in result["wake_error"]
+
+    @pytest.mark.asyncio
+    async def test_hand_off_success_omits_wake_failure_keys(self):
+        """Legacy path: successful wake leaves no wake_failed/wake_error keys."""
+        from src.agent.builtins.coordination_tool import hand_off
+
+        mc = _make_mesh_client(agent_id="scout")
+        mc.list_agents.return_value = {"analyst": {"role": "analyst"}}
+
+        result = await hand_off(
+            to="analyst",
+            summary="research done",
+            mesh_client=mc,
+        )
+
+        assert result["handed_off"] is True
+        assert "wake_failed" not in result
+        assert "wake_error" not in result
+
+    @pytest.mark.asyncio
+    async def test_hand_off_wake_error_message_is_truncated(self):
+        """Legacy path: wake_error is bounded to 200 chars to limit payload size."""
+        from src.agent.builtins.coordination_tool import hand_off
+
+        mc = _make_mesh_client(agent_id="scout")
+        mc.list_agents.return_value = {"analyst": {"role": "analyst"}}
+        huge_msg = "x" * 5000
+        mc.wake_agent.side_effect = RuntimeError(huge_msg)
+
+        result = await hand_off(
+            to="analyst",
+            summary="research done",
+            mesh_client=mc,
+        )
+
+        assert result["handed_off"] is True
+        assert result["wake_failed"] is True
+        assert len(result["wake_error"]) <= 200
+
+    @pytest.mark.asyncio
+    async def test_hand_off_v2_returns_wake_failed_when_wake_raises(self):
+        """V2 path: wake failure surfaces ``wake_failed`` + ``wake_error``."""
+        from src.agent.builtins.coordination_tool import hand_off
+
+        mc = _make_mesh_client(agent_id="scout", v2_enabled=True)
+        mc.list_agents.return_value = {"analyst": {"role": "analyst"}}
+        mc.create_task.return_value = {"id": "task_v2_abc", "status": "pending"}
+        mc.wake_agent.side_effect = RuntimeError("auth token rejected")
+
+        result = await hand_off(
+            to="analyst",
+            summary="enrich the lead",
+            mesh_client=mc,
+        )
+
+        assert result["handed_off"] is True
+        assert result["wake_failed"] is True
+        assert "auth token rejected" in result["wake_error"]
+
+    @pytest.mark.asyncio
+    async def test_hand_off_v2_success_omits_wake_failure_keys(self):
+        """V2 path: successful wake leaves no wake_failed/wake_error keys."""
+        from src.agent.builtins.coordination_tool import hand_off
+
+        mc = _make_mesh_client(agent_id="scout", v2_enabled=True)
+        mc.list_agents.return_value = {"analyst": {"role": "analyst"}}
+        mc.create_task.return_value = {"id": "task_v2_abc", "status": "pending"}
+
+        result = await hand_off(
+            to="analyst",
+            summary="enrich the lead",
+            mesh_client=mc,
+        )
+
+        assert result["handed_off"] is True
+        assert "wake_failed" not in result
+        assert "wake_error" not in result


### PR DESCRIPTION
## Summary

Bug 4 from an operator-agent bug report. Both the legacy and v2 `hand_off` paths in `src/agent/builtins/coordination_tool.py` previously wrapped `mesh_client.wake_agent(...)` in a try/except that logged at DEBUG and returned `{handed_off: True}` regardless of outcome. Wake failures (auth, network, container 5xx) were invisible to the caller, so the operator had no way to know the recipient wasn't actually notified.

## Changes

- Bumped log level from `logger.debug` to `logger.warning` on wake failure (both paths).
- On wake failure, the returned dict now includes `wake_failed: True` and `wake_error: <truncated str>` (max 200 chars to bound payload size).
- `handed_off` stays `True` intentionally — the task IS queued in SQLite/blackboard before the wake call; only the side-channel notification failed. Callers can decide whether to retry the wake or fall back to the recipient's next cron tick.
- On successful wake, the response shape is unchanged (no new keys).

## Test plan

- [x] Added 5 new tests in `tests/test_coordination.py::TestHandOffWakeFailureSurfacing` covering both legacy and v2 paths:
  - `test_hand_off_returns_wake_failed_when_wake_raises` (legacy)
  - `test_hand_off_success_omits_wake_failure_keys` (legacy)
  - `test_hand_off_wake_error_message_is_truncated` (legacy, bounds check)
  - `test_hand_off_v2_returns_wake_failed_when_wake_raises`
  - `test_hand_off_v2_success_omits_wake_failure_keys`
- [x] Full `tests/test_coordination.py` suite passes (65/65).
- [x] `ruff check` clean.

## Context

One of four PRs addressing an operator-agent bug report on the coordination tool surface.