### PR TITLE
feat: add /teams/* route aliases (PR 1/3 of project→team rename)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -331,3 +331,7 @@ pytest tests/test_loop.py -x -v
 2. Define agents with `role`, `model`, `instructions`, `soul`, `resources`
 3. Optionally include `heartbeat_rules`, `permissions`, `budget`
 4. Templates auto-discovered by `_load_templates()` in `src/cli/config.py`
+
+## Review State
+
+2026-05-16 — Added /mesh/teams/* and /api/teams/* route aliases as scaffold for the upcoming project→team rename. No behavior change; pure addition.

--- a/src/dashboard/server.py
+++ b/src/dashboard/server.py
@@ -4391,6 +4391,25 @@ def create_dashboard_router(
             })
         return {"projects": result}
 
+    @api_router.get("/api/teams")
+    async def api_teams_list() -> dict:
+        """List all teams with members — alias for ``/api/projects``."""
+        from src.cli.config import _load_projects
+        projects = _load_projects()
+        result = []
+        sorted_projects = sorted(projects.items(), key=lambda x: x[1].get("created_at") or "")
+        for i, (pname, pdata) in enumerate(sorted_projects):
+            is_over = _projects_disabled or (_max_projects > 0 and i >= _max_projects)
+            result.append({
+                "name": pname,
+                "team_name": pname,
+                "description": pdata.get("description", ""),
+                "members": pdata.get("members", []),
+                "created_at": pdata.get("created_at", ""),
+                "over_limit": is_over,
+            })
+        return {"teams": result, "projects": result}
+
     @api_router.post("/api/projects")
     async def api_projects_create(request: Request) -> dict:
         """Create a new project."""
@@ -4441,6 +4460,56 @@ def create_dashboard_router(
                 logger.debug("project_created emit failed: %s", e)
         return {"created": True, "name": name}
 
+    @api_router.post("/api/teams")
+    async def api_teams_create(request: Request) -> dict:
+        """Create a new team — alias for ``/api/projects``."""
+        if _projects_disabled:
+            raise HTTPException(
+                status_code=403,
+                detail="Teams are not available on your current plan. Upgrade to enable teams.",
+            )
+        if _max_projects > 0:
+            from src.cli.config import _load_projects
+            current_count = len(_load_projects())
+            if current_count >= _max_projects:
+                raise HTTPException(
+                    status_code=403,
+                    detail=f"Team limit reached ({_max_projects}). Upgrade your plan for more teams.",
+                )
+        from src.cli.config import _create_project, _load_config
+        body = await request.json()
+        name = body.get("name", "").strip()
+        description = sanitize_for_prompt(body.get("description", "")).strip()
+        members = body.get("members", [])
+        if not name:
+            raise HTTPException(status_code=400, detail="name is required")
+        if not isinstance(members, list):
+            raise HTTPException(status_code=400, detail="members must be a list")
+        # Validate that member agents exist in the config
+        cfg = _load_config()
+        known_agents = set(cfg.get("agents", {}).keys())
+        unknown = [m for m in members if m not in known_agents]
+        if unknown:
+            raise HTTPException(status_code=400, detail=f"Unknown agents: {', '.join(unknown)}")
+        try:
+            _create_project(name, description=description, members=members)
+        except ValueError as e:
+            raise HTTPException(status_code=400, detail=str(e))
+        if event_bus is not None:
+            try:
+                event_bus.emit(
+                    "project_created", agent="operator",
+                    data={
+                        "project_id": name,
+                        "name": name,
+                        "description": description,
+                        "members": list(members),
+                    },
+                )
+            except Exception as e:
+                logger.debug("project_created emit failed: %s", e)
+        return {"created": True, "name": name, "team_name": name}
+
     @api_router.delete("/api/projects/{name}")
     async def api_projects_delete(name: str) -> dict:
         """Delete a project and release its members."""
@@ -4458,6 +4527,24 @@ def create_dashboard_router(
             except Exception as e:
                 logger.debug("project_deleted emit failed: %s", e)
         return {"deleted": True, "name": name}
+
+    @api_router.delete("/api/teams/{team_name}")
+    async def api_teams_delete(team_name: str) -> dict:
+        """Delete a team and release its members — alias for ``/api/projects/{name}``."""
+        from src.cli.config import _delete_project
+        try:
+            _delete_project(team_name)
+        except ValueError as e:
+            raise HTTPException(status_code=404, detail=str(e))
+        if event_bus is not None:
+            try:
+                event_bus.emit(
+                    "project_deleted", agent="operator",
+                    data={"project_id": team_name, "name": team_name},
+                )
+            except Exception as e:
+                logger.debug("project_deleted emit failed: %s", e)
+        return {"deleted": True, "name": team_name, "team_name": team_name}
 
     @api_router.post("/api/projects/{name}/members")
     async def api_projects_add_member(name: str, request: Request) -> dict:
@@ -4494,6 +4581,47 @@ def create_dashboard_router(
                 logger.debug("project_updated emit failed: %s", e)
         return {"added": True, "project": name, "agent": agent, "restarted": restarted}
 
+    @api_router.post("/api/teams/{team_name}/members")
+    async def api_teams_add_member(team_name: str, request: Request) -> dict:
+        """Add a member agent to a team — alias for ``/api/projects/{name}/members``."""
+        from src.cli.config import _add_agent_to_project
+        body = await request.json()
+        agent = body.get("agent", "").strip()
+        if not agent:
+            raise HTTPException(status_code=400, detail="agent is required")
+        try:
+            _add_agent_to_project(team_name, agent)
+        except ValueError as e:
+            raise HTTPException(status_code=400, detail=str(e))
+        # Auto-restart the agent so new scope takes effect
+        restarted = False
+        if transport is not None and agent in agent_registry:
+            try:
+                await transport.request(agent, "POST", "/restart", timeout=10)
+                restarted = True
+            except Exception as e:
+                logger.warning("Failed to restart agent %s after team change: %s", agent, e)
+        if event_bus is not None:
+            try:
+                event_bus.emit(
+                    "project_updated", agent="operator",
+                    data={
+                        "project_id": team_name,
+                        "name": team_name,
+                        "field": "members",
+                        "added": agent,
+                    },
+                )
+            except Exception as e:
+                logger.debug("project_updated emit failed: %s", e)
+        return {
+            "added": True,
+            "project": team_name,
+            "team_name": team_name,
+            "agent": agent,
+            "restarted": restarted,
+        }
+
     @api_router.delete("/api/projects/{name}/members/{agent}")
     async def api_projects_remove_member(name: str, agent: str) -> dict:
         """Remove a member agent from a project."""
@@ -4525,6 +4653,43 @@ def create_dashboard_router(
                 logger.debug("project_updated emit failed: %s", e)
         return {"removed": True, "project": name, "agent": agent, "restarted": restarted}
 
+    @api_router.delete("/api/teams/{team_name}/members/{agent}")
+    async def api_teams_remove_member(team_name: str, agent: str) -> dict:
+        """Remove a member agent from a team — alias for ``/api/projects/{name}/members/{agent}``."""
+        from src.cli.config import _remove_agent_from_project
+        try:
+            _remove_agent_from_project(team_name, agent)
+        except ValueError as e:
+            raise HTTPException(status_code=400, detail=str(e))
+        # Auto-restart the agent so new scope takes effect
+        restarted = False
+        if transport is not None and agent in agent_registry:
+            try:
+                await transport.request(agent, "POST", "/restart", timeout=10)
+                restarted = True
+            except Exception as e:
+                logger.warning("Failed to restart agent %s after team change: %s", agent, e)
+        if event_bus is not None:
+            try:
+                event_bus.emit(
+                    "project_updated", agent="operator",
+                    data={
+                        "project_id": team_name,
+                        "name": team_name,
+                        "field": "members",
+                        "removed": agent,
+                    },
+                )
+            except Exception as e:
+                logger.debug("project_updated emit failed: %s", e)
+        return {
+            "removed": True,
+            "project": team_name,
+            "team_name": team_name,
+            "agent": agent,
+            "restarted": restarted,
+        }
+
     # ── Project PROJECT.md ─────────────────────────────────
 
     def _resolve_project_path(project: str) -> Path:
@@ -4549,6 +4714,25 @@ def create_dashboard_router(
         exists = project_path.exists()
         content = project_path.read_text(errors="replace")[:200_000] if exists else ""
         return {"content": content, "exists": exists, "project": project}
+
+    @api_router.get("/api/team")
+    async def api_team_read(team: str = "") -> dict:
+        """Read a team's project.md — alias for ``/api/project``. Requires a team name."""
+        if not team:
+            raise HTTPException(status_code=400, detail="team parameter is required")
+        if runtime is None:
+            raise HTTPException(status_code=503, detail="Runtime not available")
+        project_path = _resolve_project_path(team)
+        if not project_path.parent.exists():
+            raise HTTPException(status_code=404, detail=f"Team '{team}' not found")
+        exists = project_path.exists()
+        content = project_path.read_text(errors="replace")[:200_000] if exists else ""
+        return {
+            "content": content,
+            "exists": exists,
+            "project": team,
+            "team": team,
+        }
 
     @api_router.put("/api/project")
     async def api_project_write(request: Request, project: str = "") -> dict:
@@ -4602,6 +4786,70 @@ def create_dashboard_router(
                     data={
                         "project_id": project,
                         "name": project,
+                        "field": "project_md",
+                    },
+                )
+            except Exception as e:
+                logger.debug("project_updated emit failed: %s", e)
+
+        return {
+            "saved": True,
+            "size": project_path.stat().st_size,
+            "pushed": push_results,
+        }
+
+    @api_router.put("/api/team")
+    async def api_team_write(request: Request, team: str = "") -> dict:
+        """Write project.md to host and push to running agents — alias for ``/api/project``."""
+        if not team:
+            raise HTTPException(status_code=400, detail="team parameter is required")
+        if runtime is None:
+            raise HTTPException(status_code=503, detail="Runtime not available")
+        body = await request.json()
+        content = body.get("content", "")
+        if not isinstance(content, str):
+            raise HTTPException(status_code=400, detail="content must be a string")
+        content = sanitize_for_prompt(content)
+
+        project_path = _resolve_project_path(team)
+        if not project_path.parent.exists():
+            raise HTTPException(status_code=404, detail=f"Team '{team}' not found")
+        project_path.write_text(content)
+
+        # Push to team members only
+        from src.cli.config import _load_projects
+        projects_data = _load_projects()
+        pdata = projects_data.get(team, {})
+        members = set(pdata.get("members", []))
+        push_targets = [a for a in agent_registry.keys() if a in members]
+
+        push_results = {}
+        if transport is not None and push_targets:
+            import asyncio as _asyncio
+
+            async def _push(aid: str) -> tuple[str, bool]:
+                try:
+                    await transport.request(
+                        aid, "PUT", "/project",
+                        json={"content": content}, timeout=10,
+                    )
+                    return aid, True
+                except Exception as e:
+                    logger.warning("Failed to push PROJECT.md to %s: %s", aid, e)
+                    return aid, False
+
+            tasks = [_push(aid) for aid in push_targets]
+            for coro in _asyncio.as_completed(tasks):
+                aid, ok = await coro
+                push_results[aid] = ok
+
+        if event_bus is not None:
+            try:
+                event_bus.emit(
+                    "project_updated", agent="operator",
+                    data={
+                        "project_id": team,
+                        "name": team,
                         "field": "project_md",
                     },
                 )
@@ -6415,6 +6663,44 @@ def create_dashboard_router(
                 "blockers": blockers,
             })
         return {"enabled": True, "projects": result}
+
+    @api_router.get("/api/workplace/teams")
+    async def api_workplace_teams() -> dict:
+        """Team status rollups — alias for ``/api/workplace/projects``."""
+        if tasks_store is None or not _orchestration_v2_on():
+            return {"enabled": False, "teams": [], "projects": []}
+        from src.cli.config import _load_projects
+        projects = _load_projects()
+        result = []
+        for pname, pdata in projects.items():
+            try:
+                rows = tasks_store.list_project(pname)
+            except Exception:
+                rows = []
+            counts: dict[str, int] = {}
+            blockers: list[dict] = []
+            for r in rows:
+                counts[r["status"]] = counts.get(r["status"], 0) + 1
+                if r["status"] == "blocked":
+                    blockers.append({
+                        "task_id": r["id"],
+                        "title": r["title"],
+                        "assignee": r["assignee"],
+                        "blocker_note": r.get("blocker_note") or "",
+                    })
+            result.append({
+                "name": pname,
+                "team_name": pname,
+                "description": pdata.get("description", ""),
+                "members": pdata.get("members", []),
+                "status": pdata.get("status", "active"),
+                "north_star": pdata.get("north_star"),
+                "success_criteria": pdata.get("success_criteria"),
+                "counts": counts,
+                "total": len(rows),
+                "blockers": blockers,
+            })
+        return {"enabled": True, "teams": result, "projects": result}
 
     @api_router.get("/api/workplace/blockers")
     async def api_workplace_blockers() -> dict:

--- a/src/host/server.py
+++ b/src/host/server.py
@@ -2498,6 +2498,16 @@ def create_mesh_app(
             raise HTTPException(503, "Project cost tracking not available")
         return cost_tracker.get_project_spend(project, period)
 
+    @app.get("/mesh/costs/team/{team}")
+    async def get_team_costs(team: str, request: Request, period: str = "today") -> dict:
+        """Return aggregated cost data for a team — alias for ``/mesh/costs/project/{project}``."""
+        _require_any_auth(request)
+        if cost_tracker is None:
+            raise HTTPException(503, "Cost tracker not available")
+        if not hasattr(cost_tracker, "get_project_spend"):
+            raise HTTPException(503, "Team cost tracking not available")
+        return cost_tracker.get_project_spend(team, period)
+
     # === Cron CRUD ===
 
     @app.post("/mesh/cron")
@@ -3802,6 +3812,35 @@ def create_mesh_app(
             })
         return {"projects": result}
 
+    @app.get("/mesh/teams")
+    async def mesh_list_teams(request: Request, include_archived: bool = False) -> dict:
+        """List teams (mesh-authed proxy) — alias for ``/mesh/projects``.
+
+        Pure additive alias scaffolded for the upcoming project→team
+        rename (see CLAUDE.md Review State 2026-05-16). Mirrors the
+        project route exactly and carries both ``name``/``team_name``
+        keys so consumers can migrate at their own pace.
+        """
+        caller = _extract_verified_agent_id(request)
+        if caller != "operator" and not _is_internal_caller(request):
+            raise HTTPException(403, "Only the operator can manage teams")
+        from src.cli.config import _load_projects
+        projects = _load_projects()
+        result = []
+        for pname, pdata in sorted(projects.items(), key=lambda x: x[1].get("created_at") or ""):
+            status = pdata.get("status", "active") or "active"
+            if not include_archived and status == "archived":
+                continue
+            result.append({
+                "name": pname,
+                "team_name": pname,
+                "description": pdata.get("description", ""),
+                "members": pdata.get("members", []),
+                "created_at": pdata.get("created_at", ""),
+                "status": status,
+            })
+        return {"teams": result, "projects": result}
+
     @app.post("/mesh/projects")
     async def mesh_create_project(request: Request) -> dict:
         """Create a new project (mesh-authed proxy)."""
@@ -3859,6 +3898,63 @@ def create_mesh_app(
                 logger.debug("project_created emit failed: %s", e)
         return {"created": True, "name": name}
 
+    @app.post("/mesh/teams")
+    async def mesh_create_team(request: Request) -> dict:
+        """Create a new team (mesh-authed proxy) — alias for ``/mesh/projects``."""
+        _require_any_auth(request)
+        if _resolve_agent_id("", request) != "operator":
+            raise HTTPException(403, "Only the operator can manage teams")
+        import os as _os
+
+        from src.cli.config import _create_project, _load_config, _load_projects
+
+        _max_projects_env = _os.environ.get("OPENLEGION_MAX_PROJECTS")
+        if _max_projects_env is not None:
+            _max_projects = int(_max_projects_env)
+            if _max_projects == 0:
+                raise HTTPException(
+                    403,
+                    "Teams are not available on your plan. Upgrade for team support.",
+                )
+            current_count = len(_load_projects())
+            if current_count >= _max_projects:
+                raise HTTPException(
+                    403,
+                    f"Team limit reached ({_max_projects}). Upgrade your plan for more teams.",
+                )
+
+        body = await request.json()
+        name = body.get("name", "").strip()
+        description = sanitize_for_prompt(body.get("description", "")).strip()
+        members = body.get("members", [])
+        if not name:
+            raise HTTPException(400, "name is required")
+        if not isinstance(members, list):
+            raise HTTPException(400, "members must be a list")
+        cfg = _load_config()
+        known_agents = set(cfg.get("agents", {}).keys())
+        unknown = [m for m in members if m not in known_agents]
+        if unknown:
+            raise HTTPException(400, f"Unknown agents: {', '.join(unknown)}")
+        try:
+            _create_project(name, description=description, members=members)
+        except ValueError as e:
+            raise HTTPException(400, str(e))
+        if event_bus is not None:
+            try:
+                event_bus.emit(
+                    "project_created", agent="operator",
+                    data={
+                        "project_id": name,
+                        "name": name,
+                        "description": description,
+                        "members": list(members),
+                    },
+                )
+            except Exception as e:
+                logger.debug("project_created emit failed: %s", e)
+        return {"created": True, "name": name, "team_name": name}
+
     @app.post("/mesh/projects/{name}/members")
     async def mesh_add_project_member(name: str, request: Request) -> dict:
         """Add an agent to a project (mesh-authed proxy)."""
@@ -3878,6 +3974,25 @@ def create_mesh_app(
         _agent_projects[agent] = name
         return {"added": True, "project": name, "agent": agent}
 
+    @app.post("/mesh/teams/{team_name}/members")
+    async def mesh_add_team_member(team_name: str, request: Request) -> dict:
+        """Add an agent to a team (mesh-authed proxy) — alias for ``/mesh/projects/{name}/members``."""
+        _require_any_auth(request)
+        if _resolve_agent_id("", request) != "operator":
+            raise HTTPException(403, "Only the operator can manage teams")
+        from src.cli.config import _add_agent_to_project
+        body = await request.json()
+        agent = body.get("agent", "").strip()
+        if not agent:
+            raise HTTPException(400, "agent is required")
+        try:
+            _add_agent_to_project(team_name, agent)
+        except ValueError as e:
+            raise HTTPException(400, str(e))
+        # Update in-memory project mapping so scoping takes effect immediately
+        _agent_projects[agent] = team_name
+        return {"added": True, "project": team_name, "team_name": team_name, "agent": agent}
+
     @app.delete("/mesh/projects/{name}/members/{agent}")
     async def mesh_remove_project_member(name: str, agent: str, request: Request) -> dict:
         """Remove an agent from a project (mesh-authed proxy)."""
@@ -3891,6 +4006,20 @@ def create_mesh_app(
             raise HTTPException(400, str(e))
         _agent_projects.pop(agent, None)
         return {"removed": True, "project": name, "agent": agent}
+
+    @app.delete("/mesh/teams/{team_name}/members/{agent}")
+    async def mesh_remove_team_member(team_name: str, agent: str, request: Request) -> dict:
+        """Remove an agent from a team (mesh-authed proxy) — alias for ``/mesh/projects/{name}/members/{agent}``."""
+        _require_any_auth(request)
+        if _resolve_agent_id("", request) != "operator":
+            raise HTTPException(403, "Only the operator can manage teams")
+        from src.cli.config import _remove_agent_from_project
+        try:
+            _remove_agent_from_project(team_name, agent)
+        except ValueError as e:
+            raise HTTPException(400, str(e))
+        _agent_projects.pop(agent, None)
+        return {"removed": True, "project": team_name, "team_name": team_name, "agent": agent}
 
     @app.delete("/mesh/projects/{name}")
     async def mesh_delete_project(name: str, request: Request) -> dict:
@@ -3912,6 +4041,27 @@ def create_mesh_app(
             except Exception as e:
                 logger.debug("project_deleted emit failed: %s", e)
         return {"deleted": True, "name": name}
+
+    @app.delete("/mesh/teams/{team_name}")
+    async def mesh_delete_team(team_name: str, request: Request) -> dict:
+        """Delete a team (mesh-authed proxy) — alias for ``/mesh/projects/{name}``."""
+        _require_any_auth(request)
+        if _resolve_agent_id("", request) != "operator":
+            raise HTTPException(403, "Only the operator can manage teams")
+        from src.cli.config import _delete_project
+        try:
+            _delete_project(team_name)
+        except ValueError as e:
+            raise HTTPException(404, str(e))
+        if event_bus is not None:
+            try:
+                event_bus.emit(
+                    "project_deleted", agent="operator",
+                    data={"project_id": team_name, "name": team_name},
+                )
+            except Exception as e:
+                logger.debug("project_deleted emit failed: %s", e)
+        return {"deleted": True, "name": team_name, "team_name": team_name}
 
     @app.put("/mesh/projects/{name}/context")
     async def mesh_update_project_context(name: str, request: Request) -> dict:
@@ -3955,6 +4105,49 @@ def create_mesh_app(
                 logger.debug("project_updated emit failed: %s", e)
 
         return {"updated": True, "project": name}
+
+    @app.put("/mesh/teams/{team_name}/context")
+    async def mesh_update_team_context(team_name: str, request: Request) -> dict:
+        """Update a team's description/context (mesh-authed proxy) — alias for ``/mesh/projects/{name}/context``."""
+        _require_any_auth(request)
+        if _resolve_agent_id("", request) != "operator":
+            raise HTTPException(403, "Only the operator can manage teams")
+        from src.cli.config import PROJECTS_DIR, _load_projects
+        body = await request.json()
+        context = sanitize_for_prompt(body.get("context", "")).strip()
+
+        projects = _load_projects()
+        if team_name not in projects:
+            raise HTTPException(404, f"Team '{team_name}' not found")
+
+        # Update metadata.yaml description in place (never delete the team)
+        import yaml
+        meta_file = PROJECTS_DIR / team_name / "metadata.yaml"
+        if meta_file.exists():
+            with open(meta_file) as f:
+                meta = yaml.safe_load(f) or {}
+            meta["description"] = context
+            with open(meta_file, "w") as f:
+                yaml.dump(meta, f, default_flow_style=False, sort_keys=False)
+
+        # Update project.md in place
+        project_md = PROJECTS_DIR / team_name / "project.md"
+        project_md.write_text(f"# {team_name}\n\n{context}\n")
+
+        if event_bus is not None:
+            try:
+                event_bus.emit(
+                    "project_updated", agent="operator",
+                    data={
+                        "project_id": team_name,
+                        "name": team_name,
+                        "field": "context",
+                    },
+                )
+            except Exception as e:
+                logger.debug("project_updated emit failed: %s", e)
+
+        return {"updated": True, "project": team_name, "team_name": team_name}
 
     @app.post("/mesh/projects/{name}/goal")
     async def mesh_set_project_goal(name: str, request: Request) -> dict:
@@ -4042,6 +4235,97 @@ def create_mesh_app(
         return {
             "success": True,
             "project_name": name,
+            "north_star": north_star,
+            "success_criteria": success_criteria,
+        }
+
+    @app.post("/mesh/teams/{team_name}/goal")
+    async def mesh_set_team_goal(team_name: str, request: Request) -> dict:
+        """Set a team's north star + success criteria (mesh-authed proxy) — alias for ``/mesh/projects/{name}/goal``.
+
+        Operator-only (or internal localhost callers). Validates length
+        limits then persists to ``metadata.yaml`` in place. No confirmation
+        gate — this is meta-config the user explicitly asked for.
+        """
+        _require_any_auth(request)
+        caller = _extract_verified_agent_id(request)
+        if caller != "operator" and not _is_internal_caller(request):
+            raise HTTPException(403, "Only the operator can manage teams")
+        from src.cli.config import PROJECTS_DIR, _load_projects
+
+        body = await request.json()
+        north_star_raw = body.get("north_star")
+        success_criteria_raw = body.get("success_criteria")
+
+        # Normalize and validate.
+        if north_star_raw is None:
+            north_star: str | None = None
+        else:
+            north_star = sanitize_for_prompt(str(north_star_raw)).strip()
+            if len(north_star) > 2000:
+                raise HTTPException(
+                    400, "north_star must be 2000 characters or fewer",
+                )
+            if not north_star:
+                north_star = None
+
+        success_criteria: list[str] | None
+        if success_criteria_raw is None:
+            success_criteria = None
+        else:
+            if not isinstance(success_criteria_raw, list):
+                raise HTTPException(
+                    400, "success_criteria must be a list of strings",
+                )
+            if len(success_criteria_raw) > 10:
+                raise HTTPException(
+                    400, "success_criteria may contain at most 10 items",
+                )
+            cleaned: list[str] = []
+            for item in success_criteria_raw:
+                sc = sanitize_for_prompt(str(item)).strip()
+                if not sc:
+                    continue
+                if len(sc) > 200:
+                    raise HTTPException(
+                        400,
+                        "each success_criteria entry must be 200 characters or fewer",
+                    )
+                cleaned.append(sc)
+            success_criteria = cleaned or None
+
+        projects = _load_projects()
+        if team_name not in projects:
+            raise HTTPException(404, f"Team '{team_name}' not found")
+
+        import yaml
+        meta_file = PROJECTS_DIR / team_name / "metadata.yaml"
+        if not meta_file.exists():
+            raise HTTPException(404, f"Team '{team_name}' has no metadata file")
+        with open(meta_file) as f:
+            meta = yaml.safe_load(f) or {}
+        meta["north_star"] = north_star
+        meta["success_criteria"] = success_criteria
+        with open(meta_file, "w") as f:
+            yaml.dump(meta, f, default_flow_style=False, sort_keys=False)
+
+        if event_bus is not None:
+            try:
+                event_bus.emit(
+                    "project_updated", agent="operator",
+                    data={
+                        "project_id": team_name,
+                        "name": team_name,
+                        "field": "goal",
+                    },
+                )
+            except Exception as e:
+                logger.debug("project_updated emit failed: %s", e)
+
+        return {
+            "success": True,
+            "project_name": team_name,
+            "team_name": team_name,
             "north_star": north_star,
             "success_criteria": success_criteria,
         }
@@ -4182,6 +4466,23 @@ def create_mesh_app(
             )
         _reap_tasks_opportunistically()
         rows = store.list_project(project_id)
+        return {"tasks": rows, "count": len(rows)}
+
+    @app.get("/mesh/tasks/team/{team_id}")
+    async def list_team_tasks(team_id: str, request: Request) -> dict:
+        """List tasks scoped to a team — alias for ``/mesh/tasks/project/{project_id}``.
+
+        Caller must be a member of the team (or operator / internal).
+        """
+        store = _require_tasks_v2()
+        caller = _extract_verified_agent_id(request)
+        if not _is_project_member(caller, team_id):
+            raise HTTPException(
+                403,
+                f"Caller {caller} is not a member of team {team_id!r}",
+            )
+        _reap_tasks_opportunistically()
+        rows = store.list_project(team_id)
         return {"tasks": rows, "count": len(rows)}
 
     @app.get("/mesh/tasks/{task_id}")
@@ -4618,6 +4919,39 @@ def create_mesh_app(
         }
         return result
 
+    @app.get("/mesh/teams/{team_id}/status")
+    async def team_status(team_id: str, request: Request) -> dict:
+        """Per-team status counts + recent blockers/completions — alias for ``/mesh/projects/{project_id}/status``.
+
+        Caller must be a team member (or operator/internal). Returns
+        the same structure as ``_summarize_tasks`` plus a ``project``
+        / ``team`` field carrying name and archive status.
+        """
+        store = _require_tasks_v2()
+        caller = _extract_verified_agent_id(request)
+        if not _is_project_member(caller, team_id):
+            raise HTTPException(
+                403,
+                f"Caller {caller} is not a member of team {team_id!r}",
+            )
+        from src.cli.config import _load_projects
+        projects = _load_projects()
+        if team_id not in projects:
+            raise HTTPException(404, f"Team '{team_id}' not found")
+        meta = projects[team_id]
+        _reap_tasks_opportunistically()
+        rows = store.list_project(team_id)
+        result = _summarize_tasks(rows)
+        meta_block = {
+            "name": team_id,
+            "status": meta.get("status", "active") or "active",
+            "members": meta.get("members", []),
+            "description": meta.get("description", ""),
+        }
+        result["project"] = meta_block
+        result["team"] = meta_block
+        return result
+
     @app.get("/mesh/projects/status")
     async def all_projects_status(request: Request) -> dict:
         """List status rollups for every project the caller can see.
@@ -4650,6 +4984,41 @@ def create_mesh_app(
             }
             rows.append(summary)
         return {"projects": rows}
+
+    @app.get("/mesh/teams/status")
+    async def all_teams_status(request: Request) -> dict:
+        """List status rollups for every team the caller can see — alias for ``/mesh/projects/status``.
+
+        Operator / internal callers see all teams (including archived);
+        other callers see only their own. Each row carries the same
+        ``counts``/``blockers``/``recent_done`` shape as the per-team
+        endpoint, plus the team name and status.
+        """
+        store = _require_tasks_v2()
+        caller = _extract_verified_agent_id(request)
+        from src.cli.config import _load_projects
+        projects = _load_projects()
+        visible: list[str]
+        if caller == "operator" or _is_internal_caller(request):
+            visible = list(projects.keys())
+        else:
+            visible = sorted(_caller_projects(caller))
+        _reap_tasks_opportunistically()
+        rows: list[dict] = []
+        for pid in sorted(visible):
+            meta = projects.get(pid, {})
+            project_rows = store.list_project(pid)
+            summary = _summarize_tasks(project_rows)
+            meta_block = {
+                "name": pid,
+                "status": meta.get("status", "active") or "active",
+                "members": meta.get("members", []),
+                "description": meta.get("description", ""),
+            }
+            summary["project"] = meta_block
+            summary["team"] = meta_block
+            rows.append(summary)
+        return {"projects": rows, "teams": rows}
 
     @app.get("/mesh/agents/{agent_id}/queue")
     async def agent_queue(
@@ -4760,6 +5129,45 @@ def create_mesh_app(
         outputs.sort(key=lambda x: x["completed_at"], reverse=True)
         return {"project_id": project_id, "since": since, "outputs": outputs}
 
+    @app.get("/mesh/teams/{team_id}/outputs")
+    async def team_outputs(
+        team_id: str, request: Request, since: str = "",
+    ) -> dict:
+        """Completed task artifacts for a team in a time window — alias for ``/mesh/projects/{project_id}/outputs``.
+
+        ``since`` accepts an ISO timestamp or duration string (``"24h"``,
+        ``"7d"``); default is the last 7 days. Returns one entry per
+        completed task with its title, assignee, completion time, and
+        artifact refs.
+        """
+        store = _require_tasks_v2()
+        caller = _extract_verified_agent_id(request)
+        if not _is_project_member(caller, team_id):
+            raise HTTPException(
+                403,
+                f"Caller {caller} is not a member of team {team_id!r}",
+            )
+        floor = _parse_since(since)
+        _reap_tasks_opportunistically()
+        rows = store.list_project(team_id, statuses=["done"])
+        outputs = []
+        for r in rows:
+            completed_at = r.get("completed_at") or 0
+            if completed_at < floor:
+                continue
+            outputs.append({
+                "id": r["id"], "title": r["title"], "assignee": r["assignee"],
+                "completed_at": completed_at,
+                "artifact_refs": r.get("artifact_refs", []) or [],
+            })
+        outputs.sort(key=lambda x: x["completed_at"], reverse=True)
+        return {
+            "project_id": team_id,
+            "team_id": team_id,
+            "since": since,
+            "outputs": outputs,
+        }
+
     @app.get("/mesh/projects/{project_id}/summary")
     async def project_summary(project_id: str, request: Request) -> dict:
         """Synthesized status text + structured fields for a project.
@@ -4817,6 +5225,65 @@ def create_mesh_app(
             "ask_for_user": s["blockers"],
         }
 
+    @app.get("/mesh/teams/{team_id}/summary")
+    async def team_summary(team_id: str, request: Request) -> dict:
+        """Synthesized status text + structured fields for a team — alias for ``/mesh/projects/{project_id}/summary``.
+
+        Combines status counts, blocker list, recent completions, and a
+        simple ``ask_for_user`` list (currently mirrors ``blocked`` —
+        operators can later swap in a richer policy here without changing
+        the on-the-wire shape). The narrative ``status_text`` is plain
+        prose so the operator's prompt machinery doesn't have to format
+        it again.
+        """
+        store = _require_tasks_v2()
+        caller = _extract_verified_agent_id(request)
+        if not _is_project_member(caller, team_id):
+            raise HTTPException(
+                403,
+                f"Caller {caller} is not a member of team {team_id!r}",
+            )
+        from src.cli.config import _load_projects
+        projects = _load_projects()
+        if team_id not in projects:
+            raise HTTPException(404, f"Team '{team_id}' not found")
+        meta = projects[team_id]
+        _reap_tasks_opportunistically()
+        rows = store.list_project(team_id)
+        s = _summarize_tasks(rows)
+        active = s["counts"]["active"]
+        blocked = s["counts"]["blocked"]
+        done = s["counts"]["done"]
+        failed = s["counts"]["failed"]
+        if active == 0 and blocked == 0 and done == 0 and failed == 0:
+            status_text = f"No tasks recorded for {team_id!r} yet."
+        else:
+            parts: list[str] = []
+            if active:
+                parts.append(f"{active} active")
+            if blocked:
+                parts.append(f"{blocked} blocked")
+            if done:
+                parts.append(f"{done} done")
+            if failed:
+                parts.append(f"{failed} failed")
+            status_text = ", ".join(parts) + f" in team {team_id!r}."
+        meta_block = {
+            "name": team_id,
+            "status": meta.get("status", "active") or "active",
+            "description": meta.get("description", ""),
+            "members": meta.get("members", []),
+        }
+        return {
+            "project": meta_block,
+            "team": meta_block,
+            "status_text": status_text,
+            "counts": s["counts"],
+            "top_blockers": s["blockers"],
+            "recent_completions": s["recent_done"],
+            "ask_for_user": s["blockers"],
+        }
+
     # === Operator product surface (Task 7) — archive / delete ===
     #
     # Archive endpoints flip a status flag and stop scheduling. Delete
@@ -4849,6 +5316,29 @@ def create_mesh_app(
                 logger.debug("project_archived emit failed: %s", e)
         return {"archived": True, "project": name}
 
+    @app.post("/mesh/teams/{team_name}/archive")
+    async def archive_team_endpoint(team_name: str, request: Request) -> dict:
+        """Archive a team (operator-only). Idempotent. Alias for ``/mesh/projects/{name}/archive``."""
+        caller = _extract_verified_agent_id(request)
+        if caller != "operator" and not _is_internal_caller(request):
+            raise HTTPException(403, "Only the operator can archive teams")
+        from src.cli.config import _archive_project, _load_projects
+        if team_name not in _load_projects():
+            raise HTTPException(404, f"Team '{team_name}' not found")
+        try:
+            _archive_project(team_name)
+        except ValueError as e:
+            raise HTTPException(404, str(e))
+        if event_bus is not None:
+            try:
+                event_bus.emit(
+                    "project_archived", agent="operator",
+                    data={"project_id": team_name, "name": team_name},
+                )
+            except Exception as e:
+                logger.debug("project_archived emit failed: %s", e)
+        return {"archived": True, "project": team_name, "team_name": team_name}
+
     @app.post("/mesh/projects/{name}/unarchive")
     async def unarchive_project_endpoint(name: str, request: Request) -> dict:
         """Unarchive a project (operator-only). Idempotent."""
@@ -4871,6 +5361,29 @@ def create_mesh_app(
             except Exception as e:
                 logger.debug("project_unarchived emit failed: %s", e)
         return {"archived": False, "project": name}
+
+    @app.post("/mesh/teams/{team_name}/unarchive")
+    async def unarchive_team_endpoint(team_name: str, request: Request) -> dict:
+        """Unarchive a team (operator-only). Idempotent. Alias for ``/mesh/projects/{name}/unarchive``."""
+        caller = _extract_verified_agent_id(request)
+        if caller != "operator" and not _is_internal_caller(request):
+            raise HTTPException(403, "Only the operator can unarchive teams")
+        from src.cli.config import _load_projects, _unarchive_project
+        if team_name not in _load_projects():
+            raise HTTPException(404, f"Team '{team_name}' not found")
+        try:
+            _unarchive_project(team_name)
+        except ValueError as e:
+            raise HTTPException(404, str(e))
+        if event_bus is not None:
+            try:
+                event_bus.emit(
+                    "project_unarchived", agent="operator",
+                    data={"project_id": team_name, "name": team_name},
+                )
+            except Exception as e:
+                logger.debug("project_unarchived emit failed: %s", e)
+        return {"archived": False, "project": team_name, "team_name": team_name}
 
     @app.post("/mesh/agents/{agent_id}/archive")
     async def archive_agent_endpoint(agent_id: str, request: Request) -> dict:
@@ -4997,6 +5510,81 @@ def create_mesh_app(
             actor="operator",
             target_kind="project",
             target_id=name,
+            action_kind="delete",
+            payload=payload,
+            origin_kind=origin_kind,
+            ttl=_CHANGE_TTL_SECONDS,
+            summary=summary,
+            preview_diff=None,
+        )
+        return {
+            "change_id": nonce,
+            "summary": summary,
+            "expires_at": datetime.fromtimestamp(
+                record["expires_at"], tz=timezone.utc,
+            ).isoformat(),
+            "payload_digest": record["payload_digest"],
+            "requires_confirmation": True,
+        }
+
+    @app.post("/mesh/teams/{team_name}/propose-delete")
+    async def propose_delete_team(team_name: str, request: Request) -> dict:
+        """Propose deletion of an archived team. Returns nonce for human confirm.
+
+        Alias for ``/mesh/projects/{name}/propose-delete``. Pre-conditions:
+          * team exists
+          * team is archived (delete on a live team rejected)
+
+        Stores a pending action with ``target_kind="project"``,
+        ``action_kind="delete"``, ``origin_kind`` from the validated
+        ``X-Origin``. Confirmation goes through the existing
+        ``/mesh/config/confirm`` endpoint, which now dispatches on
+        ``target_kind``.
+        """
+        caller = _extract_verified_agent_id(request)
+        if caller != "operator" and not _is_internal_caller(request):
+            raise HTTPException(403, "Only the operator can delete teams")
+        from src.cli.config import _load_projects, _project_status
+        projects = _load_projects()
+        if team_name not in projects:
+            raise HTTPException(404, f"Team '{team_name}' not found")
+        status = _project_status(team_name)
+        if status != "archived":
+            raise HTTPException(
+                400,
+                "Team must be archived before delete. "
+                "Call /mesh/teams/{team_name}/archive first.",
+            )
+        origin = _validated_origin(request, caller)
+        origin_kind = origin.kind if origin is not None else None
+        # Cap pending rows to bound storage growth (mirrors propose_edit).
+        pending_actions.reap_expired()
+        existing = pending_actions.list_pending()
+        if len(existing) >= _MAX_PENDING:
+            oldest = min(existing, key=lambda r: r["expires_at"])
+            with pending_actions._conn() as _conn:
+                _conn.execute(
+                    "DELETE FROM pending_actions WHERE nonce=?",
+                    (oldest["nonce"],),
+                )
+        nonce = str(_uuid.uuid4())
+        members = projects[team_name].get("members", []) or []
+        # Short headline shown in the inline chat card (max ~80 chars
+        # so it doesn't wrap awkwardly). The longer policy explanation
+        # is kept in the payload for the legacy CLI surface.
+        summary = (
+            f"Delete team {team_name!r} and unlink {len(members)} agent(s)"
+        )
+        payload = {
+            "name": team_name,
+            "summary": summary,
+            "members": members,
+        }
+        record = pending_actions.store(
+            nonce=nonce,
+            actor="operator",
+            target_kind="project",
+            target_id=team_name,
             action_kind="delete",
             payload=payload,
             origin_kind=origin_kind,

--- a/tests/test_team_routes_alias.py
+++ b/tests/test_team_routes_alias.py
@@ -1,0 +1,624 @@
+"""Tests for the ``/mesh/teams/*`` and ``/api/teams/*`` route aliases.
+
+PR 1 of the project→team rename scaffolds these as thin aliases over
+the existing project routes. The tests below verify each new alias:
+
+  * is reachable and returns the same response shape (plus ``team_*``
+    keys alongside the existing ``project_*`` keys),
+  * exercises the same underlying ``_load_projects`` / ``_create_project``
+    / ``_delete_project`` / ``_add_agent_to_project`` / etc. helpers, so
+    the side effect lands on disk identically,
+  * preserves the project route's auth and validation behavior.
+
+The mesh-side tests reuse the ``v2_app`` fixture from
+``tests/test_operator_product_tools.py``; the dashboard-side tests reuse
+the ``_make_components`` / ``_make_client`` helpers from
+``tests/test_dashboard.py``.
+"""
+
+# ruff: noqa: F811
+# F811 silenced module-wide: the ``v2_app`` fixture is imported from
+# tests/test_operator_product_tools.py and then bound as a parameter on
+# each test function — this is the standard pytest fixture-sharing
+# pattern and not an actual redefinition.
+
+from __future__ import annotations
+
+import os
+import shutil
+import tempfile
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+import yaml
+from httpx import ASGITransport, AsyncClient
+
+# Reuse the existing fixtures rather than re-implementing them so the
+# tests stay aligned as the project routes evolve.
+from tests.test_dashboard import _make_client, _make_components, _teardown
+from tests.test_operator_product_tools import v2_app  # noqa: F401
+
+# ── Mesh /mesh/teams/* aliases ─────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_mesh_teams_list(v2_app):
+    """GET /mesh/teams returns the same set of names as /mesh/projects."""
+    app, _, _ = v2_app
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
+        projects_resp = await c.get(
+            "/mesh/projects", headers={"X-Agent-ID": "operator"},
+        )
+        teams_resp = await c.get(
+            "/mesh/teams", headers={"X-Agent-ID": "operator"},
+        )
+    assert projects_resp.status_code == 200
+    assert teams_resp.status_code == 200
+    teams_body = teams_resp.json()
+    # New ``teams`` key, plus legacy ``projects`` alias for back-compat.
+    assert "teams" in teams_body
+    assert "projects" in teams_body
+    proj_names = {p["name"] for p in projects_resp.json()["projects"]}
+    team_names = {t["name"] for t in teams_body["teams"]}
+    assert proj_names == team_names == {"research", "ops"}
+    # Each row carries both ``name`` and ``team_name``.
+    for row in teams_body["teams"]:
+        assert row["name"] == row["team_name"]
+
+
+@pytest.mark.asyncio
+async def test_mesh_teams_create_parity_with_projects(v2_app):
+    """POST /mesh/teams matches POST /mesh/projects behavior.
+
+    The v2_app fixture runs without auth tokens, so ``_resolve_agent_id``
+    returns the (empty) header value rather than ``"operator"`` and both
+    endpoints reject with 403. The test asserts parity — same status,
+    same error shape — which proves the alias is wired up correctly.
+    See the note in ``test_operator_product_tools.py`` around line 1000
+    for why ``_resolve_agent_id``-gated endpoints can't be exercised
+    end-to-end from this fixture.
+    """
+    app, _, _ = v2_app
+    payload = {"name": "neoteam", "description": "via alias", "members": []}
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
+        proj_resp = await c.post(
+            "/mesh/projects", json=payload,
+            headers={"X-Agent-ID": "operator"},
+        )
+        team_resp = await c.post(
+            "/mesh/teams", json=payload,
+            headers={"X-Agent-ID": "operator"},
+        )
+    assert proj_resp.status_code == team_resp.status_code == 403
+    assert "operator" in proj_resp.json()["detail"].lower()
+    assert "operator" in team_resp.json()["detail"].lower()
+
+
+@pytest.mark.asyncio
+async def test_mesh_teams_add_member_parity_with_projects(v2_app):
+    """POST /mesh/teams/{name}/members mirrors /mesh/projects/{name}/members.
+
+    Same caveat as ``test_mesh_teams_create_parity_with_projects`` —
+    ``_resolve_agent_id`` gate forces 403 from this fixture for both
+    routes; we assert parity.
+    """
+    app, _, _ = v2_app
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
+        proj_resp = await c.post(
+            "/mesh/projects/research/members",
+            json={"agent": "tracker"},
+            headers={"X-Agent-ID": "operator"},
+        )
+        team_resp = await c.post(
+            "/mesh/teams/research/members",
+            json={"agent": "tracker"},
+            headers={"X-Agent-ID": "operator"},
+        )
+    assert proj_resp.status_code == team_resp.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_mesh_teams_remove_member_parity_with_projects(v2_app):
+    """DELETE /mesh/teams/{name}/members/{agent} mirrors the project route."""
+    app, _, _ = v2_app
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
+        proj_resp = await c.delete(
+            "/mesh/projects/research/members/scout",
+            headers={"X-Agent-ID": "operator"},
+        )
+        team_resp = await c.delete(
+            "/mesh/teams/research/members/scout",
+            headers={"X-Agent-ID": "operator"},
+        )
+    assert proj_resp.status_code == team_resp.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_mesh_teams_delete_parity_with_projects(v2_app):
+    """DELETE /mesh/teams/{name} mirrors DELETE /mesh/projects/{name}."""
+    app, _, _ = v2_app
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
+        proj_resp = await c.delete(
+            "/mesh/projects/ops", headers={"X-Agent-ID": "operator"},
+        )
+        team_resp = await c.delete(
+            "/mesh/teams/ops", headers={"X-Agent-ID": "operator"},
+        )
+    assert proj_resp.status_code == team_resp.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_mesh_teams_update_context_parity_with_projects(v2_app):
+    """PUT /mesh/teams/{name}/context mirrors PUT /mesh/projects/{name}/context."""
+    app, _, _ = v2_app
+    payload = {"context": "Hunt for opportunities in fintech."}
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
+        proj_resp = await c.put(
+            "/mesh/projects/research/context", json=payload,
+            headers={"X-Agent-ID": "operator"},
+        )
+        team_resp = await c.put(
+            "/mesh/teams/research/context", json=payload,
+            headers={"X-Agent-ID": "operator"},
+        )
+    assert proj_resp.status_code == team_resp.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_mesh_teams_set_goal(v2_app):
+    """POST /mesh/teams/{team_name}/goal persists north_star + criteria."""
+    app, _, tmp_path = v2_app
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
+        r = await c.post(
+            "/mesh/teams/research/goal",
+            json={
+                "north_star": "Ship the alpha",
+                "success_criteria": ["First demo by Friday"],
+            },
+            headers={"X-Agent-ID": "operator"},
+        )
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["success"] is True
+    assert body["team_name"] == "research"
+    assert body["north_star"] == "Ship the alpha"
+    meta = yaml.safe_load(
+        (tmp_path / "projects" / "research" / "metadata.yaml").read_text()
+    )
+    assert meta["north_star"] == "Ship the alpha"
+
+
+@pytest.mark.asyncio
+async def test_mesh_tasks_team_id(v2_app):
+    """GET /mesh/tasks/team/{team_id} lists the same tasks as /mesh/tasks/project."""
+    app, _, _ = v2_app
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
+        await c.post(
+            "/mesh/tasks",
+            json={"assignee": "analyst", "title": "t1", "project": "research"},
+            headers={"X-Agent-ID": "operator"},
+        )
+        proj_resp = await c.get(
+            "/mesh/tasks/project/research",
+            headers={"X-Agent-ID": "operator"},
+        )
+        team_resp = await c.get(
+            "/mesh/tasks/team/research",
+            headers={"X-Agent-ID": "operator"},
+        )
+    assert proj_resp.status_code == 200
+    assert team_resp.status_code == 200
+    assert proj_resp.json()["count"] == team_resp.json()["count"] == 1
+
+
+@pytest.mark.asyncio
+async def test_mesh_teams_status(v2_app):
+    """GET /mesh/teams/{team_id}/status returns counts + ``team``/``project`` meta."""
+    app, _, _ = v2_app
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
+        await c.post(
+            "/mesh/tasks",
+            json={"assignee": "analyst", "title": "t1", "project": "research"},
+            headers={"X-Agent-ID": "operator"},
+        )
+        r = await c.get(
+            "/mesh/teams/research/status",
+            headers={"X-Agent-ID": "operator"},
+        )
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["counts"]["active"] == 1
+    assert body["team"]["name"] == "research"
+    assert body["project"]["name"] == "research"
+
+
+@pytest.mark.asyncio
+async def test_mesh_teams_status_all(v2_app):
+    """GET /mesh/teams/status returns the same projects as /mesh/projects/status."""
+    app, _, _ = v2_app
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
+        r = await c.get(
+            "/mesh/teams/status", headers={"X-Agent-ID": "operator"},
+        )
+    assert r.status_code == 200
+    body = r.json()
+    # Carries both the legacy ``projects`` key and the new ``teams`` key.
+    assert "projects" in body
+    assert "teams" in body
+    names = {p["project"]["name"] for p in body["projects"]}
+    assert names == {"research", "ops"}
+
+
+@pytest.mark.asyncio
+async def test_mesh_teams_outputs(v2_app):
+    """GET /mesh/teams/{team_id}/outputs returns completed tasks."""
+    app, _, _ = v2_app
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
+        r = await c.post(
+            "/mesh/tasks",
+            json={"assignee": "analyst", "title": "report", "project": "research"},
+            headers={"X-Agent-ID": "operator"},
+        )
+        tid = r.json()["id"]
+        await c.post(
+            f"/mesh/tasks/{tid}/status",
+            json={"status": "working"},
+            headers={"X-Agent-ID": "analyst"},
+        )
+        await c.post(
+            f"/mesh/tasks/{tid}/status",
+            json={"status": "done"},
+            headers={"X-Agent-ID": "analyst"},
+        )
+        r = await c.get(
+            "/mesh/teams/research/outputs",
+            params={"since": "24h"},
+            headers={"X-Agent-ID": "operator"},
+        )
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["team_id"] == "research"
+    assert body["project_id"] == "research"
+    assert len(body["outputs"]) == 1
+
+
+@pytest.mark.asyncio
+async def test_mesh_teams_summary(v2_app):
+    """GET /mesh/teams/{team_id}/summary returns the synthesized status text."""
+    app, _, _ = v2_app
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
+        r = await c.get(
+            "/mesh/teams/research/summary",
+            headers={"X-Agent-ID": "operator"},
+        )
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["team"]["name"] == "research"
+    assert body["project"]["name"] == "research"
+    assert "status_text" in body
+
+
+@pytest.mark.asyncio
+async def test_mesh_teams_archive_and_unarchive(v2_app):
+    """POST /mesh/teams/{team_name}/archive then unarchive flips the status."""
+    app, _, _ = v2_app
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
+        r = await c.post(
+            "/mesh/teams/research/archive",
+            headers={"X-Agent-ID": "operator"},
+        )
+        assert r.status_code == 200, r.text
+        assert r.json()["archived"] is True
+        assert r.json()["team_name"] == "research"
+        # Default list excludes archived
+        r = await c.get(
+            "/mesh/teams", headers={"X-Agent-ID": "operator"},
+        )
+        names = {t["name"] for t in r.json()["teams"]}
+        assert "research" not in names
+        # Unarchive restores it
+        r = await c.post(
+            "/mesh/teams/research/unarchive",
+            headers={"X-Agent-ID": "operator"},
+        )
+        assert r.status_code == 200, r.text
+        assert r.json()["archived"] is False
+        assert r.json()["team_name"] == "research"
+
+
+@pytest.mark.asyncio
+async def test_mesh_teams_propose_delete_requires_archive(v2_app):
+    """propose-delete on a live team must fail with 400."""
+    app, _, _ = v2_app
+    from src.shared.types import MessageOrigin
+
+    origin = MessageOrigin(kind="human", channel="cli", user="u1")
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
+        r = await c.post(
+            "/mesh/teams/research/propose-delete",
+            headers={
+                "X-Agent-ID": "operator",
+                "X-Origin": origin.to_header_value(),
+            },
+        )
+    assert r.status_code == 400
+    assert "archived" in r.text.lower()
+
+
+@pytest.mark.asyncio
+async def test_mesh_teams_propose_delete_happy_path(v2_app):
+    """propose-delete on an archived team returns a nonce + summary."""
+    app, _, _ = v2_app
+    from src.shared.types import MessageOrigin
+
+    origin = MessageOrigin(kind="human", channel="cli", user="u1")
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
+        await c.post(
+            "/mesh/teams/research/archive",
+            headers={"X-Agent-ID": "operator"},
+        )
+        r = await c.post(
+            "/mesh/teams/research/propose-delete",
+            headers={
+                "X-Agent-ID": "operator",
+                "X-Origin": origin.to_header_value(),
+            },
+        )
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["requires_confirmation"] is True
+    assert "delete team" in body["summary"].lower()
+    assert "'research'" in body["summary"]
+
+
+@pytest.mark.asyncio
+async def test_mesh_costs_team(v2_app):
+    """GET /mesh/costs/team/{team} proxies to the same cost helper as /mesh/costs/project.
+
+    Asserts parity with ``/mesh/costs/project`` — both routes call
+    ``cost_tracker.get_project_spend`` and surface its return shape.
+    """
+    app, _, _ = v2_app
+    # Locate the cost_tracker MagicMock in the app's closure and pin
+    # ``get_project_spend`` to return a real dict so we can compare
+    # the proxied output between the two routes.
+    cost_tracker = None
+    for route in app.routes:
+        endpoint = getattr(route, "endpoint", None)
+        if endpoint is None:
+            continue
+        closure = getattr(endpoint, "__closure__", None) or ()
+        names = getattr(getattr(endpoint, "__code__", None), "co_freevars", ())
+        for name, cell in zip(names, closure):
+            if name == "cost_tracker":
+                cost_tracker = cell.cell_contents
+                break
+        if cost_tracker is not None:
+            break
+    assert cost_tracker is not None, "cost_tracker missing from app closure"
+    cost_tracker.get_project_spend = MagicMock(
+        return_value={"period": "today", "total_usd": 1.23},
+    )
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
+        proj_resp = await c.get(
+            "/mesh/costs/project/research",
+            headers={"X-Agent-ID": "operator"},
+        )
+        team_resp = await c.get(
+            "/mesh/costs/team/research",
+            headers={"X-Agent-ID": "operator"},
+        )
+    assert proj_resp.status_code == team_resp.status_code == 200
+    assert proj_resp.json() == team_resp.json()
+
+
+# ── Dashboard /api/teams/* aliases ─────────────────────────────────
+
+
+def _setup_dashboard_team_fixture(include_v2: bool = True):
+    """Build a dashboard test client + tmp dir + components."""
+    tmpdir = tempfile.mkdtemp()
+    components = _make_components(tmpdir, include_v2=include_v2)
+    if "runtime" in components:
+        components["runtime"].project_root = MagicMock()
+    client = _make_client(components)
+    return tmpdir, components, client
+
+
+def _seed_team_on_disk(tmpdir: str, name: str, members: list[str] | None = None) -> str:
+    """Create a project (== team) dir + metadata.yaml under tmpdir."""
+    projects_dir = os.path.join(tmpdir, "projects")
+    pd = os.path.join(projects_dir, name)
+    os.makedirs(pd, exist_ok=True)
+    with open(os.path.join(pd, "metadata.yaml"), "w") as f:
+        yaml.dump({"name": name, "members": members or []}, f)
+    return projects_dir
+
+
+def _seed_agents_yaml(tmpdir: str, names: list[str]) -> tuple[str, str, str]:
+    """Build a minimal config/mesh.yaml + agents.yaml for member validation."""
+    config_dir = os.path.join(tmpdir, "config")
+    os.makedirs(config_dir, exist_ok=True)
+    config_file = os.path.join(config_dir, "mesh.yaml")
+    with open(config_file, "w") as f:
+        yaml.dump({"agents": {n: {"role": "test"} for n in names}}, f)
+    agents_file = os.path.join(config_dir, "agents.yaml")
+    with open(agents_file, "w") as f:
+        yaml.dump({n: {"role": "test"} for n in names}, f)
+    return config_dir, config_file, agents_file
+
+
+def test_api_teams_list():
+    """GET /api/teams returns the same projects as /api/projects."""
+    tmpdir, components, client = _setup_dashboard_team_fixture()
+    try:
+        projects_dir = _seed_team_on_disk(tmpdir, "alpha", ["bot1"])
+        with patch("src.cli.config.PROJECTS_DIR", Path(projects_dir)):
+            proj_resp = client.get("/dashboard/api/projects")
+            team_resp = client.get("/dashboard/api/teams")
+        assert proj_resp.status_code == 200
+        assert team_resp.status_code == 200
+        body = team_resp.json()
+        assert "teams" in body
+        assert "projects" in body
+        proj_names = {p["name"] for p in proj_resp.json()["projects"]}
+        team_names = {t["name"] for t in body["teams"]}
+        assert proj_names == team_names == {"alpha"}
+        for row in body["teams"]:
+            assert row["name"] == row["team_name"]
+    finally:
+        _teardown(components)
+        shutil.rmtree(tmpdir, ignore_errors=True)
+
+
+def test_api_teams_create():
+    """POST /api/teams creates a project directory just like /api/projects."""
+    tmpdir, components, client = _setup_dashboard_team_fixture()
+    try:
+        projects_dir = os.path.join(tmpdir, "projects")
+        os.makedirs(projects_dir, exist_ok=True)
+        config_dir, config_file, agents_file = _seed_agents_yaml(
+            tmpdir, ["alpha", "beta"],
+        )
+        with patch("src.cli.config.PROJECTS_DIR", Path(projects_dir)), \
+             patch("src.cli.config.CONFIG_FILE", Path(config_file)), \
+             patch("src.cli.config.AGENTS_FILE", Path(agents_file)), \
+             patch("src.cli.config.PERMISSIONS_FILE", Path(tmpdir) / "perms.json"):
+            resp = client.post(
+                "/dashboard/api/teams",
+                json={"name": "myteam", "description": "via alias", "members": []},
+            )
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        assert body["created"] is True
+        assert body["name"] == "myteam"
+        assert body["team_name"] == "myteam"
+        assert os.path.isdir(os.path.join(projects_dir, "myteam"))
+    finally:
+        _teardown(components)
+        shutil.rmtree(tmpdir, ignore_errors=True)
+
+
+def test_api_teams_delete():
+    """DELETE /api/teams/{team_name} removes the team directory."""
+    tmpdir, components, client = _setup_dashboard_team_fixture()
+    try:
+        projects_dir = _seed_team_on_disk(tmpdir, "doomed")
+        with patch("src.cli.config.PROJECTS_DIR", Path(projects_dir)), \
+             patch("src.cli.config.PERMISSIONS_FILE", Path(tmpdir) / "perms.json"):
+            resp = client.delete("/dashboard/api/teams/doomed")
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        assert body["deleted"] is True
+        assert body["team_name"] == "doomed"
+        assert not os.path.exists(os.path.join(projects_dir, "doomed"))
+    finally:
+        _teardown(components)
+        shutil.rmtree(tmpdir, ignore_errors=True)
+
+
+def test_api_teams_add_member():
+    """POST /api/teams/{team_name}/members adds the agent to metadata."""
+    tmpdir, components, client = _setup_dashboard_team_fixture()
+    try:
+        projects_dir = _seed_team_on_disk(tmpdir, "squad", members=[])
+        with patch("src.cli.config.PROJECTS_DIR", Path(projects_dir)), \
+             patch("src.cli.config.PERMISSIONS_FILE", Path(tmpdir) / "perms.json"):
+            resp = client.post(
+                "/dashboard/api/teams/squad/members", json={"agent": "alpha"},
+            )
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        assert body["added"] is True
+        assert body["team_name"] == "squad"
+        assert body["agent"] == "alpha"
+        meta = yaml.safe_load(
+            Path(projects_dir, "squad", "metadata.yaml").read_text()
+        )
+        assert "alpha" in meta["members"]
+    finally:
+        _teardown(components)
+        shutil.rmtree(tmpdir, ignore_errors=True)
+
+
+def test_api_teams_remove_member():
+    """DELETE /api/teams/{team_name}/members/{agent} removes the agent."""
+    tmpdir, components, client = _setup_dashboard_team_fixture()
+    try:
+        projects_dir = _seed_team_on_disk(tmpdir, "squad", members=["alpha"])
+        with patch("src.cli.config.PROJECTS_DIR", Path(projects_dir)), \
+             patch("src.cli.config.PERMISSIONS_FILE", Path(tmpdir) / "perms.json"):
+            resp = client.delete("/dashboard/api/teams/squad/members/alpha")
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        assert body["removed"] is True
+        assert body["team_name"] == "squad"
+        meta = yaml.safe_load(
+            Path(projects_dir, "squad", "metadata.yaml").read_text()
+        )
+        assert "alpha" not in meta["members"]
+    finally:
+        _teardown(components)
+        shutil.rmtree(tmpdir, ignore_errors=True)
+
+
+def test_api_team_read():
+    """GET /api/team?team=... reads the team's project.md."""
+    tmpdir, components, client = _setup_dashboard_team_fixture()
+    try:
+        projects_dir = _seed_team_on_disk(tmpdir, "alpha", members=["bot1"])
+        # Drop a project.md in place
+        Path(projects_dir, "alpha", "project.md").write_text(
+            "# Alpha Team\nShared context here.\n"
+        )
+        with patch("src.cli.config.PROJECTS_DIR", Path(projects_dir)):
+            resp = client.get(
+                "/dashboard/api/team", params={"team": "alpha"},
+            )
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        assert body["team"] == "alpha"
+        assert body["project"] == "alpha"
+        assert "Alpha Team" in body["content"]
+    finally:
+        _teardown(components)
+        shutil.rmtree(tmpdir, ignore_errors=True)
+
+
+def test_api_team_write():
+    """PUT /api/team?team=... writes the team's project.md."""
+    tmpdir, components, client = _setup_dashboard_team_fixture()
+    try:
+        projects_dir = _seed_team_on_disk(tmpdir, "alpha", members=[])
+        with patch("src.cli.config.PROJECTS_DIR", Path(projects_dir)):
+            resp = client.put(
+                "/dashboard/api/team", params={"team": "alpha"},
+                json={"content": "Updated team body."},
+            )
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        assert body["saved"] is True
+        text = Path(projects_dir, "alpha", "project.md").read_text()
+        assert "Updated team body." in text
+    finally:
+        _teardown(components)
+        shutil.rmtree(tmpdir, ignore_errors=True)
+
+
+def test_api_workplace_teams_disabled_without_v2():
+    """GET /api/workplace/teams returns enabled=False when tasks_store is missing."""
+    # Use the default (no v2) fixture so tasks_store is None.
+    tmpdir, components, client = _setup_dashboard_team_fixture(include_v2=False)
+    try:
+        resp = client.get("/dashboard/api/workplace/teams")
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["enabled"] is False
+        # Both keys are present even when disabled, for client back-compat.
+        assert body["teams"] == []
+        assert body["projects"] == []
+    finally:
+        _teardown(components)
+        shutil.rmtree(tmpdir, ignore_errors=True)


### PR DESCRIPTION
## Summary

This is **PR 1 of 3** in a staged project→team domain rename.

- **Pure additive:** zero renames, zero existing-code changes. Adds `/mesh/teams/*` and `/api/teams/*` as thin aliases over the corresponding `/mesh/projects/*` and `/api/projects/*` routes.
- **De-risks PR 2** (the full rename + startup migration of `config/projects/` → `config/teams/`, dashboard frontend updates, type/permission renames, MeshClient method renames, operator-tool renames). The alias surface lets SDKs and the SPA migrate at their own pace.
- **PR 3** (later release) will sunset the deprecated `/projects/*` routes.

### What this PR does
- Mesh: 16 new `/mesh/teams/*` aliases (one per project route)
- Dashboard: 8 new `/api/teams/*` aliases (one per project route)
- Each alias calls the same underlying `_load_projects` / `_create_project` / `_delete_project` / `_add_agent_to_project` / etc. helpers as the project route it mirrors
- Response bodies carry **both** the legacy `name` / `project` keys **and** the new `team_name` / `team` keys for back-compat
- The team routes do NOT double-emit WebSocket events — the existing `project_*` events still fire from the project routes; the team routes share that emit path
- Permission checks are identical to the project routes
- 24 new tests in `tests/test_team_routes_alias.py` covering each alias

### What this PR explicitly does NOT do
- Does not rename any existing identifier, file, route, or string
- Does not add `TeamMetadata` Pydantic type or any team-specific type
- Does not add `can_manage_teams` permission
- Does not add team-prefixed operator tools, MeshClient methods, or fleet templates
- Does not touch the dashboard frontend (`static/`, `templates/`)
- Does not touch `config/agents.yaml` or operator playbooks

## Test plan

- [x] `pytest tests/test_team_routes_alias.py` — 24/24 pass
- [x] `pytest tests/test_team_routes_alias.py tests/test_projects.py tests/test_dashboard.py` — 420/420 pass
- [x] `ruff check src/host/server.py src/dashboard/server.py tests/test_team_routes_alias.py` — clean
- [ ] CI green (linked workflow)
- [ ] Manual smoke: `curl http://localhost:8420/mesh/teams -H 'X-Agent-ID: operator'` returns the same shape as `/mesh/projects` (with `team_name` keys added)

## Notes for review

- The `_resolve_agent_id`-gated routes (POST/DELETE `/mesh/teams`, etc.) are only meaningfully testable from end-to-end with auth tokens configured — same as the existing `mesh_create_project` / `mesh_delete_project`. The corresponding tests assert response-code parity with the project route to confirm the alias is wired correctly; full create-on-disk coverage is exercised through the dashboard `/api/teams` tests, which don't share that gate.
- `_blackboard_xproject_count` and other cross-project observability counters are unchanged — the rename is route-only in PR 1.