### PR TITLE
fix(loop): route explained read-only deferrals to done, not failed

### DIFF
--- a/src/agent/loop.py
+++ b/src/agent/loop.py
@@ -1163,6 +1163,12 @@ class AgentLoop:
                                 result={
                                     "status": "deferred",
                                     "reason": final_text[:500],
+                                    # ``summary`` mirrors the normal done-close
+                                    # convention so the done back-edge (server
+                                    # reads ``result.summary``) surfaces the
+                                    # deferral context to the originator's
+                                    # check_inbox instead of an empty event.
+                                    "summary": final_text[:500],
                                 },
                                 tokens_used=total_tokens,
                                 duration_ms=int(duration_s * 1000),
@@ -2548,6 +2554,12 @@ class AgentLoop:
                                         result_payload={
                                             "status": "deferred",
                                             "reason": response_text[:500],
+                                            # ``summary`` feeds the done
+                                            # back-edge (server reads
+                                            # ``result.summary``) so the
+                                            # originator's check_inbox shows the
+                                            # deferral reason, not an empty event.
+                                            "summary": response_text[:500],
                                         },
                                     )
                                 else:

--- a/src/agent/loop.py
+++ b/src/agent/loop.py
@@ -1114,10 +1114,69 @@ class AgentLoop:
                     # ``{"result": {"status": "noop", "reason": "..."}}``,
                     # which escapes via ``is_structured_final``.
                     if outbound_tool_calls_count == 0 and not is_structured_final:
+                        read_only_count = tool_calls_count - outbound_tool_calls_count
+                        final_text = (llm_response.content or "").strip()
+                        # Bug 3 (explained-deferral carve-out): an agent that
+                        # called at least one READ-ONLY tool to verify a
+                        # prerequisite (backpressure / dedup / state check)
+                        # AND then explained its decision in plain prose —
+                        # rather than the structured ``{"result": {...}}``
+                        # envelope — is correctly DEFERRING, not ghosting. It
+                        # examined state and made a reasoned call. Close as
+                        # ``done`` with a ``deferred`` result payload (mirrors
+                        # the structured-noop success shape; ``deferred`` lives
+                        # only inside the payload — there is no ``deferred``
+                        # task STATUS, see VALID_STATUSES). The genuine ghost
+                        # case (zero tools, OR no explanation) still hard-fails
+                        # below.
+                        if read_only_count > 0 and final_text:
+                            self.state = "idle"
+                            self.current_task = None
+                            self.tasks_completed += 1
+                            logger.info(
+                                "execute_task explained-deferral carve-out for "
+                                "task=%s: iterations=%d tokens=%d "
+                                "outbound_tool_calls=0 read_only_tool_calls=%d "
+                                "non_empty_final=True — closing done with "
+                                "deferred result (agent examined state via "
+                                "read-only tools and explained its decision)",
+                                assignment.task_id, iterations_executed,
+                                total_tokens, read_only_count,
+                            )
+                            if self.workspace:
+                                self.workspace.append_activity(
+                                    trigger="task",
+                                    summary=(
+                                        f"Task deferred: {assignment.task_type} | "
+                                        f"{iterations_executed} iterations, "
+                                        f"{total_tokens} tokens, {duration_s}s | "
+                                        f"{read_only_count} read-only tool call(s)"
+                                    ),
+                                    tools_used=[],
+                                    duration_ms=int(duration_s * 1000),
+                                    tokens_used=total_tokens,
+                                    outcome="deferred",
+                                )
+                            result = TaskResult(
+                                task_id=assignment.task_id,
+                                status="complete",
+                                result={
+                                    "status": "deferred",
+                                    "reason": final_text[:500],
+                                },
+                                tokens_used=total_tokens,
+                                duration_ms=int(duration_s * 1000),
+                            )
+                            self._last_result = result
+                            logger.info(
+                                "execute_task exit branch=explained_deferral "
+                                "status=%s iterations=%d tokens=%d",
+                                result.status, iterations_executed, total_tokens,
+                            )
+                            return result
                         self.state = "idle"
                         self.current_task = None
                         self.tasks_failed += 1
-                        read_only_count = tool_calls_count - outbound_tool_calls_count
                         logger.error(
                             "execute_task lazy-completion guard tripped for "
                             "task=%s: iterations=%d tokens=%d "
@@ -2462,37 +2521,67 @@ class AgentLoop:
                                     (t.get("tool") or t.get("name") or "?")
                                     for t in tool_outputs
                                 ]
-                                logger.error(
-                                    "chat lazy-completion guard tripped for "
-                                    "handoff task=%s: outbound_effect=False "
-                                    "structured_final=False tools_called=%s "
-                                    "— auto-closing as failed (LLM either "
-                                    "made no tool calls or called only "
-                                    "read-only / diagnostic tools)",
-                                    task_id, tool_names,
-                                )
-                                read_only_summary = (
-                                    f" (read-only tools called: {tool_names})"
-                                    if tool_names else ""
-                                )
-                                await self._auto_close_task(
-                                    task_id, "failed",
-                                    error=(
-                                        "no_outbound_effects: the recipient "
-                                        "completed the turn without producing "
-                                        "any outbound effect (no hand_off, "
-                                        "write_blackboard, notify_user, "
-                                        "publish_event, etc.) and without "
-                                        "returning a structured "
-                                        "{\"result\": {...}} payload."
-                                        f"{read_only_summary} Handoff tasks "
-                                        "must either perform real work via an "
-                                        "outbound tool OR return a structured "
-                                        "result envelope (e.g. {\"result\": "
-                                        "{\"status\": \"noop\", \"reason\": "
-                                        "\"...\"}})."
-                                    ),
-                                )
+                                # Bug 3 (explained-deferral carve-out): if the
+                                # turn called at least one READ-ONLY tool AND
+                                # produced a non-empty prose explanation, the
+                                # recipient correctly DEFERRED (examined state
+                                # and decided) rather than ghosting. Close as
+                                # ``done`` with a ``deferred`` result payload
+                                # (mirrors the structured-noop success shape;
+                                # ``deferred`` lives only inside the payload,
+                                # the task STATUS stays ``done``). The genuine
+                                # ghost case — zero tools OR empty response —
+                                # still hard-fails below.
+                                if tool_outputs and response_text.strip():
+                                    logger.info(
+                                        "chat explained-deferral carve-out for "
+                                        "handoff task=%s: outbound_effect=False "
+                                        "non_empty_response=True tools_called=%s "
+                                        "— auto-closing done with deferred "
+                                        "result (recipient examined state via "
+                                        "read-only tools and explained its "
+                                        "decision)",
+                                        task_id, tool_names,
+                                    )
+                                    await self._auto_close_task(
+                                        task_id, "done",
+                                        result_payload={
+                                            "status": "deferred",
+                                            "reason": response_text[:500],
+                                        },
+                                    )
+                                else:
+                                    logger.error(
+                                        "chat lazy-completion guard tripped for "
+                                        "handoff task=%s: outbound_effect=False "
+                                        "structured_final=False tools_called=%s "
+                                        "— auto-closing as failed (LLM either "
+                                        "made no tool calls or called only "
+                                        "read-only / diagnostic tools)",
+                                        task_id, tool_names,
+                                    )
+                                    read_only_summary = (
+                                        f" (read-only tools called: {tool_names})"
+                                        if tool_names else ""
+                                    )
+                                    await self._auto_close_task(
+                                        task_id, "failed",
+                                        error=(
+                                            "no_outbound_effects: the recipient "
+                                            "completed the turn without producing "
+                                            "any outbound effect (no hand_off, "
+                                            "write_blackboard, notify_user, "
+                                            "publish_event, etc.) and without "
+                                            "returning a structured "
+                                            "{\"result\": {...}} payload."
+                                            f"{read_only_summary} Handoff tasks "
+                                            "must either perform real work via an "
+                                            "outbound tool OR return a structured "
+                                            "result envelope (e.g. {\"result\": "
+                                            "{\"status\": \"noop\", \"reason\": "
+                                            "\"...\"}})."
+                                        ),
+                                    )
                             else:
                                 summary = response_text[:500]
                                 await self._auto_close_task(

--- a/tests/test_loop.py
+++ b/tests/test_loop.py
@@ -357,6 +357,81 @@ async def test_lazy_guard_fires_on_iter0_text_only_with_tools_available():
 
 
 @pytest.mark.asyncio
+async def test_lazy_guard_explained_deferral_closes_done():
+    """Bug 3 (explained-deferral carve-out): an agent that calls a
+    READ-ONLY tool to verify a prerequisite AND then explains its
+    decision in plain prose (not the structured ``{"result": {...}}``
+    envelope) is correctly DEFERRING, not ghosting. The task closes as
+    ``complete`` with a ``deferred`` result payload — distinct from the
+    genuine ghost case (zero tools / empty text) which still fails."""
+    responses = [
+        # Iter 0: call a read-only tool to check backpressure / dedup.
+        LLMResponse(
+            content="",
+            tool_calls=[ToolCallInfo(name="read_blackboard", arguments={"key": "queue"})],
+            tokens_used=20,
+        ),
+        # Iter 1: explain the deferral decision in plain prose (NOT a
+        # structured result envelope).
+        LLMResponse(
+            content=(
+                "The upstream queue already has a pending item for this "
+                "request, so I'm deferring to avoid duplicate work."
+            ),
+            tokens_used=30,
+        ),
+    ]
+    loop = _make_loop(responses)
+    loop.skills.get_tool_definitions = MagicMock(
+        return_value=[{"type": "function", "function": {"name": "read_blackboard"}}]
+    )
+    loop.skills.execute = AsyncMock(return_value={"value": "pending"})
+    assignment = TaskAssignment(
+        workflow_id="wf1", step_id="s1", task_type="research",
+        input_data={"query": "test"},
+    )
+    result = await loop.execute_task(assignment)
+    assert result.status == "complete", (
+        f"explained read-only deferral must close done, not failed; "
+        f"got status={result.status} error={result.error}"
+    )
+    assert result.result["status"] == "deferred"
+    assert "deferring" in result.result["reason"]
+    assert loop.tasks_completed == 1
+    assert loop.tasks_failed == 0
+
+
+@pytest.mark.asyncio
+async def test_lazy_guard_read_only_empty_text_still_fails():
+    """Ghost-case preservation: a read-only tool call followed by an
+    EMPTY response (no explanation) is NOT a deferral — it's a ghost
+    turn. The carve-out requires non-empty prose, so this still fails."""
+    responses = [
+        LLMResponse(
+            content="",
+            tool_calls=[ToolCallInfo(name="read_blackboard", arguments={"key": "queue"})],
+            tokens_used=20,
+        ),
+        # Iter 1: empty / whitespace-only — no explanation.
+        LLMResponse(content="   ", tokens_used=30),
+    ]
+    loop = _make_loop(responses)
+    loop.skills.get_tool_definitions = MagicMock(
+        return_value=[{"type": "function", "function": {"name": "read_blackboard"}}]
+    )
+    loop.skills.execute = AsyncMock(return_value={"value": "pending"})
+    assignment = TaskAssignment(
+        workflow_id="wf1", step_id="s1", task_type="research",
+        input_data={"query": "test"},
+    )
+    result = await loop.execute_task(assignment)
+    assert result.status == "failed"
+    assert "no_outbound_effects" in (result.error or "")
+    assert loop.tasks_failed == 1
+    assert loop.tasks_completed == 0
+
+
+@pytest.mark.asyncio
 async def test_lazy_guard_passes_iter0_structured_noop():
     """Counter-test to the iter-0 fix: a legitimate one-shot noop task
     must still complete when the LLM returns the documented contract
@@ -3365,6 +3440,50 @@ class TestOutboundEffectLazyGuard:
             "outbound-effect turn must close as 'done', not 'failed'; "
             f"calls: {loop._auto_close_task.await_args_list}"
         )
+
+    @pytest.mark.asyncio
+    async def test_chat_handoff_read_only_with_prose_auto_closes_deferred(self):
+        """Bug 3 (explained-deferral carve-out): a handoff turn whose
+        tool_outputs are ALL read-only (no outbound effect) BUT whose
+        response is non-empty prose is a correct DEFERRAL, not a ghost.
+        It auto-closes as ``done`` with a ``deferred`` result payload
+        instead of ``failed`` (which polluted failure metrics)."""
+        loop = _make_loop()
+
+        async def fake_inner(_msg):
+            return {
+                "response": (
+                    "Already a pending dedup entry on the blackboard for "
+                    "this request — deferring to avoid duplicate work."
+                ),
+                "tool_outputs": [
+                    {
+                        "tool": "read_blackboard",
+                        "input": {"key": "queue"},
+                        "output": {"value": "pending"},
+                    },
+                ],
+                "tokens_used": 5,
+            }
+        loop._chat_inner = fake_inner
+        loop._auto_close_task = AsyncMock(return_value=None)
+
+        await loop.chat("hi", task_id="task_deferred")
+
+        terminal_calls = [
+            c for c in loop._auto_close_task.await_args_list
+            if len(c.args) >= 2 and c.args[1] in ("done", "failed")
+        ]
+        assert terminal_calls
+        last_terminal = terminal_calls[-1]
+        assert last_terminal.args[1] == "done", (
+            "read-only turn WITH a prose explanation must close as 'done' "
+            f"(deferral), not 'failed'; calls: "
+            f"{loop._auto_close_task.await_args_list}"
+        )
+        payload = last_terminal.kwargs.get("result_payload") or {}
+        assert payload.get("status") == "deferred"
+        assert "deferring" in payload.get("reason", "")
 
 
 # === Bug 3 chain pin: chat() error → blocker_note wiring ===

--- a/tests/test_loop.py
+++ b/tests/test_loop.py
@@ -397,6 +397,8 @@ async def test_lazy_guard_explained_deferral_closes_done():
     )
     assert result.result["status"] == "deferred"
     assert "deferring" in result.result["reason"]
+    # summary mirrors reason so the done back-edge surfaces the explanation
+    assert result.result["summary"] == result.result["reason"]
     assert loop.tasks_completed == 1
     assert loop.tasks_failed == 0
 
@@ -3484,6 +3486,8 @@ class TestOutboundEffectLazyGuard:
         payload = last_terminal.kwargs.get("result_payload") or {}
         assert payload.get("status") == "deferred"
         assert "deferring" in payload.get("reason", "")
+        # summary feeds the done back-edge → originator's check_inbox
+        assert payload.get("summary") == payload.get("reason")
 
 
 # === Bug 3 chain pin: chat() error → blocker_note wiring ===


### PR DESCRIPTION
## Problem (Bug 3)

The `no_outbound_effects` guard hard-**FAILS** a task turn when an agent produced no outbound (non-read-only) tool call **and** the final content is not a structured `{"result": {...}}` envelope. That correctly catches genuine "ghost"/lazy completions, and the existing structured-noop escape (`{"result":{"status":"noop"}}`) still works.

The real gap: an agent that correctly **DEFERS** — calls only READ-ONLY tools to verify a prerequisite (e.g. `read_blackboard` to check backpressure / dedup state) **and** then explains its decision in **plain prose** instead of the JSON envelope — was getting hard-failed. This polluted failure metrics and triggered spurious rework. A correct, explained deferral should close `done` with a `deferred` outcome, not `failed`.

## Fix (surgical carve-out, guard not restructured)

Added a carve-out at **both** guard sites, evaluated *before* the hard-fail trips:

- **Task path** (`src/agent/loop.py`, lazy-completion guard at the `outbound_tool_calls_count == 0 and not is_structured_final` site):
  - Condition: `read_only_count > 0` (i.e. `tool_calls_count - outbound_tool_calls_count > 0`) **AND** `(llm_response.content or "").strip()` is non-empty.
  - Action: returns `TaskResult(status="complete", result={"status": "deferred", "reason": final_text[:500]})`, increments `tasks_completed`, and logs a `deferred` activity outcome. Mirrors the structured-noop success shape.

- **Handoff/chat path** (`src/agent/loop.py`, inside the `handoff_is_lazy` branch — at that point `not outbound_used` is already established, so any `tool_outputs` present are all read-only):
  - Condition: `tool_outputs` non-empty **AND** `response_text.strip()` non-empty.
  - Action: `_auto_close_task(task_id, "done", result_payload={"status": "deferred", "reason": response_text[:500]})`. Otherwise falls through to the existing `failed` close.

`deferred` lives **only inside the result payload** — there is no `deferred` task STATUS. `VALID_STATUSES` (`src/host/orchestration.py`) is unchanged; the task status stays `done`/`complete`, exactly like `noop` today.

## Preserved behavior

- **Ghost case still FAILS**: zero tools, or read-only-only with empty/whitespace response.
- **Structured `{"result":{"status":"noop"}}` escape** untouched (`test_lazy_guard_passes_iter0_structured_noop`, `test_iter0_structured_final_with_tools_skips_nudge` green).
- **`_has_outbound_effect` unit tests** green.
- `test_chat_handoff_with_only_read_tools_auto_closes_failed` uses an **empty** response (`"response": ""`), so it stays green unchanged — no test modifications were needed.

## Tests added

- `test_lazy_guard_explained_deferral_closes_done` — task path: read-only tool + prose → `complete` with `{"status":"deferred",...}`.
- `test_lazy_guard_read_only_empty_text_still_fails` — ghost preservation: read-only tool + empty text → `failed`.
- `test_chat_handoff_read_only_with_prose_auto_closes_deferred` — handoff path: read-only `tool_outputs` + prose → `done` with deferred payload.

## Test results

- `pytest tests/test_loop.py -x -v` → 164 passed.
- Broad fast subset (`tests/` minus the four e2e files) → **6581 passed, 49 skipped, 0 failed**.
- `ruff check` clean on both changed files.

## Note (out of scope)

A separate "deferred" outcome counter distinct from real failures on the dashboard/metrics would be a natural follow-up, but was left out to keep this fix surgical. The `deferred` activity outcome logged on the task path is the only observability hook added.