### PR TITLE
docs(config,host): clarify operator browser delegation + canonical scope env var

### DIFF
--- a/src/cli/config.py
+++ b/src/cli/config.py
@@ -1814,6 +1814,16 @@ def _ensure_operator_agent(config_path: Path | None = None, default_model: str =
         _OPERATOR_AGENT_ID,
         permissions={
             "can_spawn": True,
+            # Operator has ``can_use_browser=False`` by design: it
+            # coordinates the fleet but does not drive browsers itself.
+            # ``request_browser_login`` / ``request_captcha_help``
+            # work through the delegation path — operator calls the
+            # skill with ``agent_id=target_worker`` so cookies / session
+            # state land in the worker's browser profile (the agent
+            # that will actually use them). See
+            # ``src/shared/operator_playbooks.py`` for the documented
+            # delegation pattern and ``tests/test_operator_config.py``
+            # for the design test.
             "can_use_browser": False,
             # Operator gets internet (HTTPS + web search) by default so
             # it can fetch reference material and answer factual

--- a/src/host/server.py
+++ b/src/host/server.py
@@ -2396,11 +2396,12 @@ def create_mesh_app(
 
         Task 5 layered a per-caller filter on the unscoped path. Today's
         legacy behavior is "every authenticated agent sees the full
-        fleet" — under ``OPENLEGION_PROJECT_SCOPE_MODE=enforce`` workers
-        see only members of their own projects (plus the always-global
-        operator). Under ``warn`` (the default), the response shape
-        stays legacy and a structured ``scope-warn`` log line is emitted
-        so operators can soak before flipping.
+        fleet" — under ``OPENLEGION_TEAM_SCOPE_MODE=enforce`` (the
+        default; legacy ``OPENLEGION_PROJECT_SCOPE_MODE`` still honored
+        as a back-compat alias) workers see only members of their own
+        projects (plus the always-global operator). Under ``warn`` the
+        response shape stays legacy and a structured ``scope-warn`` log
+        line is emitted so operators can soak before flipping.
         """
         if agent_id:
             agent_id = _resolve_agent_id(agent_id, request)


### PR DESCRIPTION
## Summary

Two documentation polish items deferred from #943. No code changes.

**(1) `src/cli/config.py` — operator browser delegation comment.** The `can_use_browser=False` default for operator looks like a mistake to anyone skimming after the trust-tier PR added explicit carve-outs for `can_browser_action`. Added an inline comment explaining the design: operator coordinates, workers drive. `request_browser_login` / `request_captcha_help` work through the documented delegation path (operator calls with `agent_id=target_worker`). Cross-references `src/shared/operator_playbooks.py` and `tests/test_operator_config.py`.

**(2) `src/host/server.py` — canonical scope env var.** `/mesh/agents` docstring referenced `OPENLEGION_PROJECT_SCOPE_MODE` and claimed `warn` was the default. Flipped to `OPENLEGION_TEAM_SCOPE_MODE` (canonical post project→team rename per PR #914) and dropped the stale `(the default)` claim — `enforce` is the actual default.

## Test plan

- [x] Pure docs; no test surface changes. Existing `test_operator_config.py` tests still pin `can_use_browser=False` as design.