### PR TITLE
fix(agent): never surface a blank chat reply (Bug 3)

### DIFF
--- a/src/agent/loop.py
+++ b/src/agent/loop.py
@@ -2542,7 +2542,21 @@ class AgentLoop:
                                 # the task STATUS stays ``done``). The genuine
                                 # ghost case — zero tools OR empty response —
                                 # still hard-fails below.
-                                if tool_outputs and response_text.strip():
+                                #
+                                # ``silent_reply`` guard: a synthetic empty-turn
+                                # marker (Bug 3) lands in ``response_text`` as
+                                # non-empty prose that literally says no text was
+                                # generated. ``_chat_inner`` is the only place that
+                                # sets ``silent_reply=True`` alongside a non-empty
+                                # response, so a marker turn must NOT be treated as
+                                # a genuine deferral explanation — otherwise a ghost
+                                # (read-only tools, originally empty) would slip
+                                # into the deferral carve-out instead of failing.
+                                if (
+                                    tool_outputs
+                                    and response_text.strip()
+                                    and not result.get("silent_reply")
+                                ):
                                     logger.info(
                                         "chat explained-deferral carve-out for "
                                         "handoff task=%s: outbound_effect=False "

--- a/src/agent/loop.py
+++ b/src/agent/loop.py
@@ -3038,7 +3038,7 @@ class AgentLoop:
         content = _extract_json_response(content)
         return content
 
-    async def _retry_empty_compose(self, system: str) -> tuple[str, int]:
+    async def _retry_empty_compose(self, system: str) -> tuple[str, int, bool]:
         """Bug 3 — single idempotent retry of the final compose call.
 
         When a chat turn's final text comes back empty (but it was NOT a
@@ -3050,17 +3050,34 @@ class AgentLoop:
         wraps transient transport errors; this adds exactly ONE extra
         compose attempt on top, never a loop.
 
-        Returns ``(content, tokens_used)``. ``content`` is the resolved
-        (non-silent) text, or ``""`` when the retry also came back empty
-        or was a deliberate ``__SILENT__`` reply. Typed credential errors
-        (``LLMAuthError`` / ``LLMConfigError``) are RE-RAISED so the
-        ``auth_failure`` / ``config_error`` taxonomy is preserved — both
-        call sites run inside a ``try`` whose typed arms surface those
-        flags (non-stream: ``auth_failure`` / ``config_error`` result
-        dicts; streaming: the matching ``done`` events). Only transient /
-        transport errors degrade to ``("", 0)``. Callers add the recovered
-        text to ``self._chat_messages`` themselves so the retry stays a
-        pure read here, and fold ``tokens_used`` into the turn total.
+        Returns the tri-state ``(content, tokens_used, deliberate_silence)``:
+
+        - ``content`` is the resolved (non-silent) text, or ``""`` when the
+          retry came back empty / blank, or when it was a deliberate
+          ``__SILENT__`` reply.
+        - ``tokens_used`` is the retry's token cost (folded into the turn
+          total by the caller).
+        - ``deliberate_silence`` is ``True`` ONLY when the retry itself
+          emitted ``__SILENT__`` — in that case the tuple is
+          ``("", tokens, True)`` and the caller MUST keep the turn silent
+          (empty reply, NO marker). This is the bit that distinguishes a
+          deliberately-silent retry from an empty/blip retry: without it
+          the caller can't tell them apart and would paper a deliberate
+          ``__SILENT__`` over with a synthetic marker.
+
+        ``_resolve_content`` is what SETS the ``__silent_reply__`` flag, so
+        it must run BEFORE the flag is read — hence the resolve-then-check
+        ordering below.
+
+        Typed credential errors (``LLMAuthError`` / ``LLMConfigError``) are
+        RE-RAISED so the ``auth_failure`` / ``config_error`` taxonomy is
+        preserved — both call sites run inside a ``try`` whose typed arms
+        surface those flags (non-stream: ``auth_failure`` / ``config_error``
+        result dicts; streaming: the matching ``done`` events). Only
+        transient / transport errors degrade to ``("", 0, False)``. Callers
+        add the recovered text to ``self._chat_messages`` themselves so the
+        retry stays a pure read here, and fold ``tokens_used`` into the turn
+        total.
         """
         try:
             llm_response = await _llm_call_with_retry(
@@ -3073,13 +3090,16 @@ class AgentLoop:
             raise  # preserve the auth_failure/config_error taxonomy
         except Exception as e:
             logger.warning("Bug 3 empty-compose retry failed: %s", e)
-            return "", 0
+            return "", 0, False
         tokens = llm_response.tokens_used
+        # Resolve FIRST — ``_resolve_content`` is what sets the
+        # ``__silent_reply__`` flag when the model emits ``__SILENT__``.
+        content = self._resolve_content(llm_response)
         # Deliberate silence on the retry is honoured — do NOT paper over
         # a model that explicitly chose ``__SILENT__`` the second time.
         if llm_response.__dict__.get("__silent_reply__"):
-            return "", tokens
-        return self._resolve_content(llm_response), tokens
+            return "", tokens, True
+        return content, tokens, False
 
     # ── Non-streaming chat ────────────────────────────────────
 
@@ -3169,10 +3189,14 @@ class AgentLoop:
                     )
                     marker_substituted = False
                     if not content.strip() and not deliberate_silence:
-                        retried, retry_tokens = await self._retry_empty_compose(system)
+                        retried, retry_tokens, retry_silent = await self._retry_empty_compose(system)
                         total_tokens += retry_tokens
                         if retried.strip():
                             content = retried
+                        elif retry_silent:
+                            # Model deliberately chose ``__SILENT__`` on the
+                            # retry — honour it (empty reply, no marker).
+                            deliberate_silence = True
                         else:
                             content = self._synthesize_empty_chat_fallback(tool_outputs)
                             marker_substituted = True
@@ -3955,17 +3979,24 @@ class AgentLoop:
                         llm_response.__dict__.get("__silent_reply__")
                     )
                     if not full_content.strip() and not deliberate_silence:
-                        retried, retry_tokens = await self._retry_empty_compose(system)
+                        retried, retry_tokens, retry_silent = await self._retry_empty_compose(system)
                         total_tokens += retry_tokens
                         if retried.strip():
                             full_content = retried
-                            # The retried text was never streamed (the
-                            # compose ran non-streaming) — append it to
-                            # the assistant message and emit it now.
-                            self._chat_messages[-1]["content"] = full_content
+                        elif retry_silent:
+                            # Model deliberately chose ``__SILENT__`` on the
+                            # retry — honour it: keep the turn silent, emit
+                            # no text_delta, leave full_content empty.
+                            full_content = ""
                         else:
                             full_content = self._synthesize_empty_chat_fallback(tool_outputs)
-                        yield {"type": "text_delta", "content": full_content}
+                        if full_content:
+                            # The retried text / marker was never streamed (the
+                            # compose ran non-streaming) — sync it into the
+                            # in-memory assistant message (matches the
+                            # non-stream path) and emit it now.
+                            self._chat_messages[-1]["content"] = full_content
+                            yield {"type": "text_delta", "content": full_content}
                     self._log_chat_turn(
                         user_message, full_content, tool_outputs,
                         turn_id=turn_id,

--- a/src/agent/loop.py
+++ b/src/agent/loop.py
@@ -3037,11 +3037,16 @@ class AgentLoop:
         compose attempt on top, never a loop.
 
         Returns ``(content, tokens_used)``. ``content`` is the resolved
-        (non-silent) text, or ``""`` when the retry also came back empty,
-        was a deliberate ``__SILENT__`` reply, or raised. Callers add the
-        recovered text to ``self._chat_messages`` themselves so the retry
-        stays a pure read here, and fold ``tokens_used`` into the turn
-        total.
+        (non-silent) text, or ``""`` when the retry also came back empty
+        or was a deliberate ``__SILENT__`` reply. Typed credential errors
+        (``LLMAuthError`` / ``LLMConfigError``) are RE-RAISED so the
+        ``auth_failure`` / ``config_error`` taxonomy is preserved — both
+        call sites run inside a ``try`` whose typed arms surface those
+        flags (non-stream: ``auth_failure`` / ``config_error`` result
+        dicts; streaming: the matching ``done`` events). Only transient /
+        transport errors degrade to ``("", 0)``. Callers add the recovered
+        text to ``self._chat_messages`` themselves so the retry stays a
+        pure read here, and fold ``tokens_used`` into the turn total.
         """
         try:
             llm_response = await _llm_call_with_retry(
@@ -3050,6 +3055,8 @@ class AgentLoop:
                 messages=self._chat_messages,
                 tools=None,
             )
+        except (LLMAuthError, LLMConfigError):
+            raise  # preserve the auth_failure/config_error taxonomy
         except Exception as e:
             logger.warning("Bug 3 empty-compose retry failed: %s", e)
             return "", 0

--- a/src/agent/loop.py
+++ b/src/agent/loop.py
@@ -2604,38 +2604,41 @@ class AgentLoop:
                                     task_id, "done",
                                     result_payload={"summary": summary},
                                 )
-                    # Bug 3 fallback: when the LLM produced zero text but
-                    # ran tool calls, the dashboard would render an empty
-                    # chat panel even though work happened (notify_user,
-                    # workflow_snapshot, etc.). Surface a synthetic
-                    # response so the user sees that the turn DID execute.
-                    # Only fires for non-handoff chats (handoff lazy
-                    # completion was already handled above) and only when
-                    # tool_outputs is non-empty (a truly silent LLM
-                    # response in a no-tool chat is a different problem
-                    # and shouldn't be papered over).
-                    if not task_id:
-                        if (
-                            not (result.get("response") or "").strip()
-                            and result.get("tool_outputs")
-                            and not result.get("silent_reply")
-                            and not result.get("tool_limit_reached")
-                        ):
-                            tool_outputs = result.get("tool_outputs") or []
-                            logger.warning(
-                                "chat empty-response fallback: %d tool "
-                                "call(s) executed but LLM produced no "
-                                "final text — surfacing synthetic notice",
-                                len(tool_outputs),
-                            )
-                            # Single source of truth for the wording —
-                            # ``_log_chat_turn`` writes the same string
-                            # to the transcript so the dashboard chat
-                            # view and ``/chat/history`` agree after a
-                            # page refresh.
-                            result["response"] = (
-                                self._synthesize_empty_chat_fallback(tool_outputs)
-                            )
+                    # Bug 3 final net: a chat turn must never surface an
+                    # empty reply unless the model deliberately chose
+                    # ``__SILENT__``. ``_chat_inner`` already retries the
+                    # compose once (tools withheld) and substitutes a
+                    # marker on every exit — normal, tool-limit, and the
+                    # zero-tools case — REGARDLESS of ``task_id`` /
+                    # ``tool_limit_reached``, setting ``silent_reply`` on
+                    # the marker path so we can distinguish it here. This
+                    # block is the belt-and-suspenders backstop: if a
+                    # response still came back empty without the silence
+                    # flag (e.g. a future code path that bypasses the
+                    # inner substitution), stamp the marker so the user
+                    # never sees a blank bubble. It now fires regardless
+                    # of ``task_id`` and even with zero tool_outputs (the
+                    # marker is generic in that case — see
+                    # ``_synthesize_empty_chat_fallback``).
+                    if (
+                        not (result.get("response") or "").strip()
+                        and not result.get("silent_reply")
+                    ):
+                        tool_outputs = result.get("tool_outputs") or []
+                        logger.warning(
+                            "chat empty-response final net tripped: %d tool "
+                            "call(s) executed but response still empty after "
+                            "inner retry/marker — surfacing synthetic notice",
+                            len(tool_outputs),
+                        )
+                        # Single source of truth for the wording —
+                        # ``_log_chat_turn`` writes the same string to the
+                        # transcript so the dashboard chat view and
+                        # ``/chat/history`` agree after a page refresh.
+                        result["response"] = (
+                            self._synthesize_empty_chat_fallback(tool_outputs)
+                        )
+                        result["silent_reply"] = True
                     return result
                 finally:
                     await self._checkpoint_chat_session()
@@ -3021,6 +3024,42 @@ class AgentLoop:
         content = _extract_json_response(content)
         return content
 
+    async def _retry_empty_compose(self, system: str) -> tuple[str, int]:
+        """Bug 3 — single idempotent retry of the final compose call.
+
+        When a chat turn's final text comes back empty (but it was NOT a
+        deliberate ``__SILENT__`` reply and NOT an auth/config/exception
+        error turn), re-ask the model ONCE with ``tools=None`` so it
+        cannot emit more tool calls and must produce prose. This is a
+        side-effect-free recovery: the messages are unchanged, only a
+        fresh completion is requested. ``_llm_call_with_retry`` still
+        wraps transient transport errors; this adds exactly ONE extra
+        compose attempt on top, never a loop.
+
+        Returns ``(content, tokens_used)``. ``content`` is the resolved
+        (non-silent) text, or ``""`` when the retry also came back empty,
+        was a deliberate ``__SILENT__`` reply, or raised. Callers add the
+        recovered text to ``self._chat_messages`` themselves so the retry
+        stays a pure read here, and fold ``tokens_used`` into the turn
+        total.
+        """
+        try:
+            llm_response = await _llm_call_with_retry(
+                self.llm.chat,
+                system=system,
+                messages=self._chat_messages,
+                tools=None,
+            )
+        except Exception as e:
+            logger.warning("Bug 3 empty-compose retry failed: %s", e)
+            return "", 0
+        tokens = llm_response.tokens_used
+        # Deliberate silence on the retry is honoured — do NOT paper over
+        # a model that explicitly chose ``__SILENT__`` the second time.
+        if llm_response.__dict__.get("__silent_reply__"):
+            return "", tokens
+        return self._resolve_content(llm_response), tokens
+
     # ── Non-streaming chat ────────────────────────────────────
 
     async def _chat_inner(self, user_message: str) -> dict:
@@ -3100,6 +3139,22 @@ class AgentLoop:
                         self._chat_total_rounds += 1
                         await self._compact_chat_context(system)
                         continue
+                    # Bug 3 — the turn produced no final text. Distinguish
+                    # a deliberate ``__SILENT__`` reply (honoured: empty,
+                    # no retry, no marker) from an accidental empty turn
+                    # (retry compose once, then fall back to a marker).
+                    deliberate_silence = bool(
+                        llm_response.__dict__.get("__silent_reply__")
+                    )
+                    marker_substituted = False
+                    if not content.strip() and not deliberate_silence:
+                        retried, retry_tokens = await self._retry_empty_compose(system)
+                        total_tokens += retry_tokens
+                        if retried.strip():
+                            content = retried
+                        else:
+                            content = self._synthesize_empty_chat_fallback(tool_outputs)
+                            marker_substituted = True
                     self._chat_messages.append({"role": "assistant", "content": content})
                     self._log_chat_turn(user_message, content, tool_outputs, turn_id=turn_id)
                     if tool_outputs and self.workspace:
@@ -3117,10 +3172,16 @@ class AgentLoop:
                         "tool_outputs": tool_outputs,
                         "tokens_used": total_tokens,
                     }
-                    if llm_response.__dict__.get("__silent_reply__"):
+                    if deliberate_silence:
                         # Mark a deliberate ``__SILENT__`` reply so the
                         # chat() empty-response fallback doesn't
                         # paper over it with a synthetic notice.
+                        result_dict["silent_reply"] = True
+                    elif marker_substituted:
+                        # Empty-turn marker substituted above. Flag so the
+                        # dashboard can badge "recovered from empty-text
+                        # turn"; reuses ``silent_reply`` (the dashboard's
+                        # existing "no live bubble to render" signal).
                         result_dict["silent_reply"] = True
                     return result_dict
 
@@ -3238,6 +3299,17 @@ class AgentLoop:
             )
             total_tokens += llm_response.tokens_used
             content = self._resolve_content(llm_response)
+            # Bug 3 — even the force-compose exit can come back empty. The
+            # call above already withheld tools, so it IS the compose
+            # retry: do NOT stack another ``_retry_empty_compose`` on top
+            # (that would double-retry the identical request). Honour a
+            # deliberate ``__SILENT__`` reply; otherwise substitute the
+            # marker so the user never sees a blank turn.
+            deliberate_silence = bool(llm_response.__dict__.get("__silent_reply__"))
+            marker_substituted = False
+            if not content.strip() and not deliberate_silence:
+                content = self._synthesize_empty_chat_fallback(tool_outputs)
+                marker_substituted = True
             self._chat_messages.append({"role": "assistant", "content": content})
             self._log_chat_turn(user_message, content, tool_outputs, turn_id=turn_id)
             if tool_outputs and self.workspace:
@@ -3256,7 +3328,7 @@ class AgentLoop:
                 "tokens_used": total_tokens,
                 "tool_limit_reached": True,
             }
-            if llm_response.__dict__.get("__silent_reply__"):
+            if deliberate_silence or marker_substituted:
                 tool_limit_result["silent_reply"] = True
             return tool_limit_result
 
@@ -3322,18 +3394,27 @@ class AgentLoop:
     def _synthesize_empty_chat_fallback(
         tool_outputs: list[dict] | None,
     ) -> str:
-        """Build the synthetic notice for an LLM turn that ran tools but
-        emitted no final text. Single source of truth so the dashboard
-        chat panel (live `done` event) and the persisted transcript
-        (`/chat/history` after refresh) carry identical text — without
-        this helper the two diverged and the operator's reply appeared
-        to vanish on page refresh.
+        """Build the synthetic notice for a chat turn that emitted no
+        final text. Single source of truth so the dashboard chat panel
+        (live `done` event) and the persisted transcript (`/chat/history`
+        after refresh) carry identical text — without this helper the two
+        diverged and the operator's reply appeared to vanish on page
+        refresh.
 
-        Returns ``""`` when there are no tools (truly silent LLM —
-        different problem, not papered over here).
+        Bug 3 — NEVER returns ``""``. With tools, the notice points the
+        user at the dashboard for the tool results. With ZERO tools, an
+        empty final text is almost always a transient model hiccup (the
+        retry-compose path already exhausted its one retry by the time we
+        get here), so we surface a generic re-send prompt rather than a
+        blank bubble. Deliberate ``__SILENT__`` replies are filtered out
+        by the callers BEFORE reaching this helper, so a generic marker
+        here can never paper over an intentional silence.
         """
         if not tool_outputs:
-            return ""
+            return (
+                "(No response was generated for this turn — likely a "
+                "transient model issue. Please re-send your message.)"
+            )
         n = len(tool_outputs)
         word = "tool call" if n == 1 else "tool calls"
         return (
@@ -3410,7 +3491,15 @@ class AgentLoop:
         # fallback so the transcript reflects what the dashboard saw
         # for this turn. Without this the assistant entry was skipped
         # entirely and a page refresh lost the turn's persistence.
-        if not assistant_msg.strip():
+        #
+        # Bug 3 — only substitute when there ARE tool_outputs. The
+        # ``_chat_inner`` / ``_chat_stream_inner`` retry-then-marker paths
+        # already pass the resolved text (recovered prose OR the marker)
+        # as ``assistant_msg``, so a genuinely empty ``assistant_msg``
+        # reaching here means a deliberate ``__SILENT__`` reply (no tools)
+        # — which must stay unlogged. Substituting the (now never-empty)
+        # generic no-tools marker here would wrongly persist silent turns.
+        if not assistant_msg.strip() and tool_outputs:
             assistant_msg = self._synthesize_empty_chat_fallback(tool_outputs)
         # Skip logging only for genuinely silent responses (SILENT
         # token, no tools called — there is nothing to persist).
@@ -3833,14 +3922,29 @@ class AgentLoop:
                     # Use accumulated text from all rounds for the transcript
                     # so intermediate messages are preserved after refresh.
                     full_content = "".join(accumulated_text) if accumulated_text else content
-                    # Empty final text + tools ran: synthesize the same
-                    # fallback the transcript will store so the live
-                    # ``done`` event and the post-refresh history agree
-                    # on what the user sees for this turn.
-                    if not full_content.strip() and tool_outputs:
-                        full_content = self._synthesize_empty_chat_fallback(tool_outputs)
-                        if full_content:
-                            yield {"type": "text_delta", "content": full_content}
+                    # Bug 3 — empty final text and NOT a deliberate
+                    # ``__SILENT__`` reply: retry the compose once (tools
+                    # withheld), then fall back to a marker. The recovered
+                    # text or the marker MUST be emitted as a text_delta
+                    # so the user actually sees it (not merely placed in
+                    # the ``done`` envelope). Applies regardless of
+                    # whether tool_outputs is empty — the marker is
+                    # generic in the no-tools case.
+                    deliberate_silence = bool(
+                        llm_response.__dict__.get("__silent_reply__")
+                    )
+                    if not full_content.strip() and not deliberate_silence:
+                        retried, retry_tokens = await self._retry_empty_compose(system)
+                        total_tokens += retry_tokens
+                        if retried.strip():
+                            full_content = retried
+                            # The retried text was never streamed (the
+                            # compose ran non-streaming) — append it to
+                            # the assistant message and emit it now.
+                            self._chat_messages[-1]["content"] = full_content
+                        else:
+                            full_content = self._synthesize_empty_chat_fallback(tool_outputs)
+                        yield {"type": "text_delta", "content": full_content}
                     self._log_chat_turn(
                         user_message, full_content, tool_outputs,
                         turn_id=turn_id,
@@ -3993,13 +4097,18 @@ class AgentLoop:
                 yield {"type": "text_delta", "content": content}
             self._chat_messages.append({"role": "assistant", "content": content})
             full_content = "".join(accumulated_text) if accumulated_text else content
-            # Same empty-final-text-with-tools fallback as the no-tool-
-            # calls path above — keep the transcript and the streaming
-            # ``done`` event in sync after a max-rounds force-final.
-            if not full_content.strip() and tool_outputs:
+            # Bug 3 — the force-compose call above already withheld tools,
+            # so it IS the compose retry; do NOT stack another
+            # ``_retry_empty_compose`` (that would double-retry the same
+            # request). Honour a deliberate ``__SILENT__`` reply;
+            # otherwise substitute the marker and emit it as a text_delta
+            # so the user never sees a blank turn. Applies regardless of
+            # whether tool_outputs is empty (generic marker in that case).
+            deliberate_silence = bool(llm_response.__dict__.get("__silent_reply__"))
+            if not full_content.strip() and not deliberate_silence:
                 full_content = self._synthesize_empty_chat_fallback(tool_outputs)
-                if full_content:
-                    yield {"type": "text_delta", "content": full_content}
+                self._chat_messages[-1]["content"] = full_content
+                yield {"type": "text_delta", "content": full_content}
             self._log_chat_turn(
                 user_message, full_content, tool_outputs, turn_id=turn_id,
             )

--- a/tests/test_loop.py
+++ b/tests/test_loop.py
@@ -20,7 +20,13 @@ from src.agent.loop import (
     AgentLoop,
     _heartbeat_mode,
 )
-from src.shared.types import LLMResponse, TaskAssignment, TokenBudget, ToolCallInfo
+from src.shared.types import (
+    SILENT_REPLY_TOKEN,
+    LLMResponse,
+    TaskAssignment,
+    TokenBudget,
+    ToolCallInfo,
+)
 
 # Audit-pass: ``_has_outbound_effect`` was moved from module-level to a
 # ``@staticmethod`` on ``AgentLoop`` so it sits with the other lazy-
@@ -813,21 +819,30 @@ async def test_non_silent_reply_passes_through():
 
 @pytest.mark.asyncio
 async def test_silent_token_after_tool_rounds_exhausted():
-    """__SILENT__ at max-rounds fallback should also be suppressed."""
-    # Use different arguments each round to avoid triggering loop detection
+    """__SILENT__ at the max-rounds force-compose exit must be honoured:
+    empty reply, NO Bug-3 marker substituted.
+
+    The loop runs ``CHAT_MAX_TOOL_ROUNDS`` tool rounds (consuming that
+    many tool-call responses), breaks, then issues the force-compose
+    call with ``tools=None`` — so the response that lands AT the
+    force-compose exit must itself be the ``__SILENT__`` reply for this
+    to exercise deliberate silence there.
+    """
+    loop = _make_loop()
+    n = loop.CHAT_MAX_TOOL_ROUNDS
+    # Use different arguments each round to avoid triggering loop detection.
     responses = [
         LLMResponse(
             content="",
             tool_calls=[ToolCallInfo(name="search", arguments={"q": f"q_{i}"})],
             tokens_used=10,
         )
-        for i in range(31)
+        for i in range(n)
     ]
-    # Fill CHAT_MAX_TOOL_ROUNDS with tool calls, then final __SILENT__
-    silent_final = LLMResponse(content="__SILENT__", tokens_used=10)
-    responses.append(silent_final)
-
-    loop = _make_loop(responses)
+    # The (n+1)th call is the force-compose (tools withheld) — make it
+    # the deliberate ``__SILENT__`` reply.
+    responses.append(LLMResponse(content="__SILENT__", tokens_used=10))
+    loop.llm.chat = AsyncMock(side_effect=responses)
     loop.skills.get_tool_definitions = MagicMock(
         return_value=[{"type": "function", "function": {"name": "search"}}]
     )
@@ -2920,11 +2935,12 @@ class TestLoopLLMErrorHandling:
 
 
 class TestChatEmptyResponseFallback:
-    """When the LLM produces zero final text but ran tool calls, the chat
-    return value gets a synthetic notice so the dashboard renders the
-    turn (instead of a blank panel). Only fires for non-handoff chats
-    (``task_id is None``). Handoff turns route through the lazy-completion
-    guard above and the fallback must NOT also run there."""
+    """When the LLM produces zero final text, the chat return value gets a
+    synthetic notice so the dashboard renders the turn (instead of a blank
+    panel). Bug 3: this now fires REGARDLESS of task_id / tool_limit and
+    even with zero tool_outputs (generic marker in that case). Deliberate
+    ``__SILENT__`` replies are still preserved (``silent_reply`` set
+    upstream) and are NOT papered over."""
 
     @pytest.mark.asyncio
     async def test_chat_empty_response_with_tools_gets_fallback(self):
@@ -2946,9 +2962,13 @@ class TestChatEmptyResponseFallback:
         assert "2 tool calls" in result["response"]
 
     @pytest.mark.asyncio
-    async def test_chat_empty_response_no_tools_unchanged(self):
-        """A truly silent no-tool LLM turn is a different problem and
-        must NOT be papered over by the fallback."""
+    async def test_chat_empty_response_no_tools_gets_generic_marker(self):
+        """Bug 3 (updated contract): a no-tool empty turn that is NOT a
+        deliberate ``__SILENT__`` reply must NOT surface a blank bubble.
+        The ``chat()`` final net substitutes the generic (no-tools)
+        marker and flags ``silent_reply``. Deliberate silence is handled
+        upstream in ``_chat_inner`` (it sets ``silent_reply`` so this net
+        leaves it alone — covered by the silent-token tests)."""
         loop = _make_loop()
 
         async def fake_inner(_msg):
@@ -2956,16 +2976,17 @@ class TestChatEmptyResponseFallback:
         loop._chat_inner = fake_inner
 
         result = await loop.chat("hi")
-        assert result["response"] == ""
-        assert result["tool_outputs"] == []
+        assert result["response"].startswith("(No response")
+        assert result.get("silent_reply") is True
 
     @pytest.mark.asyncio
-    async def test_chat_with_task_id_skips_fallback(self):
-        """Handoff (task_id) path: the lazy-completion guard fires
-        instead. An empty response with tool_outputs in task_id mode
-        means a handoff that produced no structured result; auto-close
-        as ``done`` runs above, and the synthetic fallback must NOT
-        rewrite ``response``."""
+    async def test_chat_with_task_id_still_rescued(self):
+        """Bug 3 (updated contract): the empty-response rescue is NO
+        LONGER gated on ``not task_id``. A handoff (task_id) turn that
+        ends empty with tool_outputs must also be rescued so the user
+        never sees a blank reply. ``_chat_inner`` normally substitutes
+        the marker; here we fake an empty inner result to prove the
+        ``chat()`` final net rescues it even in task_id mode."""
         loop = _make_loop()
 
         async def fake_inner(_msg):
@@ -2977,20 +2998,15 @@ class TestChatEmptyResponseFallback:
         loop._chat_inner = fake_inner
 
         # Mock the auto-close pipeline so the test doesn't depend on
-        # mesh round-trips. We just want to assert the chat-mode
-        # synthetic-response fallback does NOT fire for task_id chats.
+        # mesh round-trips.
         loop._auto_close_task = AsyncMock(return_value=None)
 
         result = await loop.chat("hi", task_id="task_X")
 
-        # The chat-mode synthetic fallback (which mentions "Completed N
-        # tool calls") must NOT have fired.
-        assert "Completed" not in (result.get("response") or "")
-        assert "tool calls" not in (result.get("response") or "")
-        # The lazy-completion guard ran for the task. With non-empty
-        # tool_outputs and an empty response, the guard goes through
-        # the "did work" branch and auto-closes as ``done``.
-        loop._auto_close_task.assert_awaited()
+        # The rescue fires regardless of task_id — response is non-empty.
+        assert result["response"].strip() != ""
+        assert "Completed" in result["response"]
+        assert result.get("silent_reply") is True
 
     # --- Transcript-persistence regression tests (chat refresh bug) ---
     #
@@ -3033,8 +3049,10 @@ class TestChatEmptyResponseFallback:
 
     def test_log_chat_turn_skips_when_empty_and_no_tools(self, tmp_path):
         """Truly silent turn (no text, no tools) — nothing to persist.
-        The fallback helper returns ``""``, the guard skips, no
-        assistant row lands in the transcript."""
+        Bug 3: ``_log_chat_turn`` only substitutes the marker when there
+        ARE tool_outputs, so a deliberate ``__SILENT__`` reply (empty
+        text, no tools) still skips persistence — no assistant row lands
+        in the transcript."""
         from src.agent.workspace import WorkspaceManager
 
         loop = _make_loop()
@@ -3049,10 +3067,12 @@ class TestChatEmptyResponseFallback:
         assert assistant_entries == []
 
     def test_synthesize_helper_pluralization(self):
-        """Pure-function contract on the helper. Empty/None → ``""``.
-        1 tool → singular "tool call". 2+ tools → plural "tool calls"."""
-        assert AgentLoop._synthesize_empty_chat_fallback(None) == ""
-        assert AgentLoop._synthesize_empty_chat_fallback([]) == ""
+        """Pure-function contract on the helper. Bug 3: Empty/None now
+        returns the GENERIC (no-tools) marker, never ``""``. 1 tool →
+        singular "tool call". 2+ tools → plural "tool calls"."""
+        generic = AgentLoop._synthesize_empty_chat_fallback(None)
+        assert generic.startswith("(No response")
+        assert AgentLoop._synthesize_empty_chat_fallback([]) == generic
 
         one = AgentLoop._synthesize_empty_chat_fallback([{"tool": "x"}])
         assert "1 tool call" in one
@@ -3796,3 +3816,167 @@ class TestChatExceptionPathsFinalizeCleanly:
             "finalize must receive the turn's turn_id so the partial "
             "supersedes cleanly"
         )
+
+
+# ── Bug 3: empty-chat-turn recovery (retry-then-marker) ──────────────
+#
+# A chat turn that runs tools (or even none) but produces no final text
+# must NEVER surface a blank reply unless the model deliberately emitted
+# ``__SILENT__``. ``_chat_inner`` / ``_chat_stream_inner`` retry the
+# final compose once with tools withheld; if still empty they substitute
+# a marker via ``_synthesize_empty_chat_fallback`` and flag the result
+# with ``silent_reply`` so the dashboard can badge the recovery. These
+# tests pin that contract across BOTH surfaces, regardless of task_id /
+# tool_limit_reached, and confirm deliberate silence is preserved.
+
+
+def _resp(content, tool_calls=None, tokens=10):
+    return LLMResponse(content=content, tool_calls=tool_calls, tokens_used=tokens)
+
+
+def _empty_after_tools_loop(final_responses):
+    """An AgentLoop wired so round 1 calls a tool, then subsequent
+    responses are returned in order. One tool round populates
+    ``tool_outputs`` before the empty/recovery exit."""
+    tool_call = ToolCallInfo(name="search", arguments={"q": "x"})
+    responses = [_resp("", tool_calls=[tool_call])] + list(final_responses)
+    loop = _make_loop(responses)
+    loop.skills.get_tool_definitions = MagicMock(return_value=[{"name": "search"}])
+    loop.skills.execute = AsyncMock(return_value={"ok": True})
+    return loop
+
+
+@pytest.mark.asyncio
+async def test_empty_chat_after_tools_retry_succeeds_returns_recovered_text():
+    """Empty final text after tools, retry yields prose → that prose is
+    the response; no marker; ``silent_reply`` not set."""
+    # round 1: tool call. round 2: empty final → triggers retry.
+    # retry compose (tools withheld): real text.
+    loop = _empty_after_tools_loop([_resp(""), _resp("Recovered answer")])
+    result = await loop.chat("ping")
+    assert result["response"] == "Recovered answer"
+    assert result.get("silent_reply") is not True
+    assert loop._chat_messages[-1]["content"] == "Recovered answer"
+
+
+@pytest.mark.asyncio
+async def test_empty_chat_after_tools_retry_also_empty_returns_marker():
+    """Empty final text after tools, retry also empty → marker response,
+    ``silent_reply`` True."""
+    loop = _empty_after_tools_loop([_resp(""), _resp("")])
+    result = await loop.chat("ping")
+    assert "Completed" in result["response"]
+    assert "tool call" in result["response"]
+    assert result.get("silent_reply") is True
+
+
+@pytest.mark.asyncio
+async def test_empty_chat_after_tools_with_task_id_is_rescued():
+    """task_id set must NOT gate the rescue (the old gate is removed):
+    the response is non-empty (recovered text or marker)."""
+    loop = _empty_after_tools_loop([_resp(""), _resp("")])
+    loop._auto_close_task = AsyncMock(return_value=None)
+    result = await loop.chat("ping", task_id="task-123")
+    assert result["response"].strip() != ""
+
+
+@pytest.mark.asyncio
+async def test_empty_chat_tool_limit_reached_is_rescued():
+    """The tool-limit force-compose exit must also be rescued — an empty
+    forced compose yields the marker, not a blank reply."""
+    loop = _make_loop()
+    loop.CHAT_MAX_TOOL_ROUNDS = 2
+    tool_call = ToolCallInfo(name="search", arguments={"q": "x"})
+    responses = [
+        _resp("", tool_calls=[tool_call]),
+        _resp("", tool_calls=[tool_call]),
+        _resp(""),  # force-final compose: empty
+    ]
+    loop.llm.chat = AsyncMock(side_effect=responses)
+    loop.skills.get_tool_definitions = MagicMock(return_value=[{"name": "search"}])
+    loop.skills.execute = AsyncMock(return_value={"ok": True})
+    result = await loop.chat("ping")
+    assert result.get("tool_limit_reached") is True
+    assert result["response"].strip() != ""
+    assert result.get("silent_reply") is True
+
+
+@pytest.mark.asyncio
+async def test_empty_chat_zero_tools_retry_empty_returns_generic_marker():
+    """Empty final text, ZERO tool_outputs, retry also empty → the
+    generic (no-tools) marker, never an empty string."""
+    # round 1 (no tools): empty → retry. retry: empty.
+    loop = _make_loop([_resp(""), _resp("")])
+    result = await loop.chat("ping")
+    assert result["response"].startswith("(No response")
+    assert result.get("silent_reply") is True
+    assert result["response"] != ""
+
+
+@pytest.mark.asyncio
+async def test_deliberate_silent_after_tools_not_rescued_and_no_retry():
+    """A deliberate ``__SILENT__`` final (after a tool round) yields an
+    empty reply with NO marker, and the retry compose is NOT called
+    (proven by the LLM mock call count)."""
+    loop = _empty_after_tools_loop([_resp(SILENT_REPLY_TOKEN)])
+    result = await loop.chat("ping")
+    assert result["response"] == ""
+    assert result.get("silent_reply") is True
+    # 2 calls only: round-1 tool call + the silent final. No 3rd retry.
+    assert loop.llm.chat.call_count == 2
+
+
+@pytest.mark.asyncio
+async def test_normal_nonempty_response_unchanged():
+    """A normal text reply is returned unchanged (regression guard) and
+    the retry compose is never invoked."""
+    loop = _make_loop([_resp("All good.")])
+    result = await loop.chat("ping")
+    assert result["response"] == "All good."
+    assert result.get("silent_reply") is not True
+    assert loop.llm.chat.call_count == 1
+
+
+@pytest.mark.asyncio
+async def test_stream_empty_after_tools_emits_marker_text_event():
+    """Streaming: empty final text after tools (retry also empty) emits a
+    text_delta carrying the marker AND the done event carries it too."""
+    tool_call = ToolCallInfo(name="search", arguments={"q": "x"})
+    responses = [
+        _resp("", tool_calls=[tool_call]),  # round 1: tool call
+        _resp(""),                          # round 2: empty final
+        _resp(""),                          # retry compose: empty
+    ]
+    loop = _make_loop(responses)
+    # Force the non-streaming fallback path: chat_stream raises so the
+    # loop falls back to ``self.llm.chat`` (our AsyncMock side_effect).
+    loop.llm.chat_stream = MagicMock(side_effect=RuntimeError("no stream"))
+    loop.skills.get_tool_definitions = MagicMock(return_value=[{"name": "search"}])
+    loop.skills.execute = AsyncMock(return_value={"ok": True})
+    events = [ev async for ev in loop.chat_stream("ping")]
+    text_events = [e for e in events if e.get("type") == "text_delta"]
+    done_events = [e for e in events if e.get("type") == "done"]
+    assert any("Completed" in (e.get("content") or "") for e in text_events)
+    assert done_events
+    assert "Completed" in (done_events[-1].get("response") or "")
+
+
+@pytest.mark.asyncio
+async def test_stream_empty_after_tools_retry_succeeds_emits_recovered_text():
+    """Streaming: empty final text after tools, retry yields prose → a
+    text_delta and done carry the recovered prose, not a marker."""
+    tool_call = ToolCallInfo(name="search", arguments={"q": "x"})
+    responses = [
+        _resp("", tool_calls=[tool_call]),   # round 1: tool call
+        _resp(""),                           # round 2: empty final
+        _resp("Streamed recovery"),          # retry compose: prose
+    ]
+    loop = _make_loop(responses)
+    loop.llm.chat_stream = MagicMock(side_effect=RuntimeError("no stream"))
+    loop.skills.get_tool_definitions = MagicMock(return_value=[{"name": "search"}])
+    loop.skills.execute = AsyncMock(return_value={"ok": True})
+    events = [ev async for ev in loop.chat_stream("ping")]
+    text_events = [e for e in events if e.get("type") == "text_delta"]
+    done_events = [e for e in events if e.get("type") == "done"]
+    assert any("Streamed recovery" in (e.get("content") or "") for e in text_events)
+    assert done_events[-1]["response"] == "Streamed recovery"

--- a/tests/test_loop.py
+++ b/tests/test_loop.py
@@ -4131,3 +4131,48 @@ async def test_stream_deliberate_silence_not_retried():
     )
     done = [e for e in events if e.get("type") == "done"]
     assert done and done[-1].get("response") == ""
+
+
+@pytest.mark.asyncio
+async def test_retry_returns_silent_token_is_honoured_not_marked():
+    """Bug 3: the first no-tool reply is empty (an accidental blip, NOT the
+    silent token), so the empty-compose retry fires; the retry itself emits
+    ``__SILENT__``. That deliberate silence on the retry MUST be honoured:
+    empty response, ``silent_reply`` flagged, and NO marker substituted.
+
+    Before the tri-state fix the silence check in ``_retry_empty_compose``
+    was dead (the flag is set inside ``_resolve_content`` which ran AFTER
+    the check), so the retry's ``__SILENT__`` was stripped to ``""`` and the
+    caller papered it over with a marker — this test would FAIL.
+    """
+    loop = _make_loop([_resp(""), _resp(SILENT_REPLY_TOKEN)])
+    result = await loop._chat_inner("ping")
+    assert result["response"] == ""
+    assert result.get("silent_reply") is True
+    resp = (result.get("response") or "")
+    assert not resp.strip().startswith("(")
+    assert "no text response" not in resp.lower()
+    assert "no response" not in resp.lower()
+
+
+@pytest.mark.asyncio
+async def test_stream_retry_returns_silent_token_emits_no_marker():
+    """Bug 3 stream: first no-tool reply empty (blip), retry emits
+    ``__SILENT__``. The deliberate retry-silence is honoured: NO text_delta
+    marker is emitted (ideally no text_delta at all) and the final ``done``
+    event carries an empty ``response``.
+    """
+    loop = _make_loop([_resp(""), _resp(SILENT_REPLY_TOKEN)])
+    # Force the non-streaming fallback so llm.chat (our side_effect) drives it.
+    loop.llm.chat_stream = MagicMock(side_effect=RuntimeError("no stream"))
+    events = [ev async for ev in loop._chat_stream_inner("ping")]
+    text_events = [e for e in events if e.get("type") == "text_delta"]
+    assert text_events == []
+    assert all(
+        "no response" not in (e.get("content") or "").lower() for e in events
+    )
+    assert all(
+        "no text response" not in (e.get("content") or "").lower() for e in events
+    )
+    done = [e for e in events if e.get("type") == "done"]
+    assert done and done[-1].get("response") == ""

--- a/tests/test_loop.py
+++ b/tests/test_loop.py
@@ -3510,6 +3510,108 @@ class TestOutboundEffectLazyGuard:
         # summary feeds the done back-edge → originator's check_inbox
         assert payload.get("summary") == payload.get("reason")
 
+    @pytest.mark.asyncio
+    async def test_ghost_handoff_empty_response_closes_failed(self):
+        """Regression (don't-let-marker-mask-ghost): a handoff turn that
+        calls ONE read-only tool then produces NO final text is a ghost
+        completion. ``_chat_inner`` substitutes a synthetic empty-turn
+        marker into ``result["response"]`` (flagging ``silent_reply``).
+        The explained-deferral carve-out MUST ignore marker turns, so the
+        task auto-closes as ``failed`` (``no_outbound_effects``) — the
+        marker must NOT be mistaken for a genuine deferral explanation.
+
+        Drives the REAL ``_chat_inner`` (round 1: read-only tool call +
+        empty text; round 2: empty final → triggers the empty-compose
+        retry; retry: also empty → marker substituted) so the actual
+        marker/silent_reply interaction with the carve-out is exercised.
+        Without the ``not result.get("silent_reply")`` gate this closes as
+        ``done``/deferred instead — defeating the ghost guard.
+        """
+        read_only_call = ToolCallInfo(name="check_inbox", arguments={})
+        responses = [
+            _resp("", tool_calls=[read_only_call]),  # round 1: read-only tool
+            _resp(""),                               # round 2: empty final
+            _resp(""),                               # empty-compose retry: empty
+        ]
+        loop = _make_loop(responses)
+        loop.skills.get_tool_definitions = MagicMock(
+            return_value=[{"name": "check_inbox"}]
+        )
+        loop.skills.execute = AsyncMock(return_value={"events": []})
+        loop._auto_close_task = AsyncMock(return_value=None)
+
+        result = await loop.chat("hi", task_id="t-ghost")
+
+        # The marker was substituted (user never sees a blank bubble) —
+        # but the task STATUS must still be a ghost failure.
+        assert result.get("silent_reply") is True
+        assert result["response"].strip() != ""
+
+        terminal_calls = [
+            c for c in loop._auto_close_task.await_args_list
+            if len(c.args) >= 2 and c.args[1] in ("done", "failed")
+        ]
+        assert terminal_calls, (
+            "expected a terminal auto_close_task call, saw: "
+            f"{loop._auto_close_task.await_args_list}"
+        )
+        last_terminal = terminal_calls[-1]
+        assert last_terminal.args[1] == "failed", (
+            "ghost turn (read-only tool, empty real text → marker) must "
+            "close as 'failed', not 'done'/deferred; the synthetic marker "
+            "must not mask the ghost. calls: "
+            f"{loop._auto_close_task.await_args_list}"
+        )
+        assert last_terminal.args[0] == "t-ghost"
+        error_msg = last_terminal.kwargs.get("error") or ""
+        assert "no_outbound_effects" in error_msg, (
+            f"expected 'no_outbound_effects' in error, got: {error_msg!r}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_genuine_deferral_handoff_closes_done_deferred(self):
+        """Counterpart: a handoff turn that calls ONE read-only tool then
+        returns REAL prose (a genuine deferral explanation, ``silent_reply``
+        NOT set) still takes the carve-out → auto-closes as ``done`` with a
+        ``deferred`` result payload. The ``silent_reply`` gate only excludes
+        synthetic marker turns; genuine explanations are unaffected.
+        """
+        read_only_call = ToolCallInfo(
+            name="read_blackboard", arguments={"key": "queue"},
+        )
+        responses = [
+            _resp("", tool_calls=[read_only_call]),  # round 1: read-only tool
+            _resp("Reviewed the blackboard; no action needed because X."),
+        ]
+        loop = _make_loop(responses)
+        loop.skills.get_tool_definitions = MagicMock(
+            return_value=[{"name": "read_blackboard"}]
+        )
+        loop.skills.execute = AsyncMock(return_value={"value": "pending"})
+        loop._auto_close_task = AsyncMock(return_value=None)
+
+        result = await loop.chat("hi", task_id="t-deferral")
+
+        # Genuine prose: no marker, silent_reply not set.
+        assert result.get("silent_reply") is not True
+        assert "no action needed" in result["response"]
+
+        terminal_calls = [
+            c for c in loop._auto_close_task.await_args_list
+            if len(c.args) >= 2 and c.args[1] in ("done", "failed")
+        ]
+        assert terminal_calls
+        last_terminal = terminal_calls[-1]
+        assert last_terminal.args[1] == "done", (
+            "genuine deferral (read-only tool + real prose) must close as "
+            f"'done', not 'failed'. calls: {loop._auto_close_task.await_args_list}"
+        )
+        assert last_terminal.args[0] == "t-deferral"
+        payload = last_terminal.kwargs.get("result_payload") or {}
+        assert payload.get("status") == "deferred", (
+            f"expected deferred result payload, got: {payload!r}"
+        )
+
 
 # === Bug 3 chain pin: chat() error → blocker_note wiring ===
 
@@ -3980,3 +4082,52 @@ async def test_stream_empty_after_tools_retry_succeeds_emits_recovered_text():
     done_events = [e for e in events if e.get("type") == "done"]
     assert any("Streamed recovery" in (e.get("content") or "") for e in text_events)
     assert done_events[-1]["response"] == "Streamed recovery"
+
+
+@pytest.mark.asyncio
+async def test_empty_compose_retry_reraises_auth_error():
+    """Regression: a credential outage DURING the empty-compose retry must
+    surface as ``auth_failure`` — not be swallowed into a benign
+    ``"(no response)"`` marker. The helper re-raises LLMAuthError /
+    LLMConfigError; ``_chat_inner``'s typed ``except`` arm tags the result.
+    """
+    from src.shared.errors import LLMAuthError
+
+    tool_call = ToolCallInfo(name="search", arguments={"q": "x"})
+    # Round 1: tool call + empty text. Round 2: empty final → triggers retry.
+    # The retry compose (3rd llm.chat) raises LLMAuthError.
+    responses = [
+        _resp("", tool_calls=[tool_call]),
+        _resp(""),
+        LLMAuthError("credentials revoked", provider="anthropic"),
+    ]
+    loop = _make_loop(responses)
+    loop.skills.get_tool_definitions = MagicMock(return_value=[{"name": "search"}])
+    loop.skills.execute = AsyncMock(return_value={"ok": True})
+    result = await loop._chat_inner("ping")
+    assert result.get("auth_failure") is True
+    # Must NOT be papered over as a successful "(no response)" marker.
+    assert "(no response" not in (result.get("response") or "").lower()
+
+
+@pytest.mark.asyncio
+async def test_stream_deliberate_silence_not_retried():
+    """Streaming deliberate ``__SILENT__`` reply: NO compose retry and NO
+    marker text event (mirror of the non-stream deliberate-silence test).
+    """
+    loop = _make_loop([_resp(SILENT_REPLY_TOKEN)])
+    # Force the non-streaming fallback so llm.chat (our side_effect) is used.
+    loop.llm.chat_stream = MagicMock(side_effect=RuntimeError("no stream"))
+    # Patch the retry helper to a sentinel so we can assert it is NOT called.
+    loop._retry_empty_compose = AsyncMock()
+
+    events = [ev async for ev in loop._chat_stream_inner("ping")]
+
+    assert loop._retry_empty_compose.call_count == 0
+    text_events = [e for e in events if e.get("type") == "text_delta"]
+    assert text_events == []
+    assert all(
+        "(no response" not in (e.get("content") or "").lower() for e in events
+    )
+    done = [e for e in events if e.get("type") == "done"]
+    assert done and done[-1].get("response") == ""


### PR DESCRIPTION
## Bug 3 — Disappearing operator messages

### Validated root cause
A `/chat` or `/chat/stream` turn can return `response=""` after successful tool calls (the model runs tools, then emits no final text), so the dashboard renders a blank reply. The existing rescue in `AgentLoop.chat()` substituted a synthetic notice, but it was gated on **`not task_id` AND `not result["tool_limit_reached"]` AND non-empty `tool_outputs`**, and the streaming path had its own handling that only fired with non-empty tools and never retried. So the bug still reproduced for:

- **handoff tasks** (`x-task-id` set) — the `not task_id` gate skipped the rescue;
- **max-tool-round exits** — the `not tool_limit_reached` gate skipped it;
- **zero-tool empty turns** — `_synthesize_empty_chat_fallback` returned `""`, so nothing was substituted;
- **every streamed turn** — `/chat/stream` never went through `chat()`'s rescue at all.

### Gaps closed
1. **task_id gate removed** — the rescue now fires regardless of whether the turn was a handoff.
2. **tool_limit gate removed** — the max-tool-round force-compose exit is rescued too.
3. **empty-tools marker** — `_synthesize_empty_chat_fallback` never returns `""`: zero tools now yields a generic "(No response was generated… please re-send)" marker; with tools it keeps the existing "(Completed N tool call(s)…)" notice.
4. **streaming covered** — `_chat_stream_inner` now retries and emits the recovered text / marker as a `text_delta` event (matching the existing streaming text-event shape) so the user actually sees it, not just in the `done` envelope.

### Design — retry-then-marker
- New `async _retry_empty_compose(self, system) -> (str, int)`: one idempotent `_llm_call_with_retry(self.llm.chat, …, tools=None)`, returns resolved content + tokens (or `("", 0)` on empty/silent/exception, logging a warning). Reused by both `_chat_inner` and `_chat_stream_inner` no-tool exits.
- On an empty, non-deliberate-silence final: retry once with tools withheld → use recovered prose if non-empty (added to `self._chat_messages` + tokens consistently with the existing final-text path), else substitute the marker.
- Both **tool-limit force-compose exits** already withhold tools, so they *are* the retry — they substitute the marker directly rather than stacking a second `_retry_empty_compose` (avoids double-retrying the identical request).
- `chat()`'s final net is now ungated and sets `silent_reply` on the marker path so the dashboard can badge "recovered from empty-text turn".
- `_log_chat_turn` only substitutes the marker when `tool_outputs` exist, so a deliberate `__SILENT__` reply (empty text, no tools) still skips persistence.

### Deliberate silence is preserved
`SILENT_REPLY_TOKEN` / `__SILENT__` → `_resolve_content` sets `__silent_reply__`. Every exit checks that flag first: no retry, no marker, returns empty with `silent_reply=True`. The retry helper also honours a `__SILENT__` reply on the second attempt. A regression test asserts the LLM mock call count to prove no extra compose call fires for deliberate silence.

### Tests
Added to `tests/test_loop.py`: retry-success, retry-empty→marker, task_id rescue, tool-limit rescue, zero-tools generic marker, deliberate-silence (with call-count assertion), normal-response passthrough, and both streaming surfaces. Updated the pre-existing empty-response / silent-token tests to the new ungated contract.

- `pytest tests/test_loop.py` → **172 passed**
- `pytest tests/test_chat_workspace.py` → **90 passed**
- `ruff check src/agent/loop.py tests/test_loop.py` → **All checks passed**

Do not merge until CI is green.
