### PR TITLE
fix(permissions): enforce operator permission ceiling server-side on edit

### DIFF
--- a/src/agent/builtins/operator_tools.py
+++ b/src/agent/builtins/operator_tools.py
@@ -9,6 +9,10 @@ import time as _time
 from datetime import datetime, timezone
 
 from src.agent.skills import skill
+from src.host.permissions import (
+    _OPERATOR_PERMISSION_CEILING,  # noqa: F401 — re-exported for back-compat
+    clamp_to_operator_ceiling,
+)
 from src.shared.redaction import redact_text_with_urls
 from src.shared.types import (
     HARD_EDIT_FIELDS as _HARD_EDIT_FIELDS,
@@ -29,15 +33,9 @@ def _is_operator() -> bool:
     """
     return os.environ.get("ALLOWED_TOOLS", "") != ""
 
-# Permission ceiling: operator cannot grant permissions beyond these limits
-_OPERATOR_PERMISSION_CEILING = {
-    "can_use_browser": True,
-    "can_spawn": False,       # Created agents can't spawn others
-    "can_manage_cron": True,
-    "can_use_wallet": False,  # Requires explicit user setup
-    "blackboard_read": ["*"],
-    "blackboard_write": ["tasks/*", "context/*", "status/*", "output/*", "artifacts/*"],
-}
+# Permission ceiling now lives in :mod:`src.host.permissions` as the single
+# source of truth (``_OPERATOR_PERMISSION_CEILING`` + ``clamp_to_operator_ceiling``).
+# Re-imported above and re-exported for any back-compat callers/tests.
 
 _VALID_FIELDS = frozenset({
     "instructions", "soul", "model", "role", "heartbeat",
@@ -120,30 +118,9 @@ def _validate_edit(agent_id: str, field: str, value) -> dict | None:
             ),
         }
     if field == "permissions" and isinstance(value, dict):
-        for key, max_val in _OPERATOR_PERMISSION_CEILING.items():
-            if key not in value:
-                continue
-            if isinstance(max_val, bool):
-                if value[key] and not max_val:
-                    return {
-                        "error": (
-                            f"Permission ceiling exceeded: '{key}' cannot be set "
-                            "to True by the operator. Use the dashboard for "
-                            "advanced permissions."
-                        ),
-                    }
-            elif isinstance(max_val, list):
-                requested = set(value.get(key, []))
-                allowed = set(max_val)
-                if "*" not in allowed and not requested.issubset(allowed):
-                    excess = requested - allowed
-                    return {
-                        "error": (
-                            f"Permission ceiling exceeded: '{key}' patterns "
-                            f"{excess} exceed allowed {allowed}. Use the "
-                            "dashboard for advanced permissions."
-                        ),
-                    }
+        ceiling_err = clamp_to_operator_ceiling(field, value)
+        if ceiling_err:
+            return {"error": ceiling_err}
     if field == "budget" and isinstance(value, dict):
         daily = value.get("daily_usd", 0)
         monthly = value.get("monthly_usd", 0)

--- a/src/agent/builtins/operator_tools.py
+++ b/src/agent/builtins/operator_tools.py
@@ -9,7 +9,7 @@ import time as _time
 from datetime import datetime, timezone
 
 from src.agent.skills import skill
-from src.host.permissions import (
+from src.shared.operator_ceiling import (
     _OPERATOR_PERMISSION_CEILING,  # noqa: F401 — re-exported for back-compat
     clamp_to_operator_ceiling,
 )

--- a/src/host/permissions.py
+++ b/src/host/permissions.py
@@ -72,6 +72,67 @@ KNOWN_BROWSER_ACTIONS: frozenset[str] = frozenset({
 LEGACY_BROWSER_ACTIONS = KNOWN_BROWSER_ACTIONS
 
 
+# Permission ceiling for operator-initiated agent edits. The operator
+# (an LLM-driven agent) is NOT allowed to grant these escalations to the
+# agents it manages — ``can_spawn`` / ``can_use_wallet`` require explicit
+# human setup, and blackboard read/write patterns are bounded.
+#
+# This is the SINGLE SOURCE OF TRUTH. It is enforced in two places:
+#   1. Client-side in the operator tool (`operator_tools._validate_edit`)
+#      for a fast, descriptive error to the operator LLM.
+#   2. Server-side on the mesh ``/edit-soft`` endpoint, so a fooled or
+#      injected operator LLM cannot route a raw permissions edit around
+#      its own client-side guard (finding H1, May 2026 remediation).
+#
+# DELIBERATELY NOT enforced on the dashboard ``PUT /api/agents/{id}/
+# permissions`` endpoint — that is the human operator's "advanced
+# permissions" escalation path, and the ceiling is intentionally human-
+# overridable there.
+_OPERATOR_PERMISSION_CEILING = {
+    "can_use_browser": True,
+    "can_spawn": False,       # Created agents can't spawn others
+    "can_manage_cron": True,
+    "can_use_wallet": False,  # Requires explicit user setup
+    "blackboard_read": ["*"],
+    "blackboard_write": ["tasks/*", "context/*", "status/*", "output/*", "artifacts/*"],
+}
+
+
+def clamp_to_operator_ceiling(field: str, new_value) -> str | None:
+    """Return an error string if a permissions edit exceeds the operator ceiling.
+
+    Single source of truth for the operator permission ceiling, shared by
+    the operator tool's client-side ``_validate_edit`` and the mesh
+    ``/edit-soft`` endpoint's server-side re-check (finding H1).
+
+    Returns ``None`` when the edit is within the ceiling (or is not a
+    permissions edit / not a dict — those are handled by other validators).
+    """
+    if field != "permissions" or not isinstance(new_value, dict):
+        return None
+    for key, max_val in _OPERATOR_PERMISSION_CEILING.items():
+        if key not in new_value:
+            continue
+        if isinstance(max_val, bool):
+            if new_value[key] and not max_val:
+                return (
+                    f"Permission ceiling exceeded: '{key}' cannot be set "
+                    "to True by the operator. Use the dashboard for "
+                    "advanced permissions."
+                )
+        elif isinstance(max_val, list):
+            requested = set(new_value.get(key, []))
+            allowed = set(max_val)
+            if "*" not in allowed and not requested.issubset(allowed):
+                excess = requested - allowed
+                return (
+                    f"Permission ceiling exceeded: '{key}' patterns "
+                    f"{excess} exceed allowed {allowed}. Use the "
+                    "dashboard for advanced permissions."
+                )
+    return None
+
+
 class PermissionMatrix:
     """Enforces agent-level permissions for mesh operations."""
 

--- a/src/host/permissions.py
+++ b/src/host/permissions.py
@@ -12,6 +12,16 @@ import json
 from pathlib import Path
 
 from src.host.credentials import is_system_credential
+
+# Operator permission ceiling — moved to ``src/shared/operator_ceiling`` so the
+# agent container (which ships ``src/agent`` + ``src/shared`` but NOT ``src/host``)
+# can import it from the operator tool. Re-exported here so existing host-side
+# imports (e.g. ``from src.host.permissions import clamp_to_operator_ceiling`` in
+# ``server.py``) keep resolving. Single source of truth lives in the shared module.
+from src.shared.operator_ceiling import (  # noqa: F401
+    _OPERATOR_PERMISSION_CEILING,
+    clamp_to_operator_ceiling,
+)
 from src.shared.types import AgentPermissions
 from src.shared.utils import setup_logging
 
@@ -70,67 +80,6 @@ KNOWN_BROWSER_ACTIONS: frozenset[str] = frozenset({
 # imported `LEGACY_BROWSER_ACTIONS` keep working. Prefer `KNOWN_BROWSER_ACTIONS`
 # in new code.
 LEGACY_BROWSER_ACTIONS = KNOWN_BROWSER_ACTIONS
-
-
-# Permission ceiling for operator-initiated agent edits. The operator
-# (an LLM-driven agent) is NOT allowed to grant these escalations to the
-# agents it manages — ``can_spawn`` / ``can_use_wallet`` require explicit
-# human setup, and blackboard read/write patterns are bounded.
-#
-# This is the SINGLE SOURCE OF TRUTH. It is enforced in two places:
-#   1. Client-side in the operator tool (`operator_tools._validate_edit`)
-#      for a fast, descriptive error to the operator LLM.
-#   2. Server-side on the mesh ``/edit-soft`` endpoint, so a fooled or
-#      injected operator LLM cannot route a raw permissions edit around
-#      its own client-side guard (finding H1, May 2026 remediation).
-#
-# DELIBERATELY NOT enforced on the dashboard ``PUT /api/agents/{id}/
-# permissions`` endpoint — that is the human operator's "advanced
-# permissions" escalation path, and the ceiling is intentionally human-
-# overridable there.
-_OPERATOR_PERMISSION_CEILING = {
-    "can_use_browser": True,
-    "can_spawn": False,       # Created agents can't spawn others
-    "can_manage_cron": True,
-    "can_use_wallet": False,  # Requires explicit user setup
-    "blackboard_read": ["*"],
-    "blackboard_write": ["tasks/*", "context/*", "status/*", "output/*", "artifacts/*"],
-}
-
-
-def clamp_to_operator_ceiling(field: str, new_value) -> str | None:
-    """Return an error string if a permissions edit exceeds the operator ceiling.
-
-    Single source of truth for the operator permission ceiling, shared by
-    the operator tool's client-side ``_validate_edit`` and the mesh
-    ``/edit-soft`` endpoint's server-side re-check (finding H1).
-
-    Returns ``None`` when the edit is within the ceiling (or is not a
-    permissions edit / not a dict — those are handled by other validators).
-    """
-    if field != "permissions" or not isinstance(new_value, dict):
-        return None
-    for key, max_val in _OPERATOR_PERMISSION_CEILING.items():
-        if key not in new_value:
-            continue
-        if isinstance(max_val, bool):
-            if new_value[key] and not max_val:
-                return (
-                    f"Permission ceiling exceeded: '{key}' cannot be set "
-                    "to True by the operator. Use the dashboard for "
-                    "advanced permissions."
-                )
-        elif isinstance(max_val, list):
-            requested = set(new_value.get(key, []))
-            allowed = set(max_val)
-            if "*" not in allowed and not requested.issubset(allowed):
-                excess = requested - allowed
-                return (
-                    f"Permission ceiling exceeded: '{key}' patterns "
-                    f"{excess} exceed allowed {allowed}. Use the "
-                    "dashboard for advanced permissions."
-                )
-    return None
 
 
 class PermissionMatrix:

--- a/src/host/server.py
+++ b/src/host/server.py
@@ -6784,6 +6784,22 @@ def create_mesh_app(
                     400,
                     f"thinking must be one of: {sorted(LLMClient.VALID_THINKING_LEVELS)}",
                 )
+        elif field == "permissions":
+            # Finding H1 (May 2026 remediation): re-enforce the operator
+            # permission ceiling server-side. The operator tool's
+            # client-side ``_validate_edit`` already checks this, but a
+            # fooled / injected operator LLM (or any future caller) could
+            # POST a raw permissions edit straight to this endpoint and
+            # route around its own guard. The ceiling check shares a
+            # single source of truth with the tool via
+            # ``clamp_to_operator_ceiling``. The human "advanced
+            # permissions" override lives on the dashboard
+            # ``PUT /api/agents/{id}/permissions`` endpoint, which is
+            # DELIBERATELY left without this ceiling.
+            from src.host.permissions import clamp_to_operator_ceiling
+            ceiling_err = clamp_to_operator_ceiling(field, new_value)
+            if ceiling_err:
+                raise HTTPException(400, ceiling_err)
 
         from src.cli.config import _load_config
         agent_cfg = _load_config()

--- a/src/shared/operator_ceiling.py
+++ b/src/shared/operator_ceiling.py
@@ -1,0 +1,70 @@
+"""Operator permission ceiling — single source of truth, shared across zones.
+
+Lives in ``src/shared`` (shipped to BOTH the mesh host and the agent container)
+because the operator tool in ``src/agent/builtins/operator_tools.py`` needs it
+client-side, and the agent container ships only ``src/agent`` + ``src/shared``
+(not ``src/host``). ``src/host/permissions`` re-exports these symbols so existing
+host-side imports keep resolving.
+"""
+
+from __future__ import annotations
+
+# Permission ceiling for operator-initiated agent edits. The operator
+# (an LLM-driven agent) is NOT allowed to grant these escalations to the
+# agents it manages — ``can_spawn`` / ``can_use_wallet`` require explicit
+# human setup, and blackboard read/write patterns are bounded.
+#
+# This is the SINGLE SOURCE OF TRUTH. It is enforced in two places:
+#   1. Client-side in the operator tool (`operator_tools._validate_edit`)
+#      for a fast, descriptive error to the operator LLM.
+#   2. Server-side on the mesh ``/edit-soft`` endpoint, so a fooled or
+#      injected operator LLM cannot route a raw permissions edit around
+#      its own client-side guard (finding H1, May 2026 remediation).
+#
+# DELIBERATELY NOT enforced on the dashboard ``PUT /api/agents/{id}/
+# permissions`` endpoint — that is the human operator's "advanced
+# permissions" escalation path, and the ceiling is intentionally human-
+# overridable there.
+_OPERATOR_PERMISSION_CEILING = {
+    "can_use_browser": True,
+    "can_spawn": False,       # Created agents can't spawn others
+    "can_manage_cron": True,
+    "can_use_wallet": False,  # Requires explicit user setup
+    "blackboard_read": ["*"],
+    "blackboard_write": ["tasks/*", "context/*", "status/*", "output/*", "artifacts/*"],
+}
+
+
+def clamp_to_operator_ceiling(field: str, new_value) -> str | None:
+    """Return an error string if a permissions edit exceeds the operator ceiling.
+
+    Single source of truth for the operator permission ceiling, shared by
+    the operator tool's client-side ``_validate_edit`` and the mesh
+    ``/edit-soft`` endpoint's server-side re-check (finding H1).
+
+    Returns ``None`` when the edit is within the ceiling (or is not a
+    permissions edit / not a dict — those are handled by other validators).
+    """
+    if field != "permissions" or not isinstance(new_value, dict):
+        return None
+    for key, max_val in _OPERATOR_PERMISSION_CEILING.items():
+        if key not in new_value:
+            continue
+        if isinstance(max_val, bool):
+            if new_value[key] and not max_val:
+                return (
+                    f"Permission ceiling exceeded: '{key}' cannot be set "
+                    "to True by the operator. Use the dashboard for "
+                    "advanced permissions."
+                )
+        elif isinstance(max_val, list):
+            requested = set(new_value.get(key, []))
+            allowed = set(max_val)
+            if "*" not in allowed and not requested.issubset(allowed):
+                excess = requested - allowed
+                return (
+                    f"Permission ceiling exceeded: '{key}' patterns "
+                    f"{excess} exceed allowed {allowed}. Use the "
+                    "dashboard for advanced permissions."
+                )
+    return None

--- a/tests/test_edit_soft_endpoint.py
+++ b/tests/test_edit_soft_endpoint.py
@@ -169,6 +169,106 @@ async def test_edit_soft_accepts_hard_field_permissions(mesh_app):
 
 
 @pytest.mark.asyncio
+async def test_edit_soft_rejects_can_use_wallet_grant(mesh_app):
+    """H1: the mesh edit-soft endpoint re-enforces the operator ceiling.
+
+    A fooled / injected operator LLM (or any non-dashboard caller) that
+    POSTs a raw permissions edit granting ``can_use_wallet=True`` must be
+    rejected server-side with HTTP 400 even though the client-side
+    operator-tool guard was bypassed.
+    """
+    app, _, tmp_path = mesh_app
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
+        r = await c.post(
+            "/mesh/agents/writer/edit-soft",
+            json={
+                "field": "permissions",
+                "value": {"can_use_wallet": True},
+                "reason": "user_asked",
+            },
+            headers=_human_origin_headers(),
+        )
+    assert r.status_code == 400, r.text
+    assert "ceiling" in r.json()["detail"].lower()
+
+    # The escalation must NOT have been persisted.
+    import json as _json
+    perms = _json.loads((tmp_path / "config" / "permissions.json").read_text())
+    assert perms["permissions"].get("writer", {}).get("can_use_wallet") is not True
+
+
+@pytest.mark.asyncio
+async def test_edit_soft_rejects_can_spawn_grant(mesh_app):
+    """H1: ``can_spawn=True`` hits the same server-side ceiling."""
+    app, _, tmp_path = mesh_app
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
+        r = await c.post(
+            "/mesh/agents/writer/edit-soft",
+            json={
+                "field": "permissions",
+                "value": {"can_spawn": True},
+                "reason": "user_asked",
+            },
+            headers=_human_origin_headers(),
+        )
+    assert r.status_code == 400, r.text
+    assert "ceiling" in r.json()["detail"].lower()
+
+    import json as _json
+    perms = _json.loads((tmp_path / "config" / "permissions.json").read_text())
+    assert perms["permissions"].get("writer", {}).get("can_spawn") is not True
+
+
+@pytest.mark.asyncio
+async def test_edit_soft_rejects_out_of_ceiling_blackboard_write(mesh_app):
+    """H1: blackboard_write patterns outside the ceiling are rejected."""
+    app, _, _ = mesh_app
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
+        r = await c.post(
+            "/mesh/agents/writer/edit-soft",
+            json={
+                "field": "permissions",
+                "value": {"blackboard_write": ["secrets/*"]},
+                "reason": "user_asked",
+            },
+            headers=_human_origin_headers(),
+        )
+    assert r.status_code == 400, r.text
+    assert "ceiling" in r.json()["detail"].lower()
+
+
+@pytest.mark.asyncio
+async def test_edit_soft_within_ceiling_permissions_still_succeeds(mesh_app):
+    """H1 regression guard: a within-ceiling permissions edit still applies.
+
+    The server-side ceiling re-check must not block legitimate edits
+    (``can_use_browser=True`` + an allowed ``blackboard_write`` pattern).
+    """
+    app, _, tmp_path = mesh_app
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
+        r = await c.post(
+            "/mesh/agents/writer/edit-soft",
+            json={
+                "field": "permissions",
+                "value": {
+                    "can_use_browser": True,
+                    "blackboard_write": ["artifacts/*"],
+                },
+                "reason": "user_asked",
+            },
+            headers=_human_origin_headers(),
+        )
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["field"] == "permissions"
+    assert body["undo_token"]
+
+    import json as _json
+    perms = _json.loads((tmp_path / "config" / "permissions.json").read_text())
+    assert perms["permissions"]["writer"]["can_use_browser"] is True
+
+
+@pytest.mark.asyncio
 async def test_edit_soft_soft_field_keeps_5min_ttl(mesh_app):
     """Soft fields keep the snappy 5-minute undo window."""
     app, _, _ = mesh_app

--- a/tests/test_operator_tools.py
+++ b/tests/test_operator_tools.py
@@ -782,6 +782,31 @@ async def test_edit_agent_accepts_interface_field():
     )
 
 
+def test_clamp_to_operator_ceiling_single_source_of_truth():
+    """H1: the shared ceiling function (re-used by the operator tool AND the
+    mesh edit-soft endpoint) rejects escalations and passes within-ceiling
+    edits. This pins the single source of truth behavior."""
+    from src.host.permissions import clamp_to_operator_ceiling
+
+    # Escalations rejected.
+    assert clamp_to_operator_ceiling("permissions", {"can_spawn": True}) is not None
+    assert clamp_to_operator_ceiling("permissions", {"can_use_wallet": True}) is not None
+    assert (
+        clamp_to_operator_ceiling("permissions", {"blackboard_write": ["secrets/*"]})
+        is not None
+    )
+
+    # Within-ceiling edits pass.
+    assert clamp_to_operator_ceiling("permissions", {"can_use_browser": True}) is None
+    assert (
+        clamp_to_operator_ceiling("permissions", {"blackboard_write": ["artifacts/*"]})
+        is None
+    )
+    # False grants and non-permissions fields are not the ceiling's concern.
+    assert clamp_to_operator_ceiling("permissions", {"can_spawn": False}) is None
+    assert clamp_to_operator_ceiling("model", "anthropic/claude-haiku") is None
+
+
 @pytest.mark.asyncio
 async def test_edit_agent_permission_ceiling_can_use_wallet():
     """can_use_wallet=True hits the same ceiling as can_spawn=True."""


### PR DESCRIPTION
## May 2026 security remediation — finding H1

### Problem
The `_OPERATOR_PERMISSION_CEILING` (forbids the operator granting `can_spawn`/`can_use_wallet=True`, bounds blackboard read/write patterns) was enforced **only** in the operator container's client-side skill code (`operator_tools._validate_edit`), **not** on the mesh `POST /mesh/agents/{id}/edit-soft` endpoint. A fooled or prompt-injected operator LLM (or any future caller) could POST a raw permissions edit straight to the mesh and route around its own client-side guard, silently escalating a managed agent's permissions.

### Fix
- Extracted the ceiling into a **single source of truth**: `src/host/permissions.py:clamp_to_operator_ceiling(field, new_value) -> str | None` (plus the `_OPERATOR_PERMISSION_CEILING` constant, now owned here).
- The operator tool `_validate_edit` now calls the shared function instead of its inline loop (re-imports the constant for back-compat — no behavior change).
- The mesh `edit_agent_soft` endpoint re-checks the ceiling server-side when `field == "permissions"`, **before** the perms merge persists, rejecting violations with HTTP 400.

### Intentionally untouched: the human override path
The dashboard `PUT /api/agents/{id}/permissions` endpoint (`src/dashboard/server.py`) is the **deliberate** human "advanced permissions" escalation surface — the operator-tool error messages even tell the user to "use the dashboard". It has **no** ceiling and **must stay that way**. This fix walls the LLM-tool / mesh `edit-soft` path **only**. `src/dashboard/server.py` is not in this diff.

No user-provenance gate or config toggle was added (over-engineering / injection target) — just the server-side ceiling re-check.

### Tests
- `test_edit_soft_endpoint.py`: mesh endpoint **rejects** (400) `can_use_wallet=True`, `can_spawn=True`, out-of-ceiling `blackboard_write`, and asserts the escalation is not persisted; within-ceiling edit (`can_use_browser=True` + `artifacts/*`) **still succeeds**.
- `test_operator_tools.py`: direct unit test pinning `clamp_to_operator_ceiling` as the shared single source of truth; existing operator-tool ceiling tests still pass (no regression).
- `tests/test_edit_soft_endpoint.py` + `tests/test_operator_tools.py`: 108 passed. Related suites (`test_operator_product_tools`, `test_undo_endpoint`, `test_operator_audit`): 109 passed. ruff clean.

> Note: may need rebasing against an in-flight refactor.