### PR TITLE
refactor(shared): drop 5 dead project_* DashboardEvent.type literals

### DIFF
--- a/src/shared/types.py
+++ b/src/shared/types.py
@@ -684,15 +684,11 @@ class DashboardEvent(BaseModel):
         # payload).
         "agent_config_updated",
         # Team (formerly "project") CRUD — create / update / delete so
-        # the teams list refreshes without polling. PR 3 stopped emitting
-        # the legacy ``project_*`` names; the literals are retained here
-        # for type-safety on any historical-record code that still parses
-        # the older events (deprecated; no longer emitted).
-        "project_created",
-        "project_updated",
-        "project_deleted",
-        "project_archived",
-        "project_unarchived",
+        # the teams list refreshes without polling. The 5 legacy
+        # ``project_*`` literals were dropped on 2026-05-18 (see
+        # refactor/drop-dead-project-literals): PR 3 of the rename had
+        # already stopped emitting them, and no consumer / dispatcher /
+        # historical-record code in src/ or tests/ still references them.
         "team_created",
         "team_updated",
         "team_deleted",


### PR DESCRIPTION
## Summary

CLAUDE.md item #17 documents these 5 literals as "no longer emitted" after the project→team rename completed in PR 3. Removes them from \`DashboardEvent.type\` (55 → 50 entries).

## Pre-removal verification (all empty / clean)

- \`grep 'DashboardEvent(type="project_'\` in src/ + tests/
- \`grep 'event_bus.emit("project_'\` in src/ + tests/
- \`grep '"project_created"|"project_updated"|"project_deleted"|"project_archived"|"project_unarchived"'\` in src/dashboard/static/, templates/

All construction sites of DashboardEvent reach the Literal via \`_emit_team_event\` → \`_PROJECT_TO_TEAM_EVENT.get(legacy_event, legacy_event)\`, which always yields \`team_*\` names.

## Out of scope (separate PR)

The 5 call sites in \`server.py\` that pass \`"project_*"\` strings to \`_emit_team_event\` (typed \`str\`, not Literal) continue to work — \`_emit_team_event\` translates before emit. The full retirement of \`_PROJECT_TO_TEAM_EVENT\` mapping + call-site rewrites is queued for the project→team alias sunset (Tier-2-B).

## Test plan

- [x] Targeted: \`pytest tests/test_types.py tests/test_dashboard.py tests/test_events.py tests/test_mesh.py\` → **483 passed, 0 failed**
- [x] Pydantic loads cleanly (\`DashboardEvent.model_fields['type']\` has 50 literals)
- [x] \`ruff check src/shared/types.py\` clean

## Risk

Zero. Pydantic Literal validation runs on construction (not on already-deserialized values), and no construction path uses any of these 5 names.