### PR TITLE
fix(agent): raise LLM output cap so large tool-call payloads don't truncate

### DIFF
--- a/src/agent/__main__.py
+++ b/src/agent/__main__.py
@@ -49,10 +49,16 @@ def main() -> None:
     llm_model = os.environ.get("LLM_MODEL", "openai/gpt-4o-mini")
     embedding_model = os.environ.get("EMBEDDING_MODEL", "")
     thinking = os.environ.get("THINKING", "off")
+    try:
+        max_output_tokens = int(os.environ.get("LLM_MAX_TOKENS", "8192"))
+    except ValueError:
+        logger.warning("Invalid LLM_MAX_TOKENS, using default 8192")
+        max_output_tokens = 8192
+    max_output_tokens = max(256, min(max_output_tokens, 200_000))
     llm = LLMClient(
         mesh_url=mesh_url, agent_id=agent_id,
         default_model=llm_model, embedding_model=embedding_model,
-        thinking=thinking,
+        thinking=thinking, max_output_tokens=max_output_tokens,
     )
     project_name = os.environ.get("PROJECT_NAME", "")
     mesh_client = MeshClient(

--- a/src/agent/llm.py
+++ b/src/agent/llm.py
@@ -38,6 +38,7 @@ class LLMClient:
         default_model: str = "openai/gpt-4o-mini",
         embedding_model: str = "",
         thinking: str = "off",
+        max_output_tokens: int = 8192,
     ):
         if thinking and thinking not in self.VALID_THINKING_LEVELS:
             logger.warning(
@@ -50,6 +51,16 @@ class LLMClient:
         self.default_model = default_model
         self.embedding_model = embedding_model
         self.thinking = thinking
+        # Default output-token cap for chat()/chat_stream() when the caller
+        # doesn't pass max_tokens explicitly. Configurable per-agent via the
+        # LLM_MAX_TOKENS env var (see __main__.py) and hot-reloadable via the
+        # agent /config endpoint. The legacy hardcoded 4096 was too small for
+        # tool calls with large argument payloads (e.g. write_file of a
+        # 15-20KB file): the model hit the cap mid-tool-call, the JSON never
+        # closed, and the call failed permanently with "Truncated tool-call
+        # arguments". 8192 is the safe floor across common modern models
+        # (gpt-4o family = 16384, Claude 3.5 Sonnet = 8192, Claude 4.x = 64K+).
+        self.max_output_tokens = max_output_tokens
         self._client: httpx.AsyncClient | None = None
         self._client_lock = asyncio.Lock()
         self._auth_token: str = os.environ.get("MESH_AUTH_TOKEN", "")
@@ -206,11 +217,13 @@ class LLMClient:
         messages: list[dict],
         tools: list[dict] | None = None,
         model: str | None = None,
-        max_tokens: int = 4096,
+        max_tokens: int | None = None,
         temperature: float = 0.7,
         **kwargs,
     ) -> LLMResponse:
         """Send a chat completion request through the mesh proxy."""
+        if max_tokens is None:
+            max_tokens = self.max_output_tokens
         params: dict = {
             "model": model or self.default_model,
             "messages": [{"role": "system", "content": system}] + messages,
@@ -259,7 +272,7 @@ class LLMClient:
         messages: list[dict],
         tools: list[dict] | None = None,
         model: str | None = None,
-        max_tokens: int = 4096,
+        max_tokens: int | None = None,
         temperature: float = 0.7,
         **kwargs,
     ) -> AsyncIterator[dict]:
@@ -270,6 +283,8 @@ class LLMClient:
           {"type": "done", "response": LLMResponse} — final assembled response
         On error, falls back by raising so caller can retry non-streaming.
         """
+        if max_tokens is None:
+            max_tokens = self.max_output_tokens
         params: dict = {
             "model": model or self.default_model,
             "messages": [{"role": "system", "content": system}] + messages,

--- a/src/agent/server.py
+++ b/src/agent/server.py
@@ -522,6 +522,7 @@ def create_agent_app(loop: AgentLoop) -> FastAPI:
         from src.agent.llm import LLMClient
         model = body.get("model") if "model" in body else None
         thinking = body.get("thinking") if "thinking" in body else None
+        max_tokens = body.get("max_tokens") if "max_tokens" in body else None
         internet = body.get("internet_access_enabled") if "internet_access_enabled" in body else None
         if "model" in body and (not isinstance(model, str) or not model):
             raise HTTPException(400, "model must be a non-empty string")
@@ -529,6 +530,14 @@ def create_agent_app(loop: AgentLoop) -> FastAPI:
             raise HTTPException(
                 400,
                 f"thinking must be one of: {sorted(LLMClient.VALID_THINKING_LEVELS)}",
+            )
+        if "max_tokens" in body and (
+            not isinstance(max_tokens, int)
+            or isinstance(max_tokens, bool)
+            or not (256 <= max_tokens <= 200_000)
+        ):
+            raise HTTPException(
+                400, "max_tokens must be an integer between 256 and 200000",
             )
         if "internet_access_enabled" in body and not isinstance(internet, bool):
             raise HTTPException(
@@ -542,6 +551,9 @@ def create_agent_app(loop: AgentLoop) -> FastAPI:
         if "thinking" in body:
             loop.llm.thinking = thinking
             updated["thinking"] = thinking
+        if "max_tokens" in body:
+            loop.llm.max_output_tokens = max_tokens
+            updated["max_tokens"] = max_tokens
         if "internet_access_enabled" in body:
             # Mesh-side push from the Operator Settings → Internet
             # access toggle. When False, hide http_request + web_search

--- a/src/host/credentials.py
+++ b/src/host/credentials.py
@@ -1565,7 +1565,7 @@ class CredentialVault:
         body: dict = {
             "model": model,
             "messages": converted,
-            "max_tokens": params.get("max_tokens", 4096),
+            "max_tokens": params.get("max_tokens", 8192),
         }
         if system_parts:
             body["system"] = "\n\n".join(system_parts)
@@ -1793,7 +1793,7 @@ class CredentialVault:
         sdk_kwargs: dict = {
             "model": body["model"],
             "messages": body["messages"],
-            "max_tokens": body.get("max_tokens", 4096),
+            "max_tokens": body.get("max_tokens", 8192),
             "stream": True,
         }
         if "system" in body:

--- a/tests/test_llm.py
+++ b/tests/test_llm.py
@@ -14,7 +14,7 @@ test pins the post-fix behavior: empty-response is now retryable.
 from __future__ import annotations
 
 import json
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -326,3 +326,45 @@ async def test_chat_stream_auth_failure_still_raises_auth_error():
             system="s", messages=[{"role": "user", "content": "x"}],
         ):
             pass
+
+
+def test_default_max_output_tokens_is_8192():
+    """The hardcoded 4096 cap was too small for large tool-call payloads."""
+    llm = LLMClient(mesh_url="http://mesh:8420", agent_id="a1")
+    assert llm.max_output_tokens == 8192
+
+
+def test_max_output_tokens_override():
+    llm = LLMClient(
+        mesh_url="http://mesh:8420", agent_id="a1", max_output_tokens=32000,
+    )
+    assert llm.max_output_tokens == 32000
+
+
+@pytest.mark.asyncio
+async def test_chat_uses_instance_max_tokens_default():
+    """chat() must send the instance max_output_tokens when caller omits it."""
+    llm = LLMClient(
+        mesh_url="http://mesh:8420", agent_id="a1", max_output_tokens=16384,
+    )
+    captured = {}
+
+    class _Resp:
+        def raise_for_status(self):
+            pass
+
+        def json(self):
+            return {
+                "success": True,
+                "data": {"content": "ok", "tool_calls": [], "tokens_used": 1,
+                         "model": "m"},
+            }
+
+    class _Client:
+        async def post(self, url, json=None, params=None, headers=None):
+            captured["max_tokens"] = json["params"]["max_tokens"]
+            return _Resp()
+
+    with patch.object(llm, "_get_client", AsyncMock(return_value=_Client())):
+        await llm.chat(system="s", messages=[{"role": "user", "content": "hi"}])
+    assert captured["max_tokens"] == 16384


### PR DESCRIPTION
## Problem

Agent tasks (e.g. `locale-translator` writing a translated ~15–20KB markdown file via `write_file`) failed permanently with:

```
Error: Truncated tool-call arguments for 'write_file': {"path": "...", "content": "---\ntitle: ...
```

Reproduced 5/5 in the production fleet on `src/content/comparison/pydantic-ai.md`; the same agent succeeds on smaller files. The variable is **payload size**, not agent logic.

## Root cause

`LLMClient.chat()` / `chat_stream()` defaulted `max_tokens=4096`, and **no caller in `loop.py` overrides it** (all 8 call sites pass no `max_tokens`). A tool call with a large argument payload needs well over 4096 output tokens just to emit the arguments JSON. The model hit the cap mid-tool-call → the streamed `input_json_delta` never closed → `_parse_tool_calls` got unterminated JSON → `LLMRetryableError("Truncated tool-call arguments")`. The cap is **deterministic**, so every retry truncated at the same boundary → permanent failure.

The streaming accumulator (`credentials.py`, accumulates `partial_json` to completion via the SDK context manager) and the truncation **detector** (`llm.py:_parse_tool_calls`) are both correct and unchanged. The only defect is the 4096 floor predating large-payload tools.

## Fix (surgical, 5 files / +81 −6)

- **`llm.py`** — add `LLMClient.max_output_tokens` (default **8192**); `chat`/`chat_stream` use it when the caller omits `max_tokens`. 8192 is the safe floor across common models (gpt-4o = 16384, Claude 3.5 Sonnet = 8192, Claude 4.x = 64K+).
- **`__main__.py`** — read `LLM_MAX_TOKENS` env (parsed + clamped 256..200000), mirroring how `THINKING` is already wired.
- **`server.py`** — hot-reload `max_tokens` via the existing `/config` endpoint (no restart), same validate-then-apply pattern as `model`/`thinking`.
- **`credentials.py`** — defense-in-depth: mesh proxy fallback `4096 → 8192` at both sites.
- **`test_llm.py`** — 3 new tests (default is 8192, ctor override, `chat()` sends the instance value).

## Why not a parser change

The original bug report hypothesized a streaming-accumulator / missing-completion-guard defect. Validated against the code, those guards **already exist and work correctly** — the deterministic 5/5 failure proves a fixed ceiling, not a flaky stream drop. The existing `LLMRetryableError` detection is retained as the correct safety net for genuine mid-flight drops (which *are* transient and benefit from retry).

## Caveat

8192 covers the reported file. A genuinely huge single write (100KB+) is a model output-length limit no parser fix can dodge — chunked writes or the streaming-body upload path remain the answer there. `LLM_MAX_TOKENS` + `/config` let operators lift the cap per-agent for legitimately large-payload agents.

## Test plan

- `pytest tests/test_llm.py` → all pass (incl. 3 new)
- Focused suite (`test_llm, test_loop, test_subagent, test_operator_config, test_costs, test_failover`) → **178 passed, 1 skipped**
- `ruff check` on all 5 files → clean