### PR TITLE
fix(dashboard): auto-scroll chat to latest on mount

### DIFF
--- a/src/dashboard/static/js/app.js
+++ b/src/dashboard/static/js/app.js
@@ -1429,6 +1429,30 @@ function dashboard() {
         document.title = this._buildTitle();
       }
 
+      // Operator chat container is x-show="operatorReady" — until fetchAgents
+      // resolves it's display:none (scrollHeight=0) and the init scroll below
+      // silently no-ops. Re-fire once when the gate flips so users land on the
+      // latest message rather than the top of the restored history.
+      this.$watch('operatorReady', (val, oldVal) => {
+        if (!val || oldVal) return;
+        this.$nextTick(() => {
+          if (this.activeTab === 'chat' || this.messengerSidePanelOpen) {
+            this._scrollChat(this.activeChatId || 'operator', true);
+          }
+        });
+      });
+
+      // Side-panel open transition — the chat-messages container mounts at
+      // scrollTop=0; force a scroll on the open edge so click-toggles land
+      // on the latest message. localStorage-restored opens are handled below
+      // since the assignment already happened during state restore.
+      this.$watch('messengerSidePanelOpen', (val) => {
+        if (!val) return;
+        this.$nextTick(() => {
+          if (this.activeChatId) this._scrollChat(this.activeChatId, true);
+        });
+      });
+
       // Ensure operator chat is initialized when landing on the chat tab
       if (this.activeTab === 'chat' || initRoute.tab === 'chat') {
         if (!this.openChats.includes('operator')) {
@@ -1441,6 +1465,14 @@ function dashboard() {
           this._scrollChat('operator', true);
           const el = document.getElementById('operator-chat-input');
           if (el) el.focus();
+        });
+      }
+
+      // Side panel restored from localStorage above (line ~1233) — the
+      // $watch doesn't fire on init-time assignment, so scroll explicitly.
+      if (this.messengerSidePanelOpen && this.activeChatId) {
+        this.$nextTick(() => {
+          this._scrollChat(this.activeChatId, true);
         });
       }
 
@@ -1824,6 +1856,7 @@ function dashboard() {
           this.chatPanelMinimized = false;
           this._loadChatHistory(this.activeChatId || 'operator');
           this.$nextTick(() => {
+            this._scrollChat(this.activeChatId || 'operator', true);
             const el = document.getElementById('operator-chat-input');
             if (el) el.focus();
           });
@@ -7680,6 +7713,7 @@ function dashboard() {
         if (!resp.ok) return;
         const data = await resp.json();
         const localMsgs = this.chatHistories[agentId] || [];
+        const wasEmpty = localMsgs.length === 0;
         if (!data.messages || data.messages.length === 0) {
           // Server returned empty — agent may be restarting or transcript not yet
           // initialized. Preserve local messages to avoid losing visible history.
@@ -7735,7 +7769,11 @@ function dashboard() {
           ? [...serverMsgs, ...trailing]
           : serverMsgs;
         this._saveChatToSession();
-        this.$nextTick(() => this._scrollChat(agentId));
+        // Force scroll when the local cache was empty (first fetch on mount) —
+        // the sticky nearBottom heuristic would otherwise treat scrollTop=0
+        // as "user scrolled to top" and skip. Live-update refreshes keep the
+        // conservative behavior to preserve a user's scroll position.
+        this.$nextTick(() => this._scrollChat(agentId, wasEmpty));
       } catch (e) {
         console.debug('_loadChatHistory failed for', agentId, e.message || e);
       }


### PR DESCRIPTION
## Summary

On page refresh / new tab / side-panel restore, the chat container landed at scrollTop=0 (top of restored history) instead of the latest message, forcing users to scroll down manually. `_scrollChat`'s sticky `nearBottom` heuristic correctly preserves scroll position during live updates, but on a fresh mount `scrollTop=0` falsely registered as "user scrolled up" and the auto-scroll silently no-op'd.

Three broken paths fixed:

- **Main `/chat` tab on refresh** — `init()` scheduled `_scrollChat('operator', true)` in `$nextTick`, but the container is gated by `x-show="operatorReady"` which only flips true after async `fetchAgents()` resolves. The 50ms scroll throttle usually fired before the gate opened, so `scrollHeight=0` and nothing scrolled. Fix: `$watch('operatorReady')` re-fires the scroll on the false→true edge.
- **Side-panel via `toggleSidePanel()`** — the open branch loaded history and focused the input but never forced a scroll. Fix: scroll call added inside the existing `$nextTick`, plus a `$watch('messengerSidePanelOpen')` to catch future open transitions uniformly.
- **Side-panel auto-open from localStorage** — restore at `init()` assigned `messengerSidePanelOpen = true` before the watcher was registered, so no event fired. Fix: explicit one-shot scroll after the operator chat init block.

Belt-and-suspenders: `_loadChatHistory` now forces the trailing scroll when the prior local cache was empty (first-load case). Live-update refreshes (cache non-empty) keep the conservative sticky behavior so a user reading older messages doesn't get yanked to the bottom.

## Test plan

- [ ] Hard refresh `/` → operator chat lands at latest message.
- [ ] Deep-link to a different tab (e.g. `/system`), open side-panel via toggle → side-panel lands at latest message.
- [ ] Open side-panel, refresh page → side-panel auto-restored AND lands at latest message.
- [ ] Scroll up to read older history, let live update fire → scroll position preserved (sticky behavior intact).
- [ ] Stream a new response → scroll follows the stream as before.

## Notes

The dashboard has no JS unit tests today; this fix is verified manually. Adding JS test infrastructure for a single bug fix would be heavy — flagging the gap.