### PR TITLE
fix(traces): restrict trace reads to operator and redact previews at capture

### DIFF
--- a/src/host/server.py
+++ b/src/host/server.py
@@ -3715,16 +3715,27 @@ def create_mesh_app(
 
     @app.get("/mesh/traces")
     async def list_traces(request: Request, limit: int = 50) -> list[dict]:
-        """Return recent trace events."""
-        _require_any_auth(request)
+        """Return recent trace events.
+
+        Operator/loopback-internal only (H16): traces carry prompt/response
+        previews across every agent. ``_require_any_auth`` accepted ANY
+        agent's bearer, enabling cross-agent disclosure — tightened to
+        ``_require_operator_or_internal``. The dashboard reads traces via the
+        ``trace_store`` object on its session-authed router, NOT this HTTP
+        endpoint, so this gate does not affect the dashboard.
+        """
+        _require_operator_or_internal(request)
         if trace_store is None:
             return []
         return trace_store.list_recent(limit=limit)
 
     @app.get("/mesh/traces/{trace_id}")
     async def get_trace(trace_id: str, request: Request) -> list[dict]:
-        """Return all events for a specific trace."""
-        _require_any_auth(request)
+        """Return all events for a specific trace.
+
+        Operator/loopback-internal only (H16) — see ``list_traces``.
+        """
+        _require_operator_or_internal(request)
         if trace_store is None:
             return []
         return trace_store.get_trace(trace_id)

--- a/src/host/traces.py
+++ b/src/host/traces.py
@@ -15,6 +15,7 @@ import threading
 import time
 from pathlib import Path
 
+from src.shared.redaction import deep_redact, redact_text_with_urls
 from src.shared.sqlite_helpers import open_db
 from src.shared.utils import dumps_safe, setup_logging
 
@@ -77,8 +78,18 @@ class TraceStore:
         error: str = "",
         meta: dict | None = None,
     ) -> None:
-        """Insert a trace event."""
-        meta_json = dumps_safe(meta) if meta else ""
+        """Insert a trace event.
+
+        Free-form text fields (``detail``, ``error``) and every string inside
+        ``meta`` (notably ``prompt_preview`` / ``response_preview``, which
+        echo user chat and model output verbatim) are redacted at capture so a
+        credential pasted in chat or emitted by the model is never persisted in
+        plaintext (H16). Redaction is centralized here rather than at each of
+        the ~8 ``record`` callsites in the mesh so no path can regress.
+        """
+        detail = redact_text_with_urls(detail)
+        error = redact_text_with_urls(error)
+        meta_json = dumps_safe(deep_redact(meta)) if meta else ""
         self._conn.execute(
             "INSERT INTO traces "
             "(trace_id, timestamp, source, agent, event_type, detail, duration_ms, status, error, meta_json) "

--- a/tests/test_denial_counter.py
+++ b/tests/test_denial_counter.py
@@ -259,10 +259,10 @@ class TestDenialCounterAuthAndRole:
         client = TestClient(app)
 
         try:
-            # ``/mesh/traces`` is gated by ``_require_any_auth`` (not
+            # ``/mesh/model-health`` is gated by ``_require_any_auth`` (not
             # ``_extract_verified_agent_id``). Hit it with no Authorization
             # header — expect 401 + counter bump.
-            resp = client.get("/mesh/traces")
+            resp = client.get("/mesh/model-health")
             assert resp.status_code == 401
             assert host_server._denial_counter["auth"] == 1
         finally:
@@ -295,7 +295,7 @@ class TestDenialCounterAuthAndRole:
 
         try:
             resp = client.get(
-                "/mesh/traces",
+                "/mesh/model-health",
                 headers={"Authorization": "Bearer wrong-token"},
             )
             assert resp.status_code == 401

--- a/tests/test_operator_trust_tier.py
+++ b/tests/test_operator_trust_tier.py
@@ -753,3 +753,70 @@ def test_raise_with_body_passthrough_on_success():
     response = httpx.Response(status_code=200, request=request, content=b"{}")
     # No exception.
     _raise_with_body(response)
+
+
+# =============================================================================
+# Trace endpoints are operator/loopback-internal only (H16)
+# =============================================================================
+#
+# ``/mesh/traces`` and ``/mesh/traces/{id}`` expose prompt/response previews
+# across every agent. They previously used ``_require_any_auth``, so any
+# agent's bearer could read every agent's stored LLM previews (cross-agent
+# disclosure). They now require operator or loopback ``x-mesh-internal``.
+
+
+@pytest.mark.asyncio
+async def test_worker_cannot_list_traces(mesh_setup):
+    """A regular agent bearer gets 403 on /mesh/traces (operator-only)."""
+    app = mesh_setup["app"]
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://test",
+    ) as client:
+        resp = await client.get(
+            "/mesh/traces",
+            headers=_hdr(mesh_setup["tokens"]["trend-scout"]),
+        )
+    assert resp.status_code == 403, resp.text
+
+
+@pytest.mark.asyncio
+async def test_worker_cannot_get_trace(mesh_setup):
+    """A regular agent bearer gets 403 on /mesh/traces/{id}."""
+    app = mesh_setup["app"]
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://test",
+    ) as client:
+        resp = await client.get(
+            "/mesh/traces/tr_anything",
+            headers=_hdr(mesh_setup["tokens"]["seo-strategist"]),
+        )
+    assert resp.status_code == 403, resp.text
+
+
+@pytest.mark.asyncio
+async def test_operator_can_list_traces(mesh_setup):
+    """Operator bearer still reads traces."""
+    app = mesh_setup["app"]
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://test",
+    ) as client:
+        resp = await client.get(
+            "/mesh/traces",
+            headers=_hdr(mesh_setup["tokens"]["operator"]),
+        )
+    assert resp.status_code == 200, resp.text
+
+
+@pytest.mark.asyncio
+async def test_internal_loopback_can_list_traces(mesh_setup):
+    """Loopback x-mesh-internal callers (health checks) still read traces."""
+    app = mesh_setup["app"]
+    transport = ASGITransport(app=app, client=("127.0.0.1", 12345))
+    async with AsyncClient(
+        transport=transport, base_url="http://test",
+    ) as client:
+        resp = await client.get(
+            "/mesh/traces",
+            headers={"x-mesh-internal": "1"},
+        )
+    assert resp.status_code == 200, resp.text

--- a/tests/test_traces.py
+++ b/tests/test_traces.py
@@ -138,7 +138,10 @@ class TestTraceStore:
 
     def test_list_trace_summaries_trigger_preview_truncation(self):
         """trigger_preview is truncated to 120 chars."""
-        long_detail = "x" * 200
+        # Space-separated words so capture-time redaction (which collapses
+        # long unbroken alnum blobs to a single [REDACTED] token, as those
+        # are indistinguishable from secrets) leaves the length intact.
+        long_detail = "word " * 60  # 300 chars
         self.store.record("tr_long", "dispatch", "a", "chat", detail=long_detail)
         summaries = self.store.list_trace_summaries(limit=10)
         assert len(summaries[0]["trigger_preview"]) == 120
@@ -267,6 +270,72 @@ class TestTraceStoreCleanup:
     def test_cleanup_nonexistent_agent(self):
         deleted = self.store.cleanup_agent("ghost")
         assert deleted == 0
+
+
+# ── Redaction at capture (H16) ───────────────────────────────
+
+class TestTraceRedactionAtCapture:
+    """Secrets must be redacted before they hit the SQLite store, not just
+    on read — a credential pasted in chat or echoed by the model can ride
+    into ``detail`` / ``error`` / ``meta`` previews."""
+
+    def setup_method(self):
+        self._tmpdir = tempfile.mkdtemp()
+        self.db_path = os.path.join(self._tmpdir, "traces.db")
+        self.store = TraceStore(db_path=self.db_path)
+
+    def teardown_method(self):
+        self.store.close()
+        shutil.rmtree(self._tmpdir, ignore_errors=True)
+
+    def test_secret_in_meta_preview_redacted_at_rest(self):
+        secret = "sk-ant-api03ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
+        self.store.record(
+            "tr_secret", "mesh.api_proxy", "alpha", "llm_call",
+            meta={"prompt_preview": f"my key is {secret}",
+                  "response_preview": f"got it: {secret}"},
+        )
+        # Assert raw SQLite bytes do not contain the secret.
+        raw = self.store._conn.execute(
+            "SELECT meta_json FROM traces WHERE trace_id = ?", ("tr_secret",)
+        ).fetchone()[0]
+        assert secret not in raw
+        assert "[REDACTED]" in raw
+
+        events = self.store.get_trace("tr_secret")
+        assert secret not in events[0]["meta"]["prompt_preview"]
+        assert secret not in events[0]["meta"]["response_preview"]
+
+    def test_secret_in_detail_redacted_at_rest(self):
+        secret = "sk-ant-api03ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
+        self.store.record("tr_d", "repl", "alpha", "chat", detail=f"token {secret}")
+        events = self.store.get_trace("tr_d")
+        assert secret not in events[0]["detail"]
+        assert "[REDACTED]" in events[0]["detail"]
+
+    def test_secret_in_error_redacted_at_rest(self):
+        secret = "sk-ant-api03ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
+        self.store.record(
+            "tr_e", "mesh", "alpha", "llm_call",
+            status="error", error=f"auth failed with {secret}",
+        )
+        events = self.store.get_trace("tr_e")
+        assert secret not in events[0]["error"]
+        assert "[REDACTED]" in events[0]["error"]
+
+    def test_sensitive_url_query_param_redacted_in_detail(self):
+        self.store.record(
+            "tr_url", "mesh", "alpha", "http_call",
+            detail="GET https://api.example.com/v1?api_key=supersecretvalue123",
+        )
+        events = self.store.get_trace("tr_url")
+        assert "supersecretvalue123" not in events[0]["detail"]
+        assert "[REDACTED]" in events[0]["detail"]
+
+    def test_benign_text_unchanged(self):
+        self.store.record("tr_ok", "repl", "alpha", "chat", detail="hello world")
+        events = self.store.get_trace("tr_ok")
+        assert events[0]["detail"] == "hello world"
 
 
 # ── _extract_prompt_preview ──────────────────────────────────


### PR DESCRIPTION
## May 2026 security remediation — finding H16

### Problem
The mesh trace endpoints `/mesh/traces` and `/mesh/traces/{id}` were gated by `_require_any_auth`, which accepts **any** valid agent bearer token. Two issues compounded:

1. **Cross-agent disclosure.** Any agent could read *every* agent's stored LLM prompt/response previews.
2. **Plaintext-at-rest.** Those previews (`prompt_preview` / `response_preview`) were persisted unredacted — a credential pasted in chat or echoed back by the model was stored in the clear in `data/traces.db`.

### Fix
1. Both endpoints now call `_require_operator_or_internal` instead of `_require_any_auth` — operator bearer or loopback `x-mesh-internal` only. A valid worker bearer gets **403** (authenticated but wrong scope), not 401.
2. `TraceStore.record` redacts at capture, before the row is written:
   - `detail` / `error` → `redact_text_with_urls` (token shapes + sensitive URL query params)
   - `meta` dict (holds the previews) → `deep_redact`
   Centralized in `record` rather than at each of the ~8 mesh callsites so no capture path can regress. Reuses `src/shared/redaction.py` (read-only, untouched).

### Dashboard not affected (verified)
The dashboard reads traces via the `trace_store` **object** directly on its session-authed router (`list_trace_summaries` / `get_trace` / `query` in `src/dashboard/server.py`), never via the `/mesh/traces` HTTP endpoint. Also verified no agent builtin/tool/mesh_client in `src/agent/` references `/mesh/traces`. So operator-gating the HTTP endpoint changes no dashboard or agent behavior.

### Tests
- `tests/test_operator_trust_tier.py`: worker bearer → 403 on both endpoints; operator → 200; loopback `x-mesh-internal` → 200.
- `tests/test_traces.py`: secret-shaped strings in `detail` / `error` / `meta` previews are redacted at rest (asserted against raw SQLite bytes); sensitive URL query params stripped; benign text unchanged.
- `test_traces.py` + `test_operator_trust_tier.py`: **82 passed**. One pre-existing truncation test used a 200-char `"x"*200` fixture that legitimately matches the long-blob secret pattern; switched it to space-separated words so it still validates the 120-char truncation.

> Note: may need rebasing against an in-flight refactor.