### PR TITLE
fix(operator): expose per-agent max_output_tokens in edit_agent (#1011)

### DIFF
--- a/src/agent/builtins/operator_tools.py
+++ b/src/agent/builtins/operator_tools.py
@@ -41,7 +41,15 @@ _VALID_FIELDS = frozenset({
     "instructions", "soul", "model", "role", "heartbeat",
     "heartbeat_schedule",
     "interface", "thinking", "budget", "permissions",
+    "max_output_tokens",
 })
+
+# Per-agent output-token cap bounds. Mirrors the clamp in
+# ``src/agent/__main__.py`` (LLM_MAX_TOKENS) and the validation in the
+# agent ``/config`` endpoint + host ``/edit-soft`` so all three layers
+# reject the same out-of-range values identically.
+_MAX_OUTPUT_TOKENS_MIN = 256
+_MAX_OUTPUT_TOKENS_MAX = 200_000
 
 # Heartbeat schedule validator. Accepts the same forms cron.py accepts:
 #  * 5-field cron expressions ("*/15 * * * *", "0 9 * * 1-5")
@@ -139,6 +147,23 @@ def _validate_edit(agent_id: str, field: str, value) -> dict | None:
         err = _validate_heartbeat_schedule(value)
         if err:
             return {"error": err}
+    if field == "max_output_tokens":
+        # bool is an int subclass — reject it explicitly so True/False
+        # can't slip through as 1/0.
+        if not isinstance(value, int) or isinstance(value, bool):
+            return {
+                "error": (
+                    f"max_output_tokens must be an integer, got {value!r}"
+                ),
+            }
+        if not (_MAX_OUTPUT_TOKENS_MIN <= value <= _MAX_OUTPUT_TOKENS_MAX):
+            return {
+                "error": (
+                    f"max_output_tokens must be "
+                    f"{_MAX_OUTPUT_TOKENS_MIN}-{_MAX_OUTPUT_TOKENS_MAX}, "
+                    f"got {value}"
+                ),
+            }
     return None
 
 
@@ -153,7 +178,8 @@ def _validate_edit(agent_id: str, field: str, value) -> dict | None:
         "before changing a heartbeat schedule).\n\n"
         "Returns ``{agent_id, config: {...}}`` with these fields: "
         "model, instructions, soul, heartbeat, heartbeat_schedule, "
-        "interface, role, permissions, budget, thinking. Pass "
+        "interface, role, permissions, budget, thinking, "
+        "max_output_tokens. Pass "
         "``fields=['instructions','soul']`` to scope the read to a subset."
     ),
     parameters={
@@ -167,7 +193,8 @@ def _validate_edit(agent_id: str, field: str, value) -> dict | None:
             "description": (
                 "Optional list of field names to return. Valid values: "
                 "model, instructions, soul, heartbeat, heartbeat_schedule, "
-                "interface, role, permissions, budget, thinking. "
+                "interface, role, permissions, budget, thinking, "
+                "max_output_tokens. "
                 "Omit or pass empty for the full config."
             ),
             "default": [],
@@ -503,8 +530,8 @@ async def list_available_models(
         "— act decisively on what the user asked for. The undo window is "
         "5 minutes for soft fields (instructions/soul/role/heartbeat/"
         "heartbeat_schedule/interface) and 30 minutes for hard fields "
-        "(model/permissions/budget/thinking) so the user has more time to "
-        "catch a costly edit.\n\n"
+        "(model/permissions/budget/thinking/max_output_tokens) so the user "
+        "has more time to catch a costly edit.\n\n"
         "Always pass `reason` so the audit trail captures intent.\n\n"
         "Fields & value formats:\n"
         "- instructions/soul/heartbeat/interface/role: string\n"
@@ -513,7 +540,11 @@ async def list_available_models(
         "- budget: {\"daily_usd\": float, \"monthly_usd\": float}\n"
         "- permissions: {\"can_use_browser\": bool, ...}\n"
         "- thinking: \"off\" | \"low\" | \"medium\" | \"high\"\n"
-        "- model: e.g. \"anthropic/claude-sonnet-4-20250514\""
+        "- model: e.g. \"anthropic/claude-sonnet-4-20250514\"\n"
+        "- max_output_tokens: integer 256-200000 — per-agent cap on output "
+        "tokens per LLM call. Raise it for agents that emit large single "
+        "tool calls (e.g. a translator that PUTs a whole file in one call) "
+        "and hit 'Truncated tool-call arguments'. Default 8192."
     ),
     parameters={
         "agent_id": {
@@ -527,11 +558,15 @@ async def list_available_models(
                 "instructions", "soul", "model", "role", "heartbeat",
                 "heartbeat_schedule",
                 "interface", "thinking", "budget", "permissions",
+                "max_output_tokens",
             ],
         },
         "value": {
-            "type": ["string", "object"],
-            "description": "New value for the field",
+            "type": ["string", "object", "integer"],
+            "description": (
+                "New value for the field. String/object for most fields; "
+                "integer for max_output_tokens."
+            ),
         },
         "reason": {
             "type": "string",

--- a/src/agent/llm.py
+++ b/src/agent/llm.py
@@ -93,11 +93,17 @@ class LLMClient:
         if m.startswith("anthropic/"):
             budget = self._THINKING_BUDGETS.get(self.thinking, 10_000)
             # Anthropic requires max_tokens > budget_tokens; ensure enough room
-            # for both thinking and output text.
+            # for both thinking and output text. Honour the configured output
+            # cap so the per-agent max_output_tokens lever is meaningful for
+            # thinking agents too (otherwise a translator that turns thinking
+            # on would re-truncate on large tool calls). ``budget + 4096`` is
+            # the historical floor — taking the max preserves the prior
+            # default behaviour exactly (8192 cap <= budget + 4096) while
+            # letting an operator-raised cap take over when it's larger.
             return {
                 "thinking": {"type": "enabled", "budget_tokens": budget},
                 "temperature": 1.0,
-                "max_tokens": budget + 4096,
+                "max_tokens": max(self.max_output_tokens, budget + 4096),
             }
         if m.startswith("openai/o") or m.startswith("o1") or m.startswith("o3") or m.startswith("o4"):
             return {"reasoning_effort": self.thinking}

--- a/src/cli/repl.py
+++ b/src/cli/repl.py
@@ -31,7 +31,7 @@ from src.cli.formatting import (
     display_stream_tool_start,
     user_prompt,
 )
-from src.shared.utils import dumps_safe
+from src.shared.utils import dumps_safe, set_llm_max_tokens_env
 
 if TYPE_CHECKING:
     from src.cli.runtime import RuntimeContext
@@ -1413,6 +1413,8 @@ class REPLSession:
         restart_env: dict[str, str] = {}
         if name == _OPERATOR_AGENT_ID:
             restart_env["ALLOWED_TOOLS"] = ",".join(_OPERATOR_ALLOWED_TOOLS)
+        # Per-agent output-token cap → LLM_MAX_TOKENS (survives /restart).
+        set_llm_max_tokens_env(restart_env, agent_cfg)
 
         # Start new container
         url = self.ctx.runtime.start_agent(

--- a/src/cli/runtime.py
+++ b/src/cli/runtime.py
@@ -26,6 +26,7 @@ from src.cli.config import (
 from src.cli.formatting import echo_fail, echo_header, echo_ok
 from src.cli.proxy import build_proxy_env_vars, resolve_agent_proxy
 from src.shared.types import RESERVED_AGENT_IDS
+from src.shared.utils import set_llm_max_tokens_env
 
 if TYPE_CHECKING:
     from src.shared.types import MessageOrigin
@@ -452,14 +453,8 @@ class RuntimeContext:
             agent_max_iters = agent_cfg.get("max_iterations")
             if agent_max_iters is not None:
                 agent_env["OPENLEGION_MAX_ITERATIONS"] = str(agent_max_iters)
-            # Per-agent output-token cap → LLM_MAX_TOKENS (read by
-            # src/agent/__main__.py at startup). Mirrors the host restart
-            # path so an edit_agent change to max_output_tokens survives a
-            # full CLI restart, not just a live hot-reload. Absent = the
-            # LLMClient default (8192).
-            agent_max_out = agent_cfg.get("max_output_tokens")
-            if isinstance(agent_max_out, int) and not isinstance(agent_max_out, bool):
-                agent_env["LLM_MAX_TOKENS"] = str(agent_max_out)
+            # Per-agent output-token cap → LLM_MAX_TOKENS (survives restart).
+            set_llm_max_tokens_env(agent_env, agent_cfg)
             if agent_id == _OPERATOR_AGENT_ID:
                 agent_env["ALLOWED_TOOLS"] = ",".join(_OPERATOR_ALLOWED_TOOLS)
                 # PR-L' — pass the boot greeting so the agent can seed

--- a/src/cli/runtime.py
+++ b/src/cli/runtime.py
@@ -452,6 +452,14 @@ class RuntimeContext:
             agent_max_iters = agent_cfg.get("max_iterations")
             if agent_max_iters is not None:
                 agent_env["OPENLEGION_MAX_ITERATIONS"] = str(agent_max_iters)
+            # Per-agent output-token cap → LLM_MAX_TOKENS (read by
+            # src/agent/__main__.py at startup). Mirrors the host restart
+            # path so an edit_agent change to max_output_tokens survives a
+            # full CLI restart, not just a live hot-reload. Absent = the
+            # LLMClient default (8192).
+            agent_max_out = agent_cfg.get("max_output_tokens")
+            if isinstance(agent_max_out, int) and not isinstance(agent_max_out, bool):
+                agent_env["LLM_MAX_TOKENS"] = str(agent_max_out)
             if agent_id == _OPERATOR_AGENT_ID:
                 agent_env["ALLOWED_TOOLS"] = ",".join(_OPERATOR_ALLOWED_TOOLS)
                 # PR-L' — pass the boot greeting so the agent can seed

--- a/src/dashboard/server.py
+++ b/src/dashboard/server.py
@@ -49,7 +49,13 @@ from src.dashboard.auth import verify_session_cookie
 from src.shared.paths import resolve_under_root
 from src.shared.sqlite_helpers import open_db
 from src.shared.types import CRED_HANDLE_RE, MCPServerConfig
-from src.shared.utils import dumps_safe, friendly_streaming_error, sanitize_for_prompt, setup_logging
+from src.shared.utils import (
+    dumps_safe,
+    friendly_streaming_error,
+    sanitize_for_prompt,
+    set_llm_max_tokens_env,
+    setup_logging,
+)
 
 if TYPE_CHECKING:
     from src.dashboard.events import EventBus
@@ -5767,6 +5773,9 @@ def create_dashboard_router(
                     _proxy_url, _network_cfg.get("no_proxy", ""),
                 )
                 _restart_env.update(_proxy_env)
+                # Per-agent output-token cap → LLM_MAX_TOKENS (survives the
+                # dashboard "restart all agents" flow, not just hot-reload).
+                set_llm_max_tokens_env(_restart_env, agent_cfg)
                 url = await loop.run_in_executor(
                     None,
                     lambda aid=agent_id, acfg=agent_cfg, sd=skills_dir, re=_restart_env: runtime.start_agent(

--- a/src/dashboard/server.py
+++ b/src/dashboard/server.py
@@ -2878,6 +2878,10 @@ def create_dashboard_router(
                 _proxy_url, cfg.get("network", {}).get("no_proxy", ""),
             )
             restart_env.update(_proxy_env)
+            # Per-agent output-token cap → LLM_MAX_TOKENS so an edit_agent
+            # change survives a single-agent dashboard restart (not just the
+            # live hot-reload). Absent = LLMClient default 8192.
+            set_llm_max_tokens_env(restart_env, agent_cfg)
             url = await asyncio.wait_for(
                 asyncio.to_thread(
                     runtime.start_agent,

--- a/src/host/health.py
+++ b/src/host/health.py
@@ -20,7 +20,7 @@ from typing import TYPE_CHECKING
 
 from src.cli.config import _load_config
 from src.cli.proxy import build_proxy_env_vars, resolve_agent_proxy
-from src.shared.utils import setup_logging
+from src.shared.utils import set_llm_max_tokens_env, setup_logging
 
 if TYPE_CHECKING:
     from src.host.mesh import MessageRouter
@@ -524,6 +524,11 @@ class HealthMonitor:
                 _proxy_url, _network_cfg.get("no_proxy", ""),
             )
             self.runtime.extra_env.update(_proxy_env)
+            # Per-agent output-token cap → LLM_MAX_TOKENS so an operator's
+            # max_output_tokens edit survives an automatic crash-recovery
+            # restart. Read from fresh YAML (the registry ``info`` dict
+            # doesn't carry it); no-op when unset → LLMClient default 8192.
+            set_llm_max_tokens_env(restart_env, _agents_cfg.get(agent_id, {}))
             try:
                 url = await loop.run_in_executor(
                     None,

--- a/src/host/server.py
+++ b/src/host/server.py
@@ -3540,6 +3540,13 @@ def create_mesh_app(
                 val = acfg.get(cfg_key, "")
                 if val:
                     env_overrides[env_key] = val
+            # Per-agent output cap → LLM_MAX_TOKENS so an edit_agent change
+            # survives container restart (the YAML row is the source of
+            # truth; __main__.py reads this env at startup). Only set when
+            # configured — absent means the LLMClient default (8192) applies.
+            _mot = acfg.get("max_output_tokens")
+            if isinstance(_mot, int) and not isinstance(_mot, bool):
+                env_overrides["LLM_MAX_TOKENS"] = str(_mot)
 
             try:
                 # Start container with per-agent env_overrides (not shared extra_env)
@@ -6734,6 +6741,9 @@ def create_mesh_app(
             "soul": raw.get("initial_soul", ""),
             "heartbeat": raw.get("initial_heartbeat", ""),
             "interface": raw.get("initial_interface", ""),
+            # Falls back to the LLMClient default (8192) when never set, so the
+            # operator sees the effective cap, not a blank.
+            "max_output_tokens": raw.get("max_output_tokens", 8192) or 8192,
         }
 
         # Permissions live in PERMISSIONS_FILE, not agents.yaml. Load via
@@ -6983,8 +6993,8 @@ def create_mesh_app(
                 except Exception:
                     pass  # Agent might not be running
 
-        # Hot-reload: runtime config (model, thinking) — env-var fields that
-        # won't get picked up by the YAML write alone.
+        # Hot-reload: runtime config (model, thinking, max_output_tokens) —
+        # env-var fields that won't get picked up by the YAML write alone.
         #
         # ``hot_reload_ok`` defaults to True for fields that don't
         # hot-reload (config-write only) so the emit doesn't lie about
@@ -6993,17 +7003,29 @@ def create_mesh_app(
         # ``agent_config_updated`` event so the SPA can render a
         # "saved — restart to apply" hint when the running agent still
         # has the old config (Docker hang, agent crash, transport timeout).
+        #
+        # The agent /config endpoint keys the output cap as ``max_tokens``
+        # (LLMClient.max_output_tokens), while the operator-facing edit field
+        # is ``max_output_tokens`` — map between the two here.
         hot_reload_ok = True
+        _config_push_key = {
+            "model": "model",
+            "thinking": "thinking",
+            "max_output_tokens": "max_tokens",
+        }.get(field)
         if (
             transport
             and agent_id in router.agent_registry
-            and field in ("model", "thinking")
-            and isinstance(new_value, str)
+            and _config_push_key is not None
+            and (
+                isinstance(new_value, str)
+                or (field == "max_output_tokens" and isinstance(new_value, int))
+            )
         ):
             try:
                 result = await transport.request(
                     agent_id, "POST", "/config",
-                    json={field: new_value}, timeout=10,
+                    json={_config_push_key: new_value}, timeout=10,
                 )
                 # transport.request returns {"error": ...} dicts for HTTP /
                 # timeout / connect failures rather than raising. Surface
@@ -7259,6 +7281,19 @@ def create_mesh_app(
                 raise HTTPException(
                     400,
                     f"thinking must be one of: {sorted(LLMClient.VALID_THINKING_LEVELS)}",
+                )
+        elif field == "max_output_tokens":
+            # Re-enforce server-side (mirrors operator_tools._validate_edit and
+            # the agent /config endpoint). bool is an int subclass — reject it
+            # so True/False can't slip through as 1/0. Range matches the
+            # LLM_MAX_TOKENS clamp in src/agent/__main__.py.
+            if not isinstance(new_value, int) or isinstance(new_value, bool):
+                raise HTTPException(
+                    400, "max_output_tokens must be an integer",
+                )
+            if not (256 <= new_value <= 200_000):
+                raise HTTPException(
+                    400, "max_output_tokens must be between 256 and 200000",
                 )
         elif field == "permissions":
             # Finding H1 (May 2026 remediation): re-enforce the operator

--- a/src/host/server.py
+++ b/src/host/server.py
@@ -55,7 +55,12 @@ from src.shared.types import (
     MessageOrigin,
     NotifyRequest,
 )
-from src.shared.utils import dumps_safe, sanitize_for_prompt, setup_logging
+from src.shared.utils import (
+    dumps_safe,
+    sanitize_for_prompt,
+    set_llm_max_tokens_env,
+    setup_logging,
+)
 
 logger = setup_logging("host.server")
 
@@ -3540,13 +3545,8 @@ def create_mesh_app(
                 val = acfg.get(cfg_key, "")
                 if val:
                     env_overrides[env_key] = val
-            # Per-agent output cap → LLM_MAX_TOKENS so an edit_agent change
-            # survives container restart (the YAML row is the source of
-            # truth; __main__.py reads this env at startup). Only set when
-            # configured — absent means the LLMClient default (8192) applies.
-            _mot = acfg.get("max_output_tokens")
-            if isinstance(_mot, int) and not isinstance(_mot, bool):
-                env_overrides["LLM_MAX_TOKENS"] = str(_mot)
+            # Per-agent output-token cap → LLM_MAX_TOKENS (survives restart).
+            set_llm_max_tokens_env(env_overrides, acfg)
 
             try:
                 # Start container with per-agent env_overrides (not shared extra_env)
@@ -7335,7 +7335,15 @@ def create_mesh_app(
             old_value = perms.get("permissions", {}).get(agent_id, {})
         else:
             yaml_key = _CONFIG_FIELD_MAP.get(field, field)
-            old_value = agents[agent_id].get(yaml_key, "")
+            # For max_output_tokens, default the "before" value to the
+            # effective cap (LLMClient default 8192) rather than "" when it
+            # was never set. This keeps the audit before-value sensible AND
+            # makes Undo work end-to-end: the undo writes back an int, which
+            # the hot-reload push forwards to the agent /config (the push
+            # guard requires an int) so the live agent actually drops back to
+            # 8192 instead of silently keeping the raised cap until restart.
+            _missing_default = 8192 if field == "max_output_tokens" else ""
+            old_value = agents[agent_id].get(yaml_key, _missing_default)
 
         # Apply directly via the same write helper used by the confirm
         # path. ``_apply_pending_change`` is async and handles audit

--- a/src/shared/types.py
+++ b/src/shared/types.py
@@ -53,14 +53,17 @@ is a mirrored constant kept for back-compat; prefer importing from
 here.
 """
 
-HARD_EDIT_FIELDS = frozenset({"model", "permissions", "budget", "thinking"})
+HARD_EDIT_FIELDS = frozenset(
+    {"model", "permissions", "budget", "thinking", "max_output_tokens"}
+)
 """Agent-config fields that earn the longer 30-min Undo window (the
 "hard" review path). Mirrors :data:`SOFT_EDIT_FIELDS` — the union is
 the full set of editable fields surfaced through the operator-tool
 layer.
 
 These are the consequential edits — model swaps, permission grants,
-budget tweaks, thinking-level changes. All edits apply immediately
+budget tweaks, thinking-level changes, output-cap changes. All edits
+apply immediately
 via ``/edit-soft``; the only difference between hard and soft fields
 is the receipt TTL, i.e. how long the user has to click Undo:
 

--- a/src/shared/utils.py
+++ b/src/shared/utils.py
@@ -13,6 +13,26 @@ from typing import Any
 UTC = timezone.utc
 
 
+def set_llm_max_tokens_env(env: dict[str, str], agent_cfg: dict) -> None:
+    """Inject ``LLM_MAX_TOKENS`` into a per-agent container env dict from the
+    agent's YAML config.
+
+    Called by every restart-from-config path (CLI start, dashboard
+    "restart agents", REPL ``/restart``, fleet-template apply) so an
+    operator's ``edit_agent`` change to ``max_output_tokens`` survives a
+    container restart — the agent reads this env at startup (see
+    ``src/agent/__main__.py``); the live ``/config`` hot-reload only covers
+    the already-running container.
+
+    No-op when the cap is unset or not a plain int, so the LLMClient default
+    (8192) then applies. ``bool`` is rejected explicitly (it is an ``int``
+    subclass) so a stray ``True``/``False`` can't become ``1``/``0``.
+    """
+    value = agent_cfg.get("max_output_tokens")
+    if isinstance(value, int) and not isinstance(value, bool):
+        env["LLM_MAX_TOKENS"] = str(value)
+
+
 def dumps_safe(obj: Any, **kwargs: Any) -> str:
     """json.dumps with `default=str` — handles datetime, UUID, Decimal, Path.
 

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -5856,6 +5856,32 @@ class TestDashboardEventBusCoverage:
             assert e["data"]["agent_id"] == "alpha"
 
     @patch("src.cli.config._load_config")
+    def test_restart_endpoint_propagates_max_output_tokens(self, mock_load):
+        """A single-agent dashboard restart must carry the operator's
+        per-agent output cap into the new container's env, or it silently
+        reverts to the 8192 default on every restart."""
+        mock_load.return_value = {
+            "llm": {"default_model": "openai/gpt-4o-mini"},
+            "agents": {
+                "alpha": {
+                    "role": "tester", "skills_dir": "",
+                    "model": "openai/gpt-4o-mini",
+                    "max_output_tokens": 32000,
+                },
+            },
+            "network": {},
+        }
+        runtime = self.components["runtime"]
+        runtime.start_agent.return_value = "http://localhost:8401"
+        runtime.wait_for_agent = AsyncMock(return_value=True)
+
+        resp = self.client.post("/dashboard/api/agents/alpha/restart")
+        assert resp.status_code == 200, resp.text
+
+        _, kwargs = runtime.start_agent.call_args
+        assert kwargs["env_overrides"].get("LLM_MAX_TOKENS") == "32000"
+
+    @patch("src.cli.config._load_config")
     def test_restart_failure_emits_state_restart_failed(self, mock_load):
         mock_load.return_value = {
             "llm": {"default_model": "openai/gpt-4o-mini"},

--- a/tests/test_edit_soft_endpoint.py
+++ b/tests/test_edit_soft_endpoint.py
@@ -148,6 +148,44 @@ async def test_edit_soft_accepts_hard_field_model_with_30min_ttl(mesh_app):
 
 
 @pytest.mark.asyncio
+async def test_edit_soft_accepts_max_output_tokens_and_writes_yaml(mesh_app):
+    """The per-agent output cap is a hard field: applies immediately, gets a
+    30-min undo window, and persists to YAML so it survives restart."""
+    app, _, tmp_path = mesh_app
+    afile = tmp_path / "config" / "agents.yaml"
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
+        r = await c.post(
+            "/mesh/agents/writer/edit-soft",
+            json={"field": "max_output_tokens", "value": 32000, "reason": "user_asked"},
+            headers=_human_origin_headers(),
+        )
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["success"] is True
+    assert body["field"] == "max_output_tokens"
+    assert body["field_class"] == "hard"
+    assert body["ttl_seconds"] == 1800
+    cfg = yaml.safe_load(afile.read_text())
+    assert cfg["agents"]["writer"]["max_output_tokens"] == 32000
+
+
+@pytest.mark.asyncio
+async def test_edit_soft_rejects_out_of_range_max_output_tokens(mesh_app):
+    """Out-of-range / non-integer caps are rejected server-side with 400,
+    mirroring the operator-tool guard and the agent /config endpoint."""
+    app, _, _ = mesh_app
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
+        for bad in (200_001, "8192"):
+            r = await c.post(
+                "/mesh/agents/writer/edit-soft",
+                json={"field": "max_output_tokens", "value": bad, "reason": "user_asked"},
+                headers=_human_origin_headers(),
+            )
+            assert r.status_code == 400, r.text
+            assert "max_output_tokens" in r.json()["detail"]
+
+
+@pytest.mark.asyncio
 async def test_edit_soft_accepts_hard_field_permissions(mesh_app):
     """Permissions edits apply immediately with a 30-min undo window."""
     app, _, _ = mesh_app

--- a/tests/test_edit_soft_endpoint.py
+++ b/tests/test_edit_soft_endpoint.py
@@ -168,6 +168,16 @@ async def test_edit_soft_accepts_max_output_tokens_and_writes_yaml(mesh_app):
     cfg = yaml.safe_load(afile.read_text())
     assert cfg["agents"]["writer"]["max_output_tokens"] == 32000
 
+    # When the cap was never set before, the recorded "before" value is the
+    # effective default (8192), not "". This makes the audit sensible and —
+    # critically — makes Undo restore an int that the hot-reload push can
+    # forward to the live agent (the push guard requires an int), instead of
+    # silently leaving the running container on the raised cap.
+    change = app.change_history.peek(body["undo_token"])
+    assert change is not None
+    assert change["old_value"] == 8192
+    assert change["new_value"] == 32000
+
 
 @pytest.mark.asyncio
 async def test_edit_soft_rejects_out_of_range_max_output_tokens(mesh_app):

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import time
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -105,6 +105,30 @@ class TestHealthRestartMissingConfig:
         monitor.runtime.start_agent.assert_called_once()
         assert health.status == "healthy"
         assert health.restart_count == 1
+
+    @pytest.mark.asyncio
+    async def test_restart_propagates_max_output_tokens(self):
+        """A crash-recovery restart must carry the operator's per-agent
+        output cap into the new container's env (LLM_MAX_TOKENS), or the
+        agent silently reverts to the 8192 default on every crash."""
+        monitor = _make_monitor({
+            "good-agent": {"role": "coder", "skills_dir": "/skills"},
+        })
+        monitor.register("good-agent")
+        health = monitor.agents["good-agent"]
+        health.consecutive_failures = 3
+        health.status = "unhealthy"
+        monitor.runtime.start_agent.return_value = "http://localhost:8401"
+        monitor.runtime.wait_for_agent = AsyncMock(return_value=True)
+
+        # The cap lives in YAML, not the registry info dict — patch the
+        # fresh-config load the restart path performs.
+        fake_cfg = {"agents": {"good-agent": {"max_output_tokens": 32000}}}
+        with patch("src.host.health._load_config", return_value=fake_cfg):
+            await monitor._try_restart("good-agent")
+
+        _, kwargs = monitor.runtime.start_agent.call_args
+        assert kwargs["env_overrides"].get("LLM_MAX_TOKENS") == "32000"
 
 
 class TestParallelHealthChecks:

--- a/tests/test_llm.py
+++ b/tests/test_llm.py
@@ -368,3 +368,32 @@ async def test_chat_uses_instance_max_tokens_default():
     with patch.object(llm, "_get_client", AsyncMock(return_value=_Client())):
         await llm.chat(system="s", messages=[{"role": "user", "content": "hi"}])
     assert captured["max_tokens"] == 16384
+
+
+def test_thinking_max_tokens_preserves_default_floor():
+    """With the default 8192 cap, an Anthropic thinking call keeps the
+    historical ``budget + 4096`` ceiling — taking the max introduces no
+    regression because 8192 <= budget + 4096 at every thinking level."""
+    llm = LLMClient(
+        mesh_url="http://mesh:8420", agent_id="a1",
+        default_model="anthropic/claude-sonnet-4-6", thinking="medium",
+    )
+    params = llm._get_thinking_params()
+    # medium budget = 10_000 → 10_000 + 4096
+    assert params["max_tokens"] == 14096
+    assert params["thinking"]["budget_tokens"] == 10_000
+
+
+def test_thinking_max_tokens_honours_raised_cap():
+    """A per-agent cap larger than ``budget + 4096`` takes over, so the
+    output-cap lever is meaningful for thinking-enabled agents too."""
+    llm = LLMClient(
+        mesh_url="http://mesh:8420", agent_id="a1",
+        default_model="anthropic/claude-sonnet-4-6", thinking="medium",
+        max_output_tokens=64000,
+    )
+    params = llm._get_thinking_params()
+    # max(64000, 10_000 + 4096) == 64000
+    assert params["max_tokens"] == 64000
+    # The thinking budget itself is unchanged — only the total ceiling grows.
+    assert params["thinking"]["budget_tokens"] == 10_000

--- a/tests/test_llm_max_tokens_env.py
+++ b/tests/test_llm_max_tokens_env.py
@@ -1,0 +1,40 @@
+"""Unit tests for set_llm_max_tokens_env — the shared helper that propagates
+a per-agent max_output_tokens cap into the container env across every
+restart-from-config path (CLI start, dashboard restart, REPL /restart,
+fleet-template apply)."""
+
+from __future__ import annotations
+
+from src.shared.utils import set_llm_max_tokens_env
+
+
+def test_sets_env_for_valid_int():
+    env: dict[str, str] = {}
+    set_llm_max_tokens_env(env, {"max_output_tokens": 32000})
+    assert env["LLM_MAX_TOKENS"] == "32000"
+
+
+def test_noop_when_absent():
+    env: dict[str, str] = {}
+    set_llm_max_tokens_env(env, {"model": "anthropic/claude-sonnet-4-6"})
+    assert "LLM_MAX_TOKENS" not in env
+
+
+def test_noop_for_bool():
+    # bool is an int subclass — must not become "1"/"0".
+    env: dict[str, str] = {}
+    set_llm_max_tokens_env(env, {"max_output_tokens": True})
+    assert "LLM_MAX_TOKENS" not in env
+
+
+def test_noop_for_non_int_value():
+    env: dict[str, str] = {}
+    set_llm_max_tokens_env(env, {"max_output_tokens": "32000"})
+    assert "LLM_MAX_TOKENS" not in env
+
+
+def test_does_not_clobber_other_keys():
+    env = {"ALLOWED_TOOLS": "a,b"}
+    set_llm_max_tokens_env(env, {"max_output_tokens": 16384})
+    assert env["ALLOWED_TOOLS"] == "a,b"
+    assert env["LLM_MAX_TOKENS"] == "16384"

--- a/tests/test_operator_tools.py
+++ b/tests/test_operator_tools.py
@@ -988,6 +988,60 @@ async def test_edit_agent_thinking_valid():
     )
 
 
+# ── max_output_tokens ────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_edit_agent_max_output_tokens_valid():
+    """An in-range integer cap passes validation and reaches edit_soft."""
+    from src.agent.builtins.operator_tools import edit_agent
+
+    mc = MagicMock()
+    mc.edit_soft = AsyncMock(return_value={
+        "success": True,
+        "undo_token": "tok-m1",
+        "expires_at": "2026-05-13T00:30:00+00:00",
+        "ttl_seconds": 1800,
+        "field_class": "hard",
+        "summary": "Raised translator's output cap",
+    })
+    result = await edit_agent(
+        "translator", "max_output_tokens", 32000,
+        reason="user_asked", mesh_client=mc,
+    )
+    assert result["applied"] is True
+    assert result["undo_token"] == "tok-m1"
+    mc.edit_soft.assert_awaited_once_with(
+        "translator", "max_output_tokens", 32000, "user_asked",
+    )
+
+
+@pytest.mark.asyncio
+async def test_edit_agent_max_output_tokens_rejects_non_int():
+    """A non-integer (or bool) value is rejected pre-mesh."""
+    from src.agent.builtins.operator_tools import edit_agent
+
+    for bad in ("8192", 8192.5, True):
+        result = await edit_agent(
+            "translator", "max_output_tokens", bad, mesh_client=MagicMock(),
+        )
+        assert "error" in result
+        assert "max_output_tokens" in result["error"]
+
+
+@pytest.mark.asyncio
+async def test_edit_agent_max_output_tokens_rejects_out_of_range():
+    """Values below 256 or above 200000 are rejected pre-mesh."""
+    from src.agent.builtins.operator_tools import edit_agent
+
+    for bad in (255, 200_001):
+        result = await edit_agent(
+            "translator", "max_output_tokens", bad, mesh_client=MagicMock(),
+        )
+        assert "error" in result
+        assert "max_output_tokens" in result["error"]
+
+
 # ── list_pending ─────────────────────────────────────────────
 
 

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -423,3 +423,13 @@ def test_agent_config_mcp_servers_round_trip_via_model_dump():
     assert dumped["mcp_servers"][0]["env"] == {"K": "v"}
 
 
+def test_max_output_tokens_is_a_hard_edit_field():
+    """The per-agent output cap earns the 30-min hard-edit undo window and
+    must not collide with the soft-field set (the two are disjoint)."""
+    from src.shared.types import HARD_EDIT_FIELDS, SOFT_EDIT_FIELDS
+
+    assert "max_output_tokens" in HARD_EDIT_FIELDS
+    assert "max_output_tokens" not in SOFT_EDIT_FIELDS
+    assert HARD_EDIT_FIELDS.isdisjoint(SOFT_EDIT_FIELDS)
+
+


### PR DESCRIPTION
Closes #1011. Also closes the residual gap in #1010 (large single tool calls that exceed even the raised default cap).

## Validation findings (important)

While validating #1010/#1011 against the codebase I found their "current state" descriptions were **stale** — they described an engine layer that didn't exist *on the branch they were written against*. But **`main` already contains [PR #990](https://github.com/openlegion-ai/openlegion/pull/990)**, which landed:

- `LLMClient.max_output_tokens` (default **8192**, was a hardcoded 4096)
- `LLM_MAX_TOKENS` env seeding in `src/agent/__main__.py`
- the agent `/config` hot-reload accepting a `max_tokens` body key

So **#1010 is effectively resolved on `main`** for the common case, and the `_parse_tool_calls` truncation→retry path is real. What remained — and is exactly what **#1011** asks for — is the **operator surface to set the cap at runtime** plus **durability across restarts**. The host never pushed the cap to `/config`, `edit_agent` couldn't set it, and `runtime.py` never wrote `LLM_MAX_TOKENS` from YAML. This PR completes that.

## Why

`locale-translator` (and any agent that emits one large tool call) can still exceed the 8192 default and fail with `Truncated tool-call arguments`. The retry can't help when the output deterministically exceeds the cap every time, and the only lever was editing the repo/env + restarting. This adds a runtime lever following the **exact** `model`/`thinking` config lifecycle (no new mechanism).

## Changes

- **`types.py`** — `max_output_tokens` joins `HARD_EDIT_FIELDS` (30-min undo window).
- **`operator_tools.py`** — `edit_agent` accepts `max_output_tokens` (int, 256–200000); `read_agent_config` surfaces it. Rejects bool/non-int/out-of-range before the mesh round-trip.
- **`host/server.py`** — `/edit-soft` re-validates server-side (defence in depth); the hot-reload push maps the canonical field `max_output_tokens` → the agent `/config` `max_tokens` key; `get_agent_config` returns the effective cap (default 8192).
- **Durability** — the host restart path and the CLI start path inject `LLM_MAX_TOKENS` into the container env from the YAML row, so an edit survives a full restart, not just a live hot-reload. (Mirrors the existing `max_iterations` → `OPENLEGION_MAX_ITERATIONS` idiom.)
- **`llm.py`** — the Anthropic thinking path now uses `max(max_output_tokens, budget + 4096)` so the cap lever is meaningful for thinking-enabled agents too. **Zero regression at the 8192 default** (8192 ≤ budget + 4096 at every thinking level).

## Range / consistency

`256–200000` matches the `LLM_MAX_TOKENS` clamp in `__main__.py` and the agent `/config` validation, so all three layers (tool guard, mesh `/edit-soft`, agent `/config`) reject the same values identically. `bool` is rejected explicitly (it's an `int` subclass).

## Tests

`190 passed` across the touched suites. New tests: `edit_agent` accept/reject, `/edit-soft` validation + YAML persistence, `HARD_EDIT_FIELDS` membership, and the thinking-budget floor/raised-cap cases.

## KISS / scope notes

- Reuses the proven `model`/`thinking` pipeline rather than inventing a parallel one.
- `AgentConfig` is left untouched — it's `extra="allow"` and the value round-trips through `model_dump`; the read/write paths use the raw YAML dict.
- Did **not** implement #1010's optional "detect repeated same-tool-call truncation → clear error" (fix option 3) — with a raisable cap the deterministic-truncation case is addressable by the operator, and that change adds retry-loop state for marginal benefit. Easy follow-up if desired.