### PR TITLE
fix(http): enforce request body-size limit on mesh and agent servers

### DIFF
--- a/src/agent/server.py
+++ b/src/agent/server.py
@@ -51,6 +51,95 @@ if TYPE_CHECKING:
 
 logger = setup_logging("agent.server")
 
+
+def _max_body_bytes() -> int:
+    """Resolve the request body-size cap (env-configurable, default 8 MiB).
+
+    Mirrors the browser service cap. Anything larger than this is either
+    operator error or a memory-DoS attempt against the JSON parser — an
+    unbounded body is buffered into RAM before parsing, so a multi-GB POST
+    from an authenticated agent could OOM the single agent process. Env
+    override ``OPENLEGION_MAX_BODY_MB`` (default 8).
+    """
+    try:
+        mb = float(os.environ.get("OPENLEGION_MAX_BODY_MB", "8"))
+    except ValueError:
+        mb = 8.0
+    if mb <= 0:
+        mb = 8.0
+    return int(mb * 1024 * 1024)
+
+
+def _install_body_size_limit(app: FastAPI) -> None:
+    """Register an outer HTTP middleware that rejects oversized bodies.
+
+    Two layers of defence:
+      1. ``Content-Length`` header check — cheap, rejects honest clients early.
+      2. Streaming byte counter — a client can omit Content-Length (chunked
+         transfer) to bypass the header check, so we also wrap the ASGI
+         receive channel and abort with HTTP 413 the moment the streamed body
+         exceeds the cap, before the whole body is buffered into RAM.
+
+    This is an outer middleware: it runs before routing and does not strip
+    headers, so it does not interfere with downstream auth / CSRF
+    dependencies.
+    """
+    from starlette.responses import JSONResponse as _StarletteJSONResponse
+
+    @app.middleware("http")
+    async def _enforce_body_size(request: Request, call_next):
+        max_bytes = _max_body_bytes()
+        cl = request.headers.get("content-length")
+        if cl is not None:
+            try:
+                size = int(cl)
+            except ValueError:
+                return _StarletteJSONResponse(
+                    {"detail": "invalid Content-Length"}, status_code=400,
+                )
+            if size > max_bytes:
+                return _StarletteJSONResponse(
+                    {"detail": "request body too large"}, status_code=413,
+                )
+
+        # Streaming guard for chunked / Content-Length-absent bodies: a
+        # client can omit Content-Length to bypass the header check, so we
+        # drain the ASGI receive channel here with a running byte counter and
+        # bail out the moment the cap is exceeded — the endpoint is never
+        # invoked and at most ``max_bytes`` ever lands in RAM. Buffered
+        # messages are then replayed to the handler unchanged so routing /
+        # auth / CSRF dependencies see the body exactly as sent.
+        original_receive = request._receive
+        received = 0
+        buffered: list[dict] = []
+        while True:
+            message = await original_receive()
+            buffered.append(message)
+            if message["type"] != "http.request":
+                # http.disconnect or other — stop draining, replay as-is.
+                break
+            received += len(message.get("body", b""))
+            if received > max_bytes:
+                return _StarletteJSONResponse(
+                    {"detail": "request body too large"}, status_code=413,
+                )
+            if not message.get("more_body", False):
+                break
+
+        _replay = iter(buffered)
+
+        async def _replay_receive():
+            try:
+                return next(_replay)
+            except StopIteration:
+                # Body fully consumed; defer to the live channel for any
+                # trailing http.disconnect.
+                return await original_receive()
+
+        request._receive = _replay_receive
+        return await call_next(request)
+
+
 _MAX_HISTORY_MEMORY_CHARS = 5000
 _MAX_HISTORY_LOGS_CHARS = 16000
 _MAX_HISTORY_LEARNINGS_CHARS = 8000
@@ -76,6 +165,7 @@ def _origin_from_mesh_request(request: Request):
 def create_agent_app(loop: AgentLoop) -> FastAPI:
     """Create the FastAPI application for an agent container."""
     app = FastAPI(title=f"OpenLegion Agent: {loop.agent_id}")
+    _install_body_size_limit(app)
     _task_accept_lock = asyncio.Lock()
 
     @app.post("/task")

--- a/src/host/server.py
+++ b/src/host/server.py
@@ -88,10 +88,11 @@ def _max_body_bytes() -> int:
 # with its own counter, but /dashboard/api/uploads does ``await request.body()``
 # (buffers the whole body before its len() check), so a full exemption would
 # reopen an OOM via that route. Matched by path prefix against request.url.path.
-_UPLOAD_ROUTE_PREFIXES: tuple[str, ...] = (
-    "/dashboard/api/uploads/",   # dashboard file uploads (route cap 50 MB; BUFFERS body)
-    "/mesh/browser/upload-stage",  # agent->browser upload staging (route cap 50 MB; streams)
-)
+# Exact-match the fixed staging route (no path param) — a prefix would also
+# match an unrelated future ``/mesh/browser/upload-stage*`` route. Prefix-match
+# the dashboard uploads subtree (it has a ``{name:path}`` param).
+_UPLOAD_ROUTE_EXACT: str = "/mesh/browser/upload-stage"  # agent->browser upload staging (route cap 50 MB; streams)
+_UPLOAD_ROUTE_PREFIX: str = "/dashboard/api/uploads/"    # dashboard file uploads (route cap 50 MB; BUFFERS body)
 
 
 def _upload_route_max_bytes() -> int:
@@ -110,7 +111,7 @@ def _upload_route_max_bytes() -> int:
 def _body_cap_for_path(path: str) -> int:
     """Per-route body cap: the higher upload cap for upload routes, else the
     global cap. Never returns "unlimited" — every route keeps an OOM backstop."""
-    if path.startswith(_UPLOAD_ROUTE_PREFIXES):
+    if path == _UPLOAD_ROUTE_EXACT or path.startswith(_UPLOAD_ROUTE_PREFIX):
         return _upload_route_max_bytes()
     return _max_body_bytes()
 

--- a/src/host/server.py
+++ b/src/host/server.py
@@ -81,13 +81,38 @@ def _max_body_bytes() -> int:
 
 
 # Routes that legitimately accept large bodies (file uploads) enforce their
-# OWN per-route size caps (50 MB) with their own streaming guards, so the
-# global 8 MiB body-size cap must not pre-empt them with a 413. Matched by
-# path prefix against ``request.url.path``.
-_BODY_SIZE_EXEMPT_PREFIXES: tuple[str, ...] = (
-    "/dashboard/api/uploads/",   # dashboard file uploads (_MAX_UPLOAD_BYTES = 50 MB)
-    "/mesh/browser/upload-stage",  # agent->browser upload staging (_UPLOAD_STAGE_MAX_BYTES = 50 MB)
+# OWN ~50 MB per-route limit, so the small global cap must not pre-empt them.
+# We give them a HIGHER cap rather than exempting them outright: the streaming
+# guard then still bounds memory (an OOM backstop) — which matters because not
+# every upload route streams. /mesh/browser/upload-stage streams chunk-by-chunk
+# with its own counter, but /dashboard/api/uploads does ``await request.body()``
+# (buffers the whole body before its len() check), so a full exemption would
+# reopen an OOM via that route. Matched by path prefix against request.url.path.
+_UPLOAD_ROUTE_PREFIXES: tuple[str, ...] = (
+    "/dashboard/api/uploads/",   # dashboard file uploads (route cap 50 MB; BUFFERS body)
+    "/mesh/browser/upload-stage",  # agent->browser upload staging (route cap 50 MB; streams)
 )
+
+
+def _upload_route_max_bytes() -> int:
+    """OOM-backstop cap for the large-upload routes. Env override
+    ``OPENLEGION_MAX_UPLOAD_BODY_MB`` (default 64). Kept comfortably above the
+    routes' own 50 MB limit so a 50-64 MB upload hits their clean per-route 413,
+    while anything larger is streaming-aborted before it is buffered into RAM.
+    """
+    try:
+        mb = float(os.environ.get("OPENLEGION_MAX_UPLOAD_BODY_MB", "64"))
+    except ValueError:
+        mb = 64.0
+    return max(1, int(mb * 1024 * 1024))
+
+
+def _body_cap_for_path(path: str) -> int:
+    """Per-route body cap: the higher upload cap for upload routes, else the
+    global cap. Never returns "unlimited" — every route keeps an OOM backstop."""
+    if path.startswith(_UPLOAD_ROUTE_PREFIXES):
+        return _upload_route_max_bytes()
+    return _max_body_bytes()
 
 
 def _install_body_size_limit(app: FastAPI) -> None:
@@ -108,10 +133,10 @@ def _install_body_size_limit(app: FastAPI) -> None:
 
     @app.middleware("http")
     async def _enforce_body_size(request: Request, call_next):
-        # Large-upload routes police their own (higher) per-route caps.
-        if request.url.path.startswith(_BODY_SIZE_EXEMPT_PREFIXES):
-            return await call_next(request)
-        max_bytes = _max_body_bytes()
+        # Per-route cap: upload routes get a higher OOM-backstop cap (not a
+        # full exemption), so the streaming guard still bounds memory even for
+        # a route that buffers its body before its own size check.
+        max_bytes = _body_cap_for_path(request.url.path)
         cl = request.headers.get("content-length")
         if cl is not None:
             try:

--- a/src/host/server.py
+++ b/src/host/server.py
@@ -80,6 +80,16 @@ def _max_body_bytes() -> int:
     return int(mb * 1024 * 1024)
 
 
+# Routes that legitimately accept large bodies (file uploads) enforce their
+# OWN per-route size caps (50 MB) with their own streaming guards, so the
+# global 8 MiB body-size cap must not pre-empt them with a 413. Matched by
+# path prefix against ``request.url.path``.
+_BODY_SIZE_EXEMPT_PREFIXES: tuple[str, ...] = (
+    "/dashboard/api/uploads/",   # dashboard file uploads (_MAX_UPLOAD_BYTES = 50 MB)
+    "/mesh/browser/upload-stage",  # agent->browser upload staging (_UPLOAD_STAGE_MAX_BYTES = 50 MB)
+)
+
+
 def _install_body_size_limit(app: FastAPI) -> None:
     """Register an outer HTTP middleware that rejects oversized bodies.
 
@@ -98,6 +108,9 @@ def _install_body_size_limit(app: FastAPI) -> None:
 
     @app.middleware("http")
     async def _enforce_body_size(request: Request, call_next):
+        # Large-upload routes police their own (higher) per-route caps.
+        if request.url.path.startswith(_BODY_SIZE_EXEMPT_PREFIXES):
+            return await call_next(request)
         max_bytes = _max_body_bytes()
         cl = request.headers.get("content-length")
         if cl is not None:

--- a/src/host/server.py
+++ b/src/host/server.py
@@ -63,6 +63,93 @@ _MAX_BB_KEY_LEN = 512  # chars — prevents abusive key lengths in blackboard
 _MAX_BB_VALUE_BYTES = 262_144  # 256 KB — bounds per-key storage to keep SQLite WAL manageable
 
 
+def _max_body_bytes() -> int:
+    """Resolve the request body-size cap (env-configurable, default 8 MiB).
+
+    Mirrors the browser service cap. An unbounded HTTP body is buffered into
+    RAM before the JSON parser runs, so a multi-GB POST from an authenticated
+    agent could OOM the single coordination process and take the whole fleet
+    down. Env override ``OPENLEGION_MAX_BODY_MB`` (default 8).
+    """
+    try:
+        mb = float(os.environ.get("OPENLEGION_MAX_BODY_MB", "8"))
+    except ValueError:
+        mb = 8.0
+    if mb <= 0:
+        mb = 8.0
+    return int(mb * 1024 * 1024)
+
+
+def _install_body_size_limit(app: FastAPI) -> None:
+    """Register an outer HTTP middleware that rejects oversized bodies.
+
+    Two layers of defence:
+      1. ``Content-Length`` header check — cheap, rejects honest clients early.
+      2. Streaming byte counter — a client can omit Content-Length (chunked
+         transfer) to bypass the header check, so we also wrap the ASGI
+         receive channel and abort with HTTP 413 the moment the streamed body
+         exceeds the cap, before the whole body is buffered into RAM.
+
+    This is an outer middleware: it runs before routing and does not strip
+    headers, so it does not interfere with downstream auth / CSRF
+    dependencies.
+    """
+    from starlette.responses import JSONResponse as _StarletteJSONResponse
+
+    @app.middleware("http")
+    async def _enforce_body_size(request: Request, call_next):
+        max_bytes = _max_body_bytes()
+        cl = request.headers.get("content-length")
+        if cl is not None:
+            try:
+                size = int(cl)
+            except ValueError:
+                return _StarletteJSONResponse(
+                    {"detail": "invalid Content-Length"}, status_code=400,
+                )
+            if size > max_bytes:
+                return _StarletteJSONResponse(
+                    {"detail": "request body too large"}, status_code=413,
+                )
+
+        # Streaming guard for chunked / Content-Length-absent bodies: a
+        # client can omit Content-Length to bypass the header check, so we
+        # drain the ASGI receive channel here with a running byte counter and
+        # bail out the moment the cap is exceeded — the endpoint is never
+        # invoked and at most ``max_bytes`` ever lands in RAM. Buffered
+        # messages are then replayed to the handler unchanged so routing /
+        # auth / CSRF dependencies see the body exactly as sent.
+        original_receive = request._receive
+        received = 0
+        buffered: list[dict] = []
+        while True:
+            message = await original_receive()
+            buffered.append(message)
+            if message["type"] != "http.request":
+                # http.disconnect or other — stop draining, replay as-is.
+                break
+            received += len(message.get("body", b""))
+            if received > max_bytes:
+                return _StarletteJSONResponse(
+                    {"detail": "request body too large"}, status_code=413,
+                )
+            if not message.get("more_body", False):
+                break
+
+        _replay = iter(buffered)
+
+        async def _replay_receive():
+            try:
+                return next(_replay)
+            except StopIteration:
+                # Body fully consumed; defer to the live channel for any
+                # trailing http.disconnect.
+                return await original_receive()
+
+        request._receive = _replay_receive
+        return await call_next(request)
+
+
 def _websockets_headers_kw(connect, headers: dict[str, str]) -> dict:
     """Return the header kwarg name supported by the installed websockets."""
     try:
@@ -596,6 +683,7 @@ def create_mesh_app(
 ) -> FastAPI:
     """Create the FastAPI application for the mesh host process."""
     app = FastAPI(title="OpenLegion Mesh")
+    _install_body_size_limit(app)
     # Exposed for external callers (dashboard, health monitor) to clean up
     # agent state when agents are removed.
     app.cleanup_agent = lambda agent_id: None  # replaced below

--- a/tests/test_body_size_limit.py
+++ b/tests/test_body_size_limit.py
@@ -1,0 +1,219 @@
+"""Request body-size limit middleware (finding H4).
+
+The mesh and agent FastAPI apps buffer the full HTTP body into memory before
+the JSON parser runs. Without a cap, an authenticated agent could POST a
+multi-GB body and OOM the single coordination / agent process — a fleet-wide
+DoS. The middleware rejects over-cap requests with HTTP 413, via both a
+Content-Length header check and a streaming byte counter (so a chunked /
+Content-Length-absent body can't bypass it).
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from src.agent.server import create_agent_app
+
+# ---------------------------------------------------------------------------
+# Agent app
+# ---------------------------------------------------------------------------
+
+def _make_agent_app():
+    loop = MagicMock()
+    loop.agent_id = "test_agent"
+    loop.role = "researcher"
+    loop.state = "idle"
+    loop._excluded_tools = frozenset()
+    loop.memory = None
+    loop.mesh_client = MagicMock()
+    loop.skills = MagicMock()
+    loop.skills.list_skills = MagicMock(return_value=[])
+    loop.skills.get_tool_definitions = MagicMock(return_value=[])
+    loop.skills.get_tool_sources = MagicMock(return_value={})
+    loop.skills.execute = AsyncMock(return_value={"ok": True})
+    loop.workspace = None
+    return create_agent_app(loop)
+
+
+@pytest.mark.asyncio
+async def test_agent_rejects_oversized_content_length():
+    """A POST declaring a Content-Length over the cap → HTTP 413."""
+    app = _make_agent_app()
+    over = 9 * 1024 * 1024  # 9 MiB > 8 MiB default cap
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://test",
+    ) as client:
+        resp = await client.post(
+            "/task",
+            content=b"x" * over,
+            headers={"content-type": "application/json"},
+        )
+    assert resp.status_code == 413, resp.text
+    assert "too large" in resp.text.lower()
+
+
+@pytest.mark.asyncio
+async def test_agent_small_request_succeeds():
+    """A normal small request passes the middleware and reaches routing."""
+    app = _make_agent_app()
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://test",
+    ) as client:
+        # GET /workspace returns {"files": []} when workspace is None — a
+        # trivial endpoint that doesn't depend on mock loop internals.
+        resp = await client.get("/workspace")
+    assert resp.status_code == 200, resp.text
+
+
+@pytest.mark.asyncio
+async def test_agent_rejects_oversized_chunked_body():
+    """A chunked body (no Content-Length) over the cap → HTTP 413.
+
+    httpx sends a generator-sourced body using chunked transfer encoding
+    (no Content-Length header), so this exercises the streaming guard, not
+    the header check.
+    """
+    app = _make_agent_app()
+    over = 9 * 1024 * 1024
+
+    async def _gen():
+        sent = 0
+        chunk = b"x" * (256 * 1024)
+        while sent < over:
+            yield chunk
+            sent += len(chunk)
+
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://test",
+    ) as client:
+        resp = await client.post(
+            "/task",
+            content=_gen(),
+            headers={"content-type": "application/json"},
+        )
+    assert resp.status_code == 413, resp.text
+    assert "too large" in resp.text.lower()
+
+
+# ---------------------------------------------------------------------------
+# Mesh app
+# ---------------------------------------------------------------------------
+
+def _make_mesh_app(tmp_path):
+    from src.host.costs import CostTracker
+    from src.host.mesh import Blackboard, MessageRouter, PubSub
+    from src.host.permissions import PermissionMatrix
+    from src.host.server import create_mesh_app
+    from src.host.traces import TraceStore
+
+    bb = Blackboard(db_path=str(tmp_path / "bb.db"))
+    pubsub = PubSub()
+    perms = PermissionMatrix()
+    router = MessageRouter(perms, {})
+    costs = CostTracker(str(tmp_path / "costs.db"))
+    traces = TraceStore(str(tmp_path / "traces.db"))
+    router.register_agent("operator", "http://operator:8400", [])
+    auth_tokens = {"operator": "operator-secret"}
+    app = create_mesh_app(
+        blackboard=bb, pubsub=pubsub, router=router, permissions=perms,
+        cost_tracker=costs, trace_store=traces, auth_tokens=auth_tokens,
+    )
+    return app, (bb, costs, traces)
+
+
+@pytest.mark.asyncio
+async def test_mesh_rejects_oversized_content_length(tmp_path, monkeypatch):
+    monkeypatch.setenv("OPENLEGION_PROJECT_SCOPE_MODE", "warn")
+    app, closers = _make_mesh_app(tmp_path)
+    over = 9 * 1024 * 1024
+    try:
+        async with AsyncClient(
+            transport=ASGITransport(app=app), base_url="http://test",
+        ) as client:
+            resp = await client.post(
+                "/mesh/agents/register",
+                content=b"x" * over,
+                headers={
+                    "content-type": "application/json",
+                    "authorization": "Bearer operator-secret",
+                },
+            )
+        assert resp.status_code == 413, resp.text
+        assert "too large" in resp.text.lower()
+    finally:
+        for c in closers:
+            c.close()
+
+
+@pytest.mark.asyncio
+async def test_mesh_small_request_succeeds(tmp_path, monkeypatch):
+    """A normal small request passes the middleware (reaches auth/routing)."""
+    monkeypatch.setenv("OPENLEGION_PROJECT_SCOPE_MODE", "warn")
+    app, closers = _make_mesh_app(tmp_path)
+    try:
+        async with AsyncClient(
+            transport=ASGITransport(app=app), base_url="http://test",
+        ) as client:
+            # Health-check endpoint hit by the provisioner — no body, must 200.
+            resp = await client.get(
+                "/mesh/agents", headers={"x-mesh-internal": "1"},
+            )
+        # The middleware must not interfere: anything other than 413/400 from
+        # the body guard means it passed through to routing.
+        assert resp.status_code == 200, resp.text
+    finally:
+        for c in closers:
+            c.close()
+
+
+@pytest.mark.asyncio
+async def test_mesh_rejects_oversized_chunked_body(tmp_path, monkeypatch):
+    """A chunked over-cap body to the mesh → HTTP 413 via the streaming guard."""
+    monkeypatch.setenv("OPENLEGION_PROJECT_SCOPE_MODE", "warn")
+    app, closers = _make_mesh_app(tmp_path)
+    over = 9 * 1024 * 1024
+
+    async def _gen():
+        sent = 0
+        chunk = b"x" * (256 * 1024)
+        while sent < over:
+            yield chunk
+            sent += len(chunk)
+
+    try:
+        async with AsyncClient(
+            transport=ASGITransport(app=app), base_url="http://test",
+        ) as client:
+            resp = await client.post(
+                "/mesh/agents/register",
+                content=_gen(),
+                headers={
+                    "content-type": "application/json",
+                    "authorization": "Bearer operator-secret",
+                },
+            )
+        assert resp.status_code == 413, resp.text
+        assert "too large" in resp.text.lower()
+    finally:
+        for c in closers:
+            c.close()
+
+
+@pytest.mark.asyncio
+async def test_env_override_lowers_cap(tmp_path, monkeypatch):
+    """OPENLEGION_MAX_BODY_MB shrinks the cap; a sub-8-MiB body now 413s."""
+    monkeypatch.setenv("OPENLEGION_MAX_BODY_MB", "1")
+    app = _make_agent_app()
+    over = 2 * 1024 * 1024  # 2 MiB > 1 MiB override
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://test",
+    ) as client:
+        resp = await client.post(
+            "/task",
+            content=b"x" * over,
+            headers={"content-type": "application/json"},
+        )
+    assert resp.status_code == 413, resp.text

--- a/tests/test_body_size_limit.py
+++ b/tests/test_body_size_limit.py
@@ -203,17 +203,16 @@ async def test_mesh_rejects_oversized_chunked_body(tmp_path, monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_mesh_upload_route_exempt_from_global_cap(tmp_path, monkeypatch):
-    """Large-upload routes must NOT be pre-empted by the 8 MiB global cap.
+async def test_upload_route_allows_body_over_global_cap(tmp_path, monkeypatch):
+    """Upload routes get the higher upload cap, not the 8 MiB global cap.
 
-    ``/mesh/browser/upload-stage`` enforces its own 50 MB per-route cap, so a
-    9 MiB body (over the 8 MiB global cap, under the 50 MB route cap) must pass
-    the body-size middleware and reach the route — never the middleware's 413.
+    A 9 MiB body (over the 8 MiB global cap, under the 64 MiB upload cap) must
+    pass the body-size middleware and reach the route — never the global 413.
     Regression for the bodysize-vs-uploads conflict (H4 review).
     """
     monkeypatch.setenv("OPENLEGION_PROJECT_SCOPE_MODE", "warn")
     app, closers = _make_mesh_app(tmp_path)
-    over_global = 9 * 1024 * 1024  # > 8 MiB global cap, < 50 MB route cap
+    over_global = 9 * 1024 * 1024  # > 8 MiB global cap, < 64 MiB upload cap
     try:
         async with AsyncClient(
             transport=ASGITransport(app=app), base_url="http://test",
@@ -226,13 +225,45 @@ async def test_mesh_upload_route_exempt_from_global_cap(tmp_path, monkeypatch):
                     "authorization": "Bearer operator-secret",
                 },
             )
-        # The middleware must not short-circuit this route with its 413. The
-        # route may itself reject (auth/validation), but never for body size at
-        # 9 MiB — so any status other than the global-cap 413 proves exemption.
+        # The middleware must not short-circuit this route with its global 413.
+        # The route may itself reject (auth/validation), but never for body size
+        # at 9 MiB — so any status other than the body-size 413 proves the
+        # higher upload cap applied.
         assert resp.status_code != 413, (
             "upload route was pre-empted by the global body-size cap: "
             f"{resp.status_code} {resp.text}"
         )
+    finally:
+        for c in closers:
+            c.close()
+
+
+@pytest.mark.asyncio
+async def test_upload_route_keeps_oom_backstop(tmp_path, monkeypatch):
+    """Upload routes are NOT fully exempt — the streaming guard still caps them.
+
+    With the upload cap lowered to 1 MiB, a 2 MiB body to an upload route must
+    still be rejected with 413, proving the OOM backstop (a full exemption
+    would let it through and let the buffering /dashboard upload route OOM).
+    """
+    monkeypatch.setenv("OPENLEGION_PROJECT_SCOPE_MODE", "warn")
+    monkeypatch.setenv("OPENLEGION_MAX_UPLOAD_BODY_MB", "1")
+    app, closers = _make_mesh_app(tmp_path)
+    over_upload = 2 * 1024 * 1024  # > 1 MiB upload cap override
+    try:
+        async with AsyncClient(
+            transport=ASGITransport(app=app), base_url="http://test",
+        ) as client:
+            resp = await client.post(
+                "/mesh/browser/upload-stage",
+                content=b"x" * over_upload,
+                headers={
+                    "content-type": "application/octet-stream",
+                    "authorization": "Bearer operator-secret",
+                },
+            )
+        assert resp.status_code == 413, resp.text
+        assert "too large" in resp.text.lower()
     finally:
         for c in closers:
             c.close()

--- a/tests/test_body_size_limit.py
+++ b/tests/test_body_size_limit.py
@@ -284,3 +284,35 @@ async def test_env_override_lowers_cap(tmp_path, monkeypatch):
             headers={"content-type": "application/json"},
         )
     assert resp.status_code == 413, resp.text
+
+
+# ---------------------------------------------------------------------------
+# _body_cap_for_path — route matching (exact upload route vs prefix subtree)
+# ---------------------------------------------------------------------------
+
+_GLOBAL_CAP = 8 * 1024 * 1024  # 8 MiB default
+
+
+def test_body_cap_exact_match_upload_stage():
+    """The fixed staging route gets the higher upload cap (exact match)."""
+    from src.host.server import _body_cap_for_path
+    assert _body_cap_for_path("/mesh/browser/upload-stage") > _GLOBAL_CAP
+
+
+def test_body_cap_dashboard_uploads_prefix():
+    """The dashboard uploads subtree (prefix) gets the higher upload cap."""
+    from src.host.server import _body_cap_for_path
+    assert _body_cap_for_path("/dashboard/api/uploads/x.png") > _GLOBAL_CAP
+
+
+def test_body_cap_upload_stage_no_overmatch():
+    """A path that merely starts with the staging route must NOT be treated as
+    an upload route — exact match, not startswith (the original over-match bug)."""
+    from src.host.server import _body_cap_for_path
+    assert _body_cap_for_path("/mesh/browser/upload-stage-evil") == _GLOBAL_CAP
+
+
+def test_body_cap_regular_route_uses_global_cap():
+    """A normal route falls back to the 8 MiB global cap."""
+    from src.host.server import _body_cap_for_path
+    assert _body_cap_for_path("/mesh/agents") == _GLOBAL_CAP

--- a/tests/test_body_size_limit.py
+++ b/tests/test_body_size_limit.py
@@ -203,6 +203,42 @@ async def test_mesh_rejects_oversized_chunked_body(tmp_path, monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_mesh_upload_route_exempt_from_global_cap(tmp_path, monkeypatch):
+    """Large-upload routes must NOT be pre-empted by the 8 MiB global cap.
+
+    ``/mesh/browser/upload-stage`` enforces its own 50 MB per-route cap, so a
+    9 MiB body (over the 8 MiB global cap, under the 50 MB route cap) must pass
+    the body-size middleware and reach the route — never the middleware's 413.
+    Regression for the bodysize-vs-uploads conflict (H4 review).
+    """
+    monkeypatch.setenv("OPENLEGION_PROJECT_SCOPE_MODE", "warn")
+    app, closers = _make_mesh_app(tmp_path)
+    over_global = 9 * 1024 * 1024  # > 8 MiB global cap, < 50 MB route cap
+    try:
+        async with AsyncClient(
+            transport=ASGITransport(app=app), base_url="http://test",
+        ) as client:
+            resp = await client.post(
+                "/mesh/browser/upload-stage",
+                content=b"x" * over_global,
+                headers={
+                    "content-type": "application/octet-stream",
+                    "authorization": "Bearer operator-secret",
+                },
+            )
+        # The middleware must not short-circuit this route with its 413. The
+        # route may itself reject (auth/validation), but never for body size at
+        # 9 MiB — so any status other than the global-cap 413 proves exemption.
+        assert resp.status_code != 413, (
+            "upload route was pre-empted by the global body-size cap: "
+            f"{resp.status_code} {resp.text}"
+        )
+    finally:
+        for c in closers:
+            c.close()
+
+
+@pytest.mark.asyncio
 async def test_env_override_lowers_cap(tmp_path, monkeypatch):
     """OPENLEGION_MAX_BODY_MB shrinks the cap; a sub-8-MiB body now 413s."""
     monkeypatch.setenv("OPENLEGION_MAX_BODY_MB", "1")


### PR DESCRIPTION
## May 2026 security remediation — finding H4

The mesh FastAPI app (`src/host/server.py`) and the agent FastAPI app
(`src/agent/server.py`) had **no HTTP request-body-size limit**. FastAPI /
Starlette buffers the full body into memory before the JSON parser runs, so
an authenticated agent (or any client reaching the agent server) could POST
a multi-GB body and OOM the single coordination process → **fleet-wide DoS**.
uvicorn has no built-in body cap; this middleware is the control.

The browser service already had the correct pattern (`_enforce_body_size`);
this PR replicates and hardens it for the other two servers.

## Change

Outer HTTP middleware on both apps:

- **Default cap 8 MiB** (matches the browser service), env-configurable via
  `OPENLEGION_MAX_BODY_MB` (default 8).
- **Content-Length check** rejects honest over-cap clients early → HTTP 413.
- **Streaming guard** for the chunked / Content-Length-absent bypass: drains
  the ASGI receive channel with a running byte counter and returns 413 the
  moment the cap is exceeded — the endpoint is never invoked and at most
  `max_bytes` ever lands in RAM. Buffered messages are replayed unchanged so
  downstream routing / auth / CSRF dependencies see the body exactly as sent.

Runs before routing, does not strip headers — no interference with the
existing auth / CSRF dependency chain. No endpoint logic changed; no
existing per-field caps lowered.

## Tests

`tests/test_body_size_limit.py` (7 tests, all passing) — for both mesh and
agent apps: over-cap Content-Length → 413, normal small request → 200,
chunked over-cap body → 413 (streaming guard), env override lowering the cap.

## Note

May need rebasing against an in-flight refactor.