### PR TITLE
fix(credentials): family-based Anthropic OAuth allowlist (stale exact-version pin caused prod 403s)

### DIFF
--- a/src/host/credentials.py
+++ b/src/host/credentials.py
@@ -259,10 +259,47 @@ OAUTH_ALLOWED_MODELS_ANTHROPIC = _parse_env_models(
     }),
 )
 
+# Whether the operator deliberately narrowed the Anthropic OAuth subset.
+# When True, ``is_model_compatible`` enforces EXACT membership against
+# ``OAUTH_ALLOWED_MODELS_ANTHROPIC`` (the operator opted into a fixed list).
+# When False (the default), the Anthropic OAuth path is FAMILY-based: any
+# Claude opus/sonnet/haiku model is accepted. An Anthropic OAuth token is
+# provider-locked (it can only ever call Anthropic), so exact-version pins
+# just produced stale-allowlist 403s every time the Claude lineup bumped a
+# version (prod: anthropic/claude-opus-4-6 → hard 403 gate=api:model_incompatible
+# even though the same OAuth credential serves claude-opus-4-8 in-process).
+_ANTHROPIC_OAUTH_ALLOWLIST_IS_OPERATOR_SET = bool(
+    os.environ.get("OPENLEGION_OAUTH_ALLOWED_MODELS_ANTHROPIC")
+)
+
+# Bare Claude families accepted by default on the Anthropic OAuth path.
+# Matched as ``<family>-*`` against the bare model name (sans ``anthropic/``).
+_ANTHROPIC_OAUTH_MODEL_FAMILIES = frozenset({
+    "claude-opus",
+    "claude-sonnet",
+    "claude-haiku",
+})
+
 _OAUTH_ALLOWED_MODELS: dict[str, frozenset[str]] = {
     "openai": OAUTH_ALLOWED_MODELS_OPENAI,
     "anthropic": OAUTH_ALLOWED_MODELS_ANTHROPIC,
 }
+
+
+def _anthropic_oauth_model_ok(model: str) -> bool:
+    """Family/prefix match for the default Anthropic OAuth allowlist.
+
+    Returns True when the bare model name (``anthropic/`` prefix stripped,
+    lowercased) belongs to one of the Claude opus/sonnet/haiku families —
+    i.e. ``claude-opus-4-6``, ``-4-7``, ``-4-8`` and future versions, plus
+    the sonnet/haiku variants. Used only when the operator has NOT pinned an
+    exact subset via the override env var.
+    """
+    bare = model.rsplit("/", 1)[-1].lower()
+    return any(
+        bare == family or bare.startswith(f"{family}-")
+        for family in _ANTHROPIC_OAUTH_MODEL_FAMILIES
+    )
 
 
 def is_oauth_token(token: str) -> bool:
@@ -955,6 +992,25 @@ class CredentialVault:
         # runtime (see ``_handle_llm`` routing), so apply the OAuth
         # allowlist. This prevents the "passes validation, fails on
         # first call" gap codex flagged.
+        #
+        # Anthropic default: family-based (any claude-opus/sonnet/haiku).
+        # An Anthropic OAuth token is provider-locked, so exact-version
+        # pins only ever produced stale-allowlist 403s on each Claude bump
+        # without buying real isolation. Operators who deliberately set the
+        # override env var still get EXACT enforcement (opt-in narrowing).
+        if (
+            provider == "anthropic"
+            and not _ANTHROPIC_OAUTH_ALLOWLIST_IS_OPERATOR_SET
+        ):
+            if _anthropic_oauth_model_ok(model):
+                return (True, None)
+            families = ", ".join(f"{f}-*" for f in sorted(_ANTHROPIC_OAUTH_MODEL_FAMILIES))
+            return (False, (
+                f"Model '{model}' is not a recognised Claude family for the "
+                f"anthropic OAuth credential. Allowed families: {families}. "
+                f"To pin an exact subset, set "
+                f"OPENLEGION_OAUTH_ALLOWED_MODELS_ANTHROPIC=...,..."
+            ))
         allowed = _OAUTH_ALLOWED_MODELS.get(provider, frozenset())
         if model in allowed:
             return (True, None)

--- a/src/host/credentials.py
+++ b/src/host/credentials.py
@@ -294,10 +294,16 @@ def _anthropic_oauth_model_ok(model: str) -> bool:
     i.e. ``claude-opus-4-6``, ``-4-7``, ``-4-8`` and future versions, plus
     the sonnet/haiku variants. Used only when the operator has NOT pinned an
     exact subset via the override env var.
+
+    A version suffix is REQUIRED (``<family>-*``): the bare family stem on
+    its own (e.g. ``claude-opus``) is not a real model, so it is rejected —
+    a truncated/typo'd config then still fails the create/edit validation
+    gate up front instead of passing here and only erroring at the provider
+    on first call.
     """
     bare = model.rsplit("/", 1)[-1].lower()
     return any(
-        bare == family or bare.startswith(f"{family}-")
+        bare.startswith(f"{family}-")
         for family in _ANTHROPIC_OAUTH_MODEL_FAMILIES
     )
 

--- a/tests/test_credentials.py
+++ b/tests/test_credentials.py
@@ -4351,6 +4351,122 @@ class TestCredentialKindAndModelCompat:
             monkeypatch.delenv("OPENLEGION_OAUTH_ALLOWED_MODELS_OPENAI", raising=False)
             importlib.reload(creds_mod)
 
+    def test_anthropic_oauth_family_accepts_any_claude_by_default(self, monkeypatch):
+        """By default (no override env), Anthropic OAuth accepts ANY model
+        in the claude-opus/sonnet/haiku families — current AND future
+        versions. Regression for the prod stale-allowlist 403: an agent
+        on anthropic/claude-opus-4-6 got gate=api:model_incompatible even
+        though the same OAuth credential serves claude-opus-4-8."""
+        self._purge_env(monkeypatch)
+        monkeypatch.setenv(
+            "OPENLEGION_SYSTEM_ANTHROPIC_API_KEY",
+            "sk-ant-oat01-" + "x" * 80,
+        )
+        v = CredentialVault()
+        assert v.get_credential_kind("anthropic") == "oauth"
+        for model in (
+            "anthropic/claude-opus-4-6",    # the prod-broken model
+            "anthropic/claude-opus-4-7",
+            "anthropic/claude-opus-4-8",    # in-process operator model
+            "anthropic/claude-sonnet-4-6",
+            "anthropic/claude-haiku-4-5-20251001",
+        ):
+            ok, reason = v.is_model_compatible(model)
+            assert ok is True, f"{model} should be compatible (reason={reason})"
+            assert reason is None
+
+    def test_anthropic_oauth_family_rejects_non_claude(self, monkeypatch):
+        """A non-Claude / unrecognised anthropic model is still rejected
+        under the family default, and the reason names the allowed families
+        plus the override env var."""
+        self._purge_env(monkeypatch)
+        monkeypatch.setenv(
+            "OPENLEGION_SYSTEM_ANTHROPIC_API_KEY",
+            "sk-ant-oat01-" + "x" * 80,
+        )
+        v = CredentialVault()
+        # Legacy claude-3-* names do NOT match the claude-opus-*/sonnet-*/
+        # haiku-* families (bare name is 'claude-3-opus-...').
+        ok, reason = v.is_model_compatible("anthropic/claude-3-opus-20240229")
+        assert ok is False
+        assert reason is not None
+        assert "claude-opus-*" in reason
+        assert "claude-sonnet-*" in reason
+        assert "claude-haiku-*" in reason
+        assert "OPENLEGION_OAUTH_ALLOWED_MODELS_ANTHROPIC" in reason
+
+    def test_anthropic_oauth_override_enforces_exact_match(self, monkeypatch):
+        """When the operator sets OPENLEGION_OAUTH_ALLOWED_MODELS_ANTHROPIC,
+        it becomes an opt-in EXACT restriction — family matching is disabled
+        and only the listed models pass."""
+        import importlib
+
+        import src.host.credentials as creds_mod
+        monkeypatch.setenv(
+            "OPENLEGION_OAUTH_ALLOWED_MODELS_ANTHROPIC",
+            "anthropic/claude-opus-4-7",
+        )
+        importlib.reload(creds_mod)
+        try:
+            # Recreate the vault from the reloaded module so it picks up
+            # the operator-set flag + parsed override set.
+            self._purge_env(monkeypatch)
+            monkeypatch.setenv(
+                "OPENLEGION_SYSTEM_ANTHROPIC_API_KEY",
+                "sk-ant-oat01-" + "x" * 80,
+            )
+            v = creds_mod.CredentialVault()
+            assert v.get_credential_kind("anthropic") == "oauth"
+            # Exact-listed model passes.
+            ok, reason = v.is_model_compatible("anthropic/claude-opus-4-7")
+            assert ok is True, reason
+            # A different (family-matching) version is now REJECTED because
+            # the operator opted into an exact subset.
+            ok2, reason2 = v.is_model_compatible("anthropic/claude-opus-4-8")
+            assert ok2 is False
+            assert reason2 is not None
+            assert "OAuth-allowed models" in reason2
+        finally:
+            monkeypatch.delenv(
+                "OPENLEGION_OAUTH_ALLOWED_MODELS_ANTHROPIC", raising=False
+            )
+            importlib.reload(creds_mod)
+
+    def test_openai_oauth_unchanged_still_exact(self, monkeypatch):
+        """The OpenAI OAuth subset is genuinely restricted (codex) and stays
+        EXACT — the Anthropic family change must not loosen it. A non-listed
+        gpt model is still rejected."""
+        self._purge_env(monkeypatch)
+        monkeypatch.setenv(
+            "OPENLEGION_SYSTEM_OPENAI_OAUTH",
+            '{"access_token":"tok","refresh_token":"ref"}',
+        )
+        v = CredentialVault()
+        assert v.get_credential_kind("openai") == "oauth"
+        # gpt-5-codex-next would "family match" if we naively reused the
+        # Anthropic logic — it must NOT, OpenAI stays exact.
+        ok, reason = v.is_model_compatible("openai/gpt-5-codex-next")
+        assert ok is False
+        assert reason is not None
+        assert "OAuth-allowed models" in reason
+        # A genuinely-listed model still passes.
+        ok2, _ = v.is_model_compatible("openai/gpt-5.3-codex")
+        assert ok2 is True
+
+    def test_anthropic_api_key_path_accepts_any_model(self, monkeypatch):
+        """A regular (non-OAuth) Anthropic api_key is unrestricted — the
+        family gate only applies to the OAuth path."""
+        self._purge_env(monkeypatch)
+        monkeypatch.setenv(
+            "OPENLEGION_SYSTEM_ANTHROPIC_API_KEY",
+            "sk-ant-api03-regular-key",
+        )
+        v = CredentialVault()
+        assert v.get_credential_kind("anthropic") == "api_key"
+        ok, reason = v.is_model_compatible("anthropic/claude-3-opus-20240229")
+        assert ok is True
+        assert reason is None
+
 
 class TestLLMAuthAndConfigErrors:
     """Tests for LLMAuthError / LLMConfigError raised from OAuth paths.

--- a/tests/test_credentials.py
+++ b/tests/test_credentials.py
@@ -4395,6 +4395,33 @@ class TestCredentialKindAndModelCompat:
         assert "claude-haiku-*" in reason
         assert "OPENLEGION_OAUTH_ALLOWED_MODELS_ANTHROPIC" in reason
 
+    def test_anthropic_oauth_family_rejects_bare_stem_without_version(self, monkeypatch):
+        """A version suffix is REQUIRED: a bare family stem with no version
+        (e.g. ``anthropic/claude-opus``) is not a real model and is rejected
+        under the family default, so a truncated/typo'd config fails the
+        create/edit validation gate up front instead of only erroring at the
+        provider on first call. The fully versioned model still passes — this
+        documents the boundary."""
+        self._purge_env(monkeypatch)
+        monkeypatch.setenv(
+            "OPENLEGION_SYSTEM_ANTHROPIC_API_KEY",
+            "sk-ant-oat01-" + "x" * 80,
+        )
+        v = CredentialVault()
+        assert v.get_credential_kind("anthropic") == "oauth"
+        for model in (
+            "anthropic/claude-opus",
+            "anthropic/claude-sonnet",
+            "anthropic/claude-haiku",
+        ):
+            ok, reason = v.is_model_compatible(model)
+            assert ok is False, f"{model} (bare stem) should be rejected"
+            assert reason is not None
+        # The fully versioned model still passes — boundary documented.
+        ok, reason = v.is_model_compatible("anthropic/claude-opus-4-8")
+        assert ok is True
+        assert reason is None
+
     def test_anthropic_oauth_override_enforces_exact_match(self, monkeypatch):
         """When the operator sets OPENLEGION_OAUTH_ALLOWED_MODELS_ANTHROPIC,
         it becomes an opt-in EXACT restriction — family matching is disabled


### PR DESCRIPTION
## Problem (production incident, kovarastudio)

A customer instance authenticates Anthropic via **OAuth** (Claude subscription token), not an API key. `CredentialVault.is_model_compatible()` gates LLM-proxy calls; on the OAuth path it checked **exact membership** in a hardcoded frozenset `{claude-opus-4-7, claude-sonnet-4-6, claude-haiku-4-5}`.

That allowlist was stale. A container agent (`content-creator`) configured for `anthropic/claude-opus-4-6` got a hard **403 `gate=api:model_incompatible` on every message** — even though the same OAuth credential serves `claude-opus-4-8` fine for the in-process operator (which bypasses this HTTP gate). Exact-version pins guarantee this breaks again on every Claude lineup bump.

## Fix

Make the Anthropic OAuth allowlist **family/prefix-based** by default: accept any `claude-opus-*` / `claude-sonnet-*` / `claude-haiku-*`. An Anthropic OAuth token is provider-locked (it can only ever call Anthropic), so this isn't a meaningful security loss — it just stops rejecting valid Claude models.

- Operators who set `OPENLEGION_OAUTH_ALLOWED_MODELS_ANTHROPIC` still get **exact** enforcement (opt-in narrowing).
- **OpenAI** OAuth (the gpt-5 subset) is **unchanged** — that subscription subset is genuinely restricted.
- Rejected-model reason string updated to name the allowed families + the override env var.

## Tests
Added coverage in `tests/test_credentials.py`: opus-4-6/-4-7/-4-8 + sonnet/haiku all compatible by default; non-Claude still rejected; env override still enforces exact; OpenAI OAuth unchanged; api_key path still unrestricted. `tests/test_credentials.py tests/test_create_agent_model_validation.py tests/test_llm_model_pin.py` → 330 passed, ruff clean.