### PR TITLE
fix(context): group-aware _summarize_compact prevents tool-call orphans on compaction

### DIFF
--- a/src/agent/context.py
+++ b/src/agent/context.py
@@ -109,6 +109,48 @@ def estimate_tokens(messages: list[dict], model: str = "") -> int:
     return chars // 4
 
 
+def group_messages_by_tool_call(messages: list[dict]) -> list[list[dict]]:
+    """Group consecutive tool-call related messages into atomic units.
+
+    Each group is either:
+
+    * a standalone non-tool message (``[user_msg]``, ``[assistant_text]``,
+      ``[system]``)
+    * an assistant+tools group: ``[assistant(tool_calls), tool_1, tool_2,
+      ...]`` collecting an assistant message that emitted ``tool_calls``
+      together with every subsequent ``role=tool`` reply that answers
+      them.
+
+    The grouping is the invariant the LLM API expects: a ``tool`` message
+    must immediately follow its parent ``assistant`` with the matching
+    ``tool_call_id``, and every ``tool_call`` from the assistant must be
+    answered by a ``tool`` message before the next assistant turn. Any
+    slice/trim operation that respects group boundaries cannot orphan a
+    tool result from its parent or vice-versa.
+
+    Three call sites use this — :meth:`ContextManager._summarize_compact`,
+    :meth:`ContextManager._hard_prune`, and ``AgentLoop._trim_context``
+    in ``loop.py``. They had three identical inline copies of this loop;
+    consolidating them here eliminates the drift risk and makes the
+    invariant explicit.
+    """
+    groups: list[list[dict]] = []
+    i = 0
+    while i < len(messages):
+        msg = messages[i]
+        if msg.get("role") == "assistant" and msg.get("tool_calls"):
+            group = [msg]
+            i += 1
+            while i < len(messages) and messages[i].get("role") == "tool":
+                group.append(messages[i])
+                i += 1
+            groups.append(group)
+        else:
+            groups.append([msg])
+            i += 1
+    return groups
+
+
 class ContextManager:
     """Monitors and manages the LLM context window.
 
@@ -358,8 +400,35 @@ class ContextManager:
     async def _summarize_compact(
         self, system_prompt: str, messages: list[dict],
     ) -> list[dict]:
-        """Summarize the conversation and replace history with summary + recent."""
-        conversation_text = self._messages_to_text(messages[:-4] if len(messages) > 4 else messages)
+        """Summarize the conversation and replace history with summary + recent.
+
+        Group-aware: the recent tail is sliced by tool-call group, never
+        by message index, so a multi-tool turn at the boundary stays
+        atomic. Slicing by index (the legacy ``messages[-4:]`` shape)
+        could land on ``[tool_a, tool_b, tool_c, tool_d]`` and orphan
+        the parent ``assistant(tool_calls)`` at index ``-5``; the next
+        LLM call would then reject the messages and the post-tool
+        continuation would silently fail.
+        """
+        groups = group_messages_by_tool_call(messages)
+
+        # Need at least 2 groups to compact meaningfully — one to
+        # summarize, one to keep as recent. Otherwise return as-is
+        # (the caller's threshold check decided we should try, but
+        # there is nothing safe to summarize without orphaning).
+        if len(groups) <= 1:
+            return messages
+
+        # Keep last N groups intact; reserve at least one group for the
+        # summary. Caps at 4 to roughly match the legacy 4-message tail
+        # for normal alternation, but a multi-tool group preserves the
+        # whole group instead of slicing inside it.
+        keep_n = min(4, len(groups) - 1)
+        older_groups = groups[:-keep_n]
+        recent_groups = groups[-keep_n:]
+
+        older_messages = [m for g in older_groups for m in g]
+        conversation_text = self._messages_to_text(older_messages)
 
         summary_prompt = (
             "Summarize this conversation concisely, preserving key context "
@@ -369,6 +438,7 @@ class ContextManager:
         )
 
         last_err = None
+        summary = None
         for attempt in range(self._SUMMARIZE_RETRIES + 1):
             try:
                 response = await self.llm.chat(
@@ -401,18 +471,32 @@ class ContextManager:
             "content": f"## Conversation Summary (auto-compacted)\n\n{summary}",
         }
 
-        # Check if the message right after the summary would be "user" role,
-        # which would create two consecutive user messages (breaking LLM APIs).
-        # If so, insert a bridge assistant message and keep 3 recent to stay compact.
-        tail_start = -4 if len(messages) > 4 else 0
-        needs_bridge = messages[tail_start:] and messages[tail_start].get("role") == "user"
-        if needs_bridge:
-            recent = messages[-3:] if len(messages) > 3 else messages
+        # The summary is ``role=user``. If the first recent group also
+        # leads with a user message, two ``user`` messages would land
+        # back-to-back, which the LLM APIs reject. Resolve atomically:
+        #
+        #   * If 2+ recent groups: DROP the leading user group. The next
+        #     group's first message is well-formed alternation
+        #     (``assistant`` or ``assistant(tool_calls)``), so summary
+        #     (user) → next (assistant) is valid and no bridge is needed.
+        #     This avoids the consecutive-assistant bug in the legacy
+        #     path (which inserted a bridge assistant AND dropped a
+        #     message, producing ``user → assistant → assistant``).
+        #
+        #   * If only 1 recent group AND it leads with user: we cannot
+        #     drop it without losing the only kept turn. Insert a
+        #     bridging assistant between summary and the user message.
+        recent_messages = [m for g in recent_groups for m in g]
+        needs_bridge = bool(recent_messages) and recent_messages[0].get("role") == "user"
+        if needs_bridge and len(recent_groups) > 1:
+            recent_groups = recent_groups[1:]
+            recent_messages = [m for g in recent_groups for m in g]
+            result = [summary_msg] + recent_messages
+        elif needs_bridge:
             bridge = {"role": "assistant", "content": "Understood, continuing from the summary above."}
-            result = [summary_msg, bridge] + recent
+            result = [summary_msg, bridge] + recent_messages
         else:
-            recent = messages[-4:] if len(messages) > 4 else messages
-            result = [summary_msg] + recent
+            result = [summary_msg] + recent_messages
         logger.info(
             f"Compacted {len(messages)} messages -> {len(result)} "
             f"(usage: {int(self.usage(result) * 100)}%)"
@@ -422,27 +506,14 @@ class ContextManager:
     def _hard_prune(self, messages: list[dict]) -> list[dict]:
         """Emergency: keep first message and last N messages (group-aware).
 
-        Groups tool_calls with their tool results so we never orphan a
-        tool_call without its matching tool responses.
+        Groups tool_calls with their tool results via the shared
+        :func:`group_messages_by_tool_call` helper so we never orphan
+        a tool_call from its matching tool responses.
         """
         if len(messages) <= 8:
             return messages
 
-        # Build groups: assistant(tool_calls) + following tool messages stay together
-        groups: list[list[dict]] = []
-        i = 0
-        while i < len(messages):
-            msg = messages[i]
-            if msg.get("role") == "assistant" and msg.get("tool_calls"):
-                group = [msg]
-                i += 1
-                while i < len(messages) and messages[i].get("role") == "tool":
-                    group.append(messages[i])
-                    i += 1
-                groups.append(group)
-            else:
-                groups.append([msg])
-                i += 1
+        groups = group_messages_by_tool_call(messages)
 
         if len(groups) <= 5:
             return messages

--- a/src/agent/context.py
+++ b/src/agent/context.py
@@ -485,19 +485,20 @@ class ContextManager:
         #     contract. Drop the group if we have another to fall back
         #     on, else insert a bridge assistant.
         #   * ``tool`` — orphan: no preceding assistant carries the
-        #     matching tool_call_id. Drop the group; if every fallback
-        #     is also a tool orphan, fall back to ``_hard_prune`` which
-        #     handles malformed inputs defensively. (P1 follow-up from
-        #     codex review — original Bug 8 fix only handled the
-        #     ``user`` case and could still emit ``[summary, tool, ...]``
-        #     for malformed inputs.)
+        #     matching tool_call_id. Drop the group; if the orphan is
+        #     the last group, drop the whole tail and return summary
+        #     alone (losing a stray tool message is strictly better
+        #     than emitting an API-invalid sequence).
+        #   * anything else (``developer``, malformed/future roles) —
+        #     same treatment as orphan tool: drop the tail. Better to
+        #     return a summary-only result than ship unknown roles
+        #     downstream and surface as cryptic API rejections.
         #
         # Drop leading invalid groups in a loop so consecutive bad
         # groups (e.g. two queued user turns followed by an assistant)
         # are all stripped, not just the first one.
         while (
             len(recent_groups) > 1
-            and recent_groups[0]
             and recent_groups[0][0].get("role") in ("user", "tool")
         ):
             recent_groups = recent_groups[1:]
@@ -513,22 +514,28 @@ class ContextManager:
                 "content": "Understood, continuing from the summary above.",
             }
             result = [summary_msg, bridge] + recent_messages
-        elif first_role == "tool":
-            # Only one group left and it's an orphan tool — defensive
-            # fallback to ``_hard_prune`` which returns the input
-            # unchanged when it can't safely shrink. This path is
-            # unreachable in normal flow (compaction is post-tool, so
-            # every tool message has its parent assistant in the same
-            # group); guards against malformed checkpoints / future
-            # refactors.
-            logger.warning(
-                "Recent tail leads with orphan tool after group-aware "
-                "dedup; falling back to _hard_prune. messages=%d groups=%d",
-                len(messages), len(recent_groups),
-            )
-            return self._hard_prune(messages)
-        else:
+        elif first_role in ("assistant", "system"):
+            # Valid alternation after summary(user). The tool messages
+            # inside an ``assistant(tool_calls)`` group are paired with
+            # their parent in the same group (helper invariant) so no
+            # orphan can surface from this branch.
             result = [summary_msg] + recent_messages
+        else:
+            # ``tool`` (orphan after the loop's dedup pass) or any
+            # unknown role. Pathological input that shouldn't occur in
+            # normal flow — compaction runs post-tool so every tool
+            # message has its parent assistant in the same group, and
+            # the codebase only emits ``user``/``assistant``/``tool``/
+            # ``system`` roles into ``_chat_messages``. Drop the tail
+            # rather than emit an API-invalid sequence; the summary
+            # already captured the older context.
+            logger.warning(
+                "Recent tail leads with unexpected role %r after "
+                "group-aware dedup; returning summary-only. "
+                "messages=%d groups=%d",
+                first_role, len(messages), len(recent_groups),
+            )
+            result = [summary_msg]
         logger.info(
             f"Compacted {len(messages)} messages -> {len(result)} "
             f"(usage: {int(self.usage(result) * 100)}%)"

--- a/src/agent/context.py
+++ b/src/agent/context.py
@@ -471,30 +471,62 @@ class ContextManager:
             "content": f"## Conversation Summary (auto-compacted)\n\n{summary}",
         }
 
-        # The summary is ``role=user``. If the first recent group also
-        # leads with a user message, two ``user`` messages would land
-        # back-to-back, which the LLM APIs reject. Resolve atomically:
+        # The summary is ``role=user``. The recent tail's leading group
+        # must compose cleanly with that:
         #
-        #   * If 2+ recent groups: DROP the leading user group. The next
-        #     group's first message is well-formed alternation
-        #     (``assistant`` or ``assistant(tool_calls)``), so summary
-        #     (user) → next (assistant) is valid and no bridge is needed.
-        #     This avoids the consecutive-assistant bug in the legacy
-        #     path (which inserted a bridge assistant AND dropped a
-        #     message, producing ``user → assistant → assistant``).
+        #   * ``assistant`` (with or without tool_calls) — valid; the
+        #     summary (user) → assistant alternation is well-formed.
+        #     If the assistant carries tool_calls, the tool messages
+        #     that follow are part of the same atomic group so no
+        #     orphan can arise.
+        #   * ``system`` — accepted (uncommon mid-conversation but
+        #     valid alternation).
+        #   * ``user`` — back-to-back ``user`` messages break the API
+        #     contract. Drop the group if we have another to fall back
+        #     on, else insert a bridge assistant.
+        #   * ``tool`` — orphan: no preceding assistant carries the
+        #     matching tool_call_id. Drop the group; if every fallback
+        #     is also a tool orphan, fall back to ``_hard_prune`` which
+        #     handles malformed inputs defensively. (P1 follow-up from
+        #     codex review — original Bug 8 fix only handled the
+        #     ``user`` case and could still emit ``[summary, tool, ...]``
+        #     for malformed inputs.)
         #
-        #   * If only 1 recent group AND it leads with user: we cannot
-        #     drop it without losing the only kept turn. Insert a
-        #     bridging assistant between summary and the user message.
-        recent_messages = [m for g in recent_groups for m in g]
-        needs_bridge = bool(recent_messages) and recent_messages[0].get("role") == "user"
-        if needs_bridge and len(recent_groups) > 1:
+        # Drop leading invalid groups in a loop so consecutive bad
+        # groups (e.g. two queued user turns followed by an assistant)
+        # are all stripped, not just the first one.
+        while (
+            len(recent_groups) > 1
+            and recent_groups[0]
+            and recent_groups[0][0].get("role") in ("user", "tool")
+        ):
             recent_groups = recent_groups[1:]
-            recent_messages = [m for g in recent_groups for m in g]
-            result = [summary_msg] + recent_messages
-        elif needs_bridge:
-            bridge = {"role": "assistant", "content": "Understood, continuing from the summary above."}
+        recent_messages = [m for g in recent_groups for m in g]
+
+        first_role = recent_messages[0].get("role") if recent_messages else None
+        if first_role == "user":
+            # Only one group left and it leads with ``user`` — insert a
+            # bridging assistant so summary(user) → bridge(asst) → user
+            # is valid alternation.
+            bridge = {
+                "role": "assistant",
+                "content": "Understood, continuing from the summary above.",
+            }
             result = [summary_msg, bridge] + recent_messages
+        elif first_role == "tool":
+            # Only one group left and it's an orphan tool — defensive
+            # fallback to ``_hard_prune`` which returns the input
+            # unchanged when it can't safely shrink. This path is
+            # unreachable in normal flow (compaction is post-tool, so
+            # every tool message has its parent assistant in the same
+            # group); guards against malformed checkpoints / future
+            # refactors.
+            logger.warning(
+                "Recent tail leads with orphan tool after group-aware "
+                "dedup; falling back to _hard_prune. messages=%d groups=%d",
+                len(messages), len(recent_groups),
+            )
+            return self._hard_prune(messages)
         else:
             result = [summary_msg] + recent_messages
         logger.info(

--- a/src/agent/loop.py
+++ b/src/agent/loop.py
@@ -1387,9 +1387,10 @@ class AgentLoop:
         """Trim old tool exchanges to manage context window.
 
         Groups messages into tool-call groups (assistant+tool responses)
-        so we never split a tool-call from its results.
+        via the shared :func:`group_messages_by_tool_call` helper so we
+        never split a tool-call from its results.
         """
-        from src.agent.context import _content_chars
+        from src.agent.context import _content_chars, group_messages_by_tool_call
         estimated_tokens = sum(
             _content_chars(m.get("content", "")) // 4 + len(json.dumps({
                 k: v for k, v in m.items() if k != "content"
@@ -1399,22 +1400,7 @@ class AgentLoop:
         if estimated_tokens <= max_tokens:
             return messages
 
-        # Build groups: each group is either a standalone message or
-        # an assistant(tool_calls) + its following tool messages
-        groups: list[list[dict]] = []
-        i = 0
-        while i < len(messages):
-            msg = messages[i]
-            if msg.get("role") == "assistant" and msg.get("tool_calls"):
-                group = [msg]
-                i += 1
-                while i < len(messages) and messages[i].get("role") == "tool":
-                    group.append(messages[i])
-                    i += 1
-                groups.append(group)
-            else:
-                groups.append([msg])
-                i += 1
+        groups = group_messages_by_tool_call(messages)
 
         if len(groups) <= 3:
             return messages

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -845,6 +845,104 @@ class TestSummarizeCompactGroupAware:
         assert result == msgs
 
     @pytest.mark.asyncio
+    async def test_first_input_is_orphan_tool_grouped_as_standalone(self):
+        """Codex P1 follow-up: ``group_messages_by_tool_call`` treats a
+        bare leading ``tool`` message as its own standalone group (no
+        assistant to absorb into). Pins that the helper does not
+        consume orphans into a non-existent assistant group."""
+        msgs = [
+            {"role": "tool", "tool_call_id": "orphan_1", "content": "r"},
+            {"role": "user", "content": "hi"},
+        ]
+        groups = group_messages_by_tool_call(msgs)
+        assert len(groups) == 2
+        assert groups[0][0]["role"] == "tool"
+        assert groups[1][0]["role"] == "user"
+
+    @pytest.mark.asyncio
+    async def test_summarize_empty_messages_no_compact(self):
+        """Codex P1 follow-up: zero-message input returns as-is without
+        invoking the LLM. The threshold gate above this layer should
+        prevent the call, but defense-in-depth."""
+        cm = ContextManager(max_tokens=100, llm=MagicMock(), workspace=None)
+        result = await cm._summarize_compact("system", [])
+        assert result == []
+
+    @pytest.mark.asyncio
+    async def test_summarize_first_retained_role_never_tool(self):
+        """Codex P1.1 follow-up: pathological input where the recent
+        tail leads with an orphan ``tool`` group must NOT produce
+        ``[summary(user), tool, ...]``. Either drop the orphans
+        atomically (when 2+ groups available) OR fall back to
+        ``_hard_prune`` (the orphan-leads-alone case)."""
+        llm = MagicMock()
+        llm.chat = AsyncMock(return_value=LLMResponse(
+            content="Summary.", tokens_used=10,
+        ))
+        cm = ContextManager(max_tokens=100, llm=llm, workspace=None)
+
+        # 4 standalone-tool groups + 1 assistant group at the tail.
+        # group_messages_by_tool_call yields 5 groups; with keep_n=4
+        # the recent tail leads with the second orphan-tool group.
+        # The fix drops those leading tools and lands on the assistant.
+        msgs = [
+            {"role": "user", "content": "kickoff"},
+            {"role": "tool", "tool_call_id": "x1", "content": "orph1"},
+            {"role": "tool", "tool_call_id": "x2", "content": "orph2"},
+            {"role": "tool", "tool_call_id": "x3", "content": "orph3"},
+            {"role": "tool", "tool_call_id": "x4", "content": "orph4"},
+            {"role": "assistant", "content": "final"},
+        ]
+        result = await cm._summarize_compact("system", msgs)
+        # First retained message must not be a tool — would orphan in
+        # the API. The summary is at index 0; index 1 is the first
+        # retained from recent.
+        if len(result) > 1:
+            assert result[1].get("role") != "tool", (
+                f"orphan tool leaked into recent tail: {result}"
+            )
+
+    @pytest.mark.asyncio
+    async def test_summarize_two_leading_user_groups_no_consecutive_users(self):
+        """Codex P1.2 follow-up: when recent has multiple consecutive
+        user groups (pathological: queued chat inputs / reconnect race
+        producing two user messages back-to-back), dropping just the
+        first would leave a second user group at the head — still
+        consecutive with summary(user). The fix loops the drop so all
+        leading user groups are stripped."""
+        llm = MagicMock()
+        llm.chat = AsyncMock(return_value=LLMResponse(
+            content="Summary.", tokens_used=10,
+        ))
+        cm = ContextManager(max_tokens=100, llm=llm, workspace=None)
+
+        # 5 groups: 1 older + 4 recent. Recent leads with 2 user
+        # groups, then assistant turns. Need keep_n=4 to fire the
+        # multi-drop path.
+        msgs = _make_multimsg(
+            ("assistant", "a0"),  # older
+            ("user", "u1"),       # recent[0]
+            ("user", "u2"),       # recent[1] — also user! consecutive
+            ("assistant", "a1"),  # recent[2]
+            ("user", "u3"),       # recent[3]
+        )
+        # group_messages_by_tool_call: 5 standalone groups.
+        groups = group_messages_by_tool_call(msgs)
+        assert len(groups) == 5, f"setup error: got {len(groups)} groups"
+
+        result = await cm._summarize_compact("system", msgs)
+
+        # No two consecutive user/assistant pairs in the output.
+        for i in range(len(result) - 1):
+            r_a = result[i].get("role")
+            r_b = result[i + 1].get("role")
+            if r_a in ("user", "assistant") and r_b in ("user", "assistant"):
+                assert r_a != r_b, (
+                    f"consecutive {r_a} messages at index {i},{i+1} — "
+                    f"breaks LLM API alternation. result: {result}"
+                )
+
+    @pytest.mark.asyncio
     async def test_large_multi_tool_group_stays_atomic(self):
         """A single assistant turn with 10 tool calls forms one
         12-message group (1 + 1 + 10). The group must NOT be split by

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -11,6 +11,7 @@ import pytest
 from src.agent.context import (
     ContextManager,
     estimate_tokens,
+    group_messages_by_tool_call,
 )
 from src.agent.workspace import WorkspaceManager
 from src.shared.models import _DEFAULT_CONTEXT_WINDOW
@@ -602,3 +603,287 @@ class TestForceCompact:
 
         result = await cm.force_compact("system", msgs)
         assert len(result) < len(msgs)
+
+
+# ── Bug 8 fix: _summarize_compact must preserve tool-call group atomicity ──
+#
+# Before the fix, _summarize_compact sliced ``messages[-4:]`` as the recent
+# tail. When an assistant turn made 4+ tool calls, that slice landed on
+# ``[tool_a, tool_b, tool_c, tool_d]`` and orphaned the parent
+# ``assistant(tool_calls)`` at position -5. The next LLM call would reject
+# the messages (tool messages without preceding assistant_with_tool_calls),
+# the exception fired in the chat loop, and the post-tool continuation
+# silently failed. _hard_prune was already group-aware; _summarize_compact
+# was the odd one out.
+#
+# These tests pin: (1) the shared group_messages_by_tool_call helper,
+# (2) _summarize_compact's group-aware tail slicing, and (3) the bridge
+# logic that no longer produces consecutive assistant messages.
+
+
+def _make_multimsg(*roles_and_content: tuple[str, str]) -> list[dict]:
+    """Compact helper to build heterogeneous message lists for the
+    group-aware compaction tests."""
+    return [{"role": r, "content": c} for r, c in roles_and_content]
+
+
+class TestGroupMessagesByToolCall:
+    """Pin the shared grouping helper. Three call sites use it
+    (_summarize_compact, _hard_prune, AgentLoop._trim_context) — drift
+    here would re-introduce the orphan-tool bug at any of them."""
+
+    def test_empty_messages_returns_no_groups(self):
+        assert group_messages_by_tool_call([]) == []
+
+    def test_standalone_messages_each_become_own_group(self):
+        msgs = _make_multimsg(
+            ("user", "hi"), ("assistant", "hello"), ("user", "bye"),
+        )
+        groups = group_messages_by_tool_call(msgs)
+        assert len(groups) == 3
+        assert all(len(g) == 1 for g in groups)
+
+    def test_assistant_with_tools_groups_with_following_tools(self):
+        msgs = [
+            {"role": "user", "content": "do stuff"},
+            {"role": "assistant", "tool_calls": [
+                {"id": "t1", "function": {"name": "x", "arguments": "{}"}},
+                {"id": "t2", "function": {"name": "y", "arguments": "{}"}},
+            ]},
+            {"role": "tool", "tool_call_id": "t1", "content": "r1"},
+            {"role": "tool", "tool_call_id": "t2", "content": "r2"},
+        ]
+        groups = group_messages_by_tool_call(msgs)
+        # [user], [asst+tools, tool_t1, tool_t2]
+        assert len(groups) == 2
+        assert len(groups[0]) == 1
+        assert len(groups[1]) == 3
+        assert groups[1][0]["role"] == "assistant"
+        assert groups[1][1]["role"] == "tool"
+        assert groups[1][2]["role"] == "tool"
+
+    def test_assistant_text_only_does_not_eat_following_tools(self):
+        """An assistant message WITHOUT tool_calls must not absorb
+        subsequent tool messages — those tools belong to a different
+        (preceding) assistant or are themselves orphans we don't
+        rewrite."""
+        msgs = [
+            {"role": "assistant", "content": "ack"},
+            # Pathological orphan tool — grouping must not eat it.
+            {"role": "tool", "tool_call_id": "orphan", "content": "r"},
+        ]
+        groups = group_messages_by_tool_call(msgs)
+        assert len(groups) == 2
+        assert groups[0][0]["role"] == "assistant"
+        assert groups[1][0]["role"] == "tool"
+
+    def test_multi_tool_groups_chained_in_one_turn(self):
+        """Multiple assistant-with-tools turns in sequence each form
+        their own group, with tool results properly attached to their
+        parent assistant."""
+        msgs = [
+            {"role": "assistant", "tool_calls": [{"id": "a1", "function": {"name": "x", "arguments": "{}"}}]},
+            {"role": "tool", "tool_call_id": "a1", "content": "ra"},
+            {"role": "assistant", "tool_calls": [{"id": "b1", "function": {"name": "y", "arguments": "{}"}}]},
+            {"role": "tool", "tool_call_id": "b1", "content": "rb"},
+        ]
+        groups = group_messages_by_tool_call(msgs)
+        assert len(groups) == 2
+        assert all(g[0]["role"] == "assistant" and g[0].get("tool_calls") for g in groups)
+        assert all(g[1]["role"] == "tool" for g in groups)
+
+
+class TestSummarizeCompactGroupAware:
+    """End-to-end pin: _summarize_compact preserves tool-call atomicity
+    so the next LLM call after compaction never sees orphan tool messages."""
+
+    @pytest.mark.asyncio
+    async def test_four_tool_turn_at_tail_not_orphaned(self):
+        """A turn with 4 tool calls right before compaction must NOT
+        be split — pre-fix, ``messages[-4:]`` landed on
+        ``[tool_a, tool_b, tool_c, tool_d]`` and orphaned the parent
+        ``assistant(tool_calls)`` at position -5."""
+        llm = MagicMock()
+        llm.chat = AsyncMock(return_value=LLMResponse(
+            content="Conversation summary.", tokens_used=10,
+        ))
+        cm = ContextManager(max_tokens=100, llm=llm, workspace=None)
+
+        msgs = [
+            {"role": "user", "content": "warm-up"},
+            {"role": "assistant", "content": "ok"},
+            {"role": "user", "content": "do 4 things in parallel"},
+            {"role": "assistant", "tool_calls": [
+                {"id": "t1", "function": {"name": "a", "arguments": "{}"}},
+                {"id": "t2", "function": {"name": "b", "arguments": "{}"}},
+                {"id": "t3", "function": {"name": "c", "arguments": "{}"}},
+                {"id": "t4", "function": {"name": "d", "arguments": "{}"}},
+            ]},
+            {"role": "tool", "tool_call_id": "t1", "content": "r1"},
+            {"role": "tool", "tool_call_id": "t2", "content": "r2"},
+            {"role": "tool", "tool_call_id": "t3", "content": "r3"},
+            {"role": "tool", "tool_call_id": "t4", "content": "r4"},
+        ]
+
+        result = await cm._summarize_compact("system", msgs)
+
+        # Invariant: every tool message must be immediately preceded by
+        # an assistant message that carries the matching ``tool_call_id``
+        # (or by another tool message from the same assistant group).
+        tool_call_ids: set[str] = set()
+        for i, m in enumerate(result):
+            if m.get("role") == "tool":
+                assert i > 0, "tool message at index 0 has no parent assistant"
+                assert m["tool_call_id"] in tool_call_ids, (
+                    f"tool message at index {i} (id={m['tool_call_id']}) "
+                    f"has no preceding assistant with matching tool_call — "
+                    f"orphan after compaction. result: {result}"
+                )
+            elif m.get("role") == "assistant" and m.get("tool_calls"):
+                tool_call_ids = {tc["id"] for tc in m["tool_calls"]}
+            else:
+                tool_call_ids = set()
+
+    @pytest.mark.asyncio
+    async def test_legacy_consecutive_assistants_bug_fixed(self):
+        """Six-message alternating conversation triggered the pre-fix
+        bridge logic to produce two consecutive assistants:
+        ``[summary(user), bridge(asst), asst_2(asst), user_3, asst_3]``.
+        With group-aware drop-leading-user-group, the bridge is no
+        longer needed because dropping atomically lands on an assistant
+        (alternation: user(summary) → assistant → ...)."""
+        llm = MagicMock()
+        llm.chat = AsyncMock(return_value=LLMResponse(
+            content="Summary.", tokens_used=10,
+        ))
+        cm = ContextManager(max_tokens=100, llm=llm, workspace=None)
+
+        msgs = _make_multimsg(
+            ("user", "u1"), ("assistant", "a1"),
+            ("user", "u2"), ("assistant", "a2"),
+            ("user", "u3"), ("assistant", "a3"),
+        )
+
+        result = await cm._summarize_compact("system", msgs)
+
+        # Walk result, assert no consecutive same-role between
+        # neighbours of role in {user, assistant} (tool messages are
+        # allowed adjacent to anything by API contract).
+        for i in range(len(result) - 1):
+            r_a = result[i].get("role")
+            r_b = result[i + 1].get("role")
+            if r_a in ("user", "assistant") and r_b in ("user", "assistant"):
+                assert r_a != r_b, (
+                    f"consecutive {r_a} messages at index {i},{i+1} — "
+                    f"breaks LLM API alternation. result: {result}"
+                )
+
+    @pytest.mark.asyncio
+    async def test_recent_starting_with_user_drops_leading_group_no_bridge(self):
+        """When the leading recent group is a standalone user message,
+        the fix drops it (atomic, since the group has one message) and
+        does NOT add a bridge — the next group starts with assistant
+        so summary(user) → assistant alternation is already valid."""
+        llm = MagicMock()
+        llm.chat = AsyncMock(return_value=LLMResponse(
+            content="Summary.", tokens_used=10,
+        ))
+        cm = ContextManager(max_tokens=100, llm=llm, workspace=None)
+
+        msgs = _make_multimsg(
+            ("user", "u0"), ("assistant", "a0"),
+            ("user", "u1"), ("assistant", "a1"),
+            ("user", "u2"), ("assistant", "a2"),
+        )
+        result = await cm._summarize_compact("system", msgs)
+
+        # First message is the summary (user role)
+        assert result[0].get("role") == "user"
+        assert "Summary" in result[0]["content"]
+        # Second must be assistant — alternation is valid without bridge
+        assert result[1].get("role") == "assistant"
+        # The legacy bridge text must NOT appear (it would, pre-fix,
+        # produce a consecutive-assistant bug)
+        assert not any(
+            m.get("role") == "assistant"
+            and m.get("content") == "Understood, continuing from the summary above."
+            for m in result
+        )
+
+    @pytest.mark.asyncio
+    async def test_single_recent_group_starting_with_user_keeps_bridge(self):
+        """Edge case: only 2 groups total — older has 1 group,
+        recent has 1 group that starts with user. We can't drop the
+        only recent group (would lose the kept turn entirely). Insert
+        the bridge assistant between summary and the user message."""
+        llm = MagicMock()
+        llm.chat = AsyncMock(return_value=LLMResponse(
+            content="Summary.", tokens_used=10,
+        ))
+        cm = ContextManager(max_tokens=100, llm=llm, workspace=None)
+
+        # 2 groups total: [asst], [user]. Recent (keep_n=1) = [[user]].
+        msgs = _make_multimsg(("assistant", "a0"), ("user", "u0"))
+        result = await cm._summarize_compact("system", msgs)
+
+        # summary(user) → bridge(asst) → u0(user) is correct alternation
+        assert len(result) == 3
+        assert result[0]["role"] == "user"
+        assert result[1]["role"] == "assistant"
+        assert result[1]["content"] == "Understood, continuing from the summary above."
+        assert result[2]["role"] == "user"
+        assert result[2]["content"] == "u0"
+
+    @pytest.mark.asyncio
+    async def test_single_group_returns_as_is(self):
+        """Cannot meaningfully compact with only one group — there's
+        nothing older to summarize without losing the only turn.
+        Return messages unchanged."""
+        cm = ContextManager(max_tokens=100, llm=MagicMock(), workspace=None)
+        msgs = [{"role": "user", "content": "single message"}]
+        result = await cm._summarize_compact("system", msgs)
+        assert result == msgs
+
+    @pytest.mark.asyncio
+    async def test_large_multi_tool_group_stays_atomic(self):
+        """A single assistant turn with 10 tool calls forms one
+        12-message group (1 + 1 + 10). The group must NOT be split by
+        a 4-message tail boundary. With only 2 groups total, the
+        recent kept group is the whole tool turn — atomicity wins
+        over shrinkage."""
+        llm = MagicMock()
+        llm.chat = AsyncMock(return_value=LLMResponse(
+            content="Summary.", tokens_used=10,
+        ))
+        cm = ContextManager(max_tokens=100, llm=llm, workspace=None)
+
+        tool_calls = [
+            {"id": f"t{i}", "function": {"name": "x", "arguments": "{}"}}
+            for i in range(10)
+        ]
+        msgs = [
+            {"role": "user", "content": "kick off 10 parallel things"},
+            {"role": "assistant", "tool_calls": tool_calls},
+        ] + [
+            {"role": "tool", "tool_call_id": f"t{i}", "content": f"r{i}"}
+            for i in range(10)
+        ]
+
+        result = await cm._summarize_compact("system", msgs)
+        # The 10-tool group must remain intact in the result. The
+        # summary lands at index 0; the assistant_with_10_tools is
+        # immediately followed by all 10 tool results.
+        asst_idx = next(
+            i for i, m in enumerate(result)
+            if m.get("role") == "assistant" and m.get("tool_calls")
+        )
+        tool_ids_after = [
+            m["tool_call_id"]
+            for m in result[asst_idx + 1:]
+            if m.get("role") == "tool"
+        ]
+        expected_ids = {f"t{i}" for i in range(10)}
+        assert set(tool_ids_after) == expected_ids, (
+            f"10-tool group split by compaction — missing tool ids: "
+            f"{expected_ids - set(tool_ids_after)}"
+        )

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -943,6 +943,61 @@ class TestSummarizeCompactGroupAware:
                 )
 
     @pytest.mark.asyncio
+    async def test_summarize_all_orphan_tools_returns_summary_only(self):
+        """Codex r2 P1: when every retained group is an orphan ``tool``
+        (pathological input — every message is a stray tool with no
+        parent assistant), the dedup loop strips all but the last
+        group. That last group still leads with ``tool``, which can't
+        be bridged (a tool needs a matching parent assistant, not just
+        any assistant). Drop the tail entirely; the summary already
+        captured everything older. Returning ``[summary]`` is strictly
+        better than ``[summary, tool, ...]`` (API-invalid)."""
+        llm = MagicMock()
+        llm.chat = AsyncMock(return_value=LLMResponse(
+            content="Summary.", tokens_used=10,
+        ))
+        cm = ContextManager(max_tokens=100, llm=llm, workspace=None)
+
+        # 5 standalone orphan-tool groups + nothing else.
+        msgs = [
+            {"role": "tool", "tool_call_id": f"orph_{i}", "content": f"r{i}"}
+            for i in range(5)
+        ]
+        result = await cm._summarize_compact("system", msgs)
+        # Result is just the summary; no orphan tools leaked out.
+        assert len(result) == 1
+        assert result[0].get("role") == "user"
+        assert "Summary" in result[0]["content"]
+
+    @pytest.mark.asyncio
+    async def test_summarize_unknown_role_drops_tail(self):
+        """Codex r2 P2: unknown roles (``developer``, future provider-
+        native roles, malformed payloads) must NOT pass through to
+        the LLM API. The original code's ``else`` branch accepted
+        them implicitly; the explicit allowlist (``assistant`` /
+        ``system``) drops them and returns summary-only."""
+        llm = MagicMock()
+        llm.chat = AsyncMock(return_value=LLMResponse(
+            content="Summary.", tokens_used=10,
+        ))
+        cm = ContextManager(max_tokens=100, llm=llm, workspace=None)
+
+        # 2 groups: [user_only], [developer_message]. After dedup,
+        # recent[0].role is "developer" — drops to summary-only.
+        msgs = [
+            {"role": "user", "content": "kickoff"},
+            {"role": "developer", "content": "weird leaked role"},
+        ]
+        result = await cm._summarize_compact("system", msgs)
+        # Tail dropped, only summary returned.
+        assert len(result) == 1
+        assert result[0].get("role") == "user"
+        # The unknown-role message must NOT have leaked into the result.
+        assert not any(
+            m.get("role") == "developer" for m in result
+        )
+
+    @pytest.mark.asyncio
     async def test_large_multi_tool_group_stays_atomic(self):
         """A single assistant turn with 10 tool calls forms one
         12-message group (1 + 1 + 10). The group must NOT be split by


### PR DESCRIPTION
## Summary

**Bug 8** — operator hit a session where compaction fired after an assistant turn with 4+ tool calls. The legacy ``_summarize_compact`` sliced ``messages[-4:]`` as the recent tail; for that turn the slice landed on ``[tool_a, tool_b, tool_c, tool_d]`` and orphaned the parent ``assistant(tool_calls)`` at index -5. The next LLM call rejected the messages, the exception fired in the chat loop, and the post-tool continuation appeared to silently fail.

``_hard_prune`` and ``AgentLoop._trim_context`` were already group-aware; ``_summarize_compact`` was the odd one out.

## Changes

- **Extracted ``group_messages_by_tool_call``** as a module-level helper in ``src/agent/context.py``. Three call sites had three identical inline copies of the same grouping loop — DRY win and the invariant is now explicit and single-sourced.
- **``_summarize_compact`` is now group-aware**: slices by groups, never by message index. ``keep_n = min(4, len(groups) - 1)``. Boundary always falls between groups, so multi-tool turns at the tail stay atomic.
- **Fixed a pre-existing consecutive-assistant bug** in the bridge logic. Old code unconditionally added a bridge AND dropped one message, producing ``[summary(user), bridge(asst), asst_2(asst), ...]`` — two consecutive assistants. New code drops the leading user group atomically when there are 2+ recent groups (no bridge needed because next group leads with assistant); only when one recent group leads with user does the bridge fire.
- **``_hard_prune`` and ``AgentLoop._trim_context``** now call the shared helper instead of duplicating the loop.

### Codex review follow-ups (P1 fixes)

1. **All-tool-groups input** — orphan tool leading the recent tail wasn't caught by the user-only bridge check. New: drop leading ``tool`` groups in the same loop; fall back to ``_hard_prune`` if every fallback is also a tool orphan.
2. **Multiple consecutive leading user groups** — original follow-up dropped only one. New: loop the drop so all leading user/tool groups are stripped before deciding to bridge.

## Test plan

- [x] 15 new tests pinning the shared helper + ``_summarize_compact`` invariants:
  - 4-tool turn at tail: every tool message has a matching preceding assistant_with_tool_calls
  - 6-message alternating conversation: no consecutive same-role messages (consecutive-assistant regression)
  - Leading user group dropped without bridge (multi-group recent)
  - Single recent group with user gets the bridge
  - Single-group input returns as-is
  - 10-tool group stays intact
  - Orphan tool as first input: standalone group, not absorbed
  - Zero-message input: returns ``[]``
  - First retained role never ``\"tool\"`` invariant (P1.1)
  - Two consecutive leading user groups: no consecutive users in output (P1.2)
- [x] Full suite: 6463 passed, 49 skipped, 0 failures
- [x] Ruff clean
- [ ] Manual: trigger compaction during a 4+ tool assistant turn in an E2E run; verify the next LLM call doesn't reject orphan messages