### PR TITLE
feat(dashboard): remove per-agent close X from messenger sidebar

### DIFF
--- a/src/dashboard/static/css/dashboard.css
+++ b/src/dashboard/static/css/dashboard.css
@@ -1109,17 +1109,6 @@ select:focus-visible,
   position: relative;
 }
 
-.messenger-contact .messenger-close-btn {
-  opacity: 0;
-  transition: opacity 0.15s;
-}
-
-.messenger-contact:hover .messenger-close-btn,
-.messenger-contact:focus-within .messenger-close-btn,
-.messenger-close-btn:focus-visible {
-  opacity: 1;
-}
-
 /* Main-content margin to avoid content hiding behind the chat panel.
    Must stay in sync with .messenger-half widths at each breakpoint. */
 .messenger-margin {

--- a/src/dashboard/static/js/app.js
+++ b/src/dashboard/static/js/app.js
@@ -5158,12 +5158,17 @@ function dashboard() {
           this.agents = (await resp.json()).agents;
           this.lastRefresh = Date.now() / 1000;
           this.connectionError = false;
-          // Prune restored chat tabs for agents that no longer exist
+          // Prune restored chat tabs for agents that no longer exist.
+          // Operator is a synthetic system chat — it is never present in
+          // ``/api/agents`` (special-cased server-side, outside
+          // ``agent_registry``), so it is pinned and excluded from
+          // staleness here. A background fleet refresh must not evict
+          // Operator from the messenger.
           const agentIds = new Set(this.agents.map(a => a.id));
-          const stale = this.openChats.filter(id => !agentIds.has(id));
+          const stale = this.openChats.filter(id => id !== 'operator' && !agentIds.has(id));
           if (stale.length) {
-            this.openChats = this.openChats.filter(id => agentIds.has(id));
-            if (this.activeChatId && !agentIds.has(this.activeChatId)) {
+            this.openChats = this.openChats.filter(id => id === 'operator' || agentIds.has(id));
+            if (this.activeChatId && this.activeChatId !== 'operator' && !agentIds.has(this.activeChatId)) {
               this.activeChatId = this.openChats[0] || null;
             }
             this._saveChatToSession();
@@ -7931,9 +7936,12 @@ function dashboard() {
       if (agentId === 'operator') {
         const others = this.openChats.filter(id => id !== 'operator');
         if (others.length === 0) {
-          // Operator is the only chat left — close the panel itself rather
-          // than removing Operator. Mirrors the Minimize control's behaviour.
+          // Operator is the only chat left — dismiss the whole messenger
+          // rather than removing Operator. Mirrors the ESC "dismiss panel"
+          // path: minimize + clear the legacy side-panel flag + restore
+          // focus (``closeSidePanel`` no-ops when not toggle-opened).
           this.chatPanelMinimized = true;
+          this.closeSidePanel();
           this._saveChatToSession();
           return;
         }

--- a/src/dashboard/static/js/app.js
+++ b/src/dashboard/static/js/app.js
@@ -7924,6 +7924,24 @@ function dashboard() {
     },
 
     closeChat(agentId) {
+      // Operator is permanent — it can never be removed from the messenger.
+      // The chat-header X, while Operator is active, either closes the whole
+      // panel (when Operator is the only open chat) or simply shifts focus to
+      // another open chat, leaving Operator pinned in ``openChats``.
+      if (agentId === 'operator') {
+        const others = this.openChats.filter(id => id !== 'operator');
+        if (others.length === 0) {
+          // Operator is the only chat left — close the panel itself rather
+          // than removing Operator. Mirrors the Minimize control's behaviour.
+          this.chatPanelMinimized = true;
+          this._saveChatToSession();
+          return;
+        }
+        // Keep Operator open; move focus to the most recently opened worker.
+        this.activeChatId = others[others.length - 1];
+        this._saveChatToSession();
+        return;
+      }
       if (this._chatAborts[agentId]) {
         this._chatAborts[agentId].abort();
         delete this._chatAborts[agentId];

--- a/src/dashboard/templates/index.html
+++ b/src/dashboard/templates/index.html
@@ -7932,9 +7932,6 @@
                 <div class="text-[11px] text-gray-500 truncate mt-0.5"
                   x-text="(chatHistories[chatId] || []).length > 0 ? (chatHistories[chatId][chatHistories[chatId].length - 1].content || '').slice(0, 40) : 'No messages yet'"></div>
               </div>
-              <button @click.stop="closeChat(chatId)" class="messenger-close-btn text-gray-500 hover:text-gray-400 transition-colors shrink-0 p-0.5 rounded" aria-label="Close chat">
-                <svg class="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12"/></svg>
-              </button>
             </div>
           </template>
         </div>


### PR DESCRIPTION
## Summary

The messenger sidebar's per-agent chat rows carried a close (X) button that squeezed the name/preview text block, causing heavy truncation on smaller laptop screens. The chat header already has a Close control, so the sidebar X was redundant.

## Changes

- **Remove the per-worker `closeChat(chatId)` button** from the sidebar row (`templates/index.html`). The freed horizontal space goes back to the `flex-1 min-w-0` text block, reducing truncation.
- **Drop the now-dead `.messenger-close-btn` CSS** (`css/dashboard.css`) — hover/focus reveal rules whose only consumer was the removed button.
- **Harden `closeChat()`** (`static/js/app.js`) so **Operator can never be removed** from the messenger:
  - Operator is the only open chat → header X closes the panel (`chatPanelMinimized = true`, mirroring the Minimize control).
  - Operator is active alongside other chats → header X shifts focus to the most-recently-opened worker, leaving Operator pinned in `openChats`.

## Notes

- Operator's sidebar row already had no X button, so the removal didn't touch it.
- The programmatic `closeChat()` caller in `removeAgent()` only ever passes a real agent id, never `'operator'`, so agent deletion is unaffected.
- Scope: **engine** dashboard (Alpine.js SPA), not the Next.js `app/`.

## Test plan

- [ ] Sidebar worker rows no longer show an X; names truncate noticeably less on narrow screens.
- [ ] Header X on a worker chat still closes it.
- [ ] Header X on Operator when it's the only chat → panel closes; Operator remains in `openChats` on reopen.
- [ ] Header X on Operator with other chats open → focus moves to another chat, Operator stays.