### PR TITLE
docs: align README, docs/, and CLAUDE.md with current code

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -48,7 +48,7 @@ Only modules with non-obvious quirks worth flagging are listed. The rest are vis
 | `src/agent/builtins/skill_tool.py` | Self-authoring with AST validation (`_FORBIDDEN_IMPORTS` / `_FORBIDDEN_CALLS` / `_FORBIDDEN_ATTRS`) |
 | `src/agent/builtins/fleet_tool.py` | Operator-only `list_templates` / `apply_template`. Validates upfront; create loop is per-slot, not atomic (Constraint #3). |
 | `src/agent/builtins/operator_tools.py` | Operator-only orchestration. `edit_agent` is the unified edit surface (all fields apply immediately + undo receipt). `read_agent_config` is its inverse. `_OPERATOR_PERMISSION_CEILING` blocks `can_spawn` / `can_use_wallet`. |
-| `src/host/server.py` | Mesh FastAPI app — 100 endpoints, all permission-checked. `_RATE_LIMITS` enforces per-category limits. `_require_operator_or_internal` is a permission tier between standard agent auth and loopback-only `x-mesh-internal`. `pending_actions` is now delete-confirmations only. |
+| `src/host/server.py` | Mesh FastAPI app — 109 endpoints, all permission-checked. `_RATE_LIMITS` enforces per-category limits. `_require_operator_or_internal` is a permission tier between standard agent auth and loopback-only `x-mesh-internal`. `pending_actions` is now delete-confirmations only. |
 | `src/host/runtime.py` | RuntimeBackend ABC → DockerBackend / SandboxBackend. Container hardening enforced here. |
 | `src/host/credentials.py` | Two-tier credential vault (SYSTEM_*/CRED_*) + LLM API proxy. OpenAI OAuth support. |
 | `src/host/permissions.py` | Per-agent ACL (glob patterns, deny-all default). `browser_actions: list[str] \| None` narrows per-action surface (`None` = all allowed, `[]` = deny all). |

--- a/README.md
+++ b/README.md
@@ -108,8 +108,8 @@ OpenClaw is the most popular personal AI assistant framework — 200K+ GitHub st
 brilliant for single-user use. For production workloads and team deployments, it
 has documented problems:
 
-- **42,000+ exposed instances** with no authentication (Bitsight, Feb 2026)
-- **341 malicious skills** found stealing user data (Koi Security / The Hacker News)
+- **42,000+ exposed instances** with no authentication ([Bitsight, Feb 2026](https://www.bitsight.com/blog/openclaw-ai-security-risks-exposed-instances))
+- **341 malicious skills** found stealing user data ([Koi Security via The Hacker News](https://thehackernews.com/2026/02/researchers-find-341-malicious-clawhub.html))
 - **CVE-2026-25253**: one-click remote code execution
 - No per-agent cost controls — runaway spend is a real risk
 - No deterministic routing — a CEO agent (LLM) decides what runs next
@@ -229,6 +229,8 @@ connections.
   with lighter caps (128MB / 0.05 CPU).
 ```
 
+To reach an agent from the host, use the mesh proxy at `:8420`, not the agent's internal `:8400`.
+
 ### Trust Zones
 
 | Level | Zone | Description |
@@ -249,8 +251,8 @@ as a single FastAPI process.
 SQLite-backed key-value store with versioning, TTL, and garbage collection.
 Team agents' blackboard access is automatically scoped to `projects/{name}/*` —
 agents use natural keys (e.g. `tasks/research_abc123`) while the MeshClient
-transparently namespaces them under the team. Solo agents have no
-blackboard access.
+transparently namespaces them under the team. Solo agents have no automatic
+team scoping; they can access only keys explicitly granted via ACL.
 
 The on-disk prefix is `projects/{name}/*` — that's a backend storage
 namespace, not a domain term, and renaming it is intentionally out of
@@ -272,7 +274,7 @@ Agents never hold API keys. All external API calls route through the mesh.
 The vault uses a two-tier prefix system: `OPENLEGION_SYSTEM_*` for LLM
 provider keys (never agent-accessible) and `OPENLEGION_CRED_*` for agent-tier
 tool/service keys. Budget limits are enforced before dispatching LLM calls
-and token usage is recorded after each response.
+and token usage is recorded after each response. `OPENLEGION_SYSTEM_*` credentials are never resolvable by agents (mesh-proxy-only). `OPENLEGION_CRED_*` are gated by per-agent `allowed_credentials`. Misclassifying one as the other yields silent invisibility.
 
 ### Model Failover
 
@@ -305,8 +307,10 @@ Matching is **exact match (or `*`)** for `can_message`, `can_publish`, and `can_
 `browser_actions` semantics: `null` (default) = all known actions allowed; `["*"]` = explicit allow-all; specific list (e.g. `["browser_navigate", "browser_screenshot"]`) = narrow allowlist; `[]` = deny all browser use even when `can_use_browser` is true.
 
 Blackboard patterns use the `projects/{name}/*` namespace. When an agent joins a
-team, it receives read/write access to that namespace. Solo agents get
-empty blackboard permissions.
+team, it receives read/write access to that namespace. Solo agents have no
+automatic team scoping; they can access only keys explicitly granted via ACL.
+
+Team scope is enforced by default (env: `OPENLEGION_TEAM_SCOPE_MODE=enforce`). Agents in different teams cannot read each other's blackboard without explicit permission.
 
 ### Container Manager
 
@@ -324,13 +328,13 @@ Agent containers are slim — no browser. Browsing is handled by a shared browse
 - **Image**: `openlegion-browser:latest` (Camoufox stealth browser + KasmVNC)
 - **Resources**: 2–8GB RAM, 1–2 CPU, 512MB–2GB shared memory — scaled by `OPENLEGION_MAX_AGENTS` plan tier
 - **Ports**: 8500 (browser API) is the only exposed port. Per-agent KasmVNC instances run internally on 6100..6163 and are reverse-proxied by the mesh at `/agent-vnc/{agent_id}/...` (no direct port exposed to the host).
-- **Capacity**: 1, 5, or 10 concurrent browser sessions on the standard plan tiers; absolute cap 64 via `OPENLEGION_BROWSER_MAX_CONCURRENT` (legacy alias `MAX_BROWSERS`). Restart the browser service to apply a change.
+- **Capacity**: autoscales by `OPENLEGION_MAX_AGENTS` — ≤1 agent → 1 session; ≤5 → 5; ≤15 → min(N, 10); >15 → min(N, 30). Absolute cap 64 via `OPENLEGION_BROWSER_MAX_CONCURRENT` (legacy alias `MAX_BROWSERS`). Managed deployments may layer their own plan tiers on top of these autoscale rules. Restart the browser service to apply a change.
 
 ### Browser Capabilities
 
 Beyond the basic navigation/screenshot/click tools, the browser service ships with:
 
-- **CAPTCHA solving.** Optional 2captcha or capsolver provider configured per-fleet via `CAPTCHA_SOLVER_KEY` + `CAPTCHA_SOLVER_PROVIDER`. Solver credentials (`CAPTCHA_SOLVER_KEY`, `CAPTCHA_SOLVER_KEY_SECONDARY`, `CAPTCHA_SOLVER_PROXY_LOGIN`, `CAPTCHA_SOLVER_PROXY_PASSWORD`) are env-only by design — they bypass the `OPENLEGION_CRED_*` vault and are stripped from `config/settings.json` at load (`_ENV_ONLY_FLAGS` in `src/browser/flags.py`). Auto-solve runs after `browser_navigate`; behavioral / persistent challenges escalate to `request_captcha_help` which posts a card to the dashboard for the user to clear via the live VNC viewer. Disabled fleet-wide with `CAPTCHA_DISABLED=1`.
+- **CAPTCHA solving.** Optional 2captcha or capsolver provider configured per-fleet via `CAPTCHA_SOLVER_KEY` + `CAPTCHA_SOLVER_PROVIDER`. Solver credentials (`CAPTCHA_SOLVER_KEY`, `CAPTCHA_SOLVER_KEY_SECONDARY`, `CAPTCHA_SOLVER_PROXY_LOGIN`, `CAPTCHA_SOLVER_PROXY_PASSWORD`) are env-only by design — they bypass the `OPENLEGION_CRED_*` vault and are stripped from `config/settings.json` at load (`_ENV_ONLY_FLAGS` in `src/browser/flags.py`). Auto-solve runs after `browser_navigate`; behavioral / persistent challenges escalate to `request_captcha_help` which posts a card to the dashboard for the user to clear via the live VNC viewer. Disabled fleet-wide with `CAPTCHA_DISABLED=1`. Behavioral / vendor JS challenges that 2captcha and capsolver cannot solve escalate via `request_captcha_help`, surfacing a VNC card to the user.
 - **Per-agent + per-tenant solver cost caps.** `CAPTCHA_COST_LIMIT_USD_PER_AGENT_MONTH` and `CAPTCHA_COST_LIMIT_USD_PER_TENANT_MONTH` enforce monthly spend with 50/80/100% threshold alerts. Per-tenant rollups available at `/dashboard/api/billing/captcha-rollup` (requires a dashboard session cookie and the `X-Requested-With` CSRF header).
 - **Fingerprint health monitoring.** A rolling per-agent rejection window detects when a fingerprint is "burned" (>50% rejection over the last 10 events across Cloudflare / DataDome / PerimeterX / Imperva / Akamai BMP signals); subsequent CAPTCHA envelopes carry `fingerprint_burn=True` and a `retry_with_fresh_profile` hint. Operator clears state manually after profile rotation.
 - **JS-challenge detection.** Vendor-specific selectors detect Cloudflare 1xxx / Under Attack / Press & Hold and similar interstitials before the agent attempts to extract content.
@@ -391,7 +395,7 @@ block (permissions, budget, fleet, cron), and searches memory for relevant facts
 Executes tool calls in a bounded loop with three caps from `loop.py`:
 `CHAT_MAX_TOOL_ROUNDS=30` per turn, `CHAT_MAX_TOTAL_ROUNDS=200` total before
 auto-compaction kicks in, and `_MAX_SESSION_CONTINUES=5` auto-continuations
-(after which the session halts with an error rather than continuing forever).
+(hardcoded, not env-overridable — after which the session halts with an error rather than continuing forever).
 
 ### Tool Loop Detection
 
@@ -583,6 +587,10 @@ activity exists, and no probes triggered, the dispatch is skipped entirely
 This 5-stage architecture (scheduler → probes → context → policy → action)
 makes always-on agents economically viable.
 
+### Task Hand-off & Auto-close
+
+Handed-off tasks auto-transition to terminal status (`done`/`failed`) only when the wake chain carries `x-task-id` (via `hand_off`'s task_id propagation). Legacy callers, heartbeats, and manual chats won't auto-close — intentional.
+
 ### Webhook Endpoints
 
 Named webhook URLs that dispatch payloads to agents. Create one from the
@@ -590,8 +598,10 @@ dashboard (System → Automation) or via the mesh API; the URL it returns is
 what you POST to. Payloads are sanitized and capped at 1MB.
 
 ```bash
-# Replace hook_a1b2c3d4 with the ID returned when you created the hook.
-curl -X POST http://localhost:8420/webhook/hook/hook_a1b2c3d4 \
+# The full URL is returned in the `url` field of the `POST /api/webhooks`
+# response (and listed on System → Automation in the dashboard). Pattern:
+#   {base}/webhook/hook/{hook_id}    e.g. http://localhost:8420/webhook/hook/hook_3f9a1c8b2d4e6f70
+curl -X POST "$WEBHOOK_URL" \
   -H "Content-Type: application/json" \
   -d '{"event": "push", "repo": "myproject"}'
 ```
@@ -632,6 +642,10 @@ Defense-in-depth with six layers:
 | Input validation | Path traversal prevention, SSRF blocking, safe condition eval (no `eval()`), token budgets, iteration limits, rate limiting | Injection, runaway loops, network abuse |
 | Unicode sanitization | Invisible character stripping at ~110 call sites across 17 source files, covering all external input boundaries | Prompt injection via hidden Unicode |
 
+Per-agent rate limits on 17 mesh endpoints (token bucket; HTTP 429 + audit log on overflow). See [`docs/security.md`](docs/security.md) for the full table.
+
+Containers run with `no-new-privileges`, `cap_drop=ALL`, `read_only=True`, `/tmp` tmpfs (100MB noexec/nosuid), UID 1000. Skills self-authored by agents pass AST validation (23 forbidden imports, 16 forbidden calls, 11 forbidden attrs).
+
 ### Dual Runtime Backend
 
 OpenLegion supports two isolation levels:
@@ -644,7 +658,7 @@ OpenLegion supports two isolation levels:
 | **Requirements** | Any Docker install | Docker Desktop 4.58+ |
 | **Enable** | `openlegion start` | `openlegion start --sandbox` |
 
-**Docker containers** (default) run agents as non-root with `no-new-privileges`, 384MB memory limit, 0.15 CPU cap, and no host filesystem access. Browser operations are handled by a shared browser service container (2–8GB RAM scaled by fleet size, 1 CPU). This is secure for most use cases.
+**Docker containers** (default) run agents as non-root with `no-new-privileges`, 384MB memory limit, 0.15 CPU cap, and no host filesystem access. Browser operations are handled by a shared browser service container (2–8GB RAM, 0.15–4.0 CPU — scaled by fleet size). This is secure for most use cases.
 
 **Docker Sandbox microVMs** give each agent its own Linux kernel via Apple Virtualization.framework (macOS) or Hyper-V (Windows). Even if an agent achieves code execution, it's trapped inside a lightweight VM with no visibility into other agents or the host. Use this when running untrusted code or when compliance requires hypervisor isolation.
 
@@ -716,6 +730,8 @@ openlegion [--verbose/-v] [--quiet/-q] [--json]
 Aliases: /exit = /quit, /agents = /status, /debug = /traces
 ```
 
+All `/edit` and `/agent edit` changes apply immediately. Soft-field edits (instructions, soul, heartbeat, heartbeat_schedule, interface, role) are undoable for 5 minutes; hard-field edits (model, permissions, budget, thinking) are undoable for 30 minutes.
+
 ### Team Templates
 
 Templates are offered during first-run setup (via `openlegion start`):
@@ -763,6 +779,8 @@ Ship the email personalization pipeline this week
 - Budget: $50/day total across all agents
 - No cold outreach to .edu or .gov domains
 ```
+
+Workspace files have per-file size caps (4–16 KB; HEARTBEAT.md uncapped). See [`docs/configuration.md`](docs/configuration.md) for the table.
 
 ### `config/mesh.yaml` — Framework Settings
 
@@ -828,7 +846,7 @@ OPENLEGION_LOG_FORMAT=text
 
 # Plan limits (0 = unlimited). HTTP 403 once exceeded.
 # OPENLEGION_MAX_AGENTS=0
-# OPENLEGION_MAX_TEAMS=0   # legacy alias: OPENLEGION_MAX_PROJECTS
+# OPENLEGION_MAX_PROJECTS=0   # new name: OPENLEGION_MAX_TEAMS
 ```
 
 ### Connecting Channels

--- a/docs/agent-tools.md
+++ b/docs/agent-tools.md
@@ -12,11 +12,11 @@ Agents interact with their environment through **skills** -- Python functions re
 
 ### File Operations
 
-All file operations are scoped to `/data` inside the container. Path traversal is blocked (two-stage: reject `..` then resolve symlinks via `lstat()`). `_MAX_READ=500_000`, `_MAX_LIST_ENTRIES=500`. Direct writes to `SOUL.md` / `AGENTS.md` / `INSTRUCTIONS.md` / `HEARTBEAT.md` / `USER.md` / `MEMORY.md` are blocked — use `update_workspace`.
+All file operations are scoped to `/data` inside the container. Path traversal is blocked (two-stage: reject `..` then resolve symlinks via `lstat()`). `_MAX_READ=500_000`, `_MAX_LIST_ENTRIES=500`. Direct writes to `SOUL.md` / `AGENTS.md` / `INSTRUCTIONS.md` / `HEARTBEAT.md` / `USER.md` / `MEMORY.md` / `INTERFACE.md` are blocked — use `update_workspace`.
 
 | Tool | Parameters | Description |
 |------|-----------|-------------|
-| `read_file` (`loop_exempt=True`) | `path`, `offset` (default 0, 0-based line), `limit` (default 0 = read all) | Read file contents with optional pagination |
+| `read_file` | `path`, `offset` (default 0, 0-based line), `limit` (default 0 = read all) | Read file contents with optional pagination |
 | `write_file` | `path`, `content`, `append` (default false) | Write or append to a file (creates directories) |
 | `list_files` | `path` (default "."), `pattern` (default "*"), `recursive` (default false) | List files with optional glob pattern matching |
 
@@ -24,7 +24,7 @@ All file operations are scoped to `/data` inside the container. Path traversal i
 
 | Tool | Parameters | Description |
 |------|-----------|-------------|
-| `http_request` (`loop_exempt=True`) | `url`, `method` (default "GET"), `headers` (default {}), `body` (default "", string), `timeout` (default 30) | Make HTTP requests (GET/POST/PUT/DELETE/PATCH). Supports `$CRED{name}` handles in URL, headers, and body for credential-blind API calls. Resolved credentials are redacted from responses. SSRF protection blocks requests to private/internal addresses (loopback, link-local, reserved ranges) including redirect targets — re-validated at each hop, max `_MAX_REDIRECTS=5`. Authorization header is stripped on cross-origin redirects. **Note:** `body` must be a string — serialize JSON manually before passing it (e.g. `json.dumps(data)`). |
+| `http_request` | `url`, `method` (default "GET"), `headers` (default {}), `body` (default "", string), `timeout` (default 30) | Make HTTP requests (GET/POST/PUT/DELETE/PATCH). Supports `$CRED{name}` handles in URL, headers, and body for credential-blind API calls. Resolved credentials are redacted from responses. SSRF protection blocks requests to private/internal addresses (loopback, link-local, reserved ranges) including redirect targets — re-validated at each hop, max `_MAX_REDIRECTS=5`. Authorization header is stripped on cross-origin redirects. **Note:** `body` must be a string — serialize JSON manually before passing it (e.g. `json.dumps(data)`). |
 
 ### Browser Automation
 
@@ -37,7 +37,7 @@ An OS-level device profile is selected by `BROWSER_DEVICE_PROFILE` (`desktop-win
 | `browser_navigate` | `url`, `wait_ms` (default 1000, capped at 10000), `wait_until` (`domcontentloaded` default / `load` / `networkidle` / `commit`), `snapshot_after` (default false), `referer` | Open URL, wait, extract page text. `referer` unset → service auto-picks; `""` → explicit no-referer; URL → caller override. Returns `{success, data: {url, title, body}, captcha?, snapshot?}` — `body` is a 1000-char preview when `snapshot_after=true`, 5000 chars otherwise. Auto-detects CAPTCHA after load and may auto-solve, charging cost (see CAPTCHA solving below); the `captcha` field appears only when a CAPTCHA was detected and not solved. |
 | `browser_warmup` | `target_url` (http/https), `intensity` (default `normal`; values: `light` / `normal` / `deep`) | Pre-task warmup that hits a search engine then the target's apex host so the session has a realistic browsing trail. Call once at session start before automating behavior-fingerprinting targets (LinkedIn, X/Twitter, Facebook, Instagram). NOT for casual sites; do NOT repeat per session. `light` = search only (1 nav); `normal` = search + apex (2 navs); `deep` = search + scroll + apex + scroll (4 actions). |
 | `browser_get_elements` | `filter` (`actionable` / `inputs` / `headings` / `landmarks`), `from_ref`, `diff_from_last` (default false), `frame` (URL substring or `f-xxxxxxxx` frame_id), `include_frames` (default true) | Accessibility tree snapshot with element refs (e1, e2, ...). Returns structured text, not a visual image. Capped at 200 elements; iframe nesting capped at 3 levels. `diff_from_last=true` returns only what changed since the prior snapshot. |
-| `browser_screenshot` (`loop_exempt=True`) | `full_page` (default false), `format` (`webp` default / `png`), `quality` (1-100, default 75), `scale` (0.5-1.0, default 1.0) | Take screenshot, return visual image. Default format is **WebP**; falls back to PNG if WebP encoding fails. |
+| `browser_screenshot` | `full_page` (default false), `format` (`webp` default / `png`), `quality` (1-100, default 75), `scale` (0.5-1.0, default 1.0) | Take screenshot, return visual image. Default format is **WebP**; falls back to PNG if WebP encoding fails. |
 | `browser_click` | `ref` or `selector`, `force` (default false), `snapshot_after` (default false), `timeout_ms` (default 10000, max 30000), `frame` | Click element by accessibility ref or CSS selector. `force` bypasses actionability checks (auto-applied for disabled button/link refs). Modal close-button clicks fall back to Escape if the modal persists. Returns `{success, data: {ref, ...}, captcha?}` — auto re-detects CAPTCHA after click. |
 | `browser_click_xy` | `x`, `y` (viewport-relative CSS pixels) | Coordinate-based click for canvas/SVG widgets without a11y nodes. Pre-checks the target via `elementFromPoint` and walks the ancestor chain — returns an `invalid_input` envelope with `actual_element` + `masked_by` when an overlay would intercept the click. Rejects bools, NaN/Inf, and out-of-viewport coords. |
 | `browser_type` | `ref` or `selector`, `text`, `clear` (default true), `fast` (default false), `snapshot_after` (default false), `frame` | Type into input field. `clear=false` appends rather than replacing. `fast=true` sets the value directly without keystrokes. |
@@ -102,7 +102,7 @@ An OS-level device profile is selected by `BROWSER_DEVICE_PROFILE` (`desktop-win
 
 | Tool | Parameters | Description |
 |------|-----------|-------------|
-| `update_workspace` | `filename`, `content` | Update a writable workspace file (`SOUL.md`, `INSTRUCTIONS.md`, `USER.md`, `HEARTBEAT.md`, or `INTERFACE.md`) to persist learnings across sessions |
+| `update_workspace` | `filename`, `content` | Update a writable workspace file (`SOUL.md`, `INSTRUCTIONS.md`, `USER.md`, `HEARTBEAT.md`, `INTERFACE.md`, `OBSERVATIONS.md`, `GOALS.md`, or `GOALS.json`) to persist learnings across sessions |
 
 ### Scheduling & Automation
 
@@ -127,7 +127,7 @@ An OS-level device profile is selected by `BROWSER_DEVICE_PROFILE` (`desktop-win
 | `spawn_fleet_agent` | `role`, `system_prompt` (default ""), `ttl` (default 3600s) | Spawn a new agent in its own isolated container with independent tools, memory, and environment. The agent joins the fleet as a peer. Permission gate: `permissions.can_spawn` (operator cannot grant this). |
 
 **AST validation for `create_skill`.** The submitted source is parsed and rejected if it touches any of:
-- `_FORBIDDEN_IMPORTS` (24 modules): `os`, `subprocess`, `shutil`, `ctypes`, `importlib`, `socket`, `sys`, `signal`, `multiprocessing`, `threading`, `pathlib`, `io`, `tempfile`, `pty`, `code`, `gc`, `inspect`, `pickle`, `shelve`, `http`, `asyncio`, `resource`, `builtins`.
+- `_FORBIDDEN_IMPORTS` (23 modules): `os`, `subprocess`, `shutil`, `ctypes`, `importlib`, `socket`, `sys`, `signal`, `multiprocessing`, `threading`, `pathlib`, `io`, `tempfile`, `pty`, `code`, `gc`, `inspect`, `pickle`, `shelve`, `http`, `asyncio`, `resource`, `builtins`.
 - `_FORBIDDEN_CALLS` (16): `eval`, `exec`, `__import__`, `compile`, `globals`, `locals`, `getattr`, `setattr`, `delattr`, `breakpoint`, `open`, `type`, `vars`, `dir`, `memoryview`, `super`.
 - `_FORBIDDEN_ATTRS` (11): `__builtins__`, `__import__`, `__subclasses__`, `__class__`, `__bases__`, `__mro__`, `__globals__`, `__code__`, `__reduce__`, `__dict__`, `builtins`.
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -69,7 +69,7 @@ The mesh host runs on the user's machine as a single FastAPI process. It is the 
 | Module | Responsibility |
 |--------|---------------|
 | `mesh.py` | Blackboard (SQLite WAL, atomic CAS, audit log with undo/archive), PubSub, MessageRouter (with cross-team block + capability-based addressing) |
-| `server.py` | FastAPI app factory — 98 `@app.*` endpoints, all permission-checked. Three auth tiers (any-auth / operator-or-internal / loopback). |
+| `server.py` | FastAPI app factory — 109 `@app.*` endpoints, all permission-checked. Three auth tiers (any-auth / operator-or-internal / loopback). |
 | `runtime.py` | `RuntimeBackend` ABC → `DockerBackend` / `SandboxBackend`; the browser-service container lives here too. SandboxBackend falls back to DockerBackend on init failure. |
 | `transport.py` | `Transport` ABC → `HttpTransport` / `SandboxTransport` |
 | `credentials.py` | Two-tier credential vault (`OPENLEGION_SYSTEM_*` / `OPENLEGION_CRED_*`) + LLM API proxy. OpenAI / Anthropic OAuth support. |

--- a/docs/channels.md
+++ b/docs/channels.md
@@ -17,7 +17,7 @@ Every channel provides a unified interface:
 All four external adapters inherit from `Channel` in `src/channels/base.py` and share:
 
 - **PairingManager** — one shared protocol (`/start <code>` claims ownership, `/allow` / `/revoke` / `/paired` per-owner) backs the pairing table shown for each channel below. The four channels are not independent flows.
-- **`sanitize_for_prompt()` on all inbound messages** — every text reaching the LLM passes through the shared sanitizer (`base.py:224`), which strips invisible Unicode and prompt-injection markers.
+- **`sanitize_for_prompt()` on all inbound messages** — every text reaching the LLM passes through the shared sanitizer (`base.py:224`), which strips invisible Unicode characters (Cc/Cf/Co/Cs/Cn categories plus variation selectors and zero-width joiners) that enable prompt injection. Credential redaction is a separate concern handled by `src/shared/redaction.py`.
 - **`MessageOrigin` stamping** — every inbound channel message is tagged with `MessageOrigin(kind="human", channel=<channel_type>, user=<user_id>)` (`base.py:246-254`). This is what lets a busy agent's reply route back to the originating user/channel after a hand-off completes (see [Notifications & Auto-Notify](#notifications--auto-notify)).
 - **`chunk_text()` helper** — splits long responses against per-platform message size limits.
 - **Streaming debounce** — Telegram, Discord, and Slack all share `_EDIT_INTERVAL = 0.5` seconds (500 ms) to batch progressive edits and stay under platform rate limits.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -73,6 +73,7 @@ model: anthropic/claude-haiku-4-5-20251001
 model: anthropic/claude-sonnet-4-6
 
 # OpenAI
+model: openai/gpt-4o-mini
 model: openai/gpt-4.1-mini
 model: openai/gpt-4.1
 
@@ -81,10 +82,24 @@ model: gemini/gemini-2.5-flash
 
 # Other supported providers
 model: deepseek/deepseek-chat
-model: xai/grok-2
+model: xai/grok-4
 model: groq/llama-3.3-70b-versatile
-model: zai/glm-4-plus
+model: zai/glm-5
 ```
+
+### Workspace File Size Limits
+
+Per-agent workspace files (seeded by `soul`, `initial_instructions`, `initial_interface`, and edited at runtime via `PUT /workspace/{filename}`) are size-capped server-side. Writes that exceed the cap return HTTP 413. Caps are defined in `src/agent/server.py:_FILE_CAPS`.
+
+| File | Cap (bytes) |
+|------|-------------|
+| `SOUL.md` | 4000 |
+| `INSTRUCTIONS.md` | 12000 |
+| `AGENTS.md` | 12000 |
+| `USER.md` | 4000 |
+| `MEMORY.md` | 16000 |
+| `HEARTBEAT.md` | uncapped |
+| `INTERFACE.md` | 4000 |
 
 ## `config/mesh.yaml`
 
@@ -291,9 +306,10 @@ Beyond credentials, these environment variables affect runtime behavior:
 | `THINKING` | `off` | Extended thinking/reasoning mode (set automatically from `thinking` in agents.yaml) |
 | `PROJECT_NAME` | -- | Team this agent belongs to (set automatically for team members). Env-var name is retained through PR 2 of the project→team rename. |
 | `EMBEDDING_MODEL` | `text-embedding-3-small` | Embedding model for memory vector search (set automatically from `llm.embedding_model` in mesh.yaml). Set to `"none"` to disable vector search |
-| `OPENLEGION_MAX_AGENTS` | `0` | Plan limit: maximum agents to start. `0` means unlimited. If set to N > 0, only the first N agents are started. **Also drives plan-aware browser-service sizing** (`src/host/runtime.py:start_browser_service`) — the browser container's memory, SHM, CPU quota, and `MAX_BROWSERS` cap are selected by the `max_agents <= 1` / `<= 5` / `> 5` branches: ≤1 → Basic (2GB / 512m / 1.0 CPU / 1 browser), ≤5 → Growth (4GB / 1g / 1.5 CPU / N browsers), >5 → Pro (8GB / 2g / 2.0 CPU / `min(N, 10)` browsers). Note: `OPENLEGION_MAX_AGENTS=0` (the default, meaning "unlimited agents") falls into the `<= 1` branch and selects the **Basic** browser-service tier — counterintuitive but intentional for self-host installs that haven't declared a plan. |
+| `OPENLEGION_MAX_AGENTS` | `0` | Plan limit: maximum agents to start. `0` means unlimited. If set to N > 0, only the first N agents are started. **Also drives plan-aware browser-service sizing** (`src/host/runtime.py:506-526`) — the browser container's memory, SHM, CPU quota, and `max_browsers` cap are selected across four `max_agents` tiers (see **Browser-Service Sizing Tiers** below). Note: `OPENLEGION_MAX_AGENTS=0` (the default, meaning "unlimited agents") falls into the `≤1` branch and selects the **Basic** browser-service tier — counterintuitive but intentional for self-host installs that haven't declared a plan. |
 | `OPENLEGION_MAX_TEAMS` (alias `OPENLEGION_MAX_PROJECTS`) | -- | Plan limit. Three-state semantics: **unset** (env var absent) → teams are unlimited; **set to `0`** → teams are disabled entirely, `POST /mesh/teams` returns HTTP 403; **set to N > 0** → only N teams are allowed. The new var name is the canonical read; the legacy one is preserved as a permanent zero-cost fallback for existing deploys. |
 | `OPENLEGION_TEAM_SCOPE_MODE` (alias `OPENLEGION_PROJECT_SCOPE_MODE`) | `enforce` | Team-scope rollout kill switch. Accepts `"warn"` or `"enforce"` (case-insensitive via `.lower()`). Invalid values default to `"enforce"` with a WARNING. **Read once at module import — restart the mesh to change.** Legacy var name preserved as a permanent fallback. |
+| `OPENLEGION_SKIP_TRUST_TIER_BOOT_GATE` | -- | Bypass the fail-closed startup gate that refuses to boot when `OPENLEGION_TEAM_SCOPE_MODE=enforce` and `auth_tokens` is empty (an unverifiable `X-Agent-ID` header would otherwise make the operator trust tier forgeable). Set to `"1"` to skip the gate. Used by `tests/conftest.py` for in-process test sessions; not for production deploys (`src/host/server.py`). |
 | `OPENLEGION_TEAM_MIGRATION_RENAME_DB` | `1` | DB column rename `tasks.project_id` → `tasks.team_id` on startup. Default-on as of PR 3 of the project→team rename; set to `0` to opt out for emergency rollback. The orchestration layer introspects the live column at init via PRAGMA so either schema shape works without source changes. |
 | `OPENLEGION_ORCHESTRATION_TASKS_V2` | `1` | Toggle the durable orchestration v2 tasks store. `"1"` enables; `"0"` falls back to the legacy blackboard task path. **Read once at module import — restart the mesh to flip.** |
 | `OPENLEGION_ORCHESTRATION_TASKS_DB` | `data/tasks.db` | Override the SQLite path for the orchestration v2 tasks store. |
@@ -304,7 +320,7 @@ Beyond credentials, these environment variables affect runtime behavior:
 | `OPENLEGION_SYSTEM_WALLET_MASTER_SEED` | -- | BIP-39 mnemonic (24 words) for HD wallet key derivation. Required to enable wallet features. Generate with `openlegion wallet init`. |
 | `OPENLEGION_WALLET_LIMIT_PER_TX_USD` | `10.0` | Default per-transaction USD cap applied when an agent's `wallet_spend_limit_per_tx_usd` is `0`. |
 | `OPENLEGION_WALLET_LIMIT_DAILY_USD` | `100.0` | Default daily aggregate USD cap applied when an agent's `wallet_spend_limit_daily_usd` is `0`. |
-| `OPENLEGION_WALLET_RATE_LIMIT_PER_HOUR` | `10` | Default transactions-per-hour cap applied when an agent's `wallet_rate_limit_per_hour` is `0`. |
+| `OPENLEGION_WALLET_RATE_LIMIT_PER_HOUR` | `10000` | Default transactions-per-hour cap applied when an agent's `wallet_rate_limit_per_hour` is `0`. |
 | `BROWSER_OS` | `windows` | OS fingerprint for Camoufox browser: `windows`, `macos`, or `linux`. Windows is recommended (≈70% desktop market share; Linux is a datacenter signal). |
 | `BROWSER_LOCALE` | `en-US` | BCP-47 locale tag for browser fingerprint (e.g. `en-US`, `de-DE`). |
 | `BROWSER_UA_VERSION` | -- | Override Firefox version in User-Agent string (e.g. `138.0`). Useful when Camoufox's bundled Firefox is too old for sites that enforce minimum browser versions (e.g. Shopify). Uses Camoufox's native config system. Ignored when a non-default `BROWSER_DEVICE_PROFILE` pins its own UA. |
@@ -323,6 +339,8 @@ Beyond credentials, these environment variables affect runtime behavior:
 | `OPENLEGION_SYSTEM_PROXY` | -- | System-wide outbound HTTP proxy URL for all agent traffic. Managed via the dashboard proxy settings page. |
 | `HTTP_PROXY` / `HTTPS_PROXY` | -- | Per-agent proxy URLs. Auto-injected into agent containers by the runtime when a per-agent proxy is configured. Read by the agent-side `http_request` tool. |
 | `OPENLEGION_TOOL_TIMEOUT` | `300` | Per-tool execution timeout in seconds (hard ceiling). |
+| `OPENLEGION_LANE_TIMEOUT_SECONDS` | `900` | Per-agent task queue timeout in seconds (`src/host/lanes.py`). |
+| `OPENLEGION_LOOP_STALE_SECONDS` | `900` | Stale loop detection threshold in seconds — agent reachable + queue depth > 0 + no iteration in window (`src/host/health.py`). |
 | `OPENLEGION_MAX_ITERATIONS` | `20` | Maximum agent loop iterations per task (clamped 1–100). Overrides the default at the agent level. |
 | `OPENLEGION_CHAT_MAX_TOOL_ROUNDS` | `30` | Maximum tool rounds per chat turn (clamped 1–200). |
 | `OPENLEGION_CHAT_MAX_TOTAL_ROUNDS` | `200` | Maximum total chat rounds before session auto-continuation (clamped 1–1000). |
@@ -331,6 +349,17 @@ Beyond credentials, these environment variables affect runtime behavior:
 | `OPENLEGION_REDACTION_URL_QUERY_ALLOW` | -- | Comma-separated list of URL query parameter names that the unified redactor (`src/shared/redaction.py`) should NOT redact. Use to keep specific identifiers visible in browser logs / artifacts when an integration intentionally puts non-secret context in the query string. |
 
 The mesh port is configured in `config/mesh.yaml` (`mesh.port`), not via environment variable.
+
+### Browser-Service Sizing Tiers
+
+Selected by `OPENLEGION_MAX_AGENTS` at `start_browser_service` (`src/host/runtime.py:506-526`). `cpu (µs)` is the Docker `cpu_quota` against the default 100,000µs period (e.g. `200000` = 2.0 CPU). `N` is the resolved `max_agents` value.
+
+| Tier | mem | shm | cpu (µs) | max_browsers |
+|---|---|---|---|---|
+| ≤1 agents | 2g | 512m | 100000 | 1 |
+| ≤5 agents | 4g | 1g | 150000 | N |
+| ≤15 agents | 8g | 2g | 200000 | min(N, 10) |
+| >15 agents | 16g | 4g | 400000 | min(N, 30) |
 
 ## Browser Service Flags
 

--- a/docs/dashboard.md
+++ b/docs/dashboard.md
@@ -27,7 +27,7 @@ A command palette (**Cmd+K** / **Ctrl+K**) provides quick access to agents, acti
 
 ### Top-Nav Bell + "Needs Attention" Badge
 
-- **Notifications bell** (top-right) — driven by `/api/notifications`. Subtle gray dot when unread items exist; click to open the dropdown. See [Notifications](#notifications-system).
+- **Notifications bell** (top-right) — driven by `/dashboard/api/notifications`. Subtle gray dot when unread items exist; click to open the dropdown. See [Notifications](#notifications-system).
 - **"N agents need attention" badge** — wired to `fleetDigest?.agents_attention?.length`, populated from the operator's `OBSERVATIONS.md` aggregation. Renders only when the count is non-zero.
 
 ## Team Management
@@ -82,7 +82,7 @@ When the shared browser service is running, an embedded KasmVNC viewer appears i
 The operator is a system agent that builds and manages your workforce. It is rendered differently from regular agents:
 
 - In the **solo fleet view** (no team selected), the operator card is **prepended** to the grid as the first card with a `system` badge.
-- Inside a team view, the operator card is **not** rendered — operator is never a team member. The backend rejects `POST /api/teams` and `POST /api/teams/{name}/members` requests that include the operator (`ValueError → HTTP 400`).
+- Inside a team view, the operator card is **not** rendered — operator is never a team member. The backend rejects `POST /dashboard/api/teams` and `POST /dashboard/api/teams/{name}/members` requests that include the operator (`ValueError → HTTP 400`).
 - Clicking the operator card routes to **Settings → Operator** (not the standard agent detail panel).
 - The operator is **excluded from quota math, fleet cost/token totals, and broadcasts** — only "real" agents count against `OPENLEGION_MAX_AGENTS` and receive broadcast messages.
 - The standard agent detail panel for operator (if reached via deep link) shows a banner directing the user to the Operator system sub-tab; **Heartbeat Pause** is hidden.
@@ -93,11 +93,11 @@ The Work tab is the user's primary surface for steering the team without managin
 
 The page composes five surfaces. In actual render order, top to bottom (`index.html` line refs):
 
-1. **Sticky "Needs You" panel** (line ~3689) — pending actions, credential requests, browser-login handoffs, CAPTCHA handoffs, and blocked tasks. Pinned with `sticky top-0`. Aggregated client-side from `/api/workplace/pending` + `/api/workplace/blockers` + operator chat asks.
-2. **Goals strip** (line ~3770) — operator-managed business outcomes from `GOALS.json` (PR 1). Status-colored chips, hides entirely when empty. Read endpoint: `GET /api/workplace/goals`. Source-of-truth tool: `manage_goals` (operator-only, capped at 10 entries).
-3. **Summary cards** (line ~3804) — operator-composed daily narratives from `WorkSummariesStore` (one row per team or solo agent per period). Rated 👍 / ➖ / 👎 with inline rework feedback that flows back into the next composition. Loaded via `GET /api/workplace/summaries`.
+1. **Sticky "Needs You" panel** (line ~3689) — pending actions, credential requests, browser-login handoffs, CAPTCHA handoffs, and blocked tasks. Pinned with `sticky top-0`. Aggregated client-side from `/dashboard/api/workplace/pending` + `/dashboard/api/workplace/blockers` + operator chat asks.
+2. **Goals strip** (line ~3770) — operator-managed business outcomes from `GOALS.json` (PR 1). Status-colored chips, hides entirely when empty. Read endpoint: `GET /dashboard/api/workplace/goals`. Source-of-truth tool: `manage_goals` (operator-only, capped at 10 entries).
+3. **Summary cards** (line ~3804) — operator-composed daily narratives from `WorkSummariesStore` (one row per team or solo agent per period). Rated 👍 / ➖ / 👎 with inline rework feedback that flows back into the next composition. Loaded via `GET /dashboard/api/workplace/summaries`.
 4. **"Tell Operator" textarea** (line ~3975) — freeform steering channel below the summaries. POSTs to the existing operator chat-stream endpoint via `sendChatTo('operator', …)`. Inline "Sent" / "Send failed" confirmation that auto-clears.
-5. **Stuck Tasks panel** (line ~4010) — tasks pending or working for >24h with no status change. Silent stale-work detection, distinct from Blockers (which are explicit `status='blocked'` raises). Each row carries Cancel + Restart-agent buttons. Computed client-side from `/api/workplace/tasks`. Hidden entirely when no tasks are stuck; appears at the bottom only when needed.
+5. **Stuck Tasks panel** (line ~4010) — tasks pending or working for >24h with no status change. Silent stale-work detection, distinct from Blockers (which are explicit `status='blocked'` raises). Each row carries Cancel + Restart-agent buttons. Computed client-side from `/dashboard/api/workplace/tasks`. Hidden entirely when no tasks are stuck; appears at the bottom only when needed.
 
 The task **drill-in modal** stays reachable from Needs You blocker actions and notification-bell payload clicks. It serves the small fraction of users who want raw task detail; the per-summary rating UI handles the common QA loop for everyone else.
 
@@ -120,7 +120,7 @@ The System tab is split into **11 sub-tabs** along the top. Default sub-tab: `ac
 | **Costs** | Per-agent LLM spend with period selector (today/week/month) and budget bars |
 | **Automation** | Cron jobs + webhook endpoints. View schedule, last run time, run count, error count. Actions: Run / Pause / Resume / Edit / Delete |
 | **Integrations** | Configured credentials with tier labels (system or agent, names only — never values), pub/sub subscriptions, model pricing |
-| **API Keys** | Named external API keys (`/api/external-api-keys`) for inbound integrations |
+| **API Keys** | Named external API keys (`/dashboard/api/external-api-keys`) for inbound integrations |
 | **Wallet** | Wallet seed init, addresses (Ethereum + Solana), RPC endpoints, per-agent wallet enablement |
 | **Network** | Fleet-wide and per-agent proxy configuration. See [Proxy Configuration](#proxy-configuration) |
 | **Storage** | Agent SQLite databases with purge buttons. Each row shows DB id, size, oldest timestamp, `purgeable` flag |
@@ -144,10 +144,10 @@ Three sub-views toggled via the `activityView` state var:
 
 Operator-only system-agent control panel. Status card with health indicator, a model picker (searchable dropdown over `availableModels`), and a heartbeat-schedule editor (number + unit, e.g. `15m`, `1h`). Heartbeat **Pause** is intentionally hidden — the operator is not subject to operator-level pause controls.
 
-Below the status card, a **Change Log** table renders the operator audit feed (`GET /api/operator-audit?per_page=20&page=N&include_archived=…`). Each entry shows actor, action, target, and timestamp. The list paginates client-side via `auditPage`.
+Below the status card, a **Change Log** table renders the operator audit feed (`GET /dashboard/api/operator-audit?per_page=20&page=N&include_archived=…`). Each entry shows actor, action, target, and timestamp. The list paginates client-side via `auditPage`.
 
 - **`include_archived` toggle** — defaults off. When enabled, archived rows surface alongside active rows. Backed by the `audit_log.archived` column.
-- **"Archive entries older than"** control — 7 / 30 / 90 days (default 30). Calls `POST /api/operator-audit/archive` with `{ "before_date": "<ISO 8601>" }`, which the dashboard proxies to `POST /mesh/audit/archive` over loopback so the operator-or-internal permission tier (not just the dashboard cookie) gates the write and the audit-of-audit row is recorded by the mesh. Soft-archive flips rows to `archived=1`.
+- **"Archive entries older than"** control — 7 / 30 / 90 days (default 30). Calls `POST /dashboard/api/operator-audit/archive` with `{ "before_date": "<ISO 8601>" }`, which the dashboard proxies to `POST /mesh/audit/archive` over loopback so the operator-or-internal permission tier (not just the dashboard cookie) gates the write and the audit-of-audit row is recorded by the mesh. Soft-archive flips rows to `archived=1`.
 - Query optimisation: the mesh-side `audit_log` table carries a composite index `idx_audit_log_active(archived, id DESC)` so the default filter is cheap.
 
 ### Browser Sub-tab
@@ -155,10 +155,10 @@ Below the status card, a **Change Log** table renders the operator audit feed (`
 | Section | Backing endpoint(s) | Notes |
 |---------|--------------------|-------|
 | Live Browser Health (fleet table) | WS `browser_metrics` events | Per-agent rows: click rate (last 100), clicks/min, snapshot p50/p95, nav timeouts, last-update age. Stale rows fade after the 30-min eviction window |
-| Interaction Speed slider | `/api/browser-settings` | Speed multiplier with presets (Off / Light / Moderate / Heavy / Maximum) |
-| Delay Between Actions slider | `/api/browser-settings` | Random pause after each browser action (0–10s) |
-| Idle Timeout | `/api/system-settings` | Container idle timeout in minutes (5–120, default 30); restart required |
-| CAPTCHA Solver | `/api/captcha-solver` | Provider dropdown (none / 2captcha / capsolver) + API key field. Stored masked; restart required |
+| Interaction Speed slider | `/dashboard/api/browser-settings` | Speed multiplier with presets (Off / Light / Moderate / Heavy / Maximum) |
+| Delay Between Actions slider | `/dashboard/api/browser-settings` | Random pause after each browser action (0–10s) |
+| Idle Timeout | `/dashboard/api/system-settings` | Container idle timeout in minutes (5–120, default 30); restart required |
+| CAPTCHA Solver | `/dashboard/api/captcha-solver` | Provider dropdown (none / 2captcha / capsolver) + API key field. Stored masked; restart required |
 
 ## Agent Management
 
@@ -193,10 +193,10 @@ The panel has **7 tabs** defined in `_IDENTITY_TABS` (`app.js`):
 | `config` | **Config** | Model, role, budget, credential access | Agent configuration (model changes trigger restart). Includes a **Remove Agent** action at the bottom |
 | `identity` | **Identity** | `SOUL.md` (4K cap), `INSTRUCTIONS.md` (12K cap), `INTERFACE.md` (4K cap) | Personality, tone, operating procedures, public collaboration contract |
 | `memory` | **Memory** | `MEMORY.md` (16K cap), `USER.md` (4K cap), `HEARTBEAT.md` (no cap) | Long-term facts, user preferences, autonomous heartbeat rules |
-| `activity` | **Activity** | Per-agent activity stream from `/api/agents/{id}/activity` | Recent agent events scoped to this agent |
+| `activity` | **Activity** | Per-agent activity stream from `/dashboard/api/agents/{id}/activity` | Recent agent events scoped to this agent |
 | `logs` | **Logs** | Daily logs + Learnings (read-only) | Daily session logs and recorded errors/corrections |
-| `capabilities` | **Tools** | Tools list (read-only) | Available tools and skill definitions from `/api/agents/{id}/capabilities` |
-| `files` | **Files** | `/data` listing for the agent | Browse files written by the agent; proxied via `/api/agents/{id}/files` |
+| `capabilities` | **Tools** | Tools list (read-only) | Available tools and skill definitions from `/dashboard/api/agents/{id}/capabilities` |
+| `files` | **Files** | `/data` listing for the agent | Browse files written by the agent; proxied via `/dashboard/api/agents/{id}/files` |
 
 Each file card shows an access badge: **Shared** (teal) for files both you and the agent can edit (`SOUL.md`, `INSTRUCTIONS.md`, `USER.md`, `HEARTBEAT.md`, `INTERFACE.md`), **Auto** (gray) for system-managed files (`MEMORY.md`). Customized files show a description subtitle; default files show a CTA prompt.
 
@@ -219,7 +219,7 @@ The dashboard proxies workspace operations through the mesh transport layer to t
 An inline collapsible card on the agent detail panel lets operators paste cookie or storage-state payloads into an agent's Firefox profile, useful for transferring an authenticated session captured manually. The card is **operator-only** and **hidden on the operator agent itself** (operator does not run a browser session).
 
 - Two input modes: **Playwright** (storage-state JSON) or **Netscape** (TSV cookie jar)
-- POSTs to `/api/agents/{id}/browser/import_cookies` with rate limit 10/hour per (operator, agent)
+- POSTs to `/dashboard/api/agents/{id}/browser/import_cookies` with rate limit 10/hour per (operator, agent)
 - A fleet kill switch (`OPENLEGION_DISABLE_COOKIE_IMPORT=1`) disables the endpoint
 - Card state lives in Alpine `x-data` only — it is **never persisted to localStorage** (cookie text is high-trust; persistence would leave session material in browser storage longer than the in-page lifetime). Inputs are cleared on success
 - Imported cookies are stored UNENCRYPTED in `cookies.sqlite` inside the agent profile; the card surfaces an inline warning banner
@@ -254,9 +254,9 @@ Persistent conversation state across reloads is backed by three endpoints (used 
 
 | Method | Path | Description |
 |--------|------|-------------|
-| `GET` | `/api/conversations` | List active conversations |
-| `POST` | `/api/conversations/{agent_id}/open` | Mark a conversation open |
-| `POST` | `/api/conversations/{agent_id}/close` | Mark a conversation closed |
+| `GET` | `/dashboard/api/conversations` | List active conversations |
+| `POST` | `/dashboard/api/conversations/{agent_id}/open` | Mark a conversation open |
+| `POST` | `/dashboard/api/conversations/{agent_id}/close` | Mark a conversation closed |
 
 ### Keyboard Shortcuts
 
@@ -323,7 +323,7 @@ WAL mode, `busy_timeout=30000`. Composite index `idx_notifications_unread_ts(rea
 
 ### Live Updates
 
-The mesh emits `notification_added` immediately after each `NotificationStore.add` call (via `_notifications_producer`) so the bell badge updates without waiting for the 60-second poll cycle. Subscribers listen for the WS event and refetch `/api/notifications` for the top page.
+The mesh emits `notification_added` immediately after each `NotificationStore.add` call (via `_notifications_producer`) so the bell badge updates without waiting for the 60-second poll cycle. Subscribers listen for the WS event and refetch `/dashboard/api/notifications` for the top page.
 
 ## Telemetry System
 
@@ -422,7 +422,7 @@ The dashboard connects to the mesh via WebSocket at `/ws/events`. Events are str
 
 ### Event Types
 
-`DashboardEvent.type` is a `Literal[…]` of **50 values** (`src/shared/types.py:552-643`). They group into nine families:
+`DashboardEvent.type` is a `Literal[…]` of **53 values** (`src/shared/types.py:729-838`). They group into nine families:
 
 | Family | Events |
 |--------|--------|
@@ -433,7 +433,8 @@ The dashboard connects to the mesh via WebSocket at `/ws/events`. Events are str
 | **Automation** | `cron_change` |
 | **Credentials / handoffs** | `credential_request`, `credential_request_cancelled`, `credential_stored`, `browser_login_request`, `browser_login_completed`, `browser_login_cancelled`, `browser_captcha_help_request`, `browser_captcha_help_completed`, `browser_captcha_help_cancelled` |
 | **Browser metrics** | `browser_metrics`, `browser_nav_probe` |
-| **Tasks** | `task_created`, `task_status_changed`, `task_outcome`, `task_artifact_added` |
+| **Tasks** | `task_created`, `task_status_changed`, `task_completed_without_handoff`, `task_outcome`, `task_artifact_added` |
+| **Work summaries** | `work_summary_created`, `work_summary_rated` — drives summary cards on the Work tab; emitted by `WorkSummariesStore` |
 | **Pending actions** | `pending_action_created`, `pending_action_resolved`, `pending_action_expired` |
 | **Operator action receipts** | `operator_action_receipt`, `operator_action_receipt_undone`, `operator_action_receipt_superseded` |
 | **Agent lifecycle** | `agent_archived`, `agent_unarchived`, `agent_restarting`, `agent_restarted`, `agent_config_updated` |
@@ -513,7 +514,7 @@ The per-agent VNC reverse proxy lives at **`/agent-vnc/{agent_id}/{path}`** on t
 
 ## CAPTCHA Rollup CSV
 
-The `/api/billing/captcha-rollup` endpoint exports per-tenant CAPTCHA-solver spend as CSV. It has **no UI** — operators reach it directly via curl. Required query params: `tenant` (team slug) and `period` (`daily` | `weekly` | `monthly`, default `monthly`).
+The `/dashboard/api/billing/captcha-rollup` endpoint exports per-tenant CAPTCHA-solver spend as CSV. It has **no UI** — operators reach it directly via curl. Required query params: `tenant` (team slug) and `period` (`daily` | `weekly` | `monthly`, default `monthly`).
 
 Column schema (one header row, then per-agent rows sorted by agent_id, then a synthetic tenant-total row):
 
@@ -589,7 +590,7 @@ The tables below are not exhaustive — they cover the user-facing surface area 
 | `GET` | `/dashboard/api/agents/{id}/workspace-logs?days=N` | Read daily logs (read-only, default 3 days) |
 | `GET` | `/dashboard/api/agents/{id}/workspace-learnings` | Read errors and corrections (read-only) |
 
-**Work (Board) Surface — `/api/workplace/*`**
+**Work (Board) Surface — `/dashboard/api/workplace/*`**
 
 These endpoints power the Work tab. They cover the summary cards, Needs-You panel, Stuck Tasks panel, task drill-in modal, and pending-action review surfaces. State-changing routes require the CSRF header. (PR 3 of the Work-tab rewrite retired `GET /workplace/outputs` and `GET /workplace/feed` along with the legacy team-outputs + activity sub-tabs.)
 
@@ -673,8 +674,8 @@ These endpoints power the Work tab. They cover the summary cards, Needs-You pane
 
 **Teams**
 
-The canonical surface is `/api/teams/*`. PR 3 removed the pre-rename
-`/api/projects/*` mirrors; JSON responses still carry a `project_id`
+The canonical surface is `/dashboard/api/teams/*`. PR 3 removed the pre-rename
+`/dashboard/api/projects/*` mirrors; JSON responses still carry a `project_id`
 key alongside `team_id` for consumer back-compat.
 
 | Method | Path | Description |
@@ -849,4 +850,4 @@ The dashboard includes several accessibility features:
 | `src/dashboard/auth.py` | `ol_session` cookie verification, hosted-mode detection via `/opt/openlegion/.subdomain`, 24h `COOKIE_MAX_AGE` + 5m skew |
 | `src/dashboard/notifications.py` | Persistent SQLite notifications store backing the top-nav bell |
 | `src/dashboard/telemetry.py` | Frontend telemetry sink with `_MAX_EVENTS=100_000` retention + 60/min per-session rate limit |
-| `src/dashboard/platform_success.py` | Per-tenant success scoring (backs `/api/dashboard/platform-success`) |
+| `src/dashboard/platform_success.py` | Per-tenant success scoring (backs `/dashboard/api/dashboard/platform-success`) |

--- a/docs/development.md
+++ b/docs/development.md
@@ -42,6 +42,10 @@ cd .claude/worktrees/your-change
 
 Never run `pip install` from a worktree — it hijacks the global `openlegion` entry point. Always merge through a GitHub PR; do not push to `main` directly.
 
+### Entry Point
+
+The `openlegion` CLI is declared as `openlegion = "src.cli:cli"` in `pyproject.toml`. `src/cli/__init__.py` re-exports `cli` from `src/cli/main.py`; the Click group lives at `src/cli/main.py:86-106`. The CLI is also module-invocable via `python -m src.cli` (see `src/cli/__main__.py`).
+
 ## Testing
 
 ### Test Categories
@@ -257,11 +261,38 @@ The shorter `5000`ms timeout on the traces DB is intentional: traces writes are 
 
 No Redis, no external databases.
 
+### Runtime Constants
+
+Bounded execution is enforced by a small set of constants in `src/agent/loop.py`:
+
+| Constant | Value | Env override |
+|---|---|---|
+| `MAX_ITERATIONS` | 20 | `OPENLEGION_MAX_ITERATIONS` (clamped 1–100) |
+| `CHAT_MAX_TOOL_ROUNDS` | 30 | env-clamped 1–200 |
+| `CHAT_MAX_TOTAL_ROUNDS` | 200 | env-clamped 1–1000 |
+| `HEARTBEAT_MAX_ITERATIONS` | 12 | — |
+| `_TOOL_TIMEOUT` | 300 (seconds) | `OPENLEGION_TOOL_TIMEOUT` |
+| `_MAX_SESSION_CONTINUES` | 5 | hardcoded |
+
+Context manager thresholds (`src/agent/context.py`): 60% proactive fact flush, 70% compact (summarize + replace), 80% warning injected into the prompt, 90% emergency hard-prune. `_hard_prune()` keeps the first message plus the last 4 tool-call groups and bridges same-role sequences.
+
+Workspace file caps (`_FILE_CAPS` in `src/agent/server.py`) are enforced on `PUT /workspace/{filename}` with HTTP 413 on overflow — see [`configuration.md`](configuration.md) for the per-file size table.
+
+### Skill Discovery
+
+Skills are auto-discovered at agent startup from three paths inside the container:
+
+- `/app/agent/builtins` — built-in tools shipped with the engine
+- `/data/custom_skills` — agent self-authored skills (persisted on the agent's data volume)
+- `/app/marketplace_skills` — installed marketplace skills
+
+Conflicts resolve in order: custom overrides built-in overrides marketplace.
+
 ## Adding New Components
 
 ### Adding a Built-in Tool
 
-1. Create `src/agent/builtins/your_tool.py`
+1. Create `src/agent/builtins/your_tool.py` (maps to `/app/agent/builtins/your_tool.py` inside the agent container at runtime)
 2. Use the `@skill` decorator
 3. Accept `mesh_client`/`workspace_manager`/`memory_store` as keyword-only args if needed (auto-injected)
 4. Return a dict
@@ -307,10 +338,10 @@ async def your_endpoint(request: Request, body: YourRequest):
 
 ### Adding a Channel
 
-1. Subclass `Channel` from `src/channels/base.py`
+1. Implement the adapter in `src/channels/your_channel.py` (subclass `Channel` from `src/channels/base.py`)
 2. Implement `start()`, `stop()`, `send_notification()`
 3. The base class `handle_message()` handles all command parsing
-4. Add startup logic in `src/cli/channels.py`
+4. Wire startup/stop lifecycle in `src/cli/channels.py:ChannelManager` — channel adapters live under `src/channels/`; `src/cli/channels.py` only orchestrates lifecycle.
 5. Add tests in `tests/test_channels.py`
 
 ### Self-Authored Skills and the Marketplace
@@ -358,8 +389,8 @@ openlegion/
 │   │       ├── fleet_tool.py    # Fleet management (operator-agent only)
 │   │       └── operator_tools.py # Operator-privileged tools (operator-agent only)
 │   ├── host/                    # Runs on the host machine
-│   │   ├── server.py            # Mesh FastAPI app
-│   │   ├── mesh.py              # Blackboard, PubSub, routing
+│   │   ├── server.py            # Mesh HTTP endpoints (~109 routes) that expose the mesh.py classes
+│   │   ├── mesh.py              # Blackboard, PubSub, MessageRouter, audit log (low-level classes)
 │   │   ├── runtime.py           # Docker/Sandbox container management
 │   │   ├── transport.py         # HTTP/Sandbox transport layer
 │   │   ├── credentials.py       # Credential vault + API proxy
@@ -461,6 +492,8 @@ openlegion/
 | `mcp` | `mcp>=1.0` | MCP tool support |
 | `channels` | `python-telegram-bot`, `discord.py`, `slack-bolt` | Messaging channels |
 | `wallet` | `web3`, `eth-account`, `mnemonic`, `solders`, `solana` | Ethereum + Solana wallet support |
+
+There is no `requirements.lock` / `Pipfile.lock` — version bounds in `pyproject.toml` are `>=` only. CI runs the test matrix on both Python 3.11 and 3.12 to catch regressions across the supported range.
 
 ## Common Mistakes
 

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -171,7 +171,7 @@ If an agent has `ALLOWED_TOOLS` configured (operator mode — `loop.py:277-287` 
 Conflicts are resolved at registration time, before execution:
 
 - If an MCP tool has the same name as a built-in skill, the MCP tool is renamed to `mcp_{server_name}_{tool_name}` and a warning is logged. The built-in always keeps its original name.
-- If two MCP servers provide tools with the same name, the first server's tool keeps the original name and the second server's tool is prefixed with `mcp_{server_name}_{tool_name}`.
+- If two MCP servers provide tools with the same name, conflicts are resolved in **config / registration order**: the first server listed in `mcp_servers` keeps the unprefixed name, and any subsequent server providing the same tool name gets prefixed with `mcp_{server_name}_{tool_name}`.
 
 After registration every tool has a unique name, so there is no runtime priority resolution.
 

--- a/docs/memory.md
+++ b/docs/memory.md
@@ -1,20 +1,15 @@
 # Memory System
 
-OpenLegion agents have a five-layer memory architecture that provides persistent, self-improving recall across sessions, tasks, and context window resets.
+OpenLegion agents have a four-layer memory architecture that provides persistent recall across sessions, tasks, and context window resets.
 
-## Five Layers
+## Four Layers
 
 ```
-Layer 5: Context Manager          <- Manages the LLM's context window
+Layer 4: Context Manager          <- Manages the LLM's context window
   |  Monitors token usage
   |  Proactive flush at 60% capacity
   |  Auto-compacts at 70% capacity
   |  Extracts facts before discarding messages
-  |
-Layer 4: Learnings                <- Self-improvement through failure tracking
-  |  learnings/errors.md         (tool failures with context)
-  |  learnings/corrections.md   (user corrections and preferences)
-  |  Auto-injected into system prompt each session
   |
 Layer 3: Workspace Files          <- Durable, human-readable storage
   |  INSTRUCTIONS.md, SOUL.md, USER.md  (loaded into system prompt)
@@ -46,10 +41,11 @@ Manages the LLM's context window to prevent overflow while preserving important 
 
 - **Model-aware token estimation**: tiktoken for OpenAI models (accurate), 3.5 chars/token for Anthropic, 4 chars/token fallback for unknown providers
 - **Model-aware context windows**: auto-detects max context from model name (12 models supported), with explicit `max_tokens` override
-- Three compaction thresholds:
+- Four compaction thresholds:
   - **60%** -- proactive flush (extract facts to MEMORY.md)
-  - **70%** -- auto-compact (summarize + trim to last 3–4 messages, preserving tool-call group boundaries). Hard-prune is used as a fallback within this path if the LLM is unavailable or summarization fails — it is not a separately triggered threshold.
+  - **70%** -- auto-compact (summarize + trim, preserving tool-call group boundaries). If the LLM is unavailable or summarization returns an empty summary (`context.py:452-453`), this path falls back to hard prune.
   - **80%** -- warning injected into system prompt telling agents to wrap up or save important facts
+  - **90%** -- emergency hard prune (`_hard_prune()`): keep first message + last 4 message groups (tool-call boundaries preserved; bridges same-role sequences). Triggers if 80% warning was not heeded or summarization fails.
 
 ### Write-Then-Compact Pattern
 
@@ -58,7 +54,7 @@ Before discarding any conversation context:
 1. **Extract** -- Asks the LLM to identify important facts from the conversation
 2. **Store** -- Saves facts to both `MEMORY.md` and the structured memory DB
 3. **Summarize** -- Creates a concise summary of the conversation so far
-4. **Replace** -- Swaps full history with: summary + last 3 or 4 messages (4 normally; 3 + a bridge assistant message when the role invariant would be violated by consecutive user messages)
+4. **Replace** -- Swaps full history with: summary + first message + last 4 message groups (groups = tool-call sequences; preserves the user→assistant(tool_calls)→tool(result)→assistant invariant by bridging same-role sequences)
 
 Nothing is permanently lost during compaction.
 
@@ -83,8 +79,8 @@ Persistent markdown files stored on the agent's `/data/workspace` volume.
 | `SOUL.md` | Agent personality and behavioral guidelines | 4K chars | System prompt |
 | `USER.md` | User preferences and working style | 4K chars | System prompt |
 | `MEMORY.md` | Curated long-term facts | 16K chars | System prompt |
-| `TEAM.md` | Team-wide context (optional, mounted read-only from host). The bootstrap loader also accepts a stray `PROJECT.md` from pre-rename workspaces as a read-only fallback. | -- | System prompt |
-| `SYSTEM.md` | System architecture guide + runtime snapshot (auto-generated, read-only) | 6K chars | System prompt |
+| `TEAM.md` | Team-wide context (optional, per-team, mounted from host, **read-only** when present). Bootstrap accepts a legacy `PROJECT.md` (also read-only) for pre-rename workspaces. | -- | When present in the team config |
+| `SYSTEM.md` | System architecture guide + runtime snapshot (auto-generated, read-only) | capped at 6K chars | System prompt |
 | `HEARTBEAT.md` | Autonomous monitoring rules | -- | Heartbeat dispatch (auto-loaded) |
 | `INTERFACE.md` | Public collaboration contract (inputs, outputs, subscriptions) | 4K chars | Not auto-loaded into system prompt — read by other agents via `get_agent_profile` |
 
@@ -212,29 +208,3 @@ Session 2: User asks "What timezone am I in?"
            -> Returns "PST" via semantic search
 ```
 
-## Learnings (`src/agent/workspace.py`)
-
-Self-improvement through failure tracking:
-
-### Error Learning
-
-When a tool call fails, the error context is recorded in `learnings/errors.md`:
-```markdown
-## 2026-02-20T10:30:00
-**Tool:** exec_command
-**Error:** Permission denied: /etc/passwd
-**Context:** Tried to read system file outside /data
-**Lesson:** File operations are scoped to /data volume
-```
-
-### Correction Learning
-
-When a user corrects the agent, it's recorded in `learnings/corrections.md`:
-```markdown
-## 2026-02-20T11:00:00
-**User said:** "No, use pytest not unittest"
-**Context:** Was writing tests with unittest framework
-**Lesson:** User prefers pytest for testing
-```
-
-Both are injected into the system prompt at the start of each session, so the agent learns from past mistakes.

--- a/docs/security.md
+++ b/docs/security.md
@@ -88,7 +88,7 @@ Credentials are split into two tiers to prevent agents from accessing LLM provid
 | **System** | `anthropic_api_key`, `openai_api_key`, `gemini_api_base` | Mesh proxy only (internal). Agents can **never** resolve these. |
 | **Agent** | `brave_search_api_key`, `myservice_password`, user-created credentials | Only agents in the `allowed_credentials` allowlist |
 
-System credentials are identified by matching known provider names with key suffixes (`_api_key`, `_api_base`). Everything else is an agent credential. The known set is `_LITELLM_NATIVE_PROVIDERS` (`src/host/credentials.py:207-211`) — **15 providers** as of this writing: `anthropic`, `openai`, `openrouter`, `gemini`, `mistral`, `deepseek`, `groq`, `together_ai`, `fireworks_ai`, `perplexity`, `minimax`, `moonshot`, `xai`, `zai`, `ollama`. A credential named e.g. `openrouter_api_key` or `mistral_api_base` is therefore system-tier and unreachable to agents regardless of `allowed_credentials` configuration.
+System credentials are identified by matching known provider names with key suffixes (`_api_key`, `_api_base`). Everything else is an agent credential. The known set is `_LITELLM_NATIVE_PROVIDERS` (`src/host/credentials.py:212-216`) — **15 providers** as of this writing: `anthropic`, `openai`, `openrouter`, `gemini`, `mistral`, `deepseek`, `groq`, `together_ai`, `fireworks_ai`, `perplexity`, `minimax`, `moonshot`, `xai`, `zai`, `ollama`. A credential named e.g. `openrouter_api_key` or `mistral_api_base` is therefore system-tier and unreachable to agents regardless of `allowed_credentials` configuration.
 
 Per-agent access is controlled by `allowed_credentials` glob patterns in `config/permissions.json`:
 
@@ -279,26 +279,25 @@ Per-agent rate limits on mesh endpoints prevent abuse and resource exhaustion:
 
 | Endpoint | Limit | Window |
 |----------|-------|--------|
-| `api_proxy` | 30 requests | 60 seconds |
-| `vault_resolve` | 5 requests | 60 seconds |
-| `vault_store` | 10 requests | 3600 seconds |
-| `blackboard_read` | 200 requests | 60 seconds |
-| `blackboard_write` | 100 requests | 60 seconds |
-| `publish` | 200 requests | 60 seconds |
-| `notify` | 10 requests | 60 seconds |
-| `cron_create` | 10 requests | 3600 seconds |
-| `spawn` | 5 requests | 3600 seconds |
-| `wallet_read` | 120 requests | 60 seconds |
-| `wallet_transfer` | 10 requests | 3600 seconds |
-| `wallet_execute` | 10 requests | 3600 seconds |
-| `image_gen` | 10 requests | 60 seconds |
-| `agent_profile` | 30 requests | 60 seconds |
-| `upload_stage` | 30 requests | 60 seconds |
-| `upload_apply` | 30 requests | 60 seconds |
-| `ext_credentials` | 30 requests | 60 seconds |
-| `ext_status` | 60 requests | 60 seconds |
+| `api_proxy` | 6000 requests | 60 seconds |
+| `vault_resolve` | 10000 requests | 60 seconds |
+| `vault_store` | 600 requests | 60 seconds |
+| `blackboard_read` | 20000 requests | 60 seconds |
+| `blackboard_write` | 10000 requests | 60 seconds |
+| `publish` | 20000 requests | 60 seconds |
+| `notify` | 3000 requests | 60 seconds |
+| `cron_create` | 1000 requests | 60 seconds |
+| `spawn` | 600 requests | 60 seconds |
+| `wallet_read` | 6000 requests | 60 seconds |
+| `wallet_transfer` | 600 requests | 60 seconds |
+| `wallet_execute` | 600 requests | 60 seconds |
+| `image_gen` | 600 requests | 60 seconds |
+| `agent_profile` | 6000 requests | 60 seconds |
+| `upload_stage` | 3000 requests | 60 seconds |
+| `upload_apply` | 3000 requests | 60 seconds |
+| `auth_failure` | 60 requests | 60 seconds |
 
-`_RATE_LIMITS` currently has 18 entries: 16 declared statically in `src/host/server.py` plus `ext_credentials` and `ext_status` registered when external-API support initializes. All other endpoints default to 100 requests per 60 seconds.
+`_RATE_LIMITS` declares 17 entries statically in `src/host/server.py:788-815`; `ext_credentials` and `ext_status` are registered dynamically when external-API support initializes. All other endpoints fall through to the default `(10000, 60)` — i.e. 10000 requests per 60 seconds. These ceilings exist to catch a genuinely runaway loop in a single-tenant deployment; cost budgets (`costs.py`) and per-tx wallet caps are the real spend guardrails.
 
 Exceeding a rate limit returns HTTP 429. Rate-limit buckets are automatically cleaned up when agents are deregistered.
 

--- a/docs/triggering.md
+++ b/docs/triggering.md
@@ -6,7 +6,7 @@ OpenLegion agents can be triggered automatically through cron schedules, heartbe
 
 Scheduled tasks that dispatch messages to agents at regular intervals. The cron scheduler runs in the mesh host (not agent containers), so schedules survive container restarts.
 
-The scheduler loop ticks every `TICK_INTERVAL = 5` seconds (`src/host/cron.py:76`). 5-field cron jobs are rate-limited to fire at most once per minute via a `last_run` dedup guard, and each job runs under a per-job `asyncio.Lock` — if a previous run is still in flight when the next tick arrives, the new run is skipped rather than overlapping. When an agent is removed, all of its jobs are purged automatically via `remove_agent_jobs(agent_id)`.
+The scheduler loop ticks every `TICK_INTERVAL = 5` seconds (`src/host/cron.py:83`). 5-field cron jobs are rate-limited to fire at most once per minute via a `last_run` dedup guard, and each job runs under a per-job `asyncio.Lock` — if a previous run is still in flight when the next tick arrives, the new run is skipped rather than overlapping. When an agent is removed, all of its jobs are purged automatically via `remove_agent_jobs(agent_id)`.
 
 ### Schedule Syntax
 
@@ -103,7 +103,7 @@ By default, cron jobs suppress empty or trivial agent responses. The complete se
 
 Heartbeats are a cost-efficient form of autonomous monitoring. They run **cheap deterministic probes first**, and only invoke the LLM when probes find actionable items.
 
-The default heartbeat schedule is `"every 15m"` (`DEFAULT_HEARTBEAT_SCHEDULE`, `src/host/cron.py:77`). The **operator agent's heartbeat is forced to `"every 15m"` regardless of `mesh.heartbeat_schedule`** — see `src/cli/runtime.py:825`.
+The default heartbeat schedule is `"every 15m"` (`DEFAULT_HEARTBEAT_SCHEDULE`, `src/host/cron.py:84`). The **operator agent's heartbeat is forced to `"every 15m"` regardless of `mesh.heartbeat_schedule`** — see `src/cli/runtime.py:973`.
 
 ### How Heartbeats Work
 
@@ -337,10 +337,10 @@ Each agent has a FIFO task lane (`src/host/lanes.py`) with three dispatch modes:
 | Mode | Behavior |
 |------|----------|
 | `followup` (default) | Queue the message; process after the current task finishes. |
-| `steer` | Inject the message into the agent's active conversation between tool rounds. Rate-limited to `_STEER_WAKEUP_MAX = 10` wakeups per `_STEER_WAKEUP_WINDOW = 3600` seconds. |
+| `steer` | Inject the message into the agent's active conversation between tool rounds. Rate-limited to `_STEER_WAKEUP_MAX = 10` injections per `_STEER_WAKEUP_WINDOW = 3600` seconds (per-agent). |
 | `collect` | Batch queued messages while the agent is busy, then dispatch them as a single combined message once the agent becomes free. |
 
-When a lane completes a task that originated from a channel handoff (`auto_notify=True`), the result is forwarded back to the originating channel/user with a `[agent_name]` prefix. The send is capped at `_NOTIFY_FORWARD_TIMEOUT = 30` seconds (`lanes.py:29`).
+When a lane completes a task that originated from a channel handoff (`auto_notify=True`), the result is forwarded back to the originating channel/user with a `[agent_name]` prefix. The send is capped at `_NOTIFY_FORWARD_TIMEOUT = 30` seconds (`lanes.py:30`).
 
 ## Notification Routing
 


### PR DESCRIPTION
## Summary

Three-phase audit pass (extract code truth → compare every doc claim → apply fixes) against the actual code in `src/`. 12 files, +175 / −125.

**Most consequential fix:** `docs/security.md` rate-limit table was 100–200× too low across all 16 endpoints (doc said `api_proxy: 30/60s`, code is `6000/60s`; default fallback `100/60s` vs actual `10000/60s`). Operators planning capacity from those numbers would dramatically under-size protection.

## What changed (by file)

- **security.md** — rate-limits table rewritten against `src/host/server.py:788-815` (17 entries; default `(10000, 60)`).
- **configuration.md** — wallet rate-limit default `10 → 10000`; browser-sizing table gains the missing `≤15` and `>15` tiers; `OPENLEGION_LANE_TIMEOUT_SECONDS` and `OPENLEGION_LOOP_STALE_SECONDS` added; new workspace file-cap subsection.
- **dashboard.md** — `DashboardEvent.type` count `50 → 53`, line range `552-643 → 729-838`; adds `task_completed_without_handoff` event and a new Work-summaries row; normalizes `/api/...` → `/dashboard/api/...` across ~15 inline endpoint references.
- **agent-tools.md** — removes false `loop_exempt=True` annotations from `read_file`/`http_request`/`browser_screenshot` (only `memory_search` is exempt); `_FORBIDDEN_IMPORTS` count `24 → 23`; `INTERFACE.md` added to protected files; `update_workspace` allowlist extended with `OBSERVATIONS.md`, `GOALS.md`, `GOALS.json`.
- **memory.md** — removes the never-implemented Learnings layer entirely (five layers → four); adds the missing 90% emergency hard-prune threshold; clarifies TEAM.md as per-team/read-only with `PROJECT.md` as legacy fallback; reframes hard prune as "last 4 message groups" not "3–4 messages".
- **triggering.md** — line-ref drift fixes (`cron.py:77 → :84`, `cron.py:76 → :83`, `runtime.py:825 → :973`, `lanes.py:29 → :30`); adds steer-wakeup rate limit (10 per hour per agent).
- **channels.md** — corrects what `sanitize_for_prompt()` actually does: strips Unicode control categories, not credentials (credential redaction lives in `src/shared/redaction.py`).
- **architecture.md** — mesh endpoint count `98 → 109` (counted via `grep -c '^@app\.' src/host/server.py`).
- **development.md** — distinguishes `host/mesh.py` (low-level classes: Blackboard, PubSub, MessageRouter, audit log) from `host/server.py` (~109 HTTP endpoints); adds Entry-point, Runtime-constants, Skill-discovery, and no-lockfile subsections; container-path mapping note; channel-vs-CLI implementation clarity.
- **mcp.md** — tool-name conflict resolution now specifies config / registration order (first server wins, subsequent get `mcp_{server}_{tool}` prefix).
- **README.md** — adds Bitsight + Koi Security citation URLs; dual-frames browser tiers (self-hosted autoscale + managed plan); adds task auto-close, soft/hard undo windows, rate limits, container hardening, AST validation, team-scope enforcement, CAPTCHA escalation pointers; clarifies solo-agent blackboard access; fixes webhook example URL; CPU range `1 CPU → 0.15–4.0`.
- **CLAUDE.md** — `server.py` endpoint count `100 → 109`.

## Notable spot-check overturns
During the fix pass, three discrepancy-report findings were overturned by code spot-checks and **not** applied:
- Code does have 15 LLM providers including `zai` (report claimed 14, no zai).
- `browser_find_text` was not actually carrying a `loop_exempt=True` annotation in the doc.
- `INTERFACE.md` protection is via `_WORKSPACE_ALLOWLIST`, not a separate `_PROTECTED_WORKSPACE_FILES` set.

## Cross-repo check
Engine's "Cross-Repo Integration" claims in `CLAUDE.md` (Provisioner → Engine SSH/health-check path, App → Engine HMAC SSO flow, `ol_session` cookie) were verified against the sibling `app/` and `provisioner/` repos' CLAUDE.md. All accurate from both sides.

## Test plan
- [x] Phase 3 verification subagent confirmed all 11 highest-priority fixes landed correctly
- [x] README setup walkthrough re-walked end-to-end — no missing prerequisites or broken examples
- [x] All `[CITATION-NEEDED]` markers replaced with live URLs
- [ ] CI passes