### PR TITLE
fix: close review-flagged gaps in PRs #899–903 (with 2x codex passes)

### DIFF
--- a/src/agent/builtins/coordination_tool.py
+++ b/src/agent/builtins/coordination_tool.py
@@ -18,7 +18,7 @@ import re
 import time
 
 from src.agent.skills import skill
-from src.shared.redaction import redact_string
+from src.shared.redaction import redact_text_with_urls
 from src.shared.task_titles import (
     LONG_TITLE_THRESHOLD,
     normalize_title_and_description,
@@ -224,9 +224,13 @@ async def hand_off(
     except Exception as e:
         # Redact credentials BEFORE truncation — an HTTP-level exception
         # may carry the failing URL with an API key in the query string.
-        # Without this the wake_error field leaks secrets into the LLM
-        # context that the caller reads back via the handoff response.
-        wake_error = redact_string(str(e))[:200]
+        # ``redact_text_with_urls`` runs ``redact_url`` on embedded URLs
+        # (catches arbitrary ``?api_key=…`` values whose key signals a
+        # credential) AND ``redact_string`` for token-shaped secrets
+        # outside URL context. Codex P1 from PR R1 review: plain
+        # ``redact_string`` left ``?api_key=anything`` intact and
+        # leaked into the LLM via the returned wake_error.
+        wake_error = redact_text_with_urls(str(e))[:200]
         logger.warning("Wake for %s failed (task still queued): %s", to, e)
 
     result = {
@@ -636,9 +640,13 @@ async def _hand_off_v2(
     except Exception as e:
         # Redact credentials BEFORE truncation — an HTTP-level exception
         # may carry the failing URL with an API key in the query string.
-        # Without this the wake_error field leaks secrets into the LLM
-        # context that the caller reads back via the handoff response.
-        wake_error = redact_string(str(e))[:200]
+        # ``redact_text_with_urls`` runs ``redact_url`` on embedded URLs
+        # (catches arbitrary ``?api_key=…`` values whose key signals a
+        # credential) AND ``redact_string`` for token-shaped secrets
+        # outside URL context. Codex P1 from PR R1 review: plain
+        # ``redact_string`` left ``?api_key=anything`` intact and
+        # leaked into the LLM via the returned wake_error.
+        wake_error = redact_text_with_urls(str(e))[:200]
         logger.warning("Wake for %s failed (task still queued): %s", to, e)
 
     result = {

--- a/src/agent/builtins/coordination_tool.py
+++ b/src/agent/builtins/coordination_tool.py
@@ -18,6 +18,7 @@ import re
 import time
 
 from src.agent.skills import skill
+from src.shared.redaction import redact_string
 from src.shared.task_titles import (
     LONG_TITLE_THRESHOLD,
     normalize_title_and_description,
@@ -221,7 +222,11 @@ async def hand_off(
             origin=origin,
         )
     except Exception as e:
-        wake_error = str(e)[:200]
+        # Redact credentials BEFORE truncation — an HTTP-level exception
+        # may carry the failing URL with an API key in the query string.
+        # Without this the wake_error field leaks secrets into the LLM
+        # context that the caller reads back via the handoff response.
+        wake_error = redact_string(str(e))[:200]
         logger.warning("Wake for %s failed (task still queued): %s", to, e)
 
     result = {
@@ -629,7 +634,11 @@ async def _hand_off_v2(
             task_id=task_id or None,
         )
     except Exception as e:
-        wake_error = str(e)[:200]
+        # Redact credentials BEFORE truncation — an HTTP-level exception
+        # may carry the failing URL with an API key in the query string.
+        # Without this the wake_error field leaks secrets into the LLM
+        # context that the caller reads back via the handoff response.
+        wake_error = redact_string(str(e))[:200]
         logger.warning("Wake for %s failed (task still queued): %s", to, e)
 
     result = {

--- a/src/agent/loop.py
+++ b/src/agent/loop.py
@@ -1717,18 +1717,32 @@ class AgentLoop:
         # state corruption (shared loop_detector, state, flush_triggered).
         # Guard is BEFORE _chat_lock to avoid blocking on a held lock.
         if self.current_task is not None:
-            await self._steer_queue.put(user_message)
-            # A task_id rode in on this wake but we're busy — the steer
-            # queue has no task_id channel, so the auto-close path would
-            # never fire. Fail the originating task now so the sender's
-            # check_inbox sees a clear ``task_failed`` back-edge with a
-            # specific reason, instead of waiting 7 days for the TTL.
-            # Best-effort: _auto_close_task is exception-safe.
+            # Two distinct paths depending on whether this is a real
+            # handoff (task_id set) or a free-form chat:
+            #
+            # - Handoff path: reject cleanly. Closing the task as
+            #   ``failed`` AND queueing it on the steer would let the
+            #   originator retry/reroute (because they see task_failed)
+            #   while THIS agent still processes the queued message —
+            #   duplicate / conflicting work (codex P2). Skip the
+            #   queue, surface the rejection in the chat reply.
+            # - Free chat path: keep legacy behavior — queue the message
+            #   into the active conversation. No durable task exists,
+            #   so there's no double-execution risk.
             if task_id:
                 await self._auto_close_task(
                     task_id, "failed",
-                    error="agent_busy_steered",
+                    error="agent_busy_handoff_rejected",
                 )
+                return {
+                    "response": (
+                        "Agent is working on another task — handoff "
+                        "rejected. Originator notified via back-edge."
+                    ),
+                    "tool_outputs": [],
+                    "tokens_used": 0,
+                }
+            await self._steer_queue.put(user_message)
             return {
                 "response": (
                     "Agent is working on a task. Your message has been queued "

--- a/src/agent/loop.py
+++ b/src/agent/loop.py
@@ -1718,6 +1718,17 @@ class AgentLoop:
         # Guard is BEFORE _chat_lock to avoid blocking on a held lock.
         if self.current_task is not None:
             await self._steer_queue.put(user_message)
+            # A task_id rode in on this wake but we're busy — the steer
+            # queue has no task_id channel, so the auto-close path would
+            # never fire. Fail the originating task now so the sender's
+            # check_inbox sees a clear ``task_failed`` back-edge with a
+            # specific reason, instead of waiting 7 days for the TTL.
+            # Best-effort: _auto_close_task is exception-safe.
+            if task_id:
+                await self._auto_close_task(
+                    task_id, "failed",
+                    error="agent_busy_steered",
+                )
             return {
                 "response": (
                     "Agent is working on a task. Your message has been queued "
@@ -1780,7 +1791,13 @@ class AgentLoop:
         result_payload: dict | None = None,
         error: str | None = None,
     ) -> None:
-        """Best-effort terminal transition. Never raises — failures log only."""
+        """Best-effort terminal transition. Never raises — failures log only.
+
+        Log severity differentiates state-conflict (HTTP 400, the
+        transition was already done or invalid for current state — benign)
+        from infrastructure failures (network / 5xx — operator action
+        required because the task will dangle in ``pending`` forever).
+        """
         try:
             await self.mesh_client.set_task_status(
                 task_id, status,
@@ -1788,10 +1805,26 @@ class AgentLoop:
                 error=error,
             )
         except Exception as e:
-            logger.warning(
-                "Failed to auto-close task %s as %s: %s",
-                task_id, status, e,
-            )
+            # Discriminate HTTP errors: 4xx is usually "state machine said
+            # no" (benign, e.g. concurrent transition already landed);
+            # 5xx / network / anything else means the mesh is unhealthy
+            # and the task will silently dangle without an alert.
+            resp = getattr(e, "response", None)
+            http_status = getattr(resp, "status_code", None)
+            if isinstance(http_status, int) and 400 <= http_status < 500:
+                logger.warning(
+                    "Auto-close %s → %s rejected by state machine (%s): %s",
+                    task_id, status, http_status, e,
+                )
+            else:
+                # No HTTP response or 5xx → the originating agent will
+                # never see this task close. Surface loudly so operators
+                # notice via standard error-log monitoring.
+                logger.error(
+                    "Auto-close %s → %s FAILED (%s) — task may dangle "
+                    "in pending until a heartbeat or manual close: %s",
+                    task_id, status, http_status or "no response", e,
+                )
 
     # ── Chat helpers (shared by streaming and non-streaming) ────
 

--- a/src/host/server.py
+++ b/src/host/server.py
@@ -4302,18 +4302,22 @@ def create_mesh_app(
                         "status": status,
                         "ts": int(time.time()),
                     }
+                    # ``body["result"]`` is supposed to be a dict, but
+                    # nothing enforces that on the wire. A caller passing
+                    # a string ("ok") used to AttributeError here and the
+                    # back-edge silently dropped — coerce defensively.
+                    raw_result = body.get("result")
+                    result_dict = raw_result if isinstance(raw_result, dict) else {}
                     if status == "blocked":
                         payload["blocker_note"] = blocker_note or ""
                     if status == "failed":
                         payload["error"] = (
                             body.get("error")
-                            or (body.get("result") or {}).get("error", "")
+                            or result_dict.get("error", "")
                             or ""
                         )
                     if status == "done":
-                        payload["summary"] = (
-                            (body.get("result") or {}).get("summary", "")
-                        )
+                        payload["summary"] = result_dict.get("summary", "")
                     blackboard.write(
                         f"inbox/{origin_user}/task_event/{task_id}",
                         payload,
@@ -5406,6 +5410,24 @@ def create_mesh_app(
         if field == "model":
             if not isinstance(new_value, str) or not new_value:
                 raise HTTPException(400, "model must be a non-empty string")
+            # Same BYOK validation as /edit-soft and create-agent —
+            # /propose is deprecated per CLAUDE.md but still active for
+            # back-compat, so close the gap here too.
+            from src.shared.models import (
+                get_available_providers,
+                resolve_provider_for_model,
+            )
+            _provider = resolve_provider_for_model(new_value)
+            _providers_with_creds = get_available_providers()
+            if _provider and _provider not in _providers_with_creds:
+                raise HTTPException(
+                    400,
+                    f"Model '{new_value}' requires '{_provider}' credentials, "
+                    f"but no {_provider.upper()} key is configured. Available "
+                    f"providers: {sorted(_providers_with_creds) or 'none'}. "
+                    f"Set OPENLEGION_SYSTEM_{_provider.upper()}_API_KEY or pick "
+                    f"a different model.",
+                )
         elif field == "thinking":
             from src.agent.llm import LLMClient
             if new_value not in LLMClient.VALID_THINKING_LEVELS:
@@ -5868,6 +5890,26 @@ def create_mesh_app(
         if field == "model":
             if not isinstance(new_value, str) or not new_value:
                 raise HTTPException(400, "model must be a non-empty string")
+            # Match create-agent BYOK validation (PR #901): block edits
+            # that would point the agent at a model whose provider has
+            # no credentials. Otherwise /edit-soft is a back-door
+            # around the create-time check — the agent would silently
+            # fail on its next LLM call.
+            from src.shared.models import (
+                get_available_providers,
+                resolve_provider_for_model,
+            )
+            _provider = resolve_provider_for_model(new_value)
+            _providers_with_creds = get_available_providers()
+            if _provider and _provider not in _providers_with_creds:
+                raise HTTPException(
+                    400,
+                    f"Model '{new_value}' requires '{_provider}' credentials, "
+                    f"but no {_provider.upper()} key is configured. Available "
+                    f"providers: {sorted(_providers_with_creds) or 'none'}. "
+                    f"Set OPENLEGION_SYSTEM_{_provider.upper()}_API_KEY or pick "
+                    f"a different model.",
+                )
         elif field == "thinking":
             from src.agent.llm import LLMClient
             if new_value not in LLMClient.VALID_THINKING_LEVELS:

--- a/src/host/server.py
+++ b/src/host/server.py
@@ -5410,24 +5410,27 @@ def create_mesh_app(
         if field == "model":
             if not isinstance(new_value, str) or not new_value:
                 raise HTTPException(400, "model must be a non-empty string")
-            # Same BYOK validation as /edit-soft and create-agent —
-            # /propose is deprecated per CLAUDE.md but still active for
-            # back-compat, so close the gap here too.
-            from src.shared.models import (
-                get_available_providers,
-                resolve_provider_for_model,
-            )
-            _provider = resolve_provider_for_model(new_value)
-            _providers_with_creds = get_available_providers()
-            if _provider and _provider not in _providers_with_creds:
-                raise HTTPException(
-                    400,
-                    f"Model '{new_value}' requires '{_provider}' credentials, "
-                    f"but no {_provider.upper()} key is configured. Available "
-                    f"providers: {sorted(_providers_with_creds) or 'none'}. "
-                    f"Set OPENLEGION_SYSTEM_{_provider.upper()}_API_KEY or pick "
-                    f"a different model.",
-                )
+            # Same BYOK validation as create_custom_agent (PR #901):
+            # use the live vault to enumerate providers — mirrors
+            # OAuth state, not just env. Skip when no vault is wired
+            # (test harnesses, sandbox transport) — matches create-agent's
+            # behavior so propose/edit and create stay consistent.
+            if credential_vault is not None:
+                from src.shared.models import resolve_provider_for_model
+                _provider = resolve_provider_for_model(new_value)
+                if _provider:
+                    _available = credential_vault.get_providers_with_credentials()
+                    if _provider not in _available:
+                        _available_list = sorted(_available) if _available else "none"
+                        raise HTTPException(
+                            400,
+                            f"Model '{new_value}' requires '{_provider}' "
+                            f"credentials, but no {_provider.upper()} key is "
+                            f"configured. Available providers: "
+                            f"{_available_list}. Set "
+                            f"OPENLEGION_SYSTEM_{_provider.upper()}_API_KEY or "
+                            f"pick a different model.",
+                        )
         elif field == "thinking":
             from src.agent.llm import LLMClient
             if new_value not in LLMClient.VALID_THINKING_LEVELS:
@@ -5890,26 +5893,26 @@ def create_mesh_app(
         if field == "model":
             if not isinstance(new_value, str) or not new_value:
                 raise HTTPException(400, "model must be a non-empty string")
-            # Match create-agent BYOK validation (PR #901): block edits
-            # that would point the agent at a model whose provider has
-            # no credentials. Otherwise /edit-soft is a back-door
-            # around the create-time check — the agent would silently
-            # fail on its next LLM call.
-            from src.shared.models import (
-                get_available_providers,
-                resolve_provider_for_model,
-            )
-            _provider = resolve_provider_for_model(new_value)
-            _providers_with_creds = get_available_providers()
-            if _provider and _provider not in _providers_with_creds:
-                raise HTTPException(
-                    400,
-                    f"Model '{new_value}' requires '{_provider}' credentials, "
-                    f"but no {_provider.upper()} key is configured. Available "
-                    f"providers: {sorted(_providers_with_creds) or 'none'}. "
-                    f"Set OPENLEGION_SYSTEM_{_provider.upper()}_API_KEY or pick "
-                    f"a different model.",
-                )
+            # Match create-agent BYOK validation (PR #901). Use the
+            # live vault, not raw env, so OAuth-only providers count;
+            # skip when no vault is wired (test harnesses) so existing
+            # vault-less tests don't regress to 400.
+            if credential_vault is not None:
+                from src.shared.models import resolve_provider_for_model
+                _provider = resolve_provider_for_model(new_value)
+                if _provider:
+                    _available = credential_vault.get_providers_with_credentials()
+                    if _provider not in _available:
+                        _available_list = sorted(_available) if _available else "none"
+                        raise HTTPException(
+                            400,
+                            f"Model '{new_value}' requires '{_provider}' "
+                            f"credentials, but no {_provider.upper()} key is "
+                            f"configured. Available providers: "
+                            f"{_available_list}. Set "
+                            f"OPENLEGION_SYSTEM_{_provider.upper()}_API_KEY or "
+                            f"pick a different model.",
+                        )
         elif field == "thinking":
             from src.agent.llm import LLMClient
             if new_value not in LLMClient.VALID_THINKING_LEVELS:

--- a/src/shared/redaction.py
+++ b/src/shared/redaction.py
@@ -301,6 +301,51 @@ def redact_string(text: str) -> str:
     return text
 
 
+# Greedy http(s) URL match. Trailing punctuation that's likely sentence
+# terminator (``.,;:)>"'``) is excluded so ``failed: https://x/?k=v.``
+# doesn't drag the dot into the URL and corrupt the rebuilt result.
+_URL_RE = re.compile(r"https?://[^\s\"'<>`]+", re.IGNORECASE)
+
+
+def redact_text_with_urls(text: str) -> str:
+    """Redact secrets from a free-form string that may contain URLs.
+
+    ``redact_string`` only catches secrets matching ``SECRET_PATTERNS``
+    (provider-token shapes, long base64/hex). It does NOT strip arbitrary
+    URL query-parameter values whose key signals a credential
+    (``api_key=anything``). Use this helper for free-form text — log
+    messages, exception strings — where URLs may carry sensitive query
+    params that don't otherwise look like tokens.
+
+    Two passes: first ``redact_url`` on every embedded URL, then
+    ``redact_string`` on the result for tokens outside URL context.
+    """
+    if not text:
+        return text
+
+    def _replace(match: re.Match[str]) -> str:
+        url = match.group(0)
+        # Strip a trailing sentence terminator BEFORE handing to redact_url
+        # (sentence terminators inside a query value are legitimate, but
+        # at the very end of a URL token they're almost certainly the
+        # surrounding prose). Preserve whatever we trim and re-append.
+        trailing = ""
+        while url and url[-1] in ".,;:!?)]>}":
+            trailing = url[-1] + trailing
+            url = url[:-1]
+        if not url:
+            return trailing
+        try:
+            redacted = redact_url(url)
+        except Exception:
+            # Defensive: never let URL-redaction failures kill the caller.
+            redacted = url
+        return redacted + trailing
+
+    text = _URL_RE.sub(_replace, text)
+    return redact_string(text)
+
+
 # ── Deep recursion over JSON-shaped structures ──────────────────────────────
 
 

--- a/tests/test_coordination.py
+++ b/tests/test_coordination.py
@@ -1483,6 +1483,40 @@ class TestHandOffWakeFailureSurfacing:
         assert "[REDACTED]" in result["wake_error"]
 
     @pytest.mark.asyncio
+    async def test_hand_off_wake_error_redacts_url_query_param_value(self):
+        """Codex P1: ``redact_string`` only catches token-shaped secrets
+        (sk-…, gho_…, AKIA…) — it leaves arbitrary URL query-param
+        values intact even when the key signals a credential (e.g.
+        ``?api_key=abc123``). The fix swaps to ``redact_text_with_urls``
+        which runs ``redact_url`` on embedded URLs first so query-param
+        values get stripped regardless of whether the value matches a
+        regex pattern.
+        """
+        from src.agent.builtins.coordination_tool import hand_off
+
+        mc = _make_mesh_client(agent_id="scout")
+        mc.list_agents.return_value = {"analyst": {"role": "analyst"}}
+        # Value is short, random — would NOT match SECRET_PATTERNS,
+        # but the query-param KEY (``api_key``) is in SENSITIVE_QUERY_PARAMS.
+        opaque_value = "abc123random"
+        leaky = (
+            f"POST https://gateway.example.com/wake?api_key={opaque_value} "
+            f"failed with 500"
+        )
+        mc.wake_agent.side_effect = RuntimeError(leaky)
+
+        result = await hand_off(
+            to="analyst",
+            summary="research done",
+            mesh_client=mc,
+        )
+
+        assert result["wake_failed"] is True
+        assert opaque_value not in result["wake_error"], (
+            f"opaque query-param value leaked: {result['wake_error']!r}"
+        )
+
+    @pytest.mark.asyncio
     async def test_hand_off_v2_returns_wake_failed_when_wake_raises(self):
         """V2 path: wake failure surfaces ``wake_failed`` + ``wake_error``."""
         from src.agent.builtins.coordination_tool import hand_off

--- a/tests/test_coordination.py
+++ b/tests/test_coordination.py
@@ -1452,6 +1452,37 @@ class TestHandOffWakeFailureSurfacing:
         assert len(result["wake_error"]) <= 200
 
     @pytest.mark.asyncio
+    async def test_hand_off_wake_error_redacts_credentials(self):
+        """Wake exception messages frequently quote the failing URL with
+        an API key in the query string. The wake_error field is read
+        back into the LLM's context, so credentials there leak into
+        the model trail. Must be redacted BEFORE truncation.
+
+        Uses an ``sk-`` prefixed token long enough to match the OpenAI/
+        Anthropic short-form SECRET_PATTERN (``sk-[A-Za-z0-9]{20,}``).
+        """
+        from src.agent.builtins.coordination_tool import hand_off
+
+        mc = _make_mesh_client(agent_id="scout")
+        mc.list_agents.return_value = {"analyst": {"role": "analyst"}}
+        leaky_token = "sk-" + "a" * 40  # matches SECRET_PATTERN
+        leaky = (
+            f"POST https://internal.example.com/wake?api_key={leaky_token} "
+            f"failed with 500"
+        )
+        mc.wake_agent.side_effect = RuntimeError(leaky)
+
+        result = await hand_off(
+            to="analyst",
+            summary="research done",
+            mesh_client=mc,
+        )
+
+        assert result["wake_failed"] is True
+        assert leaky_token not in result["wake_error"]
+        assert "[REDACTED]" in result["wake_error"]
+
+    @pytest.mark.asyncio
     async def test_hand_off_v2_returns_wake_failed_when_wake_raises(self):
         """V2 path: wake failure surfaces ``wake_failed`` + ``wake_error``."""
         from src.agent.builtins.coordination_tool import hand_off

--- a/tests/test_edit_soft_endpoint.py
+++ b/tests/test_edit_soft_endpoint.py
@@ -51,6 +51,13 @@ def mesh_app(tmp_path, monkeypatch):
     """Mesh app pinned to a tmp_path with `writer` agent on disk."""
     afile = _agents_yaml(tmp_path, names=["writer", "researcher"])
     monkeypatch.chdir(tmp_path)
+    # Existing tests assume any model string is valid. /edit-soft (and
+    # /propose) now run BYOK provider validation on the ``model`` field,
+    # so plant placeholder keys for the two providers existing tests
+    # reference (anthropic, openai). New validator-specific tests below
+    # override these with their own setenv.
+    monkeypatch.setenv("OPENLEGION_SYSTEM_ANTHROPIC_API_KEY", "sk-ant-fixture")
+    monkeypatch.setenv("OPENLEGION_SYSTEM_OPENAI_API_KEY", "sk-oai-fixture")
     import src.cli.config as cli_cfg
     monkeypatch.setattr(cli_cfg, "AGENTS_FILE", afile)
     monkeypatch.setattr(cli_cfg, "PERMISSIONS_FILE", tmp_path / "config" / "permissions.json")
@@ -190,6 +197,55 @@ async def test_edit_soft_rejects_invalid_model_value(mesh_app):
         )
     assert r.status_code == 400
     assert "model" in r.text.lower()
+
+
+@pytest.mark.asyncio
+async def test_edit_soft_rejects_model_without_provider_credentials(
+    mesh_app, monkeypatch,
+):
+    """BYOK validation closes the /edit-soft back-door: if the operator
+    tries to retarget an agent at a model whose provider has no API
+    key configured, the edit must 400 — otherwise the agent silently
+    dies on its next LLM call (same failure mode PR #901 plugged at
+    create-agent time).
+    """
+    app, _, _ = mesh_app
+    # Mesh fixture set both anthropic + openai; for this test, drop
+    # openai so requesting an openai/* model has no backing key.
+    monkeypatch.delenv("OPENLEGION_SYSTEM_OPENAI_API_KEY", raising=False)
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
+        r = await c.post(
+            "/mesh/agents/writer/edit-soft",
+            json={"field": "model", "value": "openai/gpt-4o", "reason": "u"},
+            headers=_human_origin_headers(),
+        )
+    assert r.status_code == 400, r.text
+    body = r.text.lower()
+    assert "openai" in body
+    assert "credentials" in body or "key" in body
+
+
+@pytest.mark.asyncio
+async def test_edit_soft_accepts_model_when_provider_has_credentials(
+    mesh_app,
+):
+    """Positive case: the fixture provides an anthropic key, so a
+    /edit-soft to an anthropic/* model is accepted.
+    """
+    app, _, _ = mesh_app
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
+        r = await c.post(
+            "/mesh/agents/writer/edit-soft",
+            json={
+                "field": "model",
+                "value": "anthropic/claude-sonnet-4-20250514",
+                "reason": "u",
+            },
+            headers=_human_origin_headers(),
+        )
+    assert r.status_code == 200, r.text
+    assert r.json()["field"] == "model"
 
 
 @pytest.mark.asyncio

--- a/tests/test_edit_soft_endpoint.py
+++ b/tests/test_edit_soft_endpoint.py
@@ -48,16 +48,15 @@ def _agents_yaml(tmp_path, names: list[str]) -> Path:
 
 @pytest.fixture
 def mesh_app(tmp_path, monkeypatch):
-    """Mesh app pinned to a tmp_path with `writer` agent on disk."""
+    """Mesh app pinned to a tmp_path with `writer` agent on disk.
+
+    No credential_vault is wired — matches the production behavior
+    where edit_agent_soft's BYOK model validator is a no-op when no
+    vault exists (test harnesses / sandbox transport). The dedicated
+    validator tests below construct their own vault-wired app.
+    """
     afile = _agents_yaml(tmp_path, names=["writer", "researcher"])
     monkeypatch.chdir(tmp_path)
-    # Existing tests assume any model string is valid. /edit-soft (and
-    # /propose) now run BYOK provider validation on the ``model`` field,
-    # so plant placeholder keys for the two providers existing tests
-    # reference (anthropic, openai). New validator-specific tests below
-    # override these with their own setenv.
-    monkeypatch.setenv("OPENLEGION_SYSTEM_ANTHROPIC_API_KEY", "sk-ant-fixture")
-    monkeypatch.setenv("OPENLEGION_SYSTEM_OPENAI_API_KEY", "sk-oai-fixture")
     import src.cli.config as cli_cfg
     monkeypatch.setattr(cli_cfg, "AGENTS_FILE", afile)
     monkeypatch.setattr(cli_cfg, "PERMISSIONS_FILE", tmp_path / "config" / "permissions.json")
@@ -199,53 +198,138 @@ async def test_edit_soft_rejects_invalid_model_value(mesh_app):
     assert "model" in r.text.lower()
 
 
+def _vault_wired_mesh_app(tmp_path, monkeypatch, provider_keys: dict[str, str]):
+    """Build a mesh app with a live credential_vault. ``provider_keys``
+    maps provider name → key value, e.g. ``{"anthropic": "sk-ant-x"}``.
+    Returns ``(app, server_module)``."""
+    afile = _agents_yaml(tmp_path, names=["writer"])
+    monkeypatch.chdir(tmp_path)
+    import src.cli.config as cli_cfg
+    monkeypatch.setattr(cli_cfg, "AGENTS_FILE", afile)
+    monkeypatch.setattr(
+        cli_cfg, "PERMISSIONS_FILE", tmp_path / "config" / "permissions.json",
+    )
+    (tmp_path / "config" / "permissions.json").write_text('{"permissions": {}}')
+
+    # Plant ONLY the requested provider keys; drop the others so the
+    # vault reports exactly the providers under test.
+    for prov in ("openai", "anthropic", "google", "deepseek", "xai"):
+        monkeypatch.delenv(f"OPENLEGION_SYSTEM_{prov.upper()}_API_KEY", raising=False)
+    for prov, key in provider_keys.items():
+        monkeypatch.setenv(f"OPENLEGION_SYSTEM_{prov.upper()}_API_KEY", key)
+
+    import src.host.server as server_module
+    importlib.reload(server_module)
+    from src.host.credentials import CredentialVault
+
+    blackboard = Blackboard(str(tmp_path / "bb.db"))
+    pubsub = PubSub()
+    permissions = PermissionMatrix()
+    for aid, p in (
+        ("operator", {"can_route_tasks": True, "can_manage_projects": True}),
+        ("writer", {"can_route_tasks": False}),
+    ):
+        permissions.permissions[aid] = AgentPermissions(agent_id=aid, **p)
+    router = MessageRouter(permissions, {})
+    vault = CredentialVault()  # picks up env via _load_credentials()
+
+    app = server_module.create_mesh_app(
+        blackboard=blackboard,
+        pubsub=pubsub,
+        router=router,
+        permissions=permissions,
+        credential_vault=vault,
+    )
+    return app, server_module, blackboard
+
+
 @pytest.mark.asyncio
 async def test_edit_soft_rejects_model_without_provider_credentials(
-    mesh_app, monkeypatch,
+    tmp_path, monkeypatch,
 ):
     """BYOK validation closes the /edit-soft back-door: if the operator
     tries to retarget an agent at a model whose provider has no API
     key configured, the edit must 400 — otherwise the agent silently
     dies on its next LLM call (same failure mode PR #901 plugged at
     create-agent time).
-    """
-    app, _, _ = mesh_app
-    # Mesh fixture set both anthropic + openai; for this test, drop
-    # openai so requesting an openai/* model has no backing key.
-    monkeypatch.delenv("OPENLEGION_SYSTEM_OPENAI_API_KEY", raising=False)
 
-    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
-        r = await c.post(
-            "/mesh/agents/writer/edit-soft",
-            json={"field": "model", "value": "openai/gpt-4o", "reason": "u"},
-            headers=_human_origin_headers(),
-        )
-    assert r.status_code == 400, r.text
-    body = r.text.lower()
-    assert "openai" in body
-    assert "credentials" in body or "key" in body
+    Uses a vault-wired app so the validator runs (it's a no-op when
+    credential_vault is None — matches create-agent's gating).
+    """
+    app, _, bb = _vault_wired_mesh_app(
+        tmp_path, monkeypatch,
+        provider_keys={"anthropic": "sk-ant-only"},  # NO openai
+    )
+    try:
+        async with AsyncClient(
+            transport=ASGITransport(app=app), base_url="http://t",
+        ) as c:
+            r = await c.post(
+                "/mesh/agents/writer/edit-soft",
+                json={"field": "model", "value": "openai/gpt-4o", "reason": "u"},
+                headers=_human_origin_headers(),
+            )
+        assert r.status_code == 400, r.text
+        body = r.text.lower()
+        assert "openai" in body
+        assert "credentials" in body or "key" in body
+    finally:
+        bb.close()
+        import src.host.server as server_module
+        importlib.reload(server_module)
 
 
 @pytest.mark.asyncio
 async def test_edit_soft_accepts_model_when_provider_has_credentials(
-    mesh_app,
+    tmp_path, monkeypatch,
 ):
-    """Positive case: the fixture provides an anthropic key, so a
-    /edit-soft to an anthropic/* model is accepted.
+    """Positive case: vault has an anthropic key, so /edit-soft to an
+    anthropic/* model is accepted."""
+    app, _, bb = _vault_wired_mesh_app(
+        tmp_path, monkeypatch,
+        provider_keys={"anthropic": "sk-ant-only"},
+    )
+    try:
+        async with AsyncClient(
+            transport=ASGITransport(app=app), base_url="http://t",
+        ) as c:
+            r = await c.post(
+                "/mesh/agents/writer/edit-soft",
+                json={
+                    "field": "model",
+                    "value": "anthropic/claude-sonnet-4-20250514",
+                    "reason": "u",
+                },
+                headers=_human_origin_headers(),
+            )
+        assert r.status_code == 200, r.text
+        assert r.json()["field"] == "model"
+    finally:
+        bb.close()
+        import src.host.server as server_module
+        importlib.reload(server_module)
+
+
+@pytest.mark.asyncio
+async def test_edit_soft_skips_validation_when_no_vault_wired(mesh_app):
+    """Production parity guard: when ``create_mesh_app`` is built without
+    a ``credential_vault`` (test harnesses, sandbox transport), the
+    model-field validator must be a no-op. Otherwise existing
+    vault-less tests that POST arbitrary model strings would all
+    regress to 400. Mirrors ``create_custom_agent``'s gating.
     """
     app, _, _ = mesh_app
-    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://t",
+    ) as c:
         r = await c.post(
             "/mesh/agents/writer/edit-soft",
-            json={
-                "field": "model",
-                "value": "anthropic/claude-sonnet-4-20250514",
-                "reason": "u",
-            },
+            # A provider that almost certainly has no env key in CI;
+            # without the no-vault skip this would 400.
+            json={"field": "model", "value": "cohere/command-x", "reason": "u"},
             headers=_human_origin_headers(),
         )
     assert r.status_code == 200, r.text
-    assert r.json()["field"] == "model"
 
 
 @pytest.mark.asyncio

--- a/tests/test_shared_redaction.py
+++ b/tests/test_shared_redaction.py
@@ -388,3 +388,50 @@ class TestRedactUrlPreservesCanonicalQuery:
         assert "mysecret" not in out
         assert "[REDACTED]" in out
         assert "keep=ok" in out
+
+
+class TestRedactTextWithUrls:
+    """Free-form-text redaction: catches both token-shaped secrets
+    (delegated to ``redact_string``) AND URL query-param values whose
+    key signals a credential (delegated to ``redact_url`` per-URL).
+
+    Motivated by Codex P1 from the PR R1 review of coordination_tool's
+    wake_error path — plain ``redact_string`` left ``?api_key=anyvalue``
+    intact when the value didn't match SECRET_PATTERNS, leaking
+    credentials into the LLM context."""
+
+    def test_strips_query_param_value_even_when_value_is_opaque(self):
+        from src.shared.redaction import redact_text_with_urls
+        msg = "POST https://gw.example.com/x?api_key=abc123random failed 500"
+        out = redact_text_with_urls(msg)
+        assert "abc123random" not in out
+        assert "[REDACTED]" in out
+
+    def test_still_catches_bare_tokens_outside_urls(self):
+        from src.shared.redaction import redact_text_with_urls
+        token = "sk-" + "a" * 40
+        msg = f"oauth handshake leaked {token} into the log"
+        out = redact_text_with_urls(msg)
+        assert token not in out
+        assert "[REDACTED]" in out
+
+    def test_handles_url_followed_by_sentence_terminator(self):
+        from src.shared.redaction import redact_text_with_urls
+        msg = "ping https://x.example.com/?api_key=secretvalue."
+        out = redact_text_with_urls(msg)
+        assert "secretvalue" not in out
+        # The trailing period must survive — it's prose, not URL.
+        assert out.rstrip().endswith(".")
+
+    def test_empty_input_passes_through(self):
+        from src.shared.redaction import redact_text_with_urls
+        assert redact_text_with_urls("") == ""
+        assert redact_text_with_urls(None) is None  # type: ignore[arg-type]
+
+    def test_url_without_sensitive_param_unchanged_otherwise(self):
+        from src.shared.redaction import redact_text_with_urls
+        msg = "GET https://x.example.com/v1/things?filter=red failed"
+        out = redact_text_with_urls(msg)
+        # ``filter`` is not in SENSITIVE_QUERY_PARAMS — value survives.
+        assert "filter=red" in out
+        assert "failed" in out

--- a/tests/test_task_lifecycle.py
+++ b/tests/test_task_lifecycle.py
@@ -168,34 +168,60 @@ async def test_chat_without_task_id_skips_auto_close():
     loop.mesh_client.set_task_status.assert_not_awaited()
 
 
-# ── 4b. agent-busy steered guard fails the handed-off task ───────
+# ── 4b. agent-busy handoff rejection — no steer queue + back-edge ─
 
 @pytest.mark.asyncio
-async def test_chat_with_task_id_while_busy_fails_handed_off_task():
-    """When a wake with task_id arrives but the agent is already running
-    a task, the chat() early-return queues the message to the steer
-    queue. Before the fix the originating task was orphaned — the
-    steer queue has no task_id channel so auto-close never fired and
-    the originator's check_inbox stayed empty until the 7-day TTL.
+async def test_chat_with_task_id_while_busy_rejects_handoff_without_queueing():
+    """Codex P2: previous attempt at this fix put the message on the
+    steer queue AND closed the task as failed. The originator saw
+    task_failed and could retry/reroute, while THIS agent later
+    drained the queue and processed the (now-failed) message —
+    duplicate / conflicting work.
 
-    Now we close the task as ``failed`` with a specific
-    ``agent_busy_steered`` error so the sender's check_inbox surfaces
-    a clear back-edge immediately and they can choose to retry or
-    redirect.
+    Correct semantics: a handoff with task_id arriving on a busy
+    agent must be CLEANLY rejected — no steer-queue enqueue. The
+    originator gets a clear back-edge via set_task_status(failed)
+    and is the only party that decides what to do next.
+
+    Legacy free-form chat (no task_id) keeps queueing — there's
+    no durable task in that path so no double-execution risk.
     """
     loop = _make_loop_with_mocks()
+    # Sentinel async-mock for the steer queue so we can assert NO put.
+    loop._steer_queue.put = AsyncMock(return_value=None)
     # Simulate agent already executing a task.
     loop.current_task = "task_in_flight"
 
-    result = await loop.chat("queued plz", task_id="task_arriving")
+    result = await loop.chat("handoff plz", task_id="task_arriving")
 
-    # Steered message still queued (no behavior change for the chat).
-    assert "queued" in result["response"].lower()
-    # And the arriving task got a clear failed back-edge.
+    # The handoff was rejected — response surfaces that to the caller.
+    assert "rejected" in result["response"].lower()
+    # The arriving task got a clear failed back-edge with a specific code.
     loop.mesh_client.set_task_status.assert_awaited_once()
     call = loop.mesh_client.set_task_status.await_args
     assert call.args == ("task_arriving", "failed")
-    assert call.kwargs.get("error") == "agent_busy_steered"
+    assert call.kwargs.get("error") == "agent_busy_handoff_rejected"
+    # CRITICAL: must NOT have queued the message (would cause dup-exec).
+    loop._steer_queue.put.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_chat_without_task_id_while_busy_still_queues_for_chat_ux():
+    """Legacy chat path is unchanged: a free-form chat message (no
+    task_id) on a busy agent still goes onto the steer queue so the
+    user's mid-conversation steering survives. Only the durable-task
+    handoff path skips the queue (see test above)."""
+    loop = _make_loop_with_mocks()
+    loop._steer_queue.put = AsyncMock(return_value=None)
+    loop.current_task = "task_in_flight"
+
+    result = await loop.chat("hey can you also do X?")  # no task_id
+
+    assert "queued" in result["response"].lower()
+    # No task to close (no task_id).
+    loop.mesh_client.set_task_status.assert_not_awaited()
+    # And the queue WAS exercised.
+    loop._steer_queue.put.assert_awaited_once_with("hey can you also do X?")
 
 
 # ── 4c. _auto_close_task log-severity discriminates 4xx vs 5xx ────

--- a/tests/test_task_lifecycle.py
+++ b/tests/test_task_lifecycle.py
@@ -168,6 +168,101 @@ async def test_chat_without_task_id_skips_auto_close():
     loop.mesh_client.set_task_status.assert_not_awaited()
 
 
+# ── 4b. agent-busy steered guard fails the handed-off task ───────
+
+@pytest.mark.asyncio
+async def test_chat_with_task_id_while_busy_fails_handed_off_task():
+    """When a wake with task_id arrives but the agent is already running
+    a task, the chat() early-return queues the message to the steer
+    queue. Before the fix the originating task was orphaned — the
+    steer queue has no task_id channel so auto-close never fired and
+    the originator's check_inbox stayed empty until the 7-day TTL.
+
+    Now we close the task as ``failed`` with a specific
+    ``agent_busy_steered`` error so the sender's check_inbox surfaces
+    a clear back-edge immediately and they can choose to retry or
+    redirect.
+    """
+    loop = _make_loop_with_mocks()
+    # Simulate agent already executing a task.
+    loop.current_task = "task_in_flight"
+
+    result = await loop.chat("queued plz", task_id="task_arriving")
+
+    # Steered message still queued (no behavior change for the chat).
+    assert "queued" in result["response"].lower()
+    # And the arriving task got a clear failed back-edge.
+    loop.mesh_client.set_task_status.assert_awaited_once()
+    call = loop.mesh_client.set_task_status.await_args
+    assert call.args == ("task_arriving", "failed")
+    assert call.kwargs.get("error") == "agent_busy_steered"
+
+
+# ── 4c. _auto_close_task log-severity discriminates 4xx vs 5xx ────
+
+@pytest.mark.asyncio
+async def test_auto_close_logs_5xx_at_error_not_warning(caplog):
+    """A mesh 5xx on auto-close means the task will silently dangle in
+    pending forever — must surface at ERROR so standard log monitors
+    page the operator. State-machine 4xx (benign concurrent-transition
+    races) stays at WARNING so it doesn't trigger noise alerts.
+    """
+    import logging
+    from unittest.mock import MagicMock as _MM
+
+    loop = _make_loop_with_mocks()
+
+    # Simulate httpx.HTTPStatusError shape: exception with a .response
+    # that carries a status_code int.
+    fake_resp_5xx = _MM()
+    fake_resp_5xx.status_code = 503
+    fake_resp_5xx.text = "Service Unavailable"
+    err_5xx = Exception("mesh exploded")
+    err_5xx.response = fake_resp_5xx
+    loop.mesh_client.set_task_status = AsyncMock(side_effect=err_5xx)
+
+    caplog.set_level(logging.WARNING, logger="agent.loop")
+    await loop._auto_close_task("task_x", "done")
+
+    # Exactly one log record, at ERROR level (not WARNING).
+    err_records = [
+        r for r in caplog.records
+        if r.levelno >= logging.ERROR and "task_x" in r.getMessage()
+    ]
+    assert len(err_records) == 1, (
+        f"expected 1 ERROR log for 5xx, got {len(err_records)}: "
+        f"{[r.getMessage() for r in caplog.records]}"
+    )
+    assert "FAILED" in err_records[0].getMessage()
+
+
+@pytest.mark.asyncio
+async def test_auto_close_logs_4xx_at_warning_not_error(caplog):
+    """State-machine rejections (e.g. already done, transition not
+    allowed) are 400-ish and benign. Must NOT escalate to ERROR or
+    we'll page on every concurrent-transition race.
+    """
+    import logging
+    from unittest.mock import MagicMock as _MM
+
+    loop = _make_loop_with_mocks()
+
+    fake_resp_4xx = _MM()
+    fake_resp_4xx.status_code = 400
+    fake_resp_4xx.text = "Invalid transition"
+    err_4xx = Exception("state machine said no")
+    err_4xx.response = fake_resp_4xx
+    loop.mesh_client.set_task_status = AsyncMock(side_effect=err_4xx)
+
+    caplog.set_level(logging.WARNING, logger="agent.loop")
+    await loop._auto_close_task("task_y", "done")
+
+    err_records = [r for r in caplog.records if r.levelno >= logging.ERROR]
+    assert len(err_records) == 0, (
+        f"4xx should not emit ERROR — got {[r.getMessage() for r in err_records]}"
+    )
+
+
 # ── 5/6/7: back-edge emission on terminal transition ─────────────
 
 def _setup_mesh_app(tmp_path):
@@ -322,6 +417,47 @@ async def test_terminal_transition_writes_back_edge_for_agent_origin(tmp_path):
         assert payload["status"] == "done"
         assert payload["summary"] == "all done"
         assert entry.ttl == 604800
+    finally:
+        _teardown_mesh(bb, tasks_store)
+
+
+@pytest.mark.asyncio
+async def test_back_edge_tolerates_non_dict_result(tmp_path):
+    """Before the fix, a /status call with ``result="ok"`` (a string,
+    not a dict) crashed the back-edge writer with AttributeError —
+    the status update committed but the originator's inbox stayed
+    empty. Test guards against the regression by sending a plain
+    string result and verifying:
+      (a) the status transition succeeds (200),
+      (b) the back-edge IS written (just with empty summary).
+    """
+    from httpx import ASGITransport, AsyncClient
+
+    app, bb, tasks_store, _ = _setup_mesh_app(tmp_path)
+    try:
+        rec = tasks_store.create(
+            creator="alpha",
+            assignee="beta",
+            title="Do the thing",
+            origin={"kind": "agent", "channel": "", "user": "alpha"},
+        )
+        task_id = rec["id"]
+
+        async with AsyncClient(
+            transport=ASGITransport(app=app), base_url="http://test",
+        ) as client:
+            await _advance_to_working(client, task_id)
+            resp = await client.post(
+                f"/mesh/tasks/{task_id}/status",
+                # Misuse: result is a string, not a dict.
+                json={"status": "done", "result": "ok"},
+                headers={"x-mesh-internal": "1"},
+            )
+        assert resp.status_code == 200, resp.text
+        entry = bb.read(f"inbox/alpha/task_event/{task_id}")
+        assert entry is not None, "back-edge dropped on non-dict result"
+        # Summary defaults to "" — the writer didn't crash extracting it.
+        assert entry.value.get("summary") == ""
     finally:
         _teardown_mesh(bb, tasks_store)
 


### PR DESCRIPTION
## Summary

Follow-up to the four operator-bug PRs (#899, #900, #901, #903). Two
deep-review passes (principal-engineer + 2× codex) surfaced real bugs
that the original PRs missed. Bundles all fixes here so the four
prior PRs stay clean and the fix history is one logical unit.

## Bugs closed

### From principal-engineer review

1. **Back-edge crashed on non-dict result** (host/server.py). `(body.get("result") or {}).get("summary", "")` threw `AttributeError` if a caller passed a string instead of a dict. Status update committed, back-edge silently dropped. Defensive `isinstance(_, dict)` check added.

2. **/edit-soft and /propose skipped BYOK validation** (host/server.py). PR #901 plugged the create-time gap but operators could still retarget existing agents to a model whose provider has no credentials via the edit paths. Apply the same vault-aware check.

3. **Wake errors leaked credentials** (coordination_tool.py). `str(e)[:200]` exposed exception messages verbatim — HTTP-level errors frequently quote the failing URL with an API key in the query string. Route through new `redact_text_with_urls`.

4. **`agent_busy` early-return orphaned handed-off tasks** (loop.py). When the agent was busy, the chat() early-return queued the message but task_id was dropped — originator's check_inbox stayed empty until the 7-day TTL.

5. **Auto-close 5xx logged at WARNING** (loop.py). Same severity as benign state-machine 4xx, so the case where the task SILENTLY DANGLES forever didn't trigger standard error-log monitoring. Discriminate: 4xx WARNING, 5xx / network ERROR.

### From codex review round 1 (P1)

6. **`redact_string` didn't strip URL query-param values** (shared/redaction.py + coordination_tool.py). Caught secrets matching SECRET_PATTERNS but left `?api_key=opaque_random_value` intact. New helper `redact_text_with_urls` runs `redact_url` on embedded URLs first, then SECRET_PATTERNS for token-shaped secrets outside URLs.

### From codex review round 2 (P2)

7. **edit-soft/propose model validator used env vars instead of live vault** (host/server.py). Missed OAuth-only providers AND regressed vault-less test harnesses. Mirror `create_custom_agent`'s pattern: skip when `credential_vault is None`, otherwise use `credential_vault.get_providers_with_credentials()`.

8. **Busy-handoff caused duplicate execution** (loop.py). Fix #4 marked the task `failed` BUT also put the message on `_steer_queue` — originator saw `task_failed` → retried, while this agent later drained the queue and processed the (now-routed) message. Fix: split semantics by `task_id`. Handoffs cleanly reject (no queue); free-form chat still queues.

Codex review round 3: ✓ no further findings.

## Test plan

- [x] `test_back_edge_tolerates_non_dict_result` — guards regression of #1
- [x] `test_edit_soft_rejects_model_without_provider_credentials` — guards #2
- [x] `test_edit_soft_accepts_model_when_provider_has_credentials` — positive case
- [x] `test_edit_soft_skips_validation_when_no_vault_wired` — guards regression of codex P2 (#7)
- [x] `test_hand_off_wake_error_redacts_credentials` — guards #3 (token-shape secrets)
- [x] `test_hand_off_wake_error_redacts_url_query_param_value` — guards codex P1 (#6)
- [x] `TestRedactTextWithUrls` (5 cases) — unit coverage of the new shared helper
- [x] `test_chat_with_task_id_while_busy_rejects_handoff_without_queueing` — guards #4 and codex P2 (#8)
- [x] `test_chat_without_task_id_while_busy_still_queues_for_chat_ux` — pins legacy chat-mode UX
- [x] `test_auto_close_logs_5xx_at_error_not_warning` — guards #5 (operator-visibility)
- [x] `test_auto_close_logs_4xx_at_warning_not_error` — guards against over-alerting
- [x] All 254 tests across the six affected files pass
- [x] Ruff clean

## Out of scope (flagged in review, not addressed)

- Failover-chain credential validation (separate concern, larger refactor of failover.py).
- Pagination on `list_peer_artifacts` (perf, not correctness).
- Event dedup on `check_inbox` events (UX nit; 7-day TTL bounds spam).
- Rename `_auto_close_task` → `_auto_transition_task` (cosmetic).