### PR TITLE
fix(costs): persist per-agent budget overrides across restart

### DIFF
--- a/src/host/costs.py
+++ b/src/host/costs.py
@@ -87,16 +87,23 @@ class CostTracker:
                 )
                 return
             for agent, budget in data.items():
-                if (
-                    isinstance(budget, dict)
-                    and "daily_usd" in budget
-                    and "monthly_usd" in budget
-                ):
-                    self.budgets[agent] = {
-                        "daily_usd": float(budget["daily_usd"]),
-                        "monthly_usd": float(budget["monthly_usd"]),
-                    }
-        except (json.JSONDecodeError, OSError, ValueError, TypeError) as e:
+                try:
+                    if (
+                        isinstance(budget, dict)
+                        and "daily_usd" in budget
+                        and "monthly_usd" in budget
+                    ):
+                        self.budgets[agent] = {
+                            "daily_usd": float(budget["daily_usd"]),
+                            "monthly_usd": float(budget["monthly_usd"]),
+                        }
+                except (ValueError, TypeError) as e:
+                    logger.warning(
+                        "Skipping malformed agent budget for %s in %s: %s",
+                        agent, self.budgets_path, e,
+                    )
+                    continue
+        except (json.JSONDecodeError, OSError) as e:
             logger.warning(
                 "Failed to load agent budgets from %s: %s", self.budgets_path, e
             )

--- a/src/host/costs.py
+++ b/src/host/costs.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 import json
 import os
 import tempfile
+import threading
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
@@ -41,7 +42,7 @@ class CostTracker:
     def __init__(
         self,
         db_path: str = "data/costs.db",
-        budgets_path: str = "config/agent_budgets.json",
+        budgets_path: str | None = None,
     ):
         Path(db_path).parent.mkdir(parents=True, exist_ok=True)
         self.db = open_db(db_path)
@@ -50,7 +51,23 @@ class CostTracker:
         # Per-agent budget overrides. Persisted to ``budgets_path`` so caps
         # raised/lowered by the operator survive a mesh restart (otherwise
         # they silently revert to the global default after a redeploy).
+        #
+        # When the caller doesn't pass an explicit ``budgets_path``, derive it
+        # from ``db_path``: the production default (``data/costs.db``) maps to
+        # the canonical ``config/agent_budgets.json``, while any other db path
+        # (e.g. a test tmp dir) co-locates the budgets file alongside the db so
+        # tests and tools never read/write the real ``config/`` file.
+        if budgets_path is None:
+            if db_path == "data/costs.db":
+                budgets_path = "config/agent_budgets.json"
+            else:
+                budgets_path = str(Path(db_path).parent / "agent_budgets.json")
         self.budgets_path = Path(budgets_path)
+        # Serializes the in-memory mutation + ``_save_budgets()`` so concurrent
+        # ``set_budget`` / ``cleanup_agent`` calls can't clobber the file (one
+        # writer's ``os.replace`` landing last would otherwise drop another's
+        # change).
+        self._budget_lock = threading.Lock()
         self.budgets: dict[str, dict[str, float]] = {}
         self._load_budgets()
         # ``_team_budgets`` (formerly ``_project_budgets``). Back-compat
@@ -139,8 +156,9 @@ class CostTracker:
         """Delete all cost records for an agent. Returns rows deleted."""
         cursor = self.db.execute("DELETE FROM usage WHERE agent = ?", (agent_id,))
         self.db.commit()
-        if self.budgets.pop(agent_id, None) is not None:
-            self._save_budgets()
+        with self._budget_lock:
+            if self.budgets.pop(agent_id, None) is not None:
+                self._save_budgets()
         return cursor.rowcount
 
     def set_budget(self, agent: str, daily_usd: float | None = None, monthly_usd: float | None = None) -> None:
@@ -150,8 +168,9 @@ class CostTracker:
                 daily_usd = defaults["daily_usd"]
             if monthly_usd is None:
                 monthly_usd = defaults["monthly_usd"]
-        self.budgets[agent] = {"daily_usd": daily_usd, "monthly_usd": monthly_usd}
-        self._save_budgets()
+        with self._budget_lock:
+            self.budgets[agent] = {"daily_usd": daily_usd, "monthly_usd": monthly_usd}
+            self._save_budgets()
 
     def _check_budget_post_hoc(self, agent: str) -> bool:
         """Check if agent exceeded daily/monthly budget. Returns True if over budget."""

--- a/src/host/costs.py
+++ b/src/host/costs.py
@@ -9,6 +9,8 @@ Storage: SQLite (lightweight, no external services).
 from __future__ import annotations
 
 import json
+import os
+import tempfile
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
@@ -36,15 +38,83 @@ def _default_budget() -> dict:
 class CostTracker:
     """Tracks token usage and cost per agent, enforces budgets."""
 
-    def __init__(self, db_path: str = "data/costs.db"):
+    def __init__(
+        self,
+        db_path: str = "data/costs.db",
+        budgets_path: str = "config/agent_budgets.json",
+    ):
         Path(db_path).parent.mkdir(parents=True, exist_ok=True)
         self.db = open_db(db_path)
         self.db.execute("PRAGMA journal_mode=WAL")
         self._init_schema()
+        # Per-agent budget overrides. Persisted to ``budgets_path`` so caps
+        # raised/lowered by the operator survive a mesh restart (otherwise
+        # they silently revert to the global default after a redeploy).
+        self.budgets_path = Path(budgets_path)
         self.budgets: dict[str, dict[str, float]] = {}
+        self._load_budgets()
         # ``_team_budgets`` (formerly ``_project_budgets``). Back-compat
         # property below exposes the legacy attribute name.
         self._team_budgets: dict[str, dict] = {}
+
+    def _load_budgets(self) -> None:
+        """Load per-agent budget overrides from disk (tolerant of missing/corrupt)."""
+        if not self.budgets_path.exists():
+            return
+        try:
+            data = json.loads(self.budgets_path.read_text())
+            if not isinstance(data, dict):
+                logger.warning(
+                    "agent_budgets file %s is not a JSON object; ignoring",
+                    self.budgets_path,
+                )
+                return
+            for agent, budget in data.items():
+                if (
+                    isinstance(budget, dict)
+                    and "daily_usd" in budget
+                    and "monthly_usd" in budget
+                ):
+                    self.budgets[agent] = {
+                        "daily_usd": float(budget["daily_usd"]),
+                        "monthly_usd": float(budget["monthly_usd"]),
+                    }
+        except (json.JSONDecodeError, OSError, ValueError, TypeError) as e:
+            logger.warning(
+                "Failed to load agent budgets from %s: %s", self.budgets_path, e
+            )
+
+    def _save_budgets(self) -> None:
+        """Persist per-agent budget overrides atomically (temp file + rename).
+
+        Tolerates write failures (logs, does not raise) so a transient disk
+        error never crashes the cost-tracking / LLM-proxy path.
+        """
+        try:
+            self.budgets_path.parent.mkdir(parents=True, exist_ok=True)
+            content = json.dumps(self.budgets, indent=2) + "\n"
+            fd, tmp_path = tempfile.mkstemp(
+                dir=str(self.budgets_path.parent), suffix=".tmp",
+            )
+            try:
+                with os.fdopen(fd, "w") as f:
+                    f.write(content)
+            except BaseException:
+                try:
+                    os.close(fd)
+                except OSError:
+                    pass  # already closed by fdopen
+                Path(tmp_path).unlink(missing_ok=True)
+                raise
+            try:
+                os.replace(tmp_path, self.budgets_path)
+            except Exception:
+                Path(tmp_path).unlink(missing_ok=True)
+                raise
+        except Exception as e:
+            logger.warning(
+                "Failed to persist agent budgets to %s: %s", self.budgets_path, e
+            )
 
     def _init_schema(self) -> None:
         self.db.executescript("""
@@ -69,7 +139,8 @@ class CostTracker:
         """Delete all cost records for an agent. Returns rows deleted."""
         cursor = self.db.execute("DELETE FROM usage WHERE agent = ?", (agent_id,))
         self.db.commit()
-        self.budgets.pop(agent_id, None)
+        if self.budgets.pop(agent_id, None) is not None:
+            self._save_budgets()
         return cursor.rowcount
 
     def set_budget(self, agent: str, daily_usd: float | None = None, monthly_usd: float | None = None) -> None:
@@ -80,6 +151,7 @@ class CostTracker:
             if monthly_usd is None:
                 monthly_usd = defaults["monthly_usd"]
         self.budgets[agent] = {"daily_usd": daily_usd, "monthly_usd": monthly_usd}
+        self._save_budgets()
 
     def _check_budget_post_hoc(self, agent: str) -> bool:
         """Check if agent exceeded daily/monthly budget. Returns True if over budget."""

--- a/tests/test_costs.py
+++ b/tests/test_costs.py
@@ -14,7 +14,8 @@ class TestCostTracking:
     def setup_method(self):
         self._tmpdir = tempfile.mkdtemp()
         self.db_path = os.path.join(self._tmpdir, "costs.db")
-        self.tracker = CostTracker(db_path=self.db_path)
+        self.budgets_path = os.path.join(self._tmpdir, "agent_budgets.json")
+        self.tracker = CostTracker(db_path=self.db_path, budgets_path=self.budgets_path)
 
     def teardown_method(self):
         self.tracker.close()
@@ -104,7 +105,8 @@ class TestBudgetEnforcement:
     def setup_method(self):
         self._tmpdir = tempfile.mkdtemp()
         self.db_path = os.path.join(self._tmpdir, "costs.db")
-        self.tracker = CostTracker(db_path=self.db_path)
+        self.budgets_path = os.path.join(self._tmpdir, "agent_budgets.json")
+        self.tracker = CostTracker(db_path=self.db_path, budgets_path=self.budgets_path)
 
     def teardown_method(self):
         self.tracker.close()
@@ -142,7 +144,8 @@ class TestBudgetOverrunWarning:
     def setup_method(self):
         self._tmpdir = tempfile.mkdtemp()
         self.db_path = os.path.join(self._tmpdir, "costs.db")
-        self.tracker = CostTracker(db_path=self.db_path)
+        self.budgets_path = os.path.join(self._tmpdir, "agent_budgets.json")
+        self.tracker = CostTracker(db_path=self.db_path, budgets_path=self.budgets_path)
 
     def teardown_method(self):
         self.tracker.close()
@@ -206,7 +209,8 @@ class TestProjectCostAggregation:
     def setup_method(self):
         self._tmpdir = tempfile.mkdtemp()
         self.db_path = os.path.join(self._tmpdir, "costs.db")
-        self.tracker = CostTracker(db_path=self.db_path)
+        self.budgets_path = os.path.join(self._tmpdir, "agent_budgets.json")
+        self.tracker = CostTracker(db_path=self.db_path, budgets_path=self.budgets_path)
 
     def teardown_method(self):
         self.tracker.close()
@@ -251,7 +255,8 @@ class TestCostTrackerCleanup:
     def setup_method(self):
         self._tmpdir = tempfile.mkdtemp()
         self.db_path = os.path.join(self._tmpdir, "costs.db")
-        self.tracker = CostTracker(db_path=self.db_path)
+        self.budgets_path = os.path.join(self._tmpdir, "agent_budgets.json")
+        self.tracker = CostTracker(db_path=self.db_path, budgets_path=self.budgets_path)
 
     def teardown_method(self):
         self.tracker.close()
@@ -282,6 +287,88 @@ class TestCostTrackerCleanup:
     def test_cleanup_nonexistent_agent(self):
         deleted = self.tracker.cleanup_agent("ghost")
         assert deleted == 0
+
+
+class TestBudgetPersistence:
+    """Per-agent budget overrides survive a CostTracker restart (Bug fix).
+
+    Regression: ``set_budget`` only mutated an in-memory dict, so caps
+    raised/lowered by the operator silently reverted to the global default
+    on the next mesh restart / redeploy.
+    """
+
+    def setup_method(self):
+        self._tmpdir = tempfile.mkdtemp()
+        self.db_path = os.path.join(self._tmpdir, "costs.db")
+        self.budgets_path = os.path.join(self._tmpdir, "agent_budgets.json")
+
+    def teardown_method(self):
+        shutil.rmtree(self._tmpdir, ignore_errors=True)
+
+    def test_set_budget_persists_across_restart(self):
+        tracker = CostTracker(db_path=self.db_path, budgets_path=self.budgets_path)
+        tracker.set_budget("agent1", daily_usd=42.0, monthly_usd=999.0)
+        tracker.close()
+
+        # File was written.
+        assert os.path.exists(self.budgets_path)
+
+        # A fresh tracker (simulating a mesh restart) loads the override.
+        restarted = CostTracker(db_path=self.db_path, budgets_path=self.budgets_path)
+        assert restarted.budgets["agent1"] == {
+            "daily_usd": 42.0,
+            "monthly_usd": 999.0,
+        }
+        budget = restarted.check_budget("agent1")
+        assert budget["daily_limit"] == 42.0
+        assert budget["monthly_limit"] == 999.0
+        restarted.close()
+
+    def test_missing_file_yields_empty_budgets(self):
+        # No file on disk → empty overrides, no crash.
+        assert not os.path.exists(self.budgets_path)
+        tracker = CostTracker(db_path=self.db_path, budgets_path=self.budgets_path)
+        assert tracker.budgets == {}
+        tracker.close()
+
+    def test_corrupt_file_yields_empty_budgets_and_logs(self):
+        with open(self.budgets_path, "w") as f:
+            f.write("{not valid json")
+        with patch("src.host.costs.logger") as mock_logger:
+            tracker = CostTracker(db_path=self.db_path, budgets_path=self.budgets_path)
+            assert tracker.budgets == {}
+            mock_logger.warning.assert_called_once()
+        tracker.close()
+
+    def test_cleanup_updates_persisted_file(self):
+        tracker = CostTracker(db_path=self.db_path, budgets_path=self.budgets_path)
+        tracker.set_budget("agent1", daily_usd=5.0, monthly_usd=100.0)
+        tracker.set_budget("agent2", daily_usd=7.0, monthly_usd=140.0)
+        tracker.cleanup_agent("agent1")
+        tracker.close()
+
+        # Removal is reflected on disk: a restart no longer sees agent1.
+        restarted = CostTracker(db_path=self.db_path, budgets_path=self.budgets_path)
+        assert "agent1" not in restarted.budgets
+        assert "agent2" in restarted.budgets
+        restarted.close()
+
+    def test_save_failure_does_not_crash(self):
+        from pathlib import Path
+
+        tracker = CostTracker(db_path=self.db_path, budgets_path=self.budgets_path)
+        # Point the persist path at an unwritable location so the write fails.
+        with patch.object(
+            tracker, "budgets_path",
+            Path("/proc/nonexistent/agent_budgets.json"),
+        ):
+            with patch("src.host.costs.logger") as mock_logger:
+                # Must not raise even though the write fails.
+                tracker.set_budget("agent1", daily_usd=1.0, monthly_usd=2.0)
+                mock_logger.warning.assert_called()
+        # In-memory mutation still applied.
+        assert tracker.budgets["agent1"] == {"daily_usd": 1.0, "monthly_usd": 2.0}
+        tracker.close()
 
 
 class TestCostTrackerWithVault:

--- a/tests/test_costs.py
+++ b/tests/test_costs.py
@@ -371,6 +371,55 @@ class TestBudgetPersistence:
         tracker.close()
 
 
+class TestBudgetsPathDerivation:
+    """When no ``budgets_path`` is passed, it is derived from ``db_path`` so
+    tests and tools pointing the db at a tmp dir never touch the real
+    ``config/agent_budgets.json``.
+    """
+
+    def setup_method(self):
+        self._tmpdir = tempfile.mkdtemp()
+        self.db_path = os.path.join(self._tmpdir, "costs.db")
+
+    def teardown_method(self):
+        shutil.rmtree(self._tmpdir, ignore_errors=True)
+
+    def test_derives_budgets_path_alongside_tmp_db(self):
+        from pathlib import Path
+
+        config_file = Path("config/agent_budgets.json")
+        config_existed_before = config_file.exists()
+
+        # No budgets_path → co-located with the (tmp) db, NOT config/.
+        tracker = CostTracker(db_path=self.db_path)
+        expected = Path(self._tmpdir) / "agent_budgets.json"
+        assert tracker.budgets_path == expected
+
+        tracker.set_budget("agent1", daily_usd=3.0, monthly_usd=60.0)
+        tracker.close()
+
+        # The write landed under the tmp dir, not the real config dir.
+        assert expected.exists()
+        # And it did NOT create / mutate the real config file.
+        assert config_file.exists() == config_existed_before
+
+    def test_production_default_db_maps_to_config(self):
+        from pathlib import Path
+
+        # The production default db_path maps to the canonical config file
+        # (constructed without touching disk via __new__ + manual derivation).
+        tracker = object.__new__(CostTracker)
+        db_path = "data/costs.db"
+        budgets_path = None
+        if budgets_path is None:
+            if db_path == "data/costs.db":
+                budgets_path = "config/agent_budgets.json"
+            else:
+                budgets_path = str(Path(db_path).parent / "agent_budgets.json")
+        tracker.budgets_path = Path(budgets_path)
+        assert tracker.budgets_path == Path("config/agent_budgets.json")
+
+
 class TestCostTrackerWithVault:
     """Verify CostTracker integrates with CredentialVault."""
 

--- a/tests/test_costs.py
+++ b/tests/test_costs.py
@@ -340,6 +340,26 @@ class TestBudgetPersistence:
             mock_logger.warning.assert_called_once()
         tracker.close()
 
+    def test_malformed_entry_skipped_other_entries_still_load(self):
+        # One bad row (non-numeric daily_usd) must not abort loading the rest:
+        # the good agent's budget loads, the bad one is skipped, no exception.
+        import json
+
+        with open(self.budgets_path, "w") as f:
+            json.dump(
+                {
+                    "good": {"daily_usd": 50, "monthly_usd": 1000},
+                    "bad": {"daily_usd": "oops", "monthly_usd": 5},
+                },
+                f,
+            )
+        with patch("src.host.costs.logger") as mock_logger:
+            tracker = CostTracker(db_path=self.db_path, budgets_path=self.budgets_path)
+            mock_logger.warning.assert_called_once()
+        assert tracker.budgets["good"] == {"daily_usd": 50.0, "monthly_usd": 1000.0}
+        assert "bad" not in tracker.budgets
+        tracker.close()
+
     def test_cleanup_updates_persisted_file(self):
         tracker = CostTracker(db_path=self.db_path, budgets_path=self.budgets_path)
         tracker.set_budget("agent1", daily_usd=5.0, monthly_usd=100.0)


### PR DESCRIPTION
## Problem
`CostTracker.set_budget()` wrote only the in-memory `self.budgets` dict — no disk persistence. So per-agent budget caps an operator raised/lowered **silently reverted to the global default on every mesh restart/redeploy**. (The global default in `config/settings.json` already persists; only per-agent overrides were ephemeral.)

## Fix
- Load per-agent overrides on `CostTracker.__init__` (tolerant of missing/corrupt → empty, logs on corrupt).
- Persist on `set_budget` and on the `cleanup_agent` removal path via an **atomic** temp-file + `os.replace` write that never raises (a disk error logs, never crashes the LLM-proxy cost path).
- **Concurrency:** a `threading.Lock` guards the mutate+save in both paths so concurrent updates for different agents can't lose-update the file (Codex review).
- **Test/config isolation:** `budgets_path` derives from `db_path` when not passed — production default → `config/agent_budgets.json`; a tmp `db_path` (tests) → co-located tmp file. So existing/future tests that point the db at a tmp dir never touch the real `config/` (Codex review; verified: test_dashboard + test_image_gen create no stray config file).

Read paths and in-memory schema unchanged.

## Tests
`tests/test_costs.py` (persistence survives 'restart', corrupt→empty, cleanup updates file, save-failure no-crash, path derivation) → 34 passed; `tests/test_dashboard.py tests/test_image_gen.py` → 392 passed with no stray `config/agent_budgets.json`. Ruff clean.