### PR TITLE
fix(proxy): cap LLM input, redact token logs, harden credential classification and error/oracle leaks

### DIFF
--- a/src/host/credentials.py
+++ b/src/host/credentials.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 import asyncio
 import base64
 import contextlib
+import hashlib
 import json
 import os
 import re
@@ -282,6 +283,21 @@ def is_system_credential(name: str) -> bool:
             if prefix in get_known_provider_names():
                 return True
     return False
+
+
+def _masked_upstream_error(service: str, action: str, status_code: int, detail: str) -> str:
+    """L15: log full upstream detail, return a fixed non-revealing string.
+
+    Third-party provider error bodies can embed request URLs, internal
+    hostnames, echoed parameters, or partial credential material. Agents
+    are untrusted, so they receive only a generic message plus the HTTP
+    status; operators keep the full body in the mesh log.
+    """
+    logger.error(
+        "Upstream %s/%s call failed (HTTP %s): %s",
+        service, action, status_code, detail,
+    )
+    return f"Upstream {service} call failed (HTTP {status_code})."
 
 
 def _load_oauth_config(env_var: str, label: str) -> dict | None:
@@ -627,17 +643,23 @@ class CredentialVault:
                 response = await handler(request)
 
                 if self.cost_tracker and agent_id and response.success and response.data:
-                    if not response.data.get("oauth"):
-                        tokens_used = response.data.get("tokens_used", 0)
-                        if tokens_used:
-                            model = response.data.get(
-                                "model", request.params.get("model", "unknown"),
-                            )
-                            raw_pt = response.data.get("input_tokens")
-                            prompt_tokens = raw_pt if raw_pt else int(tokens_used * 0.7)
-                            raw_ct = response.data.get("output_tokens")
-                            completion_tokens = raw_ct if raw_ct else (tokens_used - prompt_tokens)
-                            self.cost_tracker.track(agent_id, model, prompt_tokens, completion_tokens)
+                    # M8: record usage even on the OAuth path. OAuth calls
+                    # carry no per-call dollar enforcement (``_needs_budget``
+                    # is False above, so no budget gate runs), but we still
+                    # TRACK the token spend so operators retain visibility
+                    # into OAuth consumption. Previously OAuth responses were
+                    # skipped entirely, leaving a blind spot. No $ semantics
+                    # are introduced — this is observability-only tracking.
+                    tokens_used = response.data.get("tokens_used", 0)
+                    if tokens_used:
+                        model = response.data.get(
+                            "model", request.params.get("model", "unknown"),
+                        )
+                        raw_pt = response.data.get("input_tokens")
+                        prompt_tokens = raw_pt if raw_pt else int(tokens_used * 0.7)
+                        raw_ct = response.data.get("output_tokens")
+                        completion_tokens = raw_ct if raw_ct else (tokens_used - prompt_tokens)
+                        self.cost_tracker.track(agent_id, model, prompt_tokens, completion_tokens)
 
                     fixed_cost = response.data.get("fixed_cost_usd")
                     if fixed_cost and fixed_cost > 0:
@@ -721,10 +743,29 @@ class CredentialVault:
                     },
                 )
             except Exception as e:
+                # L15: keep full detail in the operator-facing log, but
+                # return a fixed, non-revealing error to the agent so raw
+                # upstream provider exceptions (which may embed URLs,
+                # internal hostnames, or partial credentials) don't leak
+                # across the trust boundary. Typed envelopes above keep
+                # their structured detail; only this generic ``str(e)``
+                # leak is masked.
+                #
+                # The HTTP status code is preserved on the envelope AND
+                # echoed in the message text. The agent-side retry
+                # classifier (src/agent/llm.py:_raise_classified_error)
+                # backstops on numeric substrings ("429"/"503"), so keeping
+                # the bare status in the masked message preserves retry
+                # behaviour without leaking any provider-supplied text.
+                _status = getattr(e, "status_code", None)
                 logger.error(f"API call failed for {request.service}/{request.action}: {e}")
+                _masked = "Upstream service call failed."
+                if _status:
+                    _masked = f"Upstream service call failed (HTTP {_status})."
                 return APIProxyResponse(
-                    success=False, error=str(e),
-                    status_code=getattr(e, "status_code", None),
+                    success=False,
+                    error=_masked,
+                    status_code=_status,
                 )
 
         if lock is not None:
@@ -1314,7 +1355,15 @@ class CredentialVault:
 
         if last_error is not None:
             raise last_error
-        raise RuntimeError(f"No API key configured for model: {requested_model}")
+        # Typed config error (not a provider leak): missing credential is
+        # operator-actionable setup info that SHOULD reach the agent. Using
+        # ``LLMConfigError`` keeps it inside the typed-envelope path so L15's
+        # generic-exception masking doesn't swallow this safe message.
+        raise LLMConfigError(
+            f"No API key configured for model: {requested_model}",
+            provider=self._resolve_provider(requested_model),
+            model=requested_model,
+        )
 
     def get_model_health(self) -> list[dict]:
         """Return diagnostic model-health data."""
@@ -1810,10 +1859,11 @@ class CredentialVault:
         if "thinking" in body:
             sdk_kwargs["thinking"] = body["thinking"]
 
-        # Debug: log token info to diagnose deployed instance issues
-        token_preview = f"{api_key[:15]}...{api_key[-4:]}" if len(api_key) > 20 else "***"
+        # Debug: log a non-reversible token fingerprint to diagnose
+        # deployed instance issues without leaking token material (L1).
+        token_preview = hashlib.sha256(api_key.encode()).hexdigest()[:8]
         logger.info(
-            "OAuth stream: model=%s, token=%s, token_len=%d",
+            "OAuth stream: model=%s, token_fp=%s, token_len=%d",
             body["model"], token_preview, len(api_key),
         )
 
@@ -1912,7 +1962,7 @@ class CredentialVault:
             msg = "Auth failed"
             if hasattr(e, "body") and isinstance(e.body, dict):
                 msg = e.body.get("error", {}).get("message", msg)
-            logger.error("OAuth AuthenticationError: token=%s, msg=%s", token_preview, msg)
+            logger.error("OAuth AuthenticationError: token_fp=%s, msg=%s", token_preview, msg)
             err_msg = f"OAuth auth failed (token may have expired): {msg}"
             # Codex P2 r3: do NOT yield an untyped error frame before
             # raising — see ``_openai_oauth_chat_stream`` for the full
@@ -1931,7 +1981,7 @@ class CredentialVault:
             msg = f"Anthropic API error (HTTP {e.status_code})"
             if detail:
                 msg += f": {detail}"
-            logger.error("OAuth APIStatusError (%d): token=%s, detail=%s", e.status_code, token_preview, detail)
+            logger.error("OAuth APIStatusError (%d): token_fp=%s, detail=%s", e.status_code, token_preview, detail)
             # 403 → auth issue; 400 with model-related text → config issue.
             # Codex P2 r3: raise typed exceptions without yielding an
             # untyped frame first (would mask the typed error in the
@@ -2039,8 +2089,9 @@ class CredentialVault:
             raise RuntimeError("No Anthropic OAuth credentials configured")
 
         token = self._anthropic_oauth["access_token"]
-        token_preview = f"{token[:15]}...{token[-4:]}" if len(token) > 20 else "***"
-        logger.info("OAuth token resolved: %s (len=%d)", token_preview, len(token))
+        # L1: non-reversible fingerprint instead of a token slice.
+        token_preview = hashlib.sha256(token.encode()).hexdigest()[:8]
+        logger.info("OAuth token resolved: fp=%s (len=%d)", token_preview, len(token))
 
         now = int(time.time())
         expires_at = self._anthropic_oauth.get("expires_at", 0)
@@ -3149,7 +3200,9 @@ class CredentialVault:
             return APIProxyResponse(
                 success=response.is_success,
                 data=response.json() if response.is_success else None,
-                error=response.text if not response.is_success else None,
+                error=None if response.is_success else _masked_upstream_error(
+                    "apollo", request.action, response.status_code, response.text,
+                ),
                 status_code=response.status_code,
             )
 
@@ -3171,7 +3224,9 @@ class CredentialVault:
             return APIProxyResponse(
                 success=response.is_success,
                 data=response.json() if response.is_success else None,
-                error=response.text if not response.is_success else None,
+                error=None if response.is_success else _masked_upstream_error(
+                    "hunter", request.action, response.status_code, response.text,
+                ),
                 status_code=response.status_code,
             )
 
@@ -3193,7 +3248,9 @@ class CredentialVault:
         return APIProxyResponse(
             success=response.is_success,
             data=response.json() if response.is_success else None,
-            error=response.text if not response.is_success else None,
+            error=None if response.is_success else _masked_upstream_error(
+                "brave_search", request.action, response.status_code, response.text,
+            ),
             status_code=response.status_code,
         )
 
@@ -3296,8 +3353,9 @@ class CredentialVault:
             if not resp.is_success:
                 return APIProxyResponse(
                     success=False,
-                    error=f"Gemini API error {resp.status_code}: "
-                    f"{resp.text[:500]}",
+                    error=_masked_upstream_error(
+                        "gemini_image", "generate", resp.status_code, resp.text[:500],
+                    ),
                     status_code=resp.status_code,
                 )
 

--- a/src/host/permissions.py
+++ b/src/host/permissions.py
@@ -88,7 +88,24 @@ class PermissionMatrix:
     def __init__(self, config_path: str = "config/permissions.json"):
         self.permissions: dict[str, AgentPermissions] = {}
         self._config_path = config_path
+        # L10: names of credentials that loaded under the SYSTEM_* tier.
+        # Injected post-construction by the runtime via
+        # ``set_system_credential_names``. Blocks agent resolution of a
+        # system secret even when its name doesn't match the provider-key
+        # shape heuristic (``is_system_credential``).
+        self._system_credential_names: frozenset[str] = frozenset()
         self._load(config_path)
+
+    def set_system_credential_names(self, names) -> None:
+        """Register the names of credentials loaded under the system tier.
+
+        Lowercased + frozen. Called by the runtime once the credential
+        vault is built so ``can_access_credential`` can deny by LOADED
+        TIER, not just by name shape (L10).
+        """
+        self._system_credential_names = frozenset(
+            n.lower() for n in (names or [])
+        )
 
     def reload(self) -> None:
         """Reload permissions from disk (e.g. after adding an agent at runtime)."""
@@ -345,17 +362,25 @@ class PermissionMatrix:
         Returns False for system credentials (always).
         Uses fnmatch against allowed_credentials patterns.
 
-        Defense-in-depth: The ``is_system_credential()`` check here blocks
-        agent access to provider-key-shaped names regardless of which tier
-        they landed in.  The primary separation is at loading time
-        (``OPENLEGION_SYSTEM_`` → ``system_credentials``, ``OPENLEGION_CRED_``
-        → ``credentials``), and ``resolve_credential()`` only returns
-        agent-tier values.  This check catches edge cases where a
-        provider-key name might appear in the agent-tier dict (e.g. via
-        ``add_credential()`` without ``system=True``).
+        Defense-in-depth: TWO independent system-tier checks block agent
+        access regardless of the matched ``allowed_credentials`` patterns.
+
+        1. L10 — LOADED TIER: any name that loaded under ``OPENLEGION_SYSTEM_``
+           (registered via ``set_system_credential_names``) is denied even
+           if its name doesn't match the provider-key shape. Closes the gap
+           where a system secret with a non-conforming name
+           (e.g. ``my_internal_token``) would otherwise be agent-resolvable.
+        2. NAME SHAPE — ``is_system_credential()`` blocks provider-key-shaped
+           names (``<provider>_api_key`` / ``_api_base``) regardless of tier,
+           catching e.g. an ``add_credential()`` without ``system=True``.
+
+        The primary separation is still at loading time, and
+        ``resolve_credential()`` only returns agent-tier values.
         """
         if self._is_trusted(agent_id):
             return True
+        if credential_name.lower() in self._system_credential_names:
+            return False
         if is_system_credential(credential_name):
             return False
         perms = self.get_permissions(agent_id)

--- a/src/host/server.py
+++ b/src/host/server.py
@@ -235,6 +235,30 @@ def _extract_prompt_preview(params: dict, max_len: int = 500) -> str:
     return ""
 
 
+# M8: generous ceiling on the serialized LLM-proxy input. Large-context
+# prompts are legitimate, so this only trips on pathological / abusive
+# payloads (~4 MiB of serialized params). Overridable for operators with
+# unusually large legitimate contexts.
+_PROXY_INPUT_MAX_BYTES = int(
+    os.environ.get("OPENLEGION_PROXY_INPUT_MAX_BYTES", str(4 * 1024 * 1024))
+)
+
+
+def _proxy_input_too_large(params: dict) -> int | None:
+    """Return the serialized byte size if it exceeds the cap, else ``None``.
+
+    Serializes ``params`` (messages, tools, etc.) to measure the worst-case
+    request body the proxy would forward. Best-effort: if serialization
+    fails for any reason we do NOT block (fail-open on the size check —
+    downstream validation still applies).
+    """
+    try:
+        size = len(json.dumps(params, default=str).encode("utf-8"))
+    except Exception:
+        return None
+    return size if size > _PROXY_INPUT_MAX_BYTES else None
+
+
 if TYPE_CHECKING:
     from src.dashboard.events import EventBus
     from src.host.api_keys import ApiKeyManager
@@ -779,6 +803,23 @@ def create_mesh_app(
         migrate_project_to_team()
     except Exception as e:
         logger.error("team_migration failed at startup: %s — continuing", e, exc_info=True)
+
+    # L10: register the loaded system-tier credential names with the
+    # permission matrix so ``can_access_credential`` denies agent access to
+    # a system secret even when its name doesn't match the provider-key
+    # shape heuristic.
+    if credential_vault is not None and hasattr(
+        permissions, "set_system_credential_names"
+    ):
+        try:
+            permissions.set_system_credential_names(
+                credential_vault.list_system_credential_names()
+            )
+        except Exception as e:
+            logger.error(
+                "Failed to register system credential names with permissions: %s",
+                e, exc_info=True,
+            )
 
     # Durable orchestration task records. ``OPENLEGION_ORCHESTRATION_TASKS_DB``
     # overrides the on-disk path — used by tests to keep the db inside
@@ -1867,6 +1908,22 @@ def create_mesh_app(
         if credential_vault is None:
             return APIProxyResponse(success=False, error="No credential vault configured")
 
+        # M8: reject pathologically large inputs before dispatch.
+        _oversize = _proxy_input_too_large(api_request.params)
+        if _oversize is not None:
+            logger.warning(
+                "Rejected oversized proxy input from agent=%s service=%s: %d bytes > %d cap",
+                agent_id, api_request.service, _oversize, _PROXY_INPUT_MAX_BYTES,
+            )
+            return APIProxyResponse(
+                success=False,
+                error=(
+                    f"Request input too large ({_oversize} bytes); "
+                    f"limit is {_PROXY_INPUT_MAX_BYTES} bytes."
+                ),
+                status_code=413,
+            )
+
         req_trace_id = request.headers.get("x-trace-id")
         prompt_preview = _extract_prompt_preview(api_request.params)
         t0 = time.time()
@@ -1969,6 +2026,19 @@ def create_mesh_app(
         _enforce_model_pin(agent_id, request, api_request)
         if credential_vault is None:
             raise HTTPException(503, "No credential vault configured")
+
+        # M8: reject pathologically large inputs before opening the stream.
+        _oversize = _proxy_input_too_large(api_request.params)
+        if _oversize is not None:
+            logger.warning(
+                "Rejected oversized stream input from agent=%s service=%s: %d bytes > %d cap",
+                agent_id, api_request.service, _oversize, _PROXY_INPUT_MAX_BYTES,
+            )
+            raise HTTPException(
+                413,
+                f"Request input too large ({_oversize} bytes); "
+                f"limit is {_PROXY_INPUT_MAX_BYTES} bytes.",
+            )
 
         req_trace_id = request.headers.get("x-trace-id")
         prompt_preview = _extract_prompt_preview(api_request.params)
@@ -5389,37 +5459,41 @@ def create_mesh_app(
         """Read a task by id.
 
         Visible to creator, assignee, project members, operator, and
-        internal callers. Other callers receive 403.
+        internal callers. L16: unauthorized callers receive the SAME 404
+        as a non-existent task so the endpoint can't be used as an
+        existence oracle (404-not-found vs 403-exists-but-denied).
         """
         store = tasks_store
         caller = _extract_verified_agent_id(request)
         record = store.get(task_id)
-        if record is None:
-            raise HTTPException(404, f"Task '{task_id}' not found")
-        if (
+        if record is not None and (
             caller in (record["creator"], record["assignee"])
             or _caller_is_operator(caller, request)
             or _is_internal_caller(request)
             or (record["project_id"] and _is_project_member(caller, record["project_id"]))
         ):
             return record
-        raise HTTPException(403, "Not authorized to read this task")
+        # Uniform 404 for both not-found and not-authorized (no oracle).
+        raise HTTPException(404, f"Task '{task_id}' not found")
 
     @app.get("/mesh/tasks/{task_id}/events")
     async def list_task_events(task_id: str, request: Request) -> dict:
-        """Audit history for a task. Same visibility rules as get_task."""
+        """Audit history for a task. Same visibility rules as get_task.
+
+        L16: unauthorized callers receive the same 404 as a non-existent
+        task to avoid leaking task existence.
+        """
         store = tasks_store
         caller = _extract_verified_agent_id(request)
         record = store.get(task_id)
-        if record is None:
-            raise HTTPException(404, f"Task '{task_id}' not found")
-        if not (
+        if record is None or not (
             caller in (record["creator"], record["assignee"])
             or _caller_is_operator(caller, request)
             or _is_internal_caller(request)
             or (record["project_id"] and _is_project_member(caller, record["project_id"]))
         ):
-            raise HTTPException(403, "Not authorized to read this task")
+            # Uniform 404 for both not-found and not-authorized (no oracle).
+            raise HTTPException(404, f"Task '{task_id}' not found")
         events = store.list_events(task_id)
         return {"events": events, "count": len(events)}
 
@@ -5828,19 +5902,21 @@ def create_mesh_app(
 
     @app.get("/mesh/work-summaries/{summary_id}")
     async def get_work_summary(summary_id: str, request: Request) -> dict:
-        """Fetch a single summary by id. Scope-checked."""
+        """Fetch a single summary by id. Scope-checked.
+
+        L16: unauthorized callers receive the same 404 as a non-existent
+        summary so the endpoint can't be used as an existence oracle.
+        """
         caller = _extract_verified_agent_id(request)
         row = summaries_store.get(summary_id)
-        if row is None:
+        if row is None or not _can_read_summary(caller, request, row):
+            if row is not None:
+                _record_denial(
+                    "scope", caller=caller, target=summary_id,
+                    gate="work_summaries.get:scope",
+                )
+            # Uniform 404 for both not-found and not-authorized (no oracle).
             raise HTTPException(404, f"Summary {summary_id!r} not found")
-        if not _can_read_summary(caller, request, row):
-            _record_denial(
-                "scope", caller=caller, target=summary_id,
-                gate="work_summaries.get:scope",
-            )
-            raise HTTPException(
-                403, f"Caller {caller} cannot read summary {summary_id!r}",
-            )
         return row
 
     @app.post("/mesh/work-summaries/{summary_id}/rating")

--- a/tests/test_credentials.py
+++ b/tests/test_credentials.py
@@ -246,7 +246,12 @@ async def test_handle_llm_no_failover_on_bad_request(monkeypatch):
         result = await v.execute_api_call(req)
 
     assert not result.success
-    assert "invalid request" in result.error
+    # L15: raw upstream provider message is masked from the agent; the
+    # status_code (400, permanent) is still surfaced so failover behaviour
+    # (no cascade on bad-request) remains observable.
+    assert "invalid request" not in (result.error or "")
+    assert result.error == "Upstream service call failed (HTTP 400)."
+    assert result.status_code == 400
 
 
 async def test_handle_llm_all_models_exhausted(monkeypatch):
@@ -272,7 +277,14 @@ async def test_handle_llm_all_models_exhausted(monkeypatch):
         result = await v.execute_api_call(req)
 
     assert not result.success
-    assert "down" in result.error
+    # L15: raw upstream message masked; status_code (503) preserved so the
+    # all-models-exhausted condition is still surfaced to the agent loop.
+    assert "down" not in (result.error or "")
+    assert result.error == "Upstream service call failed (HTTP 503)."
+    # 503 preserved both on the envelope and in the message so the agent's
+    # numeric retry-substring backstop still recognizes it as retryable.
+    assert result.status_code == 503
+    assert "503" in result.error
 
 
 async def test_handle_llm_empty_choices_triggers_failover(monkeypatch):
@@ -2381,8 +2393,9 @@ async def test_handle_llm_routes_oauth_to_direct_path(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_oauth_skips_cost_tracking(monkeypatch):
-    """OAuth calls via execute_api_call must NOT record costs."""
+async def test_oauth_tracks_usage_but_skips_budget_enforcement(monkeypatch):
+    """M8: OAuth calls via execute_api_call TRACK usage (observability)
+    but skip dollar enforcement (no preflight/budget gate)."""
     from unittest.mock import AsyncMock
 
     monkeypatch.setenv("OPENLEGION_SYSTEM_ANTHROPIC_API_KEY", "sk-ant-oat01-" + "x" * 80)
@@ -2393,7 +2406,11 @@ async def test_oauth_skips_cost_tracking(monkeypatch):
     # Mock _oauth_chat directly (it delegates to streaming internally)
     mock_result = MagicMock()
     mock_result.success = True
-    mock_result.data = {"content": "Hello!", "tokens_used": 75, "oauth": True}
+    mock_result.data = {
+        "content": "Hello!", "tokens_used": 75,
+        "input_tokens": 50, "output_tokens": 25, "oauth": True,
+        "model": "anthropic/claude-sonnet-4-6",
+    }
     v._oauth_chat = AsyncMock(return_value=mock_result)
 
     req = APIProxyRequest(
@@ -2406,7 +2423,11 @@ async def test_oauth_skips_cost_tracking(monkeypatch):
     result = await v.execute_api_call(req, agent_id="test-agent")
 
     assert result.success
-    cost_tracker.track.assert_not_called()
+    # Usage IS tracked now (spend visibility) ...
+    cost_tracker.track.assert_called_once_with(
+        "test-agent", "anthropic/claude-sonnet-4-6", 50, 25,
+    )
+    # ... but no dollar enforcement runs on the OAuth path.
     cost_tracker.preflight_check.assert_not_called()
 
 
@@ -3115,8 +3136,9 @@ async def test_codex_routing_prefixed_model(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_codex_skips_cost_tracking(monkeypatch):
-    """Codex calls via execute_api_call must NOT record costs."""
+async def test_codex_tracks_usage_but_skips_budget(monkeypatch):
+    """M8: Codex (OAuth) calls TRACK usage for visibility but skip dollar
+    enforcement (no preflight)."""
     from unittest.mock import AsyncMock
 
     monkeypatch.delenv("OPENLEGION_SYSTEM_OPENAI_API_KEY", raising=False)
@@ -3140,7 +3162,7 @@ async def test_codex_skips_cost_tracking(monkeypatch):
     )
     result = await v.execute_api_call(req, agent_id="test-agent")
     assert result.success
-    cost_tracker.track.assert_not_called()
+    cost_tracker.track.assert_called_once()
     cost_tracker.preflight_check.assert_not_called()
 
 
@@ -4941,3 +4963,88 @@ def test_resolve_single_pass_no_recursion(monkeypatch, perms_allow_all):
     assert resolved == "before $CRED{inner} after"
     # Only the outer value is in the redaction list — inner was never read.
     assert secrets == ["before $CRED{inner} after"]
+
+
+# === L15: generic upstream errors masked to the agent ===
+
+@pytest.mark.asyncio
+async def test_generic_upstream_exception_masked(monkeypatch):
+    """L15: a raw exception from a service handler is masked to a fixed,
+    non-revealing string in the agent-facing response."""
+    v = CredentialVault()
+
+    secret = "internal-host.corp.local:5432 token=sk-leak-9999"
+
+    async def boom(request):
+        raise RuntimeError(secret)
+
+    v.service_handlers["llm"] = boom
+
+    req = APIProxyRequest(
+        service="llm", action="chat",
+        params={"model": "anthropic/claude-sonnet-4-6", "messages": []},
+    )
+    result = await v.execute_api_call(req, agent_id="agent-x")
+    assert result.success is False
+    # The raw exception detail must NOT leak to the agent.
+    assert secret not in (result.error or "")
+    assert "sk-leak-9999" not in (result.error or "")
+    assert result.error == "Upstream service call failed."
+
+
+@pytest.mark.asyncio
+async def test_thirdparty_handler_error_body_masked(monkeypatch):
+    """L15: third-party (apollo/hunter/brave) HTTP error bodies are masked;
+    the agent sees only a generic message + status, not the raw body."""
+    v = CredentialVault()
+    v.credentials["brave_search_api_key"] = "bsk-test"
+
+    class _Resp:
+        is_success = False
+        status_code = 429
+        text = "rate limited: key=bsk-SECRET-LEAK quota at https://internal/x"
+
+        def json(self):
+            return {}
+
+    class _Client:
+        async def get(self, *a, **kw):
+            return _Resp()
+
+    async def _get_client():
+        return _Client()
+
+    v._get_http_client = _get_client
+
+    req = APIProxyRequest(service="brave_search", action="search", params={"q": "x"})
+    result = await v.execute_api_call(req, agent_id="agent-x")
+    assert result.success is False
+    assert "bsk-SECRET-LEAK" not in (result.error or "")
+    assert "internal" not in (result.error or "")
+    assert result.status_code == 429
+
+
+# === L1: OAuth token never logged in full ===
+
+@pytest.mark.asyncio
+async def test_oauth_resolve_token_not_logged_in_full(monkeypatch, caplog):
+    """L1: ``_ensure_anthropic_oauth_token`` logs a sha256 fingerprint,
+    never a slice of the actual token."""
+    import logging
+
+    token = "sk-ant-oat01-" + "Z" * 80
+    monkeypatch.setenv(
+        "OPENLEGION_SYSTEM_ANTHROPIC_OAUTH",
+        '{"access_token": "%s"}' % token,
+    )
+    v = CredentialVault()
+
+    with caplog.at_level(logging.INFO):
+        resolved = await v._ensure_anthropic_oauth_token()
+
+    assert resolved == token
+    logged = "\n".join(r.getMessage() for r in caplog.records)
+    # Neither the full token nor its head/tail slice may appear.
+    assert token not in logged
+    assert token[:15] not in logged
+    assert token[-4:] not in logged or "fp=" in logged  # fingerprint only

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -2959,3 +2959,113 @@ def test_mesh_wake_paired_human_origin_keeps_kind(tmp_path, monkeypatch):
         loop.call_soon_threadsafe(loop.stop)
         bb.close()
         _server._invalidate_pairing_cache()
+
+
+# === M8: LLM-proxy input size cap ===
+
+def test_proxy_input_oversize_rejected(vault_components, monkeypatch):
+    """M8: a serialized proxy input above the cap is rejected (413) before
+    dispatch — the vault handler is never reached."""
+    import src.host.server as server_module
+
+    # Shrink the cap so the test payload is cheap to build.
+    monkeypatch.setattr(server_module, "_PROXY_INPUT_MAX_BYTES", 1024)
+    # Pin the agent to the model it requests so the request clears the
+    # model-pin gate and reaches the input-cap gate under test.
+    monkeypatch.setattr(
+        "src.cli.config._load_config",
+        lambda *a, **k: {
+            "agents": {"trusted": {"model": "anthropic/claude-sonnet-4-6"}},
+        },
+    )
+    # The pin also runs an is_model_compatible() check — give the fixture
+    # vault an Anthropic key so the requested model clears it and the
+    # request reaches the input-cap gate under test.
+    vault_components["vault"].system_credentials["anthropic_api_key"] = "sk-ant-test"
+    client = vault_components["client"]
+    big = "x" * 4096
+    resp = client.post(
+        "/mesh/api",
+        params={"agent_id": "trusted"},
+        json={
+            "service": "llm", "action": "chat",
+            "params": {
+                "model": "anthropic/claude-sonnet-4-6",
+                "messages": [{"role": "user", "content": big}],
+            },
+        },
+    )
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["success"] is False
+    assert data["status_code"] == 413
+    assert "too large" in data["error"].lower()
+
+
+def test_proxy_input_under_cap_not_rejected_for_size(vault_components, monkeypatch):
+    """M8: a normal-sized prompt is NOT rejected by the size gate (it may
+    still fail downstream for other reasons, but not with a 413)."""
+    import src.host.server as server_module
+
+    monkeypatch.setattr(server_module, "_PROXY_INPUT_MAX_BYTES", 4 * 1024 * 1024)
+    # Pin the agent to the model it requests so the request clears the
+    # model-pin gate and reaches the input-cap gate under test.
+    monkeypatch.setattr(
+        "src.cli.config._load_config",
+        lambda *a, **k: {
+            "agents": {"trusted": {"model": "anthropic/claude-sonnet-4-6"}},
+        },
+    )
+    # The pin also runs an is_model_compatible() check — give the fixture
+    # vault an Anthropic key so the requested model clears it and the
+    # request reaches the input-cap gate under test.
+    vault_components["vault"].system_credentials["anthropic_api_key"] = "sk-ant-test"
+    client = vault_components["client"]
+    resp = client.post(
+        "/mesh/api",
+        params={"agent_id": "trusted"},
+        json={
+            "service": "llm", "action": "chat",
+            "params": {
+                "model": "anthropic/claude-sonnet-4-6",
+                "messages": [{"role": "user", "content": "hi"}],
+            },
+        },
+    )
+    assert resp.status_code == 200
+    data = resp.json()
+    # Whatever happens downstream, it is NOT a size rejection.
+    assert data.get("status_code") != 413
+
+
+def test_proxy_stream_input_oversize_rejected(vault_components, monkeypatch):
+    """M8: the streaming proxy rejects oversized input with HTTP 413."""
+    import src.host.server as server_module
+
+    monkeypatch.setattr(server_module, "_PROXY_INPUT_MAX_BYTES", 1024)
+    # Pin the agent to the model it requests so the request clears the
+    # model-pin gate and reaches the input-cap gate under test.
+    monkeypatch.setattr(
+        "src.cli.config._load_config",
+        lambda *a, **k: {
+            "agents": {"trusted": {"model": "anthropic/claude-sonnet-4-6"}},
+        },
+    )
+    # The pin also runs an is_model_compatible() check — give the fixture
+    # vault an Anthropic key so the requested model clears it and the
+    # request reaches the input-cap gate under test.
+    vault_components["vault"].system_credentials["anthropic_api_key"] = "sk-ant-test"
+    client = vault_components["client"]
+    big = "y" * 4096
+    resp = client.post(
+        "/mesh/api/stream",
+        params={"agent_id": "trusted"},
+        json={
+            "service": "llm", "action": "chat",
+            "params": {
+                "model": "anthropic/claude-sonnet-4-6",
+                "messages": [{"role": "user", "content": big}],
+            },
+        },
+    )
+    assert resp.status_code == 413

--- a/tests/test_orchestration_endpoints.py
+++ b/tests/test_orchestration_endpoints.py
@@ -274,9 +274,10 @@ async def test_get_task_visible_to_creator_assignee_operator(v2_app):
         # Operator can read.
         r = await c.get(f"/mesh/tasks/{tid}", headers={"X-Agent-ID": "operator"})
         assert r.status_code == 200
-        # Outsider cannot.
+        # Outsider cannot — L16: returns a uniform 404 (not 403) so the
+        # endpoint can't be used as an existence oracle.
         r = await c.get(f"/mesh/tasks/{tid}", headers={"X-Agent-ID": "tracker"})
-        assert r.status_code == 403
+        assert r.status_code == 404
 
 
 @pytest.mark.asyncio

--- a/tests/test_permissions.py
+++ b/tests/test_permissions.py
@@ -1159,3 +1159,45 @@ class TestAtomicPermissionsWrite:
         loaded = json.loads(perms_file.read_text())
         assert len(loaded["permissions"]) == 500
         assert not list(perms_file.parent.glob("*.tmp"))
+
+
+class TestCanAccessCredentialSystemTier:
+    """L10: system-tier credentials are blocked from agents by LOADED TIER,
+    not just by the provider-key name-shape heuristic."""
+
+    @pytest.fixture()
+    def cred_matrix(self, tmp_path):
+        cfg = {
+            "permissions": {
+                "worker": {
+                    # Broad allowlist that WOULD match the system secret by
+                    # pattern if the tier guard didn't exist.
+                    "allowed_credentials": ["*"],
+                },
+            },
+        }
+        path = tmp_path / "permissions.json"
+        path.write_text(json.dumps(cfg))
+        return PermissionMatrix(config_path=str(path))
+
+    def test_non_conforming_system_name_blocked_by_tier(self, cred_matrix):
+        # ``my_internal_token`` does NOT match the provider-key shape, so
+        # ``is_system_credential`` alone would allow it. The loaded-tier
+        # registry must still block it.
+        assert cred_matrix.can_access_credential("worker", "my_internal_token") is True
+        cred_matrix.set_system_credential_names(["my_internal_token"])
+        assert cred_matrix.can_access_credential("worker", "my_internal_token") is False
+
+    def test_tier_check_is_case_insensitive(self, cred_matrix):
+        cred_matrix.set_system_credential_names(["My_Internal_Token"])
+        assert cred_matrix.can_access_credential("worker", "MY_INTERNAL_TOKEN") is False
+
+    def test_agent_tier_credential_still_accessible(self, cred_matrix):
+        cred_matrix.set_system_credential_names(["my_internal_token"])
+        # An ordinary agent-tier credential is unaffected by the registry.
+        assert cred_matrix.can_access_credential("worker", "stripe_token") is True
+
+    def test_name_shape_guard_still_applies(self, cred_matrix):
+        # Even with an EMPTY tier registry, provider-key shapes stay blocked.
+        cred_matrix.set_system_credential_names([])
+        assert cred_matrix.can_access_credential("worker", "anthropic_api_key") is False

--- a/tests/test_summaries_api.py
+++ b/tests/test_summaries_api.py
@@ -334,7 +334,9 @@ async def test_get_missing_summary_returns_404(mesh_setup):
 
 
 @pytest.mark.asyncio
-async def test_get_summary_scope_403_for_outsider(mesh_setup):
+async def test_get_summary_scope_404_for_outsider(mesh_setup):
+    # L16: an unauthorized caller gets the SAME 404 as a non-existent
+    # summary so the endpoint can't be used as an existence oracle.
     store = mesh_setup["store"]
     now = time.time()
     row = store.create(
@@ -350,7 +352,7 @@ async def test_get_summary_scope_403_for_outsider(mesh_setup):
             f"/mesh/work-summaries/{row['id']}",
             headers=_hdr(mesh_setup["tokens"]["scout"]),
         )
-    assert resp.status_code == 403
+    assert resp.status_code == 404
 
 
 # =============================================================================


### PR DESCRIPTION
May 2026 credential-proxy security-hygiene remediation. Each change is behavior-preserving for legitimate use.

## Findings

**M8 — LLM-proxy input size cap.** Reject `proxy_api_call` / `proxy_api_stream` requests whose serialized `params` exceed a generous 4 MiB ceiling (overridable via `OPENLEGION_PROXY_INPUT_MAX_BYTES`) with HTTP 413, before dispatch. On the OAuth path (where `_needs_budget` is false) keep COST TRACKING — record token usage for spend visibility — while still skipping dollar enforcement. No `$` semantics introduced; large legitimate contexts are unaffected.

**L1 — Redact OAuth token logging.** The four sites that logged `token[:15]...token[-4:]` now log a non-reversible `sha256(token)[:8]` fingerprint. No functional change.

**L10 — System-tier classification by loaded vault tier.** `PermissionMatrix.can_access_credential` now denies any credential whose name loaded under `OPENLEGION_SYSTEM_` (registered via `set_system_credential_names`, wired in `create_mesh_app`), even when the name doesn't match the provider-key shape. The existing name-shape `is_system_credential` check remains as an additional guard.

**L15 — Mask generic upstream provider errors.** The generic `execute_api_call` exception handler and the apollo/hunter/brave/gemini third-party handlers now return a fixed, non-revealing error string to the agent, with full detail in `logger.error` only. HTTP status is preserved on the envelope and echoed in the message so the agent's numeric retry-substring backstop keeps working. Typed envelopes (auth/config/transient) are unchanged; the internal "No API key configured" raise is promoted to `LLMConfigError` so it stays a typed, surfaceable message rather than being masked.

**L16 — Uniform 404 to remove the existence oracle.** `get_task` / `list_task_events` / `get_work_summary` now return the same 404 for both not-found and not-authorized. Authorized callers (creator/assignee/operator/project-member) still get the record.

## Tests
Added: oversized proxy input rejected (call + stream); under-cap not size-rejected; OAuth/Codex spend still tracked but no preflight; OAuth token not logged in full; non-conformingly-named system cred blocked from agents (+ name-shape guard still applies); generic upstream error masked; third-party handler body masked; `get_task`/work-summary return 404 (not 403) for unauthorized callers. Updated pre-existing tests that encoded the old leaky behavior.

`tests/test_credentials.py tests/test_permissions.py tests/test_integration.py tests/test_orchestration_endpoints.py tests/test_summaries_api.py` — 515 passed. ruff clean.

Possible rebase against May 2026 remediation branches.