### PR TITLE
fix(runtime): isolate agent containers on the bridge network

### DIFF
--- a/src/host/runtime.py
+++ b/src/host/runtime.py
@@ -313,8 +313,20 @@ class DockerBackend(RuntimeBackend):
                 return network
         except docker.errors.NotFound:
             pass
+        # enable_icc=false disables inter-container communication on the
+        # bridge, so a compromised agent cannot open a connection to a peer
+        # agent's container (:8400). Published ports remain reachable from the
+        # host (the mesh), since that traffic crosses the bridge from the host
+        # namespace, not container-to-container.
+        #
+        # CAVEAT: this option only applies on first creation. An existing
+        # ``openlegion_agents`` network is returned unchanged above and must be
+        # recreated to pick up ICC isolation (we deliberately do NOT auto-delete
+        # a live network, which would disrupt running agents).
         return self.client.networks.create(
-            self._network_name, driver="bridge",
+            self._network_name,
+            driver="bridge",
+            options={"com.docker.network.bridge.enable_icc": "false"},
         )
 
     @staticmethod
@@ -450,7 +462,10 @@ class DockerBackend(RuntimeBackend):
             run_kwargs["network_mode"] = "host"
         else:
             run_kwargs["network"] = self._network_name
-            run_kwargs["ports"] = {"8400/tcp": port}
+            # Bind the published port to loopback only — the mesh reaches the
+            # agent via http://127.0.0.1:{port}, so there is no need to expose
+            # :8400 on all host interfaces.
+            run_kwargs["ports"] = {"8400/tcp": ("127.0.0.1", port)}
             # On Linux, host.docker.internal requires explicit mapping
             if platform.system() == "Linux":
                 run_kwargs["extra_hosts"] = {
@@ -693,7 +708,9 @@ class DockerBackend(RuntimeBackend):
                 "(use_host_network=False) for production deployments."
             )
         else:
-            run_kwargs["ports"] = {"8500/tcp": api_port}
+            # Bind the published port to loopback only — the mesh reaches the
+            # browser service via http://127.0.0.1:{api_port}.
+            run_kwargs["ports"] = {"8500/tcp": ("127.0.0.1", api_port)}
             if platform.system() == "Linux":
                 run_kwargs["extra_hosts"] = {"host.docker.internal": "host-gateway"}
             # Bridge network mode: grant minimal caps needed by the entrypoint.

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -484,6 +484,46 @@ class TestDockerBackendSlimResources:
         assert "8400/tcp" in ports
         assert "6080/tcp" not in ports
 
+    def test_agent_port_binds_loopback_only(self):
+        """Agent's published :8400 binds to 127.0.0.1 only — the mesh reaches it
+        via loopback, so it must not be exposed on all host interfaces."""
+        import docker as _docker
+
+        backend = self._make_backend()
+        mock_client = MagicMock()
+        mock_client.containers.run.return_value = MagicMock()
+        mock_client.containers.get.side_effect = _docker.errors.NotFound("not found")
+        backend.client = mock_client
+
+        backend.start_agent(agent_id="test-agent", role="test", skills_dir="")
+
+        run_call = mock_client.containers.run.call_args
+        ports = run_call.kwargs.get("ports", {})
+        host_binding = ports["8400/tcp"]
+        assert isinstance(host_binding, tuple)
+        assert host_binding[0] == "127.0.0.1"
+
+    def test_browser_port_binds_loopback_only(self):
+        """Browser service's published :8500 binds to 127.0.0.1 only."""
+        import docker as _docker
+
+        backend = self._make_backend()
+        mock_client = MagicMock()
+        mock_client.containers.run.return_value = MagicMock()
+        mock_client.containers.get.side_effect = _docker.errors.NotFound("not found")
+        backend.client = mock_client
+
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        with patch("httpx.get", return_value=mock_resp):
+            backend.start_browser_service()
+
+        run_call = mock_client.containers.run.call_args
+        ports = run_call.kwargs.get("ports", {})
+        host_binding = ports["8500/tcp"]
+        assert isinstance(host_binding, tuple)
+        assert host_binding[0] == "127.0.0.1"
+
     def test_browser_service_lifecycle(self):
         """start_browser_service creates container, stop removes it."""
         import docker as _docker
@@ -1088,7 +1128,9 @@ class TestAgentNetwork:
 
         old_internal.remove.assert_called_once()
         backend.client.networks.create.assert_called_once_with(
-            "openlegion_agents", driver="bridge",
+            "openlegion_agents",
+            driver="bridge",
+            options={"com.docker.network.bridge.enable_icc": "false"},
         )
         assert result is new_net
 
@@ -1105,9 +1147,27 @@ class TestAgentNetwork:
         result = backend._ensure_agent_network()
 
         backend.client.networks.create.assert_called_once_with(
-            "openlegion_agents", driver="bridge",
+            "openlegion_agents",
+            driver="bridge",
+            options={"com.docker.network.bridge.enable_icc": "false"},
         )
         assert result is new_net
+
+    def test_create_disables_inter_container_communication(self):
+        """New network is created with enable_icc=false so a compromised agent
+        cannot reach a peer agent's container directly on the shared bridge."""
+        import docker as _docker
+
+        backend = self._make_backend()
+        backend.client.networks.get.side_effect = _docker.errors.NotFound("nope")
+        backend.client.networks.create.return_value = MagicMock()
+
+        backend._ensure_agent_network()
+
+        create_kwargs = backend.client.networks.create.call_args.kwargs
+        assert create_kwargs["options"] == {
+            "com.docker.network.bridge.enable_icc": "false"
+        }
 
     def test_keeps_stale_if_remove_fails(self):
         """Falls back to stale internal network if removal fails."""


### PR DESCRIPTION
## Summary

Closes peer-to-peer reachability between agent containers on the shared `openlegion_agents` Docker bridge. Part of the May 2026 security remediation (`docs/security-remediation-review-2026-05-29.md`, finding **C1** / M9).

Previously a compromised agent could open a direct TCP connection to a peer agent's container (peer `:8400`) on the shared bridge, and the agent/browser published ports were exposed on all host interfaces. Two surgical changes in `src/host/runtime.py`:

1. **ICC off** — the agent bridge is created with `options={"com.docker.network.bridge.enable_icc": "false"}`, disabling inter-container communication so one agent cannot reach a peer container's `:8400`. Published ports remain reachable from the host (the mesh), since that traffic crosses the bridge from the host namespace.

2. **Loopback-bind published ports** — the agent (`:8400`) and browser-service (`:8500`) published ports now bind to `127.0.0.1` only instead of all interfaces. Safe because the mesh already reaches both via `http://127.0.0.1:{port}` (verified at the agent URL builder and the browser health-probe / URL builder). Applied **only** in the bridge branch; the host-network branch (which publishes no ports) is untouched.

This intentionally does **not** add agent-server bearer auth — that is a separate follow-up.

## Caveat (must be in release notes)

`_ensure_agent_network` returns an **existing** network unchanged, so the `enable_icc=false` option only takes effect on first creation. An already-present `openlegion_agents` network must be **recreated** (e.g. `docker network rm openlegion_agents` while the stack is stopped) to pick up ICC isolation. We deliberately do **not** auto-delete/recreate a live network, which would disrupt running agents.

## Tests

`tests/test_runtime.py` — updated the two `_ensure_agent_network` create-assertions for the new `options=` kwarg, and added:
- `test_create_disables_inter_container_communication` (ICC option on create)
- `test_agent_port_binds_loopback_only` (`:8400` → `("127.0.0.1", port)`)
- `test_browser_port_binds_loopback_only` (`:8500` → `("127.0.0.1", api_port)`)

All 114 tests in `tests/test_runtime.py` pass.

## Note

May need rebasing against an in-flight `runtime.py` refactor.