### PR TITLE
Dashboard: fold top bar into sidebar + chat/work/contrast polish

### DIFF
--- a/src/dashboard/server.py
+++ b/src/dashboard/server.py
@@ -1241,7 +1241,9 @@ def create_dashboard_router(
                     "last_check": 0,
                     "last_healthy": 0,
                     "last_task_event_ts": None,
-                    "last_worked_ts": None,
+                    # Sourced from the persistent usage ledger, so a stopped /
+                    # over-limit agent still shows when it last actually worked.
+                    "last_worked_ts": worked_map.get(agent_id),
                     "daily_cost": 0,
                     "daily_tokens": 0,
                     "role": acfg.get("role", ""),

--- a/src/dashboard/server.py
+++ b/src/dashboard/server.py
@@ -1166,6 +1166,10 @@ def create_dashboard_router(
         health_map = {h["agent"]: h for h in health_list}
         cost_list = cost_tracker.get_all_agents_spend("today")
         cost_map = {c["agent"]: c for c in cost_list}
+        # Accurate "last worked" = timestamp of the agent's most recent LLM
+        # call (from the usage ledger), distinct from the health probe's
+        # "last seen". One query for the whole fleet.
+        worked_map = cost_tracker.get_all_agents_last_worked()
 
         agent_projects = cfg.get("_agent_projects", {})
 
@@ -1201,6 +1205,7 @@ def create_dashboard_router(
                 "last_check": h.get("last_check", 0),
                 "last_healthy": h.get("last_healthy", 0),
                 "last_task_event_ts": last_task_ts,
+                "last_worked_ts": worked_map.get(agent_id),
                 "daily_cost": c.get("cost", 0),
                 "daily_tokens": c.get("tokens", 0),
                 "role": acfg.get("role", ""),
@@ -1236,6 +1241,7 @@ def create_dashboard_router(
                     "last_check": 0,
                     "last_healthy": 0,
                     "last_task_event_ts": None,
+                    "last_worked_ts": None,
                     "daily_cost": 0,
                     "daily_tokens": 0,
                     "role": acfg.get("role", ""),

--- a/src/dashboard/static/css/dashboard.css
+++ b/src/dashboard/static/css/dashboard.css
@@ -90,7 +90,10 @@
 .seg-tab-active:hover {
   background: var(--surface-hover);
   color: #fff;
-  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.3);
+  /* Stronger separation from the inactive pills: a deeper drop shadow
+     plus a 1px inset highlight so the active tab reads as raised rather
+     than merely a hair lighter. */
+  box-shadow: 0 1px 4px rgba(0, 0, 0, 0.45), inset 0 0 0 1px rgba(255, 255, 255, 0.05);
 }
 
 /* Compact variant for tight inline headers (e.g. the team hub
@@ -166,10 +169,10 @@
 }
 
 .agent-card:hover {
-  border-color: rgba(99, 102, 241, 0.3);
+  border-color: rgba(99, 102, 241, 0.45);
   box-shadow:
     0 8px 32px -4px rgba(0, 0, 0, 0.4),
-    0 0 0 1px rgba(99, 102, 241, 0.08);
+    0 0 0 1px rgba(99, 102, 241, 0.12);
   transform: translateY(-2px);
 }
 
@@ -536,8 +539,12 @@
 .empty-state-icon {
   width: 3rem;
   height: 3rem;
-  margin: 0 auto 0.75rem;
-  color: #374151;
+  margin: 0 auto 0.875rem;
+  color: #9ca3af;                          /* gray-400 — visible on the near-black canvas */
+  padding: 0.7rem;
+  background: rgba(107, 114, 128, 0.1);    /* soft circle lifts the glyph off the bg */
+  border-radius: 9999px;
+  box-sizing: content-box;
 }
 
 /* ── Event type badge — monospace pill ─────────────── */
@@ -769,8 +776,12 @@ select:focus-visible,
 .empty-state > svg {
   width: 2.5rem;
   height: 2.5rem;
-  color: #1f2937;
-  margin-bottom: 0.75rem;
+  color: #9ca3af;                          /* gray-400 — was #1f2937, invisible on dark */
+  margin-bottom: 0.875rem;
+  padding: 0.625rem;
+  background: rgba(107, 114, 128, 0.1);
+  border-radius: 9999px;
+  box-sizing: content-box;
 }
 
 .empty-state-title {
@@ -967,7 +978,7 @@ select:focus-visible,
 
 .messenger-panel {
   position: fixed;
-  top: var(--topnav-h);                      /* dock below the top nav, not under it */
+  top: var(--topnav-h);                      /* mobile/tablet: dock below the top bar */
   right: 0;
   height: calc(100% - var(--topnav-h));      /* exact remaining height — no clipped top/bottom */
   z-index: 45;                               /* above content, below modals/cmd-palette */
@@ -992,6 +1003,12 @@ select:focus-visible,
 @media (min-width: 768px) {
   .messenger-full {
     width: calc(100vw - var(--sidenav-w));
+  }
+  /* Desktop has no top bar (its contents fold into the sidebar), so the
+     panel spans the full viewport height flush with the top edge. */
+  .messenger-panel {
+    top: 0;
+    height: 100%;
   }
 }
 
@@ -1092,6 +1109,15 @@ select:focus-visible,
   .messenger-margin {
     margin-right: 0;
   }
+}
+
+/* Side-panel chat bubbles get more horizontal room than the main /chat
+   tab. The panel is only ~360–520px wide, so the shared max-w-[80%] forced
+   messages to wrap far too aggressively. Scope the widening to the side
+   panel's message log so the wide /chat tab keeps its comfortable measure.
+   Browser-expanded bubbles already opt into max-w-[95%] and are untouched. */
+[id^="side-chat-messages-"] [class*="max-w-[80%]"] {
+  max-width: 92%;
 }
 
 /* ── Chat-aware grid collapse ────────────────────────
@@ -1396,9 +1422,9 @@ select:focus-visible,
 }
 
 .chat-markdown a {
-  color: #93c5fd;
+  color: #bfdbfe;
   text-decoration: underline;
-  text-decoration-color: rgba(147, 197, 253, 0.4);
+  text-decoration-color: rgba(147, 197, 253, 0.6);
   text-underline-offset: 2px;
 }
 
@@ -1519,13 +1545,13 @@ body {
 
 .chat-input-wrap {
   display: flex;
-  align-items: center;  /* center keeps all buttons vertically aligned */
-  gap: 2px;
-  padding: 3px 3px 3px 2px;
+  align-items: flex-end;  /* keep send/attach pinned to the last line as the textarea grows */
+  gap: 3px;
+  padding: 4px;
   width: 100%;
   background: rgba(17, 17, 24, 0.8);
   border: 1px solid rgba(42, 42, 58, 0.8);
-  border-radius: 0.75rem;
+  border-radius: 0.875rem;
   transition: border-color 0.15s, box-shadow 0.15s;
 }
 
@@ -1545,19 +1571,19 @@ body {
   display: flex;
   align-items: center;
   justify-content: center;
-  width: 28px;
-  height: 28px;
-  border-radius: 0.375rem;
+  width: 32px;
+  height: 32px;
+  border-radius: 0.5rem;
   border: none;
   background: transparent;
-  color: #4b5563;
+  color: #6b7280;          /* gray-500 — discoverable at rest, not washed out */
   cursor: pointer;
   padding: 0;
   transition: color 0.15s, background-color 0.15s;
 }
 
 .chat-input-btn:hover:not(:disabled) {
-  color: #9ca3af;
+  color: #d1d5db;          /* gray-300 */
   background-color: rgba(31, 41, 55, 0.8);
 }
 
@@ -1607,16 +1633,16 @@ body {
 /* ── Chat slide-over textarea ───────────────────── */
 
 .chat-slide-textarea {
-  max-height: 120px;
+  max-height: 180px;       /* ~6 lines before it scrolls (was 120 / ~3 lines) */
   background: transparent;
   border: none;
   outline: none;
   resize: none;
   flex: 1;
   min-width: 0;
-  padding: 0.5rem 0.25rem 0.5rem 0.5rem;
-  font-size: 0.75rem;
-  line-height: 1.4;
+  padding: 0.5rem 0.5rem 0.5rem 0.6rem;
+  font-size: 0.8125rem;    /* match body scale; was 0.75rem */
+  line-height: 1.5;        /* match message bubble rhythm */
   color: #e5e7eb;
   overflow-y: auto;
 }

--- a/src/dashboard/static/css/dashboard.css
+++ b/src/dashboard/static/css/dashboard.css
@@ -390,6 +390,35 @@
   background: rgba(42, 42, 58, 0.4);
 }
 
+/* ── Per-page contextual header ─────────────────────
+   The band at the top of each tab's content holding page-scoped controls
+   (chat identity, team chips, settings sections, page title). One shared
+   look — consistent height, padding and bottom rule — so the four tabs
+   read as a single contextual top-nav system even though each renders its
+   own. Horizontal insets come from the parent <main> padding. */
+.page-header {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  min-height: 3rem;
+  padding-bottom: 0.75rem;
+  margin-bottom: 1rem;
+  border-bottom: 1px solid rgba(42, 42, 58, 0.45);
+}
+
+.page-header-title {
+  font-size: 1.0625rem;
+  font-weight: 600;
+  line-height: 1.2;
+  color: #fff;
+}
+
+.page-header-subtitle {
+  font-size: var(--fs-sm);
+  color: var(--text-muted);
+  margin-top: 0.1rem;
+}
+
 /* ── Desktop sidebar (md+) ─────────────────────────── */
 
 .side-nav {
@@ -1055,14 +1084,15 @@ select:focus-visible,
   display: none;
 }
 
-/* Expand the contact list to names + previews from 1280px up. Kept to 160px
-   (not 180) so that on a 520px panel the chat column gets ~360px — the rail
-   was eating too much width and leaving the messages too narrow. Below 1280
-   (tablets/small windows) the rail stays compact (avatar-only). */
+/* Expand the contact list to names + previews from 1280px up. Trimmed to
+   132px so the chat column gets the extra width — on a 520px panel that
+   leaves the messages ~388px, which reads far more proportionally than the
+   old 160px rail. Below 1280 (tablets/small windows) the rail stays
+   compact (avatar-only). */
 @media (min-width: 1280px) {
   .messenger-sidebar {
-    width: 160px;
-    min-width: 160px;
+    width: 132px;
+    min-width: 132px;
   }
   .messenger-sidebar .messenger-contact > div.flex-1 {
     display: block;

--- a/src/dashboard/static/css/dashboard.css
+++ b/src/dashboard/static/css/dashboard.css
@@ -1009,7 +1009,10 @@ select:focus-visible,
   position: fixed;
   top: var(--topnav-h);                      /* mobile/tablet: dock below the top bar */
   right: 0;
-  height: calc(100% - var(--topnav-h));      /* exact remaining height — no clipped top/bottom */
+  /* dvh, not %: a fixed element resolves % against the 100vh initial
+     containing block, which on mobile overshoots the visible area and
+     pushes the composer below the fold. dvh tracks the visible viewport. */
+  height: calc(100dvh - var(--topnav-h));
   z-index: 45;                               /* above content, below modals/cmd-palette */
   transition: width 0.2s cubic-bezier(0.4, 0, 0.2, 1);
 }
@@ -1037,7 +1040,7 @@ select:focus-visible,
      panel spans the full viewport height flush with the top edge. */
   .messenger-panel {
     top: 0;
-    height: 100%;
+    height: 100dvh;
   }
 }
 

--- a/src/dashboard/static/js/app.js
+++ b/src/dashboard/static/js/app.js
@@ -1158,13 +1158,12 @@ function dashboard() {
       this._initTs = Date.now();  // track page load time to skip replayed events
       const cfg = window.__config || {};
 
-      // Restore Phase 1 state from localStorage (side panel).
-      // Cosmetic — losing it is harmless, so wrap in try/catch and
-      // never block init.
-      try {
-        const v = localStorage.getItem('ol_messenger_side_panel_open');
-        if (v === '1') this.messengerSidePanelOpen = true;
-      } catch (e) { /* ignore */ }
+      // NOTE: the side panel is no longer restored from the legacy
+      // ``ol_messenger_side_panel_open`` flag. Its only writer was the
+      // messenger toggle button, now removed from both navbars, so a stale
+      // key from an older session would otherwise force the panel open with
+      // no obvious way to dismiss it. The panel now restores purely from the
+      // persisted open-chats set.
 
       // Restore Teams chip-strip expanded preference.
       try {
@@ -1396,10 +1395,18 @@ function dashboard() {
           e.preventDefault();
           this.cmdPaletteOpen = false;
         }
-        // Phase 1 — ESC also closes the messenger side panel (a11y).
-        // Order matters: cmd palette ESC handler runs first above and
+        // ESC also dismisses the messenger side panel (a11y). The panel is
+        // visible whenever a chat is open (clicking an agent drives
+        // ``openChats``) OR the legacy ``messengerSidePanelOpen`` flag is
+        // set — gate on both so ESC closes the agent-opened panel too, not
+        // just the (now removed) toggle-opened one. Dismiss by minimizing
+        // (keeps the chats; reopen by clicking an agent); ``closeSidePanel``
+        // also clears any legacy flag + restores focus.
+        // Order matters: the cmd palette ESC handler runs first above and
         // returns; we only get here if the palette wasn't open.
-        if (e.key === 'Escape' && this.messengerSidePanelOpen && this.activeTab !== 'chat') {
+        if (e.key === 'Escape' && this.activeTab !== 'chat' && !this.chatPanelMinimized
+            && (this.openChats.length > 0 || this.messengerSidePanelOpen)) {
+          this.chatPanelMinimized = true;
           this.closeSidePanel();
         }
       };

--- a/src/dashboard/static/js/app.js
+++ b/src/dashboard/static/js/app.js
@@ -474,18 +474,21 @@ function dashboard() {
 
     // System tab — sub-navigation
     systemTab: 'activity',
+    // Order: General first (its id is 'settings', relabelled "General" via
+    // systemTabLabelFor), then by how often each is used — config/monitoring
+    // up front, infrastructure plumbing last.
     systemTabs: [
+      { id: 'settings', label: 'Settings' },
       { id: 'activity', label: 'Activity' },
       { id: 'costs', label: 'Costs' },
-      { id: 'automation', label: 'Automation' },
       { id: 'integrations', label: 'Integrations' },
+      { id: 'automation', label: 'Automation' },
       { id: 'apikeys', label: 'API Keys' },
+      { id: 'operator', label: 'Operator' },
+      { id: 'browser', label: 'Browser' },
       { id: 'wallet', label: 'Wallet' },
       { id: 'network', label: 'Network' },
       { id: 'storage', label: 'Storage' },
-      { id: 'operator', label: 'Operator' },
-      { id: 'browser', label: 'Browser' },
-      { id: 'settings', label: 'Settings' },
     ],
 
     // Audit sub-tab

--- a/src/dashboard/static/js/app.js
+++ b/src/dashboard/static/js/app.js
@@ -4171,18 +4171,21 @@ function dashboard() {
     // Fresh-enough timestamps (<1 min) yield empty strings from
     // formatRelativeTime — fall back to "just now" for legibility.
     agentActivityLabel(agent) {
+      // "Last activity" = the last time the agent actually WORKED, i.e. its
+      // most recent LLM call (last_worked_ts, from the usage ledger). This
+      // deliberately does NOT use last_healthy — that's a container health
+      // probe, not work. Falls back to the last task event when the agent
+      // has no recorded LLM call yet (e.g. freshly created).
       const fmt = (sec) => {
         if (!sec) return '';
-        const ms = sec * 1000;
-        const rel = this.formatRelativeTime(ms);
+        const rel = this.formatRelativeTime(sec * 1000);
         return rel || 'just now';
       };
-      const seen = fmt(agent.last_healthy);
+      const worked = fmt(agent.last_worked_ts);
+      if (worked) return 'Worked ' + worked;
       const task = fmt(agent.last_task_event_ts);
-      const parts = [];
-      if (seen) parts.push('Seen ' + seen);
-      if (task) parts.push('Task ' + task);
-      return parts.join(' · ');
+      if (task) return 'Task ' + task;
+      return '';
     },
 
     healthLabel(status) {

--- a/src/dashboard/templates/index.html
+++ b/src/dashboard/templates/index.html
@@ -183,6 +183,46 @@
       <div class="px-4 py-4 flex items-center gap-2.5 shrink-0">
         <img src="/dashboard/static/logo.png" alt="OpenLegion" width="24" height="24" class="rounded-full">
         <span class="text-base font-bold text-white tracking-tight">OpenLegion</span>
+        <!-- Notifications bell — tucked into the brand row (top-of-app
+             convention), so it reads as part of the chrome rather than
+             floating by the search box. Dropdown opens downward. The
+             mobile top bar keeps its own copy (sidebar hidden below md). -->
+        <div class="relative ml-auto" @click.away="if ($el.offsetParent !== null) notificationsOpen = false">
+          <button @click="toggleNotifications()"
+            class="relative flex items-center justify-center w-8 h-8 rounded-md text-gray-400 hover:text-gray-200 hover:bg-gray-800/60 transition-colors cursor-pointer"
+            :title="notificationsUnreadCount > 0 ? notificationsUnreadCount + ' new notifications' : 'Notifications'"
+            :aria-label="notificationsUnreadCount > 0 ? notificationsUnreadCount + ' unread notifications' : 'Notifications'"
+            aria-haspopup="true" :aria-expanded="notificationsOpen">
+            <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+              <path d="M18 8A6 6 0 006 8c0 7-3 9-3 9h18s-3-2-3-9"/><path d="M13.73 21a2 2 0 01-3.46 0"/>
+            </svg>
+            <span x-show="notificationsUnreadCount > 0" x-cloak class="absolute top-1 right-1 w-2 h-2 rounded-full bg-indigo-400 ring-2 ring-gray-900" aria-hidden="true"></span>
+          </button>
+          <div x-show="notificationsOpen && notifications.length > 0" x-cloak
+            class="absolute left-0 top-full mt-2 w-72 max-w-[calc(100vw-2rem)] bg-gray-900 border border-gray-700 rounded-lg shadow-2xl z-50" role="menu">
+            <div class="flex items-center justify-between px-4 py-2 border-b border-gray-800">
+              <span class="text-xs text-gray-400 font-medium">Notifications</span>
+              <button x-show="notificationsUnreadCount > 0" @click="markAllNotificationsRead()" class="text-xs text-indigo-400 hover:text-indigo-300 transition-colors">Mark all as read</button>
+            </div>
+            <div class="max-h-96 overflow-y-auto custom-scrollbar">
+              <template x-for="notification in notifications" :key="notification.id">
+                <button @click="onNotificationClick(notification)" type="button"
+                  class="w-full text-left px-4 py-2.5 flex items-start gap-3 border-b border-gray-800/40 last:border-b-0 hover:bg-gray-800/40 transition-colors"
+                  :class="!notification.read_at && 'bg-indigo-900/10'">
+                  <span class="shrink-0 mt-0.5 text-sm w-5 text-center text-gray-400" x-text="notificationKindIcon(notification.kind)"></span>
+                  <div class="flex-1 min-w-0">
+                    <div class="flex items-center justify-between gap-2">
+                      <span class="text-sm text-gray-100 font-medium truncate" x-text="notification.title"></span>
+                      <span class="text-[11px] text-gray-400 shrink-0" x-text="timeAgo(notification.ts)"></span>
+                    </div>
+                    <p x-show="notification.body" class="text-xs text-gray-400 mt-0.5 line-clamp-2" x-text="notification.body"></p>
+                  </div>
+                  <span x-show="!notification.read_at" class="shrink-0 mt-1.5 w-2 h-2 rounded-full bg-indigo-400" aria-label="Unread"></span>
+                </button>
+              </template>
+            </div>
+          </div>
+        </div>
       </div>
       <nav class="flex-1 px-2 py-2 flex flex-col gap-1 overflow-y-auto" role="tablist" aria-label="Primary">
         <template x-for="tab in tabs" :key="tab.id">
@@ -239,8 +279,8 @@
           <span class="font-mono px-1 rounded bg-red-700/60 text-white text-[11px]" x-text="needsYouItems.length"></span>
         </button>
 
-        <!-- Spend + model-health + actions row -->
-        <div class="flex items-center gap-2 px-1 text-xs min-w-0">
+        <!-- Spend + model-health row -->
+        <div class="flex items-center gap-3 px-1 text-xs min-w-0">
           <button x-show="fleetTotalCost > 0" x-cloak @click="systemTab = 'costs'; switchTab('system')"
             class="flex items-center gap-1 text-gray-400 hover:text-gray-200 transition-colors min-w-0"
             title="Today's spend — view costs">
@@ -253,63 +293,6 @@
               <span class="bg-red-400 relative inline-flex rounded-full h-2 w-2"></span>
             </span>
             <span class="truncate" x-text="modelsDown + ' down'"></span>
-          </div>
-          <div class="flex items-center gap-0.5 ml-auto shrink-0">
-            <!-- Messenger side-panel toggle (hidden on Chat, where the
-                 messenger is already the page). -->
-            <button
-              x-show="activeTab !== 'chat'"
-              x-cloak
-              @click="toggleSidePanel()"
-              class="text-gray-400 hover:text-gray-200 transition-colors p-1.5 rounded relative"
-              :title="messengerSidePanelOpen ? 'Close messenger panel' : 'Open messenger panel'"
-              :aria-label="messengerSidePanelOpen ? 'Close messenger panel' : 'Open messenger panel'"
-              :aria-expanded="messengerSidePanelOpen ? 'true' : 'false'">
-              <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
-                <rect x="3" y="4" width="18" height="16" rx="2"/><line x1="14" y1="4" x2="14" y2="20"/><polyline points="8 10 11 12 8 14"/>
-              </svg>
-              <span x-show="!messengerSidePanelOpen && Object.values(chatUnread || {}).some(n => n > 0)" class="absolute top-1 right-1 w-1.5 h-1.5 rounded-full bg-amber-400"></span>
-            </button>
-            <!-- Notifications bell — dropdown opens upward (anchored to the
-                 sidebar bottom). -->
-            <div class="relative" @click.away="if ($el.offsetParent !== null) notificationsOpen = false">
-              <button
-                @click="toggleNotifications()"
-                class="relative flex items-center justify-center w-8 h-8 rounded-md text-gray-400 hover:text-gray-200 hover:bg-gray-800/60 transition-colors cursor-pointer"
-                :title="notificationsUnreadCount > 0 ? notificationsUnreadCount + ' new notifications' : 'Notifications'"
-                :aria-label="notificationsUnreadCount > 0 ? notificationsUnreadCount + ' unread notifications' : 'Notifications'"
-                aria-haspopup="true"
-                :aria-expanded="notificationsOpen">
-                <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
-                  <path d="M18 8A6 6 0 006 8c0 7-3 9-3 9h18s-3-2-3-9"/><path d="M13.73 21a2 2 0 01-3.46 0"/>
-                </svg>
-                <span x-show="notificationsUnreadCount > 0" x-cloak class="absolute top-1 right-1 w-2 h-2 rounded-full bg-indigo-400 ring-2 ring-gray-900" aria-hidden="true"></span>
-              </button>
-              <div x-show="notificationsOpen && notifications.length > 0" x-cloak
-                class="absolute left-0 bottom-full mb-2 w-72 max-w-[calc(100vw-2rem)] bg-gray-900 border border-gray-700 rounded-lg shadow-2xl z-50" role="menu">
-                <div class="flex items-center justify-between px-4 py-2 border-b border-gray-800">
-                  <span class="text-xs text-gray-400 font-medium">Notifications</span>
-                  <button x-show="notificationsUnreadCount > 0" @click="markAllNotificationsRead()" class="text-xs text-indigo-400 hover:text-indigo-300 transition-colors">Mark all as read</button>
-                </div>
-                <div class="max-h-96 overflow-y-auto custom-scrollbar">
-                  <template x-for="notification in notifications" :key="notification.id">
-                    <button @click="onNotificationClick(notification)" type="button"
-                      class="w-full text-left px-4 py-2.5 flex items-start gap-3 border-b border-gray-800/40 last:border-b-0 hover:bg-gray-800/40 transition-colors"
-                      :class="!notification.read_at && 'bg-indigo-900/10'">
-                      <span class="shrink-0 mt-0.5 text-sm w-5 text-center text-gray-400" x-text="notificationKindIcon(notification.kind)"></span>
-                      <div class="flex-1 min-w-0">
-                        <div class="flex items-center justify-between gap-2">
-                          <span class="text-sm text-gray-100 font-medium truncate" x-text="notification.title"></span>
-                          <span class="text-[11px] text-gray-400 shrink-0" x-text="timeAgo(notification.ts)"></span>
-                        </div>
-                        <p x-show="notification.body" class="text-xs text-gray-400 mt-0.5 line-clamp-2" x-text="notification.body"></p>
-                      </div>
-                      <span x-show="!notification.read_at" class="shrink-0 mt-1.5 w-2 h-2 rounded-full bg-indigo-400" aria-label="Unread"></span>
-                    </button>
-                  </template>
-                </div>
-              </div>
-            </div>
           </div>
         </div>
 
@@ -413,36 +396,6 @@
           </svg>
           <span class="hidden sm:inline">Needs you</span>
           <span class="font-mono px-1 rounded bg-red-700/60 text-white text-[11px]" x-text="needsYouItems.length"></span>
-        </button>
-        <!-- Phase 1 — side-panel toggle. Hidden on Chat tab (the messenger
-             is already full-screen there). Cmd+K is reserved for the
-             command palette so we use a visible button with a tooltip;
-             keyboard users hit it via Tab. -->
-        <button
-          x-show="activeTab !== 'chat'"
-          x-cloak
-          @click="toggleSidePanel()"
-          class="text-gray-400 hover:text-gray-200 transition-colors p-1.5 rounded relative"
-          :title="messengerSidePanelOpen ? 'Close messenger panel' : 'Open messenger panel'"
-          :aria-label="messengerSidePanelOpen ? 'Close messenger panel' : 'Open messenger panel'"
-          :aria-expanded="messengerSidePanelOpen ? 'true' : 'false'"
-        >
-          <!-- Distinct from the Chat tab's chat-bubble icon: a sidebar
-               panel pictogram (rectangle + inner divider + arrow) so the
-               control reads as "open the side panel" rather than as a
-               second chat tab. The tour copy below references "panel
-               icon" to match. -->
-          <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
-            <rect x="3" y="4" width="18" height="16" rx="2"/>
-            <line x1="14" y1="4" x2="14" y2="20"/>
-            <polyline points="8 10 11 12 8 14"/>
-          </svg>
-          <!-- Tiny unread dot when there are unread messages anywhere
-               while the panel is closed. The aggregate is computed
-               lazily off ``chatUnread`` so we don't need a getter. -->
-          <span
-            x-show="!messengerSidePanelOpen && Object.values(chatUnread || {}).some(n => n > 0)"
-            class="absolute top-1 right-1 w-1.5 h-1.5 rounded-full bg-amber-400"></span>
         </button>
         <div class="text-xs text-gray-400 hidden sm:block cursor-pointer hover:text-gray-300 transition-colors" x-show="fleetTotalCost > 0" @click="systemTab = 'costs'; switchTab('system')">
           Today: <span class="text-gray-300 font-medium" x-text="formatCost(fleetTotalCost)"></span>
@@ -548,36 +501,39 @@
 
       <!-- Operator Chat Tab -->
       <div x-show="activeTab === 'chat'" x-cloak class="h-full flex flex-col" style="min-height: calc(100vh - 8rem);">
-          <div class="flex-1 flex flex-col max-w-4xl mx-auto w-full h-full">
-            <!-- Header -->
-            <div class="flex items-center justify-between px-4 py-3 shrink-0 border-b border-gray-800/60">
-              <div class="flex items-center gap-2.5">
-                <img src="/dashboard/static/avatars/operator.png" alt="Operator" class="w-6 h-6 rounded-full">
-                <div>
-                  <h2 class="text-base font-semibold text-white">Operator</h2>
-                  <p class="text-[11px] text-gray-500 mt-0.5">Builds and manages your team</p>
-                </div>
-              </div>
-              <div class="flex items-center gap-1">
-                <!-- Reset conversation -->
-                <button @click="resetAgent('operator')"
-                  title="Reset conversation — memories preserved"
-                  class="text-gray-500 hover:text-red-400 transition-colors p-2 rounded-md"
-                  aria-label="Reset conversation">
-                  <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-                    <path d="M3 12a9 9 0 1 0 9-9 9.75 9.75 0 0 0-6.74 2.74L3 8"/>
-                    <path d="M3 3v5h5"/>
-                  </svg>
-                </button>
-                <!-- Settings -->
-                <button @click="switchTab('system'); switchSystemTab('operator')"
-                  class="text-xs px-2.5 py-1 rounded bg-gray-800 hover:bg-gray-700 text-gray-400 hover:text-white transition-colors flex items-center gap-1.5"
-                  title="Operator settings">
-                  <svg class="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="2"><path d="M12 15a3 3 0 100-6 3 3 0 000 6z"/><path d="M19.4 15a1.65 1.65 0 00.33 1.82l.06.06a2 2 0 010 2.83 2 2 0 01-2.83 0l-.06-.06a1.65 1.65 0 00-1.82-.33 1.65 1.65 0 00-1 1.51V21a2 2 0 01-2 2 2 2 0 01-2-2v-.09A1.65 1.65 0 009 19.4a1.65 1.65 0 00-1.82.33l-.06.06a2 2 0 01-2.83 0 2 2 0 010-2.83l.06-.06A1.65 1.65 0 004.68 15a1.65 1.65 0 00-1.51-1H3a2 2 0 01-2-2 2 2 0 012-2h.09A1.65 1.65 0 004.6 9a1.65 1.65 0 00-.33-1.82l-.06-.06a2 2 0 010-2.83 2 2 0 012.83 0l.06.06A1.65 1.65 0 009 4.68a1.65 1.65 0 001-1.51V3a2 2 0 012-2 2 2 0 012 2v.09a1.65 1.65 0 001 1.51 1.65 1.65 0 001.82-.33l.06-.06a2 2 0 012.83 0 2 2 0 010 2.83l-.06.06A1.65 1.65 0 0019.4 9a1.65 1.65 0 001.51 1H21a2 2 0 012 2 2 2 0 01-2 2h-.09a1.65 1.65 0 00-1.51 1z"/></svg>
-                  Settings
-                </button>
+          <!-- Page header — full-width contextual top nav for the chat tab.
+               Avatar alt is empty (decorative): the name sits right beside
+               it, and an empty alt avoids a doubled "Operator" if the image
+               ever fails to load. -->
+          <div class="page-header justify-between shrink-0">
+            <div class="flex items-center gap-2.5 min-w-0">
+              <img src="/dashboard/static/avatars/operator.png" alt="" class="w-7 h-7 rounded-full shrink-0">
+              <div class="min-w-0">
+                <div class="page-header-title">Operator</div>
+                <div class="page-header-subtitle">Builds and manages your team</div>
               </div>
             </div>
+            <div class="flex items-center gap-1 shrink-0">
+              <!-- Reset conversation -->
+              <button @click="resetAgent('operator')"
+                title="Reset conversation — memories preserved"
+                class="text-gray-500 hover:text-red-400 transition-colors p-2 rounded-md"
+                aria-label="Reset conversation">
+                <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                  <path d="M3 12a9 9 0 1 0 9-9 9.75 9.75 0 0 0-6.74 2.74L3 8"/>
+                  <path d="M3 3v5h5"/>
+                </svg>
+              </button>
+              <!-- Settings -->
+              <button @click="switchTab('system'); switchSystemTab('operator')"
+                class="text-xs px-2.5 py-1.5 rounded-md bg-gray-800 hover:bg-gray-700 text-gray-400 hover:text-white transition-colors flex items-center gap-1.5"
+                title="Operator settings">
+                <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="2"><path d="M12 15a3 3 0 100-6 3 3 0 000 6z"/><path d="M19.4 15a1.65 1.65 0 00.33 1.82l.06.06a2 2 0 010 2.83 2 2 0 01-2.83 0l-.06-.06a1.65 1.65 0 00-1.82-.33 1.65 1.65 0 00-1 1.51V21a2 2 0 01-2 2 2 2 0 01-2-2v-.09A1.65 1.65 0 009 19.4a1.65 1.65 0 00-1.82.33l-.06.06a2 2 0 01-2.83 0 2 2 0 010-2.83l.06-.06A1.65 1.65 0 004.68 15a1.65 1.65 0 00-1.51-1H3a2 2 0 01-2-2 2 2 0 012-2h.09A1.65 1.65 0 004.6 9a1.65 1.65 0 00-.33-1.82l-.06-.06a2 2 0 010-2.83 2 2 0 012.83 0l.06.06A1.65 1.65 0 009 4.68a1.65 1.65 0 001-1.51V3a2 2 0 012-2 2 2 0 012 2v.09a1.65 1.65 0 001 1.51 1.65 1.65 0 001.82-.33l.06-.06a2 2 0 012.83 0 2 2 0 010 2.83l-.06.06A1.65 1.65 0 0019.4 9a1.65 1.65 0 001.51 1H21a2 2 0 012 2 2 2 0 01-2 2h-.09a1.65 1.65 0 00-1.51 1z"/></svg>
+                Settings
+              </button>
+            </div>
+          </div>
+          <div class="flex-1 flex flex-col max-w-4xl mx-auto w-full min-h-0">
 
               <!-- Operator not ready -->
               <div x-show="!operatorReady" class="flex-1 flex items-center justify-center">
@@ -1662,7 +1618,7 @@
              + prominent "+ New Team" button (right, where + Add Agent
              used to sit). The Add-Agent control now lives as a card
              at the end of the agent grid below. -->
-        <div x-show="agents.length > 0" class="flex items-start gap-3 mb-3 min-w-0" x-cloak>
+        <div x-show="agents.length > 0" class="page-header min-w-0" x-cloak>
           <div class="flex-1 min-w-0 flex flex-col gap-1">
             <div class="flex flex-wrap items-center gap-1 transition-[max-height] duration-200"
                  :class="!teamFilterExpanded && teams.length > 6 ? 'team-chips-collapsed' : ''">
@@ -4105,6 +4061,15 @@
            and the pending-action queue (Task 2d) so a human can run an
            agent team end-to-end without inspecting blackboard keys. -->
       <div x-show="activeTab === 'workplace'" x-cloak x-init="loadWorkplace()">
+        <!-- Page header — KISS title only; the Work tab is a read-only
+             digest, so no invented controls (Needs-you / Goals are already
+             prominent surfaces below). -->
+        <div class="page-header">
+          <div class="min-w-0">
+            <div class="page-header-title">Work</div>
+            <div class="page-header-subtitle">What your fleet has shipped</div>
+          </div>
+        </div>
         <!-- Sticky "Needs you" panel — aggregates every kind of pending
              decision (durable propose/confirm rows, credential / browser-
              login / captcha cards in the operator chat, blocked tasks)

--- a/src/dashboard/templates/index.html
+++ b/src/dashboard/templates/index.html
@@ -216,25 +216,133 @@
           </button>
         </template>
       </nav>
-      <!-- Sidebar footer: connection status pill. Mirrored in mobile
-           top bar via the existing pill below. -->
-      <div class="px-4 py-3 border-t border-gray-800/40 flex items-center gap-1.5 text-xs shrink-0">
-        <span class="relative flex h-2 w-2">
-          <span :class="connected ? 'bg-green-400' : 'bg-red-400'" class="animate-ping absolute inline-flex h-full w-full rounded-full opacity-75" x-show="connected"></span>
-          <span :class="connected ? 'bg-green-400' : 'bg-red-400'" class="relative inline-flex rounded-full h-2 w-2"></span>
-        </span>
-        <span x-show="connected" class="text-green-400">Live</span>
-        <span x-show="!connected" class="text-red-400" x-text="wsReconnectIn > 0 ? 'Reconnecting in ' + wsReconnectIn + 's...' : 'Disconnected'"></span>
+      <!-- Desktop global tray (md+ only — folded down from the old top
+           bar). The top bar still carries copies of these for the mobile
+           shell, where the sidebar is hidden. Order, top→bottom: status &
+           actions, then search (kept at the bottom per design), then the
+           connection pill. -->
+      <div class="mt-auto px-2 pt-2.5 pb-2.5 flex flex-col gap-2.5 border-t border-gray-800/40 shrink-0">
+
+        <!-- Needs-you (prominent) — only when the user has pending actions -->
+        <button
+          x-show="needsYouItems.length > 0"
+          x-cloak
+          @click="switchTab('chat'); $nextTick(() => { const el = document.querySelector('[data-pending-cards]'); if (el) el.scrollIntoView({behavior: 'smooth', block: 'start'}); })"
+          class="needs-you-badge flex items-center gap-2 px-2.5 py-1.5 rounded-md text-xs font-semibold bg-red-900/40 text-red-300 border border-red-700/60 hover:bg-red-900/60 hover:border-red-600/80 transition-colors cursor-pointer w-full"
+          aria-live="polite"
+          :aria-label="needsYouItems.length + ' items need you. Click to review.'"
+          :title="'Needs you — ' + needsYouItems.length + ' awaiting your action'">
+          <svg class="w-3.5 h-3.5 shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+            <circle cx="12" cy="12" r="10"/><line x1="12" y1="8" x2="12" y2="12"/><line x1="12" y1="16" x2="12.01" y2="16"/>
+          </svg>
+          <span class="flex-1 text-left">Needs you</span>
+          <span class="font-mono px-1 rounded bg-red-700/60 text-white text-[11px]" x-text="needsYouItems.length"></span>
+        </button>
+
+        <!-- Spend + model-health + actions row -->
+        <div class="flex items-center gap-2 px-1 text-xs min-w-0">
+          <button x-show="fleetTotalCost > 0" x-cloak @click="systemTab = 'costs'; switchTab('system')"
+            class="flex items-center gap-1 text-gray-400 hover:text-gray-200 transition-colors min-w-0"
+            title="Today's spend — view costs">
+            <span class="shrink-0">Today</span>
+            <span class="text-gray-200 font-medium truncate" x-text="formatCost(fleetTotalCost)"></span>
+          </button>
+          <div x-show="modelsDown > 0" x-cloak class="flex items-center gap-1.5 text-red-400 min-w-0" role="status" :aria-label="modelsDown + ' models down'" :title="modelsDown + ' model' + (modelsDown !== 1 ? 's' : '') + ' down'">
+            <span class="relative flex h-2 w-2 shrink-0">
+              <span class="bg-red-400 animate-ping absolute inline-flex h-full w-full rounded-full opacity-75"></span>
+              <span class="bg-red-400 relative inline-flex rounded-full h-2 w-2"></span>
+            </span>
+            <span class="truncate" x-text="modelsDown + ' down'"></span>
+          </div>
+          <div class="flex items-center gap-0.5 ml-auto shrink-0">
+            <!-- Messenger side-panel toggle (hidden on Chat, where the
+                 messenger is already the page). -->
+            <button
+              x-show="activeTab !== 'chat'"
+              x-cloak
+              @click="toggleSidePanel()"
+              class="text-gray-400 hover:text-gray-200 transition-colors p-1.5 rounded relative"
+              :title="messengerSidePanelOpen ? 'Close messenger panel' : 'Open messenger panel'"
+              :aria-label="messengerSidePanelOpen ? 'Close messenger panel' : 'Open messenger panel'"
+              :aria-expanded="messengerSidePanelOpen ? 'true' : 'false'">
+              <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                <rect x="3" y="4" width="18" height="16" rx="2"/><line x1="14" y1="4" x2="14" y2="20"/><polyline points="8 10 11 12 8 14"/>
+              </svg>
+              <span x-show="!messengerSidePanelOpen && Object.values(chatUnread || {}).some(n => n > 0)" class="absolute top-1 right-1 w-1.5 h-1.5 rounded-full bg-amber-400"></span>
+            </button>
+            <!-- Notifications bell — dropdown opens upward (anchored to the
+                 sidebar bottom). -->
+            <div class="relative" @click.away="if ($el.offsetParent !== null) notificationsOpen = false">
+              <button
+                @click="toggleNotifications()"
+                class="relative flex items-center justify-center w-8 h-8 rounded-md text-gray-400 hover:text-gray-200 hover:bg-gray-800/60 transition-colors cursor-pointer"
+                :title="notificationsUnreadCount > 0 ? notificationsUnreadCount + ' new notifications' : 'Notifications'"
+                :aria-label="notificationsUnreadCount > 0 ? notificationsUnreadCount + ' unread notifications' : 'Notifications'"
+                aria-haspopup="true"
+                :aria-expanded="notificationsOpen">
+                <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                  <path d="M18 8A6 6 0 006 8c0 7-3 9-3 9h18s-3-2-3-9"/><path d="M13.73 21a2 2 0 01-3.46 0"/>
+                </svg>
+                <span x-show="notificationsUnreadCount > 0" x-cloak class="absolute top-1 right-1 w-2 h-2 rounded-full bg-indigo-400 ring-2 ring-gray-900" aria-hidden="true"></span>
+              </button>
+              <div x-show="notificationsOpen && notifications.length > 0" x-cloak
+                class="absolute left-0 bottom-full mb-2 w-72 max-w-[calc(100vw-2rem)] bg-gray-900 border border-gray-700 rounded-lg shadow-2xl z-50" role="menu">
+                <div class="flex items-center justify-between px-4 py-2 border-b border-gray-800">
+                  <span class="text-xs text-gray-400 font-medium">Notifications</span>
+                  <button x-show="notificationsUnreadCount > 0" @click="markAllNotificationsRead()" class="text-xs text-indigo-400 hover:text-indigo-300 transition-colors">Mark all as read</button>
+                </div>
+                <div class="max-h-96 overflow-y-auto custom-scrollbar">
+                  <template x-for="notification in notifications" :key="notification.id">
+                    <button @click="onNotificationClick(notification)" type="button"
+                      class="w-full text-left px-4 py-2.5 flex items-start gap-3 border-b border-gray-800/40 last:border-b-0 hover:bg-gray-800/40 transition-colors"
+                      :class="!notification.read_at && 'bg-indigo-900/10'">
+                      <span class="shrink-0 mt-0.5 text-sm w-5 text-center text-gray-400" x-text="notificationKindIcon(notification.kind)"></span>
+                      <div class="flex-1 min-w-0">
+                        <div class="flex items-center justify-between gap-2">
+                          <span class="text-sm text-gray-100 font-medium truncate" x-text="notification.title"></span>
+                          <span class="text-[11px] text-gray-400 shrink-0" x-text="timeAgo(notification.ts)"></span>
+                        </div>
+                        <p x-show="notification.body" class="text-xs text-gray-400 mt-0.5 line-clamp-2" x-text="notification.body"></p>
+                      </div>
+                      <span x-show="!notification.read_at" class="shrink-0 mt-1.5 w-2 h-2 rounded-full bg-indigo-400" aria-label="Unread"></span>
+                    </button>
+                  </template>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <!-- Search — kept at the bottom of the rail by request. -->
+        <button @click="cmdPaletteOpen = true; cmdPaletteQuery = ''; cmdPaletteResults = []; $nextTick(() => { const el = document.getElementById('cmd-palette-input'); if (el) el.focus(); })"
+          class="flex items-center gap-2.5 text-sm text-gray-400 hover:text-gray-300 bg-gray-800/40 hover:bg-gray-800/80 pl-3.5 pr-3 py-2 rounded-lg border border-gray-700/40 hover:border-gray-600/60 transition-all cursor-pointer w-full min-w-0"
+          title="Search (Cmd+K)">
+          <svg class="w-3.5 h-3.5 shrink-0 opacity-60" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="2"><circle cx="11" cy="11" r="8"/><path d="m21 21-4.35-4.35"/></svg>
+          <span class="flex-1 text-left">Search</span>
+          <kbd class="text-[11px] text-gray-500 bg-gray-900/80 px-1.5 py-0.5 rounded border border-gray-700/60 font-sans">&#8984;K</kbd>
+        </button>
+
+        <!-- Connection status pill -->
+        <div class="flex items-center gap-1.5 text-xs px-1">
+          <span class="relative flex h-2 w-2">
+            <span :class="connected ? 'bg-green-400' : 'bg-red-400'" class="animate-ping absolute inline-flex h-full w-full rounded-full opacity-75" x-show="connected"></span>
+            <span :class="connected ? 'bg-green-400' : 'bg-red-400'" class="relative inline-flex rounded-full h-2 w-2"></span>
+          </span>
+          <span x-show="connected" class="text-green-400">Live</span>
+          <span x-show="!connected" class="text-red-400" x-text="wsReconnectIn > 0 ? 'Reconnecting in ' + wsReconnectIn + 's...' : 'Disconnected'"></span>
+        </div>
       </div>
     </aside>
 
     <!-- Main column (top bar + page content) -->
     <div class="flex-1 flex flex-col min-w-0">
 
-    <!-- Top bar — slim on desktop (search + status pills only); on
-         mobile (<md) it also carries the logo + icon-only tab strip
-         since the sidebar is hidden. -->
-    <nav class="nav-bar px-3 sm:px-5 py-2.5 flex items-center shrink-0 gap-3">
+    <!-- Top bar — mobile/tablet shell ONLY (<md). On desktop the whole
+         bar is hidden: its contents (search, status, actions) are folded
+         into the sidebar tray above, giving the content column the full
+         viewport height. Below md the sidebar is hidden, so this bar
+         carries the logo + icon tab strip + global status/actions. -->
+    <nav class="nav-bar px-3 sm:px-5 py-2.5 flex md:hidden items-center shrink-0 gap-3">
       <!-- Mobile: logo + icon tabs (md:hidden). The sidebar covers
            desktop so we don't duplicate the strip there. -->
       <div class="flex md:hidden items-center gap-2 min-w-0 shrink-0">
@@ -354,7 +462,7 @@
         <!-- Phase 2 Board UX — notifications bell. Subtle gray by
              default; small indigo dot when unread items exist. Click
              toggles the dropdown with the last 10 notifications. -->
-        <div class="relative" @click.away="notificationsOpen = false">
+        <div class="relative" @click.away="if ($el.offsetParent !== null) notificationsOpen = false">
           <button
             @click="toggleNotifications()"
             class="relative flex items-center justify-center w-8 h-8 rounded-md text-gray-400 hover:text-gray-200 hover:bg-gray-800/60 transition-colors cursor-pointer"
@@ -454,7 +562,7 @@
                 <!-- Reset conversation -->
                 <button @click="resetAgent('operator')"
                   title="Reset conversation — memories preserved"
-                  class="text-gray-500 hover:text-red-400 transition-colors p-1.5 rounded"
+                  class="text-gray-500 hover:text-red-400 transition-colors p-2 rounded-md"
                   aria-label="Reset conversation">
                   <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
                     <path d="M3 12a9 9 0 1 0 9-9 9.75 9.75 0 0 0-6.74 2.74L3 8"/>
@@ -821,7 +929,7 @@
                       <div class="flex justify-end">
                         <div class="max-w-[80%] px-3 py-2 rounded-2xl rounded-br-md bg-indigo-600 text-white text-xs">
                           <div class="whitespace-pre-wrap break-words" x-text="msg.content"></div>
-                          <div x-show="formatRelativeTime(msg.ts)" class="text-[11px] mt-0.5 opacity-40 text-indigo-200"
+                          <div x-show="formatRelativeTime(msg.ts)" class="text-[11px] mt-0.5 opacity-60 text-indigo-200"
                             x-text="formatRelativeTime(msg.ts)"></div>
                         </div>
                       </div>
@@ -1352,7 +1460,7 @@
                             <div class="chat-markdown break-words" x-html="renderMarkdown(msg.content)"></div>
                             <span x-show="msg.streaming" class="inline-block w-1 h-3 bg-indigo-400 animate-pulse ml-0.5 align-text-bottom"></span>
                             <div x-show="formatRelativeTime(msg.ts)"
-                              class="text-[11px] mt-0.5 opacity-40 text-gray-400"
+                              class="text-[11px] mt-0.5 opacity-60 text-gray-400"
                               x-text="formatRelativeTime(msg.ts)"></div>
                             <!-- Phase 3 — Operator action chips. Rendered
                                  below the bubble when the response has
@@ -1533,13 +1641,13 @@
                 <textarea x-model="opMsg" id="operator-chat-input" rows="1"
                   :disabled="chatLoadingAgents['operator'] === true"
                   @keydown.enter="if (!$event.shiftKey && (opMsg.trim() || (opPendingFile && !opPendingFile.startsWith('Uploading')))) { $event.preventDefault(); let msg = opMsg.trim(); if (opPendingFile) msg = (msg ? msg + '\n\n' : '') + '\ud83d\udcce ' + opPendingFile + ' (at /data/uploads/' + opPendingFile + ')'; if (isAgentBusy('operator')) steerAgent('operator', msg); else sendChatTo('operator', msg); opMsg = ''; opPendingFile = ''; $el.style.height = 'auto'; }"
-                  @input="$el.style.height = 'auto'; $el.style.height = Math.min($el.scrollHeight, 120) + 'px'"
+                  @input="$el.style.height = 'auto'; $el.style.height = Math.min($el.scrollHeight, 180) + 'px'"
                   class="chat-slide-textarea"
                   :placeholder="opSpeechActive ? 'Listening\u2026' : (isAgentBusy('operator') ? 'Steer operator\u2026' : 'Message your operator...')"></textarea>
                 <button @click="if (opMsg.trim() || (opPendingFile && !opPendingFile.startsWith('Uploading'))) { let msg = opMsg.trim(); if (opPendingFile) msg = (msg ? msg + '\n\n' : '') + '\ud83d\udcce ' + opPendingFile + ' (at /data/uploads/' + opPendingFile + ')'; if (isAgentBusy('operator')) steerAgent('operator', msg); else sendChatTo('operator', msg); opMsg = ''; opPendingFile = ''; }"
                   :disabled="!(opMsg.trim() || (opPendingFile && !opPendingFile.startsWith('Uploading')))"
                   class="chat-input-send"
-                  :class="(opMsg.trim() || (opPendingFile && !opPendingFile.startsWith('Uploading'))) ? (isAgentBusy('operator') ? 'bg-amber-600 hover:bg-amber-500' : 'bg-indigo-600 hover:bg-indigo-500') : 'bg-gray-700 opacity-40'"
+                  :class="(opMsg.trim() || (opPendingFile && !opPendingFile.startsWith('Uploading'))) ? (isAgentBusy('operator') ? 'bg-amber-600 hover:bg-amber-500' : 'bg-indigo-600 hover:bg-indigo-500') : 'bg-gray-700/60 text-gray-500'"
                   aria-label="Send">
                   <svg width="16" height="16" viewBox="0 0 20 20" fill="currentColor"><path fill-rule="evenodd" d="M3 10a.75.75 0 0 1 .75-.75h10.638L10.23 5.29a.75.75 0 1 1 1.04-1.08l5.5 5.25a.75.75 0 0 1 0 1.08l-5.5 5.25a.75.75 0 1 1-1.04-1.08l4.158-3.96H3.75A.75.75 0 0 1 3 10Z" clip-rule="evenodd"/></svg>
                 </button>
@@ -1665,7 +1773,7 @@
                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7"/>
               </svg>
               <span class="text-xs font-medium text-gray-400 flex-shrink-0">Team</span>
-              <span class="text-[11px] px-1.5 py-0.5.5 rounded-full bg-indigo-900/30 text-indigo-400 border border-indigo-800/30 truncate max-w-[7rem] sm:max-w-[12rem] flex-shrink-0"
+              <span class="text-[11px] px-1.5 py-0.5 rounded-full bg-indigo-900/30 text-indigo-400 border border-indigo-800/30 truncate max-w-[7rem] sm:max-w-[12rem] flex-shrink-0"
                 x-text="activeTeam"></span>
               <span class="text-[11px] text-gray-500 flex-shrink-0 hidden sm:block"
                 x-text="(activeTeamData?.members || []).length + ' member' + ((activeTeamData?.members || []).length !== 1 ? 's' : '')"></span>
@@ -1833,7 +1941,7 @@
                 <div class="flex items-center gap-2 px-4 pt-3 pb-2">
                   <div x-show="Object.keys(commsSubs).length > 0" class="flex items-center gap-1.5 flex-wrap flex-1 min-w-0" x-cloak>
                     <template x-for="[topic, sAgents] in Object.entries(commsSubs).slice(0, 8)" :key="topic">
-                      <span class="text-[11px] px-1.5 py-0.5.5 rounded-full bg-purple-500/10 text-purple-400/70 border border-purple-500/20"
+                      <span class="text-[11px] px-1.5 py-0.5 rounded-full bg-purple-500/10 text-purple-400/70 border border-purple-500/20"
                         x-text="topic + ' (' + sAgents.length + ')'"></span>
                     </template>
                     <span x-show="Object.keys(commsSubs).length > 8" class="text-[11px] text-gray-500"
@@ -1996,7 +2104,7 @@
                         </div>
                         <div class="flex items-center gap-1.5 flex-wrap">
                           <template x-for="aid in agents" :key="aid">
-                            <span class="inline-flex items-center gap-1 text-[11px] px-1.5 py-0.5.5 rounded-full border border-gray-700/60 bg-gray-800/50 text-gray-400">
+                            <span class="inline-flex items-center gap-1 text-[11px] px-1.5 py-0.5 rounded-full border border-gray-700/60 bg-gray-800/50 text-gray-400">
                               <img :src="agentAvatarUrl(aid)" :alt="aid" class="w-3.5 h-3.5 rounded-full object-cover flex-shrink-0">
                               <span x-text="aid"></span>
                             </span>
@@ -2840,10 +2948,10 @@
                       <div class="border border-gray-800 rounded-lg p-3 space-y-1.5">
                         <div class="flex items-center justify-between">
                           <div class="flex items-center gap-2">
-                            <span class="text-[11px] px-1.5 py-0.5.5 rounded-full font-medium"
+                            <span class="text-[11px] px-1.5 py-0.5 rounded-full font-medium"
                               :class="entry.outcome === 'ok' ? 'bg-emerald-900/40 text-emerald-400 border border-emerald-800/40' : entry.outcome === 'error' ? 'bg-red-900/40 text-red-400 border border-red-800/40' : 'bg-amber-900/40 text-amber-400 border border-amber-800/40'"
                               x-text="entry.trigger || 'heartbeat'"></span>
-                            <span class="text-[11px] px-1.5 py-0.5.5 rounded-full bg-gray-700/50 text-gray-400 border border-gray-600/30"
+                            <span class="text-[11px] px-1.5 py-0.5 rounded-full bg-gray-700/50 text-gray-400 border border-gray-600/30"
                               x-text="entry.outcome || 'ok'"></span>
                           </div>
                           <span class="text-[11px] text-gray-500" x-text="entry.ts ? new Date(entry.ts * 1000).toLocaleString() : ''"></span>
@@ -3078,7 +3186,7 @@
                           <div class="text-xs text-gray-400 mb-2">Wallet Addresses</div>
                           <div class="flex flex-wrap gap-1.5 mb-2">
                             <template x-for="ch in agentConfigs[selectedAgent]?.wallet_allowed_chains || []" :key="ch">
-                              <span class="text-[11px] px-2 py-0.5.5 rounded-full bg-indigo-900/30 text-indigo-400 border border-indigo-800/50" x-text="ch"></span>
+                              <span class="text-[11px] px-2 py-0.5 rounded-full bg-indigo-900/30 text-indigo-400 border border-indigo-800/50" x-text="ch"></span>
                             </template>
                           </div>
                           <div class="space-y-1.5 min-w-0 overflow-hidden">
@@ -3956,8 +4064,8 @@
                       <div class="flex-1 min-w-0">
                         <div class="flex items-center gap-2">
                           <span class="font-mono text-xs text-gray-300" x-text="job.schedule"></span>
-                          <span class="text-[11px] px-1.5 py-0.5.5 rounded-full"
-                            :class="job.enabled ? 'bg-green-900/30 text-green-400' : 'bg-gray-800/50 text-gray-400'"
+                          <span class="text-[11px] px-1.5 py-0.5 rounded-full"
+                            :class="job.enabled ? 'bg-green-900/30 text-green-400 border border-green-700/40' : 'bg-gray-800/50 text-gray-400 border border-gray-700/50'"
                             x-text="job.enabled ? 'active' : 'paused'"></span>
                         </div>
                         <div class="text-[11px] text-gray-400 truncate mt-0.5" x-text="job.message"></div>
@@ -4014,7 +4122,7 @@
             </svg>
             <h2 class="text-base font-semibold text-white">Needs you</h2>
             <span aria-live="polite"
-              class="text-[11px] font-medium px-2 py-0.5.5 rounded-full bg-amber-700/50 text-amber-100"
+              class="text-[11px] font-medium px-2 py-0.5 rounded-full bg-amber-700/50 text-amber-100"
               x-text="needsYouItems.length"></span>
           </div>
           <!-- Cap the visible items at ~40vh and scroll inside the panel
@@ -4088,7 +4196,7 @@
             <span role="listitem"
               :aria-label="g.name + ' — ' + g.status"
               :title="g.status + (g.progress_note ? ': ' + g.progress_note : '')"
-              class="inline-flex items-center gap-1.5 text-[11px] px-2 py-0.5.5 rounded-full bg-gray-800/60 border border-gray-700/50"
+              class="inline-flex items-center gap-1.5 text-[11px] px-2 py-0.5 rounded-full bg-gray-800/60 border border-gray-700/50"
               :class="g.status === 'done' ? 'text-gray-400 line-through' : 'text-gray-200'"
               data-testid="workplace-goal-chip">
               <span class="w-1.5 h-1.5 rounded-full shrink-0"
@@ -4165,43 +4273,63 @@
                  rework); rated ones show the outcome chip plus the
                  operator's feedback when rework feedback was given. -->
             <template x-for="s in workplaceSummaries" :key="s.id">
-              <div class="bg-gray-800/40 border border-gray-700/50 rounded-lg p-4"
+              <div class="group relative bg-gradient-to-b from-gray-800/55 to-gray-800/25 border border-gray-700/50 rounded-xl p-4 pl-5 transition-all duration-200 hover:border-gray-600/70 hover:shadow-lg hover:shadow-black/25"
                    data-testid="workplace-summary-card"
                    :data-summary-id="s.id">
-                <!-- Header: scope + period + relative timestamp -->
-                <div class="flex items-start justify-between gap-3 mb-2">
-                  <div class="flex-1 min-w-0">
-                    <div class="text-[11px] uppercase tracking-wide text-gray-400"
-                         x-text="s.scope_kind === 'solo' ? 'Solo agent' : 'Team'"></div>
-                    <div class="text-sm font-semibold text-gray-100 truncate"
-                         x-text="s.scope_id"></div>
+                <!-- Scope accent rail — indigo for a team, cyan for a solo
+                     agent. Gives the card a clear left edge + instant
+                     team/solo read at a glance. -->
+                <span class="absolute left-0 top-3 bottom-3 w-1 rounded-full"
+                      :class="s.scope_kind === 'solo' ? 'bg-cyan-500/70' : 'bg-indigo-500/70'"
+                      aria-hidden="true"></span>
+
+                <!-- Header: scope icon + title, with relative timestamp -->
+                <div class="flex items-start justify-between gap-3 mb-3">
+                  <div class="flex items-center gap-2.5 min-w-0">
+                    <span class="shrink-0 flex items-center justify-center w-8 h-8 rounded-lg"
+                          :class="s.scope_kind === 'solo' ? 'bg-cyan-500/15 text-cyan-300' : 'bg-indigo-500/15 text-indigo-300'"
+                          aria-hidden="true">
+                      <svg x-show="s.scope_kind !== 'solo'" class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="3" width="7" height="7" rx="1"/><rect x="14" y="3" width="7" height="7" rx="1"/><rect x="3" y="14" width="7" height="7" rx="1"/><rect x="14" y="14" width="7" height="7" rx="1"/></svg>
+                      <svg x-show="s.scope_kind === 'solo'" x-cloak class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M20 21v-2a4 4 0 0 0-4-4H8a4 4 0 0 0-4 4v2"/><circle cx="12" cy="7" r="4"/></svg>
+                    </span>
+                    <div class="min-w-0">
+                      <div class="text-base font-semibold text-white truncate leading-tight"
+                           x-text="s.scope_id"></div>
+                      <div class="text-[11px] uppercase tracking-wide text-gray-400 mt-0.5"
+                           x-text="s.scope_kind === 'solo' ? 'Solo agent' : 'Team summary'"></div>
+                    </div>
                   </div>
-                  <div class="text-[11px] text-gray-400 shrink-0"
+                  <div class="text-[11px] text-gray-400 shrink-0 mt-0.5"
                        :title="new Date((s.generated_at || 0) * 1000).toLocaleString()"
                        x-text="relativeTime(s.generated_at)"></div>
                 </div>
 
                 <!-- Narrative (markdown → safe HTML via renderSummaryMarkdown). -->
-                <div class="space-y-1.5 mb-3"
+                <div class="space-y-1.5 mb-3 text-gray-300"
                      data-testid="summary-narrative"
                      x-html="renderSummaryMarkdown(s.narrative_md)"></div>
 
-                <!-- Recommendations -->
+                <!-- Recommendations — boxed callout so they read as the
+                     actionable takeaways, not just more body text. -->
                 <template x-if="(s.recommendations || []).length">
-                  <div class="mb-3">
-                    <div class="text-[11px] uppercase tracking-wide text-gray-400 mb-1">
+                  <div class="mb-3 rounded-lg bg-gray-900/40 border border-gray-700/40 p-3">
+                    <div class="flex items-center gap-1.5 text-[11px] uppercase tracking-wide text-indigo-300/90 font-semibold mb-1.5">
+                      <svg class="w-3.5 h-3.5 shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M9 18h6M10 22h4M12 2a7 7 0 0 0-4 12.7c.6.5 1 1.3 1 2.1V18h6v-1.2c0-.8.4-1.6 1-2.1A7 7 0 0 0 12 2z"/></svg>
                       Recommendations
                     </div>
-                    <ul class="list-disc ml-4 space-y-0.5">
+                    <ul class="space-y-1">
                       <template x-for="(rec, idx) in s.recommendations" :key="idx">
-                        <li class="text-xs text-gray-300" x-text="rec"></li>
+                        <li class="flex items-start gap-2 text-xs text-gray-300">
+                          <span class="mt-1.5 w-1 h-1 rounded-full bg-indigo-400/80 shrink-0" aria-hidden="true"></span>
+                          <span x-text="rec"></span>
+                        </li>
                       </template>
                     </ul>
                   </div>
                 </template>
 
                 <!-- Footer: rating buttons (unrated) or outcome chip (rated). -->
-                <div class="flex items-center justify-end gap-2 pt-2 border-t border-gray-700/30">
+                <div class="flex items-center justify-end gap-2 pt-3 border-t border-gray-700/40">
                   <!-- Rating buttons (only when unrated). Lucide-style outline
                        SVG icons (matches the rest of the dashboard) — not
                        emoji. Colors: emerald=accept, gray=acknowledge,
@@ -4214,7 +4342,7 @@
                         title="Accept — good summary"
                         aria-label="Accept this summary"
                         data-testid="summary-rate-accept"
-                        class="px-2 py-1 rounded hover:bg-emerald-500/20 text-emerald-300 transition-colors">
+                        class="px-2.5 py-1.5 rounded-md hover:bg-emerald-500/20 text-emerald-300 transition-colors">
                         <svg class="w-4 h-4" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
                           <path d="M14 9V5a3 3 0 0 0-3-3l-4 9v11h11.28a2 2 0 0 0 2-1.7l1.38-9a2 2 0 0 0-2-2.3z"/>
                           <line x1="7" y1="22" x2="7" y2="11"/>
@@ -4225,7 +4353,7 @@
                         title="Acknowledge — neutral"
                         aria-label="Acknowledge this summary without judgement"
                         data-testid="summary-rate-acknowledge"
-                        class="px-2 py-1 rounded hover:bg-gray-500/20 text-gray-400 transition-colors">
+                        class="px-2.5 py-1.5 rounded-md hover:bg-gray-500/20 text-gray-400 transition-colors">
                         <svg class="w-4 h-4" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
                           <circle cx="12" cy="12" r="10"/>
                           <line x1="8" y1="12" x2="16" y2="12"/>
@@ -4236,7 +4364,7 @@
                         title="Rework — add feedback"
                         aria-label="Mark this summary for rework"
                         data-testid="summary-rate-rework"
-                        class="px-2 py-1 rounded hover:bg-amber-500/20 text-amber-300 transition-colors">
+                        class="px-2.5 py-1.5 rounded-md hover:bg-amber-500/20 text-amber-300 transition-colors">
                         <svg class="w-4 h-4" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
                           <path d="M10 15v4a3 3 0 0 0 3 3l4-9V2H5.72a2 2 0 0 0-2 1.7l-1.38 9a2 2 0 0 0 2 2.3z"/>
                           <line x1="17" y1="13" x2="17" y2="2"/>
@@ -4247,7 +4375,7 @@
 
                   <!-- Outcome chip (rated) -->
                   <template x-if="s.rating">
-                    <span class="text-[11px] px-2 py-0.5.5 rounded-full font-medium"
+                    <span class="text-[11px] px-2 py-0.5 rounded-full font-medium capitalize"
                           :class="{
                             'bg-emerald-500/20 text-emerald-200': s.rating === 'accepted',
                             'bg-gray-500/20 text-gray-300': s.rating === 'acknowledged',
@@ -4891,8 +5019,8 @@
                         <span x-show="!job.heartbeat" class="text-gray-500 text-xs">cron</span>
                       </td>
                       <td class="py-3 px-4">
-                        <span class="text-xs px-2 py-0.5.5 rounded-full"
-                          :class="job.enabled ? 'bg-green-900/30 text-green-400' : 'bg-gray-800/50 text-gray-400'"
+                        <span class="text-xs px-2 py-0.5 rounded-full"
+                          :class="job.enabled ? 'bg-green-900/30 text-green-400 border border-green-700/40' : 'bg-gray-800/50 text-gray-400 border border-gray-700/50'"
                           x-text="job.enabled ? 'active' : 'paused'"
                         ></span>
                       </td>
@@ -5324,7 +5452,7 @@
                   <div class="flex items-center gap-2 text-xs group">
                     <span class="w-2 h-2 rounded-full" :class="(settingsData.agent_credentials || []).includes(name) ? 'bg-green-500/50' : 'bg-amber-500/50'"></span>
                     <span class="text-gray-300 font-mono flex-1 truncate" x-text="name"></span>
-                    <span class="text-[11px] px-1.5 py-0.5.5 rounded-full shrink-0" :class="(settingsData.agent_credentials || []).includes(name) ? 'bg-green-900/40 text-green-400' : 'bg-amber-900/40 text-amber-400'" x-text="(settingsData.agent_credentials || []).includes(name) ? 'agent' : 'system'"></span>
+                    <span class="text-[11px] px-1.5 py-0.5 rounded-full shrink-0" :class="(settingsData.agent_credentials || []).includes(name) ? 'bg-green-900/40 text-green-400' : 'bg-amber-900/40 text-amber-400'" x-text="(settingsData.agent_credentials || []).includes(name) ? 'agent' : 'system'"></span>
                     <div class="flex items-center gap-0 shrink-0 w-[4.5rem] justify-end">
                       <button x-show="!name.endsWith('_oauth')" @click="revealCredential(name)" class="opacity-0 group-hover:opacity-100 focus:opacity-100 text-gray-400 hover:text-gray-300 transition-opacity px-1" :title="revealedCredentials[name] ? 'Hide value' : 'Reveal value'">
                         <svg x-show="!revealedCredentials[name]" class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z"/><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z"/></svg>
@@ -5861,7 +5989,7 @@
                       </template>
                       <template x-if="networkProxy.editingAgentProxy !== ap.agent_id">
                         <td class="py-3 pr-4">
-                          <span class="inline-flex items-center gap-1 px-2 py-0.5.5 rounded-full text-[11px] font-medium"
+                          <span class="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-[11px] font-medium"
                             :class="{
                               'bg-gray-700 text-gray-300': ap.mode === 'inherit',
                               'bg-indigo-900/30 text-indigo-400 border border-indigo-800/50': ap.mode === 'custom',
@@ -6176,7 +6304,7 @@
                   <span class="text-gray-300 truncate flex-1" :title="t.trigger_preview || t.trigger_detail || t.trace_id" x-text="t.trigger_preview || t.trigger_detail || t.trace_id.substring(0, 12)"></span>
                   <span class="text-gray-500 text-[11px] font-mono shrink-0" x-text="t.event_count + ' events'"></span>
                   <span x-show="t.total_duration_ms > 0" class="text-gray-500 text-[11px] font-mono shrink-0" x-text="t.total_duration_ms + 'ms'"></span>
-                  <span x-show="t.has_error" class="text-[11px] px-1.5 py-0.5.5 rounded-full bg-red-900/30 text-red-400 border border-red-800/40 shrink-0">ERR</span>
+                  <span x-show="t.has_error" class="text-[11px] px-1.5 py-0.5 rounded-full bg-red-900/30 text-red-400 border border-red-800/40 shrink-0">ERR</span>
                   <span class="text-gray-500 text-xs font-mono shrink-0" x-text="timeAgo(t.started)"></span>
                 </div>
                 <!-- Expanded trace detail -->
@@ -6685,10 +6813,10 @@
                   <div class="flex items-center gap-3 px-3 py-2 cursor-pointer hover:bg-gray-800/40 transition-colors" @click="expanded = !expanded">
                     <div class="text-[11px] text-gray-400 w-14 shrink-0" x-text="entry.timestamp ? new Date(entry.timestamp).toLocaleTimeString([], {hour:'2-digit', minute:'2-digit'}) : ''"></div>
                     <div class="flex-1 min-w-0 flex items-center gap-1.5">
-                      <span class="text-[11px] px-1.5 py-0.5.5 rounded-full bg-indigo-900/30 text-indigo-400 border border-indigo-800/30 font-medium" x-text="entry.action"></span>
+                      <span class="text-[11px] px-1.5 py-0.5 rounded-full bg-indigo-900/30 text-indigo-400 border border-indigo-800/30 font-medium" x-text="entry.action"></span>
                       <span class="text-xs text-white font-medium truncate" x-text="entry.target"></span>
                       <span x-show="entry.field" class="text-[11px] text-gray-400 truncate" x-text="'· ' + entry.field"></span>
-                      <span x-show="entry.archived" class="text-[11px] px-1.5 py-0.5.5 rounded-full bg-gray-700/40 text-gray-400 border border-gray-600/30">archived</span>
+                      <span x-show="entry.archived" class="text-[11px] px-1.5 py-0.5 rounded-full bg-gray-700/40 text-gray-400 border border-gray-600/30">archived</span>
                     </div>
                     <!-- Revert reuses the soft-edit /changes/undo endpoint;
                          the audit row's change_id is the same uuid as the
@@ -7871,7 +7999,7 @@
           <div class="flex items-center gap-0.5 shrink-0">
             <button @click="resetAgent(activeChatId)"
               title="Reset conversation — memories preserved"
-              class="text-gray-500 hover:text-red-400 transition-colors p-1.5 rounded"
+              class="text-gray-500 hover:text-red-400 transition-colors p-2 rounded-md"
               aria-label="Reset conversation">
               <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
                 <path d="M3 12a9 9 0 1 0 9-9 9.75 9.75 0 0 0-6.74 2.74L3 8"/>
@@ -7879,7 +8007,7 @@
               </svg>
             </button>
             <button @click="chatFullScreen = !chatFullScreen"
-              class="text-gray-400 hover:text-white transition-colors p-1.5 rounded"
+              class="text-gray-400 hover:text-white transition-colors p-2 rounded-md"
               :title="chatFullScreen ? 'Half screen' : 'Full screen'"
               :aria-label="chatFullScreen ? 'Exit full screen' : 'Full screen'">
               <svg x-show="!chatFullScreen" class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M4 8V4m0 0h4M4 4l5 5m11-1V4m0 0h-4m4 0l-5 5M4 16v4m0 0h4m-4 0l5-5m11 5v-4m0 4h-4m4 0l-5-5"/></svg>
@@ -7887,12 +8015,12 @@
             </button>
             <button @click="chatPanelMinimized = true; _saveChatToSession()"
               title="Minimize" aria-label="Minimize chat"
-              class="text-gray-400 hover:text-white transition-colors p-1.5 rounded">
+              class="text-gray-400 hover:text-white transition-colors p-2 rounded-md">
               <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M19 9l-7 7-7-7"/></svg>
             </button>
             <button @click="closeChat(activeChatId)"
               title="Close chat" aria-label="Close chat"
-              class="text-gray-400 hover:text-white transition-colors p-1.5 rounded">
+              class="text-gray-400 hover:text-white transition-colors p-2 rounded-md">
               <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M6 18L18 6M6 6l12 12"/></svg>
             </button>
           </div>
@@ -8472,7 +8600,7 @@
                 <div x-show="msg.role !== 'user'" class="chat-markdown break-words" x-html="renderMarkdown(msg.content)"></div>
                 <span x-show="msg.streaming" class="inline-block w-1 h-3 bg-indigo-400 animate-pulse ml-0.5 align-text-bottom"></span>
                 <div x-show="formatRelativeTime(msg.ts)"
-                  class="text-[11px] mt-0.5 opacity-40"
+                  class="text-[11px] mt-0.5 opacity-60"
                   :class="msg.role === 'user' ? 'text-indigo-200' : 'text-gray-400'"
                   x-text="formatRelativeTime(msg.ts)"></div>
                 <template x-if="msg.tool_limit_reached">
@@ -8636,14 +8764,14 @@
             <textarea x-model="chatInput" id="chat-slide-input" rows="1"
               :disabled="chatLoadingAgents[activeChatId] === true"
               @keydown.enter="if (!$event.shiftKey && (chatInput.trim() || pendingFile)) { $event.preventDefault(); sendMsg(); }"
-              @input="$el.style.height = 'auto'; $el.style.height = Math.min($el.scrollHeight, 120) + 'px'"
+              @input="$el.style.height = 'auto'; $el.style.height = Math.min($el.scrollHeight, 180) + 'px'"
               @paste="if ($event.clipboardData.files[0]) { $event.preventDefault(); attachFile($event.clipboardData.files[0]); }"
               class="chat-slide-textarea"
               :placeholder="speechActive ? 'Listening…' : (isAgentBusy(activeChatId) ? 'Steer agent…' : 'Message…')"></textarea>
             <button @click="sendMsg()"
               :disabled="!(chatInput.trim() || pendingFile)"
               class="chat-input-send"
-              :class="(chatInput.trim() || pendingFile) ? (isAgentBusy(activeChatId) ? 'bg-amber-600 hover:bg-amber-500' : 'bg-indigo-600 hover:bg-indigo-500') : 'bg-gray-700 opacity-40'"
+              :class="(chatInput.trim() || pendingFile) ? (isAgentBusy(activeChatId) ? 'bg-amber-600 hover:bg-amber-500' : 'bg-indigo-600 hover:bg-indigo-500') : 'bg-gray-700/60 text-gray-500'"
               aria-label="Send">
               <svg width="16" height="16" viewBox="0 0 20 20" fill="currentColor"><path fill-rule="evenodd" d="M3 10a.75.75 0 0 1 .75-.75h10.638L10.23 5.29a.75.75 0 1 1 1.04-1.08l5.5 5.25a.75.75 0 0 1 0 1.08l-5.5 5.25a.75.75 0 1 1-1.04-1.08l4.158-3.96H3.75A.75.75 0 0 1 3 10Z" clip-rule="evenodd"/></svg>
             </button>

--- a/src/dashboard/templates/index.html
+++ b/src/dashboard/templates/index.html
@@ -57,7 +57,7 @@
   <!-- Custom CSS -->
   <link rel="stylesheet" href="/dashboard/static/css/dashboard.css?v={{ v }}">
 </head>
-<body class="bg-gray-950 text-gray-100 min-h-screen">
+<body class="bg-gray-950 text-gray-100 h-[100dvh] overflow-hidden">
   <script>
     window.__config = {
       wsUrl: (location.protocol === 'https:' ? 'wss://' : 'ws://') + location.host + "{{ ws_path }}",
@@ -67,7 +67,7 @@
     };
   </script>
 
-  <div x-data="dashboard()" x-init="init()" class="flex flex-col md:flex-row h-screen">
+  <div x-data="dashboard()" x-init="init()" class="flex flex-col md:flex-row h-[100dvh]">
 
     <!-- Toast notifications -->
     <div class="fixed top-16 left-1/2 -translate-x-1/2 z-[100] flex flex-col gap-2 items-center pointer-events-none max-w-sm w-full" role="status" aria-live="polite">
@@ -500,7 +500,7 @@
       </div>
 
       <!-- Operator Chat Tab -->
-      <div x-show="activeTab === 'chat'" x-cloak class="h-full flex flex-col" style="min-height: calc(100vh - 8rem);">
+      <div x-show="activeTab === 'chat'" x-cloak class="h-full flex flex-col" style="min-height: calc(100dvh - 8rem);">
           <!-- Page header — full-width contextual top nav for the chat tab.
                Avatar alt is empty (decorative): the name sits right beside
                it, and an empty alt avoids a doubled "Operator" if the image
@@ -2297,8 +2297,8 @@
                   ></span>
                 </div>
                 <div class="flex-1 min-w-0">
-                  <div class="flex items-center gap-2">
-                    <span class="font-semibold text-white group-hover:text-indigo-300 transition-colors truncate cursor-pointer"
+                  <div class="flex items-center gap-2 min-w-0">
+                    <span class="font-semibold text-white group-hover:text-indigo-300 transition-colors truncate cursor-pointer min-w-0"
                       @click="drillDown(agent.id)"
                       :title="agent.id" x-text="agent.id"></span>
                     <span x-show="agent.id === 'operator'" class="text-[11px] px-1.5 py-0.5 rounded bg-indigo-900/30 text-indigo-400 border border-indigo-800/40 shrink-0">system</span>
@@ -2395,10 +2395,10 @@
                   </span>
                   <span class="stat-value" x-text="formatCost(agent.daily_cost)"></span>
                 </div>
-                <div class="stat-row" x-show="agent.last_healthy || agent.last_task_event_ts">
+                <div class="stat-row" x-show="agent.last_worked_ts || agent.last_task_event_ts">
                   <span class="stat-label">
                     <svg fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><polyline points="12 6 12 12 16 14"/></svg>
-                    Last activity<span class="setting-hint setting-hint-sm ml-0.5" tabindex="0">?<span class="setting-hint-text">"Last seen" is the most recent successful health probe; "Last task" is the most recent task event (status change, comment, completion). The two diverge when an agent is healthy but idle, or has finished work but is now offline.</span></span>
+                    Last activity<span class="setting-hint setting-hint-sm ml-0.5" tabindex="0">?<span class="setting-hint-text">When the agent last actually worked — the time of its most recent LLM call. This is NOT container health: an idle-but-healthy agent shows its real last working time. Falls back to the most recent task event if the agent hasn't made an LLM call yet.</span></span>
                   </span>
                   <span class="stat-value text-[11px]" x-text="agentActivityLabel(agent)"></span>
                 </div>

--- a/src/host/costs.py
+++ b/src/host/costs.py
@@ -302,6 +302,33 @@ class CostTracker:
             for r in rows
         ]
 
+    def get_all_agents_last_worked(self) -> dict[str, float]:
+        """Map of agent → unix timestamp (UTC) of its most recent LLM call.
+
+        This is an accurate "last actually worked" signal: every billed LLM
+        call is recorded in the usage ledger, so the most recent row marks
+        the last time the agent did real work — distinct from the health
+        monitor's "last seen", which is just a container liveness probe.
+        Returns an empty dict if nothing is recorded yet.
+        """
+        rows = self.db.execute(
+            "SELECT agent, MAX(timestamp) FROM usage GROUP BY agent"
+        ).fetchall()
+        out: dict[str, float] = {}
+        for agent, ts in rows:
+            if not agent or not ts:
+                continue
+            try:
+                # usage.timestamp is "YYYY-MM-DD HH:MM:SS" in UTC
+                # (SQLite datetime('now')) — match _period_to_since's format.
+                dt = datetime.strptime(ts, "%Y-%m-%d %H:%M:%S").replace(
+                    tzinfo=timezone.utc
+                )
+                out[agent] = dt.timestamp()
+            except (ValueError, TypeError):
+                continue
+        return out
+
     def get_spend_by_model(self, period: str = "today") -> list[dict]:
         """Get cost breakdown by model across all agents."""
         since = _period_to_since(period)

--- a/tests/test_costs.py
+++ b/tests/test_costs.py
@@ -59,6 +59,26 @@ class TestCostTracking:
         names = {a["agent"] for a in agents}
         assert names == {"agent1", "agent2"}
 
+    def test_get_all_agents_last_worked_empty(self):
+        # No usage recorded yet → empty map (drives the "Last activity"
+        # card stat, which simply hides when there's no work to show).
+        assert self.tracker.get_all_agents_last_worked() == {}
+
+    def test_get_all_agents_last_worked(self):
+        import time
+
+        before = time.time()
+        self.tracker.track("agent1", "openai/gpt-4o-mini", 100, 50)
+        self.tracker.track("agent2", "openai/gpt-4o-mini", 200, 100)
+        worked = self.tracker.get_all_agents_last_worked()
+        assert set(worked) == {"agent1", "agent2"}
+        # Values are unix timestamps (UTC) of the most recent LLM call —
+        # i.e. real work, not a health probe. Allow a generous window for
+        # clock/second-rounding (usage.timestamp is whole-second UTC).
+        for ts in worked.values():
+            assert isinstance(ts, float)
+            assert before - 5 <= ts <= time.time() + 5
+
     def test_get_spend_by_model(self):
         self.tracker.track("agent1", "openai/gpt-4o", 1000, 500)
         self.tracker.track("agent2", "openai/gpt-4o", 500, 200)

--- a/tests/test_dashboard_ui.py
+++ b/tests/test_dashboard_ui.py
@@ -1609,38 +1609,10 @@ class TestUndoReceiptCountdown:
         assert format_undo_countdown(222) == "(3:42)"
 
 
-class TestSidePanelToggleIcon:
-    """The side-panel toggle SVG should not be the same chat-bubble
-    glyph used by the Chat tab — keeps the side-panel pictogram
-    distinct from the Chat tab so users don't confuse the two."""
-
-    def test_side_panel_toggle_is_not_chat_bubble(self):
-        # The Chat tab uses a chat-bubble path; the side-panel toggle
-        # was using the SAME path verbatim, which made the tour ambiguous
-        # ("click the chat icon" → users clicked the Chat tab). The
-        # toggle now uses a distinct rectangle + divider + arrow shape.
-        chat_bubble_path = (
-            'd="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z"'
-        )
-        # Locate the toggle button by its handler and assert the
-        # chat-bubble path does NOT appear inside its inner SVG.
-        idx = _INDEX_HTML.find("toggleSidePanel()")
-        assert idx > -1, "side-panel toggle handler missing"
-        button_block = _INDEX_HTML[idx : idx + 1500]
-        assert chat_bubble_path not in button_block, (
-            "Side-panel toggle still uses the chat-bubble SVG path; "
-            "it should be a distinct pictogram."
-        )
-
-    def test_side_panel_toggle_uses_panel_pictogram(self):
-        # Find the toggle button and verify its inner SVG carries the
-        # rectangle + divider + arrow shape.
-        idx = _INDEX_HTML.find("toggleSidePanel()")
-        assert idx > -1, "side-panel toggle handler missing"
-        snippet = _INDEX_HTML[idx : idx + 1500]
-        assert '<rect x="3" y="4" width="18" height="16"' in snippet
-        assert '<line x1="14" y1="4" x2="14" y2="20"' in snippet
-        assert '<polyline points="8 10 11 12 8 14"' in snippet
+# NOTE: TestSidePanelToggleIcon was removed — the messenger side-panel
+# toggle button was dropped from both navbars (the panel now opens by
+# clicking an agent). With no toggle in the template there's nothing to
+# assert about its icon.
 
 
 class TestWorkerDmInNeedsYou:

--- a/tests/test_dashboard_ui.py
+++ b/tests/test_dashboard_ui.py
@@ -422,16 +422,19 @@ class TestNotificationsBellMarkup:
         #    hides the dropdown entirely when empty.
         assert "No recent activity" not in _INDEX_HTML
 
-    def test_only_one_notifications_bell_renders(self):
-        # The bell SVG path is identifying enough — both Phase 1 and
-        # Phase 2 used the same ``M18 8A6 6 0 0...`` Feather icon. After
-        # the fix exactly one bell remains in the top-nav.
+    def test_notifications_bell_renders_once_per_breakpoint(self):
+        # The shell folds the desktop top bar into the sidebar, so the
+        # Phase-2 bell now renders TWICE: once in the mobile/tablet top
+        # bar (visible <md) and once in the desktop sidebar tray (visible
+        # md+). Only one is ever visible — the other's container is
+        # display:none — but both are in the DOM. The legacy Phase-1 bell
+        # is still guarded separately (test_legacy_notifications_bell_removed),
+        # so two here means "one per breakpoint", not a legacy regression.
         # Match the bell-shape path with whitespace-tolerance (Phase 1
-        # used ``A6 6 0 0 0`` while Phase 2 collapsed to ``A6 6 0 006``;
-        # any future SVG change still picks both up).
+        # used ``A6 6 0 0 0`` while Phase 2 collapsed to ``A6 6 0 006``).
         bells = re.findall(r'M18 8A6 6 0\s*0?\s*0?6 8c0 7-3 9-3 9h18s-3-2-3-9', _INDEX_HTML)
-        assert len(bells) == 1, (
-            f"Expected exactly one notifications bell SVG, found {len(bells)}"
+        assert len(bells) == 2, (
+            f"Expected exactly two notifications bells (one per breakpoint), found {len(bells)}"
         )
 
 
@@ -2280,7 +2283,10 @@ def _has_legacy_notifications_bell(html: str) -> bool:
 
 
 class TestNotificationsBellSingleton:
-    """Only one notifications bell should render after PR-B lands."""
+    """After PR-B (legacy bell removed) the only bells are the Phase-2
+    bell rendered once per responsive breakpoint (mobile top bar + desktop
+    sidebar tray) — see the shell fold-down. The legacy Phase-1 bell must
+    stay gone."""
 
     @pytest.mark.skipif(
         _has_legacy_notifications_bell(_INDEX_HTML),
@@ -2299,14 +2305,17 @@ class TestNotificationsBellSingleton:
         _has_legacy_notifications_bell(_INDEX_HTML),
         reason="depends on PR-B: only one bell after legacy is removed",
     )
-    def test_only_one_notifications_bell_renders(self):
-        """Exactly one bell SVG sits in the top-nav."""
-        # The bell SVG path is unique enough to count occurrences.
-        # Both the Phase 1 and Phase 2 variants share this path string.
+    def test_notifications_bell_renders_once_per_breakpoint(self):
+        """Exactly two Phase-2 bells: mobile top bar + desktop sidebar."""
+        # The bell SVG path is unique enough to count occurrences. The
+        # shell renders the bell once per responsive nav container (the
+        # mobile/tablet top bar and the desktop sidebar tray), only one
+        # of which is ever visible. The legacy Phase-1 bell is guarded by
+        # test_legacy_notifications_bell_removed above.
         bell_path = 'M18 8A6 6 0 0'
         count = _INDEX_HTML.count(bell_path)
-        assert count == 1, (
-            f"expected exactly 1 notifications bell after PR-B, got {count}"
+        assert count == 2, (
+            f"expected exactly 2 notifications bells (one per breakpoint), got {count}"
         )
 
 


### PR DESCRIPTION
## Summary

A UI/UX pass on the dashboard. The headline is a **shell change**: on desktop the global top bar is removed and its contents fold into the left sidebar (ChatGPT/Linear shell), giving the content column — and the chat — the full viewport height. Mobile/tablet keep the top bar since the sidebar is hidden below `md`.

### Shell
- **Sidebar bottom tray** (desktop, `md+`): needs-you, today's spend, model-health, notifications bell, messenger toggle, **search (kept at the bottom by request)**, and the connection pill. The top `nav-bar` is now `md:hidden`.
- **Messenger panel** decoupled from `--topnav-h` on desktop (`top:0` / full height); the offset stays on mobile.
- **Bug caught in review:** the bell renders in both the sidebar and the top bar (one per breakpoint) sharing one Alpine state — each `@click.away` is guarded with an `offsetParent` visibility check so the `display:none` copy doesn't slam the dropdown shut the instant the visible bell opens it.

### Work-tab cards (hierarchy)
Rebuilt the summary cards: a scope accent rail (indigo team / cyan solo), an icon chip + prominent title, and recommendations promoted into a boxed callout with bullets instead of flat body text. Rating buttons enlarged.

### Contrast / legibility (P0)
- Empty-state icons were `#1f2937`/`#374151` (invisible on the near-black canvas) → gray-400 on a soft circle. Systemic across all four tabs.
- Chat timestamps 40% → 60% opacity; markdown links brightened.

### Chat composer (P1)
Symmetric padding, controls pin to the last line as the textarea grows, larger toolbar buttons, taller textarea (120→180px, JS cap synced), body-scale font, and a clean muted disabled send button (was gray@40%, read as broken). Side-panel bubbles widened 80→92% (scoped to the panel).

### Polish (P2)
Stronger segmented-control active state and agent-card hover affordance; status-badge border rings. **Fixed `py-0.5.5`** — an invalid Tailwind class repeated **15×** that left those pill badges with no vertical padding.

## Testing
Full fast suite: **6602 passed, 49 skipped**. Two bell-singleton tests were updated (1→2 bells, one per breakpoint; legacy-bell guard untouched). `test_asset_version_is_deterministic` is a pre-existing order-dependent flake in the full sweep (passes clean in isolation; this PR doesn't touch versioning).

🤖 Generated with [Claude Code](https://claude.com/claude-code)