### PR TITLE
fix(cron): make the scheduler resilient to malformed schedules and cap jobs per agent

### DIFF
--- a/src/host/cron.py
+++ b/src/host/cron.py
@@ -36,6 +36,21 @@ logger = setup_logging("host.cron")
 
 _EMPTY_RESPONSES = frozenset({"", "ok", "heartbeat_ok", "nothing to do", "no updates"})
 _MAX_CRON_SCAN_MINUTES = 43200  # 30 days
+_DEFAULT_MAX_CRON_JOBS_PER_AGENT = 50
+
+
+def _max_cron_jobs_per_agent() -> int:
+    """Per-agent cron-job cap (M11). Env-configurable via
+    ``OPENLEGION_MAX_CRON_JOBS_PER_AGENT``; falls back to the default on
+    unset / non-integer / non-positive values."""
+    raw = os.environ.get("OPENLEGION_MAX_CRON_JOBS_PER_AGENT")
+    if raw is None:
+        return _DEFAULT_MAX_CRON_JOBS_PER_AGENT
+    try:
+        val = int(raw)
+    except ValueError:
+        return _DEFAULT_MAX_CRON_JOBS_PER_AGENT
+    return val if val > 0 else _DEFAULT_MAX_CRON_JOBS_PER_AGENT
 
 
 @dataclass
@@ -211,6 +226,16 @@ class CronScheduler:
         error = self._validate_schedule(schedule)
         if error:
             raise ValueError(error)
+        # M11: cap the number of cron jobs per agent so a single agent
+        # can't exhaust the scheduler (or the config file) by registering
+        # unbounded jobs. Default 50, env-overridable.
+        cap = _max_cron_jobs_per_agent()
+        existing = sum(1 for j in self.jobs.values() if j.agent == agent)
+        if existing >= cap:
+            raise ValueError(
+                f"Agent '{agent}' has reached the cron job limit ({cap}). "
+                f"Remove an existing job before adding another."
+            )
         job = CronJob(
             id=generate_id("cron"),
             agent=agent,
@@ -324,6 +349,15 @@ class CronScheduler:
             job = self.jobs.get(job_id)
             if not job:
                 return None
+            # H8 validate-before-mutate: a bad schedule must never persist
+            # in the live job. Validate the candidate BEFORE setattr so a
+            # rejected update leaves the job's schedule untouched (the old
+            # ordering setattr'd job.schedule first, so a poison value
+            # stuck in memory even when _compute_next_run later choked).
+            if "schedule" in kwargs:
+                error = self._validate_schedule(kwargs["schedule"])
+                if error:
+                    raise ValueError(error)
             for k, v in kwargs.items():
                 if k in self._UPDATABLE_FIELDS and hasattr(job, k):
                     setattr(job, k, v)
@@ -407,10 +441,22 @@ class CronScheduler:
     async def _tick(self) -> None:
         now = datetime.now(timezone.utc)
         for job in list(self.jobs.values()):
-            if not job.enabled:
+            # H8 crash containment: one poison job (e.g. a malformed
+            # schedule that slipped past validation) must never kill the
+            # scheduler task and silence ALL heartbeats / jobs fleet-wide.
+            # Wrap the per-job body so a raise here logs + continues to
+            # the next job instead of propagating out of the while loop.
+            try:
+                if not job.enabled:
+                    continue
+                if self._is_due(job, now):
+                    asyncio.create_task(self._execute_job(job))
+            except Exception:
+                logger.error(
+                    "Cron tick: job %s raised during scheduling — skipping",
+                    getattr(job, "id", "<unknown>"), exc_info=True,
+                )
                 continue
-            if self._is_due(job, now):
-                asyncio.create_task(self._execute_job(job))
 
     async def _execute_job(self, job: CronJob, manual: bool = False) -> str | None:
         lock = self._job_locks[job.id]
@@ -742,9 +788,58 @@ class CronScheduler:
 
         return False
 
+    # Per-field (min, max) inclusive bounds for a 5-field cron expression:
+    # minute, hour, day-of-month, month, day-of-week (0=Sun..6=Sat).
+    _CRON_FIELD_BOUNDS: tuple[tuple[int, int], ...] = (
+        (0, 59),  # minute
+        (0, 23),  # hour
+        (1, 31),  # day of month
+        (1, 12),  # month
+        (0, 6),   # day of week
+    )
+
     @staticmethod
-    def _validate_schedule(schedule: str) -> str | None:
-        """Validate a schedule string. Returns error message or None."""
+    def _validate_cron_field(field: str, low: int, high: int) -> bool:
+        """Return True iff ``field`` is a structurally valid cron field
+        within [low, high]. Rejects step 0, malformed ranges (``1-``),
+        non-numeric values, and out-of-range numbers."""
+        if field == "*":
+            return True
+        for segment in field.split(","):
+            if not segment:
+                return False
+            try:
+                if "/" in segment:
+                    base, step_str = segment.split("/", 1)
+                    step = int(step_str)
+                    if step <= 0:
+                        return False
+                    # Base may be "*" or a numeric start within bounds.
+                    if base != "*":
+                        base_val = int(base)
+                        if not (low <= base_val <= high):
+                            return False
+                elif "-" in segment:
+                    start_str, end_str = segment.split("-", 1)
+                    start, end = int(start_str), int(end_str)
+                    if start > end or start < low or end > high:
+                        return False
+                else:
+                    val = int(segment)
+                    if not (low <= val <= high):
+                        return False
+            except (ValueError, ZeroDivisionError):
+                return False
+        return True
+
+    @classmethod
+    def _validate_schedule(cls, schedule: str) -> str | None:
+        """Validate a schedule string. Returns error message or None.
+
+        Parses each of the 5 cron fields (not just field count) so a
+        poison schedule like ``*/0 * * * *`` or ``1- * * * *`` is rejected
+        at config-write time (H8) instead of crashing the scheduler loop.
+        """
         schedule = schedule.strip()
         if re.match(r"every\s+(\d+)([smhd])", schedule, re.IGNORECASE):
             return None
@@ -756,6 +851,16 @@ class CronScheduler:
                 "Example: 'every 5s' or '*/1 * * * *'"
             )
         if len(parts) == 5:
+            for field, (low, high) in zip(
+                parts, cls._CRON_FIELD_BOUNDS, strict=True,
+            ):
+                if not cls._validate_cron_field(field, low, high):
+                    return (
+                        f"Invalid cron field '{field}' in schedule "
+                        f"'{schedule}'. Each field must be '*', a number, "
+                        f"a range (a-b), a list (a,b,c), or a step (*/n with "
+                        f"n>0), within range [{low}-{high}]."
+                    )
             return None
         return f"Invalid schedule: '{schedule}'. Use 5-field cron or 'every N[s/m/h/d]'"
 
@@ -793,21 +898,27 @@ def _match_cron_field(field: str, current: int) -> bool:
     if field == "*":
         return True
     for segment in field.split(","):
-        if "/" in segment:
-            base, step_str = segment.split("/", 1)
-            step = int(step_str)
-            if base == "*" and current % step == 0:
-                return True
-        elif "-" in segment:
-            start, end = map(int, segment.split("-", 1))
-            if start <= current <= end:
-                return True
-        else:
-            try:
+        # H8: a malformed field (step 0, bad range like "1-", non-numeric)
+        # must return a non-match rather than raise — a raise here would
+        # bubble up through ``_is_due`` and (pre-fix) kill the scheduler.
+        try:
+            if "/" in segment:
+                base, step_str = segment.split("/", 1)
+                step = int(step_str)
+                # Guard the modulo: step 0 would ZeroDivisionError.
+                if step <= 0:
+                    continue
+                if base == "*" and current % step == 0:
+                    return True
+            elif "-" in segment:
+                start, end = map(int, segment.split("-", 1))
+                if start <= current <= end:
+                    return True
+            else:
                 if int(segment) == current:
                     return True
-            except ValueError:
-                pass
+        except (ValueError, ZeroDivisionError):
+            continue
     return False
 
 

--- a/tests/test_cron.py
+++ b/tests/test_cron.py
@@ -34,6 +34,27 @@ class TestCronFieldMatching:
         assert _match_cron_field("*/5", 0)
         assert not _match_cron_field("*/5", 3)
 
+    # ── H8: malformed fields must not raise (poison-job containment) ──
+
+    def test_step_zero_does_not_divide(self):
+        """``*/0`` would ZeroDivisionError on ``current % step`` — guard it."""
+        # Must return False (no match) rather than raise.
+        assert _match_cron_field("*/0", 0) is False
+        assert _match_cron_field("*/0", 5) is False
+
+    def test_negative_step_safe(self):
+        assert _match_cron_field("*/-1", 0) is False
+
+    def test_malformed_range_safe(self):
+        """``1-`` (missing end) must not raise."""
+        assert _match_cron_field("1-", 3) is False
+
+    def test_non_numeric_field_safe(self):
+        assert _match_cron_field("abc", 3) is False
+        assert _match_cron_field("1,foo,5", 3) is False
+        # A valid segment alongside a junk one still matches the valid one.
+        assert _match_cron_field("foo,5", 5) is True
+
 
 class TestCronScheduler:
     def setup_method(self):
@@ -1263,4 +1284,179 @@ class TestCronQuarantineGate:
         dispatch.reset_mock()
         await sched._execute_job(job)
         dispatch.assert_not_called()
+
+
+# ── H8 / M11: scheduler resilience + per-agent cap ──────────────────
+
+
+class TestScheduleValidation:
+    """Content-aware ``_validate_schedule`` (H8). Both the create and the
+    update mesh endpoints surface this as HTTP 400 — create via
+    ``add_job``'s ValueError, update via the direct ``_validate_schedule``
+    call before ``update_job``."""
+
+    def setup_method(self):
+        self._tmpdir = tempfile.mkdtemp()
+        self.config_path = f"{self._tmpdir}/cron.json"
+
+    def teardown_method(self):
+        shutil.rmtree(self._tmpdir, ignore_errors=True)
+
+    def test_step_zero_rejected(self):
+        sched = CronScheduler(config_path=self.config_path)
+        # The error string is what the update endpoint turns into a 400.
+        assert sched._validate_schedule("*/0 * * * *") is not None
+
+    def test_step_zero_rejected_by_create(self):
+        """add_job raises ValueError → create endpoint maps to 400."""
+        sched = CronScheduler(config_path=self.config_path)
+        with pytest.raises(ValueError):
+            sched.add_job(agent="a", schedule="*/0 * * * *", message="x")
+        assert len(sched.jobs) == 0
+
+    @pytest.mark.asyncio
+    async def test_step_zero_rejected_by_update(self):
+        """update_job validate-before-mutate: poison value never persists."""
+        sched = CronScheduler(config_path=self.config_path)
+        job = sched.add_job(agent="a", schedule="0 9 * * *", message="x")
+        # Endpoint validates first; assert _validate_schedule flags it.
+        assert sched._validate_schedule("*/0 * * * *") is not None
+        # And update_job itself refuses to persist the poison schedule.
+        with pytest.raises(ValueError):
+            await sched.update_job(job.id, schedule="*/0 * * * *")
+        # Original schedule untouched.
+        assert sched.jobs[job.id].schedule == "0 9 * * *"
+
+    def test_malformed_range_rejected(self):
+        sched = CronScheduler(config_path=self.config_path)
+        assert sched._validate_schedule("1- * * * *") is not None
+        assert sched._validate_schedule("5-2 * * * *") is not None  # start>end
+
+    def test_out_of_range_rejected(self):
+        sched = CronScheduler(config_path=self.config_path)
+        assert sched._validate_schedule("99 * * * *") is not None  # minute>59
+        assert sched._validate_schedule("* 25 * * *") is not None  # hour>23
+        assert sched._validate_schedule("* * 0 * *") is not None   # dom<1
+
+    def test_non_numeric_rejected(self):
+        sched = CronScheduler(config_path=self.config_path)
+        assert sched._validate_schedule("foo * * * *") is not None
+
+    def test_valid_schedules_accepted(self):
+        sched = CronScheduler(config_path=self.config_path)
+        for good in [
+            "0 9 * * *", "*/5 * * * *", "0 9 * * 1-5",
+            "15,45 * * * *", "* * * * *", "0 0 1 1 *",
+            "every 5m", "every 30s", "every 2h", "every 1d",
+        ]:
+            assert sched._validate_schedule(good) is None, good
+
+    def test_valid_step_and_interval_still_work(self):
+        """A normal cron and an ``every 5m`` job add + compute next_run."""
+        sched = CronScheduler(config_path=self.config_path)
+        cron_job = sched.add_job(agent="a", schedule="*/5 * * * *", message="x")
+        assert cron_job.next_run is not None
+        interval_job = sched.add_job(agent="b", schedule="every 5m", message="y")
+        assert interval_job.next_run is not None
+
+
+class TestSchedulerResilience:
+    """H8: a poison schedule forced into a live job must NOT crash the
+    scheduler. ``_tick`` wraps each job; ``_is_due``/``_match_cron`` no
+    longer raise."""
+
+    def setup_method(self):
+        self._tmpdir = tempfile.mkdtemp()
+        self.config_path = f"{self._tmpdir}/cron.json"
+
+    def teardown_method(self):
+        shutil.rmtree(self._tmpdir, ignore_errors=True)
+
+    def test_is_due_does_not_raise_on_poison_schedule(self):
+        """Forcing ``*/0 * * * *`` onto a job: _is_due returns False, no raise."""
+        sched = CronScheduler(config_path=self.config_path)
+        job = sched.add_job(agent="a", schedule="0 9 * * *", message="x")
+        # Bypass validation by mutating the live job directly (simulates a
+        # poison value loaded from an old/corrupt config file).
+        job.schedule = "*/0 * * * *"
+        job.last_run = None
+        # Force the once-per-minute window to be open.
+        now = datetime.now(timezone.utc).replace(second=0, microsecond=0)
+        # Should not raise ZeroDivisionError.
+        assert sched._is_due(job, now) is False
+
+    @pytest.mark.asyncio
+    async def test_tick_survives_poison_job(self):
+        """A poison job in _tick must not kill the scheduler — the other
+        (healthy) job must still be scheduled."""
+        dispatch = AsyncMock(return_value="ok")
+        sched = CronScheduler(config_path=self.config_path, dispatch_fn=dispatch)
+        poison = sched.add_job(agent="a", schedule="0 9 * * *", message="x")
+        healthy = sched.add_job(agent="b", schedule="every 1s", message="y")
+        # Poison the first job post-validation.
+        poison.schedule = "*/0 * * * *"
+        poison.last_run = None
+        # _tick must not raise even with the poison job present.
+        await sched._tick()
+        # Healthy interval job (no last_run) is due → an execute task fired.
+        # Give the created task a chance to run.
+        import asyncio
+        await asyncio.sleep(0)
+        # Sanity: scheduler is still usable after the poison tick.
+        assert sched.jobs[healthy.id].enabled is True
+
+    @pytest.mark.asyncio
+    async def test_tick_continues_when_is_due_raises(self):
+        """If _is_due itself raises (defensive), _tick logs + continues."""
+        dispatch = AsyncMock(return_value="ok")
+        sched = CronScheduler(config_path=self.config_path, dispatch_fn=dispatch)
+        sched.add_job(agent="a", schedule="0 9 * * *", message="x")
+        with patch.object(
+            sched, "_is_due", side_effect=RuntimeError("boom"),
+        ):
+            # Must swallow the raise rather than propagate out of the loop.
+            await sched._tick()
+
+
+class TestPerAgentCronCap:
+    """M11: per-agent cron-job cap, env-overridable."""
+
+    def setup_method(self):
+        self._tmpdir = tempfile.mkdtemp()
+        self.config_path = f"{self._tmpdir}/cron.json"
+
+    def teardown_method(self):
+        shutil.rmtree(self._tmpdir, ignore_errors=True)
+
+    def test_cap_enforced(self, monkeypatch):
+        monkeypatch.setenv("OPENLEGION_MAX_CRON_JOBS_PER_AGENT", "3")
+        sched = CronScheduler(config_path=self.config_path)
+        for i in range(3):
+            sched.add_job(agent="a", schedule="every 1h", message=f"m{i}")
+        with pytest.raises(ValueError, match="cron job limit"):
+            sched.add_job(agent="a", schedule="every 1h", message="overflow")
+        assert sum(1 for j in sched.jobs.values() if j.agent == "a") == 3
+
+    def test_cap_is_per_agent(self, monkeypatch):
+        monkeypatch.setenv("OPENLEGION_MAX_CRON_JOBS_PER_AGENT", "2")
+        sched = CronScheduler(config_path=self.config_path)
+        sched.add_job(agent="a", schedule="every 1h", message="m1")
+        sched.add_job(agent="a", schedule="every 1h", message="m2")
+        # Different agent has its own budget.
+        b = sched.add_job(agent="b", schedule="every 1h", message="m1")
+        assert b.agent == "b"
+
+    def test_default_cap(self):
+        from src.host.cron import (
+            _DEFAULT_MAX_CRON_JOBS_PER_AGENT,
+            _max_cron_jobs_per_agent,
+        )
+        assert _max_cron_jobs_per_agent() == _DEFAULT_MAX_CRON_JOBS_PER_AGENT == 50
+
+    def test_invalid_env_falls_back_to_default(self, monkeypatch):
+        from src.host.cron import _max_cron_jobs_per_agent
+        monkeypatch.setenv("OPENLEGION_MAX_CRON_JOBS_PER_AGENT", "not-a-number")
+        assert _max_cron_jobs_per_agent() == 50
+        monkeypatch.setenv("OPENLEGION_MAX_CRON_JOBS_PER_AGENT", "0")
+        assert _max_cron_jobs_per_agent() == 50
 


### PR DESCRIPTION
## May 2026 security remediation — findings H8 + M11

### H8: malformed schedule crashes the whole scheduler (fleet-wide outage)
A malformed cron schedule (e.g. `*/0 * * * *`) passed the old field-count-only validation, then crashed the scheduler loop: `_match_cron_field` computed `current % int(step_str)` → `ZeroDivisionError` on step 0 (and `ValueError` on a malformed range like `1-`). Because `_tick` ran an unguarded per-job loop inside the bare `while` in `start()`, one poison job killed the scheduler task and silenced **all** heartbeats and scheduled jobs for the entire fleet.

Fixed with defense in depth:
- **Crash containment (load-bearing):** `_tick` wraps each job's scheduling body in try/except — logs the job id and continues. One poison job can never kill the scheduler task.
- **Field guard:** `_match_cron_field` returns `False` (no match) instead of raising on step ≤ 0 or malformed range/int.
- **Content-aware validation:** `_validate_schedule` now parses all 5 cron fields (rejecting step 0, malformed/inverted ranges, out-of-range, non-numeric) instead of only counting fields. Both the create (`POST /mesh/cron` via `add_job`) and update (`PUT /mesh/cron/{id}` via the direct `_validate_schedule` call) endpoints already route through this, so both now reject a bad schedule with **400**.
- **Validate-before-mutate:** `update_job` validates the candidate schedule *before* `setattr`-ing `job.schedule`, so a rejected update can never leave a poison value stuck in the live in-memory job (the old ordering mutated first, then raised in `_compute_next_run`, persisting the bad value).

### M11: no per-agent cron-job cap
`add_job` now enforces a per-agent cap (default **50**, env-configurable via `OPENLEGION_MAX_CRON_JOBS_PER_AGENT`), raising `ValueError` past the limit which the create endpoint surfaces as **400**. Prevents a single agent from exhausting the scheduler / config file with unbounded jobs.

### Scope / compatibility
- Valid 5-field cron and `every Ns` interval schedules are unchanged. Interval parsing behavior is untouched (only guarded against crashes).
- Touches only `src/host/cron.py` + `tests/test_cron.py`. No server.py change was needed — both cron endpoints already delegate validation to the hardened `cron.py` paths.

### Tests
`python -m pytest tests/test_cron.py` → **92 passed**. New tests cover: `*/0 * * * *` rejected by create + update; `_is_due`/`_tick` survive a forced poison schedule; `_match_cron_field` handles step 0 / malformed safely; per-agent cap enforced; valid cron + `every 5m` still work.

> Note: may need rebasing against an in-flight cron/refactor branch.