### PR TITLE
fix(mesh): bind wake task-id and back-edge origin to their task, gate credential requests

### DIFF
--- a/src/host/server.py
+++ b/src/host/server.py
@@ -1211,7 +1211,36 @@ def create_mesh_app(
         # Bug 2/3 fix: thread the originating task_id through the lane so
         # the recipient's /chat call auto-closes the task when its loop
         # returns. Missing header preserves legacy fire-and-forget wakes.
+        #
+        # Finding M3 (binding): an ``x-task-id`` header is only honoured
+        # when the named task is actually assigned to the wake ``target``.
+        # Every LEGITIMATE handoff satisfies this invariant — ``hand_off``
+        # creates the task with ``assignee=to`` and then wakes that same
+        # ``to`` with ``task_id`` set, so the recipient is always the
+        # assignee taking the task over. A wake that carries a task_id for
+        # a task assigned to someone else (forged/mismatched) would, if
+        # threaded blindly, let the recipient's loop auto-close an
+        # UNRELATED agent's task on return. We do NOT reject the wake on
+        # mismatch (the wake itself may be a legitimate nudge) — we simply
+        # drop the task_id so no unrelated task is auto-closed.
         task_id = request.headers.get("x-task-id") or None
+        if task_id is not None:
+            try:
+                _task_record = tasks_store.get(task_id)
+            except Exception as e:  # pragma: no cover - defensive
+                logger.warning(
+                    "wake task_id lookup failed for %s: %s", task_id, e,
+                )
+                _task_record = None
+            if _task_record is None or _task_record.get("assignee") != target:
+                logger.info(
+                    "wake task_id %s dropped: assignee=%s != target=%s "
+                    "(M3 binding)",
+                    task_id,
+                    None if _task_record is None else _task_record.get("assignee"),
+                    target,
+                )
+                task_id = None
 
         if lane_manager is not None and dispatch_loop is not None:
             try:
@@ -2074,12 +2103,28 @@ def create_mesh_app(
         """
         agent_id = _resolve_agent_id(data.get("agent_id", ""), request)
         await _check_rate_limit("notify", agent_id)
-        # TODO(Task 4): gate on ``permissions.can_request_user_credentials``.
-        # The capability bit is wired in Task 3 (defaults False for workers,
-        # True for operator), but enforcing it here today would block every
-        # non-operator agent from asking the user for a credential.  Task 4
-        # is responsible for populating the field on workers that actually
-        # need it (template-driven) before this gate flips to enforced.
+        # Finding L2: gate on ``can_request_user_credentials``. The
+        # capability defaults False for workers and True for the operator
+        # (the operator is the fleet's credential-setup driver per the
+        # operator playbook). Templates whose workers must authenticate
+        # against login-gated external services set the bit explicitly in
+        # their YAML (browser-scraping agents: lead-enrichment ``enricher``,
+        # sales ``researcher``, social-listening ``monitor``,
+        # price-intelligence ``crawler``, review-ops ``monitor``,
+        # competitive-intel ``scout``, monitor ``watcher``) so flipping the
+        # gate does not break legitimate worker credential requests.
+        # ``can_request_user_credentials`` short-circuits True for trusted
+        # callers (operator/mesh).
+        if not permissions.can_request_user_credentials(agent_id):
+            _record_denial(
+                "permission", caller=agent_id,
+                gate="credential-request:can_request_user_credentials",
+            )
+            raise HTTPException(
+                403,
+                f"Agent {agent_id} is not permitted to request user "
+                "credentials (can_request_user_credentials not granted)",
+            )
 
         name = data.get("name", "")
         description = data.get("description", "")
@@ -4561,6 +4606,7 @@ def create_mesh_app(
             origin_kind = origin_dict.get("kind") if origin_dict else None
             origin_user = origin_dict.get("user") if origin_dict else None
             assignee = task_record.get("assignee")
+            creator = task_record.get("creator")
             task_id = task_record.get("id")
 
             # Eligibility — only cross-agent agent/operator handoffs.
@@ -4602,6 +4648,30 @@ def create_mesh_app(
             if event_kind not in _BACK_EDGE_WAKE_KINDS:
                 return
             if lane_manager is None or dispatch_loop is None:
+                return
+            # Finding L9 (binding): the back-edge EVENT above is written to
+            # ``inbox/{origin_user}/`` unconditionally so the originator's
+            # ``check_inbox`` always sees the outcome (and picks it up on
+            # heartbeat even when we skip the wake below). But the wake is
+            # a privileged action — it enqueues a lane message to
+            # ``origin_user``. ``origin_user`` is sourced from the task's
+            # stored ``origin`` dict, which (for ``kind="agent"``) is taken
+            # verbatim from the originating agent's X-Origin claim and is
+            # therefore forgeable. Only wake ``origin_user`` when it is the
+            # task's actual ``creator`` — the agent that genuinely created
+            # this handoff. A direct (single-hop) handoff satisfies this:
+            # ``hand_off`` creates the task as ``creator=<caller>`` and the
+            # caller's own origin carries ``user=<caller>``. On mismatch
+            # (forged origin, or a multi-hop chain whose origin points at a
+            # distant chain-root that is not the immediate creator) we keep
+            # the written event but skip the wake — the originator still
+            # learns via heartbeat, and no unrelated agent is woken.
+            if not creator or origin_user != creator:
+                logger.info(
+                    "back-edge wake for task %s skipped: origin_user=%s != "
+                    "creator=%s (L9 binding); event still written",
+                    task_id, origin_user, creator,
+                )
                 return
             if origin_user not in router.agent_registry:
                 return

--- a/src/templates/competitive-intel.yaml
+++ b/src/templates/competitive-intel.yaml
@@ -218,6 +218,9 @@ agents:
       blackboard_write: ["competitors/*", "artifacts/*", "tasks/*", "output/*", "status/*"]
       can_publish: ["competitor_updated", "index_updated", "new_competitor_found"]
       can_subscribe: ["research_requested", "competitor_update_requested"]
+      # Researches login-gated competitor sources via browser — may need
+      # to ask the user for a service credential.
+      can_request_user_credentials: true
 
     resources:
       memory_limit: "768m"

--- a/src/templates/lead-enrichment.yaml
+++ b/src/templates/lead-enrichment.yaml
@@ -172,6 +172,9 @@ agents:
       blackboard_write: ["leads/*", "tasks/*", "output/*", "status/*"]
       can_publish: ["lead_enriched", "batch_complete"]
       can_subscribe: ["enrich_requested"]
+      # Navigates login-gated sources (e.g. LinkedIn) — may need to ask
+      # the user for a service credential via request_credential().
+      can_request_user_credentials: true
     resources:
       memory_limit: "768m"
       cpu_limit: 0.5

--- a/src/templates/monitor.yaml
+++ b/src/templates/monitor.yaml
@@ -71,6 +71,9 @@ agents:
       blackboard_write: ["alerts/*", "tasks/*", "output/*", "status/*"]
       can_publish: ["alert_triggered"]
       can_subscribe: ["analysis_complete"]
+      # Checks login-gated sources via browser — may need to ask the user
+      # for a service credential.
+      can_request_user_credentials: true
     resources:
       memory_limit: "512m"
       cpu_limit: 0.5

--- a/src/templates/price-intelligence.yaml
+++ b/src/templates/price-intelligence.yaml
@@ -166,6 +166,9 @@ agents:
       blackboard_write: ["prices/*", "tasks/*", "output/*", "status/*"]
       can_publish: ["price_change", "extraction_failed"]
       can_subscribe: ["check_requested"]
+      # Crawls login-gated supplier/competitor pricing pages via browser —
+      # may need to ask the user for a service credential.
+      can_request_user_credentials: true
     resources:
       memory_limit: "512m"
       cpu_limit: 0.5

--- a/src/templates/review-ops.yaml
+++ b/src/templates/review-ops.yaml
@@ -151,6 +151,9 @@ agents:
       blackboard_write: ["reviews/*", "tasks/*", "output/*", "status/*"]
       can_publish: ["new_review", "negative_review"]
       can_subscribe: []
+      # Scrapes login-gated review platforms via browser — may need to ask
+      # the user for a service credential.
+      can_request_user_credentials: true
     resources:
       memory_limit: "512m"
       cpu_limit: 0.5

--- a/src/templates/sales.yaml
+++ b/src/templates/sales.yaml
@@ -60,6 +60,9 @@ agents:
       blackboard_write: ["leads/*/research", "tasks/*", "output/*", "status/*"]
       can_publish: ["research_complete"]
       can_subscribe: ["lead_added"]
+      # Researches login-gated company/contact sources (e.g. LinkedIn) —
+      # may need to ask the user for a service credential.
+      can_request_user_credentials: true
     resources:
       memory_limit: "512m"
       cpu_limit: 0.5

--- a/src/templates/social-listening.yaml
+++ b/src/templates/social-listening.yaml
@@ -148,6 +148,9 @@ agents:
       blackboard_write: ["signals/*", "tasks/*", "output/*", "status/*"]
       can_publish: ["signal_found"]
       can_subscribe: ["draft_complete"]
+      # Reads login-gated social platforms via browser — may need to ask
+      # the user for a service credential.
+      can_request_user_credentials: true
     resources:
       memory_limit: "512m"
       cpu_limit: 0.5

--- a/tests/test_back_edge_helper.py
+++ b/tests/test_back_edge_helper.py
@@ -100,6 +100,10 @@ def _record(task_id: str, **overrides) -> dict:
     base = {
         "id": task_id,
         "assignee": "writer",
+        # L9 binding: the back-edge wakes ``origin.user`` only when it
+        # equals the task's ``creator``. For a legit single-hop handoff
+        # (scout → writer), scout is both the creator and the origin user.
+        "creator": "scout",
         "title": "stage work",
         "status": "failed",
         "origin": {"kind": "agent", "channel": "", "user": "scout"},
@@ -201,6 +205,57 @@ class TestBackEdgeHelperEligibility:
             r.value.get("task_id") == "task_self_1" for r in rows
         )
         assert lane.calls == []
+
+    def test_origin_user_mismatch_writes_event_but_does_not_wake(
+        self, mesh_app_with_back_edge,
+    ):
+        """L9 binding: when ``origin.user`` is not the task ``creator``
+        (forged origin, or a multi-hop chain whose origin points at a
+        distant root), the back-edge EVENT is still written so the
+        originator's check_inbox/heartbeat sees it — but the privileged
+        wake is skipped so no arbitrary agent is interrupted."""
+        app, blackboard, lane, _loop = mesh_app_with_back_edge
+        # origin.user="analyst" (claimed) but creator="scout" (real).
+        rec = _record(
+            "task_mismatch_1",
+            creator="scout",
+            origin={"kind": "agent", "channel": "", "user": "analyst"},
+        )
+
+        app._write_task_event_back_edge(
+            rec, event_kind="task_failed",
+            payload_extras={"error": "boom"},
+        )
+        _settle()
+
+        # Event IS written to the claimed origin's inbox (delivery intact).
+        rows = blackboard.list_by_prefix("inbox/analyst/task_event/")
+        assert any(
+            r.value.get("task_id") == "task_mismatch_1" for r in rows
+        )
+        # But NO wake — origin_user != creator.
+        assert lane.calls == []
+
+    def test_origin_user_matches_creator_wakes(self, mesh_app_with_back_edge):
+        """L9 binding: the legit case (origin.user == creator) still
+        wakes the originator — auto-recovery is unaffected."""
+        app, blackboard, lane, _loop = mesh_app_with_back_edge
+        rec = _record(
+            "task_match_1",
+            creator="scout",
+            origin={"kind": "agent", "channel": "", "user": "scout"},
+        )
+
+        app._write_task_event_back_edge(
+            rec, event_kind="task_failed",
+            payload_extras={"error": "boom"},
+        )
+        _settle()
+
+        rows = blackboard.list_by_prefix("inbox/scout/task_event/")
+        assert any(r.value.get("task_id") == "task_match_1" for r in rows)
+        assert len(lane.calls) == 1
+        assert lane.calls[0]["args"][0] == "scout"
 
     def test_human_origin_skipped(self, mesh_app_with_back_edge):
         """``origin.kind=human`` callers (channels, web chat) don't get

--- a/tests/test_credential_request.py
+++ b/tests/test_credential_request.py
@@ -200,6 +200,15 @@ class TestCredentialRequestEndpoint:
         blackboard = Blackboard(str(bb_path))
         pubsub = PubSub()
         permissions = PermissionMatrix()
+        # L2 gate: /mesh/credential-request now enforces
+        # ``can_request_user_credentials``. Grant it to ``agent-1`` so the
+        # happy-path endpoint tests below exercise an *authorized* worker.
+        # ``test_denied_without_capability`` covers the deny path.
+        from src.shared.types import AgentPermissions
+        permissions.permissions["agent-1"] = AgentPermissions(
+            agent_id="agent-1", can_request_user_credentials=True,
+        )
+        self.permissions = permissions
         router = MessageRouter(permissions, {})
         costs = CostTracker(str(costs_path))
         traces = TraceStore(str(traces_path))
@@ -307,3 +316,55 @@ class TestCredentialRequestEndpoint:
         assert set(call_data.keys()) == {
             "name", "description", "service", "request_id",
         }
+
+    @pytest.mark.asyncio
+    async def test_denied_without_capability(self, _app):
+        """L2 gate: a worker lacking can_request_user_credentials is 403.
+
+        ``unprivileged`` has no permissions entry, so the matrix returns
+        the deny-all default (``can_request_user_credentials=False``).
+        """
+        from httpx import ASGITransport, AsyncClient
+
+        async with AsyncClient(
+            transport=ASGITransport(app=_app), base_url="http://test",
+        ) as client:
+            resp = await client.post(
+                "/mesh/credential-request",
+                json={
+                    "agent_id": "unprivileged",
+                    "name": "stripe_key",
+                    "description": "Your Stripe key",
+                    "service": "Stripe",
+                },
+            )
+        assert resp.status_code == 403
+        # No dashboard event must be emitted for a denied request.
+        self.event_bus.emit.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_allowed_with_capability(self, _app):
+        """L2 gate: a worker WITH the capability is allowed through."""
+        from httpx import ASGITransport, AsyncClient
+
+        from src.shared.types import AgentPermissions
+
+        self.permissions.permissions["worker-cred"] = AgentPermissions(
+            agent_id="worker-cred", can_request_user_credentials=True,
+        )
+
+        async with AsyncClient(
+            transport=ASGITransport(app=_app), base_url="http://test",
+        ) as client:
+            resp = await client.post(
+                "/mesh/credential-request",
+                json={
+                    "agent_id": "worker-cred",
+                    "name": "linkedin_key",
+                    "description": "Your LinkedIn key",
+                    "service": "LinkedIn",
+                },
+            )
+        assert resp.status_code == 200
+        assert resp.json()["requested"] is True
+        self.event_bus.emit.assert_called_once()

--- a/tests/test_credential_request_cancel.py
+++ b/tests/test_credential_request_cancel.py
@@ -27,6 +27,14 @@ def _build_mesh(tmp_path, *, lane_manager=None):
     bb = Blackboard(str(tmp_path / "bb.db"))
     pubsub = PubSub()
     perms = PermissionMatrix()
+    # L2 gate: /mesh/credential-request enforces
+    # ``can_request_user_credentials``. Grant it to ``agent-1`` so these
+    # cancellation tests can reach the request endpoint.
+    from src.shared.types import AgentPermissions
+    for _aid in ("agent-1", "a"):
+        perms.permissions[_aid] = AgentPermissions(
+            agent_id=_aid, can_request_user_credentials=True,
+        )
     router = MessageRouter(perms, {})
     costs = CostTracker(str(tmp_path / "costs.db"))
     traces = TraceStore(str(tmp_path / "traces.db"))

--- a/tests/test_templates.py
+++ b/tests/test_templates.py
@@ -228,6 +228,26 @@ class TestAddAgentPermissions(_TempConfigMixin):
         # Defaults still present
         assert "llm" in bob["allowed_apis"]
 
+    def test_can_request_user_credentials_persisted_from_template(self):
+        """L2: a template that sets ``can_request_user_credentials: true``
+        must persist the flag so the /mesh/credential-request gate lets
+        that worker through. Defaults False when the template omits it."""
+        _add_agent_to_config("scraper", "enricher", "openai/gpt-4o")
+        _add_agent_permissions("scraper", permissions={
+            "can_request_user_credentials": True,
+        })
+        _add_agent_to_config("plain", "writer", "openai/gpt-4o")
+        _add_agent_permissions("plain", permissions={
+            "can_publish": ["draft_ready"],
+        })
+        with open(self._perms_path) as f:
+            perms = json.load(f)
+        assert perms["permissions"]["scraper"]["can_request_user_credentials"] is True
+        # Omitted → falls back to the deny-all default (False).
+        assert perms["permissions"]["plain"].get(
+            "can_request_user_credentials", False,
+        ) is False
+
     def test_template_permissions_merge_with_collab_defaults(self):
         """Template permissions add to collaboration defaults, not replace."""
         _add_agent_to_config("carol", "writer", "openai/gpt-4o")

--- a/tests/test_wake_task_binding.py
+++ b/tests/test_wake_task_binding.py
@@ -1,0 +1,184 @@
+"""Tests for the M3 wake task-id binding gate on ``POST /mesh/wake``.
+
+The wake endpoint threads an ``x-task-id`` header into the lane payload
+so the recipient's loop auto-closes the task on return. Finding M3
+requires that this only happens when the named task is actually assigned
+to the wake ``target`` — otherwise a caller could ride a forged/mismatched
+task_id and cause the recipient's loop to auto-close an UNRELATED agent's
+task.
+
+Binding rule:
+  * ``assignee == target`` → task_id threaded (legit handoff auto-close).
+  * ``assignee != target`` or task missing → task_id dropped, but the
+    wake itself still proceeds (no rejection).
+
+The fixture boots a real mesh app with a fake lane + a real dispatch
+loop (so ``run_coroutine_threadsafe`` lands) and inspects the enqueue
+kwargs the endpoint produced.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import importlib
+import threading
+import time
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from src.host.mesh import Blackboard, MessageRouter, PubSub
+from src.host.permissions import PermissionMatrix
+from src.shared.types import AgentPermissions
+
+
+def _reload_server(monkeypatch, *, tasks_db: str):
+    monkeypatch.setenv("OPENLEGION_ORCHESTRATION_TASKS_DB", tasks_db)
+    import src.host.server as server_module
+    importlib.reload(server_module)
+    return server_module
+
+
+class _FakeLane:
+    """Minimal LaneManager stand-in that records enqueue calls."""
+
+    def __init__(self):
+        self.calls: list[dict] = []
+
+    async def enqueue(self, *args, **kwargs):
+        self.calls.append({"args": args, "kwargs": kwargs})
+        return "ok"
+
+
+@pytest.fixture
+def wake_app(tmp_path, monkeypatch):
+    server_module = _reload_server(
+        monkeypatch, tasks_db=str(tmp_path / "tasks.db"),
+    )
+
+    blackboard = Blackboard(str(tmp_path / "bb.db"))
+    pubsub = PubSub()
+    permissions = PermissionMatrix()
+    # ``can_message=["*"]`` so the wake's can_message gate is satisfied;
+    # the test targets the task-id binding, not the messaging gate.
+    for aid in ("scout", "writer", "analyst"):
+        permissions.permissions[aid] = AgentPermissions(
+            agent_id=aid, can_message=["*"],
+        )
+    router = MessageRouter(permissions, {
+        "scout":   "http://scout:8400",
+        "writer":  "http://writer:8400",
+        "analyst": "http://analyst:8400",
+    })
+
+    lane = _FakeLane()
+    loop = asyncio.new_event_loop()
+
+    def _run():
+        asyncio.set_event_loop(loop)
+        loop.run_forever()
+
+    thread = threading.Thread(target=_run, daemon=True)
+    thread.start()
+
+    app = server_module.create_mesh_app(
+        blackboard=blackboard,
+        pubsub=pubsub,
+        router=router,
+        permissions=permissions,
+        lane_manager=lane,  # type: ignore[arg-type]
+        dispatch_loop=loop,
+    )
+    # Grab the tasks store the app wired so the test can seed task rows.
+    tasks_store = app.tasks_store
+    yield app, lane, tasks_store
+    loop.call_soon_threadsafe(loop.stop)
+    thread.join(timeout=2)
+    blackboard.close()
+    loop.close()
+    monkeypatch.delenv("OPENLEGION_ORCHESTRATION_TASKS_DB", raising=False)
+    importlib.reload(server_module)
+
+
+def _settle(seconds: float = 0.05) -> None:
+    time.sleep(seconds)
+
+
+@pytest.mark.asyncio
+async def test_legit_handoff_threads_task_id(wake_app):
+    """assignee == target → task_id is threaded so the recipient's loop
+    auto-closes the task (the legitimate hand_off auto-close path)."""
+    app, lane, tasks_store = wake_app
+    # scout hands off to writer: create_task(assignee=writer), then wake
+    # writer with that task_id.
+    rec = tasks_store.create(
+        creator="scout", assignee="writer", title="stage work",
+    )
+    task_id = rec["id"]
+
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://test",
+    ) as client:
+        resp = await client.post(
+            "/mesh/wake",
+            params={"target": "writer", "message": "new task"},
+            headers={"X-Agent-ID": "scout", "x-task-id": task_id},
+        )
+    assert resp.status_code == 200
+    assert resp.json()["woken"] is True
+    _settle()
+
+    assert len(lane.calls) == 1
+    # task_id was threaded — auto-close works for the legit handoff.
+    assert lane.calls[0]["kwargs"].get("task_id") == task_id
+
+
+@pytest.mark.asyncio
+async def test_mismatched_task_id_dropped_not_rejected(wake_app):
+    """assignee != target → wake still succeeds but the task_id is
+    dropped so no UNRELATED task is auto-closed."""
+    app, lane, tasks_store = wake_app
+    # Task is assigned to analyst, but the wake targets writer.
+    rec = tasks_store.create(
+        creator="scout", assignee="analyst", title="analyst's task",
+    )
+    other_task_id = rec["id"]
+
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://test",
+    ) as client:
+        resp = await client.post(
+            "/mesh/wake",
+            params={"target": "writer", "message": "nudge"},
+            headers={"X-Agent-ID": "scout", "x-task-id": other_task_id},
+        )
+    # Wake is NOT rejected.
+    assert resp.status_code == 200
+    assert resp.json()["woken"] is True
+    _settle()
+
+    assert len(lane.calls) == 1
+    # task_id was DROPPED — analyst's task will not be auto-closed by
+    # writer's loop.
+    assert lane.calls[0]["kwargs"].get("task_id") is None
+
+
+@pytest.mark.asyncio
+async def test_unknown_task_id_dropped(wake_app):
+    """A task_id that does not resolve to any task is dropped (wake still
+    proceeds)."""
+    app, lane, _tasks_store = wake_app
+
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://test",
+    ) as client:
+        resp = await client.post(
+            "/mesh/wake",
+            params={"target": "writer", "message": "nudge"},
+            headers={"X-Agent-ID": "scout", "x-task-id": "does-not-exist"},
+        )
+    assert resp.status_code == 200
+    _settle()
+
+    assert len(lane.calls) == 1
+    assert lane.calls[0]["kwargs"].get("task_id") is None


### PR DESCRIPTION
May 2026 remediation of security findings **M3**, **L9**, and **L2**. Targeted binding/gating fixes that explicitly preserve every legitimate handoff auto-close and worker credential flow.

## M3 — wake task-id binding
`/mesh/wake` honoured an attacker-influenceable `x-task-id` header and threaded it into the recipient's lane **unvalidated**, letting the recipient's loop auto-close an *unrelated* agent's task on return.

Fix: look up the task and only thread the task_id when `record["assignee"] == target`. On mismatch (or unknown task) the task_id is **dropped** but the wake still proceeds (no rejection — the wake itself may be a legit nudge).

**Legit auto-close unaffected:** `hand_off` creates the task with `assignee=to` then wakes that same `to` with `task_id` set, so the recipient is always the assignee — the binding always holds for real handoffs.

## L9 — back-edge origin binding
The terminal-status back-edge wakes `origin_user`, sourced verbatim from the task's stored (forgeable) agent-kind `origin` claim.

Fix: only wake when `origin_user == record["creator"]`. The back-edge **event is still written** to `inbox/{origin_user}/` unconditionally (originator always learns via `check_inbox`/heartbeat); only the privileged interrupt wake is bound. A direct single-hop handoff has `origin_user == creator`, so legit `task_failed`/`task_blocked` recovery wakes still fire.

## L2 — credential-request gate
`/mesh/credential-request` had an un-enforced `TODO` gate — any agent could prompt the user for a credential.

Fix: enforce `can_request_user_credentials` (operator + mesh bypass as trusted). To avoid breaking legitimate worker flows, the capability is populated on the browser-scraping worker agents that authenticate against login-gated services:

- lead-enrichment `enricher`
- sales `researcher`
- social-listening `monitor`
- price-intelligence `crawler`
- review-ops `monitor`
- competitive-intel `scout`
- monitor `watcher`

The CLI template loader already forwards this boolean into `permissions.json`. The operator already receives it via backfill.

## Tests
- New `tests/test_wake_task_binding.py`: M3 thread (legit) / drop-mismatch / drop-unknown.
- `tests/test_back_edge_helper.py`: L9 mismatch-writes-but-no-wake + match-wakes; `_record` now carries `creator`.
- `tests/test_credential_request.py`: allow-with-capability / deny-without; existing happy-path tests granted the capability.
- `tests/test_credential_request_cancel.py`: fixture grants the capability.
- `tests/test_templates.py`: template `can_request_user_credentials` persistence.

All relevant suites pass locally (288 in the combined regression run); ruff clean. May need a rebase onto main.