### PR TITLE
fix(lifecycle): revoke token and wipe data volume on agent delete

### DIFF
--- a/src/host/runtime.py
+++ b/src/host/runtime.py
@@ -823,24 +823,31 @@ class DockerBackend(RuntimeBackend):
             self.browser_service_url = None
 
     def stop_agent(self, agent_id: str, *, remove_data: bool = False) -> None:
+        safe_name = _docker_safe_name(agent_id)
         if agent_id in self.agents:
-            safe_name = _docker_safe_name(agent_id)
             try:
                 self.agents[agent_id]["container"].stop(timeout=10)
                 self.agents[agent_id]["container"].remove()
                 logger.info(f"Stopped agent '{agent_id}'")
             except Exception as e:
                 logger.warning(f"Error stopping agent '{agent_id}': {e}")
-            if remove_data:
-                try:
-                    vol = self.client.volumes.get(f"openlegion_data_{safe_name}")
-                    vol.remove(force=True)
-                    logger.info(f"Removed data volume for agent '{agent_id}'")
-                except Exception as e:
-                    logger.debug(f"Volume cleanup for '{agent_id}': {e}")
             del self.agents[agent_id]
             if hasattr(self, "auth_tokens"):
                 self.auth_tokens.pop(agent_id, None)
+        # Volume removal must be INDEPENDENT of live registration: the only
+        # supported delete path is archive→delete, and archive already
+        # deregistered the agent (removed it from self.agents), so gating the
+        # wipe on ``agent_id in self.agents`` would silently leave the /data
+        # volume behind on every real delete (H12). The container — if any —
+        # was already stopped/removed above (or during archive), so the volume
+        # is free to remove by name.
+        if remove_data:
+            try:
+                vol = self.client.volumes.get(f"openlegion_data_{safe_name}")
+                vol.remove(force=True)
+                logger.info(f"Removed data volume for agent '{agent_id}'")
+            except Exception as e:
+                logger.debug(f"Volume cleanup for '{agent_id}': {e}")
 
     def health_check(self, agent_id: str) -> bool:
         if agent_id not in self.agents:

--- a/src/host/runtime.py
+++ b/src/host/runtime.py
@@ -343,8 +343,6 @@ class DockerBackend(RuntimeBackend):
         thinking: str = "",
         env_overrides: dict[str, str] | None = None,
     ) -> str:
-        import docker as _docker
-
         with self._port_lock:
             port = self._next_port
             self._next_port += 1
@@ -356,6 +354,44 @@ class DockerBackend(RuntimeBackend):
         # to allow the cryptographic ``agent_id="operator"`` claim.
         auth_token = secrets.token_urlsafe(32)
         self.auth_tokens[agent_id] = auth_token
+
+        # M16: the token is registered BEFORE ``containers.run``. If start
+        # fails anywhere below, a still-valid mesh auth token would leak for
+        # an agent that never came up. Pop it on any failure and re-raise so
+        # the caller's error handling is unchanged. Only registry insertion
+        # on the success path keeps the token.
+        try:
+            return self._start_agent_container(
+                agent_id=agent_id,
+                role=role,
+                skills_dir=skills_dir,
+                port=port,
+                auth_token=auth_token,
+                system_prompt=system_prompt,
+                model=model,
+                mcp_servers=mcp_servers,
+                thinking=thinking,
+                env_overrides=env_overrides,
+            )
+        except Exception:
+            self.auth_tokens.pop(agent_id, None)
+            raise
+
+    def _start_agent_container(
+        self,
+        *,
+        agent_id: str,
+        role: str,
+        skills_dir: str | None,
+        port: int,
+        auth_token: str,
+        system_prompt: str,
+        model: str,
+        mcp_servers: list[dict] | None,
+        thinking: str,
+        env_overrides: dict[str, str] | None,
+    ) -> str:
+        import docker as _docker
 
         mesh_host = "127.0.0.1" if self.use_host_network else "host.docker.internal"
         environment: dict[str, str] = {

--- a/src/host/server.py
+++ b/src/host/server.py
@@ -872,6 +872,17 @@ def create_mesh_app(
         data, pub/sub subscriptions, lane workers, cron jobs, cost
         records, trace records, and wallet records.
         """
+        # H11: revoke the agent's mesh auth token and reload the in-memory
+        # ACL so a deleted agent can no longer authenticate or be permission-
+        # checked, even if the container stop (in stop_agent) threw before it
+        # could pop the token. ``permissions.reload()`` re-reads
+        # config/permissions.json, from which ``_remove_agent`` has already
+        # dropped this agent. Both are idempotent — safe on the teardown path.
+        _auth_tokens.pop(agent_id, None)
+        try:
+            permissions.reload()
+        except Exception as e:
+            logger.warning("permissions.reload() during cleanup of '%s' failed: %s", agent_id, e)
         suffix = f":{agent_id}"
         stale = [k for k in _rate_ts if k.endswith(suffix)]
         for k in stale:
@@ -6056,8 +6067,24 @@ def create_mesh_app(
             from src.cli.config import _load_config, _remove_agent
             if target_id not in _load_config().get("agents", {}):
                 raise HTTPException(404, f"Agent '{target_id}' no longer exists")
+            # H11/H12: stop the container through the runtime backend (not the
+            # raw-docker path inside ``_remove_agent``) so the agent's mesh
+            # auth token is popped (H11) AND its private ``openlegion_data_*``
+            # named volume is removed (H12). ``remove_data=True`` is the delete
+            # contract — archive deliberately calls ``stop_agent`` WITHOUT it
+            # so the volume survives for unarchive. ``_remove_agent`` is then
+            # called with ``stop_container=False`` so it only does config +
+            # permissions removal and never re-runs a token/volume-blind stop.
+            if container_manager is not None:
+                try:
+                    container_manager.stop_agent(target_id, remove_data=True)
+                except Exception as e:
+                    logger.warning(
+                        "stop_agent(%s, remove_data=True) failed during delete: %s",
+                        target_id, e,
+                    )
             try:
-                _remove_agent(target_id, stop_container=container_manager is not None)
+                _remove_agent(target_id, stop_container=False)
             except Exception as e:
                 raise HTTPException(500, f"Failed to delete agent: {e}")
             # Drop runtime state via cleanup_agent (rate buckets, vault,

--- a/tests/test_operator_product_tools.py
+++ b/tests/test_operator_product_tools.py
@@ -757,6 +757,83 @@ async def test_endpoint_archive_agent_then_delete(v2_app):
     assert body["deleted"] == "agent"
 
 
+@pytest.fixture
+def v2_app_cm(tmp_path, monkeypatch):
+    """Like ``v2_app`` but also yields the ``container_manager`` mock so a
+    test can assert how the lifecycle endpoints drive it (H11/H12)."""
+    pdir = _projects_layout(tmp_path)
+    afile = _agents_yaml(tmp_path, names=["scout", "analyst", "tracker"])
+    monkeypatch.chdir(tmp_path)
+    import src.cli.config as cli_cfg
+    monkeypatch.setattr(cli_cfg, "PROJECTS_DIR", pdir)
+    monkeypatch.setattr(cli_cfg, "AGENTS_FILE", afile)
+    monkeypatch.setattr(cli_cfg, "PERMISSIONS_FILE", tmp_path / "config" / "permissions.json")
+    server_module = _reload_server(
+        monkeypatch, v2=True, tasks_db=str(tmp_path / "tasks.db"),
+    )
+    perms_map = {
+        "operator": {"can_route_tasks": True, "can_manage_projects": True},
+        "scout":    {"can_route_tasks": True, "can_message": ["analyst", "operator"]},
+        "analyst":  {"can_route_tasks": False, "can_message": ["scout"]},
+        "tracker":  {"can_route_tasks": False, "can_message": []},
+    }
+    container_manager = MagicMock()
+    container_manager.stop_agent = MagicMock(return_value=True)
+    app, bb = _build_app(
+        tmp_path, server_module,
+        perms_map=perms_map,
+        agents={
+            "scout": "http://scout:8400",
+            "analyst": "http://analyst:8400",
+            "tracker": "http://tracker:8400",
+            "operator": "http://operator:8400",
+        },
+        container_manager=container_manager,
+    )
+    yield app, container_manager
+    bb.close()
+    monkeypatch.delenv("OPENLEGION_ORCHESTRATION_TASKS_DB", raising=False)
+    importlib.reload(server_module)
+
+
+@pytest.mark.asyncio
+async def test_delete_agent_removes_volume_archive_does_not(v2_app_cm):
+    """H11/H12: confirming an agent delete calls stop_agent(remove_data=True).
+
+    Archive must NOT remove the volume — it passes no remove_data, so the
+    default ``remove_data=False`` keeps the volume for unarchive.
+    """
+    app, container_manager = v2_app_cm
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
+        # Archive first (required before delete).
+        r = await c.post("/mesh/agents/scout/archive",
+                         headers={"X-Agent-ID": "operator"})
+        assert r.status_code == 200
+        # Archive stops the container WITHOUT removing the volume.
+        archive_calls = container_manager.stop_agent.call_args_list
+        assert archive_calls, "archive should have stopped the container"
+        # No archive call may request remove_data=True.
+        for call in archive_calls:
+            assert call.kwargs.get("remove_data", False) is False
+
+        container_manager.stop_agent.reset_mock()
+
+        # Propose + confirm delete.
+        r = await c.post("/mesh/agents/scout/propose-delete",
+                         headers=_human_origin_headers())
+        assert r.status_code == 200, r.text
+        body = r.json()
+        r = await c.post("/mesh/config/confirm",
+                         json={"change_id": body["change_id"],
+                               "payload_digest": body["payload_digest"]},
+                         headers=_human_origin_headers())
+    assert r.status_code == 200
+    assert r.json()["deleted"] == "agent"
+    # H11/H12: delete routes through stop_agent with remove_data=True so the
+    # token is popped AND the private data volume is wiped.
+    container_manager.stop_agent.assert_called_once_with("scout", remove_data=True)
+
+
 @pytest.mark.asyncio
 async def test_endpoint_delete_agent_requires_archive_first(v2_app):
     app, _, _ = v2_app

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -78,6 +78,25 @@ class TestDockerBackendLifecycle:
         vol.remove.assert_called_once_with(force=True)
         assert "alpha" not in backend.agents
 
+    def test_delete_wipes_volume_for_deregistered_agent(self):
+        """H12: archive→delete is the only delete path, and archive already
+        deregistered the agent, so deleting a NOT-in-registry agent must STILL
+        wipe its /data volume (the wipe is independent of live registration)."""
+        backend = self._make_backend()
+        # "ghost" is NOT in backend.agents — simulates an already-archived /
+        # deregistered agent being deleted.
+        assert "ghost" not in backend.agents
+        vol = MagicMock()
+        backend.client.volumes.get.return_value = vol
+
+        backend.stop_agent("ghost", remove_data=True)
+
+        # The volume is wiped by name even though the agent was deregistered.
+        backend.client.volumes.get.assert_called_once_with(
+            f"openlegion_data_{_docker_safe_name('ghost')}",
+        )
+        vol.remove.assert_called_once_with(force=True)
+
     def test_archive_keeps_volume_but_pops_token(self):
         """Archive uses remove_data=False (default): volume RETAINED for unarchive."""
         backend = self._make_backend()

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -46,6 +46,81 @@ class TestDockerBackend:
         assert DockerBackend.backend_name() == "docker"
 
 
+# ── Agent lifecycle: delete vs archive token/volume semantics ──
+#
+# Security findings H11 (token revocation on delete), H12 (data volume
+# wipe on delete) and M16 (token leak on failed mid-creation).
+
+class TestDockerBackendLifecycle:
+    def _make_backend(self) -> DockerBackend:
+        backend = DockerBackend.__new__(DockerBackend)
+        backend.agents = {}
+        backend.auth_tokens = {}
+        backend.client = MagicMock()
+        return backend
+
+    def test_delete_pops_token_and_removes_volume(self):
+        """H11+H12: stop_agent(remove_data=True) revokes token + wipes volume."""
+        backend = self._make_backend()
+        backend.agents["alpha"] = {"container": MagicMock()}
+        backend.auth_tokens["alpha"] = "secret-token"
+        vol = MagicMock()
+        backend.client.volumes.get.return_value = vol
+
+        backend.stop_agent("alpha", remove_data=True)
+
+        # H11: token revoked.
+        assert "alpha" not in backend.auth_tokens
+        # H12: the agent's private named volume was removed.
+        backend.client.volumes.get.assert_called_once_with(
+            f"openlegion_data_{_docker_safe_name('alpha')}",
+        )
+        vol.remove.assert_called_once_with(force=True)
+        assert "alpha" not in backend.agents
+
+    def test_archive_keeps_volume_but_pops_token(self):
+        """Archive uses remove_data=False (default): volume RETAINED for unarchive."""
+        backend = self._make_backend()
+        backend.agents["beta"] = {"container": MagicMock()}
+        backend.auth_tokens["beta"] = "secret-token"
+
+        # Default remove_data=False — the archive contract.
+        backend.stop_agent("beta")
+
+        # Token still gets popped (archive already revoked it; that's fine).
+        assert "beta" not in backend.auth_tokens
+        # CRITICAL: volume must NOT be touched on archive.
+        backend.client.volumes.get.assert_not_called()
+        assert "beta" not in backend.agents
+
+    def test_start_agent_failure_pops_token(self):
+        """M16: a failed containers.run must not leak a registered auth token."""
+        backend = self._make_backend()
+        backend.auth_tokens = {}
+        backend.agents = {}
+        backend._port_lock = __import__("threading").Lock()
+        backend._next_port = 8400
+        backend.use_host_network = True
+        backend.mesh_host_port = 8420
+        backend.extra_env = {}
+        backend.uploads_dir = __import__("pathlib").Path("/tmp/uploads")
+        backend.project_root = __import__("pathlib").Path("/tmp/proj")
+        backend.BASE_IMAGE = "test-image"
+        backend._network_name = "openlegion_agents"
+        # containers.run raises mid-creation, after the token is registered.
+        backend.client.containers.get.side_effect = __import__(
+            "docker",
+        ).errors.NotFound("no stale")
+        backend.client.containers.run.side_effect = RuntimeError("boom")
+
+        with pytest.raises(RuntimeError, match="boom"):
+            backend.start_agent("gamma", "worker", "")
+
+        # Token must have been popped on the failure path.
+        assert "gamma" not in backend.auth_tokens
+        assert "gamma" not in backend.agents
+
+
 # ── SandboxBackend ────────────────────────────────────────────
 
 class TestSandboxBackend:


### PR DESCRIPTION
## Summary

May 2026 security remediation — findings **H11**, **H12**, **M16** (L13 skipped, see below). When an agent is **deleted**, the system must revoke its mesh auth token, remove its private `/data` named volume, and reload permissions; and a **failed mid-creation** must not leak a still-valid token. **Archive is deliberately unchanged** — it retains the volume for unarchive and already revokes the token.

## Changes

- **H11 + H12 — delete now revokes token + wipes volume** (`src/host/server.py`, `_apply_pending_delete` agent branch): routes the container stop through `container_manager.stop_agent(target_id, remove_data=True)` (pops the auth token AND removes the `openlegion_data_*` named volume), then calls `_remove_agent(stop_container=False)` for config/permissions removal only — instead of `_remove_agent`'s raw `docker.from_env()` stop that missed both.
- **H11 — defense-in-depth in `_cleanup_agent`** (`src/host/server.py`): pops the token from `_auth_tokens` and calls `permissions.reload()`, so token + in-memory ACL are revoked even if the container stop throws.
- **M16 — failed `start_agent` no longer leaks a token** (`src/host/runtime.py`): the post-token-registration body is wrapped so any failure (e.g. `containers.run` raising) pops `self.auth_tokens[agent_id]` and re-raises. Success path unchanged.

## Archive preserved

`archive_agent_endpoint` still calls `stop_agent(agent_id)` with no `remove_data`, so the default `remove_data=False` **retains the volume** for unarchive; it already revoked the token. A new test asserts archive does NOT remove the volume while delete does.

## L13 (optional) — skipped

No clean browser session-stop endpoint is reachable from the delete path (only per-action HTTP routes). The display self-heals via the browser service's 30-min idle reaper, so this was intentionally not implemented to avoid over-engineering.

## Tests

- `tests/test_runtime.py`: delete pops token + removes volume; archive keeps volume (but pops token); failed `start_agent` pops token. (114 passed)
- `tests/test_operator_product_tools.py`: end-to-end archive→propose→confirm delete asserts `stop_agent("scout", remove_data=True)` is called and archive uses no `remove_data`. (57 passed)

> Note: may need rebasing against an in-flight refactor.