### PR TITLE
fix(host,agent,coordination): make operator→agent seam observable and recoverable

### DIFF
--- a/docs/triggering.md
+++ b/docs/triggering.md
@@ -207,6 +207,19 @@ Heartbeats skip the LLM dispatch entirely (zero cost) when all four conditions a
 
 This makes always-on heartbeats economically viable even at high frequencies. See `src/host/cron.py:394`.
 
+#### Forcing the LLM to run every tick
+
+Pipeline-kicker agents — those whose entire job is to wake up on a schedule and decide what to do next — typically have no probes registered and ship with an empty `HEARTBEAT.md`. Under the four-condition skip-LLM check above they would never actually wake. Set `force_llm: true` on the cron job to bypass the skip and dispatch to the LLM on every tick regardless of the other predicates:
+
+```bash
+curl -X PUT http://localhost:8420/mesh/cron/<job_id> \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer $MESH_AUTH_TOKEN" \
+  -d '{"force_llm": true}'
+```
+
+You're opting out of the cost optimization — pick `force_llm: true` only for agents that genuinely need to think every tick. `force_llm` is in `_UPDATABLE_FIELDS` so you can flip it at runtime; it persists across mesh restarts via `config/cron.json`.
+
 ## Tool-Mode Cron
 
 In addition to dispatching a message to an agent (message mode) or running a heartbeat (heartbeat mode), cron jobs can invoke a tool directly — **without any LLM call**. This is useful for fully deterministic periodic operations where no reasoning is needed.

--- a/src/agent/builtins/coordination_tool.py
+++ b/src/agent/builtins/coordination_tool.py
@@ -211,10 +211,12 @@ async def hand_off(
     # Wake the target agent so it processes the task immediately
     # instead of waiting for its next heartbeat.  Pass origin so
     # the mesh lane worker can auto-notify the originating user.
-    # Wake failures are surfaced to the caller via ``wake_failed`` +
-    # ``wake_error`` (handed_off stays True — the task IS queued in
-    # SQLite, only the wake signal failed; the caller can decide
-    # whether to retry the wake or wait for cron).
+    # Bug 2 fix: when the wake fails the contract used to claim
+    # ``handed_off: true`` AND ``wake_failed: true`` — LLMs read
+    # ``handed_off`` and reported success to the user while the recipient
+    # never woke. We now flip ``handed_off: false`` and add
+    # ``task_queued: true`` so the LLM sees a partial outcome and can
+    # decide whether to retry or wait for the recipient's heartbeat.
     wake_error: str | None = None
     try:
         await mesh_client.wake_agent(
@@ -234,7 +236,7 @@ async def hand_off(
         logger.warning("Wake for %s failed (task still queued): %s", to, e)
 
     result = {
-        "handed_off": True,
+        "handed_off": wake_error is None,
         "to": to,
         "task_key": task_key,
         "handoff_id": handoff_id,
@@ -242,8 +244,13 @@ async def hand_off(
     if output_key:
         result["output_key"] = output_key
     if wake_error is not None:
+        result["task_queued"] = True
         result["wake_failed"] = True
         result["wake_error"] = wake_error
+        result["recovery_hint"] = (
+            "Recipient will discover via next heartbeat (default 15min). "
+            "Operator can retry hand_off or wait."
+        )
     return result
 
 
@@ -624,12 +631,17 @@ async def _hand_off_v2(
 
     # Wake the target so they pick up the task immediately. The task
     # is queued in SQLite either way; wake failures are surfaced to the
-    # caller via ``wake_failed`` + ``wake_error`` so they can decide
-    # whether to retry the wake or wait for the recipient's next cron.
+    # caller via ``handed_off=False`` + ``task_queued=True`` so they can
+    # decide whether to retry the wake or wait for the recipient's next
+    # cron. Bug 2 (PR R2): the prior contract claimed ``handed_off: true``
+    # alongside ``wake_failed: true`` — LLMs read ``handed_off`` and
+    # reported success while the recipient never woke. ``task_queued``
+    # signals the durable row exists; the recovery hint tells the LLM
+    # what will happen next.
     #
-    # Bug 2 fix: forward the task_id on the wake so the recipient's lane
-    # → /chat → loop chain auto-closes the task on completion. Without
-    # this, the Task row would sit at pending forever.
+    # Bug 2 fix (earlier): forward the task_id on the wake so the
+    # recipient's lane → /chat → loop chain auto-closes the task on
+    # completion. Without this, the Task row would sit at pending forever.
     wake_error: str | None = None
     try:
         await mesh_client.wake_agent(
@@ -650,7 +662,7 @@ async def _hand_off_v2(
         logger.warning("Wake for %s failed (task still queued): %s", to, e)
 
     result = {
-        "handed_off": True,
+        "handed_off": wake_error is None,
         "to": to,
         "handoff_id": task_id,
         "task_key": task_id,
@@ -659,8 +671,13 @@ async def _hand_off_v2(
     if artifact_ref:
         result["output_key"] = artifact_ref
     if wake_error is not None:
+        result["task_queued"] = True
         result["wake_failed"] = True
         result["wake_error"] = wake_error
+        result["recovery_hint"] = (
+            "Recipient will discover via next heartbeat (default 15min). "
+            "Operator can retry hand_off or wait."
+        )
     return result
 
 

--- a/src/agent/loop.py
+++ b/src/agent/loop.py
@@ -738,6 +738,11 @@ class AgentLoop:
                     messages=messages,
                     tools=available_tools,
                 )
+                # Bug 1 (codex P2 r2): tick after the LLM call returns —
+                # a single deep-research call can run >5 min, and bumping
+                # only at iteration head would let the staleness check fire
+                # during a perfectly healthy turn.
+                self._bump_liveness()
                 total_tokens += llm_response.tokens_used
                 if assignment.token_budget:
                     assignment.token_budget.record_usage(llm_response.tokens_used, self.llm.default_model)
@@ -808,6 +813,12 @@ class AgentLoop:
                     tool_results = await self._run_tools_parallel(
                         llm_response.tool_calls,
                     )
+                    # Bug 1 (codex P2 r2): tick after tool execution — a
+                    # long-running shell or browser action can sit at the
+                    # 300s _TOOL_TIMEOUT cap. Without this bump the next
+                    # iteration head might already be past the staleness
+                    # threshold even though the loop is healthy.
+                    self._bump_liveness()
                     for i, (result_str, _result) in enumerate(tool_results):
                         tool_msg = {
                             "role": "tool",
@@ -1288,7 +1299,7 @@ class AgentLoop:
 
     # ── Heartbeat mode ────────────────────────────────────────
 
-    async def execute_heartbeat(self, message: str) -> dict:
+    async def execute_heartbeat(self, message: str, *, force_llm: bool = False) -> dict:
         """Execute an autonomous heartbeat — stateless, separate from chat.
 
         Returns a structured dict with response, tools used, duration, etc.
@@ -1296,6 +1307,13 @@ class AgentLoop:
         _heartbeat_mode ContextVar so tools can detect heartbeat context.
         Notifications are still persisted to the chat transcript so users
         can find them in chat history.
+
+        ``force_llm`` (Bug 6 — codex P2 r2): pipeline-kicker agents have
+        no probes and ship with an empty HEARTBEAT.md, which makes the
+        ``no_heartbeat_rules`` skip below fire on every tick. When the
+        cron job sets ``force_llm: true`` the dispatcher forwards the
+        flag (via ``x-force-llm`` header) so the LLM is invoked anyway.
+        The ``agent_busy`` skip is NOT bypassed — busy is busy.
         """
         # Restrict operator to heartbeat-only tools during unsupervised execution.
         # Non-operator agents have _allowed_tools=None, so the swap is skipped.
@@ -1311,7 +1329,13 @@ class AgentLoop:
 
             # Skip the LLM call entirely when HEARTBEAT.md has no actionable
             # content and no goals are set — saves tokens on empty heartbeats.
-            if self.workspace and _is_heartbeat_empty(self.workspace.load_heartbeat_rules()):
+            # Bug 6 fix: ``force_llm`` lets the operator opt out of this
+            # optimization for pipeline-kicker agents.
+            if (
+                not force_llm
+                and self.workspace
+                and _is_heartbeat_empty(self.workspace.load_heartbeat_rules())
+            ):
                 # Still need to check goals before skipping
                 goals = await self._fetch_goals()
                 if not goals:
@@ -1600,6 +1624,12 @@ class AgentLoop:
                     tool_results = await self._run_tools_parallel(
                         llm_response.tool_calls,
                     )
+                    # Bug 1 (codex P2 r2): tick after tool execution — a
+                    # long-running shell or browser action can sit at the
+                    # 300s _TOOL_TIMEOUT cap. Without this bump the next
+                    # iteration head might already be past the staleness
+                    # threshold even though the loop is healthy.
+                    self._bump_liveness()
                     for i, (result_str, _result) in enumerate(tool_results):
                         hb_tool_msg = {
                             "role": "tool",

--- a/src/agent/loop.py
+++ b/src/agent/loop.py
@@ -307,6 +307,21 @@ class AgentLoop:
         # Reference to the active messages list — set during tool execution
         # so skills.execute() can inject it into provenance-gated tools.
         self._current_messages: list[dict] = []
+        # Liveness signal (Bug 1): single-task asyncio model means no lock
+        # needed — the loop only ticks one iteration at a time. The
+        # mesh health monitor reads these via /status to detect a dead
+        # inner loop with a live FastAPI thread.
+        self._last_iteration_ts: float | None = None
+        self._iterations_since_boot: int = 0
+
+    def _bump_liveness(self) -> None:
+        """Stamp the last-iteration timestamp + bump the boot-relative counter.
+
+        Called at the head of every iteration in execute_task and per-round
+        in the chat loops. Cheap on purpose — no I/O, no lock.
+        """
+        self._last_iteration_ts = time.time()
+        self._iterations_since_boot += 1
 
     @property
     def _skill_filter_kw(self) -> dict:
@@ -591,31 +606,58 @@ class AgentLoop:
             total_tokens = checkpoint["tokens_used"]
             assignment_json = checkpoint["assignment_json"]
 
-            # Reconcile TokenBudget mutable state
-            if assignment.token_budget:
-                assignment.token_budget.used_tokens = checkpoint["budget_used_tokens"]
-                assignment.token_budget.estimated_cost_usd = checkpoint["budget_estimated_cost"]
+            # Bug 5 (stale checkpoint rejection): if the persisted iteration
+            # is already at or past MAX_ITERATIONS, resuming would skip the
+            # for-loop entirely and immediately fall through to the
+            # "Max iterations reached" branch — looking like a 0-token,
+            # 0-iteration completion from outside. Detect that here and
+            # start fresh, clearing the corrupt checkpoint.
+            if start_iteration >= self.MAX_ITERATIONS:
+                logger.warning(
+                    "Discarding stale checkpoint for task=%s (iteration %d "
+                    ">= MAX %d) — starting fresh",
+                    assignment.task_id, start_iteration, self.MAX_ITERATIONS,
+                )
+                if self.memory:
+                    try:
+                        await self.memory._run_db(self.memory.clear_task_checkpoint)
+                    except Exception as clr_err:
+                        logger.warning(
+                            "Failed to clear stale checkpoint: %s", clr_err,
+                        )
+                checkpoint = None
+                total_tokens = 0
+                start_iteration = 0
+                assignment_json = assignment.model_dump_json()
+                messages = await self._build_initial_context(assignment)
+                if self.memory:
+                    await self.memory.decay_all()
+            else:
+                # Reconcile TokenBudget mutable state
+                if assignment.token_budget:
+                    assignment.token_budget.used_tokens = checkpoint["budget_used_tokens"]
+                    assignment.token_budget.estimated_cost_usd = checkpoint["budget_estimated_cost"]
 
-            # Restore context manager flush state
-            if self.context_manager:
-                self.context_manager._flush_triggered = checkpoint["flush_triggered"]
+                # Restore context manager flush state
+                if self.context_manager:
+                    self.context_manager._flush_triggered = checkpoint["flush_triggered"]
 
-            # Inject continuation prompt — but only if last message isn't already
-            # a user message (avoids violating role alternation invariant).
-            if messages and messages[-1].get("role") != "user":
-                messages.append({
-                    "role": "user",
-                    "content": (
-                        "You were working on this task and your session was interrupted. "
-                        "Your conversation history above reflects your progress. "
-                        "Continue from where you left off. Do not repeat completed work."
-                    ),
-                })
+                # Inject continuation prompt — but only if last message isn't already
+                # a user message (avoids violating role alternation invariant).
+                if messages and messages[-1].get("role") != "user":
+                    messages.append({
+                        "role": "user",
+                        "content": (
+                            "You were working on this task and your session was interrupted. "
+                            "Your conversation history above reflects your progress. "
+                            "Continue from where you left off. Do not repeat completed work."
+                        ),
+                    })
 
-            logger.info(
-                "Resumed task %s from iteration %d (%d tokens used)",
-                assignment.task_id, start_iteration, total_tokens,
-            )
+                logger.info(
+                    "Resumed task %s from iteration %d (%d tokens used)",
+                    assignment.task_id, start_iteration, total_tokens,
+                )
         elif checkpoint:
             # Stale checkpoint from a different task — clear it
             logger.warning(
@@ -641,6 +683,7 @@ class AgentLoop:
 
         try:
             for iteration in range(start_iteration, self.MAX_ITERATIONS):
+                self._bump_liveness()
                 if self._cancel_requested:
                     self._cancel_requested = False
                     self.state = "idle"
@@ -652,6 +695,11 @@ class AgentLoop:
                         duration_ms=int((time.time() - start) * 1000),
                     )
                     self._last_result = result
+                    logger.info(
+                        "execute_task exit branch=cancelled_iter_head status=%s "
+                        "iterations=%d tokens=%d",
+                        result.status, iteration, total_tokens,
+                    )
                     return result
 
                 if assignment.token_budget and not assignment.token_budget.can_spend(4096):
@@ -668,6 +716,11 @@ class AgentLoop:
                         duration_ms=int((time.time() - start) * 1000),
                     )
                     self._last_result = result
+                    logger.info(
+                        "execute_task exit branch=token_budget_exhausted "
+                        "status=%s iterations=%d tokens=%d",
+                        result.status, iteration, total_tokens,
+                    )
                     return result
 
                 # === DECIDE (LLM call) ===
@@ -702,6 +755,11 @@ class AgentLoop:
                         duration_ms=int((time.time() - start) * 1000),
                     )
                     self._last_result = result
+                    logger.info(
+                        "execute_task exit branch=cancelled_post_llm "
+                        "status=%s iterations=%d tokens=%d",
+                        result.status, iteration, total_tokens,
+                    )
                     return result
 
                 # === ACT ===
@@ -720,6 +778,11 @@ class AgentLoop:
                             duration_ms=int((time.time() - start) * 1000),
                         )
                         self._last_result = result
+                        logger.info(
+                            "execute_task exit branch=tool_loop_terminate "
+                            "status=%s iterations=%d tokens=%d",
+                            result.status, iteration, total_tokens,
+                        )
                         return result
 
                     # Append assistant response with tool calls (correct role)
@@ -828,6 +891,42 @@ class AgentLoop:
                             outcome="complete",
                         )
 
+                    iterations_executed = iteration + 1
+                    # Bug 5 (pathological-success rejection): if we somehow
+                    # reach this branch with zero iterations AND zero tokens
+                    # spent, something fundamental is wrong (corrupt
+                    # checkpoint, mocked LLM that no-ops, double-completion
+                    # race). Downgrade to a loud failure rather than reporting
+                    # a 3s pending→done with empty logs. This is a belt-and-
+                    # suspenders guard; it cannot fire in legitimate runs.
+                    if iterations_executed <= 0 and total_tokens <= 0:
+                        logger.error(
+                            "execute_task pathological success guard tripped "
+                            "for task=%s: iterations=%d tokens=%d — downgrading "
+                            "to failed (possible checkpoint corruption)",
+                            assignment.task_id, iterations_executed, total_tokens,
+                        )
+                        # Roll back the success bookkeeping we just did.
+                        self.tasks_completed -= 1
+                        self.tasks_failed += 1
+                        result = TaskResult(
+                            task_id=assignment.task_id,
+                            status="failed",
+                            error=(
+                                "execute_task returned success without doing "
+                                "work — possible checkpoint corruption"
+                            ),
+                            tokens_used=total_tokens,
+                            duration_ms=int(duration_s * 1000),
+                        )
+                        self._last_result = result
+                        logger.info(
+                            "execute_task exit branch=pathological_success_guard "
+                            "status=%s iterations=%d tokens=%d",
+                            result.status, iterations_executed, total_tokens,
+                        )
+                        return result
+
                     result = TaskResult(
                         task_id=assignment.task_id,
                         status="complete",
@@ -837,6 +936,11 @@ class AgentLoop:
                         duration_ms=int(duration_s * 1000),
                     )
                     self._last_result = result
+                    logger.info(
+                        "execute_task exit branch=final_response "
+                        "status=%s iterations=%d tokens=%d",
+                        result.status, iterations_executed, total_tokens,
+                    )
                     return result
 
             # Max iterations reached
@@ -865,6 +969,11 @@ class AgentLoop:
                 duration_ms=int((time.time() - start) * 1000),
             )
             self._last_result = result
+            logger.info(
+                "execute_task exit branch=max_iterations_reached status=%s "
+                "iterations=%d tokens=%d",
+                result.status, self.MAX_ITERATIONS, total_tokens,
+            )
             return result
 
         except asyncio.CancelledError:
@@ -877,6 +986,10 @@ class AgentLoop:
                 duration_ms=int((time.time() - start) * 1000),
             )
             self._last_result = result
+            logger.info(
+                "execute_task exit branch=cancelled_exception status=%s tokens=%d",
+                result.status, total_tokens,
+            )
             return result
         except Exception as e:
             self.state = "idle"
@@ -902,6 +1015,10 @@ class AgentLoop:
                 duration_ms=int((time.time() - start) * 1000),
             )
             self._last_result = result
+            logger.info(
+                "execute_task exit branch=exception status=%s tokens=%d error=%r",
+                result.status, total_tokens, str(e)[:120],
+            )
             return result
         finally:
             # Clear task checkpoint on ANY exit (success, failure, cancel, exception).
@@ -2194,6 +2311,7 @@ class AgentLoop:
 
             steer_interrupts = 0
             for _ in range(self.CHAT_MAX_TOOL_ROUNDS):
+                self._bump_liveness()
                 llm_response = await _llm_call_with_retry(
                     self.llm.chat,
                     system=system,
@@ -2616,6 +2734,8 @@ class AgentLoop:
             context_tokens=ctx_tokens,
             context_max=ctx_max,
             context_pct=ctx_pct,
+            last_iteration_ts=self._last_iteration_ts,
+            iterations_since_boot=self._iterations_since_boot,
         )
 
     # ── Streaming chat ────────────────────────────────────────
@@ -2690,6 +2810,7 @@ class AgentLoop:
 
             steer_interrupts = 0
             for _ in range(self.CHAT_MAX_TOOL_ROUNDS):
+                self._bump_liveness()
                 # Try token-level streaming, fall back to non-streaming on error
                 llm_response = None
                 used_streaming = False

--- a/src/agent/server.py
+++ b/src/agent/server.py
@@ -200,12 +200,21 @@ def create_agent_app(loop: AgentLoop) -> FastAPI:
         Task 2b: parse ``X-Origin`` so the heartbeat path stamps the
         contextvar with ``kind="heartbeat"`` for any tool / coordination
         call made during the heartbeat run.
+
+        Bug 6 (codex P2 r2): read the ``x-force-llm`` header set by
+        ``cli/runtime.py:heartbeat_dispatch`` when the cron job has
+        ``force_llm=True``. Without this propagation the cron-side skip
+        is bypassed but the loop-side skip still fires for empty
+        HEARTBEAT.md, leaving pipeline-kicker agents silent.
         """
         from src.shared.trace import current_origin
         origin = _origin_from_mesh_request(request)
+        force_llm = (request.headers.get("x-force-llm") or "").lower() in ("1", "true", "yes")
         token = current_origin.set(origin)
         try:
-            result = await loop.execute_heartbeat(sanitize_for_prompt(msg.message))
+            result = await loop.execute_heartbeat(
+                sanitize_for_prompt(msg.message), force_llm=force_llm,
+            )
         finally:
             current_origin.reset(token)
         return result

--- a/src/cli/runtime.py
+++ b/src/cli/runtime.py
@@ -565,6 +565,11 @@ class RuntimeContext:
             trace_store=self.trace_store,
             notify_fn=self._handle_notify_origin,
         )
+        # Bug 1: hand the lane queue-depth lookup to the health monitor so
+        # the staleness check (reachable+busy+no-tick → unhealthy) has
+        # the data it needs. Health monitor was built before the lane.
+        if self.health_monitor is not None:
+            self.health_monitor.set_queue_depth_fn(self.lane_manager.get_queue_depth)
 
         self._dispatch_loop = asyncio.new_event_loop()
 
@@ -682,6 +687,15 @@ class RuntimeContext:
         )
         app.include_router(webhook_manager.create_router())
         self.health_monitor._cleanup_agent = app.cleanup_agent  # type: ignore[attr-defined]
+
+        # Bug 4: lane watchdog needs the durable task store so a per-task
+        # timeout can mark the row ``failed`` (back-edge inbox event fires)
+        # instead of leaving the originator waiting forever. The store is
+        # created inside ``create_mesh_app`` so we wire it here after the
+        # fact rather than threading it through the lane constructor.
+        _tasks_store_ref = getattr(app, "tasks_store", None)
+        if _tasks_store_ref is not None and self.lane_manager is not None:
+            self.lane_manager._tasks_store = _tasks_store_ref
 
         self._init_channel_manager()
 

--- a/src/cli/runtime.py
+++ b/src/cli/runtime.py
@@ -807,18 +807,30 @@ class RuntimeContext:
                 logger.warning("Failed to invoke tool '%s' on '%s': %s", tool_name, agent_name, e)
                 return {"error": str(e)}
 
-        async def heartbeat_dispatch(agent_name: str, message: str) -> dict:
+        async def heartbeat_dispatch(
+            agent_name: str, message: str, *, force_llm: bool = False,
+        ) -> dict:
             """Dispatch heartbeat via dedicated /heartbeat endpoint.
 
             Task 2b: stamp ``kind="heartbeat"`` origin so the agent's
             tools (and downstream gates) can identify self-triggered
             heartbeat work versus a human or cron wake.
+
+            Bug 6 (codex P2 r2): ``force_llm`` is forwarded to the
+            agent via the ``x-force-llm`` header so
+            ``AgentLoop.execute_heartbeat`` skips its own ``empty
+            HEARTBEAT.md → no_heartbeat_rules`` short-circuit. Without
+            this, bypassing only the cron-side skip leaves
+            pipeline-kicker agents silent because the agent-side check
+            still fires.
             """
             from src.shared.trace import origin_header, trace_headers
             from src.shared.types import MessageOrigin
             origin = MessageOrigin(kind="heartbeat", channel="heartbeat", user="")
             headers = trace_headers()
             headers.update(origin_header(origin))
+            if force_llm:
+                headers["x-force-llm"] = "true"
             try:
                 return await self.transport.request(
                     agent_name, "POST", "/heartbeat",

--- a/src/host/cron.py
+++ b/src/host/cron.py
@@ -491,9 +491,15 @@ class CronScheduler:
 
                         message = "\n\n".join(sections)
 
-                        # Use dedicated heartbeat endpoint when available
+                        # Use dedicated heartbeat endpoint when available.
+                        # Bug 6 (codex P2 r2): propagate ``force_llm`` to the
+                        # dispatch fn so the agent-side
+                        # ``no_heartbeat_rules`` skip is also bypassed for
+                        # pipeline-kicker agents.
                         if self.heartbeat_dispatch_fn:
-                            hb_result = await self.heartbeat_dispatch_fn(job.agent, message)
+                            hb_result = await self.heartbeat_dispatch_fn(
+                                job.agent, message, force_llm=job.force_llm,
+                            )
                             # hb_result is a structured dict from execute_heartbeat
                             if isinstance(hb_result, dict):
                                 if hb_result.get("skipped"):

--- a/src/host/cron.py
+++ b/src/host/cron.py
@@ -59,6 +59,13 @@ class CronJob:
     heartbeat: bool = False
     tool_name: str | None = None    # invoke this tool directly — no LLM involved
     tool_params: str | None = None  # JSON-encoded params dict for the tool
+    # Bug 4 (force_llm): heartbeats normally short-circuit the LLM when
+    # there's nothing actionable (default HEARTBEAT.md, no recent
+    # activity, no probes triggered) to keep cost down. Pipeline-kicker
+    # agents that have no probes and an empty HEARTBEAT.md never wake
+    # under that policy. Setting ``force_llm=True`` makes the cron tick
+    # always dispatch to the LLM regardless of the skip predicate.
+    force_llm: bool = False
     last_run: str | None = None
     next_run: str | None = None
     run_count: int = 0
@@ -233,7 +240,13 @@ class CronScheduler:
             message=f"Heartbeat check for {agent}", heartbeat=True,
         )
 
-    _UPDATABLE_FIELDS = frozenset({"schedule", "message", "enabled", "suppress_empty", "tool_name", "tool_params"})
+    _UPDATABLE_FIELDS = frozenset({
+        "schedule", "message", "enabled", "suppress_empty",
+        "tool_name", "tool_params",
+        # Bug 4: operator can toggle force_llm on an existing cron job
+        # without recreating it.
+        "force_llm",
+    })
 
     async def update_job(self, job_id: str, **kwargs) -> CronJob | None:
         """Update fields on an existing cron job. Returns updated job or None."""
@@ -391,7 +404,18 @@ class CronScheduler:
 
                         # Skip-LLM optimization: no custom rules, no activity, no probes
                         # Always dispatch when manually triggered (user expects it to run)
-                        if not manual and is_default and not has_activity and not triggered:
+                        # Bug 4 (force_llm): pipeline-kicker agents (no probes,
+                        # empty HEARTBEAT.md) need the LLM every tick — they're
+                        # the wake signal for whatever pipeline they're driving.
+                        # ``force_llm=True`` short-circuits the skip so the
+                        # operator can opt out of the cost optimization.
+                        if (
+                            not manual
+                            and not job.force_llm
+                            and is_default
+                            and not has_activity
+                            and not triggered
+                        ):
                             logger.debug(
                                 "Heartbeat %s: skipped (default rules, no activity, "
                                 "no probes) for '%s'", job.id, job.agent,

--- a/src/host/health.py
+++ b/src/host/health.py
@@ -12,7 +12,9 @@ After the limit is hit, the agent is marked as 'failed' and left stopped.
 from __future__ import annotations
 
 import asyncio
+import os
 import time
+from collections.abc import Callable
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING
 
@@ -26,6 +28,12 @@ if TYPE_CHECKING:
     from src.host.transport import Transport
 
 logger = setup_logging("host.health")
+
+# Liveness staleness threshold (Bug 1) — a reachable agent with a non-empty
+# lane queue but no loop iteration in this window is treated as having a
+# dead inner loop. Default 5 minutes; legitimate long-running tools (300s
+# cap) plus normal LLM round-trip easily fit.
+_STALE_LOOP_SECONDS = int(os.environ.get("OPENLEGION_LOOP_STALE_SECONDS", "300"))
 
 
 @dataclass
@@ -55,6 +63,7 @@ class HealthMonitor:
         event_bus=None,
         cleanup_agent_fn=None,
         blackboard=None,
+        queue_depth_fn: Callable[[str], int] | None = None,
     ):
         self.runtime = runtime
         self.transport = transport
@@ -62,6 +71,12 @@ class HealthMonitor:
         self._event_bus = event_bus
         self._cleanup_agent = cleanup_agent_fn
         self._blackboard = blackboard
+        # ``queue_depth_fn`` (Bug 1) — optional callable that returns the
+        # lane queue depth for an agent_id. When wired, the health monitor
+        # combines /status liveness (last_iteration_ts) with queue depth to
+        # detect a dead inner loop with a live FastAPI thread. Without it
+        # the staleness check is a no-op (reachability behaviour unchanged).
+        self._queue_depth_fn = queue_depth_fn
         self.agents: dict[str, AgentHealth] = {}
         self._agent_lock: asyncio.Lock | None = None
         self._agent_lock_loop: asyncio.AbstractEventLoop | None = None
@@ -79,6 +94,15 @@ class HealthMonitor:
 
     def unregister(self, agent_id: str) -> None:
         self.agents.pop(agent_id, None)
+
+    def set_queue_depth_fn(self, fn: Callable[[str], int] | None) -> None:
+        """Wire (or unwire) the lane queue-depth callback after construction.
+
+        ``HealthMonitor`` is built before ``LaneManager`` in the host
+        bootstrap path; this setter lets the lane wire itself in once
+        constructed. ``None`` disables the staleness branch.
+        """
+        self._queue_depth_fn = fn
 
     async def start(self) -> None:
         self._running = True
@@ -131,6 +155,50 @@ class HealthMonitor:
                         "state": "removed", "reason": "ttl_expired",
                     })
 
+    async def _is_loop_stale(self, agent_id: str, now: float) -> bool:
+        """Return True if the agent has queued work but its loop hasn't ticked.
+
+        Bug 1 fix: ``Transport.is_reachable`` only checks the /status HTTP
+        response — a wedged inner loop with a live FastAPI thread reports
+        healthy. We compare the loop's ``last_iteration_ts`` against the
+        wall clock and only flag a problem when (a) the lane has actual
+        work waiting (``queue_depth > 0``), and (b) the loop hasn't ticked
+        in ``_STALE_LOOP_SECONDS``. An idle agent with an empty queue is
+        fine — it shouldn't be bumping the counter.
+
+        Best-effort: any error in the /status fetch or queue lookup
+        returns ``False`` so this never spuriously flags an otherwise
+        healthy agent.
+        """
+        if self._queue_depth_fn is None:
+            return False
+        try:
+            depth = self._queue_depth_fn(agent_id)
+        except Exception as e:
+            logger.debug("queue_depth_fn raised for '%s': %s", agent_id, e)
+            return False
+        if depth <= 0:
+            return False
+        try:
+            status_resp = await self.transport.request(
+                agent_id, "GET", "/status", timeout=5,
+            )
+        except Exception as e:
+            logger.debug("Liveness /status fetch failed for '%s': %s", agent_id, e)
+            return False
+        if not isinstance(status_resp, dict):
+            return False
+        if "error" in status_resp:
+            return False
+        last_ts = status_resp.get("last_iteration_ts")
+        if last_ts is None:
+            # Agent hasn't ticked yet (just booted) — not stale.
+            return False
+        try:
+            return (now - float(last_ts)) > _STALE_LOOP_SECONDS
+        except (TypeError, ValueError):
+            return False
+
     async def _check_agent(self, agent_id: str) -> None:
         health = self.agents.get(agent_id)
         if not health or health.status == "failed":
@@ -143,17 +211,32 @@ class HealthMonitor:
         try:
             reachable = await self.transport.is_reachable(agent_id, timeout=5)
             if reachable:
-                health.consecutive_failures = 0
-                health.last_healthy = now
-                new_status = "healthy"
-                health.status = new_status
-                if new_status != prev_status and self._event_bus:
-                    self._event_bus.emit("health_change", agent=agent_id, data={
-                        "previous": prev_status, "current": health.status,
-                        "failures": health.consecutive_failures,
-                        "restart_count": health.restart_count,
-                    })
-                return
+                # Liveness check (Bug 1): an agent can be reachable on
+                # /status (FastAPI thread alive) while its inner loop is
+                # hung. Only flag stale when the lane queue actually has
+                # work waiting — an idle agent legitimately stops bumping
+                # the iteration counter.
+                stale = await self._is_loop_stale(agent_id, now)
+                if stale:
+                    logger.warning(
+                        "Agent '%s' is reachable with queued work but loop "
+                        "appears stale (no iteration in >%ds) — treating as "
+                        "unhealthy",
+                        agent_id, _STALE_LOOP_SECONDS,
+                    )
+                    # Fall through to the unhealthy bookkeeping below.
+                else:
+                    health.consecutive_failures = 0
+                    health.last_healthy = now
+                    new_status = "healthy"
+                    health.status = new_status
+                    if new_status != prev_status and self._event_bus:
+                        self._event_bus.emit("health_change", agent=agent_id, data={
+                            "previous": prev_status, "current": health.status,
+                            "failures": health.consecutive_failures,
+                            "restart_count": health.restart_count,
+                        })
+                    return
         except Exception as e:
             logger.debug("Health check transport error for '%s': %s", agent_id, e)
 

--- a/src/host/health.py
+++ b/src/host/health.py
@@ -31,9 +31,16 @@ logger = setup_logging("host.health")
 
 # Liveness staleness threshold (Bug 1) — a reachable agent with a non-empty
 # lane queue but no loop iteration in this window is treated as having a
-# dead inner loop. Default 5 minutes; legitimate long-running tools (300s
-# cap) plus normal LLM round-trip easily fit.
-_STALE_LOOP_SECONDS = int(os.environ.get("OPENLEGION_LOOP_STALE_SECONDS", "300"))
+# dead inner loop. Aligned with the per-task lane watchdog default (900s)
+# so the lane watchdog gets to fail a single stuck task before the health
+# monitor escalates to an agent restart. Codex P2 r2: 300s was too
+# aggressive — the loop bumps at iteration boundaries, post-LLM, and
+# post-tool, so a single deep reasoning call or a full 300s tool timeout
+# can exceed the old threshold even on a perfectly healthy turn. With the
+# 900s default, the staleness check only fires when truly nothing has
+# happened in the same window that the lane watchdog uses to cancel the
+# task itself.
+_STALE_LOOP_SECONDS = int(os.environ.get("OPENLEGION_LOOP_STALE_SECONDS", "900"))
 
 
 @dataclass

--- a/src/host/lanes.py
+++ b/src/host/lanes.py
@@ -14,6 +14,7 @@ Three queue modes control how incoming messages interact with busy agents:
 from __future__ import annotations
 
 import asyncio
+import os
 import time
 from collections.abc import Callable, Coroutine
 from dataclasses import dataclass, field
@@ -27,6 +28,13 @@ logger = setup_logging("host.lanes")
 _STEER_WAKEUP_MAX = 10  # max wakeups per window
 _STEER_WAKEUP_WINDOW = 3600  # 1 hour window
 _NOTIFY_FORWARD_TIMEOUT = 30  # seconds — cap on auto-notify send
+# Per-task lane watchdog (Bug 4): a hung LLM stream or stuck tool call
+# previously blocked the lane indefinitely — every subsequent task for that
+# agent would queue forever. The default is generous (15 min) because some
+# deep-research workloads legitimately take that long; tune via env var.
+_DEFAULT_LANE_TIMEOUT_SECONDS = int(
+    os.getenv("OPENLEGION_LANE_TIMEOUT_SECONDS", "900"),
+)
 
 
 @dataclass
@@ -51,11 +59,24 @@ class LaneManager:
         steer_fn: Callable[..., Coroutine[Any, Any, Any]] | None = None,
         trace_store: Any = None,
         notify_fn: Callable[..., Coroutine[Any, Any, Any]] | None = None,
+        tasks_store: Any = None,
+        task_timeout_seconds: int | None = None,
     ):
         self._dispatch_fn = dispatch_fn
         self._steer_fn = steer_fn
         self._trace_store = trace_store
         self._notify_fn = notify_fn
+        # ``tasks_store`` (Bug 4): when wired, the lane watchdog marks the
+        # durable task ``failed`` with ``error="lane_timeout"`` on timeout
+        # so originators see the back-edge event instead of waiting forever.
+        # Lane keeps working without it — falls back to a loud log line.
+        self._tasks_store = tasks_store
+        # ``task_timeout_seconds`` (Bug 4): per-task wall-clock cap. Read
+        # from env at construction so each LaneManager honours its own
+        # override (and tests can pass a tight value).
+        if task_timeout_seconds is None:
+            task_timeout_seconds = _DEFAULT_LANE_TIMEOUT_SECONDS
+        self._task_timeout_seconds = task_timeout_seconds
         self._queues: dict[str, asyncio.Queue[QueuedTask]] = {}
         self._workers: dict[str, asyncio.Task] = {}
         self._pending: dict[str, list[QueuedTask]] = {}
@@ -260,12 +281,19 @@ class LaneManager:
                     dispatch_kwargs["origin"] = task.origin
                 if task.task_id is not None:
                     dispatch_kwargs["task_id"] = task.task_id
+                # Bug 4: per-task wall-clock cap. A hung LLM stream or
+                # stuck tool previously blocked the lane forever — every
+                # subsequent task for this agent would queue forever.
                 if dispatch_kwargs:
-                    result = await self._dispatch_fn(
-                        agent, task.message, **dispatch_kwargs,
+                    result = await asyncio.wait_for(
+                        self._dispatch_fn(agent, task.message, **dispatch_kwargs),
+                        timeout=self._task_timeout_seconds,
                     )
                 else:
-                    result = await self._dispatch_fn(agent, task.message)
+                    result = await asyncio.wait_for(
+                        self._dispatch_fn(agent, task.message),
+                        timeout=self._task_timeout_seconds,
+                    )
                 task.future.set_result(result)
                 # Auto-forward result to origin channel+user when requested.
                 # Runs as a background task with a timeout so a hung channel
@@ -303,6 +331,43 @@ class LaneManager:
                     forward_task = asyncio.create_task(_forward())
                     self._forward_tasks.add(forward_task)
                     forward_task.add_done_callback(self._forward_tasks.discard)
+            except asyncio.TimeoutError:
+                # Bug 4: dispatch exceeded the per-task wall-clock cap.
+                # Free the lane, mark the durable task ``failed`` so the
+                # originating agent's back-edge inbox sees the timeout,
+                # then continue serving the queue. Do NOT raise — the
+                # worker must survive a single stuck task.
+                timeout_msg = (
+                    f"Lane task {task.id} for agent={agent} timed out after "
+                    f"{self._task_timeout_seconds}s — freeing lane"
+                )
+                logger.error(timeout_msg)
+                if task.task_id and self._tasks_store is not None:
+                    try:
+                        # ``Tasks.update_status`` is sync — push it off the
+                        # event loop so a slow SQLite write can't pile back
+                        # onto the lane worker we just freed.
+                        await asyncio.get_running_loop().run_in_executor(
+                            None,
+                            lambda: self._tasks_store.update_status(
+                                task.task_id,
+                                "failed",
+                                actor="lane_watchdog",
+                                extra_payload={
+                                    "error": "lane_timeout",
+                                    "timeout_seconds": self._task_timeout_seconds,
+                                },
+                            ),
+                        )
+                    except Exception as close_err:
+                        logger.warning(
+                            "Lane watchdog failed to close task %s: %s",
+                            task.task_id, close_err,
+                        )
+                if not task.future.done():
+                    task.future.set_exception(
+                        asyncio.TimeoutError(timeout_msg),
+                    )
             except Exception as e:
                 if not task.future.done():
                     task.future.set_exception(e)
@@ -335,6 +400,22 @@ class LaneManager:
                 "busy": self._busy.get(agent, False),
             }
         return result
+
+    def get_queue_depth(self, agent: str) -> int:
+        """Return current queue depth for an agent (0 if no lane exists).
+
+        Used by HealthMonitor's loop-liveness check (Bug 1) — combine with
+        the agent's ``last_iteration_ts`` from /status to detect a wedged
+        inner loop with a live FastAPI thread. We count both queued
+        messages waiting and an in-flight task (``busy``) so the "agent has
+        actual work" predicate fires correctly during the gap between
+        dequeue and dispatch.
+        """
+        queue = self._queues.get(agent)
+        depth = queue.qsize() if queue is not None else 0
+        if self._busy.get(agent, False):
+            depth += 1
+        return depth
 
     def remove_lane(self, agent: str) -> None:
         """Remove all lane state for an agent, cancelling its worker task."""

--- a/src/shared/types.py
+++ b/src/shared/types.py
@@ -251,6 +251,14 @@ class AgentStatus(BaseModel):
     context_tokens: int = 0
     context_max: int = 0
     context_pct: float = 0.0
+    # Loop liveness signal (Bug 1) — surfaced so the mesh health monitor can
+    # detect a dead inner loop with a live FastAPI thread. ``last_iteration_ts``
+    # is wall-clock seconds (time.time()) stamped at the head of each
+    # task/chat iteration; ``iterations_since_boot`` is monotonically
+    # increasing across the agent's lifetime. Both default to safe values
+    # so older serialized payloads parse cleanly.
+    last_iteration_ts: float | None = None
+    iterations_since_boot: int = 0
 
 
 # === Blackboard & Events ===

--- a/tests/test_agent_server.py
+++ b/tests/test_agent_server.py
@@ -859,7 +859,7 @@ class TestHeartbeatOriginContextVar:
         app, mock_loop = _make_app()
         captured: list = []
 
-        async def _capture_heartbeat(_msg):
+        async def _capture_heartbeat(_msg, *, force_llm: bool = False):
             # Read the contextvar from inside the heartbeat run — that's
             # what tools (e.g. coordination_tool.hand_off) will see.
             captured.append(current_origin.get())
@@ -892,7 +892,7 @@ class TestHeartbeatOriginContextVar:
         app, mock_loop = _make_app()
         captured: list = []
 
-        async def _capture_heartbeat(_msg):
+        async def _capture_heartbeat(_msg, *, force_llm: bool = False):
             captured.append(current_origin.get())
             return {"response": "ok", "outcome": "ok", "skipped": False}
 
@@ -902,3 +902,51 @@ class TestHeartbeatOriginContextVar:
             resp = await client.post("/heartbeat", json={"message": "tick"})
         assert resp.status_code == 200
         assert captured == [None]
+
+
+class TestHeartbeatForceLlmHeader:
+    """Bug 6 (codex P2 r2): the /heartbeat endpoint must read x-force-llm
+    and forward it to ``execute_heartbeat`` so the agent-side
+    no_heartbeat_rules skip is bypassed for pipeline-kicker agents."""
+
+    @pytest.mark.asyncio
+    async def test_force_llm_header_true_propagates(self):
+        app, mock_loop = _make_app()
+        mock_loop.execute_heartbeat = AsyncMock(return_value={
+            "response": "ok", "outcome": "ok", "skipped": False,
+        })
+
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+            resp = await client.post(
+                "/heartbeat", json={"message": "tick"},
+                headers={"x-force-llm": "true"},
+            )
+        assert resp.status_code == 200
+        assert mock_loop.execute_heartbeat.call_args.kwargs.get("force_llm") is True
+
+    @pytest.mark.asyncio
+    async def test_force_llm_header_absent_defaults_false(self):
+        app, mock_loop = _make_app()
+        mock_loop.execute_heartbeat = AsyncMock(return_value={
+            "response": "ok", "outcome": "ok", "skipped": False,
+        })
+
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+            resp = await client.post("/heartbeat", json={"message": "tick"})
+        assert resp.status_code == 200
+        assert mock_loop.execute_heartbeat.call_args.kwargs.get("force_llm") is False
+
+    @pytest.mark.asyncio
+    async def test_force_llm_header_garbage_defaults_false(self):
+        app, mock_loop = _make_app()
+        mock_loop.execute_heartbeat = AsyncMock(return_value={
+            "response": "ok", "outcome": "ok", "skipped": False,
+        })
+
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+            resp = await client.post(
+                "/heartbeat", json={"message": "tick"},
+                headers={"x-force-llm": "definitely-not-a-bool"},
+            )
+        assert resp.status_code == 200
+        assert mock_loop.execute_heartbeat.call_args.kwargs.get("force_llm") is False

--- a/tests/test_coordination.py
+++ b/tests/test_coordination.py
@@ -981,7 +981,11 @@ class TestOperatorHandoff:
     @pytest.mark.asyncio
     async def test_hand_off_to_operator_survives_wake_failure(self):
         """Regression: wake_agent failure must not prevent the task from
-        being queued. The operator picks it up on its next heartbeat."""
+        being queued. The operator picks it up on its next heartbeat.
+
+        Bug 2 (operator-seam): the contract was flipped so wake failure
+        surfaces ``handed_off: false`` + ``task_queued: true`` — the
+        write still succeeds, just the wake signal didn't land."""
         from src.agent.builtins.coordination_tool import hand_off
 
         mc = _make_mesh_client(agent_id="scout")
@@ -996,8 +1000,11 @@ class TestOperatorHandoff:
             to="operator", summary="follow up", mesh_client=mc,
         )
 
-        # Handoff still succeeds — task is queued, wake is best-effort.
-        assert result["handed_off"] is True
+        # Wake failed — handed_off MUST be False so the LLM doesn't lie.
+        assert result["handed_off"] is False
+        # The durable row still landed; the operator's next heartbeat
+        # picks it up.
+        assert result["task_queued"] is True
         assert result["task_key"].startswith("global/tasks/operator/")
         # The task write happened before the wake attempt.
         mc.write_blackboard.assert_awaited()
@@ -1390,15 +1397,18 @@ class TestHandOffTitleQuality:
 class TestHandOffWakeFailureSurfacing:
     """Operator-reported Bug 4: wake_agent failures were silently swallowed.
 
-    The task IS queued in SQLite/blackboard either way, so ``handed_off``
-    stays True. But callers need visibility into wake failures so they
-    can retry the wake or warn the user, instead of silently relying on
-    the recipient's next cron tick.
+    Updated for Bug 2 (operator seam) — the prior contract claimed
+    ``handed_off: true`` even on wake failure, which made LLMs report
+    success to the user while the recipient never woke. The task IS
+    still queued in SQLite/blackboard, so we add ``task_queued: true``
+    and a ``recovery_hint`` but flip ``handed_off: false`` so the
+    caller sees a partial outcome and can decide whether to retry.
     """
 
     @pytest.mark.asyncio
     async def test_hand_off_returns_wake_failed_when_wake_raises(self):
-        """Legacy path: wake failure surfaces ``wake_failed`` + ``wake_error``."""
+        """Legacy path: wake failure surfaces ``handed_off=False`` +
+        ``task_queued=True`` + ``wake_failed`` + ``wake_error``."""
         from src.agent.builtins.coordination_tool import hand_off
 
         mc = _make_mesh_client(agent_id="scout")
@@ -1411,11 +1421,14 @@ class TestHandOffWakeFailureSurfacing:
             mesh_client=mc,
         )
 
-        # Task is still queued — handed_off stays True.
-        assert result["handed_off"] is True
-        # Wake failure is surfaced.
+        # Wake failed — the LLM must NOT see handed_off:true here.
+        assert result["handed_off"] is False
+        # Task IS queued in the durable store.
+        assert result["task_queued"] is True
+        # Wake failure detail is surfaced.
         assert result["wake_failed"] is True
         assert "agent container 503" in result["wake_error"]
+        assert "recovery_hint" in result
 
     @pytest.mark.asyncio
     async def test_hand_off_success_omits_wake_failure_keys(self):
@@ -1451,7 +1464,9 @@ class TestHandOffWakeFailureSurfacing:
             mesh_client=mc,
         )
 
-        assert result["handed_off"] is True
+        # Bug 2: handed_off flips to False on wake failure.
+        assert result["handed_off"] is False
+        assert result["task_queued"] is True
         assert result["wake_failed"] is True
         assert len(result["wake_error"]) <= 200
 
@@ -1522,7 +1537,9 @@ class TestHandOffWakeFailureSurfacing:
 
     @pytest.mark.asyncio
     async def test_hand_off_v2_returns_wake_failed_when_wake_raises(self):
-        """V2 path: wake failure surfaces ``wake_failed`` + ``wake_error``."""
+        """V2 path: wake failure flips ``handed_off=False`` and surfaces
+        ``task_queued=True`` + ``wake_failed`` + ``wake_error`` +
+        ``recovery_hint`` (Bug 2 contract honesty)."""
         from src.agent.builtins.coordination_tool import hand_off
 
         mc = _make_mesh_client(agent_id="scout", v2_enabled=True)
@@ -1536,9 +1553,11 @@ class TestHandOffWakeFailureSurfacing:
             mesh_client=mc,
         )
 
-        assert result["handed_off"] is True
+        assert result["handed_off"] is False
+        assert result["task_queued"] is True
         assert result["wake_failed"] is True
         assert "auth token rejected" in result["wake_error"]
+        assert "recovery_hint" in result
 
     @pytest.mark.asyncio
     async def test_hand_off_v2_success_omits_wake_failure_keys(self):
@@ -1558,3 +1577,39 @@ class TestHandOffWakeFailureSurfacing:
         assert result["handed_off"] is True
         assert "wake_failed" not in result
         assert "wake_error" not in result
+
+    @pytest.mark.asyncio
+    async def test_hand_off_v2_wake_failure_reports_handed_off_false(self):
+        """Pins the new contract: on wake failure ``_hand_off_v2`` MUST
+        flip ``handed_off`` to False and emit ``task_queued=True``
+        alongside the wake_failed signal. Pre-fix this returned
+        ``handed_off:true`` AND ``wake_failed:true`` — the LLM picked up
+        ``handed_off`` and reported success while the recipient never
+        actually woke (Bug 2)."""
+        from src.agent.builtins.coordination_tool import hand_off
+
+        mc = _make_mesh_client(agent_id="scout", v2_enabled=True)
+        mc.list_agents.return_value = {"analyst": {"role": "analyst"}}
+        mc.create_task.return_value = {"id": "task_v2_xyz", "status": "pending"}
+        mc.wake_agent.side_effect = RuntimeError("network unreachable")
+
+        result = await hand_off(
+            to="analyst",
+            summary="run the enrichment",
+            mesh_client=mc,
+        )
+
+        # The PRIMARY guarantee: handed_off must be False so LLMs
+        # don't tell the user the work was delivered.
+        assert result["handed_off"] is False, (
+            "wake failed but handed_off claims success — LLM will lie to user"
+        )
+        # task_queued lets the LLM know the work is durable.
+        assert result["task_queued"] is True
+        # The task_id is still surfaced so an operator can retry/reroute.
+        assert result["task_id"] == "task_v2_xyz"
+        # Wake-failure details remain available.
+        assert result["wake_failed"] is True
+        assert "network unreachable" in result["wake_error"]
+        # Recovery hint guides the LLM toward the right next action.
+        assert "heartbeat" in result["recovery_hint"].lower()

--- a/tests/test_cron.py
+++ b/tests/test_cron.py
@@ -1112,3 +1112,67 @@ class TestCronForceLlm:
         updated = await sched.update_job(job.id, force_llm=False)
         assert updated.force_llm is False
 
+    @pytest.mark.asyncio
+    async def test_force_llm_propagates_to_heartbeat_dispatch_fn(self):
+        """Bug 6 (codex P2 r2): force_llm must flow past cron into the dispatch.
+
+        The cron-side skip is only half the path — the agent's
+        ``execute_heartbeat`` runs its own ``no_heartbeat_rules`` skip on
+        empty HEARTBEAT.md. If ``force_llm`` doesn't reach the dispatch
+        callable, the loop-side skip still silences pipeline-kicker
+        agents. Pin the propagation so a future refactor can't drop it.
+        """
+        hb_dispatch = AsyncMock(return_value={
+            "response": "kicked", "summary": "", "tools_used": [],
+            "duration_ms": 10, "tokens_used": 5, "outcome": "ok",
+            "skipped": False,
+        })
+        context_fn = AsyncMock(return_value={
+            "heartbeat_rules": "",
+            "daily_logs": "",
+            "is_default_heartbeat": True,
+            "has_recent_activity": False,
+        })
+        mock_bb = MagicMock()
+        mock_bb.list_by_prefix.return_value = []
+        sched = CronScheduler(
+            config_path=self.config_path, dispatch_fn=AsyncMock(),
+            heartbeat_dispatch_fn=hb_dispatch,
+            blackboard=mock_bb, context_fn=context_fn,
+        )
+        job = sched.add_job(
+            agent="kicker", schedule="every 15m",
+            message="heartbeat", heartbeat=True, force_llm=True,
+        )
+        with patch.object(sched, "_run_heartbeat_probes", return_value=[]):
+            await sched._execute_job(job)
+        hb_dispatch.assert_called_once()
+        # force_llm=True must reach the dispatcher as a kwarg so it can
+        # set the x-force-llm header on the /heartbeat request.
+        assert hb_dispatch.call_args.kwargs.get("force_llm") is True
+
+    @pytest.mark.asyncio
+    async def test_force_llm_default_does_not_propagate_true(self):
+        """Default force_llm=False stays False through the dispatch."""
+        hb_dispatch = AsyncMock(return_value={
+            "response": "ok", "summary": "", "tools_used": [],
+            "duration_ms": 10, "tokens_used": 5, "outcome": "ok",
+            "skipped": False,
+        })
+        context_fn = AsyncMock(return_value={
+            "heartbeat_rules": "# Rules\nstuff",
+            "is_default_heartbeat": False,
+            "has_recent_activity": True,
+        })
+        sched = CronScheduler(
+            config_path=self.config_path, dispatch_fn=AsyncMock(),
+            heartbeat_dispatch_fn=hb_dispatch, context_fn=context_fn,
+        )
+        job = sched.add_job(
+            agent="regular", schedule="every 15m",
+            message="heartbeat", heartbeat=True,
+        )
+        await sched._execute_job(job)
+        hb_dispatch.assert_called_once()
+        assert hb_dispatch.call_args.kwargs.get("force_llm") is False
+

--- a/tests/test_cron.py
+++ b/tests/test_cron.py
@@ -1013,3 +1013,102 @@ class TestComputeNextRun:
         await sched.resume_job(job.id)
         assert sched.jobs[job.id].next_run is not None
 
+
+class TestCronForceLlm:
+    """Bug 4 (force_llm) — pipeline-kicker agents have no probes and an
+    empty HEARTBEAT.md, so the standard skip-LLM check would never wake
+    them. ``force_llm=True`` bypasses the skip so the LLM runs every tick."""
+
+    def setup_method(self):
+        self._tmpdir = tempfile.mkdtemp()
+        self.config_path = f"{self._tmpdir}/cron.json"
+
+    def teardown_method(self):
+        shutil.rmtree(self._tmpdir, ignore_errors=True)
+
+    @pytest.mark.asyncio
+    async def test_force_llm_dispatches_through_all_skip_conditions(self):
+        """All four skip conditions hold but force_llm=True → dispatch fires."""
+        dispatch = AsyncMock(return_value="kicked the pipeline")
+        context_fn = AsyncMock(return_value={
+            "heartbeat_rules": "",
+            "daily_logs": "",
+            "is_default_heartbeat": True,
+            "has_recent_activity": False,
+        })
+        mock_bb = MagicMock()
+        mock_bb.list_by_prefix.return_value = []
+        sched = CronScheduler(
+            config_path=self.config_path, dispatch_fn=dispatch,
+            blackboard=mock_bb, context_fn=context_fn,
+        )
+        job = sched.add_job(
+            agent="kicker", schedule="every 15m",
+            message="heartbeat", heartbeat=True,
+            force_llm=True,
+        )
+        with patch.object(sched, "_run_heartbeat_probes", return_value=[]):
+            result = await sched._execute_job(job)
+        # Even with all skip conditions met, dispatch fires.
+        dispatch.assert_called_once()
+        assert result is not None
+
+    @pytest.mark.asyncio
+    async def test_force_llm_default_unset_keeps_skipping(self):
+        """Without force_llm the skip-LLM optimization runs unchanged."""
+        dispatch = AsyncMock(return_value="should not see this")
+        context_fn = AsyncMock(return_value={
+            "heartbeat_rules": "",
+            "daily_logs": "",
+            "is_default_heartbeat": True,
+            "has_recent_activity": False,
+        })
+        mock_bb = MagicMock()
+        mock_bb.list_by_prefix.return_value = []
+        sched = CronScheduler(
+            config_path=self.config_path, dispatch_fn=dispatch,
+            blackboard=mock_bb, context_fn=context_fn,
+        )
+        # No force_llm — default False.
+        job = sched.add_job(
+            agent="regular", schedule="every 15m",
+            message="heartbeat", heartbeat=True,
+        )
+        assert job.force_llm is False
+        with patch.object(sched, "_run_heartbeat_probes", return_value=[]):
+            result = await sched._execute_job(job)
+        assert result is None
+        dispatch.assert_not_called()
+
+    def test_force_llm_persists_across_save_load_cycle(self):
+        """``CronJob.force_llm`` round-trips through the JSON config file."""
+        sched = CronScheduler(config_path=self.config_path)
+        sched.add_job(
+            agent="kicker", schedule="every 1h",
+            message="heartbeat", heartbeat=True,
+            force_llm=True,
+        )
+
+        # Reload from disk — confirm force_llm survived.
+        sched2 = CronScheduler(config_path=self.config_path)
+        loaded = list(sched2.jobs.values())[0]
+        assert loaded.force_llm is True
+
+    @pytest.mark.asyncio
+    async def test_force_llm_updatable_via_update_job(self):
+        """``_UPDATABLE_FIELDS`` allows toggling force_llm at runtime."""
+        sched = CronScheduler(config_path=self.config_path)
+        job = sched.add_job(
+            agent="kicker", schedule="every 1h",
+            message="heartbeat", heartbeat=True,
+        )
+        assert job.force_llm is False
+
+        updated = await sched.update_job(job.id, force_llm=True)
+        assert updated is not None
+        assert updated.force_llm is True
+
+        # And toggling it back off works too.
+        updated = await sched.update_job(job.id, force_llm=False)
+        assert updated.force_llm is False
+

--- a/tests/test_execute_task_guards.py
+++ b/tests/test_execute_task_guards.py
@@ -1,0 +1,210 @@
+"""Tests for the Bug 5 defensive guards in ``AgentLoop.execute_task``.
+
+Three guards:
+
+1. Stale-checkpoint rejection: a checkpoint whose ``iteration`` is at or
+   past ``MAX_ITERATIONS`` would otherwise fall through to the
+   max-iterations branch immediately, producing a 0-token "completion".
+   The guard clears the checkpoint and starts fresh.
+
+2. Pathological-success rejection: if the final-response branch is hit
+   with both ``iterations_executed == 0`` and ``total_tokens == 0`` we
+   downgrade to ``failed`` with a clear error rather than reporting a
+   ghost-success that masks corruption.
+
+3. Branch-exit logging: every ``return TaskResult(...)`` in
+   ``execute_task`` is preceded by a structured ``logger.info`` so a
+   future ghost-complete is debuggable from logs alone.
+"""
+
+from __future__ import annotations
+
+import logging
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from src.agent.loop import AgentLoop
+from src.agent.memory import MemoryStore
+from src.shared.types import LLMResponse, TaskAssignment
+
+
+def _make_loop(
+    llm_responses: list[LLMResponse] | None = None,
+    *,
+    real_memory: bool = False,
+) -> AgentLoop:
+    """Minimal AgentLoop tailored to the guard tests."""
+    if real_memory:
+        memory = MemoryStore(db_path=":memory:")
+    else:
+        memory = MagicMock()
+        memory.get_high_salience_facts = AsyncMock(return_value=[])
+        memory.decay_all = AsyncMock()
+        memory.search = AsyncMock(return_value=[])
+        memory.search_hierarchical = AsyncMock(return_value=[])
+        memory.log_action = AsyncMock()
+        memory.store_tool_outcome = AsyncMock()
+        memory.get_tool_history = MagicMock(return_value=[])
+        memory._run_db = AsyncMock(return_value=None)
+
+    skills = MagicMock()
+    skills.get_tool_definitions = MagicMock(return_value=[])
+    skills.get_descriptions = MagicMock(return_value="- no tools")
+    skills.list_skills = MagicMock(return_value=[])
+    skills.is_parallel_safe = MagicMock(return_value=True)
+    skills.get_loop_exempt_tools = MagicMock(return_value=frozenset())
+
+    llm = MagicMock()
+    if llm_responses:
+        llm.chat = AsyncMock(side_effect=llm_responses)
+    else:
+        llm.chat = AsyncMock(return_value=LLMResponse(
+            content='{"result": {"answer": "ok"}}', tokens_used=42,
+        ))
+    llm.default_model = "test-model"
+
+    mesh_client = MagicMock()
+    mesh_client.is_standalone = False
+    mesh_client.send_system_message = AsyncMock(return_value={})
+    mesh_client.read_blackboard = AsyncMock(return_value=None)
+    mesh_client.list_agents = AsyncMock(return_value={})
+
+    return AgentLoop(
+        agent_id="test_agent",
+        role="research",
+        memory=memory,
+        skills=skills,
+        llm=llm,
+        mesh_client=mesh_client,
+    )
+
+
+# ── Guard 1: stale checkpoint ────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_stale_checkpoint_at_max_iterations_starts_fresh():
+    """A checkpoint with iteration==MAX-1 implies start_iteration==MAX,
+    which the for-loop would skip entirely. Guard must clear it and run
+    a fresh task to completion."""
+    loop = _make_loop(real_memory=True)
+    task_id = "task_stale_cp"
+
+    # Pre-populate a checkpoint at the maximum iteration value.
+    assignment = TaskAssignment(
+        task_id=task_id, workflow_id="wf_test", step_id="step_1",
+        task_type="research", input_data={"query": "x"},
+    )
+
+    def _save():
+        loop.memory.save_task_checkpoint(
+            task_id=task_id,
+            messages=[{"role": "user", "content": "old"}],
+            iteration=loop.MAX_ITERATIONS - 1,  # start_iteration = MAX
+            tokens_used=0,
+            assignment_json=assignment.model_dump_json(),
+            budget_used_tokens=0,
+            budget_estimated_cost=0.0,
+            flush_triggered=False,
+        )
+
+    await loop.memory._run_db(_save)
+
+    # Sanity: checkpoint really is there.
+    pre = await loop.memory._run_db(loop.memory.load_task_checkpoint)
+    assert pre is not None
+    assert pre["iteration"] == loop.MAX_ITERATIONS - 1
+
+    # Run — the guard should discard and start fresh, letting the LLM
+    # respond with a final answer on iteration 0.
+    result = await loop.execute_task(assignment)
+
+    # If the guard didn't fire we'd hit "Max iterations reached" with
+    # 0 tokens and 0 iterations. Instead we should get a real completion.
+    assert result.status == "complete", (
+        f"expected complete, got {result.status} (error={result.error})"
+    )
+    assert result.tokens_used > 0
+
+
+# ── Guard 2: pathological success rejection ──────────────────────
+
+
+def test_pathological_guard_present_in_source():
+    """Belt-and-suspenders guard: the final-response branch will downgrade
+    to ``failed`` when both ``iterations_executed`` and ``total_tokens``
+    are zero — a combination that can't arise from a healthy run
+    (iterations_executed is always at least 1 by the time we reach the
+    success branch). Cannot be exercised via the normal loop path; we
+    pin the guard's presence and contract in source to prevent silent
+    removal during future refactors."""
+    from pathlib import Path
+
+    loop_src = Path("src/agent/loop.py").read_text()
+    # The guard's loud-log line, the operator-facing error message,
+    # and the corruption hint must all be present. The error string is
+    # split across source lines so we look for prefix + suffix.
+    assert "pathological success guard tripped" in loop_src
+    assert "execute_task returned success without doing" in loop_src
+    assert "checkpoint corruption" in loop_src
+    # And the guard must downgrade to failed, not silently log.
+    assert 'status="failed"' in loop_src
+
+
+# ── Guard 3: branch-exit logging ─────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_branch_exit_logging_fires_for_final_response(caplog):
+    """A normal completion logs an ``execute_task exit branch=...`` line
+    so future ghost-completes are diagnosable from logs."""
+    final = LLMResponse(content='{"result": {"answer": "ok"}}', tokens_used=42)
+    loop = _make_loop(llm_responses=[final])
+
+    assignment = TaskAssignment(
+        task_id="task_logger_final", workflow_id="wf_log", step_id="s1",
+        task_type="research", input_data={"q": "hello"},
+    )
+
+    with caplog.at_level(logging.INFO, logger="agent.loop"):
+        result = await loop.execute_task(assignment)
+
+    assert result.status == "complete"
+    branch_lines = [
+        r.message for r in caplog.records
+        if r.name == "agent.loop"
+        and "execute_task exit branch=" in r.message
+    ]
+    assert branch_lines, (
+        f"expected branch-exit log, got: "
+        f"{[r.message for r in caplog.records if r.name == 'agent.loop']}"
+    )
+    # The matching branch label should mention final_response.
+    assert any("branch=final_response" in m for m in branch_lines)
+
+
+@pytest.mark.asyncio
+async def test_branch_exit_logging_fires_for_exception(caplog):
+    """An exception path also produces an exit-branch log so we can
+    distinguish unrelated raises from the success path."""
+    # Force an LLM error mid-flight.
+    llm_resp = AsyncMock(side_effect=RuntimeError("llm exploded"))
+    loop = _make_loop()
+    loop.llm.chat = llm_resp
+
+    assignment = TaskAssignment(
+        task_id="task_logger_err", workflow_id="wf_log", step_id="s1",
+        task_type="research", input_data={"q": "x"},
+    )
+
+    with caplog.at_level(logging.INFO, logger="agent.loop"):
+        result = await loop.execute_task(assignment)
+
+    assert result.status == "failed"
+    branch_lines = [
+        r.message for r in caplog.records
+        if r.name == "agent.loop"
+        and "execute_task exit branch=" in r.message
+    ]
+    assert any("branch=exception" in m for m in branch_lines)

--- a/tests/test_health_liveness.py
+++ b/tests/test_health_liveness.py
@@ -1,0 +1,249 @@
+"""Tests for the loop-liveness signal (Bug 1).
+
+The health monitor previously only checked HTTP 200 on /status — a dead
+inner loop with a live FastAPI thread would report healthy. The fix
+plumbs ``last_iteration_ts`` + ``iterations_since_boot`` through
+``AgentStatus`` and adds a staleness branch in ``HealthMonitor`` that
+combines /status with the lane queue depth.
+"""
+
+from __future__ import annotations
+
+import time
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from src.host.health import HealthMonitor
+
+
+def _make_monitor(agents_info: dict | None = None, *, queue_depth_fn=None):
+    runtime = MagicMock()
+    runtime.agents = agents_info or {}
+    transport = MagicMock()
+    router = MagicMock()
+    event_bus = MagicMock()
+    monitor = HealthMonitor(
+        runtime=runtime, transport=transport, router=router,
+        event_bus=event_bus, queue_depth_fn=queue_depth_fn,
+    )
+    return monitor
+
+
+class TestLivenessFields:
+    """`AgentLoop._bump_liveness` must update the two attrs that get
+    surfaced on /status."""
+
+    def test_bump_liveness_updates_fields(self):
+        from src.agent.loop import AgentLoop
+
+        # Bypass __init__ — we only need the two attrs and the helper.
+        loop = AgentLoop.__new__(AgentLoop)
+        loop._last_iteration_ts = None
+        loop._iterations_since_boot = 0
+
+        before = time.time()
+        loop._bump_liveness()
+        after = time.time()
+
+        assert loop._iterations_since_boot == 1
+        assert loop._last_iteration_ts is not None
+        assert before <= loop._last_iteration_ts <= after
+
+        loop._bump_liveness()
+        assert loop._iterations_since_boot == 2
+
+    def test_agent_status_carries_liveness_fields(self):
+        """``AgentStatus`` must serialise the new optional fields."""
+        from src.shared.types import AgentStatus
+
+        ts = time.time()
+        s = AgentStatus(
+            agent_id="x", role="r", state="idle",
+            last_iteration_ts=ts,
+            iterations_since_boot=7,
+        )
+        dumped = s.model_dump()
+        assert dumped["last_iteration_ts"] == ts
+        assert dumped["iterations_since_boot"] == 7
+
+    def test_agent_status_defaults_safe(self):
+        """Old payloads without the fields must still deserialise."""
+        from src.shared.types import AgentStatus
+
+        s = AgentStatus.model_validate({
+            "agent_id": "x", "role": "r", "state": "idle",
+        })
+        assert s.last_iteration_ts is None
+        assert s.iterations_since_boot == 0
+
+
+class TestHealthLivenessCheck:
+    """The staleness rule: reachable + queue_depth>0 + stale iteration =>
+    unhealthy. Reachable + idle queue => healthy regardless of staleness."""
+
+    @pytest.mark.asyncio
+    async def test_reachable_busy_stale_marks_unhealthy(self):
+        """Wedged inner loop with queued work is treated as unhealthy."""
+        depth = {"agent-a": 3}
+        monitor = _make_monitor(queue_depth_fn=lambda a: depth.get(a, 0))
+        monitor.register("agent-a")
+        monitor.transport.is_reachable = AsyncMock(return_value=True)
+        # /status reports last_iteration_ts way in the past.
+        ancient = time.time() - 9999
+        monitor.transport.request = AsyncMock(return_value={
+            "agent_id": "agent-a", "state": "working",
+            "last_iteration_ts": ancient,
+            "iterations_since_boot": 12,
+        })
+
+        await monitor._check_agent("agent-a")
+        # First strike — not yet restarted but marked unhealthy.
+        h = monitor.agents["agent-a"]
+        assert h.status == "unhealthy", (
+            f"expected unhealthy, got {h.status}"
+        )
+        assert h.consecutive_failures == 1
+
+    @pytest.mark.asyncio
+    async def test_reachable_idle_stale_left_alone(self):
+        """No work in the queue → idle agent isn't expected to tick.
+        Must stay healthy even with no recent iteration."""
+        monitor = _make_monitor(queue_depth_fn=lambda a: 0)
+        monitor.register("agent-b")
+        monitor.transport.is_reachable = AsyncMock(return_value=True)
+        monitor.transport.request = AsyncMock(return_value={
+            "agent_id": "agent-b", "state": "idle",
+            "last_iteration_ts": time.time() - 9999,
+            "iterations_since_boot": 0,
+        })
+
+        await monitor._check_agent("agent-b")
+        h = monitor.agents["agent-b"]
+        assert h.status == "healthy"
+        assert h.consecutive_failures == 0
+
+    @pytest.mark.asyncio
+    async def test_reachable_busy_fresh_iteration_stays_healthy(self):
+        """Queue has work but the loop ticked recently — not stale."""
+        monitor = _make_monitor(queue_depth_fn=lambda a: 2)
+        monitor.register("agent-c")
+        monitor.transport.is_reachable = AsyncMock(return_value=True)
+        monitor.transport.request = AsyncMock(return_value={
+            "agent_id": "agent-c", "state": "working",
+            "last_iteration_ts": time.time() - 1,
+            "iterations_since_boot": 5,
+        })
+
+        await monitor._check_agent("agent-c")
+        h = monitor.agents["agent-c"]
+        assert h.status == "healthy"
+        assert h.consecutive_failures == 0
+
+    @pytest.mark.asyncio
+    async def test_no_queue_depth_fn_disables_staleness_check(self):
+        """Default wiring (no callback) must not regress reachability behaviour."""
+        monitor = _make_monitor()  # no queue_depth_fn
+        monitor.register("agent-d")
+        monitor.transport.is_reachable = AsyncMock(return_value=True)
+        # Even an obviously stale /status is ignored.
+        monitor.transport.request = AsyncMock(return_value={
+            "agent_id": "agent-d", "last_iteration_ts": 0,
+        })
+
+        await monitor._check_agent("agent-d")
+        h = monitor.agents["agent-d"]
+        assert h.status == "healthy"
+
+    @pytest.mark.asyncio
+    async def test_set_queue_depth_fn_after_construction(self):
+        """``set_queue_depth_fn`` enables the check post-hoc."""
+        monitor = _make_monitor()
+        monitor.set_queue_depth_fn(lambda a: 1)
+        monitor.register("agent-e")
+        monitor.transport.is_reachable = AsyncMock(return_value=True)
+        monitor.transport.request = AsyncMock(return_value={
+            "agent_id": "agent-e", "last_iteration_ts": time.time() - 600,
+        })
+
+        await monitor._check_agent("agent-e")
+        h = monitor.agents["agent-e"]
+        assert h.status == "unhealthy"
+
+    @pytest.mark.asyncio
+    async def test_status_fetch_failure_falls_back_to_healthy(self):
+        """A failed /status fetch must not flip an otherwise reachable
+        agent to unhealthy — best-effort branch."""
+        monitor = _make_monitor(queue_depth_fn=lambda a: 5)
+        monitor.register("agent-f")
+        monitor.transport.is_reachable = AsyncMock(return_value=True)
+        monitor.transport.request = AsyncMock(
+            side_effect=RuntimeError("status fetch died"),
+        )
+
+        await monitor._check_agent("agent-f")
+        h = monitor.agents["agent-f"]
+        assert h.status == "healthy"
+
+    @pytest.mark.asyncio
+    async def test_missing_last_iteration_ts_treated_as_not_stale(self):
+        """A freshly booted agent that hasn't ticked yet must not be
+        flagged stale."""
+        monitor = _make_monitor(queue_depth_fn=lambda a: 1)
+        monitor.register("agent-g")
+        monitor.transport.is_reachable = AsyncMock(return_value=True)
+        monitor.transport.request = AsyncMock(return_value={
+            "agent_id": "agent-g", "last_iteration_ts": None,
+        })
+
+        await monitor._check_agent("agent-g")
+        h = monitor.agents["agent-g"]
+        assert h.status == "healthy"
+
+    @pytest.mark.asyncio
+    async def test_queue_depth_fn_raises_handled_gracefully(self):
+        """If the lane callback raises, fall through to healthy."""
+        def boom(_):
+            raise RuntimeError("lane manager exploded")
+
+        monitor = _make_monitor(queue_depth_fn=boom)
+        monitor.register("agent-h")
+        monitor.transport.is_reachable = AsyncMock(return_value=True)
+        monitor.transport.request = AsyncMock(return_value={
+            "agent_id": "agent-h", "last_iteration_ts": 0,
+        })
+
+        # Pre-condition: status is "unknown" (just registered)
+        assert monitor.agents["agent-h"].status == "unknown"
+        await monitor._check_agent("agent-h")
+        h = monitor.agents["agent-h"]
+        assert h.status == "healthy"
+
+
+class TestLaneQueueDepthHelper:
+    """``LaneManager.get_queue_depth`` underpins the staleness branch."""
+
+    def test_unknown_agent_returns_zero(self):
+        from src.host.lanes import LaneManager
+
+        async def _dispatch(*args, **kw):
+            return ""
+
+        lm = LaneManager(dispatch_fn=_dispatch)
+        assert lm.get_queue_depth("never-seen") == 0
+
+    @pytest.mark.asyncio
+    async def test_busy_lane_adds_one(self):
+        """Busy flag counts as 1 even if the queue is empty."""
+        from src.host.lanes import LaneManager
+
+        async def _dispatch(*args, **kw):
+            return ""
+
+        lm = LaneManager(dispatch_fn=_dispatch)
+        lm._ensure_lane("agent")
+        # No queued tasks, but mark busy.
+        lm._busy["agent"] = True
+        assert lm.get_queue_depth("agent") == 1
+        lm._busy["agent"] = False
+        assert lm.get_queue_depth("agent") == 0

--- a/tests/test_health_liveness.py
+++ b/tests/test_health_liveness.py
@@ -162,8 +162,9 @@ class TestHealthLivenessCheck:
         monitor.set_queue_depth_fn(lambda a: 1)
         monitor.register("agent-e")
         monitor.transport.is_reachable = AsyncMock(return_value=True)
+        # Stale by 1200s (> default 900s threshold post codex P2 r2).
         monitor.transport.request = AsyncMock(return_value={
-            "agent_id": "agent-e", "last_iteration_ts": time.time() - 600,
+            "agent_id": "agent-e", "last_iteration_ts": time.time() - 1200,
         })
 
         await monitor._check_agent("agent-e")

--- a/tests/test_lanes.py
+++ b/tests/test_lanes.py
@@ -9,7 +9,7 @@ Covers:
 """
 
 import asyncio
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
@@ -468,3 +468,121 @@ async def test_origin_passed_to_dispatch_fn():
     await lm.enqueue("agent1", "hello", origin=origin)
 
     assert received_kwargs.get("origin") == origin
+
+
+# ── Per-task lane watchdog (Bug 4) ─────────────────────────────
+
+
+class TestLaneWatchdog:
+    """A hung dispatch_fn previously blocked the lane forever — every
+    subsequent task for that agent piled up indefinitely. The watchdog
+    wraps dispatch in ``asyncio.wait_for`` with a configurable timeout
+    and marks the durable task ``failed`` so the originator sees a
+    back-edge event."""
+
+    @pytest.mark.asyncio
+    async def test_hanging_dispatch_times_out_and_lane_recovers(self):
+        """Stuck dispatch is cancelled at the timeout; the next task runs."""
+        call_log = []
+
+        async def hanging_then_normal(agent, message, **kwargs):
+            call_log.append(message)
+            if message == "stuck":
+                await asyncio.sleep(60)  # never returns within the timeout
+                return "should never reach here"
+            return f"ok:{message}"
+
+        # Tight timeout so the test runs quickly.
+        lm = LaneManager(
+            dispatch_fn=hanging_then_normal,
+            task_timeout_seconds=1,
+        )
+
+        # First task hangs and should fail with TimeoutError.
+        with pytest.raises(asyncio.TimeoutError):
+            await lm.enqueue("agent1", "stuck")
+
+        # Second task on the same lane must still be picked up — the
+        # lane worker survived.
+        result = await lm.enqueue("agent1", "next")
+        assert result == "ok:next"
+        assert call_log == ["stuck", "next"]
+
+    @pytest.mark.asyncio
+    async def test_normal_dispatch_within_timeout_unchanged(self):
+        """Fast dispatch behaves exactly as before."""
+        dispatch = AsyncMock(return_value="hi")
+        lm = LaneManager(dispatch_fn=dispatch, task_timeout_seconds=5)
+
+        result = await lm.enqueue("agent1", "ping")
+        assert result == "hi"
+        dispatch.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_env_var_overrides_default_timeout(self, monkeypatch):
+        """``OPENLEGION_LANE_TIMEOUT_SECONDS`` is honoured at module load.
+        Re-importing the module after setting the env var picks it up."""
+        import importlib
+
+        monkeypatch.setenv("OPENLEGION_LANE_TIMEOUT_SECONDS", "42")
+        import src.host.lanes as lanes_mod
+
+        importlib.reload(lanes_mod)
+        try:
+            lm = lanes_mod.LaneManager(dispatch_fn=AsyncMock(return_value=""))
+            assert lm._task_timeout_seconds == 42
+        finally:
+            # Restore the default for downstream tests.
+            monkeypatch.delenv("OPENLEGION_LANE_TIMEOUT_SECONDS", raising=False)
+            importlib.reload(lanes_mod)
+
+    @pytest.mark.asyncio
+    async def test_timeout_marks_durable_task_failed(self):
+        """When the queued task has a ``task_id`` AND a tasks_store is
+        wired, the watchdog calls ``update_status('failed')`` so the
+        originator's back-edge inbox sees ``lane_timeout``."""
+        async def hanging(agent, message, **kwargs):
+            await asyncio.sleep(60)
+            return "never"
+
+        tasks_store = MagicMock()
+        tasks_store.update_status = MagicMock()
+        lm = LaneManager(
+            dispatch_fn=hanging,
+            task_timeout_seconds=1,
+            tasks_store=tasks_store,
+        )
+
+        with pytest.raises(asyncio.TimeoutError):
+            await lm.enqueue("agent1", "stuck", task_id="task-abc-123")
+
+        # update_status should have been invoked with the failed status
+        # and the lane_timeout marker.
+        tasks_store.update_status.assert_called_once()
+        args, kwargs = tasks_store.update_status.call_args
+        assert args[0] == "task-abc-123"
+        assert args[1] == "failed"
+        assert kwargs.get("actor") == "lane_watchdog"
+        extra = kwargs.get("extra_payload", {})
+        assert extra.get("error") == "lane_timeout"
+
+    @pytest.mark.asyncio
+    async def test_timeout_without_task_id_skips_task_update(self):
+        """Free-form lane messages (no task_id) just time out — no
+        durable-task bookkeeping to do."""
+        async def hanging(agent, message, **kwargs):
+            await asyncio.sleep(60)
+            return "never"
+
+        tasks_store = MagicMock()
+        tasks_store.update_status = MagicMock()
+        lm = LaneManager(
+            dispatch_fn=hanging,
+            task_timeout_seconds=1,
+            tasks_store=tasks_store,
+        )
+
+        with pytest.raises(asyncio.TimeoutError):
+            await lm.enqueue("agent1", "stuck")  # no task_id
+
+        tasks_store.update_status.assert_not_called()

--- a/tests/test_loop.py
+++ b/tests/test_loop.py
@@ -1838,6 +1838,51 @@ async def test_heartbeat_skips_when_no_rules():
 
 
 @pytest.mark.asyncio
+async def test_heartbeat_force_llm_bypasses_no_heartbeat_rules_skip():
+    """Bug 6 (codex P2 r2): force_llm=True must reach the LLM even with empty rules.
+
+    Pipeline-kicker agents intentionally have no HEARTBEAT.md content and
+    no goals (their job IS to think on a schedule and decide what to
+    do). Without force_llm propagation the agent-side
+    ``no_heartbeat_rules`` skip would silence them. Pin the bypass.
+    """
+    loop = _make_loop()
+    loop.llm.chat = AsyncMock(return_value=LLMResponse(content="kicked", tokens_used=10))
+    loop.mesh_client.introspect = AsyncMock(return_value={})
+    loop.mesh_client.read_blackboard = AsyncMock(return_value=None)
+    loop.workspace = MagicMock()
+    loop.workspace.get_bootstrap_content = MagicMock(return_value="")
+    loop.workspace.get_learnings_context = MagicMock(return_value="")
+    loop.workspace.load_heartbeat_rules = MagicMock(return_value="# Heartbeat Rules\n")
+    loop.workspace.append_daily_log = MagicMock()
+    loop.workspace.append_activity = MagicMock()
+
+    result = await loop.execute_heartbeat("Check stuff", force_llm=True)
+    assert not result.get("skipped", False)
+    loop.llm.chat.assert_called()
+
+
+@pytest.mark.asyncio
+async def test_heartbeat_force_llm_still_respects_agent_busy():
+    """Bug 6 (codex P2 r2): force_llm bypasses no_heartbeat_rules but NOT busy.
+
+    A busy agent has work in flight — running the heartbeat would
+    contend with the active state machine. force_llm is about
+    overriding the skip-LLM cost optimization, not about ignoring
+    safety interlocks. Pin that busy still wins.
+    """
+    loop = _make_loop()
+    # Mark the agent as already working.
+    await loop._chat_lock.acquire()
+    try:
+        result = await loop.execute_heartbeat("Check stuff", force_llm=True)
+        assert result["skipped"] is True
+        assert result["reason"] == "agent_busy"
+    finally:
+        loop._chat_lock.release()
+
+
+@pytest.mark.asyncio
 async def test_heartbeat_runs_when_empty_rules_but_goals_exist():
     """Heartbeat still runs when HEARTBEAT.md is empty but goals are set."""
     loop = _make_loop()


### PR DESCRIPTION
## Summary

Closes five trust gaps in the operator→agent seam surfaced in the 2026-05-17 platform audit. Each fix is small and independently reviewable; bundled together because they interlock around the same problem — the operator can't trust the runtime signals coming back from the agent fleet.

| # | Operator complaint | Fix |
|---|---|---|
| 1 | Dashboard shows agents `healthy` while their loops are dead | `AgentLoop` now stamps `last_iteration_ts` + `iterations_since_boot` at iteration head, post-LLM, and post-tool; `/status` surfaces them; `HealthMonitor` flags reachable+busy+stale as unhealthy (idle agents still pass — no false positives) |
| 2 | `hand_off` returns `handed_off: true` when wake fails — LLM reports success to user | Return `handed_off: false` + `task_queued: true` + `recovery_hint` when `wake_agent` raises. The task IS in the durable table either way; the contract just stops lying about the wake |
| 3 | `trend-scout` showed pending→done in 3s with empty logs | Three cheap guards: branch-name log at every `execute_task` exit, refuse to resume checkpoints with `iteration >= MAX_ITERATIONS`, reject `status=complete` with zero iterations AND zero tokens (downgrade to failed). Root cause is unconfirmed — these make the next occurrence debuggable and prevent the worst pathological return |
| 4 | Tasks stuck `working` for 10 days, lane blocked | `LaneManager._dispatch_fn` wrapped in `asyncio.wait_for(_DEFAULT_LANE_TIMEOUT_SECONDS=900)`. On timeout: durable task marked `failed(lane_timeout)` (back-edge inbox fires for the originator), lane freed, worker continues. `OPENLEGION_LANE_TIMEOUT_SECONDS` override |
| 6 | Autonomous pipeline-kicker agents never wake (skip-LLM strands them) | `CronJob.force_llm` boolean field bypasses the 4-condition skip; threaded end-to-end through `cron → heartbeat_dispatch_fn → x-force-llm header → /heartbeat → execute_heartbeat` so the agent-side `no_heartbeat_rules` skip is also bypassed. `agent_busy` skip still wins. Documented in `docs/triggering.md` |

Bugs explicitly dismissed after validation:
- Bug 5 (cron via /chat) — mischaracterized; lane backpressure already exists
- Bug 7 (`last_heartbeat_at` on skips) — operator misread the code; `_save()` fires before skip
- Bug 9 (`inspect_agents` asymmetric) — `read_agent_config` is the symmetric inverse already
- Bug 10 (allowlist SSRF for operator) — bad pattern; operator should use purpose-built tools
- Bug 12 (`propose_edit` missing `heartbeat_schedule`) — already in `_VALID_FIELDS`

Bugs 8 (bulk task archive) and 11 (peer workspace beyond artifacts) are real but UX-only and split for a follow-up PR.

## Test plan

- [x] `ruff check src/ tests/` — clean
- [x] Full unit + integration suite — **6125 passed, 69 skipped** (after both rounds)
- [x] New tests pin: liveness fields populated; reachable+busy+stale flagged; reachable+idle+stale left alone; lane watchdog cancels and marks failed; force_llm propagates through every hop; force_llm respects agent_busy; stale checkpoint discarded; pathological zero-work completion downgraded; hand_off returns `handed_off=false` on wake error
- [x] Two-round codex review (`codex review --base origin/main`) — fixed both P2s, second-round clean