### PR TITLE
refactor(workspace): lazy-create HEARTBEAT.md instead of eager bootstrap

### DIFF
--- a/src/agent/workspace.py
+++ b/src/agent/workspace.py
@@ -44,9 +44,18 @@ _SCAFFOLD_FILES: dict[str, str] = {
     "SOUL.md": "# Identity\n",
     "USER.md": "# User Context\n",
     "MEMORY.md": "# Long-Term Memory\n",
-    "HEARTBEAT.md": "# Heartbeat Rules\n",
     "INTERFACE.md": "# Interface\n",
 }
+# HEARTBEAT.md is intentionally NOT bootstrapped. Most agents never write
+# heartbeat rules — leaving the file absent (vs. empty) keeps the workspace
+# directory clean and avoids signalling "this agent has rules" when it
+# doesn't. Readers (loop._is_heartbeat_empty, workspace.load_heartbeat_rules,
+# /heartbeat-context, /workspace listing) all treat missing identically to
+# empty. The file is created lazily on first write — via either
+# ``edit_agent(field="heartbeat")`` (mesh-side PUT /workspace/HEARTBEAT.md),
+# the ``update_workspace`` agent tool, or the dashboard editor. Templates
+# that ship explicit heartbeat rules still seed the file via
+# ``initial_heartbeat`` below.
 
 _MAX_FILE_SIZE = 200_000
 
@@ -308,13 +317,6 @@ class WorkspaceManager:
                         + "\n"
                     )
                     path.write_text(content)
-                elif filename == "HEARTBEAT.md" and self._initial_heartbeat:
-                    content = (
-                        "# Heartbeat Rules\n\n"
-                        + self._initial_heartbeat.strip()
-                        + "\n"
-                    )
-                    path.write_text(content)
                 elif filename == "INTERFACE.md" and self._initial_interface:
                     content = (
                         "# Interface\n\n"
@@ -325,6 +327,18 @@ class WorkspaceManager:
                 else:
                     path.write_text(default_content)
                 logger.info(f"Created {filename}")
+
+        # HEARTBEAT.md: lazy-create. Only seed when a template supplied
+        # explicit rules; otherwise leave the file absent until first edit.
+        # See the _SCAFFOLD_FILES comment for the rationale.
+        heartbeat_path = self.root / self.HEARTBEAT_FILE
+        if not heartbeat_path.exists() and self._initial_heartbeat:
+            heartbeat_path.write_text(
+                "# Heartbeat Rules\n\n"
+                + self._initial_heartbeat.strip()
+                + "\n"
+            )
+            logger.info("Created %s (seeded from template)", self.HEARTBEAT_FILE)
 
     # ── Reading ──────────────────────────────────────────────
 

--- a/tests/test_loop.py
+++ b/tests/test_loop.py
@@ -1838,6 +1838,30 @@ async def test_heartbeat_skips_when_no_rules():
 
 
 @pytest.mark.asyncio
+async def test_heartbeat_dispatch_handles_missing_file():
+    """Lazy-create contract: missing HEARTBEAT.md must dispatch like empty.
+
+    After the lazy-bootstrap refactor, ``load_heartbeat_rules()`` returns
+    ``""`` (not a "# Heartbeat Rules\n" stub) when no file exists on disk.
+    ``_is_heartbeat_empty("")`` must still treat that as "no rules",
+    fire the ``no_heartbeat_rules`` skip without crashing, and never
+    reach the LLM. This pins the boundary so a future reader that grows
+    a strict-existence check can't silently break agents created after
+    the lazy-bootstrap change.
+    """
+    loop = _make_loop()
+    loop.workspace = MagicMock()
+    # Simulate the missing-file state — load_heartbeat_rules returns "".
+    loop.workspace.load_heartbeat_rules = MagicMock(return_value="")
+    loop._fetch_goals = AsyncMock(return_value=None)
+
+    result = await loop.execute_heartbeat("Check stuff")
+    assert result["skipped"] is True
+    assert result["reason"] == "no_heartbeat_rules"
+    loop.llm.chat.assert_not_called()
+
+
+@pytest.mark.asyncio
 async def test_heartbeat_force_llm_bypasses_no_heartbeat_rules_skip():
     """Bug 6 (codex P2 r2): force_llm=True must reach the LLM even with empty rules.
 

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -30,10 +30,27 @@ class TestWorkspaceScaffold:
         assert (root / "SOUL.md").exists()
         assert (root / "USER.md").exists()
         assert (root / "MEMORY.md").exists()
-        assert (root / "HEARTBEAT.md").exists()
         assert (root / "INTERFACE.md").exists()
+        # HEARTBEAT.md is lazy-created — see test_new_agent_has_no_heartbeat_file
+        assert not (root / "HEARTBEAT.md").exists()
         assert (root / "memory").is_dir()
         assert (root / "learnings").is_dir()
+
+    def test_new_agent_has_no_heartbeat_file(self):
+        """Pin the lazy-create contract: HEARTBEAT.md must NOT be bootstrapped.
+
+        Most agents never write heartbeat rules. Creating an empty file
+        signals "this agent has rules" when it doesn't, clutters the
+        workspace listing, and forces every reader to handle the empty
+        case anyway. The file is created lazily on first write.
+        """
+        root = Path(self._tmpdir)
+        assert not (root / "HEARTBEAT.md").exists()
+        # Re-instantiating must not create it either (no eager bootstrap).
+        WorkspaceManager(workspace_dir=self._tmpdir)
+        assert not (root / "HEARTBEAT.md").exists()
+        # Readers degrade gracefully on missing file
+        assert self.ws.load_heartbeat_rules() == ""
 
     def test_scaffold_preserves_existing_files(self):
         root = Path(self._tmpdir)
@@ -601,6 +618,13 @@ class TestLearnings:
         assert new_lines < original_lines
 
     def test_load_heartbeat_rules(self):
+        # No HEARTBEAT.md on a fresh workspace — lazy-create contract.
+        # See TestHeartbeatFile.test_load_heartbeat_rules_missing_file_returns_empty.
+        assert self.ws.load_heartbeat_rules() == ""
+        # Write some rules; reload reflects them.
+        (Path(self._tmpdir) / "HEARTBEAT.md").write_text(
+            "# Heartbeat Rules\n- ping inbox",
+        )
         rules = self.ws.load_heartbeat_rules()
         assert "Heartbeat Rules" in rules
 
@@ -631,12 +655,17 @@ class TestPerAgentSoul:
         assert "# Identity" in content
 
     def test_all_identity_files_scaffolded(self):
-        """All identity/workspace files are created with default content."""
+        """All identity/workspace files (sans HEARTBEAT.md) get default content.
+
+        HEARTBEAT.md is intentionally excluded — see
+        test_new_agent_has_no_heartbeat_file for the lazy-create rationale.
+        """
         root = Path(self._tmpdir)
-        for filename in ("SOUL.md", "INSTRUCTIONS.md", "USER.md", "MEMORY.md", "HEARTBEAT.md", "INTERFACE.md"):
+        for filename in ("SOUL.md", "INSTRUCTIONS.md", "USER.md", "MEMORY.md", "INTERFACE.md"):
             assert (root / filename).exists(), f"{filename} not scaffolded"
             content = (root / filename).read_text()
             assert content.strip(), f"{filename} has empty scaffold"
+        assert not (root / "HEARTBEAT.md").exists()
 
 
 class TestHeartbeatFile:
@@ -647,11 +676,27 @@ class TestHeartbeatFile:
     def teardown_method(self):
         shutil.rmtree(self._tmpdir, ignore_errors=True)
 
-    def test_heartbeat_scaffold(self):
+    def test_heartbeat_not_scaffolded(self):
+        """HEARTBEAT.md is lazy-created — no file present on a fresh workspace."""
         root = Path(self._tmpdir)
+        assert not (root / "HEARTBEAT.md").exists()
+
+    def test_first_heartbeat_write_creates_file(self):
+        """First write via update_file auto-creates HEARTBEAT.md.
+
+        This is the dashboard / edit_agent / update_workspace tool path:
+        no eager bootstrap, but the very first heartbeat edit must succeed
+        without a separate "initialize" step.
+        """
+        root = Path(self._tmpdir)
+        assert not (root / "HEARTBEAT.md").exists()
+        result = self.ws.update_file(
+            "HEARTBEAT.md", "# My Rules\n- Check inbox every hour",
+        )
+        assert result.get("updated") is True
         assert (root / "HEARTBEAT.md").exists()
-        content = (root / "HEARTBEAT.md").read_text()
-        assert "Heartbeat Rules" in content
+        rules = self.ws.load_heartbeat_rules()
+        assert "Check inbox every hour" in rules
 
     def test_custom_heartbeat_rules(self):
         root = Path(self._tmpdir)
@@ -659,6 +704,18 @@ class TestHeartbeatFile:
         ws = WorkspaceManager(workspace_dir=self._tmpdir)
         rules = ws.load_heartbeat_rules()
         assert "Check email" in rules
+
+    def test_load_heartbeat_rules_missing_file_returns_empty(self):
+        """load_heartbeat_rules returns "" when HEARTBEAT.md doesn't exist.
+
+        This is the contract every reader relies on — _is_heartbeat_empty,
+        the /heartbeat-context endpoint, and the cron skip-LLM optimization
+        all expect "" for a missing file, semantically identical to
+        "no rules".
+        """
+        root = Path(self._tmpdir)
+        assert not (root / "HEARTBEAT.md").exists()
+        assert self.ws.load_heartbeat_rules() == ""
 
 
 class TestUpdateFile:


### PR DESCRIPTION
## Summary

Most agents never write heartbeat rules — the bootstrapped `HEARTBEAT.md` stays empty forever, signalling "this agent has rules" when it doesn't and forcing every reader to handle the empty case anyway. This PR drops the eager scaffold and leans on the existing missing-vs-empty parity that readers already implement.

- `workspace.py` removes `HEARTBEAT.md` from `_SCAFFOLD_FILES`; the file is now created on first write.
- Template seeding via `initial_heartbeat` still works — moved out of the scaffold loop into an explicit conditional so the back-compat surface for fleet templates is preserved.
- `_FILE_CAPS` entry for `HEARTBEAT.md` retained (file cap still applies once it exists).

## Reader audit — every path verified

| Reader | Missing-file behavior |
|---|---|
| `workspace.load_heartbeat_rules` | `_read_file()` returns `None` → `or ""` |
| `workspace._read_file` | explicit `if not path.exists(): return None` |
| `workspace.update_file` | `path.write_text()` auto-creates; `if path.exists()` guards backup |
| `workspace.get_bootstrap_content` | `_BOOTSTRAP_FILES` never included HEARTBEAT.md |
| `loop._is_heartbeat_empty` | `if not content: return True` |
| `loop.execute_heartbeat` | composes the two above; `no_heartbeat_rules` skip fires |
| `agent/server GET /workspace` | `size = stat if exists else 0` + `is_default=True` |
| `agent/server GET /workspace/{file}` | `_read_file() or ""` |
| `agent/server PUT /workspace/{file}` | `path.write_text()` auto-creates |
| `agent/server GET /heartbeat-context` | `load_heartbeat_rules()` + default-detection on `""` |
| `host/cron` | uses `/heartbeat-context` via `context_fn`; `ctx.get("heartbeat_rules", "")` |
| `host/server edit_agent heartbeat write` | `PUT /workspace/HEARTBEAT.md` |
| `dashboard/server` | proxies to agent endpoints |
| `mesh_tool.update_workspace` | empty `old_content` maps to "Initialized" branch |
| `cli/repl` | reads via `/workspace/{filename}` returns `""` |

No reader hard-fails on missing — every one already handled the "empty file" case the same way.

## Tests

New tests pinning the lazy-create contract:
- `test_new_agent_has_no_heartbeat_file` — no eager bootstrap
- `test_first_heartbeat_write_creates_file` — auto-create on first edit
- `test_heartbeat_dispatch_handles_missing_file` — `execute_heartbeat` skips cleanly when `load_heartbeat_rules()` returns `""`

Updated existing tests to match the new surface: `test_scaffold_creates_default_files`, `test_all_identity_files_scaffolded`, `test_heartbeat_scaffold` (renamed `test_heartbeat_not_scaffolded`), `test_load_heartbeat_rules`.

## Test plan

- [x] `ruff check src/ tests/` — clean
- [x] `pytest tests/test_workspace.py tests/test_loop.py tests/test_cron.py tests/test_operator_e2e.py tests/test_agent_server.py tests/test_builtins.py tests/test_operator_fleet.py -x -q` — 556 passed
- [x] Full non-E2E suite — 6207 passed, 49 skipped
- [ ] Manual: spin up a fresh agent via `openlegion start` and confirm `ls workspace/` shows no HEARTBEAT.md, dashboard heartbeat editor still works