### PR TITLE
fix(dispatch): surface redacted blocker_note on transport error instead of opaque swallow

### DIFF
--- a/src/cli/runtime.py
+++ b/src/cli/runtime.py
@@ -624,10 +624,14 @@ class RuntimeContext:
             )
             pre = None
         if pre is not None and pre.get("status") in (
-            "done", "failed", "cancelled"
+            "done", "failed", "cancelled", "blocked"
         ):
             # Already terminal (assignee or lane watchdog beat us) — do not
-            # clobber the real status/note.
+            # clobber the real status/note. ``blocked`` is included because
+            # ``blocked → failed`` is a *valid* transition: a dispatch
+            # transport error must not overwrite an assignee-authored
+            # ``blocked`` status (and its meaningful blocker_note) with a
+            # generic dispatch note.
             logger.info(
                 "Dispatch error: task %s already terminal (status=%s) — "
                 "skipping failed-close", task_id, pre.get("status"),

--- a/src/cli/runtime.py
+++ b/src/cli/runtime.py
@@ -55,6 +55,36 @@ def _default_embedding_model(llm_model: str) -> str:
     return "none"
 
 
+# Cap on the operator-visible ``blocker_note`` written when a mesh→agent
+# ``/chat`` dispatch raises. Mirrors the lane watchdog's ``[:500]`` cap and
+# the mesh ``/mesh/tasks/{id}/status`` endpoint's 500-char ``error`` promotion.
+_DISPATCH_ERROR_NOTE_MAX = 500
+
+
+def _build_dispatch_error_note(exc: BaseException) -> str:
+    """Render a transport/agent dispatch error into a SAFE ``blocker_note``.
+
+    The exception string is UNTRUSTED — the ``/chat`` body it came from may
+    echo agent-authored content, secrets, or injection. It MUST NOT reach the
+    operator-visible ``blocker_note`` raw. We:
+
+    1. Run it through the central free-form redactor
+       (:func:`redact_text_with_urls`), which strips both token-shaped secrets
+       AND credential-keyed URL query-param values, and
+    2. Truncate to :data:`_DISPATCH_ERROR_NOTE_MAX` chars.
+
+    Returns a ``"dispatch_error: <redacted reason>"`` string. XSS in the note
+    is handled downstream by the dashboard's Jinja autoescape — this layer is
+    purely about redaction + truncation.
+    """
+    from src.shared.redaction import redact_text_with_urls
+
+    raw = str(exc).strip() or exc.__class__.__name__
+    safe = redact_text_with_urls(raw)
+    note = f"dispatch_error: {safe}"
+    return note[:_DISPATCH_ERROR_NOTE_MAX]
+
+
 class RuntimeContext:
     """Manages the full OpenLegion runtime lifecycle."""
 
@@ -561,6 +591,71 @@ class RuntimeContext:
             if self.health_monitor:
                 self.health_monitor.register(agent_id)
 
+    async def _close_task_on_dispatch_error(
+        self, task_id: str, exc: BaseException,
+    ) -> None:
+        """Mark a durable task ``failed`` after its mesh→agent dispatch raised.
+
+        Without this, ``_direct_dispatch`` used to return ``f"Error: {e}"`` —
+        an opaque string the lane recorded as a *successful* turn, so the
+        durable task never got the lane's structured failure close and the
+        operator saw a useless ``exception: Error:`` note. We mirror the lane
+        watchdog's terminal-status write here: pre-check for an
+        already-terminal status (so a real status written by the assignee
+        during a race isn't clobbered), then write a REDACTED + truncated
+        ``blocker_note``. Best-effort: a failure to close must never mask the
+        original error from the lane.
+        """
+        from src.host.orchestration import InvalidStatusTransition
+
+        tasks_store = getattr(getattr(self, "_app", None), "tasks_store", None)
+        if tasks_store is None:
+            return
+        note = _build_dispatch_error_note(exc)
+        loop = asyncio.get_running_loop()
+        try:
+            pre = await loop.run_in_executor(
+                None, lambda: tasks_store.get(task_id)
+            )
+        except Exception as pre_err:
+            logger.debug(
+                "Dispatch-error pre-check for task %s failed: %s",
+                task_id, pre_err,
+            )
+            pre = None
+        if pre is not None and pre.get("status") in (
+            "done", "failed", "cancelled"
+        ):
+            # Already terminal (assignee or lane watchdog beat us) — do not
+            # clobber the real status/note.
+            logger.info(
+                "Dispatch error: task %s already terminal (status=%s) — "
+                "skipping failed-close", task_id, pre.get("status"),
+            )
+            return
+        try:
+            await loop.run_in_executor(
+                None,
+                lambda: tasks_store.update_status(
+                    task_id,
+                    "failed",
+                    actor="dispatch",
+                    blocker_note=note,
+                    extra_payload={"error": "dispatch_error"},
+                ),
+            )
+        except InvalidStatusTransition as race_err:
+            # Benign race: task went terminal between pre-check and UPDATE.
+            logger.info(
+                "Dispatch-error close race: task %s went terminal (%s) — "
+                "skipping", task_id, race_err,
+            )
+        except Exception as close_err:
+            logger.warning(
+                "Dispatch-error failed to close task %s: %s",
+                task_id, close_err,
+            )
+
     def _setup_dispatch(self) -> None:
         from src.host.lanes import _DEFAULT_LANE_TIMEOUT_SECONDS, LaneManager
 
@@ -634,6 +729,11 @@ class RuntimeContext:
                         data={"message": message[:200], "response_length": len(response),
                               "source": "dispatch"})
                 return response
+            # NOTE: ``except Exception`` (NOT ``BaseException``/bare) is
+            # deliberate — ``asyncio.CancelledError`` MUST propagate so the
+            # lane's 900s ``wait_for`` watchdog can still cancel a long run and
+            # run its structured timeout close. Swallowing it here would wedge
+            # the lane.
             except Exception as e:
                 duration_ms = int((_time.time() - t0) * 1000)
                 if tid and self.trace_store:
@@ -642,7 +742,23 @@ class RuntimeContext:
                         event_type="chat_response", duration_ms=duration_ms,
                         status="error", error=str(e),
                     )
-                return f"Error: {e}"
+                # RC-2 fix: a transport/agent error used to be returned as a
+                # bare ``f"Error: {e}"`` string. The lane recorded that as a
+                # *successful* turn, so the durable task never went through a
+                # structured failure close — the failure surfaced only as an
+                # opaque ``exception: Error:`` note with no actionable signal,
+                # AND the raw (untrusted) error string could leak secrets.
+                #
+                # Now: when the wake carried an originating ``task_id``, close
+                # that durable task to ``failed`` with a REDACTED + truncated
+                # ``blocker_note`` (mirrors the lane watchdog's terminal write,
+                # with an already-terminal pre-check to avoid clobbering a real
+                # status on a race). The string we return is also redacted so
+                # the no-task path (manual chat / heartbeat) stays non-leaky.
+                note = _build_dispatch_error_note(e)
+                if task_id:
+                    await self._close_task_on_dispatch_error(task_id, e)
+                return note
 
         async def _direct_steer(agent_name: str, message: str) -> dict:
             try:

--- a/src/shared/redaction.py
+++ b/src/shared/redaction.py
@@ -77,6 +77,47 @@ SECRET_PATTERNS: list[re.Pattern[str]] = [
                r"(?![A-Za-z0-9._-])"),
 ]
 
+
+# ── Bearer token / connection-string userinfo redaction ─────────────────────
+#
+# These two shapes are NOT URL-query secrets (so ``redact_url`` misses them)
+# and don't match a provider-token prefix (so ``SECRET_PATTERNS`` misses them).
+# They're applied as a SEPARATE pass in ``redact_string`` so they take effect
+# everywhere ``redact_string`` runs (free-form logs, exception strings, the
+# final sweep inside ``redact_url`` / ``redact_text_with_urls``, and
+# ``deep_redact``).
+
+# ``Bearer <token>`` — case-insensitive on the ``Bearer`` keyword, covers both
+# ``Authorization: Bearer xyz`` and a bare ``Bearer xyz``. We keep the keyword
+# and replace only the credential so the shape stays readable. Anchored on a
+# preceding word boundary so we don't fire mid-word (e.g. ``Foobearer``); the
+# token run is non-whitespace so it stops at the next space / EOL.
+_BEARER_RE = re.compile(
+    r"(?<![A-Za-z0-9])(?i:Bearer)\s+\S+",
+)
+
+
+def _redact_bearer(text: str) -> str:
+    return _BEARER_RE.sub("Bearer " + _REDACTED_VALUE, text)
+
+
+# Connection-string userinfo: ``scheme://user:password@host`` for ANY scheme
+# (postgres, redis, mongodb, amqp, mysql, …) — not just http/https, which
+# ``redact_url`` already strips. We replace BOTH the username and the password
+# (the username alone can leak account ownership), keeping the scheme + host so
+# the string stays diagnostically useful. Anchored on the ``scheme://`` prefix;
+# the userinfo run excludes ``/@`` so it can't cross past the authority.
+_CONN_USERINFO_RE = re.compile(
+    r"([A-Za-z][A-Za-z0-9+.\-]*://)"   # scheme://
+    r"[^/\s:@]+:[^/\s@]+@",            # user:password@
+)
+
+
+def _redact_conn_userinfo(text: str) -> str:
+    return _CONN_USERINFO_RE.sub(
+        lambda m: f"{m.group(1)}{_REDACTED_VALUE}:{_REDACTED_VALUE}@", text,
+    )
+
 # Backward-compat alias used by the old ``_REDACT_PATTERNS`` name in
 # ``src/browser/redaction.py`` and the agent-side browser_tool.  Existing
 # imports keep working.
@@ -293,11 +334,19 @@ def redact_url(url: str) -> str:
 
 
 def redact_string(text: str) -> str:
-    """Apply :data:`SECRET_PATTERNS` to ``text`` and return the result."""
+    """Apply :data:`SECRET_PATTERNS` to ``text`` and return the result.
+
+    Also strips two shapes that aren't provider-token prefixes nor URL-query
+    secrets: ``Bearer <token>`` auth values and ``scheme://user:pass@host``
+    connection-string userinfo (any scheme). See :func:`_redact_bearer` and
+    :func:`_redact_conn_userinfo`.
+    """
     if not text:
         return text
     for pattern in SECRET_PATTERNS:
         text = pattern.sub(_REDACTED_VALUE, text)
+    text = _redact_bearer(text)
+    text = _redact_conn_userinfo(text)
     return text
 
 

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -2040,6 +2040,64 @@ class TestDispatchErrorSurfacing:
         assert fetched["status"] == "done"
 
     @pytest.mark.asyncio
+    async def test_already_blocked_task_not_clobbered(
+        self, monkeypatch, tmp_path,
+    ):
+        """An assignee-authored ``blocked`` status (and its meaningful
+        blocker_note) must NOT be overwritten by a dispatch transport error,
+        even though ``blocked → failed`` is a valid transition."""
+        store = _tasks_store(tmp_path)
+        rec = store.create(creator="op", assignee="worker", title="do thing")
+        task_id = rec["id"]
+        store.update_status(task_id, "working", actor="worker")
+        # Assignee blocked the task with a meaningful note before our close.
+        store.update_status(
+            task_id, "blocked", actor="worker",
+            blocker_note="waiting on credential CRED_FOO",
+        )
+
+        dispatch_fn, ctx, transport = _capture_dispatch_fn(
+            monkeypatch, app=_app_with_tasks(store),
+        )
+        transport.request.side_effect = RuntimeError("late dispatch error")
+
+        await dispatch_fn("worker", "go", task_id=task_id)
+
+        fetched = store.get(task_id)
+        # Status + the assignee's note both preserved.
+        assert fetched["status"] == "blocked"
+        assert fetched["blocker_note"] == "waiting on credential CRED_FOO"
+
+    @pytest.mark.asyncio
+    async def test_stored_note_strips_bearer_and_connstring(
+        self, monkeypatch, tmp_path,
+    ):
+        """A dispatch error carrying a ``Bearer`` auth value and a non-HTTP
+        connection-string password must have BOTH stripped from the stored,
+        operator-visible blocker_note (central-redactor regression)."""
+        store = _tasks_store(tmp_path)
+        rec = store.create(creator="op", assignee="worker", title="do thing")
+        task_id = rec["id"]
+        store.update_status(task_id, "working", actor="worker")
+
+        dispatch_fn, ctx, transport = _capture_dispatch_fn(
+            monkeypatch, app=_app_with_tasks(store),
+        )
+        bearer = "Bearer leakedBearerToken123"
+        conn = "postgres://dbuser:dbp4ss@db.internal:5432/main"
+        transport.request.side_effect = RuntimeError(
+            f"auth failed: {bearer}; dsn={conn}"
+        )
+
+        await dispatch_fn("worker", "go", task_id=task_id)
+
+        note = store.get(task_id)["blocker_note"]
+        assert "leakedBearerToken123" not in note
+        assert "dbp4ss" not in note
+        assert "dbuser" not in note
+        assert "[REDACTED]" in note
+
+    @pytest.mark.asyncio
     async def test_cancelled_error_is_not_swallowed(
         self, monkeypatch, tmp_path,
     ):

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -1875,3 +1875,192 @@ class TestDispatchTimeoutAlignment:
         transport.request.assert_awaited_once()
         _args, kwargs = transport.request.call_args
         assert kwargs["timeout"] == 1860  # 1800 (override) + 60
+
+
+# ── RC-2: dispatch-error surfacing + redaction ─────────────────────────────
+#
+# A transport/agent ``/chat`` error used to be returned as a bare
+# ``f"Error: {e}"`` string. The lane recorded that as a *successful* turn, so
+# the durable task never went through a structured failure close. Now a
+# dispatch error closes the durable task to ``failed`` with a REDACTED +
+# truncated ``blocker_note``. The error string is UNTRUSTED, so it must pass
+# through the central redactor before reaching the operator-visible note.
+
+
+def _tasks_store(tmp_path):
+    from src.host.orchestration import Tasks
+    return Tasks(db_path=str(tmp_path / "tasks.db"))
+
+
+def _app_with_tasks(store):
+    import types as _types
+    return _types.SimpleNamespace(tasks_store=store)
+
+
+class TestDispatchErrorRedaction:
+    """Unit tests for the pure note-builder helper."""
+
+    def test_note_is_redacted_url_query_secret(self):
+        from src.cli.runtime import _build_dispatch_error_note
+
+        secret = "supersecret_query_value_123"
+        exc = RuntimeError(
+            f"502 from https://api.example.com/run?api_key={secret}&x=1"
+        )
+        note = _build_dispatch_error_note(exc)
+
+        assert secret not in note
+        assert "[REDACTED]" in note
+        assert note.startswith("dispatch_error: ")
+
+    def test_note_is_redacted_token_shaped_secret(self):
+        from src.cli.runtime import _build_dispatch_error_note
+
+        token = "sk-ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
+        exc = RuntimeError(f"auth failed with token={token}")
+        note = _build_dispatch_error_note(exc)
+
+        assert token not in note
+        assert "[REDACTED]" in note
+
+    def test_note_truncated_to_500_chars(self):
+        from src.cli.runtime import _build_dispatch_error_note
+
+        exc = RuntimeError("x" * 2000)
+        note = _build_dispatch_error_note(exc)
+
+        assert len(note) <= 500
+
+    def test_empty_error_falls_back_to_class_name(self):
+        from src.cli.runtime import _build_dispatch_error_note
+
+        note = _build_dispatch_error_note(RuntimeError(""))
+        assert note == "dispatch_error: RuntimeError"
+
+
+class TestDispatchErrorSurfacing:
+    @pytest.mark.asyncio
+    async def test_transport_error_closes_task_failed_with_redacted_note(
+        self, monkeypatch, tmp_path,
+    ):
+        """A transport error WITH a task_id closes the durable task to
+        ``failed`` and stores a REDACTED, meaningful ``blocker_note`` — the
+        raw secret in the error string must NOT survive into the note."""
+        store = _tasks_store(tmp_path)
+        rec = store.create(creator="op", assignee="worker", title="do thing")
+        task_id = rec["id"]
+        # Move into a live (non-terminal) state so ``failed`` is a valid
+        # transition the dispatch-error close can perform.
+        store.update_status(task_id, "working", actor="worker")
+
+        dispatch_fn, ctx, transport = _capture_dispatch_fn(
+            monkeypatch, app=_app_with_tasks(store),
+        )
+        secret = "supersecret_query_value_123"
+        transport.request.side_effect = RuntimeError(
+            f"502 from https://api.example.com/run?api_key={secret}&x=1"
+        )
+
+        result = await dispatch_fn("worker", "go", task_id=task_id)
+
+        # Durable task is now terminal-failed with a redacted note.
+        fetched = store.get(task_id)
+        assert fetched["status"] == "failed"
+        note = fetched["blocker_note"]
+        assert note is not None
+        assert note.startswith("dispatch_error: ")
+        assert secret not in note
+        assert "[REDACTED]" in note
+        # Returned string is also non-leaky (no raw secret).
+        assert secret not in result
+
+    @pytest.mark.asyncio
+    async def test_stored_note_truncated_to_500_chars(
+        self, monkeypatch, tmp_path,
+    ):
+        store = _tasks_store(tmp_path)
+        rec = store.create(creator="op", assignee="worker", title="do thing")
+        task_id = rec["id"]
+        store.update_status(task_id, "working", actor="worker")
+
+        dispatch_fn, ctx, transport = _capture_dispatch_fn(
+            monkeypatch, app=_app_with_tasks(store),
+        )
+        transport.request.side_effect = RuntimeError("y" * 4000)
+
+        await dispatch_fn("worker", "go", task_id=task_id)
+
+        fetched = store.get(task_id)
+        assert fetched["status"] == "failed"
+        assert len(fetched["blocker_note"]) <= 500
+
+    @pytest.mark.asyncio
+    async def test_no_task_id_does_not_crash_and_is_non_leaky(
+        self, monkeypatch, tmp_path,
+    ):
+        """Manual chat / heartbeat path (no task_id): no durable task to
+        close, must not raise, and the returned string must be redacted."""
+        store = _tasks_store(tmp_path)
+        dispatch_fn, ctx, transport = _capture_dispatch_fn(
+            monkeypatch, app=_app_with_tasks(store),
+        )
+        secret = "sk-ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
+        transport.request.side_effect = RuntimeError(
+            f"boom token={secret}"
+        )
+
+        result = await dispatch_fn("worker", "hi")  # no task_id
+
+        assert secret not in result
+        assert "[REDACTED]" in result
+        assert result.startswith("dispatch_error: ")
+
+    @pytest.mark.asyncio
+    async def test_already_terminal_task_not_clobbered(
+        self, monkeypatch, tmp_path,
+    ):
+        """If the assignee already wrote a real terminal status during a race,
+        the dispatch-error close must NOT overwrite it."""
+        store = _tasks_store(tmp_path)
+        rec = store.create(creator="op", assignee="worker", title="do thing")
+        task_id = rec["id"]
+        store.update_status(task_id, "working", actor="worker")
+        # Assignee finished successfully before our close fires.
+        store.update_status(task_id, "done", actor="worker")
+
+        dispatch_fn, ctx, transport = _capture_dispatch_fn(
+            monkeypatch, app=_app_with_tasks(store),
+        )
+        transport.request.side_effect = RuntimeError("late error")
+
+        await dispatch_fn("worker", "go", task_id=task_id)
+
+        fetched = store.get(task_id)
+        # Real status preserved; not clobbered to ``failed``.
+        assert fetched["status"] == "done"
+
+    @pytest.mark.asyncio
+    async def test_cancelled_error_is_not_swallowed(
+        self, monkeypatch, tmp_path,
+    ):
+        """``asyncio.CancelledError`` MUST propagate so the lane's ``wait_for``
+        watchdog can still cancel a long run — the ``except Exception`` clause
+        must not catch it."""
+        import asyncio as _asyncio
+
+        store = _tasks_store(tmp_path)
+        rec = store.create(creator="op", assignee="worker", title="do thing")
+        task_id = rec["id"]
+        store.update_status(task_id, "working", actor="worker")
+
+        dispatch_fn, ctx, transport = _capture_dispatch_fn(
+            monkeypatch, app=_app_with_tasks(store),
+        )
+        transport.request.side_effect = _asyncio.CancelledError()
+
+        with pytest.raises(_asyncio.CancelledError):
+            await dispatch_fn("worker", "go", task_id=task_id)
+
+        # Task left untouched — the lane watchdog owns the timeout close.
+        fetched = store.get(task_id)
+        assert fetched["status"] == "working"

--- a/tests/test_shared_redaction.py
+++ b/tests/test_shared_redaction.py
@@ -26,6 +26,7 @@ from src.shared.redaction import (
     SENSITIVE_QUERY_PARAMS,
     deep_redact,
     redact_string,
+    redact_text_with_urls,
     redact_url,
 )
 
@@ -68,6 +69,67 @@ class TestRedactString:
     def test_jwt_redacted_anywhere_in_string(self):
         jwt = "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxIn0.signaturepartatleasttenchars"
         assert redact_string(f"Bearer {jwt}") == f"Bearer {_REDACTED}"
+
+
+# ── Unit tests: Bearer tokens + connection-string userinfo ──────────────────
+
+
+class TestBearerRedaction:
+    def test_bare_bearer_token_redacted(self):
+        assert redact_string("Bearer abc123") == f"Bearer {_REDACTED}"
+
+    def test_authorization_header_bearer_redacted(self):
+        out = redact_string("Authorization: Bearer s0me-Opaque_Token.value")
+        assert out == f"Authorization: Bearer {_REDACTED}"
+        assert "s0me-Opaque_Token" not in out
+
+    def test_bearer_case_insensitive(self):
+        # lowercase / uppercase keyword still triggers; the token is stripped.
+        assert redact_string("bearer abc123") == f"Bearer {_REDACTED}"
+        out = redact_string("BEARER xyzToken")
+        assert "xyzToken" not in out and _REDACTED in out
+
+    def test_bearer_no_false_positive_midword(self):
+        # ``Foobearer`` must not fire — the word-boundary lookbehind protects it.
+        assert redact_string("Foobearer notatoken") == "Foobearer notatoken"
+
+    def test_bearer_redacted_via_text_with_urls(self):
+        out = redact_text_with_urls("hdr Authorization: Bearer leakedToken123")
+        assert "leakedToken123" not in out
+        assert _REDACTED in out
+
+
+class TestConnectionStringRedaction:
+    def test_postgres_userinfo_password_redacted(self):
+        out = redact_string("postgres://app:s3cr3t@db.host:5432/main")
+        assert "s3cr3t" not in out
+        assert _REDACTED in out
+        assert "db.host:5432/main" in out  # scheme + host preserved
+
+    def test_redis_userinfo_redacted(self):
+        out = redact_string("redis://user:pass@cache:6379")
+        assert "pass" not in out
+        assert "user" not in out
+        assert "cache:6379" in out
+
+    def test_arbitrary_scheme_userinfo_redacted(self):
+        out = redact_string("mongodb+srv://u:p@cluster.example/db")
+        assert "u:p@" not in out
+        assert _REDACTED in out
+
+    def test_no_userinfo_left_untouched(self):
+        # No ``user:pass@`` — must not be mangled.
+        assert redact_string("postgres://db.host/main") == "postgres://db.host/main"
+
+    def test_conn_userinfo_via_text_with_urls(self):
+        out = redact_text_with_urls("DSN postgres://u:p@h/db failed to connect")
+        assert "u:p@" not in out
+        assert _REDACTED in out
+
+    def test_http_userinfo_still_handled_by_redact_url(self):
+        # Regression: web-scheme userinfo is stripped structurally by redact_url.
+        out = redact_url("https://alice:pw@host.example/admin")
+        assert "alice" not in out and "pw" not in out
 
 
 # ── Unit tests: redact_url ──────────────────────────────────────────────────


### PR DESCRIPTION
RC-2: _direct_dispatch swallowed all errors into `Error: {e}` so the lane recorded a fake success and failures surfaced as opaque `exception: Error:`. Now closes the durable task to `failed` with a REDACTED (redact_text_with_urls), truncated (<=500) blocker_note. Security-reviewed: agent error strings are untrusted → redaction strips URL-query secrets + token-shaped strings (proven in tests with a planted secret); CancelledError still propagates (except Exception, not BaseException); already-terminal pre-check avoids clobbering. Tests: 9 new, 129 passed, ruff clean.