### PR TITLE
refactor: remove dead PermissionMatrix.can_manage_projects alias

### DIFF
--- a/src/host/permissions.py
+++ b/src/host/permissions.py
@@ -275,22 +275,10 @@ class PermissionMatrix:
         return self.get_permissions(agent_id).can_manage_fleet
 
     def can_manage_teams(self, agent_id: str) -> bool:
-        """Check if agent is allowed to create/archive teams and manage membership.
-
-        Honors both ``can_manage_teams`` (new) and ``can_manage_projects``
-        (deprecated) on :class:`AgentPermissions`; the model validator
-        :meth:`AgentPermissions._unify_manage_teams_alias` already mirrors
-        either flag onto the other, so this method only needs to consult
-        one field. PR 3 retires the alias.
-        """
+        """Check if agent is allowed to create/archive teams and manage membership."""
         if self._is_trusted(agent_id):
             return True
         return self.get_permissions(agent_id).can_manage_teams
-
-    # Back-compat alias — keep until PR 3.
-    def can_manage_projects(self, agent_id: str) -> bool:
-        """DEPRECATED: alias for :meth:`can_manage_teams`."""
-        return self.can_manage_teams(agent_id)
 
     def can_edit_agent_config(self, agent_id: str) -> bool:
         """Check if agent is allowed to propose/confirm edits to other agents' config."""

--- a/tests/test_permissions.py
+++ b/tests/test_permissions.py
@@ -941,15 +941,6 @@ class TestControlPlanePermissions:
         assert m.can_manage_fleet("broad") is True
         assert m.can_manage_fleet("mesh") is True  # trusted shortcut
 
-    def test_can_manage_projects_method(self, tmp_path):
-        m = self._matrix(tmp_path, {
-            "narrow": {},
-            "broad": {"can_manage_projects": True},
-        })
-        assert m.can_manage_projects("narrow") is False
-        assert m.can_manage_projects("broad") is True
-        assert m.can_manage_projects("mesh") is True
-
     def test_can_edit_agent_config_method(self, tmp_path):
         m = self._matrix(tmp_path, {
             "narrow": {},


### PR DESCRIPTION
## Summary

Removes the deprecated `PermissionMatrix.can_manage_projects()` alias — the last leftover of the project→team rename in the permission layer.

- `can_manage_projects()` was commented *"Back-compat alias — keep until PR 3"*; the rename PRs are complete. It simply delegated to `can_manage_teams()`, had **zero `src/` callers**, and was exercised only by its own unit test. Removed the method + `test_can_manage_projects_method`.
- `can_manage_teams()` is **kept** — it's a member of the tested control-plane permission family (`_CONTROL_PLANE_FIELDS` in `tests/test_permissions.py`). Its docstring is trimmed to drop the reference to the now-removed alias.

The `AgentPermissions.can_manage_projects` config **field** + its validator are untouched (still mirrored for on-disk config back-compat — separate, documented shim).

**Net:** 2 files, −22 / +1.

## Test plan
- [x] `ruff` (E,F,W,I) clean
- [x] `tests/test_permissions.py` → **55 passed** (incl. the `_CONTROL_PLANE_FIELDS` group that initially caught an over-eager removal of `can_manage_teams`, now reverted)
- [ ] CI

Made with [Cursor](https://cursor.com)