### PR TITLE
fix(agent): silence benign already-terminal auto-close warnings + snapshot wake message

### DIFF
--- a/src/agent/loop.py
+++ b/src/agent/loop.py
@@ -1839,10 +1839,33 @@ class AgentLoop:
             resp = getattr(e, "response", None)
             http_status = getattr(resp, "status_code", None)
             if isinstance(http_status, int) and 400 <= http_status < 500:
-                logger.warning(
-                    "Auto-close %s → %s rejected by state machine (%s): %s",
-                    task_id, status, http_status, e,
-                )
+                # Sub-case: the rejection is "task is already terminal"
+                # — exactly what happens when the LLM explicitly called
+                # ``complete_task`` mid-chat and then the chat also hit
+                # ``tool_limit_reached`` or an exception. This is the
+                # COMMON production path (PR #912 made it so), not an
+                # anomaly. Log at DEBUG so ops aren't paged for it.
+                # Detect by parsing the mesh's InvalidStatusTransition
+                # message ("cannot move … from 'done'/'failed'/...").
+                err_text = ""
+                try:
+                    err_text = (getattr(resp, "text", "") or str(e)).lower()
+                except Exception:
+                    err_text = str(e).lower()
+                if any(
+                    f"from '{terminal}'" in err_text
+                    for terminal in ("done", "failed", "cancelled")
+                ):
+                    logger.debug(
+                        "Auto-close %s → %s noop: task already terminal "
+                        "(agent declared completion explicitly): %s",
+                        task_id, status, err_text[:200],
+                    )
+                else:
+                    logger.warning(
+                        "Auto-close %s → %s rejected by state machine (%s): %s",
+                        task_id, status, http_status, e,
+                    )
             else:
                 # No HTTP response or 5xx → the originating agent will
                 # never see this task close. Surface loudly so operators

--- a/tests/test_coordination.py
+++ b/tests/test_coordination.py
@@ -1078,6 +1078,61 @@ class TestCoordinationV2:
         assert "research handoff" in call_kwargs["title"]
 
     @pytest.mark.asyncio
+    async def test_hand_off_v2_wake_message_prompts_explicit_complete_task(self):
+        """Pin the wake-message format. Reason: PR #912 reversed the
+        auto-close semantics so tasks ONLY close on explicit
+        ``complete_task``. The recipient agent learns this from the
+        wake message text. If the format silently changes (e.g. a
+        well-meaning refactor strips the instruction or the task_id),
+        recipients won't know to call complete_task, and every
+        handed-off task will dangle in ``working``.
+
+        Asserts the substrings that matter for the LLM contract:
+          1. The task_id is in the message (recipient needs it for
+             the complete_task call).
+          2. The ``complete_task`` tool name is mentioned with the
+             ``task_key='{task_id}'`` template literal.
+          3. The ``summary='...'`` parameter is mentioned so
+             recipients know to include one.
+          4. The ``update_status('blocked')`` alternative is
+             mentioned for the can't-finish case.
+        """
+        from src.agent.builtins.coordination_tool import hand_off
+
+        mc = _make_mesh_client(agent_id="scout", v2_enabled=True)
+        mc.list_agents.return_value = {"analyst": {"role": "analyst"}}
+        mc.create_task.return_value = {
+            "id": "task_xyz",
+            "creator": "scout",
+            "assignee": "analyst",
+            "title": "research",
+            "status": "pending",
+        }
+
+        await hand_off(
+            to="analyst",
+            summary="research handoff",
+            mesh_client=mc,
+        )
+
+        mc.wake_agent.assert_awaited_once()
+        wake_call = mc.wake_agent.await_args
+        # First positional after ``to`` is the message string.
+        wake_message = wake_call.args[1]
+
+        # 1. Task ID must be in the message body.
+        assert "task_xyz" in wake_message
+        # 2. complete_task with task_key= template.
+        assert "complete_task" in wake_message
+        assert "task_key='task_xyz'" in wake_message
+        # 3. summary= parameter prompt.
+        assert "summary=" in wake_message
+        # 4. update_status('blocked') escape hatch.
+        assert "update_status('blocked'" in wake_message
+        # 5. Sanity: still carries the original summary text.
+        assert "research handoff" in wake_message
+
+    @pytest.mark.asyncio
     async def test_hand_off_v2_with_data_writes_artifact(self):
         from src.agent.builtins.coordination_tool import hand_off
 

--- a/tests/test_task_lifecycle.py
+++ b/tests/test_task_lifecycle.py
@@ -244,6 +244,80 @@ async def test_chat_auto_fails_task_on_chat_session_limit():
     assert calls[1].kwargs.get("error") == "chat_session_limit_reached"
 
 
+# ── 3d. auto-close noop when task is already terminal ───────────
+
+@pytest.mark.asyncio
+async def test_auto_close_noop_logs_debug_when_task_already_terminal(caplog):
+    """COMMON production path after PR #912: agent explicitly calls
+    ``complete_task`` mid-chat → task=done. Chat continues and hits
+    tool_limit (or any failure mode). Wrapper auto-fails → mesh 400
+    "cannot move from 'done'". WITHOUT this discrimination, every
+    such handoff would emit a WARNING log and flood ops alerts.
+
+    Test: simulate a 400 carrying "cannot move … from 'done'" and
+    assert the WARNING was downgraded to DEBUG. State-conflict 400s
+    for OTHER reasons (e.g. invalid status name) still WARN.
+    """
+    import logging
+    from unittest.mock import MagicMock as _MM
+
+    loop = _make_loop_with_mocks()
+
+    fake_resp = _MM()
+    fake_resp.status_code = 400
+    fake_resp.text = "cannot move task_xyz from 'done' to 'failed'"
+    err = Exception("400 Bad Request")
+    err.response = fake_resp
+    loop.mesh_client.set_task_status = AsyncMock(side_effect=err)
+
+    caplog.set_level(logging.DEBUG, logger="agent.loop")
+    await loop._auto_close_task("task_xyz", "failed", error="max_iterations_reached")
+
+    warning_records = [
+        r for r in caplog.records if r.levelno >= logging.WARNING
+    ]
+    assert not warning_records, (
+        f"already-terminal 400 should not WARN, got: "
+        f"{[r.getMessage() for r in warning_records]}"
+    )
+    # And the noop IS logged at DEBUG so ops can still trace if needed.
+    debug_records = [
+        r for r in caplog.records
+        if r.levelno == logging.DEBUG and "noop" in r.getMessage()
+    ]
+    assert len(debug_records) == 1, (
+        f"expected DEBUG noop log, got: {[r.getMessage() for r in caplog.records]}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_auto_close_unrelated_4xx_still_warns(caplog):
+    """Sanity: state-conflict 400s for reasons OTHER than
+    already-terminal still emit WARNING. The DEBUG-downgrade is
+    narrow — only "cannot move … from 'done'/'failed'/'cancelled'"
+    matches. A 400 like "invalid status name 'donr'" should still
+    warn because it's a real client bug worth seeing."""
+    import logging
+    from unittest.mock import MagicMock as _MM
+
+    loop = _make_loop_with_mocks()
+
+    fake_resp = _MM()
+    fake_resp.status_code = 400
+    fake_resp.text = "invalid status 'donr'"
+    err = Exception("400 Bad Request")
+    err.response = fake_resp
+    loop.mesh_client.set_task_status = AsyncMock(side_effect=err)
+
+    caplog.set_level(logging.WARNING, logger="agent.loop")
+    await loop._auto_close_task("task_xyz", "donr")
+
+    warning_records = [
+        r for r in caplog.records if r.levelno >= logging.WARNING
+    ]
+    assert len(warning_records) == 1
+
+
 # ── 3b. explicit complete_task path is the ONLY way to mark done ──
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Principal-engineer review of PR #912 surfaced two concerns worth fixing now:

### 1. Noisy WARNINGs on the common already-terminal path

After PR #912, this scenario is COMMON in production:
- Agent explicitly calls ``complete_task`` mid-chat → task=done
- Chat continues, hits ``tool_limit_reached`` or an exception
- Wrapper auto-fails → mesh returns 400 *"cannot move … from 'done'"*

Every such handoff was emitting a WARNING — flooding ops alerts for a benign concurrency pattern (it's the LLM's explicit completion racing with the wrapper's failure-safety net).

**Fix**: ``_auto_close_task`` now parses 400 response bodies and downgrades the *"cannot move … from '{terminal}'"* pattern to DEBUG. State-conflict 4xx for OTHER reasons (invalid status name, etc.) still WARN — that's a real client bug worth seeing.

### 2. No regression test for the wake-message format

PR #912 reversed the auto-close semantics. The recipient agent learns about the new explicit-completion contract from the wake message text alone. If the format silently changes (a well-meaning refactor strips the instruction, the task_id formatting breaks, etc.), every handed-off task will dangle in ``working`` because recipients won't know to call ``complete_task``.

**Fix**: new ``test_hand_off_v2_wake_message_prompts_explicit_complete_task`` snapshot-asserts the substrings that matter for the LLM contract:
- ``task_xyz`` (the task_id in the body)
- ``complete_task`` with ``task_key='task_xyz'`` template
- ``summary=`` parameter prompt
- ``update_status('blocked'`` escape hatch

## Test plan

- [x] ``test_hand_off_v2_wake_message_prompts_explicit_complete_task`` — wake format snapshot.
- [x] ``test_auto_close_noop_logs_debug_when_task_already_terminal`` — pins WARNING → DEBUG downgrade for the common already-terminal case.
- [x] ``test_auto_close_unrelated_4xx_still_warns`` — sanity guard that the downgrade stays narrow.
- [x] Full non-e2e suite: 6163 passed, 0 failed.
- [x] Ruff clean.
- [x] Codex review: clean. *"I did not identify any discrete, actionable correctness issues introduced by this diff."*

## Out of scope (subagent review pass also flagged these — explanations below)

- **E2E test for wake → complete_task → back-edge** — already covered piecewise. ``test_terminal_transition_writes_back_edge_for_agent_origin`` exercises the server-side back-edge with summary; ``test_explicit_complete_task_forwards_summary_to_back_edge`` exercises the agent-side. A single test that wires both via ASGITransport would be redundant and heavy.
- **Legacy hand_off task_id plumbing** — legacy uses blackboard, not orchestration. No task_id semantic exists there. V2 has been the default for a while; legacy is essentially dead code.
- **Stale-task reaper** — known limitation, deferred to a separate PR. Documented in CLAUDE.md constraint #16.
- **chat / chat_stream wrapper duplication** — cosmetic, ~150 lines. Worth a follow-up refactor but not blocking.
- **Wake message template extraction** — cosmetic; only one call site today.