### PR TITLE
fix(host): unbreak operator destructive-action confirm flow

### DIFF
--- a/src/agent/mesh_client.py
+++ b/src/agent/mesh_client.py
@@ -1328,21 +1328,43 @@ class MeshClient:
         return response.json()
 
     async def propose_delete_project(self, name: str) -> dict:
-        """Propose deletion of an archived project. Returns nonce for human confirm."""
+        """Propose deletion of an archived project. Returns nonce for human confirm.
+
+        Forwards ``current_origin`` so the mesh stores the pending row
+        with ``origin_kind="human"`` when the caller is handling a
+        human-originated message. Without this the subsequent confirm
+        fails the ``require_origin_kind="human"`` gate (Bug A).
+        """
+        from src.shared.trace import current_origin
+        headers = self._trace_headers()
+        origin = current_origin.get()
+        if origin is not None:
+            headers.update(origin_header(origin))
         client = await self._get_client()
         response = await client.post(
             f"{self.mesh_url}/mesh/projects/{name}/propose-delete",
-            headers=self._trace_headers(),
+            headers=headers,
         )
         response.raise_for_status()
         return response.json()
 
     async def propose_delete_agent(self, agent_id: str) -> dict:
-        """Propose deletion of an archived agent. Returns nonce for human confirm."""
+        """Propose deletion of an archived agent. Returns nonce for human confirm.
+
+        Forwards ``current_origin`` so the mesh stores the pending row
+        with ``origin_kind="human"`` when the caller is handling a
+        human-originated message. Without this the subsequent confirm
+        fails the ``require_origin_kind="human"`` gate (Bug A).
+        """
+        from src.shared.trace import current_origin
+        headers = self._trace_headers()
+        origin = current_origin.get()
+        if origin is not None:
+            headers.update(origin_header(origin))
         client = await self._get_client()
         response = await client.post(
             f"{self.mesh_url}/mesh/agents/{agent_id}/propose-delete",
-            headers=self._trace_headers(),
+            headers=headers,
         )
         response.raise_for_status()
         return response.json()

--- a/src/agent/mesh_client.py
+++ b/src/agent/mesh_client.py
@@ -12,7 +12,7 @@ from typing import TYPE_CHECKING
 
 import httpx
 
-from src.shared.trace import origin_header
+from src.shared.trace import current_origin, origin_header
 from src.shared.types import MeshEvent
 from src.shared.utils import setup_logging
 
@@ -79,6 +79,26 @@ class MeshClient:
         """Return current trace headers for per-request injection."""
         from src.shared.trace import trace_headers
         return trace_headers()
+
+    def _trace_and_origin_headers(self) -> dict[str, str]:
+        """Trace headers + ``X-Origin`` when a current origin is set.
+
+        Used by state-mutating *propose* paths where the mesh stores the
+        proposer's origin kind on the pending row and the subsequent
+        confirm gates on ``origin_kind="human"``. Reads from the
+        ``current_origin`` ContextVar so the pattern works transparently
+        for any code that already runs under an origin-stamped task.
+
+        Kept separate from :meth:`_trace_headers` so non-propose paths
+        (blackboard reads, status updates, etc.) don't get
+        origin-stamped — origin only carries meaning for proposes /
+        confirms that the mesh gates against.
+        """
+        headers = dict(self._trace_headers())
+        origin = current_origin.get()
+        if origin is not None:
+            headers.update(origin_header(origin))
+        return headers
 
     # Retry config for idempotent reads — resilience to transient mesh errors
     _GET_MAX_RETRIES = 2
@@ -734,12 +754,22 @@ class MeshClient:
     # === Operator agent config management ===
 
     async def propose_config_change(self, agent_id: str, field: str, value) -> dict:
-        """Propose a config change for an agent. Returns preview + change_id."""
+        """Propose a config change for an agent. Returns preview + change_id.
+
+        Forwards ``current_origin`` via :meth:`_trace_and_origin_headers`
+        so the mesh stores the pending row with ``origin_kind="human"``
+        when the caller is handling a human-originated message. Defensive
+        against the same Bug A pattern that bit the destructive-confirm
+        flow: this path is unreachable in production today (operator
+        routes through ``edit_agent``), but the mesh endpoint is still
+        wired and any future caller would silently reproduce the bug
+        without this forwarding.
+        """
         client = await self._get_client()
         response = await client.post(
             f"{self.mesh_url}/mesh/agents/{agent_id}/propose",
             json={"field": field, "value": value, "proposed_by": self.agent_id},
-            headers=self._trace_headers(),
+            headers=self._trace_and_origin_headers(),
         )
         response.raise_for_status()
         return response.json()
@@ -748,13 +778,16 @@ class MeshClient:
         """Confirm and apply a previously proposed config change.
 
         Uses the dedicated /mesh/config/confirm endpoint which resolves
-        the target agent_id from the pending change internally.
+        the target agent_id from the pending change internally. Forwards
+        ``current_origin`` so the mesh's confirm-side ``X-Origin`` re-
+        check sees a human origin (see Bug A note on
+        :meth:`propose_config_change`).
         """
         client = await self._get_client()
         response = await client.post(
             f"{self.mesh_url}/mesh/config/confirm",
             json={"change_id": change_id, "confirmed_by": self.agent_id},
-            headers=self._trace_headers(),
+            headers=self._trace_and_origin_headers(),
         )
         response.raise_for_status()
         return response.json()
@@ -1330,20 +1363,16 @@ class MeshClient:
     async def propose_delete_project(self, name: str) -> dict:
         """Propose deletion of an archived project. Returns nonce for human confirm.
 
-        Forwards ``current_origin`` so the mesh stores the pending row
-        with ``origin_kind="human"`` when the caller is handling a
-        human-originated message. Without this the subsequent confirm
-        fails the ``require_origin_kind="human"`` gate (Bug A).
+        Forwards ``current_origin`` via :meth:`_trace_and_origin_headers`
+        so the mesh stores the pending row with ``origin_kind="human"``
+        when the caller is handling a human-originated message. Without
+        this the subsequent confirm fails the
+        ``require_origin_kind="human"`` gate (Bug A).
         """
-        from src.shared.trace import current_origin
-        headers = self._trace_headers()
-        origin = current_origin.get()
-        if origin is not None:
-            headers.update(origin_header(origin))
         client = await self._get_client()
         response = await client.post(
             f"{self.mesh_url}/mesh/projects/{name}/propose-delete",
-            headers=headers,
+            headers=self._trace_and_origin_headers(),
         )
         response.raise_for_status()
         return response.json()
@@ -1351,20 +1380,16 @@ class MeshClient:
     async def propose_delete_agent(self, agent_id: str) -> dict:
         """Propose deletion of an archived agent. Returns nonce for human confirm.
 
-        Forwards ``current_origin`` so the mesh stores the pending row
-        with ``origin_kind="human"`` when the caller is handling a
-        human-originated message. Without this the subsequent confirm
-        fails the ``require_origin_kind="human"`` gate (Bug A).
+        Forwards ``current_origin`` via :meth:`_trace_and_origin_headers`
+        so the mesh stores the pending row with ``origin_kind="human"``
+        when the caller is handling a human-originated message. Without
+        this the subsequent confirm fails the
+        ``require_origin_kind="human"`` gate (Bug A).
         """
-        from src.shared.trace import current_origin
-        headers = self._trace_headers()
-        origin = current_origin.get()
-        if origin is not None:
-            headers.update(origin_header(origin))
         client = await self._get_client()
         response = await client.post(
             f"{self.mesh_url}/mesh/agents/{agent_id}/propose-delete",
-            headers=headers,
+            headers=self._trace_and_origin_headers(),
         )
         response.raise_for_status()
         return response.json()

--- a/src/dashboard/static/js/app.js
+++ b/src/dashboard/static/js/app.js
@@ -2049,6 +2049,31 @@ function dashboard() {
       }
     },
 
+    // Top-nav Needs-You badge click handler. Routes to the Work tab when
+    // any item is a durable pending action (the Work tab's unified panel
+    // renders confirm/cancel inline), otherwise falls back to chat where
+    // the credential/browser/captcha overlay cards live. The kind-aware
+    // routing replaces the legacy "always chat" handler that buried
+    // destructive operator confirms behind a tab switch.
+    _routeNeedsYouBadge() {
+      try {
+        const itemCount = (this.needsYouItems || []).length;
+        this.track('needs_you_click', {
+          item_count: itemCount,
+          item_kind: 'badge',
+          action_label: 'badge',
+        });
+        this._trackFirstAction('needs_you_click');
+      } catch (_) { /* ignore */ }
+      const hasPending = (this.needsYouItems || []).some(i => i.kind === 'pending');
+      this.switchTab(hasPending ? 'workplace' : 'chat');
+      this.$nextTick(() => {
+        const selector = hasPending ? '[data-needs-you-panel]' : '[data-pending-cards]';
+        const el = document.querySelector(selector);
+        if (el) el.scrollIntoView({ behavior: 'smooth', block: 'start' });
+      });
+    },
+
     trackEmptyStateCta(sectionId) {
       // Wired from any empty-state CTA button in the template. Caller
       // passes a stable ``section_id`` so we can compare CTA traction
@@ -3940,6 +3965,18 @@ function dashboard() {
       }
     },
 
+    // Normalises the FastAPI ``detail`` field on a pending-action confirm/cancel
+    // error. The mesh now returns ``{code, message}`` on consume() failures so
+    // the dashboard can show a precise reason; older endpoints (cancel) still
+    // return a bare string. Returns ``{text, code}`` for the toast + telemetry.
+    _formatPendingError(detail, fallback) {
+      if (!detail) return { text: String(fallback ?? ''), code: '' };
+      if (typeof detail === 'string') return { text: detail, code: '' };
+      const text = detail.message || String(fallback ?? '');
+      const code = typeof detail.code === 'string' ? detail.code : '';
+      return { text, code };
+    },
+
     async confirmPendingAction(nonce) {
       try {
         // Route via the dashboard's loopback proxy so the mesh sees
@@ -3959,7 +3996,9 @@ function dashboard() {
         );
         if (!resp.ok) {
           const data = await resp.json().catch(() => ({}));
-          this.showToast(`Confirm failed: ${data.detail || resp.status}`);
+          const { text, code } = this._formatPendingError(data.detail, resp.status);
+          this.track('pending_confirm_failed', { code: code || 'unknown', nonce });
+          this.showToast(`Confirm failed: ${text || resp.status}`);
           return;
         }
         this.workplacePending = this.workplacePending.filter(p => p.nonce !== nonce);
@@ -4028,7 +4067,13 @@ function dashboard() {
         );
         if (!resp.ok) {
           const data = await resp.json().catch(() => ({}));
-          this.showToast(`Confirm failed: ${data.detail || resp.status}`);
+          const { text, code } = this._formatPendingError(data.detail, resp.status);
+          this.track('pending_confirm_failed', {
+            code: code || 'unknown',
+            nonce: msg.event_id || '',
+            via: 'card',
+          });
+          this.showToast(`Confirm failed: ${text || resp.status}`);
           return;
         }
       } catch (e) {
@@ -7627,7 +7672,17 @@ function dashboard() {
         // 1. User messages sent after the last server timestamp
         // 2. Agent messages from just-completed streams not yet persisted
         // 3. Notifications injected via WebSocket not yet in the server transcript
+        // 4. Client-side overlay cards (pending actions, credential/browser/captcha
+        //    requests) — these are NEVER part of the server-side transcript, so the
+        //    role-allowlist filter must keep them or they vanish on every refresh.
+        const overlayRoles = new Set([
+          'pending_action_card',
+          'credential_request',
+          'browser_login_request',
+          'browser_captcha_help_request',
+        ]);
         const trailing = localMsgs.filter(m => {
+          if (overlayRoles.has(m.role)) return true;
           if (m.role === 'notification') {
             if ((m.ts || 0) <= lastServerTs) return false;
             return !serverMsgs.some(s =>

--- a/src/dashboard/static/js/app.js
+++ b/src/dashboard/static/js/app.js
@@ -19,6 +19,30 @@ window.fetch = function(input, init) {
   }
   return _origFetch.call(this, input, init);
 };
+// Client-side-only chat roles — pushed into `chatHistories[agentId]`
+// but NEVER stored server-side. Used by `_loadChatHistory` to keep
+// these cards across a history reload (the server transcript filter
+// would otherwise drop anything not in {user, agent, notification}).
+// If you push a new role into chatHistories anywhere in this file,
+// add it here so it survives reloads. Origin: PR #902 follow-up
+// (operator-confirm-flow review gaps).
+const OVERLAY_CHAT_ROLES = new Set([
+  'pending_action_card',
+  'credential_request',
+  'browser_login_request',
+  'browser_captcha_help_request',
+  'operator_action_receipt',
+  'credit_exhausted',
+]);
+
+// Needs-You item kinds whose "open" action belongs on the Work tab
+// (rather than Chat). `pending` and `blocker` live in the Work tab's
+// sticky panel / task drawer; `unrated` jumps to Work > Activity for
+// the rating buttons. Everything else (credential / browser_login /
+// captcha / worker_dm) routes to Chat where the overlay card lives.
+// Origin: PR #902 follow-up.
+const _BADGE_WORK_TAB_KINDS = new Set(['pending', 'blocker', 'unrated']);
+
 const _IDENTITY_TABS = [
   { id: 'config', label: 'Config', file: null, access: 'user' },
   { id: 'identity', label: 'Identity', file: null, access: 'user' },
@@ -2065,10 +2089,20 @@ function dashboard() {
         });
         this._trackFirstAction('needs_you_click');
       } catch (_) { /* ignore */ }
-      const hasPending = (this.needsYouItems || []).some(i => i.kind === 'pending');
-      this.switchTab(hasPending ? 'workplace' : 'chat');
+      // kind → tab mapping:
+      //   pending / blocker / unrated → Work tab (sticky Needs-You panel
+      //     for pending+blocker; Activity feed with rating buttons for
+      //     unrated). No chat surface for these.
+      //   credential / browser_login / captcha / worker_dm → Chat tab
+      //     where the overlay card lives in operator chat (or the
+      //     worker's own chat for worker_dm).
+      // See _BADGE_WORK_TAB_KINDS at the top of this file.
+      const hasWorkKind = (this.needsYouItems || []).some(
+        i => _BADGE_WORK_TAB_KINDS.has(i.kind),
+      );
+      this.switchTab(hasWorkKind ? 'workplace' : 'chat');
       this.$nextTick(() => {
-        const selector = hasPending ? '[data-needs-you-panel]' : '[data-pending-cards]';
+        const selector = hasWorkKind ? '[data-needs-you-panel]' : '[data-pending-cards]';
         const el = document.querySelector(selector);
         if (el) el.scrollIntoView({ behavior: 'smooth', block: 'start' });
       });
@@ -4017,7 +4051,11 @@ function dashboard() {
         });
         if (!resp.ok) {
           const data = await resp.json().catch(() => ({}));
-          this.showToast(`Cancel failed: ${data.detail || resp.status}`);
+          // detail is now {code, message} (matches confirm) — route
+          // through the shared formatter so `[object Object]` can't
+          // leak into the toast.
+          const { text } = this._formatPendingError(data.detail, resp.status);
+          this.showToast(`Cancel failed: ${text || resp.status}`);
           return;
         }
         this.workplacePending = this.workplacePending.filter(p => p.nonce !== nonce);
@@ -4099,7 +4137,10 @@ function dashboard() {
         );
         if (!resp.ok) {
           const data = await resp.json().catch(() => ({}));
-          this.showToast(`Cancel failed: ${data.detail || resp.status}`);
+          // detail is structured {code, message} on 404 — see comment
+          // on cancelPendingAction.
+          const { text } = this._formatPendingError(data.detail, resp.status);
+          this.showToast(`Cancel failed: ${text || resp.status}`);
           return;
         }
       } catch (e) {
@@ -7673,16 +7714,12 @@ function dashboard() {
         // 2. Agent messages from just-completed streams not yet persisted
         // 3. Notifications injected via WebSocket not yet in the server transcript
         // 4. Client-side overlay cards (pending actions, credential/browser/captcha
-        //    requests) — these are NEVER part of the server-side transcript, so the
-        //    role-allowlist filter must keep them or they vanish on every refresh.
-        const overlayRoles = new Set([
-          'pending_action_card',
-          'credential_request',
-          'browser_login_request',
-          'browser_captcha_help_request',
-        ]);
+        //    requests, operator-action receipts, credit-exhausted toasts) — these
+        //    are NEVER part of the server-side transcript, so the role-allowlist
+        //    filter must keep them or they vanish on every refresh. Roles live in
+        //    OVERLAY_CHAT_ROLES at the top of this file.
         const trailing = localMsgs.filter(m => {
-          if (overlayRoles.has(m.role)) return true;
+          if (OVERLAY_CHAT_ROLES.has(m.role)) return true;
           if (m.role === 'notification') {
             if ((m.ts || 0) <= lastServerTs) return false;
             return !serverMsgs.some(s =>

--- a/src/dashboard/templates/index.html
+++ b/src/dashboard/templates/index.html
@@ -233,7 +233,7 @@
         <button
           x-show="needsYouItems.length > 0"
           x-cloak
-          @click="switchTab('chat'); $nextTick(() => { const el = document.querySelector('[data-pending-cards]'); if (el) el.scrollIntoView({behavior: 'smooth', block: 'start'}); })"
+          @click="_routeNeedsYouBadge()"
           class="needs-you-badge flex items-center gap-1.5 px-2.5 py-1 rounded-md text-xs font-semibold bg-red-900/40 text-red-300 border border-red-700/60 hover:bg-red-900/60 hover:border-red-600/80 transition-colors cursor-pointer"
           aria-live="polite"
           :aria-label="needsYouItems.length + ' items need you. Click to review.'"
@@ -3713,6 +3713,7 @@
         <section x-show="needsYouItems.length > 0" x-cloak
           x-data="{ needsYouExpanded: false, needsYouCollapsedCap: 5 }"
           role="region" aria-label="Pending items that need you"
+          data-needs-you-panel
           class="mb-4 bg-amber-900/15 border border-amber-700/30 rounded-xl p-3 sm:p-4 sticky top-0 z-10 backdrop-blur-sm">
           <div class="flex items-center gap-2 mb-3">
             <svg class="w-4 h-4 text-amber-300 shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">

--- a/src/host/pending_actions.py
+++ b/src/host/pending_actions.py
@@ -39,6 +39,33 @@ logger = setup_logging("host.pending_actions")
 _DEFAULT_TTL_SEC = 300
 
 
+# Map ``PendingActions.consume()`` reason codes to human-readable
+# messages for the structured 400 detail. Colocated with ``consume()``
+# itself so the producer (reason codes) and consumer (humanizer) can't
+# drift apart. ``not_found`` keeps the legacy "invalid or expired"
+# phrasing so tests / dashboards that grep on that substring keep
+# passing. Exposed as a module-level public mapping so ``server.py``
+# (and any future caller) can re-use the same wording.
+PENDING_REASON_MESSAGES: dict[str, str] = {
+    "not_found": "Pending action invalid or expired",
+    "expired": "Pending action expired",
+    "digest_mismatch": "Payload changed since proposal — propose again",
+    "wrong_confirmer": "Wrong confirmer for this pending action",
+    "wrong_origin_kind": (
+        "This action requires a human-origin confirm; the original "
+        "proposal did not carry a verified human origin. "
+        "Re-issue the request from the dashboard or a paired channel."
+    ),
+}
+
+
+def format_pending_reason(reason: str | None) -> str:
+    """Translate a ``consume()`` reason code into a human-readable message."""
+    if not reason:
+        return "Pending action invalid or expired"
+    return PENDING_REASON_MESSAGES.get(reason, "Pending action invalid or expired")
+
+
 def _payload_digest(payload: Any) -> str:
     """Stable digest of the proposed payload for replay protection.
 
@@ -174,6 +201,75 @@ class PendingActions:
 
     # ── Core API ────────────────────────────────────────────────────
 
+    def _insert_row(
+        self,
+        conn: sqlite3.Connection,
+        *,
+        nonce: str,
+        actor: str,
+        target_kind: str,
+        target_id: str,
+        action_kind: str,
+        payload: Any,
+        digest: str,
+        origin_kind: str | None,
+        now: float,
+        expires_at: float,
+        summary: str | None,
+        preview_diff: str | None,
+    ) -> dict:
+        """Insert a pending row and return the record dict.
+
+        Shared INSERT + record-assembly used by :meth:`store` and
+        :meth:`store_with_cap`. Caller owns transaction boundaries
+        (``store`` runs auto-commit; ``store_with_cap`` wraps this in
+        ``BEGIN IMMEDIATE``).
+        """
+        conn.execute(
+            "INSERT OR REPLACE INTO pending_actions "
+            "(nonce, actor, target_kind, target_id, action_kind, "
+            "payload_json, payload_digest, origin_kind, created_at, "
+            "expires_at, status, summary, preview_diff) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 'pending', ?, ?)",
+            (
+                nonce, actor, target_kind, target_id, action_kind,
+                json.dumps(payload, default=str), digest, origin_kind,
+                now, expires_at, summary, preview_diff,
+            ),
+        )
+        return {
+            "nonce": nonce,
+            "actor": actor,
+            "target_kind": target_kind,
+            "target_id": target_id,
+            "action_kind": action_kind,
+            "payload": payload,
+            "payload_digest": digest,
+            "origin_kind": origin_kind,
+            "created_at": now,
+            "expires_at": expires_at,
+            "status": "pending",
+            "summary": summary,
+            "preview_diff": preview_diff,
+        }
+
+    def _emit_created(self, record: dict) -> None:
+        """Emit ``pending_action_created`` for a freshly-stored row."""
+        self._safe_emit(
+            "pending_action_created",
+            agent=record["actor"],
+            data={
+                "nonce": record["nonce"],
+                "actor": record["actor"],
+                "target_kind": record["target_kind"],
+                "target_id": record["target_id"],
+                "action_kind": record["action_kind"],
+                "expires_at": record["expires_at"],
+                "summary": record["summary"],
+                "preview_diff": record["preview_diff"],
+            },
+        )
+
     def store(
         self,
         *,
@@ -210,49 +306,94 @@ class PendingActions:
         # so a corrupt-row sweep never blocks a legitimate store.
         self._safe_reap()
         with self._conn() as conn:
-            conn.execute(
-                "INSERT OR REPLACE INTO pending_actions "
-                "(nonce, actor, target_kind, target_id, action_kind, "
-                "payload_json, payload_digest, origin_kind, created_at, "
-                "expires_at, status, summary, preview_diff) "
-                "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 'pending', ?, ?)",
-                (
-                    nonce, actor, target_kind, target_id, action_kind,
-                    json.dumps(payload, default=str), digest, origin_kind,
-                    now, expires_at, summary, preview_diff,
-                ),
+            record = self._insert_row(
+                conn,
+                nonce=nonce, actor=actor,
+                target_kind=target_kind, target_id=target_id,
+                action_kind=action_kind, payload=payload, digest=digest,
+                origin_kind=origin_kind, now=now, expires_at=expires_at,
+                summary=summary, preview_diff=preview_diff,
             )
         # Task 9 — surface to the dashboard so the System > Operator
         # panel and the inline chat bubble render the new pending nonce.
-        self._safe_emit(
-            "pending_action_created",
-            agent=actor,
-            data={
-                "nonce": nonce,
-                "actor": actor,
-                "target_kind": target_kind,
-                "target_id": target_id,
-                "action_kind": action_kind,
-                "expires_at": expires_at,
-                "summary": summary,
-                "preview_diff": preview_diff,
-            },
-        )
-        return {
-            "nonce": nonce,
-            "actor": actor,
-            "target_kind": target_kind,
-            "target_id": target_id,
-            "action_kind": action_kind,
-            "payload": payload,
-            "payload_digest": digest,
-            "origin_kind": origin_kind,
-            "created_at": now,
-            "expires_at": expires_at,
-            "status": "pending",
-            "summary": summary,
-            "preview_diff": preview_diff,
-        }
+        self._emit_created(record)
+        return record
+
+    def store_with_cap(
+        self,
+        *,
+        max_pending: int,
+        nonce: str,
+        actor: str,
+        target_kind: str,
+        target_id: str,
+        action_kind: str,
+        payload: Any,
+        origin_kind: str | None = None,
+        ttl: int = _DEFAULT_TTL_SEC,
+        summary: str | None = None,
+        preview_diff: str | None = None,
+    ) -> dict:
+        """Atomic reap + cap-check + evict + insert under one txn.
+
+        Replaces the prior call-site pattern of
+        ``reap_expired`` → ``list_pending`` → cap check → manual delete
+        → ``store`` that left a race window where two concurrent
+        proposes could both observe ``count < max`` and both insert,
+        producing ``max + N`` rows. Wrapping the sequence in a single
+        ``BEGIN IMMEDIATE`` serializes concurrent proposers so the cap
+        is honored exactly.
+
+        Eviction picks the row whose ``expires_at`` is soonest among
+        non-expired rows — matches the legacy behavior the propose
+        endpoints implemented (``min(..., key=expires_at)``).
+
+        Same return shape and same ``pending_action_created`` emit as
+        :meth:`store` so callers can swap in without other changes.
+        """
+        now = time.time()
+        digest = _payload_digest(payload)
+        expires_at = now + ttl
+        with self._conn() as conn:
+            conn.execute("BEGIN IMMEDIATE")
+            try:
+                # Reap expired in-txn so the count below reflects only
+                # rows that still count against the cap.
+                conn.execute(
+                    "DELETE FROM pending_actions WHERE expires_at < ?",
+                    (now,),
+                )
+                cur = conn.execute(
+                    "SELECT COUNT(*) FROM pending_actions",
+                ).fetchone()
+                count = int(cur[0]) if cur else 0
+                if count >= max_pending:
+                    # Evict the soonest-expiring non-expired row.
+                    oldest = conn.execute(
+                        "SELECT nonce FROM pending_actions "
+                        "ORDER BY expires_at ASC LIMIT 1",
+                    ).fetchone()
+                    if oldest is not None:
+                        conn.execute(
+                            "DELETE FROM pending_actions WHERE nonce=?",
+                            (oldest[0],),
+                        )
+                record = self._insert_row(
+                    conn,
+                    nonce=nonce, actor=actor,
+                    target_kind=target_kind, target_id=target_id,
+                    action_kind=action_kind, payload=payload, digest=digest,
+                    origin_kind=origin_kind, now=now, expires_at=expires_at,
+                    summary=summary, preview_diff=preview_diff,
+                )
+                conn.execute("COMMIT")
+            except Exception:
+                conn.execute("ROLLBACK")
+                raise
+        # Emit outside the txn so a slow subscriber doesn't hold the
+        # connection; mirrors :meth:`store` and :meth:`reap_expired`.
+        self._emit_created(record)
+        return record
 
     def peek(self, nonce: str) -> dict | None:
         """Read a pending action without consuming it.

--- a/src/host/pending_actions.py
+++ b/src/host/pending_actions.py
@@ -10,9 +10,11 @@ Schema mirrors the Blackboard pattern in ``src/host/mesh.py``: SQLite WAL,
 
 External contract: ``store(nonce, actor, target_kind, target_id, action_kind,
 payload, origin_kind, ttl)`` returns a record dict; ``consume(nonce, *,
-require_origin_kind, expected_payload_digest, confirmer)`` returns the record
-or None (expired/missing/wrong-digest/wrong-origin/wrong-actor) and atomically
-deletes on success.
+require_origin_kind, expected_payload_digest, confirmer)`` returns
+``(record, None)`` on success or ``(None, reason)`` where ``reason`` is one of
+``"not_found"``, ``"expired"``, ``"digest_mismatch"``, ``"wrong_confirmer"``,
+``"wrong_origin_kind"`` — atomically deletes on success / expired and
+preserves the row on every other failure so a legitimate retry can still win.
 
 Reaping is opportunistic: ``store`` and ``consume`` call ``reap_expired``
 themselves so callers do not need to wire a periodic task. A background
@@ -295,24 +297,36 @@ class PendingActions:
         confirmer: str | None = None,
         require_origin_kind: str | None = None,
         expected_payload_digest: str | None = None,
-    ) -> dict | None:
+    ) -> tuple[dict | None, str | None]:
         """Atomically consume a pending action.
 
-        Returns the record on success and deletes the row.
+        Returns ``(record, None)`` on success and deletes the row.
 
-        Returns None on:
-          * unknown nonce
-          * expired (also deletes the expired row inside the same txn)
-          * payload digest mismatch (replay protection -- row preserved)
-          * confirmer != actor (only the proposer can confirm -- row preserved)
-          * origin kind below required level (e.g. ``require="human"`` but
-            row has ``"agent"`` -- row preserved)
+        Returns ``(None, reason)`` on every failure mode, with a stable
+        machine-readable ``reason`` string so callers can distinguish
+        causes without parsing a human-readable message:
+
+          * ``"not_found"`` -- unknown nonce
+          * ``"expired"`` -- past expires_at (also deletes the expired row
+            inside the same txn)
+          * ``"digest_mismatch"`` -- replay protection (row preserved)
+          * ``"wrong_confirmer"`` -- ``confirmer != actor`` (row preserved)
+          * ``"wrong_origin_kind"`` -- origin kind below required level
+            (e.g. ``require="human"`` but row has ``"agent"`` or ``None``;
+            row preserved so a legitimate retry from the right caller can
+            still win)
 
         On a successful consume, the row is deleted in the same
         transaction so the same nonce cannot be replayed.
+
+        We intentionally skip the opportunistic ``_safe_reap`` on this
+        path so the per-row expired check inside ``BEGIN IMMEDIATE`` is
+        actually reachable. Otherwise a freshly-expired row gets reaped
+        by the pre-txn sweep and the caller sees ``"not_found"`` instead
+        of ``"expired"``, which masks the real failure mode. The
+        ``store`` path still reaps opportunistically, so the table
+        remains bounded.
         """
-        # Opportunistic reap on the read path. Cheap, swallowed on error.
-        self._safe_reap()
         with self._conn() as conn:
             conn.execute("BEGIN IMMEDIATE")
             try:
@@ -325,30 +339,23 @@ class PendingActions:
                 ).fetchone()
                 if not row:
                     conn.execute("COMMIT")
-                    return None
+                    return None, "not_found"
                 now = time.time()
                 if now > row[8]:
-                    # Expired -- delete and report None
                     conn.execute(
                         "DELETE FROM pending_actions WHERE nonce=?", (nonce,),
                     )
                     conn.execute("COMMIT")
-                    return None
+                    return None, "expired"
                 if expected_payload_digest and row[5] != expected_payload_digest:
-                    # Replay-protection mismatch -- preserve the row so the
-                    # legitimate confirmer can still consume it.
                     conn.execute("COMMIT")
-                    return None
+                    return None, "digest_mismatch"
                 if confirmer and row[0] != confirmer:
-                    # Wrong confirmer -- preserve the row.
                     conn.execute("COMMIT")
-                    return None
+                    return None, "wrong_confirmer"
                 if require_origin_kind and row[6] != require_origin_kind:
-                    # Origin not strong enough -- preserve the row so
-                    # nothing prevents a legitimate retry from the right
-                    # caller, but refuse to apply.
                     conn.execute("COMMIT")
-                    return None
+                    return None, "wrong_origin_kind"
                 conn.execute(
                     "DELETE FROM pending_actions WHERE nonce=?", (nonce,),
                 )
@@ -387,7 +394,7 @@ class PendingActions:
             "status": "consumed",
             "summary": row[10],
             "preview_diff": row[11],
-        }
+        }, None
 
     def cancel(
         self,

--- a/src/host/server.py
+++ b/src/host/server.py
@@ -219,10 +219,34 @@ def _get_pending_change(change_id: str) -> dict | None:
     }
 
 
+# Map ``PendingActions.consume()`` reason codes to human-readable
+# messages for the structured 400 detail. ``not_found`` keeps the legacy
+# "invalid or expired" phrasing so tests that grep on that substring keep
+# passing and dashboards built before the structured-code change continue
+# to render a sensible message.
+_PENDING_REASON_MESSAGES = {
+    "not_found": "Pending action invalid or expired",
+    "expired": "Pending action expired",
+    "digest_mismatch": "Payload changed since proposal — propose again",
+    "wrong_confirmer": "Wrong confirmer for this pending action",
+    "wrong_origin_kind": (
+        "This action requires a human-origin confirm; the original "
+        "proposal did not carry a verified human origin"
+    ),
+}
+
+
+def _humanize_pending_reason(reason: str | None) -> str:
+    """Translate a ``consume()`` reason code into a human-readable message."""
+    if not reason:
+        return "Pending action invalid or expired"
+    return _PENDING_REASON_MESSAGES.get(reason, "Pending action invalid or expired")
+
+
 def _consume_pending_change(change_id: str) -> dict | None:
     """Atomically consume a pending change. Returns legacy dict shape or None."""
     store = _get_pending_actions_store()
-    rec = store.consume(change_id)
+    rec, _ = store.consume(change_id)
     if rec is None:
         return None
     payload = rec.get("payload") or {}
@@ -6192,14 +6216,20 @@ def create_mesh_app(
                 "Use /mesh/config/confirm for delete pending actions",
             )
 
-        record = pending_actions.consume(
+        record, reason = pending_actions.consume(
             change_id,
             confirmer="operator",
             require_origin_kind="human",
             expected_payload_digest=client_digest,
         )
         if not record:
-            raise HTTPException(400, "Pending action invalid or expired")
+            raise HTTPException(
+                400,
+                detail={
+                    "code": reason,
+                    "message": _humanize_pending_reason(reason),
+                },
+            )
 
         return await _apply_pending_change(
             change_id, _record_to_legacy_change(record),
@@ -6233,14 +6263,20 @@ def create_mesh_app(
         # Consume + apply. ``consume`` is atomic: same nonce can only
         # be applied once. If the apply raises, the row is already
         # gone — the caller must propose a new change.
-        record = pending_actions.consume(
+        record, reason = pending_actions.consume(
             change_id,
             confirmer="operator",
             require_origin_kind="human",
             expected_payload_digest=client_digest,
         )
         if not record:
-            raise HTTPException(400, "Pending action invalid or expired")
+            raise HTTPException(
+                400,
+                detail={
+                    "code": reason,
+                    "message": _humanize_pending_reason(reason),
+                },
+            )
 
         # Task 7: destructive deletes use ``action_kind="delete"`` plus
         # ``target_kind in {"project", "agent"}``. Everything else stays

--- a/src/host/server.py
+++ b/src/host/server.py
@@ -35,7 +35,12 @@ from src.host.orchestration import (
     TaskNotFound,
     Tasks,
 )
-from src.host.pending_actions import PendingActions
+from src.host.pending_actions import (
+    PendingActions,
+)
+from src.host.pending_actions import (
+    format_pending_reason as _humanize_pending_reason,
+)
 from src.shared.redaction import redact_url
 from src.shared.types import (
     AGENT_ID_RE_PATTERN,
@@ -177,21 +182,16 @@ def _store_pending_change(agent_id: str, field: str, old_value: object, new_valu
 
     Backed by ``PendingActions`` (SQLite). Capped at ``_MAX_PENDING``
     rows per process; oldest expires-first row is evicted to make room.
+    The reap + cap-check + evict + insert sequence runs inside a single
+    ``BEGIN IMMEDIATE`` via :meth:`PendingActions.store_with_cap` so
+    concurrent proposers can't both observe ``count < max`` and double-
+    insert.
     """
     store = _get_pending_actions_store()
-    store.reap_expired()
-    pending = store.list_pending()
-    if len(pending) >= _MAX_PENDING:
-        # Evict the row whose ``expires_at`` is soonest -- matches the
-        # legacy behavior (``min(...)`` over ``expires_at``).
-        oldest = min(pending, key=lambda r: r["expires_at"])
-        with store._conn() as conn:
-            conn.execute(
-                "DELETE FROM pending_actions WHERE nonce=?", (oldest["nonce"],),
-            )
     change_id = str(_uuid.uuid4())
     payload = {"old_value": old_value, "new_value": new_value}
-    store.store(
+    store.store_with_cap(
+        max_pending=_MAX_PENDING,
         nonce=change_id,
         actor="operator",
         target_kind="agent",
@@ -217,30 +217,6 @@ def _get_pending_change(change_id: str) -> dict | None:
         "new_value": payload.get("new_value", ""),
         "expires_at": datetime.fromtimestamp(rec["expires_at"], tz=timezone.utc),
     }
-
-
-# Map ``PendingActions.consume()`` reason codes to human-readable
-# messages for the structured 400 detail. ``not_found`` keeps the legacy
-# "invalid or expired" phrasing so tests that grep on that substring keep
-# passing and dashboards built before the structured-code change continue
-# to render a sensible message.
-_PENDING_REASON_MESSAGES = {
-    "not_found": "Pending action invalid or expired",
-    "expired": "Pending action expired",
-    "digest_mismatch": "Payload changed since proposal — propose again",
-    "wrong_confirmer": "Wrong confirmer for this pending action",
-    "wrong_origin_kind": (
-        "This action requires a human-origin confirm; the original "
-        "proposal did not carry a verified human origin"
-    ),
-}
-
-
-def _humanize_pending_reason(reason: str | None) -> str:
-    """Translate a ``consume()`` reason code into a human-readable message."""
-    if not reason:
-        return "Pending action invalid or expired"
-    return _PENDING_REASON_MESSAGES.get(reason, "Pending action invalid or expired")
 
 
 def _consume_pending_change(change_id: str) -> dict | None:
@@ -4920,16 +4896,6 @@ def create_mesh_app(
             )
         origin = _validated_origin(request, caller)
         origin_kind = origin.kind if origin is not None else None
-        # Cap pending rows to bound storage growth (mirrors propose_edit).
-        pending_actions.reap_expired()
-        existing = pending_actions.list_pending()
-        if len(existing) >= _MAX_PENDING:
-            oldest = min(existing, key=lambda r: r["expires_at"])
-            with pending_actions._conn() as _conn:
-                _conn.execute(
-                    "DELETE FROM pending_actions WHERE nonce=?",
-                    (oldest["nonce"],),
-                )
         nonce = str(_uuid.uuid4())
         members = projects[name].get("members", []) or []
         # Short headline shown in the inline chat card (max ~80 chars
@@ -4943,7 +4909,11 @@ def create_mesh_app(
             "summary": summary,
             "members": members,
         }
-        record = pending_actions.store(
+        # Atomic reap+cap+insert — see PendingActions.store_with_cap.
+        # Replaces the legacy reap → list → manual evict → store sequence
+        # which raced under concurrent proposes.
+        record = pending_actions.store_with_cap(
+            max_pending=_MAX_PENDING,
             nonce=nonce,
             actor="operator",
             target_kind="project",
@@ -4992,22 +4962,15 @@ def create_mesh_app(
             )
         origin = _validated_origin(request, caller)
         origin_kind = origin.kind if origin is not None else None
-        pending_actions.reap_expired()
-        existing = pending_actions.list_pending()
-        if len(existing) >= _MAX_PENDING:
-            oldest = min(existing, key=lambda r: r["expires_at"])
-            with pending_actions._conn() as _conn:
-                _conn.execute(
-                    "DELETE FROM pending_actions WHERE nonce=?",
-                    (oldest["nonce"],),
-                )
         nonce = str(_uuid.uuid4())
         summary = f"Delete agent {agent_id!r} permanently"
         payload = {
             "agent_id": agent_id,
             "summary": summary,
         }
-        record = pending_actions.store(
+        # Atomic reap+cap+insert — see PendingActions.store_with_cap.
+        record = pending_actions.store_with_cap(
+            max_pending=_MAX_PENDING,
             nonce=nonce,
             actor="operator",
             target_kind="agent",
@@ -5391,18 +5354,6 @@ def create_mesh_app(
         origin = _validated_origin(request, caller)
         origin_kind = origin.kind if origin is not None else None
 
-        # Cap to ``_MAX_PENDING`` rows to bound storage growth -- mirrors
-        # the legacy in-memory eviction behavior.
-        pending_actions.reap_expired()
-        existing = pending_actions.list_pending()
-        if len(existing) >= _MAX_PENDING:
-            oldest = min(existing, key=lambda r: r["expires_at"])
-            with pending_actions._conn() as _conn:
-                _conn.execute(
-                    "DELETE FROM pending_actions WHERE nonce=?",
-                    (oldest["nonce"],),
-                )
-
         change_id = str(_uuid.uuid4())
         payload = {"old_value": old_value, "new_value": new_value}
 
@@ -5441,7 +5392,11 @@ def create_mesh_app(
                 f"from {_short(old_value)} to {_short(new_value)}"
             )
 
-        record = pending_actions.store(
+        # Atomic reap+cap+insert — see PendingActions.store_with_cap.
+        # Caps to ``_MAX_PENDING`` rows to bound storage growth without
+        # racing under concurrent proposes.
+        record = pending_actions.store_with_cap(
+            max_pending=_MAX_PENDING,
             nonce=change_id,
             actor="operator",
             target_kind="agent",
@@ -6357,7 +6312,16 @@ def create_mesh_app(
             raise HTTPException(403, "Only the operator can cancel pending actions")
         record = pending_actions.cancel(nonce, actor=caller or "operator")
         if record is None:
-            raise HTTPException(404, "Pending action not found or already expired")
+            # Structured detail mirrors the confirm path so dashboard
+            # error formatters (`_formatPendingError`) can route through
+            # one code path and surface the same {code, message} shape.
+            raise HTTPException(
+                404,
+                detail={
+                    "code": "not_found",
+                    "message": "Pending action not found or already expired",
+                },
+            )
         return {
             "ok": True,
             "nonce": nonce,

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -4967,8 +4967,16 @@ class TestWorkplaceTabRoutes:
                 nonce = url.rstrip("/").split("/")[-2]
                 record = store.cancel(nonce, actor="operator")
                 if record is None:
+                    # Match the real mesh shape — structured
+                    # {code, message} on 404 so callers can branch on
+                    # ``detail.code`` without parsing a free-form string.
                     return _StubResp(404, {
-                        "detail": "Pending action not found or already expired",
+                        "detail": {
+                            "code": "not_found",
+                            "message": (
+                                "Pending action not found or already expired"
+                            ),
+                        },
                     })
                 return _StubResp(200, {
                     "ok": True,

--- a/tests/test_operator_product_tools.py
+++ b/tests/test_operator_product_tools.py
@@ -1804,3 +1804,87 @@ async def test_operator_propose_delete_without_origin_fails_confirm(
     detail = body.get("detail")
     assert isinstance(detail, dict), f"expected structured detail, got {detail!r}"
     assert detail.get("code") == "wrong_origin_kind"
+
+
+@pytest.mark.asyncio
+async def test_legacy_propose_config_change_propagates_human_origin(
+    v2_app_with_bus_and_transport,
+):
+    """Defensive Bug A coverage for the legacy config-edit propose path.
+
+    ``MeshClient.propose_config_change`` / ``confirm_config_change`` are
+    dead in production today (operator routes through ``edit_agent`` for
+    soft + hard edits), but the mesh endpoints ``/mesh/agents/{id}/propose``
+    + ``/mesh/config/confirm`` are still wired and SDK-back-compat. A
+    future caller that re-hydrates them must not silently reproduce Bug A
+    where the stored row carries ``origin_kind=None`` and the confirm
+    fails the ``require_origin_kind="human"`` gate.
+
+    Uses the auth-token v2 fixture because the propose endpoint routes
+    through ``_resolve_agent_id``, which only consults headers when
+    ``_auth_tokens`` is configured.
+    """
+    app, _, _, _, _ = v2_app_with_bus_and_transport
+
+    from src.agent.mesh_client import MeshClient
+    from src.shared.trace import current_origin
+    from src.shared.types import MessageOrigin
+
+    # Build a MeshClient whose underlying httpx.AsyncClient hits the test
+    # app via ASGITransport. Stamps ``x-mesh-internal: 1`` + ``X-Agent-ID``
+    # so the propose/confirm endpoints' ``_resolve_agent_id`` path sees
+    # the operator identity (see _internal_operator_headers comment).
+    captured_headers: list[dict] = []
+    real_post = AsyncClient.post
+
+    async def _spying_post(self, url, **kwargs):
+        captured_headers.append(dict(kwargs.get("headers") or {}))
+        return await real_post(self, url, **kwargs)
+
+    async def _make_client(self):
+        c = AsyncClient(
+            transport=ASGITransport(app=app),
+            base_url="http://t",
+            headers={
+                "X-Agent-ID": "operator",
+                "x-mesh-internal": "1",
+            },
+        )
+        return c
+
+    # We don't monkeypatch _get_client into MeshClient because pytest-
+    # asyncio doesn't expose monkeypatch in the auth_tokens fixture —
+    # construct the client and replace the bound method directly.
+    mc = MeshClient(mesh_url="http://t", agent_id="operator")
+    mc._get_client = _make_client.__get__(mc, MeshClient)  # type: ignore[method-assign]
+
+    # Patch AsyncClient.post to capture headers so we can pin that the
+    # legacy stub forwards X-Origin (the actual regression).
+    import unittest.mock as _mock
+    with _mock.patch.object(AsyncClient, "post", _spying_post):
+        human = MessageOrigin(kind="human", channel="cli", user="u1")
+        token = current_origin.set(human)
+        try:
+            propose_resp = await mc.propose_config_change(
+                "scout", "instructions", "Updated instructions.",
+            )
+            # ``confirm_config_change`` MUST also forward the human
+            # origin — the confirm endpoint re-checks the *current*
+            # request's X-Origin in addition to the stored
+            # origin_kind, so a missing X-Origin on confirm fails with
+            # 403 even if the stored row is correct.
+            confirm_resp = await mc.confirm_config_change(
+                propose_resp["change_id"],
+            )
+        finally:
+            current_origin.reset(token)
+
+    assert confirm_resp.get("success") is True, confirm_resp
+    # Both calls must have carried X-Origin (lowercase or canonical
+    # depending on httpx's Header normalization).
+    for hdrs in captured_headers:
+        lower = {k.lower(): v for k, v in hdrs.items()}
+        assert "x-origin" in lower, (
+            f"propose/confirm call missing X-Origin: {hdrs!r}"
+        )
+

--- a/tests/test_operator_product_tools.py
+++ b/tests/test_operator_product_tools.py
@@ -1686,3 +1686,121 @@ async def test_agent_origin_does_not_request_auto_notify(v2_app_with_lanes):
     assert kwargs.get("auto_notify") is False, (
         f"agent-only origin must keep auto_notify off, got kwargs={kwargs!r}"
     )
+
+
+# ── Bug A regression: operator propose_delete must forward X-Origin ─
+#
+# These tests pin the operator's MeshClient → mesh chain end-to-end.
+# Before the fix, ``propose_delete_agent``/``propose_delete_project`` on
+# the agent-side MeshClient did NOT forward ``current_origin`` as an
+# ``X-Origin`` header, so the mesh persisted the pending row with
+# ``origin_kind=None``. A subsequent human-origin confirm then failed the
+# ``require_origin_kind="human"`` gate inside ``PendingActions.consume``
+# with a misleading "Pending action invalid or expired" message.
+
+
+@pytest.mark.asyncio
+async def test_operator_propose_delete_via_mesh_client_propagates_human_origin(
+    v2_app, monkeypatch,
+):
+    """End-to-end: operator's ``MeshClient.propose_delete_agent`` must
+    propagate ``current_origin`` so the stored pending row carries
+    ``origin_kind="human"`` and the human-origin confirm succeeds.
+    This is the unit-level reproducer for Bug A.
+    """
+    app, _, _ = v2_app
+    transport = ASGITransport(app=app)
+
+    # Archive scout first (precondition for propose-delete).
+    async with AsyncClient(transport=transport, base_url="http://t") as c:
+        r = await c.post(
+            "/mesh/agents/scout/archive",
+            headers={"X-Agent-ID": "operator"},
+        )
+        assert r.status_code == 200, r.text
+
+    # Build a MeshClient whose underlying httpx.AsyncClient hits the test
+    # app via ASGITransport, and stamps the operator's agent ID on every
+    # outbound request (the mesh otherwise can't resolve the caller).
+    from src.agent.mesh_client import MeshClient
+    from src.shared.trace import current_origin
+    from src.shared.types import MessageOrigin
+
+    async def _make_client(self):
+        return AsyncClient(
+            transport=transport,
+            base_url="http://t",
+            headers={"X-Agent-ID": "operator"},
+        )
+
+    monkeypatch.setattr(MeshClient, "_get_client", _make_client)
+
+    mc = MeshClient(mesh_url="http://t", agent_id="operator")
+    human = MessageOrigin(kind="human", channel="cli", user="u1")
+    token = current_origin.set(human)
+    try:
+        propose_resp = await mc.propose_delete_agent("scout")
+    finally:
+        current_origin.reset(token)
+
+    nonce = propose_resp["change_id"]
+    digest = propose_resp["payload_digest"]
+
+    async with AsyncClient(transport=transport, base_url="http://t") as c:
+        r = await c.post(
+            f"/mesh/pending/{nonce}/confirm",
+            json={"payload_digest": digest},
+            headers=_human_origin_headers(),
+        )
+    assert r.status_code == 200, r.text
+    assert r.json()["deleted"] == "agent"
+
+
+@pytest.mark.asyncio
+async def test_operator_propose_delete_without_origin_fails_confirm(
+    v2_app, monkeypatch,
+):
+    """Autonomous heartbeat case: ``current_origin=None`` means the
+    pending row is stored with ``origin_kind=None``. A subsequent
+    human-origin confirm must be refused with a clear ``wrong_origin_kind``
+    code — that is the correct security behavior (not a regression).
+    """
+    app, _, _ = v2_app
+    transport = ASGITransport(app=app)
+
+    async with AsyncClient(transport=transport, base_url="http://t") as c:
+        r = await c.post(
+            "/mesh/agents/scout/archive",
+            headers={"X-Agent-ID": "operator"},
+        )
+        assert r.status_code == 200, r.text
+
+    from src.agent.mesh_client import MeshClient
+
+    async def _make_client(self):
+        return AsyncClient(
+            transport=transport,
+            base_url="http://t",
+            headers={"X-Agent-ID": "operator"},
+        )
+
+    monkeypatch.setattr(MeshClient, "_get_client", _make_client)
+
+    mc = MeshClient(mesh_url="http://t", agent_id="operator")
+    # No origin set — simulating an autonomous/heartbeat propose.
+    propose_resp = await mc.propose_delete_agent("scout")
+    nonce = propose_resp["change_id"]
+    digest = propose_resp["payload_digest"]
+
+    async with AsyncClient(transport=transport, base_url="http://t") as c:
+        r = await c.post(
+            f"/mesh/pending/{nonce}/confirm",
+            json={"payload_digest": digest},
+            headers=_human_origin_headers(),
+        )
+    assert r.status_code == 400, r.text
+    # Structured detail surfaces the precise reason.
+    body = r.json()
+    detail = body.get("detail")
+    assert isinstance(detail, dict), f"expected structured detail, got {detail!r}"
+    assert detail.get("code") == "wrong_origin_kind"

--- a/tests/test_orchestration_endpoints.py
+++ b/tests/test_orchestration_endpoints.py
@@ -460,6 +460,31 @@ async def test_pending_cancel_unknown_returns_404(v2_app):
         assert r.status_code == 404
 
 
+@pytest.mark.asyncio
+async def test_cancel_endpoint_returns_structured_detail(v2_app):
+    """Cancel endpoint emits ``{code, message}`` detail (matches confirm).
+
+    The dashboard's ``_formatPendingError`` branches on ``detail.code``
+    instead of parsing the message string, so the cancel route must
+    emit the same structured shape as confirm. Before the fix, cancel
+    raised ``HTTPException(404, "string")`` and the toast would render
+    ``[object Object]`` once the dashboard handler started reading
+    ``data.detail`` as a string.
+    """
+    app, _, _ = v2_app
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
+        r = await c.post(
+            "/mesh/pending/does-not-exist/cancel",
+            headers={"X-Agent-ID": "operator", "X-Mesh-Internal": "1"},
+        )
+    assert r.status_code == 404
+    body = r.json()
+    detail = body.get("detail")
+    assert isinstance(detail, dict), f"expected structured detail, got {detail!r}"
+    assert detail.get("code") == "not_found"
+    assert isinstance(detail.get("message"), str) and detail["message"]
+
+
 # ── Hotfix: _extract_verified_agent_id honors internal callers ──────
 #
 # In production (auth tokens configured), the dashboard cancel proxy

--- a/tests/test_pending_actions.py
+++ b/tests/test_pending_actions.py
@@ -57,16 +57,20 @@ def test_store_then_consume_returns_record_then_none(tmp_path):
         nonce="n1", actor="operator", target_kind="agent",
         target_id="alpha", action_kind="model", payload={"x": 1},
     )
-    first = pa.consume("n1")
-    second = pa.consume("n1")
+    first, first_reason = pa.consume("n1")
+    second, second_reason = pa.consume("n1")
     assert first is not None
+    assert first_reason is None
     assert first["target_id"] == "alpha"
     assert second is None  # already consumed
+    assert second_reason == "not_found"
 
 
 def test_consume_unknown_nonce_returns_none(tmp_path):
     pa = _make_store(tmp_path)
-    assert pa.consume("does-not-exist") is None
+    rec, reason = pa.consume("does-not-exist")
+    assert rec is None
+    assert reason == "not_found"
 
 
 def test_peek_unknown_nonce_returns_none(tmp_path):
@@ -97,7 +101,9 @@ def test_expired_consume_returns_none_and_deletes_row(tmp_path):
         ttl=0,
     )
     time.sleep(0.01)
-    assert pa.consume("n1") is None
+    rec, reason = pa.consume("n1")
+    assert rec is None
+    assert reason == "expired"
     # Row should be gone -- a fresh store with the same nonce works.
     pa.store(
         nonce="n1", actor="operator", target_kind="agent",
@@ -150,10 +156,14 @@ def test_consume_wrong_confirmer_preserves_row(tmp_path):
         target_id="alpha", action_kind="model", payload={"x": 1},
     )
     # Wrong confirmer -- returns None and does NOT delete.
-    assert pa.consume("n1", confirmer="someone-else") is None
+    rec, reason = pa.consume("n1", confirmer="someone-else")
+    assert rec is None
+    assert reason == "wrong_confirmer"
     assert pa.peek("n1") is not None
     # Right confirmer -- succeeds.
-    assert pa.consume("n1", confirmer="operator") is not None
+    rec, reason = pa.consume("n1", confirmer="operator")
+    assert rec is not None
+    assert reason is None
 
 
 def test_consume_wrong_payload_digest_preserves_row(tmp_path):
@@ -163,10 +173,14 @@ def test_consume_wrong_payload_digest_preserves_row(tmp_path):
         target_id="alpha", action_kind="model", payload={"x": 1},
     )
     bogus_digest = "0" * 64
-    assert pa.consume("n1", expected_payload_digest=bogus_digest) is None
+    out, reason = pa.consume("n1", expected_payload_digest=bogus_digest)
+    assert out is None
+    assert reason == "digest_mismatch"
     assert pa.peek("n1") is not None
     # Real digest -- succeeds.
-    assert pa.consume("n1", expected_payload_digest=rec["payload_digest"]) is not None
+    out, reason = pa.consume("n1", expected_payload_digest=rec["payload_digest"])
+    assert out is not None
+    assert reason is None
 
 
 def test_consume_origin_kind_mismatch_preserves_row(tmp_path):
@@ -177,7 +191,9 @@ def test_consume_origin_kind_mismatch_preserves_row(tmp_path):
         origin_kind="agent",
     )
     # Require human, row says agent -- refuse.
-    assert pa.consume("n1", require_origin_kind="human") is None
+    rec, reason = pa.consume("n1", require_origin_kind="human")
+    assert rec is None
+    assert reason == "wrong_origin_kind"
     # Row preserved.
     assert pa.peek("n1") is not None
 
@@ -189,7 +205,9 @@ def test_consume_origin_kind_match_succeeds(tmp_path):
         target_id="alpha", action_kind="model", payload={"x": 1},
         origin_kind="human",
     )
-    assert pa.consume("n1", require_origin_kind="human") is not None
+    rec, reason = pa.consume("n1", require_origin_kind="human")
+    assert rec is not None
+    assert reason is None
 
 
 def test_consume_origin_kind_required_but_missing(tmp_path):
@@ -200,7 +218,9 @@ def test_consume_origin_kind_required_but_missing(tmp_path):
         target_id="alpha", action_kind="model", payload={"x": 1},
         origin_kind=None,
     )
-    assert pa.consume("n1", require_origin_kind="human") is None
+    rec, reason = pa.consume("n1", require_origin_kind="human")
+    assert rec is None
+    assert reason == "wrong_origin_kind"
     assert pa.peek("n1") is not None  # still there
 
 
@@ -271,7 +291,8 @@ def test_concurrent_consume_serializes(tmp_path):
 
     def worker():
         barrier.wait()
-        results.append(pa.consume("n1"))
+        rec, _ = pa.consume("n1")
+        results.append(rec)
 
     t1 = threading.Thread(target=worker)
     t2 = threading.Thread(target=worker)
@@ -406,8 +427,9 @@ def test_event_bus_emits_pending_action_resolved_on_consume_success(tmp_path):
         origin_kind="human",
     )
     captured.clear()
-    rec = pa.consume("n1", confirmer="operator", require_origin_kind="human")
+    rec, reason = pa.consume("n1", confirmer="operator", require_origin_kind="human")
     assert rec is not None
+    assert reason is None
     types = [c[0] for c in captured]
     assert "pending_action_resolved" in types
     evt = next(c for c in captured if c[0] == "pending_action_resolved")
@@ -543,8 +565,9 @@ def test_store_persists_summary_and_preview_diff(tmp_path):
     assert listed[0]["summary"] == rec["summary"]
     assert listed[0]["preview_diff"] == rec["preview_diff"]
 
-    consumed = pa.consume("n1", confirmer="operator")
+    consumed, reason = pa.consume("n1", confirmer="operator")
     assert consumed is not None
+    assert reason is None
     assert consumed["summary"] == rec["summary"]
     assert consumed["preview_diff"] == rec["preview_diff"]
 
@@ -576,3 +599,92 @@ def test_pending_action_created_event_carries_summary_and_diff(tmp_path):
     evt = next(c for c in captured if c[0] == "pending_action_created")
     assert evt[2]["summary"] == "Switch alpha's model from gpt-4o to claude"
     assert evt[2]["preview_diff"] == "diff goes here"
+
+
+# ── consume() returns (record, reason) — reason-code coverage ─────
+#
+# The reason codes feed the dashboard's structured 400 payload so the
+# UI can surface a precise failure mode (and telemetry can scrape the
+# code into a data attribute on the toast). One test per code, plus a
+# success-path tuple shape check.
+
+
+def test_consume_success_returns_record_and_none_reason(tmp_path):
+    pa = _make_store(tmp_path)
+    pa.store(
+        nonce="n1", actor="operator", target_kind="agent",
+        target_id="alpha", action_kind="model", payload={"x": 1},
+    )
+    rec, reason = pa.consume("n1")
+    assert rec is not None
+    assert reason is None
+    assert rec["target_id"] == "alpha"
+
+
+def test_consume_returns_not_found_for_unknown_nonce(tmp_path):
+    pa = _make_store(tmp_path)
+    rec, reason = pa.consume("does-not-exist")
+    assert rec is None
+    assert reason == "not_found"
+
+
+def test_consume_returns_expired_and_deletes_row(tmp_path):
+    pa = _make_store(tmp_path)
+    pa.store(
+        nonce="n1", actor="operator", target_kind="agent",
+        target_id="alpha", action_kind="model", payload={"x": 1},
+        ttl=0,
+    )
+    time.sleep(0.01)
+    rec, reason = pa.consume("n1")
+    assert rec is None
+    assert reason == "expired"
+    # Expired row was deleted in the same txn — peek returns None.
+    assert pa.peek("n1") is None
+
+
+def test_consume_returns_digest_mismatch_and_preserves_row(tmp_path):
+    pa = _make_store(tmp_path)
+    pa.store(
+        nonce="n1", actor="operator", target_kind="agent",
+        target_id="alpha", action_kind="model", payload={"x": 1},
+    )
+    rec, reason = pa.consume("n1", expected_payload_digest="0" * 64)
+    assert rec is None
+    assert reason == "digest_mismatch"
+    # Row preserved so the legitimate caller can still retry.
+    assert pa.peek("n1") is not None
+
+
+def test_consume_returns_wrong_confirmer_and_preserves_row(tmp_path):
+    pa = _make_store(tmp_path)
+    pa.store(
+        nonce="n1", actor="operator", target_kind="agent",
+        target_id="alpha", action_kind="model", payload={"x": 1},
+    )
+    rec, reason = pa.consume("n1", confirmer="impostor")
+    assert rec is None
+    assert reason == "wrong_confirmer"
+    assert pa.peek("n1") is not None
+
+
+def test_consume_returns_wrong_origin_kind_and_preserves_row(tmp_path):
+    """Bug A reproducer at the unit level.
+
+    A row stored with ``origin_kind=None`` (e.g. propose path that
+    forgot to forward ``current_origin``) cannot satisfy a
+    ``require_origin_kind="human"`` confirm. The store correctly
+    surfaces ``wrong_origin_kind`` as the reason so the dashboard
+    can show a precise error instead of the legacy misleading
+    "invalid or expired" message.
+    """
+    pa = _make_store(tmp_path)
+    pa.store(
+        nonce="n1", actor="operator", target_kind="agent",
+        target_id="alpha", action_kind="model", payload={"x": 1},
+        origin_kind=None,
+    )
+    rec, reason = pa.consume("n1", require_origin_kind="human")
+    assert rec is None
+    assert reason == "wrong_origin_kind"
+    assert pa.peek("n1") is not None  # still there for legitimate retry

--- a/tests/test_pending_actions.py
+++ b/tests/test_pending_actions.py
@@ -305,6 +305,129 @@ def test_concurrent_consume_serializes(tmp_path):
     assert len(successes) == 1, f"expected exactly one success, got {results}"
 
 
+def test_concurrent_consume_loser_sees_not_found(tmp_path):
+    """Loser of a concurrent consume race gets ``reason="not_found"``.
+
+    Sibling to ``test_concurrent_consume_serializes`` — pins that the
+    loser's failure reason is the stable ``not_found`` code (not None,
+    not some other reason like ``expired``) so callers can branch on
+    the code without parsing a message.
+    """
+    pa = _make_store(tmp_path)
+    pa.store(
+        nonce="n1", actor="operator", target_kind="agent",
+        target_id="alpha", action_kind="model", payload={"x": 1},
+    )
+    pairs: list[tuple] = []
+    barrier = threading.Barrier(2)
+
+    def worker():
+        barrier.wait()
+        pairs.append(pa.consume("n1"))
+
+    t1 = threading.Thread(target=worker)
+    t2 = threading.Thread(target=worker)
+    t1.start()
+    t2.start()
+    t1.join()
+    t2.join()
+
+    successes = [(r, why) for (r, why) in pairs if r is not None]
+    losers = [(r, why) for (r, why) in pairs if r is None]
+    assert len(successes) == 1, f"expected exactly one success, got {pairs}"
+    assert len(losers) == 1, f"expected exactly one loser, got {pairs}"
+    assert successes[0][1] is None, "winner should have no failure reason"
+    assert losers[0][1] == "not_found", (
+        f"loser should report not_found, got {losers[0][1]!r}"
+    )
+
+
+# ── store_with_cap (atomic reap+evict+insert) ───────────────────
+
+
+def test_store_with_cap_evicts_oldest_under_concurrent_proposes(tmp_path):
+    """N+K concurrent ``store_with_cap`` calls cap at exactly N rows.
+
+    Closes the race the legacy ``reap + list + cap-check + manual
+    evict + store`` sequence had: two proposers could both observe
+    ``count < max`` and both insert, producing N+1+ rows. The atomic
+    BEGIN IMMEDIATE version serializes them so the cap is honored.
+    """
+    pa = _make_store(tmp_path)
+    max_pending = 5
+    nonces = [f"n{i}" for i in range(max_pending + 10)]
+    barrier = threading.Barrier(len(nonces))
+    errors: list[BaseException] = []
+
+    def worker(nonce: str):
+        try:
+            barrier.wait()
+            pa.store_with_cap(
+                max_pending=max_pending,
+                nonce=nonce,
+                actor="operator",
+                target_kind="agent",
+                target_id="alpha",
+                action_kind="model",
+                payload={"i": nonce},
+                ttl=300,
+            )
+        except BaseException as e:  # pragma: no cover - surface in assert
+            errors.append(e)
+
+    threads = [threading.Thread(target=worker, args=(n,)) for n in nonces]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    assert not errors, f"unexpected errors: {errors!r}"
+    rows = pa.list_pending()
+    assert len(rows) == max_pending, (
+        f"expected exactly {max_pending} rows under concurrency, got {len(rows)}"
+    )
+
+
+def test_store_with_cap_preserves_eviction_semantics(tmp_path):
+    """Sequential ``store_with_cap`` evicts the row with smallest ``expires_at``.
+
+    Pins that the atomic eviction order matches the legacy in-memory
+    ``min(..., key=expires_at)`` behavior — the soonest-expiring row
+    is dropped first, not the lowest insertion order. Built so callers
+    that relied on the legacy semantics (legacy tests, dashboard
+    surfaces) keep behaving identically.
+    """
+    pa = _make_store(tmp_path)
+    # Insert three rows whose ``expires_at`` is *reverse* of insertion
+    # order. ``n1`` has the shortest TTL → it should be the evictee
+    # when we push a fourth row at cap=3.
+    pa.store_with_cap(
+        max_pending=3, nonce="n1", actor="operator",
+        target_kind="agent", target_id="a", action_kind="x",
+        payload={"i": 1}, ttl=10,
+    )
+    pa.store_with_cap(
+        max_pending=3, nonce="n2", actor="operator",
+        target_kind="agent", target_id="a", action_kind="x",
+        payload={"i": 2}, ttl=100,
+    )
+    pa.store_with_cap(
+        max_pending=3, nonce="n3", actor="operator",
+        target_kind="agent", target_id="a", action_kind="x",
+        payload={"i": 3}, ttl=1000,
+    )
+    # At cap → next insert should evict n1 (smallest expires_at).
+    pa.store_with_cap(
+        max_pending=3, nonce="n4", actor="operator",
+        target_kind="agent", target_id="a", action_kind="x",
+        payload={"i": 4}, ttl=500,
+    )
+    rows = {r["nonce"] for r in pa.list_pending()}
+    assert rows == {"n2", "n3", "n4"}, (
+        f"expected n1 evicted (smallest TTL), got rows={rows}"
+    )
+
+
 # ── Replace-on-duplicate behavior ─────────────────────────────────
 
 


### PR DESCRIPTION
## Summary
- **Bug A (critical):** Operator's `mesh_client.propose_delete_{agent,project}` was not forwarding `current_origin`, so the mesh stored pending rows with `origin_kind=None`. The confirm path's `require_origin_kind="human"` gate then rejected with `None != "human"`, but `consume()` collapsed five failure modes into a single misleading "Pending action invalid or expired" error. Operator's first-pass investigation pinned the `confirmer != actor` gate; closer inspection showed the real failure is upstream in propose-side origin propagation. This PR fixes the root cause AND distinguishes the five reasons so we never debug-via-grep again.
- **Bug B:** `_loadChatHistory` trailing filter only kept `user`/`agent`/`notification` roles, silently dropping client-side overlay cards on every refresh — so the inline confirm card vanished even though the row was still server-side and unexpired.
- **Bug C:** "Needs you" nav badge unconditionally switched to chat. For destructive operator confirms the right target is the Work tab's unified Needs-You panel; chat is correct only for credential/browser-login/captcha cards.

## Files (top of original commit)
- `src/agent/mesh_client.py` — origin propagation on propose
- `src/host/pending_actions.py` — `consume()` returns `(record, reason)` with 5 codes; reaper race fix on consume path
- `src/host/server.py` — structured `{code, message}` detail + reason humanizer
- `src/dashboard/static/js/app.js` — overlay-role preservation, kind-aware badge routing, structured-detail handler, telemetry on confirm failures
- `src/dashboard/templates/index.html` — badge handler + `data-needs-you-panel` anchor
- `tests/test_pending_actions.py` — 5 reason-code tests + destructure updates
- `tests/test_operator_product_tools.py` — Bug A E2E reproducer + security counterpart

## Review-driven extensions (second commit)

Two independent principal-engineer reviews (Claude + Codex) converged on the same gaps after the initial fix shipped. Bundled here in one follow-up commit so the rationale stays traceable:

- **Bug B widened from 4 → 6 overlay roles** — added `operator_action_receipt` (undo cards) and `credit_exhausted` (billing toasts). Both were silently dropped on history reload by the same role-filter logic Bug B was supposed to fix. Hoisted to module-level `OVERLAY_CHAT_ROLES`.
- **Bug C widened from 1 → 3 Work-tab kinds** — badge now routes `pending | blocker | unrated` to Work tab. Blocker's Drill-in opens a Work-tab task drawer; Unrated's Review jumps to `workplace/activity`. Routing those to chat was burying the action one tab away. Hoisted to module-level `_BADGE_WORK_TAB_KINDS`.
- **Defensive origin forwarding on legacy propose paths** — `MeshClient.propose_config_change` and `confirm_config_change` had the same Bug A pattern. Dead in production today (operator routes through `edit_agent`) but the mesh endpoint is still wired; a new shared `_trace_and_origin_headers()` helper centralizes the pattern so future callers can't silently reproduce Bug A.
- **Atomic `_MAX_PENDING` enforcement (pre-existing race, bundled bonus)** — three propose endpoints (plus the legacy `_store_pending_change` helper) were doing `reap + list + cap-check + evict + insert` outside a transaction. Two concurrent proposes could both observe `len<10` and store, producing 11+ rows, or both pick the same "oldest" to evict. New `PendingActions.store_with_cap()` wraps all four steps in a single `BEGIN IMMEDIATE`.
- **Colocated `PENDING_REASON_MESSAGES` + `format_pending_reason`** moved from `server.py` to `pending_actions.py` — keeps producer (consume reason codes) and consumer (humanizer) in one place.
- **Actionable `wrong_origin_kind` message** — appended "Re-issue the request from the dashboard or a paired channel" so the user has a concrete next step.
- **Cancel endpoint detail-shape symmetry** — `/mesh/pending/{nonce}/cancel` now emits structured `{code, message}` detail like confirm; dashboard cancel handlers route through `_formatPendingError` (would otherwise render `[object Object]`).

## Notable subagent catch (original commit)
The opportunistic `_safe_reap()` inside `consume()` was dropped. It raced the per-row expired check inside `BEGIN IMMEDIATE` — a freshly-expired row got swept by the pre-txn reaper and the caller saw `"not_found"` instead of `"expired"`, masking one of the five new reason codes. `store()` still reaps so the table remains bounded. Documented inline with the "why".

## Pre-flight verification
The Bug A E2E test (`test_operator_propose_delete_via_mesh_client_propagates_human_origin`) was confirmed to FAIL on unmodified `main` with the exact production symptom (`400 "Pending action invalid or expired"`) before applying the fix. It PASSES after. The companion test (`..._without_origin_fails_confirm`) pins the security counterpart: autonomous/heartbeat-originated proposes legitimately store `origin_kind=None` and the confirm refuses with structured `code="wrong_origin_kind"` — that is correct, not a regression.

## Test plan
- [x] `pytest tests/test_pending_actions.py -x` — passes (5 new reason-code tests + 3 new store_with_cap concurrency/eviction tests)
- [x] `pytest tests/test_operator_product_tools.py -x` — passes (Bug A E2E reproducer + security counterpart + legacy `propose_config_change` origin propagation test)
- [x] `pytest tests/test_orchestration_endpoints.py -x` — passes (new cancel-detail-shape regression test)
- [x] Full suite (`pytest tests/ --ignore=tests/test_e2e*`) — **6084 passed, 48 skipped, 0 failures**
- [x] `ruff check` on every touched src + test file — clean
- [x] Branch rebased onto current `origin/main` (would otherwise have silently reverted #900 + #901 on squash-merge)
- [ ] **Manual repro on a live dashboard:** operator `manage_agent('engine-engineer', 'delete')` → dashboard Confirm button → expect agent deleted (instead of "Pending action invalid or expired")
- [ ] **Manual Bug B check:** after the above, refresh the page mid-flow → confirm pending card stays visible in both Work tab Needs-You panel AND inline operator chat card
- [ ] **Manual Bug C check:** Click "Needs you" nav badge with a pending destructive action queued → confirm route lands on Work tab with the Needs-You panel scrolled into view, not chat
- [ ] **Manual Bug C widened check:** Trigger a blocker-only or unrated-only needsYou state → confirm badge routes to Work tab (not chat)
