### PR TITLE
fix(test): stabilize flaky test_ttl_gc_runs_once_under_concurrent_writes

### DIFF
--- a/tests/test_mesh.py
+++ b/tests/test_mesh.py
@@ -95,8 +95,13 @@ def test_ttl_gc_runs_once_under_concurrent_writes(tmp_path):
 
     bb._gc_expired_unlocked = counting_gc
 
-    # Force the last GC time far in the past so the next call triggers GC
-    bb._last_ttl_gc = 0
+    # Force the last GC time far in the past so the next call triggers GC.
+    # ``float("-inf")`` is required because ``time.monotonic()`` is unsigned
+    # and can return values < _TTL_GC_INTERVAL on cold CI runners; setting
+    # ``_last_ttl_gc = 0`` would make ``now - 0 < 60`` evaluate True and the
+    # GC would silently skip (matches the sentinel pattern in
+    # ``src/host/traces.py:29``).
+    bb._last_ttl_gc = float("-inf")
 
     start_event = threading.Event()
 


### PR DESCRIPTION
## Summary

One-line fix for a flaky test that's blocked CI on 5+ PRs today.

**Root cause:** Test resets \`bb._last_ttl_gc = 0\` to force the throttle expired before calling \`_maybe_gc_ttl()\`. But the implementation in \`src/host/mesh.py:350-352\` checks:

\`\`\`python
if now - self._last_ttl_gc < self._TTL_GC_INTERVAL:
    return
\`\`\`

On cold CI runners where \`time.monotonic()\` returns values < 60, the comparison \`monotonic() - 0 < 60\` evaluates **True** and all 5 racing threads return early without running GC. Test then asserts \`gc_call_count == 1\` but sees \`0\`.

**Fix:** \`bb._last_ttl_gc = float("-inf")\` — guarantees the arithmetic always exceeds the interval regardless of monotonic clock epoch.

This matches the precedent in \`src/host/traces.py:29\` (\`_last_age_gc = -300.0\` initial, with comment "ensure first GC runs regardless of monotonic() epoch").

## Verification

- [x] 30 local iterations: **30 passed / 0 failed** (pre-fix would flake intermittently)
- [x] \`ruff check\` clean
- [x] The throttle logic itself is correct — \`_maybe_gc_ttl\` runs under \`_write_lock\`, single GC per interval window. No deeper concurrency bug.

## Risk

Zero. Test-only change, single line, with a documented production precedent for the sentinel pattern.