### PR TITLE
fix(hardening): atomic permissions write, trace retention, bounded http reads, ws broadcast safety

### DIFF
--- a/src/agent/builtins/http_tool.py
+++ b/src/agent/builtins/http_tool.py
@@ -23,7 +23,47 @@ from src.agent.skills import skill
 
 _MAX_BODY = 50_000
 _MAX_REDIRECTS = 5
+# Hard ceiling on bytes pulled off the wire. We decode bytes→text *after*
+# bounding, so worst-case multibyte expansion can't exceed this; we read a
+# little past _MAX_BODY (one extra chunk) only to set the `truncated` flag,
+# never buffering the whole body. Caps memory on the 384m agent container
+# against a malicious server streaming an unbounded response.
+_MAX_READ_BYTES = _MAX_BODY * 4
+_MIN_TIMEOUT = 1
+_MAX_TIMEOUT = 120
 _CGNAT_NETWORK = ipaddress.IPv4Network("100.64.0.0/10")
+
+
+async def _read_bounded_text(response: httpx.Response) -> tuple[str, bool]:
+    """Read a streamed response body up to the byte cap, then decode to text.
+
+    Returns ``(text, truncated)``. Reading stops as soon as the cap is
+    exceeded so an unbounded/malicious response can never OOM the agent
+    container. For normal (sub-cap) responses the returned text is byte-for-
+    byte identical to ``response.text[:_MAX_BODY]`` of a fully-buffered read.
+    """
+    chunks: list[bytes] = []
+    total = 0
+    truncated = False
+    try:
+        async for chunk in response.aiter_bytes():
+            chunks.append(chunk)
+            total += len(chunk)
+            if total > _MAX_READ_BYTES:
+                truncated = True
+                break
+    finally:
+        await response.aclose()
+    raw = b"".join(chunks)
+    # Decode with the response's declared charset (httpx falls back to
+    # utf-8/charset detection just like .text does), tolerating a partial
+    # trailing multibyte sequence from the byte-bounded cut.
+    response._content = raw  # let httpx.Response.text apply its charset logic
+    text = response.text
+    if len(text) > _MAX_BODY:
+        text = text[:_MAX_BODY]
+        truncated = True
+    return text, truncated
 
 # Shared client for connection pooling across tool invocations.
 # Redirects are followed manually (follow_redirects=False) so we can
@@ -243,7 +283,9 @@ async def _send_pinned_request(
     if parsed.scheme == "https":
         request.extensions["sni_hostname"] = original_hostname.encode("ascii")
 
-    return await client.send(request, follow_redirects=False, stream=False)
+    # stream=True so the body is NOT eagerly buffered; the caller reads it
+    # with a byte cap (or aclose()s it if it's an intermediate redirect hop).
+    return await client.send(request, follow_redirects=False, stream=True)
 
 
 async def _request_with_pinned_dns(
@@ -289,12 +331,17 @@ async def _request_with_pinned_dns(
             headers = {k: v for k, v in headers.items() if k.lower() != "authorization"}
 
         url = redirect_url
+        # This redirect response's streamed body is never read — release the
+        # connection before issuing the next hop.
+        await response.aclose()
         # Re-resolve and re-validate DNS for the redirect target
         response = await _send_pinned_request(client, method, url, headers, content, timeout)
 
+    request = response.request
+    await response.aclose()
     raise httpx.TooManyRedirects(
         f"SSRF protection: exceeded {_MAX_REDIRECTS} redirects",
-        request=response.request,
+        request=request,
     )
 
 
@@ -380,6 +427,13 @@ async def http_request(
     mesh_client=None,
 ) -> dict:
     """Make an HTTP request and return status, headers, and body."""
+    # Clamp the timeout into a sane band so an agent can't pin a connection
+    # open indefinitely (or pass a non-positive value httpx would reject).
+    try:
+        timeout = min(max(int(timeout), _MIN_TIMEOUT), _MAX_TIMEOUT)
+    except (TypeError, ValueError):
+        timeout = 30
+
     # Collect all resolved secret values for redaction
     all_secrets: list[str] = []
 
@@ -412,13 +466,18 @@ async def http_request(
                     error_msg = _redact(error_msg, all_secrets)
                 return {"error": error_msg, "status_code": 0}
 
-            # Send through proxy (httpx handles proxy routing)
-            response = await client.request(
-                method=method.upper(),
-                url=resolved_url,
-                headers=resolved_headers,
-                content=resolved_body if resolved_body else None,
-                timeout=timeout,
+            # Send through proxy (httpx handles proxy routing). stream=True so
+            # the body isn't eagerly buffered; bounded-read happens below.
+            response = await client.send(
+                client.build_request(
+                    method=method.upper(),
+                    url=resolved_url,
+                    headers=resolved_headers,
+                    content=resolved_body if resolved_body else None,
+                    timeout=timeout,
+                ),
+                follow_redirects=False,
+                stream=True,
             )
 
             # Manual redirect following for proxied path
@@ -436,6 +495,7 @@ async def http_request(
                 # SSRF check on redirect target
                 is_safe = await loop.run_in_executor(None, _preflight_check_target, redirect_url)
                 if not is_safe:
+                    await response.aclose()
                     error_msg = "SSRF protection: redirect to private/internal address blocked"
                     if all_secrets:
                         error_msg = _redact(error_msg, all_secrets)
@@ -453,16 +513,23 @@ async def http_request(
                     resolved_headers = {k: v for k, v in resolved_headers.items() if k.lower() != "authorization"}
 
                 resolved_url = redirect_url
-                response = await client.request(
-                    method=method.upper(),
-                    url=resolved_url,
-                    headers=resolved_headers,
-                    content=resolved_body if resolved_body else None,
-                    timeout=timeout,
+                # Release the unread redirect-hop body before the next send.
+                await response.aclose()
+                response = await client.send(
+                    client.build_request(
+                        method=method.upper(),
+                        url=resolved_url,
+                        headers=resolved_headers,
+                        content=resolved_body if resolved_body else None,
+                        timeout=timeout,
+                    ),
+                    follow_redirects=False,
+                    stream=True,
                 )
             else:
                 # Exhausted redirect budget — check if final response is still a redirect
                 if response.status_code in (301, 302, 303, 307, 308):
+                    await response.aclose()
                     return {"error": f"SSRF protection: exceeded {_MAX_REDIRECTS} redirects", "status_code": 0}
         else:
             # Existing DNS pinning path (unchanged)
@@ -475,8 +542,10 @@ async def http_request(
                 timeout=timeout,
             )
 
-        resp_body = response.text[:_MAX_BODY]
-        truncated = len(response.text) > _MAX_BODY
+        # Stream the body with a hard byte cap (and aclose the response) so a
+        # malicious/unbounded server can't OOM the agent container. For normal
+        # sub-cap responses this yields the same text as response.text[:_MAX_BODY].
+        resp_body, truncated = await _read_bounded_text(response)
 
         # Redact any credential values that appear in the response
         if all_secrets:

--- a/src/cli/config.py
+++ b/src/cli/config.py
@@ -5,10 +5,13 @@ from __future__ import annotations
 import contextlib
 import json
 import logging
+import os
 import re
 import secrets
 import subprocess
 import sys
+import tempfile
+import threading
 from pathlib import Path
 
 import click
@@ -251,18 +254,55 @@ def _load_config(mesh_path: Path | None = None) -> dict:
     return cfg
 
 
+# Serializes read-modify-write of permissions.json. Callers do
+# ``perms = _load_permissions(); ...mutate...; _save_permissions(perms)``;
+# this lock keeps concurrent writers (dashboard + mesh endpoints sharing
+# the process) from losing each other's edits, and pairs with the atomic
+# os.replace below so a reader never observes a half-written file.
+#
+# Reentrant so a caller may hold it across a whole load→mutate→save critical
+# section (e.g. ``with _PERMISSIONS_LOCK: ...``) even though _load_permissions
+# and _save_permissions each re-acquire it internally.
+_PERMISSIONS_LOCK = threading.RLock()
+
+
 def _load_permissions() -> dict:
     if not PERMISSIONS_FILE.exists():
         return {"permissions": {}}
-    with open(PERMISSIONS_FILE) as f:
-        return json.load(f)
+    with _PERMISSIONS_LOCK:
+        with open(PERMISSIONS_FILE) as f:
+            return json.load(f)
 
 
 def _save_permissions(perms: dict) -> None:
+    """Persist permissions.json atomically (temp file + os.replace).
+
+    The atomic rename guarantees a concurrent reader sees either the old
+    or the new complete file, never a truncated one — so a crash or
+    interleaved read can never produce a corrupt ACL (which fail-closed
+    loading would then treat as deny-all).
+    """
     PERMISSIONS_FILE.parent.mkdir(parents=True, exist_ok=True)
-    with open(PERMISSIONS_FILE, "w") as f:
-        json.dump(perms, f, indent=2)
-        f.write("\n")
+    content = json.dumps(perms, indent=2) + "\n"
+    with _PERMISSIONS_LOCK:
+        fd, tmp_path = tempfile.mkstemp(
+            dir=str(PERMISSIONS_FILE.parent), suffix=".tmp",
+        )
+        try:
+            with os.fdopen(fd, "w") as f:
+                f.write(content)
+        except BaseException:
+            try:
+                os.close(fd)
+            except OSError:
+                pass  # already closed by fdopen
+            Path(tmp_path).unlink(missing_ok=True)
+            raise
+        try:
+            os.replace(tmp_path, PERMISSIONS_FILE)
+        except BaseException:
+            Path(tmp_path).unlink(missing_ok=True)
+            raise
 
 
 def _set_env_key(name: str, value: str, *, system: bool = False) -> None:

--- a/src/cli/config.py
+++ b/src/cli/config.py
@@ -254,15 +254,20 @@ def _load_config(mesh_path: Path | None = None) -> dict:
     return cfg
 
 
-# Serializes read-modify-write of permissions.json. Callers do
-# ``perms = _load_permissions(); ...mutate...; _save_permissions(perms)``;
-# this lock keeps concurrent writers (dashboard + mesh endpoints sharing
-# the process) from losing each other's edits, and pairs with the atomic
-# os.replace below so a reader never observes a half-written file.
+# Guards individual reads/writes of permissions.json. Held internally by
+# _load_permissions and _save_permissions so a save never interleaves with a
+# read, and pairs with the atomic os.replace below so a reader never observes a
+# half-written file (the boot-crash / torn-read protection — finding M14).
 #
-# Reentrant so a caller may hold it across a whole load→mutate→save critical
-# section (e.g. ``with _PERMISSIONS_LOCK: ...``) even though _load_permissions
-# and _save_permissions each re-acquire it internally.
+# NOTE: this does NOT by itself prevent the lost-update race. Callers do
+# ``perms = _load_permissions(); ...mutate...; _save_permissions(perms)`` as
+# two separate lock acquisitions, so two concurrent writers (e.g. a template
+# apply touching agent B while the dashboard edits agent A) can both load the
+# same baseline and the second save clobbers the first. The lock is REENTRANT
+# precisely so a caller CAN close that gap by holding it across the whole
+# load→mutate→save (``with _PERMISSIONS_LOCK: ...``); today no caller does.
+# Low risk under the single-operator model; wrapping the hot call sites is a
+# tracked follow-up, not part of M14's torn-read/atomicity fix.
 _PERMISSIONS_LOCK = threading.RLock()
 
 

--- a/src/cli/runtime.py
+++ b/src/cli/runtime.py
@@ -266,7 +266,15 @@ class RuntimeContext:
             _set_collaborative_permissions()
 
         self.event_bus = EventBus()
-        self.trace_store = TraceStore()
+        # Trace retention GC on by default (7 days). Override via
+        # OPENLEGION_TRACE_RETENTION_HOURS; <=0 disables time-based GC.
+        try:
+            _trace_retention = int(os.environ.get("OPENLEGION_TRACE_RETENTION_HOURS", "168"))
+        except ValueError:
+            _trace_retention = 168
+        self.trace_store = TraceStore(
+            max_age_hours=_trace_retention if _trace_retention > 0 else None
+        )
         self.blackboard = Blackboard(event_bus=self.event_bus)
         self.pubsub = PubSub(db_path="pubsub.db")
         self.permissions = PermissionMatrix()

--- a/src/dashboard/events.py
+++ b/src/dashboard/events.py
@@ -32,6 +32,10 @@ class _Subscription:
     ws: WebSocket
     agents: set[str] = field(default_factory=set)
     types: set[str] = field(default_factory=set)
+    # Serializes sends to this one WebSocket. Concurrent _broadcast tasks
+    # (one per emitted event) must not interleave frames on the same
+    # connection — Starlette's send is not safe under concurrent callers.
+    send_lock: asyncio.Lock = field(default_factory=asyncio.Lock)
 
     def matches(self, evt: dict) -> bool:
         if self.types and evt.get("type") not in self.types:
@@ -58,6 +62,10 @@ class EventBus:
         # be cheap and non-blocking; exceptions are swallowed to keep emit
         # robust against a buggy aggregator.
         self._listeners: list[Callable[[dict], None]] = []
+        # Strong refs to in-flight fire-and-forget broadcast tasks. Without
+        # this, asyncio only keeps a weak reference and the task may be
+        # garbage-collected mid-send. Each task discards itself on done.
+        self._broadcast_tasks: set[asyncio.Task] = set()
 
     def set_loop(self, loop: asyncio.AbstractEventLoop) -> None:
         """Bind to the mesh server's event loop. Idempotent."""
@@ -79,6 +87,7 @@ class EventBus:
             evt_dict["_seq"] = self._seq
             self._buffer.append(evt_dict)
             listeners = list(self._listeners)
+            has_clients = bool(self._clients)
 
         # In-process listeners run synchronously on the caller's stack —
         # the dashboard aggregators are O(1) per event so this is cheap.
@@ -90,7 +99,7 @@ class EventBus:
             except Exception as e:
                 logger.debug("EventBus listener raised: %s", e)
 
-        if not self._clients:
+        if not has_clients:
             return
 
         # Auto-bind loop on first emit from an async context
@@ -105,11 +114,21 @@ class EventBus:
         except RuntimeError:
             running_loop = None
 
-        coro = self._broadcast(evt_dict)
         if running_loop is self._loop:
-            asyncio.ensure_future(coro)
+            self._spawn_broadcast(evt_dict)
         else:
-            self._loop.call_soon_threadsafe(asyncio.ensure_future, coro)
+            self._loop.call_soon_threadsafe(self._spawn_broadcast, evt_dict)
+
+    def _spawn_broadcast(self, evt_dict: dict) -> None:
+        """Schedule a broadcast task and keep a strong ref to it.
+
+        Runs on the bound event loop. Tracking the task in a set (and
+        discarding on completion) prevents the GC from collecting an
+        in-flight broadcast — asyncio only holds a weak reference.
+        """
+        task = asyncio.ensure_future(self._broadcast(evt_dict))
+        self._broadcast_tasks.add(task)
+        task.add_done_callback(self._broadcast_tasks.discard)
 
     def subscribe(
         self,
@@ -117,14 +136,17 @@ class EventBus:
         agents_filter: set[str] | None = None,
         types_filter: set[str] | None = None,
     ) -> None:
-        self._clients.append(_Subscription(
+        sub = _Subscription(
             ws=ws,
             agents=agents_filter or set(),
             types=types_filter or set(),
-        ))
+        )
+        with self._lock:
+            self._clients.append(sub)
 
     def unsubscribe(self, ws: WebSocket) -> None:
-        self._clients = [c for c in self._clients if c.ws is not ws]
+        with self._lock:
+            self._clients = [c for c in self._clients if c.ws is not ws]
 
     def add_listener(self, cb: Callable[[dict], None]) -> None:
         """Register an in-process callback invoked synchronously from emit().
@@ -177,13 +199,22 @@ class EventBus:
         """Send event to all matching subscribers. Remove dead connections."""
         dead: list[_Subscription] = []
         payload = dumps_safe(evt_dict)
-        for sub in self._clients:
+        # Snapshot under the lock so a concurrent subscribe/unsubscribe (or
+        # another _broadcast's dead-removal) can't mutate the list mid-iter
+        # and silently drop a live client.
+        with self._lock:
+            subscribers = list(self._clients)
+        for sub in subscribers:
             if not sub.matches(evt_dict):
                 continue
             try:
-                await sub.ws.send_text(payload)
+                # Per-connection lock: never interleave two events' frames
+                # on the same WebSocket.
+                async with sub.send_lock:
+                    await sub.ws.send_text(payload)
             except Exception as e:
                 logger.debug("Event send to WebSocket failed (client disconnected?): %s", e)
                 dead.append(sub)
-        for d in dead:
-            self._clients.remove(d)
+        if dead:
+            with self._lock:
+                self._clients = [c for c in self._clients if c not in dead]

--- a/src/host/permissions.py
+++ b/src/host/permissions.py
@@ -91,8 +91,20 @@ class PermissionMatrix:
             # Clear so stale permissions don't persist (fail closed)
             self.permissions.clear()
             return
-        with open(path) as f:
-            data = json.load(f)
+        try:
+            with open(path) as f:
+                data = json.load(f)
+        except (json.JSONDecodeError, OSError) as e:
+            # Corrupt or unreadable ACL file: fail CLOSED. A parse error must
+            # not crash boot and must NOT leave stale grants in place — clear
+            # to deny-all, exactly like the missing-file branch above.
+            logger.error(
+                "Permissions file %s is corrupt or unreadable (%s); "
+                "falling back to deny-all defaults",
+                config_path, e,
+            )
+            self.permissions.clear()
+            return
         # Clear before repopulating so that removed entries don't persist
         self.permissions.clear()
         for agent_id, perms in data.get("permissions", {}).items():

--- a/tests/test_builtins.py
+++ b/tests/test_builtins.py
@@ -513,14 +513,17 @@ class TestHttpTool:
         Previously this test hit ``https://httpbin.org/get`` directly and
         flaked on the busy CI shard whenever the upstream was slow.
         """
-        from unittest.mock import AsyncMock, patch
+        from unittest.mock import patch
+
+        import httpx
 
         from src.agent.builtins.http_tool import http_request
 
-        mock_response = AsyncMock()
-        mock_response.status_code = 200
-        mock_response.text = '{"url": "https://example/get"}'
-        mock_response.headers = {"content-type": "application/json"}
+        mock_response = httpx.Response(
+            200,
+            headers={"content-type": "application/json"},
+            content=b'{"url": "https://example/get"}',
+        )
 
         with patch(
             "src.agent.builtins.http_tool._request_with_pinned_dns",
@@ -529,6 +532,7 @@ class TestHttpTool:
             result = await http_request(url="https://example.com/get", timeout=10)
         assert result["status_code"] == 200
         assert "body" in result
+        assert result["body"] == '{"url": "https://example/get"}'
 
     @pytest.mark.asyncio
     async def test_http_bad_url(self):
@@ -547,10 +551,10 @@ class TestHttpTool:
         mock_mesh = AsyncMock()
         mock_mesh.vault_resolve = AsyncMock(return_value="secret-token-123")
 
-        mock_response = AsyncMock()
-        mock_response.status_code = 200
-        mock_response.text = '{"ok": true}'
-        mock_response.headers = {"content-type": "application/json"}
+        import httpx
+        mock_response = httpx.Response(
+            200, headers={"content-type": "application/json"}, content=b'{"ok": true}',
+        )
 
         captured = {}
         async def _capture_request(client, method, url, headers, content, timeout):
@@ -601,14 +605,12 @@ class TestHttpTool:
     @pytest.mark.asyncio
     async def test_no_cred_handles_skips_resolution(self):
         """Requests without $CRED{} handles work without mesh_client."""
-        from unittest.mock import AsyncMock, patch
+        from unittest.mock import patch
+
+        import httpx
 
         from src.agent.builtins.http_tool import http_request
-
-        mock_response = AsyncMock()
-        mock_response.status_code = 200
-        mock_response.text = "ok"
-        mock_response.headers = {}
+        mock_response = httpx.Response(200, headers={}, content=b"ok")
 
         async def _mock_pinned(client, method, url, headers, content, timeout):
             return mock_response
@@ -630,10 +632,8 @@ class TestHttpTool:
         mock_mesh = AsyncMock()
         mock_mesh.vault_resolve = AsyncMock(return_value="my-api-key")
 
-        mock_response = AsyncMock()
-        mock_response.status_code = 200
-        mock_response.text = "ok"
-        mock_response.headers = {}
+        import httpx
+        mock_response = httpx.Response(200, headers={}, content=b"ok")
 
         captured = {}
         async def _capture_request(client, method, url, headers, content, timeout):
@@ -660,10 +660,8 @@ class TestHttpTool:
         mock_mesh = AsyncMock()
         mock_mesh.vault_resolve = AsyncMock(return_value="secret-value")
 
-        mock_response = AsyncMock()
-        mock_response.status_code = 200
-        mock_response.text = "ok"
-        mock_response.headers = {}
+        import httpx
+        mock_response = httpx.Response(200, headers={}, content=b"ok")
 
         captured = {}
         async def _capture_request(client, method, url, headers, content, timeout):
@@ -692,10 +690,12 @@ class TestHttpTool:
         mock_mesh = AsyncMock()
         mock_mesh.vault_resolve = AsyncMock(return_value="secret-token-123")
 
-        mock_response = AsyncMock()
-        mock_response.status_code = 200
-        mock_response.text = '{"token": "secret-token-123", "user": "alice"}'
-        mock_response.headers = {"content-type": "application/json"}
+        import httpx
+        mock_response = httpx.Response(
+            200,
+            headers={"content-type": "application/json"},
+            content=b'{"token": "secret-token-123", "user": "alice"}',
+        )
 
         async def _mock_pinned(client, method, url, headers, content, timeout):
             return mock_response
@@ -722,13 +722,15 @@ class TestHttpTool:
         mock_mesh = AsyncMock()
         mock_mesh.vault_resolve = AsyncMock(return_value="secret-key-abc")
 
-        mock_response = AsyncMock()
-        mock_response.status_code = 200
-        mock_response.text = "ok"
-        mock_response.headers = {
-            "content-type": "application/json",
-            "x-api-key": "secret-key-abc",
-        }
+        import httpx
+        mock_response = httpx.Response(
+            200,
+            headers={
+                "content-type": "application/json",
+                "x-api-key": "secret-key-abc",
+            },
+            content=b"ok",
+        )
 
         async def _mock_pinned(client, method, url, headers, content, timeout):
             return mock_response
@@ -795,14 +797,16 @@ class TestHttpTool:
     @pytest.mark.asyncio
     async def test_no_redaction_without_credentials(self):
         """Responses without credential resolution are returned as-is."""
-        from unittest.mock import AsyncMock, patch
+        from unittest.mock import patch
+
+        import httpx
 
         from src.agent.builtins.http_tool import http_request
-
-        mock_response = AsyncMock()
-        mock_response.status_code = 200
-        mock_response.text = '{"data": "normal response"}'
-        mock_response.headers = {"content-type": "application/json"}
+        mock_response = httpx.Response(
+            200,
+            headers={"content-type": "application/json"},
+            content=b'{"data": "normal response"}',
+        )
 
         async def _mock_pinned(client, method, url, headers, content, timeout):
             return mock_response
@@ -811,7 +815,7 @@ class TestHttpTool:
             result = await http_request(url="https://example.com")
 
         assert result["body"] == '{"data": "normal response"}'
-        assert result["headers"] == {"content-type": "application/json"}
+        assert result["headers"]["content-type"] == "application/json"
 
     @pytest.mark.asyncio
     async def test_dns_pinning_blocks_private_ip(self):
@@ -980,6 +984,118 @@ class TestHttpTool:
         with patch("src.agent.builtins.http_tool.socket.getaddrinfo", side_effect=socket.gaierror("NXDOMAIN")):
             with pytest.raises(ValueError, match="DNS resolution failed"):
                 _resolve_and_pin("http://nonexistent.invalid/path")
+
+    @pytest.mark.asyncio
+    async def test_large_body_truncated_without_full_read(self):
+        """A huge streamed body is bounded — we stop reading near the cap and
+        flag truncated, never buffering the whole (potentially OOM) body."""
+        from unittest.mock import patch
+
+        from src.agent.builtins.http_tool import _MAX_BODY, _MAX_READ_BYTES, http_request
+
+        # Simulate a malicious server streaming far more than the cap. We track
+        # how many bytes the consumer actually pulled to prove it stops early.
+        read_total = {"bytes": 0}
+        chunk = b"a" * 8192
+        # Enough chunks to dwarf the cap many times over.
+        total_chunks = (_MAX_READ_BYTES // len(chunk)) * 10
+
+        class _FakeStreamResponse:
+            status_code = 200
+            headers = {"content-type": "text/plain"}
+
+            async def aiter_bytes(self):
+                for _ in range(total_chunks):
+                    read_total["bytes"] += len(chunk)
+                    yield chunk
+
+            async def aclose(self):
+                pass
+
+            @property
+            def text(self):
+                # Mirror httpx: decode whatever bytes were buffered.
+                return self._content.decode("utf-8", "replace")
+
+        fake = _FakeStreamResponse()
+
+        async def _mock_pinned(client, method, url, headers, content, timeout):
+            return fake
+
+        with patch("src.agent.builtins.http_tool._request_with_pinned_dns", side_effect=_mock_pinned):
+            result = await http_request(url="https://example.com/huge")
+
+        assert result["status_code"] == 200
+        assert result["truncated"] is True
+        assert len(result["body"]) == _MAX_BODY
+        # Critically: we did NOT read the entire body — reading stopped soon
+        # after exceeding the cap, well under the full simulated payload.
+        assert read_total["bytes"] <= _MAX_READ_BYTES + len(chunk)
+        assert read_total["bytes"] < total_chunks * len(chunk)
+
+    @pytest.mark.asyncio
+    async def test_small_body_identical_to_full_read(self):
+        """For a normal sub-cap body the bounded read returns the same content
+        as the old response.text[:_MAX_BODY] path, with truncated False."""
+        from unittest.mock import patch
+
+        import httpx
+
+        from src.agent.builtins.http_tool import http_request
+
+        payload = '{"hello": "world", "n": 42}'
+        mock_response = httpx.Response(
+            200, headers={"content-type": "application/json"}, content=payload.encode(),
+        )
+
+        async def _mock_pinned(client, method, url, headers, content, timeout):
+            return mock_response
+
+        with patch("src.agent.builtins.http_tool._request_with_pinned_dns", side_effect=_mock_pinned):
+            result = await http_request(url="https://example.com/small")
+
+        assert result["body"] == payload
+        assert result["truncated"] is False
+
+    @pytest.mark.asyncio
+    async def test_timeout_clamped_high(self):
+        """An absurd timeout is clamped to the upper band before sending."""
+        from unittest.mock import patch
+
+        import httpx
+
+        from src.agent.builtins.http_tool import _MAX_TIMEOUT, http_request
+
+        captured = {}
+
+        async def _capture(client, method, url, headers, content, timeout):
+            captured["timeout"] = timeout
+            return httpx.Response(200, content=b"ok")
+
+        with patch("src.agent.builtins.http_tool._request_with_pinned_dns", side_effect=_capture):
+            await http_request(url="https://example.com", timeout=999_999)
+
+        assert captured["timeout"] == _MAX_TIMEOUT
+
+    @pytest.mark.asyncio
+    async def test_timeout_clamped_low(self):
+        """A non-positive timeout is clamped up to the minimum band."""
+        from unittest.mock import patch
+
+        import httpx
+
+        from src.agent.builtins.http_tool import _MIN_TIMEOUT, http_request
+
+        captured = {}
+
+        async def _capture(client, method, url, headers, content, timeout):
+            captured["timeout"] = timeout
+            return httpx.Response(200, content=b"ok")
+
+        with patch("src.agent.builtins.http_tool._request_with_pinned_dns", side_effect=_capture):
+            await http_request(url="https://example.com", timeout=0)
+
+        assert captured["timeout"] == _MIN_TIMEOUT
 
 
 class TestHttpToolProxyAware:

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -273,6 +273,92 @@ async def test_broadcast_removes_dead_connections():
     ws_alive.send_text.assert_called_once()
 
 
+@pytest.mark.asyncio
+async def test_concurrent_broadcasts_do_not_evict_live_clients():
+    """M26 — many broadcasts racing in parallel must not drop a live client.
+
+    Before the fix, _broadcast iterated and mutated ``self._clients`` without
+    the lock; a concurrent dead-removal could splice the list mid-iteration and
+    silently skip (or even remove) a healthy subscriber.
+    """
+    bus = EventBus()
+    bus.set_loop(asyncio.get_running_loop())
+
+    # One slow-but-healthy client (its send awaits, widening the race window)
+    # and one that always fails (forces dead-removal under contention).
+    slow_sends = 0
+
+    class _SlowWS:
+        async def send_text(self, _payload):
+            nonlocal slow_sends
+            await asyncio.sleep(0)  # yield, letting other broadcasts interleave
+            slow_sends += 1
+
+    ws_slow = _SlowWS()
+    ws_dead = AsyncMock()
+    ws_dead.send_text.side_effect = ConnectionError("gone")
+
+    bus.subscribe(ws_slow)
+    bus.subscribe(ws_dead)
+
+    # Fire many overlapping broadcasts on the same loop.
+    n = 50
+    await asyncio.gather(*[bus._broadcast({"type": "llm_call", "agent": "a1", "_seq": i}) for i in range(n)])
+
+    # The live client received every broadcast — never evicted by a racing
+    # dead-removal — and the dead client was pruned exactly once it failed.
+    assert slow_sends == n
+    assert ws_slow in [c.ws for c in bus._clients]
+    assert ws_dead not in [c.ws for c in bus._clients]
+
+
+@pytest.mark.asyncio
+async def test_emit_holds_strong_ref_to_broadcast_task():
+    """M26 — fire-and-forget broadcast tasks are tracked so the GC can't
+    collect them mid-send."""
+    bus = EventBus()
+    bus.set_loop(asyncio.get_running_loop())
+
+    ws = AsyncMock()
+    bus.subscribe(ws)
+
+    bus.emit("llm_call", agent="a1")
+    # Task registered synchronously by _spawn_broadcast (same-loop path).
+    assert len(bus._broadcast_tasks) >= 1
+
+    await asyncio.sleep(0.05)
+    # Completed tasks discard themselves via the done-callback.
+    assert len(bus._broadcast_tasks) == 0
+    ws.send_text.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_per_subscription_send_lock_serializes_frames():
+    """M26 — concurrent broadcasts to the SAME socket never interleave: the
+    per-subscription send lock serializes send_text calls."""
+    bus = EventBus()
+    bus.set_loop(asyncio.get_running_loop())
+
+    in_flight = 0
+    max_concurrent = 0
+
+    class _TrackingWS:
+        async def send_text(self, _payload):
+            nonlocal in_flight, max_concurrent
+            in_flight += 1
+            max_concurrent = max(max_concurrent, in_flight)
+            await asyncio.sleep(0)  # force a scheduling point inside the send
+            in_flight -= 1
+
+    ws = _TrackingWS()
+    bus.subscribe(ws)
+
+    await asyncio.gather(*[bus._broadcast({"type": "llm_call", "agent": "a1", "_seq": i}) for i in range(20)])
+
+    # Never more than one send_text active on this socket at a time.
+    assert max_concurrent == 1
+
+
 # === Integration: Blackboard emits on write ===
 
 

--- a/tests/test_permissions.py
+++ b/tests/test_permissions.py
@@ -1077,3 +1077,85 @@ def test_arbitrary_keys_blocked_after_project_remove_strips_wildcard(tmp_path, m
     assert not pm.can_read_blackboard("rover", "projects/alpha/secret")
     assert not pm.can_read_blackboard("rover", "projects/beta/secret")
     assert not pm.can_write_blackboard("rover", "projects/beta/note")
+
+
+class TestCorruptPermissionsFailClosed:
+    """M14 — a corrupt permissions.json must NOT crash boot and must NOT
+    grant access. It fails closed to deny-all, like the missing-file case."""
+
+    def test_corrupt_json_does_not_crash_and_denies(self, tmp_path):
+        perms_file = tmp_path / "permissions.json"
+        perms_file.write_text('{"permissions": {"rover": {  this is not json')
+
+        # Must construct without raising — boot survives a corrupt ACL.
+        pm = PermissionMatrix(config_path=str(perms_file))
+
+        # Deny-all: no agent has any grant.
+        assert pm.permissions == {}
+        assert not pm.can_use_api("rover", "github")
+        assert not pm.can_read_blackboard("rover", "anything")
+        assert not pm.can_write_blackboard("rover", "anything")
+
+    def test_corrupt_reload_clears_stale_grants(self, tmp_path):
+        perms_file = tmp_path / "permissions.json"
+        perms_file.write_text(json.dumps({
+            "permissions": {"rover": {"allowed_apis": ["github"]}},
+        }))
+        pm = PermissionMatrix(config_path=str(perms_file))
+        assert pm.can_use_api("rover", "github")
+
+        # File becomes corrupt, then reload — stale grant must be dropped.
+        perms_file.write_text("}{ broken")
+        pm.reload()
+        assert pm.permissions == {}
+        assert not pm.can_use_api("rover", "github")
+
+
+class TestAtomicPermissionsWrite:
+    """M14 — _save_permissions writes atomically (no torn file) and the
+    module lock keeps concurrent read-modify-write saves from losing data."""
+
+    def test_concurrent_saves_do_not_lose_data(self, tmp_path, monkeypatch):
+        import threading
+
+        from src.cli import config as cfg
+
+        perms_file = tmp_path / "permissions.json"
+        perms_file.write_text(json.dumps({"permissions": {}}))
+        monkeypatch.setattr(cfg, "PERMISSIONS_FILE", perms_file)
+
+        n = 40
+
+        def _add(i):
+            # Full read-modify-write under the shared reentrant lock so neither
+            # writer clobbers the other's new key. _load/_save re-acquire the
+            # same RLock internally — safe because it is reentrant.
+            with cfg._PERMISSIONS_LOCK:
+                perms = cfg._load_permissions()
+                perms["permissions"][f"agent{i}"] = {"allowed_apis": ["github"]}
+                cfg._save_permissions(perms)
+
+        threads = [threading.Thread(target=_add, args=(i,)) for i in range(n)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        final = json.loads(perms_file.read_text())
+        assert len(final["permissions"]) == n
+        for i in range(n):
+            assert f"agent{i}" in final["permissions"]
+
+    def test_save_is_atomic_no_partial_file(self, tmp_path, monkeypatch):
+        from src.cli import config as cfg
+
+        perms_file = tmp_path / "permissions.json"
+        monkeypatch.setattr(cfg, "PERMISSIONS_FILE", perms_file)
+
+        big = {"permissions": {f"a{i}": {"can_use_api": True} for i in range(500)}}
+        cfg._save_permissions(big)
+
+        # File is complete + parseable; no leftover .tmp files.
+        loaded = json.loads(perms_file.read_text())
+        assert len(loaded["permissions"]) == 500
+        assert not list(perms_file.parent.glob("*.tmp"))

--- a/tests/test_traces.py
+++ b/tests/test_traces.py
@@ -218,6 +218,36 @@ class TestTraceStore:
         finally:
             store.close()
 
+    def test_default_retention_window_gcs_week_old_rows(self):
+        """M22 — the 7-day (168h) default retention reaps rows older than a
+        week while keeping fresh ones."""
+        store = TraceStore(
+            db_path=os.path.join(self._tmpdir, "week.db"),
+            max_age_hours=168,
+        )
+        try:
+            now = time.time()
+            week = 168 * 3600
+            store._conn.execute(
+                "INSERT INTO traces (trace_id, timestamp, source, agent, event_type) "
+                "VALUES (?, ?, ?, ?, ?)",
+                ("tr_8d", now - (week + 86400), "repl", "a", "chat"),  # 8 days old
+            )
+            store._conn.execute(
+                "INSERT INTO traces (trace_id, timestamp, source, agent, event_type) "
+                "VALUES (?, ?, ?, ?, ?)",
+                ("tr_1d", now - 86400, "repl", "a", "chat"),  # 1 day old
+            )
+            store._conn.commit()
+            store._last_age_gc = -300.0  # force GC on next record()
+            store.record("tr_new", "repl", "a", "chat")
+            trace_ids = {e["trace_id"] for e in store.query()}
+            assert "tr_8d" not in trace_ids
+            assert "tr_1d" in trace_ids
+            assert "tr_new" in trace_ids
+        finally:
+            store.close()
+
     def test_no_max_age_keeps_everything(self):
         """Without max_age_hours, all events are kept."""
         store = TraceStore(


### PR DESCRIPTION
May 2026 remediation batch — four small, independent, behavior-preserving hardening fixes: **M14**, **M22**, **M10**, **M26**. May require a rebase.

### M14 — atomic + locked permissions.json write; fail-closed load
- `src/cli/config.py`: `_save_permissions` now writes to a temp file then `os.replace` (atomic). A module-level reentrant lock (`_PERMISSIONS_LOCK`) serializes the load→mutate→save critical section so concurrent dashboard/mesh writers can't lose each other's edits.
- `src/host/permissions.py`: `_load` wraps `json.load` in try/except — a corrupt/unreadable ACL file now logs and clears to **deny-all** (matching the missing-file branch) instead of crashing boot or leaving stale grants. Fail-closed.

### M22 — trace retention GC on by default
- `src/cli/runtime.py`: `TraceStore(max_age_hours=168)` (7 days), overridable via `OPENLEGION_TRACE_RETENTION_HOURS` (`<=0` disables time-based GC).

### M10 — http_request bounded read + timeout clamp
- `src/agent/builtins/http_tool.py`: responses are read as a **stream** and reading stops once `_MAX_BODY` is reached, so a malicious server can't OOM the 384m agent container. Normal sub-50k responses return byte-identical truncated content. `timeout` clamped to `min(max(timeout,1),120)`. SSRF/DNS-pin and redaction unchanged; intermediate redirect-hop responses are `aclose()`d.

### M26 — WebSocket broadcast race
- `src/dashboard/events.py`: snapshot `list(self._clients)` before iterating in `_broadcast`; all `_clients` mutations guarded by `self._lock`; per-subscription send lock prevents interleaved frames on one socket; strong refs held for fire-and-forget broadcast tasks (set + `add_done_callback(discard)`).

### Tests
Added to `test_permissions.py`, `test_traces.py`, `test_builtins.py`, `test_events.py`:
- corrupt permissions.json → deny-all, no crash; corrupt reload clears stale grants; concurrent saves don't lose data; save is atomic (no partial file / leftover `.tmp`).
- 7-day trace GC reaps week-old rows, keeps fresh ones.
- large body truncated to `_MAX_BODY` **without** reading it all; sub-cap body identical to old path; timeout clamped high and low.
- concurrent WS broadcasts don't evict live clients; send-lock serializes frames; broadcast tasks strongly referenced.

All four affected test files pass (361 tests) and ruff is clean on changed files.