### PR TITLE
feat(dashboard,operator): work-tab cutover — drop management-console UI, add Goals + Tell Operator, load-bounded operator (PR 2/3)

### DIFF
--- a/src/agent/builtins/operator_tools.py
+++ b/src/agent/builtins/operator_tools.py
@@ -2189,7 +2189,7 @@ async def manage_team(
 _GOALS_MD_FILENAME = "GOALS.md"
 _GOALS_JSON_FILENAME = "GOALS.json"
 
-_MAX_GOALS_ENTRIES = 20
+_MAX_GOALS_ENTRIES = 10
 _MAX_GOAL_NAME_CHARS = 120
 _MAX_GOAL_NOTE_CHARS = 500
 
@@ -2335,7 +2335,7 @@ def _validate_goal_input(goal, *, require_status: bool = True) -> tuple[dict | N
             "type": "array",
             "description": (
                 "Full goal list for action='set'. Each entry: "
-                "{name: str, status: enum, progress_note?: str}. Max 20."
+                "{name: str, status: enum, progress_note?: str}. Max 10."
             ),
             "items": {"type": "object"},
             "default": [],
@@ -2344,7 +2344,7 @@ def _validate_goal_input(goal, *, require_status: bool = True) -> tuple[dict | N
             "type": "object",
             "description": (
                 "Single goal for action='add' or 'update'. Same shape as "
-                "'goals' entries."
+                "'goals' entries. Max 10."
             ),
             "default": {},
         },
@@ -2491,3 +2491,107 @@ async def manage_goals(
 
     # Unreachable — action set is validated above.
     return {"error": f"Unknown action {action!r}"}
+
+
+# ── Per-task outcome rating (PR 2 of Work tab rewrite) ───────────────
+#
+# Operator's programmatic per-task judgment. Replaces the human-driven
+# rating buttons that lived on the "Recently delivered" cards before
+# the Work-tab cutover. The deleted UI hit the same dashboard endpoint
+# the drill-in modal uses; this tool routes through the mesh so the
+# operator agent can score completed tasks from its heartbeat loop
+# (preserves the agent-feedback machine loop: memory writes on
+# accepted/rework/rejected + auto-rework spawn on rework).
+
+_VALID_RATE_OUTCOMES = frozenset({
+    "accepted", "acknowledged", "rework", "rejected",
+})
+_MAX_RATE_FEEDBACK_CHARS = 2000
+
+
+@skill(
+    name="rate_delivery",
+    description=(
+        "Record outcome for a completed task. Operator's per-task "
+        "judgment — preserves the agent-feedback machine loop "
+        "(memory writes + auto-rework spawn). Default to "
+        "'acknowledged' when uncertain; never guess. Operator-only."
+    ),
+    parameters={
+        "task_id": {"type": "string", "description": "Task to rate."},
+        "outcome": {
+            "type": "string",
+            "enum": ["accepted", "acknowledged", "rework", "rejected"],
+            "description": (
+                "accepted = matches ask cleanly. acknowledged = neutral/"
+                "low-confidence (no memory write). rework = fixable miss "
+                "(spawns follow-up task; feedback required). rejected = "
+                "needs restart (feedback required)."
+            ),
+        },
+        "feedback": {
+            "type": "string",
+            "description": "Required for rework/rejected (max 2000 chars).",
+            "default": "",
+        },
+    },
+)
+async def rate_delivery(
+    task_id: str = "",
+    outcome: str = "",
+    feedback: str = "",
+    *,
+    mesh_client=None,
+    **_kw,
+) -> dict:
+    """Record an outcome rating on a completed task via the mesh.
+
+    Returns ``{ok, task_id, outcome, rework_task_id?}`` on success or
+    ``{error: ...}`` on validation / mesh failure. Feedback is sanitized
+    via :func:`sanitize_for_prompt` before transit so a corrupted
+    upstream string can't poison the receiving agent's memory.
+    """
+    if not _is_operator():
+        return {"error": "This tool is only available to the operator agent."}
+    if mesh_client is None:
+        return {"error": "No mesh_client available"}
+    if not isinstance(task_id, str) or not task_id.strip():
+        return {"error": "task_id is required"}
+    if outcome not in _VALID_RATE_OUTCOMES:
+        return {
+            "error": (
+                f"outcome must be one of {sorted(_VALID_RATE_OUTCOMES)}"
+            ),
+        }
+    if not isinstance(feedback, str):
+        return {"error": "feedback must be a string"}
+    feedback_clean = sanitize_for_prompt(feedback).strip()
+    if len(feedback_clean) > _MAX_RATE_FEEDBACK_CHARS:
+        return {
+            "error": (
+                f"feedback exceeds {_MAX_RATE_FEEDBACK_CHARS} chars"
+            ),
+        }
+    if outcome in ("rework", "rejected") and not feedback_clean:
+        return {
+            "error": f"feedback is required for outcome={outcome!r}",
+        }
+    try:
+        response = await mesh_client.set_task_outcome(
+            task_id.strip(), outcome, feedback_clean,
+        )
+    except Exception as e:
+        return {"error": f"Failed to rate task {task_id}: {e}"}
+    result: dict = {
+        "ok": True,
+        "task_id": task_id.strip(),
+        "outcome": outcome,
+    }
+    if isinstance(response, dict):
+        if "rework_task_id" in response:
+            result["rework_task_id"] = response["rework_task_id"]
+        if "rework_assignee" in response:
+            result["rework_assignee"] = response["rework_assignee"]
+        if "rework_error" in response:
+            result["rework_error"] = response["rework_error"]
+    return result

--- a/src/agent/mesh_client.py
+++ b/src/agent/mesh_client.py
@@ -1077,6 +1077,29 @@ class MeshClient:
         """DEPRECATED: alias for :meth:`set_team_goal`."""
         return await self.set_team_goal(project_name, north_star, success_criteria)
 
+    async def set_task_outcome(
+        self,
+        task_id: str,
+        outcome: str,
+        feedback: str = "",
+    ) -> dict:
+        """Record an operator outcome rating on a completed task.
+
+        Routes through ``POST /mesh/tasks/{task_id}/outcome`` — the
+        canonical mesh-tier endpoint that the operator's
+        ``rate_delivery`` tool calls. Returns the mesh response dict
+        (carries ``rework_task_id`` / ``rework_assignee`` when the
+        outcome triggered a follow-up task spawn).
+        """
+        client = await self._get_client()
+        response = await client.post(
+            f"{self.mesh_url}/mesh/tasks/{task_id}/outcome",
+            json={"outcome": outcome, "feedback": feedback},
+            headers=self._trace_headers(),
+        )
+        _raise_with_body(response)
+        return response.json()
+
     async def browser_command(
         self, action: str, params: dict | None = None,
         target_agent_id: str | None = None,

--- a/src/agent/workspace.py
+++ b/src/agent/workspace.py
@@ -339,29 +339,33 @@ class WorkspaceManager:
 
         # Idempotent heartbeat refresh: mirrors the INSTRUCTIONS.md
         # playbook_v2 sentinel pattern above. When the template carries a
-        # versioned marker (currently ``heartbeat_v2_workflow_aware`` —
-        # the operator workflow-awareness rewrite) and the live file
-        # lacks it, overwrite from the template. Versioned markers let
-        # us roll system-managed heartbeat updates forward without
-        # touching user-customised heartbeats (which won't have the
-        # marker because they replaced the template). New markers added
-        # in future revisions can extend this tuple.
+        # versioned marker (latest: ``heartbeat_v3_rate_delivery``) and
+        # the live file lacks the LATEST one, overwrite from the
+        # template. Versioned markers let us roll system-managed
+        # heartbeat updates forward without touching user-customised
+        # heartbeats (which won't have any marker because they replaced
+        # the template). New markers added in future revisions extend
+        # ``HEARTBEAT_SENTINELS`` at the end — the last entry is the
+        # current expectation; earlier entries stay as evidence of
+        # prior migrations.
         from src.shared.types import HEARTBEAT_SENTINELS
+        latest_sentinel = HEARTBEAT_SENTINELS[-1] if HEARTBEAT_SENTINELS else None
         if (
             heartbeat_path.exists()
             and self._initial_heartbeat
-            and any(
-                f"<!-- {m} -->" in self._initial_heartbeat
-                for m in HEARTBEAT_SENTINELS
-            )
+            and latest_sentinel
+            and f"<!-- {latest_sentinel} -->" in self._initial_heartbeat
         ):
             try:
                 existing = heartbeat_path.read_text(errors="replace")
             except Exception:
                 existing = ""
-            needs_refresh = not any(
-                f"<!-- {m} -->" in existing for m in HEARTBEAT_SENTINELS
-            )
+            # Refresh if the EXISTING file lacks the latest sentinel —
+            # i.e., it's still on a prior heartbeat version (or
+            # custom). Using ``any()`` over the whole tuple would
+            # silently skip v2→v3 upgrades because v2's marker is
+            # already present in old files.
+            needs_refresh = f"<!-- {latest_sentinel} -->" not in existing
             if needs_refresh:
                 heartbeat_path.write_text(
                     "# Heartbeat Rules\n\n"

--- a/src/cli/config.py
+++ b/src/cli/config.py
@@ -1863,22 +1863,24 @@ def _ensure_operator_agent(config_path: Path | None = None, default_model: str =
     if has_operator:
         # Refresh the operator's heartbeat field whenever the canonical
         # template gains a new sentinel marker. Mirrors the workspace-
-        # side refresh in ``WorkspaceManager._ensure_scaffold`` — a
-        # sentinel like ``heartbeat_v2_workflow_aware`` lets us roll
-        # the operator's heartbeat forward without touching agents
-        # with user-customised heartbeats.
+        # side refresh in ``WorkspaceManager._ensure_scaffold`` — the
+        # latest sentinel in ``HEARTBEAT_SENTINELS`` is the current
+        # expectation; an operator carrying only earlier markers (e.g.
+        # ``heartbeat_v2_workflow_aware`` after we add v3) needs a
+        # refresh to receive the new instructions.
         op_entry = agents_cfg["agents"].get(_OPERATOR_AGENT_ID, {}) or {}
         existing_heartbeat = op_entry.get("heartbeat") or ""
         from src.shared.types import HEARTBEAT_SENTINELS
-        new_has_sentinel = any(
-            f"<!-- {m} -->" in _OPERATOR_HEARTBEAT
-            for m in HEARTBEAT_SENTINELS
+        latest_sentinel = HEARTBEAT_SENTINELS[-1] if HEARTBEAT_SENTINELS else None
+        new_has_latest = (
+            latest_sentinel is not None
+            and f"<!-- {latest_sentinel} -->" in _OPERATOR_HEARTBEAT
         )
-        old_has_sentinel = any(
-            f"<!-- {m} -->" in existing_heartbeat
-            for m in HEARTBEAT_SENTINELS
+        old_has_latest = (
+            latest_sentinel is not None
+            and f"<!-- {latest_sentinel} -->" in existing_heartbeat
         )
-        if new_has_sentinel and not old_has_sentinel:
+        if new_has_latest and not old_has_latest:
             op_entry["heartbeat"] = _OPERATOR_HEARTBEAT
             agents_cfg["agents"][_OPERATOR_AGENT_ID] = op_entry
             AGENTS_FILE.parent.mkdir(parents=True, exist_ok=True)

--- a/src/cli/config.py
+++ b/src/cli/config.py
@@ -1657,6 +1657,12 @@ _OPERATOR_ALLOWED_TOOLS: list[str] = [
     # /api/workplace/goals. Operator-only — _is_operator() is enforced
     # at the tool boundary as well.
     "manage_goals",
+    # Per-task outcome rating (PR 2 of Work tab rewrite). Replaces
+    # the per-task 👍/➖/👎 buttons deleted from the Work tab —
+    # operator scores tasks programmatically from the heartbeat
+    # loop, preserving the agent-feedback machine loop (memory
+    # writes + auto-rework spawn).
+    "rate_delivery",
     # Lifecycle (consolidated archive/delete)
     "manage_team", "manage_agent", "manage_task",
     # Self-cleanup — operator can clear stale pending actions and prune
@@ -1704,6 +1710,7 @@ You build the workforce and step back. Users work with agents directly.
 
 _OPERATOR_HEARTBEAT = """\
 <!-- heartbeat_v2_workflow_aware -->
+<!-- heartbeat_v3_rate_delivery -->
 You are running an autonomous fleet health check. You have access ONLY to monitoring tools.
 Your previous observations are included above in OBSERVATIONS.md.
 
@@ -1778,6 +1785,47 @@ in the loop; 10 leaves headroom for the final assistant turn).
 
 If any tool call fails, record the failure in save_observations and continue.
 Do not hallucinate data you could not retrieve.
+
+## Per-task rating cadence
+
+Each heartbeat, rate up to 10 oldest unrated done tasks via
+`rate_delivery`. Prefer keeping one team's tasks contiguous if it
+helps focus. Outcomes:
+- accepted: matches the ask cleanly → reinforcement memory written
+- acknowledged: unsure or low-confidence → NO memory write (the
+  safe default when you can't confidently defend the judgment)
+- rework: fixable miss → spawns follow-up task; feedback required
+- rejected: needs starting over → feedback required, no spawn
+
+DEFAULT TO `acknowledged` WHEN UNCERTAIN. Never guess.
+
+## Workspace-as-source-of-truth
+
+Re-read GOALS.json, OBSERVATIONS.md, AGENTS.md fresh at the start of
+each cycle. Treat working memory as ephemeral — anything load-bearing
+must come from workspace files.
+
+## Surface ambiguity, don't guess
+
+If you cannot identify which team a task belongs to, or two goals
+conflict, call `notify_user` and stop. Do not guess your way through.
+
+## Goal stewardship
+
+On each cycle scan goals for staleness (no related task activity in
+14 days). Surface stale candidates in your next summary's "What I'm
+watching" section. DO NOT auto-retire goals — only the user decides
+to drop a goal.
+
+## Tool semantics (don't confuse these)
+
+- `manage_goals` — workplace-wide user-stated business outcomes.
+  Source of truth is GOALS.json. Use when user states/changes
+  direction in chat. (NEW — added in PR 1.)
+- `set_team_goal` — each team's mission statement. Rarely changes;
+  usually set on team creation.
+- `rate_delivery` — your per-task outcome judgment after a task
+  completes. Not user-facing. (NEW — added in PR 2.)
 """
 
 

--- a/src/dashboard/static/js/app.js
+++ b/src/dashboard/static/js/app.js
@@ -3000,6 +3000,15 @@ function dashboard() {
     // per-task 👍/➖/👎 buttons. POSTs to the operator chat via the
     // existing ``sendChatTo`` helper; shows a transient "Sent" banner
     // and clears the textarea on success.
+    //
+    // ``sendChatTo`` absorbs HTTP failures into the chat history
+    // (sets the assistant placeholder's ``role`` to ``error`` or
+    // ``credit_exhausted``) and returns silently rather than
+    // throwing — so a try/catch around the call wouldn't catch a
+    // 4xx/5xx POST. Detect failure by inspecting the assistant
+    // placeholder's role after the call returns. The user message
+    // is pushed at length-2 and the assistant placeholder at
+    // length-1; we check the tail.
     async submitTellOperator() {
       const text = (this.tellOperatorText || '').trim();
       if (!text || this.tellOperatorInflight) return;
@@ -3007,9 +3016,23 @@ function dashboard() {
       this.tellOperatorConfirmation = '';
       try {
         await this.sendChatTo('operator', text);
-        this.tellOperatorText = '';
-        this.tellOperatorConfirmation = "Sent — open Chat tab to see operator's response.";
-        setTimeout(() => { this.tellOperatorConfirmation = ''; }, 5000);
+        const history = this.chatHistories['operator'] || [];
+        const tail = history[history.length - 1];
+        const failed = tail && (
+          tail.role === 'error' || tail.role === 'credit_exhausted'
+        );
+        if (failed) {
+          this.tellOperatorConfirmation = (
+            tail.role === 'credit_exhausted'
+              ? 'Send failed — operator out of credit.'
+              : 'Send failed — try again.'
+          );
+          setTimeout(() => { this.tellOperatorConfirmation = ''; }, 5000);
+        } else {
+          this.tellOperatorText = '';
+          this.tellOperatorConfirmation = "Sent — open Chat tab to see operator's response.";
+          setTimeout(() => { this.tellOperatorConfirmation = ''; }, 5000);
+        }
       } catch (e) {
         this.tellOperatorConfirmation = 'Send failed — try again.';
       } finally {

--- a/src/dashboard/static/js/app.js
+++ b/src/dashboard/static/js/app.js
@@ -59,11 +59,6 @@ function dashboard() {
     // across navigation via Alpine root scope; localStorage carries it
     // through reloads so users keep their messenger open as they wander.
     messengerSidePanelOpen: false,
-    // Last time the user viewed the Work tab. PR 2 stubbed the
-    // delivery banner that consumed this (the ``recentlyDelivered``
-    // slice was removed); kept as a no-op stash so persisted-state
-    // restore paths don't break and a future banner can revive it.
-    _lastViewedHomeTs: 0,
     // Per-agent visible message count for "Load older →" pagination
     // (Phase 1 Decision 12). Default 50; click appends 50 more.
     _chatVisibleLimit: {},
@@ -1175,13 +1170,9 @@ function dashboard() {
       this._initTs = Date.now();  // track page load time to skip replayed events
       const cfg = window.__config || {};
 
-      // Restore Phase 1 state from localStorage (side panel + last-Home
-      // visit timestamp). These are cosmetic — losing them is harmless,
-      // so we wrap each in its own try/catch and never block init.
-      try {
-        const v = localStorage.getItem('ol_last_viewed_home');
-        if (v) this._lastViewedHomeTs = parseInt(v, 10) || 0;
-      } catch (e) { /* ignore */ }
+      // Restore Phase 1 state from localStorage (side panel).
+      // Cosmetic — losing it is harmless, so wrap in try/catch and
+      // never block init.
       try {
         const v = localStorage.getItem('ol_messenger_side_panel_open');
         if (v === '1') this.messengerSidePanelOpen = true;
@@ -1793,30 +1784,6 @@ function dashboard() {
     systemTabLabelFor(tab) {
       if (tab.id === 'settings') return 'General';
       return tab.label;
-    },
-
-    /** Always false — PR 2 of the Work tab rewrite removed the
-     * ``recentlyDelivered`` slice that backed this banner. The
-     * notification bell + Needs You panel cover the same surface now. */
-    get deliveryBannerVisible() {
-      return false;
-    },
-
-    /** Always empty — paired with the always-false banner. */
-    deliveryBannerSummary() {
-      return '';
-    },
-
-    /** Mark Home as viewed (clears the delivery banner). */
-    markHomeViewed() {
-      this._lastViewedHomeTs = Date.now();
-      try { localStorage.setItem('ol_last_viewed_home', String(this._lastViewedHomeTs)); } catch (e) { /* ignore */ }
-    },
-
-    /** Banner click handler — switch to Home and ack. */
-    openHomeFromBanner() {
-      this.markHomeViewed();
-      this.switchTab('workplace');
     },
 
     /** Toggle the side-panel messenger (visible on non-Chat tabs). */
@@ -2579,12 +2546,6 @@ function dashboard() {
       if (fromTab !== tab) {
         this.track('tab_view', { tab_id: tab, from_tab_id: fromTab || '' });
         this._trackFirstAction('tab_view');
-      }
-      // Phase 1 — clearing the delivery banner. The Chat banner only
-      // shows when there are deliveries newer than ``_lastViewedHomeTs``;
-      // navigating to Home is the natural "I saw it" signal.
-      if (tab === 'workplace') {
-        this.markHomeViewed();
       }
       if (tab === 'chat') {
         if (!this.openChats.includes('operator')) {

--- a/src/dashboard/static/js/app.js
+++ b/src/dashboard/static/js/app.js
@@ -59,10 +59,10 @@ function dashboard() {
     // across navigation via Alpine root scope; localStorage carries it
     // through reloads so users keep their messenger open as they wander.
     messengerSidePanelOpen: false,
-    // Last time the user viewed the Work tab. Drives the Chat tab
-    // delivery banner ("Writer delivered draft 12m ago — see on Work →")
-    // — banner shows when ``recentlyDeliveredItems`` has entries newer
-    // than this timestamp. Persisted to localStorage.
+    // Last time the user viewed the Work tab. PR 2 stubbed the
+    // delivery banner that consumed this (the ``recentlyDelivered``
+    // slice was removed); kept as a no-op stash so persisted-state
+    // restore paths don't break and a future banner can revive it.
     _lastViewedHomeTs: 0,
     // Per-agent visible message count for "Load older →" pagination
     // (Phase 1 Decision 12). Default 50; click appends 50 more.
@@ -404,28 +404,19 @@ function dashboard() {
       { id: 'task-board', label: 'Tasks' },
       { id: 'team-outputs', label: 'Outputs' },
     ],
-    // Phase 4 — Board (workplace) restructured around the kanban as
-    // the default surface. ``homeTab`` is the sub-route within the
-    // Board tab.
-    //   ``kanban`` (default) → kanban board: Needs You + Stuck tasks
-    //     + 4-column kanban (Pending / Working / Blocked / Done) with
-    //     a × cancel button on every card. Empty sections hide.
-    //   ``activity`` → single-scroll activity feed: Just delivered +
-    //     Happening now + In progress. Lifted from the legacy
-    //     ``main`` layout; reachable via the "View activity feed →"
-    //     link below the kanban or the URL ``/home/activity``.
-    // Backward compat: the legacy ``main`` value (Phase 3 default)
-    // and ``tasks`` value (Phase 3 kanban sub-page) both resolve to
-    // the new ``kanban`` default — old bookmarks land on the kanban
-    // because the kanban IS the new default. The legacy
-    // ``workplaceTab`` state stays for back-compat with deep links
-    // that still toggle it.
-    homeTab: 'kanban',
+    // PR 2 of Work tab rewrite — removed sub-nav (Summaries / Kanban /
+    // Activity) along with the kanban + activity surfaces. The Work tab
+    // now lands directly on summary cards. Stuck Tasks panel + Cancel
+    // modal + Task drill-in (reachable from Needs you + notification
+    // bell) are retained.
     workplaceEnabled: true,
     workplaceTeams: [],
     workplaceTasks: [],
     workplaceBlockers: [],
-    workplaceOutputs: [],
+    // Workplace-wide business goals (PR 2). Operator manages via
+    // ``manage_goals``; dashboard renders a read-only chip strip above
+    // the Needs You panel. Hidden entirely when empty.
+    workplaceGoals: [],
     // Work summaries surface (PR-B). One row per team per period. The
     // user rates 👍/➖/👎 with optional feedback; rating + feedback
     // flow back into operator's next composition. List is ordered
@@ -446,18 +437,6 @@ function dashboard() {
     // The template uses this to disable the rating buttons + show a
     // subtle loading affordance, preventing double-fires.
     _summaryRateInFlight: {},
-    // ``true`` once the user has explicitly chosen a homeTab (via the
-    // sub-nav toggle). Until then, the default lands on 'summaries'
-    // when at least one team exists. Small fleets (no teams) skip
-    // straight to the kanban because the team layer would be empty.
-    homeTabUserChosen: false,
-    // Memoised slice for the Activity feed's "Recently delivered"
-    // header — recomputed in ``loadWorkplaceOutputs`` so the template
-    // doesn't re-run the filter on every Alpine reactive read. See
-    // ``_recomputeRecentlyDelivered`` for the coercion rules.
-    recentlyDeliveredItems: [],
-    workplaceFeed: [],
-    workplaceFeedCap: 200,
     workplacePending: [],
     workplaceLoading: false,
     // Per-section loading + error state. Failures used to be swallowed
@@ -471,48 +450,26 @@ function dashboard() {
       teams: false,
       tasks: false,
       blockers: false,
-      outputs: false,
       pending: false,
-      feed: false,
       summaries: false,
+      goals: false,
     },
     workplaceErrors: {
       teams: '',
       tasks: '',
       blockers: '',
-      outputs: '',
       pending: '',
-      feed: '',
       summaries: '',
+      goals: '',
     },
-    // Per-task artifact preview cache for the "Recently delivered"
-    // section. Keyed by task_id so each row's preview is fetched once
-    // and reused; the value is the full /api/workplace/tasks/{id}
-    // response so the "Read full" toggle can show the inlined content
-    // without a second round-trip. ``recentlyDeliveredExpanded`` tracks
-    // which rows the user has expanded.
-    recentlyDeliveredArtifacts: {},
-    recentlyDeliveredExpanded: {},
-    _recentlyDeliveredFetching: {},
-    // Inline rework state for the "Recently delivered" cards — keyed by
-    // task_id. Opens an inline textarea on the card instead of bouncing
-    // through the drillIn modal so the user stays in flow. Cleared by
-    // ``rateDelivery`` after a successful submit. Initialized here in
-    // the data section so Alpine treats them as first-class reactive
-    // state (template helpers ``inlineReworkIsOpen`` / ``inlineReworkText``
-    // read them indirectly, but a future direct-template read should
-    // still react).
-    _inlineReworkOpen: {},
-    _inlineReworkText: {},
-    // Per-task in-flight guard for inline rating clicks — prevents a
-    // user from double-firing rateDelivery while the POST is still
-    // round-tripping. Cleared in the finally block of ``rateDelivery``.
-    _rateDeliveryInflight: {},
-    workplaceTeamFilter: '',
-    // Per-column flag: when true, the kanban column ignores the 14-day
-    // archive cutoff and shows old pending/blocked rows. Keyed by status
-    // so toggling one column doesn't expand the others.
-    boardShowArchived: {},
+    // PR 2 Tell Operator (steering affordance, replaces the deleted
+    // per-task rating UI). ``tellOperatorText`` is the textarea
+    // binding; ``tellOperatorInflight`` disables the Send button
+    // while a request is in flight; ``tellOperatorConfirmation``
+    // shows a transient "Sent" banner that auto-clears after 5s.
+    tellOperatorText: '',
+    tellOperatorInflight: false,
+    tellOperatorConfirmation: '',
     // In-flight audit-log undo so we can disable the button per-row.
     auditReverting: {},
 
@@ -805,31 +762,12 @@ function dashboard() {
         return '/system/' + (this.systemTab || 'activity');
       }
       if (this.activeTab === 'fleet') return '/agents';
-      // Phase 4 — Board (workplace) sub-routing. Default lands on
-      // the kanban (``/home``); the activity feed sub-page is at
-      // ``/home/activity``. Legacy ``/home/tasks`` still maps to
-      // the same default in ``_parsePath`` (kanban IS the default,
-      // so old bookmarks survive without a redirect).
+      // PR 2 of Work tab rewrite — single Work surface. The sub-nav
+      // (Summaries / Kanban / Activity) was removed; ``/home`` is the
+      // only Work-tab URL. Legacy ``/home/kanban``, ``/home/activity``,
+      // ``/home/summaries``, and ``/home/tasks`` all normalize to
+      // ``/home`` in ``_parsePath``.
       if (this.activeTab === 'workplace') {
-        // Every EXPLICIT Work sub-view gets its own URL so reloads
-        // preserve the user's tab choice. Bare ``/home`` means
-        // "no opinion" — ``_applyDefaultHomeTab`` decides
-        // (summaries by current policy). The kanban arm is gated
-        // on ``homeTabUserChosen`` to avoid canonicalizing bare
-        // ``/home`` into ``/home/kanban`` while the default policy
-        // is still about to fire — without that gate, ``_parsePath``
-        // seeds ``homeTab='kanban'`` as a placeholder on bare
-        // ``/home`` loads, the initial ``_pushUrl`` would emit
-        // ``/home/kanban``, and the URL bar would flicker before
-        // settling on ``/home/summaries`` once the default ran.
-        // The activity/summaries arms don't need the same guard —
-        // their only way of being set is via an explicit deep link
-        // or user click, both of which set ``homeTabUserChosen``.
-        if (this.homeTab === 'activity') return '/home/activity';
-        if (this.homeTab === 'summaries') return '/home/summaries';
-        if (this.homeTab === 'kanban' && this.homeTabUserChosen) {
-          return '/home/kanban';
-        }
         return '/home';
       }
       return '/';
@@ -851,66 +789,24 @@ function dashboard() {
         return (st ? st.label : 'System') + ' \u2014 OpenLegion';
       }
       if (this.activeTab === 'workplace') {
-        return this.homeTab === 'activity' ? 'Activity \u2014 OpenLegion' : 'Work \u2014 OpenLegion';
+        return 'Work \u2014 OpenLegion';
       }
       return 'Team \u2014 OpenLegion';
     },
 
     _parsePath(path) {
       const clean = path.replace(/^\/+/, '').replace(/\/+$/, '');
-      const route = { tab: 'chat', activityView: 'traces', systemTab: 'activity', agentId: null, identityTab: 'config', homeTab: 'kanban' };
+      const route = { tab: 'chat', activityView: 'traces', systemTab: 'activity', agentId: null, identityTab: 'config' };
       if (!clean) return route;
 
       if (clean === 'chat') { route.tab = 'chat'; return route; }
       if (clean === 'agents' || clean.startsWith('agents/')) { route.tab = 'fleet'; }
-      // Phase 4 — Board sub-routing. ``/home`` → kanban (default);
-      // ``/home/activity`` → single-scroll activity feed. Legacy
-      // ``/home/tasks`` (Phase 3 kanban sub-page URL) still resolves
-      // to the kanban — the kanban IS the default now, so old
-      // bookmarks survive without a redirect.
-      // Explicit Work sub-routes all set ``homeTabUserChosen`` so the
-      // post-load ``_applyDefaultHomeTab`` doesn't override a user's
-      // deep link. Bare ``/home`` is the only path that lets the
-      // auto-default decide (currently summaries, unconditional).
-      if (clean === 'home') {
-        // Default landing. Seed ``homeTab='summaries'`` directly
-        // here (matching the always-summaries policy that
-        // ``_applyDefaultHomeTab`` would set after load anyway) so
-        // the initial render lands on summaries without a visual
-        // flicker through the kanban placeholder. Do NOT set
-        // ``homeTabUserChosen`` — the user didn't choose; we
-        // defaulted on their behalf. That distinction matters for
-        // ``_buildPath``'s canonicalization gate.
-        route.tab = 'workplace'; route.homeTab = 'summaries';
-        return route;
-      }
-      // Segment-boundary-safe prefix match: ``startsWith('home/X/')``
-      // (with trailing slash) avoids false matches like
-      // ``home/kanbanabc`` which would otherwise canonicalize to a
-      // different tab.
-      if (clean === 'home/activity' || clean.startsWith('home/activity/')) {
-        route.tab = 'workplace'; route.homeTab = 'activity';
-        route.homeTabUserChosen = true;
-        return route;
-      }
-      if (clean === 'home/summaries' || clean.startsWith('home/summaries/')) {
-        route.tab = 'workplace'; route.homeTab = 'summaries';
-        route.homeTabUserChosen = true;
-        return route;
-      }
-      if (clean === 'home/kanban' || clean.startsWith('home/kanban/')) {
-        // Explicit kanban deep-link, symmetric with the other Work
-        // sub-routes. Without it, clicking the Kanban tab produced
-        // ``/home`` and the user's choice was lost on reload (the
-        // post-load ``_applyDefaultHomeTab`` reverted to summaries).
-        route.tab = 'workplace'; route.homeTab = 'kanban';
-        route.homeTabUserChosen = true;
-        return route;
-      }
-      if (clean === 'home/tasks' || clean.startsWith('home/tasks/')) {
-        // Legacy Phase-3 bookmark — explicit kanban request.
-        route.tab = 'workplace'; route.homeTab = 'kanban';
-        route.homeTabUserChosen = true;
+      // PR 2 of Work tab rewrite — single Work-tab URL. Any /home or
+      // legacy /home/{kanban,activity,summaries,tasks} sub-route
+      // normalizes silently to ``/home`` so old bookmarks survive
+      // without a 404 or visible redirect.
+      if (clean === 'home' || clean.startsWith('home/')) {
+        route.tab = 'workplace';
         return route;
       }
 
@@ -978,18 +874,7 @@ function dashboard() {
               this.systemTab = route.systemTab;
               if (route.systemTab === 'activity') this.activityView = route.activityView;
             }
-            if (route.tab === 'workplace') {
-              this.homeTab = route.homeTab || 'kanban';
-              if (route.homeTabUserChosen) this.homeTabUserChosen = true;
-            }
             this.switchTab(route.tab);
-          } else if (route.tab === 'workplace') {
-            // Phase 4 — already on Board; just sync sub-page state
-            // without re-running loadWorkplace (no new fetch needed).
-            if (this.homeTab !== (route.homeTab || 'kanban')) {
-              this.homeTab = route.homeTab || 'kanban';
-            }
-            if (route.homeTabUserChosen) this.homeTabUserChosen = true;
           } else if (route.tab === 'system') {
             if (this.systemTab !== route.systemTab) {
               if (this.systemTab === 'activity') this._stopActivityRefresh();
@@ -1910,41 +1795,16 @@ function dashboard() {
       return tab.label;
     },
 
-    /** True when there's a delivered item the user hasn't seen on Home. */
+    /** Always false — PR 2 of the Work tab rewrite removed the
+     * ``recentlyDelivered`` slice that backed this banner. The
+     * notification bell + Needs You panel cover the same surface now. */
     get deliveryBannerVisible() {
-      if (this.activeTab !== 'chat') return false;
-      const items = this.recentlyDeliveredItems || [];
-      if (items.length === 0) return false;
-      // ``recentlyDeliveredItems`` rows carry an ``updated_at`` ISO string
-      // (set by ``_recomputeRecentlyDelivered``). Anything newer than the
-      // last Home visit means the user hasn't acknowledged it yet.
-      for (const it of items) {
-        const ts = Date.parse(it.updated_at || it.completed_at || it.created_at || '');
-        if (ts && ts > this._lastViewedHomeTs) return true;
-      }
       return false;
     },
 
-    /** Plain-English summary for the delivery banner — newest delivery first. */
+    /** Always empty — paired with the always-false banner. */
     deliveryBannerSummary() {
-      const items = this.recentlyDeliveredItems || [];
-      if (items.length === 0) return '';
-      // Pick the newest unseen item.
-      let pick = null;
-      let pickTs = 0;
-      for (const it of items) {
-        const ts = Date.parse(it.updated_at || it.completed_at || it.created_at || '');
-        if (ts > this._lastViewedHomeTs && ts > pickTs) {
-          pickTs = ts;
-          pick = it;
-        }
-      }
-      if (!pick) return '';
-      const who = pick.assignee || pick.owner || 'A teammate';
-      const title = (pick.title || 'a task').toString().slice(0, 60);
-      const ageMin = Math.max(1, Math.round((Date.now() - pickTs) / 60000));
-      const ageStr = ageMin < 60 ? `${ageMin}m ago` : `${Math.round(ageMin / 60)}h ago`;
-      return `${who} delivered ${title} ${ageStr} — see on Work →`;
+      return '';
     },
 
     /** Mark Home as viewed (clears the delivery banner). */
@@ -2782,38 +2642,6 @@ function dashboard() {
       if (!this._skipPush) this._pushUrl(false);
     },
 
-    // Phase 4 — Board sub-page switcher. ``kanban`` is the default
-    // (kanban board with cancel buttons); ``activity`` opens the
-    // single-scroll activity feed. Legacy values (``main``,
-    // ``tasks``) are coerced to the kanban default so old call
-    // sites keep working. Pushes a new history entry so the back
-    // button returns to the previous sub-page (or out of Board
-    // entirely if the user navigated in).
-    switchHomeTab(tabId) {
-      // Accept the three valid sub-nav values; coerce anything else
-      // to the kanban default so legacy call sites keep working.
-      let target = 'kanban';
-      if (tabId === 'activity') target = 'activity';
-      else if (tabId === 'summaries') target = 'summaries';
-      // Push URL whenever EITHER the target changes OR the
-      // user-chosen flag flips false→true. The second case handles
-      // the bare ``/home`` landing: ``_parsePath`` seeded
-      // ``homeTab='summaries'`` without setting userChosen, so the
-      // URL is still bare ``/home``. Clicking the Summaries tab
-      // (or any tab matching the current state) must canonicalize
-      // the URL to ``/home/summaries`` — without this, the early
-      // ``return`` on same-target dropped the canonicalization and
-      // the URL stayed bare ``/home`` despite an explicit user
-      // gesture.
-      const targetChanged = this.homeTab !== target;
-      const userChosenFlipped = !this.homeTabUserChosen;
-      this.homeTab = target;
-      this.homeTabUserChosen = true;
-      if (targetChanged || userChosenFlipped) {
-        this._pushUrl(false);
-      }
-    },
-
     switchSystemTab(tabId) {
       if (this.systemTab === 'activity' && tabId !== 'activity') this._stopActivityRefresh();
       this.systemTab = tabId;
@@ -2918,15 +2746,10 @@ function dashboard() {
           this.loadWorkplaceTeams(),
           this.loadWorkplaceTasks(),
           this.loadWorkplaceBlockers(),
-          this.loadWorkplaceOutputs(),
-          this.loadWorkplaceFeed(),
           this.loadWorkplacePending(),
           this.loadWorkplaceSummaries(),
+          this.loadWorkplaceGoals(),
         ]);
-        // After all loads settle, pick the default homeTab if the user
-        // hasn't yet chosen one. Teams present → summary cards as the
-        // landing surface (PR-B). Solo / single-team fleets → kanban.
-        this._applyDefaultHomeTab();
       } finally {
         this.workplaceLoading = false;
       }
@@ -2934,19 +2757,16 @@ function dashboard() {
 
     // Per-section retry helper. Banners call ``retryWorkplaceSection``
     // with the section key — we clear the error first so the banner
-    // hides immediately, then re-run the section's loader. Keeping the
-    // dispatch in one place means the banner handlers in the template
-    // stay short ("@click=\"retryWorkplaceSection('feed')\"").
+    // hides immediately, then re-run the section's loader.
     retryWorkplaceSection(section) {
       this.workplaceErrors[section] = '';
       const fn = {
         teams: this.loadWorkplaceTeams,
         tasks: this.loadWorkplaceTasks,
         blockers: this.loadWorkplaceBlockers,
-        outputs: this.loadWorkplaceOutputs,
         pending: this.loadWorkplacePending,
-        feed: this.loadWorkplaceFeed,
         summaries: this.loadWorkplaceSummaries,
+        goals: this.loadWorkplaceGoals,
       }[section];
       if (fn) fn.call(this);
     },
@@ -3001,25 +2821,6 @@ function dashboard() {
         if (serial === this._summariesFetchSerial) {
           this.workplaceSectionLoading.summaries = false;
         }
-      }
-    },
-
-    // Pick the default homeTab on first Work-tab visit. Summaries
-    // is the unconditional default — operator-led strategy view is
-    // the primary mental model at every fleet size, not just at
-    // 30-agent scale. Empty state ("No summaries yet — ask
-    // operator") is the consistent landing for fresh installs. The
-    // sub-nav tab bar makes Kanban + Activity one-click reachable
-    // so the kanban-first power user is never more than a click
-    // away from their view.
-    //
-    // ``homeTabUserChosen`` is respected: an explicit user toggle
-    // or deep-link sub-route (every Work URL except bare ``/home``
-    // sets the flag) overrides the default.
-    _applyDefaultHomeTab() {
-      if (this.homeTabUserChosen) return;
-      if (this.homeTab !== 'summaries') {
-        this.homeTab = 'summaries';
       }
     },
 
@@ -3117,21 +2918,6 @@ function dashboard() {
       delete this.summaryFeedbackDrafts[summaryId];
     },
 
-    // Drill from a summary card into the scoped kanban for that team.
-    // Clears ``workplaceTasks`` BEFORE the sub-nav flip so a stale
-    // unfiltered render can't briefly leak cross-team tasks while
-    // the filtered fetch resolves (codex r1 P2). The skeleton
-    // loader fills the gap.
-    drillIntoTeamKanban(teamName) {
-      this.workplaceTeamFilter = teamName || '';
-      this.workplaceTasks = [];
-      this.workplaceSectionLoading.tasks = true;
-      this.homeTab = 'kanban';
-      this.homeTabUserChosen = true;
-      this.loadWorkplaceTasks();
-      this._pushUrl(false);
-    },
-
     async loadWorkplaceTeams() {
       this.workplaceSectionLoading.teams = true;
       this.workplaceErrors.teams = '';
@@ -3152,11 +2938,13 @@ function dashboard() {
     },
 
     async loadWorkplaceTasks() {
+      // PR 2 — feeds the Stuck Tasks panel and the drill-in modal's
+      // sibling-row updates. The team-filter query param was dropped
+      // along with the kanban surface; pull the unfiltered ledger.
       this.workplaceSectionLoading.tasks = true;
       this.workplaceErrors.tasks = '';
       try {
-        const params = this.workplaceTeamFilter ? `?project_id=${encodeURIComponent(this.workplaceTeamFilter)}` : '';
-        const resp = await fetch(`${window.__config.apiBase}/workplace/tasks${params}`);
+        const resp = await fetch(`${window.__config.apiBase}/workplace/tasks`);
         if (!resp.ok) {
           this.workplaceErrors.tasks = `Couldn't load tasks (HTTP ${resp.status})`;
           return;
@@ -3187,27 +2975,6 @@ function dashboard() {
         this.workplaceErrors.blockers = (e && e.message) ? `Couldn't load blockers: ${e.message}` : "Couldn't load blockers";
       } finally {
         this.workplaceSectionLoading.blockers = false;
-      }
-    },
-
-    async loadWorkplaceOutputs() {
-      this.workplaceSectionLoading.outputs = true;
-      this.workplaceErrors.outputs = '';
-      try {
-        const params = this.workplaceTeamFilter ? `?project_id=${encodeURIComponent(this.workplaceTeamFilter)}` : '';
-        const resp = await fetch(`${window.__config.apiBase}/workplace/outputs${params}`);
-        if (!resp.ok) {
-          this.workplaceErrors.outputs = `Couldn't load outputs (HTTP ${resp.status})`;
-          return;
-        }
-        const data = await resp.json();
-        this.workplaceEnabled = data.enabled !== false;
-        this.workplaceOutputs = data.outputs || [];
-        this._recomputeRecentlyDelivered();
-      } catch (e) {
-        this.workplaceErrors.outputs = (e && e.message) ? `Couldn't load outputs: ${e.message}` : "Couldn't load outputs";
-      } finally {
-        this.workplaceSectionLoading.outputs = false;
       }
     },
 
@@ -3245,67 +3012,48 @@ function dashboard() {
       }
     },
 
-    async loadWorkplaceFeed() {
-      this.workplaceSectionLoading.feed = true;
-      this.workplaceErrors.feed = '';
+    async loadWorkplaceGoals() {
+      // PR 2 — workplace-wide business goals managed by the operator
+      // via ``manage_goals`` (PR 1). Render is a horizontal chip strip
+      // above the Needs You panel; hidden entirely when empty.
+      this.workplaceSectionLoading.goals = true;
+      this.workplaceErrors.goals = '';
       try {
-        const params = this.workplaceTeamFilter ? `?project_id=${encodeURIComponent(this.workplaceTeamFilter)}` : '';
-        const resp = await fetch(`${window.__config.apiBase}/workplace/feed${params}`);
+        const resp = await fetch(`${window.__config.apiBase}/workplace/goals`);
         if (!resp.ok) {
-          this.workplaceErrors.feed = `Couldn't load activity (HTTP ${resp.status})`;
+          this.workplaceErrors.goals = `Couldn't load goals (HTTP ${resp.status})`;
           return;
         }
         const data = await resp.json();
-        this.workplaceEnabled = data.enabled !== false;
-        this.workplaceFeed = data.feed || [];
+        this.workplaceGoals = data.goals || [];
       } catch (e) {
-        this.workplaceErrors.feed = (e && e.message) ? `Couldn't load activity: ${e.message}` : "Couldn't load activity";
+        this.workplaceErrors.goals = (e && e.message)
+          ? `Couldn't load goals: ${e.message}`
+          : "Couldn't load goals";
       } finally {
-        this.workplaceSectionLoading.feed = false;
+        this.workplaceSectionLoading.goals = false;
       }
     },
 
-    workplaceTasksByStatus(status) {
-      // The kanban only has 4 columns (pending/working/blocked/done);
-      // the transient ``accepted`` status — emitted by ``update_status``
-      // when an agent acknowledges a task before they start working —
-      // folds into Pending so it stays visible on the board. Without
-      // this fold, ``accepted`` rows render in zero columns and the
-      // operator can't see (or cancel) them.
-      //
-      // Codex P1.5 (Option A): ``failed`` tasks fold into Done so they
-      // remain visible to the operator. Without this fold they render
-      // in zero columns and disappear from at-a-glance state. The card
-      // visual distinguishes done vs failed via a red border + status
-      // badge so the operator sees the failure (and the blocker_note)
-      // without having to drill in.
-      const tasks = this.workplaceTasks || [];
-      if (status === 'pending') {
-        return tasks.filter(t => t.status === 'pending' || t.status === 'accepted');
+    // PR 2 — Tell Operator. Steering affordance that replaced the
+    // per-task 👍/➖/👎 buttons. POSTs to the operator chat via the
+    // existing ``sendChatTo`` helper; shows a transient "Sent" banner
+    // and clears the textarea on success.
+    async submitTellOperator() {
+      const text = (this.tellOperatorText || '').trim();
+      if (!text || this.tellOperatorInflight) return;
+      this.tellOperatorInflight = true;
+      this.tellOperatorConfirmation = '';
+      try {
+        await this.sendChatTo('operator', text);
+        this.tellOperatorText = '';
+        this.tellOperatorConfirmation = "Sent — open Chat tab to see operator's response.";
+        setTimeout(() => { this.tellOperatorConfirmation = ''; }, 5000);
+      } catch (e) {
+        this.tellOperatorConfirmation = 'Send failed — try again.';
+      } finally {
+        this.tellOperatorInflight = false;
       }
-      if (status === 'done') {
-        return tasks.filter(t => t.status === 'done' || t.status === 'failed');
-      }
-      return tasks.filter(t => t.status === status);
-    },
-
-    // Icon for an activity feed entry. Plain text glyphs keep the
-    // template emoji-free; tweak here without touching the markup.
-    workplaceFeedIcon(eventType, taskStatus) {
-      if (eventType === 'created') return '+';
-      if (eventType === 'rerouted') return '→';
-      if (eventType === 'cancelled') return '✕';
-      if (eventType === 'artifact_added') return '▻';
-      if (eventType === 'task_outcome') return '★';
-      if (eventType === 'status_changed') {
-        if (taskStatus === 'done') return '✓';
-        if (taskStatus === 'blocked') return '⚠';
-        if (taskStatus === 'failed') return '✕';
-        if (taskStatus === 'cancelled') return '✕';
-        if (taskStatus === 'working') return '▶';
-        return '●';
-      }
-      return '●';
     },
 
     // ── Task drill-in modal (PR 4) ────────────────────────
@@ -3422,16 +3170,14 @@ function dashboard() {
           this.drillInError = data.detail || `Submit failed (HTTP ${resp.status})`;
           return;
         }
-        // Optimistically reflect outcome in the local lists so the
-        // kanban / outputs tab shows the rating without waiting for
-        // the next reload.
+        // Optimistically reflect outcome in workplaceTasks so the
+        // Stuck Tasks panel reflects the rating without waiting for
+        // the next reload. (PR 2 dropped ``workplaceOutputs``.)
         const updated = data.task || {};
-        for (const list of [this.workplaceTasks, this.workplaceOutputs]) {
-          const row = (list || []).find(r => r.id === this.drillInTaskId);
-          if (row) {
-            row.outcome = updated.outcome || outcome;
-            row.feedback_text = updated.feedback_text ?? (this.drillInComment || null);
-          }
+        const row = (this.workplaceTasks || []).find(r => r.id === this.drillInTaskId);
+        if (row) {
+          row.outcome = updated.outcome || outcome;
+          row.feedback_text = updated.feedback_text ?? (this.drillInComment || null);
         }
         if (outcome === 'rework' && data.rework_task_id) {
           this.showToast(`Rework task created${data.rework_assignee ? ' for ' + data.rework_assignee : ''}.`);
@@ -3652,41 +3398,10 @@ function dashboard() {
         });
       }
 
-      // Unrated deliveries — synthetic singleton entry. The user's
-      // primary feedback signal is the rating on completed work, so we
-      // surface a "N deliveries need rating" nudge once any of the
-      // Recently Delivered cards are unrated. Click jumps to the
-      // Activity sub-tab where the cards (with inline rating buttons)
-      // live.
-      const unrated = (this.recentlyDeliveredItems || []).filter(t => !t.outcome).length;
-      if (unrated > 0) {
-        items.push({
-          id: 'unrated-deliveries',
-          kind: 'unrated',
-          icon: '?',
-          title: unrated === 1
-            ? '1 delivery needs your rating'
-            : `${unrated} deliveries need your rating`,
-          subtitle: this._needsYouSubtitle({ text: 'Thumbs up, neutral, or rework' }),
-          actions: [
-            {
-              label: 'Review',
-              style: 'indigo',
-              handler: () => {
-                this.activeTab = 'workplace';
-                this.homeTab = 'activity';
-                // Scroll the first unrated card into view next tick so
-                // the user lands directly on the rating buttons.
-                requestAnimationFrame(() => {
-                  const el = document.querySelector('[data-testid="home-just-delivered"]');
-                  if (el && el.scrollIntoView) el.scrollIntoView({ behavior: 'smooth', block: 'start' });
-                });
-              },
-            },
-          ],
-        });
-      }
-
+      // PR 2 of Work tab rewrite — the legacy "N deliveries need
+      // your rating" synthetic Needs You item was removed along with
+      // the per-task rating UI. The operator now rates programmatically
+      // via ``rate_delivery`` on each heartbeat.
       return items;
     },
 
@@ -3841,261 +3556,7 @@ function dashboard() {
       return n;
     },
 
-    // Inline rate handler for the "Recently delivered" cards. Reuses
-    // the dashboard ``/workplace/tasks/{id}/outcome`` endpoint that the
-    // drillIn modal hits. Optimistically updates the local row so the
-    // buttons collapse to a rating chip without waiting for the
-    // ``task_outcome`` event round-trip.
-    //
-    // ``outcome``: 'accepted' | 'acknowledged' | 'rework'
-    //   - 'accepted' / 'acknowledged' send no feedback (silent rating).
-    //   - 'rework' opens the inline textarea; this method is called
-    //     with the comment populated.
-    async rateDelivery(taskId, outcome, feedback = '') {
-      if (!taskId) return;
-      if (this._rateDeliveryInflight[taskId]) return;
-      this._rateDeliveryInflight[taskId] = true;
-      try {
-        const resp = await fetch(
-          `${window.__config.apiBase}/workplace/tasks/${encodeURIComponent(taskId)}/outcome`,
-          {
-            method: 'POST',
-            headers: {
-              'Content-Type': 'application/json',
-              'X-Requested-With': 'XMLHttpRequest',
-            },
-            body: JSON.stringify({ outcome, feedback: feedback || '' }),
-          }
-        );
-        const data = await resp.json().catch(() => ({}));
-        if (!resp.ok) {
-          this.showToast(data.detail || `Rate failed (HTTP ${resp.status})`);
-          return;
-        }
-        // Optimistic write-back so the card flips to "Rated" without
-        // waiting on the next ``task_outcome`` WebSocket event.
-        const updated = data.task || {};
-        for (const list of [this.workplaceTasks, this.workplaceOutputs, this.recentlyDeliveredItems]) {
-          const row = (list || []).find(r => r.id === taskId);
-          if (row) {
-            row.outcome = updated.outcome || outcome;
-            row.feedback_text = updated.feedback_text ?? (feedback || null);
-          }
-        }
-        // Clear the per-card inline rework state if it was open.
-        delete this._inlineReworkOpen[taskId];
-        delete this._inlineReworkText[taskId];
-        if (outcome === 'rework' && data.rework_task_id) {
-          this.showToast(`Rework task created${data.rework_assignee ? ' for ' + data.rework_assignee : ''}.`);
-        } else if (outcome === 'rework' && data.rework_error) {
-          this.showToast(`Rework noted but follow-up task could not be spawned: ${data.rework_error}`);
-        } else {
-          this.showToast(`Rated: ${this.drillInOutcomeLabel(outcome) || outcome}.`);
-        }
-      } catch (e) {
-        this.showToast(`Rate failed: ${e.message || e}`);
-      } finally {
-        delete this._rateDeliveryInflight[taskId];
-      }
-    },
-
-    // ``_inlineReworkOpen`` / ``_inlineReworkText`` / ``_rateDeliveryInflight``
-    // declared in the data section above so Alpine treats them as
-    // reactive state. Method below just read/write them.
-    inlineReworkIsOpen(taskId) {
-      return !!(this._inlineReworkOpen && this._inlineReworkOpen[taskId]);
-    },
-
-    openInlineRework(taskId) {
-      this._inlineReworkOpen[taskId] = true;
-    },
-
-    closeInlineRework(taskId) {
-      delete this._inlineReworkOpen[taskId];
-      delete this._inlineReworkText[taskId];
-    },
-
-    inlineReworkText(taskId) {
-      return (this._inlineReworkText && this._inlineReworkText[taskId]) || '';
-    },
-
-    setInlineReworkText(taskId, value) {
-      this._inlineReworkText[taskId] = value;
-    },
-
-    submitInlineRework(taskId) {
-      const text = (this.inlineReworkText(taskId) || '').trim();
-      if (!text) {
-        this.showToast('Add a brief — what should change in the rework?');
-        return;
-      }
-      this.rateDelivery(taskId, 'rework', text);
-    },
-
-    // Recompute the memoised "Recently delivered" slice. Called whenever
-    // ``workplaceOutputs`` is refreshed. Coerces ``completed_at`` so the
-    // filter survives string timestamps and clock-skew-induced future
-    // values, then caps at 5 and sorts most-recent-first.
-    _recomputeRecentlyDelivered(limit = 5, days = 7) {
-      const cutoff = (Date.now() / 1000) - days * 86400;
-      const rows = [];
-      for (const t of (this.workplaceOutputs || [])) {
-        const sec = this._coerceCompletedAtSeconds(t.completed_at);
-        if (sec >= cutoff) {
-          // Spread + override so the original row isn't mutated and the
-          // template can still rely on ``completed_at`` being numeric
-          // seconds (its formatRelativeTime call multiplies by 1000).
-          rows.push({ ...t, completed_at: sec });
-        }
-      }
-      rows.sort((a, b) => (b.completed_at || 0) - (a.completed_at || 0));
-      this.recentlyDeliveredItems = rows.slice(0, limit);
-    },
-
-    // Back-compat shim — older callers and any future expressions should
-    // read ``recentlyDeliveredItems`` directly. Kept thin so the data
-    // field remains the single source of truth for the template.
-    recentlyDelivered() {
-      return this.recentlyDeliveredItems;
-    },
-
-    // Lazy-fetch the artifact bundle for a "Recently delivered" row so
-    // the user can read the actual output without opening the modal.
-    // The /api/workplace/tasks/{id} endpoint already returns each
-    // artifact_ref resolved to ``{kind, content, content_truncated}``
-    // (see _resolve_artifact in dashboard/server.py); we cache the
-    // first text artifact per task_id. Errors are stored on the same
-    // cache entry so a failed fetch surfaces inline rather than the
-    // row going blank.
-    async _ensureRecentlyDeliveredArtifact(taskId) {
-      if (!taskId) return;
-      if (this.recentlyDeliveredArtifacts[taskId] !== undefined) return;
-      if (this._recentlyDeliveredFetching[taskId]) return;
-      this._recentlyDeliveredFetching[taskId] = true;
-      try {
-        const resp = await fetch(`${window.__config.apiBase}/workplace/tasks/${encodeURIComponent(taskId)}`);
-        if (!resp.ok) {
-          this.recentlyDeliveredArtifacts[taskId] = { error: `HTTP ${resp.status}` };
-          return;
-        }
-        const data = await resp.json();
-        const arts = (data && data.artifacts) || [];
-        // Pick the first text artifact for the inline preview; non-text
-        // (image / pdf / missing / error) keeps the prior link-out
-        // behavior because we can't render bytes inline here.
-        const text = arts.find(a => a && a.kind === 'text' && typeof a.content === 'string');
-        if (text) {
-          this.recentlyDeliveredArtifacts[taskId] = {
-            ref: text.ref,
-            content: text.content,
-            content_truncated: !!text.content_truncated,
-            kind: 'text',
-          };
-        } else if (arts.length) {
-          // Surface the first non-text artifact's kind so the row can
-          // hint at what's there (image/pdf/missing) without crashing.
-          this.recentlyDeliveredArtifacts[taskId] = {
-            ref: arts[0].ref,
-            kind: arts[0].kind || 'unknown',
-            error: arts[0].error || null,
-          };
-        } else {
-          this.recentlyDeliveredArtifacts[taskId] = { kind: 'none' };
-        }
-      } catch (e) {
-        this.recentlyDeliveredArtifacts[taskId] = { error: (e && e.message) || 'fetch failed' };
-      } finally {
-        delete this._recentlyDeliveredFetching[taskId];
-      }
-    },
-
-    // Template helper: short preview (~300 chars) shown by default.
-    // Returns '' when the artifact isn't text or hasn't loaded yet so
-    // the template can hide the preview block until content arrives.
-    recentlyDeliveredPreview(taskId) {
-      const a = this.recentlyDeliveredArtifacts[taskId];
-      if (!a || a.kind !== 'text' || !a.content) return '';
-      const PREVIEW_CAP = 300;
-      if (a.content.length <= PREVIEW_CAP) return a.content;
-      return a.content.slice(0, PREVIEW_CAP) + '…';
-    },
-
-    // Template helper: full content for the expanded view. Falls back
-    // to '' when the artifact isn't text so the toggle can hide
-    // gracefully on non-text artifacts.
-    recentlyDeliveredFull(taskId) {
-      const a = this.recentlyDeliveredArtifacts[taskId];
-      if (!a || a.kind !== 'text') return '';
-      return a.content || '';
-    },
-
-    // True when the artifact has more than the preview cap so the
-    // "Read full" toggle should be shown. Hidden when the content fits
-    // entirely in the preview, when the artifact isn't text, or while
-    // it's still loading.
-    recentlyDeliveredHasMore(taskId) {
-      const a = this.recentlyDeliveredArtifacts[taskId];
-      if (!a || a.kind !== 'text' || !a.content) return false;
-      return a.content.length > 300;
-    },
-
-    toggleRecentlyDeliveredExpanded(taskId) {
-      this.recentlyDeliveredExpanded[taskId] = !this.recentlyDeliveredExpanded[taskId];
-    },
-
-    // Copy the artifact's full text to the clipboard. Uses the modern
-    // clipboard API when available (HTTPS / localhost) and falls back
-    // to a hidden textarea + execCommand for older browsers and the
-    // insecure-context case (file://). The toast feedback comes from
-    // the existing showToast helper so the user sees confirmation
-    // without us inventing a new banner.
-    async copyRecentlyDeliveredText(taskId) {
-      const text = this.recentlyDeliveredFull(taskId);
-      if (!text) return;
-      try {
-        if (navigator.clipboard && navigator.clipboard.writeText) {
-          await navigator.clipboard.writeText(text);
-        } else {
-          const ta = document.createElement('textarea');
-          ta.value = text;
-          ta.setAttribute('readonly', '');
-          ta.style.position = 'absolute';
-          ta.style.left = '-9999px';
-          document.body.appendChild(ta);
-          ta.select();
-          document.execCommand('copy');
-          document.body.removeChild(ta);
-        }
-        if (typeof this.showToast === 'function') this.showToast('Copied to clipboard', 2000);
-      } catch (e) {
-        if (typeof this.showToast === 'function') this.showToast('Copy failed', 3000);
-      }
-    },
-
-    // Kanban filter — drop pending/blocked rows older than 14 days
-    // unless the operator opted in for this column. Other statuses
-    // (working/done/accepted) aren't archived: completed work belongs
-    // in the Outputs tab and active work shouldn't disappear.
-    workplaceTasksByStatusFiltered(status) {
-      const all = this.workplaceTasksByStatus(status);
-      if (status !== 'pending' && status !== 'blocked') return all;
-      if (this.boardShowArchived[status]) return all;
-      const cutoff = (Date.now() / 1000) - 14 * 86400;
-      return all.filter(t => {
-        const created = typeof t.created_at === 'number'
-          ? t.created_at
-          : (t.created_at ? new Date(t.created_at).getTime() / 1000 : 0);
-        return !created || created >= cutoff;
-      });
-    },
-
-    workplaceArchivedCount(status) {
-      const total = this.workplaceTasksByStatus(status).length;
-      const visible = this.workplaceTasksByStatusFiltered(status).length;
-      return Math.max(0, total - visible);
-    },
-
-    // Phase 4 — title truncation for kanban cards + Stuck tasks
+    // PR 2 — title truncation for the Stuck tasks panel and drill-in
     // panel. Long titles (some agents accidentally hand off with
     // their full instruction text — ~250 chars seen in production)
     // wreck the kanban grid; truncate to 80 chars + ellipsis on
@@ -4156,20 +3617,6 @@ function dashboard() {
       // Oldest first so the most painful entries surface at the top.
       out.sort((a, b) => b.stuck_seconds - a.stuck_seconds);
       return out;
-    },
-
-    // Phase 4 — kanban activity feed noise filter. The legacy
-    // /workplace/feed payload includes ``status_unchanged`` rows
-    // (emitted when the same status is reported twice — typically
-    // from a heartbeat probe re-affirming "still working"). Those
-    // rows are pure implementation noise from the user's POV; we
-    // hide them by default and surface them only when
-    // ``showTechDetail`` is on. Preserves the original ``workplaceFeed``
-    // array so the WS plumbing keeps appending to one source of truth.
-    get workplaceFeedVisible() {
-      const feed = this.workplaceFeed || [];
-      if (this.showTechDetail) return feed;
-      return feed.filter(ev => ev && ev.event_type !== 'status_unchanged');
     },
 
     // Phase 4 — task cancel modal state. ``cancelTaskCandidate`` is
@@ -4566,8 +4013,8 @@ function dashboard() {
       if (!evt || !evt.type) return;
       const data = evt.data || {};
       if (evt.type === 'task_created') {
-        // Add stub row so the kanban shows the task immediately;
-        // background reload will fill in the rest.
+        // Add stub row so the Stuck Tasks panel + drill-in see it
+        // immediately; background reload fills in the rest.
         const stub = {
           id: data.task_id,
           project_id: data.project_id,
@@ -4580,7 +4027,6 @@ function dashboard() {
         if (!this.workplaceTasks.find(t => t.id === stub.id)) {
           this.workplaceTasks.unshift(stub);
         }
-        this._pushWorkplaceFeedFromEvent('created', data, stub);
       } else if (evt.type === 'task_status_changed') {
         const t = this.workplaceTasks.find(x => x.id === data.task_id);
         const prevStatus = t ? t.status : (data.from_status || data.old_status || '');
@@ -4589,13 +4035,8 @@ function dashboard() {
           if (data.assignee) t.assignee = data.assignee;
           if (data.blocker_note !== undefined) t.blocker_note = data.blocker_note;
         }
-        // Surface in feed too. Background reload is source of truth on
-        // reconnect; the client-built summary is best-effort.
-        this._pushWorkplaceFeedFromEvent('status_changed', data, t);
         // Pinned blockers list lives on a separate endpoint; refresh it
-        // whenever a task transitions in to or out of ``blocked`` (or
-        // when its blocker note may have changed) so the strip at the
-        // top of the feed doesn't go stale.
+        // whenever a task transitions in to or out of ``blocked``.
         const newStatus = data.new_status || '';
         if (
           prevStatus === 'blocked'
@@ -4604,16 +4045,14 @@ function dashboard() {
           this.loadWorkplaceBlockers();
         }
       } else if (evt.type === 'task_outcome') {
-        // Reflect the rating across every list that may show this
-        // task. Background reload remains the source of truth.
-        for (const list of [this.workplaceTasks, this.workplaceOutputs]) {
-          const row = (list || []).find(r => r.id === data.task_id);
-          if (row) {
-            row.outcome = data.outcome;
-            row.feedback_text = data.feedback || row.feedback_text || null;
-          }
+        // Reflect the rating in ``workplaceTasks`` (Stuck panel) and
+        // the open drill-in modal. Background reload is source of
+        // truth on reconnect.
+        const row = (this.workplaceTasks || []).find(r => r.id === data.task_id);
+        if (row) {
+          row.outcome = data.outcome;
+          row.feedback_text = data.feedback || row.feedback_text || null;
         }
-        // If this task is open in the drill-in modal, sync it too.
         if (this.drillInData?.task && this.drillInData.task.id === data.task_id) {
           this.drillInData.task.outcome = data.outcome;
           this.drillInData.task.feedback_text = data.feedback || null;
@@ -4745,63 +4184,6 @@ function dashboard() {
       } else if (evt.type === 'pending_action_expired') {
         this.workplacePending = this.workplacePending.filter(p => p.nonce !== data.nonce);
         this._resolvePendingActionCard(data.nonce, 'expired');
-      }
-    },
-
-    // Build a feed entry from a live WS event and prepend it. Caps the
-    // in-memory feed so long-lived sessions don't grow unbounded; the
-    // periodic full reload is the source of truth.
-    _pushWorkplaceFeedFromEvent(eventType, data, taskHint) {
-      if (!data || !data.task_id) return;
-      const t = taskHint || this.workplaceTasks.find(x => x.id === data.task_id) || {};
-      const title = data.title || t.title || '(untitled)';
-      const projectId = data.project_id || t.project_id || '';
-      const assignee = data.assignee || t.assignee || '';
-      const actor = data.actor || data.creator || data.assignee || 'unknown';
-      const status = data.new_status || t.status || '';
-      let summary;
-      if (eventType === 'created') {
-        const forWho = assignee ? ` for ${assignee}` : '';
-        const where = projectId ? ` in project ${projectId}` : '';
-        summary = `${actor} created task '${title}'${forWho}${where}`;
-      } else if (status === 'done') {
-        summary = `${actor} completed task '${title}'`;
-      } else if (status === 'blocked') {
-        const note = data.blocker_note || '';
-        summary = `${actor} marked task '${title}' as blocked${note ? ': ' + note : ''}`;
-      } else if (status === 'failed') {
-        // Bug 3 fix: surface blocker_note on failed transitions so an
-        // operator can see *why* a task died without digging into
-        // workflow_snapshot or the back-edge inbox. Mirrors the blocked
-        // branch's rendering — same column, broader semantic.
-        const note = data.blocker_note || '';
-        summary = `${actor} failed task '${title}'${note ? ': ' + note : ''}`;
-      } else if (status === 'cancelled') {
-        const reason = data.reason ? ` (${data.reason})` : '';
-        summary = `${actor} cancelled task '${title}'${reason}`;
-      } else if (status === 'working') {
-        summary = `${actor} started task '${title}'`;
-      } else if (status === 'accepted') {
-        summary = `${actor} accepted task '${title}'`;
-      } else {
-        summary = `${actor} ${eventType} on task '${title}'`;
-      }
-      const entry = {
-        event_id: `live-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
-        event_type: eventType,
-        task_id: data.task_id,
-        task_title: title,
-        project_id: projectId,
-        assignee: assignee,
-        actor: actor,
-        task_status: status,
-        blocker_note: data.blocker_note || '',
-        timestamp: Date.now() / 1000,
-        summary,
-      };
-      this.workplaceFeed.unshift(entry);
-      if (this.workplaceFeed.length > this.workplaceFeedCap) {
-        this.workplaceFeed.length = this.workplaceFeedCap;
       }
     },
 

--- a/src/dashboard/templates/index.html
+++ b/src/dashboard/templates/index.html
@@ -4021,69 +4021,36 @@
             x-text="'Show ' + (needsYouItems.length - needsYouCollapsedCap) + ' more'"></button>
         </section>
 
-        <!-- Work-tab sub-nav. Summaries is the unconditional default
-             landing surface (operator-led strategy view, scale-
-             independent). Kanban + Activity are equal-billing tabs
-             reachable in one click. The legacy "View ... →" footer
-             links + the "Back to Work" activity-back button were
-             removed when this bar landed — the tab bar replaces
-             both as a single, always-visible nav affordance. The
-             "Back to team summaries" + filter-chip block below
-             stays because it represents FILTER state, not view
-             state — clicking the Kanban tab alone doesn't clear
-             ``workplaceTeamFilter``. -->
-        <nav class="mb-3 flex items-center gap-1 border-b border-gray-700/40"
-             role="tablist" data-testid="workplace-subnav">
-          <button type="button" role="tab"
-            :aria-selected="homeTab === 'summaries'"
-            @click="switchHomeTab('summaries')"
-            data-testid="workplace-subnav-summaries"
-            class="px-3 py-1.5 text-xs font-medium border-b-2 -mb-px transition-colors"
-            :class="homeTab === 'summaries'
-              ? 'border-indigo-400 text-indigo-200'
-              : 'border-transparent text-gray-400 hover:text-gray-200'">
-            Summaries
-          </button>
-          <button type="button" role="tab"
-            :aria-selected="homeTab === 'kanban'"
-            @click="switchHomeTab('kanban')"
-            data-testid="workplace-subnav-kanban"
-            class="px-3 py-1.5 text-xs font-medium border-b-2 -mb-px transition-colors"
-            :class="homeTab === 'kanban'
-              ? 'border-indigo-400 text-indigo-200'
-              : 'border-transparent text-gray-400 hover:text-gray-200'">
-            Kanban
-          </button>
-          <button type="button" role="tab"
-            :aria-selected="homeTab === 'activity'"
-            @click="switchHomeTab('activity')"
-            data-testid="workplace-subnav-activity"
-            class="px-3 py-1.5 text-xs font-medium border-b-2 -mb-px transition-colors"
-            :class="homeTab === 'activity'
-              ? 'border-indigo-400 text-indigo-200'
-              : 'border-transparent text-gray-400 hover:text-gray-200'">
-            Activity
-          </button>
-        </nav>
-
-        <!-- PR-B: Back link when viewing the kanban under a team filter
-             (reached via "Expand task list" from a summary card). The
-             user came from summaries — let them get back without
-             touching the URL bar. -->
-        <div x-show="homeTab === 'kanban' && workplaceTeamFilter"
-             x-cloak class="mb-3 flex items-center justify-between gap-2">
-          <button type="button"
-            @click="workplaceTeamFilter = ''; switchHomeTab('summaries'); loadWorkplaceTasks();"
-            class="text-[12px] text-gray-400 hover:text-gray-200 inline-flex items-center gap-1 transition-colors"
-            data-testid="home-back-to-summaries">
-            <svg class="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M19 12H5M12 19l-7-7 7-7"/></svg>
-            Back to team summaries
-          </button>
-          <span class="text-[11px] text-gray-500"
-                data-testid="kanban-team-filter-label">
-            Filtered: <span class="text-gray-300" x-text="workplaceTeamFilter"></span>
-          </span>
-        </div>
+        <!-- Goals strip (PR 2 of Work tab rewrite). Operator-managed
+             workplace-wide business goals, read-only from this surface
+             (the user steers via the Tell Operator box below; the
+             operator runs the actual ``manage_goals`` writes). Hidden
+             entirely when no goals are tracked — discoverable via
+             Tell Operator, no empty-state CTA. -->
+        <section x-show="workplaceGoals.length > 0" x-cloak
+          data-testid="workplace-goals-strip"
+          role="list" aria-label="Tracked business goals"
+          class="mb-3 flex flex-wrap items-center gap-2">
+          <span class="text-xs uppercase tracking-wide text-gray-400 mr-1">Goals</span>
+          <template x-for="g in workplaceGoals" :key="g.name">
+            <span role="listitem"
+              :aria-label="g.name + ' — ' + g.status"
+              :title="g.status + (g.progress_note ? ': ' + g.progress_note : '')"
+              class="inline-flex items-center gap-1.5 text-[11px] px-2 py-0.5 rounded-full bg-gray-800/60 border border-gray-700/50"
+              :class="g.status === 'done' ? 'text-gray-400 line-through' : 'text-gray-200'"
+              data-testid="workplace-goal-chip">
+              <span class="w-1.5 h-1.5 rounded-full shrink-0"
+                :class="{
+                  'bg-gray-400': g.status === 'not_started' || g.status === 'done',
+                  'bg-blue-400': g.status === 'in_progress',
+                  'bg-green-400': g.status === 'on_track',
+                  'bg-amber-400': g.status === 'at_risk',
+                  'bg-red-400': g.status === 'blocked',
+                }"></span>
+              <span x-text="g.name"></span>
+            </span>
+          </template>
+        </section>
 
         <!-- Empty state when orchestration v2 is disabled -->
         <template x-if="!workplaceEnabled">
@@ -4095,16 +4062,16 @@
           </div>
         </template>
 
-        <!-- PR-B — Summary cards (homeTab === 'summaries'). Default
-             landing when ≥1 team exists. One card per team renders
-             the operator-composed daily summary: narrative (rendered
-             markdown), metrics row, recommendations bullet list, and
-             👍 / ➖ / 👎 rating buttons. 👎 opens an inline feedback
-             box; submission feeds the next summary's prompt. The
-             "Expand task list →" disclosure drills into the kanban
-             pre-filtered to that team — same kanban code, just scoped.
+        <!-- Summary cards — primary content of the Work tab. One card
+             per team renders the operator-composed daily summary:
+             narrative (rendered markdown), recommendations bullet list,
+             and 👍 / ➖ / 👎 rating buttons. 👎 opens an inline feedback
+             box; submission feeds the next summary's prompt. PR 2 of
+             the Work tab rewrite removed the sub-nav, kanban, and
+             activity surfaces — the summary view is now the
+             unconditional landing surface when the Work tab is open.
         -->
-        <template x-if="workplaceEnabled && homeTab === 'summaries'">
+        <template x-if="workplaceEnabled">
           <div class="space-y-3" data-testid="workplace-summaries-view">
             <!-- Error banner (retry path matches the other sections) -->
             <template x-if="workplaceErrors.summaries">
@@ -4184,19 +4151,7 @@
                 </template>
 
                 <!-- Footer: rating buttons (unrated) or outcome chip (rated). -->
-                <div class="flex items-center justify-between gap-2 pt-2 border-t border-gray-700/30">
-                  <!-- Drill-in to scoped kanban -->
-                  <button type="button"
-                    x-show="s.scope_kind === 'team'"
-                    @click="drillIntoTeamKanban(s.scope_id)"
-                    class="text-[11px] text-indigo-300 hover:text-indigo-100 inline-flex items-center gap-1 transition-colors"
-                    data-testid="summary-expand-tasks">
-                    Expand task list &rarr;
-                  </button>
-                  <div x-show="s.scope_kind !== 'team'" class="text-[11px] text-gray-500">
-                    Solo agent — no scoped kanban
-                  </div>
-
+                <div class="flex items-center justify-end gap-2 pt-2 border-t border-gray-700/30">
                   <!-- Rating buttons (only when unrated) -->
                   <template x-if="!s.rating">
                     <div class="flex items-center gap-1"
@@ -4271,248 +4226,49 @@
           </div>
         </template>
 
-        <!-- Phase 4 — Activity sub-page (homeTab === 'activity'). The
-             legacy Phase 3 single-scroll layout: Just delivered
-             (recentlyDeliveredItems), Happening now (workplaceFeed,
-             capped at 5 with disclosure), and In progress (a 4-card
-             slice of workplaceTasks). The kanban is now the default
-             board; this page is reached via the "View activity feed →"
-             link below the kanban. Empty sections hide entirely so an
-             idle activity feed has no extra chrome. -->
-        <template x-if="workplaceEnabled && homeTab === 'activity'">
-          <div class="space-y-4" data-testid="home-activity">
-            <!-- Just delivered — last 7 days of completed outputs.
-                 Replaces the legacy ``team-outputs`` sub-tab; kept inline
-                 with a drill-in for the full artifact preview. -->
-            <template x-if="recentlyDeliveredItems.length">
-              <div data-testid="home-just-delivered">
-                <div class="flex items-center justify-between mb-1.5">
-                  <div class="text-[11px] uppercase tracking-wide text-gray-500 font-medium">Just delivered</div>
-                </div>
-                <div class="space-y-1.5">
-                  <template x-for="t in recentlyDeliveredItems" :key="'rd-' + t.id">
-                    <!-- x-init lazy-fetches the artifact bundle on first
-                         render so the inline preview shows up without
-                         the user having to open the drill-in modal.
-                         The fetch is cached per task_id so flipping
-                         sub-tabs back and forth doesn't refetch. -->
-                    <div class="bg-gray-800/40 border border-gray-700/50 rounded-md px-2.5 py-1.5"
-                         x-init="t.artifact_refs && t.artifact_refs.length && _ensureRecentlyDeliveredArtifact(t.id)">
-                      <div class="flex items-center gap-2">
-                        <span class="text-emerald-400 text-xs shrink-0">&check;</span>
-                        <div class="min-w-0 flex-1 text-xs text-gray-200 truncate" x-text="t.title || '(untitled)'"></div>
-                        <div class="text-[11px] text-gray-500 hidden sm:block shrink-0" x-text="(t.assignee || '') + (t.completed_at ? ' · ' + (formatRelativeTime((t.completed_at || 0) * 1000) || 'just now') : '')"></div>
-                        <!-- Inline rating buttons. Hidden once the task
-                             carries an ``outcome`` — the rating chip
-                             shows instead. ``rateDelivery`` posts to
-                             the existing /workplace/tasks/{id}/outcome
-                             endpoint; the optimistic update flips this
-                             group to the chip without waiting on a
-                             round-trip. -->
-                        <template x-if="!t.outcome">
-                          <div class="flex items-center gap-1 shrink-0" data-testid="rate-buttons">
-                            <button type="button"
-                              @click.stop="rateDelivery(t.id, 'accepted')"
-                              title="Accept — looks good"
-                              aria-label="Accept this delivery"
-                              class="text-sm px-1.5 py-0.5 rounded hover:bg-emerald-500/20 text-emerald-300">&#x1F44D;</button>
-                            <button type="button"
-                              @click.stop="rateDelivery(t.id, 'acknowledged')"
-                              title="Acknowledge — reviewed without judgement"
-                              aria-label="Acknowledge this delivery without judgement"
-                              class="text-sm px-1.5 py-0.5 rounded hover:bg-gray-500/20 text-gray-400">&#x2796;</button>
-                            <button type="button"
-                              @click.stop="openInlineRework(t.id)"
-                              title="Needs rework — add a brief"
-                              aria-label="Mark this delivery for rework"
-                              class="text-sm px-1.5 py-0.5 rounded hover:bg-amber-500/20 text-amber-300">&#x1F44E;</button>
-                          </div>
-                        </template>
-                        <template x-if="t.outcome">
-                          <span class="text-[10px] px-1.5 py-0.5 rounded shrink-0"
-                                :class="t.outcome === 'accepted' ? 'bg-emerald-900/40 text-emerald-300 border border-emerald-700/40' : (t.outcome === 'rework' ? 'bg-amber-900/40 text-amber-300 border border-amber-700/40' : (t.outcome === 'rejected' ? 'bg-rose-900/40 text-rose-300 border border-rose-700/40' : 'bg-gray-700/40 text-gray-300 border border-gray-600/40'))"
-                                x-text="drillInOutcomeLabel(t.outcome) || t.outcome"></span>
-                        </template>
-                        <button type="button"
-                          @click.stop="openTaskDrillIn(t.id)"
-                          class="text-[11px] px-2 py-0.5 rounded bg-gray-700 hover:bg-gray-600 text-gray-200 shrink-0">Open</button>
-                      </div>
-                      <!-- Inline rework brief. Expands when the user
-                           clicks &#x1F44E; on the card. Submit calls the
-                           same rateDelivery handler with outcome='rework'
-                           which auto-spawns the follow-up task. Cancel
-                           clears the textarea without writing. -->
-                      <template x-if="inlineReworkIsOpen(t.id)">
-                        <div class="mt-1.5 pl-5" data-testid="inline-rework">
-                          <textarea
-                            :value="inlineReworkText(t.id)"
-                            @input="setInlineReworkText(t.id, $event.target.value)"
-                            rows="2"
-                            maxlength="2000"
-                            placeholder="What needs to change? This becomes the rework brief."
-                            class="w-full text-[11px] text-gray-200 bg-gray-900/60 border border-gray-700/50 rounded px-2 py-1.5 focus:outline-none focus:border-amber-500/60"></textarea>
-                          <div class="flex items-center gap-2 mt-1">
-                            <button type="button"
-                              @click.stop="submitInlineRework(t.id)"
-                              class="text-[11px] px-2 py-0.5 rounded bg-amber-600 hover:bg-amber-500 text-white">Submit rework</button>
-                            <button type="button"
-                              @click.stop="closeInlineRework(t.id)"
-                              class="text-[11px] px-2 py-0.5 rounded bg-gray-700 hover:bg-gray-600 text-gray-200">Cancel</button>
-                          </div>
-                        </div>
-                      </template>
-                      <!-- Inline artifact preview. Hidden until the
-                           lazy fetch completes; collapses again if the
-                           artifact turns out to be non-text or absent. -->
-                      <template x-if="t.artifact_refs && t.artifact_refs.length && recentlyDeliveredPreview(t.id)">
-                        <div class="mt-1.5 pl-5">
-                          <pre class="text-[11px] text-gray-300 whitespace-pre-wrap break-words bg-gray-900/40 rounded px-2 py-1.5 max-h-64 overflow-y-auto custom-scrollbar"
-                               x-text="recentlyDeliveredExpanded[t.id] ? recentlyDeliveredFull(t.id) : recentlyDeliveredPreview(t.id)"></pre>
-                          <div class="flex items-center gap-2 mt-1">
-                            <button type="button"
-                              x-show="recentlyDeliveredHasMore(t.id)"
-                              @click.stop="toggleRecentlyDeliveredExpanded(t.id)"
-                              class="text-[11px] text-indigo-300 hover:text-indigo-200"
-                              x-text="recentlyDeliveredExpanded[t.id] ? 'Show less' : 'Read full'"></button>
-                            <button type="button"
-                              @click.stop="copyRecentlyDeliveredText(t.id)"
-                              class="text-[11px] text-gray-400 hover:text-gray-200">Copy</button>
-                          </div>
-                        </div>
-                      </template>
-                    </div>
-                  </template>
-                </div>
-              </div>
-            </template>
-
-            <!-- Happening now — capped at 5 events on the main scroll;
-                 "See all" disclosure expands inline. Empty section hides
-                 entirely (no header, no chrome). Phase 4: source switched
-                 to ``workplaceFeedVisible`` which strips
-                 ``status_unchanged`` heartbeat noise unless the user
-                 has the "Show technical detail" toggle on. -->
-            <div x-data="{ feedExpanded: false }"
-                 x-show="workplaceFeedVisible.length || workplaceSectionLoading.feed || workplaceErrors.feed"
-                 data-testid="home-happening-now">
-              <div class="flex items-center justify-between mb-1.5">
-                <div class="text-[11px] uppercase tracking-wide text-gray-500 font-medium">Happening now</div>
-                <button type="button"
-                  x-show="!feedExpanded && workplaceFeedVisible.length > 5"
-                  @click="feedExpanded = true"
-                  class="text-[11px] text-gray-400 hover:text-gray-200">See all &rarr;</button>
-                <button type="button"
-                  x-show="feedExpanded && workplaceFeedVisible.length > 5"
-                  @click="feedExpanded = false"
-                  class="text-[11px] text-gray-400 hover:text-gray-200">Show less</button>
-              </div>
-
-              <!-- Skeleton loader for the activity feed itself while the
-                   first /workplace/feed fetch is in flight. Three pulsing
-                   rows match the visual rhythm of the real cards so the
-                   layout doesn't jump when content arrives. Hidden once
-                   the load resolves (success or error — the error banner
-                   below takes over in the failure case). -->
-              <template x-if="workplaceSectionLoading.feed && !workplaceFeedVisible.length && !workplaceErrors.feed">
-                <div class="space-y-2" data-testid="workplace-feed-skeleton">
-                  <div class="bg-gray-800/40 border border-gray-700/50 rounded-lg p-3">
-                    <div class="h-3 w-2/3 bg-gray-800 rounded animate-pulse"></div>
-                    <div class="h-2.5 w-1/3 bg-gray-800 rounded animate-pulse mt-2"></div>
-                  </div>
-                  <div class="bg-gray-800/40 border border-gray-700/50 rounded-lg p-3">
-                    <div class="h-3 w-3/4 bg-gray-800 rounded animate-pulse"></div>
-                    <div class="h-2.5 w-1/4 bg-gray-800 rounded animate-pulse mt-2"></div>
-                  </div>
-                  <div class="bg-gray-800/40 border border-gray-700/50 rounded-lg p-3">
-                    <div class="h-3 w-1/2 bg-gray-800 rounded animate-pulse"></div>
-                    <div class="h-2.5 w-1/3 bg-gray-800 rounded animate-pulse mt-2"></div>
-                  </div>
-                </div>
-              </template>
-
-              <!-- Error banner for the activity feed. Rendered when the
-                   /workplace/feed fetch fails. -->
-              <template x-if="workplaceErrors.feed">
-                <div class="bg-red-900/20 border border-red-800/40 rounded-lg p-3 flex flex-wrap items-center gap-2"
-                     role="alert" data-testid="workplace-feed-error">
-                  <span class="text-xs text-red-200 flex-1" x-text="workplaceErrors.feed"></span>
-                  <button type="button" @click="retryWorkplaceSection('feed')"
-                    class="text-[11px] font-medium px-2.5 py-1 rounded bg-red-800/40 hover:bg-red-700/50 text-red-100 transition-colls">Retry</button>
-                </div>
-              </template>
-
-              <!-- Chronological activity list, capped at 5 unless
-                   ``feedExpanded`` is true. Source is the noise-filtered
-                   ``workplaceFeedVisible`` (see getter for filtering
-                   rules). -->
-              <div class="space-y-2">
-                <template x-for="ev in (feedExpanded ? workplaceFeedVisible : workplaceFeedVisible.slice(0, 5))" :key="ev.event_id">
-                  <button type="button"
-                    class="w-full text-left bg-gray-800/40 border border-gray-700/50 rounded-lg p-3 hover:bg-gray-800/70 transition-colors"
-                    @click="openTaskDrillIn(ev.task_id)">
-                    <div class="flex items-start gap-2">
-                      <span class="text-base leading-none mt-0.5" x-text="workplaceFeedIcon(ev.event_type, ev.task_status)"></span>
-                      <div class="min-w-0 flex-1">
-                        <div class="text-sm text-gray-100" x-text="ev.summary"></div>
-                        <div class="text-[11px] text-gray-500 mt-0.5">
-                          <span x-text="formatRelativeTime((ev.timestamp || 0) * 1000) || 'just now'"></span>
-                          <span x-show="ev.project_id" class="ml-2" x-text="'· ' + ev.project_id"></span>
-                        </div>
-                      </div>
-                    </div>
-                  </button>
-                </template>
-              </div>
+        <!-- Tell Operator — primary steering affordance. PR 2 of the
+             Work tab rewrite. The user types freeform feedback; submit
+             posts to the operator chat (via ``sendChatTo('operator', …)``)
+             and surfaces a "Sent — open Chat tab" confirmation. The
+             operator handles per-task rating + team coordination from
+             the chat reply. -->
+        <template x-if="workplaceEnabled">
+          <section data-testid="workplace-tell-operator"
+            class="mt-6 rounded-lg border border-gray-700/40 bg-gray-800/30 p-4">
+            <h3 class="text-sm font-medium text-gray-200">Tell operator</h3>
+            <p class="text-xs text-gray-400 mt-1">Steer the team in plain language. Operator handles the rest.</p>
+            <textarea
+              x-model="tellOperatorText"
+              :disabled="tellOperatorInflight"
+              rows="3"
+              maxlength="2000"
+              aria-label="Message to operator"
+              placeholder="e.g. The landing page tone feels too corporate — make it warmer."
+              class="mt-2 w-full rounded bg-gray-900/50 border border-gray-700 px-3 py-2 text-sm text-gray-100 placeholder-gray-500 focus:outline-none focus:border-indigo-500"
+            ></textarea>
+            <div class="mt-2 flex items-center justify-between">
+              <span x-show="tellOperatorConfirmation" x-text="tellOperatorConfirmation"
+                class="text-xs text-green-400"
+                data-testid="tell-operator-confirmation"></span>
+              <span x-show="!tellOperatorConfirmation" class="text-xs text-gray-500">Response shows up in Chat tab.</span>
+              <button type="button"
+                @click="submitTellOperator()"
+                :disabled="tellOperatorInflight || !tellOperatorText.trim()"
+                class="ml-auto rounded bg-indigo-500 hover:bg-indigo-400 disabled:opacity-50 disabled:cursor-not-allowed px-3 py-1 text-xs text-white"
+                data-testid="tell-operator-submit">
+                <span x-text="tellOperatorInflight ? 'Sending…' : 'Send'"></span>
+              </button>
             </div>
+          </section>
+        </template>
 
-            <!-- In progress — 4-card slice of workplaceTasks filtered to
-                 working / pending / accepted statuses (most-recent
-                 first). Phase 4: "Back to Work" links to the kanban
-                 (the new default). Empty section hides entirely. -->
-            <template x-if="(workplaceTasks || []).filter(t => ['working','pending','accepted'].includes(t.status)).length">
-              <div data-testid="home-in-progress">
-                <div class="flex items-center justify-between mb-1.5">
-                  <div class="text-[11px] uppercase tracking-wide text-gray-500 font-medium">In progress</div>
-                  <button type="button" @click="switchHomeTab('kanban')"
-                    class="text-[11px] text-indigo-300 hover:text-indigo-200"
-                    data-testid="home-see-task-board">Back to Work &rarr;</button>
-                </div>
-                <div class="grid grid-cols-1 sm:grid-cols-2 gap-2">
-                  <template x-for="t in (workplaceTasks || []).filter(t => ['working','pending','accepted'].includes(t.status)).slice(0, 4)" :key="'ip-' + t.id">
-                    <div class="bg-gray-800/40 border border-gray-700/50 rounded-md px-3 py-2 cursor-pointer hover:bg-gray-800/70 hover:border-gray-600/60 transition-colors"
-                      @click="openTaskDrillIn(t.id)">
-                      <div class="text-xs font-medium text-gray-200 truncate" x-text="t.title || '(untitled)'"></div>
-                      <div class="text-[11px] text-gray-500 mt-0.5 flex items-center gap-1.5">
-                        <span class="px-1.5 py-0.5 rounded bg-gray-900/60 text-gray-400 text-[10px]" x-text="t.status"></span>
-                        <span class="truncate" x-text="t.assignee || ''"></span>
-                        <span x-show="t.project_id" class="text-gray-600 truncate" x-text="'· ' + (t.project_id || '')"></span>
-                      </div>
-                    </div>
-                  </template>
-                </div>
-              </div>
-            </template>
-
-            <!-- Idle empty state — shown only when EVERY section above
-                 is empty AND there's nothing pending. Calm prompt,
-                 verb-driven CTA. -->
-            <template x-if="!workplaceSectionLoading.feed && !workplaceErrors.feed && !workplaceFeedVisible.length && !recentlyDeliveredItems.length && !needsYouItems.length && !(workplaceTasks || []).filter(t => ['working','pending','accepted'].includes(t.status)).length">
-              <div class="text-sm text-gray-300 py-6 text-center" data-testid="home-idle-empty">
-                Your team is idle.
-                <button type="button" @click="activeTab = 'chat'"
-                  class="underline decoration-dotted text-indigo-300 hover:text-indigo-200 transition-colors">Chat with your operator</button>
-                to start something.
-              </div>
-            </template>
-            <!-- Phase 2 vocab: explicit "team starts working" empty
-                 state is preserved here for the workplaceTeams-but-no-
-                 feed case. Phase 3's idle empty state above only fires
-                 when every section is empty; this one stays so users with
-                 active teams but no fresh activity still see the
-                 reassurance copy that Phase 2 promised. -->
-            <template x-if="!workplaceSectionLoading.feed && !workplaceErrors.feed && !workplaceFeedVisible.length && workplaceTeams.length">
-              <div class="text-sm text-gray-500 py-4">Once your team starts working, you'll see updates here.</div>
-            </template>
+        <!-- PR-2 cutover note: the legacy activity sub-page (Just
+             delivered + Happening now + In progress) was removed.
+             Per-task rating moved from human UI into the operator's
+             programmatic ``rate_delivery`` tool. Stuck Tasks below
+             keeps the silent stale-work detector visible. -->
+        <template x-if="false">
+          <div class="hidden">
           </div>
         </template>
 
@@ -4607,14 +4363,11 @@
           </div>
         </template>
 
-        <!-- Phase 4 — Stuck tasks panel. Sits between "Needs you" and
-             the kanban grid so it inherits the sticky-feel of the
-             attention bar above it without claiming a sticky position
-             of its own. Only renders when ``stuckTasks`` is non-empty.
-             Shows tasks that have been pending or working >24h. Each
-             row carries [Cancel] + [Restart agent] for the operator's
-             two-fastest unblockers. -->
-        <template x-if="workplaceEnabled && homeTab === 'kanban' && stuckTasks.length">
+        <!-- Stuck tasks panel — silent stale-work detector kept across
+             the PR 2 cutover. Renders when ``stuckTasks`` is non-empty
+             (tasks pending or working >24h). Each row carries [Cancel]
+             + [Restart agent] for the operator's two-fastest unblockers. -->
+        <template x-if="workplaceEnabled && stuckTasks.length">
           <section class="bg-amber-950/30 border border-amber-800/50 rounded-xl p-3 mb-3"
             data-testid="board-stuck-tasks"
             aria-label="Stuck tasks">
@@ -4657,143 +4410,6 @@
           </section>
         </template>
 
-        <!-- Phase 4 — Kanban board (default Board view).
-             Responsive grid: 1 col on phones (<sm), 2 cols at 640px+,
-             4 cols on desktop (lg+). On the smallest phones the grid
-             still hits 1 column, which is fine for stacked reading;
-             the outer ``overflow-x-auto`` + inner ``min-w-[640px]``
-             give phone users a horizontal-scroll fallback so each
-             column keeps a usable width when they prefer the kanban
-             layout. Status columns: Pending / Working / Blocked /
-             Done — ``accepted`` (transient) folds into Pending via
-             the existing ``workplaceTasksByStatus`` filter. -->
-        <template x-if="workplaceEnabled && homeTab === 'kanban'">
-          <div data-testid="board-kanban">
-            <!-- Error banner for /workplace/tasks. Tasks lives outside
-                 the kanban grid because errored loads should still let
-                 the user retry without seeing four empty columns. -->
-            <template x-if="workplaceErrors.tasks">
-              <div class="bg-red-900/20 border border-red-800/40 rounded-lg p-3 mb-3 flex flex-wrap items-center gap-2"
-                   role="alert" data-testid="workplace-tasks-error">
-                <span class="text-xs text-red-200 flex-1" x-text="workplaceErrors.tasks"></span>
-                <button type="button" @click="retryWorkplaceSection('tasks')"
-                  class="text-[11px] font-medium px-2.5 py-1 rounded bg-red-800/40 hover:bg-red-700/50 text-red-100 transition-colors">Retry</button>
-              </div>
-            </template>
-            <!-- Skeleton kanban while /workplace/tasks is in flight -->
-            <template x-if="workplaceSectionLoading.tasks && !workplaceTasks.length && !workplaceErrors.tasks">
-              <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-2.5 mb-3" data-testid="workplace-tasks-skeleton">
-                <template x-for="i in 4" :key="'sk-task-' + i">
-                  <div class="bg-gray-800/40 border border-gray-700/50 rounded-lg p-3">
-                    <div class="h-3 w-1/2 bg-gray-800 rounded animate-pulse mb-2"></div>
-                    <div class="h-8 bg-gray-800 rounded animate-pulse mt-2"></div>
-                    <div class="h-8 bg-gray-800 rounded animate-pulse mt-2"></div>
-                  </div>
-                </template>
-              </div>
-            </template>
-          <div class="overflow-x-auto custom-scrollbar -mx-3 px-3 sm:mx-0 sm:px-0">
-            <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-2.5 min-w-[640px] sm:min-w-0">
-              <template x-for="status in ['pending','working','blocked','done']" :key="status">
-                <div class="bg-gray-800/40 border border-gray-700/50 rounded-lg p-2.5">
-                  <!-- Sticky column header so cards keep their context
-                       when the column scrolls. ``z-10`` keeps it above
-                       the cards but below the global Needs-you panel
-                       (which sits at z-10 on a different stacking
-                       context — they don't overlap visually). -->
-                  <div class="text-[11px] font-medium text-gray-300 uppercase tracking-wide mb-2 flex items-center justify-between sticky top-0 z-10 bg-gray-800/80 backdrop-blur-sm -mx-2.5 px-2.5 py-1.5 border-b border-gray-700/40">
-                    <span x-text="status"></span>
-                    <span class="text-gray-500 font-mono" x-text="workplaceTasksByStatus(status).length"></span>
-                  </div>
-                  <div class="space-y-1.5">
-                    <template x-for="t in workplaceTasksByStatusFiltered(status)" :key="t.id">
-                      <div class="group rounded-md px-2 py-1.5 text-[11px] hover:bg-gray-900/90 transition-colors relative border"
-                        :class="t.status === 'failed'
-                          ? 'bg-red-950/30 border-red-800/40 hover:border-red-700/60'
-                          : 'bg-gray-900/60 border-gray-700/40 hover:border-gray-600'"
-                        data-testid="board-kanban-card">
-                        <!-- Phase 4 cancel button: top-right × on every
-                             card; opens the confirmation modal. Hidden
-                             on the Done column (you can't cancel a
-                             completed task) and on rated cards. The
-                             ``@click.stop`` keeps the row click (drill-in)
-                             from firing. Codex P1.5 Option A: also hidden
-                             on failed tasks (they're terminal). -->
-                        <button type="button"
-                          x-show="status !== 'done' && t.status !== 'failed' && !t.outcome"
-                          @click.stop="confirmCancelTask(t)"
-                          aria-label="Cancel task"
-                          class="absolute top-1 right-1 w-5 h-5 flex items-center justify-center rounded text-gray-500 hover:text-red-300 hover:bg-red-900/30 transition-colors opacity-0 group-hover:opacity-100 focus:opacity-100"
-                          data-testid="board-kanban-card-cancel">
-                          <svg class="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M18 6L6 18M6 6l12 12"/></svg>
-                        </button>
-                        <button type="button" class="block w-full text-left pr-5"
-                          @click="openTaskDrillIn(t.id)">
-                          <div class="font-medium leading-snug"
-                            :class="t.status === 'failed' ? 'text-red-200' : 'text-gray-200'"
-                            :title="t.title"
-                            x-text="truncateTitle(t.title, 80)"></div>
-                          <div class="text-[10px] text-gray-400 mt-1 flex items-center gap-1.5">
-                            <span class="truncate" x-text="t.assignee || ''"></span>
-                            <!-- Codex P1.5 Option A: failed tasks get a
-                                 red "failed" badge that visually
-                                 distinguishes them from done tasks in the
-                                 same column. Outcome badge (if rated)
-                                 takes precedence so a re-rated failure
-                                 still shows operator intent. -->
-                            <template x-if="t.outcome">
-                              <span class="ml-auto px-1.5 py-0.5 rounded text-[9px] font-medium"
-                                :class="{
-                                  'bg-emerald-900/30 text-emerald-300': t.outcome === 'accepted',
-                                  'bg-amber-900/30 text-amber-300': t.outcome === 'rework',
-                                  'bg-red-900/30 text-red-300': t.outcome === 'rejected',
-                                }"
-                                x-text="t.outcome"></span>
-                            </template>
-                            <template x-if="!t.outcome && t.status === 'failed'">
-                              <span class="ml-auto px-1.5 py-0.5 rounded text-[9px] font-medium bg-red-900/30 text-red-300">failed</span>
-                            </template>
-                          </div>
-                          <!-- Codex P1.5 Option A: surface the
-                               blocker_note inline for failed cards so
-                               the operator sees WHY without drilling in.
-                               Humanized via _humanizeBlocker (matches
-                               the Needs-you panel rendering); falls back
-                               to the raw note if the classifier
-                               can't tag it. -->
-                          <template x-if="t.status === 'failed' && t.blocker_note">
-                            <div class="mt-1 text-[10px] text-red-300/90 leading-snug"
-                              :title="t.blocker_note"
-                              x-text="(_humanizeBlocker(t.blocker_note).label || t.blocker_note).slice(0, 100)"></div>
-                          </template>
-                        </button>
-                      </div>
-                    </template>
-                    <!-- Archived disclosure: only the pending and blocked
-                         columns hide rows older than 14 days, since they
-                         can grow unbounded when a project stalls. Other
-                         statuses keep showing every row. -->
-                    <template x-if="workplaceArchivedCount(status) > 0">
-                      <button type="button"
-                        @click="boardShowArchived = { ...boardShowArchived, [status]: !boardShowArchived[status] }"
-                        class="w-full text-[10px] text-gray-400 hover:text-gray-200 px-2 py-1 rounded border border-dashed border-gray-700/60 hover:border-gray-600 transition-colors text-left">
-                        <span x-show="!boardShowArchived[status]"
-                          x-text="'Show ' + workplaceArchivedCount(status) + ' archived ▸'"></span>
-                        <span x-show="boardShowArchived[status]" x-cloak>Hide archived &#9662;</span>
-                      </button>
-                    </template>
-                  </div>
-                </div>
-              </template>
-            </div>
-          </div>
-          <!-- Phase 4 — Activity feed link. The single-scroll layout
-               (Just delivered + Happening now + In progress) lives at
-               /home/activity; users land here only if they click in
-               (back-compat with the Phase 3 default that opened the
-               feed first). -->
-          </div>
-        </template>
 
         <!-- Phase 4 — task cancel confirmation modal. Opens via
              ``confirmCancelTask`` (kanban × button or stuck-tasks

--- a/src/dashboard/templates/index.html
+++ b/src/dashboard/templates/index.html
@@ -439,27 +439,6 @@
                 </div>
               </div>
 
-              <!-- Phase 1 — delivery banner. Slim slip above the message
-                   list when there's a delivery on Home the user hasn't
-                   seen. ``deliveryBannerVisible`` gates on
-                   ``activeTab === 'chat'``, so we stay invisible when
-                   the user is already on Home. Click → switch to Home
-                   and ack. -->
-              <div x-show="deliveryBannerVisible" x-cloak data-delivery-banner
-                @click="openHomeFromBanner()"
-                role="button" tabindex="0"
-                @keydown.enter.prevent="openHomeFromBanner()"
-                @keydown.space.prevent="openHomeFromBanner()"
-                class="mx-4 mt-2 mb-1 px-3 py-2 rounded-lg bg-indigo-900/30 border border-indigo-700/50 hover:bg-indigo-900/50 hover:border-indigo-600/70 cursor-pointer flex items-center gap-2 transition-colors">
-                <svg class="w-4 h-4 text-indigo-300 shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
-                  <path d="M3 8l7.89 5.26a2 2 0 0 0 2.22 0L21 8M5 19h14a2 2 0 0 0 2-2V7a2 2 0 0 0-2-2H5a2 2 0 0 0-2 2v10a2 2 0 0 0 2 2z"/>
-                </svg>
-                <span class="text-xs text-indigo-200 flex-1 truncate" x-text="deliveryBannerSummary()"></span>
-                <svg class="w-3 h-3 text-indigo-300 shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
-                  <path d="M9 5l7 7-7 7"/>
-                </svg>
-              </div>
-
               <!-- Pending operator-proposed actions render inline as
                    ``pending_action_card`` chat messages (see template
                    below) — matching the credential / browser-login /

--- a/src/host/server.py
+++ b/src/host/server.py
@@ -30,6 +30,8 @@ from fastapi.responses import StreamingResponse
 from src.host.change_history import ChangeHistory
 from src.host.credentials import is_system_credential
 from src.host.orchestration import (
+    MAX_FEEDBACK_CHARS,
+    VALID_OUTCOMES,
     VALID_STATUSES,
     InvalidStatusTransition,
     TaskNotFound,
@@ -6061,6 +6063,76 @@ def create_mesh_app(
                 origin,
             )
         return updated
+
+    @app.post("/mesh/tasks/{task_id}/outcome")
+    async def set_task_outcome(task_id: str, request: Request) -> dict:
+        """Record an operator outcome rating on a completed task.
+
+        Operator-or-internal. Mirrors the dashboard's
+        ``/api/workplace/tasks/{id}/outcome`` endpoint (the human-driven
+        path) — both call ``tasks_store.set_outcome`` and, on
+        ``outcome == "rework"``, spawn a follow-up task via
+        ``tasks_store.create_rework_task``. The dashboard endpoint
+        stays for the existing human flow; this one exists so the
+        operator agent can score completions from its heartbeat loop
+        without round-tripping through the UI.
+
+        Body: ``{outcome: "accepted"|"acknowledged"|"rework"|"rejected",
+        feedback: str}``. ``accepted`` / ``acknowledged`` allow empty
+        feedback (the rating IS the signal). ``rework`` / ``rejected``
+        require non-empty feedback so the agent + audit trail has
+        something to learn from.
+        """
+        _require_operator_or_internal(request)
+        try:
+            body = await request.json()
+        except (json.JSONDecodeError, ValueError) as e:
+            raise HTTPException(400, "Invalid JSON body") from e
+        if not isinstance(body, dict):
+            raise HTTPException(400, "Body must be a JSON object")
+        outcome = body.get("outcome")
+        feedback = body.get("feedback") or ""
+        if outcome not in VALID_OUTCOMES:
+            raise HTTPException(
+                400,
+                f"outcome must be one of {sorted(VALID_OUTCOMES)}",
+            )
+        if not isinstance(feedback, str):
+            raise HTTPException(400, "feedback must be a string")
+        feedback = feedback.strip()
+        if len(feedback) > MAX_FEEDBACK_CHARS:
+            raise HTTPException(
+                400, f"feedback exceeds {MAX_FEEDBACK_CHARS} chars",
+            )
+        if outcome in ("rework", "rejected") and not feedback:
+            raise HTTPException(
+                400, f"feedback is required for outcome={outcome!r}",
+            )
+        try:
+            updated = tasks_store.set_outcome(
+                task_id, outcome, feedback or None, actor="operator",
+            )
+        except TaskNotFound as e:
+            raise HTTPException(404, "Task not found") from e
+        except InvalidStatusTransition as e:
+            raise HTTPException(409, str(e)) from e
+        except ValueError as e:
+            raise HTTPException(400, str(e)) from e
+        result: dict = {"ok": True, "task": updated}
+        if outcome == "rework":
+            try:
+                rework = tasks_store.create_rework_task(
+                    task_id, feedback, actor="operator",
+                )
+            except (TaskNotFound, ValueError) as e:
+                logger.warning(
+                    "rework spawn failed for %s: %s", task_id, e,
+                )
+                result["rework_error"] = str(e)
+            else:
+                result["rework_task_id"] = rework["id"]
+                result["rework_assignee"] = rework["assignee"]
+        return result
 
     # === Operator Config Endpoints ===
 

--- a/src/shared/types.py
+++ b/src/shared/types.py
@@ -94,7 +94,10 @@ new tool surface (PR-L'). Validation lives in
 # forward. User-customised heartbeats (no sentinel) are left alone.
 # Add new markers to the END of the tuple to keep older sentinels as
 # evidence that a workspace was previously migrated.
-HEARTBEAT_SENTINELS: tuple[str, ...] = ("heartbeat_v2_workflow_aware",)
+HEARTBEAT_SENTINELS: tuple[str, ...] = (
+    "heartbeat_v2_workflow_aware",
+    "heartbeat_v3_rate_delivery",
+)
 
 # === Inter-Component Messages ===
 

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -2966,11 +2966,13 @@ class TestBoardLoadingAndErrorStates:
         assert resp.status_code == 200
         body = resp.text
         # Per-section state buckets so the template can render
-        # skeletons + error banners independently per section.
+        # skeletons + error banners independently per section. PR 2
+        # of the Work tab rewrite dropped the outputs + feed buckets
+        # along with the kanban + activity surfaces; goals (PR 1)
+        # gained one when the chip strip landed.
         assert "workplaceSectionLoading" in body
         assert "workplaceErrors" in body
-        # Sections covered (matches the loadWorkplace* surface).
-        for key in ("teams", "tasks", "blockers", "outputs", "pending", "feed"):
+        for key in ("teams", "tasks", "blockers", "pending", "summaries", "goals"):
             assert f"{key}: false" in body or f"'{key}'" in body or f'"{key}"' in body, \
                 f"app.js missing per-section bucket for {key}"
 
@@ -2979,10 +2981,10 @@ class TestBoardLoadingAndErrorStates:
         body = resp.text
         # Error path replaces silent console.error: each loader sets
         # its bucket so the banner renders.
-        assert "workplaceErrors.feed" in body
         assert "workplaceErrors.teams" in body
         assert "workplaceErrors.tasks" in body
-        assert "workplaceErrors.outputs" in body
+        assert "workplaceErrors.summaries" in body
+        assert "workplaceErrors.goals" in body
 
     def test_app_js_exposes_retry_helper(self):
         resp = self.client.get("/dashboard/static/js/app.js")
@@ -2994,60 +2996,24 @@ class TestBoardLoadingAndErrorStates:
     def test_index_html_renders_skeleton_loaders(self):
         resp = self.client.get("/dashboard/")
         body = resp.text
-        # Skeleton testid hooks per sub-tab. The pulsing rectangles
-        # use the existing animate-pulse + bg-gray-800 classes for
-        # visual consistency with the drill-in modal skeleton.
-        assert 'data-testid="workplace-feed-skeleton"' in body
-        assert 'data-testid="workplace-teams-skeleton"' in body
-        assert 'data-testid="workplace-tasks-skeleton"' in body
-        assert 'data-testid="workplace-outputs-skeleton"' in body
-        # Each skeleton is gated on workplaceSectionLoading.<section>
+        # Skeleton testid hooks for the surviving Work-tab sections
+        # (PR 2 dropped the kanban + activity skeletons; only the
+        # summaries skeleton is user-rendered today — the teams skeleton
+        # lives in the dead ``team-status`` legacy template).
+        assert 'data-testid="workplace-summaries-skeleton"' in body
+        # The skeleton is gated on workplaceSectionLoading.<section>
         # so it disappears when the load resolves.
-        assert "workplaceSectionLoading.feed" in body
-        assert "workplaceSectionLoading.teams" in body
-        assert "workplaceSectionLoading.tasks" in body
-        assert "workplaceSectionLoading.outputs" in body
+        assert "workplaceSectionLoading.summaries" in body
 
     def test_index_html_renders_error_banners_with_retry(self):
         resp = self.client.get("/dashboard/")
         body = resp.text
-        # Error banner testid hooks per sub-tab.
-        assert 'data-testid="workplace-feed-error"' in body
-        assert 'data-testid="workplace-teams-error"' in body
-        assert 'data-testid="workplace-tasks-error"' in body
-        assert 'data-testid="workplace-outputs-error"' in body
-        # Each banner has a "Retry" button bound to
-        # retryWorkplaceSection so the user can recover with one
-        # click without reloading.
-        assert "retryWorkplaceSection('feed')" in body
-        assert "retryWorkplaceSection('teams')" in body
-        assert "retryWorkplaceSection('tasks')" in body
-        assert "retryWorkplaceSection('outputs')" in body
-
-    def test_app_js_recently_delivered_inline_preview_helpers(self):
-        resp = self.client.get("/dashboard/static/js/app.js")
-        body = resp.text
-        # Helpers that back the "Recently delivered" inline preview.
-        assert "_ensureRecentlyDeliveredArtifact" in body
-        assert "recentlyDeliveredPreview" in body
-        assert "recentlyDeliveredFull" in body
-        assert "toggleRecentlyDeliveredExpanded" in body
-        assert "copyRecentlyDeliveredText" in body
-        # Copy uses the modern clipboard API with a fallback so it
-        # works on file:// and older browsers too.
-        assert "navigator.clipboard" in body
-
-    def test_index_html_recently_delivered_inline_preview_wired(self):
-        resp = self.client.get("/dashboard/")
-        body = resp.text
-        # Lazy-fetch on first render of each row.
-        assert "_ensureRecentlyDeliveredArtifact(t.id)" in body
-        # Toggle + copy buttons present on the row.
-        assert "toggleRecentlyDeliveredExpanded(t.id)" in body
-        assert "copyRecentlyDeliveredText(t.id)" in body
-        # Preview vs full content selection happens in the template.
-        assert "recentlyDeliveredFull(t.id)" in body
-        assert "recentlyDeliveredPreview(t.id)" in body
+        # Error banner testid hooks for the surviving Work-tab
+        # section (PR 2 dropped the kanban + activity banners).
+        assert 'data-testid="workplace-summaries-error"' in body
+        # The banner has a "Retry" button bound to retryWorkplaceSection
+        # so the user can recover with one click without reloading.
+        assert "retryWorkplaceSection('summaries')" in body
 
     def test_index_html_chip_prefix_does_not_overwrite(self):
         resp = self.client.get("/dashboard/")

--- a/tests/test_dashboard_telemetry.py
+++ b/tests/test_dashboard_telemetry.py
@@ -489,19 +489,17 @@ class TestPhase0FrontendWiring:
         assert "if (!this._dockOpen) return;" in close_body
         assert "this._dockOpen = false;" in close_body
 
-    def test_workplace_subtab_buttons_emit_subtab_usage(self):
+    def test_workplace_subnav_removed(self):
+        """PR 2 of Work tab rewrite — sub-nav + switchHomeTab gone.
+
+        The Summaries / Kanban / Activity sub-nav was deleted along with
+        the kanban + activity surfaces. ``switchHomeTab`` calls should
+        no longer appear in the rendered template. trackSubtabUsage
+        itself is kept in app.js for empty-state CTA telemetry — see
+        test_empty_state_cta_buttons_emit_telemetry.
+        """
         html = _TEMPLATE.read_text(encoding="utf-8")
-        # PR #879 made the kanban the default Work view and moved the
-        # single-scroll layout to ``homeTab === 'activity'``. Sub-tab IDs
-        # are now ``'kanban'`` (default) and ``'activity'`` (the legacy
-        # single-scroll). The transition handler is
-        # ``switchHomeTab('kanban' | 'activity')`` invoked from the
-        # back-link and "View activity feed →" CTA. trackSubtabUsage
-        # itself is kept in app.js for the hidden legacy renders + for
-        # empty-state CTA telemetry — see
-        # test_empty_state_cta_buttons_emit_telemetry.
-        assert "switchHomeTab('kanban')" in html
-        assert "switchHomeTab('activity')" in html
+        assert "switchHomeTab(" not in html
 
     def test_needs_you_action_button_uses_telemetry_wrapper(self):
         html = _TEMPLATE.read_text(encoding="utf-8")

--- a/tests/test_dashboard_ui.py
+++ b/tests/test_dashboard_ui.py
@@ -2105,11 +2105,11 @@ _VERB_FOR_TOOL_FALLBACK_OK = frozenset({
     "run_command",
     "wallet_execute",
     "wallet_read_contract",
-    # Operator-only programmatic surfaces (PR 1 + PR 2 of Work tab
-    # rewrite). User-visible activity feed doesn't render them with
-    # a custom verb — the fallback "using manage goals" / "using
-    # rate delivery" reads fine.
-    "manage_goals",
+    # Operator-only programmatic surface added in PR 2 of the Work
+    # tab rewrite. User-visible activity feed doesn't render it
+    # with a custom verb — the fallback "using rate delivery"
+    # reads fine. (``manage_goals`` is allowlisted by PR 1 in the
+    # ``manage_*`` cluster above.)
     "rate_delivery",
 })
 

--- a/tests/test_dashboard_ui.py
+++ b/tests/test_dashboard_ui.py
@@ -12,10 +12,11 @@ This file aggregates three layers of UI-contract tests:
    in the SPA template and JS-source-level checks for the activity
    translation helper.
 
-3. Phase 3 Home single-scroll layout + Operator action chips — verifies
-   ACTION-line parsing strips the trailing chip block, default Quick
-   actions render, the Home single-scroll section testids are wired,
-   and the kanban sub-page is gated on ``homeTab === 'tasks'``.
+3. Operator action chips + post-PR-2 Work-tab cutover surface —
+   verifies ACTION-line parsing strips the trailing chip block, default
+   Quick actions render, and the new Goals strip + Tell Operator
+   surface is wired (with the legacy sub-nav / kanban / activity
+   templates excised).
 
 We can't run a real headless browser in CI, so all assertions are
 string-level over the rendered template + static JS — enough to catch
@@ -384,10 +385,12 @@ class TestEmptyStateCTAs:
         # The fleet/team page first-run state.
         assert "Build your first team" in _INDEX_HTML
 
-    def test_workplace_feed_empty_state_user_speak(self):
-        # The activity feed empty-state text avoids "agents" — uses
-        # "team" instead.
-        assert "Once your team starts working" in _INDEX_HTML
+    def test_workplace_summary_empty_state_user_speak(self):
+        # PR 2 of Work tab rewrite — the activity feed empty-state
+        # "Once your team starts working…" was deleted along with the
+        # activity sub-page. The summary view's empty state is now the
+        # user-facing "no work yet" surface.
+        assert "No summaries yet" in _INDEX_HTML
 
 
 # ── Notifications bell ────────────────────────────────────────────────
@@ -568,20 +571,6 @@ class TestEventBusAuditFollowUpHandlers:
         )
         assert "loadWorkplaceTasks" in body, (
             "Handler must nudge the workplace tasks list (debounced)"
-        )
-
-    def test_cancel_reason_appears_in_workplace_feed_summary(self):
-        # ``_pushWorkplaceFeedFromEvent`` builds the cancelled summary.
-        # Reason must be appended in parens when present.
-        m = re.search(
-            r"} else if \(status === 'cancelled'\)\s*\{(.*?)\}",
-            _APP_JS_TEXT,
-            re.DOTALL,
-        )
-        assert m, "cancelled branch in workplace feed missing"
-        body = m.group(1)
-        assert "data.reason" in body, (
-            "Cancel summary must read data.reason from the event payload"
         )
 
     def test_cancel_reason_appears_in_format_activity_for_user(self):
@@ -813,423 +802,167 @@ class TestOperatorActionChipsMarkup:
         assert "sendOperatorChip" in nearby
 
 
-class TestHomeSingleScrollLayout:
-    """Phase 4 — Board tab restructured around the kanban as default.
-
-    The legacy single-scroll layout (Phase 3) is retained as the
-    ``activity`` sub-page; the kanban is the new default. These tests
-    verify both the new gating and the back-compat for deep links.
+class TestWorkTabPr2Cutover:
+    """PR 2 of Work tab rewrite — sub-nav (Summaries / Kanban / Activity)
+    deleted, summary cards are the unconditional landing surface, Goals
+    chip strip + Tell Operator added, /home/* URLs normalize to /home.
     """
 
-    def test_activity_layout_gated_on_home_tab(self, index_html: str):
-        # The single-scroll activity layout renders only when
-        # ``homeTab === 'activity'`` (Phase 3's ``main`` value).
-        assert "workplaceEnabled && homeTab === 'activity'" in index_html
+    def test_subnav_tab_strip_removed(self, index_html: str):
+        # The persistent Summaries / Kanban / Activity tab bar is gone.
+        assert 'data-testid="workplace-subnav"' not in index_html
+        assert 'data-testid="workplace-subnav-summaries"' not in index_html
+        assert 'data-testid="workplace-subnav-kanban"' not in index_html
+        assert 'data-testid="workplace-subnav-activity"' not in index_html
 
-    def test_kanban_layout_gated_on_home_tab_kanban(self, index_html: str):
-        # The kanban is the new default — gated on ``homeTab === 'kanban'``.
-        assert "workplaceEnabled && homeTab === 'kanban'" in index_html
+    def test_kanban_surface_removed(self, index_html: str):
+        # No more 4-column kanban grid on the Work tab.
+        assert 'data-testid="board-kanban"' not in index_html
+        assert 'data-testid="board-kanban-card"' not in index_html
+        assert 'data-testid="board-kanban-card-cancel"' not in index_html
 
-    def test_section_testids_present(self, index_html: str):
-        # Every section in the new layout has a testid so a future
-        # refactor can't accidentally hide one without tripping a test.
-        # The legacy activity-feed testids stay (still rendered on the
-        # ``activity`` sub-page); the new kanban + stuck-tasks +
-        # cancel-modal testids capture the Phase 4 surface.
+    def test_activity_subpage_removed(self, index_html: str):
+        # Activity sub-page (Just delivered + Happening now + In progress)
+        # is gone. Only the testid that's actually rendered counts —
+        # ``home-just-delivered`` etc. previously sat inside a live block.
+        # After PR 2 the block sits in an ``x-if="false"`` stub that
+        # doesn't render, but we also want the testids removed entirely
+        # so a search for the old IDs returns nothing user-visible.
+        # The dead-stub HTML in this PR carries no testids.
         for testid in (
-            "home-activity",
             "home-just-delivered",
             "home-happening-now",
             "home-in-progress",
             "home-see-task-board",
-            "board-kanban",
-            "board-kanban-card",
-            "board-kanban-card-cancel",
-            "board-stuck-tasks",
-            # Footer-link affordance ``board-view-activity`` was replaced
-            # by the persistent ``workplace-subnav-activity`` tab bar
-            # button. Same target, more prominent.
-            "workplace-subnav-summaries",
-            "workplace-subnav-kanban",
-            "workplace-subnav-activity",
-            "cancel-task-modal",
-            "cancel-task-confirm",
+            "home-activity",
+            "home-idle-empty",
+            "rate-buttons",
+            "inline-rework",
         ):
-            assert f'data-testid="{testid}"' in index_html, \
-                f"Missing testid: {testid}"
+            assert f'data-testid="{testid}"' not in index_html, \
+                f"PR 2 should have removed testid: {testid}"
 
-    def test_subtab_bar_replaces_legacy_workplace_tab(self, index_html: str):
-        # The persistent sub-nav tab bar replaces the legacy
-        # ``workplaceTab = wt.id`` click handler. All three Work
-        # sub-views (Summaries / Kanban / Activity) are reachable in
-        # one click; no view is buried behind a footer link.
-        assert "workplaceTab = wt.id; loadWorkplace()" not in index_html
-        assert 'data-testid="workplace-subnav"' in index_html
-        assert "switchHomeTab('summaries')" in index_html
-        assert "switchHomeTab('kanban')" in index_html
-        assert "switchHomeTab('activity')" in index_html
-
-    def test_activity_subpage_reachable_via_subnav(self, index_html: str):
-        # The activity sub-page is reached via the persistent tab bar,
-        # not a "Back to Work" button. Asserts the new tab affordance.
-        assert 'data-testid="workplace-subnav-activity"' in index_html
-        assert "switchHomeTab('activity')" in index_html
-
-    def test_legacy_subtabs_hidden_with_back_compat_gate(self, index_html: str):
-        # The old team-status / team-outputs renders are kept in
-        # markup behind a ``false &&`` short-circuit so nothing visible
-        # depends on ``workplaceTab`` while deep-link callers still
-        # don't NPE on the missing template.
-        assert "false && workplaceEnabled && workplaceTab === 'team-status'" in index_html
-        assert "false && workplaceEnabled && workplaceTab === 'team-outputs'" in index_html
-
-
-class TestHomeRouting:
-    """Phase 4 — ``/home`` (kanban) and ``/home/activity`` URL routes.
-
-    Legacy ``/home/tasks`` resolves to the kanban (back-compat — the
-    kanban IS the default now, so old bookmarks survive).
-    """
-
-    def test_build_path_emits_home_route(self, app_js: str):
-        # ``_buildPath`` emits four workplace sub-routes based on
-        # ``homeTab``: ``/home`` (no-opinion landing), ``/home/activity``,
-        # ``/home/summaries``, and ``/home/kanban`` (explicit kanban —
-        # added so the user's tab choice survives page reload). The
-        # kanban arm is GATED on ``this.homeTabUserChosen`` so a bare
-        # ``/home`` placeholder doesn't canonicalize to ``/home/kanban``
-        # before the always-summaries default settles.
-        assert "if (this.homeTab === 'activity') return '/home/activity'" in app_js
-        assert "if (this.homeTab === 'summaries') return '/home/summaries'" in app_js
-        assert "this.homeTab === 'kanban' && this.homeTabUserChosen" in app_js
-        assert "return '/home/kanban'" in app_js
-        assert "return '/home'" in app_js
-
-    def test_bare_home_parses_to_summaries_no_flicker(self, app_js: str):
-        # Bare ``/home`` is parsed directly to ``homeTab='summaries'``
-        # so the initial render lands on summaries without flickering
-        # through the kanban placeholder. The post-load
-        # ``_applyDefaultHomeTab`` ratifies the same value as a
-        # belt-and-suspenders no-op.
-        idx = app_js.find("if (clean === 'home') {")
-        assert idx > 0
-        # Window large enough to capture the full block + the
-        # ``return route`` line. The comment header in the block
-        # is multi-line so the actual assignment is past line 500.
-        block = app_js[idx:idx + 1200]
-        assert "route.homeTab = 'summaries'" in block
-        # And must NOT set userChosen for the bare-/home case — the
-        # user didn't choose; we defaulted on their behalf.
-        # Scope the check to JUST the bare-/home branch (find the
-        # next ``return route;`` to bound it).
-        return_idx = block.find("return route;")
-        assert return_idx > 0
-        bare_branch = block[:return_idx]
-        assert "route.homeTabUserChosen" not in bare_branch
-
-    def test_switch_home_tab_canonicalizes_url_on_same_target(self, app_js: str):
-        # When ``switchHomeTab`` is called with the same tab as the
-        # current ``homeTab``, it MUST still push the URL if
-        # ``homeTabUserChosen`` was false (bare ``/home`` landing).
-        # Without this canonicalization the URL stays bare ``/home``
-        # after the user explicitly clicks Summaries on a fresh load.
-        idx = app_js.find("switchHomeTab(tabId) {")
-        assert idx > 0
-        body = app_js[idx:idx + 1200]
-        # Push fires on target change OR user-chosen flip.
-        assert "targetChanged" in body
-        assert "userChosenFlipped" in body
-
-    def test_parse_path_recognizes_home_routes(self, app_js: str):
-        # ``_parsePath`` accepts every Work sub-route + legacy
-        # ``/home/tasks`` for back-compat with Phase 3 bookmarks.
-        assert "clean === 'home'" in app_js
-        assert "clean === 'home/activity'" in app_js or "home/activity" in app_js
-        assert "clean === 'home/summaries'" in app_js or "home/summaries" in app_js
-        assert "clean === 'home/kanban'" in app_js or "home/kanban" in app_js
-        assert "clean === 'home/tasks'" in app_js or "home/tasks" in app_js
-
-    def test_kanban_deep_link_sets_user_chosen(self, app_js: str):
-        # Explicit ``/home/kanban`` must mark ``homeTabUserChosen``
-        # so the post-load auto-default doesn't revert to summaries
-        # (regression: without this, clicking the Kanban tab
-        # produced ``/home`` which on reload lost the choice).
-        idx = app_js.find("clean === 'home/kanban'")
-        assert idx > 0
-        block = app_js[idx:idx + 800]
-        assert "route.homeTab = 'kanban'" in block
-        assert "route.homeTabUserChosen = true" in block
-
-    def test_always_summaries_default_no_conditional(self, app_js: str):
-        # ``_applyDefaultHomeTab`` must NOT condition on team /
-        # summary count any more — summaries is the unconditional
-        # default landing regardless of fleet size. Find the
-        # METHOD DEFINITION (``_applyDefaultHomeTab() {``), not
-        # a callsite — the inner body is what carries the policy.
-        idx = app_js.find("_applyDefaultHomeTab() {")
-        assert idx > 0
-        body = app_js[idx:idx + 800]
-        # No team/summary counter checks; the only guard is the
-        # user-chosen flag.
-        assert "workplaceTeams" not in body
-        assert "workplaceSummaries" not in body
-        # And it does write summaries.
-        assert "this.homeTab = 'summaries'" in body
-
-    def test_switch_home_tab_helper_present(self, app_js: str):
-        assert "switchHomeTab(tabId)" in app_js
-
-    def test_default_home_tab_is_kanban(self, app_js: str):
-        # The Alpine state default is now ``kanban`` (Phase 3 default
-        # was ``main``). This is the load-bearing change for the
-        # CPO call to make the kanban the default Board view.
-        assert "homeTab: 'kanban'" in app_js
-
-# ── New-user onboarding tutorial ─────────────────────────────────
-
-# ── Phase 4 (Board kanban-default): cancel + stuck-tasks + density ──
-
-
-class TestBoardKanbanDefaultUI:
-    """Phase 4 — Board kanban as default + task cancel + Stuck tasks
-    + activity-feed noise filter.
-
-    All assertions are string-level over the rendered template + static
-    JS — same idiom as the rest of this file. Headless-browser checks
-    are tracked separately."""
-
-    def test_work_tab_defaults_to_kanban(self, app_js: str):
-        # Default homeTab is ``kanban`` — the kanban surface IS the
-        # Board home page now.
-        assert "homeTab: 'kanban'" in app_js
-        # _parsePath default route also lands on kanban.
-        assert "homeTab: 'kanban'" in app_js
-
-    def test_kanban_card_renders_cancel_button(self, index_html: str):
-        # The × cancel button is present on every kanban card.
-        assert 'data-testid="board-kanban-card-cancel"' in index_html
-        # And it's wired to the confirm-cancel handler.
-        assert 'confirmCancelTask(t)' in index_html
-
-    def test_cancel_task_shows_confirmation_modal(self, index_html: str):
-        # Modal is present + gated on cancelTaskCandidate.
-        assert 'data-testid="cancel-task-modal"' in index_html
-        assert 'x-if="cancelTaskCandidate"' in index_html
-        # Confirm button calls cancelTaskNow().
-        assert 'data-testid="cancel-task-confirm"' in index_html
-        assert 'cancelTaskNow()' in index_html
-
-    def test_cancel_task_calls_dashboard_proxy(self, app_js: str):
-        # The cancel handler POSTs to the new dashboard cancel route
-        # (which proxies to the mesh).
-        assert "/workplace/tasks/" in app_js
-        assert "/cancel" in app_js
-        assert "cancelTaskNow" in app_js
-
-    def test_truncate_title_helper_present(self, app_js: str):
-        # truncateTitle is the helper backing the 80-char card title cap.
-        assert "truncateTitle(title, max)" in app_js
-
-    def test_kanban_card_uses_truncate_title(self, index_html: str):
-        # Cards render via truncateTitle so long agent-instruction-as-
-        # title strings (~250 chars seen in production) don't blow up
-        # the kanban grid.
-        idx = index_html.find('data-testid="board-kanban-card"')
-        assert idx > 0
-        nearby = index_html[idx:idx + 2500]
-        assert "truncateTitle(t.title, 80)" in nearby
-
-    def test_stuck_tasks_section_present(self, index_html: str):
-        # The Stuck tasks panel sits between Needs you and the kanban.
+    def test_stuck_tasks_panel_retained(self, index_html: str):
+        # Stuck Tasks panel + per-row Cancel / Restart-agent affordances
+        # survive the cutover.
         assert 'data-testid="board-stuck-tasks"' in index_html
-        # Each row has cancel + restart buttons.
         assert 'data-testid="board-stuck-task-cancel"' in index_html
         assert 'data-testid="board-stuck-task-restart"' in index_html
 
-    def test_stuck_tasks_section_hidden_when_empty(self, index_html: str):
-        # The section only renders when stuckTasks is non-empty —
-        # gated on ``stuckTasks.length`` in the x-if expression.
-        idx = index_html.find('data-testid="board-stuck-tasks"')
+    def test_cancel_task_modal_retained(self, index_html: str):
+        assert 'data-testid="cancel-task-modal"' in index_html
+        assert 'data-testid="cancel-task-confirm"' in index_html
+
+    def test_summary_cards_unconditional_landing(self, index_html: str):
+        # Summary view renders whenever the Work tab is on (no homeTab
+        # gate any more). The conditional reads ``workplaceEnabled``
+        # only.
+        assert 'data-testid="workplace-summaries-view"' in index_html
+        idx = index_html.find('data-testid="workplace-summaries-view"')
+        # Walk back to find the enclosing template tag.
+        slice_ = index_html[max(0, idx - 400):idx]
+        assert 'homeTab' not in slice_, \
+            "summary view should no longer gate on homeTab"
+
+    def test_goals_strip_present_with_chip_template(self, index_html: str):
+        # New Goals chip strip — read-only render of operator's goals.
+        assert 'data-testid="workplace-goals-strip"' in index_html
+        assert 'data-testid="workplace-goal-chip"' in index_html
+        # Hidden when no goals tracked.
+        idx = index_html.find('data-testid="workplace-goals-strip"')
+        slice_ = index_html[max(0, idx - 200):idx + 200]
+        assert "workplaceGoals.length > 0" in slice_
+
+    def test_tell_operator_section_present(self, index_html: str):
+        # Steering textarea + Send button + confirmation slot.
+        assert 'data-testid="workplace-tell-operator"' in index_html
+        assert 'data-testid="tell-operator-submit"' in index_html
+        assert 'data-testid="tell-operator-confirmation"' in index_html
+        assert "submitTellOperator()" in index_html
+
+    def test_build_path_emits_only_bare_home(self, app_js: str):
+        # PR 2 — single Work-tab URL. _buildPath returns '/home' for
+        # the Work tab; no /home/kanban, /home/activity, /home/summaries
+        # branches survive.
+        idx = app_js.find("if (this.activeTab === 'workplace')")
         assert idx > 0
-        # Walk back to find the enclosing template open tag.
-        slice_ = index_html[max(0, idx - 600):idx]
-        assert "stuckTasks.length" in slice_
+        block = app_js[idx:idx + 400]
+        assert "return '/home'" in block
+        assert "/home/activity" not in block
+        assert "/home/summaries" not in block
+        assert "/home/kanban" not in block
 
-    def test_stuck_tasks_getter_filters_pending_over_24h(self, app_js: str):
-        # The getter checks status pending/working AND age > 24h.
-        idx = app_js.find("get stuckTasks()")
+    def test_parse_path_normalizes_legacy_home_urls(self, app_js: str):
+        # Any /home/{anything} URL silently normalizes to /home so old
+        # bookmarks (kanban, activity, summaries, tasks) survive without
+        # a 404 or visible redirect.
+        idx = app_js.find("if (clean === 'home' || clean.startsWith('home/'))")
+        assert idx > 0, "legacy /home/* normalization missing"
+        block = app_js[idx:idx + 300]
+        assert "route.tab = 'workplace'" in block
+        # Verify no separate branch for /home/kanban etc. lingers.
+        assert "clean === 'home/kanban'" not in app_js
+        assert "clean === 'home/activity'" not in app_js
+        assert "clean === 'home/summaries'" not in app_js
+        assert "clean === 'home/tasks'" not in app_js
+
+    def test_home_tab_state_and_methods_removed(self, app_js: str):
+        # Compaction check — homeTab + switchHomeTab + helper methods
+        # were all removed from app.js. Their absence is what makes the
+        # template state machine collapse to a single workplace view.
+        # Comment lines that reference these names as history are fine;
+        # we only check for the JS identifiers in active use.
+        assert "homeTab: 'kanban'" not in app_js
+        assert "switchHomeTab(tabId)" not in app_js
+        assert "_applyDefaultHomeTab()" not in app_js
+        assert "drillIntoTeamKanban(" not in app_js
+
+    def test_recently_delivered_helpers_removed(self, app_js: str):
+        # PR 2 also drops the "Recently delivered" cluster.
+        assert "_recomputeRecentlyDelivered(" not in app_js
+        assert "_ensureRecentlyDeliveredArtifact(" not in app_js
+        assert "recentlyDeliveredPreview(" not in app_js
+        assert "recentlyDeliveredFull(" not in app_js
+        assert "recentlyDeliveredHasMore(" not in app_js
+        assert "copyRecentlyDeliveredText(" not in app_js
+
+    def test_inline_rework_and_rate_delivery_removed(self, app_js: str):
+        # The per-task rating handler + inline rework state are gone.
+        assert "async rateDelivery(" not in app_js
+        assert "submitInlineRework(" not in app_js
+        assert "openInlineRework(" not in app_js
+        assert "closeInlineRework(" not in app_js
+        assert "inlineReworkIsOpen(" not in app_js
+
+    def test_global_task_ws_handlers_preserved(self, app_js: str):
+        # Global task_created / task_status_changed / task_outcome
+        # handlers feed System Activity + notification bell + the
+        # drill-in modal — they MUST survive the Work-tab cutover.
+        assert "case 'task_status_changed':" in app_js
+        assert "case 'task_outcome':" in app_js
+        assert "case 'task_created':" in app_js
+
+    def test_load_workplace_drops_outputs_and_feed_loaders(self, app_js: str):
+        # The master Promise.all should NOT call the deleted loaders.
+        idx = app_js.find("async loadWorkplace()")
         assert idx > 0
-        body = app_js[idx:idx + 2000]
-        assert "'pending'" in body and "'working'" in body
-        assert "24 * 3600" in body  # the cutoff constant
+        body = app_js[idx:idx + 1200]
+        assert "loadWorkplaceTeams" in body
+        assert "loadWorkplaceTasks" in body
+        assert "loadWorkplaceBlockers" in body
+        assert "loadWorkplacePending" in body
+        assert "loadWorkplaceSummaries" in body
+        assert "loadWorkplaceGoals" in body
+        assert "loadWorkplaceOutputs" not in body
+        assert "loadWorkplaceFeed" not in body
 
-    def test_status_unchanged_filtered_from_activity_feed(self, app_js: str):
-        # formatActivityForUser returns null for status_unchanged so
-        # heartbeat noise stays out of the user-facing feed.
-        idx = app_js.find("formatActivityForUser(event)")
-        assert idx > 0
-        body = app_js[idx:idx + 4000]
-        assert "case 'status_unchanged':" in body
-        # The feed itself uses the noise-filtered view via the getter.
-        assert "get workplaceFeedVisible()" in app_js
-        assert "event_type !== 'status_unchanged'" in app_js
+    def test_workplace_goals_loader_present(self, app_js: str):
+        assert "async loadWorkplaceGoals()" in app_js
+        assert "/workplace/goals" in app_js
 
-    def test_activity_sub_page_accessible_via_subnav(self, index_html: str):
-        # Activity is reachable in one click via the persistent
-        # Summaries/Kanban/Activity tab bar at the top of the Work
-        # tab. The legacy footer-link ``board-view-activity`` was
-        # removed when the tab bar landed — same target, less
-        # buried.
-        assert 'data-testid="workplace-subnav-activity"' in index_html
-        idx = index_html.find('data-testid="workplace-subnav-activity"')
-        nearby = index_html[max(0, idx - 200):idx + 200]
-        assert "switchHomeTab('activity')" in nearby
-
-    def test_legacy_home_tasks_url_resolves_to_kanban(self, app_js: str):
-        # ``/home/tasks`` (Phase 3 kanban URL) maps to the kanban
-        # default — old bookmarks survive without a redirect.
-        assert "clean === 'home/tasks'" in app_js
-        # The branch sets homeTab = 'kanban' (not 'tasks') so the
-        # default UI lights up.
-        idx = app_js.find("clean === 'home/tasks'")
-        assert idx > 0
-        body = app_js[idx:idx + 200]
-        assert "homeTab = 'kanban'" in body
-
-
-# ── Phase 4 audit fixes: kanban accepted-fold + restart confirm + ──
-# ── vocab + stale code cleanup. ──────────────────────────────────
-
-
-class TestBoardKanbanAuditFixes:
-    """Audit-driven follow-ups on the Phase 4 kanban-default surface.
-
-    Each test maps to one finding from the post-merge audit on
-    ``feat/work-tab-kanban-default-cancel-density``. They cover:
-
-    - Critical #1: ``accepted`` tasks fold into the Pending column so
-      they stay visible on the board.
-    - Critical #2: ``restartAgentForStuck`` routes through ``showConfirm``
-      before issuing the destructive POST.
-    - High #1: Activity sub-page back-link reads "Back to Work" (not the
-      stale "Back to Board" copy that conflicts with the renamed top-nav
-      tab from PR-G).
-    - High #2: Cancel-task modal copy doesn't claim the task is
-      "re-assignable" — ``cancelled`` is a terminal state in the
-      orchestration ledger.
-    - Medium #1: Dead ``task_status_unchanged`` switch arm dropped (the
-      engine emits the single name ``status_unchanged``).
-    - Medium #2: Dead ``workplaceTaskColumns`` Alpine state removed.
-    - Medium #3: Stale ``home-main`` testid renamed to ``home-activity``.
-    - Medium #4: ``stuckTasks`` getter filters out the operator agent.
-    """
-
-    # ── Critical #1: kanban accepted-fold ─────────────────────────
-
-    def test_kanban_pending_column_includes_accepted_tasks(self, app_js: str):
-        # The kanban template hard-codes 4 columns; ``accepted`` is a
-        # transient status emitted by ``update_status`` between pending
-        # and working. The filter folds it into the Pending column so
-        # those tasks remain visible (and cancellable) on the board.
-        # Codex P1.5 Option A extended the helper to also fold ``failed``
-        # into Done — slice widened to 2000 chars so the comment block
-        # and the new branch fit.
-        idx = app_js.find("workplaceTasksByStatus(status)")
-        assert idx > 0
-        body = app_js[idx:idx + 2000]
-        # Both pending and accepted are matched in the pending branch.
-        assert "t.status === 'pending'" in body
-        assert "t.status === 'accepted'" in body
-        # Other statuses still match by exact equality.
-        assert "t.status === status" in body
-        # Codex P1.5: ``failed`` folds into ``done`` so it stays visible.
-        assert "t.status === 'failed'" in body
-        assert "t.status === 'done'" in body
-
-    # ── Critical #2: restart confirmation modal ───────────────────
-
-    def test_restart_agent_for_stuck_routes_through_show_confirm(self, app_js: str):
-        # The Stuck-tasks panel's [Restart agent] button is destructive;
-        # it now goes through ``showConfirm`` so a stray click can't
-        # interrupt active work without an explicit confirmation.
-        idx = app_js.find("async restartAgentForStuck(agentId)")
-        assert idx > 0
-        body = app_js[idx:idx + 2500]
-        assert "this.showConfirm(" in body, \
-            "restartAgentForStuck must route through showConfirm"
-        # Confirm callback wraps the destructive fetch so the modal's
-        # spinner ties to the actual restart.
-        assert "/restart" in body
-        # The confirmation copy mentions the active-work interruption.
-        assert "interrupt any active work" in body
-
-    # ── High #1: "Back to Work" copy ──────────────────────────────
-
-    def test_back_to_board_renamed_to_back_to_work(self, index_html: str):
-        # PR-G renamed the top-nav tab from Home to Work. The two
-        # back-links on the Activity sub-page must match the new label.
-        assert "Back to Work" in index_html
-        # No stale "Back to Board" copy survives.
-        assert "Back to Board" not in index_html
-
-    # ── High #2: cancel-modal copy doesn't claim re-assignability ──
-
-    def test_cancel_modal_copy_does_not_claim_reassignability(self, index_html: str):
-        # ``cancelled`` is terminal in orchestration.py — there is no
-        # transition out, so the modal must not claim the task is
-        # re-assignable. New copy points at creating a new task instead.
-        idx = index_html.find('data-testid="cancel-task-modal"')
-        assert idx > 0
-        # Window the modal block (~1.5KB is enough to cover the body
-        # text + buttons).
-        block = index_html[idx:idx + 1500]
-        assert "re-assigned" not in block, \
-            "cancel-modal must not claim cancelled tasks are re-assignable"
-        assert "create a new task" in block
-
-    # ── Medium #1: drop dead task_status_unchanged switch arm ─────
-
-    def test_task_status_unchanged_switch_arm_dropped(self, app_js: str):
-        # The engine emits ``status_unchanged`` (single name) — the
-        # ``task_status_unchanged`` arm was dead.
-        idx = app_js.find("formatActivityForUser(event)")
-        assert idx > 0
-        body = app_js[idx:idx + 4000]
-        assert "case 'status_unchanged':" in body
-        assert "case 'task_status_unchanged':" not in body, \
-            "dead task_status_unchanged switch arm must be removed"
-
-    # ── Medium #2: workplaceTaskColumns state removed ─────────────
-
-    def test_workplace_task_columns_state_removed(self, app_js: str, index_html: str):
-        # Dead Alpine state — the kanban inlines the column array; the
-        # only remaining template usage was for project count pills,
-        # which now also inlines its own array.
-        assert "workplaceTaskColumns:" not in app_js, \
-            "dead workplaceTaskColumns Alpine state must be removed"
-        assert "workplaceTaskColumns" not in index_html, \
-            "no template should reference the removed workplaceTaskColumns"
-
-    # ── Medium #3: home-main testid renamed to home-activity ──────
-
-    def test_home_main_testid_renamed_to_home_activity(self, index_html: str):
-        # The activity sub-page's container testid lines up with the
-        # surrounding ``home-just-delivered`` / ``home-happening-now``
-        # naming.
-        assert 'data-testid="home-activity"' in index_html
-        assert 'data-testid="home-main"' not in index_html
-
-    # ── Medium #4: stuckTasks filters operator ────────────────────
-
-    def test_stuck_tasks_filters_operator_assignee(self, app_js: str):
-        # Defensive filter: operator is the orchestrator, not a worker.
-        # Even if a future code path accidentally assigns work to it,
-        # the Stuck panel must not surface those rows.
-        idx = app_js.find("get stuckTasks()")
-        assert idx > 0
-        body = app_js[idx:idx + 2000]
-        assert "t.assignee === 'operator'" in body, \
-            "stuckTasks must filter out operator-assigned rows"
+    def test_tell_operator_method_present(self, app_js: str):
+        assert "async submitTellOperator()" in app_js
+        assert "sendChatTo('operator'" in app_js
 
 
 # ── Phase 4: \"What's new\" tour for existing-fleet users ──────────
@@ -2372,6 +2105,12 @@ _VERB_FOR_TOOL_FALLBACK_OK = frozenset({
     "run_command",
     "wallet_execute",
     "wallet_read_contract",
+    # Operator-only programmatic surfaces (PR 1 + PR 2 of Work tab
+    # rewrite). User-visible activity feed doesn't render them with
+    # a custom verb — the fallback "using manage goals" / "using
+    # rate delivery" reads fine.
+    "manage_goals",
+    "rate_delivery",
 })
 
 

--- a/tests/test_operator_manage_goals.py
+++ b/tests/test_operator_manage_goals.py
@@ -5,7 +5,7 @@ Covers:
 * All five actions (set / add / update / remove / list)
 * `add` rejects duplicate names
 * `update` / `remove` reject unknown names
-* `set` enforces max 20 goals + duplicate name rejection
+* `set` enforces max 10 goals + duplicate name rejection
 * Status enum validation
 * `updated_at` stamped on touched goals; preserved on untouched ones
 * GOALS.md and GOALS.json stay in sync
@@ -112,7 +112,7 @@ async def test_manage_goals_set_caps_max_entries(tmp_path):
 
     ws = _FakeWorkspace(tmp_path)
     too_many = [
-        {"name": f"g{i}", "status": "in_progress"} for i in range(21)
+        {"name": f"g{i}", "status": "in_progress"} for i in range(11)
     ]
     result = await manage_goals("set", goals=too_many, workspace_manager=ws)
     assert "error" in result
@@ -393,7 +393,7 @@ async def test_manage_goals_add_caps_at_max_entries(tmp_path):
 
     ws = _FakeWorkspace(tmp_path)
     initial = [
-        {"name": f"g{i}", "status": "in_progress"} for i in range(20)
+        {"name": f"g{i}", "status": "in_progress"} for i in range(10)
     ]
     await manage_goals("set", goals=initial, workspace_manager=ws)
     overflow = await manage_goals(

--- a/tests/test_operator_rate_delivery.py
+++ b/tests/test_operator_rate_delivery.py
@@ -1,0 +1,233 @@
+"""Tests for the ``rate_delivery`` operator tool (PR 2 of Work tab rewrite).
+
+Covers:
+
+* Operator-only gating (non-operator rejected)
+* Missing mesh_client returns error
+* Missing / empty task_id rejected
+* Unknown outcome rejected
+* feedback type validation
+* feedback required for rework / rejected
+* feedback length cap (2000 chars)
+* Happy path → POSTs to mesh and returns ok dict
+* rework outcome → surfaces ``rework_task_id`` from mesh response
+* Mesh exception → returns ``{error}`` (no crash)
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _set_operator_env(monkeypatch):
+    monkeypatch.setenv("ALLOWED_TOOLS", "rate_delivery")
+
+
+def _make_mesh(response: dict | None = None, raises: Exception | None = None):
+    mesh = AsyncMock()
+    if raises is not None:
+        mesh.set_task_outcome.side_effect = raises
+    else:
+        mesh.set_task_outcome.return_value = response or {"ok": True}
+    return mesh
+
+
+@pytest.mark.asyncio
+async def test_rate_delivery_non_operator_rejected(monkeypatch):
+    monkeypatch.delenv("ALLOWED_TOOLS", raising=False)
+    from src.agent.builtins.operator_tools import rate_delivery
+
+    result = await rate_delivery(
+        task_id="task_1", outcome="accepted", mesh_client=_make_mesh(),
+    )
+    assert "error" in result
+    assert "operator" in result["error"].lower()
+
+
+@pytest.mark.asyncio
+async def test_rate_delivery_no_mesh_client():
+    from src.agent.builtins.operator_tools import rate_delivery
+
+    result = await rate_delivery(task_id="task_1", outcome="accepted")
+    assert "error" in result
+    assert "mesh_client" in result["error"]
+
+
+@pytest.mark.asyncio
+async def test_rate_delivery_missing_task_id():
+    from src.agent.builtins.operator_tools import rate_delivery
+
+    mesh = _make_mesh()
+    result = await rate_delivery(
+        task_id="", outcome="accepted", mesh_client=mesh,
+    )
+    assert "error" in result
+    assert "task_id" in result["error"]
+    mesh.set_task_outcome.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_rate_delivery_unknown_outcome_rejected():
+    from src.agent.builtins.operator_tools import rate_delivery
+
+    mesh = _make_mesh()
+    result = await rate_delivery(
+        task_id="task_1", outcome="loved_it", mesh_client=mesh,
+    )
+    assert "error" in result
+    assert "outcome" in result["error"]
+    mesh.set_task_outcome.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_rate_delivery_feedback_must_be_string():
+    from src.agent.builtins.operator_tools import rate_delivery
+
+    mesh = _make_mesh()
+    # The skill is typed as ``feedback: str`` but the LLM could pass
+    # garbage; we defend at the boundary.
+    result = await rate_delivery(
+        task_id="task_1",
+        outcome="accepted",
+        feedback=123,  # type: ignore[arg-type]
+        mesh_client=mesh,
+    )
+    assert "error" in result
+    assert "feedback" in result["error"]
+    mesh.set_task_outcome.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_rate_delivery_rework_requires_feedback():
+    from src.agent.builtins.operator_tools import rate_delivery
+
+    mesh = _make_mesh()
+    result = await rate_delivery(
+        task_id="task_1", outcome="rework", feedback="   ",
+        mesh_client=mesh,
+    )
+    assert "error" in result
+    assert "feedback is required" in result["error"]
+    mesh.set_task_outcome.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_rate_delivery_rejected_requires_feedback():
+    from src.agent.builtins.operator_tools import rate_delivery
+
+    mesh = _make_mesh()
+    result = await rate_delivery(
+        task_id="task_1", outcome="rejected", feedback="",
+        mesh_client=mesh,
+    )
+    assert "error" in result
+    assert "feedback is required" in result["error"]
+    mesh.set_task_outcome.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_rate_delivery_feedback_length_capped():
+    from src.agent.builtins.operator_tools import rate_delivery
+
+    mesh = _make_mesh()
+    # 2001 chars — one over the cap.
+    big = "x" * 2001
+    result = await rate_delivery(
+        task_id="task_1", outcome="rework", feedback=big,
+        mesh_client=mesh,
+    )
+    assert "error" in result
+    assert "2000" in result["error"]
+    mesh.set_task_outcome.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_rate_delivery_accepted_happy_path():
+    from src.agent.builtins.operator_tools import rate_delivery
+
+    mesh = _make_mesh(response={"ok": True, "task": {"id": "task_1"}})
+    result = await rate_delivery(
+        task_id="task_1", outcome="accepted", mesh_client=mesh,
+    )
+    assert result["ok"] is True
+    assert result["task_id"] == "task_1"
+    assert result["outcome"] == "accepted"
+    mesh.set_task_outcome.assert_awaited_once_with("task_1", "accepted", "")
+
+
+@pytest.mark.asyncio
+async def test_rate_delivery_acknowledged_silent_feedback_ok():
+    """acknowledged with empty feedback is the safe default and must work."""
+    from src.agent.builtins.operator_tools import rate_delivery
+
+    mesh = _make_mesh(response={"ok": True})
+    result = await rate_delivery(
+        task_id="task_1", outcome="acknowledged", mesh_client=mesh,
+    )
+    assert result["ok"] is True
+    assert result["outcome"] == "acknowledged"
+
+
+@pytest.mark.asyncio
+async def test_rate_delivery_rework_surfaces_rework_task_id():
+    from src.agent.builtins.operator_tools import rate_delivery
+
+    mesh = _make_mesh(response={
+        "ok": True,
+        "task": {"id": "task_1"},
+        "rework_task_id": "task_2",
+        "rework_assignee": "scout",
+    })
+    result = await rate_delivery(
+        task_id="task_1",
+        outcome="rework",
+        feedback="tighten the intro paragraph",
+        mesh_client=mesh,
+    )
+    assert result["ok"] is True
+    assert result["rework_task_id"] == "task_2"
+    assert result["rework_assignee"] == "scout"
+    mesh.set_task_outcome.assert_awaited_once_with(
+        "task_1", "rework", "tighten the intro paragraph",
+    )
+
+
+@pytest.mark.asyncio
+async def test_rate_delivery_mesh_failure_returns_error():
+    from src.agent.builtins.operator_tools import rate_delivery
+
+    mesh = _make_mesh(raises=RuntimeError("mesh down"))
+    result = await rate_delivery(
+        task_id="task_1", outcome="accepted", mesh_client=mesh,
+    )
+    assert "error" in result
+    assert "mesh down" in result["error"]
+
+
+@pytest.mark.asyncio
+async def test_rate_delivery_feedback_sanitized_before_transit():
+    """Invisible Unicode / zero-width chars must be stripped via
+    ``sanitize_for_prompt`` before the mesh receives the string.
+
+    Without this guard a corrupted upstream feedback could poison the
+    receiving agent's memory write.
+    """
+    from src.agent.builtins.operator_tools import rate_delivery
+
+    mesh = _make_mesh(response={"ok": True})
+    # Zero-width space + bidi marker injected in feedback.
+    raw = "needs more depth​text‮"
+    result = await rate_delivery(
+        task_id="task_1", outcome="rework", feedback=raw,
+        mesh_client=mesh,
+    )
+    assert result["ok"] is True
+    # The mesh-side feedback must not contain the raw smuggled chars.
+    call = mesh.set_task_outcome.await_args
+    sent_feedback = call.args[2]
+    assert "​" not in sent_feedback
+    assert "‮" not in sent_feedback
+    assert "needs more depth" in sent_feedback

--- a/tests/test_orchestration_endpoints.py
+++ b/tests/test_orchestration_endpoints.py
@@ -1032,3 +1032,144 @@ async def test_assignee_whitespace_normalization_logged(v2_app, caplog):
         for rec in caplog.records
         if rec.levelno >= logging.WARNING
     ), [rec.getMessage() for rec in caplog.records]
+
+
+# ── PR 2 (Work tab cutover) — mesh outcome endpoint ─────────────────
+
+
+async def _create_and_complete(client, *, assignee: str = "analyst") -> str:
+    """Helper — create a task, mark it done. Returns the task id."""
+    r = await client.post(
+        "/mesh/tasks",
+        json={"assignee": assignee, "title": "completed work"},
+        headers={"X-Agent-ID": "scout"},
+    )
+    assert r.status_code == 200, r.text
+    tid = r.json()["id"]
+    # Mark working, then done (transition rules require working → done).
+    r = await client.post(
+        f"/mesh/tasks/{tid}/status",
+        json={"status": "working"},
+        headers={"X-Agent-ID": assignee},
+    )
+    assert r.status_code == 200, r.text
+    r = await client.post(
+        f"/mesh/tasks/{tid}/status",
+        json={"status": "done"},
+        headers={"X-Agent-ID": assignee},
+    )
+    assert r.status_code == 200, r.text
+    return tid
+
+
+@pytest.mark.asyncio
+async def test_outcome_endpoint_operator_accepts(v2_app):
+    """Operator can rate a completed task with ``accepted`` (empty feedback OK)."""
+    app, _, _ = v2_app
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://t",
+    ) as c:
+        tid = await _create_and_complete(c)
+        r = await c.post(
+            f"/mesh/tasks/{tid}/outcome",
+            json={"outcome": "accepted"},
+            headers={"X-Agent-ID": "operator"},
+        )
+        assert r.status_code == 200, r.text
+        body = r.json()
+        assert body["ok"] is True
+        assert body["task"]["outcome"] == "accepted"
+
+
+@pytest.mark.asyncio
+async def test_outcome_endpoint_rework_spawns_followup(v2_app):
+    """``rework`` outcome auto-spawns a follow-up task and surfaces its id."""
+    app, _, _ = v2_app
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://t",
+    ) as c:
+        tid = await _create_and_complete(c)
+        r = await c.post(
+            f"/mesh/tasks/{tid}/outcome",
+            json={
+                "outcome": "rework",
+                "feedback": "tighten the intro paragraph",
+            },
+            headers={"X-Agent-ID": "operator"},
+        )
+        assert r.status_code == 200, r.text
+        body = r.json()
+        assert body["ok"] is True
+        assert body["task"]["outcome"] == "rework"
+        assert "rework_task_id" in body
+        assert body["rework_assignee"] == "analyst"
+
+
+@pytest.mark.asyncio
+async def test_outcome_endpoint_rejects_unknown_outcome(v2_app):
+    """Unknown outcomes get 400, not 200."""
+    app, _, _ = v2_app
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://t",
+    ) as c:
+        tid = await _create_and_complete(c)
+        r = await c.post(
+            f"/mesh/tasks/{tid}/outcome",
+            json={"outcome": "loved_it"},
+            headers={"X-Agent-ID": "operator"},
+        )
+        assert r.status_code == 400
+        assert "outcome must be one of" in r.text
+
+
+@pytest.mark.asyncio
+async def test_outcome_endpoint_requires_feedback_for_rework(v2_app):
+    """rework / rejected require non-empty feedback (HTTP 400)."""
+    app, _, _ = v2_app
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://t",
+    ) as c:
+        tid = await _create_and_complete(c)
+        r = await c.post(
+            f"/mesh/tasks/{tid}/outcome",
+            json={"outcome": "rework", "feedback": ""},
+            headers={"X-Agent-ID": "operator"},
+        )
+        assert r.status_code == 400
+        assert "feedback is required" in r.text
+
+
+@pytest.mark.asyncio
+async def test_outcome_endpoint_returns_404_for_missing_task(v2_app):
+    app, _, _ = v2_app
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://t",
+    ) as c:
+        r = await c.post(
+            "/mesh/tasks/task_does_not_exist/outcome",
+            json={"outcome": "accepted"},
+            headers={"X-Agent-ID": "operator"},
+        )
+        assert r.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_outcome_endpoint_non_terminal_returns_409(v2_app):
+    """Tasks must be terminal before they can be rated."""
+    app, _, _ = v2_app
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://t",
+    ) as c:
+        r = await c.post(
+            "/mesh/tasks",
+            json={"assignee": "analyst", "title": "still working"},
+            headers={"X-Agent-ID": "scout"},
+        )
+        tid = r.json()["id"]
+        # Task is pending — not terminal. Try to rate it.
+        r = await c.post(
+            f"/mesh/tasks/{tid}/outcome",
+            json={"outcome": "accepted"},
+            headers={"X-Agent-ID": "operator"},
+        )
+        assert r.status_code == 409

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -6,6 +6,8 @@ import shutil
 import tempfile
 from pathlib import Path
 
+import pytest
+
 from src.agent.workspace import (
     _MAX_SYSTEM,
     WorkspaceManager,
@@ -1227,13 +1229,25 @@ class TestDeriveCapabilitiesFromInterface:
 
 
 class TestHeartbeatVersionedRefresh:
-    """When the template carries the ``heartbeat_v2_workflow_aware``
-    sentinel and the live HEARTBEAT.md lacks it, the workspace
-    overwrites on next construction. Preserves user-customised
-    heartbeats (which won't have the marker) and pushes the next
-    system-managed revision forward."""
+    """When the template carries the LATEST sentinel from
+    ``HEARTBEAT_SENTINELS`` and the live HEARTBEAT.md lacks it, the
+    workspace overwrites on next construction. Preserves user-
+    customised heartbeats (which won't have any marker) and pushes
+    the next system-managed revision forward — including upgrading
+    workspaces that carry only an older sentinel.
 
-    SENTINEL = "<!-- heartbeat_v2_workflow_aware -->"
+    The class pins to ``HEARTBEAT_SENTINELS[-1]`` so future template
+    bumps don't require touching every test — only the migration
+    semantics matter.
+    """
+
+    @classmethod
+    def setup_class(cls):
+        from src.shared.types import HEARTBEAT_SENTINELS
+        # Refresh fires when the template's LATEST sentinel isn't in
+        # the live file. Earlier sentinels are evidence of past
+        # migrations and don't block upgrades.
+        cls.SENTINEL = f"<!-- {HEARTBEAT_SENTINELS[-1]} -->"
 
     def setup_method(self):
         self._tmpdir = tempfile.mkdtemp()
@@ -1306,25 +1320,61 @@ class TestHeartbeatVersionedRefresh:
     def test_sentinel_constant_imported_from_shared_types(self):
         """``HEARTBEAT_SENTINELS`` lives in ``src.shared.types`` so the
         workspace and the operator-config heartbeat refresh stay in
-        sync. Verify the symbol resolves and includes the current
-        marker — a regression here would mean the constant was
-        re-defined locally and would silently drift."""
+        sync. Verify the symbol resolves, includes the historical
+        v2 marker, and that the LATEST sentinel drives the refresh
+        path — a regression here would mean the constant was
+        re-defined locally and would silently drift, or that the
+        check reverted to ``any()`` semantics that skip v2→v3
+        upgrades."""
         from src.shared.types import HEARTBEAT_SENTINELS
         assert isinstance(HEARTBEAT_SENTINELS, tuple)
+        # v2 stays as evidence of past migrations even after later
+        # sentinels are added.
         assert "heartbeat_v2_workflow_aware" in HEARTBEAT_SENTINELS
-        # The workspace module must consume the central constant, not
-        # define its own. Confirmed by exercising the refresh path on
-        # the canonical marker.
         path = Path(self._tmpdir) / "HEARTBEAT.md"
         path.write_text("# Heartbeat Rules\n\nLEGACY revision\n")
-        marker = f"<!-- {HEARTBEAT_SENTINELS[0]} -->"
+        latest_marker = f"<!-- {HEARTBEAT_SENTINELS[-1]} -->"
         WorkspaceManager(
             workspace_dir=self._tmpdir,
             initial_heartbeat=(
-                f"{marker}\nWorkflow-aware autonomous steps:\n"
+                f"{latest_marker}\nWorkflow-aware autonomous steps:\n"
                 "1. check_inbox\n"
             ),
         )
         content = path.read_text()
         assert "LEGACY" not in content
-        assert marker in content
+        assert latest_marker in content
+
+    def test_existing_file_with_only_old_sentinel_is_refreshed(self):
+        """Regression: file carrying ONLY an older sentinel + template
+        carrying the LATEST sentinel must refresh. The previous logic
+        used ``any()`` over all known sentinels and treated a v2-only
+        workspace as "already migrated", silently skipping v3 updates
+        for every deployed operator.
+
+        Skips when there's only one sentinel in the tuple (i.e. no
+        upgrade path to verify).
+        """
+        from src.shared.types import HEARTBEAT_SENTINELS
+        if len(HEARTBEAT_SENTINELS) < 2:
+            pytest.skip("Need ≥2 sentinels to verify upgrade path")
+        older_marker = f"<!-- {HEARTBEAT_SENTINELS[0]} -->"
+        latest_marker = f"<!-- {HEARTBEAT_SENTINELS[-1]} -->"
+        path = Path(self._tmpdir) / "HEARTBEAT.md"
+        path.write_text(
+            f"# Heartbeat Rules\n\n{older_marker}\nOlder revision text\n"
+        )
+        template = (
+            f"{older_marker}\n{latest_marker}\nNew revision\n"
+            "1. check_inbox\n"
+        )
+        WorkspaceManager(
+            workspace_dir=self._tmpdir, initial_heartbeat=template,
+        )
+        content = path.read_text()
+        assert latest_marker in content, (
+            "Latest sentinel missing — refresh didn't fire for "
+            "old-sentinel-only workspace"
+        )
+        assert "New revision" in content
+        assert "Older revision text" not in content


### PR DESCRIPTION
## Summary

PR 2 of 3 for the Work-tab rewrite. **Visible product cutover** — non-technical users stop seeing a management console; operator becomes the QA loop. Stacks on **#963 (PR 1)** and must merge after it.

## Frontend

**Removed:**
- Kanban view (4-col board)
- Activity sub-tab (Just delivered + Happening now + In progress + per-task rating UI)
- Sub-nav (Summaries / Kanban / Activity) — Summaries is now the unconditional default
- All associated Alpine state + methods (`homeTab`, `homeTabUserChosen`, `workplaceOutputs`, `workplaceFeed`, `rateDelivery`, `_inlineRework*`, `recentlyDelivered*`, etc.)
- `/home/kanban`, `/home/activity`, `/home/summaries`, `/home/tasks` URLs all normalize silently to `/home` — no 404, no flicker
- Dead delivery-banner code in chat tab (`deliveryBannerVisible`, `markHomeViewed`, `_lastViewedHomeTs`)

**Kept (avoiding cascading breakage):**
- Stuck Tasks panel — silent stale-work detection (different signal from Blockers, which are status='blocked' explicit raises)
- Task drill-in modal — reachable from Needs You + notification bell
- Global task WS handlers — feed System → Activity + notification bell
- Per-summary 👍 / ➖ / 👎 rating on summary cards (coarse feedback the user wanted to keep)

**Added:**
- **Goals strip** above Needs You, reads `/api/workplace/goals` from PR 1. Renders as a horizontal chip strip with status-colored dots; hides entirely when no goals tracked. ARIA-labeled, mobile-responsive.
- **"Tell Operator"** textarea below summary cards. Calls existing `sendChatTo('operator', ...)`; inline "Sent" confirmation that auto-clears after 5s; detects HTTP failures and surfaces "Send failed" (with credit-exhausted hint when applicable).

## Backend

- **`rate_delivery` operator tool** — programmatic per-task outcome rating. Replaces the deleted per-task UI; preserves the agent-feedback machine loop (memory writes on accepted/rejected, auto-rework spawn on rework). Operator-only.
- **`POST /mesh/tasks/{task_id}/outcome`** — mesh endpoint the tool routes through. Mirrors the existing dashboard endpoint's behaviour (auth tier: `_require_operator_or_internal`).
- **`set_task_outcome`** added to `MeshClient`.
- **`_OPERATOR_HEARTBEAT` updated** with five load-bounding rules:
  1. Each cycle: rate up to 10 oldest unrated done tasks (caps cost + hallucination)
  2. Default to `acknowledged` when uncertain — never guess
  3. Re-read GOALS.json, OBSERVATIONS.md, AGENTS.md fresh each cycle (treat working memory as ephemeral)
  4. If team / goal ambiguity, call `notify_user` and stop
  5. Goal stewardship: surface stale candidates in summaries, don't auto-retire
- **Clear tool-semantics paragraph** distinguishing `manage_goals` (workplace outcomes) from `set_team_goal` (per-team mission) from `rate_delivery` (per-task judgment).
- **Goals cap 20 → 10** in `manage_goals` for tighter operator cognitive load.
- **`_HEARTBEAT_TOOLS` allowlist updated** — `rate_delivery` and `manage_goals` now reachable from heartbeat ticks (without this, the new instructions are dead letter).
- **Sentinel migration fixed** — `HEARTBEAT_SENTINELS[-1]` drives refresh, not `any()`. Existing deployed operators on v2 now upgrade to v3 on next startup.

## Review trail

Two-pass review caught real bugs before merge:
- **Self-review** caught dead delivery-banner stubs (~30 LOC cruft) and removed.
- **Codex review** caught three must/should-fix items not in the original cutover:
  1. `rate_delivery` + `manage_goals` missing from `_HEARTBEAT_TOOLS` — fixed
  2. Sentinel migration `any()` skip — fixed in both `workspace.py` and `cli/config.py`
  3. Tell Operator "Sent" confirmation lying on HTTP failure — fixed by inspecting chat history tail

## Test plan

- [x] `ruff check src/ tests/` clean
- [x] All 896 tests across touched surfaces pass (`test_loop`, `test_workspace`, `test_operator_config`, `test_operator_heartbeat`, `test_operator_rate_delivery`, `test_operator_manage_goals`, `test_workplace_goals_endpoint`, `test_dashboard_ui`, `test_dashboard`)
- [x] `node --check src/dashboard/static/js/app.js` — JS parses
- [x] New regression test `test_existing_file_with_only_old_sentinel_is_refreshed` pins the v2→v3 upgrade path
- [ ] Manual browser walk-through (CLAUDE.md mandate for UI changes) — pending review of all 3 PRs together