### PR TITLE
refactor: remove dead internal code (no callers)

### DIFF
--- a/src/agent/workspace.py
+++ b/src/agent/workspace.py
@@ -447,10 +447,6 @@ class WorkspaceManager:
         for filename in filenames:
             target[filename] = self._get_mtime(self.root / filename)
 
-    def invalidate_bootstrap_cache(self) -> None:
-        """Explicitly invalidate the bootstrap cache."""
-        self._bootstrap_cache = None
-
     def get_bootstrap_content(self) -> str:
         """Load workspace files for system prompt with per-file and total caps.
 

--- a/src/cli/config.py
+++ b/src/cli/config.py
@@ -72,8 +72,6 @@ TEMPLATES_DIR = Path(__file__).resolve().parent.parent / "templates"
 DOCKER_IMAGE = "openlegion-agent:latest"
 BROWSER_IMAGE = "openlegion-browser:latest"
 
-MARKETPLACE_DIR = PROJECT_ROOT / "skills" / "_marketplace"
-
 # ── Provider data ───────────────────────────────────────────
 
 def _get_providers() -> list[dict[str, str]]:

--- a/src/host/failover.py
+++ b/src/host/failover.py
@@ -40,8 +40,6 @@ class ModelHealth:
     consecutive_failures: int = 0
     cooldown_until: float = 0.0
     last_error: str = ""
-    last_error_time: float = 0.0
-    last_success_time: float = 0.0
 
 
 class ModelHealthTracker:
@@ -65,7 +63,6 @@ class ModelHealthTracker:
         h.success_count += 1
         h.consecutive_failures = 0
         h.cooldown_until = 0.0
-        h.last_success_time = time.time()
 
     def record_failure(
         self, model: str, error_type: str = "", status_code: int = 0,
@@ -74,7 +71,6 @@ class ModelHealthTracker:
         h.failure_count += 1
         h.consecutive_failures += 1
         h.last_error = error_type
-        h.last_error_time = time.time()
 
         cooldown = self._compute_cooldown(h, error_type, status_code)
         h.cooldown_until = time.time() + cooldown

--- a/src/host/orchestration.py
+++ b/src/host/orchestration.py
@@ -673,27 +673,6 @@ class Tasks:
             rows = conn.execute(sql, params).fetchall()
         return [self._row_to_dict(r) for r in rows]
 
-    def list_by_creator(
-        self,
-        creator: str,
-        *,
-        include_terminal: bool = True,
-    ) -> list[dict]:
-        """List tasks created by ``creator``. Used by sender-side completion checks."""
-        clauses = ["creator = ?"]
-        params: list[Any] = [creator]
-        if not include_terminal:
-            placeholders = ",".join("?" * len(TERMINAL_STATUSES))
-            clauses.append(f"status NOT IN ({placeholders})")
-            params.extend(sorted(TERMINAL_STATUSES))
-        sql = (
-            f"SELECT {self._SELECT_COLS} FROM tasks "
-            f"WHERE {' AND '.join(clauses)} ORDER BY created_at ASC"
-        )
-        with self._conn() as conn:
-            rows = conn.execute(sql, params).fetchall()
-        return [self._row_to_dict(r) for r in rows]
-
     # ── Per-agent aggregates for the operator heartbeat (PR-J') ─────
     #
     # The system_metrics endpoint surfaces per-agent counts so the


### PR DESCRIPTION
## Summary

Surgical removal of four **genuinely dead** internal symbols — each verified to have **zero callers in `src/` and `tests/`** via ruff (`E,F,W,I` clean), vulture (60–100% confidence), and grep cross-check. Pure deletions, no behavior change.

| Symbol | Why it's dead |
|---|---|
| `Tasks.list_by_creator()` (`host/orchestration.py`) | Superseded by the back-edge `task_event` inbox (`inbox/{agent}/task_event/`); sender-side completion now flows through `check_inbox`. The method was left unwired. |
| `WorkspaceManager.invalidate_bootstrap_cache()` (`agent/workspace.py`) | Never called; the cache is invalidated by the mtime check inside `get_bootstrap_content()`. |
| `cli.config.MARKETPLACE_DIR` | Unused constant; the marketplace path lives in `src/marketplace.py`. |
| `ModelHealth.last_error_time` / `last_success_time` (`host/failover.py`) | Write-only dead state — assigned in `record_success`/`record_failure`, never read, absent from `get_status()`. |

**Net:** 4 files, 31 deletions.

## Scope discipline

Intentionally-retained back-compat shims are **left untouched** because they carry explicit keep-for-external-import intent: `MeshClient.*_project` proxies, `PRICING_CENTS`/`PRICING_CENTS_PROXY_AWARE` aliases, and the `redaction.py` re-exports. The SQLite-scaffolding and agent-ID-regex duplication are deferred (the former already has a `refactor/sqlite-connect-helper` branch in flight).

## Test plan

- [x] `ruff check` (E,F,W,I) clean on all changed files — no orphaned imports
- [x] Targeted suites green: `test_failover`, `test_workspace`, `test_orchestration`, `test_orchestration_endpoints`, `test_orchestration_migration`, `test_marketplace`, `test_cli_commands` → **468 passed**
- [ ] CI

## Related findings (NOT in this PR — flagged for a decision)

Two items the review surfaced look like **possible latent regressions, not mere doc drift**, so they're intentionally excluded pending intent confirmation:
1. Legacy env fallbacks `OPENLEGION_MAX_PROJECTS` / `OPENLEGION_PROJECT_SCOPE_MODE` are **no longer read in `src/`**, yet `docs/configuration.md` calls them "permanent fallbacks." Since `OPENLEGION_MAX_TEAMS` defaults to `0` (= teams disabled), an existing deploy that set only the old name could silently disable teams.
2. `PROJECT.md` bootstrap fallback is documented in several places + `team_migration.py` but absent from `workspace._BOOTSTRAP_FILES`.

Made with [Cursor](https://cursor.com)