### PR TITLE
fix(llm,host,agent): typed transient-error channel for OAuth throttle signals

### DIFF
--- a/src/agent/llm.py
+++ b/src/agent/llm.py
@@ -188,11 +188,24 @@ class LLMClient:
                     allowed_models=set(error_meta.get("allowed_models", [])),
                     http_status=error_meta.get("http_status"),
                 )
-            # Rate limits and transient errors should be retried.
-            # "empty response" is the Claude subscription throttle signal
-            # (Anthropic OAuth + OpenAI Codex paths emit it when the stream
-            # closes with zero content/tool_calls/thinking). Treat as transient.
-            _retryable = ("rate limit", "ratelimit", "429", "too many requests", "overloaded", "503", "empty response")
+            if error_type == "transient":
+                # Mesh-tagged transient (Claude subscription throttle,
+                # stream interruption, empty-choices response). The mesh
+                # already classified it at the source — surface as
+                # retryable so ``_llm_call_with_retry`` backs off.
+                raise LLMRetryableError(f"LLM call failed: {error_msg}")
+            # Backstop for un-tagged transient signals — third-party SDKs,
+            # future wrapper sites not yet routed through the typed channel,
+            # or paths the mesh outer handler didn't catch. Each substring
+            # corresponds to a known transient pattern; ``retrying may
+            # help`` is the deliberate suffix appended by
+            # ``friendly_streaming_error`` (src/shared/utils.py:78), so
+            # matching on it recognizes the helper's contract rather than
+            # whack-a-mole'ing message text.
+            _retryable = (
+                "rate limit", "ratelimit", "429", "too many requests",
+                "overloaded", "503", "empty response", "retrying may help",
+            )
             if any(kw in error_msg.lower() for kw in _retryable):
                 raise LLMRetryableError(f"LLM call failed: {error_msg}")
             raise RuntimeError(f"LLM call failed: {error_msg}")

--- a/src/host/credentials.py
+++ b/src/host/credentials.py
@@ -28,7 +28,7 @@ import httpx
 
 from src.agent.attachments import convert_openai_image_blocks
 from src.host.transcript import sanitize_for_provider
-from src.shared.errors import LLMAuthError, LLMConfigError
+from src.shared.errors import LLMAuthError, LLMConfigError, LLMTransientError
 from src.shared.models import KEYLESS_PROVIDERS, get_known_provider_names
 from src.shared.types import CRED_HANDLE_RE, APIProxyRequest, APIProxyResponse
 from src.shared.utils import friendly_streaming_error, setup_logging
@@ -695,6 +695,29 @@ class CredentialVault:
                         "model": e.model,
                         "http_status": e.http_status,
                         "allowed_models": sorted(e.allowed_models),
+                    },
+                )
+            except LLMTransientError as e:
+                # Typed transient — Claude subscription throttle empty-
+                # responses, RemoteProtocolError stream interruptions, etc.
+                # Reach this branch only after ``_call_llm_with_failover``
+                # exhausted the chain (failover propagates non-permanent
+                # exceptions like this one through generic ``except
+                # Exception`` first). Tagging ``error_type="transient"``
+                # routes the agent classifier to ``LLMRetryableError`` so
+                # ``_llm_call_with_retry`` backs off and retries instead
+                # of failing the task on the first hit.
+                logger.info(
+                    "LLM transient failure for agent='%s' provider=%s model=%s: %s",
+                    agent_id, e.provider, e.model, e,
+                )
+                return APIProxyResponse(
+                    success=False, error=str(e),
+                    error_type="transient",
+                    error_meta={
+                        "provider": e.provider,
+                        "model": e.model,
+                        "retry_after": e.retry_after,
                     },
                 )
             except Exception as e:
@@ -1724,6 +1747,22 @@ class CredentialVault:
                 result = data
 
         if last_error:
+            # Inspect the collected stream error for transient signals
+            # the inner stream already classified. ``friendly_streaming_error``
+            # (src/shared/utils.py) deliberately appends ``"Retrying may
+            # help."`` to ``httpx.RemoteProtocolError`` / incomplete-chunked-
+            # read failures; the empty-stream emit at line 1848 yields
+            # ``"...returned empty response"`` for subscription throttles.
+            # Raise typed so the mesh outer handler tags
+            # ``error_type="transient"`` and the agent's classifier routes
+            # via ``LLMRetryableError`` instead of failing the task.
+            le_lower = last_error.lower()
+            if "retrying may help" in le_lower or "empty response" in le_lower:
+                raise LLMTransientError(
+                    f"Anthropic OAuth error: {last_error}",
+                    provider="anthropic",
+                    model=model,
+                )
             raise RuntimeError(f"Anthropic OAuth error: {last_error}")
 
         if not result:
@@ -2682,9 +2721,15 @@ class CredentialVault:
                     raise  # _raise_typed_llm_error re-raises on no match
                 # Empty choices = failed generation — raise so failover can
                 # try the next model instead of marking this one healthy.
+                # Typed transient: the mesh outer handler tags
+                # ``error_type="transient"`` so the agent's classifier
+                # routes via ``LLMRetryableError`` (matches the OAuth
+                # empty-stream signal at ``_oauth_chat`` line ~1727).
                 if not getattr(result, "choices", None):
-                    raise RuntimeError(
-                        f"LLM returned empty response (no choices) for model {model}"
+                    raise LLMTransientError(
+                        f"LLM returned empty response (no choices) for model {model}",
+                        provider=model.split("/", 1)[0] if "/" in model else "unknown",
+                        model=model,
                     )
                 return result
 

--- a/src/shared/errors.py
+++ b/src/shared/errors.py
@@ -7,10 +7,19 @@ these per-agent; threshold crossing triggers quarantine.
 (400 model_not_found). Task fails with actionable detail; agent is
 NOT quarantined (this is operator misconfig, not a broken credential).
 
+``LLMTransientError`` → upstream call hit a transient/retryable
+condition the mesh recognizes at the source (Claude subscription
+throttle empty-responses, ``RemoteProtocolError`` stream interruptions
+wrapped by ``friendly_streaming_error``). The mesh re-emits via
+``APIProxyResponse.error_type = "transient"``; the agent consumer
+routes that to ``LLMRetryableError`` so ``_llm_call_with_retry`` backs
+off. Replaces the substring-tuple-only path that left a new wrapper
+message unclassified each time a new transient signal appeared.
+
 ``LLMRetryableError`` already exists in :mod:`src.agent.llm` — leave it
 there for back-compat (transient failures, rate limits).
 
-Both classes inherit ``RuntimeError`` so existing ``except Exception``
+All classes inherit ``RuntimeError`` so existing ``except Exception``
 handlers keep working without modification.
 """
 from __future__ import annotations
@@ -53,3 +62,37 @@ class LLMConfigError(RuntimeError):
         self.model = model
         self.allowed_models = allowed_models or set()
         self.http_status = http_status
+
+
+class LLMTransientError(RuntimeError):
+    """Raised when the LLM call hit a transient/retryable condition — the
+    caller should back off and retry rather than fail the task.
+
+    Examples: Claude subscription throttle producing an empty stream,
+    ``httpx.RemoteProtocolError`` mid-stream (wrapped by
+    ``friendly_streaming_error``), LiteLLM returning no choices.
+
+    Falls through ``_call_llm_with_failover`` the same way bare
+    ``RuntimeError`` does today — failover to the next model in the
+    chain is attempted first, then the error propagates to
+    ``execute_api_call`` which serializes it as
+    ``APIProxyResponse(error_type="transient")``.
+    """
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        provider: str = "unknown",
+        model: str | None = None,
+        retry_after: float | None = None,
+    ) -> None:
+        super().__init__(message)
+        self.provider = provider
+        self.model = model
+        # Seconds — populated when the upstream signal carries explicit
+        # backoff guidance. ``_llm_call_with_retry`` honours ``Retry-After``
+        # via the existing ``httpx.HTTPStatusError`` path; surfacing this
+        # field positions the agent loop to extend that to typed transient
+        # errors in a follow-up without changing the exception shape.
+        self.retry_after = retry_after

--- a/tests/test_credentials.py
+++ b/tests/test_credentials.py
@@ -4518,6 +4518,47 @@ class TestLLMAuthAndConfigErrors:
         # Did NOT fire — config is misconfig, not credential failure.
         assert recorded == []
 
+    @pytest.mark.asyncio
+    async def test_execute_api_call_tags_transient_without_recording(self):
+        """``execute_api_call`` tags transient errors (Claude subscription
+        throttle empty-response, RemoteProtocolError stream interruption)
+        but does NOT call the auth-failure recorder — transient errors are
+        not credential failures and must not quarantine the agent. The
+        agent's classifier (src/agent/llm.py) routes ``error_type="transient"``
+        to ``LLMRetryableError`` so ``_llm_call_with_retry`` backs off."""
+        from src.shared.errors import LLMTransientError
+        from src.shared.types import APIProxyRequest
+        v = CredentialVault()
+        recorded: list[tuple] = []
+        v.set_auth_failure_recorder(
+            lambda *a: recorded.append(a),
+        )
+
+        async def _failing_handler(req):
+            raise LLMTransientError(
+                "Anthropic OAuth error: Connection to the AI provider was "
+                "interrupted. Retrying may help.",
+                provider="anthropic",
+                model="anthropic/claude-sonnet-4-6",
+            )
+
+        v.service_handlers["llm"] = _failing_handler
+
+        req = APIProxyRequest(
+            service="llm", action="chat",
+            params={"model": "anthropic/claude-sonnet-4-6", "messages": []},
+        )
+        resp = await v.execute_api_call(req, agent_id="agent-a")
+        assert resp.success is False
+        assert resp.error_type == "transient"
+        assert (resp.error_meta or {}).get("provider") == "anthropic"
+        assert (resp.error_meta or {}).get("model") == "anthropic/claude-sonnet-4-6"
+        # ``retry_after`` field exists on the meta (None by default) — the
+        # agent loop can use it later without changing the exception shape.
+        assert "retry_after" in (resp.error_meta or {})
+        # Recorder did NOT fire — transient isn't a credential failure.
+        assert recorded == []
+
 
 class TestLiteLLMTypedErrorClassification:
     """Codex P1 r3: LiteLLM exceptions (API-key path) must classify into

--- a/tests/test_llm.py
+++ b/tests/test_llm.py
@@ -20,10 +20,20 @@ import pytest
 from src.agent.llm import LLMClient, LLMRetryableError
 
 
-def _make_mesh_response(error_msg: str) -> MagicMock:
+def _make_mesh_response(
+    error_msg: str,
+    *,
+    error_type: str | None = None,
+    error_meta: dict | None = None,
+) -> MagicMock:
     resp = MagicMock()
     resp.raise_for_status = MagicMock()
-    resp.json = MagicMock(return_value={"success": False, "error": error_msg})
+    body: dict = {"success": False, "error": error_msg}
+    if error_type is not None:
+        body["error_type"] = error_type
+    if error_meta is not None:
+        body["error_meta"] = error_meta
+    resp.json = MagicMock(return_value=body)
     return resp
 
 
@@ -78,6 +88,54 @@ async def test_rate_limit_still_retryable():
     mock_http = await client._get_client()
     mock_http.post = AsyncMock(
         return_value=_make_mesh_response("openai rate limit exceeded"),
+    )
+    with pytest.raises(LLMRetryableError):
+        await client.chat(system="s", messages=[{"role": "user", "content": "x"}])
+
+
+@pytest.mark.asyncio
+async def test_transient_error_type_classified_as_retryable():
+    """Mesh-tagged ``error_type="transient"`` (the typed channel emitted by
+    ``execute_api_call`` when ``LLMTransientError`` propagates from the
+    OAuth wrap at credentials.py:~1727 or the LiteLLM empty-choices path
+    at credentials.py:~2685) must surface as ``LLMRetryableError`` so
+    ``_llm_call_with_retry`` backs off. Mirrors the existing
+    ``auth_failure`` / ``config_error`` typed branches."""
+    client = _make_llm_client()
+    mock_http = await client._get_client()
+    mock_http.post = AsyncMock(
+        return_value=_make_mesh_response(
+            "Anthropic OAuth error: Connection to the AI provider was "
+            "interrupted. Retrying may help.",
+            error_type="transient",
+            error_meta={
+                "provider": "anthropic",
+                "model": "anthropic/claude-sonnet-4-6",
+                "retry_after": None,
+            },
+        ),
+    )
+    with pytest.raises(LLMRetryableError):
+        await client.chat(system="s", messages=[{"role": "user", "content": "x"}])
+
+
+@pytest.mark.asyncio
+async def test_retrying_may_help_substring_retryable_backstop():
+    """Backstop path — when the mesh did NOT tag ``error_type="transient"``
+    (un-tagged third-party wrapper or a path the outer handler didn't
+    catch), the substring tuple must still classify ``"Retrying may help"``
+    as retryable. The phrase is the deliberate suffix from
+    ``friendly_streaming_error`` (src/shared/utils.py:78); matching it
+    keeps the helper's contract usable as a fallback signal even without
+    the typed channel."""
+    client = _make_llm_client()
+    mock_http = await client._get_client()
+    mock_http.post = AsyncMock(
+        return_value=_make_mesh_response(
+            "Anthropic OAuth error: Connection to the AI provider was "
+            "interrupted. Retrying may help.",
+            # No error_type tag — exercises the substring path.
+        ),
     )
     with pytest.raises(LLMRetryableError):
         await client.chat(system="s", messages=[{"role": "user", "content": "x"}])


### PR DESCRIPTION
## Summary

Follow-up to #971. Operator hit a third throttle variant that PR #971's substring tuple didn't cover:

> `"Anthropic OAuth error: Connection to the AI provider was interrupted. Retrying may help."`

This string is the deliberate suffix from `friendly_streaming_error` (`src/shared/utils.py:78`) wrapping `httpx.RemoteProtocolError` / incomplete-chunked-read failures. It reached the non-stream classifier via the OAuth wrapper at `credentials.py:1727` as `RuntimeError("Anthropic OAuth error: {last_error}")` — substring tuple didn't match, task died on first hit.

**Architectural finding**: `APIProxyResponse.error_type` already exists as a typed channel — `auth_failure` and `config_error` use it (`credentials.py:673/692`), and the agent classifier routes on it (`agent/llm.py:172-189`). The transient case was the missing third typed value. This PR completes the pattern instead of growing the substring tuple a third time.

## Changes (~25 LoC across 3 source files)

1. **`src/shared/errors.py`** — add `LLMTransientError(RuntimeError)` alongside `LLMAuthError` / `LLMConfigError`. Carries `provider`, `model`, optional `retry_after`.

2. **`src/host/credentials.py`**:
   - OAuth non-stream wrapper (`~1727`): elevate to `LLMTransientError` when `last_error` carries `"retrying may help"` or `"empty response"`. Non-transient errors keep their existing `RuntimeError` path.
   - LiteLLM empty-choices (`~2685`): unconditionally raise `LLMTransientError` (the existing comment already classified this as transient).
   - `execute_api_call` outer handler: new `except LLMTransientError` branch between `LLMConfigError` and the `Exception` catch-all → serializes `APIProxyResponse(error_type="transient", error_meta={provider, model, retry_after})`. Mirrors the existing typed shape; deliberately does **not** call the auth-failure recorder (transient is not credential failure, must not quarantine).

3. **`src/agent/llm.py`**:
   - New `error_type == "transient"` branch right after the `config_error` branch → raises `LLMRetryableError` so the existing `_llm_call_with_retry` backoff (5/10/20s, 3 attempts) handles retry.
   - Substring tuple gains `"retrying may help"` as defense-in-depth for any un-tagged path (third-party SDK errors, future wrappers).

## Failover semantics preserved

`LLMTransientError` propagates through `_call_llm_with_failover` via the generic `except Exception` (same as the bare `RuntimeError` it replaces). The failover chain is still attempted before the typed error reaches the outer handler — correct behavior since a subscription throttle on one model may resolve by trying the next.

## Scope explicitly held

- Streaming consumer at `agent/llm.py:280` still raises bare `RuntimeError` without classifier. Operator's bug is non-streaming. Same structural gap; separate PR when a streaming-side user surfaces.
- SSE error chunks at `credentials.py:1848/2603/3065` yield error payloads rather than raising. Plumbing typed errors through SSE is a larger refactor; deferred.
- `LLMTransientError.retry_after` exists on the type but `_llm_call_with_retry` only honours `Retry-After` on `httpx.HTTPStatusError` today. Field positions a follow-up to extend that path without changing the exception shape.
- Bug B (compaction symptoms) and Bug C (continuation primitive) per the operator report — deferred. Bug B symptoms are believed downstream of this fix; revisit with post-fix data.

## Test plan

- [x] 2 new tests in `tests/test_llm.py` — typed channel (`test_transient_error_type_classified_as_retryable`) + substring backstop (`test_retrying_may_help_substring_retryable_backstop`). 6/6 in file pass.
- [x] 1 new test in `tests/test_credentials.py` — `test_execute_api_call_tags_transient_without_recording`. Mirrors the existing `auth_failure` / `config_error` test shape. All 3 tagged-error tests pass.
- [x] `ruff check` clean across all touched files.
- [x] Full suite: 6569 passed, 20 pre-existing dev-box OAuth-bleed quirks (all in tests that load `CredentialVault` and trip on cached local OAuth tokens — CI passes them).
- [ ] CI green
- [ ] Verify in operator runtime: locale-translator handoff that previously died on `"Retrying may help"` now retries and survives.