### PR TITLE
fix(mcp): sanitize and cap tool metadata, add startup timeout

### DIFF
--- a/src/agent/mcp_client.py
+++ b/src/agent/mcp_client.py
@@ -11,9 +11,55 @@ import asyncio
 from contextlib import AsyncExitStack
 from typing import Any
 
-from src.shared.utils import setup_logging
+from src.shared.utils import sanitize_for_prompt, setup_logging
 
 logger = setup_logging("agent.mcp")
+
+# M12: a malicious or rug-pulled MCP server can advertise an enormous tool
+# description to bloat the LLM context window (a cheap DoS / cost amplifier).
+# sanitize_for_prompt strips invisible/control chars (hygiene, lossless for
+# normal text); this cap is the real DoS control. Generous so legitimate,
+# verbose descriptions are unaffected.
+_MCP_DESCRIPTION_MAX_BYTES = 8 * 1024  # 8 KiB
+
+# L17: a hung MCP server (one that accepts the stdio connection but never
+# completes initialize/list_tools) must not block agent boot indefinitely.
+# Servers start sequentially, so one hang stalls every later server. 30s is
+# generous for legitimate slow-but-working servers.
+_MCP_STARTUP_TIMEOUT_SECONDS = 30
+
+
+def _cap_description(description: str) -> str:
+    """Length-cap a tool description by UTF-8 byte budget (M12).
+
+    Truncates on a byte budget (not char count) since the bloat threat is
+    context-window bytes. Appends a visible truncation marker so the LLM
+    isn't silently handed a half-sentence.
+    """
+    encoded = description.encode("utf-8")
+    if len(encoded) <= _MCP_DESCRIPTION_MAX_BYTES:
+        return description
+    marker = "… [truncated]"
+    budget = _MCP_DESCRIPTION_MAX_BYTES - len(marker.encode("utf-8"))
+    truncated = encoded[:budget].decode("utf-8", errors="ignore")
+    return truncated + marker
+
+
+def _sanitize_schema_strings(node: Any) -> Any:
+    """Recursively sanitize STRING VALUES in a JSON-Schema-like structure (M12).
+
+    Only string *values* are passed through sanitize_for_prompt (descriptions,
+    titles, enum strings, etc.). Keys and structure are left untouched —
+    mutating schema keys would break MCP tool-calling. Returns a new structure;
+    the input is not modified in place.
+    """
+    if isinstance(node, str):
+        return sanitize_for_prompt(node)
+    if isinstance(node, dict):
+        return {key: _sanitize_schema_strings(value) for key, value in node.items()}
+    if isinstance(node, list):
+        return [_sanitize_schema_strings(item) for item in node]
+    return node
 
 # Lazy imports — mcp SDK is only installed in agent containers.
 # These get populated on first use in start() and can be patched in tests.
@@ -83,16 +129,26 @@ class MCPClient:
                     env=server_cfg.get("env"),
                 )
 
-                transport = await self._exit_stack.enter_async_context(
-                    stdio_client(params)
-                )
-                read_stream, write_stream = transport
-                session = await self._exit_stack.enter_async_context(
-                    ClientSession(read_stream, write_stream)
-                )
-                await session.initialize()
+                # L17: bound the entire startup handshake. A hung server that
+                # never completes initialize()/list_tools() would otherwise
+                # block boot forever (servers start sequentially). On timeout
+                # this raises TimeoutError into the except below, which marks
+                # the server failed and continues to the next one.
+                async def _start_server() -> Any:
+                    transport = await self._exit_stack.enter_async_context(
+                        stdio_client(params)
+                    )
+                    read_stream, write_stream = transport
+                    session = await self._exit_stack.enter_async_context(
+                        ClientSession(read_stream, write_stream)
+                    )
+                    await session.initialize()
+                    return session, await session.list_tools()
 
-                tools_result = await session.list_tools()
+                session, tools_result = await asyncio.wait_for(
+                    _start_server(),
+                    timeout=_MCP_STARTUP_TIMEOUT_SECONDS,
+                )
                 self._sessions[name] = session
 
                 for tool in tools_result.tools:
@@ -105,11 +161,28 @@ class MCPClient:
                         )
                         tool_name = prefixed
 
-                    self._tool_to_server[tool_name] = name
-                    self._tool_schemas[tool_name] = {
-                        "name": tool_name,
-                        "description": tool.description or "",
-                        "parameters": tool.inputSchema or {"type": "object", "properties": {}},
+                    # M12: harden tool metadata before it reaches the LLM tool
+                    # payload. The name (post-prefix) and description are
+                    # sanitized (strip invisible/control chars) and the
+                    # description is length-capped (anti-bloat). The inputSchema
+                    # has its STRING VALUES sanitized recursively — keys and
+                    # structure are preserved so tool-calling is unaffected.
+                    # The sanitized name is the key the LLM sees and calls by,
+                    # so it must also be the routing key in both maps — keeping
+                    # call_tool() lookups consistent with the emitted payload.
+                    safe_name = sanitize_for_prompt(tool_name)
+                    safe_description = _cap_description(
+                        sanitize_for_prompt(tool.description or "")
+                    )
+                    safe_parameters = _sanitize_schema_strings(
+                        tool.inputSchema or {"type": "object", "properties": {}}
+                    )
+
+                    self._tool_to_server[safe_name] = name
+                    self._tool_schemas[safe_name] = {
+                        "name": safe_name,
+                        "description": safe_description,
+                        "parameters": safe_parameters,
                         "function": "mcp",
                         "_mcp_original_name": tool.name,
                     }

--- a/tests/test_mcp_client.py
+++ b/tests/test_mcp_client.py
@@ -1,5 +1,6 @@
 """Tests for MCP (Model Context Protocol) client integration."""
 
+import asyncio
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -267,6 +268,200 @@ class TestMCPClientServerFailure:
             ])
 
         assert client.has_tool("good_tool")
+
+
+class TestMCPMetadataHardening:
+    """M12: tool metadata from a (possibly malicious/rug-pulled) MCP server
+    is sanitized + length-capped before it can enter the LLM tool payload.
+    sanitize_for_prompt is lossless for normal text; the cap is the DoS
+    control. Schema string values are sanitized but keys/structure stay
+    intact so tool-calling is not broken.
+    """
+
+    @pytest.mark.asyncio
+    async def test_description_sanitized_and_length_capped(self):
+        from src.agent.mcp_client import _MCP_DESCRIPTION_MAX_BYTES
+
+        # Invisible/control chars (zero-width space U+200B, BOM U+FEFF) plus
+        # a description far larger than the cap.
+        poisoned = "Read​a﻿file " + ("A" * (_MCP_DESCRIPTION_MAX_BYTES + 5000))
+
+        client = MCPClient()
+        session = AsyncMock()
+        tools_result = MagicMock()
+        tools_result.tools = [_make_mock_tool("read_file", poisoned)]
+        session.initialize = AsyncMock()
+        session.list_tools = AsyncMock(return_value=tools_result)
+
+        p1, p2, p3 = _mcp_patches()
+        with p1, p2 as mock_stdio, p3 as mock_cs_cls:
+            _setup_mock_server(mock_stdio, mock_cs_cls, session)
+            await client.start([{"name": "fs", "command": "x"}])
+
+        desc = client.list_tools()[0]["description"]
+        # Invisible chars stripped (lossless for the legit text around them).
+        assert "​" not in desc
+        assert "﻿" not in desc
+        assert desc.startswith("Readafile ")
+        # Length-capped well under the original size.
+        assert len(desc.encode("utf-8")) <= _MCP_DESCRIPTION_MAX_BYTES
+        assert desc.endswith("… [truncated]")
+
+    @pytest.mark.asyncio
+    async def test_legit_description_unaffected(self):
+        """A normal description passes through unchanged (lossless)."""
+        client = MCPClient()
+        session = AsyncMock()
+        tools_result = MagicMock()
+        tools_result.tools = [
+            _make_mock_tool("read_file", "Read a file from disk and return contents."),
+        ]
+        session.initialize = AsyncMock()
+        session.list_tools = AsyncMock(return_value=tools_result)
+
+        p1, p2, p3 = _mcp_patches()
+        with p1, p2 as mock_stdio, p3 as mock_cs_cls:
+            _setup_mock_server(mock_stdio, mock_cs_cls, session)
+            await client.start([{"name": "fs", "command": "x"}])
+
+        assert (
+            client.list_tools()[0]["description"]
+            == "Read a file from disk and return contents."
+        )
+
+    @pytest.mark.asyncio
+    async def test_schema_string_values_sanitized_keys_and_structure_intact(self):
+        client = MCPClient()
+        session = AsyncMock()
+        tools_result = MagicMock()
+        tools_result.tools = [
+            _make_mock_tool(
+                "search",
+                "Search",
+                {
+                    "type": "object",
+                    "properties": {
+                        # Key contains a name; value description is poisoned.
+                        "query": {
+                            "type": "string",
+                            "description": "The​search query",
+                            "title": "Que﻿ry",
+                        },
+                        "limit": {"type": "integer", "description": "Max​results"},
+                    },
+                    "required": ["query"],
+                },
+            ),
+        ]
+        session.initialize = AsyncMock()
+        session.list_tools = AsyncMock(return_value=tools_result)
+
+        p1, p2, p3 = _mcp_patches()
+        with p1, p2 as mock_stdio, p3 as mock_cs_cls:
+            _setup_mock_server(mock_stdio, mock_cs_cls, session)
+            await client.start([{"name": "srv", "command": "x"}])
+
+        params = client.list_tools()[0]["parameters"]
+        props = params["properties"]
+        # Structure + keys preserved exactly.
+        assert params["type"] == "object"
+        assert params["required"] == ["query"]
+        assert set(props.keys()) == {"query", "limit"}
+        assert props["query"]["type"] == "string"
+        assert props["limit"]["type"] == "integer"
+        # String VALUES sanitized (invisible chars stripped).
+        assert props["query"]["description"] == "Thesearch query"
+        assert props["query"]["title"] == "Query"
+        assert props["limit"]["description"] == "Maxresults"
+
+    @pytest.mark.asyncio
+    async def test_invisible_char_in_tool_name_stripped_and_routable(self):
+        """A poisoned tool name is sanitized and the routing key matches the
+        emitted name, so call_tool() still resolves it.
+        """
+        client = MCPClient()
+        session = AsyncMock()
+        tools_result = MagicMock()
+        tools_result.tools = [_make_mock_tool("read​file", "Read")]
+        session.initialize = AsyncMock()
+        session.list_tools = AsyncMock(return_value=tools_result)
+
+        p1, p2, p3 = _mcp_patches()
+        with p1, p2 as mock_stdio, p3 as mock_cs_cls:
+            _setup_mock_server(mock_stdio, mock_cs_cls, session)
+            await client.start([{"name": "fs", "command": "x"}])
+
+        emitted_name = client.list_tools()[0]["name"]
+        assert emitted_name == "readfile"
+        assert client.has_tool("readfile")
+        assert not client.has_tool("read​file")
+
+
+class TestMCPStartupTimeout:
+    """L17: a hung MCP server (accepts the connection but never completes
+    the init/list_tools handshake) must time out and be marked failed so
+    agent boot proceeds instead of blocking forever.
+    """
+
+    @pytest.mark.asyncio
+    async def test_hung_server_times_out_and_boot_continues(self):
+        import src.agent.mcp_client as mcp_mod
+
+        # Drop the timeout so the test is fast; the production default is 30s.
+        with patch.object(mcp_mod, "_MCP_STARTUP_TIMEOUT_SECONDS", 0.05):
+            client = MCPClient()
+
+            async def _never_returns():
+                await asyncio.Event().wait()  # blocks forever
+
+            hung_session = AsyncMock()
+            hung_session.initialize = AsyncMock(side_effect=_never_returns)
+            hung_session.list_tools = AsyncMock(side_effect=_never_returns)
+
+            good_session = AsyncMock()
+            good_tools = MagicMock()
+            good_tools.tools = [_make_mock_tool("ok_tool")]
+            good_session.initialize = AsyncMock()
+            good_session.list_tools = AsyncMock(return_value=good_tools)
+
+            call_count = 0
+
+            def stdio_side_effect(params):
+                cm = AsyncMock()
+                cm.__aenter__ = AsyncMock(return_value=(MagicMock(), MagicMock()))
+                return cm
+
+            def session_side_effect(read, write):
+                nonlocal call_count
+                call_count += 1
+                cm = AsyncMock()
+                if call_count == 1:
+                    cm.__aenter__ = AsyncMock(return_value=hung_session)
+                else:
+                    cm.__aenter__ = AsyncMock(return_value=good_session)
+                return cm
+
+            p1 = patch("src.agent.mcp_client.StdioServerParameters", MagicMock())
+            p2 = patch(
+                "src.agent.mcp_client.stdio_client", side_effect=stdio_side_effect
+            )
+            p3 = patch(
+                "src.agent.mcp_client.ClientSession", side_effect=session_side_effect
+            )
+            with p1, p2, p3:
+                await client.start([
+                    {"name": "hung", "command": "x"},
+                    {"name": "good", "command": "y"},
+                ])
+
+        # The hung server timed out → marked failed, boot proceeded to the
+        # next server which started normally.
+        statuses = {s["name"]: s for s in client.list_server_statuses()}
+        assert statuses["hung"]["state"] == "failed"
+        assert statuses["hung"]["tools_count"] == 0
+        assert statuses["good"]["state"] == "running"
+        assert client.has_tool("ok_tool")
+        assert not client.has_tool("hung")
 
 
 class TestMCPClientLifecycle:


### PR DESCRIPTION
May 2026 remediation for findings **M12** and **L17** (MCP-integration hardening). Possible rebase if main has moved.

## M12 — tool-metadata poisoning + bloat
MCP tool metadata is attacker-controlled. A malicious or rug-pulled server can ship tool names/descriptions/`inputSchema` strings with invisible/control unicode (prompt injection) or an enormous description to bloat the LLM context window (a cheap cost/DoS amplifier).

At registration time in `MCPClient.start()`:
- tool name (post-prefix) and description → `sanitize_for_prompt`
- description byte-capped at **8 KiB** (`_MCP_DESCRIPTION_MAX_BYTES`) with a visible truncation marker
- `inputSchema` string **values** recursively sanitized; **keys and structure untouched** so tool-calling is unaffected
- sanitized name becomes the routing key so `call_tool()` lookups stay consistent with the emitted payload

`sanitize_for_prompt` is lossless hygiene for normal text; the **8 KiB cap is the real DoS control** and is generous enough that legitimate verbose descriptions pass through unchanged.

## L17 — boot-hang
A hung MCP server (accepts the stdio connection but never completes `initialize()`/`list_tools()`) previously blocked agent boot indefinitely — servers start sequentially, so one hang stalls all later ones. The startup handshake is now wrapped in `asyncio.wait_for(..., 30s)` (`_MCP_STARTUP_TIMEOUT_SECONDS`); on timeout it raises into the existing `except`, marking the server failed and continuing to the next. The **30s timeout is the real liveness control** and is generous for legitimate slow-but-working servers.

## Tests
`tests/test_mcp_client.py` — all 21 pass:
- poisoned/oversized description sanitized + byte-capped
- legit description passes through unchanged (lossless)
- schema string values sanitized, keys/structure intact
- poisoned tool name stripped yet still routable
- hung server times out → marked failed → boot proceeds to a healthy sibling

## Non-goals / safety
No change to legitimate tool descriptions (lossless + generous cap), slow-but-working servers (30s is generous), or tool-calling (schema keys/structure never mutated).