### PR TITLE
fix(llm): bounded same-model retry on transient upstream errors (503/429/5xx)

### DIFF
--- a/src/host/credentials.py
+++ b/src/host/credentials.py
@@ -1319,6 +1319,12 @@ class CredentialVault:
         if isinstance(
             error,
             (
+                # Base classes catch transient faults the specific
+                # subclasses below miss (e.g. ReadError, ConnectError
+                # subtypes). TimeoutException / NetworkError are genuinely
+                # transient, so widening to them is safe.
+                httpx.TimeoutException,
+                httpx.NetworkError,
                 httpx.ConnectError,
                 httpx.ConnectTimeout,
                 httpx.ReadTimeout,

--- a/src/host/credentials.py
+++ b/src/host/credentials.py
@@ -52,6 +52,27 @@ _OPENAI_TOKEN_URL = "https://auth.openai.com/oauth/token"
 _OPENAI_OAUTH_CLIENT_ID = "app_EMoamEEZ73f0CkXaXp7hrann"
 _OPENAI_OAUTH_REDIRECT_URI = "http://localhost:1455/auth/callback"
 
+# ── Same-model transient retry (prod 503 incident) ───────────
+# HTTP statuses that are TRANSIENT upstream-provider blips (Anthropic /
+# OpenAI outage, rate-limit, gateway hiccup). A single one of these must
+# not fail the agent's whole task — retry the SAME model briefly before
+# falling through to the failover chain. Failover alone does not cover a
+# provider-wide blip (the next chain model is on the same provider with
+# the same outage) nor a single-model agent (no failover candidate).
+#
+# Permanent statuses (400/401/403/404/402) are deliberately ABSENT — they
+# are handled by ``_is_permanent_error`` / ``_raise_typed_llm_error`` and
+# must keep their existing fast-fail behaviour.
+#   503 Service Unavailable, 502 Bad Gateway, 504 Gateway Timeout,
+#   429 Too Many Requests, 529 Anthropic "overloaded".
+_TRANSIENT_RETRY_STATUS_CODES = frozenset({502, 503, 504, 429, 529})
+# Bounded: total attempts per model = 1 initial + this many retries.
+_TRANSIENT_MAX_RETRIES = 2
+# Deterministic exponential backoff (seconds): attempt 0 → 0.5, 1 → 1.0.
+# No jitter so tests are deterministic; the sleep coroutine is injectable
+# via ``_transient_sleep`` so tests run instantly.
+_TRANSIENT_BACKOFF_BASE = 0.5
+
 
 def _model_supports_vision(model: str) -> bool:
     """Check if a model supports image content blocks.
@@ -416,6 +437,9 @@ class CredentialVault:
         self._failover_chain = FailoverChain(
             chains=chains, health=self._health_tracker,
         )
+        # Injectable backoff sleep so the same-model transient retry can be
+        # exercised instantly in tests. Defaults to ``asyncio.sleep``.
+        self._transient_sleep = asyncio.sleep
 
     async def _get_http_client(self) -> httpx.AsyncClient:
         if self._http_client is not None and not self._http_client.is_closed:
@@ -1268,6 +1292,94 @@ class CredentialVault:
         return False
 
     @staticmethod
+    def _is_transient_error(error: Exception) -> bool:
+        """Return True for transient upstream-provider blips worth retrying.
+
+        Prod 503 incident: a single transient ``HTTP 503`` from the
+        provider (Anthropic / OpenAI outage) failed an agent's whole task.
+        Failover only switches MODELS, which does not help a provider-wide
+        blip (next chain model = same provider, same outage) nor a
+        single-model agent (no failover candidate). This classifier drives
+        a bounded SAME-model retry before the failover loop moves on.
+
+        Transient (retry): 502/503/504/429/529 status codes, plus
+        connection / timeout / read errors talking to the provider.
+
+        Permanent errors (400/401/403/404/402, auth, model-incompatible)
+        are NOT classified here — they are caught by the typed-exception
+        and ``_is_permanent_error`` paths and keep their fast-fail.
+        """
+        # Typed permanent / config / auth errors must never be retried here.
+        if isinstance(error, (LLMAuthError, LLMConfigError)):
+            return False
+        status = getattr(error, "status_code", 0)
+        if status in _TRANSIENT_RETRY_STATUS_CODES:
+            return True
+        # Network-layer faults reaching the provider (no HTTP status).
+        if isinstance(
+            error,
+            (
+                httpx.ConnectError,
+                httpx.ConnectTimeout,
+                httpx.ReadTimeout,
+                httpx.WriteTimeout,
+                httpx.PoolTimeout,
+                httpx.RemoteProtocolError,
+            ),
+        ):
+            return True
+        try:
+            import litellm
+        except Exception:  # pragma: no cover - litellm always importable here
+            return False
+        return isinstance(
+            error,
+            (
+                litellm.ServiceUnavailableError,
+                litellm.RateLimitError,
+                litellm.Timeout,
+                litellm.APIConnectionError,
+                litellm.InternalServerError,
+            ),
+        )
+
+    async def _call_with_transient_retry(self, model: str, attempt_fn):
+        """Run ``attempt_fn()`` for a single model, retrying transient blips.
+
+        Bounded same-model retry-with-backoff that wraps ONE failover
+        candidate. On a transient upstream error (see ``_is_transient_error``)
+        it retries the same model up to ``_TRANSIENT_MAX_RETRIES`` times with
+        deterministic exponential backoff, then re-raises so the caller's
+        existing failover loop can fall through to the next model. Permanent
+        / typed errors propagate immediately on the first attempt — no retry.
+
+        This is the single mesh-side call site every agent (streaming and
+        non-streaming) routes through, so the fix benefits the whole fleet
+        without duplicating the agent-loop's own retry path.
+        """
+        last_error: Exception | None = None
+        for attempt in range(_TRANSIENT_MAX_RETRIES + 1):
+            try:
+                return await attempt_fn()
+            except Exception as e:
+                if not self._is_transient_error(e):
+                    raise
+                last_error = e
+                if attempt >= _TRANSIENT_MAX_RETRIES:
+                    raise
+                wait = _TRANSIENT_BACKOFF_BASE * (2 ** attempt)
+                logger.warning(
+                    "Transient upstream error for model='%s' (%s) — "
+                    "retrying same model in %.2fs (attempt %d/%d)",
+                    model, type(e).__name__, wait,
+                    attempt + 1, _TRANSIENT_MAX_RETRIES,
+                )
+                await self._transient_sleep(wait)
+        # Defensive: loop always returns or raises above.
+        assert last_error is not None  # noqa: S101
+        raise last_error
+
+    @staticmethod
     def _get_status_code(error: Exception) -> int:
         """Extract HTTP status code from a litellm exception."""
         return getattr(error, "status_code", 0)
@@ -1367,7 +1479,12 @@ class CredentialVault:
                 continue
             api_base = self._get_api_base_for_model(model)
             try:
-                result = await call_fn(model, api_key, api_base, auth_headers)
+                result = await self._call_with_transient_retry(
+                    model,
+                    lambda m=model, k=api_key, b=api_base, h=auth_headers: (
+                        call_fn(m, k, b, h)
+                    ),
+                )
                 self._health_tracker.record_success(model)
                 if model != requested_model:
                     logger.info(
@@ -1401,7 +1518,12 @@ class CredentialVault:
             if api_key or self._is_keyless_provider(fallback):
                 api_base = self._get_api_base_for_model(fallback)
                 try:
-                    result = await call_fn(fallback, api_key, api_base, auth_headers)
+                    result = await self._call_with_transient_retry(
+                        fallback,
+                        lambda m=fallback, k=api_key, b=api_base, h=auth_headers: (
+                            call_fn(m, k, b, h)
+                        ),
+                    )
                     self._health_tracker.record_success(fallback)
                     logger.info(f"Auto-fallback: '{requested_model}' → '{fallback}' succeeded")
                     return result, fallback
@@ -3018,14 +3140,22 @@ class CredentialVault:
                 }
                 if api_key:
                     llm_kwargs["api_key"] = api_key
-                try:
-                    response = await litellm.acompletion(**llm_kwargs)
-                except Exception as litellm_err:
-                    # Codex P1 r3: classify LiteLLM auth/config failures
-                    # in the streaming path too — symmetric with the
-                    # non-streaming wrapper above.
-                    self._raise_typed_llm_error(litellm_err, model=model)
-                    raise  # _raise_typed_llm_error re-raises on no match
+
+                async def _open_stream(_kwargs=llm_kwargs, _model=model):
+                    try:
+                        return await litellm.acompletion(**_kwargs)
+                    except Exception as litellm_err:
+                        # Codex P1 r3: classify LiteLLM auth/config failures
+                        # in the streaming path too — symmetric with the
+                        # non-streaming wrapper above.
+                        self._raise_typed_llm_error(litellm_err, model=_model)
+                        raise  # _raise_typed_llm_error re-raises on no match
+
+                # Same-model bounded transient retry before failover
+                # (prod 503 incident) — mirrors the non-streaming path.
+                response = await self._call_with_transient_retry(
+                    model, _open_stream,
+                )
                 used_model = model
                 if model != requested_model:
                     logger.info(f"Stream failover: '{requested_model}' → '{model}'")
@@ -3074,15 +3204,21 @@ class CredentialVault:
                         }
                         if api_key:
                             llm_kwargs["api_key"] = api_key
-                        try:
-                            response = await litellm.acompletion(**llm_kwargs)
-                        except Exception as litellm_err:
-                            # Codex P1 r3: same typed-error classification
-                            # in the last-resort fallback path.
-                            self._raise_typed_llm_error(
-                                litellm_err, model=fallback,
-                            )
-                            raise
+
+                        async def _open_fb_stream(_kwargs=llm_kwargs, _model=fallback):
+                            try:
+                                return await litellm.acompletion(**_kwargs)
+                            except Exception as litellm_err:
+                                # Codex P1 r3: same typed-error classification
+                                # in the last-resort fallback path.
+                                self._raise_typed_llm_error(
+                                    litellm_err, model=_model,
+                                )
+                                raise
+
+                        response = await self._call_with_transient_retry(
+                            fallback, _open_fb_stream,
+                        )
                         used_model = fallback
                         logger.info(f"Stream auto-fallback: '{requested_model}' → '{fallback}'")
                     except (LLMAuthError, LLMConfigError) as typed_err:

--- a/tests/test_credentials.py
+++ b/tests/test_credentials.py
@@ -189,6 +189,10 @@ async def test_handle_llm_failover_on_rate_limit(monkeypatch):
     v = CredentialVault(
         failover_config={"anthropic/claude-haiku-4-5-20251001": ["openai/gpt-4o-mini"]},
     )
+    # Skip same-model transient backoff sleeps so the test runs instantly.
+    async def _no_sleep(_seconds):
+        return None
+    v._transient_sleep = _no_sleep
 
     import litellm
 
@@ -220,7 +224,9 @@ async def test_handle_llm_failover_on_rate_limit(monkeypatch):
     assert result.success
     assert result.data["content"] == "hello from fallback"
     assert result.data["model"] == "openai/gpt-4o-mini"
-    assert call_count == 2
+    # anthropic exhausts its same-model transient retries (1 initial + 2
+    # retries = 3) BEFORE the chain falls over to the healthy openai model.
+    assert call_count == 4
 
 
 async def test_handle_llm_no_failover_on_bad_request(monkeypatch):
@@ -261,6 +267,11 @@ async def test_handle_llm_all_models_exhausted(monkeypatch):
     v = CredentialVault(
         failover_config={"anthropic/claude-haiku-4-5-20251001": ["openai/gpt-4o-mini"]},
     )
+    # Same-model transient retry now wraps each candidate; keep the test fast
+    # by skipping the backoff sleeps.
+    async def _no_sleep(_seconds):
+        return None
+    v._transient_sleep = _no_sleep
 
     import litellm
 
@@ -285,6 +296,225 @@ async def test_handle_llm_all_models_exhausted(monkeypatch):
     # numeric retry-substring backstop still recognizes it as retryable.
     assert result.status_code == 503
     assert "503" in result.error
+
+
+def _make_single_model_vault(monkeypatch):
+    """Vault with ONE model (no failover candidate) and a no-op backoff.
+
+    Reproduces the prod 503 incident shape: a solo agent on a single model
+    where failover cannot help because there is no other model to try.
+    """
+    monkeypatch.setenv("OPENLEGION_SYSTEM_ANTHROPIC_API_KEY", "sk-ant")
+    monkeypatch.delenv("OPENLEGION_SYSTEM_OPENAI_API_KEY", raising=False)
+    v = CredentialVault(failover_config={})
+    slept: list[float] = []
+
+    async def _record_sleep(seconds):
+        slept.append(seconds)
+
+    v._transient_sleep = _record_sleep
+    return v, slept
+
+
+def _good_response():
+    resp = MagicMock()
+    resp.choices = [MagicMock()]
+    resp.choices[0].message.content = "recovered"
+    resp.choices[0].message.tool_calls = None
+    resp.usage = MagicMock()
+    resp.usage.total_tokens = 7
+    return resp
+
+
+def _chat_req():
+    return APIProxyRequest(
+        service="llm", action="chat",
+        params={
+            "model": "anthropic/claude-haiku-4-5-20251001",
+            "messages": [{"role": "user", "content": "hi"}],
+        },
+    )
+
+
+async def test_transient_503_retried_same_model_then_succeeds(monkeypatch):
+    """Prod 503 incident: a transient 503 on the only model is retried on
+    the SAME model and succeeds on a later attempt — not a task failure."""
+    v, slept = _make_single_model_vault(monkeypatch)
+    import litellm
+
+    call_count = 0
+
+    async def mock_acompletion(model, messages, api_key, **kwargs):
+        nonlocal call_count
+        call_count += 1
+        if call_count < 3:
+            raise litellm.ServiceUnavailableError(
+                message="overloaded", model=model, llm_provider="anthropic",
+            )
+        return _good_response()
+
+    with patch("litellm.acompletion", side_effect=mock_acompletion):
+        result = await v.execute_api_call(_chat_req())
+
+    assert result.success
+    assert result.data["content"] == "recovered"
+    # 1 initial + 2 retries — succeeded on the 3rd attempt, same model.
+    assert call_count == 3
+    assert result.data["model"] == "anthropic/claude-haiku-4-5-20251001"
+    # Backoff was deterministic and bounded.
+    assert slept == [0.5, 1.0]
+
+
+async def test_transient_429_retried_same_model_then_succeeds(monkeypatch):
+    """A transient 429 (rate limit) is retried on the same model and
+    succeeds on the second attempt."""
+    v, slept = _make_single_model_vault(monkeypatch)
+    import litellm
+
+    call_count = 0
+
+    async def mock_acompletion(model, messages, api_key, **kwargs):
+        nonlocal call_count
+        call_count += 1
+        if call_count == 1:
+            raise litellm.RateLimitError(
+                message="429 too many requests", model=model,
+                llm_provider="anthropic",
+            )
+        return _good_response()
+
+    with patch("litellm.acompletion", side_effect=mock_acompletion):
+        result = await v.execute_api_call(_chat_req())
+
+    assert result.success
+    assert call_count == 2
+    assert slept == [0.5]
+
+
+async def test_transient_503_bounded_gives_up_after_max(monkeypatch):
+    """Persistent 503 is retried a BOUNDED number of times then surfaces a
+    clear masked error — no infinite retry, budget can't be blown."""
+    v, slept = _make_single_model_vault(monkeypatch)
+    import litellm
+
+    call_count = 0
+
+    async def mock_acompletion(model, messages, api_key, **kwargs):
+        nonlocal call_count
+        call_count += 1
+        raise litellm.ServiceUnavailableError(
+            message="still down", model=model, llm_provider="anthropic",
+        )
+
+    with patch("litellm.acompletion", side_effect=mock_acompletion):
+        result = await v.execute_api_call(_chat_req())
+
+    assert not result.success
+    # 1 initial + 2 retries = 3 attempts, then give up (single model, no
+    # failover candidate). Bounded — does not loop forever.
+    assert call_count == 3
+    assert slept == [0.5, 1.0]
+    assert result.status_code == 503
+    assert result.error == "Upstream service call failed (HTTP 503)."
+    assert "still down" not in (result.error or "")
+
+
+async def test_permanent_401_not_retried(monkeypatch):
+    """A permanent 401 auth failure fails immediately — no transient retry."""
+    v, slept = _make_single_model_vault(monkeypatch)
+    import litellm
+
+    call_count = 0
+
+    async def mock_acompletion(model, messages, api_key, **kwargs):
+        nonlocal call_count
+        call_count += 1
+        raise litellm.AuthenticationError(
+            message="bad key", model=model, llm_provider="anthropic",
+        )
+
+    with patch("litellm.acompletion", side_effect=mock_acompletion):
+        result = await v.execute_api_call(_chat_req())
+
+    assert not result.success
+    # Classified to LLMAuthError and surfaced on the FIRST attempt.
+    assert call_count == 1
+    assert slept == []
+    assert result.error_type == "auth_failure"
+
+
+async def test_permanent_400_bad_request_not_retried(monkeypatch):
+    """A permanent 400 bad-request fails immediately — no transient retry."""
+    v, slept = _make_single_model_vault(monkeypatch)
+    import litellm
+
+    call_count = 0
+
+    async def mock_acompletion(model, messages, api_key, **kwargs):
+        nonlocal call_count
+        call_count += 1
+        raise litellm.BadRequestError(
+            message="invalid request", model=model, llm_provider="anthropic",
+        )
+
+    with patch("litellm.acompletion", side_effect=mock_acompletion):
+        result = await v.execute_api_call(_chat_req())
+
+    assert not result.success
+    assert call_count == 1
+    assert slept == []
+    assert result.status_code == 400
+
+
+async def test_model_incompatible_404_not_retried(monkeypatch):
+    """A model-not-found (config error) fails immediately — no retry."""
+    v, slept = _make_single_model_vault(monkeypatch)
+    import litellm
+
+    call_count = 0
+
+    async def mock_acompletion(model, messages, api_key, **kwargs):
+        nonlocal call_count
+        call_count += 1
+        raise litellm.NotFoundError(
+            message="model not found", model=model, llm_provider="anthropic",
+        )
+
+    with patch("litellm.acompletion", side_effect=mock_acompletion):
+        result = await v.execute_api_call(_chat_req())
+
+    assert not result.success
+    assert call_count == 1
+    assert slept == []
+    assert result.error_type == "config_error"
+
+
+def test_is_transient_error_classification():
+    """Unit-level classification: transient statuses vs permanent ones."""
+    v = CredentialVault()
+
+    class _Err(Exception):
+        def __init__(self, status):
+            self.status_code = status
+
+    for status in (502, 503, 504, 429, 529):
+        assert v._is_transient_error(_Err(status)) is True, status
+    for status in (400, 401, 403, 404, 402, 200):
+        assert v._is_transient_error(_Err(status)) is False, status
+
+    # Connection / timeout faults to the provider are transient.
+    import httpx
+    assert v._is_transient_error(httpx.ConnectError("boom")) is True
+    assert v._is_transient_error(httpx.ReadTimeout("slow")) is True
+
+    # Typed permanent errors are never retried here.
+    from src.shared.errors import LLMAuthError, LLMConfigError
+    assert v._is_transient_error(
+        LLMAuthError("x", provider="anthropic"),
+    ) is False
+    assert v._is_transient_error(
+        LLMConfigError("x", provider="anthropic", model="m"),
+    ) is False
 
 
 async def test_handle_llm_empty_choices_triggers_failover(monkeypatch):
@@ -340,6 +570,10 @@ async def test_stream_failover(monkeypatch):
     v = CredentialVault(
         failover_config={"anthropic/claude-haiku-4-5-20251001": ["openai/gpt-4o-mini"]},
     )
+    # Skip same-model transient backoff sleeps so the test runs instantly.
+    async def _no_sleep(_seconds):
+        return None
+    v._transient_sleep = _no_sleep
 
     import litellm
 
@@ -371,7 +605,9 @@ async def test_stream_failover(monkeypatch):
         async for event in v.stream_llm(req):
             events.append(event)
 
-    assert call_count == 2
+    # anthropic stream-open exhausts its same-model transient retries (1
+    # initial + 2 retries = 3) BEFORE falling over to the openai stream.
+    assert call_count == 4
     # Should have text_delta and done events
     assert any("streamed" in e for e in events)
     assert any("done" in e for e in events)

--- a/tests/test_credentials.py
+++ b/tests/test_credentials.py
@@ -391,6 +391,30 @@ async def test_transient_429_retried_same_model_then_succeeds(monkeypatch):
     assert slept == [0.5]
 
 
+async def test_transient_httpx_timeout_exception_retried_then_succeeds(monkeypatch):
+    """A bare ``httpx.TimeoutException`` (base class, not one of the named
+    subclasses) raised by the upstream is classified transient, retried on
+    the same model, and succeeds on the next attempt."""
+    v, slept = _make_single_model_vault(monkeypatch)
+    import httpx
+
+    call_count = 0
+
+    async def mock_acompletion(model, messages, api_key, **kwargs):
+        nonlocal call_count
+        call_count += 1
+        if call_count == 1:
+            raise httpx.TimeoutException("slow")
+        return _good_response()
+
+    with patch("litellm.acompletion", side_effect=mock_acompletion):
+        result = await v.execute_api_call(_chat_req())
+
+    assert result.success
+    assert call_count == 2
+    assert slept == [0.5]
+
+
 async def test_transient_503_bounded_gives_up_after_max(monkeypatch):
     """Persistent 503 is retried a BOUNDED number of times then surfaces a
     clear masked error — no infinite retry, budget can't be blown."""
@@ -506,6 +530,11 @@ def test_is_transient_error_classification():
     import httpx
     assert v._is_transient_error(httpx.ConnectError("boom")) is True
     assert v._is_transient_error(httpx.ReadTimeout("slow")) is True
+    # Base classes must also classify as transient — they cover subtypes
+    # the specific subclasses above miss (e.g. httpx.ReadError).
+    assert v._is_transient_error(httpx.TimeoutException("slow")) is True
+    assert v._is_transient_error(httpx.NetworkError("net")) is True
+    assert v._is_transient_error(httpx.ReadError("partial")) is True
 
     # Typed permanent errors are never retried here.
     from src.shared.errors import LLMAuthError, LLMConfigError


### PR DESCRIPTION
## Problem (production)
A client's agent task failed outright with `LLM call failed: Upstream service call failed (HTTP 503)` — a transient upstream blip. Investigation found the mesh proxy's failover only switches **models** (useless for a provider-wide outage, and a no-op for a solo/single-model agent), so a transient 503 had **no same-model retry** and fell straight through to a task failure.

## Fix
Add a bounded same-model retry at the single mesh-side call site, **integrated into the existing failover loop** (retries the candidate, then re-raises so failover still proceeds):
- Transient (retry): 502/503/504/429/529 + httpx connection/timeout faults; max 2 retries, deterministic backoff (0.5s, 1.0s), sleep injectable for tests.
- Permanent (unchanged fast-fail): 400/401/403/404/402, model-incompatible, auth/budget — never retried.
- Does not duplicate the agent-loop retry or the failover mechanism.

## Tests
`tests/test_credentials.py`: 503/429 retried-then-succeed; bounded give-up after max; 401/400/404 not retried; classifier unit test. Updated 2 failover tests for new call counts. → 285 passed (+ 36 in failover/llm). Ruff clean.