### PR TITLE
fix: retire can_route_tasks gate — pipelines work out of the box

### DIFF
--- a/src/agent/loop.py
+++ b/src/agent/loop.py
@@ -1553,11 +1553,16 @@ class AgentLoop:
             return f"config_error: {(result.get('response') or '')[:400]}"
         if result.get("exception_caught"):
             return f"exception: {(result.get('response') or '')[:400]}"
-        # System-side handoff enforcement (Round-4 structural fix).
+        # System-side handoff enforcement (Round-5 key-name fix).
+        # The ``tool_outputs`` schema is ``{"tool": tool_name, "input":
+        # ..., "output": ...}`` per ``_chat_inner``. PR #953 mistakenly
+        # scanned ``tool_out["name"]`` which never matches any real
+        # output — enforcement was dead code in production. Tests
+        # passed because they were written against the wrong key too.
         for tool_out in result.get("tool_outputs") or []:
             if not isinstance(tool_out, dict):
                 continue
-            if tool_out.get("name") != "hand_off":
+            if tool_out.get("tool") != "hand_off":
                 continue
             payload = tool_out.get("output") or tool_out.get("result") or {}
             if not isinstance(payload, dict):

--- a/src/cli/config.py
+++ b/src/cli/config.py
@@ -528,7 +528,7 @@ def _add_agent_permissions(name: str, permissions: dict | None = None) -> None:
         for key in (
             "can_use_browser", "can_spawn", "can_manage_cron",
             "can_manage_fleet", "can_manage_teams", "can_edit_agent_config",
-            "can_view_fleet_metrics", "can_route_tasks",
+            "can_view_fleet_metrics",
             "can_request_user_credentials",
         ):
             if key in permissions:
@@ -1837,9 +1837,12 @@ def _ensure_operator_agent(config_path: Path | None = None, default_model: str =
         if not op_perms.get("can_view_fleet_metrics", False):
             op_perms["can_view_fleet_metrics"] = True
             needs_update = True
-        if not op_perms.get("can_route_tasks", False):
-            op_perms["can_route_tasks"] = True
-            needs_update = True
+        # ``can_route_tasks`` retired in favour of unified ``can_message``
+        # gate on /mesh/tasks (worker→worker handoffs need exactly one
+        # permission, not two). The field stays on AgentPermissions for
+        # back-compat with existing permissions.json files but is no
+        # longer read; we stop grant-on-backfill so new operators don't
+        # accumulate dead configuration.
         if not op_perms.get("can_request_user_credentials", False):
             op_perms["can_request_user_credentials"] = True
             needs_update = True
@@ -1899,7 +1902,6 @@ def _ensure_operator_agent(config_path: Path | None = None, default_model: str =
             "can_manage_teams": True,
             "can_edit_agent_config": True,
             "can_view_fleet_metrics": True,
-            "can_route_tasks": True,
             "can_request_user_credentials": True,
         },
     )

--- a/src/host/server.py
+++ b/src/host/server.py
@@ -4530,10 +4530,15 @@ def create_mesh_app(
     async def create_task(request: Request) -> dict:
         """Create a durable task record.
 
-        Caller must have ``can_route_tasks`` (or be the operator /
-        loopback internal). Body: ``{assignee, title, description?,
-        project?, parent_task_id?, priority?, dependencies?}``.
-        Origin is sourced from the validated ``X-Origin`` header.
+        Caller must be authorised to message the assignee
+        (``can_message(caller, assignee)``); operator and mesh-internal
+        bypass. Body: ``{assignee, title, description?, project?,
+        parent_task_id?, priority?, dependencies?}``. Origin is sourced
+        from the validated ``X-Origin`` header. The legacy
+        ``can_route_tasks`` toggle was retired — task creation is
+        structured messaging and shares the ``can_message`` trust
+        boundary, which is set to ``["*"]`` by default under collab mode
+        so multi-stage workflows work out of the box.
         """
         store = tasks_store
         caller = _extract_verified_agent_id(request)

--- a/src/host/server.py
+++ b/src/host/server.py
@@ -4553,20 +4553,6 @@ def create_mesh_app(
                 )
             },
         )
-        # ``can_route_tasks`` is the structured permission. The mesh
-        # pseudo-id and operator are auto-permitted by the matrix; the
-        # operator trust tier also bypasses unconditionally so a
-        # misconfigured grant cannot silently break task routing.
-        if not _caller_is_operator(caller, request):
-            if not permissions.can_route_tasks(caller):
-                _record_denial(
-                    "permission", caller=caller,
-                    gate="tasks.create:can_route_tasks",
-                )
-                raise HTTPException(
-                    403,
-                    f"Agent {caller} cannot route tasks (can_route_tasks not granted)",
-                )
         body = await request.json()
         # ``.strip()`` on assignee defends against a trailing newline or
         # leading space sneaking through a hand-written prompt. SQLite
@@ -4592,6 +4578,23 @@ def create_mesh_app(
             raise HTTPException(400, "title is required")
         if not assignee or not _AGENT_ID_RE.match(assignee):
             raise HTTPException(400, f"Invalid assignee: {assignee!r}")
+        # Task creation is structured messaging — same trust boundary as
+        # ``can_message(caller, assignee)``. Using one gate (instead of
+        # the legacy double-gate with the now-defunct ``can_route_tasks``
+        # toggle) means every fleet template's collab-mode default
+        # (``can_message=["*"]``) automatically enables worker→worker
+        # handoffs out of the box. Operator + mesh-internal bypass.
+        if not _caller_is_operator(caller, request) and not _is_internal_caller(request):
+            if not permissions.can_message(caller, assignee):
+                _record_denial(
+                    "permission", caller=caller, target=assignee,
+                    gate="tasks.create:can_message",
+                )
+                raise HTTPException(
+                    403,
+                    f"Agent {caller} cannot create task for {assignee!r} "
+                    "(can_message not granted)",
+                )
         # Cross-project scope: callers can only create tasks in projects
         # they belong to (operators / mesh are global). Standalone is
         # permitted (project_id=None).
@@ -4936,7 +4939,7 @@ def create_mesh_app(
 
     @app.post("/mesh/tasks/{task_id}/reroute")
     async def reroute_task(task_id: str, request: Request) -> dict:
-        """Reassign a task. Operator-only or callers with ``can_route_tasks``.
+        """Reassign a task. Operator-only (administrative recovery action).
 
         Cost-aware: refuses to reroute onto an agent that is already
         over its daily or monthly budget (HTTP 400, structured error).
@@ -4946,11 +4949,10 @@ def create_mesh_app(
         if not (
             _caller_is_operator(caller, request)
             or _is_internal_caller(request)
-            or permissions.can_route_tasks(caller)
         ):
             raise HTTPException(
                 403,
-                "Reroute requires can_route_tasks (operator-grade permission)",
+                "Reroute is operator-only (administrative recovery action)",
             )
         body = await request.json()
         new_assignee = body.get("new_assignee", "")
@@ -5009,11 +5011,10 @@ def create_mesh_app(
         if not (
             _caller_is_operator(caller, request)
             or _is_internal_caller(request)
-            or permissions.can_route_tasks(caller)
         ):
             raise HTTPException(
                 403,
-                "Retry requires can_route_tasks (operator-grade permission)",
+                "Retry is operator-only (administrative recovery action)",
             )
         original = store.get(task_id)
         if original is None:

--- a/tests/test_loop.py
+++ b/tests/test_loop.py
@@ -2923,7 +2923,8 @@ class TestChatHandoffFailureEnforcement:
             "response": "Done, handed off to bob",
             "tool_outputs": [
                 {
-                    "name": "hand_off",
+                    "tool": "hand_off",
+                    "input": {"to": "bob"},
                     "output": {
                         "handed_off": False,
                         "create_failed": True,
@@ -2943,7 +2944,8 @@ class TestChatHandoffFailureEnforcement:
             "response": "Handed off",
             "tool_outputs": [
                 {
-                    "name": "hand_off",
+                    "tool": "hand_off",
+                    "input": {"to": "carol"},
                     "output": {
                         "handed_off": False,
                         "wake_failed": True,
@@ -2963,7 +2965,8 @@ class TestChatHandoffFailureEnforcement:
             "response": "All good",
             "tool_outputs": [
                 {
-                    "name": "hand_off",
+                    "tool": "hand_off",
+                    "input": {"to": "dave"},
                     "output": {
                         "handed_off": False,
                         "output_write_failed": True,
@@ -2985,7 +2988,8 @@ class TestChatHandoffFailureEnforcement:
             "response": "Tried to hand off",
             "tool_outputs": [
                 {
-                    "name": "hand_off",
+                    "tool": "hand_off",
+                    "input": {"to": "eve"},
                     "output": {"handed_off": False, "to": "eve"},
                 },
             ],
@@ -2999,7 +3003,8 @@ class TestChatHandoffFailureEnforcement:
             "response": "Handed off to bob",
             "tool_outputs": [
                 {
-                    "name": "hand_off",
+                    "tool": "hand_off",
+                    "input": {"to": "bob"},
                     "output": {
                         "handed_off": True,
                         "to": "bob",
@@ -3011,13 +3016,14 @@ class TestChatHandoffFailureEnforcement:
         assert AgentLoop._chat_result_failure_reason(result) is None
 
     def test_non_handoff_tool_output_ignored(self):
-        """Scan only triggers on ``name == "hand_off"`` — same keys on
+        """Scan only triggers on ``tool == "hand_off"`` — same keys on
         a different tool's payload must NOT fail the task."""
         result = {
             "response": "Notified",
             "tool_outputs": [
                 {
-                    "name": "notify_user",
+                    "tool": "notify_user",
+                    "input": {},
                     "output": {"create_failed": True},
                 },
             ],
@@ -3031,7 +3037,8 @@ class TestChatHandoffFailureEnforcement:
             "response": "...",
             "tool_outputs": [
                 {
-                    "name": "hand_off",
+                    "tool": "hand_off",
+                    "input": {"to": "bob"},
                     "result": {"create_failed": True, "to": "bob"},
                 },
             ],
@@ -3047,8 +3054,34 @@ class TestChatHandoffFailureEnforcement:
         result = {
             "tool_limit_reached": True,
             "tool_outputs": [
-                {"name": "hand_off", "output": {"handed_off": True}},
+                {"tool": "hand_off", "input": {}, "output": {"handed_off": True}},
             ],
         }
         assert AgentLoop._chat_result_failure_reason(result) == \
             "max_iterations_reached"
+
+    def test_real_tool_output_schema_with_create_failed(self):
+        """Pin the integration with the actual ``_chat_inner`` schema
+        ``{"tool": tool_name, "input": ..., "output": ...}`` from
+        loop.py:2727. Guards against the PR #953 dead-code regression
+        where the scanner used the wrong key (``name``) and matched
+        nothing in production.
+        """
+        result = {
+            "response": "tried to hand off to bob",
+            "tool_outputs": [
+                {
+                    "tool": "hand_off",
+                    "input": {"to": "bob", "context": "follow-up"},
+                    "output": {
+                        "handed_off": False,
+                        "create_failed": True,
+                        "to": "bob",
+                    },
+                },
+            ],
+        }
+        reason = AgentLoop._chat_result_failure_reason(result)
+        assert reason is not None
+        assert reason.startswith("handoff_failed:")
+        assert "bob" in reason

--- a/tests/test_operator_trust_tier.py
+++ b/tests/test_operator_trust_tier.py
@@ -586,7 +586,11 @@ def test_operator_bypass_pattern_present_at_every_bypassed_gate(mesh_setup):
         "permissions.can_manage_cron(",
         "permissions.can_spawn(",
         "permissions.can_manage_fleet(",
-        "permissions.can_route_tasks(",
+        # ``permissions.can_route_tasks(`` removed: task create/reroute/
+        # retry gates were folded into ``can_message`` (create) and
+        # operator-only (reroute/retry). The legacy method is retained
+        # on PermissionMatrix for back-compat but is no longer called
+        # by server.py — so there's nothing to assert here.
     ]
     for gate in bypassed_gates:
         gate_lines = []

--- a/tests/test_orchestration_endpoints.py
+++ b/tests/test_orchestration_endpoints.py
@@ -181,6 +181,57 @@ async def test_create_task_default_collab_works_out_of_box(tmp_path, monkeypatch
 
 
 @pytest.mark.asyncio
+async def test_worker_can_create_task_for_operator(tmp_path, monkeypatch):
+    """Worker→operator task creation is the intended async escalation path.
+
+    ``/mesh/wake`` explicitly blocks worker→operator synchronous wakes
+    (workers can be steered into privileged actions by anyone able to
+    message them). The task queue is the right channel: it's async,
+    operator processes it on heartbeat. Codex review of PR #954
+    flagged this design intent — pin it with a regression test so a
+    future "mirror the wake block" patch doesn't silently break the
+    standard worker-completion path.
+    """
+    server_module = _reload_server(
+        monkeypatch, tasks_db=str(tmp_path / "tasks.db"),
+    )
+    perms_map = {
+        # Default collab-mode worker permissions.
+        "worker": {"can_message": ["*"]},
+        # Operator is permissioned the way ``_ensure_operator_agent``
+        # produces it post-PR#954 (no can_route_tasks needed).
+        "operator": {"can_message": ["*"]},
+    }
+    app, bb = _build_app(
+        tmp_path, server_module,
+        perms_map=perms_map,
+        agents={
+            "worker": "http://worker:8400",
+            "operator": "http://operator:8400",
+        },
+    )
+    try:
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
+            r = await c.post(
+                "/mesh/tasks",
+                json={
+                    "assignee": "operator",
+                    "title": "Escalating: blocker on stage 3",
+                },
+                headers={"X-Agent-ID": "worker"},
+            )
+        assert r.status_code == 200, r.text
+        body = r.json()
+        assert body["assignee"] == "operator"
+        assert body["creator"] == "worker"
+        assert body["status"] == "pending"
+    finally:
+        bb.close()
+        monkeypatch.delenv("OPENLEGION_ORCHESTRATION_TASKS_DB", raising=False)
+        importlib.reload(server_module)
+
+
+@pytest.mark.asyncio
 async def test_create_task_invalid_assignee(v2_app):
     app, _, _ = v2_app
     async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:

--- a/tests/test_orchestration_endpoints.py
+++ b/tests/test_orchestration_endpoints.py
@@ -117,15 +117,67 @@ async def test_create_task_success(v2_app):
 
 
 @pytest.mark.asyncio
-async def test_create_task_requires_can_route_tasks(v2_app):
+async def test_create_task_requires_can_message_to_assignee(v2_app):
+    """``POST /mesh/tasks`` is gated on ``can_message(caller, assignee)``.
+
+    The fixture's ``tracker`` has ``can_message=[]`` (deny all), so even
+    though ``can_route_tasks`` is the legacy back-compat field that some
+    callers still grant, lacking the per-target ``can_message`` entry is
+    the actual blocker.
+    """
     app, _, _ = v2_app
     async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
+        # tracker has can_message=[] — cannot message scout (or anyone).
         r = await c.post(
             "/mesh/tasks",
             json={"assignee": "scout", "title": "no permission"},
-            headers={"X-Agent-ID": "analyst"},
+            headers={"X-Agent-ID": "tracker"},
         )
     assert r.status_code == 403
+    assert "can_message" in r.json().get("detail", "")
+
+
+@pytest.mark.asyncio
+async def test_create_task_default_collab_works_out_of_box(tmp_path, monkeypatch):
+    """Headline architectural test: a worker with default collab-mode
+    perms (``can_message=["*"]``) can create a task for a peer
+    out-of-the-box — no ``can_route_tasks`` toggle needed.
+
+    This is the test that demonstrates pipelines work without operator
+    intervention. Mirrors the defaults applied by
+    ``cli/config.py::_add_agent_permissions``.
+    """
+    server_module = _reload_server(
+        monkeypatch, tasks_db=str(tmp_path / "tasks.db"),
+    )
+    perms_map = {
+        # No can_route_tasks set anywhere; just collab-mode defaults.
+        "alpha": {"can_message": ["*"]},
+        "bravo": {"can_message": ["*"]},
+    }
+    app, bb = _build_app(
+        tmp_path, server_module,
+        perms_map=perms_map,
+        agents={
+            "alpha": "http://alpha:8400",
+            "bravo": "http://bravo:8400",
+        },
+    )
+    try:
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
+            r = await c.post(
+                "/mesh/tasks",
+                json={"assignee": "bravo", "title": "out of the box"},
+                headers={"X-Agent-ID": "alpha"},
+            )
+        assert r.status_code == 200, r.text
+        body = r.json()
+        assert body["assignee"] == "bravo"
+        assert body["creator"] == "alpha"
+    finally:
+        bb.close()
+        monkeypatch.delenv("OPENLEGION_ORCHESTRATION_TASKS_DB", raising=False)
+        importlib.reload(server_module)
 
 
 @pytest.mark.asyncio
@@ -277,7 +329,13 @@ async def test_status_update_creator_assignee_operator_outsider(v2_app):
 
 
 @pytest.mark.asyncio
-async def test_reroute_requires_can_route_tasks(v2_app):
+async def test_reroute_requires_operator_or_internal(v2_app):
+    """Reroute is now operator-only (administrative recovery action).
+
+    Workers — even with the legacy ``can_route_tasks=True`` grant — must
+    not be able to reroute tasks. Only operator or ``x-mesh-internal``
+    callers succeed.
+    """
     app, _, _ = v2_app
     async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
         r = await c.post(
@@ -300,11 +358,58 @@ async def test_reroute_requires_can_route_tasks(v2_app):
             headers={"X-Agent-ID": "analyst"},
         )
         assert r.status_code == 403
-        # Worker WITH can_route_tasks allowed (scout has it).
+        assert "operator-only" in r.json().get("detail", "")
+        # Worker WITH legacy can_route_tasks=True ALSO denied — reroute
+        # is operator-only now (the gate no longer consults the field).
         r = await c.post(
             f"/mesh/tasks/{tid}/reroute",
             json={"new_assignee": "scout"},
             headers={"X-Agent-ID": "scout"},
+        )
+        assert r.status_code == 403
+        assert "operator-only" in r.json().get("detail", "")
+
+
+@pytest.mark.asyncio
+async def test_retry_requires_operator_or_internal(v2_app):
+    """Retry is operator-only — workers with ``can_route_tasks`` are
+    rejected. Sibling contract to reroute."""
+    app, _, _ = v2_app
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
+        # Seed a task, then force-fail it via internal call so retry
+        # is eligible.
+        r = await c.post(
+            "/mesh/tasks",
+            json={"assignee": "analyst", "title": "retry target"},
+            headers={"X-Agent-ID": "scout"},
+        )
+        tid = r.json()["id"]
+        # Drive it to failed via assignee status updates.
+        r = await c.post(
+            f"/mesh/tasks/{tid}/status",
+            json={"status": "working"},
+            headers={"X-Agent-ID": "analyst"},
+        )
+        assert r.status_code == 200
+        r = await c.post(
+            f"/mesh/tasks/{tid}/status",
+            json={"status": "failed"},
+            headers={"X-Agent-ID": "analyst"},
+        )
+        assert r.status_code == 200
+        # Worker WITH legacy can_route_tasks=True (scout) is rejected.
+        r = await c.post(
+            f"/mesh/tasks/{tid}/retry",
+            json={},
+            headers={"X-Agent-ID": "scout"},
+        )
+        assert r.status_code == 403
+        assert "operator-only" in r.json().get("detail", "")
+        # Operator succeeds.
+        r = await c.post(
+            f"/mesh/tasks/{tid}/retry",
+            json={},
+            headers={"X-Agent-ID": "operator"},
         )
         assert r.status_code == 200
 

--- a/tests/test_permissions.py
+++ b/tests/test_permissions.py
@@ -876,13 +876,18 @@ class TestControlPlanePermissions:
     """Task 3: ``can_spawn`` is now narrow; durable fleet operations
     require new control-plane permissions.
 
-    The six bits split off ``can_spawn``:
+    The control-plane bits split off ``can_spawn``:
       * ``can_manage_fleet``           — create/register named agents
       * ``can_manage_teams``           — create/archive teams, membership
       * ``can_edit_agent_config``      — propose/confirm config edits
       * ``can_view_fleet_metrics``     — fleet-wide metrics endpoints
-      * ``can_route_tasks``            — durable task records (Task 6)
       * ``can_request_user_credentials`` — user-facing credential requests
+
+    ``can_route_tasks`` was retired — task creation is now gated on
+    ``can_message(caller, assignee)`` and reroute/retry are operator-only
+    administrative actions. The field stays on ``AgentPermissions`` for
+    back-compat with existing permissions.json files but is no longer
+    read or seeded.
     """
 
     _CONTROL_PLANE_FIELDS = (
@@ -890,7 +895,6 @@ class TestControlPlanePermissions:
         "can_manage_teams",
         "can_edit_agent_config",
         "can_view_fleet_metrics",
-        "can_route_tasks",
         "can_request_user_credentials",
     )
 


### PR DESCRIPTION
## What jeff's E2E on cake.openlegion.ai revealed

The DB bisect on cake showed three operator→trend-scout tasks all `done`, **zero** rows where trend-scout was creator. trend-scout's docker log:

```
WARNING: create_task for seo-strategist failed: Client error '403 Forbidden' for url
'http://host.docker.internal:8420/mesh/tasks'… Agent trend-scout cannot ro[ute_tasks]
```

trend-scout lacks `can_route_tasks`. Same is true for **every worker on every fleet template ever shipped** — no template grants it, `_add_agent_permissions` doesn't default it, `_AGENT_PERMISSION_DEFAULTS` doesn't forward-migrate it. Only `_ensure_operator_agent` ever grants it (operator only).

The `hand_off` skill correctly built a `create_failed` envelope. The LLM ignored the directive and reported done. Pipeline silently dead. **Universal across all new fleets** running content / devteam / deep-research / competitive-intel — any multi-stage workflow.

## The architectural mistake

`can_route_tasks` was added later (the comment reads `# durable task records (Task 6)`) as a new gate on top of an existing coordination gate (`can_message`). **Two toggles guard the same trust boundary** — creating a task FOR someone IS messaging them with structure. The second gate adds friction without adding security.

## The fix

Fold `can_route_tasks` into `can_message`:

- `/mesh/tasks` POST gates on `can_message(caller, assignee)`. Workers with the default collab-mode `can_message=["*"]` get worker→worker handoffs working **out of the box, no toggle**.
- `/mesh/tasks/{id}/reroute` and `/mesh/tasks/{id}/retry` become operator-only (administrative recovery actions).
- `AgentPermissions.can_route_tasks` field stays for back-compat with existing `permissions.json` files. No data migration needed. No template edits needed.

## Plus: PR #953 enforcement was dead code

`_chat_result_failure_reason` scanned `tool_out["name"]`, but `_chat_inner` appends tool outputs with key `"tool"`. The enforcement never fired in production. Tests passed because they used the wrong key too — self-consistent fiction. Fixed to `tool_out["tool"]` so the LLM-trust gap actually closes.

## Cake live-fix (separate from this PR)

After this PR merges and the provisioner updates cake to HEAD, the existing 5 workflow agents on cake will work without any permissions.json edit because the new gate is `can_message` which they already have (`["*"]` under collab mode). **No manual data fix needed.**

## Test plan

- [x] New `test_create_task_default_collab_works_out_of_box` — headline test: Alpha/Bravo with only `can_message=["*"]` and NO `can_route_tasks` anywhere succeed in worker→worker handoffs.
- [x] New `test_real_tool_output_schema_with_create_failed` — pins enforcement against the real `_chat_inner` schema so PR #953's key-name regression cannot recur.
- [x] 9 existing tests updated (rename + key swap) + 2 source-level invariant tests updated for the retired gate.
- [x] Full fast suite: 6370 passed / 49 skipped / 0 failed.
- [x] `ruff` clean.