### PR TITLE
fix(dashboard): chat scroll-to-bottom — duplicate id collision (real root cause)

### DIFF
--- a/src/dashboard/static/js/app.js
+++ b/src/dashboard/static/js/app.js
@@ -1424,6 +1424,31 @@ function dashboard() {
         document.title = this._buildTitle();
       }
 
+      // Operator chat container is x-show="operatorReady" — until fetchAgents
+      // resolves it's display:none and any scroll fired against it no-ops.
+      // Re-fire once when the gate flips so users land on the latest message
+      // rather than the top of the restored history.
+      this.$watch('operatorReady', (val, oldVal) => {
+        if (!val || oldVal) return;
+        this.$nextTick(() => {
+          if (this.activeTab === 'chat' || this.messengerSidePanelOpen) {
+            this._scrollChat(this.activeChatId || 'operator', true);
+          }
+        });
+      });
+
+      // Side-panel open transition — the chat-messages container mounts
+      // at scrollTop=0; force a scroll on the open edge so click-toggles
+      // land on the latest message. localStorage-restored opens are
+      // handled below since the assignment already happened during state
+      // restore (the watcher only fires on subsequent changes).
+      this.$watch('messengerSidePanelOpen', (val) => {
+        if (!val) return;
+        this.$nextTick(() => {
+          if (this.activeChatId) this._scrollChat(this.activeChatId, true);
+        });
+      });
+
       // Ensure operator chat is initialized when landing on the chat tab
       if (this.activeTab === 'chat' || initRoute.tab === 'chat') {
         if (!this.openChats.includes('operator')) {
@@ -1436,6 +1461,15 @@ function dashboard() {
           this._scrollChat('operator', true);
           const el = document.getElementById('operator-chat-input');
           if (el) el.focus();
+        });
+      }
+
+      // Side panel restored from localStorage above (line ~1233) — the
+      // $watch above doesn't fire on init-time assignment, so scroll
+      // explicitly here.
+      if (this.messengerSidePanelOpen && this.activeChatId) {
+        this.$nextTick(() => {
+          this._scrollChat(this.activeChatId, true);
         });
       }
 
@@ -1819,6 +1853,9 @@ function dashboard() {
           this.chatPanelMinimized = false;
           this._loadChatHistory(this.activeChatId || 'operator');
           this.$nextTick(() => {
+            // Without this, the side-panel mounts at scrollTop=0 even
+            // though restored history is already in the container.
+            this._scrollChat(this.activeChatId || 'operator', true);
             const el = document.getElementById('operator-chat-input');
             if (el) el.focus();
           });
@@ -7621,6 +7658,7 @@ function dashboard() {
         if (!resp.ok) return;
         const data = await resp.json();
         const localMsgs = this.chatHistories[agentId] || [];
+        const wasEmpty = localMsgs.length === 0;
         if (!data.messages || data.messages.length === 0) {
           // Server returned empty — agent may be restarting or transcript not yet
           // initialized. Preserve local messages to avoid losing visible history.
@@ -7670,7 +7708,11 @@ function dashboard() {
           ? [...serverMsgs, ...trailing]
           : serverMsgs;
         this._saveChatToSession();
-        this.$nextTick(() => this._scrollChat(agentId));
+        // Force scroll when the local cache was empty (first fetch on
+        // mount) — the sticky nearBottom heuristic would otherwise treat
+        // scrollTop=0 as "user scrolled to top" and skip. Live-update
+        // refreshes keep the conservative behavior.
+        this.$nextTick(() => this._scrollChat(agentId, wasEmpty));
       } catch (e) {
         console.debug('_loadChatHistory failed for', agentId, e.message || e);
       }
@@ -7811,14 +7853,53 @@ function dashboard() {
     _scrollTimers: {},
 
     _scrollChat(agentId, force) {
-      if (this._scrollTimers[agentId]) return;
+      if (!agentId) return;
+      // Newest caller wins — the original dedup silently dropped subsequent
+      // triggers, so if the first attempt fired before the chat container
+      // had mounted (Alpine x-for / x-show / async _loadChatHistory), no
+      // later attempt would catch up.
+      if (this._scrollTimers[agentId]) clearTimeout(this._scrollTimers[agentId]);
+      let lastSet = null;
+      const findVisible = () => {
+        // The chat for a given agent can render in two surfaces: the main
+        // /chat tab (static id="chat-messages-operator", line ~481 in
+        // index.html) and the slide-out side panel (dynamic
+        // id="side-chat-messages-{agentId}"). When activeChatId='operator'
+        // both surfaces want to scroll. The main-tab element is always
+        // mounted via x-show (never removed from DOM), so a plain
+        // getElementById('chat-messages-operator') would always return the
+        // main-tab element — which is display:none whenever activeTab !==
+        // 'chat'. Pick whichever element is actually visible (offsetParent
+        // is null for display:none) so the sidebar surface gets scrolled
+        // when it's the one the user sees.
+        const candidates = [
+          document.getElementById('chat-messages-' + agentId),
+          document.getElementById('side-chat-messages-' + agentId),
+        ].filter(Boolean);
+        return candidates.find(el => el.offsetParent !== null) || candidates[0] || null;
+      };
+      const tryScroll = (allowForce) => {
+        const el = findVisible();
+        if (!el) return;
+        const distance = el.scrollHeight - el.scrollTop - el.clientHeight;
+        // If we set scrollTop earlier and it has since drifted, the user
+        // scrolled manually — respect them and stop chasing.
+        const userMoved = lastSet !== null && Math.abs(el.scrollTop - lastSet) > 4;
+        if ((allowForce && force) || (distance < 150 && !userMoved)) {
+          el.scrollTop = el.scrollHeight;
+          lastSet = el.scrollTop;
+        }
+      };
       this._scrollTimers[agentId] = setTimeout(() => {
         delete this._scrollTimers[agentId];
-        const el = document.getElementById('chat-messages-' + agentId);
-        if (!el) return;
-        // Only auto-scroll if user is near the bottom (within 150px) or forced
-        const nearBottom = force || (el.scrollHeight - el.scrollTop - el.clientHeight < 150);
-        if (nearBottom) el.scrollTop = el.scrollHeight;
+        tryScroll(true);
+        // Late-render safety net — covers (a) Alpine x-for renders that
+        // land after the 50ms timer, (b) async _loadChatHistory replacing
+        // the message array, (c) avatar image-load reflows that grow
+        // scrollHeight after the initial paint. Retries respect manual
+        // user scrolling (force is one-shot via allowForce).
+        setTimeout(() => tryScroll(false), 250);
+        setTimeout(() => tryScroll(false), 800);
       }, 50);
     },
 

--- a/src/dashboard/templates/index.html
+++ b/src/dashboard/templates/index.html
@@ -8021,8 +8021,13 @@
             </button>
           </template>
         </div>
-        <!-- Messages area -->
-        <div role="log" aria-live="polite" class="flex-1 overflow-y-auto overflow-x-hidden px-4 py-3 space-y-2" :id="'chat-messages-' + activeChatId">
+        <!-- Messages area — `side-` prefix avoids a duplicate-id collision
+             with the main /chat tab's `id="chat-messages-operator"` (line
+             ~481). Both surfaces can have the same agentId active; the
+             main-tab element is always mounted via x-show and is the FIRST
+             match in document order, so getElementById would otherwise pick
+             a display:none element and the scroll would silently no-op. -->
+        <div role="log" aria-live="polite" class="flex-1 overflow-y-auto overflow-x-hidden px-4 py-3 space-y-2" :id="'side-chat-messages-' + activeChatId">
           <!-- Collapse bar mirrors the operator-panel behaviour: when
                the active chat is the operator and there are ≥2
                unresolved pending actions, hide the cards behind a

--- a/tests/test_dashboard_ui.py
+++ b/tests/test_dashboard_ui.py
@@ -323,9 +323,11 @@ class TestTabLabelVocabulary:
         )
 
     def test_fleet_running_count_uses_team_word(self):
-        # The dynamic-label expression in the top-nav swaps "Agents (N)"
-        # for "Team (N)" once Phase 2 ships.
-        assert "'Team (' + runningAgents.length" in _INDEX_HTML
+        # PR #915 swapped the fleet-tab label from "Team (runningAgents)"
+        # to "Teams (teams.length)" so the count in parens matches the
+        # section the tab opens. The "Agents (..." form must still be
+        # absent — that was the pre-Phase-2 wording.
+        assert "'Teams (' + teams.length" in _INDEX_HTML
         assert "'Agents (' + runningAgents.length" not in _INDEX_HTML
 
 


### PR DESCRIPTION
## The real root cause

User reported the sidebar chat lands at the top instead of the latest message on refresh + open. Three rounds of fixes (#905, #911, and the toggleSidePanel changes) all looked correct in code review but didn't help in production — because they were scrolling the wrong DOM element.

**Duplicate id collision.** Two elements share `id="chat-messages-operator"`:

- **Main /chat tab** (`templates/index.html:481`): `<div x-show="operatorReady" id="chat-messages-operator">` — STATIC id, always mounted (x-show only toggles `display:none`)
- **Side panel** (`templates/index.html:8025`): `<div :id="'chat-messages-' + activeChatId">` — DYNAMIC id, also resolves to `chat-messages-operator` when the sidebar shows the operator chat

When the user is on `/home` with the sidebar open, the sidebar is visible and the main /chat tab is `display:none`. `document.getElementById('chat-messages-operator')` returns the FIRST match in document order = the main-tab element. That element has `scrollHeight=0` because it's `display:none`. We set `scrollTop = 0` which equals `scrollHeight=0`, no visible effect. The actual visible sidebar container never gets touched.

PRs #905 + #911 added correct scroll-trigger plumbing and a retry safety net — but every single retry scrolled the wrong (hidden) element.

## Additional context: silent revert

While investigating I discovered that the project→team rename PRs (#909, #914) were rebased on a stale base and silently reverted #905, #911, the entire chat-archives feature (#910), and the PR #902 follow-up Bug B/C fixes. The textual diff merged clean but the squash didn't include those interim commits.

This PR restores #905 + #911 (scroll triggers + retries) AND adds the real fix for the duplicate-id collision. **A separate restore PR is still needed** for the chat-archives feature and the #902 follow-up Bug B/C work, which are out of scope for this hotfix.

## The fix

1. **Side-panel container renamed** to `side-chat-messages-{activeChatId}` (unique prefix, no collision).
2. **`_scrollChat` prefers the visible candidate** via `offsetParent != null` check — both ID prefixes are queried and the visible one wins.
3. **Restored #905's four scroll-trigger sites**: `$watch('operatorReady')`, `$watch('messengerSidePanelOpen')`, `init()` post-restore explicit scroll, `toggleSidePanel` open branch.
4. **Restored #911's late-render retry logic**: cancel-and-reschedule (newest caller wins), plus 250ms and 800ms safety-net attempts that respect manual user scrolling.
5. **Restored `_loadChatHistory`'s `wasEmpty` force-on-first-fetch** so async fetch arrivals land on the latest message when the local cache was empty.

## Test plan
- [x] `node -c app.js` — SYNTAX_OK
- [ ] Manual: refresh on `/home` with sidebar previously open → land on latest message (was broken — this is the user's reported case)
- [ ] Manual: cold-click sidebar toggle on `/home` → land on latest message
- [ ] Manual: refresh on `/chat` → land on latest message in main tab
- [ ] Manual: scroll up in chat → new message arrives → respect scroll position
- [ ] Manual: at bottom → new message arrives → auto-scroll
- [ ] Manual: switch active chat in sidebar between agents → land on bottom for each
