### PR TITLE
feat(skills): SKILL.md loader + store + progressive-disclosure tools (PR 2)

### DIFF
--- a/docs/plans/2026-05-31-tools-skills-rename-and-skill-packs.md
+++ b/docs/plans/2026-05-31-tools-skills-rename-and-skill-packs.md
@@ -43,8 +43,8 @@ For genuinely new *executable* third-party capability, the answer is **MCP (out-
 | Task | Description | PR |
 |---|---|---|
 | Task 1 | **The rename.** `@skill`→`@tool`, `SkillRegistry`→`ToolRegistry`, `skills.py`→`tools.py`, `create_skill`/`reload_skills`→`create_tool`/`reload_tools`, storage dirs + env vars, dashboard labels, `src/shared/types.py` contract, docs. No behavior change. | PR 1 |
-| Task 2 | **`SKILL.md` loader + store.** Parse frontmatter, directory-scan a skills store, model the pack (name/description/body/scripts/refs/config/env). | PR 2 |
-| Task 3 | **Progressive disclosure tools.** `skills_list` (Level 0: names+descriptions) / `skill_view(name)` (Level 1: full body) / `skill_view(name, path)` (Level 2: reference file). | PR 2 |
+| Task 2 | **`SKILL.md` loader + store.** Parse frontmatter, directory-scan a skills store, model the pack (name/description/body/scripts/refs/config/env). **✅ shipped PR 2** (`src/agent/skills.py`). | PR 2 |
+| Task 3 | **Progressive disclosure tools.** `skills_list` (Level 0: names+descriptions) / `skill_view(name)` (Level 1: full body) / `skill_view(name, path)` (Level 2: reference file). **✅ shipped PR 2** (`src/agent/builtins/skills_tool.py`). | PR 2 |
 | Task 4 | **Invocation.** Slash-command routing (`/competitor-research ...`) + natural-language match against descriptions. Inject resolved config values + declared env into the agent context on load. | PR 3 |
 | Task 5 | **Install / distribution.** Operator-gated install path through the existing `src/marketplace.py`; per-team scoping via permissions (mirror `fleet_tool.apply_template`). Dashboard surface with built-in / custom / imported provenance. | PR 3 |
 | Task 6 | **Demote agent-authored code.** Make `create_tool` (formerly `create_skill`) operator/advanced-only now that markdown Skills cover most "teach my agent X" cases. | PR 4 |
@@ -124,10 +124,12 @@ required_environment_variables:
 
 ## Open decisions (resolve before PR 2)
 
-1. **Wire-compatibility level** — full agentskills.io drop-in (constrains us to their frontmatter, incl. the `metadata.hermes.*` namespace) vs. our own dialect with an import shim. *Lean: full compat, ingest-time mapping of the vendor namespace.*
-2. **Skill scope** — per-team store vs. global store with permission grants. *Lean: per-team, mirroring fleet templates.*
-3. **Self-authoring** — keep `create_tool` (agent writes Python) at all, or humans/MCP only? *Lean: keep but operator-gated (Task 6).*
-4. **Marketplace shape** — is `src/marketplace.py` the home for Skill distribution, and does it serve Tools (MCP) too?
+1. **Wire-compatibility level** — full agentskills.io drop-in (constrains us to their frontmatter, incl. the `metadata.hermes.*` namespace) vs. our own dialect with an import shim. *Lean: full compat, ingest-time mapping of the vendor namespace.* **RESOLVED (PR 2): full compat.** The loader requires only `name` + `description` and preserves all other frontmatter (incl. vendor `metadata.*`) verbatim in `Skill.metadata` — never rejected. Interpretation of the vendor namespace (toolset hints, config) is deferred to use-time (PR 3 / Task 4).
+2. **Skill scope** — per-team store vs. global store with permission grants. *Lean: per-team, mirroring fleet templates.* **PARTIALLY RESOLVED (PR 2): the read layer is a flat two-tier store** — bundled `/app/skills` (ro) + installed `/data/skills` (writable, installed-overrides-bundled). Per-team scoping is an *install*-time concern (where a pack lands + who sees it) and is settled in PR 3 / Task 5.
+3. **Self-authoring** — keep `create_tool` (agent writes Python) at all, or humans/MCP only? *Lean: keep but operator-gated (Task 6).* (Unchanged — PR 4.)
+4. **Marketplace shape** — is `src/marketplace.py` the home for Skill distribution, and does it serve Tools (MCP) too? *Lean: yes — PR 3 adds `install_skill` mirroring `install_tool`.*
+
+**PR 2 notes (read layer):** No `reload_skills` tool — `SkillStore` re-scans on every call, so an installed pack is visible immediately (strictly simpler than Tools' `reload_tools` dance). Bundled packs mount from the repo `skills/` dir → `/app/skills` (ro), mirroring the existing `agent_tools/_marketplace → /app/marketplace_tools` mount (no Dockerfile change). `skills_list`/`skill_view` are read-only builtins: workers get them by default (tool access isn't ACL-gated by name), added to `_READ_ONLY_TOOLS` (lazy-completion guard), the operator allowlist, and the dashboard `verbForTool` map.
 
 ---
 

--- a/skills/competitor-research/SKILL.md
+++ b/skills/competitor-research/SKILL.md
@@ -1,0 +1,32 @@
+---
+name: competitor-research
+description: Research a competitor across the web and produce a cited, structured brief.
+version: 1.0.0
+license: MIT
+metadata:
+  requires_toolsets: [web_search, http_request]
+---
+# When to Use
+
+Use this skill when asked to "research", "look into", or "produce a brief on"
+a specific competitor or company. It assumes you already have `web_search`
+and `http_request`; it adds no new capability — only a procedure.
+
+# Procedure
+
+1. Establish the basics: official site, what they sell, who they sell to.
+   Run `web_search` for the company name plus "pricing", "product", "funding".
+2. Gather 5–10 distinct sources. Prefer primary sources (the company's own
+   pages, filings, docs) over secondary commentary. Record the URL for each
+   claim as you go — every fact in the brief must be traceable.
+3. Cross-check anything surprising against a second source before stating it.
+   If two sources conflict, say so in the brief rather than picking one.
+4. Assemble the brief using the structure in
+   `references/brief-template.md` (read it with skill_view if unsure).
+
+# Pitfalls / Verification
+
+- Do not state pricing, headcount, or funding numbers without a dated source.
+- Marketing copy is not a source for capability claims — verify in docs.
+- Before reporting done, confirm every section of the template is filled and
+  every non-obvious claim has a citation.

--- a/skills/competitor-research/references/brief-template.md
+++ b/skills/competitor-research/references/brief-template.md
@@ -1,0 +1,25 @@
+# Competitor Brief — {Company}
+
+## Summary
+One paragraph: what they do, who for, why they matter to us.
+
+## Product & Positioning
+- Core product(s):
+- Target segment:
+- Stated differentiation:
+
+## Pricing
+- Model (per-seat / usage / tiered):
+- Public price points (with source + date):
+
+## Traction & Funding
+- Notable customers (sourced):
+- Funding / size (sourced, dated):
+
+## Strengths / Weaknesses
+- Strengths:
+- Weaknesses / gaps:
+
+## Sources
+1. <url> — what it supports
+2. <url> — what it supports

--- a/src/agent/builtins/skills_tool.py
+++ b/src/agent/builtins/skills_tool.py
@@ -1,0 +1,78 @@
+"""Progressive-disclosure tools for SKILL.md skill packs.
+
+These two tools are READ-ONLY: they let an agent discover and read
+procedural skill packs (instructions for using the tools it already has).
+They add no capability and widen no permission — a Skill can only ever
+orchestrate Tools the agent is already allowed to call. See
+``src/agent/skills.py`` for the loader/store.
+"""
+
+from __future__ import annotations
+
+from src.agent.skills import SkillStore
+from src.agent.tools import tool
+
+
+@tool(
+    name="skills_list",
+    description=(
+        "List available skill packs — saved step-by-step procedures for "
+        "common jobs, written in plain language. Returns each skill's name "
+        "and a one-line description. When a skill looks relevant to your "
+        "task, call skill_view(name) to read its full instructions and "
+        "follow them. Skills use only tools you already have."
+    ),
+    parameters={},
+)
+def skills_list() -> dict:
+    skills = SkillStore().list()
+    return {
+        "skills": [{"name": s.name, "description": s.description} for s in skills],
+        "count": len(skills),
+        "hint": "Call skill_view(name) to read a skill's full instructions.",
+    }
+
+
+@tool(
+    name="skill_view",
+    description=(
+        "Read a skill pack's full instructions. Call with just 'name' to get "
+        "the procedure body; pass 'path' to read a bundled reference file the "
+        "skill points you to (e.g. 'references/checklist.md'). Discover names "
+        "with skills_list first."
+    ),
+    parameters={
+        "name": {
+            "type": "string",
+            "description": "Skill name as returned by skills_list.",
+        },
+        "path": {
+            "type": "string",
+            "description": (
+                "Optional reference file path within the skill, relative to "
+                "the skill directory (e.g. 'references/checklist.md')."
+            ),
+            "default": "",
+        },
+    },
+)
+def skill_view(name: str, path: str = "") -> dict:
+    store = SkillStore()
+    skill = store.get(name)
+    if skill is None:
+        return {
+            "error": (
+                f"Skill '{name}' not found. Call skills_list to see available skills."
+            ),
+        }
+    if path:
+        content = store.read_reference(name, path)
+        if content is None:
+            return {"error": f"Reference '{path}' not found in skill '{name}'."}
+        return {"name": name, "path": path, "content": content}
+    return {
+        "name": skill.name,
+        "description": skill.description,
+        "version": skill.version,
+        "body": skill.body,
+    }

--- a/src/agent/loop.py
+++ b/src/agent/loop.py
@@ -228,6 +228,9 @@ _READ_ONLY_TOOLS = frozenset({
     "vault_list",
     # Self-introspection
     "introspect",
+    # Skill-pack discovery/read (SKILL.md packs). Pure reads — consulting
+    # a procedure is not itself outbound work.
+    "skills_list", "skill_view",
     # NOTE: ``web_search`` is intentionally NOT here — it makes an
     # external network call which counts as outbound work. Same logic
     # applies to any external HTTP / image-gen / browser tool: a worker
@@ -1703,6 +1706,8 @@ class AgentLoop:
             f"- If your first approach fails, try at least one alternative before reporting a blocker.\n"
             f"- Never respond with just text when a tool could make progress.\n"
             f"- Before acting on past context, run memory_search first.\n"
+            f"- For a non-trivial task, call skills_list first — if a skill "
+            f"(saved step-by-step procedure) fits, skill_view it and follow it.\n"
             f"- When done, respond with JSON: "
         )
         if is_standalone:

--- a/src/agent/skills.py
+++ b/src/agent/skills.py
@@ -1,0 +1,204 @@
+"""SKILL.md procedural skill packs — loader and store.
+
+Skills are *instructions*, not code. A ``SKILL.md`` is YAML frontmatter +
+a markdown body that tells the agent how to do a job using the tools it
+already has. Unlike Tools (executable ``@tool`` functions in ``tools.py``),
+a Skill adds no code to the trusted runtime — installing one never widens
+the agent's tool permissions; it only composes grants the agent already
+holds. The per-agent ACL stays the single capability chokepoint.
+
+Wire-compatible with the agentskills.io ``SKILL.md`` standard: only
+``name`` and ``description`` are required. Every other frontmatter field
+(including vendor ``metadata.*`` namespaces) is preserved verbatim in
+``Skill.metadata`` and interpreted later at use-time — never rejected here.
+
+Progressive disclosure is implemented by the ``skills_list`` / ``skill_view``
+tools in ``builtins/skills_tool.py``:
+
+    Level 0  skills_list()           → names + descriptions (cheap catalog)
+    Level 1  skill_view(name)        → full markdown body
+    Level 2  skill_view(name, path)  → a bundled reference file
+"""
+
+from __future__ import annotations
+
+import os
+import re
+from dataclasses import dataclass, field
+from pathlib import Path
+
+from src.shared.utils import setup_logging
+
+logger = setup_logging("agent.skills")
+
+# Container-side store locations, mirroring the Tools layering:
+#   bundled   → shipped read-only with the product (SKILLS_DIR, default /app/skills)
+#   installed → operator/marketplace-installed packs (writable /data volume)
+# ``installed`` overrides ``bundled`` on a name collision.
+_BUNDLED_DIR_ENV = "SKILLS_DIR"
+_DEFAULT_BUNDLED_DIR = "/app/skills"
+_INSTALLED_DIR = "/data/skills"
+
+# Skill names are matched by exact lookup, never used to build a path — but
+# we still reject path-significant characters so an installed pack can't smuggle
+# a traversal sequence into a name that later code might join onto a path.
+_NAME_RE = re.compile(r"^[a-zA-Z0-9_-]+$")
+
+
+@dataclass(frozen=True)
+class Skill:
+    """A parsed ``SKILL.md`` pack."""
+
+    name: str
+    description: str
+    body: str
+    directory: Path
+    version: str = ""
+    metadata: dict = field(default_factory=dict)
+    source: str = ""  # "bundled" | "installed"
+
+
+def _split_frontmatter(text: str) -> tuple[str, str] | None:
+    """Split a SKILL.md into ``(yaml_frontmatter, body)``; None if absent."""
+    if not text.startswith("---"):
+        return None
+    # maxsplit=2 → ["", frontmatter, body]; the body keeps any further "---".
+    parts = text.split("---", 2)
+    if len(parts) < 3:
+        return None
+    return parts[1], parts[2]
+
+
+def parse_skill_md(md_path: Path, *, source: str = "") -> Skill | None:
+    """Parse a single ``SKILL.md`` file. Returns None on any structural problem.
+
+    Required frontmatter: ``name``, ``description``. Everything else is
+    optional and preserved verbatim in ``Skill.metadata`` (minus the fields
+    promoted to first-class attributes).
+    """
+    try:
+        text = md_path.read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError) as e:
+        logger.debug("Cannot read %s: %s", md_path, e)
+        return None
+
+    split = _split_frontmatter(text)
+    if split is None:
+        logger.debug("No YAML frontmatter in %s", md_path)
+        return None
+    raw_frontmatter, body = split
+
+    try:
+        import yaml
+    except ImportError:
+        logger.error("PyYAML is required to parse SKILL.md packs")
+        return None
+    try:
+        meta = yaml.safe_load(raw_frontmatter)
+    except Exception as e:
+        logger.debug("Bad YAML frontmatter in %s: %s", md_path, e)
+        return None
+    if not isinstance(meta, dict):
+        return None
+
+    name = meta.get("name")
+    description = meta.get("description")
+    if not isinstance(name, str) or not isinstance(description, str):
+        logger.debug("Skill %s missing name/description", md_path)
+        return None
+    name = name.strip()
+    description = description.strip()
+    if not name or not description:
+        return None
+    if not _NAME_RE.match(name):
+        logger.warning("Skipping skill with unsafe name %r in %s", name, md_path)
+        return None
+
+    version = str(meta.get("version", "")).strip()
+    # Preserve everything else verbatim (vendor namespaces, config, env, …).
+    extra = {k: v for k, v in meta.items() if k not in {"name", "description", "version"}}
+
+    return Skill(
+        name=name,
+        description=description,
+        body=body.strip(),
+        directory=md_path.parent,
+        version=version,
+        metadata=extra,
+        source=source,
+    )
+
+
+class SkillStore:
+    """Scans the bundled + installed skill directories on demand.
+
+    The store is intentionally stateless — ``list``/``get`` re-scan disk on
+    every call. Catalogs are tiny and scans are cheap, and statelessness
+    means a freshly installed pack is visible immediately with no reload
+    step (contrast Tools, which need an explicit ``reload_tools``).
+    """
+
+    def __init__(
+        self,
+        bundled_dir: str | os.PathLike | None = None,
+        installed_dir: str | os.PathLike | None = None,
+    ):
+        self.bundled_dir = (
+            Path(bundled_dir)
+            if bundled_dir is not None
+            else Path(os.environ.get(_BUNDLED_DIR_ENV, _DEFAULT_BUNDLED_DIR))
+        )
+        self.installed_dir = (
+            Path(installed_dir) if installed_dir is not None else Path(_INSTALLED_DIR)
+        )
+
+    def _scan_dir(self, directory: Path, source: str) -> dict[str, Skill]:
+        found: dict[str, Skill] = {}
+        if not directory.is_dir():
+            return found
+        for md_path in sorted(directory.glob("**/SKILL.md")):
+            skill = parse_skill_md(md_path, source=source)
+            if skill is None:
+                continue
+            if skill.name in found:
+                logger.warning(
+                    "Duplicate skill %r in %s — keeping first", skill.name, source,
+                )
+                continue
+            found[skill.name] = skill
+        return found
+
+    def _all(self) -> dict[str, Skill]:
+        skills = self._scan_dir(self.bundled_dir, "bundled")
+        # Installed packs override bundled on a name collision.
+        skills.update(self._scan_dir(self.installed_dir, "installed"))
+        return skills
+
+    def list(self) -> list[Skill]:
+        return sorted(self._all().values(), key=lambda s: s.name)
+
+    def get(self, name: str) -> Skill | None:
+        return self._all().get(name)
+
+    def read_reference(self, name: str, rel_path: str) -> str | None:
+        """Read a bundled reference file inside a skill (Level 2), traversal-safe.
+
+        Resolves both the skill directory and the requested path, then verifies
+        the target stays inside the skill — this catches ``..`` traversal and
+        symlink escapes alike (a symlink pointing outside resolves outside the
+        base and fails the containment check).
+        """
+        skill = self.get(name)
+        if skill is None:
+            return None
+        base = skill.directory.resolve()
+        target = (base / rel_path).resolve()
+        if not target.is_relative_to(base):
+            logger.warning("Path traversal blocked: %r in skill %r", rel_path, name)
+            return None
+        if not target.is_file():
+            return None
+        try:
+            return target.read_text(encoding="utf-8")
+        except (OSError, UnicodeDecodeError):
+            return None

--- a/src/agent/skills.py
+++ b/src/agent/skills.py
@@ -44,6 +44,12 @@ _INSTALLED_DIR = "/data/skills"
 # a traversal sequence into a name that later code might join onto a path.
 _NAME_RE = re.compile(r"^[a-zA-Z0-9_-]+$")
 
+# Frontmatter fences are whole ``---`` lines (optional trailing whitespace; ``\r``
+# tolerated for CRLF checkouts), so a ``---`` substring inside a YAML scalar can't
+# be mistaken for a fence. One pattern serves both the opening-fence guard
+# (``.match`` at pos 0) and the body split.
+_FRONTMATTER_FENCE_RE = re.compile(r"^---[ \t\r]*$", re.MULTILINE)
+
 
 @dataclass(frozen=True)
 class Skill:
@@ -59,11 +65,17 @@ class Skill:
 
 
 def _split_frontmatter(text: str) -> tuple[str, str] | None:
-    """Split a SKILL.md into ``(yaml_frontmatter, body)``; None if absent."""
-    if not text.startswith("---"):
+    """Split a SKILL.md into ``(yaml_frontmatter, body)``; None if absent.
+
+    The ``---`` fences are matched as whole lines only (``^---$``), so a literal
+    ``---`` inside a YAML scalar (e.g. a description containing ``---``) does not
+    truncate the frontmatter. maxsplit=2 consumes just the opening and closing
+    fences; any further ``---`` in the body (a horizontal rule) is left intact.
+    """
+    if not _FRONTMATTER_FENCE_RE.match(text):
         return None
-    # maxsplit=2 → ["", frontmatter, body]; the body keeps any further "---".
-    parts = text.split("---", 2)
+    # ["", frontmatter, body]; the body keeps any further "---".
+    parts = _FRONTMATTER_FENCE_RE.split(text, maxsplit=2)
     if len(parts) < 3:
         return None
     return parts[1], parts[2]

--- a/src/cli/config.py
+++ b/src/cli/config.py
@@ -1709,6 +1709,9 @@ _OPERATOR_ALLOWED_TOOLS: list[str] = [
     "read_user_notifications",
     # Coordination + chat
     "list_templates", "apply_template", "hand_off", "check_inbox",
+    # Skill-pack discovery (SKILL.md procedures) — read-only, so the
+    # operator can see which skills its workers can draw on.
+    "skills_list", "skill_view",
     # Workflow awareness — operator-only chain inspection + single-task
     # blocking primitive (see _HEARTBEAT_TOOLS in src/agent/loop.py for
     # the heartbeat surface; both tools self-reject for non-operators).

--- a/src/dashboard/static/js/app.js
+++ b/src/dashboard/static/js/app.js
@@ -10644,6 +10644,8 @@ function dashboard() {
         compose_work_summary: 'composing a work summary',
         workflow_snapshot: 'mapping the workflow',
         await_task_event: 'waiting on a task',
+        skills_list: 'browsing its skills',
+        skill_view: 'reading a skill',
       };
       if (map[toolName]) return map[toolName];
       // Fallback: humanise the snake_case tool name.

--- a/src/host/runtime.py
+++ b/src/host/runtime.py
@@ -411,6 +411,7 @@ class DockerBackend(RuntimeBackend):
             "AGENT_ROLE": role,
             "MESH_URL": f"http://{mesh_host}:{self.mesh_host_port}",
             "TOOLS_DIR": "/app/tools",
+            "SKILLS_DIR": "/app/skills",
             "MESH_AUTH_TOKEN": auth_token,
         }
         # Route system_prompt through INITIAL_INSTRUCTIONS for spawn compat
@@ -469,6 +470,15 @@ class DockerBackend(RuntimeBackend):
             if platform.system() == "Windows":
                 mp_path = marketplace_dir.as_posix()
             volumes[mp_path] = {"bind": "/app/marketplace_tools", "mode": "ro"}
+
+        # Bundled SKILL.md skill packs (read-only). Installed/custom packs
+        # live on the writable /data volume at /data/skills (see SkillStore).
+        skills_dir = self.project_root / "skills"
+        if skills_dir.is_dir():
+            sk_path = str(skills_dir)
+            if platform.system() == "Windows":
+                sk_path = skills_dir.as_posix()
+            volumes[sk_path] = {"bind": "/app/skills", "mode": "ro"}
 
         # Read-only uploads: user-managed files agents can read but never write.
         uploads_path = str(self.uploads_dir.as_posix() if platform.system() == "Windows" else self.uploads_dir)
@@ -1038,6 +1048,16 @@ class SandboxBackend(RuntimeBackend):
         else:
             marketplace_dest.mkdir(exist_ok=True)
 
+        # Copy bundled SKILL.md skill packs
+        skills_src = self.project_root / "skills"
+        skills_dest = ws / "skills"
+        if skills_src.is_dir():
+            if skills_dest.exists():
+                shutil.rmtree(skills_dest)
+            shutil.copytree(skills_src, skills_dest, symlinks=True)
+        else:
+            skills_dest.mkdir(exist_ok=True)
+
         # Generate per-agent auth token for mesh request verification.
         # Task 4 invariant: every agent (including the operator) gets a
         # distinct token keyed by ``agent_id``; no fleet-shared token
@@ -1052,6 +1072,7 @@ class SandboxBackend(RuntimeBackend):
             "AGENT_ROLE": role,
             "MESH_URL": f"http://host.docker.internal:{self.mesh_host_port}",
             "TOOLS_DIR": "/app/tools",
+            "SKILLS_DIR": "/app/skills",
             "AGENT_PORT": str(self.AGENT_PORT),
             "MESH_AUTH_TOKEN": auth_token,
         }

--- a/tests/test_skills.py
+++ b/tests/test_skills.py
@@ -1,0 +1,245 @@
+"""Tests for the SKILL.md skill-pack loader, store, and disclosure tools."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from src.agent import skills as skills_mod
+from src.agent.builtins import skills_tool
+from src.agent.skills import Skill, SkillStore, parse_skill_md
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+
+def _write_skill(directory: Path, name: str, *, description: str = "Does a thing",
+                 extra_frontmatter: str = "", body: str = "Body.") -> Path:
+    """Create ``<directory>/<name>/SKILL.md`` and return its path."""
+    pack = directory / name
+    pack.mkdir(parents=True, exist_ok=True)
+    md = pack / "SKILL.md"
+    md.write_text(
+        f"---\nname: {name}\ndescription: {description}\n{extra_frontmatter}---\n{body}\n",
+        encoding="utf-8",
+    )
+    return md
+
+
+# ── parse_skill_md ────────────────────────────────────────────────────────
+
+def test_parse_valid(tmp_path):
+    md = _write_skill(tmp_path, "alpha", description="Find alphas", body="# Step 1\nGo.")
+    skill = parse_skill_md(md, source="bundled")
+    assert isinstance(skill, Skill)
+    assert skill.name == "alpha"
+    assert skill.description == "Find alphas"
+    assert skill.body == "# Step 1\nGo."
+    assert skill.source == "bundled"
+    assert skill.directory == md.parent
+
+
+def test_parse_no_frontmatter(tmp_path):
+    md = tmp_path / "SKILL.md"
+    md.write_text("# Just a body, no frontmatter\n", encoding="utf-8")
+    assert parse_skill_md(md) is None
+
+
+def test_parse_unterminated_frontmatter(tmp_path):
+    md = tmp_path / "SKILL.md"
+    md.write_text("---\nname: x\ndescription: y\nno closing delimiter\n", encoding="utf-8")
+    assert parse_skill_md(md) is None
+
+
+def test_parse_malformed_yaml(tmp_path):
+    md = tmp_path / "SKILL.md"
+    md.write_text("---\nname: [unclosed\n---\nbody\n", encoding="utf-8")
+    assert parse_skill_md(md) is None
+
+
+def test_parse_missing_required_fields(tmp_path):
+    md = tmp_path / "SKILL.md"
+    md.write_text("---\nname: only-name\n---\nbody\n", encoding="utf-8")
+    assert parse_skill_md(md) is None
+
+
+def test_parse_rejects_unsafe_name(tmp_path):
+    md = tmp_path / "SKILL.md"
+    md.write_text("---\nname: ../escape\ndescription: bad\n---\nbody\n", encoding="utf-8")
+    assert parse_skill_md(md) is None
+
+
+def test_parse_preserves_metadata_verbatim(tmp_path):
+    md = _write_skill(
+        tmp_path, "beta",
+        extra_frontmatter=(
+            "version: 2.1.0\n"
+            "metadata:\n"
+            "  hermes:\n"
+            "    requires_toolsets: [web_search]\n"
+        ),
+    )
+    skill = parse_skill_md(md)
+    assert skill is not None
+    assert skill.version == "2.1.0"
+    # Vendor namespace is preserved untouched, not interpreted/rejected.
+    assert skill.metadata["metadata"]["hermes"]["requires_toolsets"] == ["web_search"]
+    # Promoted fields are not duplicated into metadata.
+    assert "name" not in skill.metadata
+    assert "version" not in skill.metadata
+
+
+def test_parse_body_may_contain_triple_dash(tmp_path):
+    md = tmp_path / "SKILL.md"
+    md.write_text(
+        "---\nname: gamma\ndescription: d\n---\nIntro\n\n---\n\nA horizontal rule above.\n",
+        encoding="utf-8",
+    )
+    skill = parse_skill_md(md)
+    assert skill is not None
+    assert "horizontal rule" in skill.body
+
+
+# ── SkillStore ────────────────────────────────────────────────────────────
+
+def test_store_lists_bundled(tmp_path):
+    _write_skill(tmp_path, "one")
+    _write_skill(tmp_path, "two")
+    store = SkillStore(bundled_dir=tmp_path, installed_dir=tmp_path / "nope")
+    names = [s.name for s in store.list()]
+    assert names == ["one", "two"]  # sorted
+    assert all(s.source == "bundled" for s in store.list())
+
+
+def test_store_installed_overrides_bundled(tmp_path):
+    bundled = tmp_path / "bundled"
+    installed = tmp_path / "installed"
+    _write_skill(bundled, "shared", description="bundled version")
+    _write_skill(installed, "shared", description="installed version")
+    store = SkillStore(bundled_dir=bundled, installed_dir=installed)
+    shared = store.get("shared")
+    assert shared is not None
+    assert shared.description == "installed version"
+    assert shared.source == "installed"
+
+
+def test_store_missing_dirs_are_empty(tmp_path):
+    store = SkillStore(bundled_dir=tmp_path / "x", installed_dir=tmp_path / "y")
+    assert store.list() == []
+    assert store.get("anything") is None
+
+
+def test_store_skips_malformed_packs(tmp_path):
+    _write_skill(tmp_path, "good")
+    bad = tmp_path / "bad"
+    bad.mkdir()
+    (bad / "SKILL.md").write_text("no frontmatter here\n", encoding="utf-8")
+    store = SkillStore(bundled_dir=tmp_path, installed_dir=tmp_path / "nope")
+    assert [s.name for s in store.list()] == ["good"]
+
+
+# ── read_reference (Level 2) ──────────────────────────────────────────────
+
+def test_read_reference_happy_path(tmp_path):
+    _write_skill(tmp_path, "ref")
+    (tmp_path / "ref" / "references").mkdir()
+    (tmp_path / "ref" / "references" / "guide.md").write_text("hello ref", encoding="utf-8")
+    store = SkillStore(bundled_dir=tmp_path, installed_dir=tmp_path / "nope")
+    assert store.read_reference("ref", "references/guide.md") == "hello ref"
+
+
+def test_read_reference_traversal_blocked(tmp_path):
+    _write_skill(tmp_path, "ref")
+    secret = tmp_path / "secret.txt"
+    secret.write_text("TOP SECRET", encoding="utf-8")
+    store = SkillStore(bundled_dir=tmp_path, installed_dir=tmp_path / "nope")
+    assert store.read_reference("ref", "../secret.txt") is None
+    assert store.read_reference("ref", "../../etc/passwd") is None
+
+
+def test_read_reference_symlink_escape_blocked(tmp_path):
+    _write_skill(tmp_path, "ref")
+    outside = tmp_path / "outside.txt"
+    outside.write_text("escape", encoding="utf-8")
+    link = tmp_path / "ref" / "link.txt"
+    try:
+        link.symlink_to(outside)
+    except (OSError, NotImplementedError):
+        pytest.skip("symlinks not supported on this platform")
+    store = SkillStore(bundled_dir=tmp_path, installed_dir=tmp_path / "nope")
+    assert store.read_reference("ref", "link.txt") is None
+
+
+def test_read_reference_unknown_skill_or_file(tmp_path):
+    _write_skill(tmp_path, "ref")
+    store = SkillStore(bundled_dir=tmp_path, installed_dir=tmp_path / "nope")
+    assert store.read_reference("missing", "anything.md") is None
+    assert store.read_reference("ref", "does-not-exist.md") is None
+
+
+# ── skills_list / skill_view tools ────────────────────────────────────────
+
+@pytest.fixture
+def tool_store(tmp_path, monkeypatch):
+    """Point the tools' default SkillStore at a hermetic tmp bundled dir."""
+    bundled = tmp_path / "bundled"
+    bundled.mkdir()
+    monkeypatch.setenv("SKILLS_DIR", str(bundled))
+    # Neutralise the hard-coded installed dir so the host's /data/skills
+    # (if any) can't leak into the test.
+    monkeypatch.setattr(skills_mod, "_INSTALLED_DIR", str(tmp_path / "no-installed"))
+    return bundled
+
+
+def test_skills_list_tool_level0(tool_store):
+    _write_skill(tool_store, "research", description="Research a competitor",
+                 body="LONG BODY " * 100)
+    result = skills_tool.skills_list()
+    assert result["count"] == 1
+    entry = result["skills"][0]
+    assert entry == {"name": "research", "description": "Research a competitor"}
+    # Level 0 is a cheap catalog — the body must NOT be present.
+    assert "LONG BODY" not in str(result)
+
+
+def test_skill_view_tool_level1(tool_store):
+    _write_skill(tool_store, "research", description="d", body="# Procedure\nDo it.")
+    result = skills_tool.skill_view("research")
+    assert result["name"] == "research"
+    assert result["body"] == "# Procedure\nDo it."
+    assert "error" not in result
+
+
+def test_skill_view_tool_unknown(tool_store):
+    result = skills_tool.skill_view("nope")
+    assert "error" in result and "not found" in result["error"]
+
+
+def test_skill_view_tool_reference(tool_store):
+    _write_skill(tool_store, "research")
+    (tool_store / "research" / "references").mkdir()
+    (tool_store / "research" / "references" / "tpl.md").write_text("TEMPLATE", encoding="utf-8")
+    result = skills_tool.skill_view("research", "references/tpl.md")
+    assert result["content"] == "TEMPLATE"
+    assert result["path"] == "references/tpl.md"
+
+
+def test_skill_view_tool_bad_reference(tool_store):
+    _write_skill(tool_store, "research")
+    result = skills_tool.skill_view("research", "../escape.md")
+    assert "error" in result
+
+
+# ── bundled pack smoke test ───────────────────────────────────────────────
+
+def test_bundled_example_parses():
+    """The skill packs shipped in the repo must load cleanly."""
+    repo_skills = REPO_ROOT / "skills"
+    store = SkillStore(bundled_dir=repo_skills, installed_dir=repo_skills / "no-installed")
+    names = [s.name for s in store.list()]
+    assert "competitor-research" in names
+    skill = store.get("competitor-research")
+    assert skill is not None
+    assert skill.body
+    # Its referenced template resolves via Level 2.
+    assert store.read_reference("competitor-research", "references/brief-template.md")

--- a/tests/test_skills.py
+++ b/tests/test_skills.py
@@ -100,6 +100,31 @@ def test_parse_body_may_contain_triple_dash(tmp_path):
     assert "horizontal rule" in skill.body
 
 
+def test_parse_triple_dash_inside_frontmatter_scalar(tmp_path):
+    """A literal ``---`` inside a frontmatter value must not truncate parsing —
+    fences are whole ``---`` lines only, so the scalar is preserved and the body
+    stays intact (regression: substring split silently cut the description)."""
+    md = tmp_path / "SKILL.md"
+    md.write_text(
+        "---\nname: demo\ndescription: fast --- reliable research\n---\n# Body\nReal body.\n",
+        encoding="utf-8",
+    )
+    skill = parse_skill_md(md)
+    assert skill is not None
+    assert skill.description == "fast --- reliable research"
+    assert skill.body == "# Body\nReal body."
+
+
+def test_parse_crlf_frontmatter(tmp_path):
+    """CRLF-checked-out packs (Windows/git autocrlf) still parse."""
+    md = tmp_path / "SKILL.md"
+    md.write_bytes(b"---\r\nname: demo\r\ndescription: d\r\n---\r\n# Body\r\n")
+    skill = parse_skill_md(md)
+    assert skill is not None
+    assert skill.name == "demo"
+    assert "Body" in skill.body
+
+
 # ── SkillStore ────────────────────────────────────────────────────────────
 
 def test_store_lists_bundled(tmp_path):


### PR DESCRIPTION
**Stacked on #1014** (base = `refactor/skills-to-tools`, the Tools rename — PR 1 is unmerged, and this PR needs the `@tool`/`tools.py` world). Merge #1014 first; this PR's diff is only its own commit.

## What this is
PR 2 of the Tools/Skills split (plan: `docs/plans/2026-05-31-tools-skills-rename-and-skill-packs.md`). PR 1 *freed the word* "Skills"; this PR makes it a feature: user-pluggable **`SKILL.md` procedural packs** — *instructions, not code*. A Skill tells an agent how to do a job using the tools it already has. It adds **no code to the trusted runtime** and **never widens tool permissions** — the per-agent ACL stays the single chokepoint.

## Tasks shipped (2 + 3)
- **`src/agent/skills.py`** — `SKILL.md` parser + `SkillStore`. Wire-compatible with agentskills.io: only `name` + `description` required; all other frontmatter (incl. vendor `metadata.*`) preserved verbatim, never rejected. Two-tier store: bundled `/app/skills` (ro) + installed `/data/skills` (writable); installed overrides bundled. **Stateless** — re-scans on every call, so installs are live (no `reload_skills` needed).
- **`src/agent/builtins/skills_tool.py`** — read-only progressive disclosure: `skills_list()` (L0 names+descriptions), `skill_view(name)` (L1 body), `skill_view(name, path)` (L2 reference file, **traversal- + symlink-safe**).
- **Wiring** — `SKILLS_DIR` env + bundled-skills mount in both runtime backends (mirrors the `marketplace_tools` mount; no Dockerfile change). Added to `_READ_ONLY_TOOLS` (lazy-completion guard), operator allowlist, dashboard `verbForTool` map. One-line system-prompt hint.
- **Bundled example** — `competitor-research` pack, exercising L2 references end-to-end.

## Decisions resolved
1. **Wire-compat: full agentskills.io** — preserve unknown frontmatter, interpret at use-time.
2. **Scope: flat two-tier read store** here; per-team is an install-time concern → PR 3.

## Tests
`tests/test_skills.py` (22): parse (valid/malformed/unsafe-name/metadata-preserve/`---`-in-body), store layering + override, traversal + symlink-escape blocks, all three disclosure levels, L0 token-budget guard, bundled-pack smoke. Full fast suite green (6824 passed, 49 skipped) including the dashboard tool-verb completeness guard.

## Not in scope (later)
Invocation — slash/NL routing + config/env injection (PR 3, Task 4). Operator-gated install via `marketplace.py` + dashboard provenance surface (PR 3, Task 5). Demote `create_tool` to operator-only (PR 4, Task 6).