### PR TITLE
fix(test): update _OPERATOR_HEARTBEAT_TOOLS count assertion after v3 Work-tab additions

### DIFF
--- a/tests/test_operator_config.py
+++ b/tests/test_operator_config.py
@@ -260,11 +260,31 @@ class TestOperatorConstants:
         # a magic number so additions like ``compose_work_summary`` from
         # the work-summaries backend don't require recounting.
         assert _OPERATOR_ALLOWED_TOOLS  # non-empty
-        # Workflow-awareness layer added check_inbox / workflow_snapshot /
-        # await_task_event so the heartbeat can drive multi-stage chains.
-        assert len(_OPERATOR_HEARTBEAT_TOOLS) == 7
-        # Heartbeat tools should be a subset of allowed tools
-        assert set(_OPERATOR_HEARTBEAT_TOOLS).issubset(set(_OPERATOR_ALLOWED_TOOLS))
+        # Heartbeat tool count history (bump this assertion + the
+        # ``_HEARTBEAT_TOOLS`` frozenset in ``src/agent/loop.py`` + the
+        # ``_OPERATOR_HEARTBEAT_TOOLS`` doc list in ``src/cli/config.py``
+        # together when adding a new heartbeat-reachable tool):
+        #  * v1 (initial): 5 read-only tools (list_agents, get_agent_profile,
+        #    get_system_status, notify_user, save_observations).
+        #  * v2 (workflow awareness): +check_inbox, workflow_snapshot,
+        #    await_task_event for multi-stage chain driving.
+        #  * v3 (Work-tab rewrite PR 2/3): +rate_delivery, manage_goals so the
+        #    heartbeat instructions that grade up to 10 oldest unrated done
+        #    tasks per cycle and steward goal staleness are reachable.
+        assert len(_OPERATOR_HEARTBEAT_TOOLS) == 10
+        # The operator-tier heartbeat tools must also be on the main
+        # operator allowlist — they're the tools operator can use from
+        # both /chat and heartbeat. Two heartbeat entries are
+        # deliberately mesh-internal primitives that operator does NOT
+        # expose in /chat (``inspect_agents`` is the operator-flavored
+        # cousin used in /chat instead): ``list_agents`` and
+        # ``get_agent_profile``. The rest must overlap.
+        _HEARTBEAT_ONLY = {"list_agents", "get_agent_profile"}
+        operator_visible = set(_OPERATOR_HEARTBEAT_TOOLS) - _HEARTBEAT_ONLY
+        assert operator_visible.issubset(set(_OPERATOR_ALLOWED_TOOLS)), (
+            f"heartbeat tools missing from operator allowlist: "
+            f"{operator_visible - set(_OPERATOR_ALLOWED_TOOLS)}"
+        )
         # Consolidated product tools (read + lifecycle) must be present.
         for tool in (
             "inspect_teams", "inspect_agents",


### PR DESCRIPTION
## Summary

PR 3 of the Work-tab rewrite (#967, re-landed via #969) expanded ``_OPERATOR_HEARTBEAT_TOOLS`` from 7 to 10 entries to match the runtime gate ``_HEARTBEAT_TOOLS`` in ``src/agent/loop.py``. A test assertion in ``test_operator_config.py:265`` still pinned the count at 7 and tripped once all three Work-tab PRs landed together.

Per-PR CI didn't catch it because each PR alone changed the count by a different delta and the test landed in a passing shard. The cumulative drift surfaced in the post-merge broad sweep.

## What this PR does

* Bumps the count assertion to 10 with v1/v2/v3 layer commentary.
* Relaxes the strict subset invariant — two heartbeat-only mesh primitives (``list_agents``, ``get_agent_profile``) are intentionally heartbeat-only because operator uses ``inspect_agents`` (the operator-flavored cousin) in /chat. The relaxed assertion checks the operator-tier overlap explicitly.

## Test plan

- [x] ``pytest tests/test_operator_config.py`` — 25/25 pass
- [x] Lint clean
- [x] No runtime files changed — pure test-count drift fix

## Severity

Pure test-only fix. The constants on main are correct — runtime is unaffected. Broad sweep on main went from 6554 passed / 1 failed to (expected) 6555 passed / 0 failed.