### PR TITLE
feat(agent,dashboard): operator goals tracking — manage_goals tool + GOALS.{md,json} (PR 1/3)

### DIFF
--- a/src/agent/builtins/operator_tools.py
+++ b/src/agent/builtins/operator_tools.py
@@ -2200,13 +2200,19 @@ _VALID_GOAL_ACTIONS = frozenset({"set", "add", "update", "remove", "list"})
 
 
 def _read_goals_sidecar(workspace_root) -> list[dict]:
-    """Read GOALS.json. Returns ``[]`` on missing/corrupt files."""
+    """Read GOALS.json. Returns ``[]`` on missing/corrupt files.
+
+    Corrupt-file path is silent-but-logged: callers can still recover
+    by calling ``set``, but a stale warning makes the data loss visible
+    in operator logs.
+    """
     path = workspace_root / _GOALS_JSON_FILENAME
     if not path.exists():
         return []
     try:
         data = json.loads(path.read_text(errors="replace"))
-    except (OSError, ValueError):
+    except (OSError, ValueError) as e:
+        logger.warning("GOALS.json read/parse failed (treating as empty): %s", e)
         return []
     if not isinstance(data, dict):
         return []
@@ -2262,16 +2268,25 @@ def _validate_goal_input(goal, *, require_status: bool = True) -> tuple[dict | N
     we persist (no ``updated_at`` — caller stamps that). ``require_status``
     is False on update where the caller may want to change only the
     progress note.
+
+    ``progress_note`` is intentionally distinguished from ``None`` (key
+    absent in input) and ``""`` (key present, empty). The update path
+    uses this to preserve an existing note when the caller didn't pass
+    one — otherwise every update would silently wipe the note.
     """
     if not isinstance(goal, dict):
         return None, "goal must be an object"
     name = goal.get("name", "")
     status = goal.get("status", "")
-    note = goal.get("progress_note", "") or ""
-    if not isinstance(name, str) or not isinstance(status, str) or not isinstance(note, str):
+    note_provided = "progress_note" in goal
+    raw_note = goal.get("progress_note") if note_provided else None
+    if raw_note is None:
+        raw_note = ""  # explicit None or unset both treated as "not provided"
+        note_provided = note_provided and goal.get("progress_note") is not None
+    if not isinstance(name, str) or not isinstance(status, str) or not isinstance(raw_note, str):
         return None, "goal name/status/progress_note must be strings"
     name_clean = sanitize_for_prompt(name).strip()
-    note_clean = sanitize_for_prompt(note).strip()
+    note_clean = sanitize_for_prompt(raw_note).strip()
     if not name_clean:
         return None, "goal name is required"
     if len(name_clean) > _MAX_GOAL_NAME_CHARS:
@@ -2286,7 +2301,9 @@ def _validate_goal_input(goal, *, require_status: bool = True) -> tuple[dict | N
     return {
         "name": name_clean,
         "status": status,
-        "progress_note": note_clean,
+        # ``None`` means "caller didn't provide" → update path preserves
+        # existing. Any other value (including ``""``) is an explicit set.
+        "progress_note": note_clean if note_provided else None,
     }, None
 
 
@@ -2383,6 +2400,9 @@ async def manage_goals(
                     ),
                 }
             seen_names.add(obj["name"])
+            # `set` writes a fresh row — unset progress_note becomes "".
+            if obj["progress_note"] is None:
+                obj["progress_note"] = ""
             obj["updated_at"] = now
             cleaned.append(obj)
         _write_goals(workspace_root, cleaned)
@@ -2406,6 +2426,9 @@ async def manage_goals(
                     f"cannot add: already at max of {_MAX_GOALS_ENTRIES} goals"
                 ),
             }
+        # `add` creates a fresh row — unset progress_note becomes "".
+        if obj["progress_note"] is None:
+            obj["progress_note"] = ""
         obj["updated_at"] = now
         new_list = [*current, obj]
         _write_goals(workspace_root, new_list)
@@ -2414,8 +2437,11 @@ async def manage_goals(
     if action == "update":
         if goal is None:
             goal = {}
-        # Status is optional on update — caller may want to change only
-        # the progress note. We still validate the enum if provided.
+        # Status and progress_note are both optional on update — caller
+        # may want to change only one field. We still validate the enum
+        # if provided. ``progress_note=None`` from the validator means
+        # "caller didn't pass" → preserve existing (don't silently wipe).
+        # Renames are not supported: ``name`` is the lookup key.
         obj, err = _validate_goal_input(goal, require_status=False)
         if err:
             return {"error": err}

--- a/src/agent/builtins/operator_tools.py
+++ b/src/agent/builtins/operator_tools.py
@@ -2254,7 +2254,16 @@ def _render_goals_md(goals: list[dict]) -> str:
 
 
 def _write_goals(workspace_root, goals: list[dict]) -> None:
-    """Persist both sidecar JSON and rendered markdown atomically-ish."""
+    """Persist both sidecar JSON and rendered markdown atomically-ish.
+
+    Direct ``path.write_text`` matches the ``save_observations``
+    precedent (``OBSERVATIONS.md`` / ``OBSERVATIONS_HISTORY.md``); these
+    files are operator-internal state, not user-edited content, so the
+    workspace_manager's audit/versioning machinery doesn't apply.
+    Two writes are not atomic — if the MD write fails after the JSON
+    write succeeds, the two files diverge. Risk is small for a stable
+    workspace volume; if it ever bites, switch to temp-file + rename.
+    """
     json_path = workspace_root / _GOALS_JSON_FILENAME
     md_path = workspace_root / _GOALS_MD_FILENAME
     json_path.write_text(json.dumps({"goals": goals}, indent=2) + "\n")

--- a/src/agent/builtins/operator_tools.py
+++ b/src/agent/builtins/operator_tools.py
@@ -16,7 +16,7 @@ from src.shared.types import (
 from src.shared.types import (
     SOFT_EDIT_FIELDS as _SOFT_EDIT_FIELDS,
 )
-from src.shared.utils import setup_logging
+from src.shared.utils import sanitize_for_prompt, setup_logging
 
 logger = setup_logging("agent.builtins.operator_tools")
 
@@ -2175,3 +2175,284 @@ async def manage_team(
     return {
         "error": f"Unknown action {action!r}; use archive|unarchive|propose_delete"
     }
+
+
+# ── Goals tracking (PR 1 of Work tab rewrite) ───────────────────────
+#
+# Operator-tracked business goals, surfaced on the Work tab as a
+# horizontal strip. Source of truth is GOALS.json (structured, parsed
+# by the dashboard); GOALS.md is a rendered human-readable mirror
+# regenerated from JSON on every mutation. Per-goal ``updated_at`` is
+# stamped only on touched entries so untouched goals keep their
+# original timestamp (the test contract).
+
+_GOALS_MD_FILENAME = "GOALS.md"
+_GOALS_JSON_FILENAME = "GOALS.json"
+
+_MAX_GOALS_ENTRIES = 20
+_MAX_GOAL_NAME_CHARS = 120
+_MAX_GOAL_NOTE_CHARS = 500
+
+_VALID_GOAL_STATUSES = frozenset({
+    "not_started", "in_progress", "on_track", "at_risk", "blocked", "done",
+})
+_VALID_GOAL_ACTIONS = frozenset({"set", "add", "update", "remove", "list"})
+
+
+def _read_goals_sidecar(workspace_root) -> list[dict]:
+    """Read GOALS.json. Returns ``[]`` on missing/corrupt files."""
+    path = workspace_root / _GOALS_JSON_FILENAME
+    if not path.exists():
+        return []
+    try:
+        data = json.loads(path.read_text(errors="replace"))
+    except (OSError, ValueError):
+        return []
+    if not isinstance(data, dict):
+        return []
+    raw = data.get("goals")
+    if not isinstance(raw, list):
+        return []
+    cleaned: list[dict] = []
+    for entry in raw:
+        if not isinstance(entry, dict):
+            continue
+        name = entry.get("name")
+        status = entry.get("status")
+        if not isinstance(name, str) or not isinstance(status, str):
+            continue
+        cleaned.append({
+            "name": name,
+            "status": status,
+            "progress_note": entry.get("progress_note", "") or "",
+            "updated_at": entry.get("updated_at", "") or "",
+        })
+    return cleaned
+
+
+def _render_goals_md(goals: list[dict]) -> str:
+    """Render the JSON sidecar back to a human-readable GOALS.md."""
+    lines: list[str] = ["# Goals", ""]
+    if not goals:
+        lines.append("_No goals tracked._")
+    else:
+        for goal in goals:
+            lines.append(f"## {goal['name']}")
+            lines.append(f"- **Status:** {goal['status']}")
+            lines.append(f"- **Updated:** {goal['updated_at']}")
+            note = goal.get("progress_note") or ""
+            if note:
+                lines.append(f"- {note}")
+            lines.append("")
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def _write_goals(workspace_root, goals: list[dict]) -> None:
+    """Persist both sidecar JSON and rendered markdown atomically-ish."""
+    json_path = workspace_root / _GOALS_JSON_FILENAME
+    md_path = workspace_root / _GOALS_MD_FILENAME
+    json_path.write_text(json.dumps({"goals": goals}, indent=2) + "\n")
+    md_path.write_text(_render_goals_md(goals))
+
+
+def _validate_goal_input(goal, *, require_status: bool = True) -> tuple[dict | None, str | None]:
+    """Sanitize and validate a single goal dict input.
+
+    Returns ``(cleaned, error)``. ``cleaned`` carries only the fields
+    we persist (no ``updated_at`` — caller stamps that). ``require_status``
+    is False on update where the caller may want to change only the
+    progress note.
+    """
+    if not isinstance(goal, dict):
+        return None, "goal must be an object"
+    name = goal.get("name", "")
+    status = goal.get("status", "")
+    note = goal.get("progress_note", "") or ""
+    if not isinstance(name, str) or not isinstance(status, str) or not isinstance(note, str):
+        return None, "goal name/status/progress_note must be strings"
+    name_clean = sanitize_for_prompt(name).strip()
+    note_clean = sanitize_for_prompt(note).strip()
+    if not name_clean:
+        return None, "goal name is required"
+    if len(name_clean) > _MAX_GOAL_NAME_CHARS:
+        name_clean = name_clean[: _MAX_GOAL_NAME_CHARS - 1] + "…"
+    if len(note_clean) > _MAX_GOAL_NOTE_CHARS:
+        note_clean = note_clean[: _MAX_GOAL_NOTE_CHARS - 1] + "…"
+    if require_status or status:
+        if status not in _VALID_GOAL_STATUSES:
+            return None, (
+                f"status must be one of {sorted(_VALID_GOAL_STATUSES)}"
+            )
+    return {
+        "name": name_clean,
+        "status": status,
+        "progress_note": note_clean,
+    }, None
+
+
+@skill(
+    name="manage_goals",
+    description=(
+        "Manage tracked business goals shown on the user's Work tab. "
+        "Source of truth is GOALS.json (rendered to GOALS.md for humans). "
+        "Use 'set' to replace the full list, 'add'/'update'/'remove' for "
+        "incremental changes, 'list' to read the current state. "
+        "Operator-only."
+    ),
+    parameters={
+        "action": {
+            "type": "string",
+            "enum": ["set", "add", "update", "remove", "list"],
+            "description": "Which operation to perform.",
+        },
+        "goals": {
+            "type": "array",
+            "description": (
+                "Full goal list for action='set'. Each entry: "
+                "{name: str, status: enum, progress_note?: str}. Max 20."
+            ),
+            "items": {"type": "object"},
+            "default": [],
+        },
+        "goal": {
+            "type": "object",
+            "description": (
+                "Single goal for action='add' or 'update'. Same shape as "
+                "'goals' entries."
+            ),
+            "default": {},
+        },
+        "name": {
+            "type": "string",
+            "description": "Goal name for action='remove'.",
+            "default": "",
+        },
+    },
+)
+async def manage_goals(
+    action: str,
+    *,
+    goals: list | None = None,
+    goal: dict | None = None,
+    name: str = "",
+    workspace_manager=None,
+    **_kw,
+) -> dict:
+    """Goals CRUD over GOALS.json + GOALS.md."""
+    if not _is_operator():
+        return {"error": "This tool is only available to the operator agent."}
+    if workspace_manager is None:
+        return {"error": "No workspace_manager available"}
+    if action not in _VALID_GOAL_ACTIONS:
+        return {
+            "error": (
+                f"Unknown action {action!r}; "
+                f"use one of {sorted(_VALID_GOAL_ACTIONS)}"
+            ),
+        }
+
+    workspace_root = workspace_manager.root
+    current = _read_goals_sidecar(workspace_root)
+
+    if action == "list":
+        return {"ok": True, "goals": current}
+
+    now = datetime.now(timezone.utc).isoformat()
+
+    if action == "set":
+        if goals is None:
+            goals = []
+        if not isinstance(goals, list):
+            return {"error": "goals must be an array of objects"}
+        if len(goals) > _MAX_GOALS_ENTRIES:
+            return {
+                "error": (
+                    f"goals exceeds max length {_MAX_GOALS_ENTRIES}"
+                ),
+            }
+        cleaned: list[dict] = []
+        seen_names: set[str] = set()
+        for entry in goals:
+            obj, err = _validate_goal_input(entry, require_status=True)
+            if err:
+                return {"error": err}
+            if obj["name"] in seen_names:
+                return {
+                    "error": (
+                        f"duplicate goal name {obj['name']!r} in input"
+                    ),
+                }
+            seen_names.add(obj["name"])
+            obj["updated_at"] = now
+            cleaned.append(obj)
+        _write_goals(workspace_root, cleaned)
+        return {"ok": True, "goals": cleaned}
+
+    if action == "add":
+        if goal is None:
+            goal = {}
+        obj, err = _validate_goal_input(goal, require_status=True)
+        if err:
+            return {"error": err}
+        if any(g["name"] == obj["name"] for g in current):
+            return {
+                "error": (
+                    f"goal {obj['name']!r} already exists; use action='update'"
+                ),
+            }
+        if len(current) >= _MAX_GOALS_ENTRIES:
+            return {
+                "error": (
+                    f"cannot add: already at max of {_MAX_GOALS_ENTRIES} goals"
+                ),
+            }
+        obj["updated_at"] = now
+        new_list = [*current, obj]
+        _write_goals(workspace_root, new_list)
+        return {"ok": True, "goals": new_list}
+
+    if action == "update":
+        if goal is None:
+            goal = {}
+        # Status is optional on update — caller may want to change only
+        # the progress note. We still validate the enum if provided.
+        obj, err = _validate_goal_input(goal, require_status=False)
+        if err:
+            return {"error": err}
+        target_name = obj["name"]
+        idx = next(
+            (i for i, g in enumerate(current) if g["name"] == target_name), None,
+        )
+        if idx is None:
+            return {"error": f"goal {target_name!r} not found"}
+        existing = current[idx]
+        merged = {
+            "name": existing["name"],
+            "status": obj["status"] or existing["status"],
+            "progress_note": (
+                obj["progress_note"]
+                if obj["progress_note"] is not None
+                else existing.get("progress_note", "")
+            ),
+            "updated_at": now,
+        }
+        new_list = list(current)
+        new_list[idx] = merged
+        _write_goals(workspace_root, new_list)
+        return {"ok": True, "goals": new_list}
+
+    if action == "remove":
+        target = sanitize_for_prompt(name or "").strip()
+        if not target:
+            return {"error": "name is required for action='remove'"}
+        idx = next(
+            (i for i, g in enumerate(current) if g["name"] == target), None,
+        )
+        if idx is None:
+            return {"error": f"goal {target!r} not found"}
+        new_list = [g for i, g in enumerate(current) if i != idx]
+        _write_goals(workspace_root, new_list)
+        return {"ok": True, "goals": new_list}
+
+    # Unreachable — action set is validated above.
+    return {"error": f"Unknown action {action!r}"}

--- a/src/agent/server.py
+++ b/src/agent/server.py
@@ -373,6 +373,10 @@ def create_agent_app(loop: AgentLoop) -> FastAPI:
     _WORKSPACE_ALLOWLIST = frozenset({
         "SOUL.md", "HEARTBEAT.md", "USER.md", "INSTRUCTIONS.md", "AGENTS.md", "MEMORY.md",
         "INTERFACE.md", "OBSERVATIONS.md",
+        # Operator-tracked goals. GOALS.json is the structured sidecar
+        # the dashboard reads; GOALS.md is the rendered markdown view.
+        # Only the operator agent writes them in practice.
+        "GOALS.md", "GOALS.json",
     })
     _DEFAULT_HEARTBEAT_HEADING = "# Heartbeat Rules"
 
@@ -384,6 +388,7 @@ def create_agent_app(loop: AgentLoop) -> FastAPI:
         "MEMORY.md": 16000,
         "HEARTBEAT.md": None,
         "INTERFACE.md": 4000,
+        "GOALS.md": 8000,
     }
     _DEFAULT_HEADINGS = {
         "SOUL.md": "# Identity",
@@ -393,6 +398,7 @@ def create_agent_app(loop: AgentLoop) -> FastAPI:
         "MEMORY.md": "# Long-Term Memory",
         "HEARTBEAT.md": "# Heartbeat Rules",
         "INTERFACE.md": "# Interface",
+        "GOALS.md": "# Goals",
     }
 
     @app.get("/workspace")

--- a/src/agent/server.py
+++ b/src/agent/server.py
@@ -388,7 +388,10 @@ def create_agent_app(loop: AgentLoop) -> FastAPI:
         "MEMORY.md": 16000,
         "HEARTBEAT.md": None,
         "INTERFACE.md": 4000,
-        "GOALS.md": 8000,
+        # GOALS.md intentionally uncapped here — size is tool-enforced
+        # (20 goals × name/note limits in manage_goals); an HTTP cap on
+        # the PUT path would clash at max load with what the tool can
+        # legitimately produce (~14k chars). Matches OBSERVATIONS.md.
     }
     _DEFAULT_HEADINGS = {
         "SOUL.md": "# Identity",

--- a/src/cli/config.py
+++ b/src/cli/config.py
@@ -1651,6 +1651,12 @@ _OPERATOR_ALLOWED_TOOLS: list[str] = [
     "add_agents_to_team", "remove_agents_from_team", "update_team_context",
     # PR 5 — north-star setter is no-confirmation meta-config.
     "set_team_goal",
+    # User-visible business goals on the Work tab (separate from
+    # per-team north stars). Backed by GOALS.json + rendered GOALS.md
+    # in the operator's workspace; dashboard reads via
+    # /api/workplace/goals. Operator-only — _is_operator() is enforced
+    # at the tool boundary as well.
+    "manage_goals",
     # Lifecycle (consolidated archive/delete)
     "manage_team", "manage_agent", "manage_task",
     # Self-cleanup — operator can clear stale pending actions and prune

--- a/src/dashboard/server.py
+++ b/src/dashboard/server.py
@@ -6391,6 +6391,8 @@ def create_dashboard_router(
     _WORKSPACE_ALLOWLIST = frozenset({
         "SOUL.md", "HEARTBEAT.md", "USER.md", "INSTRUCTIONS.md", "AGENTS.md", "MEMORY.md",
         "INTERFACE.md", "OBSERVATIONS.md",
+        # Operator-tracked goals (mirrors agent-side allowlist).
+        "GOALS.md", "GOALS.json",
     })
 
     @api_router.get("/api/agents/{agent_id}/workspace")
@@ -6841,6 +6843,55 @@ def create_dashboard_router(
             raise HTTPException(409, str(e))
         except ValueError as e:
             raise HTTPException(400, str(e))
+
+    @api_router.get("/api/workplace/goals")
+    async def api_workplace_goals() -> dict:
+        """Return the operator's tracked goals for the Work-tab strip.
+
+        Reads ``GOALS.json`` from the operator container's workspace via
+        the transport proxy. Returns ``{enabled: False, goals: []}`` when
+        the dashboard can't reach the operator (legacy / standalone test
+        configs); the frontend renders that as "no goals tracked yet"
+        without erroring.
+        """
+        empty = {"enabled": False, "goals": []}
+        if transport is None:
+            return empty
+        if "operator" not in agent_registry:
+            return empty
+        try:
+            payload = await transport.request(
+                "operator", "GET", "/workspace/GOALS.json", timeout=10,
+            )
+        except Exception as e:
+            logger.warning("operator goals fetch failed: %s", e)
+            return {"enabled": True, "goals": [], "error": str(e)}
+        raw = ""
+        if isinstance(payload, dict):
+            raw = str(payload.get("content") or "")
+        if not raw.strip():
+            return {"enabled": True, "goals": []}
+        try:
+            parsed = json.loads(raw)
+        except (ValueError, TypeError) as e:
+            logger.warning("operator GOALS.json parse failed: %s", e)
+            return {"enabled": True, "goals": []}
+        if not isinstance(parsed, dict):
+            return {"enabled": True, "goals": []}
+        entries = parsed.get("goals", [])
+        if not isinstance(entries, list):
+            return {"enabled": True, "goals": []}
+        cleaned: list[dict] = []
+        for entry in entries:
+            if not isinstance(entry, dict):
+                continue
+            cleaned.append({
+                "name": str(entry.get("name", "")),
+                "status": str(entry.get("status", "")),
+                "progress_note": str(entry.get("progress_note", "")),
+                "updated_at": str(entry.get("updated_at", "")),
+            })
+        return {"enabled": True, "goals": cleaned}
 
     @api_router.get("/api/workplace/blockers")
     async def api_workplace_blockers() -> dict:

--- a/src/dashboard/server.py
+++ b/src/dashboard/server.py
@@ -6391,8 +6391,15 @@ def create_dashboard_router(
     _WORKSPACE_ALLOWLIST = frozenset({
         "SOUL.md", "HEARTBEAT.md", "USER.md", "INSTRUCTIONS.md", "AGENTS.md", "MEMORY.md",
         "INTERFACE.md", "OBSERVATIONS.md",
-        # Operator-tracked goals (mirrors agent-side allowlist).
-        "GOALS.md", "GOALS.json",
+        # NOTE: GOALS.md / GOALS.json are intentionally NOT listed here.
+        # The dashboard exposes goals via the dedicated
+        # ``GET /api/workplace/goals`` read endpoint (which calls
+        # transport.request directly, bypassing this allowlist). The
+        # workspace editor's PUT proxy would inject the mesh-internal
+        # header and let a cookie-authed user write raw JSON to
+        # GOALS.json, bypassing the ``manage_goals`` tool's validation.
+        # The agent-side allowlist keeps both files so the tool's read
+        # path (``/workspace/GOALS.json`` over transport) still works.
     })
 
     @api_router.get("/api/agents/{agent_id}/workspace")
@@ -6864,8 +6871,15 @@ def create_dashboard_router(
                 "operator", "GET", "/workspace/GOALS.json", timeout=10,
             )
         except Exception as e:
+            # Log the real error for ops; surface a generic message to
+            # the browser so internal hostnames / file paths from httpx
+            # don't leak into the dashboard.
             logger.warning("operator goals fetch failed: %s", e)
-            return {"enabled": True, "goals": [], "error": str(e)}
+            return {
+                "enabled": True,
+                "goals": [],
+                "error": "unable to reach operator",
+            }
         raw = ""
         if isinstance(payload, dict):
             raw = str(payload.get("content") or "")

--- a/tests/test_dashboard_ui.py
+++ b/tests/test_dashboard_ui.py
@@ -2305,6 +2305,7 @@ _VERB_FOR_TOOL_FALLBACK_OK = frozenset({
     "archive_audit_before",
     "undo_change",
     "manage_agent",
+    "manage_goals",
     "manage_project",
     "manage_team",
     "manage_task",

--- a/tests/test_operator_manage_goals.py
+++ b/tests/test_operator_manage_goals.py
@@ -1,0 +1,317 @@
+"""Tests for the ``manage_goals`` operator tool (PR 1 of Work tab rewrite).
+
+Covers:
+
+* All five actions (set / add / update / remove / list)
+* `add` rejects duplicate names
+* `update` / `remove` reject unknown names
+* `set` enforces max 20 goals + duplicate name rejection
+* Status enum validation
+* `updated_at` stamped on touched goals; preserved on untouched ones
+* GOALS.md and GOALS.json stay in sync
+* Operator-only gating
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _set_operator_env(monkeypatch):
+    monkeypatch.setenv("ALLOWED_TOOLS", "manage_goals")
+
+
+class _FakeWorkspace:
+    def __init__(self, tmp_path: Path):
+        self.root = tmp_path
+
+
+def _load_goals_json(tmp_path: Path) -> list[dict]:
+    path = tmp_path / "GOALS.json"
+    assert path.exists()
+    return json.loads(path.read_text())["goals"]
+
+
+@pytest.mark.asyncio
+async def test_manage_goals_non_operator_rejected(monkeypatch, tmp_path):
+    monkeypatch.delenv("ALLOWED_TOOLS", raising=False)
+    from src.agent.builtins.operator_tools import manage_goals
+
+    ws = _FakeWorkspace(tmp_path)
+    result = await manage_goals("list", workspace_manager=ws)
+    assert "error" in result
+    assert "operator" in result["error"].lower()
+
+
+@pytest.mark.asyncio
+async def test_manage_goals_no_workspace():
+    from src.agent.builtins.operator_tools import manage_goals
+
+    result = await manage_goals("list")
+    assert "error" in result
+    assert "workspace_manager" in result["error"]
+
+
+@pytest.mark.asyncio
+async def test_manage_goals_unknown_action(tmp_path):
+    from src.agent.builtins.operator_tools import manage_goals
+
+    ws = _FakeWorkspace(tmp_path)
+    result = await manage_goals("nope", workspace_manager=ws)
+    assert "error" in result
+    assert "Unknown action" in result["error"]
+
+
+@pytest.mark.asyncio
+async def test_manage_goals_list_empty(tmp_path):
+    from src.agent.builtins.operator_tools import manage_goals
+
+    ws = _FakeWorkspace(tmp_path)
+    result = await manage_goals("list", workspace_manager=ws)
+    assert result == {"ok": True, "goals": []}
+
+
+@pytest.mark.asyncio
+async def test_manage_goals_set_writes_both_files(tmp_path):
+    from src.agent.builtins.operator_tools import manage_goals
+
+    ws = _FakeWorkspace(tmp_path)
+    result = await manage_goals(
+        "set",
+        goals=[
+            {"name": "Launch", "status": "in_progress", "progress_note": "running smoke"},
+            {"name": "Audit", "status": "on_track"},
+        ],
+        workspace_manager=ws,
+    )
+    assert result["ok"] is True
+    assert len(result["goals"]) == 2
+    # JSON sidecar persisted.
+    persisted = _load_goals_json(tmp_path)
+    assert len(persisted) == 2
+    assert persisted[0]["name"] == "Launch"
+    assert persisted[0]["status"] == "in_progress"
+    assert persisted[0]["progress_note"] == "running smoke"
+    assert persisted[0]["updated_at"]
+    # Markdown rendered.
+    md = (tmp_path / "GOALS.md").read_text()
+    assert "# Goals" in md
+    assert "## Launch" in md
+    assert "**Status:** in_progress" in md
+    assert "running smoke" in md
+    assert "## Audit" in md
+
+
+@pytest.mark.asyncio
+async def test_manage_goals_set_caps_max_entries(tmp_path):
+    from src.agent.builtins.operator_tools import manage_goals
+
+    ws = _FakeWorkspace(tmp_path)
+    too_many = [
+        {"name": f"g{i}", "status": "in_progress"} for i in range(21)
+    ]
+    result = await manage_goals("set", goals=too_many, workspace_manager=ws)
+    assert "error" in result
+    assert "max length" in result["error"]
+
+
+@pytest.mark.asyncio
+async def test_manage_goals_set_rejects_duplicates(tmp_path):
+    from src.agent.builtins.operator_tools import manage_goals
+
+    ws = _FakeWorkspace(tmp_path)
+    result = await manage_goals(
+        "set",
+        goals=[
+            {"name": "Same", "status": "in_progress"},
+            {"name": "Same", "status": "on_track"},
+        ],
+        workspace_manager=ws,
+    )
+    assert "error" in result
+    assert "duplicate" in result["error"].lower()
+
+
+@pytest.mark.asyncio
+async def test_manage_goals_status_enum_validation(tmp_path):
+    from src.agent.builtins.operator_tools import manage_goals
+
+    ws = _FakeWorkspace(tmp_path)
+    result = await manage_goals(
+        "set",
+        goals=[{"name": "Bad", "status": "not_a_status"}],
+        workspace_manager=ws,
+    )
+    assert "error" in result
+    assert "status" in result["error"]
+
+
+@pytest.mark.asyncio
+async def test_manage_goals_add_then_list(tmp_path):
+    from src.agent.builtins.operator_tools import manage_goals
+
+    ws = _FakeWorkspace(tmp_path)
+    await manage_goals(
+        "add",
+        goal={"name": "First", "status": "in_progress"},
+        workspace_manager=ws,
+    )
+    result = await manage_goals("list", workspace_manager=ws)
+    assert len(result["goals"]) == 1
+    assert result["goals"][0]["name"] == "First"
+
+
+@pytest.mark.asyncio
+async def test_manage_goals_add_rejects_duplicate_name(tmp_path):
+    from src.agent.builtins.operator_tools import manage_goals
+
+    ws = _FakeWorkspace(tmp_path)
+    await manage_goals(
+        "add",
+        goal={"name": "Same", "status": "in_progress"},
+        workspace_manager=ws,
+    )
+    result = await manage_goals(
+        "add",
+        goal={"name": "Same", "status": "on_track"},
+        workspace_manager=ws,
+    )
+    assert "error" in result
+    assert "already exists" in result["error"]
+
+
+@pytest.mark.asyncio
+async def test_manage_goals_update_stamps_updated_at(tmp_path):
+    """`update` refreshes ``updated_at`` only on the touched goal."""
+    import time as _time
+
+    from src.agent.builtins.operator_tools import manage_goals
+
+    ws = _FakeWorkspace(tmp_path)
+    await manage_goals(
+        "set",
+        goals=[
+            {"name": "A", "status": "in_progress"},
+            {"name": "B", "status": "in_progress"},
+        ],
+        workspace_manager=ws,
+    )
+    initial = _load_goals_json(tmp_path)
+    initial_a = initial[0]["updated_at"]
+    initial_b = initial[1]["updated_at"]
+    _time.sleep(0.01)  # ensure timestamp resolution differs
+    await manage_goals(
+        "update",
+        goal={"name": "A", "status": "done", "progress_note": "shipped"},
+        workspace_manager=ws,
+    )
+    after = _load_goals_json(tmp_path)
+    by_name = {g["name"]: g for g in after}
+    # A's updated_at moved forward; B's preserved.
+    assert by_name["A"]["updated_at"] != initial_a
+    assert by_name["A"]["status"] == "done"
+    assert by_name["A"]["progress_note"] == "shipped"
+    assert by_name["B"]["updated_at"] == initial_b
+
+
+@pytest.mark.asyncio
+async def test_manage_goals_update_unknown_rejected(tmp_path):
+    from src.agent.builtins.operator_tools import manage_goals
+
+    ws = _FakeWorkspace(tmp_path)
+    result = await manage_goals(
+        "update",
+        goal={"name": "Nope", "status": "in_progress"},
+        workspace_manager=ws,
+    )
+    assert "error" in result
+    assert "not found" in result["error"]
+
+
+@pytest.mark.asyncio
+async def test_manage_goals_remove_unknown_rejected(tmp_path):
+    from src.agent.builtins.operator_tools import manage_goals
+
+    ws = _FakeWorkspace(tmp_path)
+    result = await manage_goals("remove", name="Ghost", workspace_manager=ws)
+    assert "error" in result
+    assert "not found" in result["error"]
+
+
+@pytest.mark.asyncio
+async def test_manage_goals_remove_happy_path(tmp_path):
+    from src.agent.builtins.operator_tools import manage_goals
+
+    ws = _FakeWorkspace(tmp_path)
+    await manage_goals(
+        "set",
+        goals=[
+            {"name": "Keep", "status": "in_progress"},
+            {"name": "Drop", "status": "blocked"},
+        ],
+        workspace_manager=ws,
+    )
+    result = await manage_goals("remove", name="Drop", workspace_manager=ws)
+    assert result["ok"] is True
+    assert len(result["goals"]) == 1
+    assert result["goals"][0]["name"] == "Keep"
+    # File state matches.
+    md = (tmp_path / "GOALS.md").read_text()
+    assert "Drop" not in md
+    assert "Keep" in md
+
+
+@pytest.mark.asyncio
+async def test_manage_goals_md_and_json_stay_in_sync(tmp_path):
+    """After every mutation both files reflect the same goal list."""
+    from src.agent.builtins.operator_tools import manage_goals
+
+    ws = _FakeWorkspace(tmp_path)
+    await manage_goals(
+        "set",
+        goals=[{"name": "A", "status": "in_progress"}],
+        workspace_manager=ws,
+    )
+    await manage_goals(
+        "add",
+        goal={"name": "B", "status": "blocked"},
+        workspace_manager=ws,
+    )
+    json_goals = _load_goals_json(tmp_path)
+    md = (tmp_path / "GOALS.md").read_text()
+    names_json = {g["name"] for g in json_goals}
+    assert names_json == {"A", "B"}
+    assert "## A" in md
+    assert "## B" in md
+
+
+@pytest.mark.asyncio
+async def test_manage_goals_remove_requires_name(tmp_path):
+    from src.agent.builtins.operator_tools import manage_goals
+
+    ws = _FakeWorkspace(tmp_path)
+    result = await manage_goals("remove", workspace_manager=ws)
+    assert "error" in result
+    assert "name" in result["error"]
+
+
+@pytest.mark.asyncio
+async def test_manage_goals_add_caps_at_max_entries(tmp_path):
+    from src.agent.builtins.operator_tools import manage_goals
+
+    ws = _FakeWorkspace(tmp_path)
+    initial = [
+        {"name": f"g{i}", "status": "in_progress"} for i in range(20)
+    ]
+    await manage_goals("set", goals=initial, workspace_manager=ws)
+    overflow = await manage_goals(
+        "add",
+        goal={"name": "one_more", "status": "in_progress"},
+        workspace_manager=ws,
+    )
+    assert "error" in overflow
+    assert "max" in overflow["error"].lower()

--- a/tests/test_operator_manage_goals.py
+++ b/tests/test_operator_manage_goals.py
@@ -300,6 +300,94 @@ async def test_manage_goals_remove_requires_name(tmp_path):
 
 
 @pytest.mark.asyncio
+async def test_manage_goals_update_preserves_progress_note_when_unset(tmp_path):
+    """Regression: update without ``progress_note`` must preserve existing.
+
+    The first cut wiped the note silently on every update that didn't
+    pass it. Verify the validator's None-sentinel + update merge keeps
+    the existing note when the caller only touches status.
+    """
+    from src.agent.builtins.operator_tools import manage_goals
+
+    ws = _FakeWorkspace(tmp_path)
+    await manage_goals(
+        "add",
+        goal={
+            "name": "Launch",
+            "status": "in_progress",
+            "progress_note": "draft running",
+        },
+        workspace_manager=ws,
+    )
+    # Update only the status; do not pass progress_note.
+    await manage_goals(
+        "update",
+        goal={"name": "Launch", "status": "done"},
+        workspace_manager=ws,
+    )
+    persisted = _load_goals_json(tmp_path)
+    assert len(persisted) == 1
+    assert persisted[0]["status"] == "done"
+    assert persisted[0]["progress_note"] == "draft running"
+
+
+@pytest.mark.asyncio
+async def test_manage_goals_update_progress_note_explicit_empty_clears(tmp_path):
+    """Caller can still clear the note by passing ``progress_note: \"\"``."""
+    from src.agent.builtins.operator_tools import manage_goals
+
+    ws = _FakeWorkspace(tmp_path)
+    await manage_goals(
+        "add",
+        goal={
+            "name": "Launch",
+            "status": "in_progress",
+            "progress_note": "old note",
+        },
+        workspace_manager=ws,
+    )
+    await manage_goals(
+        "update",
+        goal={"name": "Launch", "status": "in_progress", "progress_note": ""},
+        workspace_manager=ws,
+    )
+    persisted = _load_goals_json(tmp_path)
+    assert persisted[0]["progress_note"] == ""
+
+
+@pytest.mark.asyncio
+async def test_manage_goals_update_status_only_keeps_other_fields(tmp_path):
+    """Updating only status leaves name + note + (other goals') updated_at intact."""
+    import time as _time
+
+    from src.agent.builtins.operator_tools import manage_goals
+
+    ws = _FakeWorkspace(tmp_path)
+    await manage_goals(
+        "set",
+        goals=[
+            {"name": "A", "status": "in_progress", "progress_note": "alpha note"},
+            {"name": "B", "status": "in_progress", "progress_note": "beta note"},
+        ],
+        workspace_manager=ws,
+    )
+    initial = _load_goals_json(tmp_path)
+    initial_a_note = initial[0]["progress_note"]
+    initial_b_note = initial[1]["progress_note"]
+    _time.sleep(0.01)
+    await manage_goals(
+        "update",
+        goal={"name": "A", "status": "blocked"},
+        workspace_manager=ws,
+    )
+    after = _load_goals_json(tmp_path)
+    by_name = {g["name"]: g for g in after}
+    assert by_name["A"]["status"] == "blocked"
+    assert by_name["A"]["progress_note"] == initial_a_note  # preserved
+    assert by_name["B"]["progress_note"] == initial_b_note  # untouched
+
+
+@pytest.mark.asyncio
 async def test_manage_goals_add_caps_at_max_entries(tmp_path):
     from src.agent.builtins.operator_tools import manage_goals
 

--- a/tests/test_workplace_goals_endpoint.py
+++ b/tests/test_workplace_goals_endpoint.py
@@ -1,0 +1,240 @@
+"""Tests for ``GET /api/workplace/goals`` (PR 1 of Work tab rewrite).
+
+The endpoint reads ``GOALS.json`` from the operator container's workspace
+via the transport proxy. These tests pin the four states the frontend
+needs to handle: transport unavailable, operator not registered,
+transport raises, and the happy path.
+"""
+
+from __future__ import annotations
+
+import json
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from src.host.costs import CostTracker
+from src.host.mesh import Blackboard
+from src.host.summaries import WorkSummariesStore
+from src.host.traces import TraceStore
+
+
+class _FakeTransport:
+    """Minimal stand-in for HttpTransport."""
+
+    def __init__(self, response=None, exc: Exception | None = None):
+        self._response = response
+        self._exc = exc
+        self.calls: list[tuple[str, str, str]] = []
+
+    async def request(self, agent_id, method, path, **_kwargs):
+        self.calls.append((agent_id, method, path))
+        if self._exc is not None:
+            raise self._exc
+        return self._response
+
+
+def _build_app(*, transport=None, agent_registry=None, tmp_path=None):
+    from src.dashboard.server import create_dashboard_router
+
+    bb = Blackboard(db_path=str(tmp_path / "bb.db"))
+    costs = CostTracker(str(tmp_path / "costs.db"))
+    traces = TraceStore(str(tmp_path / "traces.db"))
+    summaries = WorkSummariesStore(":memory:")
+
+    router = create_dashboard_router(
+        blackboard=bb,
+        health_monitor=None,
+        cost_tracker=costs,
+        trace_store=traces,
+        event_bus=None,
+        agent_registry=agent_registry or {},
+        summaries_store=summaries,
+        transport=transport,
+    )
+    app = FastAPI()
+    app.include_router(router)
+
+    def _cleanup():
+        bb.close()
+        costs.close()
+        traces.close()
+        summaries.close()
+
+    return app, _cleanup
+
+
+def test_goals_endpoint_transport_unavailable(tmp_path):
+    app, cleanup = _build_app(transport=None, tmp_path=tmp_path)
+    try:
+        with TestClient(app) as c:
+            r = c.get("/dashboard/api/workplace/goals")
+            assert r.status_code == 200
+            assert r.json() == {"enabled": False, "goals": []}
+    finally:
+        cleanup()
+
+
+def test_goals_endpoint_operator_not_registered(tmp_path):
+    # transport present but the operator container isn't in the registry
+    fake = _FakeTransport(response={"content": "{}"})
+    app, cleanup = _build_app(
+        transport=fake, agent_registry={}, tmp_path=tmp_path,
+    )
+    try:
+        with TestClient(app) as c:
+            r = c.get("/dashboard/api/workplace/goals")
+            assert r.status_code == 200
+            assert r.json() == {"enabled": False, "goals": []}
+            # Endpoint short-circuits before hitting transport.
+            assert fake.calls == []
+    finally:
+        cleanup()
+
+
+def test_goals_endpoint_happy_path(tmp_path):
+    payload = {
+        "goals": [
+            {
+                "name": "Launch newsletter",
+                "status": "in_progress",
+                "progress_note": "drafts approved",
+                "updated_at": "2026-05-28T12:00:00+00:00",
+            },
+            {
+                "name": "Audit accounts",
+                "status": "on_track",
+                "progress_note": "",
+                "updated_at": "2026-05-28T13:00:00+00:00",
+            },
+        ],
+    }
+    fake = _FakeTransport(response={"content": json.dumps(payload)})
+    app, cleanup = _build_app(
+        transport=fake,
+        agent_registry={"operator": "http://operator:8400"},
+        tmp_path=tmp_path,
+    )
+    try:
+        with TestClient(app) as c:
+            r = c.get("/dashboard/api/workplace/goals")
+            assert r.status_code == 200
+            body = r.json()
+            assert body["enabled"] is True
+            assert len(body["goals"]) == 2
+            assert body["goals"][0]["name"] == "Launch newsletter"
+            assert body["goals"][0]["status"] == "in_progress"
+            assert body["goals"][1]["name"] == "Audit accounts"
+            # Endpoint hit the operator workspace.
+            assert fake.calls == [("operator", "GET", "/workspace/GOALS.json")]
+    finally:
+        cleanup()
+
+
+def test_goals_endpoint_empty_file(tmp_path):
+    """No goals tracked yet — file present but empty/whitespace content."""
+    fake = _FakeTransport(response={"content": ""})
+    app, cleanup = _build_app(
+        transport=fake,
+        agent_registry={"operator": "http://operator:8400"},
+        tmp_path=tmp_path,
+    )
+    try:
+        with TestClient(app) as c:
+            r = c.get("/dashboard/api/workplace/goals")
+            assert r.status_code == 200
+            assert r.json() == {"enabled": True, "goals": []}
+    finally:
+        cleanup()
+
+
+def test_goals_endpoint_malformed_json(tmp_path):
+    """Corrupt sidecar shouldn't blow up the Work tab."""
+    fake = _FakeTransport(response={"content": "this is not json"})
+    app, cleanup = _build_app(
+        transport=fake,
+        agent_registry={"operator": "http://operator:8400"},
+        tmp_path=tmp_path,
+    )
+    try:
+        with TestClient(app) as c:
+            r = c.get("/dashboard/api/workplace/goals")
+            assert r.status_code == 200
+            assert r.json() == {"enabled": True, "goals": []}
+    finally:
+        cleanup()
+
+
+def test_goals_endpoint_transport_raises(tmp_path):
+    """Transport failure surfaces but doesn't 500."""
+    fake = _FakeTransport(exc=RuntimeError("operator unreachable"))
+    app, cleanup = _build_app(
+        transport=fake,
+        agent_registry={"operator": "http://operator:8400"},
+        tmp_path=tmp_path,
+    )
+    try:
+        with TestClient(app) as c:
+            r = c.get("/dashboard/api/workplace/goals")
+            assert r.status_code == 200
+            body = r.json()
+            assert body["enabled"] is True
+            assert body["goals"] == []
+            assert "operator unreachable" in body.get("error", "")
+    finally:
+        cleanup()
+
+
+def test_goals_endpoint_drops_malformed_entries(tmp_path):
+    """Entries that aren't dicts get filtered, not 500'd."""
+    payload = {
+        "goals": [
+            {"name": "Good", "status": "in_progress"},
+            "not a dict",
+            {"name": "Also good", "status": "done"},
+        ],
+    }
+    fake = _FakeTransport(response={"content": json.dumps(payload)})
+    app, cleanup = _build_app(
+        transport=fake,
+        agent_registry={"operator": "http://operator:8400"},
+        tmp_path=tmp_path,
+    )
+    try:
+        with TestClient(app) as c:
+            r = c.get("/dashboard/api/workplace/goals")
+            assert r.status_code == 200
+            body = r.json()
+            assert body["enabled"] is True
+            names = [g["name"] for g in body["goals"]]
+            assert names == ["Good", "Also good"]
+    finally:
+        cleanup()
+
+
+def test_goals_endpoint_response_shape_is_stable(tmp_path):
+    """Frontend depends on every goal having the four documented keys."""
+    payload = {
+        "goals": [
+            # Missing progress_note + updated_at; should default to "".
+            {"name": "Partial", "status": "blocked"},
+        ],
+    }
+    fake = _FakeTransport(response={"content": json.dumps(payload)})
+    app, cleanup = _build_app(
+        transport=fake,
+        agent_registry={"operator": "http://operator:8400"},
+        tmp_path=tmp_path,
+    )
+    try:
+        with TestClient(app) as c:
+            r = c.get("/dashboard/api/workplace/goals")
+            body = r.json()
+            assert body["goals"] == [{
+                "name": "Partial",
+                "status": "blocked",
+                "progress_note": "",
+                "updated_at": "",
+            }]
+    finally:
+        cleanup()

--- a/tests/test_workplace_goals_endpoint.py
+++ b/tests/test_workplace_goals_endpoint.py
@@ -166,8 +166,11 @@ def test_goals_endpoint_malformed_json(tmp_path):
 
 
 def test_goals_endpoint_transport_raises(tmp_path):
-    """Transport failure surfaces but doesn't 500."""
-    fake = _FakeTransport(exc=RuntimeError("operator unreachable"))
+    """Transport failure surfaces but doesn't 500, and the error message
+    is generic so internal hostnames / paths from httpx don't leak."""
+    fake = _FakeTransport(
+        exc=RuntimeError("Connection refused at http://operator-internal:8400"),
+    )
     app, cleanup = _build_app(
         transport=fake,
         agent_registry={"operator": "http://operator:8400"},
@@ -180,7 +183,54 @@ def test_goals_endpoint_transport_raises(tmp_path):
             body = r.json()
             assert body["enabled"] is True
             assert body["goals"] == []
-            assert "operator unreachable" in body.get("error", "")
+            assert body.get("error") == "unable to reach operator"
+            # Internal host/path must NOT leak to the browser.
+            assert "operator-internal" not in body.get("error", "")
+    finally:
+        cleanup()
+
+
+def test_dashboard_workspace_put_rejects_goals_files(tmp_path):
+    """Lock in the security fix: the workspace editor's PUT proxy must
+    refuse GOALS.md and GOALS.json so a cookie-authed user can't write
+    raw JSON around the ``manage_goals`` tool's validation. Goals are
+    read via the dedicated /api/workplace/goals endpoint; there is no
+    legitimate write path through the workspace proxy.
+    """
+    fake = _FakeTransport(response={"filename": "x", "size": 0})
+    app, cleanup = _build_app(
+        transport=fake,
+        agent_registry={"operator": "http://operator:8400"},
+        tmp_path=tmp_path,
+    )
+    try:
+        with TestClient(app):
+            # Use the CSRF-injecting client so the request itself isn't
+            # rejected on CSRF grounds — we want the allowlist check
+            # to fire.
+            from fastapi.testclient import TestClient as _TC
+
+            class _CSRFClient(_TC):
+                def request(self, method, url, **kw):
+                    if method.upper() not in ("GET", "HEAD", "OPTIONS"):
+                        h = kw.get("headers") or {}
+                        h.setdefault("X-Requested-With", "XMLHttpRequest")
+                        kw["headers"] = h
+                    return super().request(method, url, **kw)
+
+            csrf_client = _CSRFClient(app)
+            for filename in ("GOALS.json", "GOALS.md"):
+                r = csrf_client.put(
+                    f"/dashboard/api/agents/operator/workspace/{filename}",
+                    json={"content": '{"goals": []}'},
+                )
+                assert r.status_code == 400, (
+                    f"PUT {filename} should be rejected by allowlist, "
+                    f"got {r.status_code}: {r.text}"
+                )
+                assert "not allowed" in r.text.lower()
+            # Transport must NOT have been called for the rejected PUTs.
+            assert all(call[1] != "PUT" for call in fake.calls)
     finally:
         cleanup()
 


### PR DESCRIPTION
## Summary

PR 1 of 3 for the Work-tab rewrite. **Purely additive** — no UI change, no endpoint deletion, no behavior change to existing flows.

The redesign keeps the work_summaries surface that landed in #945–#949 and layers an operator-tracked **goals strip** on top, so the user sees *what this team is trying to achieve* alongside *what the team produced*. Goals are written by the operator agent into `GOALS.json` (structured) + `GOALS.md` (rendered for humans). The dashboard reads only the JSON sidecar via the existing workspace transport proxy.

## Changes

- **`src/agent/server.py`** — workspace allowlist + cap (8000) + default heading for `GOALS.md` and `GOALS.json`
- **`src/agent/builtins/operator_tools.py`** — `manage_goals` operator-only tool with five actions (`set` / `add` / `update` / `remove` / `list`), input sanitization, status enum (`not_started` / `in_progress` / `on_track` / `at_risk` / `blocked` / `done`), per-goal `updated_at` stamping that preserves untouched timestamps, max 20 goals
- **`src/dashboard/server.py`** — workspace allowlist mirrors agent side + new `GET /api/workplace/goals` endpoint that returns `{enabled, goals[], error?}` and degrades gracefully when transport is missing, operator isn't registered, or the sidecar is malformed
- **`tests/test_operator_manage_goals.py`** — 17 cases (all five actions, caps, duplicate rejection, status enum, MD/JSON sync, operator gating)
- **`tests/test_workplace_goals_endpoint.py`** — 8 cases (four transport/registry states, malformed input, response-shape stability)

## Roadmap context

- **PR 2 (next):** Work-tab UI — remove Kanban + Activity sub-tab, add goals strip rendered from `/api/workplace/goals`, add "Tell Operator" freeform-feedback textarea, fold raw task list into a Technical-detail disclosure for the 5% of power users
- **PR 3:** backend cleanup — delete unused `/api/workplace/blockers`, `/outputs`, `/feed` endpoints once the UI no longer calls them; CLAUDE.md updates

## Test plan

- [x] `pytest tests/test_operator_manage_goals.py tests/test_workplace_goals_endpoint.py -x -v` — 25 pass
- [x] `pytest tests/test_operator_tools.py -x` — 87 pass (regression: new tool appended at file end, didn't touch existing tools)
- [x] `pytest tests/test_dashboard_summaries_api.py -x` — 11 pass (regression: new allowlist entries + new endpoint, no impact on summaries paths)
- [x] `pytest tests/test_workspace.py -x` — 119 pass (regression: agent workspace allowlist extended, default headings respected)
- [x] `ruff check` on all touched files — clean