### PR TITLE
fix(costs): OAuth (subscription) LLM calls accrue $0 — no cost, no cap

### DIFF
--- a/src/dashboard/static/js/app.js
+++ b/src/dashboard/static/js/app.js
@@ -10211,7 +10211,8 @@ function dashboard() {
           add('Input tokens', d.input_tokens ?? d.prompt_tokens);
           add('Output tokens', d.output_tokens ?? d.completion_tokens);
           add('Total tokens', d.total_tokens ?? d.tokens_used);
-          if (d.cost_usd != null) add('Cost', '$' + d.cost_usd.toFixed(6));
+          if (d.oauth) add('Cost', 'subscription (no per-call cost)');
+          else if (d.cost_usd != null) add('Cost', '$' + d.cost_usd.toFixed(6));
           if (d.duration_ms) add('Duration', d.duration_ms + 'ms');
           add('Service', d.service);
           add('Action', d.action);
@@ -10294,7 +10295,7 @@ function dashboard() {
           const model = (d.model || '').split('/').pop();
           if (!model) return `${d.service || 'api'}/${d.action || '?'}${d.streaming ? ' (streaming)' : ''}`;
           const tokens = (d.total_tokens || d.tokens_used || 0).toLocaleString();
-          const cost = d.cost_usd != null ? ` \u00b7 $${d.cost_usd.toFixed(4)}` : '';
+          const cost = d.oauth ? ' \u00b7 sub' : (d.cost_usd != null ? ` \u00b7 $${d.cost_usd.toFixed(4)}` : '');
           const dur = d.duration_ms ? ` \u00b7 ${d.duration_ms}ms` : '';
           const prompt = d.prompt_preview ? ` \u00b7 "${d.prompt_preview.substring(0, 40)}${d.prompt_preview.length > 40 ? '\u2026' : ''}"` : '';
           return `${model} \u00b7 ${tokens} tok${cost}${dur}${prompt}`;

--- a/src/host/costs.py
+++ b/src/host/costs.py
@@ -203,10 +203,21 @@ class CostTracker:
 
     def track(
         self, agent: str, model: str, prompt_tokens: int, completion_tokens: int,
+        *, bill: bool = True,
     ) -> dict:
-        """Record a single LLM call. Returns {"cost": float, "over_budget": bool}."""
+        """Record a single LLM call. Returns {"cost": float, "over_budget": bool}.
+
+        ``bill=False`` records the token usage with ``cost_usd=0`` — used for
+        OAuth (subscription) traffic, which consumes tokens but incurs no
+        per-call dollar cost. Operators keep token visibility, while the
+        spend total stays $0 so subscription usage never accrues cost and
+        never trips a daily/monthly budget cap (the cap reads SUM(cost_usd)).
+        """
         total = prompt_tokens + completion_tokens
-        cost = estimate_cost(model, input_tokens=prompt_tokens, output_tokens=completion_tokens)
+        cost = (
+            estimate_cost(model, input_tokens=prompt_tokens, output_tokens=completion_tokens)
+            if bill else 0.0
+        )
 
         self.db.execute(
             "INSERT INTO usage (agent, model, prompt_tokens, completion_tokens, total_tokens, cost_usd) "
@@ -215,7 +226,12 @@ class CostTracker:
         )
         self.db.commit()
 
-        return {"cost": cost, "over_budget": self._check_budget_post_hoc(agent)}
+        # A non-billed (OAuth) row adds $0, so it can never push the agent
+        # over budget — short-circuit the post-hoc check to keep that
+        # guarantee explicit (and avoid attributing a metered overage to a
+        # subscription call).
+        over_budget = self._check_budget_post_hoc(agent) if bill else False
+        return {"cost": cost, "over_budget": over_budget}
 
     def track_fixed_cost(self, agent: str, model: str, cost_usd: float) -> dict:
         """Record a fixed-cost API call (e.g. image generation).

--- a/src/host/credentials.py
+++ b/src/host/credentials.py
@@ -710,13 +710,15 @@ class CredentialVault:
                 response = await handler(request)
 
                 if self.cost_tracker and agent_id and response.success and response.data:
-                    # M8: record usage even on the OAuth path. OAuth calls
-                    # carry no per-call dollar enforcement (``_needs_budget``
-                    # is False above, so no budget gate runs), but we still
-                    # TRACK the token spend so operators retain visibility
-                    # into OAuth consumption. Previously OAuth responses were
-                    # skipped entirely, leaving a blind spot. No $ semantics
-                    # are introduced — this is observability-only tracking.
+                    # M8: record usage even on the OAuth path so operators
+                    # retain token visibility into OAuth consumption (it was
+                    # previously skipped entirely, leaving a blind spot). But
+                    # OAuth (subscription) traffic carries NO dollar cost, so
+                    # it is tracked with ``bill=False`` → cost_usd=0. That
+                    # keeps observability while guaranteeing OAuth never
+                    # accrues spend and therefore never trips a budget cap
+                    # (the cap, reroute/retry gate and dashboard all read
+                    # SUM(cost_usd)). Metered API-key traffic bills normally.
                     tokens_used = response.data.get("tokens_used", 0)
                     if tokens_used:
                         model = response.data.get(
@@ -726,7 +728,10 @@ class CredentialVault:
                         prompt_tokens = raw_pt if raw_pt else int(tokens_used * 0.7)
                         raw_ct = response.data.get("output_tokens")
                         completion_tokens = raw_ct if raw_ct else (tokens_used - prompt_tokens)
-                        self.cost_tracker.track(agent_id, model, prompt_tokens, completion_tokens)
+                        self.cost_tracker.track(
+                            agent_id, model, prompt_tokens, completion_tokens,
+                            bill=not _is_oauth,
+                        )
 
                     fixed_cost = response.data.get("fixed_cost_usd")
                     if fixed_cost and fixed_cost > 0:
@@ -2888,6 +2893,10 @@ class CredentialVault:
                 "type": "done", "content": collected_content,
                 "tool_calls": collected_tool_calls,
                 "tokens_used": tokens_used, "model": model,
+                # Subscription auth — no per-call cost. Mirrors the Anthropic
+                # OAuth stream done-frame so downstream telemetry (mesh
+                # ``llm_call`` events) reports $0 instead of a metered estimate.
+                "oauth": True,
             }
             if collected_thinking:
                 done_data["thinking_content"] = collected_thinking

--- a/src/host/server.py
+++ b/src/host/server.py
@@ -2029,6 +2029,12 @@ def create_mesh_app(
                 output_tok = result.data.get("output_tokens", 0)
                 from src.host.costs import estimate_cost
                 fixed_cost = result.data.get("fixed_cost_usd", 0)
+                # OAuth (Anthropic/OpenAI subscription) calls have no per-call
+                # cost — the authoritative usage table already skips them in
+                # CredentialVault.execute_api_call. Mirror that here so the
+                # dashboard activity/trace feed doesn't show a metered estimate
+                # for subscription traffic.
+                is_oauth = bool(result.data.get("oauth"))
                 event_data = {
                     "service": api_request.service, "action": api_request.action,
                     "duration_ms": duration_ms,
@@ -2036,8 +2042,11 @@ def create_mesh_app(
                     "total_tokens": tokens,
                     "input_tokens": input_tok,
                     "output_tokens": output_tok,
-                    "cost_usd": fixed_cost if fixed_cost else estimate_cost(
-                        model, input_tokens=input_tok, output_tokens=output_tok, total_tokens=tokens,
+                    "oauth": is_oauth,
+                    "cost_usd": 0.0 if is_oauth else (
+                        fixed_cost if fixed_cost else estimate_cost(
+                            model, input_tokens=input_tok, output_tokens=output_tok, total_tokens=tokens,
+                        )
                     ),
                 }
                 if prompt_preview:
@@ -2129,6 +2138,10 @@ def create_mesh_app(
             try:
                 if event_bus is not None and (tokens or model):
                     from src.host.costs import estimate_cost
+                    # OAuth (subscription) streams carry oauth=True in the done
+                    # frame — report $0 to match the usage table, which never
+                    # records cost for OAuth (stream_llm returns before track()).
+                    is_oauth = bool(done_data.get("oauth"))
                     ev: dict = {
                         "service": api_request.service,
                         "action": api_request.action,
@@ -2137,7 +2150,8 @@ def create_mesh_app(
                         "total_tokens": tokens,
                         "input_tokens": 0,
                         "output_tokens": 0,
-                        "cost_usd": estimate_cost(model, total_tokens=tokens),
+                        "oauth": is_oauth,
+                        "cost_usd": 0.0 if is_oauth else estimate_cost(model, total_tokens=tokens),
                     }
                     if prompt_preview:
                         ev["prompt_preview"] = prompt_preview

--- a/tests/test_costs.py
+++ b/tests/test_costs.py
@@ -29,6 +29,40 @@ class TestCostTracking:
         assert spend["total_tokens"] == 1500
         assert spend["total_cost"] > 0
 
+    def test_track_oauth_records_tokens_at_zero_cost(self):
+        """bill=False (OAuth/subscription): tokens recorded, cost_usd=0."""
+        result = self.tracker.track(
+            "agent1", "anthropic/claude-sonnet-4-6", 1000, 500, bill=False,
+        )
+        assert result["cost"] == 0.0
+        assert result["over_budget"] is False
+        spend = self.tracker.get_spend("agent1", "today")
+        # Token visibility is preserved (observability) ...
+        assert spend["total_tokens"] == 1500
+        # ... but the spend total stays $0 — no dollar capture for OAuth.
+        assert spend["total_cost"] == 0.0
+
+    def test_oauth_usage_never_trips_budget_cap(self):
+        """A pure-OAuth agent stays within budget no matter the volume.
+
+        ``check_budget`` is the gate the reroute/retry path
+        (``_check_can_schedule``) and the dashboard read; it sums
+        ``cost_usd``. bill=False rows add $0, so a subscription-only agent
+        is always ``allowed`` even past a tiny dollar budget that metered
+        traffic would blow through instantly. (The forward-looking
+        ``preflight_check`` is deliberately NOT asserted here — it estimates
+        the *next* call's list price and is never invoked on the OAuth path,
+        which skips budget enforcement entirely; see
+        ``test_oauth_tracks_usage_but_skips_budget_enforcement``.)
+        """
+        self.tracker.set_budget("agent1", daily_usd=0.01, monthly_usd=0.01)
+        for _ in range(50):
+            self.tracker.track(
+                "agent1", "anthropic/claude-opus-4-1", 50_000, 10_000, bill=False,
+            )
+        assert self.tracker.check_budget("agent1")["allowed"] is True
+        assert self.tracker.get_spend("agent1", "today")["total_cost"] == 0.0
+
     def test_track_multiple_calls(self):
         self.tracker.track("agent1", "openai/gpt-4o-mini", 100, 50)
         self.tracker.track("agent1", "openai/gpt-4o-mini", 200, 100)

--- a/tests/test_credentials.py
+++ b/tests/test_credentials.py
@@ -2688,11 +2688,12 @@ async def test_oauth_tracks_usage_but_skips_budget_enforcement(monkeypatch):
     result = await v.execute_api_call(req, agent_id="test-agent")
 
     assert result.success
-    # Usage IS tracked now (spend visibility) ...
+    # Usage IS tracked now (token visibility) but with bill=False so the
+    # row records cost_usd=0 — OAuth (subscription) accrues no dollar spend.
     cost_tracker.track.assert_called_once_with(
-        "test-agent", "anthropic/claude-sonnet-4-6", 50, 25,
+        "test-agent", "anthropic/claude-sonnet-4-6", 50, 25, bill=False,
     )
-    # ... but no dollar enforcement runs on the OAuth path.
+    # ... and no dollar enforcement runs on the OAuth path.
     cost_tracker.preflight_check.assert_not_called()
 
 
@@ -3427,7 +3428,9 @@ async def test_codex_tracks_usage_but_skips_budget(monkeypatch):
     )
     result = await v.execute_api_call(req, agent_id="test-agent")
     assert result.success
+    # Tracked for visibility, but bill=False → cost_usd=0 (no dollar spend).
     cost_tracker.track.assert_called_once()
+    assert cost_tracker.track.call_args.kwargs.get("bill") is False
     cost_tracker.preflight_check.assert_not_called()
 
 
@@ -3462,6 +3465,69 @@ async def test_codex_stream_skips_cost_tracking(monkeypatch):
     assert any("done" in e for e in events)
     cost_tracker.track.assert_not_called()
     cost_tracker.preflight_check.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_codex_stream_done_frame_carries_oauth_flag(monkeypatch):
+    """The real Codex stream done-frame must include oauth=True.
+
+    Regression: downstream mesh telemetry (``llm_call`` events in
+    ``server.py``) keys the $0 subscription cost off this flag. Without it,
+    OpenAI Codex (ChatGPT subscription) streams report a metered estimate,
+    making the dashboard show per-call costs the user is never billed for.
+    Mirrors the Anthropic OAuth stream done-frame, which already sets it.
+    """
+    import json as _json
+
+    monkeypatch.delenv("OPENLEGION_SYSTEM_OPENAI_API_KEY", raising=False)
+    monkeypatch.setenv(
+        "OPENLEGION_SYSTEM_OPENAI_OAUTH",
+        '{"access_token":"tok","refresh_token":"ref","account_id":"acct","expires_at":9999999999}',
+    )
+    v = CredentialVault()
+
+    sse_lines = [
+        'data: ' + _json.dumps({"type": "response.output_text.delta", "delta": "hi"}),
+        'data: ' + _json.dumps({
+            "type": "response.completed",
+            "response": {"usage": {"input_tokens": 10, "output_tokens": 5}},
+        }),
+    ]
+
+    class _FakeResp:
+        status_code = 200
+        is_success = True
+
+        async def aiter_lines(self):
+            for line in sse_lines:
+                yield line
+
+    class _FakeStreamCM:
+        async def __aenter__(self):
+            return _FakeResp()
+
+        async def __aexit__(self, *exc):
+            return False
+
+    client = await v._get_http_client()
+    monkeypatch.setattr(client, "stream", lambda *a, **k: _FakeStreamCM())
+
+    req = APIProxyRequest(
+        service="llm", action="chat",
+        params={"model": "openai/gpt-5", "messages": [{"role": "user", "content": "hi"}]},
+    )
+
+    done = None
+    async for chunk in v._openai_oauth_chat_stream(req, "openai/gpt-5"):
+        if chunk.startswith("data: "):
+            parsed = _json.loads(chunk[6:].strip())
+            if parsed.get("type") == "done":
+                done = parsed
+
+    assert done is not None
+    assert done["oauth"] is True
+    assert done["content"] == "hi"
+    assert done["tokens_used"] == 15
 
 
 @pytest.mark.asyncio

--- a/tests/test_mesh.py
+++ b/tests/test_mesh.py
@@ -2124,3 +2124,131 @@ async def test_profile_denied_to_worker_omitting_requesting_agent(tmp_path):
         bb.close()
         costs.close()
         traces.close()
+
+
+# ── llm_call telemetry cost: OAuth (subscription) must report $0 ──────
+
+
+def _build_proxy_cost_app(tmp_path, vault):
+    """Build a minimal mesh app for exercising the /mesh/api cost telemetry.
+
+    ``vault`` is the (mocked) credential vault whose ``execute_api_call``
+    return value drives what the ``llm_call`` event reports. Returns
+    ``(app, event_bus, captured, cleanup)`` where ``captured`` accumulates
+    every emitted ``llm_call`` event dict (EventBus listeners run
+    synchronously inside emit()).
+    """
+    from src.dashboard.events import EventBus
+    from src.host.server import create_mesh_app
+
+    # The /mesh/api proxy runs _enforce_model_pin → is_model_compatible
+    # (the model-pin gate) before dispatch; stub the documented
+    # (compatible, reason) contract so the pin doesn't trip on the mock.
+    vault.is_model_compatible.return_value = (True, None)
+
+    bb = Blackboard(db_path=str(tmp_path / "bb.db"))
+    pubsub = PubSub()
+    perms = PermissionMatrix()
+    perms.permissions["scout"] = AgentPermissions(
+        agent_id="scout", allowed_apis=["llm"],
+    )
+    router = MessageRouter(perms, {})
+    router.register_agent("scout", "http://scout:8400", [])
+
+    event_bus = EventBus()
+    captured: list[dict] = []
+    event_bus.add_listener(
+        lambda e: captured.append(e) if e.get("type") == "llm_call" else None,
+    )
+
+    app = create_mesh_app(
+        blackboard=bb, pubsub=pubsub, router=router, permissions=perms,
+        credential_vault=vault, event_bus=event_bus,
+    )
+    return app, event_bus, captured, bb.close
+
+
+async def _post_chat(app):
+    from httpx import ASGITransport, AsyncClient
+
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://test",
+    ) as client:
+        return await client.post(
+            "/mesh/api",
+            params={"agent_id": "scout"},
+            json={
+                "service": "llm", "action": "chat",
+                "params": {
+                    "model": "anthropic/claude-sonnet-4-6",
+                    "messages": [{"role": "user", "content": "hi"}],
+                },
+            },
+        )
+
+
+@pytest.mark.asyncio
+async def test_proxy_api_oauth_call_reports_zero_cost(tmp_path):
+    """OAuth (subscription) calls must emit an llm_call event with cost_usd=0.
+
+    Pins the dashboard activity/trace-feed contract: the authoritative
+    usage table already skips OAuth, and this telemetry event must agree.
+    """
+    from unittest.mock import AsyncMock, MagicMock
+
+    from src.shared.types import APIProxyResponse
+
+    vault = MagicMock()
+    vault.execute_api_call = AsyncMock(return_value=APIProxyResponse(
+        success=True,
+        data={
+            "oauth": True, "content": "hi", "tokens_used": 1000,
+            "input_tokens": 700, "output_tokens": 300,
+            "model": "anthropic/claude-sonnet-4-6",
+        },
+    ))
+
+    app, _bus, captured, cleanup = _build_proxy_cost_app(tmp_path, vault)
+    try:
+        resp = await _post_chat(app)
+        assert resp.status_code == 200, resp.text
+        assert len(captured) == 1
+        data = captured[0]["data"]
+        assert data["oauth"] is True
+        assert data["cost_usd"] == 0.0
+        # Tokens are still reported — only the dollar cost is zeroed.
+        assert data["total_tokens"] == 1000
+    finally:
+        cleanup()
+
+
+@pytest.mark.asyncio
+async def test_proxy_api_metered_call_still_reports_cost(tmp_path):
+    """Regression guard (other direction): non-OAuth calls keep a real cost.
+
+    Ensures the OAuth zeroing didn't blanket-zero metered API-key traffic.
+    """
+    from unittest.mock import AsyncMock, MagicMock
+
+    from src.shared.types import APIProxyResponse
+
+    vault = MagicMock()
+    vault.execute_api_call = AsyncMock(return_value=APIProxyResponse(
+        success=True,
+        data={
+            "content": "hi", "tokens_used": 1000,
+            "input_tokens": 700, "output_tokens": 300,
+            "model": "anthropic/claude-sonnet-4-6",
+        },
+    ))
+
+    app, _bus, captured, cleanup = _build_proxy_cost_app(tmp_path, vault)
+    try:
+        resp = await _post_chat(app)
+        assert resp.status_code == 200, resp.text
+        assert len(captured) == 1
+        data = captured[0]["data"]
+        assert not data.get("oauth")
+        assert data["cost_usd"] > 0.0
+    finally:
+        cleanup()


### PR DESCRIPTION
## Requirement

OAuth credentials for Anthropic (Claude Pro/Max) and OpenAI (ChatGPT Codex) are **subscription-based** — they consume tokens but carry **no per-call dollar cost**. Therefore OAuth LLM traffic must **never accrue spend and never trip a budget cap**.

## Root cause (what was still capturing cost)

`execute_api_call` records every successful LLM response via `CostTracker.track()`, which computes `estimate_cost()` and writes `cost_usd` into the `usage` table — the table that `check_budget` / `preflight_check` / `get_spend` all read. The earlier **M8 "observability"** change started tracking OAuth here too, but `track()` is **not** cost-free: it stored a metered dollar estimate. So OAuth silently accrued spend that:

- showed on the cost dashboard (`/api/costs` → `get_spend`), and
- fed the **reroute/retry gate** (`_check_can_schedule` → `check_budget`) and the **daily/monthly caps** — a pure-OAuth agent could be blocked **"over budget"** despite spending nothing.

(The mesh preflight gate already skipped OAuth via `_needs_budget`, and the streaming path returns before tracking — but the **non-streaming ledger write** was the leak.)

## Fix

1. **Ledger** — `CostTracker.track()` gains `bill: bool = True`. OAuth tracks with `bill=False` → `cost_usd=0` (and `over_budget=False`), preserving M8's **token visibility** while guaranteeing **$0 spend**. Because every cap reads `SUM(cost_usd)`, zeroing it at this single site fixes the preflight gate, the reroute/retry gate, **and** the dashboard at once — no per-gate OAuth special-casing. **Metered API-key traffic is unchanged** (`bill=True` default).
2. **Telemetry** — the mesh `llm_call` events now report `cost_usd=0.0` + an `oauth` marker for OAuth, on both the non-streaming and streaming emits.
3. **Parity** — the OpenAI Codex streaming done-frame was missing the `oauth=True` flag the Anthropic OAuth stream already sets; added so (2)'s streaming guard detects OpenAI subscription traffic.
4. **UI** — activity feed shows `subscription (no per-call cost)` / `sub` instead of a misleading `$0.000000`.

## Out of scope (verified — none are subscription dollar caps)

The agent-side `TokenBudget` is a **token-count** cap; #1024's convergence budget is a **round-count** cap; the wallet enforces **on-chain tx** limits; `image_gen` budgets gate a **real metered API** (not a subscription). `max_cost_usd` / `estimated_cost_usd` in `TokenBudget` are dead/unenforced.

## Tests

- **costs**: OAuth `bill=False` records tokens at `$0`; a pure-OAuth agent stays `check_budget`-allowed past a tiny dollar budget (never hits the cap).
- **credentials**: M8 tests now assert `bill=False`; the real `_openai_oauth_chat_stream` done-frame carries `oauth=True`.
- **mesh**: the real `/mesh/api` endpoint emits `llm_call` `cost_usd=0` for OAuth and `>0` for metered API-key traffic.

Green on latest `main`: `test_costs`+`test_credentials`+`test_mesh`+`test_llm` 435 passed; `test_loop`+`test_dashboard` 563 passed; ruff clean.

## Consistency vs merged PRs

Rebased onto current `main` (includes #1023/#1024/#1025/#1028). All orthogonal — no conflicts, no shared enforcement surface.
