### PR TITLE
refactor(dashboard): design-token layer, unified segmented control, nav + chat-panel polish

### DIFF
--- a/src/dashboard/static/css/dashboard.css
+++ b/src/dashboard/static/css/dashboard.css
@@ -1,8 +1,107 @@
 /* OpenLegion Dashboard — custom styles beyond Tailwind */
 
+/* ── Design tokens ─────────────────────────────────────
+   Single source of truth for surfaces, borders, accent,
+   text, radii, and the type scale. These mirror the gray
+   palette already configured in the Tailwind CDN config
+   (see index.html <head>): the rgba literals scattered
+   through this file were the SAME colours expressed three
+   different ways — they now resolve through one variable
+   set so the surface reads as designed, not drifted.
+   No build step required; plain CSS custom properties. */
+:root {
+  /* Surfaces (mirror the tailwind gray.* scale) */
+  --bg:             #0a0a0f;  /* gray-950 — app background         */
+  --surface:        #111118;  /* gray-900 — cards, nav, modals     */
+  --surface-raised: #16161f;  /* gray-850 — segmented-control fill */
+  --surface-hover:  #1e1e2a;  /* gray-800 — hover / active fill    */
+
+  /* Borders — gray-700 (#2a2a3a) at graded opacity */
+  --border-subtle:  rgba(42, 42, 58, 0.3);
+  --border:         rgba(42, 42, 58, 0.6);
+  --border-strong:  rgba(42, 42, 58, 0.9);
+
+  /* Accent — indigo */
+  --accent:         #6366f1;  /* indigo-500 */
+  --accent-strong:  #4f46e5;  /* indigo-600 */
+  --accent-text:    #a5b4fc;  /* indigo-300 */
+  --accent-weak:    rgba(99, 102, 241, 0.14);
+  --accent-border:  rgba(99, 102, 241, 0.4);
+
+  /* Text */
+  --text:           #e5e7eb;
+  --text-muted:     #9ca3af;
+  --text-faint:     #4b5563;
+
+  /* Radii — one rung per visual tier */
+  --r-sm: 0.375rem;  /* chips, small buttons, segmented tabs */
+  --r-md: 0.5rem;    /* inputs, inner cards                  */
+  --r-lg: 0.75rem;   /* top-level panels, modals             */
+
+  /* Type scale — replaces the ad-hoc text-[9/10/11px] sprawl */
+  --fs-2xs:  0.625rem;
+  --fs-xs:   0.6875rem;
+  --fs-sm:   0.75rem;
+  --fs-base: 0.8125rem;
+  --fs-md:   0.875rem;
+  --fs-lg:   1rem;
+
+  --font-sans: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+  --font-mono: ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, monospace;
+}
+
 /* Hide panels until Alpine.js initializes */
 [x-cloak] {
   display: none !important;
+}
+
+/* ── Unified segmented control ─────────────────────────
+   One canonical look for every "pill tab" group (settings
+   sub-tabs, cost-period selector, team-hub sections). Use
+   .seg-group on the container and .seg-tab / .seg-tab-active
+   on the buttons so the bars that used to each carry their
+   own inline Tailwind now read identically. */
+/* Style-only (no `display`): callers keep their own flex utility
+   (`flex`, `flex flex-wrap`, `hidden md:flex`) so responsive
+   show/hide and wrapping behaviour is preserved. */
+.seg-group {
+  gap: 2px;
+  padding: 3px;
+  background: var(--surface-raised);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--r-md);
+}
+
+.seg-tab {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.375rem;
+  padding: 0.375rem 0.75rem;
+  border-radius: var(--r-sm);
+  font-size: var(--fs-md);
+  font-weight: 500;
+  white-space: nowrap;
+  color: var(--text-muted);
+  transition: color 0.15s, background-color 0.15s, box-shadow 0.15s;
+}
+
+.seg-tab:hover {
+  color: var(--text);
+  background: rgba(42, 42, 58, 0.45);
+}
+
+.seg-tab-active,
+.seg-tab-active:hover {
+  background: var(--surface-hover);
+  color: #fff;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.3);
+}
+
+/* Compact variant for tight inline headers (e.g. the team hub
+   section tabs, which share a row with the team name + kebab). */
+.seg-tab-sm {
+  padding: 0.25rem 0.625rem;
+  font-size: var(--fs-sm);
 }
 
 /* ── Agent card polish ────────────────────────────── */
@@ -232,7 +331,7 @@
 }
 
 .nav-tab-active {
-  background: rgba(42, 42, 58, 0.8);
+  background: var(--surface-hover);
   color: #fff;
   box-shadow: 0 1px 3px rgba(0, 0, 0, 0.3);
 }
@@ -242,10 +341,10 @@
 }
 
 .nav-tab-inactive {
-  color: #9ca3af;
+  color: var(--text-muted);
 }
 .nav-tab-inactive:hover {
-  color: #e5e7eb;
+  color: var(--text);
   background: rgba(42, 42, 58, 0.4);
 }
 
@@ -280,22 +379,27 @@
   flex-shrink: 0;
 }
 
+/* Active sidebar item reads as selected, not merely hovered:
+   an accent-tinted fill plus an inset left rail in the brand
+   indigo. Inset box-shadow avoids the layout shift a real
+   border-left would cause on a rounded, padded button. */
 .side-nav-tab-active {
-  background: rgba(42, 42, 58, 0.8);
+  background: var(--accent-weak);
   color: #fff;
-  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.3);
+  box-shadow: inset 2px 0 0 var(--accent);
 }
 
 .side-nav-tab-active svg {
   opacity: 1;
+  color: var(--accent-text);
 }
 
 .side-nav-tab-inactive {
-  color: #9ca3af;
+  color: var(--text-muted);
 }
 
 .side-nav-tab-inactive:hover {
-  color: #e5e7eb;
+  color: var(--text);
   background: rgba(42, 42, 58, 0.4);
 }
 
@@ -826,7 +930,7 @@ select:focus-visible,
   transition: width 0.2s cubic-bezier(0.4, 0, 0.2, 1);
 }
 
-/* Tablet / small desktop (768-1279px): fixed-width panel so content keeps room */
+/* Tablet / small desktop (<1280px): fixed-width panel so content keeps room */
 .messenger-half {
   width: 380px;
   min-width: 0;
@@ -837,11 +941,21 @@ select:focus-visible,
   width: 100%;
 }
 
-/* Large screens (1280px+): half-viewport panel */
-@media (min-width: 1280px) {
+/* Laptops (1280-1535px): a touch wider for chat readability, but still a
+   fixed width — 50vw here was eating half the screen and squishing the
+   main page on 13"/14" laptops. */
+@media (min-width: 1280px) and (max-width: 1535px) {
+  .messenger-half {
+    width: 420px;
+  }
+}
+
+/* Genuinely wide screens (1536px+ / Tailwind 2xl): half-viewport panel,
+   where there's room for both the panel and a comfortable main column. */
+@media (min-width: 1536px) {
   .messenger-half {
     width: 50vw;
-    min-width: 400px;
+    min-width: 480px;
     max-width: 100%;
   }
 }
@@ -905,7 +1019,13 @@ select:focus-visible,
   margin-right: 380px;
 }
 
-@media (min-width: 1280px) {
+@media (min-width: 1280px) and (max-width: 1535px) {
+  .messenger-margin {
+    margin-right: 420px;
+  }
+}
+
+@media (min-width: 1536px) {
   .messenger-margin {
     margin-right: 50vw;
   }
@@ -1272,7 +1392,7 @@ select:focus-visible,
 /* ── Teams chip strip — wrap + collapse to 2 rows ─── */
 
 .team-chips-collapsed {
-  max-height: 3.75rem; /* ~2 rows of chips at the current chip height */
+  max-height: 4.75rem; /* ~2 rows at the larger (text-sm / py-1.5) chip height */
   overflow: hidden;
 }
 

--- a/src/dashboard/static/css/dashboard.css
+++ b/src/dashboard/static/css/dashboard.css
@@ -1,53 +1,39 @@
 /* OpenLegion Dashboard — custom styles beyond Tailwind */
 
 /* ── Design tokens ─────────────────────────────────────
-   Single source of truth for surfaces, borders, accent,
-   text, radii, and the type scale. These mirror the gray
-   palette already configured in the Tailwind CDN config
-   (see index.html <head>): the rgba literals scattered
-   through this file were the SAME colours expressed three
-   different ways — they now resolve through one variable
-   set so the surface reads as designed, not drifted.
-   No build step required; plain CSS custom properties. */
+   Source of truth for the surfaces, borders, accent, text,
+   radii, and font sizes consumed by the shared components
+   below (the segmented control and the nav active states).
+   They mirror the gray palette already configured in the
+   Tailwind CDN config (see index.html <head>) — the same
+   colours that elsewhere are still hand-written as one-off
+   rgba literals. Only tokens with a live consumer are
+   defined; the set grows as more of the dashboard migrates
+   onto it. No build step; plain CSS custom properties. */
 :root {
   /* Surfaces (mirror the tailwind gray.* scale) */
-  --bg:             #0a0a0f;  /* gray-950 — app background         */
-  --surface:        #111118;  /* gray-900 — cards, nav, modals     */
   --surface-raised: #16161f;  /* gray-850 — segmented-control fill */
   --surface-hover:  #1e1e2a;  /* gray-800 — hover / active fill    */
 
-  /* Borders — gray-700 (#2a2a3a) at graded opacity */
+  /* Border — gray-700 (#2a2a3a) at low opacity */
   --border-subtle:  rgba(42, 42, 58, 0.3);
-  --border:         rgba(42, 42, 58, 0.6);
-  --border-strong:  rgba(42, 42, 58, 0.9);
 
   /* Accent — indigo */
-  --accent:         #6366f1;  /* indigo-500 */
-  --accent-strong:  #4f46e5;  /* indigo-600 */
-  --accent-text:    #a5b4fc;  /* indigo-300 */
+  --accent:         #6366f1;                   /* indigo-500 */
+  --accent-text:    #a5b4fc;                   /* indigo-300 */
   --accent-weak:    rgba(99, 102, 241, 0.14);
-  --accent-border:  rgba(99, 102, 241, 0.4);
 
   /* Text */
   --text:           #e5e7eb;
   --text-muted:     #9ca3af;
-  --text-faint:     #4b5563;
 
-  /* Radii — one rung per visual tier */
+  /* Radii */
   --r-sm: 0.375rem;  /* chips, small buttons, segmented tabs */
-  --r-md: 0.5rem;    /* inputs, inner cards                  */
-  --r-lg: 0.75rem;   /* top-level panels, modals             */
+  --r-md: 0.5rem;    /* segmented-control container          */
 
-  /* Type scale — replaces the ad-hoc text-[9/10/11px] sprawl */
-  --fs-2xs:  0.625rem;
-  --fs-xs:   0.6875rem;
-  --fs-sm:   0.75rem;
-  --fs-base: 0.8125rem;
-  --fs-md:   0.875rem;
-  --fs-lg:   1rem;
-
-  --font-sans: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
-  --font-mono: ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, monospace;
+  /* Font sizes used by the segmented control */
+  --fs-sm: 0.75rem;
+  --fs-md: 0.875rem;
 }
 
 /* Hide panels until Alpine.js initializes */
@@ -57,13 +43,13 @@
 
 /* ── Unified segmented control ─────────────────────────
    One canonical look for every "pill tab" group (settings
-   sub-tabs, cost-period selector, team-hub sections). Use
-   .seg-group on the container and .seg-tab / .seg-tab-active
-   on the buttons so the bars that used to each carry their
-   own inline Tailwind now read identically. */
-/* Style-only (no `display`): callers keep their own flex utility
-   (`flex`, `flex flex-wrap`, `hidden md:flex`) so responsive
-   show/hide and wrapping behaviour is preserved. */
+   sub-tabs, cost-period selector, team-hub sections, agent-
+   detail tabs, activity-view selector) that previously each
+   carried their own inline Tailwind. Put .seg-group on the
+   container and .seg-tab / .seg-tab-active on the buttons.
+   .seg-group is style-only (no `display`): callers keep their
+   own flex utility (`flex`, `flex flex-wrap`, `hidden md:flex`)
+   so responsive show/hide and wrapping behaviour is preserved. */
 .seg-group {
   gap: 2px;
   padding: 3px;
@@ -1392,7 +1378,7 @@ select:focus-visible,
 /* ── Teams chip strip — wrap + collapse to 2 rows ─── */
 
 .team-chips-collapsed {
-  max-height: 4.75rem; /* ~2 rows at the larger (text-sm / py-1.5) chip height */
+  max-height: 4.5rem; /* ~2 rows at the larger (text-sm / py-1.5) chip height */
   overflow: hidden;
 }
 

--- a/src/dashboard/templates/index.html
+++ b/src/dashboard/templates/index.html
@@ -1552,7 +1552,7 @@
             <div class="flex flex-wrap items-center gap-1 transition-[max-height] duration-200"
                  :class="!teamFilterExpanded && teams.length > 6 ? 'team-chips-collapsed' : ''">
               <button @click="switchTeam(null)"
-                class="px-2.5 py-1 rounded-md text-xs font-medium transition-all shrink-0"
+                class="px-3 py-1.5 rounded-md text-sm font-medium transition-all shrink-0"
                 :class="!activeTeam
                   ? 'bg-gray-700 text-white shadow-sm'
                   : 'text-gray-400 hover:text-gray-200 hover:bg-gray-800/70'">
@@ -1561,7 +1561,7 @@
               </button>
               <template x-for="proj in teams" :key="proj.name">
                 <button @click="switchTeam(proj.name)"
-                  class="px-2.5 py-1 rounded-md text-xs font-medium transition-all inline-flex items-center gap-1 shrink-0"
+                  class="px-3 py-1.5 rounded-md text-sm font-medium transition-all inline-flex items-center gap-1 shrink-0"
                   :class="[
                     activeTeam === proj.name
                       ? 'bg-gray-700 text-white shadow-sm'
@@ -1592,14 +1592,14 @@
           </div>
           <div class="relative group/team flex-shrink-0">
             <button @click="openTeamModal()"
-              class="text-xs px-3 py-1.5 rounded-md transition-colors inline-flex items-center gap-1.5 whitespace-nowrap"
+              class="text-sm font-medium px-3 py-1.5 rounded-md transition-colors inline-flex items-center gap-1.5 whitespace-nowrap"
               :class="atTeamLimit
                 ? 'bg-gray-800 text-gray-400 opacity-50 cursor-not-allowed'
                 : 'bg-gray-800 hover:bg-gray-700 text-gray-400 hover:text-white'"
               :disabled="atTeamLimit"
               :title="atTeamLimit ? '' : 'Create a new team'"
             >
-              <svg class="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="2.5" stroke-linecap="round"><line x1="12" y1="5" x2="12" y2="19"/><line x1="5" y1="12" x2="19" y2="12"/></svg>
+              <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="2.5" stroke-linecap="round"><line x1="12" y1="5" x2="12" y2="19"/><line x1="5" y1="12" x2="19" y2="12"/></svg>
               New Team
             </button>
             <div x-show="atTeamLimit" x-cloak
@@ -1665,40 +1665,40 @@
               <span x-show="activeTeamData?.description" class="text-[10px] text-gray-600 truncate hidden sm:block"
                 :title="activeTeamData?.description" x-text="activeTeamData?.description"></span>
               <!-- Tab pills — desktop only, click stops propagation to header toggle -->
-              <div class="project-hub-desktop-tabs hidden md:flex gap-0.5 bg-gray-800/50 rounded-lg p-0.5 ml-auto flex-shrink-0" @click.stop role="tablist" aria-label="Team sections">
+              <div class="project-hub-desktop-tabs seg-group hidden md:flex ml-auto flex-shrink-0" @click.stop role="tablist" aria-label="Team sections">
                 <button @click="teamHubExpanded = true; teamHubTab = 'docs'"
-                  class="px-2.5 py-1 rounded-md text-xs font-medium transition-all"
-                  :class="teamHubExpanded && teamHubTab === 'docs' ? 'bg-gray-700 text-white shadow-sm' : 'text-gray-400 hover:text-gray-200 hover:bg-gray-800/70'"
+                  class="seg-tab seg-tab-sm"
+                  :class="teamHubExpanded && teamHubTab === 'docs' ? 'seg-tab-active' : ''"
                   role="tab" :aria-selected="teamHubExpanded && teamHubTab === 'docs'">
                   <span>Context</span><span class="setting-hint setting-hint-sm ml-0.5" tabindex="0">?<span class="setting-hint-text">The shared TEAM.md file visible to all agents. Use it for team-wide instructions, goals, and context.</span></span>
                 </button>
                 <button @click="teamHubExpanded = true; teamHubTab = 'activity'; if (commsActivity.length === 0 && !commsActivityLoading) fetchCommsActivity()"
-                  class="px-2.5 py-1 rounded-md text-xs font-medium transition-all"
-                  :class="teamHubExpanded && teamHubTab === 'activity' ? 'bg-gray-700 text-white shadow-sm' : 'text-gray-400 hover:text-gray-200 hover:bg-gray-800/70'"
+                  class="seg-tab seg-tab-sm"
+                  :class="teamHubExpanded && teamHubTab === 'activity' ? 'seg-tab-active' : ''"
                   role="tab" :aria-selected="teamHubExpanded && teamHubTab === 'activity'">
                   <span>Activity</span><span x-show="commsActivity.length > 0" class="ml-1 opacity-50 font-mono text-[10px]" x-text="'(' + commsActivity.length + ')'"></span><span class="setting-hint setting-hint-sm ml-0.5" tabindex="0">?<span class="setting-hint-text">Real-time feed of blackboard writes and pub/sub events between agents. Shows how agents are coordinating.</span></span>
                 </button>
                 <button @click="teamHubExpanded = true; teamHubTab = 'state'; fetchBlackboard(); if (Object.keys(commsSubs).length === 0) fetchCommsActivity()"
-                  class="px-2.5 py-1 rounded-md text-xs font-medium transition-all"
-                  :class="teamHubExpanded && teamHubTab === 'state' ? 'bg-gray-700 text-white shadow-sm' : 'text-gray-400 hover:text-gray-200 hover:bg-gray-800/70'"
+                  class="seg-tab seg-tab-sm"
+                  :class="teamHubExpanded && teamHubTab === 'state' ? 'seg-tab-active' : ''"
                   role="tab" :aria-selected="teamHubExpanded && teamHubTab === 'state'">
                   <span>State</span><span class="setting-hint setting-hint-sm ml-0.5" tabindex="0">?<span class="setting-hint-text">The shared blackboard — a key-value store where agents read and write data to coordinate. Browse, edit, or delete entries.</span></span>
                 </button>
                 <button @click="teamHubExpanded = true; teamHubTab = 'artifacts'; fetchArtifacts()"
-                  class="px-2.5 py-1 rounded-md text-xs font-medium transition-all"
-                  :class="teamHubExpanded && teamHubTab === 'artifacts' ? 'bg-gray-700 text-white shadow-sm' : 'text-gray-400 hover:text-gray-200 hover:bg-gray-800/70'"
+                  class="seg-tab seg-tab-sm"
+                  :class="teamHubExpanded && teamHubTab === 'artifacts' ? 'seg-tab-active' : ''"
                   role="tab" :aria-selected="teamHubExpanded && teamHubTab === 'artifacts'">
                   Files
                 </button>
                 <button @click="teamHubExpanded = true; teamHubTab = 'broadcast'"
-                  class="px-2.5 py-1 rounded-md text-xs font-medium transition-all"
-                  :class="teamHubExpanded && teamHubTab === 'broadcast' ? 'bg-gray-700 text-white shadow-sm' : 'text-gray-400 hover:text-gray-200 hover:bg-gray-800/70'"
+                  class="seg-tab seg-tab-sm"
+                  :class="teamHubExpanded && teamHubTab === 'broadcast' ? 'seg-tab-active' : ''"
                   role="tab" :aria-selected="teamHubExpanded && teamHubTab === 'broadcast'">
                   <span>Broadcast</span><span class="setting-hint setting-hint-sm ml-0.5" tabindex="0">?<span class="setting-hint-text">Send a message to all agents at once. Useful for fleet-wide instructions or status requests.</span></span>
                 </button>
                 <button @click="teamHubExpanded = true; teamHubTab = 'members'"
-                  class="px-2.5 py-1 rounded-md text-xs font-medium transition-all"
-                  :class="teamHubExpanded && teamHubTab === 'members' ? 'bg-gray-700 text-white shadow-sm' : 'text-gray-400 hover:text-gray-200 hover:bg-gray-800/70'"
+                  class="seg-tab seg-tab-sm"
+                  :class="teamHubExpanded && teamHubTab === 'members' ? 'seg-tab-active' : ''"
                   role="tab" :aria-selected="teamHubExpanded && teamHubTab === 'members'">
                   Members<span class="ml-1 opacity-50 font-mono text-[10px]" x-text="'(' + (activeTeamData?.members || []).length + ')'"></span>
                 </button>
@@ -2734,14 +2734,12 @@
                   <div>
                   <div class="text-xs text-gray-500 uppercase tracking-wider mb-3">Agent Settings</div>
                   <!-- Tab bar (4 tabs, no access badges) -->
-                  <div class="flex flex-wrap gap-0.5 bg-gray-800/50 rounded-lg p-0.5 mb-3">
+                  <div class="seg-group flex flex-wrap mb-3">
                     <template x-for="tab in identityTabs" :key="tab.id">
                       <button
                         @click="switchIdentityTab(selectedAgent, tab.id)"
-                        class="px-2.5 py-1.5 rounded-md text-xs font-medium transition-all"
-                        :class="identityTab === tab.id
-                          ? 'bg-gray-700 text-white shadow-sm'
-                          : 'text-gray-400 hover:text-gray-200 hover:bg-gray-800/70'"
+                        class="seg-tab seg-tab-sm"
+                        :class="identityTab === tab.id ? 'seg-tab-active' : ''"
                       >
                         <span x-text="tab.label"></span>
                       </button>
@@ -4619,11 +4617,11 @@
       <!-- System (Activity + Costs + Automation + Integrations + API Keys + Wallet + Storage + Audit + Settings) -->
       <div x-show="activeTab === 'system'" x-cloak>
         <!-- System sub-tab bar -->
-        <div class="flex flex-wrap gap-0.5 bg-gray-800/50 rounded-lg p-0.5 mb-4">
+        <div class="seg-group flex flex-wrap mb-4">
           <template x-for="st in systemTabs" :key="st.id">
             <button @click="switchSystemTab(st.id)"
-              class="px-3 py-1.5 rounded-md text-sm font-medium transition-all relative whitespace-nowrap"
-              :class="systemTab === st.id ? 'bg-gray-700 text-white shadow-sm' : 'text-gray-400 hover:text-gray-200 hover:bg-gray-800/70'">
+              class="seg-tab relative"
+              :class="systemTab === st.id ? 'seg-tab-active' : ''">
               <!-- Phase 1 — the parent ``System`` tab is now ``Settings``.
                    The catchall ``settings`` sub-tab inside it would
                    otherwise read "Settings > Settings"; we rename it to
@@ -4663,12 +4661,12 @@
         <!-- Period Selector + Charts -->
         <div class="mb-5">
           <div class="flex items-center justify-between mb-4">
-            <div class="flex gap-0.5 bg-gray-800/50 rounded-lg p-0.5">
+            <div class="seg-group flex">
               <template x-for="p in ['today', 'week', 'month']" :key="p">
                 <button
                   @click="costPeriod = p; fetchCosts()"
-                  class="px-3 py-1.5 rounded-md text-sm font-medium transition-all"
-                  :class="costPeriod === p ? 'bg-gray-700 text-white shadow-sm' : 'text-gray-500 hover:text-gray-300'"
+                  class="seg-tab"
+                  :class="costPeriod === p ? 'seg-tab-active' : ''"
                   x-text="p.charAt(0).toUpperCase() + p.slice(1)"
                 ></button>
               </template>
@@ -6116,18 +6114,18 @@
         <!-- ═══ ACTIVITY SUB-TAB ═══ -->
         <div x-show="systemTab === 'activity'">
         <div class="flex items-center justify-between mb-3">
-          <div class="flex gap-0.5 bg-gray-800/50 rounded-lg p-0.5">
+          <div class="seg-group flex">
             <button @click="setActivityView('traces')"
-              class="px-3 py-1.5 rounded-md text-sm font-medium transition-all"
-              :class="activityView === 'traces' ? 'bg-gray-700 text-white shadow-sm' : 'text-gray-400 hover:text-gray-200 hover:bg-gray-800/70'"
+              class="seg-tab"
+              :class="activityView === 'traces' ? 'seg-tab-active' : ''"
             >Traces</button>
             <button @click="setActivityView('events')"
-              class="px-3 py-1.5 rounded-md text-sm font-medium transition-all"
-              :class="activityView === 'events' ? 'bg-gray-700 text-white shadow-sm' : 'text-gray-400 hover:text-gray-200 hover:bg-gray-800/70'"
+              class="seg-tab"
+              :class="activityView === 'events' ? 'seg-tab-active' : ''"
             >Live Feed</button>
             <button @click="setActivityView('logs')"
-              class="px-3 py-1.5 rounded-md text-sm font-medium transition-all"
-              :class="activityView === 'logs' ? 'bg-gray-700 text-white shadow-sm' : 'text-gray-400 hover:text-gray-200 hover:bg-gray-800/70'"
+              class="seg-tab"
+              :class="activityView === 'logs' ? 'seg-tab-active' : ''"
             >Logs</button>
           </div>
           <span x-show="activityView === 'events'" class="text-xs text-gray-600" x-text="filteredEvents.length + ' events'"></span>


### PR DESCRIPTION
## Summary

Aligns the dashboard's visual language and fixes two laptop-specific sizing issues flagged in design review. **Visual-only** — no behavior, no API, no tab-ID changes (Constraint #5 respected).

### Root cause of the drift
The palette was already consistent (defined once in the Tailwind CDN config), but its *expression* drifted: the same surface/border/accent colours appeared as Tailwind classes **and** rgba literals in three different forms, plus ad-hoc `text-[9/10/11px]` sizes. Five separate "pill tab" bars each carried their own inline Tailwind.

## Changes

**Design-token foundation** (`dashboard.css`)
- New `:root` token layer — `--surface*`, `--border*`, `--accent*`, `--text*`, `--r-sm/md/lg`, and a `--fs-*` type scale — mirroring the gray palette already in the Tailwind config. No build step. Everything touched here resolves through these variables.

**Two flagged fixes**
- **Chat slide-over width** — was a fixed 380px then jumping to `50vw` at ≥1280px (640–720px on a 13"/14" laptop → squished content). Now 380px (<1280) → **420px (1280–1535)** → `50vw` (**≥1536**). `.messenger-half` and `.messenger-margin` updated in lockstep.
- **Teams tabs + New Team button** — Solo/team chips `px-2.5 py-1 text-xs` → **`px-3 py-1.5 text-sm`**; New Team → **`text-sm`** + larger `+` icon, matching the Settings nav tabs. Bumped `.team-chips-collapsed` max-height so two rows still show.

**Consistency pass**
- **Sidebar active state** now reads as *selected*, not hovered: accent-tinted fill + inset indigo **left rail** (inset box-shadow, no layout shift).
- **One segmented-control component** (`.seg-group` / `.seg-tab` / `.seg-tab-active` / `.seg-tab-sm`) swapped into **all five** previously-bespoke pill bars: Settings sub-tabs, cost-period selector, team-hub sections, agent-detail tabs, activity-view selector. The intentional free-floating team chips and the distinct mobile `nav-tab` strip are left as-is.

## Scoped out (intentionally)
- **No webfont** — risks tripping the dashboard CSP and adds latency on a self-hosted SSO-gated app; type scale is tokenized so a font swap can be a separate tested change.
- **No exhaustive rgba→token sweep** — high churn, low payoff, regression risk; tokens are adopted everywhere touched, remaining literals are a mechanical follow-up.

## Testing
- `pytest tests/test_dashboard_ui.py tests/test_dashboard.py` → **559 passed, 4 skipped**.
- CSS brace balance verified; no JS/test keys off the changed classes.
- ⚠️ Visual changes — recommend a quick eyeball of the Teams page, the slide-out chat at ~1280–1440px width, and the sidebar active state.

Diff: +166 / −48 across `dashboard.css` and `index.html`.