### PR TITLE
fix(health): rebuild agent from agents.yaml when runtime registry entry is missing

### DIFF
--- a/src/host/health.py
+++ b/src/host/health.py
@@ -443,6 +443,33 @@ class HealthMonitor:
             logger.warning(f"Agent '{agent_id}' unreachable, restarting...")
             await self._try_restart(agent_id)
 
+    def _info_from_yaml(self, agent_id: str) -> dict | None:
+        """Reconstruct a runtime-registry-shaped info dict from agents.yaml.
+
+        Used by ``_try_restart`` as a fallback when the runtime's in-memory
+        ``agents`` map has no entry for ``agent_id`` (e.g. the container died
+        and was deregistered during a redeploy). Mirrors the reload pattern
+        in ``cli/repl.py:_restart_agent`` so a health-monitor restart can
+        rebuild the container from disk instead of stranding the agent.
+
+        Returns ``None`` when the agent is not defined in agents.yaml at all.
+        """
+        fresh_cfg = _load_config()
+        agents_cfg = fresh_cfg.get("agents", {})
+        if agent_id not in agents_cfg:
+            return None
+        agent_cfg = agents_cfg.get(agent_id, {})
+        default_model = fresh_cfg.get("llm", {}).get(
+            "default_model", "openai/gpt-4o-mini",
+        )
+        return {
+            "role": agent_cfg.get("role", ""),
+            "skills_dir": os.path.abspath(agent_cfg.get("skills_dir", "")),
+            "model": agent_cfg.get("model", default_model),
+            "mcp_servers": agent_cfg.get("mcp_servers") or None,
+            "thinking": agent_cfg.get("thinking", ""),
+        }
+
     async def _try_restart(self, agent_id: str) -> None:
         health = self.agents[agent_id]
         now = time.time()
@@ -479,12 +506,26 @@ class HealthMonitor:
         logger.info(f"Restarting agent '{agent_id}'...")
         info = self.runtime.agents.get(agent_id)
         if not info:
-            logger.error(
-                "Cannot restart agent '%s': no stored config. "
-                "Manual restart required.", agent_id,
+            # The runtime lost its in-memory registry entry (e.g. the
+            # container died and was deregistered during a redeploy), but the
+            # agent may still be fully defined on disk. Rather than stranding
+            # it permanently, rebuild the start parameters from agents.yaml —
+            # the same fallback the CLI manual restart uses
+            # (cli/repl.py:_restart_agent). Only if the agent is ALSO absent
+            # from yaml is it truly unknown and unrecoverable.
+            info = self._info_from_yaml(agent_id)
+            if not info:
+                logger.error(
+                    "Cannot restart agent '%s': no stored config and not "
+                    "defined in agents.yaml. Manual restart required.",
+                    agent_id,
+                )
+                health.status = "failed"
+                return
+            logger.info(
+                "Agent '%s' missing from runtime registry; rebuilding "
+                "container from agents.yaml config.", agent_id,
             )
-            health.status = "failed"
-            return
         try:
             loop = asyncio.get_running_loop()
             await loop.run_in_executor(None, self.runtime.stop_agent, agent_id)

--- a/src/host/health.py
+++ b/src/host/health.py
@@ -452,9 +452,21 @@ class HealthMonitor:
         in ``cli/repl.py:_restart_agent`` so a health-monitor restart can
         rebuild the container from disk instead of stranding the agent.
 
-        Returns ``None`` when the agent is not defined in agents.yaml at all.
+        Returns ``None`` when the agent is not defined in agents.yaml at all,
+        or when the config can't be read — the caller treats ``None`` as
+        "unrecoverable, mark failed", which preserves the original
+        exception-free behaviour of the no-stored-config path (the later
+        ``_load_config`` call in ``_try_restart`` is likewise inside a
+        ``try``; this one must not be the lone unguarded read).
         """
-        fresh_cfg = _load_config()
+        try:
+            fresh_cfg = _load_config()
+        except Exception as e:
+            logger.error(
+                "Cannot reload config to restart agent '%s' from yaml: %s",
+                agent_id, e,
+            )
+            return None
         agents_cfg = fresh_cfg.get("agents", {})
         if agent_id not in agents_cfg:
             return None

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -74,18 +74,82 @@ class TestEphemeralCleanup:
 
 class TestHealthRestartMissingConfig:
     @pytest.mark.asyncio
-    async def test_restart_skipped_when_no_config(self):
-        """Restart with missing agent metadata sets status to 'failed' and does NOT call start_agent."""
-        monitor = _make_monitor({})  # empty agents dict — no config
+    async def test_restart_skipped_when_truly_unknown(self):
+        """Restart for an agent absent from BOTH the runtime registry AND
+        agents.yaml sets status to 'failed' and does NOT call start_agent."""
+        monitor = _make_monitor({})  # empty registry — no in-memory config
         monitor.register("ghost-agent")
         health = monitor.agents["ghost-agent"]
         health.consecutive_failures = 3
         health.status = "unhealthy"
 
-        await monitor._try_restart("ghost-agent")
+        # YAML also has no entry for ghost-agent → truly unrecoverable.
+        fake_cfg = {"agents": {"other-agent": {"role": "x"}}}
+        with patch("src.host.health._load_config", return_value=fake_cfg):
+            await monitor._try_restart("ghost-agent")
 
         assert health.status == "failed"
         monitor.runtime.start_agent.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_restart_falls_back_to_yaml_when_registry_missing(self):
+        """Production incident: a container died and was deregistered from the
+        runtime's in-memory ``agents`` map during a redeploy, but its config
+        still lives in agents.yaml. The restart path must rebuild the
+        container from the yaml config (with the agent's configured model)
+        instead of giving up and marking it permanently 'failed', which turned
+        a transient blip into a permanent outage."""
+        monitor = _make_monitor({})  # registry has NO entry for the agent
+        monitor.register("content-creator")
+        health = monitor.agents["content-creator"]
+        health.consecutive_failures = 3
+        health.status = "unhealthy"
+        monitor.runtime.start_agent.return_value = "http://localhost:8401"
+        monitor.runtime.wait_for_agent = AsyncMock(return_value=True)
+
+        fake_cfg = {
+            "agents": {
+                "content-creator": {
+                    "role": "writer",
+                    "skills_dir": "skills/content",
+                    "model": "anthropic/claude-3-5-sonnet",
+                },
+            },
+            "llm": {"default_model": "openai/gpt-4o-mini"},
+        }
+        with patch("src.host.health._load_config", return_value=fake_cfg):
+            await monitor._try_restart("content-creator")
+
+        # Rebuilt from yaml rather than marked failed.
+        monitor.runtime.start_agent.assert_called_once()
+        _, kwargs = monitor.runtime.start_agent.call_args
+        assert kwargs["agent_id"] == "content-creator"
+        assert kwargs["role"] == "writer"
+        assert kwargs["model"] == "anthropic/claude-3-5-sonnet"
+        assert health.status == "healthy"
+        assert health.restart_count == 1
+
+    @pytest.mark.asyncio
+    async def test_yaml_fallback_uses_default_model_when_unset(self):
+        """When the yaml agent entry omits ``model``, the fallback uses the
+        configured llm.default_model (mirrors cli/repl.py:_restart_agent)."""
+        monitor = _make_monitor({})
+        monitor.register("content-creator")
+        health = monitor.agents["content-creator"]
+        health.consecutive_failures = 3
+        health.status = "unhealthy"
+        monitor.runtime.start_agent.return_value = "http://localhost:8401"
+        monitor.runtime.wait_for_agent = AsyncMock(return_value=True)
+
+        fake_cfg = {
+            "agents": {"content-creator": {"role": "writer"}},
+            "llm": {"default_model": "anthropic/claude-3-5-haiku"},
+        }
+        with patch("src.host.health._load_config", return_value=fake_cfg):
+            await monitor._try_restart("content-creator")
+
+        _, kwargs = monitor.runtime.start_agent.call_args
+        assert kwargs["model"] == "anthropic/claude-3-5-haiku"
 
     @pytest.mark.asyncio
     async def test_restart_succeeds_with_config(self):

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -92,6 +92,32 @@ class TestHealthRestartMissingConfig:
         monitor.runtime.start_agent.assert_not_called()
 
     @pytest.mark.asyncio
+    async def test_restart_marks_failed_when_yaml_load_raises(self):
+        """New guard: when the runtime registry has NO entry for the agent
+        and the yaml fallback's ``_load_config`` RAISES (corrupt/unreadable
+        agents.yaml), ``_info_from_yaml`` swallows the exception and returns
+        ``None`` so ``_try_restart`` takes its unrecoverable path cleanly —
+        marking the agent 'failed' instead of letting the exception
+        propagate out of the health-monitor loop and stalling all other
+        agents' checks."""
+        monitor = _make_monitor({})  # registry has NO entry for the agent
+        monitor.register("ghost-agent")
+        health = monitor.agents["ghost-agent"]
+        health.consecutive_failures = 3
+        health.status = "unhealthy"
+
+        # The yaml fallback read blows up (e.g. corrupt YAML on disk).
+        with patch(
+            "src.host.health._load_config",
+            side_effect=RuntimeError("corrupt yaml"),
+        ):
+            # Must NOT propagate — no exception escapes _try_restart.
+            await monitor._try_restart("ghost-agent")
+
+        assert health.status == "failed"
+        monitor.runtime.start_agent.assert_not_called()
+
+    @pytest.mark.asyncio
     async def test_restart_falls_back_to_yaml_when_registry_missing(self):
         """Production incident: a container died and was deregistered from the
         runtime's in-memory ``agents`` map during a redeploy, but its config


### PR DESCRIPTION
## Problem (production incident, kovarastudio)

After a redeploy, an agent's container died and was deregistered from the runtime's in-memory `runtime.agents` map. The health monitor detected it unreachable, tried to auto-restart, and **gave up permanently**:

```
host.health: Agent 'content-creator' unreachable, restarting...
host.health: ERROR Cannot restart agent 'content-creator': no stored config. Manual restart required.
```

`HealthMonitor._try_restart` read **only** `runtime.agents.get(agent_id)`; when that was `None` it marked the agent `failed` and stopped — even though the agent was fully defined in `config/agents.yaml`. A transient container loss became a **permanent outage** requiring a full mesh restart to recover.

## Fix

Give the health monitor the same yaml-reload fallback the CLI manual restart (`cli/repl.py:_restart_agent`) already uses. New helper `_info_from_yaml(agent_id)` reconstructs the registry-shaped info dict (`role`/`skills_dir`/`model`/`mcp_servers`/`thinking`) from `agents.yaml`. When the in-memory entry is missing, `_try_restart` synthesizes `info` from yaml and continues through the **existing, unchanged** restart branch (same `run_in_executor` stop/start, same restart-limit/backoff accounting, same env preservation). Only when the agent is absent from yaml too is it truly unrecoverable.

## Tests
`tests/test_health.py`: truly-unknown agent still marks `failed`; **registry-missing-but-in-yaml now rebuilds** (asserts `start_agent` called with the yaml model); yaml entry without `model` falls back to `llm.default_model`. → 29 passed (+ test_health_liveness 14 passed).