### PR TITLE
feat(host): validate model provider has credentials at create time

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -180,7 +180,7 @@ Provisioner manages engine instances via Docker/systemd on Hetzner VPS:
 
 ### Config & Environment
 - `.env` file loaded via python-dotenv at CLI startup
-- `OPENLEGION_SYSTEM_<PROVIDER>_API_KEY` env vars for LLM provider keys (mesh-only)
+- `OPENLEGION_SYSTEM_<PROVIDER>_API_KEY` env vars for LLM provider keys (mesh-only). **Agent creation validates that the chosen model's provider has credentials configured** — `create_agent` / `apply_template` reject with HTTP 400 (or `ValueError` on the CLI path) if e.g. you ask for `openai/gpt-4o-mini` but only `OPENLEGION_SYSTEM_ANTHROPIC_API_KEY` is set. `available_providers` is surfaced on `/mesh/introspect?section=llm` and `/mesh/system/metrics` so the operator can pick a reachable model up front. Helpers `resolve_provider_for_model()` and `get_available_providers()` live in `src/shared/models.py`.
 - `OPENLEGION_CRED_<NAME>` env vars for agent-tier credentials
 - `OPENLEGION_MAX_AGENTS`, `OPENLEGION_MAX_PROJECTS` for plan limits
 - `OPENLEGION_LOG_FORMAT=json` for production

--- a/src/agent/builtins/introspect_tool.py
+++ b/src/agent/builtins/introspect_tool.py
@@ -23,9 +23,12 @@ from src.agent.skills import skill
         "section": {
             "type": "string",
             "description": (
-                "What to query: permissions, budget, fleet, cron, health, or all"
+                "What to query: permissions, budget, fleet, cron, health, "
+                "llm (available LLM providers), or all"
             ),
-            "enum": ["permissions", "budget", "fleet", "cron", "health", "all"],
+            "enum": [
+                "permissions", "budget", "fleet", "cron", "health", "llm", "all",
+            ],
             "default": "all",
         },
     },

--- a/src/cli/config.py
+++ b/src/cli/config.py
@@ -1285,6 +1285,24 @@ def _create_agent_from_template(
     resolved_model = model or agent_def.get("model", default_model)
     resolved_model = resolved_model.replace("{default_model}", default_model)
 
+    # BYOK-safety: reject up front if the resolved model's provider
+    # has no credentials in env. Mirrors the mesh-side check in
+    # ``create_custom_agent`` so ``apply_template`` doesn't silently
+    # mint dead-on-arrival agents (Bug 5).
+    from src.shared.models import get_available_providers, resolve_provider_for_model
+    provider = resolve_provider_for_model(resolved_model)
+    if provider:
+        available = get_available_providers()
+        if provider not in available:
+            available_list = sorted(available) if available else "none"
+            raise ValueError(
+                f"Model '{resolved_model}' requires '{provider}' "
+                f"credentials, but no {provider.upper()} key is "
+                f"configured. Available providers: {available_list}. "
+                f"Set OPENLEGION_SYSTEM_{provider.upper()}_API_KEY or "
+                "pick a different model.",
+            )
+
     instructions = agent_def.get("instructions", "") or agent_def.get("system_prompt", "")
     soul = agent_def.get("soul", "")
     heartbeat = agent_def.get("heartbeat", "")

--- a/src/host/server.py
+++ b/src/host/server.py
@@ -2462,6 +2462,22 @@ def create_mesh_app(
         if section in ("project", "all"):
             result["project"] = _agent_projects.get(agent_id)
 
+        if section in ("llm", "all"):
+            # BYOK visibility: surface the set of providers that actually
+            # have credentials configured so agents can introspect what
+            # models are reachable before they request one. Bug 5 —
+            # paired with the mesh-side validation in
+            # ``create_custom_agent``.
+            available_providers: list[str] = []
+            if credential_vault is not None:
+                try:
+                    available_providers = sorted(
+                        credential_vault.get_providers_with_credentials(),
+                    )
+                except Exception as e:
+                    logger.debug("introspect available_providers failed: %s", e)
+            result["llm"] = {"available_providers": available_providers}
+
         return result
 
     # === Project Costs ===
@@ -2947,6 +2963,29 @@ def create_mesh_app(
         # Default model
         if not model:
             model = config.get("llm", {}).get("default_model", "openai/gpt-4o-mini")
+
+        # BYOK-safety: validate the chosen model's provider has
+        # credentials configured before we spin a container that would
+        # otherwise die on its first LLM call. Bug 5 — silent
+        # dead-on-arrival agents on deployments that only have one
+        # provider key set. Skip when no vault is wired (test
+        # harnesses, sandbox transport) — the vault is the only way
+        # to enumerate which providers actually have OAuth state.
+        if credential_vault is not None:
+            from src.shared.models import resolve_provider_for_model
+            provider = resolve_provider_for_model(model)
+            if provider:
+                available = credential_vault.get_providers_with_credentials()
+                if provider not in available:
+                    available_list = sorted(available) if available else "none"
+                    raise HTTPException(
+                        400,
+                        f"Model '{model}' requires '{provider}' credentials, "
+                        f"but no {provider.upper()} key is configured. "
+                        f"Available providers: {available_list}. Set "
+                        f"OPENLEGION_SYSTEM_{provider.upper()}_API_KEY or "
+                        "pick a different model.",
+                    )
 
         # Create agent config
         import random
@@ -3552,6 +3591,21 @@ def create_mesh_app(
         from src.cli.config import _load_projects
         current_projects = len(_load_projects())
 
+        # -- BYOK visibility (Bug 5) --
+        # Operators (and the operator agent's heartbeat playbook) need
+        # to know which providers actually have credentials configured
+        # so they can pick a model that won't dead-on-arrival at create
+        # time. Paired with the up-front validation in
+        # ``create_custom_agent`` and ``_create_agent_from_template``.
+        available_providers: list[str] = []
+        if credential_vault is not None:
+            try:
+                available_providers = sorted(
+                    credential_vault.get_providers_with_credentials(),
+                )
+            except Exception as e:
+                logger.debug("system_metrics available_providers failed: %s", e)
+
         return {
             "total_agents": total,
             "healthy": healthy,
@@ -3601,6 +3655,10 @@ def create_mesh_app(
             # dict — defaultdict semantics; readers should treat missing
             # keys as zero.
             "tool_denials_24h": dict(_denial_counter),
+            # Bug 5 — BYOK provider visibility. Sorted list of provider
+            # names with credentials currently configured. Empty list
+            # means no LLM keys at all (deployment broken).
+            "available_providers": available_providers,
         }
 
     @app.get("/mesh/agents/{agent_id}/metrics")

--- a/src/shared/models.py
+++ b/src/shared/models.py
@@ -11,10 +11,13 @@ Public API:
     get_all_model_costs()         -> dict[str, tuple[float, float]]
     get_all_providers()           -> list[dict[str, str]]
     get_known_provider_names()    -> frozenset[str]
+    resolve_provider_for_model(m) -> str | None
+    get_available_providers()     -> set[str]
 """
 
 from __future__ import annotations
 
+import os
 from functools import lru_cache
 
 # ── Provider registry ─────────────────────────────────────
@@ -484,3 +487,78 @@ def estimate_cost(
     pt = input_tokens if input_tokens is not None and input_tokens > 0 else int(total_tokens * 0.7)
     ct = output_tokens if output_tokens is not None and output_tokens > 0 else (total_tokens - pt)
     return round((pt / 1000 * ir) + (ct / 1000 * or_), 6)
+
+
+# ── Provider resolution / availability ─────────────────────
+# Bare-name prefixes (e.g. ``gpt-``, ``o1``) that map to known
+# providers without a ``provider/model`` slash. Mirrors the override
+# table in ``src/host/credentials.py:_PROVIDER_PREFIX_OVERRIDES`` so
+# CLI-side validators and the mesh agree on provider resolution.
+_BARE_PROVIDER_PREFIXES: dict[str, str] = {
+    "gpt-": "openai",
+    "o1": "openai",
+    "o3": "openai",
+    "o4": "openai",
+    "ollama_chat/": "ollama",
+    "text-embedding-": "openai",
+}
+
+
+def resolve_provider_for_model(model: str) -> str | None:
+    """Extract the provider prefix from a litellm-format model string.
+
+    Returns ``None`` for empty strings or names that lack a slash and
+    don't match a known bare-name prefix. For namespaced names like
+    ``openrouter/anthropic/claude-...`` the FIRST segment (``openrouter``)
+    is returned — the outer provider is what determines which API key /
+    routing path is used at call time.
+
+    Used by ``create_agent`` / ``apply_template`` to validate up front
+    that the chosen model's provider has credentials configured.
+    """
+    if not model or not isinstance(model, str):
+        return None
+    for prefix, provider in _BARE_PROVIDER_PREFIXES.items():
+        if model.startswith(prefix):
+            return provider
+    if "/" in model:
+        return model.split("/", 1)[0]
+    return None
+
+
+def get_available_providers() -> set[str]:
+    """Return the set of lowercase provider names with credentials in env.
+
+    Pure ``os.environ`` inspection so it works from CLI / dashboard
+    paths that don't hold a live ``CredentialVault``. The mesh-side
+    equivalent ``CredentialVault.get_providers_with_credentials()``
+    additionally consults loaded OAuth state and the ``api_bases`` map;
+    callers that need that richer picture should prefer the vault method.
+
+    Detection rules (mirrors ``credentials.py`` loading):
+
+    * ``OPENLEGION_SYSTEM_<PROVIDER>_API_KEY`` → provider with key
+    * ``OPENLEGION_SYSTEM_<PROVIDER>_API_BASE`` → keyless provider
+      (e.g. ``ollama``) reachable
+    * ``OPENLEGION_SYSTEM_OPENAI_OAUTH`` → openai
+    * ``OPENLEGION_SYSTEM_ANTHROPIC_OAUTH`` → anthropic
+    """
+    providers: set[str] = set()
+    sys_prefix = "OPENLEGION_SYSTEM_"
+    for key, value in os.environ.items():
+        if not key.startswith(sys_prefix) or not value:
+            continue
+        tail = key[len(sys_prefix):]
+        if tail.endswith("_API_KEY"):
+            provider = tail[: -len("_API_KEY")].lower()
+            if provider:
+                providers.add(provider)
+        elif tail.endswith("_API_BASE"):
+            provider = tail[: -len("_API_BASE")].lower()
+            if provider in KEYLESS_PROVIDERS:
+                providers.add(provider)
+        elif tail == "OPENAI_OAUTH":
+            providers.add("openai")
+        elif tail == "ANTHROPIC_OAUTH":
+            providers.add("anthropic")
+    return providers

--- a/tests/test_create_agent_model_validation.py
+++ b/tests/test_create_agent_model_validation.py
@@ -1,0 +1,362 @@
+"""Tests for BYOK-aware model-provider validation at agent creation.
+
+Bug 5 — ``create_custom_agent`` and ``_create_agent_from_template`` used
+to pick a hardcoded default model (``openai/gpt-4o-mini``) without
+checking which providers actually had credentials. On a BYOK deployment
+with only ``OPENLEGION_SYSTEM_ANTHROPIC_API_KEY`` set, agents were
+created successfully but died silently on first LLM call.
+
+These tests pin the up-front validation: HTTP 400 (mesh) /
+``ValueError`` (CLI template path) when the resolved model's provider
+has no key in env, success when it does, and a clear "no providers
+configured" message when env has nothing at all.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from fastapi.testclient import TestClient
+
+from src.host.credentials import CredentialVault
+from src.host.mesh import Blackboard, MessageRouter, PubSub
+from src.host.permissions import PermissionMatrix
+from src.host.server import create_mesh_app
+from src.shared.models import get_available_providers, resolve_provider_for_model
+from src.shared.types import AgentPermissions
+
+# ── resolve_provider_for_model edge cases ──────────────────
+
+
+def test_resolve_provider_empty_string():
+    assert resolve_provider_for_model("") is None
+
+
+def test_resolve_provider_none_typed():
+    # Non-string inputs (defensive) — should return None, not raise.
+    assert resolve_provider_for_model(None) is None  # type: ignore[arg-type]
+
+
+def test_resolve_provider_no_slash_unknown():
+    # Bare name without slash and not in the override table → None.
+    assert resolve_provider_for_model("some-random-model") is None
+
+
+def test_resolve_provider_standard_slash_form():
+    assert resolve_provider_for_model("openai/gpt-4o-mini") == "openai"
+    assert resolve_provider_for_model("anthropic/claude-sonnet-4-5-20250929") == "anthropic"
+    assert resolve_provider_for_model("gemini/gemini-2.5-pro") == "gemini"
+
+
+def test_resolve_provider_openrouter_namespaced():
+    # ``openrouter/anthropic/claude-...`` — outer provider wins because
+    # that's what determines the API key / routing path.
+    assert (
+        resolve_provider_for_model("openrouter/anthropic/claude-3.5-sonnet")
+        == "openrouter"
+    )
+
+
+def test_resolve_provider_bare_openai_prefixes():
+    assert resolve_provider_for_model("gpt-4o-mini") == "openai"
+    assert resolve_provider_for_model("o1-preview") == "openai"
+    assert resolve_provider_for_model("o3-mini") == "openai"
+    assert resolve_provider_for_model("o4-mini") == "openai"
+
+
+def test_resolve_provider_ollama_alt_prefix():
+    assert resolve_provider_for_model("ollama_chat/llama3") == "ollama"
+
+
+# ── get_available_providers env inspection ──────────────────
+
+
+def _clear_system_env(monkeypatch):
+    """Strip every ``OPENLEGION_SYSTEM_*`` env var for a clean slate."""
+    import os
+    for key in list(os.environ):
+        if key.startswith("OPENLEGION_SYSTEM_"):
+            monkeypatch.delenv(key, raising=False)
+
+
+def test_get_available_providers_empty(monkeypatch):
+    _clear_system_env(monkeypatch)
+    assert get_available_providers() == set()
+
+
+def test_get_available_providers_picks_up_api_key(monkeypatch):
+    _clear_system_env(monkeypatch)
+    monkeypatch.setenv("OPENLEGION_SYSTEM_ANTHROPIC_API_KEY", "sk-ant")
+    assert get_available_providers() == {"anthropic"}
+
+
+def test_get_available_providers_multiple(monkeypatch):
+    _clear_system_env(monkeypatch)
+    monkeypatch.setenv("OPENLEGION_SYSTEM_ANTHROPIC_API_KEY", "sk-ant")
+    monkeypatch.setenv("OPENLEGION_SYSTEM_OPENAI_API_KEY", "sk-oai")
+    assert get_available_providers() == {"anthropic", "openai"}
+
+
+def test_get_available_providers_oauth_counts_as_openai(monkeypatch):
+    _clear_system_env(monkeypatch)
+    monkeypatch.setenv("OPENLEGION_SYSTEM_OPENAI_OAUTH", '{"token": "..."}')
+    assert "openai" in get_available_providers()
+
+
+def test_get_available_providers_ollama_api_base(monkeypatch):
+    _clear_system_env(monkeypatch)
+    monkeypatch.setenv("OPENLEGION_SYSTEM_OLLAMA_API_BASE", "http://localhost:11434")
+    assert "ollama" in get_available_providers()
+
+
+def test_get_available_providers_ignores_empty_values(monkeypatch):
+    _clear_system_env(monkeypatch)
+    monkeypatch.setenv("OPENLEGION_SYSTEM_ANTHROPIC_API_KEY", "")
+    assert get_available_providers() == set()
+
+
+# ── mesh create_custom_agent validation ────────────────────
+
+
+@pytest.fixture()
+def _mesh_env(tmp_path, monkeypatch):
+    """Patch config module paths so agent creation writes to tmp_path."""
+    cfg_dir = tmp_path / "config"
+    cfg_dir.mkdir()
+    skills_dir = tmp_path / "skills"
+    skills_dir.mkdir()
+
+    monkeypatch.setattr("src.cli.config.PROJECT_ROOT", tmp_path)
+    monkeypatch.setattr("src.cli.config.AGENTS_FILE", cfg_dir / "agents.yaml")
+    monkeypatch.setattr("src.cli.config.PERMISSIONS_FILE", cfg_dir / "permissions.json")
+    monkeypatch.setattr("src.cli.config.CONFIG_FILE", cfg_dir / "mesh.yaml")
+
+
+@pytest.fixture()
+def container_mgr():
+    mgr = MagicMock()
+    mgr.start_agent.return_value = "http://localhost:9001"
+    mgr.wait_for_agent = AsyncMock(return_value=True)
+    mgr.agents = {}
+    return mgr
+
+
+def _build_mesh_app(tmp_path, container_mgr, vault: CredentialVault | None):
+    """Build a test mesh with operator perms and an optional vault."""
+    bb = Blackboard(db_path=str(tmp_path / "bb.db"))
+    pubsub = PubSub()
+    import json as _json
+    perms_file = tmp_path / "config" / "permissions.json"
+    perms_file.parent.mkdir(parents=True, exist_ok=True)
+    perms_file.write_text(_json.dumps({
+        "permissions": {
+            "operator": {
+                "can_message": ["*"],
+                "can_spawn": True,
+                "can_manage_fleet": True,
+                "blackboard_read": ["*"],
+                "blackboard_write": ["*"],
+            },
+        },
+    }))
+    perms = PermissionMatrix.__new__(PermissionMatrix)
+    perms.permissions = {
+        "operator": AgentPermissions(
+            agent_id="operator",
+            can_message=["*"],
+            can_spawn=True,
+            can_manage_fleet=True,
+            blackboard_read=["*"],
+            blackboard_write=["*"],
+        ),
+    }
+    perms._config_path = str(perms_file)
+    router = MessageRouter(permissions=perms, agent_registry={})
+    app = create_mesh_app(
+        bb, pubsub, router, perms,
+        container_manager=container_mgr,
+        credential_vault=vault,
+    )
+    return TestClient(app), bb
+
+
+def test_create_agent_rejects_model_without_credentials(
+    tmp_path, _mesh_env, container_mgr, monkeypatch,
+):
+    """Anthropic-only deployment, ask for openai/gpt-4o-mini → 400."""
+    _clear_system_env(monkeypatch)
+    monkeypatch.setenv("OPENLEGION_SYSTEM_ANTHROPIC_API_KEY", "sk-ant-only")
+    vault = CredentialVault()
+
+    client, bb = _build_mesh_app(tmp_path, container_mgr, vault)
+    try:
+        resp = client.post(
+            "/mesh/agents/create",
+            json={
+                "agent_id": "operator",
+                "name": "byok_blind",
+                "role": "research",
+                "model": "openai/gpt-4o-mini",
+            },
+        )
+        assert resp.status_code == 400, resp.text
+        detail = resp.json()["detail"]
+        # Message must name the missing provider AND list what's available.
+        assert "openai" in detail.lower()
+        assert "anthropic" in detail.lower()
+        assert "OPENLEGION_SYSTEM_OPENAI_API_KEY" in detail
+        # Container should NOT have been started.
+        container_mgr.start_agent.assert_not_called()
+    finally:
+        bb.close()
+
+
+def test_create_agent_accepts_model_with_credentials(
+    tmp_path, _mesh_env, container_mgr, monkeypatch,
+):
+    """Anthropic key present, ask for anthropic/... → success."""
+    _clear_system_env(monkeypatch)
+    monkeypatch.setenv("OPENLEGION_SYSTEM_ANTHROPIC_API_KEY", "sk-ant-only")
+    vault = CredentialVault()
+
+    client, bb = _build_mesh_app(tmp_path, container_mgr, vault)
+    try:
+        resp = client.post(
+            "/mesh/agents/create",
+            json={
+                "agent_id": "operator",
+                "name": "byok_happy",
+                "role": "research",
+                "model": "anthropic/claude-sonnet-4-5-20250929",
+            },
+        )
+        assert resp.status_code == 200, resp.text
+        container_mgr.start_agent.assert_called_once()
+    finally:
+        bb.close()
+
+
+def test_create_agent_rejects_when_no_provider_keys_present(
+    tmp_path, _mesh_env, container_mgr, monkeypatch,
+):
+    """Zero provider keys → rejection message mentions 'none' available."""
+    _clear_system_env(monkeypatch)
+    vault = CredentialVault()
+
+    client, bb = _build_mesh_app(tmp_path, container_mgr, vault)
+    try:
+        resp = client.post(
+            "/mesh/agents/create",
+            json={
+                "agent_id": "operator",
+                "name": "no_keys_at_all",
+                "role": "test",
+                "model": "openai/gpt-4o-mini",
+            },
+        )
+        # Rejection is graceful — proper 400, clear copy.
+        assert resp.status_code == 400, resp.text
+        detail = resp.json()["detail"]
+        assert "none" in detail.lower()
+        container_mgr.start_agent.assert_not_called()
+    finally:
+        bb.close()
+
+
+def test_create_agent_skips_validation_when_no_vault(
+    tmp_path, _mesh_env, container_mgr, monkeypatch,
+):
+    """No CredentialVault wired (test harness / sandbox) → skip the
+    validation rather than block. The vault is the only thing that can
+    enumerate OAuth state, so without it we'd be guessing.
+    """
+    _clear_system_env(monkeypatch)
+    client, bb = _build_mesh_app(tmp_path, container_mgr, vault=None)
+    try:
+        resp = client.post(
+            "/mesh/agents/create",
+            json={
+                "agent_id": "operator",
+                "name": "no_vault",
+                "role": "test",
+                "model": "openai/gpt-4o-mini",
+            },
+        )
+        assert resp.status_code == 200, resp.text
+    finally:
+        bb.close()
+
+
+# ── CLI template-path validation ───────────────────────────
+
+
+def test_apply_template_rejects_model_without_credentials(tmp_path, monkeypatch):
+    """``_create_agent_from_template`` must reject up front when the
+    resolved model's provider has no key in env. Mirrors the mesh-side
+    check so ``apply_template`` doesn't silently mint dead agents.
+    """
+    _clear_system_env(monkeypatch)
+    monkeypatch.setenv("OPENLEGION_SYSTEM_ANTHROPIC_API_KEY", "sk-ant-only")
+
+    cfg_dir = tmp_path / "config"
+    cfg_dir.mkdir()
+    monkeypatch.setattr("src.cli.config.PROJECT_ROOT", tmp_path)
+    monkeypatch.setattr("src.cli.config.AGENTS_FILE", cfg_dir / "agents.yaml")
+    monkeypatch.setattr("src.cli.config.PERMISSIONS_FILE", cfg_dir / "permissions.json")
+    monkeypatch.setattr("src.cli.config.CONFIG_FILE", cfg_dir / "mesh.yaml")
+
+    # Stub the template loader so we don't depend on the on-disk YAMLs.
+    fake_template = {
+        "starter": {
+            "agents": {
+                "worker": {
+                    "role": "worker",
+                    "model": "openai/gpt-4o-mini",  # forces the openai provider
+                    "instructions": "do work",
+                },
+            },
+        },
+    }
+    monkeypatch.setattr("src.cli.config._load_templates", lambda: fake_template)
+
+    from src.cli.config import _create_agent_from_template
+    with pytest.raises(ValueError) as exc:
+        _create_agent_from_template(name="worker", template_id="starter/worker", model="")
+    msg = str(exc.value).lower()
+    assert "openai" in msg
+    assert "anthropic" in msg
+
+
+def test_apply_template_accepts_model_with_credentials(tmp_path, monkeypatch):
+    """Inverse of the above — anthropic key in env, anthropic model → OK."""
+    _clear_system_env(monkeypatch)
+    monkeypatch.setenv("OPENLEGION_SYSTEM_ANTHROPIC_API_KEY", "sk-ant-only")
+
+    cfg_dir = tmp_path / "config"
+    cfg_dir.mkdir()
+    monkeypatch.setattr("src.cli.config.PROJECT_ROOT", tmp_path)
+    monkeypatch.setattr("src.cli.config.AGENTS_FILE", cfg_dir / "agents.yaml")
+    monkeypatch.setattr("src.cli.config.PERMISSIONS_FILE", cfg_dir / "permissions.json")
+    monkeypatch.setattr("src.cli.config.CONFIG_FILE", cfg_dir / "mesh.yaml")
+
+    fake_template = {
+        "starter": {
+            "agents": {
+                "worker": {
+                    "role": "worker",
+                    "model": "anthropic/claude-sonnet-4-5-20250929",
+                    "instructions": "do work",
+                },
+            },
+        },
+    }
+    monkeypatch.setattr("src.cli.config._load_templates", lambda: fake_template)
+
+    from src.cli.config import _create_agent_from_template
+    # Should not raise.
+    _create_agent_from_template(name="worker", template_id="starter/worker", model="")
+    # And the agent should be present in agents.yaml.
+    import yaml
+    data = yaml.safe_load((cfg_dir / "agents.yaml").read_text())
+    assert "worker" in data.get("agents", {})

--- a/tests/test_templates.py
+++ b/tests/test_templates.py
@@ -42,12 +42,23 @@ class _TempConfigMixin:
         cfg_mod.PROJECT_ROOT = Path(self._tmpdir)
         # Initialize empty permissions
         self._perms_path.write_text(json.dumps({"permissions": {}}, indent=2))
+        # _create_agent_from_template now validates the chosen model's
+        # provider has a key in env (Bug 5). These tests use
+        # ``openai/gpt-4o*`` models — give them a placeholder key.
+        import os
+        self._orig_openai_key = os.environ.get("OPENLEGION_SYSTEM_OPENAI_API_KEY")
+        os.environ["OPENLEGION_SYSTEM_OPENAI_API_KEY"] = "sk-test-templates"
 
     def teardown_method(self):
         import src.cli.config as cfg_mod
         cfg_mod.AGENTS_FILE = self._orig_agents
         cfg_mod.PERMISSIONS_FILE = self._orig_perms
         cfg_mod.PROJECT_ROOT = self._orig_root
+        import os
+        if self._orig_openai_key is None:
+            os.environ.pop("OPENLEGION_SYSTEM_OPENAI_API_KEY", None)
+        else:
+            os.environ["OPENLEGION_SYSTEM_OPENAI_API_KEY"] = self._orig_openai_key
         shutil.rmtree(self._tmpdir, ignore_errors=True)
 
     def _mock_config(self, *, collab=True):


### PR DESCRIPTION
## Summary

- **Bug 5 fix.** `create_custom_agent` and `_create_agent_from_template` used to pick a hardcoded default model (`openai/gpt-4o-mini`) without checking which providers actually had credentials. On a BYOK deployment with only `OPENLEGION_SYSTEM_ANTHROPIC_API_KEY` set, agents were created successfully but died silently on first LLM call.
- Both paths now validate **up front** — HTTP 400 (mesh) / `ValueError` (CLI template path) when the resolved model's provider has no key. The message names the missing provider, lists what's available, and tells the operator which env var to set. Avoids silent dead-on-arrival agents.
- `available_providers` is also surfaced on `/mesh/introspect?section=llm` and `/mesh/system/metrics` so the operator agent's heartbeat playbook can pick a reachable model up front.

## Design notes

Scoped **out** as over-engineered (per the principal-engineer call on this fix):

- **No `deployment_mode` enum.** Validation only — no new config surface.
- **No Settings tab UI for provider preference.** No new tabs.
- **Default model unchanged.** Only the validation is new.

Helpers added to `src/shared/models.py`:

- `resolve_provider_for_model(model) -> str | None` — handles empty / no-slash / `openrouter/anthropic/...` (first segment wins) / bare-name prefixes (`gpt-`, `o1`, `ollama_chat/`, etc.). Mirrors `credentials.py:_PROVIDER_PREFIX_OVERRIDES` so CLI and mesh agree.
- `get_available_providers() -> set[str]` — pure `os.environ` inspection so the CLI template path (no live vault) can call it. Mesh side keeps using `CredentialVault.get_providers_with_credentials()` because the vault additionally knows OAuth state.

Vault-less callers (test harness, sandbox transport) skip validation rather than block.

## Test plan

- [x] `tests/test_create_agent_model_validation.py` — 19 new tests:
  - `resolve_provider_for_model` edge cases (empty, no slash, openrouter namespaced, bare openai prefixes, `ollama_chat/`)
  - `get_available_providers` env inspection (empty, single key, multi, OAuth, ollama api_base, empty-value skip)
  - mesh `create_agent` rejects mismatched provider with helpful 400; accepts when provider matches; rejects gracefully when zero providers configured; skips validation when vault is None
  - CLI `_create_agent_from_template` rejects mismatched provider with `ValueError`; accepts matching provider
- [x] Existing `tests/test_operator_create_agent.py` (16 tests) and `tests/test_credentials.py` (245 tests) still green
- [x] Updated `tests/test_templates.py` fixture to set `OPENLEGION_SYSTEM_OPENAI_API_KEY` (existing tests used `openai/gpt-4o*` without an env key) — 77 tests green
- [x] Full unit/integration suite (6052 tests) passes — sole failure was an unrelated rate-limit timing flake in `test_dashboard_telemetry` that passes when run alone
- [x] `ruff check` clean