### PR TITLE
fix(browser): release display slot on failed launch and reconcile orphans

### DIFF
--- a/src/browser/display_allocator.py
+++ b/src/browser/display_allocator.py
@@ -194,6 +194,20 @@ class DisplayAllocator:
     def is_allocated(self, display: int) -> bool:
         return display in self._allocated
 
+    def allocated_slots(self) -> list[Slot]:
+        """Snapshot of the currently-allocated slots.
+
+        Returns a fresh list (sorted by display, deterministic) reconstructed
+        from the internal allocation set, so callers can iterate without
+        exposing or mutating ``_allocated`` directly. Used by the browser
+        manager's orphan-reconciliation sweep (H13) to find slots that are
+        allocated but no longer backed by a live instance.
+        """
+        return [
+            Slot(display=d, vnc_port=port_for_display(d))
+            for d in sorted(self._allocated)
+        ]
+
     @property
     def free_count(self) -> int:
         return len(self._free)

--- a/src/browser/service.py
+++ b/src/browser/service.py
@@ -3506,6 +3506,46 @@ class BrowserManager:
             for agent_id in to_stop:
                 logger.info("Stopping idle browser for '%s'", agent_id)
                 await self._stop_instance(agent_id)
+            # H13: reclaim any display slot that is marked allocated but has
+            # no live instance backing it. A failed ``_start_browser`` tail
+            # now rolls its own slot back, but this sweep is the belt-and-
+            # braces net for any future leak path (and reclaims slots stranded
+            # by an older build before this fix). Runs under the same manager
+            # lock as instance iteration, so the live-instance view is
+            # consistent with the allocator snapshot.
+            self._reconcile_orphaned_slots()
+
+    def _reconcile_orphaned_slots(self) -> None:
+        """Release display slots allocated to no live instance.
+
+        Caller MUST hold ``self._manager_lock()`` — this reads ``_instances``
+        and mutates the allocator in lock-step. An "orphan" is a slot the
+        allocator still marks allocated while NO entry in ``_instances``
+        references it via ``inst.display_slot``. Slots belonging to a
+        starting or healthy instance are skipped: ``_start_browser`` attaches
+        the slot to its instance only after a successful launch and runs
+        under the same lock, so a slot that is mid-launch is either not yet
+        allocated or already attached to an instance that is being registered
+        within the same lock hold — never visible here as a false orphan.
+        """
+        allocator = self._display_allocator
+        if allocator is None:
+            return
+        live_displays = {
+            inst.display_slot.display
+            for inst in self._instances.values()
+            if inst.display_slot is not None
+        }
+        for slot in allocator.allocated_slots():
+            if slot.display in live_displays:
+                continue
+            logger.warning(
+                "Reconciling orphaned display slot :%d (port %d) — allocated "
+                "but no live instance; releasing",
+                slot.display, slot.vnc_port,
+            )
+            with contextlib.suppress(Exception):
+                allocator.release(slot)
 
     def touch_agent(self, agent_id: str) -> bool:
         """Reset the idle timer for one agent's browser. Sync, no lock —
@@ -4032,118 +4072,163 @@ class BrowserManager:
         else:
             os.environ["DISPLAY"] = _saved_display
 
-        # §19.3 / Phase 10 §21: inject the navigator-override init script
-        # for mobile profiles BEFORE any page is created. ``add_init_script``
-        # is registered on the BrowserContext so every page (current + new
-        # tabs) receives it at ``document_start``, ahead of any site script.
-        # Returns ``None`` for desktop profiles — no-op in that case.
-        mobile_init = build_mobile_init_script(get_device_profile(device_profile))
-        if mobile_init is not None:
-            try:
-                await context.add_init_script(script=mobile_init)
-                logger.debug(
-                    "Agent '%s' mobile navigator init script injected (profile=%s)",
-                    agent_id, device_profile,
-                )
-            except Exception as e:
-                # Non-fatal: a missing init script weakens the spoof but
-                # doesn't break the browser. Log and continue.
-                logger.warning(
-                    "Agent '%s' add_init_script failed for profile %s: %s",
-                    agent_id, device_profile, e,
-                )
-
-        pages = context.pages
-        page = pages[0] if pages else await context.new_page()
-
-        # §6.6 ``navigator.connection`` REMOVED on the Firefox UA path.
-        #
-        # Real Firefox does NOT expose ``navigator.connection`` (the
-        # NetworkInformation API is unimplemented as of FF 138; Chromium
-        # is the only major engine shipping it on by default). Injecting
-        # a synthetic ``navigator.connection`` on a UA stamped
-        # ``Firefox/`` was itself a strong cluster signal: zero real
-        # Firefox users in the population have the API, so any Firefox-
-        # shaped client that DOES expose it is by definition spoofed.
-        # Fingerprint.com / Creep.js / DataDome key directly on this
-        # inconsistency.
-        #
-        # ``_assert_firefox_ua`` enforces a Firefox UA at startup, so
-        # the right behavior is to MATCH real-Firefox population —
-        # leave the API absent. The §6.6 plan predates this analysis;
-        # the navigator probe below was updated to stop treating a
-        # missing ``navigator.connection`` as a mismatch.
-        #
-        # If a future build moves to a Chromium-shaped UA, the spoof
-        # path can be restored (gated on UA family); the
-        # ``_NAV_CONNECTION_INIT_SCRIPT`` template is retained for that
-        # purpose.
-
-        inst = CamoufoxInstance(agent_id, browser, context, page)
-        # Attach the per-agent X stack to the instance so subsequent
-        # subprocess_env() calls scope DISPLAY correctly and
-        # _stop_instance can tear the stack down.
-        inst.display_slot = slot
-        inst._x_procs = x_procs
-
-        # §20 — restore the previously-snapshotted session state.
-        #
-        # Camoufox's ``persistent_context=True`` already retains cookies +
-        # localStorage in the on-disk profile dir, so this is genuinely a
-        # SECOND-CHANNEL restore: the JSON sidecar is the operator-visible,
-        # operator-clearable copy of session state that survives even when
-        # the profile dir is wiped (operator support, profile rotation,
-        # template-based agent re-spawn). On a normal restart the sidecar
-        # and profile dir agree; if they disagree (sidecar fresher than the
-        # on-disk profile, e.g. after a profile-dir reset), the sidecar
-        # wins for cookies / localStorage so the agent stays logged in.
-        #
-        # We use Playwright's ``add_cookies`` + ``add_init_script`` here
-        # rather than launching with ``storage_state`` because Camoufox's
-        # ``persistent_context=True`` path does not pass ``storage_state``
-        # through to Firefox (it owns the profile dir directly). The end
-        # state is the same: cookies merged into the cookie jar; localStorage
-        # seeded on each origin's first navigation via the init script.
-        await self._maybe_restore_session(inst)
-
-        # §9.1 wire request listeners at the BrowserContext level so new
-        # tabs (in-page ``window.open()`` or ``browser_open_tab``) inherit
-        # them automatically. Idempotent — also re-runs after browser RESET
-        # because RESET drops the whole instance and the next get_or_start
-        # creates a fresh one with ``_network_attached=False``.
-        self._attach_network_listeners(inst)
-
-        # Discover the new X11 window for targeted focus.  ``wids_before``
-        # is empty by construction — the agent's display was just spawned,
-        # so any Firefox window discovered there is ours. (X11 WIDs are
-        # NOT unique across displays; querying any other display would
-        # risk a numeric collision.)
-        wids_before: set[int] = set()
-        wid = await self._discover_new_wid(wids_before, inst)
-        if wid:
-            inst.x11_wid = wid
-            logger.debug("Agent '%s' browser window: X11 WID %d", agent_id, wid)
-            # Start idle mouse jitter for human-like fidgeting
-            inst._jitter_task = asyncio.create_task(self._idle_mouse_jitter(inst))
-        else:
-            logger.warning(
-                "Could not discover X11 WID for '%s' — interactions on "
-                "high-sensitivity sites will use CDP (isTrusted=false)",
-                agent_id,
-            )
-            inst._jitter_task = None
-
-        # §6.3 run the navigator self-test once. Best-effort — a probe
-        # failure must not block browser start (the inconsistency is
-        # itself the operator's signal to investigate).
+        # H13: everything past the successful Camoufox launch — the first
+        # ``add_init_script`` / ``new_page`` await, session restore, and WID
+        # discovery — runs under a rollback guard. The Camoufox-failure branch
+        # above already tears the slot down on a launch failure, but these
+        # post-launch awaits were previously UNGUARDED: any one of them raising
+        # left ``get_or_start`` short of registering the instance in
+        # ``_instances`` while the allocated display slot and the live Xvnc /
+        # Camoufox processes survived — invisible to ``_cleanup_idle`` /
+        # ``stop_all`` (which iterate only ``_instances``). Repeated failures
+        # exhausted the 64-slot pool → fleet-wide browser denial. On ANY
+        # exception here we tear down the X stack (which releases the slot) and
+        # close the browser, then re-raise so the caller still sees the failure.
+        inst: CamoufoxInstance | None = None
         try:
-            await self._run_navigator_probe(inst)
-        except Exception as e:
-            logger.warning(
-                "Navigator self-test probe failed for '%s': %s", agent_id, e,
-            )
+            # §19.3 / Phase 10 §21: inject the navigator-override init script
+            # for mobile profiles BEFORE any page is created. ``add_init_script``
+            # is registered on the BrowserContext so every page (current + new
+            # tabs) receives it at ``document_start``, ahead of any site script.
+            # Returns ``None`` for desktop profiles — no-op in that case.
+            mobile_init = build_mobile_init_script(get_device_profile(device_profile))
+            if mobile_init is not None:
+                try:
+                    await context.add_init_script(script=mobile_init)
+                    logger.debug(
+                        "Agent '%s' mobile navigator init script injected (profile=%s)",
+                        agent_id, device_profile,
+                    )
+                except Exception as e:
+                    # Non-fatal: a missing init script weakens the spoof but
+                    # doesn't break the browser. Log and continue.
+                    logger.warning(
+                        "Agent '%s' add_init_script failed for profile %s: %s",
+                        agent_id, device_profile, e,
+                    )
 
-        return inst
+            pages = context.pages
+            page = pages[0] if pages else await context.new_page()
+
+            # §6.6 ``navigator.connection`` REMOVED on the Firefox UA path.
+            #
+            # Real Firefox does NOT expose ``navigator.connection`` (the
+            # NetworkInformation API is unimplemented as of FF 138; Chromium
+            # is the only major engine shipping it on by default). Injecting
+            # a synthetic ``navigator.connection`` on a UA stamped
+            # ``Firefox/`` was itself a strong cluster signal: zero real
+            # Firefox users in the population have the API, so any Firefox-
+            # shaped client that DOES expose it is by definition spoofed.
+            # Fingerprint.com / Creep.js / DataDome key directly on this
+            # inconsistency.
+            #
+            # ``_assert_firefox_ua`` enforces a Firefox UA at startup, so
+            # the right behavior is to MATCH real-Firefox population —
+            # leave the API absent. The §6.6 plan predates this analysis;
+            # the navigator probe below was updated to stop treating a
+            # missing ``navigator.connection`` as a mismatch.
+            #
+            # If a future build moves to a Chromium-shaped UA, the spoof
+            # path can be restored (gated on UA family); the
+            # ``_NAV_CONNECTION_INIT_SCRIPT`` template is retained for that
+            # purpose.
+
+            inst = CamoufoxInstance(agent_id, browser, context, page)
+            # Attach the per-agent X stack to the instance so subsequent
+            # subprocess_env() calls scope DISPLAY correctly and
+            # _stop_instance can tear the stack down.
+            inst.display_slot = slot
+            inst._x_procs = x_procs
+
+            # §20 — restore the previously-snapshotted session state.
+            #
+            # Camoufox's ``persistent_context=True`` already retains cookies +
+            # localStorage in the on-disk profile dir, so this is genuinely a
+            # SECOND-CHANNEL restore: the JSON sidecar is the operator-visible,
+            # operator-clearable copy of session state that survives even when
+            # the profile dir is wiped (operator support, profile rotation,
+            # template-based agent re-spawn). On a normal restart the sidecar
+            # and profile dir agree; if they disagree (sidecar fresher than the
+            # on-disk profile, e.g. after a profile-dir reset), the sidecar
+            # wins for cookies / localStorage so the agent stays logged in.
+            #
+            # We use Playwright's ``add_cookies`` + ``add_init_script`` here
+            # rather than launching with ``storage_state`` because Camoufox's
+            # ``persistent_context=True`` path does not pass ``storage_state``
+            # through to Firefox (it owns the profile dir directly). The end
+            # state is the same: cookies merged into the cookie jar; localStorage
+            # seeded on each origin's first navigation via the init script.
+            await self._maybe_restore_session(inst)
+
+            # §9.1 wire request listeners at the BrowserContext level so new
+            # tabs (in-page ``window.open()`` or ``browser_open_tab``) inherit
+            # them automatically. Idempotent — also re-runs after browser RESET
+            # because RESET drops the whole instance and the next get_or_start
+            # creates a fresh one with ``_network_attached=False``.
+            self._attach_network_listeners(inst)
+
+            # Discover the new X11 window for targeted focus.  ``wids_before``
+            # is empty by construction — the agent's display was just spawned,
+            # so any Firefox window discovered there is ours. (X11 WIDs are
+            # NOT unique across displays; querying any other display would
+            # risk a numeric collision.)
+            wids_before: set[int] = set()
+            wid = await self._discover_new_wid(wids_before, inst)
+            if wid:
+                inst.x11_wid = wid
+                logger.debug("Agent '%s' browser window: X11 WID %d", agent_id, wid)
+                # Start idle mouse jitter for human-like fidgeting
+                inst._jitter_task = asyncio.create_task(self._idle_mouse_jitter(inst))
+            else:
+                logger.warning(
+                    "Could not discover X11 WID for '%s' — interactions on "
+                    "high-sensitivity sites will use CDP (isTrusted=false)",
+                    agent_id,
+                )
+                inst._jitter_task = None
+
+            # §6.3 run the navigator self-test once. Best-effort — a probe
+            # failure must not block browser start (the inconsistency is
+            # itself the operator's signal to investigate).
+            try:
+                await self._run_navigator_probe(inst)
+            except Exception as e:
+                logger.warning(
+                    "Navigator self-test probe failed for '%s': %s", agent_id, e,
+                )
+
+            return inst
+        except Exception:
+            # H13 rollback: a post-launch await failed. Mirror the
+            # Camoufox-failure branch above — tear down the per-agent X
+            # stack (which releases the display slot) and close the
+            # browser so neither the slot nor any process survives. The
+            # caller never registered this instance in ``_instances``, so
+            # without this cleanup both would leak permanently.
+            #
+            # Cancel any jitter task we may have just spawned so it can't
+            # keep driving the X11 cursor against a context we're about
+            # to close.
+            jitter = getattr(inst, "_jitter_task", None) if inst is not None else None
+            if jitter is not None:
+                jitter.cancel()
+                with contextlib.suppress(Exception):
+                    await asyncio.wait_for(asyncio.shield(jitter), timeout=2.0)
+            with contextlib.suppress(Exception):
+                await asyncio.wait_for(context.close(), timeout=10.0)
+            # Tear down the X stack + release the slot. Use ``inst`` when we
+            # got far enough to attach the stack to it; otherwise fall back
+            # to a scratch carrier (same shape as the Camoufox-failure
+            # branch) so the teardown helper has ``display_slot`` + ``_x_procs``.
+            teardown_target = inst
+            if teardown_target is None or getattr(teardown_target, "display_slot", None) is None:
+                _scratch = type("_Scratch", (), {})()
+                _scratch.display_slot = slot
+                _scratch._x_procs = x_procs
+                teardown_target = _scratch
+            with contextlib.suppress(Exception):
+                await self._teardown_per_agent_x_stack(teardown_target)
+            raise
 
     async def _maybe_restore_session(self, inst: CamoufoxInstance) -> None:
         """§20 — restore cookies + localStorage from the per-agent sidecar.

--- a/tests/test_browser_service.py
+++ b/tests/test_browser_service.py
@@ -467,6 +467,272 @@ class TestPerAgentXStack:
         assert observed["env"]["DISPLAY"] == ":200"
 
 
+class TestStartBrowserSlotLeak:
+    """H13 — a failed ``_start_browser`` tail must not leak a slot/processes.
+
+    The post-launch awaits (``new_page`` / ``_maybe_restore_session`` / WID
+    discovery) run after the display slot is allocated and the Xvnc/Camoufox
+    processes are live, but the caller (``get_or_start``) registers the
+    instance in ``_instances`` only on full success. If any tail await throws
+    without rollback, the slot stays in the allocator and the processes leak,
+    invisible to ``_cleanup_idle`` / ``stop_all``. Repeated failures exhaust
+    the 64-slot pool → fleet-wide browser denial.
+    """
+
+    def _free_allocator(self, span: int = 5):
+        from src.browser.display_allocator import (
+            DisplayAllocator,
+            _port_is_bindable,
+            port_for_display,
+        )
+        for display_start in range(200, 500):
+            if all(
+                _port_is_bindable(port_for_display(d))
+                for d in range(display_start, display_start + span)
+            ):
+                break
+        else:
+            pytest.skip("no free display/VNC test range available")
+        return DisplayAllocator(
+            display_start=display_start,
+            display_end=display_start + span,
+            run_boot_sweep=False,
+        )
+
+    async def _drive_start_browser_with_failing_tail(
+        self, monkeypatch, fail_attr: str,
+    ):
+        """Run the real ``_start_browser`` with a tail step rigged to raise.
+
+        Mocks only the heavy/native boundaries (Playwright, Camoufox launch,
+        profile migration, X-stack spawn). ``_teardown_per_agent_x_stack`` is
+        left REAL so the test asserts on the genuine rollback (slot release +
+        process kill). Returns ``(mgr, allocator, raised)``.
+        """
+        from src.browser.service import BrowserManager
+
+        mgr = BrowserManager(profiles_dir="/tmp/test_profiles_h13")
+        alloc = self._free_allocator()
+        mgr._display_allocator = alloc
+
+        # Playwright — never import the real thing.
+        monkeypatch.setattr(
+            mgr, "_ensure_playwright", AsyncMock(return_value=MagicMock()),
+        )
+
+        # Fake the Camoufox launch entry point that ``_start_browser`` imports
+        # inside the function body (``from camoufox.async_api import
+        # AsyncNewBrowser``). The returned object stands in for the
+        # persistent BrowserContext.
+        import sys
+        import types as _types
+
+        class _FakeContext:
+            def __init__(self):
+                self.pages = []
+                self.close = AsyncMock()
+
+            async def add_init_script(self, *a, **k):
+                return None
+
+            async def new_page(self):
+                if fail_attr == "new_page":
+                    raise RuntimeError("boom: new_page")
+                return AsyncMock()
+
+        fake_ctx = _FakeContext()
+
+        async def _fake_new_browser(pw, **opts):
+            return fake_ctx
+
+        fake_mod = _types.ModuleType("camoufox.async_api")
+        fake_mod.AsyncNewBrowser = _fake_new_browser
+        camoufox_pkg = _types.ModuleType("camoufox")
+        monkeypatch.setitem(sys.modules, "camoufox", camoufox_pkg)
+        monkeypatch.setitem(sys.modules, "camoufox.async_api", fake_mod)
+
+        # Profile schema helpers (imported at module scope + inside the fn).
+        monkeypatch.setattr("src.browser.service.migrate_profile", lambda *a, **k: None)
+        monkeypatch.setattr(
+            "src.browser.profile_schema.sync_adblock_extension", lambda *a, **k: None,
+        )
+        # Deterministic launch options (no proxy, desktop window).
+        monkeypatch.setattr(
+            "src.browser.service.build_launch_options",
+            lambda *a, **k: {"window": (1920, 1080)},
+        )
+        monkeypatch.setattr(mgr, "get_proxy_config", lambda agent_id: None)
+        monkeypatch.setattr(
+            "src.browser.service.build_mobile_init_script", lambda *a, **k: None,
+        )
+        monkeypatch.setattr(
+            "src.browser.service.get_device_profile", lambda *a, **k: MagicMock(),
+        )
+
+        # X-stack spawn returns process handles that report "already dead" so
+        # the REAL teardown's wait loop exits fast.
+        class _MockProc:
+            def __init__(self, pid):
+                self.pid = pid
+                self._exited = False
+
+            def poll(self):
+                if self._exited:
+                    return 0
+                self._exited = True
+                return None
+
+            def wait(self, timeout=None):
+                self._exited = True
+                return 0
+
+        spawned = [_MockProc(40001), _MockProc(40002)]
+        monkeypatch.setattr(
+            mgr, "_spawn_per_agent_x_stack",
+            AsyncMock(return_value=spawned),
+        )
+        monkeypatch.setattr("src.browser.service.os.killpg", lambda *a, **k: None)
+
+        # Rig the chosen tail step to raise (for the non-new_page case).
+        if fail_attr == "_maybe_restore_session":
+            monkeypatch.setattr(
+                mgr, "_maybe_restore_session",
+                AsyncMock(side_effect=RuntimeError("boom: restore")),
+            )
+        else:
+            monkeypatch.setattr(mgr, "_maybe_restore_session", AsyncMock())
+        monkeypatch.setattr(mgr, "_attach_network_listeners", lambda inst: None)
+        monkeypatch.setattr(mgr, "_discover_new_wid", AsyncMock(return_value=None))
+        monkeypatch.setattr(mgr, "_run_navigator_probe", AsyncMock())
+
+        raised = None
+        try:
+            await mgr._start_browser("agent-h13")
+        except Exception as e:  # noqa: BLE001
+            raised = e
+        return mgr, alloc, raised, fake_ctx
+
+    @pytest.mark.asyncio
+    async def test_new_page_failure_releases_slot(self, monkeypatch):
+        mgr, alloc, raised, ctx = (
+            await self._drive_start_browser_with_failing_tail(
+                monkeypatch, "new_page",
+            )
+        )
+        assert raised is not None
+        # No instance registered.
+        assert "agent-h13" not in mgr._instances
+        # Slot fully reclaimed — pool back to empty, reusable.
+        assert alloc.allocated_count == 0
+        # The freed slot can be allocated again (pool not leaked).
+        reused = alloc.allocate()
+        assert reused is not None
+        alloc.release(reused)
+
+    @pytest.mark.asyncio
+    async def test_restore_session_failure_releases_slot_and_closes_browser(
+        self, monkeypatch,
+    ):
+        mgr, alloc, raised, ctx = (
+            await self._drive_start_browser_with_failing_tail(
+                monkeypatch, "_maybe_restore_session",
+            )
+        )
+        assert raised is not None
+        assert "agent-h13" not in mgr._instances
+        assert alloc.allocated_count == 0
+        # Browser context was closed during rollback.
+        ctx.close.assert_awaited()
+
+
+class TestReconcileOrphanedSlots:
+    """H13 — the idle sweep reclaims allocated-but-unbacked display slots."""
+
+    def _free_allocator(self, span: int = 5):
+        from src.browser.display_allocator import (
+            DisplayAllocator,
+            _port_is_bindable,
+            port_for_display,
+        )
+        for display_start in range(200, 500):
+            if all(
+                _port_is_bindable(port_for_display(d))
+                for d in range(display_start, display_start + span)
+            ):
+                break
+        else:
+            pytest.skip("no free display/VNC test range available")
+        return DisplayAllocator(
+            display_start=display_start,
+            display_end=display_start + span,
+            run_boot_sweep=False,
+        )
+
+    def test_reconcile_releases_orphan_keeps_live(self):
+        from src.browser.service import BrowserManager, CamoufoxInstance
+
+        mgr = BrowserManager(profiles_dir="/tmp/test_profiles_h13r")
+        alloc = self._free_allocator()
+        mgr._display_allocator = alloc
+
+        live_slot = alloc.allocate()
+        orphan_slot = alloc.allocate()
+        assert alloc.allocated_count == 2
+
+        # One slot is backed by a live instance; the other is orphaned.
+        live = CamoufoxInstance("live", MagicMock(), AsyncMock(), AsyncMock())
+        live.display_slot = live_slot
+        mgr._instances["live"] = live
+
+        mgr._reconcile_orphaned_slots()
+
+        # Orphan released, live slot untouched.
+        assert not alloc.is_allocated(orphan_slot.display)
+        assert alloc.is_allocated(live_slot.display)
+        assert alloc.allocated_count == 1
+
+    def test_reconcile_noop_when_all_backed(self):
+        from src.browser.service import BrowserManager, CamoufoxInstance
+
+        mgr = BrowserManager(profiles_dir="/tmp/test_profiles_h13r2")
+        alloc = self._free_allocator()
+        mgr._display_allocator = alloc
+
+        s1 = alloc.allocate()
+        s2 = alloc.allocate()
+        for name, slot in (("a", s1), ("b", s2)):
+            inst = CamoufoxInstance(name, MagicMock(), AsyncMock(), AsyncMock())
+            inst.display_slot = slot
+            mgr._instances[name] = inst
+
+        mgr._reconcile_orphaned_slots()
+        assert alloc.allocated_count == 2
+
+    def test_reconcile_noop_without_allocator(self):
+        from src.browser.service import BrowserManager
+
+        mgr = BrowserManager(profiles_dir="/tmp/test_profiles_h13r3")
+        # Never constructed — must not raise.
+        assert mgr._display_allocator is None
+        mgr._reconcile_orphaned_slots()
+        assert mgr._display_allocator is None
+
+    @pytest.mark.asyncio
+    async def test_cleanup_idle_invokes_reconcile(self):
+        from src.browser.service import BrowserManager
+
+        mgr = BrowserManager(profiles_dir="/tmp/test_profiles_h13r4")
+        alloc = self._free_allocator()
+        mgr._display_allocator = alloc
+        orphan = alloc.allocate()
+        assert alloc.allocated_count == 1
+
+        await mgr._cleanup_idle()
+        # No live instances reference the slot — the sweep reclaims it.
+        assert not alloc.is_allocated(orphan.display)
+        assert alloc.allocated_count == 0
+
+
 class TestBrowserServer:
     """Tests for the browser service FastAPI endpoints."""
 


### PR DESCRIPTION
## May 2026 security remediation — finding H13 (browser display-pool exhaustion DoS)

### The bug
`_start_browser` allocates a `(display, VNC-port)` slot from the 64-slot
`DisplayAllocator` and spawns the per-agent Xvnc/Openbox/Camoufox process
stack. The awaits **after** a successful Camoufox launch — `context.new_page()`,
`_maybe_restore_session`, and X11 WID discovery — were **unguarded**.

`get_or_start` registers the instance in `_instances` only on full success
(`instance = await self._start_browser(...)` with no try/except, then
`self._instances[agent_id] = instance`). So if any tail await raises:

- the allocated slot stays in `_display_allocator._allocated`, and
- the launched Xvnc/Camoufox processes keep running,

both **invisible** to `_cleanup_idle` / `stop_all`, which iterate only
`_instances`. With 64 slots, repeated failures exhaust the pool →
`PoolExhausted` → **fleet-wide browser denial**.

### The fix
1. **Rollback guard on the post-launch tail of `_start_browser`** — mirrors
   the existing Camoufox-failure branch. On any exception: cancel any spawned
   jitter task, close the browser context, tear down the per-agent X stack
   (which releases the slot via `_teardown_per_agent_x_stack`), then re-raise.
   No slot or process survives a failed launch. The success path is unchanged.

2. **Reconciliation sweep** in `_cleanup_idle` (`_reconcile_orphaned_slots`):
   releases any slot marked allocated but backed by no live instance. Runs
   under the manager lock so the live-instance view is consistent with the
   allocator snapshot; live/starting slots are never reclaimed. Belt-and-braces
   net for future leak paths and slots stranded by pre-fix builds.

### Allocator accessor added
`DisplayAllocator.allocated_slots()` — returns a fresh sorted list of the
currently-allocated `Slot`s so the sweep can iterate without exposing or
mutating the internal `_allocated` set.

### Tests (in `tests/test_browser_service.py`)
- `TestStartBrowserSlotLeak`: drives the real `_start_browser` with mocked
  native boundaries (Playwright/Camoufox/profile-migration/X-spawn) and a tail
  step (`new_page` / `_maybe_restore_session`) rigged to raise — asserts the
  slot is released, no instance registered, the slot is reusable, and the
  context is closed. `_teardown_per_agent_x_stack` is left **real** so the
  genuine rollback is exercised.
- `TestReconcileOrphanedSlots`: orphan released while live slot is untouched;
  no-op when all backed; no-op without an allocator; `_cleanup_idle` invokes
  the sweep.

All 512 tests in `test_display_allocator.py` + `test_browser_service.py` pass
(7 playwright-gated skips); ruff clean.

> Note: may need rebasing against an in-flight browser-service refactor.

Files changed:
- `src/browser/service.py` — tail rollback guard + `_reconcile_orphaned_slots` + `_cleanup_idle` call
- `src/browser/display_allocator.py` — `allocated_slots()` accessor
- `tests/test_browser_service.py` — two new test classes