### PR TITLE
feat: operator workflow awareness — silent-handoff defense + lane back-edge wiring + workflow_snapshot

### DIFF
--- a/src/agent/builtins/coordination_tool.py
+++ b/src/agent/builtins/coordination_tool.py
@@ -250,10 +250,20 @@ async def hand_off(
                 ),
             }
 
-    # Read the origin contextvar once so both create_task and wake_agent
-    # propagate the same provenance.
-    from src.shared.trace import current_origin as _current_origin
+    # Read origin + current task id contextvars once so both create_task
+    # and wake_agent propagate the same provenance. ``current_task_id``
+    # links the new task into the parent's workflow chain so
+    # ``workflow_snapshot`` can walk the descendants from the kickoff
+    # root. Outside a task context (heartbeats, free chat) the var is
+    # ``None`` and the new task lands as a workflow root.
+    from src.shared.trace import (
+        current_origin as _current_origin,
+    )
+    from src.shared.trace import (
+        current_task_id as _current_task_id,
+    )
     origin = _current_origin.get()
+    parent_task_id = _current_task_id.get()
 
     try:
         record = await mesh_client.create_task(
@@ -262,6 +272,7 @@ async def hand_off(
             description=description,
             project=write_project,
             priority=0,
+            parent_task_id=parent_task_id,
             artifact_refs=[artifact_ref] if artifact_ref else None,
             origin=origin,
         )

--- a/src/agent/builtins/operator_tools.py
+++ b/src/agent/builtins/operator_tools.py
@@ -890,6 +890,161 @@ async def get_team_outputs(
 
 
 @skill(
+    name="workflow_snapshot",
+    description=(
+        "Read a workflow chain snapshot for a multi-stage handoff. Pass "
+        "the kickoff task_id (the root task you created when launching "
+        "the workflow); returns every descendant stage with status and "
+        "age. Use this in heartbeats and after task_failed/task_blocked "
+        "wakes to see where the workflow is, which stage is stuck, and "
+        "what age each stage has been in its current status. Returns "
+        "{'error': 'not_found'} when the root id doesn't exist."
+    ),
+    parameters={
+        "root_task_id": {
+            "type": "string",
+            "description": "Kickoff task_id (the workflow root)",
+        },
+    },
+)
+async def workflow_snapshot(
+    root_task_id: str,
+    *,
+    mesh_client=None,
+    **_kw,
+) -> dict:
+    """Operator-only workflow chain snapshot via mesh endpoint."""
+    if not _is_operator():
+        return {"error": "This tool is only available to the operator agent."}
+    if mesh_client is None:
+        return {"error": "No mesh_client available"}
+    try:
+        result = await mesh_client.get_workflow_snapshot(root_task_id)
+    except Exception as e:
+        return {
+            "error": f"Failed to read workflow snapshot: {e}",
+            "root_task_id": root_task_id,
+        }
+    if result is None:
+        return {"error": "not_found", "root_task_id": root_task_id}
+    return result
+
+
+# Cap below the agent loop's 300s tool execution ceiling so an await
+# completes (and returns its ``timed_out`` shape) before the loop's own
+# timeout cancels the tool call. Default is well under the cap so a
+# nominal handoff completes inside one tool round.
+_AWAIT_TASK_EVENT_MAX_TIMEOUT_S = 270
+_AWAIT_TASK_EVENT_DEFAULT_TIMEOUT_S = 240
+
+
+@skill(
+    name="await_task_event",
+    description=(
+        "Block until a specific task reaches a terminal status (done / "
+        "failed / blocked / cancelled) or the timeout elapses. Polls "
+        "the operator's back-edge inbox with exponential backoff. Use "
+        "this when you need to wait for one specific child task to "
+        "finish before proceeding (e.g. confirming a setup handoff). "
+        "For multi-stage chains, prefer workflow_snapshot — this skill "
+        "is a single-task blocking primitive. Max timeout is 270s so "
+        "the call can return cleanly before the agent loop's tool "
+        "execution ceiling cancels it. Returns the terminal event or "
+        "{'timed_out': true, 'last_status_seen': '...'} on timeout."
+    ),
+    parameters={
+        "task_id": {
+            "type": "string",
+            "description": "Task id to wait on",
+        },
+        "timeout_s": {
+            "type": "integer",
+            "description": (
+                "Max seconds to wait (default 240; capped at 270 "
+                "below the 300s tool execution ceiling)"
+            ),
+            "default": _AWAIT_TASK_EVENT_DEFAULT_TIMEOUT_S,
+        },
+        "poll_interval_s": {
+            "type": "integer",
+            "description": "Initial polling interval (default 3)",
+            "default": 3,
+        },
+    },
+)
+async def await_task_event(
+    task_id: str,
+    timeout_s: int = _AWAIT_TASK_EVENT_DEFAULT_TIMEOUT_S,
+    poll_interval_s: int = 3,
+    *,
+    mesh_client=None,
+    **_kw,
+) -> dict:
+    """Poll the operator's inbox for a terminal back-edge event."""
+    import asyncio
+    import time as _time
+
+    if not _is_operator():
+        return {"error": "This tool is only available to the operator agent."}
+    if mesh_client is None:
+        return {"error": "No mesh_client available"}
+    if not task_id:
+        return {"error": "task_id is required"}
+
+    timeout = max(1, min(int(timeout_s), _AWAIT_TASK_EVENT_MAX_TIMEOUT_S))
+    interval = max(1, int(poll_interval_s))
+    terminal_kinds = {
+        "task_completed", "task_failed",
+        "task_blocked", "task_cancelled",
+    }
+    deadline = _time.monotonic() + timeout
+    last_status_seen: str | None = None
+    inbox_prefix = f"inbox/{mesh_client.agent_id}/task_event/"
+
+    while True:
+        try:
+            entries = await mesh_client.list_blackboard(
+                inbox_prefix, global_scope=True,
+            )
+        except Exception as e:
+            return {
+                "error": f"Inbox fetch failed: {e}",
+                "task_id": task_id,
+            }
+        for entry in entries:
+            value = entry.get("value") or {}
+            if value.get("task_id") != task_id:
+                continue
+            kind = value.get("kind", "")
+            if kind in terminal_kinds:
+                return {
+                    "event": {
+                        "kind": kind,
+                        "task_id": task_id,
+                        "status": value.get("status"),
+                        "title": value.get("title"),
+                        "summary": value.get("summary", ""),
+                        "error": value.get("error", ""),
+                        "blocker_note": value.get("blocker_note", ""),
+                        "ts": value.get("ts"),
+                    },
+                }
+            last_status_seen = value.get("status") or last_status_seen
+        remaining = deadline - _time.monotonic()
+        if remaining <= 0:
+            return {
+                "timed_out": True,
+                "task_id": task_id,
+                "last_status_seen": last_status_seen,
+                "waited_seconds": timeout,
+            }
+        # Exponential backoff capped at 30s and the remaining window.
+        sleep_for = min(interval, remaining, 30.0)
+        await asyncio.sleep(sleep_for)
+        interval = min(interval * 2, 30)
+
+
+@skill(
     name="inspect_agents",
     description=(
         "Read agents. Without agent_id: roster summary. With agent_id: "

--- a/src/agent/builtins/operator_tools.py
+++ b/src/agent/builtins/operator_tools.py
@@ -932,8 +932,12 @@ async def workflow_snapshot(
 
 # Cap below the agent loop's 300s tool execution ceiling so an await
 # completes (and returns its ``timed_out`` shape) before the loop's own
-# timeout cancels the tool call. Default is well under the cap so a
-# nominal handoff completes inside one tool round.
+# timeout cancels the tool call. Each inbox poll is wrapped in
+# ``asyncio.wait_for(..., _AWAIT_TASK_EVENT_POLL_BUDGET_S)`` so a stuck
+# HTTP retry chain (``_get_with_retry`` worst-case ≈ 90s with 3×30s
+# attempts) can't push our wall-clock past the ceiling — the per-poll
+# budget bounds each iteration to a known maximum.
+_AWAIT_TASK_EVENT_POLL_BUDGET_S = 15
 _AWAIT_TASK_EVENT_MAX_TIMEOUT_S = 270
 _AWAIT_TASK_EVENT_DEFAULT_TIMEOUT_S = 240
 
@@ -1002,10 +1006,33 @@ async def await_task_event(
     inbox_prefix = f"inbox/{mesh_client.agent_id}/task_event/"
 
     while True:
+        # Don't start another poll if there isn't time for it to finish
+        # cleanly. With ``_AWAIT_TASK_EVENT_POLL_BUDGET_S`` of slack we
+        # return ``timed_out`` rather than risk pushing wall-clock past
+        # the agent loop's 300s tool ceiling.
+        remaining_before_poll = deadline - _time.monotonic()
+        if remaining_before_poll <= _AWAIT_TASK_EVENT_POLL_BUDGET_S:
+            return {
+                "timed_out": True,
+                "task_id": task_id,
+                "last_status_seen": last_status_seen,
+                "waited_seconds": timeout,
+            }
         try:
-            entries = await mesh_client.list_blackboard(
-                inbox_prefix, global_scope=True,
+            # Each poll is bounded by ``_AWAIT_TASK_EVENT_POLL_BUDGET_S``
+            # to keep the worst-case iteration time predictable even if
+            # the mesh's ``_get_with_retry`` chain would otherwise burn
+            # ~90s on a flaky link.
+            entries = await asyncio.wait_for(
+                mesh_client.list_blackboard(
+                    inbox_prefix, global_scope=True,
+                ),
+                timeout=_AWAIT_TASK_EVENT_POLL_BUDGET_S,
             )
+        except asyncio.TimeoutError:
+            # Treat per-poll timeout as transient — the back-edge may
+            # arrive on the next poll. Fall through to the sleep + retry.
+            entries = []
         except Exception as e:
             return {
                 "error": f"Inbox fetch failed: {e}",

--- a/src/agent/loop.py
+++ b/src/agent/loop.py
@@ -134,10 +134,17 @@ _BLACKBOARD_TOOLS = frozenset({
 
 # Read-only tools allowed during operator heartbeat (unsupervised execution).
 # The full operator allowlist is restricted to this subset so heartbeats
-# cannot mutate fleet state without user approval.
+# cannot mutate fleet state without user approval. ``check_inbox`` is
+# read-only — needed so any agent can pick up back-edge events during
+# its heartbeat tick instead of waiting until the next /chat turn.
+# ``workflow_snapshot`` and ``await_task_event`` are operator-tier reads
+# (the skills self-reject for non-operator callers via ``_is_operator``);
+# adding them here lets operator's heartbeat surface workflow state
+# without dropping out to a full /chat turn.
 _HEARTBEAT_TOOLS = frozenset({
     "list_agents", "get_agent_profile", "get_system_status",
-    "notify_user", "save_observations",
+    "notify_user", "save_observations", "check_inbox",
+    "workflow_snapshot", "await_task_event",
 })
 
 
@@ -584,8 +591,12 @@ class AgentLoop:
         Messages grow across iterations:
           user -> assistant(tool_calls) -> tool(result) -> assistant(final)
         """
-        from src.shared.trace import current_trace_id
+        from src.shared.trace import current_task_id, current_trace_id
         current_trace_id.set(trace_id)
+        # ``execute_task`` runs as a fresh coroutine per task — contextvar
+        # scope dies with the coroutine, so no explicit reset is needed
+        # (mirrors the ``current_trace_id`` pattern on the line above).
+        current_task_id.set(assignment.task_id)
         self._loop_detector.reset()
         # State is already set to "working" by receive_task() before spawning
         # this coroutine. Setting current_task is a no-op but documents intent.
@@ -2206,9 +2217,18 @@ class AgentLoop:
                 "tokens_used": 0,
             }
 
-        from src.shared.trace import current_origin, current_trace_id
+        from src.shared.trace import (
+            current_origin,
+            current_task_id,
+            current_trace_id,
+        )
         current_trace_id.set(trace_id)
         origin_token = current_origin.set(origin)
+        # ``current_task_id`` is set only when a real durable task drove
+        # this chat turn (handoff/lane dispatch). Free chats and heartbeats
+        # leave it ``None`` so downstream tools (``hand_off``) don't
+        # falsely parent their new tasks off a non-existent ancestor.
+        task_id_token = current_task_id.set(task_id)
         try:
             async with self._chat_lock:
                 await self._maybe_restore_session()
@@ -2316,6 +2336,7 @@ class AgentLoop:
                     await self._checkpoint_chat_session()
         finally:
             current_origin.reset(origin_token)
+            current_task_id.reset(task_id_token)
 
     async def _auto_close_task(
         self, task_id: str, status: str, *,

--- a/src/agent/mesh_client.py
+++ b/src/agent/mesh_client.py
@@ -1253,6 +1253,18 @@ class MeshClient:
         _raise_with_body(response)
         return response.json()
 
+    async def get_workflow_snapshot(
+        self, root_task_id: str,
+    ) -> dict | None:
+        """Operator-tier read of a workflow chain. Returns ``None`` on 404."""
+        response = await self._get_with_retry(
+            f"{self.mesh_url}/mesh/tasks/workflow/{root_task_id}",
+        )
+        if response.status_code == 404:
+            return None
+        _raise_with_body(response)
+        return response.json()
+
     async def list_task_inbox(self, assignee: str | None = None) -> list[dict]:
         """List tasks assigned to ``assignee`` (defaults to self)."""
         target = assignee or self.agent_id

--- a/src/agent/workspace.py
+++ b/src/agent/workspace.py
@@ -346,13 +346,13 @@ class WorkspaceManager:
         # touching user-customised heartbeats (which won't have the
         # marker because they replaced the template). New markers added
         # in future revisions can extend this tuple.
-        _HEARTBEAT_SENTINELS = ("heartbeat_v2_workflow_aware",)
+        from src.shared.types import HEARTBEAT_SENTINELS
         if (
             heartbeat_path.exists()
             and self._initial_heartbeat
             and any(
                 f"<!-- {m} -->" in self._initial_heartbeat
-                for m in _HEARTBEAT_SENTINELS
+                for m in HEARTBEAT_SENTINELS
             )
         ):
             try:
@@ -360,7 +360,7 @@ class WorkspaceManager:
             except Exception:
                 existing = ""
             needs_refresh = not any(
-                f"<!-- {m} -->" in existing for m in _HEARTBEAT_SENTINELS
+                f"<!-- {m} -->" in existing for m in HEARTBEAT_SENTINELS
             )
             if needs_refresh:
                 heartbeat_path.write_text(

--- a/src/agent/workspace.py
+++ b/src/agent/workspace.py
@@ -337,6 +337,42 @@ class WorkspaceManager:
             )
             logger.info("Created %s (seeded from template)", self.HEARTBEAT_FILE)
 
+        # Idempotent heartbeat refresh: mirrors the INSTRUCTIONS.md
+        # playbook_v2 sentinel pattern above. When the template carries a
+        # versioned marker (currently ``heartbeat_v2_workflow_aware`` —
+        # the operator workflow-awareness rewrite) and the live file
+        # lacks it, overwrite from the template. Versioned markers let
+        # us roll system-managed heartbeat updates forward without
+        # touching user-customised heartbeats (which won't have the
+        # marker because they replaced the template). New markers added
+        # in future revisions can extend this tuple.
+        _HEARTBEAT_SENTINELS = ("heartbeat_v2_workflow_aware",)
+        if (
+            heartbeat_path.exists()
+            and self._initial_heartbeat
+            and any(
+                f"<!-- {m} -->" in self._initial_heartbeat
+                for m in _HEARTBEAT_SENTINELS
+            )
+        ):
+            try:
+                existing = heartbeat_path.read_text(errors="replace")
+            except Exception:
+                existing = ""
+            needs_refresh = not any(
+                f"<!-- {m} -->" in existing for m in _HEARTBEAT_SENTINELS
+            )
+            if needs_refresh:
+                heartbeat_path.write_text(
+                    "# Heartbeat Rules\n\n"
+                    + self._initial_heartbeat.strip()
+                    + "\n"
+                )
+                logger.info(
+                    "Refreshed %s from versioned template",
+                    self.HEARTBEAT_FILE,
+                )
+
     # ── Reading ──────────────────────────────────────────────
 
     def load_memory(self) -> str:

--- a/src/cli/config.py
+++ b/src/cli/config.py
@@ -1592,6 +1592,10 @@ _OPERATOR_ALLOWED_TOOLS: list[str] = [
     "list_peer_artifacts", "read_peer_artifact",
     # Coordination + chat
     "list_templates", "apply_template", "hand_off", "check_inbox",
+    # Workflow awareness — operator-only chain inspection + single-task
+    # blocking primitive (see _HEARTBEAT_TOOLS in src/agent/loop.py for
+    # the heartbeat surface; both skills self-reject for non-operators).
+    "workflow_snapshot", "await_task_event",
     # Configuration edits — edit_agent applies every field immediately
     # and emits an undo receipt (5min for soft fields, 30min for hard).
     # undo_change lets the operator self-revert within the TTL.
@@ -1628,8 +1632,14 @@ _OPERATOR_ALLOWED_TOOLS: list[str] = [
     "http_request", "web_search",
 ]
 
+# Reference list documenting the tools operator uses on heartbeat. The
+# loop's actual gate is ``_HEARTBEAT_TOOLS`` in ``src/agent/loop.py`` —
+# this list is kept in sync as documentation but is not itself consulted
+# by the runtime. New tools should be added to BOTH places (and the
+# operator HEARTBEAT.md prompt) to take effect.
 _OPERATOR_HEARTBEAT_TOOLS: list[str] = [
     "inspect_agents", "get_system_status", "notify_user", "save_observations",
+    "check_inbox", "workflow_snapshot", "await_task_event",
 ]
 
 _OPERATOR_SOUL = """\
@@ -1647,6 +1657,7 @@ You build the workforce and step back. Users work with agents directly.
 """
 
 _OPERATOR_HEARTBEAT = """\
+<!-- heartbeat_v2_workflow_aware -->
 You are running an autonomous fleet health check. You have access ONLY to monitoring tools.
 Your previous observations are included above in OBSERVATIONS.md.
 
@@ -1656,7 +1667,14 @@ in the loop; 10 leaves headroom for the final assistant turn).
 1. Review your previous observations (above) to check what you flagged last cycle.
    Do not re-alert on known issues unless they have escalated in severity.
 
-2. Call get_system_status() for fleet-wide metrics:
+2. Call check_inbox() FIRST so any task_failed / task_blocked back-edge events
+   from active workflows are surfaced before you do fleet-wide work. Skim the
+   ``events[]`` array:
+   - For each task_failed / task_blocked event note the task_id and recipient.
+   - For each event whose task is part of an orchestration you started, drop a
+     ``workflow_snapshot(root_task_id)`` call (step 4) to see chain state.
+
+3. Call get_system_status() for fleet-wide metrics:
    - Total cost, cost trend vs yesterday
    - Per-agent cost (per_agent_cost_today_usd, per_agent_cost_vs_yesterday_ratio)
    - Per-agent task health: outcome_rejected_24h_count, execution_failures_24h_count,
@@ -1664,10 +1682,20 @@ in the loop; 10 leaves headroom for the final assistant turn).
    - Agent health counts and pre-computed agents_needing_attention list
    - Plan limits and current usage
 
-3. Call inspect_agents() for the roster summary.
+4. Workflow awareness — for any active orchestration you kicked off (a task you
+   created as a root that fanned out via hand_off), call
+   ``workflow_snapshot(root_task_id)`` to see all stages. Read the response:
+   - ``summary.failed`` > 0 OR ``summary.blocked`` > 0: surface to the user
+     in step 7 with the offending stage's assignee and title.
+   - Any stage with ``status == "working"`` AND ``age_in_state_seconds > 300``:
+     mention it in your notify_user message — the agent is genuinely slow.
+     DO NOT mark the work failed; the lane watchdog handles the actual cap.
+   - Skip ``workflow_snapshot`` entirely if you have no active orchestrations.
+     One call covers an entire chain — do NOT loop.
 
-4. Drill into at most THREE most-concerning agents. PREFER one targeted call
-   per drill — don't fan out across the whole fleet:
+5. Call inspect_agents() for the roster summary if you haven't already this
+   cycle. Then drill into at most THREE most-concerning agents. PREFER one
+   targeted call per drill — don't fan out across the whole fleet:
    - Candidates are agents that appear in agents_needing_attention OR have
      per_agent_cost_vs_yesterday_ratio is not None AND > 2.0 OR
      outcome_rejected_24h_count[agent] > 5 OR
@@ -1681,14 +1709,19 @@ in the loop; 10 leaves headroom for the final assistant turn).
      inspect_agents(stale_threshold_hours=24) ONCE to pull the offending
      task IDs (the result annotates every roster entry — don't loop).
 
-5. Call save_observations() with:
+6. Call save_observations() with:
    - fleet_summary: one-line health (e.g. "5/6 healthy, cost stable")
    - agents_attention: list of agents needing attention with issue and severity
    - cost_trend: up/down/stable with percentage
+   - workflows: list of {root_task_id, summary, slow_stages} for any active
+     orchestrations you snapshotted in step 4
    - notes: stale task IDs, rejected outcomes, anything unusual not captured above
 
-6. If any agent is CRITICAL (failed state, budget exceeded, >5 rejected outcomes,
-   or stale work blocking a project), call notify_user() with a brief alert.
+7. Call notify_user() if ANY of the following triggered this cycle:
+   - A workflow stage reached task_failed or task_blocked (include task_id +
+     recipient + the kickoff root_task_id).
+   - An agent is CRITICAL (failed state, budget exceeded, >5 rejected outcomes).
+   - A workflow stage has been ``working`` for > 5 minutes (inform, don't kill).
    Do not re-notify on issues you already alerted on last cycle unless severity
    has increased.
 
@@ -1729,6 +1762,35 @@ def _ensure_operator_agent(config_path: Path | None = None, default_model: str =
         return
 
     if has_operator:
+        # Refresh the operator's heartbeat field whenever the canonical
+        # template gains a new sentinel marker. Mirrors the workspace-
+        # side refresh in ``WorkspaceManager._ensure_scaffold`` — a
+        # sentinel like ``heartbeat_v2_workflow_aware`` lets us roll
+        # the operator's heartbeat forward without touching agents
+        # with user-customised heartbeats.
+        op_entry = agents_cfg["agents"].get(_OPERATOR_AGENT_ID, {}) or {}
+        existing_heartbeat = op_entry.get("heartbeat") or ""
+        _HEARTBEAT_SENTINELS = ("heartbeat_v2_workflow_aware",)
+        new_has_sentinel = any(
+            f"<!-- {m} -->" in _OPERATOR_HEARTBEAT
+            for m in _HEARTBEAT_SENTINELS
+        )
+        old_has_sentinel = any(
+            f"<!-- {m} -->" in existing_heartbeat
+            for m in _HEARTBEAT_SENTINELS
+        )
+        if new_has_sentinel and not old_has_sentinel:
+            op_entry["heartbeat"] = _OPERATOR_HEARTBEAT
+            agents_cfg["agents"][_OPERATOR_AGENT_ID] = op_entry
+            AGENTS_FILE.parent.mkdir(parents=True, exist_ok=True)
+            with open(AGENTS_FILE, "w") as f:
+                yaml.dump(
+                    agents_cfg, f, default_flow_style=False, sort_keys=False,
+                )
+            logger.info(
+                "Refreshed operator heartbeat to versioned template",
+            )
+
         # Ensure permissions are correct even for existing operator
         # (handles upgrades where operator was created before permissions were set)
         perms = _load_permissions()

--- a/src/cli/config.py
+++ b/src/cli/config.py
@@ -1686,12 +1686,16 @@ in the loop; 10 leaves headroom for the final assistant turn).
    created as a root that fanned out via hand_off), call
    ``workflow_snapshot(root_task_id)`` to see all stages. Read the response:
    - ``summary.failed`` > 0 OR ``summary.blocked`` > 0: surface to the user
-     in step 7 with the offending stage's assignee and title.
+     in step 7 with the offending stage's assignee, title, and blocker_note
+     (the snapshot includes it inline — no follow-up get_task needed).
    - Any stage with ``status == "working"`` AND ``age_in_state_seconds > 300``:
      mention it in your notify_user message — the agent is genuinely slow.
      DO NOT mark the work failed; the lane watchdog handles the actual cap.
    - Skip ``workflow_snapshot`` entirely if you have no active orchestrations.
      One call covers an entire chain — do NOT loop.
+   - Cap at 3 snapshot calls per heartbeat: if you have more than 3 active
+     workflows, snapshot the 3 most concerning (most-recent failed events
+     wins, then most-recent task_started) and defer the rest to next cycle.
 
 5. Call inspect_agents() for the roster summary if you haven't already this
    cycle. Then drill into at most THREE most-concerning agents. PREFER one
@@ -1770,14 +1774,14 @@ def _ensure_operator_agent(config_path: Path | None = None, default_model: str =
         # with user-customised heartbeats.
         op_entry = agents_cfg["agents"].get(_OPERATOR_AGENT_ID, {}) or {}
         existing_heartbeat = op_entry.get("heartbeat") or ""
-        _HEARTBEAT_SENTINELS = ("heartbeat_v2_workflow_aware",)
+        from src.shared.types import HEARTBEAT_SENTINELS
         new_has_sentinel = any(
             f"<!-- {m} -->" in _OPERATOR_HEARTBEAT
-            for m in _HEARTBEAT_SENTINELS
+            for m in HEARTBEAT_SENTINELS
         )
         old_has_sentinel = any(
             f"<!-- {m} -->" in existing_heartbeat
-            for m in _HEARTBEAT_SENTINELS
+            for m in HEARTBEAT_SENTINELS
         )
         if new_has_sentinel and not old_has_sentinel:
             op_entry["heartbeat"] = _OPERATOR_HEARTBEAT

--- a/src/cli/runtime.py
+++ b/src/cli/runtime.py
@@ -734,6 +734,14 @@ class RuntimeContext:
         _tasks_store_ref = getattr(app, "tasks_store", None)
         if _tasks_store_ref is not None and self.lane_manager is not None:
             self.lane_manager.set_tasks_store(_tasks_store_ref)
+        # Wire the mesh's back-edge writer into the lane watchdog so a
+        # lane-timeout failure produces a ``task_failed`` inbox event for
+        # the originator AND triggers the wake-on-event chain. Without
+        # this the durable status update lands but the originating agent
+        # never learns until its next heartbeat.
+        _back_edge_fn = getattr(app, "_write_task_event_back_edge", None)
+        if _back_edge_fn is not None and self.lane_manager is not None:
+            self.lane_manager.set_back_edge_fn(_back_edge_fn)
 
         self._init_channel_manager()
 

--- a/src/cli/runtime.py
+++ b/src/cli/runtime.py
@@ -743,6 +743,34 @@ class RuntimeContext:
         if _back_edge_fn is not None and self.lane_manager is not None:
             self.lane_manager.set_back_edge_fn(_back_edge_fn)
 
+        # Per-agent watchdog override. Workflow-stage agents that run a
+        # bounded fast loop can opt into a tighter cap than the 15-min
+        # default via ``settings.watchdog_ttl_seconds`` in agents.yaml.
+        # Workers without the field stay on the module default.
+        if self.lane_manager is not None:
+            try:
+                from src.cli.config import _load_config as _load_cfg_for_lanes
+                _cfg = _load_cfg_for_lanes()
+                _agents_cfg = _cfg.get("agents", {}) or {}
+                for aid, entry in _agents_cfg.items():
+                    if not isinstance(entry, dict):
+                        continue
+                    settings = entry.get("settings") or {}
+                    ttl = settings.get("watchdog_ttl_seconds")
+                    if ttl is None:
+                        continue
+                    try:
+                        self.lane_manager.set_agent_timeout(aid, int(ttl))
+                    except (TypeError, ValueError):
+                        logger.warning(
+                            "Invalid watchdog_ttl_seconds for %s: %r — "
+                            "ignored", aid, ttl,
+                        )
+            except Exception as e:
+                logger.warning(
+                    "Per-agent watchdog override wiring failed: %s", e,
+                )
+
         self._init_channel_manager()
 
         from src.dashboard.server import create_dashboard_router, create_spa_catchall_router

--- a/src/dashboard/static/js/app.js
+++ b/src/dashboard/static/js/app.js
@@ -10724,6 +10724,8 @@ function dashboard() {
         inspect_agents: 'reviewing the team',
         list_available_models: 'checking available models',
         compose_work_summary: 'composing a work summary',
+        workflow_snapshot: 'mapping the workflow',
+        await_task_event: 'waiting on a task',
       };
       if (map[toolName]) return map[toolName];
       // Fallback: humanise the snake_case tool name.

--- a/src/host/lanes.py
+++ b/src/host/lanes.py
@@ -19,6 +19,7 @@ from collections.abc import Callable, Coroutine
 from dataclasses import dataclass, field
 from typing import Any
 
+from src.host.orchestration import InvalidStatusTransition
 from src.shared.types import SILENT_REPLY_TOKEN, MessageOrigin
 from src.shared.utils import generate_id, setup_logging
 
@@ -85,6 +86,21 @@ class LaneManager:
         # error instead of dispatched — the agent will keep failing on a
         # broken credential otherwise.
         self._quarantine_check = quarantine_check
+        # ``_back_edge_fn``: callable wired by the mesh app after both
+        # this LaneManager and ``create_mesh_app`` have been constructed
+        # (the helper is a closure over the app's blackboard / router).
+        # Called from the lane-timeout path so the originator's back-edge
+        # inbox sees a ``task_failed`` event AND gets a wake-on-event
+        # followup — without this, lane-timeout failures land in SQLite
+        # but never surface to the originating agent's awareness loop.
+        self._back_edge_fn: (
+            Callable[..., None] | None
+        ) = None
+        # Per-agent timeout overlay. ``set_agent_timeout`` writes here;
+        # ``_timeout_for`` falls back to the module default when unset.
+        # Lets workflow-stage agents (page-writer, etc.) run on a tight
+        # 10-min cap while deep-research agents keep the 15-min default.
+        self._per_agent_timeouts: dict[str, int] = {}
         self._queues: dict[str, asyncio.Queue[QueuedTask]] = {}
         self._workers: dict[str, asyncio.Task] = {}
         self._pending: dict[str, list[QueuedTask]] = {}
@@ -106,6 +122,40 @@ class LaneManager:
         ``None`` to clear.
         """
         self._tasks_store = store
+
+    def set_back_edge_fn(
+        self, fn: Callable[..., None] | None,
+    ) -> None:
+        """Wire the mesh's back-edge writer.
+
+        ``fn(task_record, *, event_kind, payload_extras=None)`` writes a
+        back-edge event to the originator's inbox and (for actionable
+        kinds) wakes the originator with a rate-limit. Called from the
+        lane-timeout path. Wired by ``create_mesh_app`` after the helper
+        closure exists. Pass ``None`` to clear.
+        """
+        self._back_edge_fn = fn
+
+    def set_agent_timeout(self, agent: str, seconds: int | None) -> None:
+        """Set a per-agent override on the per-task wall-clock cap.
+
+        ``seconds`` < 60 is clamped to 60 (a 1-second cap would make the
+        watchdog the bottleneck instead of a safety net). Pass ``None``
+        to drop back to the module default. Per-agent overrides are
+        useful for workflow stages with predictable bounds (tight cap →
+        faster recovery from a wedged step) vs deep-research agents that
+        need the generous default.
+        """
+        if seconds is None:
+            self._per_agent_timeouts.pop(agent, None)
+            return
+        self._per_agent_timeouts[agent] = max(60, int(seconds))
+
+    def _timeout_for(self, agent: str) -> int:
+        """Resolve the per-task wall-clock cap for ``agent``."""
+        return self._per_agent_timeouts.get(
+            agent, self._task_timeout_seconds,
+        )
 
     def set_quarantine_check(
         self, check: Callable[[str], bool] | None,
@@ -301,15 +351,17 @@ class LaneManager:
                 # Bug 4: per-task wall-clock cap. A hung LLM stream or
                 # stuck tool previously blocked the lane forever — every
                 # subsequent task for this agent would queue forever.
+                # Per-agent override takes precedence over the default.
+                resolved_timeout = self._timeout_for(agent)
                 if dispatch_kwargs:
                     result = await asyncio.wait_for(
                         self._dispatch_fn(agent, task.message, **dispatch_kwargs),
-                        timeout=self._task_timeout_seconds,
+                        timeout=resolved_timeout,
                     )
                 else:
                     result = await asyncio.wait_for(
                         self._dispatch_fn(agent, task.message),
-                        timeout=self._task_timeout_seconds,
+                        timeout=resolved_timeout,
                     )
                 task.future.set_result(result)
                 # Auto-forward result to origin channel+user when requested.
@@ -354,16 +406,23 @@ class LaneManager:
                 # originating agent's back-edge inbox sees the timeout,
                 # then continue serving the queue. Do NOT raise — the
                 # worker must survive a single stuck task.
+                effective_timeout = self._timeout_for(agent)
                 timeout_msg = (
                     f"Lane task {task.id} for agent={agent} timed out after "
-                    f"{self._task_timeout_seconds}s — freeing lane"
+                    f"{effective_timeout}s — freeing lane"
                 )
                 logger.error(timeout_msg)
+                fresh_record: dict | None = None
                 if task.task_id and self._tasks_store is not None:
                     try:
-                        # ``Tasks.update_status`` is sync — push it off the
-                        # event loop so a slow SQLite write can't pile back
-                        # onto the lane worker we just freed.
+                        # ``Tasks.update_status`` is sync — push it off
+                        # the event loop so a slow SQLite write can't
+                        # pile back onto the lane worker we just freed.
+                        # ``InvalidStatusTransition`` here means the
+                        # assignee already terminated the task between
+                        # our SELECT and UPDATE (a benign race) — log
+                        # and skip the back-edge so we don't double-
+                        # notify the originator.
                         await asyncio.get_running_loop().run_in_executor(
                             None,
                             lambda: self._tasks_store.update_status(
@@ -372,14 +431,42 @@ class LaneManager:
                                 actor="lane_watchdog",
                                 extra_payload={
                                     "error": "lane_timeout",
-                                    "timeout_seconds": self._task_timeout_seconds,
+                                    "timeout_seconds": effective_timeout,
                                 },
                             ),
+                        )
+                        fresh_record = self._tasks_store.get(task.task_id)
+                    except InvalidStatusTransition as race_err:
+                        logger.info(
+                            "Lane watchdog race: task %s already terminal "
+                            "(%s) — skipping back-edge",
+                            task.task_id, race_err,
                         )
                     except Exception as close_err:
                         logger.warning(
                             "Lane watchdog failed to close task %s: %s",
                             task.task_id, close_err,
+                        )
+                # Fire the back-edge writer so the originating agent
+                # learns about the timeout via inbox event + wake (for
+                # the actionable ``task_failed`` kind). Best-effort.
+                if (
+                    fresh_record is not None
+                    and self._back_edge_fn is not None
+                ):
+                    try:
+                        self._back_edge_fn(
+                            fresh_record,
+                            event_kind="task_failed",
+                            payload_extras={
+                                "error": "lane_timeout",
+                                "timeout_seconds": effective_timeout,
+                            },
+                        )
+                    except Exception as be_err:
+                        logger.warning(
+                            "Lane watchdog back-edge fire failed for "
+                            "task %s: %s", task.task_id, be_err,
                         )
                 if not task.future.done():
                     task.future.set_exception(

--- a/src/host/lanes.py
+++ b/src/host/lanes.py
@@ -413,55 +413,87 @@ class LaneManager:
                 )
                 logger.error(timeout_msg)
                 fresh_record: dict | None = None
+                already_terminal = False
                 if task.task_id and self._tasks_store is not None:
+                    # Pre-flight check: read the current status so we can
+                    # tell whether the watchdog actually transitioned the
+                    # row OR the assignee already wrote a terminal status
+                    # while we were timing out. ``Tasks.update_status``
+                    # treats ``current == status`` as a no-op success
+                    # (returns the row without raising), so without this
+                    # check the watchdog would happily overwrite the
+                    # assignee's actual back-edge payload with a generic
+                    # ``error="lane_timeout"`` at the same blackboard key.
                     try:
-                        # ``Tasks.update_status`` is sync — push it off
-                        # the event loop so a slow SQLite write can't
-                        # pile back onto the lane worker we just freed.
-                        # ``InvalidStatusTransition`` here means the
-                        # assignee already terminated the task between
-                        # our SELECT and UPDATE (a benign race) — log
-                        # and skip the back-edge so we don't double-
-                        # notify the originator.
-                        await asyncio.get_running_loop().run_in_executor(
-                            None,
-                            lambda: self._tasks_store.update_status(
-                                task.task_id,
-                                "failed",
-                                actor="lane_watchdog",
-                                extra_payload={
-                                    "error": "lane_timeout",
-                                    "timeout_seconds": effective_timeout,
-                                },
-                            ),
+                        pre = self._tasks_store.get(task.task_id)
+                        if pre is not None and pre.get("status") in (
+                            "done", "failed", "cancelled"
+                        ):
+                            already_terminal = True
+                            logger.info(
+                                "Lane watchdog: task %s already terminal "
+                                "(status=%s) — skipping update + back-edge",
+                                task.task_id, pre.get("status"),
+                            )
+                    except Exception as pre_err:
+                        logger.debug(
+                            "Lane watchdog pre-check for %s failed: %s",
+                            task.task_id, pre_err,
                         )
-                        fresh_record = self._tasks_store.get(task.task_id)
-                    except InvalidStatusTransition as race_err:
-                        logger.info(
-                            "Lane watchdog race: task %s already terminal "
-                            "(%s) — skipping back-edge",
-                            task.task_id, race_err,
-                        )
-                    except Exception as close_err:
-                        logger.warning(
-                            "Lane watchdog failed to close task %s: %s",
-                            task.task_id, close_err,
-                        )
+                    if not already_terminal:
+                        try:
+                            # ``Tasks.update_status`` is sync — push it
+                            # off the event loop so a slow SQLite write
+                            # can't pile back onto the lane worker we
+                            # just freed. ``InvalidStatusTransition``
+                            # here means a benign race terminated the
+                            # task between pre-check and UPDATE.
+                            await asyncio.get_running_loop().run_in_executor(
+                                None,
+                                lambda: self._tasks_store.update_status(
+                                    task.task_id,
+                                    "failed",
+                                    actor="lane_watchdog",
+                                    extra_payload={
+                                        "error": "lane_timeout",
+                                        "timeout_seconds": effective_timeout,
+                                    },
+                                ),
+                            )
+                            fresh_record = self._tasks_store.get(task.task_id)
+                        except InvalidStatusTransition as race_err:
+                            logger.info(
+                                "Lane watchdog race: task %s went "
+                                "terminal during update (%s) — skipping "
+                                "back-edge",
+                                task.task_id, race_err,
+                            )
+                        except Exception as close_err:
+                            logger.warning(
+                                "Lane watchdog failed to close task %s: %s",
+                                task.task_id, close_err,
+                            )
                 # Fire the back-edge writer so the originating agent
                 # learns about the timeout via inbox event + wake (for
                 # the actionable ``task_failed`` kind). Best-effort.
+                # SQLite-bound work is pushed to an executor so a
+                # blackboard write under contention can't block the
+                # shared lane-worker event loop for all agents.
                 if (
                     fresh_record is not None
                     and self._back_edge_fn is not None
                 ):
                     try:
-                        self._back_edge_fn(
-                            fresh_record,
-                            event_kind="task_failed",
-                            payload_extras={
-                                "error": "lane_timeout",
-                                "timeout_seconds": effective_timeout,
-                            },
+                        await asyncio.get_running_loop().run_in_executor(
+                            None,
+                            lambda: self._back_edge_fn(
+                                fresh_record,
+                                event_kind="task_failed",
+                                payload_extras={
+                                    "error": "lane_timeout",
+                                    "timeout_seconds": effective_timeout,
+                                },
+                            ),
                         )
                     except Exception as be_err:
                         logger.warning(

--- a/src/host/orchestration.py
+++ b/src/host/orchestration.py
@@ -93,6 +93,16 @@ _VALID_TRANSITIONS: dict[str, frozenset[str]] = {
 # fleet default only.
 DEFAULT_RETENTION_SECONDS: int = 90 * 24 * 60 * 60  # 90 days
 
+# Defense-in-depth cap on the recursive walk inside
+# ``Tasks.workflow_snapshot``. Caps the inner CTE size before the outer
+# LIMIT trims, so a pathological wide chain can't materialize a huge
+# intermediate result set. Cycles are impossible by construction
+# (parent_task_id is set at creation, never updated); this is purely a
+# memory bound on legitimate workloads. 200 is well above any plausible
+# real workflow (typical chains are 3–8 stages) but well below the
+# point at which the temporary chain table starts to matter.
+MAX_WORKFLOW_CHAIN_DEPTH: int = 200
+
 
 class InvalidStatusTransition(ValueError):
     """Raised when a status transition is not allowed by the state machine."""
@@ -773,39 +783,55 @@ class Tasks:
         creation, for never-transitioned rows).
         """
         now = time.time()
+        # Inner recursion is bounded by ``MAX_WORKFLOW_CHAIN_DEPTH`` via
+        # a depth counter so a pathological wide chain can't materialize
+        # millions of intermediate rows before the outer LIMIT trims.
+        # Cycles are impossible by construction (parent_task_id is set
+        # once at creation, never updated), but the depth guard is
+        # cheap defense-in-depth.
         with self._conn() as conn:
             rows = conn.execute(
-                "WITH RECURSIVE chain(id) AS ("
-                "  SELECT id FROM tasks WHERE id = ?"
+                "WITH RECURSIVE chain(id, depth) AS ("
+                "  SELECT id, 0 FROM tasks WHERE id = ?"
                 "  UNION ALL"
-                "  SELECT t.id FROM tasks t "
-                "    JOIN chain c ON t.parent_task_id = c.id"
+                "  SELECT t.id, c.depth + 1 FROM tasks t "
+                "    JOIN chain c ON t.parent_task_id = c.id "
+                "    WHERE c.depth < ?"
                 ") "
                 "SELECT t.id, t.parent_task_id, t.assignee, t.status, "
-                "  t.title, t.created_at, t.updated_at "
+                "  t.title, t.blocker_note, t.created_at, t.updated_at "
                 "FROM tasks t JOIN chain c ON t.id = c.id "
                 "ORDER BY t.created_at ASC LIMIT ?",
-                (root_task_id, limit),
+                (root_task_id, MAX_WORKFLOW_CHAIN_DEPTH, limit),
             ).fetchall()
         if not rows:
             return None
         stages: list[dict] = []
-        summary = {
-            "done": 0, "working": 0, "pending": 0,
-            "failed": 0, "blocked": 0, "cancelled": 0, "total": 0,
-        }
+        # Derive buckets from ``VALID_STATUSES`` so a future state added
+        # to the enum can't silently drift out of the summary math.
+        summary = {status: 0 for status in VALID_STATUSES}
+        summary["total"] = 0
         for row in rows:
-            tid, parent, assignee, status, title, created_at, updated_at = row
-            age_basis = max(updated_at or 0.0, created_at or 0.0)
+            (
+                tid, parent, assignee, status, title, blocker_note,
+                created_at, updated_at,
+            ) = row
+            age_basis = updated_at or created_at or 0.0
             age = int(now - age_basis) if age_basis > 0 else 0
-            stages.append({
+            stage: dict = {
                 "task_id": tid,
                 "parent_task_id": parent,
                 "assignee": assignee,
                 "status": status,
                 "age_in_state_seconds": age,
                 "title": title or "",
-            })
+            }
+            # Surface ``blocker_note`` only when set — saves the operator
+            # a follow-up get_task call for failed/blocked stages and
+            # keeps the snapshot quiet for nominal stages.
+            if blocker_note:
+                stage["blocker_note"] = blocker_note
+            stages.append(stage)
             if status in summary:
                 summary[status] += 1
             summary["total"] += 1

--- a/src/host/orchestration.py
+++ b/src/host/orchestration.py
@@ -506,7 +506,21 @@ class Tasks:
                 "created_at": now,
             },
         )
-        return self.get(tid)  # type: ignore[return-value]
+        # Post-write assert. Under ``isolation_level=None`` (autocommit)
+        # the INSERT above is durable before we re-read. If ``get(tid)``
+        # returns ``None`` here something genuinely surprising happened —
+        # a file-handle race, a mid-flight schema migration, a downgrade
+        # path that dropped the row. Don't return ``None`` to the caller
+        # (which then surfaces as ``null`` JSON and an ``AttributeError``
+        # inside the agent's ``hand_off``). Raise loudly so the endpoint
+        # returns 5xx and the agent's ``create_failed`` envelope fires.
+        record = self.get(tid)
+        if record is None:
+            raise RuntimeError(
+                f"task {tid!r} INSERT committed but post-read returned no "
+                "row — possible storage corruption or mid-migration race"
+            )
+        return record
 
     def get(self, task_id: str) -> dict | None:
         """Read a task by id. Returns None when not found."""
@@ -724,6 +738,78 @@ class Tasks:
                 params,
             ).fetchall()
         return [row[0] for row in rows]
+
+    def workflow_snapshot(
+        self, root_task_id: str, *, limit: int = 50,
+    ) -> dict | None:
+        """Return a snapshot of the workflow chain rooted at ``root_task_id``.
+
+        Walks the ``parent_task_id`` graph downstream from the root (the
+        operator's kickoff task) via ``WITH RECURSIVE``. Each descendant
+        task is one stage of the workflow. Returns ``None`` when the root
+        does not exist. Capped at ``limit`` rows (default 50) so a
+        runaway chain can't OOM the caller.
+
+        Output shape:
+
+        ::
+
+            {
+              "root": "task_abc",
+              "stages": [
+                {"task_id": "...", "parent_task_id": "...",
+                 "assignee": "...", "status": "...",
+                 "age_in_state_seconds": int, "title": "..."},
+                ...  # ordered by created_at ASC so the chain reads as
+                     # kickoff → downstream
+              ],
+              "summary": {"done": N, "working": N, "pending": N,
+                          "failed": N, "blocked": N, "cancelled": N,
+                          "total": N},
+            }
+
+        ``age_in_state_seconds`` is ``int(now - max(updated_at, created_at))``
+        — the wall-clock age since the last status mutation (or
+        creation, for never-transitioned rows).
+        """
+        now = time.time()
+        with self._conn() as conn:
+            rows = conn.execute(
+                "WITH RECURSIVE chain(id) AS ("
+                "  SELECT id FROM tasks WHERE id = ?"
+                "  UNION ALL"
+                "  SELECT t.id FROM tasks t "
+                "    JOIN chain c ON t.parent_task_id = c.id"
+                ") "
+                "SELECT t.id, t.parent_task_id, t.assignee, t.status, "
+                "  t.title, t.created_at, t.updated_at "
+                "FROM tasks t JOIN chain c ON t.id = c.id "
+                "ORDER BY t.created_at ASC LIMIT ?",
+                (root_task_id, limit),
+            ).fetchall()
+        if not rows:
+            return None
+        stages: list[dict] = []
+        summary = {
+            "done": 0, "working": 0, "pending": 0,
+            "failed": 0, "blocked": 0, "cancelled": 0, "total": 0,
+        }
+        for row in rows:
+            tid, parent, assignee, status, title, created_at, updated_at = row
+            age_basis = max(updated_at or 0.0, created_at or 0.0)
+            age = int(now - age_basis) if age_basis > 0 else 0
+            stages.append({
+                "task_id": tid,
+                "parent_task_id": parent,
+                "assignee": assignee,
+                "status": status,
+                "age_in_state_seconds": age,
+                "title": title or "",
+            })
+            if status in summary:
+                summary[status] += 1
+            summary["total"] += 1
+        return {"root": root_task_id, "stages": stages, "summary": summary}
 
     def update_status(
         self,

--- a/src/host/server.py
+++ b/src/host/server.py
@@ -49,6 +49,7 @@ from src.shared.types import (
     BlackboardClaimRequest,
     BlackboardWatchRequest,
     MeshEvent,
+    MessageOrigin,
     NotifyRequest,
 )
 from src.shared.utils import dumps_safe, sanitize_for_prompt, setup_logging
@@ -4392,6 +4393,139 @@ def create_mesh_app(
             return True
         return project_id in _caller_projects(agent_id)
 
+    # ── Back-edge events ─────────────────────────────────────────
+    #
+    # When a task reaches a terminal status (or a lane-timeout flips it
+    # to ``failed``), the originating agent learns via a back-edge entry
+    # written to ``inbox/{origin_user}/task_event/{task_id}``. Actionable
+    # events also wake the originator so workflow recovery is event-
+    # driven instead of heartbeat-paced. Closure-local rate-limit state
+    # coalesces bursts (e.g. lane timeout + sweep retry).
+    _BACK_EDGE_KIND_FOR_STATUS = {
+        "done": "task_completed",
+        "failed": "task_failed",
+        "blocked": "task_blocked",
+        "cancelled": "task_cancelled",
+    }
+    _BACK_EDGE_WAKE_KINDS = frozenset({"task_failed", "task_blocked"})
+    _BACK_EDGE_WAKE_WINDOW_SECONDS = 60.0
+    _back_edge_wake_state: dict[str, float] = {}
+
+    def _write_task_event_back_edge(
+        task_record: dict,
+        *,
+        event_kind: str,
+        payload_extras: dict | None = None,
+    ) -> None:
+        """Write a back-edge event for a terminal-status transition.
+
+        ``task_record`` is the post-transition row dict (must include
+        ``id``, ``assignee``, ``title``, ``status``, and the nested
+        ``origin`` dict). ``event_kind`` is the back-edge kind name
+        (``task_completed`` / ``task_failed`` / ``task_blocked`` /
+        ``task_cancelled``). ``payload_extras`` carries kind-specific
+        fields (``blocker_note``, ``error``, ``summary``) — sentinel
+        schema keys can't be shadowed.
+
+        Best-effort: every failure path is logged and swallowed. The
+        underlying status transition has already committed and the
+        back-edge must never destabilize the lifecycle.
+
+        Wake-on-event: ``task_failed`` and ``task_blocked`` also enqueue
+        a followup lane message back to the originator with a 60s rate-
+        limit per task. ``task_completed`` / ``task_cancelled`` do NOT
+        wake (operator picks them up via heartbeat — no need to interrupt
+        successful chains or explicit cancels).
+        """
+        try:
+            origin_dict = task_record.get("origin") or {}
+            origin_kind = origin_dict.get("kind") if origin_dict else None
+            origin_user = origin_dict.get("user") if origin_dict else None
+            assignee = task_record.get("assignee")
+            task_id = task_record.get("id")
+
+            # Eligibility — only cross-agent agent/operator handoffs.
+            # Self-handoffs (sender == recipient) suppress so an
+            # originating agent's check_inbox stays clean.
+            if origin_kind not in {"agent", "operator"}:
+                return
+            if not origin_user or origin_user == assignee:
+                return
+            if not task_id:
+                return
+
+            payload: dict = {
+                "kind": event_kind,
+                "task_id": task_id,
+                "recipient": assignee,
+                "title": task_record.get("title"),
+                "status": task_record.get("status"),
+                "ts": int(time.time()),
+            }
+            if payload_extras:
+                # Sentinel keys above take precedence — extras can't
+                # shadow the canonical schema fields.
+                for k, v in payload_extras.items():
+                    if k not in payload:
+                        payload[k] = v
+            try:
+                blackboard.write(
+                    f"inbox/{origin_user}/task_event/{task_id}",
+                    payload, written_by="mesh", ttl=604800,  # 7 days
+                )
+            except Exception as e:
+                logger.warning(
+                    "Back-edge write failed for task %s: %s", task_id, e,
+                )
+                return
+
+            # Wake-on-event for actionable kinds with per-task rate limit.
+            if event_kind not in _BACK_EDGE_WAKE_KINDS:
+                return
+            if lane_manager is None or dispatch_loop is None:
+                return
+            if origin_user not in router.agent_registry:
+                return
+            now = time.time()
+            last = _back_edge_wake_state.get(task_id, 0.0)
+            if now - last < _BACK_EDGE_WAKE_WINDOW_SECONDS:
+                return
+            _back_edge_wake_state[task_id] = now
+            try:
+                wake_origin = MessageOrigin(
+                    kind=origin_kind,
+                    channel=str(origin_dict.get("channel") or ""),
+                    user=str(origin_user),
+                )
+                title = task_record.get("title") or "(no title)"
+                wake_msg = (
+                    f"Task {task_id} ({title}) reached {event_kind}. "
+                    "Call check_inbox to see the event payload."
+                )
+                asyncio.run_coroutine_threadsafe(
+                    lane_manager.enqueue(
+                        origin_user, wake_msg, mode="followup",
+                        origin=wake_origin, auto_notify=False,
+                        task_id=task_id,
+                    ),
+                    dispatch_loop,
+                )
+            except Exception as e:
+                logger.warning(
+                    "Back-edge wake for %s on task %s failed: %s",
+                    origin_user, task_id, e,
+                )
+        except Exception as e:  # belt-and-suspenders
+            logger.warning(
+                "Back-edge handler crashed for task %s: %s",
+                task_record.get("id"), e,
+            )
+
+    # Expose so the lane watchdog (built in runtime.py before this app)
+    # can fire the same back-edge path on lane-timeout failures. Wired
+    # in ``runtime.py`` post-app-construction via ``set_back_edge_fn``.
+    app._write_task_event_back_edge = _write_task_event_back_edge
+
     @app.post("/mesh/tasks")
     async def create_task(request: Request) -> dict:
         """Create a durable task record.
@@ -4495,6 +4629,36 @@ def create_mesh_app(
         rows = store.list_project(team_id)
         return {"tasks": rows, "count": len(rows)}
 
+    @app.get("/mesh/tasks/workflow/{root_task_id}")
+    async def get_workflow_snapshot(
+        root_task_id: str, request: Request,
+    ) -> dict:
+        """Return a workflow chain snapshot rooted at ``root_task_id``.
+
+        Walks ``parent_task_id`` descendants from the root and reports
+        every stage's status + age. Operator-only by design — workflow
+        orchestration awareness is operator-tier, and individual workers
+        have no business inspecting a chain they don't own.
+
+        404 when the root does not exist (lets the operator distinguish
+        a typo from an empty chain).
+        """
+        caller = _extract_verified_agent_id(request)
+        if not (
+            _caller_is_operator(caller, request)
+            or _is_internal_caller(request)
+        ):
+            raise HTTPException(
+                403,
+                "workflow_snapshot is operator-only",
+            )
+        snapshot = tasks_store.workflow_snapshot(root_task_id)
+        if snapshot is None:
+            raise HTTPException(
+                404, f"Root task '{root_task_id}' not found",
+            )
+        return snapshot
+
     @app.get("/mesh/tasks/{task_id}")
     async def get_task(task_id: str, request: Request) -> dict:
         """Read a task by id.
@@ -4582,63 +4746,26 @@ def create_mesh_app(
         except TaskNotFound:
             raise HTTPException(404, f"Task '{task_id}' not found")
 
-        # Bug 3: back-edge to originating agent on terminal transitions.
-        _BACK_EDGE_STATUSES = {"done", "failed", "cancelled", "blocked"}
-        if status in _BACK_EDGE_STATUSES:
-            try:
-                fresh = store.get(task_id) or record
-                # ``Tasks._row_to_dict`` returns origin as a nested dict
-                # (``origin`` or ``None``), not flat ``origin_kind`` /
-                # ``origin_user`` columns. Read defensively.
-                origin_dict = fresh.get("origin") or {}
-                origin_kind = origin_dict.get("kind") if origin_dict else None
-                origin_user = origin_dict.get("user") if origin_dict else None
-                assignee = fresh.get("assignee")
-                if (
-                    origin_kind in {"agent", "operator"}
-                    and origin_user
-                    and origin_user != assignee
-                ):
-                    event_kind_map = {
-                        "done": "task_completed",
-                        "failed": "task_failed",
-                        "blocked": "task_blocked",
-                        "cancelled": "task_cancelled",
-                    }
-                    payload: dict = {
-                        "kind": event_kind_map[status],
-                        "task_id": task_id,
-                        "recipient": assignee,
-                        "title": fresh.get("title"),
-                        "status": status,
-                        "ts": int(time.time()),
-                    }
-                    # ``body["result"]`` is supposed to be a dict, but
-                    # nothing enforces that on the wire. A caller passing
-                    # a string ("ok") used to AttributeError here and the
-                    # back-edge silently dropped — coerce defensively.
-                    raw_result = body.get("result")
-                    result_dict = raw_result if isinstance(raw_result, dict) else {}
-                    if status == "blocked":
-                        payload["blocker_note"] = blocker_note or ""
-                    if status == "failed":
-                        payload["error"] = (
-                            body.get("error")
-                            or result_dict.get("error", "")
-                            or ""
-                        )
-                    if status == "done":
-                        payload["summary"] = result_dict.get("summary", "")
-                    blackboard.write(
-                        f"inbox/{origin_user}/task_event/{task_id}",
-                        payload,
-                        written_by="mesh",
-                        ttl=604800,  # 7 days
-                    )
-            except Exception as e:
-                logger.warning(
-                    "Back-edge write failed for task %s: %s", task_id, e,
+        # Back-edge to originating agent on terminal transitions. The
+        # helper handles eligibility, payload shaping, and the wake-on-
+        # event chain for actionable kinds.
+        event_kind = _BACK_EDGE_KIND_FOR_STATUS.get(status)
+        if event_kind is not None:
+            fresh = store.get(task_id) or record
+            raw_result = body.get("result")
+            result_dict = raw_result if isinstance(raw_result, dict) else {}
+            payload_extras: dict = {}
+            if status == "blocked":
+                payload_extras["blocker_note"] = blocker_note or ""
+            elif status == "failed":
+                payload_extras["error"] = (
+                    body.get("error") or result_dict.get("error", "") or ""
                 )
+            elif status == "done":
+                payload_extras["summary"] = result_dict.get("summary", "")
+            _write_task_event_back_edge(
+                fresh, event_kind=event_kind, payload_extras=payload_extras,
+            )
         return updated
 
     def _check_can_schedule(target_agent: str) -> tuple[bool, dict | None]:

--- a/src/shared/trace.py
+++ b/src/shared/trace.py
@@ -39,6 +39,15 @@ current_origin: contextvars.ContextVar[
     "MessageOrigin | None"
 ] = contextvars.ContextVar("current_origin", default=None)
 
+# Active durable task id, set whenever the loop is executing inside a
+# task context (``execute_task`` or ``chat(task_id=...)``). Tools that
+# create new work for downstream peers read this to establish the
+# parent_task_id linkage so ``workflow_snapshot`` can walk a chain.
+# Defaults to ``None`` outside any task context (heartbeats, free chat).
+current_task_id: contextvars.ContextVar[str | None] = contextvars.ContextVar(
+    "current_task_id", default=None,
+)
+
 
 def new_trace_id() -> str:
     """Generate a fresh trace ID: ``tr_<12-hex-chars>``."""
@@ -85,6 +94,7 @@ __all__ = [
     "ORIGIN_HEADER",
     "current_trace_id",
     "current_origin",
+    "current_task_id",
     "new_trace_id",
     "trace_headers",
     "origin_header",

--- a/src/shared/types.py
+++ b/src/shared/types.py
@@ -67,6 +67,16 @@ new tool surface (PR-L'). Validation lives in
 :func:`src.agent.builtins.operator_tools._validate_heartbeat_schedule`.
 """
 
+# Versioned markers embedded in system-managed heartbeat templates
+# (currently operator's). When a new sentinel is added here AND the
+# template, idempotent migrators in :func:`src.cli.config._ensure_operator_agent`
+# and :class:`src.agent.workspace.WorkspaceManager._ensure_scaffold`
+# detect the mismatch and roll the live agents.yaml + HEARTBEAT.md
+# forward. User-customised heartbeats (no sentinel) are left alone.
+# Add new markers to the END of the tuple to keep older sentinels as
+# evidence that a workspace was previously migrated.
+HEARTBEAT_SENTINELS: tuple[str, ...] = ("heartbeat_v2_workflow_aware",)
+
 # === Inter-Component Messages ===
 
 

--- a/tests/test_back_edge_helper.py
+++ b/tests/test_back_edge_helper.py
@@ -1,0 +1,225 @@
+"""Tests for the extracted ``_write_task_event_back_edge`` helper.
+
+The helper writes back-edge events to ``inbox/{origin_user}/task_event/{task_id}``
+on terminal status transitions and — for actionable kinds
+(``task_failed`` / ``task_blocked``) — wakes the originator via the
+lane with a 60s per-task rate limit.
+
+This module builds a minimal mesh app, grabs the closure exposed on
+``app._write_task_event_back_edge``, and exercises the eligibility /
+wake / rate-limit paths directly. The closure shares state with the
+endpoint that calls it, so this is testing the exact in-process function
+the request handler uses.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import importlib
+
+import pytest
+
+from src.host.mesh import Blackboard, MessageRouter, PubSub
+from src.host.permissions import PermissionMatrix
+from src.shared.types import AgentPermissions
+
+
+def _reload_server(monkeypatch, *, tasks_db: str):
+    monkeypatch.setenv("OPENLEGION_ORCHESTRATION_TASKS_DB", tasks_db)
+    import src.host.server as server_module
+    importlib.reload(server_module)
+    return server_module
+
+
+class _FakeLane:
+    """Minimal LaneManager stand-in that just records enqueue calls."""
+
+    def __init__(self):
+        self.calls: list[dict] = []
+
+    async def enqueue(self, *args, **kwargs):
+        self.calls.append({"args": args, "kwargs": kwargs})
+        return "ok"
+
+
+@pytest.fixture
+def mesh_app_with_back_edge(tmp_path, monkeypatch):
+    """Build a mesh app with a fake lane + dispatch loop wired so the
+    back-edge helper can fire wake calls."""
+    server_module = _reload_server(
+        monkeypatch, tasks_db=str(tmp_path / "tasks.db"),
+    )
+
+    blackboard = Blackboard(str(tmp_path / "bb.db"))
+    pubsub = PubSub()
+    permissions = PermissionMatrix()
+    for aid in ("operator", "scout", "analyst", "writer"):
+        permissions.permissions[aid] = AgentPermissions(
+            agent_id=aid, can_route_tasks=True,
+        )
+    router = MessageRouter(permissions, {
+        "operator": "http://operator:8400",
+        "scout":    "http://scout:8400",
+        "analyst":  "http://analyst:8400",
+        "writer":   "http://writer:8400",
+    })
+
+    lane = _FakeLane()
+    # The helper expects a real running loop reference for
+    # ``run_coroutine_threadsafe``. Build a loop, kick it on a worker
+    # thread, and feed the reference in.
+    loop = asyncio.new_event_loop()
+    import threading
+
+    def _run():
+        asyncio.set_event_loop(loop)
+        loop.run_forever()
+
+    thread = threading.Thread(target=_run, daemon=True)
+    thread.start()
+
+    app = server_module.create_mesh_app(
+        blackboard=blackboard,
+        pubsub=pubsub,
+        router=router,
+        permissions=permissions,
+        lane_manager=lane,  # type: ignore[arg-type]
+        dispatch_loop=loop,
+    )
+    yield app, blackboard, lane, loop
+    loop.call_soon_threadsafe(loop.stop)
+    thread.join(timeout=2)
+    blackboard.close()
+    loop.close()
+    monkeypatch.delenv("OPENLEGION_ORCHESTRATION_TASKS_DB", raising=False)
+    importlib.reload(server_module)
+
+
+def _record(task_id: str, **overrides) -> dict:
+    """Synthesize the post-transition task record shape the helper expects."""
+    base = {
+        "id": task_id,
+        "assignee": "writer",
+        "title": "stage work",
+        "status": "failed",
+        "origin": {"kind": "agent", "channel": "", "user": "scout"},
+    }
+    base.update(overrides)
+    return base
+
+
+def _settle(seconds: float = 0.05) -> None:
+    """Wait briefly so ``run_coroutine_threadsafe`` calls land on the
+    background dispatch loop."""
+    import time
+    time.sleep(seconds)
+
+
+class TestBackEdgeHelperEligibility:
+    def test_task_completed_does_not_wake(self, mesh_app_with_back_edge):
+        """``task_completed`` writes inbox + does NOT wake the originator
+        (operator picks up via heartbeat, not interrupt)."""
+        app, blackboard, lane, _loop = mesh_app_with_back_edge
+        rec = _record("task_done_1", status="done")
+
+        app._write_task_event_back_edge(
+            rec, event_kind="task_completed",
+            payload_extras={"summary": "all good"},
+        )
+        _settle()
+
+        rows = blackboard.list_by_prefix("inbox/scout/task_event/")
+        assert any(r.value.get("task_id") == "task_done_1" for r in rows)
+        # NO lane wake.
+        assert lane.calls == []
+
+    def test_task_failed_writes_inbox_and_wakes(self, mesh_app_with_back_edge):
+        """``task_failed`` writes inbox AND wakes the originator (actionable kind)."""
+        app, blackboard, lane, _loop = mesh_app_with_back_edge
+        rec = _record("task_fail_1", status="failed")
+
+        app._write_task_event_back_edge(
+            rec, event_kind="task_failed",
+            payload_extras={
+                "error": "lane_timeout", "timeout_seconds": 900,
+            },
+        )
+        _settle()
+
+        rows = blackboard.list_by_prefix("inbox/scout/task_event/")
+        payload = next(
+            r.value for r in rows
+            if r.value.get("task_id") == "task_fail_1"
+        )
+        assert payload["kind"] == "task_failed"
+        assert payload["error"] == "lane_timeout"
+        # Wake was scheduled to the originator.
+        assert len(lane.calls) == 1
+        wake = lane.calls[0]
+        # First positional arg is the target agent id (origin_user).
+        assert wake["args"][0] == "scout"
+        # task_id is forwarded so the recipient's loop can auto-close.
+        assert wake["kwargs"].get("task_id") == "task_fail_1"
+
+    def test_rate_limit_collapses_repeated_wakes(self, mesh_app_with_back_edge):
+        """Same task_id failing twice within 60s only wakes the
+        originator once — the in-memory rate-limit state coalesces bursts."""
+        app, _, lane, _loop = mesh_app_with_back_edge
+        rec = _record("task_fail_burst")
+
+        app._write_task_event_back_edge(
+            rec, event_kind="task_failed",
+            payload_extras={"error": "first"},
+        )
+        # Immediate retry — same task_id, well inside the 60s window.
+        app._write_task_event_back_edge(
+            rec, event_kind="task_failed",
+            payload_extras={"error": "retry"},
+        )
+        _settle()
+
+        # Only ONE lane wake call — the second was rate-limited away.
+        assert len(lane.calls) == 1
+
+    def test_self_handoff_skipped(self, mesh_app_with_back_edge):
+        """origin.user == assignee → suppress the back-edge so an
+        originating agent's check_inbox stays clean."""
+        app, blackboard, lane, _loop = mesh_app_with_back_edge
+        rec = _record(
+            "task_self_1",
+            assignee="scout",
+            origin={"kind": "agent", "channel": "", "user": "scout"},
+        )
+
+        app._write_task_event_back_edge(
+            rec, event_kind="task_failed",
+        )
+        _settle()
+
+        rows = blackboard.list_by_prefix("inbox/scout/task_event/")
+        assert not any(
+            r.value.get("task_id") == "task_self_1" for r in rows
+        )
+        assert lane.calls == []
+
+    def test_human_origin_skipped(self, mesh_app_with_back_edge):
+        """``origin.kind=human`` callers (channels, web chat) don't get
+        a mesh-side back-edge — humans are served by the lane-worker
+        auto-notify path instead."""
+        app, blackboard, lane, _loop = mesh_app_with_back_edge
+        rec = _record(
+            "task_human_1",
+            origin={"kind": "human", "channel": "telegram", "user": "9999"},
+        )
+
+        app._write_task_event_back_edge(
+            rec, event_kind="task_failed",
+            payload_extras={"error": "boom"},
+        )
+        _settle()
+
+        rows = blackboard.list_by_prefix("inbox/9999/task_event/")
+        assert not any(
+            r.value.get("task_id") == "task_human_1" for r in rows
+        )
+        assert lane.calls == []

--- a/tests/test_coordination.py
+++ b/tests/test_coordination.py
@@ -1271,3 +1271,55 @@ class TestFailedTransitionEnvelopeHelper:
         assert result["test_failed"] is True
         # Non-sentinel extras flow through.
         assert result["task_id"] == "task_abc"
+
+
+class TestHandOffParentTaskIdPropagation:
+    """Operator workflow awareness: ``hand_off`` reads ``current_task_id``
+    so the new task chains under the parent for ``workflow_snapshot`` to
+    walk descendants from the kickoff root."""
+
+    @pytest.mark.asyncio
+    async def test_hand_off_passes_parent_task_id_when_set(self):
+        from src.agent.builtins.coordination_tool import hand_off
+        from src.shared.trace import current_task_id
+
+        mc = _make_mesh_client(agent_id="scout")
+        mc.list_agents.return_value = {"analyst": {"role": "analyst"}}
+        mc.create_task.return_value = {"id": "task_child", "status": "pending"}
+
+        token = current_task_id.set("task_root_parent")
+        try:
+            result = await hand_off(
+                to="analyst", summary="next stage", mesh_client=mc,
+            )
+        finally:
+            current_task_id.reset(token)
+
+        assert result["handed_off"] is True
+        kwargs = mc.create_task.call_args.kwargs
+        assert kwargs.get("parent_task_id") == "task_root_parent"
+
+    @pytest.mark.asyncio
+    async def test_hand_off_passes_none_when_unset(self):
+        """Outside a task context (heartbeats, free chat) the contextvar
+        is None and create_task must receive parent_task_id=None — the
+        new task lands as a workflow root."""
+        from src.agent.builtins.coordination_tool import hand_off
+        from src.shared.trace import current_task_id
+
+        mc = _make_mesh_client(agent_id="scout")
+        mc.list_agents.return_value = {"analyst": {"role": "analyst"}}
+        mc.create_task.return_value = {"id": "task_root", "status": "pending"}
+
+        # Reset to the default (None) explicitly so the test is robust to
+        # leaking state from prior tests in this module.
+        token = current_task_id.set(None)
+        try:
+            await hand_off(
+                to="analyst", summary="kickoff", mesh_client=mc,
+            )
+        finally:
+            current_task_id.reset(token)
+
+        kwargs = mc.create_task.call_args.kwargs
+        assert kwargs.get("parent_task_id") is None

--- a/tests/test_lanes.py
+++ b/tests/test_lanes.py
@@ -638,7 +638,18 @@ class TestLanePerAgentTimeout:
             await asyncio.sleep(60)
             return "never"
 
-        fake_record = {
+        # Pre-flight ``tasks_store.get`` returns the still-working row so
+        # the watchdog's "already terminal" guard does not skip the
+        # update + back-edge. The post-update ``get`` returns the failed
+        # record that should flow through to the back-edge fn.
+        working_record = {
+            "id": "task_xyz",
+            "assignee": "agent1",
+            "title": "stuck work",
+            "status": "working",
+            "origin": {"kind": "agent", "channel": "", "user": "scout"},
+        }
+        failed_record = {
             "id": "task_xyz",
             "assignee": "agent1",
             "title": "stuck work",
@@ -647,7 +658,7 @@ class TestLanePerAgentTimeout:
         }
         tasks_store = MagicMock()
         tasks_store.update_status = MagicMock()
-        tasks_store.get = MagicMock(return_value=fake_record)
+        tasks_store.get = MagicMock(side_effect=[working_record, failed_record])
 
         back_edge_calls = []
 
@@ -667,7 +678,7 @@ class TestLanePerAgentTimeout:
         tasks_store.update_status.assert_called_once()
         assert len(back_edge_calls) == 1
         rec, kind, extras = back_edge_calls[0]
-        assert rec == fake_record
+        assert rec == failed_record
         assert kind == "task_failed"
         assert extras.get("error") == "lane_timeout"
         assert extras.get("timeout_seconds") == 1
@@ -718,3 +729,210 @@ class TestLanePerAgentTimeout:
         assert lm._back_edge_fn is not None
         lm.set_back_edge_fn(None)
         assert lm._back_edge_fn is None
+
+    @pytest.mark.asyncio
+    async def test_lane_watchdog_skips_back_edge_when_task_already_terminal(self):
+        """Same-status race: the assignee finished the task (terminal
+        status) between dispatch and the watchdog's timeout, so the
+        pre-flight ``tasks_store.get`` sees ``status in {done, failed,
+        cancelled}``. The watchdog MUST skip both ``update_status`` AND
+        the back-edge fire — otherwise the assignee's actual back-edge
+        payload would be clobbered with a synthetic ``lane_timeout``."""
+        async def hanging(agent, message, **kwargs):
+            await asyncio.sleep(60)
+            return "never"
+
+        already_failed_record = {
+            "id": "task_race",
+            "assignee": "agent1",
+            "title": "completed before watchdog",
+            "status": "failed",
+            "origin": {"kind": "agent", "channel": "", "user": "scout"},
+        }
+        tasks_store = MagicMock()
+        tasks_store.update_status = MagicMock()
+        tasks_store.get = MagicMock(return_value=already_failed_record)
+
+        back_edge_calls = []
+
+        def back_edge(task_record, *, event_kind, payload_extras=None):
+            back_edge_calls.append((task_record, event_kind, payload_extras))
+
+        lm = LaneManager(
+            dispatch_fn=hanging,
+            task_timeout_seconds=1,
+            tasks_store=tasks_store,
+        )
+        lm.set_back_edge_fn(back_edge)
+
+        with pytest.raises(asyncio.TimeoutError):
+            await lm.enqueue("agent1", "stuck", task_id="task_race")
+
+        # Pre-flight read happened; update_status + back-edge skipped.
+        tasks_store.get.assert_called_once_with("task_race")
+        tasks_store.update_status.assert_not_called()
+        assert back_edge_calls == []
+
+    @pytest.mark.asyncio
+    async def test_lane_watchdog_fires_back_edge_when_task_still_working(self):
+        """Opposite of the race case: the task is still ``working`` when
+        the watchdog fires, so the pre-check falls through and the
+        watchdog transitions the row + fires the back-edge exactly once
+        with ``event_kind='task_failed'`` and the ``lane_timeout``
+        marker in ``payload_extras``."""
+        async def hanging(agent, message, **kwargs):
+            await asyncio.sleep(60)
+            return "never"
+
+        working_record = {
+            "id": "task_live",
+            "assignee": "agent1",
+            "title": "still running",
+            "status": "working",
+            "origin": {"kind": "agent", "channel": "", "user": "scout"},
+        }
+        failed_record = dict(working_record, status="failed")
+        tasks_store = MagicMock()
+        tasks_store.update_status = MagicMock()
+        # First ``get`` (pre-check) → working. Second ``get`` (after
+        # update_status) → failed (what flows into the back-edge).
+        tasks_store.get = MagicMock(side_effect=[working_record, failed_record])
+
+        back_edge_calls = []
+
+        def back_edge(task_record, *, event_kind, payload_extras=None):
+            back_edge_calls.append((task_record, event_kind, payload_extras))
+
+        lm = LaneManager(
+            dispatch_fn=hanging,
+            task_timeout_seconds=1,
+            tasks_store=tasks_store,
+        )
+        lm.set_back_edge_fn(back_edge)
+
+        with pytest.raises(asyncio.TimeoutError):
+            await lm.enqueue("agent1", "stuck", task_id="task_live")
+
+        tasks_store.update_status.assert_called_once()
+        assert len(back_edge_calls) == 1
+        rec, kind, extras = back_edge_calls[0]
+        assert rec == failed_record
+        assert kind == "task_failed"
+        assert extras.get("error") == "lane_timeout"
+        assert extras.get("timeout_seconds") == 1
+
+
+# ── Per-agent watchdog YAML wiring ─────────────────────────────────
+
+
+class TestPerAgentWatchdogYamlWiring:
+    """The runtime's startup loop reads
+    ``agents.yaml.<id>.settings.watchdog_ttl_seconds`` and pushes each
+    valid entry into ``LaneManager.set_agent_timeout``. The loop must:
+
+    * dispatch ints unchanged into the per-agent overlay,
+    * coerce numeric strings,
+    * log + skip non-numeric values without aborting other entries,
+    * skip entries that omit the field entirely,
+    * be defensive against a malformed ``agents.yaml`` (the outer
+      try/except in runtime.py wraps the loop so startup is not
+      aborted by a parse error).
+    """
+
+    def _apply_yaml_overrides(self, lm: LaneManager, cfg: dict) -> list[str]:
+        """Mirror the runtime.py loop body — same conditions, same
+        coercion order. Returns a list of agent ids that were skipped
+        (for assertion). Kept inline so the test pins the exact logic
+        rather than monkey-patching the runtime module which would
+        drag in the full ``RuntimeContext`` startup graph."""
+        skipped: list[str] = []
+        try:
+            agents_cfg = cfg.get("agents", {}) or {}
+            for aid, entry in agents_cfg.items():
+                if not isinstance(entry, dict):
+                    skipped.append(aid)
+                    continue
+                settings = entry.get("settings") or {}
+                ttl = settings.get("watchdog_ttl_seconds")
+                if ttl is None:
+                    continue
+                try:
+                    lm.set_agent_timeout(aid, int(ttl))
+                except (TypeError, ValueError):
+                    skipped.append(aid)
+        except Exception:
+            pass
+        return skipped
+
+    def test_single_agent_ttl_lands_in_overlay(self):
+        lm = LaneManager(dispatch_fn=AsyncMock(return_value=""))
+        cfg = {
+            "agents": {
+                "alpha": {"settings": {"watchdog_ttl_seconds": 120}},
+            },
+        }
+        skipped = self._apply_yaml_overrides(lm, cfg)
+        assert skipped == []
+        assert lm._per_agent_timeouts == {"alpha": 120}
+        # _timeout_for resolves to the override, not the module default.
+        assert lm._timeout_for("alpha") == 120
+
+    def test_multiple_agents_independent_overrides(self):
+        lm = LaneManager(dispatch_fn=AsyncMock(return_value=""))
+        cfg = {
+            "agents": {
+                "alpha": {"settings": {"watchdog_ttl_seconds": 600}},
+                "beta":  {"settings": {"watchdog_ttl_seconds": 900}},
+                # gamma has no ttl → no override; falls back to default.
+                "gamma": {"settings": {}},
+                # delta omits ``settings`` entirely.
+                "delta": {},
+            },
+        }
+        self._apply_yaml_overrides(lm, cfg)
+        assert lm._per_agent_timeouts == {"alpha": 600, "beta": 900}
+        # gamma + delta fall back to module default (not in overlay dict).
+        assert "gamma" not in lm._per_agent_timeouts
+        assert "delta" not in lm._per_agent_timeouts
+
+    def test_numeric_string_ttl_is_coerced(self):
+        """YAML can yield a string when the user quotes the number;
+        the runtime loop coerces via int() before passing through."""
+        lm = LaneManager(dispatch_fn=AsyncMock(return_value=""))
+        cfg = {
+            "agents": {
+                "alpha": {"settings": {"watchdog_ttl_seconds": "300"}},
+            },
+        }
+        skipped = self._apply_yaml_overrides(lm, cfg)
+        assert skipped == []
+        assert lm._per_agent_timeouts["alpha"] == 300
+
+    def test_bad_ttl_value_skipped_other_entries_apply(self):
+        """A non-numeric value logs and skips that one agent. Other
+        agents in the same dict still get their overrides applied."""
+        lm = LaneManager(dispatch_fn=AsyncMock(return_value=""))
+        cfg = {
+            "agents": {
+                "alpha": {"settings": {"watchdog_ttl_seconds": "not_a_number"}},
+                "beta":  {"settings": {"watchdog_ttl_seconds": 420}},
+            },
+        }
+        skipped = self._apply_yaml_overrides(lm, cfg)
+        assert "alpha" in skipped
+        # Alpha was skipped; beta still applied.
+        assert "alpha" not in lm._per_agent_timeouts
+        assert lm._per_agent_timeouts == {"beta": 420}
+
+    def test_clamps_below_minimum_floor(self):
+        """``set_agent_timeout`` clamps to a 60s floor so a tiny TTL
+        in agents.yaml can't make the watchdog the bottleneck."""
+        lm = LaneManager(dispatch_fn=AsyncMock(return_value=""))
+        cfg = {
+            "agents": {
+                "alpha": {"settings": {"watchdog_ttl_seconds": 5}},
+            },
+        }
+        self._apply_yaml_overrides(lm, cfg)
+        # Clamped to 60 by ``set_agent_timeout``.
+        assert lm._per_agent_timeouts["alpha"] == 60

--- a/tests/test_lanes.py
+++ b/tests/test_lanes.py
@@ -572,3 +572,149 @@ class TestLaneQuarantineGate:
         assert call_kwargs.args[1] == "failed"
         assert call_kwargs.kwargs.get("actor") == "lane_quarantine"
         assert call_kwargs.kwargs.get("extra_payload", {}).get("error") == "agent_quarantined"
+
+
+# ── Per-agent timeout + back-edge integration (operator workflow awareness) ──
+
+
+class TestLanePerAgentTimeout:
+    """The per-agent override is the workflow-awareness layer's way to
+    give workflow-stage agents (page-writer etc.) a tight cap while
+    leaving deep-research agents on the generous default."""
+
+    @pytest.mark.asyncio
+    async def test_default_used_when_no_override(self):
+        lm = LaneManager(
+            dispatch_fn=AsyncMock(return_value=""),
+            task_timeout_seconds=300,
+        )
+        assert lm._timeout_for("any-agent") == 300
+
+    @pytest.mark.asyncio
+    async def test_per_agent_timeout_override_honored(self):
+        """``set_agent_timeout`` overrides the module default for the
+        watchdog wait. The override forces a timeout for one agent while
+        the default cap is preserved for others."""
+        async def slow(agent, message, **kwargs):
+            await asyncio.sleep(5)
+            return "would-have-completed"
+
+        # Default 300s — would let dispatch complete normally. The
+        # per-agent override is clamped to 60s, but that's still well
+        # over the dispatch hang we want to validate. We assert the
+        # resolver math directly + use a separately built lane with a
+        # 1s default (the lane will pick it up via _timeout_for).
+        lm = LaneManager(dispatch_fn=slow, task_timeout_seconds=300)
+        lm.set_agent_timeout("agent-tight", 60)
+        # Untouched agents still see the default.
+        assert lm._timeout_for("agent-loose") == 300
+        assert lm._timeout_for("agent-tight") == 60
+
+        # Functional check: tight cap on the dispatch path.
+        lm2 = LaneManager(dispatch_fn=slow, task_timeout_seconds=1)
+        with pytest.raises(asyncio.TimeoutError):
+            await lm2.enqueue("agent-x", "stuck")
+
+    @pytest.mark.asyncio
+    async def test_set_agent_timeout_clamps_below_60(self):
+        """``seconds`` < 60 is clamped to 60 — a 1-second cap would make
+        the watchdog the bottleneck instead of a safety net."""
+        lm = LaneManager(dispatch_fn=AsyncMock(return_value=""))
+        lm.set_agent_timeout("agent-a", 5)
+        assert lm._timeout_for("agent-a") == 60
+        lm.set_agent_timeout("agent-a", 120)
+        assert lm._timeout_for("agent-a") == 120
+        # None drops back to the default.
+        lm.set_agent_timeout("agent-a", None)
+        assert lm._timeout_for("agent-a") == lm._task_timeout_seconds
+
+    @pytest.mark.asyncio
+    async def test_timeout_fires_back_edge_with_task_failed(self):
+        """When a tasks_store is wired AND a back_edge_fn is set, the
+        watchdog calls the back-edge writer with event_kind=task_failed
+        and ``payload_extras={'error':'lane_timeout','timeout_seconds':N}``
+        so the originator's inbox sees the failure."""
+        async def hanging(agent, message, **kwargs):
+            await asyncio.sleep(60)
+            return "never"
+
+        fake_record = {
+            "id": "task_xyz",
+            "assignee": "agent1",
+            "title": "stuck work",
+            "status": "failed",
+            "origin": {"kind": "agent", "channel": "", "user": "scout"},
+        }
+        tasks_store = MagicMock()
+        tasks_store.update_status = MagicMock()
+        tasks_store.get = MagicMock(return_value=fake_record)
+
+        back_edge_calls = []
+
+        def back_edge(task_record, *, event_kind, payload_extras=None):
+            back_edge_calls.append((task_record, event_kind, payload_extras))
+
+        lm = LaneManager(
+            dispatch_fn=hanging,
+            task_timeout_seconds=1,
+            tasks_store=tasks_store,
+        )
+        lm.set_back_edge_fn(back_edge)
+
+        with pytest.raises(asyncio.TimeoutError):
+            await lm.enqueue("agent1", "stuck", task_id="task_xyz")
+
+        tasks_store.update_status.assert_called_once()
+        assert len(back_edge_calls) == 1
+        rec, kind, extras = back_edge_calls[0]
+        assert rec == fake_record
+        assert kind == "task_failed"
+        assert extras.get("error") == "lane_timeout"
+        assert extras.get("timeout_seconds") == 1
+
+    @pytest.mark.asyncio
+    async def test_timeout_skips_back_edge_on_invalid_status_transition(self):
+        """When ``update_status`` raises ``InvalidStatusTransition`` — the
+        race where the assignee terminated the task between our SELECT
+        and UPDATE — the worker logs the race and SKIPS the back-edge,
+        avoiding a double-notification."""
+        from src.host.orchestration import InvalidStatusTransition
+
+        async def hanging(agent, message, **kwargs):
+            await asyncio.sleep(60)
+            return "never"
+
+        tasks_store = MagicMock()
+        tasks_store.update_status = MagicMock(
+            side_effect=InvalidStatusTransition("already done"),
+        )
+        tasks_store.get = MagicMock(return_value={"id": "task_x"})
+
+        back_edge_calls = []
+
+        def back_edge(task_record, *, event_kind, payload_extras=None):
+            back_edge_calls.append((task_record, event_kind, payload_extras))
+
+        lm = LaneManager(
+            dispatch_fn=hanging,
+            task_timeout_seconds=1,
+            tasks_store=tasks_store,
+        )
+        lm.set_back_edge_fn(back_edge)
+
+        with pytest.raises(asyncio.TimeoutError):
+            await lm.enqueue("agent1", "stuck", task_id="task_x")
+
+        # update_status fired (and raised), back-edge was skipped (race).
+        tasks_store.update_status.assert_called_once()
+        assert back_edge_calls == []
+
+    @pytest.mark.asyncio
+    async def test_set_back_edge_fn_clears_with_none(self):
+        """Setter accepts None to clear the wired function — used by
+        teardown paths."""
+        lm = LaneManager(dispatch_fn=AsyncMock(return_value=""))
+        lm.set_back_edge_fn(lambda *a, **kw: None)
+        assert lm._back_edge_fn is not None
+        lm.set_back_edge_fn(None)
+        assert lm._back_edge_fn is None

--- a/tests/test_operator_config.py
+++ b/tests/test_operator_config.py
@@ -150,11 +150,21 @@ class TestEnsureOperatorModelSync(_TempConfigMixin):
         assert result["agents"]["operator"]["model"] == "anthropic/claude-3-haiku"
 
     def test_no_write_when_operator_exists(self):
-        """Does not rewrite agents.yaml when operator already exists."""
-        # Pre-create operator with matching model
+        """Does not rewrite agents.yaml when operator already exists.
+
+        The post-migration ``_ensure_operator_agent`` will refresh the
+        heartbeat when its sentinel is missing — to pin the pure no-write
+        path we seed the heartbeat with the canonical template (which
+        carries the sentinel) so the refresh branch is a no-op.
+        """
+        from src.cli.config import _OPERATOR_HEARTBEAT
+
+        # Pre-create operator with matching model AND the canonical
+        # heartbeat template (sentinel present → no refresh).
         agents_cfg = {"agents": {"operator": {
             "role": "Existing operator",
             "model": "openai/gpt-4o-mini",
+            "heartbeat": _OPERATOR_HEARTBEAT,
         }}}
         with open(self._agents_path, "w") as f:
             yaml.dump(agents_cfg, f)
@@ -250,7 +260,9 @@ class TestOperatorConstants:
         # a magic number so additions like ``compose_work_summary`` from
         # the work-summaries backend don't require recounting.
         assert _OPERATOR_ALLOWED_TOOLS  # non-empty
-        assert len(_OPERATOR_HEARTBEAT_TOOLS) == 4
+        # Workflow-awareness layer added check_inbox / workflow_snapshot /
+        # await_task_event so the heartbeat can drive multi-stage chains.
+        assert len(_OPERATOR_HEARTBEAT_TOOLS) == 7
         # Heartbeat tools should be a subset of allowed tools
         assert set(_OPERATOR_HEARTBEAT_TOOLS).issubset(set(_OPERATOR_ALLOWED_TOOLS))
         # Consolidated product tools (read + lifecycle) must be present.

--- a/tests/test_operator_config.py
+++ b/tests/test_operator_config.py
@@ -420,6 +420,42 @@ class TestOperatorConstants:
         from src.cli.config import _OPERATOR_HEARTBEAT
         assert f"HEARTBEAT_MAX_ITERATIONS={HEARTBEAT_MAX_ITERATIONS}" in _OPERATOR_HEARTBEAT
 
+    def test_heartbeat_imports_sentinel_from_shared_types(self):
+        """HEARTBEAT_SENTINELS lives in ``src.shared.types`` and the
+        operator-config refresh path imports it from there. Verifies
+        the central constant resolves and contains the canonical
+        marker actually embedded in ``_OPERATOR_HEARTBEAT``."""
+        from src.cli.config import _OPERATOR_HEARTBEAT
+        from src.shared.types import HEARTBEAT_SENTINELS
+        assert isinstance(HEARTBEAT_SENTINELS, tuple)
+        assert "heartbeat_v2_workflow_aware" in HEARTBEAT_SENTINELS
+        # Every sentinel in the tuple must appear as an HTML comment
+        # somewhere in the canonical template — otherwise the
+        # ``new_has_sentinel`` check in ``_ensure_operator_agent``
+        # would silently fail to roll the heartbeat forward.
+        present = [
+            f"<!-- {m} -->" in _OPERATOR_HEARTBEAT
+            for m in HEARTBEAT_SENTINELS
+        ]
+        assert any(present), (
+            "no HEARTBEAT_SENTINELS marker present in _OPERATOR_HEARTBEAT — "
+            "operator heartbeat refresh would never fire"
+        )
+
+    def test_heartbeat_step4_mentions_inline_blocker_note(self):
+        """Fix 4 — step 4 must surface the new inline ``blocker_note``
+        contract and the 3-call cap so the LLM doesn't loop snapshots."""
+        from src.cli.config import _OPERATOR_HEARTBEAT
+        # Snapshot now carries blocker_note inline — no follow-up
+        # get_task call needed.
+        assert "blocker_note" in _OPERATOR_HEARTBEAT
+        assert "inline" in _OPERATOR_HEARTBEAT
+        # Cap of 3 snapshot calls per heartbeat.
+        assert (
+            "Cap at 3 snapshot calls" in _OPERATOR_HEARTBEAT
+            or "cap at 3 snapshot calls" in _OPERATOR_HEARTBEAT
+        )
+
     def test_core_has_key_sections(self):
         from src.shared.operator_playbooks import _OPERATOR_CORE
         assert "Routing Work" in _OPERATOR_CORE

--- a/tests/test_operator_heartbeat.py
+++ b/tests/test_operator_heartbeat.py
@@ -88,9 +88,19 @@ async def test_heartbeat_restores_tools_on_skip():
 
 
 def test_heartbeat_tools_constant():
-    """Verify _HEARTBEAT_TOOLS has exactly the 5 expected tools."""
+    """Verify _HEARTBEAT_TOOLS carries the workflow-awareness allowlist.
+
+    The set previously had 5 entries (list_agents, get_agent_profile,
+    get_system_status, notify_user, save_observations). The operator
+    workflow-awareness layer added three operator-only reads
+    (``check_inbox`` for back-edge events, ``workflow_snapshot`` for
+    chain inspection, ``await_task_event`` for single-task blocking) so
+    the heartbeat can drive multi-stage chains without dropping out to
+    a full /chat turn.
+    """
     assert _HEARTBEAT_TOOLS == frozenset({
         "list_agents", "get_agent_profile", "get_system_status",
         "notify_user", "save_observations",
+        "check_inbox", "workflow_snapshot", "await_task_event",
     })
-    assert len(_HEARTBEAT_TOOLS) == 5
+    assert len(_HEARTBEAT_TOOLS) == 8

--- a/tests/test_operator_tools.py
+++ b/tests/test_operator_tools.py
@@ -1446,3 +1446,84 @@ class TestAwaitTaskEventSkill:
         )
         assert result.get("timed_out") is True
         assert result["task_id"] == "task_target"
+
+    @pytest.mark.asyncio
+    async def test_per_poll_timeout_treated_as_transient(self, monkeypatch):
+        """A per-poll ``asyncio.TimeoutError`` from
+        ``list_blackboard`` must NOT terminate the wait — the watchdog
+        treats it as a transient hiccup, sleeps, and polls again. We
+        prove this by raising TimeoutError on the first call then
+        returning a matching terminal event on the second."""
+        import asyncio as _aio
+
+        from src.agent.builtins import operator_tools
+        from src.agent.builtins.operator_tools import await_task_event
+
+        # Short-circuit the inter-poll sleep so the test doesn't wait.
+        # ``await_task_event`` does ``import asyncio`` locally; the
+        # module is a process singleton, so patching ``asyncio.sleep``
+        # directly is the simplest seam.
+        async def _no_sleep(_seconds):
+            return None
+
+        monkeypatch.setattr(_aio, "sleep", _no_sleep)
+        # Touch ``operator_tools`` so the import isn't flagged unused
+        # (the module ref is still useful for future seams).
+        assert operator_tools.await_task_event is await_task_event
+
+        calls = {"n": 0}
+
+        async def flaky_list_blackboard(_prefix, *, global_scope=False):
+            calls["n"] += 1
+            if calls["n"] == 1:
+                raise _aio.TimeoutError("simulated stuck poll")
+            return [
+                {"value": {
+                    "kind": "task_completed",
+                    "task_id": "task_t",
+                    "status": "done",
+                    "ts": 0,
+                }},
+            ]
+
+        mc = MagicMock()
+        mc.agent_id = "operator"
+        mc.list_blackboard = flaky_list_blackboard
+
+        result = await await_task_event(
+            "task_t", timeout_s=60, poll_interval_s=1, mesh_client=mc,
+        )
+        # We polled twice: once timed out (transient), once returned the
+        # terminal event. The error envelope path must NOT have fired.
+        assert calls["n"] == 2
+        assert "error" not in result
+        assert "event" in result
+        assert result["event"]["kind"] == "task_completed"
+
+    @pytest.mark.asyncio
+    async def test_deadline_check_skips_poll_when_too_close(self, monkeypatch):
+        """Pre-iteration deadline math: if ``deadline - now <=
+        _AWAIT_TASK_EVENT_POLL_BUDGET_S``, return ``timed_out`` without
+        starting a poll that could overrun the deadline. We monkeypatch
+        the constant to be larger than the requested timeout so the
+        pre-check fires on the very first iteration."""
+        from src.agent.builtins import operator_tools
+        from src.agent.builtins.operator_tools import await_task_event
+
+        # Force the per-poll budget higher than the user-supplied
+        # timeout so the deadline-pre-check trips on iteration 1.
+        monkeypatch.setattr(
+            operator_tools, "_AWAIT_TASK_EVENT_POLL_BUDGET_S", 30,
+        )
+
+        mc = MagicMock()
+        mc.agent_id = "operator"
+        # Should NEVER be called — the deadline check returns first.
+        mc.list_blackboard = AsyncMock(return_value=[])
+
+        result = await await_task_event(
+            "task_short", timeout_s=5, poll_interval_s=1, mesh_client=mc,
+        )
+        assert result.get("timed_out") is True
+        assert result["task_id"] == "task_short"
+        mc.list_blackboard.assert_not_called()

--- a/tests/test_operator_tools.py
+++ b/tests/test_operator_tools.py
@@ -1284,3 +1284,165 @@ async def test_archive_audit_before_surfaces_truncated_flag():
     result = await archive_audit_before("2026-04-01", mesh_client=mc)
     assert result["truncated"] is True
     assert "rerun" in result["message"].lower()
+
+
+# ── workflow_snapshot operator skill ──────────────────────────────
+
+
+class TestWorkflowSnapshotSkill:
+    """The operator-only ``workflow_snapshot`` skill is a thin wrapper
+    over ``mesh_client.get_workflow_snapshot``: it 404-maps to
+    ``{'error': 'not_found'}`` and proxies the dict otherwise."""
+
+    @pytest.mark.asyncio
+    async def test_returns_mesh_result(self):
+        from src.agent.builtins.operator_tools import workflow_snapshot
+
+        mc = MagicMock()
+        snapshot = {
+            "root": "task_root",
+            "stages": [
+                {
+                    "task_id": "task_root", "parent_task_id": None,
+                    "assignee": "scout", "status": "done",
+                    "age_in_state_seconds": 12, "title": "kickoff",
+                },
+            ],
+            "summary": {
+                "done": 1, "working": 0, "pending": 0,
+                "failed": 0, "blocked": 0, "cancelled": 0, "total": 1,
+            },
+        }
+        mc.get_workflow_snapshot = AsyncMock(return_value=snapshot)
+
+        result = await workflow_snapshot("task_root", mesh_client=mc)
+        assert result == snapshot
+        mc.get_workflow_snapshot.assert_awaited_once_with("task_root")
+
+    @pytest.mark.asyncio
+    async def test_returns_not_found_when_mesh_returns_none(self):
+        from src.agent.builtins.operator_tools import workflow_snapshot
+
+        mc = MagicMock()
+        mc.get_workflow_snapshot = AsyncMock(return_value=None)
+        result = await workflow_snapshot("task_missing", mesh_client=mc)
+        assert result == {
+            "error": "not_found", "root_task_id": "task_missing",
+        }
+
+    @pytest.mark.asyncio
+    async def test_blocked_for_non_operator(self, monkeypatch):
+        from src.agent.builtins.operator_tools import workflow_snapshot
+
+        monkeypatch.delenv("ALLOWED_TOOLS", raising=False)
+        mc = MagicMock()
+        mc.get_workflow_snapshot = AsyncMock(return_value={"root": "x"})
+        result = await workflow_snapshot("x", mesh_client=mc)
+        assert "error" in result
+        assert "operator" in result["error"].lower()
+        mc.get_workflow_snapshot.assert_not_called()
+
+
+# ── await_task_event operator skill ───────────────────────────────
+
+
+class TestAwaitTaskEventSkill:
+    """``await_task_event`` polls the operator's back-edge inbox for a
+    terminal event matching ``task_id`` with exponential backoff."""
+
+    @pytest.mark.asyncio
+    async def test_returns_event_when_already_terminal_in_inbox(self):
+        from src.agent.builtins.operator_tools import await_task_event
+
+        mc = MagicMock()
+        mc.agent_id = "operator"
+        mc.list_blackboard = AsyncMock(return_value=[
+            {"value": {
+                "kind": "task_completed",
+                "task_id": "task_abc",
+                "status": "done",
+                "title": "stage 1",
+                "summary": "ok",
+                "ts": 1000,
+            }},
+        ])
+        result = await await_task_event(
+            "task_abc", timeout_s=60, poll_interval_s=1, mesh_client=mc,
+        )
+        assert "event" in result
+        assert result["event"]["kind"] == "task_completed"
+        assert result["event"]["task_id"] == "task_abc"
+
+    @pytest.mark.asyncio
+    async def test_returns_timed_out_when_no_match(self):
+        from src.agent.builtins.operator_tools import await_task_event
+
+        mc = MagicMock()
+        mc.agent_id = "operator"
+        mc.list_blackboard = AsyncMock(return_value=[])
+        # Use the minimum (1s) timeout so the loop exits immediately.
+        result = await await_task_event(
+            "task_zzz", timeout_s=1, poll_interval_s=1, mesh_client=mc,
+        )
+        assert result.get("timed_out") is True
+        assert result["task_id"] == "task_zzz"
+        assert result["waited_seconds"] == 1
+
+    @pytest.mark.asyncio
+    async def test_timeout_capped_at_270(self):
+        """``timeout_s`` is clamped to 270 (under the 300s tool ceiling).
+        We verify by passing 600 and asserting the returned
+        ``waited_seconds`` reflects the cap on a no-match timeout."""
+        from src.agent.builtins.operator_tools import (
+            _AWAIT_TASK_EVENT_MAX_TIMEOUT_S,
+            await_task_event,
+        )
+
+        mc = MagicMock()
+        mc.agent_id = "operator"
+        # Return a matching terminal event on the first poll so the call
+        # returns immediately — we just need to validate the internal cap
+        # by inspecting it through the early-return path.
+        mc.list_blackboard = AsyncMock(return_value=[
+            {"value": {
+                "kind": "task_failed",
+                "task_id": "task_y",
+                "status": "failed",
+                "ts": 0,
+            }},
+        ])
+        result = await await_task_event(
+            "task_y", timeout_s=600, poll_interval_s=1, mesh_client=mc,
+        )
+        # Immediate event → not timed out, but the cap is documented
+        # via the module-level constant — pin the value too.
+        assert _AWAIT_TASK_EVENT_MAX_TIMEOUT_S == 270
+        assert "event" in result
+
+    @pytest.mark.asyncio
+    async def test_non_matching_task_ids_ignored(self):
+        """Events for OTHER task IDs in the inbox don't terminate the
+        wait — only matching task_ids count."""
+        from src.agent.builtins.operator_tools import await_task_event
+
+        mc = MagicMock()
+        mc.agent_id = "operator"
+        mc.list_blackboard = AsyncMock(return_value=[
+            {"value": {
+                "kind": "task_completed",
+                "task_id": "task_OTHER",
+                "status": "done",
+            }},
+            {"value": {
+                "kind": "task_completed",
+                "task_id": "task_ALSO_OTHER",
+                "status": "done",
+            }},
+        ])
+        # 1s timeout — should return timed_out because the matching id
+        # is never in the inbox.
+        result = await await_task_event(
+            "task_target", timeout_s=1, poll_interval_s=1, mesh_client=mc,
+        )
+        assert result.get("timed_out") is True
+        assert result["task_id"] == "task_target"

--- a/tests/test_orchestration.py
+++ b/tests/test_orchestration.py
@@ -1548,8 +1548,15 @@ class TestWorkflowSnapshot:
     def test_summary_buckets_reflect_statuses(self, tmp_path):
         t = _make_store(tmp_path)
         root, mid, leaf = _chain(t)
-        # Move mid through working → done; leaf to blocked. Root stays
-        # pending. The summary must count by terminal/active state.
+        # Add a fourth stage we can park in ``accepted`` — the 7th
+        # status that the original 6-bucket hard-coded code missed.
+        extra = t.create(
+            creator="writer", assignee="reviewer", title="review",
+            parent_task_id=leaf["id"],
+        )
+        # Move mid through working → done; leaf to blocked; extra to
+        # accepted. Root stays pending. The summary must count by
+        # terminal/active state across the full ``VALID_STATUSES`` set.
         t.update_status(mid["id"], "working", actor="analyst")
         t.update_status(mid["id"], "done", actor="analyst")
         t.update_status(leaf["id"], "working", actor="writer")
@@ -1557,16 +1564,33 @@ class TestWorkflowSnapshot:
             leaf["id"], "blocked", actor="writer",
             blocker_note="need clarification",
         )
+        t.update_status(extra["id"], "accepted", actor="reviewer")
         snap = t.workflow_snapshot(root["id"])
         assert snap is not None
         summary = snap["summary"]
+        # Every status in VALID_STATUSES must have a bucket — the fix
+        # derives buckets from the enum rather than a hard-coded list.
+        for status in VALID_STATUSES:
+            assert status in summary, (
+                f"missing bucket for {status!r} — buckets must derive "
+                f"from VALID_STATUSES"
+            )
         assert summary["pending"] == 1
+        assert summary["accepted"] == 1
         assert summary["done"] == 1
         assert summary["blocked"] == 1
         assert summary["working"] == 0
         assert summary["failed"] == 0
         assert summary["cancelled"] == 0
-        assert summary["total"] == 3
+        assert summary["total"] == 4
+        # The critical invariant — bucket sum equals total. The pre-fix
+        # 6-bucket math missed ``accepted`` so this would have been 3 == 4.
+        bucket_sum = sum(
+            summary[s] for s in VALID_STATUSES
+        )
+        assert bucket_sum == summary["total"], (
+            f"buckets {bucket_sum} != total {summary['total']}"
+        )
 
     def test_age_in_state_seconds_is_positive_int(self, tmp_path):
         t = _make_store(tmp_path)
@@ -1580,3 +1604,84 @@ class TestWorkflowSnapshot:
         ages = [s["age_in_state_seconds"] for s in snap["stages"]]
         assert all(isinstance(a, int) for a in ages)
         assert all(a >= 1 for a in ages), ages
+
+    def test_blocker_note_surfaces_only_on_blocked_stages(self, tmp_path):
+        """Per-stage ``blocker_note`` is included inline when set on a
+        blocked task and ABSENT on done / working / pending stages —
+        so the operator gets the context without a follow-up get_task
+        call but nominal stages stay quiet."""
+        t = _make_store(tmp_path)
+        root, mid, leaf = _chain(t)
+        # leaf → working → blocked with a note. mid → working → done
+        # (no note). root stays pending (no note).
+        t.update_status(mid["id"], "working", actor="analyst")
+        t.update_status(mid["id"], "done", actor="analyst")
+        t.update_status(leaf["id"], "working", actor="writer")
+        t.update_status(
+            leaf["id"], "blocked", actor="writer",
+            blocker_note="awaiting upstream API key",
+        )
+        snap = t.workflow_snapshot(root["id"])
+        assert snap is not None
+        by_id = {s["task_id"]: s for s in snap["stages"]}
+        # Blocked leaf carries the note inline.
+        leaf_stage = by_id[leaf["id"]]
+        assert leaf_stage["status"] == "blocked"
+        assert leaf_stage["blocker_note"] == "awaiting upstream API key"
+        # Done mid stage has no blocker_note key.
+        mid_stage = by_id[mid["id"]]
+        assert mid_stage["status"] == "done"
+        assert "blocker_note" not in mid_stage, (
+            "blocker_note must be absent on non-blocked stages so the "
+            "snapshot stays quiet for nominal workflow steps"
+        )
+        # Pending root has no blocker_note key either.
+        root_stage = by_id[root["id"]]
+        assert root_stage["status"] == "pending"
+        assert "blocker_note" not in root_stage
+
+    def test_max_workflow_chain_depth_caps_recursion(self, tmp_path):
+        """``MAX_WORKFLOW_CHAIN_DEPTH`` (=200) bounds the inner CTE
+        before the outer LIMIT trims. A 250-stage chain must materialise
+        no more rows than the depth cap allows AND the outer ``limit``
+        still applies — set ``limit=300`` so the depth bound is the
+        binding constraint."""
+        from src.host.orchestration import MAX_WORKFLOW_CHAIN_DEPTH
+        assert MAX_WORKFLOW_CHAIN_DEPTH == 200
+        t = _make_store(tmp_path)
+        # Build a linear 250-stage chain. Each new task points to the
+        # previous one as parent.
+        root = t.create(
+            creator="operator", assignee="scout", title="stage_0",
+        )
+        prev_id = root["id"]
+        for i in range(1, 250):
+            rec = t.create(
+                creator="scout", assignee="writer",
+                title=f"stage_{i}", parent_task_id=prev_id,
+            )
+            prev_id = rec["id"]
+        # limit=50 (default behaviour) — outer LIMIT is the binding cap.
+        snap = t.workflow_snapshot(root["id"])
+        assert snap is not None
+        assert len(snap["stages"]) == 50, (
+            f"default limit=50 must cap at 50 rows, got {len(snap['stages'])}"
+        )
+        # limit=300 — outer cap exceeds the recursion depth, so the
+        # depth bound becomes the binding constraint. The inner CTE
+        # walks ``depth < MAX_WORKFLOW_CHAIN_DEPTH`` (root at depth 0,
+        # descendants at depth 1..MAX_WORKFLOW_CHAIN_DEPTH-1), so we get
+        # root + MAX_WORKFLOW_CHAIN_DEPTH−1 children plus the row whose
+        # parent sits at depth MAX_WORKFLOW_CHAIN_DEPTH−1 = at most
+        # MAX_WORKFLOW_CHAIN_DEPTH + 1 rows in total.
+        snap_deep = t.workflow_snapshot(root["id"], limit=300)
+        assert snap_deep is not None
+        # The depth guard kicks in well before the chain length; we
+        # must NOT see all 250 stages even when ``limit`` allows it.
+        assert len(snap_deep["stages"]) < 250, (
+            "MAX_WORKFLOW_CHAIN_DEPTH must cap a 250-stage chain "
+            "below the chain length even when limit is generous"
+        )
+        # Loose upper bound — MAX_WORKFLOW_CHAIN_DEPTH+1 covers the
+        # off-by-one between depth values and row counts.
+        assert len(snap_deep["stages"]) <= MAX_WORKFLOW_CHAIN_DEPTH + 1

--- a/tests/test_orchestration.py
+++ b/tests/test_orchestration.py
@@ -1449,3 +1449,134 @@ def test_last_event_ts_for_agent_returns_most_recent(tmp_path):
     # The later row's event should win.
     assert ts >= rec_b["created_at"]
     assert ts >= rec_a["created_at"]
+
+
+# ── Defensive: Tasks.create post-write assert (Bug 1 catch) ─────────
+
+
+class TestTasksCreatePostWriteAssert:
+    """``Tasks.create`` re-reads its INSERT under autocommit and raises
+    RuntimeError on a missing row, so a corrupt/migrating store can't
+    leak ``None`` into the agent's hand_off envelope."""
+
+    def test_create_happy_path_returns_dict(self, tmp_path):
+        t = _make_store(tmp_path)
+        rec = t.create(creator="scout", assignee="analyst", title="hi")
+        assert isinstance(rec, dict)
+        assert rec["id"].startswith("task_")
+        assert rec["title"] == "hi"
+
+    def test_create_raises_when_post_read_returns_none(self, tmp_path):
+        """Force ``self.get(tid)`` to return None after the INSERT — the
+        post-write assert must surface as a loud RuntimeError so the
+        endpoint returns 5xx and ``hand_off`` fires its ``create_failed``
+        envelope instead of returning ``null`` JSON."""
+        t = _make_store(tmp_path)
+        # Patch the bound get() to None so the INSERT succeeds but the
+        # post-read returns nothing. This mirrors the storage-corruption
+        # / mid-migration race the assert exists to catch.
+        t.get = lambda task_id: None  # type: ignore[method-assign]
+        with pytest.raises(RuntimeError) as ei:
+            t.create(creator="scout", assignee="analyst", title="oops")
+        msg = str(ei.value)
+        assert "post-read returned no" in msg or "post-read" in msg
+
+
+# ── workflow_snapshot (operator workflow awareness) ────────────────
+
+
+def _chain(t: Tasks, *, creator="operator", project=None):
+    """Build a linear 3-stage workflow chain rooted at a kickoff task.
+
+    Returns ``(root, mid, leaf)`` records.
+    """
+    root = t.create(
+        creator=creator, assignee="scout", title="kickoff",
+        project_id=project,
+    )
+    time.sleep(0.01)
+    mid = t.create(
+        creator="scout", assignee="analyst", title="middle",
+        parent_task_id=root["id"], project_id=project,
+    )
+    time.sleep(0.01)
+    leaf = t.create(
+        creator="analyst", assignee="writer", title="leaf",
+        parent_task_id=mid["id"], project_id=project,
+    )
+    return root, mid, leaf
+
+
+class TestWorkflowSnapshot:
+    def test_linear_chain_returns_stages_in_created_order(self, tmp_path):
+        t = _make_store(tmp_path)
+        root, mid, leaf = _chain(t)
+        snap = t.workflow_snapshot(root["id"])
+        assert snap is not None
+        assert snap["root"] == root["id"]
+        # Three stages, ordered by created_at ASC (kickoff → leaf).
+        stages = snap["stages"]
+        assert [s["task_id"] for s in stages] == [
+            root["id"], mid["id"], leaf["id"],
+        ]
+        # parent_task_id chain reads as None → root → mid.
+        assert stages[0]["parent_task_id"] is None
+        assert stages[1]["parent_task_id"] == root["id"]
+        assert stages[2]["parent_task_id"] == mid["id"]
+
+    def test_missing_root_returns_none(self, tmp_path):
+        t = _make_store(tmp_path)
+        assert t.workflow_snapshot("task_does_not_exist") is None
+
+    def test_limit_caps_stage_count(self, tmp_path):
+        t = _make_store(tmp_path)
+        root = t.create(
+            creator="operator", assignee="scout", title="root",
+        )
+        # Fan out four direct children. WITH RECURSIVE walks every
+        # descendant; LIMIT 2 caps at root + 1 child = 2 rows (created_at ASC).
+        for i in range(4):
+            time.sleep(0.005)
+            t.create(
+                creator="scout", assignee="writer",
+                title=f"child{i}", parent_task_id=root["id"],
+            )
+        snap = t.workflow_snapshot(root["id"], limit=2)
+        assert snap is not None
+        assert len(snap["stages"]) == 2
+
+    def test_summary_buckets_reflect_statuses(self, tmp_path):
+        t = _make_store(tmp_path)
+        root, mid, leaf = _chain(t)
+        # Move mid through working → done; leaf to blocked. Root stays
+        # pending. The summary must count by terminal/active state.
+        t.update_status(mid["id"], "working", actor="analyst")
+        t.update_status(mid["id"], "done", actor="analyst")
+        t.update_status(leaf["id"], "working", actor="writer")
+        t.update_status(
+            leaf["id"], "blocked", actor="writer",
+            blocker_note="need clarification",
+        )
+        snap = t.workflow_snapshot(root["id"])
+        assert snap is not None
+        summary = snap["summary"]
+        assert summary["pending"] == 1
+        assert summary["done"] == 1
+        assert summary["blocked"] == 1
+        assert summary["working"] == 0
+        assert summary["failed"] == 0
+        assert summary["cancelled"] == 0
+        assert summary["total"] == 3
+
+    def test_age_in_state_seconds_is_positive_int(self, tmp_path):
+        t = _make_store(tmp_path)
+        root = t.create(
+            creator="operator", assignee="scout", title="root",
+        )
+        # Wait so age > 0.
+        time.sleep(1.1)
+        snap = t.workflow_snapshot(root["id"])
+        assert snap is not None
+        ages = [s["age_in_state_seconds"] for s in snap["stages"]]
+        assert all(isinstance(a, int) for a in ages)
+        assert all(a >= 1 for a in ages), ages

--- a/tests/test_orchestration_endpoints.py
+++ b/tests/test_orchestration_endpoints.py
@@ -550,3 +550,85 @@ async def test_public_caller_with_valid_bearer_succeeds(v2_app_with_auth):
             },
         )
         assert r.status_code == 200, r.text
+
+
+# ── GET /mesh/tasks/workflow/{root_task_id} (operator workflow awareness) ──
+
+
+@pytest.mark.asyncio
+async def test_workflow_snapshot_endpoint_operator_only(v2_app):
+    """Non-operator callers get 403; the snapshot is operator-tier
+    workflow awareness, not worker-readable."""
+    app, _, _ = v2_app
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://t",
+    ) as c:
+        # Scout creates a kickoff task so the root exists.
+        r = await c.post(
+            "/mesh/tasks",
+            json={"assignee": "analyst", "title": "kickoff"},
+            headers={"X-Agent-ID": "scout"},
+        )
+        assert r.status_code == 200, r.text
+        tid = r.json()["id"]
+
+        # Worker tries to read — 403.
+        r = await c.get(
+            f"/mesh/tasks/workflow/{tid}",
+            headers={"X-Agent-ID": "analyst"},
+        )
+        assert r.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_workflow_snapshot_endpoint_returns_snapshot_for_operator(v2_app):
+    """Operator sees the chain rooted at the kickoff task."""
+    app, _, _ = v2_app
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://t",
+    ) as c:
+        # Scout creates kickoff task.
+        r = await c.post(
+            "/mesh/tasks",
+            json={"assignee": "analyst", "title": "kickoff"},
+            headers={"X-Agent-ID": "scout"},
+        )
+        root_id = r.json()["id"]
+        # Scout creates a child of the kickoff.
+        r = await c.post(
+            "/mesh/tasks",
+            json={
+                "assignee": "analyst",
+                "title": "next stage",
+                "parent_task_id": root_id,
+            },
+            headers={"X-Agent-ID": "scout"},
+        )
+        assert r.status_code == 200, r.text
+
+        # Operator reads the snapshot.
+        r = await c.get(
+            f"/mesh/tasks/workflow/{root_id}",
+            headers={"X-Agent-ID": "operator"},
+        )
+        assert r.status_code == 200, r.text
+        body = r.json()
+        assert body["root"] == root_id
+        ids = [s["task_id"] for s in body["stages"]]
+        assert root_id in ids
+        assert body["summary"]["total"] == 2
+
+
+@pytest.mark.asyncio
+async def test_workflow_snapshot_endpoint_returns_404_for_missing_root(v2_app):
+    """Unknown root id returns 404 so the operator can distinguish a
+    typo from an empty chain."""
+    app, _, _ = v2_app
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://t",
+    ) as c:
+        r = await c.get(
+            "/mesh/tasks/workflow/task_does_not_exist",
+            headers={"X-Agent-ID": "operator"},
+        )
+        assert r.status_code == 404

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -1302,3 +1302,29 @@ class TestHeartbeatVersionedRefresh:
         )
         # Untouched.
         assert "user-written rules" in path.read_text()
+
+    def test_sentinel_constant_imported_from_shared_types(self):
+        """``HEARTBEAT_SENTINELS`` lives in ``src.shared.types`` so the
+        workspace and the operator-config heartbeat refresh stay in
+        sync. Verify the symbol resolves and includes the current
+        marker — a regression here would mean the constant was
+        re-defined locally and would silently drift."""
+        from src.shared.types import HEARTBEAT_SENTINELS
+        assert isinstance(HEARTBEAT_SENTINELS, tuple)
+        assert "heartbeat_v2_workflow_aware" in HEARTBEAT_SENTINELS
+        # The workspace module must consume the central constant, not
+        # define its own. Confirmed by exercising the refresh path on
+        # the canonical marker.
+        path = Path(self._tmpdir) / "HEARTBEAT.md"
+        path.write_text("# Heartbeat Rules\n\nLEGACY revision\n")
+        marker = f"<!-- {HEARTBEAT_SENTINELS[0]} -->"
+        WorkspaceManager(
+            workspace_dir=self._tmpdir,
+            initial_heartbeat=(
+                f"{marker}\nWorkflow-aware autonomous steps:\n"
+                "1. check_inbox\n"
+            ),
+        )
+        content = path.read_text()
+        assert "LEGACY" not in content
+        assert marker in content

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -1221,3 +1221,84 @@ class TestDeriveCapabilitiesFromInterface:
         (Path(self._tmpdir) / "INTERFACE.md").mkdir()
         result = _derive_capabilities_from_interface(self._tmpdir)
         assert result["capabilities"] == []
+
+
+# ── Idempotent HEARTBEAT.md refresh via versioned sentinel ─────────
+
+
+class TestHeartbeatVersionedRefresh:
+    """When the template carries the ``heartbeat_v2_workflow_aware``
+    sentinel and the live HEARTBEAT.md lacks it, the workspace
+    overwrites on next construction. Preserves user-customised
+    heartbeats (which won't have the marker) and pushes the next
+    system-managed revision forward."""
+
+    SENTINEL = "<!-- heartbeat_v2_workflow_aware -->"
+
+    def setup_method(self):
+        self._tmpdir = tempfile.mkdtemp()
+
+    def teardown_method(self):
+        shutil.rmtree(self._tmpdir, ignore_errors=True)
+
+    def _new_initial_heartbeat(self) -> str:
+        return (
+            f"{self.SENTINEL}\nWorkflow-aware autonomous steps:\n"
+            "1. check_inbox\n2. workflow_snapshot\n"
+        )
+
+    def test_initial_heartbeat_with_sentinel_creates_file(self):
+        """File doesn't exist + initial_heartbeat with sentinel → writes."""
+        WorkspaceManager(
+            workspace_dir=self._tmpdir,
+            initial_heartbeat=self._new_initial_heartbeat(),
+        )
+        path = Path(self._tmpdir) / "HEARTBEAT.md"
+        assert path.exists()
+        content = path.read_text()
+        assert self.SENTINEL in content
+        assert "check_inbox" in content
+
+    def test_existing_file_with_sentinel_not_overwritten(self):
+        """File exists with sentinel → no overwrite (idempotent re-init)."""
+        path = Path(self._tmpdir) / "HEARTBEAT.md"
+        path.write_text(
+            f"# Heartbeat Rules\n\n{self.SENTINEL}\n"
+            "user-edited workflow rules\n",
+        )
+        before = path.read_text()
+        WorkspaceManager(
+            workspace_dir=self._tmpdir,
+            initial_heartbeat=self._new_initial_heartbeat(),
+        )
+        assert path.read_text() == before, "Sentinel-present file must not change"
+
+    def test_existing_file_without_sentinel_is_overwritten(self):
+        """File exists WITHOUT sentinel + initial_heartbeat WITH sentinel
+        → overwrite from template (system-managed version bump)."""
+        path = Path(self._tmpdir) / "HEARTBEAT.md"
+        path.write_text(
+            "# Heartbeat Rules\n\nLEGACY rules from a prior revision\n",
+        )
+        WorkspaceManager(
+            workspace_dir=self._tmpdir,
+            initial_heartbeat=self._new_initial_heartbeat(),
+        )
+        content = path.read_text()
+        assert "LEGACY" not in content
+        assert self.SENTINEL in content
+        assert "check_inbox" in content
+
+    def test_existing_file_without_sentinel_template_without_sentinel_no_change(
+        self,
+    ):
+        """No sentinel on either side → leave the file alone. Pins the
+        "user-customised heartbeat" preservation case."""
+        path = Path(self._tmpdir) / "HEARTBEAT.md"
+        path.write_text("# Heartbeat Rules\n\nuser-written rules\n")
+        WorkspaceManager(
+            workspace_dir=self._tmpdir,
+            initial_heartbeat="No marker in this template either\n",
+        )
+        # Untouched.
+        assert "user-written rules" in path.read_text()


### PR DESCRIPTION
## Summary

Closes three connected gaps the user hit running a multi-stage SEO pipeline (trend-scout → seo-strategist → page-writer → page-validator → dev-publisher):

1. **Silent handoff drop** — `hand_off` returned `{handed_off: true}` but the row never landed in the recipient's inbox.
2. **Stuck-working tasks** — sat indefinitely until the operator manually noticed.
3. **Operator blind between heartbeats** — no event-driven signal when a stage failed/blocked/got stuck.

## What changed (3 layers, ~250 LoC + 24 tests)

**A — Defensive (Bug 1 catch)**
- `Tasks.create` raises `RuntimeError` if the post-INSERT SELECT returns `None`, instead of returning null JSON that the agent then dereferences.

**B — Stuck-working watchdog: extend the existing lane timeout**
- `LaneManager.set_back_edge_fn` + `set_agent_timeout` setters; lane-timeout path now fires the mesh's back-edge writer (`event_kind=task_failed`) so the originating agent's inbox sees the timeout AND the wake-on-event chain fires.
- `InvalidStatusTransition` race guard (assignee terminated between SELECT and UPDATE) — logged, back-edge skipped, lane worker survives.

**C — Operator workflow awareness**
- `current_task_id` ContextVar (set in `execute_task` + `chat`) so `hand_off` propagates `parent_task_id` for chain walking.
- Extracted `_write_task_event_back_edge` helper from inline code in `/mesh/tasks/{task_id}/status`. Endpoint + lane timeout both call it.
- Wake-on-event chain for actionable kinds (`task_failed`, `task_blocked`) with 60s per-task rate-limit. Successes and cancels don't wake.
- `Tasks.workflow_snapshot(root_task_id)` with `WITH RECURSIVE`, returns per-stage state + chain summary.
- `GET /mesh/tasks/workflow/{root_task_id}` (operator-only) + `mesh_client.get_workflow_snapshot` + `workflow_snapshot` operator skill.
- `await_task_event(task_id, timeout_s=240, poll_interval_s=3)` operator skill, capped at 270s below the 300s tool execution ceiling.

**Heartbeat plumbing**
- `_HEARTBEAT_TOOLS` expanded with `check_inbox`, `workflow_snapshot`, `await_task_event` so operator can actually use them during heartbeat (codex flagged this — the heartbeat allowlist would have silently dropped the new tools).
- `_OPERATOR_HEARTBEAT` prompt rewritten: `check_inbox` first, explicit workflow_snapshot step, `notify_user` on failed/blocked events.
- Versioned sentinel `<!-- heartbeat_v2_workflow_aware -->` + idempotent migration in `_ensure_operator_agent` (agents.yaml) and `WorkspaceManager._ensure_scaffold` (HEARTBEAT.md) mirrors the existing `playbook_v2` INSTRUCTIONS migration pattern — operators upgrade in place on next startup.

## Review process

Self-review pass + Codex r1 review of the plan caught:
- `_raise_with_body` already exists in mesh_client — A2 became no-op on current main (already rolled out).
- `task.updated_at` is wrong liveness signal (only ticks on store mutations, not during LLM work) — used existing lane timeout instead of a separate sweeper.
- `tool_execution_ceiling=300s` — `await_task_event` capped at 270s.
- `_HEARTBEAT_TOOLS` allowlist — surfaced two-list issue (loop-level + cli config).
- `WITH RECURSIVE` belongs in the store, not the operator skill — kept the operator skill calling the mesh endpoint.

## Test plan

- [x] 24 new tests across `test_orchestration`, `test_lanes`, `test_coordination`, `test_operator_tools`, `test_workspace`, `test_back_edge_helper`, `test_orchestration_endpoints`.
- [x] Full fast suite: 6332 passed / 49 skipped / 0 failed.
- [x] `ruff check src/ tests/` — All checks passed.