### PR TITLE
refactor(agent): use shared new_trace_id helper for auto-resume

### DIFF
--- a/src/agent/__main__.py
+++ b/src/agent/__main__.py
@@ -25,6 +25,7 @@ from src.agent.mesh_client import MeshClient
 from src.agent.server import create_agent_app
 from src.agent.skills import SkillRegistry
 from src.agent.workspace import WorkspaceManager
+from src.shared.trace import new_trace_id
 from src.shared.utils import setup_logging
 
 logger = setup_logging("agent.main")
@@ -197,7 +198,6 @@ def main() -> None:
             try:
                 cp = await loop.memory._run_db(loop.memory.load_task_checkpoint)
                 if cp:
-                    from src.shared.trace import new_trace_id
                     from src.shared.types import TaskAssignment
                     _resume_trace_id = new_trace_id()
                     assignment = TaskAssignment.model_validate_json(cp["assignment_json"])

--- a/src/agent/__main__.py
+++ b/src/agent/__main__.py
@@ -9,7 +9,6 @@ from __future__ import annotations
 import asyncio
 import json
 import os
-import secrets
 import sys
 from contextlib import asynccontextmanager, suppress
 from pathlib import Path
@@ -198,8 +197,9 @@ def main() -> None:
             try:
                 cp = await loop.memory._run_db(loop.memory.load_task_checkpoint)
                 if cp:
+                    from src.shared.trace import new_trace_id
                     from src.shared.types import TaskAssignment
-                    _resume_trace_id = f"tr_{secrets.token_hex(6)}"
+                    _resume_trace_id = new_trace_id()
                     assignment = TaskAssignment.model_validate_json(cp["assignment_json"])
                     logger.info(
                         "Auto-resuming task %s from checkpoint (iteration %d) trace=%s",

--- a/tests/test_auto_resume.py
+++ b/tests/test_auto_resume.py
@@ -92,15 +92,14 @@ class TestAutoResume:
         # We test the lifespan logic by importing and simulating the relevant
         # section. Since lifespan is tightly coupled to __main__.py, we
         # replicate the core logic here and verify behavior.
-        import secrets
-
+        from src.shared.trace import new_trace_id
         from src.shared.types import TaskAssignment as TA
 
         # Simulate the auto-resume block
         if loop.memory:
             result_cp = await loop.memory._run_db(loop.memory.load_task_checkpoint)
             if result_cp:
-                _resume_trace_id = f"tr_{secrets.token_hex(6)}"
+                _resume_trace_id = new_trace_id()
                 parsed = TA.model_validate_json(result_cp["assignment_json"])
                 loop.state = "working"
                 loop.current_task = parsed.task_id


### PR DESCRIPTION
## Summary

- Replace inlined `f"tr_{secrets.token_hex(6)}"` in agent auto-resume with `new_trace_id()` from `src/shared/trace.py` — the canonical generator
- Drop the now-unused `import secrets`
- Update `test_auto_resume.py` reproduction block in the same shape so the test mirrors production code

## Surface

Two 1-line swaps:
- `src/agent/__main__.py:202` — `secrets.token_hex(6)` → `new_trace_id()`
- `tests/test_auto_resume.py:103` — same swap in the simulation block

## Why

Eliminates the last manual trace_id generator in the codebase. `new_trace_id()` returns the identical `tr_<12 lowercase hex chars>` shape, just sourced from `uuid.uuid4().hex[:12]` instead of `secrets.token_hex(6)`. Both are CSPRNG-backed; trace-correlation behavior is unchanged.

Net: -2 LOC, +0 behavior change.

## Test plan

- [x] `pytest tests/test_auto_resume.py -x -v` — 7 passed
- [x] `ruff check` — clean
- [ ] CI green