### PR TITLE
fix: chat refresh — operator reply persists when LLM ran tools without text

### DIFF
--- a/src/agent/loop.py
+++ b/src/agent/loop.py
@@ -2393,19 +2393,20 @@ class AgentLoop:
                             and not result.get("silent_reply")
                             and not result.get("tool_limit_reached")
                         ):
-                            n_tools = len(result.get("tool_outputs") or [])
+                            tool_outputs = result.get("tool_outputs") or []
                             logger.warning(
                                 "chat empty-response fallback: %d tool "
                                 "call(s) executed but LLM produced no "
                                 "final text — surfacing synthetic notice",
-                                n_tools,
+                                len(tool_outputs),
                             )
-                            tool_word = "tool call" if n_tools == 1 else "tool calls"
+                            # Single source of truth for the wording —
+                            # ``_log_chat_turn`` writes the same string
+                            # to the transcript so the dashboard chat
+                            # view and ``/chat/history`` agree after a
+                            # page refresh.
                             result["response"] = (
-                                f"(Completed {n_tools} {tool_word}; no "
-                                "text response was generated. Check the "
-                                "dashboard for tool outputs and any "
-                                "notifications I sent.)"
+                                self._synthesize_empty_chat_fallback(tool_outputs)
                             )
                     return result
                 finally:
@@ -3028,6 +3029,30 @@ class AgentLoop:
                 "tokens_used": total_tokens, "exception_caught": True,
             }
 
+    @staticmethod
+    def _synthesize_empty_chat_fallback(
+        tool_outputs: list[dict] | None,
+    ) -> str:
+        """Build the synthetic notice for an LLM turn that ran tools but
+        emitted no final text. Single source of truth so the dashboard
+        chat panel (live `done` event) and the persisted transcript
+        (`/chat/history` after refresh) carry identical text — without
+        this helper the two diverged and the operator's reply appeared
+        to vanish on page refresh.
+
+        Returns ``""`` when there are no tools (truly silent LLM —
+        different problem, not papered over here).
+        """
+        if not tool_outputs:
+            return ""
+        n = len(tool_outputs)
+        word = "tool call" if n == 1 else "tool calls"
+        return (
+            f"(Completed {n} {word}; no text response was generated. "
+            "Check the dashboard for tool outputs and any notifications "
+            "I sent.)"
+        )
+
     def _log_chat_turn(
         self, user_msg: str, assistant_msg: str,
         tool_outputs: list[dict] | None = None,
@@ -3035,7 +3060,14 @@ class AgentLoop:
         """Append a rich summary of the chat turn to the daily log."""
         if not self.workspace:
             return
-        # Skip logging for suppressed responses (__SILENT__ → empty string)
+        # Empty final text + tool calls → substitute the synthetic
+        # fallback so the transcript reflects what the dashboard saw
+        # for this turn. Without this the assistant entry was skipped
+        # entirely and a page refresh lost the turn's persistence.
+        if not assistant_msg.strip():
+            assistant_msg = self._synthesize_empty_chat_fallback(tool_outputs)
+        # Skip logging only for genuinely silent responses (SILENT
+        # token, no tools called — there is nothing to persist).
         if not assistant_msg.strip():
             return
         # Strip auto-loaded memory context from user message before summarizing
@@ -3444,6 +3476,14 @@ class AgentLoop:
                     # Use accumulated text from all rounds for the transcript
                     # so intermediate messages are preserved after refresh.
                     full_content = "".join(accumulated_text) if accumulated_text else content
+                    # Empty final text + tools ran: synthesize the same
+                    # fallback the transcript will store so the live
+                    # ``done`` event and the post-refresh history agree
+                    # on what the user sees for this turn.
+                    if not full_content.strip() and tool_outputs:
+                        full_content = self._synthesize_empty_chat_fallback(tool_outputs)
+                        if full_content:
+                            yield {"type": "text_delta", "content": full_content}
                     self._log_chat_turn(user_message, full_content, tool_outputs)
                     if tool_outputs and self.workspace:
                         tool_names = list({t.get("tool") or t.get("name", "?") for t in tool_outputs})
@@ -3456,7 +3496,7 @@ class AgentLoop:
                         )
                     yield {
                         "type": "done",
-                        "response": content,
+                        "response": full_content,
                         "tool_outputs": tool_outputs,
                         "tokens_used": total_tokens,
                     }
@@ -3558,6 +3598,13 @@ class AgentLoop:
                 yield {"type": "text_delta", "content": content}
             self._chat_messages.append({"role": "assistant", "content": content})
             full_content = "".join(accumulated_text) if accumulated_text else content
+            # Same empty-final-text-with-tools fallback as the no-tool-
+            # calls path above — keep the transcript and the streaming
+            # ``done`` event in sync after a max-rounds force-final.
+            if not full_content.strip() and tool_outputs:
+                full_content = self._synthesize_empty_chat_fallback(tool_outputs)
+                if full_content:
+                    yield {"type": "text_delta", "content": full_content}
             self._log_chat_turn(user_message, full_content, tool_outputs)
             if tool_outputs and self.workspace:
                 tool_names = list({t.get("tool") or t.get("name", "?") for t in tool_outputs})
@@ -3570,7 +3617,7 @@ class AgentLoop:
                 )
             yield {
                 "type": "done",
-                "response": content,
+                "response": full_content,
                 "tool_outputs": tool_outputs,
                 "tokens_used": total_tokens,
                 "tool_limit_reached": True,

--- a/tests/test_loop.py
+++ b/tests/test_loop.py
@@ -2904,6 +2904,108 @@ class TestChatEmptyResponseFallback:
         # the "did work" branch and auto-closes as ``done``.
         loop._auto_close_task.assert_awaited()
 
+    # --- Transcript-persistence regression tests (chat refresh bug) ---
+    #
+    # Before the fix, when the LLM ran tools and ended with empty final
+    # text, ``_log_chat_turn`` skipped persisting the assistant entry to
+    # ``chat_transcript.jsonl``. The dashboard's live ``done`` event
+    # showed the synthetic notice fine, but the transcript loaded on
+    # page refresh had no assistant row — "the message disappeared".
+    # These tests pin the contract that the synthetic fallback now lands
+    # in the transcript (and on the daily log) when there were tools,
+    # and that truly silent turns (no text, no tools) still skip.
+
+    def test_log_chat_turn_persists_fallback_when_empty_with_tools(
+        self, tmp_path,
+    ):
+        from src.agent.workspace import WorkspaceManager
+
+        loop = _make_loop()
+        loop.workspace = WorkspaceManager(workspace_dir=str(tmp_path))
+
+        loop._log_chat_turn(
+            "user q",
+            "",
+            tool_outputs=[
+                {"tool": "notify_user", "input": {}, "output": "ok"},
+            ],
+        )
+
+        transcript = loop.workspace.load_chat_transcript()
+        assistant_entries = [
+            m for m in transcript if m.get("role") == "assistant"
+        ]
+        assert len(assistant_entries) == 1, \
+            "fallback must persist exactly one assistant entry"
+        content = assistant_entries[0]["content"]
+        assert "Completed 1 tool call" in content
+        assert content == AgentLoop._synthesize_empty_chat_fallback(
+            [{"tool": "notify_user", "input": {}, "output": "ok"}],
+        )
+
+    def test_log_chat_turn_skips_when_empty_and_no_tools(self, tmp_path):
+        """Truly silent turn (no text, no tools) — nothing to persist.
+        The fallback helper returns ``""``, the guard skips, no
+        assistant row lands in the transcript."""
+        from src.agent.workspace import WorkspaceManager
+
+        loop = _make_loop()
+        loop.workspace = WorkspaceManager(workspace_dir=str(tmp_path))
+
+        loop._log_chat_turn("user q", "", tool_outputs=None)
+
+        transcript = loop.workspace.load_chat_transcript()
+        assistant_entries = [
+            m for m in transcript if m.get("role") == "assistant"
+        ]
+        assert assistant_entries == []
+
+    def test_synthesize_helper_pluralization(self):
+        """Pure-function contract on the helper. Empty/None → ``""``.
+        1 tool → singular "tool call". 2+ tools → plural "tool calls"."""
+        assert AgentLoop._synthesize_empty_chat_fallback(None) == ""
+        assert AgentLoop._synthesize_empty_chat_fallback([]) == ""
+
+        one = AgentLoop._synthesize_empty_chat_fallback([{"tool": "x"}])
+        assert "1 tool call" in one
+        assert "1 tool calls" not in one  # no plural mis-fire
+
+        two = AgentLoop._synthesize_empty_chat_fallback(
+            [{"tool": "x"}, {"tool": "y"}],
+        )
+        assert "2 tool calls" in two
+
+        five = AgentLoop._synthesize_empty_chat_fallback(
+            [{"tool": "x"}] * 5,
+        )
+        assert "5 tool calls" in five
+
+    def test_chat_fallback_wording_matches_log_chat_turn(self, tmp_path):
+        """Anti-drift guard: the string written to the transcript by
+        ``_log_chat_turn`` must equal the helper's return value for the
+        same ``tool_outputs``. If someone re-inlines the wording in one
+        path but not the other, this test catches the divergence."""
+        from src.agent.workspace import WorkspaceManager
+
+        loop = _make_loop()
+        loop.workspace = WorkspaceManager(workspace_dir=str(tmp_path))
+
+        tool_outputs = [
+            {"tool": "web_search", "input": {"q": "x"}, "output": "r"},
+            {"tool": "notify_user", "input": {}, "output": "ok"},
+        ]
+        expected = AgentLoop._synthesize_empty_chat_fallback(tool_outputs)
+        assert expected, "helper must return non-empty when tools ran"
+
+        loop._log_chat_turn("user q", "", tool_outputs=tool_outputs)
+
+        transcript = loop.workspace.load_chat_transcript()
+        assistant_entries = [
+            m for m in transcript if m.get("role") == "assistant"
+        ]
+        assert len(assistant_entries) == 1
+        assert assistant_entries[0]["content"] == expected
+
 
 # === Round-4 structural fix: system-side hand_off failure enforcement ===
 


### PR DESCRIPTION
## Repro

User reports: "Sometimes when I refresh the page, the message from operator (the latest ones) disappears."

## Root cause

When the LLM emits empty final text after running tools (common for operator: `inspect_agents → notify_user → done`), `_log_chat_turn` at `src/agent/loop.py:3038` SKIPS persistence entirely:

```python
if not assistant_msg.strip():
    return
```

The dashboard uses `/chat/stream` (`src/dashboard/static/js/app.js:8502`), so the production path is `_chat_stream_inner` which had NO fallback at all. PR #952 added a synthetic notice (`"(Completed N tool calls...)"`) in `chat()` to keep the live `done` event populated — but it only mutated the response dict and was never written to `chat_transcript.jsonl`.

Net: user types → operator runs tools → dashboard renders whatever streamed (tool events + maybe nothing on the assistant bubble) → transcript file gets no assistant entry → refresh hits `/api/agents/{id}/chat/history` → user's message has no operator reply next to it → **"the message disappeared"**.

## Fix — single source of truth

1. New `@staticmethod AgentLoop._synthesize_empty_chat_fallback(tool_outputs)` returns the synthetic notice. Empty list → `""` (truly silent LLM not papered over).
2. `_log_chat_turn` substitutes the fallback before persisting when `assistant_msg` is empty and tools ran.
3. `_chat_stream_inner` final-no-tool-calls AND max-rounds-exhausted paths: substitute, yield a `text_delta` for live UI, set `done.response` to the synthetic text.
4. `chat()`'s PR #952 inline fallback now calls the helper — wording can no longer drift between live and persisted views.

## Test plan

- [x] Persistence unit tests on `_log_chat_turn` (real `WorkspaceManager` at `tmp_path`).
- [x] Pure-function helper tests (None / `[]` / 1 / 2 / 5 tool pluralization).
- [x] Anti-drift test: persisted content matches helper output for the same inputs.
- [x] Pre-existing PR #952 `chat()` fallback test still passes — confirms `chat()` continues to mutate `result["response"]` via the helper.
- [x] Full fast suite: 6375 passed / 49 skipped / 0 failed.
- [x] `ruff check src/ tests/` — clean.