### PR TITLE
feat(dashboard): MCP server management UI in Config tab (PR 2/2 for #959)

### DIFF
--- a/README.md
+++ b/README.md
@@ -868,7 +868,18 @@ exposed to the LLM alongside built-in skills.
 
 ### Configuration
 
-Add `mcp_servers` to any agent in `config/agents.yaml`:
+There are two ways to attach MCP servers to an agent:
+
+**1. Dashboard (recommended for most users).** Open the agent's settings → Config
+tab → **MCP Servers** section. Click **+ Add MCP server**, fill in name +
+command + args + env, hit Save. Env values that hold secrets go through a
+credential picker (saved as `$CRED{name}` handles, resolved by the mesh at
+agent start — no plaintext on disk or in the API). Per-server status dots
+(green / red with the captured error / gray pending) tell you whether each
+server actually came up. See [`docs/mcp.md`](docs/mcp.md) for the full UX.
+
+**2. Fleet template (for repeatable deployments).** Add `mcp_servers` to an
+agent in `src/templates/<template>.yaml`:
 
 ```yaml
 agents:
@@ -882,10 +893,15 @@ agents:
       - name: database
         command: mcp-server-sqlite
         args: ["--db", "/data/research.db"]
+        env:
+          DB_PASSWORD: "$CRED{research_db_password}"
 ```
 
-Each server is launched as a subprocess inside the agent container using stdio
-transport. Tools are discovered automatically via the MCP protocol and appear
+The same `MCPServerConfig` model validates both paths: `name` matches
+`^[a-zA-Z0-9][a-zA-Z0-9_-]{0,63}$`, `command` cannot contain `$CRED{...}`
+handles (use `env` or `args` instead), case-insensitive duplicate names are
+rejected. Each server is launched as a subprocess inside the agent container
+using stdio transport; tools are discovered via the MCP protocol and appear
 in the LLM's tool list alongside built-in skills.
 
 ### How It Works

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -98,6 +98,40 @@ Saving a config that doesn't actually change the persisted `mcp_servers` does NO
 
 Last-write-wins semantics for the whole `mcp_servers` field. The dashboard does not currently use an `If-Match` / etag concurrency token, so two operators editing the same agent's MCP config simultaneously will have one overwrite the other. This is consistent with how every other dashboard config edit behaves today.
 
+## Managing MCP servers from the dashboard
+
+The agent settings → Config tab has an **MCP Servers** section that wraps the contract above. The visual UI is the primary path for users — fleet templates and the REST API still work but are no longer the only way in.
+
+In display mode each configured server renders as a row with a status dot (green = running, red = failed at last startup, gray = pending restart), the command preview, and a tool-count badge. Click an agent's settings → Edit to manage.
+
+### Adding / editing / removing servers
+
+The edit-mode list reuses the inline Webhooks pattern: hover a row for **Edit** and **Remove** buttons, or click **+ Add MCP server** to open a fresh form. Each form has:
+
+- **Name** and **Command** as plain inputs (validated against the same `MCPServerConfig` model the backend uses — same regex, same length caps, same `$CRED{...}` rejection in `command`).
+- **Args** as a list-of-pairs (one input per arg + remove + `+ Add arg`). No JSON syntax to learn.
+- **Env** as a list-of-rows where each row has a key field, a **Credential | Plain text** type toggle, and the value field:
+  - **Credential** shows a dropdown filtered to the credentials the agent's `allowed_credentials` policy actually permits — the saved value becomes a `$CRED{name}` handle resolved by the mesh at agent start.
+  - **Plain text** is a regular input. If you paste something that looks like an API key (e.g. starts with `sk-`, `ghp_`, `pat-`, `Bearer ...`, or is high-entropy), an inline warning nudges you toward Credential mode.
+- A **Replace env vars** toggle (edit mode only) that defaults OFF — existing env preserves on the wire. When ON, the editor starts empty and the save replaces env wholesale; the UI explains that values are not retrievable from the masked GET (you'd need to re-supply all of them).
+- An inline Node-runtime warning chip below the command input when it starts with `npx`/`bunx`/`pnpm dlx`/`yarn dlx`/`node`/`npm`/`pnpm`/`yarn`/`bun` (the default agent image is Python-only).
+
+### Save + restart flow
+
+Clicking the outer **Save** in the Config tab will auto-commit any open MCP draft (or block with a toast if the draft is incomplete) so typed entries don't get silently dropped. If `mcp_servers` actually changed (the dashboard does the same canonical diff as the backend's `mcp_touched` check), the agent is restarted automatically. The toast reports success/failure; the per-server status dot reflects the new state once the post-restart capabilities fetch lands.
+
+If the restart itself fails (the config persisted but the container didn't come back up against it), the edit form **stays open** with a persistent red banner: *"Config saved, but agent restart failed: &lt;reason&gt;"* + a **Retry restart** button. Retry calls `POST /restart` only — the config is already on disk, no re-PUT.
+
+### Failure visibility
+
+A red status dot expands to show the captured stderr from `MCPClient.start()` (truncated to 500 chars). The common ones — `command not found`, missing or denied `$CRED{...}` reference, permission error — surface here without needing to tail container logs.
+
+Validation errors from the backend (regex failures, oversize fields, `$CRED` in `command`, etc.) come back as a structured 400 and render as **inline red text** next to the offending field. Errors that don't map to a single row (e.g. case-insensitive duplicate names rejected by the `AgentConfig` field validator) render as a banner above the list.
+
+### Operator-tool MCP management
+
+**Not yet supported.** The operator agent can READ which MCP servers are configured on each agent (through the existing capabilities surface) but cannot ADD or REMOVE them via chat. A follow-up will introduce an operator-requested-setup flow modeled on the existing credential-request and browser-login patterns: the operator surfaces a request card in the dashboard, the human reviews and saves, the agent picks up the new server on restart. Until then, MCP writes are dashboard-only.
+
 ## How It Works
 
 ### Startup Sequence

--- a/src/dashboard/static/js/app.js
+++ b/src/dashboard/static/js/app.js
@@ -6108,6 +6108,11 @@ function dashboard() {
         const resp = await fetch(`${window.__config.apiBase}/agents/${agentId}/capabilities`);
         if (resp.ok) {
           const data = await resp.json();
+          // Guard against an in-flight fetch landing after the user
+          // switched to a different agent — without this, agent A's
+          // response would overwrite the now-visible agent B's
+          // tools/status. Drop late responses.
+          if (this.selectedAgent && this.selectedAgent !== agentId) return;
           // Agent returns tool_definitions (OpenAI format: {type, function: {name, description}})
           const defs = data.tool_definitions || [];
           const sources = data.tool_sources || {};
@@ -6922,15 +6927,22 @@ function dashboard() {
     mcpStartEdit(idx) {
       const s = this.editForm.mcp_servers[idx];
       if (!s) return;
+      // If this entry was added/edited earlier in this session, the
+      // mcpCommitDraft path attached ``_replaceEnv`` and ``_envRows``;
+      // restore them so a second-pass edit doesn't silently drop the
+      // env the user already typed. For entries loaded fresh from
+      // agentConfigs (no prior draft), _envRows is [] and
+      // _replaceEnv defaults to off so existing env is preserved
+      // unless the user explicitly toggles. env_keys is all we know
+      // for these — the masked GET doesn't return values.
       this.editForm._mcpDraft = {
         name: s.name,
         command: s.command,
         _argRows: (s.args || []).map(v => ({ value: v })),
-        // env_keys is all we know on edit — we can't pre-populate values
-        // because the masked GET doesn't return them. _replaceEnv defaults
-        // off so existing env is preserved unless the user explicitly toggles.
-        _envRows: [],
-        _replaceEnv: false,
+        _envRows: Array.isArray(s._envRows)
+          ? s._envRows.map(r => ({ key: r.key, type: r.type, value: r.value }))
+          : [],
+        _replaceEnv: !!s._replaceEnv,
       };
       this.editForm._mcpEditIndex = idx;
       this.editForm._showMcpAddForm = false;
@@ -6945,6 +6957,34 @@ function dashboard() {
     mcpCommitDraft() {
       const d = this.editForm._mcpDraft;
       if (!d) return;
+      const name = (d.name || '').trim();
+      const command = (d.command || '').trim();
+      const editIdx = this.editForm._mcpEditIndex;
+      // Client-side duplicate-name rejection (case-insensitive,
+      // mirrors the backend AgentConfig field-validator). Avoids
+      // confusing top-level Pydantic 400 surfaces — also keeps
+      // ``mcpServersChanged``'s by-name Map lookup honest.
+      const lowered = name.toLowerCase();
+      const collidesAt = this.editForm.mcp_servers.findIndex(
+        (s, i) => i !== editIdx && (s.name || '').toLowerCase() === lowered,
+      );
+      if (collidesAt >= 0) {
+        this.showToast(`Another MCP server already uses name "${name}" (case-insensitive).`);
+        return;
+      }
+      // Reject cred rows with a key but no selected credential —
+      // otherwise mcpDraftToWirePayload silently drops them while
+      // env_keys would still record the key, lying to the user.
+      if (d._replaceEnv) {
+        for (const row of (d._envRows || [])) {
+          const k = (row.key || '').trim();
+          if (!k) continue;
+          if (row.type === 'cred' && !(row.value || '').trim()) {
+            this.showToast(`Env "${k}" is set to Credential mode but no credential is selected.`);
+            return;
+          }
+        }
+      }
       // env_keys is a display-only field for the inline edit UI:
       //   * In replace mode it's derived from the new rows the user supplied.
       //   * In preserve mode (not replacing) we KEEP the original entry's
@@ -6955,23 +6995,23 @@ function dashboard() {
       //     by-name semantic).
       let envKeys;
       if (d._replaceEnv) {
-        envKeys = d._envRows.map(r => (r.key || '').trim()).filter(Boolean);
-      } else if (this.editForm._mcpEditIndex >= 0) {
-        const original = this.editForm.mcp_servers[this.editForm._mcpEditIndex];
+        envKeys = (d._envRows || []).map(r => (r.key || '').trim()).filter(Boolean);
+      } else if (editIdx >= 0) {
+        const original = this.editForm.mcp_servers[editIdx];
         envKeys = (original && Array.isArray(original.env_keys)) ? [...original.env_keys] : [];
       } else {
         envKeys = [];
       }
       const entry = {
-        name: (d.name || '').trim(),
-        command: (d.command || '').trim(),
+        name,
+        command,
         args: d._argRows.map(r => r.value).filter(v => v !== ''),
         env_keys: envKeys,
         _replaceEnv: !!d._replaceEnv,
         _envRows: d._envRows,
       };
-      if (this.editForm._mcpEditIndex >= 0) {
-        this.editForm.mcp_servers.splice(this.editForm._mcpEditIndex, 1, entry);
+      if (editIdx >= 0) {
+        this.editForm.mcp_servers.splice(editIdx, 1, entry);
       } else {
         this.editForm.mcp_servers.push(entry);
       }
@@ -7132,6 +7172,19 @@ function dashboard() {
       if (this.editForm && this.editForm._mcpRestartPending) {
         this.showToast('MCP restart in progress — try again in a moment.');
         return;
+      }
+      // If the user has an open MCP draft (add or edit form) and clicks
+      // the outer Save, auto-commit the draft so the typed entries
+      // aren't silently dropped. Reject the save if the draft is
+      // incomplete (no name/command) — surface a clear toast so the
+      // user knows why their save didn't go through.
+      if (this.editForm && this.editForm._mcpDraft) {
+        const d = this.editForm._mcpDraft;
+        if (!(d.name || '').trim() || !(d.command || '').trim()) {
+          this.showToast('MCP server draft is incomplete — Apply or Cancel it before saving.');
+          return;
+        }
+        this.mcpCommitDraft();
       }
       this.configSaving = true;
       try {

--- a/src/dashboard/static/js/app.js
+++ b/src/dashboard/static/js/app.js
@@ -337,6 +337,13 @@ function dashboard() {
     configSaving: false,
     identityLogs: null,
     agentCapabilities: null,
+    // Per-agent MCP side-channels surfaced by the agent /capabilities
+    // endpoint (PR 1 of #959). agentMcpStatus[] is the per-server
+    // startup/discovery registry — drives status dots and click-to-see-
+    // error in the MCP Servers panel. agentMcpToolMap is tool_name →
+    // server_name; reserved for tool-filtering UX in a follow-up.
+    agentMcpStatus: [],
+    agentMcpToolMap: {},
     agentActivity: [],
     agentActivityLoading: false,
 
@@ -6089,6 +6096,8 @@ function dashboard() {
 
     async fetchAgentCapabilities(agentId) {
       this.agentCapabilities = null;
+      this.agentMcpStatus = [];
+      this.agentMcpToolMap = {};
       try {
         const resp = await fetch(`${window.__config.apiBase}/agents/${agentId}/capabilities`);
         if (resp.ok) {
@@ -6101,6 +6110,13 @@ function dashboard() {
             description: t.function?.description || t.description || '',
             source: sources[t.function?.name || t.name] || 'custom',
           }));
+          // PR 1 side-channels: per-server startup status registry +
+          // tool→server mapping. Both are omitted by agents that
+          // haven't been restarted into PR 1 code; the empty defaults
+          // collapse the MCP panel to the "pending" state in that case.
+          this.agentMcpStatus = Array.isArray(data.mcp_servers) ? data.mcp_servers : [];
+          this.agentMcpToolMap = (data.mcp_tool_to_server && typeof data.mcp_tool_to_server === 'object')
+            ? data.mcp_tool_to_server : {};
         }
       } catch (e) { console.warn('fetchAgentCapabilities failed:', e); }
     },
@@ -6842,6 +6858,24 @@ function dashboard() {
         ),
         allowed_credentials: credsStr,
         _credMode: credMode,
+        // MCP servers — populated from the masked GET /config response.
+        // Each entry has {name, command, args, env_keys} (env values
+        // are never returned by GET; the env field is omitted, see PR 1).
+        // Underscore-prefixed fields are UI-only and stripped on save.
+        mcp_servers: Array.isArray(cfg.mcp_servers)
+          ? cfg.mcp_servers.map(s => ({
+              name: s.name || '',
+              command: s.command || '',
+              args: Array.isArray(s.args) ? [...s.args] : [],
+              env_keys: Array.isArray(s.env_keys) ? [...s.env_keys] : [],
+            }))
+          : [],
+        _mcpDraft: null,
+        _mcpEditIndex: -1,
+        _showMcpAddForm: false,
+        _mcpRestartPending: false,
+        _mcpRestartError: null,
+        _mcpErrors: {},
       };
       this.configEditing = true;
     },
@@ -6849,6 +6883,201 @@ function dashboard() {
     cancelConfigEdit() {
       this.configEditing = false;
       this.editForm = {};
+    },
+
+    // ── MCP Servers panel helpers (PR 2 of #959) ────────────────────────
+    // The Config tab MCP Servers section uses these to manage state
+    // across add/edit/remove + save+restart orchestration. Underscore-
+    // prefixed fields on editForm (and on _mcpDraft) are UI-only and
+    // explicitly stripped via projection on save.
+
+    _mcpBlankDraft() {
+      return {
+        name: '',
+        command: '',
+        _argRows: [],            // [{value: string}]
+        _envRows: [],            // [{key: string, type: 'cred'|'plain', value: string}]
+        _replaceEnv: true,       // for add: always replace (no preserve baseline)
+      };
+    },
+
+    mcpStartAdd() {
+      this.editForm._mcpDraft = this._mcpBlankDraft();
+      this.editForm._mcpEditIndex = -1;
+      this.editForm._showMcpAddForm = true;
+    },
+
+    mcpStartEdit(idx) {
+      const s = this.editForm.mcp_servers[idx];
+      if (!s) return;
+      this.editForm._mcpDraft = {
+        name: s.name,
+        command: s.command,
+        _argRows: (s.args || []).map(v => ({ value: v })),
+        // env_keys is all we know on edit — we can't pre-populate values
+        // because the masked GET doesn't return them. _replaceEnv defaults
+        // off so existing env is preserved unless the user explicitly toggles.
+        _envRows: [],
+        _replaceEnv: false,
+      };
+      this.editForm._mcpEditIndex = idx;
+      this.editForm._showMcpAddForm = false;
+    },
+
+    mcpCancelDraft() {
+      this.editForm._mcpDraft = null;
+      this.editForm._mcpEditIndex = -1;
+      this.editForm._showMcpAddForm = false;
+    },
+
+    mcpCommitDraft() {
+      const d = this.editForm._mcpDraft;
+      if (!d) return;
+      const entry = {
+        name: (d.name || '').trim(),
+        command: (d.command || '').trim(),
+        args: d._argRows.map(r => r.value).filter(v => v !== ''),
+        // We only attach env_keys here for the read-back UI; the actual
+        // env payload that goes on the wire is built in saveAgentConfig
+        // via mcpDraftToWirePayload (which knows _replaceEnv semantics).
+        env_keys: d._envRows.map(r => (r.key || '').trim()).filter(Boolean),
+        _replaceEnv: !!d._replaceEnv,
+        _envRows: d._envRows,
+      };
+      if (this.editForm._mcpEditIndex >= 0) {
+        this.editForm.mcp_servers.splice(this.editForm._mcpEditIndex, 1, entry);
+      } else {
+        this.editForm.mcp_servers.push(entry);
+      }
+      this.mcpCancelDraft();
+    },
+
+    mcpRemoveAt(idx) {
+      const s = this.editForm.mcp_servers[idx];
+      if (!s) return;
+      this.showConfirm(
+        'Remove MCP server',
+        `Remove "${s.name}"? Agent will restart when you save.`,
+        () => { this.editForm.mcp_servers.splice(idx, 1); },
+        true,
+      );
+    },
+
+    mcpAddArgRow() {
+      if (!this.editForm._mcpDraft) return;
+      this.editForm._mcpDraft._argRows.push({ value: '' });
+    },
+
+    mcpRemoveArgRow(idx) {
+      if (!this.editForm._mcpDraft) return;
+      this.editForm._mcpDraft._argRows.splice(idx, 1);
+    },
+
+    mcpAddEnvRow() {
+      if (!this.editForm._mcpDraft) return;
+      this.editForm._mcpDraft._envRows.push({ key: '', type: 'cred', value: '' });
+    },
+
+    mcpRemoveEnvRow(idx) {
+      if (!this.editForm._mcpDraft) return;
+      this.editForm._mcpDraft._envRows.splice(idx, 1);
+    },
+
+    mcpToggleReplaceEnv() {
+      if (!this.editForm._mcpDraft) return;
+      this.editForm._mcpDraft._replaceEnv = !this.editForm._mcpDraft._replaceEnv;
+      // When replace is freshly toggled on, start with an empty editor so
+      // the user is explicitly supplying every var. When toggled off, drop
+      // any draft rows so the save flow omits env (preserve semantics).
+      if (this.editForm._mcpDraft._replaceEnv && this.editForm._mcpDraft._envRows.length === 0) {
+        // leave empty — user will + Add as needed
+      }
+      if (!this.editForm._mcpDraft._replaceEnv) {
+        this.editForm._mcpDraft._envRows = [];
+      }
+    },
+
+    mcpDetectJsRuntime(command) {
+      if (!command) return false;
+      return /^(npx|bunx|pnpm\s+dlx|yarn\s+dlx|node|npm|pnpm|yarn|bun)(\s|$)/.test(command);
+    },
+
+    mcpDetectSecretLike(value) {
+      if (!value) return false;
+      // Catches the most common prefixes that almost always indicate a secret.
+      if (/^(sk-|sk_|ghp_|gho_|ghu_|ghs_|github_pat_|pat-|xoxb-|xoxp-|Bearer\s+)/.test(value)) {
+        return true;
+      }
+      // High-entropy heuristic: long enough, mixed case, contains digits.
+      if (value.length >= 32 && /[A-Z]/.test(value) && /[a-z]/.test(value) && /[0-9]/.test(value)) {
+        return true;
+      }
+      return false;
+    },
+
+    mcpStatusFor(serverName) {
+      const match = (this.agentMcpStatus || []).find(s => s.name === serverName);
+      if (!match) return { state: 'pending', toolsCount: 0, error: null };
+      return {
+        state: match.state || 'pending',
+        toolsCount: match.tools_count || 0,
+        error: match.error || null,
+      };
+    },
+
+    mcpStatusDotClass(state) {
+      if (state === 'running') return 'bg-green-400/70';
+      if (state === 'failed') return 'bg-red-400/70';
+      return 'bg-gray-500/70';  // pending
+    },
+
+    // Build the wire payload for one server. ``_replaceEnv`` controls
+    // whether ``env`` is sent at all — omitting it triggers the PR 1
+    // preserve-by-name semantic on the backend.
+    mcpDraftToWirePayload(entry) {
+      const out = {
+        name: entry.name,
+        command: entry.command,
+        args: entry.args || [],
+      };
+      if (entry._replaceEnv) {
+        const env = {};
+        for (const row of (entry._envRows || [])) {
+          const k = (row.key || '').trim();
+          if (!k) continue;
+          if (row.type === 'cred') {
+            const credName = (row.value || '').trim();
+            if (!credName) continue;
+            env[k] = `$CRED{${credName}}`;
+          } else {
+            env[k] = row.value || '';
+          }
+        }
+        out.env = env;
+      }
+      return out;
+    },
+
+    // Diff the live editForm.mcp_servers against the persisted server
+    // list; returns true if a save needs to send mcp_servers. Used to
+    // skip a no-op PUT (matching the backend's diff-based mcp_touched).
+    mcpServersChanged(agentId) {
+      const cfg = this.agentConfigs[agentId] || {};
+      const current = cfg.mcp_servers || [];
+      const draft = this.editForm.mcp_servers || [];
+      if (current.length !== draft.length) return true;
+      const byName = new Map(current.map(s => [s.name, s]));
+      for (const d of draft) {
+        const c = byName.get(d.name);
+        if (!c) return true;
+        if (c.command !== d.command) return true;
+        const ca = c.args || [], da = d.args || [];
+        if (ca.length !== da.length) return true;
+        for (let i = 0; i < ca.length; i++) if (ca[i] !== da[i]) return true;
+        // env diff: only detectable if user explicitly toggled replace
+        if (d._replaceEnv) return true;
+      }
+      return false;
     },
 
     thinkingOptionsForModel(model) {
@@ -6875,6 +7104,12 @@ function dashboard() {
 
     async saveConfigFromDetail(agentId) {
       if (this.configSaving) return;
+      // Don't race a save against an in-flight MCP restart retry; the
+      // retry path mutates the same agent's runtime state.
+      if (this.editForm && this.editForm._mcpRestartPending) {
+        this.showToast('MCP restart in progress — try again in a moment.');
+        return;
+      }
       this.configSaving = true;
       try {
         await this.saveAgentConfig(agentId);
@@ -6905,6 +7140,16 @@ function dashboard() {
       }
       if (this.editForm.thinking !== undefined && this.editForm.thinking !== (cfg.thinking || 'off')) {
         body.thinking = this.editForm.thinking;
+      }
+      // MCP servers — only include if the user actually changed something
+      // (mcpServersChanged handles the no-op case so a benign full-body
+      // save doesn't trigger an unnecessary restart). Build the wire
+      // payload per entry: omit env for untouched entries (backend
+      // preserves by name), include env for entries the user replaced.
+      if (this.mcpServersChanged(agentId)) {
+        body.mcp_servers = (this.editForm.mcp_servers || []).map(
+          s => this.mcpDraftToWirePayload(s),
+        );
       }
       // Handle allowed_credentials + capability flags via the permissions endpoint
       const newCreds = (this.editForm.allowed_credentials || '').split(',').map(s => s.trim()).filter(Boolean);
@@ -6940,9 +7185,34 @@ function dashboard() {
           if (resp.ok) {
             configResult = await resp.json();
             allUpdated.push(...configResult.updated);
+            // Clear any prior per-row MCP errors from a failed earlier save.
+            if (this.editForm) this.editForm._mcpErrors = {};
           } else {
-            const err = await resp.json();
-            this.showToast(`Error: ${err.detail || 'Update failed'}`);
+            const err = await resp.json().catch(() => ({}));
+            // Structured Pydantic validation errors come back as
+            // ``{detail: {field: "mcp_servers", errors: [{loc, msg, type}]}}``
+            // so we can map each error back to the offending row + field
+            // for inline display. Keep edit mode open so the user sees
+            // the inline errors next to their inputs.
+            const detail = err.detail;
+            if (detail && typeof detail === 'object' && detail.field === 'mcp_servers' && Array.isArray(detail.errors)) {
+              const perRow = {};
+              for (const e of detail.errors) {
+                const loc = e.loc || [];
+                // loc[0] = "mcp_servers", loc[1] = row index, loc[2] = field name (or "args"/"env" with deeper path)
+                if (loc.length >= 3 && loc[0] === 'mcp_servers') {
+                  const ridx = Number(loc[1]);
+                  if (!Number.isFinite(ridx)) continue;
+                  const field = String(loc[2]);
+                  perRow[ridx] = perRow[ridx] || {};
+                  perRow[ridx][field] = e.msg || 'Invalid';
+                }
+              }
+              if (this.editForm) this.editForm._mcpErrors = perRow;
+              this.showToast('MCP server config has errors — see inline.');
+              return;  // KEEP edit mode open for the user to fix
+            }
+            this.showToast(`Error: ${typeof detail === 'string' ? detail : 'Update failed'}`);
             this.cancelConfigEdit();
             return;
           }
@@ -6987,8 +7257,21 @@ function dashboard() {
             const data = await restartResp.json();
             this.showToast(data.ready ? `${agentId} restarted and ready` : `${agentId} restarted (warming up)`);
             this.fetchAgents();
+            // Refresh capabilities so MCP status dots reflect the new server state
+            // (running/failed) and the post-restart tool list classification.
+            await this.fetchAgentCapabilities(agentId);
+            if (this.editForm) this.editForm._mcpRestartError = null;
           } else {
-            this.showToast(`Config updated but restart failed — restart ${agentId} manually`);
+            // Config was persisted but the container restart failed. KEEP
+            // edit mode open so the user can read the error and hit
+            // Retry restart without re-saving (config is already on disk).
+            const err = await restartResp.json().catch(() => ({}));
+            const msg = (typeof err.detail === 'string' && err.detail) ? err.detail
+                      : `restart endpoint returned ${restartResp.status}`;
+            if (this.editForm) this.editForm._mcpRestartError = msg;
+            this.showToast(`${agentId}: config saved, restart failed`);
+            await this.fetchAgentConfig(agentId);
+            return;  // do NOT cancelConfigEdit — user needs the Retry restart UI
           }
         } else if (allUpdated.length > 0) {
           this.showToast(`Updated: ${allUpdated.join(', ')}`);
@@ -6996,6 +7279,41 @@ function dashboard() {
         await this.fetchAgentConfig(agentId);
       } catch (e) { this.showToast(`Error: ${e.message}`); }
       this.cancelConfigEdit();
+    },
+
+    // Used by the persistent "Retry restart" banner in the MCP panel
+    // when a save succeeded (config persisted) but the follow-up
+    // ``POST /restart`` failed. Calls /restart again WITHOUT re-PUTting
+    // — the config is already on disk; only the container needs to come
+    // up against it. Clears the error and refreshes capabilities on success.
+    async retryMcpRestart(agentId) {
+      if (!this.editForm) return;
+      if (this.editForm._mcpRestartPending) return;
+      this.editForm._mcpRestartPending = true;
+      this.showToast(`Retrying restart for ${agentId}...`);
+      try {
+        const resp = await fetch(`${window.__config.apiBase}/agents/${agentId}/restart`, { method: 'POST' });
+        if (resp.ok) {
+          const data = await resp.json();
+          this.showToast(data.ready ? `${agentId} restarted and ready` : `${agentId} restarted (warming up)`);
+          this.editForm._mcpRestartError = null;
+          await this.fetchAgents();
+          await this.fetchAgentConfig(agentId);
+          await this.fetchAgentCapabilities(agentId);
+          this.cancelConfigEdit();
+        } else {
+          const err = await resp.json().catch(() => ({}));
+          const msg = (typeof err.detail === 'string' && err.detail) ? err.detail
+                    : `restart endpoint returned ${resp.status}`;
+          this.editForm._mcpRestartError = msg;
+          this.showToast(`Restart still failing: ${msg}`);
+        }
+      } catch (e) {
+        this.editForm._mcpRestartError = e.message || String(e);
+        this.showToast(`Restart error: ${e.message || String(e)}`);
+      } finally {
+        if (this.editForm) this.editForm._mcpRestartPending = false;
+      }
     },
 
     async restartAgent(agentId) {

--- a/src/dashboard/static/js/app.js
+++ b/src/dashboard/static/js/app.js
@@ -6109,10 +6109,12 @@ function dashboard() {
         if (resp.ok) {
           const data = await resp.json();
           // Guard against an in-flight fetch landing after the user
-          // switched to a different agent — without this, agent A's
-          // response would overwrite the now-visible agent B's
-          // tools/status. Drop late responses.
-          if (this.selectedAgent && this.selectedAgent !== agentId) return;
+          // switched to a different agent (or closed the detail panel
+          // entirely). Without this, agent A's response would overwrite
+          // the now-visible agent B's tools/status — or worse, write
+          // stale data into agentMcpStatus while no agent is selected,
+          // which then bleeds into the next agent the user opens.
+          if (this.selectedAgent !== agentId) return;
           // Agent returns tool_definitions (OpenAI format: {type, function: {name, description}})
           const defs = data.tool_definitions || [];
           const sources = data.tool_sources || {};
@@ -6960,6 +6962,17 @@ function dashboard() {
       const name = (d.name || '').trim();
       const command = (d.command || '').trim();
       const editIdx = this.editForm._mcpEditIndex;
+      // Reject whitespace-only name/command BEFORE committing — the
+      // Apply button's :disabled check is raw truthiness and lets a
+      // whitespace-only string through. Without this guard, the bad
+      // entry gets committed locally, _mcpDraft is nulled, and the
+      // outer Save's auto-commit guard sees nothing to abort on (it
+      // only checks that _mcpDraft is still set). User would only
+      // discover the issue when the backend 400s on the field-regex.
+      if (!name || !command) {
+        this.showToast('Name and command are required.');
+        return;
+      }
       // Client-side duplicate-name rejection (case-insensitive,
       // mirrors the backend AgentConfig field-validator). Avoids
       // confusing top-level Pydantic 400 surfaces — also keeps
@@ -6995,7 +7008,17 @@ function dashboard() {
       //     by-name semantic).
       let envKeys;
       if (d._replaceEnv) {
-        envKeys = (d._envRows || []).map(r => (r.key || '').trim()).filter(Boolean);
+        // Dedupe to match the wire payload's dict semantics — a later
+        // duplicate key would overwrite the earlier on the backend, so
+        // ``env_keys`` should reflect a single occurrence per key.
+        const seen = new Set();
+        envKeys = [];
+        for (const r of (d._envRows || [])) {
+          const k = (r.key || '').trim();
+          if (!k || seen.has(k)) continue;
+          seen.add(k);
+          envKeys.push(k);
+        }
       } else if (editIdx >= 0) {
         const original = this.editForm.mcp_servers[editIdx];
         envKeys = (original && Array.isArray(original.env_keys)) ? [...original.env_keys] : [];
@@ -7064,12 +7087,11 @@ function dashboard() {
     mcpToggleReplaceEnv() {
       if (!this.editForm._mcpDraft) return;
       this.editForm._mcpDraft._replaceEnv = !this.editForm._mcpDraft._replaceEnv;
-      // Toggling OFF drops any draft rows so the save flow omits env
-      // entirely (preserve-by-name semantics). Toggling ON leaves the
-      // editor empty — the user explicitly supplies every var via +Add.
-      if (!this.editForm._mcpDraft._replaceEnv) {
-        this.editForm._mcpDraft._envRows = [];
-      }
+      // Don't clear _envRows on toggle-off: the save flow already
+      // omits env entirely whenever ``_replaceEnv`` is false (see
+      // mcpDraftToWirePayload), so the rows are inert until the user
+      // toggles back ON. Preserving them across an off→on cycle stops
+      // the silent drop where a curious toggle would discard typed env.
     },
 
     mcpDetectJsRuntime(command) {

--- a/src/dashboard/static/js/app.js
+++ b/src/dashboard/static/js/app.js
@@ -7024,7 +7024,19 @@ function dashboard() {
       this.showConfirm(
         'Remove MCP server',
         `Remove "${s.name}"? Agent will restart when you save.`,
-        () => { this.editForm.mcp_servers.splice(idx, 1); },
+        () => {
+          this.editForm.mcp_servers.splice(idx, 1);
+          // Keep _mcpEditIndex pointing at the right row after the
+          // splice. If the edited row itself was removed, close the
+          // draft entirely; if a row ABOVE the edited one was removed,
+          // shift the index down by one. Without this, the inline edit
+          // form silently re-binds to a different entry's row.
+          if (this.editForm._mcpEditIndex === idx) {
+            this.mcpCancelDraft();
+          } else if (this.editForm._mcpEditIndex > idx) {
+            this.editForm._mcpEditIndex -= 1;
+          }
+        },
         true,
       );
     },
@@ -7177,7 +7189,12 @@ function dashboard() {
       // the outer Save, auto-commit the draft so the typed entries
       // aren't silently dropped. Reject the save if the draft is
       // incomplete (no name/command) — surface a clear toast so the
-      // user knows why their save didn't go through.
+      // user knows why their save didn't go through. mcpCommitDraft
+      // can ALSO reject the commit silently (duplicate name, cred row
+      // with no selected credential) — it leaves ``_mcpDraft`` in place
+      // and shows its own toast. Detect that and abort the save so the
+      // user isn't shown a contradictory "Updated: ..." success toast
+      // after a rejection.
       if (this.editForm && this.editForm._mcpDraft) {
         const d = this.editForm._mcpDraft;
         if (!(d.name || '').trim() || !(d.command || '').trim()) {
@@ -7185,6 +7202,7 @@ function dashboard() {
           return;
         }
         this.mcpCommitDraft();
+        if (this.editForm._mcpDraft) return;
       }
       this.configSaving = true;
       try {

--- a/src/dashboard/static/js/app.js
+++ b/src/dashboard/static/js/app.js
@@ -6061,6 +6061,12 @@ function dashboard() {
       const tab = this.identityCurrentTab;
       if (tab.id === 'config') {
         if (!this.agentConfigs[agentId]) await this.fetchAgentConfig(agentId);
+        // Fire-and-forget capabilities fetch so the MCP Servers panel's
+        // status dots populate without blocking the Config tab render.
+        // (The Capabilities tab path already runs this awaited; here we
+        // just need it to land so ``agentMcpStatus`` reflects per-server
+        // state.) Errors are logged inside fetchAgentCapabilities.
+        this.fetchAgentCapabilities(agentId);
         return;
       }
       // Composite tabs — load all mapped files (always refetch for freshness)
@@ -6876,6 +6882,12 @@ function dashboard() {
         _mcpRestartPending: false,
         _mcpRestartError: null,
         _mcpErrors: {},
+        _mcpGlobalError: null,
+        // Capture the agent ID this edit form is bound to so the restart-
+        // retry banner targets the right agent even if ``selectedAgent``
+        // changes (e.g. the user clicks a different agent in the list
+        // before clicking Retry).
+        _editingAgentId: this.selectedAgent,
       };
       this.configEditing = true;
     },
@@ -6933,14 +6945,28 @@ function dashboard() {
     mcpCommitDraft() {
       const d = this.editForm._mcpDraft;
       if (!d) return;
+      // env_keys is a display-only field for the inline edit UI:
+      //   * In replace mode it's derived from the new rows the user supplied.
+      //   * In preserve mode (not replacing) we KEEP the original entry's
+      //     env_keys — otherwise re-opening the row would falsely show
+      //     "No env vars" while the backend still has them. The actual
+      //     env payload is built in mcpDraftToWirePayload, which omits
+      //     env entirely when ``_replaceEnv`` is false (PR 1 preserve-
+      //     by-name semantic).
+      let envKeys;
+      if (d._replaceEnv) {
+        envKeys = d._envRows.map(r => (r.key || '').trim()).filter(Boolean);
+      } else if (this.editForm._mcpEditIndex >= 0) {
+        const original = this.editForm.mcp_servers[this.editForm._mcpEditIndex];
+        envKeys = (original && Array.isArray(original.env_keys)) ? [...original.env_keys] : [];
+      } else {
+        envKeys = [];
+      }
       const entry = {
         name: (d.name || '').trim(),
         command: (d.command || '').trim(),
         args: d._argRows.map(r => r.value).filter(v => v !== ''),
-        // We only attach env_keys here for the read-back UI; the actual
-        // env payload that goes on the wire is built in saveAgentConfig
-        // via mcpDraftToWirePayload (which knows _replaceEnv semantics).
-        env_keys: d._envRows.map(r => (r.key || '').trim()).filter(Boolean),
+        env_keys: envKeys,
         _replaceEnv: !!d._replaceEnv,
         _envRows: d._envRows,
       };
@@ -6986,12 +7012,9 @@ function dashboard() {
     mcpToggleReplaceEnv() {
       if (!this.editForm._mcpDraft) return;
       this.editForm._mcpDraft._replaceEnv = !this.editForm._mcpDraft._replaceEnv;
-      // When replace is freshly toggled on, start with an empty editor so
-      // the user is explicitly supplying every var. When toggled off, drop
-      // any draft rows so the save flow omits env (preserve semantics).
-      if (this.editForm._mcpDraft._replaceEnv && this.editForm._mcpDraft._envRows.length === 0) {
-        // leave empty — user will + Add as needed
-      }
+      // Toggling OFF drops any draft rows so the save flow omits env
+      // entirely (preserve-by-name semantics). Toggling ON leaves the
+      // editor empty — the user explicitly supplies every var via +Add.
       if (!this.editForm._mcpDraft._replaceEnv) {
         this.editForm._mcpDraft._envRows = [];
       }
@@ -7185,8 +7208,11 @@ function dashboard() {
           if (resp.ok) {
             configResult = await resp.json();
             allUpdated.push(...configResult.updated);
-            // Clear any prior per-row MCP errors from a failed earlier save.
-            if (this.editForm) this.editForm._mcpErrors = {};
+            // Clear any prior per-row + top-level MCP errors from a failed earlier save.
+            if (this.editForm) {
+              this.editForm._mcpErrors = {};
+              this.editForm._mcpGlobalError = null;
+            }
           } else {
             const err = await resp.json().catch(() => ({}));
             // Structured Pydantic validation errors come back as
@@ -7197,18 +7223,31 @@ function dashboard() {
             const detail = err.detail;
             if (detail && typeof detail === 'object' && detail.field === 'mcp_servers' && Array.isArray(detail.errors)) {
               const perRow = {};
+              const topLevel = [];
               for (const e of detail.errors) {
                 const loc = e.loc || [];
-                // loc[0] = "mcp_servers", loc[1] = row index, loc[2] = field name (or "args"/"env" with deeper path)
+                const msg = e.msg || 'Invalid';
+                // Row-level: loc = ["mcp_servers", row_idx, field_name, ...]
+                // Top-level: loc = ["mcp_servers"] — produced by field
+                // validators on AgentConfig.mcp_servers itself (e.g. the
+                // case-insensitive duplicate-name rejection). Surface
+                // these in a banner above the list so the user can see
+                // what's wrong even though there's no row to anchor on.
                 if (loc.length >= 3 && loc[0] === 'mcp_servers') {
                   const ridx = Number(loc[1]);
-                  if (!Number.isFinite(ridx)) continue;
-                  const field = String(loc[2]);
-                  perRow[ridx] = perRow[ridx] || {};
-                  perRow[ridx][field] = e.msg || 'Invalid';
+                  if (Number.isFinite(ridx)) {
+                    const field = String(loc[2]);
+                    perRow[ridx] = perRow[ridx] || {};
+                    perRow[ridx][field] = msg;
+                    continue;
+                  }
                 }
+                topLevel.push(msg);
               }
-              if (this.editForm) this.editForm._mcpErrors = perRow;
+              if (this.editForm) {
+                this.editForm._mcpErrors = perRow;
+                this.editForm._mcpGlobalError = topLevel.length ? topLevel.join('; ') : null;
+              }
               this.showToast('MCP server config has errors — see inline.');
               return;  // KEEP edit mode open for the user to fix
             }

--- a/src/dashboard/templates/index.html
+++ b/src/dashboard/templates/index.html
@@ -3524,6 +3524,10 @@
                             <button x-show="!editForm._showMcpAddForm && editForm._mcpEditIndex === -1"
                                     type="button" @click="mcpStartAdd()"
                                     class="text-xs px-3 py-1.5 rounded border border-gray-700 hover:border-gray-600 text-gray-400 hover:text-gray-300 transition-colors">+ Add MCP server</button>
+                            <!-- Top-level validation banner (errors that don't map to a single row, e.g. duplicate names) -->
+                            <div x-show="editForm._mcpGlobalError" x-cloak
+                                 class="mt-2 p-2 rounded bg-red-900/20 border border-red-800/50 text-[11px] text-red-300"
+                                 x-text="editForm._mcpGlobalError"></div>
                             <!-- Restart failure banner (post save+restart attempt) -->
                             <div x-show="editForm._mcpRestartError" x-cloak
                                  class="mt-3 p-2 rounded bg-red-900/20 border border-red-800/50 text-[11px] text-red-300 flex items-center gap-2">
@@ -3531,7 +3535,7 @@
                                 Config saved, but agent restart failed:
                                 <span class="font-mono text-red-400" x-text="editForm._mcpRestartError"></span>
                               </span>
-                              <button type="button" @click="retryMcpRestart(selectedAgent)"
+                              <button type="button" @click="retryMcpRestart(editForm._editingAgentId || selectedAgent)"
                                       class="text-[10px] px-2 py-1 rounded bg-red-900/40 hover:bg-red-900/60 text-red-200 transition-colors">Retry restart</button>
                             </div>
                           </div>

--- a/src/dashboard/templates/index.html
+++ b/src/dashboard/templates/index.html
@@ -3048,6 +3048,31 @@
                             </div>
                           </div>
                         </div>
+                        <!-- MCP Servers (read-only mirror; edit UI lives below in Config edit mode) -->
+                        <div class="bg-gray-800/50 rounded p-3 md:col-span-2">
+                          <div class="text-xs text-gray-500 mb-2 flex items-center gap-2">
+                            <span>MCP Servers</span>
+                            <span class="text-[10px] text-gray-600"
+                                  x-text="(agentConfigs[selectedAgent]?.mcp_servers || []).length + ' configured'"></span>
+                          </div>
+                          <template x-if="!(agentConfigs[selectedAgent]?.mcp_servers || []).length">
+                            <div class="text-xs text-gray-600 italic">None configured.</div>
+                          </template>
+                          <template x-for="srv in (agentConfigs[selectedAgent]?.mcp_servers || [])" :key="srv.name">
+                            <div class="flex items-center gap-3 text-xs py-1.5">
+                              <span class="w-2 h-2 rounded-full shrink-0"
+                                    :class="mcpStatusDotClass(mcpStatusFor(srv.name).state)"
+                                    :title="mcpStatusFor(srv.name).error || mcpStatusFor(srv.name).state"></span>
+                              <span class="text-gray-200 font-mono font-medium shrink-0" x-text="srv.name"></span>
+                              <span class="text-gray-600 shrink-0">&rarr;</span>
+                              <span class="text-gray-500 text-[10px] font-mono flex-1 truncate"
+                                    x-text="(srv.command || '') + (srv.args && srv.args.length ? ' ' + srv.args.join(' ') : '')"></span>
+                              <span x-show="mcpStatusFor(srv.name).state === 'running'"
+                                    class="text-[10px] px-1.5 py-0.5 rounded font-medium leading-none bg-amber-900/50 text-amber-400 border border-amber-800/50 shrink-0"
+                                    x-text="mcpStatusFor(srv.name).toolsCount + ' tools'"></span>
+                            </div>
+                          </template>
+                        </div>
                         <div class="bg-gray-800/50 rounded p-3 md:col-span-2">
                           <div class="text-xs text-gray-500 mb-1">Credential Access</div>
                           <div class="text-sm text-gray-200 font-mono mb-2">
@@ -3297,6 +3322,217 @@
                                   <span x-text="ch.label"></span>
                                 </label>
                               </template>
+                            </div>
+                          </div>
+                          <!-- MCP Servers (edit mode) — connect external tool servers to this agent. -->
+                          <div class="md:col-span-2">
+                            <label class="text-xs text-gray-500 mb-1.5 flex items-center gap-2">
+                              <span>MCP Servers</span>
+                              <span class="text-[10px] text-amber-500/70 ml-auto">restart required after changes</span>
+                            </label>
+                            <!-- Configured server list -->
+                            <template x-if="(editForm.mcp_servers || []).length">
+                              <div class="space-y-0 mb-2">
+                                <template x-for="(srv, idx) in editForm.mcp_servers" :key="srv.name + ':' + idx">
+                                  <div>
+                                    <!-- Compact row (hidden while this row is being edited) -->
+                                    <div x-show="editForm._mcpEditIndex !== idx"
+                                         class="flex items-center gap-3 text-xs group py-2 px-2 -mx-2 rounded-md hover:bg-gray-800/40 transition-colors border-b border-gray-800/30 last:border-0">
+                                      <span class="w-2 h-2 rounded-full shrink-0"
+                                            :class="mcpStatusDotClass(mcpStatusFor(srv.name).state)"
+                                            :title="mcpStatusFor(srv.name).error || mcpStatusFor(srv.name).state"></span>
+                                      <span class="text-gray-200 font-mono font-medium shrink-0" x-text="srv.name"></span>
+                                      <span class="text-gray-600 shrink-0">&rarr;</span>
+                                      <span class="text-gray-500 text-[10px] font-mono flex-1 truncate"
+                                            x-text="(srv.command || '') + (srv.args && srv.args.length ? ' ' + srv.args.join(' ') : '')"></span>
+                                      <span x-show="mcpStatusFor(srv.name).state === 'running'"
+                                            class="text-[10px] px-1.5 py-0.5 rounded font-medium leading-none bg-amber-900/50 text-amber-400 border border-amber-800/50 shrink-0"
+                                            x-text="mcpStatusFor(srv.name).toolsCount + ' tools'"></span>
+                                      <button type="button" @click="mcpStartEdit(idx)"
+                                              class="opacity-0 group-hover:opacity-100 focus:opacity-100 text-[10px] px-1.5 py-0.5 rounded bg-gray-800 hover:bg-gray-700 text-gray-400 hover:text-gray-200 transition-all shrink-0">Edit</button>
+                                      <button type="button" @click="mcpRemoveAt(idx)"
+                                              class="opacity-0 group-hover:opacity-100 focus:opacity-100 text-[10px] px-1.5 py-0.5 rounded bg-gray-800 hover:bg-red-900/30 text-gray-400 hover:text-red-400 transition-all shrink-0">Remove</button>
+                                    </div>
+                                    <!-- Failed-startup error band (collapsed under the row) -->
+                                    <div x-show="editForm._mcpEditIndex !== idx && mcpStatusFor(srv.name).state === 'failed' && mcpStatusFor(srv.name).error"
+                                         class="text-[10px] text-red-400 mt-0.5 mb-1 px-2 -mx-2"
+                                         x-text="'Failed at startup: ' + mcpStatusFor(srv.name).error"></div>
+                                    <!-- Inline edit form -->
+                                    <div x-show="editForm._mcpEditIndex === idx" x-transition
+                                         class="bg-gray-800/30 border border-gray-800 rounded-lg p-3 mt-1 mb-2 space-y-2">
+                                      <!-- name + command -->
+                                      <div class="grid grid-cols-1 sm:grid-cols-2 gap-2">
+                                        <div>
+                                          <label class="text-[10px] text-gray-500 block mb-0.5">Name</label>
+                                          <input type="text" x-model="editForm._mcpDraft.name" class="dash-input w-full" placeholder="linear">
+                                          <div x-show="editForm._mcpErrors?.[idx]?.name" class="text-[10px] text-red-400 mt-1" x-text="editForm._mcpErrors?.[idx]?.name"></div>
+                                        </div>
+                                        <div>
+                                          <label class="text-[10px] text-gray-500 block mb-0.5">Command</label>
+                                          <input type="text" x-model="editForm._mcpDraft.command" class="dash-input w-full" placeholder="mcp-server-linear">
+                                          <div x-show="mcpDetectJsRuntime(editForm._mcpDraft.command)"
+                                               class="text-[10px] text-amber-400 mt-1">Default agent image is Python-only. Node-based MCP servers need a custom image — see docs.</div>
+                                          <div x-show="editForm._mcpErrors?.[idx]?.command" class="text-[10px] text-red-400 mt-1" x-text="editForm._mcpErrors?.[idx]?.command"></div>
+                                        </div>
+                                      </div>
+                                      <!-- args (list of pairs) -->
+                                      <div>
+                                        <label class="text-[10px] text-gray-500 block mb-0.5">Args (one per row)</label>
+                                        <template x-for="(arg, aidx) in editForm._mcpDraft._argRows" :key="aidx">
+                                          <div class="flex items-center gap-1.5 mb-1">
+                                            <input type="text" x-model="arg.value" class="dash-input flex-1" placeholder="--workspace">
+                                            <button type="button" @click="mcpRemoveArgRow(aidx)" class="text-[10px] px-1.5 py-1 rounded bg-gray-800 hover:bg-red-900/30 text-gray-400 hover:text-red-400 transition-colors">×</button>
+                                          </div>
+                                        </template>
+                                        <button type="button" @click="mcpAddArgRow()" class="text-[10px] text-gray-500 hover:text-gray-300 transition-colors">+ Add arg</button>
+                                        <div x-show="editForm._mcpErrors?.[idx]?.args" class="text-[10px] text-red-400 mt-1" x-text="editForm._mcpErrors?.[idx]?.args"></div>
+                                      </div>
+                                      <!-- env: read-only display of existing env_keys (when not replacing) -->
+                                      <div>
+                                        <div class="flex items-center gap-2 mb-0.5">
+                                          <label class="text-[10px] text-gray-500">Env</label>
+                                          <button type="button" @click="mcpToggleReplaceEnv()"
+                                                  class="text-[10px] px-2 py-0.5 rounded transition-colors"
+                                                  :class="editForm._mcpDraft._replaceEnv ? 'bg-indigo-600 text-white' : 'bg-gray-800 text-gray-400 hover:bg-gray-700'"
+                                                  x-text="editForm._mcpDraft._replaceEnv ? 'Replacing — cancel to keep current' : 'Replace env vars'"></button>
+                                        </div>
+                                        <!-- Preserve mode: show existing keys read-only -->
+                                        <template x-if="!editForm._mcpDraft._replaceEnv">
+                                          <div>
+                                            <template x-if="(srv.env_keys || []).length">
+                                              <div class="flex flex-wrap gap-1">
+                                                <template x-for="k in srv.env_keys" :key="k">
+                                                  <span class="inline-flex items-center text-[10px] font-mono px-2 py-0.5 rounded bg-gray-800 text-gray-400 border border-gray-700" x-text="k"></span>
+                                                </template>
+                                              </div>
+                                            </template>
+                                            <template x-if="!(srv.env_keys || []).length">
+                                              <div class="text-[10px] text-gray-600 italic">No env vars.</div>
+                                            </template>
+                                            <div class="text-[10px] text-gray-600 italic mt-1">Values hidden. Toggle "Replace env vars" to set new values — you'll need to supply ALL env vars (existing values are not retrievable).</div>
+                                          </div>
+                                        </template>
+                                        <!-- Replace mode: row editor with type toggle -->
+                                        <template x-if="editForm._mcpDraft._replaceEnv">
+                                          <div>
+                                            <template x-for="(row, ridx) in editForm._mcpDraft._envRows" :key="ridx">
+                                              <div class="flex items-center gap-1.5 mb-1">
+                                                <input type="text" x-model="row.key" class="dash-input w-32" placeholder="KEY">
+                                                <select x-model="row.type" class="dash-select text-[11px]">
+                                                  <option value="cred">Credential</option>
+                                                  <option value="plain">Plain text</option>
+                                                </select>
+                                                <template x-if="row.type === 'cred'">
+                                                  <select x-model="row.value" class="dash-select flex-1">
+                                                    <option value="">— pick credential —</option>
+                                                    <template x-for="c in (agentConfigs[selectedAgent]?.resolved_credentials || [])" :key="c">
+                                                      <option :value="c" x-text="c"></option>
+                                                    </template>
+                                                  </select>
+                                                </template>
+                                                <template x-if="row.type === 'plain'">
+                                                  <div class="flex-1">
+                                                    <input type="text" x-model="row.value" class="dash-input w-full" placeholder="value">
+                                                    <div x-show="mcpDetectSecretLike(row.value)" class="text-[10px] text-amber-400 mt-0.5">Looks like an API key. Use Credential mode instead.</div>
+                                                  </div>
+                                                </template>
+                                                <button type="button" @click="mcpRemoveEnvRow(ridx)" class="text-[10px] px-1.5 py-1 rounded bg-gray-800 hover:bg-red-900/30 text-gray-400 hover:text-red-400 transition-colors">×</button>
+                                              </div>
+                                            </template>
+                                            <button type="button" @click="mcpAddEnvRow()" class="text-[10px] text-gray-500 hover:text-gray-300 transition-colors">+ Add env var</button>
+                                          </div>
+                                        </template>
+                                        <div x-show="editForm._mcpErrors?.[idx]?.env" class="text-[10px] text-red-400 mt-1" x-text="editForm._mcpErrors?.[idx]?.env"></div>
+                                      </div>
+                                      <!-- Buttons -->
+                                      <div class="flex items-center justify-end gap-2 pt-1">
+                                        <button type="button" @click="mcpCancelDraft()"
+                                                class="text-xs px-3 py-1.5 rounded border border-gray-700 hover:border-gray-600 text-gray-400 hover:text-gray-300 transition-colors">Cancel</button>
+                                        <button type="button" @click="mcpCommitDraft()"
+                                                :disabled="!editForm._mcpDraft?.name || !editForm._mcpDraft?.command"
+                                                class="text-xs px-3 py-1.5 rounded bg-indigo-600 hover:bg-indigo-500 text-white transition-colors disabled:opacity-50">Apply</button>
+                                      </div>
+                                    </div>
+                                  </div>
+                                </template>
+                              </div>
+                            </template>
+                            <template x-if="!(editForm.mcp_servers || []).length && !editForm._showMcpAddForm">
+                              <div class="text-xs text-gray-600 italic mb-2">No MCP servers configured. Add one to extend this agent's tools (e.g. Linear, GitHub, a database).</div>
+                            </template>
+                            <!-- Add form -->
+                            <div x-show="editForm._showMcpAddForm" x-transition
+                                 class="bg-gray-800/30 border border-gray-800 rounded-lg p-3 mt-1 mb-2 space-y-2">
+                              <div class="grid grid-cols-1 sm:grid-cols-2 gap-2">
+                                <div>
+                                  <label class="text-[10px] text-gray-500 block mb-0.5">Name</label>
+                                  <input type="text" x-model="editForm._mcpDraft.name" class="dash-input w-full" placeholder="linear">
+                                </div>
+                                <div>
+                                  <label class="text-[10px] text-gray-500 block mb-0.5">Command</label>
+                                  <input type="text" x-model="editForm._mcpDraft.command" class="dash-input w-full" placeholder="mcp-server-linear">
+                                  <div x-show="mcpDetectJsRuntime(editForm._mcpDraft.command)"
+                                       class="text-[10px] text-amber-400 mt-1">Default agent image is Python-only. Node-based MCP servers need a custom image — see docs.</div>
+                                </div>
+                              </div>
+                              <div>
+                                <label class="text-[10px] text-gray-500 block mb-0.5">Args (one per row)</label>
+                                <template x-for="(arg, aidx) in editForm._mcpDraft._argRows" :key="aidx">
+                                  <div class="flex items-center gap-1.5 mb-1">
+                                    <input type="text" x-model="arg.value" class="dash-input flex-1" placeholder="--workspace">
+                                    <button type="button" @click="mcpRemoveArgRow(aidx)" class="text-[10px] px-1.5 py-1 rounded bg-gray-800 hover:bg-red-900/30 text-gray-400 hover:text-red-400 transition-colors">×</button>
+                                  </div>
+                                </template>
+                                <button type="button" @click="mcpAddArgRow()" class="text-[10px] text-gray-500 hover:text-gray-300 transition-colors">+ Add arg</button>
+                              </div>
+                              <div>
+                                <label class="text-[10px] text-gray-500 block mb-0.5">Env vars</label>
+                                <template x-for="(row, ridx) in editForm._mcpDraft._envRows" :key="ridx">
+                                  <div class="flex items-center gap-1.5 mb-1">
+                                    <input type="text" x-model="row.key" class="dash-input w-32" placeholder="KEY">
+                                    <select x-model="row.type" class="dash-select text-[11px]">
+                                      <option value="cred">Credential</option>
+                                      <option value="plain">Plain text</option>
+                                    </select>
+                                    <template x-if="row.type === 'cred'">
+                                      <select x-model="row.value" class="dash-select flex-1">
+                                        <option value="">— pick credential —</option>
+                                        <template x-for="c in (agentConfigs[selectedAgent]?.resolved_credentials || [])" :key="c">
+                                          <option :value="c" x-text="c"></option>
+                                        </template>
+                                      </select>
+                                    </template>
+                                    <template x-if="row.type === 'plain'">
+                                      <div class="flex-1">
+                                        <input type="text" x-model="row.value" class="dash-input w-full" placeholder="value">
+                                        <div x-show="mcpDetectSecretLike(row.value)" class="text-[10px] text-amber-400 mt-0.5">Looks like an API key. Use Credential mode instead.</div>
+                                      </div>
+                                    </template>
+                                    <button type="button" @click="mcpRemoveEnvRow(ridx)" class="text-[10px] px-1.5 py-1 rounded bg-gray-800 hover:bg-red-900/30 text-gray-400 hover:text-red-400 transition-colors">×</button>
+                                  </div>
+                                </template>
+                                <button type="button" @click="mcpAddEnvRow()" class="text-[10px] text-gray-500 hover:text-gray-300 transition-colors">+ Add env var</button>
+                              </div>
+                              <div class="flex items-center justify-end gap-2 pt-1">
+                                <button type="button" @click="mcpCancelDraft()"
+                                        class="text-xs px-3 py-1.5 rounded border border-gray-700 hover:border-gray-600 text-gray-400 hover:text-gray-300 transition-colors">Cancel</button>
+                                <button type="button" @click="mcpCommitDraft()"
+                                        :disabled="!editForm._mcpDraft?.name || !editForm._mcpDraft?.command"
+                                        class="text-xs px-3 py-1.5 rounded bg-indigo-600 hover:bg-indigo-500 text-white transition-colors disabled:opacity-50">Add</button>
+                              </div>
+                            </div>
+                            <button x-show="!editForm._showMcpAddForm && editForm._mcpEditIndex === -1"
+                                    type="button" @click="mcpStartAdd()"
+                                    class="text-xs px-3 py-1.5 rounded border border-gray-700 hover:border-gray-600 text-gray-400 hover:text-gray-300 transition-colors">+ Add MCP server</button>
+                            <!-- Restart failure banner (post save+restart attempt) -->
+                            <div x-show="editForm._mcpRestartError" x-cloak
+                                 class="mt-3 p-2 rounded bg-red-900/20 border border-red-800/50 text-[11px] text-red-300 flex items-center gap-2">
+                              <span class="flex-1">
+                                Config saved, but agent restart failed:
+                                <span class="font-mono text-red-400" x-text="editForm._mcpRestartError"></span>
+                              </span>
+                              <button type="button" @click="retryMcpRestart(selectedAgent)"
+                                      class="text-[10px] px-2 py-1 rounded bg-red-900/40 hover:bg-red-900/60 text-red-200 transition-colors">Retry restart</button>
                             </div>
                           </div>
                           <div class="md:col-span-2">


### PR DESCRIPTION
## Summary

Visual CRUD surface for MCP servers in the agent Config tab, on top of PR #964's backend foundation. **Pure frontend** — no Python changes; consumes the contract PR 1 ships (`mcp_servers` masked GET, structured 400, `$CRED{name}` resolution, per-server status registry on `/capabilities`).

**Base targets `feat/mcp-backend-foundation`** so the diff stays scoped to dashboard changes only — GitHub auto-rebases the base to `main` once PR 1 merges.

Closes #959 (alongside PR #964).

## What lands in the dashboard

Inside the agent Config tab, between Capabilities toggles and Credentials access:

- **Read-only mirror** in display mode: status dot per server (green = running, red = failed, gray = pending), command preview, tool-count badge (amber, matches existing MCP source badge).
- **Inline edit/add forms** (Webhooks list pattern) with:
  - Name + command inputs; Pydantic structured 400 errors render inline per-row, per-field (edit mode stays open so the user can fix them).
  - Args as **list-of-pairs** (one input per arg + remove + Add arg) — no JSON syntax to learn.
  - Env editor with per-row mode toggle: **Credential picker** (filtered by `agentConfigs[id].resolved_credentials`, writes `$CRED{name}` to the wire) | **Plain text** input.
  - **Replace env toggle** (default OFF) — preserves existing env unless explicitly opted in (matches PR 1's "env absent = preserve" semantic). When ON, editor starts empty and save sends the full new env dict; explainer notes values aren't retrievable.
  - **JS-runtime warning chip** below the command input when it matches `npx`/`bunx`/`pnpm dlx`/`yarn dlx`/`node`/`npm`/`pnpm`/`yarn`/`bun`.
  - **Secret-heuristic warning** when a Plain env value matches common secret prefixes (`sk-`, `ghp_`, `pat-`, `Bearer ...`) or looks high-entropy — nudges toward Credential mode.
- **Per-server startup error band** under the failed row, showing the captured stderr (truncated 500 chars by PR 1). Removes the "tail container logs to debug" UX.
- **Restart-failure banner with Retry button** — on save+restart failure, edit mode stays open; the banner shows the error; Retry calls `/restart` only (no re-PUT) since config is already persisted.

## How save+restart orchestrates

1. `mcpServersChanged()` diffs against persisted; only sends `mcp_servers` if there's a real change (matches backend's diff-based `mcp_touched` — no spurious restarts).
2. Wire payload built per entry via `mcpDraftToWirePayload`: omits `env` for untouched entries (preserve), includes it for entries the user toggled to replace; credential picker values become `$CRED{name}`.
3. On structured Pydantic 400: parse `errors[].loc` → per-row field error map → inline display; **keep edit mode open**.
4. On restart failure: set `_mcpRestartError`, **keep edit mode open**, show Retry banner; retry path calls `/restart` only.
5. On restart success: refetch `/capabilities` → status dots flip to reflect the new state.

## Out of scope (intentional, deferred)

- Operator-tool MCP write surface — **Phase 3**, separate PR. Will model on the existing credential-request / browser-login pattern (operator requests via card, human configures, agent picks up).
- Tool-list filtering by server in Capabilities tab — `mcp_tool_to_server` side-channel is wired (PR 1 + this PR), UX follow-up.
- HTTP/SSE transport selector — `mcp_client.py` is stdio-only.
- "Test Connection" dry-run — save+restart IS the test; per-server status registry surfaces failures clearly.

## Test plan (manual — no JS test infra in repo)

- [ ] Open agent → Config → Edit. MCP Servers section appears between Capabilities toggles and Credentials access.
- [ ] **Add server** with plain env: name, command, two args, one Plain env var → Add → Save → restart confirms → status dot turns green with tools_count.
- [ ] **Add server with credential**: pick a credential from the picker → save → verify status green; verify GET `/config` shows the entry with `env_keys: [KEY]` and no env values.
- [ ] **Edit existing** without toggling Replace env → save → existing env preserved on the wire.
- [ ] **Toggle Replace env** → supply fresh dict → save → env replaced wholesale.
- [ ] **Remove server** → confirm modal → list collapses → save → server gone.
- [ ] **Bad name** (spaces) → save → inline error next to name input; edit mode stays open.
- [ ] **`$CRED{...}` in command** → save → inline error on command field.
- [ ] **`npx ...` command** → JS-runtime warning chip appears inline.
- [ ] **Plain env value `sk-...`** → secret-heuristic warning chip appears inline.
- [ ] **GET → no-op PUT** → no restart triggered (regression on `mcp_touched` diff).
- [ ] **Restart failure** (simulated via dead command in server) → edit mode stays open with persistent Retry banner; Retry triggers `/restart` without re-PUT.
- [ ] **Switch agents mid-edit** → MCP state resets cleanly.

## Files

- `src/dashboard/static/js/app.js` (+318 / -3) — state, helpers, save flow.
- `src/dashboard/templates/index.html` (+236) — read-only mirror, edit list, inline add/edit forms.

## Verification

- `node --check src/dashboard/static/js/app.js` — JS syntax clean.
- `pytest tests/test_dashboard.py::TestDashboardIndex` (6 tests) — template renders cleanly through the dashboard router.
- `pytest tests/test_dashboard.py::TestDashboardAgentConfig tests/test_dashboard.py::TestCapabilitiesMcpForwarding` (50 tests) — PR 1's backend tests still pass on this branch (pure-frontend change).