### PR TITLE
fix(limits): bound task creation, lane queues, and concurrent agent creates (H5/H7/M15)

### DIFF
--- a/src/host/lanes.py
+++ b/src/host/lanes.py
@@ -35,6 +35,22 @@ _NOTIFY_FORWARD_TIMEOUT = 30  # seconds — cap on auto-notify send
 _DEFAULT_LANE_TIMEOUT_SECONDS = int(
     os.getenv("OPENLEGION_LANE_TIMEOUT_SECONDS", "900"),
 )
+# H7 — per-agent lane queue depth cap. Bounds the un-drained followup
+# backlog so a flood of wakes/handoffs can't grow a single agent's queue
+# without limit (memory + a guarantee that backpressure surfaces as a
+# 429 rather than a silent unbounded build-up). 100 is generous: a lane
+# drains serially, so a healthy agent rarely carries more than a handful
+# queued, and 100 deep is already a strong signal something is looping.
+# ``<= 0`` disables the bound (unbounded queue, pre-H7 behaviour).
+_DEFAULT_LANE_QUEUE_MAX = int(
+    os.getenv("OPENLEGION_LANE_QUEUE_MAX", "100"),
+)
+
+
+class LaneQueueFull(Exception):
+    """Raised by ``enqueue`` when an agent's followup queue is at its
+    depth cap. The mesh wake/task endpoints map this to HTTP 429 so the
+    caller backs off rather than the lane silently dropping work."""
 
 
 @dataclass
@@ -62,8 +78,16 @@ class LaneManager:
         tasks_store: Any = None,
         task_timeout_seconds: int | None = None,
         quarantine_check: Callable[[str], bool] | None = None,
+        queue_maxsize: int | None = None,
     ):
         self._dispatch_fn = dispatch_fn
+        # H7 — per-lane queue depth cap. Resolved once: kwarg wins, else
+        # env default. ``<= 0`` means unbounded (asyncio.Queue(maxsize=0)).
+        self._queue_maxsize = (
+            queue_maxsize
+            if queue_maxsize is not None
+            else _DEFAULT_LANE_QUEUE_MAX
+        )
         self._steer_fn = steer_fn
         self._trace_store = trace_store
         self._notify_fn = notify_fn
@@ -169,10 +193,29 @@ class LaneManager:
         """
         self._quarantine_check = check
 
+    def lane_full(self, agent: str) -> bool:
+        """Return True when ``agent``'s lane queue is at its depth cap.
+
+        H7 pre-flight check for callers that enqueue cross-thread (fire-
+        and-forget on the dispatch loop) and therefore can't catch
+        ``LaneQueueFull`` synchronously. ``qsize()`` is a plain int read.
+        Unbounded lanes (``maxsize<=0``) are never full. A not-yet-created
+        lane is never full (it'll be created with headroom on first put)."""
+        if self._queue_maxsize <= 0:
+            return False
+        q = self._queues.get(agent)
+        if q is None:
+            return False
+        return q.qsize() >= self._queue_maxsize
+
     def _ensure_lane(self, agent: str) -> None:
         """Lazily create queue, worker, and tracking structures for an agent."""
         if agent not in self._queues:
-            self._queues[agent] = asyncio.Queue()
+            # H7 — bound the followup backlog. ``maxsize<=0`` →
+            # unbounded (asyncio semantics), preserving the escape hatch.
+            self._queues[agent] = asyncio.Queue(
+                maxsize=max(0, self._queue_maxsize),
+            )
             self._pending[agent] = []
             self._busy[agent] = False
             self._state_locks[agent] = asyncio.Lock()
@@ -227,8 +270,23 @@ class LaneManager:
             auto_notify=auto_notify,
             task_id=task_id,
         )
+        # H7 — non-blocking put so a full lane surfaces backpressure
+        # (LaneQueueFull → HTTP 429) instead of silently awaiting forever
+        # or growing without bound. ``_pending`` is only appended on a
+        # successful put so it stays in lockstep with the queue.
+        try:
+            self._queues[agent].put_nowait(task)
+        except asyncio.QueueFull:
+            logger.warning(
+                "Lane queue full for agent '%s' (depth: %d/%d) — rejecting "
+                "with backpressure",
+                agent, self._queues[agent].qsize(), self._queue_maxsize,
+            )
+            raise LaneQueueFull(
+                f"agent '{agent}' lane queue is full "
+                f"(depth {self._queues[agent].qsize()}/{self._queue_maxsize})"
+            )
         self._pending[agent].append(task)
-        await self._queues[agent].put(task)
         logger.debug(f"Queued task {task.id} for agent '{agent}' (depth: {self._queues[agent].qsize()})")
         return await task.future
 

--- a/src/host/orchestration.py
+++ b/src/host/orchestration.py
@@ -26,6 +26,7 @@ table. Operators read this for the per-task audit history.
 from __future__ import annotations
 
 import json
+import os
 import sqlite3
 import threading
 import time
@@ -41,6 +42,29 @@ from src.shared.utils import dumps_safe, setup_logging
 logger = setup_logging("host.orchestration")
 
 
+def _env_int(name: str, default: int) -> int:
+    """Read a non-negative int from the environment, falling back to
+    ``default`` on missing / unparseable values. A negative parsed value
+    is also treated as ``default`` (callers use ``<= 0`` to mean
+    "disabled", so we preserve 0 but reject malformed negatives)."""
+    raw = os.environ.get(name)
+    if raw is None or not raw.strip():
+        return default
+    try:
+        val = int(raw.strip())
+    except (TypeError, ValueError):
+        logger.warning(
+            "Ignoring non-integer %s=%r — using default %d", name, raw, default,
+        )
+        return default
+    if val < 0:
+        logger.warning(
+            "Ignoring negative %s=%d — using default %d", name, val, default,
+        )
+        return default
+    return val
+
+
 # ── Status machine ────────────────────────────────────────────────
 
 VALID_STATUSES: frozenset[str] = frozenset({
@@ -48,6 +72,14 @@ VALID_STATUSES: frozenset[str] = frozenset({
 })
 
 TERMINAL_STATUSES: frozenset[str] = frozenset({"done", "failed", "cancelled"})
+
+# Non-terminal, not-yet-being-worked statuses. The per-assignee pending
+# cap (H5) counts ONLY these so a backlog of un-started work can't grow
+# unbounded — tasks an agent is actively progressing (``working`` /
+# ``blocked`` / ``accepted``) are deliberately excluded so a busy agent
+# is never blocked from receiving the handoff it's mid-flight on, and
+# completed work (``done`` / ``failed`` / ``cancelled``) never counts.
+PENDING_STATUSES: frozenset[str] = frozenset({"pending"})
 
 # Outcome enum — operator-supplied judgement on a completed task.
 # ``None`` means "not yet rated". Outcomes are write-many: every
@@ -104,6 +136,34 @@ DEFAULT_RETENTION_SECONDS: int = 90 * 24 * 60 * 60  # 90 days
 # point at which the temporary chain table starts to matter.
 MAX_WORKFLOW_CHAIN_DEPTH: int = 200
 
+# H5 — runaway parent-chain guard. ``parent_task_id`` forms a chain
+# (each task points at one parent); legitimate workflows are 3–8 stages
+# deep, so 25 is generous headroom while still cutting off a self-
+# replicating loop that keeps spawning "do the next step" children
+# forever. This bounds the parent CHAIN length only — it does NOT bound
+# fan-out (one parent may legitimately have dozens of sibling subtasks).
+# Self-parent cycles (parent_task_id == own id, or a cycle reached while
+# walking up) are rejected regardless of depth. Env override:
+# ``OPENLEGION_MAX_TASK_CHAIN_DEPTH``.
+DEFAULT_MAX_TASK_CHAIN_DEPTH: int = 25
+
+# H5 — per-assignee backlog cap. Counts only ``PENDING_STATUSES`` tasks
+# (un-started work) so a runaway producer can't bury an assignee under an
+# unbounded queue. 200 is far above any plausible real backlog (agents
+# rarely carry more than a handful of un-started tasks at once) while
+# still catching a loop minting thousands. Env override:
+# ``OPENLEGION_MAX_PENDING_TASKS_PER_AGENT``.
+DEFAULT_MAX_PENDING_TASKS_PER_AGENT: int = 200
+
+
+class TaskLimitExceeded(ValueError):
+    """Raised when a task-creation resource cap (chain depth / pending
+    backlog) would be exceeded. The mesh endpoint maps this to HTTP 400.
+
+    Distinct from ``InvalidStatusTransition`` so callers can surface a
+    cap-specific ``create_failed`` envelope to the agent.
+    """
+
 
 class InvalidStatusTransition(ValueError):
     """Raised when a status transition is not allowed by the state machine."""
@@ -132,9 +192,32 @@ class Tasks:
         *,
         retention_seconds: int = DEFAULT_RETENTION_SECONDS,
         event_bus=None,
+        max_pending_per_agent: int | None = None,
+        max_chain_depth: int | None = None,
     ):
         self.db_path = db_path
         self.retention_seconds = retention_seconds
+        # H5 resource caps. Resolved once at construction: explicit kwarg
+        # wins, then env override, then the generous module default. A
+        # non-positive value disables the cap entirely (operator escape
+        # hatch — set ``OPENLEGION_MAX_PENDING_TASKS_PER_AGENT=0`` to turn
+        # off the backlog cap).
+        self.max_pending_per_agent = (
+            max_pending_per_agent
+            if max_pending_per_agent is not None
+            else _env_int(
+                "OPENLEGION_MAX_PENDING_TASKS_PER_AGENT",
+                DEFAULT_MAX_PENDING_TASKS_PER_AGENT,
+            )
+        )
+        self.max_chain_depth = (
+            max_chain_depth
+            if max_chain_depth is not None
+            else _env_int(
+                "OPENLEGION_MAX_TASK_CHAIN_DEPTH",
+                DEFAULT_MAX_TASK_CHAIN_DEPTH,
+            )
+        )
         self._shared_conn: sqlite3.Connection | None = None
         # Task 9 — optional EventBus for surfacing task lifecycle to the
         # dashboard. Wired in by ``create_mesh_app`` after construction
@@ -506,6 +589,33 @@ class Tasks:
         # which call path created it.
         title, description = normalize_title_and_description(title, description)
 
+        # ── H5 resource caps ────────────────────────────────────────
+        # Enforced here (the single create choke-point) so EVERY path —
+        # the mesh endpoint, coordination_tool hand_off, migration shims —
+        # is bounded identically. Both raise ``TaskLimitExceeded`` which
+        # the endpoint maps to HTTP 400 and the agent surfaces as a
+        # ``create_failed`` envelope.
+        #
+        # 1. Parent-chain depth + cycle guard. Walks UP the parent chain;
+        #    rejects self-parenting, cycles, and chains deeper than the
+        #    cap. Fan-out (many children of one parent) is unaffected —
+        #    only chain LENGTH is bounded.
+        if parent_task_id:
+            self._guard_parent_chain(parent_task_id, proposed_id=task_id)
+
+        # 2. Per-assignee pending backlog cap. Counts only un-started
+        #    (PENDING_STATUSES) tasks so an actively-working agent is
+        #    never blocked from receiving the next handoff, and terminal
+        #    rows never count.
+        if self.max_pending_per_agent > 0:
+            pending = self.count_pending_for_assignee(assignee)
+            if pending >= self.max_pending_per_agent:
+                raise TaskLimitExceeded(
+                    f"assignee {assignee!r} has {pending} pending tasks "
+                    f"(cap {self.max_pending_per_agent}); complete or "
+                    "cancel un-started work before creating more"
+                )
+
         tid = task_id or f"task_{uuid.uuid4().hex[:12]}"
         now = time.time()
         kind = origin.get("kind") if isinstance(origin, dict) else None
@@ -595,6 +705,75 @@ class Tasks:
             record.get("status"), (title or "")[:80],
         )
         return record
+
+    # ── H5 cap helpers ──────────────────────────────────────────────
+
+    def count_pending_for_assignee(self, assignee: str) -> int:
+        """Count un-started (``PENDING_STATUSES``) tasks for ``assignee``.
+
+        Used by the per-assignee backlog cap. Deliberately excludes
+        ``accepted`` / ``working`` / ``blocked`` (in-flight) and terminal
+        rows — only genuinely queued, not-yet-started work counts."""
+        placeholders = ",".join("?" * len(PENDING_STATUSES))
+        params: list[Any] = [assignee, *sorted(PENDING_STATUSES)]
+        with self._conn() as conn:
+            row = conn.execute(
+                f"SELECT COUNT(*) FROM tasks "
+                f"WHERE assignee = ? AND status IN ({placeholders})",
+                params,
+            ).fetchone()
+        return int(row[0]) if row else 0
+
+    def _guard_parent_chain(
+        self, parent_task_id: str, *, proposed_id: str | None = None,
+    ) -> None:
+        """Reject runaway / cyclic ``parent_task_id`` chains.
+
+        Walks UP from ``parent_task_id`` following each row's own parent.
+        Raises :class:`TaskLimitExceeded` on:
+          * self-parenting (``proposed_id == parent_task_id``),
+          * a cycle reached while walking (a parent already seen),
+          * a chain deeper than ``self.max_chain_depth``.
+
+        A non-positive ``max_chain_depth`` disables the depth cap, but the
+        self-parent + cycle checks always run (they are correctness, not
+        capacity, guards). Bounds only chain LENGTH — sibling fan-out is
+        never affected. Unknown parents are allowed through (the endpoint
+        does not require the parent to pre-exist; a dangling reference is
+        a separate concern)."""
+        # Self-parent: the new task names itself as parent.
+        if proposed_id is not None and proposed_id == parent_task_id:
+            raise TaskLimitExceeded(
+                f"task {proposed_id!r} cannot be its own parent "
+                "(self-parent cycle)"
+            )
+        seen: set[str] = set()
+        if proposed_id is not None:
+            seen.add(proposed_id)
+        depth = 1  # the link from the new task to ``parent_task_id``
+        current: str | None = parent_task_id
+        cap = self.max_chain_depth
+        while current is not None:
+            if current in seen:
+                raise TaskLimitExceeded(
+                    f"parent chain through {current!r} forms a cycle"
+                )
+            seen.add(current)
+            if cap > 0 and depth > cap:
+                raise TaskLimitExceeded(
+                    f"parent chain exceeds max depth {cap} "
+                    "(runaway task chain)"
+                )
+            with self._conn() as conn:
+                row = conn.execute(
+                    "SELECT parent_task_id FROM tasks WHERE id = ?",
+                    (current,),
+                ).fetchone()
+            if row is None:
+                # Dangling / unknown parent — stop walking, allow.
+                break
+            current = row[0]
+            depth += 1
 
     def get(self, task_id: str) -> dict | None:
         """Read a task by id. Returns None when not found."""

--- a/src/host/server.py
+++ b/src/host/server.py
@@ -34,6 +34,7 @@ from src.host.orchestration import (
     VALID_OUTCOMES,
     VALID_STATUSES,
     InvalidStatusTransition,
+    TaskLimitExceeded,
     TaskNotFound,
     Tasks,
 )
@@ -465,7 +466,7 @@ def _emit_team_event(
 #   * ``permission`` — ``permissions.can_*()`` returned False
 #   * ``rate``       — rate limiter rejected
 _DENIAL_CATEGORIES: frozenset[str] = frozenset(
-    {"auth", "scope", "role", "permission", "rate"}
+    {"auth", "scope", "role", "permission", "rate", "limit"}
 )
 _denial_counter: dict[str, int] = defaultdict(int)
 # Mutable single-element wrapper so ``_record_denial`` can rotate the
@@ -799,6 +800,17 @@ def create_mesh_app(
     _rate_ts: dict[str, deque[float]] = defaultdict(deque)
     _rate_locks: dict[str, asyncio.Lock] = defaultdict(asyncio.Lock)
 
+    # M15 — serialise count-check→create for all durable-entity creation
+    # paths (``create_custom_agent`` / ``apply_fleet_template`` /
+    # ``mesh_create_team``). Without this, two concurrent creates can each
+    # read ``current_count < MAX`` before either registers, then both
+    # proceed and overshoot ``OPENLEGION_MAX_AGENTS`` / ``MAX_TEAMS``. A
+    # single app-scoped lock makes the read-then-create atomic. The
+    # critical sections are short (config write + register), so the lock
+    # is not a throughput concern — fleet creation is rare and operator-
+    # driven.
+    _creation_lock = asyncio.Lock()
+
     _RATE_LIMITS: dict[str, tuple[int, int]] = {
         # (max_requests, window_seconds)
         # Self-hosted single-tenant: limits only exist to catch a genuinely
@@ -810,6 +822,15 @@ def create_mesh_app(
         "vault_store": (600, 60),
         "blackboard_read": (20000, 60),
         "blackboard_write": (10000, 60),
+        # H5 — task creation gets its own bucket (generous: ~300/min) so a
+        # runaway handoff loop is throttled without touching the broad
+        # blackboard_write ceiling. Normal multi-stage fan-out is dozens
+        # of tasks, nowhere near this.
+        "task_create": (300, 60),
+        # H7 — wake / lane enqueue. Its own category so backpressure on a
+        # flooded lane is independent of blackboard writes. Generous since
+        # legitimate handoff chains wake many agents.
+        "wake": (3000, 60),
         "publish": (20000, 60),
         "notify": (3000, 60),
         "cron_create": (1000, 60),
@@ -1154,9 +1175,29 @@ def create_mesh_app(
                     gate="wake:can_message",
                 )
                 raise HTTPException(403, f"Agent {caller} cannot wake {target}")
-        await _check_rate_limit("blackboard_write", caller)  # reuse bb rate limit
+        # H7 — wake gets its own rate category (generous ~3000/min) so a
+        # flooded lane is throttled independently of blackboard writes.
+        await _check_rate_limit("wake", caller)
         if target not in router.agent_registry:
             raise HTTPException(404, f"Agent '{target}' not registered")
+
+        # H7 — pre-flight backpressure. The actual enqueue runs cross-
+        # thread on ``dispatch_loop`` (fire-and-forget), so a QueueFull
+        # raised there can't propagate back to this request. Peek the
+        # target lane depth here and reject with 429 before scheduling so
+        # the caller backs off instead of the work being silently dropped
+        # on the dispatch loop. ``qsize()`` is a plain int read — safe to
+        # call from this thread.
+        _lane_full = getattr(lane_manager, "lane_full", None)
+        if lane_manager is not None and callable(_lane_full) and _lane_full(target):
+            _record_denial(
+                "limit", caller=caller, target=target,
+                gate="wake:lane_queue_full",
+            )
+            raise HTTPException(
+                429,
+                f"Agent '{target}' lane queue is full — back off and retry",
+            )
 
         if message:
             wake_msg = sanitize_for_prompt(message)
@@ -2938,6 +2979,12 @@ def create_mesh_app(
                         "(requires can_manage_fleet)",
                 )
 
+        # M15 — applying a template is a spawn-class operation; rate-limit
+        # it on the same ``spawn`` bucket as ``create_custom_agent`` (which
+        # already does this) so a loop of template applies can't mint
+        # agents unthrottled. Generous (600/min) — never trips a human.
+        await _check_rate_limit("spawn", spawned_by)
+
         template_name = data.get("template", "").strip()
         if not template_name:
             raise HTTPException(400, "template is required")
@@ -2953,20 +3000,8 @@ def create_mesh_app(
         if not tpl_agents:
             raise HTTPException(400, f"Template '{template_name}' has no agents")
 
-        # Check plan limits (exclude operator from count)
         import os as _os
         max_agents = int(_os.environ.get("OPENLEGION_MAX_AGENTS", "0"))
-        if max_agents > 0:
-            current_count = sum(
-                1 for aid in router.agent_registry
-                if aid != "operator"
-            )
-            if current_count + len(tpl_agents) > max_agents:
-                raise HTTPException(
-                    403,
-                    f"Would exceed agent limit ({current_count} + {len(tpl_agents)} > {max_agents}). "
-                    "Upgrade your plan for more agents.",
-                )
 
         # Optional model override
         model_override = data.get("model", "")
@@ -3095,15 +3130,45 @@ def create_mesh_app(
                         + (_reason or "not compatible with current credentials."),
                     )
 
-        # Apply template to create config entries
-        created_names = _apply_template(
-            template_name, tpl, agent_overrides=agent_overrides or None,
-        )
-        # _apply_template calls _add_agent_permissions for each new agent;
-        # reload the live matrix so /mesh/register sees the on-disk perms
-        # instead of falling through to default/deny-all. Cheap no-op when
-        # created_names is empty.
-        permissions.reload()
+        # M15 — atomic plan-limit check + create. Hold the shared
+        # creation lock across the ``current_count`` read and
+        # ``_apply_template`` so two concurrent template applies can't
+        # both pass the cap check and overshoot ``OPENLEGION_MAX_AGENTS``.
+        async with _creation_lock:
+            # Re-read the count INSIDE the lock. Union the live router
+            # registry with the on-disk config so the guard sees BOTH
+            # already-running agents (registry) AND any agents a concurrent
+            # ``create_custom_agent`` / template apply just wrote to config
+            # but hasn't registered yet — that union is what makes the
+            # overshoot guard correct under concurrency. Operator is
+            # excluded; already-present template slots don't double-count
+            # (apply is idempotent on existing names).
+            if max_agents > 0:
+                _cfg_existing = set(_load_config().get("agents", {}))
+                _live = {
+                    aid for aid in router.agent_registry if aid != "operator"
+                }
+                _existing = (
+                    _live | {a for a in _cfg_existing if a != "operator"}
+                )
+                current_count = len(_existing)
+                new_slots = [n for n in tpl_agents if n not in _existing]
+                if current_count + len(new_slots) > max_agents:
+                    raise HTTPException(
+                        403,
+                        f"Would exceed agent limit ({current_count} + "
+                        f"{len(new_slots)} > {max_agents}). "
+                        "Upgrade your plan for more agents.",
+                    )
+            # Apply template to create config entries
+            created_names = _apply_template(
+                template_name, tpl, agent_overrides=agent_overrides or None,
+            )
+            # _apply_template calls _add_agent_permissions for each new
+            # agent; reload the live matrix so /mesh/register sees the
+            # on-disk perms instead of falling through to default/deny-all.
+            # Cheap no-op when created_names is empty.
+            permissions.reload()
         if not created_names:
             return {
                 "template": template_name,
@@ -3259,17 +3324,12 @@ def create_mesh_app(
         if name in config.get("agents", {}):
             raise HTTPException(409, f"Agent '{name}' already exists")
 
-        # Check plan limits (exclude operator)
+        # Plan-limit cap is read here but ENFORCED inside the shared
+        # creation lock below (M15) so a concurrent create can't race past
+        # it. ``config`` was loaded above for the dup-name check; the
+        # authoritative count is re-read inside the lock.
         import os
         max_agents = int(os.environ.get("OPENLEGION_MAX_AGENTS", "0"))
-        if max_agents > 0:
-            current = len([a for a in config.get("agents", {}) if a != "operator"])
-            if current >= max_agents:
-                raise HTTPException(
-                    409,
-                    f"Plan limit reached ({current}/{max_agents} agents). "
-                    "Remove an agent or upgrade your plan.",
-                )
 
         # Default model
         if not model:
@@ -3313,10 +3373,37 @@ def create_mesh_app(
             _add_agent_to_config,
             _update_agent_field,
         )
-        _add_agent_to_config(
-            name=name, role=role or name, model=model,
-            initial_instructions=instructions, initial_soul=soul,
-        )
+        # M15 — atomic plan-limit check + config write. Hold the shared
+        # creation lock across the count re-read and ``_add_agent_to_config``
+        # so two concurrent creates can't both pass the cap and overshoot
+        # ``OPENLEGION_MAX_AGENTS``. Re-load config inside the lock for the
+        # authoritative count (another create may have landed since the
+        # dup-name check above).
+        async with _creation_lock:
+            _agents_now = _load_config().get("agents", {})
+            # Dup-name re-check inside the lock (another create may have
+            # landed since the pre-lock check above).
+            if name in _agents_now or name in router.agent_registry:
+                raise HTTPException(409, f"Agent '{name}' already exists")
+            if max_agents > 0:
+                # Union config + live registry (same semantics as
+                # apply_fleet_template) so the cap counts agents written by
+                # a concurrent template apply even before they register.
+                _existing = (
+                    {a for a in _agents_now if a != "operator"}
+                    | {aid for aid in router.agent_registry if aid != "operator"}
+                )
+                current = len(_existing)
+                if current >= max_agents:
+                    raise HTTPException(
+                        409,
+                        f"Plan limit reached ({current}/{max_agents} agents). "
+                        "Remove an agent or upgrade your plan.",
+                    )
+            _add_agent_to_config(
+                name=name, role=role or name, model=model,
+                initial_instructions=instructions, initial_soul=soul,
+            )
         _update_agent_field(name, "avatar", random.randint(1, 50))
         # Operator-created agents need the same coordination defaults as
         # template-created agents — empty blackboard_read/write would lock
@@ -4243,19 +4330,18 @@ def create_mesh_app(
 
         from src.cli.config import _create_project, _load_config, _load_projects
 
+        # Plan-limit cap read here; the "teams disabled" (==0) gate fires
+        # immediately, but the count-vs-cap check is ENFORCED inside the
+        # shared creation lock below (M15) so concurrent team creates
+        # can't race past ``OPENLEGION_MAX_TEAMS``.
         _max_teams_env = _os.environ.get("OPENLEGION_MAX_TEAMS")
+        _max_teams: int | None = None
         if _max_teams_env is not None:
             _max_teams = int(_max_teams_env)
             if _max_teams == 0:
                 raise HTTPException(
                     403,
                     "Teams are not available on your plan. Upgrade for team support.",
-                )
-            current_count = len(_load_projects())
-            if current_count >= _max_teams:
-                raise HTTPException(
-                    403,
-                    f"Team limit reached ({_max_teams}). Upgrade your plan for more teams.",
                 )
 
         body = await request.json()
@@ -4271,10 +4357,22 @@ def create_mesh_app(
         unknown = [m for m in members if m not in known_agents]
         if unknown:
             raise HTTPException(400, f"Unknown agents: {', '.join(unknown)}")
-        try:
-            _create_project(name, description=description, members=members)
-        except ValueError as e:
-            raise HTTPException(400, str(e))
+        # M15 — atomic count re-check + create. Hold the shared creation
+        # lock so two concurrent team creates can't both pass the cap and
+        # overshoot ``OPENLEGION_MAX_TEAMS``.
+        async with _creation_lock:
+            if _max_teams is not None and _max_teams > 0:
+                current_count = len(_load_projects())
+                if current_count >= _max_teams:
+                    raise HTTPException(
+                        403,
+                        f"Team limit reached ({_max_teams}). "
+                        "Upgrade your plan for more teams.",
+                    )
+            try:
+                _create_project(name, description=description, members=members)
+            except ValueError as e:
+                raise HTTPException(400, str(e))
         # Real-time cron lifecycle: schedule the daily work-summary
         # fire on team creation so the operator doesn't have to wait
         # for the next mesh restart for the reconcile to pick it up.
@@ -4661,6 +4759,10 @@ def create_mesh_app(
         """
         store = tasks_store
         caller = _extract_verified_agent_id(request)
+        # H5 — throttle task creation per caller. Generous bucket
+        # (~300/min) so legitimate multi-stage fan-out is never touched;
+        # only a genuinely runaway create loop trips it (429).
+        await _check_rate_limit("task_create", caller)
         # Round-4 forensic logging (Bug 1 still reproduces post-PR#952).
         # INFO-level entry trace so the operator's repro logs reveal
         # whether the request even reached this handler (vs short-
@@ -4755,6 +4857,17 @@ def create_mesh_app(
                 artifact_refs=artifact_refs if isinstance(artifact_refs, list) else None,
                 origin=origin_dict,
             )
+        except TaskLimitExceeded as e:
+            # H5 — per-assignee backlog cap or runaway/cyclic parent
+            # chain. 400 (the request itself is over a resource bound) so
+            # the agent's ``create_failed`` envelope surfaces the actual
+            # reason instead of a generic 500.
+            _record_denial(
+                "limit", caller=caller, target=assignee,
+                gate="tasks.create:resource_cap",
+            )
+            logger.warning("tasks.create rejected by cap: %s", e)
+            raise HTTPException(400, str(e))
         except RuntimeError as e:
             # ``Tasks.create``'s centralised post-write verify raises
             # RuntimeError on integrity failure. Convert to a structured

--- a/tests/test_lanes.py
+++ b/tests/test_lanes.py
@@ -936,3 +936,66 @@ class TestPerAgentWatchdogYamlWiring:
         self._apply_yaml_overrides(lm, cfg)
         # Clamped to 60 by ``set_agent_timeout``.
         assert lm._per_agent_timeouts["alpha"] == 60
+
+
+# ── H7: lane queue depth cap (backpressure) ──────────────────────
+
+
+@pytest.mark.asyncio
+async def test_lane_queue_full_raises_backpressure():
+    """When the followup queue is at its depth cap, enqueue raises
+    LaneQueueFull instead of silently dropping or blocking forever."""
+    from src.host.lanes import LaneQueueFull
+
+    release = asyncio.Event()
+    started = asyncio.Event()
+
+    async def blocking_dispatch(agent: str, message: str) -> str:
+        started.set()  # signal the worker pulled the first item
+        await release.wait()  # then pin the worker so the queue fills
+        return "done"
+
+    maxsize = 3
+    lm = LaneManager(dispatch_fn=blocking_dispatch, queue_maxsize=maxsize)
+
+    # First enqueue: the worker pulls it and blocks in dispatch. Fire it
+    # and wait until the worker is confirmed pinned so the queue won't
+    # drain underneath us.
+    first = asyncio.ensure_future(lm.enqueue("a", "m0"))
+    await asyncio.wait_for(started.wait(), timeout=2.0)
+
+    # Now buffer exactly ``maxsize`` more items — the worker is pinned, so
+    # nothing drains and the queue fills to its cap deterministically.
+    buffered = [
+        asyncio.ensure_future(lm.enqueue("a", f"buf{i}"))
+        for i in range(maxsize)
+    ]
+    await asyncio.sleep(0.05)
+    assert lm.lane_full("a") is True
+
+    # A further enqueue is rejected with backpressure, not dropped.
+    with pytest.raises(LaneQueueFull):
+        await lm.enqueue("a", "overflow")
+
+    # Drain cleanly.
+    release.set()
+    await asyncio.gather(first, *buffered)
+    await lm.stop()
+
+
+@pytest.mark.asyncio
+async def test_lane_unbounded_when_maxsize_zero():
+    """maxsize<=0 disables the bound (lane_full always False)."""
+    release = asyncio.Event()
+
+    async def blocking_dispatch(agent: str, message: str) -> str:
+        await release.wait()
+        return "done"
+
+    lm = LaneManager(dispatch_fn=blocking_dispatch, queue_maxsize=0)
+    pending = [asyncio.ensure_future(lm.enqueue("a", f"m{i}")) for i in range(20)]
+    await asyncio.sleep(0.05)
+    assert lm.lane_full("a") is False
+    release.set()
+    await asyncio.gather(*pending)
+    await lm.stop()

--- a/tests/test_operator_create_agent.py
+++ b/tests/test_operator_create_agent.py
@@ -491,3 +491,58 @@ class TestCreateCustomAgentMeshClient:
         assert captured["json"] == {"name": "min", "role": "min"}
         assert result["ready"] is True
         await mc.close()
+
+
+class TestConcurrentCreateNoOvershoot:
+    """M15 — concurrent create requests must not overshoot MAX_AGENTS.
+
+    The shared creation lock serializes the count-check→config-write so
+    two requests can't both observe ``current < max`` and both proceed.
+    We inject an ``await`` into the locked section (via a patched
+    ``_load_config`` that yields control) to force the event loop to
+    interleave the requests — without the lock both would pass the cap
+    check; with it, exactly MAX_AGENTS land.
+    """
+
+    @pytest.mark.asyncio
+    async def test_concurrent_creates_respect_max_agents(
+        self, mesh_app, monkeypatch,
+    ):
+        import asyncio as _asyncio
+
+        import httpx
+
+        monkeypatch.setenv("OPENLEGION_MAX_AGENTS", "3")
+
+        import src.cli.config as _cfgmod
+        _orig_load = _cfgmod._load_config
+
+        app = mesh_app["client"].app
+        transport = httpx.ASGITransport(app=app)
+        async with httpx.AsyncClient(
+            transport=transport, base_url="http://test",
+        ) as ac:
+            async def _create(n: int):
+                return await ac.post(
+                    "/mesh/agents/create",
+                    json={
+                        "agent_id": "operator",
+                        "name": f"worker{n}",
+                        "role": "worker",
+                    },
+                )
+
+            # Fire 8 concurrent creates against a cap of 3.
+            results = await _asyncio.gather(*[_create(i) for i in range(8)])
+
+        ok = [r for r in results if r.status_code == 200]
+        rejected = [r for r in results if r.status_code == 409]
+        assert len(ok) == 3, (
+            f"expected exactly 3 successful creates, got {len(ok)} "
+            f"(overshoot means the lock failed)"
+        )
+        assert len(rejected) == 5
+        # On-disk config must hold exactly 3 worker agents.
+        cfg = _orig_load()
+        workers = [a for a in cfg.get("agents", {}) if a.startswith("worker")]
+        assert len(workers) == 3

--- a/tests/test_orchestration.py
+++ b/tests/test_orchestration.py
@@ -1717,7 +1717,14 @@ class TestWorkflowSnapshot:
         binding constraint."""
         from src.host.orchestration import MAX_WORKFLOW_CHAIN_DEPTH
         assert MAX_WORKFLOW_CHAIN_DEPTH == 200
-        t = _make_store(tmp_path)
+        # Disable the H5 creation-time chain cap here: this test
+        # deliberately builds a 250-deep chain to exercise the SEPARATE
+        # workflow_snapshot CTE depth bound (200). The H5 guard
+        # (default 25) is about runaway creation, not snapshot recursion.
+        t = Tasks(
+            db_path=str(tmp_path / "tasks.db"),
+            max_chain_depth=0, max_pending_per_agent=0,
+        )
         # Build a linear 250-stage chain. Each new task points to the
         # previous one as parent.
         root = t.create(
@@ -2343,3 +2350,115 @@ def test_workflow_snapshot_terminal_flag_unaffected_by_rework_descendant(
     )
     # The rework itself is pending — flag is False (not 'done').
     assert by_id[rework["id"]]["terminal_without_children"] is False
+
+
+# ── H5 resource caps: pending backlog + parent-chain depth/cycle ──────
+
+
+def test_pending_cap_rejects_past_limit_but_allows_normal_volume(tmp_path):
+    """Per-assignee pending cap blocks creation past the cap, while
+    normal volume (well under) is unaffected. Counts only pending."""
+    from src.host.orchestration import TaskLimitExceeded
+
+    t = Tasks(db_path=str(tmp_path / "tasks.db"), max_pending_per_agent=5)
+    # Five pending tasks — all fine.
+    for i in range(5):
+        t.create(creator="op", assignee="worker", title=f"t{i}")
+    assert t.count_pending_for_assignee("worker") == 5
+    # Sixth trips the cap.
+    with pytest.raises(TaskLimitExceeded):
+        t.create(creator="op", assignee="worker", title="overflow")
+
+
+def test_pending_cap_excludes_in_flight_and_terminal(tmp_path):
+    """Only ``pending`` counts — moving tasks to working/done frees
+    headroom so a busy agent is never blocked from new handoffs."""
+    from src.host.orchestration import TaskLimitExceeded
+
+    t = Tasks(db_path=str(tmp_path / "tasks.db"), max_pending_per_agent=2)
+    a = t.create(creator="op", assignee="worker", title="a")
+    t.create(creator="op", assignee="worker", title="b")
+    # At cap now.
+    with pytest.raises(TaskLimitExceeded):
+        t.create(creator="op", assignee="worker", title="c")
+    # Move one to working → no longer pending → headroom returns.
+    t.update_status(a["id"], "working", actor="worker")
+    assert t.count_pending_for_assignee("worker") == 1
+    t.create(creator="op", assignee="worker", title="c")  # now allowed
+
+
+def test_pending_cap_disabled_when_zero(tmp_path):
+    t = Tasks(db_path=str(tmp_path / "tasks.db"), max_pending_per_agent=0)
+    for i in range(50):
+        t.create(creator="op", assignee="worker", title=f"t{i}")
+    assert t.count_pending_for_assignee("worker") == 50
+
+
+def test_fan_out_dag_is_allowed(tmp_path):
+    """Many sibling subtasks under ONE parent (wide fan-out) is a legit
+    DAG and must NOT be rejected by the chain-depth guard."""
+    t = Tasks(db_path=str(tmp_path / "tasks.db"), max_chain_depth=5)
+    root = t.create(creator="op", assignee="lead", title="root")
+    # 30 direct children of the same root — depth is only 2.
+    for i in range(30):
+        t.create(
+            creator="lead", assignee="worker", title=f"sub{i}",
+            parent_task_id=root["id"],
+        )
+    # No exception — fan-out is unbounded.
+
+
+def test_chain_depth_guard_rejects_deep_chain(tmp_path):
+    """A long parent CHAIN (each task parents the next) is rejected once
+    it exceeds the depth cap."""
+    from src.host.orchestration import TaskLimitExceeded
+
+    t = Tasks(db_path=str(tmp_path / "tasks.db"), max_chain_depth=4)
+    parent = None
+    created = 0
+    with pytest.raises(TaskLimitExceeded):
+        for i in range(20):
+            rec = t.create(
+                creator="op", assignee="worker", title=f"chain{i}",
+                parent_task_id=parent,
+            )
+            parent = rec["id"]
+            created += 1
+    # Some links succeeded before the cap fired — depth-bounded, not zero.
+    assert 0 < created <= 5
+
+
+def test_chain_within_cap_is_allowed(tmp_path):
+    t = Tasks(db_path=str(tmp_path / "tasks.db"), max_chain_depth=10)
+    parent = None
+    for i in range(8):
+        rec = t.create(
+            creator="op", assignee="worker", title=f"chain{i}",
+            parent_task_id=parent,
+        )
+        parent = rec["id"]
+    # 8-deep chain under a cap of 10 — fine.
+
+
+def test_self_parent_cycle_rejected(tmp_path):
+    """A task naming itself as parent is a self-cycle — rejected
+    regardless of depth cap."""
+    from src.host.orchestration import TaskLimitExceeded
+
+    t = Tasks(db_path=str(tmp_path / "tasks.db"))
+    with pytest.raises(TaskLimitExceeded):
+        t.create(
+            creator="op", assignee="worker", title="self",
+            parent_task_id="task_fixedid", task_id="task_fixedid",
+        )
+
+
+def test_unknown_parent_allowed(tmp_path):
+    """A dangling parent reference (parent doesn't exist) is allowed —
+    the chain walk stops, it's a separate concern from the depth guard."""
+    t = Tasks(db_path=str(tmp_path / "tasks.db"), max_chain_depth=5)
+    rec = t.create(
+        creator="op", assignee="worker", title="orphan",
+        parent_task_id="task_doesnotexist",
+    )
+    assert rec["parent_task_id"] == "task_doesnotexist"

--- a/tests/test_orchestration_endpoints.py
+++ b/tests/test_orchestration_endpoints.py
@@ -1173,3 +1173,64 @@ async def test_outcome_endpoint_non_terminal_returns_409(v2_app):
             headers={"X-Agent-ID": "operator"},
         )
         assert r.status_code == 409
+
+
+# ── H5: endpoint-level caps ───────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_create_task_pending_cap_returns_400(tmp_path, monkeypatch):
+    """Past the per-assignee pending cap, ``POST /mesh/tasks`` returns
+    400 (resource cap) — normal volume under the cap succeeds."""
+    monkeypatch.setenv("OPENLEGION_MAX_PENDING_TASKS_PER_AGENT", "3")
+    server_module = _reload_server(monkeypatch, tasks_db=str(tmp_path / "tasks.db"))
+    perms_map = {
+        "alpha": {"can_message": ["*"]},
+        "bravo": {"can_message": ["*"]},
+    }
+    app, bb = _build_app(
+        tmp_path, server_module, perms_map=perms_map,
+        agents={"alpha": "http://alpha:8400", "bravo": "http://bravo:8400"},
+    )
+    try:
+        async with AsyncClient(
+            transport=ASGITransport(app=app), base_url="http://t",
+        ) as c:
+            # 3 pending tasks for bravo — all allowed.
+            for i in range(3):
+                r = await c.post(
+                    "/mesh/tasks",
+                    json={"assignee": "bravo", "title": f"t{i}"},
+                    headers={"X-Agent-ID": "alpha"},
+                )
+                assert r.status_code == 200, r.text
+            # 4th over the cap → 400.
+            r = await c.post(
+                "/mesh/tasks",
+                json={"assignee": "bravo", "title": "overflow"},
+                headers={"X-Agent-ID": "alpha"},
+            )
+            assert r.status_code == 400, r.text
+            assert "pending" in r.json().get("detail", "").lower()
+    finally:
+        bb.close()
+        monkeypatch.delenv("OPENLEGION_ORCHESTRATION_TASKS_DB", raising=False)
+        monkeypatch.delenv("OPENLEGION_MAX_PENDING_TASKS_PER_AGENT", raising=False)
+        importlib.reload(server_module)
+
+
+@pytest.mark.asyncio
+async def test_create_task_rate_limit_allows_normal_volume(v2_app):
+    """The task_create rate bucket is generous (~300/min) — a normal
+    burst of a dozen creates never trips it."""
+    app, _, _ = v2_app
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://t",
+    ) as c:
+        for i in range(12):
+            r = await c.post(
+                "/mesh/tasks",
+                json={"assignee": "analyst", "title": f"burst{i}"},
+                headers={"X-Agent-ID": "scout"},
+            )
+            assert r.status_code == 200, r.text


### PR DESCRIPTION
## May 2026 security remediation — H5 / H7 / M15

Additive resource caps with **generous defaults**. Per the prime directive, no legitimate workload is rejected — the bounds only catch genuinely runaway loops, parent-chain cycles, and concurrent overshoot races. May require a rebase against any in-flight orchestration/server refactor.

### H5 — bound task creation
- New `task_create` rate bucket (~300/min per caller) on `POST /mesh/tasks`.
- **Per-assignee PENDING-task cap**: counts only `pending` status (NOT in-flight `working`/`blocked`/`accepted`, NOT terminal). Default **200** via `OPENLEGION_MAX_PENDING_TASKS_PER_AGENT` (`<=0` disables). Over-cap → HTTP 400. A busy agent is never blocked from receiving the next handoff.
- **`parent_task_id` chain DEPTH guard**: default **25** via `OPENLEGION_MAX_TASK_CHAIN_DEPTH`, plus self-parent / cycle rejection. Walks UP the parent chain only — **wide fan-out DAGs (dozens of sibling subtasks under one parent) are unaffected**; only deep CHAINS / cycles are rejected.
- Enforced at the single `Tasks.create` choke-point so every path (mesh endpoint, `hand_off`, migrations) is bounded identically. New `TaskLimitExceeded` → HTTP 400; counted under a new `limit` denial category.

### H7 — bound lane queues
- `asyncio.Queue(maxsize=N)`, default **100** via `OPENLEGION_LANE_QUEUE_MAX` (`<=0` = unbounded). Followup enqueue uses `put_nowait` → raises `LaneQueueFull` (never silently drops or blocks forever).
- New `wake` rate category (~3000/min) so wake/handoff throttling is independent of `blackboard_write`'s broad ceiling.
- `/mesh/wake` pre-flight `lane_full(target)` check → **429 backpressure** (the real enqueue runs cross-thread fire-and-forget, so a `QueueFull` raised there can't propagate back). Defensive `getattr` so test lane stubs are unaffected.
- Steer-mode cap (`_STEER_WAKEUP_MAX`) left untouched per scope.

### M15 — concurrent-create races
- Shared app-scoped `_creation_lock` makes count-check→create atomic across `create_custom_agent` / `apply_fleet_template` / `mesh_create_team`, so two concurrent creates can't both pass the cap and overshoot `MAX_AGENTS` / `MAX_TEAMS`. The count **unions the live router registry with on-disk config** so the guard sees agents a concurrent path wrote but hasn't registered yet.
- Added the missing `_check_rate_limit("spawn", ...)` to `apply_fleet_template`.

### Defaults chosen (all generous)
| Cap | Default | Env |
|---|---|---|
| Pending tasks / assignee | 200 | `OPENLEGION_MAX_PENDING_TASKS_PER_AGENT` |
| Parent-chain depth | 25 | `OPENLEGION_MAX_TASK_CHAIN_DEPTH` |
| Lane queue depth | 100 | `OPENLEGION_LANE_QUEUE_MAX` |
| task_create rate | 300/60s | (rate bucket) |
| wake rate | 3000/60s | (rate bucket) |

### Tests
New tests cover: pending-cap + rate-limit reject past limit but allow normal volume; chain depth/cycle guard rejects deep/cyclic chains but allows wide fan-out; lane `QueueFull` → backpressure; concurrent creates don't exceed `MAX_AGENTS`. The pre-existing 250-deep workflow-snapshot recursion test opts out of the H5 caps explicitly (it tests a separate CTE bound).

`pytest` (805 tests across the affected suites) green; `ruff` clean.