### PR TITLE
fix: surface rework descendants in workflow_snapshot + finalize chat turns cleanly on error

### DIFF
--- a/src/agent/loop.py
+++ b/src/agent/loop.py
@@ -3017,8 +3017,12 @@ class AgentLoop:
                 if terminate_msg:
                     self.state = "idle"
                     msg = f"Stopped: {terminate_msg}"
-                    if self.workspace:
-                        self.workspace.append_chat_message("assistant", msg)
+                    self._finalize_chat_turn(
+                        turn_id=turn_id,
+                        accumulated_content="\n".join(turn_content_parts),
+                        tool_names=turn_tool_names,
+                        closing_message=msg,
+                    )
                     return {
                         "response": msg,
                         "tool_outputs": tool_outputs,
@@ -3155,8 +3159,12 @@ class AgentLoop:
             self.state = "idle"
             logger.warning(f"Chat auth failure: {e}")
             msg = f"Auth failure: {e}"
-            if self.workspace:
-                self.workspace.append_chat_message("assistant", msg)
+            self._finalize_chat_turn(
+                turn_id=turn_id,
+                accumulated_content="\n".join(turn_content_parts),
+                tool_names=turn_tool_names,
+                closing_message=msg,
+            )
             return {
                 "response": msg, "tool_outputs": tool_outputs,
                 "tokens_used": total_tokens, "auth_failure": True,
@@ -3165,8 +3173,12 @@ class AgentLoop:
             self.state = "idle"
             logger.warning(f"Chat config error: {e}")
             msg = f"Config error: {e}"
-            if self.workspace:
-                self.workspace.append_chat_message("assistant", msg)
+            self._finalize_chat_turn(
+                turn_id=turn_id,
+                accumulated_content="\n".join(turn_content_parts),
+                tool_names=turn_tool_names,
+                closing_message=msg,
+            )
             return {
                 "response": msg, "tool_outputs": tool_outputs,
                 "tokens_used": total_tokens, "config_error": True,
@@ -3175,8 +3187,12 @@ class AgentLoop:
             self.state = "idle"
             logger.error(f"Chat failed: {e}", exc_info=True)
             msg = f"Error: {e}"
-            if self.workspace:
-                self.workspace.append_chat_message("assistant", msg)
+            self._finalize_chat_turn(
+                turn_id=turn_id,
+                accumulated_content="\n".join(turn_content_parts),
+                tool_names=turn_tool_names,
+                closing_message=msg,
+            )
             # Codex r10: tag the bare-exception return with
             # ``exception_caught`` so the chat() auto-close site can
             # detect failures-after-tool-calls and route them to
@@ -3212,6 +3228,41 @@ class AgentLoop:
             f"(Completed {n} {word}; no text response was generated. "
             "Check the dashboard for tool outputs and any notifications "
             "I sent.)"
+        )
+
+    def _finalize_chat_turn(
+        self,
+        *,
+        turn_id: str | None,
+        accumulated_content: str,
+        tool_names: list[str],
+        closing_message: str,
+    ) -> None:
+        """Write a final assistant transcript entry for an abnormal turn close.
+
+        Used by exception handlers and tool-loop terminate paths. Sharing
+        the in-flight partial's ``turn_id`` ensures
+        :meth:`WorkspaceManager.load_chat_transcript`'s dedupe replaces
+        the partial cleanly — the user sees ONE bubble carrying every
+        token streamed so far + the closing message (e.g. ``Error: ...``
+        or ``Stopped: ...``), instead of an orphaned ``partial=True``
+        entry next to a separate error bubble.
+
+        Empty ``accumulated_content`` is fine — the closing_message
+        stands alone (no leading blank lines). No-op when the agent has
+        no workspace mounted.
+        """
+        if not self.workspace:
+            return
+        prefix = (accumulated_content or "").strip()
+        final_content = (
+            f"{prefix}\n\n{closing_message}" if prefix else closing_message
+        )
+        self.workspace.append_chat_message(
+            "assistant",
+            final_content,
+            tool_names=list(tool_names) if tool_names else None,
+            turn_id=turn_id,
         )
 
     def _log_chat_turn(
@@ -3689,8 +3740,12 @@ class AgentLoop:
                 terminate_msg = self._check_tool_loop_terminate(llm_response.tool_calls)
                 if terminate_msg:
                     msg = f"Stopped: {terminate_msg}"
-                    if self.workspace:
-                        self.workspace.append_chat_message("assistant", msg)
+                    self._finalize_chat_turn(
+                        turn_id=turn_id,
+                        accumulated_content="".join(accumulated_text),
+                        tool_names=turn_tool_names,
+                        closing_message=msg,
+                    )
                     yield {
                         "type": "done",
                         "response": msg,
@@ -3847,8 +3902,12 @@ class AgentLoop:
             # to avoid double-counting against the quarantine threshold.
             logger.warning("Streaming chat auth failure: %s", e)
             msg = f"Auth failure: {e}"
-            if self.workspace:
-                self.workspace.append_chat_message("assistant", msg)
+            self._finalize_chat_turn(
+                turn_id=turn_id,
+                accumulated_content="".join(accumulated_text),
+                tool_names=turn_tool_names,
+                closing_message=msg,
+            )
             yield {
                 "type": "done",
                 "response": msg,
@@ -3859,8 +3918,12 @@ class AgentLoop:
         except LLMConfigError as e:
             logger.warning("Streaming chat config error: %s", e)
             msg = f"Config error: {e}"
-            if self.workspace:
-                self.workspace.append_chat_message("assistant", msg)
+            self._finalize_chat_turn(
+                turn_id=turn_id,
+                accumulated_content="".join(accumulated_text),
+                tool_names=turn_tool_names,
+                closing_message=msg,
+            )
             yield {
                 "type": "done",
                 "response": msg,
@@ -3871,8 +3934,12 @@ class AgentLoop:
         except Exception as e:
             logger.error("Streaming chat failed: %s", e, exc_info=True)
             msg = f"Error: {e}"
-            if self.workspace:
-                self.workspace.append_chat_message("assistant", msg)
+            self._finalize_chat_turn(
+                turn_id=turn_id,
+                accumulated_content="".join(accumulated_text),
+                tool_names=turn_tool_names,
+                closing_message=msg,
+            )
             yield {
                 "type": "done",
                 "response": msg,

--- a/src/agent/loop.py
+++ b/src/agent/loop.py
@@ -3233,7 +3233,7 @@ class AgentLoop:
     def _finalize_chat_turn(
         self,
         *,
-        turn_id: str | None,
+        turn_id: str,
         accumulated_content: str,
         tool_names: list[str],
         closing_message: str,
@@ -3251,7 +3251,21 @@ class AgentLoop:
         Empty ``accumulated_content`` is fine — the closing_message
         stands alone (no leading blank lines). No-op when the agent has
         no workspace mounted.
+
+        ``turn_id`` is required and must be non-empty — without it the
+        transcript dedupe cannot match the partial and the helper
+        degrades to writing an orphaned final entry, defeating its
+        purpose. ``_chat_inner`` / ``_chat_stream_inner`` both generate
+        ``turn_id = str(uuid.uuid4())`` at the top of the function
+        before any work that can raise, so the contract is structurally
+        safe.
         """
+        if not turn_id:
+            raise ValueError(
+                "_finalize_chat_turn requires a non-empty turn_id — "
+                "callers must mint one before the try block so the "
+                "partial dedupe is well-defined"
+            )
         if not self.workspace:
             return
         prefix = (accumulated_content or "").strip()

--- a/src/dashboard/static/js/app.js
+++ b/src/dashboard/static/js/app.js
@@ -1347,8 +1347,19 @@ function dashboard() {
           // On reconnect, refresh chat histories to catch messages from other sessions.
           // Skip on initial connect — init() already fetches them.
           if (isReconnect) {
+            // Disconnect invalidates ALL ephemeral chat-stream state — a
+            // ``text_delta`` flips ``chatStreamingAgents[id]=true`` and only
+            // ``chat_done`` clears it. If the WS dropped between those two,
+            // the flag is stuck and ``_loadChatHistory`` early-returns,
+            // silently swallowing the refetch. Reset the per-agent state
+            // across the board (not just ``openChats``) so a chat closed
+            // during the disconnect window doesn't hit a stuck flag when
+            // the user reopens it later.
+            this.chatStreamingAgents = {};
+            this._chatStreamEndAt = {};
+            this._chatAborts = {};
+            this._chatFetchedAt = {};
             for (const agentId of this.openChats) {
-              delete this._chatFetchedAt[agentId];
               this._loadChatHistory(agentId);
             }
           }

--- a/src/dashboard/static/js/app.js
+++ b/src/dashboard/static/js/app.js
@@ -1347,19 +1347,36 @@ function dashboard() {
           // On reconnect, refresh chat histories to catch messages from other sessions.
           // Skip on initial connect — init() already fetches them.
           if (isReconnect) {
-            // Disconnect invalidates ALL ephemeral chat-stream state — a
+            // Disconnect invalidates ephemeral chat-stream state — a
             // ``text_delta`` flips ``chatStreamingAgents[id]=true`` and only
             // ``chat_done`` clears it. If the WS dropped between those two,
             // the flag is stuck and ``_loadChatHistory`` early-returns,
-            // silently swallowing the refetch. Reset the per-agent state
-            // across the board (not just ``openChats``) so a chat closed
-            // during the disconnect window doesn't hit a stuck flag when
-            // the user reopens it later.
-            this.chatStreamingAgents = {};
-            this._chatStreamEndAt = {};
-            this._chatAborts = {};
-            this._chatFetchedAt = {};
+            // silently swallowing the refetch.
+            //
+            // BUT: ``_chatAborts[id]`` is an AbortController for a LOCAL
+            // SSE ``/chat/stream`` fetch — wiping it kills our handle on
+            // an active local stream and the next text_delta could land
+            // in a stale render target. Skip agents with an active local
+            // stream (their state is correct as-is) and reset state for
+            // everyone else so a stuck flag elsewhere doesn't block a
+            // later reopen.
+            const agentsToReset = Object.keys({
+              ...this.chatStreamingAgents,
+              ...this._chatStreamEndAt,
+              ...this._chatFetchedAt,
+            });
+            for (const id of agentsToReset) {
+              if (this._chatAborts && this._chatAborts[id]) continue;
+              delete this.chatStreamingAgents[id];
+              delete this._chatStreamEndAt[id];
+              delete this._chatFetchedAt[id];
+            }
             for (const agentId of this.openChats) {
+              // Skip the refetch for agents with an active local SSE
+              // stream — the persistent transcript won't include the
+              // in-flight bubble yet, and replacing chatHistories[agent]
+              // mid-stream invalidates the streaming render target.
+              if (this._chatAborts && this._chatAborts[agentId]) continue;
               this._loadChatHistory(agentId);
             }
           }

--- a/src/host/orchestration.py
+++ b/src/host/orchestration.py
@@ -813,7 +813,12 @@ class Tasks:
           completed >24h ago out of the window even if an unrelated
           metadata write happens later. Mirrors the
           :meth:`count_failed_status_since` pattern.
-        * has no row in ``tasks`` whose ``parent_task_id`` references it
+        * has no row in ``tasks`` whose ``parent_task_id`` references it.
+          ``previous_task_id`` (rework) descendants are DELIBERATELY
+          NOT considered here — a rework is a retry of the same work,
+          not the downstream handoff the chain was waiting for. See
+          ``test_previous_task_id_chain_does_not_suppress_chain_break``
+          for the pinning test on this semantic.
         * has ``outcome IS NULL`` — the operator hasn't actioned this
           delivery yet via rate / rework. Outcome-set rows drop out of
           the count because the operator already saw them.
@@ -881,11 +886,25 @@ class Tasks:
     ) -> dict | None:
         """Return a snapshot of the workflow chain rooted at ``root_task_id``.
 
-        Walks the ``parent_task_id`` graph downstream from the root (the
-        operator's kickoff task) via ``WITH RECURSIVE``. Each descendant
-        task is one stage of the workflow. Returns ``None`` when the root
-        does not exist. Capped at ``limit`` rows (default 50) so a
-        runaway chain can't OOM the caller.
+        Walks BOTH the ``parent_task_id`` graph (normal handoff chain)
+        AND the ``previous_task_id`` graph (rework lineage from
+        :meth:`create_rework_task`) downstream from the root via
+        ``WITH RECURSIVE``. Each descendant task is one stage of the
+        workflow. Returns ``None`` when the root does not exist. Capped
+        at ``limit`` rows (default 50) so a runaway chain can't OOM the
+        caller.
+
+        Walking both edges matters because rework tasks inherit the
+        failed task's ``parent_task_id`` (so the kanban renders them as
+        siblings of the failed validator) but their lineage to the
+        failed task is captured only via ``previous_task_id``. Without
+        traversing that edge:
+
+        * a snapshot rooted at a failed task would miss its rework
+          descendants (the parent inheritance points them sideways
+          rather than down)
+        * an orphan rework (parent outside the chain) would be
+          invisible even from the chain root
 
         Output shape:
 
@@ -895,6 +914,7 @@ class Tasks:
               "root": "task_abc",
               "stages": [
                 {"task_id": "...", "parent_task_id": "...",
+                 "previous_task_id": "...",  # rework stages only
                  "assignee": "...", "status": "...",
                  "age_in_state_seconds": int, "title": "..."},
                 ...  # ordered by created_at ASC so the chain reads as
@@ -913,21 +933,29 @@ class Tasks:
         # Inner recursion is bounded by ``MAX_WORKFLOW_CHAIN_DEPTH`` via
         # a depth counter so a pathological wide chain can't materialize
         # millions of intermediate rows before the outer LIMIT trims.
-        # Cycles are impossible by construction (parent_task_id is set
-        # once at creation, never updated), but the depth guard is
-        # cheap defense-in-depth.
+        # Cycles are impossible by construction (both ``parent_task_id``
+        # and ``previous_task_id`` are set once at creation, never
+        # updated, and reference tasks that already exist) but the
+        # depth guard is cheap defense-in-depth. A task reachable via
+        # both edges (e.g. a rework spawned from the chain root) lands
+        # in ``chain`` twice at potentially different depths — the
+        # outer ``IN (SELECT DISTINCT id FROM chain)`` dedupes so the
+        # task surfaces once in the snapshot.
         with self._conn() as conn:
             rows = conn.execute(
                 "WITH RECURSIVE chain(id, depth) AS ("
                 "  SELECT id, 0 FROM tasks WHERE id = ?"
                 "  UNION ALL"
                 "  SELECT t.id, c.depth + 1 FROM tasks t "
-                "    JOIN chain c ON t.parent_task_id = c.id "
+                "    JOIN chain c ON (t.parent_task_id = c.id "
+                "                  OR t.previous_task_id = c.id) "
                 "    WHERE c.depth < ?"
                 ") "
-                "SELECT t.id, t.parent_task_id, t.assignee, t.status, "
-                "  t.title, t.blocker_note, t.created_at, t.updated_at "
-                "FROM tasks t JOIN chain c ON t.id = c.id "
+                "SELECT t.id, t.parent_task_id, t.previous_task_id, "
+                "  t.assignee, t.status, t.title, t.blocker_note, "
+                "  t.created_at, t.updated_at "
+                "FROM tasks t "
+                "WHERE t.id IN (SELECT DISTINCT id FROM chain) "
                 "ORDER BY t.created_at ASC LIMIT ?",
                 (root_task_id, MAX_WORKFLOW_CHAIN_DEPTH, limit),
             ).fetchall()
@@ -940,7 +968,17 @@ class Tasks:
             # report ``terminal_without_children=True``. Uses the
             # ``idx_tasks_parent_task_id`` index so this is O(#done-stages)
             # lookups inside the same connection block.
-            done_task_ids = [row[0] for row in rows if row[3] == "done"]
+            #
+            # ``previous_task_id`` descendants (rework) are DELIBERATELY
+            # NOT considered here — a rework is a retry of the same
+            # stage, not a downstream handoff. A done task whose only
+            # follow-up is a rework is still a chain break (workflow
+            # stalled). The rework appears as its own stage in the
+            # snapshot via the CTE's ``previous_task_id`` edge walk, but
+            # it doesn't suppress its predecessor's chain-break flag.
+            # Mirrors :meth:`chain_breaks_24h` and is pinned by
+            # ``test_previous_task_id_chain_does_not_suppress_chain_break``.
+            done_task_ids = [row[0] for row in rows if row[4] == "done"]
             parent_ids_with_children: set[str] = set()
             if done_task_ids:
                 placeholders = ",".join("?" * len(done_task_ids))
@@ -959,8 +997,8 @@ class Tasks:
         summary["total"] = 0
         for row in rows:
             (
-                tid, parent, assignee, status, title, blocker_note,
-                created_at, updated_at,
+                tid, parent, previous, assignee, status, title,
+                blocker_note, created_at, updated_at,
             ) = row
             age_basis = updated_at or created_at or 0.0
             age = int(now - age_basis) if age_basis > 0 else 0
@@ -972,6 +1010,12 @@ class Tasks:
                 "age_in_state_seconds": age,
                 "title": title or "",
             }
+            # ``previous_task_id`` surfaced only when set so the operator
+            # can spot rework stages (and which task triggered them)
+            # without an extra ``get_task`` call. Nominal handoff stages
+            # have ``previous_task_id IS NULL`` and stay quiet.
+            if previous:
+                stage["previous_task_id"] = previous
             # Surface ``blocker_note`` only when set — saves the operator
             # a follow-up get_task call for failed/blocked stages and
             # keeps the snapshot quiet for nominal stages.

--- a/src/host/server.py
+++ b/src/host/server.py
@@ -4822,10 +4822,15 @@ def create_mesh_app(
     ) -> dict:
         """Return a workflow chain snapshot rooted at ``root_task_id``.
 
-        Walks ``parent_task_id`` descendants from the root and reports
-        every stage's status + age. Operator-only by design — workflow
-        orchestration awareness is operator-tier, and individual workers
-        have no business inspecting a chain they don't own.
+        Walks BOTH ``parent_task_id`` (normal handoff) and
+        ``previous_task_id`` (rework lineage from
+        :meth:`Tasks.create_rework_task`) descendants from the root and
+        reports every stage's status + age. Rework stages carry
+        ``previous_task_id`` in their stage dict so the operator can
+        identify lineage without an extra ``get_task`` call. Operator-
+        only by design — workflow orchestration awareness is operator-
+        tier, and individual workers have no business inspecting a
+        chain they don't own.
 
         404 when the root does not exist (lets the operator distinguish
         a typo from an empty chain).

--- a/tests/test_builtins.py
+++ b/tests/test_builtins.py
@@ -1348,10 +1348,9 @@ class TestCredentialRedaction:
         assert _redact_credentials("Price: $42.00") == "Price: $42.00"
         assert _redact_credentials("") == ""
 
-    def test_browser_command_redacts_response(self):
+    @pytest.mark.asyncio
+    async def test_browser_command_redacts_response(self):
         """_browser_command applies _deep_redact to the response."""
-        import asyncio
-
         from src.agent.builtins.browser_tool import _browser_command
 
         mc = AsyncMock()
@@ -1359,17 +1358,19 @@ class TestCredentialRedaction:
             "content": "key is sk-abcdefghijklmnopqrstuvwxyz"
         })
 
-        result = asyncio.get_event_loop().run_until_complete(
-            _browser_command(mc, "navigate", {"url": "https://x.com"})
-        )
+        # Native ``await`` inside an asyncio-marked test runs on the
+        # pytest-asyncio managed loop — under Python 3.11+ the legacy
+        # ``asyncio.get_event_loop().run_until_complete(...)`` pattern
+        # raises ``RuntimeError: no current event loop`` once the
+        # surrounding async test has closed its loop.
+        result = await _browser_command(mc, "navigate", {"url": "https://x.com"})
 
         assert "sk-abcdefghijklmnopqrstuvwxyz" not in str(result)
         assert "[REDACTED]" in result["content"]
 
-    def test_browser_command_redacts_error(self):
+    @pytest.mark.asyncio
+    async def test_browser_command_redacts_error(self):
         """_browser_command redacts errors too."""
-        import asyncio
-
         from src.agent.builtins.browser_tool import _browser_command
 
         mc = AsyncMock()
@@ -1377,9 +1378,7 @@ class TestCredentialRedaction:
             side_effect=Exception("fail: sk-abcdefghijklmnopqrstuvwxyz exposed")
         )
 
-        result = asyncio.get_event_loop().run_until_complete(
-            _browser_command(mc, "navigate", {})
-        )
+        result = await _browser_command(mc, "navigate", {})
 
         assert "sk-abcdefghijklmnopqrstuvwxyz" not in str(result)
         assert "[REDACTED]" in result["error"]

--- a/tests/test_chat.py
+++ b/tests/test_chat.py
@@ -207,16 +207,18 @@ class TestChatEndpoints:
         assert "injected" in data
         assert "agent_state" in data
 
-    def test_chat_steer_does_not_block(self):
+    @pytest.mark.asyncio
+    async def test_chat_steer_does_not_block(self):
         """Steer endpoint returns immediately without acquiring _chat_lock."""
-        import asyncio
-
         loop = _make_loop()
         app = create_agent_app(loop)
         client = TestClient(app)
 
-        # Manually acquire the chat lock to simulate a busy agent
-        acquired = asyncio.get_event_loop().run_until_complete(loop._chat_lock.acquire())
+        # Manually acquire the chat lock to simulate a busy agent.
+        # Native ``await`` inside an asyncio-marked test runs on the
+        # pytest-asyncio managed loop — no ``get_event_loop()`` foot-gun
+        # under Python 3.11+ where the legacy synchronous path raises.
+        acquired = await loop._chat_lock.acquire()
         assert acquired
 
         try:

--- a/tests/test_loop.py
+++ b/tests/test_loop.py
@@ -3468,3 +3468,192 @@ class TestChatAutoCloseErrorPropagation:
         # chars in _chat_result_failure_reason; the chain-tail _auto_close
         # truncation cap is 500 chars. Either way the kwarg stays bounded.
         assert len(err_kwarg) <= 500
+
+
+# === Bug 2 fix: in-flight chat turn is finalized cleanly on errors/terminate ===
+#
+# Before the fix, exception and tool-loop-terminate paths wrote a NEW
+# assistant transcript entry without ``turn_id``. The earlier ``partial``
+# entry (written before tool dispatch) stayed on disk as ``partial=True``
+# next to a separate "Error: ..." or "Stopped: ..." bubble. With
+# ``load_chat_transcript`` deduping by turn_id, the partial was an
+# orphan. These tests pin the ``_finalize_chat_turn`` helper that closes
+# the turn cleanly: one entry, same turn_id as the partial, content =
+# ``<accumulated text>\n\n<closing message>``.
+
+
+class TestFinalizeChatTurn:
+    """Helper-level pin. Exercises the contract directly without
+    standing up the full chat() / _chat_inner async machinery."""
+
+    def test_finalize_combines_accumulated_text_with_closing_message(
+        self, tmp_path,
+    ):
+        from src.agent.workspace import WorkspaceManager
+        loop = _make_loop()
+        loop.workspace = WorkspaceManager(workspace_dir=str(tmp_path))
+
+        loop._finalize_chat_turn(
+            turn_id="turn-1",
+            accumulated_content="streamed text so far",
+            tool_names=["tool_a", "tool_b"],
+            closing_message="Error: boom",
+        )
+
+        msgs = loop.workspace.load_chat_transcript()
+        assert len(msgs) == 1
+        entry = msgs[0]
+        assert entry["role"] == "assistant"
+        assert entry["content"] == "streamed text so far\n\nError: boom"
+        assert entry.get("turn_id") == "turn-1"
+        assert entry.get("tools") == ["tool_a", "tool_b"]
+        # Final entry — NOT partial.
+        assert entry.get("partial") is not True
+
+    def test_finalize_supersedes_in_flight_partial(self, tmp_path):
+        """The same turn_id as a prior partial entry must replace it in
+        the transcript dedupe. Pins the orphan-partial fix."""
+        from src.agent.workspace import WorkspaceManager
+        loop = _make_loop()
+        loop.workspace = WorkspaceManager(workspace_dir=str(tmp_path))
+
+        # Simulate the partial write that happens before tool dispatch.
+        loop.workspace.append_chat_message(
+            "assistant", "streamed text so far",
+            tool_names=["tool_a"], turn_id="turn-1", partial=True,
+        )
+        # Hit the error path → finalize.
+        loop._finalize_chat_turn(
+            turn_id="turn-1",
+            accumulated_content="streamed text so far",
+            tool_names=["tool_a"],
+            closing_message="Error: boom",
+        )
+
+        msgs = loop.workspace.load_chat_transcript()
+        # Dedupe by turn_id: ONE entry, the final one.
+        assert len(msgs) == 1
+        assert msgs[0]["content"] == "streamed text so far\n\nError: boom"
+        assert msgs[0].get("partial") is not True
+
+    def test_finalize_with_empty_accumulated_content_writes_only_closing(
+        self, tmp_path,
+    ):
+        """No streamed text yet (exception fired before LLM emitted any
+        tokens) → only the closing message lands, no leading blank lines."""
+        from src.agent.workspace import WorkspaceManager
+        loop = _make_loop()
+        loop.workspace = WorkspaceManager(workspace_dir=str(tmp_path))
+
+        loop._finalize_chat_turn(
+            turn_id="turn-1",
+            accumulated_content="",
+            tool_names=[],
+            closing_message="Error: boom",
+        )
+        msgs = loop.workspace.load_chat_transcript()
+        assert len(msgs) == 1
+        assert msgs[0]["content"] == "Error: boom"
+        assert msgs[0].get("turn_id") == "turn-1"
+        # Empty tool list → no ``tools`` key in entry.
+        assert "tools" not in msgs[0] or msgs[0]["tools"] == []
+
+    def test_finalize_no_workspace_is_noop(self):
+        """Agents without a mounted workspace must skip silently — same
+        pattern as the existing ``if self.workspace:`` guard."""
+        loop = _make_loop()
+        loop.workspace = None
+        # Must not raise.
+        loop._finalize_chat_turn(
+            turn_id="turn-1",
+            accumulated_content="text",
+            tool_names=["a"],
+            closing_message="Error: boom",
+        )
+
+
+class TestChatExceptionPathsFinalizeCleanly:
+    """End-to-end pin: the exception handlers in ``_chat_inner`` must
+    route through ``_finalize_chat_turn`` (NOT the raw ``append_chat_message``)
+    so the in-flight partial is superseded cleanly."""
+
+    @pytest.mark.asyncio
+    async def test_chat_inner_llm_config_error_finalizes_partial(
+        self, tmp_path,
+    ):
+        from src.agent.workspace import WorkspaceManager
+        from src.shared.errors import LLMConfigError
+
+        loop = _make_loop()
+        loop.workspace = WorkspaceManager(workspace_dir=str(tmp_path))
+        loop.skills.get_tool_definitions = MagicMock(return_value=[])
+        # First call: LLMConfigError mid-turn. Before this point a partial
+        # MAY exist on disk if a prior round wrote one — simulate that
+        # case so we verify supersedence.
+        loop.workspace.append_chat_message(
+            "assistant", "intermediate streamed text",
+            tool_names=["search"], turn_id="will-be-overwritten",
+            partial=True,
+        )
+        # Pre-state: one partial entry on disk.
+        pre = loop.workspace.load_chat_transcript()
+        assert len(pre) == 1
+        assert pre[0].get("partial") is True
+
+        loop.llm.chat = AsyncMock(side_effect=LLMConfigError(
+            "OAuth-allowed models: [...]; got 'openai/gpt-4o-mini'",
+            provider="openai",
+            model="openai/gpt-4o-mini",
+            allowed_models=set(),
+        ))
+
+        result = await loop._chat_inner("hello")
+        assert result.get("config_error") is True
+
+        msgs = loop.workspace.load_chat_transcript()
+        # The legacy partial is unrelated to the new turn_id — it stays
+        # as a separate entry. The NEW turn's error finalizes cleanly
+        # (no orphan partial for it).
+        # New entry's content must surface the error.
+        error_entries = [
+            m for m in msgs if "Config error" in m.get("content", "")
+        ]
+        assert len(error_entries) == 1
+        assert error_entries[0].get("partial") is not True
+        assert error_entries[0].get("turn_id"), (
+            "error finalize entry must carry a turn_id so any future "
+            "partial from the same turn dedupes against it"
+        )
+
+    @pytest.mark.asyncio
+    async def test_chat_stream_inner_generic_exception_finalizes_partial(
+        self, tmp_path,
+    ):
+        """Streaming path's generic Exception handler must finalize via
+        the same helper. Verify by patching ``_finalize_chat_turn`` and
+        checking it gets called with the error message."""
+        from src.agent.workspace import WorkspaceManager
+
+        loop = _make_loop()
+        loop.workspace = WorkspaceManager(workspace_dir=str(tmp_path))
+        loop.skills.get_tool_definitions = MagicMock(return_value=[])
+        loop.llm.chat_stream = MagicMock(
+            side_effect=RuntimeError("kaboom"),
+        )
+        loop.llm.chat = AsyncMock(side_effect=RuntimeError("kaboom"))
+
+        finalize_spy = MagicMock()
+        loop._finalize_chat_turn = finalize_spy
+
+        events = []
+        async for evt in loop._chat_stream_inner("hello"):
+            events.append(evt)
+
+        # Helper invoked exactly once for this turn.
+        assert finalize_spy.call_count == 1
+        call = finalize_spy.call_args
+        assert "Error: kaboom" in call.kwargs["closing_message"]
+        assert call.kwargs.get("turn_id"), (
+            "finalize must receive the turn's turn_id so the partial "
+            "supersedes cleanly"
+        )

--- a/tests/test_loop.py
+++ b/tests/test_loop.py
@@ -3571,6 +3571,21 @@ class TestFinalizeChatTurn:
             closing_message="Error: boom",
         )
 
+    def test_finalize_rejects_empty_turn_id(self, tmp_path):
+        """An empty/None turn_id breaks the partial-dedupe contract —
+        the helper must refuse and raise so callers can't silently
+        regress to the orphaned-partial bug."""
+        from src.agent.workspace import WorkspaceManager
+        loop = _make_loop()
+        loop.workspace = WorkspaceManager(workspace_dir=str(tmp_path))
+        with pytest.raises(ValueError, match="turn_id"):
+            loop._finalize_chat_turn(
+                turn_id="",
+                accumulated_content="text",
+                tool_names=["a"],
+                closing_message="Error: boom",
+            )
+
 
 class TestChatExceptionPathsFinalizeCleanly:
     """End-to-end pin: the exception handlers in ``_chat_inner`` must

--- a/tests/test_orchestration.py
+++ b/tests/test_orchestration.py
@@ -2127,3 +2127,200 @@ def test_previous_task_id_chain_does_not_suppress_chain_break(tmp_path):
     # from the live count only because the rework outcome was set on
     # the original (outcome IS NULL filter), NOT because the rework
     # row exists. The event fired and remains in the captured stream.
+
+
+# ── Bug 5 fix: workflow_snapshot traverses previous_task_id (rework) edges ──
+#
+# Operator hit a case where a validator failed mid-chain and a rework
+# was spawned. ``workflow_snapshot`` is what the operator's heartbeat
+# polls to see the full state of an in-flight workflow. Before the fix
+# the CTE walked ``parent_task_id`` only, so a rework — which inherits
+# the failed task's parent but carries the failed task in
+# ``previous_task_id`` — was invisible from a snapshot rooted at the
+# failed task itself, and orphan reworks (parent outside the chain)
+# were invisible from any root. These tests pin the fix.
+
+
+def test_workflow_snapshot_includes_rework_via_previous_task_id(tmp_path):
+    """A rework spawned from a failed leaf must appear in the snapshot
+    when rooted at the failed task — even though the rework's
+    ``parent_task_id`` inherits the failed task's parent (not the
+    failed task itself), the ``previous_task_id`` edge carries the
+    lineage and the CTE walks it."""
+    t = _make_store(tmp_path)
+    kickoff = t.create(creator="op", assignee="scout", title="kickoff")
+    stage = t.create(
+        creator="scout", assignee="validator", title="validate",
+        parent_task_id=kickoff["id"],
+    )
+    t.update_status(stage["id"], "working", actor="validator")
+    t.update_status(stage["id"], "done", actor="validator")
+    rework = t.create_rework_task(
+        stage["id"], "needs another pass", actor="op",
+    )
+    # Rework inherits the failed task's parent — NOT the failed task —
+    # so the parent_task_id-only CTE would miss it when rooted at stage.
+    assert rework["parent_task_id"] == kickoff["id"]
+    assert rework["previous_task_id"] == stage["id"]
+
+    # Rooted at the failed task: rework must surface via previous_task_id.
+    snap = t.workflow_snapshot(stage["id"])
+    assert snap is not None
+    ids = {s["task_id"] for s in snap["stages"]}
+    assert rework["id"] in ids, (
+        "rework descendant must appear in snapshot via previous_task_id "
+        "edge, not just parent_task_id"
+    )
+
+
+def test_workflow_snapshot_from_root_includes_rework_descendants(tmp_path):
+    """A snapshot rooted at the kickoff must also surface rework
+    descendants — they're part of the operator's full workflow view
+    regardless of which root the operator picks."""
+    t = _make_store(tmp_path)
+    kickoff = t.create(creator="op", assignee="scout", title="kickoff")
+    stage = t.create(
+        creator="scout", assignee="validator", title="validate",
+        parent_task_id=kickoff["id"],
+    )
+    t.update_status(stage["id"], "working", actor="validator")
+    t.update_status(stage["id"], "done", actor="validator")
+    rework = t.create_rework_task(
+        stage["id"], "redo this", actor="op",
+    )
+
+    snap = t.workflow_snapshot(kickoff["id"])
+    assert snap is not None
+    ids = {s["task_id"] for s in snap["stages"]}
+    assert {kickoff["id"], stage["id"], rework["id"]}.issubset(ids)
+
+
+def test_workflow_snapshot_surfaces_previous_task_id_on_rework_stages(tmp_path):
+    """Rework stages must carry ``previous_task_id`` in their stage
+    dict so the operator can identify which task triggered the
+    rework without an extra ``get_task`` round-trip. Nominal stages
+    omit the field."""
+    t = _make_store(tmp_path)
+    kickoff = t.create(creator="op", assignee="scout", title="kickoff")
+    stage = t.create(
+        creator="scout", assignee="writer", title="write",
+        parent_task_id=kickoff["id"],
+    )
+    t.update_status(stage["id"], "working", actor="writer")
+    t.update_status(stage["id"], "done", actor="writer")
+    rework = t.create_rework_task(stage["id"], "redo", actor="op")
+
+    snap = t.workflow_snapshot(kickoff["id"])
+    assert snap is not None
+    by_id = {s["task_id"]: s for s in snap["stages"]}
+    # Nominal stages: no previous_task_id key.
+    assert "previous_task_id" not in by_id[kickoff["id"]]
+    assert "previous_task_id" not in by_id[stage["id"]]
+    # Rework: previous_task_id points to the failed predecessor.
+    assert by_id[rework["id"]]["previous_task_id"] == stage["id"]
+
+
+def test_workflow_snapshot_multi_step_rework_chain(tmp_path):
+    """A rework-of-rework chain (V → V' → V'') rooted at the original
+    failed task must surface all generations. Each generation links
+    back to the previous via ``previous_task_id``."""
+    t = _make_store(tmp_path)
+    v = t.create(creator="op", assignee="validator", title="v")
+    t.update_status(v["id"], "working", actor="validator")
+    t.update_status(v["id"], "done", actor="validator")
+    v_prime = t.create_rework_task(v["id"], "retry once", actor="op")
+    t.update_status(v_prime["id"], "working", actor="validator")
+    t.update_status(v_prime["id"], "done", actor="validator")
+    v_pp = t.create_rework_task(v_prime["id"], "retry twice", actor="op")
+
+    snap = t.workflow_snapshot(v["id"])
+    assert snap is not None
+    ids = {s["task_id"] for s in snap["stages"]}
+    assert {v["id"], v_prime["id"], v_pp["id"]}.issubset(ids), (
+        "multi-step rework chain must surface every generation"
+    )
+
+
+def test_workflow_snapshot_rework_not_duplicated_when_reachable_by_both_edges(
+    tmp_path,
+):
+    """A rework whose ``parent_task_id`` AND ``previous_task_id`` both
+    fall inside the chain (e.g. rework of the root task) must appear
+    exactly once. The ``IN (SELECT DISTINCT id FROM chain)`` outer
+    dedup is what enforces this."""
+    t = _make_store(tmp_path)
+    # Root task with no parent. Rework of root: previous_task_id=root,
+    # parent_task_id=NULL (root has no parent). Reachable via
+    # previous_task_id edge but NOT parent_task_id — exercise the
+    # one-edge path. Then add a second rework that DOES have its
+    # parent in the chain to exercise the two-edge dedup path.
+    root = t.create(creator="op", assignee="writer", title="root")
+    t.update_status(root["id"], "working", actor="writer")
+    t.update_status(root["id"], "done", actor="writer")
+    rework = t.create_rework_task(root["id"], "redo", actor="op")
+    # Force the rework's parent_task_id to point at root via a direct
+    # write — simulates a future code path that explicitly threads
+    # the failed task as parent. This is the dual-edge dedup case.
+    with t._conn() as conn:
+        conn.execute(
+            "UPDATE tasks SET parent_task_id = ? WHERE id = ?",
+            (root["id"], rework["id"]),
+        )
+
+    snap = t.workflow_snapshot(root["id"])
+    assert snap is not None
+    ids = [s["task_id"] for s in snap["stages"]]
+    assert ids.count(rework["id"]) == 1, (
+        f"rework reachable via both edges must appear exactly once, "
+        f"got {ids.count(rework['id'])}"
+    )
+
+
+def test_workflow_snapshot_orphan_rework_surfaces_from_failed_root(tmp_path):
+    """A rework whose ``parent_task_id`` is outside any chain (orphan
+    parent or NULL) must still surface when the snapshot is rooted at
+    its predecessor via ``previous_task_id``. Exercises the case where
+    the predecessor IS the kickoff (its parent is NULL)."""
+    t = _make_store(tmp_path)
+    kickoff = t.create(creator="op", assignee="writer", title="kickoff")
+    t.update_status(kickoff["id"], "working", actor="writer")
+    t.update_status(kickoff["id"], "done", actor="writer")
+    # Rework of kickoff — inherits kickoff's parent (NULL) so parent
+    # chain dead-ends. Only the previous_task_id edge connects it.
+    rework = t.create_rework_task(kickoff["id"], "redo", actor="op")
+    assert rework["parent_task_id"] is None
+
+    snap = t.workflow_snapshot(kickoff["id"])
+    assert snap is not None
+    ids = {s["task_id"] for s in snap["stages"]}
+    assert rework["id"] in ids
+
+
+def test_workflow_snapshot_terminal_flag_unaffected_by_rework_descendant(
+    tmp_path,
+):
+    """``terminal_without_children`` is the *workflow*-chain marker.
+    A rework spawned via ``previous_task_id`` is NOT a downstream
+    handoff — it's a retry — so the predecessor's
+    ``terminal_without_children`` flag must stay True. Mirrors the
+    chain_breaks_24h semantic pinned by
+    ``test_previous_task_id_chain_does_not_suppress_chain_break``.
+    """
+    t = _make_store(tmp_path)
+    stage = t.create(creator="op", assignee="writer", title="leaf")
+    t.update_status(stage["id"], "working", actor="writer")
+    t.update_status(stage["id"], "done", actor="writer")
+    rework = t.create_rework_task(stage["id"], "redo", actor="op")
+
+    snap = t.workflow_snapshot(stage["id"])
+    assert snap is not None
+    by_id = {s["task_id"]: s for s in snap["stages"]}
+    # The predecessor is a done leaf — no parent_task_id descendant.
+    # Even though the rework references it via previous_task_id,
+    # terminal_without_children stays True.
+    assert by_id[stage["id"]]["terminal_without_children"] is True, (
+        "rework via previous_task_id must NOT suppress the predecessor's "
+        "chain-break flag — that flag is about workflow handoffs"
+    )
+    # The rework itself is pending — flag is False (not 'done').
+    assert by_id[rework["id"]]["terminal_without_children"] is False


### PR DESCRIPTION
## Summary

Two operator-reported bugs from the latest E2E pipeline session, plus codex review follow-ups.

### Bug 5 — workflow_snapshot misses recovery descendants

The operator's heartbeat polls \`workflow_snapshot\` to see the state of an in-flight workflow chain. The recursive CTE walked \`parent_task_id\` only, so rework tasks (spawned by \`create_rework_task\`) — which inherit the failed task's parent (NOT pointing back to the failed task) — were invisible from a snapshot rooted at the failed task. Orphan reworks (parent NULL or outside chain) were invisible from any root.

Fix: extend CTE to walk BOTH \`parent_task_id\` and \`previous_task_id\` edges; \`IN (SELECT DISTINCT id FROM chain)\` dedupes the rare two-edge case. Each rework stage now surfaces \`previous_task_id\` so the operator can identify lineage without an extra \`get_task\` call.

Critically, \`chain_breaks_24h\` and \`terminal_without_children\` semantic UNCHANGED — a rework is a retry of the same stage, not a downstream handoff, and counts as a chain break. Pinned by the existing \`test_previous_task_id_chain_does_not_suppress_chain_break\`.

### Bug 2 — chat assistant messages disappeared mid-tool

Two distinct gaps remained after PR #957's partial-write fix:

**(A) Server-side**: \`_chat_inner\` and \`_chat_stream_inner\` exception handlers (LLMAuthError / LLMConfigError / generic Exception) and tool-loop terminate paths called \`append_chat_message(\"assistant\", msg)\` without \`turn_id\`. The earlier \`partial=True\` entry stayed orphaned on disk next to a separate \"Error: ...\" / \"Stopped: ...\" bubble.

Fix: new \`_finalize_chat_turn\` helper writes ONE final entry sharing the partial's \`turn_id\` with content = \`<accumulated text>\\n\\n<closing>\`. \`load_chat_transcript\`'s dedupe replaces the partial cleanly. Used at all 8 abnormal-close sites (3 exception × 2 functions + 1 terminate × 2). Helper rejects empty \`turn_id\` with ValueError so a future refactor can't silently regress to the orphaned-partial bug.

**(B) Client-side**: WS reconnect handler in app.js cleared \`_chatFetchedAt\` but \`_loadChatHistory\` still early-returned because \`chatStreamingAgents[id]\` was stuck true (set on text_delta, cleared only on chat_done — the disconnect ate the chat_done). Reset all per-agent ephemeral chat-stream state on reconnect — BUT guard the wipe per-agent against active local SSE streams: \`_chatAborts[id]\` is the AbortController for the in-flight \`/chat/stream\` fetch, and wiping it mid-stream would kill our handle on the local render target.

### Codex review notes addressed

- P1: WS reconnect now skips agents with active local SSE streams (per-agent guard on both the state wipe AND the refetch loop).
- P2: \`_finalize_chat_turn\` requires a non-empty \`turn_id\` (raises ValueError otherwise).
- P2: server.py \`/mesh/tasks/workflow/{root_task_id}\` docstring updated to mention previous_task_id traversal.

## Test plan

- [x] 6 new tests pinning workflow_snapshot rework discovery (failed-task root, kickoff root, multi-step chain, dedup, orphan parent, terminal-flag preservation)
- [x] 7 new tests pinning _finalize_chat_turn helper behavior and the end-to-end wiring through _chat_inner's LLMConfigError path and _chat_stream_inner's generic Exception path
- [x] 1 new test for empty-turn_id rejection
- [x] Existing \`test_previous_task_id_chain_does_not_suppress_chain_break\` still passes (semantic preserved)
- [x] Full suite: 6448 passed, 49 skipped, 0 failures
- [x] Ruff clean
- [ ] Manual smoke: trigger an SEO-pipeline E2E where validator fails → confirm rework surfaces in workflow_snapshot rooted at the failed validator
- [ ] Manual smoke: send chat message that triggers a long blocking tool, drop WS mid-tool, verify the in-flight bubble persists and resumes after reconnect