### PR TITLE
feat(dashboard): sidebar nav, /teams URL, Add-Agent card; drop Fleet pulse

### DIFF
--- a/docs/agent-tools.md
+++ b/docs/agent-tools.md
@@ -102,7 +102,7 @@ An OS-level device profile is selected by `BROWSER_DEVICE_PROFILE` (`desktop-win
 
 | Tool | Parameters | Description |
 |------|-----------|-------------|
-| `update_workspace` | `filename`, `content` | Update a writable workspace file (`SOUL.md`, `INSTRUCTIONS.md`, `USER.md`, `HEARTBEAT.md`, `INTERFACE.md`, `OBSERVATIONS.md`, `GOALS.md`, or `GOALS.json`) to persist learnings across sessions |
+| `update_workspace` | `filename`, `content` | Update a writable workspace file (`SOUL.md`, `INSTRUCTIONS.md`, `USER.md`, `HEARTBEAT.md`, `INTERFACE.md`, `GOALS.md`, or `GOALS.json`) to persist learnings across sessions |
 
 ### Scheduling & Automation
 
@@ -227,7 +227,6 @@ stale LLM prompt fails fast and retries on the canonical name.
 | `edit_agent` | `agent_id`, `field` (enum: `instructions` / `soul` / `role` / `heartbeat` / `heartbeat_schedule` / `interface` / `model` / `thinking` / `budget` / `permissions`), `value`, `reason` (default `"user_asked"`; values: `user_asked` / `operator_proactive`) | Single entry point for agent config changes. ALL fields apply immediately and emit an undo receipt — soft fields (`instructions`, `soul`, `role`, `heartbeat`, `heartbeat_schedule`, `interface`) carry a 5-minute Undo window; hard fields (`model`, `thinking`, `budget`, `permissions`) carry a 30-minute Undo window. No pre-execution confirm step. `heartbeat_schedule` also retargets the live cron job in lockstep with the YAML write. |
 | `undo_change` | `undo_token` | Reverse an edit applied via `edit_agent`. Token is returned with the edit and remains valid for 5 minutes (soft fields) or 30 minutes (hard fields); 404 if expired or already undone. |
 | `confirm_edit` | `change_id` | Deprecated no-op stub. The `/edit-soft` immediate-apply refactor retired the propose-then-confirm flow; `confirm_edit` returns a friendly hint and is retained only so in-flight LLM conversations that still emit it don't error. New conversations should call `edit_agent` directly. |
-| `save_observations` | `fleet_summary`, `agents_attention` (default `[]`, items: `{agent_id, issue, severity}`), `cost_trend`, `notes` (default "") | Persist fleet health observations to `OBSERVATIONS.md` for the Fleet Digest display. Char cap 1500; history retains last 50 entries. |
 | `create_agent` | `name` (lowercase, alphanumeric + hyphens, 1–32 chars), `role`, `model` (default ""), `instructions`, `soul` (default "") | Create a new custom agent. Requires user confirmation. |
 | `create_team` | `name`, `description`, `agent_ids` (default []) | Create a new team and optionally assign agents. Requires user confirmation. |
 | `add_agents_to_team` | `team_name`, `agent_ids` | Add one or more agents to a team. Requires user confirmation. |

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -50,7 +50,7 @@ OpenLegion uses a **fleet model, not hierarchy**. There is no CEO agent that rou
 
 ### Operator agent
 
-A reserved agent named `operator` is auto-created at startup (`_ensure_operator_agent` in `src/cli/runtime.py`). It runs at lower resource caps (128MB RAM, 0.05 CPU) and carries fleet-management tools (`fleet_tool.py`, `operator_tools.py`). The operator owns `OBSERVATIONS.md` (written via `save_observations`), surfaces the Fleet pulse card on the dashboard, and is the only agent that can apply fleet templates, archive teams, or confirm hard config edits.
+A reserved agent named `operator` is auto-created at startup (`_ensure_operator_agent` in `src/cli/runtime.py`). It runs at lower resource caps (128MB RAM, 0.05 CPU) and carries fleet-management tools (`fleet_tool.py`, `operator_tools.py`). The operator is the only agent that can apply fleet templates, archive teams, or confirm hard config edits.
 
 ### Reserved agent IDs
 
@@ -98,7 +98,7 @@ Each agent runs in an isolated Docker container with its own FastAPI server (28 
 | `skills.py` | Skill discovery and registry; `@skill` decorator system. |
 | `mcp_client.py` | MCP server lifecycle management and tool routing. |
 | `memory.py` | SQLite + sqlite-vec + FTS5 hierarchical memory (`EMBEDDING_DIM=1536`, weighted 0.7 vector / 0.3 keyword with salience decay). |
-| `workspace.py` | Persistent markdown workspace. Scaffold files (`_SCAFFOLD_FILES`): `INSTRUCTIONS.md`, `SOUL.md`, `USER.md`, `MEMORY.md`, `HEARTBEAT.md`, `INTERFACE.md`. `TEAM.md` / `SYSTEM.md` are read-only bootstrap inclusions, not writable scaffolds (legacy `PROJECT.md` is retained as a read-only fallback for workspaces that pre-date the rename). Operator's `OBSERVATIONS.md` is written by the `save_observations` tool, not a generic scaffold. |
+| `workspace.py` | Persistent markdown workspace. Scaffold files (`_SCAFFOLD_FILES`): `INSTRUCTIONS.md`, `SOUL.md`, `USER.md`, `MEMORY.md`, `HEARTBEAT.md`, `INTERFACE.md`. `TEAM.md` / `SYSTEM.md` are read-only bootstrap inclusions, not writable scaffolds (legacy `PROJECT.md` is retained as a read-only fallback for workspaces that pre-date the rename). |
 | `context.py` | Context window management. Flush facts at 60%, summarize-and-replace at 70%, warn at 80%. Empty summary falls back to hard prune. Write-then-compact flushes facts to `MEMORY.md` before discarding context. |
 | `llm.py` | LLM client (`chat_stream()` and `chat()`) — routes through mesh proxy, never holds keys. |
 | `mesh_client.py` | HTTP client for agent-to-mesh communication; merges `origin_header()` into `wake_agent` / `create_task`. |
@@ -124,7 +124,7 @@ Each agent runs in an isolated Docker container with its own FastAPI server (28 
 | `introspect_tool.py` | Runtime state query — permissions, budget, fleet, cron, health. |
 | `skill_tool.py` | Self-authoring with AST validation. Forbidden imports/calls/attrs prevent `eval`, `exec`, `open`, `__subclasses__`, etc. |
 | `fleet_tool.py` | Operator-only fleet management — `list_templates`, `apply_template` (per-slot creation, not atomic across slots). |
-| `operator_tools.py` | Operator-only orchestration — `edit_agent` (single tool; all fields apply immediately and emit an undo receipt: 5-min for soft fields, 30-min for hard fields), `undo_change`, deprecated `confirm_edit` no-op stub (kept for in-flight LLM conversations), `save_observations`, `inspect_agents`, `inspect_teams` (alias `inspect_projects`), team/agent CRUD via `create_team` / `add_agents_to_team` / … (legacy `*_project` names still callable). |
+| `operator_tools.py` | Operator-only orchestration — `edit_agent` (single tool; all fields apply immediately and emit an undo receipt: 5-min for soft fields, 30-min for hard fields), `undo_change`, deprecated `confirm_edit` no-op stub (kept for in-flight LLM conversations), `inspect_agents`, `inspect_teams` (alias `inspect_projects`), team/agent CRUD via `create_team` / `add_agents_to_team` / … (legacy `*_project` names still callable). |
 | `wallet_tool.py` | Wallet operations — get address, get balance, read contract, transfer, execute (Ethereum + Solana). |
 
 ### Browser Service (`src/browser/`)

--- a/docs/dashboard.md
+++ b/docs/dashboard.md
@@ -4,31 +4,30 @@ Real-time web dashboard for fleet observability and management.
 
 ## Overview
 
-The dashboard is served at `http://localhost:8420/dashboard` (or whatever port the mesh is configured on). It provides a live view of your agent fleet across four top-nav tabs with a consolidated navigation bar, slide-over chat panels, and a keyboard command palette.
+The dashboard is served at `http://localhost:8420/dashboard` (or whatever port the mesh is configured on). It provides a live view of your agent fleet across four primary tabs — a labeled left sidebar on desktop (`md:` and up) and an icon-only top strip on mobile — with slide-over chat panels and a keyboard command palette.
 
 No additional setup is required — the dashboard starts automatically with `openlegion start`. In self-hosted and local dev mode, the dashboard is open to anyone who can reach port 8420. In hosted mode (subdomain deployments), SSO authentication is required; see [Authentication](#authentication) for details.
 
 ## Navigation
 
-### Top-Nav Tabs
+### Primary Tabs
 
-The dashboard has **four** top-level tabs. Tab IDs are frozen for URL stability (deep links, persisted preferences, dashboard endpoint paths reference them) while the user-facing labels have diverged — per CLAUDE.md #14, renaming the IDs would break links so only the labels were updated.
+The dashboard has **four** top-level tabs. Tab IDs are frozen for URL stability (deep links, persisted preferences, dashboard endpoint paths reference them) while the user-facing labels have diverged — per CLAUDE.md #14, renaming the IDs would break links so only the labels were updated. The tabs render as a labeled vertical sidebar (`<aside class="side-nav">` in `src/dashboard/templates/index.html`) on `md:` and wider, collapsing to an icon-only strip in the slim top bar on `<md` mobile viewports.
 
 | Tab ID (frozen) | User Label | What It Shows |
 |----------------|------------|--------------|
 | `chat` | **Chat** | Multi-agent chat surface — slide-over panels, streaming, command palette entry. Default tab on boot |
 | `workplace` | **Work** | Kanban / Needs-You / Activity feed / Pending Actions — the Board surface. See [Work Tab](#work-tab) |
-| `fleet` | **Team** | Agent grid with operator card prepended in standalone view, drill-down agent detail (config, identity, capabilities, files). See [Team Tab](#team-tab) |
+| `fleet` | **Teams (N)** | Agent grid with operator card prepended in standalone view, drill-down agent detail (config, identity, capabilities, files). URL `/teams` (legacy `/agents` accepted as back-compat). See [Team Tab](#team-tab) |
 | `system` | **Settings** | 11 sub-tabs: Activity / Costs / Automation / Integrations / API Keys / Wallet / Network / Storage / Operator / Browser / Settings. See [System Tab](#system-tab) |
 
 The defaults — `tabs` array and `activeTab: 'chat'` — live in `src/dashboard/static/js/app.js` (top of the `dashboard()` factory). Routes parse the URL hash into `{ tab, systemTab, agentId, identityTab, activityView }` (the Work tab has no sub-routes — `/home/*` variants all normalize to `/home`).
 
 A command palette (**Cmd+K** / **Ctrl+K**) provides quick access to agents, actions, and navigation. The search button in the nav bar also opens it.
 
-### Top-Nav Bell + "Needs Attention" Badge
+### Top-Nav Bell
 
 - **Notifications bell** (top-right) — driven by `/dashboard/api/notifications`. Subtle gray dot when unread items exist; click to open the dropdown. See [Notifications](#notifications-system).
-- **"N agents need attention" badge** — wired to `fleetDigest?.agents_attention?.length`, populated from the operator's `OBSERVATIONS.md` aggregation. Renders only when the count is non-zero.
 
 ## Team Management
 
@@ -36,19 +35,31 @@ The dashboard supports multi-team namespaces for organizing agents into
 isolated groups. The tab ID is still `fleet` (frozen for URL stability)
 but the user-facing label is **Teams**.
 
-### Team Switcher
+### Team Filter
 
-A tab bar at the top of the Teams view shows all teams plus an "All
-Agents" view. Click a team tab to filter the agent grid to that team's
-members. The "All Agents" tab shows every agent with team badges. Each
-tab displays a member count.
+A chip strip at the top of the Teams view shows a **Solo (N)** chip plus
+one chip per team, each with a member count. Click a team chip to filter
+the agent grid to that team's members; click **Solo** to show only agents
+not assigned to any team. When the team count grows past 6, the strip
+caps at two rows and a **Show all teams / Show fewer** toggle reveals or
+hides the overflow (preference persisted to
+`localStorage.ol_team_filter_expanded`).
 
 ### Create Team
 
-Click the **+** button next to the team tabs to create a new team. Enter
-a name and optional description. Teams are stored on disk under
-`config/teams/{name}/`; the startup migrator drops a `config/projects`
-symlink at the legacy path so pre-rename code paths still resolve.
+Click the **+ New Team** button on the right side of the team filter row
+to create a new team. Enter a name and optional description. Teams are
+stored on disk under `config/teams/{name}/`; the startup migrator drops
+a `config/projects` symlink at the legacy path so pre-rename code paths
+still resolve.
+
+### Add Agent
+
+The agent grid has an **Add Agent** card as its final cell — a dashed
+outline with a `+` icon. Click to open the new-agent modal; the modal
+pre-fills the active team filter so an agent created while viewing team
+X joins X by default. The card shows a disabled state with a
+"Agent limit reached" tooltip when `atAgentLimit` is true.
 
 ### Team Members
 
@@ -127,8 +138,6 @@ The System tab is split into **11 sub-tabs** along the top. Default sub-tab: `ac
 | **Operator** | Operator agent settings (model picker, heartbeat editor) and the operator audit log ("Change Log"). See [Operator Sub-tab](#operator-sub-tab) |
 | **Browser** | Live browser metrics fleet table, interaction speed/delay sliders, idle timeout, CAPTCHA solver provider/key. See [Browser Sub-tab](#browser-sub-tab) |
 | **Settings** | Default model, runtime logs viewer, miscellaneous toggles |
-
-A **Fleet pulse card** sits at the top of the System tab, rendering the operator's `OBSERVATIONS.md` aggregation.
 
 ### Activity Sub-tab (System → Activity)
 
@@ -372,7 +381,7 @@ Proxy changes auto-restart the agent and reset the browser session. In the Syste
 
 ## Broadcast
 
-Send a message to multiple agents simultaneously using the broadcast bar below the agent grid. When a team is selected, the broadcast targets only that team's members. When viewing "All Agents", it targets every agent. Solo agents (not on any team) are included only in the "All Agents" broadcast. The operator is always excluded from broadcasts. Each agent processes the message independently. Responses display inline with expand/collapse for long replies (200+ characters).
+Send a message to multiple agents simultaneously using the broadcast bar below the agent grid. When a team chip is selected, the broadcast targets only that team's members. When the **Solo** chip is selected, it targets every agent not assigned to a team. The operator is always excluded from broadcasts. Each agent processes the message independently. Responses display inline with expand/collapse for long replies (200+ characters).
 
 ## Blackboard Operations
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -253,7 +253,7 @@ All file operations are scoped to the container's `/data` volume.
 
 Workspace files (the agent's own `SOUL.md` / `INSTRUCTIONS.md` / `MEMORY.md` / etc.) are managed through a dedicated `/workspace/{filename}` endpoint on the **agent's own** FastAPI server, not via the general `/data` file tools. Three protections:
 
-- **`_WORKSPACE_ALLOWLIST` frozenset** (`src/agent/server.py:326-329`) — exactly 8 entries: `SOUL.md`, `HEARTBEAT.md`, `USER.md`, `INSTRUCTIONS.md`, `AGENTS.md`, `MEMORY.md`, `INTERFACE.md`, `OBSERVATIONS.md`. Reads / writes to anything outside this list return HTTP 400.
+- **`_WORKSPACE_ALLOWLIST` frozenset** (`src/agent/server.py`) — 9 entries: `SOUL.md`, `HEARTBEAT.md`, `USER.md`, `INSTRUCTIONS.md`, `AGENTS.md`, `MEMORY.md`, `INTERFACE.md`, `GOALS.md`, `GOALS.json`. Reads / writes to anything outside this list return HTTP 400.
 - **`_FILE_CAPS`** (`src/agent/server.py:332-340`) — char-count caps per file, enforced on `PUT` with HTTP 413 on overflow: `SOUL.md=4000`, `INSTRUCTIONS.md=12000`, `AGENTS.md=12000`, `USER.md=4000`, `MEMORY.md=16000`, `INTERFACE.md=4000`, `HEARTBEAT.md=None` (uncapped).
 - **`x-mesh-internal` gate on `PUT /workspace/{filename}`** (`src/agent/server.py:397-402`) — the agent cannot call its own workspace endpoint via `http_tool` or `exec+curl`. Writes must originate from the mesh on loopback with the internal header set. Reads from the agent's own loop are allowed without the gate.
 

--- a/src/agent/builtins/operator_tools.py
+++ b/src/agent/builtins/operator_tools.py
@@ -1,4 +1,4 @@
-"""Operator agent tools -- agent edits (with undo), observations, agent/team management."""
+"""Operator agent tools -- agent edits (with undo), inspection, agent/team management."""
 from __future__ import annotations
 
 import asyncio
@@ -617,102 +617,6 @@ async def undo_change(
         "field": result.get("field"),
         "restored_value": result.get("restored_value"),
     }
-
-
-# ── Observations ─────────────────────────────────────────────
-
-
-_MAX_OBSERVATIONS_CHARS = 1500
-_MAX_HISTORY_ENTRIES = 50
-
-
-@skill(
-    name="save_observations",
-    description=(
-        "Save fleet health observations from your monitoring check. "
-        "Writes structured data to OBSERVATIONS.md for the Fleet Digest display."
-    ),
-    parameters={
-        "fleet_summary": {
-            "type": "string",
-            "description": "One-line fleet health summary (e.g. '5/6 healthy, cost stable')",
-        },
-        "agents_attention": {
-            "type": "array",
-            "description": "Agents needing attention: [{agent_id, issue, severity}]",
-            "items": {"type": "object"},
-            "default": [],
-        },
-        "cost_trend": {
-            "type": "string",
-            "description": "Cost trend (e.g. 'up_40pct', 'stable', 'down_15pct')",
-        },
-        "notes": {
-            "type": "string",
-            "description": "Optional freeform notes",
-            "default": "",
-        },
-    },
-)
-async def save_observations(
-    fleet_summary: str,
-    cost_trend: str,
-    agents_attention: list | None = None,
-    notes: str = "",
-    *,
-    workspace_manager=None,
-    **_kw,
-) -> dict:
-    """Save fleet observations to workspace for dashboard display."""
-    if not _is_operator():
-        return {"error": "This tool is only available to the operator agent."}
-    if workspace_manager is None:
-        return {"error": "No workspace_manager available"}
-
-    timestamp = datetime.now(timezone.utc).isoformat()
-
-    obs = {
-        "timestamp": timestamp,
-        "fleet_summary": fleet_summary,
-        "agents_attention": agents_attention or [],
-        "cost_trend": cost_trend,
-        "notes": notes,
-    }
-
-    # Build markdown with JSON block
-    content = (
-        f"# Fleet Observations\nUpdated: {timestamp}\n\n"
-        f"```json\n{json.dumps(obs, indent=2)}\n```\n"
-    )
-
-    # Enforce char cap by truncating notes
-    while len(content) > _MAX_OBSERVATIONS_CHARS and notes:
-        notes = notes[:-50] + "..." if len(notes) > 50 else ""
-        obs["notes"] = notes
-        content = (
-            f"# Fleet Observations\nUpdated: {timestamp}\n\n"
-            f"```json\n{json.dumps(obs, indent=2)}\n```\n"
-        )
-
-    # Write OBSERVATIONS.md directly to workspace root (not in AGENT_WRITABLE)
-    obs_path = workspace_manager.root / "OBSERVATIONS.md"
-    obs_path.write_text(content)
-
-    # Append to OBSERVATIONS_HISTORY.md (rolling window)
-    history_path = workspace_manager.root / "OBSERVATIONS_HISTORY.md"
-    history_content = ""
-    if history_path.exists():
-        try:
-            history_content = history_path.read_text(errors="replace")
-        except OSError:
-            pass
-    history_lines = [e for e in history_content.strip().split("\n---\n") if e.strip()]
-    history_lines.append(json.dumps(obs))
-    if len(history_lines) > _MAX_HISTORY_ENTRIES:
-        history_lines = history_lines[-_MAX_HISTORY_ENTRIES:]
-    history_path.write_text("\n---\n".join(history_lines) + "\n")
-
-    return {"saved": True, "timestamp": timestamp, "chars": len(content)}
 
 
 # ── Create Agent ─────────────────────────────────────────────
@@ -2256,13 +2160,12 @@ def _render_goals_md(goals: list[dict]) -> str:
 def _write_goals(workspace_root, goals: list[dict]) -> None:
     """Persist both sidecar JSON and rendered markdown atomically-ish.
 
-    Direct ``path.write_text`` matches the ``save_observations``
-    precedent (``OBSERVATIONS.md`` / ``OBSERVATIONS_HISTORY.md``); these
-    files are operator-internal state, not user-edited content, so the
-    workspace_manager's audit/versioning machinery doesn't apply.
-    Two writes are not atomic — if the MD write fails after the JSON
-    write succeeds, the two files diverge. Risk is small for a stable
-    workspace volume; if it ever bites, switch to temp-file + rename.
+    Direct ``path.write_text`` because these files are operator-internal
+    state, not user-edited content, so the workspace_manager's
+    audit/versioning machinery doesn't apply. Two writes are not atomic —
+    if the MD write fails after the JSON write succeeds, the two files
+    diverge. Risk is small for a stable workspace volume; if it ever
+    bites, switch to temp-file + rename.
     """
     json_path = workspace_root / _GOALS_JSON_FILENAME
     md_path = workspace_root / _GOALS_MD_FILENAME

--- a/src/agent/loop.py
+++ b/src/agent/loop.py
@@ -144,7 +144,7 @@ _BLACKBOARD_TOOLS = frozenset({
 # without dropping out to a full /chat turn.
 _HEARTBEAT_TOOLS = frozenset({
     "list_agents", "get_agent_profile", "get_system_status",
-    "notify_user", "save_observations", "check_inbox",
+    "notify_user", "check_inbox",
     "workflow_snapshot", "await_task_event",
     # PR 2 of Work tab rewrite. Heartbeat instructions tell operator
     # to rate up to 10 oldest unrated done tasks via ``rate_delivery``

--- a/src/agent/server.py
+++ b/src/agent/server.py
@@ -372,7 +372,7 @@ def create_agent_app(loop: AgentLoop) -> FastAPI:
 
     _WORKSPACE_ALLOWLIST = frozenset({
         "SOUL.md", "HEARTBEAT.md", "USER.md", "INSTRUCTIONS.md", "AGENTS.md", "MEMORY.md",
-        "INTERFACE.md", "OBSERVATIONS.md",
+        "INTERFACE.md",
         # Operator-tracked goals. GOALS.json is the structured sidecar
         # the dashboard reads; GOALS.md is the rendered markdown view.
         # Only the operator agent writes them in practice.
@@ -391,7 +391,7 @@ def create_agent_app(loop: AgentLoop) -> FastAPI:
         # GOALS.md intentionally uncapped here — size is tool-enforced
         # (10 goals × name/note limits in manage_goals); an HTTP cap on
         # the PUT path would clash at max load with what the tool can
-        # legitimately produce (~7k chars). Matches OBSERVATIONS.md.
+        # legitimately produce (~7k chars).
     }
     _DEFAULT_HEADINGS = {
         "SOUL.md": "# Identity",

--- a/src/cli/config.py
+++ b/src/cli/config.py
@@ -1617,7 +1617,7 @@ _OPERATOR_AGENT_ID = "operator"
 
 _OPERATOR_ALLOWED_TOOLS: list[str] = [
     # Monitoring + heartbeat
-    "get_system_status", "notify_user", "save_observations",
+    "get_system_status", "notify_user",
     "inspect_agents", "inspect_teams",
     "list_agent_queue", "get_team_outputs",
     "summarize_team_progress",
@@ -1692,7 +1692,7 @@ _OPERATOR_ALLOWED_TOOLS: list[str] = [
 _OPERATOR_HEARTBEAT_TOOLS: list[str] = [
     # v1 baseline (read-only)
     "list_agents", "get_agent_profile", "get_system_status",
-    "notify_user", "save_observations",
+    "notify_user",
     # v2 workflow-awareness — back-edge events + chain inspection +
     # single-task blocking so the heartbeat can drive multi-stage
     # chains without dropping out to a full /chat turn.
@@ -1720,22 +1720,18 @@ _OPERATOR_HEARTBEAT = """\
 <!-- heartbeat_v2_workflow_aware -->
 <!-- heartbeat_v3_rate_delivery -->
 You are running an autonomous fleet health check. You have access ONLY to monitoring tools.
-Your previous observations are included above in OBSERVATIONS.md.
 
-Step budget: stay at or under 10 tool calls per cycle (HEARTBEAT_MAX_ITERATIONS=12
-in the loop; 10 leaves headroom for the final assistant turn).
+Step budget: stay at or under 8 tool calls per cycle (HEARTBEAT_MAX_ITERATIONS=12
+in the loop; 8 leaves headroom for the final assistant turn).
 
-1. Review your previous observations (above) to check what you flagged last cycle.
-   Do not re-alert on known issues unless they have escalated in severity.
-
-2. Call check_inbox() FIRST so any task_failed / task_blocked back-edge events
+1. Call check_inbox() FIRST so any task_failed / task_blocked back-edge events
    from active workflows are surfaced before you do fleet-wide work. Skim the
    ``events[]`` array:
    - For each task_failed / task_blocked event note the task_id and recipient.
    - For each event whose task is part of an orchestration you started, drop a
-     ``workflow_snapshot(root_task_id)`` call (step 4) to see chain state.
+     ``workflow_snapshot(root_task_id)`` call (step 3) to see chain state.
 
-3. Call get_system_status() for fleet-wide metrics:
+2. Call get_system_status() for fleet-wide metrics:
    - Total cost, cost trend vs yesterday
    - Per-agent cost (per_agent_cost_today_usd, per_agent_cost_vs_yesterday_ratio)
    - Per-agent task health: outcome_rejected_24h_count, execution_failures_24h_count,
@@ -1743,11 +1739,11 @@ in the loop; 10 leaves headroom for the final assistant turn).
    - Agent health counts and pre-computed agents_needing_attention list
    - Plan limits and current usage
 
-4. Workflow awareness — for any active orchestration you kicked off (a task you
+3. Workflow awareness — for any active orchestration you kicked off (a task you
    created as a root that fanned out via hand_off), call
    ``workflow_snapshot(root_task_id)`` to see all stages. Read the response:
    - ``summary.failed`` > 0 OR ``summary.blocked`` > 0: surface to the user
-     in step 7 with the offending stage's assignee, title, and blocker_note
+     in step 5 with the offending stage's assignee, title, and blocker_note
      (the snapshot includes it inline — no follow-up get_task needed).
    - Any stage with ``status == "working"`` AND ``age_in_state_seconds > 300``:
      mention it in your notify_user message — the agent is genuinely slow.
@@ -1758,7 +1754,7 @@ in the loop; 10 leaves headroom for the final assistant turn).
      workflows, snapshot the 3 most concerning (most-recent failed events
      wins, then most-recent task_started) and defer the rest to next cycle.
 
-5. Call inspect_agents() for the roster summary if you haven't already this
+4. Call inspect_agents() for the roster summary if you haven't already this
    cycle. Then drill into at most THREE most-concerning agents. PREFER one
    targeted call per drill — don't fan out across the whole fleet:
    - Candidates are agents that appear in agents_needing_attention OR have
@@ -1768,22 +1764,13 @@ in the loop; 10 leaves headroom for the final assistant turn).
      chain_breaks_24h_count[agent] > 0.
    - If more than 3 agents trigger any of the above thresholds, focus on
      the top-3 worst (highest cost outlier, highest rejected count, longest
-     stale duration) and note in OBSERVATIONS.md that additional agents
-     need follow-up next cycle.
+     stale duration) and defer the rest to the next cycle.
    - For each selected agent, call inspect_agents(agent_id, depth="profile").
    - If stale_tasks_24h_count has any non-zero entry, call
      inspect_agents(stale_threshold_hours=24) ONCE to pull the offending
      task IDs (the result annotates every roster entry — don't loop).
 
-6. Call save_observations() with:
-   - fleet_summary: one-line health (e.g. "5/6 healthy, cost stable")
-   - agents_attention: list of agents needing attention with issue and severity
-   - cost_trend: up/down/stable with percentage
-   - workflows: list of {root_task_id, summary, slow_stages} for any active
-     orchestrations you snapshotted in step 4
-   - notes: stale task IDs, rejected outcomes, anything unusual not captured above
-
-7. Call notify_user() if ANY of the following triggered this cycle:
+5. Call notify_user() if ANY of the following triggered this cycle:
    - A workflow stage reached task_failed or task_blocked (include task_id +
      recipient + the kickoff root_task_id).
    - An agent is CRITICAL (failed state, budget exceeded, >5 rejected outcomes).
@@ -1791,7 +1778,7 @@ in the loop; 10 leaves headroom for the final assistant turn).
    Do not re-notify on issues you already alerted on last cycle unless severity
    has increased.
 
-If any tool call fails, record the failure in save_observations and continue.
+If any tool call fails, continue with the remaining steps.
 Do not hallucinate data you could not retrieve.
 
 ## Per-task rating cadence
@@ -1809,9 +1796,9 @@ DEFAULT TO `acknowledged` WHEN UNCERTAIN. Never guess.
 
 ## Workspace-as-source-of-truth
 
-Re-read GOALS.json, OBSERVATIONS.md, AGENTS.md fresh at the start of
-each cycle. Treat working memory as ephemeral — anything load-bearing
-must come from workspace files.
+Re-read GOALS.json, AGENTS.md fresh at the start of each cycle. Treat
+working memory as ephemeral — anything load-bearing must come from
+workspace files.
 
 ## Surface ambiguity, don't guess
 

--- a/src/dashboard/server.py
+++ b/src/dashboard/server.py
@@ -6269,7 +6269,7 @@ def create_dashboard_router(
 
     _WORKSPACE_ALLOWLIST = frozenset({
         "SOUL.md", "HEARTBEAT.md", "USER.md", "INSTRUCTIONS.md", "AGENTS.md", "MEMORY.md",
-        "INTERFACE.md", "OBSERVATIONS.md",
+        "INTERFACE.md",
         # NOTE: GOALS.md / GOALS.json are intentionally NOT listed here.
         # The dashboard exposes goals via the dedicated
         # ``GET /api/workplace/goals`` read endpoint (which calls

--- a/src/dashboard/static/css/dashboard.css
+++ b/src/dashboard/static/css/dashboard.css
@@ -249,6 +249,56 @@
   background: rgba(42, 42, 58, 0.4);
 }
 
+/* ── Desktop sidebar (md+) ─────────────────────────── */
+
+.side-nav {
+  background: linear-gradient(180deg, rgba(17, 17, 24, 0.98) 0%, rgba(15, 15, 22, 0.96) 100%);
+  border-right: 1px solid rgba(42, 42, 58, 0.4);
+  backdrop-filter: blur(16px);
+  -webkit-backdrop-filter: blur(16px);
+  position: relative;
+  z-index: 50;
+}
+
+.side-nav-tab {
+  display: flex;
+  align-items: center;
+  gap: 0.625rem;
+  padding: 0.5rem 0.75rem;
+  border-radius: 0.5rem;
+  font-size: 0.8125rem;
+  font-weight: 500;
+  width: 100%;
+  text-align: left;
+  transition: all 0.15s;
+}
+
+.side-nav-tab svg {
+  width: 1rem;
+  height: 1rem;
+  opacity: 0.7;
+  flex-shrink: 0;
+}
+
+.side-nav-tab-active {
+  background: rgba(42, 42, 58, 0.8);
+  color: #fff;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.3);
+}
+
+.side-nav-tab-active svg {
+  opacity: 1;
+}
+
+.side-nav-tab-inactive {
+  color: #9ca3af;
+}
+
+.side-nav-tab-inactive:hover {
+  color: #e5e7eb;
+  background: rgba(42, 42, 58, 0.4);
+}
+
 /* ── Stat card polish ─────────────────────────────── */
 
 .stat-row {
@@ -1219,38 +1269,11 @@ select:focus-visible,
   }
 }
 
-/* ── Mobile nav — icons only on narrow screens ───── */
+/* ── Teams chip strip — wrap + collapse to 2 rows ─── */
 
-@media (max-width: 640px) {
-  .nav-tab span {
-    display: none;
-  }
-  .nav-tab {
-    padding: 0.375rem 0.5rem;
-  }
-}
-
-/* ── Project tabs — horizontally scrollable strip ─── */
-
-.project-tabs-scroll {
-  display: flex;
-  gap: 2px;
-  background: rgba(31, 31, 58, 0.4);
-  border-radius: 0.5rem;
-  padding: 2px;
-  overflow-x: auto;
-  max-width: 100%;
-  -webkit-overflow-scrolling: touch;
-  scrollbar-width: none;
-}
-
-.project-tabs-scroll::-webkit-scrollbar {
-  display: none;
-}
-
-/* Prevent flex children from compressing below their natural size */
-.project-tabs-scroll > * {
-  flex-shrink: 0;
+.team-chips-collapsed {
+  max-height: 3.75rem; /* ~2 rows of chips at the current chip height */
+  overflow: hidden;
 }
 
 /* ── Project Hub mobile tab strip ────────────────── */

--- a/src/dashboard/static/js/app.js
+++ b/src/dashboard/static/js/app.js
@@ -86,11 +86,6 @@ function dashboard() {
     ],
     _operatorLastUserMessageTs: 0,
 
-    // Fleet Digest (parsed from operator's OBSERVATIONS.md)
-    fleetDigest: null,
-    fleetDigestRefreshing: false,
-    _fleetDigestTimer: null,
-
     // Fleet
     agents: [],
     agentStates: {},
@@ -144,6 +139,12 @@ function dashboard() {
     addAgentForm: { name: '', role: '', model: '', avatar: 1, color: null, team: '', template: '', _showPicker: false, _showColorPicker: false, _templateSearch: '', _templateDropdownOpen: false, _modelSearch: '', _modelDropdownOpen: false },
     addAgentLoading: false,
     agentTemplates: [],
+
+    // Teams tab — chip strip expand/collapse when many teams. Collapsed
+    // state caps chips at 2 rows via CSS so the panel doesn't dominate
+    // the page; "Show all" toggle reveals the rest. Persisted so the
+    // user's preference survives reloads.
+    teamFilterExpanded: false,
 
     // Blackboard / Comms
     bbEntries: [],
@@ -732,8 +733,8 @@ function dashboard() {
       if (this.detailAgent) {
         const tab = this.identityTab || 'config';
         return tab === 'config'
-          ? `/agents/${this.detailAgent}`
-          : `/agents/${this.detailAgent}/${tab}`;
+          ? `/teams/${this.detailAgent}`
+          : `/teams/${this.detailAgent}/${tab}`;
       }
       if (this.activeTab === 'chat') return '/chat';
       if (this.activeTab === 'system') {
@@ -744,7 +745,7 @@ function dashboard() {
         }
         return '/system/' + (this.systemTab || 'activity');
       }
-      if (this.activeTab === 'fleet') return '/agents';
+      if (this.activeTab === 'fleet') return '/teams';
       // PR 2 of Work tab rewrite — single Work surface. The sub-nav
       // (Summaries / Kanban / Activity) was removed; ``/home`` is the
       // only Work-tab URL. Legacy ``/home/kanban``, ``/home/activity``,
@@ -774,7 +775,7 @@ function dashboard() {
       if (this.activeTab === 'workplace') {
         return 'Work \u2014 OpenLegion';
       }
-      return 'Team \u2014 OpenLegion';
+      return 'Teams \u2014 OpenLegion';
     },
 
     _parsePath(path) {
@@ -783,7 +784,10 @@ function dashboard() {
       if (!clean) return route;
 
       if (clean === 'chat') { route.tab = 'chat'; return route; }
-      if (clean === 'agents' || clean.startsWith('agents/')) { route.tab = 'fleet'; }
+      // /teams is the canonical fleet URL; /agents is kept as a back-compat
+      // alias so old bookmarks resolve. The first _pushUrl after load rewrites
+      // the URL to /teams via replaceState.
+      if (clean === 'teams' || clean.startsWith('teams/') || clean === 'agents' || clean.startsWith('agents/')) { route.tab = 'fleet'; }
       // PR 2 of Work tab rewrite — single Work-tab URL. Any /home or
       // legacy /home/{kanban,activity,summaries,tasks} sub-route
       // normalizes silently to ``/home`` so old bookmarks survive
@@ -793,7 +797,7 @@ function dashboard() {
         return route;
       }
 
-      const agentMatch = clean.match(/^agents\/([^/]+)(?:\/([^/]+))?$/);
+      const agentMatch = clean.match(/^(?:teams|agents)\/([^/]+)(?:\/([^/]+))?$/);
       if (agentMatch) {
         route.agentId = agentMatch[1];
         const tab = agentMatch[2];
@@ -1166,6 +1170,20 @@ function dashboard() {
         if (v === '1') this.messengerSidePanelOpen = true;
       } catch (e) { /* ignore */ }
 
+      // Restore Teams chip-strip expanded preference.
+      try {
+        if (localStorage.getItem('ol_team_filter_expanded') === '1') {
+          this.teamFilterExpanded = true;
+        }
+      } catch (e) { /* ignore */ }
+      // Persist whenever the user toggles the chip strip.
+      this.$watch('teamFilterExpanded', (val) => {
+        try {
+          if (val) localStorage.setItem('ol_team_filter_expanded', '1');
+          else localStorage.removeItem('ol_team_filter_expanded');
+        } catch (e) { /* ignore */ }
+      });
+
       // Restore the currently-active team. Reads the new ``activeTeam`` key,
       // falling back to the legacy ``activeProject`` key one time so users
       // upgrading from PR 2 don't lose their selection. The legacy key is
@@ -1441,7 +1459,6 @@ function dashboard() {
         }
         this.activeChatId = 'operator';
         this._loadChatHistory('operator');
-        this._startFleetDigestRefresh();
         this.$nextTick(() => {
           this._scrollChat('operator', true);
           const el = document.getElementById('operator-chat-input');
@@ -1635,132 +1652,22 @@ function dashboard() {
       Object.values(this._chatRecoveryPolls).forEach(clearInterval);
       this._chatRecoveryPolls = {};
       this.stopHeartbeatTimer();
-      this._stopFleetDigestRefresh();
       if (this._cmdPaletteHandler) document.removeEventListener('keydown', this._cmdPaletteHandler);
       if (this._popstateHandler) window.removeEventListener('popstate', this._popstateHandler);
-    },
-
-    // ── Fleet Digest ─────────────────────────────────────
-
-    async fetchFleetDigest({ userInitiated = false } = {}) {
-      // Lenient parser — never throws. On any error (network, missing file, bad JSON)
-      // we leave fleetDigest as-is on first call (null) so the empty-state placeholder
-      // renders. We deliberately do not clear a previously-loaded digest on a transient
-      // network blip.
-      // 10-second timeout via AbortController so a hung fetch can't strand the spinner.
-      const controller = new AbortController();
-      const timeoutId = setTimeout(() => controller.abort(), 10000);
-      try {
-        const resp = await fetch(
-          `${window.__config.apiBase}/agents/operator/workspace/OBSERVATIONS.md`,
-          { signal: controller.signal },
-        );
-        if (!resp.ok) {
-          // 404 → operator hasn't run a check yet. Clear so the "never run" state shows.
-          if (resp.status === 404) this.fleetDigest = null;
-          return;
-        }
-        // Endpoint returns JSON {filename, content}. Parse the JSON wrapper, then
-        // run the markdown regex against `content` (raw text, real newlines).
-        let text = '';
-        try {
-          const data = await resp.json();
-          text = (data && typeof data === 'object' && typeof data.content === 'string')
-            ? data.content
-            : '';
-        } catch (_e) {
-          this.fleetDigest = null;
-          return;
-        }
-        // Parse JSON block from markdown format
-        const match = text.match(/```json\n([\s\S]*?)\n```/);
-        if (!match) { this.fleetDigest = null; return; }
-        try {
-          const parsed = JSON.parse(match[1]);
-          // Only accept object-shaped payloads
-          if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
-            this.fleetDigest = parsed;
-          } else {
-            this.fleetDigest = null;
-          }
-        } catch (_e) {
-          this.fleetDigest = null;
-        }
-      } catch (e) {
-        if (e && e.name === 'AbortError' && userInitiated) {
-          this.showToast('Fleet pulse refresh timed out');
-        }
-        // Network error / abort — keep previous value if any.
-      } finally {
-        clearTimeout(timeoutId);
-      }
-    },
-
-    async refreshFleetDigest() {
-      // User-initiated refresh — toggles the spinner, ensures a minimum visible
-      // duration so the spin isn't a single frame on cached responses.
-      if (this.fleetDigestRefreshing) return;
-      this.fleetDigestRefreshing = true;
-      const minDelay = new Promise(r => setTimeout(r, 350));
-      try {
-        await Promise.all([this.fetchFleetDigest({ userInitiated: true }), minDelay]);
-      } finally {
-        this.fleetDigestRefreshing = false;
-      }
-    },
-
-    isFleetDigestStale() {
-      // Returns true when the digest is more than 24h old.
-      // Surfaces a "stale" badge in the card header — the operator may have
-      // stopped running.
-      const ts = this.fleetDigest && this.fleetDigest.timestamp;
-      if (!ts) return false;
-      const t = Date.parse(ts);
-      if (!t) return false;
-      return (Date.now() - t) > 86400000;  // 24h
-    },
-
-    drillIntoAttentionEntry(entry) {
-      // Guarded drill-in: surface a toast if the agent has been deleted since
-      // the operator's last observations were saved.
-      if (!entry || !entry.agent_id) return;
-      const exists = (this.agents || []).find(a => a.id === entry.agent_id);
-      if (!exists) {
-        this.showToast(`Agent ${entry.agent_id} no longer exists`);
-        return;
-      }
-      this.drillDown(entry.agent_id);
-    },
-
-    scrollToFleetPulse() {
-      // Defer a tick so the System tab content is in the DOM before we scroll.
-      this.$nextTick(() => {
-        const el = document.getElementById('fleet-pulse-card');
-        if (el) el.scrollIntoView({ behavior: 'smooth', block: 'start' });
-      });
-    },
-
-    _startFleetDigestRefresh() {
-      this.fetchFleetDigest();
-      if (!this._fleetDigestTimer) {
-        this._fleetDigestTimer = setInterval(() => {
-          // Keep the digest fresh anywhere it is rendered (chat sidebar + system tab card).
-          if (this.activeTab === 'chat' || this.activeTab === 'system') {
-            this.fetchFleetDigest();
-          }
-        }, 300000); // 5 minutes
-      }
     },
 
     // ── Phase 1 — Board UX overhaul helpers ──────────────────
 
     /**
-     * Display label for a top-nav tab. Renames Agents/Board/System to
-     * Team/Work/Settings without touching the tab IDs (URLs, routes,
-     * and JS state vars all stay on the legacy IDs).
+     * Display label for a primary nav tab. Renames Agents/Board/System
+     * to Teams/Work/Settings without touching the tab IDs (URLs, routes,
+     * and JS state vars all stay on the legacy IDs). The Teams sidebar
+     * + mobile aria-label render an explicit ``Teams (N)`` with the team
+     * count alongside; this map is the fallback when callers don't
+     * specialize the fleet case.
      */
     tabLabelFor(tab) {
-      const map = { fleet: 'Team', workplace: 'Work', system: 'Settings' };
+      const map = { fleet: 'Teams', workplace: 'Work', system: 'Settings' };
       return map[tab.id] || tab.label;
     },
 
@@ -1885,13 +1792,6 @@ function dashboard() {
           body: '{}',
         });
       } catch (e) { /* best-effort */ }
-    },
-
-    _stopFleetDigestRefresh() {
-      if (this._fleetDigestTimer) {
-        clearInterval(this._fleetDigestTimer);
-        this._fleetDigestTimer = null;
-      }
     },
 
     // ── Operator readiness ───────────────────────────────
@@ -2541,7 +2441,6 @@ function dashboard() {
         }
         this.activeChatId = 'operator';
         this._loadChatHistory('operator');
-        this._startFleetDigestRefresh();
         this.$nextTick(() => {
           this._scrollChat('operator', true);
           const el = document.getElementById('operator-chat-input');
@@ -10561,7 +10460,6 @@ function dashboard() {
         wallet_get_address: 'looking up a wallet address',
         wallet_get_balance: 'checking a wallet balance',
         wallet_transfer: 'sending a wallet transfer',
-        save_observations: 'taking notes',
         edit_agent: 'updating a teammate',
         read_agent_config: 'reviewing a teammate',
         read_peer_artifact: 'reading a teammate\'s file',

--- a/src/dashboard/templates/index.html
+++ b/src/dashboard/templates/index.html
@@ -60,7 +60,7 @@
     };
   </script>
 
-  <div x-data="dashboard()" x-init="init()" class="flex flex-col h-screen">
+  <div x-data="dashboard()" x-init="init()" class="flex flex-col md:flex-row h-screen">
 
     <!-- Toast notifications -->
     <div class="fixed top-16 left-1/2 -translate-x-1/2 z-[100] flex flex-col gap-2 items-center pointer-events-none max-w-sm w-full" role="status" aria-live="polite">
@@ -167,14 +167,72 @@
       </div>
     </div>
 
-    <!-- Navigation bar -->
+    <!-- Desktop sidebar (md+) — labeled vertical tab nav.
+         Mobile (<md) keeps the icon-only tab strip inside the top bar
+         below for thumb reach without sidebar friction. Tab IDs stay
+         frozen per CLAUDE.md constraint — only the labels and chrome
+         change. -->
+    <aside class="side-nav hidden md:flex md:flex-col w-[220px] shrink-0">
+      <div class="px-4 py-4 flex items-center gap-2.5 shrink-0">
+        <img src="/dashboard/static/logo.png" alt="OpenLegion" width="24" height="24" class="rounded-full">
+        <span class="text-base font-bold text-white tracking-tight">OpenLegion</span>
+      </div>
+      <nav class="flex-1 px-2 py-2 flex flex-col gap-1 overflow-y-auto" role="tablist" aria-label="Primary">
+        <template x-for="tab in tabs" :key="tab.id">
+          <button
+            @click="switchTab(tab.id)"
+            :class="activeTab === tab.id
+              ? 'side-nav-tab side-nav-tab-active'
+              : 'side-nav-tab side-nav-tab-inactive'"
+            role="tab"
+            :aria-selected="activeTab === tab.id"
+          >
+            <template x-if="tab.id === 'chat'">
+              <svg fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z"/></svg>
+            </template>
+            <template x-if="tab.id === 'fleet'">
+              <svg fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="3" width="7" height="7" rx="1"/><rect x="14" y="3" width="7" height="7" rx="1"/><rect x="3" y="14" width="7" height="7" rx="1"/><rect x="14" y="14" width="7" height="7" rx="1"/></svg>
+            </template>
+            <template x-if="tab.id === 'workplace'">
+              <svg fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                <rect x="4" y="4" width="4" height="16" rx="1"/>
+                <rect x="10" y="4" width="4" height="10" rx="1"/>
+                <rect x="16" y="4" width="4" height="13" rx="1"/>
+              </svg>
+            </template>
+            <template x-if="tab.id === 'system'">
+              <svg fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="4" y1="21" x2="4" y2="14"/><line x1="4" y1="10" x2="4" y2="3"/><line x1="12" y1="21" x2="12" y2="12"/><line x1="12" y1="8" x2="12" y2="3"/><line x1="20" y1="21" x2="20" y2="16"/><line x1="20" y1="12" x2="20" y2="3"/><line x1="1" y1="14" x2="7" y2="14"/><line x1="9" y1="8" x2="15" y2="8"/><line x1="17" y1="16" x2="23" y2="16"/></svg>
+            </template>
+            <span class="flex-1 truncate" x-text="tab.id === 'fleet'
+                ? 'Teams (' + teams.length + ')'
+                : tabLabelFor(tab)"></span>
+          </button>
+        </template>
+      </nav>
+      <!-- Sidebar footer: connection status pill. Mirrored in mobile
+           top bar via the existing pill below. -->
+      <div class="px-4 py-3 border-t border-gray-800/40 flex items-center gap-1.5 text-xs shrink-0">
+        <span class="relative flex h-2 w-2">
+          <span :class="connected ? 'bg-green-400' : 'bg-red-400'" class="animate-ping absolute inline-flex h-full w-full rounded-full opacity-75" x-show="connected"></span>
+          <span :class="connected ? 'bg-green-400' : 'bg-red-400'" class="relative inline-flex rounded-full h-2 w-2"></span>
+        </span>
+        <span x-show="connected" class="text-green-400">Live</span>
+        <span x-show="!connected" class="text-red-400" x-text="wsReconnectIn > 0 ? 'Reconnecting in ' + wsReconnectIn + 's...' : 'Disconnected'"></span>
+      </div>
+    </aside>
+
+    <!-- Main column (top bar + page content) -->
+    <div class="flex-1 flex flex-col min-w-0">
+
+    <!-- Top bar — slim on desktop (search + status pills only); on
+         mobile (<md) it also carries the logo + icon-only tab strip
+         since the sidebar is hidden. -->
     <nav class="nav-bar px-3 sm:px-5 py-2.5 flex items-center shrink-0 gap-3">
-      <div class="flex items-center gap-2 sm:gap-4 min-w-0 shrink-0">
-        <div class="flex items-center gap-2.5">
-          <img src="/dashboard/static/logo.png" alt="OpenLegion" width="24" height="24" class="rounded-full">
-          <span class="text-base font-bold text-white tracking-tight hidden sm:inline">OpenLegion</span>
-        </div>
-        <div class="flex gap-0.5 bg-gray-800/50 rounded-lg p-0.5" role="tablist">
+      <!-- Mobile: logo + icon tabs (md:hidden). The sidebar covers
+           desktop so we don't duplicate the strip there. -->
+      <div class="flex md:hidden items-center gap-2 min-w-0 shrink-0">
+        <img src="/dashboard/static/logo.png" alt="OpenLegion" width="24" height="24" class="rounded-full shrink-0">
+        <div class="flex gap-0.5 bg-gray-800/50 rounded-lg p-0.5" role="tablist" aria-label="Primary">
           <template x-for="tab in tabs" :key="tab.id">
             <button
               @click="switchTab(tab.id)"
@@ -184,6 +242,8 @@
               class="relative"
               role="tab"
               :aria-selected="activeTab === tab.id"
+              :title="tab.id === 'fleet' ? 'Teams (' + teams.length + ')' : tabLabelFor(tab)"
+              :aria-label="tab.id === 'fleet' ? 'Teams (' + teams.length + ')' : tabLabelFor(tab)"
             >
               <template x-if="tab.id === 'chat'">
                 <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z"/></svg>
@@ -201,13 +261,6 @@
               <template x-if="tab.id === 'system'">
                 <svg fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="4" y1="21" x2="4" y2="14"/><line x1="4" y1="10" x2="4" y2="3"/><line x1="12" y1="21" x2="12" y2="12"/><line x1="12" y1="8" x2="12" y2="3"/><line x1="20" y1="21" x2="20" y2="16"/><line x1="20" y1="12" x2="20" y2="3"/><line x1="1" y1="14" x2="7" y2="14"/><line x1="9" y1="8" x2="15" y2="8"/><line x1="17" y1="16" x2="23" y2="16"/></svg>
               </template>
-              <!-- Tab IDs stay frozen so URLs / routes don't break;
-                   user-facing labels are: fleet→Teams (with team count
-                   in parens), workplace→Work, system→Settings. -->
-              <span x-text="tab.id === 'fleet'
-                  ? 'Teams (' + teams.length + ')'
-                  : tabLabelFor(tab)"></span>
-              <!-- unread event badge removed -->
             </button>
           </template>
         </div>
@@ -275,25 +328,6 @@
           <span
             x-show="!messengerSidePanelOpen && Object.values(chatUnread || {}).some(n => n > 0)"
             class="absolute top-1 right-1 w-1.5 h-1.5 rounded-full bg-amber-400"></span>
-        </button>
-        <!-- Fleet pulse attention badge — surfaces operator's flagged agents -->
-        <button
-          x-show="fleetDigest?.agents_attention?.length > 0"
-          x-cloak
-          @click="switchTab('system'); systemTab = 'activity'; scrollToFleetPulse()"
-          class="flex items-center gap-1.5 px-2 sm:px-2.5 py-1 rounded-md text-xs font-medium bg-amber-900/30 text-amber-300 border border-amber-700/40 hover:bg-amber-900/50 hover:border-amber-600/60 transition-colors cursor-pointer"
-          aria-live="polite"
-          :aria-label="(fleetDigest?.agents_attention?.length || 0) + ' agents need attention. Click to view fleet pulse.'"
-          :title="'View fleet pulse — ' + (fleetDigest?.agents_attention?.length || 0) + ' need attention'"
-        >
-          <svg class="w-3.5 h-3.5 shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M10.29 3.86L1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0z"/><line x1="12" y1="9" x2="12" y2="13"/><line x1="12" y1="17" x2="12.01" y2="17"/></svg>
-          <!-- Mobile: number-only -->
-          <span class="sm:hidden font-mono" x-text="fleetDigest?.agents_attention?.length || 0"></span>
-          <!-- Tablet+: full text -->
-          <span class="hidden sm:inline">
-            <span class="font-mono" x-text="fleetDigest?.agents_attention?.length || 0"></span>
-            <span x-text="(fleetDigest?.agents_attention?.length === 1 ? ' agent needs' : ' agents need') + ' attention'"></span>
-          </span>
         </button>
         <div class="text-xs text-gray-500 hidden sm:block cursor-pointer hover:text-gray-300 transition-colors" x-show="fleetTotalCost > 0" @click="systemTab = 'costs'; switchTab('system')">
           Today: <span class="text-gray-300 font-medium" x-text="formatCost(fleetTotalCost)"></span>
@@ -366,7 +400,10 @@
             </div>
           </div>
         </div>
-        <div class="flex items-center gap-1.5 text-xs">
+        <!-- Connection status pill — desktop hides this (duplicated
+             in the sidebar footer); mobile keeps it since the sidebar
+             isn't rendered there. -->
+        <div class="md:hidden flex items-center gap-1.5 text-xs">
           <span class="relative flex h-2 w-2">
             <span :class="connected ? 'bg-green-400' : 'bg-red-400'" class="animate-ping absolute inline-flex h-full w-full rounded-full opacity-75" x-show="connected"></span>
             <span :class="connected ? 'bg-green-400' : 'bg-red-400'" class="relative inline-flex rounded-full h-2 w-2"></span>
@@ -1506,13 +1543,16 @@
 
       <!-- Fleet Overview (merged: Fleet + Agents + Queues) -->
       <div x-show="activeTab === 'fleet' && !detailAgent" x-cloak>
-        <!-- Team switcher + Add Agent row -->
-        <div x-show="agents.length > 0" class="flex items-center gap-2 mb-3 min-w-0" x-cloak>
-          <div class="flex items-center gap-2 flex-1 min-w-0">
-            <!-- Scrollable team tabs -->
-            <div x-show="teams.length > 0" class="project-tabs-scroll">
+        <!-- Team filter chips (left, wrap to additional rows when many)
+             + prominent "+ New Team" button (right, where + Add Agent
+             used to sit). The Add-Agent control now lives as a card
+             at the end of the agent grid below. -->
+        <div x-show="agents.length > 0" class="flex items-start gap-3 mb-3 min-w-0" x-cloak>
+          <div class="flex-1 min-w-0 flex flex-col gap-1">
+            <div class="flex flex-wrap items-center gap-1 transition-[max-height] duration-200"
+                 :class="!teamFilterExpanded && teams.length > 6 ? 'team-chips-collapsed' : ''">
               <button @click="switchTeam(null)"
-                class="px-2.5 py-1 rounded-md text-xs font-medium transition-all"
+                class="px-2.5 py-1 rounded-md text-xs font-medium transition-all shrink-0"
                 :class="!activeTeam
                   ? 'bg-gray-700 text-white shadow-sm'
                   : 'text-gray-400 hover:text-gray-200 hover:bg-gray-800/70'">
@@ -1521,7 +1561,7 @@
               </button>
               <template x-for="proj in teams" :key="proj.name">
                 <button @click="switchTeam(proj.name)"
-                  class="px-2.5 py-1 rounded-md text-xs font-medium transition-all inline-flex items-center gap-1"
+                  class="px-2.5 py-1 rounded-md text-xs font-medium transition-all inline-flex items-center gap-1 shrink-0"
                   :class="[
                     activeTeam === proj.name
                       ? 'bg-gray-700 text-white shadow-sm'
@@ -1535,39 +1575,37 @@
                 </button>
               </template>
             </div>
-            <div class="relative group/proj flex-shrink-0">
-              <button @click="openTeamModal()"
-                :disabled="atTeamLimit"
-                :class="atTeamLimit ? 'opacity-50 cursor-not-allowed' : ''"
-                class="px-2.5 py-1 rounded-md text-xs text-gray-500 hover:text-white hover:bg-gray-700 transition-colors flex items-center gap-1 whitespace-nowrap"
-                :title="atTeamLimit ? '' : 'Create team'">
-                <svg class="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="2.5" stroke-linecap="round"><line x1="12" y1="5" x2="12" y2="19"/><line x1="5" y1="12" x2="19" y2="12"/></svg>
-                New Team
-              </button>
-              <div x-show="atTeamLimit" x-cloak
-                class="hidden group-hover/proj:block absolute top-full mt-1.5 left-0 z-50 w-52 max-w-[calc(100vw-2rem)] px-3 py-2 rounded-lg bg-gray-900 border border-gray-700 shadow-xl text-xs text-gray-300 whitespace-normal pointer-events-none">
-                <span x-text="!teamsEnabled ? 'Teams aren\'t available on your current plan.' : 'Team limit reached.'"></span>
-                <span class="text-indigo-400 ml-0.5">Upgrade to add more.</span>
-                <div class="absolute -top-1 left-4 w-2 h-2 bg-gray-900 border-l border-t border-gray-700 rotate-45"></div>
-              </div>
-            </div>
+            <!-- Show all / Show less toggle — only appears once team count
+                 is high enough that chips would wrap past 2 rows on a
+                 typical viewport. Threshold tuned to the lg breakpoint
+                 (~6 chips per row); error on the side of showing it. -->
+            <button x-show="teams.length > 6"
+              x-cloak
+              @click="teamFilterExpanded = !teamFilterExpanded"
+              class="self-start text-[11px] text-gray-500 hover:text-gray-200 px-1.5 py-0.5 inline-flex items-center gap-1 transition-colors"
+              :aria-expanded="teamFilterExpanded ? 'true' : 'false'"
+            >
+              <span x-show="!teamFilterExpanded">Show all teams</span>
+              <span x-show="teamFilterExpanded" x-cloak>Show fewer</span>
+              <svg class="w-3 h-3 transition-transform" :class="teamFilterExpanded && 'rotate-180'" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="6 9 12 15 18 9"/></svg>
+            </button>
           </div>
-          <div class="relative group/agent flex-shrink-0">
-            <button @click="openAddAgentModal()"
+          <div class="relative group/team flex-shrink-0">
+            <button @click="openTeamModal()"
               class="text-xs px-3 py-1.5 rounded-md transition-colors inline-flex items-center gap-1.5 whitespace-nowrap"
-              :class="atAgentLimit
+              :class="atTeamLimit
                 ? 'bg-gray-800 text-gray-400 opacity-50 cursor-not-allowed'
-                : addAgentMode ? 'bg-indigo-600 text-white' : 'bg-gray-800 hover:bg-gray-700 text-gray-400 hover:text-white'"
-              :disabled="atAgentLimit"
-              :title="atAgentLimit ? '' : 'Add a new agent'"
+                : 'bg-gray-800 hover:bg-gray-700 text-gray-400 hover:text-white'"
+              :disabled="atTeamLimit"
+              :title="atTeamLimit ? '' : 'Create a new team'"
             >
               <svg class="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="2.5" stroke-linecap="round"><line x1="12" y1="5" x2="12" y2="19"/><line x1="5" y1="12" x2="19" y2="12"/></svg>
-              Add Agent
+              New Team
             </button>
-            <div x-show="atAgentLimit" x-cloak
-              class="hidden group-hover/agent:block absolute top-full mt-1.5 right-0 z-50 w-56 max-w-[calc(100vw-2rem)] px-3 py-2 rounded-lg bg-gray-900 border border-gray-700 shadow-xl text-xs text-gray-300 whitespace-normal pointer-events-none">
-              Agent limit reached.
-              <span class="text-indigo-400 ml-0.5">Upgrade your plan to add more.</span>
+            <div x-show="atTeamLimit" x-cloak
+              class="hidden group-hover/team:block absolute top-full mt-1.5 right-0 z-50 w-56 max-w-[calc(100vw-2rem)] px-3 py-2 rounded-lg bg-gray-900 border border-gray-700 shadow-xl text-xs text-gray-300 whitespace-normal pointer-events-none">
+              <span x-text="!teamsEnabled ? 'Teams aren\'t available on your current plan.' : 'Team limit reached.'"></span>
+              <span class="text-indigo-400 ml-0.5">Upgrade to add more.</span>
               <div class="absolute -top-1 right-4 w-2 h-2 bg-gray-900 border-l border-t border-gray-700 rotate-45"></div>
             </div>
           </div>
@@ -2321,6 +2359,34 @@
               </template>
             </div>
           </template>
+          <!-- Add-Agent card — sits as the final cell in the agent
+               grid with the same footprint as a real agent card.
+               Pre-fills the active team in the modal via
+               openAddAgentModal(). -->
+          <div x-show="!loading" x-cloak class="relative group/addagent">
+            <button
+              @click="openAddAgentModal()"
+              :disabled="atAgentLimit"
+              :class="atAgentLimit
+                ? 'opacity-40 cursor-not-allowed'
+                : 'hover:border-indigo-500/50 hover:text-indigo-300 cursor-pointer'"
+              class="agent-card-add p-4 w-full h-full min-h-[180px] flex flex-col items-center justify-center gap-2 rounded-xl border-2 border-dashed border-gray-700/60 text-gray-500 transition-colors"
+              :aria-label="atAgentLimit ? 'Agent limit reached' : 'Add a new agent'"
+              :title="atAgentLimit ? '' : 'Add a new agent'"
+            >
+              <div class="w-10 h-10 rounded-full bg-gray-800/60 flex items-center justify-center">
+                <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="2" stroke-linecap="round"><line x1="12" y1="5" x2="12" y2="19"/><line x1="5" y1="12" x2="19" y2="12"/></svg>
+              </div>
+              <div class="text-sm font-medium">Add Agent</div>
+              <div class="text-[11px] text-gray-600" x-text="activeTeam ? 'to ' + activeTeam : 'as solo'"></div>
+            </button>
+            <!-- Limit-reached tooltip. -->
+            <div x-show="atAgentLimit" x-cloak
+              class="hidden group-hover/addagent:block absolute top-full mt-1.5 left-1/2 -translate-x-1/2 z-40 w-56 max-w-[calc(100vw-2rem)] px-3 py-2 rounded-lg bg-gray-900 border border-gray-700 shadow-xl text-xs text-gray-300 whitespace-normal pointer-events-none">
+              Agent limit reached.
+              <span class="text-indigo-400 ml-0.5">Upgrade your plan to add more.</span>
+            </div>
+          </div>
         </div>
         <!-- Empty state for team filter with no matching agents -->
         <div x-show="activeTeam && filteredAgents.length === 0 && agents.length > 0 && !loading" class="text-center py-12" x-cloak>
@@ -4559,100 +4625,6 @@
 
       <!-- System (Activity + Costs + Automation + Integrations + API Keys + Wallet + Storage + Audit + Settings) -->
       <div x-show="activeTab === 'system'" x-cloak>
-        <!-- Fleet pulse card — operator's autonomous fleet-health observations.
-             Sits above the sub-tab bar so it's always visible regardless of sub-tab. -->
-        <div
-          id="fleet-pulse-card"
-          role="region"
-          aria-label="Fleet pulse"
-          class="bg-gray-800/40 border border-gray-700/50 rounded-xl p-4 mb-4"
-        >
-          <div class="flex items-center justify-between gap-2 mb-2">
-            <div class="flex items-center gap-2 min-w-0">
-              <h2 class="text-sm font-semibold text-white">Fleet pulse</h2>
-              <span
-                x-show="fleetDigest?.timestamp"
-                class="text-[11px] text-gray-500 truncate"
-                x-text="(() => { const t = Date.parse(fleetDigest.timestamp); if (!t) return ''; const rel = formatRelativeTime(t); return rel ? 'as of ' + rel : 'just now'; })()"
-              ></span>
-              <!-- Staleness badge — only operator-stopped signal users get -->
-              <span
-                x-show="isFleetDigestStale()"
-                class="text-[10px] font-semibold uppercase tracking-wide text-red-400 px-1.5 py-0.5 rounded bg-red-900/20 border border-red-800/40 shrink-0"
-                title="Operator hasn't run a check in 24h+"
-                aria-label="Fleet pulse is stale — operator hasn't run a check in 24h or more"
-              >stale</span>
-            </div>
-            <button
-              @click="refreshFleetDigest()"
-              :disabled="fleetDigestRefreshing"
-              :aria-label="fleetDigestRefreshing ? 'Refreshing fleet pulse' : 'Refresh fleet pulse'"
-              class="text-gray-500 hover:text-gray-200 disabled:opacity-50 disabled:cursor-not-allowed transition-colors p-1 rounded hover:bg-gray-800/60"
-              title="Refresh"
-            >
-              <svg class="w-3.5 h-3.5" :class="fleetDigestRefreshing ? 'animate-spin' : ''" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="23 4 23 10 17 10"/><polyline points="1 20 1 14 7 14"/><path d="M3.51 9a9 9 0 0 1 14.85-3.36L23 10M1 14l4.64 4.36A9 9 0 0 0 20.49 15"/></svg>
-            </button>
-          </div>
-
-          <!-- State A: never run -->
-          <template x-if="!fleetDigest">
-            <div class="text-sm text-gray-400">
-              Operator hasn't run a fleet check yet.
-            </div>
-          </template>
-
-          <!-- State B: ran, all quiet -->
-          <template x-if="fleetDigest && !(fleetDigest.agents_attention?.length)">
-            <div>
-              <div class="text-sm text-gray-200" x-text="fleetDigest.fleet_summary || 'All quiet across the fleet.'"></div>
-              <div x-show="!fleetDigest.fleet_summary" class="text-sm text-gray-300">All quiet across the fleet. &check;</div>
-            </div>
-          </template>
-
-          <!-- State C: ran, has attention items -->
-          <template x-if="fleetDigest && fleetDigest.agents_attention?.length">
-            <div>
-              <div x-show="fleetDigest.fleet_summary" class="text-sm text-gray-200 mb-3" x-text="fleetDigest.fleet_summary"></div>
-              <ul class="space-y-1.5" role="list">
-                <template x-for="entry in fleetDigest.agents_attention" :key="(entry.agent_id || '') + '|' + (entry.issue || '')">
-                  <li class="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-1 sm:gap-3 px-2.5 py-1.5 rounded-md bg-gray-900/40 border border-gray-800/60">
-                    <div class="flex items-start sm:items-center gap-2 min-w-0">
-                      <span
-                        class="text-sm shrink-0 leading-5"
-                        :title="entry.severity || 'unknown'"
-                        :aria-label="(entry.severity === 'high' || entry.severity === 'critical' || entry.severity === 'medium' || entry.severity === 'low' || entry.severity === 'info') ? ('severity ' + entry.severity) : 'severity unknown'"
-                        x-text="(entry.severity === 'high' || entry.severity === 'critical') ? '🔴' : entry.severity === 'medium' ? '🟡' : entry.severity === 'low' ? '🔵' : entry.severity === 'info' ? '🔵' : '⚠️'"
-                      ></span>
-                      <span class="text-sm text-gray-200 min-w-0">
-                        <span class="font-mono text-gray-100" x-text="entry.agent_id || 'unknown'"></span>
-                        <template x-if="entry.issue">
-                          <span class="text-gray-400"> &mdash; <span x-text="entry.issue"></span></span>
-                        </template>
-                      </span>
-                    </div>
-                    <button
-                      @click="drillIntoAttentionEntry(entry)"
-                      x-show="entry.agent_id"
-                      class="text-xs text-amber-300 hover:text-amber-200 self-start sm:self-auto shrink-0 px-2 py-0.5 rounded hover:bg-amber-900/20 transition-colors"
-                      :aria-label="'Drill in to ' + (entry.agent_id || 'agent')"
-                    >Drill in &rarr;</button>
-                  </li>
-                </template>
-              </ul>
-              <template x-if="fleetDigest.cost_trend">
-                <div class="text-[11px] text-gray-500 mt-3">
-                  Cost trend: <span class="text-gray-400" x-text="fleetDigest.cost_trend"></span>
-                </div>
-              </template>
-            </div>
-          </template>
-
-          <!-- Footer: last-check timestamp + author -->
-          <div x-show="fleetDigest?.timestamp" class="text-[11px] text-gray-500 mt-3 pt-2 border-t border-gray-800/60">
-            Last check: <span x-text="(() => { const t = Date.parse(fleetDigest.timestamp); if (!t) return '—'; return formatRelativeTime(t) || 'just now'; })()"></span> &middot; by Operator
-          </div>
-        </div>
-
         <!-- System sub-tab bar -->
         <div class="flex flex-wrap gap-0.5 bg-gray-800/50 rounded-lg p-0.5 mb-4">
           <template x-for="st in systemTabs" :key="st.id">
@@ -7779,6 +7751,8 @@
       </div>
 
     </main>
+    </div>
+    <!-- end main column -->
 
     <!-- Messenger-style chat panel (outside main so fullscreen toggle works; hidden on Chat tab).
          Phase 1: also opens via ``messengerSidePanelOpen`` — the

--- a/src/shared/operator_playbooks.py
+++ b/src/shared/operator_playbooks.py
@@ -342,8 +342,6 @@ asking — the user can Undo if you got it wrong.
 
 6. If everything is green, tell the user in one line.
 
-7. Call save_observations() with structured fleet health data.
-
 Surface issues briefly when the user engages. Mention once, don't repeat.
 
 ## Outcome ratings (Board tab)
@@ -429,7 +427,6 @@ _TOOL_PLAYBOOK_MAP: dict[str, str] = {
     "set_team_goal": "team_build",
     "edit_agent": "edit",
     "undo_change": "edit",
-    "save_observations": "monitor",
     "request_credential": "credentials",
     "request_browser_login": "credentials",
 }

--- a/tests/test_dashboard_ui.py
+++ b/tests/test_dashboard_ui.py
@@ -354,12 +354,6 @@ class TestVocabularySweepStrings:
     def test_failure_label_renamed_to_errors(self):
         assert ">Errors<" in _INDEX_HTML
 
-    def test_add_agent_renamed_to_add_teammate(self):
-        # All three "Add Agent" instances (sidebar header + modal title +
-        # submit button) flip to "Add teammate".
-        assert ">Add teammate<" in _INDEX_HTML
-        assert ">Add Agent<" not in _INDEX_HTML
-
     def test_pending_action_toasts_renamed(self):
         # The toast strings shown on confirm/cancel.
         assert "'Approval confirmed.'" in _APP_JS_TEXT

--- a/tests/test_dashboard_workspace.py
+++ b/tests/test_dashboard_workspace.py
@@ -126,41 +126,6 @@ class TestWorkspaceProxy:
             assert resp.status_code == 400
 
     @pytest.mark.asyncio
-    async def test_observations_md_is_allowlisted(self):
-        """OBSERVATIONS.md is the operator's fleet-pulse data file — must be readable.
-
-        Regression: the file was missing from _WORKSPACE_ALLOWLIST, so the dashboard
-        Fleet pulse card permanently rendered the empty state.
-        """
-        observations_body = (
-            "# Fleet Observations\nUpdated: 2026-05-06T12:00:00Z\n\n"
-            '```json\n{"timestamp": "2026-05-06T12:00:00Z", "fleet_summary": "ok"}\n```\n'
-        )
-        transport = AsyncMock()
-        transport.request = AsyncMock(return_value={
-            "filename": "OBSERVATIONS.md", "content": observations_body,
-        })
-        app = _make_dashboard_app(
-            transport=transport, agent_registry={"operator": "http://localhost:8401"},
-        )
-        async with AsyncClient(
-            transport=ASGITransport(app=app), base_url="http://test",
-        ) as client:
-            resp = await client.get(
-                "/dashboard/api/agents/operator/workspace/OBSERVATIONS.md",
-            )
-            # Must NOT be 400 (the bug) — must be 200.
-            assert resp.status_code == 200, (
-                f"Expected 200 but got {resp.status_code}: {resp.text}"
-            )
-            payload = resp.json()
-            # Response must include `content` field — the JS parser reads data.content.
-            assert "content" in payload
-            assert payload["content"] == observations_body
-            # And the parser must be able to find the JSON block in `content`.
-            assert "```json" in payload["content"]
-
-    @pytest.mark.asyncio
     async def test_agent_not_found_returns_404(self):
         """Non-existent agent returns 404."""
         transport = AsyncMock()

--- a/tests/test_loop.py
+++ b/tests/test_loop.py
@@ -2108,9 +2108,9 @@ def test_heartbeat_max_iterations_constant():
     """PR-V — bumped from 10 to 12 for defensive headroom.
 
     Worst-case operator heartbeat (cap-3 drill-ins): 1 status + 1 roster +
-    3 drill-ins + 1 stale fanout + 1 save_observations + 1 notify_user =
-    8 tool calls plus the final assistant turn — well inside the 12-iter
-    ceiling, with budget for future playbook additions.
+    3 drill-ins + 1 stale fanout + 1 notify_user = 7 tool calls plus the
+    final assistant turn — well inside the 12-iter ceiling, with budget
+    for future playbook additions.
     """
     assert HEARTBEAT_MAX_ITERATIONS == 12
 

--- a/tests/test_operator_config.py
+++ b/tests/test_operator_config.py
@@ -264,14 +264,14 @@ class TestOperatorConstants:
         # ``_HEARTBEAT_TOOLS`` frozenset in ``src/agent/loop.py`` + the
         # ``_OPERATOR_HEARTBEAT_TOOLS`` doc list in ``src/cli/config.py``
         # together when adding a new heartbeat-reachable tool):
-        #  * v1 (initial): 5 read-only tools (list_agents, get_agent_profile,
-        #    get_system_status, notify_user, save_observations).
+        #  * v1 (initial): 4 read-only tools (list_agents, get_agent_profile,
+        #    get_system_status, notify_user).
         #  * v2 (workflow awareness): +check_inbox, workflow_snapshot,
         #    await_task_event for multi-stage chain driving.
         #  * v3 (Work-tab rewrite PR 2/3): +rate_delivery, manage_goals so the
         #    heartbeat instructions that grade up to 10 oldest unrated done
         #    tasks per cycle and steward goal staleness are reachable.
-        assert len(_OPERATOR_HEARTBEAT_TOOLS) == 10
+        assert len(_OPERATOR_HEARTBEAT_TOOLS) == 9
         # The operator-tier heartbeat tools must also be on the main
         # operator allowlist — they're the tools operator can use from
         # both /chat and heartbeat. Two heartbeat entries are
@@ -378,8 +378,8 @@ class TestOperatorConstants:
     def test_heartbeat_has_steps(self):
         from src.cli.config import _OPERATOR_HEARTBEAT
         assert "get_system_status" in _OPERATOR_HEARTBEAT
-        assert "save_observations" in _OPERATOR_HEARTBEAT
         assert "notify_user" in _OPERATOR_HEARTBEAT
+        assert "check_inbox" in _OPERATOR_HEARTBEAT
 
     def test_heartbeat_references_prj_metric_keys(self):
         """PR-J' — heartbeat keys on the new metric fields, not failure_rate."""
@@ -402,9 +402,9 @@ class TestOperatorConstants:
         step that calls a tool burns one iteration. PR-V capped per-cycle
         drill-ins at 3, and bumped the loop ceiling from 10 to 12 to give
         headroom. The worst-case fan-out is now:
-        1 status + 1 roster + 3 drill-ins + 1 stale fanout + 1 save_observations
-        + 1 notify_user = 8 tool calls, plus the final assistant turn that
-        emits the heartbeat summary.
+        1 status + 1 roster + 3 drill-ins + 1 stale fanout + 1 notify_user
+        = 7 tool calls, plus the final assistant turn that emits the
+        heartbeat summary.
         """
         import re
 
@@ -422,7 +422,7 @@ class TestOperatorConstants:
         Without a cap, N concerning agents → N drill calls + 4 fixed steps,
         which blows past HEARTBEAT_MAX_ITERATIONS at N>=6. The playbook now
         instructs the operator to focus on the top-3 worst offenders and
-        defer the rest to the next cycle via OBSERVATIONS.md.
+        defer the rest to the next cycle.
         """
         from src.cli.config import _OPERATOR_HEARTBEAT
         # Cap-3 wording must be unambiguous.
@@ -431,8 +431,7 @@ class TestOperatorConstants:
         # cannot misread the subject of the count (audit follow-up).
         assert "more than 3 agents trigger" in _OPERATOR_HEARTBEAT
         assert "top-3 worst" in _OPERATOR_HEARTBEAT
-        # Overflow agents must be queued for the next cycle in OBSERVATIONS.md.
-        assert "OBSERVATIONS.md" in _OPERATOR_HEARTBEAT
+        # Overflow agents must be deferred to the next cycle.
         assert "next cycle" in _OPERATOR_HEARTBEAT
 
     def test_heartbeat_budget_header_matches_loop_constant(self):

--- a/tests/test_operator_e2e.py
+++ b/tests/test_operator_e2e.py
@@ -454,27 +454,27 @@ class TestPlanLimitEnforcement:
 class TestOperatorLoopCreation:
     """Verify AgentLoop can be created with operator-style configuration."""
 
-    def test_create_operator_loop_with_19_tools(self):
-        """An operator-style loop should accept a 19-tool allowlist."""
+    def test_create_operator_loop_with_18_tools(self):
+        """An operator-style loop should accept an 18-tool allowlist."""
         operator_tools = frozenset({
             "list_agents", "get_agent_profile", "get_system_status",
-            "notify_user", "save_observations", "hand_off",
+            "notify_user", "hand_off",
             "confirm_edit", "check_inbox", "update_status",
             "blackboard_read", "blackboard_write", "publish",
             "memory_search", "memory_save", "update_workspace",
             "read_file", "exec_command", "http_request", "web_search",
         })
-        assert len(operator_tools) == 19
+        assert len(operator_tools) == 18
 
         loop = _make_loop(allowed_tools=operator_tools)
         assert loop._allowed_tools == operator_tools
-        assert len(loop._allowed_tools) == 19
+        assert len(loop._allowed_tools) == 18
 
     def test_operator_heartbeat_subset(self):
         """Heartbeat tools should be a proper subset of the full allowed list."""
         full_tools = frozenset({
             "list_agents", "get_agent_profile", "get_system_status",
-            "notify_user", "save_observations", "hand_off",
+            "notify_user", "hand_off",
             "confirm_edit", "check_inbox", "update_status",
             "blackboard_read", "blackboard_write", "publish",
             "memory_search", "memory_save", "update_workspace",
@@ -482,17 +482,17 @@ class TestOperatorLoopCreation:
         })
         heartbeat_tools = frozenset({
             "list_agents", "get_agent_profile", "get_system_status",
-            "notify_user", "save_observations",
+            "notify_user",
         })
 
-        assert len(heartbeat_tools) == 5
+        assert len(heartbeat_tools) == 4
         assert heartbeat_tools.issubset(full_tools)
 
     def test_operator_loop_excludes_dangerous_tools(self):
         """Operator should not have spawn or cron tools."""
         operator_tools = frozenset({
             "list_agents", "get_agent_profile", "get_system_status",
-            "notify_user", "save_observations", "hand_off",
+            "notify_user", "hand_off",
             "confirm_edit", "check_inbox", "update_status",
             "blackboard_read", "blackboard_write", "publish",
             "memory_search", "memory_save", "update_workspace",

--- a/tests/test_operator_heartbeat.py
+++ b/tests/test_operator_heartbeat.py
@@ -18,7 +18,7 @@ async def test_heartbeat_restricts_operator_tools():
     # Simulate operator: set _allowed_tools to a superset
     operator_tools = frozenset({
         "list_agents", "get_agent_profile", "get_system_status",
-        "notify_user", "save_observations", "hand_off", "confirm_edit",
+        "notify_user", "hand_off", "confirm_edit",
     })
     loop._allowed_tools = operator_tools
     original_allowed = loop._allowed_tools
@@ -91,9 +91,8 @@ def test_heartbeat_tools_constant():
     """Verify _HEARTBEAT_TOOLS carries the heartbeat-reachable allowlist.
 
     Layer history:
-    * v1 (initial): 5 read-only tools — ``list_agents``,
-      ``get_agent_profile``, ``get_system_status``, ``notify_user``,
-      ``save_observations``.
+    * v1 (initial): 4 read-only tools — ``list_agents``,
+      ``get_agent_profile``, ``get_system_status``, ``notify_user``.
     * v2 (workflow awareness): + ``check_inbox``, ``workflow_snapshot``,
       ``await_task_event`` so the heartbeat can drive multi-stage
       chains without dropping out to a full /chat turn.
@@ -104,8 +103,8 @@ def test_heartbeat_tools_constant():
     """
     assert _HEARTBEAT_TOOLS == frozenset({
         "list_agents", "get_agent_profile", "get_system_status",
-        "notify_user", "save_observations",
+        "notify_user",
         "check_inbox", "workflow_snapshot", "await_task_event",
         "rate_delivery", "manage_goals",
     })
-    assert len(_HEARTBEAT_TOOLS) == 10
+    assert len(_HEARTBEAT_TOOLS) == 9

--- a/tests/test_operator_playbooks.py
+++ b/tests/test_operator_playbooks.py
@@ -154,7 +154,7 @@ class TestPlaybookConstants:
         # Non-domain tools that are unrelated to the rename must remain.
         for shared in {
             "create_agent", "apply_template", "edit_agent",
-            "undo_change", "save_observations",
+            "undo_change",
             "request_credential", "request_browser_login",
         }:
             assert shared in keys, f"core tool {shared} missing from playbook map"
@@ -200,7 +200,7 @@ class TestPlaybookConstants:
 
         assert "check_inbox" in _PLAYBOOK_MONITOR
         assert "get_system_status" in _PLAYBOOK_MONITOR
-        assert "save_observations" in _PLAYBOOK_MONITOR
+        assert "inspect_agents" in _PLAYBOOK_MONITOR
 
         assert "request_credential" in _PLAYBOOK_CREDENTIALS
         assert "request_browser_login" in _PLAYBOOK_CREDENTIALS

--- a/tests/test_operator_tools.py
+++ b/tests/test_operator_tools.py
@@ -1,6 +1,4 @@
-"""Tests for operator tools: observations, history, create, projects."""
-import json
-from pathlib import Path
+"""Tests for operator tools: inspect, create, manage."""
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
@@ -52,108 +50,6 @@ def test_last_message_is_user_origin_no_user_messages():
 
     msgs = [{"role": "assistant", "content": "hi"}]
     assert _last_message_is_user_origin(msgs) is False
-
-
-# ── save_observations tests ─────────────────────────────────
-
-
-class _FakeWorkspace:
-    """Minimal workspace manager stub with a real tmp directory."""
-
-    def __init__(self, tmp_path: Path):
-        self.root = tmp_path
-
-
-@pytest.mark.asyncio
-async def test_save_observations_no_workspace():
-    from src.agent.builtins.operator_tools import save_observations
-
-    result = await save_observations("all good", "stable")
-    assert "error" in result
-    assert "workspace_manager" in result["error"]
-
-
-@pytest.mark.asyncio
-async def test_save_observations_writes_files(tmp_path):
-    from src.agent.builtins.operator_tools import save_observations
-
-    ws = _FakeWorkspace(tmp_path)
-    result = await save_observations(
-        "5/6 healthy", "stable",
-        agents_attention=[{"agent_id": "writer", "issue": "slow", "severity": "low"}],
-        notes="all fine",
-        workspace_manager=ws,
-    )
-    assert result["saved"] is True
-    assert "timestamp" in result
-    assert result["chars"] > 0
-
-    # Check OBSERVATIONS.md was created
-    obs_path = tmp_path / "OBSERVATIONS.md"
-    assert obs_path.exists()
-    content = obs_path.read_text()
-    assert "Fleet Observations" in content
-    assert "5/6 healthy" in content
-
-    # Parse the JSON inside the markdown
-    json_start = content.index("```json\n") + len("```json\n")
-    json_end = content.index("\n```", json_start)
-    obs_data = json.loads(content[json_start:json_end])
-    assert obs_data["fleet_summary"] == "5/6 healthy"
-    assert obs_data["cost_trend"] == "stable"
-    assert len(obs_data["agents_attention"]) == 1
-
-    # Check OBSERVATIONS_HISTORY.md was created
-    history_path = tmp_path / "OBSERVATIONS_HISTORY.md"
-    assert history_path.exists()
-    history = history_path.read_text()
-    assert "5/6 healthy" in history
-
-
-@pytest.mark.asyncio
-async def test_save_observations_appends_history(tmp_path):
-    from src.agent.builtins.operator_tools import save_observations
-
-    ws = _FakeWorkspace(tmp_path)
-    await save_observations("check 1", "stable", workspace_manager=ws)
-    await save_observations("check 2", "up_10pct", workspace_manager=ws)
-
-    history_path = tmp_path / "OBSERVATIONS_HISTORY.md"
-    history = history_path.read_text()
-    entries = [e for e in history.strip().split("\n---\n") if e.strip()]
-    assert len(entries) == 2
-    assert "check 1" in entries[0]
-    assert "check 2" in entries[1]
-
-
-@pytest.mark.asyncio
-async def test_save_observations_truncates_long_notes(tmp_path):
-    from src.agent.builtins.operator_tools import save_observations
-
-    ws = _FakeWorkspace(tmp_path)
-    long_notes = "x" * 5000
-    result = await save_observations(
-        "ok", "stable", notes=long_notes, workspace_manager=ws,
-    )
-    assert result["saved"] is True
-    assert result["chars"] <= 1500
-
-
-@pytest.mark.asyncio
-async def test_save_observations_history_cap(tmp_path):
-    from src.agent.builtins.operator_tools import save_observations
-
-    ws = _FakeWorkspace(tmp_path)
-    # Write 55 entries, history should cap at 50
-    for i in range(55):
-        await save_observations(f"check {i}", "stable", workspace_manager=ws)
-
-    history_path = tmp_path / "OBSERVATIONS_HISTORY.md"
-    entries = [e for e in history_path.read_text().strip().split("\n---\n") if e.strip()]
-    assert len(entries) == 50
-    # Should have the last 50 entries (5-54)
-    last_entry = json.loads(entries[-1])
-    assert last_entry["fleet_summary"] == "check 54"
 
 
 # ── inspect_agents tests ────────────────────────────────────


### PR DESCRIPTION
## Summary

Bundles four related dashboard changes plus the matching backend cleanup the frontend removal enables.

- **Sidebar nav.** Top tab bar → labeled ~220px left sidebar on `md:`+. Mobile (`<md`) keeps an icon-only tab strip in the slim top bar (no drawer, no friction). Connection status pill moves to the sidebar footer on desktop. Tab IDs (`chat`/`workplace`/`fleet`/`system`) unchanged per CLAUDE.md #14.
- **`/agents` → `/teams`.** Fleet tab routes under `/teams`. `_parsePath` accepts both `/teams` and `/agents` so old bookmarks resolve; the first navigation `replaceState`s to canonical `/teams` without adding history. Tab ID `fleet` is frozen; only the URL surface and `_buildTitle` change.
- **Teams panel + Add-Agent card.** Chip strip is now `flex-wrap` with a 2-row collapse + "Show all teams" toggle when team count > 6 (preference persisted to `localStorage.ol_team_filter_expanded`). The prominent **+ New Team** button takes the right-side slot the old "+ Add Agent" button held. "+ Add Agent" moves into the agent grid as a dashed-border card sized like agent cards — calls `openAddAgentModal()` (which already pre-fills the active team filter) and shows a disabled state on `atAgentLimit`.
- **Fleet pulse removal — frontend + backend.** Card on Settings → Activity, top-nav amber attention badge, and all `fleetDigest` Alpine state + methods deleted. Backend follows: `save_observations` operator skill deleted; `OBSERVATIONS.md` removed from both `_WORKSPACE_ALLOWLIST` frozensets; heartbeat playbook drops step 5 (renumbered 1-5, budget 10 → 8); `_OPERATOR_ALLOWED_TOOLS` / `_OPERATOR_HEARTBEAT_TOOLS` / `_HEARTBEAT_TOOLS` / `_TOOL_PLAYBOOK_MAP` / `_PLAYBOOK_MONITOR` all trimmed. The operator's live signal still flows through `notify_user` for critical issues — the digest was the only consumer, deletion is verdict-A safe.
- **Docs/tests.** `docs/{dashboard,security,architecture,agent-tools}.md`, `tests/test_operator_{tools,config,heartbeat,e2e,playbooks}.py`, `tests/test_{loop,dashboard_workspace}.py` updated. The `test_observations_md_is_allowlisted` regression test is deleted (file no longer in allowlist).

## Test plan

- [x] Focused regression sweep on directly-touched test files (367 passed, Python 3.11)
- [ ] Manual dashboard smoke against a local mesh:
  - [ ] Desktop ≥ 768px: sidebar renders with all 4 tabs labeled; "Teams (N)" shows correct count; active state follows the click; Cmd+K opens palette; status pills visible in slim top bar; connection pill at sidebar footer
  - [ ] Mobile < 768px (devtools responsive): sidebar hidden; 4 tab icons render at top with `:title` / `:aria-label`; status pills + connection pill stay accessible
  - [ ] URL: clicking Teams → `/teams`; drill into agent → `/teams/<id>`; reload at `/teams` restores fleet tab; back-compat — paste `/agents` → loads on Teams tab; paste `/agents/<id>` → drills correctly
  - [ ] Teams panel: chips wrap on overflow; "Show all teams" appears at team count > 6, toggle persists across reload; "+ New Team" button on the right; "+ Add Agent" gone from row
  - [ ] Agent grid: final cell is dashed "Add Agent" card sized like agent cards; click opens modal with active team pre-selected; at `atAgentLimit` the card is dimmed with tooltip
  - [ ] Settings → Activity: Fleet-pulse card gone, sub-tab bar starts at top; no amber "N agents need attention" badge in top bar
  - [ ] Operator heartbeat cycle: tool list no longer includes `save_observations`; `notify_user` still fires for critical alerts; no errors

## Known follow-up

- On `md` narrow viewports (768–1023px), sidebar (220px) + messenger panel (380px) leave a cramped content column. Punted as a separate UX decision; messenger breakpoints are unchanged here.