### PR TITLE
fix(proxy): pin LLM proxy calls to the agent's configured model

### DIFF
--- a/src/host/server.py
+++ b/src/host/server.py
@@ -976,6 +976,103 @@ def create_mesh_app(
             return _extract_verified_agent_id(request)
         return agent_id
 
+    def _agent_allowed_models(agent_id: str) -> set[str] | None:
+        """Resolve the set of LLM models an agent is authorized to request.
+
+        Finding H3 remediation: the LLM proxy gates only on
+        ``can_use_api("llm")``, but the agent fully controls
+        ``params["model"]``. Without a per-agent pin, a cheap-model agent
+        can route through ANY configured provider key (cost drain / key
+        abuse). ``is_model_compatible`` alone does NOT close this — it
+        permits the whole API-key catalog.
+
+        Source of truth is the agent's configured model in
+        ``config/settings.json`` (``agents.{id}.model``, falling back to
+        ``llm.default_model``) — the SAME value written on
+        ``create_agent`` / ``edit_agent`` and injected as the container's
+        ``LLM_MODEL`` env. Because models are config-fixed per agent today
+        (``loop.py`` never passes a ``model=`` override — it always sends
+        ``self.default_model``), the legitimate agent only ever requests
+        this one model, so the pin is non-breaking. The pin auto-updates
+        when the operator edits the model (edit-soft rewrites this same
+        config row).
+
+        An optional operator-settable ``allowed_models`` list on the
+        agent's config row widens the set (e.g. for an agent the operator
+        deliberately lets pick among a few models). The configured model
+        is always included.
+
+        Returns ``None`` (no pin / fail-open) when the config cannot be
+        read or the agent has no resolvable model — keeps test harnesses
+        and partial-config deployments working rather than 403-ing real
+        traffic on a missing file.
+        """
+        try:
+            from src.cli.config import _load_config
+            cfg = _load_config()
+        except Exception as e:  # pragma: no cover - defensive
+            logger.debug("model-pin: config load failed for %s: %s", agent_id, e)
+            return None
+        agents_cfg = cfg.get("agents", {}) or {}
+        acfg = agents_cfg.get(agent_id) or {}
+        default_model = (cfg.get("llm", {}) or {}).get(
+            "default_model", "openai/gpt-4o-mini",
+        )
+        allowed: set[str] = set()
+        configured = acfg.get("model") or default_model
+        if isinstance(configured, str) and configured:
+            allowed.add(configured)
+        extra = acfg.get("allowed_models")
+        if isinstance(extra, list):
+            allowed.update(m for m in extra if isinstance(m, str) and m)
+        return allowed or None
+
+    def _enforce_model_pin(agent_id: str, request: Request, api_request: APIProxyRequest) -> None:
+        """403 when an agent requests an LLM model it isn't pinned to.
+
+        Applied ONLY to the agent-REQUESTED model — never to a failover
+        substitute the mesh chooses internally (failover happens deeper in
+        ``credentials._call_llm_with_failover`` on the mesh's own model
+        chain, so legitimate failover is never 403'd here).
+
+        Operators bypass the pin (they manage the fleet). Also runs the
+        cheap ``is_model_compatible`` check so an incompatible requested
+        model is rejected at the proxy boundary before dispatch.
+        """
+        if api_request.service != "llm":
+            return
+        requested_model = ""
+        if isinstance(api_request.params, dict):
+            requested_model = api_request.params.get("model", "") or ""
+        if not requested_model:
+            return
+        if _caller_is_operator(agent_id, request):
+            return
+        allowed = _agent_allowed_models(agent_id)
+        if allowed is not None and requested_model not in allowed:
+            _record_denial(
+                "permission", caller=agent_id, target=requested_model,
+                gate="api:model_pin",
+            )
+            raise HTTPException(
+                403,
+                f"Agent {agent_id} is not authorized to use model "
+                f"'{requested_model}'. Allowed: {sorted(allowed)}.",
+            )
+        # Cheap interim compatibility gate (mirrors the call-time check the
+        # LLM proxy runs) — reject requested models with no usable
+        # credentials before dispatch.
+        if credential_vault is not None:
+            compatible, reason = credential_vault.is_model_compatible(requested_model)
+            if not compatible:
+                _record_denial(
+                    "permission", caller=agent_id, target=requested_model,
+                    gate="api:model_incompatible",
+                )
+                raise HTTPException(
+                    403, reason or f"Model '{requested_model}' is not compatible.",
+                )
+
     def _resolve_browser_target(
         caller_id: str, target_claim: object, request: Request,
     ) -> str:
@@ -1530,6 +1627,8 @@ def create_mesh_app(
                     gate="api:can_use_api",
                 )
                 raise HTTPException(403, f"Agent {agent_id} cannot access {api_request.service}")
+        # H3: pin the REQUESTED model to the agent's configured model(s).
+        _enforce_model_pin(agent_id, request, api_request)
         if credential_vault is None:
             return APIProxyResponse(success=False, error="No credential vault configured")
 
@@ -1631,6 +1730,8 @@ def create_mesh_app(
                     gate="api_stream:can_use_api",
                 )
                 raise HTTPException(403, f"Agent {agent_id} cannot access {api_request.service}")
+        # H3: pin the REQUESTED model to the agent's configured model(s).
+        _enforce_model_pin(agent_id, request, api_request)
         if credential_vault is None:
             raise HTTPException(503, "No credential vault configured")
 

--- a/src/host/server.py
+++ b/src/host/server.py
@@ -1041,6 +1041,14 @@ def create_mesh_app(
         """
         if api_request.service != "llm":
             return
+        # Embeddings use a fixed, cheap embedding model (e.g. text-embedding-3-
+        # small) distinct from the agent's chat model, and drive memory
+        # store/search every turn. The pin targets chat/completion cost + key
+        # abuse, so exempt the embed action — otherwise every memory write and
+        # vector search 403s. We exempt ONLY "embed" (never allowlist "chat"),
+        # so chat AND streaming-chat stay pinned.
+        if api_request.action == "embed":
+            return
         requested_model = ""
         if isinstance(api_request.params, dict):
             requested_model = api_request.params.get("model", "") or ""

--- a/tests/test_llm_model_pin.py
+++ b/tests/test_llm_model_pin.py
@@ -1,0 +1,275 @@
+"""Tests for the H3 LLM-proxy model pin.
+
+Finding H3: the LLM proxy gated only on ``can_use_api("llm")`` while the
+agent fully controlled ``params["model"]`` — so a cheap-model agent could
+route through ANY configured provider key (cost drain / key abuse). The
+fix pins the REQUESTED model to the agent's configured model (read from
+``config/settings.json`` — the same row written at create/edit time).
+
+Scoping that matters:
+  - The pin applies ONLY to the agent-REQUESTED model, never to a
+    failover substitute the mesh chooses internally — so legitimate
+    failover (where the vault returns a *different* ``model`` than asked)
+    is never 403'd.
+  - The pin auto-updates when the operator edits the agent's model
+    (edit rewrites the same config row ``_load_config`` reads).
+"""
+
+from __future__ import annotations
+
+import importlib
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from src.host.mesh import Blackboard, MessageRouter, PubSub
+from src.host.permissions import AgentPermissions, PermissionMatrix
+from src.shared.types import APIProxyResponse
+
+
+def _reload_server():
+    import src.host.server as server_module
+    importlib.reload(server_module)
+    return server_module
+
+
+class _FakeVault:
+    """Minimal credential-vault stand-in for the proxy path.
+
+    ``execute_api_call`` echoes back whatever ``used_model`` it's told to
+    (so a test can simulate a failover substitution where the returned
+    model differs from the requested one). ``is_model_compatible`` is a
+    permissive allowlist so we test the *pin*, not compatibility.
+    """
+
+    def __init__(self, used_model: str | None = None, compatible: bool = True):
+        self._used_model = used_model
+        self._compatible = compatible
+        self.calls: list[dict] = []
+
+    async def execute_api_call(self, request, agent_id: str = ""):
+        requested = request.params.get("model", "")
+        self.calls.append({"agent_id": agent_id, "model": requested})
+        return APIProxyResponse(
+            success=True,
+            data={
+                "content": "ok",
+                "tokens_used": 1,
+                "input_tokens": 1,
+                "output_tokens": 0,
+                # Simulate the mesh's internal failover substituting a
+                # different model than the agent requested.
+                "model": self._used_model or requested,
+                "tool_calls": [],
+            },
+        )
+
+    def is_model_compatible(self, model: str):
+        if self._compatible:
+            return (True, None)
+        return (False, f"Model '{model}' is not compatible.")
+
+
+@pytest.fixture
+def pin_setup(tmp_path, monkeypatch):
+    monkeypatch.setenv("OPENLEGION_TEAM_SCOPE_MODE", "warn")
+    server = _reload_server()
+
+    bb = Blackboard(db_path=str(tmp_path / "bb.db"))
+    pubsub = PubSub()
+    perms = PermissionMatrix.__new__(PermissionMatrix)
+    perms.permissions = {
+        "operator": AgentPermissions(agent_id="operator"),
+        # Worker is granted can_use_api("llm") so the request reaches the
+        # pin gate (the pin is the surface under test, not can_use_api).
+        "writer": AgentPermissions(agent_id="writer", allowed_apis=["llm"]),
+    }
+    perms._config_path = str(tmp_path / "perms.json")
+
+    router = MessageRouter(permissions=perms, agent_registry={})
+    router.register_agent("operator", "http://operator:8400", [])
+    router.register_agent("writer", "http://writer:8400", [])
+
+    auth_tokens = {"operator": "operator-secret", "writer": "writer-secret"}
+
+    # The pin reads the agent's configured model from this config dict.
+    # Default: writer is pinned to the cheap model.
+    cfg_holder = {
+        "cfg": {
+            "llm": {"default_model": "openai/gpt-4o-mini"},
+            "agents": {"writer": {"model": "openai/gpt-4o-mini"}},
+        },
+    }
+    monkeypatch.setattr(
+        "src.cli.config._load_config", lambda *a, **k: cfg_holder["cfg"],
+    )
+
+    vault = _FakeVault()
+
+    app = server.create_mesh_app(
+        blackboard=bb,
+        pubsub=pubsub,
+        router=router,
+        permissions=perms,
+        credential_vault=vault,
+        auth_tokens=auth_tokens,
+    )
+
+    yield {
+        "app": app,
+        "vault": vault,
+        "cfg_holder": cfg_holder,
+        "tokens": auth_tokens,
+    }
+
+    bb.close()
+    monkeypatch.delenv("OPENLEGION_TEAM_SCOPE_MODE", raising=False)
+    _reload_server()
+
+
+def _hdr(token: str) -> dict:
+    return {"authorization": f"Bearer {token}"}
+
+
+def _req(model: str) -> dict:
+    return {
+        "service": "llm",
+        "action": "chat",
+        "params": {
+            "model": model,
+            "messages": [{"role": "user", "content": "hi"}],
+            "max_tokens": 16,
+        },
+        "timeout": 30,
+    }
+
+
+async def _post(app, body, token, agent_id):
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        return await client.post(
+            "/mesh/api",
+            json=body,
+            params={"agent_id": agent_id},
+            headers=_hdr(token),
+        )
+
+
+# (1) Different provider/model than configured → 403
+@pytest.mark.asyncio
+async def test_requesting_other_model_is_403(pin_setup):
+    app = pin_setup["app"]
+    resp = await _post(
+        app, _req("anthropic/claude-opus-4"), "writer-secret", "writer",
+    )
+    assert resp.status_code == 403, resp.text
+    assert "not authorized to use model" in resp.text
+    # Never reached the vault.
+    assert pin_setup["vault"].calls == []
+
+
+# (2) The agent's own configured model → allowed
+@pytest.mark.asyncio
+async def test_requesting_configured_model_allowed(pin_setup):
+    app = pin_setup["app"]
+    resp = await _post(
+        app, _req("openai/gpt-4o-mini"), "writer-secret", "writer",
+    )
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["success"] is True
+    assert pin_setup["vault"].calls[-1]["model"] == "openai/gpt-4o-mini"
+
+
+# (3) Editing the agent's model updates the pin (config row is the source
+#     of truth — the pin reads it live, so a swap flips which model passes)
+@pytest.mark.asyncio
+async def test_edit_updates_the_pin(pin_setup):
+    app = pin_setup["app"]
+    # Before edit: opus is rejected.
+    resp = await _post(
+        app, _req("anthropic/claude-opus-4"), "writer-secret", "writer",
+    )
+    assert resp.status_code == 403
+
+    # Operator "edits" the model — same effect as edit-soft rewriting the
+    # config row that _load_config returns.
+    pin_setup["cfg_holder"]["cfg"]["agents"]["writer"]["model"] = (
+        "anthropic/claude-opus-4"
+    )
+
+    # After edit: opus is now allowed, old cheap model is rejected.
+    resp = await _post(
+        app, _req("anthropic/claude-opus-4"), "writer-secret", "writer",
+    )
+    assert resp.status_code == 200, resp.text
+
+    resp = await _post(
+        app, _req("openai/gpt-4o-mini"), "writer-secret", "writer",
+    )
+    assert resp.status_code == 403
+
+
+# (4) Internal failover still works: the agent requests its configured
+#     model, the vault substitutes a *different* model internally — the
+#     pin must NOT 403 the substitute (it only gates the requested model).
+@pytest.mark.asyncio
+async def test_failover_substitute_not_blocked(pin_setup):
+    app = pin_setup["app"]
+    # Vault returns a different model than requested (failover happened
+    # deep inside _call_llm_with_failover).
+    pin_setup["vault"]._used_model = "anthropic/claude-sonnet-4"
+    resp = await _post(
+        app, _req("openai/gpt-4o-mini"), "writer-secret", "writer",
+    )
+    assert resp.status_code == 200, resp.text
+    data = resp.json()
+    assert data["success"] is True
+    # The response carries the failover substitute, and it was NOT 403'd.
+    assert data["data"]["model"] == "anthropic/claude-sonnet-4"
+
+
+# Operator bypasses the pin (manages the fleet).
+@pytest.mark.asyncio
+async def test_operator_bypasses_pin(pin_setup):
+    app = pin_setup["app"]
+    resp = await _post(
+        app, _req("anthropic/claude-opus-4"), "operator-secret", "operator",
+    )
+    assert resp.status_code == 200, resp.text
+
+
+# allowed_models widens the pin without changing the configured model.
+@pytest.mark.asyncio
+async def test_allowed_models_widens_pin(pin_setup):
+    app = pin_setup["app"]
+    pin_setup["cfg_holder"]["cfg"]["agents"]["writer"]["allowed_models"] = [
+        "anthropic/claude-opus-4",
+    ]
+    # Configured model still works.
+    resp = await _post(
+        app, _req("openai/gpt-4o-mini"), "writer-secret", "writer",
+    )
+    assert resp.status_code == 200, resp.text
+    # The extra allowed model also works.
+    resp = await _post(
+        app, _req("anthropic/claude-opus-4"), "writer-secret", "writer",
+    )
+    assert resp.status_code == 200, resp.text
+    # An un-listed model is still rejected.
+    resp = await _post(
+        app, _req("openai/gpt-4-turbo"), "writer-secret", "writer",
+    )
+    assert resp.status_code == 403
+
+
+# Incompatible requested model rejected at the proxy boundary (interim
+# is_model_compatible gate) even when it IS the configured/pinned model.
+@pytest.mark.asyncio
+async def test_incompatible_requested_model_rejected(pin_setup):
+    app = pin_setup["app"]
+    pin_setup["vault"]._compatible = False
+    resp = await _post(
+        app, _req("openai/gpt-4o-mini"), "writer-secret", "writer",
+    )
+    assert resp.status_code == 403, resp.text
+    assert "not compatible" in resp.text

--- a/tests/test_llm_model_pin.py
+++ b/tests/test_llm_model_pin.py
@@ -273,3 +273,45 @@ async def test_incompatible_requested_model_rejected(pin_setup):
     )
     assert resp.status_code == 403, resp.text
     assert "not compatible" in resp.text
+
+
+def _embed_req(model: str) -> dict:
+    return {
+        "service": "llm",
+        "action": "embed",
+        "params": {
+            "model": model,
+            "input": "some text to embed",
+        },
+        "timeout": 30,
+    }
+
+
+# Embedding calls use a fixed embedding model distinct from the agent's chat
+# model, so the chat-model pin MUST NOT 403 them — otherwise every memory
+# write and vector search breaks. The pin is gated on action != "embed".
+@pytest.mark.asyncio
+async def test_embed_off_allowlist_model_not_blocked(pin_setup):
+    app = pin_setup["app"]
+    # text-embedding-3-small is NOT in writer's allowed set (writer is pinned
+    # to openai/gpt-4o-mini) — but as an embed action it must pass the pin and
+    # reach dispatch, not 403.
+    resp = await _post(
+        app, _embed_req("text-embedding-3-small"), "writer-secret", "writer",
+    )
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["success"] is True
+    # It reached the vault (the pin did not short-circuit it).
+    assert pin_setup["vault"].calls[-1]["model"] == "text-embedding-3-small"
+
+
+# The pin still works for chat with that SAME off-allowlist model — embed is
+# the only exempt action, chat/streaming-chat stay pinned.
+@pytest.mark.asyncio
+async def test_chat_same_off_allowlist_model_still_403(pin_setup):
+    app = pin_setup["app"]
+    resp = await _post(
+        app, _req("text-embedding-3-small"), "writer-secret", "writer",
+    )
+    assert resp.status_code == 403, resp.text
+    assert "not authorized to use model" in resp.text


### PR DESCRIPTION
## H3 remediation (May 2026)

**Finding H3:** the LLM proxy (`POST /mesh/api`, `POST /mesh/api/stream`) gated only on `can_use_api("llm")`, but the agent fully controls `params["model"]`. With only that gate, a cheap-model agent can route through **any** configured provider key — a cost-drain / key-abuse vector. Re-running `is_model_compatible` alone does **not** close this: it permits the entire API-key catalog. The real fix is a per-agent model pin.

## Why this is non-breaking

Models are config-fixed per agent today. `src/agent/loop.py` never passes a `model=` override at any of its 8 `self.llm.chat` / `chat_stream` call sites — it always sends `self.default_model`, sourced from the container's `LLM_MODEL` env (= the agent's configured model). So a legitimate agent only ever requests the single model it's pinned to.

## The pin

- Reads the agent's configured model from live config (`agents.{id}.model`, falling back to `llm.default_model`) — the same row written at create/edit time and injected as `LLM_MODEL`.
- Because it reads live config, the pin **auto-updates on edit** (edit-soft rewrites that row). No new operator input.
- Optional operator-set `allowed_models` list widens the set; the configured model is always included.
- Operators bypass the pin (they manage the fleet).

## Requested-not-failover scoping

The pin applies to the agent-**REQUESTED** model ONLY, never to a failover substitute the mesh chooses internally. Failover happens deeper in `credentials._call_llm_with_failover` on the mesh's own model chain, so legitimate failover (vault returns a different model than requested) is never 403'd. The interim `is_model_compatible` check also runs in the proxy to reject incompatible requested models before dispatch. Fails open when config can't be read (test / partial-config safety).

## Tests (`tests/test_llm_model_pin.py`)

1. Agent requesting a different provider/model than configured → 403 (vault never touched).
2. Agent's own configured model → allowed.
3. Editing the agent's model updates the pin (old model now 403, new model allowed).
4. Internal failover substitute is NOT 403'd.
5. Operator bypass.
6. `allowed_models` widens the pin.
7. Incompatible requested model rejected at the proxy boundary.

All 7 pass; adjacent suites green (`test_operator_trust_tier`, `test_credentials`, `test_llm`, `test_mesh`, `test_integration`, `test_create_agent_model_validation` — 575 passed total). ruff clean.

> May 2026 remediation for H3. May require a rebase. Do **not** merge until CI is green.