### PR TITLE
fix(dashboard): make chat scroll-to-bottom robust against late renders

### DIFF
--- a/src/dashboard/static/js/app.js
+++ b/src/dashboard/static/js/app.js
@@ -8060,14 +8060,35 @@ function dashboard() {
     _scrollTimers: {},
 
     _scrollChat(agentId, force) {
-      if (this._scrollTimers[agentId]) return;
-      this._scrollTimers[agentId] = setTimeout(() => {
-        delete this._scrollTimers[agentId];
+      if (!agentId) return;
+      // The previous dedup silently dropped subsequent triggers — if the
+      // first scroll fired before the chat-messages container had mounted
+      // (Alpine x-for / x-show / async _loadChatHistory), no later attempt
+      // would catch up. Cancel and reschedule so the newest caller wins.
+      if (this._scrollTimers[agentId]) clearTimeout(this._scrollTimers[agentId]);
+      let lastSet = null;
+      const tryScroll = (allowForce) => {
         const el = document.getElementById('chat-messages-' + agentId);
         if (!el) return;
-        // Only auto-scroll if user is near the bottom (within 150px) or forced
-        const nearBottom = force || (el.scrollHeight - el.scrollTop - el.clientHeight < 150);
-        if (nearBottom) el.scrollTop = el.scrollHeight;
+        const distance = el.scrollHeight - el.scrollTop - el.clientHeight;
+        // If we set scrollTop on a prior attempt and it has since drifted,
+        // the user scrolled manually — respect that and stop chasing.
+        const userMoved = lastSet !== null && Math.abs(el.scrollTop - lastSet) > 4;
+        if ((allowForce && force) || (distance < 150 && !userMoved)) {
+          el.scrollTop = el.scrollHeight;
+          lastSet = el.scrollTop;
+        }
+      };
+      this._scrollTimers[agentId] = setTimeout(() => {
+        delete this._scrollTimers[agentId];
+        tryScroll(true);
+        // Late-render safety net — covers (a) Alpine x-for renders that
+        // land after the 50ms timer, (b) async _loadChatHistory replacing
+        // the message array, (c) avatar image-load reflows that grow
+        // scrollHeight after the initial paint. The retries respect
+        // manual user scrolling (force is one-shot via allowForce).
+        setTimeout(() => tryScroll(false), 250);
+        setTimeout(() => tryScroll(false), 800);
       }, 50);
     },
 


### PR DESCRIPTION
## Summary

User-reported regression: after merging #905 the chat sidebar still didn't land on the latest message on refresh + open. Investigation found three failure modes in \`_scrollChat\` that swallowed #905's force-scroll callers in the field.

## Failure modes

1. **Single-shot 50ms timer raced with DOM mount.** Alpine's x-for / x-show / async \`_loadChatHistory\` could finish rendering AFTER the timer fired → \`getElementById\` returned null → scroll silently no-op'd. No retry.
2. **Dedup silently dropped subsequent triggers.** If openChat and the \`messengerSidePanelOpen\` \$watch both fired within 50ms, the second one was skipped. If the first ran against missing DOM, no later attempt caught up.
3. **Avatar image-load reflow.** \`<img>\` tags in chat messages load asynchronously and grow scrollHeight after our initial paint. User ends up parked at pre-image scrollHeight — close to the bottom but visibly not at it.

## Fix
- Cancel + reschedule on each \`_scrollChat\` call so the newest caller wins.
- Guard against null \`agentId\` (would otherwise look for \`chat-messages-null\`).
- First attempt at 50ms keeps the existing force-scroll semantics.
- Two late-render safety-net attempts at 250ms and 800ms re-pin to the bottom IF the user hasn't manually scrolled. Manual scroll detection: scrollTop drift > 4px from the last value we set. force=true is one-shot via an \`allowForce\` flag, so the safety nets don't yank a user who scrolled up to read history.

## Test plan
- [x] \`node -c app.js\` — SYNTAX_OK
- [ ] Manual: refresh /chat → land on latest message (was broken)
- [ ] Manual: refresh on /home (workplace) with side panel previously open → side panel opens scrolled to bottom
- [ ] Manual: click side-panel toggle button cold → land on latest
- [ ] Manual: scroll up in chat, new message arrives → respect scroll position (don't yank back)
- [ ] Manual: scroll to bottom, new message arrives → auto-scroll (sticky)