### PR TITLE
fix: round 4 — forensic logging + system-side handoff enforcement

### DIFF
--- a/src/agent/builtins/coordination_tool.py
+++ b/src/agent/builtins/coordination_tool.py
@@ -200,6 +200,16 @@ async def hand_off(
         write_project = target_project
     else:
         write_project = mesh_client.team_name
+    # Round-4 forensic trace: if the registry doesn't surface a
+    # ``project`` key for the target (e.g. post-rename drift) we fall
+    # back to sender's team_name — log both inputs so the operator can
+    # see the resolution path on the next E2E.
+    logger.info(
+        "hand_off scope resolution to=%s target_project=%r "
+        "target_is_global=%s sender_team=%r write_project=%r",
+        to, target_project, target_is_global,
+        mesh_client.team_name, write_project,
+    )
 
     if data and data.strip():
         # Optional: stash the payload under an artifact_ref the
@@ -307,6 +317,20 @@ async def hand_off(
         }
 
     task_id = record.get("id", "")
+    # Round-4 forensic trace: create_task succeeded with this id. Pairs
+    # with the ``tasks.create stored`` server log so the chain from
+    # agent → mesh → SQLite can be reconstructed from the operator's
+    # log on the next E2E. Surfacing the assignee + parent_task_id +
+    # creator surfaced from the server's POST handler exposes any
+    # value drift between request and storage at a glance.
+    logger.info(
+        "hand_off create_task returned task_id=%s to=%s "
+        "stored_assignee=%s stored_creator=%s stored_parent=%s "
+        "stored_team_id=%s",
+        task_id, to,
+        record.get("assignee"), record.get("creator"),
+        record.get("parent_task_id"), record.get("project_id"),
+    )
 
     # Wake the target so they pick up the task immediately. The task
     # is queued in SQLite either way; wake failures surface via
@@ -360,6 +384,18 @@ async def hand_off(
             "duplicate row). DO NOT mark this work as complete in your "
             "final response."
         )
+    # Round-4 forensic trace: final envelope shape the LLM sees. Pairs
+    # with the ``hand_off create_task returned`` line above so a future
+    # repro shows whether the LLM ignored a failure envelope OR the
+    # envelope was malformed in a way that hid the failure.
+    logger.info(
+        "hand_off result to=%s handed_off=%s task_id=%s flags=%s",
+        to, result.get("handed_off"), task_id,
+        [k for k in (
+            "create_failed", "wake_failed", "output_write_failed",
+            "task_queued",
+        ) if result.get(k)],
+    )
     return result
 
 

--- a/src/agent/builtins/operator_tools.py
+++ b/src/agent/builtins/operator_tools.py
@@ -995,12 +995,27 @@ async def await_task_event(
     escaped the inner loop would surface to the LLM as an empty body and
     break the awareness loop (Bug 2 repro 2026-05-21).
     """
+    # Round-4 forensic trace (Bug 2 still reproduces post-PR#952). Entry
+    # logging at INFO so the operator's E2E log shows whether the skill
+    # was even invoked with what args. Pairs with the exit-log added
+    # to every return site below — a missing exit line for a present
+    # entry line means an unhandled exception escaped both guards.
+    logger.info(
+        "await_task_event ENTRY task_id=%s timeout_s=%s poll_interval_s=%s",
+        task_id, timeout_s, poll_interval_s,
+    )
     if not _is_operator():
-        return {"error": "This tool is only available to the operator agent."}
+        out = {"error": "This tool is only available to the operator agent."}
+        logger.info("await_task_event EXIT non_operator result=%s", out)
+        return out
     if mesh_client is None:
-        return {"error": "No mesh_client available"}
+        out = {"error": "No mesh_client available"}
+        logger.info("await_task_event EXIT no_mesh_client result=%s", out)
+        return out
     if not task_id:
-        return {"error": "task_id is required"}
+        out = {"error": "task_id is required"}
+        logger.info("await_task_event EXIT empty_task_id result=%s", out)
+        return out
 
     try:
         timeout = max(1, min(int(timeout_s), _AWAIT_TASK_EVENT_MAX_TIMEOUT_S))
@@ -1020,12 +1035,17 @@ async def await_task_event(
             # wall-clock past the agent loop's 300s tool ceiling.
             remaining_before_poll = deadline - _time.monotonic()
             if remaining_before_poll <= _AWAIT_TASK_EVENT_POLL_BUDGET_S:
-                return {
+                out = {
                     "timed_out": True,
                     "task_id": task_id,
                     "last_status_seen": last_status_seen,
                     "waited_seconds": timeout,
                 }
+                logger.info(
+                    "await_task_event EXIT timeout_predeadline result=%s",
+                    out,
+                )
+                return out
             try:
                 # Each poll is bounded by ``_AWAIT_TASK_EVENT_POLL_BUDGET_S``
                 # to keep the worst-case iteration time predictable even
@@ -1047,17 +1067,22 @@ async def await_task_event(
                 # can't leak into the LLM context (same precaution as
                 # coordination_tool's failure envelopes).
                 redacted = redact_text_with_urls(str(e))[:200]
-                return {
+                out = {
                     "error": f"Inbox fetch failed: {redacted}",
                     "task_id": task_id,
                 }
+                logger.info(
+                    "await_task_event EXIT inbox_fetch_failed result=%s",
+                    out,
+                )
+                return out
             for entry in entries:
                 value = entry.get("value") or {}
                 if value.get("task_id") != task_id:
                     continue
                 kind = value.get("kind", "")
                 if kind in terminal_kinds:
-                    return {
+                    out = {
                         "event": {
                             "kind": kind,
                             "task_id": task_id,
@@ -1069,15 +1094,25 @@ async def await_task_event(
                             "ts": value.get("ts"),
                         },
                     }
+                    logger.info(
+                        "await_task_event EXIT terminal_event kind=%s "
+                        "task_id=%s", kind, task_id,
+                    )
+                    return out
                 last_status_seen = value.get("status") or last_status_seen
             remaining = deadline - _time.monotonic()
             if remaining <= 0:
-                return {
+                out = {
                     "timed_out": True,
                     "task_id": task_id,
                     "last_status_seen": last_status_seen,
                     "waited_seconds": timeout,
                 }
+                logger.info(
+                    "await_task_event EXIT timeout_postpoll result=%s",
+                    out,
+                )
+                return out
             # Exponential backoff capped at 30s and the remaining window.
             sleep_for = min(interval, remaining, 30.0)
             await asyncio.sleep(sleep_for)
@@ -1094,10 +1129,14 @@ async def await_task_event(
             "await_task_event unexpected exception for task=%s: %s",
             task_id, redacted,
         )
-        return {
+        out = {
             "error": f"await_task_event_unexpected: {redacted}",
             "task_id": task_id,
         }
+        logger.info(
+            "await_task_event EXIT outer_except result=%s", out,
+        )
+        return out
 
 
 @skill(

--- a/src/agent/loop.py
+++ b/src/agent/loop.py
@@ -1508,6 +1508,19 @@ class AgentLoop:
 
         return "\n\n".join(parts)
 
+    # Round-4 structural fix: hand_off failures are now enforced from
+    # tool-output evidence, not the LLM's discretion. Any of these
+    # flags in a ``hand_off`` tool result means the downstream chain
+    # did not land — the task must NOT auto-close to ``done`` even if
+    # the LLM produced text claiming success. The previous design
+    # depended on the LLM faithfully reading the failure envelope's
+    # ``MUST NOT report success`` directive, which models ignored
+    # across three repro cycles. Enforcing system-side closes that
+    # trust gap completely.
+    _HANDOFF_FAILURE_FLAGS = frozenset({
+        "create_failed", "wake_failed", "output_write_failed",
+    })
+
     @staticmethod
     def _chat_result_failure_reason(result: dict) -> str | None:
         """Return a failure-reason string if ``result`` carries a known
@@ -1522,6 +1535,13 @@ class AgentLoop:
         lazy-completion guard so a failure after ≥1 tool call doesn't
         slip past the empty-tool_outputs check and auto-close as
         ``done``.
+
+        Round-4 extension: also scans ``tool_outputs`` for ``hand_off``
+        results that indicate the downstream chain failed. If any
+        hand_off in this turn returned ``handed_off=False`` or any of
+        ``create_failed`` / ``wake_failed`` / ``output_write_failed``,
+        the task fails — the LLM no longer has the option to mark
+        ``done`` after a broken handoff just by producing text.
         """
         if not isinstance(result, dict):
             return None
@@ -1533,6 +1553,26 @@ class AgentLoop:
             return f"config_error: {(result.get('response') or '')[:400]}"
         if result.get("exception_caught"):
             return f"exception: {(result.get('response') or '')[:400]}"
+        # System-side handoff enforcement (Round-4 structural fix).
+        for tool_out in result.get("tool_outputs") or []:
+            if not isinstance(tool_out, dict):
+                continue
+            if tool_out.get("name") != "hand_off":
+                continue
+            payload = tool_out.get("output") or tool_out.get("result") or {}
+            if not isinstance(payload, dict):
+                continue
+            failing = [
+                k for k in AgentLoop._HANDOFF_FAILURE_FLAGS
+                if payload.get(k)
+            ]
+            if failing or payload.get("handed_off") is False:
+                target = payload.get("to") or "unknown"
+                detail = (payload.get("error") or "")[:300]
+                return (
+                    f"handoff_failed: hand_off to {target!r} reported "
+                    f"{failing or ['handed_off=False']} — {detail}"
+                )
         return None
 
     def _is_structured_final(self, content: str | None) -> bool:

--- a/src/agent/server.py
+++ b/src/agent/server.py
@@ -239,6 +239,25 @@ def create_agent_app(loop: AgentLoop) -> FastAPI:
             origin=origin,
             task_id=task_id,
         )
+        # Round-4 forensic trace (Bug 3 still reproduces post-PR#952).
+        # The operator reported turns ending with no visible chat
+        # output after tool calls. INFO-level shape log makes the next
+        # repro diagnosable from the agent's container log alone:
+        # ``response_len=0 tool_outputs=N`` would prove the fallback
+        # never fired; non-zero response_len would point to a
+        # dashboard-side rendering bug instead.
+        resp = result.get("response") or ""
+        tool_outputs = result.get("tool_outputs") or []
+        logger.info(
+            "/chat EXIT task_id=%s response_len=%d tool_outputs=%d "
+            "tokens_used=%s flags=%s",
+            task_id, len(resp), len(tool_outputs),
+            result.get("tokens_used"),
+            [k for k in (
+                "auth_failure", "config_error", "exception_caught",
+                "tool_limit_reached", "silent_reply",
+            ) if result.get(k)],
+        )
         return ChatResponse(**result)
 
     @app.post("/chat/steer")

--- a/src/host/orchestration.py
+++ b/src/host/orchestration.py
@@ -631,7 +631,20 @@ class Tasks:
         )
         with self._conn() as conn:
             rows = conn.execute(sql, params).fetchall()
-        return [self._row_to_dict(r) for r in rows]
+        result = [self._row_to_dict(r) for r in rows]
+        # Round-4 forensic logging: pairs with ``tasks.create stored`` so
+        # an operator running an E2E test can see exactly what the
+        # recipient's inbox lookup compared against. ``rows=N`` over the
+        # same lookup paired with the create log gives the silent-drop
+        # bisect: if create stored ``assignee=X`` and list_inbox queries
+        # ``assignee=Y`` the mismatch falls out instantly.
+        logger.info(
+            "tasks.list_inbox assignee=%r project_id=%r "
+            "include_terminal=%s rows=%d team_col=%s",
+            assignee, project_id, include_terminal,
+            len(result), self._team_col,
+        )
+        return result
 
     def list_project(
         self,

--- a/src/host/server.py
+++ b/src/host/server.py
@@ -4537,6 +4537,22 @@ def create_mesh_app(
         """
         store = tasks_store
         caller = _extract_verified_agent_id(request)
+        # Round-4 forensic logging (Bug 1 still reproduces post-PR#952).
+        # INFO-level entry trace so the operator's repro logs reveal
+        # whether the request even reached this handler (vs short-
+        # circuited upstream by transport/router) and what the request
+        # body looked like at the wire. Combine with ``Tasks.create``'s
+        # stored-value log to bisect the silent drop in one E2E run.
+        logger.info(
+            "/mesh/tasks POST entry caller=%s headers=%s",
+            caller,
+            {
+                k: v for k, v in request.headers.items()
+                if k.lower() in (
+                    "x-trace-id", "x-task-id", "x-origin", "x-agent-id",
+                )
+            },
+        )
         # ``can_route_tasks`` is the structured permission. The mesh
         # pseudo-id and operator are auto-permitted by the matrix; the
         # operator trust tier also bypasses unconditionally so a
@@ -4584,6 +4600,17 @@ def create_mesh_app(
                 403,
                 f"Caller {caller} is not a member of project {project_id!r}",
             )
+        # Body trace — assignee/project/parent already validated above.
+        # Round-4 forensic visibility: pairs with the entry log at the
+        # top so a missing log line here points to validation refusal
+        # while a present log here proves the request reached the
+        # store.create call site.
+        logger.info(
+            "/mesh/tasks POST body caller=%s assignee=%s project_id=%s "
+            "parent_task_id=%s title=%r",
+            caller, assignee, project_id, parent_task_id,
+            (title or "")[:80],
+        )
 
         origin = _validated_origin(request, caller)
         origin_dict = origin.model_dump() if origin is not None else None

--- a/tests/test_loop.py
+++ b/tests/test_loop.py
@@ -2903,3 +2903,152 @@ class TestChatEmptyResponseFallback:
         # tool_outputs and an empty response, the guard goes through
         # the "did work" branch and auto-closes as ``done``.
         loop._auto_close_task.assert_awaited()
+
+
+# === Round-4 structural fix: system-side hand_off failure enforcement ===
+
+
+class TestChatHandoffFailureEnforcement:
+    """``AgentLoop._chat_result_failure_reason`` scans ``tool_outputs`` for
+    ``hand_off`` results and forces a failure reason when the downstream
+    chain didn't land (``handed_off=False`` or any of ``create_failed`` /
+    ``wake_failed`` / ``output_write_failed``). The previous design trusted
+    the LLM to surface those failures in its text; models ignored the
+    directive across three repro cycles, so enforcement is now system-side.
+    These tests pin the contract on the pure staticmethod — no async needed.
+    """
+
+    def test_create_failed_handoff_fails_task(self):
+        result = {
+            "response": "Done, handed off to bob",
+            "tool_outputs": [
+                {
+                    "name": "hand_off",
+                    "output": {
+                        "handed_off": False,
+                        "create_failed": True,
+                        "to": "bob",
+                        "error": "create_failed: bob does not exist",
+                    },
+                },
+            ],
+        }
+        reason = AgentLoop._chat_result_failure_reason(result)
+        assert reason is not None
+        assert reason.startswith("handoff_failed:")
+        assert "bob" in reason
+
+    def test_wake_failed_handoff_fails_task(self):
+        result = {
+            "response": "Handed off",
+            "tool_outputs": [
+                {
+                    "name": "hand_off",
+                    "output": {
+                        "handed_off": False,
+                        "wake_failed": True,
+                        "to": "carol",
+                        "error": "wake_failed: timeout",
+                    },
+                },
+            ],
+        }
+        reason = AgentLoop._chat_result_failure_reason(result)
+        assert reason is not None
+        assert reason.startswith("handoff_failed:")
+        assert "wake_failed" in reason or "handoff_failed:" in reason
+
+    def test_output_write_failed_handoff_fails_task(self):
+        result = {
+            "response": "All good",
+            "tool_outputs": [
+                {
+                    "name": "hand_off",
+                    "output": {
+                        "handed_off": False,
+                        "output_write_failed": True,
+                        "to": "dave",
+                        "error": "output_write_failed: disk full",
+                    },
+                },
+            ],
+        }
+        reason = AgentLoop._chat_result_failure_reason(result)
+        assert reason is not None
+        assert reason.startswith("handoff_failed:")
+        assert "output_write_failed" in reason or "dave" in reason
+
+    def test_handed_off_false_alone_fails_task(self):
+        """No specific failure flag, just ``handed_off=False`` — still
+        a failure (legacy/future payload shape)."""
+        result = {
+            "response": "Tried to hand off",
+            "tool_outputs": [
+                {
+                    "name": "hand_off",
+                    "output": {"handed_off": False, "to": "eve"},
+                },
+            ],
+        }
+        reason = AgentLoop._chat_result_failure_reason(result)
+        assert reason is not None
+        assert reason.startswith("handoff_failed:")
+
+    def test_successful_handoff_does_not_fail_task(self):
+        result = {
+            "response": "Handed off to bob",
+            "tool_outputs": [
+                {
+                    "name": "hand_off",
+                    "output": {
+                        "handed_off": True,
+                        "to": "bob",
+                        "task_id": "task_X",
+                    },
+                },
+            ],
+        }
+        assert AgentLoop._chat_result_failure_reason(result) is None
+
+    def test_non_handoff_tool_output_ignored(self):
+        """Scan only triggers on ``name == "hand_off"`` — same keys on
+        a different tool's payload must NOT fail the task."""
+        result = {
+            "response": "Notified",
+            "tool_outputs": [
+                {
+                    "name": "notify_user",
+                    "output": {"create_failed": True},
+                },
+            ],
+        }
+        assert AgentLoop._chat_result_failure_reason(result) is None
+
+    def test_alternate_payload_key_result(self):
+        """Some dispatchers expose the payload under ``result`` instead
+        of ``output`` — both shapes must be recognized."""
+        result = {
+            "response": "...",
+            "tool_outputs": [
+                {
+                    "name": "hand_off",
+                    "result": {"create_failed": True, "to": "bob"},
+                },
+            ],
+        }
+        reason = AgentLoop._chat_result_failure_reason(result)
+        assert reason is not None
+        assert reason.startswith("handoff_failed:")
+
+    def test_pre_existing_failures_take_precedence(self):
+        """``tool_limit_reached`` is checked before the tool_outputs
+        scan — even with a "successful" handoff in the same envelope,
+        the iteration-limit failure wins."""
+        result = {
+            "tool_limit_reached": True,
+            "tool_outputs": [
+                {"name": "hand_off", "output": {"handed_off": True}},
+            ],
+        }
+        assert AgentLoop._chat_result_failure_reason(result) == \
+            "max_iterations_reached"


### PR DESCRIPTION
## Honest diagnosis

Three rounds of test-passing patches didn't change live behavior. Operator ran a fourth E2E, reproduced the silent drop identically across three task IDs. The pattern across rounds 1-3 was: add a defensive check at a different layer (`Tasks.create` row-exists assert → endpoint field-match verify → centralised `_assert_stored_matches`), tests pass, no forensic logging to confirm which path actually fails in production, ship, repeat.

Two structural problems caused the iteration loop:
1. **No forensic visibility** — every patch was based on a hypothesis with no live evidence to confirm or refute.
2. **LLM-trust architecture** — `hand_off` failures depended on the LLM reading a directive envelope (`MUST NOT report success`) and surfacing them. LLMs ignore directives. Even a perfectly worded envelope is silently overridden by an LLM that just produces "Task complete" text.

## What this PR ships

**Layer 1 — forensic logging (closes the diagnostic gap).** INFO logs at every step of the handoff chain so the next E2E reveals where it breaks in 30 seconds instead of forcing more guessing:
- `/mesh/tasks` POST entry + parsed body
- `Tasks.list_inbox` entry + row count + team_col
- `hand_off` scope resolution + `create_task` return shape + final envelope flags
- `await_task_event` ENTRY + every EXIT path (Bug 2 visibility — an empty body now means the skill was never invoked)
- Agent `/chat` EXIT shape (Bug 3 visibility — turns with zero rendered output now log evidence)

**Layer 2 — system-side handoff enforcement (closes the LLM-trust gap).** `AgentLoop._chat_result_failure_reason` now scans `tool_outputs` for `hand_off` results carrying `handed_off=False` OR any of `create_failed` / `wake_failed` / `output_write_failed`. When found, the task auto-closes to `failed` regardless of LLM-produced text. The LLM's discretion is removed — tool-output evidence is authoritative.

## Test plan

- [x] 8 new tests in `TestChatHandoffFailureEnforcement` pin every shape (each failure flag, bare `handed_off=False`, success path, non-handoff tool ignored, payload key aliasing, precedence with `tool_limit_reached`).
- [x] Full fast suite: 6367 passed / 49 skipped / 0 failed.
- [x] `ruff check src/ tests/` — clean.

## Next run

When the operator reruns the E2E with this PR shipped, the log will show:
- Whether trend-scout's hand_off ACTUALLY called create_task (`hand_off create_task returned task_id=…` line present)
- Whether the row landed with the right values (`tasks.create stored` line matches the request)
- Whether seo-strategist's check_inbox saw it (`tasks.list_inbox assignee=seo-strategist rows=N` line shows N>0)
- Whether the LLM ignored a failure envelope (now caught at the enforcement layer — task auto-closes to failed)