### PR TITLE
fix(proxy): model-pin fails open for agents without an explicit configured model

### DIFF
--- a/src/host/server.py
+++ b/src/host/server.py
@@ -1237,26 +1237,30 @@ def create_mesh_app(
         abuse). ``is_model_compatible`` alone does NOT close this — it
         permits the whole API-key catalog.
 
-        Source of truth is the agent's configured model in
-        ``config/settings.json`` (``agents.{id}.model``, falling back to
-        ``llm.default_model``) — the SAME value written on
-        ``create_agent`` / ``edit_agent`` and injected as the container's
-        ``LLM_MODEL`` env. Because models are config-fixed per agent today
-        (``loop.py`` never passes a ``model=`` override — it always sends
-        ``self.default_model``), the legitimate agent only ever requests
-        this one model, so the pin is non-breaking. The pin auto-updates
-        when the operator edits the model (edit-soft rewrites this same
-        config row).
+        Source of truth is the agent's EXPLICIT configured model in
+        ``config/settings.json`` (``agents.{id}.model``) — the SAME value
+        written on ``create_agent`` / ``edit_agent`` and injected as the
+        container's ``LLM_MODEL`` env. Because models are config-fixed per
+        agent today (``loop.py`` never passes a ``model=`` override — it
+        always sends ``self.default_model``), a pinned agent only ever
+        requests this one model, so the pin is non-breaking. The pin
+        auto-updates when the operator edits the model (edit-soft rewrites
+        this same config row).
 
         An optional operator-settable ``allowed_models`` list on the
         agent's config row widens the set (e.g. for an agent the operator
-        deliberately lets pick among a few models). The configured model
-        is always included.
+        deliberately lets pick among a few models). The explicit
+        configured model is always included.
 
-        Returns ``None`` (no pin / fail-open) when the config cannot be
-        read or the agent has no resolvable model — keeps test harnesses
-        and partial-config deployments working rather than 403-ing real
-        traffic on a missing file.
+        The pin ONLY restricts agents that have an explicit per-agent
+        model (or ``allowed_models``). Agents with no explicit model are
+        NOT pinned — we return ``None`` (no pin / fail-open). We must NOT
+        fall back to the global ``llm.default_model``: an agent may not
+        actually use that model, and pinning to it 403'd legitimate
+        operator-created agents whose config carries no explicit ``model``
+        row. Also returns ``None`` when the config cannot be read — keeps
+        test harnesses and partial-config deployments working rather than
+        403-ing real traffic on a missing file.
         """
         try:
             from src.cli.config import _load_config
@@ -1266,11 +1270,8 @@ def create_mesh_app(
             return None
         agents_cfg = cfg.get("agents", {}) or {}
         acfg = agents_cfg.get(agent_id) or {}
-        default_model = (cfg.get("llm", {}) or {}).get(
-            "default_model", "openai/gpt-4o-mini",
-        )
         allowed: set[str] = set()
-        configured = acfg.get("model") or default_model
+        configured = acfg.get("model")
         if isinstance(configured, str) and configured:
             allowed.add(configured)
         extra = acfg.get("allowed_models")
@@ -1309,15 +1310,24 @@ def create_mesh_app(
             return
         allowed = _agent_allowed_models(agent_id)
         if allowed is not None and requested_model not in allowed:
-            _record_denial(
-                "permission", caller=agent_id, target=requested_model,
-                gate="api:model_pin",
-            )
-            raise HTTPException(
-                403,
-                f"Agent {agent_id} is not authorized to use model "
-                f"'{requested_model}'. Allowed: {sorted(allowed)}.",
-            )
+            # Provider-prefix-insensitive fallback compare: an explicit
+            # config of ``anthropic/claude-3-5-sonnet`` must still accept a
+            # request for the bare ``claude-3-5-sonnet`` (and vice versa),
+            # so the prefix alone can't false-trip the pin.
+            def _bare(name: str) -> str:
+                return name.rsplit("/", 1)[-1].lower()
+
+            allowed_bare = {_bare(m) for m in allowed}
+            if _bare(requested_model) not in allowed_bare:
+                _record_denial(
+                    "permission", caller=agent_id, target=requested_model,
+                    gate="api:model_pin",
+                )
+                raise HTTPException(
+                    403,
+                    f"Agent {agent_id} is not authorized to use model "
+                    f"'{requested_model}'. Allowed: {sorted(allowed)}.",
+                )
         # Cheap interim compatibility gate (mirrors the call-time check the
         # LLM proxy runs) — reject requested models with no usable
         # credentials before dispatch.

--- a/tests/test_llm_model_pin.py
+++ b/tests/test_llm_model_pin.py
@@ -315,3 +315,88 @@ async def test_chat_same_off_allowlist_model_still_403(pin_setup):
     )
     assert resp.status_code == 403, resp.text
     assert "not authorized to use model" in resp.text
+
+
+# REGRESSION (fail-open): an agent with NO explicit ``model`` field in its
+# config is NOT pinned — the old implementation fell back to the global
+# ``llm.default_model`` so the allowed set was never empty, which pinned
+# (and 403'd) operator-created agents whose config carried no model row.
+# Now the pin fails open: any requested model passes the pin and reaches
+# dispatch.
+@pytest.mark.asyncio
+async def test_agent_without_explicit_model_not_pinned(pin_setup):
+    app = pin_setup["app"]
+    # Drop writer's explicit model — config has no per-agent model. The
+    # global default_model is still openai/gpt-4o-mini, but it must NOT be
+    # used as a pin source anymore.
+    pin_setup["cfg_holder"]["cfg"]["agents"]["writer"].pop("model", None)
+    # An arbitrary model unrelated to the global default passes the pin.
+    resp = await _post(
+        app, _req("anthropic/claude-opus-4"), "writer-secret", "writer",
+    )
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["success"] is True
+    # It reached the vault (the pin did not short-circuit it).
+    assert pin_setup["vault"].calls[-1]["model"] == "anthropic/claude-opus-4"
+
+
+# An agent with no config row at all (not present under ``agents``) is also
+# unpinned — same fail-open path.
+@pytest.mark.asyncio
+async def test_agent_missing_from_config_not_pinned(pin_setup):
+    app = pin_setup["app"]
+    pin_setup["cfg_holder"]["cfg"]["agents"].pop("writer", None)
+    resp = await _post(
+        app, _req("anthropic/claude-opus-4"), "writer-secret", "writer",
+    )
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["success"] is True
+
+
+# Provider-prefix-insensitive compare: an explicit config of
+# ``anthropic/claude-...`` must accept a request for the bare
+# ``claude-...`` (the prefix alone must not false-trip the pin).
+@pytest.mark.asyncio
+async def test_prefix_insensitive_configured_prefixed_request_bare(pin_setup):
+    app = pin_setup["app"]
+    pin_setup["cfg_holder"]["cfg"]["agents"]["writer"]["model"] = (
+        "anthropic/claude-3-5-sonnet"
+    )
+    resp = await _post(
+        app, _req("claude-3-5-sonnet"), "writer-secret", "writer",
+    )
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["success"] is True
+    assert pin_setup["vault"].calls[-1]["model"] == "claude-3-5-sonnet"
+
+
+# ...and the reverse: configured bare, request prefixed.
+@pytest.mark.asyncio
+async def test_prefix_insensitive_configured_bare_request_prefixed(pin_setup):
+    app = pin_setup["app"]
+    pin_setup["cfg_holder"]["cfg"]["agents"]["writer"]["model"] = (
+        "claude-3-5-sonnet"
+    )
+    resp = await _post(
+        app, _req("anthropic/claude-3-5-sonnet"), "writer-secret", "writer",
+    )
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["success"] is True
+    assert (
+        pin_setup["vault"].calls[-1]["model"] == "anthropic/claude-3-5-sonnet"
+    )
+
+
+# Prefix-insensitivity must not weaken the pin: a genuinely different bare
+# name (same provider prefix) is still 403'd.
+@pytest.mark.asyncio
+async def test_prefix_insensitive_does_not_allow_different_bare_name(pin_setup):
+    app = pin_setup["app"]
+    pin_setup["cfg_holder"]["cfg"]["agents"]["writer"]["model"] = (
+        "anthropic/claude-3-5-sonnet"
+    )
+    resp = await _post(
+        app, _req("anthropic/claude-opus-4"), "writer-secret", "writer",
+    )
+    assert resp.status_code == 403, resp.text
+    assert "not authorized to use model" in resp.text


### PR DESCRIPTION
## Regression

The LLM-proxy model pin (`_agent_allowed_models` / `_enforce_model_pin` in `src/host/server.py`) was **403-ing legitimate operator-created agents** on their `/mesh/api` LLM calls, so they could not be messaged.

### Root cause

`_agent_allowed_models` built the allowed set as `acfg.get("model") or default_model`, where `default_model` fell back to a hardcoded global (`llm.default_model`, default `openai/gpt-4o-mini`). The allowed set was therefore **never empty**, so the function **never failed open** — directly contradicting its own docstring ("Returns None ... when the agent has no resolvable model"). Any agent without an explicit `agents.{id}.model` row (or whose model differed from the global default) got pinned to the global default and 403'd.

## Fix (KISS, surgical)

1. **`_agent_allowed_models`** now builds the allowed set ONLY from the agent's **explicit** `model` plus `allowed_models`. The global-default fallback is removed, so the function returns `None` (no pin / fail-open) when the agent has no explicit per-agent model. We must not pin an agent to a global default it may not actually use. Docstring updated to match.
2. **`_enforce_model_pin`** does a provider-prefix-**insensitive** compare: it only 403s when the requested model is not in `allowed` AND its bare name (everything after the last `/`, lowercased) is not among the bare names of `allowed`. This stops `claude-3-5-sonnet` vs `anthropic/claude-3-5-sonnet` from false-tripping the pin.

## Security stays intact

- Agents **with** an explicit `model` (or `allowed_models`) remain pinned — a genuinely different requested model still 403s (incl. a different bare name under the same provider prefix).
- `can_use_api` and `is_model_compatible` (the legitimate guard against a model whose provider key isn't configured) are **untouched**.

## Tests

`tests/test_llm_model_pin.py` — kept existing coverage (explicit-model agent 403s on off-allowlist model, edit-updates-pin, failover substitute, operator bypass, `allowed_models` widening, embed exemption, incompatible-model). Added:
- agent with **no** explicit `model` is not pinned (the regression fix), incl. agent missing from config entirely
- prefix-insensitive compare both directions (configured prefixed → bare request, configured bare → prefixed request)
- prefix-insensitivity does **not** weaken the pin: a different bare name under the same prefix still 403s

### Verification
`python -m pytest tests/test_llm_model_pin.py tests/test_credentials.py tests/test_integration.py -q` → **417 passed**.
`ruff check src/host/server.py tests/test_llm_model_pin.py` → clean.