### PR TITLE
fix(dispatch): stop dropping long agent-run output at the 120s /chat timeout

### DIFF
--- a/src/cli/runtime.py
+++ b/src/cli/runtime.py
@@ -562,7 +562,22 @@ class RuntimeContext:
                 self.health_monitor.register(agent_id)
 
     def _setup_dispatch(self) -> None:
-        from src.host.lanes import LaneManager
+        from src.host.lanes import _DEFAULT_LANE_TIMEOUT_SECONDS, LaneManager
+
+        # Long-run dispatch drop (prod incident): the mesh→agent ``/chat``
+        # call previously inherited transport's 120s default while a task
+        # run legitimately takes many minutes (loop MAX_ITERATIONS × 300s
+        # tool cap). The inner 120s timeout fired long before the lane's
+        # 900s wall-clock cap, returned ``"(no response)"`` as a *success*,
+        # and the lane treated it as a completed turn — silently dropping
+        # in-flight output. Align the inner ``/chat`` timeout with the SAME
+        # source the lane uses (``OPENLEGION_LANE_TIMEOUT_SECONDS``, 900s
+        # default) so the lane's wall-clock cap (its ``wait_for``) is the
+        # governing bound. Inner == cap by design: if the run exceeds the
+        # cap, the lane's ``wait_for`` fires first, cancels this coroutine
+        # (which cancels the in-flight httpx request), and runs the
+        # watchdog's failed-marking + back-edge path.
+        _chat_dispatch_timeout = _DEFAULT_LANE_TIMEOUT_SECONDS
 
         async def _direct_dispatch(
             agent_name: str, message: str,
@@ -594,8 +609,48 @@ class RuntimeContext:
                 result = await self.transport.request(
                     agent_name, "POST", "/chat", json={"message": message},
                     headers=extra_headers or None,
+                    timeout=_chat_dispatch_timeout,
                 )
-                response = result.get("response", "(no response)")
+                # A transport-layer error (timeout / connection / HTTP) is
+                # NOT a real agent reply — the agent may still be running.
+                # Surfacing it as a blank/"(no response)" success made long
+                # runs *look* completed (the lane recorded a finished turn)
+                # while the agent kept working and its output never reached
+                # the user. Render an honest "still working" message
+                # instead. The agent's loop persists partial/final
+                # transcript entries to its workspace independently, so the
+                # work is not lost — only this synchronous reply is.
+                if isinstance(result, dict) and result.get("error"):
+                    transport_err = result.get("error")
+                    logger.warning(
+                        "Dispatch to '%s' /chat returned transport error: %s",
+                        agent_name, transport_err,
+                    )
+                    # Close the durable task gap. ``Transport.request``
+                    # SWALLOWS timeout/connect/HTTP errors into an
+                    # ``{"error": ...}`` dict rather than raising, so the
+                    # lane records this as a *successful* completed turn —
+                    # its watchdog only fires on the wall-clock TimeoutError
+                    # path, and its generic ``except Exception`` branch does
+                    # NOT mark the durable task failed. After fix #1 the
+                    # long-run case is governed by the lane cap, but a FAST
+                    # transport error (connection refused, agent crash, HTTP
+                    # 5xx) returns here in well under the cap and would leave
+                    # a task carrying ``x-task-id`` stuck until the stale
+                    # reaper — the recipient's loop never ran, so its own
+                    # auto-close never fires. Mark it failed here, mirroring
+                    # the lane watchdog's blocker_note + already-terminal
+                    # pre-check (so we never clobber an assignee's real
+                    # back-edge payload on a benign race).
+                    await self._fail_task_on_transport_error(
+                        task_id, agent_name, transport_err,
+                    )
+                    response = (
+                        "(agent still working — its output is being saved "
+                        "to its workspace; check back shortly)"
+                    )
+                else:
+                    response = result.get("response") or "(no response)"
                 duration_ms = int((_time.time() - t0) * 1000)
                 if tid and self.trace_store:
                     self.trace_store.record(
@@ -651,6 +706,62 @@ class RuntimeContext:
 
         _dispatch_thread = threading.Thread(target=_run_dispatch_loop, daemon=True)
         _dispatch_thread.start()
+
+    async def _fail_task_on_transport_error(
+        self, task_id: str | None, agent_name: str, transport_err: object,
+    ) -> None:
+        """Mark a durable task ``failed`` after a swallowed transport error.
+
+        Covers the gap where ``Transport.request`` returns an
+        ``{"error": ...}`` dict (timeout / connect / HTTP) instead of
+        raising: the lane treats the dispatch as a successful turn, and the
+        recipient agent's loop never ran so its own auto-close never fired.
+        Without this, a task carrying ``x-task-id`` would dangle until the
+        stale-task reaper. Best-effort and idempotent — mirrors the lane
+        watchdog's already-terminal pre-check so a benign race (assignee
+        wrote a real terminal status) is never clobbered. No-op when there
+        is no task_id or no tasks store is wired yet.
+        """
+        if not task_id:
+            return
+        app = getattr(self, "_app", None)
+        tasks_store = getattr(app, "tasks_store", None) if app else None
+        if tasks_store is None:
+            return
+        try:
+            loop = asyncio.get_running_loop()
+            pre = await loop.run_in_executor(None, lambda: tasks_store.get(task_id))
+            if pre is not None and pre.get("status") in (
+                "done", "failed", "cancelled",
+            ):
+                logger.info(
+                    "Dispatch transport-error close: task %s already "
+                    "terminal (status=%s) — skipping", task_id,
+                    pre.get("status"),
+                )
+                return
+            note = (
+                f"transport_error: dispatch to '{agent_name}' failed "
+                f"({transport_err})"
+            )[:500]
+            await loop.run_in_executor(
+                None,
+                lambda: tasks_store.update_status(
+                    task_id,
+                    "failed",
+                    actor="dispatch_transport_error",
+                    blocker_note=note,
+                    extra_payload={
+                        "error": "transport_error",
+                        "agent": agent_name,
+                    },
+                ),
+            )
+        except Exception as close_err:
+            logger.warning(
+                "Dispatch transport-error failed to close task %s: %s",
+                task_id, close_err,
+            )
 
     async def _handle_notify(self, agent_name: str, message: str) -> None:
         """Push an agent notification to REPL and all active channels."""

--- a/src/cli/runtime.py
+++ b/src/cli/runtime.py
@@ -570,14 +570,12 @@ class RuntimeContext:
         # tool cap). The inner 120s timeout fired long before the lane's
         # 900s wall-clock cap, returned ``"(no response)"`` as a *success*,
         # and the lane treated it as a completed turn — silently dropping
-        # in-flight output. Align the inner ``/chat`` timeout with the SAME
-        # source the lane uses (``OPENLEGION_LANE_TIMEOUT_SECONDS``, 900s
-        # default) so the lane's wall-clock cap (its ``wait_for``) is the
-        # governing bound. Inner == cap by design: if the run exceeds the
-        # cap, the lane's ``wait_for`` fires first, cancels this coroutine
-        # (which cancels the in-flight httpx request), and runs the
-        # watchdog's failed-marking + back-edge path.
-        _chat_dispatch_timeout = _DEFAULT_LANE_TIMEOUT_SECONDS
+        # in-flight output. The inner ``/chat`` timeout is set just ABOVE
+        # the lane's ``wait_for`` cap so that on a long run the lane
+        # watchdog fires first, cancels the dispatch coroutine (cancelling
+        # the in-flight httpx request), and runs its existing failed-marking
+        # + check_inbox back-edge — the inner timeout is only a backstop.
+        _chat_dispatch_timeout = _DEFAULT_LANE_TIMEOUT_SECONDS + 60
 
         async def _direct_dispatch(
             agent_name: str, message: str,
@@ -611,46 +609,7 @@ class RuntimeContext:
                     headers=extra_headers or None,
                     timeout=_chat_dispatch_timeout,
                 )
-                # A transport-layer error (timeout / connection / HTTP) is
-                # NOT a real agent reply — the agent may still be running.
-                # Surfacing it as a blank/"(no response)" success made long
-                # runs *look* completed (the lane recorded a finished turn)
-                # while the agent kept working and its output never reached
-                # the user. Render an honest "still working" message
-                # instead. The agent's loop persists partial/final
-                # transcript entries to its workspace independently, so the
-                # work is not lost — only this synchronous reply is.
-                if isinstance(result, dict) and result.get("error"):
-                    transport_err = result.get("error")
-                    logger.warning(
-                        "Dispatch to '%s' /chat returned transport error: %s",
-                        agent_name, transport_err,
-                    )
-                    # Close the durable task gap. ``Transport.request``
-                    # SWALLOWS timeout/connect/HTTP errors into an
-                    # ``{"error": ...}`` dict rather than raising, so the
-                    # lane records this as a *successful* completed turn —
-                    # its watchdog only fires on the wall-clock TimeoutError
-                    # path, and its generic ``except Exception`` branch does
-                    # NOT mark the durable task failed. After fix #1 the
-                    # long-run case is governed by the lane cap, but a FAST
-                    # transport error (connection refused, agent crash, HTTP
-                    # 5xx) returns here in well under the cap and would leave
-                    # a task carrying ``x-task-id`` stuck until the stale
-                    # reaper — the recipient's loop never ran, so its own
-                    # auto-close never fires. Mark it failed here, mirroring
-                    # the lane watchdog's blocker_note + already-terminal
-                    # pre-check (so we never clobber an assignee's real
-                    # back-edge payload on a benign race).
-                    await self._fail_task_on_transport_error(
-                        task_id, agent_name, transport_err,
-                    )
-                    response = (
-                        "(agent still working — its output is being saved "
-                        "to its workspace; check back shortly)"
-                    )
-                else:
-                    response = result.get("response") or "(no response)"
+                response = result.get("response", "(no response)")
                 duration_ms = int((_time.time() - t0) * 1000)
                 if tid and self.trace_store:
                     self.trace_store.record(
@@ -706,62 +665,6 @@ class RuntimeContext:
 
         _dispatch_thread = threading.Thread(target=_run_dispatch_loop, daemon=True)
         _dispatch_thread.start()
-
-    async def _fail_task_on_transport_error(
-        self, task_id: str | None, agent_name: str, transport_err: object,
-    ) -> None:
-        """Mark a durable task ``failed`` after a swallowed transport error.
-
-        Covers the gap where ``Transport.request`` returns an
-        ``{"error": ...}`` dict (timeout / connect / HTTP) instead of
-        raising: the lane treats the dispatch as a successful turn, and the
-        recipient agent's loop never ran so its own auto-close never fired.
-        Without this, a task carrying ``x-task-id`` would dangle until the
-        stale-task reaper. Best-effort and idempotent — mirrors the lane
-        watchdog's already-terminal pre-check so a benign race (assignee
-        wrote a real terminal status) is never clobbered. No-op when there
-        is no task_id or no tasks store is wired yet.
-        """
-        if not task_id:
-            return
-        app = getattr(self, "_app", None)
-        tasks_store = getattr(app, "tasks_store", None) if app else None
-        if tasks_store is None:
-            return
-        try:
-            loop = asyncio.get_running_loop()
-            pre = await loop.run_in_executor(None, lambda: tasks_store.get(task_id))
-            if pre is not None and pre.get("status") in (
-                "done", "failed", "cancelled",
-            ):
-                logger.info(
-                    "Dispatch transport-error close: task %s already "
-                    "terminal (status=%s) — skipping", task_id,
-                    pre.get("status"),
-                )
-                return
-            note = (
-                f"transport_error: dispatch to '{agent_name}' failed "
-                f"({transport_err})"
-            )[:500]
-            await loop.run_in_executor(
-                None,
-                lambda: tasks_store.update_status(
-                    task_id,
-                    "failed",
-                    actor="dispatch_transport_error",
-                    blocker_note=note,
-                    extra_payload={
-                        "error": "transport_error",
-                        "agent": agent_name,
-                    },
-                ),
-            )
-        except Exception as close_err:
-            logger.warning(
-                "Dispatch transport-error failed to close task %s: %s",
-                task_id, close_err,
-            )
 
     async def _handle_notify(self, agent_name: str, message: str) -> None:
         """Push an agent notification to REPL and all active channels."""

--- a/src/cli/runtime.py
+++ b/src/cli/runtime.py
@@ -570,12 +570,17 @@ class RuntimeContext:
         # tool cap). The inner 120s timeout fired long before the lane's
         # 900s wall-clock cap, returned ``"(no response)"`` as a *success*,
         # and the lane treated it as a completed turn — silently dropping
-        # in-flight output. The inner ``/chat`` timeout is set just ABOVE
-        # the lane's ``wait_for`` cap so that on a long run the lane
-        # watchdog fires first, cancels the dispatch coroutine (cancelling
-        # the in-flight httpx request), and runs its existing failed-marking
-        # + check_inbox back-edge — the inner timeout is only a backstop.
-        _chat_dispatch_timeout = _DEFAULT_LANE_TIMEOUT_SECONDS + 60
+        # in-flight output. The inner ``/chat`` timeout is set 60s ABOVE the
+        # agent's EFFECTIVE lane cap — which may be a per-agent
+        # ``watchdog_ttl_seconds`` override (set via
+        # ``LaneManager.set_agent_timeout``), not just the module default —
+        # computed per dispatch below. That keeps the lane's ``wait_for``
+        # watchdog the sole governor of long runs for EVERY agent: on a long
+        # run the lane fires first, cancels the dispatch coroutine
+        # (cancelling the in-flight httpx request), and runs its existing
+        # failed-marking + check_inbox back-edge. The inner timeout is only a
+        # backstop. ``_DEFAULT_LANE_TIMEOUT_SECONDS`` is the fallback when no
+        # lane manager is wired.
 
         async def _direct_dispatch(
             agent_name: str, message: str,
@@ -603,11 +608,16 @@ class RuntimeContext:
             # specific task once its loop returns.
             if task_id:
                 extra_headers["x-task-id"] = task_id
+            effective_cap = (
+                self.lane_manager.timeout_for(agent_name)
+                if self.lane_manager is not None
+                else _DEFAULT_LANE_TIMEOUT_SECONDS
+            )
             try:
                 result = await self.transport.request(
                     agent_name, "POST", "/chat", json={"message": message},
                     headers=extra_headers or None,
-                    timeout=_chat_dispatch_timeout,
+                    timeout=effective_cap + 60,
                 )
                 response = result.get("response", "(no response)")
                 duration_ms = int((_time.time() - t0) * 1000)

--- a/src/host/lanes.py
+++ b/src/host/lanes.py
@@ -175,6 +175,10 @@ class LaneManager:
             return
         self._per_agent_timeouts[agent] = max(60, int(seconds))
 
+    def timeout_for(self, agent: str) -> int:
+        """Public: the effective per-task wall-clock cap for ``agent`` (per-agent override or module default)."""
+        return self._timeout_for(agent)
+
     def _timeout_for(self, agent: str) -> int:
         """Resolve the per-task wall-clock cap for ``agent``."""
         return self._per_agent_timeouts.get(

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -1762,3 +1762,140 @@ class TestBuildMcpServersEnv:
         }]
         with pytest.raises(ValueError):
             b._build_mcp_servers_env(servers, agent_id="a1")
+
+
+# ── Long-run dispatch timeout alignment (prod incident) ───────────
+#
+# Regression coverage for the production bug where heavy agent task runs
+# produced no visible output: the mesh→agent ``/chat`` call inherited
+# transport's 120s default while the lane allowed 900s, so the inner
+# timeout fired first, returned ``"(no response)"`` as a *success*, and
+# the lane recorded a completed turn while the agent kept working.
+
+
+def _capture_dispatch_fn(monkeypatch, *, app=None):
+    """Build a RuntimeContext (bypassing __init__) and capture the
+    ``_direct_dispatch`` closure that ``_setup_dispatch`` hands to the
+    LaneManager. Returns ``(dispatch_fn, ctx, transport_mock)``.
+
+    We monkeypatch ``LaneManager`` so construction doesn't require real
+    stores, and immediately stop the freshly-spawned dispatch event loop
+    so the daemon thread doesn't linger.
+    """
+    from unittest.mock import AsyncMock
+
+    from src.cli import runtime as runtime_mod
+
+    captured: dict = {}
+
+    class _FakeLaneManager:
+        def __init__(self, *args, dispatch_fn=None, **kwargs):
+            captured["dispatch_fn"] = dispatch_fn
+
+        def get_queue_depth(self, agent):  # pragma: no cover - unused
+            return 0
+
+    monkeypatch.setattr("src.host.lanes.LaneManager", _FakeLaneManager)
+
+    ctx = runtime_mod.RuntimeContext.__new__(runtime_mod.RuntimeContext)
+    transport_mock = AsyncMock()
+    ctx.transport = transport_mock
+    ctx.trace_store = None
+    ctx.event_bus = None
+    ctx.health_monitor = None
+    ctx._app = app
+
+    async def _noop_notify(*a, **k):  # pragma: no cover - unused here
+        return None
+
+    ctx._handle_notify_origin = _noop_notify
+
+    ctx._setup_dispatch()
+    # Stop the loop the setup spun up so the daemon thread exits cleanly.
+    loop = ctx._dispatch_loop
+    if loop is not None:
+        loop.call_soon_threadsafe(loop.stop)
+
+    return captured["dispatch_fn"], ctx, transport_mock
+
+
+class TestDispatchTimeoutAlignment:
+    @pytest.mark.asyncio
+    async def test_chat_request_uses_lane_cap_timeout_not_120(
+        self, monkeypatch,
+    ):
+        """``_direct_dispatch`` must pass the lane wall-clock cap as the
+        ``/chat`` timeout, not transport's 120s default."""
+        from src.host.lanes import _DEFAULT_LANE_TIMEOUT_SECONDS
+
+        dispatch_fn, _ctx, transport = _capture_dispatch_fn(monkeypatch)
+        transport.request.return_value = {"response": "done"}
+
+        result = await dispatch_fn("agent-x", "do heavy work")
+
+        assert result == "done"
+        transport.request.assert_awaited_once()
+        _args, kwargs = transport.request.call_args
+        assert kwargs["timeout"] == _DEFAULT_LANE_TIMEOUT_SECONDS
+        assert kwargs["timeout"] != 120
+        assert _DEFAULT_LANE_TIMEOUT_SECONDS == 900
+
+    @pytest.mark.asyncio
+    async def test_transport_error_is_not_blank_success(self, monkeypatch):
+        """A swallowed transport timeout/error must NOT surface as the bare
+        ``"(no response)"`` string — it returns the honest still-working
+        message instead."""
+        dispatch_fn, _ctx, transport = _capture_dispatch_fn(monkeypatch)
+        transport.request.return_value = {"error": "Timeout after 900s"}
+
+        result = await dispatch_fn("agent-x", "long run")
+
+        assert result != "(no response)"
+        assert "still working" in result
+
+    @pytest.mark.asyncio
+    async def test_transport_error_with_task_id_marks_task_failed(
+        self, monkeypatch,
+    ):
+        """When a task_id is present and the dispatch hits a transport
+        error, the durable task is marked ``failed`` with a transport
+        ``blocker_note`` (covers the fast-error gap the lane watchdog's
+        wall-clock path does not)."""
+        tasks_store = MagicMock()
+        tasks_store.get.return_value = {"status": "working"}
+        app = MagicMock()
+        app.tasks_store = tasks_store
+
+        dispatch_fn, _ctx, transport = _capture_dispatch_fn(
+            monkeypatch, app=app,
+        )
+        transport.request.return_value = {"error": "Connection failed: refused"}
+
+        result = await dispatch_fn("agent-x", "long run", task_id="task-42")
+
+        assert "still working" in result
+        tasks_store.update_status.assert_called_once()
+        _args, kwargs = tasks_store.update_status.call_args
+        assert _args[0] == "task-42"
+        assert _args[1] == "failed"
+        assert "transport_error" in kwargs["blocker_note"]
+
+    @pytest.mark.asyncio
+    async def test_transport_error_skips_already_terminal_task(
+        self, monkeypatch,
+    ):
+        """A benign race (assignee already wrote a terminal status) must not
+        be clobbered by the transport-error close."""
+        tasks_store = MagicMock()
+        tasks_store.get.return_value = {"status": "done"}
+        app = MagicMock()
+        app.tasks_store = tasks_store
+
+        dispatch_fn, _ctx, transport = _capture_dispatch_fn(
+            monkeypatch, app=app,
+        )
+        transport.request.return_value = {"error": "Timeout after 900s"}
+
+        await dispatch_fn("agent-x", "long run", task_id="task-42")
+
+        tasks_store.update_status.assert_not_called()

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -1824,8 +1824,10 @@ class TestDispatchTimeoutAlignment:
     async def test_chat_request_uses_lane_cap_timeout_not_120(
         self, monkeypatch,
     ):
-        """``_direct_dispatch`` must pass the lane wall-clock cap as the
-        ``/chat`` timeout, not transport's 120s default."""
+        """``_direct_dispatch`` must pass the ``/chat`` timeout as a backstop
+        set just ABOVE the lane wall-clock cap (cap + 60), not transport's
+        120s default — the lane's ``wait_for`` stays the sole governor of
+        long runs."""
         from src.host.lanes import _DEFAULT_LANE_TIMEOUT_SECONDS
 
         dispatch_fn, _ctx, transport = _capture_dispatch_fn(monkeypatch)
@@ -1836,66 +1838,5 @@ class TestDispatchTimeoutAlignment:
         assert result == "done"
         transport.request.assert_awaited_once()
         _args, kwargs = transport.request.call_args
-        assert kwargs["timeout"] == _DEFAULT_LANE_TIMEOUT_SECONDS
-        assert kwargs["timeout"] != 120
-        assert _DEFAULT_LANE_TIMEOUT_SECONDS == 900
-
-    @pytest.mark.asyncio
-    async def test_transport_error_is_not_blank_success(self, monkeypatch):
-        """A swallowed transport timeout/error must NOT surface as the bare
-        ``"(no response)"`` string — it returns the honest still-working
-        message instead."""
-        dispatch_fn, _ctx, transport = _capture_dispatch_fn(monkeypatch)
-        transport.request.return_value = {"error": "Timeout after 900s"}
-
-        result = await dispatch_fn("agent-x", "long run")
-
-        assert result != "(no response)"
-        assert "still working" in result
-
-    @pytest.mark.asyncio
-    async def test_transport_error_with_task_id_marks_task_failed(
-        self, monkeypatch,
-    ):
-        """When a task_id is present and the dispatch hits a transport
-        error, the durable task is marked ``failed`` with a transport
-        ``blocker_note`` (covers the fast-error gap the lane watchdog's
-        wall-clock path does not)."""
-        tasks_store = MagicMock()
-        tasks_store.get.return_value = {"status": "working"}
-        app = MagicMock()
-        app.tasks_store = tasks_store
-
-        dispatch_fn, _ctx, transport = _capture_dispatch_fn(
-            monkeypatch, app=app,
-        )
-        transport.request.return_value = {"error": "Connection failed: refused"}
-
-        result = await dispatch_fn("agent-x", "long run", task_id="task-42")
-
-        assert "still working" in result
-        tasks_store.update_status.assert_called_once()
-        _args, kwargs = tasks_store.update_status.call_args
-        assert _args[0] == "task-42"
-        assert _args[1] == "failed"
-        assert "transport_error" in kwargs["blocker_note"]
-
-    @pytest.mark.asyncio
-    async def test_transport_error_skips_already_terminal_task(
-        self, monkeypatch,
-    ):
-        """A benign race (assignee already wrote a terminal status) must not
-        be clobbered by the transport-error close."""
-        tasks_store = MagicMock()
-        tasks_store.get.return_value = {"status": "done"}
-        app = MagicMock()
-        app.tasks_store = tasks_store
-
-        dispatch_fn, _ctx, transport = _capture_dispatch_fn(
-            monkeypatch, app=app,
-        )
-        transport.request.return_value = {"error": "Timeout after 900s"}
-
-        await dispatch_fn("agent-x", "long run", task_id="task-42")
-
-        tasks_store.update_status.assert_not_called()
+        assert kwargs["timeout"] == _DEFAULT_LANE_TIMEOUT_SECONDS + 60
+        assert kwargs["timeout"] > 120

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -1791,9 +1791,22 @@ def _capture_dispatch_fn(monkeypatch, *, app=None):
     class _FakeLaneManager:
         def __init__(self, *args, dispatch_fn=None, **kwargs):
             captured["dispatch_fn"] = dispatch_fn
+            self._per_agent_timeouts: dict[str, int] = {}
 
         def get_queue_depth(self, agent):  # pragma: no cover - unused
             return 0
+
+        def set_agent_timeout(self, agent, seconds):
+            if seconds is None:
+                self._per_agent_timeouts.pop(agent, None)
+                return
+            self._per_agent_timeouts[agent] = max(60, int(seconds))
+
+        def timeout_for(self, agent):
+            from src.host.lanes import _DEFAULT_LANE_TIMEOUT_SECONDS
+            return self._per_agent_timeouts.get(
+                agent, _DEFAULT_LANE_TIMEOUT_SECONDS,
+            )
 
     monkeypatch.setattr("src.host.lanes.LaneManager", _FakeLaneManager)
 
@@ -1828,9 +1841,7 @@ class TestDispatchTimeoutAlignment:
         set just ABOVE the lane wall-clock cap (cap + 60), not transport's
         120s default — the lane's ``wait_for`` stays the sole governor of
         long runs."""
-        from src.host.lanes import _DEFAULT_LANE_TIMEOUT_SECONDS
-
-        dispatch_fn, _ctx, transport = _capture_dispatch_fn(monkeypatch)
+        dispatch_fn, ctx, transport = _capture_dispatch_fn(monkeypatch)
         transport.request.return_value = {"response": "done"}
 
         result = await dispatch_fn("agent-x", "do heavy work")
@@ -1838,5 +1849,29 @@ class TestDispatchTimeoutAlignment:
         assert result == "done"
         transport.request.assert_awaited_once()
         _args, kwargs = transport.request.call_args
-        assert kwargs["timeout"] == _DEFAULT_LANE_TIMEOUT_SECONDS + 60
+        # With no per-agent override the timeout tracks the lane's effective
+        # cap (the module default) + 60 — not transport's 120s default.
+        assert kwargs["timeout"] == ctx.lane_manager.timeout_for("agent-x") + 60
         assert kwargs["timeout"] > 120
+
+    @pytest.mark.asyncio
+    async def test_chat_request_tracks_per_agent_watchdog_ttl_override(
+        self, monkeypatch,
+    ):
+        """When an agent has a per-agent lane cap (e.g. from
+        ``settings.watchdog_ttl_seconds`` → ``set_agent_timeout``), the inner
+        ``/chat`` timeout must track THAT effective cap + 60, not the global
+        constant — otherwise a 960s hardcoded timeout would fire before an
+        1800s lane cap and re-introduce the dropped-output bug."""
+        dispatch_fn, ctx, transport = _capture_dispatch_fn(monkeypatch)
+        transport.request.return_value = {"response": "done"}
+
+        # Per-agent override (watchdog_ttl_seconds: 1800 in agents.yaml).
+        ctx.lane_manager.set_agent_timeout("some-agent", 1800)
+
+        result = await dispatch_fn("some-agent", "do heavy work")
+
+        assert result == "done"
+        transport.request.assert_awaited_once()
+        _args, kwargs = transport.request.call_args
+        assert kwargs["timeout"] == 1860  # 1800 (override) + 60


### PR DESCRIPTION
## Problem (production incident)
Heavy agent tasks produced **no visible output** and their replies 'disappeared.' Root cause: `_direct_dispatch` (cli/runtime.py) called the mesh→agent `/chat` with no `timeout=`, inheriting transport's **120s** default. A task run legitimately takes minutes (`loop MAX_ITERATIONS × 300s` tool cap). At 120s the mesh logged `Timeout reaching agent .../chat`, **dropped the in-flight response, returned `"(no response)"` as a success**, and the lane recorded a completed turn — so the agent's output never surfaced (the agent keeps running + persists to its workspace, but the synchronous reply was lost). Observed live: ~7 `/chat` timeouts for one agent, no surfaced output, operator re-issuing the task.

## Fix
Pass an explicit `timeout` to the `/chat` dispatch set **just above** the lane's wall-clock cap (`_DEFAULT_LANE_TIMEOUT_SECONDS + 60`, env `OPENLEGION_LANE_TIMEOUT_SECONDS`, default 900). Now:
- Runs that finish within the cap return their **real output** (no longer guillotined at 120s).
- Runs that exceed the cap are governed by the lane's existing `wait_for` watchdog, which cancels the dispatch (cancelling the in-flight httpx request) and marks the task `failed` with a `lane_timeout` blocker_note + check_inbox back-edge — clean, no fake reply.

The inner timeout sits *above* the cap deliberately so the lane watchdog is the sole governor of long runs (no inner-vs-cap race). Single surgical change; the agent-side incremental persistence and lane watchdog are untouched.

## Scope note
An earlier draft also added a fast-transport-error task-close helper; review (Codex) found it would deliver a misleading 'still working' bubble as a successful turn and skip the back-edge, so it was **removed** — the fast-error/connection-refused task-close is deferred to a separate, careful follow-up. This PR is intentionally just the timeout fix (the proven root cause).

## Tests
`tests/test_runtime.py`: asserts `_direct_dispatch` issues `/chat` with `timeout == _DEFAULT_LANE_TIMEOUT_SECONDS + 60` (>120). `tests/test_runtime.py tests/test_lanes.py tests/test_transport.py` → 179 passed, ruff clean.