### PR TITLE
feat(dashboard): surface chat archives on agent + operator pages

### DIFF
--- a/src/agent/loop.py
+++ b/src/agent/loop.py
@@ -2441,12 +2441,19 @@ class AgentLoop:
             result.append({"role": role, "content": content})
         return result
 
-    async def reset_chat(self) -> None:
+    async def reset_chat(self) -> dict:
         """Clear conversation history. Flushes important facts to memory
         before clearing (unless the conversation was mostly errors).
         Acquires the chat lock to avoid corrupting state during an active
-        chat turn."""
+        chat turn.
+
+        Returns ``{archived_to, message_count, memory_flushed}`` so the
+        dashboard reset toast can tell the user exactly what was preserved
+        (now discoverable via the per-agent Archives tab).
+        """
         async with self._chat_lock:
+            message_count_at_reset = len(self._chat_messages)
+            memory_flushed = False
             if self._chat_messages and self.context_manager:
                 # Skip flush if the conversation is dominated by tool errors
                 # — extracting "facts" from error messages poisons memory.
@@ -2463,6 +2470,7 @@ class AgentLoop:
                         await self.context_manager._flush_to_memory(
                             "", self._chat_messages,
                         )
+                        memory_flushed = True
                     except Exception as e:
                         logger.warning("Failed to flush memory on chat reset: %s", e)
                 else:
@@ -2471,8 +2479,9 @@ class AgentLoop:
                         "%d/%d tool errors", error_count, tool_count,
                     )
             # Archive transcript before clearing in-memory state
+            archived_to: str | None = None
             if self.workspace:
-                self.workspace.archive_chat_transcript()
+                archived_to = self.workspace.archive_chat_transcript()
             self._chat_messages = []
             self._chat_total_rounds = 0
             self._chat_auto_continues = 0
@@ -2484,6 +2493,11 @@ class AgentLoop:
             self._last_active_playbooks = []
             self._operator_playbook_scan_idx = 0
             await self._checkpoint_chat_session()
+            return {
+                "archived_to": archived_to,
+                "message_count": message_count_at_reset,
+                "memory_flushed": memory_flushed,
+            }
 
     def _build_chat_system_prompt(
         self,

--- a/src/agent/server.py
+++ b/src/agent/server.py
@@ -300,8 +300,36 @@ def create_agent_app(loop: AgentLoop) -> FastAPI:
     @app.post("/chat/reset")
     async def chat_reset() -> dict:
         """Clear conversation history."""
-        await loop.reset_chat()
-        return {"status": "ok"}
+        result = await loop.reset_chat()
+        if not isinstance(result, dict):
+            result = {}
+        return {"status": "ok", **result}
+
+    @app.get("/chat/archives")
+    async def chat_archives_list() -> dict:
+        """List archived conversation transcripts (newest first, cap 100)."""
+        if not loop.workspace:
+            return {"archives": []}
+        return {"archives": loop.workspace.list_chat_archives()}
+
+    @app.get("/chat/archives/{name}")
+    async def chat_archive_get(name: str) -> dict:
+        """Return a single archived transcript by filename."""
+        if not loop.workspace:
+            raise HTTPException(404, "No workspace")
+        messages = loop.workspace.load_chat_archive(name)
+        if messages is None:
+            raise HTTPException(404, "Archive not found")
+        return {"name": name, "messages": messages, "count": len(messages)}
+
+    @app.delete("/chat/archives/{name}")
+    async def chat_archive_delete(name: str) -> dict:
+        if not loop.workspace:
+            raise HTTPException(404, "No workspace")
+        ok = loop.workspace.delete_chat_archive(name)
+        if not ok:
+            raise HTTPException(404, "Archive not found")
+        return {"deleted": True, "name": name}
 
     @app.get("/chat/history")
     async def chat_history() -> dict:

--- a/src/agent/workspace.py
+++ b/src/agent/workspace.py
@@ -27,6 +27,7 @@ from __future__ import annotations
 import contextlib
 import json
 import math
+import os
 import re
 import time
 from datetime import datetime, timedelta, timezone
@@ -123,6 +124,18 @@ _BULLET_RE = re.compile(r"^\s*[-*]\s+(.+?)\s*$")
 # ``_\d+`` suffix is the collision-recovery slot suffix written by
 # ``archive_chat_transcript`` when two resets land in the same second.
 _ARCHIVE_NAME_RE = re.compile(r"^\d{4}-\d{2}-\d{2}_\d{6}(?:_\d+)?\.jsonl$")
+
+# Per-agent cap on archived conversation transcripts. Older archives are
+# dropped FIFO when a new archive is written. Bounds disk usage without
+# requiring a separate sweep job. Operators wanting forensic retention
+# beyond this should copy archives out of band.
+_MAX_ARCHIVES_PER_AGENT = 100
+
+# Hard ceiling on bytes ``load_chat_archive`` will read into memory.
+# Matches the 10 MiB cap downstream consumers can render safely; oversize
+# archives surface as HTTP 404 (the file is still on disk and recoverable
+# via shell if needed).
+_MAX_ARCHIVE_LOAD_BYTES = 10 * 1024 * 1024
 
 # Heading aliases — case-insensitive. Same header may have alternate
 # phrasings across templates.
@@ -734,13 +747,68 @@ class WorkspaceManager:
             logger.debug("Failed to read chat transcript: %s", e)
             return []
 
+    @staticmethod
+    def _claim_archive_slot(archive_dir: Path, base_ts: str) -> Path | None:
+        """Atomically reserve a unique archive filename.
+
+        Race-safe: uses ``os.open`` with ``O_CREAT|O_EXCL`` semantics so
+        two threads or processes racing for the same timestamp slot can't
+        both pick the same suffix. Creates the target as an empty file
+        once won; the caller then ``rename()`` s the source over the top
+        (POSIX ``rename`` atomically replaces an existing file).
+
+        Returns the claimed path, or ``None`` if 100 collisions in the
+        same wall-clock second (which is implausible enough that we
+        prefer to surface it as a no-op).
+        """
+        for suffix in [""] + [f"_{i}" for i in range(2, 100)]:
+            candidate = archive_dir / f"{base_ts}{suffix}.jsonl"
+            try:
+                # O_CREAT|O_EXCL is atomic-create-if-missing; the kernel
+                # serialises racers so exactly one caller wins each slot.
+                fd = os.open(candidate, os.O_CREAT | os.O_EXCL | os.O_WRONLY, 0o644)
+            except FileExistsError:
+                continue
+            os.close(fd)
+            return candidate
+        return None
+
+    def _evict_old_archives(self, archive_dir: Path) -> None:
+        """Trim the archive directory down to ``_MAX_ARCHIVES_PER_AGENT``.
+
+        FIFO by mtime — oldest archives drop first. Bounded disk usage
+        without a separate sweep job. The cap is read from the module
+        global on each call so tests can monkeypatch it.
+        """
+        cap = _MAX_ARCHIVES_PER_AGENT
+        try:
+            children = [c for c in archive_dir.iterdir()
+                        if c.is_file() and _ARCHIVE_NAME_RE.match(c.name)]
+        except OSError as e:
+            logger.debug("Failed to list archives for eviction: %s", e)
+            return
+        if len(children) <= cap:
+            return
+        # Sort oldest-first by mtime so the head is what we drop.
+        try:
+            children.sort(key=lambda p: p.stat().st_mtime)
+        except OSError:
+            return
+        excess = len(children) - cap
+        for victim in children[:excess]:
+            try:
+                victim.unlink()
+                logger.info("Evicted old chat archive %s (cap=%d)", victim.name, cap)
+            except OSError as e:
+                logger.debug("Failed to evict chat archive %s: %s", victim.name, e)
+
     def archive_chat_transcript(self) -> str | None:
         """Archive the current transcript on chat reset.
 
         Returns the archive filename on success, or ``None`` on no-op /
-        failure. ``rename`` on POSIX silently overwrites the target, so
-        when two resets land in the same wall-clock second we fall back
-        to a ``_2``..``_99`` suffix to keep both archives.
+        failure. The slot reservation is race-safe (see
+        :meth:`_claim_archive_slot`); after a successful archive we
+        FIFO-evict to ``_MAX_ARCHIVES_PER_AGENT`` to bound disk usage.
         """
         path = self.root / self.CHAT_TRANSCRIPT
         if not path.exists():
@@ -754,26 +822,26 @@ class WorkspaceManager:
         archive_dir = self.root / self.CHAT_ARCHIVE_DIR
         archive_dir.mkdir(exist_ok=True)
         ts = datetime.now(timezone.utc).strftime("%Y-%m-%d_%H%M%S")
-        target = archive_dir / f"{ts}.jsonl"
-        if target.exists():
-            target = None
-            for n in range(2, 100):
-                candidate = archive_dir / f"{ts}_{n}.jsonl"
-                if not candidate.exists():
-                    target = candidate
-                    break
-            if target is None:
-                logger.warning(
-                    "Failed to archive chat transcript: more than 99 archives "
-                    "in same second (%s)", ts,
-                )
-                return None
+        target = self._claim_archive_slot(archive_dir, ts)
+        if target is None:
+            logger.warning(
+                "Failed to archive chat transcript: 100 collisions in same "
+                "wall-clock second (%s)", ts,
+            )
+            return None
         try:
+            # rename() over the pre-claimed empty slot is atomic on POSIX
+            # and replaces the empty placeholder with the real transcript.
             path.rename(target)
         except Exception as e:
             logger.debug("Failed to archive chat transcript: %s", e)
+            # Best-effort: drop the empty placeholder we created above so
+            # we don't leave a zero-byte archive masquerading as content.
+            with contextlib.suppress(OSError):
+                target.unlink()
             return None
         logger.info("Archived chat transcript to %s", target.name)
+        self._evict_old_archives(archive_dir)
         return target.name
 
     def list_chat_archives(self) -> list[dict]:
@@ -813,17 +881,22 @@ class WorkspaceManager:
                         line = line.strip()
                         if not line:
                             continue
+                        try:
+                            msg = json.loads(line)
+                        except json.JSONDecodeError:
+                            # Don't count malformed lines toward the
+                            # surfaced message_count — keeps the dashboard
+                            # tally honest when an archive has truncation
+                            # garbage at the tail.
+                            continue
+                        if not isinstance(msg, dict):
+                            continue
                         message_count += 1
-                        if not preview:
-                            try:
-                                msg = json.loads(line)
-                            except json.JSONDecodeError:
-                                continue
-                            if msg.get("role") == "user":
-                                content = msg.get("content", "")
-                                if isinstance(content, str) and content:
-                                    cleaned = sanitize_for_prompt(content)
-                                    preview = (cleaned[:120] + "…") if len(cleaned) > 120 else cleaned
+                        if not preview and msg.get("role") == "user":
+                            content = msg.get("content", "")
+                            if isinstance(content, str) and content:
+                                cleaned = sanitize_for_prompt(content)
+                                preview = (cleaned[:120] + "…") if len(cleaned) > 120 else cleaned
             except OSError as e:
                 logger.debug("Skipping unreadable chat archive %s: %s", child.name, e)
                 continue
@@ -854,6 +927,18 @@ class WorkspaceManager:
         if not path.is_relative_to(archive_root):
             return None
         if not path.exists():
+            return None
+        # Bound RSS: refuse to fully buffer archives above the load cap.
+        # The file is still on disk and can be recovered out-of-band if
+        # needed — surfacing a 404 to the dashboard is the safer default.
+        try:
+            size = path.stat().st_size
+        except OSError:
+            return None
+        if size > _MAX_ARCHIVE_LOAD_BYTES:
+            logger.warning(
+                "Archive %s exceeds load cap (%d bytes); refusing", name, size,
+            )
             return None
         try:
             text = path.read_text(errors="replace").strip()

--- a/src/agent/workspace.py
+++ b/src/agent/workspace.py
@@ -118,6 +118,12 @@ _MAX_LEARNINGS_SIZE = 50_000
 _HEADING_RE = re.compile(r"^\s*##+\s+(.+?)\s*$")
 _BULLET_RE = re.compile(r"^\s*[-*]\s+(.+?)\s*$")
 
+# Strict filename gate for chat-archive entries — used by both list and
+# load/delete paths as defense-in-depth against traversal. The optional
+# ``_\d+`` suffix is the collision-recovery slot suffix written by
+# ``archive_chat_transcript`` when two resets land in the same second.
+_ARCHIVE_NAME_RE = re.compile(r"^\d{4}-\d{2}-\d{2}_\d{6}(?:_\d+)?\.jsonl$")
+
 # Heading aliases — case-insensitive. Same header may have alternate
 # phrasings across templates.
 _INTERFACE_SECTIONS: dict[str, tuple[str, ...]] = {
@@ -728,24 +734,166 @@ class WorkspaceManager:
             logger.debug("Failed to read chat transcript: %s", e)
             return []
 
-    def archive_chat_transcript(self) -> None:
-        """Archive the current transcript on chat reset."""
+    def archive_chat_transcript(self) -> str | None:
+        """Archive the current transcript on chat reset.
+
+        Returns the archive filename on success, or ``None`` on no-op /
+        failure. ``rename`` on POSIX silently overwrites the target, so
+        when two resets land in the same wall-clock second we fall back
+        to a ``_2``..``_99`` suffix to keep both archives.
+        """
         path = self.root / self.CHAT_TRANSCRIPT
         if not path.exists():
-            return
+            return None
         try:
             if path.stat().st_size == 0:
                 path.unlink(missing_ok=True)
-                return
+                return None
         except OSError:
-            return
+            return None
         archive_dir = self.root / self.CHAT_ARCHIVE_DIR
         archive_dir.mkdir(exist_ok=True)
         ts = datetime.now(timezone.utc).strftime("%Y-%m-%d_%H%M%S")
+        target = archive_dir / f"{ts}.jsonl"
+        if target.exists():
+            target = None
+            for n in range(2, 100):
+                candidate = archive_dir / f"{ts}_{n}.jsonl"
+                if not candidate.exists():
+                    target = candidate
+                    break
+            if target is None:
+                logger.warning(
+                    "Failed to archive chat transcript: more than 99 archives "
+                    "in same second (%s)", ts,
+                )
+                return None
         try:
-            path.rename(archive_dir / f"{ts}.jsonl")
+            path.rename(target)
         except Exception as e:
             logger.debug("Failed to archive chat transcript: %s", e)
+            return None
+        logger.info("Archived chat transcript to %s", target.name)
+        return target.name
+
+    def list_chat_archives(self) -> list[dict]:
+        """Return up to 100 chat archives, newest first.
+
+        Each entry surfaces enough metadata for the dashboard to render
+        a card without opening the file. Per-file errors are swallowed
+        so one bad archive can't break the list.
+        """
+        archive_dir = self.root / self.CHAT_ARCHIVE_DIR
+        if not archive_dir.exists():
+            return []
+        entries: list[tuple[float, dict]] = []
+        try:
+            children = list(archive_dir.iterdir())
+        except OSError as e:
+            logger.debug("Failed to list chat archives: %s", e)
+            return []
+        for child in children:
+            if not child.is_file():
+                continue
+            if not _ARCHIVE_NAME_RE.match(child.name):
+                continue
+            try:
+                stat = child.stat()
+            except OSError:
+                continue
+            size = stat.st_size
+            if size == 0:
+                continue
+            ts_iso = datetime.fromtimestamp(stat.st_mtime, tz=timezone.utc).isoformat()
+            message_count = 0
+            preview = ""
+            try:
+                with child.open("r") as f:
+                    for line in f:
+                        line = line.strip()
+                        if not line:
+                            continue
+                        message_count += 1
+                        if not preview:
+                            try:
+                                msg = json.loads(line)
+                            except json.JSONDecodeError:
+                                continue
+                            if msg.get("role") == "user":
+                                content = msg.get("content", "")
+                                if isinstance(content, str) and content:
+                                    cleaned = sanitize_for_prompt(content)
+                                    preview = (cleaned[:120] + "…") if len(cleaned) > 120 else cleaned
+            except OSError as e:
+                logger.debug("Skipping unreadable chat archive %s: %s", child.name, e)
+                continue
+            entries.append((stat.st_mtime, {
+                "name": child.name,
+                "ts_iso": ts_iso,
+                "size_bytes": size,
+                "message_count": message_count,
+                "preview": preview,
+            }))
+        entries.sort(key=lambda kv: kv[0], reverse=True)
+        return [e[1] for e in entries[:100]]
+
+    def load_chat_archive(self, name: str, limit: int = 500) -> list[dict] | None:
+        """Load a single chat archive, returning the most-recent ``limit`` entries.
+
+        Returns ``None`` for bad names, traversal attempts, or missing
+        files — endpoint maps that to HTTP 404.
+        """
+        if not _ARCHIVE_NAME_RE.match(name or ""):
+            return None
+        archive_dir = self.root / self.CHAT_ARCHIVE_DIR
+        try:
+            path = (archive_dir / name).resolve()
+            archive_root = archive_dir.resolve()
+        except OSError:
+            return None
+        if not path.is_relative_to(archive_root):
+            return None
+        if not path.exists():
+            return None
+        try:
+            text = path.read_text(errors="replace").strip()
+        except OSError as e:
+            logger.debug("Failed to read chat archive %s: %s", name, e)
+            return None
+        if not text:
+            return []
+        lines = text.split("\n")
+        messages: list[dict] = []
+        for line in lines[-limit:]:
+            if not line.strip():
+                continue
+            try:
+                messages.append(json.loads(line))
+            except json.JSONDecodeError:
+                continue
+        return messages
+
+    def delete_chat_archive(self, name: str) -> bool:
+        """Delete a chat archive by name. Returns ``True`` only when a
+        matching file was removed."""
+        if not _ARCHIVE_NAME_RE.match(name or ""):
+            return False
+        archive_dir = self.root / self.CHAT_ARCHIVE_DIR
+        try:
+            path = (archive_dir / name).resolve()
+            archive_root = archive_dir.resolve()
+        except OSError:
+            return False
+        if not path.is_relative_to(archive_root):
+            return False
+        if not path.exists():
+            return False
+        try:
+            path.unlink(missing_ok=True)
+        except OSError as e:
+            logger.debug("Failed to delete chat archive %s: %s", name, e)
+            return False
+        return True
 
     # ── Activity log ────────────────────────────────────────
 

--- a/src/agent/workspace.py
+++ b/src/agent/workspace.py
@@ -789,9 +789,14 @@ class WorkspaceManager:
             return
         if len(children) <= cap:
             return
-        # Sort oldest-first by mtime so the head is what we drop.
+        # Sort oldest-first by (mtime, name) so the head is what we drop.
+        # Secondary sort by filename matters when the FS has 1-second mtime
+        # resolution (or two archives land in the same wall-clock second):
+        # the archive name is timestamp-prefixed
+        # (``YYYY-MM-DD_HHMMSS[_N].jsonl``) so name order resolves ties
+        # deterministically — oldest first, newest survives.
         try:
-            children.sort(key=lambda p: p.stat().st_mtime)
+            children.sort(key=lambda p: (p.stat().st_mtime, p.name))
         except OSError:
             return
         excess = len(children) - cap
@@ -800,7 +805,12 @@ class WorkspaceManager:
                 victim.unlink()
                 logger.info("Evicted old chat archive %s (cap=%d)", victim.name, cap)
             except OSError as e:
-                logger.debug("Failed to evict chat archive %s: %s", victim.name, e)
+                # Surface as WARN so silent disk-overflow isn't invisible
+                # in operator logs — eviction failures mean the cap isn't
+                # being honored.
+                logger.warning(
+                    "Failed to evict chat archive %s: %s", victim.name, e,
+                )
 
     def archive_chat_transcript(self) -> str | None:
         """Archive the current transcript on chat reset.
@@ -953,9 +963,14 @@ class WorkspaceManager:
             if not line.strip():
                 continue
             try:
-                messages.append(json.loads(line))
+                obj = json.loads(line)
             except json.JSONDecodeError:
                 continue
+            # Mirror list_chat_archives — only surface dict entries so the
+            # dashboard renderer doesn't get scalars / lists.
+            if not isinstance(obj, dict):
+                continue
+            messages.append(obj)
         return messages
 
     def delete_chat_archive(self, name: str) -> bool:

--- a/src/dashboard/server.py
+++ b/src/dashboard/server.py
@@ -3328,10 +3328,71 @@ def create_dashboard_router(
         if transport is None:
             raise HTTPException(status_code=503, detail="Transport not available")
         try:
-            await transport.request(agent_id, "POST", "/chat/reset", timeout=10)
+            result = await transport.request(agent_id, "POST", "/chat/reset", timeout=10)
             if event_bus:
                 event_bus.emit("chat_reset", agent=agent_id)
-            return {"reset": True, "agent": agent_id}
+            if not isinstance(result, dict):
+                result = {}
+            return {
+                "reset": True,
+                "agent": agent_id,
+                **{
+                    k: result.get(k)
+                    for k in ("archived_to", "message_count", "memory_flushed")
+                },
+            }
+        except Exception as e:
+            raise HTTPException(status_code=502, detail=str(e))
+
+    @api_router.get("/api/agents/{agent_id}/chat-archives")
+    async def api_chat_archives_list(agent_id: str) -> dict:
+        """List archived conversations for an agent (newest first, cap 100)."""
+        if agent_id not in agent_registry:
+            raise HTTPException(status_code=404, detail="Agent not found")
+        if transport is None:
+            raise HTTPException(status_code=503, detail="Transport not available")
+        try:
+            return await transport.request(agent_id, "GET", "/chat/archives", timeout=10)
+        except Exception as e:
+            raise HTTPException(status_code=502, detail=str(e))
+
+    @api_router.get("/api/agents/{agent_id}/chat-archives/{name}")
+    async def api_chat_archive_get(agent_id: str, name: str) -> dict:
+        """Fetch one archived transcript by filename."""
+        if agent_id not in agent_registry:
+            raise HTTPException(status_code=404, detail="Agent not found")
+        if transport is None:
+            raise HTTPException(status_code=503, detail="Transport not available")
+        try:
+            result = await transport.request(
+                agent_id, "GET", f"/chat/archives/{name}", timeout=30,
+            )
+            if isinstance(result, dict) and "error" in result:
+                status = result.get("status_code", 502)
+                raise HTTPException(status_code=status, detail=result["error"])
+            return result
+        except HTTPException:
+            raise
+        except Exception as e:
+            raise HTTPException(status_code=502, detail=str(e))
+
+    @api_router.delete("/api/agents/{agent_id}/chat-archives/{name}")
+    async def api_chat_archive_delete(agent_id: str, name: str) -> dict:
+        """Delete an archived transcript. Router-level CSRF check applies."""
+        if agent_id not in agent_registry:
+            raise HTTPException(status_code=404, detail="Agent not found")
+        if transport is None:
+            raise HTTPException(status_code=503, detail="Transport not available")
+        try:
+            result = await transport.request(
+                agent_id, "DELETE", f"/chat/archives/{name}", timeout=10,
+            )
+            if isinstance(result, dict) and "error" in result:
+                status = result.get("status_code", 502)
+                raise HTTPException(status_code=status, detail=result["error"])
+            return result
+        except HTTPException:
+            raise
         except Exception as e:
             raise HTTPException(status_code=502, detail=str(e))
 

--- a/src/dashboard/static/js/app.js
+++ b/src/dashboard/static/js/app.js
@@ -4538,12 +4538,25 @@ function dashboard() {
 
     _toastId: 0,
 
-    showToast(msg, duration) {
+    showToast(msg, opts) {
+      // Back-compat: `opts` accepts either a number (legacy duration ms)
+      // or an object `{ action: {label, handler} | null, durationMs }`.
+      // Older callers passing `showToast('...', 2000)` keep working.
       const id = ++this._toastId;
-      this.toastQueue.push({ id, msg });
+      let duration = 4000;
+      let action = null;
+      if (typeof opts === 'number') {
+        duration = opts;
+      } else if (opts && typeof opts === 'object') {
+        if (typeof opts.durationMs === 'number') duration = opts.durationMs;
+        if (opts.action && typeof opts.action.handler === 'function') {
+          action = opts.action;
+        }
+      }
+      this.toastQueue.push({ id, msg, action });
       setTimeout(() => {
         this.toastQueue = this.toastQueue.filter(t => t.id !== id);
-      }, duration || 4000);
+      }, duration);
     },
 
     dismissToast(id) {
@@ -5705,6 +5718,21 @@ function dashboard() {
       return `${agentId || ''}/${name || ''}`;
     },
 
+    // Deep-link the user to the Archives tab for the given agent. Used
+    // by the reset toast's "View" action so a confirmation can become a
+    // navigation in one click. drillDown switches activeTab='fleet' and
+    // sets detailAgent; we then flip the identityTab and kick the fetch.
+    _openArchivesForAgent(agentId) {
+      if (!agentId) return;
+      this.drillDown(agentId);
+      this.identityTab = 'archives';
+      this.$nextTick(() => {
+        if (typeof this.loadAgentArchives === 'function') {
+          this.loadAgentArchives(agentId);
+        }
+      });
+    },
+
     async loadAgentArchives(agentId) {
       if (!agentId) return;
       // Pin the in-flight agent so stale responses (user switched agent
@@ -5712,6 +5740,9 @@ function dashboard() {
       this.agentArchivesAgentId = agentId;
       this.agentArchivesLoading = true;
       this.agentArchivesError = '';
+      // Clear stale list before fetching so the prior agent's archives
+      // don't flash while the new fetch is in flight.
+      this.agentArchives = [];
       try {
         const resp = await fetch(`${window.__config.apiBase}/agents/${encodeURIComponent(agentId)}/chat-archives`);
         if (this.agentArchivesAgentId !== agentId) return;
@@ -8648,13 +8679,21 @@ function dashboard() {
             this._saveChatToSession();
             // Friendly toast points users at Archives without alarm-shape
             // language. The confirm dialog already promises memory is
-            // preserved, so no need to restate that here. Message count
-            // appended only when meaningfully non-zero.
-            const parts = ['Fresh chat started — previous conversation saved to Archives'];
-            if (data.message_count && data.message_count > 0) {
-              parts.push(`(${data.message_count} message${data.message_count === 1 ? '' : 's'})`);
+            // preserved, so no need to restate that here. Branch on
+            // archived_to so we don't lie when no archive was written
+            // (empty transcript, write failure, 100-collision).
+            let toast;
+            let action = null;
+            if (data.archived_to) {
+              toast = 'Fresh chat started — previous conversation saved to Archives';
+              if (data.message_count && data.message_count > 0) {
+                toast += ` (${data.message_count} message${data.message_count === 1 ? '' : 's'})`;
+              }
+              action = { label: 'View', handler: () => this._openArchivesForAgent(agentId) };
+            } else {
+              toast = 'Conversation cleared';
             }
-            this.showToast(parts.join(' '));
+            this.showToast(toast, { action });
             if (this.detailAgent === agentId && this.identityTab === 'archives') {
               this.loadAgentArchives(agentId);
             }

--- a/src/dashboard/static/js/app.js
+++ b/src/dashboard/static/js/app.js
@@ -48,6 +48,7 @@ const _IDENTITY_TABS = [
   { id: 'identity', label: 'Identity', file: null, access: 'user' },
   { id: 'memory', label: 'Memory', file: null, access: 'agent' },
   { id: 'activity', label: 'Activity', file: null, access: 'auto' },
+  { id: 'archives', label: 'Archives', file: null, access: 'user' },
   { id: 'logs', label: 'Logs', file: null, access: 'auto' },
   { id: 'capabilities', label: 'Tools', file: null, access: 'auto' },
   { id: 'files', label: 'Files', file: null, access: 'auto' },
@@ -363,6 +364,14 @@ function dashboard() {
     agentCapabilities: null,
     agentActivity: [],
     agentActivityLoading: false,
+
+    // Archives identity tab — list of {name, ts_iso, size_bytes,
+    // message_count, preview} entries plus a lazy per-archive cache.
+    agentArchives: [],
+    agentArchivesLoading: false,
+    agentArchivesError: '',
+    _agentArchiveContent: {},     // name -> {messages, count, loading, error}
+    agentArchiveExpanded: {},     // name -> bool
 
     // Credit exhausted state
     creditExhausted: false,
@@ -5665,6 +5674,9 @@ function dashboard() {
       if (tab.id === 'activity') {
         await this.fetchAgentActivity(agentId);
       }
+      if (tab.id === 'archives') {
+        await this.loadAgentArchives(agentId);
+      }
       if (tab.id === 'logs') {
         await this.fetchIdentityLogs(agentId);
         await this.fetchIdentityLearnings(agentId);
@@ -5675,6 +5687,83 @@ function dashboard() {
       if (tab.id === 'files') {
         await this.fetchAgentFiles(agentId, '.');
       }
+    },
+
+    async loadAgentArchives(agentId) {
+      if (!agentId) return;
+      this.agentArchivesLoading = true;
+      this.agentArchivesError = '';
+      try {
+        const resp = await fetch(`${window.__config.apiBase}/agents/${encodeURIComponent(agentId)}/chat-archives`);
+        if (!resp.ok) {
+          this.agentArchivesError = `Couldn't load archives (HTTP ${resp.status})`;
+          this.agentArchives = [];
+          return;
+        }
+        const data = await resp.json();
+        this.agentArchives = data.archives || [];
+      } catch (e) {
+        this.agentArchivesError = (e && e.message) ? `Couldn't load archives: ${e.message}` : "Couldn't load archives";
+        this.agentArchives = [];
+      } finally {
+        this.agentArchivesLoading = false;
+      }
+    },
+
+    async openAgentArchive(agentId, name) {
+      const wasExpanded = !!this.agentArchiveExpanded[name];
+      this.agentArchiveExpanded = { ...this.agentArchiveExpanded, [name]: !wasExpanded };
+      if (wasExpanded) return;
+      if (this._agentArchiveContent[name] && !this._agentArchiveContent[name].error) return;
+      this._agentArchiveContent = {
+        ...this._agentArchiveContent,
+        [name]: { messages: [], count: 0, loading: true, error: '' },
+      };
+      try {
+        const resp = await fetch(`${window.__config.apiBase}/agents/${encodeURIComponent(agentId)}/chat-archives/${encodeURIComponent(name)}`);
+        if (!resp.ok) {
+          this._agentArchiveContent = {
+            ...this._agentArchiveContent,
+            [name]: { messages: [], count: 0, loading: false, error: `HTTP ${resp.status}` },
+          };
+          return;
+        }
+        const data = await resp.json();
+        this._agentArchiveContent = {
+          ...this._agentArchiveContent,
+          [name]: { messages: data.messages || [], count: data.count || 0, loading: false, error: '' },
+        };
+      } catch (e) {
+        this._agentArchiveContent = {
+          ...this._agentArchiveContent,
+          [name]: { messages: [], count: 0, loading: false, error: (e && e.message) || 'fetch failed' },
+        };
+      }
+    },
+
+    async deleteAgentArchive(agentId, name) {
+      this.showConfirm('Delete archive', 'Permanently delete this archived conversation? This cannot be undone.', async () => {
+        try {
+          const resp = await fetch(`${window.__config.apiBase}/agents/${encodeURIComponent(agentId)}/chat-archives/${encodeURIComponent(name)}`, {
+            method: 'DELETE',
+            headers: { 'X-Requested-With': 'XMLHttpRequest' },
+          });
+          if (!resp.ok) {
+            this.showToast(`Delete failed: HTTP ${resp.status}`);
+            return;
+          }
+          this.agentArchives = this.agentArchives.filter(a => a.name !== name);
+          const next = { ...this._agentArchiveContent };
+          delete next[name];
+          this._agentArchiveContent = next;
+          const expanded = { ...this.agentArchiveExpanded };
+          delete expanded[name];
+          this.agentArchiveExpanded = expanded;
+          this.showToast('Archive deleted');
+        } catch (e) {
+          this.showToast(`Delete error: ${e.message || e}`);
+        }
+      }, true);
     },
 
     async fetchAgentCapabilities(agentId) {
@@ -8527,10 +8616,19 @@ function dashboard() {
           this._stopChatRecovery(agentId);
           const resp = await fetch(`${window.__config.apiBase}/agents/${agentId}/reset`, { method: 'POST' });
           if (resp.ok) {
-            this.showToast(`${agentId} conversation reset`);
+            const data = await resp.json().catch(() => ({}));
             this.chatHistories[agentId] = [];
             delete this._chatFetchedAt[agentId];
             this._saveChatToSession();
+            // Toast names what was preserved so users discover the new
+            // Archives tab without having to read release notes.
+            const parts = [`${agentId} conversation reset`];
+            if (data.message_count) parts.push(`${data.message_count} messages archived`);
+            if (data.memory_flushed) parts.push('memory updated');
+            this.showToast(parts.join(' — '));
+            if (this.detailAgent === agentId && this.identityTab === 'archives') {
+              this.loadAgentArchives(agentId);
+            }
           } else {
             this.showToast('Reset failed');
           }

--- a/src/dashboard/static/js/app.js
+++ b/src/dashboard/static/js/app.js
@@ -367,11 +367,17 @@ function dashboard() {
 
     // Archives identity tab — list of {name, ts_iso, size_bytes,
     // message_count, preview} entries plus a lazy per-archive cache.
+    // NOTE: per-archive state is keyed by `${agentId}/${name}` (see
+    // _archiveKey). Archive filenames are timestamp-derived and can
+    // collide across agents that reset in the same minute — keying by
+    // name alone would surface another agent's transcript after a tab
+    // switch. Always pass through _archiveKey().
     agentArchives: [],
     agentArchivesLoading: false,
     agentArchivesError: '',
-    _agentArchiveContent: {},     // name -> {messages, count, loading, error}
-    agentArchiveExpanded: {},     // name -> bool
+    agentArchivesAgentId: '',     // pins which agent the current list is for
+    _agentArchiveContent: {},     // _archiveKey -> {messages, count, loading, error}
+    agentArchiveExpanded: {},     // _archiveKey -> bool
 
     // Credit exhausted state
     creditExhausted: false,
@@ -5689,54 +5695,73 @@ function dashboard() {
       }
     },
 
+    // Compose the composite key for per-archive UI state. Archive
+    // filenames are timestamp-derived (YYYY-MM-DD_HHMMSS.jsonl) so two
+    // agents resetting at the same minute would otherwise share a key
+    // and overwrite each other's expanded/cached transcript state.
+    // If you key archive state, always include agent_id to prevent
+    // same-name cross-agent collisions.
+    _archiveKey(agentId, name) {
+      return `${agentId || ''}/${name || ''}`;
+    },
+
     async loadAgentArchives(agentId) {
       if (!agentId) return;
+      // Pin the in-flight agent so stale responses (user switched agent
+      // mid-fetch) can be dropped on arrival.
+      this.agentArchivesAgentId = agentId;
       this.agentArchivesLoading = true;
       this.agentArchivesError = '';
       try {
         const resp = await fetch(`${window.__config.apiBase}/agents/${encodeURIComponent(agentId)}/chat-archives`);
+        if (this.agentArchivesAgentId !== agentId) return;
         if (!resp.ok) {
           this.agentArchivesError = `Couldn't load archives (HTTP ${resp.status})`;
           this.agentArchives = [];
           return;
         }
         const data = await resp.json();
+        if (this.agentArchivesAgentId !== agentId) return;
         this.agentArchives = data.archives || [];
       } catch (e) {
+        if (this.agentArchivesAgentId !== agentId) return;
         this.agentArchivesError = (e && e.message) ? `Couldn't load archives: ${e.message}` : "Couldn't load archives";
         this.agentArchives = [];
       } finally {
-        this.agentArchivesLoading = false;
+        if (this.agentArchivesAgentId === agentId) {
+          this.agentArchivesLoading = false;
+        }
       }
     },
 
     async openAgentArchive(agentId, name) {
-      const wasExpanded = !!this.agentArchiveExpanded[name];
-      this.agentArchiveExpanded = { ...this.agentArchiveExpanded, [name]: !wasExpanded };
+      const key = this._archiveKey(agentId, name);
+      const wasExpanded = !!this.agentArchiveExpanded[key];
+      this.agentArchiveExpanded = { ...this.agentArchiveExpanded, [key]: !wasExpanded };
       if (wasExpanded) return;
-      if (this._agentArchiveContent[name] && !this._agentArchiveContent[name].error) return;
+      if (this._agentArchiveContent[key] && !this._agentArchiveContent[key].error) return;
       this._agentArchiveContent = {
         ...this._agentArchiveContent,
-        [name]: { messages: [], count: 0, loading: true, error: '' },
+        [key]: { messages: [], count: 0, loading: true, error: '' },
       };
       try {
         const resp = await fetch(`${window.__config.apiBase}/agents/${encodeURIComponent(agentId)}/chat-archives/${encodeURIComponent(name)}`);
         if (!resp.ok) {
           this._agentArchiveContent = {
             ...this._agentArchiveContent,
-            [name]: { messages: [], count: 0, loading: false, error: `HTTP ${resp.status}` },
+            [key]: { messages: [], count: 0, loading: false, error: `HTTP ${resp.status}` },
           };
           return;
         }
         const data = await resp.json();
         this._agentArchiveContent = {
           ...this._agentArchiveContent,
-          [name]: { messages: data.messages || [], count: data.count || 0, loading: false, error: '' },
+          [key]: { messages: data.messages || [], count: data.count || 0, loading: false, error: '' },
         };
       } catch (e) {
         this._agentArchiveContent = {
           ...this._agentArchiveContent,
-          [name]: { messages: [], count: 0, loading: false, error: (e && e.message) || 'fetch failed' },
+          [key]: { messages: [], count: 0, loading: false, error: (e && e.message) || 'fetch failed' },
         };
       }
     },
@@ -5752,12 +5777,13 @@ function dashboard() {
             this.showToast(`Delete failed: HTTP ${resp.status}`);
             return;
           }
+          const key = this._archiveKey(agentId, name);
           this.agentArchives = this.agentArchives.filter(a => a.name !== name);
           const next = { ...this._agentArchiveContent };
-          delete next[name];
+          delete next[key];
           this._agentArchiveContent = next;
           const expanded = { ...this.agentArchiveExpanded };
-          delete expanded[name];
+          delete expanded[key];
           this.agentArchiveExpanded = expanded;
           this.showToast('Archive deleted');
         } catch (e) {
@@ -8620,12 +8646,15 @@ function dashboard() {
             this.chatHistories[agentId] = [];
             delete this._chatFetchedAt[agentId];
             this._saveChatToSession();
-            // Toast names what was preserved so users discover the new
-            // Archives tab without having to read release notes.
-            const parts = [`${agentId} conversation reset`];
-            if (data.message_count) parts.push(`${data.message_count} messages archived`);
-            if (data.memory_flushed) parts.push('memory updated');
-            this.showToast(parts.join(' — '));
+            // Friendly toast points users at Archives without alarm-shape
+            // language. The confirm dialog already promises memory is
+            // preserved, so no need to restate that here. Message count
+            // appended only when meaningfully non-zero.
+            const parts = ['Fresh chat started — previous conversation saved to Archives'];
+            if (data.message_count && data.message_count > 0) {
+              parts.push(`(${data.message_count} message${data.message_count === 1 ? '' : 's'})`);
+            }
+            this.showToast(parts.join(' '));
             if (this.detailAgent === agentId && this.identityTab === 'archives') {
               this.loadAgentArchives(agentId);
             }

--- a/src/dashboard/templates/index.html
+++ b/src/dashboard/templates/index.html
@@ -2817,6 +2817,89 @@
                     <svg class="animate-spin h-4 w-4 inline mr-1" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24"><circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle><path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z"></path></svg>
                     Loading...
                   </div>
+                  <!-- ═══ Archives tab: snapshots saved on Reset Conversation ═══ -->
+                  <!-- DUPLICATED below in System > operator panel — keep the two
+                       layouts in sync. The operator surface pins ``agentId='operator'``
+                       and loads on tab activation; otherwise the markup is identical.
+                       Backend + JS helpers are shared. -->
+                  <div x-show="identityTab === 'archives' && !identityLoading" class="space-y-3">
+                    <div class="flex items-center justify-between mb-1">
+                      <div>
+                        <div class="text-xs font-medium text-gray-300">Conversation archives</div>
+                        <div class="text-[10px] text-gray-500 mt-0.5">
+                          Snapshots saved when you reset a conversation.
+                          Memory facts are preserved separately in the Memory tab.
+                          <span x-show="agentArchives.length" x-text="'· ' + agentArchives.length + (agentArchives.length === 1 ? ' archive' : ' archives')"></span>
+                        </div>
+                      </div>
+                      <button @click="loadAgentArchives(selectedAgent)"
+                        class="text-xs px-2.5 py-1 rounded bg-gray-800 hover:bg-gray-700 text-gray-400 hover:text-white transition-colors">Refresh</button>
+                    </div>
+                    <div x-show="agentArchivesLoading" class="py-6 text-center text-gray-600 text-sm">
+                      <svg class="animate-spin h-4 w-4 inline mr-1" fill="none" viewBox="0 0 24 24"><circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"/><path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z"/></svg>
+                      Loading archives…
+                    </div>
+                    <div x-show="!agentArchivesLoading && agentArchivesError"
+                      class="border border-amber-800/40 bg-amber-900/10 text-amber-300 text-xs rounded-lg px-3 py-2 flex items-center justify-between gap-2">
+                      <span x-text="agentArchivesError"></span>
+                      <button @click="loadAgentArchives(selectedAgent)"
+                        class="text-[10px] px-2 py-0.5 rounded bg-amber-800/40 hover:bg-amber-800/60 text-amber-200 transition-colors">Retry</button>
+                    </div>
+                    <div x-show="!agentArchivesLoading && !agentArchivesError && agentArchives.length === 0"
+                      class="text-gray-600 text-sm py-6 text-center">
+                      No archives yet — they appear here when you reset a conversation.
+                    </div>
+                    <template x-for="archive in agentArchives" :key="archive.name">
+                      <div class="border border-gray-800 rounded-lg">
+                        <div class="flex items-center gap-3 px-3 py-2 cursor-pointer hover:bg-gray-800/40 transition-colors"
+                          @click="openAgentArchive(selectedAgent, archive.name)">
+                          <svg class="w-3 h-3 text-gray-600 transition-transform shrink-0"
+                            :class="agentArchiveExpanded[archive.name] && 'rotate-90'"
+                            fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7"/></svg>
+                          <div class="flex-1 min-w-0">
+                            <div class="flex items-center gap-2">
+                              <span class="text-xs text-gray-300" x-text="archive.ts_iso ? new Date(archive.ts_iso).toLocaleString() : archive.name"></span>
+                              <span class="text-[10px] px-1.5 py-0 rounded-full bg-gray-700/50 text-gray-400 border border-gray-600/30"
+                                x-text="archive.message_count + (archive.message_count === 1 ? ' msg' : ' msgs')"></span>
+                              <span class="text-[10px] text-gray-600"
+                                x-text="(archive.size_bytes / 1024).toFixed(1) + ' KB'"></span>
+                            </div>
+                            <div x-show="archive.preview" class="text-[11px] text-gray-500 mt-0.5 truncate" x-text="archive.preview"></div>
+                          </div>
+                          <button type="button" @click.stop="deleteAgentArchive(selectedAgent, archive.name)"
+                            class="text-[10px] px-2 py-0.5 rounded bg-gray-800 hover:bg-red-900/40 text-gray-500 hover:text-red-300 border border-gray-700 transition-colors shrink-0">
+                            Delete
+                          </button>
+                        </div>
+                        <div x-show="agentArchiveExpanded[archive.name]" x-cloak class="border-t border-gray-800/60 px-3 py-2 space-y-1.5">
+                          <template x-if="_agentArchiveContent[archive.name] && _agentArchiveContent[archive.name].loading">
+                            <div class="text-xs text-gray-500 py-2">Loading transcript…</div>
+                          </template>
+                          <template x-if="_agentArchiveContent[archive.name] && _agentArchiveContent[archive.name].error">
+                            <div class="text-xs text-amber-400 py-2" x-text="'Failed to load: ' + _agentArchiveContent[archive.name].error"></div>
+                          </template>
+                          <template x-if="_agentArchiveContent[archive.name] && !_agentArchiveContent[archive.name].loading && !_agentArchiveContent[archive.name].error">
+                            <div class="space-y-1.5 max-h-72 overflow-y-auto custom-scrollbar">
+                              <template x-for="(msg, mi) in _agentArchiveContent[archive.name].messages" :key="mi">
+                                <div class="flex items-start gap-2">
+                                  <span class="text-[10px] px-1.5 py-0.5 rounded-full font-medium shrink-0"
+                                    :class="msg.role === 'user' ? 'bg-indigo-900/40 text-indigo-300 border border-indigo-800/40'
+                                          : msg.role === 'assistant' ? 'bg-emerald-900/40 text-emerald-300 border border-emerald-800/40'
+                                          : msg.role === 'notification' ? 'bg-amber-900/40 text-amber-300 border border-amber-800/40'
+                                          : 'bg-gray-800 text-gray-400 border border-gray-700'"
+                                    x-text="msg.role || '?'"></span>
+                                  <div class="flex-1 min-w-0 text-xs text-gray-300 whitespace-pre-wrap break-words"
+                                    x-text="typeof msg.content === 'string' ? msg.content : JSON.stringify(msg.content)"></div>
+                                </div>
+                              </template>
+                              <div x-show="!_agentArchiveContent[archive.name].messages.length" class="text-xs text-gray-600 py-1">(empty transcript)</div>
+                            </div>
+                          </template>
+                        </div>
+                      </div>
+                    </template>
+                  </div>
+
                   <!-- ═══ Logs tab: Activity + Learnings combined ═══ -->
                   <div x-show="identityTab === 'logs' && !identityLogsLoading && !identityLearningsLoading && !identityLoading" class="space-y-4">
                     <!-- Activity section -->
@@ -6841,6 +6924,85 @@
               <span class="text-gray-500" x-text="'Page ' + auditPage + ' of ' + Math.ceil(auditTotal / 20)"></span>
               <button @click="auditPage++; fetchAuditLog()" :disabled="auditPage >= Math.ceil(auditTotal / 20)"
                 class="px-2 py-0.5 rounded bg-gray-800 text-gray-400 disabled:opacity-30">Next</button>
+            </div>
+          </div>
+
+          <!-- Conversation history (operator) — same backend + JS helpers
+               as the per-agent Archives tab, pinned to agentId='operator'.
+               Refreshes on tab activation via the $watch in x-init. -->
+          <div class="bg-gray-900 border border-gray-800 rounded-lg p-5"
+            x-init="loadAgentArchives('operator'); $watch('systemTab', v => { if (v === 'operator') loadAgentArchives('operator'); })">
+            <div class="flex items-center justify-between mb-4 gap-3 flex-wrap">
+              <div>
+                <h3 class="text-sm font-medium text-gray-200">Conversation history</h3>
+                <p class="text-[10px] text-gray-500 mt-0.5">Snapshots of past conversations with the operator.</p>
+              </div>
+              <button @click="loadAgentArchives('operator')"
+                class="text-xs px-2.5 py-1 rounded bg-gray-800 hover:bg-gray-700 text-gray-400 hover:text-white transition-colors">Refresh</button>
+            </div>
+            <div x-show="agentArchivesLoading" class="flex items-center gap-2 text-gray-500 text-xs py-6 justify-center">
+              <svg class="animate-spin h-4 w-4" fill="none" viewBox="0 0 24 24"><circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"/><path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z"/></svg>
+              Loading…
+            </div>
+            <div x-show="!agentArchivesLoading && agentArchivesError"
+              class="border border-amber-800/40 bg-amber-900/10 text-amber-300 text-xs rounded-lg px-3 py-2 flex items-center justify-between gap-2 mb-2">
+              <span x-text="agentArchivesError"></span>
+              <button @click="loadAgentArchives('operator')"
+                class="text-[10px] px-2 py-0.5 rounded bg-amber-800/40 hover:bg-amber-800/60 text-amber-200 transition-colors">Retry</button>
+            </div>
+            <div x-show="!agentArchivesLoading && !agentArchivesError && agentArchives.length === 0"
+              class="text-center py-8 text-gray-600 text-xs">
+              No archives yet. They appear here after you reset an operator conversation.
+            </div>
+            <div x-show="!agentArchivesLoading && agentArchives.length > 0" class="space-y-1.5">
+              <template x-for="archive in agentArchives" :key="archive.name">
+                <div class="rounded-lg border border-gray-800/50 bg-gray-800/30">
+                  <div class="flex items-center gap-3 px-3 py-2 cursor-pointer hover:bg-gray-800/40 transition-colors"
+                    @click="openAgentArchive('operator', archive.name)">
+                    <svg class="w-3 h-3 text-gray-600 transition-transform shrink-0"
+                      :class="agentArchiveExpanded[archive.name] && 'rotate-90'"
+                      fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7"/></svg>
+                    <div class="flex-1 min-w-0">
+                      <div class="flex items-center gap-2">
+                        <span class="text-xs text-white font-medium" x-text="archive.ts_iso ? new Date(archive.ts_iso).toLocaleString() : archive.name"></span>
+                        <span class="text-[10px] px-1.5 py-0 rounded-full bg-gray-700/50 text-gray-400 border border-gray-600/30"
+                          x-text="archive.message_count + (archive.message_count === 1 ? ' msg' : ' msgs')"></span>
+                        <span class="text-[10px] text-gray-600" x-text="(archive.size_bytes / 1024).toFixed(1) + ' KB'"></span>
+                      </div>
+                      <div x-show="archive.preview" class="text-[11px] text-gray-500 mt-0.5 truncate" x-text="archive.preview"></div>
+                    </div>
+                    <button type="button" @click.stop="deleteAgentArchive('operator', archive.name)"
+                      class="text-[10px] px-2 py-0.5 rounded bg-gray-700 hover:bg-red-900/40 text-gray-200 hover:text-red-300 disabled:opacity-50 transition-colors shrink-0">
+                      Delete
+                    </button>
+                  </div>
+                  <div x-show="agentArchiveExpanded[archive.name]" x-cloak class="border-t border-gray-800/40 px-3 pb-2.5 pt-2 space-y-1.5">
+                    <template x-if="_agentArchiveContent[archive.name] && _agentArchiveContent[archive.name].loading">
+                      <div class="text-xs text-gray-500 py-2">Loading transcript…</div>
+                    </template>
+                    <template x-if="_agentArchiveContent[archive.name] && _agentArchiveContent[archive.name].error">
+                      <div class="text-xs text-amber-400 py-2" x-text="'Failed to load: ' + _agentArchiveContent[archive.name].error"></div>
+                    </template>
+                    <template x-if="_agentArchiveContent[archive.name] && !_agentArchiveContent[archive.name].loading && !_agentArchiveContent[archive.name].error">
+                      <div class="space-y-1.5 max-h-72 overflow-y-auto custom-scrollbar">
+                        <template x-for="(msg, mi) in _agentArchiveContent[archive.name].messages" :key="mi">
+                          <div class="flex items-start gap-2">
+                            <span class="text-[10px] px-1.5 py-0.5 rounded-full font-medium shrink-0"
+                              :class="msg.role === 'user' ? 'bg-indigo-900/40 text-indigo-300 border border-indigo-800/40'
+                                    : msg.role === 'assistant' ? 'bg-emerald-900/40 text-emerald-300 border border-emerald-800/40'
+                                    : msg.role === 'notification' ? 'bg-amber-900/40 text-amber-300 border border-amber-800/40'
+                                    : 'bg-gray-800 text-gray-400 border border-gray-700'"
+                              x-text="msg.role || '?'"></span>
+                            <div class="flex-1 min-w-0 text-xs text-gray-300 whitespace-pre-wrap break-words"
+                              x-text="typeof msg.content === 'string' ? msg.content : JSON.stringify(msg.content)"></div>
+                          </div>
+                        </template>
+                        <div x-show="!_agentArchiveContent[archive.name].messages.length" class="text-xs text-gray-600 py-1">(empty transcript)</div>
+                      </div>
+                    </template>
+                  </div>
+                </div>
+              </template>
             </div>
           </div>
         </div><!-- /operator sub-tab -->

--- a/src/dashboard/templates/index.html
+++ b/src/dashboard/templates/index.html
@@ -67,6 +67,10 @@
       <template x-for="t in toastQueue" :key="t.id">
         <div class="toast text-gray-200 flex items-center gap-2 pointer-events-auto" x-transition>
           <span class="flex-1" x-text="t.msg"></span>
+          <button x-show="t.action" x-cloak
+            @click="t.action.handler(); dismissToast(t.id)"
+            class="shrink-0 underline text-indigo-300 hover:text-indigo-200 text-xs"
+            x-text="t.action && t.action.label"></button>
           <button @click="dismissToast(t.id)" aria-label="Dismiss notification" class="shrink-0 text-gray-400 hover:text-white transition-colors text-sm leading-none">&times;</button>
         </div>
       </template>

--- a/src/dashboard/templates/index.html
+++ b/src/dashboard/templates/index.html
@@ -2854,7 +2854,7 @@
                         <div class="flex items-center gap-3 px-3 py-2 cursor-pointer hover:bg-gray-800/40 transition-colors"
                           @click="openAgentArchive(selectedAgent, archive.name)">
                           <svg class="w-3 h-3 text-gray-600 transition-transform shrink-0"
-                            :class="agentArchiveExpanded[archive.name] && 'rotate-90'"
+                            :class="agentArchiveExpanded[_archiveKey(selectedAgent, archive.name)] && 'rotate-90'"
                             fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7"/></svg>
                           <div class="flex-1 min-w-0">
                             <div class="flex items-center gap-2">
@@ -2871,16 +2871,16 @@
                             Delete
                           </button>
                         </div>
-                        <div x-show="agentArchiveExpanded[archive.name]" x-cloak class="border-t border-gray-800/60 px-3 py-2 space-y-1.5">
-                          <template x-if="_agentArchiveContent[archive.name] && _agentArchiveContent[archive.name].loading">
+                        <div x-show="agentArchiveExpanded[_archiveKey(selectedAgent, archive.name)]" x-cloak class="border-t border-gray-800/60 px-3 py-2 space-y-1.5">
+                          <template x-if="_agentArchiveContent[_archiveKey(selectedAgent, archive.name)] && _agentArchiveContent[_archiveKey(selectedAgent, archive.name)].loading">
                             <div class="text-xs text-gray-500 py-2">Loading transcript…</div>
                           </template>
-                          <template x-if="_agentArchiveContent[archive.name] && _agentArchiveContent[archive.name].error">
-                            <div class="text-xs text-amber-400 py-2" x-text="'Failed to load: ' + _agentArchiveContent[archive.name].error"></div>
+                          <template x-if="_agentArchiveContent[_archiveKey(selectedAgent, archive.name)] && _agentArchiveContent[_archiveKey(selectedAgent, archive.name)].error">
+                            <div class="text-xs text-amber-400 py-2" x-text="'Failed to load: ' + _agentArchiveContent[_archiveKey(selectedAgent, archive.name)].error"></div>
                           </template>
-                          <template x-if="_agentArchiveContent[archive.name] && !_agentArchiveContent[archive.name].loading && !_agentArchiveContent[archive.name].error">
+                          <template x-if="_agentArchiveContent[_archiveKey(selectedAgent, archive.name)] && !_agentArchiveContent[_archiveKey(selectedAgent, archive.name)].loading && !_agentArchiveContent[_archiveKey(selectedAgent, archive.name)].error">
                             <div class="space-y-1.5 max-h-72 overflow-y-auto custom-scrollbar">
-                              <template x-for="(msg, mi) in _agentArchiveContent[archive.name].messages" :key="mi">
+                              <template x-for="(msg, mi) in _agentArchiveContent[_archiveKey(selectedAgent, archive.name)].messages" :key="mi">
                                 <div class="flex items-start gap-2">
                                   <span class="text-[10px] px-1.5 py-0.5 rounded-full font-medium shrink-0"
                                     :class="msg.role === 'user' ? 'bg-indigo-900/40 text-indigo-300 border border-indigo-800/40'
@@ -2892,7 +2892,7 @@
                                     x-text="typeof msg.content === 'string' ? msg.content : JSON.stringify(msg.content)"></div>
                                 </div>
                               </template>
-                              <div x-show="!_agentArchiveContent[archive.name].messages.length" class="text-xs text-gray-600 py-1">(empty transcript)</div>
+                              <div x-show="!_agentArchiveContent[_archiveKey(selectedAgent, archive.name)].messages.length" class="text-xs text-gray-600 py-1">(empty transcript)</div>
                             </div>
                           </template>
                         </div>
@@ -6960,7 +6960,7 @@
                   <div class="flex items-center gap-3 px-3 py-2 cursor-pointer hover:bg-gray-800/40 transition-colors"
                     @click="openAgentArchive('operator', archive.name)">
                     <svg class="w-3 h-3 text-gray-600 transition-transform shrink-0"
-                      :class="agentArchiveExpanded[archive.name] && 'rotate-90'"
+                      :class="agentArchiveExpanded[_archiveKey('operator', archive.name)] && 'rotate-90'"
                       fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7"/></svg>
                     <div class="flex-1 min-w-0">
                       <div class="flex items-center gap-2">
@@ -6976,16 +6976,16 @@
                       Delete
                     </button>
                   </div>
-                  <div x-show="agentArchiveExpanded[archive.name]" x-cloak class="border-t border-gray-800/40 px-3 pb-2.5 pt-2 space-y-1.5">
-                    <template x-if="_agentArchiveContent[archive.name] && _agentArchiveContent[archive.name].loading">
+                  <div x-show="agentArchiveExpanded[_archiveKey('operator', archive.name)]" x-cloak class="border-t border-gray-800/40 px-3 pb-2.5 pt-2 space-y-1.5">
+                    <template x-if="_agentArchiveContent[_archiveKey('operator', archive.name)] && _agentArchiveContent[_archiveKey('operator', archive.name)].loading">
                       <div class="text-xs text-gray-500 py-2">Loading transcript…</div>
                     </template>
-                    <template x-if="_agentArchiveContent[archive.name] && _agentArchiveContent[archive.name].error">
-                      <div class="text-xs text-amber-400 py-2" x-text="'Failed to load: ' + _agentArchiveContent[archive.name].error"></div>
+                    <template x-if="_agentArchiveContent[_archiveKey('operator', archive.name)] && _agentArchiveContent[_archiveKey('operator', archive.name)].error">
+                      <div class="text-xs text-amber-400 py-2" x-text="'Failed to load: ' + _agentArchiveContent[_archiveKey('operator', archive.name)].error"></div>
                     </template>
-                    <template x-if="_agentArchiveContent[archive.name] && !_agentArchiveContent[archive.name].loading && !_agentArchiveContent[archive.name].error">
+                    <template x-if="_agentArchiveContent[_archiveKey('operator', archive.name)] && !_agentArchiveContent[_archiveKey('operator', archive.name)].loading && !_agentArchiveContent[_archiveKey('operator', archive.name)].error">
                       <div class="space-y-1.5 max-h-72 overflow-y-auto custom-scrollbar">
-                        <template x-for="(msg, mi) in _agentArchiveContent[archive.name].messages" :key="mi">
+                        <template x-for="(msg, mi) in _agentArchiveContent[_archiveKey('operator', archive.name)].messages" :key="mi">
                           <div class="flex items-start gap-2">
                             <span class="text-[10px] px-1.5 py-0.5 rounded-full font-medium shrink-0"
                               :class="msg.role === 'user' ? 'bg-indigo-900/40 text-indigo-300 border border-indigo-800/40'
@@ -6997,7 +6997,7 @@
                               x-text="typeof msg.content === 'string' ? msg.content : JSON.stringify(msg.content)"></div>
                           </div>
                         </template>
-                        <div x-show="!_agentArchiveContent[archive.name].messages.length" class="text-xs text-gray-600 py-1">(empty transcript)</div>
+                        <div x-show="!_agentArchiveContent[_archiveKey('operator', archive.name)].messages.length" class="text-xs text-gray-600 py-1">(empty transcript)</div>
                       </div>
                     </template>
                   </div>

--- a/tests/test_agent_server.py
+++ b/tests/test_agent_server.py
@@ -888,3 +888,69 @@ class TestHeartbeatOriginContextVar:
             resp = await client.post("/heartbeat", json={"message": "tick"})
         assert resp.status_code == 200
         assert captured == [None]
+
+
+class TestChatArchives:
+    """Cover the /chat/archives list / get / delete endpoints."""
+
+    @pytest.mark.asyncio
+    async def test_chat_archives_list_endpoint(self, tmp_workspace):
+        app, loop = _make_app(tmp_workspace)
+        loop.workspace.append_chat_message("user", "session one")
+        loop.workspace.archive_chat_transcript()
+
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+            resp = await client.get("/chat/archives")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert "archives" in data
+        assert len(data["archives"]) == 1
+        archive = data["archives"][0]
+        assert archive["name"].endswith(".jsonl")
+        assert archive["message_count"] == 1
+        assert "ts_iso" in archive
+        assert "size_bytes" in archive
+
+    @pytest.mark.asyncio
+    async def test_chat_archives_list_no_workspace(self):
+        app, _ = _make_app(None)
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+            resp = await client.get("/chat/archives")
+        assert resp.status_code == 200
+        assert resp.json() == {"archives": []}
+
+    @pytest.mark.asyncio
+    async def test_chat_archive_get_endpoint(self, tmp_workspace):
+        app, loop = _make_app(tmp_workspace)
+        loop.workspace.append_chat_message("user", "hello")
+        loop.workspace.append_chat_message("assistant", "hi")
+        name = loop.workspace.archive_chat_transcript()
+        assert name is not None
+
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+            ok = await client.get(f"/chat/archives/{name}")
+            bad = await client.get("/chat/archives/does-not-exist.jsonl")
+            traversal = await client.get("/chat/archives/..%2F..%2Fpasswd")
+
+        assert ok.status_code == 200
+        body = ok.json()
+        assert body["name"] == name
+        assert body["count"] == 2
+        assert body["messages"][0]["role"] == "user"
+        assert bad.status_code == 404
+        assert traversal.status_code in (404, 422)
+
+    @pytest.mark.asyncio
+    async def test_chat_archive_delete_endpoint(self, tmp_workspace):
+        app, loop = _make_app(tmp_workspace)
+        loop.workspace.append_chat_message("user", "to delete")
+        name = loop.workspace.archive_chat_transcript()
+        assert name is not None
+
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+            first = await client.delete(f"/chat/archives/{name}")
+            second = await client.delete(f"/chat/archives/{name}")
+
+        assert first.status_code == 200
+        assert first.json() == {"deleted": True, "name": name}
+        assert second.status_code == 404

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -5667,3 +5667,92 @@ class TestDashboardEventBusCoverage:
         assert resp.status_code == 400
         deletes = [e for e in self.captured if e["type"] == "blackboard_delete"]
         assert deletes == []
+
+
+class TestDashboardChatArchivesProxy:
+    """Cover the /api/agents/{id}/chat-archives proxies + reset passthrough."""
+
+    def setup_method(self):
+        self._tmpdir = tempfile.mkdtemp()
+        self.components = _make_components(self._tmpdir, include_v2=True)
+        self.client = _make_client(self.components)
+
+    def teardown_method(self):
+        _teardown(self.components)
+        shutil.rmtree(self._tmpdir, ignore_errors=True)
+
+    def test_chat_archives_proxy_list(self):
+        payload = {
+            "archives": [
+                {
+                    "name": "2026-01-01_120000.jsonl",
+                    "ts_iso": "2026-01-01T12:00:00+00:00",
+                    "size_bytes": 1024,
+                    "message_count": 4,
+                    "preview": "Hi there",
+                },
+            ],
+        }
+        self.components["transport"].request = AsyncMock(return_value=payload)
+        resp = self.client.get("/dashboard/api/agents/alpha/chat-archives")
+        assert resp.status_code == 200
+        assert resp.json() == payload
+        self.components["transport"].request.assert_called_once_with(
+            "alpha", "GET", "/chat/archives", timeout=10,
+        )
+
+    def test_chat_archives_proxy_get(self):
+        payload = {
+            "name": "2026-01-01_120000.jsonl",
+            "messages": [{"role": "user", "content": "hi", "ts": 1}],
+            "count": 1,
+        }
+        self.components["transport"].request = AsyncMock(return_value=payload)
+        resp = self.client.get("/dashboard/api/agents/alpha/chat-archives/2026-01-01_120000.jsonl")
+        assert resp.status_code == 200
+        assert resp.json() == payload
+        self.components["transport"].request.assert_called_once_with(
+            "alpha", "GET", "/chat/archives/2026-01-01_120000.jsonl", timeout=30,
+        )
+
+    def test_chat_archives_proxy_delete(self):
+        payload = {"deleted": True, "name": "2026-01-01_120000.jsonl"}
+        self.components["transport"].request = AsyncMock(return_value=payload)
+        resp = self.client.delete("/dashboard/api/agents/alpha/chat-archives/2026-01-01_120000.jsonl")
+        assert resp.status_code == 200
+        assert resp.json() == payload
+        self.components["transport"].request.assert_called_once_with(
+            "alpha", "DELETE", "/chat/archives/2026-01-01_120000.jsonl", timeout=10,
+        )
+
+    def test_chat_archives_unknown_agent_404(self):
+        resp = self.client.get("/dashboard/api/agents/nonexistent/chat-archives")
+        assert resp.status_code == 404
+
+    def test_reset_endpoint_includes_archive_fields(self):
+        """Reset proxy echoes archived_to / message_count / memory_flushed."""
+        self.components["transport"].request = AsyncMock(return_value={
+            "status": "ok",
+            "archived_to": "2026-01-01_120000.jsonl",
+            "message_count": 7,
+            "memory_flushed": True,
+        })
+        resp = self.client.post("/dashboard/api/agents/alpha/reset")
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["reset"] is True
+        assert body["agent"] == "alpha"
+        assert body["archived_to"] == "2026-01-01_120000.jsonl"
+        assert body["message_count"] == 7
+        assert body["memory_flushed"] is True
+
+    def test_reset_endpoint_handles_missing_fields(self):
+        """Reset proxy tolerates an older agent that returns no archive fields."""
+        self.components["transport"].request = AsyncMock(return_value={"status": "ok"})
+        resp = self.client.post("/dashboard/api/agents/alpha/reset")
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["reset"] is True
+        assert body["archived_to"] is None
+        assert body["message_count"] is None
+        assert body["memory_flushed"] is None

--- a/tests/test_loop.py
+++ b/tests/test_loop.py
@@ -2350,3 +2350,28 @@ async def test_skills_reload_rebuilds_system_prompt():
     assert len(systems_seen) >= 2
     # The flag should be consumed (not stuck True)
     assert loop._skills_reloaded is False
+
+
+@pytest.mark.asyncio
+async def test_reset_chat_returns_status_dict(tmp_path):
+    """reset_chat returns archived_to / message_count / memory_flushed."""
+    from src.agent.workspace import WorkspaceManager
+
+    loop = _make_loop()
+    loop.workspace = WorkspaceManager(workspace_dir=str(tmp_path))
+    # Inject a tiny conversation; flush is best-effort and may no-op when
+    # the mock context_manager isn't configured, so we just verify shape.
+    loop._chat_messages = [
+        {"role": "user", "content": "hello", "_origin": "user"},
+        {"role": "assistant", "content": "hi"},
+    ]
+    # Persist the transcript so archive_chat_transcript has something to move.
+    loop.workspace.append_chat_message("user", "hello")
+    loop.workspace.append_chat_message("assistant", "hi")
+
+    result = await loop.reset_chat()
+    assert isinstance(result, dict)
+    assert set(result.keys()) == {"archived_to", "message_count", "memory_flushed"}
+    assert result["message_count"] == 2
+    assert isinstance(result["memory_flushed"], bool)
+    assert result["archived_to"] is None or result["archived_to"].endswith(".jsonl")

--- a/tests/test_loop.py
+++ b/tests/test_loop.py
@@ -2375,3 +2375,21 @@ async def test_reset_chat_returns_status_dict(tmp_path):
     assert result["message_count"] == 2
     assert isinstance(result["memory_flushed"], bool)
     assert result["archived_to"] is None or result["archived_to"].endswith(".jsonl")
+
+
+@pytest.mark.asyncio
+async def test_reset_chat_archived_to_none_when_no_transcript(tmp_path):
+    """No on-disk transcript → archived_to=None. The dashboard toast
+    branches on this and falls back to 'Conversation cleared' instead of
+    misleading users with a 'saved to Archives' line that never happened.
+    """
+    from src.agent.workspace import WorkspaceManager
+
+    loop = _make_loop()
+    loop.workspace = WorkspaceManager(workspace_dir=str(tmp_path))
+    # No messages, no transcript file on disk.
+    loop._chat_messages = []
+
+    result = await loop.reset_chat()
+    assert result["archived_to"] is None
+    assert result["message_count"] == 0

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -1172,3 +1172,153 @@ class TestDeriveCapabilitiesFromInterface:
         (Path(self._tmpdir) / "INTERFACE.md").mkdir()
         result = _derive_capabilities_from_interface(self._tmpdir)
         assert result["capabilities"] == []
+
+
+class TestChatArchiveSurface:
+    """Cover the list / load / delete surface added for the Archives tab."""
+
+    def setup_method(self):
+        self._tmpdir = tempfile.mkdtemp()
+        self.ws = WorkspaceManager(workspace_dir=self._tmpdir)
+
+    def teardown_method(self):
+        shutil.rmtree(self._tmpdir, ignore_errors=True)
+
+    def _write_archive(self, name: str, lines: list[str] | None = None) -> Path:
+        archive_dir = Path(self._tmpdir) / "chat_archive"
+        archive_dir.mkdir(exist_ok=True)
+        path = archive_dir / name
+        if lines is None:
+            lines = ['{"role":"user","content":"hi","ts":1}']
+        path.write_text("\n".join(lines) + "\n")
+        return path
+
+    def test_list_chat_archives_empty_dir(self):
+        assert self.ws.list_chat_archives() == []
+
+    def test_list_chat_archives_returns_newest_first(self):
+        import os
+
+        a = self._write_archive("2026-01-01_120000.jsonl")
+        b = self._write_archive("2026-01-02_120000.jsonl")
+        c = self._write_archive("2026-01-03_120000.jsonl")
+        # Force distinct mtimes regardless of write order.
+        now = 1_700_000_000
+        os.utime(a, (now, now))
+        os.utime(b, (now + 100, now + 100))
+        os.utime(c, (now + 200, now + 200))
+
+        entries = self.ws.list_chat_archives()
+        names = [e["name"] for e in entries]
+        assert names == [
+            "2026-01-03_120000.jsonl",
+            "2026-01-02_120000.jsonl",
+            "2026-01-01_120000.jsonl",
+        ]
+
+    def test_list_chat_archives_skips_empty_files(self):
+        archive_dir = Path(self._tmpdir) / "chat_archive"
+        archive_dir.mkdir(exist_ok=True)
+        (archive_dir / "2026-01-01_120000.jsonl").write_text("")
+        self._write_archive("2026-01-02_120000.jsonl")
+
+        entries = self.ws.list_chat_archives()
+        names = [e["name"] for e in entries]
+        assert names == ["2026-01-02_120000.jsonl"]
+
+    def test_list_chat_archives_skips_bad_names(self):
+        archive_dir = Path(self._tmpdir) / "chat_archive"
+        archive_dir.mkdir(exist_ok=True)
+        (archive_dir / "garbage.txt").write_text('{"role":"user","content":"x","ts":1}\n')
+        (archive_dir / "evil.jsonl.bak").write_text('{"role":"user","content":"x","ts":1}\n')
+        self._write_archive("2026-01-02_120000.jsonl")
+
+        entries = self.ws.list_chat_archives()
+        names = [e["name"] for e in entries]
+        assert names == ["2026-01-02_120000.jsonl"]
+
+    def test_list_chat_archives_preview_first_user_message(self):
+        self._write_archive(
+            "2026-01-01_120000.jsonl",
+            lines=[
+                '{"role":"assistant","content":"greetings","ts":1}',
+                '{"role":"user","content":"Hello there, how does this work?","ts":2}',
+                '{"role":"assistant","content":"like so","ts":3}',
+            ],
+        )
+        entries = self.ws.list_chat_archives()
+        assert entries[0]["preview"].startswith("Hello there")
+        assert entries[0]["message_count"] == 3
+
+    def test_load_chat_archive_valid(self):
+        self._write_archive(
+            "2026-01-01_120000.jsonl",
+            lines=[
+                '{"role":"user","content":"a","ts":1}',
+                '{"role":"assistant","content":"b","ts":2}',
+            ],
+        )
+        msgs = self.ws.load_chat_archive("2026-01-01_120000.jsonl")
+        assert msgs is not None
+        assert len(msgs) == 2
+        assert msgs[0]["content"] == "a"
+
+    def test_load_chat_archive_rejects_traversal(self):
+        assert self.ws.load_chat_archive("../../etc/passwd") is None
+        assert self.ws.load_chat_archive("..") is None
+        assert self.ws.load_chat_archive("../2026-01-01_120000.jsonl") is None
+
+    def test_load_chat_archive_missing(self):
+        assert self.ws.load_chat_archive("2026-01-01_120000.jsonl") is None
+
+    def test_load_chat_archive_rejects_unknown_extension(self):
+        archive_dir = Path(self._tmpdir) / "chat_archive"
+        archive_dir.mkdir(exist_ok=True)
+        (archive_dir / "garbage.txt").write_text('{"role":"user","content":"x","ts":1}\n')
+        assert self.ws.load_chat_archive("garbage.txt") is None
+
+    def test_delete_chat_archive_valid(self):
+        path = self._write_archive("2026-01-01_120000.jsonl")
+        assert self.ws.delete_chat_archive("2026-01-01_120000.jsonl") is True
+        assert not path.exists()
+
+    def test_delete_chat_archive_rejects_bad_name(self):
+        assert self.ws.delete_chat_archive("..") is False
+        assert self.ws.delete_chat_archive("../foo.jsonl") is False
+        assert self.ws.delete_chat_archive("garbage.txt") is False
+
+    def test_delete_chat_archive_missing_returns_false(self):
+        assert self.ws.delete_chat_archive("2026-01-01_120000.jsonl") is False
+
+    def test_archive_chat_transcript_returns_filename(self):
+        self.ws.append_chat_message("user", "Hello")
+        name = self.ws.archive_chat_transcript()
+        assert isinstance(name, str)
+        assert name.endswith(".jsonl")
+        archive_dir = Path(self._tmpdir) / "chat_archive"
+        assert (archive_dir / name).exists()
+
+    def test_archive_chat_transcript_collision_recovery(self, monkeypatch):
+        """Two resets in the same wall-clock second keep both archives."""
+        from src.agent import workspace as workspace_mod
+
+        class _FixedClock:
+            @classmethod
+            def now(cls, tz=None):
+                # Pin to a single instant so strftime returns the same ts.
+                from datetime import datetime as _dt, timezone as _tz
+                return _dt(2026, 1, 1, 12, 0, 0, tzinfo=tz or _tz.utc)
+
+        monkeypatch.setattr(workspace_mod, "datetime", _FixedClock)
+
+        self.ws.append_chat_message("user", "first")
+        first = self.ws.archive_chat_transcript()
+        assert first == "2026-01-01_120000.jsonl"
+
+        self.ws.append_chat_message("user", "second")
+        second = self.ws.archive_chat_transcript()
+        assert second == "2026-01-01_120000_2.jsonl"
+
+        archive_dir = Path(self._tmpdir) / "chat_archive"
+        assert (archive_dir / first).exists()
+        assert (archive_dir / second).exists()

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -1322,3 +1322,140 @@ class TestChatArchiveSurface:
         archive_dir = Path(self._tmpdir) / "chat_archive"
         assert (archive_dir / first).exists()
         assert (archive_dir / second).exists()
+
+    def test_archive_chat_transcript_concurrent_no_clobber(self, monkeypatch):
+        """Concurrent archivers must never collide on the same slot.
+
+        Pre-fix, two threads racing past the ``if target.exists()`` check
+        could both pick the same suffix, then both ``rename()`` over each
+        other (POSIX rename atomically replaces). With the O_EXCL slot
+        claim, exactly N distinct archives survive for N racers.
+        """
+        import threading
+        from src.agent import workspace as workspace_mod
+
+        class _FixedClock:
+            @classmethod
+            def now(cls, tz=None):
+                from datetime import datetime as _dt, timezone as _tz
+                return _dt(2026, 1, 1, 12, 0, 0, tzinfo=tz or _tz.utc)
+
+        monkeypatch.setattr(workspace_mod, "datetime", _FixedClock)
+
+        # Each thread needs its own workspace+transcript so the race is on
+        # archive-slot claiming, not on the source file itself. Sharing a
+        # single root would have threads racing to rename the same source.
+        roots: list[Path] = []
+        archive_dir = Path(self._tmpdir) / "chat_archive"
+        archive_dir.mkdir(exist_ok=True)
+        for i in range(5):
+            root = Path(self._tmpdir) / f"agent_{i}"
+            root.mkdir()
+            (root / "chat_transcript.jsonl").write_text(
+                f'{{"role":"user","content":"msg{i}","ts":{i}}}\n'
+            )
+            roots.append(root)
+
+        barrier = threading.Barrier(len(roots))
+        results: list[str | None] = [None] * len(roots)
+        errors: list[BaseException] = []
+
+        def _worker(idx: int, root: Path) -> None:
+            try:
+                # Per-thread WorkspaceManager pointing at the SAME shared
+                # archive dir via a symlink trick: rebind CHAT_ARCHIVE_DIR
+                # by giving each agent root a chat_archive symlink into
+                # the shared sink.
+                shared = Path(self._tmpdir) / "chat_archive"
+                (root / "chat_archive").symlink_to(shared, target_is_directory=True)
+                ws = WorkspaceManager(workspace_dir=str(root))
+                barrier.wait(timeout=10)
+                results[idx] = ws.archive_chat_transcript()
+            except BaseException as exc:  # pragma: no cover
+                errors.append(exc)
+
+        threads = [threading.Thread(target=_worker, args=(i, r))
+                   for i, r in enumerate(roots)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join(timeout=10)
+
+        assert not errors, f"worker errors: {errors!r}"
+        names = [n for n in results if n]
+        assert len(names) == len(roots), \
+            f"expected {len(roots)} archives, got {len(names)}: {results!r}"
+        assert len(set(names)) == len(roots), \
+            f"duplicate archive names — race clobber: {sorted(names)}"
+        for name in names:
+            assert (archive_dir / name).exists(), \
+                f"archive {name} reported written but missing on disk"
+
+    def test_archive_retention_evicts_oldest(self, monkeypatch):
+        """Per-agent FIFO cap drops oldest archives once the limit is hit."""
+        import os
+        from src.agent import workspace as workspace_mod
+
+        monkeypatch.setattr(workspace_mod, "_MAX_ARCHIVES_PER_AGENT", 3)
+
+        archive_dir = Path(self._tmpdir) / "chat_archive"
+        archive_dir.mkdir(exist_ok=True)
+        # Seed 5 archives with strictly increasing mtimes so eviction is
+        # deterministic — older files get dropped first.
+        now = 1_700_000_000
+        seeded_names = []
+        for i in range(5):
+            name = f"2026-01-0{i + 1}_120000.jsonl"
+            p = archive_dir / name
+            p.write_text('{"role":"user","content":"hi","ts":1}\n')
+            os.utime(p, (now + i * 100, now + i * 100))
+            seeded_names.append(name)
+
+        # Trigger a new archive write to engage eviction.
+        self.ws.append_chat_message("user", "fresh")
+        new_name = self.ws.archive_chat_transcript()
+        assert new_name is not None
+
+        survivors = sorted(p.name for p in archive_dir.iterdir())
+        assert len(survivors) == 3, f"expected cap=3, got {survivors!r}"
+        # Oldest two seeded archives should be the ones gone.
+        assert seeded_names[0] not in survivors
+        assert seeded_names[1] not in survivors
+
+    def test_load_chat_archive_rejects_oversize(self, monkeypatch, caplog):
+        """Oversize archives return None without buffering the file."""
+        from src.agent import workspace as workspace_mod
+
+        monkeypatch.setattr(workspace_mod, "_MAX_ARCHIVE_LOAD_BYTES", 1024)
+
+        archive_dir = Path(self._tmpdir) / "chat_archive"
+        archive_dir.mkdir(exist_ok=True)
+        name = "2026-01-01_120000.jsonl"
+        # 100 message lines ~ a few KB → comfortably over 1024 bytes.
+        lines = [
+            f'{{"role":"user","content":"message number {i:04d}","ts":{i}}}'
+            for i in range(100)
+        ]
+        (archive_dir / name).write_text("\n".join(lines) + "\n")
+
+        with caplog.at_level("WARNING", logger="agent.workspace"):
+            result = self.ws.load_chat_archive(name)
+        assert result is None
+        assert any("exceeds load cap" in rec.message for rec in caplog.records), \
+            f"expected oversize warning, got: {[r.message for r in caplog.records]}"
+
+    def test_list_chat_archives_count_excludes_bad_lines(self):
+        """message_count tallies only successfully-parsed JSON dicts."""
+        self._write_archive(
+            "2026-01-01_120000.jsonl",
+            lines=[
+                '{"role":"user","content":"ok 1","ts":1}',
+                'not json garbage',
+                '{"role":"assistant","content":"ok 2","ts":2}',
+                '[1, 2, 3]',  # valid JSON, but not a dict
+                '{"role":"user","content":"ok 3","ts":3}',
+            ],
+        )
+        entries = self.ws.list_chat_archives()
+        assert len(entries) == 1
+        assert entries[0]["message_count"] == 3

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -1459,3 +1459,73 @@ class TestChatArchiveSurface:
         entries = self.ws.list_chat_archives()
         assert len(entries) == 1
         assert entries[0]["message_count"] == 3
+
+    def test_evict_old_archives_mtime_tie_preserves_newest(self, monkeypatch):
+        """On 1-second-resolution FS / tied mtimes, the lexicographically
+        largest filename (= newest timestamp prefix) survives. Pre-fix
+        the sort was unstable on ties — the just-written archive could be
+        evicted.
+        """
+        import os
+        from src.agent import workspace as workspace_mod
+
+        monkeypatch.setattr(workspace_mod, "_MAX_ARCHIVES_PER_AGENT", 2)
+
+        archive_dir = Path(self._tmpdir) / "chat_archive"
+        archive_dir.mkdir(exist_ok=True)
+        names = [
+            "2026-01-01_120000.jsonl",
+            "2026-01-01_120001.jsonl",
+            "2026-01-01_120002.jsonl",
+        ]
+        now = 1_700_000_000
+        for n in names:
+            p = archive_dir / n
+            p.write_text('{"role":"user","content":"x","ts":1}\n')
+            os.utime(p, (now, now))
+
+        self.ws._evict_old_archives(archive_dir)
+
+        survivors = sorted(p.name for p in archive_dir.iterdir())
+        # cap=2 → drop one; lexicographically-largest must survive (it's
+        # the newest by timestamp prefix).
+        assert len(survivors) == 2
+        assert names[-1] in survivors, (
+            f"newest archive ({names[-1]}) was evicted on tied mtimes; "
+            f"survivors={survivors!r}"
+        )
+
+    def test_load_chat_archive_filters_non_dict_lines(self):
+        """load_chat_archive surfaces only dict messages — matches
+        list_chat_archives behavior. Pre-fix it accepted any JSON value
+        (lists, scalars) and handed them to the dashboard renderer."""
+        self._write_archive(
+            "2026-01-01_120000.jsonl",
+            lines=[
+                '{"role":"user","content":"hi"}',
+                '42',
+                '["list"]',
+                '{"role":"assistant","content":"hello"}',
+            ],
+        )
+        msgs = self.ws.load_chat_archive("2026-01-01_120000.jsonl")
+        assert msgs is not None
+        assert len(msgs) == 2
+        assert all(isinstance(m, dict) for m in msgs)
+        assert msgs[0]["content"] == "hi"
+        assert msgs[1]["content"] == "hello"
+
+    def test_archive_chat_transcript_returns_none_when_missing(self):
+        """No transcript on disk → archive is a no-op, returns None."""
+        # Don't write a transcript at all.
+        assert self.ws.archive_chat_transcript() is None
+
+    def test_archive_chat_transcript_returns_none_on_empty(self):
+        """Zero-byte transcript → archive is a no-op AND cleans up the
+        empty file so it doesn't masquerade as content next time."""
+        path = Path(self._tmpdir) / "chat_transcript.jsonl"
+        path.write_text("")
+        assert path.stat().st_size == 0
+
+        assert self.ws.archive_chat_transcript() is None
+        assert not path.exists(), "empty transcript should be removed"

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -1306,7 +1306,8 @@ class TestChatArchiveSurface:
             @classmethod
             def now(cls, tz=None):
                 # Pin to a single instant so strftime returns the same ts.
-                from datetime import datetime as _dt, timezone as _tz
+                from datetime import datetime as _dt
+                from datetime import timezone as _tz
                 return _dt(2026, 1, 1, 12, 0, 0, tzinfo=tz or _tz.utc)
 
         monkeypatch.setattr(workspace_mod, "datetime", _FixedClock)
@@ -1332,12 +1333,14 @@ class TestChatArchiveSurface:
         claim, exactly N distinct archives survive for N racers.
         """
         import threading
+
         from src.agent import workspace as workspace_mod
 
         class _FixedClock:
             @classmethod
             def now(cls, tz=None):
-                from datetime import datetime as _dt, timezone as _tz
+                from datetime import datetime as _dt
+                from datetime import timezone as _tz
                 return _dt(2026, 1, 1, 12, 0, 0, tzinfo=tz or _tz.utc)
 
         monkeypatch.setattr(workspace_mod, "datetime", _FixedClock)
@@ -1394,6 +1397,7 @@ class TestChatArchiveSurface:
     def test_archive_retention_evicts_oldest(self, monkeypatch):
         """Per-agent FIFO cap drops oldest archives once the limit is hit."""
         import os
+
         from src.agent import workspace as workspace_mod
 
         monkeypatch.setattr(workspace_mod, "_MAX_ARCHIVES_PER_AGENT", 3)
@@ -1467,6 +1471,7 @@ class TestChatArchiveSurface:
         evicted.
         """
         import os
+
         from src.agent import workspace as workspace_mod
 
         monkeypatch.setattr(workspace_mod, "_MAX_ARCHIVES_PER_AGENT", 2)


### PR DESCRIPTION
## Summary

Conversations archived on `Reset` (`data/agents/{id}/chat_archive/{ts}.jsonl`) had no UI surface — users had to ssh in. This PR surfaces them in two places sharing one backend + one set of JS helpers:

- **Per-agent:** new `Archives` identity tab between Activity and Logs (`/agents/{id}/archives`). Works for any agent.
- **Operator:** `Conversation history` card on the System > operator panel. Same data, pinned to `agent_id='operator'`.

Plus the reset toast now confirms what was preserved, completing the discoverability loop.

## What's in the PR

| Commit | Scope |
|---|---|
| `7e7c1eb` | Initial feature: workspace helpers, agent endpoints, dashboard proxies, JS state + methods, both render surfaces, reset response shape change, tests |
| `670003b` | Codex review fixes (4 must-fix + 1 nice-to-have + CPO copy tweak) |

## Backend (`src/agent/workspace.py`, `src/agent/loop.py`, `src/agent/server.py`, `src/dashboard/server.py`)

- `list_chat_archives` / `load_chat_archive` / `delete_chat_archive` with strict `_ARCHIVE_NAME_RE = ^\d{4}-\d{2}-\d{2}_\d{6}(?:_\d+)?\.jsonl$` and defense-in-depth `resolve().is_relative_to()`.
- `archive_chat_transcript` returns the filename and uses an atomic `os.O_CREAT|O_EXCL` slot claim (`_claim_archive_slot`) to handle same-second collisions race-safely.
- `_MAX_ARCHIVES_PER_AGENT = 100` FIFO eviction at write time bounds disk growth.
- `_MAX_ARCHIVE_LOAD_BYTES = 10 MiB` upfront `stat()` guard prevents oversize loads from spiking agent RSS.
- New endpoints: `GET /chat/archives`, `GET /chat/archives/{name}`, `DELETE /chat/archives/{name}`; dashboard proxies under `/api/agents/{id}/chat-archives`.
- `loop.reset_chat()` now returns `{archived_to, message_count, memory_flushed}`; `/api/agents/{id}/reset` passes them through.

## Frontend (`src/dashboard/static/js/app.js`, `templates/index.html`)

- New `Archives` identity tab — list view with date / count / preview, click-to-expand transcript bubbles, per-archive delete with confirm.
- Same logic embedded in System > operator via `x-init`.
- JS state keyed by `agentId/name` via `_archiveKey` helper + `agentArchivesAgentId` stale-response guard (prevents cross-agent transcript swap when two agents share an archive filename).
- Reset toast now reads `Fresh chat started — previous conversation saved to Archives (N messages)`. Less alarming than the original "memory updated" phrasing.

## Test plan
- [x] `pytest tests/test_workspace.py` — 130/130 pass (4 new: concurrent-archive race, retention cap, oversize rejection, count-excludes-bad-lines)
- [x] `pytest tests/test_loop.py tests/test_agent_server.py tests/test_dashboard.py` — all pass
- [x] `pytest tests/ --ignore=tests/test_e2e*` — 2509/2509 non-e2e tests pass (one unrelated environmental flake on `test_credentials.py::test_lazy_system_credential_providers_still_resolves` — marginal 30s subprocess-timeout that fires identically on `main` due to cold-start import cost on the local machine; CPU time identical between branch and main; expected to pass in CI)
- [x] `ruff check` on all touched src files — clean
- [x] `node -c app.js` — SYNTAX_OK
- [ ] Manual: drill into an agent, click `Archives` tab, expect empty state with message
- [ ] Manual: reset a conversation with N messages, observe the new toast wording, confirm the archive appears in the tab list
- [ ] Manual: expand an archive card, confirm the transcript bubbles render correctly
- [ ] Manual: delete an archive via the trash button, confirm the row disappears
- [ ] Manual: navigate to System > operator, confirm `Conversation history` card renders the operator's archives identically
- [ ] Manual: open two browser tabs to different agents, switch between them, confirm archive lists don't leak (regression guard for codex bug #4)

## Deferred (notes for future work)
- Bulk auto-prune sweep across all agents (per-agent cap is in place; cross-agent disk budget is separate)
- Download-as-JSONL endpoint for archives (one-line endpoint, will add when first user asks)
- Cross-archive search (low ROI for single-tenant)

## Review trail
Two independent reviews ran on the initial feature commit: my own self-review as PE+CPO and an independent codex pass. Codex caught four must-fix issues (one race, two resource-exhaustion vectors, one cross-agent JS state collision) that the self-review missed. All resolved in the follow-up commit.
