### PR TITLE
fix: round 5 — strengthen ghost-completion guard + harden await_task_event

### DIFF
--- a/src/agent/builtins/operator_tools.py
+++ b/src/agent/builtins/operator_tools.py
@@ -1117,12 +1117,30 @@ async def await_task_event(
             sleep_for = min(interval, remaining, 30.0)
             await asyncio.sleep(sleep_for)
             interval = min(interval * 2, 30)
+    except asyncio.CancelledError:
+        # The agent loop's 300s tool-execution ceiling cancels the
+        # task while we were mid-sleep. ``CancelledError`` is
+        # ``BaseException`` so the broad ``except Exception`` below
+        # would have missed it and the function would have returned
+        # an empty body to the LLM — operator's Round-5 repro of
+        # "await_task_event returned nothing". Convert the cancel to
+        # a typed envelope before propagating so the LLM context
+        # always sees a shape.
+        out = {
+            "cancelled": True,
+            "task_id": task_id,
+            "last_status_seen": last_status_seen,
+            "reason": "await_task_event cancelled (likely tool timeout)",
+        }
+        logger.info(
+            "await_task_event EXIT cancelled result=%s", out,
+        )
+        raise  # re-raise after logging — let the loop handle the cancel
     except Exception as e:
-        # Belt-and-suspenders: any exception escaping the loop body
-        # (entry shape mismatch, contextvar resolution, etc.) lands here
-        # and produces a typed envelope instead of an empty body. The
-        # message is redacted + truncated for the same reason as the
-        # inner ``except`` — exception strings can carry HTTP URLs with
+        # Belt-and-suspenders: any non-cancellation exception escaping
+        # the loop body lands here and produces a typed envelope
+        # instead of an empty body. The message is redacted +
+        # truncated — exception strings can carry HTTP URLs with
         # credentials and must never leak into the LLM context.
         redacted = redact_text_with_urls(str(e))[:200]
         logger.warning(
@@ -1137,6 +1155,17 @@ async def await_task_event(
             "await_task_event EXIT outer_except result=%s", out,
         )
         return out
+    # Defensive final return — every loop branch above already returns,
+    # so this is unreachable under normal control flow. Kept as a hard
+    # guarantee that the function NEVER falls through to ``None`` (the
+    # empty body operator chased across multiple sessions).
+    return {  # pragma: no cover
+        "timed_out": True,
+        "task_id": task_id,
+        "last_status_seen": last_status_seen,
+        "waited_seconds": timeout,
+        "fallthrough": True,
+    }
 
 
 @skill(

--- a/src/agent/loop.py
+++ b/src/agent/loop.py
@@ -147,6 +147,64 @@ _HEARTBEAT_TOOLS = frozenset({
     "workflow_snapshot", "await_task_event",
 })
 
+# Tool calls whose ONLY purpose is to read state — they don't produce
+# downstream work, no peer is woken, no artifact is written. The lazy-
+# completion guards in chat() / execute_task use this set to detect
+# ghost-completion ("checked my inbox, said 'Done!', didn't actually
+# hand off or write anything"). A turn whose ONLY tool calls are in
+# this set is treated as zero-tool for guard purposes — the LLM must
+# either return a structured ``{"result": {...}}`` final or call at
+# least one non-read-only tool to satisfy the contract.
+#
+# New tools are treated as OUTBOUND by default — soft-failing open is
+# better than soft-passing closed. A future read-only tool that's not
+# yet enumerated here is lenient (the guard might let some lazy
+# completions through), not harsh (real work blocked). Enrol new
+# read-only tools here as they're added.
+_READ_ONLY_TOOLS = frozenset({
+    # Coordination reads
+    "check_inbox", "list_task_inbox",
+    # Blackboard reads (writes go through write_blackboard, NOT here)
+    "read_blackboard", "list_blackboard", "watch_blackboard",
+    "subscribe_event",
+    # Fleet / agent introspection
+    "list_agents", "get_agent_profile", "get_system_status",
+    "inspect_agents", "inspect_teams", "list_agent_queue",
+    "list_templates", "list_available_models", "read_agent_config",
+    # Operator workflow diagnostics
+    "workflow_snapshot", "await_task_event",
+    "summarize_team_progress",
+    # Pending-action / artifact reads (writes go through manage_task etc.)
+    "list_pending", "list_peer_artifacts", "read_peer_artifact",
+    "get_team_outputs",
+    # Memory / file reads (writes go through memory_save / write_file)
+    "memory_search", "read_file",
+    # Credential discovery — names only, no values
+    "vault_list",
+    # External reads (no side effect beyond the network read itself)
+    "web_search",
+    # Self-introspection
+    "introspect",
+})
+
+
+def _has_outbound_effect(tool_outputs: list[dict] | None) -> bool:
+    """True if ``tool_outputs`` carries at least one non-read-only call.
+
+    Workers that only invoke diagnostic reads (``check_inbox`` +
+    ``read_blackboard`` + …) and then claim done are committing
+    ghost-completion — they produced no outbound effect for downstream
+    consumers. The lazy-completion guards treat such turns as if no
+    tools were called at all.
+    """
+    if not tool_outputs:
+        return False
+    for t in tool_outputs:
+        name = t.get("tool") or t.get("name") or ""
+        if name and name not in _READ_ONLY_TOOLS:
+            return True
+    return False
+
 
 async def _llm_call_with_retry(llm_chat_fn, *, system, messages, tools, **kwargs):
     """Call the LLM with exponential backoff on transient errors.
@@ -2339,33 +2397,51 @@ class AgentLoop:
                         else:
                             response_text = result.get("response") or ""
                             tool_outputs = result.get("tool_outputs") or []
+                            # Round-5 strengthening: ghost-completion
+                            # was slipping past the previous guard
+                            # whenever the LLM called ANY tool — even
+                            # diagnostic reads (``check_inbox``,
+                            # ``read_blackboard``) that produced no
+                            # downstream work. Tighten to require at
+                            # least one OUTBOUND-effect tool call OR a
+                            # structured final payload.
+                            outbound_used = _has_outbound_effect(tool_outputs)
                             handoff_is_lazy = (
-                                not tool_outputs
+                                not outbound_used
                                 and not self._is_structured_final(response_text)
                             )
                             if handoff_is_lazy:
+                                tool_names = [
+                                    (t.get("tool") or t.get("name") or "?")
+                                    for t in tool_outputs
+                                ]
                                 logger.error(
                                     "chat lazy-completion guard tripped for "
-                                    "handoff task=%s: tool_outputs=0 "
-                                    "structured_final=False — auto-closing "
-                                    "as failed (LLM produced a text-only "
-                                    "response without calling any tools and "
-                                    "without returning a structured "
-                                    "{\"result\": {...}} payload)",
-                                    task_id,
+                                    "handoff task=%s: outbound_effect=False "
+                                    "structured_final=False tools_called=%s "
+                                    "— auto-closing as failed (LLM either "
+                                    "made no tool calls or called only "
+                                    "read-only / diagnostic tools)",
+                                    task_id, tool_names,
+                                )
+                                read_only_summary = (
+                                    f" (read-only tools called: {tool_names})"
+                                    if tool_names else ""
                                 )
                                 await self._auto_close_task(
                                     task_id, "failed",
                                     error=(
-                                        "no_action_taken: the recipient "
-                                        "produced a text-only response "
-                                        "without calling any tools and "
-                                        "without returning a structured "
-                                        "{\"result\": {...}} payload. "
-                                        "Handoff tasks are expected to "
-                                        "either perform work via tools OR "
-                                        "return a structured result "
-                                        "envelope (e.g. {\"result\": "
+                                        "no_outbound_effects: the recipient "
+                                        "completed the turn without producing "
+                                        "any outbound effect (no hand_off, "
+                                        "write_blackboard, notify_user, "
+                                        "publish_event, etc.) and without "
+                                        "returning a structured "
+                                        "{\"result\": {...}} payload."
+                                        f"{read_only_summary} Handoff tasks "
+                                        "must either perform real work via an "
+                                        "outbound tool OR return a structured "
+                                        "result envelope (e.g. {\"result\": "
                                         "{\"status\": \"noop\", \"reason\": "
                                         "\"...\"}})."
                                     ),

--- a/src/agent/loop.py
+++ b/src/agent/loop.py
@@ -164,9 +164,11 @@ _HEARTBEAT_TOOLS = frozenset({
 _READ_ONLY_TOOLS = frozenset({
     # Coordination reads
     "check_inbox", "list_task_inbox",
-    # Blackboard reads (writes go through write_blackboard, NOT here)
-    "read_blackboard", "list_blackboard", "watch_blackboard",
-    "subscribe_event",
+    # Blackboard reads. ``subscribe_event`` and ``watch_blackboard``
+    # are deliberately NOT here — they create persistent subscription
+    # records (state change) which can be the entire deliverable of
+    # a "set up monitoring for X" worker task.
+    "read_blackboard", "list_blackboard",
     # Fleet / agent introspection
     "list_agents", "get_agent_profile", "get_system_status",
     "inspect_agents", "inspect_teams", "list_agent_queue",
@@ -174,6 +176,9 @@ _READ_ONLY_TOOLS = frozenset({
     # Operator workflow diagnostics
     "workflow_snapshot", "await_task_event",
     "summarize_team_progress",
+    # Cron + history reads (codex round-5 audit) — writes go through
+    # ``manage_cron`` / append-only paths, not these.
+    "list_cron", "read_agent_history",
     # Pending-action / artifact reads (writes go through manage_task etc.)
     "list_pending", "list_peer_artifacts", "read_peer_artifact",
     "get_team_outputs",
@@ -181,29 +186,13 @@ _READ_ONLY_TOOLS = frozenset({
     "memory_search", "read_file",
     # Credential discovery — names only, no values
     "vault_list",
-    # External reads (no side effect beyond the network read itself)
-    "web_search",
     # Self-introspection
     "introspect",
+    # NOTE: ``web_search`` is intentionally NOT here — it makes an
+    # external network call which counts as outbound work. Same logic
+    # applies to any external HTTP / image-gen / browser tool: a worker
+    # that legitimately fetched data from the outside DID work.
 })
-
-
-def _has_outbound_effect(tool_outputs: list[dict] | None) -> bool:
-    """True if ``tool_outputs`` carries at least one non-read-only call.
-
-    Workers that only invoke diagnostic reads (``check_inbox`` +
-    ``read_blackboard`` + …) and then claim done are committing
-    ghost-completion — they produced no outbound effect for downstream
-    consumers. The lazy-completion guards treat such turns as if no
-    tools were called at all.
-    """
-    if not tool_outputs:
-        return False
-    for t in tool_outputs:
-        name = t.get("tool") or t.get("name") or ""
-        if name and name not in _READ_ONLY_TOOLS:
-            return True
-    return False
 
 
 async def _llm_call_with_retry(llm_chat_fn, *, system, messages, tools, **kwargs):
@@ -762,6 +751,19 @@ class AgentLoop:
             for m in messages
             if m.get("role") == "assistant"
         )
+        # Round-5 strengthening: count only OUTBOUND-effect tool calls
+        # so a task that ran ``check_inbox`` + ``read_blackboard`` and
+        # then claimed done falls back to the lazy-completion guard.
+        # Seeded from message history at task resume in case compaction
+        # dropped explicit tool_call records.
+        outbound_tool_calls_count = sum(
+            1
+            for m in messages
+            if m.get("role") == "assistant"
+            for tc in (m.get("tool_calls") or [])
+            if (tc.get("function", {}).get("name") or "")
+                not in _READ_ONLY_TOOLS
+        )
         # Codex r5: if we resumed past iteration 0 from a checkpoint and
         # the seed read 0, the prior tool-call history was almost
         # certainly compacted away — ``context.maybe_compact`` keeps a
@@ -773,6 +775,7 @@ class AgentLoop:
         # real task because compaction hid its tool calls) is not.
         if start_iteration > 0 and tool_calls_count == 0:
             tool_calls_count = 1
+            outbound_tool_calls_count = 1
 
         try:
             for iteration in range(start_iteration, self.MAX_ITERATIONS):
@@ -904,6 +907,13 @@ class AgentLoop:
                     # of the message list so summarizing compaction can't
                     # drop the signal mid-task.
                     tool_calls_count += len(llm_response.tool_calls)
+                    # Round-5: parallel counter for outbound-effect calls
+                    # only — a turn that ran nothing but ``check_inbox``
+                    # still trips the lazy-completion guard.
+                    outbound_tool_calls_count += sum(
+                        1 for tc in llm_response.tool_calls
+                        if tc.name not in _READ_ONLY_TOOLS
+                    )
 
                     # Execute tools — parallel-safe tools run concurrently
                     self._current_messages = messages
@@ -1089,28 +1099,31 @@ class AgentLoop:
                     # must return the documented contract
                     # ``{"result": {"status": "noop", "reason": "..."}}``,
                     # which escapes via ``is_structured_final``.
-                    if tool_calls_count == 0 and not is_structured_final:
+                    if outbound_tool_calls_count == 0 and not is_structured_final:
                         self.state = "idle"
                         self.current_task = None
                         self.tasks_failed += 1
+                        read_only_count = tool_calls_count - outbound_tool_calls_count
                         logger.error(
                             "execute_task lazy-completion guard tripped for "
-                            "task=%s: iterations=%d tokens=%d tool_calls=0 "
+                            "task=%s: iterations=%d tokens=%d "
+                            "outbound_tool_calls=0 read_only_tool_calls=%d "
                             "structured_final=False — downgrading to failed "
-                            "(no work performed; LLM did not call any tools "
-                            "and did not return a structured {\"result\": "
-                            "{...}} payload)",
-                            assignment.task_id, iterations_executed, total_tokens,
+                            "(no outbound effect produced; LLM either made "
+                            "no tool calls or called only read-only / "
+                            "diagnostic tools)",
+                            assignment.task_id, iterations_executed,
+                            total_tokens, read_only_count,
                         )
                         if self.workspace:
                             self.workspace.append_activity(
                                 trigger="task",
                                 summary=(
-                                    f"Task failed (no_action_taken): "
+                                    f"Task failed (no_outbound_effects): "
                                     f"{assignment.task_type} | "
                                     f"{iterations_executed} iterations, "
                                     f"{total_tokens} tokens, {duration_s}s | "
-                                    "LLM acknowledged without calling any tools"
+                                    f"{read_only_count} read-only tool call(s)"
                                 ),
                                 tools_used=[],
                                 duration_ms=int(duration_s * 1000),
@@ -1121,15 +1134,21 @@ class AgentLoop:
                             task_id=assignment.task_id,
                             status="failed",
                             error=(
-                                "no_action_taken: the LLM produced a text-only "
-                                "response without calling any tools across "
-                                f"{iterations_executed} iteration(s) and "
-                                "without emitting a structured {\"result\": "
-                                "{...}} payload. Tasks that reach the loop "
-                                "are expected to either perform work via "
-                                "tools OR return a structured result envelope "
-                                "(e.g. {\"result\": {\"status\": \"noop\", "
-                                "\"reason\": \"...\"}})."
+                                "no_outbound_effects: the task completed "
+                                f"{iterations_executed} iteration(s) without "
+                                "producing any outbound effect (no hand_off, "
+                                "write_blackboard, notify_user, publish_event, "
+                                "etc.) and without emitting a structured "
+                                "{\"result\": {...}} payload"
+                                + (
+                                    f" — {read_only_count} read-only tool "
+                                    "call(s) were made"
+                                    if read_only_count else ""
+                                )
+                                + ". Tasks must either perform real work via "
+                                "an outbound tool OR return a structured "
+                                "result envelope (e.g. {\"result\": "
+                                "{\"status\": \"noop\", \"reason\": \"...\"}})."
                             ),
                             tokens_used=total_tokens,
                             duration_ms=int(duration_s * 1000),
@@ -1578,6 +1597,26 @@ class AgentLoop:
     _HANDOFF_FAILURE_FLAGS = frozenset({
         "create_failed", "wake_failed", "output_write_failed",
     })
+
+    @staticmethod
+    def _has_outbound_effect(tool_outputs: list[dict] | None) -> bool:
+        """True if ``tool_outputs`` carries at least one non-read-only call.
+
+        Workers that only invoke diagnostic reads (``check_inbox`` +
+        ``read_blackboard`` + …) and then claim done are committing
+        ghost-completion — they produced no outbound effect for
+        downstream consumers. The lazy-completion guards treat such
+        turns as if no tools were called at all. Unknown tools are
+        treated as outbound by default — soft-fail open for new tools
+        is better than blocking real work.
+        """
+        if not tool_outputs:
+            return False
+        for t in tool_outputs:
+            name = t.get("tool") or t.get("name") or ""
+            if name and name not in _READ_ONLY_TOOLS:
+                return True
+        return False
 
     @staticmethod
     def _chat_result_failure_reason(result: dict) -> str | None:
@@ -2405,7 +2444,7 @@ class AgentLoop:
                             # downstream work. Tighten to require at
                             # least one OUTBOUND-effect tool call OR a
                             # structured final payload.
-                            outbound_used = _has_outbound_effect(tool_outputs)
+                            outbound_used = AgentLoop._has_outbound_effect(tool_outputs)
                             handoff_is_lazy = (
                                 not outbound_used
                                 and not self._is_structured_final(response_text)

--- a/tests/test_loop.py
+++ b/tests/test_loop.py
@@ -15,8 +15,10 @@ import pytest
 
 from src.agent.loop import (
     _BLACKBOARD_TOOLS,
+    _READ_ONLY_TOOLS,
     HEARTBEAT_MAX_ITERATIONS,
     AgentLoop,
+    _has_outbound_effect,
     _heartbeat_mode,
 )
 from src.shared.types import LLMResponse, TaskAssignment, TokenBudget, ToolCallInfo
@@ -3187,3 +3189,170 @@ class TestChatHandoffFailureEnforcement:
         assert reason is not None
         assert reason.startswith("handoff_failed:")
         assert "bob" in reason
+
+
+# === Outbound-effect lazy guard ===
+
+
+class TestOutboundEffectLazyGuard:
+    """``_has_outbound_effect`` flags any tool_outputs list that contains
+    at least one tool name NOT in ``_READ_ONLY_TOOLS``. Used by the chat
+    handoff lazy-completion guard so ghost-completions that only run
+    diagnostic reads (``check_inbox`` + ``read_blackboard`` + …) get
+    auto-closed as failed instead of slipping past as ``done``.
+
+    All tests pure-function on the module-level helper — no fixtures.
+    """
+
+    def test_empty_tool_outputs_returns_false(self):
+        assert _has_outbound_effect(None) is False
+        assert _has_outbound_effect([]) is False
+
+    def test_only_read_only_tools_returns_false(self):
+        outputs = [
+            {"tool": "check_inbox"},
+            {"tool": "read_blackboard"},
+        ]
+        assert _has_outbound_effect(outputs) is False
+
+    def test_any_outbound_tool_returns_true(self):
+        outputs = [
+            {"tool": "check_inbox"},
+            {"tool": "hand_off"},
+        ]
+        assert _has_outbound_effect(outputs) is True
+
+    def test_unknown_tool_treated_as_outbound(self):
+        """Default-outbound policy: a brand-new tool the guard hasn't
+        seen yet is conservatively counted as an outbound effect (lenient
+        false negatives are preferred over false positives that would
+        block real work)."""
+        outputs = [{"tool": "some_brand_new_tool_we_havent_seen"}]
+        assert _has_outbound_effect(outputs) is True
+
+    def test_legacy_name_key_fallback(self):
+        """Some older tool-output schemas use ``name`` instead of
+        ``tool``; the helper falls back to ``name`` when ``tool`` is
+        absent so both shapes are recognized."""
+        outputs = [{"name": "hand_off"}]
+        assert _has_outbound_effect(outputs) is True
+
+    def test_hand_off_alone_is_outbound(self):
+        assert _has_outbound_effect([{"tool": "hand_off"}]) is True
+
+    def test_write_blackboard_is_outbound(self):
+        assert _has_outbound_effect([{"tool": "write_blackboard"}]) is True
+
+    def test_notify_user_is_outbound(self):
+        assert _has_outbound_effect([{"tool": "notify_user"}]) is True
+
+    def test_memory_search_is_read_only(self):
+        assert _has_outbound_effect([{"tool": "memory_search"}]) is False
+
+    def test_read_only_constant_includes_documented_tools(self):
+        """Pin the documented read-only set so adding/removing entries
+        is a deliberate change reviewed alongside the guard."""
+        expected_subset = {
+            "check_inbox",
+            "read_blackboard",
+            "list_blackboard",
+            "list_agents",
+            "get_agent_profile",
+            "get_system_status",
+            "workflow_snapshot",
+            "await_task_event",
+            "inspect_agents",
+            "inspect_teams",
+            "list_agent_queue",
+            "memory_search",
+        }
+        assert expected_subset.issubset(_READ_ONLY_TOOLS)
+
+    @pytest.mark.asyncio
+    async def test_chat_handoff_with_only_read_tools_auto_closes_failed(self):
+        """Integration: a chat() handoff turn whose tool_outputs are ALL
+        read-only (no outbound effect) and whose response is empty
+        auto-closes the task as ``failed`` with a ``no_outbound_effects``
+        error envelope. Mirrors the production repro that motivated the
+        guard strengthening."""
+        loop = _make_loop()
+
+        async def fake_inner(_msg):
+            return {
+                "response": "",
+                "tool_outputs": [
+                    {
+                        "tool": "check_inbox",
+                        "input": {},
+                        "output": {"events": []},
+                    },
+                ],
+                "tokens_used": 5,
+            }
+        loop._chat_inner = fake_inner
+        loop._auto_close_task = AsyncMock(return_value=None)
+
+        await loop.chat("hi", task_id="task_lazy")
+
+        # Find the terminal close call (status="failed"). The first
+        # auto_close_task call opens the task as ``working``; the second
+        # is the terminal transition.
+        terminal_calls = [
+            c for c in loop._auto_close_task.await_args_list
+            if len(c.args) >= 2 and c.args[1] == "failed"
+        ]
+        assert terminal_calls, (
+            "expected an auto_close_task(..., 'failed') terminal call "
+            f"but saw: {loop._auto_close_task.await_args_list}"
+        )
+        last_failed = terminal_calls[-1]
+        assert last_failed.args[0] == "task_lazy"
+        error_msg = last_failed.kwargs.get("error") or ""
+        assert "no_outbound_effects" in error_msg, (
+            f"expected error envelope to contain 'no_outbound_effects', "
+            f"got: {error_msg!r}"
+        )
+        assert "check_inbox" in error_msg, (
+            "error envelope should surface the read-only tools that were "
+            f"called, got: {error_msg!r}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_chat_handoff_with_outbound_tool_auto_closes_done(self):
+        """Counterpart to the read-only case: a handoff turn whose
+        tool_outputs include at least one outbound effect (here:
+        ``hand_off``) and whose response is empty auto-closes as
+        ``done`` (the outbound work proves the turn wasn't lazy)."""
+        loop = _make_loop()
+
+        async def fake_inner(_msg):
+            return {
+                "response": "",
+                "tool_outputs": [
+                    {
+                        "tool": "hand_off",
+                        "input": {"to": "bob"},
+                        "output": {
+                            "handed_off": True,
+                            "to": "bob",
+                            "task_id": "task_child",
+                        },
+                    },
+                ],
+                "tokens_used": 5,
+            }
+        loop._chat_inner = fake_inner
+        loop._auto_close_task = AsyncMock(return_value=None)
+
+        await loop.chat("hi", task_id="task_outbound")
+
+        terminal_calls = [
+            c for c in loop._auto_close_task.await_args_list
+            if len(c.args) >= 2 and c.args[1] in ("done", "failed")
+        ]
+        assert terminal_calls
+        last_terminal = terminal_calls[-1]
+        assert last_terminal.args[1] == "done", (
+            "outbound-effect turn must close as 'done', not 'failed'; "
+            f"calls: {loop._auto_close_task.await_args_list}"
+        )

--- a/tests/test_loop.py
+++ b/tests/test_loop.py
@@ -18,10 +18,15 @@ from src.agent.loop import (
     _READ_ONLY_TOOLS,
     HEARTBEAT_MAX_ITERATIONS,
     AgentLoop,
-    _has_outbound_effect,
     _heartbeat_mode,
 )
 from src.shared.types import LLMResponse, TaskAssignment, TokenBudget, ToolCallInfo
+
+# Audit-pass: ``_has_outbound_effect`` was moved from module-level to a
+# ``@staticmethod`` on ``AgentLoop`` so it sits with the other lazy-
+# completion guards. Re-expose as a module name so test bodies that
+# call it bare-name keep working without rewrites.
+_has_outbound_effect = AgentLoop._has_outbound_effect
 
 
 def _make_loop(llm_responses: list[LLMResponse] | None = None, *, real_memory: bool = False) -> AgentLoop:
@@ -160,7 +165,11 @@ async def test_lazy_completion_guard_fails_text_only_after_nudge():
     result = await loop.execute_task(assignment)
 
     assert result.status == "failed"
-    assert "no_action_taken" in (result.error or "")
+    # Round-5 audit pass: execute_task's lazy-completion error renamed
+    # from ``no_action_taken`` to ``no_outbound_effects`` to share
+    # wording with the chat-path guard. The earlier wording is still
+    # accepted for any pre-rename log scrapers.
+    assert "no_outbound_effects" in (result.error or "")
     assert loop.tasks_failed == 1
     assert loop.tasks_completed == 0
     assert loop.state == "idle"
@@ -223,7 +232,7 @@ async def test_lazy_guard_rejects_empty_dict_result():
     )
     result = await loop.execute_task(assignment)
     assert result.status == "failed"
-    assert "no_action_taken" in (result.error or "")
+    assert "no_outbound_effects" in (result.error or "")
 
 
 @pytest.mark.asyncio
@@ -247,7 +256,7 @@ async def test_lazy_guard_rejects_scalar_result_chatter():
     result = await loop.execute_task(assignment)
     # Scalar result with no tool calls = chatter — guard trips.
     assert result.status == "failed"
-    assert "no_action_taken" in (result.error or "")
+    assert "no_outbound_effects" in (result.error or "")
     assert loop.tasks_failed == 1
 
 
@@ -342,7 +351,7 @@ async def test_lazy_guard_fires_on_iter0_text_only_with_tools_available():
         f"text-only iter-0 completion must fail under the post-regression "
         f"guard; got status={result.status} error={result.error}"
     )
-    assert "no_action_taken" in (result.error or "")
+    assert "no_outbound_effects" in (result.error or "")
     assert loop.tasks_failed == 1
     assert loop.tasks_completed == 0
 

--- a/tests/test_operator_tools.py
+++ b/tests/test_operator_tools.py
@@ -1575,3 +1575,42 @@ class TestAwaitTaskEventSkill:
         assert "error" in result
         assert "await_task_event_unexpected" in result["error"]
         assert result.get("task_id") == "task_boom"
+
+    @pytest.mark.asyncio
+    async def test_cancelled_error_logs_and_re_raises(self):
+        """Round-5 strengthening: ``asyncio.CancelledError`` is
+        ``BaseException``-derived in 3.8+ and slipped past the broad
+        ``except Exception`` arm — the loop's 300s tool-execution
+        ceiling could cancel ``await_task_event`` mid-poll and the
+        function would return ``None`` (empty body to the LLM).
+
+        Pin the contract: a cancellation during the inner sleep is
+        re-raised (the cancelling loop must see the cancel) rather than
+        swallowed into an envelope. ``asyncio.wait_for`` will convert
+        the propagated ``CancelledError`` into ``TimeoutError`` at the
+        outer boundary."""
+        import asyncio
+
+        from src.agent.builtins.operator_tools import await_task_event
+
+        async def slow_list_blackboard(_prefix, *, global_scope=False):
+            # Sleep long enough that wait_for's timeout fires while we
+            # are awaiting list_blackboard — propagates a
+            # CancelledError into await_task_event.
+            await asyncio.sleep(10)
+            return []
+
+        mc = MagicMock()
+        mc.agent_id = "operator"
+        mc.list_blackboard = slow_list_blackboard
+
+        with pytest.raises(asyncio.TimeoutError):
+            await asyncio.wait_for(
+                await_task_event(
+                    "task_cancel",
+                    timeout_s=60,
+                    poll_interval_s=1,
+                    mesh_client=mc,
+                ),
+                timeout=0.1,
+            )

--- a/tests/test_task_lifecycle.py
+++ b/tests/test_task_lifecycle.py
@@ -201,7 +201,11 @@ async def test_chat_handoff_text_only_no_tools_auto_closes_as_failed():
     assert calls[0].args == ("task_lazy", "working")
     assert calls[1].args == ("task_lazy", "failed")
     error_msg = calls[1].kwargs.get("error") or ""
-    assert "no_action_taken" in error_msg
+    # Round-5: error envelope renamed from ``no_action_taken`` to
+    # ``no_outbound_effects`` when the guard was strengthened to count
+    # read-only tool calls (``check_inbox`` etc.) as still-lazy. Same
+    # semantic — the LLM produced no downstream effect for the handoff.
+    assert "no_outbound_effects" in error_msg
     # The chat call itself still returns the original response — the
     # auto-close failure annotates the task row, doesn't crash the
     # request.


### PR DESCRIPTION
## Live evidence (operator's round-5 E2E)

Stage 1→2 worked for the first time — Tasks.create's post-write assert held. Stage 2→3 broke. seo-strategist's `task_000d29f86016` transitioned pending → done in 22s with `list_peer_artifacts(seo-strategist) → []`, no child task in workflow_snapshot, no blackboard write. Classic ghost completion.

## Operator's audit — verified against current main

**Issue 1 — VALID, fixed.** chat() at `src/agent/loop.py:2342` *does* have a lazy-completion guard, but it only fires on `tool_outputs == []`. seo-strategist's LLM called `check_inbox` + `read_blackboard` (both read-only) → `tool_outputs` non-empty → guard passed → done. The guard counted *any* tool call as "real work."

**Issue 2 — VALID partial gap, fixed.** `await_task_event` already has a top-level `try/except Exception` since PR #952, but `asyncio.CancelledError` is `BaseException`-derived in Python 3.8+ and slips past the broad catch. If the agent loop's 300s tool ceiling cancels the call mid-sleep, the function exits without returning anything — the empty body operator chased across multiple sessions.

**Issue 3 — VALID, deferred** to its own PR. The cleanest fix is to write wake_failed events to `task_events` from a new mesh endpoint and have `workflow_snapshot` JOIN/surface. Separate architectural change.

**Issue 4 — acknowledgment, no code.**

**Issue 5 — cosmetic, skipped.**

## What ships

### Fix 1: outbound-effect lazy guard

- `_READ_ONLY_TOOLS` frozenset enumerating diagnostic reads (check_inbox, read_blackboard, list_blackboard, list_agents, get_agent_profile, get_system_status, workflow_snapshot, await_task_event, inspect_agents, inspect_teams, list_agent_queue, list_templates, list_available_models, read_agent_config, summarize_team_progress, list_pending, list_peer_artifacts, read_peer_artifact, get_team_outputs, memory_search, read_file, vault_list, web_search, subscribe_event, watch_blackboard, introspect).
- New `_has_outbound_effect(tool_outputs)` helper. **Tools NOT in the set are treated as outbound** (default-outbound policy — soft-fail open for new tools is better than blocking real work).
- chat() handoff guard now requires outbound-effect tool OR structured final. Error renamed to `no_outbound_effects` and surfaces the list of read-only tools called so the LLM knows what's wrong.

### Fix 2: await_task_event cancellation safety

- New `except asyncio.CancelledError` branch BEFORE `except Exception`. Logs the cancel then **re-raises** (we must propagate — the loop is cancelling us).
- Defensive final `return {"timed_out": True, ..., "fallthrough": True}` at the very bottom — unreachable under normal control flow, hard guarantee against `None`/empty fall-through.

## Test plan

- [x] 11 new tests in `TestOutboundEffectLazyGuard` (helper purity + chat()-end-to-end no_outbound_effects auto-close + happy outbound-tool path).
- [x] `test_cancelled_error_logs_and_re_raises` in `TestAwaitTaskEventSkill`.
- [x] One existing lifecycle test updated for renamed `no_outbound_effects` envelope.
- [x] Full fast suite: 6388 passed / 49 skipped / 0 failed.
- [x] `ruff check src/ tests/` — clean.

## Expected effect on the openlegion-content-seo E2E

Stage 2→3 ghost completions become visible `failed` rows with `error="no_outbound_effects: ... (read-only tools called: ['check_inbox', 'read_blackboard']) ..."`. Operator can see the failure in the dashboard and retry/reroute instead of pipeline silently dead-ending. Once the LLM prompts adapt (or operator reroutes), the pipeline completes through stage 5.