### PR TITLE
fix(agent): close streaming chat_stream lifecycle gaps + 3x codex passes

### DIFF
--- a/src/agent/loop.py
+++ b/src/agent/loop.py
@@ -2729,6 +2729,28 @@ class AgentLoop:
                                 if err:
                                     internal_error = str(err)
                         yield event
+                except asyncio.CancelledError:
+                    # Client disconnect / server cancel after the
+                    # task was marked ``working``. ``CancelledError``
+                    # is NOT an ``Exception`` subclass in Python
+                    # 3.8+, so the broader except below doesn't see
+                    # it. Without this branch the task stays stuck
+                    # in ``working`` forever (codex P2 from PR R2
+                    # round 2). Best-effort close via shield so our
+                    # cancellation can't kill the close mid-flight;
+                    # suppress the propagated CancelledError from
+                    # the awaited shield so we always re-raise the
+                    # original cancellation cleanly.
+                    if task_id:
+                        import contextlib
+                        with contextlib.suppress(asyncio.CancelledError):
+                            await asyncio.shield(
+                                self._auto_close_task(
+                                    task_id, "cancelled",
+                                    error="agent_chat_cancelled",
+                                )
+                            )
+                    raise
                 except Exception as e:
                     # Auto-fail the originating task before propagating
                     # (mirrors the non-streaming chat() path). Re-raise

--- a/src/agent/loop.py
+++ b/src/agent/loop.py
@@ -2623,6 +2623,7 @@ class AgentLoop:
     async def chat_stream(
         self, user_message: str, *, trace_id: str | None = None,
         origin: "MessageOrigin | None" = None,
+        task_id: str | None = None,
     ):
         """Streaming chat that yields SSE events as they happen.
 
@@ -2631,9 +2632,43 @@ class AgentLoop:
           {"type": "tool_result", "name": str, "output": any}
           {"type": "text_delta", "content": str}
           {"type": "done", "response": str, "tool_outputs": list, "tokens_used": int}
+
+        ``task_id`` mirrors :meth:`chat` — when set, the streaming turn
+        is treated as the execution of that specific task. On clean
+        completion we call ``set_task_status(done)`` with the
+        accumulated response as summary; on exception we call
+        ``set_task_status(failed)`` before re-raising. Without
+        ``task_id`` (legacy callers, free-form chat) the auto-close
+        is skipped. Closes the streaming-path gap left by PR #903
+        which only plumbed task_id through the non-streaming
+        :meth:`chat`.
         """
-        # Redirect to steer queue if a task is running.
+        # Redirect to steer queue if a task is running. Mirrors the
+        # non-streaming path's split: a task_id handoff arriving on
+        # a busy agent gets cleanly rejected (no steer queue, clear
+        # back-edge) so the originator doesn't redirect work while
+        # we silently queue and re-execute it later. Free-form
+        # chat (no task_id) keeps the legacy steer-queue UX.
         if self.current_task is not None:
+            if task_id:
+                await self._auto_close_task(
+                    task_id, "failed",
+                    error="agent_busy_handoff_rejected",
+                )
+                yield {
+                    "type": "text_delta",
+                    "content": (
+                        "Agent is working on another task — handoff "
+                        "rejected. Originator notified via back-edge."
+                    ),
+                }
+                yield {
+                    "type": "done",
+                    "response": "",
+                    "tool_outputs": [],
+                    "tokens_used": 0,
+                }
+                return
             await self._steer_queue.put(user_message)
             yield {
                 "type": "text_delta",
@@ -2650,19 +2685,59 @@ class AgentLoop:
             }
             return
 
-        from src.shared.trace import current_origin, current_trace_id
-        current_trace_id.set(trace_id)
-        origin_token = current_origin.set(origin)
-        try:
-            async with self._chat_lock:
-                await self._maybe_restore_session()
+        # NOTE: ``current_origin`` / ``current_trace_id`` are intentionally
+        # NOT set here. The /chat/stream endpoint's ``event_generator``
+        # sets them in the OUTER task before the per-iteration
+        # ``asyncio.ensure_future`` loop spawns child tasks — that way
+        # every iteration's task inherits them via context copy.
+        # Setting here would be both redundant AND broken: the
+        # ``set()`` runs in iteration 1's task, the matching
+        # ``reset(token)`` at the finally runs in iteration N's task,
+        # and Python's ``ContextVar.reset()`` raises ValueError when
+        # the token was created in a different context.
+        async with self._chat_lock:
+            await self._maybe_restore_session()
+            # Capture the final response for task auto-close. The
+            # ``done`` event carries the full response; collecting
+            # text_delta would also work but ``done`` is canonical.
+            final_response = ""
+            tool_limit_hit = False
+            try:
                 try:
                     async for event in self._chat_stream_inner(user_message):
+                        if isinstance(event, dict):
+                            if event.get("type") == "done":
+                                final_response = event.get("response", "") or ""
+                                if event.get("tool_limit_reached"):
+                                    tool_limit_hit = True
                         yield event
-                finally:
-                    await self._checkpoint_chat_session()
-        finally:
-            current_origin.reset(origin_token)
+                except Exception as e:
+                    # Auto-fail the originating task before propagating
+                    # (mirrors the non-streaming chat() path). Re-raise
+                    # so the existing error handling above can surface
+                    # the failure to the caller.
+                    if task_id:
+                        await self._auto_close_task(
+                            task_id, "failed",
+                            error=str(e)[:500],
+                        )
+                    raise
+                # Auto-close on clean completion. ``tool_limit_reached``
+                # is a known terminal condition we want to surface as
+                # ``failed`` with a specific reason rather than ``done``.
+                if task_id:
+                    if tool_limit_hit:
+                        await self._auto_close_task(
+                            task_id, "failed",
+                            error="max_iterations_reached",
+                        )
+                    else:
+                        await self._auto_close_task(
+                            task_id, "done",
+                            result_payload={"summary": final_response[:500]},
+                        )
+            finally:
+                await self._checkpoint_chat_session()
 
     async def _chat_stream_inner(self, user_message: str):
         self.state = "working"

--- a/src/agent/loop.py
+++ b/src/agent/loop.py
@@ -2697,11 +2697,20 @@ class AgentLoop:
         # the token was created in a different context.
         async with self._chat_lock:
             await self._maybe_restore_session()
+            # State machine requires pending → working before → done
+            # (same as the non-streaming chat path — codex P1 from
+            # PR R2 review caught this gap). Without it, every
+            # streaming handoff would be a no-op pending → done
+            # which 4xx's and leaves the task pending forever.
+            # Best-effort: _auto_close_task is exception-safe.
+            if task_id:
+                await self._auto_close_task(task_id, "working")
             # Capture the final response for task auto-close. The
             # ``done`` event carries the full response; collecting
             # text_delta would also work but ``done`` is canonical.
             final_response = ""
             tool_limit_hit = False
+            internal_error: str | None = None
             try:
                 try:
                     async for event in self._chat_stream_inner(user_message):
@@ -2710,6 +2719,15 @@ class AgentLoop:
                                 final_response = event.get("response", "") or ""
                                 if event.get("tool_limit_reached"):
                                     tool_limit_hit = True
+                                # _chat_stream_inner catches Exception
+                                # internally and yields a ``done`` event
+                                # with ``error: str``. Detect it so we
+                                # don't misclassify a swallowed failure
+                                # as a successful close (codex P2 from
+                                # PR R2 review).
+                                err = event.get("error")
+                                if err:
+                                    internal_error = str(err)
                         yield event
                 except Exception as e:
                     # Auto-fail the originating task before propagating
@@ -2722,11 +2740,19 @@ class AgentLoop:
                             error=str(e)[:500],
                         )
                     raise
-                # Auto-close on clean completion. ``tool_limit_reached``
-                # is a known terminal condition we want to surface as
-                # ``failed`` with a specific reason rather than ``done``.
+                # Auto-close on completion. Three possible terminal
+                # states for the streaming path:
+                #   1. ``internal_error`` — _chat_stream_inner caught
+                #      an exception and emitted error-flagged done.
+                #   2. ``tool_limit_reached`` — max-iterations exit.
+                #   3. Otherwise — clean completion.
                 if task_id:
-                    if tool_limit_hit:
+                    if internal_error is not None:
+                        await self._auto_close_task(
+                            task_id, "failed",
+                            error=internal_error[:500],
+                        )
+                    elif tool_limit_hit:
                         await self._auto_close_task(
                             task_id, "failed",
                             error="max_iterations_reached",
@@ -2958,11 +2984,18 @@ class AgentLoop:
             msg = f"Error: {e}"
             if self.workspace:
                 self.workspace.append_chat_message("assistant", msg)
+            # ``error`` field flags this as a swallowed internal
+            # failure so the outer ``chat_stream`` wrapper can
+            # auto-close the originating task as ``failed`` instead
+            # of misclassifying it as ``done`` (the response text
+            # "Error: ..." is human-readable but not parseable
+            # reliably as a failure signal — codex P2 from PR R2).
             yield {
                 "type": "done",
                 "response": msg,
                 "tool_outputs": tool_outputs,
                 "tokens_used": total_tokens,
+                "error": str(e),
             }
         finally:
             self.state = "idle"

--- a/src/agent/server.py
+++ b/src/agent/server.py
@@ -243,6 +243,10 @@ def create_agent_app(loop: AgentLoop) -> FastAPI:
         """Streaming chat. Returns SSE events for tool use and text deltas."""
         _trace_id = request.headers.get("x-trace-id")
         _origin = _origin_from_mesh_request(request)
+        # Mirrors the non-streaming /chat path (PR #903): when a
+        # wake rides ``x-task-id``, plumb it so the streaming loop
+        # auto-closes the originating handoff task on completion.
+        _task_id = request.headers.get("x-task-id") or None
 
         async def event_generator():
             # Set current_origin / current_trace_id in THIS task's
@@ -265,7 +269,7 @@ def create_agent_app(loop: AgentLoop) -> FastAPI:
 
             stream = loop.chat_stream(
                 sanitize_for_prompt(msg.message), trace_id=_trace_id,
-                origin=_origin,
+                origin=_origin, task_id=_task_id,
             )
             stream_iter = stream.__aiter__()
             # Use asyncio.wait (not wait_for) so the pending __anext__

--- a/tests/test_chat_stream_origin_propagation.py
+++ b/tests/test_chat_stream_origin_propagation.py
@@ -100,7 +100,7 @@ class _FakeLoop:
         self.current_task = None
         self.recorded_origin_at_tool_time: str | None = "SENTINEL_NOT_RECORDED"
 
-    async def chat_stream(self, message: str, *, trace_id=None, origin=None):
+    async def chat_stream(self, message: str, *, trace_id=None, origin=None, task_id=None):
         # Yield a couple of text_delta-shaped events first. Each yield
         # represents a streaming SSE chunk, and the event_generator
         # in the endpoint will spawn a fresh ensure_future task per
@@ -173,3 +173,173 @@ async def test_chat_stream_endpoint_propagates_origin_to_late_iteration_tools():
         f"path will fail confirm with 'did not carry a verified "
         f"human origin'."
     )
+
+
+# Latent ValueError guard: loop.chat_stream's old inner set/reset
+# pattern raised at end-of-stream because the token was created in
+# iteration 1's task and reset() ran in iteration N's task. Removing
+# the inner set/reset (now redundant after the outer hoist) eliminated
+# that. This test pins it down.
+
+class _CleanStreamLoop:
+    """Yields a few events and exits cleanly. With the bug, the inner
+    finally's reset(token) would raise ValueError at stream end."""
+
+    def __init__(self):
+        self.agent_id = "operator"
+        self.state = "idle"
+        self.current_task = None
+
+    async def chat_stream(self, message, *, trace_id=None, origin=None, task_id=None):
+        yield {"type": "text_delta", "content": "hello "}
+        yield {"type": "text_delta", "content": "world"}
+        yield {"type": "done", "response": "hello world", "tool_outputs": [], "tokens_used": 5}
+
+
+@pytest.mark.asyncio
+async def test_chat_stream_no_valueerror_at_stream_end():
+    """Regression for the latent ValueError: loop.chat_stream used to
+    do an inner ``current_origin.set()`` in iteration 1's task and
+    match it with ``current_origin.reset(token)`` at its finally —
+    which runs in iteration N's task, a different context. Python's
+    ``ContextVar.reset()`` rejects cross-context resets with
+    ValueError. The exception surfaced through ``next_e.result()``
+    and broke out of event_generator's loop with an unhandled
+    exception. Removing the inner set/reset (now redundant after
+    PR #906's outer hoist) fixes this. Test asserts the stream
+    completes without any exception leaking into the response.
+    """
+    import logging
+
+    from httpx import ASGITransport, AsyncClient
+
+    from src.agent.server import create_agent_app
+    from src.shared.trace import origin_header
+    from src.shared.types import MessageOrigin
+
+    app = create_agent_app(_CleanStreamLoop())  # type: ignore[arg-type]
+    human = MessageOrigin(kind="human", channel="dashboard", user="user1")
+    headers = {"x-mesh-internal": "1"}
+    headers.update(origin_header(human))
+
+    lines: list[str] = []
+    caplog_records: list[logging.LogRecord] = []
+
+    class _CaptureHandler(logging.Handler):
+        def emit(self, record):
+            caplog_records.append(record)
+
+    root_logger = logging.getLogger()
+    handler = _CaptureHandler(level=logging.WARNING)
+    root_logger.addHandler(handler)
+    try:
+        async with AsyncClient(
+            transport=ASGITransport(app=app), base_url="http://test",
+        ) as client:
+            async with client.stream(
+                "POST", "/chat/stream",
+                json={"message": "hi"},
+                headers=headers,
+                timeout=10,
+            ) as resp:
+                assert resp.status_code == 200
+                async for line in resp.aiter_lines():
+                    if line:
+                        lines.append(line)
+    finally:
+        root_logger.removeHandler(handler)
+
+    # All three events landed.
+    assert any('"text_delta"' in line for line in lines), lines
+    assert any('"done"' in line for line in lines), lines
+    # No ValueError-from-Context-reset in the captured warning logs.
+    valueerror_records = [
+        r for r in caplog_records
+        if "different Context" in r.getMessage()
+        or "Token" in r.getMessage() and "Context" in r.getMessage()
+    ]
+    assert not valueerror_records, (
+        f"ValueError leaked from inner reset: {[r.getMessage() for r in valueerror_records]}"
+    )
+
+
+# task_id plumbing through /chat/stream — closes the gap PR #903
+# left open. The streaming chat now auto-closes the originating
+# handoff task on completion (mirrors the non-streaming /chat).
+
+class _RecordingMeshClient:
+    """Records all set_task_status calls for assertion."""
+
+    def __init__(self):
+        self.calls: list[tuple[str, str, dict]] = []
+
+    async def set_task_status(self, task_id, status, *, result=None, error=None):
+        self.calls.append((task_id, status, {"result": result, "error": error}))
+        return {}
+
+
+class _LoopWithTaskClose:
+    """Yields a clean stream, then auto-close should fire via task_id."""
+
+    def __init__(self):
+        self.agent_id = "operator"
+        self.state = "idle"
+        self.current_task = None
+        self.mesh_client = _RecordingMeshClient()
+        # Async lock + queue used by the busy-handoff branch — even
+        # though this test doesn't exercise it, the real chat_stream
+        # checks ``self.current_task`` first.
+        self._chat_lock = asyncio.Lock()
+        # _checkpoint_chat_session is called in the finally.
+        self._checkpointed = False
+
+    async def _maybe_restore_session(self):
+        return None
+
+    async def _checkpoint_chat_session(self):
+        self._checkpointed = True
+
+    async def _chat_stream_inner(self, user_message):
+        yield {"type": "text_delta", "content": "ok"}
+        yield {"type": "done", "response": "all done", "tool_outputs": [], "tokens_used": 3}
+
+    async def _auto_close_task(self, task_id, status, *, result_payload=None, error=None):
+        # Delegate to the recording mesh_client so assertions stay simple.
+        await self.mesh_client.set_task_status(
+            task_id, status, result=result_payload, error=error,
+        )
+
+
+@pytest.mark.asyncio
+async def test_chat_stream_auto_closes_task_on_clean_done():
+    """When ``x-task-id`` rides the streaming wake, ``loop.chat_stream``
+    must auto-call ``set_task_status(done)`` on clean completion —
+    same contract as the non-streaming ``loop.chat`` (PR #903).
+    Without this, dashboard-routed handoffs that happen to land on
+    streaming chat never close.
+    """
+    # Use the real loop.chat_stream method on a stand-in that has
+    # the helpers it needs but a simple inner generator. We invoke
+    # chat_stream directly (not via the endpoint) — the contract
+    # under test is the loop-side auto-close, not the endpoint
+    # plumbing (covered by the test above).
+    from src.agent.loop import AgentLoop
+
+    stand_in = _LoopWithTaskClose()
+    # Steal the real chat_stream method, bind it to our stand-in.
+    method = AgentLoop.chat_stream.__get__(stand_in, AgentLoop)
+    events = []
+    async for ev in method("hi", task_id="task_alpha"):
+        events.append(ev)
+
+    # Stream produced both events.
+    assert any(e.get("type") == "done" for e in events), events
+    # Auto-close fired exactly once, with the right shape.
+    assert len(stand_in.mesh_client.calls) == 1
+    task_id, status, payload = stand_in.mesh_client.calls[0]
+    assert task_id == "task_alpha"
+    assert status == "done"
+    assert payload["result"] == {"summary": "all done"}
+    assert payload["error"] is None
+    # Checkpoint still ran.
+    assert stand_in._checkpointed

--- a/tests/test_chat_stream_origin_propagation.py
+++ b/tests/test_chat_stream_origin_propagation.py
@@ -311,18 +311,16 @@ class _LoopWithTaskClose:
 
 
 @pytest.mark.asyncio
-async def test_chat_stream_auto_closes_task_on_clean_done():
+async def test_chat_stream_auto_closes_task_with_working_then_done():
     """When ``x-task-id`` rides the streaming wake, ``loop.chat_stream``
-    must auto-call ``set_task_status(done)`` on clean completion —
-    same contract as the non-streaming ``loop.chat`` (PR #903).
-    Without this, dashboard-routed handoffs that happen to land on
-    streaming chat never close.
+    must transition the task pending → working → done. Codex P1 from
+    the R2 review: an earlier draft of this PR called
+    ``set_task_status(done)`` straight from ``pending``, which the
+    state machine 4xx's, leaving the task pending forever (Bug 2
+    silently reproduced for streaming handoffs). Mirror the
+    non-streaming ``chat()`` path: open as ``working`` at body
+    start, close as ``done`` on clean exit.
     """
-    # Use the real loop.chat_stream method on a stand-in that has
-    # the helpers it needs but a simple inner generator. We invoke
-    # chat_stream directly (not via the endpoint) — the contract
-    # under test is the loop-side auto-close, not the endpoint
-    # plumbing (covered by the test above).
     from src.agent.loop import AgentLoop
 
     stand_in = _LoopWithTaskClose()
@@ -334,12 +332,111 @@ async def test_chat_stream_auto_closes_task_on_clean_done():
 
     # Stream produced both events.
     assert any(e.get("type") == "done" for e in events), events
-    # Auto-close fired exactly once, with the right shape.
-    assert len(stand_in.mesh_client.calls) == 1
-    task_id, status, payload = stand_in.mesh_client.calls[0]
-    assert task_id == "task_alpha"
-    assert status == "done"
-    assert payload["result"] == {"summary": "all done"}
-    assert payload["error"] is None
+    # Two transitions, in order: working then done.
+    assert len(stand_in.mesh_client.calls) == 2, stand_in.mesh_client.calls
+    first_id, first_status, _ = stand_in.mesh_client.calls[0]
+    assert (first_id, first_status) == ("task_alpha", "working")
+    second_id, second_status, second_payload = stand_in.mesh_client.calls[1]
+    assert (second_id, second_status) == ("task_alpha", "done")
+    assert second_payload["result"] == {"summary": "all done"}
+    assert second_payload["error"] is None
     # Checkpoint still ran.
     assert stand_in._checkpointed
+
+
+# Swallowed-error guard: _chat_stream_inner catches Exception and
+# yields a ``done`` event with ``error: str`` so the outer wrapper
+# can auto-close the task as ``failed``. Without the ``error`` flag
+# (codex P2 from PR R2), a swallowed LLM/tool/runtime failure would
+# be misclassified as ``done`` with response "Error: ..." — the
+# originating agent sees task_completed instead of task_failed.
+
+class _LoopWithErrorStream(_LoopWithTaskClose):
+    async def _chat_stream_inner(self, user_message):
+        # Mimic _chat_stream_inner's except-Exception branch: yield
+        # a done with error flag instead of raising.
+        yield {"type": "text_delta", "content": "starting..."}
+        yield {
+            "type": "done",
+            "response": "Error: upstream LLM hiccup",
+            "tool_outputs": [],
+            "tokens_used": 0,
+            "error": "upstream LLM hiccup",
+        }
+
+
+@pytest.mark.asyncio
+async def test_chat_stream_auto_fails_task_on_swallowed_error():
+    """When _chat_stream_inner swallows an exception and emits an
+    error-flagged ``done`` event, the wrapper must transition the
+    task to ``failed`` (with the inner error in the back-edge
+    payload), NOT ``done``. Codex P2: previously the wrapper only
+    detected ``tool_limit_reached`` and treated everything else as
+    success, so swallowed failures were silently reported as
+    ``task_completed``.
+    """
+    from src.agent.loop import AgentLoop
+
+    stand_in = _LoopWithErrorStream()
+    method = AgentLoop.chat_stream.__get__(stand_in, AgentLoop)
+    events = []
+    async for ev in method("hi", task_id="task_bravo"):
+        events.append(ev)
+
+    # Stream still surfaces the error-flagged done to the SSE caller
+    # (so the dashboard chat shows the error). The user-visible
+    # behavior is unchanged.
+    assert any(e.get("type") == "done" and "error" in e for e in events), events
+    # working + failed transitions, in order.
+    assert len(stand_in.mesh_client.calls) == 2, stand_in.mesh_client.calls
+    first = stand_in.mesh_client.calls[0]
+    assert first[0:2] == ("task_bravo", "working")
+    second = stand_in.mesh_client.calls[1]
+    assert second[0:2] == ("task_bravo", "failed")
+    assert second[2]["error"] == "upstream LLM hiccup"
+
+
+class _LoopWithToolLimitStream(_LoopWithTaskClose):
+    async def _chat_stream_inner(self, user_message):
+        yield {"type": "text_delta", "content": "going..."}
+        yield {
+            "type": "done",
+            "response": "...stopped after N tool rounds",
+            "tool_outputs": [],
+            "tokens_used": 100,
+            "tool_limit_reached": True,
+        }
+
+
+@pytest.mark.asyncio
+async def test_chat_stream_auto_fails_task_on_tool_limit():
+    """``tool_limit_reached`` is a known terminal condition we want to
+    surface as ``failed`` with a specific reason rather than ``done``
+    — same contract as the non-streaming chat path."""
+    from src.agent.loop import AgentLoop
+
+    stand_in = _LoopWithToolLimitStream()
+    method = AgentLoop.chat_stream.__get__(stand_in, AgentLoop)
+    async for _ in method("hi", task_id="task_charlie"):
+        pass
+
+    calls = stand_in.mesh_client.calls
+    assert len(calls) == 2
+    assert calls[0][0:2] == ("task_charlie", "working")
+    assert calls[1][0:2] == ("task_charlie", "failed")
+    assert calls[1][2]["error"] == "max_iterations_reached"
+
+
+@pytest.mark.asyncio
+async def test_chat_stream_without_task_id_skips_auto_close():
+    """Legacy / free-form chat (no task_id) must not call
+    set_task_status at all — same contract as the non-streaming
+    chat path."""
+    from src.agent.loop import AgentLoop
+
+    stand_in = _LoopWithTaskClose()
+    method = AgentLoop.chat_stream.__get__(stand_in, AgentLoop)
+    async for _ in method("hi"):  # no task_id
+        pass
+
+    assert stand_in.mesh_client.calls == []

--- a/tests/test_chat_stream_origin_propagation.py
+++ b/tests/test_chat_stream_origin_propagation.py
@@ -440,3 +440,40 @@ async def test_chat_stream_without_task_id_skips_auto_close():
         pass
 
     assert stand_in.mesh_client.calls == []
+
+
+# Cancellation guard: codex P2 from PR R2 round 2 caught that
+# asyncio.CancelledError (Python 3.8+: BaseException, not Exception)
+# bypassed the except-Exception branch and left the task stuck in
+# ``working``. The fix catches CancelledError separately and closes
+# the task as ``cancelled`` (best-effort via asyncio.shield).
+
+class _LoopWithCancelledStream(_LoopWithTaskClose):
+    async def _chat_stream_inner(self, user_message):
+        yield {"type": "text_delta", "content": "starting..."}
+        # Simulate client-disconnect / server-cancel mid-stream.
+        raise asyncio.CancelledError()
+
+
+@pytest.mark.asyncio
+async def test_chat_stream_closes_task_as_cancelled_on_cancel():
+    """When the streaming chat is cancelled (client disconnect, server
+    cancel) AFTER the task was marked ``working``, the wrapper must
+    transition it to ``cancelled`` instead of leaving it stuck.
+    """
+    from src.agent.loop import AgentLoop
+
+    stand_in = _LoopWithCancelledStream()
+    method = AgentLoop.chat_stream.__get__(stand_in, AgentLoop)
+
+    # Iterate until the cancel propagates out as CancelledError.
+    with pytest.raises(asyncio.CancelledError):
+        async for _ in method("hi", task_id="task_delta"):
+            pass
+
+    # working → cancelled, in order.
+    calls = stand_in.mesh_client.calls
+    assert len(calls) == 2, calls
+    assert calls[0][0:2] == ("task_delta", "working")
+    assert calls[1][0:2] == ("task_delta", "cancelled")
+    assert calls[1][2]["error"] == "agent_chat_cancelled"


### PR DESCRIPTION
## Summary

Three review-driven cleanups on top of PR #906 (which fixed the dashboard-chat origin propagation). PR #906 closed the immediate operator delete-confirm bug; this PR closes the surrounding lifecycle gaps the deeper review surfaced.

## Bugs closed

1. **Latent ValueError in loop.chat_stream** — the inner ``current_origin.set/reset`` pattern raised at end-of-stream because the token was created in iteration 1's task and ``reset()`` ran in iteration N's task. Python's ``ContextVar.reset()`` rejects cross-context resets. Confirmed in a minimal repro; surfaced through ``next_e.result()`` as an unhandled exception. Removed the now-redundant inner set/reset since PR #906's outer hoist covers all iterations.

2. **No x-task-id plumbing through /chat/stream** — PR #903 added task_id auto-close to ``loop.chat`` (non-streaming) but missed ``loop.chat_stream``. Dashboard-routed handoffs landed on streaming chat and never auto-closed (silently reproducing Bug 2 for that path). Now ``/chat/stream`` reads ``x-task-id`` and forwards it through; ``chat_stream`` mirrors the non-streaming contract.

3. **codex P1**: missing ``pending → working`` transition in the new streaming auto-close path. State machine rejects ``pending → done`` so every streaming handoff would have silently dangled in pending.

4. **codex P2**: ``_chat_stream_inner`` catches Exception internally and yields a ``done`` event with response="Error: ...". The wrapper only special-cased ``tool_limit_reached``, so swallowed LLM/tool/runtime failures got reported to the originator as ``task_completed``. Added an explicit ``error`` field on the inner error-yield so the wrapper can distinguish error-done from success-done.

5. **codex P2 round 2**: ``asyncio.CancelledError`` is a ``BaseException``, not an ``Exception`` (Python 3.8+), so the except-Exception block doesn't see it. When a streaming request was cancelled after the task was marked ``working``, the task stayed stuck in working forever. Now catches CancelledError separately and closes as ``cancelled`` (best-effort via ``asyncio.shield`` so our own cancellation can't kill the close mid-flight).

Codex round 3: clean. "The changes correctly propagate origin context for streaming chat and add task status auto-close behavior without introducing an evident functional regression."

## Test plan

- [x] ``test_chat_stream_no_valueerror_at_stream_end`` — pins the ValueError fix.
- [x] ``test_chat_stream_auto_closes_task_with_working_then_done`` — pins the working+done sequence (codex P1 regression guard).
- [x] ``test_chat_stream_auto_fails_task_on_swallowed_error`` — pins the error-yield detection (codex P2 regression guard).
- [x] ``test_chat_stream_auto_fails_task_on_tool_limit`` — pins the tool-limit-reached → failed path.
- [x] ``test_chat_stream_without_task_id_skips_auto_close`` — pins the legacy chat-mode no-op.
- [x] ``test_chat_stream_closes_task_as_cancelled_on_cancel`` — pins the CancelledError fix (codex P2 round 2 regression guard).
- [x] 322 tests pass across ``test_chat_stream_origin_propagation`` + ``test_loop`` + ``test_task_lifecycle`` + ``test_agent_server`` + ``test_coordination`` + ``test_operator_product_tools``.
- [x] Ruff clean.
- [x] Full non-e2e suite: 6112 passed, 0 failed (one pre-existing flake ``test_post_telemetry_rate_limits_at_60_per_min`` that passes in isolation).