### PR TITLE
fix(agent): retry truncated streamed tool-call args + close chat_stream transient-retry asymmetry

### DIFF
--- a/src/agent/llm.py
+++ b/src/agent/llm.py
@@ -99,6 +99,66 @@ class LLMClient:
                 params[k] = v
 
     @staticmethod
+    def _raise_classified_error(
+        error_msg: str,
+        error_type: str | None,
+        error_meta: dict,
+        *,
+        prefix: str,
+    ) -> None:
+        """Raise the typed exception for a mesh error payload. Always raises.
+
+        Fix 3 (seam follow-up): the mesh proxy tags distinguished exceptions on
+        APIProxyResponse.error_type so we can re-raise the same type the agent
+        loop expects to catch. Without this, every credential failure looks
+        like a generic RuntimeError to the loop and the quarantine path doesn't
+        trigger via the agent's report channel (mesh also records directly, but
+        the agent-side branches still need the type).
+
+        Shared by ``chat`` (``prefix="LLM call failed"``) and ``chat_stream``
+        (``prefix="LLM stream error"``) so the streaming path gets the same
+        ``transient`` + substring-backstop retry handling the non-streaming path
+        has always had.
+        """
+        if error_type == "auth_failure":
+            from src.shared.errors import LLMAuthError
+            raise LLMAuthError(
+                error_msg,
+                provider=error_meta.get("provider", "unknown"),
+                model=error_meta.get("model"),
+                http_status=error_meta.get("http_status"),
+            )
+        if error_type == "config_error":
+            from src.shared.errors import LLMConfigError
+            raise LLMConfigError(
+                error_msg,
+                provider=error_meta.get("provider", "unknown"),
+                model=error_meta.get("model", ""),
+                allowed_models=set(error_meta.get("allowed_models", [])),
+                http_status=error_meta.get("http_status"),
+            )
+        if error_type == "transient":
+            # Mesh-tagged transient (Claude subscription throttle, stream
+            # interruption, empty-choices response). The mesh already
+            # classified it at the source — surface as retryable so
+            # ``_llm_call_with_retry`` backs off.
+            raise LLMRetryableError(f"{prefix}: {error_msg}")
+        # Backstop for un-tagged transient signals — third-party SDKs, future
+        # wrapper sites not yet routed through the typed channel, or paths the
+        # mesh outer handler didn't catch. Each substring corresponds to a known
+        # transient pattern; ``retrying may help`` is the deliberate suffix
+        # appended by ``friendly_streaming_error`` (src/shared/utils.py:78), so
+        # matching on it recognizes the helper's contract rather than
+        # whack-a-mole'ing message text.
+        _retryable = (
+            "rate limit", "ratelimit", "429", "too many requests",
+            "overloaded", "503", "empty response", "retrying may help",
+        )
+        if any(kw in error_msg.lower() for kw in _retryable):
+            raise LLMRetryableError(f"{prefix}: {error_msg}")
+        raise RuntimeError(f"{prefix}: {error_msg}")
+
+    @staticmethod
     def _parse_tool_calls(raw_calls: list[dict]) -> list[ToolCallInfo] | None:
         """Parse raw tool-call dicts into ToolCallInfo objects."""
         tool_calls: list[ToolCallInfo] = []
@@ -107,15 +167,31 @@ class LLMClient:
             if args is None:
                 args = {}
             elif isinstance(args, str):
-                try:
-                    args = json.loads(args)
-                except json.JSONDecodeError:
-                    logger.warning(
-                        "Malformed tool arguments for %s: %s",
-                        tc.get("name"),
-                        args[:200] if isinstance(args, str) else args,
-                    )
-                    args = {"raw": args}
+                if args.strip() == "":
+                    # Legitimate no-arg tool call (e.g. check_inbox()).
+                    # Empty / whitespace-only arguments are valid and MUST
+                    # keep working — do not raise.
+                    args = {}
+                else:
+                    try:
+                        args = json.loads(args)
+                    except json.JSONDecodeError as e:
+                        # Non-empty arguments that won't parse means the tool
+                        # call was truncated mid-stream (provider hit the output
+                        # token cap mid-tool-call, or the stream dropped before
+                        # the JSON closed). Treat as retryable so
+                        # ``_llm_call_with_retry``'s backoff re-issues the call
+                        # (and the streaming caller falls back to non-streaming
+                        # where a complete response can assemble) rather than
+                        # dispatching a ``{"raw": <truncated>}`` stub that fails
+                        # downstream with a confusing missing-required-param
+                        # error. (Incident: ``edit_agent`` received a payload
+                        # whose JSON cut off mid-string, e.g.
+                        # ``{"agent_id": "page-validator", "field": ...``.)
+                        raise LLMRetryableError(
+                            f"Truncated tool-call arguments for "
+                            f"{tc.get('name')!r}: {args[:200]}"
+                        ) from e
             # json.loads can return non-dict types (null→None, "42"→int,
             # "[1,2]"→list).  Normalise to dict so ToolCallInfo validation
             # and downstream execute() don't crash.
@@ -161,54 +237,12 @@ class LLMClient:
         data = response.json()
 
         if not data.get("success"):
-            error_msg = data.get("error", "")
-            # Fix 3 (seam follow-up): the mesh proxy tags distinguished
-            # exceptions on APIProxyResponse.error_type so we can re-raise
-            # the same type the agent loop expects to catch. Without
-            # this, every credential failure looks like a generic
-            # RuntimeError to the loop and the quarantine path doesn't
-            # trigger via the agent's report channel (mesh also records
-            # directly, but the agent-side branches still need the type).
-            error_type = data.get("error_type")
-            error_meta = data.get("error_meta") or {}
-            if error_type == "auth_failure":
-                from src.shared.errors import LLMAuthError
-                raise LLMAuthError(
-                    error_msg,
-                    provider=error_meta.get("provider", "unknown"),
-                    model=error_meta.get("model"),
-                    http_status=error_meta.get("http_status"),
-                )
-            if error_type == "config_error":
-                from src.shared.errors import LLMConfigError
-                raise LLMConfigError(
-                    error_msg,
-                    provider=error_meta.get("provider", "unknown"),
-                    model=error_meta.get("model", ""),
-                    allowed_models=set(error_meta.get("allowed_models", [])),
-                    http_status=error_meta.get("http_status"),
-                )
-            if error_type == "transient":
-                # Mesh-tagged transient (Claude subscription throttle,
-                # stream interruption, empty-choices response). The mesh
-                # already classified it at the source — surface as
-                # retryable so ``_llm_call_with_retry`` backs off.
-                raise LLMRetryableError(f"LLM call failed: {error_msg}")
-            # Backstop for un-tagged transient signals — third-party SDKs,
-            # future wrapper sites not yet routed through the typed channel,
-            # or paths the mesh outer handler didn't catch. Each substring
-            # corresponds to a known transient pattern; ``retrying may
-            # help`` is the deliberate suffix appended by
-            # ``friendly_streaming_error`` (src/shared/utils.py:78), so
-            # matching on it recognizes the helper's contract rather than
-            # whack-a-mole'ing message text.
-            _retryable = (
-                "rate limit", "ratelimit", "429", "too many requests",
-                "overloaded", "503", "empty response", "retrying may help",
+            self._raise_classified_error(
+                data.get("error", ""),
+                data.get("error_type"),
+                data.get("error_meta") or {},
+                prefix="LLM call failed",
             )
-            if any(kw in error_msg.lower() for kw in _retryable):
-                raise LLMRetryableError(f"LLM call failed: {error_msg}")
-            raise RuntimeError(f"LLM call failed: {error_msg}")
 
         result = data["data"]
         return LLMResponse(
@@ -271,29 +305,19 @@ class LLMClient:
                     continue
 
                 if "error" in data:
-                    # Fix 3 (seam follow-up): distinguished error types
-                    # ride the SSE payload so the agent loop can route
-                    # to the auth-failure / config-error branches.
-                    error_type = data.get("error_type")
-                    error_meta = data.get("error_meta") or {}
-                    if error_type == "auth_failure":
-                        from src.shared.errors import LLMAuthError
-                        raise LLMAuthError(
-                            data["error"],
-                            provider=error_meta.get("provider", "unknown"),
-                            model=error_meta.get("model"),
-                            http_status=error_meta.get("http_status"),
-                        )
-                    if error_type == "config_error":
-                        from src.shared.errors import LLMConfigError
-                        raise LLMConfigError(
-                            data["error"],
-                            provider=error_meta.get("provider", "unknown"),
-                            model=error_meta.get("model", ""),
-                            allowed_models=set(error_meta.get("allowed_models", [])),
-                            http_status=error_meta.get("http_status"),
-                        )
-                    raise RuntimeError(f"LLM stream error: {data['error']}")
+                    # Distinguished error types ride the SSE payload so the
+                    # agent loop can route to the auth-failure / config-error
+                    # branches. Shared helper also adds the ``transient`` +
+                    # substring-backstop retry handling that ``chat`` has —
+                    # closing the streaming-path asymmetry (a mid-stream
+                    # transient is now retried rather than raised as a bare
+                    # RuntimeError).
+                    self._raise_classified_error(
+                        data["error"],
+                        data.get("error_type"),
+                        data.get("error_meta") or {},
+                        prefix="LLM stream error",
+                    )
 
                 if data.get("type") == "text_delta":
                     yield {"type": "text_delta", "content": data.get("content", "")}

--- a/tests/test_llm.py
+++ b/tests/test_llm.py
@@ -13,11 +13,13 @@ test pins the post-fix behavior: empty-response is now retryable.
 
 from __future__ import annotations
 
+import json
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
 from src.agent.llm import LLMClient, LLMRetryableError
+from src.shared.errors import LLMAuthError
 
 
 def _make_mesh_response(
@@ -155,3 +157,172 @@ async def test_unrelated_runtime_error_still_permanent():
         await client.chat(system="s", messages=[{"role": "user", "content": "x"}])
     # Must NOT be the retryable subclass.
     assert not isinstance(exc_info.value, LLMRetryableError)
+
+
+# --------------------------------------------------------------------------
+# _parse_tool_calls — truncated-args retryable carve-out
+#
+# A streamed tool call whose JSON ``arguments`` got truncated (provider hit
+# the output token cap mid-tool-call, or the stream dropped before the JSON
+# closed) used to degrade to ``{"raw": <truncated>}`` and dispatch a stub that
+# failed downstream with a confusing missing-required-param error (the
+# ``edit_agent`` incident). It is now raised as ``LLMRetryableError`` so the
+# call is retried (and the streaming caller falls back to non-streaming).
+# Empty / whitespace-only args remain a legitimate no-arg call.
+# --------------------------------------------------------------------------
+
+
+def test_parse_tool_calls_truncated_args_raises_retryable():
+    """Non-empty unparseable args = truncated mid-stream → retryable."""
+    raw = [{
+        "name": "edit_agent",
+        "arguments": '{"agent_id": "page-validator", "field": "instructions", "value": "You are page-validator',
+    }]
+    with pytest.raises(LLMRetryableError) as exc_info:
+        LLMClient._parse_tool_calls(raw)
+    # Message surfaces the tool name + a truncated preview for the operator.
+    assert "edit_agent" in str(exc_info.value)
+
+
+def test_parse_tool_calls_empty_string_args_is_no_arg_call():
+    """Empty-string args = legitimate no-arg tool call → {} (no raise)."""
+    raw = [{"name": "check_inbox", "arguments": ""}]
+    parsed = LLMClient._parse_tool_calls(raw)
+    assert parsed is not None
+    assert len(parsed) == 1
+    assert parsed[0].name == "check_inbox"
+    assert parsed[0].arguments == {}
+
+
+def test_parse_tool_calls_whitespace_only_args_is_no_arg_call():
+    """Whitespace-only args = legitimate no-arg tool call → {} (no raise)."""
+    raw = [{"name": "check_inbox", "arguments": "   \n\t  "}]
+    parsed = LLMClient._parse_tool_calls(raw)
+    assert parsed is not None
+    assert parsed[0].arguments == {}
+
+
+def test_parse_tool_calls_valid_object_args_parsed():
+    """Valid JSON object args parse into the dict unchanged."""
+    raw = [{"name": "edit_agent", "arguments": '{"agent_id": "x", "field": "model"}'}]
+    parsed = LLMClient._parse_tool_calls(raw)
+    assert parsed is not None
+    assert parsed[0].arguments == {"agent_id": "x", "field": "model"}
+
+
+def test_parse_tool_calls_valid_non_dict_json_normalised_to_empty():
+    """Valid-but-non-dict JSON (e.g. ``"42"`` → int) normalises to {} and
+    MUST NOT raise — distinct from the truncated-args case."""
+    raw = [{"name": "noop", "arguments": "42"}]
+    parsed = LLMClient._parse_tool_calls(raw)
+    assert parsed is not None
+    assert parsed[0].arguments == {}
+
+
+# --------------------------------------------------------------------------
+# chat_stream — error classification + truncated done-frame
+# --------------------------------------------------------------------------
+
+
+def _make_stream_client(frames: list[dict]) -> LLMClient:
+    """Build an LLMClient whose ``client.stream(...)`` yields the given SSE
+    ``data:`` frames via an async context manager."""
+    client = LLMClient(
+        mesh_url="http://mesh.test",
+        agent_id="test-agent",
+        default_model="anthropic/claude-sonnet-4-6",
+    )
+
+    class _FakeResponse:
+        def raise_for_status(self):
+            pass
+
+        async def aiter_lines(self):
+            for frame in frames:
+                yield f"data: {json.dumps(frame)}"
+
+    class _FakeStreamCtx:
+        async def __aenter__(self):
+            return _FakeResponse()
+
+        async def __aexit__(self, *exc):
+            return False
+
+    mock_http = MagicMock()
+    mock_http.stream = MagicMock(return_value=_FakeStreamCtx())
+    client._get_client = AsyncMock(return_value=mock_http)
+    return client
+
+
+@pytest.mark.asyncio
+async def test_chat_stream_truncated_done_frame_raises_retryable():
+    """A ``done`` frame carrying a truncated tool-call ``arguments`` must
+    raise ``LLMRetryableError`` out of the generator so the loop falls back
+    to non-streaming."""
+    client = _make_stream_client([
+        {
+            "type": "done",
+            "content": "",
+            "tool_calls": [{
+                "name": "edit_agent",
+                "arguments": '{"agent_id": "page-validator", "field": "instructions", "value": "You are',
+            }],
+            "tokens_used": 10,
+            "model": "anthropic/claude-sonnet-4-6",
+        },
+    ])
+    with pytest.raises(LLMRetryableError):
+        async for _ in client.chat_stream(
+            system="s", messages=[{"role": "user", "content": "x"}],
+        ):
+            pass
+
+
+@pytest.mark.asyncio
+async def test_chat_stream_transient_error_type_retryable():
+    """Mesh-tagged ``error_type="transient"`` mid-stream must now retry
+    (was a bare RuntimeError before the helper extraction)."""
+    client = _make_stream_client([
+        {
+            "error": "Connection to the AI provider was interrupted.",
+            "error_type": "transient",
+            "error_meta": {"provider": "anthropic"},
+        },
+    ])
+    with pytest.raises(LLMRetryableError):
+        async for _ in client.chat_stream(
+            system="s", messages=[{"role": "user", "content": "x"}],
+        ):
+            pass
+
+
+@pytest.mark.asyncio
+async def test_chat_stream_untagged_substring_backstop_retryable():
+    """Substring backstop now works for streaming — an untagged error whose
+    message contains ``retrying may help`` is retryable."""
+    client = _make_stream_client([
+        {"error": "Provider hiccup. Retrying may help."},
+    ])
+    with pytest.raises(LLMRetryableError):
+        async for _ in client.chat_stream(
+            system="s", messages=[{"role": "user", "content": "x"}],
+        ):
+            pass
+
+
+@pytest.mark.asyncio
+async def test_chat_stream_auth_failure_still_raises_auth_error():
+    """Sanity — typed ``auth_failure`` still raises ``LLMAuthError`` (not
+    the retryable subclass) through the shared helper."""
+    client = _make_stream_client([
+        {
+            "error": "Invalid API key",
+            "error_type": "auth_failure",
+            "error_meta": {"provider": "anthropic", "http_status": 401},
+        },
+    ])
+    with pytest.raises(LLMAuthError):
+        async for _ in client.chat_stream(
+            system="s", messages=[{"role": "user", "content": "x"}],
+        ):
+            pass


### PR DESCRIPTION
## Problem

When the streaming LLM path assembled a tool call whose JSON `arguments` got truncated (provider hit the output token cap mid-tool-call, OR the stream dropped before the JSON closed), the agent silently dispatched a garbage `{"raw": <truncated>}` stub to the tool. Operators saw `edit_agent` fail with payloads like:

```
{'raw': '{"agent_id": "page-validator", "field": "instructions", "value": "You are page-validator...'}
```

— the JSON cut off mid-string. The tool then failed downstream with a confusing missing-required-param error.

## Root cause (`src/agent/llm.py`)

1. `_parse_tool_calls`: a string `arguments` that failed `json.loads` was logged and degraded to `args = {"raw": args}`, then dispatched. Both `chat` and `chat_stream`'s `done` branch funnel through this one staticmethod — the single correct chokepoint.
2. `chat_stream` had a transient-error asymmetry vs `chat`: its error branch handled only `auth_failure` / `config_error` then raised a bare `RuntimeError`. It lacked the `error_type == "transient"` branch AND the `_retryable` substring backstop that `chat` has, so a mesh-tagged or substring-detectable transient surfacing mid-stream was NOT retried.

## Fix (agent-side only)

**Change 1 — `_parse_tool_calls` raises retryable on truncated args (NOT on empty).**
- Empty / whitespace-only string args → `{}` (legitimate no-arg tool call, e.g. `check_inbox()`); never raises.
- Non-empty args that fail `json.loads` → raise `LLMRetryableError` (with tool name + ≤200-char preview) instead of dispatching a `{"raw":...}` stub. Truncated JSON means a truncated tool call; retry backs off via `_llm_call_with_retry`, and the streaming caller falls back to non-streaming (loop.py ~3683 broad except → `_llm_call_with_retry(self.llm.chat, ...)`) where a complete response can assemble.
- Valid-but-non-dict JSON (e.g. `"42"`) still normalises to `{}` (non-raising).

**Change 2 — DRY the error classifier + close the `chat_stream` asymmetry.**
- Extracted the inline `auth_failure` / `config_error` / `transient` / substring-backstop / `RuntimeError` ladder into `_raise_classified_error(error_msg, error_type, error_meta, *, prefix)`.
- `chat` calls it with `prefix="LLM call failed"`; `chat_stream` calls it with `prefix="LLM stream error"` — exact existing prefixes preserved so no string-asserting test breaks.
- This adds the missing `transient` + substring-backstop retry handling to streaming.

## Out of scope (deliberate)

`src/host/credentials.py` server-side stream assembly and the default `max_tokens` are untouched. Server-side `finish_reason`/`stop_reason` length-cap tagging is a possible future enhancement, but the agent-side parse-validation already catches truncation universally (truncated JSON won't parse), so it's not needed for correctness here.

## Tests (`tests/test_llm.py`, +10)

- `_parse_tool_calls`: truncated args → retryable; empty / whitespace → `{}`; valid object → parsed dict; non-dict JSON (`"42"`) → `{}`.
- `chat_stream`: truncated `done` frame → `LLMRetryableError`; `error_type="transient"` → retryable; untagged `"retrying may help"` → retryable (substring backstop now works for streaming); `auth_failure` → still `LLMAuthError`.
- Existing `chat` classification tests unchanged and still pass (helper preserves behavior + prefix).

`tests/test_llm.py` 15 passed · `tests/test_loop.py` 161 passed · broad fast subset 6585 passed / 49 skipped (one unrelated pre-existing flake: `test_cli_commands.py::TestStopNoDocker::test_stop_no_docker`, a Docker-environment-dependent assertion that passes standalone; this PR does not touch the CLI or that test). `ruff check` clean.