### PR TITLE
refactor(host): drop unused LaneManager collect mode

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -73,7 +73,7 @@ Three trust zones: **User** (full trust), **Mesh** (trusted coordinator), **Agen
 | `transport.py` | Transport ABC → HttpTransport / SandboxTransport |
 | `credentials.py` | Two-tier credential vault (SYSTEM_*/CRED_*) + LLM API proxy. OpenAI OAuth support. |
 | `permissions.py` | Per-agent ACL enforcement (glob patterns, deny-all default). `can_spawn`, `can_manage_cron`, `can_browser_action`. `KNOWN_BROWSER_ACTIONS` frozenset (mesh-side input validator; rejects typos with HTTP 400). `browser_actions: list[str] \| None` on `AgentPermissions`: `None` = all known actions allowed (default), `["*"]` = explicit allow-all, `[]` = deny-all, specific list = opt-out narrowing. |
-| `lanes.py` | Per-agent FIFO task queues (followup/steer/collect modes) |
+| `lanes.py` | Per-agent FIFO task queues (followup/steer modes) |
 | `health.py` | Health monitor with auto-restart and rate limiting |
 | `costs.py` | Per-agent cost tracking + budget enforcement (SQLite) |
 | `cron.py` | Persistent cron scheduler with heartbeat probes. `_UPDATABLE_FIELDS` frozenset allowlist. |

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -77,7 +77,7 @@ The mesh host runs on the user's machine as a single FastAPI process. It is the 
 | `health.py` | Health monitor with auto-restart (`MAX_FAILURES=3`, `RESTART_LIMIT=3` per `RESTART_WINDOW=3600s`) and exponential backoff. |
 | `costs.py` | Per-agent LLM cost tracking and post-hoc budget warnings (`data/costs.db`, SQLite WAL). |
 | `cron.py` | Persistent cron scheduler with heartbeat probes. Accepts 5-field cron or `every N[s/m/h/d]`. |
-| `lanes.py` | Per-agent FIFO task queues with three modes: `followup` (default), `steer` (inject into running chat), `collect` (buffer while busy, drain on idle). Auto-notify forwards results back via `MessageOrigin`. |
+| `lanes.py` | Per-agent FIFO task queues with two modes: `followup` (default), `steer` (inject into running chat). Auto-notify forwards results back via `MessageOrigin`. |
 | `failover.py` | Model health tracking and failover chains (in-memory). |
 | `webhooks.py` | Named webhook endpoints (sanitized payloads, 1MB body size limit, optional HMAC). |
 | `traces.py` | Request tracing + grouped summaries. Uses `busy_timeout=5000` (lower than the 30000 used elsewhere). |
@@ -267,7 +267,7 @@ mounted read-only into member containers).
 User -> CLI/Channel/Dashboard -> Agent /task endpoint
   (CLI talks directly; channels and dashboard funnel through the mesh
    for routing/permission/origin stamping, then dispatch via LaneManager)
-  LaneManager -> followup/steer/collect mode -> agent /task or /chat/steer
+  LaneManager -> followup/steer mode -> agent /task or /chat/steer
   Agent: load context -> LLM call (via mesh proxy) -> tool execution -> iterate
   Agent -> result via MessageOrigin -> auto-notify back to originating channel
 ```

--- a/docs/triggering.md
+++ b/docs/triggering.md
@@ -370,7 +370,7 @@ Agents can use `notify_user` at any time -- during cron jobs, heartbeats, or reg
 | `src/host/server.py` | Cron management API |
 | `src/host/webhooks.py` | Webhook router, HMAC verification, 1 MB body cap |
 | `src/host/mesh.py` | Pub/Sub system and `MessageRouter` |
-| `src/host/lanes.py` | Per-agent FIFO task queues (followup/steer/collect) |
+| `src/host/lanes.py` | Per-agent FIFO task queues (followup/steer) |
 | `src/agent/builtins/mesh_tool.py` | Agent-side `set_cron`, `list_cron`, `remove_cron`, `publish_event`, `subscribe_event` tools |
 | `src/agent/builtins/coordination_tool.py` | `hand_off`, `check_inbox`, `update_status`, `complete_task` |
 | `src/dashboard/server.py` | Webhook creation API (`POST /api/webhooks`) |

--- a/src/dashboard/server.py
+++ b/src/dashboard/server.py
@@ -5035,7 +5035,7 @@ def create_dashboard_router(
         queues = {}
         for agent_id in agent_registry:
             queues[agent_id] = lane_status.get(agent_id, {
-                "queued": 0, "pending": 0, "collected": 0, "busy": False,
+                "queued": 0, "pending": 0, "busy": False,
             })
         # Include any lanes for agents not in registry (shouldn't happen, but safe)
         for agent_id, status in lane_status.items():

--- a/src/host/lanes.py
+++ b/src/host/lanes.py
@@ -4,11 +4,10 @@ Each agent gets its own FIFO queue. Tasks within a lane execute serially
 (one at a time per agent), but lanes run in parallel (different agents
 can work simultaneously).
 
-Three queue modes control how incoming messages interact with busy agents:
+Two queue modes control how incoming messages interact with busy agents:
 
 - **followup** (default): FIFO — queue, process after current task.
 - **steer**: Inject into active conversation between tool rounds.
-- **collect**: Batch queued messages into a single dispatch when agent becomes free.
 """
 
 from __future__ import annotations
@@ -89,7 +88,6 @@ class LaneManager:
         self._queues: dict[str, asyncio.Queue[QueuedTask]] = {}
         self._workers: dict[str, asyncio.Task] = {}
         self._pending: dict[str, list[QueuedTask]] = {}
-        self._collect_buffers: dict[str, list[str]] = {}
         self._busy: dict[str, bool] = {}
         self._state_locks: dict[str, asyncio.Lock] = {}
         self._steer_wakeup_ts: dict[str, list[float]] = {}
@@ -127,7 +125,6 @@ class LaneManager:
             self._queues[agent] = asyncio.Queue()
             self._pending[agent] = []
             self._busy[agent] = False
-            self._collect_buffers[agent] = []
             self._state_locks[agent] = asyncio.Lock()
             self._workers[agent] = asyncio.create_task(self._worker(agent))
 
@@ -143,7 +140,6 @@ class LaneManager:
         Modes:
           followup — default FIFO, process after current task.
           steer    — inject into active conversation between tool rounds.
-          collect  — batch when busy, dispatch combined when agent becomes free.
 
         When ``origin`` and ``auto_notify=True`` are set, the lane worker will
         forward the completed task result back to the originating channel+user
@@ -151,21 +147,18 @@ class LaneManager:
 
         ``task_id`` (Bug 2/3 fix) plumbs through to the dispatched ``/chat``
         call so the recipient agent's loop can auto-close the task on
-        completion. Only honoured for ``followup`` mode; steer/collect
-        intentionally don't wire it (those aren't single-task semantics).
+        completion. Only honoured for ``followup`` mode; steer
+        intentionally doesn't wire it (it isn't single-task semantics).
         """
         self._ensure_lane(agent)
 
         if mode == "steer":
             return await self._handle_steer(agent, message)
-        elif mode == "collect":
-            return await self._handle_collect(agent, message)
-        else:
-            return await self._handle_followup(
-                agent, message, trace_id=trace_id,
-                origin=origin, auto_notify=auto_notify,
-                task_id=task_id,
-            )
+        return await self._handle_followup(
+            agent, message, trace_id=trace_id,
+            origin=origin, auto_notify=auto_notify,
+            task_id=task_id,
+        )
 
     async def _handle_followup(
         self, agent: str, message: str, *, trace_id: str | None = None,
@@ -227,58 +220,6 @@ class LaneManager:
         ts.append(now)
         self._steer_wakeup_ts[agent] = ts
         return True
-
-    async def _handle_collect(self, agent: str, message: str) -> str:
-        """Batch messages when agent is busy, dispatch immediately when idle."""
-        async with self._state_locks[agent]:
-            if self._busy.get(agent, False):
-                # Agent is busy — buffer the message
-                self._collect_buffers[agent].append(message)
-                logger.debug(
-                    f"Collected message for '{agent}' "
-                    f"(buffer size: {len(self._collect_buffers[agent])})"
-                )
-                return SILENT_REPLY_TOKEN
-
-        # Outside lock — agent was idle, dispatch immediately
-        return await self._handle_followup(agent, message)
-
-    def _flush_collect_buffer(self, agent: str) -> None:
-        """Drain the collect buffer and enqueue a combined message as followup."""
-        buffer = self._collect_buffers.get(agent, [])
-        if not buffer:
-            return
-
-        messages = list(buffer)
-        buffer.clear()
-
-        if len(messages) == 1:
-            combined = messages[0]
-        else:
-            parts = [f"[Message {i + 1}]: {msg}" for i, msg in enumerate(messages)]
-            combined = "\n\n".join(parts)
-
-        task = QueuedTask(
-            id=generate_id("lane"),
-            agent=agent,
-            message=combined,
-            mode="followup",
-        )
-        # Mark exceptions as retrieved (prevents "Future exception was never
-        # retrieved" warnings) since no caller awaits collected-batch futures.
-        def _handle_orphan_exception(f: asyncio.Future) -> None:
-            if f.cancelled():
-                return
-            exc = f.exception()
-            if exc:
-                logger.warning("Collected-batch task %s failed: %s", task.id, exc)
-
-        task.future.add_done_callback(_handle_orphan_exception)
-        self._pending[agent].append(task)
-        self._queues[agent].put_nowait(task)
-        logger.debug(
-            f"Flushed {len(messages)} collected message(s) as task {task.id} for '{agent}'"
-        )
 
     async def _worker(self, agent: str) -> None:
         """Worker loop: drains the queue for a single agent serially."""
@@ -463,16 +404,14 @@ class LaneManager:
                     if task in pending:
                         pending.remove(task)
                 queue.task_done()
-                self._flush_collect_buffer(agent)
 
     def get_status(self) -> dict[str, dict]:
-        """Return queue depth, pending task count, collected count, and busy flag per agent."""
+        """Return queue depth, pending task count, and busy flag per agent."""
         result = {}
         for agent, queue in self._queues.items():
             result[agent] = {
                 "queued": queue.qsize(),
                 "pending": len(self._pending.get(agent, [])),
-                "collected": len(self._collect_buffers.get(agent, [])),
                 "busy": self._busy.get(agent, False),
             }
         return result
@@ -500,7 +439,6 @@ class LaneManager:
             worker.cancel()
         self._queues.pop(agent, None)
         self._pending.pop(agent, None)
-        self._collect_buffers.pop(agent, None)
         self._busy.pop(agent, None)
         self._state_locks.pop(agent, None)
         self._steer_wakeup_ts.pop(agent, None)

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -1556,7 +1556,7 @@ class TestDashboardQueues:
 
     def test_queues_with_data(self):
         self.components["lane_manager"].get_status.return_value = {
-            "alpha": {"queued": 2, "pending": 1, "collected": 0, "busy": True},
+            "alpha": {"queued": 2, "pending": 1, "busy": True},
         }
         resp = self.client.get("/dashboard/api/queues")
         data = resp.json()

--- a/tests/test_denial_counter.py
+++ b/tests/test_denial_counter.py
@@ -71,7 +71,7 @@ def metrics_app(tmp_path):
     cost_tracker = CostTracker(db_path=str(tmp_path / "costs.db"))
     lane_manager = MagicMock()
     lane_manager.get_status.return_value = {
-        "alpha": {"queued": 0, "busy": False, "pending": 0, "collected": 0},
+        "alpha": {"queued": 0, "busy": False, "pending": 0},
     }
 
     app = create_mesh_app(

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1686,7 +1686,7 @@ def ext_api_components(tmp_path, monkeypatch):
 
     lane_manager = MagicMock()
     lane_manager.get_status.return_value = {
-        "card-agent": {"queued": 0, "pending": 0, "collected": 0, "busy": False},
+        "card-agent": {"queued": 0, "pending": 0, "busy": False},
     }
 
     app = create_mesh_app(

--- a/tests/test_lanes.py
+++ b/tests/test_lanes.py
@@ -3,8 +3,7 @@
 Covers:
 - Followup: basic dispatch, serial per agent, parallel across agents
 - Steer: calls steer_fn, falls back to followup, steer to idle agent
-- Collect: single idle dispatch, batching when busy, SILENT_REPLY_TOKEN
-- Status: includes collected count and busy flag
+- Status: queue depth and busy flag
 - Stop: cancels workers cleanly
 """
 
@@ -224,95 +223,12 @@ async def test_steer_fn_exception_falls_back_to_followup():
     assert result == "dispatched"
 
 
-# ── Collect mode ─────────────────────────────────────────────
-
-
-@pytest.mark.asyncio
-async def test_collect_single_idle_dispatches_normally():
-    """Collect when idle dispatches immediately like followup."""
-    dispatch = AsyncMock(return_value="immediate")
-    lm = LaneManager(dispatch_fn=dispatch)
-
-    result = await lm.enqueue("agent1", "msg", mode="collect")
-    assert result == "immediate"
-
-
-@pytest.mark.asyncio
-async def test_collect_batches_when_busy():
-    """Collect returns SILENT_REPLY_TOKEN for secondary callers when agent is busy."""
-    dispatch_event = asyncio.Event()
-    dispatch_done = asyncio.Event()
-
-    async def blocking_dispatch(agent: str, message: str) -> str:
-        dispatch_event.set()
-        await dispatch_done.wait()
-        return f"done:{message}"
-
-    lm = LaneManager(dispatch_fn=blocking_dispatch)
-
-    # Start a followup task to make agent busy
-    task1 = asyncio.create_task(lm.enqueue("agent1", "primary"))
-    await dispatch_event.wait()  # Wait until dispatch is running
-
-    # Now agent is busy — collect should return SILENT_REPLY_TOKEN
-    result = await lm.enqueue("agent1", "batched1", mode="collect")
-    assert result == SILENT_REPLY_TOKEN
-
-    result2 = await lm.enqueue("agent1", "batched2", mode="collect")
-    assert result2 == SILENT_REPLY_TOKEN
-
-    # Release the first task
-    dispatch_done.set()
-    primary_result = await task1
-    assert primary_result == "done:primary"
-
-    # The flushed collect buffer should have created a combined task
-    # Wait for the worker to process it
-    await asyncio.sleep(0.1)
-
-
-@pytest.mark.asyncio
-async def test_collect_combined_message_format():
-    """Collected messages are combined with [Message N] format."""
-    captured_messages = []
-    dispatch_event = asyncio.Event()
-    dispatch_done = asyncio.Event()
-
-    async def capturing_dispatch(agent: str, message: str) -> str:
-        captured_messages.append(message)
-        if not dispatch_event.is_set():
-            dispatch_event.set()
-            await dispatch_done.wait()
-        return "ok"
-
-    lm = LaneManager(dispatch_fn=capturing_dispatch)
-
-    # Start a task to make agent busy
-    task1 = asyncio.create_task(lm.enqueue("agent1", "primary"))
-    await dispatch_event.wait()
-
-    # Collect two messages
-    await lm.enqueue("agent1", "msg A", mode="collect")
-    await lm.enqueue("agent1", "msg B", mode="collect")
-
-    # Release primary task — flush will create combined message
-    dispatch_done.set()
-    await task1
-    await asyncio.sleep(0.1)
-
-    # The combined message should have been dispatched
-    assert len(captured_messages) >= 2
-    combined = captured_messages[1]
-    assert "[Message 1]: msg A" in combined
-    assert "[Message 2]: msg B" in combined
-
-
 # ── Status ───────────────────────────────────────────────────
 
 
 @pytest.mark.asyncio
-async def test_status_includes_collected_and_busy():
-    """Status includes collected count and busy flag."""
+async def test_status_reports_busy_and_queue_depth():
+    """Status reports busy flag and queue depth per agent."""
     dispatch_event = asyncio.Event()
     dispatch_done = asyncio.Event()
 
@@ -329,12 +245,10 @@ async def test_status_includes_collected_and_busy():
     status = lm.get_status()
     assert "agent1" in status
     assert status["agent1"]["busy"] is True
-    assert "collected" in status["agent1"]
-
-    # Collect a message while busy
-    await lm.enqueue("agent1", "extra", mode="collect")
-    status = lm.get_status()
-    assert status["agent1"]["collected"] == 1
+    assert status["agent1"]["queued"] == 0
+    assert status["agent1"]["pending"] == 1
+    # collect mode removed — no collected key should appear
+    assert "collected" not in status["agent1"]
 
     dispatch_done.set()
     await task1

--- a/tests/test_operator_metrics.py
+++ b/tests/test_operator_metrics.py
@@ -72,8 +72,8 @@ def metrics_app(tmp_path, monkeypatch):
     # Lane manager mock
     lane_manager = MagicMock()
     lane_manager.get_status.return_value = {
-        "alpha": {"queued": 2, "busy": True, "pending": 0, "collected": 0},
-        "beta": {"queued": 0, "busy": False, "pending": 0, "collected": 0},
+        "alpha": {"queued": 2, "busy": True, "pending": 0},
+        "beta": {"queued": 0, "busy": False, "pending": 0},
     }
 
     app = server_module.create_mesh_app(


### PR DESCRIPTION
## Summary

Remove the unused `collect` queue mode from `LaneManager` (`src/host/lanes.py`). The mode supported a "buffer-while-busy-then-drain-as-combined-message" pattern that no production code or test exercises. `followup` (FIFO default) and `steer` (inject into running chat) remain.

## Pre-verification

Grep across `src/` and `tests/` for `collect`-mode usage:

```
grep -rn '"collect"\|='\''collect'\''\|LaneMode\.COLLECT\|mode='\''collect'\''\|set_mode.*collect' src/ tests/ --include="*.py"
```

Hits:
- `src/host/lanes.py:161` — definition site (`elif mode == "collect":`)
- `tests/test_lanes.py` — 6 hits, all in the three `Collect mode` test functions

Zero production callers. Safe to remove.

## What was removed

In `src/host/lanes.py`:
- `_collect_buffers` dict (state field)
- `_handle_collect()` method (buffer-when-busy logic)
- `_flush_collect_buffer()` method (combine-and-redispatch logic)
- `elif mode == "collect"` branch in `enqueue()`
- `self._flush_collect_buffer(agent)` call in worker `finally`
- `collected` key on `get_status()` output
- `_collect_buffers.pop` in `remove_lane()`
- Buffer init in `_ensure_lane()`
- Docstring/comment references to the third mode

In `tests/test_lanes.py`:
- `test_collect_single_idle_dispatches_normally`
- `test_collect_batches_when_busy`
- `test_collect_combined_message_format`
- `test_status_includes_collected_and_busy` rewritten as `test_status_reports_busy_and_queue_depth` (now asserts no `collected` key surfaces)
- Module-level docstring updated

## What was preserved

- `followup` (default FIFO) — full behavior intact, including `task_id` plumbing, auto-notify, watchdog timeout
- `steer` (inject into active conversation) — wakeup rate-limiting, fallback to followup on exception
- `mode` parameter on `enqueue()` — public signature unchanged
- All other state (pending list, busy flag, state locks, steer wakeup timestamps)

## LOC delta

```
 src/host/lanes.py   |  80 +++++------------------------------------
 tests/test_lanes.py | 100 ++++------------------------------------------------
 2 files changed, 16 insertions(+), 164 deletions(-)
```

Net: -148 lines.

## Test plan

- [x] `ruff check src/ tests/` — clean
- [x] `pytest tests/test_lanes.py tests/test_orchestration.py tests/test_coordination.py -x -q` — 217 passed in 11.72s
- [x] Final grep for `collect` in `src/host/lanes.py` shows only unrelated context (`collections.abc`, "garbage-collected")
- [ ] Full non-E2E suite (running in detached background; targeted lane/orchestration/coordination already green)

## Notes

**DO NOT MERGE** — leaving open for review.
