### PR TITLE
refactor(shared): consolidate SQLite connect+pragma boilerplate

### DIFF
--- a/src/agent/memory.py
+++ b/src/agent/memory.py
@@ -28,6 +28,7 @@ from typing import Any, TypeVar
 import sqlite_vec
 from sqlite_vec import serialize_float32
 
+from src.shared.sqlite_helpers import open_db
 from src.shared.types import MemoryFact, MemoryLog
 from src.shared.utils import generate_id, setup_logging
 
@@ -64,9 +65,8 @@ class MemoryStore:
         categorize_fn: CategorizeFn | None = None,
     ):
         self._close_lock = threading.Lock()
-        self.db = sqlite3.connect(db_path, check_same_thread=False)
+        self.db = open_db(db_path)
         self.db.execute("PRAGMA journal_mode=WAL")
-        self.db.execute("PRAGMA busy_timeout=30000")
         self.db.enable_load_extension(True)
         sqlite_vec.load(self.db)
         self.db.enable_load_extension(False)

--- a/src/dashboard/conversations.py
+++ b/src/dashboard/conversations.py
@@ -35,10 +35,10 @@ implicit index on ``session_id`` that ``list_for_session()`` rides.
 
 from __future__ import annotations
 
-import sqlite3
 import time
 from pathlib import Path
 
+from src.shared.sqlite_helpers import open_db
 from src.shared.utils import setup_logging
 
 logger = setup_logging("dashboard.conversations")
@@ -55,9 +55,8 @@ class OpenedConversationsStore:
 
     def __init__(self, db_path: str | Path = "data/dashboard_conversations.db") -> None:
         Path(str(db_path)).parent.mkdir(parents=True, exist_ok=True)
-        self.db = sqlite3.connect(str(db_path), check_same_thread=False)
+        self.db = open_db(db_path)
         self.db.execute("PRAGMA journal_mode=WAL")
-        self.db.execute("PRAGMA busy_timeout=30000")
         self._init_schema()
 
     def _init_schema(self) -> None:

--- a/src/dashboard/notifications.py
+++ b/src/dashboard/notifications.py
@@ -29,11 +29,11 @@ via offset; the dashboard only ever reads the first page.
 from __future__ import annotations
 
 import json
-import sqlite3
 import time
 from pathlib import Path
 from typing import Any
 
+from src.shared.sqlite_helpers import open_db
 from src.shared.utils import setup_logging
 
 logger = setup_logging("dashboard.notifications")
@@ -58,9 +58,8 @@ class NotificationStore:
 
     def __init__(self, db_path: str = "data/dashboard_notifications.db") -> None:
         Path(db_path).parent.mkdir(parents=True, exist_ok=True)
-        self.db = sqlite3.connect(db_path, check_same_thread=False)
+        self.db = open_db(db_path)
         self.db.execute("PRAGMA journal_mode=WAL")
-        self.db.execute("PRAGMA busy_timeout=30000")
         self._init_schema()
 
     def _init_schema(self) -> None:

--- a/src/dashboard/telemetry.py
+++ b/src/dashboard/telemetry.py
@@ -17,13 +17,13 @@ yet — operators read the table directly via ``sqlite3 data/telemetry.db
 from __future__ import annotations
 
 import json
-import sqlite3
 import threading
 import time
 from collections import defaultdict, deque
 from pathlib import Path
 from typing import Any
 
+from src.shared.sqlite_helpers import open_db
 from src.shared.utils import setup_logging
 
 logger = setup_logging("dashboard.telemetry")
@@ -48,9 +48,8 @@ class DashboardTelemetry:
 
     def __init__(self, db_path: str = "data/telemetry.db") -> None:
         Path(db_path).parent.mkdir(parents=True, exist_ok=True)
-        self.db = sqlite3.connect(db_path, check_same_thread=False)
+        self.db = open_db(db_path)
         self.db.execute("PRAGMA journal_mode=WAL")
-        self.db.execute("PRAGMA busy_timeout=30000")
         self._lock = threading.Lock()
         self._init_schema()
         # Per-session rate buckets — sliding window of recent timestamps.

--- a/src/host/costs.py
+++ b/src/host/costs.py
@@ -9,11 +9,11 @@ Storage: SQLite (lightweight, no external services).
 from __future__ import annotations
 
 import json
-import sqlite3
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
 from src.shared.models import estimate_cost, get_model_cost  # noqa: F401 — re-export
+from src.shared.sqlite_helpers import open_db
 from src.shared.utils import setup_logging
 
 logger = setup_logging("host.costs")
@@ -38,9 +38,8 @@ class CostTracker:
 
     def __init__(self, db_path: str = "data/costs.db"):
         Path(db_path).parent.mkdir(parents=True, exist_ok=True)
-        self.db = sqlite3.connect(db_path, check_same_thread=False)
+        self.db = open_db(db_path)
         self.db.execute("PRAGMA journal_mode=WAL")
-        self.db.execute("PRAGMA busy_timeout=30000")
         self._init_schema()
         self.budgets: dict[str, dict[str, float]] = {}
         # ``_team_budgets`` (formerly ``_project_budgets``). Back-compat

--- a/src/host/mesh.py
+++ b/src/host/mesh.py
@@ -18,6 +18,7 @@ from typing import TYPE_CHECKING, Any
 
 import httpx
 
+from src.shared.sqlite_helpers import open_db
 from src.shared.types import AgentMessage, BlackboardEntry
 from src.shared.utils import setup_logging
 
@@ -47,9 +48,8 @@ class Blackboard:
     """
 
     def __init__(self, db_path: str = "blackboard.db", event_bus=None):
-        self.db = sqlite3.connect(db_path, check_same_thread=False)
+        self.db = open_db(db_path)
         self.db.execute("PRAGMA journal_mode=WAL")
-        self.db.execute("PRAGMA busy_timeout=30000")
         self._write_lock = threading.Lock()
         self._event_bus = event_bus
         self._last_ttl_gc: float = 0.0
@@ -610,9 +610,8 @@ class PubSub:
         self._lock = threading.Lock()
 
         if db_path is not None:
-            self._db = sqlite3.connect(db_path, check_same_thread=False)
+            self._db = open_db(db_path)
             self._db.execute("PRAGMA journal_mode=WAL")
-            self._db.execute("PRAGMA busy_timeout=30000")
             self._init_schema()
             self._load_subscriptions()
             self._load_events()

--- a/src/host/traces.py
+++ b/src/host/traces.py
@@ -15,6 +15,7 @@ import threading
 import time
 from pathlib import Path
 
+from src.shared.sqlite_helpers import open_db
 from src.shared.utils import setup_logging
 
 logger = setup_logging("host.traces")
@@ -28,9 +29,8 @@ class TraceStore:
         self._last_age_gc: float = -300.0  # ensure first GC runs regardless of monotonic() epoch
         self._gc_lock = threading.Lock()
         Path(db_path).parent.mkdir(parents=True, exist_ok=True)
-        self._conn = sqlite3.connect(db_path, check_same_thread=False)
+        self._conn = open_db(db_path, busy_timeout_ms=5000)
         self._conn.execute("PRAGMA journal_mode=WAL")
-        self._conn.execute("PRAGMA busy_timeout=5000")
         self._conn.execute("""
             CREATE TABLE IF NOT EXISTS traces (
                 id         INTEGER PRIMARY KEY AUTOINCREMENT,

--- a/src/host/wallet.py
+++ b/src/host/wallet.py
@@ -17,7 +17,6 @@ import base64
 import hashlib
 import hmac as _hmac
 import os
-import sqlite3
 import time
 from collections import deque
 from datetime import datetime, timezone
@@ -26,6 +25,7 @@ from typing import TYPE_CHECKING, Any
 
 import httpx
 
+from src.shared.sqlite_helpers import open_db
 from src.shared.utils import setup_logging
 
 if TYPE_CHECKING:
@@ -137,9 +137,8 @@ class WalletService:
         )
         self._chains = self._load_chains()
         Path(db_path).parent.mkdir(parents=True, exist_ok=True)
-        self.db = sqlite3.connect(db_path, check_same_thread=False)
+        self.db = open_db(db_path)
         self.db.execute("PRAGMA journal_mode=WAL")
-        self.db.execute("PRAGMA busy_timeout=30000")
         self._init_schema()
 
         # Policy defaults (overridable via env vars)

--- a/src/shared/sqlite_helpers.py
+++ b/src/shared/sqlite_helpers.py
@@ -1,0 +1,21 @@
+"""Shared SQLite helpers — common connect + pragma boilerplate."""
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+
+def open_db(
+    path: str | Path,
+    *,
+    busy_timeout_ms: int = 30000,
+    check_same_thread: bool = False,
+) -> sqlite3.Connection:
+    """Open a sqlite3 connection with the engine's standard pragmas.
+
+    Caller is responsible for any additional pragmas (journal_mode,
+    foreign_keys, etc.) and for closing the connection.
+    """
+    conn = sqlite3.connect(str(path), check_same_thread=check_same_thread)
+    conn.execute(f"PRAGMA busy_timeout={int(busy_timeout_ms)}")
+    return conn

--- a/src/shared/sqlite_helpers.py
+++ b/src/shared/sqlite_helpers.py
@@ -15,6 +15,12 @@ def open_db(
 
     Caller is responsible for any additional pragmas (journal_mode,
     foreign_keys, etc.) and for closing the connection.
+
+    Not covered by this helper (set inline at the call site instead):
+      - ``isolation_level=None`` (autocommit) — pass to ``sqlite3.connect``
+        directly; the helper does not expose it.
+      - URI form (``file:...?mode=ro`` with ``uri=True``) — use
+        ``sqlite3.connect`` directly for read-only or other URI modes.
     """
     conn = sqlite3.connect(str(path), check_same_thread=check_same_thread)
     conn.execute(f"PRAGMA busy_timeout={int(busy_timeout_ms)}")


### PR DESCRIPTION
## Summary
- Adds `src/shared/sqlite_helpers.py::open_db(path, *, busy_timeout_ms=30000, check_same_thread=False)`.
- Migrates 9 sites across 8 files (mesh, costs, traces, wallet, agent/memory, dashboard conversations/notifications/telemetry).
- Drops 4 now-unused `import sqlite3` lines.

## Context
Part of a 4-PR cleanup batch. The 2-line `sqlite3.connect(...)` + `PRAGMA busy_timeout=...` pattern repeated in ~13 modules. The helper is **intentionally minimal** — callers retain responsibility for additional pragmas (WAL, foreign_keys, etc.) so per-site behavior stays visible at the call site.

**11 sites NOT migrated** (documented reasons — left intact to avoid forcing the helper to grow):
- 6 sites (`pending_actions`, `change_history`, `orchestration`): use `isolation_level=None` (autocommit) inside `@contextmanager` — outside helper signature
- 2 sites (`team_migration`): default `check_same_thread=True` / no busy_timeout (read-only inspection)
- 2 sites (`dashboard/server.py`): URI form `file:...?mode=ro` with `uri=True` / default `check_same_thread=True`

**Pragma order at migrated sites:** changed from `connect→WAL→busy_timeout` to `connect→busy_timeout→WAL`. Both are independent idempotent connection-level settings; the full suite confirms no behavior change.

## Test plan
- [x] Full non-E2E pytest suite: **6145 passed**, 42 skipped, 0 failed
- [x] Targeted: 673/673 across all touched modules (test_mesh, test_costs, test_traces, test_wallet, test_memory, test_dashboard_*)
- [x] Smoke: `open_db(':memory:')` returns connection with `busy_timeout=30000`
- [x] `ruff check src/ tests/` passes

## Risk
Net **+15 LOC** (helper adds, site delta is roughly net-flat — half the original sites had compound pragmas the helper deliberately doesn't cover). Trade-off accepted: clarity at the common case, no behavior tunnel for the rare cases.