### PR TITLE
fix(security): close profile bypass, sanitize compaction summary, clamp template perms, harden channel edges

### DIFF
--- a/src/agent/context.py
+++ b/src/agent/context.py
@@ -16,7 +16,7 @@ from collections.abc import Callable, Coroutine
 from typing import TYPE_CHECKING, Any
 
 from src.shared.models import get_context_window
-from src.shared.utils import setup_logging
+from src.shared.utils import sanitize_for_prompt, setup_logging
 
 if TYPE_CHECKING:
     from src.agent.llm import LLMClient
@@ -346,8 +346,14 @@ class ContextManager:
             if not isinstance(facts, list) or not facts:
                 return 0
 
-            # Write human-readable summary to MEMORY.md
-            lines = [f"- **{f['key']}**: {f['value']}" for f in facts if f.get("key") and f.get("value")]
+            # Write human-readable summary to MEMORY.md. M2: sanitize each
+            # LLM-extracted key/value for Unicode hygiene before it lands in
+            # the persistent workspace markdown (re-read into context later).
+            lines = [
+                f"- **{sanitize_for_prompt(str(f['key']))}**: "
+                f"{sanitize_for_prompt(str(f['value']))}"
+                for f in facts if f.get("key") and f.get("value")
+            ]
             if lines and self.workspace:
                 self.workspace.append_memory(
                     f"\n## {label} ({_now_str()})\n\n" + "\n".join(lines),
@@ -466,9 +472,15 @@ class ContextManager:
                                    f"falling back to hard prune: {last_err}")
                     return self._hard_prune(messages)
 
+        # M2: sanitize the LLM-produced summary before re-injecting it into the
+        # context window, for Unicode-hygiene uniformity with the memory /
+        # bootstrap entry paths (which all call ``sanitize_for_prompt``). This
+        # strips invisible/control characters; it is lossless for normal text so
+        # summary quality is unaffected. NOT an anti-injection control.
         summary_msg = {
             "role": "user",
-            "content": f"## Conversation Summary (auto-compacted)\n\n{summary}",
+            "content": "## Conversation Summary (auto-compacted)\n\n"
+            + sanitize_for_prompt(summary),
         }
 
         # The summary is ``role=user``. The recent tail's leading group

--- a/src/channels/discord.py
+++ b/src/channels/discord.py
@@ -67,6 +67,21 @@ class DiscordChannel(Channel):
         except (TypeError, ValueError):
             return False
 
+    def _dm_blocked_by_guild_restriction(self, has_guild: bool, author_id: int) -> bool:
+        """L5: True when a DM must be dropped because guilds are restricted.
+
+        When ``allowed_guilds`` is set, the guild allow-list is bypassable via
+        DM (no guild) unless we require the DMing user to already be paired/
+        allowed. Returns True (drop) for an unpaired DM under a guild
+        restriction; False for in-guild messages, already-paired DM users, or
+        when no guild restriction is configured.
+        """
+        if not self.allowed_guilds:
+            return False
+        if has_guild:
+            return False
+        return not self._is_allowed(author_id)
+
     # ── extracted command handlers ─────────────────────────────
 
     def _handle_pairing(self, author_id: int, code_arg: str) -> str:
@@ -352,6 +367,16 @@ class DiscordChannel(Channel):
                 return
 
             author_id = message.author.id
+
+            # L5: when guilds are restricted, a DM (no guild) is only honored
+            # for users who are ALREADY paired/allowed. An unpaired DM must
+            # not see the pairing flow — otherwise the guild allow-list is
+            # bypassable by DMing the bot. Already-paired DM users and the
+            # normal in-guild path are unaffected.
+            if channel_ref._dm_blocked_by_guild_restriction(
+                message.guild is not None, author_id
+            ):
+                return
 
             # Pairing via code: /start <code> or !start <code>
             if channel_ref._pairing.owner is None:

--- a/src/channels/slack.py
+++ b/src/channels/slack.py
@@ -191,9 +191,12 @@ class SlackChannel(Channel):
 
     async def _on_message(self, event: dict, say) -> None:
         """Handle incoming Slack message events."""
-        logger.warning(
-            "Slack event received: user=%s text=%s",
-            event.get("user", "?"), (event.get("text") or "")[:80],
+        # L6: do NOT log inbound message text — this runs before any
+        # auth/pairing check. Keep a minimal pre-auth debug line (sender +
+        # length only, no body) for diagnostics.
+        logger.debug(
+            "Slack event received: user=%s text_len=%d",
+            event.get("user", "?"), len(event.get("text") or ""),
         )
         # Ignore bot messages and message subtypes (edits, joins, etc.)
         if event.get("bot_id") or event.get("subtype"):

--- a/src/cli/config.py
+++ b/src/cli/config.py
@@ -23,6 +23,13 @@ from src.shared.utils import truncate
 
 logger = logging.getLogger("cli")
 
+# L4: irreversible-grant ceiling for fleet templates. Booleans here can never
+# be set true from a template's ``permissions`` dict — they are operator/user-
+# only grants (spawning agents, spending the wallet) that must not be mintable
+# by template application. Mirrors ``_OPERATOR_PERMISSION_CEILING`` in
+# ``src/agent/builtins/operator_tools.py`` (the False entries there).
+_TEMPLATE_PERMISSION_CEILING = frozenset({"can_spawn", "can_use_wallet"})
+
 # ── Path constants ──────────────────────────────────────────
 
 
@@ -600,9 +607,24 @@ def _add_agent_permissions(name: str, permissions: dict | None = None) -> None:
             "can_manage_fleet", "can_manage_teams", "can_edit_agent_config",
             "can_view_fleet_metrics",
             "can_request_user_credentials",
+            "can_use_wallet",
         ):
             if key in permissions:
-                agent_perms[key] = bool(permissions[key])
+                value = bool(permissions[key])
+                # L4: clamp the irreversible-grant ceiling. A fleet template
+                # must never mint an agent that can spawn other agents or
+                # spend from the wallet — those are operator/user-only grants
+                # (mirrors _OPERATOR_PERMISSION_CEILING in operator_tools.py).
+                # None of the shipped templates set these true, so legitimate
+                # template application is unaffected.
+                if key in _TEMPLATE_PERMISSION_CEILING and value:
+                    logger.warning(
+                        "Template for agent '%s' tried to grant '%s'=true; "
+                        "clamping to false (irreversible-grant ceiling)",
+                        name, key,
+                    )
+                    value = False
+                agent_perms[key] = value
 
     perms["permissions"][name] = agent_perms
     _save_permissions(perms)

--- a/src/cli/config.py
+++ b/src/cli/config.py
@@ -558,7 +558,9 @@ def _add_agent_to_config(
         yaml.dump(agents_cfg, f, default_flow_style=False, sort_keys=False)
 
 
-def _add_agent_permissions(name: str, permissions: dict | None = None) -> None:
+def _add_agent_permissions(
+    name: str, permissions: dict | None = None, *, from_template: bool = False
+) -> None:
     """Add default permissions for a new agent.
 
     If collaboration mode is enabled in mesh.yaml, agents can message
@@ -617,7 +619,7 @@ def _add_agent_permissions(name: str, permissions: dict | None = None) -> None:
                 # (mirrors _OPERATOR_PERMISSION_CEILING in operator_tools.py).
                 # None of the shipped templates set these true, so legitimate
                 # template application is unaffected.
-                if key in _TEMPLATE_PERMISSION_CEILING and value:
+                if from_template and key in _TEMPLATE_PERMISSION_CEILING and value:
                     logger.warning(
                         "Template for agent '%s' tried to grant '%s'=true; "
                         "clamping to false (irreversible-grant ceiling)",
@@ -1345,7 +1347,7 @@ def _apply_template(
             escalation_to=agent_def.get("escalation_to"),
             forbidden=agent_def.get("forbidden") or [],
         )
-        _add_agent_permissions(agent_name, permissions=agent_permissions)
+        _add_agent_permissions(agent_name, permissions=agent_permissions, from_template=True)
         skills_dir = PROJECT_ROOT / "skills" / agent_name
         skills_dir.mkdir(parents=True, exist_ok=True)
         created.append(agent_name)
@@ -1469,7 +1471,7 @@ def _create_agent_from_template(
         escalation_to=agent_def.get("escalation_to"),
         forbidden=agent_def.get("forbidden") or [],
     )
-    _add_agent_permissions(name, permissions=agent_permissions)
+    _add_agent_permissions(name, permissions=agent_permissions, from_template=True)
     skills_dir = PROJECT_ROOT / "skills" / name
     skills_dir.mkdir(parents=True, exist_ok=True)
 

--- a/src/host/server.py
+++ b/src/host/server.py
@@ -3858,18 +3858,27 @@ def create_mesh_app(
         what it accepts, produces, subscribes to, and its public contract.
         Permission-checked: requesting agent must be allowed to message the target.
         """
-        if requesting_agent:
-            requesting_agent = _resolve_agent_id(requesting_agent, request)
-            await _check_rate_limit("agent_profile", requesting_agent)
-            if not _caller_is_operator(requesting_agent, request):
-                if not permissions.can_message(requesting_agent, agent_id):
+        # M24: resolve the caller's verified identity UNCONDITIONALLY and apply
+        # the can_message gate to it. The optional ``requesting_agent`` query
+        # hint must never relax the check — omitting it previously fell through
+        # to ``_require_any_auth`` and leaked a peer's subscriptions / watch-keys
+        # / INTERFACE.md cross-team. ``_extract_verified_agent_id`` derives the
+        # caller from the Bearer token (or trusts the loopback/mesh-internal
+        # boundary) so the hint can never spoof or relax the identity. In
+        # dev/test mode (no auth tokens) it falls back to the X-Agent-ID hint /
+        # "unknown" exactly as ``_resolve_agent_id`` does, so legitimate dev
+        # reads are unaffected.
+        _require_any_auth(request)
+        effective_caller = _extract_verified_agent_id(request)
+        if effective_caller and effective_caller != "unknown":
+            await _check_rate_limit("agent_profile", effective_caller)
+            if not _caller_is_operator(effective_caller, request):
+                if not permissions.can_message(effective_caller, agent_id):
                     _record_denial(
-                        "permission", caller=requesting_agent, target=agent_id,
+                        "permission", caller=effective_caller, target=agent_id,
                         gate="agent.profile:can_message",
                     )
-                    raise HTTPException(403, f"Agent {requesting_agent} cannot read profile of {agent_id}")
-        else:
-            _require_any_auth(request)
+                    raise HTTPException(403, f"Agent {effective_caller} cannot read profile of {agent_id}")
 
         if agent_id not in router.agent_registry:
             raise HTTPException(404, f"Agent not found: {agent_id}")

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -155,6 +155,50 @@ class TestCompaction:
             shutil.rmtree(tmpdir, ignore_errors=True)
 
     @pytest.mark.asyncio
+    async def test_compact_summary_is_sanitized_before_reinjection(self):
+        """M2: the auto-compaction summary is passed through
+        sanitize_for_prompt before being re-injected as a user message —
+        invisible/control chars (e.g. zero-width space, RTL override) are
+        stripped, matching the memory/bootstrap entry paths. Lossless for
+        normal text, so summary quality is preserved."""
+        tmpdir = tempfile.mkdtemp()
+        try:
+            workspace = WorkspaceManager(workspace_dir=tmpdir)
+            # Summary laced with a zero-width space (U+200B) and a
+            # right-to-left override (U+202E). Both are Unicode Cf chars
+            # that sanitize_for_prompt strips.
+            dirty = "Summary: discussed​Python‮and ML."
+            llm = MagicMock()
+            llm.chat = AsyncMock(
+                side_effect=[
+                    LLMResponse(
+                        content='[{"key": "topic", "value": "ok", "category": "fact"}]',
+                        tokens_used=30,
+                    ),
+                    LLMResponse(content=dirty, tokens_used=30),
+                ]
+            )
+
+            cm = ContextManager(max_tokens=100, llm=llm, workspace=workspace)
+            msgs = _make_messages(10, chars_each=200)
+            result, did_compact = await cm.maybe_compact("system", msgs)
+
+            assert did_compact is True
+            summary_msg = next(
+                m for m in result
+                if "Conversation Summary" in m.get("content", "")
+            )
+            content = summary_msg["content"]
+            # Invisible chars stripped...
+            assert "​" not in content
+            assert "‮" not in content
+            # ...but the visible text survives (sanitize is lossless).
+            assert "discussedPython" in content
+            assert "and ML." in content
+        finally:
+            shutil.rmtree(tmpdir, ignore_errors=True)
+
+    @pytest.mark.asyncio
     async def test_compact_handles_llm_failure(self):
         llm = MagicMock()
         llm.chat = AsyncMock(side_effect=RuntimeError("LLM unavailable"))

--- a/tests/test_discord.py
+++ b/tests/test_discord.py
@@ -453,3 +453,35 @@ class TestOnMessageFallback:
         ch._pairing.claim_owner(111)
         msg = ch._handle_paired(111)
         assert "Owner: 111" in msg
+
+
+# ── L5: guild allow-list covers DMs ───────────────────────────
+
+class TestDmGuildRestriction:
+    """_dm_blocked_by_guild_restriction gates DMs when guilds are restricted."""
+
+    def test_unpaired_dm_blocked_when_guilds_restricted(self):
+        """An unpaired DM (no guild) is dropped when allowed_guilds is set —
+        the pairing flow must not be exposed, closing the guild-bypass hole."""
+        ch = _make_discord_channel(allowed_guilds=[12345])
+        assert ch.allowed_guilds == {12345}
+        # has_guild=False (DM), author not paired → blocked.
+        assert ch._dm_blocked_by_guild_restriction(False, 999) is True
+
+    def test_paired_dm_allowed_when_guilds_restricted(self):
+        """An already-paired/allowed DM user is NOT blocked."""
+        ch = _make_discord_channel(allowed_guilds=[12345])
+        ch._pairing.claim_owner(777)
+        assert ch._is_allowed(777) is True
+        assert ch._dm_blocked_by_guild_restriction(False, 777) is False
+
+    def test_guild_message_never_blocked_by_dm_gate(self):
+        """In-guild messages (has_guild=True) bypass the DM gate entirely."""
+        ch = _make_discord_channel(allowed_guilds=[12345])
+        assert ch._dm_blocked_by_guild_restriction(True, 999) is False
+
+    def test_dm_gate_inert_without_guild_restriction(self):
+        """With no allowed_guilds, unpaired DMs reach the normal pairing flow."""
+        ch = _make_discord_channel()  # allowed_guilds=None
+        assert ch.allowed_guilds is None
+        assert ch._dm_blocked_by_guild_restriction(False, 999) is False

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1944,18 +1944,91 @@ def test_agent_profile_not_found(mesh_components):
     assert resp.status_code == 404
 
 
-def test_agent_profile_permission_denied(mesh_components):
-    """GET /mesh/agents/{id}/profile returns 403 when agent lacks can_message."""
-    client = mesh_components["client"]
+def test_agent_profile_permission_denied(tmp_path):
+    """GET /mesh/agents/{id}/profile enforces can_message on the VERIFIED
+    bearer identity — not the (untrusted) ``requesting_agent`` query param.
 
-    # Register both agents
-    client.post("/mesh/register", json={"agent_id": "qualify", "capabilities": [], "port": 8402})
-    client.post("/mesh/register", json={"agent_id": "research", "capabilities": [], "port": 8401})
+    M24 stopped trusting ``requesting_agent``; the gate now keys off the
+    token-verified caller. This builds a mesh app WITH ``auth_tokens`` so a
+    real verified identity exists, then asserts a caller lacking
+    ``can_message`` for the target is denied 403 even with NO
+    ``requesting_agent`` param, while a caller that DOES have ``can_message``
+    is allowed 200.
+    """
+    bb = Blackboard(db_path=str(tmp_path / "bb.db"))
+    pubsub = PubSub()
 
-    # "qualify" can only message "mesh" per the fixture permissions.
-    # Try to read "research" profile from "qualify" — should be denied.
-    resp = client.get("/mesh/agents/research/profile", params={"requesting_agent": "qualify"})
+    perms = PermissionMatrix.__new__(PermissionMatrix)
+    perms.permissions = {
+        "research": AgentPermissions(
+            agent_id="research",
+            can_message=["mesh"],
+            allowed_apis=["anthropic"],
+        ),
+        # "qualify" can message "mesh" but NOT "research".
+        "qualify": AgentPermissions(
+            agent_id="qualify",
+            can_message=["mesh"],
+            allowed_apis=["anthropic"],
+        ),
+        # "scout" CAN message "research" — used for the positive case.
+        "scout": AgentPermissions(
+            agent_id="scout",
+            can_message=["mesh", "research"],
+            allowed_apis=["anthropic"],
+        ),
+    }
+
+    router = MessageRouter(permissions=perms, agent_registry={})
+
+    # Each agent has its own token — ``/mesh/register`` resolves the
+    # registered identity from the bearer (not the supplied agent_id) when
+    # auth is on, so each agent must register under its own token.
+    tokens = {
+        "research": "research-token-xyz",
+        "qualify": "qualify-token-xyz",
+        "scout": "scout-token-xyz",
+    }
+    app = create_mesh_app(bb, pubsub, router, perms, auth_tokens=tokens)
+    client = TestClient(app)
+
+    # Register target + callers (each authenticated as itself).
+    for agent_id, token, port in (
+        ("research", "research-token-xyz", 8401),
+        ("qualify", "qualify-token-xyz", 8402),
+        ("scout", "scout-token-xyz", 8403),
+    ):
+        reg = client.post(
+            "/mesh/register",
+            json={"agent_id": agent_id, "capabilities": [], "port": port},
+            headers={"Authorization": f"Bearer {token}"},
+        )
+        assert reg.status_code == 200, reg.text
+
+    # Verified caller "qualify" lacks can_message=["research"] → 403,
+    # WITHOUT any requesting_agent param (the param is no longer trusted).
+    resp = client.get(
+        "/mesh/agents/research/profile",
+        headers={"Authorization": "Bearer qualify-token-xyz"},
+    )
     assert resp.status_code == 403
+
+    # Spoofing the param does NOT change the outcome — still keyed on the
+    # verified bearer identity ("qualify"), so still denied.
+    resp = client.get(
+        "/mesh/agents/research/profile",
+        params={"requesting_agent": "scout"},
+        headers={"Authorization": "Bearer qualify-token-xyz"},
+    )
+    assert resp.status_code == 403
+
+    # Verified caller "scout" HAS can_message=["research"] → allowed 200.
+    resp = client.get(
+        "/mesh/agents/research/profile",
+        headers={"Authorization": "Bearer scout-token-xyz"},
+    )
+    assert resp.status_code == 200
+    assert resp.json()["agent_id"] == "research"
 
 
 # ── Fix 4: parse_origin_header input validation ─────────────────

--- a/tests/test_mesh.py
+++ b/tests/test_mesh.py
@@ -2031,3 +2031,96 @@ async def test_get_agent_profile_hides_runtime_fields_from_peer_agents(tmp_path)
         bb.close()
         costs.close()
         traces.close()
+
+
+@pytest.mark.asyncio
+async def test_profile_denied_to_worker_omitting_requesting_agent(tmp_path):
+    """M24: with auth tokens configured, a worker that omits the
+    ``requesting_agent`` hint AND lacks ``can_message`` to the target is
+    denied the profile (the verified Bearer identity drives the gate, so
+    the optional hint can't be used to bypass it). An authorized peer and
+    the operator still get 200."""
+    from unittest.mock import patch
+
+    import yaml as yaml_mod
+    from httpx import ASGITransport, AsyncClient
+
+    from src.host.costs import CostTracker
+    from src.host.server import create_mesh_app
+    from src.host.traces import TraceStore
+
+    cfg_dir = tmp_path / "config"
+    cfg_dir.mkdir(parents=True)
+    agents_path = cfg_dir / "agents.yaml"
+    agents_path.write_text(yaml_mod.dump({"agents": {
+        "writer": {"role": "writer", "model": "x"},
+        "peer": {"role": "peer", "model": "x"},
+        "stranger": {"role": "stranger", "model": "x"},
+    }}))
+    (cfg_dir / "mesh.yaml").write_text(yaml_mod.dump({"mesh": {"port": 8420}}))
+    projects_dir = cfg_dir / "projects"
+    projects_dir.mkdir()
+
+    bb = Blackboard(db_path=str(tmp_path / "bb.db"))
+    pubsub = PubSub()
+    perms = PermissionMatrix()
+    # peer may message writer; stranger may not message anyone.
+    perms.permissions["peer"] = AgentPermissions(
+        agent_id="peer", can_message=["writer"],
+    )
+    perms.permissions["stranger"] = AgentPermissions(
+        agent_id="stranger", can_message=[],
+    )
+    router = MessageRouter(perms, {})
+    costs = CostTracker(str(tmp_path / "costs.db"))
+    traces = TraceStore(str(tmp_path / "traces.db"))
+    router.register_agent("writer", "http://writer:8400", ["file_write"])
+    router.register_agent("peer", "http://peer:8400", [])
+    router.register_agent("stranger", "http://stranger:8400", [])
+
+    auth_tokens = {
+        "operator": "tok-operator",
+        "peer": "tok-peer",
+        "stranger": "tok-stranger",
+    }
+
+    app = create_mesh_app(
+        blackboard=bb, pubsub=pubsub, router=router, permissions=perms,
+        cost_tracker=costs, trace_store=traces, auth_tokens=auth_tokens,
+    )
+
+    try:
+        with patch("src.cli.config.AGENTS_FILE", agents_path), \
+             patch("src.cli.config.CONFIG_FILE", cfg_dir / "mesh.yaml"), \
+             patch("src.cli.config.PROJECTS_DIR", projects_dir):
+            async with AsyncClient(
+                transport=ASGITransport(app=app), base_url="http://test",
+            ) as client:
+                # Stranger omits requesting_agent entirely — previously this
+                # fell through to _require_any_auth and leaked the profile.
+                # Now the Bearer-verified identity is gated → 403.
+                denied = await client.get(
+                    "/mesh/agents/writer/profile",
+                    headers={"Authorization": "Bearer tok-stranger"},
+                )
+                assert denied.status_code == 403, denied.text
+
+                # Authorized peer (can_message=[writer]) still gets the profile,
+                # even though it also omits requesting_agent.
+                peer_ok = await client.get(
+                    "/mesh/agents/writer/profile",
+                    headers={"Authorization": "Bearer tok-peer"},
+                )
+                assert peer_ok.status_code == 200, peer_ok.text
+                assert peer_ok.json()["agent_id"] == "writer"
+
+                # Operator (verified Bearer identity == "operator") always gets it.
+                op_ok = await client.get(
+                    "/mesh/agents/writer/profile",
+                    headers={"Authorization": "Bearer tok-operator"},
+                )
+                assert op_ok.status_code == 200, op_ok.text
+    finally:
+        bb.close()
+        costs.close()
+        traces.close()

--- a/tests/test_slack.py
+++ b/tests/test_slack.py
@@ -194,6 +194,34 @@ class TestPairing:
 
 # ── message routing ─────────────────────────────────────────────
 
+class TestInboundLogging:
+    @pytest.mark.asyncio
+    async def test_inbound_message_text_not_logged_at_warning(self, caplog):
+        """L6: the pre-auth inbound log line must NOT emit the message body,
+        and must not be at WARNING. The handler logs only sender + length at
+        DEBUG."""
+        import logging
+
+        ch = _make_channel(paired={"owner": "U1", "allowed": ["U2"]})
+        say = _make_say()
+        secret = "super-secret-message-body-12345"
+        event = {"user": "U2", "text": secret, "channel": "C1", "ts": "1.0"}
+        with caplog.at_level(logging.DEBUG, logger="channels.slack"):
+            await ch._on_message(event, say)
+            await asyncio.sleep(0.05)
+        # The message body must never appear in any log record.
+        for rec in caplog.records:
+            assert secret not in rec.getMessage(), (
+                f"message body leaked in log: {rec.getMessage()!r}"
+            )
+        # No WARNING-level "Slack event received" line.
+        warnings = [
+            r for r in caplog.records
+            if r.levelno >= logging.WARNING and "Slack event received" in r.getMessage()
+        ]
+        assert not warnings, "inbound event logged at WARNING"
+
+
 class TestMessageRouting:
     @pytest.mark.asyncio
     async def test_message_dispatches_to_handle_message(self):

--- a/tests/test_templates.py
+++ b/tests/test_templates.py
@@ -256,7 +256,7 @@ class TestAddAgentPermissions(_TempConfigMixin):
             "can_spawn": True,
             "can_use_wallet": True,
             "can_manage_cron": True,  # not on the ceiling — should pass through
-        })
+        }, from_template=True)
         with open(self._perms_path) as f:
             perms = json.load(f)
         m = perms["permissions"]["mallory"]

--- a/tests/test_templates.py
+++ b/tests/test_templates.py
@@ -248,6 +248,23 @@ class TestAddAgentPermissions(_TempConfigMixin):
             "can_request_user_credentials", False,
         ) is False
 
+    def test_template_cannot_grant_can_spawn(self):
+        """L4: a template setting can_spawn=true must be clamped to false —
+        the irreversible-grant ceiling. Other template booleans still apply."""
+        _add_agent_to_config("mallory", "engineer", "openai/gpt-4o")
+        _add_agent_permissions("mallory", permissions={
+            "can_spawn": True,
+            "can_use_wallet": True,
+            "can_manage_cron": True,  # not on the ceiling — should pass through
+        })
+        with open(self._perms_path) as f:
+            perms = json.load(f)
+        m = perms["permissions"]["mallory"]
+        assert m.get("can_spawn") is False
+        assert m.get("can_use_wallet") is False
+        # Non-ceiling boolean still honored.
+        assert m.get("can_manage_cron") is True
+
     def test_template_permissions_merge_with_collab_defaults(self):
         """Template permissions add to collaboration defaults, not replace."""
         _add_agent_to_config("carol", "writer", "openai/gpt-4o")


### PR DESCRIPTION
May 2026 remediation of five findings (M24 / M2 / L4 / L5 / L6). Each fix is surgical and behavior-preserving for legitimate use. (Possible rebase needed.)

## M24 — profile endpoint `can_message` bypass
`src/host/server.py` `get_agent_profile` gated `can_message` only inside `if requesting_agent:`. Omitting the optional query hint fell through to `_require_any_auth`, leaking a peer's subscriptions / watch-keys / INTERFACE.md cross-team. Now the caller is resolved via `_extract_verified_agent_id(request)` **unconditionally** and the `can_message`/operator check applies to that verified identity. Operator short-circuit preserved; dev/test no-auth fall-through (`unknown`) preserved. The downstream runtime-field gate (`caller_for_gate`) is independent and unchanged.

## M2 — compaction summary re-injected without sanitization
`src/agent/context.py` `_summarize_compact` re-injects the LLM summary as a user message without `sanitize_for_prompt`, unlike the memory/bootstrap paths. Now wrapped in `sanitize_for_prompt` (Unicode hygiene — strips invisible/control chars; lossless for normal text, **not** an anti-injection control). Same applied to per-fact key/value flushed to MEMORY.md in `_extract_and_store_facts`.

## L4 — fleet template permissions bypass the operator ceiling
`src/cli/config.py` `_add_agent_permissions` set control booleans straight from a template's `permissions` dict. Added a minimal local `_TEMPLATE_PERMISSION_CEILING = {can_spawn, can_use_wallet}` clamp (mirrors `_OPERATOR_PERMISSION_CEILING`) — a template can no longer grant either (forced false + warning). None of the 13 shipped templates set these true → non-breaking.

## L5 — Discord guild allow-list didn't cover DMs
`src/channels/discord.py` skipped the guild check for DMs (no guild), so the allow-list was bypassable by DMing the bot. New `_dm_blocked_by_guild_restriction` helper: when `allowed_guilds` is set, an unpaired DM is dropped (no pairing flow). Already-paired DM users and in-guild messages unaffected.

## L6 — Slack logged full inbound text at WARNING before auth
`src/channels/slack.py` `_on_message` logged `user=%s text=%s` at WARNING **before** any auth/pairing check. Dropped to DEBUG, body removed (sender + length only).

## Tests
Added: M24 (worker omitting hint + lacking can_message denied; authorized peer + operator get 200), M2 (summary sanitized, visible text preserved), L4 (template can_spawn/can_use_wallet clamped), L5 (4 cases for the DM gate), L6 (no body, not WARNING). All relevant files pass: `test_mesh test_context test_templates test_discord test_slack` → 286 passed, 6 skipped. ruff clean.