### PR TITLE
feat(host,agent,dashboard): MCP server config foundation (PR 1/2 for #959)

### DIFF
--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -40,16 +40,69 @@ There is no top-level `config/agents.yaml` file shipped with the repo — agents
 
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
-| `name` | string | Yes | Unique identifier for the server |
-| `command` | string | Yes | Command to launch the server |
-| `args` | list[string] | No | Command-line arguments (defaults to `[]`) |
-| `env` | dict[string, string] | No | Environment variables for the server process (defaults to `None`, meaning the subprocess inherits the agent container's environment) |
+| `name` | string | Yes | Unique identifier (1-64 chars, `^[a-zA-Z0-9][a-zA-Z0-9_-]*$`). Used as a prefix when a tool name collides with a built-in or another server's tool (`mcp_<server>_<tool>`). Case-insensitive duplicate names are rejected. |
+| `command` | string | Yes | Command to launch the server (max 256 chars). **Cannot contain `$CRED{name}` handles** — use `env` or `args` if a credential needs to reach the subprocess. |
+| `args` | list[string] | No | Command-line arguments (defaults to `[]`, max 32 entries × 512 chars). May contain `$CRED{name}` handles — the mesh resolves them at agent start. |
+| `env` | dict[string, string] | No | Environment variables for the server process (defaults to `None`, max 32 entries × 4096-char values). Values may contain `$CRED{name}` handles. |
+
+Entries are validated by `src.shared.types.MCPServerConfig` at load time (`src/cli/config.py:_load_config`), at PUT time (`/api/agents/{id}/config`), and persisted as plain dicts so existing tooling that diffs `config/agents.yaml` keeps working.
+
+### Credential handles in `env` and `args`
+
+`$CRED{name}` references the agent-tier credential vault. The mesh resolves them just before serializing the `MCP_SERVERS` env var for the agent container — the resolved plaintext goes into the subprocess environment, never to disk and never through the API surface.
+
+```yaml
+mcp_servers:
+  - name: linear
+    command: mcp-server-linear
+    args: ["--workspace", "ol"]
+    env:
+      LINEAR_API_KEY: "$CRED{linear_token}"
+```
+
+**Permission gate.** Each handle is checked against the agent's `allowed_credentials` glob list (via `permissions.can_access_credential`) at **both** PUT time (so the dashboard rejects an unsavable config synchronously) and runtime (so a permission revoked after save is enforced on next restart).
+
+**What handles protect (and what they don't):**
+
+| Surface | Protected? |
+|---|---|
+| `config/agents.yaml` on disk | ✅ stored as `$CRED{name}` reference |
+| `audit_log` table | ✅ env values redacted; only keys preserved |
+| `GET /api/agents/{id}/config` | ✅ `env` field omitted; `env_keys` returned instead |
+| Container `MCP_SERVERS` env var | ❌ plaintext after mesh resolves |
+| MCP subprocess `env` | ❌ plaintext (the subprocess needs the value to authenticate — this is a protocol fact, not a routing problem) |
+| Container process memory | ❌ plaintext |
+
+The runtime exposure is bounded by the existing container hardening (UID 1000, `cap_drop=ALL`, `read_only` filesystem, 384 MB memory cap). Persistent storage and observability surfaces are the threat-model windows that credential handles close.
+
+**Failure modes:**
+
+- **Vault not wired.** `RuntimeBackend` raises a clear startup error if the config contains `$CRED{...}` handles but the mesh credential vault was not plumbed in via `set_credential_resolver`. Silent literal-passthrough was rejected as a footgun: a misconfigured deploy would otherwise ship literal `$CRED{...}` strings to subprocesses.
+- **Credential missing.** Agent start raises `ValueError`; the dashboard surfaces this through the existing restart-failed UX with the credential name in the error message. Fix by storing the credential and retrying restart.
+- **Permission denied.** Same as missing — agent start raises with the credential name. Fix by extending the agent's `allowed_credentials` glob.
+
+### Dashboard `GET /config` env masking
+
+`env` values are never returned by the dashboard config API. Each MCP server entry in the response omits the `env` key entirely and returns `env_keys: ["KEY1", "KEY2"]` instead — the dashboard renders the list of env-var names without ever holding the values.
+
+The `env` field is **omitted**, not returned as `null`. This is deliberate: a naive `GET → edit → PUT` round-trip would otherwise lose env because the PUT handler treats "`env` present in body" as "replace wholesale." Omission lets the PUT handler tell "client preserved env" from "client wants to clear env":
+
+- **Field absent from request body** → preserve persisted env for this server (matched by name).
+- **Field present (as `{}` or `{K: v}`)** → replace wholesale.
+
+### `mcp_touched` only fires on real diffs
+
+Saving a config that doesn't actually change the persisted `mcp_servers` does NOT restart the agent. The PUT handler canonicalizes both sides (Pydantic model load + `model_dump(exclude_none=False)`, sorted by `name.lower()`, with `env={}` normalized to `env=None`) and only triggers the restart if the diff is non-empty.
+
+### Concurrent edits
+
+Last-write-wins semantics for the whole `mcp_servers` field. The dashboard does not currently use an `If-Match` / etag concurrency token, so two operators editing the same agent's MCP config simultaneously will have one overwrite the other. This is consistent with how every other dashboard config edit behaves today.
 
 ## How It Works
 
 ### Startup Sequence
 
-1. The runtime layer (`DockerBackend` in `src/host/runtime.py`) reads `mcp_servers` from the agent's record and serializes it as JSON into the `MCP_SERVERS` environment variable passed to the agent container (`environment["MCP_SERVERS"] = json.dumps(mcp_servers)`)
+1. The runtime layer (`DockerBackend` / `SandboxBackend` in `src/host/runtime.py`) reads `mcp_servers` from the agent's record and serializes it as JSON into the `MCP_SERVERS` environment variable passed to the agent container (`environment["MCP_SERVERS"] = self._build_mcp_servers_env(...)`). Any `$CRED{name}` handles in `env` values or `args` strings are resolved here against the mesh credential vault — the agent container receives plaintext values; the persisted config retains the handle.
 2. Agent container starts; `src/agent/__main__.py` reads `MCP_SERVERS`
 3. `MCPClient` is created and passed to `SkillRegistry`
 4. During lifespan startup, `MCPClient.start()` launches each server:
@@ -194,3 +247,13 @@ Common causes:
 ### Name conflicts
 
 If your MCP tool has the same name as a built-in (e.g., `exec_command`), it will be prefixed. Check logs for "conflicts with existing tool, renamed to" warnings.
+
+### Dashboard shows a red status dot
+
+The agent's `/capabilities` endpoint exposes a per-server startup registry — each entry has `{state, tools_count, error}`. Failed startups capture the exception message (truncated to 500 chars); clicking the row in the dashboard surfaces the error verbatim, so you don't need to tail container logs for the common cases (`command not found`, missing env var, permission denied on a credential handle).
+
+Note: the registry reflects the **last startup attempt** only — it is not a live health probe. A server that started successfully but crashed mid-session is not marked failed until the next agent restart re-runs discovery.
+
+## Future: operator-requested setup
+
+A planned follow-up will let the operator agent request MCP setup through the existing credential-request / browser-login pattern: the operator surfaces a dashboard card describing the tool it needs, the human reviews + saves, the agent picks up the new server on restart. The operator never edits MCP config directly — this preserves the operator-first positioning while sidestepping the prompt-injection risk of giving operator chat the power to install arbitrary subprocesses.

--- a/src/agent/builtins/__init__.py
+++ b/src/agent/builtins/__init__.py
@@ -4,7 +4,11 @@ These are auto-discovered by SkillRegistry alongside custom skills.
 They provide core capabilities: shell execution, file I/O, HTTP, and browser.
 """
 
-import re
+# Re-exported from src.shared.types — that's the canonical location for
+# the credential handle syntax shared by agent-side (http_tool) and
+# mesh-side (host.credentials, host.runtime) resolvers. Re-export kept
+# here so existing ``from src.agent.builtins import CRED_HANDLE_RE``
+# callers in http_tool.py don't need to be touched.
+from src.shared.types import CRED_HANDLE_RE
 
-# Shared pattern for credential handle syntax: $CRED{name}
-CRED_HANDLE_RE = re.compile(r"\$CRED\{([^}]+)\}")
+__all__ = ["CRED_HANDLE_RE"]

--- a/src/agent/mcp_client.py
+++ b/src/agent/mcp_client.py
@@ -35,6 +35,14 @@ class MCPClient:
         self._sessions: dict[str, Any] = {}  # server_name → ClientSession
         self._tool_to_server: dict[str, str] = {}  # tool_name → server_name
         self._tool_schemas: dict[str, dict] = {}  # tool_name → schema dict
+        # Startup/discovery status registry. Updated in ``start()`` per
+        # server: success path sets ``state="running"`` with ``tools_count``
+        # and ``error=None``; failure path sets ``state="failed"`` with
+        # the captured exception message. This reflects the last startup
+        # attempt only — NOT live health (no in-flight probes). The
+        # dashboard reads this via ``/capabilities`` to render per-server
+        # status dots and click-to-see-error.
+        self._server_status: dict[str, dict] = {}
 
     async def start(self, servers: list[dict], builtin_names: set[str] | None = None) -> None:
         """Start MCP server subprocesses and discover their tools.
@@ -49,6 +57,19 @@ class MCPClient:
         """
         if StdioServerParameters is None:
             logger.error("MCP SDK not installed — cannot start MCP servers")
+            # Mark every configured server as failed so the dashboard's
+            # per-server status registry surfaces the cause instead of
+            # silently showing zero servers. Operator sees red dots +
+            # actionable error rather than wondering why nothing
+            # discovered.
+            for server_cfg in servers:
+                name = server_cfg.get("name") if isinstance(server_cfg, dict) else None
+                if isinstance(name, str):
+                    self._server_status[name] = {
+                        "state": "failed",
+                        "tools_count": 0,
+                        "error": "MCP SDK not installed in agent container",
+                    }
             return
 
         builtin_names = builtin_names or set()
@@ -97,8 +118,21 @@ class MCPClient:
                     f"MCP server '{name}' started: "
                     f"{len(tools_result.tools)} tools discovered"
                 )
+                self._server_status[name] = {
+                    "state": "running",
+                    "tools_count": len(tools_result.tools),
+                    "error": None,
+                }
             except Exception as e:
                 logger.error(f"Failed to start MCP server '{name}': {e}")
+                # Capture the error string (truncated) so the dashboard
+                # can surface it on click — operator should not need to
+                # tail container logs to diagnose a failed MCP start.
+                self._server_status[name] = {
+                    "state": "failed",
+                    "tools_count": 0,
+                    "error": str(e)[:500],
+                }
 
     async def stop(self) -> None:
         """Shut down all MCP server connections."""
@@ -109,10 +143,39 @@ class MCPClient:
         self._sessions.clear()
         self._tool_to_server.clear()
         self._tool_schemas.clear()
+        self._server_status.clear()
 
     def list_tools(self) -> list[dict]:
         """Return all discovered MCP tools as schema dicts."""
         return list(self._tool_schemas.values())
+
+    def list_server_statuses(self) -> list[dict]:
+        """Return per-server startup/discovery status as a list of dicts.
+
+        Each entry: ``{name, state, tools_count, error}`` where
+        ``state`` is ``"running"`` or ``"failed"``. Reflects the last
+        startup attempt only — NOT live health. The dashboard renders
+        per-server status dots from this list and exposes the error
+        string when a server failed to start.
+
+        Servers that were never attempted (no call to :meth:`start`)
+        are not present in the list.
+        """
+        return [
+            {"name": name, **status}
+            for name, status in self._server_status.items()
+        ]
+
+    def get_tool_to_server(self) -> dict[str, str]:
+        """Return a snapshot of the ``tool_name → server_name`` mapping.
+
+        Surfaced through ``/capabilities`` so the dashboard can filter
+        the existing tool list by MCP server when the user clicks a
+        server's tool-count badge — the OpenAI tool definition format
+        has no field for per-tool source metadata, so this side-channel
+        is the contract.
+        """
+        return dict(self._tool_to_server)
 
     async def call_tool(self, name: str, arguments: dict) -> dict:
         """Route a tool call to the correct MCP server.

--- a/src/agent/server.py
+++ b/src/agent/server.py
@@ -30,7 +30,7 @@ import mimetypes
 import os
 import re
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from fastapi import FastAPI, HTTPException, Request
 from fastapi.responses import StreamingResponse
@@ -143,16 +143,33 @@ def create_agent_app(loop: AgentLoop) -> FastAPI:
 
         Respects the same exclude filter used when calling the LLM, so the
         dashboard accurately reflects what the agent can actually use.
+
+        Includes two MCP side-channels for the dashboard:
+
+        * ``mcp_servers`` — per-server startup/discovery status registry
+          (state, tools_count, error). Drives the per-server status dot
+          and the click-to-see-error UX.
+        * ``mcp_tool_to_server`` — ``{tool_name: server_name}`` mapping
+          for filtering the tool list by server. Sidesteps the OpenAI
+          tool definition format which has no place for per-tool source
+          metadata.
+
+        Both are omitted when no MCP client is wired to the loop.
         """
         exc = loop._excluded_tools
         alw = loop._allowed_tools if isinstance(loop._allowed_tools, frozenset) else None
-        return {
+        result: dict[str, Any] = {
             "agent_id": loop.agent_id,
             "role": loop.role,
             "skills": loop.skills.list_skills(exclude=exc, allowed=alw),
             "tool_definitions": loop.skills.get_tool_definitions(exclude=exc, allowed=alw),
             "tool_sources": loop.skills.get_tool_sources(exclude=exc, allowed=alw),
         }
+        mcp_client = getattr(loop.skills, "_mcp_client", None)
+        if mcp_client is not None:
+            result["mcp_servers"] = mcp_client.list_server_statuses()
+            result["mcp_tool_to_server"] = mcp_client.get_tool_to_server()
+        return result
 
     @app.post("/invoke")
     async def invoke_tool(request: Request) -> dict:

--- a/src/cli/config.py
+++ b/src/cli/config.py
@@ -15,7 +15,7 @@ import click
 import yaml
 
 from src.shared.operator_playbooks import _OPERATOR_CORE
-from src.shared.types import RESERVED_AGENT_IDS
+from src.shared.types import RESERVED_AGENT_IDS, MCPServerConfig
 from src.shared.utils import truncate
 
 logger = logging.getLogger("cli")
@@ -207,6 +207,33 @@ def _load_config(mesh_path: Path | None = None) -> dict:
         with open(AGENTS_FILE) as f:
             agents_data = yaml.safe_load(f) or {}
             cfg.setdefault("agents", {}).update(agents_data.get("agents", {}))
+
+    # T7: validate ``mcp_servers`` entries via MCPServerConfig at the
+    # load boundary. Malformed entries (bad name regex, oversized
+    # strings, $CRED handles in command, unknown extra fields) are
+    # logged and dropped — DO NOT crash the whole agent load over one
+    # bad row. The dashboard PUT path enforces the same model for
+    # newly-saved configs; this is the safety net for legacy entries
+    # written before T2 landed.
+    for _agent_id, _agent_cfg in cfg.get("agents", {}).items():
+        if not isinstance(_agent_cfg, dict):
+            continue
+        _raw_servers = _agent_cfg.get("mcp_servers")
+        if not _raw_servers:
+            continue
+        _kept: list[dict] = []
+        for _entry in _raw_servers:
+            try:
+                _parsed = MCPServerConfig.model_validate(_entry)
+                _kept.append(_parsed.model_dump(exclude_none=False))
+            except Exception as _e:
+                _name = _entry.get("name") if isinstance(_entry, dict) else "<?>"
+                logger.warning(
+                    "Dropping malformed mcp_servers entry %r for agent %r: %s",
+                    _name, _agent_id, _e,
+                )
+        # Replace the raw list with the validated subset (may be empty).
+        _agent_cfg["mcp_servers"] = _kept if _kept else None
 
     # Load projects and build reverse map (agent → project)
     projects = _load_projects()

--- a/src/cli/runtime.py
+++ b/src/cli/runtime.py
@@ -278,6 +278,15 @@ class RuntimeContext:
             failover_config=failover_config or None,
             default_model=default_model,
         )
+        # Plumb the credential resolver into the already-constructed runtime
+        # backend so $CRED{name} handles in MCP server configs (env values
+        # and args) resolve at agent start. Idempotent; safe if the runtime
+        # is later replaced (the sandbox→docker fallback path in
+        # _start_agents also calls set_credential_resolver explicitly).
+        self.runtime.set_credential_resolver(
+            vault=self.credential_vault,
+            permissions=self.permissions,
+        )
         self.router = MessageRouter(
             self.permissions, self.agent_urls,
             trace_store=self.trace_store,
@@ -496,6 +505,11 @@ class RuntimeContext:
                         project_root=str(PROJECT_ROOT),
                     )
                     self.runtime.extra_env = saved_extra_env
+                    # Re-plumb the credential resolver into the fresh backend.
+                    self.runtime.set_credential_resolver(
+                        vault=self.credential_vault,
+                        permissions=self.permissions,
+                    )
                     self.transport = HttpTransport()
                     _ensure_docker_image()
                     url = self.runtime.start_agent(

--- a/src/dashboard/server.py
+++ b/src/dashboard/server.py
@@ -42,11 +42,13 @@ from urllib.parse import urlparse
 from fastapi import APIRouter, Depends, File, HTTPException, Request, UploadFile
 from fastapi.responses import FileResponse, HTMLResponse
 from jinja2 import Environment, FileSystemLoader
+from pydantic import ValidationError
 
 from src.cli.proxy import build_proxy_env_vars, resolve_agent_proxy
 from src.dashboard.auth import verify_session_cookie
 from src.shared.paths import resolve_under_root
 from src.shared.sqlite_helpers import open_db
+from src.shared.types import CRED_HANDLE_RE, MCPServerConfig
 from src.shared.utils import dumps_safe, friendly_streaming_error, sanitize_for_prompt, setup_logging
 
 if TYPE_CHECKING:
@@ -152,6 +154,99 @@ def _get_builtin_tool_names() -> frozenset[str]:
 
 
 _get_builtin_tool_names._cache = None  # type: ignore[attr-defined]
+
+
+def _mask_mcp_servers_for_get(servers: list[dict] | None) -> list[dict]:
+    """Return ``mcp_servers`` with env values stripped, suitable for GET
+    responses. Env values may be plaintext secrets or ``$CRED{name}``
+    handles pointing at one; neither is safe to ship over the API.
+
+    Each server entry retains ``name``, ``command``, and ``args``;
+    ``env`` is omitted entirely (NOT returned as ``null``) and replaced
+    with ``env_keys`` — a sorted list of the env variable names. The
+    omission is deliberate: a naive ``GET → edit → PUT`` round-trip
+    would otherwise lose env when the PUT handler interprets a present
+    ``env=null`` as "replace with no env." The PUT contract is "env
+    absent = preserve, env present (dict or {}) = replace wholesale"
+    (see T5 in :func:`_api_put_agent_config`).
+    """
+    if not servers:
+        return []
+    result: list[dict] = []
+    for s in servers:
+        masked = {k: v for k, v in s.items() if k != "env"}
+        env = s.get("env") or {}
+        masked["env_keys"] = sorted(env.keys()) if env else []
+        result.append(masked)
+    return result
+
+
+def _canonicalize_mcp_servers(servers: list | None) -> list[dict]:
+    """Return a stable canonical form of ``mcp_servers`` for diff
+    comparison. Used by the PUT handler to set ``mcp_touched`` only
+    when an effective change occurred — a GET → no-op PUT round-trip
+    must not trigger a container restart.
+
+    Canonicalization:
+
+    * Parse each entry through :class:`MCPServerConfig` to normalize
+      missing-optional fields (e.g. ``args`` → ``[]``, ``env`` →
+      ``None``) and shape coercion (Pydantic v2 returns dicts on
+      ``model_dump``).
+    * Sort the list by ``name.lower()`` so the comparison is
+      independent of input order.
+    * Normalize ``env == {}`` to ``env is None`` so an empty dict and
+      a missing field compare equal.
+
+    If any entry fails Pydantic validation, returns the raw list
+    unchanged — better to over-report a diff (false positive
+    ``mcp_touched``) than to silently mask a malformed legacy entry.
+    The CLI load path (T7) drops malformed entries before they reach
+    this function in normal flow.
+    """
+    if not servers:
+        return []
+    parsed: list[MCPServerConfig] = []
+    for s in servers:
+        try:
+            parsed.append(MCPServerConfig.model_validate(s))
+        except Exception:
+            return list(servers)
+    parsed.sort(key=lambda s: s.name.lower())
+    result: list[dict] = []
+    for s in parsed:
+        d = s.model_dump(exclude_none=False)
+        if d.get("env") == {}:
+            d["env"] = None
+        result.append(d)
+    return result
+
+
+def _redact_mcp_env_for_audit(value: object) -> object:
+    """Strip env VALUES from an ``mcp_servers`` payload for audit-log
+    logging. Keys are preserved so an operator reviewing the audit
+    trail can see which env vars changed; the values are not
+    persisted to the audit table (which would be a covert plaintext
+    secret leak otherwise — values may be ``$CRED{name}`` handles or
+    raw secrets, and both are sensitive).
+
+    Returns the original value unchanged if it isn't shaped like an
+    ``mcp_servers`` list-of-dicts payload — the audit caller handles
+    both old-and-new sides identically and may pass an empty string
+    on first-write.
+    """
+    if not isinstance(value, list):
+        return value
+    redacted: list[dict] = []
+    for s in value:
+        if not isinstance(s, dict):
+            return value  # not the shape we redact
+        copy = {k: v for k, v in s.items() if k != "env"}
+        env = s.get("env") or {}
+        if env:
+            copy["env_keys"] = sorted(env.keys())
+        redacted.append(copy)
+    return redacted
 
 
 def _compute_asset_version() -> str:
@@ -2450,7 +2545,16 @@ def create_dashboard_router(
             "color": agent_cfg.get("color"),
             "budget": agent_cfg.get("budget", {}),
             "thinking": agent_cfg.get("thinking", "off") or "off",
-            "mcp_servers": agent_cfg.get("mcp_servers") or [],
+            # MCP server entries are masked: env values (which may be
+            # plaintext secrets or ``$CRED{name}`` handles pointing at
+            # one) are NEVER returned. The UI binds to ``env_keys`` to
+            # render the list of variable names. The ``env`` field is
+            # omitted from each entry so a naive GET→PUT round-trip
+            # cannot accidentally clear env (PUT semantics in T5:
+            # ``env`` absent = preserve; present = replace wholesale).
+            "mcp_servers": _mask_mcp_servers_for_get(
+                agent_cfg.get("mcp_servers"),
+            ),
             "allowed_credentials": allowed_creds,
             "available_credentials": sorted(agent_cred_names),
             "system_credentials": system_cred_names,
@@ -2625,21 +2729,148 @@ def create_dashboard_router(
             mcp_val = body["mcp_servers"]
             if not isinstance(mcp_val, list):
                 raise HTTPException(status_code=400, detail="mcp_servers must be a list")
-            for srv in mcp_val:
-                if not isinstance(srv, dict) or "name" not in srv or "command" not in srv:
+
+            # ── env preserve-or-replace, per-server ───────────────────
+            # If a server dict OMITS the ``env`` key in the request body,
+            # the persisted env from the current server-of-same-name is
+            # preserved. If ``env`` is present (as a dict, ``{}``, or
+            # ``None``), it replaces wholesale. This matches the GET
+            # contract (env is masked / omitted from responses) so a
+            # naive GET → PUT round-trip preserves env rather than
+            # accidentally clearing it.
+            current_servers = agent_cfg.get("mcp_servers") or []
+            current_env_by_name: dict[str, object] = {}
+            for cs in current_servers:
+                if isinstance(cs, dict) and isinstance(cs.get("name"), str):
+                    current_env_by_name[cs["name"]] = cs.get("env")
+
+            effective_raw: list[dict] = []
+            for raw in mcp_val:
+                if not isinstance(raw, dict):
                     raise HTTPException(
                         status_code=400,
-                        detail="Each MCP server must have 'name' and 'command' keys",
+                        detail="Each MCP server must be a JSON object",
                     )
-            pending_writes.append(("mcp_servers", mcp_val if mcp_val else None))
-            mcp_touched = True
+                s = dict(raw)
+                # Strip ``env_keys`` if the client replayed a GET response
+                # verbatim — GET adds it as the masked stand-in for ``env``
+                # (see ``_mask_mcp_servers_for_get``). MCPServerConfig has
+                # ``extra="forbid"`` so leaving it in would reject the PUT.
+                # The field is purely a display-side artifact; the source
+                # of truth for env keys is the persisted ``env`` dict.
+                s.pop("env_keys", None)
+                if "env" not in raw:
+                    # Preserve from current persisted entry of same name.
+                    s["env"] = current_env_by_name.get(raw.get("name"))
+                effective_raw.append(s)
+
+            # ── Pydantic validation (replaces hand-rolled checks) ─────
+            try:
+                validated = [
+                    MCPServerConfig.model_validate(s) for s in effective_raw
+                ]
+            except ValidationError as ve:
+                # Surface the structured Pydantic error so the dashboard
+                # can map it back to the offending field for inline UI.
+                # Strip ``ctx`` and ``input`` — they can contain raw
+                # exception objects that FastAPI's JSON encoder rejects.
+                safe_errors = [
+                    {
+                        "loc": [str(p) for p in e.get("loc", ())],
+                        "msg": e.get("msg", ""),
+                        "type": e.get("type", ""),
+                    }
+                    for e in ve.errors(include_url=False)
+                ]
+                raise HTTPException(
+                    status_code=400,
+                    detail={"field": "mcp_servers", "errors": safe_errors},
+                )
+            # Case-insensitive duplicate-name rejection (mirrors the
+            # AgentConfig field validator added in T2).
+            names_lower = [v.name.lower() for v in validated]
+            if len(set(names_lower)) != len(names_lower):
+                raise HTTPException(
+                    status_code=400,
+                    detail="Duplicate MCP server names (case-insensitive) are not allowed",
+                )
+
+            # ── PUT-time $CRED check: permission + existence ──────────
+            # Reject the PUT with a clear error if any $CRED reference
+            # in env values or args strings (a) the agent isn't allowed
+            # to use, or (b) doesn't exist in the vault. Mirrors the
+            # runtime-time check in :func:`src.host.credentials.resolve_cred_handles`
+            # but surfaces failures synchronously rather than at agent
+            # start — better UX, lets the operator fix the credentials
+            # surface before saving the config.
+            def _check_cred_refs(text: str, where: str) -> None:
+                for cred_name in set(CRED_HANDLE_RE.findall(text or "")):
+                    if permissions is not None and not permissions.can_access_credential(
+                        agent_id, cred_name,
+                    ):
+                        raise HTTPException(
+                            status_code=400,
+                            detail=(
+                                f"Agent {agent_id!r} does not have permission "
+                                f"to access credential {cred_name!r} "
+                                f"(referenced in {where})."
+                            ),
+                        )
+                    if (
+                        credential_vault is not None
+                        and credential_vault.resolve_credential(cred_name) is None
+                    ):
+                        raise HTTPException(
+                            status_code=400,
+                            detail=(
+                                f"Credential {cred_name!r} referenced in "
+                                f"{where} does not exist in the vault. "
+                                f"Store it via the credentials surface first."
+                            ),
+                        )
+
+            for srv_idx, srv in enumerate(validated):
+                for arg_idx, arg in enumerate(srv.args):
+                    _check_cred_refs(arg, f"mcp_servers[{srv_idx}].args[{arg_idx}]")
+                for env_key, env_val in (srv.env or {}).items():
+                    _check_cred_refs(
+                        env_val, f"mcp_servers[{srv_idx}].env[{env_key!r}]",
+                    )
+
+            # ── mcp_touched only on real diff ────────────────────────
+            # Convert validated MCPServerConfig objects back to dicts
+            # for storage. Compare canonicalized new vs canonicalized
+            # current — a GET → unchanged PUT must NOT trigger a
+            # container restart (previously the flag fired any time
+            # ``mcp_servers`` appeared in the body, regardless of value).
+            effective_dicts = [
+                v.model_dump(exclude_none=False) for v in validated
+            ]
+            if (
+                _canonicalize_mcp_servers(effective_dicts)
+                != _canonicalize_mcp_servers(current_servers)
+            ):
+                pending_writes.append((
+                    "mcp_servers", effective_dicts if effective_dicts else None,
+                ))
+                mcp_touched = True
 
         # Phase 2: apply writes now that every field validated.
         updated: list[str] = []
         def _audit(field: str, old_value: object, new_value: object) -> None:
             """Log a dashboard-initiated edit. Never raises — a broken audit
             sink must not block the caller's config change, but silent
-            failure is worth a warning so it doesn't rot unnoticed."""
+            failure is worth a warning so it doesn't rot unnoticed.
+
+            ``mcp_servers`` env VALUES are redacted before logging — they
+            may be plaintext secrets or ``$CRED{name}`` handles, and the
+            audit table is not a safe place for either. Env KEYS are
+            preserved as ``env_keys`` so a reviewer can still see which
+            env vars changed.
+            """
+            if field == "mcp_servers":
+                old_value = _redact_mcp_env_for_audit(old_value)
+                new_value = _redact_mcp_env_for_audit(new_value)
             try:
                 blackboard.log_audit(
                     action="edit_agent",
@@ -3094,17 +3325,34 @@ def create_dashboard_router(
             data = await transport.request(agent_id, "GET", "/capabilities", timeout=10)
         except Exception as e:
             raise HTTPException(status_code=502, detail=str(e))
+        # Defensive: if the agent transport returned a non-dict shape
+        # (malformed-but-valid JSON like a list or a string), surface
+        # 502 rather than crashing the backfill block with AttributeError.
+        if not isinstance(data, dict):
+            raise HTTPException(
+                status_code=502,
+                detail="Agent /capabilities returned a non-object response",
+            )
         # Backfill tool_sources for agents running pre-badge code (no container
         # restart required).  The host process has access to the builtins package
         # and can classify tools without executing agent-side code.
         if "tool_sources" not in data:
             builtins = _get_builtin_tool_names()
             sources: dict[str, str] = {}
+            # If the agent surfaced an mcp_tool_to_server side-channel
+            # (post-T6 agents), every name listed there is an MCP tool.
+            # Older agents lack this field, in which case we fall back
+            # to builtin/custom classification only — there's no
+            # legitimate way to identify MCP tools from the OpenAI
+            # tool-definition format alone (the prior heuristic
+            # ``tool.get("function") == "mcp"`` was always False because
+            # the OpenAI format puts a dict at ``function``).
+            mcp_names: set[str] = set(data.get("mcp_tool_to_server") or {})
             for tool in data.get("tool_definitions", []):
                 name = (tool.get("function") or {}).get("name") or tool.get("name")
                 if not name:
                     continue
-                if tool.get("function") == "mcp":
+                if name in mcp_names:
                     sources[name] = "mcp"
                 elif name in builtins:
                     sources[name] = "builtin"

--- a/src/host/credentials.py
+++ b/src/host/credentials.py
@@ -22,6 +22,7 @@ import re
 import time
 from collections.abc import Callable
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 import httpx
 
@@ -29,8 +30,11 @@ from src.agent.attachments import convert_openai_image_blocks
 from src.host.transcript import sanitize_for_provider
 from src.shared.errors import LLMAuthError, LLMConfigError
 from src.shared.models import KEYLESS_PROVIDERS, get_known_provider_names
-from src.shared.types import APIProxyRequest, APIProxyResponse
+from src.shared.types import CRED_HANDLE_RE, APIProxyRequest, APIProxyResponse
 from src.shared.utils import friendly_streaming_error, setup_logging
+
+if TYPE_CHECKING:
+    from src.host.permissions import PermissionMatrix
 
 logger = setup_logging("host.credentials")
 
@@ -3335,3 +3339,65 @@ class CredentialVault:
                 "fixed_cost_usd": cost,
             },
         )
+
+
+def resolve_cred_handles(
+    text: str,
+    *,
+    vault: CredentialVault,
+    permissions: PermissionMatrix,
+    agent_id: str,
+) -> tuple[str, list[str]]:
+    """Resolve ``$CRED{name}`` handles in *text* against the mesh vault.
+
+    Mesh-side, synchronous counterpart to
+    :func:`src.agent.builtins.http_tool._resolve_creds`. Both use the
+    shared :data:`src.shared.types.CRED_HANDLE_RE` regex; both perform
+    a single-pass replacement so a resolved value that happens to
+    contain ``$CRED{...}`` is never re-resolved.
+
+    Args:
+        text: Input string possibly containing one or more
+            ``$CRED{name}`` handles. Strings without any handle are
+            returned unchanged.
+        vault: The mesh credential vault.
+        permissions: Permission matrix used to gate each handle.
+        agent_id: The agent whose ``allowed_credentials`` patterns
+            apply to this resolution.
+
+    Returns:
+        A tuple of ``(resolved_text, resolved_secret_values)``. The
+        secret list lets callers redact resolved values from any
+        downstream log statement (mirroring the agent-side helper).
+
+    Raises:
+        ValueError: If a referenced credential does not exist in the
+            vault, or if the agent does not have permission to access
+            it. The message names the credential so the caller can
+            surface a clear error to the operator.
+    """
+    matches = CRED_HANDLE_RE.findall(text)
+    if not matches:
+        return text, []
+
+    resolved: dict[str, str] = {}
+    secrets: list[str] = []
+    for cred_name in set(matches):
+        if not permissions.can_access_credential(agent_id, cred_name):
+            raise ValueError(
+                f"Agent {agent_id!r} does not have permission to access "
+                f"credential {cred_name!r}.",
+            )
+        value = vault.resolve_credential(cred_name)
+        if value is None:
+            raise ValueError(
+                f"Credential {cred_name!r} referenced by agent "
+                f"{agent_id!r} does not exist in the vault.",
+            )
+        resolved[cred_name] = value
+        secrets.append(value)
+
+    resolved_text = CRED_HANDLE_RE.sub(
+        lambda m: resolved.get(m.group(1), m.group(0)), text,
+    )
+    return resolved_text, secrets

--- a/src/host/runtime.py
+++ b/src/host/runtime.py
@@ -22,9 +22,14 @@ import subprocess
 import threading
 import time
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
+from src.shared.types import CRED_HANDLE_RE
 from src.shared.utils import setup_logging
+
+if TYPE_CHECKING:
+    from src.host.credentials import CredentialVault
+    from src.host.permissions import PermissionMatrix
 
 logger = setup_logging("host.runtime")
 
@@ -37,8 +42,33 @@ def _docker_safe_name(agent_id: str) -> str:
     return _DOCKER_NAME_RE.sub("_", agent_id)
 
 
+def _mcp_servers_contain_cred_handles(mcp_servers: list[dict]) -> bool:
+    """Return True if any server's env value or args string contains a
+    ``$CRED{name}`` reference. Used for the pre-flight error when the
+    vault/permissions resolver has not been wired into the backend.
+    """
+    for s in mcp_servers:
+        for a in s.get("args") or []:
+            if isinstance(a, str) and CRED_HANDLE_RE.search(a):
+                return True
+        for v in (s.get("env") or {}).values():
+            if isinstance(v, str) and CRED_HANDLE_RE.search(v):
+                return True
+    return False
+
+
 class RuntimeBackend(abc.ABC):
     """Abstract backend for starting, stopping, and monitoring agents."""
+
+    # Class-level defaults for the mesh credential resolver. Wired by
+    # ``RuntimeContext`` via :meth:`set_credential_resolver` once the
+    # vault and permission matrix exist. Class-level placement means
+    # tests that bypass ``__init__`` via ``.__new__()`` still get safe
+    # ``None`` defaults — MCP configs with ``$CRED{...}`` handles will
+    # fail loudly at ``start_agent`` rather than silently shipping
+    # literal handles to subprocesses.
+    _vault: CredentialVault | None = None
+    _permissions: PermissionMatrix | None = None
 
     def __init__(self, mesh_host_port: int = 8420, project_root: str | None = None):
         self.mesh_host_port = mesh_host_port
@@ -49,6 +79,93 @@ class RuntimeBackend(abc.ABC):
         self.agents: dict[str, dict] = {}
         self.auth_tokens: dict[str, str] = {}
         self.extra_env: dict[str, str] = {}
+
+    def set_credential_resolver(
+        self,
+        *,
+        vault: CredentialVault | None,
+        permissions: PermissionMatrix | None,
+    ) -> None:
+        """Plumb the mesh credential vault and permission matrix into the
+        backend so it can resolve ``$CRED{name}`` handles inside
+        ``mcp_servers`` configs when starting an agent.
+
+        Idempotent — safe to call multiple times. Until called (or if
+        called with ``vault=None``), any MCP config containing a
+        credential handle will be rejected at ``start_agent`` so a
+        misconfigured deploy fails loudly rather than shipping literal
+        ``$CRED{...}`` strings to subprocesses.
+        """
+        self._vault = vault
+        self._permissions = permissions
+
+    def _build_mcp_servers_env(
+        self,
+        mcp_servers: list[dict] | None,
+        *,
+        agent_id: str,
+    ) -> str:
+        """Serialize ``mcp_servers`` for the ``MCP_SERVERS`` container
+        env var, resolving any ``$CRED{name}`` handles in env values
+        and args strings against the mesh credential vault.
+
+        ``command`` is passed through literally — handles there are
+        rejected at config validation time by
+        :class:`src.shared.types.MCPServerConfig`.
+
+        Raises ``ValueError`` if the config references credential
+        handles but the resolver has not been wired
+        (vault/permissions are ``None``), or if any referenced
+        credential is missing from the vault or denied by the agent's
+        ``allowed_credentials`` policy. Callers (``start_agent``)
+        propagate this so the failure surfaces through the existing
+        agent-restart error path.
+        """
+        if not mcp_servers:
+            return json.dumps(mcp_servers or [])
+
+        has_refs = _mcp_servers_contain_cred_handles(mcp_servers)
+        if not has_refs:
+            return json.dumps(mcp_servers)
+
+        if self._vault is None or self._permissions is None:
+            raise ValueError(
+                "MCP server config for agent "
+                f"{agent_id!r} contains $CRED{{...}} references but the "
+                "mesh credential vault is not wired into RuntimeBackend. "
+                "Call set_credential_resolver(vault=..., permissions=...) "
+                "before starting agents, or remove credential handles "
+                "from mcp_servers.",
+            )
+
+        from src.host.credentials import resolve_cred_handles
+
+        resolved_servers: list[dict] = []
+        for s in mcp_servers:
+            s_copy = dict(s)
+            args = s.get("args") or []
+            if args:
+                s_copy["args"] = [
+                    resolve_cred_handles(
+                        a, vault=self._vault, permissions=self._permissions,
+                        agent_id=agent_id,
+                    )[0]
+                    if isinstance(a, str) else a
+                    for a in args
+                ]
+            env = s.get("env") or {}
+            if env:
+                s_copy["env"] = {
+                    k: resolve_cred_handles(
+                        v, vault=self._vault, permissions=self._permissions,
+                        agent_id=agent_id,
+                    )[0]
+                    if isinstance(v, str) else v
+                    for k, v in env.items()
+                }
+            resolved_servers.append(s_copy)
+
+        return json.dumps(resolved_servers)
 
     @abc.abstractmethod
     def start_agent(
@@ -254,7 +371,9 @@ class DockerBackend(RuntimeBackend):
         if model:
             environment["LLM_MODEL"] = model
         if mcp_servers:
-            environment["MCP_SERVERS"] = json.dumps(mcp_servers)
+            environment["MCP_SERVERS"] = self._build_mcp_servers_env(
+                mcp_servers, agent_id=agent_id,
+            )
         if thinking:
             environment["THINKING"] = thinking
         environment.update(self.extra_env)
@@ -882,7 +1001,9 @@ class SandboxBackend(RuntimeBackend):
         if model:
             env_cfg["LLM_MODEL"] = model
         if mcp_servers:
-            env_cfg["MCP_SERVERS"] = json.dumps(mcp_servers)
+            env_cfg["MCP_SERVERS"] = self._build_mcp_servers_env(
+                mcp_servers, agent_id=agent_id,
+            )
         if thinking:
             env_cfg["THINKING"] = thinking
         env_cfg.update(self.extra_env)

--- a/src/shared/types.py
+++ b/src/shared/types.py
@@ -6,11 +6,12 @@ Agent containers and the host process share only these types.
 
 from __future__ import annotations
 
+import re
 import uuid
 from datetime import datetime, timezone
 from typing import Any, Literal
 
-from pydantic import BaseModel, Field, model_validator
+from pydantic import BaseModel, Field, field_validator, model_validator
 
 
 def _generate_id(prefix: str, length: int = 12) -> str:
@@ -33,6 +34,24 @@ its profile silently stomped the next time an operator ran the canary.
 
 AGENT_ID_RE_PATTERN = r"^[a-zA-Z0-9][a-zA-Z0-9_-]{0,63}$"
 """Canonical agent ID regex — 1-64 chars, alphanumeric start, then alphanumeric/hyphen/underscore."""
+
+MCP_SERVER_NAME_RE_PATTERN = r"^[a-zA-Z0-9][a-zA-Z0-9_-]{0,63}$"
+"""MCP server name regex — matches :data:`AGENT_ID_RE_PATTERN` convention.
+
+Used as a prefix when an MCP tool conflicts with a built-in skill or
+another server's tool (``mcp_<server>_<tool>`` — see
+:mod:`src.agent.mcp_client`).
+"""
+
+CRED_HANDLE_RE = re.compile(r"\$CRED\{([^}]+)\}")
+"""Credential handle regex — ``$CRED{name}`` references resolved by the
+mesh against :class:`src.host.credentials.CredentialVault` at the point
+of use.
+
+This is the canonical location. ``src.agent.builtins.CRED_HANDLE_RE``
+is a mirrored constant kept for back-compat; prefer importing from
+here.
+"""
 
 HARD_EDIT_FIELDS = frozenset({"model", "permissions", "budget", "thinking"})
 """Agent-config fields that earn the longer 30-min Undo window (the
@@ -376,6 +395,72 @@ class AgentPermissions(BaseModel):
 # === Agent Configuration ===
 
 
+class MCPServerConfig(BaseModel):
+    """Configuration for a single MCP (Model Context Protocol) server.
+
+    Each agent may declare zero or more servers via
+    :attr:`AgentConfig.mcp_servers`. The mesh launches each as a stdio
+    subprocess inside the agent container (see :mod:`src.agent.mcp_client`).
+
+    Credential handles (``$CRED{name}``) may appear in ``env`` values
+    and in ``args`` strings; the mesh resolves them against the
+    credential vault at agent start. They are **not** permitted in
+    ``command`` — rejected here so users get a clear validation error
+    instead of a confusing "executable not found" failure later.
+
+    The outer :class:`AgentConfig` keeps ``extra="allow"`` for forward
+    compatibility, but this nested model enforces ``extra="forbid"``
+    so typos like ``commnad`` fail loudly.
+    """
+
+    model_config = {"extra": "forbid"}
+
+    name: str = Field(
+        min_length=1, max_length=64, pattern=MCP_SERVER_NAME_RE_PATTERN,
+    )
+    command: str = Field(min_length=1, max_length=256)
+    args: list[str] = Field(default_factory=list, max_length=32)
+    env: dict[str, str] | None = None
+
+    @field_validator("command")
+    @classmethod
+    def _command_no_cred_handle(cls, v: str) -> str:
+        if CRED_HANDLE_RE.search(v):
+            raise ValueError(
+                "Credential handles ($CRED{...}) are not allowed in `command` "
+                "— use `env` or `args` instead.",
+            )
+        return v
+
+    @field_validator("args")
+    @classmethod
+    def _args_per_item_length(cls, v: list[str]) -> list[str]:
+        for i, a in enumerate(v):
+            if len(a) > 512:
+                raise ValueError(f"args[{i}] too long (max 512 chars)")
+        return v
+
+    @field_validator("env")
+    @classmethod
+    def _env_shape(
+        cls, v: dict[str, str] | None,
+    ) -> dict[str, str] | None:
+        if v is None:
+            return v
+        if len(v) > 32:
+            raise ValueError("env may have at most 32 entries")
+        for k, val in v.items():
+            if not k or len(k) > 128:
+                raise ValueError(
+                    f"invalid env key: {k!r} (must be 1-128 chars)",
+                )
+            if len(val) > 4096:
+                raise ValueError(
+                    f"env value for {k!r} too long (max 4096 chars)",
+                )
+        return v
+
+
 class AgentConfig(BaseModel):
     """Structured fields for an agent entry in ``config/agents.yaml``.
 
@@ -418,7 +503,33 @@ class AgentConfig(BaseModel):
     escalation_to: str | None = None
     forbidden: list[str] = Field(default_factory=list)
 
+    # MCP server configurations. Validated strictly via MCPServerConfig
+    # despite the outer ``extra="allow"`` policy (Pydantic enforces the
+    # nested model's ``extra="forbid"`` independently of the parent).
+    # Credential handles in env/args resolved by the mesh at agent start.
+    mcp_servers: list[MCPServerConfig] | None = None
+
     model_config = {"extra": "allow"}
+
+    @field_validator("mcp_servers")
+    @classmethod
+    def _no_duplicate_mcp_names(
+        cls, v: list[MCPServerConfig] | None,
+    ) -> list[MCPServerConfig] | None:
+        if not v:
+            return v
+        seen: set[str] = set()
+        dups: list[str] = []
+        for s in v:
+            lower = s.name.lower()
+            if lower in seen and lower not in dups:
+                dups.append(lower)
+            seen.add(lower)
+        if dups:
+            raise ValueError(
+                f"Duplicate MCP server names (case-insensitive): {dups}",
+            )
+        return v
 
 
 # === Teams ===

--- a/tests/test_cli_commands.py
+++ b/tests/test_cli_commands.py
@@ -1600,3 +1600,94 @@ class TestWorkplaceCLICommands:
         # And X-Origin so the human-confirmation gate accepts it
         assert "kind=human" in headers.get("X-Origin", "")
         assert "channel=cli" in headers.get("X-Origin", "")
+
+
+class TestLoadConfigMcpServersValidation:
+    """T7 — ``_load_config`` validates each agent's ``mcp_servers``
+    entries through :class:`MCPServerConfig`. Malformed entries are
+    logged and dropped at the load boundary so a single bad row
+    doesn't crash agent startup. The dashboard PUT path enforces the
+    same model on the write side; this is the safety net for legacy
+    rows written before the formal model existed.
+    """
+
+    def _write_agents_yaml(self, tmp_path, agents: dict) -> "Path":
+        agents_file = tmp_path / "agents.yaml"
+        agents_file.write_text(yaml.safe_dump({"agents": agents}))
+        return agents_file
+
+    def _load(self, tmp_path, agents_file):
+        from src.cli.config import _load_config
+        with (
+            patch("src.cli.config.AGENTS_FILE", agents_file),
+            patch("src.cli.config.CONFIG_FILE", tmp_path / "mesh.yaml"),
+            patch("src.cli.config.PROJECTS_DIR", tmp_path / "projects"),
+            patch("src.cli.config.NETWORK_FILE", tmp_path / "network.yaml"),
+        ):
+            return _load_config()
+
+    def test_well_formed_servers_load_cleanly(self, tmp_path):
+        agents_file = self._write_agents_yaml(tmp_path, {
+            "alpha": {
+                "role": "x",
+                "mcp_servers": [{
+                    "name": "linear", "command": "mcp-server-linear",
+                    "args": ["--workspace", "ol"],
+                    "env": {"K": "v"},
+                }],
+            },
+        })
+        cfg = self._load(tmp_path, agents_file)
+        servers = cfg["agents"]["alpha"]["mcp_servers"]
+        assert len(servers) == 1
+        assert servers[0]["name"] == "linear"
+        # Env survives the round-trip (Pydantic + model_dump).
+        assert servers[0]["env"] == {"K": "v"}
+
+    def test_malformed_entry_dropped_keeps_well_formed(self, tmp_path, caplog):
+        agents_file = self._write_agents_yaml(tmp_path, {
+            "alpha": {
+                "role": "x",
+                "mcp_servers": [
+                    # First entry is fine
+                    {"name": "good", "command": "x"},
+                    # Bad name regex (spaces) → drop with warning
+                    {"name": "bad name", "command": "y"},
+                    # Bad command ($CRED handle) → drop with warning
+                    {"name": "with_cred", "command": "$CRED{secret}"},
+                ],
+            },
+        })
+        with caplog.at_level("WARNING", logger="cli"):
+            cfg = self._load(tmp_path, agents_file)
+        servers = cfg["agents"]["alpha"]["mcp_servers"]
+        assert [s["name"] for s in servers] == ["good"]
+        # Two warnings — one per malformed row
+        warnings = [r for r in caplog.records if r.levelname == "WARNING"]
+        assert sum(
+            "Dropping malformed mcp_servers entry" in r.getMessage()
+            for r in warnings
+        ) == 2
+
+    def test_all_malformed_yields_none(self, tmp_path):
+        agents_file = self._write_agents_yaml(tmp_path, {
+            "alpha": {
+                "role": "x",
+                "mcp_servers": [
+                    {"name": "bad name", "command": "x"},
+                    {"command": "no_name_field"},  # missing name
+                ],
+            },
+        })
+        cfg = self._load(tmp_path, agents_file)
+        # Empty after drop is collapsed to None (matches the persisted
+        # convention used elsewhere — see _update_agent_field).
+        assert cfg["agents"]["alpha"]["mcp_servers"] is None
+
+    def test_no_mcp_servers_no_op(self, tmp_path):
+        # Agents without mcp_servers field are untouched.
+        agents_file = self._write_agents_yaml(tmp_path, {
+            "alpha": {"role": "x"},
+        })
+        cfg = self._load(tmp_path, agents_file)
+        assert "mcp_servers" not in cfg["agents"]["alpha"]

--- a/tests/test_cli_commands.py
+++ b/tests/test_cli_commands.py
@@ -3,6 +3,7 @@
 import json
 import os
 import tempfile
+from pathlib import Path
 from unittest.mock import patch
 
 import yaml

--- a/tests/test_credentials.py
+++ b/tests/test_credentials.py
@@ -11,6 +11,7 @@ from src.host.credentials import (
     CredentialVault,
     _extract_content,
     is_system_credential,
+    resolve_cred_handles,
 )
 from src.shared.types import APIProxyRequest, APIProxyResponse
 
@@ -4794,3 +4795,108 @@ class TestOAuthStreamDoesNotYieldUntypedFrame:
             "OAuth stream must not yield an untyped error frame before "
             f"raising LLMConfigError — got {yielded!r}"
         )
+
+
+# === resolve_cred_handles (mesh-side $CRED{name} resolver) ===
+
+
+@pytest.fixture
+def vault_with_creds(monkeypatch):
+    """A vault holding two agent-tier credentials."""
+    monkeypatch.setenv("OPENLEGION_CRED_LINEAR_TOKEN", "linear-secret-value")
+    monkeypatch.setenv("OPENLEGION_CRED_GITHUB_TOKEN", "ghp-secret-value")
+    return CredentialVault()
+
+
+@pytest.fixture
+def perms_allow_all():
+    """Permission matrix that allows any agent → any credential."""
+    p = MagicMock()
+    p.can_access_credential.return_value = True
+    return p
+
+
+@pytest.fixture
+def perms_deny_all():
+    """Permission matrix that denies any credential access."""
+    p = MagicMock()
+    p.can_access_credential.return_value = False
+    return p
+
+
+def test_resolve_no_handles_passthrough(vault_with_creds, perms_allow_all):
+    resolved, secrets = resolve_cred_handles(
+        "plain text with no handles",
+        vault=vault_with_creds, permissions=perms_allow_all, agent_id="a1",
+    )
+    assert resolved == "plain text with no handles"
+    assert secrets == []
+
+
+def test_resolve_single_handle(vault_with_creds, perms_allow_all):
+    resolved, secrets = resolve_cred_handles(
+        "Bearer $CRED{linear_token}",
+        vault=vault_with_creds, permissions=perms_allow_all, agent_id="a1",
+    )
+    assert resolved == "Bearer linear-secret-value"
+    assert secrets == ["linear-secret-value"]
+
+
+def test_resolve_multiple_distinct_handles(vault_with_creds, perms_allow_all):
+    resolved, secrets = resolve_cred_handles(
+        "a=$CRED{linear_token} b=$CRED{github_token}",
+        vault=vault_with_creds, permissions=perms_allow_all, agent_id="a1",
+    )
+    assert "linear-secret-value" in resolved
+    assert "ghp-secret-value" in resolved
+    assert set(secrets) == {"linear-secret-value", "ghp-secret-value"}
+
+
+def test_resolve_repeated_handle_resolves_once_replaces_all(
+    vault_with_creds, perms_allow_all,
+):
+    resolved, secrets = resolve_cred_handles(
+        "$CRED{linear_token} and $CRED{linear_token} again",
+        vault=vault_with_creds, permissions=perms_allow_all, agent_id="a1",
+    )
+    assert resolved == "linear-secret-value and linear-secret-value again"
+    # Deduped — the secret appears once in the redaction list.
+    assert secrets == ["linear-secret-value"]
+
+
+def test_resolve_missing_credential_raises(vault_with_creds, perms_allow_all):
+    with pytest.raises(ValueError) as excinfo:
+        resolve_cred_handles(
+            "$CRED{does_not_exist}",
+            vault=vault_with_creds, permissions=perms_allow_all, agent_id="a1",
+        )
+    msg = str(excinfo.value)
+    assert "does_not_exist" in msg
+    assert "a1" in msg  # error names the agent so operator can diagnose
+
+
+def test_resolve_permission_denied_raises(vault_with_creds, perms_deny_all):
+    with pytest.raises(ValueError) as excinfo:
+        resolve_cred_handles(
+            "$CRED{linear_token}",
+            vault=vault_with_creds, permissions=perms_deny_all, agent_id="a1",
+        )
+    assert "permission" in str(excinfo.value).lower()
+    assert "linear_token" in str(excinfo.value)
+
+
+def test_resolve_single_pass_no_recursion(monkeypatch, perms_allow_all):
+    """If a resolved value itself contains $CRED{...}, do NOT re-resolve it.
+    Matches the http_tool single-pass policy that prevents double-resolution.
+    """
+    monkeypatch.setenv("OPENLEGION_CRED_OUTER", "before $CRED{inner} after")
+    monkeypatch.setenv("OPENLEGION_CRED_INNER", "INNER-VALUE")
+    v = CredentialVault()
+    resolved, secrets = resolve_cred_handles(
+        "$CRED{outer}",
+        vault=v, permissions=perms_allow_all, agent_id="a1",
+    )
+    # The literal '$CRED{inner}' from the outer's value is preserved as-is.
+    assert resolved == "before $CRED{inner} after"
+    # Only the outer value is in the redaction list — inner was never read.
+    assert secrets == ["before $CRED{inner} after"]

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -1444,6 +1444,404 @@ class TestDashboardAgentConfig:
         assert data["thinking"] == "off"
         assert data["mcp_servers"] == []
 
+    @patch("src.cli.config._load_config")
+    def test_get_config_masks_mcp_env_values(self, mock_load):
+        """``GET /config`` must never return env values. Each server's
+        env dict is stripped; ``env_keys`` carries the variable names so
+        the dashboard can render the env list without ever holding the
+        plaintext secrets or ``$CRED{name}`` handles."""
+        mock_load.return_value = {
+            "llm": {"default_model": "openai/gpt-4.1-mini"},
+            "agents": {
+                "alpha": {
+                    "model": "openai/gpt-4.1",
+                    "mcp_servers": [{
+                        "name": "linear",
+                        "command": "mcp-server-linear",
+                        "args": ["--workspace", "ol"],
+                        "env": {
+                            "LINEAR_API_KEY": "lin_pat_super_secret_123",
+                            "DEBUG": "1",
+                        },
+                    }],
+                },
+            },
+        }
+        resp = self.client.get("/dashboard/api/agents/alpha/config")
+        data = resp.json()
+        s = data["mcp_servers"][0]
+        # The env field is OMITTED entirely (not returned as null).
+        # Round-tripping the GET back through PUT must not accidentally
+        # clear env — PR's PUT contract treats "env absent" as preserve.
+        assert "env" not in s
+        # env_keys carries the variable names, sorted, with no values.
+        assert s["env_keys"] == ["DEBUG", "LINEAR_API_KEY"]
+        # Other fields pass through untouched.
+        assert s["name"] == "linear"
+        assert s["command"] == "mcp-server-linear"
+        assert s["args"] == ["--workspace", "ol"]
+        # No env values leak anywhere in the response payload.
+        assert "lin_pat_super_secret_123" not in resp.text
+
+    @patch("src.cli.config._load_config")
+    def test_get_config_no_env_returns_empty_env_keys(self, mock_load):
+        mock_load.return_value = {
+            "llm": {"default_model": "openai/gpt-4.1-mini"},
+            "agents": {
+                "alpha": {
+                    "model": "openai/gpt-4.1",
+                    "mcp_servers": [{
+                        "name": "fs", "command": "mcp-server-fs",
+                    }],
+                },
+            },
+        }
+        resp = self.client.get("/dashboard/api/agents/alpha/config")
+        data = resp.json()
+        s = data["mcp_servers"][0]
+        assert "env" not in s
+        assert s["env_keys"] == []
+
+    @patch("src.cli.config._update_agent_field")
+    @patch("src.cli.config._load_config")
+    def test_audit_log_redacts_mcp_env_values(self, mock_load, _mock_update):
+        """When ``mcp_servers`` is edited, the audit_log row stores env
+        KEYS only — never values. Values may be ``$CRED{name}`` handles
+        or raw secrets; either way they don't belong in audit storage.
+        """
+        mock_load.return_value = {
+            "llm": {"default_model": "openai/gpt-4.1-mini"},
+            "agents": {
+                "alpha": {
+                    "model": "openai/gpt-4.1",
+                    "mcp_servers": [{
+                        "name": "linear", "command": "x",
+                        "env": {"OLD_KEY": "old-secret-value"},
+                    }],
+                },
+            },
+        }
+        # PUT a new mcp_servers payload — old has OLD_KEY value, new has
+        # NEW_KEY value. Both env VALUES must be absent from the audit row.
+        resp = self.client.put(
+            "/dashboard/api/agents/alpha/config",
+            json={"mcp_servers": [{
+                "name": "linear", "command": "x",
+                "env": {"NEW_KEY": "new-secret-value"},
+            }]},
+        )
+        assert resp.status_code == 200
+
+        # Inspect what landed in the audit_log via the operator-audit
+        # endpoint (the dashboard surface that exposes blackboard.audit_log).
+        audit_resp = self.client.get("/dashboard/api/operator-audit")
+        assert audit_resp.status_code == 200
+        entries = audit_resp.json().get("entries", [])
+        mcp_rows = [r for r in entries if r.get("field") == "mcp_servers"]
+        assert mcp_rows, f"no mcp_servers audit row found in {entries!r}"
+        row = mcp_rows[0]
+        before = row.get("before_value") or ""
+        after = row.get("after_value") or ""
+        # CRITICAL: env values must NOT appear in either before or after.
+        assert "old-secret-value" not in before, (
+            f"old env value leaked into audit_log.before_value: {before!r}"
+        )
+        assert "new-secret-value" not in after, (
+            f"new env value leaked into audit_log.after_value: {after!r}"
+        )
+        # Env keys ARE preserved so reviewers can see what changed.
+        assert "OLD_KEY" in before
+        assert "NEW_KEY" in after
+
+    # ── T5: PUT env preserve/replace + permission + diff ──────────────
+
+    @patch("src.cli.config._update_agent_field")
+    @patch("src.cli.config._load_config")
+    def test_get_then_put_roundtrip_safe(self, mock_load, mock_update):
+        """The exact GET response replayed through PUT must succeed —
+        otherwise the dashboard UI breaks for any "load config, edit
+        one field, save back" flow. GET adds ``env_keys`` as the masked
+        stand-in for env; PUT must strip that before Pydantic validation
+        (``MCPServerConfig`` has ``extra="forbid"`` and would otherwise
+        reject the round-trip)."""
+        mock_load.return_value = {
+            "llm": {"default_model": "openai/gpt-4.1-mini"},
+            "agents": {
+                "alpha": {
+                    "model": "openai/gpt-4.1",
+                    "mcp_servers": [{
+                        "name": "linear", "command": "x",
+                        "args": ["--workspace", "ol"],
+                        "env": {"LINEAR_API_KEY": "kept-secret"},
+                    }],
+                },
+            },
+        }
+        # GET first.
+        get_resp = self.client.get("/dashboard/api/agents/alpha/config")
+        assert get_resp.status_code == 200
+        round_trip = get_resp.json()["mcp_servers"]
+        assert "env_keys" in round_trip[0]  # GET adds it
+        assert "env" not in round_trip[0]   # GET omits it
+
+        # PUT the exact GET response back.
+        put_resp = self.client.put(
+            "/dashboard/api/agents/alpha/config",
+            json={"mcp_servers": round_trip},
+        )
+        assert put_resp.status_code == 200, put_resp.json()
+        # No restart triggered — env preserved → canonical diff is empty.
+        assert put_resp.json()["restart_required"] is False
+
+    @patch("src.cli.config._update_agent_field")
+    @patch("src.cli.config._load_config")
+    def test_put_config_env_omitted_preserves_existing(
+        self, mock_load, mock_update,
+    ):
+        """When the PUT body lists a server with no ``env`` key, the
+        persisted env (matched by server name) is preserved. This keeps
+        a GET → edit → PUT round-trip from accidentally clearing secrets
+        the dashboard never showed."""
+        mock_load.return_value = {
+            "llm": {"default_model": "openai/gpt-4.1-mini"},
+            "agents": {
+                "alpha": {
+                    "model": "openai/gpt-4.1",
+                    "mcp_servers": [{
+                        "name": "linear", "command": "x",
+                        "env": {"LINEAR_API_KEY": "kept-secret"},
+                    }],
+                },
+            },
+        }
+        # PUT same server, no env field → should preserve.
+        resp = self.client.put(
+            "/dashboard/api/agents/alpha/config",
+            json={"mcp_servers": [{
+                "name": "linear", "command": "x",
+                "args": ["--debug"],  # changing args, not env
+            }]},
+        )
+        assert resp.status_code == 200
+        # Find the persisted payload from the mocked _update_agent_field call.
+        calls = [c for c in mock_update.call_args_list if c.args[1] == "mcp_servers"]
+        assert calls, "expected mcp_servers to be written"
+        written = calls[-1].args[2]
+        # Env preserved verbatim.
+        assert written[0]["env"] == {"LINEAR_API_KEY": "kept-secret"}
+        # Args changed as requested.
+        assert written[0]["args"] == ["--debug"]
+
+    @patch("src.cli.config._update_agent_field")
+    @patch("src.cli.config._load_config")
+    def test_put_config_env_present_replaces_wholesale(
+        self, mock_load, mock_update,
+    ):
+        mock_load.return_value = {
+            "llm": {"default_model": "openai/gpt-4.1-mini"},
+            "agents": {
+                "alpha": {
+                    "model": "openai/gpt-4.1",
+                    "mcp_servers": [{
+                        "name": "linear", "command": "x",
+                        "env": {"OLD": "v1"},
+                    }],
+                },
+            },
+        }
+        resp = self.client.put(
+            "/dashboard/api/agents/alpha/config",
+            json={"mcp_servers": [{
+                "name": "linear", "command": "x",
+                "env": {"NEW": "v2"},  # explicit env → replace
+            }]},
+        )
+        assert resp.status_code == 200
+        calls = [c for c in mock_update.call_args_list if c.args[1] == "mcp_servers"]
+        written = calls[-1].args[2]
+        assert written[0]["env"] == {"NEW": "v2"}
+        # OLD must be gone.
+        assert "OLD" not in (written[0].get("env") or {})
+
+    @patch("src.cli.config._update_agent_field")
+    @patch("src.cli.config._load_config")
+    def test_put_config_env_empty_dict_clears(self, mock_load, mock_update):
+        mock_load.return_value = {
+            "llm": {"default_model": "openai/gpt-4.1-mini"},
+            "agents": {
+                "alpha": {
+                    "model": "openai/gpt-4.1",
+                    "mcp_servers": [{
+                        "name": "linear", "command": "x", "env": {"X": "y"},
+                    }],
+                },
+            },
+        }
+        resp = self.client.put(
+            "/dashboard/api/agents/alpha/config",
+            json={"mcp_servers": [{
+                "name": "linear", "command": "x", "env": {},
+            }]},
+        )
+        assert resp.status_code == 200
+        calls = [c for c in mock_update.call_args_list if c.args[1] == "mcp_servers"]
+        written = calls[-1].args[2]
+        # env_after must NOT have any keys (empty dict or None — both
+        # canonicalize to None in storage; we accept either).
+        assert not (written[0].get("env") or {})
+
+    @patch("src.cli.config._update_agent_field")
+    @patch("src.cli.config._load_config")
+    def test_put_config_noop_does_not_trigger_restart(
+        self, mock_load, mock_update,
+    ):
+        """A GET → unchanged PUT round-trip must not flip
+        ``mcp_touched`` — that was the prior bug where any PUT
+        containing ``mcp_servers`` (even unchanged) triggered a restart."""
+        existing = [{
+            "name": "linear", "command": "mcp-server-linear",
+            "args": ["--workspace", "ol"],
+            "env": {"K": "v"},
+        }]
+        mock_load.return_value = {
+            "llm": {"default_model": "openai/gpt-4.1-mini"},
+            "agents": {
+                "alpha": {
+                    "model": "openai/gpt-4.1",
+                    "mcp_servers": existing,
+                },
+            },
+        }
+        # Replay the exact persisted payload — no real change.
+        resp = self.client.put(
+            "/dashboard/api/agents/alpha/config",
+            json={"mcp_servers": existing},
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        # restart_required must be False — no diff, no restart.
+        assert data["restart_required"] is False
+        # mcp_servers must NOT appear in updated (no write happened).
+        assert "mcp_servers" not in data.get("updated", [])
+
+    @patch("src.cli.config._update_agent_field")
+    @patch("src.cli.config._load_config")
+    def test_put_config_invalid_name_returns_structured_400(
+        self, mock_load, mock_update,
+    ):
+        """Pydantic validation surfaces structured errors (field path +
+        message) so the dashboard can map back to the offending input."""
+        mock_load.return_value = {
+            "llm": {"default_model": "openai/gpt-4.1-mini"},
+            "agents": {"alpha": {"model": "openai/gpt-4.1"}},
+        }
+        resp = self.client.put(
+            "/dashboard/api/agents/alpha/config",
+            json={"mcp_servers": [{
+                "name": "bad name with spaces", "command": "x",
+            }]},
+        )
+        assert resp.status_code == 400
+        detail = resp.json().get("detail")
+        # Structured: {"field": "mcp_servers", "errors": [Pydantic-error-dicts]}
+        assert isinstance(detail, dict)
+        assert detail["field"] == "mcp_servers"
+        assert any("name" in str(e.get("loc", "")) for e in detail["errors"])
+
+    @patch("src.cli.config._update_agent_field")
+    @patch("src.cli.config._load_config")
+    def test_put_config_rejects_cred_in_command(self, mock_load, mock_update):
+        mock_load.return_value = {
+            "llm": {"default_model": "openai/gpt-4.1-mini"},
+            "agents": {"alpha": {"model": "openai/gpt-4.1"}},
+        }
+        resp = self.client.put(
+            "/dashboard/api/agents/alpha/config",
+            json={"mcp_servers": [{
+                "name": "x", "command": "$CRED{secret}",
+            }]},
+        )
+        assert resp.status_code == 400
+
+    @patch("src.cli.config._update_agent_field")
+    @patch("src.cli.config._load_config")
+    def test_put_config_rejects_cred_permission_denied(
+        self, mock_load, mock_update,
+    ):
+        """Agent's ``allowed_credentials`` gates env $CRED references."""
+        mock_load.return_value = {
+            "llm": {"default_model": "openai/gpt-4.1-mini"},
+            "agents": {"alpha": {"model": "openai/gpt-4.1"}},
+        }
+        # Pre-load a credential into the vault (so existence check passes),
+        # but deny the agent permission to use it.
+        vault = self.components["credential_vault"]
+        vault.credentials["forbidden_cred"] = "any-value"
+        perms = self.components["permissions"]
+        perms.can_access_credential = MagicMock(return_value=False)
+
+        resp = self.client.put(
+            "/dashboard/api/agents/alpha/config",
+            json={"mcp_servers": [{
+                "name": "x", "command": "y",
+                "env": {"KEY": "$CRED{forbidden_cred}"},
+            }]},
+        )
+        assert resp.status_code == 400
+        assert "permission" in resp.json()["detail"].lower()
+
+    @patch("src.cli.config._update_agent_field")
+    @patch("src.cli.config._load_config")
+    def test_put_config_rejects_missing_cred(self, mock_load, mock_update):
+        """A $CRED reference to a credential not in the vault is
+        rejected at PUT time with a clear actionable error."""
+        mock_load.return_value = {
+            "llm": {"default_model": "openai/gpt-4.1-mini"},
+            "agents": {"alpha": {"model": "openai/gpt-4.1"}},
+        }
+        # Permissions allow anything; vault returns None (cred missing).
+        perms = self.components["permissions"]
+        perms.can_access_credential = MagicMock(return_value=True)
+        vault = self.components["credential_vault"]
+        vault.resolve_credential = MagicMock(return_value=None)
+
+        resp = self.client.put(
+            "/dashboard/api/agents/alpha/config",
+            json={"mcp_servers": [{
+                "name": "x", "command": "y",
+                "env": {"KEY": "$CRED{does_not_exist}"},
+            }]},
+        )
+        assert resp.status_code == 400
+        assert "does not exist" in resp.json()["detail"].lower()
+
+    @patch("src.cli.config._update_agent_field")
+    @patch("src.cli.config._load_config")
+    def test_put_config_cred_in_args_also_validated(
+        self, mock_load, mock_update,
+    ):
+        """$CRED handles in ``args`` strings go through the same
+        permission + existence check as env values."""
+        mock_load.return_value = {
+            "llm": {"default_model": "openai/gpt-4.1-mini"},
+            "agents": {"alpha": {"model": "openai/gpt-4.1"}},
+        }
+        perms = self.components["permissions"]
+        perms.can_access_credential = MagicMock(return_value=True)
+        vault = self.components["credential_vault"]
+        vault.resolve_credential = MagicMock(return_value=None)
+
+        resp = self.client.put(
+            "/dashboard/api/agents/alpha/config",
+            json={"mcp_servers": [{
+                "name": "x", "command": "y",
+                "args": ["--token", "$CRED{missing_in_args}"],
+            }]},
+        )
+        assert resp.status_code == 400
+        # Error message should point at the args path
+        assert "args" in resp.json()["detail"].lower()
+
     @patch("src.cli.config._update_agent_field")
     @patch("src.cli.config._load_config")
     def test_put_config_thinking(self, mock_load, mock_update):
@@ -1518,9 +1916,17 @@ class TestDashboardAgentConfig:
     @patch("src.cli.config._update_agent_field")
     @patch("src.cli.config._load_config")
     def test_put_config_mcp_servers_empty_clears(self, mock_load, mock_update):
+        """PUT with empty list MUST clear when persisted is non-empty
+        (real diff). When persisted is already empty, it's a no-op — see
+        ``test_put_config_noop_does_not_trigger_restart``."""
         mock_load.return_value = {
             "llm": {"default_model": "openai/gpt-4.1-mini"},
-            "agents": {"alpha": {"model": "openai/gpt-4.1-mini"}},
+            "agents": {
+                "alpha": {
+                    "model": "openai/gpt-4.1-mini",
+                    "mcp_servers": [{"name": "linear", "command": "x"}],
+                },
+            },
         }
         resp = self.client.put(
             "/dashboard/api/agents/alpha/config",
@@ -5624,3 +6030,115 @@ class TestDashboardEventBusCoverage:
         assert resp.status_code == 400
         deletes = [e for e in self.captured if e["type"] == "blackboard_delete"]
         assert deletes == []
+
+
+class TestCapabilitiesMcpForwarding:
+    """``GET /dashboard/api/agents/{id}/capabilities`` proxies the agent's
+    ``/capabilities`` and (a) forwards the new ``mcp_servers`` status
+    registry and ``mcp_tool_to_server`` mapping unchanged, and (b)
+    correctly classifies MCP tools in ``tool_sources`` using
+    ``mcp_tool_to_server`` — fixing the prior broken check
+    (``tool.get("function") == "mcp"`` was always False because the
+    OpenAI tool format puts a dict at ``function``).
+    """
+
+    def setup_method(self):
+        self.tmp_dir = tempfile.mkdtemp(prefix="ol_caps_")
+        self.components = _make_components(self.tmp_dir, include_v2=True)
+        self.transport_mock = self.components["transport"]
+        self.client = _make_client(self.components)
+
+    def teardown_method(self):
+        _teardown(self.components)
+        shutil.rmtree(self.tmp_dir, ignore_errors=True)
+
+    def test_forwards_mcp_servers_status_registry(self):
+        """The agent's per-server status registry passes through
+        unchanged so the dashboard can render status dots."""
+        self.transport_mock.request = AsyncMock(return_value={
+            "agent_id": "alpha", "role": "r", "skills": {},
+            "tool_definitions": [], "tool_sources": {},
+            "mcp_servers": [
+                {"name": "linear", "state": "running", "tools_count": 8, "error": None},
+                {"name": "github", "state": "failed", "tools_count": 0,
+                 "error": "command not found: gh-mcp"},
+            ],
+        })
+        resp = self.client.get("/dashboard/api/agents/alpha/capabilities")
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["mcp_servers"][0]["name"] == "linear"
+        assert body["mcp_servers"][0]["state"] == "running"
+        assert body["mcp_servers"][1]["error"] == "command not found: gh-mcp"
+
+    def test_forwards_mcp_tool_to_server_mapping(self):
+        self.transport_mock.request = AsyncMock(return_value={
+            "agent_id": "alpha", "role": "r", "skills": {},
+            "tool_definitions": [], "tool_sources": {},
+            "mcp_tool_to_server": {
+                "linear_create_issue": "linear",
+                "gh_list_repos": "github",
+            },
+        })
+        resp = self.client.get("/dashboard/api/agents/alpha/capabilities")
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["mcp_tool_to_server"] == {
+            "linear_create_issue": "linear",
+            "gh_list_repos": "github",
+        }
+
+    def test_backfill_classifies_mcp_tools_via_mapping(self):
+        """When the agent supplies ``mcp_tool_to_server`` and does NOT
+        supply ``tool_sources``, the dashboard backfill must mark
+        those names as ``source=mcp``. Pre-fix this branch was dead
+        because the prior ``tool.get('function') == 'mcp'`` check
+        was always False against the OpenAI tool format.
+        """
+        self.transport_mock.request = AsyncMock(return_value={
+            "agent_id": "alpha", "role": "r", "skills": {},
+            "tool_definitions": [
+                {"type": "function", "function": {"name": "linear_create_issue"}},
+                {"type": "function", "function": {"name": "gh_list_repos"}},
+            ],
+            "mcp_tool_to_server": {
+                "linear_create_issue": "linear",
+                "gh_list_repos": "github",
+            },
+            # tool_sources intentionally absent → forces backfill
+        })
+        resp = self.client.get("/dashboard/api/agents/alpha/capabilities")
+        body = resp.json()
+        assert body["tool_sources"]["linear_create_issue"] == "mcp"
+        assert body["tool_sources"]["gh_list_repos"] == "mcp"
+
+    def test_backfill_legacy_agent_without_mapping(self):
+        """An older agent (no ``mcp_tool_to_server``) cannot have its
+        MCP tools identified — we just classify by builtin/custom.
+        This is the documented limitation when the side-channel is
+        absent; the new backfill must not crash.
+        """
+        self.transport_mock.request = AsyncMock(return_value={
+            "agent_id": "alpha", "role": "r", "skills": {},
+            "tool_definitions": [
+                {"type": "function", "function": {"name": "some_unknown_tool"}},
+            ],
+            # No tool_sources, no mcp_tool_to_server
+        })
+        resp = self.client.get("/dashboard/api/agents/alpha/capabilities")
+        body = resp.json()
+        # Falls into "custom" (not "mcp", not "builtin")
+        assert body["tool_sources"]["some_unknown_tool"] == "custom"
+
+    def test_omits_mcp_fields_when_agent_does_not_provide(self):
+        """An older agent (no MCP client wired, or pre-T6 code) won't
+        emit the new fields; the dashboard response simply omits them.
+        """
+        self.transport_mock.request = AsyncMock(return_value={
+            "agent_id": "alpha", "role": "r", "skills": {},
+            "tool_definitions": [], "tool_sources": {},
+        })
+        resp = self.client.get("/dashboard/api/agents/alpha/capabilities")
+        body = resp.json()
+        assert "mcp_servers" not in body
+        assert "mcp_tool_to_server" not in body

--- a/tests/test_mcp_client.py
+++ b/tests/test_mcp_client.py
@@ -277,6 +277,7 @@ class TestMCPClientLifecycle:
         client._sessions = {"test": MagicMock()}
         client._tool_to_server = {"tool": "test"}
         client._tool_schemas = {"tool": {"name": "tool"}}
+        client._server_status = {"test": {"state": "running"}}
 
         client._exit_stack = AsyncMock()
         client._exit_stack.aclose = AsyncMock()
@@ -287,6 +288,7 @@ class TestMCPClientLifecycle:
         assert len(client._sessions) == 0
         assert len(client._tool_to_server) == 0
         assert len(client._tool_schemas) == 0
+        assert len(client._server_status) == 0
 
     def test_has_tool(self):
         """has_tool returns True only for registered MCP tools."""
@@ -294,4 +296,180 @@ class TestMCPClientLifecycle:
         client._tool_to_server = {"mcp_tool": "server"}
 
         assert client.has_tool("mcp_tool")
+
+
+# === Per-server status registry + tool-to-server mapping (T6) ===
+
+
+class TestMCPServerStatusRegistry:
+    """The MCPClient tracks per-server startup/discovery status so the
+    dashboard can render status dots and surface the error string on a
+    failed-start row click. NOT live health — registry reflects the
+    last ``start()`` attempt only.
+    """
+
+    @pytest.mark.asyncio
+    async def test_running_status_recorded_on_successful_start(self):
+        client = MCPClient()
+
+        session = AsyncMock()
+        tools_result = MagicMock()
+        tools_result.tools = [
+            _make_mock_tool("read_file"),
+            _make_mock_tool("write_file"),
+        ]
+        session.initialize = AsyncMock()
+        session.list_tools = AsyncMock(return_value=tools_result)
+
+        p1 = patch("src.agent.mcp_client.StdioServerParameters", MagicMock())
+        p2 = patch("src.agent.mcp_client.stdio_client")
+        p3 = patch("src.agent.mcp_client.ClientSession")
+
+        with p1, p2 as mock_stdio, p3 as mock_cs_cls:
+            _setup_mock_server(mock_stdio, mock_cs_cls, session)
+            await client.start([{"name": "fs", "command": "x"}])
+
+        statuses = client.list_server_statuses()
+        assert len(statuses) == 1
+        assert statuses[0] == {
+            "name": "fs", "state": "running", "tools_count": 2, "error": None,
+        }
+
+    @pytest.mark.asyncio
+    async def test_failed_status_captures_error_message(self):
+        client = MCPClient()
+
+        def boom(params):
+            cm = AsyncMock()
+            cm.__aenter__ = AsyncMock(
+                side_effect=RuntimeError("command not found: linear-server"),
+            )
+            return cm
+
+        p1 = patch("src.agent.mcp_client.StdioServerParameters", MagicMock())
+        p2 = patch("src.agent.mcp_client.stdio_client", side_effect=boom)
+        p3 = patch("src.agent.mcp_client.ClientSession")
+
+        with p1, p2, p3:
+            await client.start([{"name": "linear", "command": "linear-server"}])
+
+        statuses = client.list_server_statuses()
+        assert len(statuses) == 1
+        s = statuses[0]
+        assert s["name"] == "linear"
+        assert s["state"] == "failed"
+        assert s["tools_count"] == 0
+        assert "command not found" in s["error"]
+
+    @pytest.mark.asyncio
+    async def test_mixed_success_failure_recorded_independently(self):
+        """A failing server doesn't tank the registry entry for a
+        successful sibling — both must appear with their respective
+        states. Mirrors the existing graceful-failure behavior.
+        """
+        client = MCPClient()
+
+        good_session = AsyncMock()
+        good_tools = MagicMock()
+        good_tools.tools = [_make_mock_tool("ok_tool")]
+        good_session.initialize = AsyncMock()
+        good_session.list_tools = AsyncMock(return_value=good_tools)
+
+        call_count = 0
+
+        def side_effect(params):
+            nonlocal call_count
+            call_count += 1
+            cm = AsyncMock()
+            if call_count == 1:
+                cm.__aenter__ = AsyncMock(side_effect=RuntimeError("bad"))
+            else:
+                cm.__aenter__ = AsyncMock(return_value=(MagicMock(), MagicMock()))
+            return cm
+
+        p1 = patch("src.agent.mcp_client.StdioServerParameters", MagicMock())
+        p2 = patch("src.agent.mcp_client.stdio_client", side_effect=side_effect)
+        p3 = patch("src.agent.mcp_client.ClientSession")
+
+        with p1, p2, p3 as mock_cs_cls:
+            scm = AsyncMock()
+            scm.__aenter__ = AsyncMock(return_value=good_session)
+            mock_cs_cls.return_value = scm
+            await client.start([
+                {"name": "bad", "command": "x"},
+                {"name": "good", "command": "y"},
+            ])
+
+        by_name = {s["name"]: s for s in client.list_server_statuses()}
+        assert by_name["bad"]["state"] == "failed"
+        assert by_name["bad"]["tools_count"] == 0
+        assert by_name["good"]["state"] == "running"
+        assert by_name["good"]["tools_count"] == 1
+
+
+class TestMCPToolToServerMapping:
+    """The ``get_tool_to_server`` side-channel lets the dashboard filter
+    the existing tool list by MCP server when the user clicks a
+    server's tool-count badge. Captures both non-conflicting tool
+    names AND the conflict-rename case (``mcp_<server>_<tool>``).
+    """
+
+    @pytest.mark.asyncio
+    async def test_non_conflict_tool_maps_to_server_under_original_name(self):
+        client = MCPClient()
+
+        session = AsyncMock()
+        tools_result = MagicMock()
+        tools_result.tools = [_make_mock_tool("read_file")]
+        session.initialize = AsyncMock()
+        session.list_tools = AsyncMock(return_value=tools_result)
+
+        p1 = patch("src.agent.mcp_client.StdioServerParameters", MagicMock())
+        p2 = patch("src.agent.mcp_client.stdio_client")
+        p3 = patch("src.agent.mcp_client.ClientSession")
+        with p1, p2 as mock_stdio, p3 as mock_cs_cls:
+            _setup_mock_server(mock_stdio, mock_cs_cls, session)
+            await client.start([{"name": "fs", "command": "x"}])
+
+        mapping = client.get_tool_to_server()
+        assert mapping == {"read_file": "fs"}
+
+    @pytest.mark.asyncio
+    async def test_conflict_renamed_tool_maps_under_prefixed_name(self):
+        # A tool name that collides with a built-in gets renamed to
+        # ``mcp_<server>_<tool>``; the mapping must use that key (the
+        # one the LLM and dashboard see) so filtering works.
+        client = MCPClient()
+
+        session = AsyncMock()
+        tools_result = MagicMock()
+        tools_result.tools = [_make_mock_tool("exec_command")]
+        session.initialize = AsyncMock()
+        session.list_tools = AsyncMock(return_value=tools_result)
+
+        p1 = patch("src.agent.mcp_client.StdioServerParameters", MagicMock())
+        p2 = patch("src.agent.mcp_client.stdio_client")
+        p3 = patch("src.agent.mcp_client.ClientSession")
+        with p1, p2 as mock_stdio, p3 as mock_cs_cls:
+            _setup_mock_server(mock_stdio, mock_cs_cls, session)
+            # ``exec_command`` collides with a built-in name → renamed
+            await client.start(
+                [{"name": "shell", "command": "x"}],
+                builtin_names={"exec_command"},
+            )
+
+        mapping = client.get_tool_to_server()
+        # Renamed key, not the original ``exec_command``
+        assert "mcp_shell_exec_command" in mapping
+        assert mapping["mcp_shell_exec_command"] == "shell"
+        # Original name is NOT in the mapping (it's the built-in's name)
+        assert "exec_command" not in mapping
+
+    def test_get_tool_to_server_returns_snapshot_not_alias(self):
+        """Mutating the returned dict must not bleed into MCPClient state."""
+        client = MCPClient()
+        client._tool_to_server = {"a": "s1"}
+        snap = client.get_tool_to_server()
+        snap["b"] = "s2"
+        assert "b" not in client._tool_to_server
         assert not client.has_tool("other_tool")

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -1450,3 +1450,161 @@ class TestEntrypointHelpers:
         )
         assert result.returncode == 0
         assert "skipping firewall setup" in result.stderr
+
+
+# ── _build_mcp_servers_env: $CRED{name} resolution at agent start ──
+
+
+class TestBuildMcpServersEnv:
+    """The mesh resolves $CRED handles in mcp_servers env values and args
+    just before serializing MCP_SERVERS for the agent container. The
+    command field is left literal (handles there are rejected at config
+    validation time). When the vault is not wired, configs with handles
+    must fail loudly so a misconfigured deploy doesn't ship literal
+    ``$CRED{...}`` to subprocesses.
+    """
+
+    def _backend(self, vault=None, permissions=None):
+        b = _make_docker_backend()
+        if vault is not None:
+            b._vault = vault
+        if permissions is not None:
+            b._permissions = permissions
+        return b
+
+    def _vault_with(self, monkeypatch, **creds):
+        from src.host.credentials import CredentialVault
+        for name, value in creds.items():
+            monkeypatch.setenv(f"OPENLEGION_CRED_{name.upper()}", value)
+        return CredentialVault()
+
+    def _perms_allow_all(self):
+        p = MagicMock()
+        p.can_access_credential.return_value = True
+        return p
+
+    def _perms_deny_all(self):
+        p = MagicMock()
+        p.can_access_credential.return_value = False
+        return p
+
+    def test_empty_servers_returns_empty_json_array(self):
+        b = self._backend()
+        assert b._build_mcp_servers_env(None, agent_id="a1") == "[]"
+        assert b._build_mcp_servers_env([], agent_id="a1") == "[]"
+
+    def test_plain_config_no_handles_passes_through(self):
+        b = self._backend()
+        servers = [{
+            "name": "fs", "command": "mcp-server-fs", "args": ["/data"],
+            "env": {"DEBUG": "1"},
+        }]
+        result = json.loads(b._build_mcp_servers_env(servers, agent_id="a1"))
+        assert result == servers
+
+    def test_handle_in_env_resolves_when_vault_wired(self, monkeypatch):
+        b = self._backend(
+            vault=self._vault_with(monkeypatch, linear_token="LINEAR-SECRET"),
+            permissions=self._perms_allow_all(),
+        )
+        servers = [{
+            "name": "linear", "command": "mcp-server-linear",
+            "env": {"API_KEY": "$CRED{linear_token}"},
+        }]
+        result = json.loads(b._build_mcp_servers_env(servers, agent_id="a1"))
+        assert result[0]["env"]["API_KEY"] == "LINEAR-SECRET"
+
+    def test_handle_in_args_resolves_when_vault_wired(self, monkeypatch):
+        b = self._backend(
+            vault=self._vault_with(monkeypatch, linear_token="LINEAR-SECRET"),
+            permissions=self._perms_allow_all(),
+        )
+        servers = [{
+            "name": "linear", "command": "mcp-server-linear",
+            "args": ["--token", "$CRED{linear_token}"],
+        }]
+        result = json.loads(b._build_mcp_servers_env(servers, agent_id="a1"))
+        assert result[0]["args"] == ["--token", "LINEAR-SECRET"]
+
+    def test_handle_in_env_without_vault_raises_clearly(self):
+        # vault and permissions still None (class defaults).
+        b = self._backend()
+        servers = [{
+            "name": "x", "command": "y",
+            "env": {"KEY": "$CRED{anything}"},
+        }]
+        with pytest.raises(ValueError) as excinfo:
+            b._build_mcp_servers_env(servers, agent_id="a1")
+        msg = str(excinfo.value)
+        assert "$CRED" in msg
+        assert "a1" in msg
+        assert "set_credential_resolver" in msg
+
+    def test_handle_in_args_without_vault_raises_clearly(self):
+        b = self._backend()
+        servers = [{
+            "name": "x", "command": "y",
+            "args": ["--token", "$CRED{anything}"],
+        }]
+        with pytest.raises(ValueError):
+            b._build_mcp_servers_env(servers, agent_id="a1")
+
+    def test_clean_config_without_vault_does_not_raise(self):
+        # No $CRED references → vault wiring not required.
+        b = self._backend()
+        servers = [{"name": "x", "command": "y", "args": ["a"], "env": {"K": "v"}}]
+        # Should not raise.
+        result = json.loads(b._build_mcp_servers_env(servers, agent_id="a1"))
+        assert result == servers
+
+    def test_missing_credential_propagates_value_error(self, monkeypatch):
+        # Vault has linear_token; config asks for github_token.
+        b = self._backend(
+            vault=self._vault_with(monkeypatch, linear_token="x"),
+            permissions=self._perms_allow_all(),
+        )
+        servers = [{
+            "name": "x", "command": "y",
+            "env": {"K": "$CRED{github_token}"},
+        }]
+        with pytest.raises(ValueError) as excinfo:
+            b._build_mcp_servers_env(servers, agent_id="a1")
+        assert "github_token" in str(excinfo.value)
+
+    def test_permission_denied_propagates_value_error(self, monkeypatch):
+        b = self._backend(
+            vault=self._vault_with(monkeypatch, linear_token="x"),
+            permissions=self._perms_deny_all(),
+        )
+        servers = [{
+            "name": "x", "command": "y",
+            "env": {"K": "$CRED{linear_token}"},
+        }]
+        with pytest.raises(ValueError) as excinfo:
+            b._build_mcp_servers_env(servers, agent_id="a1")
+        assert "permission" in str(excinfo.value).lower()
+
+    def test_setter_wires_vault_and_permissions(self, monkeypatch):
+        b = self._backend()
+        v = self._vault_with(monkeypatch, linear_token="ABC")
+        p = self._perms_allow_all()
+        b.set_credential_resolver(vault=v, permissions=p)
+        servers = [{
+            "name": "x", "command": "y",
+            "env": {"K": "$CRED{linear_token}"},
+        }]
+        result = json.loads(b._build_mcp_servers_env(servers, agent_id="a1"))
+        assert result[0]["env"]["K"] == "ABC"
+
+    def test_setter_with_none_resets_to_unwired(self):
+        # Wiring None re-creates the "no resolver" state — refs would re-raise.
+        b = self._backend()
+        b._vault = MagicMock()  # pretend wired
+        b._permissions = MagicMock()
+        b.set_credential_resolver(vault=None, permissions=None)
+        servers = [{
+            "name": "x", "command": "y",
+            "env": {"K": "$CRED{anything}"},
+        }]
+        with pytest.raises(ValueError):
+            b._build_mcp_servers_env(servers, agent_id="a1")

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -6,11 +6,15 @@ import re
 from pathlib import Path
 from typing import get_args
 
+import pytest
+from pydantic import ValidationError
+
 from src.shared.types import (
     AgentConfig,
     AgentMessage,
     AgentStatus,
     DashboardEvent,
+    MCPServerConfig,
     TaskAssignment,
     TaskResult,
     TokenBudget,
@@ -203,5 +207,199 @@ def test_every_emit_string_in_src_matches_a_dashboard_event_literal():
         f"strip the emit call. Silent ValidationError swallowing means "
         f"these events never reach the dashboard."
     )
+
+
+# === MCPServerConfig ===
+
+
+def test_mcp_server_minimal_parses_cleanly():
+    s = MCPServerConfig(name="linear", command="mcp-server-linear")
+    assert s.name == "linear"
+    assert s.command == "mcp-server-linear"
+    assert s.args == []
+    assert s.env is None
+
+
+def test_mcp_server_full_parses_cleanly():
+    s = MCPServerConfig(
+        name="fs_main",
+        command="mcp-server-filesystem",
+        args=["--root", "/data"],
+        env={"DEBUG": "1"},
+    )
+    assert s.args == ["--root", "/data"]
+    assert s.env == {"DEBUG": "1"}
+
+
+@pytest.mark.parametrize(
+    "bad_name",
+    [
+        "-leading-hyphen",
+        "_leading-underscore",
+        "name with spaces",
+        "weird/slash",
+        "dot.notation",
+        "",
+        "x" * 65,
+    ],
+)
+def test_mcp_server_name_regex_rejects_invalid(bad_name):
+    with pytest.raises(ValidationError):
+        MCPServerConfig(name=bad_name, command="x")
+
+
+def test_mcp_server_command_empty_rejected():
+    with pytest.raises(ValidationError):
+        MCPServerConfig(name="x", command="")
+
+
+def test_mcp_server_command_too_long_rejected():
+    with pytest.raises(ValidationError):
+        MCPServerConfig(name="x", command="y" * 257)
+
+
+def test_mcp_server_command_rejects_cred_handle():
+    with pytest.raises(ValidationError) as excinfo:
+        MCPServerConfig(name="x", command="$CRED{my_token}")
+    # Clear actionable error pointing the user to env/args
+    assert "command" in str(excinfo.value)
+    assert "env" in str(excinfo.value) or "args" in str(excinfo.value)
+
+
+def test_mcp_server_command_rejects_cred_handle_substring():
+    # Even if the handle is embedded, reject
+    with pytest.raises(ValidationError):
+        MCPServerConfig(
+            name="x", command="wrapper --token=$CRED{tok} run",
+        )
+
+
+def test_mcp_server_args_allows_cred_handle():
+    s = MCPServerConfig(
+        name="x", command="y", args=["--token", "$CRED{my_token}"],
+    )
+    assert s.args == ["--token", "$CRED{my_token}"]
+
+
+def test_mcp_server_env_allows_cred_handle():
+    s = MCPServerConfig(
+        name="x", command="y", env={"API_KEY": "$CRED{my_token}"},
+    )
+    assert s.env == {"API_KEY": "$CRED{my_token}"}
+
+
+def test_mcp_server_args_max_length():
+    with pytest.raises(ValidationError):
+        MCPServerConfig(name="x", command="y", args=["a"] * 33)
+
+
+def test_mcp_server_args_per_item_length():
+    with pytest.raises(ValidationError):
+        MCPServerConfig(name="x", command="y", args=["a" * 513])
+
+
+def test_mcp_server_env_max_entries():
+    too_many = {f"K{i}": "v" for i in range(33)}
+    with pytest.raises(ValidationError):
+        MCPServerConfig(name="x", command="y", env=too_many)
+
+
+def test_mcp_server_env_value_too_long():
+    with pytest.raises(ValidationError):
+        MCPServerConfig(name="x", command="y", env={"K": "v" * 4097})
+
+
+def test_mcp_server_env_empty_key_rejected():
+    with pytest.raises(ValidationError):
+        MCPServerConfig(name="x", command="y", env={"": "v"})
+
+
+def test_mcp_server_env_long_key_rejected():
+    with pytest.raises(ValidationError):
+        MCPServerConfig(name="x", command="y", env={"K" * 129: "v"})
+
+
+def test_mcp_server_rejects_extra_fields():
+    with pytest.raises(ValidationError):
+        MCPServerConfig(
+            name="x", command="y", commnad="typo", env=None,  # type: ignore[call-arg]
+        )
+
+
+# === AgentConfig.mcp_servers integration ===
+
+
+def test_agent_config_mcp_servers_default_none():
+    c = AgentConfig()
+    assert c.mcp_servers is None
+
+
+def test_agent_config_mcp_servers_empty_list_ok():
+    c = AgentConfig(mcp_servers=[])
+    assert c.mcp_servers == []
+
+
+def test_agent_config_mcp_servers_parses_nested():
+    c = AgentConfig(
+        mcp_servers=[
+            {"name": "linear", "command": "mcp-server-linear"},
+            {"name": "fs", "command": "mcp-server-filesystem", "args": ["/data"]},
+        ],
+    )
+    assert len(c.mcp_servers) == 2
+    assert isinstance(c.mcp_servers[0], MCPServerConfig)
+    assert c.mcp_servers[1].args == ["/data"]
+
+
+def test_agent_config_mcp_servers_rejects_case_insensitive_duplicates():
+    with pytest.raises(ValidationError) as excinfo:
+        AgentConfig(
+            mcp_servers=[
+                {"name": "Linear", "command": "x"},
+                {"name": "linear", "command": "y"},
+            ],
+        )
+    assert "duplicate" in str(excinfo.value).lower()
+
+
+def test_agent_config_mcp_servers_allows_distinct_names():
+    c = AgentConfig(
+        mcp_servers=[
+            {"name": "linear", "command": "x"},
+            {"name": "github", "command": "y"},
+        ],
+    )
+    assert {s.name for s in c.mcp_servers} == {"linear", "github"}
+
+
+def test_agent_config_keeps_extra_allow_for_outer_unknown_fields():
+    # Outer extra=allow is preserved — unknown top-level fields don't break load.
+    c = AgentConfig(role="researcher", some_legacy_field=42)  # type: ignore[call-arg]
+    dumped = c.model_dump()
+    assert dumped.get("some_legacy_field") == 42
+
+
+def test_agent_config_nested_mcp_server_extras_still_forbidden():
+    # extra=allow on the outer model does NOT leak into nested MCPServerConfig.
+    with pytest.raises(ValidationError) as excinfo:
+        AgentConfig(
+            mcp_servers=[
+                {"name": "linear", "command": "x", "bogus_nested_field": 1},
+            ],
+        )
+    # Error points to the right path
+    assert "mcp_servers" in str(excinfo.value)
+
+
+def test_agent_config_mcp_servers_round_trip_via_model_dump():
+    # Downstream consumers read mcp_servers via .get() expecting dicts.
+    c = AgentConfig(
+        mcp_servers=[
+            {"name": "linear", "command": "mcp-server-linear", "env": {"K": "v"}},
+        ],
+    )
+    dumped = c.model_dump()
+    assert isinstance(dumped["mcp_servers"][0], dict)
+    assert dumped["mcp_servers"][0]["env"] == {"K": "v"}
 
 


### PR DESCRIPTION
## Summary

Backend foundation for visual MCP server management in the dashboard, addressing #959. **UI lands in PR 2** — this PR is deliberately invisible to end users; it lays the contract PR 2 builds against.

- Promotes `mcp_servers` from `extra="allow"`-rider to a formal `MCPServerConfig` Pydantic model with regex + length caps, case-insensitive duplicate-name rejection, and `$CRED{name}` handles rejected in `command` field.
- Mesh-side `$CRED{name}` resolver wired into agent start: vault + permissions plumbed into `RuntimeBackend`; resolution applied to env values **and** args strings (NOT command); missing or permission-denied credentials hard-fail `start_agent`; vault not wired + config with refs hard-fails too (no silent literal passthrough).
- `PUT /api/agents/{id}/config` rewritten with Pydantic validation, env preserve-or-replace semantics, PUT-time `$CRED` permission + existence check, and diff-based `mcp_touched` (no-op PUT no longer restarts).
- `GET /api/agents/{id}/config` masks env values: returns `env_keys` list + omits `env` field entirely (round-trip safe). `audit_log` redacts env values too.
- `MCPClient` adds per-server startup/discovery status registry (`state`, `tools_count`, `error`) + `mcp_tool_to_server` mapping — both surfaced via agent `/capabilities` for the dashboard to render status dots and classify tools.
- Fixes the broken `tool.get("function") == "mcp"` backfill check at the dashboard capabilities endpoint (always False against OpenAI tool format).
- CLI `_load_config` validates `mcp_servers` at the load boundary; malformed entries dropped with warning rather than crashing.

## Why this approach

| Decision | Rationale |
|---|---|
| Stdio-only transport | Matches existing `MCPClient` — HTTP/SSE transports are not wired today; promising them in the UI before the protocol layer exists is a debt trap |
| `$CRED{name}` handles in `env`/`args`, NOT `command` | Credential-from-shell-name is a weird pattern; rejecting at PUT prevents the confusing "executable not found" silent failure |
| Hard-fail on missing/denied CRED at runtime | Skip-with-empty-string is the worst failure mode — subprocess may "succeed" against unauthenticated endpoints with no signal to operator |
| GET returns `env_keys`, omits `env` | A naive GET → PUT round-trip must not accidentally clear env. Omission distinguishes "preserve" from "replace with empty" |
| PUT strips `env_keys` before validation | GET adds it as the masked display surface; `MCPServerConfig.extra="forbid"` would otherwise reject the round-trip |
| Diff-based `mcp_touched` | Cosmetic full-body PUT (touching only `model`) should not restart the agent. Canonicalization handles `env={}`/`env=None`/missing equivalence |
| Per-server status as "last startup attempt" only | Live MCP health probes are out of scope; the registry is what the dashboard needs to render meaningful status dots |
| Operator-tool MCP write surface NOT included | Deferred to Phase 3 (operator-requested setup via the same credential-request / browser-login pattern). Keeping it out of PR 1/2 sidesteps the prompt-injection risk of giving operator chat the power to install arbitrary subprocesses |

## Out of scope (intentional, not oversights)

- **No dashboard UI** — PR 2 of 2
- **No HTTP/SSE transport** — `mcp_client.py` is stdio-only; promised in the UI was a non-starter
- **No "Test Connection" dry-run** — save+restart cycle IS the test; pre-flight is more debt than value
- **No operator-tool MCP write** — Phase 3 follow-up
- **No live MCP health probes** — startup/discovery status only

## Test plan

- [x] `tests/test_types.py` — `MCPServerConfig` validation (regex, length caps, `$CRED` in command, duplicate names case-insensitive, nested `extra="forbid"` enforced under outer `extra="allow"`)
- [x] `tests/test_credentials.py` — `resolve_cred_handles` (no-op passthrough, single handle, multiple distinct, repeated dedupe, missing/denied raises, single-pass non-recursion)
- [x] `tests/test_runtime.py` — `_build_mcp_servers_env` (empty, no refs, env+args resolution, vault-not-wired raises, missing/denied propagates, setter wires/un-wires)
- [x] `tests/test_mcp_client.py` — per-server status registry (success/failure/mixed), tool_to_server mapping (non-conflict and conflict-renamed), MCP SDK missing marks servers failed
- [x] `tests/test_dashboard.py` — `TestDashboardAgentConfig`: env masking on GET, env_keys present + env omitted, audit redaction, env preserve/replace, no-op PUT no restart, structured 400 on Pydantic errors, `$CRED` in command rejected, permission-denied rejected, missing cred rejected, `$CRED` in args validated, GET → PUT round-trip safe
- [x] `tests/test_dashboard.py::TestCapabilitiesMcpForwarding` — forwards `mcp_servers` registry and `mcp_tool_to_server`; backfill classifies MCP tools via the new side-channel
- [x] `tests/test_cli_commands.py::TestLoadConfigMcpServersValidation` — well-formed loads cleanly, malformed dropped with warning, all-malformed yields None, no-op when no `mcp_servers`

**Pre-existing flakiness flagged:** `test_credentials_import_does_not_eagerly_load_litellm` + `test_lazy_system_credential_providers_still_resolves` fail when test_credentials.py runs AFTER test_dashboard.py/test_runtime.py in the same pytest session (litellm gets pulled into `sys.modules` by an unrelated import chain in the earlier suites). Passes when isolated. **Not caused by this PR** — should be filed as a separate issue.

## Breaking changes

`GET /api/agents/{id}/config` response shape changed for `mcp_servers` entries: `env` field omitted, `env_keys` field added. Only known consumer is the dashboard itself; CLI display reads only `name`. Documented in `docs/mcp.md`.