### PR TITLE
feat(integrations): one-click OAuth "Connect" flow (Google first)

### DIFF
--- a/docs/plans/2026-06-04-integrations-oauth-strategy.md
+++ b/docs/plans/2026-06-04-integrations-oauth-strategy.md
@@ -1,0 +1,128 @@
+# Integrations / OAuth — Product Strategy & Decision Record
+
+**Date:** 2026-06-04
+**Author:** Product (CPO review)
+**Status:** Accepted direction; implementation phased
+**Related:** `docs/plans/2026-06-04-oauth-integrations-connect-flow.md` (the Option-B implementation)
+
+---
+
+## 1. The job-to-be-done
+
+Users want their **agents to act on their behalf in the SaaS tools they already use** — read my
+Drive, send Gmail, post to my Facebook Page, read my Slack — **without becoming an OAuth-app
+developer.** The original complaint was concrete: *"setting up Google Drive / Meta is a real pain —
+many steps just to get a token to paste into the vault."*
+
+## 2. Honest assessment of what we shipped (Option B, BYO app)
+
+Option B (bring-your-own OAuth app: the user registers their own app, supplies client_id/secret
+once, then connects) is the **right foundation but not the end-state.**
+
+- ✅ It fixes the **repeat** pain — no more hand-minting tokens, no more expiry surprises
+  (transparent refresh). It validates the entire vault → `$CRED{}` → agent-tool plumbing.
+- ❌ It does **not** remove the pain the user actually described. The "many steps" *are* the
+  app registration (create a cloud project, configure the consent screen, add scopes + redirect
+  URI, pass verification). Option B leaves all of that with the user.
+
+**Conclusion:** ship B as the bridge (it unblocks self-hosters and power users today), but treat
+**Option A as the destination.**
+
+## 3. The destination — Option A (first-party "Connect")
+
+We own **verified OAuth apps**; the user clicks *Connect Google*, consents, done. **Zero developer
+steps.** This is the Zapier / Notion / Linear pattern and the version that genuinely kills the pain.
+Deferred for real reasons — provider app verification (Google/Meta), central secret custody, and a
+broker. Because we built B's `store_connection` to be callable from both the local callback *and* an
+internal push endpoint, A is mostly "swap where the client secret comes from + a broker in `app/`."
+
+## 4. The third axis — build vs. adopt (decide before provider #5)
+
+Hand-maintaining OAuth dances for N providers is a forever-tax (API deprecations, scope changes,
+re-verification). Two ways to avoid owning the long tail:
+
+- **MCP connectors** — the ecosystem is standardizing here; mature Google/Slack/GitHub MCP servers
+  already exist with brokered OAuth. The engine can be an MCP *client* and inherit them.
+- **Aggregator** (Nango / Composio / Paragon / Merge) — vendors whose whole product is
+  "OAuth + refresh + normalized APIs for 200+ SaaS." Rent the treadmill.
+
+**Recommended posture:** hand-build the top 3–5 highest-value providers (where we want deep, typed
+tools); adopt MCP/aggregator for the long tail.
+
+## 5. Sequencing (north star → now)
+
+| Phase | What | Status |
+|---|---|---|
+| **Now** | Option B generic BYO-app OAuth; Google first; on the credentials page | ✅ Built |
+| **Next** | Option A first-party connectors for the **top 3** (broker in `app/`) | Proposed |
+| **Then** | Decide build-vs-buy; adopt MCP/aggregator for the long tail | Proposed |
+| **Layer** | Typed skills (`drive_list_files()`, `gmail_send()`) over top connections so agents stop doing raw REST | Proposed |
+
+**Lighthouse first-party three (vote):** **Google + Microsoft + Slack** for broad business coverage —
+swap Slack → **GitHub** if the ICP skews dev-fleet.
+
+## 6. Placement decision (UI/IA)
+
+OAuth connections are **outbound credentials** (agents reach *out*), not **inbound channels**
+(platforms reaching *in*, e.g. Telegram/Slack/Webhooks). "Integrations" in this product already means
+the latter. **Decision:** the connect UI lives on the **credentials page** (the `apikeys` sub-tab,
+relabeled "API Keys & Connections"), presented as "Connect a service" beside manual key entry —
+*not* under Channels/Webhooks.
+
+## 7. Provider roadmap (the registry is provider-agnostic; friction is the provider, not our code)
+
+| Tier | Providers | Effort | Notes |
+|---|---|---|---|
+| **Drop-in** (standard OAuth2 + refresh) | Microsoft 365 / Graph (Outlook, OneDrive, Teams), Slack, GitHub/GitLab, Notion, Linear/Jira, Dropbox/Box | Low | ~A registry row each. Notion tokens don't expire — our "no refresh → return current" path already handles it. **Microsoft is the highest-value easy win for business users.** |
+| **Wrinkles** | HubSpot, Salesforce, Shopify, Stripe Connect | Medium | Salesforce returns a per-org `instance_url`; Shopify is per-store subdomain. The flexible connection dict stores the extras, but each needs a small per-provider hook. |
+| **Hard** | **Meta** (Facebook/Instagram/Threads), X/Twitter | High | See §8. |
+
+## 8. Meta — the hard case (named by the user)
+
+Meta is very doable but is a **tier-2 build**, and the strongest argument for first-party + aggregator:
+
+1. **Different token lifecycle.** No standard `refresh_token` grant. Short-lived user token →
+   exchange for a **long-lived (~60-day) token** (`fb_exchange_token`), re-exchanged before expiry.
+   Needs a **provider-specific refresh hook**, not the generic one (our architecture anticipated the
+   "long-lived / no-refresh" branch, but Meta's refresh is custom logic).
+2. **Heavy review.** Production permissions require **App Review + Business Verification**,
+   per-capability (Pages, IG publishing, Ads, WhatsApp). Slower/stricter than Google.
+3. **Asset selection.** After connecting, the agent must pick *which* Page / IG Business account /
+   Ad account to act on — an extra UX step beyond the token.
+4. **WhatsApp overlap.** We already have a WhatsApp *inbound channel* (webhook). OAuth into a
+   WhatsApp Business account is a different thing — keep them distinct in the UI to avoid confusion.
+
+## 9. Differentiators worth marketing
+
+- **Connect once → the whole agent fleet can use it** (governed per-agent via `allowed_credentials`).
+  Single-assistant competitors can't say that.
+- **Agents only ever see a short-lived access token** — never the refresh token, never the client
+  secret. A real enterprise-trust story, not just plumbing.
+
+## 10. Open decisions / next actions
+
+- [ ] Confirm the lighthouse-three for Option A (Google + Microsoft + Slack vs. GitHub swap).
+- [ ] Build-vs-buy spike: evaluate MCP-client path and one aggregator (Nango or Composio) before #5.
+- [ ] First typed skill on top of a connection (likely `gmail_send` / `drive_list_files`) to remove
+      the raw-REST caveat.
+- [ ] Option A broker design in `app/` (central verified apps + internal push into the engine vault).
+
+## 11. Engineering follow-ups (from the Option-B PR review)
+
+Tracked, non-blocking — surfaced during the end-to-end review of the shipped Option-B code:
+
+- [ ] **MCP `$CRED{}` env injection doesn't refresh.** `resolve_cred_handles` (sync, called at
+      agent spawn in `runtime.py`) returns a connection's stored token without on-demand refresh, so
+      an agent that uses a connection *only* via an MCP server (never via `http_request`) could get a
+      stale token. The primary `http_request` path refreshes correctly. Fix: async-resolve in the MCP
+      spawn path, or pre-refresh connections before spawn.
+- [ ] **System-cred denylist not re-synced at runtime.** `set_system_credential_names` is populated
+      at startup; runtime `add_credential(system=True)` for `*_client_id/secret` doesn't update it, so
+      `can_access_credential`/`/vault/status` can confirm a client-cred *name's existence* to an agent
+      (the value stays unresolvable — no leak). Fix: register integration client-cred names into the
+      permission denylist on setup. (Note: the `is_system_credential` suffix approach won't work —
+      `google` isn't a known provider name.)
+- [ ] **Post-connect redirect lands on `/dashboard/`** (default tab), not back on the API Keys page.
+      Toast fires either way; restore the `apikeys` sub-tab via the return URL.
+- [ ] **Typed connection skills** (`drive_list_files()`, `gmail_send()`) so agents stop hand-writing
+      Google REST calls through `http_request`.

--- a/docs/plans/2026-06-04-oauth-integrations-connect-flow.md
+++ b/docs/plans/2026-06-04-oauth-integrations-connect-flow.md
@@ -1,0 +1,210 @@
+# One-Click Integrations — OAuth "Connect" Flow
+
+**Date:** 2026-06-04
+**Status:** Proposed
+**Scope:** Replace the manual "go fetch a token and paste it" flow for third-party data
+integrations with an in-engine OAuth authorization-code flow. Ship **Option B** (bring-your-own
+OAuth app, engine handles the dance + refresh) first, with **Google** (Drive / Gmail / Calendar)
+as the first provider. Keep the design provider-agnostic and broker-ready so **Option A**
+(first-party verified connectors, zero user setup) can layer on later.
+
+---
+
+## 1. Problem
+
+Today, connecting a third-party service (Google Drive, Meta, Slack) means the user acts as their
+own OAuth-app developer:
+
+1. Create a project in the provider's dev console, enable APIs, mint a token by hand.
+2. Paste it into the dashboard → `POST /api/credentials` → stored as `OPENLEGION_CRED_<name>`.
+3. Agents later reference it as `$CRED{name}`, resolved by the mesh (`http_tool.py:_resolve_creds`
+   → `mesh_client.vault_resolve` → `CredentialVault.resolve_credential`); the raw secret is never
+   exposed to the agent and is redacted from logs/output.
+
+There is **no OAuth flow** for these providers and **no refresh** — a hand-pasted token that expires
+forces the user to repeat the whole dance.
+
+The irony: `src/host/credentials.py` already implements a **full authorization-code flow with
+refresh + expiry handling** — but only for the OpenAI LLM endpoint
+(`_ensure_openai_oauth_token` → `POST https://auth.openai.com/oauth/token`,
+`grant_type=refresh_token`, 5-min expiry buffer, atomic re-persist). Token storage, refresh,
+expiry, and redaction are solved. What's missing:
+
+- A **callback endpoint** on the mesh host (the code even references the OpenAI redirect URI
+  `http://localhost:1455/auth/callback`, which lives outside this codebase).
+- A **per-provider OAuth client registry** for data providers (not LLM providers).
+- A vault concept for **structured, auto-refreshing connections** that still resolve as
+  `$CRED{...}` bearer tokens.
+
+---
+
+## 2. Design overview
+
+```
+Dashboard  ──Connect──▶  GET /integrations/google/connect
+                              │  build state (CSRF, single-use, TTL, session-bound)
+                              │  build authorize URL (access_type=offline, prompt=consent)
+                              ▼
+                         302 → accounts.google.com consent screen
+                              │  user approves
+                              ▼
+Google  ──redirect──▶  GET /integrations/google/callback?code&state
+                              │  validate state
+                              │  exchange code → {access, refresh, expiry, scopes, email}
+                              │  store as structured connection in vault
+                              ▼
+                         302 → dashboard /#integrations?connected=google
+
+Agent later:  Authorization: Bearer $CRED{google_drive}
+                 └─ vault resolves → ensures fresh token (refresh if near expiry) → bearer
+```
+
+The key elegance: agents keep using `$CRED{google_drive}` exactly as today. The vault transparently
+refreshes the access token on resolve, so connections never go stale and the agent never sees the
+refresh token.
+
+---
+
+## 3. Components
+
+### 3.1 Provider registry — `src/host/oauth_providers.py` (new)
+
+Provider-agnostic, declarative. No user-supplied URLs (SSRF-safe: endpoints are fixed per provider).
+
+```python
+@dataclass(frozen=True)
+class OAuthProvider:
+    key: str                       # "google"
+    label: str                     # "Google"
+    authorize_url: str             # https://accounts.google.com/o/oauth2/v2/auth
+    token_url: str                 # https://oauth2.googleapis.com/token
+    scopes: dict[str, list[str]]   # named scope bundles: drive_ro, gmail_send, calendar, ...
+    extra_authorize_params: dict   # {"access_type": "offline", "prompt": "consent"}
+    userinfo_url: str | None       # for display: which account is connected
+    uses_pkce: bool = True
+```
+
+`GOOGLE` entry ships first. `scopes` lets the operator pick least-privilege bundles
+(e.g. `drive.readonly` vs `drive`). `access_type=offline` + `prompt=consent` are required to
+guarantee Google returns a refresh token.
+
+### 3.2 BYO client credentials (Option B)
+
+The user registers their **own** Google OAuth app once and supplies:
+
+- `OPENLEGION_SYSTEM_GOOGLE_CLIENT_ID`
+- `OPENLEGION_SYSTEM_GOOGLE_CLIENT_SECRET`
+
+Stored **system-tier** (mesh-only, never agent-resolvable, redacted via `deep_redact`). Entered
+through a small "Set up provider" form in the dashboard (writes via the existing system-tier
+`add_credential` path).
+
+The user adds this exact redirect URI to their Google app:
+`https://{their-subdomain}.engine.openlegion.ai/integrations/google/callback`
+
+Requires a new config value `OPENLEGION_PUBLIC_BASE_URL` (the engine's externally reachable origin)
+so the callback URL is built correctly. Document the one-time setup in the dashboard UI.
+
+### 3.3 Structured connections in the vault — `src/host/credentials.py`
+
+Add a `connections: dict[str, dict]` store, mirroring `_openai_oauth`'s shape:
+
+```json
+{
+  "provider": "google",
+  "access_token": "...",
+  "refresh_token": "...",
+  "expires_at": 1733300000,
+  "scopes": ["https://www.googleapis.com/auth/drive.readonly"],
+  "account": "user@example.com"
+}
+```
+
+- `store_connection(name, data)` — persist atomically to `.env` (reuse `_persist_to_env`), keyed
+  e.g. `OPENLEGION_CONN_<NAME>` as a JSON blob (new tier, distinct from CRED/SYSTEM).
+- `ensure_connection_token(name)` — generalize `_ensure_openai_oauth_token`: if within 5-min of
+  `expires_at`, `POST token_url` with `grant_type=refresh_token` + client_id/secret, update + persist.
+- **Resolve path:** when `resolve_credential(name)` hits a connection, return
+  `ensure_connection_token(name)` (a fresh bearer) instead of a static secret. This is what makes
+  `$CRED{google_drive}` "just work" for agents, with auto-refresh, no agent exposure.
+
+Permissioning: connections respect the same `allowed_credentials` glob patterns agents already use,
+so an agent must be granted `google_*` (or similar) to resolve them.
+
+### 3.4 Mesh endpoints — `src/host/server.py`
+
+- `GET /integrations` — list providers + connection status (dashboard-auth gated).
+- `GET /integrations/{provider}/connect?name=&scopes=` — build `state`, redirect (302) to the
+  provider authorize URL. Operator/dashboard-auth gated.
+- `GET /integrations/{provider}/callback?code=&state=` — validate `state`, exchange code, store
+  connection, 302 back to the dashboard. (Reaches the user's browser carrying the `ol_session`
+  cookie, so it passes Caddy `forward_auth`; `state` is the real CSRF guard.)
+- `POST /integrations/{provider}/disconnect` — revoke (best-effort) + delete connection.
+
+`state` store: single-use, TTL-bound (~10 min), bound to the dashboard session and to the requested
+`{name, scopes}`. Persist in SQLite (WAL) or in-memory with TTL — must be validated before any code
+exchange. Reuse the CSRF/`X-Requested-With` conventions already in the dashboard layer.
+
+### 3.5 Dashboard UI — `src/dashboard/server.py` + templates
+
+Turn the credentials panel into an **Integrations** list:
+
+- Per provider: status chip (Connected as `user@…`, scopes, expiry) or **Connect** button.
+- Connect → full-page navigation to `/integrations/google/connect` (returns to dashboard on success).
+- First-run per provider: "Set up your Google app" form (client_id/secret + a copyable redirect URI
+  and a link to the provider console steps).
+- Disconnect button → `POST /integrations/google/disconnect`.
+
+Keep the existing raw paste-a-token path available as an "Advanced / manual" fallback.
+
+---
+
+## 4. Security checklist
+
+- `state`: unguessable, single-use, TTL-bound, session-bound; validated before code exchange.
+- `client_secret` + all tokens: system/connection tier, never agent-resolvable, run through
+  `deep_redact` / `redact_url` in every log + response path.
+- Fixed per-provider endpoints (no user-supplied token/authorize URLs) → no SSRF surface added.
+- PKCE on by default where the provider supports it.
+- Least-privilege scopes: operator selects scope bundles; default to read-only where it exists.
+- Refresh-on-resolve returns only a short-lived access token to the agent; refresh token stays in
+  the vault.
+- Disconnect attempts provider-side revocation, then purges local tokens + `.env` entry.
+
+## 5. Option A readiness (later)
+
+The registry is already provider-agnostic. First-party connectors differ only in:
+
+1. client_id/secret come from **central** config instead of BYO.
+2. The consent dance runs through a **broker in `app/`** (central verified redirect URI), which then
+   pushes the resulting connection into the engine vault via an internal,
+   `x-mesh-internal`-authenticated endpoint.
+
+So: make `store_connection` callable from **both** the local callback (Option B) and an internal
+push endpoint (Option A). No engine rework needed when Option A lands — only Google/Meta app
+verification + the broker.
+
+---
+
+## 6. Work breakdown (Option B, Google)
+
+1. `oauth_providers.py` registry + `GOOGLE` entry + scope bundles.
+2. `credentials.py`: connection store, `store_connection`, `ensure_connection_token`
+   (generalized from `_ensure_openai_oauth_token`), resolve-path hook, `.env` persistence + redaction.
+3. `OPENLEGION_PUBLIC_BASE_URL` config + redirect-URI builder.
+4. `server.py`: `/integrations` list, `/connect`, `/callback`, `/disconnect` + `state` store.
+5. Dashboard: Integrations panel, provider-setup form, connect/disconnect, status display.
+6. Tests: mocked token exchange, state validation (reuse/expiry/forgery), refresh-on-resolve,
+   redaction, permission gating via `allowed_credentials`.
+7. Docs: per-provider setup steps (redirect URI, scopes) surfaced in-UI.
+
+---
+
+## 7. Open questions
+
+- **`state` store backing:** new tiny SQLite table vs in-memory dict with TTL? (Leaning SQLite WAL
+  to match the rest of the host and survive restart mid-flow.)
+- **Connection naming:** auto-name (`google_drive`) vs operator-chosen handle? Auto with override.
+- **Multi-account:** support multiple Google connections (work + personal) under distinct names?
+- **`OPENLEGION_PUBLIC_BASE_URL`:** derive from the SSO subdomain config if one already exists,
+  else require explicit config.

--- a/src/dashboard/server.py
+++ b/src/dashboard/server.py
@@ -793,6 +793,43 @@ def create_dashboard_router(
         if not request.headers.get("X-Requested-With"):
             raise HTTPException(403, "Missing X-Requested-With header")
 
+    # ── OAuth integrations (connect/callback) state + helpers ───────────
+    from src.host.oauth_state import OAuthStateStore
+    _oauth_state_store = OAuthStateStore()
+
+    def _oauth_session_hash(request: Request) -> str:
+        """Bind OAuth state to the caller's dashboard session (cookie hash).
+
+        Mirrors :func:`_conversations_session_id`. Falls back to a dev constant
+        when the ``ol_session`` cookie is absent (single-operator self-hosted).
+        """
+        raw = request.cookies.get("ol_session", "")
+        if not raw:
+            return "dev:operator"
+        return hashlib.sha256(raw.encode()).hexdigest()[:16]
+
+    def _public_base_url(request: Request) -> str:
+        """Externally-reachable origin for building OAuth redirect URIs.
+
+        Prefers ``OPENLEGION_PUBLIC_BASE_URL`` (exact, what the operator
+        registered with the provider); otherwise derives from the forwarded
+        Host/proto Caddy sets. The redirect URI must match byte-for-byte across
+        the authorize call, the token exchange, and the provider registration.
+        """
+        explicit = os.environ.get("OPENLEGION_PUBLIC_BASE_URL", "").strip()
+        if explicit:
+            return explicit.rstrip("/")
+        proto = request.headers.get("x-forwarded-proto") or request.url.scheme
+        host = (
+            request.headers.get("x-forwarded-host")
+            or request.headers.get("host")
+            or request.url.netloc
+        )
+        return f"{proto}://{host}"
+
+    def _oauth_redirect_uri(request: Request, provider_key: str) -> str:
+        return f"{_public_base_url(request)}/dashboard/integrations/{provider_key}/callback"
+
     def _mask_proxy_url(url: str) -> str:
         """Mask credentials in a proxy URL for display."""
         if not url:
@@ -4122,6 +4159,160 @@ def create_dashboard_router(
             raise HTTPException(status_code=404, detail=f"Credential '{name}' not found")
         masked = value[-4:].rjust(len(value), "*") if len(value) > 4 else "****"
         return {"name": name, "value": masked}
+
+    # ── OAuth integrations (one-click Connect) ──────────────
+    #
+    # Bring-your-own-app flow: the operator registers their own OAuth app and
+    # supplies client_id/secret once (POST .../setup, stored system-tier), then
+    # connects via the browser redirect dance. The resulting connection resolves
+    # as ``$CRED{<name>}`` with transparent token refresh — agents never touch
+    # the refresh token. The connect/callback GETs inherit ``_verify_dashboard_auth``
+    # (cookie rides Google's redirect) and are CSRF-exempt as safe methods; the
+    # single-use, session-bound ``state`` is the real CSRF guard.
+
+    @api_router.get("/api/integrations")
+    async def api_list_integrations(request: Request) -> dict:
+        """List providers, whether their client is configured, and connections."""
+        from src.host.oauth_providers import OAUTH_PROVIDERS
+        if credential_vault is None:
+            return {"providers": []}
+        conns_by_provider: dict[str, list] = {}
+        for c in credential_vault.list_connections():
+            conns_by_provider.setdefault(c["provider"], []).append(c)
+        providers = []
+        for key, p in OAUTH_PROVIDERS.items():
+            providers.append({
+                "key": key,
+                "label": p.label,
+                "configured": credential_vault.has_oauth_client(p),
+                "redirect_uri": _oauth_redirect_uri(request, key),
+                "scope_bundles": [
+                    {"key": b.key, "label": b.label, "description": b.description}
+                    for b in p.scope_bundles
+                ],
+                "connections": conns_by_provider.get(key, []),
+            })
+        return {"providers": providers}
+
+    @api_router.post("/api/integrations/{provider}/setup")
+    async def api_setup_integration(provider: str, request: Request) -> dict:
+        """Store the operator's OAuth client id/secret for a provider (system-tier)."""
+        from src.host.oauth_providers import get_provider
+        p = get_provider(provider)
+        if p is None:
+            raise HTTPException(404, f"Unknown provider: {provider}")
+        if credential_vault is None:
+            raise HTTPException(503, "Credential vault not available")
+        body = await request.json()
+        client_id = body.get("client_id", "").strip()
+        client_secret = body.get("client_secret", "").strip()
+        if not client_id or not client_secret:
+            raise HTTPException(400, "client_id and client_secret are required")
+        credential_vault.add_credential(p.client_id_key, client_id, system=True)
+        credential_vault.add_credential(p.client_secret_key, client_secret, system=True)
+        return {
+            "configured": True,
+            "provider": provider,
+            "redirect_uri": _oauth_redirect_uri(request, provider),
+        }
+
+    @api_router.get("/integrations/{provider}/connect")
+    async def integration_connect(
+        provider: str, request: Request, name: str = "", scopes: str = "",
+    ):
+        """Begin the OAuth dance: mint state, redirect to the provider consent."""
+        from fastapi.responses import RedirectResponse
+
+        from src.host.oauth_providers import generate_pkce, get_provider
+        p = get_provider(provider)
+        if p is None:
+            raise HTTPException(404, f"Unknown provider: {provider}")
+        if credential_vault is None:
+            raise HTTPException(503, "Credential vault not available")
+        if not credential_vault.has_oauth_client(p):
+            raise HTTPException(400, f"{p.label} OAuth client not configured")
+        bundle_keys = [s.strip() for s in scopes.split(",") if s.strip()]
+        # Reject unknown bundle keys rather than silently under-scoping a
+        # connection that would then look "connected" but lack data access.
+        unknown = [k for k in bundle_keys if p.bundle(k) is None]
+        if unknown:
+            raise HTTPException(400, f"Unknown scope bundle(s): {', '.join(unknown)}")
+        resolved_scopes = p.resolve_scopes(bundle_keys)
+        conn_name = re.sub(r"[^a-z0-9_]", "_", (name or provider).strip().lower())[:64]
+        conn_name = conn_name.strip("_") or provider
+        verifier, challenge = generate_pkce()
+        redirect_uri = _oauth_redirect_uri(request, provider)
+        state = _oauth_state_store.create(
+            provider=provider,
+            connection_name=conn_name,
+            scopes=tuple(resolved_scopes),
+            code_verifier=verifier,
+            redirect_uri=redirect_uri,
+            session_hash=_oauth_session_hash(request),
+        )
+        url = credential_vault.build_authorize_url(
+            p, redirect_uri=redirect_uri, state=state,
+            scopes=resolved_scopes, code_challenge=challenge,
+        )
+        return RedirectResponse(url, status_code=302)
+
+    @api_router.get("/integrations/{provider}/callback")
+    async def integration_callback(
+        provider: str, request: Request,
+        code: str = "", state: str = "", error: str = "",
+    ):
+        """Provider redirect target: validate state, exchange code, store conn."""
+        from fastapi.responses import RedirectResponse
+
+        from src.host.oauth_providers import get_provider
+        landing = "/dashboard/"
+
+        def _back(params: str):
+            return RedirectResponse(f"{landing}?{params}", status_code=302)
+
+        if error:
+            return _back(f"integration_error={re.sub(r'[^a-zA-Z0-9_-]', '', error)[:64]}")
+        p = get_provider(provider)
+        if p is None or credential_vault is None:
+            return _back("integration_error=unknown_provider")
+        pending = _oauth_state_store.consume(
+            state, session_hash=_oauth_session_hash(request),
+        )
+        if pending is None or pending.provider != provider or not code:
+            return _back("integration_error=invalid_state")
+        try:
+            conn = await credential_vault.exchange_oauth_code(
+                p, code=code, redirect_uri=pending.redirect_uri,
+                code_verifier=pending.code_verifier,
+            )
+            # A connection that needs refresh but came back without a refresh
+            # token would silently die at first expiry — reject it now with a
+            # clear, actionable error instead of storing a dead connection.
+            if p.refresh_required and not conn.get("refresh_token"):
+                logger.warning(
+                    "OAuth callback for %s returned no refresh_token; rejecting",
+                    provider,
+                )
+                return _back("integration_error=no_refresh_token")
+            credential_vault.store_connection(pending.connection_name, conn)
+        except Exception as exc:  # noqa: BLE001 — surface as a UI banner
+            logger.warning("OAuth callback exchange failed for %s: %s", provider, exc)
+            return _back("integration_error=exchange_failed")
+        logger.info(
+            "Integration connected: %s (%s)", pending.connection_name, provider,
+        )
+        return _back(f"integration_connected={pending.connection_name}")
+
+    @api_router.post("/api/integrations/{name}/disconnect")
+    async def api_disconnect_integration(name: str, request: Request) -> dict:
+        """Revoke (best-effort) and remove an OAuth connection."""
+        if credential_vault is None:
+            raise HTTPException(503, "Credential vault not available")
+        await credential_vault.revoke_connection(name)
+        existed = credential_vault.remove_credential(name)
+        if not existed:
+            raise HTTPException(404, f"Connection '{name}' not found")
+        return {"removed": True, "name": name}
 
     # ── External API key management ─────────────────────────
 

--- a/src/dashboard/static/js/app.js
+++ b/src/dashboard/static/js/app.js
@@ -483,7 +483,7 @@ function dashboard() {
       { id: 'costs', label: 'Costs' },
       { id: 'integrations', label: 'Integrations' },
       { id: 'automation', label: 'Automation' },
-      { id: 'apikeys', label: 'API Keys' },
+      { id: 'apikeys', label: 'API Keys & Connections' },
       { id: 'operator', label: 'Operator' },
       { id: 'browser', label: 'Browser' },
       { id: 'wallet', label: 'Wallet' },
@@ -527,6 +527,14 @@ function dashboard() {
     channels: [],
     channelConnectType: '',
     channelTokens: {},
+
+    // OAuth integrations (Google Drive/Gmail/Calendar via bring-your-own-app)
+    integrations: [],                 // [{ key, label, configured, redirect_uri, scope_bundles, connections }]
+    integrationSetup: {},             // { [providerKey]: { client_id, client_secret } } — setup form state
+    integrationSetupSaving: '',       // providerKey currently saving its OAuth client
+    integrationConnectName: {},       // { [providerKey]: connectionName } — defaults to provider key
+    integrationSelectedScopes: {},    // { [providerKey]: { [bundleKey]: bool } } — checkbox state
+    integrationDisconnecting: '',     // connection name currently being disconnected
 
 
     // Webhooks
@@ -866,7 +874,7 @@ function dashboard() {
                 this.fetchChannels(); this.fetchWebhooks(); this.fetchApiKeys();
               }
               if (route.systemTab === 'apikeys') {
-                this.fetchSettings();
+                this.fetchSettings(); this.loadIntegrations();
               }
               if (route.systemTab === 'settings') {
                 this.fetchBrowserSettings();
@@ -1157,6 +1165,10 @@ function dashboard() {
     init() {
       this._initTs = Date.now();  // track page load time to skip replayed events
       const cfg = window.__config || {};
+
+      // Surface the OAuth-integration callback result (?integration_connected /
+      // ?integration_error) as a toast, then scrub the query param.
+      this._handleIntegrationRedirect();
 
       // NOTE: the side panel is no longer restored from the legacy
       // ``ol_messenger_side_panel_open`` flag. Its only writer was the
@@ -2468,6 +2480,10 @@ function dashboard() {
           this.fetchChannels();
           this.fetchApiKeys();
         }
+        if (this.systemTab === 'apikeys') {
+          this.fetchSettings();
+          this.loadIntegrations();
+        }
         if (this.systemTab === 'network') {
           this.loadNetworkProxy();
         }
@@ -2498,7 +2514,7 @@ function dashboard() {
       this.systemTab = tabId;
       this._pushUrl(false);
       if (tabId === 'integrations') { this.fetchChannels(); this.fetchWebhooks(); this.fetchApiKeys(); }
-      if (tabId === 'apikeys') { this.fetchSettings(); }
+      if (tabId === 'apikeys') { this.fetchSettings(); this.loadIntegrations(); }
       if (tabId === 'storage') { this.fetchUploads(); this.fetchStorage(); this.fetchDatabaseDetails(); }
       if (tabId === 'network') { this.loadNetworkProxy(); }
       if (tabId === 'settings') { this.fetchBrowserSettings(); this.fetchSystemSettings(); }
@@ -9221,6 +9237,122 @@ function dashboard() {
         const resp = await fetch(`${window.__config.apiBase}/channels`);
         if (resp.ok) this.channels = (await resp.json()).channels || [];
       } catch (e) { console.warn('fetchChannels failed:', e); }
+    },
+
+    // ── OAuth integrations (Google Drive/Gmail/Calendar) ─────────────
+    // The connect/disconnect endpoints live under ``apiBase`` (/dashboard/api);
+    // the full-page consent redirect lives one level up at /dashboard/integrations.
+    _integrationsBase() {
+      // apiBase is "/dashboard/api" → strip the trailing "/api" for the
+      // browser-redirect connect route which is NOT under /api.
+      return (window.__config.apiBase || '').replace(/\/api$/, '');
+    },
+
+    async loadIntegrations() {
+      try {
+        const resp = await fetch(`${window.__config.apiBase}/integrations`);
+        if (!resp.ok) return;
+        const data = await resp.json();
+        this.integrations = data.providers || [];
+        // Seed per-provider form defaults without clobbering in-flight edits.
+        for (const p of this.integrations) {
+          if (!this.integrationSetup[p.key]) {
+            this.integrationSetup[p.key] = { client_id: '', client_secret: '' };
+          }
+          if (this.integrationConnectName[p.key] === undefined) {
+            this.integrationConnectName[p.key] = p.key;
+          }
+          if (!this.integrationSelectedScopes[p.key]) {
+            this.integrationSelectedScopes[p.key] = {};
+          }
+        }
+      } catch (e) { console.warn('loadIntegrations failed:', e); }
+    },
+
+    async setupIntegration(providerKey) {
+      if (this.integrationSetupSaving) return;
+      const form = this.integrationSetup[providerKey] || {};
+      const clientId = (form.client_id || '').trim();
+      const clientSecret = (form.client_secret || '').trim();
+      if (!clientId || !clientSecret) {
+        this.showToast('Client ID and Client Secret are required');
+        return;
+      }
+      this.integrationSetupSaving = providerKey;
+      try {
+        const resp = await fetch(`${window.__config.apiBase}/integrations/${encodeURIComponent(providerKey)}/setup`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json', 'X-Requested-With': 'XMLHttpRequest' },
+          credentials: 'same-origin',
+          body: JSON.stringify({ client_id: clientId, client_secret: clientSecret }),
+        });
+        if (resp.ok) {
+          this.showToast('OAuth app saved. You can now connect.');
+          this.integrationSetup[providerKey] = { client_id: '', client_secret: '' };
+          await this.loadIntegrations();
+        } else {
+          const err = await resp.json().catch(() => ({}));
+          this.showToast(`Error: ${err.detail || 'Setup failed'}`);
+        }
+      } catch (e) { this.showToast(`Error: ${e.message || e}`); }
+      finally { this.integrationSetupSaving = ''; }
+    },
+
+    connectIntegration(providerKey) {
+      const name = (this.integrationConnectName[providerKey] || providerKey).trim() || providerKey;
+      const selected = this.integrationSelectedScopes[providerKey] || {};
+      const bundles = Object.keys(selected).filter(k => selected[k]);
+      if (!bundles.length) {
+        this.showToast('Select at least one access bundle to connect');
+        return;
+      }
+      const params = new URLSearchParams({ name, scopes: bundles.join(',') });
+      // Full-page navigation — the auth cookie rides Google's redirect back.
+      window.location.href = `${this._integrationsBase()}/integrations/${encodeURIComponent(providerKey)}/connect?${params.toString()}`;
+    },
+
+    async disconnectIntegration(name) {
+      if (this.integrationDisconnecting) return;
+      this.integrationDisconnecting = name;
+      try {
+        const resp = await fetch(`${window.__config.apiBase}/integrations/${encodeURIComponent(name)}/disconnect`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json', 'X-Requested-With': 'XMLHttpRequest' },
+          credentials: 'same-origin',
+          body: '{}',
+        });
+        if (resp.ok) {
+          this.showToast(`Disconnected: ${name}`);
+          await this.loadIntegrations();
+        } else {
+          const err = await resp.json().catch(() => ({}));
+          this.showToast(`Error: ${err.detail || 'Disconnect failed'}`);
+        }
+      } catch (e) { this.showToast(`Error: ${e.message || e}`); }
+      finally { this.integrationDisconnecting = ''; }
+    },
+
+    // Read ?integration_connected / ?integration_error from the OAuth callback
+    // redirect, surface a toast, then scrub the query param so a refresh
+    // doesn't re-toast.
+    _handleIntegrationRedirect() {
+      try {
+        const params = new URLSearchParams(window.location.search);
+        const connected = params.get('integration_connected');
+        const error = params.get('integration_error');
+        if (!connected && !error) return;
+        if (connected) {
+          this.showToast(`Connected: ${connected}`);
+        } else if (error) {
+          const pretty = String(error).replace(/_/g, ' ');
+          this.showToast(`Integration failed: ${pretty}`);
+        }
+        params.delete('integration_connected');
+        params.delete('integration_error');
+        const qs = params.toString();
+        const newUrl = window.location.pathname + (qs ? `?${qs}` : '') + window.location.hash;
+        window.history.replaceState({}, '', newUrl);
+      } catch (e) { /* ignore */ }
     },
 
     _channelFields(type) {

--- a/src/dashboard/templates/index.html
+++ b/src/dashboard/templates/index.html
@@ -5406,6 +5406,110 @@
             <a :href="settingsData.app_url + '/credits'" target="_blank" rel="noopener noreferrer" class="ml-auto text-[11px] text-indigo-400 hover:text-indigo-300 normal-case tracking-normal font-normal">Manage credits &rarr;</a>
           </template>
         </div>
+
+        <!-- Connect a service (Google Drive / Gmail / Calendar via OAuth) -->
+        <div class="text-xs text-gray-400 uppercase tracking-wider mb-3 flex items-center gap-1.5">Connect a service<span class="setting-hint" tabindex="0">?<span class="setting-hint-text">Connect Google (Drive, Gmail, Calendar) with a one-click OAuth flow. Register your own Google Cloud OAuth client once, then connect accounts. Agents resolve the connection by name with transparent token refresh — they never see the tokens.</span></span></div>
+        <div class="grid grid-cols-1 sm:grid-cols-2 gap-4 mb-6 chat-grid">
+          <template x-for="prov in integrations" :key="prov.key">
+            <div class="bg-gray-900 border border-gray-800 rounded-lg p-4">
+              <div class="flex items-center justify-between mb-3">
+                <div class="flex items-center gap-2">
+                  <div class="w-2 h-2 rounded-full" :class="prov.configured ? 'bg-emerald-400' : 'bg-gray-600'"></div>
+                  <span class="text-sm font-medium text-white" x-text="prov.label"></span>
+                </div>
+                <span class="text-[11px] px-1.5 py-0.5 rounded-full" :class="prov.configured ? 'bg-emerald-900/40 text-emerald-400' : 'bg-gray-800 text-gray-400'" x-text="prov.configured ? 'App configured' : 'Not set up'"></span>
+              </div>
+
+              <!-- Setup form: register the operator's OAuth client -->
+              <template x-if="!prov.configured">
+                <div class="space-y-2">
+                  <div class="text-xs text-gray-400 mb-1">Set up your Google app</div>
+                  <div class="rounded-md border border-gray-800 bg-gray-950 px-3 py-2 mb-1">
+                    <div class="text-[11px] text-gray-400 mb-1">Add this as an Authorized redirect URI in your Google Cloud OAuth client.</div>
+                    <div class="flex items-center gap-2">
+                      <code class="text-[11px] text-indigo-300/90 bg-gray-800 px-2 py-1 rounded font-mono flex-1 break-all select-all" x-text="prov.redirect_uri"></code>
+                      <button @click="copyToClipboard(prov.redirect_uri)" class="text-[11px] px-2 py-0.5 rounded bg-gray-800 hover:bg-gray-700 text-gray-400 shrink-0" title="Copy redirect URI">Copy</button>
+                    </div>
+                  </div>
+                  <div>
+                    <label class="block text-xs text-gray-400 mb-1">Client ID</label>
+                    <input type="text" :disabled="integrationSetupSaving === prov.key" x-model="integrationSetup[prov.key].client_id"
+                      placeholder="xxxx.apps.googleusercontent.com"
+                      class="w-full bg-gray-800 border border-gray-700 rounded px-2 py-1 text-xs text-white focus:border-indigo-500 focus:outline-none">
+                  </div>
+                  <div>
+                    <label class="block text-xs text-gray-400 mb-1">Client Secret</label>
+                    <input type="password" :disabled="integrationSetupSaving === prov.key" x-model="integrationSetup[prov.key].client_secret"
+                      placeholder="GOCSPX-..."
+                      class="w-full bg-gray-800 border border-gray-700 rounded px-2 py-1 text-xs text-white focus:border-indigo-500 focus:outline-none">
+                  </div>
+                  <div class="flex pt-1">
+                    <button @click="setupIntegration(prov.key)" :disabled="integrationSetupSaving === prov.key"
+                      class="text-xs px-3 py-1.5 bg-indigo-600 hover:bg-indigo-500 text-white rounded-lg transition-colors inline-flex items-center gap-1.5 disabled:opacity-50">
+                      <svg x-show="integrationSetupSaving === prov.key" x-cloak class="animate-spin h-3 w-3" fill="none" viewBox="0 0 24 24"><circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"/><path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z"/></svg>
+                      <span x-text="integrationSetupSaving === prov.key ? 'Saving...' : 'Save'"></span>
+                    </button>
+                  </div>
+                </div>
+              </template>
+
+              <!-- Connect control + existing connections -->
+              <template x-if="prov.configured">
+                <div class="space-y-3">
+                  <!-- Existing connections -->
+                  <template x-if="(prov.connections || []).length">
+                    <div class="space-y-1">
+                      <template x-for="conn in prov.connections" :key="conn.name">
+                        <div class="flex items-center gap-2 text-xs group bg-gray-950/60 border border-gray-800 rounded-md px-2 py-1.5">
+                          <span class="w-2 h-2 rounded-full bg-emerald-400/70 shrink-0"></span>
+                          <div class="flex-1 min-w-0">
+                            <div class="text-gray-200 font-mono truncate" x-text="conn.account || conn.name"></div>
+                            <div class="text-[11px] text-gray-400 truncate">
+                              <span x-text="conn.name"></span> &middot; <span x-text="(conn.scopes || []).length"></span> scope(s)
+                            </div>
+                          </div>
+                          <button @click="disconnectIntegration(conn.name)" :disabled="integrationDisconnecting === conn.name"
+                            class="text-[11px] px-2 py-0.5 rounded bg-gray-800 hover:bg-red-900/30 text-gray-400 hover:text-red-400 transition-colors shrink-0 disabled:opacity-50"
+                            x-text="integrationDisconnecting === conn.name ? '...' : 'Disconnect'"></button>
+                        </div>
+                      </template>
+                    </div>
+                  </template>
+
+                  <!-- New connection -->
+                  <div class="border-t border-gray-800 pt-3 space-y-2">
+                    <div class="text-xs text-gray-400">Connect an account</div>
+                    <div>
+                      <label class="block text-[11px] text-gray-400 mb-1">Connection name</label>
+                      <input type="text" x-model="integrationConnectName[prov.key]" :placeholder="prov.key"
+                        class="w-full bg-gray-800 border border-gray-700 rounded px-2 py-1 text-xs text-white focus:border-indigo-500 focus:outline-none">
+                    </div>
+                    <div class="space-y-1">
+                      <template x-for="bundle in prov.scope_bundles" :key="bundle.key">
+                        <label class="flex items-start gap-2 text-xs text-gray-300 cursor-pointer select-none">
+                          <input type="checkbox" x-model="integrationSelectedScopes[prov.key][bundle.key]"
+                            class="mt-0.5 rounded border-gray-700 bg-gray-800 text-indigo-500 focus:ring-indigo-500/30">
+                          <span>
+                            <span class="text-gray-200" x-text="bundle.label"></span>
+                            <span class="block text-[11px] text-gray-400 leading-snug" x-text="bundle.description"></span>
+                          </span>
+                        </label>
+                      </template>
+                    </div>
+                    <div class="flex pt-1">
+                      <button @click="connectIntegration(prov.key)"
+                        class="text-xs px-3 py-1.5 bg-indigo-600 hover:bg-indigo-500 text-white rounded-lg transition-colors">
+                        Connect
+                      </button>
+                    </div>
+                  </div>
+                </div>
+              </template>
+            </div>
+          </template>
+        </div>
+        <div x-show="integrations.length === 0" class="text-sm text-gray-400 py-4 mb-6">No connectable services available</div>
+
         <div class="mb-6" x-show="settingsData">
           <div class="bg-gray-900 border border-gray-800 rounded-lg p-4">
             <div class="text-sm text-gray-400 mb-2">

--- a/src/host/credentials.py
+++ b/src/host/credentials.py
@@ -28,6 +28,7 @@ from typing import TYPE_CHECKING
 import httpx
 
 from src.agent.attachments import convert_openai_image_blocks
+from src.host.oauth_providers import get_provider
 from src.host.transcript import sanitize_for_provider
 from src.shared.errors import LLMAuthError, LLMConfigError, LLMTransientError
 from src.shared.models import KEYLESS_PROVIDERS, get_known_provider_names
@@ -216,6 +217,11 @@ def _remove_from_env(env_key: str, env_file: str = "") -> None:
 # ── Prefix constants ───────────────────────────────────────
 SYSTEM_PREFIX = "OPENLEGION_SYSTEM_"
 AGENT_PREFIX = "OPENLEGION_CRED_"
+# Structured OAuth "connections" minted by the integrations connect/callback
+# flow (Google Drive/Gmail/Calendar, etc.). Stored as JSON blobs, one env var
+# per connection. Agent-tier resolvable (subject to ``allowed_credentials``
+# globs) but resolve to a freshly-refreshed access token, never the raw blob.
+CONNECTION_PREFIX = "OPENLEGION_CONN_"
 
 # System credential patterns — used by is_system_credential() for
 # defense-in-depth permission checks and by CLI/dashboard for
@@ -412,6 +418,14 @@ class CredentialVault:
         self._openai_oauth_lock = asyncio.Lock()
         self._anthropic_oauth: dict | None = None
         self._anthropic_oauth_lock = asyncio.Lock()
+        # Structured third-party OAuth connections (integrations connect flow).
+        # ``connections[name]`` = {provider, access_token, refresh_token,
+        # expires_at, scopes, account}. Per-name locks serialize refresh so
+        # concurrent agent resolves don't double-refresh; ``_connection_locks``
+        # itself is guarded by ``_connection_locks_guard``.
+        self.connections: dict[str, dict] = {}
+        self._connection_locks: dict[str, asyncio.Lock] = {}
+        self._connection_locks_guard = asyncio.Lock()
         # ``_auth_failure_recorder`` (Fix 4 in seam follow-up): optional
         # callback ``(agent_id, provider, model, http_status) -> None``
         # invoked when an LLM call raises ``LLMAuthError`` during
@@ -512,6 +526,23 @@ class CredentialVault:
             "OPENLEGION_SYSTEM_ANTHROPIC_OAUTH", "Anthropic",
         )
 
+        # Phase 3: structured OAuth connections (integrations connect flow)
+        self.connections = {}
+        for key, value in os.environ.items():
+            if key.startswith(CONNECTION_PREFIX):
+                conn_name = key[len(CONNECTION_PREFIX):].lower()
+                try:
+                    parsed = json.loads(value)
+                except (json.JSONDecodeError, ValueError):
+                    logger.warning("Failed to parse connection %s: invalid JSON", conn_name)
+                    continue
+                if isinstance(parsed, dict) and parsed.get("access_token"):
+                    self.connections[conn_name] = parsed
+                else:
+                    logger.warning(
+                        "Failed to load connection %s: missing access_token", conn_name,
+                    )
+
         loaded_system = list(self.system_credentials.keys())
         loaded_agent = list(self.credentials.keys())
         if loaded_system:
@@ -553,12 +584,33 @@ class CredentialVault:
 
         System-tier credentials are never returned here — they are only
         accessible internally by the mesh proxy handlers.
+
+        For OAuth connections this returns the *current* (possibly stale)
+        access token without refreshing — sufficient for existence checks and
+        sync callers. Agent-facing resolution goes through
+        :meth:`resolve_credential_async`, which refreshes on demand.
         """
-        return self.credentials.get(name.lower())
+        lower = name.lower()
+        if lower in self.connections:
+            return self.connections[lower].get("access_token")
+        return self.credentials.get(lower)
+
+    async def resolve_credential_async(self, name: str) -> str | None:
+        """Resolve a credential, refreshing OAuth connection tokens on demand.
+
+        This is the agent-facing path (``$CRED{name}`` via ``/mesh/vault/resolve``):
+        a connection resolves to a freshly-refreshed access token so agents
+        never see a stale token and never touch the refresh token.
+        """
+        lower = name.lower()
+        if lower in self.connections:
+            return await self.ensure_connection_token(lower)
+        return self.credentials.get(lower)
 
     def list_credential_names(self) -> list[str]:
         """Return all credential names across both tiers (never values)."""
         combined = set(self.system_credentials.keys()) | set(self.credentials.keys())
+        combined |= set(self.connections.keys())
         if self._openai_oauth is not None:
             combined.add("openai_oauth")
         if self._anthropic_oauth is not None:
@@ -566,12 +618,13 @@ class CredentialVault:
         return sorted(combined)
 
     def list_agent_credential_names(self) -> list[str]:
-        """Return agent-tier credential names only.
+        """Return agent-tier resolvable credential names.
 
-        Since loading already sorts credentials into the correct tier,
-        this simply returns ``credentials`` keys — no filtering needed.
+        Includes both plain agent-tier secrets and OAuth connections — both are
+        resolvable by agents (subject to ``allowed_credentials`` globs) via
+        ``$CRED{name}``.
         """
-        return list(self.credentials.keys())
+        return list(self.credentials.keys()) + list(self.connections.keys())
 
     def list_system_credential_names(self) -> list[str]:
         """Return system-tier credential names only."""
@@ -600,6 +653,13 @@ class CredentialVault:
             if existed:
                 logger.info("Credential removed: anthropic_oauth")
             return existed
+        # OAuth connection removal (integrations connect flow)
+        if cred_key in self.connections:
+            self.connections.pop(cred_key, None)
+            self._connection_locks.pop(cred_key, None)
+            _remove_from_env(f"{CONNECTION_PREFIX}{name.upper()}")
+            logger.info("Connection removed: %s", cred_key)
+            return True
         if cred_key.endswith("_api_base"):
             existed = cred_key in self.api_bases
             self.api_bases.pop(cred_key, None)
@@ -624,7 +684,259 @@ class CredentialVault:
             return True
         if lower == "anthropic_oauth" and self._anthropic_oauth is not None:
             return True
+        if lower in self.connections:
+            return True
         return lower in self.credentials or lower in self.system_credentials
+
+    # ── OAuth integrations (connect/callback flow) ──────────────────────
+    #
+    # ``store_connection`` / ``ensure_connection_token`` generalize the
+    # OpenAI-OAuth refresh machinery (``_ensure_openai_oauth_token``) to
+    # arbitrary third-party data providers. Client id/secret are operator-owned
+    # (system-tier); agents only ever see a short-lived access token.
+
+    _CONNECTION_NAME_RE = re.compile(r"^[a-z0-9_]{1,64}$")
+
+    def has_oauth_client(self, provider) -> bool:
+        """True if the operator has configured client id+secret for *provider*."""
+        return bool(
+            self.system_credentials.get(provider.client_id_key)
+            and self.system_credentials.get(provider.client_secret_key)
+        )
+
+    def build_authorize_url(
+        self, provider, *, redirect_uri: str, state: str,
+        scopes: list[str], code_challenge: str | None = None,
+    ) -> str:
+        """Build the provider authorize URL for the consent redirect."""
+        from urllib.parse import urlencode
+        params = {
+            "client_id": self.system_credentials.get(provider.client_id_key, ""),
+            "redirect_uri": redirect_uri,
+            "response_type": "code",
+            "scope": " ".join(scopes),
+            "state": state,
+        }
+        params.update(provider.extra_authorize_params)
+        if provider.uses_pkce and code_challenge:
+            params["code_challenge"] = code_challenge
+            params["code_challenge_method"] = "S256"
+        return f"{provider.authorize_url}?{urlencode(params)}"
+
+    async def exchange_oauth_code(
+        self, provider, *, code: str, redirect_uri: str,
+        code_verifier: str | None = None,
+    ) -> dict:
+        """Exchange an authorization code for tokens. Returns a connection dict.
+
+        Does NOT persist — the caller stores via :meth:`store_connection` so the
+        connection name is decided at the dashboard layer. Raises ``RuntimeError``
+        on a failed exchange (error text is truncated; tokens never logged).
+        """
+        client_id = self.system_credentials.get(provider.client_id_key, "")
+        client_secret = self.system_credentials.get(provider.client_secret_key, "")
+        if not client_id or not client_secret:
+            raise RuntimeError(f"No OAuth client configured for {provider.key}")
+        data = {
+            "grant_type": "authorization_code",
+            "code": code,
+            "client_id": client_id,
+            "client_secret": client_secret,
+            "redirect_uri": redirect_uri,
+        }
+        if code_verifier:
+            data["code_verifier"] = code_verifier
+        client = await self._get_http_client()
+        try:
+            resp = await client.post(
+                provider.token_url, data=data,
+                headers={"Content-Type": "application/x-www-form-urlencoded"},
+                timeout=30,
+            )
+        except (httpx.TimeoutException, httpx.ConnectError) as exc:
+            raise RuntimeError(f"{provider.key} token exchange failed: {exc}") from exc
+        if not resp.is_success:
+            raise RuntimeError(
+                f"{provider.key} token exchange failed "
+                f"(HTTP {resp.status_code}): {resp.text[:200]}"
+            )
+        payload = resp.json()
+        access = payload.get("access_token", "")
+        if not access:
+            raise RuntimeError(f"{provider.key} token exchange returned no access_token")
+        expires_in = int(payload.get("expires_in", 3600))
+        scope_str = payload.get("scope", "")
+        account = await self._fetch_oauth_account(provider, access)
+        return {
+            "provider": provider.key,
+            "access_token": access,
+            "refresh_token": payload.get("refresh_token", ""),
+            "expires_at": int(time.time()) + expires_in,
+            "scopes": scope_str.split() if scope_str else [],
+            "account": account,
+        }
+
+    async def _fetch_oauth_account(self, provider, access_token: str) -> str:
+        """Best-effort: which account did the user connect (for display only)."""
+        if not provider.userinfo_url:
+            return ""
+        try:
+            client = await self._get_http_client()
+            resp = await client.get(
+                provider.userinfo_url,
+                headers={"Authorization": f"Bearer {access_token}"},
+                timeout=15,
+            )
+            if resp.is_success:
+                return str(resp.json().get(provider.userinfo_email_field, ""))
+        except Exception as exc:  # noqa: BLE001 — display-only, never fatal
+            logger.debug("userinfo fetch failed for %s: %s", provider.key, exc)
+        return ""
+
+    def store_connection(self, name: str, data: dict) -> str:
+        """Persist an OAuth connection (JSON blob) and return its $CRED handle.
+
+        Goes through the JSON env path rather than ``add_credential`` (which
+        strips whitespace and would corrupt the blob). Name must be a safe
+        env-key segment.
+        """
+        name = name.lower()
+        if not self._CONNECTION_NAME_RE.match(name):
+            raise ValueError(
+                "Connection name must be 1-64 chars of [a-z0-9_]",
+            )
+        if not data.get("access_token"):
+            raise ValueError("connection requires access_token")
+        self.connections[name] = data
+        _persist_to_env(f"{CONNECTION_PREFIX}{name.upper()}", json.dumps(data))
+        logger.info("Connection stored: %s (%s)", name, data.get("provider", ""))
+        return f"$CRED{{{name}}}"
+
+    async def _get_connection_lock(self, name: str) -> asyncio.Lock:
+        async with self._connection_locks_guard:
+            lock = self._connection_locks.get(name)
+            if lock is None:
+                lock = asyncio.Lock()
+                self._connection_locks[name] = lock
+            return lock
+
+    async def ensure_connection_token(self, name: str) -> str:
+        """Return a valid access token for a connection, refreshing if needed.
+
+        Generalizes ``_ensure_openai_oauth_token``: 5-minute expiry buffer,
+        per-name lock with double-check. If the provider issued no refresh
+        token (offline access not granted, or a long-lived token), returns the
+        current token — a 401 then surfaces naturally to the agent rather than
+        failing the resolve.
+        """
+        name = name.lower()
+        conn = self.connections.get(name)
+        if conn is None:
+            raise RuntimeError(f"No connection: {name}")
+        now = int(time.time())
+        if conn.get("expires_at", 0) > now + 300:
+            return conn["access_token"]
+
+        lock = await self._get_connection_lock(name)
+        async with lock:
+            conn = self.connections.get(name)
+            if conn is None:
+                raise RuntimeError(f"No connection: {name}")
+            now = int(time.time())
+            if conn.get("expires_at", 0) > now + 300:
+                return conn["access_token"]
+            refresh_token = conn.get("refresh_token", "")
+            if not refresh_token:
+                return conn["access_token"]
+            provider = get_provider(conn.get("provider", ""))
+            if provider is None:
+                return conn["access_token"]
+            client_id = self.system_credentials.get(provider.client_id_key, "")
+            client_secret = self.system_credentials.get(provider.client_secret_key, "")
+            if not client_id or not client_secret:
+                return conn["access_token"]
+            client = await self._get_http_client()
+            try:
+                resp = await client.post(
+                    provider.token_url,
+                    data={
+                        "grant_type": "refresh_token",
+                        "client_id": client_id,
+                        "client_secret": client_secret,
+                        "refresh_token": refresh_token,
+                    },
+                    headers={"Content-Type": "application/x-www-form-urlencoded"},
+                    timeout=30,
+                )
+            except (httpx.TimeoutException, httpx.ConnectError) as exc:
+                raise RuntimeError(
+                    f"{provider.key} token refresh request failed: {exc}",
+                ) from exc
+            if not resp.is_success:
+                raise RuntimeError(
+                    f"{provider.key} token refresh failed "
+                    f"(HTTP {resp.status_code}): {resp.text[:200]}"
+                )
+            payload = resp.json()
+            new_access = payload.get("access_token", "")
+            if not new_access:
+                raise RuntimeError(f"{provider.key} refresh returned no access_token")
+            expires_in = int(payload.get("expires_in", 3600))
+            updated = dict(conn)
+            updated["access_token"] = new_access
+            # Most providers (Google) do NOT re-issue a refresh token on
+            # refresh — keep the existing one unless a new one is returned.
+            updated["refresh_token"] = payload.get("refresh_token", refresh_token)
+            updated["expires_at"] = int(time.time()) + expires_in
+            # If the connection was disconnected while this refresh was in
+            # flight (remove_credential pops it without taking this lock), do
+            # NOT resurrect it: hand the token to the current caller but neither
+            # re-store nor re-persist it.
+            if name not in self.connections:
+                logger.info(
+                    "Connection %s removed during refresh; not persisting", name,
+                )
+                return new_access
+            self.connections[name] = updated
+            _persist_to_env(
+                f"{CONNECTION_PREFIX}{name.upper()}", json.dumps(updated),
+            )
+            logger.info("Connection token refreshed: %s", name)
+            return new_access
+
+    def list_connections(self) -> list[dict]:
+        """Return display metadata for all connections (never tokens)."""
+        return [
+            {
+                "name": name,
+                "provider": conn.get("provider", ""),
+                "account": conn.get("account", ""),
+                "scopes": conn.get("scopes", []),
+                "expires_at": conn.get("expires_at", 0),
+            }
+            for name, conn in sorted(self.connections.items())
+        ]
+
+    async def revoke_connection(self, name: str) -> None:
+        """Best-effort provider-side token revocation. Never raises."""
+        conn = self.connections.get(name.lower())
+        if not conn:
+            return
+        provider = get_provider(conn.get("provider", ""))
+        if provider is None or not provider.revoke_url:
+            return
+        token = conn.get("refresh_token") or conn.get("access_token")
+        if not token:
+            return
+        try:
+            client = await self._get_http_client()
+            await client.post(
+                provider.revoke_url, data={"token": token},
+                headers={"Content-Type": "application/x-www-form-urlencoded"},
+                timeout=15,
+            )
+        except Exception as exc:  # noqa: BLE001 — best-effort, never fatal
+            logger.debug("Revoke failed for %s: %s", name, exc)
 
     def _register_handlers(self) -> None:
         """Register API call handlers for each supported service."""

--- a/src/host/oauth_providers.py
+++ b/src/host/oauth_providers.py
@@ -1,0 +1,183 @@
+"""OAuth provider registry for one-click third-party "Connect" integrations.
+
+Declarative, provider-agnostic configuration for the authorization-code flow
+that backs in-engine integrations (Google Drive / Gmail / Calendar first).
+Provider endpoints are fixed here — never user-supplied — so the connect /
+callback flow adds no SSRF surface.
+
+Bring-your-own-app model (Option B): the operator registers their own OAuth
+app with the provider and supplies the client_id / client_secret as
+system-tier credentials (``OPENLEGION_SYSTEM_<PROVIDER>_CLIENT_ID`` /
+``_CLIENT_SECRET``). The engine performs the code exchange and token refresh;
+agents only ever see a short-lived access token via ``$CRED{<connection>}``.
+
+The registry is deliberately broker-ready (Option A): first-party connectors
+differ only in where the client credentials come from and who runs the consent
+dance — the provider table below is unchanged.
+"""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import secrets
+from dataclasses import dataclass, field
+
+
+@dataclass(frozen=True)
+class ScopeBundle:
+    """A named, least-privilege bundle of provider scopes the operator can pick."""
+
+    key: str
+    label: str
+    scopes: tuple[str, ...]
+    description: str = ""
+
+
+@dataclass(frozen=True)
+class OAuthProvider:
+    """Fixed configuration for a single OAuth provider."""
+
+    key: str
+    label: str
+    authorize_url: str
+    token_url: str
+    scope_bundles: tuple[ScopeBundle, ...]
+    # Scopes always requested (e.g. for account/email display). Merged with
+    # whatever bundles the operator selects.
+    base_scopes: tuple[str, ...] = ()
+    # Extra query params appended to the authorize URL. For Google these force
+    # a refresh token to be issued (``access_type=offline`` + ``prompt=consent``).
+    extra_authorize_params: dict[str, str] = field(default_factory=dict)
+    # Best-effort account display (which account did the user connect).
+    userinfo_url: str | None = None
+    userinfo_email_field: str = "email"
+    # Best-effort token revocation on disconnect.
+    revoke_url: str | None = None
+    uses_pkce: bool = True
+    # True when this provider's access tokens expire AND a refresh token is
+    # required to keep the connection alive (Google). The callback rejects a
+    # connection that comes back without a refresh token rather than storing one
+    # that silently dies at first expiry. Set False for providers whose tokens
+    # don't expire / need no refresh (e.g. Notion).
+    refresh_required: bool = True
+
+    @property
+    def client_id_key(self) -> str:
+        """System-tier credential name holding the operator's OAuth client id."""
+        return f"{self.key}_client_id"
+
+    @property
+    def client_secret_key(self) -> str:
+        """System-tier credential name holding the operator's OAuth client secret."""
+        return f"{self.key}_client_secret"
+
+    def bundle(self, key: str) -> ScopeBundle | None:
+        for b in self.scope_bundles:
+            if b.key == key:
+                return b
+        return None
+
+    def resolve_scopes(self, bundle_keys: list[str]) -> list[str]:
+        """Merge base scopes with the requested bundles, de-duplicated, ordered.
+
+        Unknown bundle keys are ignored (callers validate separately if they
+        want to reject them). Always includes ``base_scopes`` so account
+        display keeps working regardless of which data bundles were chosen.
+        """
+        out: list[str] = list(self.base_scopes)
+        for key in bundle_keys:
+            b = self.bundle(key)
+            if b is None:
+                continue
+            for s in b.scopes:
+                if s not in out:
+                    out.append(s)
+        # Drop any accidental dupes from base_scopes overlap, preserve order.
+        seen: set[str] = set()
+        ordered: list[str] = []
+        for s in out:
+            if s not in seen:
+                seen.add(s)
+                ordered.append(s)
+        return ordered
+
+
+GOOGLE = OAuthProvider(
+    key="google",
+    label="Google",
+    authorize_url="https://accounts.google.com/o/oauth2/v2/auth",
+    token_url="https://oauth2.googleapis.com/token",
+    base_scopes=("openid", "email"),
+    extra_authorize_params={
+        # ``offline`` + ``consent`` are both required for Google to return a
+        # refresh token (and to re-issue one on re-consent). Without them the
+        # connection silently can't be refreshed and dies at first expiry.
+        "access_type": "offline",
+        "prompt": "consent",
+        "include_granted_scopes": "true",
+    },
+    userinfo_url="https://www.googleapis.com/oauth2/v2/userinfo",
+    revoke_url="https://oauth2.googleapis.com/revoke",
+    uses_pkce=True,
+    scope_bundles=(
+        ScopeBundle(
+            key="drive_readonly",
+            label="Drive (read-only)",
+            scopes=("https://www.googleapis.com/auth/drive.readonly",),
+            description="Read files and folders in Google Drive.",
+        ),
+        ScopeBundle(
+            key="drive_file",
+            label="Drive (files created by app)",
+            scopes=("https://www.googleapis.com/auth/drive.file",),
+            description="Read/write only the files this app creates or opens.",
+        ),
+        ScopeBundle(
+            key="gmail_readonly",
+            label="Gmail (read-only)",
+            scopes=("https://www.googleapis.com/auth/gmail.readonly",),
+            description="Read Gmail messages and metadata.",
+        ),
+        ScopeBundle(
+            key="gmail_send",
+            label="Gmail (send)",
+            scopes=("https://www.googleapis.com/auth/gmail.send",),
+            description="Send mail as the connected account.",
+        ),
+        ScopeBundle(
+            key="calendar_readonly",
+            label="Calendar (read-only)",
+            scopes=("https://www.googleapis.com/auth/calendar.readonly",),
+            description="Read calendars and events.",
+        ),
+        ScopeBundle(
+            key="calendar",
+            label="Calendar (read/write)",
+            scopes=("https://www.googleapis.com/auth/calendar",),
+            description="Read and write calendars and events.",
+        ),
+    ),
+)
+
+
+OAUTH_PROVIDERS: dict[str, OAuthProvider] = {
+    GOOGLE.key: GOOGLE,
+}
+
+
+def get_provider(key: str) -> OAuthProvider | None:
+    return OAUTH_PROVIDERS.get((key or "").lower())
+
+
+def generate_pkce() -> tuple[str, str]:
+    """Return ``(code_verifier, code_challenge)`` for PKCE S256.
+
+    ``code_verifier`` is a high-entropy URL-safe string (43–128 chars per
+    RFC 7636); ``code_challenge`` is the base64url-encoded SHA-256 of it with
+    padding stripped.
+    """
+    verifier = secrets.token_urlsafe(64)[:128]
+    digest = hashlib.sha256(verifier.encode("ascii")).digest()
+    challenge = base64.urlsafe_b64encode(digest).rstrip(b"=").decode("ascii")
+    return verifier, challenge

--- a/src/host/oauth_state.py
+++ b/src/host/oauth_state.py
@@ -1,0 +1,102 @@
+"""Single-use, TTL-bound OAuth state store for the connect/callback dance.
+
+The ``state`` parameter is the CSRF guard for the OAuth redirect flow. Each
+entry is:
+
+* unguessable — ``secrets.token_urlsafe`` (256 bits),
+* single-use — consumed on first read,
+* TTL-bound — default 10 minutes,
+* session-bound — tied to a hash of the caller's dashboard session cookie so a
+  state minted in one browser can't be redeemed from another.
+
+In-memory by design. A process restart mid-flow simply means the user re-clicks
+"Connect" (the whole dance lasts seconds). This is NOT a module-level global —
+one instance is created per dashboard router and closed over, so it carries no
+cross-process or cross-test leakage (cf. CLAUDE.md constraint #8).
+"""
+
+from __future__ import annotations
+
+import secrets
+import threading
+import time
+from dataclasses import dataclass
+
+
+@dataclass
+class PendingAuth:
+    provider: str
+    connection_name: str
+    scopes: tuple[str, ...]
+    code_verifier: str
+    redirect_uri: str
+    session_hash: str
+    expires_at: float
+
+
+class OAuthStateStore:
+    def __init__(self, ttl_seconds: int = 600, max_entries: int = 512) -> None:
+        self._ttl = ttl_seconds
+        self._max = max_entries
+        self._lock = threading.Lock()
+        self._pending: dict[str, PendingAuth] = {}
+
+    def create(
+        self,
+        *,
+        provider: str,
+        connection_name: str,
+        scopes: tuple[str, ...],
+        code_verifier: str,
+        redirect_uri: str,
+        session_hash: str,
+        now: float | None = None,
+    ) -> str:
+        """Mint a new state token and record the pending auth. Returns the token."""
+        ts = time.time() if now is None else now
+        state = secrets.token_urlsafe(32)
+        entry = PendingAuth(
+            provider=provider,
+            connection_name=connection_name,
+            scopes=tuple(scopes),
+            code_verifier=code_verifier,
+            redirect_uri=redirect_uri,
+            session_hash=session_hash,
+            expires_at=ts + self._ttl,
+        )
+        with self._lock:
+            self._reap(ts)
+            # Bound memory: if somehow over cap, drop the soonest-to-expire.
+            if len(self._pending) >= self._max:
+                oldest = min(self._pending, key=lambda k: self._pending[k].expires_at)
+                self._pending.pop(oldest, None)
+            self._pending[state] = entry
+        return state
+
+    def consume(
+        self, state: str, *, session_hash: str, now: float | None = None,
+    ) -> PendingAuth | None:
+        """Validate + remove a state token.
+
+        Returns the :class:`PendingAuth` only if the token exists, has not
+        expired, and the session hash matches. Always single-use: the token is
+        removed whether or not validation succeeds (so a leaked/expired token
+        can't be retried). Returns ``None`` on any failure.
+        """
+        ts = time.time() if now is None else now
+        with self._lock:
+            entry = self._pending.pop(state, None)
+            self._reap(ts)
+        if entry is None:
+            return None
+        if entry.expires_at < ts:
+            return None
+        if not secrets.compare_digest(entry.session_hash, session_hash):
+            return None
+        return entry
+
+    def _reap(self, ts: float) -> None:
+        """Drop expired entries. Caller holds the lock."""
+        expired = [k for k, v in self._pending.items() if v.expires_at < ts]
+        for k in expired:
+            self._pending.pop(k, None)

--- a/src/host/server.py
+++ b/src/host/server.py
@@ -2271,7 +2271,14 @@ def create_mesh_app(
             extra={"extra_data": {"agent_id": agent_id, "credential": name}},
         )
 
-        value = credential_vault.resolve_credential(name)
+        # Async resolve so OAuth "connections" refresh their access token on
+        # demand (agents see a fresh bearer, never the refresh token). Plain
+        # credentials fall through to the in-memory lookup.
+        try:
+            value = await credential_vault.resolve_credential_async(name)
+        except Exception as exc:  # noqa: BLE001 — surface refresh failures as 502
+            logger.warning("Credential resolve failed for %s: %s", name, exc)
+            raise HTTPException(502, f"Credential resolve failed: {name}") from exc
         if value is None:
             raise HTTPException(404, f"Credential not found: {name}")
         return {"name": name, "value": value}

--- a/tests/test_oauth_integrations.py
+++ b/tests/test_oauth_integrations.py
@@ -1,0 +1,405 @@
+"""Tests for the OAuth "Connect" integrations flow.
+
+Covers the vault connection store (load/store/remove/list), refresh-on-resolve
+(the load-bearing seam that lets ``$CRED{google_drive}`` auto-refresh), the
+authorize-URL builder, code exchange, and the single-use/session-bound OAuth
+state store. HTTP is mocked — no network.
+"""
+
+from __future__ import annotations
+
+import json
+import time
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+import src.host.credentials as cred_mod
+from src.host.credentials import CONNECTION_PREFIX, CredentialVault
+from src.host.oauth_providers import GOOGLE, generate_pkce, get_provider
+from src.host.oauth_state import OAuthStateStore
+
+
+@pytest.fixture
+def captured_env(monkeypatch):
+    """Capture _persist/_remove env writes instead of touching the real .env."""
+    store: dict[str, str] = {}
+    monkeypatch.setattr(
+        cred_mod, "_persist_to_env",
+        lambda k, val, **kw: store.__setitem__(k, val),
+    )
+    monkeypatch.setattr(
+        cred_mod, "_remove_from_env",
+        lambda k, **kw: store.pop(k, None),
+    )
+    return store
+
+
+def _fake_response(*, status=200, payload=None, text=""):
+    resp = AsyncMock()
+    resp.is_success = 200 <= status < 300
+    resp.status_code = status
+    resp.json = lambda: (payload or {})
+    resp.text = text
+    return resp
+
+
+def _vault_with_fake_http(*, post=None, get=None) -> CredentialVault:
+    v = CredentialVault()
+    fake = AsyncMock()
+    fake.is_closed = False
+    if post is not None:
+        fake.post = post
+    if get is not None:
+        fake.get = get
+    v._http_client = fake
+    return v
+
+
+# ── Provider registry ────────────────────────────────────────────────────
+
+def test_google_provider_registered():
+    p = get_provider("google")
+    assert p is GOOGLE
+    assert p.client_id_key == "google_client_id"
+    assert p.client_secret_key == "google_client_secret"
+    # offline+consent are required for a refresh token to be issued
+    assert p.extra_authorize_params.get("access_type") == "offline"
+    assert p.extra_authorize_params.get("prompt") == "consent"
+
+
+def test_resolve_scopes_merges_base_and_dedupes():
+    p = get_provider("google")
+    scopes = p.resolve_scopes(["drive_readonly", "drive_readonly", "gmail_send"])
+    assert scopes[:2] == ["openid", "email"]
+    assert "https://www.googleapis.com/auth/drive.readonly" in scopes
+    assert "https://www.googleapis.com/auth/gmail.send" in scopes
+    # no duplicates
+    assert len(scopes) == len(set(scopes))
+
+
+def test_unknown_provider_is_none():
+    assert get_provider("dropbox") is None
+    assert get_provider("") is None
+
+
+def test_generate_pkce_shape():
+    verifier, challenge = generate_pkce()
+    assert 43 <= len(verifier) <= 128
+    assert "=" not in challenge  # base64url, padding stripped
+
+
+# ── Connection store: load / store / resolve / remove ────────────────────
+
+def test_connection_loads_from_env(monkeypatch):
+    blob = json.dumps({
+        "provider": "google", "access_token": "at-1",
+        "refresh_token": "rt-1", "expires_at": 9999999999,
+        "scopes": ["s"], "account": "u@e.com",
+    })
+    monkeypatch.setenv(f"{CONNECTION_PREFIX}GOOGLE_DRIVE", blob)
+    v = CredentialVault()
+    assert "google_drive" in v.connections
+    assert v.has_credential("google_drive")
+    # sync resolve returns current access token (existence checks, etc.)
+    assert v.resolve_credential("google_drive") == "at-1"
+    # connections are agent-resolvable handles
+    assert "google_drive" in v.list_agent_credential_names()
+
+
+def test_connection_invalid_json_skipped(monkeypatch):
+    monkeypatch.setenv(f"{CONNECTION_PREFIX}BROKEN", "{not json")
+    monkeypatch.setenv(f"{CONNECTION_PREFIX}NOTOKEN", json.dumps({"provider": "google"}))
+    v = CredentialVault()
+    assert "broken" not in v.connections
+    assert "notoken" not in v.connections
+
+
+def test_store_connection_roundtrip(captured_env):
+    v = CredentialVault()
+    handle = v.store_connection("google_drive", {
+        "provider": "google", "access_token": "at", "refresh_token": "rt",
+        "expires_at": 9999999999, "scopes": [], "account": "a@b.com",
+    })
+    assert handle == "$CRED{google_drive}"
+    assert f"{CONNECTION_PREFIX}GOOGLE_DRIVE" in captured_env
+    assert v.connections["google_drive"]["access_token"] == "at"
+
+
+def test_store_connection_rejects_bad_name(captured_env):
+    v = CredentialVault()
+    with pytest.raises(ValueError):
+        v.store_connection("bad name!", {"access_token": "x"})
+    with pytest.raises(ValueError):
+        v.store_connection("google", {"refresh_token": "x"})  # no access_token
+
+
+def test_list_connections_excludes_tokens(monkeypatch):
+    monkeypatch.setenv(f"{CONNECTION_PREFIX}G", json.dumps({
+        "provider": "google", "access_token": "secret-at",
+        "refresh_token": "secret-rt", "expires_at": 123,
+        "scopes": ["x"], "account": "u@e.com",
+    }))
+    v = CredentialVault()
+    listed = v.list_connections()
+    assert listed == [{
+        "name": "g", "provider": "google", "account": "u@e.com",
+        "scopes": ["x"], "expires_at": 123,
+    }]
+    flat = json.dumps(listed)
+    assert "secret-at" not in flat and "secret-rt" not in flat
+
+
+def test_remove_connection(captured_env, monkeypatch):
+    monkeypatch.setenv(f"{CONNECTION_PREFIX}G", json.dumps({
+        "provider": "google", "access_token": "at",
+    }))
+    v = CredentialVault()
+    assert v.remove_credential("g") is True
+    assert "g" not in v.connections
+    assert v.remove_credential("g") is False  # idempotent
+
+
+# ── Refresh-on-resolve (the load-bearing seam) ───────────────────────────
+
+@pytest.mark.asyncio
+async def test_resolve_async_no_refresh_when_fresh():
+    post = AsyncMock()
+    v = _vault_with_fake_http(post=post)
+    v.connections["g"] = {
+        "provider": "google", "access_token": "fresh",
+        "refresh_token": "rt", "expires_at": int(time.time()) + 3600,
+    }
+    assert await v.resolve_credential_async("g") == "fresh"
+    post.assert_not_awaited()  # no network when token is valid
+
+
+@pytest.mark.asyncio
+async def test_resolve_async_refreshes_when_expired(captured_env):
+    post = AsyncMock(return_value=_fake_response(payload={
+        "access_token": "new-at", "expires_in": 3600,
+        # Google does NOT re-issue a refresh token on refresh
+    }))
+    v = _vault_with_fake_http(post=post)
+    v.system_credentials["google_client_id"] = "cid"
+    v.system_credentials["google_client_secret"] = "csec"
+    v.connections["g"] = {
+        "provider": "google", "access_token": "old-at",
+        "refresh_token": "rt-keep", "expires_at": int(time.time()) - 10,
+    }
+    token = await v.resolve_credential_async("g")
+    assert token == "new-at"
+    post.assert_awaited_once()
+    # refresh_token preserved (not blanked), expiry advanced, persisted
+    assert v.connections["g"]["refresh_token"] == "rt-keep"
+    assert v.connections["g"]["expires_at"] > int(time.time()) + 3000
+    assert f"{CONNECTION_PREFIX}G" in captured_env
+
+
+@pytest.mark.asyncio
+async def test_resolve_async_no_refresh_token_returns_current():
+    post = AsyncMock()
+    v = _vault_with_fake_http(post=post)
+    v.connections["g"] = {
+        "provider": "google", "access_token": "stale",
+        "refresh_token": "", "expires_at": int(time.time()) - 10,
+    }
+    # No refresh token: return current token, don't crash, don't call network
+    assert await v.resolve_credential_async("g") == "stale"
+    post.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_resolve_async_refresh_http_error_raises(captured_env):
+    post = AsyncMock(return_value=_fake_response(status=400, text="bad_grant"))
+    v = _vault_with_fake_http(post=post)
+    v.system_credentials["google_client_id"] = "cid"
+    v.system_credentials["google_client_secret"] = "csec"
+    v.connections["g"] = {
+        "provider": "google", "access_token": "old",
+        "refresh_token": "rt", "expires_at": int(time.time()) - 10,
+    }
+    with pytest.raises(RuntimeError):
+        await v.resolve_credential_async("g")
+
+
+@pytest.mark.asyncio
+async def test_refresh_does_not_resurrect_disconnected_connection(captured_env):
+    """If the operator disconnects mid-refresh, the refresh must not re-store it."""
+    v = CredentialVault()
+    v.system_credentials["google_client_id"] = "cid"
+    v.system_credentials["google_client_secret"] = "csec"
+    v.connections["g"] = {
+        "provider": "google", "access_token": "old",
+        "refresh_token": "rt", "expires_at": int(time.time()) - 10,
+    }
+
+    async def _post(*a, **k):
+        v.connections.pop("g", None)  # simulate disconnect during refresh
+        return _fake_response(payload={"access_token": "new-at", "expires_in": 3600})
+
+    fake = AsyncMock()
+    fake.is_closed = False
+    fake.post = AsyncMock(side_effect=_post)
+    v._http_client = fake
+
+    token = await v.ensure_connection_token("g")
+    assert token == "new-at"            # caller still gets the token
+    assert "g" not in v.connections      # but it is NOT resurrected
+
+
+@pytest.mark.asyncio
+async def test_plain_credential_unaffected_by_async_resolve():
+    v = _vault_with_fake_http(post=AsyncMock())
+    v.credentials["github_token"] = "ghp_x"
+    assert await v.resolve_credential_async("github_token") == "ghp_x"
+    assert await v.resolve_credential_async("missing") is None
+
+
+# ── Authorize URL + code exchange ────────────────────────────────────────
+
+def test_has_oauth_client():
+    v = CredentialVault()
+    p = get_provider("google")
+    assert v.has_oauth_client(p) is False
+    v.system_credentials["google_client_id"] = "cid"
+    v.system_credentials["google_client_secret"] = "csec"
+    assert v.has_oauth_client(p) is True
+
+
+def test_build_authorize_url():
+    v = CredentialVault()
+    v.system_credentials["google_client_id"] = "cid-123"
+    p = get_provider("google")
+    url = v.build_authorize_url(
+        p, redirect_uri="https://x.test/dashboard/integrations/google/callback",
+        state="st-abc", scopes=["openid", "email"], code_challenge="chal",
+    )
+    assert url.startswith("https://accounts.google.com/o/oauth2/v2/auth?")
+    assert "client_id=cid-123" in url
+    assert "state=st-abc" in url
+    assert "code_challenge=chal" in url
+    assert "code_challenge_method=S256" in url
+    assert "access_type=offline" in url
+    assert "scope=openid+email" in url
+
+
+@pytest.mark.asyncio
+async def test_exchange_oauth_code(captured_env):
+    post = AsyncMock(return_value=_fake_response(payload={
+        "access_token": "at-x", "refresh_token": "rt-x",
+        "expires_in": 1800, "scope": "openid email scope.a",
+    }))
+    get = AsyncMock(return_value=_fake_response(payload={"email": "user@example.com"}))
+    v = _vault_with_fake_http(post=post, get=get)
+    v.system_credentials["google_client_id"] = "cid"
+    v.system_credentials["google_client_secret"] = "csec"
+    p = get_provider("google")
+    conn = await v.exchange_oauth_code(
+        p, code="auth-code", redirect_uri="https://x/cb", code_verifier="ver",
+    )
+    assert conn["provider"] == "google"
+    assert conn["access_token"] == "at-x"
+    assert conn["refresh_token"] == "rt-x"
+    assert conn["scopes"] == ["openid", "email", "scope.a"]
+    assert conn["account"] == "user@example.com"
+    assert conn["expires_at"] > int(time.time()) + 1700
+    # PKCE verifier forwarded in the token request body
+    _, kwargs = post.call_args
+    assert kwargs["data"]["code_verifier"] == "ver"
+    assert kwargs["data"]["grant_type"] == "authorization_code"
+
+
+@pytest.mark.asyncio
+async def test_exchange_oauth_code_no_client_raises():
+    v = _vault_with_fake_http(post=AsyncMock())
+    p = get_provider("google")
+    with pytest.raises(RuntimeError):
+        await v.exchange_oauth_code(p, code="c", redirect_uri="r")
+
+
+@pytest.mark.asyncio
+async def test_exchange_account_fetch_failure_is_nonfatal(captured_env):
+    post = AsyncMock(return_value=_fake_response(payload={
+        "access_token": "at", "refresh_token": "rt", "expires_in": 3600,
+    }))
+    get = AsyncMock(side_effect=Exception("userinfo down"))
+    v = _vault_with_fake_http(post=post, get=get)
+    v.system_credentials["google_client_id"] = "cid"
+    v.system_credentials["google_client_secret"] = "csec"
+    conn = await v.exchange_oauth_code(
+        get_provider("google"), code="c", redirect_uri="r",
+    )
+    assert conn["access_token"] == "at"
+    assert conn["account"] == ""  # best-effort, swallowed
+
+
+# ── End-to-end: the agent's http_request resolver path ───────────────────
+
+@pytest.mark.asyncio
+async def test_http_tool_resolves_connection_to_refreshed_bearer(captured_env):
+    """Full agent path: http_tool._resolve_creds → mesh vault_resolve →
+    vault.resolve_credential_async → ensure_connection_token (refresh) → bearer.
+
+    Proves an agent's ``Authorization: Bearer $CRED{google_drive}`` ends up
+    carrying a *freshly refreshed* token, never the stale one or the refresh
+    token. The outbound HTTP call after this point is unchanged stock code.
+    """
+    from src.agent.builtins.http_tool import _resolve_creds
+
+    vault = CredentialVault()
+    vault.system_credentials["google_client_id"] = "cid"
+    vault.system_credentials["google_client_secret"] = "csec"
+    vault.connections["google_drive"] = {
+        "provider": "google", "access_token": "OLD",
+        "refresh_token": "rt", "expires_at": int(time.time()) - 10,  # expired
+    }
+    fake = AsyncMock()
+    fake.is_closed = False
+    fake.post = AsyncMock(return_value=_fake_response(
+        payload={"access_token": "FRESH", "expires_in": 3600},
+    ))
+    vault._http_client = fake
+
+    # mesh_client.vault_resolve mirrors POST /mesh/vault/resolve, which the mesh
+    # endpoint backs with resolve_credential_async.
+    async def _vault_resolve(name):
+        return await vault.resolve_credential_async(name)
+
+    mesh = MagicMock()
+    mesh.vault_resolve = _vault_resolve
+
+    resolved, secrets = await _resolve_creds("Bearer $CRED{google_drive}", mesh)
+    assert resolved == "Bearer FRESH"   # refreshed token reached the header
+    assert "FRESH" in secrets            # and is captured for redaction
+    assert "rt" not in resolved          # refresh token never surfaces
+
+
+# ── State store ──────────────────────────────────────────────────────────
+
+def test_state_store_single_use_and_session_bound():
+    s = OAuthStateStore(ttl_seconds=600)
+    st = s.create(
+        provider="google", connection_name="g", scopes=("a",),
+        code_verifier="v", redirect_uri="r", session_hash="sess",
+    )
+    # wrong session rejected (and consumed)
+    assert s.consume(st, session_hash="other") is None
+    st2 = s.create(
+        provider="google", connection_name="g2", scopes=("a",),
+        code_verifier="v", redirect_uri="r", session_hash="sess",
+    )
+    got = s.consume(st2, session_hash="sess")
+    assert got is not None and got.connection_name == "g2"
+    # single-use: replay fails
+    assert s.consume(st2, session_hash="sess") is None
+
+
+def test_state_store_expiry():
+    s = OAuthStateStore(ttl_seconds=600)
+    st = s.create(
+        provider="google", connection_name="g", scopes=("a",),
+        code_verifier="v", redirect_uri="r", session_hash="sess",
+        now=time.time() - 1000,
+    )
+    assert s.consume(st, session_hash="sess") is None

--- a/tests/test_oauth_integrations_endpoints.py
+++ b/tests/test_oauth_integrations_endpoints.py
@@ -1,0 +1,256 @@
+"""HTTP-level tests for the OAuth integrations dashboard endpoints.
+
+Exercises the connect/callback/setup/disconnect wiring through the real
+dashboard router + TestClient: state minting + single-use/session-bound
+consumption, the 302 redirects (success and every error branch), and that
+setup persists client creds system-tier. The token exchange is mocked — no
+network. (Vault-level refresh/store logic is unit-tested in
+``tests/test_oauth_integrations.py``.)
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import tempfile
+import time
+from unittest import mock
+from unittest.mock import AsyncMock, MagicMock
+from urllib.parse import parse_qs, urlparse
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+import src.host.credentials as cred_mod
+from src.dashboard.events import EventBus
+from src.host.costs import CostTracker
+from src.host.credentials import CredentialVault
+from src.host.health import HealthMonitor
+from src.host.mesh import Blackboard
+from src.host.traces import TraceStore
+
+
+class _CSRFTestClient(TestClient):
+    def request(self, method, url, **kwargs):
+        if method.upper() not in ("GET", "HEAD", "OPTIONS"):
+            headers = kwargs.get("headers") or {}
+            headers.setdefault("X-Requested-With", "XMLHttpRequest")
+            kwargs["headers"] = headers
+        return super().request(method, url, **kwargs)
+
+
+def _make_components(tmp_path: str) -> dict:
+    bb = Blackboard(db_path=os.path.join(tmp_path, "bb.db"))
+    cost_tracker = CostTracker(db_path=os.path.join(tmp_path, "costs.db"))
+    trace_store = TraceStore(db_path=os.path.join(tmp_path, "traces.db"))
+    runtime_mock = MagicMock()
+    runtime_mock.browser_service_url = None
+    health_monitor = HealthMonitor(
+        runtime=runtime_mock, transport=MagicMock(), router=MagicMock(),
+    )
+    return {
+        "blackboard": bb,
+        "health_monitor": health_monitor,
+        "cost_tracker": cost_tracker,
+        "trace_store": trace_store,
+        "event_bus": EventBus(),
+        "agent_registry": {},
+        "runtime": runtime_mock,
+    }
+
+
+class TestIntegrationEndpoints:
+    def setup_method(self):
+        self._tmpdir = tempfile.mkdtemp()
+        # No real .env writes from setup/store/remove.
+        self._p = mock.patch.object(cred_mod, "_persist_to_env", lambda *a, **k: None)
+        self._r = mock.patch.object(cred_mod, "_remove_from_env", lambda *a, **k: None)
+        self._p.start()
+        self._r.start()
+        self.vault = CredentialVault()
+        # Start clean so ambient OPENLEGION_* env doesn't leak into assertions.
+        self.vault.system_credentials.pop("google_client_id", None)
+        self.vault.system_credentials.pop("google_client_secret", None)
+        self.vault.connections.clear()
+        self.components = _make_components(self._tmpdir)
+        self.components["credential_vault"] = self.vault
+        router = __import__(
+            "src.dashboard.server", fromlist=["create_dashboard_router"],
+        ).create_dashboard_router(**self.components, mesh_port=8420)
+        app = FastAPI()
+        app.include_router(router)
+        self.client = _CSRFTestClient(app)
+
+    def teardown_method(self):
+        self._p.stop()
+        self._r.stop()
+        self.components["cost_tracker"].close()
+        self.components["trace_store"].close()
+        self.components["blackboard"].close()
+        shutil.rmtree(self._tmpdir, ignore_errors=True)
+
+    def _setup_google(self):
+        return self.client.post(
+            "/dashboard/api/integrations/google/setup",
+            json={"client_id": "cid.apps.googleusercontent.com", "client_secret": "GOCSPX-x"},
+        )
+
+    # ── list + setup ────────────────────────────────────────────────────
+
+    def test_list_unconfigured(self):
+        resp = self.client.get("/dashboard/api/integrations")
+        assert resp.status_code == 200
+        providers = resp.json()["providers"]
+        google = next(p for p in providers if p["key"] == "google")
+        assert google["configured"] is False
+        assert google["connections"] == []
+        assert any(b["key"] == "drive_readonly" for b in google["scope_bundles"])
+        assert google["redirect_uri"].endswith("/dashboard/integrations/google/callback")
+
+    def test_setup_then_configured(self):
+        assert self._setup_google().status_code == 200
+        assert self.vault.system_credentials["google_client_id"] == "cid.apps.googleusercontent.com"
+        google = next(
+            p for p in self.client.get("/dashboard/api/integrations").json()["providers"]
+            if p["key"] == "google"
+        )
+        assert google["configured"] is True
+
+    def test_setup_missing_fields_400(self):
+        resp = self.client.post(
+            "/dashboard/api/integrations/google/setup",
+            json={"client_id": "x", "client_secret": ""},
+        )
+        assert resp.status_code == 400
+
+    def test_setup_unknown_provider_404(self):
+        resp = self.client.post(
+            "/dashboard/api/integrations/dropbox/setup",
+            json={"client_id": "x", "client_secret": "y"},
+        )
+        assert resp.status_code == 404
+
+    # ── connect ─────────────────────────────────────────────────────────
+
+    def test_connect_requires_client(self):
+        resp = self.client.get(
+            "/dashboard/integrations/google/connect", follow_redirects=False,
+        )
+        assert resp.status_code == 400  # client not configured
+
+    def test_connect_redirects_to_provider(self):
+        self._setup_google()
+        resp = self.client.get(
+            "/dashboard/integrations/google/connect?name=mydrive&scopes=drive_readonly",
+            follow_redirects=False,
+        )
+        assert resp.status_code == 302
+        loc = resp.headers["location"]
+        assert loc.startswith("https://accounts.google.com/o/oauth2/v2/auth?")
+        q = parse_qs(urlparse(loc).query)
+        assert q["state"][0]
+        assert "code_challenge" in q
+        assert q["code_challenge_method"][0] == "S256"
+        assert "drive.readonly" in q["scope"][0]
+        assert q["access_type"][0] == "offline"
+
+    def test_connect_unknown_provider_404(self):
+        resp = self.client.get(
+            "/dashboard/integrations/dropbox/connect", follow_redirects=False,
+        )
+        assert resp.status_code == 404
+
+    # ── callback ────────────────────────────────────────────────────────
+
+    def _mint_state(self) -> str:
+        self._setup_google()
+        resp = self.client.get(
+            "/dashboard/integrations/google/connect?name=mydrive&scopes=drive_readonly",
+            follow_redirects=False,
+        )
+        return parse_qs(urlparse(resp.headers["location"]).query)["state"][0]
+
+    def test_callback_invalid_state(self):
+        resp = self.client.get(
+            "/dashboard/integrations/google/callback?code=abc&state=bogus",
+            follow_redirects=False,
+        )
+        assert resp.status_code == 302
+        assert "integration_error=invalid_state" in resp.headers["location"]
+
+    def test_callback_provider_error(self):
+        resp = self.client.get(
+            "/dashboard/integrations/google/callback?error=access_denied",
+            follow_redirects=False,
+        )
+        assert resp.status_code == 302
+        assert "integration_error=access_denied" in resp.headers["location"]
+
+    def test_callback_happy_path_stores_connection(self):
+        state = self._mint_state()
+        self.vault.exchange_oauth_code = AsyncMock(return_value={
+            "provider": "google", "access_token": "at", "refresh_token": "rt",
+            "expires_at": int(time.time()) + 3600, "scopes": ["s"], "account": "u@e.com",
+        })
+        resp = self.client.get(
+            f"/dashboard/integrations/google/callback?code=authcode&state={state}",
+            follow_redirects=False,
+        )
+        assert resp.status_code == 302
+        assert "integration_connected=mydrive" in resp.headers["location"]
+        assert "mydrive" in self.vault.connections
+        # state is single-use — replaying the same state now fails
+        replay = self.client.get(
+            f"/dashboard/integrations/google/callback?code=authcode&state={state}",
+            follow_redirects=False,
+        )
+        assert "integration_error=invalid_state" in replay.headers["location"]
+
+    def test_callback_no_refresh_token_rejected(self):
+        # Google needs a refresh token; a connection without one would die at
+        # first expiry, so the callback must reject it rather than store it.
+        state = self._mint_state()
+        self.vault.exchange_oauth_code = AsyncMock(return_value={
+            "provider": "google", "access_token": "at", "refresh_token": "",
+            "expires_at": int(time.time()) + 3600, "scopes": ["s"], "account": "",
+        })
+        resp = self.client.get(
+            f"/dashboard/integrations/google/callback?code=c&state={state}",
+            follow_redirects=False,
+        )
+        assert resp.status_code == 302
+        assert "integration_error=no_refresh_token" in resp.headers["location"]
+        assert "mydrive" not in self.vault.connections
+
+    def test_connect_unknown_scope_bundle_400(self):
+        self._setup_google()
+        resp = self.client.get(
+            "/dashboard/integrations/google/connect?scopes=bogus_bundle",
+            follow_redirects=False,
+        )
+        assert resp.status_code == 400
+
+    def test_callback_exchange_failure_redirects(self):
+        state = self._mint_state()
+        self.vault.exchange_oauth_code = AsyncMock(side_effect=RuntimeError("bad_grant"))
+        resp = self.client.get(
+            f"/dashboard/integrations/google/callback?code=authcode&state={state}",
+            follow_redirects=False,
+        )
+        assert resp.status_code == 302
+        assert "integration_error=exchange_failed" in resp.headers["location"]
+        assert "mydrive" not in self.vault.connections
+
+    # ── disconnect ──────────────────────────────────────────────────────
+
+    def test_disconnect(self):
+        self.vault.connections["mydrive"] = {
+            "provider": "google", "access_token": "at", "refresh_token": "rt",
+        }
+        resp = self.client.post("/dashboard/api/integrations/mydrive/disconnect")
+        assert resp.status_code == 200
+        assert "mydrive" not in self.vault.connections
+
+    def test_disconnect_missing_404(self):
+        resp = self.client.post("/dashboard/api/integrations/nope/disconnect")
+        assert resp.status_code == 404


### PR DESCRIPTION
## What

Replaces the manual "mint a token → paste into the vault" flow with an in-engine **OAuth2 authorization-code + PKCE "Connect"** dance. Operators register their own OAuth app once (bring-your-own-app), then connect accounts in one click. The engine handles the code exchange and **transparent token refresh**.

Agents keep using `$CRED{<name>}` exactly as before — it now resolves to a **freshly-refreshed access token**, so connections never go stale and agents never see the refresh token or the client secret.

## Why this shape

- The real pain was *repeat* friction (hand-minting tokens, expiry surprises). BYO-app fixes that and validates the whole `vault → $CRED → agent` path without taking on provider app-verification yet. First-party zero-setup connectors are a follow-up; `store_connection` is already callable from both the local callback and a future broker push.
- OAuth connections are **outbound credentials**, not inbound channels, so the UI lives on the credentials page (**"API Keys & Connections"**), not Integrations.

## End-to-end journey (verified against real code)

1. Settings → API Keys & Connections → enter Google client id/secret (stored system-tier).
2. Register the shown redirect URI in Google Console.
3. Pick scopes → Connect → PKCE + single-use/session-bound `state` → consent → `/callback` exchanges + stores the connection.
4. A worker agent (internet on by default; `allowed_credentials: ["*"]`) `vault_list`s the connection and calls `http_request` to `googleapis.com` with `Authorization: Bearer $CRED{google_drive}` — resolved via `/mesh/vault/resolve` → `resolve_credential_async` → refresh → fresh bearer, then out via the agent's bridge network.

## Files

- `src/host/oauth_providers.py` — provider registry (Google) + PKCE. Fixed endpoints → no new SSRF surface.
- `src/host/oauth_state.py` — single-use, TTL-bound, session-bound OAuth state (CSRF guard).
- `src/host/credentials.py` — `OPENLEGION_CONN_*` connection tier; store + refresh-on-resolve generalized from the OpenAI-OAuth code. Client id/secret stay system-tier, unresolvable by agents.
- `src/host/server.py` — `/mesh/vault/resolve` awaits `resolve_credential_async` (the seam http_request + browser tool ride).
- `src/dashboard/server.py` + `templates/index.html` + `static/js/app.js` — setup/connect/callback/disconnect + the "Connect a service" card.
- `docs/plans/` — implementation plan + product/decision strategy doc.

## Review hardening (from an adversarial + Codex pass)

- Reject a connection with **no refresh token** rather than store a dead-on-arrival one.
- Don't **resurrect** a connection disconnected mid-refresh.
- **400** on unknown scope bundles; refresh failures surface as **502** (never a stale token).

## New config

`OPENLEGION_PUBLIC_BASE_URL` (redirect-URI origin; falls back to forwarded Host). Redirect URI: `https://{subdomain}/dashboard/integrations/google/callback`.

## Tests

**39 OAuth-specific** — vault unit, dashboard endpoint (state mint, single-use replay, every error redirect), and an **end-to-end test through the agent's own `$CRED` resolver** proving resolve → refresh → bearer. Broader regression (credentials/permissions/dashboard) green; ruff clean.

## Follow-ups (non-blocking, tracked in the strategy doc)

- MCP `$CRED{}` env injection doesn't refresh (secondary path; `http_request` does).
- Runtime sync of the system-cred denylist for `*_client_id/secret` (existence-disclosure only; values stay unresolvable).
- Post-connect redirect restores the API Keys sub-tab.
- Typed connection skills (`drive_list_files()`, `gmail_send()`).