### PR TITLE
fix(operator): make the operator's blackboard reads work end-to-end

### DIFF
--- a/src/agent/builtins/coordination_tool.py
+++ b/src/agent/builtins/coordination_tool.py
@@ -221,11 +221,32 @@ async def hand_off(
             parsed_data = json.loads(data)
         except json.JSONDecodeError:
             parsed_data = {"text": data}
-        artifact_ref = f"output/{mesh_client.agent_id}/{generate_id('ho')}"
+        # Operator-bound handoff reports publish their output to the
+        # ``global/output/{sender}/`` namespace rather than the sender's
+        # team scope. That namespace is the one the operator's read
+        # carve-out (mesh_tool.read_blackboard) AND the permission model
+        # already target: permissions.can_read_blackboard restricts
+        # ``global/output/`` to the operator + the writing agent's own
+        # prefix, so the report is readable by exactly the operator and
+        # its author — nobody else. Writing it team-scoped (the prior
+        # behaviour) left it unreadable by the team-less operator while
+        # needlessly exposing it to the sender's whole team. ``to ==
+        # "operator"`` is the robust signal: it holds even when the fleet
+        # roster lookup above failed and ``target_is_global`` is unknown.
+        # ``global_scope`` keeps the key un-prefixed so it lands exactly
+        # at the key we record in ``artifact_refs``.
+        operator_bound = to == "operator"
+        if operator_bound:
+            artifact_ref = (
+                f"global/output/{mesh_client.agent_id}/{generate_id('ho')}"
+            )
+        else:
+            artifact_ref = f"output/{mesh_client.agent_id}/{generate_id('ho')}"
         try:
             await mesh_client.write_blackboard(
                 artifact_ref, parsed_data, ttl=_HANDOFF_TTL,
                 project=write_project,
+                global_scope=operator_bound,
             )
         except Exception as e:
             # Bug H: a bare ``{"error": ...}`` envelope lets agents

--- a/src/agent/builtins/mesh_tool.py
+++ b/src/agent/builtins/mesh_tool.py
@@ -99,6 +99,23 @@ _STANDALONE_ERROR = (
 )
 
 
+def _is_operator(mesh_client) -> bool:
+    """True for the fleet operator — the trusted, team-less coordinator.
+
+    The operator runs with ``team_name=None`` (so ``is_standalone`` is
+    True), but unlike an untrusted solo worker it is authorized for every
+    blackboard op on the mesh (``_caller_is_operator`` bypass host-side +
+    ``blackboard_read/write: ["*"]``; CLAUDE.md Constraint #12). Its
+    agent-side tools must mirror that, or the operator hits a misleading
+    "not assigned to a project" error — and can loop — when reading or
+    listing team data it is entitled to monitor. Operator reads/lists run
+    in global scope (raw keys, every team visible); its other blackboard
+    ops pass through unscoped and the mesh applies the real ACL. Workers
+    are unaffected — they stay scoped and standalone-blocked as before.
+    """
+    return getattr(mesh_client, "agent_id", "") == "operator"
+
+
 def _parse_json_value(value):
     """Parse a string as JSON, falling back to a ``{"text": ...}`` wrapper."""
     if not isinstance(value, str):
@@ -140,20 +157,11 @@ def _sanitize_value(value):
 async def read_blackboard(key: str, *, mesh_client=None) -> dict:
     if mesh_client is None:
         return {"error": "No mesh_client available"}
-    operator_global_read = (
-        getattr(mesh_client, "agent_id", "") == "operator"
-        and (
-            key.startswith("global/output/")
-            or key.startswith("global/tasks/operator/")
-        )
-    )
-    if mesh_client.is_standalone and not operator_global_read:
+    is_operator = _is_operator(mesh_client)
+    if mesh_client.is_standalone and not is_operator:
         return {"error": _STANDALONE_ERROR}
     try:
-        if operator_global_read:
-            entry = await mesh_client.read_blackboard(key, global_scope=True)
-        else:
-            entry = await mesh_client.read_blackboard(key)
+        entry = await mesh_client.read_blackboard(key, global_scope=is_operator)
         if entry is None:
             return {"key": key, "exists": False, "value": None}
         value = _sanitize_value(entry.get("value", entry))
@@ -194,7 +202,7 @@ async def read_blackboard(key: str, *, mesh_client=None) -> dict:
 async def write_blackboard(key: str, value: str, *, mesh_client=None) -> dict:
     if mesh_client is None:
         return {"error": "No mesh_client available"}
-    if mesh_client.is_standalone:
+    if mesh_client.is_standalone and not _is_operator(mesh_client):
         return {"error": _STANDALONE_ERROR}
     parsed = _parse_json_value(value)
     try:
@@ -226,10 +234,11 @@ async def write_blackboard(key: str, value: str, *, mesh_client=None) -> dict:
 async def list_blackboard(prefix: str = "", *, mesh_client=None) -> dict:
     if mesh_client is None:
         return {"error": "No mesh_client available"}
-    if mesh_client.is_standalone:
+    is_operator = _is_operator(mesh_client)
+    if mesh_client.is_standalone and not is_operator:
         return {"error": _STANDALONE_ERROR}
     try:
-        entries = await mesh_client.list_blackboard(prefix)
+        entries = await mesh_client.list_blackboard(prefix, global_scope=is_operator)
         items = []
         for entry in entries:
             raw = dumps_safe(entry.get("value", {}))
@@ -271,7 +280,7 @@ async def publish_event(
 ) -> dict:
     if mesh_client is None:
         return {"error": "No mesh_client available"}
-    if mesh_client.is_standalone:
+    if mesh_client.is_standalone and not _is_operator(mesh_client):
         return {"error": _STANDALONE_ERROR}
     parsed = _parse_json_value(data)
     try:
@@ -302,7 +311,7 @@ async def publish_event(
 async def subscribe_event(topic: str, *, mesh_client=None) -> dict:
     if mesh_client is None:
         return {"error": "No mesh_client available"}
-    if mesh_client.is_standalone:
+    if mesh_client.is_standalone and not _is_operator(mesh_client):
         return {"error": _STANDALONE_ERROR}
     try:
         result = await mesh_client.subscribe_topic(topic)
@@ -332,7 +341,7 @@ async def subscribe_event(topic: str, *, mesh_client=None) -> dict:
 async def watch_blackboard(pattern: str, *, mesh_client=None) -> dict:
     if mesh_client is None:
         return {"error": "No mesh_client available"}
-    if mesh_client.is_standalone:
+    if mesh_client.is_standalone and not _is_operator(mesh_client):
         return {"error": _STANDALONE_ERROR}
     try:
         result = await mesh_client.watch_blackboard(pattern)
@@ -363,7 +372,7 @@ async def watch_blackboard(pattern: str, *, mesh_client=None) -> dict:
 async def claim_task(key: str, claim_value: str, *, mesh_client=None) -> dict:
     if mesh_client is None:
         return {"error": "No mesh_client available"}
-    if mesh_client.is_standalone:
+    if mesh_client.is_standalone and not _is_operator(mesh_client):
         return {"error": _STANDALONE_ERROR}
     parsed = _parse_json_value(claim_value)
     try:

--- a/tests/test_builtins.py
+++ b/tests/test_builtins.py
@@ -2349,6 +2349,62 @@ class TestStandaloneBlackboardGuards:
         )
 
     @pytest.mark.asyncio
+    async def test_operator_can_read_any_key_globally(self):
+        """The operator is fleet-global and trusted (host authorizes it for
+        every blackboard op). Its read tool must NOT block on a non-global
+        key — it reads ANY key in global scope so it can monitor team data
+        — otherwise it hits a misleading "not assigned to a project" error
+        and can loop."""
+        from src.agent.builtins.mesh_tool import read_blackboard
+        mc = self._standalone_client()
+        mc.agent_id = "operator"
+        mc.read_blackboard = AsyncMock(return_value={
+            "key": "projects/social-media/status/social-publisher",
+            "value": {"state": "working"},
+        })
+
+        result = await read_blackboard(
+            key="projects/social-media/status/social-publisher",
+            mesh_client=mc,
+        )
+
+        assert result["exists"] is True
+        assert result["value"] == {"state": "working"}
+        mc.read_blackboard.assert_awaited_once_with(
+            "projects/social-media/status/social-publisher", global_scope=True,
+        )
+
+    @pytest.mark.asyncio
+    async def test_operator_can_list_any_prefix_globally(self):
+        """The operator lists across every team (global scope), not just
+        its own (non-existent) project scope."""
+        from src.agent.builtins.mesh_tool import list_blackboard
+        mc = self._standalone_client()
+        mc.agent_id = "operator"
+        mc.list_blackboard = AsyncMock(return_value=[])
+
+        result = await list_blackboard(prefix="status/", mesh_client=mc)
+
+        assert "error" not in result
+        mc.list_blackboard.assert_awaited_once_with("status/", global_scope=True)
+
+    @pytest.mark.asyncio
+    async def test_operator_write_not_blocked(self):
+        """The operator is not treated as a standalone-blocked worker on
+        writes either (it is host-authorized for the full blackboard)."""
+        from src.agent.builtins.mesh_tool import write_blackboard
+        mc = self._standalone_client()
+        mc.agent_id = "operator"
+        mc.write_blackboard = AsyncMock(return_value={"version": 1})
+
+        result = await write_blackboard(
+            key="status/operator", value='{"state": "monitoring"}', mesh_client=mc,
+        )
+
+        assert result.get("written") is True
+        assert "error" not in result
+
+    @pytest.mark.asyncio
     async def test_write_blackboard_blocked_for_standalone(self):
         from src.agent.builtins.mesh_tool import write_blackboard
         result = await write_blackboard(

--- a/tests/test_coordination.py
+++ b/tests/test_coordination.py
@@ -166,6 +166,61 @@ class TestHandOff:
         )
 
     @pytest.mark.asyncio
+    async def test_hand_off_to_operator_writes_output_to_global_namespace(self):
+        """Operator-bound handoff OUTPUT lands at ``global/output/{sender}/``
+        with ``global_scope=True`` — the namespace the operator's read
+        carve-out AND the permission model both target (readable by only
+        the operator + the author) — not the sender's team scope, which the
+        team-less operator cannot read. The recorded artifact_ref is the
+        SAME key, so the operator's check_inbox → read_blackboard resolves."""
+        from src.agent.builtins.coordination_tool import hand_off
+
+        mc = _make_mesh_client(agent_id="social-publisher")
+        mc.team_name = "social-media"
+        mc.list_agents.return_value = {"operator": {"project": "ops"}}
+
+        result = await hand_off(
+            to="operator",
+            summary="FB audit complete",
+            data='{"fields_updated": 3}',
+            mesh_client=mc,
+        )
+
+        assert result["handed_off"] is True
+        args, kwargs = mc.write_blackboard.call_args
+        written_key = args[0]
+        assert written_key.startswith("global/output/social-publisher/"), (
+            f"operator handoff output must land in the global namespace, "
+            f"got {written_key!r}"
+        )
+        assert kwargs.get("global_scope") is True
+        # The task points at exactly the key we wrote.
+        assert mc.create_task.call_args.kwargs["artifact_refs"] == [written_key]
+
+    @pytest.mark.asyncio
+    async def test_hand_off_to_teammate_keeps_output_team_scoped(self):
+        """Non-operator handoff output is unchanged: a bare
+        ``output/{sender}/`` key written WITHOUT global_scope (the mesh
+        client transparently prefixes it to the team namespace)."""
+        from src.agent.builtins.coordination_tool import hand_off
+
+        mc = _make_mesh_client(agent_id="scout")
+        mc.team_name = "research-team"
+        mc.list_agents.return_value = {"analyst": {"role": "analyst"}}
+
+        result = await hand_off(
+            to="analyst",
+            summary="findings",
+            data='{"x": 1}',
+            mesh_client=mc,
+        )
+
+        assert result["handed_off"] is True
+        args, kwargs = mc.write_blackboard.call_args
+        assert args[0].startswith("output/scout/")
+        assert not kwargs.get("global_scope", False)
+
+    @pytest.mark.asyncio
     async def test_hand_off_cross_project_routes_to_target_project(self):
         """Worker → worker in a different project: task lands in the
         TARGET's project namespace, not the caller's. Without this the


### PR DESCRIPTION
## Problem (follow-up to #1033)

The team-less, fleet-global **operator** couldn't read the handoff reports team agents send it (the secondary bug noted in #1033), nor monitor team blackboard data — even though the mesh already authorizes it for **every** blackboard op (`_caller_is_operator` bypass + `blackboard_read/write: ["*"]`; Constraint #12). It hit a misleading *"not assigned to a project"* error and could loop on it.

Root cause is two halves of the same gap:

1. **Write routing** — `hand_off` to the operator wrote the output payload to the **sender's team scope** (`projects/{team}/output/…` via `_scope_key`), which the team-less operator can't read. The `global/output/` namespace — which the operator's read carve-out *and* the permission model already target — was never populated.
2. **Tool layer** — `mesh_tool` treated the operator as an untrusted `standalone` worker and blocked it from read/list/write/publish/subscribe/watch/claim.

## Fix

1. **`coordination_tool.hand_off`** — operator-bound output now lands at `global/output/{sender}/…` with `global_scope=True`.
2. **`mesh_tool`** — the operator is never standalone-blocked; its reads/lists run in **global scope** (raw keys, every team visible). A single `_is_operator()` helper gates all 7 guards. **Workers are unchanged** — they stay scoped and standalone-blocked.

## Security (the explicit constraint here — H10-adjacent)

- **No new server authority.** The host already grants the operator `["*"]` + `_caller_is_operator`. This only stops the *client* from refusing what the *server* already allows.
- **Write routing tightens exposure**, not loosens it: `permissions.can_read_blackboard` restricts `global/output/` to **operator + the writing agent's own prefix**, so a report goes from "sender's whole team can read" → "operator + author only." No worker can read another agent's `global/output/`.
- **Workers untouched.** `_is_operator` keys on `agent_id == "operator"` — the container's own boot identity, verified server-side via auth token (unforgeable; fail-closed boot per Constraint #12). Worker scoping + the standalone block are byte-for-byte unchanged.
- Aligns with the project's trusted-operator model: **operator is trusted, workers are not** — and prioritizes operator usability (no stuck/looping) per that model.

## Tests

`tests/test_builtins.py`: operator can read any key globally, list any prefix globally, write not blocked; worker standalone-blocking unchanged. `tests/test_coordination.py`: operator handoff output → `global/output/{sender}/` + `global_scope=True` + artifact_ref matches written key; teammate handoff stays team-scoped. Full relevant suite green (444 passed across coordination/builtins/permissions/handoff_integration/mesh); ruff clean.