### PR TITLE
fix(browser): harden VNC proxy path handling and add browser SSRF parity

### DIFF
--- a/src/browser/service.py
+++ b/src/browser/service.py
@@ -12,6 +12,7 @@ import asyncio
 import base64
 import contextlib
 import inspect
+import ipaddress
 import json
 import math
 import mimetypes
@@ -19,6 +20,7 @@ import os
 import random
 import re
 import signal
+import socket
 import subprocess
 import time
 import uuid
@@ -1495,6 +1497,102 @@ _BLOCKED_URL_SCHEMES = frozenset({
 })
 _ALLOWED_URL_SCHEMES = frozenset({"http", "https"})
 
+# SSRF blocklist (M21 — browser SSRF parity). Mirrors the agent-side
+# ``http_tool._is_blocked_ip`` logic so navigate/open_tab refuse to
+# reach private/loopback/metadata ranges even if the container iptables
+# egress filter is missing or misconfigured. This is a second, defence-
+# in-depth layer — it MUST only block private/metadata IPs, never
+# legitimate public navigation.
+_BROWSER_CGNAT_NETWORK = ipaddress.IPv4Network("100.64.0.0/10")
+
+
+def _browser_ip_is_blocked(
+    ip: ipaddress.IPv4Address | ipaddress.IPv6Address,
+) -> bool:
+    """Return True if ``ip`` is in a range that should be blocked for SSRF.
+
+    Covers RFC1918 private, loopback, link-local (incl. 169.254.169.254
+    cloud metadata), reserved, unspecified, multicast, and CGNAT, plus
+    the IPv4-mapped / 6to4 / Teredo embedded-IPv4 escape hatches.
+    """
+    if (ip.is_private or ip.is_loopback or ip.is_link_local
+            or ip.is_reserved or ip.is_unspecified or ip.is_multicast):
+        return True
+    if isinstance(ip, ipaddress.IPv4Address) and ip in _BROWSER_CGNAT_NETWORK:
+        return True
+    if isinstance(ip, ipaddress.IPv6Address) and ip.ipv4_mapped:
+        mapped = ip.ipv4_mapped
+        if (mapped.is_private or mapped.is_loopback or mapped.is_link_local
+                or mapped.is_reserved or mapped.is_unspecified
+                or mapped.is_multicast):
+            return True
+        if mapped in _BROWSER_CGNAT_NETWORK:
+            return True
+    if isinstance(ip, ipaddress.IPv6Address) and ip.sixtofour:
+        embedded = ip.sixtofour
+        if (embedded.is_private or embedded.is_loopback
+                or embedded.is_link_local or embedded.is_reserved
+                or embedded.is_unspecified or embedded.is_multicast):
+            return True
+        if embedded in _BROWSER_CGNAT_NETWORK:
+            return True
+    if isinstance(ip, ipaddress.IPv6Address) and ip.teredo:
+        _, teredo_client = ip.teredo
+        if (teredo_client.is_private or teredo_client.is_loopback
+                or teredo_client.is_link_local or teredo_client.is_reserved
+                or teredo_client.is_unspecified or teredo_client.is_multicast):
+            return True
+        if teredo_client in _BROWSER_CGNAT_NETWORK:
+            return True
+    return False
+
+
+def _browser_host_is_blocked(host: str) -> bool:
+    """Resolve ``host`` and return True if ANY resolved IP is blocked.
+
+    A literal IP host is checked directly. A DNS name is resolved and
+    every returned address is screened so a domain that resolves to a
+    private/metadata IP (DNS-based SSRF) is also rejected.
+
+    An empty host is blocked (host-less URLs were already rejected by the
+    callers, but this is belt-and-braces). Resolution *failure* fails
+    OPEN — a name that doesn't resolve can't reach anything, so we let
+    the browser engine surface the real network error (e.g.
+    ``ERR_NAME_NOT_RESOLVED``) rather than masking it. The security
+    property we care about — never reaching a private/metadata IP — is
+    only relevant when resolution succeeds, and that case IS screened.
+    The browser engine performs its own resolution at connect time; this
+    is a best-effort pre-flight, not a DNS pin.
+    """
+    if not host:
+        return True
+    # Strip IPv6 brackets if present (``[::1]`` → ``::1``).
+    candidate = host.strip()
+    if candidate.startswith("[") and candidate.endswith("]"):
+        candidate = candidate[1:-1]
+    # Literal IP — check directly, no DNS.
+    try:
+        ip = ipaddress.ip_address(candidate)
+        return _browser_ip_is_blocked(ip)
+    except ValueError:
+        pass
+    # Hostname — resolve all addresses and screen each. Fail open on a
+    # resolution error (see docstring).
+    try:
+        infos = socket.getaddrinfo(candidate, None)
+    except (socket.gaierror, UnicodeError, OSError):
+        return False
+    for info in infos:
+        addr = info[4][0]
+        # Drop any zone id (``fe80::1%eth0``) before parsing.
+        addr = addr.split("%", 1)[0]
+        try:
+            ip = ipaddress.ip_address(addr)
+        except ValueError:
+            continue
+        if _browser_ip_is_blocked(ip):
+            return True
+    return False
 
 
 _MAX_WAIT_MS = 10000  # 10 seconds max wait after navigation
@@ -3642,9 +3740,15 @@ class BrowserManager:
                 "-SecurityTypes", "None",
                 "-disableBasicAuth",
                 "-AlwaysShared",
-                "-interface", "0.0.0.0",
-                "-http-header", "X-Frame-Options=ALLOWALL",
-                "-http-header", "Access-Control-Allow-Origin=*",
+                # M6: bind to loopback only. The in-container proxy in
+                # src/browser/server.py reaches KasmVNC via
+                # ``http://127.0.0.1:{port}`` over loopback, so binding to
+                # 0.0.0.0 only added external reachability with no benefit.
+                "-interface", "127.0.0.1",
+                # L12: the viewer is always same-origin via the mesh proxy,
+                # so drop the wildcard CORS override and frame any origin.
+                # SAMEORIGIN still permits the dashboard's same-origin iframe.
+                "-http-header", "X-Frame-Options=SAMEORIGIN",
             ]
             xvnc = await loop.run_in_executor(
                 None, lambda: _spawn(xvnc_cmd, name="Xvnc"),
@@ -4938,6 +5042,14 @@ class BrowserManager:
             return {
                 "success": False,
                 "error": "URL missing host component",
+            }
+        # M21: SSRF parity — reject private/loopback/metadata/CGNAT hosts.
+        # Second defence layer independent of the container iptables egress
+        # filter. ``hostname`` strips port + userinfo; only public IPs pass.
+        if _browser_host_is_blocked(parsed.hostname or ""):
+            return {
+                "success": False,
+                "error": "URL host resolves to a blocked (private/loopback/metadata) address",
             }
         if wait_until not in _VALID_WAIT_UNTIL:
             valid = sorted(_VALID_WAIT_UNTIL)
@@ -10695,6 +10807,14 @@ class BrowserManager:
             return _err(
                 "invalid_input",
                 f"URL scheme '{parsed.scheme}' is not allowed",
+            )
+        if not parsed.netloc:
+            return _err("invalid_input", "URL missing host component")
+        # M21: SSRF parity — reject private/loopback/metadata/CGNAT hosts.
+        if _browser_host_is_blocked(parsed.hostname or ""):
+            return _err(
+                "invalid_input",
+                "URL host resolves to a blocked (private/loopback/metadata) address",
             )
 
         inst = await self.get_or_start(agent_id)

--- a/src/host/server.py
+++ b/src/host/server.py
@@ -74,6 +74,25 @@ def _websockets_headers_kw(connect, headers: dict[str, str]) -> dict:
     return {"extra_headers": headers}
 
 
+def _vnc_path_is_safe(agent_id: str, path: str) -> bool:
+    """H14: reject path-traversal on the per-agent VNC proxy.
+
+    Starlette has already percent-decoded ``{path:path}`` by the time it
+    reaches the handler, so a ``..%2f..%2f`` attempt arrives here as the
+    literal ``../../``. The noVNC client only ever requests relative
+    sub-paths (``index.html``, ``vendor/foo.js``, ``websockify``) — it
+    never uses ``..`` — so rejecting any ``..`` segment is safe for the
+    viewer. We also assert the constructed upstream path stays under the
+    agent's ``/agent-vnc/{agent_id}/`` prefix as a belt-and-braces check.
+    """
+    normalized = path.replace("\\", "/")
+    if any(seg == ".." for seg in normalized.split("/")):
+        return False
+    prefix = f"/agent-vnc/{agent_id}/"
+    constructed = f"/agent-vnc/{agent_id}/{path}"
+    return constructed.startswith(prefix)
+
+
 def _extract_prompt_preview(params: dict, max_len: int = 500) -> str:
     """Extract the last user message content as a short preview string."""
     for msg in reversed(params.get("messages", [])):
@@ -8631,6 +8650,8 @@ def create_mesh_app(
             raise HTTPException(401, auth_error)
         if not _AGENT_ID_RE.fullmatch(agent_id):
             raise HTTPException(404)
+        if not _vnc_path_is_safe(agent_id, path):
+            raise HTTPException(400, "Invalid VNC path")
         svc_url = getattr(container_manager, "browser_service_url", None)
         svc_token = getattr(container_manager, "browser_auth_token", "")
         if not svc_url:
@@ -8655,6 +8676,10 @@ def create_mesh_app(
         ct = resp.headers.get("content-type")
         if ct:
             headers["content-type"] = ct
+        # M17: never let the browser MIME-sniff proxied VNC assets. KasmVNC
+        # declares correct content-types, so nosniff is transparent to the
+        # viewer while closing the sniff-based content-confusion vector.
+        headers["x-content-type-options"] = "nosniff"
         return StreamingResponse(
             iter([resp.content]),
             status_code=resp.status_code,
@@ -8685,6 +8710,9 @@ def create_mesh_app(
                         return
         if not _AGENT_ID_RE.fullmatch(agent_id):
             await websocket.close(code=1008, reason="invalid agent_id")
+            return
+        if not _vnc_path_is_safe(agent_id, path):
+            await websocket.close(code=1008, reason="invalid VNC path")
             return
         svc_url = getattr(container_manager, "browser_service_url", None)
         svc_token = getattr(container_manager, "browser_auth_token", "")

--- a/tests/test_browser_service.py
+++ b/tests/test_browser_service.py
@@ -12013,3 +12013,91 @@ class TestSnapshotDiffSubsetShortCircuit:
         # ``scope`` is included to signal the caller that the diff was
         # not produced.
         assert result["data"].get("scope") == "navigation"
+
+
+class TestBrowserSsrfParity:
+    """M21: navigate/open_tab reject private/loopback/metadata hosts.
+
+    Second defence-in-depth SSRF layer independent of the container
+    iptables egress filter. Only private/metadata IPs are blocked —
+    legitimate PUBLIC navigation must still pass.
+    """
+
+    def test_block_helper_metadata_and_private(self):
+        from src.browser.service import _browser_host_is_blocked
+        # Cloud metadata endpoint (link-local).
+        assert _browser_host_is_blocked("169.254.169.254")
+        # RFC1918 private ranges.
+        assert _browser_host_is_blocked("10.0.0.5")
+        assert _browser_host_is_blocked("192.168.1.1")
+        assert _browser_host_is_blocked("172.16.0.1")
+        # Loopback.
+        assert _browser_host_is_blocked("127.0.0.1")
+        assert _browser_host_is_blocked("[::1]")
+        # CGNAT (RFC 6598).
+        assert _browser_host_is_blocked("100.64.0.1")
+        # IPv4-mapped IPv6 loopback escape hatch.
+        assert _browser_host_is_blocked("::ffff:127.0.0.1")
+        # Empty host fails closed.
+        assert _browser_host_is_blocked("")
+
+    def test_block_helper_allows_public_ip(self):
+        from src.browser.service import _browser_host_is_blocked
+        # Public literal IPs must NOT be blocked (no DNS needed).
+        assert not _browser_host_is_blocked("1.1.1.1")
+        assert not _browser_host_is_blocked("8.8.8.8")
+        assert not _browser_host_is_blocked("93.184.216.34")  # example.com
+
+    @pytest.mark.asyncio
+    async def test_navigate_rejects_metadata_ip(self):
+        mgr = BrowserManager(profiles_dir="/tmp/test_profiles")
+        # get_or_start should never be reached — assert by making it raise.
+        mgr.get_or_start = AsyncMock(
+            side_effect=AssertionError("get_or_start must not be called"),
+        )
+        result = await mgr.navigate("a1", "http://169.254.169.254/latest/meta-data/")
+        assert result["success"] is False
+        assert "blocked" in result["error"].lower()
+
+    @pytest.mark.asyncio
+    async def test_navigate_rejects_private_ip(self):
+        mgr = BrowserManager(profiles_dir="/tmp/test_profiles")
+        mgr.get_or_start = AsyncMock(
+            side_effect=AssertionError("get_or_start must not be called"),
+        )
+        result = await mgr.navigate("a1", "http://10.0.0.5/")
+        assert result["success"] is False
+        assert "blocked" in result["error"].lower()
+
+    @pytest.mark.asyncio
+    async def test_navigate_allows_public_url(self):
+        # A public host passes the SSRF gate and proceeds toward
+        # get_or_start (which we stub to short-circuit). The point is the
+        # SSRF guard does NOT reject a legitimate public URL.
+        mgr = BrowserManager(profiles_dir="/tmp/test_profiles")
+        sentinel = {"success": False, "error": "stub-reached-get_or_start"}
+
+        async def _boom(*a, **k):
+            raise _ReachedGetOrStart()
+
+        mgr.get_or_start = _boom
+        with pytest.raises(_ReachedGetOrStart):
+            await mgr.navigate("a1", "http://1.1.1.1/")
+        # If the SSRF gate had rejected the public URL, navigate would have
+        # returned before get_or_start and no exception would be raised.
+        _ = sentinel
+
+    @pytest.mark.asyncio
+    async def test_open_tab_rejects_metadata_ip(self):
+        mgr = BrowserManager(profiles_dir="/tmp/test_profiles")
+        mgr.get_or_start = AsyncMock(
+            side_effect=AssertionError("get_or_start must not be called"),
+        )
+        result = await mgr.open_tab("a1", "http://169.254.169.254/")
+        assert result["success"] is False
+        msg = result["error"]["message"] if isinstance(result["error"], dict) else result["error"]
+        assert "blocked" in msg.lower()
+
+
+class _ReachedGetOrStart(Exception):
+    """Marker — navigate passed the SSRF gate and reached get_or_start."""

--- a/tests/test_per_agent_vnc.py
+++ b/tests/test_per_agent_vnc.py
@@ -382,3 +382,34 @@ class TestBrowserStatusActiveAgents:
         body = resp.json()
         assert body.get("active_browsers", -1) == 0
         assert body.get("agents", "missing") == []
+
+
+class TestVncProxyPathTraversal:
+    """H14: the mesh-side VNC proxy must reject ``..`` path traversal.
+
+    Starlette percent-decodes ``{path:path}`` before the handler runs,
+    so a ``..%2f..%2f`` request arrives as the literal ``../../``. The
+    noVNC client never uses ``..`` (only relative sub-paths), so the
+    guard is transparent to the real viewer.
+    """
+
+    def test_traversal_segment_rejected(self):
+        from src.host.server import _vnc_path_is_safe
+        # ``..%2f..%2fetc%2fpasswd`` decodes to this:
+        assert not _vnc_path_is_safe("agent1", "../../etc/passwd")
+        assert not _vnc_path_is_safe("agent1", "vendor/../../secret")
+        assert not _vnc_path_is_safe("agent1", "..")
+        # Backslash-normalized traversal also rejected.
+        assert not _vnc_path_is_safe("agent1", "..\\..\\etc")
+
+    def test_normal_subpaths_pass(self):
+        from src.host.server import _vnc_path_is_safe
+        # Exactly the paths the noVNC client requests.
+        assert _vnc_path_is_safe("agent1", "index.html")
+        assert _vnc_path_is_safe("agent1", "vendor/pako/pako_inflate.js")
+        assert _vnc_path_is_safe("agent1", "app/ui.js")
+        assert _vnc_path_is_safe("agent1", "core/rfb.js")
+        assert _vnc_path_is_safe("agent1", "websockify")
+        assert _vnc_path_is_safe("agent1", "")
+        # A filename that merely contains dots (not a ``..`` segment) is fine.
+        assert _vnc_path_is_safe("agent1", "foo..bar.js")


### PR DESCRIPTION
May 2026 security remediation. Hardens the per-agent VNC reverse proxy and adds a defence-in-depth SSRF layer to the browser service. Does NOT change the noVNC viewer behaviour or block legitimate public navigation.

## Findings

**H14 — VNC proxy path traversal.** Both the HTTP (`vnc_http_proxy_per_agent`) and WS (`vnc_ws_proxy_per_agent`) handlers in `src/host/server.py` now reject any `..` segment in the Starlette-decoded `{path}` (HTTP 400 / WS close 1008) and assert the constructed upstream path stays under `/agent-vnc/{agent_id}/`. Logic lives in the new module-level `_vnc_path_is_safe`. The noVNC client only requests relative sub-paths (`index.html`, `vendor/*`, `app/ui.js`, `core/rfb.js`, `websockify`) so the viewer is unaffected.

**M17 — content-type sniffing.** The proxied VNC HTTP response now carries `X-Content-Type-Options: nosniff`. KasmVNC declares correct content-types, so nosniff is transparent to the viewer.

**M6 — KasmVNC bind.** Xvnc now binds `-interface 127.0.0.1` instead of `0.0.0.0`. The in-container proxy (`src/browser/server.py`) reaches KasmVNC over `http://127.0.0.1:{port}`, so this removes external reachability with no functional change.

**L12 — Xvnc headers.** Dropped the `Access-Control-Allow-Origin=*` override and changed `X-Frame-Options=ALLOWALL` to `SAMEORIGIN`. The viewer is always same-origin via the mesh proxy.

**M21 — browser SSRF parity.** `navigate`/`open_tab` in `src/browser/service.py` now resolve the target host and reject private/loopback/metadata/CGNAT IPs via a local mirror of the agent-side `http_tool._is_blocked_ip` blocklist (RFC1918, loopback, link-local incl. 169.254.169.254 metadata, reserved, multicast, CGNAT, plus IPv4-mapped/6to4/Teredo embedded-IPv4). A second SSRF layer independent of the container iptables egress filter. Resolution failure fails OPEN so legitimate public navigation and genuine DNS errors (`ERR_NAME_NOT_RESOLVED`) are unaffected.

## Tests

Added to `tests/test_per_agent_vnc.py` and `tests/test_browser_service.py`:
- `..%2f..%2f`-decoded traversal paths rejected; normal noVNC sub-paths pass.
- `navigate`/`open_tab` to `http://169.254.169.254/` and `http://10.0.0.5/` rejected; a public URL passes the SSRF gate.
- `_browser_host_is_blocked` unit coverage for metadata/private/loopback/CGNAT/IPv4-mapped vs public literals.

`python -m pytest tests/test_per_agent_vnc.py tests/test_browser_service.py` → 514 passed, 7 skipped. ruff clean.

Possible rebase needed.