### PR TITLE
fix(llm,agent): retry OAuth empty-response + per-agent max_iterations override

### DIFF
--- a/src/agent/llm.py
+++ b/src/agent/llm.py
@@ -188,8 +188,11 @@ class LLMClient:
                     allowed_models=set(error_meta.get("allowed_models", [])),
                     http_status=error_meta.get("http_status"),
                 )
-            # Rate limits and transient errors should be retried
-            _retryable = ("rate limit", "ratelimit", "429", "too many requests", "overloaded", "503")
+            # Rate limits and transient errors should be retried.
+            # "empty response" is the Claude subscription throttle signal
+            # (Anthropic OAuth + OpenAI Codex paths emit it when the stream
+            # closes with zero content/tool_calls/thinking). Treat as transient.
+            _retryable = ("rate limit", "ratelimit", "429", "too many requests", "overloaded", "503", "empty response")
             if any(kw in error_msg.lower() for kw in _retryable):
                 raise LLMRetryableError(f"LLM call failed: {error_msg}")
             raise RuntimeError(f"LLM call failed: {error_msg}")

--- a/src/cli/runtime.py
+++ b/src/cli/runtime.py
@@ -435,6 +435,15 @@ class RuntimeContext:
             initial_interface = agent_cfg.get("initial_interface", "")
             if initial_interface:
                 agent_env["INITIAL_INTERFACE"] = initial_interface
+            # Per-agent task-loop iteration cap. Overrides the global
+            # OPENLEGION_MAX_ITERATIONS (from dashboard system settings,
+            # injected into extra_env above) because env_overrides is
+            # applied after extra_env in DockerBackend (see
+            # src/host/runtime.py line ~262). Clamping to 1-100 happens
+            # agent-side in _clamp_env (src/agent/loop.py).
+            agent_max_iters = agent_cfg.get("max_iterations")
+            if agent_max_iters is not None:
+                agent_env["OPENLEGION_MAX_ITERATIONS"] = str(agent_max_iters)
             if agent_id == _OPERATOR_AGENT_ID:
                 agent_env["ALLOWED_TOOLS"] = ",".join(_OPERATOR_ALLOWED_TOOLS)
                 # PR-L' — pass the boot greeting so the agent can seed

--- a/src/shared/types.py
+++ b/src/shared/types.py
@@ -512,6 +512,14 @@ class AgentConfig(BaseModel):
     # Credential handles in env/args resolved by the mesh at agent start.
     mcp_servers: list[MCPServerConfig] | None = None
 
+    # Per-agent override of the task-loop iteration cap (AgentLoop.MAX_ITERATIONS,
+    # default 20). High-fan-out workers (e.g. a translator emitting one PR per
+    # locale) need more headroom than the default. None = inherit the global
+    # OPENLEGION_MAX_ITERATIONS / hard-coded default. The agent-side reader
+    # (_clamp_env in src/agent/loop.py) clamps to 1-100 regardless of source,
+    # so an absurd value here can't blow the cap.
+    max_iterations: int | None = Field(default=None, ge=1, le=100)
+
     model_config = {"extra": "allow"}
 
     @field_validator("mcp_servers")

--- a/tests/test_llm.py
+++ b/tests/test_llm.py
@@ -1,0 +1,99 @@
+"""Unit tests for LLMClient — focused on the retryable-error classifier.
+
+The classifier at src/agent/llm.py:~192 decides whether a mesh-returned LLM
+failure is transient (raise LLMRetryableError → backoff retry in
+_llm_call_with_retry) or permanent (raise RuntimeError → fail the task).
+
+Operator reported tasks dying on "Anthropic OAuth error: Model X returned
+empty response" — the Claude subscription throttle signal. Pre-fix, that
+phrase matched no keyword in the _retryable tuple and fell through to a
+permanent RuntimeError, killing the task on the first throttle hit. This
+test pins the post-fix behavior: empty-response is now retryable.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from src.agent.llm import LLMClient, LLMRetryableError
+
+
+def _make_mesh_response(error_msg: str) -> MagicMock:
+    resp = MagicMock()
+    resp.raise_for_status = MagicMock()
+    resp.json = MagicMock(return_value={"success": False, "error": error_msg})
+    return resp
+
+
+def _make_llm_client() -> LLMClient:
+    client = LLMClient(
+        mesh_url="http://mesh.test",
+        agent_id="test-agent",
+        default_model="anthropic/claude-sonnet-4-6",
+    )
+    mock_http = AsyncMock()
+    client._get_client = AsyncMock(return_value=mock_http)
+    return client
+
+
+@pytest.mark.asyncio
+async def test_empty_response_classified_as_retryable():
+    """Claude subscription throttle ('empty response') must surface as
+    LLMRetryableError so _llm_call_with_retry backs off rather than
+    failing the task on the first occurrence."""
+    client = _make_llm_client()
+    mock_http = await client._get_client()
+    mock_http.post = AsyncMock(
+        return_value=_make_mesh_response(
+            "Anthropic OAuth error: Model anthropic/claude-sonnet-4-6 returned empty response",
+        ),
+    )
+    with pytest.raises(LLMRetryableError):
+        await client.chat(system="s", messages=[{"role": "user", "content": "x"}])
+
+
+@pytest.mark.asyncio
+async def test_non_stream_empty_response_no_choices_retryable():
+    """The non-stream OAuth path (credentials.py:~2687) emits
+    'LLM returned empty response (no choices) for model X' — same root
+    cause, must classify identically."""
+    client = _make_llm_client()
+    mock_http = await client._get_client()
+    mock_http.post = AsyncMock(
+        return_value=_make_mesh_response(
+            "LLM returned empty response (no choices) for model anthropic/claude-sonnet-4-6",
+        ),
+    )
+    with pytest.raises(LLMRetryableError):
+        await client.chat(system="s", messages=[{"role": "user", "content": "x"}])
+
+
+@pytest.mark.asyncio
+async def test_rate_limit_still_retryable():
+    """Pre-existing classifications must still fire — regression guard
+    for the keyword tuple extension."""
+    client = _make_llm_client()
+    mock_http = await client._get_client()
+    mock_http.post = AsyncMock(
+        return_value=_make_mesh_response("openai rate limit exceeded"),
+    )
+    with pytest.raises(LLMRetryableError):
+        await client.chat(system="s", messages=[{"role": "user", "content": "x"}])
+
+
+@pytest.mark.asyncio
+async def test_unrelated_runtime_error_still_permanent():
+    """Permanent failures must NOT be reclassified as retryable.
+    Budget-exhausted / config-error / invalid-prompt should still fail
+    the task immediately."""
+    client = _make_llm_client()
+    mock_http = await client._get_client()
+    mock_http.post = AsyncMock(
+        return_value=_make_mesh_response("Budget exceeded for agent test-agent"),
+    )
+    with pytest.raises(RuntimeError) as exc_info:
+        await client.chat(system="s", messages=[{"role": "user", "content": "x"}])
+    # Must NOT be the retryable subclass.
+    assert not isinstance(exc_info.value, LLMRetryableError)

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -379,6 +379,26 @@ def test_agent_config_keeps_extra_allow_for_outer_unknown_fields():
     assert dumped.get("some_legacy_field") == 42
 
 
+def test_agent_config_max_iterations_defaults_none():
+    """Unset max_iterations inherits the global cap (None sentinel)."""
+    c = AgentConfig(role="researcher")
+    assert c.max_iterations is None
+
+
+def test_agent_config_max_iterations_accepts_in_range():
+    """High-fan-out workers can opt into a larger task-loop cap."""
+    c = AgentConfig(role="locale-translator", max_iterations=80)
+    assert c.max_iterations == 80
+
+
+@pytest.mark.parametrize("bad_value", [0, -1, 101, 1000])
+def test_agent_config_max_iterations_rejects_out_of_range(bad_value):
+    """Mirror the agent-side _clamp_env range so misconfigurations
+    fail loudly at load time rather than silently being clamped."""
+    with pytest.raises(ValidationError):
+        AgentConfig(role="x", max_iterations=bad_value)
+
+
 def test_agent_config_nested_mcp_server_extras_still_forbidden():
     # extra=allow on the outer model does NOT leak into nested MCPServerConfig.
     with pytest.raises(ValidationError) as excinfo:


### PR DESCRIPTION
## Summary

Operator reported `locale-translator` failing the same logical task across 4 heartbeats with three different labels: 3× `Anthropic OAuth error: Model X returned empty response`, 1× `max_iterations_reached`. Root cause: the empty-response signal from the Claude subscription throttle was treated as a permanent failure (plain `RuntimeError`) and never reached the existing retry path. Compounded by a global 20-iter task cap that's structurally insufficient for ~6 tool-rounds × 12 locales = 70+ iter fan-out workers.

KISS plan, two surgical changes; full continuation-primitive proposal (`defer_remaining_work` / `done_partial`) deferred — likely unnecessary once T1+T2 ship.

### T1 — Empty-response is retryable (the real bug)

`src/agent/llm.py:192` — extend the `_retryable` keyword tuple with `"empty response"`. All four credentials.py emission sites (three OAuth stream paths + one non-stream `(no choices)` path) emit that substring, so one classifier line covers them all. The existing `_llm_call_with_retry` (5/10/20s backoff, `LLMRetryableError`) does the rest.

Streaming-path classifier (`agent/llm.py:280`) intentionally NOT extended — operator's failure is task-only (non-streaming chat). Same structural gap exists there; separate PR if/when a user-facing chat case surfaces.

### T2 — Per-agent `max_iterations` override

- `AgentConfig.max_iterations: int | None = Field(ge=1, le=100)` (`src/shared/types.py`)
- `src/cli/runtime.py` `_start_agents` populates `agent_env["OPENLEGION_MAX_ITERATIONS"]` from the per-agent value when set
- Existing `env_overrides` plumbing (DockerBackend env dict + SandboxBackend `.agent.env`) delivers it to the container
- Existing `_clamp_env(...)` at `src/agent/loop.py:242` picks it up on AgentLoop init — per-agent value wins over the global setting because `env_overrides` applies after `extra_env` in `host/runtime.py`

Out of T2 scope (revisit if data shows we need it):
- `HEARTBEAT_MAX_ITERATIONS=12` separate cap — locale-translator failure log shows `task_*` IDs (task path), not heartbeat-tick work
- Adding to `SOFT/HARD_EDIT_FIELDS` for live-edit — operator can set in YAML; live-edit can be follow-up

### Decisions made

- **Health-tracker side effect left as-is.** `credentials.py:1516` records `record_failure(model, "EmptyResponse", 0)` per-attempt — a successfully retried throttle still logs up to 3 health failures, which may briefly cool the model via failover. Accepted as backpressure (failover *should* react when the subscription misbehaves).
- **No new continuation primitive.** Existing blackboard-ledger pattern + `hand_off(to=self)` cover the operator's resume case. After T1+T2 each heartbeat task should be able to survive throttles AND finish all 12 locales, so the symptom dissolves before the primitive is justified.

## Test plan

- [x] 4 new tests in `tests/test_llm.py` — classifier matrix (OAuth-style empty-response, no-choices empty-response, rate-limit regression guard, negative case ensuring budget-exceeded stays permanent)
- [x] 3 new tests in `tests/test_types.py` — `max_iterations` default None, in-range accept, out-of-range reject (parametric)
- [x] Targeted suite: `tests/test_llm.py tests/test_types.py` — 52 passed
- [x] Broad spot-check: `test_llm test_llm_param_allowlist test_types test_credentials` — 340 passed minus 1 local-env failure (`test_credentials.py::test_missing_api_key_returns_error` — host has cached Anthropic OAuth tokens that the test does not clear; CI environment doesn't have them)
- [x] `ruff check` clean across all touched files
- [ ] CI green
- [ ] Verify in operator runtime: locale-translator heartbeat survives a throttle event and per-agent `max_iterations: 80` lifts the cap as expected