### PR TITLE
fix(dashboard): nav tab shows 'Teams (N)' with team count

### DIFF
--- a/src/dashboard/templates/index.html
+++ b/src/dashboard/templates/index.html
@@ -201,12 +201,11 @@
               <template x-if="tab.id === 'system'">
                 <svg fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="4" y1="21" x2="4" y2="14"/><line x1="4" y1="10" x2="4" y2="3"/><line x1="12" y1="21" x2="12" y2="12"/><line x1="12" y1="8" x2="12" y2="3"/><line x1="20" y1="21" x2="20" y2="16"/><line x1="20" y1="12" x2="20" y2="3"/><line x1="1" y1="14" x2="7" y2="14"/><line x1="9" y1="8" x2="15" y2="8"/><line x1="17" y1="16" x2="23" y2="16"/></svg>
               </template>
-              <!-- Phase 1: ``Agents`` becomes ``Team`` (and the (N)
-                   running counter rides along); ``Board``→``Work``,
-                   ``System``→``Settings``. Tab IDs stay frozen so URLs
-                   / routes don't break. -->
-              <span x-text="(tab.id === 'fleet' && agents.length)
-                  ? 'Team (' + runningAgents.length + ')'
+              <!-- Tab IDs stay frozen so URLs / routes don't break;
+                   user-facing labels are: fleet→Teams (with team count
+                   in parens), workplace→Work, system→Settings. -->
+              <span x-text="tab.id === 'fleet'
+                  ? 'Teams (' + teams.length + ')'
                   : tabLabelFor(tab)"></span>
               <!-- unread event badge removed -->
             </button>


### PR DESCRIPTION
## Summary
The fleet nav tab was still rendering as 'Team (N)' with N = agent count — a leftover from before the project→team rename. Now renders 'Teams (N)' with N = teams.length so the tab matches the section it opens.

## Test plan
- [x] Reload dashboard, fleet tab in top nav shows "Teams (N)" where N matches the team count under that tab
- [x] N reads 0 cleanly when there are no teams (clear empty state)
- [x] No console error / TypeError on first render