### PR TITLE
fix(channels): owner-gate privileged commands, require WhatsApp signature, dedup webhooks

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -170,7 +170,7 @@ SHM (shared memory) is critical for Firefox compositor IPC — too small causes 
 | `telegram.py` | Telegram Bot API adapter (sanitized streaming). |
 | `discord.py` | Discord Bot adapter (sanitized streaming). |
 | `slack.py` | Slack adapter (Socket Mode via slack-bolt, sanitized streaming). |
-| `whatsapp.py` | WhatsApp Cloud API adapter. `X-Hub-Signature-256` HMAC verification when `WHATSAPP_APP_SECRET` is set; warns once and disables verification otherwise. |
+| `whatsapp.py` | WhatsApp Cloud API adapter. `WHATSAPP_APP_SECRET` is mandatory (decoupled from `MESH_AUTH_TOKEN`): `start()` raises without it and the webhook returns 503 fail-closed. Mandatory `X-Hub-Signature-256` HMAC verification (401 on mismatch). Inbound dedup by `message["id"]` via bounded TTL/LRU set. |
 
 ### Dashboard (`src/dashboard/`)
 

--- a/docs/channels.md
+++ b/docs/channels.md
@@ -299,7 +299,12 @@ WhatsApp uses the **Cloud API** (pinned to Graph API `v21.0` via `_GRAPH_API_BAS
 
 ### Security
 
-**Production deployments must set `WHATSAPP_APP_SECRET`.** Without it, `X-Hub-Signature-256` webhook signature verification is disabled — any HTTP client can inject arbitrary messages. When `MESH_AUTH_TOKEN` is set (i.e., production mode) and `WHATSAPP_APP_SECRET` is absent, channel startup raises a `RuntimeError` (`src/channels/whatsapp.py:103-108`). Incoming signatures are compared with `hmac.compare_digest` (timing-safe).
+**`WHATSAPP_APP_SECRET` is mandatory whenever the WhatsApp channel is enabled** (decoupled from `MESH_AUTH_TOKEN` as of the May 2026 H9 remediation). Without it, `X-Hub-Signature-256` webhook signature verification is impossible and any HTTP client could inject arbitrary messages, so the channel fails closed:
+
+- `start()` raises a `RuntimeError` if `WHATSAPP_APP_SECRET` is absent — the channel refuses to boot.
+- As defense in depth, the webhook POST handler also returns **HTTP 503** when the secret is unset rather than processing unauthenticated input.
+
+Incoming signatures are compared with `hmac.compare_digest` (timing-safe); a mismatch returns HTTP 401. Inbound messages are de-duplicated by their WhatsApp `message["id"]` via a bounded TTL/LRU set, so Cloud API retries/replays don't double-fire dispatch.
 
 Set the app secret to the value shown in the Meta dashboard under your WhatsApp app → App Settings → App Secret:
 

--- a/src/channels/base.py
+++ b/src/channels/base.py
@@ -178,6 +178,17 @@ class Channel(abc.ABC):
             type(self).__name__, user_id,
         )
 
+    def _resolve_owner(self, user_id: str) -> bool:
+        """Whether ``user_id`` is the channel owner.
+
+        Base default is ``False`` (fail-closed): a channel with no owner
+        concept grants no privileged access.  Subclasses with a
+        ``PairingManager`` override this to consult ``_is_owner`` and to
+        normalize their platform-specific user-key format (e.g. Slack's
+        ``user_id:thread_ts`` composite) before the lookup.
+        """
+        return False
+
     def _get_active_agent(self, user_id: str) -> str:
         return self._active_agent.get(user_id, self.default_agent)
 
@@ -240,7 +251,10 @@ class Channel(abc.ABC):
 
         # Slash commands
         if message.startswith("/"):
-            return await self._handle_command(user_id, message, current, agents)
+            is_owner = self._resolve_owner(user_id)
+            return await self._handle_command(
+                user_id, message, current, agents, is_owner,
+            )
 
         # Normal message: build origin and dispatch to agent.
         # Task 2b: stamp typed ``MessageOrigin`` (kind="human") so the
@@ -260,11 +274,26 @@ class Channel(abc.ABC):
             return ""  # Suppress silent/empty responses
         return f"[{target}] {response}"
 
+    #: Commands gated to the channel owner only. Non-owner allowed users
+    #: keep chat + read-only commands (/use, /agents, /status, /costs, /help)
+    #: but are refused these privileged, state-mutating / sensitive ones.
+    _OWNER_ONLY_COMMANDS = frozenset({
+        "/addkey", "/steer", "/broadcast", "/reset", "/debug",
+    })
+
     async def _handle_command(
         self, user_id: str, message: str, current: str, agents: list[str],
+        is_owner: bool = False,
     ) -> str:
         parts = message.split(None, 1)
         cmd = parts[0].lower()
+
+        # H2: owner-gate privileged commands. Allowed (non-owner) users are
+        # already authenticated for chat + read-only commands, but these
+        # commands can mint credentials, inject context, broadcast, reset
+        # state, or expose traces — restrict them to the owner.
+        if cmd in self._OWNER_ONLY_COMMANDS and not is_owner:
+            return f"'{cmd}' is owner only."
 
         if cmd == "/use":
             if len(parts) < 2:
@@ -404,18 +433,22 @@ class Channel(abc.ABC):
                 "  /use <agent>      Switch active agent",
                 "  /agents           List all agents",
                 "  /status           Show agent health",
-                "  /broadcast <msg>  Send to all agents",
             ]
-            if self.steer_fn:
-                lines.append("  /steer <msg>      Inject message into busy agent's context")
-            if self.debug_fn:
-                lines.append("  /debug [trace_id] Show recent traces or trace detail")
-            lines.extend([
-                "  /costs            Show today's LLM spend",
-                "  /addkey <svc> <key>  Add an API credential",
-                "  /reset            Clear conversation with active agent",
-                "  /help             Show this help",
-            ])
+            # Owner-only commands surface in help only for the owner so
+            # non-owner allowed users aren't told about commands they can't run.
+            if is_owner:
+                lines.append("  /broadcast <msg>  Send to all agents")
+                if self.steer_fn:
+                    lines.append("  /steer <msg>      Inject message into busy agent's context")
+                if self.debug_fn:
+                    lines.append("  /debug [trace_id] Show recent traces or trace detail")
+            lines.append("  /costs            Show today's LLM spend")
+            if is_owner:
+                lines.extend([
+                    "  /addkey <svc> <key>  Add an API credential",
+                    "  /reset            Clear conversation with active agent",
+                ])
+            lines.append("  /help             Show this help")
             return "\n".join(lines)
 
         return f"Unknown command: {cmd}. Type /help for commands."

--- a/src/channels/discord.py
+++ b/src/channels/discord.py
@@ -56,6 +56,17 @@ class DiscordChannel(Channel):
     def _is_owner(self, user_id: int) -> bool:
         return self._pairing.is_owner(user_id)
 
+    def _resolve_owner(self, user_id: str) -> bool:
+        """Owner check for base ``handle_message`` (H2 privileged-command gate).
+
+        ``handle_message`` receives the Discord user id as a string; the
+        pairing store keys on the integer id, so coerce before lookup.
+        """
+        try:
+            return self._is_owner(int(user_id))
+        except (TypeError, ValueError):
+            return False
+
     # ── extracted command handlers ─────────────────────────────
 
     def _handle_pairing(self, author_id: int, code_arg: str) -> str:

--- a/src/channels/slack.py
+++ b/src/channels/slack.py
@@ -179,6 +179,16 @@ class SlackChannel(Channel):
     def _is_owner(self, user_id: str) -> bool:
         return self._pairing.is_owner(user_id)
 
+    def _resolve_owner(self, user_id: str) -> bool:
+        """Owner check for base ``handle_message`` (H2 privileged-command gate).
+
+        ``handle_message`` is called with the composite ``user_id:thread_ts``
+        key from ``_get_user_key``; the pairing store keys on the bare Slack
+        user id, so strip the thread suffix before the lookup.
+        """
+        bare_user_id = user_id.partition(":")[0]
+        return self._is_owner(bare_user_id)
+
     async def _on_message(self, event: dict, say) -> None:
         """Handle incoming Slack message events."""
         logger.warning(

--- a/src/channels/telegram.py
+++ b/src/channels/telegram.py
@@ -278,6 +278,17 @@ class TelegramChannel(Channel):
     def _is_owner(self, user_id: int) -> bool:
         return self._pairing.is_owner(user_id)
 
+    def _resolve_owner(self, user_id: str) -> bool:
+        """Owner check for base ``handle_message`` (H2 privileged-command gate).
+
+        ``handle_message`` receives the Telegram user id as a string; the
+        pairing store keys on the integer id, so coerce before lookup.
+        """
+        try:
+            return self._is_owner(int(user_id))
+        except (TypeError, ValueError):
+            return False
+
     async def _cmd_start(self, update, context) -> None:
         user_id = update.effective_user.id
         username = update.effective_user.username or update.effective_user.first_name

--- a/src/channels/whatsapp.py
+++ b/src/channels/whatsapp.py
@@ -22,7 +22,9 @@ import asyncio
 import hashlib
 import hmac
 import os
+import time
 import weakref
+from collections import OrderedDict
 
 import httpx
 from fastapi import APIRouter, HTTPException, Query, Request
@@ -34,6 +36,47 @@ logger = setup_logging("channels.whatsapp")
 
 MAX_WA_LEN = 4096
 _GRAPH_API_BASE = "https://graph.facebook.com/v21.0"
+
+# M7: inbound dedup. WhatsApp Cloud API redelivers webhooks on any non-2xx /
+# slow response, so the same message["id"] can arrive several times. Bound the
+# seen-set so it can't grow without limit, and expire entries after a TTL so a
+# long-lived process doesn't reject a legitimately-reused id forever.
+_DEDUP_TTL_SECONDS = 3600
+_DEDUP_MAX_IDS = 4096
+
+
+class _SeenIds:
+    """Bounded TTL/LRU set of already-processed message ids.
+
+    Not thread-safe by design — only touched from the single webhook event
+    loop. ``add`` returns False when the id was already present (a replay).
+    """
+
+    def __init__(self, ttl: float = _DEDUP_TTL_SECONDS, maxlen: int = _DEDUP_MAX_IDS):
+        self._ttl = ttl
+        self._maxlen = maxlen
+        self._ids: OrderedDict[str, float] = OrderedDict()
+
+    def add(self, msg_id: str, now: float | None = None) -> bool:
+        """Record ``msg_id``; return True if newly seen, False if a replay."""
+        if not msg_id:
+            # No id to dedup on — treat as new so the message still processes.
+            return True
+        now = time.monotonic() if now is None else now
+        # Drop expired entries (cheap amortized sweep from the oldest end).
+        while self._ids:
+            oldest_id, ts = next(iter(self._ids.items()))
+            if now - ts > self._ttl:
+                self._ids.popitem(last=False)
+            else:
+                break
+        if msg_id in self._ids:
+            return False
+        self._ids[msg_id] = now
+        # LRU cap: evict oldest insertions beyond the bound.
+        while len(self._ids) > self._maxlen:
+            self._ids.popitem(last=False)
+        return True
 
 
 class WhatsAppChannel(Channel):
@@ -73,6 +116,7 @@ class WhatsAppChannel(Channel):
         self._phone_numbers: set[str] = set()
         self._denied_notified: set[str] = set()
         self._pairing = PairingManager("config/whatsapp_paired.json")
+        self._seen_ids = _SeenIds()  # M7: inbound webhook dedup
 
     def _client_for_loop(self) -> httpx.AsyncClient | None:
         """Return a per-loop httpx client, creating it lazily on first use.
@@ -100,10 +144,16 @@ class WhatsAppChannel(Channel):
         return client
 
     async def start(self) -> None:
-        if os.environ.get("MESH_AUTH_TOKEN") and not os.environ.get("WHATSAPP_APP_SECRET"):
+        # H9: WHATSAPP_APP_SECRET is mandatory whenever this channel is enabled,
+        # decoupled from MESH_AUTH_TOKEN. Real WhatsApp delivery requires the
+        # Meta app secret anyway; without it webhook signatures cannot be
+        # verified and any HTTP client could inject messages. Fail closed.
+        if not os.environ.get("WHATSAPP_APP_SECRET"):
             raise RuntimeError(
-                "WHATSAPP_APP_SECRET is required in production (MESH_AUTH_TOKEN is set). "
-                "Without it, webhook signature verification is disabled."
+                "WHATSAPP_APP_SECRET is required to run the WhatsApp channel. "
+                "Without it, webhook signature verification is disabled and any "
+                "HTTP client could inject messages. Set the app secret from the "
+                "Meta app dashboard."
             )
         # Warm the cache for the current loop and mirror the client onto
         # ``_http`` so existing readiness checks (``if not self._http``)
@@ -193,6 +243,14 @@ class WhatsAppChannel(Channel):
     def _is_owner(self, phone: str) -> bool:
         return self._pairing.is_owner(phone)
 
+    def _resolve_owner(self, user_id: str) -> bool:
+        """Owner check for base ``handle_message`` (H2 privileged-command gate).
+
+        WhatsApp keys users by phone number, which is exactly what
+        ``handle_message`` receives, so this is a direct pairing lookup.
+        """
+        return self._is_owner(user_id)
+
     def create_router(self) -> APIRouter:
         """Create a FastAPI router for WhatsApp webhook endpoints."""
         router = APIRouter(prefix="/channels/whatsapp")
@@ -214,22 +272,28 @@ class WhatsAppChannel(Channel):
         @router.post("/webhook")
         async def receive_webhook(request: Request) -> dict:
             """Receive incoming WhatsApp messages."""
-            # Verify X-Hub-Signature-256 -- required for production security
+            # H9: signature verification is mandatory. Without an app secret we
+            # cannot authenticate the sender, so fail closed (503) rather than
+            # process unauthenticated input. start() already refuses to boot the
+            # channel without WHATSAPP_APP_SECRET; this is defense in depth.
             app_secret = os.environ.get("WHATSAPP_APP_SECRET", "")
-            if not app_secret and not getattr(receive_webhook, "_no_secret_warned", False):
-                logger.warning(
-                    "WHATSAPP_APP_SECRET not set — webhook signature verification DISABLED. "
-                    "Any HTTP client can inject messages. Set the app secret from Meta dashboard."
+            if not app_secret:
+                logger.error(
+                    "WhatsApp webhook rejected: WHATSAPP_APP_SECRET not set — "
+                    "signature verification impossible. Refusing to process."
                 )
-                receive_webhook._no_secret_warned = True  # type: ignore[attr-defined]
-            if app_secret:
-                raw_body = await request.body()
-                signature = request.headers.get("X-Hub-Signature-256", "")
-                expected = "sha256=" + hmac.new(
-                    app_secret.encode(), raw_body, hashlib.sha256,
-                ).hexdigest()
-                if not hmac.compare_digest(signature, expected):
-                    raise HTTPException(status_code=401, detail="Invalid signature")
+                raise HTTPException(
+                    status_code=503,
+                    detail="WhatsApp webhook unavailable: app secret not configured",
+                )
+
+            raw_body = await request.body()
+            signature = request.headers.get("X-Hub-Signature-256", "")
+            expected = "sha256=" + hmac.new(
+                app_secret.encode(), raw_body, hashlib.sha256,
+            ).hexdigest()
+            if not hmac.compare_digest(signature, expected):
+                raise HTTPException(status_code=401, detail="Invalid signature")
 
             try:
                 body = await request.json()
@@ -242,6 +306,13 @@ class WhatsAppChannel(Channel):
                 for change in entry.get("changes", []):
                     value = change.get("value", {})
                     for message in value.get("messages", []):
+                        # M7: skip replays/retries of an already-seen message id.
+                        if not channel_ref._seen_ids.add(message.get("id", "")):
+                            logger.info(
+                                "WhatsApp webhook: duplicate message id %s ignored",
+                                message.get("id", ""),
+                            )
+                            continue
                         asyncio.create_task(
                             channel_ref._process_message(message)
                         )

--- a/src/host/webhooks.py
+++ b/src/host/webhooks.py
@@ -12,6 +12,8 @@ import hashlib
 import hmac
 import json
 import secrets
+import time
+from collections import OrderedDict
 from collections.abc import Callable
 from datetime import datetime, timezone
 from pathlib import Path
@@ -21,6 +23,52 @@ from fastapi import APIRouter, HTTPException, Request
 from src.shared.utils import dumps_safe, generate_id, sanitize_for_prompt, setup_logging
 
 logger = setup_logging("host.webhooks")
+
+# M7: inbound dedup. Senders that retry on a slow/failed response can replay an
+# identical delivery. When the caller supplies a delivery id / nonce header we
+# remember it in a bounded TTL/LRU set and drop repeats so we don't double-fire
+# the agent dispatch. Bounded so a flood of unique ids can't exhaust memory.
+_DEDUP_TTL_SECONDS = 3600
+_DEDUP_MAX_IDS = 4096
+# Common delivery-id / idempotency headers, checked in order.
+_NONCE_HEADERS = (
+    "x-webhook-id",
+    "x-webhook-nonce",
+    "x-idempotency-key",
+    "x-delivery-id",
+    "x-github-delivery",
+)
+
+
+class _SeenNonces:
+    """Bounded TTL/LRU set of already-processed webhook delivery ids."""
+
+    def __init__(self, ttl: float = _DEDUP_TTL_SECONDS, maxlen: int = _DEDUP_MAX_IDS):
+        self._ttl = ttl
+        self._maxlen = maxlen
+        self._ids: OrderedDict[str, float] = OrderedDict()
+
+    def add(self, nonce: str, now: float | None = None) -> bool:
+        """Record ``nonce``; return True if newly seen, False if a replay.
+
+        An empty nonce means the caller supplied no delivery id, so we can't
+        dedup — treat as new and let the message process.
+        """
+        if not nonce:
+            return True
+        now = time.monotonic() if now is None else now
+        while self._ids:
+            _oldest, ts = next(iter(self._ids.items()))
+            if now - ts > self._ttl:
+                self._ids.popitem(last=False)
+            else:
+                break
+        if nonce in self._ids:
+            return False
+        self._ids[nonce] = now
+        while len(self._ids) > self._maxlen:
+            self._ids.popitem(last=False)
+        return True
 
 
 def _build_message(hook: dict, body_json: str, *, test: bool = False) -> str:
@@ -43,6 +91,7 @@ class WebhookManager:
         self.config_path = Path(config_path)
         self.hooks: dict[str, dict] = {}
         self.dispatch_fn = dispatch_fn
+        self._seen_nonces = _SeenNonces()  # M7: inbound dedup
         self._load()
 
     def _load(self) -> None:
@@ -181,6 +230,18 @@ class WebhookManager:
                 ).hexdigest()
                 if not hmac.compare_digest(sig_header, expected):
                     raise HTTPException(status_code=401, detail="Invalid signature")
+
+            # M7: drop replays of an already-seen delivery id / nonce. Checked
+            # after signature verification so an unauthenticated caller can't
+            # poison the dedup set with a victim's future delivery id.
+            nonce = ""
+            for header in _NONCE_HEADERS:
+                nonce = request.headers.get(header, "")
+                if nonce:
+                    break
+            if not manager._seen_nonces.add(nonce):
+                logger.info("Webhook %s: duplicate delivery %s ignored", hook_id, nonce)
+                return {"status": "duplicate", "hook": hook["name"]}
 
             try:
                 body = json.loads(raw_body)

--- a/tests/test_channels.py
+++ b/tests/test_channels.py
@@ -27,17 +27,30 @@ except ImportError:
 # ── Test concrete channel ─────────────────────────────────────
 
 class StubChannel(Channel):
-    """Concrete channel for testing base class behaviour."""
+    """Concrete channel for testing base class behaviour.
 
-    def __init__(self, **kwargs):
+    ``owner_ids`` controls which user ids ``_resolve_owner`` treats as the
+    owner. Defaults to ``None`` meaning *everyone is the owner* — this keeps
+    the broad command-coverage tests (which dispatch as an arbitrary "u1"
+    user) exercising the privileged-command paths. Tests that need a
+    non-owner user pass an explicit ``owner_ids`` set.
+    """
+
+    def __init__(self, owner_ids: set | None = None, **kwargs):
         super().__init__(**kwargs)
         self.notifications: list[str] = []
+        self._owner_ids = owner_ids
 
     async def start(self):
         pass
 
     async def stop(self):
         pass
+
+    def _resolve_owner(self, user_id: str) -> bool:
+        if self._owner_ids is None:
+            return True
+        return user_id in self._owner_ids
 
     async def send_notification(self, text: str) -> None:
         self.notifications.append(text)
@@ -325,6 +338,98 @@ class TestAddKeyCommand:
         ch = _make_channel()
         result = await ch.handle_message("u1", "/help")
         assert "/addkey" in result
+
+
+# ── H2: owner-gating of privileged commands ──────────────────
+
+class TestPrivilegedCommandOwnerGate:
+    """Non-owner allowed users keep chat + read-only commands but are
+    refused privileged ones (/addkey, /steer, /broadcast, /reset, /debug)."""
+
+    def _owner_aware_channel(self, **overrides):
+        # owner == "owner", everyone else is a non-owner allowed user.
+        stored: list = []
+
+        def addkey_fn(svc, key):
+            stored.append((svc, key))
+
+        steered: list = []
+
+        def steer_fn(agent, msg):
+            steered.append((agent, msg))
+
+        def debug_fn(trace_id=None):
+            return [{"trace_id": "abc", "agent": "alpha", "event_type": "chat"}]
+
+        defaults = {
+            "owner_ids": {"owner"},
+            "addkey_fn": addkey_fn,
+            "steer_fn": steer_fn,
+            "debug_fn": debug_fn,
+        }
+        defaults.update(overrides)
+        ch = _make_channel(**defaults)
+        ch._stored = stored
+        ch._steered = steered
+        return ch
+
+    @pytest.mark.asyncio
+    async def test_non_owner_refused_addkey(self):
+        ch = self._owner_aware_channel()
+        result = await ch.handle_message("intruder", "/addkey openai sk-evil")
+        assert "owner only" in result.lower()
+        assert ch._stored == []  # credential NOT stored
+
+    @pytest.mark.asyncio
+    async def test_owner_can_addkey(self):
+        ch = self._owner_aware_channel()
+        result = await ch.handle_message("owner", "/addkey openai sk-good")
+        assert "stored" in result.lower()
+        assert ch._stored == [("openai_api_key", "sk-good")]
+
+    @pytest.mark.asyncio
+    async def test_non_owner_refused_steer_broadcast_reset_debug(self):
+        ch = self._owner_aware_channel()
+        for cmd in ("/steer focus", "/broadcast hi", "/reset", "/debug"):
+            result = await ch.handle_message("intruder", cmd)
+            assert "owner only" in result.lower(), f"{cmd} not gated: {result}"
+        assert ch._steered == []
+        assert ch._resets == []
+
+    @pytest.mark.asyncio
+    async def test_owner_can_use_privileged_commands(self):
+        ch = self._owner_aware_channel()
+        assert "Steered" in await ch.handle_message("owner", "/steer focus")
+        assert "Broadcast" in await ch.handle_message("owner", "/broadcast hi")
+        assert "reset" in (await ch.handle_message("owner", "/reset")).lower()
+        assert "traces" in (await ch.handle_message("owner", "/debug")).lower()
+
+    @pytest.mark.asyncio
+    async def test_non_owner_keeps_chat_and_readonly(self):
+        """Non-owner allowed user can still chat and use read-only commands."""
+        ch = self._owner_aware_channel()
+        # Normal chat
+        chat = await ch.handle_message("intruder", "hello there")
+        assert "[alpha]" in chat
+        # Read-only commands all succeed (no "owner only")
+        for cmd in ("/agents", "/status", "/costs", "/use beta", "/help"):
+            result = await ch.handle_message("intruder", cmd)
+            assert "owner only" not in result.lower(), f"{cmd} wrongly gated"
+
+    @pytest.mark.asyncio
+    async def test_help_hides_privileged_for_non_owner(self):
+        ch = self._owner_aware_channel()
+        non_owner = await ch.handle_message("intruder", "/help")
+        assert "/addkey" not in non_owner
+        assert "/broadcast" not in non_owner
+        assert "/steer" not in non_owner
+        assert "/reset" not in non_owner
+        # read-only still listed
+        assert "/agents" in non_owner
+        assert "/costs" in non_owner
+        owner = await ch.handle_message("owner", "/help")
+        assert "/addkey" in owner
+        assert "/broadcast" in owner
 
 
 # ── Discord !-to-/ command translation ────────────────────────

--- a/tests/test_webhooks.py
+++ b/tests/test_webhooks.py
@@ -320,6 +320,55 @@ class TestWebhookRouter:
         resp = client.post(f"/webhook/hook/{hook['id']}", json={"event": "push"})
         assert resp.status_code == 401
 
+    def test_duplicate_nonce_dispatched_once(self):
+        """M7: replays with the same delivery-id header dispatch only once."""
+        dispatch = AsyncMock(return_value="ok")
+        app, mgr = self._make_app(dispatch_fn=dispatch)
+        hook = mgr.add_hook(agent="a", name="dedup")
+        client = TestClient(app)
+
+        headers = {"X-Webhook-Id": "delivery-123"}
+        r1 = client.post(f"/webhook/hook/{hook['id']}", json={"x": 1}, headers=headers)
+        r2 = client.post(f"/webhook/hook/{hook['id']}", json={"x": 1}, headers=headers)
+
+        assert r1.status_code == 200 and r1.json()["status"] == "processed"
+        assert r2.status_code == 200 and r2.json()["status"] == "duplicate"
+        dispatch.assert_called_once()
+        # call_count only incremented for the processed delivery
+        assert mgr.hooks[hook["id"]]["call_count"] == 1
+
+    def test_distinct_nonces_both_dispatched(self):
+        dispatch = AsyncMock(return_value="ok")
+        app, mgr = self._make_app(dispatch_fn=dispatch)
+        hook = mgr.add_hook(agent="a", name="dedup2")
+        client = TestClient(app)
+
+        client.post(f"/webhook/hook/{hook['id']}", json={}, headers={"X-Webhook-Id": "d1"})
+        client.post(f"/webhook/hook/{hook['id']}", json={}, headers={"X-Webhook-Id": "d2"})
+        assert dispatch.call_count == 2
+
+    def test_no_nonce_not_deduped(self):
+        """Without a delivery-id header, every delivery still processes."""
+        dispatch = AsyncMock(return_value="ok")
+        app, mgr = self._make_app(dispatch_fn=dispatch)
+        hook = mgr.add_hook(agent="a", name="nonce-less")
+        client = TestClient(app)
+
+        client.post(f"/webhook/hook/{hook['id']}", json={"x": 1})
+        client.post(f"/webhook/hook/{hook['id']}", json={"x": 1})
+        assert dispatch.call_count == 2
+
+    def test_github_delivery_header_deduped(self):
+        dispatch = AsyncMock(return_value="ok")
+        app, mgr = self._make_app(dispatch_fn=dispatch)
+        hook = mgr.add_hook(agent="a", name="gh")
+        client = TestClient(app)
+
+        headers = {"X-GitHub-Delivery": "gh-uuid-1"}
+        client.post(f"/webhook/hook/{hook['id']}", json={}, headers=headers)
+        client.post(f"/webhook/hook/{hook['id']}", json={}, headers=headers)
+        dispatch.assert_called_once()
+
     def test_list_hooks_does_not_mutate_stored_data(self):
         """Callers mutating returned dicts must not pollute the manager's state."""
         app, mgr = self._make_app()

--- a/tests/test_whatsapp.py
+++ b/tests/test_whatsapp.py
@@ -7,6 +7,9 @@ Uses FastAPI TestClient for webhook endpoint tests.
 
 from __future__ import annotations
 
+import hashlib
+import hmac
+import json
 import logging
 from unittest.mock import AsyncMock, MagicMock
 
@@ -15,6 +18,18 @@ from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
 from src.channels.whatsapp import WhatsAppChannel
+
+_TEST_APP_SECRET = "test-app-secret"
+
+
+def _sign(secret: str, payload: dict) -> tuple[bytes, dict]:
+    """Serialize ``payload`` and produce a valid X-Hub-Signature-256 header."""
+    raw = json.dumps(payload).encode()
+    sig = "sha256=" + hmac.new(secret.encode(), raw, hashlib.sha256).hexdigest()
+    return raw, {
+        "content-type": "application/json",
+        "X-Hub-Signature-256": sig,
+    }
 
 # ── helpers ──────────────────────────────────────────────────────
 
@@ -75,13 +90,14 @@ def _make_http_mock():
     return http
 
 
-def _webhook_payload(from_phone: str, text: str) -> dict:
+def _webhook_payload(from_phone: str, text: str, msg_id: str = "wamid.test1") -> dict:
     """Create a standard WhatsApp webhook payload for a text message."""
     return {
         "entry": [{
             "changes": [{
                 "value": {
                     "messages": [{
+                        "id": msg_id,
                         "from": from_phone,
                         "type": "text",
                         "text": {"body": text},
@@ -199,25 +215,156 @@ class TestIncomingMessages:
 # ── webhook POST endpoint ───────────────────────────────────────
 
 class TestWebhookPost:
-    def test_webhook_post_returns_ok(self):
+    def test_webhook_post_returns_ok(self, monkeypatch):
+        monkeypatch.setenv("WHATSAPP_APP_SECRET", _TEST_APP_SECRET)
+        ch = _make_channel(paired={"owner": "+1234", "allowed": []})
+        app = _make_app(ch)
+        client = TestClient(app)
+        payload = _webhook_payload("+1234", "hello")
+        raw, headers = _sign(_TEST_APP_SECRET, payload)
+        resp = client.post("/channels/whatsapp/webhook", content=raw, headers=headers)
+        assert resp.status_code == 200
+        assert resp.json()["status"] == "ok"
+
+    def test_webhook_post_empty_body_ok(self, monkeypatch):
+        monkeypatch.setenv("WHATSAPP_APP_SECRET", _TEST_APP_SECRET)
+        ch = _make_channel(paired={"owner": "+1234", "allowed": []})
+        app = _make_app(ch)
+        client = TestClient(app)
+        raw = b"not json"
+        sig = "sha256=" + hmac.new(
+            _TEST_APP_SECRET.encode(), raw, hashlib.sha256,
+        ).hexdigest()
+        resp = client.post(
+            "/channels/whatsapp/webhook",
+            content=raw,
+            headers={"content-type": "application/json", "X-Hub-Signature-256": sig},
+        )
+        assert resp.status_code == 200
+
+
+# ── H9: signature mandatory (fail-closed) ───────────────────────
+
+class TestWebhookSignatureMandatory:
+    def test_no_secret_returns_503(self, monkeypatch):
+        """Without WHATSAPP_APP_SECRET the webhook fails closed with 503."""
+        monkeypatch.delenv("WHATSAPP_APP_SECRET", raising=False)
         ch = _make_channel(paired={"owner": "+1234", "allowed": []})
         app = _make_app(ch)
         client = TestClient(app)
         payload = _webhook_payload("+1234", "hello")
         resp = client.post("/channels/whatsapp/webhook", json=payload)
-        assert resp.status_code == 200
-        assert resp.json()["status"] == "ok"
+        assert resp.status_code == 503
 
-    def test_webhook_post_empty_body_ok(self):
+    def test_bad_signature_returns_401(self, monkeypatch):
+        monkeypatch.setenv("WHATSAPP_APP_SECRET", _TEST_APP_SECRET)
         ch = _make_channel(paired={"owner": "+1234", "allowed": []})
         app = _make_app(ch)
         client = TestClient(app)
+        payload = _webhook_payload("+1234", "hello")
         resp = client.post(
             "/channels/whatsapp/webhook",
-            content=b"not json",
-            headers={"content-type": "application/json"},
+            json=payload,
+            headers={"X-Hub-Signature-256": "sha256=deadbeef"},
         )
+        assert resp.status_code == 401
+
+    def test_valid_signature_processed(self, monkeypatch):
+        monkeypatch.setenv("WHATSAPP_APP_SECRET", _TEST_APP_SECRET)
+        ch = _make_channel(paired={"owner": "+1234", "allowed": []})
+        app = _make_app(ch)
+        client = TestClient(app)
+        payload = _webhook_payload("+1234", "hello")
+        raw, headers = _sign(_TEST_APP_SECRET, payload)
+        resp = client.post("/channels/whatsapp/webhook", content=raw, headers=headers)
         assert resp.status_code == 200
+        assert resp.json()["status"] == "ok"
+
+
+# ── start() guard requires app secret (H9) ──────────────────────
+
+class TestStartRequiresAppSecret:
+    @pytest.mark.asyncio
+    async def test_start_raises_without_app_secret(self, monkeypatch):
+        monkeypatch.delenv("WHATSAPP_APP_SECRET", raising=False)
+        monkeypatch.delenv("MESH_AUTH_TOKEN", raising=False)
+        ch = _make_channel()
+        with pytest.raises(RuntimeError, match="WHATSAPP_APP_SECRET"):
+            await ch.start()
+
+    @pytest.mark.asyncio
+    async def test_start_ok_with_app_secret(self, monkeypatch):
+        monkeypatch.setenv("WHATSAPP_APP_SECRET", _TEST_APP_SECRET)
+        ch = _make_channel()
+        await ch.start()  # must not raise
+        await ch.stop()
+
+
+# ── M7: inbound dedup by message id ─────────────────────────────
+
+class TestWebhookDedup:
+    def test_replay_same_id_processed_once(self, monkeypatch):
+        """A replayed webhook (same message id) only dispatches once."""
+        monkeypatch.setenv("WHATSAPP_APP_SECRET", _TEST_APP_SECRET)
+        ch = _make_channel(paired={"owner": "+1234", "allowed": []})
+
+        processed: list = []
+
+        async def fake_process(message):
+            processed.append(message.get("id"))
+
+        ch._process_message = fake_process  # type: ignore[assignment]
+        app = _make_app(ch)
+        client = TestClient(app)
+
+        payload = _webhook_payload("+1234", "hello", msg_id="wamid.DUP")
+        raw, headers = _sign(_TEST_APP_SECRET, payload)
+
+        first = client.post("/channels/whatsapp/webhook", content=raw, headers=headers)
+        second = client.post("/channels/whatsapp/webhook", content=raw, headers=headers)
+
+        assert first.status_code == 200
+        assert second.status_code == 200
+        assert second.json()["status"] == "ok"
+        # Despite two deliveries, only the first dispatched.
+        assert processed == ["wamid.DUP"]
+
+    def test_distinct_ids_both_processed(self, monkeypatch):
+        monkeypatch.setenv("WHATSAPP_APP_SECRET", _TEST_APP_SECRET)
+        ch = _make_channel(paired={"owner": "+1234", "allowed": []})
+
+        processed: list = []
+
+        async def fake_process(message):
+            processed.append(message.get("id"))
+
+        ch._process_message = fake_process  # type: ignore[assignment]
+        app = _make_app(ch)
+        client = TestClient(app)
+
+        for mid in ("wamid.A", "wamid.B"):
+            payload = _webhook_payload("+1234", "hi", msg_id=mid)
+            raw, headers = _sign(_TEST_APP_SECRET, payload)
+            client.post("/channels/whatsapp/webhook", content=raw, headers=headers)
+
+        assert processed == ["wamid.A", "wamid.B"]
+
+    def test_seen_ids_unit(self):
+        from src.channels.whatsapp import _SeenIds
+
+        seen = _SeenIds(ttl=100, maxlen=3)
+        assert seen.add("a") is True
+        assert seen.add("a") is False  # replay
+        assert seen.add("") is True  # empty id never dedups
+        assert seen.add("") is True
+
+    def test_seen_ids_ttl_expiry(self):
+        from src.channels.whatsapp import _SeenIds
+
+        seen = _SeenIds(ttl=10, maxlen=10)
+        assert seen.add("x", now=0.0) is True
+        assert seen.add("x", now=5.0) is False  # within TTL
+        assert seen.add("x", now=100.0) is True  # expired → seen as new
 
 
 # ── pairing flow ────────────────────────────────────────────────


### PR DESCRIPTION
May 2026 channel-auth remediation: **H2 + H9 + M7**. (Branch may need a rebase before merge.)

## H2 — Owner-gate privileged channel commands
Previously any *allowed* (non-owner) user on Telegram/Discord/Slack/WhatsApp could run `/addkey`, `/steer`, `/broadcast`, `/reset`, `/debug` — minting credentials, injecting context into agents, broadcasting, resetting state, or reading traces.

- Base `Channel` now resolves the owner via a per-subclass `_resolve_owner()` hook and threads an `is_owner` flag into `_handle_command`.
  - Telegram/Discord coerce the `str` user id back to `int` for the pairing lookup.
  - Slack strips the `user_id:thread_ts` composite key.
  - WhatsApp uses the phone number directly.
- Non-owner allowed users keep **normal chat** + read-only commands (`/use`, `/agents`, `/status`, `/costs`, `/help`). `/help` hides owner-only commands from non-owners.
- `/allow`, `/revoke`, `/paired` gating is unchanged (already owner-only per subclass).

## H9 — WhatsApp signature mandatory, decoupled from `MESH_AUTH_TOKEN`
`WHATSAPP_APP_SECRET` is now required whenever the WhatsApp channel is enabled (real WhatsApp delivery needs the Meta app secret regardless).

- `start()` raises `RuntimeError` without it (was gated on `MESH_AUTH_TOKEN`).
- `receive_webhook` **fails closed with HTTP 503** when the secret is unset, instead of processing unauthenticated input. Signature mismatch still returns 401 (timing-safe `hmac.compare_digest`).

## M7 — Inbound webhook dedup
- WhatsApp: dedup by `message["id"]` via a bounded TTL/LRU set so Cloud API retries/replays don't double-fire `_process_message`.
- Generic mesh webhook (`host/webhooks.py`): analogous nonce guard keyed on common delivery-id headers (`X-Webhook-Id`, `X-Idempotency-Key`, `X-GitHub-Delivery`, …), checked *after* signature verification so an unauthenticated caller can't poison the set.

## Not broken
Normal chat for allowed non-owner users, real WhatsApp delivery (valid signed payloads process once), `/allow`/`/revoke`/`/paired` gating, and message routing all unchanged.

## Tests
`tests/test_channels.py`, `tests/test_whatsapp.py`, `tests/test_webhooks.py` — added coverage:
- non-owner refused `/addkey` (+ steer/broadcast/reset/debug) but can chat + use read-only commands; owner can run all; help hides privileged commands from non-owners
- WhatsApp webhook: no secret → 503, bad signature → 401, valid signed → processed; replay of same `message["id"]` ignored; `start()` requires the secret
- generic webhook: duplicate delivery-id dispatched once, distinct ids both dispatch, no-nonce not deduped

`python -m pytest tests/test_channels.py tests/test_whatsapp.py tests/test_webhooks.py tests/test_slack.py tests/test_discord.py` → **210 passed, 21 skipped** (skips are telegram/discord libs not installed). Ruff clean.