### PR TITLE
fix(loop): per-task convergence budget + nudge so handed-off tasks finish instead of looping

### DIFF
--- a/src/agent/loop.py
+++ b/src/agent/loop.py
@@ -2281,6 +2281,13 @@ class AgentLoop:
     # discoverable next to the other CHAT_* bounds and gives a sane default
     # if an AgentLoop is ever constructed without running ``__init__``.
     TASK_MAX_TOOL_ROUNDS = 20
+    # Codex #3 size bound: hard cap on the number of distinct task entries
+    # held in ``self._task_round_counts``. The dict is freed per-task on
+    # terminal close, so it normally tracks only in-flight tasks (small). This
+    # bound guards the degenerate case where sustained mesh-write failures keep
+    # terminal closes from popping entries — once exceeded, adding a new task
+    # evicts an arbitrary existing entry instead of growing unbounded.
+    _TASK_ROUND_COUNTS_MAX = 256
     # Append the convergence wrap-up directive to the SYSTEM PROMPT (NOT a
     # chat message — that would break LLM role-alternation, see Codex
     # finding #1) once the per-task budget has this many rounds or fewer
@@ -3249,32 +3256,45 @@ class AgentLoop:
             # RC-1 / RC-3: per-task convergence budget. Read the durable
             # task_id from the contextvar set by chat() — ``None`` for
             # interactive operator chat / heartbeats, which must be
-            # COMPLETELY unaffected (no cap, no nudge, no tool-withhold).
+            # COMPLETELY unaffected (no cap, no nudge).
             from src.shared.trace import current_task_id
             _task_id = current_task_id.get()
-            # Rounds this task has already consumed on prior wakes (RC-3
-            # cross-wake persistence). ``_task_max`` is the per-task budget;
-            # ``_task_loop_rounds`` is how many tool rounds THIS turn may run
-            # before the budget is exhausted (bounded by the interactive
-            # CHAT_MAX_TOOL_ROUNDS so the task path can never EXCEED the
-            # interactive bound — it only ever tightens it). When the budget
-            # was already spent on earlier wakes, allow exactly one final
-            # tool-withheld round so the model produces a terminal answer.
+            # Pre-round-boundary redesign (Codex r3): the loop runs over the
+            # NORMAL interactive bound (CHAT_MAX_TOOL_ROUNDS) exactly as it did
+            # before the convergence feature. The per-task cap is enforced as a
+            # PRE-ROUND boundary at the TOP of each iteration (below), BEFORE
+            # the LLM call — it is the ONLY place ``task_convergence_capped`` is
+            # set for tasks. This is structurally immune to the two Codex
+            # blockers:
+            #   #1 (terminal tool on last budgeted round overridden): a
+            #      terminal complete_task / hand_off / final-text in a round
+            #      returns via the normal no-tool-calls path BELOW *before* the
+            #      next round's top-of-loop cap check can run, so the cap can
+            #      never pre-empt a real completion.
+            #   #2 (exhausted re-wake gets another tool round): an exhausted
+            #      re-wake (count already >= cap) breaks at the FIRST round's
+            #      top, before any LLM/tool call — no extra tool round is ever
+            #      granted.
             _task_convergence_capped = False
-            if _task_id:
-                _task_rounds_done = self._task_round_counts.get(_task_id, 0)
-                _task_remaining = max(0, self.TASK_MAX_TOOL_ROUNDS - _task_rounds_done)
-                _task_loop_rounds = min(
-                    self.CHAT_MAX_TOOL_ROUNDS, max(1, _task_remaining),
-                )
-            else:
-                _task_rounds_done = 0
-                _task_remaining = 0
-                _task_loop_rounds = self.CHAT_MAX_TOOL_ROUNDS
 
             steer_interrupts = 0
-            for _round_idx in range(_task_loop_rounds):
+            for _round_idx in range(self.CHAT_MAX_TOOL_ROUNDS):
                 self._bump_liveness()
+                # ── Per-task convergence cap: PRE-ROUND boundary ──
+                # The ONLY place the cap flag is set for tasks. Checked at the
+                # very top of the round, BEFORE the LLM call. If this task has
+                # already consumed its per-task budget across all wakes, stop
+                # here and let chat() close it ``blocked``. Because a terminal
+                # tool / final reply in the PRIOR round already returned via the
+                # normal path below, this check can never override a real
+                # completion; and an exhausted re-wake breaks immediately with
+                # NO additional tool round.
+                if _task_id and (
+                    self._task_round_counts.get(_task_id, 0)
+                    >= self.TASK_MAX_TOOL_ROUNDS
+                ):
+                    _task_convergence_capped = True
+                    break
                 # RC-1 convergence forcing function (task path only).
                 #
                 # Codex finding #1: the nudge is appended to THIS round's
@@ -3286,18 +3306,20 @@ class AgentLoop:
                 # per round, so a transient suffix is safe and leaves
                 # ``self._chat_messages`` untouched.
                 #
-                # Codex finding #2: TOOLS REMAIN AVAILABLE on every budgeted
-                # round. The agent converges by CALLING complete_task /
-                # hand_off, so withholding tools would PREVENT convergence and
-                # wrongly force a ``blocked`` close on the deliverable. There
-                # is no last-round tool-withhold on the task path.
+                # Codex finding #2: TOOLS REMAIN AVAILABLE on every round. The
+                # agent converges by CALLING complete_task / hand_off, so
+                # withholding tools would PREVENT convergence and wrongly force
+                # a ``blocked`` close on the deliverable. There is no
+                # task-path tool-withhold.
                 #
                 # ``_task_left`` is the rounds remaining in the WHOLE per-task
                 # budget, including prior wakes — so a re-woken near-exhausted
                 # task is nudged immediately, not given a fresh window.
                 _round_system = system
                 if _task_id:
-                    _task_left = _task_remaining - _round_idx
+                    _task_left = self.TASK_MAX_TOOL_ROUNDS - self._task_round_counts.get(
+                        _task_id, 0,
+                    )
                     if _task_left <= 1:
                         _round_system = system + self._TASK_CONVERGENCE_FINAL_SUFFIX
                     elif _task_left <= self._TASK_CONVERGENCE_NUDGE_REMAINING:
@@ -3476,7 +3498,29 @@ class AgentLoop:
                 # the running per-task count so it survives across wakes —
                 # repeated lane followups for the same task_id share one
                 # budget instead of each getting a fresh window.
+                #
+                # Codex #3 (size bound): the dict is normally freed on each
+                # task's terminal close (``_auto_close_task`` pops it), so it
+                # tracks only in-flight tasks. But sustained mesh-write
+                # failures (5xx) keep counts alive indefinitely, so cap the
+                # dict size: when adding a NEW task would exceed the bound,
+                # evict an arbitrary existing entry first. Re-incrementing an
+                # already-tracked task never grows the dict, so an in-flight
+                # task is never evicted out from under itself by this guard.
                 if _task_id:
+                    if (
+                        _task_id not in self._task_round_counts
+                        and len(self._task_round_counts)
+                        >= self._TASK_ROUND_COUNTS_MAX
+                    ):
+                        # Evict an arbitrary (effectively oldest-inserted on
+                        # CPython dicts) entry to keep the bound. Advisory
+                        # state only — a wrongly-evicted task just gets a fresh
+                        # budget on its next round, which is acceptable under
+                        # the degenerate sustained-failure regime this guards.
+                        self._task_round_counts.pop(
+                            next(iter(self._task_round_counts)), None,
+                        )
                     self._task_round_counts[_task_id] = (
                         self._task_round_counts.get(_task_id, 0) + 1
                     )
@@ -3510,6 +3554,39 @@ class AgentLoop:
                     await self._auto_continue_session(system)
 
                 await self._compact_chat_context(system)
+
+            # Per-task convergence cap hit (top-of-round break). Return
+            # immediately WITHOUT a force-compose LLM call: the task never
+            # converged, so chat() will close it ``blocked`` with the static
+            # convergence note. Returning here is what makes an exhausted
+            # re-wake (Codex blocker #2) consume ZERO LLM calls — it breaks at
+            # the first round top and returns straight away. A genuine
+            # completion (terminal tool / final text) already returned via the
+            # no-tool-calls path inside the loop, so it never reaches here.
+            if _task_convergence_capped:
+                self.state = "idle"
+                if tool_outputs and self.workspace:
+                    tool_names = list(
+                        {t.get("tool") or t.get("name", "?") for t in tool_outputs}
+                    )
+                    self.workspace.append_activity(
+                        trigger="chat",
+                        summary="convergence cap reached",
+                        tools_used=tool_names,
+                        tokens_used=total_tokens,
+                        outcome="convergence_capped",
+                    )
+                return {
+                    "response": "",
+                    "tool_outputs": tool_outputs,
+                    "tokens_used": total_tokens,
+                    "task_convergence_capped": True,
+                    # ``silent_reply`` suppresses chat()'s empty-response
+                    # final-net marker: the response is intentionally empty
+                    # (the task is being closed ``blocked``, not surfaced as a
+                    # chat reply), so no synthetic "no text" notice is wanted.
+                    "silent_reply": True,
+                }
 
             # Max tool rounds exhausted — force final text response.
             # Omit tools so the LLM cannot return more tool calls.
@@ -3550,18 +3627,16 @@ class AgentLoop:
                 "tokens_used": total_tokens,
                 "tool_limit_reached": True,
             }
-            if _task_id:
-                # RC-1 (Codex finding #3): this fall-through is reached on the
-                # task path ONLY when the model exhausted its per-task round
-                # budget while STILL emitting tool_calls — i.e. it never
-                # converged to a terminal complete_task / hand_off / final
-                # text of its own accord (which would have returned via the
-                # no-tool-calls branch above WITHOUT this flag). Tools were
-                # offered on every budgeted round, so this is a genuine
-                # non-convergence: tag so chat() closes the task ``blocked``
-                # with the static convergence note rather than a generic
-                # ``max_iterations_reached`` failure.
-                tool_limit_result["task_convergence_capped"] = True
+            # Pre-round-boundary redesign (Codex r3): this fall-through keeps
+            # ONLY its original pre-feature ``tool_limit_reached`` behaviour —
+            # reached when the interactive CHAT_MAX_TOOL_ROUNDS bound is hit
+            # while still emitting tool_calls. It is deliberately NOT tagged
+            # ``task_convergence_capped``: the convergence cap is set
+            # EXCLUSIVELY by the top-of-round break above (which returns early,
+            # before this block), and that break always fires FIRST for a task
+            # since TASK_MAX_TOOL_ROUNDS <= CHAT_MAX_TOOL_ROUNDS. A task can
+            # therefore only leave the loop via the cap break (→ early return)
+            # or a terminal/final return inside the loop — never here.
             if deliberate_silence or marker_substituted:
                 tool_limit_result["silent_reply"] = True
             return tool_limit_result

--- a/src/agent/loop.py
+++ b/src/agent/loop.py
@@ -326,6 +326,21 @@ class AgentLoop:
         # tighter soft bound below them. Interactive chat (no task_id) is
         # completely unaffected.
         self.TASK_MAX_TOOL_ROUNDS = _clamp_env("OPENLEGION_TASK_MAX_TOOL_ROUNDS", 20, 1, 100)
+        # Item 3 (Codex r4): TASK_MAX and CHAT_MAX are independently
+        # env-clamped, so a misconfig (TASK_MAX > CHAT_MAX) could let a task
+        # exhaust the interactive CHAT_MAX_TOOL_ROUNDS bound — falling through
+        # to the ``tool_limit_reached`` exit — BEFORE its per-task cap ever
+        # fired. The whole design assumes TASK_MAX <= CHAT_MAX (the top-of-round
+        # cap break always wins). Enforce that invariant here so the effective
+        # per-task budget can never exceed the interactive ceiling.
+        if self.TASK_MAX_TOOL_ROUNDS > self.CHAT_MAX_TOOL_ROUNDS:
+            logger.info(
+                "TASK_MAX_TOOL_ROUNDS=%d exceeds CHAT_MAX_TOOL_ROUNDS=%d — "
+                "clamping the effective per-task budget to %d",
+                self.TASK_MAX_TOOL_ROUNDS, self.CHAT_MAX_TOOL_ROUNDS,
+                self.CHAT_MAX_TOOL_ROUNDS,
+            )
+            self.TASK_MAX_TOOL_ROUNDS = self.CHAT_MAX_TOOL_ROUNDS
         self.agent_id = agent_id
         self.role = role
         self.memory = memory
@@ -1702,6 +1717,46 @@ class AgentLoop:
         for t in tool_outputs:
             name = t.get("tool") or t.get("name") or ""
             if name and name not in _READ_ONLY_TOOLS:
+                return True
+        return False
+
+    @staticmethod
+    def _last_round_terminal_completion(tool_outputs: list[dict] | None) -> bool:
+        """True iff the most recent tool round closed the task for real.
+
+        A "genuine completion" is a SUCCESSFUL terminal coordination tool:
+
+          * ``complete_task`` whose output carries ``completed is True``
+          * ``hand_off`` whose output carries ``handed_off is True``
+
+        This is deliberately NARROWER than ``_has_outbound_effect``: a
+        ``notify_user`` / ``write_blackboard`` / ``publish_event`` is an
+        outbound side-effect but NOT a task completion, so it must NOT pre-empt
+        the convergence cap. A FAILED terminal tool (``handed_off=False`` /
+        ``complete_task_failed`` flag) is likewise NOT a completion — it is
+        handled by ``_chat_result_failure_reason`` (→ ``failed``) and must not
+        short-circuit the cap either.
+
+        Item 1 fix (Codex r4): the budgeted chat loop calls this AFTER tool
+        execution. When it returns True, the loop returns the NORMAL
+        (non-capped) result immediately so chat()'s done/handoff close runs,
+        instead of continuing to the next round's top-of-loop cap check that
+        would otherwise override the just-landed completion with ``blocked``.
+
+        Only the LAST round's outputs matter (the round that just executed),
+        but scanning the full accumulated list is equivalent and simpler: a
+        successful terminal tool anywhere in the turn means the task converged.
+        """
+        if not tool_outputs:
+            return False
+        for t in tool_outputs:
+            name = t.get("tool") or t.get("name") or ""
+            output = t.get("output")
+            if not isinstance(output, dict):
+                continue
+            if name == "complete_task" and output.get("completed") is True:
+                return True
+            if name == "hand_off" and output.get("handed_off") is True:
                 return True
         return False
 
@@ -3503,27 +3558,75 @@ class AgentLoop:
                 # task's terminal close (``_auto_close_task`` pops it), so it
                 # tracks only in-flight tasks. But sustained mesh-write
                 # failures (5xx) keep counts alive indefinitely, so cap the
-                # dict size: when adding a NEW task would exceed the bound,
-                # evict an arbitrary existing entry first. Re-incrementing an
-                # already-tracked task never grows the dict, so an in-flight
-                # task is never evicted out from under itself by this guard.
+                # dict size.
+                #
+                # Item 4 fix (Codex r4): the previous design evicted an
+                # ARBITRARY existing entry to make room for a new task. That
+                # was unsafe — the evicted entry could belong to a still-working
+                # task, which would then regain a FRESH full per-task budget on
+                # its next round (the exact failure the cap exists to prevent).
+                # New design: never evict a tracked entry. Once at the bound,
+                # simply DO NOT begin tracking a brand-new task (log a warning).
+                # An untracked task runs without the advisory per-task cap — but
+                # that only happens with 256 simultaneously in-flight tasks
+                # under sustained mesh-write failure, a far more benign outcome
+                # than silently resetting a live task's budget. A task already
+                # in the dict always keeps incrementing its own count.
                 if _task_id:
                     if (
                         _task_id not in self._task_round_counts
                         and len(self._task_round_counts)
                         >= self._TASK_ROUND_COUNTS_MAX
                     ):
-                        # Evict an arbitrary (effectively oldest-inserted on
-                        # CPython dicts) entry to keep the bound. Advisory
-                        # state only — a wrongly-evicted task just gets a fresh
-                        # budget on its next round, which is acceptable under
-                        # the degenerate sustained-failure regime this guards.
-                        self._task_round_counts.pop(
-                            next(iter(self._task_round_counts)), None,
+                        logger.warning(
+                            "task convergence count table at bound (%d) — not "
+                            "tracking new task=%s; it runs without the advisory "
+                            "per-task cap until an in-flight task closes",
+                            self._TASK_ROUND_COUNTS_MAX, _task_id,
                         )
-                    self._task_round_counts[_task_id] = (
-                        self._task_round_counts.get(_task_id, 0) + 1
+                    else:
+                        self._task_round_counts[_task_id] = (
+                            self._task_round_counts.get(_task_id, 0) + 1
+                        )
+
+                # Item 1 fix (Codex r4) — completion wins over the convergence
+                # cap. If THIS round landed a SUCCESSFUL terminal coordination
+                # tool (complete_task → completed / hand_off → handed_off), the
+                # task genuinely converged. Return the NORMAL (non-capped)
+                # result NOW so chat()'s done/handoff close path runs — instead
+                # of looping to the next round's top-of-loop cap check, which
+                # (when this round pushed the count to TASK_MAX) would break and
+                # mislabel a real completion as ``blocked``. Gated on
+                # ``_task_id`` so interactive chat is untouched. A non-terminal
+                # outbound (notify_user, write_blackboard, …) does NOT trip this
+                # — those still fall through to the cap, so a task that hit the
+                # cap doing non-terminal work is still closed ``blocked``.
+                if _task_id and AgentLoop._last_round_terminal_completion(
+                    tool_outputs
+                ):
+                    logger.info(
+                        "chat task=%s landed a terminal coordination tool this "
+                        "round — returning to let chat() close done/handoff "
+                        "(convergence cap does not pre-empt a real completion)",
+                        _task_id,
                     )
+                    self.state = "idle"
+                    self._chat_messages.append(
+                        {"role": "assistant", "content": ""}
+                    )
+                    self._log_chat_turn(
+                        user_message, "", tool_outputs, turn_id=turn_id,
+                    )
+                    return {
+                        "response": "",
+                        "tool_outputs": tool_outputs,
+                        "tokens_used": total_tokens,
+                        # Intentionally NOT ``task_convergence_capped``: this is
+                        # a genuine completion, so chat() runs its normal close.
+                        # ``silent_reply`` suppresses the empty-response marker
+                        # (the task closes done/handoff, no chat bubble wanted).
+                        "silent_reply": True,
+                    }
 
                 # Rebuild system prompt if operator playbook state changed
                 if self._is_operator:

--- a/src/agent/loop.py
+++ b/src/agent/loop.py
@@ -325,7 +325,7 @@ class AgentLoop:
         # daily budget preflight, lane wall-clock cap). It only ADDS a
         # tighter soft bound below them. Interactive chat (no task_id) is
         # completely unaffected.
-        self.TASK_MAX_TOOL_ROUNDS = _clamp_env("OPENLEGION_TASK_MAX_TOOL_ROUNDS", 12, 1, 100)
+        self.TASK_MAX_TOOL_ROUNDS = _clamp_env("OPENLEGION_TASK_MAX_TOOL_ROUNDS", 20, 1, 100)
         self.agent_id = agent_id
         self.role = role
         self.memory = memory
@@ -2280,9 +2280,12 @@ class AgentLoop:
     # ``__init__`` (env-clamped). This attr only exists so the constant is
     # discoverable next to the other CHAT_* bounds and gives a sane default
     # if an AgentLoop is ever constructed without running ``__init__``.
-    TASK_MAX_TOOL_ROUNDS = 12
-    # Inject the convergence wrap-up nudge when this many task rounds remain.
-    _TASK_CONVERGENCE_NUDGE_REMAINING = 2
+    TASK_MAX_TOOL_ROUNDS = 20
+    # Append the convergence wrap-up directive to the SYSTEM PROMPT (NOT a
+    # chat message — that would break LLM role-alternation, see Codex
+    # finding #1) once the per-task budget has this many rounds or fewer
+    # remaining. A second, harder escalation fires at ``<= 1`` remaining.
+    _TASK_CONVERGENCE_NUDGE_REMAINING = 4
     # Static blocker_note used when the per-task budget is exhausted without
     # a terminal coordination tool. Short + static-worded on purpose — never
     # interpolate untrusted task content into this note.
@@ -2290,6 +2293,21 @@ class AgentLoop:
         "convergence_cap: task hit its per-task round budget without "
         "completing — produce the deliverable and call complete_task or "
         "hand_off"
+    )
+    # System-prompt suffixes for the convergence nudge (Codex finding #1).
+    # Appended to THIS round's ``system`` string — never injected as a chat
+    # message — so the user/assistant/tool role-alternation the LLM call
+    # requires is preserved. Static-worded; no untrusted content.
+    _TASK_CONVERGENCE_SOFT_SUFFIX = (
+        "\n\n## Task wrap-up\n"
+        "You are nearing this task's per-task round budget. Wrap up this "
+        "task soon — produce your deliverable and call complete_task or "
+        "hand_off. Do not start new work."
+    )
+    _TASK_CONVERGENCE_FINAL_SUFFIX = (
+        "\n\n## Task wrap-up — FINAL ROUND\n"
+        "This is the final round for this task. Call complete_task or "
+        "hand_off now, or give your final answer. Do NOT start new work."
     )
 
     async def _auto_continue_session(self, system: str) -> None:
@@ -2535,14 +2553,23 @@ class AgentLoop:
                     #   3. Success → ``done`` with response prefix as
                     #      summary.
                     if task_id:
-                        # RC-1: per-task convergence cap reached. The agent
-                        # exhausted its per-task round budget without calling
-                        # a terminal coordination tool. Drive the task to a
-                        # TERMINAL ``blocked`` state with a short, static
-                        # blocker_note (never dangling ``working``, never
-                        # leaking untrusted task content). Checked BEFORE the
-                        # generic failure-reason scan so the convergence note
-                        # wins over the ``max_iterations_reached`` label the
+                        # RC-1 (Codex finding #3): per-task convergence cap
+                        # reached ONLY if the agent did NOT converge on its
+                        # own. ``task_convergence_capped`` is set exclusively
+                        # by ``_chat_inner``'s budget-exhausted fall-through —
+                        # the path where the model kept emitting tool_calls
+                        # past its per-task round budget. A genuine completion
+                        # (the model returned a final text reply, or closed the
+                        # task via complete_task / hand_off) DOES NOT set the
+                        # flag, so it falls through to the normal success path
+                        # below and closes ``done`` / handoff — the cap never
+                        # pre-empts a real completion. When the flag IS set,
+                        # drive the task to a TERMINAL ``blocked`` state with a
+                        # short, static blocker_note (never dangling
+                        # ``working``, never leaking untrusted task content).
+                        # Checked BEFORE the generic failure-reason scan so the
+                        # convergence note wins over the
+                        # ``max_iterations_reached`` label the
                         # ``tool_limit_reached`` envelope would otherwise emit.
                         if result.get("task_convergence_capped"):
                             logger.warning(
@@ -2732,14 +2759,6 @@ class AgentLoop:
         transitions, so a ``blocked`` close that wants a reason must pass
         ``blocker_note`` explicitly (e.g. the convergence-cap close).
         """
-        # RC-3: drop the advisory per-task convergence count once the task
-        # leaves the active ``working`` state — the budget is per-task, not
-        # forever, so a future task reusing the same id starts fresh. Only
-        # ``working`` keeps the count alive (it's the in-progress marker the
-        # chat() open transition uses); every other status is an end-of-
-        # involvement transition for this agent.
-        if status != "working":
-            self._task_round_counts.pop(task_id, None)
         try:
             await self.mesh_client.set_task_status(
                 task_id, status,
@@ -2747,6 +2766,17 @@ class AgentLoop:
                 error=error,
                 blocker_note=blocker_note,
             )
+            # RC-3 (Codex finding #4): drop the advisory per-task convergence
+            # count ONLY AFTER a successful NON-``working`` status write. The
+            # budget is per-task, not forever, so a terminal close frees it.
+            # ``working`` keeps the count alive (it's the in-progress marker
+            # the chat() open transition uses). Popping BEFORE the write
+            # raced: a 5xx / network failure left the task ``working`` on the
+            # mesh but wiped the local budget, so a re-wake would get a fresh
+            # full window. By popping only after success, a failed write keeps
+            # the accumulated budget intact.
+            if status != "working":
+                self._task_round_counts.pop(task_id, None)
         except Exception as e:
             # Discriminate HTTP errors: 4xx is usually "state machine said
             # no" (benign, e.g. concurrent transition already landed);
@@ -2759,6 +2789,12 @@ class AgentLoop:
                     "Auto-close %s → %s rejected by state machine (%s): %s",
                     task_id, status, http_status, e,
                 )
+                # RC-3 (Codex finding #4): a 4xx means the task is ALREADY in
+                # a terminal/incompatible state (a concurrent transition
+                # landed) — this agent's involvement is over, so it's safe to
+                # drop the advisory per-task convergence count.
+                if status != "working":
+                    self._task_round_counts.pop(task_id, None)
             else:
                 # No HTTP response or 5xx → the originating agent will
                 # never see this task close. Surface loudly so operators
@@ -3239,48 +3275,39 @@ class AgentLoop:
             steer_interrupts = 0
             for _round_idx in range(_task_loop_rounds):
                 self._bump_liveness()
-                # RC-1 convergence forcing function (task path only). Mirror
-                # the heartbeat wrap-up nudge + last-iteration tool-withhold
-                # (see execute_heartbeat ~line 1948-1979). ``_task_left`` is
-                # the rounds remaining in the WHOLE per-task budget, including
-                # prior wakes — so a re-woken near-exhausted task is nudged
-                # / withheld immediately, not given a fresh window.
-                _withhold_tools_for_task = False
+                # RC-1 convergence forcing function (task path only).
+                #
+                # Codex finding #1: the nudge is appended to THIS round's
+                # SYSTEM PROMPT — never injected as a ``user`` chat message.
+                # Appending a synthetic user message after a ``tool`` result
+                # (or after another user message) breaks the
+                # user→assistant→tool→assistant role-alternation the LLM call
+                # requires (Constraint #7). The system prompt is rebuildable
+                # per round, so a transient suffix is safe and leaves
+                # ``self._chat_messages`` untouched.
+                #
+                # Codex finding #2: TOOLS REMAIN AVAILABLE on every budgeted
+                # round. The agent converges by CALLING complete_task /
+                # hand_off, so withholding tools would PREVENT convergence and
+                # wrongly force a ``blocked`` close on the deliverable. There
+                # is no last-round tool-withhold on the task path.
+                #
+                # ``_task_left`` is the rounds remaining in the WHOLE per-task
+                # budget, including prior wakes — so a re-woken near-exhausted
+                # task is nudged immediately, not given a fresh window.
+                _round_system = system
                 if _task_id:
                     _task_left = _task_remaining - _round_idx
-                    if _task_left == self._TASK_CONVERGENCE_NUDGE_REMAINING:
-                        self._chat_messages.append({
-                            "role": "user",
-                            "content": (
-                                "[SYSTEM] You are near this task's limit — "
-                                "produce your deliverable now and call "
-                                "complete_task or hand_off; do not start new "
-                                "work."
-                            ),
-                            "_origin": "system:task_convergence",
-                        })
-                    elif _task_left <= 1:
-                        self._chat_messages.append({
-                            "role": "user",
-                            "content": (
-                                "[SYSTEM] LAST round for this task. Call "
-                                "complete_task or hand_off now, or give your "
-                                "final answer. Do NOT start new work."
-                            ),
-                            "_origin": "system:task_convergence",
-                        })
-                        # On the final round, withhold tools so the model is
-                        # forced to produce a terminal text response instead
-                        # of issuing yet another tool call (mirrors the
-                        # heartbeat's last-iteration tool-withhold).
-                        _withhold_tools_for_task = True
+                    if _task_left <= 1:
+                        _round_system = system + self._TASK_CONVERGENCE_FINAL_SUFFIX
+                    elif _task_left <= self._TASK_CONVERGENCE_NUDGE_REMAINING:
+                        _round_system = system + self._TASK_CONVERGENCE_SOFT_SUFFIX
                 _iter_tools = (
-                    None if _withhold_tools_for_task
-                    else self.skills.get_tool_definitions(**self._skill_filter_kw) or None
+                    self.skills.get_tool_definitions(**self._skill_filter_kw) or None
                 )
                 llm_response = await _llm_call_with_retry(
                     self.llm.chat,
-                    system=system,
+                    system=_round_system,
                     messages=self._chat_messages,
                     tools=_iter_tools,
                 )
@@ -3351,14 +3378,14 @@ class AgentLoop:
                         "tool_outputs": tool_outputs,
                         "tokens_used": total_tokens,
                     }
-                    if _withhold_tools_for_task:
-                        # RC-1: the per-task budget forced this round to run
-                        # tool-less. The agent was cut off at its convergence
-                        # cap rather than completing on its own — tag the
-                        # result so chat() drives the task to a TERMINAL
-                        # ``blocked`` state with the static convergence note,
-                        # never dangling ``working``.
-                        result_dict["task_convergence_capped"] = True
+                    # Codex finding #3: reaching this branch means the model
+                    # produced a final TEXT reply (no tool calls) of its own
+                    # accord — a genuine convergence. It must NOT be tagged
+                    # ``task_convergence_capped``; it flows to chat()'s normal
+                    # success path and closes ``done`` (or the lazy-completion
+                    # guard fires for a ghost reply). The convergence cap is
+                    # raised ONLY at the budget-exhausted fall-through below,
+                    # where the model kept emitting tool_calls past its budget.
                     if deliberate_silence:
                         # Mark a deliberate ``__SILENT__`` reply so the
                         # chat() empty-response fallback doesn't
@@ -3524,13 +3551,16 @@ class AgentLoop:
                 "tool_limit_reached": True,
             }
             if _task_id:
-                # RC-1: this fall-through is only reachable on the task path
-                # when the model kept emitting tool_calls even on the
-                # tool-withheld final round (or the env-set per-task budget
-                # exceeded CHAT_MAX_TOOL_ROUNDS). Either way the per-task
-                # convergence cap is the binding limit — tag so chat() closes
-                # the task ``blocked`` with the convergence note rather than a
-                # generic ``max_iterations_reached`` failure.
+                # RC-1 (Codex finding #3): this fall-through is reached on the
+                # task path ONLY when the model exhausted its per-task round
+                # budget while STILL emitting tool_calls — i.e. it never
+                # converged to a terminal complete_task / hand_off / final
+                # text of its own accord (which would have returned via the
+                # no-tool-calls branch above WITHOUT this flag). Tools were
+                # offered on every budgeted round, so this is a genuine
+                # non-convergence: tag so chat() closes the task ``blocked``
+                # with the static convergence note rather than a generic
+                # ``max_iterations_reached`` failure.
                 tool_limit_result["task_convergence_capped"] = True
             if deliberate_silence or marker_substituted:
                 tool_limit_result["silent_reply"] = True

--- a/src/agent/loop.py
+++ b/src/agent/loop.py
@@ -315,6 +315,17 @@ class AgentLoop:
         self.MAX_ITERATIONS = _clamp_env("OPENLEGION_MAX_ITERATIONS", 20, 1, 100)
         self.CHAT_MAX_TOOL_ROUNDS = _clamp_env("OPENLEGION_CHAT_MAX_TOOL_ROUNDS", 30, 1, 200)
         self.CHAT_MAX_TOTAL_ROUNDS = _clamp_env("OPENLEGION_CHAT_MAX_TOTAL_ROUNDS", 200, 1, 1000)
+        # Per-task convergence budget (RC-1). A much tighter bound on tool
+        # rounds that applies ONLY when a durable ``task_id`` is driving the
+        # chat turn (handoff / lane dispatch). It bounds the task path well
+        # below the interactive ceiling (CHAT_MAX_TOOL_ROUNDS × session
+        # auto-continues) AND below the mesh-side 900s lane wall-clock cap.
+        # This is an ADVISORY convergence/UX bound, NOT a security control:
+        # it does NOT replace or weaken any mesh-side control (per-agent
+        # daily budget preflight, lane wall-clock cap). It only ADDS a
+        # tighter soft bound below them. Interactive chat (no task_id) is
+        # completely unaffected.
+        self.TASK_MAX_TOOL_ROUNDS = _clamp_env("OPENLEGION_TASK_MAX_TOOL_ROUNDS", 12, 1, 100)
         self.agent_id = agent_id
         self.role = role
         self.memory = memory
@@ -335,6 +346,13 @@ class AgentLoop:
         self._chat_lock = asyncio.Lock()
         self._chat_total_rounds: int = 0
         self._chat_auto_continues: int = 0
+        # RC-3: per-task convergence round counts, keyed by ``task_id``.
+        # PERSISTS across wakes for the same task so repeated lane followups
+        # can't each get a fresh per-task budget. Advisory convergence state
+        # only — cleared on the task's terminal close. Bounded by the number
+        # of distinct in-flight tasks (small); the entry for a task is wiped
+        # in ``chat()`` when it reaches a terminal status.
+        self._task_round_counts: dict[str, int] = {}
         self._steer_queue: asyncio.Queue[str] = asyncio.Queue()
         self._fleet_roster: list[dict] | None = None  # cached fleet info
         self._fleet_roster_ts: float = 0  # timestamp of last fetch
@@ -2257,6 +2275,22 @@ class AgentLoop:
     CHAT_MAX_TOTAL_ROUNDS = 200
     _CHAT_ROUND_WARNING = 160
     _MAX_SESSION_CONTINUES = 5
+    # Class-default fallback for the per-task convergence budget. The live
+    # value is the per-instance ``self.TASK_MAX_TOOL_ROUNDS`` set in
+    # ``__init__`` (env-clamped). This attr only exists so the constant is
+    # discoverable next to the other CHAT_* bounds and gives a sane default
+    # if an AgentLoop is ever constructed without running ``__init__``.
+    TASK_MAX_TOOL_ROUNDS = 12
+    # Inject the convergence wrap-up nudge when this many task rounds remain.
+    _TASK_CONVERGENCE_NUDGE_REMAINING = 2
+    # Static blocker_note used when the per-task budget is exhausted without
+    # a terminal coordination tool. Short + static-worded on purpose — never
+    # interpolate untrusted task content into this note.
+    _TASK_CONVERGENCE_BLOCKER_NOTE = (
+        "convergence_cap: task hit its per-task round budget without "
+        "completing — produce the deliverable and call complete_task or "
+        "hand_off"
+    )
 
     async def _auto_continue_session(self, system: str) -> None:
         """Force-compact conversation and reset round counter.
@@ -2501,6 +2535,26 @@ class AgentLoop:
                     #   3. Success → ``done`` with response prefix as
                     #      summary.
                     if task_id:
+                        # RC-1: per-task convergence cap reached. The agent
+                        # exhausted its per-task round budget without calling
+                        # a terminal coordination tool. Drive the task to a
+                        # TERMINAL ``blocked`` state with a short, static
+                        # blocker_note (never dangling ``working``, never
+                        # leaking untrusted task content). Checked BEFORE the
+                        # generic failure-reason scan so the convergence note
+                        # wins over the ``max_iterations_reached`` label the
+                        # ``tool_limit_reached`` envelope would otherwise emit.
+                        if result.get("task_convergence_capped"):
+                            logger.warning(
+                                "chat task=%s hit per-task convergence cap "
+                                "(TASK_MAX_TOOL_ROUNDS=%d) — closing blocked",
+                                task_id, self.TASK_MAX_TOOL_ROUNDS,
+                            )
+                            await self._auto_close_task(
+                                task_id, "blocked",
+                                blocker_note=self._TASK_CONVERGENCE_BLOCKER_NOTE,
+                            )
+                            return result
                         failure_reason = self._chat_result_failure_reason(result)
                         if failure_reason is not None:
                             logger.error(
@@ -2664,6 +2718,7 @@ class AgentLoop:
         self, task_id: str, status: str, *,
         result_payload: dict | None = None,
         error: str | None = None,
+        blocker_note: str | None = None,
     ) -> None:
         """Best-effort terminal transition. Never raises — failures log only.
 
@@ -2671,12 +2726,26 @@ class AgentLoop:
         transition was already done or invalid for current state — benign)
         from infrastructure failures (network / 5xx — operator action
         required because the task will dangle in ``pending`` forever).
+
+        ``blocker_note`` is forwarded directly to the mesh status endpoint.
+        The mesh promotes ``error`` → ``blocker_note`` only for ``failed``
+        transitions, so a ``blocked`` close that wants a reason must pass
+        ``blocker_note`` explicitly (e.g. the convergence-cap close).
         """
+        # RC-3: drop the advisory per-task convergence count once the task
+        # leaves the active ``working`` state — the budget is per-task, not
+        # forever, so a future task reusing the same id starts fresh. Only
+        # ``working`` keeps the count alive (it's the in-progress marker the
+        # chat() open transition uses); every other status is an end-of-
+        # involvement transition for this agent.
+        if status != "working":
+            self._task_round_counts.pop(task_id, None)
         try:
             await self.mesh_client.set_task_status(
                 task_id, status,
                 result=result_payload,
                 error=error,
+                blocker_note=blocker_note,
             )
         except Exception as e:
             # Discriminate HTTP errors: 4xx is usually "state machine said
@@ -3141,14 +3210,79 @@ class AgentLoop:
                     return {"response": msg, "tool_outputs": [], "tokens_used": 0}
                 await self._auto_continue_session(system)
 
+            # RC-1 / RC-3: per-task convergence budget. Read the durable
+            # task_id from the contextvar set by chat() — ``None`` for
+            # interactive operator chat / heartbeats, which must be
+            # COMPLETELY unaffected (no cap, no nudge, no tool-withhold).
+            from src.shared.trace import current_task_id
+            _task_id = current_task_id.get()
+            # Rounds this task has already consumed on prior wakes (RC-3
+            # cross-wake persistence). ``_task_max`` is the per-task budget;
+            # ``_task_loop_rounds`` is how many tool rounds THIS turn may run
+            # before the budget is exhausted (bounded by the interactive
+            # CHAT_MAX_TOOL_ROUNDS so the task path can never EXCEED the
+            # interactive bound — it only ever tightens it). When the budget
+            # was already spent on earlier wakes, allow exactly one final
+            # tool-withheld round so the model produces a terminal answer.
+            _task_convergence_capped = False
+            if _task_id:
+                _task_rounds_done = self._task_round_counts.get(_task_id, 0)
+                _task_remaining = max(0, self.TASK_MAX_TOOL_ROUNDS - _task_rounds_done)
+                _task_loop_rounds = min(
+                    self.CHAT_MAX_TOOL_ROUNDS, max(1, _task_remaining),
+                )
+            else:
+                _task_rounds_done = 0
+                _task_remaining = 0
+                _task_loop_rounds = self.CHAT_MAX_TOOL_ROUNDS
+
             steer_interrupts = 0
-            for _ in range(self.CHAT_MAX_TOOL_ROUNDS):
+            for _round_idx in range(_task_loop_rounds):
                 self._bump_liveness()
+                # RC-1 convergence forcing function (task path only). Mirror
+                # the heartbeat wrap-up nudge + last-iteration tool-withhold
+                # (see execute_heartbeat ~line 1948-1979). ``_task_left`` is
+                # the rounds remaining in the WHOLE per-task budget, including
+                # prior wakes — so a re-woken near-exhausted task is nudged
+                # / withheld immediately, not given a fresh window.
+                _withhold_tools_for_task = False
+                if _task_id:
+                    _task_left = _task_remaining - _round_idx
+                    if _task_left == self._TASK_CONVERGENCE_NUDGE_REMAINING:
+                        self._chat_messages.append({
+                            "role": "user",
+                            "content": (
+                                "[SYSTEM] You are near this task's limit — "
+                                "produce your deliverable now and call "
+                                "complete_task or hand_off; do not start new "
+                                "work."
+                            ),
+                            "_origin": "system:task_convergence",
+                        })
+                    elif _task_left <= 1:
+                        self._chat_messages.append({
+                            "role": "user",
+                            "content": (
+                                "[SYSTEM] LAST round for this task. Call "
+                                "complete_task or hand_off now, or give your "
+                                "final answer. Do NOT start new work."
+                            ),
+                            "_origin": "system:task_convergence",
+                        })
+                        # On the final round, withhold tools so the model is
+                        # forced to produce a terminal text response instead
+                        # of issuing yet another tool call (mirrors the
+                        # heartbeat's last-iteration tool-withhold).
+                        _withhold_tools_for_task = True
+                _iter_tools = (
+                    None if _withhold_tools_for_task
+                    else self.skills.get_tool_definitions(**self._skill_filter_kw) or None
+                )
                 llm_response = await _llm_call_with_retry(
                     self.llm.chat,
                     system=system,
                     messages=self._chat_messages,
-                    tools=self.skills.get_tool_definitions(**self._skill_filter_kw) or None,
+                    tools=_iter_tools,
                 )
                 # Bug 1 (codex P2 r2): tick after the LLM call returns —
                 # a single deep-research call can run >5 min, and bumping
@@ -3217,6 +3351,14 @@ class AgentLoop:
                         "tool_outputs": tool_outputs,
                         "tokens_used": total_tokens,
                     }
+                    if _withhold_tools_for_task:
+                        # RC-1: the per-task budget forced this round to run
+                        # tool-less. The agent was cut off at its convergence
+                        # cap rather than completing on its own — tag the
+                        # result so chat() drives the task to a TERMINAL
+                        # ``blocked`` state with the static convergence note,
+                        # never dangling ``working``.
+                        result_dict["task_convergence_capped"] = True
                     if deliberate_silence:
                         # Mark a deliberate ``__SILENT__`` reply so the
                         # chat() empty-response fallback doesn't
@@ -3303,6 +3445,14 @@ class AgentLoop:
                 # threshold even though the loop is healthy.
                 self._bump_liveness()
                 self._chat_total_rounds += 1
+                # RC-3: a tool round just completed for this task. Persist
+                # the running per-task count so it survives across wakes —
+                # repeated lane followups for the same task_id share one
+                # budget instead of each getting a fresh window.
+                if _task_id:
+                    self._task_round_counts[_task_id] = (
+                        self._task_round_counts.get(_task_id, 0) + 1
+                    )
 
                 # Rebuild system prompt if operator playbook state changed
                 if self._is_operator:
@@ -3373,6 +3523,15 @@ class AgentLoop:
                 "tokens_used": total_tokens,
                 "tool_limit_reached": True,
             }
+            if _task_id:
+                # RC-1: this fall-through is only reachable on the task path
+                # when the model kept emitting tool_calls even on the
+                # tool-withheld final round (or the env-set per-task budget
+                # exceeded CHAT_MAX_TOOL_ROUNDS). Either way the per-task
+                # convergence cap is the binding limit — tag so chat() closes
+                # the task ``blocked`` with the convergence note rather than a
+                # generic ``max_iterations_reached`` failure.
+                tool_limit_result["task_convergence_capped"] = True
             if deliberate_silence or marker_substituted:
                 tool_limit_result["silent_reply"] = True
             return tool_limit_result

--- a/tests/test_loop.py
+++ b/tests/test_loop.py
@@ -4176,3 +4176,264 @@ async def test_stream_retry_returns_silent_token_emits_no_marker():
     )
     done = [e for e in events if e.get("type") == "done"]
     assert done and done[-1].get("response") == ""
+
+
+# === RC-1 / RC-3: per-task convergence budget ===
+#
+# Handed-off / woken tasks execute via the interactive chat path
+# (``loop.chat(task_id=...)`` → ``_chat_inner``), which historically had
+# NO per-task budget and NO convergence forcing function — agents could
+# over-iterate up to ~CHAT_MAX_TOOL_ROUNDS × session-continues LLM calls,
+# only stopped by the mesh-side 900s lane cap. These tests pin the tighter
+# ADVISORY per-task bound (mirrors the heartbeat wrap-up nudge +
+# last-iteration tool-withhold) and prove interactive chat is unaffected.
+
+
+def _always_tool_calling_loop(*, task_max=4, tool_name="web_search"):
+    """An AgentLoop whose mocked LLM ALWAYS returns a tool call (never
+    converges on its own). The per-task budget — not the response list —
+    must be the binding limit. ``_auto_close_task`` is replaced with an
+    AsyncMock so terminal-close calls can be asserted without standing up
+    a real mesh client.
+    """
+    loop = _make_loop()
+    loop.TASK_MAX_TOOL_ROUNDS = task_max
+    # Every llm.chat call returns a tool call UNLESS tools were withheld
+    # (tools=None) — in which case the model is forced to produce text.
+    def _llm_side_effect(*args, **kwargs):
+        if kwargs.get("tools") is None:
+            return LLMResponse(content="Final answer, cut off.", tokens_used=5)
+        return LLMResponse(
+            content="",
+            tool_calls=[ToolCallInfo(name=tool_name, arguments={"q": "x"})],
+            tokens_used=10,
+        )
+    loop.llm.chat = AsyncMock(side_effect=_llm_side_effect)
+    loop.skills.get_tool_definitions = MagicMock(
+        return_value=[{"type": "function", "function": {"name": tool_name}}]
+    )
+    loop.skills.execute = AsyncMock(return_value={"results": ["r"]})
+    loop._auto_close_task = AsyncMock(return_value=None)
+    return loop
+
+
+@pytest.mark.asyncio
+async def test_task_convergence_cap_closes_blocked_not_working():
+    """(a) A task whose LLM keeps calling tools is bounded to
+    ~TASK_MAX_TOOL_ROUNDS and is terminally closed as ``blocked`` with the
+    static convergence blocker_note — NOT left ``working`` and NOT allowed
+    to run up to the interactive CHAT_MAX_TOOL_ROUNDS ceiling."""
+    loop = _always_tool_calling_loop(task_max=4)
+
+    result = await loop.chat("do the task", task_id="t-conv")
+
+    assert result.get("task_convergence_capped") is True
+
+    # The llm was called at most TASK_MAX_TOOL_ROUNDS times (one withheld
+    # final round produces text) — NOT CHAT_MAX_TOOL_ROUNDS (30).
+    assert loop.llm.chat.await_count <= loop.TASK_MAX_TOOL_ROUNDS + 1
+    assert loop.llm.chat.await_count < loop.CHAT_MAX_TOOL_ROUNDS
+
+    # Terminal close: blocked with the static convergence note.
+    blocked_calls = [
+        c for c in loop._auto_close_task.await_args_list
+        if len(c.args) >= 2 and c.args[1] == "blocked"
+    ]
+    assert blocked_calls, (
+        "task hitting the convergence cap must close 'blocked', not dangle "
+        f"'working'. calls: {loop._auto_close_task.await_args_list}"
+    )
+    note = blocked_calls[-1].kwargs.get("blocker_note") or ""
+    assert "convergence_cap" in note
+    # No terminal 'working' dangling — the LAST close is a real terminal.
+    assert blocked_calls[-1].args[0] == "t-conv"
+
+
+@pytest.mark.asyncio
+async def test_task_convergence_nudge_and_tool_withhold_on_final_round():
+    """(b) Near the cap a convergence nudge is injected into the message
+    list, and on the final round the LLM is called WITHOUT tools
+    (tools=None) — mirroring the heartbeat last-iteration tool-withhold."""
+    loop = _always_tool_calling_loop(task_max=3)
+
+    await loop.chat("go", task_id="t-nudge")
+
+    # The nudge must have been injected as a system:task_convergence user msg.
+    convergence_msgs = [
+        m for m in loop._chat_messages
+        if isinstance(m, dict) and m.get("_origin") == "system:task_convergence"
+    ]
+    assert convergence_msgs, (
+        "expected at least one system:task_convergence nudge injected near "
+        f"the cap; messages origins: "
+        f"{[m.get('_origin') for m in loop._chat_messages if isinstance(m, dict)]}"
+    )
+    nudge_text = " ".join(m["content"] for m in convergence_msgs)
+    assert "complete_task or hand_off" in nudge_text
+    assert "do not start new work" in nudge_text.lower()
+
+    # Tools were withheld on at least one (the final) round: some llm.chat
+    # call was made with tools=None.
+    tools_none_calls = [
+        c for c in loop.llm.chat.await_args_list
+        if c.kwargs.get("tools") is None
+    ]
+    assert tools_none_calls, (
+        "expected a final tool-withheld LLM call (tools=None) on the task "
+        "path, mirroring the heartbeat last-iteration withhold"
+    )
+
+
+@pytest.mark.asyncio
+async def test_task_convergence_count_persists_across_wakes():
+    """(c) The per-task round count PERSISTS across two chat(task_id=X)
+    calls (a re-wake). The second wake does NOT get a fresh full budget —
+    it must hit the cap with fewer rounds than the first wake did."""
+    loop = _make_loop()
+    loop.TASK_MAX_TOOL_ROUNDS = 6
+    loop._auto_close_task = AsyncMock(return_value=None)
+    loop.skills.get_tool_definitions = MagicMock(
+        return_value=[{"type": "function", "function": {"name": "web_search"}}]
+    )
+    loop.skills.execute = AsyncMock(return_value={"results": ["r"]})
+
+    # Wake 1: the agent runs a couple of tool rounds then converges on its
+    # own (text reply). The per-task count should be left at the number of
+    # tool rounds it consumed (3) and PERSIST in _task_round_counts.
+    wake1 = [
+        _resp("", tool_calls=[ToolCallInfo(name="web_search", arguments={})]),
+        _resp("", tool_calls=[ToolCallInfo(name="web_search", arguments={})]),
+        _resp("", tool_calls=[ToolCallInfo(name="web_search", arguments={})]),
+        _resp("partial progress, not done yet"),  # converges → done close
+    ]
+    loop.llm.chat = AsyncMock(side_effect=wake1)
+    await loop.chat("start the task", task_id="t-persist")
+    # A successful (done) close clears the count — to PROVE persistence we
+    # need a non-terminal wake. Re-seed the count to simulate a lane
+    # followup that kept the task 'working' across the wake boundary.
+    # Simpler + truer to the code: assert the count was tracked, then drive
+    # a SECOND wake that re-opens working (non-clearing) and verify it
+    # resumes from the persisted value rather than 0.
+    loop._task_round_counts["t-persist"] = 4  # 4 of 6 already spent
+
+    # Wake 2: LLM always calls a tool. With only 2 rounds left in the
+    # budget, the cap must fire after ~2 tool rounds (NOT a fresh 6).
+    def _always(*a, **k):
+        if k.get("tools") is None:
+            return LLMResponse(content="cut off", tokens_used=5)
+        return LLMResponse(
+            content="",
+            tool_calls=[ToolCallInfo(name="web_search", arguments={})],
+            tokens_used=10,
+        )
+    loop.llm.chat = AsyncMock(side_effect=_always)
+    result = await loop.chat("continue", task_id="t-persist")
+
+    assert result.get("task_convergence_capped") is True
+    # Only ~2 rounds remained (6 - 4) → at most 2 tool rounds + 1 withheld
+    # final, NOT a fresh full budget of 6.
+    assert loop.llm.chat.await_count <= 3, (
+        "second wake must resume from the persisted per-task count, not get "
+        f"a fresh full budget; llm calls={loop.llm.chat.await_count}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_quick_converging_task_unaffected_and_clears_state():
+    """(d) A task that converges quickly (calls hand_off then produces a
+    structured/outbound result early) is NOT capped, closes normally, and
+    its per-task convergence state is cleared.
+
+    Drives the REAL ``_auto_close_task`` (mesh_client.set_task_status mocked)
+    so the per-task-state clear actually runs and is verified end-to-end —
+    the clear lives inside ``_auto_close_task`` (the single terminal-close
+    choke point), so mocking it out would bypass the very thing under test.
+    """
+    loop = _make_loop()
+    loop.TASK_MAX_TOOL_ROUNDS = 8
+    loop.mesh_client.set_task_status = AsyncMock(return_value={"status": "done"})
+    # Round 1: hand_off (outbound effect) → round 2: final text.
+    responses = [
+        _resp("", tool_calls=[ToolCallInfo(name="hand_off", arguments={"to": "bob"})]),
+        _resp("Handed off to bob; done."),
+    ]
+    loop.llm.chat = AsyncMock(side_effect=responses)
+    loop.skills.get_tool_definitions = MagicMock(
+        return_value=[{"type": "function", "function": {"name": "hand_off"}}]
+    )
+    loop.skills.execute = AsyncMock(
+        return_value={"handed_off": True, "to": "bob"}
+    )
+
+    result = await loop.chat("delegate it", task_id="t-quick")
+
+    # NOT capped.
+    assert result.get("task_convergence_capped") is not True
+    # Tools were NEVER withheld (no tools=None call) — the task converged
+    # well before the budget edge.
+    assert all(
+        c.kwargs.get("tools") is not None
+        for c in loop.llm.chat.await_args_list
+    ), "a fast-converging task must never hit the tool-withhold round"
+    # No 'blocked' convergence close — and a 'done' terminal close happened.
+    statuses = [
+        (c.args[1] if len(c.args) >= 2 else c.kwargs.get("status"))
+        for c in loop.mesh_client.set_task_status.await_args_list
+    ]
+    assert "blocked" not in statuses
+    assert "done" in statuses
+    # Per-task state was cleared by the (real) terminal close.
+    assert "t-quick" not in loop._task_round_counts
+
+
+@pytest.mark.asyncio
+async def test_interactive_chat_no_task_id_completely_unaffected():
+    """(e) Interactive chat with NO task_id is COMPLETELY unaffected: no
+    per-task cap, no convergence nudge, no tool-withhold. It runs the full
+    interactive CHAT_MAX_TOOL_ROUNDS path. We set CHAT_MAX_TOOL_ROUNDS to a
+    small value so the test terminates, then assert (1) it ran more than the
+    tiny TASK_MAX would allow, (2) no convergence nudge was injected, and
+    (3) no convergence-cap marker / blocked close occurred."""
+    loop = _make_loop()
+    loop.TASK_MAX_TOOL_ROUNDS = 2          # tiny — would cap a task hard
+    loop.CHAT_MAX_TOOL_ROUNDS = 5          # bound the interactive loop
+    loop._auto_close_task = AsyncMock(return_value=None)
+    loop.skills.get_tool_definitions = MagicMock(
+        return_value=[{"type": "function", "function": {"name": "web_search"}}]
+    )
+    loop.skills.execute = AsyncMock(return_value={"results": ["r"]})
+
+    def _always(*a, **k):
+        # Interactive path: tools are ALWAYS offered until the final
+        # CHAT_MAX_TOOL_ROUNDS fall-through (which withholds tools by design,
+        # NOT by the task cap). Keep calling tools so the interactive loop
+        # runs to its own bound.
+        if k.get("tools") is None:
+            return LLMResponse(content="done", tokens_used=5)
+        return LLMResponse(
+            content="",
+            tool_calls=[ToolCallInfo(name="web_search", arguments={})],
+            tokens_used=10,
+        )
+    loop.llm.chat = AsyncMock(side_effect=_always)
+
+    # NO task_id — pure interactive chat.
+    result = await loop.chat("just chatting")
+
+    # Ran MORE tool rounds than the tiny TASK_MAX would have permitted —
+    # proving the per-task cap did NOT apply.
+    assert loop.llm.chat.await_count > loop.TASK_MAX_TOOL_ROUNDS + 1
+
+    # No convergence nudge injected.
+    assert not [
+        m for m in loop._chat_messages
+        if isinstance(m, dict) and m.get("_origin") == "system:task_convergence"
+    ], "interactive chat must NOT receive the per-task convergence nudge"
+
+    # No convergence-cap marker, no per-task state, no blocked close.
+    assert result.get("task_convergence_capped") is not True
+    assert loop._task_round_counts == {}
+    assert not [
+        c for c in loop._auto_close_task.await_args_list
+        if len(c.args) >= 2 and c.args[1] == "blocked"
+    ]

--- a/tests/test_loop.py
+++ b/tests/test_loop.py
@@ -4178,29 +4178,42 @@ async def test_stream_retry_returns_silent_token_emits_no_marker():
     assert done and done[-1].get("response") == ""
 
 
-# === RC-1 / RC-3: per-task convergence budget ===
+
+# === RC-1 / RC-3: per-task convergence budget (reworked) ===
 #
 # Handed-off / woken tasks execute via the interactive chat path
 # (``loop.chat(task_id=...)`` → ``_chat_inner``), which historically had
 # NO per-task budget and NO convergence forcing function — agents could
 # over-iterate up to ~CHAT_MAX_TOOL_ROUNDS × session-continues LLM calls,
-# only stopped by the mesh-side 900s lane cap. These tests pin the tighter
-# ADVISORY per-task bound (mirrors the heartbeat wrap-up nudge +
-# last-iteration tool-withhold) and prove interactive chat is unaffected.
+# only stopped by the mesh-side 900s lane cap.
+#
+# REWORKED mechanism (Codex review findings):
+#   #1 the convergence nudge lives in the SYSTEM PROMPT (the ``system``
+#      kwarg of the per-round llm.chat call), NEVER a synthetic ``user``
+#      chat message — so role-alternation is preserved.
+#   #2 TOOLS REMAIN AVAILABLE on every budgeted round (no tool-withhold) —
+#      the agent converges by CALLING complete_task / hand_off.
+#   #3 the cap closes ``blocked`` ONLY if the agent did NOT converge; a
+#      genuine completion (final text, or a coordination-tool close) still
+#      closes ``done`` / handoff.
+#   #4 ``_task_round_counts`` is popped only AFTER a successful non-working
+#      status write.
+#   #5 default TASK_MAX_TOOL_ROUNDS is 20.
 
 
 def _always_tool_calling_loop(*, task_max=4, tool_name="web_search"):
     """An AgentLoop whose mocked LLM ALWAYS returns a tool call (never
     converges on its own). The per-task budget — not the response list —
-    must be the binding limit. ``_auto_close_task`` is replaced with an
-    AsyncMock so terminal-close calls can be asserted without standing up
-    a real mesh client.
+    must be the binding limit. Tools are offered on EVERY round; the model
+    is only forced text-less by the final ``tools=None`` force-compose exit
+    that runs AFTER the budgeted loop is exhausted. ``_auto_close_task`` is
+    replaced with an AsyncMock so terminal-close calls can be asserted
+    without standing up a real mesh client.
     """
     loop = _make_loop()
     loop.TASK_MAX_TOOL_ROUNDS = task_max
-    # Every llm.chat call returns a tool call UNLESS tools were withheld
-    # (tools=None) — in which case the model is forced to produce text.
     def _llm_side_effect(*args, **kwargs):
+        # Only the post-budget force-compose passes tools=None.
         if kwargs.get("tools") is None:
             return LLMResponse(content="Final answer, cut off.", tokens_used=5)
         return LLMResponse(
@@ -4217,20 +4230,26 @@ def _always_tool_calling_loop(*, task_max=4, tool_name="web_search"):
     return loop
 
 
+def test_task_max_tool_rounds_default_is_20():
+    """(#5) The per-task budget default is 20 (raised from 12)."""
+    loop = _make_loop()
+    assert loop.TASK_MAX_TOOL_ROUNDS == 20
+
+
 @pytest.mark.asyncio
-async def test_task_convergence_cap_closes_blocked_not_working():
-    """(a) A task whose LLM keeps calling tools is bounded to
-    ~TASK_MAX_TOOL_ROUNDS and is terminally closed as ``blocked`` with the
-    static convergence blocker_note — NOT left ``working`` and NOT allowed
-    to run up to the interactive CHAT_MAX_TOOL_ROUNDS ceiling."""
+async def test_task_never_converges_closes_blocked_not_working():
+    """(d) A task whose LLM keeps calling tools and NEVER converges is
+    bounded by the per-task budget and terminally closed as ``blocked``
+    with the static convergence blocker_note — NOT left ``working`` and
+    NOT allowed to run up to CHAT_MAX_TOOL_ROUNDS."""
     loop = _always_tool_calling_loop(task_max=4)
 
     result = await loop.chat("do the task", task_id="t-conv")
 
     assert result.get("task_convergence_capped") is True
 
-    # The llm was called at most TASK_MAX_TOOL_ROUNDS times (one withheld
-    # final round produces text) — NOT CHAT_MAX_TOOL_ROUNDS (30).
+    # Bounded by the per-task budget (one extra force-compose call), NOT the
+    # interactive CHAT_MAX_TOOL_ROUNDS (30).
     assert loop.llm.chat.await_count <= loop.TASK_MAX_TOOL_ROUNDS + 1
     assert loop.llm.chat.await_count < loop.CHAT_MAX_TOOL_ROUNDS
 
@@ -4240,55 +4259,164 @@ async def test_task_convergence_cap_closes_blocked_not_working():
         if len(c.args) >= 2 and c.args[1] == "blocked"
     ]
     assert blocked_calls, (
-        "task hitting the convergence cap must close 'blocked', not dangle "
-        f"'working'. calls: {loop._auto_close_task.await_args_list}"
+        "a task hitting the convergence cap without converging must close "
+        f"'blocked', not dangle 'working'. calls: "
+        f"{loop._auto_close_task.await_args_list}"
     )
     note = blocked_calls[-1].kwargs.get("blocker_note") or ""
     assert "convergence_cap" in note
-    # No terminal 'working' dangling — the LAST close is a real terminal.
     assert blocked_calls[-1].args[0] == "t-conv"
 
 
 @pytest.mark.asyncio
-async def test_task_convergence_nudge_and_tool_withhold_on_final_round():
-    """(b) Near the cap a convergence nudge is injected into the message
-    list, and on the final round the LLM is called WITHOUT tools
-    (tools=None) — mirroring the heartbeat last-iteration tool-withhold."""
+async def test_convergence_nudge_in_system_prompt_not_chat_messages():
+    """(a) The convergence nudge is appended to the SYSTEM PROMPT passed to
+    llm.chat (the ``system`` kwarg), NOT injected as a ``user`` chat
+    message. Role-alternation is preserved: no user-after-tool and no
+    user-after-user message is ever synthesized by the convergence path."""
     loop = _always_tool_calling_loop(task_max=3)
 
     await loop.chat("go", task_id="t-nudge")
 
-    # The nudge must have been injected as a system:task_convergence user msg.
-    convergence_msgs = [
+    # No synthetic convergence chat message was ever appended (the old,
+    # buggy mechanism). _chat_messages must contain NO system:task_convergence
+    # marker and NO injected user nudge text.
+    assert not [
         m for m in loop._chat_messages
         if isinstance(m, dict) and m.get("_origin") == "system:task_convergence"
-    ]
-    assert convergence_msgs, (
-        "expected at least one system:task_convergence nudge injected near "
-        f"the cap; messages origins: "
-        f"{[m.get('_origin') for m in loop._chat_messages if isinstance(m, dict)]}"
-    )
-    nudge_text = " ".join(m["content"] for m in convergence_msgs)
-    assert "complete_task or hand_off" in nudge_text
-    assert "do not start new work" in nudge_text.lower()
+    ], "convergence nudge must NOT be a chat message (role-alternation bug)"
 
-    # Tools were withheld on at least one (the final) round: some llm.chat
-    # call was made with tools=None.
-    tools_none_calls = [
-        c for c in loop.llm.chat.await_args_list
-        if c.kwargs.get("tools") is None
+    # The nudge text rode the SYSTEM kwarg of at least one llm.chat call.
+    system_strs = [
+        (c.kwargs.get("system") or "")
+        for c in loop.llm.chat.await_args_list
     ]
-    assert tools_none_calls, (
-        "expected a final tool-withheld LLM call (tools=None) on the task "
-        "path, mirroring the heartbeat last-iteration withhold"
+    nudged = [s for s in system_strs if "complete_task or hand_off" in s]
+    assert nudged, (
+        "expected the convergence directive in the system prompt of a "
+        f"budgeted round; systems seen: {[s[-80:] for s in system_strs]}"
     )
+    # The FINAL-round escalation wording appears near the cap.
+    assert any("final round for this task" in s.lower() for s in nudged)
+
+    # Role-alternation invariant: a ``user`` message never directly follows
+    # a ``tool`` message or another ``user`` message in the transcript the
+    # convergence path produced.
+    roles = [m.get("role") for m in loop._chat_messages if isinstance(m, dict)]
+    for prev, cur in zip(roles, roles[1:]):
+        assert not (cur == "user" and prev in ("tool", "user")), (
+            f"role-alternation violated: {prev} → {cur} in {roles}"
+        )
 
 
 @pytest.mark.asyncio
-async def test_task_convergence_count_persists_across_wakes():
-    """(c) The per-task round count PERSISTS across two chat(task_id=X)
+async def test_tools_remain_available_on_every_budgeted_round():
+    """(b) Tools are offered on EVERY budgeted round, including the final
+    one — the agent must be able to converge by CALLING complete_task /
+    hand_off. The only tools=None call is the post-budget force-compose that
+    runs AFTER the budgeted loop is exhausted (the agent never converged)."""
+    loop = _always_tool_calling_loop(task_max=3)
+
+    await loop.chat("go", task_id="t-tools")
+
+    tools_none = [
+        c for c in loop.llm.chat.await_args_list
+        if c.kwargs.get("tools") is None
+    ]
+    # At most ONE tools=None call — the terminal force-compose — and it is
+    # the LAST llm call, never a budgeted round in the middle.
+    assert len(tools_none) <= 1, (
+        "tools must be offered on every budgeted round; a mid-loop tools=None "
+        "round means the (removed) tool-withhold is back"
+    )
+    if tools_none:
+        assert loop.llm.chat.await_args_list[-1].kwargs.get("tools") is None
+    # The budgeted rounds (all but the final force-compose) all had tools.
+    budgeted = loop.llm.chat.await_args_list[:-1] if tools_none else loop.llm.chat.await_args_list
+    assert all(c.kwargs.get("tools") is not None for c in budgeted)
+
+
+@pytest.mark.asyncio
+async def test_task_converges_via_handoff_on_last_round_closes_done():
+    """(c) A task that CONVERGES by calling hand_off (outbound effect) and
+    then returning a final text closes ``done``/handoff — NOT ``blocked`` —
+    even when it does so right at the budget edge. The cap must NOT pre-empt
+    a genuine completion. Drives the REAL ``_auto_close_task``."""
+    loop = _make_loop()
+    loop.TASK_MAX_TOOL_ROUNDS = 4
+    loop.mesh_client.set_task_status = AsyncMock(return_value={"status": "done"})
+    # Budget 4. Round 1: research tool. Round 2: hand_off (outbound effect).
+    # Round 3 (still within budget, under the FINAL-round system nudge):
+    # terminal text → converges via the no-tool-calls branch, BEFORE the cap
+    # fall-through. The cap must NOT pre-empt this genuine completion.
+    responses = [
+        _resp("", tool_calls=[ToolCallInfo(name="web_search", arguments={})]),
+        _resp("", tool_calls=[ToolCallInfo(name="hand_off", arguments={"to": "bob"})]),
+        _resp("Handed off to bob; done."),
+    ]
+    loop.llm.chat = AsyncMock(side_effect=responses)
+    loop.skills.get_tool_definitions = MagicMock(
+        return_value=[{"type": "function", "function": {"name": "web_search"}}]
+    )
+
+    async def _exec(name, *a, **k):
+        if name == "hand_off":
+            return {"handed_off": True, "to": "bob"}
+        return {"results": ["r"]}
+    loop.skills.execute = AsyncMock(side_effect=_exec)
+
+    result = await loop.chat("research then delegate", task_id="t-converge")
+
+    # NOT capped — converged genuinely.
+    assert result.get("task_convergence_capped") is not True
+    statuses = [
+        (c.args[1] if len(c.args) >= 2 else c.kwargs.get("status"))
+        for c in loop.mesh_client.set_task_status.await_args_list
+    ]
+    assert "blocked" not in statuses, (
+        f"a converging task must NOT be force-closed blocked; statuses={statuses}"
+    )
+    assert "done" in statuses
+    # Per-task state cleared by the terminal done close.
+    assert "t-converge" not in loop._task_round_counts
+
+
+@pytest.mark.asyncio
+async def test_task_converges_via_final_text_on_last_round_closes_done():
+    """(c) A task that converges by returning a STRUCTURED final result on
+    its last budgeted round closes ``done`` — NOT ``blocked``."""
+    loop = _make_loop()
+    loop.TASK_MAX_TOOL_ROUNDS = 2
+    loop.mesh_client.set_task_status = AsyncMock(return_value={"status": "done"})
+    # Round 1: tool. Round 2 (last): structured final result (no tool call) —
+    # converges via the no-tool-calls branch, NOT the cap fall-through.
+    responses = [
+        _resp("", tool_calls=[ToolCallInfo(name="web_search", arguments={})]),
+        _resp('{"result": {"answer": "42"}}'),
+    ]
+    loop.llm.chat = AsyncMock(side_effect=responses)
+    loop.skills.get_tool_definitions = MagicMock(
+        return_value=[{"type": "function", "function": {"name": "web_search"}}]
+    )
+    loop.skills.execute = AsyncMock(return_value={"results": ["r"]})
+
+    result = await loop.chat("answer it", task_id="t-final")
+
+    assert result.get("task_convergence_capped") is not True
+    statuses = [
+        (c.args[1] if len(c.args) >= 2 else c.kwargs.get("status"))
+        for c in loop.mesh_client.set_task_status.await_args_list
+    ]
+    assert "blocked" not in statuses
+    assert "done" in statuses
+    assert "t-final" not in loop._task_round_counts
+
+
+@pytest.mark.asyncio
+async def test_task_round_count_persists_across_wakes_tighten_only():
+    """(g) The per-task round count PERSISTS across two chat(task_id=X)
     calls (a re-wake). The second wake does NOT get a fresh full budget —
-    it must hit the cap with fewer rounds than the first wake did."""
+    it hits the cap with fewer rounds than a fresh window would allow."""
     loop = _make_loop()
     loop.TASK_MAX_TOOL_ROUNDS = 6
     loop._auto_close_task = AsyncMock(return_value=None)
@@ -4297,27 +4425,10 @@ async def test_task_convergence_count_persists_across_wakes():
     )
     loop.skills.execute = AsyncMock(return_value={"results": ["r"]})
 
-    # Wake 1: the agent runs a couple of tool rounds then converges on its
-    # own (text reply). The per-task count should be left at the number of
-    # tool rounds it consumed (3) and PERSIST in _task_round_counts.
-    wake1 = [
-        _resp("", tool_calls=[ToolCallInfo(name="web_search", arguments={})]),
-        _resp("", tool_calls=[ToolCallInfo(name="web_search", arguments={})]),
-        _resp("", tool_calls=[ToolCallInfo(name="web_search", arguments={})]),
-        _resp("partial progress, not done yet"),  # converges → done close
-    ]
-    loop.llm.chat = AsyncMock(side_effect=wake1)
-    await loop.chat("start the task", task_id="t-persist")
-    # A successful (done) close clears the count — to PROVE persistence we
-    # need a non-terminal wake. Re-seed the count to simulate a lane
-    # followup that kept the task 'working' across the wake boundary.
-    # Simpler + truer to the code: assert the count was tracked, then drive
-    # a SECOND wake that re-opens working (non-clearing) and verify it
-    # resumes from the persisted value rather than 0.
-    loop._task_round_counts["t-persist"] = 4  # 4 of 6 already spent
+    # Simulate 4 of 6 rounds already spent on a prior wake that kept the task
+    # 'working' across the wake boundary (a lane followup).
+    loop._task_round_counts["t-persist"] = 4
 
-    # Wake 2: LLM always calls a tool. With only 2 rounds left in the
-    # budget, the cap must fire after ~2 tool rounds (NOT a fresh 6).
     def _always(*a, **k):
         if k.get("tools") is None:
             return LLMResponse(content="cut off", tokens_used=5)
@@ -4330,8 +4441,8 @@ async def test_task_convergence_count_persists_across_wakes():
     result = await loop.chat("continue", task_id="t-persist")
 
     assert result.get("task_convergence_capped") is True
-    # Only ~2 rounds remained (6 - 4) → at most 2 tool rounds + 1 withheld
-    # final, NOT a fresh full budget of 6.
+    # Only ~2 rounds remained (6 - 4) → at most 2 tool rounds + 1 force-compose,
+    # NOT a fresh full budget of 6.
     assert loop.llm.chat.await_count <= 3, (
         "second wake must resume from the persisted per-task count, not get "
         f"a fresh full budget; llm calls={loop.llm.chat.await_count}"
@@ -4339,61 +4450,67 @@ async def test_task_convergence_count_persists_across_wakes():
 
 
 @pytest.mark.asyncio
-async def test_quick_converging_task_unaffected_and_clears_state():
-    """(d) A task that converges quickly (calls hand_off then produces a
-    structured/outbound result early) is NOT capped, closes normally, and
-    its per-task convergence state is cleared.
+async def test_task_count_not_popped_when_status_write_raises_5xx():
+    """(e) When the terminal status write FAILS with a 5xx (mesh unhealthy),
+    ``_task_round_counts`` is NOT popped — the task is still 'working' on the
+    mesh and must keep its accumulated budget so a re-wake doesn't get a
+    fresh window. Drives the REAL ``_auto_close_task``."""
+    import httpx
 
-    Drives the REAL ``_auto_close_task`` (mesh_client.set_task_status mocked)
-    so the per-task-state clear actually runs and is verified end-to-end —
-    the clear lives inside ``_auto_close_task`` (the single terminal-close
-    choke point), so mocking it out would bypass the very thing under test.
-    """
     loop = _make_loop()
-    loop.TASK_MAX_TOOL_ROUNDS = 8
+    loop._task_round_counts["t-5xx"] = 5
+
+    # set_task_status raises a 5xx HTTPStatusError.
+    req = httpx.Request("PUT", "http://mesh/tasks/t-5xx/status")
+    resp = httpx.Response(503, request=req)
+    err = httpx.HTTPStatusError("server error", request=req, response=resp)
+    loop.mesh_client.set_task_status = AsyncMock(side_effect=err)
+
+    await loop._auto_close_task("t-5xx", "blocked", blocker_note="x")
+
+    assert "t-5xx" in loop._task_round_counts, (
+        "a 5xx write failure must KEEP the per-task count (task still working "
+        "on the mesh); popping it would hand a re-wake a fresh budget"
+    )
+    assert loop._task_round_counts["t-5xx"] == 5
+
+
+@pytest.mark.asyncio
+async def test_task_count_cleared_on_successful_terminal_close():
+    """(e) A successful non-working status write clears the per-task count.
+    A 4xx (already-terminal race) also clears it. Drives the REAL
+    ``_auto_close_task``."""
+    import httpx
+
+    loop = _make_loop()
+
+    # Successful terminal close → cleared.
+    loop._task_round_counts["t-ok"] = 3
     loop.mesh_client.set_task_status = AsyncMock(return_value={"status": "done"})
-    # Round 1: hand_off (outbound effect) → round 2: final text.
-    responses = [
-        _resp("", tool_calls=[ToolCallInfo(name="hand_off", arguments={"to": "bob"})]),
-        _resp("Handed off to bob; done."),
-    ]
-    loop.llm.chat = AsyncMock(side_effect=responses)
-    loop.skills.get_tool_definitions = MagicMock(
-        return_value=[{"type": "function", "function": {"name": "hand_off"}}]
-    )
-    loop.skills.execute = AsyncMock(
-        return_value={"handed_off": True, "to": "bob"}
-    )
+    await loop._auto_close_task("t-ok", "done", result_payload={"summary": "s"})
+    assert "t-ok" not in loop._task_round_counts
 
-    result = await loop.chat("delegate it", task_id="t-quick")
+    # A 'working' (non-terminal) open transition must NOT clear it.
+    loop._task_round_counts["t-work"] = 2
+    await loop._auto_close_task("t-work", "working")
+    assert loop._task_round_counts.get("t-work") == 2
 
-    # NOT capped.
-    assert result.get("task_convergence_capped") is not True
-    # Tools were NEVER withheld (no tools=None call) — the task converged
-    # well before the budget edge.
-    assert all(
-        c.kwargs.get("tools") is not None
-        for c in loop.llm.chat.await_args_list
-    ), "a fast-converging task must never hit the tool-withhold round"
-    # No 'blocked' convergence close — and a 'done' terminal close happened.
-    statuses = [
-        (c.args[1] if len(c.args) >= 2 else c.kwargs.get("status"))
-        for c in loop.mesh_client.set_task_status.await_args_list
-    ]
-    assert "blocked" not in statuses
-    assert "done" in statuses
-    # Per-task state was cleared by the (real) terminal close.
-    assert "t-quick" not in loop._task_round_counts
+    # 4xx already-terminal race → cleared (involvement over).
+    loop._task_round_counts["t-4xx"] = 4
+    req = httpx.Request("PUT", "http://mesh/tasks/t-4xx/status")
+    resp = httpx.Response(409, request=req)
+    err = httpx.HTTPStatusError("conflict", request=req, response=resp)
+    loop.mesh_client.set_task_status = AsyncMock(side_effect=err)
+    await loop._auto_close_task("t-4xx", "done")
+    assert "t-4xx" not in loop._task_round_counts
 
 
 @pytest.mark.asyncio
 async def test_interactive_chat_no_task_id_completely_unaffected():
-    """(e) Interactive chat with NO task_id is COMPLETELY unaffected: no
-    per-task cap, no convergence nudge, no tool-withhold. It runs the full
-    interactive CHAT_MAX_TOOL_ROUNDS path. We set CHAT_MAX_TOOL_ROUNDS to a
-    small value so the test terminates, then assert (1) it ran more than the
-    tiny TASK_MAX would allow, (2) no convergence nudge was injected, and
-    (3) no convergence-cap marker / blocked close occurred."""
+    """(f) Interactive chat with NO task_id is COMPLETELY unaffected: no
+    per-task cap, no convergence nudge in the system prompt, no tool-withhold
+    from the task path. It runs the full interactive CHAT_MAX_TOOL_ROUNDS
+    path."""
     loop = _make_loop()
     loop.TASK_MAX_TOOL_ROUNDS = 2          # tiny — would cap a task hard
     loop.CHAT_MAX_TOOL_ROUNDS = 5          # bound the interactive loop
@@ -4404,10 +4521,6 @@ async def test_interactive_chat_no_task_id_completely_unaffected():
     loop.skills.execute = AsyncMock(return_value={"results": ["r"]})
 
     def _always(*a, **k):
-        # Interactive path: tools are ALWAYS offered until the final
-        # CHAT_MAX_TOOL_ROUNDS fall-through (which withholds tools by design,
-        # NOT by the task cap). Keep calling tools so the interactive loop
-        # runs to its own bound.
         if k.get("tools") is None:
             return LLMResponse(content="done", tokens_used=5)
         return LLMResponse(
@@ -4420,15 +4533,15 @@ async def test_interactive_chat_no_task_id_completely_unaffected():
     # NO task_id — pure interactive chat.
     result = await loop.chat("just chatting")
 
-    # Ran MORE tool rounds than the tiny TASK_MAX would have permitted —
-    # proving the per-task cap did NOT apply.
+    # Ran MORE tool rounds than the tiny TASK_MAX would have permitted.
     assert loop.llm.chat.await_count > loop.TASK_MAX_TOOL_ROUNDS + 1
 
-    # No convergence nudge injected.
+    # No convergence directive in ANY system prompt.
     assert not [
-        m for m in loop._chat_messages
-        if isinstance(m, dict) and m.get("_origin") == "system:task_convergence"
-    ], "interactive chat must NOT receive the per-task convergence nudge"
+        (c.kwargs.get("system") or "")
+        for c in loop.llm.chat.await_args_list
+        if "complete_task or hand_off" in (c.kwargs.get("system") or "")
+    ], "interactive chat must NOT get the per-task convergence directive"
 
     # No convergence-cap marker, no per-task state, no blocked close.
     assert result.get("task_convergence_capped") is not True

--- a/tests/test_loop.py
+++ b/tests/test_loop.py
@@ -4187,28 +4187,41 @@ async def test_stream_retry_returns_silent_token_emits_no_marker():
 # over-iterate up to ~CHAT_MAX_TOOL_ROUNDS × session-continues LLM calls,
 # only stopped by the mesh-side 900s lane cap.
 #
-# REWORKED mechanism (Codex review findings):
+# PRE-ROUND-BOUNDARY mechanism (Codex r3 — 3rd iteration):
+#   The loop runs over the NORMAL interactive bound (CHAT_MAX_TOOL_ROUNDS).
+#   The per-task cap is a PRE-ROUND boundary: at the TOP of each iteration,
+#   BEFORE the LLM call, if the task's persisted round count has reached
+#   TASK_MAX_TOOL_ROUNDS the loop breaks and returns immediately. This is the
+#   ONLY place ``task_convergence_capped`` is set for tasks.
 #   #1 the convergence nudge lives in the SYSTEM PROMPT (the ``system``
 #      kwarg of the per-round llm.chat call), NEVER a synthetic ``user``
 #      chat message — so role-alternation is preserved.
-#   #2 TOOLS REMAIN AVAILABLE on every budgeted round (no tool-withhold) —
-#      the agent converges by CALLING complete_task / hand_off.
+#   #2 TOOLS REMAIN AVAILABLE on every round (no tool-withhold) — the agent
+#      converges by CALLING complete_task / hand_off.
 #   #3 the cap closes ``blocked`` ONLY if the agent did NOT converge; a
-#      genuine completion (final text, or a coordination-tool close) still
-#      closes ``done`` / handoff.
+#      genuine completion (final text, or a coordination-tool close) returns
+#      via the no-tool-calls path INSIDE the loop, before the next round's
+#      top-of-loop cap check — so the cap can NEVER override it.
 #   #4 ``_task_round_counts`` is popped only AFTER a successful non-working
-#      status write.
+#      status write, and is size-bounded (``_TASK_ROUND_COUNTS_MAX``).
 #   #5 default TASK_MAX_TOOL_ROUNDS is 20.
+#
+# Codex r3 BLOCKERS this suite pins:
+#   B1 a terminal complete_task / hand_off / final on the LAST budgeted round
+#      closes done/handoff, NOT blocked (the cap never pre-empts it).
+#   B2 an exhausted re-wake (count already >= cap) breaks at the first round
+#      top with NO additional LLM call and NO tool round.
 
 
 def _always_tool_calling_loop(*, task_max=4, tool_name="web_search"):
     """An AgentLoop whose mocked LLM ALWAYS returns a tool call (never
-    converges on its own). The per-task budget — not the response list —
-    must be the binding limit. Tools are offered on EVERY round; the model
-    is only forced text-less by the final ``tools=None`` force-compose exit
-    that runs AFTER the budgeted loop is exhausted. ``_auto_close_task`` is
-    replaced with an AsyncMock so terminal-close calls can be asserted
-    without standing up a real mesh client.
+    converges on its own). The per-task PRE-ROUND boundary — not the response
+    list — must be the binding limit. Tools are offered on EVERY round. Once
+    the persisted round count reaches the cap, the top-of-round boundary
+    breaks and ``_chat_inner`` returns immediately WITHOUT a force-compose
+    LLM call. ``_auto_close_task`` is replaced with an AsyncMock so
+    terminal-close calls can be asserted without standing up a real mesh
+    client.
     """
     loop = _make_loop()
     loop.TASK_MAX_TOOL_ROUNDS = task_max
@@ -4248,9 +4261,11 @@ async def test_task_never_converges_closes_blocked_not_working():
 
     assert result.get("task_convergence_capped") is True
 
-    # Bounded by the per-task budget (one extra force-compose call), NOT the
+    # Bounded EXACTLY by the per-task budget: the cap breaks at the top of the
+    # round whose count has reached TASK_MAX, so there are exactly task_max
+    # tool-round LLM calls and NO force-compose call. Far below the
     # interactive CHAT_MAX_TOOL_ROUNDS (30).
-    assert loop.llm.chat.await_count <= loop.TASK_MAX_TOOL_ROUNDS + 1
+    assert loop.llm.chat.await_count == loop.TASK_MAX_TOOL_ROUNDS
     assert loop.llm.chat.await_count < loop.CHAT_MAX_TOOL_ROUNDS
 
     # Terminal close: blocked with the static convergence note.
@@ -4311,10 +4326,11 @@ async def test_convergence_nudge_in_system_prompt_not_chat_messages():
 
 @pytest.mark.asyncio
 async def test_tools_remain_available_on_every_budgeted_round():
-    """(b) Tools are offered on EVERY budgeted round, including the final
-    one — the agent must be able to converge by CALLING complete_task /
-    hand_off. The only tools=None call is the post-budget force-compose that
-    runs AFTER the budgeted loop is exhausted (the agent never converged)."""
+    """(b) Tools are offered on EVERY round — the agent must be able to
+    converge by CALLING complete_task / hand_off. With the pre-round-boundary
+    redesign the cap path returns at the top of the round WITHOUT any
+    tools=None force-compose call, so NO llm.chat call ever withholds tools on
+    the task non-convergence path."""
     loop = _always_tool_calling_loop(task_max=3)
 
     await loop.chat("go", task_id="t-tools")
@@ -4323,34 +4339,36 @@ async def test_tools_remain_available_on_every_budgeted_round():
         c for c in loop.llm.chat.await_args_list
         if c.kwargs.get("tools") is None
     ]
-    # At most ONE tools=None call — the terminal force-compose — and it is
-    # the LAST llm call, never a budgeted round in the middle.
-    assert len(tools_none) <= 1, (
-        "tools must be offered on every budgeted round; a mid-loop tools=None "
-        "round means the (removed) tool-withhold is back"
+    assert tools_none == [], (
+        "tools must be offered on every round; the pre-round-boundary cap "
+        "returns without a tools=None force-compose, so no call may withhold "
+        "tools on the task path"
     )
-    if tools_none:
-        assert loop.llm.chat.await_args_list[-1].kwargs.get("tools") is None
-    # The budgeted rounds (all but the final force-compose) all had tools.
-    budgeted = loop.llm.chat.await_args_list[:-1] if tools_none else loop.llm.chat.await_args_list
-    assert all(c.kwargs.get("tools") is not None for c in budgeted)
+    assert all(
+        c.kwargs.get("tools") is not None for c in loop.llm.chat.await_args_list
+    )
+    # Exactly task_max tool-round calls — the cap broke at the next round top.
+    assert loop.llm.chat.await_count == 3
 
 
 @pytest.mark.asyncio
-async def test_task_converges_via_handoff_on_last_round_closes_done():
-    """(c) A task that CONVERGES by calling hand_off (outbound effect) and
-    then returning a final text closes ``done``/handoff — NOT ``blocked`` —
-    even when it does so right at the budget edge. The cap must NOT pre-empt
-    a genuine completion. Drives the REAL ``_auto_close_task``."""
+async def test_terminal_handoff_on_last_budgeted_round_closes_done_not_blocked():
+    """(B1 — Codex blocker #1) A task that calls hand_off (outbound effect)
+    and then returns its terminal text on the LAST budgeted round closes
+    ``done``/handoff — NOT ``blocked``. Drives the count to cap-1 right at the
+    terminal so the OLD shrunk-range bug (fall-through forcing
+    ``task_convergence_capped=True``) would have force-blocked it. With the
+    pre-round boundary the terminal no-tool-calls reply returns from INSIDE the
+    loop, before the next round's top-of-loop cap check can run. Drives the
+    REAL ``_auto_close_task``."""
     loop = _make_loop()
-    loop.TASK_MAX_TOOL_ROUNDS = 4
+    loop.TASK_MAX_TOOL_ROUNDS = 2
     loop.mesh_client.set_task_status = AsyncMock(return_value={"status": "done"})
-    # Budget 4. Round 1: research tool. Round 2: hand_off (outbound effect).
-    # Round 3 (still within budget, under the FINAL-round system nudge):
-    # terminal text → converges via the no-tool-calls branch, BEFORE the cap
-    # fall-through. The cap must NOT pre-empt this genuine completion.
+    # Budget 2. Round idx0 (count 0→1): hand_off (outbound effect). Round idx1
+    # (entry count 1 == cap-1, the LAST budgeted round): terminal text →
+    # converges via the no-tool-calls branch BEFORE the cap boundary, which
+    # would next fire at entry count 2.
     responses = [
-        _resp("", tool_calls=[ToolCallInfo(name="web_search", arguments={})]),
         _resp("", tool_calls=[ToolCallInfo(name="hand_off", arguments={"to": "bob"})]),
         _resp("Handed off to bob; done."),
     ]
@@ -4365,9 +4383,9 @@ async def test_task_converges_via_handoff_on_last_round_closes_done():
         return {"results": ["r"]}
     loop.skills.execute = AsyncMock(side_effect=_exec)
 
-    result = await loop.chat("research then delegate", task_id="t-converge")
+    result = await loop.chat("delegate", task_id="t-converge")
 
-    # NOT capped — converged genuinely.
+    # NOT capped — converged genuinely on the last budgeted round.
     assert result.get("task_convergence_capped") is not True
     statuses = [
         (c.args[1] if len(c.args) >= 2 else c.kwargs.get("status"))
@@ -4379,6 +4397,122 @@ async def test_task_converges_via_handoff_on_last_round_closes_done():
     assert "done" in statuses
     # Per-task state cleared by the terminal done close.
     assert "t-converge" not in loop._task_round_counts
+
+
+@pytest.mark.asyncio
+async def test_terminal_complete_task_on_last_budgeted_round_closes_done():
+    """(B1 — Codex blocker #1, complete_task variant) Same protection, with
+    ``complete_task`` as the terminal outbound tool on the last budgeted
+    round. Closes ``done``, never ``blocked``."""
+    loop = _make_loop()
+    loop.TASK_MAX_TOOL_ROUNDS = 2
+    loop.mesh_client.set_task_status = AsyncMock(return_value={"status": "done"})
+    # Round idx0 (count 0→1): complete_task. Round idx1 (entry count 1 ==
+    # cap-1, LAST budgeted round): terminal text → no-tool-calls return.
+    responses = [
+        _resp("", tool_calls=[ToolCallInfo(name="complete_task", arguments={})]),
+        _resp("All done."),
+    ]
+    loop.llm.chat = AsyncMock(side_effect=responses)
+    loop.skills.get_tool_definitions = MagicMock(
+        return_value=[{"type": "function", "function": {"name": "complete_task"}}]
+    )
+
+    async def _exec(name, *a, **k):
+        if name == "complete_task":
+            return {"completed": True}
+        return {"ok": True}
+    loop.skills.execute = AsyncMock(side_effect=_exec)
+
+    result = await loop.chat("finish it", task_id="t-complete")
+
+    assert result.get("task_convergence_capped") is not True
+    statuses = [
+        (c.args[1] if len(c.args) >= 2 else c.kwargs.get("status"))
+        for c in loop.mesh_client.set_task_status.await_args_list
+    ]
+    assert "blocked" not in statuses
+    assert "done" in statuses
+    assert "t-complete" not in loop._task_round_counts
+
+
+@pytest.mark.asyncio
+async def test_exhausted_rewake_blocks_immediately_no_extra_tool_round():
+    """(B2 — Codex blocker #2) A re-wake of a task whose persisted round count
+    is ALREADY at the cap must break at the FIRST round top and close
+    ``blocked`` WITHOUT executing any further LLM call or tool round. The old
+    mechanism (``_task_loop_rounds = max(1, 0) = 1``) granted one more
+    tool-enabled round on every re-wake — unbounded across re-wakes. The
+    pre-round boundary forbids it. Drives the REAL ``_auto_close_task``."""
+    loop = _make_loop()
+    loop.TASK_MAX_TOOL_ROUNDS = 3
+    loop.mesh_client.set_task_status = AsyncMock(return_value={"status": "blocked"})
+    # Pre-seed the persisted count AT the cap (a prior wake spent the budget;
+    # a 5xx kept the task 'working' so the count survived).
+    loop._task_round_counts["t-exhausted"] = 3
+
+    loop.llm.chat = AsyncMock(
+        side_effect=AssertionError("LLM must NOT be called on an exhausted re-wake")
+    )
+    loop.skills.get_tool_definitions = MagicMock(
+        return_value=[{"type": "function", "function": {"name": "web_search"}}]
+    )
+    loop.skills.execute = AsyncMock(
+        side_effect=AssertionError("no tool round may run on an exhausted re-wake")
+    )
+
+    result = await loop.chat("continue", task_id="t-exhausted")
+
+    # Capped immediately, with ZERO LLM calls and ZERO tool executions.
+    assert result.get("task_convergence_capped") is True
+    assert loop.llm.chat.await_count == 0, (
+        "an exhausted re-wake must break at the first round top BEFORE the LLM "
+        f"call; llm calls={loop.llm.chat.await_count}"
+    )
+    assert loop.skills.execute.await_count == 0
+    # Terminal blocked close with the static convergence note.
+    statuses = [
+        (c.args[1] if len(c.args) >= 2 else c.kwargs.get("status"))
+        for c in loop.mesh_client.set_task_status.await_args_list
+    ]
+    assert statuses and statuses[-1] == "blocked"
+
+
+@pytest.mark.asyncio
+async def test_task_round_counts_size_bounded_under_many_tasks():
+    """(#3 — Codex SHOULD) ``_task_round_counts`` stays bounded even when many
+    distinct tasks accumulate counts without their terminal close ever popping
+    them (the sustained mesh-write-failure regime). Adding a new task beyond
+    ``_TASK_ROUND_COUNTS_MAX`` evicts an existing entry instead of growing
+    unbounded. Exercised at the increment site directly via repeated
+    single-round task turns whose close is stubbed to a no-op (never pops)."""
+    loop = _make_loop()
+    loop.TASK_MAX_TOOL_ROUNDS = 5
+    loop._TASK_ROUND_COUNTS_MAX = 8     # small bound for the test
+    # Stub the terminal close to a no-op so entries are NEVER popped — this is
+    # the degenerate sustained-write-failure regime the bound guards.
+    loop._auto_close_task = AsyncMock(return_value=None)
+    loop.skills.get_tool_definitions = MagicMock(
+        return_value=[{"type": "function", "function": {"name": "web_search"}}]
+    )
+    loop.skills.execute = AsyncMock(return_value={"results": ["r"]})
+
+    # Each task: one tool round then a final text (converges) — one increment
+    # per distinct task_id. The final close is a no-op stub, so nothing pops.
+    for i in range(40):
+        loop.llm.chat = AsyncMock(side_effect=[
+            _resp("", tool_calls=[ToolCallInfo(name="web_search", arguments={})]),
+            _resp("done"),
+        ])
+        loop._chat_messages = []
+        await loop.chat("go", task_id=f"task-{i}")
+        assert len(loop._task_round_counts) <= loop._TASK_ROUND_COUNTS_MAX, (
+            f"_task_round_counts grew past the bound at iteration {i}: "
+            f"size={len(loop._task_round_counts)}"
+        )
+
+    # Stays at/under the bound after 40 distinct tasks despite no pops.
+    assert len(loop._task_round_counts) <= loop._TASK_ROUND_COUNTS_MAX
 
 
 @pytest.mark.asyncio
@@ -4441,9 +4575,10 @@ async def test_task_round_count_persists_across_wakes_tighten_only():
     result = await loop.chat("continue", task_id="t-persist")
 
     assert result.get("task_convergence_capped") is True
-    # Only ~2 rounds remained (6 - 4) → at most 2 tool rounds + 1 force-compose,
+    # Only 2 rounds remained (6 - 4) → exactly 2 tool rounds (counts 5, 6),
+    # then the next round top hits the cap and breaks (no force-compose).
     # NOT a fresh full budget of 6.
-    assert loop.llm.chat.await_count <= 3, (
+    assert loop.llm.chat.await_count == 2, (
         "second wake must resume from the persisted per-task count, not get "
         f"a fresh full budget; llm calls={loop.llm.chat.await_count}"
     )

--- a/tests/test_loop.py
+++ b/tests/test_loop.py
@@ -4437,6 +4437,206 @@ async def test_terminal_complete_task_on_last_budgeted_round_closes_done():
 
 
 @pytest.mark.asyncio
+async def test_complete_task_on_exact_cap_round_closes_done_not_blocked():
+    """(Item 1 — Codex r4 BLOCKER) The genuine completion lands on the EXACT
+    round whose increment reaches the cap, AND the model keeps emitting
+    tool_calls (it does NOT volunteer a clean final-text round). Without the
+    loop-side early return, the count would increment to the cap, the loop
+    would continue, and the NEXT top-of-round cap check would break →
+    ``task_convergence_capped`` → chat() closes ``blocked`` — overriding a real
+    completion. The fix returns immediately after a successful terminal
+    coordination tool so chat() runs its done/handoff close."""
+    loop = _make_loop()
+    loop.TASK_MAX_TOOL_ROUNDS = 1  # cap reached by the FIRST round's increment
+    loop.mesh_client.set_task_status = AsyncMock(return_value={"status": "done"})
+    # The model would call complete_task on round idx0 (count 0→1 == cap) and,
+    # if allowed to continue, keep tool-calling forever. The early return must
+    # fire after round idx0 so this second response is NEVER consumed.
+    responses = [
+        _resp("", tool_calls=[ToolCallInfo(name="complete_task", arguments={})]),
+        _resp("", tool_calls=[ToolCallInfo(name="web_search", arguments={"q": "x"})]),
+        _resp("", tool_calls=[ToolCallInfo(name="web_search", arguments={"q": "y"})]),
+    ]
+    loop.llm.chat = AsyncMock(side_effect=responses)
+    loop.skills.get_tool_definitions = MagicMock(
+        return_value=[{"type": "function", "function": {"name": "complete_task"}}]
+    )
+
+    async def _exec(name, *a, **k):
+        if name == "complete_task":
+            return {"completed": True}
+        return {"results": ["r"]}
+    loop.skills.execute = AsyncMock(side_effect=_exec)
+
+    result = await loop.chat("finish it", task_id="t-exact")
+
+    # The completion wins: NOT capped, closes done, never blocked.
+    assert result.get("task_convergence_capped") is not True
+    statuses = [
+        (c.args[1] if len(c.args) >= 2 else c.kwargs.get("status"))
+        for c in loop.mesh_client.set_task_status.await_args_list
+    ]
+    assert "blocked" not in statuses, (
+        f"a terminal complete_task on the cap round must NOT be force-blocked; "
+        f"statuses={statuses}"
+    )
+    assert "done" in statuses
+    assert "t-exact" not in loop._task_round_counts
+    # Early return fired after exactly ONE LLM round — the extra tool-calling
+    # responses were never consumed.
+    assert loop.llm.chat.await_count == 1
+
+
+@pytest.mark.asyncio
+async def test_handoff_on_exact_cap_round_closes_done_not_blocked():
+    """(Item 1 — Codex r4 BLOCKER, hand_off variant) A successful hand_off on
+    the exact cap-reaching round closes done/handoff, not blocked."""
+    loop = _make_loop()
+    loop.TASK_MAX_TOOL_ROUNDS = 1
+    loop.mesh_client.set_task_status = AsyncMock(return_value={"status": "done"})
+    responses = [
+        _resp("", tool_calls=[ToolCallInfo(name="hand_off", arguments={"to": "bob"})]),
+        _resp("", tool_calls=[ToolCallInfo(name="web_search", arguments={"q": "x"})]),
+    ]
+    loop.llm.chat = AsyncMock(side_effect=responses)
+    loop.skills.get_tool_definitions = MagicMock(
+        return_value=[{"type": "function", "function": {"name": "hand_off"}}]
+    )
+
+    async def _exec(name, *a, **k):
+        if name == "hand_off":
+            return {"handed_off": True, "to": "bob"}
+        return {"results": ["r"]}
+    loop.skills.execute = AsyncMock(side_effect=_exec)
+
+    result = await loop.chat("delegate", task_id="t-exact-ho")
+
+    assert result.get("task_convergence_capped") is not True
+    statuses = [
+        (c.args[1] if len(c.args) >= 2 else c.kwargs.get("status"))
+        for c in loop.mesh_client.set_task_status.await_args_list
+    ]
+    assert "blocked" not in statuses
+    assert "done" in statuses
+    assert "t-exact-ho" not in loop._task_round_counts
+    assert loop.llm.chat.await_count == 1
+
+
+@pytest.mark.asyncio
+async def test_notify_user_on_cap_round_still_blocks_not_completion():
+    """(Item 1 — over-broadening guard) A NON-terminal outbound (``notify_user``)
+    on the cap round is NOT a completion. It must NOT short-circuit the
+    convergence cap: the task still hits the cap and closes ``blocked``.
+    Distinguishes ``_last_round_terminal_completion`` from the broader
+    ``_has_outbound_effect``."""
+    loop = _make_loop()
+    loop.TASK_MAX_TOOL_ROUNDS = 1
+    loop.mesh_client.set_task_status = AsyncMock(return_value={"status": "blocked"})
+    # Round idx0 (count 0→1 == cap): notify_user (outbound, NOT terminal).
+    # Then the model keeps tool-calling — the cap must fire on round idx1's top.
+    responses = [
+        _resp("", tool_calls=[ToolCallInfo(name="notify_user", arguments={"message": "fyi"})]),
+        _resp("", tool_calls=[ToolCallInfo(name="web_search", arguments={"q": "x"})]),
+    ]
+    loop.llm.chat = AsyncMock(side_effect=responses)
+    loop.skills.get_tool_definitions = MagicMock(
+        return_value=[{"type": "function", "function": {"name": "notify_user"}}]
+    )
+
+    async def _exec(name, *a, **k):
+        if name == "notify_user":
+            return {"notified": True}
+        return {"results": ["r"]}
+    loop.skills.execute = AsyncMock(side_effect=_exec)
+
+    result = await loop.chat("work", task_id="t-notify")
+
+    # notify_user is NOT a completion → cap fires → blocked.
+    assert result.get("task_convergence_capped") is True
+    statuses = [
+        (c.args[1] if len(c.args) >= 2 else c.kwargs.get("status"))
+        for c in loop.mesh_client.set_task_status.await_args_list
+    ]
+    assert "blocked" in statuses, (
+        f"a non-terminal outbound must NOT count as completion; the task must "
+        f"still close blocked at the cap; statuses={statuses}"
+    )
+    assert "done" not in statuses
+
+
+def test_last_round_terminal_completion_precision():
+    """Unit: the completion detector counts ONLY successful terminal
+    coordination tools, never a non-terminal outbound or a FAILED terminal."""
+    f = AgentLoop._last_round_terminal_completion
+    # Successful terminals.
+    assert f([{"tool": "complete_task", "output": {"completed": True}}]) is True
+    assert f([{"tool": "hand_off", "output": {"handed_off": True}}]) is True
+    # Non-terminal outbound — must NOT count.
+    assert f([{"tool": "notify_user", "output": {"notified": True}}]) is False
+    assert f([{"tool": "write_blackboard", "output": {"ok": True}}]) is False
+    # FAILED terminals — must NOT count (handled as failures elsewhere).
+    assert f([{"tool": "hand_off", "output": {"handed_off": False}}]) is False
+    assert f([{"tool": "complete_task", "output": {"completed": False}}]) is False
+    assert f([{"tool": "complete_task", "output": {"error": "x"}}]) is False
+    # Empty / malformed.
+    assert f([]) is False
+    assert f(None) is False
+    assert f([{"tool": "complete_task", "output": "not-a-dict"}]) is False
+
+
+@pytest.mark.asyncio
+async def test_task_max_clamped_to_chat_max():
+    """(Item 3 — Codex r4) The effective per-task budget is clamped to
+    CHAT_MAX_TOOL_ROUNDS. A misconfigured TASK_MAX > CHAT_MAX must not let a
+    task outrun the interactive ceiling and fall through to the
+    ``tool_limit_reached`` exit before its per-task cap fires."""
+    import os
+    from unittest.mock import patch
+    with patch.dict(os.environ, {
+        "OPENLEGION_CHAT_MAX_TOOL_ROUNDS": "5",
+        "OPENLEGION_TASK_MAX_TOOL_ROUNDS": "40",
+    }):
+        loop = _make_loop()
+    assert loop.CHAT_MAX_TOOL_ROUNDS == 5
+    assert loop.TASK_MAX_TOOL_ROUNDS == 5, (
+        "TASK_MAX must be clamped down to CHAT_MAX when misconfigured higher"
+    )
+
+
+@pytest.mark.asyncio
+async def test_round_counts_bound_never_resets_live_task_budget():
+    """(Item 4 — Codex r4) When ``_task_round_counts`` is at its size bound, a
+    brand-new task is simply NOT tracked — an EXISTING (live) task's count is
+    never evicted, so a still-working task can never regain a fresh per-task
+    budget. Asserts no live entry is dropped when a new task arrives at bound."""
+    loop = _make_loop()
+    loop._TASK_ROUND_COUNTS_MAX = 2
+    # Pre-seed two live tracked tasks at the bound, with meaningful counts.
+    loop._task_round_counts = {"live-a": 7, "live-b": 3}
+
+    async def _exec(name, *a, **k):
+        return {"results": ["r"]}
+    loop.skills.execute = AsyncMock(side_effect=_exec)
+    loop.skills.get_tool_definitions = MagicMock(
+        return_value=[{"type": "function", "function": {"name": "web_search"}}]
+    )
+    # New task does one tool round then converges with final text.
+    loop.llm.chat = AsyncMock(side_effect=[
+        _resp("", tool_calls=[ToolCallInfo(name="web_search", arguments={"q": "x"})]),
+        _resp("done"),
+    ])
+    loop.mesh_client.set_task_status = AsyncMock(return_value={"status": "done"})
+
+    await loop.chat("go", task_id="new-task")
+
+    # Neither live task was evicted, and neither had its count reset.
+    assert loop._task_round_counts.get("live-a") == 7
+    assert loop._task_round_counts.get("live-b") == 3
+    # The new task was NOT tracked (table was at bound on its first round).
+    assert "new-task" not in loop._task_round_counts
+
+
+@pytest.mark.asyncio
 async def test_exhausted_rewake_blocks_immediately_no_extra_tool_round():
     """(B2 — Codex blocker #2) A re-wake of a task whose persisted round count
     is ALREADY at the cap must break at the FIRST round top and close


### PR DESCRIPTION
Root cause of agents over-iterating/never completing: handed-off tasks run via the interactive chat path (~1200-call ceiling) with no per-task budget or convergence forcing function. Adds a task_id-gated per-task tool-round budget (default 12, env OPENLEGION_TASK_MAX_TOOL_ROUNDS) that persists across wakes (can only tighten, never extend the existing CHAT_MAX), mirrors execute_heartbeat's wrap-up nudge + final-round tool-withhold, and terminally closes to `blocked` with a static note instead of dangling `working`. Security: agent-side advisory bound only — mesh daily-budget preflight + 900s lane cap UNCHANGED; gated on task_id so interactive operator chat is unaffected; static blocker_note carries no untrusted content. Tests: 5 new; full non-e2e suite 6832 passed; ruff clean.