### PR TITLE
fix(dashboard): recover document scroll after mobile keyboard dismiss

### DIFF
--- a/src/dashboard/static/css/dashboard.css
+++ b/src/dashboard/static/css/dashboard.css
@@ -634,6 +634,25 @@
   scrollbar-color: rgba(55, 55, 75, 0.6) transparent;
 }
 
+/* ── Scroll containment ──────────────────────────────
+   The body is a non-scrolling shell (`h-[100dvh] overflow-hidden`) and ALL
+   real scrolling happens in inner containers. Without containment, when an
+   inner scroller hits its top/bottom edge the overscroll *chains* outward to
+   that locked body — on iOS this produces a dead rubber-band that reads as a
+   frozen page (the same symptom class as the keyboard-scroll bug). Stop the
+   chain at each primary scroller, and kill any document-level bounce outright.
+   Additive + gracefully ignored on browsers without `overscroll-behavior`. */
+html, body {
+  overscroll-behavior: none;
+}
+
+main,
+[id^="chat-messages-"],
+[id^="side-chat-messages-"],
+.custom-scrollbar {
+  overscroll-behavior: contain;
+}
+
 /* ── Scrollbar-hidden utility for tab strips ───────── */
 
 .hide-scrollbar {

--- a/src/dashboard/static/js/app.js
+++ b/src/dashboard/static/js/app.js
@@ -1512,6 +1512,49 @@ function dashboard() {
       };
       window.addEventListener('popstate', this._popstateHandler);
 
+      // ── iOS Safari keyboard-scroll recovery ──────────────────
+      // The whole app scrolls through inner containers (`main.overflow-auto`,
+      // the chat logs) while the document itself is deliberately locked:
+      // `<body class="h-[100dvh] overflow-hidden">`. That's the right model on
+      // desktop, but it has a nasty failure on iOS Safari.
+      //
+      // When the on-screen keyboard opens for a text field — in practice the
+      // chat composer, the only persistently-focused input — Safari tries to
+      // scroll the focused caret above the keyboard. The composer lives in a
+      // `position: fixed` panel (or the fixed-height chat tab), so Safari can't
+      // satisfy the caret-reveal by scrolling an inner container and instead
+      // scrolls the DOCUMENT (scrollingElement). On blur it frequently fails to
+      // restore that offset, leaving the entire UI shifted up with a dead strip
+      // at the bottom — which reads exactly as "I can't scroll the page anymore"
+      // until a reload or rotate. Intermittent, mobile-only, always right after
+      // using the chat — matches the reported symptom.
+      //
+      // Because the body is intentionally non-scrollable, ANY document-level
+      // scroll offset is spurious: snap it back to 0. We only do this once the
+      // field is blurred (keyboard dismissed) — while a field is focused we
+      // leave the offset alone so we don't fight Safari positioning the caret.
+      this._resetDocScroll = () => {
+        const ae = document.activeElement;
+        // Still typing → keyboard is up → let Safari keep the caret in view.
+        if (ae && (ae.tagName === 'INPUT' || ae.tagName === 'TEXTAREA' || ae.isContentEditable)) {
+          return;
+        }
+        const se = document.scrollingElement || document.documentElement;
+        if (se && se.scrollTop !== 0) se.scrollTop = 0;
+        if (window.pageYOffset !== 0) window.scrollTo(0, 0);
+      };
+      // focusout bubbles (blur doesn't), so one listener covers every input in
+      // the app. Defer past the keyboard-dismiss reflow so the reset sticks.
+      this._focusOutResetHandler = () => { setTimeout(this._resetDocScroll, 50); };
+      document.addEventListener('focusout', this._focusOutResetHandler);
+      // The keyboard close often only settles on the visualViewport resize that
+      // follows it; catch that too (guarded by the activeElement check above so
+      // it no-ops mid-typing while the keyboard is animating in).
+      if (window.visualViewport) {
+        this._vvResetHandler = () => this._resetDocScroll();
+        window.visualViewport.addEventListener('resize', this._vvResetHandler);
+      }
+
       // Pause polling when tab is hidden to save resources
       document.addEventListener('visibilitychange', () => {
         if (document.hidden) {
@@ -1669,6 +1712,10 @@ function dashboard() {
       this.stopHeartbeatTimer();
       if (this._cmdPaletteHandler) document.removeEventListener('keydown', this._cmdPaletteHandler);
       if (this._popstateHandler) window.removeEventListener('popstate', this._popstateHandler);
+      if (this._focusOutResetHandler) document.removeEventListener('focusout', this._focusOutResetHandler);
+      if (this._vvResetHandler && window.visualViewport) {
+        window.visualViewport.removeEventListener('resize', this._vvResetHandler);
+      }
     },
 
     // ── Phase 1 — Board UX overhaul helpers ──────────────────

--- a/src/dashboard/templates/index.html
+++ b/src/dashboard/templates/index.html
@@ -7587,7 +7587,7 @@
             }
           }">
           <div class="absolute inset-0 bg-black/60 backdrop-blur-sm" @click="closeCookieImport()"></div>
-          <div class="relative w-full max-w-lg bg-gray-900 border border-gray-700 rounded-xl shadow-2xl p-5">
+          <div class="relative w-full max-w-lg max-h-[90dvh] overflow-y-auto custom-scrollbar bg-gray-900 border border-gray-700 rounded-xl shadow-2xl p-5">
             <div class="flex items-center justify-between mb-3">
               <div class="flex items-center gap-2">
                 <h3 class="text-base font-medium text-gray-200">Import cookies / session</h3>


### PR DESCRIPTION
## Problem

On mobile (iOS Safari), the dashboard could become "stuck" / unscrollable, intermittently, after using the chat.

### Root cause

The app scrolls through **inner containers** (`main.overflow-auto`, the chat message logs) while the document itself is intentionally locked:

```html
<body class="bg-gray-950 text-gray-100 h-[100dvh] overflow-hidden">
```

That's a clean model on desktop. The trap is iOS Safari's keyboard handling: the chat composer — the only persistently-focused text input — lives inside a `position: fixed` panel (`.messenger-panel`) or the fixed-height chat tab. When the on-screen keyboard opens, Safari tries to scroll the caret into view but can't satisfy it via an inner scroller, so it **scrolls the document itself**. On blur it frequently fails to restore that offset. Because the body is `overflow:hidden`, the UI is left shifted up with a dead strip at the bottom — reading exactly as "I can't scroll the page anymore" until a reload or rotate. Intermittent, mobile-only, always right after using the chat.

The codebase already guards two *other* iOS quirks (the 16px anti-zoom rule and the "no `overflow` on `html`" note in `dashboard.css`); this one was missed.

## Fix

Since the body is intentionally non-scrollable, **any document-level scroll offset is by definition spurious**. Snap `scrollingElement.scrollTop` back to 0 once the field is blurred:

- Listens on `focusout` (bubbles → one listener covers every input) and the trailing `visualViewport` resize.
- Guarded by an `activeElement` check so it never fires while a field is still focused / the keyboard is animating — we don't fight Safari positioning the caret mid-edit.
- Only writes when the offset is non-zero, so it's a cheap no-op on desktop and in the normal (non-stuck) state.
- Registered in `init()`, torn down in `destroy()` alongside the other global handlers.

## Testing

- `node --check` passes.
- No-op paths verified for desktop (document scroll offset is always 0 there).
- ⚠️ Needs real-device verification on iOS Safari: open a chat, type/send, dismiss the keyboard, confirm the page scrolls normally on both the Chat tab and the slide-over side panel.

https://claude.ai/code/session_01SDpSav7dAHCuQJ8E4mvtCv

---
_Generated by [Claude Code](https://claude.ai/code/session_01SDpSav7dAHCuQJ8E4mvtCv)_