### PR TITLE
refactor(shared): extract resolve_under_root path-traversal helper (11 sites)

### DIFF
--- a/src/agent/builtins/image_gen_tool.py
+++ b/src/agent/builtins/image_gen_tool.py
@@ -13,6 +13,7 @@ import re
 from pathlib import Path
 
 from src.agent.skills import skill
+from src.shared.paths import resolve_under_root
 from src.shared.utils import setup_logging
 
 logger = setup_logging("agent.image_gen")
@@ -90,9 +91,13 @@ async def generate_image(
     if "." not in filename:
         filename += ".png"
 
-    # Final safety check: ensure resolved path stays within artifacts dir
-    resolved = (_ARTIFACTS_DIR / filename).resolve()
-    if not str(resolved).startswith(str(_ARTIFACTS_DIR.resolve())):
+    # Final safety check: ensure resolved path stays within artifacts dir.
+    # NOTE: the prior check used str().startswith() which has a latent
+    # suffix-collision bug (``/x/artifacts2`` would false-pass against root
+    # ``/x/artifacts``); resolve_under_root uses is_relative_to which
+    # correctly rejects that case.
+    resolved = resolve_under_root(_ARTIFACTS_DIR, filename)
+    if resolved is None:
         return {"error": "Invalid filename — path traversal not allowed"}
 
     try:

--- a/src/agent/builtins/mesh_tool.py
+++ b/src/agent/builtins/mesh_tool.py
@@ -11,6 +11,7 @@ import time
 from pathlib import Path
 
 from src.agent.skills import skill
+from src.shared.paths import resolve_under_root
 from src.shared.utils import dumps_safe, sanitize_for_prompt, setup_logging
 
 logger = setup_logging("agent.builtins.mesh_tool")
@@ -415,8 +416,8 @@ async def save_artifact(
     try:
         artifacts_dir = Path(workspace_manager.root) / "artifacts"
         artifacts_dir.mkdir(parents=True, exist_ok=True)
-        filepath = (artifacts_dir / name).resolve()
-        if not filepath.is_relative_to(artifacts_dir.resolve()):
+        filepath = resolve_under_root(artifacts_dir, name)
+        if filepath is None:
             return {"error": f"Invalid artifact name: {name}"}
         filepath.parent.mkdir(parents=True, exist_ok=True)
         filepath.write_text(content)

--- a/src/agent/server.py
+++ b/src/agent/server.py
@@ -35,6 +35,7 @@ from typing import TYPE_CHECKING
 from fastapi import FastAPI, HTTPException, Request
 from fastapi.responses import StreamingResponse
 
+from src.shared.paths import resolve_under_root
 from src.shared.types import (
     AgentMessage,
     ChatMessage,
@@ -608,8 +609,8 @@ def create_agent_app(loop: AgentLoop) -> FastAPI:
         if not _ARTIFACT_NAME_RE.match(name):
             raise HTTPException(400, f"Invalid artifact name: {name}")
         artifacts_dir = Path(loop.workspace.root) / "artifacts"
-        filepath = (artifacts_dir / name).resolve()
-        if not filepath.is_relative_to(artifacts_dir.resolve()):
+        filepath = resolve_under_root(artifacts_dir, name)
+        if filepath is None:
             raise HTTPException(400, "Path traversal not allowed")
         if not filepath.is_file():
             raise HTTPException(404, f"Artifact not found: {name}")
@@ -703,9 +704,8 @@ def create_agent_app(loop: AgentLoop) -> FastAPI:
 
         artifacts_dir = Path(loop.workspace.root) / "artifacts"
         artifacts_dir.mkdir(parents=True, exist_ok=True)
-        target = (artifacts_dir / name).resolve()
-        resolved_dir = artifacts_dir.resolve()
-        if not target.is_relative_to(resolved_dir):
+        target = resolve_under_root(artifacts_dir, name)
+        if target is None:
             raise HTTPException(400, "Path traversal not allowed")
         target.parent.mkdir(parents=True, exist_ok=True)
 
@@ -745,7 +745,7 @@ def create_agent_app(loop: AgentLoop) -> FastAPI:
             raise HTTPException(400, "Empty request body")
 
         os.replace(partial, final)
-        rel_name = str(final.relative_to(resolved_dir))
+        rel_name = str(final.relative_to(artifacts_dir.resolve()))
         mime = mimetypes.guess_type(rel_name)[0] or "application/octet-stream"
         logger.info(
             "Ingested artifact %s (%d bytes)", rel_name, bytes_written,
@@ -765,8 +765,8 @@ def create_agent_app(loop: AgentLoop) -> FastAPI:
         if not _ARTIFACT_NAME_RE.match(name):
             raise HTTPException(400, f"Invalid artifact name: {name}")
         artifacts_dir = Path(loop.workspace.root) / "artifacts"
-        filepath = (artifacts_dir / name).resolve()
-        if not filepath.is_relative_to(artifacts_dir.resolve()):
+        filepath = resolve_under_root(artifacts_dir, name)
+        if filepath is None:
             raise HTTPException(400, "Path traversal not allowed")
         if not filepath.is_file():
             raise HTTPException(404, f"Artifact not found: {name}")

--- a/src/agent/workspace.py
+++ b/src/agent/workspace.py
@@ -35,6 +35,7 @@ import time
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
+from src.shared.paths import resolve_under_root
 from src.shared.utils import dumps_safe, sanitize_for_prompt, setup_logging
 
 logger = setup_logging("agent.workspace")
@@ -465,9 +466,8 @@ class WorkspaceManager:
         return combined
 
     def _read_file(self, relative_path: str) -> str | None:
-        path = self.root / relative_path
-        resolved = path.resolve()
-        if not resolved.is_relative_to(self.root.resolve()):
+        path = resolve_under_root(self.root, relative_path)
+        if path is None:
             return None
         if not path.exists() or not path.is_file():
             return None
@@ -514,9 +514,9 @@ class WorkspaceManager:
         if len(content) > self._MAX_WRITABLE_SIZE:
             return {"error": f"Content too large ({len(content)} chars). Max is {self._MAX_WRITABLE_SIZE}."}
 
-        path = (self.root / filename).resolve()
         # Defense-in-depth: ensure resolved path stays within workspace
-        if not path.is_relative_to(self.root.resolve()):
+        path = resolve_under_root(self.root, filename)
+        if path is None:
             return {"error": f"Invalid filename: {filename}"}
         backup_dir = self.root / "backups"
         backup_dir.mkdir(exist_ok=True)

--- a/src/browser/server.py
+++ b/src/browser/server.py
@@ -20,6 +20,7 @@ from fastapi import FastAPI, HTTPException, Request, WebSocket
 from fastapi.responses import JSONResponse, StreamingResponse
 
 from src.browser.service import BrowserManager, BrowserPoolExhausted
+from src.shared.paths import resolve_under_root
 from src.shared.trace import TRACE_HEADER, current_trace_id
 from src.shared.types import AGENT_ID_RE_PATTERN
 from src.shared.utils import setup_logging
@@ -1064,15 +1065,14 @@ def create_browser_app(manager: BrowserManager, lifespan=None) -> FastAPI:
         root = Path(_UPLOADS_ROOT)
         if not root.is_dir():
             raise HTTPException(503, "Uploads directory not available")
-        root = root.resolve()
         try:
             p = Path(path)
         except ValueError:
             raise HTTPException(400, "Invalid path")
         if p.is_absolute() or ".." in p.parts:
             raise HTTPException(400, "Invalid path")
-        candidate = (root / path).resolve()
-        if not candidate.is_relative_to(root):
+        candidate = resolve_under_root(root, path)
+        if candidate is None:
             raise HTTPException(400, "Path traversal not allowed")
         if not candidate.exists() or not candidate.is_file():
             raise HTTPException(404, f"Upload not found: {path}")

--- a/src/dashboard/server.py
+++ b/src/dashboard/server.py
@@ -7154,8 +7154,8 @@ def create_dashboard_router(
 
     @api_router.get("/static/{file_path:path}")
     async def static_file(file_path: str, v: str | None = None) -> FileResponse:
-        full = (_STATIC_DIR / file_path).resolve()
-        if not str(full).startswith(str(_STATIC_DIR)) or not full.is_file():
+        full = resolve_under_root(_STATIC_DIR, file_path)
+        if full is None or not full.is_file():
             raise HTTPException(status_code=404, detail="Not found")
         suffix = full.suffix.lower()
         # When served with a versioned URL (?v=<hash>), cache aggressively —

--- a/src/dashboard/server.py
+++ b/src/dashboard/server.py
@@ -45,6 +45,7 @@ from jinja2 import Environment, FileSystemLoader
 
 from src.cli.proxy import build_proxy_env_vars, resolve_agent_proxy
 from src.dashboard.auth import verify_session_cookie
+from src.shared.paths import resolve_under_root
 from src.shared.sqlite_helpers import open_db
 from src.shared.utils import dumps_safe, friendly_streaming_error, sanitize_for_prompt, setup_logging
 
@@ -6305,9 +6306,8 @@ def create_dashboard_router(
             raise HTTPException(400, "Invalid path")
         if p.is_absolute() or ".." in p.parts:
             raise HTTPException(400, "Invalid path")
-        root = _uploads_dir().resolve()
-        candidate = (root / name).resolve()
-        if not candidate.is_relative_to(root):
+        candidate = resolve_under_root(_uploads_dir(), name)
+        if candidate is None:
             raise HTTPException(400, "Path traversal not allowed")
         return candidate
 

--- a/src/host/server.py
+++ b/src/host/server.py
@@ -36,6 +36,7 @@ from src.host.orchestration import (
     Tasks,
 )
 from src.host.pending_actions import PendingActions
+from src.shared.paths import resolve_under_root
 from src.shared.redaction import redact_url
 from src.shared.types import (
     AGENT_ID_RE_PATTERN,
@@ -6929,14 +6930,10 @@ def create_mesh_app(
         _UPLOAD_STAGE_MAX_MB = 50
     _UPLOAD_STAGE_MAX_BYTES = _UPLOAD_STAGE_MAX_MB * 1024 * 1024
 
-    _stage_dir_resolved = _UPLOAD_STAGE_DIR.resolve()
-
     def _stage_paths(handle: str) -> tuple[_Path, _Path]:
-        bin_path = (_UPLOAD_STAGE_DIR / f"{handle}.bin").resolve()
-        meta_path = (_UPLOAD_STAGE_DIR / f"{handle}.json").resolve()
-        if not bin_path.is_relative_to(_stage_dir_resolved):
-            raise HTTPException(400, "invalid handle")
-        if not meta_path.is_relative_to(_stage_dir_resolved):
+        bin_path = resolve_under_root(_UPLOAD_STAGE_DIR, f"{handle}.bin")
+        meta_path = resolve_under_root(_UPLOAD_STAGE_DIR, f"{handle}.json")
+        if bin_path is None or meta_path is None:
             raise HTTPException(400, "invalid handle")
         return bin_path, meta_path
 

--- a/src/shared/paths.py
+++ b/src/shared/paths.py
@@ -1,0 +1,39 @@
+"""Shared filesystem path helpers — primitives for safe path containment.
+
+Kept separate from ``utils.py`` because path-containment is a security
+primitive and benefits from being discoverable in a path-named module
+rather than mixed with JSON/id/text helpers.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def resolve_under_root(root: Path, name: str | Path) -> Path | None:
+    """Resolve ``root / name`` and return it iff it stays within ``root``.
+
+    Both ``root`` and the final candidate are resolved (symlinks followed,
+    ``..`` collapsed) so the check rejects:
+
+    - traversal via ``..`` (e.g. ``"../etc/passwd"``)
+    - absolute paths (e.g. ``"/etc/passwd"`` — Python's ``/`` operator
+      lets an absolute right-hand side override the left)
+    - symlinks whose target escapes ``root``
+    - suffix-collision prefixes (e.g. ``/tmp/artifacts2`` is NOT inside
+      ``/tmp/artifacts`` — ``startswith`` would false-positive here)
+
+    Returns ``None`` when the resolved path escapes ``root``. Callers own
+    the error response (HTTPException, dict-error, silent ``None``).
+
+    Not solved by this helper:
+
+    - TOCTOU between resolve and subsequent file ops (caller's concern)
+    - Filename validation (empty string, ``"."`` etc. resolve to ``root``
+      itself and pass the containment check; callers should reject those
+      upstream via regex/allowlist)
+    """
+    root_resolved = root.resolve()
+    target = (root_resolved / name).resolve()
+    if not target.is_relative_to(root_resolved):
+        return None
+    return target

--- a/src/shared/paths.py
+++ b/src/shared/paths.py
@@ -16,14 +16,17 @@ def resolve_under_root(root: Path, name: str | Path) -> Path | None:
     ``..`` collapsed) so the check rejects:
 
     - traversal via ``..`` (e.g. ``"../etc/passwd"``)
-    - absolute paths (e.g. ``"/etc/passwd"`` — Python's ``/`` operator
-      lets an absolute right-hand side override the left)
+    - **any absolute ``name``** (e.g. ``"/etc/passwd"``, or even
+      ``"/x/root_resolved/file"`` that happens to land inside ``root`` —
+      relative-name semantics are enforced unconditionally so callers
+      never accidentally accept a fully-qualified path)
     - symlinks whose target escapes ``root``
     - suffix-collision prefixes (e.g. ``/tmp/artifacts2`` is NOT inside
       ``/tmp/artifacts`` — ``startswith`` would false-positive here)
 
-    Returns ``None`` when the resolved path escapes ``root``. Callers own
-    the error response (HTTPException, dict-error, silent ``None``).
+    Returns ``None`` when ``name`` is absolute or when the resolved path
+    escapes ``root``. Callers own the error response (HTTPException,
+    dict-error, silent ``None``).
 
     Not solved by this helper:
 
@@ -32,6 +35,8 @@ def resolve_under_root(root: Path, name: str | Path) -> Path | None:
       itself and pass the containment check; callers should reject those
       upstream via regex/allowlist)
     """
+    if Path(name).is_absolute():
+        return None
     root_resolved = root.resolve()
     target = (root_resolved / name).resolve()
     if not target.is_relative_to(root_resolved):

--- a/tests/test_shared_paths.py
+++ b/tests/test_shared_paths.py
@@ -25,6 +25,37 @@ def test_absolute_path_escapes_returns_none(tmp_path: Path):
     assert resolve_under_root(tmp_path, "/etc/passwd") is None
 
 
+def test_absolute_path_inside_root_still_rejected(tmp_path: Path):
+    """Even an absolute name that *would* land inside root is rejected.
+
+    This pins the unconditional ``is_absolute()`` guard: callers must pass
+    relative names, otherwise a tightly-targeted absolute path could
+    accept a fully-qualified path that happens to fall under root and
+    bypass relative-name input validation upstream.
+    """
+    # Construct an absolute path whose resolved value IS under tmp_path.
+    absolute_inside = str((tmp_path / "subdir" / "file.txt").resolve())
+    assert resolve_under_root(tmp_path, absolute_inside) is None
+
+
+def test_symlink_inside_root_resolves(tmp_path: Path):
+    """Positive case: symlink whose target IS inside root must succeed.
+
+    Pairs with the negative ``test_symlink_escape_returns_none`` — the
+    helper must not reject all symlinks, only those whose target escapes.
+    """
+    target = tmp_path / "real_file.txt"
+    target.write_text("hi")
+    link = tmp_path / "link_to_real"
+    os.symlink(target, link)
+    try:
+        result = resolve_under_root(tmp_path, "link_to_real")
+        assert result == target.resolve()
+    finally:
+        link.unlink()
+        target.unlink()
+
+
 def test_symlink_escape_returns_none(tmp_path: Path):
     """A symlink whose target is outside root must be rejected."""
     outside = tmp_path.parent / "outside_target.txt"

--- a/tests/test_shared_paths.py
+++ b/tests/test_shared_paths.py
@@ -1,0 +1,78 @@
+"""Tests for ``src.shared.paths.resolve_under_root``."""
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+from src.shared.paths import resolve_under_root
+
+
+def test_valid_nested_path_returns_resolved(tmp_path: Path):
+    """Valid name under root returns the resolved absolute path."""
+    (tmp_path / "sub").mkdir()
+    result = resolve_under_root(tmp_path, "sub/file.txt")
+    assert result == (tmp_path / "sub" / "file.txt").resolve()
+
+
+def test_dot_dot_traversal_returns_none(tmp_path: Path):
+    """`..` traversal that escapes root returns None."""
+    assert resolve_under_root(tmp_path, "../escape.txt") is None
+    assert resolve_under_root(tmp_path, "sub/../../escape.txt") is None
+
+
+def test_absolute_path_escapes_returns_none(tmp_path: Path):
+    """Absolute path RHS overrides root via `/` operator — must be rejected."""
+    assert resolve_under_root(tmp_path, "/etc/passwd") is None
+
+
+def test_symlink_escape_returns_none(tmp_path: Path):
+    """A symlink whose target is outside root must be rejected."""
+    outside = tmp_path.parent / "outside_target.txt"
+    outside.write_text("secret")
+    link = tmp_path / "symlink"
+    os.symlink(outside, link)
+    try:
+        assert resolve_under_root(tmp_path, "symlink") is None
+    finally:
+        link.unlink()
+        outside.unlink()
+
+
+def test_suffix_collision_returns_none(tmp_path: Path):
+    """`/a/bcd` is NOT inside `/a/b` — startswith-style checks would
+    false-positive here, but is_relative_to correctly rejects."""
+    sibling = tmp_path.parent / (tmp_path.name + "_sibling")
+    sibling.mkdir()
+    try:
+        # Build a relative path that escapes root then re-enters a sibling
+        # whose name shares a prefix with root.
+        rel = f"../{sibling.name}/file.txt"
+        assert resolve_under_root(tmp_path, rel) is None
+    finally:
+        sibling.rmdir()
+
+
+def test_empty_name_resolves_to_root(tmp_path: Path):
+    """Empty name returns root itself (caller validates filename separately)."""
+    # Empty / "." both resolve to root and pass containment.
+    assert resolve_under_root(tmp_path, "") == tmp_path.resolve()
+    assert resolve_under_root(tmp_path, ".") == tmp_path.resolve()
+
+
+def test_nonexistent_path_still_validates(tmp_path: Path):
+    """Helper does not require the candidate to exist — pure path math."""
+    result = resolve_under_root(tmp_path, "does_not_exist.md")
+    assert result == (tmp_path / "does_not_exist.md").resolve()
+
+
+def test_nonexistent_root_still_validates(tmp_path: Path):
+    """`root.resolve()` does not require existence."""
+    fake_root = tmp_path / "does_not_exist_root"
+    result = resolve_under_root(fake_root, "file.txt")
+    assert result == (fake_root / "file.txt").resolve()
+
+
+def test_path_argument_accepted(tmp_path: Path):
+    """Accepts Path as the name argument too, not only str."""
+    result = resolve_under_root(tmp_path, Path("sub/file.txt"))
+    assert result == (tmp_path / "sub" / "file.txt").resolve()


### PR DESCRIPTION
## Summary

- New helper `src/shared/paths.py::resolve_under_root(root, name) -> Path | None` for the `(root / name).resolve() + is_relative_to(root.resolve())` containment idiom
- 11 callsites migrated across 7 source files
- 9 characterization tests pinning the contract (incl. suffix-collision case)
- Helper returns `Path | None`; callsites preserve their original error shape (HTTPException, dict-error, silent None) — no API change at any callsite

## Migrated sites

| File | Sites | Error shape preserved |
|---|---|---|
| `src/agent/server.py` | 3 (read / ingest / delete) | HTTPException(400, "Path traversal not allowed") |
| `src/agent/workspace.py` | 2 (_read_file / update_file) | `None` and `{"error": ...}` respectively |
| `src/agent/builtins/mesh_tool.py` | 1 (save_artifact) | `{"error": f"Invalid artifact name: {name}"}` |
| `src/agent/builtins/image_gen_tool.py` | 1 (final filename check) | **see behavior-change note below** |
| `src/browser/server.py` | 1 (`/uploads/{path}`) | HTTPException(400) |
| `src/dashboard/server.py` | 1 (`_resolve_upload_path`) | HTTPException(400) |
| `src/host/server.py` | 1 function, 2 calls (`_stage_paths`) | HTTPException(400, "invalid handle") |

## :warning: One behavior change at `image_gen_tool.py:94-95`

That site previously used `str(resolved).startswith(str(_ARTIFACTS_DIR.resolve()))` which has a latent suffix-collision bug: `/x/artifacts2/foo` would false-pass against root `/x/artifacts`. `is_relative_to` correctly rejects this.

**Practical impact**: zero. Upstream sanitization at lines 86-87 (`Path(filename).name` + `_FILENAME_UNSAFE_RE`) strips directory components and unsafe chars before this final check, so no realistic input could trigger the bypass. But the guard is now correct in principle.

## Out of scope (deferred)

- `src/agent/builtins/file_tool.py:46-74` — two-stage symlink walk with intermediate target check; deeper defense, not a direct match for this helper.
- `src/dashboard/server.py:7157` — static-asset `str().startswith()` check (same latent-bug shape as image_gen_tool). Codex review flagged as "not a simple replacement" so deferred to a focused follow-up.

## Test plan

- [x] 9/9 new helper tests pass (`tests/test_shared_paths.py`)
- [x] `tests/test_agent_server.py` — 58/58 pass
- [x] `tests/test_workspace.py` — 116/116 pass
- [x] `tests/test_builtins.py` — 221/221 pass
- [x] `tests/test_image_gen.py` — 27/27 pass (incl. `test_generate_image_path_traversal`)
- [x] `tests/test_dashboard.py` + `tests/test_browser_upload_mesh.py` — 377/377 pass
- [x] `ruff check` — clean on all 9 touched files
- [ ] CI green

## Net

+151 / -31. Helper + tests + cleaner callsites. One site tightens (security improvement), rest are pure refactor.