### PR TITLE
Operator capability defaults + unified onboarding modal

### DIFF
--- a/src/agent/loop.py
+++ b/src/agent/loop.py
@@ -133,6 +133,26 @@ _BLACKBOARD_TOOLS = frozenset({
     "claim_task", "hand_off", "check_inbox", "update_status", "complete_task",
 })
 
+# Runtime-toggleable capability gates. Each gate maps to the set of tools
+# hidden from the LLM surface when that capability is switched OFF (via the
+# Operator Settings toggles → agent ``/config`` push, or the boot-time env
+# seed). Folding both gates through a single ``_disabled_gates`` set lets the
+# internet and browser toggles coexist without one clobbering the other.
+_RUNTIME_GATE_TOOLS: dict[str, frozenset[str]] = {
+    "internet": frozenset({"http_request", "web_search"}),
+    # Mirrors the @skill names in ``builtins/browser_tool.py``.
+    "browser": frozenset({
+        "browser_navigate", "browser_warmup", "browser_get_elements",
+        "browser_wait_for", "browser_screenshot", "browser_click",
+        "browser_click_xy", "browser_type", "browser_hover", "browser_scroll",
+        "browser_reset", "browser_press_key", "browser_go_back",
+        "browser_go_forward", "browser_switch_tab", "browser_find_text",
+        "browser_fill_form", "browser_open_tab", "browser_inspect_requests",
+        "browser_detect_captcha", "browser_upload_file",
+        "browser_solve_captcha", "browser_download",
+    }),
+}
+
 # Read-only tools allowed during operator heartbeat (unsupervised execution).
 # The full operator allowlist is restricted to this subset so heartbeats
 # cannot mutate fleet state without user approval. ``check_inbox`` is
@@ -397,14 +417,21 @@ class AgentLoop:
         # effective surface). Empty by default; populated only when
         # mesh explicitly tells the agent to hide tools.
         #
-        # Boot-time seeding: ``OL_INTERNET_ACCESS_ENABLED=false`` env
-        # var sets the runtime filter immediately so a restart while
-        # the toggle is OFF doesn't briefly re-expose the tools. Mesh
-        # passes this env var when launching the operator container
-        # based on ``operator.can_use_internet`` in permissions.json.
-        self._runtime_disabled_tools: frozenset[str] = frozenset()
+        # Boot-time seeding: ``OL_INTERNET_ACCESS_ENABLED=false`` /
+        # ``OL_BROWSER_ACCESS_ENABLED=false`` env vars set the runtime
+        # filter immediately so a restart while a toggle is OFF doesn't
+        # briefly re-expose the tools. Mesh passes these env vars when
+        # launching the operator container based on
+        # ``operator.can_use_internet`` / ``can_use_browser`` in
+        # permissions.json. Both gates are tracked independently so one
+        # toggle never clobbers the other.
+        self._disabled_gates: set[str] = set()
         if os.environ.get("OL_INTERNET_ACCESS_ENABLED", "true").lower() == "false":
-            self._runtime_disabled_tools = frozenset({"http_request", "web_search"})
+            self._disabled_gates.add("internet")
+        if os.environ.get("OL_BROWSER_ACCESS_ENABLED", "true").lower() == "false":
+            self._disabled_gates.add("browser")
+        self._runtime_disabled_tools: frozenset[str] = frozenset()
+        self._recompute_runtime_disabled()
         self._skills_reloaded: bool = False
         self._is_operator: bool = allowed_tools is not None
         self._operator_playbook_state: dict[str, int] = {}  # playbook -> turns since trigger
@@ -463,11 +490,32 @@ class AgentLoop:
             )
         return kw
 
-    def set_runtime_disabled_tools(self, tools: list[str] | set[str]) -> None:
-        """Replace the runtime-disabled-tool set.
+    def _recompute_runtime_disabled(self) -> None:
+        """Rebuild ``_runtime_disabled_tools`` from the active gate set."""
+        tools: set[str] = set()
+        for gate in self._disabled_gates:
+            tools |= _RUNTIME_GATE_TOOLS.get(gate, frozenset())
+        self._runtime_disabled_tools = frozenset(tools)
 
-        Called by the agent's ``/config`` endpoint when the mesh pushes
-        a permission change. Empty input clears the filter.
+    def set_runtime_gate(self, gate: str, enabled: bool) -> None:
+        """Flip a single capability gate (``internet`` / ``browser``).
+
+        Called by the agent's ``/config`` endpoint when the mesh pushes a
+        permission change. ``enabled=True`` clears the gate (tools become
+        visible again); ``enabled=False`` hides that gate's tools. Other
+        gates are untouched, so the internet and browser toggles compose.
+        """
+        if enabled:
+            self._disabled_gates.discard(gate)
+        else:
+            self._disabled_gates.add(gate)
+        self._recompute_runtime_disabled()
+
+    def set_runtime_disabled_tools(self, tools: list[str] | set[str]) -> None:
+        """Replace the runtime-disabled-tool set directly.
+
+        Retained for callers/tests that set the raw tool set. Prefer
+        ``set_runtime_gate`` for the internet/browser capability toggles.
         """
         self._runtime_disabled_tools = frozenset(tools or ())
 

--- a/src/agent/server.py
+++ b/src/agent/server.py
@@ -621,6 +621,7 @@ def create_agent_app(loop: AgentLoop) -> FastAPI:
         thinking = body.get("thinking") if "thinking" in body else None
         max_tokens = body.get("max_tokens") if "max_tokens" in body else None
         internet = body.get("internet_access_enabled") if "internet_access_enabled" in body else None
+        browser = body.get("browser_access_enabled") if "browser_access_enabled" in body else None
         if "model" in body and (not isinstance(model, str) or not model):
             raise HTTPException(400, "model must be a non-empty string")
         if "thinking" in body and thinking not in LLMClient.VALID_THINKING_LEVELS:
@@ -640,6 +641,10 @@ def create_agent_app(loop: AgentLoop) -> FastAPI:
             raise HTTPException(
                 400, "internet_access_enabled must be a boolean",
             )
+        if "browser_access_enabled" in body and not isinstance(browser, bool):
+            raise HTTPException(
+                400, "browser_access_enabled must be a boolean",
+            )
 
         updated: dict = {}
         if "model" in body:
@@ -654,16 +659,15 @@ def create_agent_app(loop: AgentLoop) -> FastAPI:
         if "internet_access_enabled" in body:
             # Mesh-side push from the Operator Settings → Internet
             # access toggle. When False, hide http_request + web_search
-            # from the next LLM tool surface so the operator can't call
-            # them. When True, clear the runtime-disabled set so the
-            # static allowlist takes over again.
-            disabled = (
-                frozenset()
-                if internet
-                else frozenset({"http_request", "web_search"})
-            )
-            loop.set_runtime_disabled_tools(disabled)
+            # from the next LLM tool surface; when True, restore them.
+            loop.set_runtime_gate("internet", internet)
             updated["internet_access_enabled"] = internet
+        if "browser_access_enabled" in body:
+            # Mesh-side push from the Operator Settings → Browser access
+            # toggle. When False, hide the browser_* tools from the next
+            # LLM tool surface; when True, restore them.
+            loop.set_runtime_gate("browser", browser)
+            updated["browser_access_enabled"] = browser
         return {"updated": updated}
 
     @app.get("/workspace-logs")

--- a/src/cli/config.py
+++ b/src/cli/config.py
@@ -1754,6 +1754,20 @@ _OPERATOR_ALLOWED_TOOLS: list[str] = [
     # agent's runtime filters these out of the effective allowlist when
     # the Operator Settings → Internet access toggle is OFF).
     "http_request", "web_search",
+    # Browser access (gated by ``can_use_browser`` permission — the
+    # agent's runtime filters these out of the effective allowlist when
+    # the Operator Settings → Browser access toggle is OFF). Mirrors the
+    # full worker browser surface from ``builtins/browser_tool.py`` so
+    # the operator can navigate the web directly. ``request_browser_login``
+    # (above) remains the delegation path for landing a worker's cookies.
+    "browser_navigate", "browser_warmup", "browser_get_elements",
+    "browser_wait_for", "browser_screenshot", "browser_click",
+    "browser_click_xy", "browser_type", "browser_hover", "browser_scroll",
+    "browser_reset", "browser_press_key", "browser_go_back",
+    "browser_go_forward", "browser_switch_tab", "browser_find_text",
+    "browser_fill_form", "browser_open_tab", "browser_inspect_requests",
+    "browser_detect_captcha", "browser_upload_file", "browser_solve_captcha",
+    "browser_download",
 ]
 
 # Reference list documenting the tools operator uses on heartbeat. The
@@ -2091,6 +2105,13 @@ def _ensure_operator_agent(config_path: Path | None = None, default_model: str =
         if "can_use_internet" not in op_perms:
             op_perms["can_use_internet"] = True
             needs_update = True
+        # Browser access: backfill True for existing operators that
+        # predate the field. Idempotent — once set (True OR False), the
+        # ``not in`` guard skips so the user's explicit OFF choice in
+        # Operator Settings is preserved across restarts.
+        if "can_use_browser" not in op_perms:
+            op_perms["can_use_browser"] = True
+            needs_update = True
         if needs_update:
             perms.setdefault("permissions", {})[_OPERATOR_AGENT_ID] = op_perms
             _save_permissions(perms)
@@ -2113,17 +2134,17 @@ def _ensure_operator_agent(config_path: Path | None = None, default_model: str =
         _OPERATOR_AGENT_ID,
         permissions={
             "can_spawn": True,
-            # Operator has ``can_use_browser=False`` by design: it
-            # coordinates the fleet but does not drive browsers itself.
-            # ``request_browser_login`` / ``request_captcha_help``
-            # work through the delegation path — operator calls the
-            # skill with ``agent_id=target_worker`` so cookies / session
-            # state land in the worker's browser profile (the agent
-            # that will actually use them). See
-            # ``src/shared/operator_playbooks.py`` for the documented
-            # delegation pattern and ``tests/test_operator_config.py``
-            # for the design test.
-            "can_use_browser": False,
+            # Operator gets ``can_use_browser=True`` by default so it can
+            # browse the web directly to help users navigate and answer
+            # questions without first spinning up a worker. The dashboard
+            # surfaces a toggle in Operator Settings → "Browser access"
+            # that flips this off when the user wants the operator
+            # sandboxed (mirrors the internet-access toggle). The
+            # delegation path (``request_browser_login`` with
+            # ``agent_id=target_worker``) still works for landing a
+            # worker's session cookies — see
+            # ``src/shared/operator_playbooks.py``.
+            "can_use_browser": True,
             # Operator gets internet (HTTPS + web search) by default so
             # it can fetch reference material and answer factual
             # questions without delegating to a worker. The dashboard

--- a/src/cli/config.py
+++ b/src/cli/config.py
@@ -605,7 +605,8 @@ def _add_agent_permissions(
         # explicit grants in ``_ensure_operator_agent`` get persisted to
         # permissions.json instead of being silently dropped.
         for key in (
-            "can_use_browser", "can_spawn", "can_manage_cron",
+            "can_use_browser", "can_use_internet", "can_spawn",
+            "can_manage_cron",
             "can_manage_fleet", "can_manage_teams", "can_edit_agent_config",
             "can_view_fleet_metrics",
             "can_request_user_credentials",

--- a/src/cli/runtime.py
+++ b/src/cli/runtime.py
@@ -487,28 +487,30 @@ class RuntimeContext:
             set_llm_max_tokens_env(agent_env, agent_cfg)
             if agent_id == _OPERATOR_AGENT_ID:
                 agent_env["ALLOWED_TOOLS"] = ",".join(_OPERATOR_ALLOWED_TOOLS)
-                # PR-L' — pass the boot greeting so the agent can seed
-                # its chat transcript on first start. Idempotency is
-                # gated agent-side on a sentinel file in /data/workspace,
-                # so subsequent restarts and chat-resets do NOT re-emit.
-                from src.shared.operator_playbooks import _OPERATOR_GREETING
-                agent_env["INITIAL_GREETING"] = _OPERATOR_GREETING
-                # Seed the runtime internet-access state from the
-                # operator's stored permission so a restart while the
-                # toggle is OFF doesn't briefly re-expose http_request /
-                # web_search. ``_load_permissions`` is cheap (JSON read);
-                # default-True matches the operator-by-default UX.
+                # NOTE: the operator no longer seeds a boot greeting into
+                # its chat transcript. The onboarding modal + in-chat
+                # starting-point card cover the first-run experience; a
+                # seeded assistant message stacked confusingly underneath
+                # that card.
+                # Seed the runtime internet/browser access state from the
+                # operator's stored permissions so a restart while a
+                # toggle is OFF doesn't briefly re-expose the gated tools.
+                # ``_load_permissions`` is cheap (JSON read); default-True
+                # matches the operator-by-default UX.
                 try:
                     from src.cli.config import _load_permissions
                     _op_perms = _load_permissions().get(
                         "permissions", {},
                     ).get(_OPERATOR_AGENT_ID, {})
-                    _internet_on = _op_perms.get("can_use_internet", True)
                     agent_env["OL_INTERNET_ACCESS_ENABLED"] = (
-                        "true" if _internet_on else "false"
+                        "true" if _op_perms.get("can_use_internet", True) else "false"
+                    )
+                    agent_env["OL_BROWSER_ACCESS_ENABLED"] = (
+                        "true" if _op_perms.get("can_use_browser", True) else "false"
                     )
                 except Exception:
                     agent_env["OL_INTERNET_ACCESS_ENABLED"] = "true"
+                    agent_env["OL_BROWSER_ACCESS_ENABLED"] = "true"
 
             # Project env vars
             project_name = agent_projects.get(agent_id)

--- a/src/dashboard/server.py
+++ b/src/dashboard/server.py
@@ -6042,7 +6042,11 @@ def create_dashboard_router(
 
         # Restart all agents in parallel
         _network_cfg = cfg.get("network", {})
-        from src.cli.config import _OPERATOR_AGENT_ID, _OPERATOR_ALLOWED_TOOLS
+        from src.cli.config import (
+            _OPERATOR_AGENT_ID,
+            _OPERATOR_ALLOWED_TOOLS,
+            _load_permissions,
+        )
 
         async def _restart_one(agent_id: str) -> tuple[str, str]:
             agent_cfg = agents_cfg.get(agent_id, {})
@@ -6057,6 +6061,25 @@ def create_dashboard_router(
                 _restart_env: dict[str, str] = {}
                 if agent_id == _OPERATOR_AGENT_ID:
                     _restart_env["ALLOWED_TOOLS"] = ",".join(_OPERATOR_ALLOWED_TOOLS)
+                    # Re-seed internet/browser access flags so a fleet
+                    # restart (incl. the dashboard's auto-restart on
+                    # restart-gated setting changes) doesn't silently
+                    # re-enable a capability the operator toggled OFF.
+                    # Mirrors the single-agent restart path; default True
+                    # matches the operator-by-default UX.
+                    try:
+                        _op_perms = _load_permissions().get(
+                            "permissions", {},
+                        ).get(_OPERATOR_AGENT_ID, {})
+                        _restart_env["OL_INTERNET_ACCESS_ENABLED"] = (
+                            "true" if _op_perms.get("can_use_internet", True) else "false"
+                        )
+                        _restart_env["OL_BROWSER_ACCESS_ENABLED"] = (
+                            "true" if _op_perms.get("can_use_browser", True) else "false"
+                        )
+                    except Exception:
+                        _restart_env["OL_INTERNET_ACCESS_ENABLED"] = "true"
+                        _restart_env["OL_BROWSER_ACCESS_ENABLED"] = "true"
                 _proxy_url = resolve_agent_proxy(agent_id, agents_cfg, _network_cfg)
                 _proxy_env = build_proxy_env_vars(
                     _proxy_url, _network_cfg.get("no_proxy", ""),

--- a/src/dashboard/server.py
+++ b/src/dashboard/server.py
@@ -2900,7 +2900,7 @@ def create_dashboard_router(
             restart_env: dict[str, str] = {}
             if agent_id == _OPERATOR_AGENT_ID:
                 restart_env["ALLOWED_TOOLS"] = ",".join(_OPERATOR_ALLOWED_TOOLS)
-                # Re-seed internet-access flag on restart so the
+                # Re-seed internet/browser access flags on restart so the
                 # operator's toggle state survives the bounce. Default
                 # True matches the operator-by-default UX.
                 try:
@@ -2910,8 +2910,12 @@ def create_dashboard_router(
                     restart_env["OL_INTERNET_ACCESS_ENABLED"] = (
                         "true" if _op_perms.get("can_use_internet", True) else "false"
                     )
+                    restart_env["OL_BROWSER_ACCESS_ENABLED"] = (
+                        "true" if _op_perms.get("can_use_browser", True) else "false"
+                    )
                 except Exception:
                     restart_env["OL_INTERNET_ACCESS_ENABLED"] = "true"
+                    restart_env["OL_BROWSER_ACCESS_ENABLED"] = "true"
             # Proxy goes in env_overrides (not runtime.extra_env) so
             # concurrent single-agent restarts don't stomp each other.
             _proxy_url = resolve_agent_proxy(
@@ -5401,6 +5405,76 @@ def create_dashboard_router(
                 )
         except Exception as e:
             logger.warning("operator internet-access set proxy failed: %s", e)
+            raise HTTPException(502, f"Mesh unreachable: {e}")
+        if resp.status_code >= 400:
+            try:
+                detail = resp.json().get("detail", resp.text)
+            except Exception:
+                detail = resp.text
+            raise HTTPException(resp.status_code, detail)
+        return resp.json()
+
+    # ── Operator: browser access toggle ───────────────────────
+
+    @api_router.get("/api/operator/browser-access")
+    async def api_operator_browser_access_status() -> dict:
+        """Return the operator's current browser-access state.
+
+        Proxies to mesh ``GET /mesh/operator/browser-access``. The
+        Operator Settings UI calls this on mount to render the toggle.
+        """
+        import httpx
+        url = f"http://127.0.0.1:{mesh_port}/mesh/operator/browser-access"
+        try:
+            async with httpx.AsyncClient(timeout=10) as client:
+                resp = await client.get(
+                    url,
+                    headers={"x-mesh-internal": "1", "X-Agent-ID": "operator"},
+                )
+        except Exception as e:
+            logger.warning("operator browser-access status proxy failed: %s", e)
+            raise HTTPException(502, f"Mesh unreachable: {e}")
+        if resp.status_code >= 400:
+            try:
+                detail = resp.json().get("detail", resp.text)
+            except Exception:
+                detail = resp.text
+            raise HTTPException(resp.status_code, detail)
+        return resp.json()
+
+    @api_router.post("/api/operator/browser-access")
+    async def api_operator_browser_access_set(request: Request) -> dict:
+        """Flip the operator's browser access on/off.
+
+        Body: ``{"enabled": bool}``. Proxies to mesh
+        ``POST /mesh/operator/browser-access``. Response shape:
+        ``{success, enabled, previous, live}``.
+        """
+        try:
+            body = await request.json()
+        except Exception:
+            body = {}
+        if not isinstance(body, dict) or "enabled" not in body:
+            raise HTTPException(400, "'enabled' is required")
+        enabled = body.get("enabled")
+        if not isinstance(enabled, bool):
+            raise HTTPException(400, "'enabled' must be a boolean")
+        import httpx
+        url = f"http://127.0.0.1:{mesh_port}/mesh/operator/browser-access"
+        try:
+            async with httpx.AsyncClient(timeout=15) as client:
+                resp = await client.post(
+                    url,
+                    json={"enabled": enabled},
+                    headers={
+                        "X-Requested-With": "XMLHttpRequest",
+                        "x-mesh-internal": "1",
+                        "X-Agent-ID": "operator",
+                        "Content-Type": "application/json",
+                    },
+                )
+        except Exception as e:
+            logger.warning("operator browser-access set proxy failed: %s", e)
             raise HTTPException(502, f"Mesh unreachable: {e}")
         if resp.status_code >= 400:
             try:

--- a/src/dashboard/server.py
+++ b/src/dashboard/server.py
@@ -5879,6 +5879,17 @@ def create_dashboard_router(
         "health_restart_window": (int, 60, 86400),
     }
 
+    # Settings seeded into agent containers as env vars at launch — they
+    # only take effect after the agent restarts (the restart-agents path
+    # re-reads settings.json). The dashboard auto-restarts the fleet when
+    # one of these changes so the user never has stale config silently
+    # in effect. Budgets are per-new-agent defaults and health_* apply
+    # live above, so neither needs a restart.
+    _RESTART_REQUIRED_SETTINGS: frozenset[str] = frozenset({
+        "max_iterations", "chat_max_tool_rounds",
+        "chat_max_total_rounds", "tool_timeout",
+    })
+
     _SYSTEM_SETTINGS_DEFAULTS: dict[str, float | int] = {
         "default_daily_budget": 10.0,
         "default_monthly_budget": 200.0,
@@ -5946,7 +5957,8 @@ def create_dashboard_router(
                 if cfg_key in updated:
                     setattr(health_monitor, attr, settings[cfg_key])
 
-        return {"updated": updated}
+        restart_required = bool(set(updated) & _RESTART_REQUIRED_SETTINGS)
+        return {"updated": updated, "restart_required": restart_required}
 
     @api_router.post("/api/default-model")
     async def api_set_default_model(request: Request) -> dict:

--- a/src/dashboard/server.py
+++ b/src/dashboard/server.py
@@ -2496,6 +2496,7 @@ def create_dashboard_router(
             "system_credentials": system_cred_names,
             "resolved_credentials": resolved,
             "can_use_browser": agent_perms.can_use_browser if agent_perms else False,
+            "can_use_internet": agent_perms.can_use_internet if agent_perms else False,
             "can_spawn": agent_perms.can_spawn if agent_perms else False,
             "can_manage_cron": agent_perms.can_manage_cron if agent_perms else False,
             "can_use_wallet": agent_perms.can_use_wallet if agent_perms else False,
@@ -3200,6 +3201,7 @@ def create_dashboard_router(
             "allowed_apis": perms.allowed_apis,
             "available_credentials": available_creds,
             "can_use_browser": perms.can_use_browser,
+            "can_use_internet": perms.can_use_internet,
             "can_spawn": perms.can_spawn,
             "can_manage_cron": perms.can_manage_cron,
         }
@@ -3229,7 +3231,7 @@ def create_dashboard_router(
                 raise HTTPException(status_code=400, detail="allowed_apis must be a list of strings")
             agent_perms["allowed_apis"] = val
             updated.append("allowed_apis")
-        for flag in ("can_use_browser", "can_spawn", "can_manage_cron", "can_use_wallet"):
+        for flag in ("can_use_browser", "can_use_internet", "can_spawn", "can_manage_cron", "can_use_wallet"):
             if flag in body:
                 agent_perms[flag] = bool(body[flag])
                 updated.append(flag)

--- a/src/dashboard/static/js/app.js
+++ b/src/dashboard/static/js/app.js
@@ -654,17 +654,6 @@ function dashboard() {
     _wizardBuildPoll: null,
     _wizardCompleteTimer: null,
 
-    // New-user onboarding tutorial. Three modal steps that orient a
-    // brand-new user on the layout + Operator concept. Skippable;
-    // persists to ``localStorage.olSeenTutorial = 'true'`` on completion
-    // or skip. Repurposed from the Phase-4 "What's new" tour
-    // infrastructure, but the audience is inverted: tutorial fires for
-    // EMPTY fleets (new users) and runs BEFORE the empty-fleet wizard.
-    // Once tutorial completes, ``_maybeStartWizard`` takes over.
-    newUserTutorial: { step: 0 },  // 0 = closed; 1..3 = visible
-    _newUserTutorialPrevFocus: null,
-    _newUserTutorialKeyHandler: null,
-
     // Track the element focused before the side panel opened so ESC
     // restores focus to the original trigger on close.
     _messengerSidePanelPrevFocus: null,
@@ -1228,21 +1217,6 @@ function dashboard() {
         if (active) this.activeTeam = active;
       } catch (_) { /* ignore */ }
 
-      // Migration: users who saw the legacy "What's new" tour (Phase 4)
-      // had the ``olSeenWhatsNew`` flag set. Those users had non-empty
-      // fleets — they're not new — and shouldn't see the new-user
-      // tutorial either. Carry the flag forward so the tutorial stays
-      // suppressed for everyone who already passed through the legacy
-      // tour. Idempotent — only writes when ``olSeenTutorial`` is unset.
-      try {
-        if (
-          localStorage.getItem('olSeenWhatsNew') === 'true' &&
-          !localStorage.getItem('olSeenTutorial')
-        ) {
-          localStorage.setItem('olSeenTutorial', 'true');
-        }
-      } catch (_) { /* private mode — ignore */ }
-
       // Build credential service options from server-injected providers
       const allProviders = cfg.allProviders || [];
       this.credServiceOptions = [
@@ -1720,7 +1694,7 @@ function dashboard() {
       try {
         if (this.messengerSidePanelOpen) {
           // Capture the previously focused element so ESC can restore
-          // focus on close (mirrors _newUserTutorialPrevFocus pattern).
+          // focus on close.
           try { this._messengerSidePanelPrevFocus = document.activeElement; } catch (_) {}
           localStorage.setItem('ol_messenger_side_panel_open', '1');
           // Open Operator by default if no chat is active.
@@ -1838,7 +1812,6 @@ function dashboard() {
       // wizard. Without this, an operator that boots slowly (e.g.
       // first start) would have skipped wizard kickoff at fetchAgents.
       if (!wasReady && this.operatorReady) {
-        try { this._maybeStartTutorial(); } catch (_) { /* ignore */ }
         try { this._maybeStartWizard(); } catch (_) { /* ignore */ }
       }
     },
@@ -2333,129 +2306,7 @@ function dashboard() {
       if (this.showSetup) return;
       if (!this.operatorReady) return;
       if (!this._isFirstVisit()) return;
-      // Tutorial takes precedence — wizard fires only after the
-      // tutorial completes (or was already seen). The completion
-      // handler in ``_completeTutorial`` re-invokes ``_maybeStartWizard``
-      // when the user reaches the final step naturally.
-      if (this.newUserTutorial && this.newUserTutorial.step !== 0) return;
       this.startWizard();
-    },
-
-    // ── New-user onboarding tutorial ──────────────────────────
-    //
-    // 3-step modal that orients a brand-new user on the layout +
-    // Operator concept. Detection: agents.length === 0 (excluding
-    // operator) AND ``localStorage.olSeenTutorial !== 'true'`` AND no
-    // active wizard. Runs BEFORE the empty-fleet wizard — the wizard
-    // is gated on ``newUserTutorial.step === 0`` so the two never
-    // overlap. On completion of step 3, we dismiss the tutorial and
-    // immediately fire the wizard so the user lands directly in the
-    // team-building flow. On any exit path — skip, dismiss, or
-    // reaching step 3 — we set the seen flag so the tutorial never
-    // re-shows for that browser.
-
-    _maybeStartTutorial() {
-      if (this.newUserTutorial.step !== 0) return;
-      if (this.wizard && this.wizard.step !== 'idle') return;
-      // Setup modal owns the screen first — don't stack under it.
-      if (this.showSetup) return;
-      try {
-        if (localStorage.getItem('olSeenTutorial') === 'true') return;
-      } catch (_) { /* private mode — show once per session */ }
-      // Use the canonical first-visit detector — covers empty fleet AND
-      // "no real user message in operator history". A returning user
-      // who deleted their fleet but already chatted with the operator
-      // is NOT a new user; suppressing the tutorial in that case
-      // matches the wizard's gating semantics.
-      if (!this._isFirstVisit()) return;
-      this.startTutorial();
-    },
-
-    startTutorial() {
-      this.newUserTutorial = { step: 1 };
-      this.track('tutorial_started', {});
-      // Capture focus + install ESC handler. Focus the modal on next
-      // tick so screen-readers announce the dialog.
-      try { this._newUserTutorialPrevFocus = document.activeElement; } catch (_) {}
-      this._newUserTutorialKeyHandler = (e) => {
-        if (e.key === 'Escape') {
-          e.preventDefault();
-          this.dismissTutorial('escape');
-        } else if (e.key === 'Tab') {
-          // Lightweight focus trap — keep tab cycling inside the modal.
-          const root = document.querySelector('[data-testid="tutorial-modal"]');
-          if (!root) return;
-          const focusable = root.querySelectorAll(
-            'button:not([disabled]), [href], [tabindex]:not([tabindex="-1"])'
-          );
-          if (focusable.length === 0) return;
-          const first = focusable[0];
-          const last = focusable[focusable.length - 1];
-          if (e.shiftKey && document.activeElement === first) {
-            e.preventDefault();
-            last.focus();
-          } else if (!e.shiftKey && document.activeElement === last) {
-            e.preventDefault();
-            first.focus();
-          }
-        }
-      };
-      window.addEventListener('keydown', this._newUserTutorialKeyHandler);
-      this.$nextTick(() => {
-        const root = document.querySelector('[data-testid="tutorial-modal"]');
-        const target = root && root.querySelector('[data-testid="tutorial-primary"]');
-        if (target && typeof target.focus === 'function') target.focus();
-      });
-    },
-
-    tutorialNext() {
-      if (this.newUserTutorial.step >= 3) {
-        this._completeTutorial('completed');
-        return;
-      }
-      this.newUserTutorial.step += 1;
-      this.track('tutorial_step', { step: this.newUserTutorial.step });
-      this.$nextTick(() => {
-        const root = document.querySelector('[data-testid="tutorial-modal"]');
-        const target = root && root.querySelector('[data-testid="tutorial-primary"]');
-        if (target && typeof target.focus === 'function') target.focus();
-      });
-    },
-
-    tutorialBack() {
-      if (this.newUserTutorial.step > 1) {
-        this.newUserTutorial.step -= 1;
-        this.track('tutorial_step', { step: this.newUserTutorial.step, direction: 'back' });
-      }
-    },
-
-    dismissTutorial(reason) {
-      this._completeTutorial(reason || 'dismissed');
-    },
-
-    _completeTutorial(reason) {
-      const lastStep = this.newUserTutorial.step;
-      try { localStorage.setItem('olSeenTutorial', 'true'); } catch (_) {}
-      this.newUserTutorial = { step: 0 };
-      this.track('tutorial_finished', { reason: reason, lastStep: lastStep });
-      if (this._newUserTutorialKeyHandler) {
-        window.removeEventListener('keydown', this._newUserTutorialKeyHandler);
-        this._newUserTutorialKeyHandler = null;
-      }
-      try {
-        if (this._newUserTutorialPrevFocus && this._newUserTutorialPrevFocus.focus) {
-          this._newUserTutorialPrevFocus.focus();
-        }
-      } catch (_) {}
-      this._newUserTutorialPrevFocus = null;
-      // On natural completion (Got it on step 3), hand off to the
-      // empty-fleet wizard so the user lands directly in team-building.
-      // Skip / ESC / overlay-click do NOT auto-fire the wizard — the
-      // user signaled they want out, respect that.
-      if (reason === 'completed') {
-        this.track('tutorial_to_wizard_transition', {});
-        try { this._maybeStartWizard(); } catch (_) { /* ignore */ }
-      }
     },
 
     // ── Tab switching ─────────────────────────────────────
@@ -5216,12 +5067,6 @@ function dashboard() {
           this._fetchCoordination();
           // Update operator readiness for the Chat tab
           this.checkOperatorReady();
-          // New-user onboarding tutorial — runs FIRST when both are
-          // eligible. ``_maybeStartWizard`` gates on
-          // ``newUserTutorial.step === 0`` so the wizard never fires
-          // while the tutorial is open. On natural completion of the
-          // tutorial, ``_completeTutorial`` re-invokes the wizard.
-          this._maybeStartTutorial();
           // Phase -1 wizard — first-visit detection runs after every
           // ``fetchAgents`` resolve so a freshly-spawned agent (still
           // loading at init time) doesn't pop the wizard. Re-entrant

--- a/src/dashboard/static/js/app.js
+++ b/src/dashboard/static/js/app.js
@@ -6086,6 +6086,7 @@ function dashboard() {
         budget_monthly: cfg.budget?.monthly_usd || '',
         thinking: cfg.thinking || 'off',
         can_use_browser: cfg.can_use_browser ?? false,
+        can_use_internet: cfg.can_use_internet ?? false,
         can_spawn: cfg.can_spawn ?? false,
         can_manage_cron: cfg.can_manage_cron ?? false,
         can_use_wallet: cfg.can_use_wallet ?? false,
@@ -6509,7 +6510,7 @@ function dashboard() {
       const credsChanged = JSON.stringify(newCreds) !== JSON.stringify(oldCreds);
       const permBody = {};
       if (credsChanged) permBody.allowed_credentials = newCreds;
-      for (const flag of ['can_use_browser', 'can_spawn', 'can_manage_cron', 'can_use_wallet']) {
+      for (const flag of ['can_use_browser', 'can_use_internet', 'can_spawn', 'can_manage_cron', 'can_use_wallet']) {
         if (this.editForm[flag] !== (cfg[flag] ?? false)) permBody[flag] = this.editForm[flag];
       }
       // Wallet allowed chains (from checkbox state)

--- a/src/dashboard/static/js/app.js
+++ b/src/dashboard/static/js/app.js
@@ -6593,6 +6593,8 @@ function dashboard() {
           if (permResp.ok) {
             const permResult = await permResp.json();
             allUpdated.push(...permResult.updated);
+            // Capability changes apply live — the permissions endpoint
+            // reloads the mesh matrix, so no restart is needed here.
           } else {
             const err = await permResp.json();
             this.showToast(`Error updating permissions: ${err.detail || 'Update failed'}`);
@@ -7660,6 +7662,11 @@ function dashboard() {
           if (resp.ok) {
             const data = await resp.json();
             if (data.updated?.length) this.showToast(`Updated ${data.updated.join(', ')}`);
+            // Execution-limit settings are env-seeded at launch — apply
+            // them automatically so the change isn't silently stale.
+            if (data.restart_required) {
+              await this._restartAllAgentsAuto('Applying setting — restarting agents…');
+            }
           } else {
             const err = await resp.json().catch(() => ({}));
             this.showToast(`Error: ${err.detail || 'Update failed'}`);
@@ -7679,11 +7686,71 @@ function dashboard() {
         if (resp.ok) {
           if (this.systemSettings) this.systemSettings.default_model = model;
           this.showToast(`Default model set to ${model}`);
+          // Agents resolve their model at launch, so the new default
+          // only takes effect for default-model agents after a restart.
+          // Auto-apply so the change isn't silently stale.
+          await this._restartAllAgentsAuto('Applying default model — restarting agents…');
         } else {
           const err = await resp.json().catch(() => ({}));
           this.showToast(`Error: ${err.detail || 'Update failed'}`);
         }
       } catch (e) { console.warn('saveDefaultModel failed:', e); }
+    },
+
+    // Restart the whole fleet WITHOUT a confirmation prompt. Used to
+    // auto-apply dashboard changes that are only picked up at container
+    // launch (execution limits, default model). The user-facing
+    // ``restartAllAgents`` keeps its confirm dialog for manual use.
+    async _restartAllAgentsAuto(reason) {
+      this._restartingAll = true;
+      this.showToast(reason || 'Applying changes — restarting agents…');
+      try {
+        const resp = await fetch(`${window.__config.apiBase}/restart-agents`, { method: 'POST' });
+        if (resp.ok) {
+          const data = await resp.json();
+          const agents = Object.entries(data.restarted || {});
+          const ok = agents.filter(([, s]) => s === 'ready').length;
+          this.showToast(`Applied — restarted ${ok}/${agents.length} agents`);
+          this.fetchAgents();
+        } else {
+          const err = await resp.json().catch(() => ({}));
+          this.showToast(`Saved, but restart failed: ${err.detail || resp.status}`);
+        }
+      } catch (e) { this.showToast(`Saved, but restart failed: ${e.message}`); }
+      this._restartingAll = false;
+    },
+
+    // Operator Settings → model change. PUTs the operator config (which
+    // hot-reloads the model live when possible) and auto-restarts the
+    // operator if the server reports the change needs a bounce.
+    async saveOperatorModel(model) {
+      if (!model) return;
+      try {
+        const resp = await fetch(`${window.__config.apiBase}/agents/operator/config`, {
+          method: 'PUT',
+          headers: { 'Content-Type': 'application/json', 'X-Requested-With': 'XMLHttpRequest' },
+          body: JSON.stringify({ model }),
+        });
+        if (!resp.ok) {
+          const err = await resp.json().catch(() => ({}));
+          this.showToast(`Error: ${err.detail || 'Update failed'}`);
+          return;
+        }
+        const data = await resp.json().catch(() => ({}));
+        if (data.restart_required) {
+          this.showToast('Operator model set — restarting operator…');
+          const r = await fetch(`${window.__config.apiBase}/agents/operator/restart`, { method: 'POST' });
+          if (r.ok) {
+            const d = await r.json().catch(() => ({}));
+            this.showToast(d.ready ? 'Operator restarted and ready' : 'Operator restarting…');
+          } else {
+            this.showToast('Operator model saved, restart failed');
+          }
+        } else {
+          this.showToast(`Operator model set to ${model}`);
+        }
+        this.fetchAgents();
+      } catch (e) { this.showToast(`Error: ${e.message}`); }
     },
 
     restartAllAgents() {

--- a/src/dashboard/static/js/app.js
+++ b/src/dashboard/static/js/app.js
@@ -1948,9 +1948,11 @@ function dashboard() {
     },
 
     trackEmptyStateCta(sectionId) {
-      // Wired from any empty-state CTA button in the template. Caller
-      // passes a stable ``section_id`` so we can compare CTA traction
-      // across the surfaces Phase 1+ may rework.
+      // Phase-0 baseline telemetry hook. Currently unwired — the operator
+      // empty-state intent chips that called it were removed when
+      // onboarding collapsed into the single setup modal — but retained
+      // (like trackSubtabUsage) so a future empty-state CTA can re-wire it
+      // without re-introducing the helper. See TestPhase0FrontendWiring.
       this.track('empty_state_cta_click', { section_id: sectionId || 'unknown' });
       this._trackFirstAction('empty_state_cta_click');
     },
@@ -9204,6 +9206,14 @@ function dashboard() {
           const err = await opResp.json().catch(() => ({}));
           this.showToast(`Error setting operator model: ${err.detail || opResp.status}`);
           return;
+        }
+        // The model normally hot-reloads live, but if the container
+        // couldn't be reached the server asks for a restart — honour it
+        // so the operator isn't left on its boot default. Mirrors
+        // saveOperatorModel().
+        const opData = await opResp.json().catch(() => ({}));
+        if (opData.restart_required) {
+          await fetch(`${window.__config.apiBase}/agents/operator/restart`, { method: 'POST' }).catch(() => {});
         }
 
         try { localStorage.setItem('ol_setup_done', '1'); } catch (_) { /* ignore */ }

--- a/src/dashboard/static/js/app.js
+++ b/src/dashboard/static/js/app.js
@@ -637,6 +637,11 @@ function dashboard() {
     onboardIsLlmProvider: false,
     onboardCustomModels: '',
     onboardCustomLabel: '',
+    // Initial setup modal — model selections + completion flag.
+    onboardOperatorModel: '',
+    onboardDefaultModel: '',
+    onboardFinishing: false,
+    _setupDone: false,
 
     // Phase -1 — Empty-fleet onboarding wizard (hypothesis test).
     // States: 'idle' (off) | 'ask' (chip card) | 'confirming' (operator
@@ -940,12 +945,25 @@ function dashboard() {
 
     // ── Computed ───────────────────────────────────────────
 
-    get showOnboarding() {
-      if (this.loading) return false;
-      // Show onboarding when settings haven't loaded yet (fallback) or when
-      // credentials are missing / no agents exist — prevents blank page.
-      if (!this.settingsData) return this.agents.length === 0;
-      return !this.settingsData.has_llm_credentials || this.agents.length === 0;
+    // Non-skippable initial-setup modal. Shows for genuinely-new
+    // installs until the user adds LLM access (a key OR OpenLegion
+    // credits) AND picks their Operator + Default agent models. Hidden
+    // for established installs (already have credentials + a real
+    // teammate) and once setup has been finished.
+    get showSetup() {
+      if (this.loading || !this.settingsData) return false;
+      if (this._setupDone) return false;
+      try { if (localStorage.getItem('ol_setup_done') === '1') return false; } catch (_) { /* ignore */ }
+      // Established install — don't interrupt returning users.
+      if (this.settingsData.has_llm_credentials && this.agents.some(a => a.id !== 'operator')) return false;
+      return true;
+    },
+
+    // Finish button is enabled only once LLM access is configured and
+    // both model choices are made.
+    get setupCanFinish() {
+      return !!(this.settingsData && this.settingsData.has_llm_credentials
+        && this.onboardOperatorModel && this.onboardDefaultModel);
     },
 
     get addAgentNameValid() {
@@ -2310,6 +2328,9 @@ function dashboard() {
       // localStorage and emit telemetry while the user sees nothing.
       // ``checkOperatorReady`` retries this on health transitions.
       if (this.wizard.step !== 'idle') return;
+      // Don't surface the in-chat starting-point card under the
+      // non-skippable setup modal — wait until setup is finished.
+      if (this.showSetup) return;
       if (!this.operatorReady) return;
       if (!this._isFirstVisit()) return;
       // Tutorial takes precedence — wizard fires only after the
@@ -2336,6 +2357,8 @@ function dashboard() {
     _maybeStartTutorial() {
       if (this.newUserTutorial.step !== 0) return;
       if (this.wizard && this.wizard.step !== 'idle') return;
+      // Setup modal owns the screen first — don't stack under it.
+      if (this.showSetup) return;
       try {
         if (localStorage.getItem('olSeenTutorial') === 'true') return;
       } catch (_) { /* private mode — show once per session */ }
@@ -9296,6 +9319,58 @@ function dashboard() {
         }
       } catch (e) { this.showToast(`Error: ${e.message}`); }
       finally { this.onboardSaving = false; }
+    },
+
+    // Complete the initial-setup modal: persist the Default agent model
+    // (mesh.yaml) and the Operator model, then mark setup done so the
+    // modal never reappears. The operator model hot-reloads live; the
+    // default model only matters for future agents (none exist yet at
+    // first setup), so no fleet restart is needed here.
+    async finishSetup() {
+      if (this.onboardFinishing) return;
+      if (!this.settingsData?.has_llm_credentials) {
+        this.showToast('Add an API key or use OpenLegion credits to continue.');
+        return;
+      }
+      if (!this.onboardOperatorModel || !this.onboardDefaultModel) {
+        this.showToast('Pick both an Operator model and a Default agent model.');
+        return;
+      }
+      this.onboardFinishing = true;
+      try {
+        const dmResp = await fetch(`${window.__config.apiBase}/default-model`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json', 'X-Requested-With': 'XMLHttpRequest' },
+          body: JSON.stringify({ model: this.onboardDefaultModel }),
+        });
+        if (!dmResp.ok) {
+          const err = await dmResp.json().catch(() => ({}));
+          this.showToast(`Error setting default model: ${err.detail || dmResp.status}`);
+          return;
+        }
+        if (this.systemSettings) this.systemSettings.default_model = this.onboardDefaultModel;
+
+        const opResp = await fetch(`${window.__config.apiBase}/agents/operator/config`, {
+          method: 'PUT',
+          headers: { 'Content-Type': 'application/json', 'X-Requested-With': 'XMLHttpRequest' },
+          body: JSON.stringify({ model: this.onboardOperatorModel }),
+        });
+        if (!opResp.ok) {
+          const err = await opResp.json().catch(() => ({}));
+          this.showToast(`Error setting operator model: ${err.detail || opResp.status}`);
+          return;
+        }
+
+        try { localStorage.setItem('ol_setup_done', '1'); } catch (_) { /* ignore */ }
+        this._setupDone = true;
+        this.showToast('Setup complete — say hello to your Operator.');
+        this.fetchAgents();
+        this.fetchSettings();
+      } catch (e) {
+        this.showToast(`Setup failed: ${e.message}`);
+      } finally {
+        this.onboardFinishing = false;
+      }
     },
 
     // ── Channels ──────────────────────────────────────────

--- a/src/dashboard/templates/index.html
+++ b/src/dashboard/templates/index.html
@@ -1467,64 +1467,15 @@
                   </div>
                 </div>
 
-                <!-- First-run: no agents yet.
-                     TODO: seed an actual assistant message in the
-                     operator's chat history on first container boot
-                     so the chat opens with a warm greeting from the
-                     operator instead of a passive empty-state. The
-                     deeper version requires cross-container coordination
-                     (boot detection in src/cli/runtime.py + a one-shot
-                     assistant message persisted via the agent's
-                     transcript, with idempotent detection so restarts
-                     don't re-greet). For now we keep the welcoming
-                     empty-state UI below — it's the silent-operator
-                     mitigation per the PR-F audit. -->
-                <div x-show="wizard.step === 'idle' && !(chatHistories['operator'] || []).length && !chatLoadingAgents['operator'] && agents.filter(a => a.id !== 'operator').length === 0"
-                  class="flex-1 flex flex-col items-center justify-center px-4">
-                  <img src="/dashboard/static/avatars/operator.png" alt="Operator" class="w-10 h-10 rounded-full mb-3 opacity-80">
-                  <div class="text-sm font-semibold text-white mb-1">Hi — I'm your Operator.</div>
-                  <div class="text-[11px] text-gray-400 mb-1 max-w-md text-center leading-relaxed">
-                    I help you build and run AI agent teams. Tell me what you'd like your team to handle, in plain English.
-                  </div>
-                  <div class="text-[11px] text-gray-400 mb-5 max-w-md text-center leading-relaxed">
-                    Pick a starting point below or describe your own — I'll handle the setup.
-                  </div>
-                  <!-- Curated intent-based options — uniform size -->
-                  <div class="flex flex-col gap-1.5 w-full max-w-sm">
-                    <button @click="trackEmptyStateCta('operator_intent_content'); let el = document.getElementById('operator-chat-input'); if (el) { let s = Alpine.$data(el.closest('[x-data]')); if (s) { let chip = (maxAgents > 0 && maxAgents <= 1) ? 'I need a content agent for writing, editing, and research' : 'I need a content team — writing, editing, and research'; s.opMsg = chip + (s.opMsg ? ' ' + s.opMsg : ''); $nextTick(() => { el.focus(); el.setSelectionRange(el.value.length, el.value.length); }); } }"
-                      class="flex items-center gap-3 w-full text-left px-4 py-2.5 rounded-lg bg-gray-800/50 border border-gray-700/50 hover:border-indigo-500/40 hover:bg-indigo-600/5 transition-all group">
-                      <svg class="w-4 h-4 text-gray-400 group-hover:text-indigo-400 shrink-0 transition-colors" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="1.5"><path stroke-linecap="round" stroke-linejoin="round" d="M12 6.042A8.967 8.967 0 006 3.75c-1.052 0-2.062.18-3 .512v14.25A8.987 8.987 0 016 18c2.305 0 4.408.867 6 2.292m0-14.25a8.966 8.966 0 016-2.292c1.052 0 2.062.18 3 .512v14.25A8.987 8.987 0 0018 18a8.967 8.967 0 00-6 2.292m0-14.25v14.25"/></svg>
-                      <div class="min-w-0"><div class="text-xs text-gray-200 group-hover:text-white">Content &amp; Marketing</div></div>
-                    </button>
-                    <button @click="trackEmptyStateCta('operator_intent_research'); let el = document.getElementById('operator-chat-input'); if (el) { let s = Alpine.$data(el.closest('[x-data]')); if (s) { let chip = (maxAgents > 0 && maxAgents <= 1) ? 'I need a research agent to gather intelligence and produce reports' : 'I need a research team to gather intelligence and produce reports'; s.opMsg = chip + (s.opMsg ? ' ' + s.opMsg : ''); $nextTick(() => { el.focus(); el.setSelectionRange(el.value.length, el.value.length); }); } }"
-                      class="flex items-center gap-3 w-full text-left px-4 py-2.5 rounded-lg bg-gray-800/50 border border-gray-700/50 hover:border-indigo-500/40 hover:bg-indigo-600/5 transition-all group">
-                      <svg class="w-4 h-4 text-gray-400 group-hover:text-indigo-400 shrink-0 transition-colors" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="1.5"><path stroke-linecap="round" stroke-linejoin="round" d="M21 21l-5.197-5.197m0 0A7.5 7.5 0 105.196 5.196a7.5 7.5 0 0010.607 10.607z"/></svg>
-                      <div class="min-w-0"><div class="text-xs text-gray-200 group-hover:text-white">Research &amp; Analysis</div></div>
-                    </button>
-                    <button @click="trackEmptyStateCta('operator_intent_sales'); let el = document.getElementById('operator-chat-input'); if (el) { let s = Alpine.$data(el.closest('[x-data]')); if (s) { let chip = (maxAgents > 0 && maxAgents <= 1) ? 'I need a sales agent for prospecting and outreach' : 'I need a sales team for prospecting and outreach'; s.opMsg = chip + (s.opMsg ? ' ' + s.opMsg : ''); $nextTick(() => { el.focus(); el.setSelectionRange(el.value.length, el.value.length); }); } }"
-                      class="flex items-center gap-3 w-full text-left px-4 py-2.5 rounded-lg bg-gray-800/50 border border-gray-700/50 hover:border-indigo-500/40 hover:bg-indigo-600/5 transition-all group">
-                      <svg class="w-4 h-4 text-gray-400 group-hover:text-indigo-400 shrink-0 transition-colors" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="1.5"><path stroke-linecap="round" stroke-linejoin="round" d="M2.25 6.75c0 8.284 6.716 15 15 15h2.25a2.25 2.25 0 002.25-2.25v-1.372c0-.516-.351-.966-.852-1.091l-4.423-1.106c-.44-.11-.902.055-1.173.417l-.97 1.293c-.282.376-.769.542-1.21.38a12.035 12.035 0 01-7.143-7.143c-.162-.441.004-.928.38-1.21l1.293-.97c.363-.271.527-.734.417-1.173L6.963 3.102a1.125 1.125 0 00-1.091-.852H4.5A2.25 2.25 0 002.25 4.5v2.25z"/></svg>
-                      <div class="min-w-0"><div class="text-xs text-gray-200 group-hover:text-white">Sales &amp; Outreach</div></div>
-                    </button>
-                    <button @click="trackEmptyStateCta('operator_intent_devteam'); let el = document.getElementById('operator-chat-input'); if (el) { let s = Alpine.$data(el.closest('[x-data]')); if (s) { let chip = (maxAgents > 0 && maxAgents <= 1) ? 'I need a development agent for planning, coding, and code review' : 'I need a development team — planning, coding, and code review'; s.opMsg = chip + (s.opMsg ? ' ' + s.opMsg : ''); $nextTick(() => { el.focus(); el.setSelectionRange(el.value.length, el.value.length); }); } }"
-                      class="flex items-center gap-3 w-full text-left px-4 py-2.5 rounded-lg bg-gray-800/50 border border-gray-700/50 hover:border-indigo-500/40 hover:bg-indigo-600/5 transition-all group">
-                      <svg class="w-4 h-4 text-gray-400 group-hover:text-indigo-400 shrink-0 transition-colors" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="1.5"><path stroke-linecap="round" stroke-linejoin="round" d="M17.25 6.75L22.5 12l-5.25 5.25m-10.5 0L1.5 12l5.25-5.25m7.5-3l-4.5 16.5"/></svg>
-                      <div class="min-w-0"><div class="text-xs text-gray-200 group-hover:text-white">Software Development</div></div>
-                    </button>
-                    <button @click="trackEmptyStateCta('operator_intent_other'); $nextTick(() => { let el = document.getElementById('operator-chat-input'); if (el) el.focus(); })"
-                      class="flex items-center gap-3 w-full text-left px-4 py-2.5 rounded-lg bg-transparent border border-gray-800/40 hover:border-gray-700/60 hover:bg-gray-800/20 transition-all group">
-                      <svg class="w-4 h-4 text-gray-500 group-hover:text-gray-400 shrink-0 transition-colors" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="1.5"><path stroke-linecap="round" stroke-linejoin="round" d="M8.625 12a.375.375 0 11-.75 0 .375.375 0 01.75 0zm0 0H8.25m4.125 0a.375.375 0 11-.75 0 .375.375 0 01.75 0zm0 0H12m4.125 0a.375.375 0 11-.75 0 .375.375 0 01.75 0zm0 0h-.375M21 12c0 4.556-4.03 8.25-9 8.25a9.764 9.764 0 01-2.555-.337A5.972 5.972 0 015.41 20.97a5.969 5.969 0 01-.474-.065 4.48 4.48 0 00.978-2.025c.09-.457-.133-.901-.467-1.226C3.93 16.178 3 14.189 3 12c0-4.556 4.03-8.25 9-8.25s9 3.694 9 8.25z"/></svg>
-                      <div class="min-w-0"><div class="text-xs text-gray-400 group-hover:text-gray-300">Something else&hellip;</div></div>
-                    </button>
-                  </div>
-                </div>
-
-                <!-- Regular empty state (has agents but no chat yet) -->
-                <div x-show="!(chatHistories['operator'] || []).length && !chatLoadingAgents['operator'] && agents.filter(a => a.id !== 'operator').length > 0"
+                <!-- Empty state — shown whenever the operator chat has no
+                     messages and the in-chat wizard isn't open. Covers
+                     both new users (who dismissed the wizard) and
+                     returning users between sessions. -->
+                <div x-show="wizard.step === 'idle' && !(chatHistories['operator'] || []).length && !chatLoadingAgents['operator']"
                   class="empty-state h-full justify-center">
                   <svg class="w-8 h-8" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="1.5"><path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z"/></svg>
                   <div class="empty-state-title">Chat with your operator</div>
-                  <div class="empty-state-desc">Ask about team status, optimize teammates, or build new teams.</div>
+                  <div class="empty-state-desc">Tell me what you'd like your team to handle, or ask about status — I'll take it from here.</div>
                 </div>
               </div>
 
@@ -8953,133 +8904,6 @@
         </div>
       </div>
     </div>
-
-    <!-- New-user onboarding tutorial. Three skippable modal steps;
-         persists ``localStorage.olSeenTutorial`` on completion or
-         dismiss. Repurposed from the Phase-4 "What's new" tour
-         infrastructure — same modal chrome, focus trap, ESC handler
-         (wired in app.js), and mobile full-screen via ``sm:max-w-md``.
-         The audience is inverted: this fires for EMPTY fleets and runs
-         BEFORE the empty-fleet wizard. On natural completion, the
-         wizard auto-fires so the user lands directly in team-building. -->
-    <template x-if="newUserTutorial.step !== 0">
-      <div class="fixed inset-0 z-[150] flex items-center justify-center bg-black/70 backdrop-blur-sm p-0 sm:p-4"
-           data-testid="tutorial-overlay"
-           @click.self="dismissTutorial('overlay')">
-        <div role="dialog" aria-modal="true" :aria-labelledby="'tutorial-title-' + newUserTutorial.step"
-             data-testid="tutorial-modal"
-             class="relative w-full h-full sm:h-auto sm:max-w-md sm:rounded-2xl bg-gradient-to-b from-indigo-900/40 to-gray-900/95 sm:border sm:border-indigo-700/40 shadow-2xl overflow-y-auto sm:overflow-visible flex flex-col sm:block">
-          <!-- Step 1 — Welcome / what is OpenLegion -->
-          <template x-if="newUserTutorial.step === 1">
-            <div class="px-6 pt-8 pb-6 sm:pt-7 sm:pb-6 flex-1 flex flex-col">
-              <div class="flex items-start justify-between mb-3">
-                <div class="text-[11px] uppercase tracking-wide text-indigo-300/80">Step 1 of 3</div>
-                <button @click="dismissTutorial('skip_button')"
-                        data-testid="tutorial-skip"
-                        aria-label="Skip tutorial"
-                        class="text-gray-400 hover:text-gray-300 transition-colors p-1 -mr-1 -mt-1 rounded text-xs">
-                  Skip
-                </button>
-              </div>
-              <h2 id="tutorial-title-1" class="text-lg font-semibold text-white mb-2">
-                Welcome to OpenLegion
-              </h2>
-              <p class="text-sm text-gray-300 leading-relaxed mb-6 flex-1">
-                OpenLegion is your AI team manager. You hire AI workers, give them tasks,
-                and watch them deliver &mdash; like a small remote team.
-              </p>
-              <div class="flex items-center justify-end gap-2">
-                <button @click="dismissTutorial('skip_button')"
-                        class="text-xs font-medium px-4 py-2 rounded-lg bg-transparent hover:bg-gray-800/60 text-gray-400 transition-colors">
-                  Skip
-                </button>
-                <button @click="tutorialNext()"
-                        data-testid="tutorial-primary"
-                        class="text-xs font-medium px-4 py-2 rounded-lg bg-indigo-600 hover:bg-indigo-500 text-white transition-colors">
-                  Show me how
-                </button>
-              </div>
-            </div>
-          </template>
-
-          <!-- Step 2 — Meet your Operator -->
-          <template x-if="newUserTutorial.step === 2">
-            <div class="px-6 pt-8 pb-6 sm:pt-7 sm:pb-6 flex-1 flex flex-col">
-              <div class="flex items-start justify-between mb-3">
-                <div class="text-[11px] uppercase tracking-wide text-indigo-300/80">Step 2 of 3</div>
-                <button @click="dismissTutorial('skip_button')"
-                        aria-label="Skip tutorial"
-                        class="text-gray-400 hover:text-gray-300 transition-colors p-1 -mr-1 -mt-1 rounded text-xs">
-                  Skip
-                </button>
-              </div>
-              <h2 id="tutorial-title-2" class="text-lg font-semibold text-white mb-3">
-                Meet your Operator
-              </h2>
-              <div class="rounded-xl bg-gray-900/60 border border-indigo-500/30 p-4 mb-4 flex items-center gap-3">
-                <div class="w-10 h-10 rounded-full bg-indigo-600/30 border border-indigo-400/50 flex items-center justify-center shrink-0">
-                  <!-- Chat-bubble pictogram pointing at the Chat tab. -->
-                  <svg class="w-5 h-5 text-indigo-300" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-                    <path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z"/>
-                  </svg>
-                </div>
-                <div class="text-xs text-gray-300 leading-relaxed">You&rsquo;re in <span class="font-semibold text-indigo-200">Chat</span> &mdash; talk to your Operator here.</div>
-              </div>
-              <p class="text-sm text-gray-300 leading-relaxed mb-6 flex-1">
-                The Operator is your team lead. You talk to them in Chat (you&rsquo;re here
-                now). They route work, manage your team, and ping you when you&rsquo;re
-                needed.
-              </p>
-              <div class="flex items-center justify-between gap-2">
-                <button @click="tutorialBack()"
-                        class="text-xs font-medium px-4 py-2 rounded-lg bg-transparent hover:bg-gray-800/60 text-gray-400 transition-colors">
-                  Back
-                </button>
-                <button @click="tutorialNext()"
-                        data-testid="tutorial-primary"
-                        class="text-xs font-medium px-4 py-2 rounded-lg bg-indigo-600 hover:bg-indigo-500 text-white transition-colors">
-                  Next
-                </button>
-              </div>
-            </div>
-          </template>
-
-          <!-- Step 3 — See what your team is doing -->
-          <template x-if="newUserTutorial.step === 3">
-            <div class="px-6 pt-8 pb-6 sm:pt-7 sm:pb-6 flex-1 flex flex-col">
-              <div class="flex items-start justify-between mb-3">
-                <div class="text-[11px] uppercase tracking-wide text-indigo-300/80">Step 3 of 3</div>
-              </div>
-              <h2 id="tutorial-title-3" class="text-lg font-semibold text-white mb-3">
-                See what your team is doing
-              </h2>
-              <div class="rounded-xl bg-gray-900/60 border border-indigo-500/30 p-4 mb-4 flex items-center gap-3">
-                <span class="inline-flex items-center justify-center min-w-[18px] h-[18px] px-1 rounded-full bg-red-500 text-[11px] font-bold text-white">3</span>
-                <span class="text-gray-400">+</span>
-                <svg class="w-4 h-4 text-gray-300" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M15 17h5l-1.405-1.405A2.032 2.032 0 0118 14.158V11a6.002 6.002 0 00-4-5.659V5a2 2 0 10-4 0v.341C7.67 6.165 6 8.388 6 11v3.159c0 .538-.214 1.055-.595 1.436L4 17h5m6 0v1a3 3 0 11-6 0v-1m6 0H9"/></svg>
-                <div class="text-xs text-gray-300 leading-relaxed flex-1">A red badge means something needs you.</div>
-              </div>
-              <p class="text-sm text-gray-300 leading-relaxed mb-6 flex-1">
-                <span class="font-semibold text-indigo-200">Work</span> shows what your team
-                has delivered and what&rsquo;s in progress. Anything that needs you shows
-                as a red badge in the top-right &mdash; across every tab.
-              </p>
-              <div class="flex items-center justify-between gap-2">
-                <button @click="tutorialBack()"
-                        class="text-xs font-medium px-4 py-2 rounded-lg bg-transparent hover:bg-gray-800/60 text-gray-400 transition-colors">
-                  Back
-                </button>
-                <button @click="tutorialNext()"
-                        data-testid="tutorial-primary"
-                        class="text-xs font-medium px-4 py-2 rounded-lg bg-indigo-600 hover:bg-indigo-500 text-white transition-colors">
-                  Got it, let&rsquo;s build a team
-                </button>
-              </div>
-            </div>
-          </template>
-        </div>
-      </div>
-    </template>
 
     <!-- Minimized chat pill -->
     <div x-show="activeTab !== 'chat' && openChats.length > 0 && chatPanelMinimized" x-cloak

--- a/src/dashboard/templates/index.html
+++ b/src/dashboard/templates/index.html
@@ -6652,7 +6652,7 @@
                     </div>
                   </div>
                   <div class="flex items-center gap-2">
-                    <button @click="if(opModelValue.trim()) { fetch(window.__config.apiBase + '/agents/operator/config', { method: 'PUT', headers: {'Content-Type':'application/json', 'X-Requested-With':'XMLHttpRequest'}, body: JSON.stringify({model: opModelValue.trim()}) }).then(() => { fetchAgents(); opModelEditing = false; }); }"
+                    <button @click="if(opModelValue.trim()) { saveOperatorModel(opModelValue.trim()).then(() => { opModelEditing = false; }); }"
                       class="text-xs px-2.5 py-1 rounded bg-indigo-600 hover:bg-indigo-500 text-white transition-colors">Save</button>
                     <button @click="opModelEditing = false; _opModelDropdownOpen = false"
                       class="text-xs px-2.5 py-1 rounded bg-gray-700 hover:bg-gray-600 text-gray-400 transition-colors">Cancel</button>

--- a/src/dashboard/templates/index.html
+++ b/src/dashboard/templates/index.html
@@ -2471,141 +2471,6 @@
             <svg class="size-4" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12"/></svg>
           </button>
         </div>
-        <!-- Onboarding banner (first-run) -->
-        <!-- Initial setup — a single, non-skippable modal that every new
-             user completes before reaching the workspace. Covers (1) LLM
-             credentials (skippable when OpenLegion credits are present)
-             and (2) choosing the Operator model + Default agent model.
-             Visibility is driven by ``showSetup`` (see app.js). There is
-             intentionally no close button / backdrop-dismiss. -->
-        <div x-show="showSetup && !loading" x-cloak
-             x-init="$watch('showSetup', v => { if (v) { onboardDefaultModel = onboardDefaultModel || (systemSettings && systemSettings.default_model) || ''; onboardOperatorModel = onboardOperatorModel || (opAgent && opAgent.model) || ''; } })"
-             class="fixed inset-0 z-[160] flex items-center justify-center p-4 bg-black/70 backdrop-blur-sm">
-          <div class="w-full max-w-lg bg-gray-900 border border-indigo-800/40 rounded-xl p-6 shadow-2xl max-h-[90vh] overflow-y-auto" data-testid="setup-modal">
-          <h3 class="text-lg font-semibold text-white mb-1">Welcome to OpenLegion</h3>
-          <p class="text-xs text-gray-400 mb-5">A couple of quick steps to get your workspace ready.</p>
-          <div class="space-y-5">
-            <!-- Step 1: API key -->
-            <div class="flex items-start gap-3">
-              <div class="shrink-0 w-6 h-6 rounded-full flex items-center justify-center text-xs font-bold"
-                :class="settingsData?.has_llm_credentials ? 'bg-emerald-600 text-white' : 'bg-gray-700 text-gray-400'">
-                <span x-show="settingsData?.has_llm_credentials">&#10003;</span>
-                <span x-show="!settingsData?.has_llm_credentials">1</span>
-              </div>
-              <div class="flex-1">
-                <div class="text-sm font-medium text-gray-200 mb-2" x-text="settingsData?.credit_proxy_configured && !settingsData?.has_byok_keys ? 'Configure LLM access' : 'Add an API key'"></div>
-                <div x-show="!settingsData?.has_llm_credentials" class="space-y-2">
-                  <div class="flex flex-wrap gap-2">
-                    <select x-model="onboardProvider" :disabled="onboardSaving" class="dash-select text-xs w-40" @change="onboardAuthType = 'api_key'; if ($event.target.value !== '__custom__') { onboardCustomService = ''; onboardIsLlmProvider = false; onboardCustomModels = ''; onboardCustomLabel = ''; }">
-                      <option value="">Provider...</option>
-                      {% for p in providers %}
-                      <option value="{{ p.name }}">{{ p.label }}</option>
-                      {% endfor %}
-                      <option value="__custom__">Custom...</option>
-                    </select>
-                    <template x-if="onboardProvider === '__custom__'">
-                      <input type="text" x-model="onboardCustomService" :disabled="onboardSaving" class="dash-input text-xs w-40" placeholder="Provider name">
-                    </template>
-                    <template x-if="onboardProvider === 'anthropic' || onboardProvider === 'openai'">
-                      <select x-model="onboardAuthType" :disabled="onboardSaving" class="dash-select text-xs w-48">
-                        <option value="api_key">API Key (recommended)</option>
-                        <option value="oauth" x-text="onboardProvider === 'openai' ? 'ChatGPT OAuth (JSON)' : 'Subscription Token'"></option>
-                      </select>
-                    </template>
-                    <input type="password" x-model="onboardKey" :disabled="onboardSaving" class="dash-input flex-1 min-w-0 sm:min-w-[200px]"
-                      :placeholder="onboardAuthType === 'oauth' ? (onboardProvider === 'openai' ? '{&quot;access_token&quot;:...,&quot;refresh_token&quot;:...}' : 'sk-ant-oat01-...') : 'API key'">
-                  </div>
-                  <template x-if="onboardAuthType === 'oauth' && onboardProvider === 'anthropic'">
-                    <div class="text-[11px] text-amber-400/80 leading-snug">
-                      Experimental — uses unofficial OAuth that may break without notice. Generate with: <code class="font-mono bg-gray-800 px-1 rounded">claude setup-token</code>
-                    </div>
-                  </template>
-                  <template x-if="onboardAuthType === 'oauth' && onboardProvider === 'openai'">
-                    <div class="text-[11px] text-amber-400/80 leading-snug">
-                      Paste the JSON blob from <code class="font-mono bg-gray-800 px-1 rounded">~/.codex/auth.json</code> containing <code class="font-mono bg-gray-800 px-1 rounded">access_token</code> and <code class="font-mono bg-gray-800 px-1 rounded">refresh_token</code>.
-                    </div>
-                  </template>
-                  <div x-show="onboardAuthType !== 'oauth'" class="flex flex-wrap gap-2 items-center">
-                    <input type="text" x-model="onboardBaseUrl" :disabled="onboardSaving" class="dash-input flex-1 min-w-0 sm:min-w-[200px]" placeholder="Custom API base URL (optional)">
-                  </div>
-                  <template x-if="onboardProvider === '__custom__'">
-                    <div class="space-y-1.5">
-                      <label class="inline-flex items-center gap-1.5 text-xs text-gray-400 cursor-pointer select-none">
-                        <input type="checkbox" x-model="onboardIsLlmProvider" class="rounded border-gray-700 bg-gray-800 text-indigo-500 focus:ring-indigo-500/30">
-                        This is an LLM provider
-                      </label>
-                      <template x-if="onboardIsLlmProvider">
-                        <div class="space-y-1.5">
-                          <input type="text" x-model="onboardCustomLabel" :disabled="onboardSaving" class="dash-input w-full text-xs" placeholder="Display name (e.g. My Provider)">
-                          <textarea x-model="onboardCustomModels" :disabled="onboardSaving" class="dash-input w-full text-xs" rows="2" placeholder="Model names, comma-separated (e.g. model-7b, model-70b)"></textarea>
-                          <div class="text-[11px] text-gray-400">Models will be available as <code class="bg-gray-800 px-0.5 rounded" x-text="(onboardCustomService || 'provider') + '/model-name'"></code>. Must be OpenAI-compatible.</div>
-                        </div>
-                      </template>
-                    </div>
-                  </template>
-                  <div class="flex flex-wrap gap-2 items-center">
-                    <button @click="submitOnboardCredential()" :disabled="onboardSaving || !onboardProvider || !onboardKey || (onboardProvider === '__custom__' && !onboardCustomService.trim())"
-                      class="text-xs px-4 py-1.5 rounded bg-indigo-600 hover:bg-indigo-500 text-white disabled:opacity-50 transition-colors inline-flex items-center gap-1.5">
-                      <svg x-show="onboardSaving" x-cloak class="animate-spin h-3 w-3" fill="none" viewBox="0 0 24 24"><circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"/><path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z"/></svg>
-                      <span x-text="onboardSaving ? 'Saving...' : 'Save'"></span>
-                    </button>
-                  </div>
-                </div>
-                <div x-show="settingsData?.has_llm_credentials" class="space-y-1">
-                  <div x-show="settingsData?.has_byok_keys" class="text-xs text-emerald-400">API key configured</div>
-                  <div x-show="settingsData?.credit_proxy_configured && !settingsData?.has_byok_keys" class="text-xs text-emerald-400">Credits configured</div>
-                  <div x-show="settingsData?.credit_proxy_configured && !settingsData?.has_byok_keys" class="text-[11px] text-gray-400">
-                    Add your own API key above for zero-markup access<template x-if="settingsData?.app_url"><span>, or <a :href="settingsData.app_url + '/credits'" target="_blank" rel="noopener noreferrer" class="text-indigo-400 hover:text-indigo-300">manage credits</a></span></template>
-                  </div>
-                </div>
-              </div>
-            </div>
-            <!-- Step 2: Choose models. Required for everyone — we no
-                 longer auto-assign a default. Disabled until LLM access
-                 (a key OR OpenLegion credits) is configured above. -->
-            <div class="flex items-start gap-3" :class="!settingsData?.has_llm_credentials ? 'opacity-50 pointer-events-none' : ''">
-              <div class="shrink-0 w-6 h-6 rounded-full flex items-center justify-center text-xs font-bold"
-                :class="(onboardOperatorModel && onboardDefaultModel) ? 'bg-emerald-600 text-white' : 'bg-gray-700 text-gray-400'">
-                <span x-show="onboardOperatorModel && onboardDefaultModel">&#10003;</span>
-                <span x-show="!(onboardOperatorModel && onboardDefaultModel)">2</span>
-              </div>
-              <div class="flex-1 space-y-3">
-                <div class="text-sm font-medium text-gray-200">Choose your models</div>
-                <div>
-                  <label class="text-xs text-gray-400 mb-1 block">Operator model
-                    <span class="text-gray-500">— powers the assistant you chat with</span></label>
-                  <select x-model="onboardOperatorModel" class="dash-select text-xs w-full" data-testid="setup-operator-model">
-                    <option value="">Select model…</option>
-                    <template x-for="m in availableModels" :key="m">
-                      <option :value="m" x-text="m"></option>
-                    </template>
-                  </select>
-                </div>
-                <div>
-                  <label class="text-xs text-gray-400 mb-1 block">Default agent model
-                    <span class="text-gray-500">— used by new teammates unless overridden</span></label>
-                  <select x-model="onboardDefaultModel" class="dash-select text-xs w-full" data-testid="setup-default-model">
-                    <option value="">Select model…</option>
-                    <template x-for="m in availableModels" :key="m">
-                      <option :value="m" x-text="m"></option>
-                    </template>
-                  </select>
-                </div>
-              </div>
-            </div>
-          </div>
-          <div class="mt-6 flex items-center justify-end gap-3">
-            <span x-show="!settingsData?.has_llm_credentials" class="text-[11px] text-gray-500">Add LLM access to continue</span>
-            <button @click="finishSetup()"
-              :disabled="!setupCanFinish || onboardFinishing"
-              class="text-xs px-4 py-2 rounded bg-indigo-600 hover:bg-indigo-500 text-white disabled:opacity-50 transition-colors inline-flex items-center gap-1.5"
-              data-testid="setup-finish">
-              <svg x-show="onboardFinishing" x-cloak class="animate-spin h-3 w-3" fill="none" viewBox="0 0 24 24"><circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"/><path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z"/></svg>
-              <span x-text="onboardFinishing ? 'Finishing…' : 'Finish setup'"></span>
-            </button>
-          </div>
-          </div>
-        </div>
       </div>
 
 
@@ -8904,6 +8769,141 @@
         </div>
       </div>
     </div>
+
+        <!-- Initial setup — a single, non-skippable modal that every new
+             user completes before reaching the workspace. Covers (1) LLM
+             credentials (skippable when OpenLegion credits are present)
+             and (2) choosing the Operator model + Default agent model.
+             Visibility is driven by ``showSetup`` (see app.js). There is
+             intentionally no close button / backdrop-dismiss. -->
+        <div x-show="showSetup && !loading" x-cloak
+             x-init="$watch('showSetup', v => { if (v) { onboardDefaultModel = onboardDefaultModel || (systemSettings && systemSettings.default_model) || ''; onboardOperatorModel = onboardOperatorModel || ((agents.find(a => a.id === 'operator') || {}).model) || ''; } })"
+             class="fixed inset-0 z-[160] flex items-center justify-center p-4 bg-black/70 backdrop-blur-sm">
+          <div class="w-full max-w-lg bg-gray-900 border border-indigo-800/40 rounded-xl p-6 shadow-2xl max-h-[90vh] overflow-y-auto" data-testid="setup-modal">
+          <h3 class="text-lg font-semibold text-white mb-1">Welcome to OpenLegion</h3>
+          <p class="text-xs text-gray-400 mb-5">A couple of quick steps to get your workspace ready.</p>
+          <div class="space-y-5">
+            <!-- Step 1: API key -->
+            <div class="flex items-start gap-3">
+              <div class="shrink-0 w-6 h-6 rounded-full flex items-center justify-center text-xs font-bold"
+                :class="settingsData?.has_llm_credentials ? 'bg-emerald-600 text-white' : 'bg-gray-700 text-gray-400'">
+                <span x-show="settingsData?.has_llm_credentials">&#10003;</span>
+                <span x-show="!settingsData?.has_llm_credentials">1</span>
+              </div>
+              <div class="flex-1">
+                <div class="text-sm font-medium text-gray-200 mb-2" x-text="settingsData?.credit_proxy_configured && !settingsData?.has_byok_keys ? 'Configure LLM access' : 'Add an API key'"></div>
+                <div x-show="!settingsData?.has_llm_credentials" class="space-y-2">
+                  <div class="flex flex-wrap gap-2">
+                    <select x-model="onboardProvider" :disabled="onboardSaving" class="dash-select text-xs w-40" @change="onboardAuthType = 'api_key'; if ($event.target.value !== '__custom__') { onboardCustomService = ''; onboardIsLlmProvider = false; onboardCustomModels = ''; onboardCustomLabel = ''; }">
+                      <option value="">Provider...</option>
+                      {% for p in providers %}
+                      <option value="{{ p.name }}">{{ p.label }}</option>
+                      {% endfor %}
+                      <option value="__custom__">Custom...</option>
+                    </select>
+                    <template x-if="onboardProvider === '__custom__'">
+                      <input type="text" x-model="onboardCustomService" :disabled="onboardSaving" class="dash-input text-xs w-40" placeholder="Provider name">
+                    </template>
+                    <template x-if="onboardProvider === 'anthropic' || onboardProvider === 'openai'">
+                      <select x-model="onboardAuthType" :disabled="onboardSaving" class="dash-select text-xs w-48">
+                        <option value="api_key">API Key (recommended)</option>
+                        <option value="oauth" x-text="onboardProvider === 'openai' ? 'ChatGPT OAuth (JSON)' : 'Subscription Token'"></option>
+                      </select>
+                    </template>
+                    <input type="password" x-model="onboardKey" :disabled="onboardSaving" class="dash-input flex-1 min-w-0 sm:min-w-[200px]"
+                      :placeholder="onboardAuthType === 'oauth' ? (onboardProvider === 'openai' ? '{&quot;access_token&quot;:...,&quot;refresh_token&quot;:...}' : 'sk-ant-oat01-...') : 'API key'">
+                  </div>
+                  <template x-if="onboardAuthType === 'oauth' && onboardProvider === 'anthropic'">
+                    <div class="text-[11px] text-amber-400/80 leading-snug">
+                      Experimental — uses unofficial OAuth that may break without notice. Generate with: <code class="font-mono bg-gray-800 px-1 rounded">claude setup-token</code>
+                    </div>
+                  </template>
+                  <template x-if="onboardAuthType === 'oauth' && onboardProvider === 'openai'">
+                    <div class="text-[11px] text-amber-400/80 leading-snug">
+                      Paste the JSON blob from <code class="font-mono bg-gray-800 px-1 rounded">~/.codex/auth.json</code> containing <code class="font-mono bg-gray-800 px-1 rounded">access_token</code> and <code class="font-mono bg-gray-800 px-1 rounded">refresh_token</code>.
+                    </div>
+                  </template>
+                  <div x-show="onboardAuthType !== 'oauth'" class="flex flex-wrap gap-2 items-center">
+                    <input type="text" x-model="onboardBaseUrl" :disabled="onboardSaving" class="dash-input flex-1 min-w-0 sm:min-w-[200px]" placeholder="Custom API base URL (optional)">
+                  </div>
+                  <template x-if="onboardProvider === '__custom__'">
+                    <div class="space-y-1.5">
+                      <label class="inline-flex items-center gap-1.5 text-xs text-gray-400 cursor-pointer select-none">
+                        <input type="checkbox" x-model="onboardIsLlmProvider" class="rounded border-gray-700 bg-gray-800 text-indigo-500 focus:ring-indigo-500/30">
+                        This is an LLM provider
+                      </label>
+                      <template x-if="onboardIsLlmProvider">
+                        <div class="space-y-1.5">
+                          <input type="text" x-model="onboardCustomLabel" :disabled="onboardSaving" class="dash-input w-full text-xs" placeholder="Display name (e.g. My Provider)">
+                          <textarea x-model="onboardCustomModels" :disabled="onboardSaving" class="dash-input w-full text-xs" rows="2" placeholder="Model names, comma-separated (e.g. model-7b, model-70b)"></textarea>
+                          <div class="text-[11px] text-gray-400">Models will be available as <code class="bg-gray-800 px-0.5 rounded" x-text="(onboardCustomService || 'provider') + '/model-name'"></code>. Must be OpenAI-compatible.</div>
+                        </div>
+                      </template>
+                    </div>
+                  </template>
+                  <div class="flex flex-wrap gap-2 items-center">
+                    <button @click="submitOnboardCredential()" :disabled="onboardSaving || !onboardProvider || !onboardKey || (onboardProvider === '__custom__' && !onboardCustomService.trim())"
+                      class="text-xs px-4 py-1.5 rounded bg-indigo-600 hover:bg-indigo-500 text-white disabled:opacity-50 transition-colors inline-flex items-center gap-1.5">
+                      <svg x-show="onboardSaving" x-cloak class="animate-spin h-3 w-3" fill="none" viewBox="0 0 24 24"><circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"/><path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z"/></svg>
+                      <span x-text="onboardSaving ? 'Saving...' : 'Save'"></span>
+                    </button>
+                  </div>
+                </div>
+                <div x-show="settingsData?.has_llm_credentials" class="space-y-1">
+                  <div x-show="settingsData?.has_byok_keys" class="text-xs text-emerald-400">API key configured</div>
+                  <div x-show="settingsData?.credit_proxy_configured && !settingsData?.has_byok_keys" class="text-xs text-emerald-400">Credits configured</div>
+                  <div x-show="settingsData?.credit_proxy_configured && !settingsData?.has_byok_keys" class="text-[11px] text-gray-400">
+                    Add your own API key above for zero-markup access<template x-if="settingsData?.app_url"><span>, or <a :href="settingsData.app_url + '/credits'" target="_blank" rel="noopener noreferrer" class="text-indigo-400 hover:text-indigo-300">manage credits</a></span></template>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <!-- Step 2: Choose models. Required for everyone — we no
+                 longer auto-assign a default. Disabled until LLM access
+                 (a key OR OpenLegion credits) is configured above. -->
+            <div class="flex items-start gap-3" :class="!settingsData?.has_llm_credentials ? 'opacity-50 pointer-events-none' : ''">
+              <div class="shrink-0 w-6 h-6 rounded-full flex items-center justify-center text-xs font-bold"
+                :class="(onboardOperatorModel && onboardDefaultModel) ? 'bg-emerald-600 text-white' : 'bg-gray-700 text-gray-400'">
+                <span x-show="onboardOperatorModel && onboardDefaultModel">&#10003;</span>
+                <span x-show="!(onboardOperatorModel && onboardDefaultModel)">2</span>
+              </div>
+              <div class="flex-1 space-y-3">
+                <div class="text-sm font-medium text-gray-200">Choose your models</div>
+                <div>
+                  <label class="text-xs text-gray-400 mb-1 block">Operator model
+                    <span class="text-gray-500">— powers the assistant you chat with</span></label>
+                  <select x-model="onboardOperatorModel" class="dash-select text-xs w-full" data-testid="setup-operator-model">
+                    <option value="">Select model…</option>
+                    <template x-for="m in availableModels" :key="m">
+                      <option :value="m" x-text="m"></option>
+                    </template>
+                  </select>
+                </div>
+                <div>
+                  <label class="text-xs text-gray-400 mb-1 block">Default agent model
+                    <span class="text-gray-500">— used by new teammates unless overridden</span></label>
+                  <select x-model="onboardDefaultModel" class="dash-select text-xs w-full" data-testid="setup-default-model">
+                    <option value="">Select model…</option>
+                    <template x-for="m in availableModels" :key="m">
+                      <option :value="m" x-text="m"></option>
+                    </template>
+                  </select>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div class="mt-6 flex items-center justify-end gap-3">
+            <span x-show="!settingsData?.has_llm_credentials" class="text-[11px] text-gray-500">Add LLM access to continue</span>
+            <button @click="finishSetup()"
+              :disabled="!setupCanFinish || onboardFinishing"
+              class="text-xs px-4 py-2 rounded bg-indigo-600 hover:bg-indigo-500 text-white disabled:opacity-50 transition-colors inline-flex items-center gap-1.5"
+              data-testid="setup-finish">
+              <svg x-show="onboardFinishing" x-cloak class="animate-spin h-3 w-3" fill="none" viewBox="0 0 24 24"><circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"/><path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z"/></svg>
+              <span x-text="onboardFinishing ? 'Finishing…' : 'Finish setup'"></span>
+            </button>
+          </div>
+          </div>
+        </div>
 
     <!-- Minimized chat pill -->
     <div x-show="activeTab !== 'chat' && openChats.length > 0 && chatPanelMinimized" x-cloak

--- a/src/dashboard/templates/index.html
+++ b/src/dashboard/templates/index.html
@@ -3053,6 +3053,12 @@
                               Browser
                             </span>
                             <span class="inline-flex items-center gap-1.5 text-xs px-2 py-1 rounded"
+                              :class="agentConfigs[selectedAgent]?.can_use_internet ? 'bg-indigo-900/30 text-indigo-400 border border-indigo-800/50' : 'bg-gray-800 text-gray-500 border border-gray-700'"
+                              title="Use http_request and web_search to reach the internet">
+                              <span class="w-1.5 h-1.5 rounded-full" :class="agentConfigs[selectedAgent]?.can_use_internet ? 'bg-indigo-400' : 'bg-gray-600'"></span>
+                              Internet
+                            </span>
+                            <span class="inline-flex items-center gap-1.5 text-xs px-2 py-1 rounded"
                               :class="agentConfigs[selectedAgent]?.can_spawn ? 'bg-indigo-900/30 text-indigo-400 border border-indigo-800/50' : 'bg-gray-800 text-gray-500 border border-gray-700'"
                               title="Create sub-agents for parallel work">
                               <span class="w-1.5 h-1.5 rounded-full" :class="agentConfigs[selectedAgent]?.can_spawn ? 'bg-indigo-400' : 'bg-gray-600'"></span>
@@ -3389,6 +3395,15 @@
                                     :class="editForm.can_use_browser ? 'translate-x-3' : ''"></span>
                                 </button>
                                 <span class="text-xs" :class="editForm.can_use_browser ? 'text-gray-200' : 'text-gray-400'">Browser</span>
+                              </label>
+                              <label class="flex items-center gap-2 cursor-pointer">
+                                <button type="button" @click="editForm.can_use_internet = !editForm.can_use_internet"
+                                  class="relative inline-flex w-7 h-4 rounded-full transition-colors flex-shrink-0"
+                                  :class="editForm.can_use_internet ? 'bg-indigo-600' : 'bg-gray-700'">
+                                  <span class="absolute top-0.5 left-0.5 w-3 h-3 rounded-full bg-white transition-transform"
+                                    :class="editForm.can_use_internet ? 'translate-x-3' : ''"></span>
+                                </button>
+                                <span class="text-xs" :class="editForm.can_use_internet ? 'text-gray-200' : 'text-gray-400'">Internet</span>
                               </label>
                               <label class="flex items-center gap-2 cursor-pointer">
                                 <button type="button" @click="editForm.can_spawn = !editForm.can_spawn"
@@ -6750,11 +6765,15 @@
                immediately (no restart). ``null`` = state not yet
                fetched; ``opInternetLoading`` debounces double-clicks. -->
           <div class="bg-gray-900 border border-gray-800 rounded-lg p-5"
-               x-data="{ opInternetEnabled: null, opInternetLoading: false, opInternetLive: true }"
+               x-data="{ opInternetEnabled: null, opInternetLoading: false, opInternetLive: true, opBrowserEnabled: null, opBrowserLoading: false, opBrowserLive: true }"
                x-init="(async () => {
                  try {
                    const r = await fetch(`${window.__config.apiBase}/operator/internet-access`);
                    if (r.ok) { const d = await r.json(); opInternetEnabled = !!d.enabled; }
+                 } catch (e) { /* leave null → toggle disabled */ }
+                 try {
+                   const r2 = await fetch(`${window.__config.apiBase}/operator/browser-access`);
+                   if (r2.ok) { const d2 = await r2.json(); opBrowserEnabled = !!d2.enabled; }
                  } catch (e) { /* leave null → toggle disabled */ }
                })()"
                data-testid="operator-capabilities-card">
@@ -6807,6 +6826,60 @@
               </button>
             </div>
             <div x-show="opInternetEnabled === true && !opInternetLive"
+                 class="mt-2 text-[11px] text-amber-400">
+              Saved — restart the operator to fully apply
+              (the container couldn't be reached for live update).
+            </div>
+
+            <!-- Browser access — mirrors the internet toggle. Flips the
+                 operator's ``can_use_browser`` permission via the
+                 dedicated ``/api/operator/browser-access`` endpoint which
+                 pushes to the running container so the browser_* tools
+                 appear/disappear from the next LLM call (no restart). -->
+            <div class="flex items-center justify-between gap-3 mt-4 pt-4 border-t border-gray-800/60">
+              <div class="min-w-0 flex-1">
+                <div class="text-xs text-gray-200">Browser access</div>
+                <div class="text-[11px] text-gray-400 mt-0.5">
+                  Lets the operator drive its own web browser
+                  (<code class="text-gray-400">browser_navigate</code>,
+                  <code class="text-gray-400">browser_click</code>, …) to
+                  navigate sites directly. Off-toggle filters them out of
+                  the next LLM call — no container restart needed.
+                </div>
+              </div>
+              <button type="button"
+                @click="(async () => {
+                  if (opBrowserEnabled === null || opBrowserLoading) return;
+                  const next = !opBrowserEnabled;
+                  opBrowserLoading = true;
+                  try {
+                    const r = await fetch(`${window.__config.apiBase}/operator/browser-access`, {
+                      method: 'POST',
+                      headers: { 'Content-Type': 'application/json', 'X-Requested-With': 'XMLHttpRequest' },
+                      body: JSON.stringify({ enabled: next }),
+                    });
+                    const d = await r.json().catch(() => ({}));
+                    if (!r.ok) { showToast(d.detail || `Toggle failed (HTTP ${r.status})`); return; }
+                    opBrowserEnabled = !!d.enabled;
+                    opBrowserLive = d.live !== false;
+                    showToast(opBrowserEnabled ? 'Browser access enabled.' : 'Browser access disabled.');
+                  } catch (e) {
+                    showToast(`Toggle failed: ${e.message || e}`);
+                  } finally {
+                    opBrowserLoading = false;
+                  }
+                })()"
+                :disabled="opBrowserEnabled === null || opBrowserLoading"
+                :aria-pressed="opBrowserEnabled === true"
+                :aria-label="opBrowserEnabled ? 'Disable browser access for operator' : 'Enable browser access for operator'"
+                :class="opBrowserEnabled === null ? 'bg-gray-700 cursor-wait' : (opBrowserEnabled ? 'bg-emerald-600 hover:bg-emerald-500' : 'bg-gray-700 hover:bg-gray-600')"
+                class="relative inline-flex h-5 w-9 shrink-0 items-center rounded-full transition-colors focus:outline-none focus:ring-2 focus:ring-indigo-500/40 disabled:opacity-60"
+                data-testid="operator-browser-toggle">
+                <span :class="opBrowserEnabled ? 'translate-x-5' : 'translate-x-1'"
+                      class="inline-block h-3 w-3 transform rounded-full bg-white transition-transform"></span>
+              </button>
+            </div>
+            <div x-show="opBrowserEnabled === true && !opBrowserLive"
                  class="mt-2 text-[11px] text-amber-400">
               Saved — restart the operator to fully apply
               (the container couldn't be reached for live update).

--- a/src/dashboard/templates/index.html
+++ b/src/dashboard/templates/index.html
@@ -2521,9 +2521,19 @@
           </button>
         </div>
         <!-- Onboarding banner (first-run) -->
-        <div x-show="showOnboarding && !loading" x-cloak class="mb-6 bg-gray-900 border border-indigo-800/40 rounded-xl p-6">
-          <h3 class="text-base font-semibold text-white mb-4">Get started</h3>
-          <div class="space-y-4">
+        <!-- Initial setup — a single, non-skippable modal that every new
+             user completes before reaching the workspace. Covers (1) LLM
+             credentials (skippable when OpenLegion credits are present)
+             and (2) choosing the Operator model + Default agent model.
+             Visibility is driven by ``showSetup`` (see app.js). There is
+             intentionally no close button / backdrop-dismiss. -->
+        <div x-show="showSetup && !loading" x-cloak
+             x-init="$watch('showSetup', v => { if (v) { onboardDefaultModel = onboardDefaultModel || (systemSettings && systemSettings.default_model) || ''; onboardOperatorModel = onboardOperatorModel || (opAgent && opAgent.model) || ''; } })"
+             class="fixed inset-0 z-[160] flex items-center justify-center p-4 bg-black/70 backdrop-blur-sm">
+          <div class="w-full max-w-lg bg-gray-900 border border-indigo-800/40 rounded-xl p-6 shadow-2xl max-h-[90vh] overflow-y-auto" data-testid="setup-modal">
+          <h3 class="text-lg font-semibold text-white mb-1">Welcome to OpenLegion</h3>
+          <p class="text-xs text-gray-400 mb-5">A couple of quick steps to get your workspace ready.</p>
+          <div class="space-y-5">
             <!-- Step 1: API key -->
             <div class="flex items-start gap-3">
               <div class="shrink-0 w-6 h-6 rounded-full flex items-center justify-center text-xs font-bold"
@@ -2599,25 +2609,50 @@
                 </div>
               </div>
             </div>
-            <!-- Step 2: Create agent -->
-            <div class="flex items-start gap-3">
+            <!-- Step 2: Choose models. Required for everyone — we no
+                 longer auto-assign a default. Disabled until LLM access
+                 (a key OR OpenLegion credits) is configured above. -->
+            <div class="flex items-start gap-3" :class="!settingsData?.has_llm_credentials ? 'opacity-50 pointer-events-none' : ''">
               <div class="shrink-0 w-6 h-6 rounded-full flex items-center justify-center text-xs font-bold"
-                :class="agents.length > 0 ? 'bg-emerald-600 text-white' : 'bg-gray-700 text-gray-400'">
-                <span x-show="agents.length > 0">&#10003;</span>
-                <span x-show="agents.length === 0">2</span>
+                :class="(onboardOperatorModel && onboardDefaultModel) ? 'bg-emerald-600 text-white' : 'bg-gray-700 text-gray-400'">
+                <span x-show="onboardOperatorModel && onboardDefaultModel">&#10003;</span>
+                <span x-show="!(onboardOperatorModel && onboardDefaultModel)">2</span>
               </div>
-              <div class="flex-1">
-                <div class="text-sm font-medium text-gray-200 mb-2">Build your first team</div>
-                <button @click="openAddAgentModal()"
-                  :disabled="!settingsData?.has_llm_credentials"
-                  class="text-xs px-4 py-1.5 rounded bg-indigo-600 hover:bg-indigo-500 text-white disabled:opacity-50 transition-colors inline-flex items-center gap-1.5"
-                  x-show="agents.length === 0">
-                  <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="2"><line x1="12" y1="5" x2="12" y2="19"/><line x1="5" y1="12" x2="19" y2="12"/></svg>
-                  Add teammate
-                </button>
-                <div x-show="agents.length > 0" class="text-xs text-emerald-400">Teammate running</div>
+              <div class="flex-1 space-y-3">
+                <div class="text-sm font-medium text-gray-200">Choose your models</div>
+                <div>
+                  <label class="text-xs text-gray-400 mb-1 block">Operator model
+                    <span class="text-gray-500">— powers the assistant you chat with</span></label>
+                  <select x-model="onboardOperatorModel" class="dash-select text-xs w-full" data-testid="setup-operator-model">
+                    <option value="">Select model…</option>
+                    <template x-for="m in availableModels" :key="m">
+                      <option :value="m" x-text="m"></option>
+                    </template>
+                  </select>
+                </div>
+                <div>
+                  <label class="text-xs text-gray-400 mb-1 block">Default agent model
+                    <span class="text-gray-500">— used by new teammates unless overridden</span></label>
+                  <select x-model="onboardDefaultModel" class="dash-select text-xs w-full" data-testid="setup-default-model">
+                    <option value="">Select model…</option>
+                    <template x-for="m in availableModels" :key="m">
+                      <option :value="m" x-text="m"></option>
+                    </template>
+                  </select>
+                </div>
               </div>
             </div>
+          </div>
+          <div class="mt-6 flex items-center justify-end gap-3">
+            <span x-show="!settingsData?.has_llm_credentials" class="text-[11px] text-gray-500">Add LLM access to continue</span>
+            <button @click="finishSetup()"
+              :disabled="!setupCanFinish || onboardFinishing"
+              class="text-xs px-4 py-2 rounded bg-indigo-600 hover:bg-indigo-500 text-white disabled:opacity-50 transition-colors inline-flex items-center gap-1.5"
+              data-testid="setup-finish">
+              <svg x-show="onboardFinishing" x-cloak class="animate-spin h-3 w-3" fill="none" viewBox="0 0 24 24"><circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"/><path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z"/></svg>
+              <span x-text="onboardFinishing ? 'Finishing…' : 'Finish setup'"></span>
+            </button>
+          </div>
           </div>
         </div>
       </div>

--- a/src/host/health.py
+++ b/src/host/health.py
@@ -554,9 +554,9 @@ class HealthMonitor:
             restart_env: dict[str, str] = {}
             if agent_id == _OPERATOR_AGENT_ID:
                 restart_env["ALLOWED_TOOLS"] = ",".join(_OPERATOR_ALLOWED_TOOLS)
-                # Re-seed the internet-access flag so a health-restart
-                # doesn't undo the user's toggle. Same logic as
-                # cli/runtime.py.
+                # Re-seed the internet/browser access flags so a
+                # health-restart doesn't undo the user's toggle. Same
+                # logic as cli/runtime.py.
                 try:
                     _op_perms = _load_permissions().get(
                         "permissions", {},
@@ -564,8 +564,12 @@ class HealthMonitor:
                     restart_env["OL_INTERNET_ACCESS_ENABLED"] = (
                         "true" if _op_perms.get("can_use_internet", True) else "false"
                     )
+                    restart_env["OL_BROWSER_ACCESS_ENABLED"] = (
+                        "true" if _op_perms.get("can_use_browser", True) else "false"
+                    )
                 except Exception:
                     restart_env["OL_INTERNET_ACCESS_ENABLED"] = "true"
+                    restart_env["OL_BROWSER_ACCESS_ENABLED"] = "true"
 
             loop = asyncio.get_running_loop()
             # Load fresh config for proxy resolution

--- a/src/host/server.py
+++ b/src/host/server.py
@@ -7738,6 +7738,112 @@ def create_mesh_app(
         op_perms = perms.get("permissions", {}).get(_OPERATOR_AGENT_ID, {})
         return {"enabled": bool(op_perms.get("can_use_internet", False))}
 
+    @app.post("/mesh/operator/browser-access")
+    async def operator_browser_access(request: Request) -> dict:
+        """Toggle the operator's ability to use the browser_* tools.
+
+        Body: ``{"enabled": bool}``. Operator-only or internal callers.
+        Mirrors ``operator_internet_access``: (1) flip
+        ``operator.can_use_browser`` in permissions.json + reload the
+        mesh matrix; (2) push to the operator container's ``/config`` so
+        the agent loop hides/shows the browser_* tools immediately. The
+        permissions write is the source of truth; ``live`` reports
+        whether the container-side push succeeded.
+        """
+        _require_any_auth(request)
+        caller = _extract_verified_agent_id(request)
+        if not _caller_is_operator(caller, request) and not _is_internal_caller(request):
+            raise HTTPException(
+                403, "Only the operator can toggle browser access",
+            )
+
+        data = await request.json()
+        if "enabled" not in data:
+            raise HTTPException(400, "'enabled' is required")
+        enabled = data.get("enabled")
+        if not isinstance(enabled, bool):
+            raise HTTPException(400, "'enabled' must be a boolean")
+
+        from src.cli.config import (
+            _OPERATOR_AGENT_ID,
+            _load_permissions,
+            _save_permissions,
+        )
+
+        perms = _load_permissions()
+        op_perms = perms.setdefault("permissions", {}).setdefault(
+            _OPERATOR_AGENT_ID, {},
+        )
+        previous = bool(op_perms.get("can_use_browser", False))
+        op_perms["can_use_browser"] = enabled
+        _save_permissions(perms)
+        if permissions is not None:
+            permissions.reload()
+
+        hot_reload_ok = True
+        if transport is not None and _OPERATOR_AGENT_ID in router.agent_registry:
+            try:
+                result = await transport.request(
+                    _OPERATOR_AGENT_ID, "POST", "/config",
+                    json={"browser_access_enabled": enabled}, timeout=10,
+                )
+                if isinstance(result, dict) and "error" in result:
+                    hot_reload_ok = False
+                    logger.warning(
+                        "Operator /config push failed: %s", result["error"],
+                    )
+            except Exception as e:
+                hot_reload_ok = False
+                logger.warning("Operator /config push raised: %s", e)
+
+        blackboard.log_audit(
+            action="edit_agent",
+            target=_OPERATOR_AGENT_ID,
+            field="can_use_browser",
+            before_value=json.dumps(previous),
+            after_value=json.dumps(enabled),
+            undoable=False,
+        )
+
+        if event_bus is not None:
+            try:
+                event_bus.emit(
+                    "agent_config_updated", agent=_OPERATOR_AGENT_ID,
+                    data={
+                        "agent_id": _OPERATOR_AGENT_ID,
+                        "field": "can_use_browser",
+                        "live": hot_reload_ok,
+                    },
+                )
+            except Exception as e:
+                logger.debug(
+                    "agent_config_updated emit failed for browser-access: %s", e,
+                )
+
+        return {
+            "success": True,
+            "enabled": enabled,
+            "previous": previous,
+            "live": hot_reload_ok,
+        }
+
+    @app.get("/mesh/operator/browser-access")
+    async def operator_browser_access_status(request: Request) -> dict:
+        """Read the operator's current browser-access state.
+
+        Returned shape: ``{"enabled": bool}``.
+        """
+        _require_any_auth(request)
+        caller = _extract_verified_agent_id(request)
+        if not _caller_is_operator(caller, request) and not _is_internal_caller(request):
+            raise HTTPException(
+                403, "Only the operator can read browser-access state",
+            )
+        from src.cli.config import _OPERATOR_AGENT_ID, _load_permissions
+        perms = _load_permissions()
+        op_perms = perms.get("permissions", {}).get(_OPERATOR_AGENT_ID, {})
+        return {"enabled": bool(op_perms.get("can_use_browser", False))}
+
     @app.post("/mesh/changes/undo/{undo_token}")
     async def undo_change(undo_token: str, request: Request) -> dict:
         """Reverse a recent soft edit. 5-minute TTL.

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -3032,16 +3032,6 @@ class TestBoardLoadingAndErrorStates:
         # so the user can recover with one click without reloading.
         assert "retryWorkplaceSection('summaries')" in body
 
-    def test_index_html_chip_prefix_does_not_overwrite(self):
-        resp = self.client.get("/dashboard/")
-        body = resp.text
-        # The four onboarding chips now prepend their suggestion to
-        # whatever the user has already typed (chip + ' ' + opMsg)
-        # rather than clobbering it. Caret moves to the end via
-        # setSelectionRange so typing continues naturally.
-        assert "s.opMsg = chip + (s.opMsg ? ' ' + s.opMsg : '')" in body
-        assert "el.setSelectionRange(el.value.length, el.value.length)" in body
-
 
 class TestBoardTemplateDescriptions:
     """PR-M — fleet-template descriptions rewritten as user outcomes.

--- a/tests/test_dashboard_telemetry.py
+++ b/tests/test_dashboard_telemetry.py
@@ -494,9 +494,7 @@ class TestPhase0FrontendWiring:
 
         The Summaries / Kanban / Activity sub-nav was deleted along with
         the kanban + activity surfaces. ``switchHomeTab`` calls should
-        no longer appear in the rendered template. trackSubtabUsage
-        itself is kept in app.js for empty-state CTA telemetry — see
-        test_empty_state_cta_buttons_emit_telemetry.
+        no longer appear in the rendered template.
         """
         html = _TEMPLATE.read_text(encoding="utf-8")
         assert "switchHomeTab(" not in html
@@ -511,20 +509,3 @@ class TestPhase0FrontendWiring:
         # raw call path.
         assert '@click="action.handler()"' not in html
 
-    def test_empty_state_cta_buttons_emit_telemetry(self):
-        html = _TEMPLATE.read_text(encoding="utf-8")
-        # Each empty-state intent chip on the operator empty state has a
-        # stable section_id so we can compare CTA traction across them.
-        # ``recently_delivered_view_all`` was retired in Phase 3 when the
-        # Workplace sub-tab bar collapsed into the single-scroll Home
-        # layout — there's no "View all →" button to instrument anymore.
-        for section_id in (
-            "operator_intent_content",
-            "operator_intent_research",
-            "operator_intent_sales",
-            "operator_intent_devteam",
-            "operator_intent_other",
-        ):
-            assert f"trackEmptyStateCta('{section_id}')" in html, (
-                f"missing trackEmptyStateCta call for: {section_id}"
-            )

--- a/tests/test_dashboard_ui.py
+++ b/tests/test_dashboard_ui.py
@@ -371,8 +371,9 @@ class TestVocabularySweepStrings:
 
 class TestEmptyStateCTAs:
     def test_team_empty_state_has_cta(self):
-        # The fleet/team page first-run state.
-        assert "Build your first team" in _INDEX_HTML
+        # First-run is now the single setup modal.
+        assert "Welcome to OpenLegion" in _INDEX_HTML
+        assert 'data-testid="setup-finish"' in _INDEX_HTML
 
     def test_workplace_summary_empty_state_user_speak(self):
         # PR 2 of Work tab rewrite — the activity feed empty-state
@@ -993,196 +994,71 @@ class TestWorkTabPr2Cutover:
         assert "tellOperatorConfirmation" not in app_js
 
 
-# ── Phase 4: \"What's new\" tour for existing-fleet users ──────────
+# ── Initial setup modal (single, non-skippable onboarding) ───────
 
 
-class TestNewUserTutorialMarkup:
-    """The 3-step tutorial modal is hard-coded into the SPA template."""
+class TestSetupModalMarkup:
+    """The one-and-only start modal: credentials + model selection."""
 
-    def test_modal_block_is_present(self):
+    def test_modal_present_and_gated_on_showSetup(self):
         html = _read(_TEMPLATE)
-        assert 'data-testid="tutorial-modal"' in html
+        assert 'data-testid="setup-modal"' in html
+        assert 'x-show="showSetup' in html
 
-    def test_modal_renders_only_when_step_not_zero(self):
+    def test_modal_requires_both_model_selections(self):
         html = _read(_TEMPLATE)
-        assert "newUserTutorial.step !== 0" in html
+        assert 'data-testid="setup-operator-model"' in html
+        assert 'data-testid="setup-default-model"' in html
 
-    def test_modal_has_three_steps(self):
+    def test_finish_button_present(self):
         html = _read(_TEMPLATE)
-        for step in (1, 2, 3):
-            assert f"newUserTutorial.step === {step}" in html, (
-                f"missing tutorial step: {step}"
-            )
+        assert 'data-testid="setup-finish"' in html
+        assert "finishSetup()" in html
 
-    def test_modal_has_dialog_role_and_modal_aria(self):
+    def test_legacy_tutorial_markup_removed(self):
+        # Non-skippable single modal — the old 3-step tutorial is gone.
         html = _read(_TEMPLATE)
-        # role=dialog + aria-modal=true on the same element as the
-        # data-testid hook — required for screen readers.
-        assert re.search(
-            r'role="dialog"[^>]*?aria-modal="true"[^>]*?data-testid="tutorial-modal"'
-            r'|data-testid="tutorial-modal"[^>]*?role="dialog"',
-            html,
-        ), "tutorial modal missing role=dialog/aria-modal"
-
-    def test_step1_copy_present(self):
-        html = _read(_TEMPLATE)
-        assert "Welcome to OpenLegion" in html
-        assert "AI team manager" in html
-        assert "Show me how" in html
-
-    def test_step2_copy_present(self):
-        html = _read(_TEMPLATE)
-        assert "Meet your Operator" in html
-        assert "team lead" in html
-
-    def test_step3_copy_present(self):
-        html = _read(_TEMPLATE)
-        assert "See what your team is doing" in html
-        assert "Got it, let&rsquo;s build a team" in html
-
-    def test_skip_button_dismisses_tutorial(self):
-        html = _read(_TEMPLATE)
-        assert 'data-testid="tutorial-skip"' in html
-        assert "dismissTutorial(" in html
-
-    def test_primary_button_has_focus_target(self):
-        # Focus management: each step's primary advance button is
-        # auto-focused on entry (via querySelector in app.js).
-        html = _read(_TEMPLATE)
-        assert 'data-testid="tutorial-primary"' in html
+        assert 'data-testid="tutorial-modal"' not in html
+        assert 'data-testid="tutorial-skip"' not in html
+        assert "newUserTutorial" not in html
 
 
-class TestNewUserTutorialJsState:
-    """Alpine handlers for the tutorial state machine."""
+class TestSetupModalJsState:
+    """Alpine state + handler for the setup modal."""
 
-    def test_tutorial_state_object_declared(self):
+    def test_setup_state_declared(self):
         js = _read(_APP_JS)
-        assert "newUserTutorial: { step: 0 }" in js
+        for name in ("onboardOperatorModel", "onboardDefaultModel", "_setupDone:"):
+            assert name in js, f"missing setup state: {name}"
 
-    def test_tutorial_handlers_declared(self):
+    def test_setup_getters_declared(self):
         js = _read(_APP_JS)
-        for handler in (
-            "_maybeStartTutorial()",
-            "startTutorial()",
-            "tutorialNext()",
-            "tutorialBack()",
-            "dismissTutorial(reason)",
-            "_completeTutorial(reason)",
+        assert "get showSetup()" in js
+        assert "get setupCanFinish()" in js
+
+    def test_finishSetup_persists_both_models(self):
+        js = _read(_APP_JS)
+        assert "async finishSetup()" in js
+        assert "/default-model" in js
+        assert "/agents/operator/config" in js
+        assert "ol_setup_done" in js
+
+    def test_tutorial_handlers_fully_removed(self):
+        js = _read(_APP_JS)
+        for gone in (
+            "newUserTutorial",
+            "_maybeStartTutorial",
+            "startTutorial(",
+            "dismissTutorial",
+            "_completeTutorial",
         ):
-            assert handler in js, f"missing tutorial handler: {handler}"
-
-    def test_tutorial_persists_seen_flag(self):
-        js = _read(_APP_JS)
-        # Seen flag freezes the tutorial after first completion/dismiss.
-        assert "olSeenTutorial" in js
-        assert "localStorage.setItem('olSeenTutorial', 'true')" in js
-
-    def test_tutorial_fires_for_new_users_only(self):
-        js = _read(_APP_JS)
-        # Detection delegates to ``_isFirstVisit()`` — empty fleet AND
-        # no real user message in the operator transcript. The wizard
-        # uses the same detector so the two stay in lockstep.
-        assert "_maybeStartTutorial" in js
-        m = re.search(
-            r"_maybeStartTutorial\(\)\s*\{(.*?)\n    \},",
-            _APP_JS_TEXT,
-            re.DOTALL,
-        )
-        assert m, "_maybeStartTutorial body missing"
-        body = m.group(1)
-        assert "_isFirstVisit()" in body, (
-            "tutorial gate should delegate to _isFirstVisit"
-        )
-
-    def test_tutorial_does_not_fire_for_existing_users(self):
-        # The detector early-returns when ``_isFirstVisit()`` is false —
-        # any non-empty fleet OR any prior user message in the operator
-        # transcript skips the tutorial.
-        m = re.search(
-            r"_maybeStartTutorial\(\)\s*\{(.*?)\n    \},",
-            _APP_JS_TEXT,
-            re.DOTALL,
-        )
-        assert m, "_maybeStartTutorial body missing"
-        body = m.group(1)
-        assert "if (!this._isFirstVisit()) return" in body, (
-            "tutorial should bail when _isFirstVisit() is false"
-        )
-
-    def test_tutorial_does_not_fire_for_returning_user_with_chat_history(self):
-        # Audit fix: the legacy gate checked only ``fleetAgents.length``
-        # which mis-classified a returning user who deleted their fleet
-        # but already chatted with the operator as "new". Delegating to
-        # ``_isFirstVisit()`` adds the "no user message in
-        # chatHistories.operator" check, so a returning chat-only user
-        # is correctly excluded.
-        m_first_visit = re.search(
-            r"_isFirstVisit\(\)\s*\{(.*?)\n    \},",
-            _APP_JS_TEXT,
-            re.DOTALL,
-        )
-        assert m_first_visit, "_isFirstVisit body missing"
-        first_visit_body = m_first_visit.group(1)
-        # Confirm _isFirstVisit covers BOTH conditions: empty fleet AND
-        # no prior user message in operator chatHistories.
-        assert "this.agents.some" in first_visit_body, (
-            "_isFirstVisit must check the agents list"
-        )
-        assert "chatHistories['operator']" in first_visit_body, (
-            "_isFirstVisit must check operator chat history"
-        )
-        assert "m.role === 'user'" in first_visit_body, (
-            "_isFirstVisit must filter on user-role messages"
-        )
-        # And confirm the tutorial actually delegates to it (not an
-        # inline fleetAgents-only check).
-        m_tut = re.search(
-            r"_maybeStartTutorial\(\)\s*\{(.*?)\n    \},",
-            _APP_JS_TEXT,
-            re.DOTALL,
-        )
-        assert m_tut, "_maybeStartTutorial body missing"
-        tut_body = m_tut.group(1)
-        assert "_isFirstVisit()" in tut_body
-        # The legacy fleetAgents.length-only inline check should be
-        # gone — _isFirstVisit replaces it.
-        assert "fleetAgents.length !== 0" not in tut_body, (
-            "legacy fleet-only check should be removed in favor of _isFirstVisit"
-        )
-
-    def test_tutorial_emits_locked_telemetry_events(self):
-        js = _read(_APP_JS)
-        for evt in (
-            "tutorial_started",
-            "tutorial_step",
-            "tutorial_finished",
-            "tutorial_to_wizard_transition",
-        ):
-            assert f"'{evt}'" in js, f"missing tutorial telemetry event: {evt}"
-
-    def test_tutorial_handles_escape_key(self):
-        js = _read(_APP_JS)
-        # ESC dismisses the modal. Tab-trap is also wired here.
-        assert "e.key === 'Escape'" in js
+            assert gone not in js, f"tutorial remnant should be removed: {gone}"
 
 
-class TestTutorialWizardSequencing:
-    """The tutorial must run BEFORE the empty-fleet wizard."""
+class TestWizardIsSoleInChatSurface:
+    """The build-wizard is the single skippable in-chat onboarding."""
 
-    def test_tutorial_fires_before_wizard_when_both_eligible(self):
-        # ``fetchAgents`` invokes _maybeStartTutorial BEFORE
-        # _maybeStartWizard so a brand-new user sees the tutorial first.
-        js = _APP_JS_TEXT
-        idx_tutorial = js.find("this._maybeStartTutorial()")
-        idx_wizard = js.find("this._maybeStartWizard()")
-        assert idx_tutorial != -1, "fetchAgents should call _maybeStartTutorial"
-        assert idx_wizard != -1, "fetchAgents should call _maybeStartWizard"
-        assert idx_tutorial < idx_wizard, (
-            "tutorial must be invoked before wizard so it gets first dibs"
-        )
-
-    def test_wizard_does_not_fire_while_tutorial_active(self):
-        # _maybeStartWizard early-returns when newUserTutorial.step !== 0.
+    def test_wizard_no_longer_gates_on_tutorial(self):
         m = re.search(
             r"_maybeStartWizard\(\)\s*\{(.*?)\n    \},",
             _APP_JS_TEXT,
@@ -1190,54 +1066,18 @@ class TestTutorialWizardSequencing:
         )
         assert m, "_maybeStartWizard body missing"
         body = m.group(1)
-        assert "newUserTutorial" in body, (
-            "wizard should gate on tutorial state to avoid double-mount"
+        assert "newUserTutorial" not in body, (
+            "wizard should no longer reference the removed tutorial"
         )
-        assert re.search(
-            r"newUserTutorial\.step\s*!==\s*0", body
-        ), "wizard guard should bail when tutorial is open"
-
-    def test_wizard_fires_after_tutorial_completes(self):
-        # _completeTutorial calls _maybeStartWizard on natural
-        # completion (reason === 'completed') so the user lands in
-        # the team-building flow without an extra click.
-        m = re.search(
-            r"_completeTutorial\(reason\)\s*\{(.*?)\n    \},",
-            _APP_JS_TEXT,
-            re.DOTALL,
-        )
-        assert m, "_completeTutorial body missing"
-        body = m.group(1)
-        assert "tutorial_to_wizard_transition" in body, (
-            "completion handler should emit transition telemetry"
-        )
-        assert "_maybeStartWizard" in body, (
-            "completion handler should invoke the wizard"
-        )
-        assert "reason === 'completed'" in body, (
-            "wizard should only auto-fire on natural completion, not skip/escape"
+        assert "this.showSetup" in body, (
+            "wizard must wait for the setup modal to finish"
         )
 
-
-class TestTutorialBackCompatMigration:
-    """Users who saw the legacy whats-new tour should not see the
-    tutorial — they're not new users."""
-
-    def test_old_olSeenWhatsNew_users_do_not_see_tutorial_again(self):
-        # init() should migrate olSeenWhatsNew='true' → olSeenTutorial='true'.
-        js = _APP_JS_TEXT
-        # The migration check looks at olSeenWhatsNew and, if set,
-        # writes olSeenTutorial. We grep for the combined fragment.
-        assert "olSeenWhatsNew" in js, "migration must reference legacy flag"
-        m = re.search(
-            r"localStorage\.getItem\('olSeenWhatsNew'\)\s*===\s*'true'\s*&&\s*"
-            r"!localStorage\.getItem\('olSeenTutorial'\)",
-            js,
-        )
-        assert m, "migration check missing — old whats-new users would see tutorial"
-        assert (
-            "localStorage.setItem('olSeenTutorial', 'true')" in js
-        ), "migration must write olSeenTutorial flag"
+    def test_static_welcome_card_removed(self):
+        # The duplicate in-chat 'Hi I'm your Operator' card is gone; the
+        # wizard owns the starting-point chips now.
+        html = _read(_TEMPLATE)
+        assert "First-run: no agents yet" not in html
 
 
 # ── Phase 4: wizard polish ───────────────────────────────────────
@@ -2440,131 +2280,11 @@ class TestActionChipDuringStream:
 # ── Tutorial gating edge cases ───────────────────────────────────
 
 
-class TestTutorialGatingEdgeCases:
-    """The tutorial's gating logic must be defensive about edge conditions."""
-
-    def test_existing_fleet_does_not_fire_tutorial(self):
-        """Fleet size > 0 (non-operator) suppresses the tutorial."""
-        # The empty-fleet check now lives in _isFirstVisit() and
-        # _maybeStartTutorial delegates to it. Confirm both halves of
-        # the contract are wired.
-        m_first_visit = re.search(
-            r"_isFirstVisit\(\)\s*\{(.*?)\n    \},",
-            _APP_JS_TEXT,
-            re.DOTALL,
-        )
-        assert m_first_visit, "_isFirstVisit body missing"
-        first_visit_body = m_first_visit.group(1)
-        # The fleet check happens inside _isFirstVisit (returns false
-        # when any non-operator agent exists).
-        assert "a.id !== 'operator'" in first_visit_body, (
-            "_isFirstVisit should exclude the operator from the fleet check"
-        )
-        assert "if (hasFleetAgents) return false" in first_visit_body, (
-            "_isFirstVisit must return false when fleet is non-empty"
-        )
-
-        m = re.search(
-            r"_maybeStartTutorial\(\)\s*\{(.*?)\n    \},",
-            _APP_JS_TEXT,
-            re.DOTALL,
-        )
-        assert m, "_maybeStartTutorial body missing"
-        body = m.group(1)
-        assert "if (!this._isFirstVisit()) return" in body, (
-            "non-empty-fleet guard missing — tutorial would fire on existing fleets"
-        )
-
-    def test_skip_persists_seen_flag(self):
-        """Skip path writes olSeenTutorial just like completion."""
-        # Skip → dismissTutorial('skip_button') → _completeTutorial →
-        # localStorage.setItem('olSeenTutorial', 'true'). The shared
-        # _completeTutorial path is the single write site.
-        m = re.search(
-            r"_completeTutorial\(reason\)\s*\{(.*?)\n    \},",
-            _APP_JS_TEXT,
-            re.DOTALL,
-        )
-        assert m, "_completeTutorial body missing"
-        body = m.group(1)
-        assert "localStorage.setItem('olSeenTutorial', 'true')" in body
-
-    def test_localstorage_unavailable_falls_through_to_show_once(self):
-        """When localStorage throws (private mode) the tutorial still fires.
-
-        The seen-flag check is wrapped in try/catch. The ``catch`` arm
-        is a no-op so the function continues to the agent check — i.e.
-        the tutorial shows once per session in private mode.
-        """
-        m = re.search(
-            r"_maybeStartTutorial\(\)\s*\{(.*?)\n    \},",
-            _APP_JS_TEXT,
-            re.DOTALL,
-        )
-        assert m, "_maybeStartTutorial body missing"
-        body = m.group(1)
-        # The catch must not return — only the try return early-exits.
-        # The simplest contract check: the comment marks the private-
-        # mode policy and the catch arm is empty.
-        assert re.search(
-            r"catch\s*\(_\)\s*\{\s*/\*[^*]*private mode[^*]*\*/\s*\}",
-            body,
-        ), "private-mode catch arm should be a documented no-op"
-
-    def test_tutorial_state_does_not_persist_across_reload(self):
-        """Tutorial state lives in memory only — reload aborts mid-flight."""
-        # The wizard persists to localStorage.ol_wizard; the tutorial
-        # explicitly does NOT. _maybeStartTutorial gates only on the
-        # seen flag, not on a stored step. We assert the tutorial
-        # bootstrap reads neither a stored step nor calls a persist
-        # helper from the seen-flag branch.
-        m = re.search(
-            r"_maybeStartTutorial\(\)\s*\{(.*?)\n    \},",
-            _APP_JS_TEXT,
-            re.DOTALL,
-        )
-        assert m, "_maybeStartTutorial body missing"
-        body = m.group(1)
-        # Tutorial state object must not be hydrated from localStorage.
-        # (The seen flag is the only persisted bit.)
-        assert "ol_tutorial_step" not in _APP_JS_TEXT, (
-            "tutorial step should not be persisted — reload must abort the tutorial"
-        )
-        # The function reads only ``olSeenTutorial``, not a stored step.
-        assert "getItem('olSeenTutorial')" in body
-        assert "getItem('ol_tutorial_step'" not in body
-
-
 # ── Polish fix tests (verify the audit fixes landed) ─────────────
 
 
 class TestPolishFixesApplied:
     """Verify each polish fix from the user-journey audit is in place."""
-
-    def test_tutorial_modal_uses_unique_title_ids(self):
-        """Each step's <h2> has a unique id; aria-labelledby is dynamic.
-
-        Inherited from the original whats-new audit fix — each step
-        carries a distinct ``tutorial-title-N`` so screen readers
-        announce the correct dialog title when steps render in sequence.
-        """
-        for n in (1, 2, 3):
-            assert f'id="tutorial-title-{n}"' in _INDEX_HTML, (
-                f"missing unique title id for step {n}"
-            )
-        # The aria-labelledby binding must reference the dynamic id.
-        assert (
-            ":aria-labelledby=\"'tutorial-title-' + newUserTutorial.step\""
-            in _INDEX_HTML
-        ), "aria-labelledby should bind dynamically to the active step"
-        # The legacy whats-new ids should be gone.
-        assert 'id="whats-new-title"' not in _INDEX_HTML, (
-            "legacy whats-new title id still present"
-        )
-        for n in (1, 2, 3):
-            assert f'id="whats-new-title-{n}"' not in _INDEX_HTML, (
-                f"legacy whats-new title id (step {n}) still present"
-            )
 
     def test_credential_notification_icon_is_plain_text(self):
         """The 'credential' kind icon is 'K' — markup is emoji-free."""

--- a/tests/test_operator_config.py
+++ b/tests/test_operator_config.py
@@ -74,7 +74,11 @@ class TestEnsureOperatorCreates(_TempConfigMixin):
             perms = json.load(f)
         assert "operator" in perms["permissions"]
         assert perms["permissions"]["operator"]["can_spawn"] is True
-        assert perms["permissions"]["operator"]["can_use_browser"] is False
+        # Operator gets browser + internet on by default so it can navigate
+        # the web directly to help users; both are togglable in Operator
+        # Settings. See _ensure_operator_agent in src/cli/config.py.
+        assert perms["permissions"]["operator"]["can_use_browser"] is True
+        assert perms["permissions"]["operator"]["can_use_internet"] is True
 
         # Check skills dir created
         skills_dir = Path(self._tmpdir) / "skills" / "operator"
@@ -387,14 +391,22 @@ class TestOperatorConstants:
         assert "write_file" not in _OPERATOR_ALLOWED_TOOLS
 
     def test_request_browser_login_in_allowlist(self):
-        """Operator must be allowed to delegate browser login requests to workers.
+        """Operator must be able to delegate browser login requests to workers.
 
-        Operator itself has ``can_use_browser: False`` by design — it uses
-        the delegation path (``request_browser_login(agent_id=worker)``)
-        so session cookies land in the worker's browser profile.
+        Even though the operator now has its own browser access, the
+        delegation path (``request_browser_login(agent_id=worker)``)
+        remains the way to land session cookies in a *worker's* browser
+        profile.
         """
         from src.cli.config import _OPERATOR_ALLOWED_TOOLS
         assert "request_browser_login" in _OPERATOR_ALLOWED_TOOLS
+
+    def test_browser_tools_in_allowlist(self):
+        """Operator's curated allowlist exposes the browser_* surface so the
+        Browser-access toggle (can_use_browser) has tools to gate."""
+        from src.cli.config import _OPERATOR_ALLOWED_TOOLS
+        assert "browser_navigate" in _OPERATOR_ALLOWED_TOOLS
+        assert "browser_click" in _OPERATOR_ALLOWED_TOOLS
 
     def test_operator_agent_id(self):
         from src.cli.config import _OPERATOR_AGENT_ID


### PR DESCRIPTION
## Summary

Reworks operator/agent capability defaults and collapses first-run onboarding into a single modal.

### Operator capabilities
- Operator now defaults to **browser ON** (`can_use_browser=True`) and **internet ON**, with the full `browser_*` tool surface in its allowlist and an independent runtime gate so the two toggles compose cleanly.
- **Operator Settings → Capabilities** gains **Internet** and **Browser** toggles (live push, no restart), backed by new `/mesh/operator/browser-access` + dashboard-proxy endpoints. Capability state is re-seeded across every restart path.
- Fixes a latent bug where `can_use_internet` was dropped on fresh agent/operator creation.

### Per-agent config visibility
- The agent config editor now exposes an **Internet** toggle + badge alongside Browser / Spawn / Schedules / Wallet, so the operator can see and flip every capability. (New agents already default to browser + schedules ON.)

### Onboarding → one unified modal
- A single **non-skippable setup modal** is now the only start surface: credential entry (auto-satisfied/skippable when OpenLegion credits exist) plus **required Operator-model and Default-agent-model** pickers — no more silently auto-assigned default.
- **Removed** the separate 3-step orientation tutorial entirely (state, handlers, modal markup, focus-trap, and the `olSeenTutorial`/`olSeenWhatsNew` migration), the operator's seeded greeting message, and the duplicate in-chat "Hi I'm your Operator" welcome card.
- The build-wizard remains the single **skippable** in-chat surface (clear dismiss on every step); the empty state now covers new users too.

### Auto-restart
- Restart-gated dashboard changes (execution limits, default-model, operator-model) now apply automatically. Per-agent capability toggles already apply live via matrix reload.

## Testing
- `pytest tests/` (excluding e2e): **2062 passed**, 17 skipped. Dashboard UI tests updated for the new modal.
- The lone failure in the local run (`test_read_file_permission_error`) is a pre-existing container artifact — it runs as root, so `chmod 000` doesn't block reads and the expected error never fires. Untouched by this PR.

## Note — out of scope (provisioner)
The "OpenLegion credits → auto-set default model to the openlegion-routed LLM" behavior lives in the **provisioner**, not the engine. The engine now always prompts for model selection regardless, so a pre-set default won't skip the picker. Stopping the provisioner from writing that default would be a separate change in that repo.

https://claude.ai/code/session_01LFd4sbyoJPUYL4p2LxeYRA

---
_Generated by [Claude Code](https://claude.ai/code/session_01LFd4sbyoJPUYL4p2LxeYRA)_